### PR TITLE
incr.comp.: Track expanded spans instead of FileMaps.

### DIFF
--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -176,7 +176,6 @@ pub enum DepNode<D: Clone + Debug> {
     IsMirAvailable(D),
     ItemAttrs(D),
     FnArgNames(D),
-    FileMap(D, Arc<String>),
 }
 
 impl<D: Clone + Debug> DepNode<D> {
@@ -307,7 +306,6 @@ impl<D: Clone + Debug> DepNode<D> {
             ConstIsRvaluePromotableToStatic(ref d) => op(d).map(ConstIsRvaluePromotableToStatic),
             IsMirAvailable(ref d) => op(d).map(IsMirAvailable),
             GlobalMetaData(ref d, kind) => op(d).map(|d| GlobalMetaData(d, kind)),
-            FileMap(ref d, ref file_name) => op(d).map(|d| FileMap(d, file_name.clone())),
         }
     }
 }

--- a/src/librustc/ich/hcx.rs
+++ b/src/librustc/ich/hcx.rs
@@ -74,6 +74,11 @@ impl<'a, 'tcx: 'a> StableHashingContext<'a, 'tcx> {
         }
     }
 
+    pub fn force_span_hashing(mut self) -> Self {
+        self.hash_spans = true;
+        self
+    }
+
     #[inline]
     pub fn while_hashing_hir_bodies<F: FnOnce(&mut Self)>(&mut self,
                                                           hash_bodies: bool,

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -11,8 +11,9 @@
 pub use self::code_stats::{CodeStats, DataTypeKind, FieldInfo};
 pub use self::code_stats::{SizeKind, TypeSizeInfo, VariantInfo};
 
-use dep_graph::{DepGraph, DepNode};
-use hir::def_id::{DefId, CrateNum, DefIndex, CRATE_DEF_INDEX};
+use dep_graph::DepGraph;
+use hir::def_id::{CrateNum, DefIndex};
+
 use lint;
 use middle::cstore::CrateStore;
 use middle::dependency_format;
@@ -32,7 +33,7 @@ use syntax::parse::ParseSess;
 use syntax::symbol::Symbol;
 use syntax::{ast, codemap};
 use syntax::feature_gate::AttributeType;
-use syntax_pos::{Span, MultiSpan, FileMap};
+use syntax_pos::{Span, MultiSpan};
 
 use rustc_back::{LinkerFlavor, PanicStrategy};
 use rustc_back::target::Target;
@@ -46,7 +47,6 @@ use std::io::Write;
 use std::rc::Rc;
 use std::fmt;
 use std::time::Duration;
-use std::sync::Arc;
 
 mod code_stats;
 pub mod config;
@@ -625,21 +625,6 @@ pub fn build_session_(sopts: config::Options,
         }
     };
     let target_cfg = config::build_target_config(&sopts, &span_diagnostic);
-
-    // Hook up the codemap with a callback that allows it to register FileMap
-    // accesses with the dependency graph.
-    let cm_depgraph = dep_graph.clone();
-    let codemap_dep_tracking_callback = Box::new(move |filemap: &FileMap| {
-        let def_id = DefId {
-            krate: CrateNum::from_u32(filemap.crate_of_origin),
-            index: CRATE_DEF_INDEX,
-        };
-        let name = Arc::new(filemap.name.clone());
-        let dep_node = DepNode::FileMap(def_id, name);
-
-        cm_depgraph.read(dep_node);
-    });
-    codemap.set_dep_tracking_callback(codemap_dep_tracking_callback);
 
     let p_s = parse::ParseSess::with_span_handler(span_diagnostic, codemap);
     let default_sysroot = match sopts.maybe_sysroot {

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -103,18 +103,11 @@ impl FileLoader for RealFileLoader {
 //
 
 pub struct CodeMap {
-    // The `files` field should not be visible outside of libsyntax so that we
-    // can do proper dependency tracking.
     pub(super) files: RefCell<Vec<Rc<FileMap>>>,
     file_loader: Box<FileLoader>,
     // This is used to apply the file path remapping as specified via
     // -Zremap-path-prefix to all FileMaps allocated within this CodeMap.
     path_mapping: FilePathMapping,
-    // The CodeMap will invoke this callback whenever a specific FileMap is
-    // accessed. The callback starts out as a no-op but when the dependency
-    // graph becomes available later during the compilation process, it is
-    // be replaced with something that notifies the dep-tracking system.
-    dep_tracking_callback: RefCell<Box<Fn(&FileMap)>>,
 }
 
 impl CodeMap {
@@ -123,7 +116,6 @@ impl CodeMap {
             files: RefCell::new(Vec::new()),
             file_loader: Box::new(RealFileLoader),
             path_mapping: path_mapping,
-            dep_tracking_callback: RefCell::new(Box::new(|_| {})),
         }
     }
 
@@ -134,16 +126,11 @@ impl CodeMap {
             files: RefCell::new(Vec::new()),
             file_loader: file_loader,
             path_mapping: path_mapping,
-            dep_tracking_callback: RefCell::new(Box::new(|_| {})),
         }
     }
 
     pub fn path_mapping(&self) -> &FilePathMapping {
         &self.path_mapping
-    }
-
-    pub fn set_dep_tracking_callback(&self, cb: Box<Fn(&FileMap)>) {
-        *self.dep_tracking_callback.borrow_mut() = cb;
     }
 
     pub fn file_exists(&self, path: &Path) -> bool {
@@ -156,15 +143,6 @@ impl CodeMap {
     }
 
     pub fn files(&self) -> Ref<Vec<Rc<FileMap>>> {
-        let files = self.files.borrow();
-        for file in files.iter() {
-            (self.dep_tracking_callback.borrow())(file);
-        }
-        files
-    }
-
-    /// Only use this if you do your own dependency tracking!
-    pub fn files_untracked(&self) -> Ref<Vec<Rc<FileMap>>> {
         self.files.borrow()
     }
 
@@ -310,8 +288,6 @@ impl CodeMap {
 
         let files = self.files.borrow();
         let f = (*files)[idx].clone();
-
-        (self.dep_tracking_callback.borrow())(&f);
 
         match f.lookup_line(pos) {
             Some(line) => Ok(FileMapAndLine { fm: f, line: line }),
@@ -502,7 +478,6 @@ impl CodeMap {
     pub fn get_filemap(&self, filename: &str) -> Option<Rc<FileMap>> {
         for fm in self.files.borrow().iter() {
             if filename == fm.name {
-               (self.dep_tracking_callback.borrow())(fm);
                 return Some(fm.clone());
             }
         }
@@ -513,7 +488,6 @@ impl CodeMap {
     pub fn lookup_byte_offset(&self, bpos: BytePos) -> FileMapAndBytePos {
         let idx = self.lookup_filemap_idx(bpos);
         let fm = (*self.files.borrow())[idx].clone();
-        (self.dep_tracking_callback.borrow())(&fm);
         let offset = bpos - fm.start_pos;
         FileMapAndBytePos {fm: fm, pos: offset}
     }
@@ -523,8 +497,6 @@ impl CodeMap {
         let idx = self.lookup_filemap_idx(bpos);
         let files = self.files.borrow();
         let map = &(*files)[idx];
-
-        (self.dep_tracking_callback.borrow())(map);
 
         // The number of extra bytes due to multibyte chars in the FileMap
         let mut total_extra_bytes = 0;

--- a/src/test/incremental/rlib_cross_crate/auxiliary/a.rs
+++ b/src/test/incremental/rlib_cross_crate/auxiliary/a.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // no-prefer-dynamic
+// compile-flags: -Z query-dep-graph
 
 #![crate_type="rlib"]
 

--- a/src/test/incremental/type_alias_cross_crate/auxiliary/a.rs
+++ b/src/test/incremental/type_alias_cross_crate/auxiliary/a.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z query-dep-graph
+
 #![crate_type="rlib"]
 
 #[cfg(rpass1)]


### PR DESCRIPTION
This PR removes explicit tracking of FileMaps in response to #42101. The reasoning behind being able to just *not* track access to FileMaps is similar to why we don't track access to the `DefId->DefPath` map:
1. One can only get ahold of a `Span` value by accessing the HIR (for local things) or a `metadata::schema::Entry` (for things from external crates).
2. For both of these things we compute a hash that incorporates the *expanded spans*, that is, what we hash is in the (FileMap independent) format `filename:line:col`. 
3. Consequently, everything that emits a span should already be tracked via its dependency to something that has the span included in its hash and changes would be detected via that hash.

One caveat here is that we have to be conservative when exporting things in metadata. A crate can be built without debuginfo and would thus by default not incorporate most spans into the metadata hashes. However, a downstream crate can make an inline copy of things in the upstream crate and span changes in the upstream crate would then go undetected, even if the downstream uses them (e.g. by emitting debuginfo for an inlined function). For this reason, we always incorporate spans into metadata hashes for now (there might be more efficient ways to handle this safely when red-green tracking is implemented).

r? @nikomatsakis 