### PR TITLE
Support borrow, scope and move visualization through RLS

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "rls-data"
-version = "0.6.0"
+version = "0.8.0"
 dependencies = [
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1371,7 +1371,7 @@ name = "rustc_save_analysis"
 version = "0.0.0"
 dependencies = [
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-data 0.6.0",
+ "rls-data 0.8.0",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc 0.0.0",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1050,7 +1050,6 @@ dependencies = [
 [[package]]
 name = "rls-data"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1372,10 +1371,11 @@ name = "rustc_save_analysis"
 version = "0.0.0"
 dependencies = [
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-data 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-data 0.6.0",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc 0.0.0",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_borrowck 0.0.0",
  "rustc_typeck 0.0.0",
  "syntax 0.0.0",
  "syntax_pos 0.0.0",
@@ -2084,7 +2084,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9191b1f57603095f105d317e375d19b1c9c5c3185ea9633a99a6dcbed04457"
 "checksum rls-analysis 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8d77d58e8933752142b5b92e3f8ba6d6f1630be6da5627c492268a43f79ffbda"
 "checksum rls-data 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "374a8fad31cc0681a7bfd8a04079dd4afd0e981d34e18a171b1a467445bdf51e"
-"checksum rls-data 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9e2087477364c34faca86c2476765deb1185dbae3c598cfb1eb040f3a74d22b5"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
 "checksum rls-vfs 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ace07060dd154731b39254864245cbdd33c8f5f64fe1f630a089c72e2468f854"
 "checksum rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3058a43ada2c2d0b92b3ae38007a2d0fa5e9db971be260e0171408a4ff471c95"

--- a/src/librustc_borrowck/borrowck/gather_loans/mod.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/mod.rs
@@ -291,6 +291,9 @@ impl<'a, 'tcx> GatherLoanCtxt<'a, 'tcx> {
         }
     }
 
+    /// Given a region for a loan (Loan/SafeLoan), returns the corresponding loan_scope,
+    /// which is a CodeExtent that could represent the gen_scope and/or kill_scope
+    /// of a loan.
     fn loan_scope_from_region(&self, loan_region: ty::Region<'tcx>) -> Option<region::CodeExtent> {
         Some(match *loan_region {
             ty::ReScope(scope) => scope,

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -103,6 +103,7 @@ pub struct AnalysisResult<'a, 'tcx: 'a> {
     pub safe_loans: Vec<SafeLoan>,
     pub all_loans: Vec<Loan<'tcx>>,
     pub move_data: move_data::MoveData<'tcx>,
+    pub span: Option<Span>,
 }
 
 fn borrowck_provider<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, owner_def_id: DefId) {
@@ -163,6 +164,7 @@ fn borrowck<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, owner_def_id: DefId, save_ana
             safe_loans,
             all_loans,
             move_data: flowed_moves.move_data,
+            span: tcx.hir.span_if_local(owner_def_id)
         })
     } else {
         None

--- a/src/librustc_borrowck/lib.rs
+++ b/src/librustc_borrowck/lib.rs
@@ -43,7 +43,8 @@ extern crate core; // for NonZero
 
 pub use borrowck::check_crate;
 pub use borrowck::build_borrowck_dataflow_data_for_fn;
-pub use borrowck::{AnalysisData, BorrowckCtxt, ElaborateDrops};
+pub use borrowck::{AnalysisData, AnalysisResult, BorrowckCtxt, ElaborateDrops, Loan, SafeLoan};
+pub use borrowck::move_data::{MoveData, Move, Assignment};
 
 // NB: This module needs to be declared first so diagnostics are
 // registered before they are used.

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -505,9 +505,11 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
         if save_analysis(sess) {
             control.after_analysis.callback = box |state| {
                 time(state.session.time_passes(), "save analysis", || {
+                    let borrow_analysis = state.borrow_analysis_map.take().unwrap();
                     save::process_crate(state.tcx.unwrap(),
                                         state.expanded_crate.unwrap(),
                                         state.analysis.unwrap(),
+                                        borrow_analysis,
                                         state.crate_name.unwrap(),
                                         DumpHandler::new(save_analysis_format(state.session),
                                                          state.out_dir,

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -233,7 +233,7 @@ impl PpSourceMode {
                                                                  arena,
                                                                  arenas,
                                                                  id,
-                                                                 |tcx, _, _, _| {
+                                                                 |tcx, _, _, _, _| {
                     let empty_tables = ty::TypeckTables::empty();
                     let annotation = TypedAnnotation {
                         tcx: tcx,
@@ -992,7 +992,7 @@ fn print_with_analysis<'tcx, 'a: 'tcx>(sess: &'a Session,
                                                      arena,
                                                      arenas,
                                                      crate_name,
-                                                     |tcx, _, _, _| {
+                                                     |tcx, _, _, _, _| {
         match ppm {
             PpmMir | PpmMirCFG => {
                 if let Some(nodeid) = nodeid {

--- a/src/librustc_save_analysis/Cargo.toml
+++ b/src/librustc_save_analysis/Cargo.toml
@@ -11,10 +11,11 @@ crate-type = ["dylib"]
 [dependencies]
 log = "0.3"
 rustc = { path = "../librustc" }
+rustc_borrowck = { path = "../librustc_borrowck" }
 rustc_typeck = { path = "../librustc_typeck" }
 syntax = { path = "../libsyntax" }
 syntax_pos = { path = "../libsyntax_pos" }
-rls-data = "0.6"
+rls-data = { path = "../../../rls-data", default-features = true, features = ["borrows"] }
 rls-span = "0.4"
 # FIXME(#40527) should move rustc serialize out of tree
 rustc-serialize = "0.3"

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -206,6 +206,7 @@ impl<'l, 'tcx: 'l, 'll, D: Dump + 'll> DumpVisitor<'l, 'tcx, 'll, D> {
             scopes: scopes,
             loans: loans,
             moves: moves,
+            span: analysis_result.span.map(|s| self.span_from_span(s))
         };
 
         self.dumper.dump_per_fn_borrow_data(data);

--- a/src/librustc_save_analysis/json_api_dumper.rs
+++ b/src/librustc_save_analysis/json_api_dumper.rs
@@ -14,7 +14,7 @@ use rustc_serialize::json::as_json;
 
 use Dump;
 
-use rls_data::{Analysis, Import, Def, CratePreludeData, Format, Relation};
+use rls_data::{Analysis, Import, Def, CratePreludeData, Format, Relation, BorrowData};
 
 
 // A dumper to dump a restricted set of JSON information, designed for use with
@@ -62,5 +62,8 @@ impl<'b, W: Write + 'b> Dump for JsonApiDumper<'b, W> {
             data.attributes = vec![];
             self.result.defs.push(data);
         }
+    }
+    fn dump_per_fn_borrow_data(&mut self, data: BorrowData) {
+        self.result.per_fn_borrows.push(data);
     }
 }

--- a/src/librustc_save_analysis/json_dumper.rs
+++ b/src/librustc_save_analysis/json_dumper.rs
@@ -13,7 +13,7 @@ use std::io::Write;
 use rustc_serialize::json::as_json;
 
 use rls_data::{self, Analysis, Import, Def, DefKind, Ref, RefKind, MacroRef,
-               Relation, CratePreludeData};
+               Relation, CratePreludeData, BorrowData};
 use rls_span::{Column, Row};
 
 use Dump;
@@ -109,5 +109,9 @@ impl<'b, O: DumpOutput + 'b> Dump for JsonDumper<O> {
 
     fn dump_relation(&mut self, data: Relation) {
         self.result.relations.push(data);
+    }
+
+    fn dump_per_fn_borrow_data(&mut self, data: BorrowData) {
+        self.result.per_fn_borrows.push(data);
     }
 }

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -177,7 +177,7 @@ pub fn run_core(search_paths: SearchPaths,
                                                      &arena,
                                                      &arenas,
                                                      &name,
-                                                     |tcx, analysis, _, result| {
+                                                     |tcx, analysis, _, _, result| {
         if let Err(_) = result {
             sess.fatal("Compilation failed, aborting rustdoc");
         }


### PR DESCRIPTION
This PR is not ready to merge yet. I'm looking to get more detailed feedback with all of the code for context. This is also dependent on `rls-data` being updated in crates.io (so I can fix the relative paths in the `Cargo.toml` files) and on the [code review in `rls-analysis`](https://github.com/nrc/rls-analysis/pull/71), mostly in that the `HashMap` used to store the `BorrowData` structs might change to a `Vec`.