### PR TITLE
Integrate jobserver support to parallel codegen

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -293,6 +293,9 @@ dependencies = [
 [[package]]
 name = "core"
 version = "0.0.0"
+dependencies = [
+ "rand 0.0.0",
+]
 
 [[package]]
 name = "crates-io"
@@ -1099,6 +1102,7 @@ dependencies = [
  "flate2 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "fmt_macros 0.0.0",
  "graphviz 0.0.0",
+ "jobserver 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_back 0.0.0",
@@ -1394,8 +1398,10 @@ dependencies = [
 name = "rustc_trans"
 version = "0.0.0"
 dependencies = [
+ "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jobserver 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc 0.0.0",

--- a/src/libcore/Cargo.toml
+++ b/src/libcore/Cargo.toml
@@ -9,6 +9,9 @@ path = "lib.rs"
 test = false
 bench = false
 
+[dev-dependencies]
+rand = { path = "../librand" }
+
 [[test]]
 name = "coretests"
 path = "../libcore/tests/lib.rs"

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["dylib"]
 arena = { path = "../libarena" }
 fmt_macros = { path = "../libfmt_macros" }
 graphviz = { path = "../libgraphviz" }
+jobserver = "0.1"
 log = "0.3"
 owning_ref = "0.3.3"
 rustc_back = { path = "../librustc_back" }

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -61,6 +61,7 @@ extern crate rustc_errors as errors;
 #[macro_use] extern crate syntax;
 extern crate syntax_pos;
 #[macro_use] #[no_link] extern crate rustc_bitflags;
+extern crate jobserver;
 
 extern crate serialize as rustc_serialize; // used by deriving
 

--- a/src/librustc_trans/Cargo.toml
+++ b/src/librustc_trans/Cargo.toml
@@ -10,7 +10,9 @@ crate-type = ["dylib"]
 test = false
 
 [dependencies]
+crossbeam = "0.2"
 flate2 = "0.2"
+jobserver = "0.1.5"
 log = "0.3"
 owning_ref = "0.3.3"
 rustc = { path = "../librustc" }

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -40,6 +40,7 @@ use rustc::dep_graph::WorkProduct;
 use syntax_pos::symbol::Symbol;
 
 extern crate flate2;
+extern crate crossbeam;
 extern crate libc;
 extern crate owning_ref;
 #[macro_use] extern crate rustc;
@@ -52,6 +53,7 @@ extern crate rustc_const_math;
 #[macro_use]
 #[no_link]
 extern crate rustc_bitflags;
+extern crate jobserver;
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate syntax;

--- a/src/test/compile-fail/asm-src-loc-codegen-units.rs
+++ b/src/test/compile-fail/asm-src-loc-codegen-units.rs
@@ -7,17 +7,16 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-//
+
 // WONTFIX(#20184) Needs landing pads (not present in stage1) or the compiler hangs.
 // ignore-stage1
 // compile-flags: -C codegen-units=2
-// error-pattern: build without -C codegen-units for more exact errors
 // ignore-emscripten
 
 #![feature(asm)]
 
 fn main() {
     unsafe {
-        asm!("nowayisthisavalidinstruction");
+        asm!("nowayisthisavalidinstruction"); //~ ERROR instruction
     }
 }

--- a/src/test/compile-fail/auxiliary/issue-36881-aux.rs
+++ b/src/test/compile-fail/auxiliary/issue-36881-aux.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,22 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![no_std]
-
-extern crate serialize as rustc_serialize;
-
-#[derive(RustcEncodable)]  //~ ERROR this trait cannot be derived
-struct Bar {
-    x: u32,
-}
-
-#[derive(RustcDecodable)]  //~ ERROR this trait cannot be derived
-struct Baz {
-    x: u32,
-}
-
-fn main() {
-    Foo { x: 0 };
-    Bar { x: 0 };
-    Baz { x: 0 };
-}
+pub trait Foo {}

--- a/src/test/compile-fail/auxiliary/lint_unused_extern_crate2.rs
+++ b/src/test/compile-fail/auxiliary/lint_unused_extern_crate2.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,22 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![no_std]
-
-extern crate serialize as rustc_serialize;
-
-#[derive(RustcEncodable)]  //~ ERROR this trait cannot be derived
-struct Bar {
-    x: u32,
-}
-
-#[derive(RustcDecodable)]  //~ ERROR this trait cannot be derived
-struct Baz {
-    x: u32,
-}
-
-fn main() {
-    Foo { x: 0 };
-    Bar { x: 0 };
-    Baz { x: 0 };
-}
+pub fn foo() {}

--- a/src/test/compile-fail/auxiliary/lint_unused_extern_crate3.rs
+++ b/src/test/compile-fail/auxiliary/lint_unused_extern_crate3.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,22 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![no_std]
-
-extern crate serialize as rustc_serialize;
-
-#[derive(RustcEncodable)]  //~ ERROR this trait cannot be derived
-struct Bar {
-    x: u32,
-}
-
-#[derive(RustcDecodable)]  //~ ERROR this trait cannot be derived
-struct Baz {
-    x: u32,
-}
-
-fn main() {
-    Foo { x: 0 };
-    Bar { x: 0 };
-    Baz { x: 0 };
-}
+pub fn foo() {}

--- a/src/test/compile-fail/auxiliary/lint_unused_extern_crate4.rs
+++ b/src/test/compile-fail/auxiliary/lint_unused_extern_crate4.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -7,23 +7,3 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
-#![no_std]
-
-extern crate serialize as rustc_serialize;
-
-#[derive(RustcEncodable)]  //~ ERROR this trait cannot be derived
-struct Bar {
-    x: u32,
-}
-
-#[derive(RustcDecodable)]  //~ ERROR this trait cannot be derived
-struct Baz {
-    x: u32,
-}
-
-fn main() {
-    Foo { x: 0 };
-    Bar { x: 0 };
-    Baz { x: 0 };
-}

--- a/src/test/compile-fail/issue-36881.rs
+++ b/src/test/compile-fail/issue-36881.rs
@@ -8,9 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(rand)]
+// aux-build:issue-36881-aux.rs
 
 fn main() {
-    extern crate rand;
-    use rand::Rng; //~ ERROR unresolved import
+    extern crate issue_36881_aux;
+    use issue_36881_aux::Foo; //~ ERROR unresolved import
 }

--- a/src/test/compile-fail/lint-unused-extern-crate.rs
+++ b/src/test/compile-fail/lint-unused-extern-crate.rs
@@ -9,34 +9,34 @@
 // except according to those terms.
 
 // aux-build:lint_unused_extern_crate.rs
+// aux-build:lint_unused_extern_crate2.rs
+// aux-build:lint_unused_extern_crate3.rs
+// aux-build:lint_unused_extern_crate4.rs
 
 #![deny(unused_extern_crates)]
 #![allow(unused_variables)]
 #![allow(deprecated)]
-#![feature(alloc)]
-#![feature(libc)]
-#![feature(rand)]
 
-extern crate libc; //~ ERROR: unused extern crate
+extern crate lint_unused_extern_crate4; //~ ERROR: unused extern crate
 
-extern crate alloc as collecs; // no error, it is used
+extern crate lint_unused_extern_crate3; // no error, it is used
 
-extern crate rand; // no error, the use marks it as used
-                   // even if imported objects aren't used
+extern crate lint_unused_extern_crate2; // no error, the use marks it as used
+                                        // even if imported objects aren't used
 
 extern crate lint_unused_extern_crate as other; // no error, the use * marks it as used
 
 #[allow(unused_imports)]
-use rand::isaac::IsaacRng;
+use lint_unused_extern_crate2::foo as bar;
 
 use other::*;
 
 mod foo {
-    // Test that this is unused even though an earler `extern crate rand` is used.
-    extern crate rand; //~ ERROR unused extern crate
+    // Test that this is unused even though an earler `extern crate` is used.
+    extern crate lint_unused_extern_crate2; //~ ERROR unused extern crate
 }
 
 fn main() {
-    let x: collecs::vec::Vec<usize> = Vec::new();
+    lint_unused_extern_crate3::foo();
     let y = foo();
 }

--- a/src/test/run-pass/auxiliary/allocator-dummy.rs
+++ b/src/test/run-pass/auxiliary/allocator-dummy.rs
@@ -10,10 +10,12 @@
 
 // no-prefer-dynamic
 
-#![feature(allocator, core_intrinsics)]
+#![feature(allocator, core_intrinsics, panic_unwind)]
 #![allocator]
 #![crate_type = "rlib"]
 #![no_std]
+
+extern crate unwind;
 
 pub static mut HITS: usize = 0;
 


### PR DESCRIPTION
This commit integrates the `jobserver` crate into the compiler. The crate was
previously integrated in to Cargo as part of rust-lang/cargo#4110. The purpose
here is to two-fold:

* Primarily the compiler can cooperate with Cargo on parallelism. When you run
  `cargo build -j4` then this'll make sure that the entire build process between
  Cargo/rustc won't use more than 4 cores, whereas today you'd get 4 rustc
  instances which may all try to spawn lots of threads.

* Secondarily rustc/Cargo can now integrate with a foreign GNU `make` jobserver.
  This means that if you call cargo/rustc from `make` or another
  jobserver-compatible implementation it'll use foreign parallelism settings
  instead of creating new ones locally.

As the number of parallel codegen instances in the compiler continues to grow
over time with the advent of incremental compilation it's expected that this'll
become more of a problem, so this is intended to nip concurrent concerns in the
bud by having all the tools to cooperate!

Note that while rustc has support for itself creating a jobserver it's far more
likely that rustc will always use the jobserver configured by Cargo. Cargo today
will now set a jobserver unconditionally for rustc to use.