### PR TITLE
Add a comment for disabling errexit, try to debug appveyor cache

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -148,8 +148,7 @@ test_script:
   - sh src/ci/run.sh
 
 on_failure:
-  - cat %CD%\sccache.log
-  - cat C:\Users\appveyor\AppData\Local\Temp\1\build-cache-logs\*.log
+  - cat %CD%\sccache.log || exit 0
 
 cache:
   - C:\cache\rustsrc

--- a/src/ci/init_repo.sh
+++ b/src/ci/init_repo.sh
@@ -41,6 +41,8 @@ if [ ! -f "$cache_valid_file" ]; then
     rm -rf "$CACHE_DIR"
     mkdir "$CACHE_DIR"
 else
+    # Ignore errors while gathering information about the possible brokenness
+    # of the git repo since our gathered info will tell us something is wrong
     set +o errexit
     stat_lines=$(cd "$cache_src_dir" && git status --porcelain | wc -l)
     stat_ec=$(cd "$cache_src_dir" && git status >/dev/null 2>&1; echo $?)


### PR DESCRIPTION
Comments added as requested.

Also, lets add some cache debugging to appveyor. I *think* this is how to ignore errors in cmd.exe (and I did try it on my own machine), but I'm not 100% sure how appveyor runs them. In the worst case it'll fail but I guess that isn't the end of the world since the build has already failed by this point.

r? @TimNN 