### PR TITLE
re-add the call to `super_statement` in EraseRegions

### DIFF
--- a/src/librustc_mir/transform/erase_regions.rs
+++ b/src/librustc_mir/transform/erase_regions.rs
@@ -67,12 +67,13 @@ impl<'a, 'tcx> MutVisitor<'tcx> for EraseRegionsVisitor<'a, 'tcx> {
     }
 
     fn visit_statement(&mut self,
-                       _block: BasicBlock,
+                       block: BasicBlock,
                        statement: &mut Statement<'tcx>,
-                       _location: Location) {
+                       location: Location) {
         if let StatementKind::EndRegion(_) = statement.kind {
             statement.kind = StatementKind::Nop;
         }
+        self.super_statement(block, statement, location);
     }
 }
 

--- a/src/test/run-pass/dynamic-drop.rs
+++ b/src/test/run-pass/dynamic-drop.rs
@@ -106,6 +106,18 @@ fn struct_dynamic_drop(a: &Allocator, c0: bool, c1: bool, c: bool) {
     }
 }
 
+fn field_assignment(a: &Allocator, c0: bool) {
+    let mut x = (TwoPtrs(a.alloc(), a.alloc()), a.alloc());
+
+    x.1 = a.alloc();
+    x.1 = a.alloc();
+
+    let f = (x.0).0;
+    if c0 {
+        (x.0).0 = f;
+    }
+}
+
 fn assignment2(a: &Allocator, c0: bool, c1: bool) {
     let mut _v = a.alloc();
     let mut _w = a.alloc();
@@ -206,6 +218,9 @@ fn main() {
     run_test(|a| struct_dynamic_drop(a, true, false, true));
     run_test(|a| struct_dynamic_drop(a, true, true, false));
     run_test(|a| struct_dynamic_drop(a, true, true, true));
+
+    run_test(|a| field_assignment(a, false));
+    run_test(|a| field_assignment(a, true));
 
     run_test_nopanic(|a| union1(a));
 }


### PR DESCRIPTION
The move gathering code is sensitive to type-equality - that is rather
un-robust and I plan to fix it eventually, but that's a more invasive
change. And we want to fix the visitor anyway.

Fixes #42903.

r? @eddyb 