### PR TITLE
rustc_trans: do not store pair fields if they are ZSTs.

### DIFF
--- a/src/test/codegen/mir_zst_stores.rs
+++ b/src/test/codegen/mir_zst_stores.rs
@@ -13,13 +13,15 @@
 #![crate_type = "lib"]
 use std::marker::PhantomData;
 
-
+#[derive(Copy, Clone)]
 struct Zst { phantom: PhantomData<Zst> }
 
 // CHECK-LABEL: @mir
+// CHECK-NOT: store{{.*}}undef
 #[no_mangle]
-fn mir(){
-    // CHECK-NOT: getelementptr
-    // CHECK-NOT: store{{.*}}undef
+fn mir() {
     let x = Zst { phantom: PhantomData };
+    let y = (x, 0);
+    drop(y);
+    drop((0, x));
 }


### PR DESCRIPTION
Should help with #39882 even if it's not a complete fix AFAICT.