### PR TITLE
Refactor parsing of trait object types

### DIFF
--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -17,7 +17,7 @@ pub use self::PathParameters::*;
 pub use symbol::Symbol as Name;
 pub use util::ThinVec;
 
-use syntax_pos::{mk_sp, Span, DUMMY_SP, ExpnId};
+use syntax_pos::{mk_sp, BytePos, Span, DUMMY_SP, ExpnId};
 use codemap::{respan, Spanned};
 use abi::Abi;
 use ext::hygiene::SyntaxContext;
@@ -1714,6 +1714,16 @@ pub struct PolyTraitRef {
     pub trait_ref: TraitRef,
 
     pub span: Span,
+}
+
+impl PolyTraitRef {
+    pub fn new(lifetimes: Vec<LifetimeDef>, path: Path, lo: BytePos, hi: BytePos) -> Self {
+        PolyTraitRef {
+            bound_lifetimes: lifetimes,
+            trait_ref: TraitRef { path: path, ref_id: DUMMY_NODE_ID },
+            span: mk_sp(lo, hi),
+        }
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -657,7 +657,7 @@ impl<'a> Parser<'a> {
             }
             ExpansionKind::Expr => Expansion::Expr(self.parse_expr()?),
             ExpansionKind::OptExpr => Expansion::OptExpr(Some(self.parse_expr()?)),
-            ExpansionKind::Ty => Expansion::Ty(self.parse_ty_no_plus()?),
+            ExpansionKind::Ty => Expansion::Ty(self.parse_ty()?),
             ExpansionKind::Pat => Expansion::Pat(self.parse_pat()?),
         })
     }

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -414,7 +414,7 @@ pub fn parse_arm_panic(parser: &mut Parser) -> Arm {
 }
 
 pub fn parse_ty_panic(parser: &mut Parser) -> P<Ty> {
-    panictry!(parser.parse_ty_no_plus())
+    panictry!(parser.parse_ty())
 }
 
 pub fn parse_stmt_panic(parser: &mut Parser) -> Option<Stmt> {

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -512,7 +512,7 @@ fn parse_nt<'a>(p: &mut Parser<'a>, sp: Span, name: &str) -> Nonterminal {
         },
         "pat" => token::NtPat(panictry!(p.parse_pat())),
         "expr" => token::NtExpr(panictry!(p.parse_expr())),
-        "ty" => token::NtTy(panictry!(p.parse_ty_no_plus())),
+        "ty" => token::NtTy(panictry!(p.parse_ty())),
         // this could be handled like a token, since it is one
         "ident" => match p.token {
             token::Ident(sn) => {

--- a/src/test/compile-fail/E0178.rs
+++ b/src/test/compile-fail/E0178.rs
@@ -17,15 +17,12 @@ struct Bar<'a> {
     x: &'a Foo + 'a,
     //~^ ERROR E0178
     //~| NOTE expected a path
-    //~| ERROR at least one non-builtin trait is required for an object type
     y: &'a mut Foo + 'a,
     //~^ ERROR E0178
     //~| NOTE expected a path
-    //~| ERROR at least one non-builtin trait is required for an object type
     z: fn() -> Foo + 'a,
     //~^ ERROR E0178
     //~| NOTE expected a path
-    //~| ERROR at least one non-builtin trait is required for an object type
 }
 
 fn main() {

--- a/src/test/compile-fail/issue-34334.rs
+++ b/src/test/compile-fail/issue-34334.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 fn main () {
-    let sr: Vec<(u32, _, _) = vec![]; //~ ERROR expected one of `+`, `,`, or `>`, found `=`
+    let sr: Vec<(u32, _, _) = vec![]; //~ ERROR expected one of `,` or `>`, found `=`
     let sr2: Vec<(u32, _, _)> = sr.iter().map(|(faction, th_sender, th_receiver)| {}).collect();
     //~^ ERROR cannot find value `sr` in this scope
 }

--- a/src/test/compile-fail/privacy/restricted/tuple-struct-fields/test2.rs
+++ b/src/test/compile-fail/privacy/restricted/tuple-struct-fields/test2.rs
@@ -12,8 +12,8 @@ macro_rules! define_struct {
     ($t:ty) => {
         struct S1(pub $t);
         struct S2(pub (foo) ());
-        struct S3(pub $t ()); //~ ERROR expected one of `+` or `,`, found `(`
-                              //~| ERROR expected one of `+`, `;`, or `where`, found `(`
+        struct S3(pub $t ()); //~ ERROR expected `,`, found `(`
+                              //~| ERROR expected one of `;` or `where`, found `(`
     }
 }
 

--- a/src/test/compile-fail/privacy/restricted/tuple-struct-fields/test3.rs
+++ b/src/test/compile-fail/privacy/restricted/tuple-struct-fields/test3.rs
@@ -12,8 +12,8 @@ macro_rules! define_struct {
     ($t:ty) => {
         struct S1(pub($t));
         struct S2(pub (foo) ());
-        struct S3(pub($t) ()); //~ ERROR expected one of `+` or `,`, found `(`
-                               //~| ERROR expected one of `+`, `;`, or `where`, found `(`
+        struct S3(pub($t) ()); //~ ERROR expected `,`, found `(`
+                               //~| ERROR expected one of `;` or `where`, found `(`
     }
 }
 

--- a/src/test/compile-fail/trait-object-macro-matcher.rs
+++ b/src/test/compile-fail/trait-object-macro-matcher.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,9 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-mod foo {
-    type T = ();
-    struct S1(pub(foo) (), pub(T), pub(crate) (), pub(((), T)));
-    struct S2(pub((foo)) ()); //~ ERROR expected `,`, found `(`
-                              //~| ERROR expected one of `;` or `where`, found `(`
+// `ty` matcher accepts trait object types
+
+macro_rules! m {
+    ($t: ty) => ( let _: $t; )
+}
+
+fn main() {
+    m!(Copy + Send + 'static); //~ ERROR the trait `std::marker::Copy` cannot be made into an object
 }

--- a/src/test/compile-fail/trait-object-reference-without-parens-suggestion.rs
+++ b/src/test/compile-fail/trait-object-reference-without-parens-suggestion.rs
@@ -13,10 +13,9 @@ fn main() {
     //~^ ERROR expected a path
     //~| HELP try adding parentheses
     //~| SUGGESTION let _: &(Copy + 'static);
-    //~| ERROR at least one non-builtin trait is required for an object type
+    //~| ERROR the trait `std::marker::Copy` cannot be made into an object
     let _: &'static Copy + 'static;
     //~^ ERROR expected a path
     //~| HELP try adding parentheses
     //~| SUGGESTION let _: &'static (Copy + 'static);
-    //~| ERROR at least one non-builtin trait is required for an object type
 }

--- a/src/test/parse-fail/bounds-obj-parens.rs
+++ b/src/test/parse-fail/bounds-obj-parens.rs
@@ -10,6 +10,6 @@
 
 // compile-flags: -Z parse-only
 
-type A = Box<(Fn(D::Error) -> E) + 'static + Send + Sync>; // OK
+type A = Box<(Fn(D::Error) -> E) + 'static + Send + Sync>; // OK (but see #39318)
 
 FAIL //~ ERROR

--- a/src/test/parse-fail/issue-17904.rs
+++ b/src/test/parse-fail/issue-17904.rs
@@ -13,6 +13,6 @@
 struct Baz<U> where U: Eq(U); //This is parsed as the new Fn* style parenthesis syntax.
 struct Baz<U> where U: Eq(U) -> R; // Notice this parses as well.
 struct Baz<U>(U) where U: Eq; // This rightfully signals no error as well.
-struct Foo<T> where T: Copy, (T); //~ ERROR expected one of `+`, `:`, `==`, or `=`, found `;`
+struct Foo<T> where T: Copy, (T); //~ ERROR expected one of `:`, `==`, or `=`, found `;`
 
 fn main() {}

--- a/src/test/parse-fail/removed-syntax-ptr-lifetime.rs
+++ b/src/test/parse-fail/removed-syntax-ptr-lifetime.rs
@@ -10,4 +10,4 @@
 
 // compile-flags: -Z parse-only
 
-type bptr = &lifetime/isize; //~ ERROR expected one of `!`, `(`, `+`, `::`, `;`, or `<`, found `/`
+type bptr = &lifetime/isize; //~ ERROR expected one of `!`, `(`, `::`, `;`, or `<`, found `/`

--- a/src/test/parse-fail/removed-syntax-uniq-mut-ty.rs
+++ b/src/test/parse-fail/removed-syntax-uniq-mut-ty.rs
@@ -10,4 +10,4 @@
 
 // compile-flags: -Z parse-only
 
-type mut_box = Box<mut isize>; //~ ERROR expected type, found keyword `mut`
+type mut_box = Box<mut isize>; //~ ERROR expected one of `>`, lifetime, or type, found `mut`

--- a/src/test/parse-fail/trailing-plus-in-bounds.rs
+++ b/src/test/parse-fail/trailing-plus-in-bounds.rs
@@ -13,7 +13,7 @@
 use std::fmt::Debug;
 
 fn main() {
-    let x: Box<Debug+> = box 3 as Box<Debug+>;
-    //~^ ERROR at least one type parameter bound must be specified
-    //~^^ ERROR at least one type parameter bound must be specified
+    let x: Box<Debug+> = box 3 as Box<Debug+>; // Trailing `+` is OK
 }
+
+FAIL //~ ERROR

--- a/src/test/parse-fail/trait-object-macro-matcher.rs
+++ b/src/test/parse-fail/trait-object-macro-matcher.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,9 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-mod foo {
-    type T = ();
-    struct S1(pub(foo) (), pub(T), pub(crate) (), pub(((), T)));
-    struct S2(pub((foo)) ()); //~ ERROR expected `,`, found `(`
-                              //~| ERROR expected one of `;` or `where`, found `(`
+// A single lifetime is not parsed as a type.
+// `ty` matcher in particular doesn't accept a single lifetime
+
+macro_rules! m {
+    ($t: ty) => ( let _: $t; )
+}
+
+fn main() {
+    m!('static); //~ ERROR expected type, found `'static`
 }

--- a/src/test/parse-fail/trait-object-polytrait-priority.rs
+++ b/src/test/parse-fail/trait-object-polytrait-priority.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,9 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-mod foo {
-    type T = ();
-    struct S1(pub(foo) (), pub(T), pub(crate) (), pub(((), T)));
-    struct S2(pub((foo)) ()); //~ ERROR expected `,`, found `(`
-                              //~| ERROR expected one of `;` or `where`, found `(`
+trait Trait<'a> {}
+
+fn main() {
+    let _: &for<'a> Trait<'a> + 'static;
+    //~^ ERROR expected a path on the left-hand side of `+`, not `& for<'a>Trait<'a>`
+    //~| NOTE expected a path
+    //~| HELP try adding parentheses
+    //~| SUGGESTION &( for<'a>Trait<'a> + 'static)
 }

--- a/src/test/run-pass/issue-28279.rs
+++ b/src/test/run-pass/issue-28279.rs
@@ -18,7 +18,7 @@ fn test1() -> Rc<for<'a> Fn(&'a usize) + 'static> {
     }
 }
 
-fn test2() -> *mut for<'a> Fn(&'a usize) + 'static {
+fn test2() -> *mut (for<'a> Fn(&'a usize) + 'static) {
     if let Some(_) = Some(1) {
         loop{}
     } else {
@@ -27,4 +27,3 @@ fn test2() -> *mut for<'a> Fn(&'a usize) + 'static {
 }
 
 fn main() {}
-


### PR DESCRIPTION
Bugs are fixed and code is cleaned up.

User visible changes:
- `ty` matcher in macros accepts trait object types like `Write + Send` (https://github.com/rust-lang/rust/issues/39080)
- Buggy priority of `+` in trait object types starting with `for` is fixed (https://github.com/rust-lang/rust/issues/39317). `&for<'a> Trait<'a> + Send` is now parsed as `(&for<'a> Trait<'a>) + Send` and requires parens `&(for<'a> Trait<'a> + Send)`. For comparison, `&Send + for<'a> Trait<'a>` was parsed like this since [Nov 27, 2014](https://github.com/rust-lang/rust/pull/19298).
- Trailing `+`s are supported in trait objects, like in other bounds.
- Better error reporting for trait objects starting with `?Sized`.

Fixes https://github.com/rust-lang/rust/issues/39080
Fixes https://github.com/rust-lang/rust/issues/39317 [breaking-change]
Closes https://github.com/rust-lang/rust/issues/39298
cc https://github.com/rust-lang/rust/issues/39085 (fixed, then reverted https://github.com/rust-lang/rust/pull/40043#issuecomment-286570653)
cc https://github.com/rust-lang/rust/issues/39318 (fixed, then reverted https://github.com/rust-lang/rust/pull/40043#issuecomment-284493890)

r? @nikomatsakis 