### PR TITLE
spec safety of CString::into_raw with custom allocators

### DIFF
--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -273,7 +273,9 @@ impl CString {
     /// this string.
     ///
     /// More details about custom memory allocators can be found in
-    /// [the book](../../unstable-book/allocator.html).
+    /// [the book](../../unstable-book/allocator.html). The alignment
+    /// used for allocation is guaranteed to always be the same as the
+    /// alignment for `u8`.
     ///
     /// Failure to call `from_raw` will lead to a memory leak.
     #[stable(feature = "cstr_memory", since = "1.4.0")]

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -266,10 +266,14 @@ impl CString {
 
     /// Transfers ownership of the string to a C caller.
     ///
-    /// The pointer must be returned to Rust and reconstituted using
-    /// `from_raw` to be properly deallocated. Specifically, one
+    /// Unless the same memory allocator is used for both Rust and C,
+    /// the acquired pointer must be returned to Rust and reconstituted
+    /// using `from_raw` to be properly deallocated. Specifically, one
     /// should *not* use the standard C `free` function to deallocate
     /// this string.
+    ///
+    /// More details about custom memory allocators can be found in
+    /// [the book](../../unstable-book/allocator.html).
     ///
     /// Failure to call `from_raw` will lead to a memory leak.
     #[stable(feature = "cstr_memory", since = "1.4.0")]


### PR DESCRIPTION
The current implementation allows pointer returned from CString::into_raw() to
be safely freed inside C iff the same allocator is used for both C and Rust.
This is in contrast to its documentation, which state you must not do that.
Following the documentation instead of the implementation has serious usability
concerns, however - needing to adapt APIs to allow Rust to free these strings
is a big burden for projects wanting to integrate some Rust into their C
codebase.

r? @steveklabnik 