### PR TITLE
Unify rules about commas in match arms and semicolons in expressions

### DIFF
--- a/src/libsyntax/parse/classify.rs
+++ b/src/libsyntax/parse/classify.rs
@@ -12,7 +12,7 @@
 
 // Predicates on exprs and stmts that the pretty-printer and parser use
 
-use ast::{self, BlockCheckMode};
+use ast;
 
 /// Does this expression require a semicolon to be treated
 /// as a statement? The negation of this: 'can this expression
@@ -32,13 +32,6 @@ pub fn expr_requires_semi_to_be_stmt(e: &ast::Expr) -> bool {
         ast::ExprKind::Loop(..) |
         ast::ExprKind::ForLoop(..) => false,
         _ => true,
-    }
-}
-
-pub fn expr_is_simple_block(e: &ast::Expr) -> bool {
-    match e.node {
-        ast::ExprKind::Block(ref block) => block.rules == BlockCheckMode::Default,
-        _ => false,
     }
 }
 

--- a/src/libsyntax/parse/classify.rs
+++ b/src/libsyntax/parse/classify.rs
@@ -30,7 +30,8 @@ pub fn expr_requires_semi_to_be_stmt(e: &ast::Expr) -> bool {
         ast::ExprKind::While(..) |
         ast::ExprKind::WhileLet(..) |
         ast::ExprKind::Loop(..) |
-        ast::ExprKind::ForLoop(..) => false,
+        ast::ExprKind::ForLoop(..) |
+        ast::ExprKind::Catch(..) => false,
         _ => true,
     }
 }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3209,8 +3209,7 @@ impl<'a> Parser<'a> {
         self.expect(&token::FatArrow)?;
         let expr = self.parse_expr_res(RESTRICTION_STMT_EXPR, None)?;
 
-        let require_comma =
-            !classify::expr_is_simple_block(&expr)
+        let require_comma = classify::expr_requires_semi_to_be_stmt(&expr)
             && self.token != token::CloseDelim(token::Brace);
 
         if require_comma {

--- a/src/test/run-pass/catch-expr.rs
+++ b/src/test/run-pass/catch-expr.rs
@@ -71,4 +71,10 @@ pub fn main() {
         Ok(&my_string)
     };
     assert_eq!(res, Ok("test"));
+
+    do catch {
+        ()
+    }
+
+    ();
 }

--- a/src/test/run-pass/optional_comma_in_match_arm.rs
+++ b/src/test/run-pass/optional_comma_in_match_arm.rs
@@ -1,0 +1,45 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let x = 1;
+
+    match x {
+        1 => loop { break; },
+        2 => while true { break; },
+        3 => if true { () },
+        4 => if true { () } else { () },
+        5 => match () { () => () },
+        6 => { () },
+        7 => unsafe { () },
+        _ => (),
+    }
+
+    match x {
+        1 => loop { break; }
+        2 => while true { break; }
+        3 => if true { () }
+        4 => if true { () } else { () }
+        5 => match () { () => () }
+        6 => { () }
+        7 => unsafe { () }
+        _ => ()
+    }
+
+    let r: &i32 = &x;
+
+    match r {
+        // Absence of comma should not cause confusion between a pattern
+        // and a bitwise and.
+        &1 => if true { () } else { () }
+        &2 => (),
+        _ =>()
+    }
+}

--- a/src/test/run-pass/optional_comma_in_match_arm.rs
+++ b/src/test/run-pass/optional_comma_in_match_arm.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-pretty issue #37199
+
 fn main() {
     let x = 1;
 


### PR DESCRIPTION
Original discussion: https://internals.rust-lang.org/t/syntax-of-block-like-expressions-in-match-arms/5025/7.

Currently, rust uses different rules to determine if `,` is needed after an expression in a match arm and if `;` is needed in an expression statement:

```Rust
fn stmt() {
    # no need for semicolons
    { () }
    if true { () } else { () }
    loop {}
    while true {}
}

fn match_arm(n: i32) {
    match n {
        1 => { () } # can omit comma here
        2 => if true { () } else { () }, # but all other cases do need commas. 
        3 => loop { },
        4 => while true {},
        _ => ()
    }
}
```

This seems weird: why would you want to require `,` after and `if`? 

This PR unifies the rules. It is backwards compatible because it allows strictly more programs. 