### PR TITLE
first pass at isolating dep-graph tasks

### DIFF
--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -77,12 +77,37 @@ impl DepGraph {
         op()
     }
 
+    /// Starts a new dep-graph task. Dep-graph tasks are specified
+    /// using a free function (`task`) and **not** a closure -- this
+    /// is intentional because we want to exercise tight control over
+    /// what state they have access to. In particular, we want to
+    /// prevent implicit 'leaks' of tracked state into the task (which
+    /// could then be read without generating correct edges in the
+    /// dep-graph -- see the [README] for more details on the
+    /// dep-graph). To this end, the task function gets exactly two
+    /// pieces of state: the context `cx` and an argument `arg`. Both
+    /// of these bits of state must be of some type that implements
+    /// `DepGraphSafe` and hence does not leak.
+    ///
+    /// The choice of two arguments is not fundamental. One argument
+    /// would work just as well, since multiple values can be
+    /// collected using tuples. However, using two arguments works out
+    /// to be quite convenient, since it is common to need a context
+    /// (`cx`) and some argument (e.g., a `DefId` identifying what
+    /// item to process).
+    ///
+    /// For cases where you need some other number of arguments:
+    ///
+    /// - If you only need one argument, just use `()` for the `arg`
+    ///   parameter.
+    /// - If you need 3+ arguments, use a tuple for the
+    ///   `arg` parameter.
+    ///
+    /// [README]: README.md
     pub fn with_task<C, A, R>(&self, key: DepNode<DefId>, cx: C, arg: A, task: fn(C, A) -> R) -> R
         where C: DepGraphSafe, A: DepGraphSafe
     {
         let _task = self.in_task(key);
-        cx.read(self);
-        arg.read(self);
         task(cx, arg)
     }
 

--- a/src/librustc/dep_graph/mod.rs
+++ b/src/librustc/dep_graph/mod.rs
@@ -15,6 +15,8 @@ mod edges;
 mod graph;
 mod query;
 mod raii;
+#[macro_use]
+mod safe;
 mod shadow;
 mod thread;
 mod visit;
@@ -25,6 +27,8 @@ pub use self::dep_node::WorkProductId;
 pub use self::graph::DepGraph;
 pub use self::graph::WorkProduct;
 pub use self::query::DepGraphQuery;
+pub use self::safe::AssertDepGraphSafe;
+pub use self::safe::DepGraphSafe;
 pub use self::visit::visit_all_bodies_in_krate;
 pub use self::visit::visit_all_item_likes_in_krate;
 pub use self::raii::DepTask;

--- a/src/librustc/dep_graph/mod.rs
+++ b/src/librustc/dep_graph/mod.rs
@@ -15,7 +15,6 @@ mod edges;
 mod graph;
 mod query;
 mod raii;
-#[macro_use]
 mod safe;
 mod shadow;
 mod thread;

--- a/src/librustc/dep_graph/safe.rs
+++ b/src/librustc/dep_graph/safe.rs
@@ -1,0 +1,70 @@
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use hir::BodyId;
+use hir::def_id::DefId;
+use syntax::ast::NodeId;
+use ty::TyCtxt;
+
+use super::graph::DepGraph;
+
+/// The `DepGraphSafe` auto trait is used to specify what kinds of
+/// values are safe to "leak" into a task.  The idea is that this
+/// should be only be implemented for things like the tcx, which will
+/// create reads in the dep-graph whenever the trait loads anything
+/// that might depend on the input program.
+pub trait DepGraphSafe {
+    fn read(&self, graph: &DepGraph);
+}
+
+impl DepGraphSafe for BodyId {
+    fn read(&self, _graph: &DepGraph) {
+        // a BodyId on its own doesn't give access to any particular state
+    }
+}
+
+impl DepGraphSafe for NodeId {
+    fn read(&self, _graph: &DepGraph) {
+        // a DefId doesn't give any particular state
+    }
+}
+
+impl DepGraphSafe for DefId {
+    fn read(&self, _graph: &DepGraph) {
+        // a DefId doesn't give any particular state
+    }
+}
+
+impl<'a, 'gcx, 'tcx> DepGraphSafe for TyCtxt<'a, 'gcx, 'tcx> {
+    fn read(&self, _graph: &DepGraph) {
+    }
+}
+
+impl<A, B> DepGraphSafe for (A, B)
+    where A: DepGraphSafe, B: DepGraphSafe
+{
+    fn read(&self, graph: &DepGraph) {
+        self.0.read(graph);
+        self.1.read(graph);
+    }
+}
+
+impl DepGraphSafe for () {
+    fn read(&self, _graph: &DepGraph) {
+    }
+}
+
+/// A convenient override. We should phase out usage of this over
+/// time.
+pub struct AssertDepGraphSafe<T>(pub T);
+impl<T> DepGraphSafe for AssertDepGraphSafe<T> {
+    fn read(&self, _graph: &DepGraph) {
+    }
+}

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -70,7 +70,6 @@ mod macros;
 pub mod diagnostics;
 
 pub mod cfg;
-#[macro_use]
 pub mod dep_graph;
 pub mod hir;
 pub mod infer;

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -70,6 +70,7 @@ mod macros;
 pub mod diagnostics;
 
 pub mod cfg;
+#[macro_use]
 pub mod dep_graph;
 pub mod hir;
 pub mod infer;

--- a/src/librustc_incremental/persist/load.rs
+++ b/src/librustc_incremental/persist/load.rs
@@ -192,7 +192,11 @@ pub fn decode_dep_graph<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 clean_work_products.insert(wp.clone());
             }
 
-            tcx.dep_graph.with_task(n, || ()); // create the node with no inputs
+            tcx.dep_graph.with_task(n, (), (), create_node);
+
+            fn create_node((): (), (): ()) {
+                // just create the node with no inputs
+            }
         }
     }
 

--- a/src/librustc_mir/mir_map.rs
+++ b/src/librustc_mir/mir_map.rs
@@ -38,11 +38,13 @@ use std::cell::RefCell;
 use std::mem;
 
 pub fn build_mir_for_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
-    tcx.dep_graph.with_task(DepNode::MirKrate, || {
+    tcx.dep_graph.with_task(DepNode::MirKrate, tcx, (), build_mir_for_crate_task);
+
+    fn build_mir_for_crate_task<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, (): ()) {
         tcx.visit_all_bodies_in_krate(|body_owner_def_id, _body_id| {
             tcx.item_mir(body_owner_def_id);
         });
-    });
+    }
 }
 
 pub fn provide(providers: &mut Providers) {

--- a/src/librustc_trans/context.rs
+++ b/src/librustc_trans/context.rs
@@ -10,7 +10,8 @@
 
 use llvm;
 use llvm::{ContextRef, ModuleRef, ValueRef};
-use rustc::dep_graph::{DepGraph, DepNode, DepTrackingMap, DepTrackingMapConfig, WorkProduct};
+use rustc::dep_graph::{DepGraph, DepGraphSafe, DepNode, DepTrackingMap,
+                       DepTrackingMapConfig, WorkProduct};
 use middle::cstore::LinkMeta;
 use rustc::hir;
 use rustc::hir::def::ExportMap;
@@ -272,6 +273,11 @@ pub struct CrateContext<'a, 'tcx: 'a> {
     /// The index of `local` in `local_ccxs`.  This is used in
     /// `maybe_iter(true)` to identify the original `LocalCrateContext`.
     index: usize,
+}
+
+impl<'a, 'tcx> DepGraphSafe for CrateContext<'a, 'tcx> {
+    fn read(&self, _graph: &DepGraph) {
+    }
 }
 
 pub struct CrateContextIterator<'a, 'tcx: 'a> {

--- a/src/librustc_trans/context.rs
+++ b/src/librustc_trans/context.rs
@@ -276,8 +276,6 @@ pub struct CrateContext<'a, 'tcx: 'a> {
 }
 
 impl<'a, 'tcx> DepGraphSafe for CrateContext<'a, 'tcx> {
-    fn read(&self, _graph: &DepGraph) {
-    }
 }
 
 pub struct CrateContextIterator<'a, 'tcx: 'a> {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -539,13 +539,15 @@ pub fn check_item_types<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) -> CompileResult 
 }
 
 pub fn check_item_bodies<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) -> CompileResult {
-    tcx.sess.track_errors(|| {
-        tcx.dep_graph.with_task(DepNode::TypeckBodiesKrate, || {
-            tcx.visit_all_bodies_in_krate(|body_owner_def_id, _body_id| {
-                tcx.item_tables(body_owner_def_id);
-            });
+    return tcx.sess.track_errors(|| {
+        tcx.dep_graph.with_task(DepNode::TypeckBodiesKrate, tcx, (), check_item_bodies_task);
+    });
+
+    fn check_item_bodies_task<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, (): ()) {
+        tcx.visit_all_bodies_in_krate(|body_owner_def_id, _body_id| {
+            tcx.item_tables(body_owner_def_id);
         });
-    })
+    }
 }
 
 pub fn provide(providers: &mut Providers) {


### PR DESCRIPTION
This intentionally leaves `DepGraph::in_task()`, the more common form,
alone. Eventually all uses of `DepGraph::in_task()` should be ported
to `with_task()`, but I wanted to start with a smaller subset.

I also used `AssertDepGraphSafe` on the closures that are found in
trans. This is because the types there are non-trivial and I wanted to
lay down the mechanism and come back to the more subtle cases.

The current approach taken in this PR has a downside: it is necessary
to manually "reify" fn types into fn pointers when starting a task,
like so:

    dep_graph.with_task(..., task_fn as fn(_))

this is because `with_task` takes some type `T` that implements
`DepGraphTask` rather than taking a `fn()` type directly. *This* is so
that we can accept closure and also so that we can accept fns with
multiple arities. I am not sure this is the right approach.

Originally I wanted to use closures bound by an auto trait, but that
approach has some limitations:

- the trait cannot have a `read()` method; since the current method
  is unused, that may not be a problem.
- more importantly, we would want the auto trait to be "undefined" for all types
  *by default* -- that is, this use case doesn't really fit the typical
  auto trait scenario. For example, imagine that there is a `u32` loaded
  out of a `hir::Node` -- we don't really want to be passing that
  `u32` into the task!