### PR TITLE
Unignore android for previously spuriously failing test.

### DIFF
--- a/src/test/run-pass/out-of-stack.rs
+++ b/src/test/run-pass/out-of-stack.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-android: FIXME (#20004)
 // ignore-musl
 // ignore-asmjs
 


### PR DESCRIPTION
Will see if this start failing again, in which case we'll re-ignore the test.

In theory, #20004 could be fixed by this. I've left that open because it's possible that this will resume the previous spurious failures, and marked it as A-spurious so people doing PR triage catch that. I will leave a comment there saying that if we see failures from this test on android, we should re-ignore it.