### PR TITLE
rustdoc: Stop stripping empty modules

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1349,7 +1349,7 @@ impl Context {
         // these modules are recursed into, but not rendered normally
         // (a flag on the context).
         if !self.render_redirect_pages {
-            self.render_redirect_pages = maybe_ignore_item(&item);
+            self.render_redirect_pages = item.is_stripped();
         }
 
         if item.is_mod() {
@@ -1432,7 +1432,7 @@ impl Context {
         // BTreeMap instead of HashMap to get a sorted output
         let mut map = BTreeMap::new();
         for item in &m.items {
-            if maybe_ignore_item(item) { continue }
+            if item.is_stripped() { continue }
 
             let short = item.type_().css_class();
             let myname = match item.name {
@@ -1733,7 +1733,7 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
         if let clean::DefaultImplItem(..) = items[*i].inner {
             return false;
         }
-        !maybe_ignore_item(&items[*i])
+        !items[*i].is_stripped()
     }).collect::<Vec<usize>>();
 
     // the order of item types in the listing
@@ -1900,17 +1900,6 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
         write!(w, "</table>")?;
     }
     Ok(())
-}
-
-fn maybe_ignore_item(it: &clean::Item) -> bool {
-    match it.inner {
-        clean::StrippedItem(..) => true,
-        clean::ModuleItem(ref m) => {
-            it.doc_value().is_none() && m.items.is_empty()
-                                     && it.visibility != Some(clean::Public)
-        },
-        _ => false,
-    }
 }
 
 fn short_stability(item: &clean::Item, cx: &Context, show_reason: bool) -> Vec<String> {
@@ -3332,7 +3321,7 @@ fn sidebar_module(fmt: &mut fmt::Formatter, _it: &clean::Item,
             if let clean::DefaultImplItem(..) = it.inner {
                 false
             } else {
-                !maybe_ignore_item(it) && !it.is_stripped() && it.type_() == myty
+                !it.is_stripped() && it.type_() == myty
             }
         }) {
             let (short, name) = match myty {

--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -145,20 +145,12 @@ impl<'a> fold::DocFolder for Stripper<'a> {
             self.fold_item_recur(i)
         };
 
-        i.and_then(|i| {
-            match i.inner {
-                // emptied modules have no need to exist
-                clean::ModuleItem(ref m)
-                    if m.items.is_empty() &&
-                       i.doc_value().is_none() => None,
-                _ => {
-                    if self.update_retained {
-                        self.retained.insert(i.def_id);
-                    }
-                    Some(i)
-                }
+        if let Some(ref i) = i {
+            if self.update_retained {
+                self.retained.insert(i.def_id);
             }
-        })
+        }
+        i
     }
 }
 

--- a/src/test/rustdoc/empty-mod-private.rs
+++ b/src/test/rustdoc/empty-mod-private.rs
@@ -1,0 +1,27 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-tidy-linelength
+// compile-flags: --no-defaults --passes collapse-docs --passes unindent-comments --passes strip-priv-imports
+
+// @has 'empty_mod_private/index.html' '//a[@href="foo/index.html"]' 'foo'
+// @has 'empty_mod_private/sidebar-items.js' 'foo'
+// @matches 'empty_mod_private/foo/index.html' '//h1' 'Module empty_mod_private::foo'
+mod foo {}
+
+// @has 'empty_mod_private/index.html' '//a[@href="bar/index.html"]' 'bar'
+// @has 'empty_mod_private/sidebar-items.js' 'bar'
+// @matches 'empty_mod_private/bar/index.html' '//h1' 'Module empty_mod_private::bar'
+mod bar {
+    // @has 'empty_mod_private/bar/index.html' '//a[@href="baz/index.html"]' 'baz'
+    // @has 'empty_mod_private/bar/sidebar-items.js' 'baz'
+    // @matches 'empty_mod_private/bar/baz/index.html' '//h1' 'Module empty_mod_private::bar::baz'
+    mod baz {}
+}

--- a/src/test/rustdoc/empty-mod-public.rs
+++ b/src/test/rustdoc/empty-mod-public.rs
@@ -1,0 +1,24 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// @has 'empty_mod_public/index.html' '//a[@href="foo/index.html"]' 'foo'
+// @has 'empty_mod_public/sidebar-items.js' 'foo'
+// @matches 'empty_mod_public/foo/index.html' '//h1' 'Module empty_mod_public::foo'
+pub mod foo {}
+
+// @has 'empty_mod_public/index.html' '//a[@href="bar/index.html"]' 'bar'
+// @has 'empty_mod_public/sidebar-items.js' 'bar'
+// @matches 'empty_mod_public/bar/index.html' '//h1' 'Module empty_mod_public::bar'
+pub mod bar {
+    // @has 'empty_mod_public/bar/index.html' '//a[@href="baz/index.html"]' 'baz'
+    // @has 'empty_mod_public/bar/sidebar-items.js' 'baz'
+    // @matches 'empty_mod_public/bar/baz/index.html' '//h1' 'Module empty_mod_public::bar::baz'
+    pub mod baz {}
+}


### PR DESCRIPTION
There is no good reason to strip empty modules with no documentation and
doing so causes subtle problems.

Fixes #42590