### PR TITLE
Update OpenSSL download location

### DIFF
--- a/src/ci/docker/dist-i686-linux/build-openssl.sh
+++ b/src/ci/docker/dist-i686-linux/build-openssl.sh
@@ -12,9 +12,10 @@
 set -ex
 source shared.sh
 
-VERSION=1.0.2j
+VERSION=1.0.2k
+URL=https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/openssl-$VERSION.tar.gz
 
-curl https://www.openssl.org/source/openssl-$VERSION.tar.gz | tar xzf -
+curl $URL | tar xzf -
 
 cd openssl-$VERSION
 hide_output ./config --prefix=/rustroot shared -fPIC

--- a/src/ci/docker/dist-x86_64-linux/build-openssl.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-openssl.sh
@@ -12,9 +12,10 @@
 set -ex
 source shared.sh
 
-VERSION=1.0.2j
+VERSION=1.0.2k
+URL=https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/openssl-$VERSION.tar.gz
 
-curl https://www.openssl.org/source/openssl-$VERSION.tar.gz | tar xzf -
+curl $URL | tar xzf -
 
 cd openssl-$VERSION
 hide_output ./config --prefix=/rustroot shared -fPIC


### PR DESCRIPTION
In rustbuild itself we download from our mirror but in the containers we don't
do this yet. The OpenSSL download url changes from time to time (it breaks when
they release a new version) so let's download from our mirror instead.