### PR TITLE
Don't ever warn about #[used] items being dead code.

### DIFF
--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -283,6 +283,12 @@ fn has_allow_dead_code_or_lang_attr(attrs: &[ast::Attribute]) -> bool {
         return true;
     }
 
+    // #[used] also keeps the item alive forcefully,
+    // e.g. for placing it in a specific section.
+    if attr::contains_name(attrs, "used") {
+        return true;
+    }
+
     let dead_code = lint::builtin::DEAD_CODE.name_lower();
     for attr in lint::gather_attrs(attrs) {
         match attr {

--- a/src/test/run-pass/issue-41628.rs
+++ b/src/test/run-pass/issue-41628.rs
@@ -1,0 +1,17 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(dead_code)]
+#![feature(used)]
+
+#[used]
+static FOO: u32 = 0;
+
+fn main() {}


### PR DESCRIPTION
Fixes #41628 by whitelisting `#[used]` items in `rustc::middle::dead`.