### PR TITLE
Issue #39688 - Help people find String::as_bytes() for UTF-8

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -433,6 +433,10 @@ impl String {
     ///
     /// [`str::from_utf8()`]: ../../std/str/fn.from_utf8.html
     ///
+    /// The inverse of this method is [`as_bytes`].
+    ///
+    /// [`as_bytes`]: #method.as_bytes
+    ///
     /// # Errors
     ///
     /// Returns `Err` if the slice is not UTF-8 with a description as to why the
@@ -978,6 +982,10 @@ impl String {
     }
 
     /// Returns a byte slice of this `String`'s contents.
+    ///
+    /// The inverse of this method is [`from_utf8`].
+    ///
+    /// [`from_utf8`]: #method.from_utf8
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Added in links for the inverse functions so people will know that as_bytes() is the inverse of from_utf8() and vice versa.
?r @steveklabnik 