### PR TITLE
Update LLVM to pull in patch that removes extraneous null check.

### DIFF
--- a/src/rustllvm/llvm-rebuild-trigger
+++ b/src/rustllvm/llvm-rebuild-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be (optionally) cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2017-03-23
+2017-03-28

--- a/src/test/codegen/no-extra-null-check-on-iterator.rs
+++ b/src/test/codegen/no-extra-null-check-on-iterator.rs
@@ -1,0 +1,31 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -O
+
+// See issue #37945.
+
+#![crate_type = "lib"]
+
+use std::slice::Iter;
+
+// CHECK-LABEL: @is_empty_1
+#[no_mangle]
+pub fn is_empty_1(xs: Iter<f32>) -> bool {
+// CHECK-NOT: icmp eq float* {{.*}}, null
+    {xs}.next().is_none()
+}
+
+// CHECK-LABEL: @is_empty_2
+#[no_mangle]
+pub fn is_empty_2(xs: Iter<f32>) -> bool {
+// CHECK-NOT: icmp eq float* {{.*}}, null
+    xs.map(|&x| x).next().is_none()
+}


### PR DESCRIPTION
Fixes #37945.