### PR TITLE
Add Utf8Error::error_len, to help incremental and/or lossy decoding.

### DIFF
--- a/src/libcollectionstest/lib.rs
+++ b/src/libcollectionstest/lib.rs
@@ -28,6 +28,7 @@
 #![feature(test)]
 #![feature(unboxed_closures)]
 #![feature(unicode)]
+#![feature(utf8_error_resume_from)]
 
 extern crate collections;
 extern crate test;

--- a/src/libcollectionstest/lib.rs
+++ b/src/libcollectionstest/lib.rs
@@ -28,7 +28,7 @@
 #![feature(test)]
 #![feature(unboxed_closures)]
 #![feature(unicode)]
-#![feature(utf8_error_resume_from)]
+#![feature(utf8_error_error_len)]
 
 extern crate collections;
 extern crate test;

--- a/src/libcollectionstest/str.rs
+++ b/src/libcollectionstest/str.rs
@@ -543,31 +543,31 @@ fn from_utf8_mostly_ascii() {
 #[test]
 fn from_utf8_error() {
     macro_rules! test {
-        ($input: expr, $expected_valid_up_to: expr, $expected_resume_from: expr) => {
+        ($input: expr, $expected_valid_up_to: expr, $expected_error_len: expr) => {
             let error = from_utf8($input).unwrap_err();
             assert_eq!(error.valid_up_to(), $expected_valid_up_to);
-            assert_eq!(error.resume_from(), $expected_resume_from);
+            assert_eq!(error.error_len(), $expected_error_len);
         }
     }
-    test!(b"A\xC3\xA9 \xFF ", 4, Some(5));
-    test!(b"A\xC3\xA9 \x80 ", 4, Some(5));
-    test!(b"A\xC3\xA9 \xC1 ", 4, Some(5));
-    test!(b"A\xC3\xA9 \xC1", 4, Some(5));
+    test!(b"A\xC3\xA9 \xFF ", 4, Some(1));
+    test!(b"A\xC3\xA9 \x80 ", 4, Some(1));
+    test!(b"A\xC3\xA9 \xC1 ", 4, Some(1));
+    test!(b"A\xC3\xA9 \xC1", 4, Some(1));
     test!(b"A\xC3\xA9 \xC2", 4, None);
-    test!(b"A\xC3\xA9 \xC2 ", 4, Some(5));
-    test!(b"A\xC3\xA9 \xC2\xC0", 4, Some(5));
+    test!(b"A\xC3\xA9 \xC2 ", 4, Some(1));
+    test!(b"A\xC3\xA9 \xC2\xC0", 4, Some(1));
     test!(b"A\xC3\xA9 \xE0", 4, None);
-    test!(b"A\xC3\xA9 \xE0\x9F", 4, Some(5));
+    test!(b"A\xC3\xA9 \xE0\x9F", 4, Some(1));
     test!(b"A\xC3\xA9 \xE0\xA0", 4, None);
-    test!(b"A\xC3\xA9 \xE0\xA0\xC0", 4, Some(6));
-    test!(b"A\xC3\xA9 \xE0\xA0 ", 4, Some(6));
-    test!(b"A\xC3\xA9 \xED\xA0\x80 ", 4, Some(5));
+    test!(b"A\xC3\xA9 \xE0\xA0\xC0", 4, Some(2));
+    test!(b"A\xC3\xA9 \xE0\xA0 ", 4, Some(2));
+    test!(b"A\xC3\xA9 \xED\xA0\x80 ", 4, Some(1));
     test!(b"A\xC3\xA9 \xF1", 4, None);
     test!(b"A\xC3\xA9 \xF1\x80", 4, None);
     test!(b"A\xC3\xA9 \xF1\x80\x80", 4, None);
-    test!(b"A\xC3\xA9 \xF1 ", 4, Some(5));
-    test!(b"A\xC3\xA9 \xF1\x80 ", 4, Some(6));
-    test!(b"A\xC3\xA9 \xF1\x80\x80 ", 4, Some(7));
+    test!(b"A\xC3\xA9 \xF1 ", 4, Some(1));
+    test!(b"A\xC3\xA9 \xF1\x80 ", 4, Some(2));
+    test!(b"A\xC3\xA9 \xF1\x80\x80 ", 4, Some(3));
 }
 
 #[test]

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -166,7 +166,7 @@ impl Utf8Error {
     ///   that starts at the index given by `valid_up_to()`.
     ///   Decoding should resume after that sequence
     ///   (after inserting a U+FFFD REPLACEMENT CHARACTER) in case of lossy decoding.
-    #[unstable(feature = "utf8_error_error_len", reason ="new", issue = "0")]
+    #[unstable(feature = "utf8_error_error_len", reason ="new", issue = "40494")]
     pub fn error_len(&self) -> Option<usize> {
         self.error_len.map(|len| len as usize)
     }


### PR DESCRIPTION
Without this, code outside of the standard library needs to reimplement most of the logic `from_utf8` to interpret the bytes after `valid_up_to()`.