### PR TITLE
Fixed typo in doc comments for swap_remove

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -678,8 +678,9 @@ impl<T> Vec<T> {
         self.len = len;
     }
 
-    /// Removes an element from anywhere in the vector and returns it, replacing
-    /// it with the last element.
+    /// Removes an element from the vector and returns it.
+    /// 
+    /// The removed element is replaced by the last element of the vector.
     ///
     /// This does not preserve ordering, but is O(1).
     ///

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -679,7 +679,7 @@ impl<T> Vec<T> {
     }
 
     /// Removes an element from the vector and returns it.
-    /// 
+    ///
     /// The removed element is replaced by the last element of the vector.
     ///
     /// This does not preserve ordering, but is O(1).

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -678,7 +678,7 @@ impl<T> Vec<T> {
         self.len = len;
     }
 
-    /// Removes an element from anywhere in the vector and return it, replacing
+    /// Removes an element from anywhere in the vector and returns it, replacing
     /// it with the last element.
     ///
     /// This does not preserve ordering, but is O(1).


### PR DESCRIPTION
While reading the Vec docs, I came across the docs for swap_remove. I believe there is a typo in the comment and ```return``` should be ```returns```. This PR fixes this issue. 

I also feel that the entire doc comment is a bit of a run-on and could be changed to something along the lines of ```Removes an element from anywhere in the vector and returns it. The vector is mutated and the removed element is replaced by the last element of the vector. ```

Thoughts?