### PR TITLE
Add support for image, rules and footnotes

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -116,6 +116,7 @@ macro_rules! event_loop_break {
             match event {
                 $($end_event)|* => break,
                 Event::Text(ref s) => {
+                    debug!("Text");
                     inner($id, s);
                     if $escape {
                         $buf.push_str(&format!("{}", Escape(s)));
@@ -123,8 +124,11 @@ macro_rules! event_loop_break {
                         $buf.push_str(s);
                     }
                 }
-                Event::SoftBreak | Event::HardBreak if !$buf.is_empty() => {
-                    $buf.push(' ');
+                Event::SoftBreak => {
+                    debug!("SoftBreak");
+                    if !$buf.is_empty() {
+                        $buf.push(' ');
+                    }
                 }
                 x => {
                     looper($parser, &mut $buf, Some(x), $toc_builder, $shorter, $id);
@@ -165,6 +169,7 @@ pub fn render(w: &mut fmt::Formatter,
               print_toc: bool,
               shorter: MarkdownOutputStyle) -> fmt::Result {
     fn code_block(parser: &mut ParserWrapper, buffer: &mut String, lang: &str) {
+        debug!("CodeBlock");
         let mut origtext = String::new();
         while let Some(event) = parser.next() {
             match event {
@@ -244,6 +249,7 @@ pub fn render(w: &mut fmt::Formatter,
 
     fn heading(parser: &mut ParserWrapper, buffer: &mut String,
                toc_builder: &mut Option<TocBuilder>, shorter: MarkdownOutputStyle, level: i32) {
+        debug!("Heading");
         let mut ret = String::new();
         let mut id = String::new();
         event_loop_break!(parser, toc_builder, shorter, ret, true, &mut Some(&mut id),
@@ -279,6 +285,7 @@ pub fn render(w: &mut fmt::Formatter,
     fn inline_code(parser: &mut ParserWrapper, buffer: &mut String,
                    toc_builder: &mut Option<TocBuilder>, shorter: MarkdownOutputStyle,
                    id: &mut Option<&mut String>) {
+        debug!("InlineCode");
         let mut content = String::new();
         event_loop_break!(parser, toc_builder, shorter, content, false, id, Event::End(Tag::Code));
         buffer.push_str(&format!("<code>{}</code>",
@@ -288,6 +295,7 @@ pub fn render(w: &mut fmt::Formatter,
     fn link(parser: &mut ParserWrapper, buffer: &mut String, toc_builder: &mut Option<TocBuilder>,
             shorter: MarkdownOutputStyle, url: &str, title: &str,
             id: &mut Option<&mut String>) {
+        debug!("Link");
         let mut content = String::new();
         event_loop_break!(parser, toc_builder, shorter, content, true, id,
                           Event::End(Tag::Link(_, _)));
@@ -302,6 +310,7 @@ pub fn render(w: &mut fmt::Formatter,
     fn image(parser: &mut ParserWrapper, buffer: &mut String, toc_builder: &mut Option<TocBuilder>,
             shorter: MarkdownOutputStyle, url: &str, mut title: String,
             id: &mut Option<&mut String>) {
+        debug!("Image");
         event_loop_break!(parser, toc_builder, shorter, title, true, id,
                           Event::End(Tag::Image(_, _)));
         buffer.push_str(&format!("<img src=\"{}\" alt=\"{}\">", url, title));
@@ -310,6 +319,7 @@ pub fn render(w: &mut fmt::Formatter,
     fn paragraph(parser: &mut ParserWrapper, buffer: &mut String,
                  toc_builder: &mut Option<TocBuilder>, shorter: MarkdownOutputStyle,
                  id: &mut Option<&mut String>) {
+        debug!("Paragraph");
         let mut content = String::new();
         event_loop_break!(parser, toc_builder, shorter, content, true, id,
                           Event::End(Tag::Paragraph));
@@ -318,6 +328,7 @@ pub fn render(w: &mut fmt::Formatter,
 
     fn table_cell(parser: &mut ParserWrapper, buffer: &mut String,
                   toc_builder: &mut Option<TocBuilder>, shorter: MarkdownOutputStyle) {
+        debug!("TableCell");
         let mut content = String::new();
         event_loop_break!(parser, toc_builder, shorter, content, true, &mut None,
                           Event::End(Tag::TableHead) |
@@ -329,6 +340,7 @@ pub fn render(w: &mut fmt::Formatter,
 
     fn table_row(parser: &mut ParserWrapper, buffer: &mut String,
                  toc_builder: &mut Option<TocBuilder>, shorter: MarkdownOutputStyle) {
+        debug!("TableRow");
         let mut content = String::new();
         while let Some(event) = parser.next() {
             match event {
@@ -348,6 +360,7 @@ pub fn render(w: &mut fmt::Formatter,
 
     fn table_head(parser: &mut ParserWrapper, buffer: &mut String,
                   toc_builder: &mut Option<TocBuilder>, shorter: MarkdownOutputStyle) {
+        debug!("TableHead");
         let mut content = String::new();
         while let Some(event) = parser.next() {
             match event {
@@ -367,6 +380,7 @@ pub fn render(w: &mut fmt::Formatter,
 
     fn table(parser: &mut ParserWrapper, buffer: &mut String, toc_builder: &mut Option<TocBuilder>,
              shorter: MarkdownOutputStyle) {
+        debug!("Table");
         let mut content = String::new();
         let mut rows = String::new();
         while let Some(event) = parser.next() {
@@ -392,6 +406,7 @@ pub fn render(w: &mut fmt::Formatter,
 
     fn blockquote(parser: &mut ParserWrapper, buffer: &mut String,
                   toc_builder: &mut Option<TocBuilder>, shorter: MarkdownOutputStyle) {
+        debug!("BlockQuote");
         let mut content = String::new();
         event_loop_break!(parser, toc_builder, shorter, content, true, &mut None,
                           Event::End(Tag::BlockQuote));
@@ -400,6 +415,7 @@ pub fn render(w: &mut fmt::Formatter,
 
     fn list_item(parser: &mut ParserWrapper, buffer: &mut String,
                  toc_builder: &mut Option<TocBuilder>, shorter: MarkdownOutputStyle) {
+        debug!("ListItem");
         let mut content = String::new();
         while let Some(event) = parser.next() {
             match event {
@@ -417,6 +433,7 @@ pub fn render(w: &mut fmt::Formatter,
 
     fn list(parser: &mut ParserWrapper, buffer: &mut String, toc_builder: &mut Option<TocBuilder>,
             shorter: MarkdownOutputStyle) {
+        debug!("List");
         let mut content = String::new();
         while let Some(event) = parser.next() {
             match event {
@@ -435,6 +452,7 @@ pub fn render(w: &mut fmt::Formatter,
     fn emphasis(parser: &mut ParserWrapper, buffer: &mut String,
                 toc_builder: &mut Option<TocBuilder>, shorter: MarkdownOutputStyle,
                 id: &mut Option<&mut String>) {
+        debug!("Emphasis");
         let mut content = String::new();
         event_loop_break!(parser, toc_builder, shorter, content, false, id,
                           Event::End(Tag::Emphasis));
@@ -443,6 +461,7 @@ pub fn render(w: &mut fmt::Formatter,
 
     fn strong(parser: &mut ParserWrapper, buffer: &mut String, toc_builder: &mut Option<TocBuilder>,
               shorter: MarkdownOutputStyle, id: &mut Option<&mut String>) {
+        debug!("Strong");
         let mut content = String::new();
         event_loop_break!(parser, toc_builder, shorter, content, false, id,
                           Event::End(Tag::Strong));
@@ -452,6 +471,7 @@ pub fn render(w: &mut fmt::Formatter,
     fn footnote(parser: &mut ParserWrapper, buffer: &mut String,
                 toc_builder: &mut Option<TocBuilder>, shorter: MarkdownOutputStyle,
                 id: &mut Option<&mut String>) {
+        debug!("FootnoteDefinition");
         let mut content = String::new();
         event_loop_break!(parser, toc_builder, shorter, content, true, id,
                           Event::End(Tag::FootnoteDefinition(_)));
@@ -460,6 +480,7 @@ pub fn render(w: &mut fmt::Formatter,
 
     fn rule(parser: &mut ParserWrapper, buffer: &mut String, toc_builder: &mut Option<TocBuilder>,
             shorter: MarkdownOutputStyle, id: &mut Option<&mut String>) {
+        debug!("Rule");
         let mut content = String::new();
         event_loop_break!(parser, toc_builder, shorter, content, true, id,
                           Event::End(Tag::Rule));
@@ -508,6 +529,7 @@ pub fn render(w: &mut fmt::Formatter,
                     rule(parser, buffer, toc_builder, shorter, id);
                 }
                 Event::Start(Tag::FootnoteDefinition(ref def)) => {
+                    debug!("FootnoteDefinition");
                     let mut content = String::new();
                     let def = def.as_ref();
                     footnote(parser, &mut content, toc_builder, shorter, id);
@@ -523,12 +545,22 @@ pub fn render(w: &mut fmt::Formatter,
                                                  }));
                 }
                 Event::FootnoteReference(ref reference) => {
+                    debug!("FootnoteReference");
                     let entry = parser.get_entry(reference.as_ref());
                     buffer.push_str(&format!("<sup id=\"supref{0}\"><a href=\"#ref{0}\">{0}</a>\
                                               </sup>",
                                              (*entry).1));
                 }
+                Event::HardBreak => {
+                    debug!("HardBreak");
+                    if shorter.is_fancy() {
+                        buffer.push_str("<br>");
+                    } else if !buffer.is_empty() {
+                        buffer.push(' ');
+                    }
+                }
                 Event::Html(h) | Event::InlineHtml(h) => {
+                    debug!("Html/InlineHtml");
                     buffer.push_str(&*h);
                 }
                 _ => {}

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -585,11 +585,13 @@ pub fn render(w: &mut fmt::Formatter,
         }
     }
     if !parser.footnotes.is_empty() {
+        let mut v: Vec<_> = parser.footnotes.values().collect();
+        v.sort_by(|a, b| a.1.cmp(&b.1));
         buffer.push_str(&format!("<div class=\"footnotes\"><hr><ol>{}</ol></div>",
-                                 parser.footnotes.values()
-                                                 .map(|&(ref s, _)| s.as_str())
-                                                 .collect::<Vec<_>>()
-                                                 .join("")));
+                                 v.iter()
+                                  .map(|s| s.0.as_str())
+                                  .collect::<Vec<_>>()
+                                  .join("")));
     }
     let mut ret = toc_builder.map_or(Ok(()), |builder| {
         write!(w, "<nav id=\"TOC\">{}</nav>", builder.into_toc())

--- a/src/librustdoc/passes/unindent_comments.rs
+++ b/src/librustdoc/passes/unindent_comments.rs
@@ -82,7 +82,7 @@ fn unindent(s: &str) -> String {
     });
 
     if !lines.is_empty() {
-        let mut unindented = vec![ lines[0].trim().to_string() ];
+        let mut unindented = vec![ lines[0].trim_left().to_string() ];
         unindented.extend_from_slice(&lines[1..].iter().map(|&line| {
             if line.chars().all(|c| c.is_whitespace()) {
                 line.to_string()
@@ -159,5 +159,16 @@ mod unindent_tests {
         let s = "    \tline1\n    \tline2".to_string();
         let r = unindent(&s);
         assert_eq!(r, "line1\nline2");
+    }
+
+    #[test]
+    fn should_not_trim() {
+        let s = "\t    line1  \n\t    line2".to_string();
+        let r = unindent(&s);
+        assert_eq!(r, "line1  \nline2");
+
+        let s = "    \tline1  \n    \tline2".to_string();
+        let r = unindent(&s);
+        assert_eq!(r, "line1  \nline2");
     }
 }

--- a/src/test/rustdoc/check-hard-break.rs
+++ b/src/test/rustdoc/check-hard-break.rs
@@ -10,7 +10,7 @@
 
 #![crate_name = "foo"]
 
-// ignore-tidy-linelength
+// ignore-tidy-end-whitespace
 
 // @has foo/fn.f.html
 // @has - '<p>hard break:<br>after hard break</p>'

--- a/src/test/rustdoc/check-hard-break.rs
+++ b/src/test/rustdoc/check-hard-break.rs
@@ -1,0 +1,19 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "foo"]
+
+// ignore-tidy-linelength
+
+// @has foo/fn.f.html
+// @has - '<p>hard break:<br>after hard break</p>'
+/// hard break:  
+/// after hard break
+pub fn f() {}

--- a/src/test/rustdoc/check-rule-image-footnote.rs
+++ b/src/test/rustdoc/check-rule-image-footnote.rs
@@ -1,0 +1,35 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "foo"]
+
+// @has foo/fn.f.html
+// @has - '<p>hard break: after hard break</p><hr>'
+// @has - '<img src="https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png" alt="Rust">'
+// @has - '<li id="ref1">'
+// @has - '<sup id="supref1"><a href="#ref1">1</a></sup>'
+/// markdown test
+///
+/// this is a [link].
+///
+/// [link]: https://example.com "this is a title"
+///
+/// hard break:
+/// after hard break
+///
+/// -----------
+///
+/// a footnote[^footnote].
+///
+/// [^footnote]: Thing
+///
+/// ![Rust](https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png)
+#[deprecated(note = "Struct<T>")]
+pub fn f() {}

--- a/src/test/rustdoc/check-rule-image-footnote.rs
+++ b/src/test/rustdoc/check-rule-image-footnote.rs
@@ -10,11 +10,10 @@
 
 #![crate_name = "foo"]
 
+// ignore-tidy-linelength
+
 // @has foo/fn.f.html
-// @has - '<p>hard break: after hard break</p><hr>'
-// @has - '<img src="https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png" alt="Rust">'
-// @has - '<li id="ref1">'
-// @has - '<sup id="supref1"><a href="#ref1">1</a></sup>'
+// @has - '<p>markdown test</p><p>this is a <a href="https://example.com" title="this is a title">link</a>.</p><p>hard break: after hard break</p><hr><p>a footnote<sup id="supref1"><a href="#ref1">1</a></sup>.</p><p>another footnote<sup id="supref2"><a href="#ref2">2</a></sup>.</p><p><img src="https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png" alt="Rust"></p><div class="footnotes"><hr><ol><li id="ref1"><p>Thing&nbsp;<a href="#supref1" rev="footnote">↩</a></p></li><li id="ref2"><p>Another Thing&nbsp;<a href="#supref2" rev="footnote">↩</a></p></li></ol></div>'
 /// markdown test
 ///
 /// this is a [link].
@@ -28,7 +27,13 @@
 ///
 /// a footnote[^footnote].
 ///
+/// another footnote[^footnotebis].
+///
 /// [^footnote]: Thing
+///
+///
+/// [^footnotebis]: Another Thing
+///
 ///
 /// ![Rust](https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png)
 #[deprecated(note = "Struct<T>")]

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -110,6 +110,7 @@ pub fn check(path: &Path, bad: &mut bool) {
         let skip_cr = contents.contains("ignore-tidy-cr");
         let skip_tab = contents.contains("ignore-tidy-tab");
         let skip_length = contents.contains("ignore-tidy-linelength");
+        let skip_end_whitespace = contents.contains("ignore-tidy-end-whitespace");
         for (i, line) in contents.split("\n").enumerate() {
             let mut err = |msg: &str| {
                 println!("{}:{}: {}", file.display(), i + 1, msg);
@@ -122,7 +123,7 @@ pub fn check(path: &Path, bad: &mut bool) {
             if line.contains("\t") && !skip_tab {
                 err("tab character");
             }
-            if line.ends_with(" ") || line.ends_with("\t") {
+            if !skip_end_whitespace && (line.ends_with(" ") || line.ends_with("\t")) {
                 err("trailing whitespace");
             }
             if line.contains("\r") && !skip_cr {


### PR DESCRIPTION
Part of #40912.

r? @rust-lang/docs 

PS: the footnotes are waiting for https://github.com/google/pulldown-cmark/pull/21 to be merged to be fully working.