### PR TITLE
Add an in-place rotate method for slices to libcore

### DIFF
--- a/src/doc/unstable-book/src/SUMMARY.md
+++ b/src/doc/unstable-book/src/SUMMARY.md
@@ -195,6 +195,7 @@
     - [sip_hash_13](library-features/sip-hash-13.md)
     - [slice_concat_ext](library-features/slice-concat-ext.md)
     - [slice_get_slice](library-features/slice-get-slice.md)
+    - [slice_rotate](library-features/slice-rotate.md)
     - [slice_rsplit](library-features/slice-rsplit.md)
     - [sort_internals](library-features/sort-internals.md)
     - [sort_unstable](library-features/sort-unstable.md)

--- a/src/doc/unstable-book/src/library-features/slice-rotate.md
+++ b/src/doc/unstable-book/src/library-features/slice-rotate.md
@@ -1,7 +1,7 @@
 # `slice_rotate`
 
-The tracking issue for this feature is: [#123456789]
+The tracking issue for this feature is: [#41891]
 
-[#123456789]: https://github.com/rust-lang/rust/issues/123456789
+[#41891]: https://github.com/rust-lang/rust/issues/41891
 
 ------------------------

--- a/src/doc/unstable-book/src/library-features/slice-rotate.md
+++ b/src/doc/unstable-book/src/library-features/slice-rotate.md
@@ -1,0 +1,7 @@
+# `slice_rotate`
+
+The tracking issue for this feature is: [#123456789]
+
+[#123456789]: https://github.com/rust-lang/rust/issues/123456789
+
+------------------------

--- a/src/libcollections/benches/lib.rs
+++ b/src/libcollections/benches/lib.rs
@@ -13,6 +13,7 @@
 #![feature(i128_type)]
 #![feature(rand)]
 #![feature(repr_simd)]
+#![feature(slice_rotate)]
 #![feature(sort_unstable)]
 #![feature(test)]
 

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -55,6 +55,7 @@
 #![feature(shared)]
 #![feature(slice_get_slice)]
 #![feature(slice_patterns)]
+#![cfg_attr(not(test), feature(slice_rotate))]
 #![feature(slice_rsplit)]
 #![cfg_attr(not(test), feature(sort_unstable))]
 #![feature(specialization)]

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -1337,6 +1337,58 @@ impl<T> [T] {
         core_slice::SliceExt::sort_unstable_by_key(self, f);
     }
 
+    /// Permutes the slice in-place such that `self[mid..]` move to the
+    /// beginning of the slice while `self[..mid]` move to the end of the
+    /// slice.  Equivalently, rotates the slice `mid` places to the left
+    /// or `k = self.len() - mid` places to the right.
+    ///
+    /// Rotation by `mid` and rotation by `k` are inverse operations.
+    /// The method returns `k`, which is also the new location of
+    /// the formerly-first element.
+    ///
+    /// This is a "k-rotation", a permutation in which item `i` moves to
+    /// position `i + k`, modulo the length of the slice.  See _Elements
+    /// of Programming_ [§10.4][eop].
+    ///
+    /// [eop]: https://books.google.com/books?id=CO9ULZGINlsC&pg=PA178&q=k-rotation
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `mid` is greater than the length of the
+    /// slice.  (Note that `mid == self.len()` does _not_ panic; it's a nop
+    /// rotation with `k == 0`, the inverse of a rotation with `mid == 0`.)
+    ///
+    /// # Complexity
+    ///
+    /// Takes linear (in `self.len()`) time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(slice_rotate)]
+    ///
+    /// let mut a = [1, 2, 3, 4, 5, 6, 7];
+    /// let k = a.rotate(2);
+    /// assert_eq!(&a, &[3, 4, 5, 6, 7, 1, 2]);
+    /// a.rotate(k);
+    /// assert_eq!(&a, &[1, 2, 3, 4, 5, 6, 7]);
+    ///
+    /// fn extend_at<T, I>(v: &mut Vec<T>, index: usize, iter: I)
+    ///     where I: Iterator<Item=T>
+    /// {
+    ///     let mid = v.len() - index;
+    ///     v.extend(iter);
+    ///     v[index..].rotate(mid);
+    /// }
+    /// let mut v = (0..10).collect();
+    /// extend_at(&mut v, 7, 100..104);
+    /// assert_eq!(&v, &[0, 1, 2, 3, 4, 5, 6, 100, 101, 102, 103, 7, 8, 9]);
+    /// ```
+    #[unstable(feature = "slice_rotate", issue = "123456789")]
+    pub fn rotate(&mut self, mid: usize) -> usize {
+        core_slice::SliceExt::rotate(self, mid)
+    }
+
     /// Copies the elements from `src` into `self`.
     ///
     /// The length of `src` must be the same as `self`.

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -1387,7 +1387,7 @@ impl<T> [T] {
     /// slide(&mut v, 6..8, 1);
     /// assert_eq!(&v, &[0, 3, 7, 4, 5, 6, 1, 2, 8, 9]);
     /// ```
-    #[unstable(feature = "slice_rotate", issue = "123456789")]
+    #[unstable(feature = "slice_rotate", issue = "41891")]
     pub fn rotate(&mut self, mid: usize) -> usize {
         core_slice::SliceExt::rotate(self, mid)
     }

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -1373,16 +1373,19 @@ impl<T> [T] {
     /// a.rotate(k);
     /// assert_eq!(&a, &[1, 2, 3, 4, 5, 6, 7]);
     ///
-    /// fn extend_at<T, I>(v: &mut Vec<T>, index: usize, iter: I)
-    ///     where I: Iterator<Item=T>
-    /// {
-    ///     let mid = v.len() - index;
-    ///     v.extend(iter);
-    ///     v[index..].rotate(mid);
+    /// use std::ops::Range;
+    /// fn slide<T>(slice: &mut [T], range: Range<usize>, to: usize) {
+    ///     if to < range.start {
+    ///         slice[to..range.end].rotate(range.start-to);
+    ///     } else if to > range.end {
+    ///         slice[range.start..to].rotate(range.end-range.start);
+    ///     }
     /// }
-    /// let mut v = (0..10).collect();
-    /// extend_at(&mut v, 7, 100..104);
-    /// assert_eq!(&v, &[0, 1, 2, 3, 4, 5, 6, 100, 101, 102, 103, 7, 8, 9]);
+    /// let mut v: Vec<_> = (0..10).collect();
+    /// slide(&mut v, 1..4, 7);
+    /// assert_eq!(&v, &[0, 4, 5, 6, 1, 2, 3, 7, 8, 9]);
+    /// slide(&mut v, 6..8, 1);
+    /// assert_eq!(&v, &[0, 3, 7, 4, 5, 6, 1, 2, 8, 9]);
     /// ```
     #[unstable(feature = "slice_rotate", issue = "123456789")]
     pub fn rotate(&mut self, mid: usize) -> usize {

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -1342,13 +1342,11 @@ impl<T> [T] {
     /// slice.  Equivalently, rotates the slice `mid` places to the left
     /// or `k = self.len() - mid` places to the right.
     ///
-    /// Rotation by `mid` and rotation by `k` are inverse operations.
-    /// The method returns `k`, which is also the new location of
-    /// the formerly-first element.
-    ///
     /// This is a "k-rotation", a permutation in which item `i` moves to
     /// position `i + k`, modulo the length of the slice.  See _Elements
     /// of Programming_ [§10.4][eop].
+    ///
+    /// Rotation by `mid` and rotation by `k` are inverse operations.
     ///
     /// [eop]: https://books.google.com/books?id=CO9ULZGINlsC&pg=PA178&q=k-rotation
     ///
@@ -1368,8 +1366,10 @@ impl<T> [T] {
     /// #![feature(slice_rotate)]
     ///
     /// let mut a = [1, 2, 3, 4, 5, 6, 7];
-    /// let k = a.rotate(2);
+    /// let mid = 2;
+    /// a.rotate(mid);
     /// assert_eq!(&a, &[3, 4, 5, 6, 7, 1, 2]);
+    /// let k = a.len() - mid;
     /// a.rotate(k);
     /// assert_eq!(&a, &[1, 2, 3, 4, 5, 6, 7]);
     ///
@@ -1388,8 +1388,8 @@ impl<T> [T] {
     /// assert_eq!(&v, &[0, 3, 7, 4, 5, 6, 1, 2, 8, 9]);
     /// ```
     #[unstable(feature = "slice_rotate", issue = "41891")]
-    pub fn rotate(&mut self, mid: usize) -> usize {
-        core_slice::SliceExt::rotate(self, mid)
+    pub fn rotate(&mut self, mid: usize) {
+        core_slice::SliceExt::rotate(self, mid);
     }
 
     /// Copies the elements from `src` into `self`.

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -1337,8 +1337,8 @@ impl<T> [T] {
         core_slice::SliceExt::sort_unstable_by_key(self, f);
     }
 
-    /// Permutes the slice in-place such that `self[mid..]` move to the
-    /// beginning of the slice while `self[..mid]` move to the end of the
+    /// Permutes the slice in-place such that `self[mid..]` moves to the
+    /// beginning of the slice while `self[..mid]` moves to the end of the
     /// slice.  Equivalently, rotates the slice `mid` places to the left
     /// or `k = self.len() - mid` places to the right.
     ///

--- a/src/libcollections/tests/lib.rs
+++ b/src/libcollections/tests/lib.rs
@@ -20,6 +20,7 @@
 #![feature(pattern)]
 #![feature(placement_in_syntax)]
 #![feature(rand)]
+#![feature(slice_rotate)]
 #![feature(splice)]
 #![feature(step_by)]
 #![feature(str_escape)]

--- a/src/libcollections/tests/slice.rs
+++ b/src/libcollections/tests/slice.rs
@@ -467,6 +467,42 @@ fn test_sort_stability() {
 }
 
 #[test]
+fn test_rotate() {
+    let expected: Vec<_> = (0..13).collect();
+    let mut v = Vec::new();
+
+    // no-ops
+    v.clone_from(&expected);
+    v.rotate(0);
+    assert_eq!(v, expected);
+    v.rotate(expected.len());
+    assert_eq!(v, expected);
+    let mut zst_array = [(), (), ()];
+    zst_array.rotate(2);
+
+    // happy path
+    v = (5..13).chain(0..5).collect();
+    let k = v.rotate(8);
+    assert_eq!(v, expected);
+    assert_eq!(k, 5);
+
+    let expected: Vec<_> = (0..1000).collect();
+
+    // small rotations in large slice, uses ptr::copy
+    v = (2..1000).chain(0..2).collect();
+    v.rotate(998);
+    assert_eq!(v, expected);
+    v = (998..1000).chain(0..998).collect();
+    v.rotate(2);
+    assert_eq!(v, expected);
+
+    // non-small prime rotation, has a few rounds of swapping
+    v = (389..1000).chain(0..389).collect();
+    v.rotate(1000-389);
+    assert_eq!(v, expected);
+}
+
+#[test]
 fn test_concat() {
     let v: [Vec<i32>; 0] = [];
     let c = v.concat();

--- a/src/libcollections/tests/slice.rs
+++ b/src/libcollections/tests/slice.rs
@@ -482,9 +482,8 @@ fn test_rotate() {
 
     // happy path
     v = (5..13).chain(0..5).collect();
-    let k = v.rotate(8);
+    v.rotate(8);
     assert_eq!(v, expected);
-    assert_eq!(k, 5);
 
     let expected: Vec<_> = (0..1000).collect();
 

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -203,7 +203,7 @@ pub trait SliceExt {
     #[stable(feature = "core", since = "1.6.0")]
     fn ends_with(&self, needle: &[Self::Item]) -> bool where Self::Item: PartialEq;
 
-    #[unstable(feature = "slice_rotate", issue = "123456789")]
+    #[unstable(feature = "slice_rotate", issue = "41891")]
     fn rotate(&mut self, mid: usize) -> usize;
 
     #[stable(feature = "clone_from_slice", since = "1.7.0")]

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -204,7 +204,7 @@ pub trait SliceExt {
     fn ends_with(&self, needle: &[Self::Item]) -> bool where Self::Item: PartialEq;
 
     #[unstable(feature = "slice_rotate", issue = "41891")]
-    fn rotate(&mut self, mid: usize) -> usize;
+    fn rotate(&mut self, mid: usize);
 
     #[stable(feature = "clone_from_slice", since = "1.7.0")]
     fn clone_from_slice(&mut self, src: &[Self::Item]) where Self::Item: Clone;
@@ -639,7 +639,7 @@ impl<T> SliceExt for [T] {
         self.binary_search_by(|p| p.borrow().cmp(x))
     }
 
-    fn rotate(&mut self, mid: usize) -> usize {
+    fn rotate(&mut self, mid: usize) {
         assert!(mid <= self.len());
         let k = self.len() - mid;
 
@@ -647,8 +647,6 @@ impl<T> SliceExt for [T] {
             let p = self.as_mut_ptr();
             rotate::ptr_rotate(mid, p.offset(mid as isize), k);
         }
-
-        k
     }
 
     #[inline]

--- a/src/libcore/slice/rotate.rs
+++ b/src/libcore/slice/rotate.rs
@@ -104,51 +104,9 @@ pub unsafe fn ptr_rotate<T>(mut left: usize, mid: *mut T, mut right: usize) {
     }
 }
 
-unsafe fn ptr_swap_u8(a: *mut u8, b: *mut u8, n: usize) {
-    for i in 0..n {
-        ptr::swap(a.offset(i as isize), b.offset(i as isize));
-    }
-}
-unsafe fn ptr_swap_u16(a: *mut u16, b: *mut u16, n: usize) {
-    for i in 0..n {
-        ptr::swap(a.offset(i as isize), b.offset(i as isize));
-    }
-}
-unsafe fn ptr_swap_u32(a: *mut u32, b: *mut u32, n: usize) {
-    for i in 0..n {
-        ptr::swap(a.offset(i as isize), b.offset(i as isize));
-    }
-}
-unsafe fn ptr_swap_u64(a: *mut u64, b: *mut u64, n: usize) {
-    for i in 0..n {
-        ptr::swap(a.offset(i as isize), b.offset(i as isize));
-    }
-}
-
 unsafe fn ptr_swap_n<T>(a: *mut T, b: *mut T, n: usize) {
-    // Doing this as a generic is 16% & 40% slower in two of the `String`
-    // benchmarks, as (based on the block names) LLVM doesn't vectorize it.
-    // Since this is just operating on raw memory, dispatch to a version
-    // with appropriate alignment.  Helps with code size as well, by
-    // avoiding monomorphizing different unrolled loops for `i32`,
-    // `u32`, `f32`, `[u32; 1]`, etc.
-    let size_of_t = mem::size_of::<T>();
-    let align_of_t = mem::align_of::<T>();
-
-    let a64 = mem::align_of::<u64>();
-    if a64 == 8 && align_of_t % a64 == 0 {
-        return ptr_swap_u64(a as *mut u64, b as *mut u64, n * (size_of_t / 8));
+    for i in 0..n {
+        // These are nonoverlapping, so use mem::swap instead of ptr::swap
+        mem::swap(&mut *a.offset(i as isize), &mut *b.offset(i as isize));
     }
-
-    let a32 = mem::align_of::<u32>();
-    if a32 == 4 && align_of_t % a32 == 0 {
-        return ptr_swap_u32(a as *mut u32, b as *mut u32, n * (size_of_t / 4));
-    }
-
-    let a16 = mem::align_of::<u16>();
-    if a16 == 2 && align_of_t % a16 == 0 {
-        return ptr_swap_u16(a as *mut u16, b as *mut u16, n * (size_of_t / 2));
-    }
-
-    ptr_swap_u8(a as *mut u8, b as *mut u8, n * size_of_t);
 }

--- a/src/libcore/slice/rotate.rs
+++ b/src/libcore/slice/rotate.rs
@@ -1,0 +1,154 @@
+// Copyright 2012-2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use cmp;
+use mem;
+use ptr;
+
+/// Rotation is much faster if it has access to a little bit of memory. This
+/// union provides a RawVec-like interface, but to a fixed-size stack buffer.
+#[allow(unions_with_drop_fields)]
+union RawArray<T> {
+    /// Ensure this is appropriately aligned for T, and is big
+    /// enough for two elements even if T is enormous.
+    typed: [T; 2],
+    /// For normally-sized types, especially things like u8, having more
+    /// than 2 in the buffer is necessary for usefulness, so pad it out
+    /// enough to be helpful, but not so big as to risk overflow.
+    _extra: [usize; 32],
+}
+
+impl<T> RawArray<T> {
+    fn new() -> Self {
+        unsafe { mem::uninitialized() }
+    }
+    fn ptr(&self) -> *mut T {
+        unsafe { &self.typed as *const T as *mut T }
+    }
+    fn cap() -> usize {
+        if mem::size_of::<T>() == 0 {
+            usize::max_value()
+        } else {
+            mem::size_of::<Self>() / mem::size_of::<T>()
+        }
+    }
+}
+
+/// Rotates the range `[mid-left, mid+right)` such that the element at `mid`
+/// becomes the first element.  Equivalently, rotates the range `left`
+/// elements to the left or `right` elements to the right.
+///
+/// # Safety
+///
+/// The specified range must be valid for reading and writing.
+/// The type `T` must have non-zero size.
+///
+/// # Algorithm
+///
+/// For longer rotations, swap the left-most `delta = min(left, right)`
+/// elements with the right-most `delta` elements.  LLVM vectorizes this,
+/// which is profitable as we only reach this step for a "large enough"
+/// rotation.  Doing this puts `delta` elements on the larger side into the
+/// correct position, leaving a smaller rotate problem.  Demonstration:
+///
+/// ```text
+/// [ 6 7 8 9 10 11 12 13 . 1 2 3 4 5 ]
+/// 1 2 3 4 5 [ 11 12 13 . 6 7 8 9 10 ]
+/// 1 2 3 4 5 [ 8 9 10 . 6 7 ] 11 12 13
+/// 1 2 3 4 5 6 7 [ 10 . 8 9 ] 11 12 13
+/// 1 2 3 4 5 6 7 [ 9 . 8 ] 10 11 12 13
+/// 1 2 3 4 5 6 7 8 [ . ] 9 10 11 12 13
+/// ```
+///
+/// Once the rotation is small enough, copy some elements into a stack
+/// buffer, `memmove` the others, and move the ones back from the buffer.
+pub unsafe fn ptr_rotate<T>(mut left: usize, mid: *mut T, mut right: usize) {
+    loop {
+        let delta = cmp::min(left, right);
+        if delta <= RawArray::<T>::cap() {
+            break;
+        }
+
+        ptr_swap_n(
+            mid.offset(-(left as isize)),
+            mid.offset((right-delta) as isize),
+            delta);
+
+        if left <= right {
+            right -= delta;
+        } else {
+            left -= delta;
+        }
+    }
+
+    let rawarray = RawArray::new();
+    let buf = rawarray.ptr();
+
+    let dim = mid.offset(-(left as isize)).offset(right as isize);
+    if left <= right {
+        ptr::copy_nonoverlapping(mid.offset(-(left as isize)), buf, left);
+        ptr::copy(mid, mid.offset(-(left as isize)), right);
+        ptr::copy_nonoverlapping(buf, dim, left);
+    }
+    else {
+        ptr::copy_nonoverlapping(mid, buf, right);
+        ptr::copy(mid.offset(-(left as isize)), dim, left);
+        ptr::copy_nonoverlapping(buf, mid.offset(-(left as isize)), right);
+    }
+}
+
+unsafe fn ptr_swap_u8(a: *mut u8, b: *mut u8, n: usize) {
+    for i in 0..n {
+        ptr::swap(a.offset(i as isize), b.offset(i as isize));
+    }
+}
+unsafe fn ptr_swap_u16(a: *mut u16, b: *mut u16, n: usize) {
+    for i in 0..n {
+        ptr::swap(a.offset(i as isize), b.offset(i as isize));
+    }
+}
+unsafe fn ptr_swap_u32(a: *mut u32, b: *mut u32, n: usize) {
+    for i in 0..n {
+        ptr::swap(a.offset(i as isize), b.offset(i as isize));
+    }
+}
+unsafe fn ptr_swap_u64(a: *mut u64, b: *mut u64, n: usize) {
+    for i in 0..n {
+        ptr::swap(a.offset(i as isize), b.offset(i as isize));
+    }
+}
+
+unsafe fn ptr_swap_n<T>(a: *mut T, b: *mut T, n: usize) {
+    // Doing this as a generic is 16% & 40% slower in two of the `String`
+    // benchmarks, as (based on the block names) LLVM doesn't vectorize it.
+    // Since this is just operating on raw memory, dispatch to a version
+    // with appropriate alignment.  Helps with code size as well, by
+    // avoiding monomorphizing different unrolled loops for `i32`,
+    // `u32`, `f32`, `[u32; 1]`, etc.
+    let size_of_t = mem::size_of::<T>();
+    let align_of_t = mem::align_of::<T>();
+
+    let a64 = mem::align_of::<u64>();
+    if a64 == 8 && align_of_t % a64 == 0 {
+        return ptr_swap_u64(a as *mut u64, b as *mut u64, n * (size_of_t / 8));
+    }
+
+    let a32 = mem::align_of::<u32>();
+    if a32 == 4 && align_of_t % a32 == 0 {
+        return ptr_swap_u32(a as *mut u32, b as *mut u32, n * (size_of_t / 4));
+    }
+
+    let a16 = mem::align_of::<u16>();
+    if a16 == 2 && align_of_t % a16 == 0 {
+        return ptr_swap_u16(a as *mut u16, b as *mut u16, n * (size_of_t / 2));
+    }
+
+    ptr_swap_u8(a as *mut u8, b as *mut u8, n * size_of_t);
+}

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -29,6 +29,7 @@
 #![feature(raw)]
 #![feature(sip_hash_13)]
 #![feature(slice_patterns)]
+#![feature(slice_rotate)]
 #![feature(sort_internals)]
 #![feature(sort_unstable)]
 #![feature(step_by)]

--- a/src/libcore/tests/slice.rs
+++ b/src/libcore/tests/slice.rs
@@ -246,9 +246,9 @@ fn test_rotate() {
         a[i] = i;
     }
 
-    let k = a.rotate(42);
+    a.rotate(42);
+    let k = N - 42;
 
-    assert_eq!(k, N - 42);
     for i in 0..N {
         assert_eq!(a[(i+k)%N], i);
     }

--- a/src/libcore/tests/slice.rs
+++ b/src/libcore/tests/slice.rs
@@ -239,6 +239,22 @@ fn test_find_rfind() {
 }
 
 #[test]
+fn test_rotate() {
+    const N: usize = 600;
+    let a: &mut [_] = &mut [0; N];
+    for i in 0..N {
+        a[i] = i;
+    }
+
+    let k = a.rotate(42);
+
+    assert_eq!(k, N - 42);
+    for i in 0..N {
+        assert_eq!(a[(i+k)%N], i);
+    }
+}
+
+#[test]
 fn sort_unstable() {
     let mut v = [0; 600];
     let mut tmp = [0; 600];


### PR DESCRIPTION
A helpful primitive for moving chunks of data around inside a slice.

For example, if you have a range selected and are drag-and-dropping it somewhere else (Example from [Sean Parent's talk](https://youtu.be/qH6sSOr-yk8?t=560)).

(If this should be an RFC instead of a PR, please let me know.)

Edit: changed example