### PR TITLE
Fix unexpected panic with the -Z treat-err-as-bug option

### DIFF
--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -99,7 +99,10 @@ impl<'a> DiagnosticBuilder<'a> {
 
         self.handler.emitter.borrow_mut().emit(&self);
         self.cancel();
-        self.handler.panic_if_treat_err_as_bug();
+
+        if self.level == Level::Error {
+            self.handler.panic_if_treat_err_as_bug();
+        }
 
         // if self.is_fatal() {
         //     panic!(FatalError);


### PR DESCRIPTION
This fix an issue where the compiler panics even if there is no error when passed with the `-Z treat-err-as-bug` option.

Fixes #35886.

r? @Mark-Simulacrum 