### PR TITLE
Removes Default for Box<Path>.

### DIFF
--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1224,14 +1224,6 @@ impl Into<Box<Path>> for PathBuf {
     }
 }
 
-#[stable(feature = "box_default_extra", since = "1.17.0")]
-impl Default for Box<Path> {
-    fn default() -> Box<Path> {
-        let boxed: Box<OsStr> = Default::default();
-        unsafe { mem::transmute(boxed) }
-    }
-}
-
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T: ?Sized + AsRef<OsStr>> From<&'a T> for PathBuf {
     fn from(s: &'a T) -> PathBuf {
@@ -3729,11 +3721,5 @@ mod tests {
         assert_eq!(path, &*boxed);
         assert_eq!(&*boxed, &*path_buf);
         assert_eq!(&*path_buf, path);
-    }
-
-    #[test]
-    fn boxed_default() {
-        let boxed = <Box<Path>>::default();
-        assert!(boxed.as_os_str().is_empty());
     }
 }


### PR DESCRIPTION
This was not supposed to be added. cc @alexcrichton