### PR TITLE
rustdoc: Cleanup associated const value rendering

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1487,7 +1487,7 @@ pub struct PolyTrait {
 /// A representation of a Type suitable for hyperlinking purposes. Ideally one can get the original
 /// type out of the AST/TyCtxt given one of these, if more information is needed. Most importantly
 /// it does not preserve mutability or boxes.
-#[derive(Clone, RustcEncodable, RustcDecodable, PartialEq)]
+#[derive(Clone, RustcEncodable, RustcDecodable, PartialEq, Debug)]
 pub enum Type {
     /// structs/enums/traits (most that'd be an hir::TyPath)
     ResolvedPath {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1662,9 +1662,9 @@ fn md_render_assoc_item(item: &clean::Item) -> String {
     match item.inner {
         clean::AssociatedConstItem(ref ty, ref default) => {
             if let Some(default) = default.as_ref() {
-                format!("```\n{}: {:?} = {}\n```\n\n", item.name.as_ref().unwrap(), ty, default)
+                format!("```\n{}: {:#} = {}\n```\n\n", item.name.as_ref().unwrap(), ty, default)
             } else {
-                format!("```\n{}: {:?}\n```\n\n", item.name.as_ref().unwrap(), ty)
+                format!("```\n{}: {:#}\n```\n\n", item.name.as_ref().unwrap(), ty)
             }
         }
         _ => String::new(),

--- a/src/test/rustdoc/assoc-consts.rs
+++ b/src/test/rustdoc/assoc-consts.rs
@@ -26,3 +26,21 @@ impl Bar {
     // @has - '//*[@class="docblock"]' 'BAR: usize = 3'
     pub const BAR: usize = 3;
 }
+
+pub struct Baz<'a, U: 'a, T>(T, &'a [U]);
+
+impl Bar {
+    // @has assoc_consts/struct.Bar.html '//*[@id="associatedconstant.BAZ"]' \
+    //      "const BAZ: Baz<'static, u8, u32>"
+    // @has - '//*[@class="docblock"]' "BAZ: Baz<'static, u8, u32> = Baz(321, &[1, 2, 3])"
+    pub const BAZ: Baz<'static, u8, u32> = Baz(321, &[1, 2, 3]);
+}
+
+pub fn f(_: &(ToString + 'static)) {}
+
+impl Bar {
+    // @has assoc_consts/struct.Bar.html '//*[@id="associatedconstant.F"]' \
+    //      "const F: fn(_: &(ToString + 'static))"
+    // @has - '//*[@class="docblock"]' "F: fn(_: &(ToString + 'static)) = f"
+    pub const F: fn(_: &(ToString + 'static)) = f;
+}


### PR DESCRIPTION
Rather than (ab)using Debug for outputting the type in plain text use the
alternate format parameter which already does exactly that. This fixes
type parameters for example which would output raw HTML.

Also cleans up adding parens around references to trait objects.