### PR TITLE
Print -Zincremental-info to stderr instead of stdout.

### DIFF
--- a/src/librustc_incremental/persist/file_format.rs
+++ b/src/librustc_incremental/persist/file_format.rs
@@ -117,9 +117,9 @@ fn report_format_mismatch(sess: &Session, file: &Path, message: &str) {
     debug!("read_file: {}", message);
 
     if sess.opts.debugging_opts.incremental_info {
-        println!("incremental: ignoring cache artifact `{}`: {}",
-                 file.file_name().unwrap().to_string_lossy(),
-                 message);
+        eprintln!("incremental: ignoring cache artifact `{}`: {}",
+                  file.file_name().unwrap().to_string_lossy(),
+                  message);
     }
 }
 

--- a/src/librustc_incremental/persist/fs.rs
+++ b/src/librustc_incremental/persist/fs.rs
@@ -435,8 +435,8 @@ fn copy_files(target_dir: &Path,
     }
 
     if print_stats_on_success {
-        println!("incremental: session directory: {} files hard-linked", files_linked);
-        println!("incremental: session directory: {} files copied", files_copied);
+        eprintln!("incremental: session directory: {} files hard-linked", files_linked);
+        eprintln!("incremental: session directory: {} files copied", files_copied);
     }
 
     Ok(files_linked > 0 || files_copied == 0)

--- a/src/librustc_incremental/persist/load.rs
+++ b/src/librustc_incremental/persist/load.rs
@@ -151,8 +151,8 @@ pub fn decode_dep_graph<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
     if prev_commandline_args_hash != tcx.sess.opts.dep_tracking_hash() {
         if tcx.sess.opts.debugging_opts.incremental_info {
-            println!("incremental: completely ignoring cache because of \
-                      differing commandline arguments");
+            eprintln!("incremental: completely ignoring cache because of \
+                       differing commandline arguments");
         }
         // We can't reuse the cache, purge it.
         debug!("decode_dep_graph: differing commandline arg hashes");
@@ -309,8 +309,8 @@ fn reconcile_work_products<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                     all_files_exist = false;
 
                     if tcx.sess.opts.debugging_opts.incremental_info {
-                        println!("incremental: could not find file for up-to-date work product: {}",
-                                 path.display());
+                        eprintln!("incremental: could not find file for \
+                                   up-to-date work product: {}", path.display());
                     }
                 }
             }
@@ -418,10 +418,10 @@ fn process_edge<'a, 'tcx, 'edges>(
                         format!("{:?}", blame)
                     };
 
-                    println!("incremental: module {:?} is dirty because {:?} \
-                              changed or was removed",
-                             wp_id,
-                             blame_str);
+                    eprintln!("incremental: module {:?} is dirty because {:?} \
+                               changed or was removed",
+                              wp_id,
+                              blame_str);
                 }
             }
         }

--- a/src/librustc_incremental/persist/save.rs
+++ b/src/librustc_incremental/persist/save.rs
@@ -47,8 +47,8 @@ pub fn save_dep_graph<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let query = tcx.dep_graph.query();
 
     if tcx.sess.opts.debugging_opts.incremental_info {
-        println!("incremental: {} nodes in dep-graph", query.graph.len_nodes());
-        println!("incremental: {} edges in dep-graph", query.graph.len_edges());
+        eprintln!("incremental: {} nodes in dep-graph", query.graph.len_nodes());
+        eprintln!("incremental: {} edges in dep-graph", query.graph.len_edges());
     }
 
     let mut hcx = HashContext::new(tcx, incremental_hashes_map);
@@ -258,9 +258,9 @@ pub fn encode_dep_graph(tcx: TyCtxt,
     graph.encode(encoder)?;
 
     if tcx.sess.opts.debugging_opts.incremental_info {
-        println!("incremental: {} nodes in reduced dep-graph", graph.nodes.len());
-        println!("incremental: {} edges in serialized dep-graph", graph.edge_list_data.len());
-        println!("incremental: {} hashes in serialized dep-graph", graph.hashes.len());
+        eprintln!("incremental: {} nodes in reduced dep-graph", graph.nodes.len());
+        eprintln!("incremental: {} edges in serialized dep-graph", graph.edge_list_data.len());
+        eprintln!("incremental: {} hashes in serialized dep-graph", graph.hashes.len());
     }
 
     if tcx.sess.opts.debugging_opts.incremental_dump_hash {

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -893,7 +893,7 @@ fn dump_incremental_data(trans: &CrateTranslation) {
             ModuleSource::Translated(..) => (),
         }
     }
-    println!("incremental: re-using {} out of {} modules", reuse, trans.modules.len());
+    eprintln!("incremental: re-using {} out of {} modules", reuse, trans.modules.len());
 }
 
 struct WorkItem {

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -1150,9 +1150,9 @@ pub fn trans_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                     Some(work_product)
                 } else {
                     if scx.sess().opts.debugging_opts.incremental_info {
-                        println!("incremental: CGU `{}` invalidated because of \
-                                  changed partitioning hash.",
-                                 cgu.name());
+                        eprintln!("incremental: CGU `{}` invalidated because of \
+                                   changed partitioning hash.",
+                                   cgu.name());
                     }
                     debug!("trans_reuse_previous_work_products: \
                             not reusing {:?} because hash changed to {:?}",


### PR DESCRIPTION
Fixes #42583.

The [cargo-incremental](https://github.com/nikomatsakis/cargo-incremental) tool probably does not need to be updated. It already merges stdout and stderr before parsing the compiler's output.

r? @alexcrichton 