### PR TITLE
Always quote program name in Command::spawn on Windows

### DIFF
--- a/src/test/run-make/windows-spawn/Makefile
+++ b/src/test/run-make/windows-spawn/Makefile
@@ -1,0 +1,14 @@
+-include ../tools.mk
+
+ifdef IS_WINDOWS
+
+all:
+	$(RUSTC) -o "$(TMPDIR)/hopefullydoesntexist bar.exe" hello.rs
+	$(RUSTC) spawn.rs
+	$(TMPDIR)/spawn.exe
+
+else
+
+all:
+
+endif

--- a/src/test/run-make/windows-spawn/hello.rs
+++ b/src/test/run-make/windows-spawn/hello.rs
@@ -1,0 +1,13 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    println!("Hello World!");
+}

--- a/src/test/run-make/windows-spawn/spawn.rs
+++ b/src/test/run-make/windows-spawn/spawn.rs
@@ -1,0 +1,22 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::io::ErrorKind;
+use std::process::Command;
+
+fn main() {
+    // Make sure it doesn't try to run "hopefullydoesntexist bar.exe".
+    assert_eq!(Command::new("hopefullydoesntexist")
+                   .arg("bar")
+                   .spawn()
+                   .unwrap_err()
+                   .kind(),
+               ErrorKind::NotFound);
+}


### PR DESCRIPTION
[`CreateProcess`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms682425.aspx) will interpret args as part of the binary name if it
doesn't find the binary using just the unquoted name. For example if
`foo.exe` doesn't exist, `Command::new("foo").arg("bar").spawn()` will
try to launch `foo bar.exe` which is clearly not desired.