### PR TITLE
Improve cleaning of the bottom of the backtrace

### DIFF
--- a/src/libstd/rt.rs
+++ b/src/libstd/rt.rs
@@ -29,8 +29,7 @@ pub use panicking::{begin_panic, begin_panic_fmt, update_panic_count};
 
 #[cfg(not(test))]
 #[lang = "start"]
-fn lang_start(main: *const u8, argc: isize, argv: *const *const u8) -> isize {
-    use mem;
+fn lang_start(main: fn(), argc: isize, argv: *const *const u8) -> isize {
     use panic;
     use sys;
     use sys_common;
@@ -54,7 +53,9 @@ fn lang_start(main: *const u8, argc: isize, argv: *const *const u8) -> isize {
         sys::args::init(argc, argv);
 
         // Let's run some code!
-        let res = panic::catch_unwind(mem::transmute::<_, fn()>(main));
+        let res = panic::catch_unwind(|| {
+            ::sys_common::backtrace::__rust_begin_short_backtrace(main)
+        });
         sys_common::cleanup();
         res.is_err()
     };

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -358,7 +358,9 @@ impl Builder {
             }
             unsafe {
                 thread_info::set(imp::guard::current(), their_thread);
-                let try_result = panic::catch_unwind(panic::AssertUnwindSafe(f));
+                let try_result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                    ::sys_common::backtrace::__rust_begin_short_backtrace(f)
+                }));
                 *their_packet.get() = Some(try_result);
             }
         };


### PR DESCRIPTION
Following https://github.com/rust-lang/rust/pull/40264. It only cleans the bottom of the trace (after the main). It handles correctly the normal main, tests, benchmarks and threads.

I kept `skipped_before` since it will be used later for the cleaning of the top.