### PR TITLE
Add compile fail test for stmt_expr_attributes

### DIFF
--- a/src/test/compile-fail/feature-gate-stmt_expr_attributes.rs
+++ b/src/test/compile-fail/feature-gate-stmt_expr_attributes.rs
@@ -1,0 +1,14 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const X: i32 = #[allow(dead_code)] 8;
+//~^ ERROR attributes on non-item statements and expressions are experimental. (see issue #15701)
+
+fn main() {}

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -167,7 +167,6 @@ pub fn check(path: &Path, bad: &mut bool) {
 
     // FIXME get this whitelist empty.
     let whitelist = vec![
-        "stmt_expr_attributes",
         "cfg_target_thread_local", "unwind_attributes",
     ];
 


### PR DESCRIPTION
Adds a missing feature gate test for `stmt_expr_attributes`. Issue #39059.
