### PR TITLE
Generalize Iterator::cloned to take Deref

### DIFF
--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use cmp::Ordering;
+use ops::Deref;
 
 use super::{Chain, Cycle, Cloned, Enumerate, Filter, FilterMap, FlatMap, Fuse};
 use super::{Inspect, Map, Peekable, Scan, Skip, SkipWhile, Take, TakeWhile, Rev};
@@ -1851,7 +1852,8 @@ pub trait Iterator {
 
     /// Creates an iterator which [`clone()`]s all of its elements.
     ///
-    /// This is useful when you have an iterator over `&T`, but you need an
+    /// This is useful when you have an iterator over a type that implements
+    /// `Deref<Target=T>` (such as `&T` and `&mut T`), but you need an
     /// iterator over `T`.
     ///
     /// [`clone()`]: ../../std/clone/trait.Clone.html#tymethod.clone
@@ -1872,8 +1874,8 @@ pub trait Iterator {
     /// assert_eq!(v_map, vec![1, 2, 3]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn cloned<'a, T: 'a>(self) -> Cloned<Self>
-        where Self: Sized + Iterator<Item=&'a T>, T: Clone
+    fn cloned<'a, T: 'a, U>(self) -> Cloned<Self>
+        where Self: Sized + Iterator<Item=U>, T: Clone, U : Deref<Target=T>
     {
         Cloned { it: self }
     }

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -303,6 +303,7 @@ use cmp;
 use fmt;
 use iter_private::TrustedRandomAccess;
 use usize;
+use ops::Deref;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::iterator::Iterator;
@@ -402,13 +403,13 @@ pub struct Cloned<I> {
 }
 
 #[stable(feature = "iter_cloned", since = "1.1.0")]
-impl<'a, I, T: 'a> Iterator for Cloned<I>
-    where I: Iterator<Item=&'a T>, T: Clone
+impl<'a, I, T: 'a, U> Iterator for Cloned<I>
+    where I: Iterator<Item=U>, T: Clone, U : Deref<Target=T>
 {
     type Item = T;
 
     fn next(&mut self) -> Option<T> {
-        self.it.next().cloned()
+        self.it.next().map(|x| x.deref().clone())
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -418,22 +419,22 @@ impl<'a, I, T: 'a> Iterator for Cloned<I>
     fn fold<Acc, F>(self, init: Acc, mut f: F) -> Acc
         where F: FnMut(Acc, Self::Item) -> Acc,
     {
-        self.it.fold(init, move |acc, elt| f(acc, elt.clone()))
+        self.it.fold(init, move |acc, elt| f(acc, elt.deref().clone()))
     }
 }
 
 #[stable(feature = "iter_cloned", since = "1.1.0")]
-impl<'a, I, T: 'a> DoubleEndedIterator for Cloned<I>
-    where I: DoubleEndedIterator<Item=&'a T>, T: Clone
+impl<'a, I, T: 'a, U> DoubleEndedIterator for Cloned<I>
+    where I: DoubleEndedIterator<Item=U>, T: Clone, U : Deref<Target=T>
 {
     fn next_back(&mut self) -> Option<T> {
-        self.it.next_back().cloned()
+        self.it.next_back().map(|x| x.deref().clone())
     }
 }
 
 #[stable(feature = "iter_cloned", since = "1.1.0")]
-impl<'a, I, T: 'a> ExactSizeIterator for Cloned<I>
-    where I: ExactSizeIterator<Item=&'a T>, T: Clone
+impl<'a, I, T: 'a, U> ExactSizeIterator for Cloned<I>
+    where I: ExactSizeIterator<Item=U>, T: Clone, U : Deref<Target=T>
 {
     fn len(&self) -> usize {
         self.it.len()
@@ -445,13 +446,13 @@ impl<'a, I, T: 'a> ExactSizeIterator for Cloned<I>
 }
 
 #[unstable(feature = "fused", issue = "35602")]
-impl<'a, I, T: 'a> FusedIterator for Cloned<I>
-    where I: FusedIterator<Item=&'a T>, T: Clone
+impl<'a, I, T: 'a, U> FusedIterator for Cloned<I>
+    where I: FusedIterator<Item=U>, T: Clone, U : Deref<Target=T>
 {}
 
 #[doc(hidden)]
-unsafe impl<'a, I, T: 'a> TrustedRandomAccess for Cloned<I>
-    where I: TrustedRandomAccess<Item=&'a T>, T: Clone
+unsafe impl<'a, I, T: 'a, U> TrustedRandomAccess for Cloned<I>
+    where I: TrustedRandomAccess<Item=U>, T: Clone, U : Deref<Target=T>
 {
     unsafe fn get_unchecked(&mut self, i: usize) -> Self::Item {
         self.it.get_unchecked(i).clone()
@@ -462,9 +463,10 @@ unsafe impl<'a, I, T: 'a> TrustedRandomAccess for Cloned<I>
 }
 
 #[unstable(feature = "trusted_len", issue = "37572")]
-unsafe impl<'a, I, T: 'a> TrustedLen for Cloned<I>
-    where I: TrustedLen<Item=&'a T>,
-          T: Clone
+unsafe impl<'a, I, T: 'a, U> TrustedLen for Cloned<I>
+    where I: TrustedLen<Item=U>,
+          T: Clone,
+          U: Deref<Target=T>
 {}
 
 /// An iterator that repeats endlessly.


### PR DESCRIPTION
I found it annoying that `cloned` dosen't work if `Item=&mut T`. Is this a good way to fix it? Probably breaks inference for somebody and needs crater (if it's correct at all).