### PR TITLE
Improve option API docs

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -933,9 +933,15 @@ impl<'a, A> Clone for Iter<'a, A> {
     }
 }
 
-/// An iterator over a mutable reference of the contained item in an [`Option`].
+/// An iterator over a mutable reference to the [`Some`] variant of an [`Option`].
+///
+/// The iterator yields one value if the [`Option`] is a [`Some`] variant, otherwise none.
+///
+/// This `struct` is created by [`Option::iter_mut`] function.
 ///
 /// [`Option`]: enum.Option.html
+/// [`Some`]: enum.Option.html#variant.Some
+/// [`Option::iter_mut`]: enum.Option.html#method.iter_mut
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug)]
 pub struct IterMut<'a, A: 'a> { inner: Item<&'a mut A> }

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -894,9 +894,15 @@ impl<A> ExactSizeIterator for Item<A> {}
 impl<A> FusedIterator for Item<A> {}
 unsafe impl<A> TrustedLen for Item<A> {}
 
-/// An iterator over a reference of the contained item in an [`Option`].
+/// An iterator over a reference to the [`Some`] variant of an [`Option`].
+///
+/// The iterator yields one value if the [`Option`] is a [`Some`] variant, otherwise none.
+///
+/// This `struct` is created by [`Option::iter`] function.
 ///
 /// [`Option`]: enum.Option.html
+/// [`Some`]: enum.Option.html#variant.Some
+/// [`Option::iter`]: enum.Option.html#method.iter
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug)]
 pub struct Iter<'a, A: 'a> { inner: Item<&'a A> }

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -964,9 +964,15 @@ impl<'a, A> FusedIterator for IterMut<'a, A> {}
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<'a, A> TrustedLen for IterMut<'a, A> {}
 
-/// An iterator over the item contained inside an [`Option`].
+/// An iterator over the value in [`Some`] variant of an [`Option`].
+///
+/// The iterator yields one value if the [`Option`] is a [`Some`] variant, otherwise none.
+///
+/// This `struct` is created by [`Option::into_iter`] function.
 ///
 /// [`Option`]: enum.Option.html
+/// [`Some`]: enum.Option.html#variant.Some
+/// [`Option::into_iter`]: enum.Option.html#method.into_iter
 #[derive(Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct IntoIter<A> { inner: Item<A> }

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -896,9 +896,9 @@ unsafe impl<A> TrustedLen for Item<A> {}
 
 /// An iterator over a reference to the [`Some`] variant of an [`Option`].
 ///
-/// The iterator yields one value if the [`Option`] is a [`Some`] variant, otherwise none.
+/// The iterator yields one value if the [`Option`] is a [`Some`], otherwise none.
 ///
-/// This `struct` is created by [`Option::iter`] function.
+/// This `struct` is created by the [`Option::iter`] function.
 ///
 /// [`Option`]: enum.Option.html
 /// [`Some`]: enum.Option.html#variant.Some
@@ -941,9 +941,9 @@ impl<'a, A> Clone for Iter<'a, A> {
 
 /// An iterator over a mutable reference to the [`Some`] variant of an [`Option`].
 ///
-/// The iterator yields one value if the [`Option`] is a [`Some`] variant, otherwise none.
+/// The iterator yields one value if the [`Option`] is a [`Some`], otherwise none.
 ///
-/// This `struct` is created by [`Option::iter_mut`] function.
+/// This `struct` is created by the [`Option::iter_mut`] function.
 ///
 /// [`Option`]: enum.Option.html
 /// [`Some`]: enum.Option.html#variant.Some
@@ -978,9 +978,9 @@ unsafe impl<'a, A> TrustedLen for IterMut<'a, A> {}
 
 /// An iterator over the value in [`Some`] variant of an [`Option`].
 ///
-/// The iterator yields one value if the [`Option`] is a [`Some`] variant, otherwise none.
+/// The iterator yields one value if the [`Option`] is a [`Some`], otherwise none.
 ///
-/// This `struct` is created by [`Option::into_iter`] function.
+/// This `struct` is created by the [`Option::into_iter`] function.
 ///
 /// [`Option`]: enum.Option.html
 /// [`Some`]: enum.Option.html#variant.Some


### PR DESCRIPTION
Associated Issue: #29366 

Improve `option` API docs for
* `IntoIter` struct
* `Iter` struct
* `IterMut` struct

r? @steveklabnik 