### PR TITLE
Add max and min to Ord

### DIFF
--- a/src/doc/unstable-book/src/SUMMARY.md
+++ b/src/doc/unstable-book/src/SUMMARY.md
@@ -165,6 +165,7 @@
     - [n16](library-features/n16.md)
     - [never_type_impls](library-features/never-type-impls.md)
     - [nonzero](library-features/nonzero.md)
+    - [ord_max_min](library-features/ord-max-min.md)
     - [offset_to](library-features/offset-to.md)
     - [once_poison](library-features/once-poison.md)
     - [oom](library-features/oom.md)

--- a/src/doc/unstable-book/src/library-features/ord-max-min.md
+++ b/src/doc/unstable-book/src/library-features/ord-max-min.md
@@ -1,0 +1,7 @@
+# `ord-max-min`
+
+The tracking issue for this feature is: [#25663]
+
+[#25663]: https://github.com/rust-lang/rust/issues/25663
+
+------------------------

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -443,6 +443,42 @@ pub trait Ord: Eq + PartialOrd<Self> {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     fn cmp(&self, other: &Self) -> Ordering;
+
+    /// Compares and returns the maximum of two values.
+    ///
+    /// Returns the second argument if the comparison determines them to be equal.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(ord_max_min)]
+    ///
+    /// assert_eq!(2, 1.max(2));
+    /// assert_eq!(2, 2.max(2));
+    /// ```
+    #[unstable(feature = "ord_max_min", issue = "25663")]
+    fn max(self, other: Self) -> Self
+    where Self: Sized {
+        if other >= self { other } else { self }
+    }
+
+    /// Compares and returns the minimum of two values.
+    ///
+    /// Returns the first argument if the comparison determines them to be equal.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(ord_max_min)]
+    ///
+    /// assert_eq!(1, 1.min(2));
+    /// assert_eq!(2, 2.min(2));
+    /// ```
+    #[unstable(feature = "ord_max_min", issue = "25663")]
+    fn min(self, other: Self) -> Self
+    where Self: Sized {
+        if self <= other { self } else { other }
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -714,6 +714,8 @@ pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
 ///
 /// Returns the first argument if the comparison determines them to be equal.
 ///
+/// Internally uses an alias to `Ord::min`.
+///
 /// # Examples
 ///
 /// ```
@@ -725,12 +727,14 @@ pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn min<T: Ord>(v1: T, v2: T) -> T {
-    if v1 <= v2 { v1 } else { v2 }
+    v1.min(v2)
 }
 
 /// Compares and returns the maximum of two values.
 ///
 /// Returns the second argument if the comparison determines them to be equal.
+///
+/// Internally uses an alias to `Ord::max`.
 ///
 /// # Examples
 ///
@@ -743,7 +747,7 @@ pub fn min<T: Ord>(v1: T, v2: T) -> T {
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn max<T: Ord>(v1: T, v2: T) -> T {
-    if v2 >= v1 { v2 } else { v1 }
+    v1.max(v2)
 }
 
 // Implementation of PartialEq, Eq, PartialOrd and Ord for primitive types

--- a/src/libcore/tests/cmp.rs
+++ b/src/libcore/tests/cmp.rs
@@ -29,6 +29,16 @@ fn test_mut_int_totalord() {
 }
 
 #[test]
+fn test_ord_max_min() {
+    assert_eq!(1.max(2), 2);
+    assert_eq!(2.max(1), 2);
+    assert_eq!(1.min(2), 1);
+    assert_eq!(2.min(1), 1);
+    assert_eq!(1.max(1), 1);
+    assert_eq!(1.min(1), 1);
+}
+
+#[test]
 fn test_ordering_reverse() {
     assert_eq!(Less.reverse(), Greater);
     assert_eq!(Equal.reverse(), Equal);

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -26,6 +26,7 @@
 #![feature(iter_rfind)]
 #![feature(libc)]
 #![feature(nonzero)]
+#![feature(ord_max_min)]
 #![feature(rand)]
 #![feature(raw)]
 #![feature(sip_hash_13)]


### PR DESCRIPTION
Pursuant to issue #25663, this PR adds max and min methods with default implementations to std::cmp::Ord. It also modifies std::cmp::max|min to internally alias to Ord::max|min, so that any overrides of the default implementations are automatically used by std::cmp::max|min.

Closes #25663