### PR TITLE
Fix formatting in the docs for std::process::Command::envs()

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -437,6 +437,7 @@ impl Command {
     /// # Examples
     ///
     /// Basic usage:
+    ///
     /// ```no_run
     /// use std::process::{Command, Stdio};
     /// use std::env;

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -439,6 +439,8 @@ impl Command {
     /// Basic usage:
     ///
     /// ```no_run
+    /// #![feature(command_envs)]
+    ///
     /// use std::process::{Command, Stdio};
     /// use std::env;
     /// use std::collections::HashMap;


### PR DESCRIPTION
An empty line between the *Basic usage:* text and the example is required to properly format the code. Without the empty line, the example is not formatted as code.

[Here](https://doc.rust-lang.org/std/process/struct.Command.html#method.envs) you can see the current (improper) formatting.
