### PR TITLE
Add compile fail test for unboxed_closures feature

### DIFF
--- a/src/test/compile-fail/feature-gate-unboxed-closures.rs
+++ b/src/test/compile-fail/feature-gate-unboxed-closures.rs
@@ -1,0 +1,24 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Test;
+
+impl FnOnce<(u32, u32)> for Test {
+    type Output = u32;
+
+    extern "rust-call" fn call_once(self, (a, b): (u32, u32)) -> u32 {
+        a + b
+    }
+    //~^^^ ERROR rust-call ABI is subject to change (see issue #29625)
+}
+
+fn main() {
+    assert_eq!(Test(1u32, 2u32), 3u32);
+}

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -169,8 +169,8 @@ pub fn check(path: &Path, bad: &mut bool) {
     let whitelist = vec![
         "abi_ptx", "simd",
         "cfg_target_has_atomic",
-        "unboxed_closures", "stmt_expr_attributes",
-        "cfg_target_thread_local", "unwind_attributes"
+        "stmt_expr_attributes",
+        "cfg_target_thread_local", "unwind_attributes",
     ];
 
     // Only check the number of lang features.


### PR DESCRIPTION
Hello, this is my first contribution to rust.
Issue #39059.