### PR TITLE
Fix suggestion span error with a line containing multibyte characters

### DIFF
--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -90,7 +90,8 @@ impl CodeSuggestion {
                          hi_opt: Option<&Loc>) {
             let (lo, hi_opt) = (lo.col.to_usize(), hi_opt.map(|hi| hi.col.to_usize()));
             if let Some(line) = line_opt {
-                if line.len() > lo {
+                if let Some(lo) = line.char_indices().map(|(i, _)| i).nth(lo) {
+                    let hi_opt = hi_opt.and_then(|hi| line.char_indices().map(|(i, _)| i).nth(hi));
                     buf.push_str(match hi_opt {
                         Some(hi) => &line[lo..hi],
                         None => &line[lo..],

--- a/src/test/ui/span/suggestion-non-ascii.rs
+++ b/src/test/ui/span/suggestion-non-ascii.rs
@@ -1,0 +1,16 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+fn main() {
+    let tup = (1,);
+    println!("☃{}", tup[0]);
+}
+

--- a/src/test/ui/span/suggestion-non-ascii.stderr
+++ b/src/test/ui/span/suggestion-non-ascii.stderr
@@ -1,0 +1,11 @@
+error: cannot index a value of type `({integer},)`
+  --> $DIR/suggestion-non-ascii.rs:14:21
+   |
+14 |     println!("☃{}", tup[0]);
+   |                     ^^^^^^
+   |
+help: to access tuple elements, use tuple indexing syntax as shown
+   |     println!("☃{}", tup.0);
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This PR fixes broken suggestions caused by multibyte characters.

e.g. for this code, rustc provides a broken suggestion ([playground](https://is.gd/DWGLu7)):

```rust
fn main() {
    let tup = (1,);
    println!("☃{}", tup[0]);
}
```

```
error: cannot index a value of type `({integer},)`
 --> <anon>:3:21
  |
3 |     println!("☃{}", tup[0]);
  |                     ^^^^^^
  |
help: to access tuple elements, use tuple indexing syntax as shown
  |     println!("☃{}"tup.00]);

error: aborting due to previous error
```

`CodeSuggestion::splice_lines` is misusing `Loc.col` (`CharPos`) as a byte offset when slicing source.