### PR TITLE
travis: Add timestamps to all build messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,9 @@ matrix:
       osx_image: xcode8.2
       install: &osx_install_sccache >
         travis_retry curl -o /usr/local/bin/sccache https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-03-16-sccache-x86_64-apple-darwin &&
-          chmod +x /usr/local/bin/sccache
+          chmod +x /usr/local/bin/sccache &&
+        travis_retry curl -o /usr/local/bin/stamp https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-03-17-stamp-x86_64-apple-darwin &&
+          chmod +x /usr/local/bin/stamp
     - env: >
         RUST_CHECK_TARGET=check
         RUST_CONFIGURE_ARGS=--build=i686-apple-darwin
@@ -118,6 +120,11 @@ env:
     # AWS_SECRET_ACCESS_KEY=...
     - secure: "Pixhh0hXDqGCdOyLtGFjli3J2AtDWIpyb2btIrLe956nCBDRutRoMm6rv5DI9sFZN07Mms7VzNNvhc9wCW1y63JAm414d2Co7Ob8kWMZlz9l9t7ACHuktUiis8yr+S4Quq1Vqd6pqi7pf2J++UxC8R/uLeqVrubzr6+X7AbmEFE="
 
+# Note that this is overridden on OSX builders
+install: >
+  travis_retry curl -o /usr/local/bin/stamp https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-03-17-stamp-x86_64-unknown-linux-musl &&
+    chmod +x /usr/local/bin/stamp
+
 before_script:
   - >
       echo "#### Disk usage before running script:";
@@ -129,11 +136,11 @@ script:
       if [ "$ALLOW_PR" = "" ] && [ "$TRAVIS_BRANCH" != "auto" ]; then
           echo skipping, not a full build;
       elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
-          travis_retry sh -c 'git submodule deinit -f . && git submodule update --init' &&
-          src/ci/run.sh;
+          travis_retry stamp sh -c 'git submodule deinit -f . && git submodule update --init' &&
+          stamp src/ci/run.sh;
       else
-          travis_retry sh -c 'git submodule deinit -f . && git submodule update --init' &&
-          src/ci/docker/run.sh $IMAGE;
+          travis_retry stamp sh -c 'git submodule deinit -f . && git submodule update --init' &&
+          stamp src/ci/docker/run.sh $IMAGE;
       fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,9 +79,7 @@ matrix:
         MACOSX_STD_DEPLOYMENT_TARGET=10.7
       os: osx
       osx_image: xcode8.2
-      install: >
-        travis_retry curl -o /usr/local/bin/sccache https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-03-16-sccache-x86_64-apple-darwin &&
-          chmod +x /usr/local/bin/sccache
+      install: *osx_install_sccache
     - env: >
         RUST_CHECK_TARGET=dist
         RUST_CONFIGURE_ARGS="--target=aarch64-apple-ios,armv7-apple-ios,armv7s-apple-ios,i386-apple-ios,x86_64-apple-ios --enable-extended"
@@ -122,8 +120,9 @@ env:
 
 # Note that this is overridden on OSX builders
 install: >
-  travis_retry curl -o /usr/local/bin/stamp https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-03-17-stamp-x86_64-unknown-linux-musl &&
-    chmod +x /usr/local/bin/stamp
+  travis_retry curl -o $HOME/stamp https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-03-17-stamp-x86_64-unknown-linux-musl &&
+    chmod +x $HOME/stamp &&
+    export PATH=$PATH:$HOME
 
 before_script:
   - >

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -24,7 +24,6 @@ ci_dir=`cd $(dirname $0) && pwd`
 source "$ci_dir/shared.sh"
 
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-sccache"
-RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-quiet-tests"
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-manage-submodules"
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-locked-deps"
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-cargo-openssl-static"


### PR DESCRIPTION
When debugging why builds are taking so long it's often useful to get the
timestamp of all log messages as we're not always timing every tiny step of the
build. I wrote a [utility] for prepending a relative timestamp from the start of
a process which is now downloaded to the builders and is what we wrap the entire
build invocation in.

[utility]: https://github.com/alexcrichton/stamp-rs

Closes #40577