### PR TITLE
Rustdoc sidebar style improvements

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -189,7 +189,6 @@ nav.sub {
 }
 
 .sidebar .location {
-	border: 1px solid;
 	font-size: 17px;
 	margin: 30px 0 20px 0;
 	text-align: center;

--- a/src/librustdoc/html/static/styles/main.css
+++ b/src/librustdoc/html/static/styles/main.css
@@ -38,7 +38,7 @@ pre {
 }
 
 .sidebar {
-	background-color: #F1F1F1;
+	background-color: #F8F8F8;
 }
 
 .sidebar .current {
@@ -46,13 +46,11 @@ pre {
 }
 
 .sidebar .location {
-	border-color: #000;
-	background-color: #fff;
-	color: #333;
+	background-color: #e1e1e1;
 }
 
 .block a:hover {
-	background: #F5F5F5;
+	background: #EEEEEE;
 }
 
 .line-numbers span { color: #c67e2d; }


### PR DESCRIPTION
Some improvements of the sidebar style

* The sidebar now has a visually more pleasant color.
  Its still different from the main site, so its still
  easy to spot a difference

* Hovering the entries in the sidebar now has a
  discernible difference to the sidebar background,
  fixing a regression of commit 2bb2a2975f25e8ba7a372898e7e112f1cec5db01

* The very unpleasant black border around the crate name has been removed.

Screenshot before the change: ![screenshot_20170320_183015](https://cloud.githubusercontent.com/assets/8872119/24112942/70177b3e-0d9b-11e7-8fbf-12d5f6c9b626.png)

Screenshot after the change: ![screenshot_20170320_182916](https://cloud.githubusercontent.com/assets/8872119/24112963/7f3a438a-0d9b-11e7-94d6-5007dbfd4e33.png)

