### PR TITLE
Remove sometimes in std::io::Read doc

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -389,7 +389,7 @@ fn read_to_end<R: Read + ?Sized>(r: &mut R, buf: &mut Vec<u8>) -> Result<usize> 
 
 /// The `Read` trait allows for reading bytes from a source.
 ///
-/// Implementors of the `Read` trait are sometimes called 'readers'.
+/// Implementors of the `Read` trait are called 'readers'.
 ///
 /// Readers are defined by one required method, `read()`. Each call to `read`
 /// will attempt to pull bytes from this source into a provided buffer. A


### PR DESCRIPTION
We use it immediately in the next sentence, and the word is filler.

A different conversation to make is whether we want to call them Readers in the documentation at all. And whether it's actually called "Readers" elsewhere.