### PR TITLE
rustc_llvm: re-run build script when env var LLVM_CONFIG changes

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -276,10 +276,6 @@ pub fn rustc(build: &Build, target: &str, compiler: &Compiler) {
     if build.is_rust_llvm(target) {
         cargo.env("LLVM_RUSTLLVM", "1");
     }
-    if let Some(ref cfg_file) = build.flags.config {
-        let cfg_path = t!(PathBuf::from(cfg_file).canonicalize());
-        cargo.env("CFG_LLVM_TOML", cfg_path.into_os_string());
-    }
     cargo.env("LLVM_CONFIG", build.llvm_config(target));
     let target_config = build.config.target_config.get(target);
     if let Some(s) = target_config.and_then(|c| c.llvm_config.as_ref()) {

--- a/src/librustc_asan/build.rs
+++ b/src/librustc_asan/build.rs
@@ -32,4 +32,5 @@ fn main() {
             .build_target("asan")
             .build();
     }
+    println!("cargo:rerun-if-env-changed=LLVM_CONFIG");
 }

--- a/src/librustc_llvm/build.rs
+++ b/src/librustc_llvm/build.rs
@@ -60,11 +60,7 @@ fn main() {
         });
 
     println!("cargo:rerun-if-changed={}", llvm_config.display());
-
-    if let Some(cfg_toml) = env::var_os("CFG_LLVM_TOML") {
-        let cfg_path = PathBuf::from(cfg_toml);
-        println!("cargo:rerun-if-changed={}", cfg_path.display());
-    }
+    println!("cargo:rerun-if-env-changed=LLVM_CONFIG");
 
     // Test whether we're cross-compiling LLVM. This is a pretty rare case
     // currently where we're producing an LLVM for a different platform than

--- a/src/librustc_lsan/build.rs
+++ b/src/librustc_lsan/build.rs
@@ -32,4 +32,5 @@ fn main() {
             .build_target("lsan")
             .build();
     }
+    println!("cargo:rerun-if-env-changed=LLVM_CONFIG");
 }

--- a/src/librustc_msan/build.rs
+++ b/src/librustc_msan/build.rs
@@ -32,4 +32,5 @@ fn main() {
             .build_target("msan")
             .build();
     }
+    println!("cargo:rerun-if-env-changed=LLVM_CONFIG");
 }

--- a/src/librustc_tsan/build.rs
+++ b/src/librustc_tsan/build.rs
@@ -32,4 +32,5 @@ fn main() {
             .build_target("tsan")
             .build();
     }
+    println!("cargo:rerun-if-env-changed=LLVM_CONFIG");
 }


### PR DESCRIPTION
This removes the changes done in #42429 and use the newly introduced `cargo:rerun-if-env-changed` in https://github.com/rust-lang/cargo/pull/4125.
As `LLVM_CONFIG` env var points to the `llvm-config` and changes when it gets configured in `config.toml` or removed from it, we can re-run the build script if this env var changes.

closes #42444 

r? @alexcrichton