### PR TITLE
doc: Use "macOS" terminology consistently

### DIFF
--- a/src/doc/book/src/ffi.md
+++ b/src/doc/book/src/ffi.md
@@ -408,7 +408,7 @@ libraries:
 * Static - `#[link(name = "my_build_dependency", kind = "static")]`
 * Frameworks - `#[link(name = "CoreFoundation", kind = "framework")]`
 
-Note that frameworks are only available on OSX targets.
+Note that frameworks are only available on macOS targets.
 
 The different `kind` values are meant to differentiate how the native library
 participates in linkage. From a linkage perspective, the Rust compiler creates
@@ -437,7 +437,7 @@ A few examples of how this model can be used are:
   is included in a final target (like a binary), the native library will be
   linked in.
 
-On OSX, frameworks behave with the same semantics as a dynamic library.
+On macOS, frameworks behave with the same semantics as a dynamic library.
 
 # Unsafe blocks
 

--- a/src/doc/book/src/getting-started.md
+++ b/src/doc/book/src/getting-started.md
@@ -167,7 +167,7 @@ fn main() {
 }
 ```
 
-Save the file, and go back to your terminal window. On Linux or OSX, enter the
+Save the file, and go back to your terminal window. On Linux or macOS, enter the
 following commands:
 
 ```bash
@@ -253,7 +253,7 @@ $ rustc main.rs
 
 If you come from a C or C++ background, you'll notice that this is similar to
 `gcc` or `clang`. After compiling successfully, Rust should output a binary
-executable, which you can see on Linux or OSX by entering the `ls` command in
+executable, which you can see on Linux or macOS by entering the `ls` command in
 your shell as follows:
 
 ```bash

--- a/src/doc/reference/src/attributes.md
+++ b/src/doc/reference/src/attributes.md
@@ -219,7 +219,7 @@ command line using `--cfg` (e.g. `rustc main.rs --cfg foo --cfg 'bar="baz"'`).
 Rust code then checks for their presence using the `#[cfg(...)]` attribute:
 
 ```
-// The function is only included in the build when compiling for OSX
+// The function is only included in the build when compiling for macOS
 #[cfg(target_os = "macos")]
 fn macos_only() {
   // ...

--- a/src/doc/reference/src/linkage.md
+++ b/src/doc/reference/src/linkage.md
@@ -46,7 +46,7 @@ be ignored in favor of only building the artifacts specified by command line.
 * `--crate-type=cdylib`, `#[crate_type = "cdylib"]` - A dynamic system
   library will be produced.  This is used when compiling Rust code as
   a dynamic library to be loaded from another language.  This output type will
-  create `*.so` files on Linux, `*.dylib` files on OSX, and `*.dll` files on
+  create `*.so` files on Linux, `*.dylib` files on macOS, and `*.dll` files on
   Windows.
 
 * `--crate-type=rlib`, `#[crate_type = "rlib"]` - A "Rust library" file will be


### PR DESCRIPTION
One line in the documentation used the term macOS while the other six used OSX. Be consistent and use the current product brand of macOS.