### PR TITLE
Revert #39485, fixing type-inference regressions

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4099,6 +4099,17 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             };
 
             if self.diverges.get().always() {
+                if let ExpectHasType(ety) = expected {
+                    // Avoid forcing a type (only `!` for now) in unreachable code.
+                    // FIXME(aburka) do we need this special case? and should it be is_uninhabited?
+                    if !ety.is_never() {
+                        if let Some(ref e) = blk.expr {
+                            // Coerce the tail expression to the right type.
+                            self.demand_coerce(e, ty, ety);
+                        }
+                    }
+                }
+
                 ty = self.next_diverging_ty_var(TypeVariableOrigin::DivergingBlockExpr(blk.span));
             } else if let ExpectHasType(ety) = expected {
                 if let Some(ref e) = blk.expr {

--- a/src/test/compile-fail/issue-10176.rs
+++ b/src/test/compile-fail/issue-10176.rs
@@ -1,0 +1,19 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn f() -> isize {
+    (return 1, return 2)
+//~^ ERROR mismatched types
+//~| expected type `isize`
+//~| found type `(_, _)`
+//~| expected isize, found tuple
+}
+
+fn main() {}

--- a/src/test/compile-fail/issue-5500.rs
+++ b/src/test/compile-fail/issue-5500.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn g() {
+fn main() {
     &panic!()
+    //~^ ERROR mismatched types
+    //~| expected type `()`
+    //~| found type `&_`
+    //~| expected (), found reference
 }
-
-fn f() -> isize {
-    (return 1, return 2)
-}
-
-fn main() {}

--- a/src/test/run-pass/issue-15763.rs
+++ b/src/test/run-pass/issue-15763.rs
@@ -8,8 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(unused_features)]
-#![allow(unreachable_code)]
+#![allow(unknown_features)]
 #![feature(box_syntax)]
 
 #[derive(PartialEq, Debug)]
@@ -29,14 +28,14 @@ struct Foo {
 }
 
 fn foo() -> Result<Foo, isize> {
-    return Ok::<Foo, isize>(Foo {
+    return Ok(Foo {
         x: Bar { x: 22 },
         a: return Err(32)
     });
 }
 
 fn baz() -> Result<Foo, isize> {
-    Ok::<Foo, isize>(Foo {
+    Ok(Foo {
         x: Bar { x: 22 },
         a: return Err(32)
     })

--- a/src/test/run-pass/issue-39984.rs
+++ b/src/test/run-pass/issue-39984.rs
@@ -1,0 +1,21 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for issue #39984.
+//
+// The key here is that the error type of the `Ok` call ought to be
+// constrained to `String`, even though it is dead-code.
+
+fn main() {}
+
+fn t() -> Result<(), String> {
+    return Err("".into());
+    Ok(())
+}

--- a/src/test/run-pass/project-defer-unification.rs
+++ b/src/test/run-pass/project-defer-unification.rs
@@ -11,8 +11,6 @@
 // A regression test extracted from image-0.3.11. The point of
 // failure was in `index_colors` below.
 
-#![allow(unused)]
-
 use std::ops::{Deref, DerefMut};
 
 #[derive(Copy, Clone)]
@@ -94,7 +92,7 @@ pub fn index_colors<Pix>(image: &ImageBuffer<Pix, Vec<u8>>)
                          -> ImageBuffer<Luma<u8>, Vec<u8>>
 where Pix: Pixel<Subpixel=u8> + 'static,
 {
-    let mut indices: ImageBuffer<Luma<u8>, Vec<u8>> = loop { };
+    let mut indices: ImageBuffer<_,Vec<_>> = loop { };
     for (pixel, idx) in image.pixels().zip(indices.pixels_mut()) {
         // failured occurred here ^^ because we were requiring that we
         // could project Pixel or Subpixel from `T_indices` (type of


### PR DESCRIPTION
This reverts PR #39485, which should fix the immediate regressions. Eventually I'd like to land https://github.com/rust-lang/rust/pull/40224 -- or some variant of it -- which revisits the question fo dead-code and inference.

r? @eddyb 
cc @canndrew