### PR TITLE
Parse macros named "default" correctly.

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3749,6 +3749,16 @@ impl<'a> Parser<'a> {
                         t.is_keyword(keywords::Pub))
     }
 
+    fn eat_defaultness(&mut self) -> bool {
+        let is_defaultness = self.is_defaultness();
+        if is_defaultness {
+            self.bump()
+        } else {
+            self.expected_tokens.push(TokenType::Keyword(keywords::Default));
+        }
+        is_defaultness
+    }
+
     fn eat_macro_def(&mut self, attrs: &[Attribute], vis: &Visibility)
                      -> PResult<'a, Option<P<Item>>> {
         let lo = self.span;
@@ -5223,8 +5233,7 @@ impl<'a> Parser<'a> {
 
     /// Parse defaultness: DEFAULT or nothing
     fn parse_defaultness(&mut self) -> PResult<'a, Defaultness> {
-        if self.is_defaultness() {
-            self.bump();
+        if self.eat_defaultness() {
             Ok(Defaultness::Default)
         } else {
             Ok(Defaultness::Final)

--- a/src/test/run-pass/macro-named-default.rs
+++ b/src/test/run-pass/macro-named-default.rs
@@ -1,0 +1,27 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! default {
+    ($($x:tt)*) => { $($x)* }
+}
+
+default! {
+    struct A;
+}
+
+impl A {
+    default! {
+        fn foo(&self) {}
+    }
+}
+
+fn main() {
+    A.foo();
+}


### PR DESCRIPTION
Fixes #42292.