### PR TITLE
Add String::parse_into.

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -121,6 +121,7 @@
 #![feature(str_internals)]
 #![feature(str_mut_extras)]
 #![feature(trusted_len)]
+#![feature(try_from)]
 #![feature(unboxed_closures)]
 #![feature(unicode)]
 #![feature(unique)]

--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -56,6 +56,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+use core::convert::TryFrom;
 use core::fmt;
 use core::hash;
 use core::iter::{FromIterator, FusedIterator};
@@ -1366,6 +1367,25 @@ impl String {
             string: self_ptr,
             replace_with: replace_with
         }
+    }
+
+    /// Parses this string into another type.
+    ///
+    /// This is very similar to [`str::parse`], but this method works directly on
+    /// `String` instead.
+    ///
+    /// # Errors
+    ///
+    /// Will return [`Error`] if it's not possible to parse this string into the
+    /// desired type.
+    ///
+    /// [`str::parse`]: ../../std/primitive.str.html#method.parse
+    /// [`Err`]: ../../core/convert/trait.TryFrom.html#associatedtype.Error
+    /// ```
+    #[inline]
+    #[unstable(feature = "parse_into", issue = "0")]
+    pub fn parse_into<F: TryFrom<String>>(self) -> Result<F, F::Error> {
+        TryFrom::try_from(self)
     }
 
     /// Converts this `String` into a `Box<str>`.


### PR DESCRIPTION
I suggested this in the tracking issue for `TryFrom` and figured that I'd include this here and see what people think.

Essentially, some types which parse from a string need to allocate a string internally anyway. This would create a method that allows people to parse directly from an already-allocated string if they already have one, using `TryFrom`.

If it's preferred, we could specialise the `FromStr` implementation and go that route instead, but I figured that I'd use `TryFrom` directly considering how `FromStr` will be deprecated in favour of `TryFrom`.