### PR TITLE
Fix GDB pretty-printer for tuples and pointers

### DIFF
--- a/src/etc/debugger_pretty_printers_common.py
+++ b/src/etc/debugger_pretty_printers_common.py
@@ -354,3 +354,8 @@ def extract_type_name(qualified_type_name):
         return qualified_type_name
     else:
         return qualified_type_name[index + 2:]
+
+try:
+    compat_str = unicode  # Python 2
+except NameError:
+    compat_str = str

--- a/src/etc/debugger_pretty_printers_common.py
+++ b/src/etc/debugger_pretty_printers_common.py
@@ -46,6 +46,7 @@ TYPE_KIND_CSTYLE_ENUM       = 14
 TYPE_KIND_PTR               = 15
 TYPE_KIND_FIXED_SIZE_VEC    = 16
 TYPE_KIND_REGULAR_UNION     = 17
+TYPE_KIND_OS_STRING         = 18
 
 ENCODED_ENUM_PREFIX = "RUST$ENCODED$ENUM$"
 ENUM_DISR_FIELD_NAME = "RUST$ENUM$DISR"
@@ -63,6 +64,9 @@ STD_VEC_FIELD_NAMES = [STD_VEC_FIELD_NAME_BUF,
 
 # std::String related constants
 STD_STRING_FIELD_NAMES = ["vec"]
+
+# std::ffi::OsString related constants
+OS_STRING_FIELD_NAMES = ["inner"]
 
 
 class Type(object):
@@ -161,6 +165,11 @@ class Type(object):
         if (unqualified_type_name.startswith("String") and
             self.__conforms_to_field_layout(STD_STRING_FIELD_NAMES)):
             return TYPE_KIND_STD_STRING
+
+        # OS STRING
+        if (unqualified_type_name == "OsString" and
+            self.__conforms_to_field_layout(OS_STRING_FIELD_NAMES)):
+            return TYPE_KIND_OS_STRING
 
         # ENUM VARIANTS
         if fields[0].name == ENUM_DISR_FIELD_NAME:

--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -78,7 +78,7 @@ class GdbValue(rustpp.Value):
 
     def as_integer(self):
         if self.gdb_val.type.code == gdb.TYPE_CODE_PTR:
-            as_str = str(self.gdb_val).split()[0]
+            as_str = unicode(self.gdb_val).split()[0]
             return int(as_str, 0)
         return int(self.gdb_val)
 

--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -100,8 +100,10 @@ def rust_pretty_printer_lookup_function(gdb_val):
     val = GdbValue(gdb_val)
     type_kind = val.type.get_type_kind()
 
-    if (type_kind == rustpp.TYPE_KIND_REGULAR_STRUCT or
-        type_kind == rustpp.TYPE_KIND_EMPTY):
+    if type_kind == rustpp.TYPE_KIND_EMPTY:
+        return RustEmptyPrinter(val)
+
+    if type_kind == rustpp.TYPE_KIND_REGULAR_STRUCT:
         return RustStructPrinter(val,
                                  omit_first_field = False,
                                  omit_type_name = False,
@@ -174,6 +176,14 @@ def rust_pretty_printer_lookup_function(gdb_val):
 #=------------------------------------------------------------------------------
 # Pretty Printer Classes
 #=------------------------------------------------------------------------------
+class RustEmptyPrinter(object):
+    def __init__(self, val):
+        self.__val = val
+
+    def to_string(self):
+        return self.__val.type.get_unqualified_type_name()
+
+
 class RustStructPrinter(object):
     def __init__(self, val, omit_first_field, omit_type_name, is_tuple_like):
         self.__val = val

--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -78,7 +78,8 @@ class GdbValue(rustpp.Value):
 
     def as_integer(self):
         if self.gdb_val.type.code == gdb.TYPE_CODE_PTR:
-            return int(str(self.gdb_val), 0)
+            as_str = str(self.gdb_val).split()[0]
+            return int(as_str, 0)
         return int(self.gdb_val)
 
     def get_wrapped_value(self):

--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -186,10 +186,10 @@ class RustStructPrinter(object):
         cs = []
         wrapped_value = self.__val.get_wrapped_value()
 
-        for field in self.__val.type.get_fields():
+        for number, field in enumerate(self.__val.type.get_fields()):
             field_value = wrapped_value[field.name]
             if self.__is_tuple_like:
-                cs.append(("", field_value))
+                cs.append((str(number), field_value))
             else:
                 cs.append((field.name, field_value))
 

--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -78,7 +78,7 @@ class GdbValue(rustpp.Value):
 
     def as_integer(self):
         if self.gdb_val.type.code == gdb.TYPE_CODE_PTR:
-            as_str = unicode(self.gdb_val).split()[0]
+            as_str = rustpp.compat_str(self.gdb_val).split()[0]
             return int(as_str, 0)
         return int(self.gdb_val)
 

--- a/src/test/debuginfo/pretty-std.rs
+++ b/src/test/debuginfo/pretty-std.rs
@@ -38,8 +38,11 @@
 // gdbg-check:$6 = None
 // gdbr-check:$6 = core::option::Option::None
 
-// gdb-command: print some_string
-// gdbr-check:$7 = Some = {"IAMA optional string!"}
+// gdbr-command: print os_string
+// gdbr-check:$7 = "IAMA OS string 😃"
+
+// gdbr-command: print some_string
+// gdbr-check:$8 = Some = {"IAMA optional string!"}
 
 
 // === LLDB TESTS ==================================================================================
@@ -66,6 +69,8 @@
 
 
 #![allow(unused_variables)]
+use std::ffi::OsString;
+
 
 fn main() {
 
@@ -80,6 +85,9 @@ fn main() {
 
     // String
     let string = "IAMA string!".to_string();
+
+    // OsString
+    let os_string = OsString::from("IAMA OS string \u{1F603}");
 
     // Option
     let some = Some(8i16);

--- a/src/test/debuginfo/pretty-std.rs
+++ b/src/test/debuginfo/pretty-std.rs
@@ -38,11 +38,11 @@
 // gdbg-check:$6 = None
 // gdbr-check:$6 = core::option::Option::None
 
-// gdbr-command: print os_string
-// gdbr-check:$7 = "IAMA OS string 😃"
+// gdb-command: print os_string
+// gdb-check:$7 = "IAMA OS string 😃"
 
-// gdbr-command: print some_string
-// gdbr-check:$8 = Some = {"IAMA optional string!"}
+// gdb-command: print some_string
+// gdb-check:$8 = Some = {"IAMA optional string!"}
 
 
 // === LLDB TESTS ==================================================================================

--- a/src/test/debuginfo/pretty-std.rs
+++ b/src/test/debuginfo/pretty-std.rs
@@ -38,6 +38,9 @@
 // gdbg-check:$6 = None
 // gdbr-check:$6 = core::option::Option::None
 
+// gdb-command: print some_string
+// gdbr-check:$7 = Some = {"IAMA optional string!"}
+
 
 // === LLDB TESTS ==================================================================================
 
@@ -81,6 +84,8 @@ fn main() {
     // Option
     let some = Some(8i16);
     let none: Option<i64> = None;
+
+    let some_string = Some("IAMA optional string!".to_owned());
 
     zzz(); // #break
 }


### PR DESCRIPTION
Names of children should not be the same, because GDB uses them to distinguish the children.

|Before|After|
|---|---|
|![tuples_before](https://cloud.githubusercontent.com/assets/1297574/26527639/5d6cf10e-43a0-11e7-9498-abfcddb08055.png)|![tuples_after](https://cloud.githubusercontent.com/assets/1297574/26527655/9699233a-43a0-11e7-83c6-f58f713b51a0.png)|

`main.rs`
```rust
enum Test {
    Zero,
    One(i32),
    Two(i32, String),
    Three(i32, String, Vec<String>),
}

fn main() {
    let tuple = (1, 2, "Asdfgh");
    let zero = Test::Zero;
    let one = Test::One(10);
    let two = Test::Two(42, "Qwerty".to_owned());
    let three = Test::Three(9000,
                            "Zxcvbn".to_owned(),
                            vec!["lorem".to_owned(), "ipsum".to_owned(), "dolor".to_owned()]);
    println!(""); // breakpoint here
}
```

`launch.json`
```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "type": "gdb",
            "request": "launch",
            "gdbpath": "rust-gdb",
            "name": "Launch Program",
            "valuesFormatting": "prettyPrinters", //this requires plugin Native Debug >= 0.20.0
            "target": "./target/debug/test_pretty_printers",
            "cwd": "${workspaceRoot}"
        }
    ]
}
```