### PR TITLE
Add helpful hint in io docs about how ? is not allowed in main()

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -150,6 +150,7 @@
 //! 
 //! ```
 //! let mut input = String::new();
+//! 
 //! match io::stdin().read_line(&mut input) {
 //!     Err(why) => panic!("Failed to read input: {}", why.description()),
 //!     Ok(_) => println!("You typed: {}", input.trim()),

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -144,7 +144,8 @@
 //! # Ok(())
 //! # }
 //! ```
-//! Note that you cannot use the `?` operator in functions that do not return a `Result` (e.g. `main()`).
+//!
+//! Note that you cannot use the `?` operator in functions that do not return a `Result<T, E>` (e.g. `main`).
 //! Instead, you can `match` on the return value to catch any possible errors:
 //! 
 //! ```

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -144,6 +144,16 @@
 //! # Ok(())
 //! # }
 //! ```
+//! Note that you cannot use the `?` operator in functions that do not return a `Result` (e.g. `main()`).
+//! Instead, you can `match` on the return value to catch any possible errors:
+//! 
+//! ```
+//! let mut input = String::new();
+//! match io::stdin().read_line(&mut input) {
+//!     Err(why) => panic!("Failed to read input: {}", why.description()),
+//!     Ok(_) => println!("You typed: {}", input.trim()),
+//! }
+//! ```
 //!
 //! And a very common source of output is standard output:
 //!

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -145,16 +145,14 @@
 //! # }
 //! ```
 //!
-//! Note that you cannot use the `?` operator in functions that do not return a `Result<T, E>` (e.g. `main`).
-//! Instead, you can `match` on the return value to catch any possible errors:
-//! 
+//! Note that you cannot use the `?` operator in functions that do not return
+//! a `Result<T, E>` (e.g. `main`). Instead, you can call `.unwrap()` or `match`
+//! on the return value to catch any possible errors:
+//!
 //! ```
 //! let mut input = String::new();
-//! 
-//! match io::stdin().read_line(&mut input) {
-//!     Err(why) => panic!("Failed to read input: {}", why.description()),
-//!     Ok(_) => println!("You typed: {}", input.trim()),
-//! }
+//!
+//! io::stdin().read_line(&mut input).unwrap();
 //! ```
 //!
 //! And a very common source of output is standard output:

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -150,6 +150,8 @@
 //! on the return value to catch any possible errors:
 //!
 //! ```
+//! use std::io;
+//!
 //! let mut input = String::new();
 //!
 //! io::stdin().read_line(&mut input).unwrap();


### PR DESCRIPTION
This is my effort to help alleviate the confusion caused by the error message:
```rust
error[E0277]: the trait bound `(): std::ops::Carrier` is not satisfied
  --> hello_world.rs:72:5
   |
72 |     io::stdin().read_line(&mut d_input)?;
   |     ------------------------------------
   |     |
   |     the trait `std::ops::Carrier` is not implemented for `()`
   |     in this macro invocation
   |
   = note: required by `std::ops::Carrier::from_error`

error: aborting due to previous error
```
This has been discussed at length in https://github.com/rust-lang/rust/issues/35946, but I figured it would be helpful to mention in the docs.
Reading user input is one of the first things beginners will look up in the docs, so my thinking was they'd see this warning here and not have to deal with the [tricky error message](https://blog.rust-lang.org/2017/03/02/lang-ergonomics.html).

If you think this isn't the right place to put this in the docs, that's understandable, I'm open to suggestions for putting it elsewhere or removing it entirely.