### PR TITLE
x.py: chdir to rust root folder, so that x.py can be called from other directories

### DIFF
--- a/x.py
+++ b/x.py
@@ -15,6 +15,7 @@ import os
 import sys
 rust_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.join(rust_dir, "src", "bootstrap"))
+os.chdir(rust_dir)
 
 import bootstrap
 bootstrap.main()


### PR DESCRIPTION
I have my emacs "M-x compile" set up to do `~/path/to/rust/x.py build ...`, but emacs will call this from whatever directory the current file is in, which is how I noticed that the working directory *does* matter for `x.py`. For example, after changing it, it re-downloads the bootstrap compiler, because that is stored somewhere relative.

Given that cargo also makes it so that the working directory doesn't matter for the build, I felt it'd make sense to implement the same for `x.py`.