### PR TITLE
[stable] Prepare the 1.17.0 release

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -41,7 +41,7 @@ fi
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
 if [ "$DEPLOY$DEPLOY_ALT" != "" ]; then
-  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=beta"
+  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=stable"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"
 
   if [ "$NO_LLVM_ASSERTIONS" = "1" ]; then


### PR DESCRIPTION
* Update channel we're building
* Update the cargo submodule to the tip of the `rust-1.17.0` branch