### PR TITLE
Add a lint to disallow anonymous parameters

### DIFF
--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -112,6 +112,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
     add_early_builtin!(sess,
                        UnusedParens,
                        UnusedImportBraces,
+                       AnonymousParameters,
                        );
 
     add_early_builtin_with_new!(sess,
@@ -243,6 +244,10 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
         FutureIncompatibleInfo {
             id: LintId::of(MISSING_FRAGMENT_SPECIFIER),
             reference: "issue #40107 <https://github.com/rust-lang/rust/issues/40107>",
+        },
+        FutureIncompatibleInfo {
+            id: LintId::of(ANONYMOUS_PARAMETERS),
+            reference: "issue #41686 <https://github.com/rust-lang/rust/issues/41686>",
         },
         ]);
 

--- a/src/test/compile-fail/anon-params-deprecated.rs
+++ b/src/test/compile-fail/anon-params-deprecated.rs
@@ -1,0 +1,25 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![forbid(anonymous_parameters)]
+// Test for the anonymous_parameters deprecation lint (RFC 1685)
+
+trait T {
+    fn foo(i32); //~ ERROR use of deprecated anonymous parameter
+                 //~| WARNING hard error
+
+    fn bar_with_default_impl(String, String) {}
+    //~^ ERROR use of deprecated anonymous parameter
+    //~| WARNING hard error
+    //~| ERROR use of deprecated anonymous parameter
+    //~| WARNING hard error
+}
+
+fn main() {}


### PR DESCRIPTION
Adds a (allow by default) lint to disallow anonymous parameters, like it was decided in RFC 1685 (rust-lang/rfcs#1685).

cc tracking issue #41686