### PR TITLE
Make lang_start public so `#[start]` overrides can init the stdlib

### DIFF
--- a/src/libstd/rt.rs
+++ b/src/libstd/rt.rs
@@ -29,7 +29,7 @@ pub use panicking::{begin_panic, begin_panic_fmt, update_panic_count};
 
 #[cfg(not(test))]
 #[lang = "start"]
-fn lang_start(main: *const u8, argc: isize, argv: *const *const u8) -> isize {
+pub fn lang_start(main: *const u8, argc: isize, argv: *const *const u8) -> isize {
     use mem;
     use panic;
     use sys;


### PR DESCRIPTION
Let's say you have:
```
#![feature(start)]
use std::env;
#[start]
pub fn mystart(_argc: isize, _argv: *const *const u8) -> isize {
    mainprogram();
    5
}
fn mainprogram () {
    println!("{:?}", env::args().collect::<Vec<_>>())
}
```
https://is.gd/tXAz9Z

But this doesn't do [stdlib initialization](https://github.com/rust-lang/rust/blob/1.15.1/src/libstd/rt.rs#L30) before executing the program, so it prints out `[]`. Making `lang_start` public allows a user who knows what they're doing to initialise the stdlib.

Note that this function is still inaccessible unless you use the `rt` feature.