### PR TITLE
[beta] Prepare the 1.17.0 beta release

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -37,8 +37,12 @@ use channel;
 use util::{cp_r, libdir, is_dylib, cp_filtered, copy, exe};
 
 fn pkgname(build: &Build, component: &str) -> String {
-    assert!(component.starts_with("rust")); // does not work with cargo
-    format!("{}-{}", component, build.rust_package_vers())
+    if component == "cargo" {
+        format!("{}-{}", component, build.cargo_package_vers())
+    } else {
+        assert!(component.starts_with("rust"));
+        format!("{}-{}", component, build.rust_package_vers())
+    }
 }
 
 fn distdir(build: &Build) -> PathBuf {
@@ -537,7 +541,7 @@ pub fn cargo(build: &Build, stage: u32, target: &str) {
     let src = build.src.join("cargo");
     let etc = src.join("src/etc");
     let release_num = build.cargo_release_num();
-    let name = format!("cargo-{}", build.package_vers(&release_num));
+    let name = pkgname(build, "cargo");
     let version = build.cargo_info.version(build, &release_num);
 
     let tmp = tmpdir(build);
@@ -595,12 +599,11 @@ pub fn extended(build: &Build, stage: u32, target: &str) {
     println!("Dist extended stage{} ({})", stage, target);
 
     let dist = distdir(build);
-    let cargo_vers = build.cargo_release_num();
     let rustc_installer = dist.join(format!("{}-{}.tar.gz",
                                             pkgname(build, "rustc"),
                                             target));
-    let cargo_installer = dist.join(format!("cargo-{}-{}.tar.gz",
-                                            build.package_vers(&cargo_vers),
+    let cargo_installer = dist.join(format!("{}-{}.tar.gz",
+                                            pkgname(build, "cargo"),
                                             target));
     let docs_installer = dist.join(format!("{}-{}.tar.gz",
                                            pkgname(build, "rust-docs"),
@@ -678,7 +681,7 @@ pub fn extended(build: &Build, stage: u32, target: &str) {
 
         cp_r(&work.join(&format!("{}-{}", pkgname(build, "rustc"), target)),
              &pkg.join("rustc"));
-        cp_r(&work.join(&format!("cargo-nightly-{}", target)),
+        cp_r(&work.join(&format!("{}-{}", pkgname(build, "cargo"), target)),
              &pkg.join("cargo"));
         cp_r(&work.join(&format!("{}-{}", pkgname(build, "rust-docs"), target)),
              &pkg.join("rust-docs"));
@@ -730,7 +733,7 @@ pub fn extended(build: &Build, stage: u32, target: &str) {
         cp_r(&work.join(&format!("{}-{}", pkgname(build, "rustc"), target))
                   .join("rustc"),
              &exe.join("rustc"));
-        cp_r(&work.join(&format!("cargo-nightly-{}", target))
+        cp_r(&work.join(&format!("{}-{}", pkgname(build, "cargo"), target))
                   .join("cargo"),
              &exe.join("cargo"));
         cp_r(&work.join(&format!("{}-{}", pkgname(build, "rust-docs"), target))

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -994,6 +994,11 @@ impl Build {
         self.package_vers(channel::CFG_RELEASE_NUM)
     }
 
+    /// Returns the value of `package_vers` above for Cargo
+    fn cargo_package_vers(&self) -> String {
+        self.package_vers(&self.cargo_release_num())
+    }
+
     /// Returns the `version` string associated with this compiler for Rust
     /// itself.
     ///

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -41,7 +41,7 @@ fi
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
 if [ "$DEPLOY$DEPLOY_ALT" != "" ]; then
-  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=nightly"
+  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=beta"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"
 
   if [ "$NO_LLVM_ASSERTIONS" = "1" ]; then

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,5 +12,5 @@
 # tarball for a stable release you'll likely see `1.x.0-$date` where `1.x.0` was
 # released on `$date`
 
-rustc: beta-2017-02-01
-cargo: 407edef22e894266eb562618cba5ca9757051946
+rustc: 1.16.0-2017-03-11
+cargo: 6b05583d71f982bcad049b9fa094c637c062e751


### PR DESCRIPTION
* Update stage0.txt to pending 1.16.0 release and current stable cargo rev from
  1.16.0
* Update the release channel on CI to beta
* Update the cargo submodule to master