### PR TITLE
Reenable opt-level 3

### DIFF
--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -21,14 +21,6 @@ exclude = [
   "tools/rls",
 ]
 
-# Curiously, compiletest will segfault if compiled with opt-level=3 on 64-bit
-# MSVC when running the compile-fail test suite when a should-fail test panics.
-# But hey if this is removed and it gets past the bots, sounds good to me.
-[profile.release]
-opt-level = 2
-[profile.bench]
-opt-level = 2
-
 # These options are controlled from our rustc wrapper script, so turn them off
 # here and have them controlled elsewhere.
 [profile.dev]


### PR DESCRIPTION
This comment is quite old, let's see what would happen with current MSVC.

Since there's no AppVeyor test for PR, the best way is to try if it get through homu. I don't recommend doing this in roll-up.