### PR TITLE
Panic on errors in `format!` or `<T: Display>::to_string`

### DIFF
--- a/src/libcollections/fmt.rs
+++ b/src/libcollections/fmt.rs
@@ -524,6 +524,7 @@ use string;
 pub fn format(args: Arguments) -> string::String {
     let capacity = args.estimated_capacity();
     let mut output = string::String::with_capacity(capacity);
-    let _ = output.write_fmt(args);
+    output.write_fmt(args)
+          .expect("a formatting trait implementation returned an error");
     output
 }

--- a/src/libcollections/macros.rs
+++ b/src/libcollections/macros.rs
@@ -72,6 +72,12 @@ macro_rules! vec {
 ///
 /// [fmt]: ../std/fmt/index.html
 ///
+/// # Panics
+///
+/// `format!` panics if a formatting trait implementation returns an error.
+/// This indicates an incorrect implementation
+/// since `fmt::Write for String` never returns an error itself.
+///
 /// # Examples
 ///
 /// ```

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -1888,13 +1888,20 @@ pub trait ToString {
     fn to_string(&self) -> String;
 }
 
+/// # Panics
+///
+/// In this implementation, the `to_string` method panics
+/// if the `Display` implementation returns an error.
+/// This indicates an incorrect `Display` implementation
+/// since `fmt::Write for String` never returns an error itself.
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: fmt::Display + ?Sized> ToString for T {
     #[inline]
     default fn to_string(&self) -> String {
         use core::fmt::Write;
         let mut buf = String::new();
-        let _ = buf.write_fmt(format_args!("{}", self));
+        buf.write_fmt(format_args!("{}", self))
+           .expect("a Display implementation return an error unexpectedly");
         buf.shrink_to_fit();
         buf
     }


### PR DESCRIPTION
… instead of silently ignoring a result.

`fmt::Write for String` never returns `Err`, so implementations of `Display` (or other traits of that family) never should either.

Fixes #40103