### PR TITLE
Add missing OperandPair struct field index adjustments. Fixes #41479.

### DIFF
--- a/src/test/run-pass/issue-41479.rs
+++ b/src/test/run-pass/issue-41479.rs
@@ -1,0 +1,18 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn split<A, B>(pair: (A, B)) {
+    let _a = pair.0;
+    let _b = pair.1;
+}
+
+fn main() {
+    split(((), ((), ())));
+}


### PR DESCRIPTION
This is a bug fix for a regression in https://github.com/rust-lang/rust/commit/6d841da4a0d7629f826117f99052e3d4a7997a7e.