### PR TITLE
Make lifetime elision docs clearer

### DIFF
--- a/src/doc/book/src/lifetimes.md
+++ b/src/doc/book/src/lifetimes.md
@@ -349,8 +349,8 @@ to it.
 
 ## Lifetime Elision
 
-Rust supports powerful local type inference in the bodies of functions but not in their item signatures. 
-It's forbidden to allow reasoning about types based on the item signature alone. 
+Rust supports powerful local type inference in the bodies of functions, but it
+deliberately does not perform any reasoning about types for item signatures. 
 However, for ergonomic reasons, a very restricted secondary inference algorithm called 
 “lifetime elision” does apply when judging lifetimes. Lifetime elision is concerned solely with inferring 
 lifetime parameters using three easily memorizable and unambiguous rules. This means lifetime elision 


### PR DESCRIPTION
Previously it said
"It's forbidden to allow reasoning about types based on the item signature alone."

I think that sentence is wrong. Rust **uses** the item signatures to perform type inference within the body. I think what's meant is the other way around: It does not infer types for item signatures.

r? @steveklabnik 