### PR TITLE
syntax_pos::Symbol should not implement Sync

### DIFF
--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -81,6 +81,7 @@ pub struct Symbol(u32);
 
 // The interner in thread-local, so `Symbol` shouldn't move between threads.
 impl !Send for Symbol { }
+impl !Sync for Symbol { }
 
 impl Symbol {
     /// Maps a string to its interned representation.


### PR DESCRIPTION
Fixes #42407