### PR TITLE
Under MinGW, x.py fails to run with UnboundLocalError.

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -414,8 +414,8 @@ class RustBuild(object):
         # The goal here is to come up with the same triple as LLVM would,
         # at least for the subset of platforms we're willing to target.
         if ostype == 'Linux':
-            os = subprocess.check_output(['uname', '-o']).strip().decode(default_encoding)
-            if os == 'Android':
+            os_from_sp = subprocess.check_output(['uname', '-o']).strip().decode(default_encoding)
+            if os_from_sp == 'Android':
                 ostype = 'linux-android'
             else:
                 ostype = 'unknown-linux-gnu'

--- a/x.py
+++ b/x.py
@@ -9,7 +9,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-# This file is only a "symlink" to boostrap.py, all logic should go there.
+# This file is only a "symlink" to bootstrap.py, all logic should go there.
 
 import os
 import sys


### PR DESCRIPTION
Under MinGW, `x.py` will fail with the following errors: 

```bash
$ ./x.py
Traceback (most recent call last):
  File "./x.py", line 20, in <module>
    bootstrap.main()
  File "C:/src/rust/src/bootstrap/bootstrap.py", line 620, in main
    bootstrap()
  File "C:/src/rust/src/bootstrap/bootstrap.py", line 601, in bootstrap
    rb.build = rb.build_triple()
  File "C:/src/rust/src/bootstrap/bootstrap.py", line 459, in build_triple
    if os.environ.get('MSYSTEM') == 'MINGW64':
UnboundLocalError: local variable 'os' referenced before assignment
```

The reason is due to the `build_triple` function in `src/bootstrap/bootstrap.py` (Line 416):

```python
if ostype == 'Linux':
    os = subprocess.check_output(['uname', '-o']).strip().decode(default_encoding)
        
```

Here, the assignment to `os` is causing the `os` module to be shadowed.

Then, in (Line 459):

```python
if os.environ.get('MSYSTEM') == 'MINGW64':
    cputype = 'x86_64'
```

`os` now refers to the uninitialized local variable, not the `os` module.

Easiest fix is to simply rename the `os` variable to something like `os_from_sp`.

Also, there is a small typo fix in `x.py` referencing the wrong file name.
