### PR TITLE
traits::select: quickly filter out predicates from other traits

### DIFF
--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -1300,8 +1300,13 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
                             .iter()
                             .filter_map(|o| o.to_opt_poly_trait_ref());
 
+        // micro-optimization: filter out predicates relating to different
+        // traits.
         let matching_bounds =
-            all_bounds.filter(
+            all_bounds.filter(|p| p.def_id() == stack.obligation.predicate.def_id());
+
+        let matching_bounds =
+            matching_bounds.filter(
                 |bound| self.evaluate_where_clause(stack, bound.clone()).may_apply());
 
         let param_candidates =


### PR DESCRIPTION
this improves most pre-trans passes's performance by ~1%.

That missed the spring cleaning PR because I wanted to ship it.

r? @eddyb