### PR TITLE
Implement Mul<usize> and MulAssign<usize> for String

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -60,7 +60,7 @@ use core::fmt;
 use core::hash;
 use core::iter::{FromIterator, FusedIterator};
 use core::mem;
-use core::ops::{self, Add, AddAssign, Index, IndexMut};
+use core::ops::{self, Add, AddAssign, Index, IndexMut, Mul, MulAssign};
 use core::ptr;
 use core::str as core_str;
 use core::str::pattern::Pattern;
@@ -1707,6 +1707,48 @@ impl<'a> AddAssign<&'a str> for String {
     #[inline]
     fn add_assign(&mut self, other: &str) {
         self.push_str(other);
+    }
+}
+
+/// Implements the `*` operator for multiplying `String` content.
+///
+/// ```
+/// let one = String::from("one");
+/// assert_eq!(one * 3, "oneoneone");
+/// ```
+#[stable(feature = "stringmultiply", since = "1.18.0")]
+impl Mul<usize> for String {
+    type Output = String;
+
+    #[inline]
+    fn mul(self, rhs: usize) -> String {
+        let size = self.len() * rhs;
+        let mut out = String::with_capacity(size);
+        for _ in 0..rhs {
+            out.push_str(self.as_str());
+        }
+        out
+    }
+}
+
+/// Implements the `*=` operator for multiplyng `String` content.
+///
+/// ```
+/// let mut one = String::from("one");
+/// one *= 3;
+/// assert_eq!(one, "oneoneone");
+/// ```
+#[stable(feature = "stringmultiply", since = "1.18.0")]
+impl MulAssign<usize> for String {
+    #[inline]
+    fn mul_assign(&mut self, rhs: usize) {
+        let content = self.clone();
+        let size = content.len() * rhs;
+        self.clear();
+        self.reserve(size);
+        for _ in 0..rhs {
+            self.push_str(content.as_str());
+        }
     }
 }
 

--- a/src/libcollections/tests/string.rs
+++ b/src/libcollections/tests/string.rs
@@ -207,6 +207,24 @@ fn test_add_assign() {
 }
 
 #[test]
+fn test_mul() {
+    let s = String::from("abcประเทศไทย中华Việt Nam") * 0;
+    assert_eq!(s, "");
+    let s = String::from("abcประเทศไทย中华Việt Nam") * 2;
+    assert_eq!(s, "abcประเทศไทย中华Việt Namabcประเทศไทย中华Việt Nam");
+}
+
+#[test]
+fn test_mul_assign() {
+    let mut s = String::from("abcประเทศไทย中华Việt Nam");
+    s *= 0;
+    assert_eq!(s, "");
+    s = String::from("abcประเทศไทย中华Việt Nam");
+    s *= 2;
+    assert_eq!(s, "abcประเทศไทย中华Việt Namabcประเทศไทย中华Việt Nam");
+}
+
+#[test]
 fn test_push() {
     let mut data = String::from("ประเทศไทย中");
     data.push('华');


### PR DESCRIPTION
This PR adds ability to multiply the content of the `String`. Those with Python experience may find the implemented behaviour familiar.

```rust
let one = String::from("one");
assert_eq!(one * 3, "oneoneone");

let mut one = String::from("one");
one *= 3;
assert_eq!(one, "oneoneone");
```

I followed the precedence set by #34890 when implementing Mul and MulAssign traits.

Also this is my very first contribution to the Rust itself, so if I missed anything important I'd be glad to learn.