### PR TITLE
Make 'overlapping_inherent_impls' lint a hard error

### DIFF
--- a/src/test/ui/codemap_tests/coherence-overlapping-inherent-impl-trait.rs
+++ b/src/test/ui/codemap_tests/coherence-overlapping-inherent-impl-trait.rs
@@ -11,6 +11,6 @@
 #![allow(dead_code)]
 
 trait C {}
-impl C { fn f() {} } //~ ERROR duplicate definitions with name `f`
+impl C { fn f() {} }
 impl C { fn f() {} }
 fn main() { }

--- a/src/test/ui/codemap_tests/coherence-overlapping-inherent-impl-trait.stderr
+++ b/src/test/ui/codemap_tests/coherence-overlapping-inherent-impl-trait.stderr
@@ -1,0 +1,10 @@
+error[E0592]: duplicate definitions with name `f`
+  --> $DIR/coherence-overlapping-inherent-impl-trait.rs:14:10
+   |
+14 | impl C { fn f() {} }
+   |          ^^^^^^^^^ duplicate definitions for `f`
+15 | impl C { fn f() {} }
+   |          --------- other definition for `f`
+
+error: aborting due to previous error
+

--- a/src/test/ui/codemap_tests/overlapping_inherent_impls.rs
+++ b/src/test/ui/codemap_tests/overlapping_inherent_impls.rs
@@ -16,7 +16,7 @@
 struct Foo;
 
 impl Foo {
-    fn id() {} //~ ERROR duplicate definitions
+    fn id() {}
 }
 
 impl Foo {
@@ -26,7 +26,7 @@ impl Foo {
 struct Bar<T>(T);
 
 impl<T> Bar<T> {
-    fn bar(&self) {} //~ ERROR duplicate definitions
+    fn bar(&self) {}
 }
 
 impl Bar<u32> {
@@ -36,7 +36,7 @@ impl Bar<u32> {
 struct Baz<T>(T);
 
 impl<T: Copy> Baz<T> {
-    fn baz(&self) {} //~ ERROR duplicate definitions
+    fn baz(&self) {}
 }
 
 impl<T> Baz<Vec<T>> {

--- a/src/test/ui/codemap_tests/overlapping_inherent_impls.stderr
+++ b/src/test/ui/codemap_tests/overlapping_inherent_impls.stderr
@@ -1,0 +1,29 @@
+error[E0592]: duplicate definitions with name `id`
+  --> $DIR/overlapping_inherent_impls.rs:19:5
+   |
+19 |     fn id() {}
+   |     ^^^^^^^^^^ duplicate definitions for `id`
+...
+23 |     fn id() {}
+   |     ---------- other definition for `id`
+
+error[E0592]: duplicate definitions with name `bar`
+  --> $DIR/overlapping_inherent_impls.rs:29:5
+   |
+29 |     fn bar(&self) {}
+   |     ^^^^^^^^^^^^^^^^ duplicate definitions for `bar`
+...
+33 |     fn bar(&self) {}
+   |     ---------------- other definition for `bar`
+
+error[E0592]: duplicate definitions with name `baz`
+  --> $DIR/overlapping_inherent_impls.rs:39:5
+   |
+39 |     fn baz(&self) {}
+   |     ^^^^^^^^^^^^^^^^ duplicate definitions for `baz`
+...
+43 |     fn baz(&self) {}
+   |     ---------------- other definition for `baz`
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
This is ought to be implemented in PR #40728. Unfortunately, when I rebased the PR to resolve merge conflict, the "hard error" code disappeared. This PR complements the initial PR.

Now the following rust code gives the following error:
```rust
struct Foo;

impl Foo {
    fn id() {}
}

impl Foo {
    fn id() {}
}

fn main() {}
```
```
error[E0592]: duplicate definitions with name `id`
 --> /home/topecongiro/test.rs:4:5
  |
4 |     fn id() {}
  |     ^^^^^^^^^^ duplicate definitions for `id`
...
8 |     fn id() {}
  |     ---------- other definition for `id`

error: aborting due to previous error
```