### PR TITLE
Update CONTRIBUTING.md regarding documentation contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -312,9 +312,11 @@ the other rollup-eligible patches too, and they'll get tested and merged at
 the same time.
 
 To find documentation-related issues, sort by the [T-doc label][tdoc].
-You can find documentation style guidelines in [RFC 1574][rfc1574].
 
 [tdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen%20is%3Aissue%20label%3AT-doc
+
+You can find documentation style guidelines in [RFC 1574][rfc1574].
+
 [rfc1574]: https://github.com/rust-lang/rfcs/blob/master/text/1574-more-api-documentation-conventions.md#appendix-a-full-conventions-text
 
 In many cases, you don't need a full `./x.py doc`. You can use `rustdoc` directly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -311,9 +311,11 @@ To save @bors some work, and to get small changes through more quickly, when
 the other rollup-eligible patches too, and they'll get tested and merged at
 the same time.
 
-To find documentation-related issues, sort by the [A-docs label][adocs].
+To find documentation-related issues, sort by the [T-doc label][tdoc].
+You can find documentation style guidelines in [RFC 1574][rfc1574].
 
-[adocs]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-docs
+[tdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen%20is%3Aissue%20label%3AT-doc
+[rfc1574]: https://github.com/rust-lang/rfcs/blob/master/text/1574-more-api-documentation-conventions.md#appendix-a-full-conventions-text
 
 In many cases, you don't need a full `./x.py doc`. You can use `rustdoc` directly
 to check small fixes. For example, `rustdoc src/doc/reference.md` will render


### PR DESCRIPTION
Changed link to documentation issues from A-docs to T-doc as this has just been migrated.
Added a link to the documentation style guidelines in RFC 1574 (I've linked to [Appendix A][1] specifically since that's the combined version).

r? @steveklabnik

[1]: https://github.com/rust-lang/rfcs/blob/master/text/1574-more-api-documentation-conventions.md#appendix-a-full-conventions-text