### PR TITLE
Remove 'static bound in assoc const test.

### DIFF
--- a/src/test/run-pass/associated-const-outer-ty-refs.rs
+++ b/src/test/run-pass/associated-const-outer-ty-refs.rs
@@ -13,8 +13,7 @@ trait Lattice {
     const BOTTOM: Self;
 }
 
-// FIXME(#33573): this should work without the 'static lifetime bound.
-impl<T: 'static> Lattice for Option<T> {
+impl<T> Lattice for Option<T> {
     const BOTTOM: Option<T> = None;
 }
 


### PR DESCRIPTION
Types do not have to be `'static` to be referenced in
associated consts.

Fixes #33573.