### PR TITLE
Explain why a closure is `FnOnce` in closure errors.

### DIFF
--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -1682,7 +1682,11 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     {
         if let InferTables::InProgress(tables) = self.tables {
             if let Some(id) = self.tcx.hir.as_local_node_id(def_id) {
-                return tables.borrow().closure_kinds.get(&id).cloned();
+                return tables.borrow()
+                             .closure_kinds
+                             .get(&id)
+                             .cloned()
+                             .map(|(kind, _)| kind);
             }
         }
 

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -58,6 +58,7 @@ use syntax::abi;
 use syntax::ast::{self, Name, NodeId};
 use syntax::attr;
 use syntax::symbol::{Symbol, keywords};
+use syntax_pos::Span;
 
 use hir;
 
@@ -229,8 +230,9 @@ pub struct TypeckTables<'tcx> {
     /// Records the type of each closure.
     pub closure_tys: NodeMap<ty::PolyFnSig<'tcx>>,
 
-    /// Records the kind of each closure.
-    pub closure_kinds: NodeMap<ty::ClosureKind>,
+    /// Records the kind of each closure and the span of the variable that
+    /// cause the closure to be this kind.
+    pub closure_kinds: NodeMap<(ty::ClosureKind, Option<Span>)>,
 
     /// For each fn, records the "liberated" types of its arguments
     /// and return type. Liberated means that all bound regions

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -230,9 +230,9 @@ pub struct TypeckTables<'tcx> {
     /// Records the type of each closure.
     pub closure_tys: NodeMap<ty::PolyFnSig<'tcx>>,
 
-    /// Records the kind of each closure and the span of the variable that
-    /// cause the closure to be this kind.
-    pub closure_kinds: NodeMap<(ty::ClosureKind, Option<Span>)>,
+    /// Records the kind of each closure and the span and name of the variable
+    /// that caused the closure to be this kind.
+    pub closure_kinds: NodeMap<(ty::ClosureKind, Option<(Span, ast::Name)>)>,
 
     /// For each fn, records the "liberated" types of its arguments
     /// and return type. Liberated means that all bound regions

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -596,10 +596,11 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                         if let Some(&(ty::ClosureKind::FnOnce, Some((span, name)))) =
                             self.tables.closure_kinds.get(&node_id)
                         {
-                            err.help(&format!("closure cannot be invoked more than once because \
-                                              it moves the variable `{}` out of its environment",
-                                              name));
-                            err.span_label(span, format!("{} moved here", name));
+                            err.span_note(span, &format!(
+                                "closure cannot be invoked more than once because \
+                                it moves the variable `{}` out of its environment",
+                                name
+                            ));
                             false
                         } else {
                             true

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -597,6 +597,9 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                         if let Ok(ty::ClosureKind::FnOnce) =
                            ty::queries::closure_kind::try_get(self.tcx, DUMMY_SP, id) {
                             err.help("closure was moved because it only implements `FnOnce`");
+                            if let Some(&(_kind, Some(span))) = self.tables.closure_kinds.get( ) {
+                                err.span_label(span, "move occured here");
+                            }
                             false
                         } else {
                             true

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -103,7 +103,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         self.tables.borrow_mut().closure_tys.insert(expr.id, sig);
         match opt_kind {
             Some(kind) => {
-                self.tables.borrow_mut().closure_kinds.insert(expr.id, kind);
+                self.tables.borrow_mut().closure_kinds.insert(expr.id, (kind, None));
             }
             None => {}
         }

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -802,7 +802,7 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
 
             let closure_kinds = &self.tables.borrow().closure_kinds;
             let closure_kind = match closure_kinds.get(&closure_id) {
-                Some(&k) => k,
+                Some(&(k, _)) => k,
                 None => {
                     return Err(MethodError::ClosureAmbiguity(trait_def_id));
                 }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -702,7 +702,7 @@ fn closure_kind<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                           def_id: DefId)
                           -> ty::ClosureKind {
     let node_id = tcx.hir.as_local_node_id(def_id).unwrap();
-    tcx.typeck_tables_of(def_id).closure_kinds[&node_id]
+    tcx.typeck_tables_of(def_id).closure_kinds[&node_id].0
 }
 
 fn adt_destructor<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,

--- a/src/test/ui/fn_once-moved.rs
+++ b/src/test/ui/fn_once-moved.rs
@@ -20,5 +20,6 @@ fn main() {
     debug_dump_dict();
     debug_dump_dict();
     //~^ ERROR use of moved value: `debug_dump_dict`
-    //~| NOTE closure was moved because it only implements `FnOnce`
+    //~| NOTE closure cannot be invoked more than once because it moves the
+    //~| variable `dict` out of its environment
 }

--- a/src/test/ui/fn_once-moved.stderr
+++ b/src/test/ui/fn_once-moved.stderr
@@ -1,12 +1,15 @@
 error[E0382]: use of moved value: `debug_dump_dict`
   --> $DIR/fn_once-moved.rs:21:5
    |
+16 |         for (key, value) in dict {
+   |                             ---- dict moved here
+...
 20 |     debug_dump_dict();
    |     --------------- value moved here
 21 |     debug_dump_dict();
    |     ^^^^^^^^^^^^^^^ value used here after move
    |
-   = help: closure was moved because it only implements `FnOnce`
+   = help: closure cannot be invoked more than once because it moves the variable `dict` out of its environment
 
 error: aborting due to previous error
 

--- a/src/test/ui/fn_once-moved.stderr
+++ b/src/test/ui/fn_once-moved.stderr
@@ -1,15 +1,16 @@
 error[E0382]: use of moved value: `debug_dump_dict`
   --> $DIR/fn_once-moved.rs:21:5
    |
-16 |         for (key, value) in dict {
-   |                             ---- dict moved here
-...
 20 |     debug_dump_dict();
    |     --------------- value moved here
 21 |     debug_dump_dict();
    |     ^^^^^^^^^^^^^^^ value used here after move
    |
-   = help: closure cannot be invoked more than once because it moves the variable `dict` out of its environment
+note: closure cannot be invoked more than once because it moves the variable `dict` out of its environment
+  --> $DIR/fn_once-moved.rs:16:29
+   |
+16 |         for (key, value) in dict {
+   |                             ^^^^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fixes: #42065