### PR TITLE
rustdoc: Don't ICE on `use *;`

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1019,7 +1019,11 @@ impl fmt::Display for clean::Import {
                 }
             }
             clean::Import::Glob(ref src) => {
-                write!(f, "use {}::*;", *src)
+                if src.path.segments.is_empty() {
+                    write!(f, "use *;")
+                } else {
+                    write!(f, "use {}::*;", *src)
+                }
             }
         }
     }

--- a/src/test/rustdoc/issue-42875.rs
+++ b/src/test/rustdoc/issue-42875.rs
@@ -1,0 +1,23 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --no-defaults
+
+#![crate_name = "foo"]
+
+// @has foo/a/index.html '//code' 'use *;'
+mod a {
+    use *;
+}
+
+// @has foo/b/index.html '//code' 'pub use *;'
+pub mod b {
+    pub use *;
+}


### PR DESCRIPTION
Fixes #42875