### PR TITLE
make ui test output patch compatible #41948

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2415,11 +2415,11 @@ actual:\n\
         println!("expected {}:\n{}\n", kind, expected);
         println!("diff of {}:\n", kind);
 
-        for diff in diff::lines(actual, expected) {
+        for diff in diff::lines(expected, actual) {
             match diff {
-                diff::Result::Left(l)    => println!("+{}", l),
+                diff::Result::Left(l)    => println!("-{}", l),
                 diff::Result::Both(l, _) => println!(" {}", l),
-                diff::Result::Right(r)   => println!("-{}", r),
+                diff::Result::Right(r)   => println!("+{}", r),
             }
         }
 


### PR DESCRIPTION
Hello!

Previously with #41474 I've changed the internals of UI test output comparison mechanism.

That change didn't change the diff format that we were producing but we needed to improve it anyway.

This makes unified diff lines a little bit more `patch` compatible.

Also I tried to introduce a unit test to check this but couldn't decide which of the following to implement:

1. Should I replace `println` macros with `Writer`s? And access the produced output within a test?
2. Should I add an external test (something like `src/test/run-pass/command-exec.rs`)
3. There are crates that capture `stdout`. Are they safe to use here? (I don't think so)

Thanks!

cc @nikomatsakis 