### PR TITLE
Make list of native artifacts to link more compact.

### DIFF
--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -681,15 +681,29 @@ fn link_staticlib(sess: &Session, objects: &[PathBuf], out_filename: &Path,
                                  platforms, and so may need to be preserved");
     }
 
+    let mut libraries = String::new();
+    let mut frameworks = String::new();
+    fn push(s: &mut String, kind: &str, lib: &NativeLibrary) {
+        if s.is_empty() {
+            *s = format!("{}: {}", kind, lib.name)
+        } else {
+            s.push_str(&format!(", {}", lib.name))
+        }
+    }
     for lib in all_native_libs.iter().filter(|l| relevant_lib(sess, l)) {
-        let name = match lib.kind {
+        match lib.kind {
             NativeLibraryKind::NativeStaticNobundle |
-            NativeLibraryKind::NativeUnknown => "library",
-            NativeLibraryKind::NativeFramework => "framework",
+            NativeLibraryKind::NativeUnknown => push(&mut libraries, "library", lib),
+            NativeLibraryKind::NativeFramework => push(&mut frameworks, "framework", lib),
             // These are included, no need to print them
             NativeLibraryKind::NativeStatic => continue,
-        };
-        sess.note_without_error(&format!("{}: {}", name, lib.name));
+        }
+    }
+    if !libraries.is_empty() {
+        sess.note_without_error(&libraries);
+    }
+    if !frameworks.is_empty() {
+        sess.note_without_error(&frameworks);
     }
 }
 


### PR DESCRIPTION
Before:

```
note: link against the following native artifacts when linking against this static library

note: the order and any duplication can be significant on some platforms, and so may need to be preserved

note: library: util

note: library: dl

note: library: rt

note: library: pthread

note: library: gcc_s

note: library: c

note: library: m

note: library: rt

note: library: util

    Finished dev [unoptimized + debuginfo] target(s) in 330.48 secs
```

After:

```
note: link against the following native artifacts when linking against this static library

note: the order and any duplication can be significant on some platforms, and so may need to be preserved

note: library: util, dl, rt, pthread, gcc_s, c, m, rt, util

    Finished dev [unoptimized + debuginfo] target(s) in 330.17 secs
```