### PR TITLE
Implement the illegal_floating_point_literal_pattern compat lint

### DIFF
--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -113,6 +113,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
                        UnusedParens,
                        UnusedImportBraces,
                        AnonymousParameters,
+                       IllegalFloatLiteralPattern,
                        );
 
     add_early_builtin_with_new!(sess,
@@ -200,6 +201,10 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
         FutureIncompatibleInfo {
             id: LintId::of(ILLEGAL_FLOATING_POINT_CONSTANT_PATTERN),
             reference: "issue #36890 <https://github.com/rust-lang/rust/issues/36890>",
+        },
+        FutureIncompatibleInfo {
+            id: LintId::of(ILLEGAL_FLOATING_POINT_LITERAL_PATTERN),
+            reference: "issue #41620 <https://github.com/rust-lang/rust/issues/41620>",
         },
         FutureIncompatibleInfo {
             id: LintId::of(ILLEGAL_STRUCT_OR_ENUM_CONSTANT_PATTERN),

--- a/src/test/compile-fail/issue-41255.rs
+++ b/src/test/compile-fail/issue-41255.rs
@@ -1,0 +1,51 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Matching against float literals should result in a linter error
+
+#![feature(slice_patterns)]
+#![feature(exclusive_range_pattern)]
+#![allow(unused)]
+#![forbid(illegal_floating_point_literal_pattern)]
+
+fn main() {
+    let x = 42.0;
+    match x {
+        5.0 => {}, //~ ERROR floating-point literals cannot be used
+                   //~| WARNING hard error
+        5.0f32 => {}, //~ ERROR floating-point literals cannot be used
+                      //~| WARNING hard error
+        -5.0 => {}, //~ ERROR floating-point literals cannot be used
+                    //~| WARNING hard error
+        1.0 .. 33.0 => {}, //~ ERROR floating-point literals cannot be used
+                           //~| WARNING hard error
+                           //~| ERROR floating-point literals cannot be used
+                           //~| WARNING hard error
+        39.0 ... 70.0 => {}, //~ ERROR floating-point literals cannot be used
+                             //~| WARNING hard error
+                             //~| ERROR floating-point literals cannot be used
+                             //~| WARNING hard error
+        _ => {},
+    };
+    let y = 5.0;
+    // Same for tuples
+    match (x, 5) {
+        (3.14, 1) => {}, //~ ERROR floating-point literals cannot be used
+                         //~| WARNING hard error
+        _ => {},
+    }
+    // Or structs
+    struct Foo { x: f32 };
+    match (Foo { x }) {
+        Foo { x: 2.0 } => {}, //~ ERROR floating-point literals cannot be used
+                              //~| WARNING hard error
+        _ => {},
+    }
+}

--- a/src/test/compile-fail/issue-41255.rs
+++ b/src/test/compile-fail/issue-41255.rs
@@ -39,12 +39,16 @@ fn main() {
     match (x, 5) {
         (3.14, 1) => {}, //~ ERROR floating-point literals cannot be used
                          //~| WARNING hard error
+                         //~| ERROR floating-point literals cannot be used
+                         //~| WARNING hard error
         _ => {},
     }
     // Or structs
     struct Foo { x: f32 };
     match (Foo { x }) {
         Foo { x: 2.0 } => {}, //~ ERROR floating-point literals cannot be used
+                              //~| WARNING hard error
+                              //~| ERROR floating-point literals cannot be used
                               //~| WARNING hard error
         _ => {},
     }

--- a/src/test/compile-fail/non-exhaustive-match.rs
+++ b/src/test/compile-fail/non-exhaustive-match.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(slice_patterns)]
+#![allow(illegal_floating_point_literal_pattern)]
 
 enum t { a, b, }
 


### PR DESCRIPTION
Adds a future-compatibility lint for the [breaking-change] introduced by issue #41620 . cc issue #41255 .
