### PR TITLE
Fix a typo in path.rs docs

### DIFF
--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1501,7 +1501,7 @@ impl Path {
     /// assert_eq!(path.to_string_lossy(), "foo.txt");
     /// ```
     ///
-    /// Had `os_str` contained invalid unicode, the `to_string_lossy` call might
+    /// Had `path` contained invalid unicode, the `to_string_lossy` call might
     /// have returned `"fo�.txt"`.
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn to_string_lossy(&self) -> Cow<str> {


### PR DESCRIPTION
The name of the variable used in the example is `path`, not `os_str`.