### PR TITLE
Print exception traceback when build fails

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -685,7 +685,8 @@ def main():
             exit_code = e.code
         else:
             exit_code = 1
-            print(e)
+        import traceback
+        traceback.print_exc()
         if not help_triggered:
             print("Build completed unsuccessfully in %s" %
                   format_build_time(time() - start_time))


### PR DESCRIPTION
The background is that we're getting a build failure with no details for ppc64el 1.17, which had been totally fine on a different Debian machine.

https://buildd.debian.org/status/fetch.php?pkg=rustc&arch=ppc64el&ver=1.17.0%2Bdfsg2-6&stamp=1498003106&raw=0

~~~~
configure: configured in release mode. for development consider --enable-debug
configure: 
configure: run `python ./x.py --help`
configure: 
make[1]: Leaving directory '/<<BUILDDIR>>/rustc-1.17.0+dfsg2'
   debian/rules override_dh_auto_build-arch
make[1]: Entering directory '/<<BUILDDIR>>/rustc-1.17.0+dfsg2'
/usr/bin/make -C src/rt/hoedown src/html_blocks.c
make[2]: Entering directory '/<<BUILDDIR>>/rustc-1.17.0+dfsg2/src/rt/hoedown'
gperf -L ANSI-C -N hoedown_find_block_tag -c -C -E -S 1 --ignore-case -m100 html_block_names.gperf > src/html_blocks.c
make[2]: Leaving directory '/<<BUILDDIR>>/rustc-1.17.0+dfsg2/src/rt/hoedown'
./x.py build --config debian/config.toml -v
Build completed unsuccessfully in 0:00:00
~~~~