### PR TITLE
Fix race in test_inherit_env

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1418,6 +1418,15 @@ mod tests {
                 continue
             }
 
+            // `env` tests set and unset randomly generated variables
+            // with names starting with `TEST`. So between variable capture
+            // and process spawn `TEST*` variables can be unset
+            // if `env` tests executed concurrently with this test.
+            // Thus `TEST*` variables must not be checked in this test.
+            if k.starts_with("TEST") {
+                continue;
+            }
+
             // Windows has hidden environment variables whose names start with
             // equals signs (`=`). Those do not show up in the output of the
             // `set` command.


### PR DESCRIPTION
`env` tests set (and unset) randomly generated variables with names
starting with `TEST`. So in `test_inherit_env` between variable
capture and process spawn `TEST*` variables can be unset if `env`
tests executed concurrently.  Thus `TEST*` variables must not be
checked in that test.