### PR TITLE
Reduce visual clutter of multiline start when possible

### DIFF
--- a/src/librustc_errors/snippet.rs
+++ b/src/librustc_errors/snippet.rs
@@ -63,7 +63,7 @@ impl MultilineAnnotation {
             start_col: self.start_col,
             end_col: self.start_col + 1,
             is_primary: self.is_primary,
-            label: Some("starting here...".to_owned()),
+            label: None,
             annotation_type: AnnotationType::MultilineStart(self.depth)
         }
     }
@@ -73,10 +73,7 @@ impl MultilineAnnotation {
             start_col: self.end_col - 1,
             end_col: self.end_col,
             is_primary: self.is_primary,
-            label: match self.label {
-                Some(ref label) => Some(format!("...ending here: {}", label)),
-                None => Some("...ending here".to_owned()),
-            },
+            label: self.label.clone(),
             annotation_type: AnnotationType::MultilineEnd(self.depth)
         }
     }
@@ -106,9 +103,9 @@ pub enum AnnotationType {
     // Each of these corresponds to one part of the following diagram:
     //
     //     x |   foo(1 + bar(x,
-    //       |  _________^ starting here...           < MultilineStart
-    //     x | |             y),                      < MultilineLine
-    //       | |______________^ ...ending here: label < MultilineEnd
+    //       |  _________^              < MultilineStart
+    //     x | |             y),        < MultilineLine
+    //       | |______________^ label   < MultilineEnd
     //     x |       z);
     /// Annotation marking the first character of a fully shown multiline span
     MultilineStart(usize),
@@ -187,6 +184,15 @@ impl Annotation {
             label.len() > 0
         } else {
             false
+        }
+    }
+
+    pub fn takes_space(&self) -> bool {
+        // Multiline annotations always have to keep vertical space.
+        match self.annotation_type {
+            AnnotationType::MultilineStart(_) |
+            AnnotationType::MultilineEnd(_) => true,
+            _ => false,
         }
     }
 }

--- a/src/libsyntax/test_snippet.rs
+++ b/src/libsyntax/test_snippet.rs
@@ -128,9 +128,9 @@ error: foo
  --> test.rs:2:10
   |
 2 |   fn foo() {
-  |  __________^ starting here...
+  |  __________^
 3 | | }
-  | |_^ ...ending here: test
+  | |_^ test
 
 "#);
 }
@@ -161,11 +161,11 @@ error: foo
  --> test.rs:2:10
   |
 2 |   fn foo() {
-  |  __________^ starting here...
+  |  __________^
 3 | |
 4 | |
 5 | |   }
-  | |___^ ...ending here: test
+  | |___^ test
 
 "#);
 }
@@ -207,14 +207,14 @@ error: foo
  --> test.rs:3:3
   |
 3 |      X0 Y0
-  |  ____^__- starting here...
+  |  ____^__-
   | | ___|
-  | ||   starting here...
+  | ||
 4 | ||   X1 Y1
 5 | ||   X2 Y2
-  | ||____^__- ...ending here: `Y` is a good letter too
+  | ||____^__- `Y` is a good letter too
   |  |____|
-  |       ...ending here: `X` is a good letter
+  |       `X` is a good letter
 
 "#);
 }
@@ -256,13 +256,13 @@ error: foo
  --> test.rs:3:3
   |
 3 |      X0 Y0
-  |  ____^__- starting here...
+  |  ____^__-
   | | ___|
-  | ||   starting here...
+  | ||
 4 | ||   Y1 X1
-  | ||____-__^ ...ending here: `X` is a good letter
+  | ||____-__^ `X` is a good letter
   | |_____|
-  |       ...ending here: `Y` is a good letter too
+  |       `Y` is a good letter too
 
 "#);
 }
@@ -306,13 +306,13 @@ error: foo
  --> test.rs:3:6
   |
 3 |      X0 Y0 Z0
-  |   ______^ starting here...
+  |   ______^
 4 |  |   X1 Y1 Z1
-  |  |_________- starting here...
+  |  |_________-
 5 | ||   X2 Y2 Z2
-  | ||____^ ...ending here: `X` is a good letter
+  | ||____^ `X` is a good letter
 6 | |    X3 Y3 Z3
-  | |_____- ...ending here: `Y` is a good letter too
+  | |_____- `Y` is a good letter too
 
 "#);
 }
@@ -366,16 +366,16 @@ error: foo
  --> test.rs:3:3
   |
 3 |       X0 Y0 Z0
-  |  _____^__-__- starting here...
+  |  _____^__-__-
   | | ____|__|
-  | || ___|  starting here...
-  | |||   starting here...
+  | || ___|
+  | |||
 4 | |||   X1 Y1 Z1
 5 | |||   X2 Y2 Z2
-  | |||____^__-__- ...ending here: `Z` label
+  | |||____^__-__- `Z` label
   |  ||____|__|
-  |   |____|  ...ending here: `Y` is a good letter too
-  |        ...ending here: `X` is a good letter
+  |   |____|  `Y` is a good letter too
+  |        `X` is a good letter
 
 "#);
 }
@@ -430,17 +430,17 @@ error: foo
  --> test.rs:3:6
   |
 3 |      X0 Y0 Z0
-  |   ______^ starting here...
+  |   ______^
 4 |  |   X1 Y1 Z1
-  |  |____^_- starting here...
+  |  |____^_-
   | ||____|
-  | |     ...ending here: `X` is a good letter
+  | |     `X` is a good letter
 5 | |    X2 Y2 Z2
-  | |____-______- ...ending here: `Y` is a good letter too
+  | |____-______- `Y` is a good letter too
   |  ____|
-  | |    starting here...
+  | |
 6 | |    X3 Y3 Z3
-  | |________- ...ending here: `Z`
+  | |________- `Z`
 
 "#);
 }
@@ -458,7 +458,7 @@ fn foo() {
     vec![
         SpanLabel {
             start: Position {
-                string: "Y0",
+                string: "X0",
                 count: 1,
             },
             end: Position {
@@ -481,16 +481,15 @@ fn foo() {
     ],
     r#"
 error: foo
- --> test.rs:3:6
+ --> test.rs:3:3
   |
-3 |     X0 Y0 Z0
-  |  ______^ starting here...
+3 | /   X0 Y0 Z0
 4 | |   X1 Y1 Z1
-  | |____^ ...ending here: `X` is a good letter
+  | |____^ `X` is a good letter
 5 |     X2 Y2 Z2
-  |  ______- starting here...
+  |  ______-
 6 | |   X3 Y3 Z3
-  | |__________- ...ending here: `Y` is a good letter too
+  | |__________- `Y` is a good letter too
 
 "#);
 }
@@ -534,14 +533,14 @@ error: foo
  --> test.rs:3:6
   |
 3 |      X0 Y0 Z0
-  |   ______^ starting here...
+  |   ______^
 4 |  |   X1 Y1 Z1
-  |  |____^____- starting here...
+  |  |____^____-
   | ||____|
-  | |     ...ending here: `X` is a good letter
+  | |     `X` is a good letter
 5 | |    X2 Y2 Z2
 6 | |    X3 Y3 Z3
-  | |___________- ...ending here: `Y` is a good letter too
+  | |___________- `Y` is a good letter too
 
 "#);
 }
@@ -982,18 +981,18 @@ error: foo
   --> test.rs:3:6
    |
 3  |      X0 Y0 Z0
-   |   ______^ starting here...
+   |   ______^
 4  |  |   X1 Y1 Z1
-   |  |____^____- starting here...
+   |  |____^____-
    | ||____|
-   | |     ...ending here: `X` is a good letter
+   | |     `X` is a good letter
 5  | |  1
 6  | |  2
 7  | |  3
 ...  |
 15 | |    X2 Y2 Z2
 16 | |    X3 Y3 Z3
-   | |___________- ...ending here: `Y` is a good letter too
+   | |___________- `Y` is a good letter too
 
 "#);
 }
@@ -1047,21 +1046,21 @@ error: foo
   --> test.rs:3:6
    |
 3  |      X0 Y0 Z0
-   |   ______^ starting here...
+   |   ______^
 4  |  | 1
 5  |  | 2
 6  |  | 3
 7  |  |   X1 Y1 Z1
-   |  |_________- starting here...
+   |  |_________-
 8  | || 4
 9  | || 5
 10 | || 6
 11 | ||   X2 Y2 Z2
-   | ||__________- ...ending here: `Z` is a good letter too
+   | ||__________- `Z` is a good letter too
 ...   |
 15 |  | 10
 16 |  |   X3 Y3 Z3
-   |  |_______^ ...ending here: `Y` is a good letter
+   |  |_______^ `Y` is a good letter
 
 "#);
 }

--- a/src/test/ui/compare-method/region-extra-2.stderr
+++ b/src/test/ui/compare-method/region-extra-2.stderr
@@ -4,12 +4,11 @@ error[E0276]: impl has stricter requirements than trait
 15 |       fn renew<'b: 'a>(self) -> &'b mut [T];
    |       -------------------------------------- definition of `renew` from trait
 ...
-19 |       fn renew<'b: 'a>(self) -> &'b mut [T] where 'a: 'b {
-   |  _____^ starting here...
+19 | /     fn renew<'b: 'a>(self) -> &'b mut [T] where 'a: 'b {
 20 | |         //~^ ERROR E0276
 21 | |         &mut self[..]
 22 | |     }
-   | |_____^ ...ending here: impl has extra requirement `'a: 'b`
+   | |_____^ impl has extra requirement `'a: 'b`
 
 error: aborting due to previous error
 

--- a/src/test/ui/compare-method/traits-misc-mismatch-2.stderr
+++ b/src/test/ui/compare-method/traits-misc-mismatch-2.stderr
@@ -4,12 +4,11 @@ error[E0276]: impl has stricter requirements than trait
 19 |       fn zip<B, U: Iterator<U>>(self, other: U) -> ZipIterator<Self, U>;
    |       ------------------------------------------------------------------ definition of `zip` from trait
 ...
-23 |       fn zip<B, U: Iterator<B>>(self, other: U) -> ZipIterator<T, U> {
-   |  _____^ starting here...
+23 | /     fn zip<B, U: Iterator<B>>(self, other: U) -> ZipIterator<T, U> {
 24 | |     //~^ ERROR E0276
 25 | |         ZipIterator{a: self, b: other}
 26 | |     }
-   | |_____^ ...ending here: impl has extra requirement `U: Iterator<B>`
+   | |_____^ impl has extra requirement `U: Iterator<B>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/issue-40006.stderr
+++ b/src/test/ui/did_you_mean/issue-40006.stderr
@@ -2,17 +2,17 @@ error: missing `fn`, `type`, or `const` for impl-item declaration
   --> $DIR/issue-40006.rs:11:9
    |
 11 |   impl X {
-   |  _________^ starting here...
+   |  _________^
 12 | |     Y
-   | |____^ ...ending here: missing `fn`, `type`, or `const`
+   | |____^ missing `fn`, `type`, or `const`
 
 error: missing `fn`, `type`, or `const` for trait-item declaration
   --> $DIR/issue-40006.rs:17:10
    |
 17 |   trait X {
-   |  __________^ starting here...
+   |  __________^
 18 | |     X() {}
-   | |____^ ...ending here: missing `fn`, `type`, or `const`
+   | |____^ missing `fn`, `type`, or `const`
 
 error: expected `[`, found `#`
   --> $DIR/issue-40006.rs:19:17
@@ -24,17 +24,17 @@ error: missing `fn`, `type`, or `const` for trait-item declaration
   --> $DIR/issue-40006.rs:19:21
    |
 19 |       fn xxx() { ### }
-   |  _____________________^ starting here...
+   |  _____________________^
 20 | |     L = M;
-   | |____^ ...ending here: missing `fn`, `type`, or `const`
+   | |____^ missing `fn`, `type`, or `const`
 
 error: missing `fn`, `type`, or `const` for trait-item declaration
   --> $DIR/issue-40006.rs:20:11
    |
 20 |       L = M;
-   |  ___________^ starting here...
+   |  ___________^
 21 | |     Z = { 2 + 3 };
-   | |____^ ...ending here: missing `fn`, `type`, or `const`
+   | |____^ missing `fn`, `type`, or `const`
 
 error: expected one of `const`, `extern`, `fn`, `type`, `unsafe`, or `}`, found `;`
   --> $DIR/issue-40006.rs:21:18

--- a/src/test/ui/dropck/dropck-eyepatch-implies-unsafe-impl.stderr
+++ b/src/test/ui/dropck/dropck-eyepatch-implies-unsafe-impl.stderr
@@ -1,26 +1,24 @@
 error[E0569]: requires an `unsafe impl` declaration due to `#[may_dangle]` attribute
   --> $DIR/dropck-eyepatch-implies-unsafe-impl.rs:32:1
    |
-32 |   impl<#[may_dangle] A, B: fmt::Debug> Drop for Pt<A, B> {
-   |  _^ starting here...
+32 | / impl<#[may_dangle] A, B: fmt::Debug> Drop for Pt<A, B> {
 33 | |     //~^ ERROR requires an `unsafe impl` declaration due to `#[may_dangle]` attribute
 34 | |
 35 | |     // (unsafe to access self.1  due to #[may_dangle] on A)
 36 | |     fn drop(&mut self) { println!("drop {} {:?}", self.0, self.2); }
 37 | | }
-   | |_^ ...ending here
+   | |_^
 
 error[E0569]: requires an `unsafe impl` declaration due to `#[may_dangle]` attribute
   --> $DIR/dropck-eyepatch-implies-unsafe-impl.rs:38:1
    |
-38 |   impl<#[may_dangle] 'a, 'b, B: fmt::Debug> Drop for Pr<'a, 'b, B> {
-   |  _^ starting here...
+38 | / impl<#[may_dangle] 'a, 'b, B: fmt::Debug> Drop for Pr<'a, 'b, B> {
 39 | |     //~^ ERROR requires an `unsafe impl` declaration due to `#[may_dangle]` attribute
 40 | |
 41 | |     // (unsafe to access self.1 due to #[may_dangle] on 'a)
 42 | |     fn drop(&mut self) { println!("drop {} {:?}", self.0, self.2); }
 43 | | }
-   | |_^ ...ending here
+   | |_^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issue-37311-type-length-limit/issue-37311.stderr
+++ b/src/test/ui/issue-37311-type-length-limit/issue-37311.stderr
@@ -1,11 +1,10 @@
 error: reached the type-length limit while instantiating `<T as Foo><(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(), &()), &(&()...`
   --> $DIR/issue-37311.rs:23:5
    |
-23 |       fn recurse(&self) {
-   |  _____^ starting here...
+23 | /     fn recurse(&self) {
 24 | |         (self, self).recurse();
 25 | |     }
-   | |_____^ ...ending here
+   | |_____^
    |
    = note: consider adding a `#![type_length_limit="2097152"]` attribute to your crate
 

--- a/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else.stderr
+++ b/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else.stderr
@@ -8,18 +8,18 @@ note: ...the reference is valid for the lifetime 'a as defined on the body at 11
   --> $DIR/ex1-return-one-existing-name-if-else.rs:11:44
    |
 11 |   fn foo<'a>(x: &'a i32, y: &i32) -> &'a i32 {
-   |  ____________________________________________^ starting here...
+   |  ____________________________________________^
 12 | |     if x > y { x } else { y }
 13 | | }
-   | |_^ ...ending here
+   | |_^
 note: ...but the borrowed content is only valid for the anonymous lifetime #1 defined on the body at 11:43
   --> $DIR/ex1-return-one-existing-name-if-else.rs:11:44
    |
 11 |   fn foo<'a>(x: &'a i32, y: &i32) -> &'a i32 {
-   |  ____________________________________________^ starting here...
+   |  ____________________________________________^
 12 | |     if x > y { x } else { y }
 13 | | }
-   | |_^ ...ending here
+   | |_^
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex2a-push-one-existing-name.stderr
+++ b/src/test/ui/lifetime-errors/ex2a-push-one-existing-name.stderr
@@ -10,18 +10,18 @@ note: the anonymous lifetime #2 defined on the body at 15:51...
   --> $DIR/ex2a-push-one-existing-name.rs:15:52
    |
 15 |   fn foo<'a>(x: &mut Vec<Ref<'a, i32>>, y: Ref<i32>) {
-   |  ____________________________________________________^ starting here...
+   |  ____________________________________________________^
 16 | |     x.push(y);
 17 | | }
-   | |_^ ...ending here
+   | |_^
 note: ...does not necessarily outlive the lifetime 'a as defined on the body at 15:51
   --> $DIR/ex2a-push-one-existing-name.rs:15:52
    |
 15 |   fn foo<'a>(x: &mut Vec<Ref<'a, i32>>, y: Ref<i32>) {
-   |  ____________________________________________________^ starting here...
+   |  ____________________________________________________^
 16 | |     x.push(y);
 17 | | }
-   | |_^ ...ending here
+   | |_^
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex2b-push-no-existing-names.stderr
+++ b/src/test/ui/lifetime-errors/ex2b-push-no-existing-names.stderr
@@ -10,18 +10,18 @@ note: the anonymous lifetime #3 defined on the body at 15:43...
   --> $DIR/ex2b-push-no-existing-names.rs:15:44
    |
 15 |   fn foo(x: &mut Vec<Ref<i32>>, y: Ref<i32>) {
-   |  ____________________________________________^ starting here...
+   |  ____________________________________________^
 16 | |     x.push(y);
 17 | | }
-   | |_^ ...ending here
+   | |_^
 note: ...does not necessarily outlive the anonymous lifetime #2 defined on the body at 15:43
   --> $DIR/ex2b-push-no-existing-names.rs:15:44
    |
 15 |   fn foo(x: &mut Vec<Ref<i32>>, y: Ref<i32>) {
-   |  ____________________________________________^ starting here...
+   |  ____________________________________________^
 16 | |     x.push(y);
 17 | | }
-   | |_^ ...ending here
+   | |_^
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex2c-push-inference-variable.stderr
+++ b/src/test/ui/lifetime-errors/ex2c-push-inference-variable.stderr
@@ -8,11 +8,11 @@ note: first, the lifetime cannot outlive the lifetime 'c as defined on the body 
   --> $DIR/ex2c-push-inference-variable.rs:15:67
    |
 15 |   fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
-   |  ___________________________________________________________________^ starting here...
+   |  ___________________________________________________________________^
 16 | |     let z = Ref { data: y.data };
 17 | |     x.push(z);
 18 | | }
-   | |_^ ...ending here
+   | |_^
 note: ...so that reference does not outlive borrowed content
   --> $DIR/ex2c-push-inference-variable.rs:16:25
    |
@@ -22,11 +22,11 @@ note: but, the lifetime must be valid for the lifetime 'b as defined on the body
   --> $DIR/ex2c-push-inference-variable.rs:15:67
    |
 15 |   fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
-   |  ___________________________________________________________________^ starting here...
+   |  ___________________________________________________________________^
 16 | |     let z = Ref { data: y.data };
 17 | |     x.push(z);
 18 | | }
-   | |_^ ...ending here
+   | |_^
 note: ...so that expression is assignable (expected Ref<'b, _>, found Ref<'_, _>)
   --> $DIR/ex2c-push-inference-variable.rs:17:12
    |

--- a/src/test/ui/lifetime-errors/ex2d-push-inference-variable-2.stderr
+++ b/src/test/ui/lifetime-errors/ex2d-push-inference-variable-2.stderr
@@ -8,12 +8,12 @@ note: first, the lifetime cannot outlive the lifetime 'c as defined on the body 
   --> $DIR/ex2d-push-inference-variable-2.rs:15:67
    |
 15 |   fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
-   |  ___________________________________________________________________^ starting here...
+   |  ___________________________________________________________________^
 16 | |     let a: &mut Vec<Ref<i32>> = x;
 17 | |     let b = Ref { data: y.data };
 18 | |     a.push(b);
 19 | | }
-   | |_^ ...ending here
+   | |_^
 note: ...so that reference does not outlive borrowed content
   --> $DIR/ex2d-push-inference-variable-2.rs:17:25
    |
@@ -23,12 +23,12 @@ note: but, the lifetime must be valid for the lifetime 'b as defined on the body
   --> $DIR/ex2d-push-inference-variable-2.rs:15:67
    |
 15 |   fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
-   |  ___________________________________________________________________^ starting here...
+   |  ___________________________________________________________________^
 16 | |     let a: &mut Vec<Ref<i32>> = x;
 17 | |     let b = Ref { data: y.data };
 18 | |     a.push(b);
 19 | | }
-   | |_^ ...ending here
+   | |_^
 note: ...so that expression is assignable (expected &mut std::vec::Vec<Ref<'_, i32>>, found &mut std::vec::Vec<Ref<'b, i32>>)
   --> $DIR/ex2d-push-inference-variable-2.rs:16:33
    |

--- a/src/test/ui/lifetime-errors/ex2e-push-inference-variable-3.stderr
+++ b/src/test/ui/lifetime-errors/ex2e-push-inference-variable-3.stderr
@@ -8,12 +8,12 @@ note: first, the lifetime cannot outlive the lifetime 'c as defined on the body 
   --> $DIR/ex2e-push-inference-variable-3.rs:15:67
    |
 15 |   fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
-   |  ___________________________________________________________________^ starting here...
+   |  ___________________________________________________________________^
 16 | |     let a: &mut Vec<Ref<i32>> = x;
 17 | |     let b = Ref { data: y.data };
 18 | |     Vec::push(a, b);
 19 | | }
-   | |_^ ...ending here
+   | |_^
 note: ...so that reference does not outlive borrowed content
   --> $DIR/ex2e-push-inference-variable-3.rs:17:25
    |
@@ -23,12 +23,12 @@ note: but, the lifetime must be valid for the lifetime 'b as defined on the body
   --> $DIR/ex2e-push-inference-variable-3.rs:15:67
    |
 15 |   fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
-   |  ___________________________________________________________________^ starting here...
+   |  ___________________________________________________________________^
 16 | |     let a: &mut Vec<Ref<i32>> = x;
 17 | |     let b = Ref { data: y.data };
 18 | |     Vec::push(a, b);
 19 | | }
-   | |_^ ...ending here
+   | |_^
 note: ...so that expression is assignable (expected &mut std::vec::Vec<Ref<'_, i32>>, found &mut std::vec::Vec<Ref<'b, i32>>)
   --> $DIR/ex2e-push-inference-variable-3.rs:16:33
    |

--- a/src/test/ui/mismatched_types/abridged.stderr
+++ b/src/test/ui/mismatched_types/abridged.stderr
@@ -37,15 +37,14 @@ error[E0308]: mismatched types
 error[E0308]: mismatched types
   --> $DIR/abridged.rs:42:5
    |
-42 |       X {
-   |  _____^ starting here...
+42 | /     X {
 43 | |         x: X {
 44 | |             x: "".to_string(),
 45 | |             y: 2,
 46 | |         },
 47 | |         y: 3,
 48 | |     }
-   | |_____^ ...ending here: expected struct `std::string::String`, found integral variable
+   | |_____^ expected struct `std::string::String`, found integral variable
    |
    = note: expected type `X<X<_, std::string::String>, std::string::String>`
               found type `X<X<_, {integer}>, {integer}>`
@@ -53,15 +52,14 @@ error[E0308]: mismatched types
 error[E0308]: mismatched types
   --> $DIR/abridged.rs:52:5
    |
-52 |       X {
-   |  _____^ starting here...
+52 | /     X {
 53 | |         x: X {
 54 | |             x: "".to_string(),
 55 | |             y: 2,
 56 | |         },
 57 | |         y: "".to_string(),
 58 | |     }
-   | |_____^ ...ending here: expected struct `std::string::String`, found integral variable
+   | |_____^ expected struct `std::string::String`, found integral variable
    |
    = note: expected type `X<X<_, std::string::String>, _>`
               found type `X<X<_, {integer}>, _>`

--- a/src/test/ui/mismatched_types/main.stderr
+++ b/src/test/ui/mismatched_types/main.stderr
@@ -2,9 +2,9 @@ error[E0308]: mismatched types
   --> $DIR/main.rs:12:18
    |
 12 |       let x: u32 = (
-   |  __________________^ starting here...
+   |  __________________^
 13 | |     );
-   | |_____^ ...ending here: expected u32, found ()
+   | |_____^ expected u32, found ()
    |
    = note: expected type `u32`
               found type `()`

--- a/src/test/ui/missing-items/m2.stderr
+++ b/src/test/ui/missing-items/m2.stderr
@@ -3,10 +3,9 @@ error: main function not found
 error[E0046]: not all trait items implemented, missing: `CONSTANT`, `Type`, `method`
   --> $DIR/m2.rs:20:1
    |
-20 |   impl m1::X for X {
-   |  _^ starting here...
+20 | / impl m1::X for X {
 21 | | }
-   | |_^ ...ending here: missing `CONSTANT`, `Type`, `method` in implementation
+   | |_^ missing `CONSTANT`, `Type`, `method` in implementation
    |
    = note: `CONSTANT` from trait: `const CONSTANT: u32;`
    = note: `Type` from trait: `type Type;`

--- a/src/test/ui/span/impl-wrong-item-for-trait.stderr
+++ b/src/test/ui/span/impl-wrong-item-for-trait.stderr
@@ -19,15 +19,14 @@ error[E0046]: not all trait items implemented, missing: `bar`
 16 |       fn bar(&self);
    |       -------------- `bar` from trait
 ...
-22 |   impl Foo for FooConstForMethod {
-   |  _^ starting here...
+22 | / impl Foo for FooConstForMethod {
 23 | |     //~^ ERROR E0046
 24 | |     //~| NOTE missing `bar` in implementation
 25 | |     const bar: u64 = 1;
 ...  |
 28 | |     const MY_CONST: u32 = 1;
 29 | | }
-   | |_^ ...ending here: missing `bar` in implementation
+   | |_^ missing `bar` in implementation
 
 error[E0324]: item `MY_CONST` is an associated method, which doesn't match its trait `Foo`
   --> $DIR/impl-wrong-item-for-trait.rs:37:5
@@ -44,15 +43,14 @@ error[E0046]: not all trait items implemented, missing: `MY_CONST`
 17 |       const MY_CONST: u32;
    |       -------------------- `MY_CONST` from trait
 ...
-33 |   impl Foo for FooMethodForConst {
-   |  _^ starting here...
+33 | / impl Foo for FooMethodForConst {
 34 | |     //~^ ERROR E0046
 35 | |     //~| NOTE missing `MY_CONST` in implementation
 36 | |     fn bar(&self) {}
 ...  |
 39 | |     //~| NOTE does not match trait
 40 | | }
-   | |_^ ...ending here: missing `MY_CONST` in implementation
+   | |_^ missing `MY_CONST` in implementation
 
 error[E0325]: item `bar` is an associated type, which doesn't match its trait `Foo`
   --> $DIR/impl-wrong-item-for-trait.rs:47:5
@@ -69,23 +67,21 @@ error[E0046]: not all trait items implemented, missing: `bar`
 16 |       fn bar(&self);
    |       -------------- `bar` from trait
 ...
-44 |   impl Foo for FooTypeForMethod {
-   |  _^ starting here...
+44 | / impl Foo for FooTypeForMethod {
 45 | |     //~^ ERROR E0046
 46 | |     //~| NOTE missing `bar` in implementation
 47 | |     type bar = u64;
 ...  |
 50 | |     const MY_CONST: u32 = 1;
 51 | | }
-   | |_^ ...ending here: missing `bar` in implementation
+   | |_^ missing `bar` in implementation
 
 error[E0046]: not all trait items implemented, missing: `fmt`
   --> $DIR/impl-wrong-item-for-trait.rs:53:1
    |
-53 |   impl Debug for FooTypeForMethod {
-   |  _^ starting here...
+53 | / impl Debug for FooTypeForMethod {
 54 | | }
-   | |_^ ...ending here: missing `fmt` in implementation
+   | |_^ missing `fmt` in implementation
    |
    = note: `fmt` from trait: `fn(&Self, &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error>`
 

--- a/src/test/ui/span/issue-23729.stderr
+++ b/src/test/ui/span/issue-23729.stderr
@@ -1,15 +1,14 @@
 error[E0046]: not all trait items implemented, missing: `Item`
   --> $DIR/issue-23729.rs:20:9
    |
-20 |           impl Iterator for Recurrence {
-   |  _________^ starting here...
+20 | /         impl Iterator for Recurrence {
 21 | |             //~^ ERROR E0046
 22 | |             //~| NOTE missing `Item` in implementation
 23 | |             //~| NOTE `Item` from trait: `type Item;`
 ...  |
 36 | |             }
 37 | |         }
-   | |_________^ ...ending here: missing `Item` in implementation
+   | |_________^ missing `Item` in implementation
    |
    = note: `Item` from trait: `type Item;`
 

--- a/src/test/ui/span/issue-23827.stderr
+++ b/src/test/ui/span/issue-23827.stderr
@@ -1,15 +1,14 @@
 error[E0046]: not all trait items implemented, missing: `Output`
   --> $DIR/issue-23827.rs:36:1
    |
-36 |   impl<C: Component> FnOnce<(C,)> for Prototype {
-   |  _^ starting here...
+36 | / impl<C: Component> FnOnce<(C,)> for Prototype {
 37 | |     //~^ ERROR E0046
 38 | |     //~| NOTE missing `Output` in implementation
 39 | |     //~| NOTE `Output` from trait: `type Output;`
 ...  |
 42 | |     }
 43 | | }
-   | |_^ ...ending here: missing `Output` in implementation
+   | |_^ missing `Output` in implementation
    |
    = note: `Output` from trait: `type Output;`
 

--- a/src/test/ui/span/issue-24356.stderr
+++ b/src/test/ui/span/issue-24356.stderr
@@ -1,14 +1,13 @@
 error[E0046]: not all trait items implemented, missing: `Target`
   --> $DIR/issue-24356.rs:30:9
    |
-30 |           impl Deref for Thing {
-   |  _________^ starting here...
+30 | /         impl Deref for Thing {
 31 | |             //~^ ERROR E0046
 32 | |             //~| NOTE missing `Target` in implementation
 33 | |             //~| NOTE `Target` from trait: `type Target;`
 34 | |             fn deref(&self) -> i8 { self.0 }
 35 | |         }
-   | |_________^ ...ending here: missing `Target` in implementation
+   | |_________^ missing `Target` in implementation
    |
    = note: `Target` from trait: `type Target;`
 

--- a/src/test/ui/span/issue-7575.stderr
+++ b/src/test/ui/span/issue-7575.stderr
@@ -38,11 +38,10 @@ error: no method named `fff` found for type `Myisize` in the current scope
 note: candidate #1 is defined in an impl for the type `Myisize`
   --> $DIR/issue-7575.rs:51:5
    |
-51 |       fn fff(i: isize) -> isize { //~ NOTE candidate
-   |  _____^ starting here...
+51 | /     fn fff(i: isize) -> isize { //~ NOTE candidate
 52 | |         i
 53 | |     }
-   | |_____^ ...ending here
+   | |_____^
 
 error: no method named `is_str` found for type `T` in the current scope
   --> $DIR/issue-7575.rs:85:7
@@ -54,11 +53,10 @@ error: no method named `is_str` found for type `T` in the current scope
 note: candidate #1 is defined in the trait `ManyImplTrait`
   --> $DIR/issue-7575.rs:57:5
    |
-57 |       fn is_str() -> bool { //~ NOTE candidate
-   |  _____^ starting here...
+57 | /     fn is_str() -> bool { //~ NOTE candidate
 58 | |         false
 59 | |     }
-   | |_____^ ...ending here
+   | |_____^
    = help: to disambiguate the method call, write `ManyImplTrait::is_str(t)` instead
    = help: items from traits can only be used if the trait is implemented and in scope; the following trait defines an item `is_str`, perhaps you need to implement it:
    = help: candidate #1: `ManyImplTrait`

--- a/src/test/ui/span/lint-unused-unsafe.stderr
+++ b/src/test/ui/span/lint-unused-unsafe.stderr
@@ -49,68 +49,62 @@ note: because it's nested under this `unsafe` fn
 error: unnecessary `unsafe` block
   --> $DIR/lint-unused-unsafe.rs:33:9
    |
-33 |           unsafe {                         //~ ERROR: unnecessary `unsafe` block
-   |  _________^ starting here...
+33 | /         unsafe {                         //~ ERROR: unnecessary `unsafe` block
 34 | |             unsf()
 35 | |         }
-   | |_________^ ...ending here: unnecessary `unsafe` block
+   | |_________^ unnecessary `unsafe` block
    |
 note: because it's nested under this `unsafe` block
   --> $DIR/lint-unused-unsafe.rs:32:5
    |
-32 |       unsafe {                             // don't put the warning here
-   |  _____^ starting here...
+32 | /     unsafe {                             // don't put the warning here
 33 | |         unsafe {                         //~ ERROR: unnecessary `unsafe` block
 34 | |             unsf()
 35 | |         }
 36 | |     }
-   | |_____^ ...ending here
+   | |_____^
 
 error: unnecessary `unsafe` block
   --> $DIR/lint-unused-unsafe.rs:39:5
    |
-39 |       unsafe {                             //~ ERROR: unnecessary `unsafe` block
-   |  _____^ starting here...
+39 | /     unsafe {                             //~ ERROR: unnecessary `unsafe` block
 40 | |         unsafe {                         //~ ERROR: unnecessary `unsafe` block
 41 | |             unsf()
 42 | |         }
 43 | |     }
-   | |_____^ ...ending here: unnecessary `unsafe` block
+   | |_____^ unnecessary `unsafe` block
    |
 note: because it's nested under this `unsafe` fn
   --> $DIR/lint-unused-unsafe.rs:38:1
    |
-38 |   unsafe fn bad7() {
-   |  _^ starting here...
+38 | / unsafe fn bad7() {
 39 | |     unsafe {                             //~ ERROR: unnecessary `unsafe` block
 40 | |         unsafe {                         //~ ERROR: unnecessary `unsafe` block
 41 | |             unsf()
 42 | |         }
 43 | |     }
 44 | | }
-   | |_^ ...ending here
+   | |_^
 
 error: unnecessary `unsafe` block
   --> $DIR/lint-unused-unsafe.rs:40:9
    |
-40 |           unsafe {                         //~ ERROR: unnecessary `unsafe` block
-   |  _________^ starting here...
+40 | /         unsafe {                         //~ ERROR: unnecessary `unsafe` block
 41 | |             unsf()
 42 | |         }
-   | |_________^ ...ending here: unnecessary `unsafe` block
+   | |_________^ unnecessary `unsafe` block
    |
 note: because it's nested under this `unsafe` fn
   --> $DIR/lint-unused-unsafe.rs:38:1
    |
-38 |   unsafe fn bad7() {
-   |  _^ starting here...
+38 | / unsafe fn bad7() {
 39 | |     unsafe {                             //~ ERROR: unnecessary `unsafe` block
 40 | |         unsafe {                         //~ ERROR: unnecessary `unsafe` block
 41 | |             unsf()
 42 | |         }
 43 | |     }
 44 | | }
-   | |_^ ...ending here
+   | |_^
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/span/multiline-span-E0072.stderr
+++ b/src/test/ui/span/multiline-span-E0072.stderr
@@ -1,14 +1,13 @@
 error[E0072]: recursive type `ListNode` has infinite size
   --> $DIR/multiline-span-E0072.rs:12:1
    |
-12 |   struct
-   |  _^ starting here...
+12 | / struct
 13 | | ListNode
 14 | | {
 15 | |     head: u8,
 16 | |     tail: Option<ListNode>,
 17 | | }
-   | |_^ ...ending here: recursive type has infinite size
+   | |_^ recursive type has infinite size
    |
    = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `ListNode` representable
 

--- a/src/test/ui/span/multiline-span-simple.stderr
+++ b/src/test/ui/span/multiline-span-simple.stderr
@@ -2,12 +2,12 @@ error[E0277]: the trait bound `u32: std::ops::Add<()>` is not satisfied
   --> $DIR/multiline-span-simple.rs:23:9
    |
 23 |       foo(1 as u32 +
-   |  _________^ starting here...
+   |  _________^
 24 | |
 25 | |         bar(x,
 26 | |
 27 | |             y),
-   | |______________^ ...ending here: the trait `std::ops::Add<()>` is not implemented for `u32`
+   | |______________^ the trait `std::ops::Add<()>` is not implemented for `u32`
    |
    = note: no implementation for `u32 + ()`
 

--- a/src/test/ui/type-check/issue-40294.stderr
+++ b/src/test/ui/type-check/issue-40294.stderr
@@ -1,15 +1,14 @@
 error[E0282]: type annotations needed
   --> $DIR/issue-40294.rs:15:1
    |
-15 |   fn foo<'a,'b,T>(x: &'a T, y: &'b T)
-   |  _^ starting here...
+15 | / fn foo<'a,'b,T>(x: &'a T, y: &'b T)
 16 | |     where &'a T : Foo,
 17 | |           &'b T : Foo
 18 | | {
 19 | |     x.foo();
 20 | |     y.foo();
 21 | | }
-   | |_^ ...ending here: cannot infer type for `&'a T`
+   | |_^ cannot infer type for `&'a T`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
When a span starts on a line with nothing but whitespace to the left,
and there are no other annotations in that line, simplify the visual
representation of the span.

Go from:

```rust
error[E0072]: recursive type `A` has infinite size
 --> file2.rs:1:1
  |
1 |   struct A {
  |  _^ starting here...
2 | |     a: A,
3 | | }
  | |_^ ...ending here: recursive type has infinite size
  |
```

To:

```rust
error[E0072]: recursive type `A` has infinite size
 --> file2.rs:1:1
  |
1 | / struct A {
2 | |     a: A,
3 | | }
  | |_^ recursive type has infinite size
```

Re: #38246.

r? @nikomatsakis CC @jonathandturner