### PR TITLE
Don't let .debug_gdb_scripts become loadable into memory.

### DIFF
--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -701,7 +701,7 @@ pub fn maybe_create_entry_wrapper(ccx: &CrateContext) {
 
         let bld = Builder::new_block(ccx, llfn, "top");
 
-        debuginfo::gdb::insert_reference_to_gdb_debug_scripts_section_global(ccx, &bld);
+        debuginfo::gdb::insert_reference_to_gdb_debug_scripts_section_global(ccx);
 
         let (start_fn, args) = if use_start_lang_item {
             let start_def_id = ccx.tcx().require_lang_item(StartFnLangItem);

--- a/src/librustc_trans/consts.rs
+++ b/src/librustc_trans/consts.rs
@@ -273,7 +273,7 @@ pub fn trans_static<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
 
         if attr::contains_name(attrs, "used") {
             // This static will be stored in the llvm.used variable which is an array of i8*
-            let cast = llvm::LLVMConstPointerCast(g, Type::i8p(ccx).to_ref());
+            let cast = ptrcast(g, Type::i8p(ccx));
             ccx.used_statics().borrow_mut().push(cast);
         }
 

--- a/src/librustc_trans/debuginfo/gdb.rs
+++ b/src/librustc_trans/debuginfo/gdb.rs
@@ -12,9 +12,9 @@
 
 use llvm;
 
-use common::{C_bytes, CrateContext, C_i32};
+use common::{C_bytes, CrateContext};
 use base;
-use builder::Builder;
+use consts;
 use declare;
 use type_::Type;
 use session::config::NoDebugInfo;
@@ -23,19 +23,13 @@ use std::ptr;
 use syntax::attr;
 
 
-/// Inserts a side-effect free instruction sequence that makes sure that the
-/// .debug_gdb_scripts global is referenced, so it isn't removed by the linker.
-pub fn insert_reference_to_gdb_debug_scripts_section_global(ccx: &CrateContext, builder: &Builder) {
+/// Inserts the .debug_gdb_scripts global into the set of symbols
+/// to be placed in `llvm.used`, so it isn't removed by the linker.
+pub fn insert_reference_to_gdb_debug_scripts_section_global(ccx: &CrateContext) {
     if needs_gdb_debug_scripts_section(ccx) {
         let gdb_debug_scripts_section_global = get_or_insert_gdb_debug_scripts_section_global(ccx);
-        // Load just the first byte as that's all that's necessary to force
-        // LLVM to keep around the reference to the global.
-        let indices = [C_i32(ccx, 0), C_i32(ccx, 0)];
-        let element = builder.inbounds_gep(gdb_debug_scripts_section_global, &indices);
-        let volative_load_instruction = builder.volatile_load(element);
-        unsafe {
-            llvm::LLVMSetAlignment(volative_load_instruction, 1);
-        }
+        let cast = consts::ptrcast(gdb_debug_scripts_section_global, Type::i8p(ccx));
+        ccx.used_statics().borrow_mut().push(cast);
     }
 }
 


### PR DESCRIPTION
Fixes #41626 by applying what I did in #35409 for metadata sections, to this section.