### PR TITLE
syntax: Parse trait object types starting with a lifetime bound

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1451,9 +1451,9 @@ impl<'a> Parser<'a> {
         } else if self.eat_keyword(keywords::Impl) {
             // FIXME: figure out priority of `+` in `impl Trait1 + Trait2` (#34511).
             TyKind::ImplTrait(self.parse_ty_param_bounds()?)
-        } else if self.check(&token::Question) {
+        } else if self.check(&token::Question) ||
+                  self.check_lifetime() && self.look_ahead(1, |t| t == &token::BinOp(token::Plus)){
             // Bound list (trait object type)
-            // Bound lists starting with `'lt` are not currently supported (#40043)
             TyKind::TraitObject(self.parse_ty_param_bounds_common(allow_plus)?)
         } else {
             let msg = format!("expected type, found {}", self.this_token_descr());

--- a/src/test/compile-fail/trait-object-vs-lifetime-2.rs
+++ b/src/test/compile-fail/trait-object-vs-lifetime-2.rs
@@ -8,14 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// `ty` matcher accepts trait object types
+// A few contrived examples where lifetime should (or should not) be parsed as an object type.
+// Lifetimes parsed as types are still rejected later by semantic checks.
 
-macro_rules! m {
-    ($t: ty) => ( let _: $t; )
-}
+// compile-flags: -Z continue-parse-after-error
 
-fn main() {
-    m!(Copy + Send + 'static); //~ ERROR the trait `std::marker::Copy` cannot be made into an object
-    m!('static + Send);
-    m!('static +); //~ ERROR at least one non-builtin trait is required for an object type
-}
+// `'static` is a lifetime, `'static +` is a type, `'a` is a type
+fn g() where
+    'static: 'static,
+    'static +: 'static + Copy,
+    //~^ ERROR at least one non-builtin trait is required for an object type
+{}
+
+fn main() {}

--- a/src/test/compile-fail/trait-object-vs-lifetime.rs
+++ b/src/test/compile-fail/trait-object-vs-lifetime.rs
@@ -1,0 +1,29 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// A few contrived examples where lifetime should (or should not) be parsed as an object type.
+// Lifetimes parsed as types are still rejected later by semantic checks.
+
+// compile-flags: -Z continue-parse-after-error
+
+struct S<'a, T>(&'a u8, T);
+
+fn main() {
+    // `'static` is a lifetime argument, `'static +` is a type argument
+    let _: S<'static, u8>;
+    let _: S<'static, 'static +>;
+    //~^ at least one non-builtin trait is required for an object type
+    let _: S<'static, 'static>;
+    //~^ ERROR wrong number of lifetime parameters: expected 1, found 2
+    //~| ERROR wrong number of type arguments: expected 1, found 0
+    let _: S<'static +, 'static>;
+    //~^ ERROR lifetime parameters must be declared prior to type parameters
+    //~| ERROR at least one non-builtin trait is required for an object type
+}

--- a/src/test/run-pass/trait-object-lifetime-first.rs
+++ b/src/test/run-pass/trait-object-lifetime-first.rs
@@ -8,14 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// `ty` matcher accepts trait object types
+use std::fmt::Display;
 
-macro_rules! m {
-    ($t: ty) => ( let _: $t; )
-}
+static BYTE: u8 = 33;
 
 fn main() {
-    m!(Copy + Send + 'static); //~ ERROR the trait `std::marker::Copy` cannot be made into an object
-    m!('static + Send);
-    m!('static +); //~ ERROR at least one non-builtin trait is required for an object type
+    let x: &('static + Display) = &BYTE;
+    let y: Box<'static + Display> = Box::new(BYTE);
+    let xstr = format!("{}", x);
+    let ystr = format!("{}", y);
+    assert_eq!(xstr, "33");
+    assert_eq!(ystr, "33");
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/39085

This was originally implemented in https://github.com/rust-lang/rust/pull/40043, then reverted, then there was some [agreement](https://github.com/rust-lang/rust/issues/39318#issuecomment-289108720) that it should be supported.
(This is hopefully the last PR related to bound parsing.)