### PR TITLE
Add a missing error-return case.

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4744,8 +4744,8 @@ impl<'a> Parser<'a> {
             let lo = self.span;
             let pth = self.parse_path(PathStyle::Mod)?;
             let bang_err = self.expect(&token::Not);
-            if let Err(mut err) = err {
-                if let Err(mut bang_err) = bang_err {
+            match (err, bang_err) {
+                (Err(mut err), Err(mut bang_err)) => {
                     // Given this code `pub path(`, it seems like this is not setting the
                     // visibility of a macro invocation, but rather a mistyped method declaration.
                     // Create a diagnostic pointing out that `fn` is missing.
@@ -4758,11 +4758,13 @@ impl<'a> Parser<'a> {
                     //     pub  path(
                     //        ^^ `sp` below will point to this
                     let sp = prev_span.between(self.prev_span);
-                    err = self.diagnostic()
+                    let mut err = self.diagnostic()
                         .struct_span_err(sp, "missing `fn` for method declaration");
                     err.span_label(sp, &"missing `fn`");
+                    return Err(err);
                 }
-                return Err(err);
+                (Err(err), _) | (_, Err(err)) => return Err(err),
+                (_, _) => ()
             }
 
             // eat a matched-delimiter token tree:

--- a/src/test/compile-fail/issue-41161.rs
+++ b/src/test/compile-fail/issue-41161.rs
@@ -1,0 +1,12 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+impl X { not_a_macro_invocation }
+//~^ ERROR expected one of `!` or `::`, found `}`


### PR DESCRIPTION
Fixes #41161.
It was a little mistake in #40815.