### PR TITLE
Support armhf abi on 64-bit ARM cpus

### DIFF
--- a/configure
+++ b/configure
@@ -512,7 +512,7 @@ case $CFG_CPUTYPE in
         CFG_OSTYPE="${CFG_OSTYPE}eabihf"
         ;;
 
-    armv7l)
+    armv7l | armv8l)
         CFG_CPUTYPE=armv7
         CFG_OSTYPE="${CFG_OSTYPE}eabihf"
         ;;

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -465,7 +465,7 @@ class RustBuild(object):
             cputype = 'i686'
         elif cputype in {'xscale', 'arm'}:
             cputype = 'arm'
-        elif cputype == 'armv7l':
+        elif cputype in {'armv7l', 'armv8l'}:
             cputype = 'arm'
             ostype += 'eabihf'
         elif cputype == 'aarch64':


### PR DESCRIPTION
They report their `uname -m` as armv8l rather than aarch64.

Patch originally by Matthias Klose <doko@debian.org>