### PR TITLE
Implement function-like procedural macros ( `#[proc_macro]`)

### DIFF
--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -125,6 +125,10 @@ pub mod __internal {
         fn register_attr_proc_macro(&mut self,
                                     name: &str,
                                     expand: fn(TokenStream, TokenStream) -> TokenStream);
+
+        fn register_bang_proc_macro(&mut self,
+                                    name: &str,
+                                    expand: fn(TokenStream) -> TokenStream);
     }
 
     // Emulate scoped_thread_local!() here essentially

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -586,7 +586,7 @@ impl<'a> CrateLoader<'a> {
         use proc_macro::__internal::Registry;
         use rustc_back::dynamic_lib::DynamicLibrary;
         use syntax_ext::deriving::custom::ProcMacroDerive;
-        use syntax_ext::proc_macro_impl::AttrProcMacro;
+        use syntax_ext::proc_macro_impl::{AttrProcMacro, BangProcMacro};
 
         let path = match dylib {
             Some(dylib) => dylib,
@@ -627,6 +627,15 @@ impl<'a> CrateLoader<'a> {
                                         expand: fn(TokenStream, TokenStream) -> TokenStream) {
                 let expand = SyntaxExtension::AttrProcMacro(
                     Box::new(AttrProcMacro { inner: expand })
+                );
+                self.0.push((Symbol::intern(name), Rc::new(expand)));
+            }
+
+            fn register_bang_proc_macro(&mut self,
+                                        name: &str,
+                                        expand: fn(TokenStream) -> TokenStream) {
+                let expand = SyntaxExtension::ProcMacro(
+                    Box::new(BangProcMacro { inner: expand })
                 );
                 self.0.push((Symbol::intern(name), Rc::new(expand)));
             }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -763,6 +763,11 @@ pub const BUILTIN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeG
                                            "attribute proc macros are currently unstable",
                                            cfg_fn!(proc_macro))),
 
+    ("proc_macro", Normal, Gated(Stability::Unstable,
+                                 "proc_macro",
+                                 "function-like proc macros are currently unstable",
+                                 cfg_fn!(proc_macro))),
+
     ("rustc_derive_registrar", Normal, Gated(Stability::Unstable,
                                              "rustc_derive_registrar",
                                              "used internally by rustc",

--- a/src/test/compile-fail-fulldeps/proc-macro/auxiliary/bang_proc_macro.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/auxiliary/bang_proc_macro.rs
@@ -1,0 +1,23 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// force-host
+// no-prefer-dynamic
+#![feature(proc_macro)]
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro]
+pub fn bang_proc_macro(input: TokenStream) -> TokenStream {
+    input
+}

--- a/src/test/compile-fail-fulldeps/proc-macro/macro-use-bang.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/macro-use-bang.rs
@@ -1,0 +1,21 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:bang_proc_macro.rs
+
+#![feature(proc_macro)]
+
+#[macro_use]
+extern crate bang_proc_macro;
+
+fn main() {
+    bang_proc_macro!(println!("Hello, world!"));
+    //~^ ERROR: procedural macros cannot be imported with `#[macro_use]`
+}

--- a/src/test/compile-fail-fulldeps/proc-macro/resolve-error.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/resolve-error.rs
@@ -11,6 +11,7 @@
 // aux-build:derive-foo.rs
 // aux-build:derive-clona.rs
 // aux-build:attr_proc_macro.rs
+// aux-build:bang_proc_macro.rs
 
 #![feature(proc_macro)]
 
@@ -19,10 +20,16 @@ extern crate derive_foo;
 #[macro_use]
 extern crate derive_clona;
 extern crate attr_proc_macro;
+extern crate bang_proc_macro;
 
 use attr_proc_macro::attr_proc_macro;
+use bang_proc_macro::bang_proc_macro;
 
 macro_rules! FooWithLongNam {
+    () => {}
+}
+
+macro_rules! attr_proc_mac {
     () => {}
 }
 
@@ -61,7 +68,12 @@ fn main() {
 
     attr_proc_macra!();
     //~^ ERROR cannot find macro `attr_proc_macra!` in this scope
+    //~^^ HELP did you mean `attr_proc_mac!`?
 
     Dlona!();
     //~^ ERROR cannot find macro `Dlona!` in this scope
+
+    bang_proc_macrp!();
+    //~^ ERROR cannot find macro `bang_proc_macrp!` in this scope
+    //~^^ HELP did you mean `bang_proc_macro!`?
 }

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/bang-macro.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/bang-macro.rs
@@ -1,0 +1,26 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+#![feature(proc_macro)]
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro]
+pub fn rewrite(input: TokenStream) -> TokenStream {
+    let input = input.to_string();
+
+    assert_eq!(input, r#""Hello, world!""#);
+
+    r#""NOT Hello, world!""#.parse().unwrap()
+}

--- a/src/test/run-pass-fulldeps/proc-macro/bang-macro.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/bang-macro.rs
@@ -1,0 +1,20 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:bang-macro.rs
+
+#![feature(proc_macro)]
+
+extern crate bang_macro;
+use bang_macro::rewrite;
+
+fn main() {
+    assert_eq!(rewrite!("Hello, world!"), "NOT Hello, world!");
+}


### PR DESCRIPTION
Adds the `#[proc_macro]` attribute, which expects bare functions of the kind `fn(TokenStream) -> TokenStream`, which can be invoked like `my_macro!()`.

cc rust-lang/rfcs#1913, #38356

r? @jseyfried
cc @nrc