### PR TITLE
Remove unused lifetimes.

### DIFF
--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -530,7 +530,7 @@ impl<'a> From<&'a OsStr> for Box<OsStr> {
 }
 
 #[stable(feature = "os_string_from_box", since = "1.18.0")]
-impl<'a> From<Box<OsStr>> for OsString {
+impl From<Box<OsStr>> for OsString {
     fn from(boxed: Box<OsStr>) -> OsString {
         boxed.into_os_string()
     }

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1342,7 +1342,7 @@ impl<'a> From<&'a Path> for Box<Path> {
 }
 
 #[stable(feature = "path_buf_from_box", since = "1.18.0")]
-impl<'a> From<Box<Path>> for PathBuf {
+impl From<Box<Path>> for PathBuf {
     fn from(boxed: Box<Path>) -> PathBuf {
         boxed.into_path_buf()
     }


### PR DESCRIPTION
This was a typo that made it onto master. Noted by @dtolnay in #42127.

Also note #41960 which suggests warning these.