### PR TITLE
Update ChildStderr docs to be clearer

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -233,8 +233,9 @@ impl fmt::Debug for ChildStdout {
     }
 }
 
-/// A handle to a child process's stderr. This struct is used in the [`stderr`]
-/// field on [`Child`].
+/// A handle to a child process's stderr. It can be used to
+/// read any errors that the child process has output while
+/// running.
 ///
 /// [`Child`]: struct.Child.html
 /// [`stderr`]: struct.Child.html#structfield.stderr

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -233,9 +233,9 @@ impl fmt::Debug for ChildStdout {
     }
 }
 
-/// A handle to a child process's stderr. It can be used to
-/// read any errors that the child process has output while
-/// running.
+/// A handle to a child process's stderr.
+///
+/// This struct is used in the [`stderr`] field on [`Child`].
 ///
 /// [`Child`]: struct.Child.html
 /// [`stderr`]: struct.Child.html#structfield.stderr


### PR DESCRIPTION
Before the docs only had a line about where it was found and that it was
a handle to stderr. This commit changes it so that the summary second line is
removed and that it's a bit clearer about what can be done with it. Part of
#29370