### PR TITLE
Add hint about the return code of panic!

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -456,7 +456,7 @@ macro_rules! writeln {
 ///
 /// # Panics
 ///
-/// This will always [panic!](macro.panic.html).
+/// This will always [panic!](macro.panic.html)
 ///
 /// # Examples
 ///

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -456,7 +456,7 @@ macro_rules! writeln {
 ///
 /// # Panics
 ///
-/// This will always panic.
+/// This will always [panic!](macro.panic.html).
 ///
 /// # Examples
 ///

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -26,7 +26,7 @@
 ///
 /// # Current implementation
 ///
-/// If the main thread panics it will return with code `101`.
+/// If the main thread panics it will terminate all your threads and end your program with code `101`.
 ///
 /// # Examples
 ///

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -26,7 +26,8 @@
 ///
 /// # Current implementation
 ///
-/// If the main thread panics it will terminate all your threads and end your program with code `101`.
+/// If the main thread panics it will terminate all your threads and end your
+/// program with code `101`.
 ///
 /// # Examples
 ///

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -24,6 +24,8 @@
 /// The multi-argument form of this macro panics with a string and has the
 /// `format!` syntax for building a string.
 ///
+/// # Current implementation
+///
 /// If the main thread panics it will return with code `101`.
 ///
 /// # Examples

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -24,6 +24,8 @@
 /// The multi-argument form of this macro panics with a string and has the
 /// `format!` syntax for building a string.
 ///
+/// If the main thread panics it will return with code `101`.
+///
 /// # Examples
 ///
 /// ```should_panic


### PR DESCRIPTION
I hope the link works on all cases, since the `unreachable` doc is copied to `std::` as well.