### PR TITLE
Create directory for dump-mir-dir automatically

### DIFF
--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -111,6 +111,7 @@ fn dump_matched_mir_node<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         let p = Path::new(file_dir);
         file_path.push(p);
     };
+    let _ = fs::create_dir_all(&file_path);
     let file_name = format!("rustc.node{}{}{}.{}.{}.mir",
                             source.item_id(), promotion_id, pass_num, pass_name, disambiguator);
     file_path.push(&file_name);


### PR DESCRIPTION
Fixes #35543 r? @Mark-Simulacrum 

@Mark-Simulacrum I know someone else said that they'll work on this, but it has been 3+ weeks and I had nothing to do and wanted to contribute a bit.

I now added the call to automatically create the directory as discussed, but was wondering how you feel about the suggestion to set a default directory, i.e. `target/mir`?