### PR TITLE
Hoedown big comeback!

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,6 +5,10 @@
 [submodule "src/compiler-rt"]
 	path = src/compiler-rt
 	url = https://github.com/rust-lang/compiler-rt.git
+[submodule "src/rt/hoedown"]
+	path = src/rt/hoedown
+	url = https://github.com/rust-lang/hoedown.git
+	branch = rust-2015-09-21-do-not-delete
 [submodule "src/jemalloc"]
 	path = src/jemalloc
 	url = https://github.com/rust-lang/jemalloc.git

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -197,6 +197,28 @@ their own copyright notices and license terms:
     USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
     OF SUCH DAMAGE.
 
+* Hoedown, the markdown parser, under src/rt/hoedown, is
+  licensed as follows.
+
+    Copyright (c) 2008, Natacha Porté
+    Copyright (c) 2011, Vicent Martí
+    Copyright (c) 2013, Devin Torres and the Hoedown authors
+
+    Permission to use, copy, modify, and distribute this
+    software for any purpose with or without fee is hereby
+    granted, provided that the above copyright notice and
+    this permission notice appear in all copies.
+
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR
+    DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE
+    INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+    SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR
+    ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA
+    OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+    OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+    CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
 * libbacktrace, under src/libbacktrace:
 
     Copyright (C) 2012-2014 Free Software Foundation, Inc.

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustdoc"
 version = "0.0.0"
+build = "build.rs"
 
 [lib]
 name = "rustdoc"

--- a/src/librustdoc/build.rs
+++ b/src/librustdoc/build.rs
@@ -1,0 +1,30 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate build_helper;
+extern crate gcc;
+
+fn main() {
+    let src_dir = std::path::Path::new("../rt/hoedown/src");
+    build_helper::rerun_if_changed_anything_in_dir(src_dir);
+    let mut cfg = gcc::Config::new();
+    cfg.file("../rt/hoedown/src/autolink.c")
+       .file("../rt/hoedown/src/buffer.c")
+       .file("../rt/hoedown/src/document.c")
+       .file("../rt/hoedown/src/escape.c")
+       .file("../rt/hoedown/src/html.c")
+       .file("../rt/hoedown/src/html_blocks.c")
+       .file("../rt/hoedown/src/html_smartypants.c")
+       .file("../rt/hoedown/src/stack.c")
+       .file("../rt/hoedown/src/version.c")
+       .include(src_dir)
+       .compile("libhoedown.a");
+}
+

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -25,7 +25,7 @@ use externalfiles::{ExternalHtml, LoadStringError, load_string};
 use html::render::reset_ids;
 use html::escape::Escape;
 use html::markdown;
-use html::markdown::{Markdown, MarkdownWithToc, find_testable_code};
+use html::markdown::{Markdown, MarkdownWithToc, find_testable_code, old_find_testable_code};
 use test::{TestOptions, Collector};
 
 /// Separate any lines at the start of the file that begin with `# ` or `%`.
@@ -159,6 +159,7 @@ pub fn test(input: &str, cfgs: Vec<String>, libs: SearchPaths, externs: Externs,
     let mut collector = Collector::new(input.to_string(), cfgs, libs, externs,
                                        true, opts, maybe_sysroot, None,
                                        Some(input.to_owned()));
+    old_find_testable_code(&input_str, &mut collector, DUMMY_SP);
     find_testable_code(&input_str, &mut collector, DUMMY_SP);
     test_args.insert(0, "rustdoctest".to_string());
     testing::test_main(&test_args, collector.tests);

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -86,6 +86,7 @@ fn filter_dirs(path: &Path) -> bool {
         "src/rust-installer",
         "src/liblibc",
         "src/vendor",
+        "src/rt/hoedown",
     ];
     skip.iter().any(|p| path.ends_with(p))
 }


### PR DESCRIPTION
```bash
> cargo +local test
   Compiling libc v0.2.20
   Compiling sysinfo v0.3.4 (file:///Users/imperio/rust/sysinfo)
    Finished dev [unoptimized + debuginfo] target(s) in 3.2 secs
     Running target/debug/deps/disk_list-dbd70897f1f7e080

running 1 test
test test_disks ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured

     Running target/debug/deps/sysinfo-8ad11103abdf5941

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured

   Doc-tests sysinfo
WARNING: src/sysinfo.rs -  (line 45) test will be run in the next rustdoc version. If it's not supposed to, please update your documentation and make it compliant to common mark specifications.
WARNING: src/sysinfo.rs -  (line 48) test will be run in the next rustdoc version. If it's not supposed to, please update your documentation and make it compliant to common mark specifications.

running 1 test
test src/sysinfo.rs -  (line 14) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
```

r? @rust-lang/docs 