### PR TITLE
Bump stage0 to fix ARM LLVM

### DIFF
--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,4 +12,4 @@
 # tarball for a stable release you'll likely see `1.x.0-$date` where `1.x.0` was
 # released on `$date`
 
-rustc: beta-2017-03-21
+rustc: beta-2017-04-05


### PR DESCRIPTION
There was a serious ARM codegen bug in LLVM that was fixed by #40779,
also backported to beta.  This updates stage0 to 1.17.0-beta.3 to pick
up that change, so ARM can bootstrap natively again.

Fixes #41291
cc @arielb1