### PR TITLE
str: Make docs consistently punctuated

### DIFF
--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -332,7 +332,7 @@ impl fmt::Display for Utf8Error {
 Section: Iterators
 */
 
-/// Iterator for the char (representing *Unicode Scalar Values*) of a string
+/// Iterator for the char (representing *Unicode Scalar Values*) of a string.
 ///
 /// Created with the method [`chars`].
 ///


### PR DESCRIPTION
Every so slightly pointless one character PR, but this was driving me nuts while reading the docs a moment ago (all the [other public structs](https://doc.rust-lang.org/std/str/index.html#structs) have descriptions that end in a full-stop).