### PR TITLE
Introduce tidy lint to check for inconsistent tracking issues

### DIFF
--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -428,7 +428,7 @@ impl Rc<str> {
     #[doc(hidden)]
     #[unstable(feature = "rustc_private",
                reason = "for internal use in rustc",
-               issue = "0")]
+               issue = "27812")]
     pub fn __from_str(value: &str) -> Rc<str> {
         unsafe {
             // Allocate enough space for `RcBox<str>`.
@@ -453,7 +453,7 @@ impl<T> Rc<[T]> {
     #[doc(hidden)]
     #[unstable(feature = "rustc_private",
                reason = "for internal use in rustc",
-               issue = "0")]
+               issue = "27812")]
     pub fn __from_array(value: Box<[T]>) -> Rc<[T]> {
         unsafe {
             let ptr: *mut RcBox<[T]> =

--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -99,7 +99,7 @@ use mem;
 #[allow(deprecated)]
 pub use self::sip::SipHasher;
 
-#[unstable(feature = "sip_hash_13", issue = "29754")]
+#[unstable(feature = "sip_hash_13", issue = "34767")]
 #[allow(deprecated)]
 pub use self::sip::{SipHasher13, SipHasher24};
 

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -2085,7 +2085,7 @@ pub trait StrExt {
     fn is_char_boundary(&self, index: usize) -> bool;
     #[stable(feature = "core", since = "1.6.0")]
     fn as_bytes(&self) -> &[u8];
-    #[unstable(feature = "str_mut_extras", issue = "0")]
+    #[unstable(feature = "str_mut_extras", issue = "41119")]
     unsafe fn as_bytes_mut(&mut self) -> &mut [u8];
     #[stable(feature = "core", since = "1.6.0")]
     fn find<'a, P: Pattern<'a>>(&'a self, pat: P) -> Option<usize>;

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -26,7 +26,7 @@
 #![deny(warnings)]
 
 #![cfg_attr(stage0, feature(staged_api))]
-#![feature(unicode)]
+#![feature(rustc_private)]
 
 pub use self::Piece::*;
 pub use self::Position::*;

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -33,7 +33,6 @@
 #![feature(quote)]
 #![feature(rustc_diagnostic_macros)]
 #![feature(slice_patterns)]
-#![feature(unicode)]
 #![feature(conservative_impl_trait)]
 #![feature(command_envs)]
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -484,7 +484,7 @@ pub mod rt;
 // but it may be stabilized long-term. As a result we're exposing a hidden,
 // unstable module so we can get our build working.
 #[doc(hidden)]
-#[unstable(feature = "rand", issue = "0")]
+#[unstable(feature = "rand", issue = "27703")]
 pub mod __rand {
     pub use rand::{thread_rng, ThreadRng, Rng};
 }

--- a/src/libstd/rand/mod.rs
+++ b/src/libstd/rand/mod.rs
@@ -56,7 +56,7 @@
 //!     between the two sources. (Also note that, on some systems e.g. FreeBSD, both `/dev/random`
 //!     and `/dev/urandom` may block once if the CSPRNG has not seeded yet.)
 
-#![unstable(feature = "rand", issue = "0")]
+#![unstable(feature = "rand", issue = "27703")]
 
 use cell::RefCell;
 use fmt;

--- a/src/libstd_unicode/char.rs
+++ b/src/libstd_unicode/char.rs
@@ -599,9 +599,9 @@ impl char {
     /// 'XID_Start' is a Unicode Derived Property specified in
     /// [UAX #31](http://unicode.org/reports/tr31/#NFKC_Modifications),
     /// mostly similar to `ID_Start` but modified for closure under `NFKx`.
-    #[unstable(feature = "unicode",
+    #[unstable(feature = "rustc_private",
                reason = "mainly needed for compiler internals",
-               issue = "0")]
+               issue = "27812")]
     #[inline]
     pub fn is_xid_start(self) -> bool {
         derived_property::XID_Start(self)
@@ -613,9 +613,9 @@ impl char {
     /// 'XID_Continue' is a Unicode Derived Property specified in
     /// [UAX #31](http://unicode.org/reports/tr31/#NFKC_Modifications),
     /// mostly similar to 'ID_Continue' but modified for closure under NFKx.
-    #[unstable(feature = "unicode",
+    #[unstable(feature = "rustc_private",
                reason = "mainly needed for compiler internals",
-               issue = "0")]
+               issue = "27812")]
     #[inline]
     pub fn is_xid_continue(self) -> bool {
         derived_property::XID_Continue(self)

--- a/src/tools/tidy/src/unstable_book.rs
+++ b/src/tools/tidy/src/unstable_book.rs
@@ -87,7 +87,7 @@ pub fn check(path: &path::Path, bad: &mut bool) {
     // Library features
 
     let lang_features = collect_lang_features(path);
-    let lib_features = collect_lib_features(path, bad, &lang_features);
+    let lib_features = collect_lib_features(path);
 
     let unstable_lib_feature_names = collect_unstable_feature_names(&lib_features);
     let unstable_book_lib_features_section_file_names =

--- a/src/tools/unstable-book-gen/src/main.rs
+++ b/src/tools/unstable-book-gen/src/main.rs
@@ -129,8 +129,7 @@ fn main() {
     let dest_path = Path::new(&dest_path_str).join("src");
 
     let lang_features = collect_lang_features(src_path);
-    let mut bad = false;
-    let lib_features = collect_lib_features(src_path, &mut bad, &lang_features);
+    let lib_features = collect_lib_features(src_path);
 
     let doc_src_path = src_path.join(PATH_STR);
 


### PR DESCRIPTION
This PR
* Refactors the collect_lib_features function to work in a
      non-checking mode (no bad pointer needed, and list of
      lang features).
* Introduces checking whether unstable/stable tags for a
      given feature have inconsistent tracking issues, as in,
      multiple tracking issues per feature.
* Fixes such inconsistencies throughout the codebase.