### PR TITLE
Add option to display warnings in rustdoc

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -104,7 +104,8 @@ pub fn run_core(search_paths: SearchPaths,
                 externs: config::Externs,
                 input: Input,
                 triple: Option<String>,
-                maybe_sysroot: Option<PathBuf>) -> (clean::Crate, RenderInfo)
+                maybe_sysroot: Option<PathBuf>,
+                allow_warnings: bool) -> (clean::Crate, RenderInfo)
 {
     // Parse, resolve, and typecheck the given crate.
 
@@ -119,7 +120,7 @@ pub fn run_core(search_paths: SearchPaths,
         maybe_sysroot: maybe_sysroot,
         search_paths: search_paths,
         crate_types: vec![config::CrateTypeRlib],
-        lint_opts: vec![(warning_lint, lint::Allow)],
+        lint_opts: if !allow_warnings { vec![(warning_lint, lint::Allow)] } else { vec![] },
         lint_cap: Some(lint::Allow),
         externs: externs,
         target_triple: triple.unwrap_or(config::host_triple().to_string()),

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -172,6 +172,7 @@ pub fn opts() -> Vec<RustcOptGroup> {
                          or `#![doc(html_playground_url=...)]`",
                         "URL")),
         unstable(optflag("", "enable-commonmark", "to enable commonmark doc rendering/testing")),
+        unstable(optflag("", "display-warnings", "to print code warnings when testing doc")),
     ]
 }
 
@@ -279,14 +280,16 @@ pub fn main_args(args: &[String]) -> isize {
     let crate_name = matches.opt_str("crate-name");
     let playground_url = matches.opt_str("playground-url");
     let maybe_sysroot = matches.opt_str("sysroot").map(PathBuf::from);
+    let display_warnings = matches.opt_present("display-warnings");
 
     match (should_test, markdown_input) {
         (true, true) => {
-            return markdown::test(input, cfgs, libs, externs, test_args, maybe_sysroot, render_type)
+            return markdown::test(input, cfgs, libs, externs, test_args, maybe_sysroot, render_type,
+                                  display_warnings)
         }
         (true, false) => {
             return test::run(input, cfgs, libs, externs, test_args, crate_name, maybe_sysroot,
-                             render_type)
+                             render_type, display_warnings)
         }
         (false, true) => return markdown::render(input,
                                                  output.unwrap_or(PathBuf::from("doc")),
@@ -388,13 +391,15 @@ where R: 'static + Send, F: 'static + Send + FnOnce(Output) -> R {
 
     let cr = PathBuf::from(cratefile);
     info!("starting to run rustc");
+    let display_warnings = matches.opt_present("display-warnings");
 
     let (tx, rx) = channel();
     rustc_driver::monitor(move || {
         use rustc::session::config::Input;
 
         let (mut krate, renderinfo) =
-            core::run_core(paths, cfgs, externs, Input::File(cr), triple, maybe_sysroot);
+            core::run_core(paths, cfgs, externs, Input::File(cr), triple, maybe_sysroot,
+                           display_warnings);
 
         info!("finished with rustc");
 

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -166,9 +166,7 @@ pub fn test(input: &str, cfgs: Vec<String>, libs: SearchPaths, externs: Externs,
     old_find_testable_code(&input_str, &mut collector, DUMMY_SP);
     find_testable_code(&input_str, &mut collector, DUMMY_SP);
     test_args.insert(0, "rustdoctest".to_string());
-    if display_warnings {
-        test_args.insert(1, "--display-stdout".to_string());
-    }
-    testing::test_main(&test_args, collector.tests);
+    testing::test_main(&test_args, collector.tests,
+                       testing::Options::new().display_output(display_warnings));
     0
 }

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -150,7 +150,7 @@ pub fn render(input: &str, mut output: PathBuf, matches: &getopts::Matches,
 /// Run any tests/code examples in the markdown file `input`.
 pub fn test(input: &str, cfgs: Vec<String>, libs: SearchPaths, externs: Externs,
             mut test_args: Vec<String>, maybe_sysroot: Option<PathBuf>,
-            render_type: RenderType) -> isize {
+            render_type: RenderType, display_warnings: bool) -> isize {
     let input_str = match load_string(input) {
         Ok(s) => s,
         Err(LoadStringError::ReadFail) => return 1,
@@ -166,6 +166,9 @@ pub fn test(input: &str, cfgs: Vec<String>, libs: SearchPaths, externs: Externs,
     old_find_testable_code(&input_str, &mut collector, DUMMY_SP);
     find_testable_code(&input_str, &mut collector, DUMMY_SP);
     test_args.insert(0, "rustdoctest".to_string());
+    if display_warnings {
+        test_args.insert(1, "--display-stdout".to_string());
+    }
     testing::test_main(&test_args, collector.tests);
     0
 }

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -126,12 +126,10 @@ pub fn run(input: &str,
     }
 
     test_args.insert(0, "rustdoctest".to_string());
-    if display_warnings {
-        test_args.insert(1, "--display-stdout".to_string());
-    }
 
     testing::test_main(&test_args,
-                       collector.tests.into_iter().collect());
+                       collector.tests.into_iter().collect(),
+                       testing::Options::new().display_output(display_warnings));
     0
 }
 

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -58,7 +58,8 @@ pub fn run(input: &str,
            mut test_args: Vec<String>,
            crate_name: Option<String>,
            maybe_sysroot: Option<PathBuf>,
-           render_type: RenderType)
+           render_type: RenderType,
+           display_warnings: bool)
            -> isize {
     let input_path = PathBuf::from(input);
     let input = config::Input::File(input_path.clone());
@@ -125,6 +126,9 @@ pub fn run(input: &str,
     }
 
     test_args.insert(0, "rustdoctest".to_string());
+    if display_warnings {
+        test_args.insert(1, "--display-stdout".to_string());
+    }
 
     testing::test_main(&test_args,
                        collector.tests.into_iter().collect());

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -442,7 +442,7 @@ We're going to be building a module that looks more or less like:
 mod __test {
   extern crate test (name = "test", vers = "...");
   fn main() {
-    test::test_main_static(&::os::args()[], tests)
+    test::test_main_static(&::os::args()[], tests, test::Options::new())
   }
 
   static tests : &'static [test::TestDescAndFn] = &[
@@ -478,7 +478,7 @@ fn mk_main(cx: &mut TestCtxt) -> P<ast::Item> {
     //        pub fn main() {
     //            #![main]
     //            use std::slice::AsSlice;
-    //            test::test_main_static(::std::os::args().as_slice(), TESTS);
+    //            test::test_main_static(::std::os::args().as_slice(), TESTS, test::Options::new());
     //        }
 
     let sp = ignored_span(cx, DUMMY_SP);

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -336,6 +336,7 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
         test_threads: None,
         skip: vec![],
         list: false,
+        display_stdout: false,
     }
 }
 

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -336,7 +336,7 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
         test_threads: None,
         skip: vec![],
         list: false,
-        display_stdout: false,
+        options: test::Options::new(),
     }
 }
 


### PR DESCRIPTION
Part of #41574.

r? @alexcrichton 

The output for this file:

```rust
/// ```
/// fn foo(x: u32) {}
///
/// foo(2);
/// let x = 1;
/// panic!();
/// ```
fn foo() {}

/// ```
/// fn foo(x: u32) {}
///
/// foo(2);
/// let x = 1;
/// ```
fn foo2() {}

/// ```
/// fn foo(x: u32) {}
///
/// foo(2);
/// let x = 1;
/// panic!();
/// ```
fn foo3() {}

fn main() {
}
```

is the following:

```
> ./build/x86_64-apple-darwin/stage1/bin/rustdoc -Z unstable-options --display-warnings --test test.rs

running 3 tests
test test.rs - foo (line 1) ... FAILED
test test.rs - foo3 (line 18) ... FAILED
test test.rs - foo2 (line 10) ... ok

successes:

---- test.rs - foo2 (line 10) stdout ----
	warning: unused variable: `x`
 --> <anon>:2:8
  |
2 | fn foo(x: u32) {}
  |        ^
  |
  = note: #[warn(unused_variables)] on by default

warning: unused variable: `x`
 --> <anon>:5:5
  |
5 | let x = 1;
  |     ^
  |
  = note: #[warn(unused_variables)] on by default



successes:
    test.rs - foo2 (line 10)

failures:

---- test.rs - foo (line 1) stdout ----
	warning: unused variable: `x`
 --> <anon>:2:8
  |
2 | fn foo(x: u32) {}
  |        ^
  |
  = note: #[warn(unused_variables)] on by default

warning: unused variable: `x`
 --> <anon>:5:5
  |
5 | let x = 1;
  |     ^
  |
  = note: #[warn(unused_variables)] on by default

thread 'rustc' panicked at 'test executable failed:

thread 'main' panicked at 'explicit panic', <anon>:6
note: Run with `RUST_BACKTRACE=1` for a backtrace.

', src/librustdoc/test.rs:317
note: Run with `RUST_BACKTRACE=1` for a backtrace.

---- test.rs - foo3 (line 18) stdout ----
	warning: unused variable: `x`
 --> <anon>:2:8
  |
2 | fn foo(x: u32) {}
  |        ^
  |
  = note: #[warn(unused_variables)] on by default

warning: unused variable: `x`
 --> <anon>:5:5
  |
5 | let x = 1;
  |     ^
  |
  = note: #[warn(unused_variables)] on by default

thread 'rustc' panicked at 'test executable failed:

thread 'main' panicked at 'explicit panic', <anon>:6
note: Run with `RUST_BACKTRACE=1` for a backtrace.

', src/librustdoc/test.rs:317


failures:
    test.rs - foo (line 1)
    test.rs - foo3 (line 18)

test result: FAILED. 1 passed; 2 failed; 0 ignored; 0 measured
```