### PR TITLE
rustdoc: Use `create_dir_all` to create output directory

### DIFF
--- a/src/test/run-make/rustdoc-output-path/Makefile
+++ b/src/test/run-make/rustdoc-output-path/Makefile
@@ -1,0 +1,4 @@
+-include ../tools.mk
+
+all:
+	$(HOST_RPATH_ENV) '$(RUSTDOC)' -o "$(TMPDIR)/foo/bar/doc" foo.rs

--- a/src/test/run-make/rustdoc-output-path/foo.rs
+++ b/src/test/run-make/rustdoc-output-path/foo.rs
@@ -1,0 +1,11 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub struct Foo;


### PR DESCRIPTION
Currently rustdoc will fail if passed `-o foo/doc` if the `foo`
directory doesn't exist.

Also remove unneeded `mkdir` as `create_dir_all` can now handle
concurrent invocations since #39799.