### PR TITLE
Fix @martinhath's mailmap entry

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -139,6 +139,7 @@ Margaret Meyerhofer <mmeyerho@andrew.cmu.edu> <mmeyerho@andrew>
 Mark Sinclair <mark.edward.x@gmail.com>
 Mark Sinclair <mark.edward.x@gmail.com> =Mark Sinclair <=125axel125@gmail.com>
 Markus Westerlind <marwes91@gmail.com> Markus <marwes91@gmail.com>
+Martin Hafskjold Thoresen <martinhath@gmail.com>
 Matej Lach <matej.lach@gmail.com> Matej Ľach <matej.lach@gmail.com>
 Matt Brubeck <mbrubeck@limpet.net> <mbrubeck@cs.hmc.edu>
 Matthew Auld <matthew.auld@intel.com>


### PR DESCRIPTION
I stumbled upon a name duplication issue in [rust-lang-nursery/thanks](https://github.com/rust-lang-nursery/thanks/), and realized that this problem is easily fixable. I've (hopefully) done the right thing here. It works locally (`git shortlog | grep "Thoresen"` only returns one entry instead of two).

I didn't bother creating an issue in the `thanks` repository, since I did the `.mailmap` editing myself.