### PR TITLE
Compile WASM as WASM instead of asm.js

### DIFF
--- a/src/librustc_back/target/wasm32_unknown_emscripten.rs
+++ b/src/librustc_back/target/wasm32_unknown_emscripten.rs
@@ -14,7 +14,7 @@ use super::emscripten_base::{cmd};
 
 pub fn target() -> Result<Target, String> {
     let mut post_link_args = LinkArgs::new();
-    post_link_args.insert(LinkerFlavor::Gcc,
+    post_link_args.insert(LinkerFlavor::Em,
                           vec!["-s".to_string(),
                                "BINARYEN=1".to_string(),
                                "-s".to_string(),


### PR DESCRIPTION
Looks like the LinkerFlavor change introduced in #40018 accidentally uses GCC for the WebAssembly target, causing Rust to never actually pass the post link args to emscripten. This then causes the code to be compiled as asm.js instead of WebAssembly, because the Binaryen tools never run due to the missing linker argument.