### PR TITLE
rustc: Whitelist the FMA target feature

### DIFF
--- a/src/librustc_driver/target_features.rs
+++ b/src/librustc_driver/target_features.rs
@@ -25,7 +25,7 @@ const ARM_WHITELIST: &'static [&'static str] = &["neon\0", "vfp2\0", "vfp3\0", "
 const X86_WHITELIST: &'static [&'static str] = &["avx\0", "avx2\0", "bmi\0", "bmi2\0", "sse\0",
                                                  "sse2\0", "sse3\0", "sse4.1\0", "sse4.2\0",
                                                  "ssse3\0", "tbm\0", "lzcnt\0", "popcnt\0",
-                                                 "sse4a\0", "rdrnd\0", "rdseed\0"];
+                                                 "sse4a\0", "rdrnd\0", "rdseed\0", "fma\0"];
 
 /// Add `target_feature = "..."` cfgs for a variety of platform
 /// specific features (SSE, NEON etc.).


### PR DESCRIPTION
This commit adds the entry `"fma\0"` to the whitelist for the x86
target. LLVM already supports fma but rustc did not directly. Previously
rustc permitted `+fma` in the target-feature argument and enabled the use
of FMA instructions, but it did not list it in the configuration and
attributes.

fixes #40406