### PR TITLE
Don't byteswap Fingerprints when encoding

### DIFF
--- a/src/librustc/ich/fingerprint.rs
+++ b/src/librustc/ich/fingerprint.rs
@@ -8,12 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use rustc_serialize::{Encodable, Decodable, Encoder, Decoder};
 use rustc_data_structures::stable_hasher;
 use std::mem;
 use std::slice;
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Clone, Copy)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Clone, Copy, RustcEncodable, RustcDecodable)]
 pub struct Fingerprint(u64, u64);
 
 impl Fingerprint {
@@ -34,23 +33,6 @@ impl Fingerprint {
 
     pub fn to_hex(&self) -> String {
         format!("{:x}{:x}", self.0, self.1)
-    }
-}
-
-impl Encodable for Fingerprint {
-    #[inline]
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-        s.emit_u64(self.0.to_le())?;
-        s.emit_u64(self.1.to_le())
-    }
-}
-
-impl Decodable for Fingerprint {
-    #[inline]
-    fn decode<D: Decoder>(d: &mut D) -> Result<Fingerprint, D::Error> {
-        let _0 = u64::from_le(d.read_u64()?);
-        let _1 = u64::from_le(d.read_u64()?);
-        Ok(Fingerprint(_0, _1))
     }
 }
 


### PR DESCRIPTION
Byteswapping Fingerprints when encoding is unnessesary and breaks if the Fingerprint is later decoded on a machine with different endianness to the one it was encoded on.

Fixes #42239

This PR fixes a regression caused by #42082. @michaelwoerister