### PR TITLE
Make overlapping_inherent_impls lint a hard error

### DIFF
--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -197,10 +197,6 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
             reference: "issue #36888 <https://github.com/rust-lang/rust/issues/36888>",
         },
         FutureIncompatibleInfo {
-            id: LintId::of(OVERLAPPING_INHERENT_IMPLS),
-            reference: "issue #36889 <https://github.com/rust-lang/rust/issues/36889>",
-        },
-        FutureIncompatibleInfo {
             id: LintId::of(ILLEGAL_FLOATING_POINT_CONSTANT_PATTERN),
             reference: "issue #36890 <https://github.com/rust-lang/rust/issues/36890>",
         },
@@ -263,4 +259,5 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
     store.register_removed("drop_with_repr_extern", "drop flags have been removed");
     store.register_removed("transmute_from_fn_item_types",
         "always cast functions before transmuting them");
+    store.register_removed("overlapping_inherent_impls", "converted into hard error, see #36889");
 }

--- a/src/librustc_typeck/coherence/inherent_impls.rs
+++ b/src/librustc_typeck/coherence/inherent_impls.rs
@@ -322,4 +322,3 @@ impl<'a, 'tcx> InherentCollect<'a, 'tcx> {
         }
     }
 }
-

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -4212,4 +4212,5 @@ register_diagnostics! {
            // but `{}` was found in the type `{}`
     E0567, // auto traits can not have type parameters
     E0568, // auto-traits can not have predicates,
+    E0592, // duplicate definitions with name `{}`
 }

--- a/src/test/compile-fail/coherence-overlapping-inherent-impl-trait.rs
+++ b/src/test/compile-fail/coherence-overlapping-inherent-impl-trait.rs
@@ -9,10 +9,8 @@
 // except according to those terms.
 
 #![allow(dead_code)]
-#![deny(overlapping_inherent_impls)]
 
 trait C {}
 impl C { fn f() {} } //~ ERROR duplicate definitions with name `f`
-//~^ WARN: this was previously accepted
 impl C { fn f() {} }
 fn main() { }

--- a/src/test/compile-fail/inherent-overlap.rs
+++ b/src/test/compile-fail/inherent-overlap.rs
@@ -17,7 +17,6 @@ struct Foo;
 
 impl Foo {
     fn id() {} //~ ERROR duplicate definitions
-    //~^ WARN previously accepted
 }
 
 impl Foo {
@@ -28,7 +27,6 @@ struct Bar<T>(T);
 
 impl<T> Bar<T> {
     fn bar(&self) {} //~ ERROR duplicate definitions
-    //~^ WARN previously accepted
 }
 
 impl Bar<u32> {
@@ -39,7 +37,6 @@ struct Baz<T>(T);
 
 impl<T: Copy> Baz<T> {
     fn baz(&self) {} //~ ERROR duplicate definitions
-    //~^ WARN previously accepted
 }
 
 impl<T> Baz<Vec<T>> {


### PR DESCRIPTION
Closes #36889.