### PR TITLE
ICH: Handle case of removed FileMaps.

### DIFF
--- a/src/librustc_incremental/persist/hash.rs
+++ b/src/librustc_incremental/persist/hash.rs
@@ -79,7 +79,11 @@ impl<'a, 'tcx> HashContext<'a, 'tcx> {
 
             DepNode::FileMap(def_id, ref name) => {
                 if def_id.is_local() {
-                    Some(self.incremental_hashes_map[dep_node])
+                    // We will have been able to retrace the DefId (which is
+                    // always the local CRATE_DEF_INDEX), but the file with the
+                    // given name might have been removed, so we use get() in
+                    // order to allow for that case.
+                    self.incremental_hashes_map.get(dep_node).map(|x| *x)
                 } else {
                     Some(self.metadata_hash(DepNode::FileMap(def_id, name.clone()),
                                             def_id.krate,

--- a/src/test/incremental/remove_source_file/auxiliary/mod.rs
+++ b/src/test/incremental/remove_source_file/auxiliary/mod.rs
@@ -1,0 +1,13 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn print_hello() {
+    println!("hello");
+}

--- a/src/test/incremental/remove_source_file/main.rs
+++ b/src/test/incremental/remove_source_file/main.rs
@@ -1,0 +1,31 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This test case makes sure that the compiler doesn't crash due to a failing
+// table lookup when a source file is removed.
+
+// revisions:rpass1 rpass2
+
+// Note that we specify -g so that the FileMaps actually get referenced by the
+// incr. comp. cache:
+// compile-flags: -Z query-dep-graph -g
+
+#[cfg(rpass1)]
+mod auxiliary;
+
+#[cfg(rpass1)]
+fn main() {
+    auxiliary::print_hello();
+}
+
+#[cfg(rpass2)]
+fn main() {
+    println!("hello");
+}


### PR DESCRIPTION
This PR fixes a bug introduced in #41709 where removing a source file between compilation sessions would cause an ICE:
https://travis-ci.org/rust-icci/crossbeam/jobs/230582234#L633

r? @nikomatsakis 