### PR TITLE
[beta] Prepare the 1.18.0 beta release

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -171,7 +171,7 @@ class RustBuild(object):
             if os.path.exists(self.bin_root()):
                 shutil.rmtree(self.bin_root())
             filename = "rust-std-{}-{}.tar.gz".format(channel, self.build)
-            url = "https://static.rust-lang.org/dist/" + self.stage0_rustc_date()
+            url = "https://dev-static.rust-lang.org/dist/" + self.stage0_rustc_date()
             tarball = os.path.join(rustc_cache, filename)
             if not os.path.exists(tarball):
                 get("{}/{}".format(url, filename), tarball, verbose=self.verbose)
@@ -180,7 +180,7 @@ class RustBuild(object):
                    verbose=self.verbose)
 
             filename = "rustc-{}-{}.tar.gz".format(channel, self.build)
-            url = "https://static.rust-lang.org/dist/" + self.stage0_rustc_date()
+            url = "https://dev-static.rust-lang.org/dist/" + self.stage0_rustc_date()
             tarball = os.path.join(rustc_cache, filename)
             if not os.path.exists(tarball):
                 get("{}/{}".format(url, filename), tarball, verbose=self.verbose)
@@ -192,7 +192,7 @@ class RustBuild(object):
 
             if "pc-windows-gnu" in self.build:
                 filename = "rust-mingw-{}-{}.tar.gz".format(channel, self.build)
-                url = "https://static.rust-lang.org/dist/" + self.stage0_rustc_date()
+                url = "https://dev-static.rust-lang.org/dist/" + self.stage0_rustc_date()
                 tarball = os.path.join(rustc_cache, filename)
                 if not os.path.exists(tarball):
                     get("{}/{}".format(url, filename), tarball, verbose=self.verbose)
@@ -201,8 +201,8 @@ class RustBuild(object):
         if self.cargo().startswith(self.bin_root()) and \
                 (not os.path.exists(self.cargo()) or self.cargo_out_of_date()):
             self.print_what_it_means_to_bootstrap()
-            filename = "cargo-{}-{}.tar.gz".format(channel, self.build)
-            url = "https://static.rust-lang.org/dist/" + self.stage0_rustc_date()
+            filename = "cargo-{}-{}.tar.gz".format('0.18.0', self.build)
+            url = "https://dev-static.rust-lang.org/dist/" + self.stage0_rustc_date()
             tarball = os.path.join(rustc_cache, filename)
             if not os.path.exists(tarball):
                 get("{}/{}".format(url, filename), tarball, verbose=self.verbose)

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -40,7 +40,7 @@ fi
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
 if [ "$DEPLOY$DEPLOY_ALT" != "" ]; then
-  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=nightly"
+  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=beta"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"
 
   if [ "$NO_LLVM_ASSERTIONS" = "1" ]; then

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,4 +12,4 @@
 # tarball for a stable release you'll likely see `1.x.0-$date` where `1.x.0` was
 # released on `$date`
 
-rustc: beta-2017-04-05
+rustc: 1.17.0-2017-04-25

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -230,7 +230,7 @@ impl Builder {
         self.package("rust-std", &mut manifest.pkg, TARGETS);
         self.package("rust-docs", &mut manifest.pkg, TARGETS);
         self.package("rust-src", &mut manifest.pkg, &["*"]);
-        self.package("rls", &mut manifest.pkg, HOSTS);
+        // self.package("rls", &mut manifest.pkg, HOSTS);
         self.package("rust-analysis", &mut manifest.pkg, TARGETS);
 
         let mut pkg = Package {
@@ -270,10 +270,10 @@ impl Builder {
                 });
             }
 
-            extensions.push(Component {
-                pkg: "rls".to_string(),
-                target: host.to_string(),
-            });
+            // extensions.push(Component {
+            //     pkg: "rls".to_string(),
+            //     target: host.to_string(),
+            // });
             extensions.push(Component {
                 pkg: "rust-analysis".to_string(),
                 target: host.to_string(),


### PR DESCRIPTION
* Update the cargo submodule
* Update the stage0 bootstrap compiler, temporarily downloading it from
  dev-static.rust-lang.org until it's released this Thursday.
* Update release channel being compiled to beta
* Disable the RLS release (will only happen on this one beta release)