### PR TITLE
Add -march=armv7-a parameter to armv7 android linker

### DIFF
--- a/src/librustc_back/target/armv7_linux_androideabi.rs
+++ b/src/librustc_back/target/armv7_linux_androideabi.rs
@@ -18,6 +18,8 @@ pub fn target() -> TargetResult {
     let mut base = super::android_base::opts();
     base.features = "+v7,+thumb2,+vfp3,+d16,-neon".to_string();
     base.max_atomic_width = Some(64);
+    base.pre_link_args
+        .get_mut(&LinkerFlavor::Gcc).unwrap().push("-march=armv7-a".to_string());
 
     Ok(Target {
         llvm_target: "armv7-none-linux-android".to_string(),


### PR DESCRIPTION
Without this option, the linker fails to link any library that uses `std::future`. The error points some undefined references, like `std::__future_base::_Result_base`.

For example, it fails to link rustc because llvm 4.0 uses `std::future`. 

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64735