### PR TITLE
doc: fix inconsistency in error output in guessing-game.md

### DIFF
--- a/src/doc/book/src/guessing-game.md
+++ b/src/doc/book/src/guessing-game.md
@@ -255,7 +255,7 @@ and other whitespace. This helps you split up long lines. We _could_ have
 done:
 
 ```rust,ignore
-    io::stdin().read_line(&mut guess).expect("failed to read line");
+    io::stdin().read_line(&mut guess).expect("Failed to read line");
 ```
 
 But that gets hard to read. So we’ve split it up, two lines for two method
@@ -473,7 +473,7 @@ fn main() {
     let mut guess = String::new();
 
     io::stdin().read_line(&mut guess)
-        .expect("failed to read line");
+        .expect("Failed to read line");
 
     println!("You guessed: {}", guess);
 }
@@ -563,7 +563,7 @@ fn main() {
     let mut guess = String::new();
 
     io::stdin().read_line(&mut guess)
-        .expect("failed to read line");
+        .expect("Failed to read line");
 
     println!("You guessed: {}", guess);
 
@@ -678,7 +678,7 @@ fn main() {
     let mut guess = String::new();
 
     io::stdin().read_line(&mut guess)
-        .expect("failed to read line");
+        .expect("Failed to read line");
 
     let guess: u32 = guess.trim().parse()
         .expect("Please type a number!");
@@ -780,7 +780,7 @@ fn main() {
         let mut guess = String::new();
 
         io::stdin().read_line(&mut guess)
-            .expect("failed to read line");
+            .expect("Failed to read line");
 
         let guess: u32 = guess.trim().parse()
             .expect("Please type a number!");
@@ -847,7 +847,7 @@ fn main() {
         let mut guess = String::new();
 
         io::stdin().read_line(&mut guess)
-            .expect("failed to read line");
+            .expect("Failed to read line");
 
         let guess: u32 = guess.trim().parse()
             .expect("Please type a number!");
@@ -892,7 +892,7 @@ fn main() {
         let mut guess = String::new();
 
         io::stdin().read_line(&mut guess)
-            .expect("failed to read line");
+            .expect("Failed to read line");
 
         let guess: u32 = match guess.trim().parse() {
             Ok(num) => num,
@@ -981,7 +981,7 @@ fn main() {
         let mut guess = String::new();
 
         io::stdin().read_line(&mut guess)
-            .expect("failed to read line");
+            .expect("Failed to read line");
 
         let guess: u32 = match guess.trim().parse() {
             Ok(num) => num,


### PR DESCRIPTION
The line '.expect("failed to read line");' is partly started with a
lower case 'f' and partly with an uppercase one, adding additional
spurious changes to otherwise clean diffs if each sample is
copy-and-pasted over the previous.
This change starts the string with an uppercase everywhere which is in
line with the style of the other strings.