### PR TITLE
Improve error message for const extern fn

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5981,6 +5981,10 @@ impl<'a> Parser<'a> {
             return Ok(Some(self.parse_item_foreign_fn(visibility, lo, attrs)?));
         }
 
+        if self.check_keyword(keywords::Const) {
+            return Err(self.span_fatal(self.span, "extern items cannot be `const`"));
+        }
+
         // FIXME #5668: this will occur for a macro invocation:
         match self.parse_macro_use_or_failure(attrs, true, false, lo, visibility)? {
             Some(item) => {

--- a/src/test/parse-fail/removed-syntax-extern-const.rs
+++ b/src/test/parse-fail/removed-syntax-extern-const.rs
@@ -12,5 +12,5 @@
 
 extern {
     const i: isize;
-    //~^ ERROR expected one of `fn`, `pub`, `static`, or `}`, found `const`
+    //~^ ERROR extern items cannot be `const`
 }


### PR DESCRIPTION
It's currently ``error: unmatched visibility `pub` ``, which is a nonsensical error in this context.