### PR TITLE
[Doc] Improve `thread::spawn` documentation

### DIFF
--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -412,7 +412,7 @@ impl Builder {
 /// handler.join().unwrap();
 /// ```
 ///
-/// As mentionned in the module documentation, threads are usualy made to
+/// As mentioned in the module documentation, threads are usually made to
 /// communicate using [`channels`], here is how it usually looks.
 ///
 /// This example also shows how to use `move`, in order to give ownership

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -400,7 +400,7 @@ impl Builder {
 ///
 /// # Examples
 ///
-/// Simple thread creation.
+/// Creating a thread.
 ///
 /// ```
 /// use std::thread;
@@ -413,7 +413,7 @@ impl Builder {
 /// ```
 ///
 /// As mentionned in the module documentation, threads are usualy made to
-/// communicate using [`channel`s][`channels`], here is how it usually looks.
+/// communicate using [`channels`], here is how it usually looks.
 ///
 /// This example also shows how to use `move`, in order to give ownership
 /// of values to a thread.

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -425,15 +425,15 @@ impl Builder {
 /// let (tx, rx) = channel();
 ///
 /// let sender = thread::spawn(move || {
-///     tx.send("Hello, thread".to_owned());
+///     let _ = tx.send("Hello, thread".to_owned());
 /// });
 ///
 /// let receiver = thread::spawn(move || {
 ///     println!("{}", rx.recv().unwrap());
 /// });
 ///
-/// sender.join();
-/// receiver.join();
+/// let _ = sender.join();
+/// let _ = receiver.join();
 /// ```
 ///
 /// A thread can also return a value through its [`JoinHandle`], you can use
@@ -449,7 +449,7 @@ impl Builder {
 /// });
 ///
 /// let result = computation.join().unwrap();
-/// println!("{}", v);
+/// println!("{}", result);
 /// ```
 ///
 /// [`channels`]: ../../std/sync/mpsc/index.html

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -315,6 +315,8 @@ impl Builder {
     /// thread finishes). The join handle can be used to block on
     /// termination of the child thread, including recovering its panics.
     ///
+    /// For a more complete documentation see [`thread::spawn`][`spawn`].
+    ///
     /// # Errors
     ///
     /// Unlike the [`spawn`] free function, this method yields an
@@ -392,13 +394,9 @@ impl Builder {
 /// Panics if the OS fails to create a thread; use [`Builder::spawn`]
 /// to recover from such errors.
 ///
-/// [`JoinHandle`]: ../../std/thread/struct.JoinHandle.html
-/// [`join`]: ../../std/thread/struct.JoinHandle.html#method.join
-/// [`Err`]: ../../std/result/enum.Result.html#variant.Err
-/// [`panic`]: ../../std/macro.panic.html
-/// [`Builder::spawn`]: ../../std/thread/struct.Builder.html#method.spawn
-///
 /// # Examples
+///
+/// Simple thread creation.
 ///
 /// ```
 /// use std::thread;
@@ -409,6 +407,53 @@ impl Builder {
 ///
 /// handler.join().unwrap();
 /// ```
+///
+/// As mentionned in the module documentation, threads are usualy made to
+/// communicate using [`channel`s][`channels`], here is how it usually looks.
+///
+/// This example also shows how to use `move`, in order to give ownership
+/// of values to a thread.
+///
+/// ```
+/// use std::thread;
+/// use std::sync::mpsc::channel;
+///
+/// let (tx, rx) = channel();
+///
+/// let sender = thread::spawn(move || {
+///     tx.send("Hello, thread".to_owned());
+/// });
+///
+/// let receiver = thread::spawn(move || {
+///     println!("{}", rx.recv().unwrap());
+/// });
+///
+/// sender.join();
+/// receiver.join();
+/// ```
+///
+/// A thread can also return a value through its [`JoinHandle`], you can use
+/// this to make asynchronous computations (futures might be more appropriate
+/// though).
+///
+/// ```
+/// use std::thread;
+///
+/// let computation = thread::spawn(|| {
+///     // Some expensive computation.
+///     42
+/// });
+///
+/// let result = computation.join().unwrap();
+/// println!("{}", v);
+/// ```
+///
+/// [`channels`]: ../../std/sync/mpsc/index.html
+/// [`JoinHandle`]: ../../std/thread/struct.JoinHandle.html
+/// [`join`]: ../../std/thread/struct.JoinHandle.html#method.join
+/// [`Err`]: ../../std/result/enum.Result.html#variant.Err
+/// [`panic`]: ../../std/macro.panic.html
+/// [`Builder::spawn`]: ../../std/thread/struct.Builder.html#method.spawn
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn spawn<F, T>(f: F) -> JoinHandle<T> where
     F: FnOnce() -> T, F: Send + 'static, T: Send + 'static

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -389,6 +389,10 @@ impl Builder {
 /// panics, [`join`] will return an [`Err`] containing the argument given to
 /// [`panic`].
 ///
+/// This will create a thread using default parameters of [`Builder`], if you
+/// want to specify the stack size or the name of the thread, use this API
+/// instead.
+///
 /// # Panics
 ///
 /// Panics if the OS fails to create a thread; use [`Builder::spawn`]
@@ -454,6 +458,7 @@ impl Builder {
 /// [`Err`]: ../../std/result/enum.Result.html#variant.Err
 /// [`panic`]: ../../std/macro.panic.html
 /// [`Builder::spawn`]: ../../std/thread/struct.Builder.html#method.spawn
+/// [`Builder`]: ../../std/thread/struct.Builder.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn spawn<F, T>(f: F) -> JoinHandle<T> where
     F: FnOnce() -> T, F: Send + 'static, T: Send + 'static


### PR DESCRIPTION
Part of #29378

- Add two examples to `thread::spawn` doumentation that show common uses of threads.
- Add a link to `thread::Builder` in the `thread::spawn` documentation for configuring threads.
- Add a link to `thread::spawn` in `thread::Builder` in order to avoid documentation duplication.

r? @steveklabnik 