### PR TITLE
Add `_` to the list of keywords

### DIFF
--- a/src/doc/grammar.md
+++ b/src/doc/grammar.md
@@ -154,19 +154,19 @@ token : simple_token | ident | literal | symbol | whitespace token ;
 
 <p id="keyword-table-marker"></p>
 
-|          |          |          |          |         |
-|----------|----------|----------|----------|---------|
-| abstract | alignof  | as       | become   | box     |
-| break    | const    | continue | crate    | do      |
-| else     | enum     | extern   | false    | final   |
-| fn       | for      | if       | impl     | in      |
-| let      | loop     | macro    | match    | mod     |
-| move     | mut      | offsetof | override | priv    |
-| proc     | pub      | pure     | ref      | return  |
-| Self     | self     | sizeof   | static   | struct  |
-| super    | trait    | true     | type     | typeof  |
-| unsafe   | unsized  | use      | virtual  | where   |
-| while    | yield    |          |          |         |
+|          |          |          |          |          |
+|----------|----------|----------|----------|----------|
+| _        | abstract | alignof  | as       | become   |
+| box      | break    | const    | continue | crate    |
+| do       | else     | enum     | extern   | false    |
+| final    | fn       | for      | if       | impl     |
+| in       | let      | loop     | macro    | match    |
+| mod      | move     | mut      | offsetof | override |
+| priv     | proc     | pub      | pure     | ref      |
+| return   | Self     | self     | sizeof   | static   |
+| struct   | super    | trait    | true     | type     |
+| typeof   | unsafe   | unsized  | use      | virtual  |
+| where    | while    | yield    |          |          |
 
 
 Each of these keywords has special meaning in its grammar, and all of them are


### PR DESCRIPTION
also, make sure the keyword table is correctly spaced

note: the reference also needs to be updated. This is not the only way to do this in the grammar, but it's my preferred way.