### PR TITLE
rustbuild: unset DESTDIR before building

### DIFF
--- a/src/bootstrap/bin/main.rs
+++ b/src/bootstrap/bin/main.rs
@@ -33,5 +33,8 @@ fn main() {
         config.update_with_config_mk();
     }
 
+    // Unset DESTDIR as it interferes with some build systems (libgit2)
+    env::remove_var("DESTDIR");
+
     Build::new(flags, config).build();
 }

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -98,6 +98,7 @@ pub struct Config {
     pub quiet_tests: bool,
     // Fallback musl-root for all targets
     pub musl_root: Option<PathBuf>,
+    pub destdir: Option<PathBuf>,
     pub prefix: Option<PathBuf>,
     pub docdir: Option<PathBuf>,
     pub libdir: Option<PathBuf>,
@@ -313,6 +314,8 @@ impl Config {
         set(&mut config.sanitizers, build.sanitizers);
         set(&mut config.openssl_static, build.openssl_static);
 
+        // Cache DESTDIR environment variable as we unset it later on
+        config.destdir = env::var_os("DESTDIR").map(PathBuf::from);
         if let Some(ref install) = toml.install {
             config.prefix = install.prefix.clone().map(PathBuf::from);
             config.mandir = install.mandir.clone().map(PathBuf::from);

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -13,7 +13,6 @@
 //! This module is responsible for installing the standard library,
 //! compiler, and documentation.
 
-use std::env;
 use std::fs;
 use std::path::{Path, PathBuf, Component};
 use std::process::Command;
@@ -36,7 +35,7 @@ pub fn install(build: &Build, stage: u32, host: &str) {
     let libdir = prefix.join(libdir);
     let mandir = prefix.join(mandir);
 
-    let destdir = env::var_os("DESTDIR").map(PathBuf::from);
+    let destdir = build.config.destdir.as_ref();
 
     let prefix = add_destdir(&prefix, &destdir);
     let docdir = add_destdir(&docdir, &destdir);
@@ -76,9 +75,9 @@ fn install_sh(build: &Build, package: &str, name: &str, stage: u32, host: &str,
     build.run(&mut cmd);
 }
 
-fn add_destdir(path: &Path, destdir: &Option<PathBuf>) -> PathBuf {
+fn add_destdir(path: &Path, destdir: &Option<&PathBuf>) -> PathBuf {
     let mut ret = match *destdir {
-        Some(ref dest) => dest.clone(),
+        Some(dest) => dest.clone(),
         None => return path.to_path_buf(),
     };
     for part in path.components() {


### PR DESCRIPTION
Store it in config and unset it, otherwise it can cause problems such as
libgit2 installing libgit2.a inside of $DESTDIR instead of in the build
tree, and then cargo not finding it to link statically libgit2-sys