### PR TITLE
[beta] rebase LLVM on top of 4.0.1

### DIFF
--- a/src/rustllvm/llvm-rebuild-trigger
+++ b/src/rustllvm/llvm-rebuild-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be (optionally) cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2017-06-18
+2017-06-28


### PR DESCRIPTION
This backports fixes several codegen bugs, including #42893.

This also un-commits the introduction of #42750 (the StackColoring improvement) to beta. That seemed to have occurred by accident in #42927, but I'm not comfortable with sneaking a subtle codegen change like this to beta.

r? @alexcrichton 