### PR TITLE
Move Bound to libcore.

### DIFF
--- a/src/doc/unstable-book/src/SUMMARY.md
+++ b/src/doc/unstable-book/src/SUMMARY.md
@@ -106,6 +106,7 @@
     - [c_void_variant](library-features/c-void-variant.md)
     - [char_escape_debug](library-features/char-escape-debug.md)
     - [coerce_unsized](library-features/coerce-unsized.md)
+    - [core_collections](library-features/core-collections.md)
     - [collection_placement](library-features/collection-placement.md)
     - [collections_range](library-features/collections-range.md)
     - [collections](library-features/collections.md)

--- a/src/doc/unstable-book/src/library-features/core-collections.md
+++ b/src/doc/unstable-book/src/library-features/core-collections.md
@@ -1,0 +1,7 @@
+# `core_collections`
+
+The tracking issue for this feature is: [#0]
+
+[#0]: https://github.com/rust-lang/rust/issues/0
+
+------------------------

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -130,59 +130,11 @@ pub mod btree_set {
 
 #[cfg(not(test))]
 mod std {
-    pub use core::ops;      // RangeFull
+    pub use core::ops; // RangeFull
 }
 
-/// An endpoint of a range of keys.
-///
-/// # Examples
-///
-/// `Bound`s are range endpoints:
-///
-/// ```
-/// #![feature(collections_range)]
-///
-/// use std::collections::range::RangeArgument;
-/// use std::collections::Bound::*;
-///
-/// assert_eq!((..100).start(), Unbounded);
-/// assert_eq!((1..12).start(), Included(&1));
-/// assert_eq!((1..12).end(), Excluded(&12));
-/// ```
-///
-/// Using a tuple of `Bound`s as an argument to [`BTreeMap::range`].
-/// Note that in most cases, it's better to use range syntax (`1..5`) instead.
-///
-/// ```
-/// use std::collections::BTreeMap;
-/// use std::collections::Bound::{Excluded, Included, Unbounded};
-///
-/// let mut map = BTreeMap::new();
-/// map.insert(3, "a");
-/// map.insert(5, "b");
-/// map.insert(8, "c");
-///
-/// for (key, value) in map.range((Excluded(3), Included(8))) {
-///     println!("{}: {}", key, value);
-/// }
-///
-/// assert_eq!(Some((&3, &"a")), map.range((Unbounded, Included(5))).next());
-/// ```
-///
-/// [`BTreeMap::range`]: btree_map/struct.BTreeMap.html#method.range
 #[stable(feature = "collections_bound", since = "1.17.0")]
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
-pub enum Bound<T> {
-    /// An inclusive bound.
-    #[stable(feature = "collections_bound", since = "1.17.0")]
-    Included(T),
-    /// An exclusive bound.
-    #[stable(feature = "collections_bound", since = "1.17.0")]
-    Excluded(T),
-    /// An infinite endpoint. Indicates that there is no bound in this direction.
-    #[stable(feature = "collections_bound", since = "1.17.0")]
-    Unbounded,
-}
+pub use core::collections::Bound;
 
 /// An intermediate trait for specialization of `Extend`.
 #[doc(hidden)]

--- a/src/libcore/collections.rs
+++ b/src/libcore/collections.rs
@@ -1,0 +1,71 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Collection types.
+//!
+//! See [`std::collections`](../../std/collections/index.html) for a detailed
+//! discussion of collections in Rust.
+
+/// An endpoint of a range of keys.
+///
+/// # Examples
+///
+/// `Bound`s are range endpoints:
+///
+/// ```
+/// #![feature(collections_range)]
+///
+/// use std::collections::range::RangeArgument;
+/// use std::collections::Bound::*;
+///
+/// assert_eq!((..100).start(), Unbounded);
+/// assert_eq!((1..12).start(), Included(&1));
+/// assert_eq!((1..12).end(), Excluded(&12));
+/// ```
+///
+/// Using a tuple of `Bound`s as an argument to [`BTreeMap::range`].
+/// Note that in most cases, it's better to use range syntax (`1..5`) instead.
+///
+/// ```
+/// use std::collections::BTreeMap;
+/// use std::collections::Bound::{Excluded, Included, Unbounded};
+///
+/// let mut map = BTreeMap::new();
+/// map.insert(3, "a");
+/// map.insert(5, "b");
+/// map.insert(8, "c");
+///
+/// for (key, value) in map.range((Excluded(3), Included(8))) {
+///     println!("{}: {}", key, value);
+/// }
+///
+/// assert_eq!(Some((&3, &"a")), map.range((Unbounded, Included(5))).next());
+/// ```
+///
+/// [`BTreeMap::range`]: ../../collections/btree_map/struct.BTreeMap.html#method.range
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[stable(feature = "collections_bound", since = "1.17.0")]
+pub enum Bound<T> {
+    /// An inclusive bound.
+    #[stable(feature = "collections_bound", since = "1.17.0")]
+    Included(
+        #[stable(feature = "collections_bound", since = "1.17.0")] // ???
+        T
+    ),
+    /// An exclusive bound.
+    #[stable(feature = "collections_bound", since = "1.17.0")]
+    Excluded(
+        #[stable(feature = "collections_bound", since = "1.17.0")] // ???
+        T
+    ),
+    /// An infinite endpoint. Indicates that there is no bound in this direction.
+    #[stable(feature = "collections_bound", since = "1.17.0")]
+    Unbounded,
+}

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -171,6 +171,9 @@ pub mod str;
 pub mod hash;
 pub mod fmt;
 
+#[unstable(feature = "core_collections", issue = "0")]
+pub mod collections;
+
 // note: does not need to be public
 mod char_private;
 mod iter_private;


### PR DESCRIPTION
Half of a redone version of #41460. This creates a new module, `core::collections`, which currently only contains this type.