### PR TITLE
Nit: LLVM & Clang latest version is 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Read ["Installing Rust"] from [The Book].
 
 1. Make sure you have installed the dependencies:
 
-   * `g++` 4.7 or later or `clang++` 3.x
+   * `g++` 4.7 or later or `clang++` 3.x or later
    * `python` 2.7 (but not 3.x)
    * GNU `make` 3.81 or later
    * `cmake` 3.4.3 or later


### PR DESCRIPTION
Small nit: since latest Clang version is 4.0 it's nice to reflect this in the documentation.

Also, I couldn't find anything, but there might be any hard-coded check that Clang version matches "3.X" anywhere in the build system; if there is one, it'd be great to bump that one too.