### PR TITLE
try to fix the build on emscripten

### DIFF
--- a/src/ci/docker/emscripten/build-emscripten.sh
+++ b/src/ci/docker/emscripten/build-emscripten.sh
@@ -43,6 +43,10 @@ if [ ! -d emsdk_portable ]; then
     exit 1
 fi
 
+# Some versions of the EMSDK set the permissions of the root directory to
+# 0700. Ensure the directory is readable by all users.
+chmod 755 emsdk_portable
+
 source emsdk_portable/emsdk_env.sh
 hide_output emsdk update
 hide_output emsdk install --build=Release sdk-tag-1.37.1-32bit

--- a/src/ci/docker/emscripten/build-emscripten.sh
+++ b/src/ci/docker/emscripten/build-emscripten.sh
@@ -29,7 +29,20 @@ exit 1
 }
 
 curl https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz | \
-      tar xzf -
+    tar xzf -
+
+# Some versions of the EMSDK archive have their contents in .emsdk-portable
+# and others in emsdk_portable. Make sure the EMSDK ends up in a fixed path.
+if [ -d emsdk-portable ]; then
+    mv emsdk-portable emsdk_portable
+fi
+
+if [ ! -d emsdk_portable ]; then
+    echo "ERROR: Invalid emsdk archive. Dumping working directory." >&2
+    ls -l
+    exit 1
+fi
+
 source emsdk_portable/emsdk_env.sh
 hide_output emsdk update
 hide_output emsdk install --build=Release sdk-tag-1.37.1-32bit


### PR DESCRIPTION
The "upstream" emscripten tar.gz now extracts to `emsdk-portable` instead of `emsdk_portable`, breaking our CI. It might be better to vendor a specific version of emscripten instead of using the latest, but I could not find a good way of doing that.

r? @alexcrichton 