### PR TITLE
Add .editorconfig to src/rustllvm

### DIFF
--- a/src/rustllvm/.editorconfig
+++ b/src/rustllvm/.editorconfig
@@ -1,0 +1,6 @@
+[*.{h,cpp}]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
... which uses 2 space indent instead of common 4 spaces.