### PR TITLE
Basic documentation for inclusive range syntax

### DIFF
--- a/src/doc/unstable-book/src/inclusive-range-syntax.md
+++ b/src/doc/unstable-book/src/inclusive-range-syntax.md
@@ -6,5 +6,15 @@ The tracking issue for this feature is: [#28237]
 
 ------------------------
 
+To get a range that goes from 0 to 10 and includes the value 10, you
+can write `0...10`:
 
+```rust
+#![feature(inclusive_range_syntax)]
 
+fn main() {
+    for i in 0...10 {
+        println!("{}", i);
+    }
+}
+```


### PR DESCRIPTION
Done so that we can remove mention of this from the stable documentation ⚠️.