### PR TITLE
Point out correct turbofish usage on `Foo<Bar<Baz>>`

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2919,7 +2919,10 @@ impl<'a> Parser<'a> {
                 let op_span = mk_sp(op.span.lo, self.span.hi);
                 let mut err = self.diagnostic().struct_span_err(op_span,
                     "chained comparison operators require parentheses");
-                if op.node == BinOpKind::Lt && *outer_op == AssocOp::Greater {
+                if op.node == BinOpKind::Lt &&
+                    *outer_op == AssocOp::Less ||  // Include `<` to provide this recommendation
+                    *outer_op == AssocOp::Greater  // even in a case like the following:
+                {                                  //     Foo<Bar<Baz<Qux, ()>>>
                     err.help(
                         "use `::<...>` instead of `<...>` if you meant to specify type arguments");
                 }

--- a/src/test/ui/did_you_mean/issue-40396.rs
+++ b/src/test/ui/did_you_mean/issue-40396.rs
@@ -1,0 +1,23 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn foo() {
+    println!("{:?}", (0..13).collect<Vec<i32>>());
+}
+
+fn bar() {
+    println!("{:?}", Vec<i32>::new());
+}
+
+fn qux() {
+    println!("{:?}", (0..13).collect<Vec<i32>());
+}
+
+fn main() {}

--- a/src/test/ui/did_you_mean/issue-40396.stderr
+++ b/src/test/ui/did_you_mean/issue-40396.stderr
@@ -1,0 +1,34 @@
+error: chained comparison operators require parentheses
+  --> $DIR/issue-40396.rs:12:37
+   |
+12 |     println!("{:?}", (0..13).collect<Vec<i32>>());
+   |                                     ^^^^^^^^
+   |
+   = help: use `::<...>` instead of `<...>` if you meant to specify type arguments
+
+error: chained comparison operators require parentheses
+  --> $DIR/issue-40396.rs:16:25
+   |
+16 |     println!("{:?}", Vec<i32>::new());
+   |                         ^^^^^^^
+   |
+   = help: use `::<...>` instead of `<...>` if you meant to specify type arguments
+
+error: chained comparison operators require parentheses
+  --> $DIR/issue-40396.rs:20:37
+   |
+20 |     println!("{:?}", (0..13).collect<Vec<i32>());
+   |                                     ^^^^^^^^
+   |
+   = help: use `::<...>` instead of `<...>` if you meant to specify type arguments
+
+error: chained comparison operators require parentheses
+  --> $DIR/issue-40396.rs:20:41
+   |
+20 |     println!("{:?}", (0..13).collect<Vec<i32>());
+   |                                         ^^^^^^
+   |
+   = help: use `::<...>` instead of `<...>` if you meant to specify type arguments
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Whenever we parse a chain of binary operations, as long as the first
operation is `<` and the subsequent operations are either `>` or `<`,
present the following diagnostic help:

    use `::<...>` instead of `<...>` if you meant to specify type arguments

This will lead to spurious recommendations on situations like
`2 < 3 < 4` but should be clear from context that the help doesn't apply
in that case.

Fixes #40396.