### PR TITLE
Point to let when modifying field of immutable variable

### DIFF
--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -195,6 +195,21 @@ pub struct cmt_<'tcx> {
 pub type cmt<'tcx> = Rc<cmt_<'tcx>>;
 
 impl<'tcx> cmt_<'tcx> {
+    pub fn get_def(&self) -> Option<ast::NodeId> {
+        match self.cat {
+            Categorization::Deref(ref cmt, ..) |
+            Categorization::Interior(ref cmt, _) |
+            Categorization::Downcast(ref cmt, _) => {
+                if let Categorization::Local(nid) = cmt.cat {
+                    Some(nid)
+                } else {
+                    None
+                }
+            }
+            _ => None
+        }
+    }
+
     pub fn get_field(&self, name: ast::Name) -> Option<DefId> {
         match self.cat {
             Categorization::Deref(ref cmt, ..) |

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -748,7 +748,9 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
             db.span_label(span, &msg);
         }
         if let Some(span) = local_def {
-            db.span_label(span, &"this should be `mut`");
+            if let Ok(snippet) = self.tcx.sess.codemap().span_to_snippet(span) {
+                db.span_label(span, &format!("consider changing this to `mut {}`", snippet));
+            }
         }
         db
     }

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -747,9 +747,9 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
         if let Some((span, msg)) = immutable_field {
             db.span_label(span, &msg);
         }
-        if let Some(span) = local_def {
-            if let Ok(snippet) = self.tcx.sess.codemap().span_to_snippet(span) {
-                db.span_label(span, &format!("consider changing this to `mut {}`", snippet));
+        if let Some(let_span) = local_def {
+            if let Ok(snippet) = self.tcx.sess.codemap().span_to_snippet(let_span) {
+                db.span_label(let_span, &format!("consider changing this to `mut {}`", snippet));
             }
         }
         db
@@ -1119,6 +1119,11 @@ before rustc 1.16, this temporary lived longer - see issue #39283 \
                         }
                     } else {
                         db.span_label(*error_span, &format!("cannot borrow mutably"));
+                    }
+                } else if let Categorization::Interior(ref cmt, _) = err.cmt.cat {
+                    if let mc::MutabilityCategory::McImmutable = cmt.mutbl {
+                        db.span_label(*error_span,
+                                      &"cannot mutably borrow immutable field");
                     }
                 }
             }

--- a/src/test/ui/did_you_mean/issue-39544.stderr
+++ b/src/test/ui/did_you_mean/issue-39544.stderr
@@ -2,7 +2,7 @@ error: cannot borrow immutable field `z.x` as mutable
   --> $DIR/issue-39544.rs:21:18
    |
 20 |     let z = Z { x: X::Y };
-   |         - this should be `mut`
+   |         - consider changing this to `mut z`
 21 |     let _ = &mut z.x;
    |                  ^^^
 

--- a/src/test/ui/did_you_mean/issue-39544.stderr
+++ b/src/test/ui/did_you_mean/issue-39544.stderr
@@ -1,6 +1,8 @@
 error: cannot borrow immutable field `z.x` as mutable
   --> $DIR/issue-39544.rs:21:18
    |
+20 |     let z = Z { x: X::Y };
+   |         - this should be `mut`
 21 |     let _ = &mut z.x;
    |                  ^^^
 

--- a/src/test/ui/did_you_mean/issue-39544.stderr
+++ b/src/test/ui/did_you_mean/issue-39544.stderr
@@ -4,7 +4,7 @@ error: cannot borrow immutable field `z.x` as mutable
 20 |     let z = Z { x: X::Y };
    |         - consider changing this to `mut z`
 21 |     let _ = &mut z.x;
-   |                  ^^^
+   |                  ^^^ cannot mutably borrow immutable field
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Point at the immutable local variable when trying to modify one of its
fields.

Given a file:

```rust
struct Foo {
    pub v: Vec<String>
}

fn main() {
    let f = Foo { v: Vec::new() };
    f.v.push("cat".to_string());
}
```

present the following output:

```
error: cannot borrow immutable field `f.v` as mutable
 --> file.rs:7:13
  |
6 |    let f = Foo { v: Vec::new() };
  |        - this should be `mut`
7 |    f.v.push("cat".to_string());
  |    ^^^

error: aborting due to previous error
```

Fix #27593.