### PR TITLE
Turn sufficiently old compatibility lints into hard errors

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -131,65 +131,9 @@ declare_lint! {
 }
 
 declare_lint! {
-    pub INACCESSIBLE_EXTERN_CRATE,
-    Deny,
-    "use of inaccessible extern crate erroneously allowed"
-}
-
-declare_lint! {
-    pub INVALID_TYPE_PARAM_DEFAULT,
-    Deny,
-    "type parameter default erroneously allowed in invalid location"
-}
-
-declare_lint! {
-    pub ILLEGAL_FLOATING_POINT_CONSTANT_PATTERN,
-    Deny,
-    "floating-point constants cannot be used in patterns"
-}
-
-declare_lint! {
-    pub ILLEGAL_STRUCT_OR_ENUM_CONSTANT_PATTERN,
-    Deny,
-    "constants of struct or enum type can only be used in a pattern if \
-     the struct or enum has `#[derive(PartialEq, Eq)]`"
-}
-
-declare_lint! {
-    pub RAW_POINTER_DERIVE,
-    Warn,
-    "uses of #[derive] with raw pointers are rarely correct"
-}
-
-declare_lint! {
-    pub HR_LIFETIME_IN_ASSOC_TYPE,
-    Deny,
-    "binding for associated type references higher-ranked lifetime \
-     that does not appear in the trait input types"
-}
-
-declare_lint! {
-    pub OVERLAPPING_INHERENT_IMPLS,
-    Deny,
-    "two overlapping inherent impls define an item with the same name were erroneously allowed"
-}
-
-declare_lint! {
     pub RENAMED_AND_REMOVED_LINTS,
     Warn,
     "lints that have been renamed or removed"
-}
-
-declare_lint! {
-    pub SUPER_OR_SELF_IN_GLOBAL_PATH,
-    Deny,
-    "detects super or self keywords at the beginning of global path"
-}
-
-declare_lint! {
-    pub LIFETIME_UNDERSCORE,
-    Deny,
-    "lifetimes or labels named `'_` were erroneously allowed"
 }
 
 declare_lint! {
@@ -280,17 +224,8 @@ impl LintPass for HardwiredLints {
             TRIVIAL_CASTS,
             TRIVIAL_NUMERIC_CASTS,
             PRIVATE_IN_PUBLIC,
-            INACCESSIBLE_EXTERN_CRATE,
-            INVALID_TYPE_PARAM_DEFAULT,
-            ILLEGAL_FLOATING_POINT_CONSTANT_PATTERN,
-            ILLEGAL_STRUCT_OR_ENUM_CONSTANT_PATTERN,
             CONST_ERR,
-            RAW_POINTER_DERIVE,
-            OVERLAPPING_INHERENT_IMPLS,
             RENAMED_AND_REMOVED_LINTS,
-            SUPER_OR_SELF_IN_GLOBAL_PATH,
-            HR_LIFETIME_IN_ASSOC_TYPE,
-            LIFETIME_UNDERSCORE,
             RESOLVE_TRAIT_ON_DEFAULTED_UNIT,
             SAFE_EXTERN_STATICS,
             PATTERNS_IN_FNS_WITHOUT_BODY,

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -131,6 +131,12 @@ declare_lint! {
 }
 
 declare_lint! {
+    pub INVALID_TYPE_PARAM_DEFAULT,
+    Deny,
+    "type parameter default erroneously allowed in invalid location"
+}
+
+declare_lint! {
     pub RENAMED_AND_REMOVED_LINTS,
     Warn,
     "lints that have been renamed or removed"
@@ -224,6 +230,7 @@ impl LintPass for HardwiredLints {
             TRIVIAL_CASTS,
             TRIVIAL_NUMERIC_CASTS,
             PRIVATE_IN_PUBLIC,
+            INVALID_TYPE_PARAM_DEFAULT,
             CONST_ERR,
             RENAMED_AND_REMOVED_LINTS,
             RESOLVE_TRAIT_ON_DEFAULTED_UNIT,

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -179,7 +179,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
     // - Create a lint defaulting to warn as normal, with ideally the same error
     //   message you would normally give
     // - Add a suitable reference, typically an RFC or tracking issue. Go ahead
-    //   and include the full URL.
+    //   and include the full URL, sort items in ascending order of issue numbers.
     // - Later, change lint to error
     // - Eventually, remove lint
     store.register_future_incompatible(sess,
@@ -189,48 +189,12 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
             reference: "issue #34537 <https://github.com/rust-lang/rust/issues/34537>",
         },
         FutureIncompatibleInfo {
-            id: LintId::of(INACCESSIBLE_EXTERN_CRATE),
-            reference: "issue #36886 <https://github.com/rust-lang/rust/issues/36886>",
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(INVALID_TYPE_PARAM_DEFAULT),
-            reference: "issue #36887 <https://github.com/rust-lang/rust/issues/36887>",
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(SUPER_OR_SELF_IN_GLOBAL_PATH),
-            reference: "issue #36888 <https://github.com/rust-lang/rust/issues/36888>",
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(ILLEGAL_FLOATING_POINT_CONSTANT_PATTERN),
-            reference: "issue #36890 <https://github.com/rust-lang/rust/issues/36890>",
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(ILLEGAL_FLOATING_POINT_LITERAL_PATTERN),
-            reference: "issue #41620 <https://github.com/rust-lang/rust/issues/41620>",
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(ILLEGAL_STRUCT_OR_ENUM_CONSTANT_PATTERN),
-            reference: "issue #36891 <https://github.com/rust-lang/rust/issues/36891>",
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(HR_LIFETIME_IN_ASSOC_TYPE),
-            reference: "issue #33685 <https://github.com/rust-lang/rust/issues/33685>",
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(LIFETIME_UNDERSCORE),
-            reference: "issue #36892 <https://github.com/rust-lang/rust/issues/36892>",
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(RESOLVE_TRAIT_ON_DEFAULTED_UNIT),
-            reference: "issue #39216 <https://github.com/rust-lang/rust/issues/39216>",
+            id: LintId::of(PATTERNS_IN_FNS_WITHOUT_BODY),
+            reference: "issue #35203 <https://github.com/rust-lang/rust/issues/35203>",
         },
         FutureIncompatibleInfo {
             id: LintId::of(SAFE_EXTERN_STATICS),
-            reference: "issue #36247 <https://github.com/rust-lang/rust/issues/35112>",
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(PATTERNS_IN_FNS_WITHOUT_BODY),
-            reference: "issue #35203 <https://github.com/rust-lang/rust/issues/35203>",
+            reference: "issue #36247 <https://github.com/rust-lang/rust/issues/36247>",
         },
         FutureIncompatibleInfo {
             id: LintId::of(EXTRA_REQUIREMENT_IN_IMPL),
@@ -249,17 +213,25 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
             reference: "issue #39207 <https://github.com/rust-lang/rust/issues/39207>",
         },
         FutureIncompatibleInfo {
+            id: LintId::of(RESOLVE_TRAIT_ON_DEFAULTED_UNIT),
+            reference: "issue #39216 <https://github.com/rust-lang/rust/issues/39216>",
+        },
+        FutureIncompatibleInfo {
             id: LintId::of(MISSING_FRAGMENT_SPECIFIER),
             reference: "issue #40107 <https://github.com/rust-lang/rust/issues/40107>",
         },
         FutureIncompatibleInfo {
-            id: LintId::of(PARENTHESIZED_PARAMS_IN_TYPES_AND_MODULES),
-            reference: "issue #42238 <https://github.com/rust-lang/rust/issues/42238>",
+            id: LintId::of(ILLEGAL_FLOATING_POINT_LITERAL_PATTERN),
+            reference: "issue #41620 <https://github.com/rust-lang/rust/issues/41620>",
         },
         FutureIncompatibleInfo {
             id: LintId::of(ANONYMOUS_PARAMETERS),
             reference: "issue #41686 <https://github.com/rust-lang/rust/issues/41686>",
         },
+        FutureIncompatibleInfo {
+            id: LintId::of(PARENTHESIZED_PARAMS_IN_TYPES_AND_MODULES),
+            reference: "issue #42238 <https://github.com/rust-lang/rust/issues/42238>",
+        }
         ]);
 
     // Register renamed and removed lints
@@ -275,5 +247,20 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
     store.register_removed("drop_with_repr_extern", "drop flags have been removed");
     store.register_removed("transmute_from_fn_item_types",
         "always cast functions before transmuting them");
-    store.register_removed("overlapping_inherent_impls", "converted into hard error, see #36889");
+    store.register_removed("hr_lifetime_in_assoc_type",
+        "converted into hard error, see https://github.com/rust-lang/rust/issues/33685");
+    store.register_removed("inaccessible_extern_crate",
+        "converted into hard error, see https://github.com/rust-lang/rust/issues/36886");
+    store.register_removed("invalid_type_param_default",
+        "converted into hard error, see https://github.com/rust-lang/rust/issues/36887");
+    store.register_removed("super_or_self_in_global_path",
+        "converted into hard error, see https://github.com/rust-lang/rust/issues/36888");
+    store.register_removed("overlapping_inherent_impls",
+        "converted into hard error, see https://github.com/rust-lang/rust/issues/36889");
+    store.register_removed("illegal_floating_point_constant_pattern",
+        "converted into hard error, see https://github.com/rust-lang/rust/issues/36890");
+    store.register_removed("illegal_struct_or_enum_constant_pattern",
+        "converted into hard error, see https://github.com/rust-lang/rust/issues/36891");
+    store.register_removed("lifetime_underscore",
+        "converted into hard error, see https://github.com/rust-lang/rust/issues/36892");
 }

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -197,6 +197,10 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
             reference: "issue #36247 <https://github.com/rust-lang/rust/issues/36247>",
         },
         FutureIncompatibleInfo {
+            id: LintId::of(INVALID_TYPE_PARAM_DEFAULT),
+            reference: "issue #36887 <https://github.com/rust-lang/rust/issues/36887>",
+        },
+        FutureIncompatibleInfo {
             id: LintId::of(EXTRA_REQUIREMENT_IN_IMPL),
             reference: "issue #37166 <https://github.com/rust-lang/rust/issues/37166>",
         },
@@ -251,8 +255,6 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
         "converted into hard error, see https://github.com/rust-lang/rust/issues/33685");
     store.register_removed("inaccessible_extern_crate",
         "converted into hard error, see https://github.com/rust-lang/rust/issues/36886");
-    store.register_removed("invalid_type_param_default",
-        "converted into hard error, see https://github.com/rust-lang/rust/issues/36887");
     store.register_removed("super_or_self_in_global_path",
         "converted into hard error, see https://github.com/rust-lang/rust/issues/36888");
     store.register_removed("overlapping_inherent_impls",

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1069,6 +1069,10 @@ impl<'a> NameBinding<'a> {
             _ => false,
         }
     }
+
+    fn descr(&self) -> &'static str {
+        if self.is_extern_crate() { "extern crate" } else { self.def().kind_name() }
+    }
 }
 
 /// Interns the names of the primitive types.
@@ -3424,18 +3428,7 @@ impl<'a> Resolver<'a> {
 
         for &PrivacyError(span, name, binding) in &self.privacy_errors {
             if !reported_spans.insert(span) { continue }
-            if binding.is_extern_crate() {
-                // Warn when using an inaccessible extern crate.
-                let node_id = match binding.kind {
-                    NameBindingKind::Import { directive, .. } => directive.id,
-                    _ => unreachable!(),
-                };
-                let msg = format!("extern crate `{}` is private", name);
-                self.session.add_lint(lint::builtin::INACCESSIBLE_EXTERN_CRATE, node_id, span, msg);
-            } else {
-                let def = binding.def();
-                self.session.span_err(span, &format!("{} `{}` is private", def.kind_name(), name));
-            }
+            self.session.span_err(span, &format!("{} `{}` is private", binding.descr(), name));
         }
     }
 

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -54,6 +54,7 @@ There are some shortcomings in this design:
 */
 
 use astconv::{AstConv, Bounds};
+use lint;
 use constrained_type_params as ctp;
 use middle::lang_items::SizedTraitLangItem;
 use middle::const_val::ConstVal;
@@ -896,8 +897,12 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
         if !allow_defaults && p.default.is_some() {
             if !tcx.sess.features.borrow().default_type_parameter_fallback {
-                tcx.sess.span_err(p.span, "defaults for type parameters are only allowed in \
-                                           `struct`, `enum`, `type`, or `trait` definitions.");
+                tcx.sess.add_lint(
+                    lint::builtin::INVALID_TYPE_PARAM_DEFAULT,
+                    p.id,
+                    p.span,
+                    format!("defaults for type parameters are only allowed in `struct`, \
+                             `enum`, `type`, or `trait` definitions."));
             }
         }
 

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -54,7 +54,6 @@ There are some shortcomings in this design:
 */
 
 use astconv::{AstConv, Bounds};
-use lint;
 use constrained_type_params as ctp;
 use middle::lang_items::SizedTraitLangItem;
 use middle::const_val::ConstVal;
@@ -897,12 +896,8 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
         if !allow_defaults && p.default.is_some() {
             if !tcx.sess.features.borrow().default_type_parameter_fallback {
-                tcx.sess.add_lint(
-                    lint::builtin::INVALID_TYPE_PARAM_DEFAULT,
-                    p.id,
-                    p.span,
-                    format!("defaults for type parameters are only allowed in `struct`, \
-                             `enum`, `type`, or `trait` definitions."));
+                tcx.sess.span_err(p.span, "defaults for type parameters are only allowed in \
+                                           `struct`, `enum`, `type`, or `trait` definitions.");
             }
         }
 

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -231,20 +231,12 @@ fn mk_reexport_mod(cx: &mut TestCtxt,
                    -> (P<ast::Item>, Ident) {
     let super_ = Ident::from_str("super");
 
-    // Generate imports with `#[allow(private_in_public)]` to work around issue #36768.
-    let allow_private_in_public = cx.ext_cx.attribute(DUMMY_SP, cx.ext_cx.meta_list(
-        DUMMY_SP,
-        Symbol::intern("allow"),
-        vec![cx.ext_cx.meta_list_item_word(DUMMY_SP, Symbol::intern("private_in_public"))],
-    ));
     let items = tests.into_iter().map(|r| {
         cx.ext_cx.item_use_simple(DUMMY_SP, ast::Visibility::Public,
                                   cx.ext_cx.path(DUMMY_SP, vec![super_, r]))
-            .map_attrs(|_| vec![allow_private_in_public.clone()])
     }).chain(tested_submods.into_iter().map(|(r, sym)| {
         let path = cx.ext_cx.path(DUMMY_SP, vec![super_, r, sym]);
         cx.ext_cx.item_use_simple_(DUMMY_SP, ast::Visibility::Public, r, path)
-            .map_attrs(|_| vec![allow_private_in_public.clone()])
     })).collect();
 
     let reexport_mod = ast::Mod {

--- a/src/test/compile-fail/associated-types/bound-lifetime-constrained.rs
+++ b/src/test/compile-fail/associated-types/bound-lifetime-constrained.rs
@@ -12,7 +12,6 @@
 
 #![allow(dead_code)]
 #![feature(rustc_attrs)]
-#![allow(hr_lifetime_in_assoc_type)]
 
 trait Foo<'a> {
     type Item;

--- a/src/test/compile-fail/associated-types/bound-lifetime-in-return-only.rs
+++ b/src/test/compile-fail/associated-types/bound-lifetime-in-return-only.rs
@@ -13,7 +13,6 @@
 #![allow(dead_code)]
 #![feature(rustc_attrs)]
 #![feature(unboxed_closures)]
-#![deny(hr_lifetime_in_assoc_type)]
 
 trait Foo {
     type Item;

--- a/src/test/compile-fail/extern-crate-visibility.rs
+++ b/src/test/compile-fail/extern-crate-visibility.rs
@@ -8,21 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(unused)]
-
 mod foo {
     extern crate core;
 }
 
 // Check that private crates can be used from outside their modules, albeit with warnings
-use foo::core; //~ WARN extern crate `core` is private
-//~^ WARN this was previously accepted by the compiler but is being phased out
 use foo::core::cell; //~ ERROR extern crate `core` is private
-//~^ WARN this was previously accepted by the compiler but is being phased out
 
 fn f() {
     foo::core::cell::Cell::new(0); //~ ERROR extern crate `core` is private
-    //~^ WARN this was previously accepted by the compiler but is being phased out
 
     use foo::*;
     mod core {} // Check that private crates are not glob imported

--- a/src/test/compile-fail/future-incompatible-lint-group.rs
+++ b/src/test/compile-fail/future-incompatible-lint-group.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,22 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(warnings)]
+#![deny(future_incompatible)]
 
-mod foo {
-    pub mod bar {
-        pub struct S {
-            pub(in foo) x: i32,
-        }
-    }
-
-    fn f() {
-        use foo::bar::S;
-        S { x: 0 }; // ok
-    }
+trait Tr {
+    fn f(u8) {} //~ ERROR use of deprecated anonymous parameter
+                //~^ WARN this was previously accepted
 }
 
-fn main() {
-    use foo::bar::S;
-    S { x: 0 }; //~ ERROR private
-}
+fn main() {}

--- a/src/test/compile-fail/generic-impl-less-params-with-defaults.rs
+++ b/src/test/compile-fail/generic-impl-less-params-with-defaults.rs
@@ -13,7 +13,7 @@ use std::marker;
 struct Foo<A, B, C = (A, B)>(
     marker::PhantomData<(A,B,C)>);
 
-impl<A, B, C = (A, B)> Foo<A, B, C> {
+impl<A, B, C> Foo<A, B, C> {
     fn new() -> Foo<A, B, C> {Foo(marker::PhantomData)}
 }
 

--- a/src/test/compile-fail/generic-impl-more-params-with-defaults.rs
+++ b/src/test/compile-fail/generic-impl-more-params-with-defaults.rs
@@ -15,7 +15,7 @@ struct Heap;
 struct Vec<T, A = Heap>(
     marker::PhantomData<(T,A)>);
 
-impl<T, A = Heap> Vec<T, A> {
+impl<T, A> Vec<T, A> {
     fn new() -> Vec<T, A> {Vec(marker::PhantomData)}
 }
 

--- a/src/test/compile-fail/issue-1920-1.rs
+++ b/src/test/compile-fail/issue-1920-1.rs
@@ -11,7 +11,7 @@
 //! Test that absolute path names are correct when a crate is not linked into the root namespace
 
 mod foo {
-    extern crate core;
+    pub extern crate core;
 }
 
 fn assert_clone<T>() where T : Clone { }

--- a/src/test/compile-fail/issue-1920-3.rs
+++ b/src/test/compile-fail/issue-1920-3.rs
@@ -11,7 +11,7 @@
 //! Test that when a crate is linked multiple times that the shortest absolute path name is used
 
 mod foo {
-    extern crate core;
+    pub extern crate core;
 }
 
 extern crate core;

--- a/src/test/compile-fail/issue-6804.rs
+++ b/src/test/compile-fail/issue-6804.rs
@@ -19,13 +19,11 @@ fn main() {
     let x = NAN;
     match x {
         NAN => {}, //~ ERROR floating point constants cannot be used
-                   //~| WARNING hard error
         _ => {},
     };
 
     match [x, 1.0] {
         [NAN, _] => {}, //~ ERROR floating point constants cannot be used
-                        //~| WARNING hard error
         _ => {},
     };
 }

--- a/src/test/compile-fail/lifetime-underscore.rs
+++ b/src/test/compile-fail/lifetime-underscore.rs
@@ -9,17 +9,13 @@
 // except according to those terms.
 
 fn _f<'_>() //~ ERROR invalid lifetime name `'_`
-//~^ WARN this was previously accepted
     -> &'_ u8 //~ ERROR invalid lifetime name `'_`
-    //~^ WARN this was previously accepted
 {
     panic!();
 }
 
 fn main() {
     '_: loop { //~ ERROR invalid label name `'_`
-    //~^ WARN this was previously accepted
         break '_ //~ ERROR invalid label name `'_`
-        //~^ WARN this was previously accepted
     }
 }

--- a/src/test/compile-fail/match-argm-statics-2.rs
+++ b/src/test/compile-fail/match-argm-statics-2.rs
@@ -10,8 +10,10 @@
 
 use self::Direction::{North, East, South, West};
 
+#[derive(PartialEq, Eq)]
 struct NewBool(bool);
 
+#[derive(PartialEq, Eq)]
 enum Direction {
     North,
     East,

--- a/src/test/compile-fail/privacy/restricted/test.rs
+++ b/src/test/compile-fail/privacy/restricted/test.rs
@@ -10,7 +10,6 @@
 
 // aux-build:pub_restricted.rs
 
-#![deny(private_in_public)]
 #![allow(warnings)]
 extern crate pub_restricted;
 

--- a/src/test/compile-fail/private-in-public-lint.rs
+++ b/src/test/compile-fail/private-in-public-lint.rs
@@ -18,8 +18,6 @@ mod m1 {
 }
 
 mod m2 {
-    #![deny(future_incompatible)]
-
     pub struct Pub;
     struct Priv;
 

--- a/src/test/compile-fail/private-variant-reexport.rs
+++ b/src/test/compile-fail/private-variant-reexport.rs
@@ -8,31 +8,20 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![deny(private_in_public)]
-#![allow(dead_code)]
-
-extern crate core;
-pub use core as reexported_core; //~ ERROR extern crate `core` is private, and cannot be reexported
-//~^ WARNING hard error
-
 mod m1 {
     pub use ::E::V; //~ ERROR variant `V` is private, and cannot be reexported
-    //~^ WARNING hard error
 }
 
 mod m2 {
     pub use ::E::{V}; //~ ERROR variant `V` is private, and cannot be reexported
-    //~^ WARNING hard error
 }
 
 mod m3 {
     pub use ::E::V::{self}; //~ ERROR variant `V` is private, and cannot be reexported
-    //~^ WARNING hard error
 }
 
 mod m4 {
     pub use ::E::*; //~ ERROR variant `V` is private, and cannot be reexported
-    //~^ WARNING hard error
 }
 
 enum E { V }

--- a/src/test/compile-fail/pub-reexport-priv-extern-crate.rs
+++ b/src/test/compile-fail/pub-reexport-priv-extern-crate.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,18 +8,24 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(private_in_public)]
+#![allow(unused)]
 
-mod foo {
+extern crate core;
+pub use core as reexported_core; //~ ERROR `core` is private, and cannot be reexported
+
+mod foo1 {
+    extern crate core;
+}
+
+mod foo2 {
+    use foo1::core; //~ ERROR `core` is private, and cannot be reexported
     pub mod bar {
         extern crate core;
     }
 }
 
 mod baz {
-    pub use foo::bar::core;
+    pub use foo2::bar::core; //~ ERROR `core` is private, and cannot be reexported
 }
 
-fn main() {
-    baz::core::cell::Cell::new(0u32);
-}
+fn main() {}

--- a/src/test/compile-fail/pub-reexport-priv-extern-crate.rs
+++ b/src/test/compile-fail/pub-reexport-priv-extern-crate.rs
@@ -9,9 +9,11 @@
 // except according to those terms.
 
 #![allow(unused)]
+#![deny(private_in_public)]
 
 extern crate core;
 pub use core as reexported_core; //~ ERROR `core` is private, and cannot be reexported
+                                 //~^ WARN this was previously accepted
 
 mod foo1 {
     extern crate core;
@@ -19,6 +21,7 @@ mod foo1 {
 
 mod foo2 {
     use foo1::core; //~ ERROR `core` is private, and cannot be reexported
+                    //~^ WARN this was previously accepted
     pub mod bar {
         extern crate core;
     }
@@ -26,6 +29,7 @@ mod foo2 {
 
 mod baz {
     pub use foo2::bar::core; //~ ERROR `core` is private, and cannot be reexported
+                             //~^ WARN this was previously accepted
 }
 
 fn main() {}

--- a/src/test/compile-fail/resolve-self-in-impl.rs
+++ b/src/test/compile-fail/resolve-self-in-impl.rs
@@ -17,7 +17,6 @@ trait Tr<T = u8> {
 
 impl Tr<Self> for S {} // OK
 impl<T: Tr<Self>> Tr<T> for S {} // OK
-impl<T = Self> Tr<T> for S {} // OK
 impl Tr for S where Self: Copy {} // OK
 impl Tr for S where S<Self>: Copy {} // OK
 impl Tr for S where Self::A: Copy {} // OK

--- a/src/test/compile-fail/rfc1445/feature-gate.rs
+++ b/src/test/compile-fail/rfc1445/feature-gate.rs
@@ -16,8 +16,7 @@
 
 // gate-test-structural_match
 
-#![allow(dead_code)]
-#![deny(future_incompatible)]
+#![allow(unused)]
 #![feature(rustc_attrs)]
 #![cfg_attr(with_gate, feature(structural_match))]
 

--- a/src/test/compile-fail/rfc1445/match-forbidden-without-eq.rs
+++ b/src/test/compile-fail/rfc1445/match-forbidden-without-eq.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(dead_code)]
-#![deny(future_incompatible)]
-
 use std::f32;
 
 #[derive(PartialEq)]
@@ -25,7 +22,6 @@ fn main() {
     match y {
         FOO => { }
         //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
-        //~| WARNING will become a hard error
         _ => { }
     }
 
@@ -33,7 +29,6 @@ fn main() {
     match x {
         f32::INFINITY => { }
         //~^ ERROR floating point constants cannot be used in patterns
-        //~| WARNING will become a hard error
         _ => { }
     }
 }

--- a/src/test/compile-fail/rfc1445/match-requires-both-partialeq-and-eq.rs
+++ b/src/test/compile-fail/rfc1445/match-requires-both-partialeq-and-eq.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(dead_code)]
-#![deny(future_incompatible)]
-
 #[derive(Eq)]
 struct Foo {
     x: u32
@@ -29,7 +26,6 @@ fn main() {
     match y {
         FOO => { }
         //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
-        //~| WARNING will become a hard error
         _ => { }
     }
 }

--- a/src/test/compile-fail/type-parameter-invalid-lint.rs
+++ b/src/test/compile-fail/type-parameter-invalid-lint.rs
@@ -10,11 +10,16 @@
 
 // gate-test-default_type_parameter_fallback
 
+#![deny(invalid_type_param_default)]
+#![allow(unused)]
+
 fn avg<T=i32>(_: T) {}
 //~^ ERROR defaults for type parameters are only allowed
+//~| WARN this was previously accepted
 
 struct S<T>(T);
 impl<T=i32> S<T> {}
 //~^ ERROR defaults for type parameters are only allowed
+//~| WARN this was previously accepted
 
 fn main() {}

--- a/src/test/compile-fail/type-parameter-invalid-lint.rs
+++ b/src/test/compile-fail/type-parameter-invalid-lint.rs
@@ -10,16 +10,11 @@
 
 // gate-test-default_type_parameter_fallback
 
-#![deny(future_incompatible)]
-#![allow(dead_code)]
-
 fn avg<T=i32>(_: T) {}
 //~^ ERROR defaults for type parameters are only allowed
-//~| WARNING hard error
 
 struct S<T>(T);
 impl<T=i32> S<T> {}
 //~^ ERROR defaults for type parameters are only allowed
-//~| WARNING hard error
 
 fn main() {}

--- a/src/test/compile-fail/use-super-global-path.rs
+++ b/src/test/compile-fail/use-super-global-path.rs
@@ -15,11 +15,9 @@ struct Z;
 
 mod foo {
     use ::super::{S, Z}; //~ ERROR global paths cannot start with `super`
-    //~^ WARN this was previously accepted by the compiler but is being phased out
 
     pub fn g() {
         use ::super::main; //~ ERROR global paths cannot start with `super`
-        //~^ WARN this was previously accepted by the compiler but is being phased out
         main();
     }
 }


### PR DESCRIPTION
It's been almost 7 months since https://github.com/rust-lang/rust/pull/36894 was merged, so it's time to take the next step.

[breaking-change], needs crater run.

PRs/issues submitted to affected crates:
https://github.com/alexcrichton/ctest/pull/17
https://github.com/Sean1708/rusty-cheddar/pull/55
https://github.com/m-r-r/helianto/pull/3
https://github.com/azdle/virgil/pull/1
https://github.com/rust-locale/rust-locale/issues/24
https://github.com/mneumann/acyclic-network-rs/pull/1
https://github.com/reem/rust-typemap/pull/38

cc https://internals.rust-lang.org/t/moving-forward-on-forward-compatibility-lints/4204
cc https://github.com/rust-lang/rust/issues/34537 https://github.com/rust-lang/rust/issues/36887
Closes https://github.com/rust-lang/rust/issues/36886
Closes https://github.com/rust-lang/rust/issues/36888
Closes https://github.com/rust-lang/rust/issues/36890
Closes https://github.com/rust-lang/rust/issues/36891
Closes https://github.com/rust-lang/rust/issues/36892
r? @nikomatsakis 