### PR TITLE
Change object safety violation message

### DIFF
--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -46,7 +46,7 @@ impl ObjectSafetyViolation {
                 "the trait cannot require that `Self : Sized`".into(),
             ObjectSafetyViolation::SupertraitSelf =>
                 "the trait cannot use `Self` as a type parameter \
-                 in the supertrait listing".into(),
+                 in the supertraits or where-clauses".into(),
             ObjectSafetyViolation::Method(name, MethodViolationCode::StaticMethod) =>
                 format!("method `{}` has no receiver", name).into(),
             ObjectSafetyViolation::Method(name, MethodViolationCode::ReferencesSelf) =>

--- a/src/test/compile-fail/object-safety-supertrait-mentions-Self.rs
+++ b/src/test/compile-fail/object-safety-supertrait-mentions-Self.rs
@@ -24,7 +24,7 @@ fn make_bar<T:Bar<u32>>(t: &T) -> &Bar<u32> {
 
 fn make_baz<T:Baz>(t: &T) -> &Baz {
     //~^ ERROR E0038
-    //~| NOTE the trait cannot use `Self` as a type parameter in the supertrait listing
+    //~| NOTE the trait cannot use `Self` as a type parameter in the supertraits or where-clauses
     //~| NOTE the trait `Baz` cannot be made into an object
     t
 }


### PR DESCRIPTION
Hello!

This is my first pull request to rust so hopefully all goes well. This PR should fix issue #40670. I changed the error message in object_safety.rs and the corresponding compile-fail test in object-safety-supertrait-mentions-Self.rs.

Once the changes were made, I ran ```python x.py test src/tools/tidy``` and ```python x.py test```. Tidy passed and the compile-fail tests passed, however the test suite failed on the tcp tests as my machine has IPv6 disabled. I'm not sure what to do in this case besides letting travis run the suite against my changes. Please let me know if there's anything I can do to help further.

Thanks!
Mandeep