### PR TITLE
Specialize Iterator::last for DoubleEndedIterator.

### DIFF
--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -203,9 +203,7 @@ pub trait Iterator {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn last(self) -> Option<Self::Item> where Self: Sized {
-        let mut last = None;
-        for x in self { last = Some(x); }
-        last
+        SpecLast::last(self)
     }
 
     /// Returns the `n`th element of the iterator.
@@ -2237,5 +2235,22 @@ impl<'a, I: Iterator + ?Sized> Iterator for &'a mut I {
     fn size_hint(&self) -> (usize, Option<usize>) { (**self).size_hint() }
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         (**self).nth(n)
+    }
+}
+
+/// Allows specialization for `Iterator::last`.
+trait SpecLast: Iterator + Sized {
+    fn last(self) -> Option<Self::Item>;
+}
+impl<T: Iterator> SpecLast for T {
+    default fn last(self) -> Option<Self::Item> {
+        let mut last = None;
+        for x in self { last = Some(x); }
+        last
+    }
+}
+impl<T: DoubleEndedIterator> SpecLast for T {
+    fn last(mut self) -> Option<Self::Item> {
+        self.next_back()
     }
 }

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1159,11 +1159,6 @@ macro_rules! iterator {
                 self.iter_nth(n)
             }
 
-            #[inline]
-            fn last(mut self) -> Option<$elem> {
-                self.next_back()
-            }
-
             fn all<F>(&mut self, mut predicate: F) -> bool
                 where F: FnMut(Self::Item) -> bool,
             {

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -542,12 +542,6 @@ impl<'a> Iterator for Chars<'a> {
         // `isize::MAX` (that's well below `usize::MAX`).
         ((len + 3) / 4, Some(len))
     }
-
-    #[inline]
-    fn last(mut self) -> Option<char> {
-        // No need to go through the entire string.
-        self.next_back()
-    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -634,12 +628,6 @@ impl<'a> Iterator for CharIndices<'a> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
-
-    #[inline]
-    fn last(mut self) -> Option<(usize, char)> {
-        // No need to go through the entire string.
-        self.next_back()
-    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -699,11 +687,6 @@ impl<'a> Iterator for Bytes<'a> {
     #[inline]
     fn count(self) -> usize {
         self.0.count()
-    }
-
-    #[inline]
-    fn last(self) -> Option<Self::Item> {
-        self.0.last()
     }
 
     #[inline]


### PR DESCRIPTION
Fixes #41691.

This optimisation has been applied manually on a lot of different iterators, including some in the standard library, but it makes more sense to do it automatically with specialisation.