### PR TITLE
Fix nightly-only experimental API display

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1878,7 +1878,7 @@ fn short_stability(item: &clean::Item, cx: &Context, show_reason: bool) -> Vec<S
                                             &cx.shared.issue_tracker_base_url,
                                             stab.issue) {
                     (true, &Some(ref tracker_url), Some(issue_no)) if issue_no > 0 =>
-                        format!(" (<code>{}</code> <a href=\"{}{}\">#{}</a>)",
+                        format!(" (<code>{} </code><a href=\"{}{}\">#{}</a>)",
                                 Escape(&stab.feature), tracker_url, issue_no, issue_no),
                     (false, &Some(ref tracker_url), Some(issue_no)) if issue_no > 0 =>
                         format!(" (<a href=\"{}{}\">#{}</a>)", Escape(&tracker_url), issue_no,
@@ -1890,12 +1890,12 @@ fn short_stability(item: &clean::Item, cx: &Context, show_reason: bool) -> Vec<S
                 if stab.unstable_reason.is_empty() {
                     stability.push(format!("<div class='stab unstable'>\
                                             <span class=microscope>🔬</span> \
-                                            This is a nightly-only experimental API. &nbsp;{}\
+                                            This is a nightly-only experimental API. {}\
                                             </div>",
-                                   unstable_extra));
+                                           unstable_extra));
                 } else {
                     let text = format!("<summary><span class=microscope>🔬</span> \
-                                        This is a nightly-only experimental API. &nbsp;{}\
+                                        This is a nightly-only experimental API. {}\
                                         </summary>{}",
                                        unstable_extra, MarkdownHtml(&stab.unstable_reason));
                     stability.push(format!("<div class='stab unstable'><details>{}</details></div>",

--- a/src/test/rustdoc/issue-27759.rs
+++ b/src/test/rustdoc/issue-27759.rs
@@ -14,12 +14,12 @@
 #![unstable(feature="test", issue="27759")]
 
 // @has issue_27759/unstable/index.html
-// @has - '<code>test</code>'
+// @has - '<code>test </code>'
 // @has - '<a href="http://issue_url/27759">#27759</a>'
 #[unstable(feature="test", issue="27759")]
 pub mod unstable {
     // @has issue_27759/unstable/fn.issue.html
-    // @has - '<code>test_function</code>'
+    // @has - '<code>test_function </code>'
     // @has - '<a href="http://issue_url/1234567890">#1234567890</a>'
     #[unstable(feature="test_function", issue="1234567890")]
     pub fn issue() {}

--- a/src/test/rustdoc/issue-32374.rs
+++ b/src/test/rustdoc/issue-32374.rs
@@ -18,10 +18,10 @@
 
 // @has issue_32374/struct.T.html '//*[@class="stab deprecated"]' \
 //      'Deprecated since 1.0.0: text'
-// @has - '<code>test</code>'
+// @has - '<code>test </code>'
 // @has - '<a href="http://issue_url/32374">#32374</a>'
 // @matches issue_32374/struct.T.html '//*[@class="stab unstable"]' \
-//      '🔬 This is a nightly-only experimental API.   \(test #32374\)$'
+//      '🔬 This is a nightly-only experimental API.  \(test #32374\)$'
 #[rustc_deprecated(since = "1.0.0", reason = "text")]
 #[unstable(feature = "test", issue = "32374")]
 pub struct T;
@@ -29,11 +29,11 @@ pub struct T;
 // @has issue_32374/struct.U.html '//*[@class="stab deprecated"]' \
 //      'Deprecated since 1.0.0: deprecated'
 // @has issue_32374/struct.U.html '//*[@class="stab unstable"]' \
-//      '🔬 This is a nightly-only experimental API.  (test #32374)'
+//      '🔬 This is a nightly-only experimental API. (test #32374)'
 // @has issue_32374/struct.U.html '//details' \
-//      '🔬 This is a nightly-only experimental API.  (test #32374)'
+//      '🔬 This is a nightly-only experimental API. (test #32374)'
 // @has issue_32374/struct.U.html '//summary' \
-//      '🔬 This is a nightly-only experimental API.  (test #32374)'
+//      '🔬 This is a nightly-only experimental API. (test #32374)'
 // @has issue_32374/struct.U.html '//details/p' \
 //      'unstable'
 #[rustc_deprecated(since = "1.0.0", reason = "deprecated")]


### PR DESCRIPTION
Before:

<img width="1440" alt="screen shot 2017-02-23 at 12 53 09" src="https://cloud.githubusercontent.com/assets/3050060/23258119/0c9cf6f2-f9c7-11e6-9989-15b4346dade0.png">


After:

<img width="1440" alt="screen shot 2017-02-23 at 12 51 40" src="https://cloud.githubusercontent.com/assets/3050060/23258076/e6881118-f9c6-11e6-826c-442a73502b59.png">

r? @frewsxcv 