### PR TITLE
Add shell=True to bootstrap's subprocess execution

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -377,7 +377,7 @@ class RustBuild(object):
         self.run(args, env)
 
     def run(self, args, env):
-        proc = subprocess.Popen(args, env=env)
+        proc = subprocess.Popen(args, env=env, shell=True)
         ret = proc.wait()
         if ret != 0:
             sys.exit(ret)


### PR DESCRIPTION
Fixes: #40529

I didn't test this with Windows so, we'll see how it goes.

Thanks!