### PR TITLE
Consider changing to & for let bindings #40402

### DIFF
--- a/src/librustc_borrowck/borrowck/gather_loans/move_error.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/move_error.rs
@@ -79,13 +79,10 @@ fn report_move_errors<'a, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>, errors: &Vec<Move
                 let initializer =
                     e.init.as_ref().expect("should have an initializer to get an error");
                 if let Ok(snippet) = bccx.tcx.sess.codemap().span_to_snippet(initializer.span) {
-                    if snippet.len() > 10 {
-                        err.help(&format!("consider borrowing this with `&`"));
-                    } else {
-                        err.help(&format!("consider changing to `&{}`", snippet));
-                    }
+                    err.span_suggestion(initializer.span,
+                                        "consider using a reference instead",
+                                        format!("&{}", snippet));
                 }
-
             }
             _ => {
                 for move_to in &error.move_to_places {

--- a/src/test/ui/issue-40402-ref-hints/issue-40402-1.stderr
+++ b/src/test/ui/issue-40402-ref-hints/issue-40402-1.stderr
@@ -2,9 +2,10 @@ error[E0507]: cannot move out of indexed content
   --> $DIR/issue-40402-1.rs:19:13
    |
 19 |     let e = f.v[0];
-   |             ^^^^^^ cannot move out of indexed content
-   |
-   = help: consider changing to `&f.v[0]`
+   |             ^^^^^^
+   |             |
+   |             help: consider using a reference instead `&f.v[0]`
+   |             cannot move out of indexed content
 
 error: aborting due to previous error
 

--- a/src/test/ui/issue-40402-ref-hints/issue-40402-1.stderr
+++ b/src/test/ui/issue-40402-ref-hints/issue-40402-1.stderr
@@ -3,6 +3,8 @@ error[E0507]: cannot move out of indexed content
    |
 19 |     let e = f.v[0];
    |             ^^^^^^ cannot move out of indexed content
+   |
+   = help: consider changing to `&f.v[0]`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This is a fix for #40402 

For the example
```
fn main() {
    let v = vec![String::from("oh no")];
    
    let e = v[0];
}
```

It gives
```
error[E0507]: cannot move out of indexed content
 --> ex1.rs:4:13
  |
4 |     let e = v[0];
  |             ^^^^ cannot move out of indexed content
  |
  = help: consider changing to `&v[0]`

error: aborting due to previous error
```

Another alternative is
```
error[E0507]: cannot move out of indexed content
 --> ex1.rs:4:13
  |
4 |     let e = v[0];
  |             ^^^^ consider changing to `&v[0]`

error: aborting due to previous error
```
Also refer to #41564 for more details.

r? @nikomatsakis
