### PR TITLE
rustdoc: Don't run Markdown tests twice

### DIFF
--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -163,8 +163,12 @@ pub fn test(input: &str, cfgs: Vec<String>, libs: SearchPaths, externs: Externs,
                                        true, opts, maybe_sysroot, None,
                                        Some(input.to_owned()),
                                        render_type);
-    old_find_testable_code(&input_str, &mut collector, DUMMY_SP);
-    find_testable_code(&input_str, &mut collector, DUMMY_SP);
+    if render_type == RenderType::Pulldown {
+        old_find_testable_code(&input_str, &mut collector, DUMMY_SP);
+        find_testable_code(&input_str, &mut collector, DUMMY_SP);
+    } else {
+        old_find_testable_code(&input_str, &mut collector, DUMMY_SP);
+    }
     test_args.insert(0, "rustdoctest".to_string());
     testing::test_main(&test_args, collector.tests,
                        testing::Options::new().display_output(display_warnings));


### PR DESCRIPTION
This matches the behaviour for finding tests in Rust files.

This was a regression from 1.17 to 1.18 so it would be a good idea to backport this to beta so at least 1.19 won't also be affected.

Fixes #42726

r? @GuillaumeGomez