### PR TITLE
macros: fix bug parsing `#[derive]` invocations

### DIFF
--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -222,8 +222,10 @@ impl<'a> base::Resolver for Resolver<'a> {
             let name = unwrap_or!(attrs[i].name(), continue);
 
             if name == "derive" {
-                let result = attrs[i].parse_list(&self.session.parse_sess,
-                                                 |parser| parser.parse_path(PathStyle::Mod));
+                let result = attrs[i].parse_list(&self.session.parse_sess, |parser| {
+                    parser.parse_path_allowing_meta(PathStyle::Mod)
+                });
+
                 let mut traits = match result {
                     Ok(traits) => traits,
                     Err(mut e) => {

--- a/src/libsyntax/ext/derive.rs
+++ b/src/libsyntax/ext/derive.rs
@@ -26,7 +26,8 @@ pub fn collect_derives(cx: &mut ExtCtxt, attrs: &mut Vec<ast::Attribute>) -> Vec
             return true;
         }
 
-        match attr.parse_list(cx.parse_sess, |parser| parser.parse_path(PathStyle::Mod)) {
+        match attr.parse_list(cx.parse_sess,
+                              |parser| parser.parse_path_allowing_meta(PathStyle::Mod)) {
             Ok(ref traits) if traits.is_empty() => {
                 cx.span_warn(attr.span, "empty trait list in `derive`");
                 false

--- a/src/test/run-pass/issue-40962.rs
+++ b/src/test/run-pass/issue-40962.rs
@@ -1,0 +1,20 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! m {
+    ($i:meta) => {
+        #[derive($i)]
+        struct S;
+    }
+}
+
+m!(Clone);
+
+fn main() {}


### PR DESCRIPTION
Fixes #40962 (introduced in #40346).
r? @nrc 