### PR TITLE
Multiple unused formatting argument are now labels, less unused argument spam

### DIFF
--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -794,8 +794,10 @@ pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt,
             } else {
                 let mut diag = cx.ecx.struct_span_err(cx.fmtsp,
                     "multiple unused formatting arguments");
-                for (sp, msg) in errs {
-                    diag.span_note(sp, msg);
+
+                // Push all the unused errors to the DiagnosticBuilder's `MultiSpan`.
+                for (sp, _) in errs {
+                    diag.span_label(sp, &"unused");
                 }
                 diag
             }

--- a/src/test/ui/macros/format-foreign.rs
+++ b/src/test/ui/macros/format-foreign.rs
@@ -10,6 +10,13 @@
 
 fn main() {
     println!("%.*3$s %s!\n", "Hello,", "World", 4);
+    println!(
+        "%.*3$s %s!\n",
+        "Hello,",
+        "World",
+        4
+    );
+
     println!("%1$*2$.*3$f", 123.456);
 
     // This should *not* produce hints, on the basis that there's equally as

--- a/src/test/ui/macros/format-foreign.stderr
+++ b/src/test/ui/macros/format-foreign.stderr
@@ -2,51 +2,60 @@ error: multiple unused formatting arguments
   --> $DIR/format-foreign.rs:12:5
    |
 12 |     println!("%.*3$s %s!/n", "Hello,", "World", 4);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^--------^^-------^^-^^
+   |                              |         |        |
+   |                              |         |        unused
+   |                              |         unused
+   |                              unused
    |
-note: argument never used
-  --> $DIR/format-foreign.rs:12:30
+   = help: `%.*3$s` should be written as `{:.2$}`
+   = help: `%s` should be written as `{}`
+   = note: printf formatting not supported; see the documentation for `std::fmt`
+   = note: this error originates in a macro outside of the current crate
+
+error: multiple unused formatting arguments
+  --> $DIR/format-foreign.rs:13:5
    |
-12 |     println!("%.*3$s %s!/n", "Hello,", "World", 4);
-   |                              ^^^^^^^^
-note: argument never used
-  --> $DIR/format-foreign.rs:12:40
+13 |       println!(
+   |  _____^ starting here...
+14 | |         "%.*3$s %s!/n",
+15 | |         "Hello,",
+   | |         -------- unused
+16 | |         "World",
+   | |         ------- unused
+17 | |         4
+   | |         - unused
+18 | |     );
+   | |______^ ...ending here
    |
-12 |     println!("%.*3$s %s!/n", "Hello,", "World", 4);
-   |                                        ^^^^^^^
-note: argument never used
-  --> $DIR/format-foreign.rs:12:49
-   |
-12 |     println!("%.*3$s %s!/n", "Hello,", "World", 4);
-   |                                                 ^
    = help: `%.*3$s` should be written as `{:.2$}`
    = help: `%s` should be written as `{}`
    = note: printf formatting not supported; see the documentation for `std::fmt`
    = note: this error originates in a macro outside of the current crate
 
 error: argument never used
-  --> $DIR/format-foreign.rs:13:29
+  --> $DIR/format-foreign.rs:20:29
    |
-13 |     println!("%1$*2$.*3$f", 123.456);
+20 |     println!("%1$*2$.*3$f", 123.456);
    |                             ^^^^^^^
    |
    = help: `%1$*2$.*3$f` should be written as `{0:1$.2$}`
    = note: printf formatting not supported; see the documentation for `std::fmt`
 
 error: argument never used
-  --> $DIR/format-foreign.rs:17:30
+  --> $DIR/format-foreign.rs:24:30
    |
-17 |     println!("{} %f", "one", 2.0);
+24 |     println!("{} %f", "one", 2.0);
    |                              ^^^
 
 error: named argument never used
-  --> $DIR/format-foreign.rs:19:39
+  --> $DIR/format-foreign.rs:26:39
    |
-19 |     println!("Hi there, $NAME.", NAME="Tim");
+26 |     println!("Hi there, $NAME.", NAME="Tim");
    |                                       ^^^^^
    |
    = help: `$NAME` should be written as `{NAME}`
    = note: shell formatting not supported; see the documentation for `std::fmt`
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
As my first contribution to the Rust compiler I took a shot at the issue #37718. Instead of printing a list of notes for every individual unused argument, it now displays what arguments are unused underneath each argument, using the `span_label` function from the `DiagnosticBuilder` struct.

Example:
```
error: multiple unused formatting arguments
  -->  /Users/nickvernij/Programming/rust/src/test/ui/macros/format-foreign.rs:12:5
   |
12 |     println!("%.*3$s %s!/n", "Hello,", "World", 4);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^--------^^-------^^-^^
   |                              |         |        |
   |                              |         |        unused
   |                              |         unused
   |                              unused
   |
```

I modified the test that was used before this change, and added a test that checks this method with a function whose arguments are written on multiple lines.

I ran the style guideline test as described in the contributing guidelines, and a test on the UI tests. Again, this is my first PR here, so I might've missed something somewhere.