### PR TITLE
Use custom cargo/rustc paths when parsing flags.

### DIFF
--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -242,11 +242,18 @@ Arguments:
         let cwd = t!(env::current_dir());
         let paths = matches.free[1..].iter().map(|p| cwd.join(p)).collect::<Vec<_>>();
 
+        let cfg_file = matches.opt_str("config").map(PathBuf::from).or_else(|| {
+            if fs::metadata("config.toml").is_ok() {
+                Some(PathBuf::from("config.toml"))
+            } else {
+                None
+            }
+        });
 
         // All subcommands can have an optional "Available paths" section
         if matches.opt_present("verbose") {
             let flags = Flags::parse(&["build".to_string()]);
-            let mut config = Config::default();
+            let mut config = Config::parse(&flags.build, cfg_file.clone());
             config.build = flags.build.clone();
             let mut build = Build::new(flags, config);
             metadata::build(&mut build);
@@ -306,14 +313,6 @@ Arguments:
             }
         };
 
-
-        let cfg_file = matches.opt_str("config").map(PathBuf::from).or_else(|| {
-            if fs::metadata("config.toml").is_ok() {
-                Some(PathBuf::from("config.toml"))
-            } else {
-                None
-            }
-        });
 
         let mut stage = matches.opt_str("stage").map(|j| j.parse().unwrap());
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/41779, probably also https://github.com/rust-lang/rust/issues/42543 (I think they're duplicates).

I'm not entirely happy with the implementation, since it means we parse the configuration twice, but it's the minimal solution. I think the other choice is to move both calls to Config::parse inside Flags::parse and merge them, but I don't know if that's a good idea.

r? @alexcrichton 