### PR TITLE
rustbuild: Fix compiler docs yet again

### DIFF
--- a/src/bootstrap/bin/rustdoc.rs
+++ b/src/bootstrap/bin/rustdoc.rs
@@ -41,11 +41,11 @@ fn main() {
         .env(bootstrap::util::dylib_path_var(),
              env::join_paths(&dylib_path).unwrap());
 
-    // Pass the `rustbuild` feature flag to crates which rustbuild is
-    // building. See the comment in bootstrap/lib.rs where this env var is
-    // set for more details.
-    if env::var_os("RUSTBUILD_UNSTABLE").is_some() {
-        cmd.arg("--cfg").arg("rustbuild");
+    // Force all crates compiled by this compiler to (a) be unstable and (b)
+    // allow the `rustc_private` feature to link to other unstable crates
+    // also in the sysroot.
+    if env::var_os("RUSTC_FORCE_UNSTABLE").is_some() {
+        cmd.arg("-Z").arg("force-unstable-if-unmarked");
     }
 
     std::process::exit(match cmd.status() {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -106,7 +106,8 @@ pub fn run_core(search_paths: SearchPaths,
                 input: Input,
                 triple: Option<String>,
                 maybe_sysroot: Option<PathBuf>,
-                allow_warnings: bool) -> (clean::Crate, RenderInfo)
+                allow_warnings: bool,
+                force_unstable_if_unmarked: bool) -> (clean::Crate, RenderInfo)
 {
     // Parse, resolve, and typecheck the given crate.
 
@@ -128,6 +129,10 @@ pub fn run_core(search_paths: SearchPaths,
         // Ensure that rustdoc works even if rustc is feature-staged
         unstable_features: UnstableFeatures::Allow,
         actually_rustdoc: true,
+        debugging_opts: config::DebuggingOptions {
+            force_unstable_if_unmarked: force_unstable_if_unmarked,
+            ..config::basic_debugging_options()
+        },
         ..config::basic_options().clone()
     };
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -410,13 +410,17 @@ where R: 'static + Send, F: 'static + Send + FnOnce(Output) -> R {
     info!("starting to run rustc");
     let display_warnings = matches.opt_present("display-warnings");
 
+    let force_unstable_if_unmarked = matches.opt_strs("Z").iter().any(|x| {
+        *x == "force-unstable-if-unmarked"
+    });
+
     let (tx, rx) = channel();
     rustc_driver::monitor(move || {
         use rustc::session::config::Input;
 
         let (mut krate, renderinfo) =
             core::run_core(paths, cfgs, externs, Input::File(cr), triple, maybe_sysroot,
-                           display_warnings);
+                           display_warnings, force_unstable_if_unmarked);
 
         info!("finished with rustc");
 


### PR DESCRIPTION
Add support for `-Z force-unstable-if-unmarked` to rustdoc.

r? @alexcrichton