### PR TITLE
Document direct implementations on type aliases.

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -311,6 +311,9 @@ impl Item {
     pub fn is_ty_method(&self) -> bool {
         self.type_() == ItemType::TyMethod
     }
+    pub fn is_typedef(&self) -> bool {
+        self.type_() == ItemType::Typedef
+    }
     pub fn is_primitive(&self) -> bool {
         self.type_() == ItemType::Primitive
     }

--- a/src/test/rustdoc/typedef.rs
+++ b/src/test/rustdoc/typedef.rs
@@ -1,0 +1,35 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub trait MyTrait {
+    fn method_on_mytrait() {}
+}
+
+pub struct MyStruct;
+
+impl MyStruct {
+    pub fn method_on_mystruct() {}
+}
+
+// @has typedef/type.MyAlias.html
+// @has - '//*[@class="impl"]//code' 'impl MyAlias'
+// @has - '//*[@class="impl"]//code' 'impl MyTrait for MyAlias'
+// @has - 'Alias docstring'
+// @has - '//*[@class="sidebar"]//p[@class="location"]' 'Type Definition MyAlias'
+// @has - '//*[@class="sidebar"]//a[@href="#methods"]' 'Methods'
+// @has - '//*[@class="sidebar"]//a[@href="#implementations"]' 'Trait Implementations'
+/// Alias docstring
+pub type MyAlias = MyStruct;
+
+impl MyAlias {
+    pub fn method_on_myalias() {}
+}
+
+impl MyTrait for MyAlias {}


### PR DESCRIPTION
This improves #32077, but is not a complete fix.

For a type alias `type NewType = AliasedType`, it will include any `impl NewType` and `impl
Trait for NewType` blocks in the documentation for `NewType`.

A complete fix would include the implementations from the aliased type in the type alias' documentation, so that users have a complete picture of methods that are available on the alias. However, to do this properly would require a fix for #14072, as the alias may affect the type parameters of the type alias, making the documentation difficult to understand. (That is, for `type Result = std::result::Result<(), ()>` we would ideally show documentation for `impl Result<(), ()>`, rather than generic documentation for `impl<T, E> Result<T, E>`).

I think this improvement is worthwhile, as it exposes implementations which are not currently documented by rustdoc. The documentation for the implementations on the aliased type are still accessible by clicking through to the docs for that type. (Although perhaps it's now less obvious to the user that they should click-through to get there).