### PR TITLE
support pub(restricted) in thread_local!

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -282,6 +282,7 @@
 #![feature(link_args)]
 #![feature(linkage)]
 #![feature(macro_reexport)]
+#![feature(macro_vis_matcher)]
 #![feature(needs_panic_runtime)]
 #![feature(never_type)]
 #![feature(num_bits_bytes)]

--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -133,37 +133,15 @@ macro_rules! thread_local {
     // empty (base case for the recursion)
     () => {};
 
-    // process multiple declarations where the first one is private
-    ($(#[$attr:meta])* static $name:ident: $t:ty = $init:expr; $($rest:tt)*) => (
-        __thread_local_inner!($(#[$attr])* [] $name, $t, $init);
+    // process multiple declarations
+    ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = $init:expr; $($rest:tt)*) => (
+        __thread_local_inner!($(#[$attr])* $vis $name, $t, $init);
         thread_local!($($rest)*);
     );
 
-    // handle a single private declaration
-    ($(#[$attr:meta])* static $name:ident: $t:ty = $init:expr) => (
-        __thread_local_inner!($(#[$attr])* [] $name, $t, $init);
-    );
-
-    // handle multiple declarations where the first one is public
-    ($(#[$attr:meta])* pub static $name:ident: $t:ty = $init:expr; $($rest:tt)*) => (
-        __thread_local_inner!($(#[$attr])* [pub] $name, $t, $init);
-        thread_local!($($rest)*);
-    );
-
-    // handle a single public declaration
-    ($(#[$attr:meta])* pub static $name:ident: $t:ty = $init:expr) => (
-        __thread_local_inner!($(#[$attr])* [pub] $name, $t, $init);
-    );
-
-    // handle multiple declarations where the first one is restricted public
-    ($(#[$attr:meta])* pub $vis:tt static $name:ident: $t:ty = $init:expr; $($rest:tt)*) => (
-        __thread_local_inner!($(#[$attr])* [pub $vis] $name, $t, $init);
-        thread_local!($($rest)*);
-    );
-
-    // handle a single restricted public declaration
-    ($(#[$attr:meta])* pub $vis:tt static $name:ident: $t:ty = $init:expr) => (
-        __thread_local_inner!($(#[$attr])* [pub $vis] $name, $t, $init);
+    // handle a single declaration
+    ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = $init:expr) => (
+        __thread_local_inner!($(#[$attr])* $vis $name, $t, $init);
     );
 }
 
@@ -174,8 +152,8 @@ macro_rules! thread_local {
 #[macro_export]
 #[allow_internal_unstable]
 macro_rules! __thread_local_inner {
-    ($(#[$attr:meta])* [$($vis:tt)*] $name:ident, $t:ty, $init:expr) => {
-        $(#[$attr])* $($vis)* static $name: $crate::thread::LocalKey<$t> = {
+    ($(#[$attr:meta])* $vis:vis $name:ident, $t:ty, $init:expr) => {
+        $(#[$attr])* $vis static $name: $crate::thread::LocalKey<$t> = {
             fn __init() -> $t { $init }
 
             fn __getit() -> $crate::option::Option<

--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -106,6 +106,7 @@ impl<T: 'static> fmt::Debug for LocalKey<T> {
     }
 }
 
+#[cfg(not(stage0))]
 /// Declare a new thread local storage key of type `std::thread::LocalKey`.
 ///
 /// # Syntax
@@ -145,6 +146,7 @@ macro_rules! thread_local {
     );
 }
 
+#[cfg(not(stage0))]
 #[doc(hidden)]
 #[unstable(feature = "thread_local_internals",
            reason = "should not be necessary",
@@ -175,6 +177,71 @@ macro_rules! __thread_local_inner {
             $crate::thread::LocalKey::new(__getit, __init)
         };
     }
+}
+
+#[cfg(stage0)]
+/// Declare a new thread local storage key of type `std::thread::LocalKey`.
+#[macro_export]
+#[stable(feature = "rust1", since = "1.0.0")]
+#[allow_internal_unstable]
+macro_rules! thread_local {
+    // rule 0: empty (base case for the recursion)
+    () => {};
+
+    // rule 1: process multiple declarations where the first one is private
+    ($(#[$attr:meta])* static $name:ident: $t:ty = $init:expr; $($rest:tt)*) => (
+        thread_local!($(#[$attr])* static $name: $t = $init); // go to rule 2
+        thread_local!($($rest)*);
+    );
+
+    // rule 2: handle a single private declaration
+    ($(#[$attr:meta])* static $name:ident: $t:ty = $init:expr) => (
+        $(#[$attr])* static $name: $crate::thread::LocalKey<$t> =
+            __thread_local_inner!($t, $init);
+    );
+
+    // rule 3: handle multiple declarations where the first one is public
+    ($(#[$attr:meta])* pub static $name:ident: $t:ty = $init:expr; $($rest:tt)*) => (
+        thread_local!($(#[$attr])* pub static $name: $t = $init); // go to rule 4
+        thread_local!($($rest)*);
+    );
+
+    // rule 4: handle a single public declaration
+    ($(#[$attr:meta])* pub static $name:ident: $t:ty = $init:expr) => (
+        $(#[$attr])* pub static $name: $crate::thread::LocalKey<$t> =
+            __thread_local_inner!($t, $init);
+    );
+}
+
+#[cfg(stage0)]
+#[doc(hidden)]
+#[unstable(feature = "thread_local_internals",
+           reason = "should not be necessary",
+           issue = "0")]
+#[macro_export]
+#[allow_internal_unstable]
+macro_rules! __thread_local_inner {
+    ($t:ty, $init:expr) => {{
+        fn __init() -> $t { $init }
+
+        fn __getit() -> $crate::option::Option<
+            &'static $crate::cell::UnsafeCell<
+                $crate::option::Option<$t>>>
+        {
+            #[thread_local]
+            #[cfg(target_thread_local)]
+            static __KEY: $crate::thread::__FastLocalKeyInner<$t> =
+                $crate::thread::__FastLocalKeyInner::new();
+
+            #[cfg(not(target_thread_local))]
+            static __KEY: $crate::thread::__OsLocalKeyInner<$t> =
+                $crate::thread::__OsLocalKeyInner::new();
+
+            __KEY.get()
+        }
+
+        $crate::thread::LocalKey::new(__getit, __init)
+    }}
 }
 
 /// Indicator of the state of a thread local storage key.

--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -111,7 +111,7 @@ impl<T: 'static> fmt::Debug for LocalKey<T> {
 /// # Syntax
 ///
 /// The macro wraps any number of static declarations and makes them thread local.
-/// Each static may be public or private, and attributes are allowed. Example:
+/// Publicity and attributes for each static are allowed. Example:
 ///
 /// ```
 /// use std::cell::RefCell;
@@ -130,31 +130,40 @@ impl<T: 'static> fmt::Debug for LocalKey<T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[allow_internal_unstable]
 macro_rules! thread_local {
-    // rule 0: empty (base case for the recursion)
+    // empty (base case for the recursion)
     () => {};
 
-    // rule 1: process multiple declarations where the first one is private
+    // process multiple declarations where the first one is private
     ($(#[$attr:meta])* static $name:ident: $t:ty = $init:expr; $($rest:tt)*) => (
-        thread_local!($(#[$attr])* static $name: $t = $init); // go to rule 2
+        __thread_local_inner!($(#[$attr])* [] $name, $t, $init);
         thread_local!($($rest)*);
     );
 
-    // rule 2: handle a single private declaration
+    // handle a single private declaration
     ($(#[$attr:meta])* static $name:ident: $t:ty = $init:expr) => (
-        $(#[$attr])* static $name: $crate::thread::LocalKey<$t> =
-            __thread_local_inner!($t, $init);
+        __thread_local_inner!($(#[$attr])* [] $name, $t, $init);
     );
 
-    // rule 3: handle multiple declarations where the first one is public
+    // handle multiple declarations where the first one is public
     ($(#[$attr:meta])* pub static $name:ident: $t:ty = $init:expr; $($rest:tt)*) => (
-        thread_local!($(#[$attr])* pub static $name: $t = $init); // go to rule 4
+        __thread_local_inner!($(#[$attr])* [pub] $name, $t, $init);
         thread_local!($($rest)*);
     );
 
-    // rule 4: handle a single public declaration
+    // handle a single public declaration
     ($(#[$attr:meta])* pub static $name:ident: $t:ty = $init:expr) => (
-        $(#[$attr])* pub static $name: $crate::thread::LocalKey<$t> =
-            __thread_local_inner!($t, $init);
+        __thread_local_inner!($(#[$attr])* [pub] $name, $t, $init);
+    );
+
+    // handle multiple declarations where the first one is restricted public
+    ($(#[$attr:meta])* pub $vis:tt static $name:ident: $t:ty = $init:expr; $($rest:tt)*) => (
+        __thread_local_inner!($(#[$attr])* [pub $vis] $name, $t, $init);
+        thread_local!($($rest)*);
+    );
+
+    // handle a single restricted public declaration
+    ($(#[$attr:meta])* pub $vis:tt static $name:ident: $t:ty = $init:expr) => (
+        __thread_local_inner!($(#[$attr])* [pub $vis] $name, $t, $init);
     );
 }
 
@@ -165,27 +174,29 @@ macro_rules! thread_local {
 #[macro_export]
 #[allow_internal_unstable]
 macro_rules! __thread_local_inner {
-    ($t:ty, $init:expr) => {{
-        fn __init() -> $t { $init }
+    ($(#[$attr:meta])* [$($vis:tt)*] $name:ident, $t:ty, $init:expr) => {
+        $(#[$attr])* $($vis)* static $name: $crate::thread::LocalKey<$t> = {
+            fn __init() -> $t { $init }
 
-        fn __getit() -> $crate::option::Option<
-            &'static $crate::cell::UnsafeCell<
-                $crate::option::Option<$t>>>
-        {
-            #[thread_local]
-            #[cfg(target_thread_local)]
-            static __KEY: $crate::thread::__FastLocalKeyInner<$t> =
-                $crate::thread::__FastLocalKeyInner::new();
+            fn __getit() -> $crate::option::Option<
+                &'static $crate::cell::UnsafeCell<
+                    $crate::option::Option<$t>>>
+            {
+                #[thread_local]
+                #[cfg(target_thread_local)]
+                static __KEY: $crate::thread::__FastLocalKeyInner<$t> =
+                    $crate::thread::__FastLocalKeyInner::new();
 
-            #[cfg(not(target_thread_local))]
-            static __KEY: $crate::thread::__OsLocalKeyInner<$t> =
-                $crate::thread::__OsLocalKeyInner::new();
+                #[cfg(not(target_thread_local))]
+                static __KEY: $crate::thread::__OsLocalKeyInner<$t> =
+                    $crate::thread::__OsLocalKeyInner::new();
 
-            __KEY.get()
-        }
+                __KEY.get()
+            }
 
-        $crate::thread::LocalKey::new(__getit, __init)
-    }}
+            $crate::thread::LocalKey::new(__getit, __init)
+        };
+    }
 }
 
 /// Indicator of the state of a thread local storage key.

--- a/src/test/run-pass/thread-local-syntax.rs
+++ b/src/test/run-pass/thread-local-syntax.rs
@@ -11,13 +11,21 @@
 #![deny(missing_docs)]
 //! this tests the syntax of `thread_local!`
 
-thread_local! {
-    // no docs
-    #[allow(unused)]
-    static FOO: i32 = 42;
-    /// docs
-    pub static BAR: String = String::from("bar");
+mod foo {
+    mod bar {
+        thread_local! {
+            // no docs
+            #[allow(unused)]
+            static FOO: i32 = 42;
+            /// docs
+            pub static BAR: String = String::from("bar");
+
+            // look at these restrictions!!
+            pub(crate) static BAZ: usize = 0;
+            pub(in foo) static QUUX: usize = 0;
+        }
+        thread_local!(static SPLOK: u32 = 0);
+    }
 }
-thread_local!(static BAZ: u32 = 0);
 
 fn main() {}


### PR DESCRIPTION
`pub(restricted)` was stabilized in #40556 so let's go!

Here is a [playground](https://play.rust-lang.org/?gist=f55f32f164a6ed18c219fec8f8293b98&version=nightly&backtrace=1).

I changed the interface of `__thread_local_inner!`, which is supposedly unstable but this is not checked for macros (#34097 cc @petrochenkov @jseyfried), so this may be an issue.