### PR TITLE
Don't call `fmt::Write::write_str` for statically empty strings

### DIFF
--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -751,8 +751,10 @@ pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt,
     let mut arg_index_consumed = vec![0usize; cx.arg_index_map.len()];
     for piece in pieces {
         if let Some(piece) = cx.trans_piece(&piece, &mut arg_index_consumed) {
-            let s = cx.trans_literal_string();
-            cx.str_pieces.push(s);
+            if !cx.literal.is_empty() {
+                let s = cx.trans_literal_string();
+                cx.str_pieces.push(s);
+            }
             cx.pieces.push(piece);
         }
     }


### PR DESCRIPTION
This means that `writeln!(something, "{}{}", s1, s2)` no longer calls
`write_str` two times with empty strings (before each substitution).

See #31966 for an earlier attempt.