### PR TITLE
More accurate wording in the reference with regards to privacy

### DIFF
--- a/src/doc/reference/src/visibility-and-privacy.md
+++ b/src/doc/reference/src/visibility-and-privacy.md
@@ -39,11 +39,9 @@ pub enum State {
 With the notion of an item being either public or private, Rust allows item
 accesses in two cases:
 
-1. If an item is public, then it can be used externally through any of its
-   accessible ancestors (either by anyone that has an access to an ancestor
-   in the case of a chain of public ancestors,
-   or by the siblings of a private ancestor, in the case of a chain of public
-   ancestors terminating into a private ancestor).
+1. If an item is public, then it can be accessed externally from some module
+   `m` if you can access all the item's parent modules from `m`. You can
+   also potentially be able to name the item through re-exports. See below.
 2. If an item is private, it may be accessed by the current module and its
    descendants.
 

--- a/src/doc/reference/src/visibility-and-privacy.md
+++ b/src/doc/reference/src/visibility-and-privacy.md
@@ -40,7 +40,10 @@ With the notion of an item being either public or private, Rust allows item
 accesses in two cases:
 
 1. If an item is public, then it can be used externally through any of its
-   public ancestors.
+   accessible ancestors (either by anyone that has an access to an ancestor
+   in the case of a chain of public ancestors,
+   or by the siblings of a private ancestor, in the case of a chain of public
+   ancestors terminating into a private ancestor).
 2. If an item is private, it may be accessed by the current module and its
    descendants.
 


### PR DESCRIPTION
Lately there has been some discussion about the module system and privacy. While reading this discussion, I remembered a case which is described in the reference this way:

> A crate needs a global available "helper module" to itself, but it doesn't want to expose the helper module as a public API. To accomplish this, the root of the crate's hierarchy would have a private module which then internally has a "public API". Because the entire crate is a descendant of the root, then the entire local crate can access this private module through the second case.

However, the "general rules" stated above this example are slightly incongruous with this:

> If an item is public, then it can be used externally through any of its public ancestors.

This isn't wrong, but nothing is said about the case where an item is public, and it has a private ancestor!

I made a short example here: https://play.rust-lang.org/?gist=5aeca813685bf1f8de0e581f259c5bdc&version=stable&backtrace=0
Here, `hello()` and `inner_inner::hello_hello()` are public, an can be used from the sibling items of its private ancestor module, because even if the module is *private*, it's *accessible*.

So the real rule (as exemplified by the example) seems not to be about the *publicity*, but *accessibility*. This is why I changed the wording to the following:

> If an item is public, then it can be used externally through any of its
   accessible ancestors (either by anyone that has an access to an ancestor
   in the case of a chain of public ancestors,
   or by the siblings of a private ancestor, in the case of a chain of public
   ancestors terminating into a private ancestor).

r? @steveklabnik