### PR TITLE
rustdoc: Fix implementors list javascript

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1083,10 +1083,10 @@
                 code.innerHTML = structs[j];
 
                 var x = code.getElementsByTagName('a');
-                for (var i = 0; i < x.length; i++) {
-                    var href = x[i].href;
+                for (var k = 0; k < x.length; k++) {
+                    var href = x[k].getAttribute('href');
                     if (href && href.indexOf('http') !== 0) {
-                        x[i].href = rootPath + href;
+                        x[k].setAttribute('href', rootPath + href);
                     }
                 }
                 var li = document.createElement('li');


### PR DESCRIPTION
* Use a different loop variable, `i` was already taken. This caused
missing items in the implementors list.
* Use `.getAttribute('href')` rather than `.href` to get the relative
URL which is what it needs to actually fix the links.

More fallout from #41307.

r? @GuillaumeGomez