### PR TITLE
[beta] rustbuild: set __CARGO_DEFAULT_LIB_METADATA to channel

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -347,7 +347,7 @@ impl Build {
 
         // FIXME: Temporary fix for https://github.com/rust-lang/cargo/issues/3005
         // Force cargo to output binaries with disambiguating hashes in the name
-        cargo.env("__CARGO_DEFAULT_LIB_METADATA", "1");
+        cargo.env("__CARGO_DEFAULT_LIB_METADATA", &self.config.channel);
 
         let stage;
         if compiler.stage == 0 && self.local_rebuild {


### PR DESCRIPTION
This is a backport of #42977 for beta