### PR TITLE
Note different versions of same crate when absolute paths of different types match.

### DIFF
--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -337,9 +337,12 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             if !(did1.is_local() || did2.is_local()) && did1.krate != did2.krate {
                 let exp_path = self.tcx.item_path_str(did1);
                 let found_path = self.tcx.item_path_str(did2);
+                let exp_abs_path = self.tcx.absolute_item_path_str(did1);
+                let found_abs_path = self.tcx.absolute_item_path_str(did2);
                 // We compare strings because DefPath can be different
                 // for imported and non-imported crates
-                if exp_path == found_path {
+                if exp_path == found_path
+                || exp_abs_path == found_abs_path {
                     let crate_name = self.tcx.sess.cstore.crate_name(did1.krate);
                     err.span_note(sp, &format!("Perhaps two different versions \
                                                 of crate `{}` are being used?",

--- a/src/test/run-make/type-mismatch-same-crate-name/Makefile
+++ b/src/test/run-make/type-mismatch-same-crate-name/Makefile
@@ -1,0 +1,19 @@
+-include ../tools.mk
+
+all:
+	# compile two different versions of crateA
+	$(RUSTC) --crate-type=rlib crateA.rs -C metadata=-1 -C extra-filename=-1
+	$(RUSTC) --crate-type=rlib crateA.rs -C metadata=-2 -C extra-filename=-2
+	# make crateB depend on version 1 of crateA
+	$(RUSTC) --crate-type=rlib crateB.rs --extern crateA=$(TMPDIR)/libcrateA-1.rlib
+	# make crateC depend on version 2 of crateA
+	$(RUSTC) crateC.rs --extern crateA=$(TMPDIR)/libcrateA-2.rlib 2>&1 | \
+		grep -z \
+	"mismatched types.*\
+	crateB::try_foo(foo2);.*\
+	expected struct \`crateA::foo::Foo\`, found struct \`crateA::Foo\`.*\
+	different versions of crate \`crateA\`.*\
+	mismatched types.*\
+	crateB::try_bar(bar2);.*\
+	expected trait \`crateA::bar::Bar\`, found trait \`crateA::Bar\`.*\
+	different versions of crate \`crateA\`"

--- a/src/test/run-make/type-mismatch-same-crate-name/Makefile
+++ b/src/test/run-make/type-mismatch-same-crate-name/Makefile
@@ -8,7 +8,7 @@ all:
 	$(RUSTC) --crate-type=rlib crateB.rs --extern crateA=$(TMPDIR)/libcrateA-1.rlib
 	# make crateC depend on version 2 of crateA
 	$(RUSTC) crateC.rs --extern crateA=$(TMPDIR)/libcrateA-2.rlib 2>&1 | \
-		grep -z \
+		tr -d '\r\n' | grep \
 	"mismatched types.*\
 	crateB::try_foo(foo2);.*\
 	expected struct \`crateA::foo::Foo\`, found struct \`crateA::Foo\`.*\

--- a/src/test/run-make/type-mismatch-same-crate-name/crateA.rs
+++ b/src/test/run-make/type-mismatch-same-crate-name/crateA.rs
@@ -1,0 +1,26 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+mod foo {
+    pub struct Foo;
+}
+
+mod bar {
+    pub trait Bar{}
+
+    pub fn bar() -> Box<Bar> {
+        unimplemented!()
+    }
+}
+
+// This makes the publicly accessible path
+// differ from the internal one.
+pub use foo::Foo;
+pub use bar::{Bar, bar};

--- a/src/test/run-make/type-mismatch-same-crate-name/crateB.rs
+++ b/src/test/run-make/type-mismatch-same-crate-name/crateB.rs
@@ -1,0 +1,14 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate crateA;
+
+pub fn try_foo(x: crateA::Foo){}
+pub fn try_bar(x: Box<crateA::Bar>){}

--- a/src/test/run-make/type-mismatch-same-crate-name/crateC.rs
+++ b/src/test/run-make/type-mismatch-same-crate-name/crateC.rs
@@ -1,0 +1,35 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This tests the extra note reported when a type error deals with
+// seemingly identical types.
+// The main use case of this error is when there are two crates
+// (generally different versions of the same crate) with the same name
+// causing a type mismatch.
+
+// The test is nearly the same as the one in
+// compile-fail/type-mismatch-same-crate-name.rs
+// but deals with the case where one of the crates
+// is only introduced as an indirect dependency.
+// and the type is accessed via a reexport.
+// This is similar to how the error can be introduced
+// when using cargo's automatic dependency resolution.
+
+extern crate crateA;
+
+fn main() {
+    let foo2 = crateA::Foo;
+    let bar2 = crateA::bar();
+    {
+        extern crate crateB;
+        crateB::try_foo(foo2);
+        crateB::try_bar(bar2);
+    }
+}


### PR DESCRIPTION
The current check to address #22750 only works when the paths of the mismatched types relative to the current crate are equal, but this does not always work if one of the types is only included through an indirect dependency. If reexports are involved, the indirectly included path can e.g. [contain private modules](https://github.com/rust-lang/rust/issues/22750#issuecomment-302755516).

This PR takes care of these cases by also comparing the *absolute* path, which is equal if the type hasn't moved in the module hierarchy between versions. A more coarse check would be to compare only the crate names instead of full paths, but that might lead to too many false positives.

Additionally, I believe it would be helpful to show where the differing crates came from, i.e. the information in `rustc::middle::cstore::CrateSource`, but I'm not sure yet how to nicely display all of that, so I'm leaving it to a future PR.