### PR TITLE
Prohibit parenthesized params in more types.

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -237,6 +237,12 @@ declare_lint! {
 }
 
 declare_lint! {
+    pub PARENTHESIZED_PARAMS_IN_TYPES_AND_MODULES,
+    Warn,
+    "detects parenthesized generic parameters in type and module names"
+}
+
+declare_lint! {
     pub DEPRECATED,
     Warn,
     "detects use of deprecated items"
@@ -286,6 +292,7 @@ impl LintPass for HardwiredLints {
             LEGACY_IMPORTS,
             LEGACY_CONSTRUCTOR_VISIBILITY,
             MISSING_FRAGMENT_SPECIFIER,
+            PARENTHESIZED_PARAMS_IN_TYPES_AND_MODULES,
             DEPRECATED
         )
     }

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -251,6 +251,10 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
             reference: "issue #40107 <https://github.com/rust-lang/rust/issues/40107>",
         },
         FutureIncompatibleInfo {
+            id: LintId::of(PARENTHESIZED_PARAMS_IN_TYPES_AND_MODULES),
+            reference: "issue #42238 <https://github.com/rust-lang/rust/issues/42238>",
+        },
+        FutureIncompatibleInfo {
             id: LintId::of(ANONYMOUS_PARAMETERS),
             reference: "issue #41686 <https://github.com/rust-lang/rust/issues/41686>",
         },

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4495,7 +4495,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     (&data.lifetimes[..], &data.types[..], data.infer_types, &data.bindings[..])
                 }
                 Some(&hir::ParenthesizedParameters(_)) => {
-                    AstConv::prohibit_parenthesized_params(self, &segment.as_ref().unwrap().0);
+                    AstConv::prohibit_parenthesized_params(self, &segment.as_ref().unwrap().0,
+                                                           false);
                     (&[][..], &[][..], true, &[][..])
                 }
                 None => (&[][..], &[][..], true, &[][..])

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4495,7 +4495,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     (&data.lifetimes[..], &data.types[..], data.infer_types, &data.bindings[..])
                 }
                 Some(&hir::ParenthesizedParameters(_)) => {
-                    span_bug!(span, "parenthesized parameters cannot appear in ExprPath");
+                    AstConv::prohibit_parenthesized_params(self, &segment.as_ref().unwrap().0);
+                    (&[][..], &[][..], true, &[][..])
                 }
                 None => (&[][..], &[][..], true, &[][..])
             }

--- a/src/test/compile-fail/issue-22560.rs
+++ b/src/test/compile-fail/issue-22560.rs
@@ -19,7 +19,10 @@ type Test = Add +
             //~| ERROR E0191
             //~| NOTE missing associated type `Output` value
             Sub;
-            //~^ ERROR E0225
+            //~^ ERROR E0393
+            //~| NOTE missing reference to `RHS`
+            //~| NOTE because of the default `Self` reference, type parameters must be specified on object types
+            //~| ERROR E0225
             //~| NOTE non-Send/Sync additional trait
 
 fn main() { }

--- a/src/test/compile-fail/issue-32995-2.rs
+++ b/src/test/compile-fail/issue-32995-2.rs
@@ -8,14 +8,23 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![deny(parenthesized_params_in_types_and_modules)]
+//~^ NOTE lint level defined here
+//~| NOTE lint level defined here
+//~| NOTE lint level defined here
+#![allow(dead_code, unused_variables)]
 #![feature(conservative_impl_trait)]
 
 fn main() {
     { fn f<X: ::std::marker()::Send>() {} }
     //~^ ERROR parenthesized parameters may only be used with a trait
+    //~| WARN previously accepted
+    //~| NOTE issue #42238
 
     { fn f() -> impl ::std::marker()::Send { } }
     //~^ ERROR parenthesized parameters may only be used with a trait
+    //~| WARN previously accepted
+    //~| NOTE issue #42238
 }
 
 #[derive(Clone)]
@@ -23,3 +32,5 @@ struct X;
 
 impl ::std::marker()::Copy for X {}
 //~^ ERROR parenthesized parameters may only be used with a trait
+//~| WARN previously accepted
+//~| NOTE issue #42238

--- a/src/test/compile-fail/issue-32995-2.rs
+++ b/src/test/compile-fail/issue-32995-2.rs
@@ -1,0 +1,25 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(conservative_impl_trait)]
+
+fn main() {
+    { fn f<X: ::std::marker()::Send>() {} }
+    //~^ ERROR parenthesized parameters may only be used with a trait
+
+    { fn f() -> impl ::std::marker()::Send { } }
+    //~^ ERROR parenthesized parameters may only be used with a trait
+}
+
+#[derive(Clone)]
+struct X;
+
+impl ::std::marker()::Copy for X {}
+//~^ ERROR parenthesized parameters may only be used with a trait

--- a/src/test/compile-fail/issue-32995.rs
+++ b/src/test/compile-fail/issue-32995.rs
@@ -17,6 +17,22 @@ fn main() {
 
     let b: ::std::boxed()::Box<_> = Box::new(1);
     //~^ ERROR parenthesized parameters may only be used with a trait
+
+    macro_rules! pathexpr {
+        ($p:path) => { $p }
+    }
+
+    let p = pathexpr!(::std::str()::from_utf8)(b"foo").unwrap();
+    //~^ ERROR parenthesized parameters may only be used with a trait
+
+    let p = pathexpr!(::std::str::from_utf8())(b"foo").unwrap();
+    //~^ ERROR parenthesized parameters may only be used with a trait
+
+    let o : Box<::std::marker()::Send> = Box::new(1);
+    //~^ ERROR parenthesized parameters may only be used with a trait
+
+    let o : Box<Send + ::std::marker()::Sync> = Box::new(1);
+    //~^ ERROR parenthesized parameters may only be used with a trait
 }
 
 fn foo<X:Default>() {

--- a/src/test/compile-fail/issue-32995.rs
+++ b/src/test/compile-fail/issue-32995.rs
@@ -8,15 +8,26 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn main() {
-    let s: String() = String::from("foo");
-    //~^ ERROR parenthesized parameters may only be used with a trait
+#![deny(parenthesized_params_in_types_and_modules)]
+//~^ NOTE lint level defined here
+//~| NOTE lint level defined here
+//~| NOTE lint level defined here
+//~| NOTE lint level defined here
+//~| NOTE lint level defined here
+//~| NOTE lint level defined here
+//~| NOTE lint level defined here
+#![allow(dead_code, unused_variables)]
 
+fn main() {
     let x: usize() = 1;
     //~^ ERROR parenthesized parameters may only be used with a trait
+    //~| WARN previously accepted
+    //~| NOTE issue #42238
 
     let b: ::std::boxed()::Box<_> = Box::new(1);
     //~^ ERROR parenthesized parameters may only be used with a trait
+    //~| WARN previously accepted
+    //~| NOTE issue #42238
 
     macro_rules! pathexpr {
         ($p:path) => { $p }
@@ -24,18 +35,28 @@ fn main() {
 
     let p = pathexpr!(::std::str()::from_utf8)(b"foo").unwrap();
     //~^ ERROR parenthesized parameters may only be used with a trait
+    //~| WARN previously accepted
+    //~| NOTE issue #42238
 
     let p = pathexpr!(::std::str::from_utf8())(b"foo").unwrap();
     //~^ ERROR parenthesized parameters may only be used with a trait
+    //~| WARN previously accepted
+    //~| NOTE issue #42238
 
     let o : Box<::std::marker()::Send> = Box::new(1);
     //~^ ERROR parenthesized parameters may only be used with a trait
+    //~| WARN previously accepted
+    //~| NOTE issue #42238
 
     let o : Box<Send + ::std::marker()::Sync> = Box::new(1);
     //~^ ERROR parenthesized parameters may only be used with a trait
+    //~| WARN previously accepted
+    //~| NOTE issue #42238
 }
 
 fn foo<X:Default>() {
     let d : X() = Default::default();
     //~^ ERROR parenthesized parameters may only be used with a trait
+    //~| WARN previously accepted
+    //~| NOTE issue #42238
 }

--- a/src/test/compile-fail/issue-32995.rs
+++ b/src/test/compile-fail/issue-32995.rs
@@ -1,0 +1,25 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let s: String() = String::from("foo");
+    //~^ ERROR parenthesized parameters may only be used with a trait
+
+    let x: usize() = 1;
+    //~^ ERROR parenthesized parameters may only be used with a trait
+
+    let b: ::std::boxed()::Box<_> = Box::new(1);
+    //~^ ERROR parenthesized parameters may only be used with a trait
+}
+
+fn foo<X:Default>() {
+    let d : X() = Default::default();
+    //~^ ERROR parenthesized parameters may only be used with a trait
+}


### PR DESCRIPTION
Prohibit parenthesized parameters in primitive types, type parameters, `Self`, etc.

Fixes #32995.
