### PR TITLE
rustbuild: Remove RUSTFLAGS logic in rustc shim

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -232,12 +232,6 @@ fn main() {
             if let Some(rpath) = rpath {
                 cmd.arg("-C").arg(format!("link-args={}", rpath));
             }
-
-            if let Ok(s) = env::var("RUSTFLAGS") {
-                for flag in s.split_whitespace() {
-                    cmd.arg(flag);
-                }
-            }
         }
 
         if target.contains("pc-windows-msvc") {


### PR DESCRIPTION
This was added in #38072 but I can't recall why and AFAIK Cargo already handles
this. This was discovered through #42146 where passing duplicate flags was
causing problems.