### PR TITLE
rustdoc: collapse docblock before showing label

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -951,14 +951,21 @@
         if (relatedDoc.is(".docblock")) {
             if (relatedDoc.is(":visible")) {
                 if (animate === true) {
-                    relatedDoc.slideUp({duration: 'fast', easing: 'linear'});
-                    toggle.children(".toggle-label").fadeIn();
+                    relatedDoc.slideUp({
+                        duration: 'fast',
+                        easing: 'linear',
+                        complete: function() {
+                            toggle.children(".toggle-label").fadeIn();
+                            toggle.parent(".toggle-wrapper").addClass("collapsed");
+                            toggle.children(".inner").text(labelForToggleButton(true));
+                        },
+                    });
                 } else {
                     relatedDoc.hide();
                     toggle.children(".toggle-label").show();
+                    toggle.parent(".toggle-wrapper").addClass("collapsed");
+                    toggle.children(".inner").text(labelForToggleButton(true));
                 }
-                toggle.parent(".toggle-wrapper").addClass("collapsed");
-                toggle.children(".inner").text(labelForToggleButton(true));
             } else {
                 relatedDoc.slideDown({duration: 'fast', easing: 'linear'});
                 toggle.parent(".toggle-wrapper").removeClass("collapsed");


### PR DESCRIPTION
The animation for collapsing descriptions is currently pretty jarring, as the label starts fading in as the description is collapsing. This causes the description to jump down a line (and sometimes change indentation) while animating.

This PR modifies this behavior to collapse the block entirely before starting to fade in the collapse button label.

While this PR works well for descriptions of structs, traits, etc., it still does not look ideal for attributes. I'd appreciate any suggestions for improving that animation. Perhaps we want to optimize for the single-attribute case, and try not to collapse the attribute list entirely before fading in the label?