### PR TITLE
Add tombstone checks to make sure incr-comp reads aren't dirtied

### DIFF
--- a/src/librustc/dep_graph/dep_tracking_map.rs
+++ b/src/librustc/dep_graph/dep_tracking_map.rs
@@ -10,6 +10,10 @@
 
 use hir::def_id::DefId;
 use rustc_data_structures::fx::FxHashMap;
+
+#[cfg(debug_assertions)]
+use rustc_data_structures::fx::FxHashSet;
+
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::ops::Index;
@@ -26,6 +30,8 @@ pub struct DepTrackingMap<M: DepTrackingMapConfig> {
     phantom: PhantomData<M>,
     graph: DepGraph,
     map: FxHashMap<M::Key, M::Value>,
+    #[cfg(debug_assertions)]
+    tombstones: RefCell<FxHashSet<M::Key>>,
 }
 
 pub trait DepTrackingMapConfig {
@@ -35,11 +41,22 @@ pub trait DepTrackingMapConfig {
 }
 
 impl<M: DepTrackingMapConfig> DepTrackingMap<M> {
+    #[cfg(debug_assertions)]
     pub fn new(graph: DepGraph) -> DepTrackingMap<M> {
         DepTrackingMap {
             phantom: PhantomData,
             graph: graph,
-            map: FxHashMap()
+            map: FxHashMap(),
+            tombstones: RefCell::new(FxHashSet()),
+        }
+    }
+
+    #[cfg(not(debug_assertions))]
+    pub fn new(graph: DepGraph) -> DepTrackingMap<M> {
+        DepTrackingMap {
+            phantom: PhantomData,
+            graph: graph,
+            map: FxHashMap(),
         }
     }
 
@@ -59,13 +76,31 @@ impl<M: DepTrackingMapConfig> DepTrackingMap<M> {
 
     pub fn get(&self, k: &M::Key) -> Option<&M::Value> {
         self.read(k);
-        self.map.get(k)
+        let result = self.map.get(k);
+
+        #[cfg(debug_assertions)]
+        {
+            if result.is_none() {
+                self.tombstones.borrow_mut().insert(k.clone());
+            }
+        }
+
+        result
     }
 
     pub fn insert(&mut self, k: M::Key, v: M::Value) {
         self.write(&k);
+
+        // If we ever read a `None` value for this key, we do not want
+        // to permit a later write to it. The only valid use case for
+        // this is the memoization pattern: for that, use `memoize()`
+        // below
+        #[cfg(debug_assertions)]
+        assert!(!self.tombstones.borrow().contains(&k),
+                "inserting to `{0:?}` after reading from `{0:?}`",
+                M::to_dep_node(&k));
         let old_value = self.map.insert(k, v);
-        assert!(old_value.is_none());
+        assert!(old_value.is_none(), "inserted value twice");
     }
 
     pub fn entry(&mut self, k: M::Key) -> Entry<M::Key, M::Value> {
@@ -75,7 +110,13 @@ impl<M: DepTrackingMapConfig> DepTrackingMap<M> {
 
     pub fn contains_key(&self, k: &M::Key) -> bool {
         self.read(k);
-        self.map.contains_key(k)
+        if self.map.contains_key(k) {
+            true
+        } else {
+            #[cfg(debug_assertions)]
+            self.tombstones.borrow_mut().insert(k.clone());
+            false
+        }
     }
 
     pub fn keys(&self) -> Vec<M::Key> {
@@ -125,7 +166,7 @@ impl<M: DepTrackingMapConfig> MemoizationMap for RefCell<DepTrackingMap<M>> {
     ///     let item_def_id = ccx.tcx.hir.local_def_id(it.id);
     ///     ccx.tcx.item_types.memoized(item_def_id, || {
     ///         ccx.tcx.dep_graph.read(DepNode::Hir(item_def_id)); // (*)
-    ///         compute_type_of_item(ccx, item)
+    ///         Some(compute_type_of_item(ccx, item))
     ///     });
     /// }
     /// ```
@@ -134,7 +175,7 @@ impl<M: DepTrackingMapConfig> MemoizationMap for RefCell<DepTrackingMap<M>> {
     /// accesses the body of the item `item`, so we register a read
     /// from `Hir(item_def_id)`.
     fn memoize<OP>(&self, key: M::Key, op: OP) -> M::Value
-        where OP: FnOnce() -> M::Value
+        where OP: FnOnce() -> Option<M::Value>
     {
         let graph;
         {
@@ -147,9 +188,18 @@ impl<M: DepTrackingMapConfig> MemoizationMap for RefCell<DepTrackingMap<M>> {
         }
 
         let _task = graph.in_task(M::to_dep_node(&key));
-        let result = op();
-        self.borrow_mut().map.insert(key, result.clone());
-        result
+        if let Some(result) = op() {
+            let old_value = self.borrow_mut().map.insert(key, result.clone());
+            assert!(old_value.is_none());
+            result
+        } else {
+            self.borrow().map
+                         .get(&key)
+                         .unwrap_or_else(|| bug!(
+                            "memoize closure failed to write to {:?}", M::to_dep_node(&key)
+                         ))
+                         .clone()
+        }
     }
 }
 

--- a/src/librustc/ty/contents.rs
+++ b/src/librustc/ty/contents.rs
@@ -125,7 +125,7 @@ impl fmt::Debug for TypeContents {
 
 impl<'a, 'tcx> ty::TyS<'tcx> {
     pub fn type_contents(&'tcx self, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> TypeContents {
-        return tcx.tc_cache.memoize(self, || tc_ty(tcx, self, &mut FxHashMap()));
+        return tcx.tc_cache.memoize(self, || Some(tc_ty(tcx, self, &mut FxHashMap())));
 
         fn tc_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                            ty: Ty<'tcx>,

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -208,7 +208,7 @@ pub trait MemoizationMap {
     /// added into the dep graph. See the `DepTrackingMap` impl for
     /// more details!
     fn memoize<OP>(&self, key: Self::Key, op: OP) -> Self::Value
-        where OP: FnOnce() -> Self::Value;
+        where OP: FnOnce() -> Option<Self::Value>;
 }
 
 impl<K, V, S> MemoizationMap for RefCell<HashMap<K,V,S>>
@@ -218,15 +218,18 @@ impl<K, V, S> MemoizationMap for RefCell<HashMap<K,V,S>>
     type Value = V;
 
     fn memoize<OP>(&self, key: K, op: OP) -> V
-        where OP: FnOnce() -> V
+        where OP: FnOnce() -> Option<V>
     {
         let result = self.borrow().get(&key).cloned();
         match result {
             Some(result) => result,
             None => {
-                let result = op();
-                self.borrow_mut().insert(key, result.clone());
-                result
+                if let Some(result) = op() {
+                    self.borrow_mut().insert(key, result.clone());
+                    result
+                } else {
+                    self.borrow().get(&key).unwrap().clone()
+                }
             }
         }
     }

--- a/src/librustc_trans/common.rs
+++ b/src/librustc_trans/common.rs
@@ -488,7 +488,7 @@ pub fn fulfill_obligation<'a, 'tcx>(scx: &SharedCrateContext<'a, 'tcx>,
             let vtable = infcx.drain_fulfillment_cx_or_panic(span, &mut fulfill_cx, &vtable);
 
             info!("Cache miss: {:?} => {:?}", trait_ref, vtable);
-            vtable
+            Some(vtable)
         })
     })
 }

--- a/src/librustc_trans/monomorphize.rs
+++ b/src/librustc_trans/monomorphize.rs
@@ -121,7 +121,7 @@ impl<'a, 'b, 'gcx> TypeFolder<'gcx, 'gcx> for AssociatedTypeNormalizer<'a, 'b, '
         } else {
             self.shared.project_cache().memoize(ty, || {
                 debug!("AssociatedTypeNormalizer: ty={:?}", ty);
-                self.shared.tcx().normalize_associated_type(&ty)
+                Some(self.shared.tcx().normalize_associated_type(&ty))
             })
         }
     }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -617,7 +617,7 @@ fn convert_enum_variant_types<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         prev_discr = Some(if let Some(e) = variant.node.disr_expr {
             let expr_did = tcx.hir.local_def_id(e.node_id);
             let result = tcx.maps.monomorphic_const_eval.memoize(expr_did, || {
-                evaluate_disr_expr(tcx, e)
+                Some(evaluate_disr_expr(tcx, e))
             });
 
             match result {


### PR DESCRIPTION
Part of #40305.

r? @nikomatsakis 