### PR TITLE
Update link to COMPILER_TESTS.md in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -406,5 +406,5 @@ are:
 [rr]: https://doc.rust-lang.org/book/README.html
 [tlgba]: http://tomlee.co/2014/04/a-more-detailed-tour-of-the-rust-compiler/
 [ro]: http://www.rustaceans.org/
-[rctd]: ./COMPILER_TESTS.md
+[rctd]: ./src/test/COMPILER_TESTS.md
 [cheatsheet]: https://buildbot.rust-lang.org/homu/


### PR DESCRIPTION
Link to compiler test documentation was broken after the file was moved by #40086.
This updates the link to the new location of the file.