### PR TITLE
bootstrap: improve 'build --help' by explaining what exactly the last example does

### DIFF
--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -196,13 +196,14 @@ Arguments:
         ./x.py build
         ./x.py build --stage 1
 
-    For a quick build with a usable compile, you can pass:
+    For a quick build of a usable compiler, you can pass:
 
         ./x.py build --stage 1 src/libtest
 
     This will first build everything once (like --stage 0 without further
     arguments would), and then use the compiler built in stage 0 to build
-    src/libtest and its dependencies.");
+    src/libtest and its dependencies.
+    Once this is done, build/$ARCH/stage1 contains a usable compiler.");
             }
             "test" => {
                 subcommand_help.push_str("\n

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -198,7 +198,11 @@ Arguments:
 
     For a quick build with a usable compile, you can pass:
 
-        ./x.py build --stage 1 src/libtest");
+        ./x.py build --stage 1 src/libtest
+
+    This will first build everything once (like --stage 0 without further
+    arguments would), and then use the compiler built in stage 0 to build
+    src/libtest and its dependencies.");
             }
             "test" => {
                 subcommand_help.push_str("\n


### PR DESCRIPTION
I recently found myself confused about what exactly gets built how often when I run which command; I think this would have helped me.

One thing I did not touch, but I feel could also be improved, is the wording just above: "For a quick build with a usable compile, you can pass".  I am not a native speaker, but this sounds odd to me. Do you mean "For a quick build of a usable compiler" (but then it should say where the usable compiler is produced)? Or do you mean "For a quick build testing if the compiler is usable"? I can reword this, but I'd like to make sure I understand the intent of the message.

What about
```
    For a quick build of a usable compiler, you can pass:

        ./x.py build --stage 1 src/libtest

    This will first build everything once (like --stage 0 without further
    arguments would), and then use the compiler built in stage 0 to build
    src/libtest and its dependencies.
    Once this is done, build/$ARCH/stage1 contains a usable compiler.
```
However, I am not sure this is actually true. In particular, why even bother building the libstd in stage 1? AFAIK that ends up in `build/*/stage1-std`, not in `build/*/stage1` (which is filled from `build/*/stage0-*`).