### PR TITLE
Do not recommend private fields called as method

### DIFF
--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -196,19 +196,23 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
                                     let field_ty = field.ty(tcx, substs);
 
-                                    if self.is_fn_ty(&field_ty, span) {
-                                        err.help(&format!("use `({0}.{1})(...)` if you \
-                                                           meant to call the function \
-                                                           stored in the `{1}` field",
-                                                          expr_string,
-                                                          item_name));
+                                    if tcx.vis_is_accessible_from(field.vis, self.body_id) {
+                                        if self.is_fn_ty(&field_ty, span) {
+                                            err.help(&format!("use `({0}.{1})(...)` if you \
+                                                               meant to call the function \
+                                                               stored in the `{1}` field",
+                                                              expr_string,
+                                                              item_name));
+                                        } else {
+                                            err.help(&format!("did you mean to write `{0}.{1}` \
+                                                               instead of `{0}.{1}(...)`?",
+                                                              expr_string,
+                                                              item_name));
+                                        }
+                                        err.span_label(span, &"field, not a method");
                                     } else {
-                                        err.help(&format!("did you mean to write `{0}.{1}` \
-                                                           instead of `{0}.{1}(...)`?",
-                                                          expr_string,
-                                                          item_name));
+                                        err.span_label(span, &"private field, not a method");
                                     }
-                                    err.span_label(span, &"field, not a method");
                                     break;
                                 }
                             }

--- a/src/test/ui/suggestions/confuse-field-and-method/private-field.rs
+++ b/src/test/ui/suggestions/confuse-field-and-method/private-field.rs
@@ -1,0 +1,29 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub mod animal {
+    pub struct Dog {
+        pub age: usize,
+        dog_age: usize,
+    }
+
+    impl Dog {
+        pub fn new(age: usize) -> Dog {
+            Dog { age: age, dog_age: age * 7 }
+        }
+    }
+}
+
+fn main() {
+    let dog = animal::Dog::new(3);
+    let dog_age = dog.dog_age();
+    //let dog_age = dog.dog_age;
+    println!("{}", dog_age);
+}

--- a/src/test/ui/suggestions/confuse-field-and-method/private-field.stderr
+++ b/src/test/ui/suggestions/confuse-field-and-method/private-field.stderr
@@ -1,0 +1,8 @@
+error: no method named `dog_age` found for type `animal::Dog` in the current scope
+  --> $DIR/private-field.rs:26:23
+   |
+26 |     let dog_age = dog.dog_age();
+   |                       ^^^^^^^ private field, not a method
+
+error: aborting due to previous error
+


### PR DESCRIPTION
```rust
error: no method named `dog_age` found for type `animal::Dog` in the current scope
  --> $DIR/private-field.rs:26:23
   |
26 |     let dog_age = dog.dog_age();
   |                       ^^^^^^^ private field, not a method
```
Fix #27654.