### PR TITLE
[beta] Fix link to book repo

### DIFF
--- a/src/doc/book/src/README.md
+++ b/src/doc/book/src/README.md
@@ -36,4 +36,4 @@ is the first. After this:
 The source files from which this book is generated can be found on
 [GitHub][book].
 
-[book]: https://github.com/rust-lang/rust/tree/master/src/doc/book
+[book]: https://github.com/rust-lang/book/tree/master/first-edition/src


### PR DESCRIPTION
This is a backport to beta, to be clear. I don't think we *have* to take this, but opened this PR to see if we should consider it to save six weeks of breakage.

Due to extracting the book out into its own repo, this link is broken. This fixes it to point to the right place. This was originally filed as https://github.com/rust-lang/book/issues/633.