### PR TITLE
trace_macro: Show both the macro call and its expansion. #42072.

### DIFF
--- a/src/test/ui/macros/trace-macro.stderr
+++ b/src/test/ui/macros/trace-macro.stderr
@@ -4,6 +4,9 @@ note: trace_macro
 14 |     println!("Hello, World!");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expands to `println! { "Hello, World!" }`
-   = note: expands to `print! { concat ! ( "Hello, World!" , "/n" ) }`
+   = note: expanding `println! { "Hello, World!" }`
+   = note: to `print ! ( concat ! ( "Hello, World!" , "/n" ) )`
+   = note: expanding `print! { concat ! ( "Hello, World!" , "/n" ) }`
+   = note: to `$crate :: io :: _print ( format_args ! ( concat ! ( "Hello, World!" , "/n" ) )
+           )`
 


### PR DESCRIPTION
See #42072 for the initial motivation behind this.

The change is not the minimal fix, but I want this behavior almost every time I use `trace_macros`.