### PR TITLE
Remove unused feature from error index generator

### DIFF
--- a/src/tools/error_index_generator/main.rs
+++ b/src/tools/error_index_generator/main.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(rustc_private, rustdoc)]
+#![feature(rustc_private)]
 
 extern crate syntax;
 extern crate rustdoc;


### PR DESCRIPTION
Remove feature `rustdoc`.