### PR TITLE
Impl Clone for DefaultHasher

### DIFF
--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -2384,7 +2384,7 @@ impl BuildHasher for RandomState {
 /// [`Hasher`]: ../../hash/trait.Hasher.html
 #[stable(feature = "hashmap_default_hasher", since = "1.13.0")]
 #[allow(deprecated)]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct DefaultHasher(SipHasher13);
 
 impl DefaultHasher {


### PR DESCRIPTION
It's useful for a hasher to be `Clone`. It's also strange for any type to not be `Clone`. `DefaultHasher` is not meant to be used directly, but being in std it can be useful as a placeholder. I don't see any forward compatibility hazard if the hasher is changed since it's very rare for something to not be `Clone`.