### PR TITLE
add 'mir' to rustc help menu and man doc

### DIFF
--- a/man/rustc.1
+++ b/man/rustc.1
@@ -50,7 +50,7 @@ Comma separated list of types of crates for the compiler to emit.
 \fB\-\-crate\-name\fR \fINAME\fR
 Specify the name of the crate being built.
 .TP
-\fB\-\-emit\fR [asm|llvm\-bc|llvm\-ir|obj|link|dep\-info][=\fIPATH\fR]
+\fB\-\-emit\fR [asm|llvm\-bc|llvm\-ir|obj|link|dep\-info|mir][=\fIPATH\fR]
 Configure the output that \fBrustc\fR will produce. Each emission may also have
 an optional explicit output \fIPATH\fR specified for that particular emission
 kind. This path takes precedence over the \fB-o\fR option.

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1246,7 +1246,7 @@ pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
                "NAME"),
         opt::multi_s("", "emit", "Comma separated list of types of output for \
                               the compiler to emit",
-                 "[asm|llvm-bc|llvm-ir|obj|metadata|link|dep-info]"),
+                 "[asm|llvm-bc|llvm-ir|obj|metadata|link|dep-info|mir]"),
         opt::multi_s("", "print", "Comma separated list of compiler information to \
                                print on stdout", &format!("[{}]",
                                &print_opts.join("|"))),


### PR DESCRIPTION
add 'mir' to '--emit' flag list for 'rustc'.
This is added because 'rustc' can now generate MIR (referencing to
"Teach rustc --emit=mir #39891").