### PR TITLE
Make wasm32 buildbot test LLVM backend

### DIFF
--- a/configure
+++ b/configure
@@ -490,6 +490,7 @@ valopt musl-root-armhf "" "arm-unknown-linux-musleabihf install directory"
 valopt musl-root-armv7 "" "armv7-unknown-linux-musleabihf install directory"
 valopt extra-filename "" "Additional data that is hashed and passed to the -C extra-filename flag"
 valopt qemu-armhf-rootfs "" "rootfs in qemu testing, you probably don't want to use this"
+valopt experimental-targets "" "experimental LLVM targets to build"
 
 if [ -e ${CFG_SRC_DIR}.git ]
 then

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -497,6 +497,9 @@ impl Config {
                 "CFG_TARGET" if value.len() > 0 => {
                     self.target.extend(value.split(" ").map(|s| s.to_string()));
                 }
+                "CFG_EXPERIMENTAL_TARGETS" if value.len() > 0 => {
+                    self.llvm_experimental_targets = Some(value.to_string());
+                }
                 "CFG_MUSL_ROOT" if value.len() > 0 => {
                     self.musl_root = Some(parse_configure_path(value));
                 }

--- a/src/ci/docker/disabled/wasm32/Dockerfile
+++ b/src/ci/docker/disabled/wasm32/Dockerfile
@@ -38,7 +38,7 @@ ENV EM_CONFIG=/emsdk-portable/.emscripten
 
 ENV TARGETS=wasm32-unknown-emscripten,wasm32-experimental-emscripten
 
-ENV RUST_CONFIGURE_ARGS --target=$TARGETS
+ENV RUST_CONFIGURE_ARGS --target=$TARGETS --experimental-targets=WebAssembly
 
 ENV SCRIPT python2.7 ../x.py test --target $TARGETS
 

--- a/src/ci/docker/disabled/wasm32/Dockerfile
+++ b/src/ci/docker/disabled/wasm32/Dockerfile
@@ -20,8 +20,8 @@ COPY scripts/dumb-init.sh /scripts/
 RUN sh /scripts/dumb-init.sh
 
 # emscripten
-COPY scripts/emscripten.sh /scripts/
-RUN bash /scripts/emscripten.sh
+COPY scripts/emscripten-wasm.sh /scripts/
+RUN bash /scripts/emscripten-wasm.sh
 COPY disabled/wasm32/node.sh /usr/local/bin/node
 
 # cache

--- a/src/ci/docker/disabled/wasm32/Dockerfile
+++ b/src/ci/docker/disabled/wasm32/Dockerfile
@@ -20,7 +20,7 @@ RUN sh /scripts/dumb-init.sh
 # emscripten
 COPY scripts/emscripten.sh /scripts/
 RUN bash /scripts/emscripten.sh
-COPY wasm32/node.sh /usr/local/bin/node
+COPY disabled/wasm32/node.sh /usr/local/bin/node
 
 # env
 ENV PATH=$PATH:/emsdk-portable
@@ -30,9 +30,9 @@ ENV EMSCRIPTEN=/emsdk-portable/emscripten/1.37.13/
 ENV BINARYEN_ROOT=/emsdk-portable/clang/e1.37.13_64bit/binaryen/
 ENV EM_CONFIG=/emsdk-portable/.emscripten
 
-ENV TARGETS=wasm32-unknown-emscripten
+ENV TARGETS=wasm32-unknown-emscripten,wasm32-experimental-emscripten
 
-ENV RUST_CONFIGURE_ARGS --target=$TARGETS
+ENV RUST_CONFIGURE_ARGS --target=$TARGETS --experimental-targets=WebAssembly
 
 ENV SCRIPT python2.7 ../x.py test --target $TARGETS
 

--- a/src/ci/docker/disabled/wasm32/Dockerfile
+++ b/src/ci/docker/disabled/wasm32/Dockerfile
@@ -11,7 +11,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   cmake \
   sudo \
   gdb \
-  xz-utils
+  xz-utils \
+  jq \
+  bzip2
 
 # dumb-init
 COPY scripts/dumb-init.sh /scripts/
@@ -21,6 +23,10 @@ RUN sh /scripts/dumb-init.sh
 COPY scripts/emscripten.sh /scripts/
 RUN bash /scripts/emscripten.sh
 COPY disabled/wasm32/node.sh /usr/local/bin/node
+
+# cache
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
 
 # env
 ENV PATH=$PATH:/emsdk-portable
@@ -32,13 +38,9 @@ ENV EM_CONFIG=/emsdk-portable/.emscripten
 
 ENV TARGETS=wasm32-unknown-emscripten,wasm32-experimental-emscripten
 
-ENV RUST_CONFIGURE_ARGS --target=$TARGETS --experimental-targets=WebAssembly
+ENV RUST_CONFIGURE_ARGS --target=$TARGETS
 
 ENV SCRIPT python2.7 ../x.py test --target $TARGETS
-
-# cache
-COPY scripts/sccache.sh /scripts/
-RUN sh /scripts/sccache.sh
 
 # init
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/src/ci/docker/scripts/emscripten.sh
+++ b/src/ci/docker/scripts/emscripten.sh
@@ -40,8 +40,11 @@ hide_output ./emsdk install sdk-1.37.13-64bit
 source ./emsdk_env.sh
 echo "main(){}" > a.c
 HOME=/emsdk-portable/ emcc a.c
-HOME=/emsdk-portable/ emcc -s BINARYEN=1 a.c
+HOME=/emsdk-portable/ emcc -s WASM=1 a.c
 rm -f a.*
+
+# Make emscripten use Rust's LLVM
+echo "LLVM_ROOT='/checkout/obj/build/x86_64-unknown-linux-gnu/llvm/bin'" >> /root/.emscripten
 
 # Make emsdk usable by any user
 cp /root/.emscripten /emsdk-portable

--- a/src/ci/docker/scripts/emscripten.sh
+++ b/src/ci/docker/scripts/emscripten.sh
@@ -27,14 +27,34 @@ exit 1
   set -x
 }
 
+# Download emsdk
 cd /
 curl -L https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz | \
     tar -xz
+
+# Download last known good emscripten from WebAssembly waterfall
+BUILD=$(curl -L https://storage.googleapis.com/wasm-llvm/builds/linux/lkgr.json | \
+    jq '.build | tonumber')
+curl -L https://storage.googleapis.com/wasm-llvm/builds/linux/$BUILD/wasm-binaries.tbz2 | \
+    hide_output tar xvkj
+
+# node 8 is required to run wasm
+cd /
+curl -L https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-x64.tar.xz | \
+    tar -xJ
 
 cd /emsdk-portable
 ./emsdk update
 hide_output ./emsdk install sdk-1.37.13-64bit
 ./emsdk activate sdk-1.37.13-64bit
+
+# Make emscripten use wasm-ready node and LLVM tools
+echo "NODE_JS='/node-v8.0.0-linux-x64/bin/node'" >> /root/.emscripten
+echo "LLVM_ROOT='/wasm-install/bin'" >> /root/.emscripten
+
+# Make emsdk usable by any user
+cp /root/.emscripten /emsdk-portable
+chmod a+rxw -R /emsdk-portable
 
 # Compile and cache libc
 source ./emsdk_env.sh
@@ -42,15 +62,3 @@ echo "main(){}" > a.c
 HOME=/emsdk-portable/ emcc a.c
 HOME=/emsdk-portable/ emcc -s WASM=1 a.c
 rm -f a.*
-
-# Make emscripten use Rust's LLVM
-echo "LLVM_ROOT='/checkout/obj/build/x86_64-unknown-linux-gnu/llvm/bin'" >> /root/.emscripten
-
-# Make emsdk usable by any user
-cp /root/.emscripten /emsdk-portable
-chmod a+rxw -R /emsdk-portable
-
-# node 8 is required to run wasm
-cd /
-curl -L https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-x64.tar.xz | \
-    tar -xJ

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -282,6 +282,9 @@ pub struct TargetOptions {
     /// user-defined libraries.
     pub post_link_args: LinkArgs,
 
+    /// Environment variables to be set before invoking the linker.
+    pub link_env: Vec<(String, String)>,
+
     /// Extra arguments to pass to the external assembler (when used)
     pub asm_args: Vec<String>,
 
@@ -451,6 +454,7 @@ impl Default for TargetOptions {
             pre_link_objects_dll: Vec::new(),
             post_link_objects: Vec::new(),
             late_link_args: LinkArgs::new(),
+            link_env: Vec::new(),
             archive_format: "gnu".to_string(),
             custom_unwind_resume: false,
             lib_allocation_crate: "alloc_system".to_string(),

--- a/src/librustc_back/target/wasm32_experimental_emscripten.rs
+++ b/src/librustc_back/target/wasm32_experimental_emscripten.rs
@@ -30,6 +30,7 @@ pub fn target() -> Result<Target, String> {
         // possibly interpret the wasm, and a .wasm file
         exe_suffix: ".js".to_string(),
         linker_is_gnu: true,
+        link_env: vec![("EMCC_WASM_BACKEND".to_string(), "1".to_string())],
         allow_asm: false,
         obj_is_bitcode: true,
         is_like_emscripten: true,

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -785,6 +785,9 @@ fn link_natively(sess: &Session,
     if let Some(args) = sess.target.target.options.post_link_args.get(&flavor) {
         cmd.args(args);
     }
+    for &(ref k, ref v) in &sess.target.target.options.link_env {
+        cmd.env(k, v);
+    }
 
     if sess.opts.debugging_opts.print_link_args {
         println!("{:?}", &cmd);

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1280,12 +1280,6 @@ actual:\n\
         let extra_link_args = vec!["-L".to_owned(),
                                    aux_dir.to_str().unwrap().to_owned()];
 
-        let mut env = self.props.rustc_env.clone();
-        // Tell emscripten to link using libc produced with LLVM backend
-        if self.config.target.contains("wasm32") && self.config.target.contains("experimental") {
-            env.push(("EMCC_WASM_BACKEND".to_string(), "1".to_string()));
-        }
-
         for rel_ab in &self.props.aux_builds {
             let aux_testpaths = self.compute_aux_test_paths(rel_ab);
             let aux_props = self.props.from_aux_file(&aux_testpaths.file,
@@ -1325,7 +1319,7 @@ actual:\n\
             };
             let aux_args = aux_cx.make_compile_args(crate_type, &aux_testpaths.file, aux_output);
             let auxres = aux_cx.compose_and_run(aux_args,
-                                                env.clone(),
+                                                Vec::new(),
                                                 aux_cx.config.compile_lib_path.to_str().unwrap(),
                                                 Some(aux_dir.to_str().unwrap()),
                                                 None);
@@ -1338,7 +1332,7 @@ actual:\n\
         }
 
         self.compose_and_run(args,
-                             env,
+                             self.props.rustc_env.clone(),
                              self.config.compile_lib_path.to_str().unwrap(),
                              Some(aux_dir.to_str().unwrap()),
                              input)

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1280,6 +1280,12 @@ actual:\n\
         let extra_link_args = vec!["-L".to_owned(),
                                    aux_dir.to_str().unwrap().to_owned()];
 
+        let mut env = self.props.rustc_env.clone();
+        // Tell emscripten to link using libc produced with LLVM backend
+        if self.config.target.contains("wasm32") && self.config.target.contains("experimental") {
+            env.push(("EMCC_WASM_BACKEND".to_string(), "1".to_string()));
+        }
+
         for rel_ab in &self.props.aux_builds {
             let aux_testpaths = self.compute_aux_test_paths(rel_ab);
             let aux_props = self.props.from_aux_file(&aux_testpaths.file,
@@ -1319,7 +1325,7 @@ actual:\n\
             };
             let aux_args = aux_cx.make_compile_args(crate_type, &aux_testpaths.file, aux_output);
             let auxres = aux_cx.compose_and_run(aux_args,
-                                                Vec::new(),
+                                                env.clone(),
                                                 aux_cx.config.compile_lib_path.to_str().unwrap(),
                                                 Some(aux_dir.to_str().unwrap()),
                                                 None);
@@ -1332,12 +1338,11 @@ actual:\n\
         }
 
         self.compose_and_run(args,
-                             self.props.rustc_env.clone(),
+                             env,
                              self.config.compile_lib_path.to_str().unwrap(),
                              Some(aux_dir.to_str().unwrap()),
                              input)
     }
-
 
     fn compose_and_run(&self,
                        ProcArgs{ args, prog }: ProcArgs,


### PR DESCRIPTION
This adds the experimental targets option to configure so it can be used
by the builders and changes the wasm32 Dockerfile accordingly. Instead
of using LLVM from the emsdk, the builder's emscripten tools now uses
the Rust in-tree LLVM, since this is the one built with wasm support.