### PR TITLE
libsyntax/parse: fix missing kind error reporting

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -617,14 +617,14 @@ impl<'a> Parser<'a> {
             ExpansionKind::TraitItems => {
                 let mut items = SmallVector::new();
                 while self.token != token::Eof {
-                    items.push(self.parse_trait_item()?);
+                    items.push(self.parse_trait_item(&mut false)?);
                 }
                 Expansion::TraitItems(items)
             }
             ExpansionKind::ImplItems => {
                 let mut items = SmallVector::new();
                 while self.token != token::Eof {
-                    items.push(self.parse_impl_item()?);
+                    items.push(self.parse_impl_item(&mut false)?);
                 }
                 Expansion::ImplItems(items)
             }

--- a/src/test/parse-fail/issue-21153.rs
+++ b/src/test/parse-fail/issue-21153.rs
@@ -10,7 +10,6 @@
 
 // compile-flags: -Z parse-only
 
-trait MyTrait<T>: Iterator {
-    Item = T; //~ ERROR expected one of `!` or `::`, found `=`
-              //~| ERROR expected item, found `=`
+trait MyTrait<T>: Iterator { //~ ERROR missing `fn`, `type`, or `const`
+    Item = T;
 }

--- a/src/test/parse-fail/trait-pub-assoc-const.rs
+++ b/src/test/parse-fail/trait-pub-assoc-const.rs
@@ -10,7 +10,7 @@
 
 trait Foo {
     pub const Foo: u32;
-     //~^ ERROR expected one of `const`, `extern`, `fn`, `type`, or `unsafe`, found `pub`
+    //~^ ERROR expected one of `const`, `extern`, `fn`, `type`, `unsafe`, or `}`, found `pub`
 }
 
 fn main() {}

--- a/src/test/parse-fail/trait-pub-assoc-ty.rs
+++ b/src/test/parse-fail/trait-pub-assoc-ty.rs
@@ -10,7 +10,7 @@
 
 trait Foo {
     pub type Foo;
-    //~^ ERROR expected one of `const`, `extern`, `fn`, `type`, or `unsafe`, found `pub`
+    //~^ ERROR expected one of `const`, `extern`, `fn`, `type`, `unsafe`, or `}`, found `pub`
 }
 
 fn main() {}

--- a/src/test/parse-fail/trait-pub-method.rs
+++ b/src/test/parse-fail/trait-pub-method.rs
@@ -10,7 +10,7 @@
 
 trait Foo {
     pub fn foo();
-    //~^ ERROR expected one of `const`, `extern`, `fn`, `type`, or `unsafe`, found `pub`
+    //~^ ERROR expected one of `const`, `extern`, `fn`, `type`, `unsafe`, or `}`, found `pub`
 }
 
 fn main() {}

--- a/src/test/ui/did_you_mean/issue-40006.rs
+++ b/src/test/ui/did_you_mean/issue-40006.rs
@@ -8,7 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+impl X {
+    Y
+}
+
 struct S;
+
+trait X {
+    X() {}
+    fn xxx() { ### }
+    L = M;
+    Z = { 2 + 3 };
+    ::Y ();
+}
 
 impl S {
     pub hello_method(&self) {

--- a/src/test/ui/did_you_mean/issue-40006.stderr
+++ b/src/test/ui/did_you_mean/issue-40006.stderr
@@ -1,8 +1,68 @@
-error: missing `fn` for method declaration
-  --> $DIR/issue-40006.rs:14:8
+error: missing `fn`, `type`, or `const` for impl-item declaration
+  --> $DIR/issue-40006.rs:11:9
    |
-14 |     pub hello_method(&self) {
-   |        ^ missing `fn`
+11 |   impl X {
+   |  _________^ starting here...
+12 | |     Y
+   | |____^ ...ending here: missing `fn`, `type`, or `const`
+
+error: missing `fn`, `type`, or `const` for trait-item declaration
+  --> $DIR/issue-40006.rs:17:10
+   |
+17 |   trait X {
+   |  __________^ starting here...
+18 | |     X() {}
+   | |____^ ...ending here: missing `fn`, `type`, or `const`
+
+error: expected `[`, found `#`
+  --> $DIR/issue-40006.rs:19:17
+   |
+19 |     fn xxx() { ### }
+   |                 ^
+
+error: missing `fn`, `type`, or `const` for trait-item declaration
+  --> $DIR/issue-40006.rs:19:21
+   |
+19 |       fn xxx() { ### }
+   |  _____________________^ starting here...
+20 | |     L = M;
+   | |____^ ...ending here: missing `fn`, `type`, or `const`
+
+error: missing `fn`, `type`, or `const` for trait-item declaration
+  --> $DIR/issue-40006.rs:20:11
+   |
+20 |       L = M;
+   |  ___________^ starting here...
+21 | |     Z = { 2 + 3 };
+   | |____^ ...ending here: missing `fn`, `type`, or `const`
+
+error: expected one of `const`, `extern`, `fn`, `type`, `unsafe`, or `}`, found `;`
+  --> $DIR/issue-40006.rs:21:18
+   |
+21 |     Z = { 2 + 3 };
+   |                  ^ expected one of `const`, `extern`, `fn`, `type`, `unsafe`, or `}` here
+
+error: expected one of `!` or `::`, found `(`
+  --> $DIR/issue-40006.rs:22:9
+   |
+22 |     ::Y ();
+   |        -^ unexpected token
+   |        |
+   |        expected one of `!` or `::` here
+
+error: missing `fn`, `type`, or `const` for impl-item declaration
+  --> $DIR/issue-40006.rs:26:8
+   |
+26 |     pub hello_method(&self) {
+   |        ^ missing `fn`, `type`, or `const`
+
+error[E0038]: the trait `X` cannot be made into an object
+  --> $DIR/issue-40006.rs:11:6
+   |
+11 | impl X {
+   |      ^ the trait `X` cannot be made into an object
+   |
+   = note: method `xxx` has no receiver
 
 error: aborting due to previous error
 

--- a/src/test/ui/token/issue-41155.stderr
+++ b/src/test/ui/token/issue-41155.stderr
@@ -6,5 +6,13 @@ error: expected one of `(`, `const`, `default`, `extern`, `fn`, `type`, or `unsa
 13 | }
    | ^ unexpected token
 
-error: aborting due to previous error
+error[E0412]: cannot find type `S` in this scope
+  --> $DIR/issue-41155.rs:11:6
+   |
+11 | impl S {
+   |      ^ not found in this scope
+
+error: main function not found
+
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Fixes #41161.
Fixes #41239.