### PR TITLE
Disallow underscore suffix for string-like literals.

### DIFF
--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -479,7 +479,20 @@ impl<'a> StringReader<'a> {
         }
 
         self.with_str_from(start, |string| {
-            Some(Symbol::intern(string))
+            if string == "_" {
+                self.sess.span_diagnostic
+                    .struct_span_warn(mk_sp(start, self.pos),
+                                      "underscore literal suffix is not allowed")
+                    .warn("this was previously accepted by the compiler but is \
+                          being phased out; it will become a hard error in \
+                          a future release!")
+                    .note("for more information, see issue #42326 \
+                          <https://github.com/rust-lang/rust/issues/42326>")
+                    .emit();
+                None
+            } else {
+                Some(Symbol::intern(string))
+            }
         })
     }
 

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -479,11 +479,7 @@ impl<'a> StringReader<'a> {
         }
 
         self.with_str_from(start, |string| {
-            if string == "_" {
-                None
-            } else {
-                Some(Symbol::intern(string))
-            }
+            Some(Symbol::intern(string))
         })
     }
 

--- a/src/test/parse-fail/underscore-suffix-for-string.rs
+++ b/src/test/parse-fail/underscore-suffix-for-string.rs
@@ -1,0 +1,13 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let a = "Foo"_; //~ ERROR string literal with a suffix is invalid
+}

--- a/src/test/parse-fail/underscore-suffix-for-string.rs
+++ b/src/test/parse-fail/underscore-suffix-for-string.rs
@@ -9,5 +9,12 @@
 // except according to those terms.
 
 fn main() {
-    let a = "Foo"_; //~ ERROR string literal with a suffix is invalid
+    let _ = "Foo"_;
+    //~^ WARNING underscore literal suffix is not allowed
+    //~| WARNING this was previously accepted
+    //~| NOTE issue #42326
 }
+
+FAIL
+//~^ ERROR
+//~| NOTE


### PR DESCRIPTION
This patch turns string/bytestring/char/byte literals followed by an underscore, like `"Foo"_`, to an error.

`scan_optional_raw_name` will parse `_` as a valid raw name, but it will be rejected by the parser. I also considered just stopping parsing when the suffix is `_`, but in that case `"Foo"_` will be lexed as two valid tokens.

Fixes the latter half of #41723.