### PR TITLE
Explicate what "Rc" and "Arc" stand for.

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -42,8 +42,8 @@ use heap::deallocate;
 /// necessarily) at _exactly_ `MAX_REFCOUNT + 1` references.
 const MAX_REFCOUNT: usize = (isize::MAX) as usize;
 
-/// A thread-safe reference-counting pointer. "Arc" stands for "Atomically
-/// Reference Counted".
+/// A thread-safe reference-counting pointer. 'Arc' stands for 'Atomically
+/// Reference Counted'.
 ///
 /// The type `Arc<T>` provides shared ownership of a value of type `T`,
 /// allocated in the heap. Invoking [`clone`][clone] on `Arc` produces

--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -42,7 +42,8 @@ use heap::deallocate;
 /// necessarily) at _exactly_ `MAX_REFCOUNT + 1` references.
 const MAX_REFCOUNT: usize = (isize::MAX) as usize;
 
-/// A thread-safe reference-counting pointer.
+/// A thread-safe reference-counting pointer. "Arc" stands for "Atomically
+/// Reference Counted".
 ///
 /// The type `Arc<T>` provides shared ownership of a value of type `T`,
 /// allocated in the heap. Invoking [`clone`][clone] on `Arc` produces

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -10,8 +10,8 @@
 
 #![allow(deprecated)]
 
-//! Single-threaded reference-counting pointers. "Rc" stands for "Reference
-//! Counted".
+//! Single-threaded reference-counting pointers. 'Rc' stands for 'Reference
+//! Counted'.
 //!
 //! The type [`Rc<T>`][`Rc`] provides shared ownership of a value of type `T`,
 //! allocated in the heap. Invoking [`clone`][clone] on [`Rc`] produces a new
@@ -267,7 +267,8 @@ struct RcBox<T: ?Sized> {
     value: T,
 }
 
-/// A single-threaded reference-counting pointer.
+/// A single-threaded reference-counting pointer. 'Rc' stands for 'Reference
+/// Counted'.
 ///
 /// See the [module-level documentation](./index.html) for more details.
 ///

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -10,7 +10,8 @@
 
 #![allow(deprecated)]
 
-//! Single-threaded reference-counting pointers.
+//! Single-threaded reference-counting pointers. "Rc" stands for "Reference
+//! Counted".
 //!
 //! The type [`Rc<T>`][`Rc`] provides shared ownership of a value of type `T`,
 //! allocated in the heap. Invoking [`clone`][clone] on [`Rc`] produces a new


### PR DESCRIPTION
A person on the weekly "Easy Questions" Reddit thread [was mystified by what `Arc`/`Rc` means](https://www.reddit.com/r/rust/comments/6dyud9/hey_rustaceans_got_an_easy_question_ask_here/did87ds/). Though this is explained in various places, it's not mentioned in the documentation directly.

This PR adds an explanation of the `Rc`/`Arc` acronyms to their respective documentations. There are two things I'm not sure of:

* Does "Rc" mean "Reference Count**er**" or "Reference Count**ed**"? ~~I went with the former.~~ *Edit:* I've changed this to use the latter alternative.
* Should this information be spelled out elsewhere, such as in the docs for the `rc` module?