### PR TITLE
Make the filenames of .stamp files generated by compiletest shorter

### DIFF
--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -486,11 +486,9 @@ pub fn make_test(config: &Config, testpaths: &TestPaths) -> test::TestDescAndFn 
 }
 
 fn stamp(config: &Config, testpaths: &TestPaths) -> PathBuf {
-    let stamp_name = format!("{}-H-{}-T-{}-S-{}.stamp",
+    let stamp_name = format!("{}-{}.stamp",
                              testpaths.file.file_name().unwrap()
                                            .to_str().unwrap(),
-                             config.host,
-                             config.target,
                              config.stage_id);
     config.build_base.canonicalize()
           .unwrap_or(config.build_base.clone())


### PR DESCRIPTION
Otherwise we run into filename length limitations on some file systems. See https://bugs.launchpad.net/ecryptfs/+bug/344878 for an example where we only can have ~145 characters for filenames.

r? @alexcrichton  