### PR TITLE
Re-enable appveyor cache

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -141,15 +141,18 @@ install:
   - set SCCACHE_ERROR_LOG=%CD%/sccache.log
 
 test_script:
-  - appveyor-retry sh -c 'git submodule deinit -f . && git submodule update --init'
+  - if not exist C:\cache\rustsrc\NUL mkdir C:\cache\rustsrc
+  - sh src/ci/init_repo.sh . /c/cache/rustsrc
   - set SRC=.
   - set NO_CCACHE=1
   - sh src/ci/run.sh
 
 on_failure:
-  - cat %CD%/sccache.log
+  - cat %CD%\sccache.log
+  - cat C:\Users\appveyor\AppData\Local\Temp\1\build-cache-logs\*.log
 
 cache:
+  - C:\cache\rustsrc
   - "build/i686-pc-windows-msvc/llvm -> src/rustllvm/llvm-rebuild-trigger"
   - "build/x86_64-pc-windows-msvc/llvm -> src/rustllvm/llvm-rebuild-trigger"
   - "i686-pc-windows-msvc/llvm -> src/rustllvm/llvm-rebuild-trigger"

--- a/src/ci/init_repo.sh
+++ b/src/ci/init_repo.sh
@@ -38,9 +38,20 @@ fi
 
 # Wipe the cache if it's not valid, or mark it as invalid while we update it
 if [ ! -f "$cache_valid_file" ]; then
-    rm -rf "$CACHE_DIR" && mkdir "$CACHE_DIR"
+    rm -rf "$CACHE_DIR"
+    mkdir "$CACHE_DIR"
 else
-    rm "$cache_valid_file"
+    stat_lines=$(cd "$cache_src_dir" && git status --porcelain | wc -l)
+    stat_ec=$(cd "$cache_src_dir" && git status >/dev/null 2>&1 && echo $?)
+    if [ ! -d "$cache_src_dir/.git" -o $stat_lines != 0 -o $stat_ec != 0 ]; then
+        # Something is badly wrong - the cache valid file is here, but something
+        # about the git repo is fishy. Nuke it all, just in case
+        echo "WARNING: $cache_valid_file exists but bad repo: l:$stat_lines, ec:$stat_ec"
+        rm -rf "$CACHE_DIR"
+        mkdir "$CACHE_DIR"
+    else
+        rm "$cache_valid_file"
+    fi
 fi
 
 # Update the cache (a pristine copy of the rust source master)


### PR DESCRIPTION
After breaking the queue last time, I'm cautiously back with a PR to re-enable caching on appveyor.

If you look at https://ci.appveyor.com/project/rust-lang/rust/build/1.0.2623/job/46o90by4ari6gege (one of the multiple runs that failed), there are actually two errors - one for restoring the cache, one right at the bottom for creating a directory. I only noticed the restore error at the time as I was a bit rushed to revert and didn't stop to wonder why it continued - turns out appveyor [does not abort on cache restore failure](https://github.com/appveyor/ci/issues/723).

Turns out the cause of the build failures was the cache directory existing and me being thinking that because mkdir on windows is [recursive by default](http://stackoverflow.com/a/905239/2352259), it ignores the error if the directory already exists. Apparently this is not true, so now it checks if the directory exists before attempting to create.

In addition, I've added some more paranoia to double check everything is sane.