### PR TITLE
Only emit one error for `use foo::self;`

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -482,6 +482,16 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
             if let Some(err) = self.finalize_import(import) {
                 errors = true;
 
+                if let SingleImport { source, ref result, .. } = import.subclass {
+                    if source.name == "self" {
+                        // Silence `unresolved import` error if E0429 is already emitted
+                        match result.value_ns.get() {
+                            Err(Determined) => continue,
+                            _ => {},
+                        }
+                    }
+                }
+
                 // If the error is a single failed import then create a "fake" import
                 // resolution for it so that later resolve stages won't complain.
                 self.import_dummy_binding(import);

--- a/src/test/compile-fail/E0429.rs
+++ b/src/test/compile-fail/E0429.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 use std::fmt::self; //~ ERROR E0429
-                    //~^ ERROR E0432
 
 fn main () {
 }

--- a/src/test/compile-fail/use-keyword.rs
+++ b/src/test/compile-fail/use-keyword.rs
@@ -13,9 +13,8 @@
 
 mod a {
     mod b {
-        use self as A; //~ ERROR `self` imports are only allowed within a { } list
-        //~^ ERROR unresolved import `self` [E0432]
-        //~| no `self` in the root
+        use self as A;
+        //~^ ERROR `self` imports are only allowed within a { } list
         use super as B;
         //~^ ERROR unresolved import `super` [E0432]
         //~| no `super` in the root

--- a/src/test/compile-fail/use-mod-4.rs
+++ b/src/test/compile-fail/use-mod-4.rs
@@ -11,4 +11,7 @@
 use foo::self; //~ ERROR unresolved import `foo::self`
 //~^ ERROR `self` imports are only allowed within a { } list
 
+use std::mem::self;
+//~^ ERROR `self` imports are only allowed within a { } list
+
 fn main() {}


### PR DESCRIPTION
Currently `use foo::self;` would emit both E0429 and E0432. This commit silence the latter one (assuming `foo` is a valid module).

Fixes #42559