### PR TITLE
Modify str Structs descriptions

### DIFF
--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -137,10 +137,10 @@ impl<S: Borrow<str>> SliceConcatExt<str> for [S] {
 ///
 /// [`u16`]: ../../std/primitive.u16.html
 ///
-/// This struct is created by the [`encode_utf16()`] method on [`str`].
+/// This struct is created by the [`encode_utf16`] method on [`str`].
 /// See its documentation for more.
 ///
-/// [`encode_utf16()`]: ../../std/primitive.str.html#method.encode_utf16
+/// [`encode_utf16`]: ../../std/primitive.str.html#method.encode_utf16
 /// [`str`]: ../../std/primitive.str.html
 #[derive(Clone)]
 #[stable(feature = "encode_utf16", since = "1.8.0")]

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -133,9 +133,15 @@ impl<S: Borrow<str>> SliceConcatExt<str> for [S] {
     }
 }
 
-/// External iterator for a string's UTF-16 code units.
+/// An iterator of [`u16`] over the string encoded as UTF-16.
 ///
-/// For use with the `std::iter` module.
+/// [`u16`]: ../../std/primitive.u16.html
+///
+/// This struct is created by the [`encode_utf16()`] method on [`str`].
+/// See its documentation for more.
+///
+/// [`encode_utf16()`]: ../../std/primitive.str.html#method.encode_utf16
+/// [`str`]: ../../std/primitive.str.html
 #[derive(Clone)]
 #[stable(feature = "encode_utf16", since = "1.8.0")]
 pub struct EncodeUtf16<'a> {

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -553,7 +553,15 @@ impl<'a> Chars<'a> {
     }
 }
 
-/// Iterator for a string's characters and their byte offsets.
+/// An iterator over the [`char`]s of a string slice, and their positions.
+///
+/// [`char`]: ../../std/primitive.char.html
+///
+/// This struct is created by the [`char_indices()`] method on [`str`].
+/// See its documentation for more.
+///
+/// [`char_indices()`]: ../../std/primitive.str.html#method.char_indices
+/// [`str`]: ../../std/primitive.str.html
 #[derive(Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct CharIndices<'a> {

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -625,12 +625,13 @@ impl<'a> CharIndices<'a> {
     }
 }
 
-/// External iterator for a string's bytes.
-/// Use with the `std::iter` module.
+/// An iterator over the bytes of a string slice.
 ///
-/// Created with the method [`bytes`].
+/// This struct is created by the [`bytes()`] method on [`str`].
+/// See its documentation for more.
 ///
-/// [`bytes`]: ../../std/primitive.str.html#method.bytes
+/// [`bytes()`]: ../../std/primitive.str.html#method.bytes
+/// [`str`]: ../../std/primitive.str.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Clone, Debug)]
 pub struct Bytes<'a>(Cloned<slice::Iter<'a, u8>>);

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -369,11 +369,15 @@ impl fmt::Display for Utf8Error {
 Section: Iterators
 */
 
-/// Iterator for the char (representing *Unicode Scalar Values*) of a string.
+/// An iterator over the [`char`]s of a string slice.
 ///
-/// Created with the method [`chars`].
+/// [`char`]: ../../std/primitive.char.html
 ///
-/// [`chars`]: ../../std/primitive.str.html#method.chars
+/// This struct is created by the [`chars()`] method on [`str`].
+/// See its documentation for more.
+///
+/// [`chars()`]: ../../std/primitive.str.html#method.chars
+/// [`str`]: ../../std/primitive.str.html
 #[derive(Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Chars<'a> {

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -373,10 +373,10 @@ Section: Iterators
 ///
 /// [`char`]: ../../std/primitive.char.html
 ///
-/// This struct is created by the [`chars()`] method on [`str`].
+/// This struct is created by the [`chars`] method on [`str`].
 /// See its documentation for more.
 ///
-/// [`chars()`]: ../../std/primitive.str.html#method.chars
+/// [`chars`]: ../../std/primitive.str.html#method.chars
 /// [`str`]: ../../std/primitive.str.html
 #[derive(Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -561,10 +561,10 @@ impl<'a> Chars<'a> {
 ///
 /// [`char`]: ../../std/primitive.char.html
 ///
-/// This struct is created by the [`char_indices()`] method on [`str`].
+/// This struct is created by the [`char_indices`] method on [`str`].
 /// See its documentation for more.
 ///
-/// [`char_indices()`]: ../../std/primitive.str.html#method.char_indices
+/// [`char_indices`]: ../../std/primitive.str.html#method.char_indices
 /// [`str`]: ../../std/primitive.str.html
 #[derive(Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -639,10 +639,10 @@ impl<'a> CharIndices<'a> {
 
 /// An iterator over the bytes of a string slice.
 ///
-/// This struct is created by the [`bytes()`] method on [`str`].
+/// This struct is created by the [`bytes`] method on [`str`].
 /// See its documentation for more.
 ///
-/// [`bytes()`]: ../../std/primitive.str.html#method.bytes
+/// [`bytes`]: ../../std/primitive.str.html#method.bytes
 /// [`str`]: ../../std/primitive.str.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Clone, Debug)]
@@ -1176,10 +1176,10 @@ generate_pattern_iterators! {
 
 /// An iterator over the lines of a string, as string slices.
 ///
-/// This struct is created with the [`lines()`] method on [`str`].
+/// This struct is created with the [`lines`] method on [`str`].
 /// See its documentation for more.
 ///
-/// [`lines()`]: ../../std/primitive.str.html#method.lines
+/// [`lines`]: ../../std/primitive.str.html#method.lines
 /// [`str`]: ../../std/primitive.str.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Clone, Debug)]

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -1161,9 +1161,13 @@ generate_pattern_iterators! {
     delegate double ended;
 }
 
-/// Created with the method [`lines`].
+/// An iterator over the lines of a string, as string slices.
 ///
-/// [`lines`]: ../../std/primitive.str.html#method.lines
+/// This struct is created with the [`lines()`] method on [`str`].
+/// See its documentation for more.
+///
+/// [`lines()`]: ../../std/primitive.str.html#method.lines
+/// [`str`]: ../../std/primitive.str.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Clone, Debug)]
 pub struct Lines<'a>(Map<SplitTerminator<'a, char>, LinesAnyMap>);

--- a/src/libstd_unicode/u_str.rs
+++ b/src/libstd_unicode/u_str.rs
@@ -17,8 +17,13 @@ use core::char;
 use core::iter::{Filter, FusedIterator};
 use core::str::Split;
 
-/// An iterator over the non-whitespace substrings of a string,
-/// separated by any amount of whitespace.
+/// An iterator over sub-slices of the original string slice.
+///
+/// This struct is created by the [`split_whitespace()`] method on [`str`].
+/// See its documentation for more.
+///
+/// [`split_whitespace()`]: ../../std/primitive.str.html#method.split_whitespace
+/// [`str`]: ../../std/primitive.str.html
 #[stable(feature = "split_whitespace", since = "1.1.0")]
 pub struct SplitWhitespace<'a> {
     inner: Filter<Split<'a, fn(char) -> bool>, fn(&&str) -> bool>,

--- a/src/libstd_unicode/u_str.rs
+++ b/src/libstd_unicode/u_str.rs
@@ -20,10 +20,10 @@ use core::str::Split;
 /// An iterator over the non-whitespace substrings of a string,
 /// separated by any amount of whitespace.
 ///
-/// This struct is created by the [`split_whitespace()`] method on [`str`].
+/// This struct is created by the [`split_whitespace`] method on [`str`].
 /// See its documentation for more.
 ///
-/// [`split_whitespace()`]: ../../std/primitive.str.html#method.split_whitespace
+/// [`split_whitespace`]: ../../std/primitive.str.html#method.split_whitespace
 /// [`str`]: ../../std/primitive.str.html
 #[stable(feature = "split_whitespace", since = "1.1.0")]
 pub struct SplitWhitespace<'a> {

--- a/src/libstd_unicode/u_str.rs
+++ b/src/libstd_unicode/u_str.rs
@@ -17,7 +17,8 @@ use core::char;
 use core::iter::{Filter, FusedIterator};
 use core::str::Split;
 
-/// An iterator over sub-slices of the original string slice.
+/// An iterator over the non-whitespace substrings of a string,
+/// separated by any amount of whitespace.
 ///
 /// This struct is created by the [`split_whitespace()`] method on [`str`].
 /// See its documentation for more.


### PR DESCRIPTION
References #29375. Modified descriptions of multiple structs to be more in line with structs found under [`std::iter`](https://doc.rust-lang.org/std/iter/#structs), such as [`Chain`](https://doc.rust-lang.org/std/iter/struct.Chain.html) and [`Enumerate`](https://doc.rust-lang.org/std/iter/struct.Enumerate.html)