### PR TITLE
Make rustdoc.js use license comments.

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1,12 +1,14 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
+/*!
+ * Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+ * file at the top-level directory of this distribution and at
+ * http://rust-lang.org/COPYRIGHT.
+ *
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
+ */
 
 /*jslint browser: true, es5: true */
 /*globals $: true, rootPath: true */

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -169,8 +169,10 @@ fn licenseck(file: &Path, contents: &str) -> bool {
     lines.windows(LICENSE.lines().count()).any(|window| {
         let offset = if window.iter().all(|w| w.starts_with("//")) {
             2
-        } else if window.iter().all(|w| w.starts_with("#")) {
+        } else if window.iter().all(|w| w.starts_with('#')) {
             1
+        } else if window.iter().all(|w| w.starts_with(" *")) {
+            2
         } else {
             return false
         };


### PR DESCRIPTION
This will ensure that JS minifiers and the like will preserve the license statement even after minimisation.