### PR TITLE
Generate XZ-compressed tarballs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,9 @@ matrix:
         MACOSX_DEPLOYMENT_TARGET=10.7
       os: osx
       osx_image: xcode7
-      install: *osx_install_sccache
+      install:
+        - brew update && brew install xz
+        - *osx_install_sccache
     - env: >
         RUST_CHECK_TARGET=dist
         RUST_CONFIGURE_ARGS="--target=aarch64-apple-ios,armv7-apple-ios,armv7s-apple-ios,i386-apple-ios,x86_64-apple-ios --enable-extended"
@@ -106,7 +108,9 @@ matrix:
         MACOSX_DEPLOYMENT_TARGET=10.7
       os: osx
       osx_image: xcode7
-      install: *osx_install_sccache
+      install:
+        - brew update && brew install xz
+        - *osx_install_sccache
 
     # "alternate" deployments, these are "nightlies" but don't have assertions
     # turned on, they're deployed to a different location primarily for projects
@@ -123,7 +127,9 @@ matrix:
         MACOSX_DEPLOYMENT_TARGET=10.7
       os: osx
       osx_image: xcode7
-      install: *osx_install_sccache
+      install:
+        - brew update && brew install xz
+        - *osx_install_sccache
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,8 @@ matrix:
       os: osx
       osx_image: xcode7
       install:
-        - brew update && brew install xz
+        - travis_retry brew update
+        - travis_retry brew install xz
         - *osx_install_sccache
     - env: >
         RUST_CHECK_TARGET=dist
@@ -109,7 +110,8 @@ matrix:
       os: osx
       osx_image: xcode7
       install:
-        - brew update && brew install xz
+        - travis_retry brew update
+        - travis_retry brew install xz
         - *osx_install_sccache
 
     # "alternate" deployments, these are "nightlies" but don't have assertions
@@ -128,7 +130,8 @@ matrix:
       os: osx
       osx_image: xcode7
       install:
-        - brew update && brew install xz
+        - travis_retry brew update
+        - travis_retry brew install xz
         - *osx_install_sccache
 
 env:

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -116,6 +116,8 @@ struct Target {
     available: bool,
     url: Option<String>,
     hash: Option<String>,
+    xz_url: Option<String>,
+    xz_hash: Option<String>,
     components: Option<Vec<Component>>,
     extensions: Option<Vec<Component>>,
 }
@@ -126,6 +128,8 @@ impl Target {
             available: false,
             url: None,
             hash: None,
+            xz_url: None,
+            xz_hash: None,
             components: None,
             extensions: None,
         }
@@ -258,6 +262,8 @@ impl Builder {
                     continue
                 }
             };
+            let xz_filename = filename.replace(".tar.gz", ".tar.xz");
+            let xz_digest = self.digests.remove(&xz_filename);
             let mut components = Vec::new();
             let mut extensions = Vec::new();
 
@@ -301,6 +307,8 @@ impl Builder {
                 available: true,
                 url: Some(self.url(&filename)),
                 hash: Some(digest),
+                xz_url: xz_digest.as_ref().map(|_| self.url(&xz_filename)),
+                xz_hash: xz_digest,
                 components: Some(components),
                 extensions: Some(extensions),
             });
@@ -320,11 +328,15 @@ impl Builder {
                 Some(digest) => digest,
                 None => return (name.to_string(), Target::unavailable()),
             };
+            let xz_filename = filename.replace(".tar.gz", ".tar.xz");
+            let xz_digest = self.digests.remove(&xz_filename);
 
             (name.to_string(), Target {
                 available: true,
                 url: Some(self.url(&filename)),
                 hash: Some(digest),
+                xz_url: xz_digest.as_ref().map(|_| self.url(&xz_filename)),
+                xz_hash: xz_digest,
                 components: None,
                 extensions: None,
             })

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -293,7 +293,7 @@ impl Builder {
 
             pkg.target.insert(host.to_string(), Target {
                 available: true,
-                url: Some(self.url("rust", host)),
+                url: Some(self.url(&filename)),
                 hash: Some(digest),
                 components: Some(components),
                 extensions: Some(extensions),
@@ -325,7 +325,7 @@ impl Builder {
 
             (name.to_string(), Target {
                 available: true,
-                url: Some(self.url(pkgname, name)),
+                url: Some(self.url(&filename)),
                 hash: Some(digest),
                 components: None,
                 extensions: None,
@@ -338,11 +338,11 @@ impl Builder {
         });
     }
 
-    fn url(&self, component: &str, target: &str) -> String {
+    fn url(&self, filename: &str) -> String {
         format!("{}/{}/{}",
                 self.s3_address,
                 self.date,
-                self.filename(component, target))
+                filename)
     }
 
     fn filename(&self, component: &str, target: &str) -> String {

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -120,6 +120,18 @@ struct Target {
     extensions: Option<Vec<Component>>,
 }
 
+impl Target {
+    fn unavailable() -> Target {
+        Target {
+            available: false,
+            url: None,
+            hash: None,
+            components: None,
+            extensions: None,
+        }
+    }
+}
+
 #[derive(RustcEncodable)]
 struct Component {
     pkg: String,
@@ -242,13 +254,7 @@ impl Builder {
             let digest = match self.digests.remove(&filename) {
                 Some(digest) => digest,
                 None => {
-                    pkg.target.insert(host.to_string(), Target {
-                        available: false,
-                        url: None,
-                        hash: None,
-                        components: None,
-                        extensions: None,
-                    });
+                    pkg.target.insert(host.to_string(), Target::unavailable());
                     continue
                 }
             };
@@ -312,15 +318,7 @@ impl Builder {
             let filename = self.filename(pkgname, name);
             let digest = match self.digests.remove(&filename) {
                 Some(digest) => digest,
-                None => {
-                    return (name.to_string(), Target {
-                        available: false,
-                        url: None,
-                        hash: None,
-                        components: None,
-                        extensions: None,
-                    })
-                }
+                None => return (name.to_string(), Target::unavailable()),
             };
 
             (name.to_string(), Target {


### PR DESCRIPTION
Integrate the new `rust-installer` and extend manifests with keys for xz-compressed tarballs.

One of the steps required for https://github.com/rust-lang/rust/issues/21724