### PR TITLE
rustc: treat const bodies like fn bodies in middle::region.

### DIFF
--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -140,23 +140,6 @@ impl<'this, 'tcx> NestedVisitorMap<'this, 'tcx> {
 /// to monitor future changes to `Visitor` in case a new method with a
 /// new default implementation gets introduced.)
 pub trait Visitor<'v> : Sized {
-    /// Invokes the suitable visitor method for the given `Node`
-    /// extracted from the hir map.
-    fn visit_hir_map_node(&mut self, node: map::Node<'v>) {
-        match node {
-            map::NodeItem(a) => self.visit_item(a),
-            map::NodeForeignItem(a) => self.visit_foreign_item(a),
-            map::NodeTraitItem(a) => self.visit_trait_item(a),
-            map::NodeImplItem(a) => self.visit_impl_item(a),
-            map::NodeExpr(a) => self.visit_expr(a),
-            map::NodeStmt(a) => self.visit_stmt(a),
-            map::NodeTy(a) => self.visit_ty(a),
-            map::NodePat(a) => self.visit_pat(a),
-            map::NodeBlock(a) => self.visit_block(a),
-            _ => bug!("Visitor::visit_hir_map_node() not yet impl for node `{:?}`", node)
-        }
-    }
-
     ///////////////////////////////////////////////////////////////////////////
     // Nested items.
 

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -442,25 +442,34 @@ impl<'hir> Map<'hir> {
         self.local_def_id(self.body_owner(id))
     }
 
-    /// Given a body owner's id, returns the `BodyId` associated with it.
-    pub fn body_owned_by(&self, id: NodeId) -> BodyId {
+    /// Given a node id, returns the `BodyId` associated with it,
+    /// if the node is a body owner, otherwise returns `None`.
+    pub fn maybe_body_owned_by(&self, id: NodeId) -> Option<BodyId> {
         if let Some(entry) = self.find_entry(id) {
             if let Some(body_id) = entry.associated_body() {
                 // For item-like things and closures, the associated
                 // body has its own distinct id, and that is returned
                 // by `associated_body`.
-                body_id
+                Some(body_id)
             } else {
                 // For some expressions, the expression is its own body.
                 if let EntryExpr(_, expr) = entry {
-                    BodyId { node_id: expr.id }
+                    Some(BodyId { node_id: expr.id })
                 } else {
-                    span_bug!(self.span(id), "id `{}` has no associated body: {:?}", id, entry);
+                    None
                 }
             }
         } else {
             bug!("no entry for id `{}`", id)
         }
+    }
+
+    /// Given a body owner's id, returns the `BodyId` associated with it.
+    pub fn body_owned_by(&self, id: NodeId) -> BodyId {
+        self.maybe_body_owned_by(id).unwrap_or_else(|| {
+            span_bug!(self.span(id), "body_owned_by: {} has no associated body",
+                      self.node_to_string(id));
+        })
     }
 
     pub fn ty_param_owner(&self, id: NodeId) -> NodeId {

--- a/src/test/run-pass/associated-const-type-parameters.rs
+++ b/src/test/run-pass/associated-const-type-parameters.rs
@@ -27,6 +27,12 @@ impl Foo for Def {
     const X: i32 = 97;
 }
 
+struct Proxy<T>(T);
+
+impl<T: Foo> Foo for Proxy<T> {
+    const X: i32 = T::X;
+}
+
 fn sub<A: Foo, B: Foo>() -> i32 {
     A::X - B::X
 }
@@ -38,4 +44,7 @@ fn main() {
     assert_eq!(97, Def::get_x());
     assert_eq!(-86, sub::<Abc, Def>());
     assert_eq!(86, sub::<Def, Abc>());
+    assert_eq!(-86, sub::<Proxy<Abc>, Def>());
+    assert_eq!(-86, sub::<Abc, Proxy<Def>>());
+    assert_eq!(86, sub::<Proxy<Def>, Proxy<Abc>>());
 }


### PR DESCRIPTION
Allows `T::ASSOC_CONST` to be used without a `T: 'static` bound.

cc @rust-lang/compiler @rust-lang/lang