### PR TITLE
Allow `default type` to be projected in the fully monomorphic case

### DIFF
--- a/src/librustc/traits/project.rs
+++ b/src/librustc/traits/project.rs
@@ -38,28 +38,9 @@ use util::common::FN_OUTPUT_NAME;
 /// more or less conservative.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Reveal {
-    /// At type-checking time, we refuse to project any associated
-    /// type that is marked `default`. Non-`default` ("final") types
-    /// are always projected. This is necessary in general for
-    /// soundness of specialization. However, we *could* allow
-    /// projections in fully-monomorphic cases. We choose not to,
-    /// because we prefer for `default type` to force the type
-    /// definition to be treated abstractly by any consumers of the
-    /// impl. Concretely, that means that the following example will
-    /// fail to compile:
-    ///
-    /// ```
-    /// trait Assoc {
-    ///     type Output;
-    /// }
-    ///
-    /// impl<T> Assoc for T {
-    ///     default type Output = bool;
-    /// }
-    ///
-    /// fn main() {
-    ///     let <() as Assoc>::Output = true;
-    /// }
+    /// At type-checking time, we avoid projecting the concrete type of
+    /// `impl Trait`. We do allow other monomorphic projections, such as
+    /// `default type` in the fully monomorphic case.
     UserFacing,
 
     /// At trans time, all monomorphic projections will succeed.
@@ -949,15 +930,13 @@ fn assemble_candidates_from_impls<'cx, 'gcx, 'tcx>(
                 // get a result which isn't correct for all monomorphizations.
                 let new_candidate = if !is_default {
                     Some(ProjectionTyCandidate::Select)
-                } else if obligation.param_env.reveal == Reveal::All {
+                } else {
                     assert!(!poly_trait_ref.needs_infer());
                     if !poly_trait_ref.needs_subst() {
                         Some(ProjectionTyCandidate::Select)
                     } else {
                         None
                     }
-                } else {
-                    None
                 };
 
                 candidate_set.vec.extend(new_candidate);

--- a/src/test/compile-fail/specialization/defaultimpl/specialization-default-projection.rs
+++ b/src/test/compile-fail/specialization/defaultimpl/specialization-default-projection.rs
@@ -32,10 +32,10 @@ fn generic<T>() -> <T as Foo>::Assoc {
 }
 
 fn monomorphic() -> () {
-    // Even though we know that `()` is not specialized in a
-    // downstream crate, typeck refuses to project here.
+    // Since we know that `()` is not specialized in a
+    // downstream crate, typeck allows projection here.
 
-    generic::<()>() //~ ERROR mismatched types
+    generic::<()>()
 }
 
 fn main() {

--- a/src/test/compile-fail/specialization/specialization-default-projection.rs
+++ b/src/test/compile-fail/specialization/specialization-default-projection.rs
@@ -32,10 +32,10 @@ fn generic<T>() -> <T as Foo>::Assoc {
 }
 
 fn monomorphic() -> () {
-    // Even though we know that `()` is not specialized in a
-    // downstream crate, typeck refuses to project here.
+    // Since we know that `()` is not specialized in a
+    // downstream crate, typeck allows projection here.
 
-    generic::<()>() //~ ERROR mismatched types
+    generic::<()>()
 }
 
 fn main() {

--- a/src/test/compile-fail/ufcs-partially-resolved.rs
+++ b/src/test/compile-fail/ufcs-partially-resolved.rs
@@ -45,7 +45,7 @@ fn main() {
     <u8 as A>::N::NN; //~ ERROR cannot find associated type `N` in `A`
     let _: <u8 as Tr>::Y::NN; //~ ERROR ambiguous associated type
     let _: <u8 as E>::Y::NN; //~ ERROR expected associated type, found variant `E::Y`
-    <u8 as Tr>::Y::NN; //~ ERROR no associated item named `NN` found for type `<u8 as Tr>::Y`
+    <u8 as Tr>::Y::NN; //~ ERROR no associated item named `NN` found for type `u16`
     <u8 as E>::Y::NN; //~ ERROR expected associated type, found variant `E::Y`
 
     let _: <u8 as Tr::N>::NN; //~ ERROR cannot find associated type `NN` in `Tr::N`
@@ -62,5 +62,5 @@ fn main() {
     let _: <u8 as Dr>::Z; //~ ERROR expected associated type, found method `Dr::Z`
     <u8 as Dr>::X; //~ ERROR expected method or associated constant, found associated type `Dr::X`
     let _: <u8 as Dr>::Z::N; //~ ERROR expected associated type, found method `Dr::Z`
-    <u8 as Dr>::X::N; //~ ERROR no associated item named `N` found for type `<u8 as Dr>::X`
+    <u8 as Dr>::X::N; //~ ERROR no associated item named `N` found for type `u16`
 }


### PR DESCRIPTION
While I understand the intention behind this decision, I think there are
a ton of cases that it disables which haven't been considered.
Ultimately users are more likely to run into this limitation when trying
to use a type that has a bound such as: `T:
SomeTrait<AssocType=SpecificValue>`. The fact that this bound can fail
can end up being extremely non-local and confusing.

To put this another way, I think the effect of this ends up being the
opposite of what was intended. Simply because I allow an impl to be
specialized, I can no longer use any type which uses that impl in a
context with additional bounds beyond the original trait. Even when I
know the exact type and know that the bounds have been met.

As a simple example, let's say we wanted to change the blanket `impl<T:
Iterator> IntoIterator for T` to be a `default impl` so that iterators
could implement it differently if they chose to (a bit contrived, but
maybe item is a type parameter instead of an associated type in this
case). By adding the word `default`, I can no longer pass any iterator
to any function which has additional bounds (e.g. `T: IntoIterator,
T::Iterator: ExactSizeIterator`), even though I know those bounds have
been met.

With this example, it's reasonable to say "well just don't use
specialization here, that's the tradeoff". However, many of the use
cases for specialization are for places where there is no reasonable way
to write a base impl of a trait in a way that doesn't overlap with more
concrete impls. Here is a more concrete use case from Diesel:
https://is.gd/IjMCMp (simplified version https://is.gd/eImBH7)

You could also consider cases like this code (which doesn't compile for
other reasons, but gets the point accross): https://is.gd/UlniuY

Ultimately disallowing projection in the monomorphic case neuters most
uses of `default type`. While I understand the intention of wanting to
force it to be treated as an abstract interface, ultimately *some* code
has to be monomorphic, and will want to rely on the concrete value of
the type. The fact that some concrete type happens to use an impl that
was specializable by other types should not remove the ability to do
that.