### PR TITLE
FRC target support

### DIFF
--- a/src/librustc_back/target/arm_frc_linux_gnueabi.rs
+++ b/src/librustc_back/target/arm_frc_linux_gnueabi.rs
@@ -22,7 +22,7 @@ pub fn target() -> TargetResult {
         arch: "arm".to_string(),
         target_os: "linux".to_string(),
         target_env: "gnu".to_string(),
-        target_vendor: "frc".to_string(),
+        target_vendor: "frc-roboRIO-2015".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
 
         options: TargetOptions {

--- a/src/librustc_back/target/arm_frc_linux_gnueabi.rs
+++ b/src/librustc_back/target/arm_frc_linux_gnueabi.rs
@@ -1,0 +1,35 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use LinkerFlavor;
+use target::{Target, TargetOptions, TargetResult};
+
+pub fn target() -> TargetResult {
+    let mut base = super::linux_base::opts();
+    base.max_atomic_width = Some(64);
+    Ok(Target {
+        llvm_target: "arm-frc-linux-gnueabi".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        data_layout: "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
+        arch: "arm".to_string(),
+        target_os: "linux".to_string(),
+        target_env: "gnu".to_string(),
+        target_vendor: "frc".to_string(),
+        linker_flavor: LinkerFlavor::Gcc,
+
+        options: TargetOptions {
+            features: "+v7,+vfp3".to_string(),
+            cpu: "cortex-a9".to_string(),
+            abi_blacklist: super::arm_base::abi_blacklist(),
+            .. base
+        },
+    })
+}

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -160,7 +160,7 @@ supported_targets! {
     ("mipsel-unknown-linux-uclibc", mipsel_unknown_linux_uclibc),
 
     ("arm-frc-linux-gnueabi", arm_frc_linux_gnueabi),
-    
+
     ("sparc64-unknown-linux-gnu", sparc64_unknown_linux_gnu),
 
     ("i686-linux-android", i686_linux_android),

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -159,6 +159,8 @@ supported_targets! {
     ("mips-unknown-linux-uclibc", mips_unknown_linux_uclibc),
     ("mipsel-unknown-linux-uclibc", mipsel_unknown_linux_uclibc),
 
+    ("arm-frc-linux-gnueabi", arm_frc_linux_gnueabi),
+    
     ("sparc64-unknown-linux-gnu", sparc64_unknown_linux_gnu),
 
     ("i686-linux-android", i686_linux_android),


### PR DESCRIPTION
This PR adds support for [target platform](http://forums.ni.com/t5/FIRST-Robotics-Competition/roboRIO-Details-and-Specifications/ta-p/3494658) used in the FIRST Robotics Competition.