### PR TITLE
Saves created temp directory if save-temps option is used.

### DIFF
--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -431,6 +431,10 @@ fn link_binary_output(sess: &Session,
         out_filenames.push(out_filename);
     }
 
+    if sess.opts.cg.save_temps {
+        let _ = tmpdir.into_path();
+    }
+
     out_filenames
 }
 


### PR DESCRIPTION
Should fix #38068.