### PR TITLE
Allow bare CR in ////-style comment.

### DIFF
--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -504,7 +504,7 @@ impl<'a> StringReader<'a> {
                     self.bump();
 
                     // line comments starting with "///" or "//!" are doc-comments
-                    let doc_comment = self.ch_is('/') || self.ch_is('!');
+                    let doc_comment = (self.ch_is('/') && !self.nextch_is('/')) || self.ch_is('!');
                     let start_bpos = self.pos - BytePos(2);
 
                     while !self.is_eof() {

--- a/src/test/parse-fail/lex-bare-cr-string-literal-doc-comment.rs
+++ b/src/test/parse-fail/lex-bare-cr-string-literal-doc-comment.rs
@@ -21,6 +21,12 @@ pub fn bar() {}
 //~^^ ERROR: bare CR not allowed in block doc-comment
 
 fn main() {
+    //! doc comment with bare CR: ''
+    //~^ ERROR: bare CR not allowed in doc-comment
+
+    /*! block doc comment with bare CR: '' */
+    //~^ ERROR: bare CR not allowed in block doc-comment
+
     // the following string literal has a bare CR in it
     let _s = "foobar"; //~ ERROR: bare CR not allowed in string
 

--- a/src/test/run-pass/lex-bare-cr-nondoc-comment.rs
+++ b/src/test/run-pass/lex-bare-cr-nondoc-comment.rs
@@ -1,0 +1,18 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-tidy-cr
+
+// nondoc comment with bare CR: ''
+//// nondoc comment with bare CR: ''
+/* block nondoc comment with bare CR: '' */
+
+fn main() {
+}


### PR DESCRIPTION
Fixes #40624 in a way that bare CR is allowed in all non-doc comments.