### PR TITLE
Don't warn about `char` comparisons in constexprs

### DIFF
--- a/src/librustc_const_eval/eval.rs
+++ b/src/librustc_const_eval/eval.rs
@@ -490,6 +490,17 @@ fn eval_const_expr_partial<'a, 'tcx>(cx: &ConstContext<'a, 'tcx>,
               _ => span_bug!(e.span, "typeck error"),
              })
           }
+          (Char(a), Char(b)) => {
+            Bool(match op.node {
+              hir::BiEq => a == b,
+              hir::BiNe => a != b,
+              hir::BiLt => a < b,
+              hir::BiLe => a <= b,
+              hir::BiGe => a >= b,
+              hir::BiGt => a > b,
+              _ => span_bug!(e.span, "typeck error"),
+             })
+          }
 
           _ => signal!(e, MiscBinaryOp),
         }

--- a/src/test/run-pass/const-err.rs
+++ b/src/test/run-pass/const-err.rs
@@ -13,6 +13,10 @@
 #![deny(const_err)]
 
 const X: *const u8 = b"" as _;
+const Y: bool = 'A' == 'B';
+const Z: char = 'A';
+const W: bool = Z <= 'B';
+
 
 fn main() {
     let _ = ((-1 as i8) << 8 - 1) as f32;


### PR DESCRIPTION
Fixes #40970 by evaluating const-exprs for comparisons on `char`s properly.