### PR TITLE
rustc: Check if def_path_hash_to_def_id is populated before accessing.

### DIFF
--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -257,11 +257,11 @@ macro_rules! define_dep_nodes {
             pub fn extract_def_id(&self, tcx: TyCtxt) -> Option<DefId> {
                 if self.kind.can_reconstruct_query_key() {
                     let def_path_hash = DefPathHash(self.hash);
-                    tcx.def_path_hash_to_def_id
-                       .as_ref()
-                       .unwrap()
-                       .get(&def_path_hash)
-                       .cloned()
+                    if let Some(ref def_path_map) = tcx.def_path_hash_to_def_id.as_ref() {
+                        def_path_map.get(&def_path_hash).cloned()
+                    } else {
+                       None
+                    }
                 } else {
                     None
                 }

--- a/src/test/run-pass/rustc-rust-log.rs
+++ b/src/test/run-pass/rustc-rust-log.rs
@@ -1,0 +1,13 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// rustc-env:RUST_LOG=debug
+
+fn main() {}


### PR DESCRIPTION
Without this patch, there is an ICE when running rustc with
RUST_LOG=debug. This patch updates extract_def_id to check if the map
has been populated before accessing it. This fixes the problem, but
maybe we do not need to compute the incremental hashes maps in the first
place when we are not in incremental mode?