### PR TITLE
convert calls to `visit_all_item_likes_in_krate`

### DIFF
--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -61,8 +61,6 @@ pub enum DepNode<D: Clone + Debug> {
     RegionResolveCrate,
     PluginRegistrar,
     StabilityIndex,
-    CollectItem(D),
-    CollectItemSig(D),
     Coherence,
     Resolve,
     EntryPoint,
@@ -71,15 +69,9 @@ pub enum DepNode<D: Clone + Debug> {
     CoherenceCheckImpl(D),
     CoherenceOverlapCheck(D),
     CoherenceOverlapCheckSpecial(D),
-    CoherenceOrphanCheck(D),
     Variance,
-    WfCheck(D),
-    TypeckItemType(D),
     UnusedTraitCheck,
-    CheckConst(D),
     PrivacyAccessLevels(CrateNum),
-    IntrinsicCheck(D),
-    MatchCheck(D),
 
     // Represents the MIR for a fn; also used as the task node for
     // things read/modify that MIR.
@@ -92,7 +84,6 @@ pub enum DepNode<D: Clone + Debug> {
     RvalueCheck(D),
     Reachability,
     DeadCheck,
-    StabilityCheck(D),
     LateLintCheck,
     TransCrate,
     TransCrateItem(D),
@@ -184,12 +175,10 @@ impl<D: Clone + Debug> DepNode<D> {
         }
 
         check! {
-            CollectItem,
             BorrowCheck,
             Hir,
             HirBody,
             TransCrateItem,
-            TypeckItemType,
             AssociatedItems,
             ItemSignature,
             AssociatedItemDefIds,
@@ -237,18 +226,10 @@ impl<D: Clone + Debug> DepNode<D> {
             Hir(ref d) => op(d).map(Hir),
             HirBody(ref d) => op(d).map(HirBody),
             MetaData(ref d) => op(d).map(MetaData),
-            CollectItem(ref d) => op(d).map(CollectItem),
-            CollectItemSig(ref d) => op(d).map(CollectItemSig),
             CoherenceCheckTrait(ref d) => op(d).map(CoherenceCheckTrait),
             CoherenceCheckImpl(ref d) => op(d).map(CoherenceCheckImpl),
             CoherenceOverlapCheck(ref d) => op(d).map(CoherenceOverlapCheck),
             CoherenceOverlapCheckSpecial(ref d) => op(d).map(CoherenceOverlapCheckSpecial),
-            CoherenceOrphanCheck(ref d) => op(d).map(CoherenceOrphanCheck),
-            WfCheck(ref d) => op(d).map(WfCheck),
-            TypeckItemType(ref d) => op(d).map(TypeckItemType),
-            CheckConst(ref d) => op(d).map(CheckConst),
-            IntrinsicCheck(ref d) => op(d).map(IntrinsicCheck),
-            MatchCheck(ref d) => op(d).map(MatchCheck),
             Mir(ref d) => op(d).map(Mir),
             MirShim(ref def_ids) => {
                 let def_ids: Option<Vec<E>> = def_ids.iter().map(op).collect();
@@ -256,7 +237,6 @@ impl<D: Clone + Debug> DepNode<D> {
             }
             BorrowCheck(ref d) => op(d).map(BorrowCheck),
             RvalueCheck(ref d) => op(d).map(RvalueCheck),
-            StabilityCheck(ref d) => op(d).map(StabilityCheck),
             TransCrateItem(ref d) => op(d).map(TransCrateItem),
             TransInlinedItem(ref d) => op(d).map(TransInlinedItem),
             AssociatedItems(ref d) => op(d).map(AssociatedItems),

--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -56,21 +56,14 @@ pub enum DepNode<D: Clone + Debug> {
     WorkProduct(Arc<WorkProductId>),
 
     // Represents different phases in the compiler.
-    CollectLanguageItems,
-    ResolveLifetimes,
     RegionResolveCrate,
-    PluginRegistrar,
-    StabilityIndex,
     Coherence,
     Resolve,
-    EntryPoint,
-    CheckEntryFn,
     CoherenceCheckTrait(D),
     CoherenceCheckImpl(D),
     CoherenceOverlapCheck(D),
     CoherenceOverlapCheckSpecial(D),
     Variance,
-    UnusedTraitCheck,
     PrivacyAccessLevels(CrateNum),
 
     // Represents the MIR for a fn; also used as the task node for
@@ -83,13 +76,10 @@ pub enum DepNode<D: Clone + Debug> {
     BorrowCheck(D),
     RvalueCheck(D),
     Reachability,
-    DeadCheck,
     LateLintCheck,
-    TransCrate,
     TransCrateItem(D),
     TransInlinedItem(D),
     TransWriteMetadata,
-    LinkBinary,
 
     // Nodes representing bits of computed IR in the tcx. Each shared
     // table in the tcx (or elsewhere) maps to one of these
@@ -200,24 +190,14 @@ impl<D: Clone + Debug> DepNode<D> {
             BorrowCheckKrate => Some(BorrowCheckKrate),
             MirKrate => Some(MirKrate),
             TypeckBodiesKrate => Some(TypeckBodiesKrate),
-            CollectLanguageItems => Some(CollectLanguageItems),
-            ResolveLifetimes => Some(ResolveLifetimes),
             RegionResolveCrate => Some(RegionResolveCrate),
-            PluginRegistrar => Some(PluginRegistrar),
-            StabilityIndex => Some(StabilityIndex),
             Coherence => Some(Coherence),
             Resolve => Some(Resolve),
-            EntryPoint => Some(EntryPoint),
-            CheckEntryFn => Some(CheckEntryFn),
             Variance => Some(Variance),
-            UnusedTraitCheck => Some(UnusedTraitCheck),
             PrivacyAccessLevels(k) => Some(PrivacyAccessLevels(k)),
             Reachability => Some(Reachability),
-            DeadCheck => Some(DeadCheck),
             LateLintCheck => Some(LateLintCheck),
-            TransCrate => Some(TransCrate),
             TransWriteMetadata => Some(TransWriteMetadata),
-            LinkBinary => Some(LinkBinary),
 
             // work product names do not need to be mapped, because
             // they are always absolute.

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -12,7 +12,6 @@
 // closely. The idea is that all reachable symbols are live, codes called
 // from live codes are live, and everything else is dead.
 
-use dep_graph::DepNode;
 use hir::map as hir_map;
 use hir::{self, PatKind};
 use hir::intravisit::{self, Visitor, NestedVisitorMap};
@@ -594,7 +593,6 @@ impl<'a, 'tcx> Visitor<'tcx> for DeadVisitor<'a, 'tcx> {
 }
 
 pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
-    let _task = tcx.dep_graph.in_task(DepNode::DeadCheck);
     let access_levels = &ty::queries::privacy_access_levels::get(tcx, DUMMY_SP, LOCAL_CRATE);
     let krate = tcx.hir.krate();
     let live_symbols = find_live(tcx, access_levels, krate);

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 
-use dep_graph::DepNode;
 use hir::map as hir_map;
 use hir::def_id::{CRATE_DEF_INDEX};
 use session::{config, Session};
@@ -57,8 +56,6 @@ impl<'a, 'tcx> ItemLikeVisitor<'tcx> for EntryContext<'a, 'tcx> {
 }
 
 pub fn find_entry_point(session: &Session, hir_map: &hir_map::Map) {
-    let _task = hir_map.dep_graph.in_task(DepNode::EntryPoint);
-
     let any_exe = session.crate_types.borrow().iter().any(|ty| {
         *ty == config::CrateTypeExecutable
     });

--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use dep_graph::DepNode;
 use hir::def::Def;
 use hir::def_id::DefId;
 use infer::InferCtxt;
@@ -25,7 +24,7 @@ pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     let mut visitor = ItemVisitor {
         tcx: tcx
     };
-    tcx.visit_all_item_likes_in_krate(DepNode::IntrinsicCheck, &mut visitor.as_deep_visitor());
+    tcx.hir.krate().visit_all_item_likes(&mut visitor.as_deep_visitor());
 }
 
 struct ItemVisitor<'a, 'tcx: 'a> {

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -21,7 +21,6 @@
 
 pub use self::LangItem::*;
 
-use dep_graph::DepNode;
 use hir::map as hir_map;
 use session::Session;
 use hir::def_id::DefId;
@@ -236,7 +235,6 @@ pub fn extract(attrs: &[ast::Attribute]) -> Option<Symbol> {
 pub fn collect_language_items(session: &Session,
                               map: &hir_map::Map)
                               -> LanguageItems {
-    let _task = map.dep_graph.in_task(DepNode::CollectLanguageItems);
     let krate: &hir::Crate = map.krate();
     let mut collector = LanguageItemCollector::new(session, map);
     collector.collect(krate);

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -15,7 +15,6 @@
 //! used between functions, and they operate in a purely top-down
 //! way. Therefore we break lifetime name resolution into a separate pass.
 
-use dep_graph::DepNode;
 use hir::map::Map;
 use session::Session;
 use hir::def::Def;
@@ -259,7 +258,6 @@ const ROOT_SCOPE: ScopeRef<'static> = &Scope::Root;
 pub fn krate(sess: &Session,
              hir_map: &Map)
              -> Result<NamedRegionMap, usize> {
-    let _task = hir_map.dep_graph.in_task(DepNode::ResolveLifetimes);
     let krate = hir_map.krate();
     let mut map = NamedRegionMap {
         defs: NodeMap(),

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -424,7 +424,7 @@ impl<'a, 'tcx> Index<'tcx> {
 /// features and possibly prints errors.
 pub fn check_unstable_api_usage<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     let mut checker = Checker { tcx: tcx };
-    tcx.visit_all_item_likes_in_krate(DepNode::StabilityCheck, &mut checker.as_deep_visitor());
+    tcx.hir.krate().visit_all_item_likes(&mut checker.as_deep_visitor());
 }
 
 struct Checker<'a, 'tcx: 'a> {

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -13,7 +13,6 @@
 
 pub use self::StabilityLevel::*;
 
-use dep_graph::DepNode;
 use hir::map as hir_map;
 use lint;
 use hir::def::Def;
@@ -383,7 +382,6 @@ impl<'a, 'tcx> Index<'tcx> {
         // Put the active features into a map for quick lookup
         self.active_features = active_lib_features.iter().map(|&(ref s, _)| s.clone()).collect();
 
-        let _task = tcx.dep_graph.in_task(DepNode::StabilityIndex);
         let krate = tcx.hir.krate();
         let mut annotator = Annotator {
             tcx: tcx,
@@ -397,7 +395,6 @@ impl<'a, 'tcx> Index<'tcx> {
     }
 
     pub fn new(hir_map: &hir_map::Map) -> Index<'tcx> {
-        let _task = hir_map.dep_graph.in_task(DepNode::StabilityIndex);
         let krate = hir_map.krate();
 
         let mut is_staged_api = false;
@@ -662,7 +659,6 @@ pub fn check_unused_or_stable_features<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     let access_levels = &ty::queries::privacy_access_levels::get(tcx, DUMMY_SP, LOCAL_CRATE);
 
     if tcx.stability.borrow().staged_api[&LOCAL_CRATE] && tcx.sess.features.borrow().staged_api {
-        let _task = tcx.dep_graph.in_task(DepNode::StabilityIndex);
         let krate = tcx.hir.krate();
         let mut missing = MissingStabilityAnnotations {
             tcx: tcx,

--- a/src/librustc_const_eval/check_match.rs
+++ b/src/librustc_const_eval/check_match.rs
@@ -14,8 +14,6 @@ use _match::WitnessPreference::*;
 
 use pattern::{Pattern, PatternContext, PatternError, PatternKind};
 
-use rustc::dep_graph::DepNode;
-
 use rustc::middle::expr_use_visitor::{ConsumeMode, Delegate, ExprUseVisitor};
 use rustc::middle::expr_use_visitor::{LoanCause, MutateMode};
 use rustc::middle::expr_use_visitor as euv;
@@ -56,8 +54,7 @@ impl<'a, 'tcx> Visitor<'tcx> for OuterVisitor<'a, 'tcx> {
 }
 
 pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
-    tcx.visit_all_item_likes_in_krate(DepNode::MatchCheck,
-                                      &mut OuterVisitor { tcx: tcx }.as_deep_visitor());
+    tcx.hir.krate().visit_all_item_likes(&mut OuterVisitor { tcx: tcx }.as_deep_visitor());
     tcx.sess.abort_if_errors();
 }
 

--- a/src/librustc_driver/derive_registrar.rs
+++ b/src/librustc_driver/derive_registrar.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use rustc::dep_graph::DepNode;
 use rustc::hir::itemlikevisit::ItemLikeVisitor;
 use rustc::hir::map::Map;
 use rustc::hir;
@@ -16,7 +15,6 @@ use syntax::ast;
 use syntax::attr;
 
 pub fn find(hir_map: &Map) -> Option<ast::NodeId> {
-    let _task = hir_map.dep_graph.in_task(DepNode::PluginRegistrar);
     let krate = hir_map.krate();
 
     let mut finder = Finder { registrar: None };

--- a/src/librustc_mir/mir_map.rs
+++ b/src/librustc_mir/mir_map.rs
@@ -68,7 +68,7 @@ pub fn build_mir_for_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
                 NestedVisitorMap::None
             }
         }
-        tcx.visit_all_item_likes_in_krate(DepNode::Mir, &mut GatherCtors {
+        tcx.hir.krate().visit_all_item_likes(&mut GatherCtors {
             tcx: tcx
         }.as_deep_visitor());
     }

--- a/src/librustc_passes/consts.rs
+++ b/src/librustc_passes/consts.rs
@@ -24,7 +24,6 @@
 // - It's not possible to take the address of a static item with unsafe interior. This is enforced
 // by borrowck::gather_loans
 
-use rustc::dep_graph::DepNode;
 use rustc::ty::cast::CastKind;
 use rustc_const_eval::ConstContext;
 use rustc::middle::const_val::ConstEvalErr;
@@ -459,15 +458,14 @@ fn check_adjustments<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>, e: &hir::Exp
 }
 
 pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
-    tcx.visit_all_item_likes_in_krate(DepNode::CheckConst,
-                                      &mut CheckCrateVisitor {
-                                          tcx: tcx,
-                                          tables: &ty::TypeckTables::empty(),
-                                          in_fn: false,
-                                          promotable: false,
-                                          mut_rvalue_borrows: NodeSet(),
-                                          param_env: tcx.empty_parameter_environment(),
-                                      }.as_deep_visitor());
+    tcx.hir.krate().visit_all_item_likes(&mut CheckCrateVisitor {
+        tcx: tcx,
+        tables: &ty::TypeckTables::empty(),
+        in_fn: false,
+        promotable: false,
+        mut_rvalue_borrows: NodeSet(),
+        param_env: tcx.empty_parameter_environment(),
+    }.as_deep_visitor());
     tcx.sess.abort_if_errors();
 }
 

--- a/src/librustc_plugin/build.rs
+++ b/src/librustc_plugin/build.rs
@@ -14,7 +14,6 @@ use syntax::ast;
 use syntax::attr;
 use errors;
 use syntax_pos::Span;
-use rustc::dep_graph::DepNode;
 use rustc::hir::map::Map;
 use rustc::hir::itemlikevisit::ItemLikeVisitor;
 use rustc::hir;
@@ -44,7 +43,6 @@ impl<'v> ItemLikeVisitor<'v> for RegistrarFinder {
 pub fn find_plugin_registrar(diagnostic: &errors::Handler,
                              hir_map: &Map)
                              -> Option<ast::NodeId> {
-    let _task = hir_map.dep_graph.in_task(DepNode::PluginRegistrar);
     let krate = hir_map.krate();
 
     let mut finder = RegistrarFinder { registrars: Vec::new() };

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -192,8 +192,6 @@ pub fn link_binary(sess: &Session,
                    trans: &CrateTranslation,
                    outputs: &OutputFilenames,
                    crate_name: &str) -> Vec<PathBuf> {
-    let _task = sess.dep_graph.in_task(DepNode::LinkBinary);
-
     let mut out_filenames = Vec::new();
     for &crate_type in sess.crate_types.borrow().iter() {
         // Ignore executable crates if we have -Z no-trans, as they will error.

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -38,7 +38,7 @@ use rustc::hir::def_id::LOCAL_CRATE;
 use middle::lang_items::StartFnLangItem;
 use middle::cstore::EncodedMetadata;
 use rustc::ty::{self, Ty, TyCtxt};
-use rustc::dep_graph::{AssertDepGraphSafe, DepNode};
+use rustc::dep_graph::AssertDepGraphSafe;
 use rustc::middle::cstore::LinkMeta;
 use rustc::hir::map as hir_map;
 use rustc::util::common::time;
@@ -1057,8 +1057,6 @@ pub fn trans_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                              analysis: ty::CrateAnalysis,
                              incremental_hashes_map: &IncrementalHashesMap)
                              -> CrateTranslation {
-    let _task = tcx.dep_graph.in_task(DepNode::TransCrate);
-
     // Be careful with this krate: obviously it gives access to the
     // entire contents of the krate. So if you push any subtasks of
     // `TransCrate`, you need to be careful to register "reads" of the

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -82,7 +82,6 @@ pub use self::compare_method::{compare_impl_method, compare_const_impl};
 use self::TupleArgumentsFlag::*;
 
 use astconv::AstConv;
-use dep_graph::DepNode;
 use fmt_macros::{Parser, Piece, Position};
 use hir::def::{Def, CtorKind};
 use hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
@@ -577,14 +576,13 @@ impl<'a, 'tcx> ItemLikeVisitor<'tcx> for CheckItemTypesVisitor<'a, 'tcx> {
 pub fn check_wf_new<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) -> CompileResult {
     tcx.sess.track_errors(|| {
         let mut visit = wfcheck::CheckTypeWellFormedVisitor::new(tcx);
-        tcx.visit_all_item_likes_in_krate(DepNode::WfCheck, &mut visit.as_deep_visitor());
+        tcx.hir.krate().visit_all_item_likes(&mut visit.as_deep_visitor());
     })
 }
 
 pub fn check_item_types<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) -> CompileResult {
     tcx.sess.track_errors(|| {
-        tcx.visit_all_item_likes_in_krate(DepNode::TypeckItemType,
-                                          &mut CheckItemTypesVisitor { tcx });
+        tcx.hir.krate().visit_all_item_likes(&mut CheckItemTypesVisitor { tcx });
     })
 }
 

--- a/src/librustc_typeck/check_unused.rs
+++ b/src/librustc_typeck/check_unused.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 use lint;
-use rustc::dep_graph::DepNode;
 use rustc::ty::TyCtxt;
 
 use syntax::ast;
@@ -62,8 +61,6 @@ impl<'a, 'tcx, 'v> ItemLikeVisitor<'v> for CheckVisitor<'a, 'tcx> {
 }
 
 pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
-    let _task = tcx.dep_graph.in_task(DepNode::UnusedTraitCheck);
-
     let mut used_trait_imports = DefIdSet();
     for &body_id in tcx.hir.krate().bodies.keys() {
         let item_id = tcx.hir.body_owner(body_id);

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -18,7 +18,6 @@
 use hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use rustc::ty::{self, TyCtxt, TypeFoldable};
 use rustc::ty::maps::Providers;
-use rustc::dep_graph::DepNode;
 
 use syntax::ast;
 use syntax_pos::DUMMY_SP;
@@ -132,7 +131,6 @@ fn coherent_trait<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 }
 
 pub fn check_coherence<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
-    let _task = tcx.dep_graph.in_task(DepNode::Coherence);
     for &trait_def_id in tcx.hir.krate().trait_impls.keys() {
         ty::queries::coherent_trait::get(tcx, DUMMY_SP, (LOCAL_CRATE, trait_def_id));
     }

--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -13,13 +13,12 @@
 
 use rustc::traits;
 use rustc::ty::{self, TyCtxt};
-use rustc::dep_graph::DepNode;
 use rustc::hir::itemlikevisit::ItemLikeVisitor;
 use rustc::hir;
 
 pub fn check<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     let mut orphan = OrphanChecker { tcx: tcx };
-    tcx.visit_all_item_likes_in_krate(DepNode::CoherenceOrphanCheck, &mut orphan);
+    tcx.hir.krate().visit_all_item_likes(&mut orphan);
 }
 
 struct OrphanChecker<'cx, 'tcx: 'cx> {

--- a/src/librustc_typeck/coherence/overlap.rs
+++ b/src/librustc_typeck/coherence/overlap.rs
@@ -24,7 +24,7 @@ pub fn check_default_impls<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
 
     // this secondary walk specifically checks for some other cases,
     // like defaulted traits, for which additional overlap rules exist
-    tcx.visit_all_item_likes_in_krate(DepNode::CoherenceOverlapCheckSpecial, &mut overlap);
+    tcx.hir.krate().visit_all_item_likes(&mut overlap);
 }
 
 pub fn check_impl<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, node_id: ast::NodeId) {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -64,7 +64,6 @@ use rustc::ty::{ToPredicate, ReprOptions};
 use rustc::ty::{self, AdtKind, ToPolyTraitRef, Ty, TyCtxt};
 use rustc::ty::maps::Providers;
 use rustc::ty::util::IntTypeExt;
-use rustc::dep_graph::DepNode;
 use util::nodemap::{NodeMap, FxHashMap};
 
 use rustc_const_math::ConstInt;
@@ -87,7 +86,7 @@ use rustc::hir::def_id::DefId;
 
 pub fn collect_item_types<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     let mut visitor = CollectItemTypesVisitor { tcx: tcx };
-    tcx.visit_all_item_likes_in_krate(DepNode::CollectItem, &mut visitor.as_deep_visitor());
+    tcx.hir.krate().visit_all_item_likes(&mut visitor.as_deep_visitor());
 }
 
 pub fn provide(providers: &mut Providers) {
@@ -126,57 +125,13 @@ struct CollectItemTypesVisitor<'a, 'tcx: 'a> {
     tcx: TyCtxt<'a, 'tcx, 'tcx>
 }
 
-impl<'a, 'tcx> CollectItemTypesVisitor<'a, 'tcx> {
-    /// Collect item types is structured into two tasks. The outer
-    /// task, `CollectItem`, walks the entire content of an item-like
-    /// thing, including its body. It also spawns an inner task,
-    /// `CollectItemSig`, which walks only the signature. This inner
-    /// task is the one that writes the item-type into the various
-    /// maps.  This setup ensures that the item body is never
-    /// accessible to the task that computes its signature, so that
-    /// changes to the body don't affect the signature.
-    ///
-    /// Consider an example function `foo` that also has a closure in its body:
-    ///
-    /// ```
-    /// fn foo(<sig>) {
-    ///     ...
-    ///     let bar = || ...; // we'll label this closure as "bar" below
-    /// }
-    /// ```
-    ///
-    /// This results in a dep-graph like so. I've labeled the edges to
-    /// document where they arise.
-    ///
-    /// ```
-    /// [HirBody(foo)] -2--> [CollectItem(foo)] -4-> [ItemSignature(bar)]
-    ///                       ^           ^
-    ///                       1           3
-    /// [Hir(foo)] -----------+-6-> [CollectItemSig(foo)] -5-> [ItemSignature(foo)]
-    /// ```
-    ///
-    /// 1. This is added by the `visit_all_item_likes_in_krate`.
-    /// 2. This is added when we fetch the item body.
-    /// 3. This is added because `CollectItem` launches `CollectItemSig`.
-    ///    - it is arguably false; if we refactor the `with_task` system;
-    ///      we could get probably rid of it, but it is also harmless enough.
-    /// 4. This is added by the code in `visit_expr` when we write to `item_types`.
-    /// 5. This is added by the code in `convert_item` when we write to `item_types`;
-    ///    note that this write occurs inside the `CollectItemSig` task.
-    /// 6. Added by reads from within `op`.
-    fn with_collect_item_sig(&self, id: ast::NodeId, op: fn(TyCtxt<'a, 'tcx, 'tcx>, ast::NodeId)) {
-        let def_id = self.tcx.hir.local_def_id(id);
-        self.tcx.dep_graph.with_task(DepNode::CollectItemSig(def_id), self.tcx, id, op);
-    }
-}
-
 impl<'a, 'tcx> Visitor<'tcx> for CollectItemTypesVisitor<'a, 'tcx> {
     fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
         NestedVisitorMap::OnlyBodies(&self.tcx.hir)
     }
 
     fn visit_item(&mut self, item: &'tcx hir::Item) {
-        self.with_collect_item_sig(item.id, convert_item);
+        convert_item(self.tcx, item.id);
         intravisit::walk_item(self, item);
     }
 
@@ -209,12 +164,12 @@ impl<'a, 'tcx> Visitor<'tcx> for CollectItemTypesVisitor<'a, 'tcx> {
     }
 
     fn visit_trait_item(&mut self, trait_item: &'tcx hir::TraitItem) {
-        self.with_collect_item_sig(trait_item.id, convert_trait_item);
+        convert_trait_item(self.tcx, trait_item.id);
         intravisit::walk_trait_item(self, trait_item);
     }
 
     fn visit_impl_item(&mut self, impl_item: &'tcx hir::ImplItem) {
-        self.with_collect_item_sig(impl_item.id, convert_impl_item);
+        convert_impl_item(self.tcx, impl_item.id);
         intravisit::walk_impl_item(self, impl_item);
     }
 }

--- a/src/librustc_typeck/impl_wf_check.rs
+++ b/src/librustc_typeck/impl_wf_check.rs
@@ -19,7 +19,6 @@
 //! fixed, but for the moment it's easier to do these checks early.
 
 use constrained_type_params as ctp;
-use rustc::dep_graph::DepNode;
 use rustc::hir;
 use rustc::hir::itemlikevisit::ItemLikeVisitor;
 use rustc::hir::def_id::DefId;
@@ -63,7 +62,7 @@ pub fn impl_wf_check<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     // We will tag this as part of the WF check -- logically, it is,
     // but it's one that we must perform earlier than the rest of
     // WfCheck.
-    tcx.visit_all_item_likes_in_krate(DepNode::WfCheck, &mut ImplWfCheck { tcx: tcx });
+    tcx.hir.krate().visit_all_item_likes(&mut ImplWfCheck { tcx: tcx });
 }
 
 struct ImplWfCheck<'a, 'tcx: 'a> {

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -104,7 +104,6 @@ pub use rustc::middle;
 pub use rustc::session;
 pub use rustc::util;
 
-use dep_graph::DepNode;
 use hir::map as hir_map;
 use rustc::infer::InferOk;
 use rustc::ty::subst::Substs;
@@ -273,7 +272,6 @@ fn check_start_fn_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 }
 
 fn check_for_entry_fn<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
-    let _task = tcx.dep_graph.in_task(DepNode::CheckEntryFn);
     if let Some((id, sp)) = *tcx.sess.entry_fn.borrow() {
         match tcx.sess.entry_type.get() {
             Some(config::EntryMain) => check_main_fn_ty(tcx, id, sp),

--- a/src/test/compile-fail/dep-graph-struct-signature.rs
+++ b/src/test/compile-fail/dep-graph-struct-signature.rs
@@ -35,44 +35,36 @@ mod signatures {
     use WillChange;
 
     #[rustc_then_this_would_need(ItemSignature)] //~ ERROR no path
-    #[rustc_then_this_would_need(CollectItem)] //~ ERROR no path
     trait Bar {
         #[rustc_then_this_would_need(ItemSignature)] //~ ERROR OK
-        #[rustc_then_this_would_need(CollectItem)] //~ ERROR OK
         fn do_something(x: WillChange);
     }
 
     #[rustc_then_this_would_need(ItemSignature)] //~ ERROR OK
-    #[rustc_then_this_would_need(CollectItem)] //~ ERROR OK
     fn some_fn(x: WillChange) { }
 
     #[rustc_then_this_would_need(ItemSignature)] //~ ERROR OK
-    #[rustc_then_this_would_need(CollectItem)] //~ ERROR OK
     fn new_foo(x: u32, y: u32) -> WillChange {
         WillChange { x: x, y: y }
     }
 
     #[rustc_then_this_would_need(ItemSignature)] //~ ERROR OK
-    #[rustc_then_this_would_need(CollectItem)] //~ ERROR OK
     impl WillChange {
         fn new(x: u32, y: u32) -> WillChange { loop { } }
     }
 
     #[rustc_then_this_would_need(ItemSignature)] //~ ERROR OK
-    #[rustc_then_this_would_need(CollectItem)] //~ ERROR OK
     impl WillChange {
         fn method(&self, x: u32) { }
     }
 
     #[rustc_then_this_would_need(ItemSignature)] //~ ERROR OK
-    #[rustc_then_this_would_need(CollectItem)] //~ ERROR OK
     struct WillChanges {
         x: WillChange,
         y: WillChange
     }
 
     #[rustc_then_this_would_need(ItemSignature)] //~ ERROR OK
-    #[rustc_then_this_would_need(CollectItem)] //~ ERROR OK
     fn indirect(x: WillChanges) { }
 }
 
@@ -80,17 +72,14 @@ mod invalid_signatures {
     use WontChange;
 
     #[rustc_then_this_would_need(ItemSignature)] //~ ERROR no path
-    #[rustc_then_this_would_need(CollectItem)] //~ ERROR no path
     trait A {
         fn do_something_else_twice(x: WontChange);
     }
 
     #[rustc_then_this_would_need(ItemSignature)] //~ ERROR no path
-    #[rustc_then_this_would_need(CollectItem)] //~ ERROR no path
     fn b(x: WontChange) { }
 
     #[rustc_then_this_would_need(ItemSignature)] //~ ERROR no path from `WillChange`
-    #[rustc_then_this_would_need(CollectItem)] //~ ERROR no path from `WillChange`
     fn c(x: u32) { }
 }
 


### PR DESCRIPTION
We no longer need to track the tasks in these cases since these
particular tasks have no outputs (except, potentially, errors...)  and
they always execute.

cc #40746 

r? @eddyb 