### PR TITLE
Make unused-extern-crate warn-by-default

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1327,7 +1327,6 @@ dependencies = [
  "graphviz 0.0.0",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc 0.0.0",
- "rustc_data_structures 0.0.0",
  "rustc_errors 0.0.0",
  "rustc_mir 0.0.0",
  "syntax 0.0.0",
@@ -1464,7 +1463,6 @@ dependencies = [
  "proc_macro 0.0.0",
  "rustc 0.0.0",
  "rustc_back 0.0.0",
- "rustc_const_math 0.0.0",
  "rustc_data_structures 0.0.0",
  "rustc_errors 0.0.0",
  "serialize 0.0.0",
@@ -1605,6 +1603,7 @@ dependencies = [
 name = "rustc_tsan"
 version = "0.0.0"
 dependencies = [
+ "alloc 0.0.0",
  "alloc_system 0.0.0",
  "build_helper 0.1.0",
  "cmake 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1859,7 +1858,6 @@ name = "syntax_ext"
 version = "0.0.0"
 dependencies = [
  "fmt_macros 0.0.0",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc_macro 0.0.0",
  "rustc_errors 0.0.0",
  "syntax 0.0.0",

--- a/src/liballoc/tests/lib.rs
+++ b/src/liballoc/tests/lib.rs
@@ -10,7 +10,6 @@
 
 #![deny(warnings)]
 
-#![feature(alloc)]
 #![feature(attr_literals)]
 #![feature(box_syntax)]
 #![feature(inclusive_range_syntax)]
@@ -27,14 +26,10 @@
 #![feature(splice)]
 #![feature(str_escape)]
 #![feature(string_retain)]
-#![feature(test)]
 #![feature(unboxed_closures)]
 #![feature(unicode)]
 
-extern crate alloc;
-extern crate test;
 extern crate std_unicode;
-extern crate core;
 
 use std::hash::{Hash, Hasher};
 use std::collections::hash_map::DefaultHasher;

--- a/src/liballoc_jemalloc/lib.rs
+++ b/src/liballoc_jemalloc/lib.rs
@@ -19,7 +19,7 @@
 #![feature(libc)]
 #![feature(linkage)]
 #![feature(staged_api)]
-#![cfg_attr(dummy_jemalloc, allow(dead_code))]
+#![cfg_attr(dummy_jemalloc, allow(dead_code, unused_extern_crates))]
 #![cfg_attr(not(dummy_jemalloc), feature(allocator_api))]
 
 extern crate alloc;

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -26,7 +26,6 @@
 #![feature(inclusive_range)]
 #![feature(inclusive_range_syntax)]
 #![feature(iter_rfind)]
-#![feature(libc)]
 #![feature(nonzero)]
 #![feature(ord_max_min)]
 #![feature(rand)]
@@ -41,13 +40,10 @@
 #![feature(test)]
 #![feature(trusted_len)]
 #![feature(try_from)]
-#![feature(unicode)]
 #![feature(unique)]
 
 extern crate core;
 extern crate test;
-extern crate libc;
-extern crate std_unicode;
 extern crate rand;
 
 mod any;

--- a/src/libpanic_unwind/lib.rs
+++ b/src/libpanic_unwind/lib.rs
@@ -34,7 +34,9 @@
 #![feature(core_intrinsics)]
 #![feature(lang_items)]
 #![feature(libc)]
-#![feature(panic_unwind)]
+#![cfg_attr(not(any(target_env = "msvc",
+                    all(windows, target_arch = "x86_64", target_env = "gnu"))),
+            feature(panic_unwind))]
 #![feature(raw)]
 #![feature(staged_api)]
 #![feature(unwind_attributes)]
@@ -45,6 +47,7 @@
 
 extern crate alloc;
 extern crate libc;
+#[cfg(not(any(target_env = "msvc", all(windows, target_arch = "x86_64", target_env = "gnu"))))]
 extern crate unwind;
 
 use core::intrinsics;

--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -522,6 +522,8 @@ define_dep_nodes!( <'tcx>
     [] DylibDepFormats(DefId),
     [] IsAllocator(DefId),
     [] IsPanicRuntime(DefId),
+    [] IsCompilerBuiltins(DefId),
+    [] HasGlobalAllocator(DefId),
     [] ExternCrate(DefId),
     [] LintLevels,
 );

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -26,6 +26,7 @@
 #![feature(core_intrinsics)]
 #![feature(discriminant_value)]
 #![feature(i128_type)]
+#![cfg_attr(windows, feature(libc))]
 #![feature(never_type)]
 #![feature(nonzero)]
 #![feature(quote)]
@@ -44,6 +45,8 @@ extern crate core;
 extern crate fmt_macros;
 extern crate getopts;
 extern crate graphviz;
+#[cfg(windows)]
+extern crate libc;
 extern crate owning_ref;
 extern crate rustc_back;
 extern crate rustc_data_structures;

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -26,7 +26,6 @@
 #![feature(core_intrinsics)]
 #![feature(discriminant_value)]
 #![feature(i128_type)]
-#![feature(libc)]
 #![feature(never_type)]
 #![feature(nonzero)]
 #![feature(quote)]
@@ -45,7 +44,6 @@ extern crate core;
 extern crate fmt_macros;
 extern crate getopts;
 extern crate graphviz;
-extern crate libc;
 extern crate owning_ref;
 extern crate rustc_back;
 extern crate rustc_data_structures;
@@ -62,7 +60,9 @@ extern crate serialize as rustc_serialize; // used by deriving
 
 // Note that librustc doesn't actually depend on these crates, see the note in
 // `Cargo.toml` for this crate about why these are here.
+#[allow(unused_extern_crates)]
 extern crate flate2;
+#[allow(unused_extern_crates)]
 extern crate test;
 
 #[macro_use]

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -30,7 +30,7 @@ declare_lint! {
 
 declare_lint! {
     pub UNUSED_EXTERN_CRATES,
-    Allow,
+    Warn,
     "extern crates that are never used"
 }
 

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -797,6 +797,8 @@ pub struct GlobalCtxt<'tcx> {
 
     pub maybe_unused_trait_imports: NodeSet,
 
+    pub maybe_unused_extern_crates: Vec<(NodeId, Span, CrateNum)>,
+
     // Internal cache for metadata decoding. No need to track deps on this.
     pub rcache: RefCell<FxHashMap<ty::CReaderCacheKey, Ty<'tcx>>>,
 
@@ -1038,6 +1040,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             mir_passes,
             freevars: RefCell::new(resolutions.freevars),
             maybe_unused_trait_imports: resolutions.maybe_unused_trait_imports,
+            maybe_unused_extern_crates: resolutions.maybe_unused_extern_crates,
             rcache: RefCell::new(FxHashMap()),
             normalized_cache: RefCell::new(FxHashMap()),
             inhabitedness_cache: RefCell::new(FxHashMap()),

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -797,7 +797,7 @@ pub struct GlobalCtxt<'tcx> {
 
     pub maybe_unused_trait_imports: NodeSet,
 
-    pub maybe_unused_extern_crates: Vec<(NodeId, Span, CrateNum)>,
+    pub maybe_unused_extern_crates: Vec<(NodeId, Span)>,
 
     // Internal cache for metadata decoding. No need to track deps on this.
     pub rcache: RefCell<FxHashMap<ty::CReaderCacheKey, Ty<'tcx>>>,

--- a/src/librustc/ty/maps.rs
+++ b/src/librustc/ty/maps.rs
@@ -516,6 +516,18 @@ impl<'tcx> QueryDescription for queries::is_panic_runtime<'tcx> {
     }
 }
 
+impl<'tcx> QueryDescription for queries::is_compiler_builtins<'tcx> {
+    fn describe(_: TyCtxt, _: DefId) -> String {
+        "checking if the crate is_compiler_builtins".to_string()
+    }
+}
+
+impl<'tcx> QueryDescription for queries::has_global_allocator<'tcx> {
+    fn describe(_: TyCtxt, _: DefId) -> String {
+        "checking if the crate has_global_allocator".to_string()
+    }
+}
+
 impl<'tcx> QueryDescription for queries::extern_crate<'tcx> {
     fn describe(_: TyCtxt, _: DefId) -> String {
         "getting crate's ExternCrateData".to_string()
@@ -1079,6 +1091,8 @@ define_maps! { <'tcx>
 
     [] is_allocator: IsAllocator(DefId) -> bool,
     [] is_panic_runtime: IsPanicRuntime(DefId) -> bool,
+    [] is_compiler_builtins: IsCompilerBuiltins(DefId) -> bool,
+    [] has_global_allocator: HasGlobalAllocator(DefId) -> bool,
 
     [] extern_crate: ExternCrate(DefId) -> Rc<Option<ExternCrate>>,
 

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -131,7 +131,7 @@ pub struct Resolutions {
     pub freevars: FreevarMap,
     pub trait_map: TraitMap,
     pub maybe_unused_trait_imports: NodeSet,
-    pub maybe_unused_extern_crates: Vec<(NodeId, Span, CrateNum)>,
+    pub maybe_unused_extern_crates: Vec<(NodeId, Span)>,
     pub export_map: ExportMap,
 }
 

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -131,6 +131,7 @@ pub struct Resolutions {
     pub freevars: FreevarMap,
     pub trait_map: TraitMap,
     pub maybe_unused_trait_imports: NodeSet,
+    pub maybe_unused_extern_crates: Vec<(NodeId, Span, CrateNum)>,
     pub export_map: ExportMap,
 }
 

--- a/src/librustc_borrowck/Cargo.toml
+++ b/src/librustc_borrowck/Cargo.toml
@@ -15,6 +15,5 @@ syntax = { path = "../libsyntax" }
 syntax_pos = { path = "../libsyntax_pos" }
 graphviz = { path = "../libgraphviz" }
 rustc = { path = "../librustc" }
-rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_mir = { path = "../librustc_mir" }
 rustc_errors = { path = "../librustc_errors" }

--- a/src/librustc_borrowck/lib.rs
+++ b/src/librustc_borrowck/lib.rs
@@ -28,9 +28,7 @@ extern crate rustc_errors as errors;
 extern crate graphviz as dot;
 #[macro_use]
 extern crate rustc;
-extern crate rustc_data_structures;
 extern crate rustc_mir;
-extern crate core; // for NonZero
 
 pub use borrowck::check_crate;
 pub use borrowck::build_borrowck_dataflow_data_for_fn;

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -877,6 +877,7 @@ pub fn phase_2_configure_and_expand<F>(sess: &Session,
             export_map: resolver.export_map,
             trait_map: resolver.trait_map,
             maybe_unused_trait_imports: resolver.maybe_unused_trait_imports,
+            maybe_unused_extern_crates: resolver.maybe_unused_extern_crates,
         },
         hir_forest,
     })

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -20,7 +20,7 @@
 #![deny(warnings)]
 
 #![feature(box_syntax)]
-#![feature(libc)]
+#![cfg_attr(unix, feature(libc))]
 #![feature(quote)]
 #![feature(rustc_diagnostic_macros)]
 #![feature(set_stdio)]
@@ -29,6 +29,7 @@ extern crate arena;
 extern crate getopts;
 extern crate graphviz;
 extern crate env_logger;
+#[cfg(unix)]
 extern crate libc;
 extern crate rustc;
 extern crate rustc_allocator;

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -16,10 +16,11 @@
 #![feature(custom_attribute)]
 #![allow(unused_attributes)]
 #![feature(range_contains)]
-#![feature(libc)]
+#![cfg_attr(unix, feature(libc))]
 #![feature(conservative_impl_trait)]
 
 extern crate term;
+#[cfg(unix)]
 extern crate libc;
 extern crate serialize as rustc_serialize;
 extern crate syntax_pos;

--- a/src/librustc_metadata/Cargo.toml
+++ b/src/librustc_metadata/Cargo.toml
@@ -15,7 +15,6 @@ owning_ref = "0.3.3"
 proc_macro = { path = "../libproc_macro" }
 rustc = { path = "../librustc" }
 rustc_back = { path = "../librustc_back" }
-rustc_const_math = { path = "../librustc_const_math" }
 rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_errors = { path = "../librustc_errors" }
 serialize = { path = "../libserialize" }

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -137,6 +137,8 @@ provide! { <'tcx> tcx, def_id, cdata,
 
     dylib_dependency_formats => { Rc::new(cdata.get_dylib_dependency_formats(&tcx.dep_graph)) }
     is_panic_runtime => { cdata.is_panic_runtime(&tcx.dep_graph) }
+    is_compiler_builtins => { cdata.is_compiler_builtins(&tcx.dep_graph) }
+    has_global_allocator => { cdata.has_global_allocator(&tcx.dep_graph) }
     extern_crate => { Rc::new(cdata.extern_crate.get()) }
 }
 

--- a/src/librustc_metadata/lib.rs
+++ b/src/librustc_metadata/lib.rs
@@ -39,7 +39,6 @@ extern crate proc_macro;
 #[macro_use]
 extern crate rustc;
 extern crate rustc_back;
-extern crate rustc_const_math;
 extern crate rustc_data_structures;
 
 mod diagnostics;

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -264,7 +264,7 @@ impl<'a> Resolver<'a> {
                     id: item.id,
                     parent,
                     imported_module: Cell::new(Some(module)),
-                    subclass: ImportDirectiveSubclass::ExternCrate,
+                    subclass: ImportDirectiveSubclass::ExternCrate { cnum: crate_id },
                     span: item.span,
                     module_path: Vec::new(),
                     vis: Cell::new(vis),

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -264,7 +264,7 @@ impl<'a> Resolver<'a> {
                     id: item.id,
                     parent,
                     imported_module: Cell::new(Some(module)),
-                    subclass: ImportDirectiveSubclass::ExternCrate { cnum: crate_id },
+                    subclass: ImportDirectiveSubclass::ExternCrate,
                     span: item.span,
                     module_path: Vec::new(),
                     vis: Cell::new(vis),

--- a/src/librustc_resolve/check_unused.rs
+++ b/src/librustc_resolve/check_unused.rs
@@ -120,8 +120,8 @@ pub fn check_crate(resolver: &mut Resolver, krate: &ast::Crate) {
             _ if directive.used.get() ||
                  directive.vis.get() == ty::Visibility::Public ||
                  directive.span.source_equal(&DUMMY_SP) => {}
-            ImportDirectiveSubclass::ExternCrate { cnum } => {
-                resolver.maybe_unused_extern_crates.push((directive.id, directive.span, cnum));
+            ImportDirectiveSubclass::ExternCrate => {
+                resolver.maybe_unused_extern_crates.push((directive.id, directive.span));
             }
             ImportDirectiveSubclass::MacroUse => {
                 let lint = lint::builtin::UNUSED_IMPORTS;

--- a/src/librustc_resolve/check_unused.rs
+++ b/src/librustc_resolve/check_unused.rs
@@ -120,10 +120,8 @@ pub fn check_crate(resolver: &mut Resolver, krate: &ast::Crate) {
             _ if directive.used.get() ||
                  directive.vis.get() == ty::Visibility::Public ||
                  directive.span.source_equal(&DUMMY_SP) => {}
-            ImportDirectiveSubclass::ExternCrate => {
-                let lint = lint::builtin::UNUSED_EXTERN_CRATES;
-                let msg = "unused extern crate";
-             ;   resolver.session.buffer_lint(lint, directive.id, directive.span, msg)
+            ImportDirectiveSubclass::ExternCrate { cnum } => {
+                resolver.maybe_unused_extern_crates.push((directive.id, directive.span, cnum));
             }
             ImportDirectiveSubclass::MacroUse => {
                 let lint = lint::builtin::UNUSED_IMPORTS;

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -35,7 +35,7 @@ use rustc::middle::cstore::CrateLoader;
 use rustc::session::Session;
 use rustc::lint;
 use rustc::hir::def::*;
-use rustc::hir::def_id::{CRATE_DEF_INDEX, LOCAL_CRATE, DefId};
+use rustc::hir::def_id::{CRATE_DEF_INDEX, LOCAL_CRATE, CrateNum, DefId};
 use rustc::ty;
 use rustc::hir::{Freevar, FreevarMap, TraitCandidate, TraitMap, GlobMap};
 use rustc::util::nodemap::{NodeMap, NodeSet, FxHashMap, FxHashSet, DefIdMap};
@@ -1102,7 +1102,7 @@ impl<'a> NameBinding<'a> {
         match self.kind {
             NameBindingKind::Import {
                 directive: &ImportDirective {
-                    subclass: ImportDirectiveSubclass::ExternCrate, ..
+                    subclass: ImportDirectiveSubclass::ExternCrate { .. }, ..
                 }, ..
             } => true,
             _ => false,
@@ -1250,6 +1250,7 @@ pub struct Resolver<'a> {
 
     used_imports: FxHashSet<(NodeId, Namespace)>,
     pub maybe_unused_trait_imports: NodeSet,
+    pub maybe_unused_extern_crates: Vec<(NodeId, Span, CrateNum)>,
 
     /// privacy errors are delayed until the end in order to deduplicate them
     privacy_errors: Vec<PrivacyError<'a>>,
@@ -1457,6 +1458,7 @@ impl<'a> Resolver<'a> {
 
             used_imports: FxHashSet(),
             maybe_unused_trait_imports: NodeSet(),
+            maybe_unused_extern_crates: Vec::new(),
 
             privacy_errors: Vec::new(),
             ambiguity_errors: Vec::new(),

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -35,7 +35,7 @@ use rustc::middle::cstore::CrateLoader;
 use rustc::session::Session;
 use rustc::lint;
 use rustc::hir::def::*;
-use rustc::hir::def_id::{CRATE_DEF_INDEX, LOCAL_CRATE, CrateNum, DefId};
+use rustc::hir::def_id::{CRATE_DEF_INDEX, LOCAL_CRATE, DefId};
 use rustc::ty;
 use rustc::hir::{Freevar, FreevarMap, TraitCandidate, TraitMap, GlobMap};
 use rustc::util::nodemap::{NodeMap, NodeSet, FxHashMap, FxHashSet, DefIdMap};
@@ -1102,7 +1102,7 @@ impl<'a> NameBinding<'a> {
         match self.kind {
             NameBindingKind::Import {
                 directive: &ImportDirective {
-                    subclass: ImportDirectiveSubclass::ExternCrate { .. }, ..
+                    subclass: ImportDirectiveSubclass::ExternCrate, ..
                 }, ..
             } => true,
             _ => false,
@@ -1250,7 +1250,7 @@ pub struct Resolver<'a> {
 
     used_imports: FxHashSet<(NodeId, Namespace)>,
     pub maybe_unused_trait_imports: NodeSet,
-    pub maybe_unused_extern_crates: Vec<(NodeId, Span, CrateNum)>,
+    pub maybe_unused_extern_crates: Vec<(NodeId, Span)>,
 
     /// privacy errors are delayed until the end in order to deduplicate them
     privacy_errors: Vec<PrivacyError<'a>>,

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -19,7 +19,7 @@ use {resolve_error, ResolutionError};
 
 use rustc::ty;
 use rustc::lint::builtin::PUB_USE_OF_PRIVATE_EXTERN_CRATE;
-use rustc::hir::def_id::DefId;
+use rustc::hir::def_id::{CrateNum, DefId};
 use rustc::hir::def::*;
 use rustc::util::nodemap::{FxHashMap, FxHashSet};
 
@@ -48,7 +48,9 @@ pub enum ImportDirectiveSubclass<'a> {
         max_vis: Cell<ty::Visibility>, // The visibility of the greatest reexport.
         // n.b. `max_vis` is only used in `finalize_import` to check for reexport errors.
     },
-    ExternCrate,
+    ExternCrate {
+        cnum: CrateNum,
+    },
     MacroUse,
 }
 
@@ -924,7 +926,7 @@ fn import_directive_subclass_to_string(subclass: &ImportDirectiveSubclass) -> St
     match *subclass {
         SingleImport { source, .. } => source.to_string(),
         GlobImport { .. } => "*".to_string(),
-        ExternCrate => "<extern crate>".to_string(),
+        ExternCrate { .. } => "<extern crate>".to_string(),
         MacroUse => "#[macro_use]".to_string(),
     }
 }

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -19,7 +19,7 @@ use {resolve_error, ResolutionError};
 
 use rustc::ty;
 use rustc::lint::builtin::PUB_USE_OF_PRIVATE_EXTERN_CRATE;
-use rustc::hir::def_id::{CrateNum, DefId};
+use rustc::hir::def_id::DefId;
 use rustc::hir::def::*;
 use rustc::util::nodemap::{FxHashMap, FxHashSet};
 
@@ -48,9 +48,7 @@ pub enum ImportDirectiveSubclass<'a> {
         max_vis: Cell<ty::Visibility>, // The visibility of the greatest reexport.
         // n.b. `max_vis` is only used in `finalize_import` to check for reexport errors.
     },
-    ExternCrate {
-        cnum: CrateNum,
-    },
+    ExternCrate,
     MacroUse,
 }
 
@@ -926,7 +924,7 @@ fn import_directive_subclass_to_string(subclass: &ImportDirectiveSubclass) -> St
     match *subclass {
         SingleImport { source, .. } => source.to_string(),
         GlobImport { .. } => "*".to_string(),
-        ExternCrate { .. } => "<extern crate>".to_string(),
+        ExternCrate => "<extern crate>".to_string(),
         MacroUse => "#[macro_use]".to_string(),
     }
 }

--- a/src/librustc_tsan/Cargo.toml
+++ b/src/librustc_tsan/Cargo.toml
@@ -14,5 +14,6 @@ build_helper = { path = "../build_helper" }
 cmake = "0.1.18"
 
 [dependencies]
+alloc = { path = "../liballoc" }
 alloc_system = { path = "../liballoc_system" }
 core = { path = "../libcore" }

--- a/src/librustc_tsan/lib.rs
+++ b/src/librustc_tsan/lib.rs
@@ -9,8 +9,10 @@
 // except according to those terms.
 
 #![sanitizer_runtime]
-#![feature(sanitizer_runtime)]
 #![feature(alloc_system)]
+#![feature(allocator_api)]
+#![feature(global_allocator)]
+#![feature(sanitizer_runtime)]
 #![feature(staged_api)]
 #![no_std]
 #![unstable(feature = "sanitizer_runtime_lib",
@@ -18,3 +20,8 @@
             issue = "0")]
 
 extern crate alloc_system;
+
+use alloc_system::System;
+
+#[global_allocator]
+static ALLOC: System = System;

--- a/src/librustc_typeck/check_unused.rs
+++ b/src/librustc_typeck/check_unused.rs
@@ -72,4 +72,14 @@ pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
 
     let mut visitor = CheckVisitor { tcx, used_trait_imports };
     tcx.hir.krate().visit_all_item_likes(&mut visitor);
+
+    for &(id, span, cnum) in &tcx.maybe_unused_extern_crates {
+        if !tcx.is_compiler_builtins(cnum.as_def_id())
+            && !tcx.is_panic_runtime(cnum.as_def_id())
+            && !tcx.has_global_allocator(cnum.as_def_id()) {
+                let lint = lint::builtin::UNUSED_EXTERN_CRATES;
+                let msg = "unused extern crate";
+                tcx.lint_node(lint, id, span, msg);
+            }
+    }
 }

--- a/src/librustc_typeck/check_unused.rs
+++ b/src/librustc_typeck/check_unused.rs
@@ -73,10 +73,11 @@ pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     let mut visitor = CheckVisitor { tcx, used_trait_imports };
     tcx.hir.krate().visit_all_item_likes(&mut visitor);
 
-    for &(id, span, cnum) in &tcx.maybe_unused_extern_crates {
-        if !tcx.is_compiler_builtins(cnum.as_def_id())
-            && !tcx.is_panic_runtime(cnum.as_def_id())
-            && !tcx.has_global_allocator(cnum.as_def_id()) {
+    for &(id, span) in &tcx.maybe_unused_extern_crates {
+        let cnum = tcx.sess.cstore.extern_mod_stmt_cnum(id).unwrap().as_def_id();
+        if !tcx.is_compiler_builtins(cnum)
+            && !tcx.is_panic_runtime(cnum)
+            && !tcx.has_global_allocator(cnum) {
                 let lint = lint::builtin::UNUSED_EXTERN_CRATES;
                 let msg = "unused extern crate";
                 tcx.lint_node(lint, id, span, msg);

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -283,7 +283,7 @@
 #![feature(on_unimplemented)]
 #![feature(oom)]
 #![feature(optin_builtin_traits)]
-#![feature(panic_unwind)]
+#![cfg_attr(any(unix, target_os = "redox"), feature(panic_unwind))]
 #![feature(peek)]
 #![feature(placement_in_syntax)]
 #![feature(placement_new_protocol)]
@@ -358,6 +358,7 @@ extern crate std_unicode;
 extern crate libc;
 
 // We always need an unwinder currently for backtraces
+#[cfg(any(unix, target_os = "redox"))]
 extern crate unwind;
 
 // compiler-rt intrinsics

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -283,7 +283,7 @@
 #![feature(on_unimplemented)]
 #![feature(oom)]
 #![feature(optin_builtin_traits)]
-#![cfg_attr(any(unix, target_os = "redox"), feature(panic_unwind))]
+#![feature(panic_unwind)]
 #![feature(peek)]
 #![feature(placement_in_syntax)]
 #![feature(placement_new_protocol)]
@@ -358,7 +358,7 @@ extern crate std_unicode;
 extern crate libc;
 
 // We always need an unwinder currently for backtraces
-#[cfg(any(unix, target_os = "redox"))]
+#[allow(unused_extern_crates)]
 extern crate unwind;
 
 // compiler-rt intrinsics

--- a/src/libstd/prelude/mod.rs
+++ b/src/libstd/prelude/mod.rs
@@ -23,6 +23,7 @@
 //! On a technical level, Rust inserts
 //!
 //! ```
+//! # #[allow(unused_extern_crates)]
 //! extern crate std;
 //! ```
 //!

--- a/src/libstd/sys/unix/ext/fs.rs
+++ b/src/libstd/sys/unix/ext/fs.rs
@@ -154,8 +154,6 @@ pub trait OpenOptionsExt {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(libc)]
-    /// extern crate libc;
     /// use std::fs::OpenOptions;
     /// use std::os::unix::fs::OpenOptionsExt;
     ///

--- a/src/libsyntax_ext/Cargo.toml
+++ b/src/libsyntax_ext/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["dylib"]
 
 [dependencies]
 fmt_macros = { path = "../libfmt_macros" }
-log = "0.3"
 proc_macro = { path = "../libproc_macro" }
 rustc_errors = { path = "../librustc_errors" }
 syntax = { path = "../libsyntax" }

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -18,7 +18,6 @@
 #![feature(proc_macro_internals)]
 
 extern crate fmt_macros;
-extern crate log;
 #[macro_use]
 extern crate syntax;
 extern crate syntax_pos;

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -35,13 +35,14 @@
 #![deny(warnings)]
 
 #![feature(asm)]
-#![feature(libc)]
+#![cfg_attr(unix, feature(libc))]
 #![feature(set_stdio)]
 #![feature(panic_unwind)]
 #![feature(staged_api)]
 
 extern crate getopts;
 extern crate term;
+#[cfg(unix)]
 extern crate libc;
 extern crate panic_unwind;
 

--- a/src/test/compile-fail-fulldeps/plugin-as-extern-crate.rs
+++ b/src/test/compile-fail-fulldeps/plugin-as-extern-crate.rs
@@ -15,6 +15,7 @@
 // libsyntax is not compiled for it.
 
 #![deny(plugin_as_library)]
+#![allow(unused_extern_crates)]
 
 extern crate macro_crate_test; //~ ERROR compiler plugin used as an ordinary library
 

--- a/src/test/compile-fail/E0254.rs
+++ b/src/test/compile-fail/E0254.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(alloc)]
+#![allow(unused_extern_crates)]
 
 extern crate alloc;
 //~^ NOTE previous import of the extern crate `alloc` here

--- a/src/test/compile-fail/E0259.rs
+++ b/src/test/compile-fail/E0259.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(alloc, libc)]
+#![allow(unused_extern_crates)]
 
 extern crate alloc;
 //~^ NOTE previous import of the extern crate `alloc` here

--- a/src/test/compile-fail/E0260.rs
+++ b/src/test/compile-fail/E0260.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(alloc)]
+#![allow(unused_extern_crates)]
 
 extern crate alloc;
 //~^ NOTE previous import of the extern crate `alloc` here

--- a/src/test/compile-fail/auxiliary/lint_unused_extern_crate5.rs
+++ b/src/test/compile-fail/auxiliary/lint_unused_extern_crate5.rs
@@ -1,0 +1,9 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.

--- a/src/test/compile-fail/enable-unstable-lib-feature.rs
+++ b/src/test/compile-fail/enable-unstable-lib-feature.rs
@@ -16,6 +16,7 @@
 #![deny(non_snake_case)] // To trigger a hard error
 
 // Shouldn't generate a warning about unstable features
+#[allow(unused_extern_crates)]
 extern crate stability_cfg2;
 
 pub fn BOGUS() { } //~ ERROR

--- a/src/test/compile-fail/issue-36881.rs
+++ b/src/test/compile-fail/issue-36881.rs
@@ -11,6 +11,7 @@
 // aux-build:issue-36881-aux.rs
 
 fn main() {
+    #[allow(unused_extern_crates)]
     extern crate issue_36881_aux;
     use issue_36881_aux::Foo; //~ ERROR unresolved import
 }

--- a/src/test/compile-fail/lint-stability-deprecated.rs
+++ b/src/test/compile-fail/lint-stability-deprecated.rs
@@ -14,7 +14,7 @@
 // aux-build:stability_cfg2.rs
 
 #![warn(deprecated)]
-#![allow(dead_code)]
+#![allow(dead_code, unused_extern_crates)]
 #![feature(staged_api, test_feature, rustc_attrs)]
 
 #![stable(feature = "rust1", since = "1.0.0")]

--- a/src/test/compile-fail/lint-unused-extern-crate.rs
+++ b/src/test/compile-fail/lint-unused-extern-crate.rs
@@ -12,12 +12,15 @@
 // aux-build:lint_unused_extern_crate2.rs
 // aux-build:lint_unused_extern_crate3.rs
 // aux-build:lint_unused_extern_crate4.rs
+// aux-build:lint_unused_extern_crate5.rs
 
 #![deny(unused_extern_crates)]
 #![allow(unused_variables)]
 #![allow(deprecated)]
 
-extern crate lint_unused_extern_crate4; //~ ERROR: unused extern crate
+extern crate lint_unused_extern_crate5; //~ ERROR: unused extern crate
+
+pub extern crate lint_unused_extern_crate4; // no error, it is reexported
 
 extern crate lint_unused_extern_crate3; // no error, it is used
 

--- a/src/test/compile-fail/macro-reexport-malformed-1.rs
+++ b/src/test/compile-fail/macro-reexport-malformed-1.rs
@@ -11,5 +11,6 @@
 #![no_std]
 #![feature(macro_reexport)]
 
+#[allow(unused_extern_crates)]
 #[macro_reexport]  //~ ERROR bad macro reexport
 extern crate std;

--- a/src/test/compile-fail/macro-reexport-malformed-2.rs
+++ b/src/test/compile-fail/macro-reexport-malformed-2.rs
@@ -11,5 +11,6 @@
 #![no_std]
 #![feature(macro_reexport)]
 
+#[allow(unused_extern_crates)]
 #[macro_reexport="foo"]  //~ ERROR bad macro reexport
 extern crate std;

--- a/src/test/compile-fail/macro-reexport-malformed-3.rs
+++ b/src/test/compile-fail/macro-reexport-malformed-3.rs
@@ -11,5 +11,6 @@
 #![no_std]
 #![feature(macro_reexport)]
 
+#[allow(unused_extern_crates)]
 #[macro_reexport(foo="bar")]  //~ ERROR bad macro reexport
 extern crate std;

--- a/src/test/compile-fail/macro-use-bad-args-1.rs
+++ b/src/test/compile-fail/macro-use-bad-args-1.rs
@@ -10,5 +10,6 @@
 
 #![no_std]
 
+#[allow(unused_extern_crates)]
 #[macro_use(foo(bar))]  //~ ERROR bad macro import
 extern crate std;

--- a/src/test/compile-fail/macro-use-bad-args-2.rs
+++ b/src/test/compile-fail/macro-use-bad-args-2.rs
@@ -10,5 +10,6 @@
 
 #![no_std]
 
+#[allow(unused_extern_crates)]
 #[macro_use(foo="bar")]  //~ ERROR bad macro import
 extern crate std;

--- a/src/test/compile-fail/no-std-inject.rs
+++ b/src/test/compile-fail/no-std-inject.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![no_std]
+#![allow(unused_extern_crates)]
 
 extern crate core; //~ ERROR: the name `core` is defined multiple times
 extern crate std;

--- a/src/test/compile-fail/placement-expr-unstable.rs
+++ b/src/test/compile-fail/placement-expr-unstable.rs
@@ -12,8 +12,6 @@
 
 #![feature(placement_in_syntax)]
 
-extern crate core;
-
 fn main() {
     use std::boxed::HEAP; //~ ERROR use of unstable library feature
 

--- a/src/test/compile-fail/resolve-conflict-extern-crate-vs-extern-crate.rs
+++ b/src/test/compile-fail/resolve-conflict-extern-crate-vs-extern-crate.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(unused_extern_crates)]
 extern crate std;
 //~^ ERROR the name `std` is defined multiple times
 

--- a/src/test/compile-fail/resolve_self_super_hint.rs
+++ b/src/test/compile-fail/resolve_self_super_hint.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(alloc)]
+#![allow(unused_extern_crates)]
 
 mod a {
     extern crate alloc;

--- a/src/test/compile-fail/unused-attr.rs
+++ b/src/test/compile-fail/unused-attr.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #![deny(unused_attributes)]
-#![allow(dead_code, unused_imports)]
+#![allow(dead_code, unused_imports, unused_extern_crates)]
 #![feature(custom_attribute)]
 
 #![foo] //~ ERROR unused attribute

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -14,6 +14,7 @@
 
 #![deny(warnings)]
 
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 extern crate libc;
 extern crate test;
 extern crate getopts;


### PR DESCRIPTION
Apart from enabling the lint, this pull request also removes existing unused crates in the codebase, and fix some amount of false positives on crates with special purposes.

Now that all false positive issues are closed, it should be possible to make it available to wider users.

Quote:
> Now that macro modularization is implemented, this is true today! *https://github.com/rust-lang/rust/issues/30849#issuecomment-286573218*

Concerns: can break some `#[deny(warnings)]`.

Close #42591