### PR TITLE
update LLVM with fix for PR32379

### DIFF
--- a/src/rustllvm/llvm-rebuild-trigger
+++ b/src/rustllvm/llvm-rebuild-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be (optionally) cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2017-03-19
+2017-03-23

--- a/src/test/run-pass/auxiliary/llvm_pr32379.rs
+++ b/src/test/run-pass/auxiliary/llvm_pr32379.rs
@@ -1,0 +1,15 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn pr32379(mut data: u64, f1: bool, f2: bool) -> u64 {
+    if f1 { data &= !2; }
+    if f2 { data |= 2; }
+    data
+}

--- a/src/test/run-pass/llvm-pr32379.rs
+++ b/src/test/run-pass/llvm-pr32379.rs
@@ -1,0 +1,23 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:llvm_pr32379.rs
+
+// LLVM PR #32379 (https://bugs.llvm.org/show_bug.cgi?id=32379), which
+// applies to upstream LLVM 3.9.1, is known to cause rustc itself to be
+// miscompiled on ARM (Rust issue #40593). Because cross builds don't test
+// our *compiler* on ARM, have a test for the miscompilation directly.
+
+extern crate llvm_pr32379;
+
+pub fn main() {
+    let val = llvm_pr32379::pr32379(2, false, false);
+    assert_eq!(val, 2);
+}


### PR DESCRIPTION
Fixes #40593.

The "root" codegen bug fixed here is that, when generating ARM code, unpatched LLVM 3.9/3.9.1 miscompiles bit operations in rare circumstances - this can cause user code compiled via LLVM (through both `rustc` and `clang`) to subtly return incorrect results - for more details, see the test in this PR or in the LLVM rare report.

One effect of that LLVM bug is that `rustc` 1.17 (and possibly other versions) is miscompiled on ARM. The code generated by a miscompiled `rustc` lacks destructor calls in many circumstances.

Users who run an affected/miscompiled `rustc` - 1.17 or above - on an ARM build machine will be affected by the (fairly blatant) missing destructor bug, regardless of the target architecture (this includes the official `1.17.0-beta.1`, `1.17.0-beta.2`, and some official 1.17/1.18 nightlies).

Users who use an affected LLVM (that's any unpatched LLVM 3.9/3.9.1), whether through `rustc` (in any version that supports 3.9 - that's 1.12 or above) or through `clang`, who compile code to an ARM target architecture might be affected by the (fairly hard to hit) bit operation bug, regardless of the build machine.

Distributors and user who want to compile rustc using their own LLVM should apply the [patch](https://github.com/llvm-mirror/llvm/commit/cdc303e5ed4d3110e6f70931775a70bb1de44ed6) to avoid miscompilations. 

r? @alexcrichton 
Beta-nominating because regression (rustc 1.16 is not blatantly miscompiled). This also picks a fix for the (MSVC-affecting) PR29151.