### PR TITLE
Revert "Implement AsRawFd/IntoRawFd for RawFd"

### DIFF
--- a/src/libstd/sys/unix/ext/io.rs
+++ b/src/libstd/sys/unix/ext/io.rs
@@ -73,13 +73,6 @@ pub trait IntoRawFd {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl AsRawFd for RawFd {
-    fn as_raw_fd(&self) -> RawFd {
-        *self
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
 impl AsRawFd for fs::File {
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().raw()
@@ -91,14 +84,6 @@ impl FromRawFd for fs::File {
         fs::File::from_inner(sys::fs::File::from_inner(fd))
     }
 }
-
-#[stable(feature = "into_raw_os", since = "1.4.0")]
-impl IntoRawFd for RawFd {
-    fn into_raw_fd(self) -> RawFd {
-        self
-    }
-}
-
 #[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawFd for fs::File {
     fn into_raw_fd(self) -> RawFd {


### PR DESCRIPTION
This reverts commit 2cf686f2cdd6446a3cd47df0305ead40fabe85df (#40842)

RawFd is a type alias for c_int, which is itself a type alias for i32.
As a result, adding AsRawFd and IntoRawFd impls for RawFd actually adds
them for i32.

As a result, the reverted commit makes this valid:

```
use std::os::unix::io::AsRawFd;

fn arf<T: AsRawFd>(_: T) {}

fn main() {
    arf(32i32)
}
```

Implimenting AsRawFd and IntoRawFd for i32 breaks the promises of both
those traits that their methods return a valid RawFd.

r? @aturon
cc @Mic92 @kamalmarhubi