### PR TITLE
add test for nested macro def (#31946)

### DIFF
--- a/src/test/run-pass/macro-nested_definition_issue-31946.rs
+++ b/src/test/run-pass/macro-nested_definition_issue-31946.rs
@@ -1,0 +1,18 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    println!("{}", {
+        macro_rules! foo {
+            ($name:expr) => { concat!("hello ", $name) }
+        }
+        foo!("rust")
+    });
+}


### PR DESCRIPTION
Adds a test for issue #31946 which was fixed in 1.12.0.

Closes #31946.