### PR TITLE
Allow types passed to [] to coerce, like .index()

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3912,7 +3912,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                   let base_t = self.structurally_resolved_type(expr.span, base_t);
                   match self.lookup_indexing(expr, base, base_t, idx_t, lvalue_pref) {
                       Some((index_ty, element_ty)) => {
-                          self.demand_eqtype(expr.span, index_ty, idx_t);
+                          self.demand_coerce(idx, idx_t, index_ty);
                           element_ty
                       }
                       None => {

--- a/src/test/run-pass/issue-40085.rs
+++ b/src/test/run-pass/issue-40085.rs
@@ -1,0 +1,22 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::ops::Index;
+fn bar() {}
+static UNIT: () = ();
+struct S;
+impl Index<fn()> for S {
+    type Output = ();
+    fn index(&self, _: fn()) -> &() { &UNIT }
+}
+fn main() {
+    S.index(bar);
+    S[bar];
+}


### PR DESCRIPTION
Fixes #40085 

Basically steals the relevant part of [check_argument_types](https://github.com/rust-lang/rust/blob/1.15.1/src/librustc_typeck/check/mod.rs#L2653-L2672).