### PR TITLE
Structs doc: Change "pointers" to "references"

### DIFF
--- a/src/doc/book/src/structs.md
+++ b/src/doc/book/src/structs.md
@@ -88,7 +88,7 @@ fn main() {
 }
 ```
 
-Your structure can still contain `&mut` pointers, which will let
+Your structure can still contain `&mut` references, which will let
 you do some kinds of mutation:
 
 ```rust


### PR DESCRIPTION
Let's call them "references" instead of "pointers". That's how they're called in chapter 4.9 "References and Borrowing".

r? @steveklabnik 