### PR TITLE
Correct another typo in procedural macros chapter of the Book.

### DIFF
--- a/src/doc/book/src/procedural-macros.md
+++ b/src/doc/book/src/procedural-macros.md
@@ -170,7 +170,7 @@ a representation of our type (which can be either a `struct` or an `enum`).
 Check out the [docs](https://docs.rs/syn/0.10.5/syn/struct.MacroInput.html),
 there is some useful information there. We are able to get the name of the
 type using `ast.ident`. The `quote!` macro lets us write up the Rust code
-that we wish to return and convert it into `Tokens`. `quote!` let's us use some
+that we wish to return and convert it into `Tokens`. `quote!` lets us use some
 really cool templating mechanics; we simply write `#name` and `quote!` will
 replace it with the variable named `name`. You can even do some repetition
 similar to regular macros work. You should check out the


### PR DESCRIPTION
Another (and the only remaining) instance of the lets/let's mistake fixed in c8292fc / 36b00cf.

r? @steveklabnik
