### PR TITLE
Attempt to make the android emulator use less CPU

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   fast_finish: true
   include:
     # Linux builders, all docker images
-    - env: IMAGE=arm-android
+    - env: IMAGE=arm-android ALLOW_PR=1
     - env: IMAGE=armhf-gnu
     - env: IMAGE=cross DEPLOY=1
     - env: IMAGE=dist-aarch64-linux DEPLOY=1

--- a/src/ci/docker/arm-android/Dockerfile
+++ b/src/ci/docker/arm-android/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:16.04
 
+RUN dpkg --add-architecture i386 && apt-get update && apt-get install -y eatmydata libeatmydata1:i386 && ls -hl /usr/lib/x86_64-linux-gnu/libeatmydata.so
+ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libeatmydata.so
+
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/src/ci/docker/arm-android/install-sdk.sh
+++ b/src/ci/docker/arm-android/install-sdk.sh
@@ -32,5 +32,5 @@ echo "no" | android create avd \
                 --target android-18 \
                 --abi armeabi-v7a
 stat /root/.android/avd/arm-18.avd/config.ini
-/bin/echo -e '\nhw.audioInput=no\nhw.audioOutput=no\n' >> \
+/bin/echo -e '\nhw.audioInput=no\nhw.audioOutput=no\nhw.trackBall=no\nhw.mainKeys=no\nhw.gsmModem=no\nhw.gps=no\nhw.battery=no\nhw.accelerometer=no\nhw.sdCard=no\nhw.lcd.backlight=no\nhw.camera.back=none\nhw.sensors.proximity=no\nhw.sensors.magnetic_field=no\nhw.sensors.orientation=no\nhw.sensors.temperature=no' >> \
     /root/.android/avd/arm-18.avd/config.ini

--- a/src/ci/docker/arm-android/install-sdk.sh
+++ b/src/ci/docker/arm-android/install-sdk.sh
@@ -31,3 +31,6 @@ echo "no" | android create avd \
                 --name arm-18 \
                 --target android-18 \
                 --abi armeabi-v7a
+stat /root/.android/avd/arm-18.avd/config.ini
+/bin/echo -e '\nhw.audioInput=no\nhw.audioOutput=no\n' >> \
+    /root/.android/avd/arm-18.avd/config.ini

--- a/src/ci/docker/arm-android/start-emulator.sh
+++ b/src/ci/docker/arm-android/start-emulator.sh
@@ -14,5 +14,7 @@ set -ex
 # Setting SHELL to a file instead on a symlink helps android
 # emulator identify the system
 export SHELL=/bin/bash
-nohup nohup emulator @arm-18 -no-window -partition-size 2047 0<&- &>/dev/null &
+stat $LD_PRELOAD
+stat /usr/lib/i386-linux-gnu/libeatmydata.so
+LD_PRELOAD="/usr/lib/i386-linux-gnu/libeatmydata.so $LD_PRELOAD" nohup nohup emulator @arm-18 -no-window -partition-size 2047 0<&- &>/dev/null &
 exec "$@"

--- a/src/ci/docker/arm-android/start-emulator.sh
+++ b/src/ci/docker/arm-android/start-emulator.sh
@@ -16,5 +16,5 @@ set -ex
 export SHELL=/bin/bash
 stat $LD_PRELOAD
 stat /usr/lib/i386-linux-gnu/libeatmydata.so
-LD_PRELOAD="/usr/lib/i386-linux-gnu/libeatmydata.so $LD_PRELOAD" nohup nohup emulator @arm-18 -no-window -partition-size 2047 0<&- &>/dev/null &
+LD_PRELOAD="/usr/lib/i386-linux-gnu/libeatmydata.so $LD_PRELOAD" nohup nohup emulator @arm-18 -no-boot-anim -no-window -partition-size 2047 0<&- &>/dev/null &
 exec "$@"


### PR DESCRIPTION
I was playing around locally and noticed constant ~90% cpu usage of one core and found http://stackoverflow.com/questions/7297585/android-emulator-uses-100-cpu-even-if-nothing-i-running-on-it. Maybe this is one reason why Android builds are so slow?

Since the queue is empty I've set `ALLOW_PR=1` for android so we can if my theory is correct and the PR build is actually faster. I'll remove it before this gets merged.

r? @alexcrichton 