### PR TITLE
Make sccache a bit quieter

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -147,7 +147,7 @@ pub fn llvm(build: &Build, target: &str) {
     }
 
     if env::var_os("SCCACHE_ERROR_LOG").is_some() {
-        cfg.env("RUST_LOG", "sccache=debug");
+        cfg.env("RUST_LOG", "sccache=info");
     }
 
     // FIXME: we don't actually need to build all LLVM tools and all LLVM

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -38,7 +38,6 @@ if [ "$SCCACHE_BUCKET" != "" ]; then
     args="$args --env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
     args="$args --env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY"
     args="$args --env SCCACHE_ERROR_LOG=/tmp/sccache/sccache.log"
-    args="$args --env SCCACHE_LOG_LEVEL=debug"
     args="$args --volume $objdir/tmp:/tmp/sccache"
 else
     mkdir -p $HOME/.cache/sccache


### PR DESCRIPTION
...and remove the single mention of `SCCACHE_LOG_LEVEL` that would only take effect on Docker (i.e. Linux) builds since it had no effect anyway (because [`RUST_LOG` takes priority](https://github.com/mozilla/sccache/blob/ec10cdb2ddeb3dde9891bea1fa095e504a60a28a/src/main.rs#L124-L128)).

r? @frewsxcv 