### PR TITLE
Remove 'elided' from lifetime resolution error

### DIFF
--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -1363,7 +1363,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
             m.push_str(&(if n == 1 {
                 help_name
             } else {
-                format!("one of {}'s {} elided {}lifetimes", help_name, n,
+                format!("one of {}'s {} {}lifetimes", help_name, n,
                         if have_bound_regions { "free " } else { "" } )
             })[..]);
 

--- a/src/test/compile-fail/issue-26638.rs
+++ b/src/test/compile-fail/issue-26638.rs
@@ -10,7 +10,7 @@
 
 fn parse_type(iter: Box<Iterator<Item=&str>+'static>) -> &str { iter.next() }
 //~^ ERROR missing lifetime specifier [E0106]
-//~^^ HELP 2 elided lifetimes
+//~^^ HELP 2 lifetimes
 
 fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
 //~^ ERROR missing lifetime specifier [E0106]

--- a/src/test/compile-fail/issue-30255.rs
+++ b/src/test/compile-fail/issue-30255.rs
@@ -17,19 +17,19 @@ struct S<'a> {
 
 fn f(a: &S, b: i32) -> &i32 {
 //~^ ERROR missing lifetime specifier [E0106]
-//~^^ HELP does not say which one of `a`'s 2 elided lifetimes it is borrowed from
+//~^^ HELP does not say which one of `a`'s 2 lifetimes it is borrowed from
     panic!();
 }
 
 fn g(a: &S, b: bool, c: &i32) -> &i32 {
 //~^ ERROR missing lifetime specifier [E0106]
-//~^^ HELP does not say whether it is borrowed from one of `a`'s 2 elided lifetimes or `c`
+//~^^ HELP does not say whether it is borrowed from one of `a`'s 2 lifetimes or `c`
     panic!();
 }
 
 fn h(a: &bool, b: bool, c: &S, d: &i32) -> &i32 {
 //~^ ERROR missing lifetime specifier [E0106]
-//~^^ HELP does not say whether it is borrowed from `a`, one of `c`'s 2 elided lifetimes, or `d`
+//~^^ HELP does not say whether it is borrowed from `a`, one of `c`'s 2 lifetimes, or `d`
     panic!();
 }
 

--- a/src/test/compile-fail/lifetime-elision-return-type-requires-explicit-lifetime.rs
+++ b/src/test/compile-fail/lifetime-elision-return-type-requires-explicit-lifetime.rs
@@ -28,7 +28,7 @@ struct Foo<'a> {
 // Lifetime annotation needed because we have two lifetimes: one as a parameter
 // and one on the reference.
 fn h(_x: &Foo) -> &isize { //~ ERROR missing lifetime specifier
-//~^ HELP the signature does not say which one of `_x`'s 2 elided lifetimes it is borrowed from
+//~^ HELP the signature does not say which one of `_x`'s 2 lifetimes it is borrowed from
     panic!()
 }
 


### PR DESCRIPTION
Removes 'elided' from lifetime resolution errors
Removes 'elided' from relevant error messaging tests

This PR resolves https://github.com/rust-lang/rust/issues/29094

r? @Mark-Simulacrum 