### PR TITLE
fix format grammar

### DIFF
--- a/src/libcollections/fmt.rs
+++ b/src/libcollections/fmt.rs
@@ -306,7 +306,8 @@
 //! `%`. The actual grammar for the formatting syntax is:
 //!
 //! ```text
-//! format_string := <text> [ format <text> ] *
+//! format_string := <text> [ maybe-format <text> ] *
+//! maybe-format := '{' '{' | '}' '}' | <format>
 //! format := '{' [ argument ] [ ':' format_spec ] '}'
 //! argument := integer | identifier
 //!


### PR DESCRIPTION
This is just a trivial change to get the escaped squigglies into the grammar.

r? @steveklabnik