### PR TITLE
reduce stack requirements for floating-point formatting

### DIFF
--- a/src/libcore/benches/num/flt2dec/mod.rs
+++ b/src/libcore/benches/num/flt2dec/mod.rs
@@ -13,6 +13,10 @@ mod strategy {
     mod grisu;
 }
 
+use std::f64;
+use std::io::Write;
+use std::vec::Vec;
+use test::Bencher;
 use core::num::flt2dec::{decode, DecodableFloat, FullDecoded, Decoded};
 use core::num::flt2dec::MAX_SIG_DIGITS;
 
@@ -21,4 +25,24 @@ pub fn decode_finite<T: DecodableFloat>(v: T) -> Decoded {
         FullDecoded::Finite(decoded) => decoded,
         full_decoded => panic!("expected finite, got {:?} instead", full_decoded)
     }
+}
+
+#[bench]
+fn bench_small_shortest(b: &mut Bencher) {
+    let mut buf = Vec::with_capacity(20);
+
+    b.iter(|| {
+        buf.clear();
+        write!(&mut buf, "{}", 3.1415926f64).unwrap()
+    });
+}
+
+#[bench]
+fn bench_big_shortest(b: &mut Bencher) {
+    let mut buf = Vec::with_capacity(300);
+
+    b.iter(|| {
+        buf.clear();
+        write!(&mut buf, "{}", f64::MAX).unwrap()
+    });
 }

--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -11,6 +11,35 @@
 use fmt::{Formatter, Result, LowerExp, UpperExp, Display, Debug};
 use num::flt2dec;
 
+// Don't inline this so callers don't use the stack space this function
+// requires unless they have to.
+#[inline(never)]
+fn float_to_decimal_common_exact<T>(fmt: &mut Formatter, num: &T,
+                                    sign: flt2dec::Sign, precision: usize) -> Result
+    where T: flt2dec::DecodableFloat
+{
+    let mut buf = [0; 1024]; // enough for f32 and f64
+    let mut parts = [flt2dec::Part::Zero(0); 16];
+    let formatted = flt2dec::to_exact_fixed_str(flt2dec::strategy::grisu::format_exact,
+                                                *num, sign, precision,
+                                                false, &mut buf, &mut parts);
+    fmt.pad_formatted_parts(&formatted)
+}
+
+// Don't inline this so callers that call both this and the above won't wind
+// up using the combined stack space of both functions in some cases.
+#[inline(never)]
+fn float_to_decimal_common_shortest<T>(fmt: &mut Formatter,
+                                       num: &T, sign: flt2dec::Sign) -> Result
+    where T: flt2dec::DecodableFloat
+{
+    let mut buf = [0; flt2dec::MAX_SIG_DIGITS]; // enough for f32 and f64
+    let mut parts = [flt2dec::Part::Zero(0); 16];
+    let formatted = flt2dec::to_shortest_str(flt2dec::strategy::grisu::format_shortest,
+                                             *num, sign, 0, false, &mut buf, &mut parts);
+    fmt.pad_formatted_parts(&formatted)
+}
+
 // Common code of floating point Debug and Display.
 fn float_to_decimal_common<T>(fmt: &mut Formatter, num: &T, negative_zero: bool) -> Result
     where T: flt2dec::DecodableFloat
@@ -23,15 +52,41 @@ fn float_to_decimal_common<T>(fmt: &mut Formatter, num: &T, negative_zero: bool)
         (true,  true)  => flt2dec::Sign::MinusPlusRaw,
     };
 
+    if let Some(precision) = fmt.precision {
+        float_to_decimal_common_exact(fmt, num, sign, precision)
+    } else {
+        float_to_decimal_common_shortest(fmt, num, sign)
+    }
+}
+
+// Don't inline this so callers don't use the stack space this function
+// requires unless they have to.
+#[inline(never)]
+fn float_to_exponential_common_exact<T>(fmt: &mut Formatter, num: &T,
+                                        sign: flt2dec::Sign, precision: usize,
+                                        upper: bool) -> Result
+    where T: flt2dec::DecodableFloat
+{
     let mut buf = [0; 1024]; // enough for f32 and f64
     let mut parts = [flt2dec::Part::Zero(0); 16];
-    let formatted = if let Some(precision) = fmt.precision {
-        flt2dec::to_exact_fixed_str(flt2dec::strategy::grisu::format_exact, *num, sign,
-                                    precision, false, &mut buf, &mut parts)
-    } else {
-        flt2dec::to_shortest_str(flt2dec::strategy::grisu::format_shortest, *num, sign,
-                                 0, false, &mut buf, &mut parts)
-    };
+    let formatted = flt2dec::to_exact_exp_str(flt2dec::strategy::grisu::format_exact,
+                                              *num, sign, precision,
+                                              upper, &mut buf, &mut parts);
+    fmt.pad_formatted_parts(&formatted)
+}
+
+// Don't inline this so callers that call both this and the above won't wind
+// up using the combined stack space of both functions in some cases.
+#[inline(never)]
+fn float_to_exponential_common_shortest<T>(fmt: &mut Formatter,
+                                           num: &T, sign: flt2dec::Sign,
+                                           upper: bool) -> Result
+    where T: flt2dec::DecodableFloat
+{
+    let mut buf = [0; flt2dec::MAX_SIG_DIGITS]; // enough for f32 and f64
+    let mut parts = [flt2dec::Part::Zero(0); 16];
+    let formatted = flt2dec::to_shortest_exp_str(flt2dec::strategy::grisu::format_shortest, *num,
+                                                 sign, (0, 0), upper, &mut buf, &mut parts);
     fmt.pad_formatted_parts(&formatted)
 }
 
@@ -45,17 +100,12 @@ fn float_to_exponential_common<T>(fmt: &mut Formatter, num: &T, upper: bool) -> 
         true  => flt2dec::Sign::MinusPlus,
     };
 
-    let mut buf = [0; 1024]; // enough for f32 and f64
-    let mut parts = [flt2dec::Part::Zero(0); 16];
-    let formatted = if let Some(precision) = fmt.precision {
+    if let Some(precision) = fmt.precision {
         // 1 integral digit + `precision` fractional digits = `precision + 1` total digits
-        flt2dec::to_exact_exp_str(flt2dec::strategy::grisu::format_exact, *num, sign,
-                                  precision + 1, upper, &mut buf, &mut parts)
+        float_to_exponential_common_exact(fmt, num, sign, precision + 1, upper)
     } else {
-        flt2dec::to_shortest_exp_str(flt2dec::strategy::grisu::format_shortest, *num, sign,
-                                     (0, 0), upper, &mut buf, &mut parts)
-    };
-    fmt.pad_formatted_parts(&formatted)
+        float_to_exponential_common_shortest(fmt, num, sign, upper)
+    }
 }
 
 macro_rules! floating {

--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use fmt::{Formatter, Result, LowerExp, UpperExp, Display, Debug};
+use mem;
 use num::flt2dec;
 
 // Don't inline this so callers don't use the stack space this function
@@ -18,12 +19,14 @@ fn float_to_decimal_common_exact<T>(fmt: &mut Formatter, num: &T,
                                     sign: flt2dec::Sign, precision: usize) -> Result
     where T: flt2dec::DecodableFloat
 {
-    let mut buf = [0; 1024]; // enough for f32 and f64
-    let mut parts = [flt2dec::Part::Zero(0); 5];
-    let formatted = flt2dec::to_exact_fixed_str(flt2dec::strategy::grisu::format_exact,
-                                                *num, sign, precision,
-                                                false, &mut buf, &mut parts);
-    fmt.pad_formatted_parts(&formatted)
+    unsafe {
+        let mut buf: [u8; 1024] = mem::uninitialized(); // enough for f32 and f64
+        let mut parts: [flt2dec::Part; 5] = mem::uninitialized();
+        let formatted = flt2dec::to_exact_fixed_str(flt2dec::strategy::grisu::format_exact,
+                                                    *num, sign, precision,
+                                                    false, &mut buf, &mut parts);
+        fmt.pad_formatted_parts(&formatted)
+    }
 }
 
 // Don't inline this so callers that call both this and the above won't wind
@@ -33,11 +36,14 @@ fn float_to_decimal_common_shortest<T>(fmt: &mut Formatter,
                                        num: &T, sign: flt2dec::Sign) -> Result
     where T: flt2dec::DecodableFloat
 {
-    let mut buf = [0; flt2dec::MAX_SIG_DIGITS]; // enough for f32 and f64
-    let mut parts = [flt2dec::Part::Zero(0); 5];
-    let formatted = flt2dec::to_shortest_str(flt2dec::strategy::grisu::format_shortest,
-                                             *num, sign, 0, false, &mut buf, &mut parts);
-    fmt.pad_formatted_parts(&formatted)
+    unsafe {
+        // enough for f32 and f64
+        let mut buf: [u8; flt2dec::MAX_SIG_DIGITS] = mem::uninitialized();
+        let mut parts: [flt2dec::Part; 5] = mem::uninitialized();
+        let formatted = flt2dec::to_shortest_str(flt2dec::strategy::grisu::format_shortest,
+                                                 *num, sign, 0, false, &mut buf, &mut parts);
+        fmt.pad_formatted_parts(&formatted)
+    }
 }
 
 // Common code of floating point Debug and Display.
@@ -67,12 +73,14 @@ fn float_to_exponential_common_exact<T>(fmt: &mut Formatter, num: &T,
                                         upper: bool) -> Result
     where T: flt2dec::DecodableFloat
 {
-    let mut buf = [0; 1024]; // enough for f32 and f64
-    let mut parts = [flt2dec::Part::Zero(0); 7];
-    let formatted = flt2dec::to_exact_exp_str(flt2dec::strategy::grisu::format_exact,
-                                              *num, sign, precision,
-                                              upper, &mut buf, &mut parts);
-    fmt.pad_formatted_parts(&formatted)
+    unsafe {
+        let mut buf: [u8; 1024] = mem::uninitialized(); // enough for f32 and f64
+        let mut parts: [flt2dec::Part; 7] = mem::uninitialized();
+        let formatted = flt2dec::to_exact_exp_str(flt2dec::strategy::grisu::format_exact,
+                                                  *num, sign, precision,
+                                                  upper, &mut buf, &mut parts);
+        fmt.pad_formatted_parts(&formatted)
+    }
 }
 
 // Don't inline this so callers that call both this and the above won't wind
@@ -83,11 +91,15 @@ fn float_to_exponential_common_shortest<T>(fmt: &mut Formatter,
                                            upper: bool) -> Result
     where T: flt2dec::DecodableFloat
 {
-    let mut buf = [0; flt2dec::MAX_SIG_DIGITS]; // enough for f32 and f64
-    let mut parts = [flt2dec::Part::Zero(0); 7];
-    let formatted = flt2dec::to_shortest_exp_str(flt2dec::strategy::grisu::format_shortest, *num,
-                                                 sign, (0, 0), upper, &mut buf, &mut parts);
-    fmt.pad_formatted_parts(&formatted)
+    unsafe {
+        // enough for f32 and f64
+        let mut buf: [u8; flt2dec::MAX_SIG_DIGITS] = mem::uninitialized();
+        let mut parts: [flt2dec::Part; 7] = mem::uninitialized();
+        let formatted = flt2dec::to_shortest_exp_str(flt2dec::strategy::grisu::format_shortest,
+                                                     *num, sign, (0, 0), upper,
+                                                     &mut buf, &mut parts);
+        fmt.pad_formatted_parts(&formatted)
+    }
 }
 
 // Common code of floating point LowerExp and UpperExp.

--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -19,7 +19,7 @@ fn float_to_decimal_common_exact<T>(fmt: &mut Formatter, num: &T,
     where T: flt2dec::DecodableFloat
 {
     let mut buf = [0; 1024]; // enough for f32 and f64
-    let mut parts = [flt2dec::Part::Zero(0); 16];
+    let mut parts = [flt2dec::Part::Zero(0); 5];
     let formatted = flt2dec::to_exact_fixed_str(flt2dec::strategy::grisu::format_exact,
                                                 *num, sign, precision,
                                                 false, &mut buf, &mut parts);
@@ -34,7 +34,7 @@ fn float_to_decimal_common_shortest<T>(fmt: &mut Formatter,
     where T: flt2dec::DecodableFloat
 {
     let mut buf = [0; flt2dec::MAX_SIG_DIGITS]; // enough for f32 and f64
-    let mut parts = [flt2dec::Part::Zero(0); 16];
+    let mut parts = [flt2dec::Part::Zero(0); 5];
     let formatted = flt2dec::to_shortest_str(flt2dec::strategy::grisu::format_shortest,
                                              *num, sign, 0, false, &mut buf, &mut parts);
     fmt.pad_formatted_parts(&formatted)
@@ -68,7 +68,7 @@ fn float_to_exponential_common_exact<T>(fmt: &mut Formatter, num: &T,
     where T: flt2dec::DecodableFloat
 {
     let mut buf = [0; 1024]; // enough for f32 and f64
-    let mut parts = [flt2dec::Part::Zero(0); 16];
+    let mut parts = [flt2dec::Part::Zero(0); 7];
     let formatted = flt2dec::to_exact_exp_str(flt2dec::strategy::grisu::format_exact,
                                               *num, sign, precision,
                                               upper, &mut buf, &mut parts);
@@ -84,7 +84,7 @@ fn float_to_exponential_common_shortest<T>(fmt: &mut Formatter,
     where T: flt2dec::DecodableFloat
 {
     let mut buf = [0; flt2dec::MAX_SIG_DIGITS]; // enough for f32 and f64
-    let mut parts = [flt2dec::Part::Zero(0); 16];
+    let mut parts = [flt2dec::Part::Zero(0); 7];
     let formatted = flt2dec::to_shortest_exp_str(flt2dec::strategy::grisu::format_shortest, *num,
                                                  sign, (0, 0), upper, &mut buf, &mut parts);
     fmt.pad_formatted_parts(&formatted)


### PR DESCRIPTION
Doing this speeds up float formatting by ~10% or so, and also makes the formatting code more suitable for embedded environments where stack space is at a premium.