### PR TITLE
Disable ref hint for pattern in let and adding ui tests #40402

### DIFF
--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -95,6 +95,14 @@ enum MapEntry<'hir> {
     RootCrate,
 }
 
+/// Represents the kind of pattern
+#[derive(Debug, Clone, Copy)]
+pub enum PatternSource<'hir> {
+    MatchExpr(&'hir Expr),
+    LetDecl(&'hir Local),
+    Other,
+}
+
 impl<'hir> Clone for MapEntry<'hir> {
     fn clone(&self) -> MapEntry<'hir> {
         *self
@@ -637,7 +645,7 @@ impl<'hir> Map<'hir> {
             Err(id) => id,
         }
     }
-
+    
     /// Returns the nearest enclosing scope. A scope is an item or block.
     /// FIXME it is not clear to me that all items qualify as scopes - statics
     /// and associated types probably shouldn't, for example. Behaviour in this

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -95,14 +95,6 @@ enum MapEntry<'hir> {
     RootCrate,
 }
 
-/// Represents the kind of pattern
-#[derive(Debug, Clone, Copy)]
-pub enum PatternSource<'hir> {
-    MatchExpr(&'hir Expr),
-    LetDecl(&'hir Local),
-    Other,
-}
-
 impl<'hir> Clone for MapEntry<'hir> {
     fn clone(&self) -> MapEntry<'hir> {
         *self
@@ -645,7 +637,7 @@ impl<'hir> Map<'hir> {
             Err(id) => id,
         }
     }
-    
+
     /// Returns the nearest enclosing scope. A scope is an item or block.
     /// FIXME it is not clear to me that all items qualify as scopes - statics
     /// and associated types probably shouldn't, for example. Behaviour in this

--- a/src/librustc_borrowck/borrowck/gather_loans/move_error.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/move_error.rs
@@ -17,6 +17,7 @@ use rustc::ty;
 use syntax::ast;
 use syntax_pos;
 use errors::DiagnosticBuilder;
+use rustc::hir::map::PatternSource;
 
 pub struct MoveErrorCollector<'tcx> {
     errors: Vec<MoveError<'tcx>>
@@ -40,12 +41,12 @@ impl<'tcx> MoveErrorCollector<'tcx> {
 
 pub struct MoveError<'tcx> {
     move_from: mc::cmt<'tcx>,
-    move_to: Option<MoveSpanAndPath>
+    move_to: Option<MoveSpanAndPath<'tcx>>
 }
 
 impl<'tcx> MoveError<'tcx> {
     pub fn with_move_info(move_from: mc::cmt<'tcx>,
-                          move_to: Option<MoveSpanAndPath>)
+                          move_to: Option<MoveSpanAndPath<'tcx>>)
                           -> MoveError<'tcx> {
         MoveError {
             move_from: move_from,
@@ -55,32 +56,43 @@ impl<'tcx> MoveError<'tcx> {
 }
 
 #[derive(Clone)]
-pub struct MoveSpanAndPath {
+pub struct MoveSpanAndPath<'tcx> {
     pub span: syntax_pos::Span,
     pub name: ast::Name,
+    pub pat_source: PatternSource<'tcx>,
 }
 
 pub struct GroupedMoveErrors<'tcx> {
     move_from: mc::cmt<'tcx>,
-    move_to_places: Vec<MoveSpanAndPath>
+    move_to_places: Vec<MoveSpanAndPath<'tcx>>
 }
 
-fn report_move_errors<'a, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>,
-                                errors: &Vec<MoveError<'tcx>>) {
+fn report_move_errors<'a, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>, errors: &Vec<MoveError<'tcx>>) {
     let grouped_errors = group_errors_with_same_origin(errors);
     for error in &grouped_errors {
         let mut err = report_cannot_move_out_of(bccx, error.move_from.clone());
         let mut is_first_note = true;
-        for move_to in &error.move_to_places {
-            err = note_move_destination(err, move_to.span, move_to.name, is_first_note);
-            is_first_note = false;
+	
+	if let Some(pattern_source) = error.move_to_places.get(0){
+ 
+        match pattern_source.pat_source {
+            PatternSource::LetDecl(_) => {}
+            _ => {
+                for move_to in &error.move_to_places {
+
+                    err = note_move_destination(err, move_to.span, move_to.name, is_first_note);
+                    is_first_note = false;
+                }
+            }
         }
+    }
         if let NoteClosureEnv(upvar_id) = error.move_from.note {
-            err.span_label(bccx.tcx.hir.span(upvar_id.var_id), &"captured outer variable");
+            err.span_label(bccx.tcx.hir.span(upvar_id.var_id), &"captured   outer variable");
         }
         err.emit();
+	
+	}
     }
-}
 
 fn group_errors_with_same_origin<'tcx>(errors: &Vec<MoveError<'tcx>>)
                                        -> Vec<GroupedMoveErrors<'tcx>> {

--- a/src/test/compile-fail/borrowck/borrowck-vec-pattern-nesting.rs
+++ b/src/test/compile-fail/borrowck/borrowck-vec-pattern-nesting.rs
@@ -54,7 +54,6 @@ fn c() {
         _ => {}
     }
     let a = vec[0]; //~ ERROR cannot move out
-    //~^ NOTE to prevent move
     //~| cannot move out of here
 }
 
@@ -68,7 +67,6 @@ fn d() {
         _ => {}
     }
     let a = vec[0]; //~ ERROR cannot move out
-    //~^ NOTE to prevent move
     //~| cannot move out of here
 }
 
@@ -84,7 +82,6 @@ fn e() {
         _ => {}
     }
     let a = vec[0]; //~ ERROR cannot move out
-    //~^ NOTE to prevent move
     //~| cannot move out of here
 }
 

--- a/src/test/ui/issue-40402-ref-hints/issue-40402-1.rs
+++ b/src/test/ui/issue-40402-ref-hints/issue-40402-1.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Check that we do not suggest `ref f` here in the `main()` function.
 struct Foo {
     pub v: Vec<String>,
 }

--- a/src/test/ui/issue-40402-ref-hints/issue-40402-1.rs
+++ b/src/test/ui/issue-40402-ref-hints/issue-40402-1.rs
@@ -1,0 +1,19 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo {
+    pub v: Vec<String>,
+}
+
+fn main() {
+    let mut f = Foo { v: Vec::new() };
+    f.v.push("hello".to_string());
+    let e = f.v[0];
+}

--- a/src/test/ui/issue-40402-ref-hints/issue-40402-1.stderr
+++ b/src/test/ui/issue-40402-ref-hints/issue-40402-1.stderr
@@ -1,0 +1,8 @@
+error[E0507]: cannot move out of indexed content
+  --> $DIR/issue-40402-1.rs:18:13
+   |
+18 |     let e = f.v[0];
+   |             ^^^^^^ cannot move out of indexed content
+
+error: aborting due to previous error
+

--- a/src/test/ui/issue-40402-ref-hints/issue-40402-1.stderr
+++ b/src/test/ui/issue-40402-ref-hints/issue-40402-1.stderr
@@ -1,7 +1,7 @@
 error[E0507]: cannot move out of indexed content
-  --> $DIR/issue-40402-1.rs:18:13
+  --> $DIR/issue-40402-1.rs:19:13
    |
-18 |     let e = f.v[0];
+19 |     let e = f.v[0];
    |             ^^^^^^ cannot move out of indexed content
 
 error: aborting due to previous error

--- a/src/test/ui/issue-40402-ref-hints/issue-40402-2.rs
+++ b/src/test/ui/issue-40402-ref-hints/issue-40402-2.rs
@@ -1,0 +1,14 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let x = vec![(String::new(), String::new())];
+    let (a, b) = x[0];
+}

--- a/src/test/ui/issue-40402-ref-hints/issue-40402-2.rs
+++ b/src/test/ui/issue-40402-ref-hints/issue-40402-2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Check that we do suggest `(ref a, ref b)` here, since `a` and `b`
+// are nested within a pattern
 fn main() {
     let x = vec![(String::new(), String::new())];
     let (a, b) = x[0];

--- a/src/test/ui/issue-40402-ref-hints/issue-40402-2.stderr
+++ b/src/test/ui/issue-40402-ref-hints/issue-40402-2.stderr
@@ -1,7 +1,7 @@
 error[E0507]: cannot move out of indexed content
-  --> $DIR/issue-40402-2.rs:13:18
+  --> $DIR/issue-40402-2.rs:15:18
    |
-13 |     let (a, b) = x[0];
+15 |     let (a, b) = x[0];
    |          -  -    ^^^^ cannot move out of indexed content
    |          |  |
    |          |  ...and here (use `ref b` or `ref mut b`)

--- a/src/test/ui/issue-40402-ref-hints/issue-40402-2.stderr
+++ b/src/test/ui/issue-40402-ref-hints/issue-40402-2.stderr
@@ -1,0 +1,11 @@
+error[E0507]: cannot move out of indexed content
+  --> $DIR/issue-40402-2.rs:13:18
+   |
+13 |     let (a, b) = x[0];
+   |          -  -    ^^^^ cannot move out of indexed content
+   |          |  |
+   |          |  ...and here (use `ref b` or `ref mut b`)
+   |          hint: to prevent move, use `ref a` or `ref mut a`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
A fix to #40402 

The `to prevent move, use ref e or ref mut e ` has been disabled.
```
fn main() {
    let v = vec![String::from("oh no")];
    
    let e = v[0];
}
```
now gives
```
error[E0507]: cannot move out of indexed content
 --> example.rs:4:13
  |
4 |     let e = v[0];
  |             ^^^^ cannot move out of indexed content

error: aborting due to previous error
```
I have added ui tests for the same and also modified a compile-fail test.