### PR TITLE
incr.comp.: Remove DepGraph::write() and its callers

### DIFF
--- a/src/librustc/dep_graph/dep_tracking_map.rs
+++ b/src/librustc/dep_graph/dep_tracking_map.rs
@@ -11,7 +11,6 @@
 use hir::def_id::DefId;
 use rustc_data_structures::fx::FxHashMap;
 use std::cell::RefCell;
-use std::collections::hash_map::Entry;
 use std::ops::Index;
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -50,27 +49,9 @@ impl<M: DepTrackingMapConfig> DepTrackingMap<M> {
         self.graph.read(dep_node);
     }
 
-    /// Registers a (synthetic) write to the key `k`. Usually this is
-    /// invoked automatically by `insert`.
-    fn write(&self, k: &M::Key) {
-        let dep_node = M::to_dep_node(k);
-        self.graph.write(dep_node);
-    }
-
     pub fn get(&self, k: &M::Key) -> Option<&M::Value> {
         self.read(k);
         self.map.get(k)
-    }
-
-    pub fn insert(&mut self, k: M::Key, v: M::Value) {
-        self.write(&k);
-        let old_value = self.map.insert(k, v);
-        assert!(old_value.is_none());
-    }
-
-    pub fn entry(&mut self, k: M::Key) -> Entry<M::Key, M::Value> {
-        self.write(&k);
-        self.map.entry(k)
     }
 
     pub fn contains_key(&self, k: &M::Key) -> bool {

--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -117,12 +117,6 @@ impl DepGraph {
         }
     }
 
-    pub fn write(&self, v: DepNode<DefId>) {
-        if self.data.thread.is_enqueue_enabled() {
-            self.data.thread.enqueue(DepMessage::Write(v));
-        }
-    }
-
     /// Indicates that a previous work product exists for `v`. This is
     /// invoked during initial start-up based on what nodes are clean
     /// (and what files exist in the incr. directory).

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -689,7 +689,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             export_map: resolutions.export_map,
             fulfilled_predicates: RefCell::new(fulfilled_predicates),
             hir: hir,
-            maps: maps::Maps::new(dep_graph, providers),
+            maps: maps::Maps::new(providers),
             mir_passes,
             freevars: RefCell::new(resolutions.freevars),
             maybe_unused_trait_imports: resolutions.maybe_unused_trait_imports,


### PR DESCRIPTION
After months of yak shaving, we are finally there `:)`

The existence of `DepGraph::write()` was one of the two main ways for introducing cycles into the dep-graph -- something we need to avoid in the future. The other way, re-opening nodes to add more edges, is next on the list. 

r? @nikomatsakis 