### PR TITLE
Crate metadata nondefid args

### DIFF
--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -50,6 +50,7 @@ pub enum DepNode<D: Clone + Debug> {
     // Represents the metadata for a given HIR node, typically found
     // in an extern crate.
     MetaData(D),
+    MetaDataByCrateNum(CrateNum),
 
     // Represents some artifact that we save to disk. Note that these
     // do not have a def-id as part of their identifier.
@@ -208,6 +209,7 @@ impl<D: Clone + Debug> DepNode<D> {
             MirKeys => Some(MirKeys),
             LateLintCheck => Some(LateLintCheck),
             TransWriteMetadata => Some(TransWriteMetadata),
+            MetaDataByCrateNum(c) => Some(MetaDataByCrateNum(c)),
 
             // work product names do not need to be mapped, because
             // they are always absolute.

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -197,10 +197,7 @@ pub trait CrateStore {
     fn associated_item_cloned(&self, def: DefId) -> ty::AssociatedItem;
 
     // flags
-    fn is_const_fn(&self, did: DefId) -> bool;
-    fn is_default_impl(&self, impl_did: DefId) -> bool;
     fn is_foreign_item(&self, did: DefId) -> bool;
-    fn is_dllimport_foreign_item(&self, def: DefId) -> bool;
     fn is_statically_included_foreign_item(&self, def_id: DefId) -> bool;
     fn is_exported_symbol(&self, def_id: DefId) -> bool;
 
@@ -325,10 +322,7 @@ impl CrateStore for DummyCrateStore {
         { bug!("associated_item_cloned") }
 
     // flags
-    fn is_const_fn(&self, did: DefId) -> bool { bug!("is_const_fn") }
-    fn is_default_impl(&self, impl_did: DefId) -> bool { bug!("is_default_impl") }
     fn is_foreign_item(&self, did: DefId) -> bool { bug!("is_foreign_item") }
-    fn is_dllimport_foreign_item(&self, id: DefId) -> bool { false }
     fn is_statically_included_foreign_item(&self, def_id: DefId) -> bool { false }
     fn is_exported_symbol(&self, def_id: DefId) -> bool { false }
 

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -223,10 +223,6 @@ pub trait CrateStore {
     fn crate_hash(&self, cnum: CrateNum) -> Svh;
     fn crate_disambiguator(&self, cnum: CrateNum) -> Symbol;
     fn plugin_registrar_fn(&self, cnum: CrateNum) -> Option<DefId>;
-    fn derive_registrar_fn(&self, cnum: CrateNum) -> Option<DefId>;
-    fn native_libraries(&self, cnum: CrateNum) -> Vec<NativeLibrary>;
-    fn exported_symbols(&self, cnum: CrateNum) -> Vec<DefId>;
-    fn is_no_builtins(&self, cnum: CrateNum) -> bool;
 
     // resolve
     fn retrace_path(&self,
@@ -354,12 +350,6 @@ impl CrateStore for DummyCrateStore {
                            -> Symbol { bug!("crate_disambiguator") }
     fn plugin_registrar_fn(&self, cnum: CrateNum) -> Option<DefId>
         { bug!("plugin_registrar_fn") }
-    fn derive_registrar_fn(&self, cnum: CrateNum) -> Option<DefId>
-        { bug!("derive_registrar_fn") }
-    fn native_libraries(&self, cnum: CrateNum) -> Vec<NativeLibrary>
-        { bug!("native_libraries") }
-    fn exported_symbols(&self, cnum: CrateNum) -> Vec<DefId> { bug!("exported_symbols") }
-    fn is_no_builtins(&self, cnum: CrateNum) -> bool { bug!("is_no_builtins") }
 
     // resolve
     fn retrace_path(&self,

--- a/src/librustc/ty/maps.rs
+++ b/src/librustc/ty/maps.rs
@@ -347,11 +347,23 @@ impl<'tcx> QueryDescription for queries::const_is_rvalue_promotable_to_static<'t
     }
 }
 
-impl<'tcx> QueryDescription for queries::is_mir_available<'tcx> {
-    fn describe(tcx: TyCtxt, def_id: DefId) -> String {
-        format!("checking if item is mir available: `{}`",
-            tcx.item_path_str(def_id))
+macro_rules! simple_query_description {
+    ($($fn_name:ident, $desc:expr),*,) => {
+        $(
+        impl<'tcx> QueryDescription for queries::$fn_name<'tcx> {
+            fn describe(tcx: TyCtxt, def_id: DefId) -> String {
+                format!(concat!($desc, "`: {}`"),
+                    tcx.item_path_str(def_id))
+            }
+        }
+        )*
     }
+}
+
+simple_query_description! {
+    is_mir_available, "checking if item is mir available",
+    is_const_fn, "checking if item is const fn",
+    is_dllimport_foreign_item, "checking if item is dll import foreign item",
 }
 
 macro_rules! define_maps {
@@ -786,6 +798,10 @@ define_maps! { <'tcx>
     [] item_body_nested_bodies: metadata_dep_node(DefId) -> Rc<BTreeMap<hir::BodyId, hir::Body>>,
     [] const_is_rvalue_promotable_to_static: metadata_dep_node(DefId) -> bool,
     [] is_mir_available: metadata_dep_node(DefId) -> bool,
+
+    [] is_const_fn: metadata_dep_node(DefId) -> bool,
+    [] is_default_impl: metadata_dep_node(DefId) -> bool,
+    [] is_dllimport_foreign_item: metadata_dep_node(DefId) -> bool,
 }
 
 fn coherent_trait_dep_node((_, def_id): (CrateNum, DefId)) -> DepNode<DefId> {

--- a/src/librustc_const_eval/eval.rs
+++ b/src/librustc_const_eval/eval.rs
@@ -352,7 +352,7 @@ fn eval_const_expr_partial<'a, 'tcx>(cx: &ConstContext<'a, 'tcx>,
                 signal!(e, TypeckError)
             }
           } else {
-            if tcx.sess.cstore.is_const_fn(def_id) {
+            if tcx.is_const_fn(def_id) {
                 tcx.sess.cstore.item_body(tcx, def_id)
             } else {
                 signal!(e, TypeckError)

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -11,7 +11,7 @@
 use cstore;
 use encoder;
 use locator;
-use schema;
+use schema::{self, EntryKind};
 
 use rustc::dep_graph::DepTrackingMapConfig;
 use rustc::middle::cstore::{CrateStore, CrateSource, LibSource, DepKind,
@@ -22,7 +22,7 @@ use rustc::middle::lang_items;
 use rustc::session::Session;
 use rustc::ty::{self, TyCtxt};
 use rustc::ty::maps::Providers;
-use rustc::hir::def_id::{CrateNum, DefId, DefIndex, CRATE_DEF_INDEX, LOCAL_CRATE};
+use rustc::hir::def_id::{CrateNum, DefId, DefIndex, CRATE_DEF_INDEX};
 
 use rustc::dep_graph::DepNode;
 use rustc::hir::map::{DefKey, DefPath, DisambiguatedDefPathData};
@@ -128,6 +128,16 @@ provide! { <'tcx> tcx, def_id, cdata
         !cdata.is_proc_macro(def_id.index) &&
         cdata.maybe_entry(def_id.index).and_then(|item| item.decode(cdata).mir).is_some()
     }
+    is_const_fn => { cdata.is_const_fn(def_id.index) }
+    is_default_impl => {
+        match cdata.entry(def_id.index).kind {
+            EntryKind::DefaultImpl(_) => true,
+            _ => false,
+        }
+    }
+    is_dllimport_foreign_item => {
+        cdata.dllimport_foreign_items.contains(&def_id.index)
+    }
 }
 
 impl CrateStore for cstore::CStore {
@@ -195,17 +205,6 @@ impl CrateStore for cstore::CStore {
         self.get_crate_data(def.krate).get_associated_item(def.index)
     }
 
-    fn is_const_fn(&self, did: DefId) -> bool
-    {
-        self.dep_graph.read(DepNode::MetaData(did));
-        self.get_crate_data(did.krate).is_const_fn(did.index)
-    }
-
-    fn is_default_impl(&self, impl_did: DefId) -> bool {
-        self.dep_graph.read(DepNode::MetaData(impl_did));
-        self.get_crate_data(impl_did.krate).is_default_impl(impl_did.index)
-    }
-
     fn is_foreign_item(&self, did: DefId) -> bool {
         self.get_crate_data(did.krate).is_foreign_item(did.index)
     }
@@ -217,14 +216,6 @@ impl CrateStore for cstore::CStore {
 
     fn is_exported_symbol(&self, def_id: DefId) -> bool {
         self.get_crate_data(def_id.krate).exported_symbols.contains(&def_id.index)
-    }
-
-    fn is_dllimport_foreign_item(&self, def_id: DefId) -> bool {
-        if def_id.krate == LOCAL_CRATE {
-            self.dllimport_foreign_items.borrow().contains(&def_id.index)
-        } else {
-            self.get_crate_data(def_id.krate).is_dllimport_foreign_item(def_id.index)
-        }
     }
 
     fn dylib_dependency_formats(&self, cnum: CrateNum)

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -1018,17 +1018,6 @@ impl<'a, 'tcx> CrateMetadata {
         }
     }
 
-    pub fn is_dllimport_foreign_item(&self, id: DefIndex) -> bool {
-        self.dllimport_foreign_items.contains(&id)
-    }
-
-    pub fn is_default_impl(&self, impl_id: DefIndex) -> bool {
-        match self.entry(impl_id).kind {
-            EntryKind::DefaultImpl(_) => true,
-            _ => false,
-        }
-    }
-
     pub fn closure_kind(&self, closure_id: DefIndex) -> ty::ClosureKind {
         match self.entry(closure_id).kind {
             EntryKind::Closure(data) => data.decode(self).kind,

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -117,7 +117,7 @@ pub fn is_const_fn(tcx: TyCtxt, def_id: DefId) -> bool {
             false
         }
     } else {
-        tcx.sess.cstore.is_const_fn(def_id)
+        tcx.is_const_fn(def_id)
     }
 }
 

--- a/src/librustc_passes/consts.rs
+++ b/src/librustc_passes/consts.rs
@@ -102,7 +102,7 @@ impl<'a, 'gcx> CheckCrateVisitor<'a, 'gcx> {
                 fn_like.constness() == hir::Constness::Const
             })
         } else {
-            self.tcx.sess.cstore.is_const_fn(def_id)
+            self.tcx.is_const_fn(def_id)
         };
     }
 }

--- a/src/librustc_trans/back/symbol_export.rs
+++ b/src/librustc_trans/back/symbol_export.rs
@@ -80,7 +80,7 @@ impl ExportedSymbols {
             // If this crate is a plugin and/or a custom derive crate, then
             // we're not even going to link those in so we skip those crates.
             if scx.sess().cstore.plugin_registrar_fn(cnum).is_some() ||
-               scx.sess().cstore.derive_registrar_fn(cnum).is_some() {
+               scx.tcx().derive_registrar_fn(cnum).is_some() {
                 continue;
             }
 
@@ -97,8 +97,7 @@ impl ExportedSymbols {
                 scx.sess().cstore.is_compiler_builtins(cnum);
 
             let crate_exports = scx
-                .sess()
-                .cstore
+                .tcx()
                 .exported_symbols(cnum)
                 .iter()
                 .map(|&def_id| {

--- a/src/librustc_trans/callee.rs
+++ b/src/librustc_trans/callee.rs
@@ -111,7 +111,7 @@ pub fn get_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         }
 
         if ccx.use_dll_storage_attrs() &&
-            ccx.sess().cstore.is_dllimport_foreign_item(instance.def_id())
+            ccx.tcx().is_dllimport_foreign_item(instance.def_id())
         {
             unsafe {
                 llvm::LLVMSetDLLStorageClass(llfn, llvm::DLLStorageClass::DllImport);

--- a/src/librustc_trans/consts.rs
+++ b/src/librustc_trans/consts.rs
@@ -199,7 +199,7 @@ pub fn get_static(ccx: &CrateContext, def_id: DefId) -> ValueRef {
         g
     };
 
-    if ccx.use_dll_storage_attrs() && ccx.sess().cstore.is_dllimport_foreign_item(def_id) {
+    if ccx.use_dll_storage_attrs() && ccx.tcx().is_dllimport_foreign_item(def_id) {
         // For foreign (native) libs we know the exact storage type to use.
         unsafe {
             llvm::LLVMSetDLLStorageClass(g, llvm::DLLStorageClass::DllImport);

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -167,7 +167,7 @@ pub fn build_external_trait(cx: &DocContext, did: DefId) -> clean::Trait {
 fn build_external_function(cx: &DocContext, did: DefId) -> clean::Function {
     let sig = cx.tcx.type_of(did).fn_sig();
 
-    let constness = if cx.tcx.sess.cstore.is_const_fn(did) {
+    let constness = if cx.tcx.is_const_fn(did) {
         hir::Constness::Const
     } else {
         hir::Constness::NotConst
@@ -306,7 +306,7 @@ pub fn build_impl(cx: &DocContext, did: DefId, ret: &mut Vec<clean::Item>) {
     }
 
     // If this is a defaulted impl, then bail out early here
-    if tcx.sess.cstore.is_default_impl(did) {
+    if tcx.is_default_impl(did) {
         return ret.push(clean::Item {
             inner: clean::DefaultImplItem(clean::DefaultImpl {
                 // FIXME: this should be decoded
@@ -368,7 +368,7 @@ pub fn build_impl(cx: &DocContext, did: DefId, ret: &mut Vec<clean::Item>) {
                     clean::TyMethodItem(clean::TyMethod {
                         unsafety, decl, generics, abi
                     }) => {
-                        let constness = if tcx.sess.cstore.is_const_fn(item.def_id) {
+                        let constness = if tcx.is_const_fn(item.def_id) {
                             hir::Constness::Const
                         } else {
                             hir::Constness::NotConst


### PR DESCRIPTION
Builds on https://github.com/rust-lang/rust/pull/41766
cc #41417

I started working on queryifying the crate metadata functions that take `CrateNum` as an argument. However, a lot of these showed up in trans, which doesn't currently have access to `tcx`. I plumbed it through, but after doing so I'm not sure how to set it up in driver, which makes me think this wasn't the right thing to do :laughing: I'm imagining there's a reason that trans relies upon `Session` instead of `TyCtxt`. If that's the case, how should I proceed?

r? @nikomatsakis 