### PR TITLE
Point at only one char on `Span::next_point`

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -592,8 +592,10 @@ impl<'a> Parser<'a> {
             } else {
                 label_sp
             };
-            err.span_label(sp, &label_exp);
-            if !sp.source_equal(&self.span) {
+            if self.span.contains(sp) {
+                err.span_label(self.span, &label_exp);
+            } else {
+                err.span_label(sp, &label_exp);
                 err.span_label(self.span, &"unexpected token");
             }
             Err(err)

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -89,7 +89,7 @@ impl Span {
     /// Returns a new span representing the next character after the end-point of this span
     pub fn next_point(self) -> Span {
         let lo = cmp::max(self.hi.0, self.lo.0 + 1);
-        Span { lo: BytePos(lo), hi: BytePos(lo + 1), ..self }
+        Span { lo: BytePos(lo), hi: BytePos(lo), ..self }
     }
 
     /// Returns `self` if `self` is not the dummy span, and `other` otherwise.

--- a/src/test/ui/token/issue-41155.rs
+++ b/src/test/ui/token/issue-41155.rs
@@ -1,0 +1,13 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+impl S {
+    pub
+}

--- a/src/test/ui/token/issue-41155.stderr
+++ b/src/test/ui/token/issue-41155.stderr
@@ -1,0 +1,10 @@
+error: expected one of `(`, `const`, `default`, `extern`, `fn`, `type`, or `unsafe`, found `}`
+  --> $DIR/issue-41155.rs:13:1
+   |
+12 |     pub
+   |        - expected one of 7 possible tokens here
+13 | }
+   | ^ unexpected token
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Avoid pointing at two chars so the diagnostic output doesn't display a
multiline span when starting beyond a line end.

Fix #41155.

Instead of

```rust
error: expected one of `(`, `const`, `default`, `extern`, `fn`, `type`, or `unsafe`, found `}`
 --> <anon>:3:1
  |
1 |   impl S {	pub
  |  _____________- starting here...
2 | |     
  | |  ...ending here: expected one of 7 possible tokens here
3 |   }
  |   ^ unexpected token
```

show

```rust
error: expected one of `(`, `const`, `default`, `extern`, `fn`, `type`, or `unsafe`, found `}`
  --> <anon>:13:1
   |
12 |     pub
   |        - expected one of 7 possible tokens here
13 | }
   | ^ unexpected token
```