### PR TITLE
Add an option to run rustbuild on low priority on Windows and Unix

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -94,6 +94,7 @@ pub struct Config {
     pub backtrace: bool, // support for RUST_BACKTRACE
 
     // misc
+    pub low_priority: bool,
     pub channel: String,
     pub quiet_tests: bool,
     // Fallback musl-root for all targets
@@ -146,6 +147,7 @@ struct Build {
     target: Vec<String>,
     cargo: Option<String>,
     rustc: Option<String>,
+    low_priority: Option<bool>,
     compiler_docs: Option<bool>,
     docs: Option<bool>,
     submodules: Option<bool>,
@@ -302,6 +304,7 @@ impl Config {
         config.nodejs = build.nodejs.map(PathBuf::from);
         config.gdb = build.gdb.map(PathBuf::from);
         config.python = build.python.map(PathBuf::from);
+        set(&mut config.low_priority, build.low_priority);
         set(&mut config.compiler_docs, build.compiler_docs);
         set(&mut config.docs, build.docs);
         set(&mut config.submodules, build.submodules);

--- a/src/bootstrap/config.toml.example
+++ b/src/bootstrap/config.toml.example
@@ -152,6 +152,9 @@
 # known-good version of OpenSSL, compile it, and link it to Cargo.
 #openssl-static = false
 
+# Run the build with low priority
+#low_priority = false
+
 # =============================================================================
 # General install configuration options
 # =============================================================================

--- a/src/bootstrap/config.toml.example
+++ b/src/bootstrap/config.toml.example
@@ -152,8 +152,9 @@
 # known-good version of OpenSSL, compile it, and link it to Cargo.
 #openssl-static = false
 
-# Run the build with low priority
-#low_priority = false
+# Run the build with low priority, by setting the process group's "nice" value
+# to +10 on Unix platforms, and by using a "low priority" job object on Windows.
+#low-priority = false
 
 # =============================================================================
 # General install configuration options

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -115,17 +115,9 @@ mod job;
 mod job {
     use libc;
 
-    //apparently glibc defines their own enum for this parameter, in a different type
-    #[cfg(not(any(target_env = "musl", target_env = "musleabi", target_env = "musleabihf",
-                  target_os = "emscripten", target_arch = "mips", target_arch = "mipsel")))]
-    const PRIO_PGRP: libc::c_uint = libc::PRIO_PGRP as libc::c_uint;
-    #[cfg(any(target_env = "musl", target_env = "musleabi", target_env = "musleabihf",
-              target_os = "emscripten", target_arch = "mips", target_arch = "mipsel"))]
-    const PRIO_PGRP: libc::c_int = libc::PRIO_PGRP;
-
     pub unsafe fn setup(build: &mut ::Build) {
         if build.config.low_priority {
-            libc::setpriority(PRIO_PGRP, 0, 10);
+            libc::setpriority(libc::PRIO_PGRP as _, 0, 10);
         }
     }
 }


### PR DESCRIPTION
This is a resurrection of #40776, combining their Windows setup with an additional setup on Unix to set the program group's *nice*ness to +10 (low-but-not-lowest priority, mirroring the priority in the Windows setup) when the `low_priority` option is on.