### PR TITLE
Fix search when looking to sources

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -236,6 +236,9 @@ nav.sub {
 	overflow: auto;
 	padding-left: 0;
 }
+#search {
+	margin-left: 230px;
+}
 .content pre.line-numbers {
 	float: left;
 	border: none;


### PR DESCRIPTION
Before:

<img width="1440" alt="screen shot 2017-05-11 at 22 33 28" src="https://cloud.githubusercontent.com/assets/3050060/25970761/03fd2ade-369a-11e7-9fd6-783c23455589.png">

After:

<img width="1440" alt="screen shot 2017-05-11 at 22 34 05" src="https://cloud.githubusercontent.com/assets/3050060/25970770/09ac71ce-369a-11e7-9038-559f414e07b5.png">

r? @rust-lang/docs 