### PR TITLE
Fix text formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ $ ./configure
 $ make && sudo make install
 ```
 
-When using the configure script, the generated config.mk` file may override the
+When using the configure script, the generated `config.mk` file may override the
 `config.toml` file. To go back to the `config.toml` file, delete the generated
 `config.mk` file.
 


### PR DESCRIPTION
There was a missing backtick in the README.