### PR TITLE
travis: Fix typos in linux-tested-targets

### DIFF
--- a/src/ci/docker/linux-tested-targets/Dockerfile
+++ b/src/ci/docker/linux-tested-targets/Dockerfile
@@ -39,8 +39,8 @@ ENV RUST_CONFIGURE_ARGS \
 # way to produce "super compatible" binaries.
 #
 # See: https://github.com/rust-lang/rust/issues/34978
-ENV CFLAGS_i686_unknown_linux_gnu=-Wa,-mrelax-relocations=no \
-    CFLAGS_x86_64_unknown_linux_gnu=-Wa,-mrelax-relocations=no
+ENV CFLAGS_i686_unknown_linux_musl=-Wa,-mrelax-relocations=no \
+    CFLAGS_x86_64_unknown_linux_musl=-Wa,-mrelax-relocations=no
 
 ENV SCRIPT \
       python2.7 ../x.py test \


### PR DESCRIPTION
These flags were supposed to be relevant for musl, not for gnu

cc #39979