### PR TITLE
Changing error message from `contains interior mutability` to `may contain interior mutability`

### DIFF
--- a/src/librustc_mir/diagnostics.rs
+++ b/src/librustc_mir/diagnostics.rs
@@ -309,8 +309,8 @@ use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
 
 const A: AtomicUsize = ATOMIC_USIZE_INIT;
 static B: &'static AtomicUsize = &A;
-// error: cannot borrow a constant which contains interior mutability, create a
-//        static instead
+// error: cannot borrow a constant which may contain interior mutability,  
+//        create a static instead
 ```
 
 A `const` represents a constant value that should never change. If one takes
@@ -338,8 +338,8 @@ use std::cell::Cell;
 
 const A: Cell<usize> = Cell::new(1);
 const B: &'static Cell<usize> = &A;
-// error: cannot borrow a constant which contains interior mutability, create
-//        a static instead
+// error: cannot borrow a constant which may contain interior mutability, 
+//        create a static instead
 
 // or:
 struct C { a: Cell<usize> }

--- a/src/librustc_mir/diagnostics.rs
+++ b/src/librustc_mir/diagnostics.rs
@@ -309,7 +309,7 @@ use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
 
 const A: AtomicUsize = ATOMIC_USIZE_INIT;
 static B: &'static AtomicUsize = &A;
-// error: cannot borrow a constant which may contain interior mutability,  
+// error: cannot borrow a constant which may contain interior mutability,
 //        create a static instead
 ```
 
@@ -338,7 +338,7 @@ use std::cell::Cell;
 
 const A: Cell<usize> = Cell::new(1);
 const B: &'static Cell<usize> = &A;
-// error: cannot borrow a constant which may contain interior mutability, 
+// error: cannot borrow a constant which may contain interior mutability,
 //        create a static instead
 
 // or:

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -663,7 +663,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Qualifier<'a, 'tcx, 'tcx> {
                         self.add(Qualif::NOT_CONST);
                         if self.mode != Mode::Fn {
                             span_err!(self.tcx.sess, self.span, E0492,
-                                      "cannot borrow a constant which contains \
+                                      "cannot borrow a constant which may contain \
                                        interior mutability, create a static instead");
                         }
                     }

--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -112,7 +112,7 @@ pub trait UnwindSafe {}
 /// This is a "helper marker trait" used to provide impl blocks for the
 /// `UnwindSafe` trait, for more information see that documentation.
 #[stable(feature = "catch_unwind", since = "1.9.0")]
-#[rustc_on_unimplemented = "the type {Self} contains interior mutability \
+#[rustc_on_unimplemented = "the type {Self} may contain interior mutability \
                             and a reference may not be safely transferrable \
                             across a catch_unwind boundary"]
 pub trait RefUnwindSafe {}

--- a/src/test/compile-fail/issue-17718-const-borrow.rs
+++ b/src/test/compile-fail/issue-17718-const-borrow.rs
@@ -14,13 +14,13 @@ use std::cell::UnsafeCell;
 
 const A: UnsafeCell<usize> = UnsafeCell::new(1);
 const B: &'static UnsafeCell<usize> = &A;
-//~^ ERROR: cannot borrow a constant which contains interior mutability
+//~^ ERROR: cannot borrow a constant which may contain interior mutability
 
 struct C { a: UnsafeCell<usize> }
 const D: C = C { a: UnsafeCell::new(1) };
 const E: &'static UnsafeCell<usize> = &D.a;
-//~^ ERROR: cannot borrow a constant which contains interior mutability
+//~^ ERROR: cannot borrow a constant which may contain interior mutability
 const F: &'static C = &D;
-//~^ ERROR: cannot borrow a constant which contains interior mutability
+//~^ ERROR: cannot borrow a constant which may contain interior mutability
 
 fn main() {}

--- a/src/test/ui/interior-mutability/interior-mutability.rs
+++ b/src/test/ui/interior-mutability/interior-mutability.rs
@@ -1,0 +1,16 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::cell::Cell;
+use std::panic::catch_unwind;
+fn main() {
+    let mut x = Cell::new(22);
+    catch_unwind(|| { x.set(23); });
+}

--- a/src/test/ui/interior-mutability/interior-mutability.stderr
+++ b/src/test/ui/interior-mutability/interior-mutability.stderr
@@ -1,0 +1,14 @@
+error[E0277]: the trait bound `std::cell::UnsafeCell<i32>: std::panic::RefUnwindSafe` is not satisfied in `std::cell::Cell<i32>`
+  --> $DIR/interior-mutability.rs:15:5
+   |
+15 |     catch_unwind(|| { x.set(23); });
+   |     ^^^^^^^^^^^^ the type std::cell::UnsafeCell<i32> may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+   |
+   = help: within `std::cell::Cell<i32>`, the trait `std::panic::RefUnwindSafe` is not implemented for `std::cell::UnsafeCell<i32>`
+   = note: required because it appears within the type `std::cell::Cell<i32>`
+   = note: required because of the requirements on the impl of `std::panic::UnwindSafe` for `&std::cell::Cell<i32>`
+   = note: required because it appears within the type `[closure@$DIR/interior-mutability.rs:15:18: 15:35 x:&std::cell::Cell<i32>]`
+   = note: required by `std::panic::catch_unwind`
+
+error: aborting due to previous error(s)
+


### PR DESCRIPTION
Fixes #40313 . I have changed the message from `contains interior mutability` to `may contain interior mutability` for the following example
```
use std::cell::Cell;
use std::panic::catch_unwind;
fn main() {
    let mut x = Cell::new(22);
    catch_unwind(|| { x.set(23); });
}
```
which has been added as a ui test.

Also, the message [here](https://github.com/gaurikholkar/rust/blob/master/src/librustc_mir/transform/qualify_consts.rs#L666) and it's respective `compile-fail` test have been modified.

cc @nikomatsakis  @Mark-Simulacrum  @eddyb 
