### PR TITLE
Update docs for std::str

### DIFF
--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -59,6 +59,27 @@ pub use std_unicode::str::SplitWhitespace;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::pattern;
 
+/// Unicode string slices.
+///
+/// The `&str` type is one of the two main string types, the other being `String`. Unlike its `String` counterpart, its contents
+/// are borrowed and therefore cannot be moved someplace else.
+///
+/// # Basic Usage
+/// A basic string declaration of `&str` type:
+///
+/// ```
+/// let hello_world = "Hello, World!";
+/// ```
+/// Here we have declared a string literal, also known as a string slice.
+/// String literals have a static lifetime, which means the string `hello_world`
+/// is guaranteed to be valid for the duration of the entire program. We can explicitly specify
+/// `hello_world`'s lifetime as well:
+///
+/// ```
+/// let hello_world:&'static str = "Hello, world!";
+/// ```
+///
+
 #[unstable(feature = "slice_concat_ext",
            reason = "trait should not have to exist",
            issue = "27747")]

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -11,10 +11,10 @@
 //! Unicode string slices.
 //!
 //! The `&str` type is one of the two main string types, the other being `String`.
-//! Unlike its `String` counterpart, its contents are borrowed and therefore
-//! cannot be moved someplace else.
+//! Unlike its `String` counterpart, its contents are borrowed.
 //!
 //! # Basic Usage
+//!
 //! A basic string declaration of `&str` type:
 //!
 //! ```
@@ -27,7 +27,7 @@
 //! We can explicitly specify `hello_world`'s lifetime as well:
 //!
 //! ```
-//! let hello_world:&'static str = "Hello, world!";
+//! let hello_world: &'static str = "Hello, world!";
 //! ```
 //!
 //! *[See also the `str` primitive type](../../std/primitive.str.html).*

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -10,8 +10,9 @@
 
 //! Unicode string slices.
 //!
-//! The `&str` type is one of the two main string types, the other being `String`. Unlike its `String` counterpart, its contents
-//! are borrowed and therefore cannot be moved someplace else.
+//! The `&str` type is one of the two main string types, the other being `String`.
+//! Unlike its `String` counterpart, its contents are borrowed and therefore
+//! cannot be moved someplace else.
 //!
 //! # Basic Usage
 //! A basic string declaration of `&str` type:
@@ -22,8 +23,8 @@
 //!
 //! Here we have declared a string literal, also known as a string slice.
 //! String literals have a static lifetime, which means the string `hello_world`
-//! is guaranteed to be valid for the duration of the entire program. We can explicitly specify
-//! `hello_world`'s lifetime as well:
+//! is guaranteed to be valid for the duration of the entire program.
+//! We can explicitly specify `hello_world`'s lifetime as well:
 //!
 //! ```
 //! let hello_world:&'static str = "Hello, world!";

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -10,8 +10,26 @@
 
 //! Unicode string slices.
 //!
+//! The `&str` type is one of the two main string types, the other being `String`. Unlike its `String` counterpart, its contents
+//! are borrowed and therefore cannot be moved someplace else.
+//!
+//! # Basic Usage
+//! A basic string declaration of `&str` type:
+//!
+//! ```
+//! let hello_world = "Hello, World!";
+//! ```
+//!
+//! Here we have declared a string literal, also known as a string slice.
+//! String literals have a static lifetime, which means the string `hello_world`
+//! is guaranteed to be valid for the duration of the entire program. We can explicitly specify
+//! `hello_world`'s lifetime as well:
+//!
+//! ```
+//! let hello_world:&'static str = "Hello, world!";
+//! ```
+//!
 //! *[See also the `str` primitive type](../../std/primitive.str.html).*
-
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -58,27 +76,6 @@ pub use core::str::{from_utf8_unchecked, ParseBoolError};
 pub use std_unicode::str::SplitWhitespace;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::pattern;
-
-/// Unicode string slices.
-///
-/// The `&str` type is one of the two main string types, the other being `String`. Unlike its `String` counterpart, its contents
-/// are borrowed and therefore cannot be moved someplace else.
-///
-/// # Basic Usage
-/// A basic string declaration of `&str` type:
-///
-/// ```
-/// let hello_world = "Hello, World!";
-/// ```
-/// Here we have declared a string literal, also known as a string slice.
-/// String literals have a static lifetime, which means the string `hello_world`
-/// is guaranteed to be valid for the duration of the entire program. We can explicitly specify
-/// `hello_world`'s lifetime as well:
-///
-/// ```
-/// let hello_world:&'static str = "Hello, world!";
-/// ```
-///
 
 #[unstable(feature = "slice_concat_ext",
            reason = "trait should not have to exist",


### PR DESCRIPTION
fixes #29375 

I noticed there are docs for the `str` primitive type, which contained extensive examples, so my additions give a more general explanation of `&str`. But please let me know if something can be explained more or changed.

r? @steveklabnik 