### PR TITLE
ci: test cross compiling core for the thumb targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
     - env: IMAGE=emscripten
     - env: IMAGE=i686-gnu
     - env: IMAGE=i686-gnu-nopt
+    - env: IMAGE=thumb
     - env: IMAGE=x86_64-gnu
     - env: IMAGE=x86_64-gnu-full-bootstrap
     - env: IMAGE=x86_64-gnu-aux

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -29,6 +29,18 @@ use channel::GitInfo;
 use util::{exe, libdir, is_dylib, copy};
 use {Build, Compiler, Mode};
 
+pub fn core(build: &Build, target: &str, compiler: &Compiler) {
+    println!("Building stage{} core artifacts ({} -> {})", compiler.stage,
+             compiler.host, target);
+
+    let mut cargo = build.cargo(compiler, Mode::Libstd, target, "build");
+
+    cargo.arg("--manifest-path")
+        .arg(build.src.join("src/libcore/Cargo.toml"));
+
+    build.run(&mut cargo);
+}
+
 /// Build the standard library.
 ///
 /// This will build the standard library for a particular stage of the build

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -123,7 +123,8 @@ pub fn check(build: &mut Build) {
         // On emscripten we don't actually need the C compiler to just
         // build the target artifacts, only for testing. For the sake
         // of easier bot configuration, just skip detection.
-        if target.contains("emscripten") {
+        // Likewise with the thumbv*m-none-eabi* targets
+        if target.contains("emscripten") || target.starts_with("thumbv") {
             continue;
         }
 

--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -264,6 +264,12 @@ pub fn build_rules<'a>(build: &'a Build) -> Rules {
         .dep(|s| s.name("libtest-link"));
 
     for (krate, path, _default) in krates("std") {
+        if krate.name == "core" {
+            rules.build("build-crate-core", "src/libcore")
+                .dep(move |s| s.name("rustc").host(&build.config.build).target(s.host))
+                .run(move |s| compile::core(build, s.target, &s.compiler()));
+            continue;
+        }
         rules.build(&krate.build_step, path)
              .dep(|s| s.name("startup-objects"))
              .dep(move |s| s.name("rustc").host(&build.config.build).target(s.host))

--- a/src/ci/docker/thumb/Dockerfile
+++ b/src/ci/docker/thumb/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  g++ \
+  make \
+  file \
+  curl \
+  ca-certificates \
+  python2.7 \
+  git \
+  cmake \
+  sudo \
+  gdb \
+  xz-utils
+
+RUN curl -o /usr/local/bin/sccache \
+      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-04-04-sccache-x86_64-unknown-linux-musl && \
+      chmod +x /usr/local/bin/sccache
+
+RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
+    dpkg -i dumb-init_*.deb && \
+    rm dumb-init_*.deb
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
+ENV TARGETS=thumbv6m-none-eabi
+ENV TARGETS=$TARGETS,thumbv7m-none-eabi
+ENV TARGETS=$TARGETS,thumbv7em-none-eabi
+ENV TARGETS=$TARGETS,thumbv7em-none-eabihf
+
+ENV RUST_CONFIGURE_ARGS \
+    --target=$TARGETS
+ENV SCRIPT python2.7 ../x.py build --target $TARGETS src/libcore


### PR DESCRIPTION
this commit adds a new path, src/libcore, to bootstrap that (cross) compiles
only the core crate for the target, and a thumb image that will test cross
compiling core for the 4 existing thumb targets.

closes #38828

r? @alexcrichton

I'm not sure if the .travis.yml changes are correct / enough but
`./src/ci/docker/run.sh thumb` does the core cross compilation test