### PR TITLE
add `FromStr` Impl for `char`

### DIFF
--- a/src/doc/unstable-book/src/library-features/char-error-internals.md
+++ b/src/doc/unstable-book/src/library-features/char-error-internals.md
@@ -1,0 +1,5 @@
+# `char_error_internals`
+
+This feature is internal to the Rust compiler and is not intended for general use.
+
+------------------------

--- a/src/libcore/tests/char.rs
+++ b/src/libcore/tests/char.rs
@@ -10,6 +10,7 @@
 
 use std::{char,str};
 use std::convert::TryFrom;
+use std::str::FromStr;
 
 #[test]
 fn test_convert() {
@@ -26,6 +27,16 @@ fn test_convert() {
     assert_eq!(char::try_from(0x10FFFF_u32), Ok('\u{10FFFF}'));
     assert!(char::try_from(0x110000_u32).is_err());
     assert!(char::try_from(0xFFFF_FFFF_u32).is_err());
+}
+
+#[test]
+fn test_from_str() {
+    assert_eq!(char::from_str("a").unwrap(), 'a');
+    assert_eq!(char::try_from("a").unwrap(), 'a');
+    assert_eq!(char::from_str("\0").unwrap(), '\0');
+    assert_eq!(char::from_str("\u{D7FF}").unwrap(), '\u{d7FF}');
+    assert!(char::from_str("").is_err());
+    assert!(char::from_str("abc").is_err());
 }
 
 #[test]

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -321,6 +321,14 @@ impl Error for char::CharTryFromError {
     }
 }
 
+#[stable(feature = "char_from_str", since = "1.19.0")]
+impl Error for char::ParseCharError {
+    fn description(&self) -> &str {
+        self.__description()
+    }
+}
+
+
 // copied from any.rs
 impl Error + 'static {
     /// Returns true if the boxed type is the same as `T`

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -253,6 +253,7 @@
 #![feature(cfg_target_thread_local)]
 #![feature(cfg_target_vendor)]
 #![feature(char_escape_debug)]
+#![feature(char_error_internals)]
 #![feature(char_internals)]
 #![feature(collections)]
 #![feature(collections_range)]

--- a/src/libstd_unicode/char.rs
+++ b/src/libstd_unicode/char.rs
@@ -38,6 +38,8 @@ use tables::{conversions, derived_property, general_category, property};
 pub use core::char::{MAX, from_digit, from_u32, from_u32_unchecked};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::char::{EscapeDebug, EscapeDefault, EscapeUnicode};
+#[stable(feature = "char_from_str", since = "1.19.0")]
+pub use core::char::ParseCharError;
 
 // unstable reexports
 #[unstable(feature = "try_from", issue = "33417")]


### PR DESCRIPTION
fixes #24939.

is it possible to use pub(restricted) instead of using a stability attribute for the internal error representation? is it needed at all?