### PR TITLE
Support AddressSanitizer and ThreadSanitizer on x86_64-apple-darwin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
     # version that we're using, 8.2, cannot compile LLVM for OSX 10.7.
     - env: >
         RUST_CHECK_TARGET=check
-        RUST_CONFIGURE_ARGS=--build=x86_64-apple-darwin
+        RUST_CONFIGURE_ARGS="--build=x86_64-apple-darwin --enable-sanitizers"
         SRC=.
         RUSTC_RETRY_LINKER_ON_SEGFAULT=1
         SCCACHE_ERROR_LOG=/tmp/sccache.log
@@ -98,7 +98,7 @@ matrix:
       install: *osx_install_sccache
     - env: >
         RUST_CHECK_TARGET=dist
-        RUST_CONFIGURE_ARGS="--target=aarch64-apple-ios,armv7-apple-ios,armv7s-apple-ios,i386-apple-ios,x86_64-apple-ios --enable-extended"
+        RUST_CONFIGURE_ARGS="--target=aarch64-apple-ios,armv7-apple-ios,armv7s-apple-ios,i386-apple-ios,x86_64-apple-ios --enable-extended --enable-sanitizers"
         SRC=.
         DEPLOY=1
         RUSTC_RETRY_LINKER_ON_SEGFAULT=1

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -115,6 +115,13 @@ pub fn std_link(build: &Build,
     if target.contains("musl") && !target.contains("mips") {
         copy_musl_third_party_objects(build, target, &libdir);
     }
+
+    if build.config.sanitizers && compiler.stage != 0 && target == "x86_64-apple-darwin" {
+        // The sanitizers are only built in stage1 or above, so the dylibs will
+        // be missing in stage0 and causes panic. See the `std()` function above
+        // for reason why the sanitizers are not built in stage0.
+        copy_apple_sanitizer_dylibs(&build.native_dir(target), "osx", &libdir);
+    }
 }
 
 /// Copies the crt(1,i,n).o startup objects
@@ -123,6 +130,18 @@ pub fn std_link(build: &Build,
 fn copy_musl_third_party_objects(build: &Build, target: &str, into: &Path) {
     for &obj in &["crt1.o", "crti.o", "crtn.o"] {
         copy(&build.musl_root(target).unwrap().join("lib").join(obj), &into.join(obj));
+    }
+}
+
+fn copy_apple_sanitizer_dylibs(native_dir: &Path, platform: &str, into: &Path) {
+    for &sanitizer in &["asan", "tsan"] {
+        let filename = format!("libclang_rt.{}_{}_dynamic.dylib", sanitizer, platform);
+        let mut src_path = native_dir.join(sanitizer);
+        src_path.push("build");
+        src_path.push("lib");
+        src_path.push("darwin");
+        src_path.push(&filename);
+        copy(&src_path, &into.join(filename));
     }
 }
 

--- a/src/bootstrap/metadata.rs
+++ b/src/bootstrap/metadata.rs
@@ -58,6 +58,7 @@ fn build_krate(build: &mut Build, krate: &str) {
     // the dependency graph and what `-p` arguments there are.
     let mut cargo = Command::new(&build.cargo);
     cargo.arg("metadata")
+         .arg("--format-version").arg("1")
          .arg("--manifest-path").arg(build.src.join(krate).join("Cargo.toml"));
     let output = output(&mut cargo);
     let output: Output = json::decode(&output).unwrap();

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -51,7 +51,7 @@ pub struct Config {
     pub uint_type: UintTy,
 }
 
-#[derive(Clone, Hash)]
+#[derive(Clone, Hash, Debug)]
 pub enum Sanitizer {
     Address,
     Leak,

--- a/src/librustc_asan/build.rs
+++ b/src/librustc_asan/build.rs
@@ -12,14 +12,13 @@ extern crate build_helper;
 extern crate cmake;
 
 use std::env;
-use build_helper::native_lib_boilerplate;
+use build_helper::sanitizer_lib_boilerplate;
 
 use cmake::Config;
 
 fn main() {
     if let Some(llvm_config) = env::var_os("LLVM_CONFIG") {
-        let native = match native_lib_boilerplate("compiler-rt", "asan", "clang_rt.asan-x86_64",
-                                                  "build/lib/linux") {
+        let native = match sanitizer_lib_boilerplate("asan") {
             Ok(native) => native,
             _ => return,
         };

--- a/src/librustc_lsan/build.rs
+++ b/src/librustc_lsan/build.rs
@@ -12,14 +12,13 @@ extern crate build_helper;
 extern crate cmake;
 
 use std::env;
-use build_helper::native_lib_boilerplate;
+use build_helper::sanitizer_lib_boilerplate;
 
 use cmake::Config;
 
 fn main() {
     if let Some(llvm_config) = env::var_os("LLVM_CONFIG") {
-        let native = match native_lib_boilerplate("compiler-rt", "lsan", "clang_rt.lsan-x86_64",
-                                                  "build/lib/linux") {
+        let native = match sanitizer_lib_boilerplate("lsan") {
             Ok(native) => native,
             _ => return,
         };

--- a/src/librustc_msan/build.rs
+++ b/src/librustc_msan/build.rs
@@ -12,14 +12,13 @@ extern crate build_helper;
 extern crate cmake;
 
 use std::env;
-use build_helper::native_lib_boilerplate;
+use build_helper::sanitizer_lib_boilerplate;
 
 use cmake::Config;
 
 fn main() {
     if let Some(llvm_config) = env::var_os("LLVM_CONFIG") {
-        let native = match native_lib_boilerplate("compiler-rt", "msan", "clang_rt.msan-x86_64",
-                                                  "build/lib/linux") {
+        let native = match sanitizer_lib_boilerplate("msan") {
             Ok(native) => native,
             _ => return,
         };

--- a/src/librustc_tsan/build.rs
+++ b/src/librustc_tsan/build.rs
@@ -12,14 +12,13 @@ extern crate build_helper;
 extern crate cmake;
 
 use std::env;
-use build_helper::native_lib_boilerplate;
+use build_helper::sanitizer_lib_boilerplate;
 
 use cmake::Config;
 
 fn main() {
     if let Some(llvm_config) = env::var_os("LLVM_CONFIG") {
-        let native = match native_lib_boilerplate("compiler-rt", "tsan", "clang_rt.tsan-x86_64",
-                                                  "build/lib/linux") {
+        let native = match sanitizer_lib_boilerplate("tsan") {
             Ok(native) => native,
             _ => return,
         };

--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -23,6 +23,10 @@ compiler_builtins = { path = "../libcompiler_builtins" }
 std_unicode = { path = "../libstd_unicode" }
 unwind = { path = "../libunwind" }
 
+[target.x86_64-apple-darwin.dependencies]
+rustc_asan = { path = "../librustc_asan" }
+rustc_tsan = { path = "../librustc_tsan" }
+
 [target.x86_64-unknown-linux-gnu.dependencies]
 rustc_asan = { path = "../librustc_asan" }
 rustc_lsan = { path = "../librustc_lsan" }

--- a/src/test/run-make/sanitizer-address/Makefile
+++ b/src/test/run-make/sanitizer-address/Makefile
@@ -1,11 +1,19 @@
 -include ../tools.mk
 
-# NOTE the address sanitizer only supports x86_64 linux
-ifdef SANITIZER_SUPPORT
-all:
-	$(RUSTC) -g -Z sanitizer=address -Z print-link-args overflow.rs | grep -q librustc_asan
-	$(TMPDIR)/overflow 2>&1 | grep -q stack-buffer-overflow
-else
-all:
+# NOTE the address sanitizer only supports x86_64 linux and macOS
 
+ifeq ($(TARGET),x86_64-apple-darwin)
+ASAN_SUPPORT=$(SANITIZER_SUPPORT)
+EXTRA_RUSTFLAG=-C rpath
+else
+ifeq ($(TARGET),x86_64-unknown-linux-gnu)
+ASAN_SUPPORT=$(SANITIZER_SUPPORT)
+EXTRA_RUSTFLAG=
+endif
+endif
+
+all:
+ifeq ($(ASAN_SUPPORT),1)
+	$(RUSTC) -g -Z sanitizer=address -Z print-link-args $(EXTRA_RUSTFLAG) overflow.rs | grep -q librustc_asan
+	$(TMPDIR)/overflow 2>&1 | grep -q stack-buffer-overflow
 endif

--- a/src/test/run-make/sanitizer-invalid-target/Makefile
+++ b/src/test/run-make/sanitizer-invalid-target/Makefile
@@ -1,4 +1,4 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) -Z sanitizer=leak --target i686-unknown-linux-gnu hello.rs 2>&1 | grep -q 'Sanitizers only work with the `x86_64-unknown-linux-gnu` target'
+	$(RUSTC) -Z sanitizer=leak --target i686-unknown-linux-gnu hello.rs 2>&1 | grep -q 'LeakSanitizer only works with the `x86_64-unknown-linux-gnu` target'

--- a/src/test/run-make/sanitizer-leak/Makefile
+++ b/src/test/run-make/sanitizer-leak/Makefile
@@ -1,10 +1,10 @@
 -include ../tools.mk
 
-ifdef SANITIZER_SUPPORT
 all:
+ifeq ($(TARGET),x86_64-unknown-linux-gnu)
+ifdef SANITIZER_SUPPORT
 	$(RUSTC) -C opt-level=1 -g -Z sanitizer=leak -Z print-link-args leak.rs | grep -q librustc_lsan
 	$(TMPDIR)/leak 2>&1 | grep -q 'detected memory leaks'
-else
-all:
-
 endif
+endif
+

--- a/src/test/run-make/sanitizer-memory/Makefile
+++ b/src/test/run-make/sanitizer-memory/Makefile
@@ -1,10 +1,10 @@
 -include ../tools.mk
 
-ifdef SANITIZER_SUPPORT
 all:
+ifeq ($(TARGET),x86_64-unknown-linux-gnu)
+ifdef SANITIZER_SUPPORT
 	$(RUSTC) -g -Z sanitizer=memory -Z print-link-args uninit.rs | grep -q librustc_msan
 	$(TMPDIR)/uninit 2>&1 | grep -q use-of-uninitialized-value
-else
-all:
-
 endif
+endif
+

--- a/src/test/run-make/sysroot-crates-are-unstable/Makefile
+++ b/src/test/run-make/sysroot-crates-are-unstable/Makefile
@@ -1,7 +1,7 @@
 -include ../tools.mk
 
-# This is a whitelist of crates which are stable, we don't check for the
-# instability of these crates as they're all stable!
+# This is a whitelist of files which are stable crates or simply are not crates,
+# we don't check for the instability of these crates as they're all stable!
 STABLE_CRATES := \
 	std \
 	core \
@@ -9,7 +9,8 @@ STABLE_CRATES := \
 	rsbegin.o \
 	rsend.o \
 	dllcrt2.o \
-	crt2.o
+	crt2.o \
+	clang_rt.%_dynamic.dylib
 
 # Generate a list of all crates in the sysroot. To do this we list all files in
 # rustc's sysroot, look at the filename, strip everything after the `-`, and


### PR DESCRIPTION
[ASan](https://clang.llvm.org/docs/AddressSanitizer.html#supported-platforms) and [TSan](https://clang.llvm.org/docs/ThreadSanitizer.html#supported-platforms) are supported on macOS, and this commit enables their support.

The sanitizers are always built as `*.dylib` on Apple platforms, so they cannot be statically linked into the corresponding `rustc_?san.rlib`. The dylibs are directly copied to `lib/rustlib/x86_64-apple-darwin/lib/` instead.

Note, although Xcode also ships with their own copies of ASan/TSan dylibs, we cannot use them due to version mismatch.

----

~~There is a caveat: the sanitizer libraries are linked as `@rpath/` (due to https://reviews.llvm.org/D6018), so the user needs to additionally pass `-C rpath`:~~

**Edit:** Passing rpath is now automatic.

----

(cc #39699)