### PR TITLE
Remove some needless // gate-test- comments

### DIFF
--- a/src/test/compile-fail-fulldeps/proc-macro/feature-gate-proc_macro.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/feature-gate-proc_macro.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 // aux-build:attr_proc_macro.rs
-// gate-test-proc_macro
 #![feature(use_extern_macros)]
 
 extern crate attr_proc_macro;

--- a/src/test/compile-fail/feature-gate-global_asm.rs
+++ b/src/test/compile-fail/feature-gate-global_asm.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// gate-test-global_asm
-
 global_asm!(""); //~ ERROR `global_asm!` is not stable
 
 fn main() {}


### PR DESCRIPTION
Also, add detection to treat such comments as tidy errors.
We also remove the found_lib_feature code because it
was just repeating the found_feature code. Originally it
was intended to allow for gate-test lines for
lib features, but apparently nobody missed it.