### PR TITLE
Fix emscripten test detection

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -550,7 +550,7 @@ fn find_tests(dir: &Path,
         let filename = e.file_name().into_string().unwrap();
         if (target.contains("windows") && filename.ends_with(".exe")) ||
            (!target.contains("windows") && !filename.contains(".")) ||
-           (target.contains("emscripten") && filename.contains(".js")){
+           (target.contains("emscripten") && filename.ends_with(".js")) {
             dst.push(e.path());
         }
     }


### PR DESCRIPTION
Without this change `rustbuild` will attempt to run `.js.map` files (if they exist) resulting in lots of sadness.

r? @alexcrichton