### PR TITLE
travis: Attempt to debug out of disk errors

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -58,8 +58,12 @@ else
   fi
 fi
 
+df -h
+
 $SRC/configure $RUST_CONFIGURE_ARGS
 retry make prepare
+
+df -h
 
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
     ncpus=$(sysctl -n hw.ncpu)
@@ -76,3 +80,5 @@ else
   make -j $ncpus
   make $RUST_CHECK_TARGET -j $ncpus
 fi
+
+df -h


### PR DESCRIPTION
Sprinkle a few `df -h` calls to see if we can see how much space our builds are
taking up and also how much space we've got to work with.