### PR TITLE
Stabilize unions with `Copy` fields and no destructor

### DIFF
--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -65,7 +65,6 @@
 #![feature(trusted_len)]
 #![feature(unicode)]
 #![feature(unique)]
-#![feature(untagged_unions)]
 #![cfg_attr(not(test), feature(str_checked_slicing))]
 #![cfg_attr(test, feature(rand, test))]
 #![feature(offset_to)]

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -625,6 +625,27 @@ impl<'a, 'tcx> Visitor<'tcx> for Checker<'a, 'tcx> {
                 }
             }
 
+            // There's no good place to insert stability check for non-Copy unions,
+            // so semi-randomly perform it here in stability.rs
+            hir::ItemUnion(..) if !self.tcx.sess.features.borrow().untagged_unions => {
+                let def_id = self.tcx.hir.local_def_id(item.id);
+                let adt_def = self.tcx.adt_def(def_id);
+                let ty = self.tcx.type_of(def_id);
+
+                if adt_def.has_dtor(self.tcx) {
+                    emit_feature_err(&self.tcx.sess.parse_sess,
+                                     "untagged_unions", item.span, GateIssue::Language,
+                                     "unions with `Drop` implementations are unstable");
+                } else {
+                    let param_env = self.tcx.param_env(def_id);
+                    if !param_env.can_type_implement_copy(self.tcx, ty, item.span).is_ok() {
+                        emit_feature_err(&self.tcx.sess.parse_sess,
+                                        "untagged_unions", item.span, GateIssue::Language,
+                                        "unions with non-`Copy` fields are unstable");
+                    }
+                }
+            }
+
             _ => (/* pass */)
         }
         intravisit::walk_item(self, item);

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -29,7 +29,6 @@
 #![feature(nonzero)]
 #![feature(unboxed_closures)]
 #![feature(fn_traits)]
-#![feature(untagged_unions)]
 #![feature(associated_consts)]
 #![feature(unsize)]
 #![feature(i128_type)]

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -1207,12 +1207,6 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 }
             }
 
-            ast::ItemKind::Union(..) => {
-                gate_feature_post!(&self, untagged_unions,
-                                   i.span,
-                                   "unions are unstable and possibly buggy");
-            }
-
             ast::ItemKind::DefaultImpl(..) => {
                 gate_feature_post!(&self, optin_builtin_traits,
                                    i.span,

--- a/src/test/compile-fail/borrowck/borrowck-union-borrow-nested.rs
+++ b/src/test/compile-fail/borrowck/borrowck-union-borrow-nested.rs
@@ -8,10 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-tidy-linelength
-
-#![feature(untagged_unions)]
-
 #[derive(Clone, Copy)]
 struct S {
     a: u8,

--- a/src/test/compile-fail/borrowck/borrowck-union-borrow.rs
+++ b/src/test/compile-fail/borrowck/borrowck-union-borrow.rs
@@ -10,8 +10,6 @@
 
 // ignore-tidy-linelength
 
-#![feature(untagged_unions)]
-
 #[derive(Clone, Copy)]
 union U {
     a: u8,

--- a/src/test/compile-fail/borrowck/borrowck-union-uninitialized.rs
+++ b/src/test/compile-fail/borrowck/borrowck-union-uninitialized.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
-
 struct S {
     a: u8,
 }

--- a/src/test/compile-fail/privacy/union-field-privacy-1.rs
+++ b/src/test/compile-fail/privacy/union-field-privacy-1.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
-
 mod m {
     pub union U {
         pub a: u8,

--- a/src/test/compile-fail/privacy/union-field-privacy-2.rs
+++ b/src/test/compile-fail/privacy/union-field-privacy-2.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
-
 mod m {
     pub union U {
         pub a: u8,

--- a/src/test/compile-fail/union/union-const-eval.rs
+++ b/src/test/compile-fail/union/union-const-eval.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
-
 union U {
     a: usize,
     b: usize,

--- a/src/test/compile-fail/union/union-const-pat.rs
+++ b/src/test/compile-fail/union/union-const-pat.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
-
 union U {
     a: usize,
     b: usize,

--- a/src/test/compile-fail/union/union-derive.rs
+++ b/src/test/compile-fail/union/union-derive.rs
@@ -10,8 +10,6 @@
 
 // Most traits cannot be derived for unions.
 
-#![feature(untagged_unions)]
-
 #[derive(
     PartialEq, //~ ERROR this trait cannot be derived for unions
     PartialOrd, //~ ERROR this trait cannot be derived for unions

--- a/src/test/compile-fail/union/union-empty.rs
+++ b/src/test/compile-fail/union/union-empty.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
-
 union U {} //~ ERROR unions cannot have zero fields
 
 fn main() {}

--- a/src/test/compile-fail/union/union-feature-gate.rs
+++ b/src/test/compile-fail/union/union-feature-gate.rs
@@ -10,8 +10,28 @@
 
 // gate-test-untagged_unions
 
-union U { //~ ERROR unions are unstable and possibly buggy
+union U1 { // OK
     a: u8,
+}
+
+union U2<T: Copy> { // OK
+    a: T,
+}
+
+union U3 { //~ ERROR unions with non-`Copy` fields are unstable
+    a: String,
+}
+
+union U4<T> { //~ ERROR unions with non-`Copy` fields are unstable
+    a: T,
+}
+
+union U5 { //~ ERROR unions with `Drop` implementations are unstable
+    a: u8,
+}
+
+impl Drop for U5 {
+    fn drop(&mut self) {}
 }
 
 fn main() {}

--- a/src/test/compile-fail/union/union-fields.rs
+++ b/src/test/compile-fail/union/union-fields.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
-
 union U {
     a: u8,
     b: u16,

--- a/src/test/compile-fail/union/union-generic.rs
+++ b/src/test/compile-fail/union/union-generic.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
-
 use std::rc::Rc;
 
 union U<T: Copy> {

--- a/src/test/compile-fail/union/union-lint-dead-code.rs
+++ b/src/test/compile-fail/union/union-lint-dead-code.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
 #![deny(dead_code)]
 
 union Foo {

--- a/src/test/compile-fail/union/union-repr-c.rs
+++ b/src/test/compile-fail/union/union-repr-c.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
 #![allow(unused)]
 #![deny(improper_ctypes)]
 

--- a/src/test/compile-fail/union/union-suggest-field.rs
+++ b/src/test/compile-fail/union/union-suggest-field.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
-
 union U {
     principal: u8,
 }

--- a/src/test/debuginfo/union-smoke.rs
+++ b/src/test/debuginfo/union-smoke.rs
@@ -34,7 +34,6 @@
 #![allow(unused)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![feature(untagged_unions)]
 
 union U {
     a: (u8, u8),

--- a/src/test/run-pass/union/auxiliary/union.rs
+++ b/src/test/run-pass/union/auxiliary/union.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
-
 pub union U {
     pub a: u8,
     pub b: u16,

--- a/src/test/run-pass/union/union-backcomp.rs
+++ b/src/test/run-pass/union/union-backcomp.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
-
 macro_rules! union {
     () => (struct S;)
 }

--- a/src/test/run-pass/union/union-basic.rs
+++ b/src/test/run-pass/union/union-basic.rs
@@ -13,8 +13,6 @@
 // FIXME: This test case makes little-endian assumptions.
 // ignore-s390x
 
-#![feature(untagged_unions)]
-
 extern crate union;
 use std::mem::{size_of, align_of, zeroed};
 

--- a/src/test/run-pass/union/union-c-interop.rs
+++ b/src/test/run-pass/union/union-c-interop.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
-
 #[derive(Clone, Copy)]
 #[repr(C)]
 struct LARGE_INTEGER_U {

--- a/src/test/run-pass/union/union-const-trans.rs
+++ b/src/test/run-pass/union/union-const-trans.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
-
 union U {
     a: u64,
     b: u64,

--- a/src/test/run-pass/union/union-inherent-method.rs
+++ b/src/test/run-pass/union/union-inherent-method.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
-
 union U {
     a: u8,
 }

--- a/src/test/run-pass/union/union-macro.rs
+++ b/src/test/run-pass/union/union-macro.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
-
 macro_rules! duplicate {
    ($i: item) => {
         mod m1 {

--- a/src/test/run-pass/union/union-pat-refutability.rs
+++ b/src/test/run-pass/union/union-pat-refutability.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
-
 #[repr(u32)]
 enum Tag { I, F }
 

--- a/src/test/run-pass/union/union-trait-impl.rs
+++ b/src/test/run-pass/union/union-trait-impl.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
-
 use std::fmt;
 
 union U {

--- a/src/test/run-pass/union/union-transmute.rs
+++ b/src/test/run-pass/union/union-transmute.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
-
 extern crate core;
 use core::f32;
 

--- a/src/test/rustdoc/union.rs
+++ b/src/test/rustdoc/union.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
-
 // @has union/union.U.html
 pub union U {
     // @has - //pre "pub a: u8"

--- a/src/test/ui/print_type_sizes/packed.rs
+++ b/src/test/ui/print_type_sizes/packed.rs
@@ -18,8 +18,6 @@
 // aligned (while on most it is 8-byte aligned) and so the resulting
 // padding and overall computed sizes can be quite different.
 
-#![feature(untagged_unions)]
-
 #![allow(dead_code)]
 
 #[derive(Default)]


### PR DESCRIPTION
What else is needed:
- [x] Documentation (https://github.com/rust-lang-nursery/reference/pull/57).
- [x] Making assignments to `Copy` union fields safe (https://github.com/rust-lang/rust/pull/42083).
- [ ] Backport? (The "stabilization decision" is from [Apr 13](https://github.com/rust-lang/rust/issues/32836#issuecomment-294018091), it's just this PR is late.)

cc https://github.com/rust-lang/rust/issues/32836
r? @nikomatsakis 