### PR TITLE
[MSP430] Update LLVM submodule to fix size and alignment of structs.

### DIFF
--- a/src/rustllvm/llvm-rebuild-trigger
+++ b/src/rustllvm/llvm-rebuild-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be (optionally) cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2017-06-19
+2017-06-26


### PR DESCRIPTION
Without this patch the struct
```Rust
#[repr(C)]
struct A {
    a: u8,
}
```
has size 2 and alignment 2.

But MSP430 EABI dictates that such struct should have size 1 and alignment 1.

This pull request also includes changes from https://github.com/rust-lang/rust/pull/42816 because they were merged in llvm earlier.