### PR TITLE
Position span label correctly when it isn't last

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -445,8 +445,11 @@ impl EmitterWriter {
                             && next.has_label())     // multiline start/end, move it to a new line
                         || (annotation.has_label()   // so as not to overlap the orizontal lines.
                             && next.takes_space())
-                        || (annotation.takes_space()
-                            && next.takes_space())
+                        || (annotation.takes_space() && next.takes_space())
+                        || (overlaps(next, annotation, l)
+                            && next.end_col <= annotation.end_col
+                            && next.has_label()
+                            && p == 0)  // Avoid #42595.
                     {
                         // This annotation needs a new line in the output.
                         p += 1;

--- a/src/libsyntax/test_snippet.rs
+++ b/src/libsyntax/test_snippet.rs
@@ -736,6 +736,49 @@ error: foo
 }
 
 #[test]
+fn multiple_labels_secondary_without_message_3() {
+    test_harness(r#"
+fn foo() {
+  a  bc  d
+}
+"#,
+    vec![
+        SpanLabel {
+            start: Position {
+                string: "a",
+                count: 1,
+            },
+            end: Position {
+                string: "b",
+                count: 1,
+            },
+            label: "`a` is a good letter",
+        },
+        SpanLabel {
+            start: Position {
+                string: "c",
+                count: 1,
+            },
+            end: Position {
+                string: "d",
+                count: 1,
+            },
+            label: "",
+        },
+    ],
+    r#"
+error: foo
+ --> test.rs:3:3
+  |
+3 |   a  bc  d
+  |   ^^^^----
+  |   |
+  |   `a` is a good letter
+
+"#);
+}
+
+#[test]
 fn multiple_labels_without_message() {
     test_harness(r#"
 fn foo() {


### PR DESCRIPTION
Fix #42595.

Before:

```
15 |     map.entry("e").or_insert(0) += 1;
   |     ---------------------------^^^^^ot use `+=` on type `&mut {integer}`
```

After:

```
15 |     map.entry("e").or_insert(0) += 1;
   |     ---------------------------^^^^^
   |     |
   |     cannot use `+=` on type `&mut {integer}`
```