### PR TITLE
config.toml.example: point out that optimize = false won't speed up a full bootstrap

### DIFF
--- a/src/bootstrap/config.toml.example
+++ b/src/bootstrap/config.toml.example
@@ -175,6 +175,9 @@
 [rust]
 
 # Whether or not to optimize the compiler and standard library
+# Note: the slowness of the non optimized compiler compiling itself usually
+#       outweighs the time gains in not doing optimizations, therefore a
+#       full bootstrap takes much more time with optimize set to false.
 #optimize = true
 
 # Number of codegen units to use for each compiler invocation. A value of 0


### PR DESCRIPTION
Originally I've learned about this by @eddyb pointing this out to me over IRC, and after having told someone today the same over IRC I've thought that this is a common mistake and should be prevented by a note in config.toml.example

r? @eddyb 