### PR TITLE
Add compile-fail tests for remaining items in whitelist and remove it

### DIFF
--- a/src/test/compile-fail/auxiliary/cfg-target-thread-local.rs
+++ b/src/test/compile-fail/auxiliary/cfg-target-thread-local.rs
@@ -1,0 +1,17 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(thread_local)]
+#![feature(cfg_target_thread_local)]
+#![crate_type = "lib"]
+
+#[no_mangle]
+#[cfg_attr(target_thread_local, thread_local)]
+pub static FOO: u32 = 3;

--- a/src/test/compile-fail/feature-gate-cfg-target-thread-local.rs
+++ b/src/test/compile-fail/feature-gate-cfg-target-thread-local.rs
@@ -1,0 +1,27 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-windows
+// aux-build:cfg-target-thread-local.rs
+
+#![feature(thread_local)]
+
+extern crate cfg_target_thread_local;
+
+extern {
+    #[cfg_attr(target_thread_local, thread_local)]
+    //~^ `cfg(target_thread_local)` is experimental and subject to change (see issue #29594)
+
+    static FOO: u32;
+}
+
+fn main() {
+    assert_eq!(FOO, 3);
+}

--- a/src/test/compile-fail/feature-gate-unwind-attributes.rs
+++ b/src/test/compile-fail/feature-gate-unwind-attributes.rs
@@ -1,0 +1,28 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -C no-prepopulate-passes
+
+#![crate_type = "lib"]
+
+extern {
+// CHECK: Function Attrs: nounwind
+// CHECK-NEXT: declare void @extern_fn
+    fn extern_fn();
+// CHECK-NOT: Function Attrs: nounwind
+// CHECK: declare void @unwinding_extern_fn
+    #[unwind] //~ ERROR #[unwind] is experimental
+    fn unwinding_extern_fn();
+}
+
+pub unsafe fn force_declare() {
+    extern_fn();
+    unwinding_extern_fn();
+}

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -165,16 +165,11 @@ pub fn check(path: &Path, bad: &mut bool) {
         }
     });
 
-    // FIXME get this whitelist empty.
-    let whitelist = vec![
-    ];
-
     // Only check the number of lang features.
     // Obligatory testing for library features is dumb.
     let gate_untested = features.iter()
                                 .filter(|&(_, f)| f.level == Status::Unstable)
                                 .filter(|&(_, f)| !f.has_gate_test)
-                                .filter(|&(n, _)| !whitelist.contains(&n.as_str()))
                                 .collect::<Vec<_>>();
 
     for &(name, _) in gate_untested.iter() {

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -167,7 +167,7 @@ pub fn check(path: &Path, bad: &mut bool) {
 
     // FIXME get this whitelist empty.
     let whitelist = vec![
-        "cfg_target_thread_local", "unwind_attributes",
+        "cfg_target_thread_local",
     ];
 
     // Only check the number of lang features.

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -167,7 +167,6 @@ pub fn check(path: &Path, bad: &mut bool) {
 
     // FIXME get this whitelist empty.
     let whitelist = vec![
-        "cfg_target_thread_local",
     ];
 
     // Only check the number of lang features.


### PR DESCRIPTION
Add compile-fail tests for `cfg_target_thread_local` and `unwind_attributes`, and remove the whitelist.

Let me know if I should clean up the tests (or if I've done anything else wrong, this is my first contribution to rust).

cc/ @est31 

