### PR TITLE
fix innacuracy in mir TerminatorKind::SwitchInt docs

### DIFF
--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -467,7 +467,7 @@ pub enum TerminatorKind<'tcx> {
         values: Cow<'tcx, [ConstInt]>,
 
         /// Possible branch sites. The last element of this vector is used
-        /// for the otherwise branch, so values.len() == targets.len() + 1
+        /// for the otherwise branch, so targets.len() == values.len() + 1
         /// should hold.
         // This invariant is quite non-obvious and also could be improved.
         // One way to make this invariant is to have something like this instead:


### PR DESCRIPTION
Each index of `values` corresponds to an index of `targets`, and `targets` additionally has a "default case" element at its end, so `targets.len() == values.len() + 1`, not the other way around. For example, [here](https://github.com/rust-lang/rust/blob/0aeb9c12979e6da753701a798d04105b6b1a8c28/src/librustc/mir/mod.rs#L549-L550) is a concrete instance of `SwitchInt` being constructed with `targets.len() == 2` and `values.len() == 1`.