### PR TITLE
Implement lazy loading of external crates' sources.

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1682,6 +1682,7 @@ dependencies = [
 name = "syntax_pos"
 version = "0.0.0"
 dependencies = [
+ "rustc_data_structures 0.0.0",
  "serialize 0.0.0",
 ]
 

--- a/src/librustc/ich/impls_syntax.rs
+++ b/src/librustc/ich/impls_syntax.rs
@@ -337,6 +337,7 @@ impl<'a, 'gcx, 'tcx> HashStable<StableHashingContext<'a, 'gcx, 'tcx>> for FileMa
             // Do not hash the source as it is not encoded
             src: _,
             src_hash,
+            external_src: _,
             start_pos,
             end_pos: _,
             ref lines,

--- a/src/librustc/ich/impls_syntax.rs
+++ b/src/librustc/ich/impls_syntax.rs
@@ -336,6 +336,7 @@ impl<'a, 'gcx, 'tcx> HashStable<StableHashingContext<'a, 'gcx, 'tcx>> for FileMa
             crate_of_origin,
             // Do not hash the source as it is not encoded
             src: _,
+            src_hash,
             start_pos,
             end_pos: _,
             ref lines,
@@ -349,6 +350,8 @@ impl<'a, 'gcx, 'tcx> HashStable<StableHashingContext<'a, 'gcx, 'tcx>> for FileMa
             krate: CrateNum::from_u32(crate_of_origin),
             index: CRATE_DEF_INDEX,
         }.hash_stable(hcx, hasher);
+
+        src_hash.hash_stable(hcx, hasher);
 
         // We only hash the relative position within this filemap
         let lines = lines.borrow();

--- a/src/librustc_data_structures/stable_hasher.rs
+++ b/src/librustc_data_structures/stable_hasher.rs
@@ -78,6 +78,17 @@ impl StableHasherResult for [u8; 20] {
     }
 }
 
+impl StableHasherResult for u128 {
+    fn finish(mut hasher: StableHasher<Self>) -> Self {
+        let hash_bytes: &[u8] = hasher.finalize();
+        assert!(hash_bytes.len() >= mem::size_of::<u64>() * 2);
+
+        unsafe {
+            ::std::ptr::read_unaligned(hash_bytes.as_ptr() as *const u128)
+        }
+    }
+}
+
 impl StableHasherResult for u64 {
     fn finish(mut hasher: StableHasher<Self>) -> Self {
         hasher.state.finalize();

--- a/src/librustc_data_structures/stable_hasher.rs
+++ b/src/librustc_data_structures/stable_hasher.rs
@@ -81,7 +81,7 @@ impl StableHasherResult for [u8; 20] {
 impl StableHasherResult for u128 {
     fn finish(mut hasher: StableHasher<Self>) -> Self {
         let hash_bytes: &[u8] = hasher.finalize();
-        assert!(hash_bytes.len() >= mem::size_of::<u64>() * 2);
+        assert!(hash_bytes.len() >= mem::size_of::<u128>());
 
         unsafe {
             ::std::ptr::read_unaligned(hash_bytes.as_ptr() as *const u128)

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -17,6 +17,7 @@ use RenderSpan::*;
 use snippet::{Annotation, AnnotationType, Line, MultilineAnnotation, StyledString, Style};
 use styled_buffer::StyledBuffer;
 
+use std::borrow::Cow;
 use std::io::prelude::*;
 use std::io;
 use std::rc::Rc;
@@ -911,7 +912,8 @@ impl EmitterWriter {
         // Print out the annotate source lines that correspond with the error
         for annotated_file in annotated_files {
             // we can't annotate anything if the source is unavailable.
-            if annotated_file.file.src.is_none() {
+            if annotated_file.file.src.is_none()
+                    && annotated_file.file.external_src.borrow().is_absent() {
                 continue;
             }
 
@@ -1012,7 +1014,7 @@ impl EmitterWriter {
                     } else if line_idx_delta == 2 {
                         let unannotated_line = annotated_file.file
                             .get_line(annotated_file.lines[line_idx].line_index)
-                            .unwrap_or("");
+                            .unwrap_or_else(|| Cow::from(""));
 
                         let last_buffer_line_num = buffer.num_lines();
 

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -131,7 +131,7 @@ impl EmitterWriter {
         }
     }
 
-    fn preprocess_annotations(&self, msp: &MultiSpan) -> Vec<FileWithAnnotatedLines> {
+    fn preprocess_annotations(&mut self, msp: &MultiSpan) -> Vec<FileWithAnnotatedLines> {
         fn add_annotation_to_file(file_vec: &mut Vec<FileWithAnnotatedLines>,
                                   file: Rc<FileMap>,
                                   line_index: usize,
@@ -175,6 +175,9 @@ impl EmitterWriter {
                 if span_label.span == DUMMY_SP {
                     continue;
                 }
+
+                cm.load_source_for_filemap(cm.span_to_filename(span_label.span));
+
                 let lo = cm.lookup_char_pos(span_label.span.lo);
                 let mut hi = cm.lookup_char_pos(span_label.span.hi);
 

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -103,7 +103,7 @@ pub trait CodeMapper {
     fn span_to_filename(&self, sp: Span) -> FileName;
     fn merge_spans(&self, sp_lhs: Span, sp_rhs: Span) -> Option<Span>;
     fn call_span_if_macro(&self, sp: Span) -> Span;
-    fn load_source_for_filemap(&mut self, file: FileName) -> bool;
+    fn load_source_for_filemap(&self, file: FileName) -> bool;
 }
 
 impl CodeSuggestion {

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -50,7 +50,7 @@ pub mod registry;
 pub mod styled_buffer;
 mod lock;
 
-use syntax_pos::{BytePos, Loc, FileLinesResult, FileName, MultiSpan, Span, NO_EXPANSION};
+use syntax_pos::{BytePos, Loc, FileLinesResult, FileMap, FileName, MultiSpan, Span, NO_EXPANSION};
 
 #[derive(Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
 pub enum RenderSpan {
@@ -104,7 +104,7 @@ pub trait CodeMapper {
     fn span_to_filename(&self, sp: Span) -> FileName;
     fn merge_spans(&self, sp_lhs: Span, sp_rhs: Span) -> Option<Span>;
     fn call_span_if_macro(&self, sp: Span) -> Span;
-    fn load_source_for_filemap(&self, file: FileName) -> bool;
+    fn ensure_filemap_source_present(&self, file_map: Rc<FileMap>) -> bool;
 }
 
 impl CodeSuggestion {

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -103,6 +103,7 @@ pub trait CodeMapper {
     fn span_to_filename(&self, sp: Span) -> FileName;
     fn merge_spans(&self, sp_lhs: Span, sp_rhs: Span) -> Option<Span>;
     fn call_span_if_macro(&self, sp: Span) -> Span;
+    fn load_source_for_filemap(&mut self, file: FileName) -> bool;
 }
 
 impl CodeSuggestion {

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -765,7 +765,7 @@ impl<'a, 'tcx> CrateMetadata {
         assert!(!self.is_proc_macro(id));
         let ast = self.entry(id).ast.unwrap();
         let def_id = self.local_def_id(id);
-        let body = ast.decode(self).body.decode(self);
+        let body = ast.decode((self, tcx)).body.decode((self, tcx));
         tcx.hir.intern_inlined_body(def_id, body)
     }
 

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -1148,6 +1148,7 @@ impl<'a, 'tcx> CrateMetadata {
             // containing the information we need.
             let syntax_pos::FileMap { name,
                                       name_was_remapped,
+                                      src_hash,
                                       start_pos,
                                       end_pos,
                                       lines,
@@ -1173,6 +1174,7 @@ impl<'a, 'tcx> CrateMetadata {
             let local_version = local_codemap.new_imported_filemap(name,
                                                                    name_was_remapped,
                                                                    self.cnum.as_u32(),
+                                                                   src_hash,
                                                                    source_length,
                                                                    lines,
                                                                    multibyte_chars);

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -559,19 +559,9 @@ impl CodeMapper for CodeMap {
         }
         sp
     }
-    fn load_source_for_filemap(&self, filename: FileName) -> bool {
-        let file_map = if let Some(fm) = self.get_filemap(&filename) {
-            fm
-        } else {
-            return false;
-        };
-
-        if *file_map.external_src.borrow() == ExternalSource::AbsentOk {
-            let src = self.file_loader.read_file(Path::new(&filename)).ok();
-            return file_map.add_external_src(src);
-        }
-
-        false
+    fn ensure_filemap_source_present(&self, file_map: Rc<FileMap>) -> bool {
+        let src = self.file_loader.read_file(Path::new(&file_map.name)).ok();
+        return file_map.add_external_src(src)
     }
 }
 

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -559,7 +559,7 @@ impl CodeMapper for CodeMap {
         }
         sp
     }
-    fn load_source_for_filemap(&mut self, filename: FileName) -> bool {
+    fn load_source_for_filemap(&self, filename: FileName) -> bool {
         let file_map = if let Some(fm) = self.get_filemap(&filename) {
             fm
         } else {

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -618,6 +618,7 @@ impl FilePathMapping {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::borrow::Cow;
     use std::rc::Rc;
 
     #[test]
@@ -627,12 +628,12 @@ mod tests {
                                 "first line.\nsecond line".to_string());
         fm.next_line(BytePos(0));
         // Test we can get lines with partial line info.
-        assert_eq!(fm.get_line(0), Some("first line."));
+        assert_eq!(fm.get_line(0), Some(Cow::from("first line.")));
         // TESTING BROKEN BEHAVIOR: line break declared before actual line break.
         fm.next_line(BytePos(10));
-        assert_eq!(fm.get_line(1), Some("."));
+        assert_eq!(fm.get_line(1), Some(Cow::from(".")));
         fm.next_line(BytePos(12));
-        assert_eq!(fm.get_line(2), Some("second line"));
+        assert_eq!(fm.get_line(2), Some(Cow::from("second line")));
     }
 
     #[test]

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -567,13 +567,8 @@ impl CodeMapper for CodeMap {
         };
 
         if *file_map.external_src.borrow() == ExternalSource::AbsentOk {
-            let mut external_src = file_map.external_src.borrow_mut();
-            if let Ok(src) = self.file_loader.read_file(Path::new(&filename)) {
-                *external_src = ExternalSource::Present(src);
-                return true;
-            } else {
-                *external_src = ExternalSource::AbsentErr;
-            }
+            let src = self.file_loader.read_file(Path::new(&filename)).ok();
+            return file_map.add_external_src(src);
         }
 
         false

--- a/src/libsyntax/json.rs
+++ b/src/libsyntax/json.rs
@@ -314,7 +314,7 @@ impl DiagnosticSpanLine {
                          h_end: usize)
                          -> DiagnosticSpanLine {
         DiagnosticSpanLine {
-            text: fm.get_line(index).unwrap_or("").to_owned(),
+            text: fm.get_line(index).map_or(String::new(), |l| l.into_owned()),
             highlight_start: h_start,
             highlight_end: h_end,
         }

--- a/src/libsyntax_pos/Cargo.toml
+++ b/src/libsyntax_pos/Cargo.toml
@@ -10,3 +10,4 @@ crate-type = ["dylib"]
 
 [dependencies]
 serialize = { path = "../libserialize" }
+rustc_data_structures = { path = "../librustc_data_structures" }

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -374,6 +374,14 @@ pub struct MultiByteChar {
     pub bytes: usize,
 }
 
+#[derive(PartialEq, Eq, Clone)]
+pub enum ExternalSource {
+    Present(String),
+    AbsentOk,
+    AbsentErr,
+    Unneeded,
+}
+
 /// A single source in the CodeMap.
 #[derive(Clone)]
 pub struct FileMap {
@@ -389,6 +397,9 @@ pub struct FileMap {
     pub src: Option<Rc<String>>,
     /// The source code's hash
     pub src_hash: u128,
+    /// The external source code (used for external crates, which will have a `None`
+    /// value as `self.src`.
+    pub external_src: RefCell<ExternalSource>,
     /// The start position of this source in the CodeMap
     pub start_pos: BytePos,
     /// The end position of this source in the CodeMap
@@ -513,6 +524,7 @@ impl Decodable for FileMap {
                 end_pos: end_pos,
                 src: None,
                 src_hash: src_hash,
+                external_src: RefCell::new(ExternalSource::AbsentOk),
                 lines: RefCell::new(lines),
                 multibyte_chars: RefCell::new(multibyte_chars)
             })
@@ -545,6 +557,7 @@ impl FileMap {
             crate_of_origin: 0,
             src: Some(Rc::new(src)),
             src_hash: src_hash,
+            external_src: RefCell::new(ExternalSource::Unneeded),
             start_pos: start_pos,
             end_pos: Pos::from_usize(end_pos),
             lines: RefCell::new(Vec::new()),

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -604,6 +604,26 @@ impl FileMap {
         lines.push(pos);
     }
 
+    /// add externally loaded source.
+    /// if the hash of the input doesn't match or no input is supplied via None,
+    /// it is interpreted as an error and the corresponding enum variant is set.
+    pub fn add_external_src(&self, src: Option<String>) -> bool {
+        let mut external_src = self.external_src.borrow_mut();
+        if let Some(src) = src {
+            let mut hasher: StableHasher<u128> = StableHasher::new();
+            hasher.write(src.as_bytes());
+
+            if hasher.finish() == self.src_hash {
+                *external_src = ExternalSource::Present(src);
+                return true;
+            }
+        } else {
+            *external_src = ExternalSource::AbsentErr;
+        }
+
+        false
+    }
+
     /// get a line from the list of pre-computed line-beginnings.
     /// line-number here is 0-based.
     pub fn get_line(&self, line_number: usize) -> Option<Cow<str>> {

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -374,12 +374,33 @@ pub struct MultiByteChar {
     pub bytes: usize,
 }
 
+/// The state of the lazy external source loading mechanism of a FileMap.
 #[derive(PartialEq, Eq, Clone)]
 pub enum ExternalSource {
+    /// The external source has been loaded already.
     Present(String),
+    /// No attempt has been made to load the external source.
     AbsentOk,
+    /// A failed attempt has been made to load the external source.
     AbsentErr,
+    /// No external source has to be loaded, since the FileMap represents a local crate.
     Unneeded,
+}
+
+impl ExternalSource {
+    pub fn is_absent(&self) -> bool {
+        match *self {
+            ExternalSource::Present(_) => false,
+            _ => true,
+        }
+    }
+
+    pub fn get_source(&self) -> Option<&str> {
+        match *self {
+            ExternalSource::Present(ref src) => Some(src),
+            _ => None,
+        }
+    }
 }
 
 /// A single source in the CodeMap.
@@ -620,7 +641,7 @@ impl FileMap {
     }
 
     pub fn is_imported(&self) -> bool {
-        self.src.is_none()
+        self.src.is_none() // TODO: change to something more sensible
     }
 
     pub fn byte_length(&self) -> u32 {

--- a/src/test/ui/issue-38875/auxiliary/issue_38875_b.rs
+++ b/src/test/ui/issue-38875/auxiliary/issue_38875_b.rs
@@ -1,0 +1,11 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub const FOO: usize = *&0;

--- a/src/test/ui/issue-38875/issue_38875.rs
+++ b/src/test/ui/issue-38875/issue_38875.rs
@@ -1,0 +1,17 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue_38875_b.rs
+
+extern crate issue_38875_b;
+
+fn main() {
+    let test_x = [0; issue_38875_b::FOO];
+}

--- a/src/test/ui/issue-38875/issue_38875.stderr
+++ b/src/test/ui/issue-38875/issue_38875.stderr
@@ -1,0 +1,14 @@
+error[E0080]: constant evaluation error
+  --> $DIR/auxiliary/issue_38875_b.rs:11:24
+   |
+11 | pub const FOO: usize = *&0;
+   |                        ^^^ unimplemented constant expression: deref operation
+   |
+note: for repeat count here
+  --> $DIR/issue_38875.rs:16:22
+   |
+16 |     let test_x = [0; issue_38875_b::FOO];
+   |                      ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error(s)
+

--- a/src/test/ui/issue-41652/issue_41652.stderr
+++ b/src/test/ui/issue-41652/issue_41652.stderr
@@ -6,6 +6,11 @@ error[E0599]: no method named `f` found for type `{integer}` in the current scop
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: candidate #1 is defined in the trait `issue_41652_b::Tr`
+  --> $DIR/auxiliary/issue_41652_b.rs:14:5
+   |
+14 | /     fn f()
+15 | |         where Self: Sized;
+   | |__________________________^
    = help: to disambiguate the method call, write `issue_41652_b::Tr::f(3)` instead
 
 error: aborting due to previous error(s)


### PR DESCRIPTION
Fixes #38875. This is a follow-up to #42507. When a (now correctly translated) span from an external crate is referenced in a error, warning or info message, we still don't have the source code being referenced.
Since stuffing the source in the serialized metadata of an rlib is extremely wasteful, the following scheme has been implemented:

* File maps now contain a source hash that gets serialized as well.
* When a span is rendered in a message, the source hash in the corresponding file map(s) is used to try and load the source from the corresponding file on disk. If the file is not found or the hashes don't match, the failed attempt is recorded (and not retried).
* The machinery fetching source lines from file maps is augmented to use the lazily loaded external source as a secondary fallback for file maps belonging to external crates.

This required a small change to the expected stderr of one UI test (it now renders a span, where previously was none).

Further work can be done based on this - some of the machinery previously used to hide external spans is possibly obsolete and the hashing code can be reused in different places as well.

r? @eddyb