### PR TITLE
[libstd_unicode] Change UNICODE_VERSION to use u32

### DIFF
--- a/src/libstd_unicode/tables.rs
+++ b/src/libstd_unicode/tables.rs
@@ -12,9 +12,32 @@
 
 #![allow(missing_docs, non_upper_case_globals, non_snake_case)]
 
-/// The version of [Unicode](http://www.unicode.org/)
-/// that the unicode parts of `CharExt` and `UnicodeStrPrelude` traits are based on.
-pub const UNICODE_VERSION: (u32, u32, u32) = (10, 0, 0);
+/// Represents a Unicode Version.
+///
+/// See also: <http://www.unicode.org/versions/>
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct UnicodeVersion {
+    /// Major version.
+    pub major: u32,
+
+    /// Minor version.
+    pub minor: u32,
+
+    /// Micro (or Update) version.
+    pub micro: u32,
+
+    // Private field to keep struct expandable.
+    _priv: (),
+}
+
+/// The version of [Unicode](http://www.unicode.org/) that the Unicode parts of
+/// `CharExt` and `UnicodeStrPrelude` traits are based on.
+pub const UNICODE_VERSION: UnicodeVersion = UnicodeVersion {
+    major: 10,
+    minor: 0,
+    micro: 0,
+    _priv: (),
+};
 
 
 // BoolTrie is a trie for representing a set of Unicode codepoints. It is

--- a/src/libstd_unicode/tables.rs
+++ b/src/libstd_unicode/tables.rs
@@ -14,7 +14,7 @@
 
 /// The version of [Unicode](http://www.unicode.org/)
 /// that the unicode parts of `CharExt` and `UnicodeStrPrelude` traits are based on.
-pub const UNICODE_VERSION: (u64, u64, u64) = (10, 0, 0);
+pub const UNICODE_VERSION: (u32, u32, u32) = (10, 0, 0);
 
 
 // BoolTrie is a trie for representing a set of Unicode codepoints. It is

--- a/src/libstd_unicode/unicode.py
+++ b/src/libstd_unicode/unicode.py
@@ -562,7 +562,7 @@ if __name__ == "__main__":
         rf.write("""
 /// The version of [Unicode](http://www.unicode.org/)
 /// that the unicode parts of `CharExt` and `UnicodeStrPrelude` traits are based on.
-pub const UNICODE_VERSION: (u64, u64, u64) = (%s, %s, %s);
+pub const UNICODE_VERSION: (u32, u32, u32) = (%s, %s, %s);
 """ % unicode_version)
         (canon_decomp, compat_decomp, gencats, combines,
                 to_upper, to_lower, to_title) = load_unicode_data("UnicodeData.txt")

--- a/src/libstd_unicode/unicode.py
+++ b/src/libstd_unicode/unicode.py
@@ -560,9 +560,32 @@ if __name__ == "__main__":
             pattern = "for Version (\d+)\.(\d+)\.(\d+) of the Unicode"
             unicode_version = re.search(pattern, readme.read()).groups()
         rf.write("""
-/// The version of [Unicode](http://www.unicode.org/)
-/// that the unicode parts of `CharExt` and `UnicodeStrPrelude` traits are based on.
-pub const UNICODE_VERSION: (u32, u32, u32) = (%s, %s, %s);
+/// Represents a Unicode Version.
+///
+/// See also: <http://www.unicode.org/versions/>
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct UnicodeVersion {
+    /// Major version.
+    pub major: u32,
+
+    /// Minor version.
+    pub minor: u32,
+
+    /// Micro (or Update) version.
+    pub micro: u32,
+
+    // Private field to keep struct expandable.
+    _priv: (),
+}
+
+/// The version of [Unicode](http://www.unicode.org/) that the Unicode parts of
+/// `CharExt` and `UnicodeStrPrelude` traits are based on.
+pub const UNICODE_VERSION: UnicodeVersion = UnicodeVersion {
+    major: %s,
+    minor: %s,
+    micro: %s,
+    _priv: (),
+};
 """ % unicode_version)
         (canon_decomp, compat_decomp, gencats, combines,
                 to_upper, to_lower, to_title) = load_unicode_data("UnicodeData.txt")


### PR DESCRIPTION
Looks like there's no strong reason to keep these values at `u64`.

With the current plans for the Unicode Standard, `u8` should be enough for the next 200 years. To stay on the safe side, I'm using `u16` here. I don't see a reason to go with anything machine-dependent/more-efficient.