### PR TITLE
mark calls in the unwind path as !noinline

### DIFF
--- a/src/test/run-pass/issue-41696.rs
+++ b/src/test/run-pass/issue-41696.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 // this used to cause exponential code-size blowup during LLVM passes.
-// ignore-test FIXME #41696
-// min-llvm-version 3.9
 
 #![feature(test)]
 


### PR DESCRIPTION
The unwind path is always cold, so that should not have bad performance
implications.  This avoids catastrophic exponential inlining, and also
decreases the size of librustc.so by 1.5% (OTOH, the size of `libstd.so`
increased by 0.5% for some reason).

Fixes #41696.

r? @nagisa