### PR TITLE
Use proper span for tuple index parsed as float

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2498,10 +2498,10 @@ impl<'a> Parser<'a> {
                   }
                   token::Literal(token::Float(n), _suf) => {
                     self.bump();
-                    let prev_span = self.prev_span;
                     let fstr = n.as_str();
-                    let mut err = self.diagnostic().struct_span_err(prev_span,
+                    let mut err = self.diagnostic().struct_span_err(self.prev_span,
                         &format!("unexpected token: `{}`", n));
+                    err.span_label(self.prev_span, &"unexpected token");
                     if fstr.chars().all(|x| "0123456789.".contains(x)) {
                         let float = match fstr.parse::<f64>().ok() {
                             Some(f) => f,
@@ -2519,7 +2519,7 @@ impl<'a> Parser<'a> {
                             word(&mut s.s, fstr.splitn(2, ".").last().unwrap())
                         });
                         err.span_suggestion(
-                            prev_span,
+                            lo.to(self.prev_span),
                             "try parenthesizing the first index",
                             sugg);
                     }

--- a/src/test/ui/suggestions/tuple-float-index.rs
+++ b/src/test/ui/suggestions/tuple-float-index.rs
@@ -11,7 +11,5 @@
 // compile-flags: -Z parse-only
 
 fn main () {
-    (1, (2, 3)).1.1; //~ ERROR unexpected token
-                     //~^ HELP try parenthesizing the first index
-                     //~| SUGGESTION ((1, (2, 3)).1).1
+    (1, (2, 3)).1.1;
 }

--- a/src/test/ui/suggestions/tuple-float-index.stderr
+++ b/src/test/ui/suggestions/tuple-float-index.stderr
@@ -1,0 +1,11 @@
+error: unexpected token: `1.1`
+  --> $DIR/tuple-float-index.rs:14:17
+   |
+14 |     (1, (2, 3)).1.1;
+   |                 ^^^ unexpected token
+   |
+help: try parenthesizing the first index
+   |     ((1, (2, 3)).1).1;
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fix diagnostic suggestion from:

```rust
help: try parenthesizing the first index
  |     (1, (2, 3)).((1, (2, 3)).1).1;
```

to the correct:

```rust
help: try parenthesizing the first index
  |     ((1, (2, 3)).1).1;
```

Fix #41081.