### PR TITLE
Run tests for the cargo submodule in tree

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -78,14 +78,6 @@ pub fn linkcheck(build: &Build, host: &str) {
 pub fn cargotest(build: &Build, stage: u32, host: &str) {
     let ref compiler = Compiler::new(stage, host);
 
-    // Configure PATH to find the right rustc. NB. we have to use PATH
-    // and not RUSTC because the Cargo test suite has tests that will
-    // fail if rustc is not spelled `rustc`.
-    let path = build.sysroot(compiler).join("bin");
-    let old_path = ::std::env::var("PATH").expect("");
-    let sep = if cfg!(windows) { ";" } else {":" };
-    let ref newpath = format!("{}{}{}", path.display(), sep, old_path);
-
     // Note that this is a short, cryptic, and not scoped directory name. This
     // is currently to minimize the length of path on Windows where we otherwise
     // quickly run into path name limit constraints.
@@ -95,9 +87,35 @@ pub fn cargotest(build: &Build, stage: u32, host: &str) {
     let _time = util::timeit();
     let mut cmd = Command::new(build.tool(&Compiler::new(0, host), "cargotest"));
     build.prepare_tool_cmd(compiler, &mut cmd);
-    build.run(cmd.env("PATH", newpath)
-                 .arg(&build.cargo)
-                 .arg(&out_dir));
+    build.run(cmd.arg(&build.cargo)
+                 .arg(&out_dir)
+                 .env("RUSTC", build.compiler_path(compiler))
+                 .env("RUSTDOC", build.rustdoc(compiler)))
+}
+
+/// Runs `cargo test` for `cargo` packaged with Rust.
+pub fn cargo(build: &Build, stage: u32, host: &str) {
+    let ref compiler = Compiler::new(stage, host);
+
+    // Configure PATH to find the right rustc. NB. we have to use PATH
+    // and not RUSTC because the Cargo test suite has tests that will
+    // fail if rustc is not spelled `rustc`.
+    let path = build.sysroot(compiler).join("bin");
+    let old_path = ::std::env::var("PATH").expect("");
+    let sep = if cfg!(windows) { ";" } else {":" };
+    let ref newpath = format!("{}{}{}", path.display(), sep, old_path);
+
+    let mut cargo = build.cargo(compiler, Mode::Tool, host, "test");
+    cargo.arg("--manifest-path").arg(build.src.join("cargo/Cargo.toml"));
+
+    // Don't build tests dynamically, just a pain to work with
+    cargo.env("RUSTC_NO_PREFER_DYNAMIC", "1");
+
+    // Don't run cross-compile tests, we may not have cross-compiled libstd libs
+    // available.
+    cargo.env("CFG_DISABLE_CROSS_TESTS", "1");
+
+    build.run(cargo.env("PATH", newpath));
 }
 
 /// Runs the `tidy` tool as compiled in `stage` by the `host` compiler.

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -557,6 +557,19 @@ impl Build {
             cargo.env("RUSTC_SAVE_ANALYSIS", "api".to_string());
         }
 
+        // When being built Cargo will at some point call `nmake.exe` on Windows
+        // MSVC. Unfortunately `nmake` will read these two environment variables
+        // below and try to intepret them. We're likely being run, however, from
+        // MSYS `make` which uses the same variables.
+        //
+        // As a result, to prevent confusion and errors, we remove these
+        // variables from our environment to prevent passing MSYS make flags to
+        // nmake, causing it to blow up.
+        if cfg!(target_env = "msvc") {
+            cargo.env_remove("MAKE");
+            cargo.env_remove("MAKEFLAGS");
+        }
+
         // Environment variables *required* needed throughout the build
         //
         // FIXME: should update code to not require this env var

--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -55,6 +55,7 @@ check:
 check-aux:
 	$(Q)$(BOOTSTRAP) test \
 		src/tools/cargotest \
+		cargo \
 		src/test/pretty \
 		src/test/run-pass/pretty \
 		src/test/run-fail/pretty \

--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -470,6 +470,10 @@ pub fn build_rules<'a>(build: &'a Build) -> Rules {
          .dep(|s| s.name("librustc"))
          .host(true)
          .run(move |s| check::cargotest(build, s.stage, s.target));
+    rules.test("check-cargo", "cargo")
+         .dep(|s| s.name("tool-cargo"))
+         .host(true)
+         .run(move |s| check::cargo(build, s.stage, s.target));
     rules.test("check-tidy", "src/tools/tidy")
          .dep(|s| s.name("tool-tidy").stage(0))
          .default(true)

--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -23,12 +23,6 @@ struct Test {
 
 const TEST_REPOS: &'static [Test] = &[
     Test {
-        name: "cargo",
-        repo: "https://github.com/rust-lang/cargo",
-        sha: "0e1e34be7540bdaed4918457654fbf028cf69e56",
-        lock: None,
-    },
-    Test {
         name: "iron",
         repo: "https://github.com/iron/iron",
         sha: "21c7dae29c3c214c08533c2a55ac649b418f2fe3",
@@ -61,20 +55,6 @@ const TEST_REPOS: &'static [Test] = &[
 ];
 
 fn main() {
-    // One of the projects being tested here is Cargo, and when being tested
-    // Cargo will at some point call `nmake.exe` on Windows MSVC. Unfortunately
-    // `nmake` will read these two environment variables below and try to
-    // intepret them. We're likely being run, however, from MSYS `make` which
-    // uses the same variables.
-    //
-    // As a result, to prevent confusion and errors, we remove these variables
-    // from our environment to prevent passing MSYS make flags to nmake, causing
-    // it to blow up.
-    if cfg!(target_env = "msvc") {
-        env::remove_var("MAKE");
-        env::remove_var("MAKEFLAGS");
-    }
-
     let args = env::args().collect::<Vec<_>>();
     let ref cargo = args[1];
     let out_dir = Path::new(&args[2]);


### PR DESCRIPTION
Previously the `cargotest` suite would run some arbitrary revision of Cargo's
test suite, but now that we're bundling it in tree we should be running the
Cargo submodule's test suite instead.