### PR TITLE
travis: Use upstream LLVM repositories for Fuchsia

### DIFF
--- a/src/ci/docker/dist-fuchsia/Dockerfile
+++ b/src/ci/docker/dist-fuchsia/Dockerfile
@@ -14,13 +14,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   xz-utils \
   swig \
   libedit-dev \
-  libncurses5-dev
+  libncurses5-dev \
+  patch
 
 RUN curl -L https://cmake.org/files/v3.8/cmake-3.8.0-rc1-Linux-x86_64.tar.gz | \
       tar xzf - -C /usr/local --strip-components=1
 
 WORKDIR /tmp
-COPY shared.sh build-toolchain.sh /tmp/
+COPY shared.sh build-toolchain.sh compiler-rt-dso-handle.patch /tmp/
 RUN /tmp/build-toolchain.sh
 
 RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \

--- a/src/ci/docker/dist-fuchsia/build-toolchain.sh
+++ b/src/ci/docker/dist-fuchsia/build-toolchain.sh
@@ -9,32 +9,42 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+# ignore-tidy-linelength
+
 set -ex
 source shared.sh
 
 # Download sources
 SRCS=(
-  "https://fuchsia.googlesource.com/magenta magenta ac69119"
-  "https://fuchsia.googlesource.com/third_party/llvm llvm 5463083"
-  "https://fuchsia.googlesource.com/third_party/clang llvm/tools/clang 4ff7b4b"
-  "https://fuchsia.googlesource.com/third_party/lld llvm/tools/lld fd465a3"
-  "https://fuchsia.googlesource.com/third_party/lldb llvm/tools/lldb 6bb11f8"
-  "https://fuchsia.googlesource.com/third_party/compiler-rt llvm/runtimes/compiler-rt 52d4ecc"
-  "https://fuchsia.googlesource.com/third_party/libcxx llvm/runtimes/libcxx e891cc8"
-  "https://fuchsia.googlesource.com/third_party/libcxxabi llvm/runtimes/libcxxabi f0f0257"
-  "https://fuchsia.googlesource.com/third_party/libunwind llvm/runtimes/libunwind 50bddc1"
+  "https://fuchsia.googlesource.com/magenta magenta d17073dc8de344ead3b65e8cc6a12280dec38c84"
+  "https://llvm.googlesource.com/llvm llvm 3f58a16d8eec385e2b3ebdfbb84ff9d3bf27e025"
+  "https://llvm.googlesource.com/clang llvm/tools/clang 727ea63e6e82677f6e10e05e08bc7d6bdbae3111"
+  "https://llvm.googlesource.com/lld llvm/tools/lld a31286c1366e5e89b8872803fded13805a1a084b"
+  "https://llvm.googlesource.com/lldb llvm/tools/lldb 0b2384abec4cb99ad66687712e07dee4dd9d187e"
+  "https://llvm.googlesource.com/compiler-rt llvm/runtimes/compiler-rt 9093a35c599fe41278606a20b51095ea8bd5a081"
+  "https://llvm.googlesource.com/libcxx llvm/runtimes/libcxx 607e0c71ec4f7fd377ad3f6c47b08dbe89f66eaa"
+  "https://llvm.googlesource.com/libcxxabi llvm/runtimes/libcxxabi 0a3a1a8a5ca5ef69e0f6b7d5b9d13e63e6fd2c19"
+  "https://llvm.googlesource.com/libunwind llvm/runtimes/libunwind e128003563d99d9ee62247c4cee40f07d21c03e3"
 )
 
 fetch() {
   mkdir -p $2
   pushd $2 > /dev/null
-  curl -sL $1/+archive/$3.tar.gz | tar xzf -
+  git init
+  git remote add origin $1
+  git fetch --depth=1 origin $3
+  git reset --hard FETCH_HEAD
   popd > /dev/null
 }
 
 for i in "${SRCS[@]}"; do
   fetch $i
 done
+
+# Remove this once https://reviews.llvm.org/D28791 is resolved
+cd llvm/runtimes/compiler-rt
+patch -Np1 < /tmp/compiler-rt-dso-handle.patch
+cd ../../..
 
 # Build toolchain
 cd llvm

--- a/src/ci/docker/dist-fuchsia/compiler-rt-dso-handle.patch
+++ b/src/ci/docker/dist-fuchsia/compiler-rt-dso-handle.patch
@@ -1,0 +1,41 @@
+diff --git a/lib/builtins/CMakeLists.txt b/lib/builtins/CMakeLists.txt
+index fc4384af2..b442264c0 100644
+--- a/lib/builtins/CMakeLists.txt
++++ b/lib/builtins/CMakeLists.txt
+@@ -194,6 +194,12 @@ if(APPLE)
+     atomic_thread_fence.c)
+ endif()
+ 
++if(FUCHSIA)
++  set(GENERIC_SOURCES
++    ${GENERIC_SOURCES}
++    dso_handle.c)
++endif()
++
+ if(NOT WIN32 OR MINGW)
+   set(GENERIC_SOURCES
+       ${GENERIC_SOURCES}
+diff --git a/lib/builtins/dso_handle.c b/lib/builtins/dso_handle.c
+new file mode 100644
+index 000000000..7766cd0aa
+--- /dev/null
++++ b/lib/builtins/dso_handle.c
+@@ -0,0 +1,18 @@
++/* ===-- dso_handle.c - Provide __dso_handle -------------------------------===
++ *
++ *               The LLVM Compiler Infrastructure
++ *
++ * This file is dual licensed under the MIT and the University of Illinois Open
++ * Source Licenses. See LICENSE.TXT for details.
++ *
++ * ===----------------------------------------------------------------------===
++ */
++
++/* __dso_handle symbol is mandated by C++ ABI with a value which is an address
++ * in one of the object's segments, and as such this symbol has to be included
++ * statically and cannot be a part of a shared library. Traditionally, it has
++ * been defined in crtbegin.o but there's no principled reason for it to be
++ * there. We defined this symbol in the builtin library which is built as a
++ * static library and always included in the final link.
++ */
++__attribute__((visibility("hidden"))) void *const __dso_handle;


### PR DESCRIPTION
The Fuchsia copies of LLVM repositories contain additional patches
for work-in-progress features and there is some amount of churn that
may break Rust. Use upstream LLVM repositories instead for building
the toolchain used by the Fuchsia builder.