### PR TITLE
allow stable features in compiletest

### DIFF
--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -17,6 +17,7 @@
 #![feature(libc)]
 
 #![deny(warnings)]
+#![allow(stable_features)]
 
 extern crate libc;
 extern crate test;


### PR DESCRIPTION
1.17 stabilized the static_in_const feature, which is used in compiletest. This results in a warning, which `#![deny(warnings)]` in the same file turns into an error.
This patch allows stable features to be used, so the compile works both for 1.16 and 1.17.