### PR TITLE
Remove unused adt-def insertion by constructor DefIndex

### DIFF
--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -558,7 +558,6 @@ impl<'a, 'tcx> CrateMetadata {
             EntryKind::Union(_, _) => ty::AdtKind::Union,
             _ => bug!("get_adt_def called on a non-ADT {:?}", did),
         };
-        let mut ctor_index = None;
         let variants = if let ty::AdtKind::Enum = kind {
             item.children
                 .decode(self)
@@ -570,8 +569,7 @@ impl<'a, 'tcx> CrateMetadata {
                 })
                 .collect()
         } else {
-            let (variant, struct_ctor) = self.get_variant(&item, item_id, tcx);
-            ctor_index = struct_ctor;
+            let (variant, _struct_ctor) = self.get_variant(&item, item_id, tcx);
             vec![variant]
         };
         let (kind, repr) = match item.kind {
@@ -581,13 +579,7 @@ impl<'a, 'tcx> CrateMetadata {
             _ => bug!("get_adt_def called on a non-ADT {:?}", did),
         };
 
-        let adt = tcx.alloc_adt_def(did, kind, variants, repr);
-        if let Some(ctor_index) = ctor_index {
-            // Make adt definition available through constructor id as well.
-            tcx.maps.adt_def.borrow_mut().insert(self.local_def_id(ctor_index), adt);
-        }
-
-        adt
+        tcx.alloc_adt_def(did, kind, variants, repr)
     }
 
     pub fn get_predicates(&self,

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -689,12 +689,6 @@ fn adt_def<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let node_id = tcx.hir.as_local_node_id(def_id).unwrap();
     let item = match tcx.hir.get(node_id) {
         NodeItem(item) => item,
-
-        // Make adt definition available through constructor id as well.
-        NodeStructCtor(_) => {
-            return tcx.lookup_adt_def(tcx.hir.get_parent_did(node_id));
-        }
-
         _ => bug!()
     };
 


### PR DESCRIPTION
It looks to me like ADT definitions weren't being looked up by constructor id, and a test run supports my theory.

In any case, I'm not sure it would have worked in its current configuration. If I understand correctly, the `adt_def` map entry from constructor id -> adt def would only be present after a successful call to `queries::adt_def::get` with the proper ADT `DefIndex`. Trying to look up an adt_def by the constructor index prior to a successful lookup by ADT index would fail since `item.kind` would be `EntryKind::Fn` (for the constructor function) and so would trigger the `bug!`.

r? @nikomatsakis