### PR TITLE
don't ICE on cross-crate associated const type mismatch

### DIFF
--- a/src/test/compile-fail/auxiliary/issue_41549.rs
+++ b/src/test/compile-fail/auxiliary/issue_41549.rs
@@ -1,0 +1,15 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(associated_consts)]
+
+pub trait Trait {
+    const CONST: u32;
+}

--- a/src/test/compile-fail/issue-41549.rs
+++ b/src/test/compile-fail/issue-41549.rs
@@ -1,0 +1,23 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue_41549.rs
+
+#![feature(associated_consts)]
+
+extern crate issue_41549;
+
+struct S;
+
+impl issue_41549::Trait for S {
+    const CONST: () = (); //~ ERROR incompatible type for trait
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #41549.

r? @eddyb