### PR TITLE
Only run check-linkchecker when actually building docs

### DIFF
--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -463,7 +463,7 @@ pub fn build_rules<'a>(build: &'a Build) -> Rules {
     rules.test("check-linkchecker", "src/tools/linkchecker")
          .dep(|s| s.name("tool-linkchecker").stage(0))
          .dep(|s| s.name("default:doc"))
-         .default(true)
+         .default(build.config.docs)
          .host(true)
          .run(move |s| check::linkcheck(build, s.target));
     rules.test("check-cargotest", "src/tools/cargotest")


### PR DESCRIPTION
Otherwise the build fails, when running tests but not building docs, e.g.:
https://buildd.debian.org/status/fetch.php?pkg=rustc&arch=ppc64el&ver=1.17.0%2Bdfsg2-3&stamp=1497403375&raw=0