### PR TITLE
Move Rc and Arc to 32-bit reference counts

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -32,7 +32,7 @@ use core::ops::CoerceUnsized;
 use core::ptr::{self, Shared};
 use core::marker::Unsize;
 use core::hash::{Hash, Hasher};
-use core::{isize, usize};
+use core::{i32, u32};
 use core::convert::From;
 use heap::deallocate;
 
@@ -40,7 +40,8 @@ use heap::deallocate;
 ///
 /// Going above this limit will abort your program (although not
 /// necessarily) at _exactly_ `MAX_REFCOUNT + 1` references.
-const MAX_REFCOUNT: usize = (isize::MAX) as usize;
+const MAX_REFCOUNT: u32 = (i32::MAX) as u32;
+const WEAK_LOCK_SENTINEL: u32 = u32::MAX;
 
 /// A thread-safe reference-counting pointer.
 ///
@@ -198,12 +199,12 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for Weak<T> {
 }
 
 struct ArcInner<T: ?Sized> {
-    strong: atomic::AtomicUsize,
+    strong: atomic::AtomicU32,
 
-    // the value usize::MAX acts as a sentinel for temporarily "locking" the
+    // the value u32::MAX acts as a sentinel for temporarily "locking" the
     // ability to upgrade weak pointers or downgrade strong ones; this is used
     // to avoid races in `make_mut` and `get_mut`.
-    weak: atomic::AtomicUsize,
+    weak: atomic::AtomicU32,
 
     data: T,
 }
@@ -227,8 +228,8 @@ impl<T> Arc<T> {
         // Start the weak pointer count as 1 which is the weak pointer that's
         // held by all the strong pointers (kinda), see std/rc.rs for more info
         let x: Box<_> = box ArcInner {
-            strong: atomic::AtomicUsize::new(1),
-            weak: atomic::AtomicUsize::new(1),
+            strong: atomic::AtomicU32::new(1),
+            weak: atomic::AtomicU32::new(1),
             data: data,
         };
         Arc { ptr: unsafe { Shared::new(Box::into_raw(x)) } }
@@ -361,13 +362,13 @@ impl<T: ?Sized> Arc<T> {
 
         loop {
             // check if the weak counter is currently "locked"; if so, spin.
-            if cur == usize::MAX {
+            if cur == WEAK_LOCK_SENTINEL {
                 cur = this.inner().weak.load(Relaxed);
                 continue;
             }
 
             // NOTE: this code currently ignores the possibility of overflow
-            // into usize::MAX; in general both Rc and Arc need to be adjusted
+            // into u32::MAX; in general both Rc and Arc need to be adjusted
             // to deal with overflow.
 
             // Unlike with Clone(), we need this to be an Acquire read to
@@ -405,7 +406,7 @@ impl<T: ?Sized> Arc<T> {
     #[inline]
     #[stable(feature = "arc_counts", since = "1.15.0")]
     pub fn weak_count(this: &Self) -> usize {
-        this.inner().weak.load(SeqCst) - 1
+        (this.inner().weak.load(SeqCst) - 1) as usize
     }
 
     /// Gets the number of strong (`Arc`) pointers to this value.
@@ -431,7 +432,7 @@ impl<T: ?Sized> Arc<T> {
     #[inline]
     #[stable(feature = "arc_counts", since = "1.15.0")]
     pub fn strong_count(this: &Self) -> usize {
-        this.inner().strong.load(SeqCst)
+        this.inner().strong.load(SeqCst) as usize
     }
 
     #[inline]
@@ -597,7 +598,7 @@ impl<T: Clone> Arc<T> {
             // invalidate the other weak refs.
 
             // Note that it is not possible for the read of `weak` to yield
-            // usize::MAX (i.e., locked), since the weak count can only be
+            // u32::MAX (i.e., locked), since the weak count can only be
             // locked by a thread with a strong reference.
 
             // Materialize our own implicit weak pointer, so that it can clean
@@ -685,7 +686,7 @@ impl<T: ?Sized> Arc<T> {
         // The acquire label here ensures a happens-before relationship with any
         // writes to `strong` prior to decrements of the `weak` count (via drop,
         // which uses Release).
-        if self.inner().weak.compare_exchange(1, usize::MAX, Acquire, Relaxed).is_ok() {
+        if self.inner().weak.compare_exchange(1, WEAK_LOCK_SENTINEL, Acquire, Relaxed).is_ok() {
             // Due to the previous acquire read, this will observe any writes to
             // `strong` that were due to upgrading weak pointers; only strong
             // clones remain, which require that the strong count is > 1 anyway.
@@ -788,8 +789,8 @@ impl<T> Weak<T> {
         unsafe {
             Weak {
                 ptr: Shared::new(Box::into_raw(box ArcInner {
-                    strong: atomic::AtomicUsize::new(0),
-                    weak: atomic::AtomicUsize::new(1),
+                    strong: atomic::AtomicU32::new(0),
+                    weak: atomic::AtomicU32::new(1),
                     data: uninitialized(),
                 })),
             }
@@ -1183,7 +1184,7 @@ mod tests {
     use std::sync::Mutex;
     use std::convert::From;
 
-    struct Canary(*mut atomic::AtomicUsize);
+    struct Canary(*mut atomic::AtomicU32);
 
     impl Drop for Canary {
         fn drop(&mut self) {
@@ -1348,16 +1349,16 @@ mod tests {
 
     #[test]
     fn drop_arc() {
-        let mut canary = atomic::AtomicUsize::new(0);
-        let x = Arc::new(Canary(&mut canary as *mut atomic::AtomicUsize));
+        let mut canary = atomic::AtomicU32::new(0);
+        let x = Arc::new(Canary(&mut canary as *mut atomic::AtomicU32));
         drop(x);
         assert!(canary.load(Acquire) == 1);
     }
 
     #[test]
     fn drop_arc_weak() {
-        let mut canary = atomic::AtomicUsize::new(0);
-        let arc = Arc::new(Canary(&mut canary as *mut atomic::AtomicUsize));
+        let mut canary = atomic::AtomicU32::new(0);
+        let arc = Arc::new(Canary(&mut canary as *mut atomic::AtomicU32));
         let arc_weak = Arc::downgrade(&arc);
         assert!(canary.load(Acquire) == 0);
         drop(arc);

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -83,6 +83,7 @@
 #![cfg_attr(not(test), feature(exact_size_is_empty))]
 #![feature(fundamental)]
 #![feature(generic_param_attrs)]
+#![feature(integer_atomics)]
 #![feature(lang_items)]
 #![feature(needs_allocator)]
 #![feature(optin_builtin_traits)]

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -243,8 +243,8 @@ use heap::deallocate;
 use raw_vec::RawVec;
 
 struct RcBox<T: ?Sized> {
-    strong: Cell<usize>,
-    weak: Cell<usize>,
+    strong: Cell<u32>,
+    weak: Cell<u32>,
     value: T,
 }
 
@@ -422,8 +422,8 @@ impl Rc<str> {
     pub fn __from_str(value: &str) -> Rc<str> {
         unsafe {
             // Allocate enough space for `RcBox<str>`.
-            let aligned_len = 2 + (value.len() + size_of::<usize>() - 1) / size_of::<usize>();
-            let vec = RawVec::<usize>::with_capacity(aligned_len);
+            let aligned_len = 2 + (value.len() + size_of::<u32>() - 1) / size_of::<u32>();
+            let vec = RawVec::<u32>::with_capacity(aligned_len);
             let ptr = vec.ptr();
             forget(vec);
             // Initialize fields of `RcBox<str>`.
@@ -432,7 +432,7 @@ impl Rc<str> {
             ptr::copy_nonoverlapping(value.as_ptr(), ptr.offset(2) as *mut u8, value.len());
             // Combine the allocation address and the string length into a fat pointer to `RcBox`.
             let rcbox_ptr: *mut RcBox<str> = mem::transmute([ptr as usize, value.len()]);
-            assert!(aligned_len * size_of::<usize>() == size_of_val(&*rcbox_ptr));
+            assert!(aligned_len * size_of::<u32>() == size_of_val(&*rcbox_ptr));
             Rc { ptr: Shared::new(rcbox_ptr) }
         }
     }
@@ -475,7 +475,7 @@ impl<T: ?Sized> Rc<T> {
     #[inline]
     #[stable(feature = "rc_counts", since = "1.15.0")]
     pub fn weak_count(this: &Self) -> usize {
-        this.weak() - 1
+        (this.weak() - 1) as usize
     }
 
     /// Gets the number of strong (`Rc`) pointers to this value.
@@ -493,7 +493,7 @@ impl<T: ?Sized> Rc<T> {
     #[inline]
     #[stable(feature = "rc_counts", since = "1.15.0")]
     pub fn strong_count(this: &Self) -> usize {
-        this.strong()
+        this.strong() as usize
     }
 
     /// Returns true if there are no other `Rc` or [`Weak`][weak] pointers to
@@ -1127,7 +1127,7 @@ trait RcBoxPtr<T: ?Sized> {
     fn inner(&self) -> &RcBox<T>;
 
     #[inline]
-    fn strong(&self) -> usize {
+    fn strong(&self) -> u32 {
         self.inner().strong.get()
     }
 
@@ -1142,7 +1142,7 @@ trait RcBoxPtr<T: ?Sized> {
     }
 
     #[inline]
-    fn weak(&self) -> usize {
+    fn weak(&self) -> u32 {
         self.inner().weak.get()
     }
 


### PR DESCRIPTION
Why this is profitable: This represents a potential memory savings on 64-bit platforms, although the allocator may happily overallocate, yielding no practical reduction in memory footprint for any given type. This can also reduce the pressure to vend a version of Rc/Arc that doesn't have weak counts: if you're storing a 64-bit aligned type (anything with a pointer/index), removing the weak count represents no potential space savings, as it would just be replaced with padding.

Why this is fine: We already pay the cost of overflow checks on our reference counts for esoteric safety reasons. So the only concern is that this will break applications that would exceed a 31-bit counter (1 bit is reserved). Any application that overflows a 31-bit counter on 64-bit is either doing `mem::forget` nonsense (and is broken) or has ~17GB committed to pointing to a single Rc allocation 2 billion times (and is almost certainly broken).

Prior art: both Swift and Firefox already use 32-bit counts (Swift having weak references as well).

This implementation is currently a lazy minimal implementation. It's possible that fusing the weak/strong counts into a single u64 would enable "fused" operations which check/manipulate both counts at once. This was more work than I was willing to invest into this change at this point in time, but is interesting future work.

Someone should probably review the Arc changes carefully, in case I ruined something important.