### PR TITLE
Remove unused code from librustc_errors

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -1373,7 +1373,7 @@ impl Destination {
 
     fn apply_style(&mut self, lvl: Level, style: Style) -> io::Result<()> {
         match style {
-            Style::FileNameStyle | Style::LineAndColumn => {}
+            Style::LineAndColumn => {}
             Style::LineNumber => {
                 self.start_attr(term::Attr::Bold)?;
                 if cfg!(windows) {
@@ -1382,16 +1382,8 @@ impl Destination {
                     self.start_attr(term::Attr::ForegroundColor(term::color::BRIGHT_BLUE))?;
                 }
             }
-            Style::ErrorCode => {
-                self.start_attr(term::Attr::Bold)?;
-                self.start_attr(term::Attr::ForegroundColor(term::color::BRIGHT_MAGENTA))?;
-            }
             Style::Quotation => {}
-            Style::OldSchoolNote => {
-                self.start_attr(term::Attr::Bold)?;
-                self.start_attr(term::Attr::ForegroundColor(term::color::BRIGHT_GREEN))?;
-            }
-            Style::OldSchoolNoteText | Style::HeaderMsg => {
+            Style::HeaderMsg => {
                 self.start_attr(term::Attr::Bold)?;
                 if cfg!(windows) {
                     self.start_attr(term::Attr::ForegroundColor(term::color::BRIGHT_WHITE))?;

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -41,9 +41,9 @@ use std::rc::Rc;
 pub mod diagnostic;
 pub mod diagnostic_builder;
 pub mod emitter;
-pub mod snippet;
+mod snippet;
 pub mod registry;
-pub mod styled_buffer;
+mod styled_buffer;
 mod lock;
 
 use syntax_pos::{BytePos, Loc, FileLinesResult, FileMap, FileName, MultiSpan, Span, NO_EXPANSION};

--- a/src/librustc_errors/snippet.rs
+++ b/src/librustc_errors/snippet.rs
@@ -206,7 +206,6 @@ pub struct StyledString {
 #[derive(Copy, Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
 pub enum Style {
     HeaderMsg,
-    FileNameStyle,
     LineAndColumn,
     LineNumber,
     Quotation,
@@ -214,10 +213,7 @@ pub enum Style {
     UnderlineSecondary,
     LabelPrimary,
     LabelSecondary,
-    OldSchoolNoteText,
-    OldSchoolNote,
     NoStyle,
-    ErrorCode,
     Level(Level),
     Highlight,
 }

--- a/src/librustc_errors/styled_buffer.rs
+++ b/src/librustc_errors/styled_buffer.rs
@@ -111,12 +111,6 @@ impl StyledBuffer {
         }
     }
 
-    pub fn set_style(&mut self, line: usize, col: usize, style: Style) {
-        if self.styles.len() > line && self.styles[line].len() > col {
-            self.styles[line][col] = style;
-        }
-    }
-
     pub fn prepend(&mut self, line: usize, string: &str, style: Style) {
         self.ensure_lines(line);
         let string_len = string.len();

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -25,7 +25,6 @@ use std::rc::Rc;
 
 use codemap::{self, CodeMap, ExpnInfo, NameAndSpan, MacroAttribute, dummy_spanned};
 use errors;
-use errors::snippet::{SnippetData};
 use config;
 use entry::{self, EntryPointType};
 use ext::base::{ExtCtxt, Resolver};


### PR DESCRIPTION
While extracting librustc_errors into a [reusable library](https://github.com/kevinmehall/codemap-diagnostic), I noticed some obsolete code that the `dead_code` warning missed because it was marked `pub` but not used elsewhere.