### PR TITLE
Tiny update to rustdoc CSS

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -378,6 +378,8 @@ h4 > code, h3 > code, .invisible > code {
 .content .fn .where,
 .content .where.fmt-newline {
 	display: block;
+	color: #4E4C4C
+	font-size: 0.8em;
 }
 /* Bit of whitespace to indent it */
 .content .method .where::before,


### PR DESCRIPTION
Just makes trait bounds a bit less blaring.  I find it decreases the noise in the common case when I'm not terribly interested in them, while making them still easily visible when I am.  Example screenshot here: https://alopex.li/temp/rustdoc-small-traits.png

Not sure if anyone besides me cares about this, but...  :smile: