### PR TITLE
Use simple io::Error for &[u8] Read and Write impl

### DIFF
--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -208,6 +208,7 @@ impl ErrorKind {
 /// the heap (for normal construction via Error::new) is too costly.
 #[stable(feature = "io_error_from_errorkind", since = "1.14.0")]
 impl From<ErrorKind> for Error {
+    #[inline]
     fn from(kind: ErrorKind) -> Error {
         Error {
             repr: Repr::Simple(kind)

--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use cmp;
-use io::{self, SeekFrom, Read, Write, Seek, BufRead, Error, ErrorKind};
+use io::{self, SeekFrom, Read, Write, Seek, BufRead, ErrorKind};
 use fmt;
 use mem;
 
@@ -174,8 +174,7 @@ impl<'a> Read for &'a [u8] {
     #[inline]
     fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
         if buf.len() > self.len() {
-            return Err(Error::new(ErrorKind::UnexpectedEof,
-                                  "failed to fill whole buffer"));
+            return Err(ErrorKind::UnexpectedEof.into());
         }
         let (a, b) = self.split_at(buf.len());
 
@@ -223,7 +222,7 @@ impl<'a> Write for &'a mut [u8] {
         if self.write(data)? == data.len() {
             Ok(())
         } else {
-            Err(Error::new(ErrorKind::WriteZero, "failed to write whole buffer"))
+            Err(ErrorKind::WriteZero.into())
         }
     }
 


### PR DESCRIPTION
I'm not sure this change is gonna fly because of the worse error message (see end of post), but here's the case.

I was checking https://www.reddit.com/r/rust/comments/6cjs7u/analyzing_the_performance_of_a_hash/ and I pinpointed the cause of slowness to the io::read_exact implementation that byteorder read_u32 calls.
It turns out that the optimizer isn't smart enough to avoid the creation of the result altogether and creates a relatively costly io::Error just to discard it after (edit: reason being that creating an io::Error involves a function call and the optimizer can't blindly remove that side effect).

I played a bit with the code and if the code is simple enough (simple enum creation after the inlines) it optimizes out just as well as the version with the branch+unwrap().

Playground link for before: http://play.integer32.com/?gist=04569213693e4862ef1e13a19e408cd5
Playground link for after: http://play.integer32.com/?gist=3755fc64d339c81d8cb01ea41cc0862b

code
```
fn write(&mut self, mut bytes: &[u8]) {
    while let Ok(n) = bytes.read_u32::<NE>() {
        self.write_u32(n);
    }

    for byte in bytes {
        let i = *byte;
        self.add_to_hash(i as usize);
    }
}
```

before

```
cmpq    $4, %rbx
jb  .LBB0_6
....
.LBB0_6:
leaq    str.0(%rip), %rdi
movl    $27, %esi
callq   _ZN3std5error205_$LT$impl$u20$core..convert..From$LT$$RF$$u27$b$u20$str$GT$$u20$for$u20$alloc..boxed..Box$LT$std..error..Error$u20$$u2b$$u20$core..marker..Send$u20$$u2b$$u20$core..marker..Sync$u20$$u2b$$u20$$u27$a$GT$$GT$4from17hf12a25e4e8752742E@PLT
movq    %rdx, %rcx
leaq    8(%rsp), %rdi
movl    $17, %esi
movq    %rax, %rdx
callq   _ZN3std2io5error5Error4_new17h3674736498de977fE@PLT
cmpb    $2, 8(%rsp)
jb  .LBB0_11
```


after

```
cmpq	$4, %rsi
jb	.LBB0_6
...
.LBB0_6:
testq	%rsi, %rsi
je	.LBB0_7
```

Error message changes:

```
println!("display -> {}", read_u32(&mut bytes).unwrap_err());
println!("debug -> {:?}", read_u32(&mut bytes).unwrap_err());

before:
display -> failed to write whole buffer
debug -> Error { repr: Custom(Custom { kind: WriteZero, error: StringError("failed to write whole buffer") }) }

after:
display -> write zero
debug -> Error { repr: Kind(WriteZero) }

```