### PR TITLE
Remove obsolete --disable-elf-tls configure switch.

### DIFF
--- a/configure
+++ b/configure
@@ -510,7 +510,6 @@ valopt default-ar     "ar" "the default ar"
 opt_nosave manage-submodules 1 "let the build manage the git submodules"
 opt_nosave clang 0 "prefer clang to gcc for building the runtime"
 opt_nosave jemalloc 1 "build liballoc with jemalloc"
-opt elf-tls 1 "elf thread local storage on platforms where supported"
 opt full-bootstrap 0 "build three compilers instead of two"
 opt extended 0 "build an extended rust tool set"
 


### PR DESCRIPTION
Support for disabling ELF-style thread local storage in
the standard library at configure time was removed in
pulls #30417 and #30678, in favour of a member in
the TargetOptions database. The new mentod respects
MACOSX_DEPLOYMENT_TARGET on macOS, addressing the
original use case for this configure optionl

However, those commits left the configure option itself
in place. It's no longer referenced anywhere and can
be removed.