### PR TITLE
suppress log of test run that actually tests nothing

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -616,6 +616,9 @@ impl<T: Write> ConsoleTestState<T> {
 
     pub fn write_run_start(&mut self, len: usize) -> io::Result<()> {
         self.total = len;
+        if len == 0 {
+            return Ok(());
+        }
         let noun = if len != 1 {
             "tests"
         } else {
@@ -705,6 +708,9 @@ impl<T: Write> ConsoleTestState<T> {
 
     pub fn write_run_finish(&mut self) -> io::Result<bool> {
         assert!(self.passed + self.failed + self.ignored + self.measured == self.total);
+        if self.total == 0 {
+            return Ok(true);
+        }
 
         let success = self.failed == 0;
         if !success {


### PR DESCRIPTION
This should eliminate logs like this

```
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
```

Cargo test output will be more readable with only relevant information