### PR TITLE
[beta] macro: fix issue with sequence repetitions on beta

### DIFF
--- a/src/test/run-pass/issue-39709.rs
+++ b/src/test/run-pass/issue-39709.rs
@@ -8,8 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+macro_rules! id { ($($t:tt)*) => { $($t)* } }
+
 fn main() {
     println!("{}", { macro_rules! x { ($()*) => {} } 33 });
-    //~^ ERROR no syntax variables matched as repeating at this depth
+    id!(macro_rules! m { ($($i:ident),*) => { ($($i),*) } });
+    let (foo, bar) = (0, 0);
+    assert_eq!(m!(foo, bar), (0, 0));
 }
-


### PR DESCRIPTION
This fixes #40381 by fixing #39390 on beta.

#39118 (currently in beta) worsened preexisting issue #39390, which I fixed entirely on nightly in #39419.

#39419 is large and the fix is a breaking change (in theory), so I tried to be clever and make beta bug-for-bug compatible with stable in #39730. However, #39390 didn't impact stable as much as I thought and I ended up introducing a new bug (#40381).

This PR fixes #39390 entirely on beta as minimally as possible. While it is technically a [breaking-change], we haven't seen any breakage from #39419 on the nightlies or with Crater.

r? @nrc 