### PR TITLE
Fix building std without backtrace feature, which was broken in ca8b754

### DIFF
--- a/src/libstd/rt.rs
+++ b/src/libstd/rt.rs
@@ -35,6 +35,8 @@ fn lang_start(main: fn(), argc: isize, argv: *const *const u8) -> isize {
     use sys_common;
     use sys_common::thread_info;
     use thread::Thread;
+    #[cfg(not(feature = "backtrace"))]
+    use mem;
 
     sys::init();
 
@@ -53,9 +55,12 @@ fn lang_start(main: fn(), argc: isize, argv: *const *const u8) -> isize {
         sys::args::init(argc, argv);
 
         // Let's run some code!
+        #[cfg(feature = "backtrace")]
         let res = panic::catch_unwind(|| {
             ::sys_common::backtrace::__rust_begin_short_backtrace(main)
         });
+        #[cfg(not(feature = "backtrace"))]
+        let res = panic::catch_unwind(mem::transmute::<_, fn()>(main));
         sys_common::cleanup();
         res.is_err()
     };

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -359,9 +359,12 @@ impl Builder {
             }
             unsafe {
                 thread_info::set(imp::guard::current(), their_thread);
+                #[cfg(feature = "backtrace")]
                 let try_result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
                     ::sys_common::backtrace::__rust_begin_short_backtrace(f)
                 }));
+                #[cfg(not(feature = "backtrace"))]
+                let try_result = panic::catch_unwind(panic::AssertUnwindSafe(f));
                 *their_packet.get() = Some(try_result);
             }
         };


### PR DESCRIPTION
Fixes #42139