### PR TITLE
libcore: fix compilation on 16bit target (MSP430).

### DIFF
--- a/src/libcore/slice/sort.rs
+++ b/src/libcore/slice/sort.rs
@@ -527,7 +527,9 @@ fn break_patterns<T>(v: &mut [T]) {
             // we first take it modulo a power of two, and then decrease by `len` until it fits
             // into the range `[0, len - 1]`.
             let mut other = gen_usize() & (modulus - 1);
-            while other >= len {
+
+            // `other` is guaranteed to be less than `2 * len`.
+            if other >= len {
                 other -= len;
             }
 


### PR DESCRIPTION
Since PR #40601 has been merged, libcore no longer compiles on MSP430.
The reason is this code in `break_patterns`:
```rust
 let mut random = len;
 random ^= random << 13;
 random ^= random >> 17;
 random ^= random << 5;
 random &= modulus - 1;
```
It assumes that `len` is at least a 32 bit integer.
As a workaround replace `break_patterns` with an empty function for 16bit targets.

cc @stjepang 
cc @alexcrichton 