### PR TITLE
rustc: T: 'empty always holds for all types.

### DIFF
--- a/src/librustc/infer/region_inference/mod.rs
+++ b/src/librustc/infer/region_inference/mod.rs
@@ -1200,6 +1200,13 @@ impl<'a, 'gcx, 'tcx> RegionVarBindings<'a, 'gcx, 'tcx> {
         for verify in self.verifys.borrow().iter() {
             debug!("collect_errors: verify={:?}", verify);
             let sub = normalize(self.tcx, var_data, verify.region);
+
+            // This was an inference variable which didn't get
+            // constrained, therefore it can be assume to hold.
+            if let ty::ReEmpty = *sub {
+                continue;
+            }
+
             if verify.bound.is_met(region_rels, var_data, sub) {
                 continue;
             }

--- a/src/test/run-pass/issue-42467.rs
+++ b/src/test/run-pass/issue-42467.rs
@@ -1,0 +1,32 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo<T>(T);
+
+struct IntoIter<T>(T);
+
+impl<'a, T: 'a> Iterator for IntoIter<T> {
+    type Item = ();
+
+    fn next(&mut self) -> Option<()> {
+        None
+    }
+}
+
+impl<T> IntoIterator for Foo<T> {
+    type Item = ();
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> IntoIter<T> {
+        IntoIter(self.0)
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #42467 by special-casing `ReEmpty` to always hold, even for parameters.
The reason this is the case is that `ReEmpty` is the result of inferring a region variable with no constraints attached to it, so there is no lifetime a type would contain which would be strictly shorter.

r? @nikomatsakis 