### PR TITLE
COPYRIGHT: remove hoedown license

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -197,28 +197,6 @@ their own copyright notices and license terms:
     USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
     OF SUCH DAMAGE.
 
-* Hoedown, the markdown parser, under src/rt/hoedown, is
-  licensed as follows.
-
-    Copyright (c) 2008, Natacha Porté
-    Copyright (c) 2011, Vicent Martí
-    Copyright (c) 2013, Devin Torres and the Hoedown authors
-
-    Permission to use, copy, modify, and distribute this
-    software for any purpose with or without fee is hereby
-    granted, provided that the above copyright notice and
-    this permission notice appear in all copies.
-
-    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR
-    DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE
-    INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-    FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
-    SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR
-    ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA
-    OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
-    OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
-    CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
 * libbacktrace, under src/libbacktrace:
 
     Copyright (C) 2012-2014 Free Software Foundation, Inc.

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -82,11 +82,9 @@ fn filter_dirs(path: &Path) -> bool {
         "src/llvm",
         "src/libbacktrace",
         "src/compiler-rt",
-        "src/rt/hoedown",
         "src/rustllvm",
         "src/rust-installer",
         "src/liblibc",
-        "src/tools/cargo",
         "src/vendor",
     ];
     skip.iter().any(|p| path.ends_with(p))


### PR DESCRIPTION
Hoedown was removed in b96fef8411f

Also cleanup src/tools/tidy/src/main.rs