### PR TITLE
Add missing tests for 'E-needstest' labeled issues

### DIFF
--- a/src/test/compile-fail/issue-35988.rs
+++ b/src/test/compile-fail/issue-35988.rs
@@ -1,0 +1,16 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum E {
+    V([Box<E>]),
+    //~^ ERROR the trait bound `[std::boxed::Box<E>]: std::marker::Sized` is not satisfied [E0277]
+}
+
+fn main() {}

--- a/src/test/compile-fail/lint-missing-copy-implementations.rs
+++ b/src/test/compile-fail/lint-missing-copy-implementations.rs
@@ -1,0 +1,25 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// See issue 19712
+
+#![deny(missing_copy_implementations)]
+
+mod inner {
+    pub struct Foo { //~ ERROR type could implement `Copy`; consider adding `impl Copy`
+        pub field: i32
+    }
+}
+
+pub fn foo() -> inner::Foo {
+    inner::Foo { field: 42 }
+}
+
+fn main() {}

--- a/src/test/run-pass/issue-24947.rs
+++ b/src/test/run-pass/issue-24947.rs
@@ -1,0 +1,35 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// #24947 ICE using a trait-associated const in an array size
+
+#![feature(associated_consts)]
+
+struct Foo;
+
+impl Foo {
+    const SIZE: usize = 8;
+}
+
+trait Bar {
+    const BAR_SIZE: usize;
+}
+
+impl Bar for Foo {
+    const BAR_SIZE: usize = 12;
+}
+
+#[allow(unused_variables)]
+fn main() {
+    let w: [u8; 12] = [0u8; <Foo as Bar>::BAR_SIZE];
+    let x: [u8; 12] = [0u8; <Foo>::BAR_SIZE];
+    let y: [u8; 8] = [0u8; <Foo>::SIZE];
+    let z: [u8; 8] = [0u8; Foo::SIZE];
+}

--- a/src/test/run-pass/issue-28600.rs
+++ b/src/test/run-pass/issue-28600.rs
@@ -1,0 +1,23 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// #28600 ICE: pub extern fn with parameter type &str inside struct impl
+
+struct Test;
+
+impl Test {
+    #[allow(dead_code)]
+    #[allow(unused_variables)]
+    pub extern fn test(val: &str) {
+
+    }
+}
+
+fn main() {}

--- a/src/test/run-pass/issue-34751.rs
+++ b/src/test/run-pass/issue-34751.rs
@@ -1,0 +1,19 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// #34751 ICE: 'rustc' panicked at 'assertion failed: !substs.has_regions_escaping_depth(0)'
+
+#[allow(dead_code)]
+
+use std::marker::PhantomData;
+
+fn f<'a>(PhantomData::<&'a u8>: PhantomData<&'a u8>) {}
+
+fn main() {}


### PR DESCRIPTION
This PR adds missing tests for issue #35988, #19712, ~~#18627~~, #24947, #28600 and #34751.

Fixes #35988 
Fixes #19712 
Fixes #24947 
Fixes #28600 
Fixes #34751