### PR TITLE
travis: Randomly try to suppress OSX segfaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,10 @@ env:
     # AWS_SECRET_ACCESS_KEY=...
     - secure: "Pixhh0hXDqGCdOyLtGFjli3J2AtDWIpyb2btIrLe956nCBDRutRoMm6rv5DI9sFZN07Mms7VzNNvhc9wCW1y63JAm414d2Co7Ob8kWMZlz9l9t7ACHuktUiis8yr+S4Quq1Vqd6pqi7pf2J++UxC8R/uLeqVrubzr6+X7AbmEFE="
 
+    # random shot in the dark to try to suppress OSX linker assertions seen on
+    # rust-lang/rust#38878
+    - LD_PIPELINE_FIFO=true
+
 script:
   - >
       if [ "$ALLOW_PR" = "" ] && [ "$TRAVIS_BRANCH" != "auto" ]; then


### PR DESCRIPTION
This is a complete random shot in the dark to help suppress the OSX linker
segfaults being found on #38878. The segfault happens apparently during an
assertion in [this source file][1]. That apparently is related to a worker
thread pool for parsing a bunch of object files. Presumably there's some
concurrency bug triggering the segfault?

Poking around the source to see if we could disable this multithreading behavior
didn't turn up many results, but one check in the [file above][1] was related to
`_options.pipelineEnabled()` which seemed suspicious. That in turn is read from
[this file] in the `fPipelineFifo` instance variable (if it's non-null).

That instance variable is in turn set from [another file][3] as a result of
`getenv("LD_PIPELINE_FIFO")`. This PR now sets that env var for all builders,
including the OSX ones.

Will this help? I have no idea! But it at least seems related and hopefully
isn't too hard to try out and/or back out.

[1]: https://opensource.apple.com/source/ld64/ld64-274.2/src/ld/InputFiles.cpp.auto.html
[2]: https://opensource.apple.com/source/ld64/ld64-274.2/src/ld/Options.h.auto.html
[3]: https://opensource.apple.com/source/ld64/ld64-274.2/src/ld/Options.cpp.auto.html