### PR TITLE
std: Prevent deadlocks in doctests on Windows

### DIFF
--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -723,7 +723,9 @@ struct Inner {
 ///
 /// # Examples
 ///
-/// ```
+/// ```no_run
+/// # // Note that this example isn't executed by default because it causes
+/// # // deadlocks on Windows unfortunately (see #25824)
 /// use std::thread::Builder;
 ///
 /// for i in 0..5 {


### PR DESCRIPTION
Windows historically has problems with threads panicking and the main thread
exiting at the same time, typically causing deadlocks. In the past (#25824)
we've joined on threads but this just prevents running the test for now to avoid
tampering with the example.