### PR TITLE
Add contribution instructions to stdlib docs

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -94,6 +94,12 @@
 //! compiler - but they are documented here the same). Like the prelude, the
 //! standard macros are imported by default into all crates.
 //!
+//! # Contributing changes to the documentation
+//!
+//! The source for this documentation can be found on [github](https://github.com/rust-lang/rust/tree/master/src/libstd).
+//! To contribute changes, you can search for nearby strings in github to find
+//! relevant files, then submit pull-requests with your suggested changes.
+//!
 //! # A Tour of The Rust Standard Library
 //!
 //! The rest of this crate documentation is dedicated to pointing out notable

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -97,12 +97,12 @@
 //! # Contributing changes to the documentation
 //!
 //! Check out the rust contribution guidelines [here](https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md).
-//! The source for this documentation can be found on [Github](https://github.com/rust-lang/rust/tree/master/src/libstd).
+//! The source for this documentation can be found on [Github](https://github.com/rust-lang).
 //! To contribute changes, make sure you read the guidelines first, then submit
 //! pull-requests for your suggested changes.
 //! 
 //! Contributions are appreciated! If you see a part of the docs that can be
-//! improved, submit a PR, or chat with us first on irc.mozilla.org #rust.
+//! improved, submit a PR, or chat with us first on irc.mozilla.org #rust-docs.
 //!
 //! # A Tour of The Rust Standard Library
 //!

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -96,9 +96,13 @@
 //!
 //! # Contributing changes to the documentation
 //!
-//! The source for this documentation can be found on [github](https://github.com/rust-lang/rust/tree/master/src/libstd).
-//! To contribute changes, you can search for nearby strings in github to find
-//! relevant files, then submit pull-requests with your suggested changes.
+//! Check out the rust contribution guidelines [here](https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md).
+//! The source for this documentation can be found on [Github](https://github.com/rust-lang/rust/tree/master/src/libstd).
+//! To contribute changes, make sure you read the guidelines first, then submit
+//! pull-requests for your suggested changes.
+//! 
+//! Contributions are appreciated! If you see a part of the docs that can be
+//! improved, submit a PR, or chat with us first on irc.mozilla.org #rust.
 //!
 //! # A Tour of The Rust Standard Library
 //!

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -96,11 +96,12 @@
 //!
 //! # Contributing changes to the documentation
 //!
-//! Check out the rust contribution guidelines [here](https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md).
+//! Check out the rust contribution guidelines [here](
+//! https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md).
 //! The source for this documentation can be found on [Github](https://github.com/rust-lang).
 //! To contribute changes, make sure you read the guidelines first, then submit
 //! pull-requests for your suggested changes.
-//! 
+//!
 //! Contributions are appreciated! If you see a part of the docs that can be
 //! improved, submit a PR, or chat with us first on irc.mozilla.org #rust-docs.
 //!


### PR DESCRIPTION
Generally programming language docs have instructions on how to contribute changes.

I couldn't find any in the rust docs, so I figured I'd add an instructions section, let me know if this belongs somewhere else!