### PR TITLE
Impl len, is_empty directly for OsString.

### DIFF
--- a/src/doc/unstable-book/src/osstring-len.md
+++ b/src/doc/unstable-book/src/osstring-len.md
@@ -1,0 +1,8 @@
+# `osstring_len
+
+The tracking issue for this feature is: [#0]
+
+[#0]: https://github.com/rust-lang/rust/issues/0
+
+------------------------
+

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -65,6 +65,51 @@ impl OsString {
         OsString { inner: Buf::from_string(String::new()) }
     }
 
+    /// Checks whether the `OsString` is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::ffi::OsString;
+    ///
+    /// let mut os_string = OsString::new();
+    /// assert!(os_string.is_empty());
+    ///
+    /// os_string.push("foo");
+    /// assert!(!os_string.is_empty());
+    /// ```
+    #[stable(feature = "osstring_len", since = "1.18.0")]
+    pub fn is_empty(&self) -> bool {
+        self.inner.inner.is_empty()
+    }
+
+    /// Returns the length of this `OsString`.
+    ///
+    /// Note that this does **not** return the number of bytes in this string
+    /// as, for example, OS strings on Windows are encoded as a list of `u16`
+    /// rather than a list of bytes. This number is simply useful for passing to
+    /// other methods like [`OsString::with_capacity`] to avoid reallocations.
+    ///
+    /// See `OsStr` introduction for more information about encoding.
+    ///
+    /// [`OsString::with_capacity`]: struct.OsString.html#method.with_capacity
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::ffi::OsString;
+    ///
+    /// let mut os_string = OsString::new();
+    /// assert_eq!(os_string.len(), 0);
+    ///
+    /// os_string.push("foo");
+    /// assert_eq!(os_string.len(), 3);
+    /// ```
+    #[stable(feature = "osstring_len", since = "1.18.0")]
+    pub fn len(&self) -> usize {
+        self.inner.inner.len()
+    }
+
     /// Converts to an [`OsStr`] slice.
     ///
     /// [`OsStr`]: struct.OsStr.html


### PR DESCRIPTION
Right now, unlike `Vec` and `String`, which directly implement `len` and `is_empty`, `OsString` instead defers to `OsStr::len` and `OsStr::is_empty`. It makes sense to include these methods directly on `OsString` so that things like `OsString::len` and `OsString::is_empty` point to existing methods.

I haven't made a tracking issue for this because I'd like to see what the libs team thinks of this change first, but it's a relatively simple PR with little maintenance burden imho.