### PR TITLE
Remove superfluous `;;` sequences

### DIFF
--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -1018,7 +1018,7 @@ impl str {
     ///
     /// ```
     /// let x = "(///)".to_string();
-    /// let d: Vec<_> = x.split('/').collect();;
+    /// let d: Vec<_> = x.split('/').collect();
     ///
     /// assert_eq!(d, &["(", "", "", ")"]);
     /// ```

--- a/src/librustc_passes/consts.rs
+++ b/src/librustc_passes/consts.rs
@@ -141,7 +141,7 @@ impl<'a, 'tcx> Visitor<'tcx> for CheckCrateVisitor<'a, 'tcx> {
         let outer_penv = self.tcx.infer_ctxt(body_id, Reveal::UserFacing).enter(|infcx| {
             let param_env = infcx.param_env.clone();
             let outer_penv = mem::replace(&mut self.param_env, param_env);
-            let region_maps = &self.tcx.region_maps(item_def_id);;
+            let region_maps = &self.tcx.region_maps(item_def_id);
             euv::ExprUseVisitor::new(self, region_maps, &infcx).consume_body(body);
             outer_penv
         });

--- a/src/librustc_trans/mir/block.rs
+++ b/src/librustc_trans/mir/block.rs
@@ -901,7 +901,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
         let llty = type_of::type_of(bcx.ccx, val.ty);
         let cast_ptr = bcx.pointercast(dst.llval, llty.ptr_to());
         let in_type = val.ty;
-        let out_type = dst.ty.to_ty(bcx.tcx());;
+        let out_type = dst.ty.to_ty(bcx.tcx());
         let llalign = cmp::min(bcx.ccx.align_of(in_type), bcx.ccx.align_of(out_type));
         self.store_operand(bcx, cast_ptr, Some(llalign), val);
     }

--- a/src/test/run-pass/issue-16671.rs
+++ b/src/test/run-pass/issue-16671.rs
@@ -13,7 +13,7 @@
 fn foo<F: FnOnce()>(_f: F) { }
 
 fn main() {
-    let mut var = Vec::new();;
+    let mut var = Vec::new();
     foo(move|| {
         var.push(1);
     });


### PR DESCRIPTION
Ran across a doubled `;;` in the docstring for `str::split`. Grep found a few more. :)