### PR TITLE
Removal pass for anonymous parameters

### DIFF
--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -276,7 +276,7 @@ pub trait Into<T>: Sized {
 pub trait From<T>: Sized {
     /// Performs the conversion.
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn from(T) -> Self;
+    fn from(t: T) -> Self;
 }
 
 /// An attempted conversion that consumes `self`, which may or may not be

--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -276,7 +276,7 @@ pub trait Into<T>: Sized {
 pub trait From<T>: Sized {
     /// Performs the conversion.
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn from(t: T) -> Self;
+    fn from(_: T) -> Self;
 }
 
 /// An attempted conversion that consumes `self`, which may or may not be

--- a/src/libcore/hash/sip.rs
+++ b/src/libcore/hash/sip.rs
@@ -403,8 +403,8 @@ impl<S: Sip> Default for Hasher<S> {
 
 #[doc(hidden)]
 trait Sip {
-    fn c_rounds(&mut State);
-    fn d_rounds(&mut State);
+    fn c_rounds(_: &mut State);
+    fn d_rounds(_: &mut State);
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -2878,10 +2878,10 @@ pub trait Carrier {
     type Error;
 
     /// Create a `Carrier` from a success value.
-    fn from_success(Self::Success) -> Self;
+    fn from_success(_: Self::Success) -> Self;
 
     /// Create a `Carrier` from an error value.
-    fn from_error(Self::Error) -> Self;
+    fn from_error(_: Self::Error) -> Self;
 
     /// Translate this `Carrier` to another implementation of `Carrier` with the
     /// same associated types.

--- a/src/librand/distributions/mod.rs
+++ b/src/librand/distributions/mod.rs
@@ -53,7 +53,7 @@ pub trait Sample<Support> {
 // trait called `Sample` and the other should be `DependentSample`.
 pub trait IndependentSample<Support>: Sample<Support> {
     /// Generate a random value.
-    fn ind_sample<R: Rng>(&self, &mut R) -> Support;
+    fn ind_sample<R: Rng>(&self, _: &mut R) -> Support;
 }
 
 /// A wrapper for generating types that implement `Rand` via the

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -329,7 +329,7 @@ impl<'a, R: fmt::Debug> fmt::Debug for AsciiGenerator<'a, R> {
 /// the same stream of randomness multiple times.
 pub trait SeedableRng<Seed>: Rng {
     /// Reseed an RNG with the given seed.
-    fn reseed(&mut self, Seed);
+    fn reseed(&mut self, _: Seed);
 
     /// Create a new RNG with the given seed.
     fn from_seed(seed: Seed) -> Self;

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1804,7 +1804,7 @@ mod dep_tracking {
     use rustc_back::PanicStrategy;
 
     pub trait DepTrackingHash {
-        fn hash(&self, &mut DefaultHasher, ErrorOutputType);
+        fn hash(&self, hasher: &mut DefaultHasher, error_format: ErrorOutputType);
     }
 
     macro_rules! impl_dep_tracking_hash_via_hash {

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1467,7 +1467,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 
 pub trait InternAs<T: ?Sized, R> {
     type Output;
-    fn intern_with<F>(self, F) -> Self::Output
+    fn intern_with<F>(self, f: F) -> Self::Output
         where F: FnOnce(&T) -> R;
 }
 

--- a/src/librustc_data_structures/indexed_vec.rs
+++ b/src/librustc_data_structures/indexed_vec.rs
@@ -24,7 +24,7 @@ use rustc_serialize as serialize;
 ///
 /// (purpose: avoid mixing indexes for different bitvector domains.)
 pub trait Idx: Copy + 'static + Eq + Debug {
-    fn new(usize) -> Self;
+    fn new(idx: usize) -> Self;
     fn index(self) -> usize;
 }
 

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -343,7 +343,7 @@ pub trait CompilerCalls<'a> {
 
     // Create a CompilController struct for controlling the behaviour of
     // compilation.
-    fn build_controller(&mut self, &Session, &getopts::Matches) -> CompileController<'a>;
+    fn build_controller(&mut self, _: &Session, _: &getopts::Matches) -> CompileController<'a>;
 }
 
 // CompilerCalls instance for a regular rustc build.

--- a/src/librustc_save_analysis/dump.rs
+++ b/src/librustc_save_analysis/dump.rs
@@ -13,28 +13,28 @@ use super::external_data::*;
 use rls_data::CratePreludeData;
 
 pub trait Dump {
-    fn crate_prelude(&mut self, CratePreludeData) {}
-    fn enum_data(&mut self, EnumData) {}
-    fn extern_crate(&mut self, ExternCrateData) {}
-    fn impl_data(&mut self, ImplData) {}
-    fn inheritance(&mut self, InheritanceData) {}
-    fn function(&mut self, FunctionData) {}
-    fn function_ref(&mut self, FunctionRefData) {}
-    fn function_call(&mut self, FunctionCallData) {}
-    fn method(&mut self, MethodData) {}
-    fn method_call(&mut self, MethodCallData) {}
-    fn macro_data(&mut self, MacroData) {}
-    fn macro_use(&mut self, MacroUseData) {}
-    fn mod_data(&mut self, ModData) {}
-    fn mod_ref(&mut self, ModRefData) {}
-    fn struct_data(&mut self, StructData) {}
-    fn struct_variant(&mut self, StructVariantData) {}
-    fn trait_data(&mut self, TraitData) {}
-    fn tuple_variant(&mut self, TupleVariantData) {}
-    fn type_ref(&mut self, TypeRefData) {}
-    fn typedef(&mut self, TypeDefData) {}
-    fn use_data(&mut self, UseData) {}
-    fn use_glob(&mut self, UseGlobData) {}
-    fn variable(&mut self, VariableData) {}
-    fn variable_ref(&mut self, VariableRefData) {}
+    fn crate_prelude(&mut self, _: CratePreludeData) {}
+    fn enum_data(&mut self, _: EnumData) {}
+    fn extern_crate(&mut self, _: ExternCrateData) {}
+    fn impl_data(&mut self, _: ImplData) {}
+    fn inheritance(&mut self, _: InheritanceData) {}
+    fn function(&mut self, _: FunctionData) {}
+    fn function_ref(&mut self, _: FunctionRefData) {}
+    fn function_call(&mut self, _: FunctionCallData) {}
+    fn method(&mut self, _: MethodData) {}
+    fn method_call(&mut self, _: MethodCallData) {}
+    fn macro_data(&mut self, _: MacroData) {}
+    fn macro_use(&mut self, _: MacroUseData) {}
+    fn mod_data(&mut self, _: ModData) {}
+    fn mod_ref(&mut self, _: ModRefData) {}
+    fn struct_data(&mut self, _: StructData) {}
+    fn struct_variant(&mut self, _: StructVariantData) {}
+    fn trait_data(&mut self, _: TraitData) {}
+    fn tuple_variant(&mut self, _: TupleVariantData) {}
+    fn type_ref(&mut self, _: TypeRefData) {}
+    fn typedef(&mut self, _: TypeDefData) {}
+    fn use_data(&mut self, _: UseData) {}
+    fn use_glob(&mut self, _: UseGlobData) {}
+    fn variable(&mut self, _: VariableData) {}
+    fn variable_ref(&mut self, _: VariableRefData) {}
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -503,7 +503,7 @@ impl<'a> Iterator for ListAttributesIter<'a> {
 
 pub trait AttributesExt {
     /// Finds an attribute as List and returns the list of attributes nested inside.
-    fn lists<'a>(&'a self, &'a str) -> ListAttributesIter<'a>;
+    fn lists<'a>(&'a self, name: &'a str) -> ListAttributesIter<'a>;
 }
 
 impl AttributesExt for [ast::Attribute] {
@@ -518,7 +518,7 @@ impl AttributesExt for [ast::Attribute] {
 
 pub trait NestedAttributesExt {
     /// Returns whether the attribute list contains a specific `Word`
-    fn has_word(self, &str) -> bool;
+    fn has_word(self, word: &str) -> bool;
 }
 
 impl<I: IntoIterator<Item=ast::NestedMetaItem>> NestedAttributesExt for I {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -89,7 +89,7 @@ impl<'a, 'tcx> DocContext<'a, 'tcx> {
 }
 
 pub trait DocAccessLevels {
-    fn is_doc_reachable(&self, DefId) -> bool;
+    fn is_doc_reachable(&self, did: DefId) -> bool;
 }
 
 impl DocAccessLevels for AccessLevels<DefId> {

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -134,7 +134,7 @@ pub trait Writer {
     fn string<T: Display>(&mut self,
                           text: T,
                           klass: Class,
-                          tas: Option<&TokenAndSpan>)
+                          tok: Option<&TokenAndSpan>)
                           -> io::Result<()>;
 }
 

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -114,7 +114,7 @@ pub enum Class {
 pub trait Writer {
     /// Called when we start processing a span of text that should be highlighted.
     /// The `Class` argument specifies how it should be highlighted.
-    fn enter_span(&mut self, Class) -> io::Result<()>;
+    fn enter_span(&mut self, _: Class) -> io::Result<()>;
 
     /// Called at the end of a span of highlighted text.
     fn exit_span(&mut self) -> io::Result<()>;
@@ -131,7 +131,11 @@ pub trait Writer {
     /// ```
     /// The latter can be thought of as a shorthand for the former, which is
     /// more flexible.
-    fn string<T: Display>(&mut self, T, Class, Option<&TokenAndSpan>) -> io::Result<()>;
+    fn string<T: Display>(&mut self,
+                          text: T,
+                          klass: Class,
+                          tas: Option<&TokenAndSpan>)
+                          -> io::Result<()>;
 }
 
 // Implement `Writer` for anthing that can be written to, this just implements

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -52,7 +52,7 @@ pub trait AstBuilder {
     fn ty_mt(&self, ty: P<ast::Ty>, mutbl: ast::Mutability) -> ast::MutTy;
 
     fn ty(&self, span: Span, ty: ast::TyKind) -> P<ast::Ty>;
-    fn ty_path(&self, ast::Path) -> P<ast::Ty>;
+    fn ty_path(&self, path: ast::Path) -> P<ast::Ty>;
     fn ty_ident(&self, span: Span, idents: ast::Ident) -> P<ast::Ty>;
 
     fn ty_rptr(&self, span: Span,


### PR DESCRIPTION
Removes occurences of anonymous parameters from the
rustc codebase, as they are to be deprecated.

See issue #41686 and RFC 1685.

r? @frewsxcv 