### PR TITLE
Revert "Reenable opt-level 3"

### DIFF
--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -18,6 +18,14 @@ members = [
   "tools/rls",
 ]
 
+# Curiously, compiletest will segfault if compiled with opt-level=3 on 64-bit
+# MSVC when running the compile-fail test suite when a should-fail test panics.
+# But hey if this is removed and it gets past the bots, sounds good to me.
+[profile.release]
+opt-level = 2
+[profile.bench]
+opt-level = 2
+
 # These options are controlled from our rustc wrapper script, so turn them off
 # here and have them controlled elsewhere.
 [profile.dev]


### PR DESCRIPTION
This reverts commit 30383b2384864173b9238a121f8e83f8968f1e51, from #41967.

We believe that this is causing the failures when compiling rustc on 64 bit (which are probably segfaults).

cc @ishitatsuyuki 

