### PR TITLE
Fix typo in char::to_uppercase documentation

### DIFF
--- a/src/libstd_unicode/char.rs
+++ b/src/libstd_unicode/char.rs
@@ -846,7 +846,7 @@ impl char {
     /// will be returned back by the iterator.
     ///
     /// This performs complex unconditional mappings with no tailoring: it maps
-    /// one Unicode character to its lowercase equivalent according to the
+    /// one Unicode character to its uppercase equivalent according to the
     /// [Unicode database] and the additional complex mappings
     /// [`SpecialCasing.txt`]. Conditional mappings (based on context or
     /// language) are not considered here.

--- a/src/libstd_unicode/char.rs
+++ b/src/libstd_unicode/char.rs
@@ -842,7 +842,7 @@ impl char {
     /// Returns an iterator that yields the uppercase equivalent of a `char`
     /// as one or more `char`s.
     ///
-    /// If a character does not have a uppercase equivalent, the same character
+    /// If a character does not have an uppercase equivalent, the same character
     /// will be returned back by the iterator.
     ///
     /// This performs complex unconditional mappings with no tailoring: it maps


### PR DESCRIPTION
Original documentation appears to have been copied from `char::to_lowercase` in a manner that made it imply that `char::to_uppercase` actually mapped unicode characters to their **lowercase** equivalent.