### PR TITLE
Add whitespace around "=" in assoc items

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1096,9 +1096,9 @@ impl fmt::Display for clean::ImportSource {
 impl fmt::Display for clean::TypeBinding {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if f.alternate() {
-            write!(f, "{}={:#}", self.name, self.ty)
+            write!(f, "{} = {:#}", self.name, self.ty)
         } else {
-            write!(f, "{}={}", self.name, self.ty)
+            write!(f, "{} = {}", self.name, self.ty)
         }
     }
 }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2808,7 +2808,7 @@ fn render_assoc_items(w: &mut fmt::Formatter,
             }
             AssocItemRender::DerefFor { trait_, type_, deref_mut_ } => {
                 write!(w, "<h2 id='deref-methods'>Methods from \
-                               {}&lt;Target={}&gt;</h2>", trait_, type_)?;
+                               {}&lt;Target = {}&gt;</h2>", trait_, type_)?;
                 RenderMode::ForDeref { mut_: deref_mut_ }
             }
         };

--- a/src/test/rustdoc/doc-assoc-item.rs
+++ b/src/test/rustdoc/doc-assoc-item.rs
@@ -1,0 +1,28 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub struct Foo<T> {
+    x: T,
+}
+
+pub trait Bar {
+    type Fuu;
+
+    fn foo(foo: Self::Fuu);
+}
+
+// @has doc_assoc_item/struct.Foo.html '//*[@class="impl"]' 'impl<T: Bar<Fuu = u32>> Foo<T>'
+impl<T: Bar<Fuu = u32>> Foo<T> {
+    pub fn new(t: T) -> Foo<T> {
+        Foo {
+            x: t,
+        }
+    }
+}

--- a/src/test/rustdoc/issue-20646.rs
+++ b/src/test/rustdoc/issue-20646.rs
@@ -23,7 +23,7 @@ pub trait Trait {
 }
 
 // @has issue_20646/fn.fun.html \
-//      '//*[@class="rust fn"]' 'where T: Trait<Output=i32>'
+//      '//*[@class="rust fn"]' 'where T: Trait<Output = i32>'
 pub fn fun<T>(_: T) where T: Trait<Output=i32> {}
 
 pub mod reexport {
@@ -31,6 +31,6 @@ pub mod reexport {
     //      '//*[@id="associatedtype.Output"]' \
     //      'type Output'
     // @has issue_20646/reexport/fn.fun.html \
-    //      '//*[@class="rust fn"]' 'where T: Trait<Output=i32>'
+    //      '//*[@class="rust fn"]' 'where T: Trait<Output = i32>'
     pub use issue_20646::{Trait, fun};
 }


### PR DESCRIPTION
Part of #40641.

r? @rust-lang/docs 

Before:

<img width="1440" alt="screen shot 2017-03-20 at 22 42 34" src="https://cloud.githubusercontent.com/assets/3050060/24123102/89181d8c-0dbe-11e7-897c-841497cf7001.png">

After:

<img width="1440" alt="screen shot 2017-03-20 at 22 42 36" src="https://cloud.githubusercontent.com/assets/3050060/24123118/8dec176e-0dbe-11e7-9759-cabbd062a4c2.png">