### PR TITLE
fix broken link to nomicon in Unsize docs

### DIFF
--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -120,7 +120,7 @@ pub trait Sized {
 /// [coerceunsized]: ../ops/trait.CoerceUnsized.html
 /// [rc]: ../../std/rc/struct.Rc.html
 /// [RFC982]: https://github.com/rust-lang/rfcs/blob/master/text/0982-dst-coercion.md
-
+/// [nomicon-coerce]: ../../nomicon/coercions.html
 #[unstable(feature = "unsize", issue = "27732")]
 #[lang="unsize"]
 pub trait Unsize<T: ?Sized> {


### PR DESCRIPTION
Add a missing link that is currently broken in the docs (see the last sentence of https://doc.rust-lang.org/std/marker/trait.Unsize.html)