### PR TITLE
Don't warn on lifetime generic no_mangle functions.

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1114,10 +1114,10 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidNoMangleItems {
                                           it.name);
                         cx.span_lint(PRIVATE_NO_MANGLE_FNS, it.span, &msg);
                     }
-                    if generics.is_parameterized() {
+                    if generics.is_type_parameterized() {
                         cx.span_lint(NO_MANGLE_GENERIC_ITEMS,
                                      it.span,
-                                     "generic functions must be mangled");
+                                     "functions generic over types must be mangled");
                     }
                 }
             }

--- a/src/test/compile-fail/generic-no-mangle.rs
+++ b/src/test/compile-fail/generic-no-mangle.rs
@@ -11,9 +11,15 @@
 #![deny(no_mangle_generic_items)]
 
 #[no_mangle]
-pub fn foo<T>() {} //~ ERROR generic functions must be mangled
+pub fn foo<T>() {} //~ ERROR functions generic over types must be mangled
 
 #[no_mangle]
-pub extern fn bar<T>() {} //~ ERROR generic functions must be mangled
+pub extern fn bar<T>() {} //~ ERROR functions generic over types must be mangled
+
+#[no_mangle]
+pub fn baz(x: &i32) -> &i32 { x }
+
+#[no_mangle]
+pub fn qux<'a>(x: &'a i32) -> &i32 { x }
 
 fn main() {}


### PR DESCRIPTION
Fixes #40342.