### PR TITLE
Implement `std::ascii::AsciiExt` for `Cow<str>`.

### DIFF
--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -974,21 +974,17 @@ impl<'a> AsciiExt for Cow<'a, str> {
 
     #[inline]
     fn make_ascii_uppercase(&mut self) {
-        // Determine how many of the first N bytes are _not_ lowercase.
-        let num_not_lowercase =
-            self.bytes().take_while(|c| !c.is_ascii_lowercase()).count();
-        // If all the bytes are not lowercase, we don't need to do anything.
-        if num_not_lowercase == self.len() {
-            return;
-        }
-        // At least one character in the string is lowercase, so we'll need to
-        // build a new string.
+        // Determine how position of first lowercase byte.
+        let pos_first_lower = match self.bytes().position(|c| c.is_ascii_lowercase()) {
+            Some(p) => p,
+            None => return,
+        };
         let mut bytes = Vec::with_capacity(self.len());
-        unsafe { bytes.set_len(num_not_lowercase); }
-        bytes.copy_from_slice(&self.as_bytes()[..num_not_lowercase]);
+        unsafe { bytes.set_len(pos_first_lower); }
+        bytes.copy_from_slice(&self.as_bytes()[..pos_first_lower]);
         bytes.extend(
             self.bytes()
-                .skip(num_not_lowercase)
+                .skip(pos_first_lower)
                 .map(|b| b.to_ascii_uppercase()));
         // make_ascii_uppercase() preserves the UTF-8 invariant.
         let s = unsafe { String::from_utf8_unchecked(bytes) };
@@ -997,21 +993,17 @@ impl<'a> AsciiExt for Cow<'a, str> {
 
     #[inline]
     fn make_ascii_lowercase(&mut self) {
-        // Determine how many of the first N bytes are _not_ uppercase.
-        let num_not_uppercase =
-            self.bytes().take_while(|c| !c.is_ascii_uppercase()).count();
-        // If all the bytes are not uppercase, we don't need to do anything.
-        if num_not_uppercase == self.len() {
-            return;
-        }
-        // At least one character in the string is uppercase, so we'll need to
-        // build a new string.
+        // Determine how position of first uppercase byte.
+        let pos_first_lower = match self.bytes().position(|c| c.is_ascii_uppercase()) {
+            Some(p) => p,
+            None => return,
+        };
         let mut bytes = Vec::with_capacity(self.len());
-        unsafe { bytes.set_len(num_not_uppercase); }
-        bytes.copy_from_slice(&self.as_bytes()[..num_not_uppercase]);
+        unsafe { bytes.set_len(pos_first_lower); }
+        bytes.copy_from_slice(&self.as_bytes()[..pos_first_lower]);
         bytes.extend(
             self.bytes()
-                .skip(num_not_uppercase)
+                .skip(pos_first_lower)
                 .map(|b| b.to_ascii_uppercase()));
         // make_ascii_uppercase() preserves the UTF-8 invariant.
         let s = unsafe { String::from_utf8_unchecked(bytes) };

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -974,7 +974,7 @@ impl<'a> AsciiExt for Cow<'a, str> {
 
     #[inline]
     fn make_ascii_uppercase(&mut self) {
-        // Determine how position of first lowercase byte.
+        // Determine position of first lowercase byte.
         let pos_first_lower = match self.bytes().position(|c| c.is_ascii_lowercase()) {
             Some(p) => p,
             None => return,
@@ -993,18 +993,18 @@ impl<'a> AsciiExt for Cow<'a, str> {
 
     #[inline]
     fn make_ascii_lowercase(&mut self) {
-        // Determine how position of first uppercase byte.
-        let pos_first_lower = match self.bytes().position(|c| c.is_ascii_uppercase()) {
+        // Determine position of first uppercase byte.
+        let pos_first_upper = match self.bytes().position(|c| c.is_ascii_uppercase()) {
             Some(p) => p,
             None => return,
         };
         let mut bytes = Vec::with_capacity(self.len());
-        unsafe { bytes.set_len(pos_first_lower); }
-        bytes.copy_from_slice(&self.as_bytes()[..pos_first_lower]);
+        unsafe { bytes.set_len(pos_first_upper); }
+        bytes.copy_from_slice(&self.as_bytes()[..pos_first_upper]);
         bytes.extend(
             self.bytes()
-                .skip(pos_first_lower)
-                .map(|b| b.to_ascii_uppercase()));
+                .skip(pos_first_upper)
+                .map(|b| b.to_ascii_lowercase()));
         // make_ascii_uppercase() preserves the UTF-8 invariant.
         let s = unsafe { String::from_utf8_unchecked(bytes) };
         *self = Cow::Owned(s)

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -959,16 +959,12 @@ impl<'a> AsciiExt for Cow<'a, str> {
 
     #[inline]
     fn to_ascii_uppercase(&self) -> Self::Owned {
-        let mut cow = self.clone();
-        cow.make_ascii_uppercase();
-        cow
+        Cow::Owned((**self).to_ascii_uppercase())
     }
 
     #[inline]
     fn to_ascii_lowercase(&self) -> Self::Owned {
-        let mut cow = self.clone();
-        cow.make_ascii_lowercase();
-        cow
+        Cow::Owned((**self).to_ascii_lowercase())
     }
 
     #[inline]

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -974,7 +974,7 @@ impl<'a> AsciiExt for Cow<'a, str> {
 
     #[inline]
     fn make_ascii_uppercase(&mut self) {
-        // Determine how many bytes are _not_ lowercase.
+        // Determine how many of the first N bytes are _not_ lowercase.
         let num_not_lowercase =
             self.bytes().take_while(|c| !c.is_ascii_lowercase()).count();
         // If all the bytes are not lowercase, we don't need to do anything.


### PR DESCRIPTION
I was in a situation where I wanted to call `make_ascii_uppercase` on a `Cow<str>` and noticed the only way to do that is to clone the data in the `Cow` (I think?).

Opening this a little prematurely to make sure this eligible consideration. If it is, ~i'll need to clean it up a little, fix a but where it doesn't process a byte (see the FIXME), and~ add some tests. Also, if this is desired, I can extend this to work on `Cow<[u8]>`.