### PR TITLE
Rebase LLVM on top of LLVM 4.0.1

### DIFF
--- a/src/rustllvm/llvm-rebuild-trigger
+++ b/src/rustllvm/llvm-rebuild-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be (optionally) cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2017-06-19
+2017-06-27


### PR DESCRIPTION
Fixes #42893.

Please don't backport this to beta as-is - I'm not sure I want rust-lang/llvm#84 to sneak to beta before it gets sufficient testing.

r? @alexcrichton 

