### PR TITLE
Fix 'associate type' typo

### DIFF
--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -962,7 +962,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
     pub fn prohibit_projection(&self, span: Span) {
         let mut err = struct_span_err!(self.tcx().sess, span, E0229,
                                        "associated type bindings are not allowed here");
-        err.span_label(span, "associate type not allowed here").emit();
+        err.span_label(span, "associated type not allowed here").emit();
     }
 
     // Check a type Path and convert it to a Ty.

--- a/src/test/compile-fail/E0229.rs
+++ b/src/test/compile-fail/E0229.rs
@@ -22,7 +22,7 @@ impl Foo for isize {
 
 fn baz<I>(x: &<I as Foo<A=Bar>>::A) {}
 //~^ ERROR associated type bindings are not allowed here [E0229]
-//~| NOTE associate type not allowed here
+//~| NOTE associated type not allowed here
 
 fn main() {
 }

--- a/src/test/compile-fail/issue-23543.rs
+++ b/src/test/compile-fail/issue-23543.rs
@@ -16,7 +16,7 @@ pub trait D {
     fn f<T>(self)
         where T<Bogus = Foo>: A;
         //~^ ERROR associated type bindings are not allowed here [E0229]
-        //~| NOTE associate type not allowed here
+        //~| NOTE associated type not allowed here
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-23544.rs
+++ b/src/test/compile-fail/issue-23544.rs
@@ -14,7 +14,7 @@ pub trait D {
     fn f<T>(self)
         where T<Bogus = Self::AlsoBogus>: A;
         //~^ ERROR associated type bindings are not allowed here [E0229]
-        //~| NOTE associate type not allowed here
+        //~| NOTE associated type not allowed here
 }
 
 fn main() {}


### PR DESCRIPTION
I came across an error message mentioning an 'associate type'.

Since this is the only instance of this term in rustc (it's 'associated type' everywhere else), I think this might be a typo.