### PR TITLE
Stabilize float_bits_conv for Rust 1.20

### DIFF
--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -1090,12 +1090,11 @@ impl f32 {
     /// # Examples
     ///
     /// ```
-    /// #![feature(float_bits_conv)]
     /// assert_ne!((1f32).to_bits(), 1f32 as u32); // to_bits() is not casting!
     /// assert_eq!((12.5f32).to_bits(), 0x41480000);
     ///
     /// ```
-    #[unstable(feature = "float_bits_conv", reason = "recently added", issue = "40470")]
+    #[stable(feature = "float_bits_conv", since = "1.21.0")]
     #[inline]
     pub fn to_bits(self) -> u32 {
         unsafe { ::mem::transmute(self) }
@@ -1118,7 +1117,6 @@ impl f32 {
     /// # Examples
     ///
     /// ```
-    /// #![feature(float_bits_conv)]
     /// use std::f32;
     /// let v = f32::from_bits(0x41480000);
     /// let difference = (v - 12.5).abs();
@@ -1127,7 +1125,7 @@ impl f32 {
     /// let snan = 0x7F800001;
     /// assert_ne!(f32::from_bits(snan).to_bits(), snan);
     /// ```
-    #[unstable(feature = "float_bits_conv", reason = "recently added", issue = "40470")]
+    #[stable(feature = "float_bits_conv", since = "1.21.0")]
     #[inline]
     pub fn from_bits(mut v: u32) -> Self {
         const EXP_MASK: u32   = 0x7F800000;

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -1005,12 +1005,11 @@ impl f64 {
     /// # Examples
     ///
     /// ```
-    /// #![feature(float_bits_conv)]
     /// assert!((1f64).to_bits() != 1f64 as u64); // to_bits() is not casting!
     /// assert_eq!((12.5f64).to_bits(), 0x4029000000000000);
     ///
     /// ```
-    #[unstable(feature = "float_bits_conv", reason = "recently added", issue = "40470")]
+    #[stable(feature = "float_bits_conv", since = "1.21.0")]
     #[inline]
     pub fn to_bits(self) -> u64 {
         unsafe { ::mem::transmute(self) }
@@ -1033,7 +1032,6 @@ impl f64 {
     /// # Examples
     ///
     /// ```
-    /// #![feature(float_bits_conv)]
     /// use std::f64;
     /// let v = f64::from_bits(0x4029000000000000);
     /// let difference = (v - 12.5).abs();
@@ -1042,7 +1040,7 @@ impl f64 {
     /// let snan = 0x7FF0000000000001;
     /// assert_ne!(f64::from_bits(snan).to_bits(), snan);
     /// ```
-    #[unstable(feature = "float_bits_conv", reason = "recently added", issue = "40470")]
+    #[stable(feature = "float_bits_conv", since = "1.21.0")]
     #[inline]
     pub fn from_bits(mut v: u64) -> Self {
         const EXP_MASK: u64   = 0x7FF0000000000000;

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -317,7 +317,6 @@
 #![feature(unwind_attributes)]
 #![feature(vec_push_all)]
 #![cfg_attr(test, feature(update_panic_count))]
-#![cfg_attr(test, feature(float_bits_conv))]
 
 #![cfg_attr(not(stage0), default_lib_allocator)]
 


### PR DESCRIPTION
Stabilizes the `float_bits_conv` lib feature for the 1.20 release of Rust. I've initially implemented the feature in #39271 and later made PR #43025 to output quiet NaNs even on platforms with different encodings, which seems to have been the only unresolved issue of the API.

Due to PR #43025 being only applied to master this stabilisation can't happen for Rust 1.19 through the usual "stabilisation on beta" system that is being done for library APIs.

r? @BurntSushi 

closes #40470.