### PR TITLE
Improve reallocation in alloc_system on Windows

### DIFF
--- a/src/libcollections/tests/lib.rs
+++ b/src/libcollections/tests/lib.rs
@@ -10,6 +10,7 @@
 
 #![deny(warnings)]
 
+#![feature(attr_literals)]
 #![feature(box_syntax)]
 #![feature(inclusive_range_syntax)]
 #![feature(collection_placement)]
@@ -19,6 +20,7 @@
 #![feature(pattern)]
 #![feature(placement_in_syntax)]
 #![feature(rand)]
+#![feature(repr_align)]
 #![feature(slice_rotate)]
 #![feature(splice)]
 #![feature(step_by)]

--- a/src/libcollections/tests/vec.rs
+++ b/src/libcollections/tests/vec.rs
@@ -781,3 +781,18 @@ fn from_into_inner() {
     assert_eq!(vec, [2, 3]);
     assert!(ptr != vec.as_ptr());
 }
+
+#[test]
+fn overaligned_allocations() {
+    #[repr(align(256))]
+    struct Foo(usize);
+    let mut v = vec![Foo(273)];
+    for i in 0..0x1000 {
+        v.reserve_exact(i);
+        assert!(v[0].0 == 273);
+        assert!(v.as_ptr() as usize & 0xff == 0);
+        v.shrink_to_fit();
+        assert!(v[0].0 == 273);
+        assert!(v.as_ptr() as usize & 0xff == 0);
+    }
+}


### PR DESCRIPTION
For allocations where the alignment is greater than the alignment guaranteed by `HeapAlloc`, the implementation will overallocate by `align` bytes. `align_ptr` will the get the first address within that allocation satisfying the alignment (other than the base of the allocation) and write the address of the original allocation a pointer size before that aligned address. What the offset is within any given overaligned allocation varies on a per allocation basis, which means the offset of data written to the allocation varies on a per allocation basis.

The old version of `reallocate` would always call `HeapRealloc`, which will move the allocation to a new address, which has the side effect of causing the aligned offset within the allocation to possibly change. Since the data itself wasn't moved to the new offset but remained at its old offset, this effectively *changed* the data in the allocation which is of course quite bad.

The new version does exactly what the unix version does, which is to allocate a brand new buffer, figure out what the aligned address is, and then memcpy over the data from the old aligned address to the new aligned address, which works just fine.

While I was at it, I updated `reallocate_inplace` to be able to do inplace reallocations of overaligned data. Because inplace reallocation does not change the base address of the allocation, it does not change the aligned offset, therefore the data will safely remain in the same location without issue.

Fixes https://github.com/rust-lang/rust/issues/42025