### PR TITLE
README: note how to enable debugging for rustc

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ Read ["Installation"] from [The Book].
 
     > ***Note:*** Install locations can be adjusted by copying the config file
     > from `./src/bootstrap/config.toml.example` to `./config.toml`, and
-    > adjusting the `prefix` option under `[install]`. Various other options are
-    > also supported, and are documented in the config file.
+    > adjusting the `prefix` option under `[install]`. Various other options, such
+    > as enabling debug information, are also supported, and are documented in
+    > the config file.
 
     When complete, `sudo ./x.py install` will place several programs into
     `/usr/local/bin`: `rustc`, the Rust compiler, and `rustdoc`, the


### PR DESCRIPTION
I got stuck on this for a bit, looking for a debug option in `./x.py build --help`.

Diff without newline changes:

Before:

> Various other options are also supported, and are documented in the config file.

After:

> Various other options, such as enabling debug information, are also supported, and are documented in the config file.