### PR TITLE
Reenable linkchecker for books

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -270,7 +270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "mdbook"
-version = "0.0.15"
+version = "0.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.20.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -401,7 +401,7 @@ name = "rustbook"
 version = "0.1.0"
 dependencies = [
  "clap 2.20.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "mdbook 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mdbook 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -991,7 +991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6abe0ee2e758cd6bc8a2cd56726359007748fbf4128da998b65d0b70f881e19b"
 "checksum libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "684f330624d8c3784fb9558ca46c4ce488073a8d22450415c5eb4f4cfb0d11b5"
 "checksum log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ab83497bf8bf4ed2a74259c1c802351fcd67a65baa86394b6ba73c36f4838054"
-"checksum mdbook 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "9a6b8e6eb10d1c6beeca799fe5919778cf5c6f22a4f2abb5f50faea1221adeae"
+"checksum mdbook 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "14e8a6aca534ac51bad1c1886b10f6d6948a14fa70b1b20a1e41c9e5c0fe3019"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a16a42856a256b39c6d3484f097f6713e14feacd9bfb02290917904fae46c81c"
 "checksum num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "cee7e88156f3f9e19bdd598f8d6c9db7bf4078f99f8381f43a55b09648d1a6e3"

--- a/src/doc/book/src/casting-between-types.md
+++ b/src/doc/book/src/casting-between-types.md
@@ -8,7 +8,7 @@ most dangerous features of Rust!
 # Coercion
 
 Coercion between types is implicit and has no syntax of its own, but can
-be spelled out with [`as`](#Explicit%20coercions).
+be spelled out with [`as`](#explicit-coercions).
 
 Coercion occurs in `let`, `const`, and `static` statements; in
 function call arguments; in field values in struct initialization; and in a

--- a/src/doc/book/src/closures.md
+++ b/src/doc/book/src/closures.md
@@ -463,7 +463,7 @@ fn factory() -> &(Fn(i32) -> i32) {
 
 Right. Because we have a reference, we need to give it a lifetime. But
 our `factory()` function takes no arguments, so
-[elision](lifetimes.html#Lifetime%20Elision) doesn’t kick in here. Then what
+[elision](lifetimes.html#lifetime-elision) doesn’t kick in here. Then what
 choices do we have? Try `'static`:
 
 ```rust,ignore

--- a/src/doc/book/src/compiler-plugins.md
+++ b/src/doc/book/src/compiler-plugins.md
@@ -127,7 +127,7 @@ enum.  For a more involved macro example, see
 
 ## Tips and tricks
 
-Some of the [macro debugging tips](macros.html#Debugging%20macro%20code) are applicable.
+Some of the [macro debugging tips](macros.html#debugging-macro-code) are applicable.
 
 You can use `syntax::parse` to turn token trees into
 higher-level syntax elements like expressions:

--- a/src/doc/book/src/concurrency.md
+++ b/src/doc/book/src/concurrency.md
@@ -55,7 +55,7 @@ For sharing references across threads, Rust provides a wrapper type called
 `Arc<T>`. `Arc<T>` implements `Send` and `Sync` if and only if `T` implements
 both `Send` and `Sync`. For example, an object of type `Arc<RefCell<U>>` cannot
 be transferred across threads because
-[`RefCell`](choosing-your-guarantees.html#RefCell%3CT%3E) does not implement
+[`RefCell`](choosing-your-guarantees.html#refcellt) does not implement
 `Sync`, consequently `Arc<RefCell<U>>` would not implement `Send`.
 
 These two traits allow you to use the type system to make strong guarantees
@@ -126,7 +126,7 @@ closure only captures a _reference to `x`_. This is a problem, because the
 thread may outlive the scope of `x`, leading to a dangling pointer.
 
 To fix this, we use a `move` closure as mentioned in the error message. `move`
-closures are explained in depth [here](closures.html#move%20closures); basically
+closures are explained in depth [here](closures.html#move-closures); basically
 they move variables from their environment into themselves.
 
 ```rust

--- a/src/doc/book/src/error-handling.md
+++ b/src/doc/book/src/error-handling.md
@@ -21,35 +21,35 @@ sum types and combinators, and try to motivate the way Rust does error handling
 incrementally. As such, programmers with experience in other expressive type
 systems may want to jump around.
 
-* [The Basics](#The%20Basics)
-    * [Unwrapping explained](#Unwrapping%20explained)
-    * [The `Option` type](#The%20Option%20type)
-        * [Composing `Option<T>` values](#Composing%20Option%3CT%3E%20values)
-    * [The `Result` type](#The%20Result%20type)
-        * [Parsing integers](#Parsing%20integers)
-        * [The `Result` type alias idiom](#The%20Result%20type%20alias%20idiom)
-    * [A brief interlude: unwrapping isn't evil](#A%20brief%20interlude:%20unwrapping%20isnt%20evil)
-* [Working with multiple error types](#Working%20with%20multiple%20error%20types)
-    * [Composing `Option` and `Result`](#Composing%20Option%20and%20Result)
-    * [The limits of combinators](#The%20limits%20of%20combinators)
-    * [Early returns](#Early%20returns)
-    * [The `try!` macro](#The%20try%20macro)
-    * [Defining your own error type](#Defining%20your%20own%20error%20type)
-* [Standard library traits used for error handling](#Standard%20library%20traits%20used%20for%20error%20handling)
-    * [The `Error` trait](#The%20Error%20trait)
-    * [The `From` trait](#The%20From%20trait)
-    * [The real `try!` macro](#The%20real%20try%20macro)
-    * [Composing custom error types](#Composing%20custom%20error%20types)
-    * [Advice for library writers](#Advice%20for%20library%20writers)
-* [Case study: A program to read population data](#Case%20study:%20A%20program%20to%20read%20population%20data)
-    * [Initial setup](#Initial%20setup)
-    * [Argument parsing](#Argument%20parsing)
-    * [Writing the logic](#Writing%20the%20logic)
-    * [Error handling with `Box<Error>`](#Error%20handling%20with%20Box%3CError%3E)
-    * [Reading from stdin](#Reading%20from%20stdin)
-    * [Error handling with a custom type](#Error%20handling%20with%20a%20custom%20type)
-    * [Adding functionality](#Adding%20functionality)
-* [The short story](#The%20short%20story)
+* [The Basics](#the-basics)
+    * [Unwrapping explained](#unwrapping-explained)
+    * [The `Option` type](#the-option-type)
+        * [Composing `Option<T>` values](#composing-optiont-values)
+    * [The `Result` type](#the-result-type)
+        * [Parsing integers](#parsing-integers)
+        * [The `Result` type alias idiom](#the-result-type-alias-idiom)
+    * [A brief interlude: unwrapping isn't evil](#a-brief-interlude-unwrapping-isnt-evil)
+* [Working with multiple error types](#working-with-multiple-error-types)
+    * [Composing `Option` and `Result`](#composing-option-and-result)
+    * [The limits of combinators](#the-limits-of-combinators)
+    * [Early returns](#early-returns)
+    * [The `try!` macro](#the-try-macro)
+    * [Defining your own error type](#defining-your-own-error-type)
+* [Standard library traits used for error handling](#standard-library-traits-used-for-error-handling)
+    * [The `Error` trait](#the-error-trait)
+    * [The `From` trait](#the-from-trait)
+    * [The real `try!` macro](#the-real-try-macro)
+    * [Composing custom error types](#composing-custom-error-types)
+    * [Advice for library writers](#advice-for-library-writers)
+* [Case study: A program to read population data](#case-study-a-program-to-read-population-data)
+    * [Initial setup](#initial-setup)
+    * [Argument parsing](#argument-parsing)
+    * [Writing the logic](#writing-the-logic)
+    * [Error handling with `Box<Error>`](#error-handling-with-boxerror)
+    * [Reading from stdin](#reading-from-stdin)
+    * [Error handling with a custom type](#error-handling-with-a-custom-type)
+    * [Adding functionality](#adding-functionality)
+* [The short story](#the-short-story)
 
 # The Basics
 
@@ -796,7 +796,7 @@ because of the return types of
 [`std::fs::File::open`](../std/fs/struct.File.html#method.open) and
 [`std::io::Read::read_to_string`](../std/io/trait.Read.html#method.read_to_string).
 (Note that they both use the [`Result` type alias
-idiom](#The%20Result%20type%20alias%20idiom) described previously. If you
+idiom](#the-result-type-alias-idiom) described previously. If you
 click on the `Result` type, you'll [see the type
 alias](../std/io/type.Result.html), and consequently, the underlying
 `io::Error` type.)  The third problem is described by the
@@ -1120,7 +1120,7 @@ returns an `&Error`, which is itself a trait object. We'll revisit the
 
 For now, it suffices to show an example implementing the `Error` trait. Let's
 use the error type we defined in the
-[previous section](#Defining%20your%20own%20error%20type):
+[previous section](#defining-your-own-error-type):
 
 ```rust
 use std::io;
@@ -1493,19 +1493,19 @@ representation. But certainly, this will vary depending on use cases.
 At a minimum, you should probably implement the
 [`Error`](../std/error/trait.Error.html)
 trait. This will give users of your library some minimum flexibility for
-[composing errors](#The%20real%20try%20macro). Implementing the `Error` trait also
+[composing errors](#the-real-try-macro). Implementing the `Error` trait also
 means that users are guaranteed the ability to obtain a string representation
 of an error (because it requires impls for both `fmt::Debug` and
 `fmt::Display`).
 
 Beyond that, it can also be useful to provide implementations of `From` on your
 error types. This allows you (the library author) and your users to
-[compose more detailed errors](#Composing%20custom%20error%20types). For example,
+[compose more detailed errors](#composing-custom-error-types). For example,
 [`csv::Error`](http://burntsushi.net/rustdoc/csv/enum.Error.html)
 provides `From` impls for both `io::Error` and `byteorder::Error`.
 
 Finally, depending on your tastes, you may also want to define a
-[`Result` type alias](#The%20Result%20type%20alias%20idiom), particularly if your
+[`Result` type alias](#the-result-type-alias-idiom), particularly if your
 library defines a single error type. This is used in the standard library
 for [`io::Result`](../std/io/type.Result.html)
 and [`fmt::Result`](../std/fmt/type.Result.html).
@@ -1538,7 +1538,7 @@ and [`rustc-serialize`](https://crates.io/crates/rustc-serialize) crates.
 
 We're not going to spend a lot of time on setting up a project with
 Cargo because it is already covered well in [the Cargo
-section](getting-started.html#Hello%20Cargo) and [Cargo's documentation][14].
+section](getting-started.html#hello-cargo) and [Cargo's documentation][14].
 
 To get started from scratch, run `cargo new --bin city-pop` and make sure your
 `Cargo.toml` looks something like this:
@@ -1729,7 +1729,7 @@ error types and you don't need any `From` implementations. The downside is that
 since `Box<Error>` is a trait object, it *erases the type*, which means the
 compiler can no longer reason about its underlying type.
 
-[Previously](#The%20limits%20of%20combinators) we started refactoring our code by
+[Previously](#the-limits-of-combinators) we started refactoring our code by
 changing the type of our function from `T` to `Result<T, OurErrorType>`. In
 this case, `OurErrorType` is only `Box<Error>`. But what's `T`? And can we add
 a return type to `main`?

--- a/src/doc/book/src/ffi.md
+++ b/src/doc/book/src/ffi.md
@@ -680,7 +680,7 @@ pub extern fn hello_rust() -> *const u8 {
 
 The `extern` makes this function adhere to the C calling convention, as
 discussed above in "[Foreign Calling
-Conventions](ffi.html#Foreign%20calling%20conventions)". The `no_mangle`
+Conventions](ffi.html#foreign-calling-conventions)". The `no_mangle`
 attribute turns off Rust's name mangling, so that it is easier to link to.
 
 # FFI and panics

--- a/src/doc/book/src/getting-started.md
+++ b/src/doc/book/src/getting-started.md
@@ -236,7 +236,7 @@ language]*, which means that most things are expressions, rather than
 statements. The `;` indicates that this expression is over, and the next one is
 ready to begin. Most lines of Rust code end with a `;`.
 
-[expression-oriented language]: glossary.html#Expression-Oriented%20Language
+[expression-oriented language]: glossary.html#expression-oriented-language
 
 ## Compiling and Running Are Separate Steps
 

--- a/src/doc/book/src/glossary.md
+++ b/src/doc/book/src/glossary.md
@@ -56,7 +56,7 @@ They can be used to manage control flow in a modular fashion.
 
 A type without a statically known size or alignment. ([more info][link])
 
-[link]: ../nomicon/exotic-sizes.html#Dynamically%20Sized%20Types%20(DSTs)
+[link]: ../nomicon/exotic-sizes.html#dynamically-sized-types-dsts
 
 ### Expression
 
@@ -76,8 +76,8 @@ In an expression-oriented language, (nearly) every statement is an expression
 and therefore returns a value. Consequently, these expression statements can
 themselves form part of larger expressions.
 
-[expression]: glossary.html#Expression
-[statement]: glossary.html#Statement
+[expression]: glossary.html#expression
+[statement]: glossary.html#statement
 
 ### Statement
 

--- a/src/doc/book/src/guessing-game.md
+++ b/src/doc/book/src/guessing-game.md
@@ -119,7 +119,7 @@ there are no arguments, and `{` starts the body of the function. Because
 we didn’t include a return type, it’s assumed to be `()`, an empty
 [tuple][tuples].
 
-[tuples]: primitive-types.html#Tuples
+[tuples]: primitive-types.html#tuples
 
 ```rust,ignore
     println!("Guess the number!");
@@ -727,7 +727,7 @@ thirty-two bit integer. Rust has [a number of built-in number types][number],
 but we’ve chosen `u32`. It’s a good default choice for a small positive number.
 
 [parse]: ../std/primitive.str.html#method.parse
-[number]: primitive-types.html#Numeric%20types
+[number]: primitive-types.html#numeric-types
 
 Just like `read_line()`, our call to `parse()` could cause an error. What if
 our string contained `A👍%`? There’d be no way to convert that to a number. As

--- a/src/doc/book/src/lifetimes.md
+++ b/src/doc/book/src/lifetimes.md
@@ -139,7 +139,7 @@ associated with it, but the compiler lets you elide (i.e. omit, see
 ["Lifetime Elision"][lifetime-elision] below) them in common cases. Before we
 get to that, though, let’s look at a short example with explicit lifetimes:
 
-[lifetime-elision]: #Lifetime%20Elision
+[lifetime-elision]: #lifetime-elision
 
 ```rust,ignore
 fn bar<'a>(...)

--- a/src/doc/book/src/macros.md
+++ b/src/doc/book/src/macros.md
@@ -430,7 +430,7 @@ Even when Rust code contains un-expanded macros, it can be parsed as a full
 tools that process code. It also has a few consequences for the design of
 Rust’s macro system.
 
-[ast]: glossary.html#Abstract%20Syntax%20Tree
+[ast]: glossary.html#abstract-syntax-tree
 
 One consequence is that Rust must determine, when it parses a macro invocation,
 whether the macro stands in for

--- a/src/doc/book/src/mutability.md
+++ b/src/doc/book/src/mutability.md
@@ -89,7 +89,7 @@ philosophy, memory safety, and the mechanism by which Rust guarantees it, the
 > * exactly one mutable reference (`&mut T`).
 
 [ownership]: ownership.html
-[borrowing]: references-and-borrowing.html#Borrowing
+[borrowing]: references-and-borrowing.html#borrowing
 
 So, that’s the real definition of ‘immutability’: is this safe to have two
 pointers to? In `Arc<T>`’s case, yes: the mutation is entirely contained inside

--- a/src/doc/book/src/ownership.md
+++ b/src/doc/book/src/ownership.md
@@ -65,10 +65,10 @@ elements onto them.
 Vectors have a [generic type][generics] `Vec<T>`, so in this example `v` will have type
 `Vec<i32>`. We'll cover [generics] in detail in a later chapter.
 
-[arrays]: primitive-types.html#Arrays
+[arrays]: primitive-types.html#arrays
 [vectors]: vectors.html
-[heap]: the-stack-and-the-heap.html#The%20Heap
-[stack]: the-stack-and-the-heap.html#The%20Stack
+[heap]: the-stack-and-the-heap.html#the-heap
+[stack]: the-stack-and-the-heap.html#the-stack
 [bindings]: variable-bindings.html
 [generics]: generics.html
 
@@ -136,7 +136,7 @@ Rust allocates memory for an integer [i32] on the [stack][sh], copies the bit
 pattern representing the value of 10 to the allocated memory and binds the
 variable name x to this memory region for future reference.
 
-[i32]: primitive-types.html#Numeric%20types
+[i32]: primitive-types.html#numeric-types
 
 Now consider the following code fragment:
 

--- a/src/doc/book/src/primitive-types.md
+++ b/src/doc/book/src/primitive-types.md
@@ -232,7 +232,7 @@ soon.
 You can assign one tuple into another, if they have the same contained types
 and [arity]. Tuples have the same arity when they have the same length.
 
-[arity]: glossary.html#Arity
+[arity]: glossary.html#arity
 
 ```rust
 let mut x = (1, 2); // x: (i32, i32)

--- a/src/doc/book/src/syntax-index.md
+++ b/src/doc/book/src/syntax-index.md
@@ -196,18 +196,18 @@
 [Associated Types]: associated-types.html
 [Attributes]: attributes.html
 [Casting Between Types (`as`)]: casting-between-types.html#as
-[Closures (`move` closures)]: closures.html#move%20closures
+[Closures (`move` closures)]: closures.html#move-closures
 [Closures]: closures.html
 [Comments]: comments.html
-[Crates and Modules (Defining Modules)]: crates-and-modules.html#Defining%20modules
-[Crates and Modules (Exporting a Public Interface)]: crates-and-modules.html#Exporting%20a%20public%20interface
-[Crates and Modules (Importing External Crates)]: crates-and-modules.html#Importing%20external%20crates
-[Crates and Modules (Importing Modules with `use`)]: crates-and-modules.html#Importing%20modules%20with%20use
-[Crates and Modules (Re-exporting with `pub use`)]: crates-and-modules.html#Re-exporting%20with%20pub%20use
-[Diverging Functions]: functions.html#Diverging%20functions
+[Crates and Modules (Defining Modules)]: crates-and-modules.html#defining-modules
+[Crates and Modules (Exporting a Public Interface)]: crates-and-modules.html#exporting-a-public-interface
+[Crates and Modules (Importing External Crates)]: crates-and-modules.html#importing-external-crates
+[Crates and Modules (Importing Modules with `use`)]: crates-and-modules.html#importing-modules-with-use
+[Crates and Modules (Re-exporting with `pub use`)]: crates-and-modules.html#re-exporting-with-pub-use
+[Diverging Functions]: functions.html#diverging-functions
 [Enums]: enums.html
 [Foreign Function Interface]: ffi.html
-[Functions (Early Returns)]: functions.html#Early%20returns
+[Functions (Early Returns)]: functions.html#early-returns
 [Functions]: functions.html
 [Generics]: generics.html
 [Iterators]: iterators.html
@@ -216,24 +216,24 @@
 [Loops (`for`)]: loops.html#for
 [Loops (`loop`)]: loops.html#loop
 [Loops (`while`)]: loops.html#while
-[Loops (Ending Iteration Early)]: loops.html#Ending%20iteration%20early
-[Loops (Loops Labels)]: loops.html#Loop%20labels
+[Loops (Ending Iteration Early)]: loops.html#ending-iteration-early
+[Loops (Loops Labels)]: loops.html#loop-labels
 [Macros]: macros.html
 [Match]: match.html
-[Method Syntax (Method Calls)]: method-syntax.html#Method%20calls
+[Method Syntax (Method Calls)]: method-syntax.html#method-calls
 [Method Syntax]: method-syntax.html
 [Mutability]: mutability.html
 [Operators and Overloading]: operators-and-overloading.html
-[Patterns (`ref` and `ref mut`)]: patterns.html#ref%20and%20ref%20mut
-[Patterns (Bindings)]: patterns.html#Bindings
-[Patterns (Ignoring bindings)]: patterns.html#Ignoring%20bindings
-[Patterns (Multiple patterns)]: patterns.html#Multiple%20patterns
-[Patterns (Ranges)]: patterns.html#Ranges
+[Patterns (`ref` and `ref mut`)]: patterns.html#ref-and-ref-mut
+[Patterns (Bindings)]: patterns.html#bindings
+[Patterns (Ignoring bindings)]: patterns.html#ignoring-bindings
+[Patterns (Multiple patterns)]: patterns.html#multiple-patterns
+[Patterns (Ranges)]: patterns.html#ranges
 [Primitive Types (`char`)]: primitive-types.html#char
-[Primitive Types (Arrays)]: primitive-types.html#Arrays
-[Primitive Types (Booleans)]: primitive-types.html#Booleans
-[Primitive Types (Tuple Indexing)]: primitive-types.html#Tuple%20indexing
-[Primitive Types (Tuples)]: primitive-types.html#Tuples
+[Primitive Types (Arrays)]: primitive-types.html#arrays
+[Primitive Types (Booleans)]: primitive-types.html#booleans
+[Primitive Types (Tuple Indexing)]: primitive-types.html#tuple-indexing
+[Primitive Types (Tuples)]: primitive-types.html#tuples
 [Raw Pointers]: raw-pointers.html
 [Reference (Byte String Literals)]: ../reference.html#byte-string-literals
 [Reference (Integer literals)]: ../reference.html#integer-literals
@@ -241,13 +241,13 @@
 [Reference (Raw String Literals)]: ../reference.html#raw-string-literals
 [References and Borrowing]: references-and-borrowing.html
 [Strings]: strings.html
-[Structs (Update syntax)]: structs.html#Update%20syntax
+[Structs (Update syntax)]: structs.html#update-syntax
 [Structs]: structs.html
-[Traits (`where` clause)]: traits.html#Where%20clause
-[Traits (Multiple Trait Bounds)]: traits.html#Multiple%20trait%20bounds
+[Traits (`where` clause)]: traits.html#where-clause
+[Traits (Multiple Trait Bounds)]: traits.html#multiple-trait-bounds
 [Traits]: traits.html
 [Universal Function Call Syntax]: ufcs.html
-[Universal Function Call Syntax (Angle-bracket Form)]: ufcs.html#Angle-bracket%20Form
+[Universal Function Call Syntax (Angle-bracket Form)]: ufcs.html#angle-bracket-form
 [Unsafe]: unsafe.html
-[Unsized Types (`?Sized`)]: unsized-types.html#Sized
+[Unsized Types (`?Sized`)]: unsized-types.html#sized
 [Variable Bindings]: variable-bindings.html

--- a/src/doc/book/src/traits.md
+++ b/src/doc/book/src/traits.md
@@ -81,7 +81,7 @@ Traits are useful because they allow a type to make certain promises about its
 behavior. Generic functions can exploit this to constrain, or [bound][bounds], the types they
 accept. Consider this function, which does not compile:
 
-[bounds]: glossary.html#Bounds
+[bounds]: glossary.html#bounds
 
 ```rust,ignore
 fn print_area<T>(shape: T) {

--- a/src/doc/book/src/type-aliases.md
+++ b/src/doc/book/src/type-aliases.md
@@ -55,7 +55,7 @@ if x == y {
 This compiles without error. Values of a `Num` type are the same as a value of
 type `i32`, in every way. You can use [tuple struct] to really get a new type.
 
-[tuple struct]: structs.html#Tuple%20structs
+[tuple struct]: structs.html#tuple-structs
 
 You can also use type aliases with generics:
 

--- a/src/doc/book/src/vectors.md
+++ b/src/doc/book/src/vectors.md
@@ -151,6 +151,6 @@ API documentation][vec].
 [vec]: ../std/vec/index.html
 [box]: ../std/boxed/index.html
 [generic]: generics.html
-[panic]: concurrency.html#Panics
+[panic]: concurrency.html#panics
 [get]: ../std/vec/struct.Vec.html#method.get
 [get_mut]: ../std/vec/struct.Vec.html#method.get_mut

--- a/src/doc/nomicon/src/lifetime-mismatch.md
+++ b/src/doc/nomicon/src/lifetime-mismatch.md
@@ -78,4 +78,4 @@ TODO: other common problems? SEME regions stuff, mostly?
 
 
 
-[ex2]: lifetimes.html#Example%3A%20aliasing%20a%20mutable%20reference
+[ex2]: lifetimes.html#example-aliasing-a-mutable-reference

--- a/src/doc/nomicon/src/repr-rust.md
+++ b/src/doc/nomicon/src/repr-rust.md
@@ -151,4 +151,4 @@ use fairly elaborate algorithms to cache bits throughout nested types with
 special constrained representations. As such it is *especially* desirable that
 we leave enum layout unspecified today.
 
-[dst]: exotic-sizes.html#Dynamically%20Sized%20Types%20(DSTs)
+[dst]: exotic-sizes.html#dynamically-sized-types-dsts

--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2108,7 +2108,7 @@ On `struct`s:
   list of names `#[macro_use(foo, bar)]` restricts the import to just those
   macros named.  The `extern crate` must appear at the crate root, not inside
   `mod`, which ensures proper function of the [`$crate` macro
-  variable](book/macros.html#The%20variable%20%24crate).
+  variable](book/macros.html#the-variable-crate).
 
 - `macro_reexport` on an `extern crate` — re-export the named macros.
 
@@ -2118,7 +2118,7 @@ On `struct`s:
   link it into the output.
 
 See the [macros section of the
-book](book/macros.html#Scoping%20and%20macro%20import%2Fexport) for more information on
+book](book/macros.html#scoping-and-macro-importexport) for more information on
 macro scope.
 
 
@@ -2277,7 +2277,7 @@ For any lint check `C`:
 
 The lint checks supported by the compiler can be found via `rustc -W help`,
 along with their default settings.  [Compiler
-plugins](book/compiler-plugins.html#Lint%20plugins) can provide additional lint checks.
+plugins](book/compiler-plugins.html#lint-plugins) can provide additional lint checks.
 
 ```{.ignore}
 pub mod m1 {

--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -102,7 +102,7 @@ const MAX_REFCOUNT: usize = (isize::MAX) as usize;
 /// [downgrade]: struct.Arc.html#method.downgrade
 /// [upgrade]: struct.Weak.html#method.upgrade
 /// [`None`]: ../../std/option/enum.Option.html#variant.None
-/// [assoc]: ../../book/method-syntax.html#Associated%20functions
+/// [assoc]: ../../book/method-syntax.html#associated-functions
 ///
 /// # Examples
 ///

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -215,7 +215,7 @@
 //! [downgrade]: struct.Rc.html#method.downgrade
 //! [upgrade]: struct.Weak.html#method.upgrade
 //! [`None`]: ../../std/option/enum.Option.html#variant.None
-//! [assoc]: ../../book/method-syntax.html#Associated%20functions
+//! [assoc]: ../../book/method-syntax.html#associated-functions
 //! [mutability]: ../../std/cell/index.html#introducing-mutability-inside-of-something-immutable
 
 #![stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -525,7 +525,7 @@ pub fn replace<T>(dest: &mut T, mut src: T) -> T {
 /// it will not release any borrows, as borrows are based on lexical scope.
 ///
 /// This effectively does nothing for
-/// [types which implement `Copy`](../../book/ownership.html#Copy%20types),
+/// [types which implement `Copy`](../../book/ownership.html#copy-types),
 /// e.g. integers. Such values are copied and _then_ moved into the function,
 /// so the value persists after this function call.
 ///

--- a/src/libcore/raw.rs
+++ b/src/libcore/raw.rs
@@ -25,7 +25,7 @@
 /// Book][moreinfo] contains more details about the precise nature of
 /// these internals.
 ///
-/// [moreinfo]: ../../book/trait-objects.html#Representation
+/// [moreinfo]: ../../book/trait-objects.html#representation
 ///
 /// `TraitObject` is guaranteed to match layouts, but it is not the
 /// type of trait objects (e.g. the fields are not directly accessible

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -189,8 +189,8 @@
 //! [`sync`]: sync/index.html
 //! [`thread`]: thread/index.html
 //! [`use std::env`]: env/index.html
-//! [`use`]: ../book/crates-and-modules.html#Importing%20Modules%20with%20use
-//! [crate root]: ../book/crates-and-modules.html#Basic%20terminology%3A%20Crates%20and%20Modules
+//! [`use`]: ../book/crates-and-modules.html#importing-modules-with-use
+//! [crate root]: ../book/crates-and-modules.html#basic-terminology-crates-and-modules
 //! [crates.io]: https://crates.io
 //! [deref coercions]: ../book/deref-coercions.html
 //! [files]: fs/struct.File.html

--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -490,7 +490,7 @@ mod prim_str { }
 /// assert_eq!(tuple.2, 'c');
 /// ```
 ///
-/// For more about tuples, see [the book](../book/primitive-types.html#Tuples).
+/// For more about tuples, see [the book](../book/primitive-types.html#tuples).
 ///
 /// # Trait implementations
 ///

--- a/src/tools/rustbook/Cargo.toml
+++ b/src/tools/rustbook/Cargo.toml
@@ -8,5 +8,5 @@ license = "MIT/Apache-2.0"
 clap = "2.19.3"
 
 [dependencies.mdbook]
-version = "0.0.15"
+version = "0.0.16"
 default-features = false


### PR DESCRIPTION
In some senses, this is a revert of https://github.com/rust-lang/rust/pull/39633/commits/cacb3bc9c741a7d41a1085af850cd3ff852307f5#diff-b64563d143f859565c8357a28ef81101R212; we disabled linkchecker for the book because the links were added by JavaScript. Now, that's fixed upstream, and so we can re-enable the checker.

This also involves two other fixes: we have to check for `name`s as well as `id`s for links, and the linking algorithm of mdBook changed to the same as rustdoc's, so we change some links back.

~~~This isn't quite ready yet; it's [depending on a PR of mine to mdBook](https://github.com/azerupi/mdBook/pull/209). After that's released, this should be the last of these kinds of shenanigans~~~ 😄

This is good to go 😄 