### PR TITLE
Fix personality_fn within the compiler_builtins

### DIFF
--- a/src/libcompiler_builtins/lib.rs
+++ b/src/libcompiler_builtins/lib.rs
@@ -402,15 +402,16 @@ pub mod reimpls {
     }
 
     trait AbsExt: Sized {
-        fn uabs(self) -> u128 {
-            self.iabs() as u128
-        }
+        fn uabs(self) -> u128;
         fn iabs(self) -> i128;
     }
 
     impl AbsExt for i128 {
+        fn uabs(self) -> u128 {
+            self.iabs() as u128
+        }
         fn iabs(self) -> i128 {
-            let s = self >> 127;
+            let s = self.wrapping_shr(127);
             ((self ^ s).wrapping_sub(s))
         }
     }


### PR DESCRIPTION
compiler_builtins may not have any unwinding within it to link correctly. This is notoriously
finicky, and this small piece of change removes yet another case where personality function
happens to get introduced.

Side note: I do remember solving the exact same thing before. I wonder why it has reappered...

@cuviper, could you please try building beta with this patch applied? It should apply cleanly. If it works, I’ll nominate to land this into beta.

Fixes(?) https://github.com/rust-lang/rust/issues/40251