### PR TITLE
travis: See if OSX generates crash dumps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,8 +153,16 @@ after_failure:
       echo "#### Build failed; Disk usage after running script:";
       df -h;
       du . | sort -nr | head -n100
+
+  # One of these is the linux sccache log, one is the OSX sccache log. Instead
+  # of worrying about what system we are just cat both. One of these commands
+  # will fail but that's ok, they'll both get executed.
   - cat obj/tmp/sccache.log
   - cat /tmp/sccache.log
+
+  # Random attempt at debugging currently. Just poking around in here to see if
+  # anything shows up.
+  - ls $HOME/Library/Logs/DiagnosticReports/
 
 # Save tagged docker images we created and load them if they're available
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -164,6 +164,10 @@ after_failure:
   # anything shows up.
   - ls $HOME/Library/Logs/DiagnosticReports/
 
+  # attempt to debug anything killed by the oom killer on linux, just to see if
+  # it happened
+  - dmesg | grep -i kill
+
 # Save tagged docker images we created and load them if they're available
 before_cache:
   - docker history -q rust-ci |


### PR DESCRIPTION
I know for a fact we've had sccache segfault on various platforms and we've also
historically had a lot of problems with the linker on OSX. Let's just poke
around in the crash log directory to see if anything exists. If in the future we
see a build we think segfaulted *and* there's contents here then we can add some
bits that actually print out the logs.