### PR TITLE
Using X headings #39850

### DIFF
--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -11,18 +11,18 @@ Other unofficial documentation may exist elsewhere; for example, the [Rust
 Learning] project collects documentation from the community, and [Docs.rs]
 builds documentation for individual Rust packages.
 
-## API Documentation
+# API Documentation
 
 Rust provides a standard library with a number of features; [we host its
 documentation here][api].
 
-## Extended Error Documentation
+# Extended Error Documentation
 
 Many of Rust's errors come with error codes, and you can request extended
 diagnostics from the compiler on those errors. We also [have the text of those
 extended errors on the web][err], if you prefer to read them that way.
 
-## The Rust Bookshelf
+# The Rust Bookshelf
 
 Rust provides a number of book-length sets of documentation, collectively
 nicknamed 'The Rust Bookshelf.'


### PR DESCRIPTION
Fix for issue #39850, the headings should now be 1, 2, and 3.