### PR TITLE
[RFC] Alternative approach to retries in CI

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -84,7 +84,7 @@ def _download(path, url, probably_big, verbose, exception):
             option = "-#"
         else:
             option = "-s"
-        run(["curl", option, "--retry", "3", "-Sf", "-o", path, url],
+        run(["curl", option, "-Sf", "-o", path, url],
             verbose=verbose,
             exception=exception)
 

--- a/src/ci/retryify.sh
+++ b/src/ci/retryify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+set -e
+
+EXECUTABLES=("clang" "cc" "curl" "git")
+WRAPPER_PATH=`mktemp -d`
+export PATH=$WRAPPER_PATH:$PATH
+
+for i in "${EXECUTABLES[@]}"
+do
+
+FILE=$WRAPPER_PATH/$i
+tee $FILE <<TEMPLATE > /dev/null
+#!/usr/bin/env bash
+WP='$WRAPPER_PATH'
+PATH=\${PATH//":\$WP:"/":"} # delete any instances in the middle
+PATH=\${PATH/#"\$WP:"/} # delete any instance at the beginning
+PATH=\${PATH/%":\$WP"/} # delete any instance in the at the end
+export PATH
+for iter in 1 2 3
+do
+    $i \$@ && break
+done
+TEMPLATE
+
+chmod +x $FILE
+
+done
+
+echo "export PATH=$PATH"

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -21,6 +21,7 @@ if [ "$NO_CHANGE_USER" = "" ]; then
 fi
 
 ci_dir=`cd $(dirname $0) && pwd`
+source "$ci_dir/retryify.sh"
 source "$ci_dir/shared.sh"
 
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-sccache"

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -769,38 +769,7 @@ fn link_natively(sess: &Session,
     // with some thread pool working in the background. It seems that no one
     // currently knows a fix for this so in the meantime we're left with this...
     info!("{:?}", &cmd);
-    let retry_on_segfault = env::var("RUSTC_RETRY_LINKER_ON_SEGFAULT").is_ok();
-    let mut prog;
-    let mut i = 0;
-    loop {
-        i += 1;
-        prog = time(sess.time_passes(), "running linker", || cmd.output());
-        if !retry_on_segfault || i > 3 {
-            break
-        }
-        let output = match prog {
-            Ok(ref output) => output,
-            Err(_) => break,
-        };
-        if output.status.success() {
-            break
-        }
-        let mut out = output.stderr.clone();
-        out.extend(&output.stdout);
-        let out = String::from_utf8_lossy(&out);
-        let msg = "clang: error: unable to execute command: \
-                   Segmentation fault: 11";
-        if !out.contains(msg) {
-            break
-        }
-
-        sess.struct_warn("looks like the linker segfaulted when we tried to \
-                          call it, automatically retrying again")
-            .note(&format!("{:?}", cmd))
-            .note(&out)
-            .emit();
-    }
-
+    let prog = time(sess.time_passes(), "running linker", || cmd.output());
     match prog {
         Ok(prog) => {
             fn escape_string(s: &[u8]) -> String {


### PR DESCRIPTION
This introduces wrapper scripts which retry the binaries.  This makes it trivial
to add commands to retry in order to work-around the spurious failures related
to commands.

For example, failures related to sccache or artefact upload could be made less critical by retrying
sccache/s3 stuff with this approach.

cc @alexcrichton @aturon 