### PR TITLE
Remove `FusedIterator` implementation of `iter::Scan`

### DIFF
--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -1778,10 +1778,6 @@ impl<B, I, St, F> Iterator for Scan<I, St, F> where
     }
 }
 
-#[unstable(feature = "fused", issue = "35602")]
-impl<B, I, St, F> FusedIterator for Scan<I, St, F>
-    where I: FusedIterator, F: FnMut(&mut St, I::Item) -> Option<B> {}
-
 /// An iterator that maps each element to an iterator, and yields the elements
 /// of the produced iterators.
 ///


### PR DESCRIPTION
Fixes #41964.

This is a breaking change.