### PR TITLE
Reduce verbosity of build logs

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -184,7 +184,7 @@ pub fn llvm(build: &Build, target: &str) {
     configure_compilers(&mut cfg);
 
     if env::var_os("SCCACHE_ERROR_LOG").is_some() {
-        cfg.env("RUST_LOG", "sccache=info");
+        cfg.env("RUST_LOG", "sccache=warn");
     }
 
     // FIXME: we don't actually need to build all LLVM tools and all LLVM

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -79,6 +79,7 @@ exec docker \
   --env DEPLOY_ALT=$DEPLOY_ALT \
   --env LOCAL_USER_ID=`id -u` \
   --env TRAVIS=${TRAVIS-false} \
+  --env TRAVIS_BRANCH \
   --volume "$HOME/.cargo:/cargo" \
   --volume "$HOME/rustsrc:$HOME/rustsrc" \
   --privileged \

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -23,6 +23,10 @@ fi
 ci_dir=`cd $(dirname $0) && pwd`
 source "$ci_dir/shared.sh"
 
+if [ "$TRAVIS" == "true" ] && [ "$TRAVIS_BRANCH" != "auto" ]; then
+    RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-quiet-tests"
+fi
+
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-sccache"
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-manage-submodules"
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-locked-deps"


### PR DESCRIPTION
This does two separate things.
 - Sets sccache logging to warn instead of info.
 - Makes tests when running for a given PR (not on auto branch) quiet. (cc @eddyb)

r? @alexcrichton 
