### PR TITLE
Use an (over-writable) environment variable for the `gdb` command

### DIFF
--- a/src/etc/rust-gdb
+++ b/src/etc/rust-gdb
@@ -17,10 +17,10 @@ RUSTC_SYSROOT=`rustc --print=sysroot`
 GDB_PYTHON_MODULE_DIRECTORY="$RUSTC_SYSROOT/lib/rustlib/etc"
 
 # Run GDB with the additional arguments that load the pretty printers
-# Set the environment variable `GDB_CMD` to overwrite the call to a
+# Set the environment variable `RUST_GDB` to overwrite the call to a
 # different/specific command (defaults to `gdb`).
-GDB_CMD="${GDB_CMD:-gdb}"
-PYTHONPATH="$PYTHONPATH:$GDB_PYTHON_MODULE_DIRECTORY" ${GDB_CMD} \
+RUST_GDB="${RUST_GDB:-gdb}"
+PYTHONPATH="$PYTHONPATH:$GDB_PYTHON_MODULE_DIRECTORY" ${RUST_GDB} \
   -d "$GDB_PYTHON_MODULE_DIRECTORY" \
   -iex "add-auto-load-safe-path $GDB_PYTHON_MODULE_DIRECTORY" \
   "$@"

--- a/src/etc/rust-gdb
+++ b/src/etc/rust-gdb
@@ -17,7 +17,10 @@ RUSTC_SYSROOT=`rustc --print=sysroot`
 GDB_PYTHON_MODULE_DIRECTORY="$RUSTC_SYSROOT/lib/rustlib/etc"
 
 # Run GDB with the additional arguments that load the pretty printers
-PYTHONPATH="$PYTHONPATH:$GDB_PYTHON_MODULE_DIRECTORY" gdb \
+# Set the environment variable `GDB_CMD` to overwrite the call to a
+# different/specific command (defaults to `gdb`).
+GDB_CMD="${GDB_CMD:-gdb}"
+PYTHONPATH="$PYTHONPATH:$GDB_PYTHON_MODULE_DIRECTORY" ${GDB_CMD} \
   -d "$GDB_PYTHON_MODULE_DIRECTORY" \
   -iex "add-auto-load-safe-path $GDB_PYTHON_MODULE_DIRECTORY" \
   "$@"


### PR DESCRIPTION
Instead of hard-coding the command to run, using the environment
variable `GDB_CMD` (that defaults to `gdb`) allows using a different
debugger than the default `gdb` executable.

This gives the possibility to use `cgdb` as the debugger, which provides
a nicer user interface. Note that one has to use `GDB_CMD="cgdb --"` to
use cgdb (note the trailing `--`) to let cgdb pass the proper arguments
to `gdb`.