### PR TITLE
core: fix unused_macro warning

### DIFF
--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -918,6 +918,7 @@ impl<T> AtomicPtr<T> {
     }
 }
 
+#[cfg(target_has_atomic = "ptr")]
 macro_rules! atomic_int {
     ($stable:meta,
      $stable_cxchg:meta,


### PR DESCRIPTION
when compiling the crate for a target with max-atomic-width = 0

fixes #42097