### PR TITLE
Compact display of static lib dependencies

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -340,6 +340,7 @@ pub enum PrintRequest {
     RelocationModels,
     CodeModels,
     TargetSpec,
+    NativeStaticLibs,
 }
 
 pub enum Input {
@@ -1292,7 +1293,7 @@ pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
                                print on stdout",
                      "[crate-name|file-names|sysroot|cfg|target-list|\
                        target-cpus|target-features|relocation-models|\
-                       code-models|target-spec-json]"),
+                       code-models|target-spec-json|native-static-deps]"),
         opt::flagmulti_s("g",  "",  "Equivalent to -C debuginfo=2"),
         opt::flagmulti_s("O", "", "Equivalent to -C opt-level=2"),
         opt::opt_s("o", "", "Write output to <filename>", "FILENAME"),
@@ -1638,6 +1639,7 @@ pub fn build_session_options_and_crate_config(matches: &getopts::Matches)
             "target-features" => PrintRequest::TargetFeatures,
             "relocation-models" => PrintRequest::RelocationModels,
             "code-models" => PrintRequest::CodeModels,
+            "native-static-libs" => PrintRequest::NativeStaticLibs,
             "target-spec-json" => {
                 if nightly_options::is_unstable_enabled(matches) {
                     PrintRequest::TargetSpec

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -742,7 +742,9 @@ impl RustcDefaultCalls {
                         odir: &Option<PathBuf>,
                         ofile: &Option<PathBuf>)
                         -> Compilation {
-        if sess.opts.prints.is_empty() {
+        // PrintRequest::NativeStaticLibs is special - printed during linking
+        // (empty iterator returns true)
+        if sess.opts.prints.iter().all(|&p| p==PrintRequest::NativeStaticLibs) {
             return Compilation::Continue;
         }
 
@@ -851,6 +853,9 @@ impl RustcDefaultCalls {
                 }
                 PrintRequest::TargetCPUs | PrintRequest::TargetFeatures => {
                     rustc_trans::print(*req, sess);
+                }
+                PrintRequest::NativeStaticLibs => {
+                    println!("Native static libs can be printed only during linking");
                 }
             }
         }

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -699,7 +699,7 @@ fn print_native_static_libs(sess: &Session, all_native_libs: &[NativeLibrary]) {
                                  against this static library. The order and any duplication \
                                  can be significant on some platforms.");
         // Prefix for greppability
-        sess.note_without_error(format!("native-static-libs: {}", &lib_args.join(" ")));
+        sess.note_without_error(&format!("native-static-libs: {}", &lib_args.join(" ")));
     }
 }
 

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -647,11 +647,13 @@ fn link_staticlib(sess: &Session,
     ab.build();
 
     if !all_native_libs.is_empty() {
-        sess.note_without_error("link against the following native artifacts when linking against \
-                                 this static library");
-        sess.note_without_error("the order and any duplication can be significant on some \
-                                 platforms, and so may need to be preserved");
+            print_native_static_libs_legacy(sess, &all_native_libs);
     }
+}
+
+fn print_native_static_libs_legacy(sess: &Session, all_native_libs: &[NativeLibrary]) {
+    sess.note_without_error("link against the following native artifacts when linking against \
+                             this static library");
 
     for lib in all_native_libs.iter().filter(|l| relevant_lib(sess, l)) {
         let name = match lib.kind {


### PR DESCRIPTION
Fixes #33173

Instead of displaying one dependency per line, I've changed the format to display them all in one line. 

As a bonus they're in format of linker flags (`-lfoo`), so the output can be copy&pasted if one is actually going to link as suggested.
