### PR TITLE
Refactor suggestions into a structured form internally

### DIFF
--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -161,7 +161,7 @@ pub mod __internal {
 }
 
 fn parse_to_lex_err(mut err: DiagnosticBuilder) -> LexError {
-    err.cancel();
+    let _ = err.cancel();
     LexError { _inner: () }
 }
 

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -483,7 +483,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             self.tcx.sess.add_lint_diagnostic(EXTRA_REQUIREMENT_IN_IMPL,
                                               node_id,
                                               (*err).clone());
-            err.cancel();
+            let _ = err.cancel();
         }
 
         err

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -34,7 +34,7 @@ use syntax::abi::Abi;
 use syntax::codemap::CodeMap;
 use errors;
 use errors::emitter::Emitter;
-use errors::{Level, DiagnosticBuilder};
+use errors::{Level, Diagnostic};
 use syntax::feature_gate::UnstableFeatures;
 use syntax::symbol::Symbol;
 use syntax_pos::DUMMY_SP;
@@ -78,7 +78,7 @@ fn remove_message(e: &mut ExpectErrorEmitter, msg: &str, lvl: Level) {
 }
 
 impl Emitter for ExpectErrorEmitter {
-    fn emit(&mut self, db: &DiagnosticBuilder) {
+    fn emit(&mut self, db: Diagnostic) {
         remove_message(self, &db.message(), db.level);
         for child in &db.children {
             remove_message(self, &child.message(), child.level);

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -25,7 +25,7 @@ pub struct Diagnostic {
     pub code_hints: Option<DiagnosticCodeHint>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
 pub enum DiagnosticCodeHint {
     Suggestion {
         msg: String,

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -10,9 +10,7 @@
 
 use CodeSuggestion;
 use Level;
-use RenderSpan;
-use RenderSpan::Suggestion;
-use std::fmt;
+use std::{fmt, iter};
 use syntax_pos::{MultiSpan, Span};
 use snippet::Style;
 
@@ -24,6 +22,19 @@ pub struct Diagnostic {
     pub code: Option<String>,
     pub span: MultiSpan,
     pub children: Vec<SubDiagnostic>,
+    pub code_hints: Option<DiagnosticCodeHint>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum DiagnosticCodeHint {
+    Suggestion {
+        msg: String,
+        sugg: CodeSuggestion,
+    },
+    Guesses {
+        msg: String,
+        guesses: Vec<CodeSuggestion>,
+    },
 }
 
 /// For example a note attached to an error.
@@ -32,7 +43,7 @@ pub struct SubDiagnostic {
     pub level: Level,
     pub message: Vec<(String, Style)>,
     pub span: MultiSpan,
-    pub render_span: Option<RenderSpan>,
+    pub render_span: Option<MultiSpan>,
 }
 
 impl Diagnostic {
@@ -47,6 +58,7 @@ impl Diagnostic {
             code: code,
             span: MultiSpan::new(),
             children: vec![],
+            code_hints: None,
         }
     }
 
@@ -109,12 +121,12 @@ impl Diagnostic {
     }
 
     pub fn note(&mut self, msg: &str) -> &mut Self {
-        self.sub(Level::Note, msg, MultiSpan::new(), None);
+        self.sub(Level::Note, msg, MultiSpan::new());
         self
     }
 
     pub fn highlighted_note(&mut self, msg: Vec<(String, Style)>) -> &mut Self {
-        self.sub_with_highlights(Level::Note, msg, MultiSpan::new(), None);
+        self.sub_with_highlights(Level::Note, msg, MultiSpan::new());
         self
     }
 
@@ -122,12 +134,12 @@ impl Diagnostic {
                                          sp: S,
                                          msg: &str)
                                          -> &mut Self {
-        self.sub(Level::Note, msg, sp.into(), None);
+        self.sub(Level::Note, msg, sp.into());
         self
     }
 
     pub fn warn(&mut self, msg: &str) -> &mut Self {
-        self.sub(Level::Warning, msg, MultiSpan::new(), None);
+        self.sub(Level::Warning, msg, MultiSpan::new());
         self
     }
 
@@ -135,12 +147,12 @@ impl Diagnostic {
                                          sp: S,
                                          msg: &str)
                                          -> &mut Self {
-        self.sub(Level::Warning, msg, sp.into(), None);
+        self.sub(Level::Warning, msg, sp.into());
         self
     }
 
     pub fn help(&mut self , msg: &str) -> &mut Self {
-        self.sub(Level::Help, msg, MultiSpan::new(), None);
+        self.sub(Level::Help, msg, MultiSpan::new());
         self
     }
 
@@ -148,7 +160,7 @@ impl Diagnostic {
                                          sp: S,
                                          msg: &str)
                                          -> &mut Self {
-        self.sub(Level::Help, msg, sp.into(), None);
+        self.sub(Level::Help, msg, sp.into());
         self
     }
 
@@ -156,14 +168,41 @@ impl Diagnostic {
     ///
     /// See `diagnostic::RenderSpan::Suggestion` for more information.
     pub fn span_suggestion(&mut self, sp: Span, msg: &str, suggestion: String) -> &mut Self {
-        self.sub(Level::Help,
-                 msg,
-                 MultiSpan::new(),
-                 Some(Suggestion(CodeSuggestion {
-                     msp: sp.into(),
-                     substitutes: vec![suggestion],
-                 })));
+        assert!(self.code_hints.is_none(),
+                "use guesses to assign multiple suggestions to an error");
+        self.code_hints = Some(DiagnosticCodeHint::Suggestion {
+            sugg: CodeSuggestion {
+                msp: sp.into(),
+                substitutes: vec![suggestion],
+            },
+            msg: msg.to_owned(),
+        });
         self
+    }
+
+    /// Prints out a message with one or multiple suggested edits of the
+    /// code, which may break the code, require manual intervention
+    /// or be plain out wrong, but might possibly be the correct solution.
+    ///
+    /// See `diagnostic::RenderSpan::Guesses` for more information.
+    pub fn span_guesses<I>(&mut self, sp: Span, msg: &str, guesses: I) -> &mut Self
+        where I: IntoIterator<Item = String>
+    {
+        assert!(self.code_hints.is_none(),
+                "cannot attach multiple guesses to the same error");
+        let guesses = guesses.into_iter().map(|guess| CodeSuggestion {
+            msp: sp.into(),
+            substitutes: vec![guess],
+        }).collect();
+        self.code_hints = Some(DiagnosticCodeHint::Guesses {
+            guesses: guesses,
+            msg: msg.to_owned(),
+        });
+        self
+    }
+
+    pub fn span_guess(&mut self, sp: Span, msg: &str, guess: String) -> &mut Self {
+        self.span_guesses(sp, msg, iter::once(guess))
     }
 
     pub fn set_span<S: Into<MultiSpan>>(&mut self, sp: S) -> &mut Self {
@@ -201,15 +240,12 @@ impl Diagnostic {
     fn sub(&mut self,
            level: Level,
            message: &str,
-           span: MultiSpan,
-           render_span: Option<RenderSpan>) {
-        let sub = SubDiagnostic {
-            level: level,
-            message: vec![(message.to_owned(), Style::NoStyle)],
-            span: span,
-            render_span: render_span,
-        };
-        self.children.push(sub);
+           span: MultiSpan) {
+        self.sub_with_highlights(
+            level,
+            vec![(message.to_owned(), Style::NoStyle)],
+            span,
+        );
     }
 
     /// Convenience function for internal use, clients should use one of the
@@ -217,13 +253,12 @@ impl Diagnostic {
     fn sub_with_highlights(&mut self,
                            level: Level,
                            message: Vec<(String, Style)>,
-                           span: MultiSpan,
-                           render_span: Option<RenderSpan>) {
+                           span: MultiSpan) {
         let sub = SubDiagnostic {
             level: level,
             message: message,
             span: span,
-            render_span: render_span,
+            render_span: None,
         };
         self.children.push(sub);
     }

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -155,11 +155,7 @@ impl Diagnostic {
     /// Prints out a message with a suggested edit of the code.
     ///
     /// See `diagnostic::RenderSpan::Suggestion` for more information.
-    pub fn span_suggestion<S: Into<MultiSpan>>(&mut self,
-                                               sp: S,
-                                               msg: &str,
-                                               suggestion: String)
-                                               -> &mut Self {
+    pub fn span_suggestion(&mut self, sp: Span, msg: &str, suggestion: String) -> &mut Self {
         self.sub(Level::Help,
                  msg,
                  MultiSpan::new(),

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -62,15 +62,6 @@ impl Diagnostic {
         }
     }
 
-    /// Cancel the diagnostic (a structured diagnostic must either be emitted or
-    /// cancelled or it will panic when dropped).
-    /// BEWARE: if this DiagnosticBuilder is an error, then creating it will
-    /// bump the error count on the Handler and cancelling it won't undo that.
-    /// If you want to decrement the error count you should use `Handler::cancel`.
-    pub fn cancel(&mut self) {
-        self.level = Level::Cancelled;
-    }
-
     pub fn cancelled(&self) -> bool {
         self.level == Level::Cancelled
     }

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -146,11 +146,19 @@ impl<'a> DiagnosticBuilder<'a> {
                                     -> &mut Self);
     forward!(pub fn set_span<S: Into<MultiSpan>>(&mut self, sp: S) -> &mut Self);
     forward!(pub fn code(&mut self, s: String) -> &mut Self);
+    forward!(pub fn span_guess(&mut self, sp: Span, msg: &str, guess: String) -> &mut Self);
 
     /// Convenience function for internal use, clients should use one of the
     /// struct_* methods on Handler.
     pub fn new(handler: &'a Handler, level: Level, message: &str) -> DiagnosticBuilder<'a> {
         DiagnosticBuilder::new_with_code(handler, level, None, message)
+    }
+    
+    pub fn span_guesses<I>(&mut self, sp: Span, msg: &str, guesses: I) -> &mut Self
+        where I: IntoIterator<Item = String>
+    {
+        self.diagnostic.span_guesses(sp, msg, guesses);
+        self
     }
 
     /// Convenience function for internal use, clients should use one of the

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -139,11 +139,11 @@ impl<'a> DiagnosticBuilder<'a> {
                                                   sp: S,
                                                   msg: &str)
                                                   -> &mut Self);
-    forward!(pub fn span_suggestion<S: Into<MultiSpan>>(&mut self,
-                                                        sp: S,
-                                                        msg: &str,
-                                                        suggestion: String)
-                                                        -> &mut Self);
+    forward!(pub fn span_suggestion(&mut self,
+                                    sp: Span,
+                                    msg: &str,
+                                    suggestion: String)
+                                    -> &mut Self);
     forward!(pub fn set_span<S: Into<MultiSpan>>(&mut self, sp: S) -> &mut Self);
     forward!(pub fn code(&mut self, s: String) -> &mut Self);
 

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -154,7 +154,7 @@ impl<'a> DiagnosticBuilder<'a> {
     pub fn new(handler: &'a Handler, level: Level, message: &str) -> DiagnosticBuilder<'a> {
         DiagnosticBuilder::new_with_code(handler, level, None, message)
     }
-    
+
     pub fn span_guesses<I>(&mut self, sp: Span, msg: &str, guesses: I) -> &mut Self
         where I: IntoIterator<Item = String>
     {

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -997,19 +997,6 @@ impl EmitterWriter {
                         Err(e) => panic!("failed to emit error: {}", e)
                     }
                 }
-                match db.code_hints {
-                    Some(DiagnosticCodeHint::Suggestion { msg, sugg }) => {
-                        match self.emit_suggestion_default(&sugg,
-                                                           &Level::Help,
-                                                           &vec![(msg, Style::NoStyle)],
-                                                           max_line_num_len) {
-                            Err(e) => panic!("failed to emit error: {}", e),
-                            _ => ()
-                        }
-                    }
-                    Some(DiagnosticCodeHint::Guesses { .. }) => unimplemented!(),
-                    None => {}
-                }
                 for child in db.children {
                     match child.render_span {
                         Some(ref msp) => {
@@ -1035,6 +1022,19 @@ impl EmitterWriter {
                             }
                         }
                     }
+                }
+                match db.code_hints {
+                    Some(DiagnosticCodeHint::Suggestion { msg, sugg }) => {
+                        match self.emit_suggestion_default(&sugg,
+                                                           &Level::Help,
+                                                           &vec![(msg, Style::NoStyle)],
+                                                           max_line_num_len) {
+                            Err(e) => panic!("failed to emit error: {}", e),
+                            _ => ()
+                        }
+                    }
+                    Some(DiagnosticCodeHint::Guesses { .. }) => unimplemented!(),
+                    None => {}
                 }
             }
             Err(e) => panic!("failed to emit error: {}", e),

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -255,32 +255,34 @@ impl Handler {
                                                     sp: S,
                                                     msg: &str)
                                                     -> DiagnosticBuilder<'a> {
-        let mut result = DiagnosticBuilder::new(self, Level::Warning, msg);
-        result.set_span(sp);
-        if !self.can_emit_warnings {
-            result.cancel();
+        if self.can_emit_warnings {
+            let mut result = DiagnosticBuilder::new(self, Level::Warning, msg);
+            result.set_span(sp);
+            result
+        } else {
+            self.struct_dummy()
         }
-        result
     }
     pub fn struct_span_warn_with_code<'a, S: Into<MultiSpan>>(&'a self,
                                                               sp: S,
                                                               msg: &str,
                                                               code: &str)
                                                               -> DiagnosticBuilder<'a> {
-        let mut result = DiagnosticBuilder::new(self, Level::Warning, msg);
-        result.set_span(sp);
-        result.code(code.to_owned());
-        if !self.can_emit_warnings {
-            result.cancel();
+        if self.can_emit_warnings {
+            let mut result = DiagnosticBuilder::new(self, Level::Warning, msg);
+            result.set_span(sp);
+            result.code(code.to_owned());
+            result
+        } else {
+            self.struct_dummy()
         }
-        result
     }
     pub fn struct_warn<'a>(&'a self, msg: &str) -> DiagnosticBuilder<'a> {
-        let mut result = DiagnosticBuilder::new(self, Level::Warning, msg);
-        if !self.can_emit_warnings {
-            result.cancel();
+        if self.can_emit_warnings {
+            DiagnosticBuilder::new(self, Level::Warning, msg)
+        } else {
+            self.struct_dummy()
         }
-        result
     }
     pub fn struct_span_err<'a, S: Into<MultiSpan>>(&'a self,
                                                    sp: S,
@@ -326,7 +328,7 @@ impl Handler {
     }
 
     pub fn cancel(&self, err: &mut DiagnosticBuilder) {
-        err.cancel();
+        let _ = err.cancel();
     }
 
     fn panic_if_treat_err_as_bug(&self) {

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -51,20 +51,6 @@ use syntax_pos::{BytePos, Loc, FileLinesResult, FileName, MultiSpan, Span, NO_EX
 use syntax_pos::MacroBacktrace;
 
 #[derive(Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
-pub enum RenderSpan {
-    /// A FullSpan renders with both with an initial line for the
-    /// message, prefixed by file:linenum, followed by a summary of
-    /// the source code covered by the span.
-    FullSpan(MultiSpan),
-
-    /// A suggestion renders with both with an initial line for the
-    /// message, prefixed by file:linenum, followed by a summary
-    /// of hypothetical source code, where each `String` is spliced
-    /// into the lines in place of the code covered by each span.
-    Suggestion(CodeSuggestion),
-}
-
-#[derive(Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct CodeSuggestion {
     pub msp: MultiSpan,
     pub substitutes: Vec<String>,
@@ -204,7 +190,7 @@ impl error::Error for ExplicitBug {
     }
 }
 
-pub use diagnostic::{Diagnostic, SubDiagnostic};
+pub use diagnostic::{Diagnostic, SubDiagnostic, DiagnosticCodeHint};
 pub use diagnostic_builder::DiagnosticBuilder;
 
 /// A handler deals with errors; certain errors

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -22,7 +22,7 @@ use {CrateTranslation, ModuleLlvm, ModuleSource, ModuleTranslation};
 use util::common::{time, time_depth, set_time_depth};
 use util::common::path2cstr;
 use util::fs::link_or_copy;
-use errors::{self, Handler, Level, DiagnosticBuilder};
+use errors::{self, Handler, Level};
 use errors::emitter::Emitter;
 use syntax_pos::MultiSpan;
 use context::{is_pie_binary, get_reloc_model};
@@ -120,7 +120,7 @@ impl SharedEmitter {
 }
 
 impl Emitter for SharedEmitter {
-    fn emit(&mut self, db: &DiagnosticBuilder) {
+    fn emit(&mut self, db: errors::Diagnostic) {
         self.buffer.lock().unwrap().push(Diagnostic {
             msg: db.message(),
             code: db.code.clone(),

--- a/src/libsyntax/json.rs
+++ b/src/libsyntax/json.rs
@@ -156,7 +156,7 @@ impl Diagnostic {
                 let sugg = Diagnostic {
                     message: msg.clone(),
                     code: None,
-                    level: "note",
+                    level: "help",
                     spans: DiagnosticSpan::from_suggestion(sugg, je),
                     children: Vec::new(),
                     rendered: Some(sugg.splice_lines(je.cm.borrow())),


### PR DESCRIPTION
work towards making #39458 possible without user visible changes.

This PR changes suggestions from being converted to regular diagnostics by the `span_suggestion` call, and instead moves this to the `emit` call on the specific emitter (json or command line).

r? @nrc 

cc @petrochenkov 