### PR TITLE
Support #![deny(missing_docs)] together with #[proc_macro_derive]

### DIFF
--- a/src/libsyntax_ext/proc_macro_registrar.rs
+++ b/src/libsyntax_ext/proc_macro_registrar.rs
@@ -441,8 +441,12 @@ fn mk_registrar(cx: &mut ExtCtxt,
         i.vis = ast::Visibility::Public;
         i
     });
+    let doc_hidden = cx.meta_list_item_word(span, Symbol::intern("hidden"));
+    let doc_hidden = cx.meta_list(span, Symbol::intern("doc"), vec![doc_hidden]);
+    let doc_hidden = cx.attribute(span, doc_hidden);
     let ident = ast::Ident::with_empty_ctxt(Symbol::gensym("registrar"));
     let module = cx.item_mod(span, span, ident, Vec::new(), vec![krate, func]).map(|mut i| {
+        i.attrs.push(doc_hidden);
         i.vis = ast::Visibility::Public;
         i
     });


### PR DESCRIPTION
Currently rustc will abort with a lint error when `#[proc_macro_derive]`
is used together with `#![deny(missing_docs)]`, because the generated code
does not have docs. To fix this, this PR adds `#[doc(hidden)]` to the generated code.

This PR should probably include a test as well, however I don't know the test system very well. I tried adding the file below to `run-pass-fulldeps/proc-macro`, however I did not get an error even when running without my patch.

```rust
// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
// file at the top-level directory of this distribution and at
// http://rust-lang.org/COPYRIGHT.
//
// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
// option. This file may not be copied, modified, or distributed
// except according to those terms.

//! The purpose of this crate is to test that #![deny(missing_docs)] can be
//! used together with #[proc_macro_derive]
   
// no-prefer-dynamic
// compile-flags: --test

#![crate_type = "proc-macro"]
#![deny(missing_docs)]

extern crate proc_macro;

use proc_macro::TokenStream;

/// Function documentation
#[proc_macro_derive(Foo)]
pub fn derive_foo(_input: TokenStream) -> TokenStream {
    "".parse().unwrap()
}
```

When I run rustc manually on that file, it works with my patch applied, but without it I get the following error message:

```
error: missing documentation for a module
 --> src/test/run-pass-fulldeps/proc-macro/derive-doc.rs:1:1
  |
1 | // Copyright 2016 The Rust Project Developers. See the COPYRIGHT
  | ^
  |
note: lint level defined here
 --> src/test/run-pass-fulldeps/proc-macro/derive-doc.rs:18:9
  |
18| #![deny(missing_docs)]
  |         ^^^^^^^^^^^^

error: missing documentation for a function
 --> src/test/run-pass-fulldeps/proc-macro/derive-doc.rs:1:1
  |
1 | // Copyright 2016 The Rust Project Developers. See the COPYRIGHT
  | ^

error: aborting due to 2 previous errors
```