### PR TITLE
Unit-like structs doc: Improve code sample

### DIFF
--- a/src/doc/book/src/structs.md
+++ b/src/doc/book/src/structs.md
@@ -259,9 +259,10 @@ You can define a `struct` with no members at all:
 struct Electron {} // Use empty braces...
 struct Proton;     // ...or just a semicolon.
 
-// Whether you declared the struct with braces or not, do the same when creating one.
+// Use the same notation when creating an instance.
 let x = Electron {};
 let y = Proton;
+let z = Electron; // Error
 ```
 
 Such a `struct` is called ‘unit-like’ because it resembles the empty

--- a/src/doc/book/src/structs.md
+++ b/src/doc/book/src/structs.md
@@ -255,7 +255,7 @@ rather than positions.
 
 You can define a `struct` with no members at all:
 
-```rust
+```rust,compile_fail,E0423
 struct Electron {} // Use empty braces...
 struct Proton;     // ...or just a semicolon.
 


### PR DESCRIPTION
r? @steveklabnik 

BTW it seems that
```Rust
let p = Proton {};
```
compiles without an error. That's why I didn't add it to the example. It's about consistency anyway.