### PR TITLE
Update Cargo to fix nightly channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
         SRC=.
         RUSTC_RETRY_LINKER_ON_SEGFAULT=1
         SCCACHE_ERROR_LOG=/tmp/sccache.log
-        RUST_LOG=sccache
+        RUST_LOG=sccache=debug
       os: osx
       osx_image: xcode8.2
       install: &osx_install_sccache >
@@ -59,7 +59,7 @@ matrix:
         SRC=.
         RUSTC_RETRY_LINKER_ON_SEGFAULT=1
         SCCACHE_ERROR_LOG=/tmp/sccache.log
-        RUST_LOG=sccache
+        RUST_LOG=sccache=debug
       os: osx
       osx_image: xcode8.2
       install: *osx_install_sccache
@@ -71,7 +71,7 @@ matrix:
         DEPLOY=1
         RUSTC_RETRY_LINKER_ON_SEGFAULT=1
         SCCACHE_ERROR_LOG=/tmp/sccache.log
-        RUST_LOG=sccache
+        RUST_LOG=sccache=debug
       os: osx
       osx_image: xcode8.2
       install: >
@@ -84,7 +84,7 @@ matrix:
         DEPLOY=1
         RUSTC_RETRY_LINKER_ON_SEGFAULT=1
         SCCACHE_ERROR_LOG=/tmp/sccache.log
-        RUST_LOG=sccache
+        RUST_LOG=sccache=debug
       os: osx
       osx_image: xcode8.2
       install: *osx_install_sccache
@@ -101,7 +101,7 @@ matrix:
         DEPLOY_ALT=1
         RUSTC_RETRY_LINKER_ON_SEGFAULT=1
         SCCACHE_ERROR_LOG=/tmp/sccache.log
-        RUST_LOG=sccache
+        RUST_LOG=sccache=debug
       os: osx
       osx_image: xcode8.2
       install: *osx_install_sccache

--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -42,9 +42,22 @@ struct Info {
 
 impl GitInfo {
     pub fn new(dir: &Path) -> GitInfo {
-        if !dir.join(".git").is_dir() {
+        // See if this even begins to look like a git dir
+        if !dir.join(".git").exists() {
             return GitInfo { inner: None }
         }
+
+        // Make sure git commands work
+        let out = Command::new("git")
+                          .arg("rev-parse")
+                          .current_dir(dir)
+                          .output()
+                          .expect("failed to spawn git");
+        if !out.status.success() {
+            return GitInfo { inner: None }
+        }
+
+        // Ok, let's scrape some info
         let ver_date = output(Command::new("git").current_dir(dir)
                                       .arg("log").arg("-1")
                                       .arg("--date=short")

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -232,7 +232,7 @@ impl Build {
             None => false,
         };
         let rust_info = channel::GitInfo::new(&src);
-        let cargo_info = channel::GitInfo::new(&src.join("src/tools/cargo"));
+        let cargo_info = channel::GitInfo::new(&src.join("cargo"));
 
         Build {
             flags: flags,


### PR DESCRIPTION
This commit updates Cargo with rust-lang/cargo#3820 which includes a fix for
rust-lang/cargo#3819. At the same time this also slightly tweaks how rustbuild
builds cargo to ensure that all the build information (including git info and
such) makes its way into the binary.

Closes rust-lang/cargo#3819