### PR TITLE
Overhaul Bootstrap (x.py) Command-Line-Parsing & Help Output

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -591,9 +591,10 @@ def bootstrap():
 
 def main():
     start_time = time()
+    help_triggered = ('-h' in sys.argv) or ('--help' in sys.argv) or (len(sys.argv) == 1)
     try:
         bootstrap()
-        if ('-h' not in sys.argv) and ('--help' not in sys.argv):
+        if not help_triggered:
             print("Build completed successfully in %s" % format_build_time(time() - start_time))
     except (SystemExit, KeyboardInterrupt) as e:
         if hasattr(e, 'code') and isinstance(e.code, int):
@@ -601,7 +602,7 @@ def main():
         else:
             exit_code = 1
             print(e)
-        if ('-h' not in sys.argv) and ('--help' not in sys.argv):
+        if not help_triggered:
             print("Build completed unsuccessfully in %s" % format_build_time(time() - start_time))
         sys.exit(exit_code)
 

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -593,14 +593,16 @@ def main():
     start_time = time()
     try:
         bootstrap()
-        print("Build completed successfully in %s" % format_build_time(time() - start_time))
+        if ('-h' not in sys.argv) and ('--help' not in sys.argv):
+            print("Build completed successfully in %s" % format_build_time(time() - start_time))
     except (SystemExit, KeyboardInterrupt) as e:
         if hasattr(e, 'code') and isinstance(e.code, int):
             exit_code = e.code
         else:
             exit_code = 1
             print(e)
-        print("Build completed unsuccessfully in %s" % format_build_time(time() - start_time))
+        if ('-h' not in sys.argv) and ('--help' not in sys.argv):
+            print("Build completed unsuccessfully in %s" % format_build_time(time() - start_time))
         sys.exit(exit_code)
 
 if __name__ == '__main__':

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -18,7 +18,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::process;
 
-use getopts::{Options};
+use getopts::Options;
 
 use Build;
 use config::Config;

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -90,19 +90,31 @@ impl Flags {
         opts.optflag("h", "help", "print this help message");
 
         let usage = |n, opts: &Options| -> ! {
-            let subcommand = args.get(0).map(|s| &**s);
-            let brief = format!("Usage: x.py <subcommand> [options] [<args>...]");
+            let subcommand_help = format!("\
+Usage: x.py <subcommand> [options] [<paths>...]
 
-            println!("{}", opts.usage(&brief));
+Subcommands:
+    build       Compile either the compiler or libraries
+    test        Build and run some test suites
+    bench       Build and run some benchmarks
+    doc         Build documentation
+    clean       Clean out build directories
+    dist        Build and/or install distribution artifacts
+
+To learn more about a subcommand, run `./x.py <subcommand> -h`");
+
+            println!("{}", opts.usage(&subcommand_help));
+
+            let subcommand = args.get(0).map(|s| &**s);
             match subcommand {
                 Some("build") => {
                     println!("\
 Arguments:
-    This subcommand accepts a number of positional arguments of directories to
-    the crates and/or artifacts to compile. For example:
+    This subcommand accepts a number of paths to directories to the crates 
+    and/or artifacts to compile. For example:
 
         ./x.py build src/libcore
-        ./x.py build src/libproc_macro
+        ./x.py build src/libcore src/libproc_macro
         ./x.py build src/libstd --stage 1
 
     If no arguments are passed then the complete artifacts for that stage are
@@ -120,8 +132,8 @@ Arguments:
                 Some("test") => {
                     println!("\
 Arguments:
-    This subcommand accepts a number of positional arguments of directories to
-    tests that should be compiled and run. For example:
+    This subcommand accepts a number of paths to directories to tests that
+    should be compiled and run. For example:
 
         ./x.py test src/test/run-pass
         ./x.py test src/libstd --test-args hash_map
@@ -138,12 +150,12 @@ Arguments:
                 Some("doc") => {
                     println!("\
 Arguments:
-    This subcommand accepts a number of positional arguments of directories of
-    documentation to build. For example:
+    This subcommand accepts a number of paths to directories of documentation
+    to build. For example:
 
         ./x.py doc src/doc/book
         ./x.py doc src/doc/nomicon
-        ./x.py doc src/libstd
+        ./x.py doc src/doc/book src/libstd
 
     If no arguments are passed then everything is documented:
 
@@ -155,6 +167,7 @@ Arguments:
                 _ => {}
             }
 
+
             if let Some(subcommand) = subcommand {
                 if subcommand == "build" ||
                    subcommand == "test" ||
@@ -162,7 +175,6 @@ Arguments:
                    subcommand == "doc" ||
                    subcommand == "clean" ||
                    subcommand == "dist"  {
-                    println!("Available invocations:");
                     if args.iter().any(|a| a == "-v") {
                         let flags = Flags::parse(&["build".to_string()]);
                         let mut config = Config::default();
@@ -171,25 +183,13 @@ Arguments:
                         metadata::build(&mut build);
                         step::build_rules(&build).print_help(subcommand);
                     } else {
-                        println!("    ... elided, run `./x.py {} -h -v` to see",
+                        println!("Run `./x.py {} -h -v` to see a list of available paths.",
                                  subcommand);
                     }
 
                     println!("");
                 }
             }
-
-println!("\
-Subcommands:
-    build       Compile either the compiler or libraries
-    test        Build and run some test suites
-    bench       Build and run some benchmarks
-    doc         Build documentation
-    clean       Clean out build directories
-    dist        Build and/or install distribution artifacts
-
-To learn more about a subcommand, run `./x.py <subcommand> -h`
-");
 
             process::exit(n);
         };
@@ -256,8 +256,7 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`
                 }
             }
             "--help" => usage(0, &opts),
-            cmd => {
-                println!("unknown subcommand: {}", cmd);
+            _ => {
                 usage(1, &opts);
             }
         };

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -89,7 +89,7 @@ impl Flags {
         opts.optopt("j", "jobs", "number of jobs to run in parallel", "JOBS");
         opts.optflag("h", "help", "print this help message");
 
-        let usage = |n, opts: &Options| -> ! {
+        let usage = |exit_code, opts: &Options| -> ! {
             let subcommand_help = format!("\
 Usage: x.py <subcommand> [options] [<paths>...]
 
@@ -191,7 +191,7 @@ Arguments:
                 }
             }
 
-            process::exit(n);
+            process::exit(exit_code);
         };
         if args.len() == 0 {
             println!("a subcommand must be passed");

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -137,10 +137,10 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`");
 
         // Some subcommands get extra options
         match subcommand.as_str() {
-            "test"  => opts.optmulti("", "test-args", "extra arguments", "ARGS"),
-            "bench" => opts.optmulti("", "test-args", "extra arguments", "ARGS"),
-            "dist"  => opts.optflag("", "install", "run installer as well"),
-            _ => { }
+            "test"  => { opts.optmulti("", "test-args", "extra arguments", "ARGS"); },
+            "bench" => { opts.optmulti("", "test-args", "extra arguments", "ARGS"); },
+            "dist"  => { opts.optflag("", "install", "run installer as well"); },
+            _ => { },
         };
 
         // Done specifying what options are possible, so do the getopts parsing

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -90,12 +90,11 @@ impl Flags {
         opts.optflag("h", "help", "print this help message");
 
         let usage = |n, opts: &Options| -> ! {
-            let command = args.get(0).map(|s| &**s);
-            let brief = format!("Usage: x.py {} [options] [<args>...]",
-                                command.unwrap_or("<command>"));
+            let subcommand = args.get(0).map(|s| &**s);
+            let brief = format!("Usage: x.py <subcommand> [options] [<args>...]");
 
             println!("{}", opts.usage(&brief));
-            match command {
+            match subcommand {
                 Some("build") => {
                     println!("\
 Arguments:
@@ -156,13 +155,13 @@ Arguments:
                 _ => {}
             }
 
-            if let Some(command) = command {
-                if command == "build" ||
-                   command == "dist" ||
-                   command == "doc" ||
-                   command == "test" ||
-                   command == "bench" ||
-                   command == "clean"  {
+            if let Some(subcommand) = subcommand {
+                if subcommand == "build" ||
+                   subcommand == "dist" ||
+                   subcommand == "doc" ||
+                   subcommand == "test" ||
+                   subcommand == "bench" ||
+                   subcommand == "clean"  {
                     println!("Available invocations:");
                     if args.iter().any(|a| a == "-v") {
                         let flags = Flags::parse(&["build".to_string()]);
@@ -170,10 +169,10 @@ Arguments:
                         config.build = flags.build.clone();
                         let mut build = Build::new(flags, config);
                         metadata::build(&mut build);
-                        step::build_rules(&build).print_help(command);
+                        step::build_rules(&build).print_help(subcommand);
                     } else {
                         println!("    ... elided, run `./x.py {} -h -v` to see",
-                                 command);
+                                 subcommand);
                     }
 
                     println!("");
@@ -189,13 +188,13 @@ Subcommands:
     clean       Clean out build directories
     dist        Build and/or install distribution artifacts
 
-To learn more about a subcommand, run `./x.py <command> -h`
+To learn more about a subcommand, run `./x.py <subcommand> -h`
 ");
 
             process::exit(n);
         };
         if args.len() == 0 {
-            println!("a command must be passed");
+            println!("a subcommand must be passed");
             usage(1, &opts);
         }
         let parse = |opts: &Options| {
@@ -258,7 +257,7 @@ To learn more about a subcommand, run `./x.py <command> -h`
             }
             "--help" => usage(0, &opts),
             cmd => {
-                println!("unknown command: {}", cmd);
+                println!("unknown subcommand: {}", cmd);
                 usage(1, &opts);
             }
         };

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -212,6 +212,8 @@ Arguments:
         let remaining_as_path = |m: &Matches| {
             m.free.iter().map(|p| cwd.join(p)).collect::<Vec<_>>()
         };
+        // TODO: Parse subcommand nicely up at top, so options can occur before the subcommand.
+        // TODO: Get the subcommand-specific options below into the help output
 
         let m: Matches;
         let cmd = match &args[0][..] {

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -244,7 +244,7 @@ Arguments:
                 Subcommand::Doc { paths: paths }
             }
             "clean" => {
-                if matches.free.len() > 0 {
+                if paths.len() > 0 {
                     println!("\nclean takes no arguments\n");
                     usage(1, &opts, &subcommand_help, &extra_help);
                 }

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -157,11 +157,11 @@ Arguments:
 
             if let Some(subcommand) = subcommand {
                 if subcommand == "build" ||
-                   subcommand == "dist" ||
-                   subcommand == "doc" ||
                    subcommand == "test" ||
                    subcommand == "bench" ||
-                   subcommand == "clean"  {
+                   subcommand == "doc" ||
+                   subcommand == "clean" ||
+                   subcommand == "dist"  {
                     println!("Available invocations:");
                     if args.iter().any(|a| a == "-v") {
                         let flags = Flags::parse(&["build".to_string()]);
@@ -219,10 +219,6 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`
                 m = parse(&opts);
                 Subcommand::Build { paths: remaining_as_path(&m) }
             }
-            "doc" => {
-                m = parse(&opts);
-                Subcommand::Doc { paths: remaining_as_path(&m) }
-            }
             "test" => {
                 opts.optmulti("", "test-args", "extra arguments", "ARGS");
                 m = parse(&opts);
@@ -238,6 +234,10 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`
                     paths: remaining_as_path(&m),
                     test_args: m.opt_strs("test-args"),
                 }
+            }
+            "doc" => {
+                m = parse(&opts);
+                Subcommand::Doc { paths: remaining_as_path(&m) }
             }
             "clean" => {
                 m = parse(&opts);

--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -978,26 +978,25 @@ invalid rule dependency graph detected, was a rule added and maybe typo'd?
         }
     }
 
-    pub fn print_help(&self, command: &str) {
+    pub fn get_help(&self, command: &str) -> Option<String> {
         let kind = match command {
             "build" => Kind::Build,
             "doc" => Kind::Doc,
             "test" => Kind::Test,
             "bench" => Kind::Bench,
             "dist" => Kind::Dist,
-            _ => return,
+            _ => return None,
         };
         let rules = self.rules.values().filter(|r| r.kind == kind);
         let rules = rules.filter(|r| !r.path.contains("nowhere"));
         let mut rules = rules.collect::<Vec<_>>();
         rules.sort_by_key(|r| r.path);
 
-        println!("Available paths:\n");
+        let mut help_string = String::from("Available paths:\n");
         for rule in rules {
-            print!("    ./x.py {} {}", command, rule.path);
-
-            println!("");
+            help_string.push_str(format!("    ./x.py {} {}\n", command, rule.path).as_str());
         }
+        Some(help_string)
     }
 
     /// Construct the top-level build steps that we're going to be executing,


### PR DESCRIPTION
While working on #40417, I got frustrated with the behavior of x.py and the bootstrap binary it wraps, so I decided to do something about it.  This PR should improve documentation, make the command-line-parsing more flexible, and clean up some of the internals.  No command that worked before should stop working.  At least that's the theory. :-)

This should resolve at least #40920 and #38373.

Changes:

- No more manual args manipulation -- getopts used everywhere except the one place it's not possible.  As a result, options can be in any position, now, even before the subcommand.
- The additional options for test, bench, and dist now appear in the help output.
- No more single-letter variable bindings used internally for large scopes.
- Don't output the time measurement when just invoking `x.py` or explicitly passing `-h` or `--help`
- Logic is now much more linear.  We build strings up, and then print them.
- Refer to subcommands as subcommands everywhere (some places we were saying "command")
- Other minor stuff.

@alexcrichton This is my first PR. Do I need to do something specific to request reviewers or anything?