### PR TITLE
[RFC] add Duration::as_millis

### DIFF
--- a/src/doc/unstable-book/src/SUMMARY.md
+++ b/src/doc/unstable-book/src/SUMMARY.md
@@ -65,6 +65,7 @@
 - [drop_types_in_const](drop-types-in-const.md)
 - [dropck_eyepatch](dropck-eyepatch.md)
 - [dropck_parametricity](dropck-parametricity.md)
+- [duration_as_millis](duration-as-millis.md)
 - [enumset](enumset.md)
 - [error_type_id](error-type-id.md)
 - [exact_size_is_empty](exact-size-is-empty.md)

--- a/src/doc/unstable-book/src/duration-as-millis.md
+++ b/src/doc/unstable-book/src/duration-as-millis.md
@@ -1,0 +1,5 @@
+# `duration_as_millis`
+
+The tracking issue for this feature is: FIXME
+
+------------------------

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -126,6 +126,23 @@ impl Duration {
     #[inline]
     pub fn as_secs(&self) -> u64 { self.secs }
 
+    /// Returns the number of whole milliseconds represented by this `Duration`.
+    ///
+    /// The extra precision represented by this duration is ignored (i.e. extra
+    /// nanoseconds are not represented in the returned value).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::time::Duration;
+    ///
+    /// let half_second = Duration::from_millis(500);
+    /// assert_eq!(half_second.as_millis(), 500);
+    /// ```
+    #[unstable(feature = "duration_as_millis", issue = "0")]
+    #[inline]
+    pub fn as_millis(&self) -> u64 { self.secs * 1000 + self.nanos as u64 / 1_000_000 }
+
     /// Returns the nanosecond precision represented by this `Duration`.
     ///
     /// This method does **not** return the length of the duration when

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -141,7 +141,9 @@ impl Duration {
     /// ```
     #[unstable(feature = "duration_as_millis", issue = "0")]
     #[inline]
-    pub fn as_millis(&self) -> u64 { self.secs * 1000 + self.nanos as u64 / 1_000_000 }
+    pub fn as_millis(&self) -> u64 {
+        self.secs * MILLIS_PER_SEC + (self.nanos / NANOS_PER_MILLI) as u64
+    }
 
     /// Returns the nanosecond precision represented by this `Duration`.
     ///


### PR DESCRIPTION
This PR adds a function to parallel `Duration::from_millis`, to get the milliseconds back out. It reduces friction when using other APIs that deal in milliseconds, while allowing Rust code to use `Duration` internally.

Example: I wanted to take in a `Duration` and [pass it as milliseconds](https://github.com/haptics-nri/nri/blob/beb532642b49286bd8fd15d790ad8b08cd832c89/crates/drivers/structure/src/wrapper.rs#L344) to an FFI function that expects an int, and it's [messy](https://github.com/haptics-nri/nri/blob/beb532642b49286bd8fd15d790ad8b08cd832c89/crates/drivers/structure/src/wrapper.rs#L19) to implement this function outside of std.