### PR TITLE
rustbuild improvements

### DIFF
--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -46,24 +46,24 @@ pub fn install(build: &Build, stage: u32, host: &str) {
     let empty_dir = build.out.join("tmp/empty_dir");
     t!(fs::create_dir_all(&empty_dir));
     if build.config.docs {
-        install_sh(&build, "docs", "rust-docs", stage, host, &prefix,
-                   &docdir, &libdir, &mandir, &empty_dir);
+        install_sh(&build, "docs", "rust-docs", &build.rust_package_vers(),
+                   stage, host, &prefix, &docdir, &libdir, &mandir, &empty_dir);
     }
 
     for target in build.config.target.iter() {
-        install_sh(&build, "std", "rust-std", stage, target, &prefix,
+        install_sh(&build, "std", "rust-std", &build.rust_package_vers(), stage, target, &prefix,
                    &docdir, &libdir, &mandir, &empty_dir);
     }
 
-    install_sh(&build, "rustc", "rustc", stage, host, &prefix,
+    install_sh(&build, "rustc", "rustc", &build.rust_package_vers(), stage, host, &prefix,
                &docdir, &libdir, &mandir, &empty_dir);
     t!(fs::remove_dir_all(&empty_dir));
 }
 
-fn install_sh(build: &Build, package: &str, name: &str, stage: u32, host: &str,
+fn install_sh(build: &Build, package: &str, name: &str, version: &str, stage: u32, host: &str,
               prefix: &Path, docdir: &Path, libdir: &Path, mandir: &Path, empty_dir: &Path) {
     println!("Install {} stage{} ({})", package, stage, host);
-    let package_name = format!("{}-{}-{}", name, build.rust_package_vers(), host);
+    let package_name = format!("{}-{}-{}", name, version, host);
 
     let mut cmd = Command::new("sh");
     cmd.current_dir(empty_dir)

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -51,12 +51,20 @@ pub fn install(build: &Build, stage: u32, host: &str) {
     }
 
     for target in build.config.target.iter() {
-        install_sh(&build, "std", "rust-std", &build.rust_package_vers(), stage, target, &prefix,
-                   &docdir, &libdir, &mandir, &empty_dir);
+        install_sh(&build, "std", "rust-std", &build.rust_package_vers(),
+                   stage, target, &prefix, &docdir, &libdir, &mandir, &empty_dir);
     }
 
-    install_sh(&build, "rustc", "rustc", &build.rust_package_vers(), stage, host, &prefix,
-               &docdir, &libdir, &mandir, &empty_dir);
+    install_sh(&build, "rustc", "rustc", &build.rust_package_vers(),
+               stage, host, &prefix, &docdir, &libdir, &mandir, &empty_dir);
+
+    if build.config.extended {
+        install_sh(&build, "cargo", "cargo", &build.cargo_package_vers(),
+                   stage, host, &prefix, &docdir, &libdir, &mandir, &empty_dir);
+        install_sh(&build, "rls", "rls", &build.rls_package_vers(),
+                   stage, host, &prefix, &docdir, &libdir, &mandir, &empty_dir);
+    }
+
     t!(fs::remove_dir_all(&empty_dir));
 }
 

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -55,15 +55,15 @@ pub fn install(build: &Build, stage: u32, host: &str) {
                    stage, target, &prefix, &docdir, &libdir, &mandir, &empty_dir);
     }
 
-    install_sh(&build, "rustc", "rustc", &build.rust_package_vers(),
-               stage, host, &prefix, &docdir, &libdir, &mandir, &empty_dir);
-
     if build.config.extended {
         install_sh(&build, "cargo", "cargo", &build.cargo_package_vers(),
                    stage, host, &prefix, &docdir, &libdir, &mandir, &empty_dir);
         install_sh(&build, "rls", "rls", &build.rls_package_vers(),
                    stage, host, &prefix, &docdir, &libdir, &mandir, &empty_dir);
     }
+
+    install_sh(&build, "rustc", "rustc", &build.rust_package_vers(),
+               stage, host, &prefix, &docdir, &libdir, &mandir, &empty_dir);
 
     t!(fs::remove_dir_all(&empty_dir));
 }

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1048,6 +1048,11 @@ impl Build {
         self.package_vers(&self.release_num("cargo"))
     }
 
+    /// Returns the value of `package_vers` above for rls
+    fn rls_package_vers(&self) -> String {
+        self.package_vers(&self.release_num("rls"))
+    }
+
     /// Returns the `version` string associated with this compiler for Rust
     /// itself.
     ///

--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -575,6 +575,7 @@ pub fn build_rules<'a>(build: &'a Build) -> Rules {
          .dep(|s| s.name("libstd-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "qemu-test-client"));
     rules.build("tool-cargo", "cargo")
+         .host(true)
          .default(build.config.extended)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("libstd-tool"))

--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -575,6 +575,7 @@ pub fn build_rules<'a>(build: &'a Build) -> Rules {
          .dep(|s| s.name("libstd-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "qemu-test-client"));
     rules.build("tool-cargo", "cargo")
+         .default(build.config.extended)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("libstd-tool"))
          .dep(|s| s.stage(0).host(s.target).name("openssl"))
@@ -588,6 +589,7 @@ pub fn build_rules<'a>(build: &'a Build) -> Rules {
          .run(move |s| compile::tool(build, s.stage, s.target, "cargo"));
     rules.build("tool-rls", "rls")
          .host(true)
+         .default(build.config.extended)
          .dep(|s| s.name("librustc-tool"))
          .dep(|s| s.stage(0).host(s.target).name("openssl"))
          .dep(move |s| {


### PR DESCRIPTION
Properly hook up cargo and rls in the build phase, and install them, when extended build is enabled.