### PR TITLE
Possible mistake in lexer rule for octal integer

### DIFF
--- a/src/grammar/lexer.l
+++ b/src/grammar/lexer.l
@@ -126,7 +126,7 @@ while    { return WHILE; }
 {ident}  { return IDENT; }
 
 0x[0-9a-fA-F_]+                                    { BEGIN(suffix); return LIT_INTEGER; }
-0o[0-8_]+                                          { BEGIN(suffix); return LIT_INTEGER; }
+0o[0-7_]+                                          { BEGIN(suffix); return LIT_INTEGER; }
 0b[01_]+                                           { BEGIN(suffix); return LIT_INTEGER; }
 [0-9][0-9_]*                                       { BEGIN(suffix); return LIT_INTEGER; }
 [0-9][0-9_]*\.(\.|[a-zA-Z])    { yyless(yyleng - 2); BEGIN(suffix); return LIT_INTEGER; }


### PR DESCRIPTION
Original rule allowed for digits 0-8, but octal is 0-7.

The compiler correctly prevents you from placing an 8 in an octal, so I'm assuming this is caught on a later stage. Still, shouldn't the lexer already catch this?