### PR TITLE
rustdoc: Hide `self: Box<Self>` in list of deref methods

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -124,6 +124,7 @@ impl<'a, 'tcx> Clean<Crate> for visit_ast::RustdocVisitor<'a, 'tcx> {
             let mut r = cx.renderinfo.borrow_mut();
             r.deref_trait_did = cx.tcx.lang_items.deref_trait();
             r.deref_mut_trait_did = cx.tcx.lang_items.deref_mut_trait();
+            r.owned_box_did = cx.tcx.lang_items.owned_box();
         }
 
         let mut externs = Vec::new();

--- a/src/test/rustdoc/issue-35169-2.rs
+++ b/src/test/rustdoc/issue-35169-2.rs
@@ -19,6 +19,8 @@ impl Foo {
     pub fn by_explicit_ref(self: &Foo) {}
     pub fn by_mut_ref(&mut self) {}
     pub fn by_explicit_mut_ref(self: &mut Foo) {}
+    pub fn by_explicit_box(self: Box<Foo>) {}
+    pub fn by_explicit_self_box(self: Box<Self>) {}
     pub fn static_foo() {}
 }
 
@@ -41,5 +43,9 @@ impl DerefMut for Bar {
 // @has - '//*[@id="method.by_mut_ref"]' 'fn by_mut_ref(&mut self)'
 // @has - '//*[@id="by_explicit_mut_ref.v"]' 'fn by_explicit_mut_ref(self: &mut Foo)'
 // @has - '//*[@id="method.by_explicit_mut_ref"]' 'fn by_explicit_mut_ref(self: &mut Foo)'
+// @!has - '//*[@id="by_explicit_box.v"]' 'fn by_explicit_box(self: Box<Foo>)'
+// @!has - '//*[@id="method.by_explicit_box"]' 'fn by_explicit_box(self: Box<Foo>)'
+// @!has - '//*[@id="by_explicit_self_box.v"]' 'fn by_explicit_self_box(self: Box<Self>)'
+// @!has - '//*[@id="method.by_explicit_self_box"]' 'fn by_explicit_self_box(self: Box<Self>)'
 // @!has - '//*[@id="static_foo.v"]' 'fn static_foo()'
 // @!has - '//*[@id="method.static_foo"]' 'fn static_foo()'

--- a/src/test/rustdoc/issue-35169.rs
+++ b/src/test/rustdoc/issue-35169.rs
@@ -18,6 +18,8 @@ impl Foo {
     pub fn by_explicit_ref(self: &Foo) {}
     pub fn by_mut_ref(&mut self) {}
     pub fn by_explicit_mut_ref(self: &mut Foo) {}
+    pub fn by_explicit_box(self: Box<Foo>) {}
+    pub fn by_explicit_self_box(self: Box<Self>) {}
     pub fn static_foo() {}
 }
 
@@ -36,5 +38,9 @@ impl Deref for Bar {
 // @!has - '//*[@id="method.by_mut_ref"]' 'fn by_mut_ref(&mut self)'
 // @!has - '//*[@id="by_explicit_mut_ref.v"]' 'fn by_explicit_mut_ref(self: &mut Foo)'
 // @!has - '//*[@id="method.by_explicit_mut_ref"]' 'fn by_explicit_mut_ref(self: &mut Foo)'
+// @!has - '//*[@id="by_explicit_box.v"]' 'fn by_explicit_box(self: Box<Foo>)'
+// @!has - '//*[@id="method.by_explicit_box"]' 'fn by_explicit_box(self: Box<Foo>)'
+// @!has - '//*[@id="by_explicit_self_box.v"]' 'fn by_explicit_self_box(self: Box<Self>)'
+// @!has - '//*[@id="method.by_explicit_self_box"]' 'fn by_explicit_self_box(self: Box<Self>)'
 // @!has - '//*[@id="static_foo.v"]' 'fn static_foo()'
 // @!has - '//*[@id="method.static_foo"]' 'fn static_foo()'


### PR DESCRIPTION
These methods can never be called through deref so there is no point including them. For example you can't call [`into_boxed_bytes`](https://doc.rust-lang.org/nightly/std/string/struct.String.html#method.into_boxed_bytes) or [`into_string`](https://doc.rust-lang.org/nightly/std/string/struct.String.html#method.into_string) on `String`.