### PR TITLE
report the total number of errors on compilation failure

### DIFF
--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -28,6 +28,7 @@ use syntax::attr;
 use syntax::ptr::P;
 use syntax_pos::Span;
 use errors::DiagnosticBuilder;
+use util::common::ErrorReported;
 use util::nodemap::{NodeMap, NodeSet, FxHashSet, FxHashMap, DefIdMap};
 use rustc_back::slice;
 
@@ -255,7 +256,7 @@ const ROOT_SCOPE: ScopeRef<'static> = &Scope::Root;
 
 pub fn krate(sess: &Session,
              hir_map: &Map)
-             -> Result<NamedRegionMap, usize> {
+             -> Result<NamedRegionMap, ErrorReported> {
     let krate = hir_map.krate();
     let mut map = NamedRegionMap {
         defs: NodeMap(),

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -21,7 +21,7 @@ use session::search_paths::PathKind;
 use session::config::DebugInfoLevel;
 use ty::tls;
 use util::nodemap::{FxHashMap, FxHashSet};
-use util::common::duration_to_secs_str;
+use util::common::{duration_to_secs_str, ErrorReported};
 
 use syntax::ast::NodeId;
 use errors::{self, DiagnosticBuilder};
@@ -255,7 +255,10 @@ impl Session {
     pub fn abort_if_errors(&self) {
         self.diagnostic().abort_if_errors();
     }
-    pub fn track_errors<F, T>(&self, f: F) -> Result<T, usize>
+    pub fn compile_status(&self) -> Result<(), CompileIncomplete> {
+        compile_result_from_err_count(self.err_count())
+    }
+    pub fn track_errors<F, T>(&self, f: F) -> Result<T, ErrorReported>
         where F: FnOnce() -> T
     {
         let old_count = self.err_count();
@@ -264,7 +267,7 @@ impl Session {
         if errors == 0 {
             Ok(result)
         } else {
-            Err(errors)
+            Err(ErrorReported)
         }
     }
     pub fn span_warn<S: Into<MultiSpan>>(&self, sp: S, msg: &str) {
@@ -802,15 +805,23 @@ pub fn early_warn(output: config::ErrorOutputType, msg: &str) {
     handler.emit(&MultiSpan::new(), msg, errors::Level::Warning);
 }
 
-// Err(0) means compilation was stopped, but no errors were found.
-// This would be better as a dedicated enum, but using try! is so convenient.
-pub type CompileResult = Result<(), usize>;
+#[derive(Copy, Clone, Debug)]
+pub enum CompileIncomplete {
+    Stopped,
+    Errored(ErrorReported)
+}
+impl From<ErrorReported> for CompileIncomplete {
+    fn from(err: ErrorReported) -> CompileIncomplete {
+        CompileIncomplete::Errored(err)
+    }
+}
+pub type CompileResult = Result<(), CompileIncomplete>;
 
 pub fn compile_result_from_err_count(err_count: usize) -> CompileResult {
     if err_count == 0 {
         Ok(())
     } else {
-        Err(err_count)
+        Err(CompileIncomplete::Errored(ErrorReported))
     }
 }
 

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -13,7 +13,8 @@ use rustc::hir::lowering::lower_crate;
 use rustc::ich::Fingerprint;
 use rustc_data_structures::stable_hasher::StableHasher;
 use rustc_mir as mir;
-use rustc::session::{Session, CompileResult, compile_result_from_err_count};
+use rustc::session::{Session, CompileResult};
+use rustc::session::CompileIncomplete;
 use rustc::session::config::{self, Input, OutputFilenames, OutputType,
                              OutputTypes};
 use rustc::session::search_paths::PathKind;
@@ -23,7 +24,7 @@ use rustc::middle::privacy::AccessLevels;
 use rustc::mir::transform::{MIR_CONST, MIR_VALIDATED, MIR_OPTIMIZED, Passes};
 use rustc::ty::{self, TyCtxt, Resolutions, GlobalArenas};
 use rustc::traits;
-use rustc::util::common::time;
+use rustc::util::common::{ErrorReported, time};
 use rustc::util::nodemap::NodeSet;
 use rustc::util::fs::rename_or_copy_remove;
 use rustc_borrowck as borrowck;
@@ -78,7 +79,9 @@ pub fn compile_input(sess: &Session,
             }
 
             if control.$point.stop == Compilation::Stop {
-                return compile_result_from_err_count($tsess.err_count());
+                // FIXME: shouldn't this return Err(CompileIncomplete::Stopped)
+                // if there are no errors?
+                return $tsess.compile_status();
             }
         }}
     }
@@ -91,7 +94,7 @@ pub fn compile_input(sess: &Session,
             Ok(krate) => krate,
             Err(mut parse_error) => {
                 parse_error.emit();
-                return Err(1);
+                return Err(CompileIncomplete::Errored(ErrorReported));
             }
         };
 
@@ -194,7 +197,7 @@ pub fn compile_input(sess: &Session,
                 (control.after_analysis.callback)(&mut state);
 
                 if control.after_analysis.stop == Compilation::Stop {
-                    return result.and_then(|_| Err(0usize));
+                    return result.and_then(|_| Err(CompileIncomplete::Stopped));
                 }
             }
 
@@ -564,7 +567,7 @@ pub fn phase_2_configure_and_expand<F>(sess: &Session,
                                        addl_plugins: Option<Vec<String>>,
                                        make_glob_map: MakeGlobMap,
                                        after_expand: F)
-                                       -> Result<ExpansionResult, usize>
+                                       -> Result<ExpansionResult, CompileIncomplete>
     where F: FnOnce(&ast::Crate) -> CompileResult,
 {
     let time_passes = sess.time_passes();
@@ -636,7 +639,7 @@ pub fn phase_2_configure_and_expand<F>(sess: &Session,
     // Lint plugins are registered; now we can process command line flags.
     if sess.opts.describe_lints {
         super::describe_lints(&sess.lint_store.borrow(), true);
-        return Err(0);
+        return Err(CompileIncomplete::Stopped);
     }
     sess.track_errors(|| sess.lint_store.borrow_mut().process_command_line(sess))?;
 
@@ -839,7 +842,7 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
                                                arenas: &'tcx GlobalArenas<'tcx>,
                                                name: &str,
                                                f: F)
-                                               -> Result<R, usize>
+                                               -> Result<R, CompileIncomplete>
     where F: for<'a> FnOnce(TyCtxt<'a, 'tcx, 'tcx>,
                             ty::CrateAnalysis,
                             IncrementalHashesMap,
@@ -1019,7 +1022,7 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
         // lint warnings and so on -- kindck used to do this abort, but
         // kindck is gone now). -nmatsakis
         if sess.err_count() > 0 {
-            return Ok(f(tcx, analysis, incremental_hashes_map, Err(sess.err_count())));
+            return Ok(f(tcx, analysis, incremental_hashes_map, sess.compile_status()));
         }
 
         analysis.reachable =
@@ -1035,12 +1038,7 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
 
         time(time_passes, "lint checking", || lint::check_crate(tcx));
 
-        // The above three passes generate errors w/o aborting
-        if sess.err_count() > 0 {
-            return Ok(f(tcx, analysis, incremental_hashes_map, Err(sess.err_count())));
-        }
-
-        Ok(f(tcx, analysis, incremental_hashes_map, Ok(())))
+        return Ok(f(tcx, analysis, incremental_hashes_map, tcx.sess.compile_status()));
     })
 }
 
@@ -1116,11 +1114,7 @@ pub fn phase_5_run_llvm_passes(sess: &Session,
          "serialize work products",
          move || rustc_incremental::save_work_products(sess));
 
-    if sess.err_count() > 0 {
-        Err(sess.err_count())
-    } else {
-        Ok(())
-    }
+    sess.compile_status()
 }
 
 /// Run the linker on any artifacts that resulted from the LLVM run.

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -113,7 +113,8 @@ const BUG_REPORT_URL: &'static str = "https://github.com/rust-lang/rust/blob/mas
 fn abort_msg(err_count: usize) -> String {
     match err_count {
         0 => "aborting with no errors (maybe a bug?)".to_owned(),
-        _ => "aborting due to previous error(s)".to_owned(),
+        1 => "aborting due to previous error".to_owned(),
+        e => format!("aborting due to {} previous errors", e),
     }
 }
 

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -506,7 +506,10 @@ impl Handler {
 
                 return;
             }
-            _ => s = "aborting due to previous error(s)".to_string(),
+            1 => s = "aborting due to previous error".to_string(),
+            _ => {
+                s = format!("aborting due to {} previous errors", self.err_count.get());
+            }
         }
 
         panic!(self.fatal(&s));

--- a/src/librustc_passes/static_recursion.rs
+++ b/src/librustc_passes/static_recursion.rs
@@ -12,8 +12,9 @@
 // recursively.
 
 use rustc::hir::map as hir_map;
-use rustc::session::{CompileResult, Session};
+use rustc::session::Session;
 use rustc::hir::def::{Def, CtorKind};
+use rustc::util::common::ErrorReported;
 use rustc::util::nodemap::{NodeMap, NodeSet};
 
 use syntax::ast;
@@ -86,7 +87,9 @@ impl<'a, 'hir: 'a> Visitor<'hir> for CheckCrateVisitor<'a, 'hir> {
     }
 }
 
-pub fn check_crate<'hir>(sess: &Session, hir_map: &hir_map::Map<'hir>) -> CompileResult {
+pub fn check_crate<'hir>(sess: &Session, hir_map: &hir_map::Map<'hir>)
+                         -> Result<(), ErrorReported>
+{
     let mut visitor = CheckCrateVisitor {
         sess: sess,
         hir_map: hir_map,

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -108,7 +108,7 @@ use rustc::ty::subst::Substs;
 use rustc::ty::{self, Ty, TyCtxt};
 use rustc::ty::maps::Providers;
 use rustc::traits::{FulfillmentContext, ObligationCause, ObligationCauseCode, Reveal};
-use session::config;
+use session::{CompileIncomplete, config};
 use util::common::time;
 
 use syntax::ast;
@@ -293,7 +293,8 @@ pub fn provide(providers: &mut Providers) {
 }
 
 pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>)
-                             -> Result<(), usize> {
+                             -> Result<(), CompileIncomplete>
+{
     let time_passes = tcx.sess.time_passes();
 
     // this ensures that later parts of type checking can assume that items
@@ -328,12 +329,7 @@ pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>)
     check_unused::check_crate(tcx);
     check_for_entry_fn(tcx);
 
-    let err_count = tcx.sess.err_count();
-    if err_count == 0 {
-        Ok(())
-    } else {
-        Err(err_count)
-    }
+    tcx.sess.compile_status()
 }
 
 /// A quasi-deprecated helper used in rustdoc and save-analysis to get

--- a/src/test/run-make/llvm-phase/test.rs
+++ b/src/test/run-make/llvm-phase/test.rs
@@ -85,6 +85,6 @@ fn main() {
     let (result, _) = rustc_driver::run_compiler(
         &args, &mut JitCalls, Some(box JitLoader), None);
     if let Err(n) = result {
-        panic!("Error {}", n);
+        panic!("Error {:?}", n);
     }
 }

--- a/src/test/ui/block-result/block-must-not-have-result-do.stderr
+++ b/src/test/ui/block-result/block-must-not-have-result-do.stderr
@@ -7,5 +7,5 @@ error[E0308]: mismatched types
    = note: expected type `()`
               found type `bool`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/block-result/block-must-not-have-result-res.stderr
+++ b/src/test/ui/block-result/block-must-not-have-result-res.stderr
@@ -7,5 +7,5 @@ error[E0308]: mismatched types
    = note: expected type `()`
               found type `bool`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/block-result/block-must-not-have-result-while.stderr
+++ b/src/test/ui/block-result/block-must-not-have-result-while.stderr
@@ -7,5 +7,5 @@ error[E0308]: mismatched types
    = note: expected type `()`
               found type `bool`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/block-result/consider-removing-last-semi.stderr
+++ b/src/test/ui/block-result/consider-removing-last-semi.stderr
@@ -26,5 +26,5 @@ error[E0308]: mismatched types
    = note: expected type `std::string::String`
               found type `()`
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/block-result/issue-11714.stderr
+++ b/src/test/ui/block-result/issue-11714.stderr
@@ -13,5 +13,5 @@ error[E0308]: mismatched types
    = note: expected type `i32`
               found type `()`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/block-result/issue-13428.stderr
+++ b/src/test/ui/block-result/issue-13428.stderr
@@ -29,5 +29,5 @@ error[E0308]: mismatched types
    = note: expected type `std::string::String`
               found type `()`
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/block-result/issue-13624.stderr
+++ b/src/test/ui/block-result/issue-13624.stderr
@@ -16,5 +16,5 @@ error[E0308]: mismatched types
    = note: expected type `()`
               found type `a::Enum`
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/block-result/issue-20862.stderr
+++ b/src/test/ui/block-result/issue-20862.stderr
@@ -15,5 +15,5 @@ error[E0618]: expected function, found `()`
 17 |     let x = foo(5)(2);
    |             ^^^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/block-result/issue-22645.stderr
+++ b/src/test/ui/block-result/issue-22645.stderr
@@ -17,5 +17,5 @@ error[E0308]: mismatched types
    = note: expected type `()`
               found type `Bob`
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/block-result/issue-3563.stderr
+++ b/src/test/ui/block-result/issue-3563.stderr
@@ -15,5 +15,5 @@ error[E0308]: mismatched types
    = note: expected type `()`
               found type `[closure@$DIR/issue-3563.rs:13:9: 13:20 self:_]`
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/block-result/issue-5500.stderr
+++ b/src/test/ui/block-result/issue-5500.stderr
@@ -7,5 +7,5 @@ error[E0308]: mismatched types
    = note: expected type `()`
               found type `&_`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/block-result/unexpected-return-on-unit.stderr
+++ b/src/test/ui/block-result/unexpected-return-on-unit.stderr
@@ -11,5 +11,5 @@ help: did you mean to add a semicolon here?
 help: possibly return type missing here?
    | fn bar() -> usize {
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-in-static.stderr
+++ b/src/test/ui/borrowck/borrowck-in-static.stderr
@@ -6,5 +6,5 @@ error[E0507]: cannot move out of captured outer variable in an `Fn` closure
 15 |     Box::new(|| x) //~ ERROR cannot move out of captured outer variable
    |                 ^ cannot move out of captured outer variable in an `Fn` closure
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/borrowck/unboxed-closures-move-upvar-from-non-once-ref-closure.stderr
+++ b/src/test/ui/borrowck/unboxed-closures-move-upvar-from-non-once-ref-closure.stderr
@@ -7,5 +7,5 @@ error[E0507]: cannot move out of captured outer variable in an `Fn` closure
 21 |         y.into_iter();
    |         ^ cannot move out of captured outer variable in an `Fn` closure
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/check_match/issue-35609.stderr
+++ b/src/test/ui/check_match/issue-35609.stderr
@@ -46,5 +46,5 @@ error[E0004]: non-exhaustive patterns: `Some(B)`, `Some(C)`, `Some(D)` and 2 mor
 49 |     match Some(A) {
    |           ^^^^^^^ patterns `Some(B)`, `Some(C)`, `Some(D)` and 2 more not covered
 
-error: aborting due to previous error(s)
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/closure_context/issue-26046-fn-mut.stderr
+++ b/src/test/ui/closure_context/issue-26046-fn-mut.stderr
@@ -16,5 +16,5 @@ note: closure is `FnMut` because it mutates the variable `num` here
 15 |         num += 1;
    |         ^^^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/closure_context/issue-26046-fn-once.stderr
+++ b/src/test/ui/closure_context/issue-26046-fn-once.stderr
@@ -16,5 +16,5 @@ note: closure is `FnOnce` because it moves the variable `vec` out of its environ
 15 |         vec
    |         ^^^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/closure_context/issue-42065.stderr
+++ b/src/test/ui/closure_context/issue-42065.stderr
@@ -12,5 +12,5 @@ note: closure cannot be invoked more than once because it moves the variable `di
 16 |         for (key, value) in dict {
    |                             ^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/bad-format-args.stderr
+++ b/src/test/ui/codemap_tests/bad-format-args.stderr
@@ -22,5 +22,5 @@ error: expected token: `,`
    |
    = note: this error originates in a macro outside of the current crate
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/codemap_tests/coherence-overlapping-inherent-impl-trait.stderr
+++ b/src/test/ui/codemap_tests/coherence-overlapping-inherent-impl-trait.stderr
@@ -6,5 +6,5 @@ error[E0592]: duplicate definitions with name `f`
 15 | impl C { fn f() {} }
    |          --------- other definition for `f`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/empty_span.stderr
+++ b/src/test/ui/codemap_tests/empty_span.stderr
@@ -4,5 +4,5 @@ error[E0321]: cross-crate traits with a default impl, like `std::marker::Send`, 
 17 |     unsafe impl Send for &'static Foo { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/huge_multispan_highlight.stderr
+++ b/src/test/ui/codemap_tests/huge_multispan_highlight.stderr
@@ -7,5 +7,5 @@ error[E0596]: cannot borrow immutable local variable `x` as mutable
 100 |     let y = &mut x;
     |                  ^ cannot borrow mutably
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/issue-11715.stderr
+++ b/src/test/ui/codemap_tests/issue-11715.stderr
@@ -8,5 +8,5 @@ error[E0499]: cannot borrow `x` as mutable more than once at a time
 101 | }
     | - first borrow ends here
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/issue-28308.stderr
+++ b/src/test/ui/codemap_tests/issue-28308.stderr
@@ -6,5 +6,5 @@ error[E0600]: cannot apply unary operator `!` to type `&'static str`
    |
    = note: this error originates in a macro outside of the current crate
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/one_line.stderr
+++ b/src/test/ui/codemap_tests/one_line.stderr
@@ -7,5 +7,5 @@ error[E0499]: cannot borrow `v` as mutable more than once at a time
    |     |      second mutable borrow occurs here
    |     first mutable borrow occurs here
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/overlapping_inherent_impls.stderr
+++ b/src/test/ui/codemap_tests/overlapping_inherent_impls.stderr
@@ -25,5 +25,5 @@ error[E0592]: duplicate definitions with name `baz`
 43 |     fn baz(&self) {}
    |     ---------------- other definition for `baz`
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/codemap_tests/overlapping_spans.stderr
+++ b/src/test/ui/codemap_tests/overlapping_spans.stderr
@@ -7,5 +7,5 @@ error[E0509]: cannot move out of type `S`, which implements the `Drop` trait
    |         |    hint: to prevent move, use `ref _s` or `ref mut _s`
    |         cannot move out of here
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/tab.stderr
+++ b/src/test/ui/codemap_tests/tab.stderr
@@ -4,5 +4,5 @@ error[E0425]: cannot find value `bar` in this scope
 14 | \tbar;
    | \t^^^ not found in this scope
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/unicode.stderr
+++ b/src/test/ui/codemap_tests/unicode.stderr
@@ -4,5 +4,5 @@ error: invalid ABI: expected one of [cdecl, stdcall, fastcall, vectorcall, thisc
 11 | extern "路濫狼á́́" fn foo() {}
    |        ^^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/coercion-missing-tail-expected-type.stderr
+++ b/src/test/ui/coercion-missing-tail-expected-type.stderr
@@ -24,5 +24,5 @@ error[E0308]: mismatched types
    = note: expected type `std::result::Result<u8, u64>`
               found type `()`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/coercion-missing-tail-expected-type.stderr
+++ b/src/test/ui/coercion-missing-tail-expected-type.stderr
@@ -24,5 +24,5 @@ error[E0308]: mismatched types
    = note: expected type `std::result::Result<u8, u64>`
               found type `()`
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/compare-method/proj-outlives-region.stderr
+++ b/src/test/ui/compare-method/proj-outlives-region.stderr
@@ -11,5 +11,5 @@ error[E0276]: impl has stricter requirements than trait
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #37166 <https://github.com/rust-lang/rust/issues/37166>
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/compare-method/region-extra-2.stderr
+++ b/src/test/ui/compare-method/region-extra-2.stderr
@@ -10,5 +10,5 @@ error[E0276]: impl has stricter requirements than trait
 22 | |     }
    | |_____^ impl has extra requirement `'a: 'b`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/compare-method/region-extra.stderr
+++ b/src/test/ui/compare-method/region-extra.stderr
@@ -7,5 +7,5 @@ error[E0276]: impl has stricter requirements than trait
 22 |     fn foo() where 'a: 'b { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ impl has extra requirement `'a: 'b`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/compare-method/region-unrelated.stderr
+++ b/src/test/ui/compare-method/region-unrelated.stderr
@@ -11,5 +11,5 @@ error[E0276]: impl has stricter requirements than trait
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #37166 <https://github.com/rust-lang/rust/issues/37166>
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/compare-method/reordered-type-param.stderr
+++ b/src/test/ui/compare-method/reordered-type-param.stderr
@@ -10,5 +10,5 @@ error[E0053]: method `b` has an incompatible type for trait
    = note: expected type `fn(&E, F) -> F`
               found type `fn(&E, G) -> G`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/compare-method/trait-bound-on-type-parameter.stderr
+++ b/src/test/ui/compare-method/trait-bound-on-type-parameter.stderr
@@ -7,5 +7,5 @@ error[E0276]: impl has stricter requirements than trait
 25 |     fn b<F: Sync, G>(&self, _x: F) -> F { panic!() } //~ ERROR E0276
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl has extra requirement `F: std::marker::Sync`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/compare-method/traits-misc-mismatch-1.stderr
+++ b/src/test/ui/compare-method/traits-misc-mismatch-1.stderr
@@ -61,5 +61,5 @@ error[E0276]: impl has stricter requirements than trait
 76 |     fn method<G: Getter<usize>>(&self) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl has extra requirement `G: Getter<usize>`
 
-error: aborting due to previous error(s)
+error: aborting due to 7 previous errors
 

--- a/src/test/ui/compare-method/traits-misc-mismatch-2.stderr
+++ b/src/test/ui/compare-method/traits-misc-mismatch-2.stderr
@@ -10,5 +10,5 @@ error[E0276]: impl has stricter requirements than trait
 26 | |     }
    | |_____^ impl has extra requirement `U: Iterator<B>`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/cross-crate-macro-backtrace/main.stderr
+++ b/src/test/ui/cross-crate-macro-backtrace/main.stderr
@@ -6,5 +6,5 @@ error: invalid reference to argument `0` (no arguments given)
    |
    = note: this error originates in a macro outside of the current crate
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/E0178.stderr
+++ b/src/test/ui/did_you_mean/E0178.stderr
@@ -22,5 +22,5 @@ error[E0178]: expected a path on the left-hand side of `+`, not `fn() -> Foo`
 17 |     z: fn() -> Foo + 'a,
    |        ^^^^^^^^^^^^^^^^ perhaps you forgot parentheses?
 
-error: aborting due to previous error(s)
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/did_you_mean/issue-21659-show-relevant-trait-impls-1.stderr
+++ b/src/test/ui/did_you_mean/issue-21659-show-relevant-trait-impls-1.stderr
@@ -8,5 +8,5 @@ error[E0277]: the trait bound `Bar: Foo<usize>` is not satisfied
              <Bar as Foo<i32>>
              <Bar as Foo<u8>>
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/issue-21659-show-relevant-trait-impls-2.stderr
+++ b/src/test/ui/did_you_mean/issue-21659-show-relevant-trait-impls-2.stderr
@@ -11,5 +11,5 @@ error[E0277]: the trait bound `Bar: Foo<usize>` is not satisfied
              <Bar as Foo<u8>>
            and 2 others
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/issue-31424.stderr
+++ b/src/test/ui/did_you_mean/issue-31424.stderr
@@ -15,5 +15,5 @@ error[E0596]: cannot borrow immutable argument `self` as mutable
 23 |         (&mut self).bar();
    |               ^^^^ cannot borrow mutably
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/did_you_mean/issue-34126.stderr
+++ b/src/test/ui/did_you_mean/issue-34126.stderr
@@ -7,5 +7,5 @@ error[E0596]: cannot borrow immutable argument `self` as mutable
    |                       try removing `&mut` here
    |                       cannot reborrow mutably
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/issue-34337.stderr
+++ b/src/test/ui/did_you_mean/issue-34337.stderr
@@ -7,5 +7,5 @@ error[E0596]: cannot borrow immutable local variable `key` as mutable
    |              try removing `&mut` here
    |              cannot reborrow mutably
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/issue-35937.stderr
+++ b/src/test/ui/did_you_mean/issue-35937.stderr
@@ -22,5 +22,5 @@ error[E0594]: cannot assign to immutable field `s.x`
 30 |     s.x += 1;
    |     ^^^^^^^^ cannot mutably borrow immutable field
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/did_you_mean/issue-36798.stderr
+++ b/src/test/ui/did_you_mean/issue-36798.stderr
@@ -4,5 +4,5 @@ error[E0609]: no field `baz` on type `Foo`
 17 |     f.baz;
    |       ^^^ did you mean `bar`?
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/issue-36798_unknown_field.stderr
+++ b/src/test/ui/did_you_mean/issue-36798_unknown_field.stderr
@@ -4,5 +4,5 @@ error[E0609]: no field `zz` on type `Foo`
 17 |     f.zz;
    |       ^^ unknown field
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/issue-37139.stderr
+++ b/src/test/ui/did_you_mean/issue-37139.stderr
@@ -7,5 +7,5 @@ error[E0596]: cannot borrow immutable local variable `x` as mutable
    |                       try removing `&mut` here
    |                       cannot reborrow mutably
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/issue-38054-do-not-show-unresolved-names.stderr
+++ b/src/test/ui/did_you_mean/issue-38054-do-not-show-unresolved-names.stderr
@@ -10,5 +10,5 @@ error[E0432]: unresolved import `Foo1`
 13 | use Foo1;
    |     ^^^^ no `Foo1` in the root
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/did_you_mean/issue-38147-1.stderr
+++ b/src/test/ui/did_you_mean/issue-38147-1.stderr
@@ -6,5 +6,5 @@ error[E0389]: cannot borrow data mutably in a `&` reference
 27 |         self.s.push('x');
    |         ^^^^^^ assignment into an immutable reference
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/issue-38147-2.stderr
+++ b/src/test/ui/did_you_mean/issue-38147-2.stderr
@@ -7,5 +7,5 @@ error[E0596]: cannot borrow immutable borrowed content `*self.s` as mutable
 17 |         self.s.push('x');
    |         ^^^^^^ cannot borrow as mutable
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/issue-38147-3.stderr
+++ b/src/test/ui/did_you_mean/issue-38147-3.stderr
@@ -7,5 +7,5 @@ error[E0596]: cannot borrow immutable borrowed content `*self.s` as mutable
 17 |         self.s.push('x');
    |         ^^^^^^ cannot borrow as mutable
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/issue-38147-4.stderr
+++ b/src/test/ui/did_you_mean/issue-38147-4.stderr
@@ -6,5 +6,5 @@ error[E0389]: cannot borrow data mutably in a `&` reference
 16 |     f.s.push('x');
    |     ^^^ assignment into an immutable reference
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/issue-39544.stderr
+++ b/src/test/ui/did_you_mean/issue-39544.stderr
@@ -96,5 +96,5 @@ error[E0594]: cannot assign to immutable borrowed content `*x.0`
 58 |     *x.0 = 1;
    |     ^^^^^^^^ cannot borrow as mutable
 
-error: aborting due to previous error(s)
+error: aborting due to 12 previous errors
 

--- a/src/test/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
+++ b/src/test/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
@@ -39,5 +39,5 @@ error[E0277]: the trait bound `bool: Foo<i32>` is not satisfied
            and 2 others
    = note: required by `Foo::bar`
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/did_you_mean/issue-40006.stderr
+++ b/src/test/ui/did_you_mean/issue-40006.stderr
@@ -64,5 +64,5 @@ error[E0038]: the trait `X` cannot be made into an object
    |
    = note: method `xxx` has no receiver
 
-error: aborting due to previous error
+error: aborting due to 9 previous errors
 

--- a/src/test/ui/did_you_mean/issue-40006.stderr
+++ b/src/test/ui/did_you_mean/issue-40006.stderr
@@ -64,5 +64,5 @@ error[E0038]: the trait `X` cannot be made into an object
    |
    = note: method `xxx` has no receiver
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/issue-40396.stderr
+++ b/src/test/ui/did_you_mean/issue-40396.stderr
@@ -30,5 +30,5 @@ error: chained comparison operators require parentheses
    |
    = help: use `::<...>` instead of `<...>` if you meant to specify type arguments
 
-error: aborting due to previous error(s)
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/did_you_mean/issue-40823.stderr
+++ b/src/test/ui/did_you_mean/issue-40823.stderr
@@ -4,5 +4,5 @@ error[E0596]: cannot borrow immutable borrowed content `*buf` as mutable
 13 |     buf.iter_mut();
    |     ^^^ cannot borrow as mutable
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/issue-41679.stderr
+++ b/src/test/ui/did_you_mean/issue-41679.stderr
@@ -6,5 +6,5 @@ error: `~` can not be used as a unary operator
    |
    = help: use `!` instead of `~` if you meant to perform bitwise negation
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/recursion_limit.stderr
+++ b/src/test/ui/did_you_mean/recursion_limit.stderr
@@ -17,5 +17,5 @@ error[E0275]: overflow evaluating the requirement `K: std::marker::Send`
    = note: required because it appears within the type `A`
    = note: required by `is_send`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/recursion_limit_deref.stderr
+++ b/src/test/ui/did_you_mean/recursion_limit_deref.stderr
@@ -19,5 +19,5 @@ error[E0308]: mismatched types
    = note: expected type `&Bottom`
               found type `&Top`
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/did_you_mean/trait-object-reference-without-parens-suggestion.stderr
+++ b/src/test/ui/did_you_mean/trait-object-reference-without-parens-suggestion.stderr
@@ -18,5 +18,5 @@ error[E0038]: the trait `std::marker::Copy` cannot be made into an object
    |
    = note: the trait cannot require that `Self : Sized`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/trait-object-reference-without-parens-suggestion.stderr
+++ b/src/test/ui/did_you_mean/trait-object-reference-without-parens-suggestion.stderr
@@ -18,5 +18,5 @@ error[E0038]: the trait `std::marker::Copy` cannot be made into an object
    |
    = note: the trait cannot require that `Self : Sized`
 
-error: aborting due to previous error
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/dropck/dropck-eyepatch-extern-crate.stderr
+++ b/src/test/ui/dropck/dropck-eyepatch-extern-crate.stderr
@@ -42,5 +42,5 @@ error[E0597]: `c` does not live long enough
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/dropck/dropck-eyepatch-implies-unsafe-impl.stderr
+++ b/src/test/ui/dropck/dropck-eyepatch-implies-unsafe-impl.stderr
@@ -20,5 +20,5 @@ error[E0569]: requires an `unsafe impl` declaration due to `#[may_dangle]` attri
 43 | | }
    | |_^
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/dropck/dropck-eyepatch-reorder.stderr
+++ b/src/test/ui/dropck/dropck-eyepatch-reorder.stderr
@@ -42,5 +42,5 @@ error[E0597]: `c` does not live long enough
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/dropck/dropck-eyepatch.stderr
+++ b/src/test/ui/dropck/dropck-eyepatch.stderr
@@ -42,5 +42,5 @@ error[E0597]: `c` does not live long enough
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/fmt/format-string-error.stderr
+++ b/src/test/ui/fmt/format-string-error.stderr
@@ -16,5 +16,5 @@ error: invalid format string: unmatched `}` found
    = note: if you intended to print `}`, you can escape it using `}}`
    = note: this error originates in a macro outside of the current crate
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/impl-trait/equality.stderr
+++ b/src/test/ui/impl-trait/equality.stderr
@@ -51,5 +51,5 @@ error[E0308]: mismatched types
    = note: expected type `impl Foo` (i32)
               found type `impl Foo` (u32)
 
-error: aborting due to previous error(s)
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/impl-trait/issue-21659-show-relevant-trait-impls-3.stderr
+++ b/src/test/ui/impl-trait/issue-21659-show-relevant-trait-impls-3.stderr
@@ -8,5 +8,5 @@ error[E0599]: no method named `foo` found for type `Bar` in the current scope
    = note: the following trait defines an item `foo`, perhaps you need to implement it:
            candidate #1: `Foo`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/impl-trait/method-suggestion-no-duplication.stderr
+++ b/src/test/ui/impl-trait/method-suggestion-no-duplication.stderr
@@ -10,5 +10,5 @@ error[E0599]: no method named `is_empty` found for type `Foo` in the current sco
            candidate #2: `core::slice::SliceExt`
            candidate #3: `core::str::StrExt`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/impl-trait/no-method-suggested-traits.stderr
+++ b/src/test/ui/impl-trait/no-method-suggested-traits.stderr
@@ -226,5 +226,5 @@ error[E0599]: no method named `method3` found for type `std::rc::Rc<&mut std::bo
 131 |     std::rc::Rc::new(&mut Box::new(&no_method_suggested_traits::Bar::X)).method3();
     |                                                                          ^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to 24 previous errors
 

--- a/src/test/ui/impl-trait/trait_type.stderr
+++ b/src/test/ui/impl-trait/trait_type.stderr
@@ -31,5 +31,5 @@ error[E0046]: not all trait items implemented, missing: `fmt`
    |
    = note: `fmt` from trait: `fn(&Self, &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error>`
 
-error: aborting due to previous error(s)
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/interior-mutability/interior-mutability.stderr
+++ b/src/test/ui/interior-mutability/interior-mutability.stderr
@@ -10,5 +10,5 @@ error[E0277]: the trait bound `std::cell::UnsafeCell<i32>: std::panic::RefUnwind
    = note: required because it appears within the type `[closure@$DIR/interior-mutability.rs:15:18: 15:35 x:&std::cell::Cell<i32>]`
    = note: required by `std::panic::catch_unwind`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/invalid-module-declaration/invalid-module-declaration.stderr
+++ b/src/test/ui/invalid-module-declaration/invalid-module-declaration.stderr
@@ -10,5 +10,5 @@ note: maybe move this module `$DIR/auxiliary/foo/bar.rs` to its own directory vi
 11 | pub mod baz;
    |         ^^^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/issue-22644.stderr
+++ b/src/test/ui/issue-22644.stderr
@@ -20,5 +20,5 @@ error: `<` is interpreted as a start of generic arguments for `usize`, not a com
 help: if you want to compare the casted value then write:
    |     println!("{}", (a as usize) < 4);
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/issue-26548.stderr
+++ b/src/test/ui/issue-26548.stderr
@@ -5,5 +5,5 @@ note: ...which then requires computing layout of `std::option::Option<<S as Mirr
 note: ...which then requires computing layout of `<S as Mirror>::It`...
   = note: ...which then again requires computing layout of `S`, completing the cycle.
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/issue-33525.rs
+++ b/src/test/ui/issue-33525.rs
@@ -1,0 +1,15 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    a;
+    "".lorem;
+    "".ipsum;
+}

--- a/src/test/ui/issue-33525.stderr
+++ b/src/test/ui/issue-33525.stderr
@@ -1,0 +1,20 @@
+error[E0425]: cannot find value `a` in this scope
+  --> $DIR/issue-33525.rs:12:5
+   |
+12 |     a;
+   |     ^ not found in this scope
+
+error[E0609]: no field `lorem` on type `&'static str`
+  --> $DIR/issue-33525.rs:13:8
+   |
+13 |     "".lorem;
+   |        ^^^^^
+
+error[E0609]: no field `ipsum` on type `&'static str`
+  --> $DIR/issue-33525.rs:14:8
+   |
+14 |     "".ipsum;
+   |        ^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/issue-37311-type-length-limit/issue-37311.stderr
+++ b/src/test/ui/issue-37311-type-length-limit/issue-37311.stderr
@@ -8,5 +8,5 @@ error: reached the type-length limit while instantiating `<T as Foo><(&(&(&(&(&(
    |
    = note: consider adding a `#![type_length_limit="2097152"]` attribute to your crate
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/issue-38875/issue_38875.stderr
+++ b/src/test/ui/issue-38875/issue_38875.stderr
@@ -10,5 +10,5 @@ note: for repeat count here
 16 |     let test_x = [0; issue_38875_b::FOO];
    |                      ^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/issue-40402-ref-hints/issue-40402-1.stderr
+++ b/src/test/ui/issue-40402-ref-hints/issue-40402-1.stderr
@@ -7,5 +7,5 @@ error[E0507]: cannot move out of indexed content
    |             help: consider using a reference instead `&f.v[0]`
    |             cannot move out of indexed content
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/issue-40402-ref-hints/issue-40402-2.stderr
+++ b/src/test/ui/issue-40402-ref-hints/issue-40402-2.stderr
@@ -7,5 +7,5 @@ error[E0507]: cannot move out of indexed content
    |          |  ...and here (use `ref b` or `ref mut b`)
    |          hint: to prevent move, use `ref a` or `ref mut a`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/issue-41652/issue_41652.stderr
+++ b/src/test/ui/issue-41652/issue_41652.stderr
@@ -13,5 +13,5 @@ note: candidate #1 is defined in the trait `issue_41652_b::Tr`
    | |__________________________^
    = help: to disambiguate the method call, write `issue_41652_b::Tr::f(3)` instead
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else-2.stderr
+++ b/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else-2.stderr
@@ -6,5 +6,5 @@ error[E0621]: explicit lifetime required in the type of `x`
 12 |     if x > y { x } else { y }
    |                ^ lifetime `'a` required
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else-3.stderr
+++ b/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else-3.stderr
@@ -6,5 +6,5 @@ error[E0621]: explicit lifetime required in parameter type
 12 |     if x > y { x } else { y }
    |                           ^ lifetime `'a` required
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl-2.stderr
+++ b/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl-2.stderr
@@ -6,5 +6,5 @@ error[E0621]: explicit lifetime required in the type of `x`
 14 |    if x > y { x } else { y }
    |               ^ lifetime `'a` required
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl-3.stderr
+++ b/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl-3.stderr
@@ -7,5 +7,5 @@ error[E0621]: explicit lifetime required in the type of `x`
 18 |     if true { &self.field } else { x }
    |                                    ^ lifetime `'a` required
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl.stderr
+++ b/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl.stderr
@@ -23,5 +23,5 @@ note: ...but the borrowed content is only valid for the anonymous lifetime #1 de
 23 | |     }
    | |_____^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else.stderr
+++ b/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else.stderr
@@ -6,5 +6,5 @@ error[E0621]: explicit lifetime required in the type of `y`
 12 |     if x > y { x } else { y }
    |                           ^ lifetime `'a` required
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.stderr
+++ b/src/test/ui/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.stderr
@@ -23,5 +23,5 @@ note: ...but the borrowed content is only valid for the lifetime 'a as defined o
 20 | |   }
    | |___^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex1-return-one-existing-name-self-is-anon.stderr
+++ b/src/test/ui/lifetime-errors/ex1-return-one-existing-name-self-is-anon.stderr
@@ -23,5 +23,5 @@ note: ...but the borrowed content is only valid for the anonymous lifetime #1 de
 20 | |     }
    | |_____^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex1b-return-no-names-if-else.stderr
+++ b/src/test/ui/lifetime-errors/ex1b-return-no-names-if-else.stderr
@@ -6,5 +6,5 @@ error[E0106]: missing lifetime specifier
    |
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `x` or `y`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex2a-push-one-existing-name-2.stderr
+++ b/src/test/ui/lifetime-errors/ex2a-push-one-existing-name-2.stderr
@@ -6,5 +6,5 @@ error[E0621]: explicit lifetime required in the type of `x`
 16 |     y.push(x);
    |            ^ lifetime `'a` required
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex2a-push-one-existing-name.stderr
+++ b/src/test/ui/lifetime-errors/ex2a-push-one-existing-name.stderr
@@ -6,5 +6,5 @@ error[E0621]: explicit lifetime required in the type of `y`
 16 |     x.push(y);
    |            ^ lifetime `'a` required
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex2b-push-no-existing-names.stderr
+++ b/src/test/ui/lifetime-errors/ex2b-push-no-existing-names.stderr
@@ -21,5 +21,5 @@ note: ...does not necessarily outlive the anonymous lifetime #2 defined on the f
 17 | | }
    | |_^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex2c-push-inference-variable.stderr
+++ b/src/test/ui/lifetime-errors/ex2c-push-inference-variable.stderr
@@ -31,5 +31,5 @@ note: ...so that expression is assignable (expected Ref<'b, _>, found Ref<'_, _>
 17 |     x.push(z);
    |            ^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex2d-push-inference-variable-2.stderr
+++ b/src/test/ui/lifetime-errors/ex2d-push-inference-variable-2.stderr
@@ -33,5 +33,5 @@ note: ...so that expression is assignable (expected &mut std::vec::Vec<Ref<'_, i
 16 |     let a: &mut Vec<Ref<i32>> = x;
    |                                 ^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex2e-push-inference-variable-3.stderr
+++ b/src/test/ui/lifetime-errors/ex2e-push-inference-variable-3.stderr
@@ -33,5 +33,5 @@ note: ...so that expression is assignable (expected &mut std::vec::Vec<Ref<'_, i
 16 |     let a: &mut Vec<Ref<i32>> = x;
    |                                 ^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/borrowck-let-suggestion.stderr
+++ b/src/test/ui/lifetimes/borrowck-let-suggestion.stderr
@@ -10,5 +10,5 @@ error[E0597]: borrowed value does not live long enough
    |
    = note: consider using a `let` binding to increase its lifetime
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/lint/command-line-lint-group-deny.stderr
+++ b/src/test/ui/lint/command-line-lint-group-deny.stderr
@@ -6,5 +6,5 @@ error: variable `_InappropriateCamelCasing` should have a snake case name such a
    |
    = note: `-D non-snake-case` implied by `-D bad-style`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/lint/command-line-lint-group-forbid.stderr
+++ b/src/test/ui/lint/command-line-lint-group-forbid.stderr
@@ -6,5 +6,5 @@ error: variable `_InappropriateCamelCasing` should have a snake case name such a
    |
    = note: `-F non-snake-case` implied by `-F bad-style`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/lint/lint-group-style.stderr
+++ b/src/test/ui/lint/lint-group-style.stderr
@@ -63,5 +63,5 @@ note: lint level defined here
    |                 ^^^^^^^^^
    = note: #[warn(non_camel_case_types)] implied by #[warn(bad_style)]
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/outer-forbid.stderr
+++ b/src/test/ui/lint/outer-forbid.stderr
@@ -25,5 +25,5 @@ error[E0453]: allow(bad_style) overruled by outer forbid(non_snake_case)
 19 | #[allow(unused, unused_variables, bad_style)]
    |                                   ^^^^^^^^^ overruled by previous forbid
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/loop-break-value-no-repeat.stderr
+++ b/src/test/ui/loop-break-value-no-repeat.stderr
@@ -4,5 +4,5 @@ error[E0571]: `break` with value from a `for` loop
 22 |         break 22
    |         ^^^^^^^^ can only break with a value inside `loop`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/macros/bad_hello.stderr
+++ b/src/test/ui/macros/bad_hello.stderr
@@ -4,5 +4,5 @@ error: expected a literal
 12 |     println!(3 + 4);
    |              ^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/macros/format-foreign.stderr
+++ b/src/test/ui/macros/format-foreign.stderr
@@ -48,5 +48,5 @@ error: named argument never used
    = help: `$NAME` should be written as `{NAME}`
    = note: shell formatting not supported; see the documentation for `std::fmt`
 
-error: aborting due to previous error(s)
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/macros/macro-backtrace-invalid-internals.stderr
+++ b/src/test/ui/macros/macro-backtrace-invalid-internals.stderr
@@ -52,5 +52,5 @@ error[E0613]: attempted to access tuple index `0` on type `{integer}`, but the t
 56 |     let _ = fake_anon_field_expr!();
    |             ----------------------- in this macro invocation
 
-error: aborting due to previous error(s)
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/macros/macro-backtrace-nested.stderr
+++ b/src/test/ui/macros/macro-backtrace-nested.stderr
@@ -16,5 +16,5 @@ error[E0425]: cannot find value `fake` in this scope
 28 |     call_nested_expr_sum!();
    |     ------------------------ in this macro invocation
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/macros/macro-backtrace-println.stderr
+++ b/src/test/ui/macros/macro-backtrace-println.stderr
@@ -7,5 +7,5 @@ error: invalid reference to argument `0` (no arguments given)
 28 |     myprintln!("{}");
    |     ----------------- in this macro invocation
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/mismatched_types/E0053.stderr
+++ b/src/test/ui/mismatched_types/E0053.stderr
@@ -22,5 +22,5 @@ error[E0053]: method `bar` has an incompatible type for trait
    = note: expected type `fn(&Bar)`
               found type `fn(&mut Bar)`
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/mismatched_types/E0281.stderr
+++ b/src/test/ui/mismatched_types/E0281.stderr
@@ -9,5 +9,5 @@ error[E0281]: type mismatch: `[closure@$DIR/E0281.rs:14:9: 14:24]` implements th
    |
    = note: required by `foo`
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 

--- a/src/test/ui/mismatched_types/E0281.stderr
+++ b/src/test/ui/mismatched_types/E0281.stderr
@@ -9,5 +9,5 @@ error[E0281]: type mismatch: `[closure@$DIR/E0281.rs:14:9: 14:24]` implements th
    |
    = note: required by `foo`
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/mismatched_types/E0409.stderr
+++ b/src/test/ui/mismatched_types/E0409.stderr
@@ -15,5 +15,5 @@ error[E0308]: mismatched types
    = note: expected type `&{integer}`
               found type `{integer}`
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/mismatched_types/E0409.stderr
+++ b/src/test/ui/mismatched_types/E0409.stderr
@@ -15,5 +15,5 @@ error[E0308]: mismatched types
    = note: expected type `&{integer}`
               found type `{integer}`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/mismatched_types/abridged.stderr
+++ b/src/test/ui/mismatched_types/abridged.stderr
@@ -52,5 +52,5 @@ error[E0308]: mismatched types
    = note: expected type `X<X<_, std::string::String>, _>`
               found type `X<X<_, {integer}>, _>`
 
-error: aborting due to previous error(s)
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/mismatched_types/binops.stderr
+++ b/src/test/ui/mismatched_types/binops.stderr
@@ -46,5 +46,5 @@ error[E0277]: the trait bound `{integer}: std::cmp::PartialEq<std::result::Resul
    |
    = help: the trait `std::cmp::PartialEq<std::result::Result<{integer}, _>>` is not implemented for `{integer}`
 
-error: aborting due to 7 previous errors
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/mismatched_types/binops.stderr
+++ b/src/test/ui/mismatched_types/binops.stderr
@@ -46,5 +46,5 @@ error[E0277]: the trait bound `{integer}: std::cmp::PartialEq<std::result::Resul
    |
    = help: the trait `std::cmp::PartialEq<std::result::Result<{integer}, _>>` is not implemented for `{integer}`
 
-error: aborting due to previous error(s)
+error: aborting due to 7 previous errors
 

--- a/src/test/ui/mismatched_types/cast-rfc0401.stderr
+++ b/src/test/ui/mismatched_types/cast-rfc0401.stderr
@@ -246,5 +246,5 @@ help: did you mean `*s`?
 81 |     vec![0.0].iter().map(|s| s as f32).collect::<Vec<f32>>();
    |                              ^
 
-error: aborting due to previous error(s)
+error: aborting due to 34 previous errors
 

--- a/src/test/ui/mismatched_types/closure-arg-count.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-count.stderr
@@ -31,5 +31,5 @@ error[E0593]: closure takes 1 argument but 2 arguments are required
    |               |
    |               expected closure that takes 2 arguments
 
-error: aborting due to previous error(s)
+error: aborting due to 7 previous errors
 

--- a/src/test/ui/mismatched_types/closure-arg-count.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-count.stderr
@@ -31,5 +31,5 @@ error[E0593]: closure takes 1 argument but 2 arguments are required
    |               |
    |               expected closure that takes 2 arguments
 
-error: aborting due to 7 previous errors
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/mismatched_types/closure-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-mismatch.stderr
@@ -20,5 +20,5 @@ error[E0281]: type mismatch: `[closure@$DIR/closure-mismatch.rs:18:9: 18:15]` im
    = note: required because of the requirements on the impl of `Foo` for `[closure@$DIR/closure-mismatch.rs:18:9: 18:15]`
    = note: required by `baz`
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/mismatched_types/const-fn-in-trait.stderr
+++ b/src/test/ui/mismatched_types/const-fn-in-trait.stderr
@@ -10,5 +10,5 @@ error[E0379]: trait fns cannot be declared const
 21 |     const fn f() -> u32 { 22 }
    |     ^^^^^ trait fns cannot be const
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/mismatched_types/fn-variance-1.stderr
+++ b/src/test/ui/mismatched_types/fn-variance-1.stderr
@@ -14,5 +14,5 @@ error[E0281]: type mismatch: `fn(&isize) {takes_imm}` implements the trait `for<
    |
    = note: required by `apply`
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/mismatched_types/for-loop-has-unit-body.stderr
+++ b/src/test/ui/mismatched_types/for-loop-has-unit-body.stderr
@@ -7,5 +7,5 @@ error[E0308]: mismatched types
    = note: expected type `()`
               found type `{integer}`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/mismatched_types/issue-19109.stderr
+++ b/src/test/ui/mismatched_types/issue-19109.stderr
@@ -9,5 +9,5 @@ error[E0308]: mismatched types
    = note: expected type `()`
               found type `*mut Trait`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/mismatched_types/issue-26480.stderr
+++ b/src/test/ui/mismatched_types/issue-26480.stderr
@@ -18,5 +18,5 @@ error[E0605]: non-primitive cast: `{integer}` as `()`
    |
    = note: an `as` expression can only be used to convert between primitive types. Consider using the `From` trait
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/mismatched_types/issue-35030.stderr
+++ b/src/test/ui/mismatched_types/issue-35030.stderr
@@ -7,5 +7,5 @@ error[E0308]: mismatched types
    = note: expected type `bool` (type parameter)
               found type `bool` (bool)
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/mismatched_types/issue-36053-2.stderr
+++ b/src/test/ui/mismatched_types/issue-36053-2.stderr
@@ -17,5 +17,5 @@ error[E0281]: type mismatch: `[closure@$DIR/issue-36053-2.rs:17:39: 17:53]` impl
    |                                requires `for<'r> std::ops::FnMut<(&'r &str,)>`
    |                                expected &str, found str
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/mismatched_types/issue-36053-2.stderr
+++ b/src/test/ui/mismatched_types/issue-36053-2.stderr
@@ -17,5 +17,5 @@ error[E0281]: type mismatch: `[closure@$DIR/issue-36053-2.rs:17:39: 17:53]` impl
    |                                requires `for<'r> std::ops::FnMut<(&'r &str,)>`
    |                                expected &str, found str
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/mismatched_types/issue-38371.stderr
+++ b/src/test/ui/mismatched_types/issue-38371.stderr
@@ -32,5 +32,5 @@ error[E0529]: expected an array or slice, found `u32`
 34 | fn ugh(&[bar]: &u32) {
    |         ^^^^^ pattern cannot match with input type `u32`
 
-error: aborting due to previous error(s)
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/mismatched_types/main.stderr
+++ b/src/test/ui/mismatched_types/main.stderr
@@ -9,5 +9,5 @@ error[E0308]: mismatched types
    = note: expected type `u32`
               found type `()`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/mismatched_types/method-help-unsatisfied-bound.stderr
+++ b/src/test/ui/mismatched_types/method-help-unsatisfied-bound.stderr
@@ -7,5 +7,5 @@ error[E0599]: no method named `unwrap` found for type `std::result::Result<(), F
    = note: the method `unwrap` exists but the following trait bounds were not satisfied:
            `Foo : std::fmt::Debug`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/mismatched_types/overloaded-calls-bad.stderr
+++ b/src/test/ui/mismatched_types/overloaded-calls-bad.stderr
@@ -19,5 +19,5 @@ error[E0057]: this function takes 1 parameter but 2 parameters were supplied
 45 |     let ans = s("burma", "shave");
    |                 ^^^^^^^^^^^^^^^^ expected 1 parameter
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/mismatched_types/trait-bounds-cant-coerce.stderr
+++ b/src/test/ui/mismatched_types/trait-bounds-cant-coerce.stderr
@@ -7,5 +7,5 @@ error[E0308]: mismatched types
    = note: expected type `std::boxed::Box<Foo + std::marker::Send + 'static>`
               found type `std::boxed::Box<Foo + 'static>`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/mismatched_types/trait-impl-fn-incompatibility.stderr
+++ b/src/test/ui/mismatched_types/trait-impl-fn-incompatibility.stderr
@@ -22,5 +22,5 @@ error[E0053]: method `bar` has an incompatible type for trait
    = note: expected type `fn(&mut Bar, &mut Bar)`
               found type `fn(&mut Bar, &Bar)`
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
+++ b/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
@@ -12,5 +12,5 @@ error[E0281]: type mismatch: `[closure@$DIR/unboxed-closures-vtable-mismatch.rs:
    |
    = note: required by `call_it`
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
+++ b/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
@@ -12,5 +12,5 @@ error[E0281]: type mismatch: `[closure@$DIR/unboxed-closures-vtable-mismatch.rs:
    |
    = note: required by `call_it`
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 

--- a/src/test/ui/missing-items/issue-40221.stderr
+++ b/src/test/ui/missing-items/issue-40221.stderr
@@ -4,5 +4,5 @@ error[E0004]: non-exhaustive patterns: `C(QA)` not covered
 21 |     match proto {
    |           ^^^^^ pattern `C(QA)` not covered
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/missing-items/m2.stderr
+++ b/src/test/ui/missing-items/m2.stderr
@@ -11,5 +11,5 @@ error[E0046]: not all trait items implemented, missing: `CONSTANT`, `Type`, `met
    = note: `Type` from trait: `type Type;`
    = note: `method` from trait: `fn(&Self, std::string::String) -> <Self as m1::X>::Type`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/missing-items/m2.stderr
+++ b/src/test/ui/missing-items/m2.stderr
@@ -11,5 +11,5 @@ error[E0046]: not all trait items implemented, missing: `CONSTANT`, `Type`, `met
    = note: `Type` from trait: `type Type;`
    = note: `method` from trait: `fn(&Self, std::string::String) -> <Self as m1::X>::Type`
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/missing-items/missing-type-parameter.stderr
+++ b/src/test/ui/missing-items/missing-type-parameter.stderr
@@ -4,5 +4,5 @@ error[E0282]: type annotations needed
 14 |     foo();
    |     ^^^ cannot infer type for `X`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/pub/pub-restricted-error-fn.stderr
+++ b/src/test/ui/pub/pub-restricted-error-fn.stderr
@@ -4,5 +4,5 @@ error: unmatched visibility `pub`
 13 | pub(crate) () fn foo() {}
    |          ^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/pub/pub-restricted-error.stderr
+++ b/src/test/ui/pub/pub-restricted-error.stderr
@@ -4,5 +4,5 @@ error: expected identifier, found `(`
 16 |     pub(crate) () foo: usize,
    |                ^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/pub/pub-restricted-non-path.stderr
+++ b/src/test/ui/pub/pub-restricted-non-path.stderr
@@ -4,5 +4,5 @@ error: expected identifier, found `.`
 13 | pub (.) fn afn() {}
    |      ^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/pub/pub-restricted.stderr
+++ b/src/test/ui/pub/pub-restricted.stderr
@@ -48,5 +48,5 @@ error: visibilities can only be restricted to ancestor modules
 33 |         pub (in x) non_parent_invalid: usize,
    |                 ^
 
-error: aborting due to previous error(s)
+error: aborting due to 5 previous errors
 

--- a/src/test/ui/reachable/expr_add.stderr
+++ b/src/test/ui/reachable/expr_add.stderr
@@ -10,5 +10,5 @@ note: lint level defined here
 13 | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_again.stderr
+++ b/src/test/ui/reachable/expr_again.stderr
@@ -11,5 +11,5 @@ note: lint level defined here
    |         ^^^^^^^^^^^^^^^^
    = note: this error originates in a macro outside of the current crate
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_array.stderr
+++ b/src/test/ui/reachable/expr_array.stderr
@@ -16,5 +16,5 @@ error: unreachable expression
 25 |     let x: [usize; 2] = [22, return];
    |                         ^^^^^^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/reachable/expr_assign.stderr
+++ b/src/test/ui/reachable/expr_assign.stderr
@@ -22,5 +22,5 @@ error: unreachable expression
 36 |     *{return; &mut i} = 22;
    |               ^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/reachable/expr_block.stderr
+++ b/src/test/ui/reachable/expr_block.stderr
@@ -18,5 +18,5 @@ error: unreachable statement
    |
    = note: this error originates in a macro outside of the current crate
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/reachable/expr_box.stderr
+++ b/src/test/ui/reachable/expr_box.stderr
@@ -10,5 +10,5 @@ note: lint level defined here
 13 | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_call.stderr
+++ b/src/test/ui/reachable/expr_call.stderr
@@ -16,5 +16,5 @@ error: unreachable expression
 28 |     bar(return);
    |     ^^^^^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/reachable/expr_cast.stderr
+++ b/src/test/ui/reachable/expr_cast.stderr
@@ -10,5 +10,5 @@ note: lint level defined here
 14 | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_if.stderr
+++ b/src/test/ui/reachable/expr_if.stderr
@@ -11,5 +11,5 @@ note: lint level defined here
    |         ^^^^^^^^^^^^^^^^
    = note: this error originates in a macro outside of the current crate
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_loop.stderr
+++ b/src/test/ui/reachable/expr_loop.stderr
@@ -27,5 +27,5 @@ error: unreachable statement
    |
    = note: this error originates in a macro outside of the current crate
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/reachable/expr_match.stderr
+++ b/src/test/ui/reachable/expr_match.stderr
@@ -26,5 +26,5 @@ error: unreachable statement
    |
    = note: this error originates in a macro outside of the current crate
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/reachable/expr_method.stderr
+++ b/src/test/ui/reachable/expr_method.stderr
@@ -16,5 +16,5 @@ error: unreachable expression
 31 |     Foo.bar(return);
    |     ^^^^^^^^^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/reachable/expr_repeat.stderr
+++ b/src/test/ui/reachable/expr_repeat.stderr
@@ -10,5 +10,5 @@ note: lint level defined here
 14 | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_return.stderr
+++ b/src/test/ui/reachable/expr_return.stderr
@@ -10,5 +10,5 @@ note: lint level defined here
 14 | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_struct.stderr
+++ b/src/test/ui/reachable/expr_struct.stderr
@@ -28,5 +28,5 @@ error: unreachable expression
 40 |     let x = Foo { a: 22, b: return };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/reachable/expr_tup.stderr
+++ b/src/test/ui/reachable/expr_tup.stderr
@@ -16,5 +16,5 @@ error: unreachable expression
 25 |     let x: (usize, usize) = (2, return);
    |                             ^^^^^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/reachable/expr_type.stderr
+++ b/src/test/ui/reachable/expr_type.stderr
@@ -10,5 +10,5 @@ note: lint level defined here
 14 | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_unary.stderr
+++ b/src/test/ui/reachable/expr_unary.stderr
@@ -4,5 +4,5 @@ error[E0600]: cannot apply unary operator `!` to type `!`
 18 |     let x: ! = ! { return; 22 };
    |                ^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_while.stderr
+++ b/src/test/ui/reachable/expr_while.stderr
@@ -27,5 +27,5 @@ error: unreachable statement
    |
    = note: this error originates in a macro outside of the current crate
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/regions-fn-subtyping-return-static.stderr
+++ b/src/test/ui/regions-fn-subtyping-return-static.stderr
@@ -9,5 +9,5 @@ error[E0308]: mismatched types
    = note: lifetime parameter `'b` declared on fn `bar` appears only in the return type, but here is required to be higher-ranked, which means that `'b` must appear in both argument and return types
    = note: this error is the result of a recent bug fix; for more information, see issue #33685 <https://github.com/rust-lang/rust/issues/33685>
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/resolve/enums-are-namespaced-xc.stderr
+++ b/src/test/ui/resolve/enums-are-namespaced-xc.stderr
@@ -25,5 +25,5 @@ error[E0422]: cannot find struct, variant or union type `C` in module `namespace
 help: possible candidate is found in another module, you can import it into scope
    | use namespaced_enums::Foo::C;
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/resolve/issue-14254.stderr
+++ b/src/test/ui/resolve/issue-14254.stderr
@@ -144,5 +144,5 @@ error[E0425]: cannot find value `bah` in this scope
 
 error[E0601]: main function not found
 
-error: aborting due to previous error(s)
+error: aborting due to 25 previous errors
 

--- a/src/test/ui/resolve/issue-16058.stderr
+++ b/src/test/ui/resolve/issue-16058.stderr
@@ -9,5 +9,5 @@ help: possible better candidates are found in other modules, you can import them
    | use std::io::Result;
    | use std::thread::Result;
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/resolve/issue-17518.stderr
+++ b/src/test/ui/resolve/issue-17518.stderr
@@ -7,5 +7,5 @@ error[E0422]: cannot find struct, variant or union type `E` in this scope
 help: possible candidate is found in another module, you can import it into scope
    | use SomeEnum::E;
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/resolve/issue-18252.stderr
+++ b/src/test/ui/resolve/issue-18252.stderr
@@ -4,5 +4,5 @@ error[E0423]: expected function, found struct variant `Foo::Variant`
 16 |     let f = Foo::Variant(42);
    |             ^^^^^^^^^^^^ did you mean `Foo::Variant { /* fields */ }`?
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/resolve/issue-19452.stderr
+++ b/src/test/ui/resolve/issue-19452.stderr
@@ -10,5 +10,5 @@ error[E0423]: expected value, found struct variant `issue_19452_aux::Homura::Mad
 22 |     let homura = issue_19452_aux::Homura::Madoka;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ did you mean `issue_19452_aux::Homura::Madoka { /* fields */ }`?
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve/issue-23305.stderr
+++ b/src/test/ui/resolve/issue-23305.stderr
@@ -11,5 +11,5 @@ note: the cycle begins when processing `<impl at $DIR/issue-23305.rs:15:1: 15:20
    | ^^^^^^^^^^^^^^^^^^^
    = note: ...which then again requires processing `<impl at $DIR/issue-23305.rs:15:1: 15:20>`, completing the cycle.
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/resolve/issue-2356.stderr
+++ b/src/test/ui/resolve/issue-2356.stderr
@@ -106,5 +106,5 @@ error[E0424]: expected value, found module `self`
 122 |     self += 1;
     |     ^^^^ `self` value is only available in methods with `self` parameter
 
-error: aborting due to previous error(s)
+error: aborting due to 17 previous errors
 

--- a/src/test/ui/resolve/issue-24968.stderr
+++ b/src/test/ui/resolve/issue-24968.stderr
@@ -4,5 +4,5 @@ error[E0411]: cannot find type `Self` in this scope
 11 | fn foo(_: Self) {
    |           ^^^^ `Self` is only available in traits and impls
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/resolve/issue-33876.stderr
+++ b/src/test/ui/resolve/issue-33876.stderr
@@ -4,5 +4,5 @@ error[E0423]: expected value, found trait `Bar`
 20 |     let any: &Any = &Bar; //~ ERROR expected value, found trait `Bar`
    |                      ^^^ not a value
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/resolve/issue-3907-2.stderr
+++ b/src/test/ui/resolve/issue-3907-2.stderr
@@ -6,5 +6,5 @@ error[E0038]: the trait `issue_3907::Foo` cannot be made into an object
    |
    = note: method `bar` has no receiver
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/resolve/issue-39226.stderr
+++ b/src/test/ui/resolve/issue-39226.stderr
@@ -7,5 +7,5 @@ error[E0423]: expected value, found struct `Handle`
    |                 did you mean `handle`?
    |                 did you mean `Handle { /* fields */ }`?
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/resolve/issue-5035-2.stderr
+++ b/src/test/ui/resolve/issue-5035-2.stderr
@@ -7,5 +7,5 @@ error[E0277]: the trait bound `I + 'static: std::marker::Sized` is not satisfied
    = help: the trait `std::marker::Sized` is not implemented for `I + 'static`
    = note: all local variables must have a statically known size
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/resolve/issue-6702.stderr
+++ b/src/test/ui/resolve/issue-6702.stderr
@@ -4,5 +4,5 @@ error[E0423]: expected function, found struct `Monster`
 17 |     let _m = Monster(); //~ ERROR expected function, found struct `Monster`
    |              ^^^^^^^ did you mean `Monster { /* fields */ }`?
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/resolve/levenshtein.stderr
+++ b/src/test/ui/resolve/levenshtein.stderr
@@ -46,5 +46,5 @@ error[E0425]: cannot find value `second` in module `m`
 32 |     let b: m::first = m::second; // Misspelled item in module.
    |                          ^^^^^^ did you mean `Second`?
 
-error: aborting due to previous error(s)
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -65,5 +65,5 @@ error[E0603]: tuple struct `Z` is private
 45 |     xcrate::m::n::Z; //~ ERROR tuple struct `Z` is private
    |     ^^^^^^^^^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/resolve/resolve-assoc-suggestions.stderr
+++ b/src/test/ui/resolve/resolve-assoc-suggestions.stderr
@@ -52,5 +52,5 @@ error[E0425]: cannot find value `method` in this scope
 52 |         method;
    |         ^^^^^^ did you mean `self.method(...)`?
 
-error: aborting due to previous error(s)
+error: aborting due to 9 previous errors
 

--- a/src/test/ui/resolve/resolve-hint-macro.stderr
+++ b/src/test/ui/resolve/resolve-hint-macro.stderr
@@ -4,5 +4,5 @@ error[E0423]: expected function, found macro `assert`
 12 |     assert(true);
    |     ^^^^^^ did you mean `assert!(...)`?
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/resolve/resolve-speculative-adjustment.stderr
+++ b/src/test/ui/resolve/resolve-speculative-adjustment.stderr
@@ -22,5 +22,5 @@ error[E0425]: cannot find function `method` in this scope
 38 |         method();
    |         ^^^^^^ did you mean `self.method(...)`?
 
-error: aborting due to previous error(s)
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
+++ b/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
@@ -74,5 +74,5 @@ error[E0423]: expected function, found module `a::b`
 
 error[E0601]: main function not found
 
-error: aborting due to previous error(s)
+error: aborting due to 10 previous errors
 

--- a/src/test/ui/resolve/token-error-correct-2.stderr
+++ b/src/test/ui/resolve/token-error-correct-2.stderr
@@ -16,5 +16,5 @@ error[E0425]: cannot find value `foo` in this scope
 14 |     if foo {
    |        ^^^ not found in this scope
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve/token-error-correct-3.stderr
+++ b/src/test/ui/resolve/token-error-correct-3.stderr
@@ -42,5 +42,5 @@ error[E0308]: mismatched types
    = note: expected type `()`
               found type `std::result::Result<bool, std::io::Error>`
 
-error: aborting due to previous error
+error: aborting due to 5 previous errors
 

--- a/src/test/ui/resolve/token-error-correct-3.stderr
+++ b/src/test/ui/resolve/token-error-correct-3.stderr
@@ -42,5 +42,5 @@ error[E0308]: mismatched types
    = note: expected type `()`
               found type `std::result::Result<bool, std::io::Error>`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/resolve/token-error-correct.stderr
+++ b/src/test/ui/resolve/token-error-correct.stderr
@@ -52,5 +52,5 @@ error[E0425]: cannot find function `bar` in this scope
 14 |     foo(bar(;
    |         ^^^ not found in this scope
 
-error: aborting due to previous error(s)
+error: aborting due to 7 previous errors
 

--- a/src/test/ui/resolve/tuple-struct-alias.stderr
+++ b/src/test/ui/resolve/tuple-struct-alias.stderr
@@ -28,5 +28,5 @@ error[E0532]: expected tuple struct/variant, found type alias `A`
    |         did you mean `S`?
    |         did you mean `A { /* fields */ }`?
 
-error: aborting due to previous error(s)
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/resolve/unresolved_static_type_field.stderr
+++ b/src/test/ui/resolve/unresolved_static_type_field.stderr
@@ -7,5 +7,5 @@ error[E0425]: cannot find value `cx` in this scope
    |           did you mean `self.cx`?
    |           `self` value is only available in methods with `self` parameter
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/shadowed-type-parameter.stderr
+++ b/src/test/ui/shadowed-type-parameter.stderr
@@ -24,5 +24,5 @@ error[E0194]: type parameter `T` shadows another type parameter of the same name
 18 |     fn shadow_in_method<T>(&self) {}
    |                         ^ shadows another type parameter
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/span/E0046.stderr
+++ b/src/test/ui/span/E0046.stderr
@@ -7,5 +7,5 @@ error[E0046]: not all trait items implemented, missing: `foo`
 18 | impl Foo for Bar {}
    | ^^^^^^^^^^^^^^^^^^^ missing `foo` in implementation
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/E0057.stderr
+++ b/src/test/ui/span/E0057.stderr
@@ -10,5 +10,5 @@ error[E0057]: this function takes 1 parameter but 2 parameters were supplied
 15 |     let c = f(2, 3); //~ ERROR E0057
    |               ^^^^ expected 1 parameter
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/E0072.stderr
+++ b/src/test/ui/span/E0072.stderr
@@ -9,5 +9,5 @@ error[E0072]: recursive type `ListNode` has infinite size
    |
    = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `ListNode` representable
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/E0204.stderr
+++ b/src/test/ui/span/E0204.stderr
@@ -34,5 +34,5 @@ error[E0204]: the trait `Copy` may not be implemented for this type
 31 |     Bar(&'a mut bool),
    |         ------------- this field does not implement `Copy`
 
-error: aborting due to previous error(s)
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/span/E0493.stderr
+++ b/src/test/ui/span/E0493.stderr
@@ -7,5 +7,5 @@ error[E0493]: constants are not allowed to have destructors
 27 | const F : Foo = Foo { a : 0 };
    |                 ^^^^^^^^^^^^^ constants cannot have destructors
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/E0535.stderr
+++ b/src/test/ui/span/E0535.stderr
@@ -4,5 +4,5 @@ error[E0535]: invalid argument
 11 | #[inline(unknown)] //~ ERROR E0535
    |          ^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/E0536.stderr
+++ b/src/test/ui/span/E0536.stderr
@@ -4,5 +4,5 @@ error[E0536]: expected 1 cfg-pattern
 11 | #[cfg(not())] //~ ERROR E0536
    |       ^^^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/E0537.stderr
+++ b/src/test/ui/span/E0537.stderr
@@ -4,5 +4,5 @@ error[E0537]: invalid predicate `unknown`
 11 | #[cfg(unknown())] //~ ERROR E0537
    |       ^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
+++ b/src/test/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
@@ -82,5 +82,5 @@ error[E0596]: cannot borrow immutable borrowed content `*x` as mutable
 143 |     *x.y_mut() = 3; //~ ERROR cannot borrow
     |      ^ cannot borrow as mutable
 
-error: aborting due to previous error(s)
+error: aborting due to 10 previous errors
 

--- a/src/test/ui/span/borrowck-borrow-overloaded-deref-mut.stderr
+++ b/src/test/ui/span/borrowck-borrow-overloaded-deref-mut.stderr
@@ -30,5 +30,5 @@ error[E0596]: cannot borrow immutable borrowed content `*x` as mutable
 63 |     **x = 3; //~ ERROR cannot borrow
    |      ^^ cannot borrow as mutable
 
-error: aborting due to previous error(s)
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/span/borrowck-call-is-borrow-issue-12224.stderr
+++ b/src/test/ui/span/borrowck-call-is-borrow-issue-12224.stderr
@@ -47,5 +47,5 @@ error[E0507]: cannot move out of captured outer variable in an `FnMut` closure
 72 |         foo(f);
    |             ^ cannot move out of captured outer variable in an `FnMut` closure
 
-error: aborting due to previous error(s)
+error: aborting due to 5 previous errors
 

--- a/src/test/ui/span/borrowck-call-method-from-mut-aliasable.stderr
+++ b/src/test/ui/span/borrowck-call-method-from-mut-aliasable.stderr
@@ -7,5 +7,5 @@ error[E0596]: cannot borrow immutable borrowed content `*x` as mutable
 27 |     x.h(); //~ ERROR cannot borrow
    |     ^ cannot borrow as mutable
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/borrowck-fn-in-const-b.stderr
+++ b/src/test/ui/span/borrowck-fn-in-const-b.stderr
@@ -6,5 +6,5 @@ error[E0596]: cannot borrow immutable borrowed content `*x` as mutable
 17 |         x.push(format!("this is broken"));
    |         ^ cannot borrow as mutable
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/borrowck-let-suggestion-suffixes.stderr
+++ b/src/test/ui/span/borrowck-let-suggestion-suffixes.stderr
@@ -48,5 +48,5 @@ error[E0597]: borrowed value does not live long enough
    |
    = note: consider using a `let` binding to increase its lifetime
 
-error: aborting due to previous error(s)
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/span/borrowck-object-mutability.stderr
+++ b/src/test/ui/span/borrowck-object-mutability.stderr
@@ -16,5 +16,5 @@ error[E0596]: cannot borrow immutable `Box` content `*x` as mutable
 29 |     x.borrowed_mut(); //~ ERROR cannot borrow
    |     ^ cannot borrow as mutable
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/borrowck-ref-into-rvalue.stderr
+++ b/src/test/ui/span/borrowck-ref-into-rvalue.stderr
@@ -12,5 +12,5 @@ error[E0597]: borrowed value does not live long enough
    |
    = note: consider using a `let` binding to increase its lifetime
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/coerce-suggestions.stderr
+++ b/src/test/ui/span/coerce-suggestions.stderr
@@ -58,5 +58,5 @@ error[E0308]: mismatched types
    = help: try with `&mut format!("foo")`
    = note: this error originates in a macro outside of the current crate
 
-error: aborting due to previous error(s)
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/span/destructor-restrictions.stderr
+++ b/src/test/ui/span/destructor-restrictions.stderr
@@ -8,5 +8,5 @@ error[E0597]: `*a` does not live long enough
    |     |
    |     `*a` dropped here while still borrowed
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/dropck-object-cycle.stderr
+++ b/src/test/ui/span/dropck-object-cycle.stderr
@@ -9,5 +9,5 @@ error[E0597]: `*m` does not live long enough
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/dropck_arr_cycle_checked.stderr
+++ b/src/test/ui/span/dropck_arr_cycle_checked.stderr
@@ -63,5 +63,5 @@ error[E0597]: `b2` does not live long enough
     |
     = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/span/dropck_direct_cycle_with_drop.stderr
+++ b/src/test/ui/span/dropck_direct_cycle_with_drop.stderr
@@ -19,5 +19,5 @@ error[E0597]: `d1` does not live long enough
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/dropck_misc_variants.stderr
+++ b/src/test/ui/span/dropck_misc_variants.stderr
@@ -19,5 +19,5 @@ error[E0597]: `v` does not live long enough
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/dropck_vec_cycle_checked.stderr
+++ b/src/test/ui/span/dropck_vec_cycle_checked.stderr
@@ -63,5 +63,5 @@ error[E0597]: `c2` does not live long enough
     |
     = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/span/impl-wrong-item-for-trait.stderr
+++ b/src/test/ui/span/impl-wrong-item-for-trait.stderr
@@ -85,5 +85,5 @@ error[E0046]: not all trait items implemented, missing: `fmt`
    |
    = note: `fmt` from trait: `fn(&Self, &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error>`
 
-error: aborting due to 7 previous errors
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/span/impl-wrong-item-for-trait.stderr
+++ b/src/test/ui/span/impl-wrong-item-for-trait.stderr
@@ -85,5 +85,5 @@ error[E0046]: not all trait items implemented, missing: `fmt`
    |
    = note: `fmt` from trait: `fn(&Self, &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error>`
 
-error: aborting due to previous error(s)
+error: aborting due to 7 previous errors
 

--- a/src/test/ui/span/issue-11925.stderr
+++ b/src/test/ui/span/issue-11925.stderr
@@ -10,5 +10,5 @@ error[E0597]: `x` does not live long enough
 23 | }
    | - borrowed value needs to live until here
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/issue-15480.stderr
+++ b/src/test/ui/span/issue-15480.stderr
@@ -11,5 +11,5 @@ error[E0597]: borrowed value does not live long enough
    |
    = note: consider using a `let` binding to increase its lifetime
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/issue-23338-locals-die-before-temps-of-body.stderr
+++ b/src/test/ui/span/issue-23338-locals-die-before-temps-of-body.stderr
@@ -18,5 +18,5 @@ error[E0597]: `y` does not live long enough
    |     |
    |     `y` dropped here while still borrowed
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/issue-23729.stderr
+++ b/src/test/ui/span/issue-23729.stderr
@@ -12,5 +12,5 @@ error[E0046]: not all trait items implemented, missing: `Item`
    |
    = note: `Item` from trait: `type Item;`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/issue-23827.stderr
+++ b/src/test/ui/span/issue-23827.stderr
@@ -12,5 +12,5 @@ error[E0046]: not all trait items implemented, missing: `Output`
    |
    = note: `Output` from trait: `type Output;`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/issue-24356.stderr
+++ b/src/test/ui/span/issue-24356.stderr
@@ -11,5 +11,5 @@ error[E0046]: not all trait items implemented, missing: `Target`
    |
    = note: `Target` from trait: `type Target;`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/issue-24690.stderr
+++ b/src/test/ui/span/issue-24690.stderr
@@ -30,5 +30,5 @@ note: lint level defined here
    |         ^^^^^^^^
    = note: #[deny(unused_variables)] implied by #[deny(warnings)]
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/span/issue-24805-dropck-child-has-items-via-parent.stderr
+++ b/src/test/ui/span/issue-24805-dropck-child-has-items-via-parent.stderr
@@ -9,5 +9,5 @@ error[E0597]: `d1` does not live long enough
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/issue-24805-dropck-trait-has-items.stderr
+++ b/src/test/ui/span/issue-24805-dropck-trait-has-items.stderr
@@ -28,5 +28,5 @@ error[E0597]: `d1` does not live long enough
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/span/issue-24895-copy-clone-dropck.stderr
+++ b/src/test/ui/span/issue-24895-copy-clone-dropck.stderr
@@ -8,5 +8,5 @@ error[E0597]: `d1` does not live long enough
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/issue-25199.stderr
+++ b/src/test/ui/span/issue-25199.stderr
@@ -19,5 +19,5 @@ error[E0597]: `container` does not live long enough
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/issue-26656.stderr
+++ b/src/test/ui/span/issue-26656.stderr
@@ -8,5 +8,5 @@ error[E0597]: `ticking` does not live long enough
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/issue-27522.stderr
+++ b/src/test/ui/span/issue-27522.stderr
@@ -7,5 +7,5 @@ error[E0308]: mismatched method receiver
    = note: expected type `&Self`
               found type `&SomeType`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/issue-29106.stderr
+++ b/src/test/ui/span/issue-29106.stderr
@@ -18,5 +18,5 @@ error[E0597]: `x` does not live long enough
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/issue-29595.stderr
+++ b/src/test/ui/span/issue-29595.stderr
@@ -6,5 +6,5 @@ error[E0277]: the trait bound `u8: Tr` is not satisfied
    |
    = note: required by `Tr::C`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/issue-33884.stderr
+++ b/src/test/ui/span/issue-33884.stderr
@@ -8,5 +8,5 @@ error[E0308]: mismatched types
               found type `std::string::String`
    = note: this error originates in a macro outside of the current crate
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/issue-34264.stderr
+++ b/src/test/ui/span/issue-34264.stderr
@@ -45,5 +45,5 @@ error[E0061]: this function takes 2 parameters but 3 parameters were supplied
 19 |     bar(1, 2, 3);
    |         ^^^^^^^ expected 2 parameters
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/span/issue-34264.stderr
+++ b/src/test/ui/span/issue-34264.stderr
@@ -45,5 +45,5 @@ error[E0061]: this function takes 2 parameters but 3 parameters were supplied
 19 |     bar(1, 2, 3);
    |         ^^^^^^^ expected 2 parameters
 
-error: aborting due to 3 previous errors
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/span/issue-36530.stderr
+++ b/src/test/ui/span/issue-36530.stderr
@@ -14,5 +14,5 @@ error: The attribute `foo` is currently unknown to the compiler and may have mea
    |
    = help: add #![feature(custom_attribute)] to the crate attributes to enable
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/issue-36537.stderr
+++ b/src/test/ui/span/issue-36537.stderr
@@ -8,5 +8,5 @@ error[E0597]: `a` does not live long enough
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/issue-37767.stderr
+++ b/src/test/ui/span/issue-37767.stderr
@@ -55,5 +55,5 @@ note: candidate #2 is defined in the trait `F`
    |     ^^^^^^^^^^^^^^^
    = help: to disambiguate the method call, write `F::foo(a)` instead
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/span/issue-39018.stderr
+++ b/src/test/ui/span/issue-39018.stderr
@@ -15,5 +15,5 @@ error[E0369]: binary operation `+` cannot be applied to type `World`
    |
    = note: an implementation of `std::ops::Add` might be missing for `World`
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/issue-39698.stderr
+++ b/src/test/ui/span/issue-39698.stderr
@@ -38,5 +38,5 @@ error[E0408]: variable `c` is not bound in all patterns
    |         |             pattern doesn't bind `c`
    |         pattern doesn't bind `c`
 
-error: aborting due to previous error(s)
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/span/issue-40157.stderr
+++ b/src/test/ui/span/issue-40157.stderr
@@ -10,5 +10,5 @@ error[E0597]: `foo` does not live long enough
    |
    = note: this error originates in a macro outside of the current crate
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/issue-7575.stderr
+++ b/src/test/ui/span/issue-7575.stderr
@@ -63,5 +63,5 @@ note: candidate #1 is defined in the trait `ManyImplTrait`
    = note: the following trait defines an item `is_str`, perhaps you need to implement it:
            candidate #1: `ManyImplTrait`
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/span/issue28498-reject-ex1.stderr
+++ b/src/test/ui/span/issue28498-reject-ex1.stderr
@@ -19,5 +19,5 @@ error[E0597]: `foo.data` does not live long enough
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/issue28498-reject-lifetime-param.stderr
+++ b/src/test/ui/span/issue28498-reject-lifetime-param.stderr
@@ -20,5 +20,5 @@ error[E0597]: `first_dropped` does not live long enough
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/issue28498-reject-passed-to-fn.stderr
+++ b/src/test/ui/span/issue28498-reject-passed-to-fn.stderr
@@ -20,5 +20,5 @@ error[E0597]: `first_dropped` does not live long enough
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/issue28498-reject-trait-bound.stderr
+++ b/src/test/ui/span/issue28498-reject-trait-bound.stderr
@@ -20,5 +20,5 @@ error[E0597]: `first_dropped` does not live long enough
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/lint-unused-unsafe.stderr
+++ b/src/test/ui/span/lint-unused-unsafe.stderr
@@ -106,5 +106,5 @@ note: because it's nested under this `unsafe` fn
 44 | | }
    | |_^
 
-error: aborting due to previous error(s)
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/span/loan-extend.stderr
+++ b/src/test/ui/span/loan-extend.stderr
@@ -9,5 +9,5 @@ error[E0597]: `short` does not live long enough
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/move-closure.stderr
+++ b/src/test/ui/span/move-closure.stderr
@@ -7,5 +7,5 @@ error[E0308]: mismatched types
    = note: expected type `()`
               found type `[closure@$DIR/move-closure.rs:15:17: 15:27]`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/multiline-span-E0072.stderr
+++ b/src/test/ui/span/multiline-span-E0072.stderr
@@ -12,5 +12,5 @@ error[E0072]: recursive type `ListNode` has infinite size
    |
    = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `ListNode` representable
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/multiline-span-simple.stderr
+++ b/src/test/ui/span/multiline-span-simple.stderr
@@ -6,5 +6,5 @@ error[E0277]: the trait bound `u32: std::ops::Add<()>` is not satisfied
    |
    = help: the trait `std::ops::Add<()>` is not implemented for `u32`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/mut-arg-hint.stderr
+++ b/src/test/ui/span/mut-arg-hint.stderr
@@ -22,5 +22,5 @@ error[E0596]: cannot borrow immutable borrowed content `*a` as mutable
 25 |         a.push_str("foo");
    |         ^ cannot borrow as mutable
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/span/mut-ptr-cant-outlive-ref.stderr
+++ b/src/test/ui/span/mut-ptr-cant-outlive-ref.stderr
@@ -8,5 +8,5 @@ error[E0597]: `b` does not live long enough
 20 | }
    | - borrowed value needs to live until here
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/pub-struct-field.stderr
+++ b/src/test/ui/span/pub-struct-field.stderr
@@ -15,5 +15,5 @@ error[E0124]: field `bar` is already declared
 17 |     pub(crate) bar: u8,
    |     ^^^^^^^^^^^^^^^^^^ field already declared
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/range-2.stderr
+++ b/src/test/ui/span/range-2.stderr
@@ -20,5 +20,5 @@ error[E0597]: `b` does not live long enough
 21 | }
    | - borrowed value needs to live until here
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/recursive-type-field.stderr
+++ b/src/test/ui/span/recursive-type-field.stderr
@@ -27,5 +27,5 @@ error[E0072]: recursive type `Bar` has infinite size
    |
    = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `Bar` representable
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/regionck-unboxed-closure-lifetimes.stderr
+++ b/src/test/ui/span/regionck-unboxed-closure-lifetimes.stderr
@@ -9,5 +9,5 @@ error[E0597]: `c` does not live long enough
 20 | }
    | - borrowed value needs to live until here
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/regions-close-over-borrowed-ref-in-obj.stderr
+++ b/src/test/ui/span/regions-close-over-borrowed-ref-in-obj.stderr
@@ -9,5 +9,5 @@ error[E0597]: borrowed value does not live long enough
 23 | }
    | - temporary value needs to live until here
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/regions-close-over-type-parameter-2.stderr
+++ b/src/test/ui/span/regions-close-over-type-parameter-2.stderr
@@ -9,5 +9,5 @@ error[E0597]: `tmp0` does not live long enough
    |     |
    |     `tmp0` dropped here while still borrowed
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/regions-escape-loop-via-variable.stderr
+++ b/src/test/ui/span/regions-escape-loop-via-variable.stderr
@@ -8,5 +8,5 @@ error[E0597]: `x` does not live long enough
 23 | }
    | - borrowed value needs to live until here
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/regions-escape-loop-via-vec.stderr
+++ b/src/test/ui/span/regions-escape-loop-via-vec.stderr
@@ -37,5 +37,5 @@ error[E0506]: cannot assign to `x` because it is borrowed
 24 |         x += 1; //~ ERROR cannot assign
    |         ^^^^^^ assignment to borrowed `x` occurs here
 
-error: aborting due to previous error(s)
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/span/regions-infer-borrow-scope-within-loop.stderr
+++ b/src/test/ui/span/regions-infer-borrow-scope-within-loop.stderr
@@ -10,5 +10,5 @@ error[E0597]: `*x` does not live long enough
 30 | }
    | - borrowed value needs to live until here
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/send-is-not-static-ensures-scoping.stderr
+++ b/src/test/ui/span/send-is-not-static-ensures-scoping.stderr
@@ -24,5 +24,5 @@ error[E0597]: `y` does not live long enough
 35 | }
    | - borrowed value needs to live until here
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/send-is-not-static-std-sync-2.stderr
+++ b/src/test/ui/span/send-is-not-static-std-sync-2.stderr
@@ -32,5 +32,5 @@ error[E0597]: `x` does not live long enough
 44 | }
    | - borrowed value needs to live until here
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/span/send-is-not-static-std-sync.stderr
+++ b/src/test/ui/span/send-is-not-static-std-sync.stderr
@@ -52,5 +52,5 @@ error[E0505]: cannot move out of `y` because it is borrowed
 49 |     drop(y); //~ ERROR cannot move out
    |          ^ move out of `y` occurs here
 
-error: aborting due to previous error(s)
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/span/slice-borrow.stderr
+++ b/src/test/ui/span/slice-borrow.stderr
@@ -9,5 +9,5 @@ error[E0597]: borrowed value does not live long enough
 19 | }
    | - temporary value needs to live until here
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/suggestion-non-ascii.stderr
+++ b/src/test/ui/span/suggestion-non-ascii.stderr
@@ -4,5 +4,5 @@ error[E0608]: cannot index into a value of type `({integer},)`
 14 |     println!("☃{}", tup[0]);
    |                     ^^^^^^ help: to access tuple elements, use `tup.0`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/type-binding.stderr
+++ b/src/test/ui/span/type-binding.stderr
@@ -4,5 +4,5 @@ error[E0220]: associated type `Trget` not found for `std::ops::Deref`
 16 | fn homura<T: Deref<Trget = i32>>(_: T) {}
    |                    ^^^^^^^^^^^ associated type `Trget` not found
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/span/typo-suggestion.stderr
+++ b/src/test/ui/span/typo-suggestion.stderr
@@ -10,5 +10,5 @@ error[E0425]: cannot find value `fob` in this scope
 18 |     println!("Hello {}", fob);
    |                          ^^^ did you mean `foo`?
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/vec-must-not-hide-type-from-dropck.stderr
+++ b/src/test/ui/span/vec-must-not-hide-type-from-dropck.stderr
@@ -19,5 +19,5 @@ error[E0597]: `c1` does not live long enough
     |
     = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/vec_refs_data_with_early_death.stderr
+++ b/src/test/ui/span/vec_refs_data_with_early_death.stderr
@@ -20,5 +20,5 @@ error[E0597]: `y` does not live long enough
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error(s)
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/wf-method-late-bound-regions.stderr
+++ b/src/test/ui/span/wf-method-late-bound-regions.stderr
@@ -9,5 +9,5 @@ error[E0597]: `pointer` does not live long enough
 33 | }
    | - borrowed value needs to live until here
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/static-lifetime.stderr
+++ b/src/test/ui/static-lifetime.stderr
@@ -6,5 +6,5 @@ error[E0477]: the type `std::borrow::Cow<'a, A>` does not fulfill the required l
    |
    = note: type must satisfy the static lifetime
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/suggestions/confuse-field-and-method/issue-18343.stderr
+++ b/src/test/ui/suggestions/confuse-field-and-method/issue-18343.stderr
@@ -6,5 +6,5 @@ error[E0599]: no method named `closure` found for type `Obj<[closure@$DIR/issue-
    |
    = help: use `(o.closure)(...)` if you meant to call the function stored in the `closure` field
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/suggestions/confuse-field-and-method/issue-2392.stderr
+++ b/src/test/ui/suggestions/confuse-field-and-method/issue-2392.stderr
@@ -86,5 +86,5 @@ error[E0599]: no method named `f3` found for type `FuncContainer` in the current
     |
     = help: use `((*self.container).f3)(...)` if you meant to call the function stored in the `f3` field
 
-error: aborting due to previous error(s)
+error: aborting due to 11 previous errors
 

--- a/src/test/ui/suggestions/confuse-field-and-method/issue-32128.stderr
+++ b/src/test/ui/suggestions/confuse-field-and-method/issue-32128.stderr
@@ -6,5 +6,5 @@ error[E0599]: no method named `example` found for type `Example` in the current 
    |
    = help: use `(demo.example)(...)` if you meant to call the function stored in the `example` field
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/suggestions/confuse-field-and-method/issue-33784.stderr
+++ b/src/test/ui/suggestions/confuse-field-and-method/issue-33784.stderr
@@ -22,5 +22,5 @@ error[E0599]: no method named `c_fn_ptr` found for type `&D` in the current scop
    |
    = help: use `(s.c_fn_ptr)(...)` if you meant to call the function stored in the `c_fn_ptr` field
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/suggestions/confuse-field-and-method/private-field.stderr
+++ b/src/test/ui/suggestions/confuse-field-and-method/private-field.stderr
@@ -4,5 +4,5 @@ error[E0599]: no method named `dog_age` found for type `animal::Dog` in the curr
 26 |     let dog_age = dog.dog_age();
    |                       ^^^^^^^ private field, not a method
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/suggestions/tuple-float-index.stderr
+++ b/src/test/ui/suggestions/tuple-float-index.stderr
@@ -7,5 +7,5 @@ error: unexpected token: `1.1`
    |     |           unexpected token
    |     help: try parenthesizing the first index `((1, (2, 3)).1).1`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/token/bounds-obj-parens.stderr
+++ b/src/test/ui/token/bounds-obj-parens.stderr
@@ -4,5 +4,5 @@ error: expected one of `!` or `::`, found `<eof>`
 15 | FAIL
    | ^^^^ expected one of `!` or `::` here
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/token/issue-10636-2.stderr
+++ b/src/test/ui/token/issue-10636-2.stderr
@@ -24,5 +24,5 @@ error: expected expression, found `)`
 
 error[E0601]: main function not found
 
-error: aborting due to previous error(s)
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/token/issue-41155.stderr
+++ b/src/test/ui/token/issue-41155.stderr
@@ -14,5 +14,5 @@ error[E0412]: cannot find type `S` in this scope
 
 error[E0601]: main function not found
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/token/macro-incomplete-parse.stderr
+++ b/src/test/ui/token/macro-incomplete-parse.stderr
@@ -28,5 +28,5 @@ note: caused by the macro expansion here; the usage of `ignored_pat!` is likely 
 37 |         ignored_pat!() => (), //~ NOTE caused by the macro expansion here
    |         ^^^^^^^^^^^^^^
 
-error: aborting due to previous error(s)
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/token/trailing-plus-in-bounds.stderr
+++ b/src/test/ui/token/trailing-plus-in-bounds.stderr
@@ -4,5 +4,5 @@ error: expected one of `!` or `::`, found `<eof>`
 19 | FAIL
    | ^^^^ expected one of `!` or `::` here
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/transmute/main.stderr
+++ b/src/test/ui/transmute/main.stderr
@@ -34,5 +34,5 @@ error[E0512]: transmute called with types of different sizes
    = note: source type: i32 (32 bits)
    = note: target type: Foo (0 bits)
 
-error: aborting due to previous error(s)
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/transmute/transmute-from-fn-item-types-error.stderr
+++ b/src/test/ui/transmute/transmute-from-fn-item-types-error.stderr
@@ -104,5 +104,5 @@ error[E0512]: transmute called with types of different sizes
    = note: source type: std::option::Option<fn()> (64 bits)
    = note: target type: u32 (32 bits)
 
-error: aborting due to previous error(s)
+error: aborting due to 11 previous errors
 

--- a/src/test/ui/transmute/transmute-type-parameters.stderr
+++ b/src/test/ui/transmute/transmute-type-parameters.stderr
@@ -52,5 +52,5 @@ error[E0512]: transmute called with types of different sizes
    = note: source type: std::option::Option<T> (size can vary because of T)
    = note: target type: i32 (32 bits)
 
-error: aborting due to previous error(s)
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/type-check/assignment-in-if.stderr
+++ b/src/test/ui/type-check/assignment-in-if.stderr
@@ -55,5 +55,5 @@ error[E0308]: mismatched types
    = note: expected type `bool`
               found type `()`
 
-error: aborting due to previous error(s)
+error: aborting due to 5 previous errors
 

--- a/src/test/ui/type-check/cannot_infer_local_or_array.stderr
+++ b/src/test/ui/type-check/cannot_infer_local_or_array.stderr
@@ -6,5 +6,5 @@ error[E0282]: type annotations needed
    |         |
    |         consider giving `x` a type
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/type-check/cannot_infer_local_or_vec.stderr
+++ b/src/test/ui/type-check/cannot_infer_local_or_vec.stderr
@@ -8,5 +8,5 @@ error[E0282]: type annotations needed
    |
    = note: this error originates in a macro outside of the current crate
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/type-check/cannot_infer_local_or_vec_in_tuples.stderr
+++ b/src/test/ui/type-check/cannot_infer_local_or_vec_in_tuples.stderr
@@ -8,5 +8,5 @@ error[E0282]: type annotations needed
    |
    = note: this error originates in a macro outside of the current crate
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/type-check/issue-22897.stderr
+++ b/src/test/ui/type-check/issue-22897.stderr
@@ -4,5 +4,5 @@ error[E0282]: type annotations needed
 14 |     [];
    |     ^^ cannot infer type for `[_; 0]`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/type-check/issue-40294.stderr
+++ b/src/test/ui/type-check/issue-40294.stderr
@@ -12,5 +12,5 @@ error[E0283]: type annotations required: cannot resolve `&'a T: Foo`
    |
    = note: required by `Foo`
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 

--- a/src/test/ui/type-check/unknown_type_for_closure.stderr
+++ b/src/test/ui/type-check/unknown_type_for_closure.stderr
@@ -4,5 +4,5 @@ error[E0282]: type annotations needed
 12 |     let x = |_| {    };
    |              ^ consider giving this closure parameter a type
 
-error: aborting due to previous error(s)
+error: aborting due to previous error
 


### PR DESCRIPTION
Prior to this PR, when we aborted because a "critical pass" failed, we displayed the number of errors from that critical pass. While that's the number of errors that caused compilation to abort in *that place*, that's not what people really want to know. Instead, always report the total number of errors, and don't bother to track the number of errors from the last pass that failed.
    
This changes the compiler driver API to handle errors more smoothly, therefore is a compiler-api-[breaking-change].

Fixes #42793.

r? @eddyb 
