### PR TITLE
auto load pretty print for gdb

### DIFF
--- a/src/etc/gdb_load_rust_pretty_printers.py
+++ b/src/etc/gdb_load_rust_pretty_printers.py
@@ -9,4 +9,4 @@
 # except according to those terms.
 
 import gdb_rust_pretty_printing
-gdb_rust_pretty_printing.register_printers(gdb.current_objfile())
+gdb_rust_pretty_printing.register_printers(gdb)

--- a/src/etc/rust-gdb
+++ b/src/etc/rust-gdb
@@ -23,4 +23,5 @@ RUST_GDB="${RUST_GDB:-gdb}"
 PYTHONPATH="$PYTHONPATH:$GDB_PYTHON_MODULE_DIRECTORY" ${RUST_GDB} \
   -d "$GDB_PYTHON_MODULE_DIRECTORY" \
   -iex "add-auto-load-safe-path $GDB_PYTHON_MODULE_DIRECTORY" \
+  -iex "source $GDB_PYTHON_MODULE_DIRECTORY/gdb_load_rust_pretty_printers.py" \
   "$@"


### PR DESCRIPTION
fix issue when registering pretty print.
add pretty print functionality on startup.

This works on osx 10.11, so I'm not sure if the changes would conflict with anyone else.