### PR TITLE
[WIP] Reduce HTML output in rustdoc

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -293,6 +293,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "minifier"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,6 +785,7 @@ dependencies = [
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "minifier 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc 0.0.0",
  "rustc_back 0.0.0",
@@ -1006,6 +1015,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5141eca02775a762cc6cd564d8d2c50f67c0ea3a372cbf1c51592b3e029e10ad"
 "checksum mdbook 0.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "06a68e8738e42b38a02755d3ce5fa12d559e17acb238e4326cbc3cc056e65280"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
+"checksum minifier 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e0880c7490a97dd8f99630b9e956fa70d85d961b5938da11d819e7dd85ea0"
 "checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
 "checksum num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "cee7e88156f3f9e19bdd598f8d6c9db7bf4078f99f8381f43a55b09648d1a6e3"
 "checksum open 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3478ed1686bd1300c8a981a940abc92b06fac9cbef747f4c668d4e032ff7b842"

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -26,6 +26,7 @@ serialize = { path = "../libserialize" }
 syntax = { path = "../libsyntax" }
 syntax_pos = { path = "../libsyntax_pos" }
 pulldown-cmark = { version = "0.0.14", default-features = false }
+minifier = "0.0.3"
 
 [build-dependencies]
 build_helper = { path = "../build_helper" }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -75,6 +75,8 @@ use html::item_type::ItemType;
 use html::markdown::{self, Markdown, MarkdownHtml, MarkdownSummaryLine};
 use html::{highlight, layout};
 
+use minifier::html::minify;
+
 /// A pair of name and its optional document.
 pub type NameDoc = (String, Option<String>);
 
@@ -951,13 +953,14 @@ impl<'a> SourceCollector<'a> {
             href.push_str(component);
             href.push('/');
         });
-        let mut fname = p.file_name().expect("source has no filename")
+        let mut fname = p.file_name()
+                         .expect("source has no filename")
                          .to_os_string();
         fname.push(".html");
         cur.push(&fname);
         href.push_str(&fname.to_string_lossy());
 
-        let mut w = BufWriter::new(File::create(&cur)?);
+        let mut w = BufWriter::new(Vec::new());
         let title = format!("{} -- source", cur.file_name().unwrap()
                                                .to_string_lossy());
         let desc = format!("Source to the Rust file `{}`.", filename);
@@ -972,6 +975,12 @@ impl<'a> SourceCollector<'a> {
                        &page, &(""), &Source(contents),
                        self.scx.css_file_extension.is_some())?;
         w.flush()?;
+        let mut file = File::create(&cur)?;
+        let content = unsafe {
+            minify(&String::from_utf8_unchecked(w.into_inner().expect("Couldn't get html content")))
+        };
+        file.write(content.as_bytes())?;
+        file.sync_all()?;
         self.scx.local_sources.insert(p, href);
         Ok(())
     }
@@ -1362,7 +1371,8 @@ impl Context {
                     let joint_dst = this.dst.join("index.html");
                     try_err!(fs::create_dir_all(&this.dst), &this.dst);
                     let mut dst = try_err!(File::create(&joint_dst), &joint_dst);
-                    try_err!(dst.write_all(&buf), &joint_dst);
+                    let content = unsafe { minify(&String::from_utf8_unchecked(buf)) };
+                    try_err!(dst.write_all(content.as_bytes()), &joint_dst);
                 }
 
                 let m = match item.inner {

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -32,6 +32,7 @@ extern crate arena;
 extern crate getopts;
 extern crate env_logger;
 extern crate libc;
+extern crate minifier;
 extern crate rustc;
 extern crate rustc_data_structures;
 extern crate rustc_trans;


### PR DESCRIPTION
```bash
 > du -sh normal/std/index.html
 60K	normal/std/index.html
 > du -sh build/x86_64-apple-darwin/doc/std/index.html
 36K	build/x86_64-apple-darwin/doc/std/index.html
```

r? @rust-lang/docs 