### PR TITLE
rustdoc: Break words in the location box of the sidebar.

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -193,6 +193,7 @@ nav.sub {
 	font-size: 17px;
 	margin: 30px 0 20px 0;
 	text-align: center;
+	word-wrap: break-word;
 }
 
 .location:empty {


### PR DESCRIPTION
This prevents long names from overflowing.

Before:
![before](https://img.bananium.fr/eijebong/afcfe18b-393e-4d3b-bc11-fe3def6659b9.png)

After:
![after](https://img.bananium.fr/eijebong/9483466b-3b6c-4509-ab0f-fd0c6572ef27.png)