### PR TITLE
Give step_trait a distinct tracking issue from step_by

### DIFF
--- a/src/doc/unstable-book/src/library-features/step-trait.md
+++ b/src/doc/unstable-book/src/library-features/step-trait.md
@@ -1,7 +1,7 @@
 # `step_trait`
 
-The tracking issue for this feature is: [#27741]
+The tracking issue for this feature is: [#42168]
 
-[#27741]: https://github.com/rust-lang/rust/issues/27741
+[#42168]: https://github.com/rust-lang/rust/issues/42168
 
 ------------------------

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -309,7 +309,7 @@ pub use self::iterator::Iterator;
 
 #[unstable(feature = "step_trait",
            reason = "likely to be replaced by finer-grained traits",
-           issue = "27741")]
+           issue = "42168")]
 pub use self::range::Step;
 #[unstable(feature = "step_by", reason = "recent addition",
            issue = "27741")]

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -20,7 +20,7 @@ use super::{FusedIterator, TrustedLen};
 /// two `Step` objects.
 #[unstable(feature = "step_trait",
            reason = "likely to be replaced by finer-grained traits",
-           issue = "27741")]
+           issue = "42168")]
 pub trait Step: PartialOrd + Sized {
     /// Steps `self` if possible.
     fn step(&self, by: &Self) -> Option<Self>;
@@ -55,7 +55,7 @@ macro_rules! step_impl_unsigned {
     ($($t:ty)*) => ($(
         #[unstable(feature = "step_trait",
                    reason = "likely to be replaced by finer-grained traits",
-                   issue = "27741")]
+                   issue = "42168")]
         impl Step for $t {
             #[inline]
             fn step(&self, by: &$t) -> Option<$t> {
@@ -115,7 +115,7 @@ macro_rules! step_impl_signed {
     ($($t:ty)*) => ($(
         #[unstable(feature = "step_trait",
                    reason = "likely to be replaced by finer-grained traits",
-                   issue = "27741")]
+                   issue = "42168")]
         impl Step for $t {
             #[inline]
             fn step(&self, by: &$t) -> Option<$t> {
@@ -187,7 +187,7 @@ macro_rules! step_impl_no_between {
     ($($t:ty)*) => ($(
         #[unstable(feature = "step_trait",
                    reason = "likely to be replaced by finer-grained traits",
-                   issue = "27741")]
+                   issue = "42168")]
         impl Step for $t {
             #[inline]
             fn step(&self, by: &$t) -> Option<$t> {


### PR DESCRIPTION
iterator_step_by has decoupled their futures, so the tracking issue should split.

Old issue: https://github.com/rust-lang/rust/issues/27741
New issue: https://github.com/rust-lang/rust/issues/42168

r? @alexcrichton (another follow-up to closed PR https://github.com/rust-lang/rust/pull/42110#issuecomment-303176049)