### PR TITLE
Upgrade CString to not allocate on empty.

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -293,6 +293,7 @@
 #![feature(slice_concat_ext)]
 #![feature(slice_patterns)]
 #![feature(staged_api)]
+#![feature(static_in_const)]
 #![feature(stmt_expr_attributes)]
 #![feature(str_char)]
 #![feature(str_internals)]


### PR DESCRIPTION
This is done by letting `CString` contain an empty slice, while also returning a static, NUL-terminated slice when necessary.

This shouldn't be too much of a maintenance burden, but I'll put this PR up and let the libs team decide if they want to keep this.