### PR TITLE
Extend the unused macro lint to macros 2.0

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1200,7 +1200,7 @@ pub struct Resolver<'a> {
     pub found_unresolved_macro: bool,
 
     // List of crate local macros that we need to warn about as being unused.
-    // Right now this only includes macro_rules! macros, and 2.0 macros.
+    // Right now this only includes macro_rules! macros, and macros 2.0.
     unused_macros: FxHashSet<DefId>,
 
     // Maps the `Mark` of an expansion to its containing module or block.

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1200,7 +1200,7 @@ pub struct Resolver<'a> {
     pub found_unresolved_macro: bool,
 
     // List of crate local macros that we need to warn about as being unused.
-    // Right now this only includes macro_rules! macros.
+    // Right now this only includes macro_rules! macros, and 2.0 macros.
     unused_macros: FxHashSet<DefId>,
 
     // Maps the `Mark` of an expansion to its containing module or block.

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -316,6 +316,7 @@ impl<'a> base::Resolver for Resolver<'a> {
         for did in self.unused_macros.iter() {
             let id_span = match *self.macro_map[did] {
                 SyntaxExtension::NormalTT(_, isp, _) => isp,
+                SyntaxExtension::DeclMacro(.., osp) => osp,
                 _ => None,
             };
             if let Some((id, span)) = id_span {
@@ -735,6 +736,9 @@ impl<'a> Resolver<'a> {
             let module = self.current_module;
             let def = Def::Macro(def_id, MacroKind::Bang);
             let vis = self.resolve_visibility(&item.vis);
+            if vis != ty::Visibility::Public {
+                self.unused_macros.insert(def_id);
+            }
             self.define(module, ident, MacroNS, (def, vis, item.span, expansion));
         }
     }

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -552,7 +552,9 @@ pub enum SyntaxExtension {
     BuiltinDerive(BuiltinDeriveFn),
 
     /// A declarative macro, e.g. `macro m() {}`.
-    DeclMacro(Box<TTMacroExpander>, Option<Span> /* definition site span */),
+    ///
+    /// The second element is the definition site span.
+    DeclMacro(Box<TTMacroExpander>, Option<(ast::NodeId, Span)>),
 }
 
 impl SyntaxExtension {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -472,8 +472,9 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
 
         let marked_tts = noop_fold_tts(mac.node.stream(), &mut Marker(mark));
         let opt_expanded = match *ext {
-            SyntaxExtension::DeclMacro(ref expand, def_site_span) => {
-                if let Err(msg) = validate_and_set_expn_info(def_site_span, false) {
+            SyntaxExtension::DeclMacro(ref expand, def_span) => {
+                if let Err(msg) = validate_and_set_expn_info(def_span.map(|(_, s)| s),
+                                                             false) {
                     self.cx.span_err(path.span, &msg);
                     return kind.dummy(span);
                 }

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -266,7 +266,7 @@ pub fn compile(sess: &ParseSess, features: &RefCell<Features>, def: &ast::Item) 
         let allow_internal_unstable = attr::contains_name(&def.attrs, "allow_internal_unstable");
         NormalTT(exp, Some((def.id, def.span)), allow_internal_unstable)
     } else {
-        SyntaxExtension::DeclMacro(exp, Some(def.span))
+        SyntaxExtension::DeclMacro(exp, Some((def.id, def.span)))
     }
 }
 

--- a/src/test/compile-fail/feature-gate-decl_macro.rs
+++ b/src/test/compile-fail/feature-gate-decl_macro.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_macros)]
+
 macro m() {} //~ ERROR `macro` is experimental (see issue #39412)
 //~| HELP add #![feature(decl_macro)] to the crate attributes to enable
 

--- a/src/test/compile-fail/unused-macro-rules.rs
+++ b/src/test/compile-fail/unused-macro-rules.rs
@@ -8,13 +8,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(decl_macro)]
 #![deny(unused_macros)]
 
 // Most simple case
-macro unused { //~ ERROR: unused macro definition
-    () => {}
+macro_rules! unused { //~ ERROR: unused macro definition
+    () => {};
 }
+
+// Test macros created by macros
+macro_rules! create_macro {
+    () => {
+        macro_rules! m { //~ ERROR: unused macro definition
+            () => {};
+        }
+    };
+}
+create_macro!();
 
 #[allow(unused_macros)]
 mod bar {
@@ -22,14 +31,8 @@ mod bar {
     // works.
 
     #[deny(unused_macros)]
-    macro unused { //~ ERROR: unused macro definition
-        () => {}
-    }
-}
-
-mod boo {
-    pub(crate) macro unused { //~ ERROR: unused macro definition
-        () => {}
+    macro_rules! unused { //~ ERROR: unused macro definition
+        () => {};
     }
 }
 


### PR DESCRIPTION
Extends the unused macro lint (added in PR #41907) to macros 2.0 (added in PR #40847).

r? @jseyfried 