### PR TITLE
Fix error message for mismatched types

### DIFF
--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -498,7 +498,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             if is_if_let_fallback {
                 let cause = self.cause(expr.span, ObligationCauseCode::IfExpressionWithNoElse);
                 assert!(arm_ty.is_nil());
-                coercion.coerce_forced_unit(self, &cause, &mut |_| ());
+                coercion.coerce_forced_unit(self, &cause, &mut |_| (), true);
             } else {
                 let cause = self.cause(expr.span, ObligationCauseCode::MatchExpressionArm {
                     arm_span: arm.body.span,

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -1104,7 +1104,7 @@ impl<'gcx, 'tcx, 'exprs, E> CoerceMany<'gcx, 'tcx, 'exprs, E>
             // Another example is `break` with no argument expression.
             assert!(expression_ty.is_nil());
             assert!(expression_ty.is_nil(), "if let hack without unit type");
-            fcx.eq_types(true, cause, expression_ty, self.merged_ty())
+            fcx.eq_types(label_expression_as_expected, cause, expression_ty, self.merged_ty())
                .map(|infer_ok| {
                    fcx.register_infer_ok_obligations(infer_ok);
                    expression_ty
@@ -1128,6 +1128,10 @@ impl<'gcx, 'tcx, 'exprs, E> CoerceMany<'gcx, 'tcx, 'exprs, E>
             }
             Err(err) => {
                 let (expected, found) = if label_expression_as_expected {
+                    // In the case where this is a "forced unit", like
+                    // `break`, we want to call the `()` "expected"
+                    // since it is implied by the syntax.
+                    // (Note: not all force-units work this way.)"
                     (expression_ty, self.final_ty.unwrap_or(self.expected_ty))
                 } else {
                     // Otherwise, the "expected" type for error

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -1001,7 +1001,12 @@ impl<'gcx, 'tcx, 'exprs, E> CoerceMany<'gcx, 'tcx, 'exprs, E>
                       expression_ty: Ty<'tcx>,
                       expression_diverges: Diverges)
     {
-        self.coerce_inner(fcx, cause, Some(expression), expression_ty, expression_diverges, None, false)
+        self.coerce_inner(fcx,
+                          cause,
+                          Some(expression),
+                          expression_ty,
+                          expression_diverges,
+                          None, false)
     }
 
     /// Indicates that one of the inputs is a "forced unit". This

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4078,7 +4078,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 // this implies that the type of the block will be
                 // `!`).
                 //
-                // #41425 -- label the implicit `()` as being the "found type" here, rather than the "expected type".
+                // #41425 -- label the implicit `()` as being the
+                // "found type" here, rather than the "expected type".
                 if !self.diverges.get().always() {
                     coerce.coerce_forced_unit(self, &self.misc(blk.span), &mut |err| {
                         if let Some(expected_ty) = expected.only_has_type(self) {

--- a/src/test/ui/coercion-missing-tail-expected-type.rs
+++ b/src/test/ui/coercion-missing-tail-expected-type.rs
@@ -1,0 +1,20 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// #41425 -- error message "mismatched types" has wrong types
+
+fn plus_one(x: i32) -> i32 {
+    x + 1;
+}
+
+fn main() {
+    let x = plus_one(5);
+    println!("X = {}", x);
+}

--- a/src/test/ui/coercion-missing-tail-expected-type.stderr
+++ b/src/test/ui/coercion-missing-tail-expected-type.stderr
@@ -5,7 +5,7 @@ error[E0308]: mismatched types
    |  ____________________________^
 14 | |     x + 1;
 15 | | }
-   | |_^ expected (), found i32
+   | |_^ expected i32, found ()
    |
    = note: expected type `i32`
               found type `()`

--- a/src/test/ui/coercion-missing-tail-expected-type.stderr
+++ b/src/test/ui/coercion-missing-tail-expected-type.stderr
@@ -1,0 +1,19 @@
+error[E0308]: mismatched types
+  --> $DIR/coercion-missing-tail-expected-type.rs:13:28
+   |
+13 |   fn plus_one(x: i32) -> i32 {
+   |  ____________________________^
+14 | |     x + 1;
+15 | | }
+   | |_^ expected (), found i32
+   |
+   = note: expected type `i32`
+              found type `()`
+help: consider removing this semicolon:
+  --> $DIR/coercion-missing-tail-expected-type.rs:14:10
+   |
+14 |     x + 1;
+   |          ^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This addresses #41425 by implementing the changes mentioned in the
following comment:
https://github.com/rust-lang/rust/issues/41425#issuecomment-296754508