### PR TITLE
Always show end line of multiline annotations

### DIFF
--- a/src/librustc_errors/snippet.rs
+++ b/src/librustc_errors/snippet.rs
@@ -97,9 +97,6 @@ pub enum AnnotationType {
     /// Annotation under a single line of code
     Singleline,
 
-    /// Annotation under the first character of a multiline span
-    Minimized,
-
     /// Annotation enclosing the first and last character of a multiline span
     Multiline(MultilineAnnotation),
 
@@ -118,6 +115,9 @@ pub enum AnnotationType {
     /// Annotation marking the last character of a fully shown multiline span
     MultilineEnd(usize),
     /// Line at the left enclosing the lines of a fully shown multiline span
+    // Just a placeholder for the drawing algorithm, to know that it shouldn't skip the first 4
+    // and last 2 lines of code. The actual line is drawn in `emit_message_default` and not in
+    // `draw_multiline_line`.
     MultilineLine(usize),
 }
 
@@ -144,13 +144,6 @@ pub struct Annotation {
 }
 
 impl Annotation {
-    pub fn is_minimized(&self) -> bool {
-        match self.annotation_type {
-            AnnotationType::Minimized => true,
-            _ => false,
-        }
-    }
-
     /// Wether this annotation is a vertical line placeholder.
     pub fn is_line(&self) -> bool {
         if let AnnotationType::MultilineLine(_) = self.annotation_type {

--- a/src/libsyntax/test_snippet.rs
+++ b/src/libsyntax/test_snippet.rs
@@ -932,3 +932,137 @@ error: foo
 
 "#);
 }
+
+#[test]
+fn long_snippet() {
+    test_harness(r#"
+fn foo() {
+  X0 Y0 Z0
+  X1 Y1 Z1
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+  X2 Y2 Z2
+  X3 Y3 Z3
+}
+"#,
+    vec![
+        SpanLabel {
+            start: Position {
+                string: "Y0",
+                count: 1,
+            },
+            end: Position {
+                string: "X1",
+                count: 1,
+            },
+            label: "`X` is a good letter",
+        },
+        SpanLabel {
+            start: Position {
+                string: "Z1",
+                count: 1,
+            },
+            end: Position {
+                string: "Z3",
+                count: 1,
+            },
+            label: "`Y` is a good letter too",
+        },
+    ],
+    r#"
+error: foo
+  --> test.rs:3:6
+   |
+3  |      X0 Y0 Z0
+   |   ______^ starting here...
+4  |  |   X1 Y1 Z1
+   |  |____^____- starting here...
+   | ||____|
+   | |     ...ending here: `X` is a good letter
+5  | |  1
+6  | |  2
+7  | |  3
+...  |
+15 | |    X2 Y2 Z2
+16 | |    X3 Y3 Z3
+   | |___________- ...ending here: `Y` is a good letter too
+
+"#);
+}
+
+#[test]
+fn long_snippet_multiple_spans() {
+    test_harness(r#"
+fn foo() {
+  X0 Y0 Z0
+1
+2
+3
+  X1 Y1 Z1
+4
+5
+6
+  X2 Y2 Z2
+7
+8
+9
+10
+  X3 Y3 Z3
+}
+"#,
+    vec![
+        SpanLabel {
+            start: Position {
+                string: "Y0",
+                count: 1,
+            },
+            end: Position {
+                string: "Y3",
+                count: 1,
+            },
+            label: "`Y` is a good letter",
+        },
+        SpanLabel {
+            start: Position {
+                string: "Z1",
+                count: 1,
+            },
+            end: Position {
+                string: "Z2",
+                count: 1,
+            },
+            label: "`Z` is a good letter too",
+        },
+    ],
+    r#"
+error: foo
+  --> test.rs:3:6
+   |
+3  |      X0 Y0 Z0
+   |   ______^ starting here...
+4  |  | 1
+5  |  | 2
+6  |  | 3
+7  |  |   X1 Y1 Z1
+   |  |_________- starting here...
+8  | || 4
+9  | || 5
+10 | || 6
+11 | ||   X2 Y2 Z2
+   | ||__________- ...ending here: `Z` is a good letter too
+...   |
+15 |  | 10
+16 |  |   X3 Y3 Z3
+   |  |_______^ ...ending here: `Y` is a good letter
+
+"#);
+}
+

--- a/src/test/ui/span/impl-wrong-item-for-trait.stderr
+++ b/src/test/ui/span/impl-wrong-item-for-trait.stderr
@@ -24,8 +24,7 @@ error[E0046]: not all trait items implemented, missing: `bar`
 23 | |     //~^ ERROR E0046
 24 | |     //~| NOTE missing `bar` in implementation
 25 | |     const bar: u64 = 1;
-26 | |     //~^ ERROR E0323
-27 | |     //~| NOTE does not match trait
+...  |
 28 | |     const MY_CONST: u32 = 1;
 29 | | }
    | |_^ ...ending here: missing `bar` in implementation
@@ -50,8 +49,7 @@ error[E0046]: not all trait items implemented, missing: `MY_CONST`
 34 | |     //~^ ERROR E0046
 35 | |     //~| NOTE missing `MY_CONST` in implementation
 36 | |     fn bar(&self) {}
-37 | |     fn MY_CONST() {}
-38 | |     //~^ ERROR E0324
+...  |
 39 | |     //~| NOTE does not match trait
 40 | | }
    | |_^ ...ending here: missing `MY_CONST` in implementation
@@ -76,8 +74,7 @@ error[E0046]: not all trait items implemented, missing: `bar`
 45 | |     //~^ ERROR E0046
 46 | |     //~| NOTE missing `bar` in implementation
 47 | |     type bar = u64;
-48 | |     //~^ ERROR E0325
-49 | |     //~| NOTE does not match trait
+...  |
 50 | |     const MY_CONST: u32 = 1;
 51 | | }
    | |_^ ...ending here: missing `bar` in implementation

--- a/src/test/ui/span/issue-23729.stderr
+++ b/src/test/ui/span/issue-23729.stderr
@@ -1,8 +1,15 @@
 error[E0046]: not all trait items implemented, missing: `Item`
   --> $DIR/issue-23729.rs:20:9
    |
-20 |         impl Iterator for Recurrence {
-   |         ^ missing `Item` in implementation
+20 |           impl Iterator for Recurrence {
+   |  _________^ starting here...
+21 | |             //~^ ERROR E0046
+22 | |             //~| NOTE missing `Item` in implementation
+23 | |             //~| NOTE `Item` from trait: `type Item;`
+...  |
+36 | |             }
+37 | |         }
+   | |_________^ ...ending here: missing `Item` in implementation
    |
    = note: `Item` from trait: `type Item;`
 

--- a/src/test/ui/span/issue-23827.stderr
+++ b/src/test/ui/span/issue-23827.stderr
@@ -6,8 +6,7 @@ error[E0046]: not all trait items implemented, missing: `Output`
 37 | |     //~^ ERROR E0046
 38 | |     //~| NOTE missing `Output` in implementation
 39 | |     //~| NOTE `Output` from trait: `type Output;`
-40 | |     extern "rust-call" fn call_once(self, (comp,): (C,)) -> Prototype {
-41 | |         Fn::call(&self, (comp,))
+...  |
 42 | |     }
 43 | | }
    | |_^ ...ending here: missing `Output` in implementation


### PR DESCRIPTION
```rust
error[E0046]: not all trait items implemented, missing: `Item`
  --> $DIR/issue-23729.rs:20:9
   |
20 |           impl Iterator for Recurrence {
   |  _________^ starting here...
21 | |             //~^ ERROR E0046
22 | |             //~| NOTE missing `Item` in implementation
23 | |             //~| NOTE `Item` from trait: `type Item;`
...  |
36 | |             }
37 | |         }
   | |_________^ ...ending here: missing `Item` in implementation
   |
   = note: `Item` from trait: `type Item;`
```

instead of

```rust
error[E0046]: not all trait items implemented, missing: `Item`
  --> $DIR/issue-23729.rs:20:9
   |
20 |         impl Iterator for Recurrence {
   |         ^ missing `Item` in implementation
   |
   = note: `Item` from trait: `type Item;`
```