### PR TITLE
rustdoc: Fix a few issues with associated consts

### DIFF
--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -83,7 +83,8 @@ impl<'a> fold::DocFolder for Stripper<'a> {
             clean::TraitItem(..) | clean::FunctionItem(..) |
             clean::VariantItem(..) | clean::MethodItem(..) |
             clean::ForeignFunctionItem(..) | clean::ForeignStaticItem(..) |
-            clean::ConstantItem(..) | clean::UnionItem(..) => {
+            clean::ConstantItem(..) | clean::UnionItem(..) |
+            clean::AssociatedConstItem(..) => {
                 if i.def_id.is_local() {
                     if !self.access_levels.is_exported(i.def_id) {
                         return None;
@@ -117,8 +118,7 @@ impl<'a> fold::DocFolder for Stripper<'a> {
             // Primitives are never stripped
             clean::PrimitiveItem(..) => {}
 
-            // Associated consts and types are never stripped
-            clean::AssociatedConstItem(..) |
+            // Associated types are never stripped
             clean::AssociatedTypeItem(..) => {}
         }
 

--- a/src/test/rustdoc/assoc-consts.rs
+++ b/src/test/rustdoc/assoc-consts.rs
@@ -16,9 +16,27 @@ pub trait Foo {
     // @has - '//*[@id="associatedconstant.FOO"]' 'const FOO: usize'
     // @has - '//*[@class="docblock"]' 'FOO: usize = 12'
     const FOO: usize = 12;
+    // @has - '//*[@id="associatedconstant.FOO_NO_DEFAULT"]' 'const FOO_NO_DEFAULT: bool'
+    const FOO_NO_DEFAULT: bool;
+    // @!has - FOO_HIDDEN
+    #[doc(hidden)]
+    const FOO_HIDDEN: u8 = 0;
 }
 
 pub struct Bar;
+
+impl Foo for Bar {
+    // @has assoc_consts/struct.Bar.html '//code' 'impl Foo for Bar'
+    // @has - '//*[@id="associatedconstant.FOO"]' 'const FOO: usize'
+    // @has - '//*[@class="docblock"]' 'FOO: usize = 12'
+    const FOO: usize = 12;
+    // @has - '//*[@id="associatedconstant.FOO_NO_DEFAULT"]' 'const FOO_NO_DEFAULT: bool'
+    // @has - '//*[@class="docblock"]' 'FOO_NO_DEFAULT: bool = false'
+    const FOO_NO_DEFAULT: bool = false;
+    // @!has - FOO_HIDDEN
+    #[doc(hidden)]
+    const FOO_HIDDEN: u8 = 0;
+}
 
 impl Bar {
     // @has assoc_consts/struct.Bar.html '//*[@id="associatedconstant.BAR"]' \
@@ -43,4 +61,65 @@ impl Bar {
     //      "const F: fn(_: &(ToString + 'static))"
     // @has - '//*[@class="docblock"]' "F: fn(_: &(ToString + 'static)) = f"
     pub const F: fn(_: &(ToString + 'static)) = f;
+}
+
+impl Bar {
+    // @!has assoc_consts/struct.Bar.html 'BAR_PRIVATE'
+    const BAR_PRIVATE: char = 'a';
+    // @!has assoc_consts/struct.Bar.html 'BAR_HIDDEN'
+    #[doc(hidden)]
+    pub const BAR_HIDDEN: &'static str = "a";
+}
+
+// @has assoc_consts/trait.Qux.html
+pub trait Qux {
+    // @has - '//*[@id="associatedconstant.QUX0"]' 'const QUX0: u8'
+    // @has - '//*[@class="docblock"]' "Docs for QUX0 in trait."
+    /// Docs for QUX0 in trait.
+    const QUX0: u8;
+    // @has - '//*[@id="associatedconstant.QUX1"]' 'const QUX1: i8'
+    // @has - '//*[@class="docblock"]' "Docs for QUX1 in trait."
+    /// Docs for QUX1 in trait.
+    const QUX1: i8;
+    // @has - '//*[@id="associatedconstant.QUX_DEFAULT0"]' 'const QUX_DEFAULT0: u16'
+    // @has - '//*[@class="docblock"]' "QUX_DEFAULT0: u16 = 1"
+    // @has - '//*[@class="docblock"]' "Docs for QUX_DEFAULT0 in trait."
+    /// Docs for QUX_DEFAULT0 in trait.
+    const QUX_DEFAULT0: u16 = 1;
+    // @has - '//*[@id="associatedconstant.QUX_DEFAULT1"]' 'const QUX_DEFAULT1: i16'
+    // @has - '//*[@class="docblock"]' "QUX_DEFAULT1: i16 = 2"
+    // @has - '//*[@class="docblock"]' "Docs for QUX_DEFAULT1 in trait."
+    /// Docs for QUX_DEFAULT1 in trait.
+    const QUX_DEFAULT1: i16 = 2;
+    // @has - '//*[@id="associatedconstant.QUX_DEFAULT2"]' 'const QUX_DEFAULT2: u32'
+    // @has - '//*[@class="docblock"]' "QUX_DEFAULT2: u32 = 3"
+    // @has - '//*[@class="docblock"]' "Docs for QUX_DEFAULT2 in trait."
+    /// Docs for QUX_DEFAULT2 in trait.
+    const QUX_DEFAULT2: u32 = 3;
+}
+
+// @has assoc_consts/struct.Bar.html '//code' 'impl Qux for Bar'
+impl Qux for Bar {
+    // @has - '//*[@id="associatedconstant.QUX0"]' 'const QUX0: u8'
+    // @has - '//*[@class="docblock"]' "QUX0: u8 = 4"
+    // @has - '//*[@class="docblock"]' "Docs for QUX0 in trait."
+    /// Docs for QUX0 in trait.
+    const QUX0: u8 = 4;
+    // @has - '//*[@id="associatedconstant.QUX1"]' 'const QUX1: i8'
+    // @has - '//*[@class="docblock"]' "QUX1: i8 = 5"
+    // @has - '//*[@class="docblock"]' "Docs for QUX1 in impl."
+    /// Docs for QUX1 in impl.
+    const QUX1: i8 = 5;
+    // @has - '//*[@id="associatedconstant.QUX_DEFAULT0"]' 'const QUX_DEFAULT0: u16'
+    // @has - '//*[@class="docblock"]' "QUX_DEFAULT0: u16 = 6"
+    // @has - '//*[@class="docblock"]' "Docs for QUX_DEFAULT0 in trait."
+    const QUX_DEFAULT0: u16 = 6;
+    // @has - '//*[@id="associatedconstant.QUX_DEFAULT1"]' 'const QUX_DEFAULT1: i16'
+    // @has - '//*[@class="docblock"]' "QUX_DEFAULT1: i16 = 7"
+    // @has - '//*[@class="docblock"]' "Docs for QUX_DEFAULT1 in impl."
+    /// Docs for QUX_DEFAULT1 in impl.
+    const QUX_DEFAULT1: i16 = 7;
+    // @has - '//*[@id="associatedconstant.QUX_DEFAULT2"]' 'const QUX_DEFAULT2: u32'
+    // @has - '//*[@class="docblock"]' "QUX_DEFAULT2: u32 = 3"
+    // @has - '//*[@class="docblock"]' "Docs for QUX_DEFAULT2 in trait."
 }


### PR DESCRIPTION
* Make sure private consts are stripped.
* Don't show a code block for the value if there is none.
* Make sure default values are shown in impls.
* Make sure docs from the trait are used if the impl has no docs.