### PR TITLE
Short-circuit Rc/Arc equality checking on equal pointers where T: Eq

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(specialization)]
 #![stable(feature = "rust1", since = "1.0.0")]
 
 //! Thread-safe reference-counting pointers.
@@ -1018,6 +1019,9 @@ impl<T: ?Sized + PartialEq> PartialEq for Arc<T> {
     ///
     /// Two `Arc`s are equal if their inner values are equal.
     ///
+    /// If `T` also implements `Eq`, two `Arc`s that point to the same value are
+    /// always equal.
+    ///
     /// # Examples
     ///
     /// ```
@@ -1027,13 +1031,16 @@ impl<T: ?Sized + PartialEq> PartialEq for Arc<T> {
     ///
     /// assert!(five == Arc::new(5));
     /// ```
-    fn eq(&self, other: &Arc<T>) -> bool {
+    default fn eq(&self, other: &Arc<T>) -> bool {
         *(*self) == *(*other)
     }
 
     /// Inequality for two `Arc`s.
     ///
     /// Two `Arc`s are unequal if their inner values are unequal.
+    ///
+    /// If `T` also implements `Eq`, two `Arc`s that point to the same value are
+    /// never unequal.
     ///
     /// # Examples
     ///
@@ -1044,8 +1051,21 @@ impl<T: ?Sized + PartialEq> PartialEq for Arc<T> {
     ///
     /// assert!(five != Arc::new(6));
     /// ```
-    fn ne(&self, other: &Arc<T>) -> bool {
+    default fn ne(&self, other: &Arc<T>) -> bool {
         *(*self) != *(*other)
+    }
+}
+#[doc(hidden)]
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T: ?Sized + Eq> PartialEq for Arc<T> {
+    #[inline(always)]
+    fn eq(&self, other: &Arc<T>) -> bool {
+        Arc::ptr_eq(self, other) || *(*self) == *(*other)
+    }
+
+    #[inline(always)]
+    fn ne(&self, other: &Arc<T>) -> bool {
+        !Arc::ptr_eq(self, other) && *(*self) != *(*other)
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(specialization)]
 #![allow(deprecated)]
 
 //! Single-threaded reference-counting pointers. 'Rc' stands for 'Reference
@@ -773,6 +774,9 @@ impl<T: ?Sized + PartialEq> PartialEq for Rc<T> {
     ///
     /// Two `Rc`s are equal if their inner values are equal.
     ///
+    /// If `T` also implements `Eq`, two `Rc`s that point to the same value are
+    /// always equal.
+    ///
     /// # Examples
     ///
     /// ```
@@ -783,13 +787,16 @@ impl<T: ?Sized + PartialEq> PartialEq for Rc<T> {
     /// assert!(five == Rc::new(5));
     /// ```
     #[inline(always)]
-    fn eq(&self, other: &Rc<T>) -> bool {
+    default fn eq(&self, other: &Rc<T>) -> bool {
         **self == **other
     }
 
     /// Inequality for two `Rc`s.
     ///
     /// Two `Rc`s are unequal if their inner values are unequal.
+    ///
+    /// If `T` also implements `Eq`, two `Rc`s that point to the same value are
+    /// never unequal.
     ///
     /// # Examples
     ///
@@ -801,8 +808,22 @@ impl<T: ?Sized + PartialEq> PartialEq for Rc<T> {
     /// assert!(five != Rc::new(6));
     /// ```
     #[inline(always)]
-    fn ne(&self, other: &Rc<T>) -> bool {
+    default fn ne(&self, other: &Rc<T>) -> bool {
         **self != **other
+    }
+}
+
+#[doc(hidden)]
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T: ?Sized + Eq> PartialEq for Rc<T> {
+    #[inline(always)]
+    fn eq(&self, other: &Rc<T>) -> bool {
+        Rc::ptr_eq(self, other) || **self == **other
+    }
+
+    #[inline(always)]
+    fn ne(&self, other: &Rc<T>) -> bool {
+        !Rc::ptr_eq(self, other) && **self != **other
     }
 }
 


### PR DESCRIPTION
Closes #42655

--------------

Some notes:

* Testing this would perhaps be a bunch more involved than the production code itself, so I went without tests for now.
* I'm not sure if comparison functions should short-circuit. For example, `rc1 < rc2` could return `false` if they point to them same object where `T: Eq`. It's perhaps a less clear-cut case than equality checking, so I decided to leave it out. We can always add it later if somebody can make a good argument.
* I found it rather difficult to work on this because `touch src/liballoc/rc.rs && ./x.py test -i src/liballoc --test-args rc::` takes 15 minutes (it recompiles a whole bunch of things after `liballoc`.) Am I doing something wrong?