### PR TITLE
rustbuild: Add a way to build all tools as part of 'x.py build'

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -49,6 +49,7 @@ pub struct Config {
     pub target_config: HashMap<String, Target>,
     pub full_bootstrap: bool,
     pub extended: bool,
+    pub build_all_tools: bool,
     pub sanitizers: bool,
     pub profiler: bool,
 
@@ -162,6 +163,7 @@ struct Build {
     python: Option<String>,
     full_bootstrap: Option<bool>,
     extended: Option<bool>,
+    build_all_tools: Option<bool>,
     verbose: Option<usize>,
     sanitizers: Option<bool>,
     profiler: Option<bool>,
@@ -320,6 +322,7 @@ impl Config {
         set(&mut config.vendor, build.vendor);
         set(&mut config.full_bootstrap, build.full_bootstrap);
         set(&mut config.extended, build.extended);
+        set(&mut config.build_all_tools, build.build_all_tools);
         set(&mut config.verbose, build.verbose);
         set(&mut config.sanitizers, build.sanitizers);
         set(&mut config.profiler, build.profiler);
@@ -482,6 +485,7 @@ impl Config {
                 ("VENDOR", self.vendor),
                 ("FULL_BOOTSTRAP", self.full_bootstrap),
                 ("EXTENDED", self.extended),
+                ("BUILD_ALL_TOOLS", self.build_all_tools),
                 ("SANITIZERS", self.sanitizers),
                 ("PROFILER", self.profiler),
                 ("DIST_SRC", self.rust_dist_src),

--- a/src/bootstrap/config.toml.example
+++ b/src/bootstrap/config.toml.example
@@ -143,11 +143,17 @@
 # option to true.
 #full-bootstrap = false
 
-# Enable a build of the and extended rust tool set which is not only the
-# compiler but also tools such as Cargo. This will also produce "combined
-# installers" which are used to install Rust and Cargo together. This is
+# Enable a build of the extended rust tool set which is not only the
+# compiler but also tools such as Cargo or RLS. This will also produce "combined
+# installers" which are used to install Rust, Cargo and RLS together. This is
 # disabled by default.
 #extended = false
+
+# Build all the tools as part of the "build" phase instead of lazily
+# waiting for those to be needed. This will cause tools such as rust-installer
+# and rustbook to be built early on instead of during installation or
+# documentation generation. This is disabled by default.
+#build-all-tools = false
 
 # Verbosity level: 0 == not verbose, 1 == verbose, 2 == very verbose
 #verbose = 0

--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -541,52 +541,77 @@ pub fn build_rules<'a>(build: &'a Build) -> Rules {
     //
     // Tools used during the build system but not shipped
     rules.build("tool-rustbook", "src/tools/rustbook")
+         .default(build.config.build_all_tools)
+         .host(true)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("librustc-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "rustbook"));
     rules.build("tool-error-index", "src/tools/error_index_generator")
+         .default(build.config.build_all_tools)
+         .host(true)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("librustc-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "error_index_generator"));
     rules.build("tool-unstable-book-gen", "src/tools/unstable-book-gen")
+         .default(build.config.build_all_tools)
+         .host(true)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("libstd-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "unstable-book-gen"));
     rules.build("tool-tidy", "src/tools/tidy")
+         .default(build.config.build_all_tools)
+         .host(true)
+         .only_build(true)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("libstd-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "tidy"));
     rules.build("tool-linkchecker", "src/tools/linkchecker")
+         .default(build.config.build_all_tools)
+         .host(true)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("libstd-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "linkchecker"));
     rules.build("tool-cargotest", "src/tools/cargotest")
+         .default(build.config.build_all_tools)
+         .host(true)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("libstd-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "cargotest"));
     rules.build("tool-compiletest", "src/tools/compiletest")
+         .default(build.config.build_all_tools)
+         .host(true)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("libtest-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "compiletest"));
     rules.build("tool-build-manifest", "src/tools/build-manifest")
+         .default(build.config.build_all_tools)
+         .host(true)
+         .only_build(true)
+         .only_host_build(true)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("libstd-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "build-manifest"));
     rules.build("tool-remote-test-server", "src/tools/remote-test-server")
+         .default(build.config.build_all_tools)
+         .host(true)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("libstd-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "remote-test-server"));
     rules.build("tool-remote-test-client", "src/tools/remote-test-client")
+         .default(build.config.build_all_tools)
+         .host(true)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("libstd-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "remote-test-client"));
     rules.build("tool-rust-installer", "src/tools/rust-installer")
+         .default(build.config.build_all_tools)
+         .host(true)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("libstd-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "rust-installer"));
     rules.build("tool-cargo", "src/tools/cargo")
+         .default(build.config.extended || build.config.build_all_tools)
          .host(true)
-         .default(build.config.extended)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("libstd-tool"))
          .dep(|s| s.stage(0).host(s.target).name("openssl"))
@@ -599,8 +624,8 @@ pub fn build_rules<'a>(build: &'a Build) -> Rules {
          })
          .run(move |s| compile::tool(build, s.stage, s.target, "cargo"));
     rules.build("tool-rls", "src/tools/rls")
+         .default(build.config.extended || build.config.build_all_tools)
          .host(true)
-         .default(build.config.extended)
          .dep(|s| s.name("librustc-tool"))
          .dep(|s| s.stage(0).host(s.target).name("openssl"))
          .dep(move |s| {

--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -543,18 +543,21 @@ pub fn build_rules<'a>(build: &'a Build) -> Rules {
     rules.build("tool-rustbook", "src/tools/rustbook")
          .default(build.config.build_all_tools)
          .host(true)
+         .only_stage(0)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("librustc-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "rustbook"));
     rules.build("tool-error-index", "src/tools/error_index_generator")
          .default(build.config.build_all_tools)
          .host(true)
+         .only_stage(0)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("librustc-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "error_index_generator"));
     rules.build("tool-unstable-book-gen", "src/tools/unstable-book-gen")
          .default(build.config.build_all_tools)
          .host(true)
+         .only_stage(0)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("libstd-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "unstable-book-gen"));
@@ -562,24 +565,28 @@ pub fn build_rules<'a>(build: &'a Build) -> Rules {
          .default(build.config.build_all_tools)
          .host(true)
          .only_build(true)
+         .only_stage(0)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("libstd-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "tidy"));
     rules.build("tool-linkchecker", "src/tools/linkchecker")
          .default(build.config.build_all_tools)
          .host(true)
+         .only_stage(0)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("libstd-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "linkchecker"));
     rules.build("tool-cargotest", "src/tools/cargotest")
          .default(build.config.build_all_tools)
          .host(true)
+         .only_stage(0)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("libstd-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "cargotest"));
     rules.build("tool-compiletest", "src/tools/compiletest")
          .default(build.config.build_all_tools)
          .host(true)
+         .only_stage(0)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("libtest-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "compiletest"));
@@ -588,6 +595,7 @@ pub fn build_rules<'a>(build: &'a Build) -> Rules {
          .host(true)
          .only_build(true)
          .only_host_build(true)
+         .only_stage(0)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("libstd-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "build-manifest"));
@@ -600,12 +608,14 @@ pub fn build_rules<'a>(build: &'a Build) -> Rules {
     rules.build("tool-remote-test-client", "src/tools/remote-test-client")
          .default(build.config.build_all_tools)
          .host(true)
+         .only_stage(0)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("libstd-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "remote-test-client"));
     rules.build("tool-rust-installer", "src/tools/rust-installer")
          .default(build.config.build_all_tools)
          .host(true)
+         .only_stage(0)
          .dep(|s| s.name("maybe-clean-tools"))
          .dep(|s| s.name("libstd-tool"))
          .run(move |s| compile::tool(build, s.stage, s.target, "rust-installer"));
@@ -980,6 +990,9 @@ struct Rule<'a> {
     /// targets.
     only_build: bool,
 
+    /// Whether this rule is only built for one stage (usually stage 0).
+    only_stage: Option<u32>,
+
     /// A list of "order only" dependencies. This rules does not actually
     /// depend on these rules, but if they show up in the dependency graph then
     /// this rule must be executed after all these rules.
@@ -1008,6 +1021,7 @@ impl<'a> Rule<'a> {
             host: false,
             only_host_build: false,
             only_build: false,
+            only_stage: None,
             after: Vec::new(),
         }
     }
@@ -1057,6 +1071,11 @@ impl<'a, 'b> RuleBuilder<'a, 'b> {
 
     fn only_host_build(&mut self, only_host_build: bool) -> &mut Self {
         self.rule.only_host_build = only_host_build;
+        self
+    }
+
+    fn only_stage(&mut self, stage: u32) -> &mut Self {
+        self.rule.only_stage = Some(stage);
         self
     }
 }
@@ -1225,6 +1244,7 @@ invalid rule dependency graph detected, was a rule added and maybe typo'd?
             Subcommand::Install { ref paths } => (Kind::Install, &paths[..]),
             Subcommand::Clean => panic!(),
         };
+        let current_stage = self.sbuild.stage;
 
         let mut rules: Vec<_> = self.rules.values().filter_map(|rule| {
             if rule.kind != kind {
@@ -1278,7 +1298,10 @@ invalid rule dependency graph detected, was a rule added and maybe typo'd?
 
             hosts.iter().flat_map(move |host| {
                 arr.iter().map(move |target| {
-                    self.sbuild.name(rule.name).target(target).host(host)
+                    self.sbuild.name(rule.name)
+                               .target(target)
+                               .host(host)
+                               .stage(rule.only_stage.unwrap_or(current_stage))
                 })
             })
         }).collect()


### PR DESCRIPTION
With these two patches and the feature turned on, running `./x.py install` after `./x.py build` doesn't need to compile anything. Only the doc/dist/install steps are actually doing something.