### PR TITLE
Fixes other targets rustlibs installation

### DIFF
--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -49,12 +49,17 @@ pub fn install(build: &Build, stage: u32, host: &str) {
         install_sh(&build, "docs", "rust-docs", stage, host, &prefix,
                    &docdir, &libdir, &mandir, &empty_dir);
     }
+
+    for target in build.config.target.iter() {
+        install_sh(&build, "std", "rust-std", stage, target, &prefix,
+                   &docdir, &libdir, &mandir, &empty_dir);
+    }
+
     if build.config.rust_save_analysis {
         install_sh(&build, "analysis", "rust-analysis", stage, host, &prefix,
                    &docdir, &libdir, &mandir, &empty_dir);
     }
-    install_sh(&build, "std", "rust-std", stage, host, &prefix,
-               &docdir, &libdir, &mandir, &empty_dir);
+
     install_sh(&build, "rustc", "rustc", stage, host, &prefix,
                &docdir, &libdir, &mandir, &empty_dir);
     t!(fs::remove_dir_all(&empty_dir));


### PR DESCRIPTION
When the user select more than one target to generate rustlibs for, rustbuild will only install the host one.

This patch fixes it, more info in https://github.com/rust-lang/rust/issues/39235#issuecomment-285878858