### PR TITLE
windows: Copy libwinpthread-1.dll into libdir bin

### DIFF
--- a/src/etc/make-win-dist.py
+++ b/src/etc/make-win-dist.py
@@ -49,7 +49,8 @@ def make_win_dist(rust_root, plat_root, target_triple):
         elif key == "libraries":
             lib_path.extend(val.lstrip(' =').split(';'))
 
-    target_tools = ["gcc.exe", "ld.exe", "ar.exe", "dlltool.exe"]
+    target_tools = ["gcc.exe", "ld.exe", "ar.exe", "dlltool.exe",
+                    "libwinpthread-1.dll"]
 
     rustc_dlls = ["libstdc++-6.dll", "libwinpthread-1.dll"]
     if target_triple.startswith("i686-"):


### PR DESCRIPTION
Recently we switched from the win32 MinGW toolchain to the pthreads-based
toolchain. We ship `gcc.exe` from this toolchain with the `rust-mingw` package
in the standard distribution but the pthreads version of `gcc.exe` depends on
`libwinpthread-1.dll`. While we're shipping this DLL for the compiler to depend
on we're not shipping it for gcc. As a workaround just copy the dll to gcc.exe
location and don't attempt to share for now.

cc https://github.com/rust-lang/rust/issues/31840#issuecomment-297478538