### PR TITLE
Improve the style of the sidebar in rustdoc output

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -167,7 +167,11 @@ nav.sub {
 	position: absolute;
 	left: 0;
 	top: 0;
-	min-height: 100%;
+	min-height: 100vh;
+}
+
+.sidebar .current {
+	margin-right: -20px;
 }
 
 .content, nav { max-width: 960px; }
@@ -185,9 +189,14 @@ nav.sub {
 }
 
 .sidebar .location {
+	border: 1px solid;
 	font-size: 17px;
 	margin: 30px 0 20px 0;
 	text-align: center;
+}
+
+.location:empty {
+	border: none;
 }
 
 .location a:first-child { font-weight: 500; }

--- a/src/librustdoc/html/static/styles/main.css
+++ b/src/librustdoc/html/static/styles/main.css
@@ -37,8 +37,17 @@ pre {
     background-color: #F5F5F5;
 }
 
+.sidebar {
+    background-color: #F1F1F1;
+}
+
+.sidebar .current {
+    background-color: #fff;
+}
+
 .sidebar .location {
-    background: #e1e1e1;
+    border-color: #000;
+    background-color: #fff;
     color: #333;
 }
 


### PR DESCRIPTION
Makes the sidebar a light grey and highlights the currently viewed item in the sidebar more prominently. 

All visual design credit goes to @johnwhelchel (#37856)

Sample screenshots:

![screen shot 2017-03-04 at 12 29 48 pm](https://cloud.githubusercontent.com/assets/831192/23580829/db6c26c2-00d6-11e7-8d89-822e25ba79f0.png)

![screen shot 2017-03-04 at 12 30 10 pm](https://cloud.githubusercontent.com/assets/831192/23580828/db69eeca-00d6-11e7-9f89-1e06fd3bf098.png)

![screen shot 2017-03-04 at 12 30 31 pm](https://cloud.githubusercontent.com/assets/831192/23580830/db6d00ce-00d6-11e7-89ca-cd03e148a121.png)

