### PR TITLE
Ignore variadic FFI test on AArch64

### DIFF
--- a/src/test/compile-fail/variadic-ffi.rs
+++ b/src/test/compile-fail/variadic-ffi.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-arm stdcall isn't suppported
+// ignore-aarch64 stdcall isn't suppported
 
 extern "stdcall" {
     fn printf(_: *const u8, ...); //~ ERROR: variadic function must have C or cdecl calling


### PR DESCRIPTION
I've cross compiled Rust to `aarch64-linux-gnu`, and tried to run the compile-fail tests, but `variadic-ffi.rs` fails with the following error:

```
The ABI `"stdcall"` is not supported for the current target [E0570]
```

The test seems to be ignored on (32-bit) ARM, so I turned it off for AArch64 too.