### PR TITLE
Fix incorrect hex value in doc comment example.

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1035,7 +1035,7 @@ impl Child {
 /// ```no_run
 /// use std::process;
 ///
-/// process::exit(0x0f00);
+/// process::exit(0x0100);
 /// ```
 ///
 /// [platform-specific behavior]: #platform-specific-behavior


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/41682.