### PR TITLE
Add markdown-[before|after]-content options

### DIFF
--- a/src/librustdoc/externalfiles.rs
+++ b/src/librustdoc/externalfiles.rs
@@ -13,6 +13,7 @@ use std::io::prelude::*;
 use std::io;
 use std::path::Path;
 use std::str;
+use html::markdown::{Markdown, RenderType};
 
 #[derive(Clone)]
 pub struct ExternalHtml{
@@ -28,7 +29,8 @@ pub struct ExternalHtml{
 }
 
 impl ExternalHtml {
-    pub fn load(in_header: &[String], before_content: &[String], after_content: &[String])
+    pub fn load(in_header: &[String], before_content: &[String], after_content: &[String],
+                md_before_content: &[String], md_after_content: &[String], render: RenderType)
             -> Option<ExternalHtml> {
         load_external_files(in_header)
             .and_then(|ih|
@@ -36,8 +38,16 @@ impl ExternalHtml {
                     .map(|bc| (ih, bc))
             )
             .and_then(|(ih, bc)|
+                load_external_files(md_before_content)
+                    .map(|m_bc| (ih, format!("{}{}", bc, Markdown(&m_bc, render))))
+            )
+            .and_then(|(ih, bc)|
                 load_external_files(after_content)
                     .map(|ac| (ih, bc, ac))
+            )
+            .and_then(|(ih, bc, ac)|
+                load_external_files(md_after_content)
+                    .map(|m_ac| (ih, bc, format!("{}{}", ac, Markdown(&m_ac, render))))
             )
             .map(|(ih, bc, ac)|
                 ExternalHtml {

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -159,6 +159,14 @@ pub fn opts() -> Vec<RustcOptGroup> {
                         "files to include inline between the content and </body> of a rendered \
                          Markdown file or generated documentation",
                         "FILES")),
+        unstable(optmulti("", "markdown-before-content",
+                          "files to include inline between <body> and the content of a rendered \
+                           Markdown file or generated documentation",
+                          "FILES")),
+        unstable(optmulti("", "markdown-after-content",
+                          "files to include inline between the content and </body> of a rendered \
+                           Markdown file or generated documentation",
+                          "FILES")),
         stable(optopt("", "markdown-playground-url",
                       "URL to send code snippets to", "URL")),
         stable(optflag("", "markdown-no-toc", "don't include table of contents")),
@@ -274,7 +282,10 @@ pub fn main_args(args: &[String]) -> isize {
     let external_html = match ExternalHtml::load(
             &matches.opt_strs("html-in-header"),
             &matches.opt_strs("html-before-content"),
-            &matches.opt_strs("html-after-content")) {
+            &matches.opt_strs("html-after-content"),
+            &matches.opt_strs("markdown-before-content"),
+            &matches.opt_strs("markdown-after-content"),
+            render_type) {
         Some(eh) => eh,
         None => return 3,
     };


### PR DESCRIPTION
cc @nical

r? @rust-lang/docs 