### PR TITLE
Make rustc errors colorful.

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -236,6 +236,15 @@ fn main() {
         }
     }
 
+    let color = match env::var("RUSTC_COLOR") {
+        Ok(s) => usize::from_str(&s).expect("RUSTC_COLOR should be an integer"),
+        Err(_) => 0,
+    };
+
+    if color != 0 {
+        cmd.arg("--color=always");
+    }
+
     if verbose > 1 {
         writeln!(&mut io::stderr(), "rustc command: {:?}", cmd).unwrap();
     }


### PR DESCRIPTION
Rustbuild passes --message-format=json to Cargo to learn about the
dependencies for a given build, which then makes Cargo steal the
stderr/stdout for the compiler process, leading to non colorful output.
To avoid this, detection of stderr being a tty is added to rustbuild,
and an environment variable is used to communicate with the rustc shim.

Fixes https://github.com/rust-lang/rust/issues/42801.

r? @alexcrichton 