### PR TITLE
rustc: Exit quickly on only `--emit dep-info`

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -125,6 +125,10 @@ pub fn compile_input(sess: &Session,
         };
 
         write_out_deps(sess, &outputs, &crate_name);
+        if sess.opts.output_types.contains_key(&OutputType::DepInfo) &&
+            sess.opts.output_types.keys().count() == 1 {
+            return Ok(())
+        }
 
         let arena = DroplessArena::new();
         let arenas = GlobalArenas::new();

--- a/src/test/run-make/dep-info-doesnt-run-much/Makefile
+++ b/src/test/run-make/dep-info-doesnt-run-much/Makefile
@@ -1,0 +1,4 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) foo.rs --emit dep-info

--- a/src/test/run-make/dep-info-doesnt-run-much/foo.rs
+++ b/src/test/run-make/dep-info-doesnt-run-much/foo.rs
@@ -1,0 +1,15 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// We're only emitting dep info, so we shouldn't be running static analysis to
+// figure out that this program is erroneous.
+fn main() {
+    let a: u8 = "a";
+}


### PR DESCRIPTION
This commit alters the compiler to exit quickly if the only output being emitted
is `dep-info`, which doesn't need a lot of other information to generate.

Closes #40328