### PR TITLE
Added core::cmp::Reverse for sort_by_key reverse sorting

### DIFF
--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -333,7 +333,7 @@ impl Ordering {
 /// use std::cmp::Reverse;
 ///
 /// let mut v = vec![1, 2, 3, 4, 5, 6];
-/// v.sort_by_key(|&num| (num >= 3, Reverse(num)));
+/// v.sort_by_key(|&num| (num > 3, Reverse(num)));
 /// assert_eq!(v, vec![3, 2, 1, 6, 5, 4]);
 /// ```
 #[derive(PartialEq, Eq, Debug)]

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -330,6 +330,7 @@ impl Ordering {
 /// Example usage:
 ///
 /// ```
+/// #![feature(reverse_cmp_key)]
 /// use std::cmp::Reverse;
 ///
 /// let mut v = vec![1, 2, 3, 4, 5, 6];
@@ -337,10 +338,10 @@ impl Ordering {
 /// assert_eq!(v, vec![3, 2, 1, 6, 5, 4]);
 /// ```
 #[derive(PartialEq, Eq, Debug)]
-#[stable(feature = "rust1", since = "1.18.0")]
+#[unstable(feature = "reverse_cmp_key", issue = "40720")]
 pub struct Reverse<T>(pub T);
 
-#[stable(feature = "rust1", since = "1.18.0")]
+#[unstable(feature = "reverse_cmp_key", issue = "40720")]
 impl<T: PartialOrd> PartialOrd for Reverse<T> {
     #[inline]
     fn partial_cmp(&self, other: &Reverse<T>) -> Option<Ordering> {
@@ -348,7 +349,7 @@ impl<T: PartialOrd> PartialOrd for Reverse<T> {
     }
 }
 
-#[stable(feature = "rust1", since = "1.18.0")]
+#[unstable(feature = "reverse_cmp_key", issue = "40720")]
 impl<T: Ord> Ord for Reverse<T> {
     #[inline]
     fn cmp(&self, other: &Reverse<T>) -> Ordering {

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -322,6 +322,40 @@ impl Ordering {
     }
 }
 
+/// A helper struct for reverse ordering.
+///
+/// This struct is a helper to be used with functions like `Vec::sort_by_key` and
+/// can be used to reverse order a part of a key.
+///
+/// Example usage:
+///
+/// ```
+/// use std::cmp::Reverse;
+///
+/// let mut v = vec![1, 2, 3, 4, 5, 6];
+/// v.sort_by_key(|&num| (num >= 3, Reverse(num)));
+/// assert_eq!(v, vec![3, 2, 1, 6, 5, 4]);
+/// ```
+#[derive(PartialEq, Eq, Debug)]
+#[stable(feature = "rust1", since = "1.8.0")]
+pub struct Reverse<T: Ord + PartialOrd + Eq + PartialEq>(pub T);
+
+#[stable(feature = "rust1", since = "1.8.0")]
+impl<T: Ord + PartialOrd + Eq + PartialEq> PartialOrd for Reverse<T> {
+    #[inline]
+    fn partial_cmp(&self, other: &Reverse<T>) -> Option<Ordering> {
+        other.0.partial_cmp(&self.0)
+    }
+}
+
+#[stable(feature = "rust1", since = "1.8.0")]
+impl<T: Ord + PartialOrd + Eq + PartialEq> Ord for Reverse<T> {
+    #[inline]
+    fn cmp(&self, other: &Reverse<T>) -> Ordering {
+        other.0.cmp(&self.0)
+    }
+}
+
 /// Trait for types that form a [total order](https://en.wikipedia.org/wiki/Total_order).
 ///
 /// An order is a total order if it is (for all `a`, `b` and `c`):

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -337,19 +337,19 @@ impl Ordering {
 /// assert_eq!(v, vec![3, 2, 1, 6, 5, 4]);
 /// ```
 #[derive(PartialEq, Eq, Debug)]
-#[stable(feature = "rust1", since = "1.8.0")]
-pub struct Reverse<T: Ord + PartialOrd + Eq + PartialEq>(pub T);
+#[stable(feature = "rust1", since = "1.18.0")]
+pub struct Reverse<T>(pub T);
 
-#[stable(feature = "rust1", since = "1.8.0")]
-impl<T: Ord + PartialOrd + Eq + PartialEq> PartialOrd for Reverse<T> {
+#[stable(feature = "rust1", since = "1.18.0")]
+impl<T: PartialOrd> PartialOrd for Reverse<T> {
     #[inline]
     fn partial_cmp(&self, other: &Reverse<T>) -> Option<Ordering> {
         other.0.partial_cmp(&self.0)
     }
 }
 
-#[stable(feature = "rust1", since = "1.8.0")]
-impl<T: Ord + PartialOrd + Eq + PartialEq> Ord for Reverse<T> {
+#[stable(feature = "rust1", since = "1.18.0")]
+impl<T: Ord> Ord for Reverse<T> {
     #[inline]
     fn cmp(&self, other: &Reverse<T>) -> Ordering {
         other.0.cmp(&self.0)

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -338,10 +338,10 @@ impl Ordering {
 /// assert_eq!(v, vec![3, 2, 1, 6, 5, 4]);
 /// ```
 #[derive(PartialEq, Eq, Debug)]
-#[unstable(feature = "reverse_cmp_key", issue = "40720")]
+#[unstable(feature = "reverse_cmp_key", issue = "40893")]
 pub struct Reverse<T>(pub T);
 
-#[unstable(feature = "reverse_cmp_key", issue = "40720")]
+#[unstable(feature = "reverse_cmp_key", issue = "40893")]
 impl<T: PartialOrd> PartialOrd for Reverse<T> {
     #[inline]
     fn partial_cmp(&self, other: &Reverse<T>) -> Option<Ordering> {
@@ -349,7 +349,7 @@ impl<T: PartialOrd> PartialOrd for Reverse<T> {
     }
 }
 
-#[unstable(feature = "reverse_cmp_key", issue = "40720")]
+#[unstable(feature = "reverse_cmp_key", issue = "40893")]
 impl<T: Ord> Ord for Reverse<T> {
     #[inline]
     fn cmp(&self, other: &Reverse<T>) -> Ordering {


### PR DESCRIPTION
I'm not sure if this is the best way to go about proposing this feature but it's pretty useful. It allows you to use `sort_by_key` and return tuples where a single item is then reversed to how it normally sorts.

I quite miss something like this in Rust currently though I'm not sure if this is the best way to implement it.