### PR TITLE
librustc error_reporting.rs cleanup.

### DIFF
--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -533,55 +533,54 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
 
                         if self.tcx.sess.has_errors() && trait_predicate.references_error() {
                             return;
-                        } else {
-                            let trait_ref = trait_predicate.to_poly_trait_ref();
-                            let (post_message, pre_message) =
-                                self.get_parent_trait_ref(&obligation.cause.code)
-                                    .map(|t| (format!(" in `{}`", t), format!("within `{}`, ", t)))
-                                    .unwrap_or((String::new(), String::new()));
-                            let mut err = struct_span_err!(
-                                self.tcx.sess,
-                                span,
-                                E0277,
-                                "the trait bound `{}` is not satisfied{}",
-                                trait_ref.to_predicate(),
-                                post_message);
-                            err.span_label(span,
-                                            &format!("{}the trait `{}` is not \
-                                                        implemented for `{}`",
-                                                    pre_message,
-                                                    trait_ref,
-                                                    trait_ref.self_ty()));
-
-                            // Try to report a help message
-
-                            if !trait_ref.has_infer_types() &&
-                                self.predicate_can_apply(trait_ref) {
-                                // If a where-clause may be useful, remind the
-                                // user that they can add it.
-                                //
-                                // don't display an on-unimplemented note, as
-                                // these notes will often be of the form
-                                //     "the type `T` can't be frobnicated"
-                                // which is somewhat confusing.
-                                err.help(&format!("consider adding a `where {}` bound",
-                                                    trait_ref.to_predicate()));
-                            } else if let Some(s) = self.on_unimplemented_note(trait_ref,
-                                                                                obligation) {
-                                // If it has a custom "#[rustc_on_unimplemented]"
-                                // error message, let's display it!
-                                err.note(&s);
-                            } else {
-                                // If we can't show anything useful, try to find
-                                // similar impls.
-                                let impl_candidates =
-                                    self.find_similar_impl_candidates(trait_ref);
-                                if impl_candidates.len() > 0 {
-                                    self.report_similar_impl_candidates(trait_ref, &mut err);
-                                }
-                            }
-                            err
                         }
+                        let trait_ref = trait_predicate.to_poly_trait_ref();
+                        let (post_message, pre_message) =
+                            self.get_parent_trait_ref(&obligation.cause.code)
+                                .map(|t| (format!(" in `{}`", t), format!("within `{}`, ", t)))
+                                .unwrap_or((String::new(), String::new()));
+                        let mut err = struct_span_err!(
+                            self.tcx.sess,
+                            span,
+                            E0277,
+                            "the trait bound `{}` is not satisfied{}",
+                            trait_ref.to_predicate(),
+                            post_message);
+                        err.span_label(span,
+                                        &format!("{}the trait `{}` is not \
+                                                    implemented for `{}`",
+                                                pre_message,
+                                                trait_ref,
+                                                trait_ref.self_ty()));
+
+                        // Try to report a help message
+
+                        if !trait_ref.has_infer_types() &&
+                            self.predicate_can_apply(trait_ref) {
+                            // If a where-clause may be useful, remind the
+                            // user that they can add it.
+                            //
+                            // don't display an on-unimplemented note, as
+                            // these notes will often be of the form
+                            //     "the type `T` can't be frobnicated"
+                            // which is somewhat confusing.
+                            err.help(&format!("consider adding a `where {}` bound",
+                                                trait_ref.to_predicate()));
+                        } else if let Some(s) = self.on_unimplemented_note(trait_ref,
+                                                                            obligation) {
+                            // If it has a custom "#[rustc_on_unimplemented]"
+                            // error message, let's display it!
+                            err.note(&s);
+                        } else {
+                            // If we can't show anything useful, try to find
+                            // similar impls.
+                            let impl_candidates =
+                                self.find_similar_impl_candidates(trait_ref);
+                            if impl_candidates.len() > 0 {
+                                self.report_similar_impl_candidates(trait_ref, &mut err);
+                            }
+                        }
+                        err
                     }
 
                     ty::Predicate::Equate(ref predicate) => {

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -21,7 +21,6 @@ use super::{
     SelectionContext,
     SelectionError,
     ObjectSafetyViolation,
-    MethodViolationCode,
 };
 
 use fmt_macros::{Parser, Piece, Position};
@@ -679,38 +678,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             if !reported_violations.insert(violation.clone()) {
                 continue;
             }
-            let buf;
-            let note = match violation {
-                ObjectSafetyViolation::SizedSelf => {
-                    "the trait cannot require that `Self : Sized`"
-                }
-
-                ObjectSafetyViolation::SupertraitSelf => {
-                    "the trait cannot use `Self` as a type parameter \
-                         in the supertrait listing"
-                }
-
-                ObjectSafetyViolation::Method(name,
-                                              MethodViolationCode::StaticMethod) => {
-                    buf = format!("method `{}` has no receiver", name);
-                    &buf
-                }
-
-                ObjectSafetyViolation::Method(name,
-                                              MethodViolationCode::ReferencesSelf) => {
-                    buf = format!("method `{}` references the `Self` type \
-                                       in its arguments or return type",
-                                  name);
-                    &buf
-                }
-
-                ObjectSafetyViolation::Method(name,
-                                              MethodViolationCode::Generic) => {
-                    buf = format!("method `{}` has generic type parameters", name);
-                    &buf
-                }
-            };
-            err.note(note);
+            err.note(&violation.error_msg());
         }
         err
     }

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -535,14 +535,10 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                             return;
                         } else {
                             let trait_ref = trait_predicate.to_poly_trait_ref();
-                            let (post_message, pre_message) = match self.get_parent_trait_ref(
-                                &obligation.cause.code)
-                            {
-                                Some(t) => {
-                                    (format!(" in `{}`", t), format!("within `{}`, ", t))
-                                }
-                                None => (String::new(), String::new()),
-                            };
+                            let (post_message, pre_message) =
+                                self.get_parent_trait_ref(&obligation.cause.code)
+                                    .map(|t| (format!(" in `{}`", t), format!("within `{}`, ", t)))
+                                    .unwrap_or((String::new(), String::new()));
                             let mut err = struct_span_err!(
                                 self.tcx.sess,
                                 span,

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1086,24 +1086,6 @@ impl<'tcx> InstantiatedPredicates<'tcx> {
     }
 }
 
-impl<'tcx> TraitRef<'tcx> {
-    pub fn new(def_id: DefId, substs: &'tcx Substs<'tcx>) -> TraitRef<'tcx> {
-        TraitRef { def_id: def_id, substs: substs }
-    }
-
-    pub fn self_ty(&self) -> Ty<'tcx> {
-        self.substs.type_at(0)
-    }
-
-    pub fn input_types<'a>(&'a self) -> impl DoubleEndedIterator<Item=Ty<'tcx>> + 'a {
-        // Select only the "input types" from a trait-reference. For
-        // now this is all the types that appear in the
-        // trait-reference, but it should eventually exclude
-        // associated types.
-        self.substs.types()
-    }
-}
-
 /// When type checking, we use the `ParameterEnvironment` to track
 /// details about the type/lifetime parameters that are in scope.
 /// It primarily stores the bounds information.

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -389,6 +389,24 @@ pub struct TraitRef<'tcx> {
     pub substs: &'tcx Substs<'tcx>,
 }
 
+impl<'tcx> TraitRef<'tcx> {
+    pub fn new(def_id: DefId, substs: &'tcx Substs<'tcx>) -> TraitRef<'tcx> {
+        TraitRef { def_id: def_id, substs: substs }
+    }
+
+    pub fn self_ty(&self) -> Ty<'tcx> {
+        self.substs.type_at(0)
+    }
+
+    pub fn input_types<'a>(&'a self) -> impl DoubleEndedIterator<Item=Ty<'tcx>> + 'a {
+        // Select only the "input types" from a trait-reference. For
+        // now this is all the types that appear in the
+        // trait-reference, but it should eventually exclude
+        // associated types.
+        self.substs.types()
+    }
+}
+
 pub type PolyTraitRef<'tcx> = Binder<TraitRef<'tcx>>;
 
 impl<'tcx> PolyTraitRef<'tcx> {


### PR DESCRIPTION
Read some code in librustc, mainly in error_reporting.rs, and cleaned up some things along the way. I recommend looking at each commit individually or looking at the [whitespace insensitive diff](https://github.com/rust-lang/rust/pull/39977/files?w=1).