### PR TITLE
Fix issue #41652

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -270,8 +270,10 @@ impl EmitterWriter {
                           line: &Line,
                           width_offset: usize,
                           code_offset: usize) -> Vec<(usize, Style)> {
-        let source_string = file.get_line(line.line_index - 1)
-            .unwrap_or("");
+        let source_string = match file.get_line(line.line_index - 1) {
+            Some(s) => s,
+            None => return Vec::new(),
+        };
 
         let line_offset = buffer.num_lines();
 
@@ -909,6 +911,11 @@ impl EmitterWriter {
 
         // Print out the annotate source lines that correspond with the error
         for annotated_file in annotated_files {
+            // we can't annotate anything if the source is unavailable.
+            if annotated_file.file.src.is_none() {
+                continue;
+            }
+
             // print out the span location and spacer before we print the annotated source
             // to do this, we need to know if this span will be primary
             let is_primary = primary_lo.file.name == annotated_file.file.name;

--- a/src/test/ui/issue-41652/auxiliary/issue_41652_b.rs
+++ b/src/test/ui/issue-41652/auxiliary/issue_41652_b.rs
@@ -1,0 +1,16 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub trait Tr {
+    // Note: The function needs to be declared over multiple lines to reproduce
+    // the crash. DO NOT reformat.
+    fn f()
+        where Self: Sized;
+}

--- a/src/test/ui/issue-41652/issue_41652.rs
+++ b/src/test/ui/issue-41652/issue_41652.rs
@@ -1,0 +1,26 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue_41652_b.rs
+
+extern crate issue_41652_b;
+
+struct S;
+
+impl issue_41652_b::Tr for S {
+    fn f() {
+        3.f()
+        //~^ ERROR no method named `f` found for type `{integer}` in the current scope
+        //~| NOTE found the following associated functions
+        //~| NOTE candidate #1 is defined in the trait `issue_41652_b::Tr`
+    }
+}
+
+fn main() {}

--- a/src/test/ui/issue-41652/issue_41652.stderr
+++ b/src/test/ui/issue-41652/issue_41652.stderr
@@ -1,0 +1,12 @@
+error: no method named `f` found for type `{integer}` in the current scope
+  --> $DIR/issue_41652.rs:19:11
+   |
+19 |         3.f()
+   |           ^
+   |
+   = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
+note: candidate #1 is defined in the trait `issue_41652_b::Tr`
+   = help: to disambiguate the method call, write `issue_41652_b::Tr::f(3)` instead
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fix issue #41652. Don't print anything in `render_source_line()` if no source code is given.

(cc @jonathandturner #34789)
