### PR TITLE
compiletest: force GDB to print values in the Rust format.

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -647,6 +647,11 @@ actual:\n\
                                              exe_file.to_str().unwrap()
                                              .replace(r"\", r"\\")));
 
+                // Force GDB to print values in the Rust format.
+                if self.config.gdb_native_rust {
+                    script_str.push_str("set language rust\n");
+                }
+
                 // Add line breakpoints
                 for line in &breakpoint_lines {
                     script_str.push_str(&format!("break '{}':{}\n",


### PR DESCRIPTION
Based on @nodakai's https://github.com/rust-lang/rust/issues/40557#issuecomment-294368330 and @infinity0's https://github.com/rust-lang/rust/issues/40557#issuecomment-300133591.
Fixes #40557.