### PR TITLE
LLVM: Update submodule to include x86-interrupt ABI patches

### DIFF
--- a/src/rustllvm/llvm-auto-clean-trigger
+++ b/src/rustllvm/llvm-auto-clean-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be forcibly cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2017-02-15
+2017-03-02


### PR DESCRIPTION
Update LLVM submodule to `rust-llvm-2016-10-29` branch (commit https://github.com/rust-lang/llvm/commit/50ab09fb43f038e4f824eea6cb278f560d3e8621).