### PR TITLE
Allow variadic functions with cdecl calling convention.

### DIFF
--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -4078,7 +4078,7 @@ register_diagnostics! {
 //  E0217, // ambiguous associated type, defined in multiple supertraits
 //  E0218, // no associated type defined
 //  E0219, // associated type defined in higher-ranked supertrait
-//  E0222, // Error code E0045 (variadic function must have C calling
+//  E0222, // Error code E0045 (variadic function must have C or cdecl calling
            // convention) duplicate
     E0224, // at least one non-builtin train is required for an object type
     E0227, // ambiguous lifetime bound, explicit lifetime bound required

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -141,11 +141,10 @@ fn require_c_abi_if_variadic(tcx: TyCtxt,
                              decl: &hir::FnDecl,
                              abi: Abi,
                              span: Span) {
-    if decl.variadic && abi != Abi::C {
+    if decl.variadic && !(abi == Abi::C || abi == Abi::Cdecl) {
         let mut err = struct_span_err!(tcx.sess, span, E0045,
-                  "variadic function must have C calling convention");
-        err.span_label(span, "variadics require C calling conventions")
-            .emit();
+                  "variadic function must have C or cdecl calling convention");
+        err.span_label(span, "variadics require C or cdecl calling convention").emit();
     }
 }
 

--- a/src/test/compile-fail/E0045.rs
+++ b/src/test/compile-fail/E0045.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 extern "Rust" { fn foo(x: u8, ...); }   //~ ERROR E0045
-                                        //~| NOTE variadics require C calling conventions
+                                        //~| NOTE variadics require C or cdecl calling convention
 
 fn main() {
 }

--- a/src/test/compile-fail/variadic-ffi-2.rs
+++ b/src/test/compile-fail/variadic-ffi-2.rs
@@ -8,8 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn baz(f: extern "cdecl" fn(usize, ...)) {
-    //~^ ERROR: variadic function must have C calling convention
+// ignore-arm stdcall isn't suppported
+
+fn baz(f: extern "stdcall" fn(usize, ...)) {
+    //~^ ERROR: variadic function must have C or cdecl calling convention
     f(22, 44);
 }
 

--- a/src/test/compile-fail/variadic-ffi.rs
+++ b/src/test/compile-fail/variadic-ffi.rs
@@ -8,8 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern "cdecl" {
-    fn printf(_: *const u8, ...); //~ ERROR: variadic function must have C calling convention
+// ignore-arm stdcall isn't suppported
+
+extern "stdcall" {
+    fn printf(_: *const u8, ...); //~ ERROR: variadic function must have C or cdecl calling
 }
 
 extern {


### PR DESCRIPTION
Fixes #40244.