### PR TITLE
Add RWPI/ROPI relocation model support

### DIFF
--- a/src/librustc_llvm/ffi.rs
+++ b/src/librustc_llvm/ffi.rs
@@ -284,13 +284,13 @@ pub enum CodeGenOptLevel {
 #[derive(Copy, Clone, PartialEq)]
 #[repr(C)]
 pub enum RelocMode {
-    Default = 0,
-    Static = 1,
-    PIC = 2,
-    DynamicNoPic = 3,
-    ROPI = 4,
-    RWPI = 5,
-    ROPI_RWPI = 6,
+    Default,
+    Static,
+    PIC,
+    DynamicNoPic,
+    ROPI,
+    RWPI,
+    ROPI_RWPI,
 }
 
 /// LLVMRustCodeModel

--- a/src/librustc_llvm/ffi.rs
+++ b/src/librustc_llvm/ffi.rs
@@ -288,6 +288,9 @@ pub enum RelocMode {
     Static = 1,
     PIC = 2,
     DynamicNoPic = 3,
+    ROPI = 4,
+    RWPI = 5,
+    ROPI_RWPI = 6,
 }
 
 /// LLVMRustCodeModel

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -37,11 +37,14 @@ use std::sync::mpsc::channel;
 use std::thread;
 use libc::{c_uint, c_void};
 
-pub const RELOC_MODEL_ARGS : [(&'static str, llvm::RelocMode); 4] = [
+pub const RELOC_MODEL_ARGS : [(&'static str, llvm::RelocMode); 7] = [
     ("pic", llvm::RelocMode::PIC),
     ("static", llvm::RelocMode::Static),
     ("default", llvm::RelocMode::Default),
     ("dynamic-no-pic", llvm::RelocMode::DynamicNoPic),
+    ("ropi", llvm::RelocMode::ROPI),
+    ("rwpi", llvm::RelocMode::RWPI),
+    ("ropi-rwpi", llvm::RelocMode::ROPI_RWPI),
 ];
 
 pub const CODE_GEN_MODEL_ARGS : [(&'static str, llvm::CodeModel); 5] = [

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -290,7 +290,7 @@ extern "C" void LLVMRustPrintTargetFeatures(LLVMTargetMachineRef) {
 
 extern "C" LLVMTargetMachineRef LLVMRustCreateTargetMachine(
     const char *TripleStr, const char *CPU, const char *Feature,
-    LLVMRustCodeModel RustCM, LLVMRelocMode Reloc,
+    LLVMRustCodeModel RustCM, int Reloc,
     LLVMRustCodeGenOptLevel RustOptLevel, bool UseSoftFloat,
     bool PositionIndependentExecutable, bool FunctionSections,
     bool DataSections) {
@@ -304,15 +304,26 @@ extern "C" LLVMTargetMachineRef LLVMRustCreateTargetMachine(
   auto OptLevel = fromRust(RustOptLevel);
 
   switch (Reloc) {
-  case LLVMRelocStatic:
+  case 1:
     RM = Reloc::Static;
     break;
-  case LLVMRelocPIC:
+  case 2:
     RM = Reloc::PIC_;
     break;
-  case LLVMRelocDynamicNoPic:
+  case 3:
     RM = Reloc::DynamicNoPIC;
     break;
+#if LLVM_VERSION_GE(4, 0)
+  case 4:
+    RM = Reloc::ROPI;
+    break;
+  case 5:
+    RM = Reloc::RWPI;
+    break;
+  case 6:
+    RM = Reloc::ROPI_RWPI;
+    break;
+#endif
   default:
 #if LLVM_VERSION_LE(3, 8)
     RM = Reloc::Default;


### PR DESCRIPTION
This PR adds support for using LLVM 4's ROPI and RWPI relocation models for ARM.

ROPI (Read-Only Position Independence) and RWPI (Read-Write Position Independence) are two new relocation models in LLVM for the ARM backend ([LLVM changset](https://reviews.llvm.org/rL278015)). The motivation is that these are the specific strategies we use in userspace [Tock](https://www.tockos.org) apps, so supporting this is an important step (perhaps the final step, but can't confirm yet) in enabling userspace Rust processes.

## Explanation

ROPI makes all code and immutable accesses PC relative, but not assumed to be overriden at runtime (so for example, jumps are always relative).

RWPI uses a base register (`r9`) that stores the addresses of the GOT in memory so the runtime (e.g. a kernel) only adjusts r9 tell running code where the GOT is.

## Complications adding support in Rust

While this landed in LLVM master back in August, the header files in `llvm-c` have not been updated yet to reflect it. Rust replicates that header file's version of the `LLVMRelocMode` enum as the Rust enum `llvm::RelocMode` and uses an implicit cast in the ffi to translate from Rust's notion of the relocation model to the LLVM library's notion.

My workaround for this currently is to replace the `LLVMRelocMode` argument to `LLVMTargetMachineRef` with an int and using the hardcoded int representation of the `RelocMode` enum. This is A Bad Idea(tm), but I think very nearly the right thing.

Would a better alternative be to patch rust-llvm to support these enum variants (also a fairly trivial change)?