### PR TITLE
RangeFrom should have an infinite size_hint

### DIFF
--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -130,9 +130,10 @@ pub trait Iterator {
     ///
     /// ```
     /// // an infinite iterator has no upper bound
+    /// // and the maximum possible lower bound
     /// let iter = 0..;
     ///
-    /// assert_eq!((0, None), iter.size_hint());
+    /// assert_eq!((usize::max_value(), None), iter.size_hint());
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -543,6 +543,11 @@ impl<A: Step> Iterator for ops::RangeFrom<A> where
         mem::swap(&mut n, &mut self.start);
         Some(n)
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (usize::MAX, None)
+    }
 }
 
 #[unstable(feature = "fused", issue = "35602")]

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -764,6 +764,7 @@ fn test_iterator_size_hint() {
     let v2 = &[10, 11, 12];
     let vi = v.iter();
 
+    assert_eq!((0..).size_hint(), (usize::MAX, None));
     assert_eq!(c.size_hint(), (usize::MAX, None));
     assert_eq!(vi.clone().size_hint(), (10, Some(10)));
 


### PR DESCRIPTION
Before,
```rust
(0..).take(4).size_hint() == (0, Some(4))
```

With this change,
```rust
(0..).take(4).size_hint() == (4, Some(4))
```