### PR TITLE
Stop triggering Travis CI for the 'master' branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ git:
   depth: 1
   submodules: false
 
+branches:
+  except:
+    - master
+
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
Building the 'master' branch seems redundant since everything is supposed to go through the 'auto' branch via bors.