### PR TITLE
Add the RLS to .exe, .msi, and .pkg installers

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -949,6 +949,8 @@ pub fn extended(build: &Build, stage: u32, target: &str) {
         let _ = fs::remove_dir_all(&exe);
         t!(fs::create_dir_all(exe.join("rustc")));
         t!(fs::create_dir_all(exe.join("cargo")));
+        t!(fs::create_dir_all(exe.join("rls")));
+        t!(fs::create_dir_all(exe.join("rust-analysis")));
         t!(fs::create_dir_all(exe.join("rust-docs")));
         t!(fs::create_dir_all(exe.join("rust-std")));
         cp_r(&work.join(&format!("{}-{}", pkgname(build, "rustc"), target))
@@ -963,11 +965,19 @@ pub fn extended(build: &Build, stage: u32, target: &str) {
         cp_r(&work.join(&format!("{}-{}", pkgname(build, "rust-std"), target))
                   .join(format!("rust-std-{}", target)),
              &exe.join("rust-std"));
+        cp_r(&work.join(&format!("{}-{}", pkgname(build, "rls"), target))
+                  .join("rls"),
+             &exe.join("rls"));
+        cp_r(&work.join(&format!("{}-{}", pkgname(build, "rust-analysis"), target))
+                  .join(format!("rust-analysis-{}", target)),
+             &exe.join("rust-analysis"));
 
         t!(fs::remove_file(exe.join("rustc/manifest.in")));
         t!(fs::remove_file(exe.join("cargo/manifest.in")));
         t!(fs::remove_file(exe.join("rust-docs/manifest.in")));
         t!(fs::remove_file(exe.join("rust-std/manifest.in")));
+        t!(fs::remove_file(exe.join("rls/manifest.in")));
+        t!(fs::remove_file(exe.join("rust-analysis/manifest.in")));
 
         if target.contains("windows-gnu") {
             t!(fs::create_dir_all(exe.join("rust-mingw")));
@@ -1041,6 +1051,26 @@ pub fn extended(build: &Build, stage: u32, target: &str) {
                         .arg("-dr").arg("Std")
                         .arg("-var").arg("var.StdDir")
                         .arg("-out").arg(exe.join("StdGroup.wxs")));
+        build.run(Command::new(&heat)
+                        .current_dir(&exe)
+                        .arg("dir")
+                        .arg("rls")
+                        .args(&heat_flags)
+                        .arg("-cg").arg("RlsGroup")
+                        .arg("-dr").arg("Rls")
+                        .arg("-var").arg("var.RlsDir")
+                        .arg("-out").arg(exe.join("RlsGroup.wxs"))
+                        .arg("-t").arg(etc.join("msi/remove-duplicates.xsl")));
+        build.run(Command::new(&heat)
+                        .current_dir(&exe)
+                        .arg("dir")
+                        .arg("rust-analysis")
+                        .args(&heat_flags)
+                        .arg("-cg").arg("AnalysisGroup")
+                        .arg("-dr").arg("Analysis")
+                        .arg("-var").arg("var.AnalysisDir")
+                        .arg("-out").arg(exe.join("AnalysisGroup.wxs"))
+                        .arg("-t").arg(etc.join("msi/remove-duplicates.xsl")));
         if target.contains("windows-gnu") {
             build.run(Command::new(&heat)
                             .current_dir(&exe)
@@ -1064,6 +1094,8 @@ pub fn extended(build: &Build, stage: u32, target: &str) {
                .arg("-dDocsDir=rust-docs")
                .arg("-dCargoDir=cargo")
                .arg("-dStdDir=rust-std")
+               .arg("-dRlsDir=rls")
+               .arg("-dAnalysisDir=rust-analysis")
                .arg("-arch").arg(&arch)
                .arg("-out").arg(&output)
                .arg(&input);
@@ -1081,6 +1113,8 @@ pub fn extended(build: &Build, stage: u32, target: &str) {
         candle("DocsGroup.wxs".as_ref());
         candle("CargoGroup.wxs".as_ref());
         candle("StdGroup.wxs".as_ref());
+        candle("RlsGroup.wxs".as_ref());
+        candle("AnalysisGroup.wxs".as_ref());
 
         if target.contains("windows-gnu") {
             candle("GccGroup.wxs".as_ref());
@@ -1103,6 +1137,8 @@ pub fn extended(build: &Build, stage: u32, target: &str) {
            .arg("DocsGroup.wixobj")
            .arg("CargoGroup.wixobj")
            .arg("StdGroup.wixobj")
+           .arg("RlsGroup.wixobj")
+           .arg("AnalysisGroup.wixobj")
            .current_dir(&exe);
 
         if target.contains("windows-gnu") {

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -899,6 +899,8 @@ pub fn extended(build: &Build, stage: u32, target: &str) {
         t!(fs::create_dir_all(pkg.join("cargo")));
         t!(fs::create_dir_all(pkg.join("rust-docs")));
         t!(fs::create_dir_all(pkg.join("rust-std")));
+        t!(fs::create_dir_all(pkg.join("rls")));
+        t!(fs::create_dir_all(pkg.join("rust-analysis")));
 
         cp_r(&work.join(&format!("{}-{}", pkgname(build, "rustc"), target)),
              &pkg.join("rustc"));
@@ -908,11 +910,17 @@ pub fn extended(build: &Build, stage: u32, target: &str) {
              &pkg.join("rust-docs"));
         cp_r(&work.join(&format!("{}-{}", pkgname(build, "rust-std"), target)),
              &pkg.join("rust-std"));
+        cp_r(&work.join(&format!("{}-{}", pkgname(build, "rls"), target)),
+             &pkg.join("rls"));
+        cp_r(&work.join(&format!("{}-{}", pkgname(build, "rust-analysis"), target)),
+             &pkg.join("rust-analysis"));
 
         install(&etc.join("pkg/postinstall"), &pkg.join("rustc"), 0o755);
         install(&etc.join("pkg/postinstall"), &pkg.join("cargo"), 0o755);
         install(&etc.join("pkg/postinstall"), &pkg.join("rust-docs"), 0o755);
         install(&etc.join("pkg/postinstall"), &pkg.join("rust-std"), 0o755);
+        install(&etc.join("pkg/postinstall"), &pkg.join("rls"), 0o755);
+        install(&etc.join("pkg/postinstall"), &pkg.join("rust-analysis"), 0o755);
 
         let pkgbuild = |component: &str| {
             let mut cmd = Command::new("pkgbuild");
@@ -926,6 +934,8 @@ pub fn extended(build: &Build, stage: u32, target: &str) {
         pkgbuild("cargo");
         pkgbuild("rust-docs");
         pkgbuild("rust-std");
+        pkgbuild("rls");
+        pkgbuild("rust-analysis");
 
         // create an 'uninstall' package
         install(&etc.join("pkg/postinstall"), &pkg.join("uninstall"), 0o755);

--- a/src/etc/installer/exe/rust.iss
+++ b/src/etc/installer/exe/rust.iss
@@ -46,6 +46,7 @@ Name: gcc; Description: "Linker and platform libraries"; Types: full
 Name: docs; Description: "HTML documentation"; Types: full
 Name: cargo; Description: "Cargo, the Rust package manager"; Types: full
 Name: std; Description: "The Rust Standard Library"; Types: full
+Name: rls; Description: "RLS, the Rust Language Server"
 
 [Files]
 Source: "rustc/*.*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs; Components: rust
@@ -55,6 +56,8 @@ Source: "rust-mingw/*.*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs;
 Source: "rust-docs/*.*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs; Components: docs
 Source: "cargo/*.*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs; Components: cargo
 Source: "rust-std/*.*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs; Components: std
+Source: "rls/*.*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs; Components: rls
+Source: "rust-analysis/*.*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs; Components: rls
 
 [Code]
 const

--- a/src/etc/installer/msi/rust.wxs
+++ b/src/etc/installer/msi/rust.wxs
@@ -170,6 +170,8 @@
                     <Directory Id="Docs" Name="." />
                     <Directory Id="Cargo" Name="." />
                     <Directory Id="Std" Name="." />
+                    <Directory Id="Rls" Name="." />
+                    <Directory Id="Analysis" Name="." />
                 </Directory>
             </Directory>
 
@@ -272,6 +274,14 @@
                  AllowAdvertise="no">
                  <ComponentRef Id="PathEnvPerMachine" />
                  <ComponentRef Id="PathEnvPerUser" />
+        </Feature>
+        <Feature Id="RLS"
+                 Title="RLS, the Rust Language Server"
+                 Display="7"
+                 Level="2"
+                 AllowAdvertise="no">
+                 <ComponentGroupRef Id="RlsGroup" />
+                 <ComponentGroupRef Id="AnalysisGroup" />
         </Feature>
 
         <UIRef Id="RustUI" />

--- a/src/etc/installer/pkg/Distribution.xml
+++ b/src/etc/installer/pkg/Distribution.xml
@@ -16,6 +16,7 @@
     <line choice="rust-std"/>
 	<line choice="cargo"/>
 	<line choice="rust-docs"/>
+	<line choice="rls"/>
       </line>
       <line choice="uninstall" />
     </choices-outline>
@@ -61,10 +62,20 @@
 	    >
         <pkg-ref id="org.rust-lang.rust-docs"/>
     </choice>
+    <choice id="rls" visible="true"
+	    title="RLS" description="RLS, the Rust Language Server"
+	    selected="(!choices.uninstall.selected &amp;&amp; choices['rls'].selected) || (choices.uninstall.selected &amp;&amp; choices.install.selected)"
+        start_selected="false"
+	    >
+        <pkg-ref id="org.rust-lang.rls"/>
+        <pkg-ref id="org.rust-lang.rust-analysis"/>
+    </choice>
     <pkg-ref id="org.rust-lang.rustc" version="0" onConclusion="none">rustc.pkg</pkg-ref>
     <pkg-ref id="org.rust-lang.cargo" version="0" onConclusion="none">cargo.pkg</pkg-ref>
     <pkg-ref id="org.rust-lang.rust-docs" version="0" onConclusion="none">rust-docs.pkg</pkg-ref>
     <pkg-ref id="org.rust-lang.rust-std" version="0" onConclusion="none">rust-std.pkg</pkg-ref>
+    <pkg-ref id="org.rust-lang.rls" version="0" onConclusion="none">rls.pkg</pkg-ref>
+    <pkg-ref id="org.rust-lang.rust-analysis" version="0" onConclusion="none">rust-analysis.pkg</pkg-ref>
     <pkg-ref id="org.rust-lang.uninstall" version="0" onConclusion="none">uninstall.pkg</pkg-ref>
     <background file="rust-logo.png" mime-type="image/png"
                 alignment="bottomleft"/>

--- a/src/etc/installer/pkg/Distribution.xml
+++ b/src/etc/installer/pkg/Distribution.xml
@@ -12,61 +12,61 @@
     </volume-check>
     <choices-outline>
       <line choice="install">
-	<line choice="rustc"/>
-    <line choice="rust-std"/>
-	<line choice="cargo"/>
-	<line choice="rust-docs"/>
-	<line choice="rls"/>
+      <line choice="rustc"/>
+      <line choice="rust-std"/>
+      <line choice="cargo"/>
+      <line choice="rust-docs"/>
+      <line choice="rls"/>
       </line>
       <line choice="uninstall" />
     </choices-outline>
     <!--
-	These 'selected' scripts ensure that install and uninstall can never be selected at
-	the same time. Exectly how they work is pretty mysterious, tied to the unspecified algorithm
-	the installer uses to traverse the options after one is toggled.
+    These 'selected' scripts ensure that install and uninstall can never be selected at
+    the same time. Exectly how they work is pretty mysterious, tied to the unspecified algorithm
+    the installer uses to traverse the options after one is toggled.
       -->
     <choice id="install" visible="true"
-	    title="Install Rust" description="Install the Rust compiler, package manager and documentation."
-	    customLocation="/usr/local"
-	    selected="!choices.uninstall.selected"
-	    />
+        title="Install Rust" description="Install the Rust compiler, package manager and documentation."
+        customLocation="/usr/local"
+        selected="!choices.uninstall.selected"
+        />
     <choice id="uninstall" visible="true"
-	    title="Uninstall Rust" description="Select this option to uninstall an existing Rust installation."
-	    customLocation="/usr/local"
-	    selected="!(choices.install.selected || choices.rustc.selected || choices.cargo.selected || choices['rust-docs'].selected)"
-	    start_selected="false"
-	    >
-        <pkg-ref id="org.rust-lang.uninstall" />
+        title="Uninstall Rust" description="Select this option to uninstall an existing Rust installation."
+        customLocation="/usr/local"
+        selected="!(choices.install.selected || choices.rustc.selected || choices.cargo.selected || choices['rust-docs'].selected)"
+        start_selected="false"
+        >
+        <pkg-ref id="org.rust-lang.uninstall"/>
     </choice>
     <choice id="rustc" visible="true"
-	    title="Compiler" description="rustc, the Rust compiler, and rustdoc, the API documentation tool."
-	    selected="(!choices.uninstall.selected &amp;&amp; choices.rustc.selected) || (choices.uninstall.selected &amp;&amp; choices.install.selected)"
-	    >
+        title="Compiler" description="rustc, the Rust compiler, and rustdoc, the API documentation tool."
+        selected="(!choices.uninstall.selected &amp;&amp; choices.rustc.selected) || (choices.uninstall.selected &amp;&amp; choices.install.selected)"
+        >
         <pkg-ref id="org.rust-lang.rustc"/>
     </choice>
     <choice id="cargo" visible="true"
-	    title="Cargo" description="cargo, the Rust package manager."
-	    selected="(!choices.uninstall.selected &amp;&amp; choices.cargo.selected) || (choices.uninstall.selected &amp;&amp; choices.install.selected)"
-	    >
+        title="Cargo" description="cargo, the Rust package manager."
+        selected="(!choices.uninstall.selected &amp;&amp; choices.cargo.selected) || (choices.uninstall.selected &amp;&amp; choices.install.selected)"
+        >
         <pkg-ref id="org.rust-lang.cargo"/>
     </choice>
     <choice id="rust-std" visible="true"
-	    title="Standard Library" description="The Rust standard library."
-	    selected="(!choices.uninstall.selected &amp;&amp; choices['rust-std'].selected) || (choices.uninstall.selected &amp;&amp; choices.install.selected)"
-	    >
+        title="Standard Library" description="The Rust standard library."
+        selected="(!choices.uninstall.selected &amp;&amp; choices['rust-std'].selected) || (choices.uninstall.selected &amp;&amp; choices.install.selected)"
+        >
         <pkg-ref id="org.rust-lang.rust-std"/>
     </choice>
     <choice id="rust-docs" visible="true"
-	    title="Documentation" description="HTML documentation."
-	    selected="(!choices.uninstall.selected &amp;&amp; choices['rust-docs'].selected) || (choices.uninstall.selected &amp;&amp; choices.install.selected)"
-	    >
+        title="Documentation" description="HTML documentation."
+        selected="(!choices.uninstall.selected &amp;&amp; choices['rust-docs'].selected) || (choices.uninstall.selected &amp;&amp; choices.install.selected)"
+        >
         <pkg-ref id="org.rust-lang.rust-docs"/>
     </choice>
     <choice id="rls" visible="true"
-	    title="RLS" description="RLS, the Rust Language Server"
-	    selected="(!choices.uninstall.selected &amp;&amp; choices['rls'].selected) || (choices.uninstall.selected &amp;&amp; choices.install.selected)"
+        title="RLS" description="RLS, the Rust Language Server"
+        selected="(!choices.uninstall.selected &amp;&amp; choices['rls'].selected) || (choices.uninstall.selected &amp;&amp; choices.install.selected)"
         start_selected="false"
-	    >
+        >
         <pkg-ref id="org.rust-lang.rls"/>
         <pkg-ref id="org.rust-lang.rust-analysis"/>
     </choice>


### PR DESCRIPTION
This directly addresses issue #42157, adding the RLS as a non-default component in the mentioned installers. The windows installers appear to have the right functionality added, but I don't have a machine that runs OSX, so it would be great if someone could test whether my .pkg commit adds the RLS correctly. The final commit also fixes some formatting issues I'd noticed while working on the installers, but I don't know if that's within the scope of this PR, so input would be appreciated.