### PR TITLE
improve collapse toggle render (css)

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -617,6 +617,11 @@ a.test-arrow:hover{
 	top: 0;
 }
 
+h3 > .collapse-toggle, h4 > .collapse-toggle {
+	font-size: 0.8em;
+	top: 5px;
+}
+
 .toggle-wrapper > .collapse-toggle {
 	left: -24px;
 	margin-top: 0px;


### PR DESCRIPTION
The `[-]` toggle for functions in docs _seems_ too big. It's just an impression, but it's something I noticed long time ago (maybe I have bad taste). I never thought to fix it, but, today I think: "Ok, why not suggest it.". Feel free to close without explanation!

Preview changes below:

From this:

<img width="1003" alt="capture d ecran 2017-05-15 a 17 14 45" src="https://cloud.githubusercontent.com/assets/1575946/26064816/5c84de86-3992-11e7-976b-41c625cace0f.png">

To this:

<img width="996" alt="capture d ecran 2017-05-15 a 17 15 02" src="https://cloud.githubusercontent.com/assets/1575946/26064854/78325dac-3992-11e7-88f6-2c43db43421c.png">

