### PR TITLE
Improve documentation of next_power_of_two

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -2340,6 +2340,9 @@ macro_rules! uint_impl {
         }
 
         /// Returns the smallest power of two greater than or equal to `self`.
+        /// When return value overflows, it panics in debug mode and return
+        /// value is wrapped in release mode.
+        ///
         /// More details about overflow behavior can be found in [RFC 560].
         ///
         /// # Examples

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -2328,7 +2328,7 @@ macro_rules! uint_impl {
         }
 
         /// Returns the smallest power of two greater than or equal to `self`.
-        /// Unspecified behavior on overflow.
+        /// More details about overflow behavior can be found in [RFC 560].
         ///
         /// # Examples
         ///
@@ -2338,6 +2338,8 @@ macro_rules! uint_impl {
         /// assert_eq!(2u8.next_power_of_two(), 2);
         /// assert_eq!(3u8.next_power_of_two(), 4);
         /// ```
+        ///
+        /// [RFC 560]: https://github.com/rust-lang/rfcs/blob/master/text/0560-integer-overflow.md
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
         pub fn next_power_of_two(self) -> Self {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -2327,12 +2327,22 @@ macro_rules! uint_impl {
             (self.wrapping_sub(1)) & self == 0 && !(self == 0)
         }
 
+        // Returns one less than next greater power of two.
+        // (For 8u8 next greater power of two is 16u8 and for 6u8 it is 8u8)
+        //
+        // 8u8.round_up_to_one_less_than_a_power_of_two() == 15
+        // 6u8.round_up_to_one_less_than_a_power_of_two() == 7
         fn round_up_to_one_less_than_a_power_of_two(self) -> Self {
             let bits = size_of::<Self>() as u32 * 8;
             let z = self.leading_zeros();
             (if z == bits { 0 as Self } else { !0 }).wrapping_shr(z)
         }
 
+        // Returns one less than next power of two.
+        // (For 8u8 next power of two is 8u8 and for 6u8 it is 8u8)
+        //
+        // 8u8.one_less_than_next_power_of_two() == 7
+        // 6u8.one_less_than_next_power_of_two() == 7
         fn one_less_than_next_power_of_two(self) -> Self {
             self.wrapping_sub(1)
                 .round_up_to_one_less_than_a_power_of_two()
@@ -2340,10 +2350,10 @@ macro_rules! uint_impl {
         }
 
         /// Returns the smallest power of two greater than or equal to `self`.
-        /// When return value overflows, it panics in debug mode and return
-        /// value is wrapped in release mode.
         ///
-        /// More details about overflow behavior can be found in [RFC 560].
+        /// When return value overflows (i.e. `self > (1 << (N-1))` for type
+        /// `uN`), it panics in debug mode and return value is wrapped to 0 in
+        /// release mode (the only situation in which method can return 0).
         ///
         /// # Examples
         ///
@@ -2353,8 +2363,6 @@ macro_rules! uint_impl {
         /// assert_eq!(2u8.next_power_of_two(), 2);
         /// assert_eq!(3u8.next_power_of_two(), 4);
         /// ```
-        ///
-        /// [RFC 560]: https://github.com/rust-lang/rfcs/blob/master/text/0560-integer-overflow.md
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
         pub fn next_power_of_two(self) -> Self {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -2376,12 +2376,7 @@ macro_rules! uint_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         pub fn checked_next_power_of_two(self) -> Option<Self> {
-            let npot = self.one_less_than_next_power_of_two().wrapping_add(1);
-            if npot >= self {
-                Some(npot)
-            } else {
-                None
-            }
+            self.one_less_than_next_power_of_two().checked_add(1)
         }
     }
 }

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -2345,7 +2345,11 @@ macro_rules! uint_impl {
         pub fn next_power_of_two(self) -> Self {
             let bits = size_of::<Self>() * 8;
             let one: Self = 1;
-            one << ((bits - self.wrapping_sub(one).leading_zeros() as usize) % bits)
+            if self == 0 {
+                1
+            } else {
+                one << (bits - self.wrapping_sub(one).leading_zeros() as usize)
+            }
         }
 
         /// Returns the smallest power of two greater than or equal to `n`. If
@@ -2363,7 +2367,9 @@ macro_rules! uint_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         pub fn checked_next_power_of_two(self) -> Option<Self> {
-            let npot = self.next_power_of_two();
+            let bits = size_of::<Self>() * 8;
+            let one: Self = 1;
+            let npot = one << ((bits - self.wrapping_sub(one).leading_zeros() as usize) % bits);
             if npot >= self {
                 Some(npot)
             } else {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -2348,7 +2348,7 @@ macro_rules! uint_impl {
             if self == 0 {
                 1
             } else {
-                one << (bits - self.wrapping_sub(one).leading_zeros() as usize)
+                one << (bits - (self - one).leading_zeros() as usize)
             }
         }
 

--- a/src/libstd/num.rs
+++ b/src/libstd/num.rs
@@ -176,7 +176,10 @@ mod tests {
             fn $test_name() {
                 #![test]
                 assert_eq!((0 as $T).checked_next_power_of_two(), Some(1));
-                assert!(($T::MAX / 2).checked_next_power_of_two().is_some());
+                let smax = $T::MAX >> 1;
+                assert_eq!(smax.checked_next_power_of_two(), Some(smax+1));
+                assert_eq!((smax + 1).checked_next_power_of_two(), Some(smax + 1));
+                assert_eq!((smax + 2).checked_next_power_of_two(), None);
                 assert_eq!(($T::MAX - 1).checked_next_power_of_two(), None);
                 assert_eq!($T::MAX.checked_next_power_of_two(), None);
                 let mut next_power = 1;


### PR DESCRIPTION
Clarify overflow behavior of `next_power_of_two`.

Related Issue: #18604