### PR TITLE
LLVM: Update submodule to include SRet support patch for MSP430.

### DIFF
--- a/src/rustllvm/llvm-auto-clean-trigger
+++ b/src/rustllvm/llvm-auto-clean-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be forcibly cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2017-03-02
+2017-03-04


### PR DESCRIPTION
This patch is needed to fix #38824 on MSP430.
I know that LLVM 4 is coming soon, but it would be great to have at least one working nightly before the update.

cc @awygle
r? @alexcrichton 
