### PR TITLE
rustc: provide adt_sized_constraint as an on-demand query.

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -898,6 +898,7 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
 
     let mut extern_providers = ty::maps::Providers::default();
     cstore::provide(&mut extern_providers);
+    ty::provide_extern(&mut extern_providers);
 
     TyCtxt::create_and_enter(sess,
                              local_providers,


### PR DESCRIPTION
By using `queries::adt_sized_constraint::try_get`, we can detect cycles without a separate stack.
r? @nikomatsakis