### PR TITLE
Implement all PartialOrd methods for Reverse

### DIFF
--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -347,6 +347,15 @@ impl<T: PartialOrd> PartialOrd for Reverse<T> {
     fn partial_cmp(&self, other: &Reverse<T>) -> Option<Ordering> {
         other.0.partial_cmp(&self.0)
     }
+
+    #[inline]
+    fn lt(&self, other: &Self) -> bool { other.0 < self.0 }
+    #[inline]
+    fn le(&self, other: &Self) -> bool { other.0 <= self.0 }
+    #[inline]
+    fn ge(&self, other: &Self) -> bool { other.0 >= self.0 }
+    #[inline]
+    fn gt(&self, other: &Self) -> bool { other.0 > self.0 }
 }
 
 #[unstable(feature = "reverse_cmp_key", issue = "40893")]


### PR DESCRIPTION
When making a forwarding wrapper we must in general forward all methods,
so that we use the type's own `lt` for example instead of the default.

Example important case: f32's partial_cmp does several operations but
its lt is a primitive.

Follow up on #40720