### PR TITLE
use field init shorthand in src/librustc/

### DIFF
--- a/src/librustc/cfg/construct.rs
+++ b/src/librustc/cfg/construct.rs
@@ -58,11 +58,11 @@ pub fn construct<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let tables = tcx.typeck_tables_of(owner_def_id);
 
     let mut cfg_builder = CFGBuilder {
-        tcx: tcx,
+        tcx,
         owner_def_id,
-        tables: tables,
-        graph: graph,
-        fn_exit: fn_exit,
+        tables,
+        graph,
+        fn_exit,
         loop_scopes: Vec::new(),
         breakable_block_scopes: Vec::new(),
     };
@@ -70,8 +70,8 @@ pub fn construct<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     cfg_builder.add_contained_edge(body_exit, fn_exit);
     let CFGBuilder { graph, .. } = cfg_builder;
     CFG {
-        graph: graph,
-        entry: entry,
+        graph,
+        entry,
         exit: fn_exit,
     }
 }

--- a/src/librustc/dep_graph/dep_tracking_map.rs
+++ b/src/librustc/dep_graph/dep_tracking_map.rs
@@ -36,7 +36,7 @@ impl<M: DepTrackingMapConfig> DepTrackingMap<M> {
     pub fn new(graph: DepGraph) -> DepTrackingMap<M> {
         DepTrackingMap {
             phantom: PhantomData,
-            graph: graph,
+            graph,
             map: FxHashMap(),
         }
     }

--- a/src/librustc/dep_graph/query.rs
+++ b/src/librustc/dep_graph/query.rs
@@ -36,8 +36,8 @@ impl DepGraphQuery {
         }
 
         DepGraphQuery {
-            graph: graph,
-            indices: indices
+            graph,
+            indices,
         }
     }
 

--- a/src/librustc/dep_graph/shadow.rs
+++ b/src/librustc/dep_graph/shadow.rs
@@ -59,7 +59,7 @@ impl ShadowGraph {
 
         ShadowGraph {
             stack: RefCell::new(vec![]),
-            forbidden_edge: forbidden_edge,
+            forbidden_edge,
         }
     }
 

--- a/src/librustc/dep_graph/thread.rs
+++ b/src/librustc/dep_graph/thread.rs
@@ -78,7 +78,7 @@ impl DepGraphThreadData {
         }
 
         DepGraphThreadData {
-            enabled: enabled,
+            enabled,
             shadow_graph: ShadowGraph::new(),
             messages: VecCell::with_capacity(INITIAL_CAPACITY),
             swap_in: rx2,

--- a/src/librustc/hir/map/blocks.rs
+++ b/src/librustc/hir/map/blocks.rs
@@ -130,9 +130,9 @@ impl<'a> ClosureParts<'a> {
         ClosureParts {
             decl: d,
             body: b,
-            id: id,
+            id,
             span: s,
-            attrs: attrs,
+            attrs,
         }
     }
 }
@@ -149,7 +149,7 @@ impl<'a> FnLikeNode<'a> {
         };
         if fn_like {
             Some(FnLikeNode {
-                node: node
+                node,
             })
         } else {
             None
@@ -224,12 +224,12 @@ impl<'a> FnLikeNode<'a> {
                         id: i.id,
                         name: i.name,
                         decl: &decl,
-                        unsafety: unsafety,
+                        unsafety,
                         body: block,
-                        generics: generics,
-                        abi: abi,
+                        generics,
+                        abi,
                         vis: &i.vis,
-                        constness: constness,
+                        constness,
                         span: i.span,
                         attrs: &i.attrs,
                     }),

--- a/src/librustc/hir/map/collector.rs
+++ b/src/librustc/hir/map/collector.rs
@@ -28,7 +28,7 @@ pub struct NodeCollector<'hir> {
 impl<'hir> NodeCollector<'hir> {
     pub fn root(krate: &'hir Crate) -> NodeCollector<'hir> {
         let mut collector = NodeCollector {
-            krate: krate,
+            krate,
             map: vec![],
             parent_node: CRATE_NODE_ID,
         };

--- a/src/librustc/hir/map/def_collector.rs
+++ b/src/librustc/hir/map/def_collector.rs
@@ -36,8 +36,8 @@ pub struct MacroInvocationData {
 impl<'a> DefCollector<'a> {
     pub fn new(definitions: &'a mut Definitions, expansion: Mark) -> Self {
         DefCollector {
-            definitions: definitions,
-            expansion: expansion,
+            definitions,
+            expansion,
             parent_def: None,
             visit_macro_invoc: None,
         }
@@ -86,7 +86,7 @@ impl<'a> DefCollector<'a> {
         if let Some(ref mut visit) = self.visit_macro_invoc {
             visit(MacroInvocationData {
                 mark: id.placeholder_to_mark(),
-                const_expr: const_expr,
+                const_expr,
                 def_index: self.parent_def.unwrap(),
             })
         }

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -190,9 +190,9 @@ impl Decodable for DefPathTable {
         }
 
         Ok(DefPathTable {
-            index_to_key: index_to_key,
-            key_to_index: key_to_index,
-            def_path_hashes: def_path_hashes,
+            index_to_key,
+            key_to_index,
+            def_path_hashes,
         })
     }
 }
@@ -578,7 +578,7 @@ impl Definitions {
         let mut key = DefKey {
             parent: Some(parent),
             disambiguated_data: DisambiguatedDefPathData {
-                data: data,
+                data,
                 disambiguator: 0
             }
         };

--- a/src/librustc/hir/map/hir_id_validator.rs
+++ b/src/librustc/hir/map/hir_id_validator.rs
@@ -16,7 +16,7 @@ use rustc_data_structures::fx::FxHashMap;
 
 pub fn check_crate<'hir>(hir_map: &hir::map::Map<'hir>) {
     let mut outer_visitor = OuterVisitor {
-        hir_map: hir_map,
+        hir_map,
         errors: vec![],
     };
 
@@ -49,7 +49,7 @@ impl<'a, 'hir: 'a> OuterVisitor<'a, 'hir> {
                          hir_map: &'a hir::map::Map<'hir>)
                          -> HirIdValidator<'a, 'hir> {
         HirIdValidator {
-            hir_map: hir_map,
+            hir_map,
             owner_def_index: None,
             hir_ids_seen: FxHashMap(),
             errors: Vec::new(),

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -228,7 +228,7 @@ pub struct Forest {
 impl Forest {
     pub fn new(krate: Crate, dep_graph: &DepGraph) -> Forest {
         Forest {
-            krate: krate,
+            krate,
             dep_graph: dep_graph.clone(),
             inlined_bodies: TypedArena::new()
         }
@@ -1057,10 +1057,10 @@ pub fn map_crate<'hir>(forest: &'hir mut Forest,
     }
 
     let map = Map {
-        forest: forest,
+        forest,
         dep_graph: forest.dep_graph.clone(),
-        map: map,
-        definitions: definitions,
+        map,
+        definitions,
         inlined_bodies: RefCell::new(DefIdMap()),
     };
 

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -218,7 +218,7 @@ impl PathSegment {
     /// Convert an identifier to the corresponding segment.
     pub fn from_name(name: Name) -> PathSegment {
         PathSegment {
-            name: name,
+            name,
             parameters: PathParameters::none()
         }
     }

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -176,7 +176,7 @@ impl<'a> State<'a> {
                 cur_lit: 0,
             },
             boxes: Vec::new(),
-            ann: ann,
+            ann,
         }
     }
 }
@@ -196,7 +196,7 @@ pub fn to_string<F>(ann: &PpAnn, f: F) -> String
                 cur_lit: 0,
             },
             boxes: Vec::new(),
-            ann: ann,
+            ann,
         };
         f(&mut printer).unwrap();
         eof(&mut printer.s).unwrap();

--- a/src/librustc/ich/caching_codemap_view.rs
+++ b/src/librustc/ich/caching_codemap_view.rs
@@ -44,7 +44,7 @@ impl<'gcx> CachingCodemapView<'gcx> {
         };
 
         CachingCodemapView {
-            codemap: codemap,
+            codemap,
             line_cache: [entry.clone(), entry.clone(), entry.clone()],
             time_stamp: 0,
         }

--- a/src/librustc/ich/hcx.rs
+++ b/src/librustc/ich/hcx.rs
@@ -65,13 +65,13 @@ impl<'a, 'gcx, 'tcx> StableHashingContext<'a, 'gcx, 'tcx> {
         ignored_attr_names.sort();
 
         StableHashingContext {
-            tcx: tcx,
+            tcx,
             codemap: CachingCodemapView::new(tcx),
             hash_spans: hash_spans_initial,
             hash_bodies: true,
             overflow_checks_enabled: check_overflow_initial,
             node_id_hashing_mode: NodeIdHashingMode::HashDefPath,
-            ignored_attr_names: ignored_attr_names,
+            ignored_attr_names,
         }
     }
 

--- a/src/librustc/infer/combine.rs
+++ b/src/librustc/infer/combine.rs
@@ -268,7 +268,7 @@ impl<'infcx, 'gcx, 'tcx> CombineFields<'infcx, 'gcx, 'tcx> {
             infcx: self.infcx,
             span: self.trace.cause.span,
             for_vid_sub_root: self.infcx.type_variables.borrow_mut().sub_root_var(for_vid),
-            ambient_variance: ambient_variance,
+            ambient_variance,
             needs_wf: false,
         };
 

--- a/src/librustc/infer/freshen.rs
+++ b/src/librustc/infer/freshen.rs
@@ -48,7 +48,7 @@ impl<'a, 'gcx, 'tcx> TypeFreshener<'a, 'gcx, 'tcx> {
     pub fn new(infcx: &'a InferCtxt<'a, 'gcx, 'tcx>)
                -> TypeFreshener<'a, 'gcx, 'tcx> {
         TypeFreshener {
-            infcx: infcx,
+            infcx,
             freshen_count: 0,
             freshen_map: FxHashMap(),
         }

--- a/src/librustc/infer/fudge.rs
+++ b/src/librustc/infer/fudge.rs
@@ -102,7 +102,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             infcx: self,
             type_variables: &type_variables,
             region_vars: &region_vars,
-            origin: origin
+            origin,
         };
 
         Ok(value.fold_with(&mut fudger))

--- a/src/librustc/infer/higher_ranked/mod.rs
+++ b/src/librustc/infer/higher_ranked/mod.rs
@@ -218,7 +218,7 @@ impl<'a, 'gcx, 'tcx> CombineFields<'a, 'gcx, 'tcx> {
 
             Ok(HrMatchResult {
                 value: a_value,
-                unconstrained_regions: unconstrained_regions,
+                unconstrained_regions,
             })
         });
     }

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -458,9 +458,9 @@ impl<'gcx> TransNormalize<'gcx> for LvalueTy<'gcx> {
             LvalueTy::Ty { ty } => LvalueTy::Ty { ty: ty.trans_normalize(infcx, param_env) },
             LvalueTy::Downcast { adt_def, substs, variant_index } => {
                 LvalueTy::Downcast {
-                    adt_def: adt_def,
+                    adt_def,
                     substs: substs.trans_normalize(infcx, param_env),
-                    variant_index: variant_index
+                    variant_index,
                 }
             }
         }
@@ -674,7 +674,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                       -> CombineFields<'a, 'gcx, 'tcx> {
         CombineFields {
             infcx: self,
-            trace: trace,
+            trace,
             cause: None,
             param_env,
             obligations: PredicateObligations::new(),
@@ -1235,7 +1235,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         self.report_and_explain_type_error(
             trace,
             &TypeError::TyParamDefaultMismatch(ExpectedFound {
-                expected: expected,
+                expected,
                 found: actual
             }))
             .emit();
@@ -1279,7 +1279,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         let span = cause.span;
         let match_trait_ref = match_a.skip_binder().projection_ty.trait_ref;
         let trace = TypeTrace {
-            cause: cause,
+            cause,
             values: TraitRefs(ExpectedFound::new(true, match_trait_ref, match_b))
         };
 
@@ -1443,10 +1443,10 @@ impl<'tcx> SubregionOrigin<'tcx> {
                                                                        lint_id } =>
                 SubregionOrigin::CompareImplMethodObligation {
                     span: cause.span,
-                    item_name: item_name,
-                    impl_item_def_id: impl_item_def_id,
-                    trait_item_def_id: trait_item_def_id,
-                    lint_id: lint_id,
+                    item_name,
+                    impl_item_def_id,
+                    trait_item_def_id,
+                    lint_id,
                 },
 
             _ => default(),

--- a/src/librustc/infer/region_inference/mod.rs
+++ b/src/librustc/infer/region_inference/mod.rs
@@ -354,7 +354,7 @@ impl<'a, 'gcx, 'tcx> TaintSet<'tcx> {
 impl<'a, 'gcx, 'tcx> RegionVarBindings<'a, 'gcx, 'tcx> {
     pub fn new(tcx: TyCtxt<'a, 'gcx, 'tcx>) -> RegionVarBindings<'a, 'gcx, 'tcx> {
         RegionVarBindings {
-            tcx: tcx,
+            tcx,
             var_origins: RefCell::new(Vec::new()),
             values: RefCell::new(None),
             constraints: RefCell::new(FxHashMap()),
@@ -378,7 +378,7 @@ impl<'a, 'gcx, 'tcx> RegionVarBindings<'a, 'gcx, 'tcx> {
         debug!("RegionVarBindings: start_snapshot({})", length);
         self.undo_log.borrow_mut().push(OpenSnapshot);
         RegionSnapshot {
-            length: length,
+            length,
             region_snapshot: self.unification_table.borrow_mut().snapshot(),
             skolemization_count: self.skolemization_count.get(),
         }
@@ -733,10 +733,10 @@ impl<'a, 'gcx, 'tcx> RegionVarBindings<'a, 'gcx, 'tcx> {
                                 sub: Region<'tcx>,
                                 bound: VerifyBound<'tcx>) {
         self.add_verify(Verify {
-            kind: kind,
-            origin: origin,
+            kind,
+            origin,
             region: sub,
-            bound: bound
+            bound,
         });
     }
 
@@ -1459,7 +1459,7 @@ impl<'a, 'gcx, 'tcx> RegionVarBindings<'a, 'gcx, 'tcx> {
                     ConstrainRegSubVar(region, _) |
                     ConstrainVarSubReg(_, region) => {
                         state.result.push(RegionAndOrigin {
-                            region: region,
+                            region,
                             origin: this.constraints.borrow().get(&edge.data).unwrap().clone(),
                         });
                     }

--- a/src/librustc/infer/type_variable.rs
+++ b/src/librustc/infer/type_variable.rs
@@ -181,8 +181,8 @@ impl<'tcx> TypeVariableTable<'tcx> {
         self.sub_relations.new_key(());
         let index = self.values.push(TypeVariableData {
             value: Bounded { default: default },
-            origin: origin,
-            diverging: diverging
+            origin,
+            diverging,
         });
         let v = ty::TyVid { index: index as u32 };
         debug!("new_var: diverging={:?} index={:?}", diverging, v);
@@ -369,7 +369,7 @@ impl<'tcx> sv::SnapshotVecDelegate for Delegate<'tcx> {
     fn reverse(values: &mut Vec<TypeVariableData<'tcx>>, action: Instantiate<'tcx>) {
         let Instantiate { vid, default } = action;
         values[vid.index as usize].value = Bounded {
-            default: default
+            default,
         };
     }
 }

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -140,8 +140,8 @@ impl<'a, S: Into<MultiSpan>> IntoEarlyLint for (S, &'a str) {
         let mut diagnostic = Diagnostic::new(errors::Level::Warning, msg);
         diagnostic.set_span(span);
         EarlyLint {
-            id: id,
-            diagnostic: diagnostic,
+            id,
+            diagnostic,
         }
     }
 }
@@ -149,7 +149,7 @@ impl<'a, S: Into<MultiSpan>> IntoEarlyLint for (S, &'a str) {
 impl IntoEarlyLint for Diagnostic {
     fn into_early_lint(self, id: LintId) -> EarlyLint {
         EarlyLint {
-            id: id,
+            id,
             diagnostic: self,
         }
     }
@@ -805,8 +805,8 @@ impl<'a> EarlyContext<'a> {
     fn new(sess: &'a Session,
            krate: &'a ast::Crate) -> EarlyContext<'a> {
         EarlyContext {
-            sess: sess,
-            krate: krate,
+            sess,
+            krate,
             lint_sess: LintSession::new(&sess.lint_store),
         }
     }
@@ -1350,10 +1350,10 @@ pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     let krate = tcx.hir.krate();
 
     let mut cx = LateContext {
-        tcx: tcx,
+        tcx,
         tables: &ty::TypeckTables::empty(),
         param_env: ty::ParamEnv::empty(Reveal::UserFacing),
-        access_levels: access_levels,
+        access_levels,
         lint_sess: LintSession::new(&tcx.sess.lint_store),
     };
 

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -294,7 +294,7 @@ impl LintId {
     /// Get the `LintId` for a `Lint`.
     pub fn of(lint: &'static Lint) -> LintId {
         LintId {
-            lint: lint,
+            lint,
         }
     }
 

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -260,16 +260,16 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
         let nodeid_to_index = build_nodeid_to_index(body, cfg);
 
         DataFlowContext {
-            tcx: tcx,
-            analysis_name: analysis_name,
-            words_per_id: words_per_id,
-            nodeid_to_index: nodeid_to_index,
-            bits_per_id: bits_per_id,
-            oper: oper,
-            gens: gens,
+            tcx,
+            analysis_name,
+            words_per_id,
+            nodeid_to_index,
+            bits_per_id,
+            oper,
+            gens,
             action_kills: kills1,
             scope_kills: kills2,
-            on_entry: on_entry
+            on_entry,
         }
     }
 

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -383,8 +383,8 @@ fn create_and_seed_worklist<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
     // Seed implemented trait items
     let mut life_seeder = LifeSeeder {
-        worklist: worklist,
-        krate: krate,
+        worklist,
+        krate,
     };
     krate.visit_all_item_likes(&mut life_seeder);
 
@@ -397,8 +397,8 @@ fn find_live<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                        -> Box<FxHashSet<ast::NodeId>> {
     let worklist = create_and_seed_worklist(tcx, access_levels, krate);
     let mut symbol_visitor = MarkSymbolVisitor {
-        worklist: worklist,
-        tcx: tcx,
+        worklist,
+        tcx,
         tables: &ty::TypeckTables::empty(),
         live_symbols: box FxHashSet(),
         struct_has_extern_repr: false,

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -261,7 +261,7 @@ impl<'a, 'tcx> Visitor<'tcx> for EffectCheckVisitor<'a, 'tcx> {
 
 pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     let mut visitor = EffectCheckVisitor {
-        tcx: tcx,
+        tcx,
         tables: &ty::TypeckTables::empty(),
         body_id: hir::BodyId { node_id: ast::CRATE_NODE_ID },
         unsafe_context: UnsafeContext::new(SafeContext),

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -71,7 +71,7 @@ pub fn find_entry_point(session: &Session, hir_map: &hir_map::Map) {
     }
 
     let mut ctxt = EntryContext {
-        session: session,
+        session,
         map: hir_map,
         main_fn: None,
         attr_main_fn: None,

--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -20,7 +20,7 @@ use hir;
 
 pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     let mut visitor = ItemVisitor {
-        tcx: tcx
+        tcx,
     };
     tcx.hir.krate().visit_all_item_likes(&mut visitor.as_deep_visitor());
 }

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -156,10 +156,10 @@ impl<'a, 'tcx> LanguageItemCollector<'a, 'tcx> {
         $( item_refs.insert($name, $variant as usize); )*
 
         LanguageItemCollector {
-            session: session,
-            hir_map: hir_map,
+            session,
+            hir_map,
             items: LanguageItems::new(),
-            item_refs: item_refs,
+            item_refs,
         }
     }
 

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -269,7 +269,7 @@ struct IrMaps<'a, 'tcx: 'a> {
 impl<'a, 'tcx> IrMaps<'a, 'tcx> {
     fn new(tcx: TyCtxt<'a, 'tcx, 'tcx>) -> IrMaps<'a, 'tcx> {
         IrMaps {
-            tcx: tcx,
+            tcx,
             num_live_nodes: 0,
             num_vars: 0,
             live_node_map: NodeMap(),
@@ -385,7 +385,7 @@ fn visit_local<'a, 'tcx>(ir: &mut IrMaps<'a, 'tcx>, local: &'tcx hir::Local) {
         ir.add_live_node_for_node(p_id, VarDefNode(sp));
         ir.add_variable(Local(LocalInfo {
           id: p_id,
-          name: name
+          name,
         }));
     });
     intravisit::walk_local(ir, local);
@@ -400,7 +400,7 @@ fn visit_arm<'a, 'tcx>(ir: &mut IrMaps<'a, 'tcx>, arm: &'tcx hir::Arm) {
             ir.add_live_node_for_node(p_id, VarDefNode(sp));
             ir.add_variable(Local(LocalInfo {
                 id: p_id,
-                name: name
+                name,
             }));
         })
     }
@@ -534,8 +534,8 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
         let num_vars = ir.num_vars;
 
         Liveness {
-            ir: ir,
-            tables: tables,
+            ir,
+            tables,
             s: specials,
             successors: vec![invalid_node(); num_live_nodes],
             users: vec![invalid_users(); num_live_nodes * num_vars],

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -656,8 +656,8 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
           Def::Local(def_id) => {
             let vid = self.tcx.hir.as_local_node_id(def_id).unwrap();
             Ok(Rc::new(cmt_ {
-                id: id,
-                span: span,
+                id,
+                span,
                 cat: Categorization::Local(vid),
                 mutbl: MutabilityCategory::from_local(self.tcx, vid),
                 ty: expr_ty,
@@ -706,7 +706,7 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
             None => span_bug!(span, "missing closure kind")
         };
 
-        let upvar_id = ty::UpvarId { var_id: var_id,
+        let upvar_id = ty::UpvarId { var_id,
                                      closure_expr_id: fn_node_id };
         let var_ty = self.node_ty(var_id)?;
 
@@ -717,8 +717,8 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
         // from the environment (perhaps we should eventually desugar
         // this field further, but it will do for now).
         let cmt_result = cmt_ {
-            id: id,
-            span: span,
+            id,
+            span,
             cat: Categorization::Upvar(Upvar {id: upvar_id, kind: kind}),
             mutbl: var_mutbl,
             ty: var_ty,
@@ -743,7 +743,7 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
         // If this is a by-ref capture, then the upvar we loaded is
         // actually a reference, so we have to add an implicit deref
         // for that.
-        let upvar_id = ty::UpvarId { var_id: var_id,
+        let upvar_id = ty::UpvarId { var_id,
                                      closure_expr_id: fn_node_id };
         let upvar_capture = self.tables.upvar_capture(upvar_id);
         let cmt_result = match upvar_capture {
@@ -753,8 +753,8 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
             ty::UpvarCapture::ByRef(upvar_borrow) => {
                 let ptr = BorrowedPtr(upvar_borrow.kind, upvar_borrow.region);
                 cmt_ {
-                    id: id,
-                    span: span,
+                    id,
+                    span,
                     cat: Categorization::Deref(Rc::new(cmt_result), ptr),
                     mutbl: MutabilityCategory::from_borrow_kind(upvar_borrow.kind),
                     ty: var_ty,
@@ -813,8 +813,8 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
         }
 
         let ret = cmt_ {
-            id: id,
-            span: span,
+            id,
+            span,
             cat: Categorization::Deref(Rc::new(cmt_result), env_ptr),
             mutbl: deref_mutbl,
             ty: var_ty,

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -374,11 +374,11 @@ fn reachable_set<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, crate_num: CrateNum) -> 
         *ty == config::CrateTypeProcMacro
     });
     let mut reachable_context = ReachableContext {
-        tcx: tcx,
+        tcx,
         tables: &ty::TypeckTables::empty(),
         reachable_symbols: NodeSet(),
         worklist: Vec::new(),
-        any_library: any_library,
+        any_library,
     };
 
     // Step 1: Seed the worklist with all nodes which were found to be public as
@@ -398,8 +398,8 @@ fn reachable_set<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, crate_num: CrateNum) -> 
     }
     {
         let mut collect_private_impl_items = CollectPrivateImplItemsVisitor {
-            tcx: tcx,
-            access_levels: access_levels,
+            tcx,
+            access_levels,
             worklist: &mut reachable_context.worklist,
         };
         tcx.hir.krate().visit_all_item_likes(&mut collect_private_impl_items);

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -266,8 +266,8 @@ pub fn krate(sess: &Session,
     };
     sess.track_errors(|| {
         let mut visitor = LifetimeContext {
-            sess: sess,
-            hir_map: hir_map,
+            sess,
+            hir_map,
             map: &mut map,
             scope: ROOT_SCOPE,
             trait_ref_hack: false,
@@ -341,7 +341,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
                     Region::early(&mut index, def)
                 }).collect();
                 let scope = Scope::Binder {
-                    lifetimes: lifetimes,
+                    lifetimes,
                     s: ROOT_SCOPE
                 };
                 self.with(scope, |old_scope, this| {
@@ -777,13 +777,13 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
         let xcrate_object_lifetime_defaults =
             replace(&mut self.xcrate_object_lifetime_defaults, DefIdMap());
         let mut this = LifetimeContext {
-            sess: sess,
-            hir_map: hir_map,
+            sess,
+            hir_map,
             map: *map,
             scope: &wrap_scope,
             trait_ref_hack: self.trait_ref_hack,
-            labels_in_fn: labels_in_fn,
-            xcrate_object_lifetime_defaults: xcrate_object_lifetime_defaults,
+            labels_in_fn,
+            xcrate_object_lifetime_defaults,
         };
         debug!("entering scope {:?}", this.scope);
         f(self.scope, &mut this);
@@ -849,7 +849,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
         }).collect();
 
         let scope = Scope::Binder {
-            lifetimes: lifetimes,
+            lifetimes,
             s: self.scope
         };
         self.with(scope, move |old_scope, this| {
@@ -1206,7 +1206,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
         };
 
         let scope = Scope::Elision {
-            elide: elide,
+            elide,
             s: self.scope
         };
         self.with(scope, |_, this| this.visit_ty(output));
@@ -1620,7 +1620,7 @@ fn insert_late_bound_lifetimes(map: &mut NamedRegionMap,
             map.issue_32330.insert(
                 lifetime.lifetime.id,
                 ty::Issue32330 {
-                    fn_def_id: fn_def_id,
+                    fn_def_id,
                     region_name: name,
                 });
             continue;

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -70,14 +70,14 @@ impl DeprecationEntry {
     fn local(attr: Deprecation, id: DefId) -> DeprecationEntry {
         assert!(id.is_local());
         DeprecationEntry {
-            attr: attr,
+            attr,
             origin: Some(id.index),
         }
     }
 
     fn external(attr: Deprecation) -> DeprecationEntry {
         DeprecationEntry {
-            attr: attr,
+            attr,
             origin: None,
         }
     }
@@ -384,7 +384,7 @@ impl<'a, 'tcx> Index<'tcx> {
 
         let krate = tcx.hir.krate();
         let mut annotator = Annotator {
-            tcx: tcx,
+            tcx,
             index: self,
             parent_stab: None,
             parent_depr: None,
@@ -424,7 +424,7 @@ impl<'a, 'tcx> Index<'tcx> {
         let mut staged_api = FxHashMap();
         staged_api.insert(LOCAL_CRATE, is_staged_api);
         Index {
-            staged_api: staged_api,
+            staged_api,
             stab_map: DefIdMap(),
             depr_map: DefIdMap(),
             active_features: FxHashSet(),
@@ -717,8 +717,8 @@ pub fn check_unused_or_stable_features<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     if tcx.stability.borrow().staged_api[&LOCAL_CRATE] {
         let krate = tcx.hir.krate();
         let mut missing = MissingStabilityAnnotations {
-            tcx: tcx,
-            access_levels: access_levels,
+            tcx,
+            access_levels,
         };
         missing.check_missing_stability(ast::CRATE_NODE_ID, krate.span);
         intravisit::walk_crate(&mut missing, krate);

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -136,15 +136,15 @@ impl<'tcx> Mir<'tcx> {
         assert_eq!(local_decls[RETURN_POINTER].ty, return_ty);
 
         Mir {
-            basic_blocks: basic_blocks,
-            visibility_scopes: visibility_scopes,
-            promoted: promoted,
-            return_ty: return_ty,
-            local_decls: local_decls,
-            arg_count: arg_count,
-            upvar_decls: upvar_decls,
+            basic_blocks,
+            visibility_scopes,
+            promoted,
+            return_ty,
+            local_decls,
+            arg_count,
+            upvar_decls,
             spread_arg: None,
-            span: span,
+            span,
             cache: cache::Cache::new()
         }
     }
@@ -395,10 +395,10 @@ impl<'tcx> LocalDecl<'tcx> {
     pub fn new_temp(ty: Ty<'tcx>, span: Span) -> Self {
         LocalDecl {
             mutability: Mutability::Mut,
-            ty: ty,
+            ty,
             name: None,
             source_info: SourceInfo {
-                span: span,
+                span,
                 scope: ARGUMENT_VISIBILITY_SCOPE
             },
             is_user_variable: false
@@ -414,7 +414,7 @@ impl<'tcx> LocalDecl<'tcx> {
             mutability: Mutability::Mut,
             ty: return_ty,
             source_info: SourceInfo {
-                span: span,
+                span,
                 scope: ARGUMENT_VISIBILITY_SCOPE
             },
             name: None,     // FIXME maybe we do want some name here?
@@ -629,7 +629,7 @@ impl<'tcx> BasicBlockData<'tcx> {
     pub fn new(terminator: Option<Terminator<'tcx>>) -> BasicBlockData<'tcx> {
         BasicBlockData {
             statements: vec![],
-            terminator: terminator,
+            terminator,
             is_cleanup: false,
         }
     }
@@ -941,7 +941,7 @@ impl<'tcx> Lvalue<'tcx> {
     pub fn elem(self, elem: LvalueElem<'tcx>) -> Lvalue<'tcx> {
         Lvalue::Projection(Box::new(LvalueProjection {
             base: self,
-            elem: elem,
+            elem,
         }))
     }
 }
@@ -1023,7 +1023,7 @@ impl<'tcx> Operand<'tcx> {
         span: Span,
     ) -> Self {
         Operand::Constant(box Constant {
-            span: span,
+            span,
             ty: tcx.type_of(def_id).subst(tcx, substs),
             literal: Literal::Value { value: ConstVal::Function(def_id, substs) },
         })
@@ -1470,7 +1470,7 @@ impl<'tcx> TypeFoldable<'tcx> for Statement<'tcx> {
             Assign(ref lval, ref rval) => Assign(lval.fold_with(folder), rval.fold_with(folder)),
             SetDiscriminant { ref lvalue, variant_index } => SetDiscriminant {
                 lvalue: lvalue.fold_with(folder),
-                variant_index: variant_index
+                variant_index,
             },
             StorageLive(ref lval) => StorageLive(lval.fold_with(folder)),
             StorageDead(ref lval) => StorageDead(lval.fold_with(folder)),
@@ -1490,7 +1490,7 @@ impl<'tcx> TypeFoldable<'tcx> for Statement<'tcx> {
         };
         Statement {
             source_info: self.source_info,
-            kind: kind
+            kind,
         }
     }
 
@@ -1530,14 +1530,14 @@ impl<'tcx> TypeFoldable<'tcx> for Terminator<'tcx> {
             },
             Drop { ref location, target, unwind } => Drop {
                 location: location.fold_with(folder),
-                target: target,
-                unwind: unwind
+                target,
+                unwind,
             },
             DropAndReplace { ref location, ref value, target, unwind } => DropAndReplace {
                 location: location.fold_with(folder),
                 value: value.fold_with(folder),
-                target: target,
-                unwind: unwind
+                target,
+                unwind,
             },
             Call { ref func, ref args, ref destination, cleanup } => {
                 let dest = destination.as_ref().map(|&(ref loc, dest)| {
@@ -1548,7 +1548,7 @@ impl<'tcx> TypeFoldable<'tcx> for Terminator<'tcx> {
                     func: func.fold_with(folder),
                     args: args.fold_with(folder),
                     destination: dest,
-                    cleanup: cleanup
+                    cleanup,
                 }
             },
             Assert { ref cond, expected, ref msg, target, cleanup } => {
@@ -1562,10 +1562,10 @@ impl<'tcx> TypeFoldable<'tcx> for Terminator<'tcx> {
                 };
                 Assert {
                     cond: cond.fold_with(folder),
-                    expected: expected,
-                    msg: msg,
-                    target: target,
-                    cleanup: cleanup
+                    expected,
+                    msg,
+                    target,
+                    cleanup,
                 }
             },
             Resume => Resume,
@@ -1574,7 +1574,7 @@ impl<'tcx> TypeFoldable<'tcx> for Terminator<'tcx> {
         };
         Terminator {
             source_info: self.source_info,
-            kind: kind
+            kind,
         }
     }
 
@@ -1716,8 +1716,8 @@ impl<'tcx, B, V> TypeFoldable<'tcx> for Projection<'tcx, B, V>
         };
 
         Projection {
-            base: base,
-            elem: elem
+            base,
+            elem,
         }
     }
 
@@ -1750,7 +1750,7 @@ impl<'tcx> TypeFoldable<'tcx> for Literal<'tcx> {
     fn super_fold_with<'gcx: 'tcx, F: TypeFolder<'gcx, 'tcx>>(&self, folder: &mut F) -> Self {
         match *self {
             Literal::Item { def_id, substs } => Literal::Item {
-                def_id: def_id,
+                def_id,
                 substs: substs.fold_with(folder)
             },
             _ => self.clone()

--- a/src/librustc/mir/tcx.rs
+++ b/src/librustc/mir/tcx.rs
@@ -58,7 +58,7 @@ impl<'a, 'gcx, 'tcx> LvalueTy<'tcx> {
                              })
                              .ty;
                 LvalueTy::Ty {
-                    ty: ty,
+                    ty,
                 }
             }
             ProjectionElem::Index(_) | ProjectionElem::ConstantIndex { .. } =>
@@ -85,8 +85,8 @@ impl<'a, 'gcx, 'tcx> LvalueTy<'tcx> {
                         assert!(adt_def.is_enum());
                         assert!(index < adt_def.variants.len());
                         assert_eq!(adt_def, adt_def1);
-                        LvalueTy::Downcast { adt_def: adt_def,
-                                             substs: substs,
+                        LvalueTy::Downcast { adt_def,
+                                             substs,
                                              variant_index: index }
                     }
                     _ => {
@@ -104,9 +104,9 @@ impl<'tcx> TypeFoldable<'tcx> for LvalueTy<'tcx> {
             LvalueTy::Ty { ty } => LvalueTy::Ty { ty: ty.fold_with(folder) },
             LvalueTy::Downcast { adt_def, substs, variant_index } => {
                 LvalueTy::Downcast {
-                    adt_def: adt_def,
+                    adt_def,
                     substs: substs.fold_with(folder),
-                    variant_index: variant_index
+                    variant_index,
                 }
             }
         }

--- a/src/librustc/mir/traversal.rs
+++ b/src/librustc/mir/traversal.rs
@@ -44,9 +44,9 @@ impl<'a, 'tcx> Preorder<'a, 'tcx> {
         let worklist = vec![root];
 
         Preorder {
-            mir: mir,
+            mir,
             visited: BitVector::new(mir.basic_blocks().len()),
-            worklist: worklist
+            worklist,
         }
     }
 }
@@ -106,7 +106,7 @@ pub struct Postorder<'a, 'tcx: 'a> {
 impl<'a, 'tcx> Postorder<'a, 'tcx> {
     pub fn new(mir: &'a Mir<'tcx>, root: BasicBlock) -> Postorder<'a, 'tcx> {
         let mut po = Postorder {
-            mir: mir,
+            mir,
             visited: BitVector::new(mir.basic_blocks().len()),
             visit_stack: Vec::new()
         };
@@ -251,8 +251,8 @@ impl<'a, 'tcx> ReversePostorder<'a, 'tcx> {
         let len = blocks.len();
 
         ReversePostorder {
-            mir: mir,
-            blocks: blocks,
+            mir,
+            blocks,
             idx: len
         }
     }

--- a/src/librustc/session/code_stats.rs
+++ b/src/librustc/session/code_stats.rs
@@ -82,12 +82,12 @@ impl CodeStats {
                                          opt_discr_size: Option<Size>,
                                          variants: Vec<VariantInfo>) {
         let info = TypeSizeInfo {
-            kind: kind,
+            kind,
             type_description: type_desc.to_string(),
             align: align.abi(),
             overall_size: overall_size.bytes(),
             opt_discr_size: opt_discr_size.map(|s| s.bytes()),
-            variants: variants,
+            variants,
         };
         self.type_sizes.insert(info);
     }

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1122,9 +1122,9 @@ pub fn build_target_config(opts: &Options, sp: &Handler) -> Config {
     };
 
     Config {
-        target: target,
-        int_type: int_type,
-        uint_type: uint_type,
+        target,
+        int_type,
+        uint_type,
     }
 }
 
@@ -1150,7 +1150,7 @@ impl RustcOptGroup {
         where F: Fn(&mut getopts::Options) -> &mut getopts::Options + 'static,
     {
         RustcOptGroup {
-            name: name,
+            name,
             apply: Box::new(f),
             stability: OptionStability::Stable,
         }
@@ -1160,7 +1160,7 @@ impl RustcOptGroup {
         where F: Fn(&mut getopts::Options) -> &mut getopts::Options + 'static,
     {
         RustcOptGroup {
-            name: name,
+            name,
             apply: Box::new(f),
             stability: OptionStability::Unstable,
         }
@@ -1627,28 +1627,28 @@ pub fn build_session_options_and_crate_config(matches: &getopts::Matches)
     let incremental = debugging_opts.incremental.as_ref().map(|m| PathBuf::from(m));
 
     (Options {
-        crate_types: crate_types,
+        crate_types,
         optimize: opt_level,
-        debuginfo: debuginfo,
-        lint_opts: lint_opts,
-        lint_cap: lint_cap,
-        describe_lints: describe_lints,
+        debuginfo,
+        lint_opts,
+        lint_cap,
+        describe_lints,
         output_types: OutputTypes(output_types),
-        search_paths: search_paths,
+        search_paths,
         maybe_sysroot: sysroot_opt,
         target_triple: target,
-        test: test,
-        incremental: incremental,
-        debugging_opts: debugging_opts,
-        prints: prints,
-        cg: cg,
-        error_format: error_format,
+        test,
+        incremental,
+        debugging_opts,
+        prints,
+        cg,
+        error_format,
         externs: Externs(externs),
-        crate_name: crate_name,
+        crate_name,
         alt_std_name: None,
-        libs: libs,
+        libs,
         unstable_features: UnstableFeatures::from_environment(),
-        debug_assertions: debug_assertions,
+        debug_assertions,
         actually_rustdoc: false,
     },
     cfg)

--- a/src/librustc/session/filesearch.rs
+++ b/src/librustc/session/filesearch.rs
@@ -104,10 +104,10 @@ impl<'a> FileSearch<'a> {
                kind: PathKind) -> FileSearch<'a> {
         debug!("using sysroot = {}, triple = {}", sysroot.display(), triple);
         FileSearch {
-            sysroot: sysroot,
-            search_paths: search_paths,
-            triple: triple,
-            kind: kind,
+            sysroot,
+            search_paths,
+            triple,
+            kind,
         }
     }
 

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -485,7 +485,7 @@ impl Session {
 
         *incr_comp_session = IncrCompSession::Active {
             session_directory: session_dir,
-            lock_file: lock_file,
+            lock_file,
         };
     }
 
@@ -515,7 +515,7 @@ impl Session {
 
         // Note: This will also drop the lock file, thus unlocking the directory
         *incr_comp_session = IncrCompSession::InvalidBecauseOfErrors {
-            session_directory: session_directory
+            session_directory,
         };
     }
 
@@ -695,18 +695,18 @@ pub fn build_session_(sopts: config::Options,
     let sess = Session {
         dep_graph: dep_graph.clone(),
         target: target_cfg,
-        host: host,
+        host,
         opts: sopts,
-        cstore: cstore,
+        cstore,
         parse_sess: p_s,
         // For a library crate, this is always none
         entry_fn: RefCell::new(None),
         entry_type: Cell::new(None),
         plugin_registrar_fn: Cell::new(None),
         derive_registrar_fn: Cell::new(None),
-        default_sysroot: default_sysroot,
-        local_crate_source_file: local_crate_source_file,
-        working_dir: working_dir,
+        default_sysroot,
+        local_crate_source_file,
+        working_dir,
         lint_store: RefCell::new(lint::LintStore::new()),
         lints: RefCell::new(lint::LintTable::new()),
         one_time_diagnostics: RefCell::new(FxHashSet()),
@@ -733,10 +733,10 @@ pub fn build_session_(sopts: config::Options,
             decode_def_path_tables_time: Cell::new(Duration::from_secs(0)),
         },
         code_stats: RefCell::new(CodeStats::new()),
-        optimization_fuel_crate: optimization_fuel_crate,
-        optimization_fuel_limit: optimization_fuel_limit,
-        print_fuel_crate: print_fuel_crate,
-        print_fuel: print_fuel,
+        optimization_fuel_crate,
+        optimization_fuel_limit,
+        print_fuel_crate,
+        print_fuel,
         out_of_fuel: Cell::new(false),
         // Note that this is unsafe because it may misinterpret file descriptors
         // on Unix as jobserver file descriptors. We hopefully execute this near

--- a/src/librustc/traits/coherence.rs
+++ b/src/librustc/traits/coherence.rs
@@ -47,7 +47,7 @@ fn with_fresh_ty_vars<'cx, 'gcx, 'tcx>(selcx: &mut SelectionContext<'cx, 'gcx, '
     let impl_substs = selcx.infcx().fresh_substs_for_item(DUMMY_SP, impl_def_id);
 
     let header = ty::ImplHeader {
-        impl_def_id: impl_def_id,
+        impl_def_id,
         self_ty: tcx.type_of(impl_def_id),
         trait_ref: tcx.impl_trait_ref(impl_def_id),
         predicates: tcx.predicates_of(impl_def_id).predicates
@@ -102,7 +102,7 @@ fn overlap<'cx, 'gcx, 'tcx>(selcx: &mut SelectionContext<'cx, 'gcx, 'tcx>,
                      .chain(&b_impl_header.predicates)
                      .map(|p| infcx.resolve_type_vars_if_possible(p))
                      .map(|p| Obligation { cause: ObligationCause::dummy(),
-                                           param_env: param_env,
+                                           param_env,
                                            recursion_depth: 0,
                                            predicate: p })
                      .chain(obligations)

--- a/src/librustc/traits/fulfill.rs
+++ b/src/librustc/traits/fulfill.rs
@@ -152,11 +152,11 @@ impl<'a, 'gcx, 'tcx> FulfillmentContext<'tcx> {
                           cause: ObligationCause<'tcx>)
     {
         let trait_ref = ty::TraitRef {
-            def_id: def_id,
+            def_id,
             substs: infcx.tcx.mk_substs_trait(ty, &[]),
         };
         self.register_predicate_obligation(infcx, Obligation {
-            cause: cause,
+            cause,
             recursion_depth: 0,
             param_env,
             predicate: trait_ref.to_predicate()
@@ -191,7 +191,7 @@ impl<'a, 'gcx, 'tcx> FulfillmentContext<'tcx> {
         }
 
         self.predicates.register_obligation(PendingPredicateObligation {
-            obligation: obligation,
+            obligation,
             stalled_on: vec![]
         });
     }
@@ -259,7 +259,7 @@ impl<'a, 'gcx, 'tcx> FulfillmentContext<'tcx> {
 
             // Process pending obligations.
             let outcome = self.predicates.process_obligations(&mut FulfillProcessor {
-                selcx: selcx,
+                selcx,
                 region_obligations: &mut self.region_obligations,
             });
             debug!("select: outcome={:?}", outcome);
@@ -606,7 +606,7 @@ impl<'a, 'gcx, 'tcx> GlobalFulfilledPredicates<'gcx> {
     pub fn new(dep_graph: DepGraph) -> GlobalFulfilledPredicates<'gcx> {
         GlobalFulfilledPredicates {
             set: FxHashSet(),
-            dep_graph: dep_graph,
+            dep_graph,
         }
     }
 

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -396,7 +396,7 @@ pub fn type_known_to_meet_bound<'a, 'gcx, 'tcx>(infcx: &InferCtxt<'a, 'gcx, 'tcx
            infcx.tcx.item_path_str(def_id));
 
     let trait_ref = ty::TraitRef {
-        def_id: def_id,
+        def_id,
         substs: infcx.tcx.mk_substs_trait(ty, &[]),
     };
     let obligation = Obligation {

--- a/src/librustc/traits/project.rs
+++ b/src/librustc/traits/project.rs
@@ -245,11 +245,11 @@ impl<'a, 'b, 'gcx, 'tcx> AssociatedTypeNormalizer<'a, 'b, 'gcx, 'tcx> {
            -> AssociatedTypeNormalizer<'a, 'b, 'gcx, 'tcx>
     {
         AssociatedTypeNormalizer {
-            selcx: selcx,
-            param_env: param_env,
-            cause: cause,
+            selcx,
+            param_env,
+            cause,
             obligations: vec![],
-            depth: depth,
+            depth,
         }
     }
 
@@ -371,7 +371,7 @@ pub fn normalize_projection_type<'a, 'b, 'gcx, 'tcx>(
             let ty_var = selcx.infcx().next_ty_var(
                 TypeVariableOrigin::NormalizeProjectionType(tcx.def_span(def_id)));
             let projection = ty::Binder(ty::ProjectionPredicate {
-                projection_ty: projection_ty,
+                projection_ty,
                 ty: ty_var
             });
             let obligation = Obligation::with_depth(
@@ -514,12 +514,12 @@ fn opt_normalize_projection_type<'a, 'b, 'gcx, 'tcx>(
                 obligations.extend(normalizer.obligations);
                 Normalized {
                     value: normalized_ty,
-                    obligations: obligations,
+                    obligations,
                 }
             } else {
                 Normalized {
                     value: projected_ty,
-                    obligations: obligations,
+                    obligations,
                 }
             };
             infcx.projection_cache.borrow_mut()
@@ -586,7 +586,7 @@ fn normalize_to_error<'a, 'gcx, 'tcx>(selcx: &mut SelectionContext<'a, 'gcx, 'tc
                                       -> NormalizedTy<'tcx>
 {
     let trait_ref = projection_ty.trait_ref.to_poly_trait_ref();
-    let trait_obligation = Obligation { cause: cause,
+    let trait_obligation = Obligation { cause,
                                         recursion_depth: depth,
                                         param_env,
                                         predicate: trait_ref.to_predicate() };
@@ -1232,7 +1232,7 @@ fn confirm_param_env_candidate<'cx, 'gcx, 'tcx>(
         Ok(InferOk { value: ty_match, obligations }) => {
             Progress {
                 ty: ty_match.value,
-                obligations: obligations,
+                obligations,
                 cacheable: ty_match.unconstrained_regions.is_empty(),
             }
         }
@@ -1306,7 +1306,7 @@ fn assoc_ty_def<'cx, 'gcx, 'tcx>(
         if item.kind == ty::AssociatedKind::Type && item.name == assoc_ty_name {
             return specialization_graph::NodeItem {
                 node: specialization_graph::Node::Impl(impl_def_id),
-                item: item,
+                item,
             };
         }
     }

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -212,7 +212,7 @@ impl<'a, 'tcx> ty::Lift<'tcx> for SelectionCandidate<'a> {
         Some(match *self {
             BuiltinCandidate { has_nested } => {
                 BuiltinCandidate {
-                    has_nested: has_nested
+                    has_nested,
                 }
             }
             ImplCandidate(def_id) => ImplCandidate(def_id),
@@ -290,7 +290,7 @@ pub struct EvaluationCache<'tcx> {
 impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
     pub fn new(infcx: &'cx InferCtxt<'cx, 'gcx, 'tcx>) -> SelectionContext<'cx, 'gcx, 'tcx> {
         SelectionContext {
-            infcx: infcx,
+            infcx,
             freshener: infcx.freshener(),
             intercrate: false,
             inferred_obligations: SnapshotVec::new(),
@@ -299,7 +299,7 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
 
     pub fn intercrate(infcx: &'cx InferCtxt<'cx, 'gcx, 'tcx>) -> SelectionContext<'cx, 'gcx, 'tcx> {
         SelectionContext {
-            infcx: infcx,
+            infcx,
             freshener: infcx.freshener(),
             intercrate: true,
             inferred_obligations: SnapshotVec::new(),
@@ -2205,7 +2205,7 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
         debug!("vtable_default_impl: obligations={:?}", obligations);
 
         VtableDefaultImplData {
-            trait_def_id: trait_def_id,
+            trait_def_id,
             nested: obligations
         }
     }
@@ -2273,7 +2273,7 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
         // e.g. `impl<U: Tr, V: Iterator<Item=U>> Foo<<U as Tr>::T> for V`
         impl_obligations.append(&mut substs.obligations);
 
-        VtableImplData { impl_def_id: impl_def_id,
+        VtableImplData { impl_def_id,
                          substs: substs.value,
                          nested: impl_obligations }
     }
@@ -2336,7 +2336,7 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
 
         VtableObjectData {
             upcast_trait_ref: upcast_trait_ref.unwrap(),
-            vtable_base: vtable_base,
+            vtable_base,
             nested: vec![]
         }
     }
@@ -2405,7 +2405,7 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
             ty::Predicate::ClosureKind(closure_def_id, kind)));
 
         Ok(VtableClosureData {
-            closure_def_id: closure_def_id,
+            closure_def_id,
             substs: substs.clone(),
             nested: obligations
         })
@@ -2826,8 +2826,8 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
             obligation.predicate.to_poly_trait_ref().fold_with(&mut self.freshener);
 
         TraitObligationStack {
-            obligation: obligation,
-            fresh_trait_ref: fresh_trait_ref,
+            obligation,
+            fresh_trait_ref,
             previous: previous_stack,
         }
     }
@@ -2911,7 +2911,7 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
             predicate.obligations.into_iter().chain(
                 Some(Obligation {
                     cause: cause.clone(),
-                    recursion_depth: recursion_depth,
+                    recursion_depth,
                     param_env,
                     predicate: predicate.value
                 }))

--- a/src/librustc/traits/structural_impls.rs
+++ b/src/librustc/traits/structural_impls.rs
@@ -209,15 +209,15 @@ impl<'a, 'tcx> Lift<'tcx> for traits::ObligationCauseCode<'a> {
                                                  trait_item_def_id,
                                                  lint_id } => {
                 Some(super::CompareImplMethodObligation {
-                    item_name: item_name,
-                    impl_item_def_id: impl_item_def_id,
-                    trait_item_def_id: trait_item_def_id,
-                    lint_id: lint_id,
+                    item_name,
+                    impl_item_def_id,
+                    trait_item_def_id,
+                    lint_id,
                 })
             }
             super::ExprAssignable => Some(super::ExprAssignable),
             super::MatchExpressionArm { arm_span, source } => {
-                Some(super::MatchExpressionArm { arm_span: arm_span,
+                Some(super::MatchExpressionArm { arm_span,
                                                  source: source })
             }
             super::IfExpression => Some(super::IfExpression),
@@ -253,7 +253,7 @@ impl<'a, 'tcx> Lift<'tcx> for traits::ObligationCause<'a> {
             traits::ObligationCause {
                 span: self.span,
                 body_id: self.body_id,
-                code: code,
+                code,
             }
         })
     }
@@ -271,9 +271,9 @@ impl<'a, 'tcx> Lift<'tcx> for traits::Vtable<'a, ()> {
             }) => {
                 tcx.lift(&substs).map(|substs| {
                     traits::VtableImpl(traits::VtableImplData {
-                        impl_def_id: impl_def_id,
-                        substs: substs,
-                        nested: nested
+                        impl_def_id,
+                        substs,
+                        nested,
                     })
                 })
             }
@@ -285,17 +285,17 @@ impl<'a, 'tcx> Lift<'tcx> for traits::Vtable<'a, ()> {
             }) => {
                 tcx.lift(&substs).map(|substs| {
                     traits::VtableClosure(traits::VtableClosureData {
-                        closure_def_id: closure_def_id,
-                        substs: substs,
-                        nested: nested
+                        closure_def_id,
+                        substs,
+                        nested,
                     })
                 })
             }
             traits::VtableFnPointer(traits::VtableFnPointerData { fn_ty, nested }) => {
                 tcx.lift(&fn_ty).map(|fn_ty| {
                     traits::VtableFnPointer(traits::VtableFnPointerData {
-                        fn_ty: fn_ty,
-                        nested: nested,
+                        fn_ty,
+                        nested,
                     })
                 })
             }
@@ -309,8 +309,8 @@ impl<'a, 'tcx> Lift<'tcx> for traits::Vtable<'a, ()> {
                 tcx.lift(&upcast_trait_ref).map(|trait_ref| {
                     traits::VtableObject(traits::VtableObjectData {
                         upcast_trait_ref: trait_ref,
-                        vtable_base: vtable_base,
-                        nested: nested
+                        vtable_base,
+                        nested,
                     })
                 })
             }

--- a/src/librustc/traits/util.rs
+++ b/src/librustc/traits/util.rs
@@ -288,7 +288,7 @@ pub fn supertrait_def_ids<'cx, 'gcx, 'tcx>(tcx: TyCtxt<'cx, 'gcx, 'tcx>,
                                            -> SupertraitDefIds<'cx, 'gcx, 'tcx>
 {
     SupertraitDefIds {
-        tcx: tcx,
+        tcx,
         stack: vec![trait_def_id],
         visited: Some(trait_def_id).into_iter().collect(),
     }
@@ -399,8 +399,8 @@ pub fn predicates_for_generics<'tcx>(cause: ObligationCause<'tcx>,
 
     generic_bounds.predicates.iter().map(|predicate| {
         Obligation { cause: cause.clone(),
-                     recursion_depth: recursion_depth,
-                     param_env: param_env,
+                     recursion_depth,
+                     param_env,
                      predicate: predicate.clone() }
     }).collect()
 }
@@ -413,9 +413,9 @@ pub fn predicate_for_trait_ref<'tcx>(
     -> PredicateObligation<'tcx>
 {
     Obligation {
-        cause: cause,
-        param_env: param_env,
-        recursion_depth: recursion_depth,
+        cause,
+        param_env,
+        recursion_depth,
         predicate: trait_ref.to_predicate(),
     }
 }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -107,7 +107,7 @@ pub struct CtxtInterners<'tcx> {
 impl<'gcx: 'tcx, 'tcx> CtxtInterners<'tcx> {
     fn new(arena: &'tcx DroplessArena) -> CtxtInterners<'tcx> {
         CtxtInterners {
-            arena: arena,
+            arena,
             type_: RefCell::new(FxHashSet()),
             type_list: RefCell::new(FxHashSet()),
             substs: RefCell::new(FxHashSet()),
@@ -732,12 +732,12 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             global_interners: interners,
             dep_graph: dep_graph.clone(),
             types: common_types,
-            named_region_map: named_region_map,
+            named_region_map,
             trait_map: resolutions.trait_map,
             export_map: resolutions.export_map,
             fulfilled_predicates: RefCell::new(fulfilled_predicates),
-            hir: hir,
-            def_path_hash_to_def_id: def_path_hash_to_def_id,
+            hir,
+            def_path_hash_to_def_id,
             maps: maps::Maps::new(providers),
             mir_passes,
             freevars: RefCell::new(resolutions.freevars),
@@ -745,7 +745,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             rcache: RefCell::new(FxHashMap()),
             normalized_cache: RefCell::new(FxHashMap()),
             inhabitedness_cache: RefCell::new(FxHashMap()),
-            lang_items: lang_items,
+            lang_items,
             used_unsafe: RefCell::new(NodeSet()),
             used_mut_nodes: RefCell::new(NodeSet()),
             stability: RefCell::new(stability),
@@ -753,7 +753,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             evaluation_cache: traits::EvaluationCache::new(),
             rvalue_promotable_to_static: RefCell::new(NodeMap()),
             crate_name: Symbol::intern(crate_name),
-            data_layout: data_layout,
+            data_layout,
             layout_interner: RefCell::new(FxHashSet()),
             layout_depth: Cell::new(0),
             derive_macros: RefCell::new(NodeMap()),
@@ -964,8 +964,8 @@ pub mod tls {
             let prev = tls.get();
             tls.set(Some((gcx_ptr, interners_ptr)));
             let ret = f(TyCtxt {
-                gcx: gcx,
-                interners: interners
+                gcx,
+                interners,
             });
             tls.set(prev);
             ret
@@ -980,8 +980,8 @@ pub mod tls {
             let gcx = unsafe { &*(gcx as *const GlobalCtxt) };
             let interners = unsafe { &*(interners as *const CtxtInterners) };
             f(TyCtxt {
-                gcx: gcx,
-                interners: interners
+                gcx,
+                interners,
             })
         })
     }
@@ -1408,7 +1408,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                       substs: &'tcx Substs<'tcx>)
         -> Ty<'tcx> {
         self.mk_closure_from_closure_substs(closure_id, ClosureSubsts {
-            substs: substs
+            substs,
         })
     }
 

--- a/src/librustc/ty/fold.rs
+++ b/src/librustc/ty/fold.rs
@@ -238,10 +238,10 @@ impl<'a, 'gcx, 'tcx> RegionFolder<'a, 'gcx, 'tcx> {
         where F : FnMut(ty::Region<'tcx>, u32) -> ty::Region<'tcx>
     {
         RegionFolder {
-            tcx: tcx,
-            skipped_regions: skipped_regions,
+            tcx,
+            skipped_regions,
             current_depth: 1,
-            fld_r: fld_r,
+            fld_r,
         }
     }
 }
@@ -393,9 +393,9 @@ impl<'a, 'gcx, 'tcx> RegionReplacer<'a, 'gcx, 'tcx> {
         where F : FnMut(ty::BoundRegion) -> ty::Region<'tcx>
     {
         RegionReplacer {
-            tcx: tcx,
+            tcx,
             current_depth: 1,
-            fld_r: fld_r,
+            fld_r,
             map: FxHashMap()
         }
     }
@@ -621,7 +621,7 @@ impl LateBoundRegionsCollector {
         LateBoundRegionsCollector {
             current_depth: 1,
             regions: FxHashSet(),
-            just_constrained: just_constrained,
+            just_constrained,
         }
     }
 }

--- a/src/librustc/ty/inhabitedness/def_id_forest.rs
+++ b/src/librustc/ty/inhabitedness/def_id_forest.rs
@@ -52,7 +52,7 @@ impl<'a, 'gcx, 'tcx> DefIdForest {
         let mut root_ids = SmallVec::new();
         root_ids.push(id);
         DefIdForest {
-            root_ids: root_ids,
+            root_ids,
         }
     }
 

--- a/src/librustc/ty/item_path.rs
+++ b/src/librustc/ty/item_path.rs
@@ -397,7 +397,7 @@ struct LocalPathBuffer {
 impl LocalPathBuffer {
     fn new(root_mode: RootMode) -> LocalPathBuffer {
         LocalPathBuffer {
-            root_mode: root_mode,
+            root_mode,
             str: String::new(),
         }
     }

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -609,7 +609,7 @@ impl<'a, 'tcx> Struct {
         };
 
         let mut ret = Struct {
-            align: align,
+            align,
             primitive_align: align,
             packed: repr.packed(),
             sized: true,
@@ -910,10 +910,10 @@ impl<'a, 'tcx> Union {
     fn new(dl: &TargetDataLayout, packed: bool) -> Union {
         let align = if packed { dl.i8_align } else { dl.aggregate_align };
         Union {
-            align: align,
+            align,
             primitive_align: align,
             min_size: Size::from_bytes(0),
-            packed: packed,
+            packed,
         }
     }
 
@@ -1169,8 +1169,8 @@ impl<'a, 'tcx> Layout {
                     sized: true,
                     align: element.align(dl),
                     primitive_align: element.primitive_align(dl),
-                    element_size: element_size,
-                    count: count
+                    element_size,
+                    count,
                 }
             }
             ty::TySlice(element) => {
@@ -1280,9 +1280,9 @@ impl<'a, 'tcx> Layout {
                     // grok.
                     let (discr, signed) = Integer::repr_discr(tcx, ty, &def.repr, min, max);
                     return success(CEnum {
-                        discr: discr,
-                        signed: signed,
-                        non_zero: non_zero,
+                        discr,
+                        signed,
+                        non_zero,
                         // FIXME: should be u128?
                         min: min as u64,
                         max: max as u64
@@ -1364,7 +1364,7 @@ impl<'a, 'tcx> Layout {
                             };
                             return success(RawNullablePointer {
                                 nndiscr: discr as u64,
-                                value: value,
+                                value,
                             });
                         }
 
@@ -1491,10 +1491,10 @@ impl<'a, 'tcx> Layout {
 
                 General {
                     discr: ity,
-                    variants: variants,
-                    size: size,
-                    align: align,
-                    primitive_align: primitive_align
+                    variants,
+                    size,
+                    align,
+                    primitive_align,
                 }
             }
 
@@ -1957,7 +1957,7 @@ impl<'a, 'tcx> SizeSkeleton<'tcx> {
                 ty::TyParam(_) | ty::TyProjection(_) => {
                     assert!(tail.has_param_types() || tail.has_self_ty());
                     Ok(SizeSkeleton::Pointer {
-                        non_zero: non_zero,
+                        non_zero,
                         tail: tcx.erase_regions(&tail)
                     })
                 }
@@ -2016,7 +2016,7 @@ impl<'a, 'tcx> SizeSkeleton<'tcx> {
                         return Ok(SizeSkeleton::Pointer {
                             non_zero: non_zero ||
                                 Some(def.did) == tcx.lang_items.non_zero(),
-                            tail: tail
+                            tail,
                         });
                     } else {
                         return Err(err);
@@ -2030,7 +2030,7 @@ impl<'a, 'tcx> SizeSkeleton<'tcx> {
                     (None, Some(SizeSkeleton::Pointer { non_zero: true, tail })) => {
                         Ok(SizeSkeleton::Pointer {
                             non_zero: false,
-                            tail: tail
+                            tail,
                         })
                     }
                     _ => Err(err)
@@ -2115,7 +2115,7 @@ impl<'a, 'tcx> LayoutTyper<'tcx> for LayoutCx<'a, 'tcx> {
         let ty = self.normalize_projections(ty);
 
         Ok(TyLayout {
-            ty: ty,
+            ty,
             layout: ty.layout(self.tcx, self.param_env)?,
             variant_index: None
         })

--- a/src/librustc/ty/maps.rs
+++ b/src/librustc/ty/maps.rs
@@ -246,7 +246,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             if let Some((i, _)) = stack.iter().enumerate().rev()
                                        .find(|&(_, &(_, ref q))| *q == query) {
                 return Err(CycleError {
-                    span: span,
+                    span,
                     cycle: RefMut::map(stack, |stack| &mut stack[i..])
                 });
             }

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -964,8 +964,8 @@ impl<'tcx> TraitPredicate<'tcx> {
                 .next()
                 .unwrap_or(trait_def_id);
         DepNode::new(tcx, DepConstructor::TraitSelect {
-            trait_def_id: trait_def_id,
-            input_def_id: input_def_id
+            trait_def_id,
+            input_def_id,
         })
     }
 
@@ -1244,12 +1244,12 @@ impl<'tcx> ParamEnv<'tcx> {
         if value.has_param_types() || value.has_self_ty() {
             ParamEnvAnd {
                 param_env: self,
-                value: value,
+                value,
             }
         } else {
             ParamEnvAnd {
                 param_env: ParamEnv::empty(self.reveal),
-                value: value,
+                value,
             }
         }
     }
@@ -1487,10 +1487,10 @@ impl<'a, 'gcx, 'tcx> AdtDef {
             AdtKind::Struct => {}
         }
         AdtDef {
-            did: did,
-            variants: variants,
-            flags: flags,
-            repr: repr,
+            did,
+            variants,
+            flags,
+            repr,
         }
     }
 
@@ -2113,11 +2113,11 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 
         AssociatedItem {
             name: trait_item_ref.name,
-            kind: kind,
+            kind,
             // Visibility of trait items is inherited from their traits.
             vis: Visibility::from_hir(parent_vis, trait_item_ref.id.node_id, self),
             defaultness: trait_item_ref.defaultness,
-            def_id: def_id,
+            def_id,
             container: TraitContainer(parent_def_id),
             method_has_self_argument: has_self
         }
@@ -2138,11 +2138,11 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 
         ty::AssociatedItem {
             name: impl_item_ref.name,
-            kind: kind,
+            kind,
             // Visibility of trait impl items doesn't matter.
             vis: ty::Visibility::from_hir(&impl_item_ref.vis, impl_item_ref.id.node_id, self),
             defaultness: impl_item_ref.defaultness,
-            def_id: def_id,
+            def_id,
             container: ImplContainer(parent_def_id),
             method_has_self_argument: has_self
         }

--- a/src/librustc/ty/relate.rs
+++ b/src/librustc/ty/relate.rs
@@ -182,8 +182,8 @@ impl<'tcx> Relate<'tcx> for ty::FnSig<'tcx> {
         Ok(ty::FnSig {
             inputs_and_output: relation.tcx().intern_type_list(&inputs_and_output),
             variadic: a.variadic,
-            unsafety: unsafety,
-            abi: abi
+            unsafety,
+            abi,
         })
     }
 }
@@ -250,9 +250,9 @@ impl<'tcx> Relate<'tcx> for ty::ExistentialProjection<'tcx> {
             let trait_ref = relation.relate(&a.trait_ref, &b.trait_ref)?;
             let ty = relation.relate(&a.ty, &b.ty)?;
             Ok(ty::ExistentialProjection {
-                trait_ref: trait_ref,
+                trait_ref,
                 item_name: a.item_name,
-                ty: ty
+                ty,
             })
         }
     }

--- a/src/librustc/ty/structural_impls.rs
+++ b/src/librustc/ty/structural_impls.rs
@@ -78,7 +78,7 @@ impl<'a, 'tcx> Lift<'tcx> for ty::TraitRef<'a> {
     fn lift_to_tcx<'b, 'gcx>(&self, tcx: TyCtxt<'b, 'gcx, 'tcx>) -> Option<Self::Lifted> {
         tcx.lift(&self.substs).map(|substs| ty::TraitRef {
             def_id: self.def_id,
-            substs: substs
+            substs,
         })
     }
 }
@@ -88,7 +88,7 @@ impl<'a, 'tcx> Lift<'tcx> for ty::ExistentialTraitRef<'a> {
     fn lift_to_tcx<'b, 'gcx>(&self, tcx: TyCtxt<'b, 'gcx, 'tcx>) -> Option<Self::Lifted> {
         tcx.lift(&self.substs).map(|substs| ty::ExistentialTraitRef {
             def_id: self.def_id,
-            substs: substs
+            substs,
         })
     }
 }
@@ -98,7 +98,7 @@ impl<'a, 'tcx> Lift<'tcx> for ty::TraitPredicate<'a> {
     fn lift_to_tcx<'b, 'gcx>(&self, tcx: TyCtxt<'b, 'gcx, 'tcx>)
                              -> Option<ty::TraitPredicate<'tcx>> {
         tcx.lift(&self.trait_ref).map(|trait_ref| ty::TraitPredicate {
-            trait_ref: trait_ref
+            trait_ref,
         })
     }
 }
@@ -117,8 +117,8 @@ impl<'a, 'tcx> Lift<'tcx> for ty::SubtypePredicate<'a> {
                              -> Option<ty::SubtypePredicate<'tcx>> {
         tcx.lift(&(self.a, self.b)).map(|(a, b)| ty::SubtypePredicate {
             a_is_expected: self.a_is_expected,
-            a: a,
-            b: b,
+            a,
+            b,
         })
     }
 }
@@ -146,8 +146,8 @@ impl<'a, 'tcx> Lift<'tcx> for ty::ProjectionPredicate<'a> {
                              -> Option<ty::ProjectionPredicate<'tcx>> {
         tcx.lift(&(self.projection_ty, self.ty)).map(|(projection_ty, ty)| {
             ty::ProjectionPredicate {
-                projection_ty: projection_ty,
-                ty: ty
+                projection_ty,
+                ty,
             }
         })
     }
@@ -158,9 +158,9 @@ impl<'a, 'tcx> Lift<'tcx> for ty::ExistentialProjection<'a> {
     fn lift_to_tcx<'b, 'gcx>(&self, tcx: TyCtxt<'b, 'gcx, 'tcx>) -> Option<Self::Lifted> {
         tcx.lift(&(self.trait_ref, self.ty)).map(|(trait_ref, ty)| {
             ty::ExistentialProjection {
-                trait_ref: trait_ref,
+                trait_ref,
                 item_name: self.item_name,
-                ty: ty
+                ty,
             }
         })
     }
@@ -300,8 +300,8 @@ impl<'tcx, T: Lift<'tcx>> Lift<'tcx> for ty::error::ExpectedFound<T> {
         tcx.lift(&self.expected).and_then(|expected| {
             tcx.lift(&self.found).map(|found| {
                 ty::error::ExpectedFound {
-                    expected: expected,
-                    found: found
+                    expected,
+                    found,
                 }
             })
         })
@@ -313,7 +313,7 @@ impl<'a, 'tcx> Lift<'tcx> for type_variable::Default<'a> {
     fn lift_to_tcx<'b, 'gcx>(&self, tcx: TyCtxt<'b, 'gcx, 'tcx>) -> Option<Self::Lifted> {
         tcx.lift(&self.ty).map(|ty| {
             type_variable::Default {
-                ty: ty,
+                ty,
                 origin_span: self.origin_span,
                 def_id: self.def_id
             }

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -571,8 +571,8 @@ impl<'a, 'tcx> ProjectionTy<'tcx> {
             |item| item.name == item_name).unwrap().def_id;
 
         ProjectionTy {
-            trait_ref: trait_ref,
-            item_def_id: item_def_id,
+            trait_ref,
+            item_def_id,
         }
     }
 

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -352,9 +352,9 @@ impl<'tcx, T:TypeFoldable<'tcx>> Subst<'tcx> for T {
                                span: Option<Span>)
                                -> T
     {
-        let mut folder = SubstFolder { tcx: tcx,
-                                       substs: substs,
-                                       span: span,
+        let mut folder = SubstFolder { tcx,
+                                       substs,
+                                       span,
                                        root_ty: None,
                                        ty_stack_depth: 0,
                                        region_binders_passed: 0 };

--- a/src/librustc/ty/wf.rs
+++ b/src/librustc/ty/wf.rs
@@ -31,10 +31,10 @@ pub fn obligations<'a, 'gcx, 'tcx>(infcx: &InferCtxt<'a, 'gcx, 'tcx>,
                                    span: Span)
                                    -> Option<Vec<traits::PredicateObligation<'tcx>>>
 {
-    let mut wf = WfPredicates { infcx: infcx,
-                                param_env: param_env,
-                                body_id: body_id,
-                                span: span,
+    let mut wf = WfPredicates { infcx,
+                                param_env,
+                                body_id,
+                                span,
                                 out: vec![] };
     if wf.compute(ty) {
         debug!("wf::obligations({:?}, body_id={:?}) = {:?}", ty, body_id, wf.out);


### PR DESCRIPTION
Commentary on #37340 [suggested](https://github.com/rust-lang/rust/issues/37340#issuecomment-255513390) using the new field init syntax in the compiler. Do we care about this? If so, here's a pull request for the librustc/ directory. While [`rustfmt` might do this in the future](https://github.com/rust-lang/rust/issues/37340#issuecomment-255513712), in the meantime, some simple Python will do:

```python
#!/usr/bin/env python3

import os, re, sys

OPPORTUNITY = re.compile(r" (\w+): \1,?\n")

def field_init_shorthand_substitution(filename):
    with open(filename) as f:
        text = f.read()
        revised = OPPORTUNITY.sub(r" \1,\n", text)
    with open(filename, 'w') as f:
        f.write(revised)

def substitute_in_directory(path):
    for dirname, _subdirs, basenames in os.walk(path):
        for basename in basenames:
            field_init_shorthand_substitution(os.path.join(dirname, basename))

if __name__ == "__main__":
    substitute_in_directory(sys.argv[1])
```

**Update 3 July**: edited the search (respectively replace) regex to ` (\w+): \1,?\n` (` \1,\n`) from ` (\w+): \1,` (` \1,`)