### PR TITLE
rustbuild: ensure CFG_RELEASE_CHANNEL is always defined

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -245,7 +245,6 @@ pub fn rustc(build: &Build, target: &str, compiler: &Compiler) {
     // Set some configuration variables picked up by build scripts and
     // the compiler alike
     cargo.env("CFG_RELEASE", build.rust_release())
-         .env("CFG_RELEASE_CHANNEL", &build.config.channel)
          .env("CFG_VERSION", build.rust_version())
          .env("CFG_PREFIX", build.config.prefix.clone().unwrap_or(PathBuf::new()));
 
@@ -460,8 +459,6 @@ pub fn tool(build: &Build, stage: u32, target: &str, tool: &str) {
         cargo.env("OPENSSL_DIR", dir);
         cargo.env("LIBZ_SYS_STATIC", "1");
     }
-
-    cargo.env("CFG_RELEASE_CHANNEL", &build.config.channel);
 
     let info = GitInfo::new(&dir);
     if let Some(sha) = info.sha() {

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -429,6 +429,10 @@ impl Build {
                  .env("RUSTC_SNAPSHOT_LIBDIR", self.rustc_libdir(compiler));
         }
 
+        // Ensure we have access to the release channel we're building everywhere.
+        // This is used by cargo to compute the libraries hash.
+        cargo.env("CFG_RELEASE_CHANNEL", &self.config.channel);
+
         // There are two invariants we must maintain:
         // * stable crates cannot depend on unstable crates (general Rust rule),
         // * crates that end up in the sysroot must be unstable (rustbuild rule).


### PR DESCRIPTION
We're already setting that for the rustc and the rls compilation, this just extends it to all the other steps.