### PR TITLE
Disable git caches again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -192,10 +192,6 @@ before_cache:
     grep -v missing |
     xargs docker save |
     gzip > $HOME/docker/rust-ci.tar.gz
-  - if [ ! -f $HOME/rustsrc/cache_valid1 ]; then
-        echo "WARNING rustsrc cache was invalid when saving";
-        rm -rf $HOME/rustsrc && mkdir $HOME/rustsrc;
-    fi
 before_install:
   - zcat $HOME/docker/rust-ci.tar.gz | docker load || true
   - mkdir -p $HOME/rustsrc
@@ -206,7 +202,6 @@ notifications:
 cache:
   directories:
     - $HOME/docker
-    - $HOME/rustsrc
 
 before_deploy:
   - mkdir -p deploy/$TRAVIS_COMMIT

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -151,7 +151,6 @@ on_failure:
   - cat %CD%\sccache.log || exit 0
 
 cache:
-  - C:\cache\rustsrc
   - "build/i686-pc-windows-msvc/llvm -> src/rustllvm/llvm-rebuild-trigger"
   - "build/x86_64-pc-windows-msvc/llvm -> src/rustllvm/llvm-rebuild-trigger"
   - "i686-pc-windows-msvc/llvm -> src/rustllvm/llvm-rebuild-trigger"


### PR DESCRIPTION
The appveyor ones aren't working anyway (I need to talk to appveyor about them being corrupt) and the travis cache is taking too long to restore and is being killed, which is sometimes causing bad things to happen because the integrity checking made assumptions that restore was atomic.

I could fix the integrity checks, but we clearly need a different approach if restore is taking too long. Let's disable it all for now.