### PR TITLE
Pass path to python from bootstrap.py to bootstrap.rs

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -668,6 +668,7 @@ def bootstrap():
     env["BUILD"] = rb.build
     env["SRC"] = rb.rust_root
     env["BOOTSTRAP_PARENT_ID"] = str(os.getpid())
+    env["BOOTSTRAP_PYTHON"] = sys.executable
     run(args, env=env, verbose=rb.verbose)
 
 

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -23,6 +23,7 @@ use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::process::Command;
+use std::path::PathBuf;
 
 use build_helper::output;
 
@@ -86,6 +87,12 @@ pub fn check(build: &mut Build) {
         }
     }
 
+    if build.config.python.is_none() {
+        // set by bootstrap.py
+        if let Some(v) = env::var_os("BOOTSTRAP_PYTHON") {
+            build.config.python = Some(PathBuf::from(v));
+        }
+    }
     if build.config.python.is_none() {
         build.config.python = have_cmd("python2.7".as_ref());
     }


### PR DESCRIPTION
When bootstrap is executed with python not in `$PATH`, (e. g.
`c:\Python27\python.exe x.py test`) bootstrap cannot find python
and crashes.

This commit passes path to python in `BOOTSTRAP_PYTHON` env var.

Fixes #41647.