### PR TITLE
Fix slice binary search signature mismatch

### DIFF
--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -1116,10 +1116,10 @@ impl<T> [T] {
     ///          (1, 2), (2, 3), (4, 5), (5, 8), (3, 13),
     ///          (1, 21), (2, 34), (4, 55)];
     ///
-    /// assert_eq!(s.binary_search_by_key(&13, |&(a,b)| b),  Ok(9));
-    /// assert_eq!(s.binary_search_by_key(&4, |&(a,b)| b),   Err(7));
-    /// assert_eq!(s.binary_search_by_key(&100, |&(a,b)| b), Err(13));
-    /// let r = s.binary_search_by_key(&1, |&(a,b)| b);
+    /// assert_eq!(s.binary_search_by_key(&13, |&(a, ref b)| b),  Ok(9));
+    /// assert_eq!(s.binary_search_by_key(&4, |&(a, ref b)| b),   Err(7));
+    /// assert_eq!(s.binary_search_by_key(&100, |&(a, ref b)| b), Err(13));
+    /// let r = s.binary_search_by_key(&1, |&(a, ref b)| b);
     /// assert!(match r { Ok(1...4) => true, _ => false, });
     /// ```
     #[stable(feature = "slice_binary_search_by_key", since = "1.10.0")]

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -1125,8 +1125,8 @@ impl<T> [T] {
     #[stable(feature = "slice_binary_search_by_key", since = "1.10.0")]
     #[inline]
     pub fn binary_search_by_key<'a, B, F, Q: ?Sized>(&'a self, b: &Q, f: F) -> Result<usize, usize>
-        where F: FnMut(&'a T) -> B,
-              B: Borrow<Q>,
+        where F: FnMut(&'a T) -> &'a B,
+              B: Borrow<Q> + 'a,
               Q: Ord
     {
         core_slice::SliceExt::binary_search_by_key(self, b, f)

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -1046,8 +1046,9 @@ impl<T> [T] {
     /// assert!(match r { Ok(1...4) => true, _ => false, });
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn binary_search(&self, x: &T) -> Result<usize, usize>
-        where T: Ord
+    pub fn binary_search<Q: ?Sized>(&self, x: &Q) -> Result<usize, usize>
+        where T: Borrow<Q>,
+              Q: Ord
     {
         core_slice::SliceExt::binary_search(self, x)
     }
@@ -1123,9 +1124,10 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "slice_binary_search_by_key", since = "1.10.0")]
     #[inline]
-    pub fn binary_search_by_key<'a, B, F>(&'a self, b: &B, f: F) -> Result<usize, usize>
+    pub fn binary_search_by_key<'a, B, F, Q: ?Sized>(&'a self, b: &Q, f: F) -> Result<usize, usize>
         where F: FnMut(&'a T) -> B,
-              B: Ord
+              B: Borrow<Q>,
+              Q: Ord
     {
         core_slice::SliceExt::binary_search_by_key(self, b, f)
     }

--- a/src/libcollections/tests/slice.rs
+++ b/src/libcollections/tests/slice.rs
@@ -354,8 +354,8 @@ fn test_binary_search() {
     assert_eq!([2].binary_search(&5).ok(), None);
     assert_eq!([2].binary_search(&2).ok(), Some(0));
 
-    assert_eq!([].binary_search(&1).ok(), None);
-    assert_eq!([].binary_search(&5).ok(), None);
+    assert_eq!([0;0].binary_search(&1).ok(), None);
+    assert_eq!([0;0].binary_search(&5).ok(), None);
 
     assert!([1, 1, 1, 1, 1].binary_search(&1).ok() != None);
     assert!([1, 1, 1, 1, 2].binary_search(&1).ok() != None);

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -131,8 +131,8 @@ pub trait SliceExt {
 
     #[stable(feature = "slice_binary_search_by_key", since = "1.10.0")]
     fn binary_search_by_key<'a, B, F, Q: ?Sized>(&'a self, b: &Q, f: F) -> Result<usize, usize>
-        where F: FnMut(&'a Self::Item) -> B,
-              B: Borrow<Q>,
+        where F: FnMut(&'a Self::Item) -> &'a B,
+              B: Borrow<Q> + 'a,
               Q: Ord;
 
     #[stable(feature = "core", since = "1.6.0")]
@@ -612,8 +612,8 @@ impl<T> SliceExt for [T] {
 
     #[inline]
     fn binary_search_by_key<'a, B, F, Q: ?Sized>(&'a self, b: &Q, mut f: F) -> Result<usize, usize>
-        where F: FnMut(&'a Self::Item) -> B,
-              B: Borrow<Q>,
+        where F: FnMut(&'a Self::Item) -> &'a B,
+              B: Borrow<Q> + 'a,
               Q: Ord
     {
         self.binary_search_by(|k| f(k).borrow().cmp(b))

--- a/src/test/run-pass/slice_binary_search.rs
+++ b/src/test/run-pass/slice_binary_search.rs
@@ -24,6 +24,6 @@ fn main() {
     ];
 
     let key: &str = "def";
-    let r = xs.binary_search_by_key(&key, |e| &e.topic);
+    let r = xs.binary_search_by_key(key, |e| &e.topic);
     assert_eq!(Ok(1), r.map(|i| i));
 }


### PR DESCRIPTION
#37761 paramaterized `binary_search` over `Borrow` in `core::SliceExt`. This PR does the same for `std::slice`, so that the std and core slice APIs match.

Fixes #41561