### PR TITLE
incr.comp.: Make DepNode `Copy` and valid across compilation sessions

### DIFF
--- a/src/librustc/dep_graph/debug.rs
+++ b/src/librustc/dep_graph/debug.rs
@@ -12,7 +12,6 @@
 
 use super::dep_node::DepNode;
 use std::error::Error;
-use std::fmt::Debug;
 
 /// A dep-node filter goes from a user-defined string to a query over
 /// nodes. Right now the format is like this:
@@ -39,7 +38,7 @@ impl DepNodeFilter {
     }
 
     /// Tests whether `node` meets the filter, returning true if so.
-    pub fn test<D: Clone + Debug>(&self, node: &DepNode<D>) -> bool {
+    pub fn test(&self, node: &DepNode) -> bool {
         let debug_str = format!("{:?}", node);
         self.text.split("&")
                  .map(|s| s.trim())
@@ -67,10 +66,10 @@ impl EdgeFilter {
         }
     }
 
-    pub fn test<D: Clone + Debug>(&self,
-                                  source: &DepNode<D>,
-                                  target: &DepNode<D>)
-                                  -> bool {
+    pub fn test(&self,
+                source: &DepNode,
+                target: &DepNode)
+                -> bool {
         self.source.test(source) && self.target.test(target)
     }
 }

--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -8,79 +8,280 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use hir::def_id::CrateNum;
+use hir::def_id::{CrateNum, DefId};
+use hir::map::DefPathHash;
+
 use ich::Fingerprint;
-use rustc_data_structures::stable_hasher::StableHasher;
-use std::fmt::Debug;
+use ty::TyCtxt;
+use rustc_data_structures::stable_hasher::{StableHasher, HashStable};
+use ich::StableHashingContext;
 use std::hash::Hash;
 
-macro_rules! try_opt {
-    ($e:expr) => (
-        match $e {
-            Some(r) => r,
-            None => return None,
-        }
-    )
+// erase!() just makes tokens go away. It's used to specify which macro argument
+// is repeated (i.e. which sub-expression of the macro we are in) but don't need
+// to actually use any of the arguments.
+macro_rules! erase {
+    ($x:tt) => ({})
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, RustcEncodable, RustcDecodable)]
-pub enum DepNode<D: Clone + Debug> {
-    // The `D` type is "how definitions are identified".
-    // During compilation, it is always `DefId`, but when serializing
-    // it is mapped to `DefPath`.
+macro_rules! define_dep_nodes {
+    ($(
+        $variant:ident $(( $($tuple_arg:tt),* ))*
+                       $({ $($struct_arg_name:ident : $struct_arg_ty:ty),* })*
+      ),*
+    ) => (
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash,
+                 RustcEncodable, RustcDecodable)]
+        pub enum DepKind {
+            $($variant),*
+        }
 
-    /// Represents the `Krate` as a whole (the `hir::Krate` value) (as
-    /// distinct from the krate module). This is basically a hash of
-    /// the entire krate, so if you read from `Krate` (e.g., by calling
-    /// `tcx.hir.krate()`), we will have to assume that any change
-    /// means that you need to be recompiled. This is because the
-    /// `Krate` value gives you access to all other items. To avoid
-    /// this fate, do not call `tcx.hir.krate()`; instead, prefer
-    /// wrappers like `tcx.visit_all_items_in_krate()`.  If there is no
-    /// suitable wrapper, you can use `tcx.dep_graph.ignore()` to gain
-    /// access to the krate, but you must remember to add suitable
-    /// edges yourself for the individual items that you read.
+        impl DepKind {
+            #[allow(unreachable_code)]
+            #[inline]
+            pub fn can_reconstruct_query_key(&self) -> bool {
+                match *self {
+                    $(
+                        DepKind :: $variant => {
+                            // tuple args
+                            $({
+                                return <( $($tuple_arg,)* ) as DepNodeParams>
+                                    ::CAN_RECONSTRUCT_QUERY_KEY;
+                            })*
+
+                            // struct args
+                            $({
+                                return <( $($struct_arg_ty,)* ) as DepNodeParams>
+                                    ::CAN_RECONSTRUCT_QUERY_KEY;
+                            })*
+
+                            true
+                        }
+                    )*
+                }
+            }
+
+            #[allow(unreachable_code)]
+            #[inline]
+            pub fn has_params(&self) -> bool {
+                match *self {
+                    $(
+                        DepKind :: $variant => {
+                            // tuple args
+                            $({
+                                $(erase!($tuple_arg);)*
+                                return true;
+                            })*
+
+                            // struct args
+                            $({
+                                $(erase!($struct_arg_name);)*
+                                return true;
+                            })*
+
+                            false
+                        }
+                    )*
+                }
+            }
+        }
+
+        pub enum DepConstructor {
+            $(
+                $variant $(( $($tuple_arg),* ))*
+                         $({ $($struct_arg_name : $struct_arg_ty),* })*
+            ),*
+        }
+
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash,
+                 RustcEncodable, RustcDecodable)]
+        pub struct DepNode {
+            pub kind: DepKind,
+            pub hash: Fingerprint,
+        }
+
+        impl DepNode {
+            #[allow(unreachable_code, non_snake_case)]
+            pub fn new(tcx: TyCtxt, dep: DepConstructor) -> DepNode {
+                match dep {
+                    $(
+                        DepConstructor :: $variant $(( $($tuple_arg),* ))*
+                                                   $({ $($struct_arg_name),* })*
+                            =>
+                        {
+                            // tuple args
+                            $({
+                                let tupled_args = ( $($tuple_arg,)* );
+                                let hash = DepNodeParams::to_fingerprint(&tupled_args,
+                                                                         tcx);
+                                return DepNode {
+                                    kind: DepKind::$variant,
+                                    hash
+                                };
+                            })*
+
+                            // struct args
+                            $({
+                                let tupled_args = ( $($struct_arg_name,)* );
+                                let hash = DepNodeParams::to_fingerprint(&tupled_args,
+                                                                         tcx);
+                                return DepNode {
+                                    kind: DepKind::$variant,
+                                    hash
+                                };
+                            })*
+
+                            DepNode {
+                                kind: DepKind::$variant,
+                                hash: Fingerprint::zero(),
+                            }
+                        }
+                    )*
+                }
+            }
+
+            /// Construct a DepNode from the given DepKind and DefPathHash. This
+            /// method will assert that the given DepKind actually requires a
+            /// single DefId/DefPathHash parameter.
+            #[inline]
+            pub fn from_def_path_hash(kind: DepKind,
+                                      def_path_hash: DefPathHash)
+                                      -> DepNode {
+                assert!(kind.can_reconstruct_query_key() && kind.has_params());
+                DepNode {
+                    kind,
+                    hash: def_path_hash.0,
+                }
+            }
+
+            /// Create a new, parameterless DepNode. This method will assert
+            /// that the DepNode corresponding to the given DepKind actually
+            /// does not require any parameters.
+            #[inline]
+            pub fn new_no_params(kind: DepKind) -> DepNode {
+                assert!(!kind.has_params());
+                DepNode {
+                    kind,
+                    hash: Fingerprint::zero(),
+                }
+            }
+
+            /// Extract the DefId corresponding to this DepNode. This will work
+            /// if two conditions are met:
+            ///
+            /// 1. The Fingerprint of the DepNode actually is a DefPathHash, and
+            /// 2. the item that the DefPath refers to exists in the current tcx.
+            ///
+            /// Condition (1) is determined by the DepKind variant of the
+            /// DepNode. Condition (2) might not be fulfilled if a DepNode
+            /// refers to something from the previous compilation session that
+            /// has been removed.
+            #[inline]
+            pub fn extract_def_id(&self, tcx: TyCtxt) -> Option<DefId> {
+                if self.kind.can_reconstruct_query_key() {
+                    let def_path_hash = DefPathHash(self.hash);
+                    tcx.def_path_hash_to_def_id
+                       .as_ref()
+                       .unwrap()
+                       .get(&def_path_hash)
+                       .cloned()
+                } else {
+                    None
+                }
+            }
+
+            /// Used in testing
+            pub fn from_label_string(label: &str,
+                                     def_path_hash: DefPathHash)
+                                     -> Result<DepNode, ()> {
+                let kind = match label {
+                    $(
+                        stringify!($variant) => DepKind::$variant,
+                    )*
+                    _ => return Err(()),
+                };
+
+                if !kind.can_reconstruct_query_key() {
+                    return Err(());
+                }
+
+                if kind.has_params() {
+                    Ok(def_path_hash.to_dep_node(kind))
+                } else {
+                    Ok(DepNode::new_no_params(kind))
+                }
+            }
+        }
+    );
+}
+
+impl DefPathHash {
+    #[inline]
+    pub fn to_dep_node(self, kind: DepKind) -> DepNode {
+        DepNode::from_def_path_hash(kind, self)
+    }
+}
+
+impl DefId {
+    #[inline]
+    pub fn to_dep_node(self, tcx: TyCtxt, kind: DepKind) -> DepNode {
+        DepNode::from_def_path_hash(kind, tcx.def_path_hash(self))
+    }
+}
+
+define_dep_nodes!(
+    // Represents the `Krate` as a whole (the `hir::Krate` value) (as
+    // distinct from the krate module). This is basically a hash of
+    // the entire krate, so if you read from `Krate` (e.g., by calling
+    // `tcx.hir.krate()`), we will have to assume that any change
+    // means that you need to be recompiled. This is because the
+    // `Krate` value gives you access to all other items. To avoid
+    // this fate, do not call `tcx.hir.krate()`; instead, prefer
+    // wrappers like `tcx.visit_all_items_in_krate()`.  If there is no
+    // suitable wrapper, you can use `tcx.dep_graph.ignore()` to gain
+    // access to the krate, but you must remember to add suitable
+    // edges yourself for the individual items that you read.
     Krate,
 
-    /// Represents the HIR node with the given node-id
-    Hir(D),
+    // Represents the HIR node with the given node-id
+    Hir(DefId),
 
-    /// Represents the body of a function or method. The def-id is that of the
-    /// function/method.
-    HirBody(D),
+    // Represents the body of a function or method. The def-id is that of the
+    // function/method.
+    HirBody(DefId),
 
-    /// Represents the metadata for a given HIR node, typically found
-    /// in an extern crate.
-    MetaData(D),
+    // Represents the metadata for a given HIR node, typically found
+    // in an extern crate.
+    MetaData(DefId),
 
-    /// Represents some artifact that we save to disk. Note that these
-    /// do not have a def-id as part of their identifier.
+    // Represents some artifact that we save to disk. Note that these
+    // do not have a def-id as part of their identifier.
     WorkProduct(WorkProductId),
 
     // Represents different phases in the compiler.
-    RegionMaps(D),
+    RegionMaps(DefId),
     Coherence,
     Resolve,
-    CoherenceCheckTrait(D),
-    CoherenceCheckImpl(D),
-    CoherenceOverlapCheck(D),
-    CoherenceOverlapCheckSpecial(D),
+    CoherenceCheckTrait(DefId),
+    CoherenceCheckImpl(DefId),
+    CoherenceOverlapCheck(DefId),
+    CoherenceOverlapCheckSpecial(DefId),
     Variance,
     PrivacyAccessLevels(CrateNum),
 
     // Represents the MIR for a fn; also used as the task node for
     // things read/modify that MIR.
     MirKrate,
-    Mir(D),
-    MirShim(Vec<D>),
+    Mir(DefId),
+    MirShim(DefIdList),
 
     BorrowCheckKrate,
-    BorrowCheck(D),
-    RvalueCheck(D),
+    BorrowCheck(DefId),
+    RvalueCheck(DefId),
     Reachability,
     MirKeys,
     LateLintCheck,
-    TransCrateItem(D),
+    TransCrateItem(DefId),
     TransWriteMetadata,
     CrateVariances,
 
@@ -89,38 +290,38 @@ pub enum DepNode<D: Clone + Debug> {
     // nodes. Often we map multiple tables to the same node if there
     // is no point in distinguishing them (e.g., both the type and
     // predicates for an item wind up in `ItemSignature`).
-    AssociatedItems(D),
-    ItemSignature(D),
-    ItemVarianceConstraints(D),
-    ItemVariances(D),
-    IsForeignItem(D),
-    TypeParamPredicates((D, D)),
-    SizedConstraint(D),
-    DtorckConstraint(D),
-    AdtDestructor(D),
-    AssociatedItemDefIds(D),
-    InherentImpls(D),
+    AssociatedItems(DefId),
+    ItemSignature(DefId),
+    ItemVarianceConstraints(DefId),
+    ItemVariances(DefId),
+    IsForeignItem(DefId),
+    TypeParamPredicates { item_id: DefId, param_id: DefId },
+    SizedConstraint(DefId),
+    DtorckConstraint(DefId),
+    AdtDestructor(DefId),
+    AssociatedItemDefIds(DefId),
+    InherentImpls(DefId),
     TypeckBodiesKrate,
-    TypeckTables(D),
-    UsedTraitImports(D),
-    ConstEval(D),
-    SymbolName(D),
-    SpecializationGraph(D),
-    ObjectSafety(D),
-    IsCopy(D),
-    IsSized(D),
-    IsFreeze(D),
-    NeedsDrop(D),
-    Layout(D),
+    TypeckTables(DefId),
+    UsedTraitImports(DefId),
+    ConstEval(DefId),
+    SymbolName(DefId),
+    SpecializationGraph(DefId),
+    ObjectSafety(DefId),
+    IsCopy(DefId),
+    IsSized(DefId),
+    IsFreeze(DefId),
+    NeedsDrop(DefId),
+    Layout(DefId),
 
-    /// The set of impls for a given trait. Ultimately, it would be
-    /// nice to get more fine-grained here (e.g., to include a
-    /// simplified type), but we can't do that until we restructure the
-    /// HIR to distinguish the *header* of an impl from its body.  This
-    /// is because changes to the header may change the self-type of
-    /// the impl and hence would require us to be more conservative
-    /// than changes in the impl body.
-    TraitImpls(D),
+    // The set of impls for a given trait. Ultimately, it would be
+    // nice to get more fine-grained here (e.g., to include a
+    // simplified type), but we can't do that until we restructure the
+    // HIR to distinguish the *header* of an impl from its body.  This
+    // is because changes to the header may change the self-type of
+    // the impl and hence would require us to be more conservative
+    // than changes in the impl body.
+    TraitImpls(DefId),
 
     AllLocalTraitImpls,
 
@@ -129,184 +330,80 @@ pub enum DepNode<D: Clone + Debug> {
     // Otherwise the write into the map would be incorrectly
     // attributed to the first task that happened to fill the cache,
     // which would yield an overly conservative dep-graph.
-    TraitItems(D),
-    ReprHints(D),
+    TraitItems(DefId),
+    ReprHints(DefId),
 
-    /// Trait selection cache is a little funny. Given a trait
-    /// reference like `Foo: SomeTrait<Bar>`, there could be
-    /// arbitrarily many def-ids to map on in there (e.g., `Foo`,
-    /// `SomeTrait`, `Bar`). We could have a vector of them, but it
-    /// requires heap-allocation, and trait sel in general can be a
-    /// surprisingly hot path. So instead we pick two def-ids: the
-    /// trait def-id, and the first def-id in the input types. If there
-    /// is no def-id in the input types, then we use the trait def-id
-    /// again. So for example:
-    ///
-    /// - `i32: Clone` -> `TraitSelect { trait_def_id: Clone, self_def_id: Clone }`
-    /// - `u32: Clone` -> `TraitSelect { trait_def_id: Clone, self_def_id: Clone }`
-    /// - `Clone: Clone` -> `TraitSelect { trait_def_id: Clone, self_def_id: Clone }`
-    /// - `Vec<i32>: Clone` -> `TraitSelect { trait_def_id: Clone, self_def_id: Vec }`
-    /// - `String: Clone` -> `TraitSelect { trait_def_id: Clone, self_def_id: String }`
-    /// - `Foo: Trait<Bar>` -> `TraitSelect { trait_def_id: Trait, self_def_id: Foo }`
-    /// - `Foo: Trait<i32>` -> `TraitSelect { trait_def_id: Trait, self_def_id: Foo }`
-    /// - `(Foo, Bar): Trait` -> `TraitSelect { trait_def_id: Trait, self_def_id: Foo }`
-    /// - `i32: Trait<Foo>` -> `TraitSelect { trait_def_id: Trait, self_def_id: Foo }`
-    ///
-    /// You can see that we map many trait refs to the same
-    /// trait-select node.  This is not a problem, it just means
-    /// imprecision in our dep-graph tracking.  The important thing is
-    /// that for any given trait-ref, we always map to the **same**
-    /// trait-select node.
-    TraitSelect { trait_def_id: D, input_def_id: D },
+    // Trait selection cache is a little funny. Given a trait
+    // reference like `Foo: SomeTrait<Bar>`, there could be
+    // arbitrarily many def-ids to map on in there (e.g., `Foo`,
+    // `SomeTrait`, `Bar`). We could have a vector of them, but it
+    // requires heap-allocation, and trait sel in general can be a
+    // surprisingly hot path. So instead we pick two def-ids: the
+    // trait def-id, and the first def-id in the input types. If there
+    // is no def-id in the input types, then we use the trait def-id
+    // again. So for example:
+    //
+    // - `i32: Clone` -> `TraitSelect { trait_def_id: Clone, self_def_id: Clone }`
+    // - `u32: Clone` -> `TraitSelect { trait_def_id: Clone, self_def_id: Clone }`
+    // - `Clone: Clone` -> `TraitSelect { trait_def_id: Clone, self_def_id: Clone }`
+    // - `Vec<i32>: Clone` -> `TraitSelect { trait_def_id: Clone, self_def_id: Vec }`
+    // - `String: Clone` -> `TraitSelect { trait_def_id: Clone, self_def_id: String }`
+    // - `Foo: Trait<Bar>` -> `TraitSelect { trait_def_id: Trait, self_def_id: Foo }`
+    // - `Foo: Trait<i32>` -> `TraitSelect { trait_def_id: Trait, self_def_id: Foo }`
+    // - `(Foo, Bar): Trait` -> `TraitSelect { trait_def_id: Trait, self_def_id: Foo }`
+    // - `i32: Trait<Foo>` -> `TraitSelect { trait_def_id: Trait, self_def_id: Foo }`
+    //
+    // You can see that we map many trait refs to the same
+    // trait-select node.  This is not a problem, it just means
+    // imprecision in our dep-graph tracking.  The important thing is
+    // that for any given trait-ref, we always map to the **same**
+    // trait-select node.
+    TraitSelect { trait_def_id: DefId, input_def_id: DefId },
 
-    /// For proj. cache, we just keep a list of all def-ids, since it is
-    /// not a hotspot.
-    ProjectionCache { def_ids: Vec<D> },
+    // For proj. cache, we just keep a list of all def-ids, since it is
+    // not a hotspot.
+    ProjectionCache { def_ids: DefIdList },
 
-    ParamEnv(D),
-    DescribeDef(D),
-    DefSpan(D),
-    Stability(D),
-    Deprecation(D),
-    ItemBodyNestedBodies(D),
-    ConstIsRvaluePromotableToStatic(D),
-    ImplParent(D),
-    TraitOfItem(D),
-    IsExportedSymbol(D),
-    IsMirAvailable(D),
-    ItemAttrs(D),
-    FnArgNames(D),
+    ParamEnv(DefId),
+    DescribeDef(DefId),
+    DefSpan(DefId),
+    Stability(DefId),
+    Deprecation(DefId),
+    ItemBodyNestedBodies(DefId),
+    ConstIsRvaluePromotableToStatic(DefId),
+    ImplParent(DefId),
+    TraitOfItem(DefId),
+    IsExportedSymbol(DefId),
+    IsMirAvailable(DefId),
+    ItemAttrs(DefId),
+    FnArgNames(DefId)
+);
+
+trait DepNodeParams<'a, 'gcx: 'tcx + 'a, 'tcx: 'a> {
+    const CAN_RECONSTRUCT_QUERY_KEY: bool;
+    fn to_fingerprint(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Fingerprint;
 }
 
-impl<D: Clone + Debug> DepNode<D> {
-    /// Used in testing
-    pub fn from_label_string(label: &str, data: D) -> Result<DepNode<D>, ()> {
-        macro_rules! check {
-            ($($name:ident,)*) => {
-                match label {
-                    $(stringify!($name) => Ok(DepNode::$name(data)),)*
-                    _ => Err(())
-                }
-            }
-        }
+impl<'a, 'gcx: 'tcx + 'a, 'tcx: 'a, T> DepNodeParams<'a, 'gcx, 'tcx> for T
+    where T: HashStable<StableHashingContext<'a, 'gcx, 'tcx>>
+{
+    default const CAN_RECONSTRUCT_QUERY_KEY: bool = false;
 
-        if label == "Krate" {
-            // special case
-            return Ok(DepNode::Krate);
-        }
+    default fn to_fingerprint(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Fingerprint {
+        let mut hcx = StableHashingContext::new(tcx);
+        let mut hasher = StableHasher::new();
 
-        check! {
-            BorrowCheck,
-            Hir,
-            HirBody,
-            TransCrateItem,
-            AssociatedItems,
-            ItemSignature,
-            ItemVariances,
-            IsForeignItem,
-            AssociatedItemDefIds,
-            InherentImpls,
-            TypeckTables,
-            UsedTraitImports,
-            TraitImpls,
-            ReprHints,
-        }
+        self.hash_stable(&mut hcx, &mut hasher);
+
+        hasher.finish()
     }
+}
 
-    pub fn map_def<E, OP>(&self, mut op: OP) -> Option<DepNode<E>>
-        where OP: FnMut(&D) -> Option<E>, E: Clone + Debug
-    {
-        use self::DepNode::*;
+impl<'a, 'gcx: 'tcx + 'a, 'tcx: 'a> DepNodeParams<'a, 'gcx, 'tcx> for (DefId,) {
+    const CAN_RECONSTRUCT_QUERY_KEY: bool = true;
 
-        match *self {
-            Krate => Some(Krate),
-            BorrowCheckKrate => Some(BorrowCheckKrate),
-            MirKrate => Some(MirKrate),
-            TypeckBodiesKrate => Some(TypeckBodiesKrate),
-            Coherence => Some(Coherence),
-            CrateVariances => Some(CrateVariances),
-            Resolve => Some(Resolve),
-            Variance => Some(Variance),
-            PrivacyAccessLevels(k) => Some(PrivacyAccessLevels(k)),
-            Reachability => Some(Reachability),
-            MirKeys => Some(MirKeys),
-            LateLintCheck => Some(LateLintCheck),
-            TransWriteMetadata => Some(TransWriteMetadata),
-
-            // work product names do not need to be mapped, because
-            // they are always absolute.
-            WorkProduct(ref id) => Some(WorkProduct(id.clone())),
-
-            IsCopy(ref d) => op(d).map(IsCopy),
-            IsSized(ref d) => op(d).map(IsSized),
-            IsFreeze(ref d) => op(d).map(IsFreeze),
-            NeedsDrop(ref d) => op(d).map(NeedsDrop),
-            Layout(ref d) => op(d).map(Layout),
-            Hir(ref d) => op(d).map(Hir),
-            HirBody(ref d) => op(d).map(HirBody),
-            MetaData(ref d) => op(d).map(MetaData),
-            CoherenceCheckTrait(ref d) => op(d).map(CoherenceCheckTrait),
-            CoherenceCheckImpl(ref d) => op(d).map(CoherenceCheckImpl),
-            CoherenceOverlapCheck(ref d) => op(d).map(CoherenceOverlapCheck),
-            CoherenceOverlapCheckSpecial(ref d) => op(d).map(CoherenceOverlapCheckSpecial),
-            Mir(ref d) => op(d).map(Mir),
-            MirShim(ref def_ids) => {
-                let def_ids: Option<Vec<E>> = def_ids.iter().map(op).collect();
-                def_ids.map(MirShim)
-            }
-            BorrowCheck(ref d) => op(d).map(BorrowCheck),
-            RegionMaps(ref d) => op(d).map(RegionMaps),
-            RvalueCheck(ref d) => op(d).map(RvalueCheck),
-            TransCrateItem(ref d) => op(d).map(TransCrateItem),
-            AssociatedItems(ref d) => op(d).map(AssociatedItems),
-            ItemSignature(ref d) => op(d).map(ItemSignature),
-            ItemVariances(ref d) => op(d).map(ItemVariances),
-            ItemVarianceConstraints(ref d) => op(d).map(ItemVarianceConstraints),
-            IsForeignItem(ref d) => op(d).map(IsForeignItem),
-            TypeParamPredicates((ref item, ref param)) => {
-                Some(TypeParamPredicates((try_opt!(op(item)), try_opt!(op(param)))))
-            }
-            SizedConstraint(ref d) => op(d).map(SizedConstraint),
-            DtorckConstraint(ref d) => op(d).map(DtorckConstraint),
-            AdtDestructor(ref d) => op(d).map(AdtDestructor),
-            AssociatedItemDefIds(ref d) => op(d).map(AssociatedItemDefIds),
-            InherentImpls(ref d) => op(d).map(InherentImpls),
-            TypeckTables(ref d) => op(d).map(TypeckTables),
-            UsedTraitImports(ref d) => op(d).map(UsedTraitImports),
-            ConstEval(ref d) => op(d).map(ConstEval),
-            SymbolName(ref d) => op(d).map(SymbolName),
-            SpecializationGraph(ref d) => op(d).map(SpecializationGraph),
-            ObjectSafety(ref d) => op(d).map(ObjectSafety),
-            TraitImpls(ref d) => op(d).map(TraitImpls),
-            AllLocalTraitImpls => Some(AllLocalTraitImpls),
-            TraitItems(ref d) => op(d).map(TraitItems),
-            ReprHints(ref d) => op(d).map(ReprHints),
-            TraitSelect { ref trait_def_id, ref input_def_id } => {
-                op(trait_def_id).and_then(|trait_def_id| {
-                    op(input_def_id).and_then(|input_def_id| {
-                        Some(TraitSelect { trait_def_id: trait_def_id,
-                                           input_def_id: input_def_id })
-                    })
-                })
-            }
-            ProjectionCache { ref def_ids } => {
-                let def_ids: Option<Vec<E>> = def_ids.iter().map(op).collect();
-                def_ids.map(|d| ProjectionCache { def_ids: d })
-            }
-            ParamEnv(ref d) => op(d).map(ParamEnv),
-            DescribeDef(ref d) => op(d).map(DescribeDef),
-            DefSpan(ref d) => op(d).map(DefSpan),
-            Stability(ref d) => op(d).map(Stability),
-            Deprecation(ref d) => op(d).map(Deprecation),
-            ItemAttrs(ref d) => op(d).map(ItemAttrs),
-            FnArgNames(ref d) => op(d).map(FnArgNames),
-            ImplParent(ref d) => op(d).map(ImplParent),
-            TraitOfItem(ref d) => op(d).map(TraitOfItem),
-            IsExportedSymbol(ref d) => op(d).map(IsExportedSymbol),
-            ItemBodyNestedBodies(ref d) => op(d).map(ItemBodyNestedBodies),
-            ConstIsRvaluePromotableToStatic(ref d) => op(d).map(ConstIsRvaluePromotableToStatic),
-            IsMirAvailable(ref d) => op(d).map(IsMirAvailable),
-        }
+    fn to_fingerprint(&self, tcx: TyCtxt) -> Fingerprint {
+        tcx.def_path_hash(self.0).0
     }
 }
 
@@ -315,14 +412,38 @@ impl<D: Clone + Debug> DepNode<D> {
 /// some independent path or string that persists between runs without
 /// the need to be mapped or unmapped. (This ensures we can serialize
 /// them even in the absence of a tcx.)
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, RustcEncodable, RustcDecodable)]
-pub struct WorkProductId(pub Fingerprint);
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash,
+         RustcEncodable, RustcDecodable)]
+pub struct WorkProductId {
+    hash: Fingerprint
+}
 
 impl WorkProductId {
     pub fn from_cgu_name(cgu_name: &str) -> WorkProductId {
         let mut hasher = StableHasher::new();
         cgu_name.len().hash(&mut hasher);
         cgu_name.hash(&mut hasher);
-        WorkProductId(hasher.finish())
+        WorkProductId {
+            hash: hasher.finish()
+        }
+    }
+
+    pub fn from_fingerprint(fingerprint: Fingerprint) -> WorkProductId {
+        WorkProductId {
+            hash: fingerprint
+        }
+    }
+
+    pub fn to_dep_node(self) -> DepNode {
+        DepNode {
+            kind: DepKind::WorkProduct,
+            hash: self.hash,
+        }
     }
 }
+
+impl_stable_hash_for!(struct ::dep_graph::WorkProductId {
+    hash
+});
+
+type DefIdList = Vec<DefId>;

--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use hir::def_id::DefId;
 use rustc_data_structures::fx::FxHashMap;
 use session::config::OutputType;
 use std::cell::{Ref, RefCell};
@@ -57,7 +56,7 @@ impl DepGraph {
         self.data.thread.is_fully_enabled()
     }
 
-    pub fn query(&self) -> DepGraphQuery<DefId> {
+    pub fn query(&self) -> DepGraphQuery {
         self.data.thread.query()
     }
 
@@ -65,7 +64,7 @@ impl DepGraph {
         raii::IgnoreTask::new(&self.data.thread)
     }
 
-    pub fn in_task<'graph>(&'graph self, key: DepNode<DefId>) -> Option<raii::DepTask<'graph>> {
+    pub fn in_task<'graph>(&'graph self, key: DepNode) -> Option<raii::DepTask<'graph>> {
         raii::DepTask::new(&self.data.thread, key)
     }
 
@@ -103,14 +102,14 @@ impl DepGraph {
     ///   `arg` parameter.
     ///
     /// [README]: README.md
-    pub fn with_task<C, A, R>(&self, key: DepNode<DefId>, cx: C, arg: A, task: fn(C, A) -> R) -> R
+    pub fn with_task<C, A, R>(&self, key: DepNode, cx: C, arg: A, task: fn(C, A) -> R) -> R
         where C: DepGraphSafe, A: DepGraphSafe
     {
         let _task = self.in_task(key);
         task(cx, arg)
     }
 
-    pub fn read(&self, v: DepNode<DefId>) {
+    pub fn read(&self, v: DepNode) {
         if self.data.thread.is_enqueue_enabled() {
             self.data.thread.enqueue(DepMessage::Read(v));
         }

--- a/src/librustc/dep_graph/mod.rs
+++ b/src/librustc/dep_graph/mod.rs
@@ -28,3 +28,5 @@ pub use self::query::DepGraphQuery;
 pub use self::safe::AssertDepGraphSafe;
 pub use self::safe::DepGraphSafe;
 pub use self::raii::DepTask;
+
+pub use self::dep_node::{DepKind, DepConstructor};

--- a/src/librustc/dep_graph/raii.rs
+++ b/src/librustc/dep_graph/raii.rs
@@ -8,17 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use hir::def_id::DefId;
 use super::DepNode;
 use super::thread::{DepGraphThreadData, DepMessage};
 
 pub struct DepTask<'graph> {
     data: &'graph DepGraphThreadData,
-    key: Option<DepNode<DefId>>,
+    key: Option<DepNode>,
 }
 
 impl<'graph> DepTask<'graph> {
-    pub fn new(data: &'graph DepGraphThreadData, key: DepNode<DefId>)
+    pub fn new(data: &'graph DepGraphThreadData, key: DepNode)
                -> Option<DepTask<'graph>> {
         if data.is_enqueue_enabled() {
             data.enqueue(DepMessage::PushTask(key.clone()));

--- a/src/librustc/dep_graph/shadow.rs
+++ b/src/librustc/dep_graph/shadow.rs
@@ -26,7 +26,6 @@
 //! specify an edge filter to be applied to each edge as it is
 //! created.  See `./README.md` for details.
 
-use hir::def_id::DefId;
 use std::cell::RefCell;
 use std::env;
 
@@ -36,7 +35,7 @@ use super::debug::EdgeFilter;
 
 pub struct ShadowGraph {
     // if you push None onto the stack, that corresponds to an Ignore
-    stack: RefCell<Vec<Option<DepNode<DefId>>>>,
+    stack: RefCell<Vec<Option<DepNode>>>,
     forbidden_edge: Option<EdgeFilter>,
 }
 
@@ -114,8 +113,8 @@ impl ShadowGraph {
     }
 
     fn check_edge(&self,
-                  source: Option<Option<&DepNode<DefId>>>,
-                  target: Option<Option<&DepNode<DefId>>>) {
+                  source: Option<Option<&DepNode>>,
+                  target: Option<Option<&DepNode>>) {
         assert!(ENABLED);
         match (source, target) {
             // cannot happen, one side is always Some(Some(_))
@@ -141,9 +140,9 @@ impl ShadowGraph {
 
 // Do a little juggling: we get back a reference to an option at the
 // top of the stack, convert it to an optional reference.
-fn top<'s>(stack: &'s Vec<Option<DepNode<DefId>>>) -> Option<Option<&'s DepNode<DefId>>> {
+fn top<'s>(stack: &'s Vec<Option<DepNode>>) -> Option<Option<&'s DepNode>> {
     stack.last()
-        .map(|n: &'s Option<DepNode<DefId>>| -> Option<&'s DepNode<DefId>> {
+        .map(|n: &'s Option<DepNode>| -> Option<&'s DepNode> {
             // (*)
             // (*) type annotation just there to clarify what would
             // otherwise be some *really* obscure code

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -25,7 +25,7 @@
 //! for all lint attributes.
 use self::TargetLint::*;
 
-use dep_graph::DepNode;
+use dep_graph::{DepNode, DepKind};
 use middle::privacy::AccessLevels;
 use ty::{self, TyCtxt};
 use session::{config, early_error, Session};
@@ -1321,7 +1321,7 @@ fn check_lint_name_cmdline(sess: &Session, lint_cx: &LintStore,
 ///
 /// Consumes the `lint_store` field of the `Session`.
 pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
-    let _task = tcx.dep_graph.in_task(DepNode::LateLintCheck);
+    let _task = tcx.dep_graph.in_task(DepNode::new_no_params(DepKind::LateLintCheck));
 
     let access_levels = &tcx.privacy_access_levels(LOCAL_CRATE);
 

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -381,7 +381,7 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
         assert!(!obligation.predicate.has_escaping_regions());
 
         let tcx = self.tcx();
-        let dep_node = obligation.predicate.dep_node();
+        let dep_node = obligation.predicate.dep_node(tcx);
         let _task = tcx.dep_graph.in_task(dep_node);
 
         let stack = self.push_stack(TraitObligationStackList::empty(), obligation);
@@ -514,11 +514,13 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
         debug!("evaluate_predicate_recursively({:?})",
                obligation);
 
+        let tcx = self.tcx();
+
         // Check the cache from the tcx of predicates that we know
         // have been proven elsewhere. This cache only contains
         // predicates that are global in scope and hence unaffected by
         // the current environment.
-        if self.tcx().fulfilled_predicates.borrow().check_duplicate(&obligation.predicate) {
+        if tcx.fulfilled_predicates.borrow().check_duplicate(tcx, &obligation.predicate) {
             return EvaluatedToOk;
         }
 

--- a/src/librustc/traits/trans/mod.rs
+++ b/src/librustc/traits/trans/mod.rs
@@ -13,7 +13,8 @@
 // seems likely that they should eventually be merged into more
 // general routines.
 
-use dep_graph::{DepGraph, DepNode, DepTrackingMap, DepTrackingMapConfig};
+use dep_graph::{DepGraph, DepNode, DepTrackingMap, DepTrackingMapConfig,
+                DepConstructor};
 use hir::def_id::DefId;
 use infer::TransNormalize;
 use std::cell::RefCell;
@@ -40,7 +41,7 @@ impl<'a, 'tcx> TyCtxt<'a, 'tcx, 'tcx> {
         // Remove any references to regions; this helps improve caching.
         let trait_ref = self.erase_regions(&trait_ref);
 
-        self.trans_trait_caches.trait_cache.memoize(trait_ref, || {
+        self.trans_trait_caches.trait_cache.memoize(self, trait_ref, || {
             debug!("trans::fulfill_obligation(trait_ref={:?}, def_id={:?})",
                    trait_ref, trait_ref.def_id());
 
@@ -138,7 +139,7 @@ impl<'a, 'gcx> TypeFolder<'gcx, 'gcx> for AssociatedTypeNormalizer<'a, 'gcx> {
         if !ty.has_projection_types() {
             ty
         } else {
-            self.tcx.trans_trait_caches.project_cache.memoize(ty, || {
+            self.tcx.trans_trait_caches.project_cache.memoize(self.tcx, ty, || {
                 debug!("AssociatedTypeNormalizer: ty={:?}", ty);
                 self.tcx.normalize_associated_type(&ty)
             })
@@ -170,8 +171,8 @@ pub struct TraitSelectionCache<'tcx> {
 impl<'tcx> DepTrackingMapConfig for TraitSelectionCache<'tcx> {
     type Key = ty::PolyTraitRef<'tcx>;
     type Value = Vtable<'tcx, ()>;
-    fn to_dep_node(key: &ty::PolyTraitRef<'tcx>) -> DepNode<DefId> {
-        key.to_poly_trait_predicate().dep_node()
+    fn to_dep_node(tcx: TyCtxt, key: &ty::PolyTraitRef<'tcx>) -> DepNode {
+        key.to_poly_trait_predicate().dep_node(tcx)
     }
 }
 
@@ -184,7 +185,7 @@ pub struct ProjectionCache<'gcx> {
 impl<'gcx> DepTrackingMapConfig for ProjectionCache<'gcx> {
     type Key = Ty<'gcx>;
     type Value = Ty<'gcx>;
-    fn to_dep_node(key: &Self::Key) -> DepNode<DefId> {
+    fn to_dep_node(tcx: TyCtxt, key: &Self::Key) -> DepNode {
         // Ideally, we'd just put `key` into the dep-node, but we
         // can't put full types in there. So just collect up all the
         // def-ids of structs/enums as well as any traits that we
@@ -208,7 +209,7 @@ impl<'gcx> DepTrackingMapConfig for ProjectionCache<'gcx> {
                })
                .collect();
 
-        DepNode::ProjectionCache { def_ids: def_ids }
+        DepNode::new(tcx, DepConstructor::ProjectionCache { def_ids: def_ids })
     }
 }
 

--- a/src/librustc/ty/instance.rs
+++ b/src/librustc/ty/instance.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use dep_graph::DepNode;
+use dep_graph::DepConstructor;
 use hir::def_id::DefId;
 use ty::{self, Ty, TypeFoldable, Substs};
 use util::ppaux;
@@ -60,7 +60,8 @@ impl<'tcx> InstanceDef<'tcx> {
         tcx.get_attrs(self.def_id())
     }
 
-    pub(crate) fn dep_node(&self) -> DepNode<DefId> {
+    pub //(crate)
+     fn dep_node(&self) -> DepConstructor {
         // HACK: def-id binning, project-style; someone replace this with
         // real on-demand.
         let ty = match self {
@@ -69,7 +70,7 @@ impl<'tcx> InstanceDef<'tcx> {
             _ => None
         }.into_iter();
 
-        DepNode::MirShim(
+        DepConstructor::MirShim(
             Some(self.def_id()).into_iter().chain(
                 ty.flat_map(|t| t.walk()).flat_map(|t| match t.sty {
                    ty::TyAdt(adt_def, _) => Some(adt_def.did),

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -15,7 +15,7 @@ pub use self::IntVarValue::*;
 pub use self::LvaluePreference::*;
 pub use self::fold::TypeFoldable;
 
-use dep_graph::DepNode;
+use dep_graph::{DepNode, DepConstructor};
 use hir::{map as hir_map, FreevarMap, TraitMap};
 use hir::def::{Def, CtorKind, ExportMap};
 use hir::def_id::{CrateNum, DefId, DefIndex, CRATE_DEF_INDEX, LOCAL_CRATE};
@@ -918,7 +918,7 @@ impl<'tcx> TraitPredicate<'tcx> {
     }
 
     /// Creates the dep-node for selecting/evaluating this trait reference.
-    fn dep_node(&self) -> DepNode<DefId> {
+    fn dep_node(&self, tcx: TyCtxt) -> DepNode {
         // Extact the trait-def and first def-id from inputs.  See the
         // docs for `DepNode::TraitSelect` for more information.
         let trait_def_id = self.def_id();
@@ -931,10 +931,10 @@ impl<'tcx> TraitPredicate<'tcx> {
                 })
                 .next()
                 .unwrap_or(trait_def_id);
-        DepNode::TraitSelect {
+        DepNode::new(tcx, DepConstructor::TraitSelect {
             trait_def_id: trait_def_id,
             input_def_id: input_def_id
-        }
+        })
     }
 
     pub fn input_types<'a>(&'a self) -> impl DoubleEndedIterator<Item=Ty<'tcx>> + 'a {
@@ -952,9 +952,9 @@ impl<'tcx> PolyTraitPredicate<'tcx> {
         self.0.def_id()
     }
 
-    pub fn dep_node(&self) -> DepNode<DefId> {
+    pub fn dep_node(&self, tcx: TyCtxt) -> DepNode {
         // ok to skip binder since depnode does not care about regions
-        self.0.dep_node()
+        self.0.dep_node(tcx)
     }
 }
 

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -19,6 +19,8 @@ use std::iter::repeat;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
+use ty::TyCtxt;
+
 // The name of the associated type for `Fn` return types
 pub const FN_OUTPUT_NAME: &'static str = "Output";
 
@@ -209,7 +211,7 @@ pub trait MemoizationMap {
     /// needed in the `op` to ensure that the correct edges are
     /// added into the dep graph. See the `DepTrackingMap` impl for
     /// more details!
-    fn memoize<OP>(&self, key: Self::Key, op: OP) -> Self::Value
+    fn memoize<OP>(&self, tcx: TyCtxt, key: Self::Key, op: OP) -> Self::Value
         where OP: FnOnce() -> Self::Value;
 }
 
@@ -219,7 +221,7 @@ impl<K, V, S> MemoizationMap for RefCell<HashMap<K,V,S>>
     type Key = K;
     type Value = V;
 
-    fn memoize<OP>(&self, key: K, op: OP) -> V
+    fn memoize<OP>(&self, _tcx: TyCtxt, key: K, op: OP) -> V
         where OP: FnOnce() -> V
     {
         let result = self.borrow().get(&key).cloned();

--- a/src/librustc_incremental/calculate_svh/mod.rs
+++ b/src/librustc_incremental/calculate_svh/mod.rs
@@ -29,7 +29,7 @@
 
 use std::cell::RefCell;
 use std::hash::Hash;
-use rustc::dep_graph::DepNode;
+use rustc::dep_graph::{DepNode, DepKind};
 use rustc::hir;
 use rustc::hir::def_id::{CRATE_DEF_INDEX, DefId};
 use rustc::hir::map::DefPathHash;
@@ -44,7 +44,7 @@ use rustc_data_structures::accumulate_vec::AccumulateVec;
 pub type IchHasher = StableHasher<Fingerprint>;
 
 pub struct IncrementalHashesMap {
-    hashes: FxHashMap<DepNode<DefId>, Fingerprint>,
+    hashes: FxHashMap<DepNode, Fingerprint>,
 
     // These are the metadata hashes for the current crate as they were stored
     // during the last compilation session. They are only loaded if
@@ -62,16 +62,16 @@ impl IncrementalHashesMap {
         }
     }
 
-    pub fn get(&self, k: &DepNode<DefId>) -> Option<&Fingerprint> {
+    pub fn get(&self, k: &DepNode) -> Option<&Fingerprint> {
         self.hashes.get(k)
     }
 
-    pub fn insert(&mut self, k: DepNode<DefId>, v: Fingerprint) -> Option<Fingerprint> {
-        self.hashes.insert(k, v)
+    pub fn insert(&mut self, k: DepNode, v: Fingerprint) {
+        assert!(self.hashes.insert(k, v).is_none());
     }
 
     pub fn iter<'a>(&'a self)
-                    -> ::std::collections::hash_map::Iter<'a, DepNode<DefId>, Fingerprint> {
+                    -> ::std::collections::hash_map::Iter<'a, DepNode, Fingerprint> {
         self.hashes.iter()
     }
 
@@ -80,10 +80,10 @@ impl IncrementalHashesMap {
     }
 }
 
-impl<'a> ::std::ops::Index<&'a DepNode<DefId>> for IncrementalHashesMap {
+impl<'a> ::std::ops::Index<&'a DepNode> for IncrementalHashesMap {
     type Output = Fingerprint;
 
-    fn index(&self, index: &'a DepNode<DefId>) -> &Fingerprint {
+    fn index(&self, index: &'a DepNode) -> &Fingerprint {
         match self.hashes.get(index) {
             Some(fingerprint) => fingerprint,
             None => {
@@ -100,7 +100,7 @@ struct ComputeItemHashesVisitor<'a, 'tcx: 'a> {
 
 impl<'a, 'tcx: 'a> ComputeItemHashesVisitor<'a, 'tcx> {
     fn compute_and_store_ich_for_item_like<T>(&mut self,
-                                              dep_node: DepNode<DefId>,
+                                              dep_node: DepNode,
                                               hash_bodies: bool,
                                               item_like: T)
         where T: HashStable<StableHashingContext<'a, 'tcx, 'tcx>>
@@ -143,36 +143,29 @@ impl<'a, 'tcx: 'a> ComputeItemHashesVisitor<'a, 'tcx> {
         // add each item (in some deterministic order) to the overall
         // crate hash.
         {
-            let hcx = &mut self.hcx;
             let mut item_hashes: Vec<_> =
                 self.hashes.iter()
-                           .filter_map(|(item_dep_node, &item_hash)| {
+                           .filter_map(|(&item_dep_node, &item_hash)| {
                                 // This `match` determines what kinds of nodes
                                 // go into the SVH:
-                                match *item_dep_node {
-                                    DepNode::Hir(_) |
-                                    DepNode::HirBody(_) => {
+                                match item_dep_node.kind {
+                                    DepKind::Hir |
+                                    DepKind::HirBody => {
                                         // We want to incoporate these into the
                                         // SVH.
                                     }
-                                    DepNode::AllLocalTraitImpls => {
+                                    DepKind::AllLocalTraitImpls => {
                                         // These are already covered by hashing
                                         // the HIR.
                                         return None
                                     }
                                     ref other => {
-                                        bug!("Found unexpected DepNode during \
+                                        bug!("Found unexpected DepKind during \
                                               SVH computation: {:?}",
                                              other)
                                     }
                                 }
 
-                                // Convert from a DepNode<DefId> to a
-                                // DepNode<u64> where the u64 is the hash of
-                                // the def-id's def-path:
-                                let item_dep_node =
-                                    item_dep_node.map_def(|&did| Some(hcx.def_path_hash(did)))
-                                                 .unwrap();
                                 Some((item_dep_node, item_hash))
                            })
                            .collect();
@@ -183,7 +176,7 @@ impl<'a, 'tcx: 'a> ComputeItemHashesVisitor<'a, 'tcx> {
         krate.attrs.hash_stable(&mut self.hcx, &mut crate_state);
 
         let crate_hash = crate_state.finish();
-        self.hashes.insert(DepNode::Krate, crate_hash);
+        self.hashes.insert(DepNode::new_no_params(DepKind::Krate), crate_hash);
         debug!("calculate_crate_hash: crate_hash={:?}", crate_hash);
     }
 
@@ -206,11 +199,11 @@ impl<'a, 'tcx: 'a> ComputeItemHashesVisitor<'a, 'tcx> {
             body_ids: _,
         } = *krate;
 
-        let def_id = DefId::local(CRATE_DEF_INDEX);
-        self.compute_and_store_ich_for_item_like(DepNode::Hir(def_id),
+        let def_path_hash = self.hcx.tcx().hir.definitions().def_path_hash(CRATE_DEF_INDEX);
+        self.compute_and_store_ich_for_item_like(def_path_hash.to_dep_node(DepKind::Hir),
                                                  false,
                                                  (module, (span, attrs)));
-        self.compute_and_store_ich_for_item_like(DepNode::HirBody(def_id),
+        self.compute_and_store_ich_for_item_like(def_path_hash.to_dep_node(DepKind::HirBody),
                                                  true,
                                                  (module, (span, attrs)));
     }
@@ -255,27 +248,43 @@ impl<'a, 'tcx: 'a> ComputeItemHashesVisitor<'a, 'tcx> {
         let mut hasher = StableHasher::new();
         impls.hash_stable(&mut self.hcx, &mut hasher);
 
-        self.hashes.insert(DepNode::AllLocalTraitImpls, hasher.finish());
+        self.hashes.insert(DepNode::new_no_params(DepKind::AllLocalTraitImpls),
+                           hasher.finish());
     }
 }
 
 impl<'a, 'tcx: 'a> ItemLikeVisitor<'tcx> for ComputeItemHashesVisitor<'a, 'tcx> {
     fn visit_item(&mut self, item: &'tcx hir::Item) {
         let def_id = self.hcx.tcx().hir.local_def_id(item.id);
-        self.compute_and_store_ich_for_item_like(DepNode::Hir(def_id), false, item);
-        self.compute_and_store_ich_for_item_like(DepNode::HirBody(def_id), true, item);
+        let def_path_hash = self.hcx.tcx().def_path_hash(def_id);
+        self.compute_and_store_ich_for_item_like(def_path_hash.to_dep_node(DepKind::Hir),
+                                                 false,
+                                                 item);
+        self.compute_and_store_ich_for_item_like(def_path_hash.to_dep_node(DepKind::HirBody),
+                                                 true,
+                                                 item);
     }
 
     fn visit_trait_item(&mut self, item: &'tcx hir::TraitItem) {
         let def_id = self.hcx.tcx().hir.local_def_id(item.id);
-        self.compute_and_store_ich_for_item_like(DepNode::Hir(def_id), false, item);
-        self.compute_and_store_ich_for_item_like(DepNode::HirBody(def_id), true, item);
+        let def_path_hash = self.hcx.tcx().def_path_hash(def_id);
+        self.compute_and_store_ich_for_item_like(def_path_hash.to_dep_node(DepKind::Hir),
+                                                 false,
+                                                 item);
+        self.compute_and_store_ich_for_item_like(def_path_hash.to_dep_node(DepKind::HirBody),
+                                                 true,
+                                                 item);
     }
 
     fn visit_impl_item(&mut self, item: &'tcx hir::ImplItem) {
         let def_id = self.hcx.tcx().hir.local_def_id(item.id);
-        self.compute_and_store_ich_for_item_like(DepNode::Hir(def_id), false, item);
-        self.compute_and_store_ich_for_item_like(DepNode::HirBody(def_id), true, item);
+        let def_path_hash = self.hcx.tcx().def_path_hash(def_id);
+        self.compute_and_store_ich_for_item_like(def_path_hash.to_dep_node(DepKind::Hir),
+                                                 false,
+                                                 item);
+        self.compute_and_store_ich_for_item_like(def_path_hash.to_dep_node(DepKind::HirBody),
+                                                 true,
+                                                 item);
     }
 }
 
@@ -297,8 +306,13 @@ pub fn compute_incremental_hashes_map<'a, 'tcx: 'a>(tcx: TyCtxt<'a, 'tcx, 'tcx>)
 
         for macro_def in krate.exported_macros.iter() {
             let def_id = tcx.hir.local_def_id(macro_def.id);
-            visitor.compute_and_store_ich_for_item_like(DepNode::Hir(def_id), false, macro_def);
-            visitor.compute_and_store_ich_for_item_like(DepNode::HirBody(def_id), true, macro_def);
+            let def_path_hash = tcx.def_path_hash(def_id);
+            visitor.compute_and_store_ich_for_item_like(def_path_hash.to_dep_node(DepKind::Hir),
+                                                        false,
+                                                        macro_def);
+            visitor.compute_and_store_ich_for_item_like(def_path_hash.to_dep_node(DepKind::HirBody),
+                                                        true,
+                                                        macro_def);
         }
 
         visitor.compute_and_store_ich_for_trait_impls(krate);

--- a/src/librustc_incremental/persist/data.rs
+++ b/src/librustc_incremental/persist/data.rs
@@ -22,7 +22,7 @@ use rustc_data_structures::indexed_vec::{IndexVec, Idx};
 #[derive(Debug, RustcEncodable, RustcDecodable)]
 pub struct SerializedDepGraph {
     /// The set of all DepNodes in the graph
-    pub nodes: IndexVec<DepNodeIndex, DepNode<DefPathHash>>,
+    pub nodes: IndexVec<DepNodeIndex, DepNode>,
     /// For each DepNode, stores the list of edges originating from that
     /// DepNode. Encoded as a [start, end) pair indexing into edge_list_data,
     /// which holds the actual DepNodeIndices of the target nodes.
@@ -34,7 +34,7 @@ pub struct SerializedDepGraph {
     /// These are output nodes that have no incoming edges. We track
     /// these separately so that when we reload all edges, we don't
     /// lose track of these nodes.
-    pub bootstrap_outputs: Vec<DepNode<DefPathHash>>,
+    pub bootstrap_outputs: Vec<DepNode>,
 
     /// These are hashes of two things:
     /// - the HIR nodes in this crate
@@ -87,7 +87,7 @@ impl Idx for DepNodeIndex {
 #[derive(Debug, RustcEncodable, RustcDecodable)]
 pub struct SerializedHash {
     /// def-id of thing being hashed
-    pub dep_node: DepNode<DefPathHash>,
+    pub dep_node: DepNode,
 
     /// the hash as of previous compilation, computed by code in
     /// `hash` module

--- a/src/librustc_incremental/persist/dirty_clean.rs
+++ b/src/librustc_incremental/persist/dirty_clean.rs
@@ -41,7 +41,7 @@
 //!
 
 use super::load::DirtyNodes;
-use rustc::dep_graph::{DepGraphQuery, DepNode};
+use rustc::dep_graph::{DepGraphQuery, DepNode, DepKind};
 use rustc::hir;
 use rustc::hir::def_id::DefId;
 use rustc::hir::itemlikevisit::ItemLikeVisitor;
@@ -64,14 +64,10 @@ pub fn check_dirty_clean_annotations<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     }
 
     let _ignore = tcx.dep_graph.in_ignore();
-    let def_path_hash_to_def_id = tcx.def_path_hash_to_def_id.as_ref().unwrap();
-    let dirty_inputs: FxHashSet<DepNode<DefId>> =
+    let dirty_inputs: FxHashSet<DepNode> =
         dirty_inputs.keys()
-                    .filter_map(|dep_node| {
-                        dep_node.map_def(|def_path_hash| {
-                            def_path_hash_to_def_id.get(def_path_hash).cloned()
-                        })
-                    })
+                    .filter(|dep_node| dep_node.extract_def_id(tcx).is_some())
+                    .cloned()
                     .collect();
 
     let query = tcx.dep_graph.query();
@@ -100,18 +96,19 @@ pub fn check_dirty_clean_annotations<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
 pub struct DirtyCleanVisitor<'a, 'tcx:'a> {
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
-    query: &'a DepGraphQuery<DefId>,
-    dirty_inputs: FxHashSet<DepNode<DefId>>,
+    query: &'a DepGraphQuery,
+    dirty_inputs: FxHashSet<DepNode>,
     checked_attrs: FxHashSet<ast::AttrId>,
 }
 
 impl<'a, 'tcx> DirtyCleanVisitor<'a, 'tcx> {
-    fn dep_node(&self, attr: &Attribute, def_id: DefId) -> DepNode<DefId> {
+    fn dep_node(&self, attr: &Attribute, def_id: DefId) -> DepNode {
+        let def_path_hash = self.tcx.def_path_hash(def_id);
         for item in attr.meta_item_list().unwrap_or_else(Vec::new) {
             if item.check_name(LABEL) {
                 let value = expect_associated_value(self.tcx, &item);
-                match DepNode::from_label_string(&value.as_str(), def_id) {
-                    Ok(def_id) => return def_id,
+                match DepNode::from_label_string(&value.as_str(), def_path_hash) {
+                    Ok(dep_node) => return dep_node,
                     Err(()) => {
                         self.tcx.sess.span_fatal(
                             item.span,
@@ -124,24 +121,30 @@ impl<'a, 'tcx> DirtyCleanVisitor<'a, 'tcx> {
         self.tcx.sess.span_fatal(attr.span, "no `label` found");
     }
 
-    fn dep_node_str(&self, dep_node: &DepNode<DefId>) -> DepNode<String> {
-        dep_node.map_def(|&def_id| Some(self.tcx.item_path_str(def_id))).unwrap()
+    fn dep_node_str(&self, dep_node: &DepNode) -> String {
+        if let Some(def_id) = dep_node.extract_def_id(self.tcx) {
+            format!("{:?}({})",
+                    dep_node.kind,
+                    self.tcx.item_path_str(def_id))
+        } else {
+            format!("{:?}({:?})", dep_node.kind, dep_node.hash)
+        }
     }
 
-    fn assert_dirty(&self, item_span: Span, dep_node: DepNode<DefId>) {
+    fn assert_dirty(&self, item_span: Span, dep_node: DepNode) {
         debug!("assert_dirty({:?})", dep_node);
 
-        match dep_node {
-            DepNode::Krate |
-            DepNode::Hir(_) |
-            DepNode::HirBody(_) => {
+        match dep_node.kind {
+            DepKind::Krate |
+            DepKind::Hir |
+            DepKind::HirBody => {
                 // HIR nodes are inputs, so if we are asserting that the HIR node is
                 // dirty, we check the dirty input set.
                 if !self.dirty_inputs.contains(&dep_node) {
                     let dep_node_str = self.dep_node_str(&dep_node);
                     self.tcx.sess.span_err(
                         item_span,
-                        &format!("`{:?}` not found in dirty set, but should be dirty",
+                        &format!("`{}` not found in dirty set, but should be dirty",
                                  dep_node_str));
                 }
             }
@@ -152,25 +155,25 @@ impl<'a, 'tcx> DirtyCleanVisitor<'a, 'tcx> {
                     let dep_node_str = self.dep_node_str(&dep_node);
                     self.tcx.sess.span_err(
                         item_span,
-                        &format!("`{:?}` found in dep graph, but should be dirty", dep_node_str));
+                        &format!("`{}` found in dep graph, but should be dirty", dep_node_str));
                 }
             }
         }
     }
 
-    fn assert_clean(&self, item_span: Span, dep_node: DepNode<DefId>) {
+    fn assert_clean(&self, item_span: Span, dep_node: DepNode) {
         debug!("assert_clean({:?})", dep_node);
 
-        match dep_node {
-            DepNode::Krate |
-            DepNode::Hir(_) |
-            DepNode::HirBody(_) => {
+        match dep_node.kind {
+            DepKind::Krate |
+            DepKind::Hir |
+            DepKind::HirBody => {
                 // For HIR nodes, check the inputs.
                 if self.dirty_inputs.contains(&dep_node) {
                     let dep_node_str = self.dep_node_str(&dep_node);
                     self.tcx.sess.span_err(
                         item_span,
-                        &format!("`{:?}` found in dirty-node set, but should be clean",
+                        &format!("`{}` found in dirty-node set, but should be clean",
                                  dep_node_str));
                 }
             }
@@ -180,7 +183,7 @@ impl<'a, 'tcx> DirtyCleanVisitor<'a, 'tcx> {
                     let dep_node_str = self.dep_node_str(&dep_node);
                     self.tcx.sess.span_err(
                         item_span,
-                        &format!("`{:?}` not found in dep graph, but should be clean",
+                        &format!("`{}` not found in dep graph, but should be clean",
                                  dep_node_str));
                 }
             }

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -255,6 +255,13 @@ impl CStore {
     pub fn do_extern_mod_stmt_cnum(&self, emod_id: ast::NodeId) -> Option<CrateNum> {
         self.extern_mod_crate_map.borrow().get(&emod_id).cloned()
     }
+
+    pub fn read_dep_node(&self, def_id: DefId) {
+        use rustc::middle::cstore::CrateStore;
+        let def_path_hash = self.def_path_hash(def_id);
+        let dep_node = def_path_hash.to_dep_node(::rustc::dep_graph::DepKind::MetaData);
+        self.dep_graph.read(dep_node);
+    }
 }
 
 impl CrateMetadata {

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -22,8 +22,6 @@ use rustc::session::Session;
 use rustc::ty::{self, TyCtxt};
 use rustc::ty::maps::Providers;
 use rustc::hir::def_id::{CrateNum, DefId, DefIndex, CRATE_DEF_INDEX, LOCAL_CRATE};
-
-use rustc::dep_graph::{DepNode};
 use rustc::hir::map::{DefKey, DefPath, DisambiguatedDefPathData, DefPathHash};
 use rustc::hir::map::definitions::{DefPathTable, GlobalMetaDataKind};
 use rustc::util::nodemap::{NodeSet, DefIdMap};
@@ -48,7 +46,10 @@ macro_rules! provide {
                                         DepTrackingMapConfig>::Value {
                 assert!(!$def_id.is_local());
 
-                $tcx.dep_graph.read(DepNode::MetaData($def_id));
+                let def_path_hash = $tcx.def_path_hash($def_id);
+                let dep_node = def_path_hash.to_dep_node(::rustc::dep_graph::DepKind::MetaData);
+
+                $tcx.dep_graph.read(dep_node);
 
                 let $cdata = $tcx.sess.cstore.crate_data_as_rc_any($def_id.krate);
                 let $cdata = $cdata.downcast_ref::<cstore::CrateMetadata>()
@@ -140,12 +141,12 @@ impl CrateStore for cstore::CStore {
     }
 
     fn visibility(&self, def: DefId) -> ty::Visibility {
-        self.dep_graph.read(DepNode::MetaData(def));
+        self.read_dep_node(def);
         self.get_crate_data(def.krate).get_visibility(def.index)
     }
 
     fn item_generics_cloned(&self, def: DefId) -> ty::Generics {
-        self.dep_graph.read(DepNode::MetaData(def));
+        self.read_dep_node(def);
         self.get_crate_data(def.krate).get_generics(def.index)
     }
 
@@ -161,19 +162,19 @@ impl CrateStore for cstore::CStore {
 
     fn impl_defaultness(&self, def: DefId) -> hir::Defaultness
     {
-        self.dep_graph.read(DepNode::MetaData(def));
+        self.read_dep_node(def);
         self.get_crate_data(def.krate).get_impl_defaultness(def.index)
     }
 
     fn associated_item_cloned(&self, def: DefId) -> ty::AssociatedItem
     {
-        self.dep_graph.read(DepNode::MetaData(def));
+        self.read_dep_node(def);
         self.get_crate_data(def.krate).get_associated_item(def.index)
     }
 
     fn is_const_fn(&self, did: DefId) -> bool
     {
-        self.dep_graph.read(DepNode::MetaData(did));
+        self.read_dep_node(did);
         self.get_crate_data(did.krate).is_const_fn(did.index)
     }
 
@@ -344,13 +345,13 @@ impl CrateStore for cstore::CStore {
 
     fn struct_field_names(&self, def: DefId) -> Vec<ast::Name>
     {
-        self.dep_graph.read(DepNode::MetaData(def));
+        self.read_dep_node(def);
         self.get_crate_data(def.krate).get_struct_field_names(def.index)
     }
 
     fn item_children(&self, def_id: DefId) -> Vec<def::Export>
     {
-        self.dep_graph.read(DepNode::MetaData(def_id));
+        self.read_dep_node(def_id);
         let mut result = vec![];
         self.get_crate_data(def_id.krate)
             .each_child_of_item(def_id.index, |child| result.push(child));
@@ -398,11 +399,12 @@ impl CrateStore for cstore::CStore {
                            tcx: TyCtxt<'a, 'tcx, 'tcx>,
                            def_id: DefId)
                            -> &'tcx hir::Body {
-        if let Some(cached) = tcx.hir.get_inlined_body(def_id) {
+        self.read_dep_node(def_id);
+
+        if let Some(cached) = tcx.hir.get_inlined_body_untracked(def_id) {
             return cached;
         }
 
-        self.dep_graph.read(DepNode::MetaData(def_id));
         debug!("item_body({:?}): inlining item", def_id);
 
         self.get_crate_data(def_id.krate).item_body(tcx, def_id.index)

--- a/src/librustc_metadata/schema.rs
+++ b/src/librustc_metadata/schema.rs
@@ -203,7 +203,7 @@ impl<T> Tracked<T> {
         }
     }
 
-    pub fn get(&self, dep_graph: &DepGraph, dep_node: DepNode<DefId>) -> &T {
+    pub fn get(&self, dep_graph: &DepGraph, dep_node: DepNode) -> &T {
         dep_graph.read(dep_node);
         &self.state
     }

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -23,7 +23,7 @@ use rustc::middle::dependency_format::Linkage;
 use CrateTranslation;
 use rustc::util::common::time;
 use rustc::util::fs::fix_windows_verbatim_for_gcc;
-use rustc::dep_graph::DepNode;
+use rustc::dep_graph::{DepKind, DepNode};
 use rustc::hir::def_id::CrateNum;
 use rustc::hir::svh::Svh;
 use rustc_back::tempdir::TempDir;
@@ -134,8 +134,9 @@ pub fn find_crate_name(sess: Option<&Session>,
 }
 
 pub fn build_link_meta(incremental_hashes_map: &IncrementalHashesMap) -> LinkMeta {
+    let krate_dep_node = &DepNode::new_no_params(DepKind::Krate);
     let r = LinkMeta {
-        crate_hash: Svh::new(incremental_hashes_map[&DepNode::Krate].to_smaller_hash()),
+        crate_hash: Svh::new(incremental_hashes_map[krate_dep_node].to_smaller_hash()),
     };
     info!("{:?}", r);
     return r;

--- a/src/librustc_trans/partitioning.rs
+++ b/src/librustc_trans/partitioning.rs
@@ -167,8 +167,8 @@ impl<'tcx> CodegenUnit<'tcx> {
         WorkProductId::from_cgu_name(self.name())
     }
 
-    pub fn work_product_dep_node(&self) -> DepNode<DefId> {
-        DepNode::WorkProduct(self.work_product_id())
+    pub fn work_product_dep_node(&self) -> DepNode {
+        self.work_product_id().to_dep_node()
     }
 
     pub fn compute_symbol_name_hash<'a>(&self,

--- a/src/librustc_typeck/coherence/inherent_impls.rs
+++ b/src/librustc_typeck/coherence/inherent_impls.rs
@@ -17,7 +17,7 @@
 //! `tcx.inherent_impls(def_id)`). That value, however,
 //! is computed by selecting an idea from this table.
 
-use rustc::dep_graph::DepNode;
+use rustc::dep_graph::DepKind;
 use rustc::hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use rustc::hir;
 use rustc::hir::itemlikevisit::ItemLikeVisitor;
@@ -79,7 +79,8 @@ pub fn inherent_impls<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     });
 
     for &impl_def_id in &result[..] {
-        tcx.dep_graph.read(DepNode::Hir(impl_def_id));
+        let def_path_hash = tcx.def_path_hash(impl_def_id);
+        tcx.dep_graph.read(def_path_hash.to_dep_node(DepKind::Hir));
     }
 
     result

--- a/src/librustc_typeck/coherence/overlap.rs
+++ b/src/librustc_typeck/coherence/overlap.rs
@@ -15,7 +15,7 @@
 use rustc::traits;
 use rustc::ty::{self, TyCtxt, TypeFoldable};
 use syntax::ast;
-use rustc::dep_graph::DepNode;
+use rustc::dep_graph::DepKind;
 use rustc::hir;
 use rustc::hir::itemlikevisit::ItemLikeVisitor;
 
@@ -39,7 +39,8 @@ pub fn check_impl<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, node_id: ast::NodeId) {
     }
 
     let _task =
-        tcx.dep_graph.in_task(DepNode::CoherenceOverlapCheck(trait_def_id));
+      tcx.dep_graph.in_task(trait_def_id.to_dep_node(tcx,
+                                                     DepKind::CoherenceOverlapCheck));
 
     // Trigger building the specialization graph for the trait of this impl.
     // This will detect any overlap errors.

--- a/src/librustc_typeck/variance/constraints.rs
+++ b/src/librustc_typeck/variance/constraints.rs
@@ -15,7 +15,7 @@
 
 use hir::def_id::DefId;
 use middle::resolve_lifetime as rl;
-use rustc::dep_graph::{AssertDepGraphSafe, DepNode};
+use rustc::dep_graph::{AssertDepGraphSafe, DepKind};
 use rustc::ty::subst::Substs;
 use rustc::ty::{self, Ty, TyCtxt};
 use rustc::hir::map as hir_map;
@@ -104,7 +104,8 @@ impl<'a, 'tcx, 'v> ItemLikeVisitor<'v> for ConstraintContext<'a, 'tcx> {
             hir::ItemEnum(..) |
             hir::ItemStruct(..) |
             hir::ItemUnion(..) => {
-                tcx.dep_graph.with_task(DepNode::ItemVarianceConstraints(def_id),
+                let dep_node = def_id.to_dep_node(tcx, DepKind::ItemVarianceConstraints);
+                tcx.dep_graph.with_task(dep_node,
                                         AssertDepGraphSafe(self),
                                         def_id,
                                         visit_item_task);

--- a/src/test/incremental/dirty_clean.rs
+++ b/src/test/incremental/dirty_clean.rs
@@ -38,8 +38,8 @@ mod y {
     #[rustc_clean(label="TypeckTables", cfg="cfail2")]
     #[rustc_clean(label="TransCrateItem", cfg="cfail2")]
     pub fn y() {
-        //[cfail2]~^ ERROR `TypeckTables("y::y")` not found in dep graph, but should be clean
-        //[cfail2]~| ERROR `TransCrateItem("y::y")` not found in dep graph, but should be clean
+        //[cfail2]~^ ERROR `TypeckTables(y::y)` not found in dep graph, but should be clean
+        //[cfail2]~| ERROR `TransCrateItem(y::y)` not found in dep graph, but should be clean
         x::x();
     }
 }
@@ -48,7 +48,7 @@ mod z {
     #[rustc_dirty(label="TypeckTables", cfg="cfail2")]
     #[rustc_dirty(label="TransCrateItem", cfg="cfail2")]
     pub fn z() {
-        //[cfail2]~^ ERROR `TypeckTables("z::z")` found in dep graph, but should be dirty
-        //[cfail2]~| ERROR `TransCrateItem("z::z")` found in dep graph, but should be dirty
+        //[cfail2]~^ ERROR `TypeckTables(z::z)` found in dep graph, but should be dirty
+        //[cfail2]~| ERROR `TransCrateItem(z::z)` found in dep graph, but should be dirty
     }
 }


### PR DESCRIPTION
This PR moves `DepNode` to a representation that does not need retracing and thus simplifies comparing dep-graphs from different compilation sessions. The code also gets a lot simpler in many places, since we don't need the generic parameter on `DepNode` anymore.  See https://github.com/rust-lang/rust/issues/42294 for details.

~~NOTE: Only the last commit of this is new, the rest is already reviewed in https://github.com/rust-lang/rust/pull/42504.~~

This PR is almost done but there are some things I still want to do:
- [x] Add some module-level documentation to `dep_node.rs`, explaining especially what the `define_dep_nodes!()` macro is about.
- [x] Do another pass over the dep-graph loading logic. I suspect that we can get rid of building the `edges` map and also use arrays instead of hash maps in some places.

cc @rust-lang/compiler 
r? @nikomatsakis 