### PR TITLE
Remove doc about highlighting code in other languages #40301

### DIFF
--- a/src/doc/book/src/documentation.md
+++ b/src/doc/book/src/documentation.md
@@ -183,24 +183,6 @@ To write some Rust code in a comment, use the triple graves:
 # fn foo() {}
 ```
 
-If you want something that's not Rust code, you can add an annotation:
-
-```rust
-/// ```c
-/// printf("Hello, world\n");
-/// ```
-# fn foo() {}
-```
-
-This will highlight according to whatever language you're showing off.
-If you're only showing plain text, choose `text`.
-
-It's important to choose the correct annotation here, because `rustdoc` uses it
-in an interesting way: It can be used to actually test your examples in a
-library crate, so that they don't get out of date. If you have some C code but
-`rustdoc` thinks it's Rust because you left off the annotation, `rustdoc` will
-complain when trying to generate the documentation.
-
 ## Documentation as tests
 
 Let's discuss our sample example documentation:

--- a/src/doc/book/src/documentation.md
+++ b/src/doc/book/src/documentation.md
@@ -170,8 +170,6 @@ more than one section:
 # fn foo() {}
 ```
 
-Let's discuss the details of these code blocks.
-
 #### Code block annotations
 
 To write some Rust code in a comment, use the triple graves:
@@ -182,6 +180,9 @@ To write some Rust code in a comment, use the triple graves:
 /// ```
 # fn foo() {}
 ```
+
+This will add code highlighting. If you are only showing plain text, put `text`
+instead of `rust` after the triple graves (see below).
 
 ## Documentation as tests
 


### PR DESCRIPTION
This doesn't appear to be true any longer, so removing it to avoid confusion. See #40301 

Thoughts:
- may be a good idea to remove "Let's discuss the details of these code blocks.", as there's not much being discussed at this point;
- does `text` still work?

r? @steveklabnik