### PR TITLE
replace `monomorphic-const-eval` with `discriminants`

### DIFF
--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -119,7 +119,7 @@ pub enum DepNode<D: Clone + Debug> {
     TypeckBodiesKrate,
     TypeckTables(D),
     UsedTraitImports(D),
-    MonomorphicConstEval(D),
+    Discriminants(D),
 
     // The set of impls for a given trait. Ultimately, it would be
     // nice to get more fine-grained here (e.g., to include a
@@ -278,7 +278,7 @@ impl<D: Clone + Debug> DepNode<D> {
             InherentImpls(ref d) => op(d).map(InherentImpls),
             TypeckTables(ref d) => op(d).map(TypeckTables),
             UsedTraitImports(ref d) => op(d).map(UsedTraitImports),
-            MonomorphicConstEval(ref d) => op(d).map(MonomorphicConstEval),
+            Discriminants(ref d) => op(d).map(Discriminants),
             TraitImpls(ref d) => op(d).map(TraitImpls),
             TraitItems(ref d) => op(d).map(TraitItems),
             ReprHints(ref d) => op(d).map(ReprHints),

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -1217,7 +1217,7 @@ impl<'a, 'gcx, 'tcx> Layout {
                     let (mut min, mut max, mut non_zero) = (i64::max_value(),
                                                             i64::min_value(),
                                                             true);
-                    for discr in def.discriminants(tcx) {
+                    for &discr in &def.discriminants(tcx)[..] {
                         let x = discr.to_u128_unchecked() as i64;
                         if x == 0 { non_zero = false; }
                         if x < min { min = x; }

--- a/src/librustc/ty/maps.rs
+++ b/src/librustc/ty/maps.rs
@@ -10,7 +10,7 @@
 
 use dep_graph::{DepGraph, DepNode, DepTrackingMap, DepTrackingMapConfig};
 use hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
-use middle::const_val::ConstVal;
+use middle::const_val::ConstInt;
 use middle::privacy::AccessLevels;
 use mir;
 use session::CompileResult;
@@ -439,9 +439,8 @@ define_maps! { <'tcx>
     /// (Defined only for LOCAL_CRATE)
     pub crate_inherent_impls_overlap_check: crate_inherent_impls_dep_node(CrateNum) -> (),
 
-    /// Results of evaluating monomorphic constants embedded in
-    /// other items, such as enum variant explicit discriminants.
-    pub monomorphic_const_eval: MonomorphicConstEval(DefId) -> Result<ConstVal<'tcx>, ()>,
+    /// Computes the final discriminant for each variant of an enum.
+    pub discriminants: Discriminants(DefId) -> Rc<Vec<ConstInt>>,
 
     /// Performs the privacy check and computes "access levels".
     pub privacy_access_levels: PrivacyAccessLevels(CrateNum) -> Rc<AccessLevels>,

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -76,6 +76,7 @@ provide! { <'tcx> tcx, def_id, cdata
         tcx.alloc_trait_def(cdata.get_trait_def(def_id.index))
     }
     adt_def => { cdata.get_adt_def(def_id.index, tcx) }
+    discriminants => { Rc::new(cdata.get_discriminants(def_id.index)) }
     adt_destructor => {
         let _ = cdata;
         tcx.calculate_dtor(def_id, &mut |_,_| Ok(()))

--- a/src/librustc_metadata/schema.rs
+++ b/src/librustc_metadata/schema.rs
@@ -14,7 +14,7 @@ use index;
 use rustc::hir;
 use rustc::hir::def::{self, CtorKind};
 use rustc::hir::def_id::{DefIndex, DefId};
-use rustc::middle::const_val::ConstVal;
+use rustc::middle::const_val::ConstInt;
 use rustc::middle::cstore::{DepKind, LinkagePreference, NativeLibrary};
 use rustc::middle::lang_items;
 use rustc::mir;
@@ -230,9 +230,9 @@ pub enum EntryKind<'tcx> {
     Type,
     Enum(ReprOptions),
     Field,
-    Variant(Lazy<VariantData<'tcx>>),
-    Struct(Lazy<VariantData<'tcx>>, ReprOptions),
-    Union(Lazy<VariantData<'tcx>>, ReprOptions),
+    Variant(Lazy<VariantData>),
+    Struct(Lazy<VariantData>, ReprOptions),
+    Union(Lazy<VariantData>, ReprOptions),
     Fn(Lazy<FnData>),
     ForeignFn(Lazy<FnData>),
     Mod(Lazy<ModData>),
@@ -263,10 +263,10 @@ pub struct FnData {
 }
 
 #[derive(RustcEncodable, RustcDecodable)]
-pub struct VariantData<'tcx> {
+pub struct VariantData {
     pub ctor_kind: CtorKind,
     pub discr: ty::VariantDiscr,
-    pub evaluated_discr: Option<ConstVal<'tcx>>,
+    pub evaluated_discr: ConstInt,
 
     /// If this is a struct's only variant, this
     /// is the index of the "struct ctor" item.

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -191,7 +191,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 let mut targets = Vec::with_capacity(used_variants + 1);
                 let mut values = Vec::with_capacity(used_variants);
                 let tcx = self.hir.tcx();
-                for (idx, discr) in adt_def.discriminants(tcx).enumerate() {
+                for (idx, &discr) in adt_def.discriminants(tcx).iter().enumerate() {
                     target_blocks.place_back() <- if variants.contains(idx) {
                         values.push(discr);
                         *(targets.place_back() <- self.cfg.start_new_block())

--- a/src/librustc_mir/util/elaborate_drops.rs
+++ b/src/librustc_mir/util/elaborate_drops.rs
@@ -384,7 +384,7 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
                 };
                 let mut otherwise = None;
                 let mut unwind_otherwise = None;
-                for (variant_index, discr) in adt.discriminants(self.tcx()).enumerate() {
+                for (variant_index, &discr) in adt.discriminants(self.tcx()).iter().enumerate() {
                     let subpath = self.elaborator.downcast_subpath(
                         self.path, variant_index);
                     if let Some(variant_path) = subpath {

--- a/src/librustc_trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/debuginfo/metadata.rs
@@ -1468,6 +1468,7 @@ fn prepare_enum_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
 
     let def = enum_type.ty_adt_def().unwrap();
     let enumerators_metadata: Vec<DIDescriptor> = def.discriminants(cx.tcx())
+        .iter()
         .zip(&def.variants)
         .map(|(discr, v)| {
             let token = v.name.as_str();

--- a/src/librustc_trans/disr.rs
+++ b/src/librustc_trans/disr.rs
@@ -8,40 +8,21 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use rustc::middle::const_val::ConstVal;
 use rustc::ty::{self, TyCtxt};
+use rustc::ty::util::IntTypeExt;
 use rustc_const_math::ConstInt;
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct Disr(pub u64);
 
 impl Disr {
-    pub fn for_variant(tcx: TyCtxt,
-                       def: &ty::AdtDef,
-                       variant_index: usize) -> Self {
-        let mut explicit_index = variant_index;
-        let mut explicit_value = Disr(0);
-        loop {
-            match def.variants[explicit_index].discr {
-                ty::VariantDiscr::Relative(0) => break,
-                ty::VariantDiscr::Relative(distance) => {
-                    explicit_index -= distance;
-                }
-                ty::VariantDiscr::Explicit(expr_did) => {
-                    match tcx.maps.monomorphic_const_eval.borrow()[&expr_did] {
-                        Ok(ConstVal::Integral(v)) => {
-                            explicit_value = Disr::from(v);
-                            break;
-                        }
-                        _ => {
-                            explicit_index -= 1;
-                        }
-                    }
-                }
-            }
-        }
-        let distance = variant_index - explicit_index;
-        explicit_value.wrapping_add(Disr::from(distance))
+    pub fn for_variant(tcx: TyCtxt, def: &ty::AdtDef, variant_index: usize) -> Self {
+        let v = if def.is_enum() {
+            def.discriminants(tcx)[variant_index]
+        } else {
+            def.repr.discr_type().initial_discriminant(tcx.global_tcx())
+        };
+        Disr::from(v)
     }
 
     pub fn wrapping_add(self, other: Self) -> Self {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1370,7 +1370,7 @@ pub fn check_enum<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     }
 
     let mut disr_vals: Vec<ConstInt> = Vec::new();
-    for (discr, v) in def.discriminants(tcx).zip(vs) {
+    for (&discr, v) in def.discriminants(tcx).iter().zip(vs) {
         // Check for duplicate discriminant values
         if let Some(i) = disr_vals.iter().position(|&x| x == discr) {
             let variant_i_node_id = tcx.hir.as_local_node_id(def.variants[i].did).unwrap();


### PR DESCRIPTION
This query applies to get an enum def-id and yields a vector of
discriminants.

Progress towards https://github.com/rust-lang/rust/issues/40614.

r? @eddyb 