### PR TITLE
rustbuild: build and test target shortcuts

### DIFF
--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -1049,8 +1049,18 @@ invalid rule dependency graph detected, was a rule added and maybe typo'd?
             if paths.len() == 0 && rule.default {
                 Some((rule, 0))
             } else {
-                paths.iter().position(|path| path.ends_with(rule.path))
-                     .map(|priority| (rule, priority))
+                paths.iter().position(|path| {
+                    // Try `path` and also `path` with some prefixes, so commands
+                    // `test run-pass`, `test test/run-pass`, `test src/test/run-pass`
+                    // all execute rule `src/test/run-pass`.
+                    for prefix in &["", "src/", "src/test/", "src/tools/"] {
+                        if rule.path.starts_with(prefix) &&
+                           path.ends_with(&rule.path[prefix.len()..]) {
+                            return true;
+                        }
+                    }
+                    false
+                }).map(|priority| (rule, priority))
             }
         }).collect();
 


### PR DESCRIPTION
The idea is simple - `x.py build path` (or `x.py test` or other commands) desugars into `x.py build path src/path src/test/path src/tools/path`.
As a result `x.py test tidy`, `x.py test compile-fail`, `s.py build libstd` all do what's expected.

As far as I can see there are no ambiguities right now, but if they appear, they could be easily disambiguated  - `x.py test test/x` (runs test group `x`), `x.py test tools/x` (runs tool `x`).

r? @alexcrichton 