### PR TITLE
E0090: Add explanation for error message

### DIFF
--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -1223,6 +1223,18 @@ fn main() {
 ```
 "##,
 
+E0090: r##"
+The wrong number of lifetimes were supplied. For example:
+
+```compile_fail,E0090
+fn foo<'a: 'b, 'b: 'a>() {}
+
+fn main() {
+    foo::<'static>(); // error, expected 2 lifetime parameters
+}
+```
+"##,
+
 E0091: r##"
 You gave an unnecessary type parameter in a type alias. Erroneous code
 example:
@@ -4120,7 +4132,6 @@ register_diagnostics! {
 //  E0068,
 //  E0085,
 //  E0086,
-    E0090,
     E0103, // @GuillaumeGomez: I was unable to get this error, try your best!
     E0104,
 //  E0123,

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -1224,13 +1224,23 @@ fn main() {
 "##,
 
 E0090: r##"
-The wrong number of lifetimes were supplied. For example:
+You gave too few lifetime parameters. Example:
 
 ```compile_fail,E0090
 fn foo<'a: 'b, 'b: 'a>() {}
 
 fn main() {
     foo::<'static>(); // error, expected 2 lifetime parameters
+}
+```
+
+Please check you give the right number of lifetime parameters. Example:
+
+```
+fn foo<'a: 'b, 'b: 'a>() {}
+
+fn main() {
+    foo::<'static, 'static>();
 }
 ```
 "##,


### PR DESCRIPTION
See #32777

    $ rustc --explain E0090
    The wrong number of lifetimes were supplied. For example:
    
    ```
    fn foo<'a: 'b, 'b: 'a>() {}
    
    fn main() {
        foo::<'static>(); // error, expected 2 lifetime parameters
    }
    ```