### PR TITLE
Suggest `!` for bitwise negation when encountering a `~`

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2700,6 +2700,19 @@ impl<'a> Parser<'a> {
                 let (span, e) = self.interpolated_or_expr_span(e)?;
                 (span, self.mk_unary(UnOp::Not, e))
             }
+            // Suggest `!` for bitwise negation when encountering a `~`
+            token::Tilde => {
+                self.bump();
+                let e = self.parse_prefix_expr(None);
+                let (span, e) = self.interpolated_or_expr_span(e)?;
+                let span_of_tilde = lo;
+                let mut err = self.diagnostic().struct_span_err(span_of_tilde,
+                        "`~` can not be used as an unary operator");
+                err.span_label(span_of_tilde, &"did you mean `!`?");
+                err.help("use `!` instead of `~` if you meant to perform bitwise negation");
+                err.emit();
+                (span, self.mk_unary(UnOp::Not, e))
+            }
             token::BinOp(token::Minus) => {
                 self.bump();
                 let e = self.parse_prefix_expr(None);

--- a/src/test/ui/did_you_mean/issue-41679.rs
+++ b/src/test/ui/did_you_mean/issue-41679.rs
@@ -1,0 +1,13 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let x = ~1;
+}

--- a/src/test/ui/did_you_mean/issue-41679.stderr
+++ b/src/test/ui/did_you_mean/issue-41679.stderr
@@ -1,0 +1,10 @@
+error: `~` can not be used as an unary operator
+  --> $DIR/issue-41679.rs:12:13
+   |
+12 |     let x = ~1;
+   |             ^ did you mean `!`?
+   |
+   = help: use `!` instead of `~` if you meant to perform bitwise negation
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fix #41679 

Here is a program

```rust
fn main() {
    let x = ~1;
}
```

It's output:
```
error: `~` can not be used as an unary operator
 --> /home/fcc/temp/test.rs:4:13
  |
4 |     let x = ~1;
  |             ^^
  |
  = help: use `!` instead of `~` if you meant to bitwise negation
```

cc @bstrie 