### PR TITLE
Fixing basic typos in Doc Comments

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -635,7 +635,7 @@ impl Build {
     }
 
     /// Returns the root output directory for all Cargo output in a given stage,
-    /// running a particular compiler, wehther or not we're building the
+    /// running a particular compiler, whether or not we're building the
     /// standard library, and targeting the specified architecture.
     fn cargo_out(&self,
                  compiler: &Compiler,
@@ -1036,7 +1036,7 @@ impl Build {
 }
 
 impl<'a> Compiler<'a> {
-    /// Creates a new complier for the specified stage/host
+    /// Creates a new compiler for the specified stage/host
     fn new(stage: u32, host: &'a str) -> Compiler<'a> {
         Compiler { stage: stage, host: host }
     }

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -11,7 +11,7 @@
 //! Compilation of native dependencies like LLVM.
 //!
 //! Native projects like LLVM unfortunately aren't suited just yet for
-//! compilation in build scripts that Cargo has. This is because thie
+//! compilation in build scripts that Cargo has. This is because the
 //! compilation takes a *very* long time but also because we don't want to
 //! compile LLVM 3 times as part of a normal bootstrap (we want it cached).
 //!

--- a/src/liballoc/allocator.rs
+++ b/src/liballoc/allocator.rs
@@ -497,7 +497,7 @@ pub unsafe trait Alloc {
     ///   to allocate that block of memory.
     unsafe fn dealloc(&mut self, ptr: *mut u8, layout: Layout);
 
-    /// Allocator-specific method for signalling an out-of-memory
+    /// Allocator-specific method for signaling an out-of-memory
     /// condition.
     ///
     /// `oom` aborts the thread or process, optionally performing
@@ -508,7 +508,7 @@ pub unsafe trait Alloc {
     /// unsatisfied allocation request (signaled by an error such as
     /// `AllocErr::Exhausted`), and wish to abandon computation rather
     /// than attempt to recover locally. Such clients should pass the
-    /// signalling error value back into `oom`, where the allocator
+    /// signaling error value back into `oom`, where the allocator
     /// may incorporate that error value into its diagnostic report
     /// before aborting.
     ///

--- a/src/liballoc/allocator.rs
+++ b/src/liballoc/allocator.rs
@@ -40,7 +40,7 @@ fn size_align<T>() -> (usize, usize) {
 ///
 /// (Note however that layouts are *not* required to have positive
 /// size, even though many allocators require that all memory
-/// requeusts have positive size. A caller to the `Alloc::alloc`
+/// requests have positive size. A caller to the `Alloc::alloc`
 /// method must either ensure that conditions like this are met, or
 /// use specific allocators with looser requirements.)
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -213,7 +213,7 @@ impl Layout {
     ///
     /// Returns `Some((k, offset))`, where `k` is layout of the concatenated
     /// record and `offset` is the relative location, in bytes, of the
-    /// start of the `next` embedded witnin the concatenated record
+    /// start of the `next` embedded within the concatenated record
     /// (assuming that the record itself starts at offset 0).
     ///
     /// On arithmetic overflow, returns `None`.
@@ -266,11 +266,11 @@ impl Layout {
     /// Creates a layout describing the record for `self` followed by
     /// `next` with no additional padding between the two. Since no
     /// padding is inserted, the alignment of `next` is irrelevant,
-    /// and is not incoporated *at all* into the resulting layout.
+    /// and is not incorporated *at all* into the resulting layout.
     ///
     /// Returns `(k, offset)`, where `k` is layout of the concatenated
     /// record and `offset` is the relative location, in bytes, of the
-    /// start of the `next` embedded witnin the concatenated record
+    /// start of the `next` embedded within the concatenated record
     /// (assuming that the record itself starts at offset 0).
     ///
     /// (The `offset` is always the same as `self.size()`; we use this

--- a/src/liballoc/btree/node.rs
+++ b/src/liballoc/btree/node.rs
@@ -132,7 +132,7 @@ impl<K, V> InternalNode<K, V> {
 
 /// An owned pointer to a node. This basically is either `Box<LeafNode<K, V>>` or
 /// `Box<InternalNode<K, V>>`. However, it contains no information as to which of the two types
-/// of nodes is acutally behind the box, and, partially due to this lack of information, has no
+/// of nodes is actually behind the box, and, partially due to this lack of information, has no
 /// destructor.
 struct BoxedNode<K, V> {
     ptr: Unique<LeafNode<K, V>>
@@ -270,7 +270,7 @@ impl<K, V> Root<K, V> {
 // correct variance.
 /// A reference to a node.
 ///
-/// This type has a number of paramaters that controls how it acts:
+/// This type has a number of parameters that controls how it acts:
 /// - `BorrowType`: This can be `Immut<'a>` or `Mut<'a>` for some `'a` or `Owned`.
 ///    When this is `Immut<'a>`, the `NodeRef` acts roughly like `&'a Node`,
 ///    when this is `Mut<'a>`, the `NodeRef` acts roughly like `&'a mut Node`,
@@ -775,7 +775,7 @@ impl<Node: Copy, Type> Clone for Handle<Node, Type> {
 }
 
 impl<Node, Type> Handle<Node, Type> {
-    /// Retrieves the node that contains the edge of key/value pair this handle pointes to.
+    /// Retrieves the node that contains the edge of key/value pair this handle points to.
     pub fn into_node(self) -> Node {
         self.node
     }

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -496,12 +496,12 @@ impl<T, A: Alloc> RawVec<T, A> {
     /// Attempts to ensure that the buffer contains at least enough space to hold
     /// `used_cap + needed_extra_cap` elements. If it doesn't already have
     /// enough capacity, will reallocate in place enough space plus comfortable slack
-    /// space to get amortized `O(1)` behaviour. Will limit this behaviour
+    /// space to get amortized `O(1)` behavior. Will limit this behaviour
     /// if it would needlessly cause itself to panic.
     ///
     /// If `used_cap` exceeds `self.cap()`, this may fail to actually allocate
     /// the requested space. This is not really unsafe, but the unsafe
-    /// code *you* write that relies on the behaviour of this function may break.
+    /// code *you* write that relies on the behavior of this function may break.
     ///
     /// Returns true if the reallocation attempt has succeeded, or false otherwise.
     ///

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -1031,7 +1031,7 @@ unsafe impl<A, B> TrustedLen for Zip<A, B>
 /// Now consider this twist where we add a call to `rev`. This version will
 /// print `('c', 1), ('b', 2), ('a', 3)`. Note that the letters are reversed,
 /// but the values of the counter still go in order. This is because `map()` is
-/// still being called lazilly on each item, but we are popping items off the
+/// still being called lazily on each item, but we are popping items off the
 /// back of the vector now, instead of shifting them from the front.
 ///
 /// ```rust

--- a/src/libcore/iter/traits.rs
+++ b/src/libcore/iter/traits.rs
@@ -362,7 +362,7 @@ pub trait Extend<A> {
 /// In a similar fashion to the [`Iterator`] protocol, once a
 /// `DoubleEndedIterator` returns `None` from a `next_back()`, calling it again
 /// may or may not ever return `Some` again. `next()` and `next_back()` are
-/// interchangable for this purpose.
+/// interchangeable for this purpose.
 ///
 /// [`Iterator`]: trait.Iterator.html
 ///

--- a/src/libcore/num/dec2flt/rawfp.rs
+++ b/src/libcore/num/dec2flt/rawfp.rs
@@ -102,10 +102,10 @@ pub trait RawFloat : Float + Copy + Debug + LowerExp
     /// The number of bits in the exponent.
     const EXP_BITS: u8;
 
-    /// The number of bits in the singificand, *including* the hidden bit.
+    /// The number of bits in the significand, *including* the hidden bit.
     const SIG_BITS: u8;
 
-    /// The number of bits in the singificand, *excluding* the hidden bit.
+    /// The number of bits in the significand, *excluding* the hidden bit.
     const EXPLICIT_SIG_BITS: u8;
 
     /// The maximum legal exponent in fractional representation.
@@ -123,7 +123,7 @@ pub trait RawFloat : Float + Copy + Debug + LowerExp
     /// `MIN_EXP` for integral representation, i.e., with the shift applied.
     const MIN_EXP_INT: i16;
 
-    /// The maximum normalized singificand in integral representation.
+    /// The maximum normalized significand in integral representation.
     const MAX_SIG: u64;
 
     /// The minimal normalized significand in integral representation.

--- a/src/libcore/ops/place.rs
+++ b/src/libcore/ops/place.rs
@@ -59,7 +59,7 @@ pub trait Place<Data: ?Sized> {
 /// or `Copy`, since the `make_place` method takes `self` by value.
 #[unstable(feature = "placement_new_protocol", issue = "27779")]
 pub trait Placer<Data: ?Sized> {
-    /// `Place` is the intermedate agent guarding the
+    /// `Place` is the intermediate agent guarding the
     /// uninitialized state for `Data`.
     type Place: InPlace<Data>;
 

--- a/src/libcore/ops/try.rs
+++ b/src/libcore/ops/try.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-/// A trait for customizing the behaviour of the `?` operator.
+/// A trait for customizing the behavior of the `?` operator.
 ///
 /// A type implementing `Try` is one that has a canonical way to view it
 /// in terms of a success/failure dichotomy.  This trait allows both

--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -1632,7 +1632,7 @@ unsafe fn atomic_xor<T>(dst: *mut T, val: T, order: Ordering) -> T {
 ///
 ///     pub fn lock(&self) {
 ///         while !self.flag.compare_and_swap(false, true, Ordering::Relaxed) {}
-///         // This fence syncronizes-with store in `unlock`.
+///         // This fence synchronizes-with store in `unlock`.
 ///         fence(Ordering::Acquire);
 ///     }
 ///

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -11,7 +11,7 @@
 //! Generate files suitable for use with [Graphviz](http://www.graphviz.org/)
 //!
 //! The `render` function generates output (e.g. an `output.dot` file) for
-//! use with [Graphviz](http://www.graphviz.org/) by walking a labelled
+//! use with [Graphviz](http://www.graphviz.org/) by walking a labeled
 //! graph. (Graphviz can then automatically lay out the nodes and edges
 //! of the graph, and also optionally render the graph as an image or
 //! other [output formats](
@@ -150,7 +150,7 @@
 //!
 //! The output from this example renders four nodes that make up the
 //! Hasse-diagram for the subsets of the set `{x, y}`. Each edge is
-//! labelled with the &sube; character (specified using the HTML character
+//! labeled with the &sube; character (specified using the HTML character
 //! entity `&sube`).
 //!
 //! ```rust
@@ -789,7 +789,7 @@ mod tests {
     }
 
     struct LabelledGraph {
-        /// The name for this graph. Used for labelling generated `digraph`.
+        /// The name for this graph. Used for labeling generated `digraph`.
         name: &'static str,
 
         /// Each node is an index into `node_labels`; these labels are

--- a/src/librand/distributions/gamma.rs
+++ b/src/librand/distributions/gamma.rs
@@ -254,7 +254,7 @@ impl IndependentSample<f64> for ChiSquared {
 
 /// The Fisher F distribution `F(m, n)`.
 ///
-/// This distribution is equivalent to the ratio of two normalised
+/// This distribution is equivalent to the ratio of two normalized
 /// chi-squared distributions, that is, `F(m,n) = (χ²(m)/m) /
 /// (χ²(n)/n)`.
 pub struct FisherF {

--- a/src/librand/isaac.rs
+++ b/src/librand/isaac.rs
@@ -76,7 +76,7 @@ impl IsaacRng {
         rng
     }
 
-    /// Initialises `self`. If `use_rsl` is true, then use the current value
+    /// Initializes `self`. If `use_rsl` is true, then use the current value
     /// of `rsl` as a seed, otherwise construct one algorithmically (not
     /// randomly).
     fn init(&mut self, use_rsl: bool) {
@@ -367,7 +367,7 @@ impl Isaac64Rng {
         rng
     }
 
-    /// Initialises `self`. If `use_rsl` is true, then use the current value
+    /// Initializes `self`. If `use_rsl` is true, then use the current value
     /// of `rsl` as a seed, otherwise construct one algorithmically (not
     /// randomly).
     fn init(&mut self, use_rsl: bool) {

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -180,7 +180,7 @@ pub trait Rng: Sized {
     /// This method does *not* have a requirement to bear any fixed
     /// relationship to the other methods, for example, it does *not*
     /// have to result in the same output as progressively filling
-    /// `dest` with `self.gen::<u8>()`, and any such behaviour should
+    /// `dest` with `self.gen::<u8>()`, and any such behavior should
     /// not be relied upon.
     ///
     /// This method should guarantee that `dest` is entirely filled

--- a/src/librand/reseeding.rs
+++ b/src/librand/reseeding.rs
@@ -24,7 +24,7 @@ pub struct ReseedingRng<R, Rsdr> {
     rng: R,
     generation_threshold: usize,
     bytes_generated: usize,
-    /// Controls the behaviour when reseeding the RNG.
+    /// Controls the behavior when reseeding the RNG.
     pub reseeder: Rsdr,
 }
 

--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -87,7 +87,7 @@ pub enum NestedVisitorMap<'this, 'tcx: 'this> {
     /// Do not visit nested item-like things, but visit nested things
     /// that are inside of an item-like.
     ///
-    /// **This is the most common choice.** A very commmon pattern is
+    /// **This is the most common choice.** A very common pattern is
     /// to use `visit_all_item_likes()` as an outer loop,
     /// and to have the visitor that visits the contents of each item
     /// using this setting.

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -248,7 +248,7 @@ pub struct Map<'hir> {
     pub forest: &'hir Forest,
 
     /// Same as the dep_graph in forest, just available with one fewer
-    /// deref. This is a gratuitious micro-optimization.
+    /// deref. This is a gratuitous micro-optimization.
     pub dep_graph: DepGraph,
 
     /// NodeIds are sequential integers from 0, so we can be

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -658,7 +658,7 @@ impl<'hir> Map<'hir> {
 
     /// Returns the nearest enclosing scope. A scope is an item or block.
     /// FIXME it is not clear to me that all items qualify as scopes - statics
-    /// and associated types probably shouldn't, for example. Behaviour in this
+    /// and associated types probably shouldn't, for example. Behavior in this
     /// regard should be expected to be highly unstable.
     pub fn get_enclosing_scope(&self, id: NodeId) -> Option<NodeId> {
         match self.walk_parent_nodes(id, |node| match *node {

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -497,7 +497,7 @@ impl Crate {
         &self.impl_items[&id]
     }
 
-    /// Visits all items in the crate in some determinstic (but
+    /// Visits all items in the crate in some deterministic (but
     /// unspecified) order. If you just need to process every item,
     /// but don't care about nesting, this method is the best choice.
     ///

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -24,7 +24,7 @@
 //! a span, but also more information so that we can generate a meaningful
 //! error message.
 //!
-//! Having a catalogue of all the different reasons an error can arise is
+//! Having a catalog of all the different reasons an error can arise is
 //! also useful for other reasons, like cross-referencing FAQs etc, though
 //! we are not really taking advantage of this yet.
 //!

--- a/src/librustc/infer/higher_ranked/mod.rs
+++ b/src/librustc/infer/higher_ranked/mod.rs
@@ -616,7 +616,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         (result, map)
     }
 
-    /// Searches the region constriants created since `snapshot` was started
+    /// Searches the region constraints created since `snapshot` was started
     /// and checks to determine whether any of the skolemized regions created
     /// in `skol_map` would "escape" -- meaning that they are related to
     /// other regions in some way. If so, the higher-ranked subtyping doesn't

--- a/src/librustc/infer/resolve.rs
+++ b/src/librustc/infer/resolve.rs
@@ -46,7 +46,7 @@ impl<'a, 'gcx, 'tcx> TypeFolder<'gcx, 'tcx> for OpportunisticTypeResolver<'a, 'g
 }
 
 /// The opportunistic type and region resolver is similar to the
-/// opportunistic type resolver, but also opportunistly resolves
+/// opportunistic type resolver, but also opportunistically resolves
 /// regions. It is useful for canonicalization.
 pub struct OpportunisticTypeAndRegionResolver<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
     infcx: &'a InferCtxt<'a, 'gcx, 'tcx>,

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -76,7 +76,7 @@ pub struct LintStore {
     /// is true if the lint group was added by a plugin.
     lint_groups: FxHashMap<&'static str, (Vec<LintId>, bool)>,
 
-    /// Extra info for future incompatibility lints, descibing the
+    /// Extra info for future incompatibility lints, describing the
     /// issue or RFC that caused the incompatibility.
     future_incompatible: FxHashMap<LintId, FutureIncompatibleInfo>,
 }
@@ -163,7 +163,7 @@ pub struct FutureIncompatibleInfo {
     pub reference: &'static str // e.g., a URL for an issue/PR/RFC or error code
 }
 
-/// The targed of the `by_name` map, which accounts for renaming/deprecation.
+/// The target of the `by_name` map, which accounts for renaming/deprecation.
 enum TargetLint {
     /// A direct lint target
     Id(LintId),

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -72,7 +72,7 @@ use mir::transform::MirSource;
 ///  (M1.): Misc extent of the whole `let a = ...;` statement.
 ///  (M2.): Misc extent of the `f()` expression.
 ///  (M3.): Misc extent of the `f().g(..)` expression.
-///  (M4.): Misc extent of the block labelled `'b:`.
+///  (M4.): Misc extent of the block labeled `'b:`.
 ///  (M5.): Misc extent of the `let x = d();` statement
 ///  (D6.): DestructionScope for temporaries created during M5.
 ///  (R7.): Remainder extent for block `'b:`, stmt 0 (let x = ...).

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -676,7 +676,7 @@ impl<'tcx> Debug for TerminatorKind<'tcx> {
 
 impl<'tcx> TerminatorKind<'tcx> {
     /// Write the "head" part of the terminator; that is, its name and the data it uses to pick the
-    /// successor basic block, if any. The only information not inlcuded is the list of possible
+    /// successor basic block, if any. The only information not included is the list of possible
     /// successors, which may be rendered differently between the text and the graphviz format.
     pub fn fmt_head<W: Write>(&self, fmt: &mut W) -> fmt::Result {
         use self::TerminatorKind::*;

--- a/src/librustc/mir/traversal.rs
+++ b/src/librustc/mir/traversal.rs
@@ -216,7 +216,7 @@ impl<'a, 'tcx> Iterator for Postorder<'a, 'tcx> {
 ///
 /// Reverse postorder is the reverse order of a postorder traversal.
 /// This is different to a preorder traversal and represents a natural
-/// linearisation of control-flow.
+/// linearization of control-flow.
 ///
 /// ```text
 ///

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -108,7 +108,7 @@ pub struct Session {
 
     /// Map from imported macro spans (which consist of
     /// the localized span for the macro body) to the
-    /// macro name and defintion span in the source crate.
+    /// macro name and definition span in the source crate.
     pub imported_macro_spans: RefCell<HashMap<Span, (String, Span)>>,
 
     incr_comp_session: RefCell<IncrCompSession>,

--- a/src/librustc/traits/fulfill.rs
+++ b/src/librustc/traits/fulfill.rs
@@ -43,7 +43,7 @@ pub struct GlobalFulfilledPredicates<'tcx> {
 /// consists of a list of obligations that must be (eventually)
 /// satisfied. The job is to track which are satisfied, which yielded
 /// errors, and which are still pending. At any point, users can call
-/// `select_where_possible`, and the fulfilment context will try to do
+/// `select_where_possible`, and the fulfillment context will try to do
 /// selection, retaining only those obligations that remain
 /// ambiguous. This may be helpful in pushing type inference
 /// along. Once all type inference constraints have been generated, the

--- a/src/librustc/traits/project.rs
+++ b/src/librustc/traits/project.rs
@@ -1362,7 +1362,7 @@ impl<'tcx> ProjectionCache<'tcx> {
     }
 
     /// Try to start normalize `key`; returns an error if
-    /// normalization already occured (this error corresponds to a
+    /// normalization already occurred (this error corresponds to a
     /// cache hit, so it's actually a good thing).
     fn try_start(&mut self, key: ty::ProjectionTy<'tcx>)
                  -> Result<(), ProjectionCacheEntry<'tcx>> {

--- a/src/librustc/traits/specialize/mod.rs
+++ b/src/librustc/traits/specialize/mod.rs
@@ -107,7 +107,7 @@ pub fn translate_substs<'a, 'gcx, 'tcx>(infcx: &InferCtxt<'a, 'gcx, 'tcx>,
 }
 
 /// Given a selected impl described by `impl_data`, returns the
-/// definition and substitions for the method with the name `name`
+/// definition and substitutions for the method with the name `name`
 /// the kind `kind`, and trait method substitutions `substs`, in
 /// that impl, a less specialized impl, or the trait default,
 /// whichever applies.

--- a/src/librustc/traits/specialize/specialization_graph.rs
+++ b/src/librustc/traits/specialize/specialization_graph.rs
@@ -95,7 +95,7 @@ impl<'a, 'gcx, 'tcx> Children {
     }
 
     /// Attempt to insert an impl into this set of children, while comparing for
-    /// specialiation relationships.
+    /// specialization relationships.
     fn insert(&mut self,
               tcx: TyCtxt<'a, 'gcx, 'tcx>,
               impl_def_id: DefId,

--- a/src/librustc/ty/adjustment.rs
+++ b/src/librustc/ty/adjustment.rs
@@ -29,7 +29,7 @@ use ty::subst::Substs;
 /// by `autoref`, to either a raw or borrowed pointer. In these cases unsize is
 /// `false`.
 ///
-/// 2. A thin-to-fat coercon involves unsizing the underlying data. We start
+/// 2. A thin-to-fat coercion involves unsizing the underlying data. We start
 /// with a thin pointer, deref a number of times, unsize the underlying data,
 /// then autoref. The 'unsize' phase may change a fixed length array to a
 /// dynamically sized one, a concrete object to a trait object, or statically

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -536,7 +536,7 @@ pub struct GlobalCtxt<'tcx> {
 
     /// A vector of every trait accessible in the whole crate
     /// (i.e. including those from subcrates). This is used only for
-    /// error reporting, and so is lazily initialised and generally
+    /// error reporting, and so is lazily initialized and generally
     /// shouldn't taint the common path (hence the RefCell).
     pub all_traits: RefCell<Option<Vec<DefId>>>,
 }

--- a/src/librustc/ty/inhabitedness/def_id_forest.rs
+++ b/src/librustc/ty/inhabitedness/def_id_forest.rs
@@ -24,9 +24,9 @@ use ty::{DefId, DefIdTree};
 #[derive(Clone)]
 pub struct DefIdForest {
     /// The minimal set of DefIds required to represent the whole set.
-    /// If A and B are DefIds in the DefIdForest, and A is a desecendant
+    /// If A and B are DefIds in the DefIdForest, and A is a descendant
     /// of B, then only B will be in root_ids.
-    /// We use a SmallVec here because (for its use for cacheing inhabitedness)
+    /// We use a SmallVec here because (for its use for caching inhabitedness)
     /// its rare that this will contain even two ids.
     root_ids: SmallVec<[DefId; 1]>,
 }

--- a/src/librustc/ty/item_path.rs
+++ b/src/librustc/ty/item_path.rs
@@ -125,7 +125,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 
     /// If possible, this pushes a global path resolving to `external_def_id` that is visible
     /// from at least one local module and returns true. If the crate defining `external_def_id` is
-    /// declared with an `extern crate`, the path is guarenteed to use the `extern crate`.
+    /// declared with an `extern crate`, the path is guaranteed to use the `extern crate`.
     pub fn try_push_visible_item_path<T>(self, buffer: &mut T, external_def_id: DefId) -> bool
         where T: ItemPathBuffer
     {

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -741,7 +741,7 @@ pub type Region<'tcx> = &'tcx RegionKind;
 ///
 /// The process of doing that is called "skolemization". The bound regions
 /// are replaced by skolemized markers, which don't satisfy any relation
-/// not explicity provided.
+/// not explicitly provided.
 ///
 /// There are 2 kinds of skolemized regions in rustc: `ReFree` and
 /// `ReSkolemized`. When checking an item's body, `ReFree` is supposed

--- a/src/librustc_borrowck/borrowck/mir/dataflow/impls.rs
+++ b/src/librustc_borrowck/borrowck/mir/dataflow/impls.rs
@@ -211,7 +211,7 @@ impl<'a, 'tcx: 'a> HasMoveData<'tcx> for DefinitelyInitializedLvals<'a, 'tcx> {
 /// you if an l-value *might* be uninitialized at a given point in the
 /// control flow. But `MovingOutStatements` also includes the added
 /// data of *which* particular statement causing the deinitialization
-/// that the borrow checker's error meessage may need to report.
+/// that the borrow checker's error message may need to report.
 #[allow(dead_code)]
 pub struct MovingOutStatements<'a, 'tcx: 'a> {
     tcx: TyCtxt<'a, 'tcx, 'tcx>,

--- a/src/librustc_borrowck/borrowck/mir/dataflow/mod.rs
+++ b/src/librustc_borrowck/borrowck/mir/dataflow/mod.rs
@@ -321,11 +321,11 @@ pub trait BitDenotation {
     /// basic block) according to the effects of evaluating statement.
     ///
     /// This is used, in particular, for building up the
-    /// "transfer-function" represnting the overall-effect of the
+    /// "transfer-function" representing the overall-effect of the
     /// block, represented via GEN and KILL sets.
     ///
     /// The statement is identified as `bb_data[idx_stmt]`, where
-    /// `bb_data` is the sequence of statements identifed by `bb` in
+    /// `bb_data` is the sequence of statements identified by `bb` in
     /// the MIR.
     fn statement_effect(&self,
                         sets: &mut BlockSets<Self::Idx>,
@@ -337,7 +337,7 @@ pub trait BitDenotation {
     /// the terminator.
     ///
     /// This is used, in particular, for building up the
-    /// "transfer-function" represnting the overall-effect of the
+    /// "transfer-function" representing the overall-effect of the
     /// block, represented via GEN and KILL sets.
     ///
     /// The effects applied here cannot depend on which branch the

--- a/src/librustc_borrowck/borrowck/mir/gather_moves.rs
+++ b/src/librustc_borrowck/borrowck/mir/gather_moves.rs
@@ -257,7 +257,7 @@ impl<'a, 'tcx> MoveDataBuilder<'a, 'tcx> {
     /// NOTE: lvalues behind references *do not* get a move path, which is
     /// problematic for borrowck.
     ///
-    /// Maybe we should have seperate "borrowck" and "moveck" modes.
+    /// Maybe we should have separate "borrowck" and "moveck" modes.
     fn move_path_for(&mut self, lval: &Lvalue<'tcx>)
                      -> Result<MovePathIndex, MovePathError>
     {

--- a/src/librustc_data_structures/accumulate_vec.rs
+++ b/src/librustc_data_structures/accumulate_vec.rs
@@ -13,7 +13,7 @@
 //! Space for up to N elements is provided on the stack.  If more elements are collected, Vec is
 //! used to store the values on the heap.
 //!
-//! The N above is determined by Array's implementor, by way of an associatated constant.
+//! The N above is determined by Array's implementor, by way of an associated constant.
 
 use std::ops::{Deref, DerefMut};
 use std::iter::{self, IntoIterator, FromIterator};

--- a/src/librustc_data_structures/ivar.rs
+++ b/src/librustc_data_structures/ivar.rs
@@ -14,7 +14,7 @@ use std::cell::Cell;
 /// A write-once variable. When constructed, it is empty, and
 /// can only be set once.
 ///
-/// Ivars ensure that data that can only be initialised once. A full
+/// Ivars ensure that data that can only be initialized once. A full
 /// implementation is used for concurrency and blocks on a read of an
 /// unfulfilled value. This implementation is more minimal and panics
 /// if you attempt to read the value before it has been set. It is also

--- a/src/librustc_data_structures/small_vec.rs
+++ b/src/librustc_data_structures/small_vec.rs
@@ -14,7 +14,7 @@
 //! used to store the values on the heap. SmallVec is similar to AccumulateVec, but adds
 //! the ability to push elements.
 //!
-//! The N above is determined by Array's implementor, by way of an associatated constant.
+//! The N above is determined by Array's implementor, by way of an associated constant.
 
 use std::ops::{Deref, DerefMut};
 use std::iter::{IntoIterator, FromIterator};

--- a/src/librustc_data_structures/stable_hasher.rs
+++ b/src/librustc_data_structures/stable_hasher.rs
@@ -193,7 +193,7 @@ impl<W> Hasher for StableHasher<W> {
 
 
 /// Something that implements `HashStable<CTX>` can be hashed in a way that is
-/// stable across multiple compiliation sessions.
+/// stable across multiple compilation sessions.
 pub trait HashStable<CTX> {
     fn hash_stable<W: StableHasherResult>(&self,
                                           hcx: &mut CTX,

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -277,7 +277,7 @@ pub fn source_name(input: &Input) -> String {
     }
 }
 
-/// CompileController is used to customise compilation, it allows compilation to
+/// CompileController is used to customize compilation, it allows compilation to
 /// be stopped and/or to call arbitrary code at various points in compilation.
 /// It also allows for various flags to be set to influence what information gets
 /// collected during compilation.

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -93,9 +93,9 @@ impl Diagnostic {
     }
 
     /// Cancel the diagnostic (a structured diagnostic must either be emitted or
-    /// cancelled or it will panic when dropped).
+    /// canceled or it will panic when dropped).
     /// BEWARE: if this DiagnosticBuilder is an error, then creating it will
-    /// bump the error count on the Handler and cancelling it won't undo that.
+    /// bump the error count on the Handler and canceling it won't undo that.
     /// If you want to decrement the error count you should use `Handler::cancel`.
     pub fn cancel(&mut self) {
         self.level = Level::Cancelled;

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -192,7 +192,7 @@ impl<'a> Debug for DiagnosticBuilder<'a> {
     }
 }
 
-/// Destructor bomb - a `DiagnosticBuilder` must be either emitted or cancelled
+/// Destructor bomb - a `DiagnosticBuilder` must be either emitted or canceled
 /// or we emit a bug.
 impl<'a> Drop for DiagnosticBuilder<'a> {
     fn drop(&mut self) {

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -805,7 +805,7 @@ impl EmitterWriter {
             .map(|_| " ")
             .collect::<String>();
 
-        /// Return wether `style`, or the override if present and the style is `NoStyle`.
+        /// Return whether `style`, or the override if present and the style is `NoStyle`.
         fn style_or_override(style: Style, override_style: Option<Style>) -> Style {
             if let Some(o) = override_style {
                 if style == Style::NoStyle {

--- a/src/librustc_errors/snippet.rs
+++ b/src/librustc_errors/snippet.rs
@@ -141,7 +141,7 @@ pub struct Annotation {
 }
 
 impl Annotation {
-    /// Wether this annotation is a vertical line placeholder.
+    /// Whether this annotation is a vertical line placeholder.
     pub fn is_line(&self) -> bool {
         if let AnnotationType::MultilineLine(_) = self.annotation_type {
             true

--- a/src/librustc_incremental/persist/preds/compress/construct.rs
+++ b/src/librustc_incremental/persist/preds/compress/construct.rs
@@ -14,7 +14,7 @@
 //! representation of the DAG):
 //!
 //! - SCCs, in the form of a union-find repr that can convert each node to
-//!   its *cycle head* (an arbitrarly chosen representative from the cycle)
+//!   its *cycle head* (an arbitrarily chosen representative from the cycle)
 //! - a vector of *leaf nodes*, just a convenience
 //! - a vector of *parents* for each node (in some cases, nodes have no parents,
 //!   or their parent is another member of same cycle; in that case, the vector

--- a/src/librustc_mir/build/scope.rs
+++ b/src/librustc_mir/build/scope.rs
@@ -112,7 +112,7 @@ pub struct Scope<'tcx> {
     /// for unwinding, for several reasons:
     ///  * clang doesn't emit llvm.lifetime.end for C++ unwinding
     ///  * LLVM's memory dependency analysis can't handle it atm
-    ///  * pollutting the cleanup MIR with StorageDead creates
+    ///  * polluting the cleanup MIR with StorageDead creates
     ///    landing pads even though there's no actual destructors
     ///  * freeing up stack space has no effect during unwinding
     pub(super) needs_cleanup: bool,

--- a/src/librustc_mir/hair/mod.rs
+++ b/src/librustc_mir/hair/mod.rs
@@ -80,7 +80,7 @@ pub enum StmtKind<'tcx> {
 
 /// The Hair trait implementor translates their expressions (`&'tcx H::Expr`)
 /// into instances of this `Expr` enum. This translation can be done
-/// basically as lazilly or as eagerly as desired: every recursive
+/// basically as lazily or as eagerly as desired: every recursive
 /// reference to an expression in this enum is an `ExprRef<'tcx>`, which
 /// may in turn be another instance of this enum (boxed), or else an
 /// untranslated `&'tcx H::Expr`. Note that instances of `Expr` are very

--- a/src/librustc_mir/transform/erase_regions.rs
+++ b/src/librustc_mir/transform/erase_regions.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! This pass erases all early-bound regions from the types occuring in the MIR.
+//! This pass erases all early-bound regions from the types occurring in the MIR.
 //! We want to do this once just before trans, so trans does not have to take
 //! care erasing regions all over the place.
 

--- a/src/librustc_trans/attributes.rs
+++ b/src/librustc_trans/attributes.rs
@@ -46,7 +46,7 @@ pub fn unwind(val: ValueRef, can_unwind: bool) {
     Attribute::NoUnwind.toggle_llfn(Function, val, !can_unwind);
 }
 
-/// Tell LLVM whether it should optimise function for size.
+/// Tell LLVM whether it should optimize function for size.
 #[inline]
 #[allow(dead_code)] // possibly useful function
 pub fn set_optimize_for_size(val: ValueRef, optimize: bool) {

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -645,7 +645,7 @@ pub fn set_link_section(ccx: &CrateContext,
     }
 }
 
-/// Create the `main` function which will initialise the rust runtime and call
+/// Create the `main` function which will initialize the rust runtime and call
 /// users main function.
 pub fn maybe_create_entry_wrapper(ccx: &CrateContext) {
     let (main_def_id, span) = match *ccx.sess().entry_fn.borrow() {

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -186,7 +186,7 @@ pub fn compare_simd_types<'a, 'tcx>(
 /// adjustment.
 ///
 /// The `old_info` argument is a bit funny. It is intended for use
-/// in an upcast, where the new vtable for an object will be drived
+/// in an upcast, where the new vtable for an object will be derived
 /// from the old one.
 pub fn unsized_info<'ccx, 'tcx>(ccx: &CrateContext<'ccx, 'tcx>,
                                 source: Ty<'tcx>,

--- a/src/librustc_trans/debuginfo/doc.rs
+++ b/src/librustc_trans/debuginfo/doc.rs
@@ -92,7 +92,7 @@
 //! encounters a recursive reference, it will hit the cache and does not try to
 //! describe the type anew.
 //!
-//! This behaviour is encapsulated in the 'RecursiveTypeDescription' enum,
+//! This behavior is encapsulated in the 'RecursiveTypeDescription' enum,
 //! which represents a kind of continuation, storing all state needed to
 //! continue traversal at the type members after the type has been registered
 //! with the cache. (This implementation approach might be a tad over-

--- a/src/librustc_trans/debuginfo/doc.rs
+++ b/src/librustc_trans/debuginfo/doc.rs
@@ -156,13 +156,13 @@
 //! (2) Structs, enums and traits have a multipart identifier
 //!
 //!     (1) The first part is the SVH (strict version hash) of the crate they
-//!          wereoriginally defined in
+//!          were originally defined in
 //!
 //!     (2) The second part is the ast::NodeId of the definition in their
-//!          originalcrate
+//!          original crate
 //!
 //!     (3) The final part is a concatenation of the type IDs of their concrete
-//!          typearguments if they are generic types.
+//!          type arguments if they are generic types.
 //!
 //! (3) Tuple-, pointer and function types are structurally identified, which
 //!     means that they are equivalent if their component types are equivalent

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -1021,7 +1021,7 @@ impl<'gcx, 'tcx, 'exprs, E> CoerceMany<'gcx, 'tcx, 'exprs, E>
     }
 
     /// Indicates that one of the inputs is a "forced unit". This
-    /// occurs in a case like `if foo { ... };`, where the issing else
+    /// occurs in a case like `if foo { ... };`, where the missing else
     /// generates a "forced unit". Another example is a `loop { break;
     /// }`, where the `break` has no argument expression. We treat
     /// these cases slightly differently for error-reporting

--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -22,7 +22,7 @@ use util::nodemap::FxHashSet;
 
 use syntax_pos::Span;
 
-/// check_drop_impl confirms that the Drop implementation identfied by
+/// check_drop_impl confirms that the Drop implementation identified by
 /// `drop_impl_did` is not any more specialized than the type it is
 /// attached to (Issue #8142).
 ///

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -167,7 +167,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
     /// `lookup_method_in_trait` is used for overloaded operators.
     /// It does a very narrow slice of what the normal probe/confirm path does.
     /// In particular, it doesn't really do any probing: it simply constructs
-    /// an obligation for aparticular trait with the given self-type and checks
+    /// an obligation for a particular trait with the given self-type and checks
     /// whether that trait is implemented.
     ///
     /// FIXME(#18741) -- It seems likely that we can consolidate some of this

--- a/src/librustc_typeck/constrained_type_params.rs
+++ b/src/librustc_typeck/constrained_type_params.rs
@@ -97,7 +97,7 @@ pub fn identify_constrained_type_params<'tcx>(predicates: &[ty::Predicate<'tcx>]
 
 /// Order the predicates in `predicates` such that each parameter is
 /// constrained before it is used, if that is possible, and add the
-/// paramaters so constrained to `input_parameters`. For example,
+/// parameter so constrained to `input_parameters`. For example,
 /// imagine the following impl:
 ///
 ///     impl<T: Debug, U: Iterator<Item=T>> Trait for U

--- a/src/librustc_typeck/variance/constraints.rs
+++ b/src/librustc_typeck/variance/constraints.rs
@@ -53,7 +53,7 @@ pub struct Constraint<'a> {
     pub variance: &'a VarianceTerm<'a>,
 }
 
-/// To build constriants, we visit one item (type, trait) at a time
+/// To build constraints, we visit one item (type, trait) at a time
 /// and look at its contents. So e.g. if we have
 ///
 ///     struct Foo<T> {

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -106,7 +106,7 @@ pub enum Class {
 }
 
 /// Trait that controls writing the output of syntax highlighting. Users should
-/// implement this trait to customise writing output.
+/// implement this trait to customize writing output.
 ///
 /// The classifier will call into the `Writer` implementation as it finds spans
 /// of text to highlight. Exactly how that text should be highlighted is up to

--- a/src/librustdoc/html/toc.rs
+++ b/src/librustdoc/html/toc.rs
@@ -95,7 +95,7 @@ impl TocBuilder {
     /// self.top_level, D is in C.children, and C, E, F, G are in
     /// self.chain.
     ///
-    /// When we attempt to push H, we realise that first G is not the
+    /// When we attempt to push H, we realize that first G is not the
     /// parent (level is too high) so it is popped from chain and put
     /// into F.children, then F isn't the parent (level is equal, aka
     /// sibling), so it's also popped and put into E.children.

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -398,7 +398,7 @@ pub fn main_args(args: &[String]) -> isize {
     })
 }
 
-/// Prints an uniformised error message on the standard error output
+/// Prints an uniformized error message on the standard error output
 fn print_error<T>(error_message: T) where T: Display {
     writeln!(
         &mut io::stderr(),

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -834,7 +834,7 @@ impl CStr {
     ///
     /// It is your responsibility to make sure that the underlying memory is not
     /// freed too early. For example, the following code will cause undefined
-    /// behaviour when `ptr` is used inside the `unsafe` block:
+    /// behavior when `ptr` is used inside the `unsafe` block:
     ///
     /// ```no_run
     /// use std::ffi::{CString};

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -123,7 +123,7 @@ impl OsString {
 
     /// Creates a new `OsString` with the given capacity.
     ///
-    /// The string will be able to hold exactly `capacity` lenth units of other
+    /// The string will be able to hold exactly `capacity` length units of other
     /// OS strings without reallocating. If `capacity` is 0, the string will not
     /// allocate.
     ///

--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -333,7 +333,7 @@ impl TcpStream {
         self.0.write_timeout()
     }
 
-    /// Receives data on the socket from the remote adress to which it is
+    /// Receives data on the socket from the remote address to which it is
     /// connected, without removing that data from the queue. On success,
     /// returns the number of bytes peeked.
     ///

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -622,7 +622,7 @@ impl UdpSocket {
         self.0.recv(buf)
     }
 
-    /// Receives data on the socket from the remote adress to which it is
+    /// Receives data on the socket from the remote address to which it is
     /// connected, without removing that data from the queue. On success,
     /// returns the number of bytes peeked.
     ///

--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -37,7 +37,7 @@ pub use panicking::{take_hook, set_hook, PanicInfo, Location};
 /// In Rust a function can "return" early if it either panics or calls a
 /// function which transitively panics. This sort of control flow is not always
 /// anticipated, and has the possibility of causing subtle bugs through a
-/// combination of two cricial components:
+/// combination of two crucial components:
 ///
 /// 1. A data structure is in a temporarily invalid state when the thread
 ///    panics.

--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -171,7 +171,7 @@ pub fn take_hook() -> Box<Fn(&PanicInfo) + 'static + Sync + Send> {
 /// use std::panic;
 ///
 /// panic::set_hook(Box::new(|panic_info| {
-///     println!("panic occured: {:?}", panic_info.payload().downcast_ref::<&str>().unwrap());
+///     println!("panic occurred: {:?}", panic_info.payload().downcast_ref::<&str>().unwrap());
 /// }));
 ///
 /// panic!("Normal panic");
@@ -196,7 +196,7 @@ impl<'a> PanicInfo<'a> {
     /// use std::panic;
     ///
     /// panic::set_hook(Box::new(|panic_info| {
-    ///     println!("panic occured: {:?}", panic_info.payload().downcast_ref::<&str>().unwrap());
+    ///     println!("panic occurred: {:?}", panic_info.payload().downcast_ref::<&str>().unwrap());
     /// }));
     ///
     /// panic!("Normal panic");
@@ -221,9 +221,9 @@ impl<'a> PanicInfo<'a> {
     ///
     /// panic::set_hook(Box::new(|panic_info| {
     ///     if let Some(location) = panic_info.location() {
-    ///         println!("panic occured in file '{}' at line {}", location.file(), location.line());
+    ///         println!("panic occurred in file '{}' at line {}", location.file(), location.line());
     ///     } else {
-    ///         println!("panic occured but can't get location information...");
+    ///         println!("panic occurred but can't get location information...");
     ///     }
     /// }));
     ///
@@ -249,9 +249,9 @@ impl<'a> PanicInfo<'a> {
 ///
 /// panic::set_hook(Box::new(|panic_info| {
 ///     if let Some(location) = panic_info.location() {
-///         println!("panic occured in file '{}' at line {}", location.file(), location.line());
+///         println!("panic occurred in file '{}' at line {}", location.file(), location.line());
 ///     } else {
-///         println!("panic occured but can't get location information...");
+///         println!("panic occurred but can't get location information...");
 ///     }
 /// }));
 ///
@@ -274,9 +274,9 @@ impl<'a> Location<'a> {
     ///
     /// panic::set_hook(Box::new(|panic_info| {
     ///     if let Some(location) = panic_info.location() {
-    ///         println!("panic occured in file '{}'", location.file());
+    ///         println!("panic occurred in file '{}'", location.file());
     ///     } else {
-    ///         println!("panic occured but can't get location information...");
+    ///         println!("panic occurred but can't get location information...");
     ///     }
     /// }));
     ///
@@ -296,9 +296,9 @@ impl<'a> Location<'a> {
     ///
     /// panic::set_hook(Box::new(|panic_info| {
     ///     if let Some(location) = panic_info.location() {
-    ///         println!("panic occured at line {}", location.line());
+    ///         println!("panic occurred at line {}", location.line());
     ///     } else {
-    ///         println!("panic occured but can't get location information...");
+    ///         println!("panic occurred but can't get location information...");
     ///     }
     /// }));
     ///

--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -221,7 +221,8 @@ impl<'a> PanicInfo<'a> {
     ///
     /// panic::set_hook(Box::new(|panic_info| {
     ///     if let Some(location) = panic_info.location() {
-    ///        println!("panic occurred in file '{}' at line {}", location.file(), location.line());
+    ///         println!("panic occurred in file '{}' at line {}", 
+    ///                  location.file(), location.line());
     ///     } else {
     ///         println!("panic occurred but can't get location information...");
     ///     }

--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -221,7 +221,7 @@ impl<'a> PanicInfo<'a> {
     ///
     /// panic::set_hook(Box::new(|panic_info| {
     ///     if let Some(location) = panic_info.location() {
-    ///         println!("panic occurred in file '{}' at line {}", location.file(), location.line());
+    ///        println!("panic occurred in file '{}' at line {}", location.file(), location.line());
     ///     } else {
     ///         println!("panic occurred but can't get location information...");
     ///     }

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -476,7 +476,7 @@ impl<'a> Hash for PrefixComponent<'a> {
 
 /// A single component of a path.
 ///
-/// A `Component` roughtly corresponds to a substring between path separators
+/// A `Component` roughly corresponds to a substring between path separators
 /// (`/` or `\`).
 ///
 /// This `enum` is created by iterating over [`Components`], which in turn is
@@ -571,7 +571,7 @@ impl<'a> AsRef<OsStr> for Component<'a> {
     }
 }
 
-/// An interator over the [`Component`]s of a [`Path`].
+/// An iterator over the [`Component`]s of a [`Path`].
 ///
 /// This `struct` is created by the [`components`] method on [`Path`].
 /// See its documentation for more.
@@ -2018,7 +2018,7 @@ impl Path {
     /// * Repeated separators are ignored, so `a/b` and `a//b` both have
     ///   `a` and `b` as components.
     ///
-    /// * Occurentces of `.` are normalized away, exept if they are at the
+    /// * Occurrences of `.` are normalized away, except if they are at the
     ///   beginning of the path. For example, `a/./b`, `a/b/`, `a/b/.` and
     ///   `a/b` all have `a` and `b` as components, but `./a/b` starts with
     ///   an additional [`CurDir`] component.

--- a/src/libstd/sync/once.rs
+++ b/src/libstd/sync/once.rs
@@ -387,7 +387,7 @@ impl Drop for Finish {
 impl OnceState {
     /// Returns whether the associated [`Once`] has been poisoned.
     ///
-    /// Once an initalization routine for a [`Once`] has panicked it will forever
+    /// Once an initialization routine for a [`Once`] has panicked it will forever
     /// indicate to future forced initialization routines that it is poisoned.
     ///
     /// [`Once`]: struct.Once.html

--- a/src/libstd/sys/redox/args.rs
+++ b/src/libstd/sys/redox/args.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Global initialization and retreival of command line arguments.
+//! Global initialization and retrieval of command line arguments.
 //!
 //! On some platforms these are stored during runtime startup,
 //! and on some they are retrieved from the system on demand.

--- a/src/libstd/sys/redox/ext/fs.rs
+++ b/src/libstd/sys/redox/ext/fs.rs
@@ -114,7 +114,7 @@ pub trait OpenOptionsExt {
     #[stable(feature = "fs_ext", since = "1.1.0")]
     fn mode(&mut self, mode: u32) -> &mut Self;
 
-    /// Pass custom flags to the `flags` agument of `open`.
+    /// Pass custom flags to the `flags` argument of `open`.
     ///
     /// The bits that define the access mode are masked out with `O_ACCMODE`, to
     /// ensure they do not interfere with the access mode set by Rusts options.

--- a/src/libstd/sys/redox/ext/process.rs
+++ b/src/libstd/sys/redox/ext/process.rs
@@ -47,7 +47,7 @@ pub trait CommandExt {
     /// # Notes
     ///
     /// This closure will be run in the context of the child process after a
-    /// `fork`. This primarily means that any modificatons made to memory on
+    /// `fork`. This primarily means that any modifications made to memory on
     /// behalf of this closure will **not** be visible to the parent process.
     /// This is often a very constrained environment where normal operations
     /// like `malloc` or acquiring a mutex are not guaranteed to work (due to

--- a/src/libstd/sys/redox/syscall/call.rs
+++ b/src/libstd/sys/redox/syscall/call.rs
@@ -40,7 +40,7 @@ pub unsafe fn brk(addr: usize) -> Result<usize> {
 ///
 /// * `EACCES` - permission is denied for one of the components of `path`, or `path`
 /// * `EFAULT` - `path` does not point to the process's addressible memory
-/// * `EIO` - an I/O error occured
+/// * `EIO` - an I/O error occurred
 /// * `ENOENT` - `path` does not exit
 /// * `ENOTDIR` - `path` is not a directory
 pub fn chdir(path: &str) -> Result<usize> {
@@ -290,7 +290,7 @@ pub fn waitpid(pid: usize, status: &mut usize, options: usize) -> Result<usize> 
 /// * `EAGAIN` - the file descriptor was opened with `O_NONBLOCK` and writing would block
 /// * `EBADF` - the file descriptor is not valid or is not open for writing
 /// * `EFAULT` - `buf` does not point to the process's addressible memory
-/// * `EIO` - an I/O error occured
+/// * `EIO` - an I/O error occurred
 /// * `ENOSPC` - the device containing the file descriptor has no room for data
 /// * `EPIPE` - the file descriptor refers to a pipe or socket whose reading end is closed
 pub fn write(fd: usize, buf: &[u8]) -> Result<usize> {

--- a/src/libstd/sys/unix/args.rs
+++ b/src/libstd/sys/unix/args.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Global initialization and retreival of command line arguments.
+//! Global initialization and retrieval of command line arguments.
 //!
 //! On some platforms these are stored during runtime startup,
 //! and on some they are retrieved from the system on demand.

--- a/src/libstd/sys/unix/ext/fs.rs
+++ b/src/libstd/sys/unix/ext/fs.rs
@@ -46,7 +46,7 @@ pub trait FileExt {
     ///
     /// The current file cursor is not affected by this function.
     ///
-    /// When writing beyond the end of the file, the file is appropiately
+    /// When writing beyond the end of the file, the file is appropriately
     /// extended and the intermediate bytes are initialized with the value 0.
     ///
     /// Note that similar to `File::write`, it is not an error to return a
@@ -161,7 +161,7 @@ pub trait OpenOptionsExt {
     #[stable(feature = "fs_ext", since = "1.1.0")]
     fn mode(&mut self, mode: u32) -> &mut Self;
 
-    /// Pass custom flags to the `flags` agument of `open`.
+    /// Pass custom flags to the `flags` argument of `open`.
     ///
     /// The bits that define the access mode are masked out with `O_ACCMODE`, to
     /// ensure they do not interfere with the access mode set by Rusts options.

--- a/src/libstd/sys/unix/ext/net.rs
+++ b/src/libstd/sys/unix/ext/net.rs
@@ -327,7 +327,7 @@ impl UnixStream {
     ///
     /// The returned `UnixStream` is a reference to the same stream that this
     /// object references. Both handles will read and write the same stream of
-    /// data, and options set on one stream will be propogated to the other
+    /// data, and options set on one stream will be propagated to the other
     /// stream.
     ///
     /// # Examples
@@ -655,7 +655,7 @@ impl UnixListener {
     /// Accepts a new incoming connection to this listener.
     ///
     /// This function will block the calling thread until a new Unix connection
-    /// is established. When established, the corersponding [`UnixStream`] and
+    /// is established. When established, the corresponding [`UnixStream`] and
     /// the remote peer's address will be returned.
     ///
     /// [`UnixStream`]: ../../../../std/os/unix/net/struct.UnixStream.html

--- a/src/libstd/sys/unix/ext/process.rs
+++ b/src/libstd/sys/unix/ext/process.rs
@@ -47,7 +47,7 @@ pub trait CommandExt {
     /// # Notes
     ///
     /// This closure will be run in the context of the child process after a
-    /// `fork`. This primarily means that any modificatons made to memory on
+    /// `fork`. This primarily means that any modifications made to memory on
     /// behalf of this closure will **not** be visible to the parent process.
     /// This is often a very constrained environment where normal operations
     /// like `malloc` or acquiring a mutex are not guaranteed to work (due to

--- a/src/libstd/sys/windows/ext/fs.rs
+++ b/src/libstd/sys/windows/ext/fs.rs
@@ -66,7 +66,7 @@ pub trait FileExt {
     /// from the current cursor. The current cursor **is** affected by this
     /// function, it is set to the end of the write.
     ///
-    /// When writing beyond the end of the file, the file is appropiately
+    /// When writing beyond the end of the file, the file is appropriately
     /// extended and the intermediate bytes are left uninitialized.
     ///
     /// Note that similar to `File::write`, it is not an error to return a

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -529,7 +529,7 @@ pub fn current() -> Thread {
 /// Thus the pattern of `yield`ing after a failed poll is rather common when
 /// implementing low-level shared resources or synchronization primitives.
 ///
-/// However programmers will usualy prefer to use, [`channel`]s, [`Condvar`]s,
+/// However programmers will usually prefer to use, [`channel`]s, [`Condvar`]s,
 /// [`Mutex`]es or [`join`] for their synchronisation routines, as they avoid
 /// thinking about thread schedulling.
 ///
@@ -893,7 +893,7 @@ struct Inner {
 /// The [`thread::current`] function is available even for threads not spawned
 /// by the APIs of this module.
 ///
-/// There is usualy no need to create a `Thread` struct yourself, one
+/// There is usually no need to create a `Thread` struct yourself, one
 /// should instead use a function like `spawn` to create new threads, see the
 /// docs of [`Builder`] and [`spawn`] for more details.
 ///

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -530,7 +530,7 @@ pub fn current() -> Thread {
 /// implementing low-level shared resources or synchronization primitives.
 ///
 /// However programmers will usually prefer to use, [`channel`]s, [`Condvar`]s,
-/// [`Mutex`]es or [`join`] for their synchronisation routines, as they avoid
+/// [`Mutex`]es or [`join`] for their synchronization routines, as they avoid
 /// thinking about thread schedulling.
 ///
 /// Note that [`channel`]s for example are implemented using this primitive.

--- a/src/libstd/time/mod.rs
+++ b/src/libstd/time/mod.rs
@@ -112,7 +112,7 @@ pub struct Instant(time::Instant);
 ///            println!("{}", elapsed.as_secs());
 ///        }
 ///        Err(e) => {
-///            // an error occured!
+///            // an error occurred!
 ///            println!("Error: {:?}", e);
 ///        }
 ///    }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -547,8 +547,8 @@ pub enum PatKind {
     TupleStruct(Path, Vec<P<Pat>>, Option<usize>),
 
     /// A possibly qualified path pattern.
-    /// Unquailfied path patterns `A::B::C` can legally refer to variants, structs, constants
-    /// or associated constants. Quailfied path patterns `<A>::B::C`/`<A as Trait>::B::C` can
+    /// Unqualified path patterns `A::B::C` can legally refer to variants, structs, constants
+    /// or associated constants. Qualified path patterns `<A>::B::C`/`<A as Trait>::B::C` can
     /// only legally refer to associated constants.
     Path(Option<QSelf>, Path),
 

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -435,7 +435,7 @@ pub fn mk_attr_inner(span: Span, id: AttrId, item: MetaItem) -> Attribute {
     mk_spanned_attr_inner(span, id, item)
 }
 
-/// Returns an innter attribute with the given value and span.
+/// Returns an inner attribute with the given value and span.
 pub fn mk_spanned_attr_inner(sp: Span, id: AttrId, item: MetaItem) -> Attribute {
     Attribute {
         id: id,

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -760,7 +760,7 @@ mod tests {
     }
 
     /// Given a string like " ~~~~~~~~~~~~ ", produces a span
-    /// coverting that range. The idea is that the string has the same
+    /// covering that range. The idea is that the string has the same
     /// length as the input, and we uncover the byte positions.  Note
     /// that this can span lines and so on.
     fn span_from_selection(input: &str, selection: &str) -> Span {
@@ -770,7 +770,7 @@ mod tests {
         Span { lo: BytePos(left_index), hi: BytePos(right_index + 1), ctxt: NO_EXPANSION }
     }
 
-    /// Test span_to_snippet and span_to_lines for a span coverting 3
+    /// Test span_to_snippet and span_to_lines for a span covering 3
     /// lines in the middle of a file.
     #[test]
     fn span_to_snippet_and_lines_spanning_multiple_lines() {

--- a/src/libsyntax/json.rs
+++ b/src/libsyntax/json.rs
@@ -11,7 +11,7 @@
 //! A JSON emitter for errors.
 //!
 //! This works by converting errors to a simplified structural format (see the
-//! structs at the start of the file) and then serialising them. These should
+//! structs at the start of the file) and then serializing them. These should
 //! contain as much information about the error as possible.
 //!
 //! The format of the JSON output should be considered *unstable*. For now the

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1691,7 +1691,7 @@ impl<'a> Parser<'a> {
     ///
     /// Assumes that the leading `<` has been parsed already.
     ///
-    /// Qualifed paths are a part of the universal function call
+    /// Qualified paths are a part of the universal function call
     /// syntax (UFCS).
     ///
     /// `qualified_path = <type [as trait_ref]>::path`

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -23,7 +23,7 @@
 //!   and lifetimes for methods.)
 //! - Additional bounds on the type parameters (`TraitDef.additional_bounds`)
 //!
-//! The most important thing for implementers is the `Substructure` and
+//! The most important thing for implementors is the `Substructure` and
 //! `SubstructureFields` objects. The latter groups 5 possibilities of the
 //! arguments:
 //!

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -304,7 +304,7 @@ impl MultiSpan {
         &self.primary_spans
     }
 
-    /// Replaces all occurances of one Span with another. Used to move Spans in areas that don't
+    /// Replaces all occurrences of one Span with another. Used to move Spans in areas that don't
     /// display well (like std macros). Returns true if replacements occurred.
     pub fn replace(&mut self, before: Span, after: Span) -> bool {
         let mut replacements_occurred = false;


### PR DESCRIPTION
Files checked : *.rs files inside 'src' directory.

Only Doc comments (/// and //!) are fixed.


Note: the non American-English spellings are left unchanged.
