### PR TITLE
Mention Vec::into_boxed_slice in documentation of [T]::into_vec

### DIFF
--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -1411,9 +1411,7 @@ impl<T> [T] {
     /// Converts `self` into a vector without clones or allocation.
     ///
     /// The resulting vector can be converted back into a box via
-    /// the [`into_boxed_slice`] method.
-    ///
-    /// [`into_boxed_slice`]: vec/struct.Vec.html#method.into_boxed_slice
+    /// `Vec<T>`'s `into_boxed_slice` method.
     ///
     /// # Examples
     ///

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -1410,6 +1410,11 @@ impl<T> [T] {
 
     /// Converts `self` into a vector without clones or allocation.
     ///
+    /// The resulting vector can be converted back into a box via
+    /// the [`into_boxed_slice`] method.
+    ///
+    /// [`into_boxed_slice`]: vec/struct.Vec.html#method.into_boxed_slice
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
This is a documentation fix.

`Vec::into_boxed_slice` and `[T]::into_vec` are inverses, so it makes sense to mention the other in their respective documentation for visibility. `Vec::into_boxed_slice` already mentions `[T]::into_vec`, but not the other way around until now.

Tagging @steveklabnik per his request.