### PR TITLE
Use the existing path when removing the prefix fails

### DIFF
--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -137,7 +137,9 @@ pub fn build_rules<'a>(build: &'a Build) -> Rules {
         while let Some(krate) = list.pop() {
             let default = krate == name;
             let krate = &build.crates[krate];
-            let path = krate.path.strip_prefix(&build.src).unwrap();
+            let path = krate.path.strip_prefix(&build.src)
+                // This handles out of tree paths
+                .unwrap_or(&krate.path);
             ret.push((krate, path.to_str().unwrap(), default));
             for dep in krate.deps.iter() {
                 if visited.insert(dep) && dep != "build_helper" {


### PR DESCRIPTION
This allows the use of out-of-tree paths to be specified. I found this while trying to build with a modified version of `rls-data`, which is currently pointing to a version on crates.io.

cc @alexcrichton 

Also, it wasn't clear if I needed to add a test for this (or how). I didn't see any tests that took paths into consideration.