### PR TITLE
Add serial tests

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -499,6 +499,7 @@ impl Collector {
                 ignore: should_ignore,
                 // compiler failures are test failures
                 should_panic: testing::ShouldPanic::No,
+                serial: false,
             },
             testfn: testing::DynTestFn(box move |()| {
                 let panic = io::set_panic(None);

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -530,6 +530,7 @@ pub const BUILTIN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeG
     ("derive", Normal, Ungated),
     ("should_panic", Normal, Ungated),
     ("ignore", Normal, Ungated),
+    ("serial", Normal, Ungated),
     ("no_implicit_prelude", Normal, Ungated),
     ("reexport_test_harness_main", Normal, Ungated),
     ("link_args", Normal, Ungated),

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -212,6 +212,7 @@ pub struct TestDesc {
     pub name: TestName,
     pub ignore: bool,
     pub should_panic: ShouldPanic,
+    pub serial: bool,
 }
 
 #[derive(Clone)]
@@ -423,7 +424,10 @@ Test Attributes:
     #[ignore]      - When applied to a function which is already attributed as a
                      test, then the test runner will ignore these tests during
                      normal test runs. Running with --ignored will run these
-                     tests."#,
+                     tests.
+    #[serial]      - When applied to a function which is already attributed as a
+                     test, then the test runner will not run these tests in
+                     parallel with any other tests."#,
              usage = getopts::usage(&message, &optgroups()));
 }
 
@@ -944,12 +948,14 @@ fn should_sort_failures_before_printing_them() {
         name: StaticTestName("a"),
         ignore: false,
         should_panic: ShouldPanic::No,
+        serial: false,
     };
 
     let test_b = TestDesc {
         name: StaticTestName("b"),
         ignore: false,
         should_panic: ShouldPanic::No,
+        serial: false,
     };
 
     let mut st = ConsoleTestState {
@@ -1705,6 +1711,7 @@ mod tests {
                 name: StaticTestName("whatever"),
                 ignore: true,
                 should_panic: ShouldPanic::No,
+                serial: false,
             },
             testfn: DynTestFn(Box::new(move |()| f())),
         };
@@ -1722,6 +1729,7 @@ mod tests {
                 name: StaticTestName("whatever"),
                 ignore: true,
                 should_panic: ShouldPanic::No,
+                serial: false,
             },
             testfn: DynTestFn(Box::new(move |()| f())),
         };
@@ -1741,6 +1749,7 @@ mod tests {
                 name: StaticTestName("whatever"),
                 ignore: false,
                 should_panic: ShouldPanic::Yes,
+                serial: false,
             },
             testfn: DynTestFn(Box::new(move |()| f())),
         };
@@ -1760,6 +1769,7 @@ mod tests {
                 name: StaticTestName("whatever"),
                 ignore: false,
                 should_panic: ShouldPanic::YesWithMessage("error message"),
+                serial: false,
             },
             testfn: DynTestFn(Box::new(move |()| f())),
         };
@@ -1781,6 +1791,7 @@ mod tests {
                 name: StaticTestName("whatever"),
                 ignore: false,
                 should_panic: ShouldPanic::YesWithMessage(expected),
+                serial: false,
             },
             testfn: DynTestFn(Box::new(move |()| f())),
         };
@@ -1798,6 +1809,7 @@ mod tests {
                 name: StaticTestName("whatever"),
                 ignore: false,
                 should_panic: ShouldPanic::Yes,
+                serial: false,
             },
             testfn: DynTestFn(Box::new(move |()| f())),
         };
@@ -1831,6 +1843,7 @@ mod tests {
                                  name: StaticTestName("1"),
                                  ignore: true,
                                  should_panic: ShouldPanic::No,
+                                 serial: false,
                              },
                              testfn: DynTestFn(Box::new(move |()| {})),
                          },
@@ -1839,6 +1852,7 @@ mod tests {
                                  name: StaticTestName("2"),
                                  ignore: false,
                                  should_panic: ShouldPanic::No,
+                                 serial: false,
                              },
                              testfn: DynTestFn(Box::new(move |()| {})),
                          }];
@@ -1862,6 +1876,7 @@ mod tests {
                     name: StaticTestName(name),
                     ignore: false,
                     should_panic: ShouldPanic::No,
+                    serial: false,
                 },
                 testfn: DynTestFn(Box::new(move |()| {}))
             })
@@ -1943,6 +1958,7 @@ mod tests {
                         name: DynTestName((*name).clone()),
                         ignore: false,
                         should_panic: ShouldPanic::No,
+                        serial: false,
                     },
                     testfn: DynTestFn(Box::new(move |()| testfn())),
                 };

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1141,33 +1141,33 @@ pub fn run_tests<F>(opts: &TestOpts, tests: Vec<TestDescAndFn>, mut callback: F)
         pending -= 1;
     }
 
-                             for test in serial {
-                                 callback(TeWait(test.desc.clone(), test.testfn.padding()))?;
-                                 let timeout = Instant::now() + Duration::from_secs(TEST_WARN_TIMEOUT_S);
-                                 running_tests.insert(test.desc.clone(), timeout);
-                                 run_test(opts, !opts.run_tests, test, tx.clone());
+    for test in serial {
+        callback(TeWait(test.desc.clone(), test.testfn.padding()))?;
+        let timeout = Instant::now() + Duration::from_secs(TEST_WARN_TIMEOUT_S);
+        running_tests.insert(test.desc.clone(), timeout);
+        run_test(opts, !opts.run_tests, test, tx.clone());
 
-                                 let mut res;
-                                 loop {
-                                     if let Some(timeout) = calc_timeout(&running_tests) {
-                                         res = rx.recv_timeout(timeout);
-                                         for test in get_timed_out_tests(&mut running_tests) {
-                                             callback(TeTimeout(test))?;
-                                         }
-                                         if res != Err(RecvTimeoutError::Timeout) {
-                                             break;
-                                         }
-                                     } else {
-                                         res = rx.recv().map_err(|_| RecvTimeoutError::Disconnected);
-                                         break;
-                                     }
-                                 }
+        let mut res;
+        loop {
+            if let Some(timeout) = calc_timeout(&running_tests) {
+                res = rx.recv_timeout(timeout);
+                for test in get_timed_out_tests(&mut running_tests) {
+                    callback(TeTimeout(test))?;
+                }
+                if res != Err(RecvTimeoutError::Timeout) {
+                    break;
+                }
+            } else {
+                res = rx.recv().map_err(|_| RecvTimeoutError::Disconnected);
+                break;
+            }
+        }
 
-                                 let (desc, result, stdout) = res.unwrap();
-                                 running_tests.remove(&desc);
+        let (desc, result, stdout) = res.unwrap();
+        running_tests.remove(&desc);
 
-                                 callback(TeResult(desc, result, stdout))?;
-                             }
+        callback(TeResult(desc, result, stdout))?;
+    }
 
     if opts.bench_benchmarks {
         // All benchmarks run at the end, in serial.
@@ -2049,7 +2049,8 @@ mod tests {
             match e {
                 TestEvent::TeFilteredOut(n) if n > 0 => panic!("filtered out"),
                 TestEvent::TeTimeout(_) => panic!("timeout"),
-                TestEvent::TeResult(_, ref result, _) if result != &TestResult::TrOk => panic!("result not okay"),
+                TestEvent::TeResult(_, ref result, _) if result != &TestResult::TrOk =>
+                    panic!("result not okay"),
                 _ => Ok(())
             }
         }).unwrap();
@@ -2100,7 +2101,8 @@ mod tests {
             match e {
                 TestEvent::TeFilteredOut(n) if n > 0 => panic!("filtered out"),
                 TestEvent::TeTimeout(_) => panic!("timeout"),
-                TestEvent::TeResult(_, ref result, _) if result != &TestResult::TrOk => panic!("result not okay"),
+                TestEvent::TeResult(_, ref result, _) if result != &TestResult::TrOk =>
+                    panic!("result not okay"),
                 _ => Ok(())
             }
         }).unwrap();

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1726,8 +1726,11 @@ pub mod bench {
 mod tests {
     use test::{TrFailed, TrFailedMsg, TrIgnored, TrOk, filter_tests, parse_opts, TestDesc,
                TestDescAndFn, TestOpts, run_test, MetricMap, StaticTestName, DynTestName,
-               DynTestFn, ShouldPanic};
+               DynTestFn, ShouldPanic, TestResult};
+    use super::{TestEvent, run_tests};
     use std::sync::mpsc::channel;
+    use std::sync::{Arc, RwLock};
+    use std::thread::sleep;
     use bench;
     use Bencher;
 
@@ -2015,9 +2018,6 @@ mod tests {
 
     #[test]
     pub fn stress_test_serial_tests() {
-        use super::{TestEvent, TestResult, run_tests};
-        use std::sync::{Arc, RwLock};
-
         let mut opts = TestOpts::new();
         opts.run_tests = true;
         opts.test_threads = Some(100);
@@ -2060,10 +2060,7 @@ mod tests {
 
     #[test]
     pub fn run_concurrent_tests_concurrently() {
-        use super::{TestEvent, TestResult, run_tests};
-        use std::thread::sleep;
         use std::time::Duration;
-        use std::sync::mpsc::channel;
 
         let mut opts = TestOpts::new();
         opts.run_tests = true;

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -2014,6 +2014,65 @@ mod tests {
     }
 
     #[test]
+    pub fn stress_test_serial_tests() {
+        use std::env;
+        use std::fs;
+        use std::time::{SystemTime, UNIX_EPOCH};
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        use std::path::PathBuf;
+        use super::{TestEvent, TestResult, run_tests};
+
+        fn test_fn(path: PathBuf) {
+            use std::fs::File;
+            use std::io::Write;
+
+            {
+                let mut f = File::create(&path)
+                    .expect("create stress test file");
+                f.write_all(b"stress")
+                    .expect("write to stress test file");
+            }
+        }
+
+        let mut opts = TestOpts::new();
+        opts.run_tests = true;
+
+        let limit = 100;
+
+        let dir = env::temp_dir();
+        let path = dir.join(format!("rust-stress-test-file-{}", SystemTime::now().duration_since(UNIX_EPOCH).expect("time since Unix epoch").as_secs()));
+
+        let tests = (0..limit)
+            .map(|n| TestDescAndFn {
+                desc: TestDesc {
+                    name: DynTestName(format!("stress_{:?}", n)),
+                    ignore: false,
+                    should_panic: ShouldPanic::No,
+                    serial: true,
+                },
+                testfn: DynTestFn(Box::new(|()| { test_fn(path.to_owned()) }))
+            })
+            .collect::<Vec<_>>();
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            run_tests(&opts, tests, |e| {
+                match e {
+                    TestEvent::TeFilteredOut(n) if n > 0 => panic!("filtered out"),
+                    TestEvent::TeTimeout(_) => panic!("timeout"),
+                    TestEvent::TeResult(_, ref result, _) if result != &TestResult::TrOk => panic!("result not okay"),
+                    _ => Ok(())
+                }
+            });
+        }));
+
+        if path.exists() {
+            fs::remove_file(&path).expect("remove file");
+        }
+
+        result.unwrap()
+    }
+
+    #[test]
     pub fn test_metricmap_compare() {
         let mut m1 = MetricMap::new();
         let mut m2 = MetricMap::new();

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -475,6 +475,7 @@ pub fn make_test(config: &Config, testpaths: &TestPaths) -> test::TestDescAndFn 
             name: make_test_name(config, testpaths),
             ignore: ignore,
             should_panic: should_panic,
+            serial: false,
         },
         testfn: make_test_closure(config, testpaths),
     }


### PR DESCRIPTION
This PR adds a `#[serial]` attribute that marks tests that should be executed one-by-one rather than concurrently (per #33519).

I’ve confirmed that the `libtest` tests pass. I wasn’t able to run the full suite as a lot of the `run_make` tests seem to fail on my Windows system, but everything passed up to that point. I also ran a tidy check and fixed a couple of small errors.

Rust (and PR!) newbie here, so please do let me know if I’m doing something poorly or incorrectly!