### PR TITLE
refactor the handling of lvalue ops

### DIFF
--- a/src/librustc_typeck/check/autoderef.rs
+++ b/src/librustc_typeck/check/autoderef.rs
@@ -10,7 +10,7 @@
 
 use astconv::AstConv;
 
-use super::FnCtxt;
+use super::{FnCtxt, LvalueOp};
 
 use check::coercion::AsCoercionSite;
 use rustc::infer::InferOk;
@@ -18,7 +18,7 @@ use rustc::traits;
 use rustc::ty::{self, Ty, TraitRef};
 use rustc::ty::{ToPredicate, TypeFoldable};
 use rustc::ty::{MethodCall, MethodCallee};
-use rustc::ty::{LvaluePreference, NoPreference, PreferMutLvalue};
+use rustc::ty::{LvaluePreference, NoPreference};
 use rustc::hir;
 
 use syntax_pos::Span;
@@ -213,39 +213,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                 span: Span,
                                 base_expr: Option<&hir::Expr>,
                                 base_ty: Ty<'tcx>,
-                                lvalue_pref: LvaluePreference)
+                                pref: LvaluePreference)
                                 -> Option<InferOk<'tcx, MethodCallee<'tcx>>> {
-        debug!("try_overloaded_deref({:?},{:?},{:?},{:?})",
-               span,
-               base_expr,
-               base_ty,
-               lvalue_pref);
-        // Try DerefMut first, if preferred.
-        let method = match (lvalue_pref, self.tcx.lang_items.deref_mut_trait()) {
-            (PreferMutLvalue, Some(trait_did)) => {
-                self.lookup_method_in_trait(span,
-                                            base_expr,
-                                            Symbol::intern("deref_mut"),
-                                            trait_did,
-                                            base_ty,
-                                            None)
-            }
-            _ => None,
-        };
+        let rcvr = base_expr.map(|base_expr| super::AdjustedRcvr {
+            rcvr_expr: base_expr, autoderefs: 0, unsize: false
+        });
 
-        // Otherwise, fall back to Deref.
-        let method = match (method, self.tcx.lang_items.deref_trait()) {
-            (None, Some(trait_did)) => {
-                self.lookup_method_in_trait(span,
-                                            base_expr,
-                                            Symbol::intern("deref"),
-                                            trait_did,
-                                            base_ty,
-                                            None)
-            }
-            (method, _) => method,
-        };
-
-        method
+        self.try_overloaded_lvalue_op(span, rcvr, base_ty, &[], pref, LvalueOp::Deref)
     }
 }

--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -165,11 +165,13 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             };
 
             match self.lookup_method_in_trait_adjusted(call_expr.span,
-                                                       Some(&callee_expr),
+                                                       Some(super::AdjustedRcvr {
+                                                           rcvr_expr: callee_expr,
+                                                           autoderefs,
+                                                           unsize: false
+                                                       }),
                                                        method_name,
                                                        trait_def_id,
-                                                       autoderefs,
-                                                       false,
                                                        adjusted_ty,
                                                        None) {
                 None => continue,

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -398,12 +398,15 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
         let method = match trait_did {
             Some(trait_did) => {
-                self.lookup_method_in_trait(expr.span,
-                                            Some(lhs_expr),
-                                            opname,
-                                            trait_did,
-                                            lhs_ty,
-                                            Some(other_tys))
+                let lhs_expr = Some(super::AdjustedRcvr {
+                    rcvr_expr: lhs_expr, autoderefs: 0, unsize: false
+                });
+                self.lookup_method_in_trait_adjusted(expr.span,
+                                                     lhs_expr,
+                                                     opname,
+                                                     trait_did,
+                                                     lhs_ty,
+                                                     Some(other_tys))
             }
             None => None
         };

--- a/src/test/run-pass/issue-41604.rs
+++ b/src/test/run-pass/issue-41604.rs
@@ -1,0 +1,20 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct B;
+
+impl B {
+    fn init(&mut self) {}
+}
+
+fn main() {
+    let mut b = [B];
+    b[1-1].init();
+}


### PR DESCRIPTION
I think I got the code into a "mostly sane" situation.

Fixes #41604.

beta-nominating because fixes regression in #41578. I think I can do a smaller fix, but the previous code is too fragile.

r? @eddyb 