### PR TITLE
restore TyCtxt::push_impl_path() logic for checking whether types are available

### DIFF
--- a/src/librustc/ty/item_path.rs
+++ b/src/librustc/ty/item_path.rs
@@ -221,7 +221,13 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         let use_types = !impl_def_id.is_local() || {
             // Otherwise, use filename/line-number if forced.
             let force_no_types = FORCE_IMPL_FILENAME_LINE.with(|f| f.get());
-            !force_no_types && {
+
+            // Check whether type info is available, because typeck might not have
+            // completed yet.
+            let types_available = self.maps.impl_trait_ref.borrow().contains_key(&impl_def_id) &&
+                self.maps.type_of.borrow().contains_key(&impl_def_id);
+
+            !force_no_types && types_available && {
                 // Otherwise, use types if we can query them without inducing a cycle.
                 ty::queries::impl_trait_ref::try_get(self, DUMMY_SP, impl_def_id).is_ok() &&
                     ty::queries::type_of::try_get(self, DUMMY_SP, impl_def_id).is_ok()


### PR DESCRIPTION
Fixes #41697 by restoring some logic that got removed in https://github.com/rust-lang/rust/commit/2cca2567d9a39f159e392c47c8be6d94087242c9.

Note that I don't have a super strong grasp of what exactly is happening is this code. It's entirely possible that @nikomatsakis had a good reason for removing these lines, in which case maybe there is a better fix.