### PR TITLE
Box docs: no allocation is done for ZSTs.

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -225,6 +225,8 @@ impl<T: ?Sized> Drop for IntermediateBox<T> {
 impl<T> Box<T> {
     /// Allocates memory on the heap and then places `x` into it.
     ///
+    /// This doesn't actually allocate if `T` is zero-sized.
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
Updated to add a small bit saying that ZSTs don't actually allocate on `Box::new`.