### PR TITLE
Improve wording in the -{W,A,F,D} options

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -738,7 +738,7 @@ Available lint options:
               Allow <foo>
     -D <foo>           Deny <foo>
     -F <foo>           Forbid <foo> \
-              (deny, and deny all overrides)
+              (deny <foo> and all attempts to override)
 
 ");
 


### PR DESCRIPTION
This was so trivial that I'm wondering whether I'm missing something.

Fixes #28708.