### PR TITLE
Forward more Iterator methods

### DIFF
--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -359,10 +359,18 @@ impl<I> Iterator for Rev<I> where I: DoubleEndedIterator {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 
+    #[inline]
     fn find<P>(&mut self, predicate: P) -> Option<Self::Item>
         where P: FnMut(&Self::Item) -> bool
     {
         self.iter.rfind(predicate)
+    }
+
+    #[inline]
+    fn rposition<P>(&mut self, predicate: P) -> Option<usize> where
+        P: FnMut(Self::Item) -> bool
+    {
+        self.iter.position(predicate)
     }
 }
 

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -710,6 +710,37 @@ impl<'a> Iterator for Bytes<'a> {
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         self.0.nth(n)
     }
+
+    #[inline]
+    fn all<F>(&mut self, f: F) -> bool where F: FnMut(Self::Item) -> bool {
+        self.0.all(f)
+    }
+
+    #[inline]
+    fn any<F>(&mut self, f: F) -> bool where F: FnMut(Self::Item) -> bool {
+        self.0.any(f)
+    }
+
+    #[inline]
+    fn find<P>(&mut self, predicate: P) -> Option<Self::Item> where
+        P: FnMut(&Self::Item) -> bool
+    {
+        self.0.find(predicate)
+    }
+
+    #[inline]
+    fn position<P>(&mut self, predicate: P) -> Option<usize> where
+        P: FnMut(Self::Item) -> bool
+    {
+        self.0.position(predicate)
+    }
+
+    #[inline]
+    fn rposition<P>(&mut self, predicate: P) -> Option<usize> where
+        P: FnMut(Self::Item) -> bool
+    {
+        self.0.rposition(predicate)
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -717,6 +748,13 @@ impl<'a> DoubleEndedIterator for Bytes<'a> {
     #[inline]
     fn next_back(&mut self) -> Option<u8> {
         self.0.next_back()
+    }
+
+    #[inline]
+    fn rfind<P>(&mut self, predicate: P) -> Option<Self::Item> where
+        P: FnMut(&Self::Item) -> bool
+    {
+        self.0.rfind(predicate)
     }
 }
 


### PR DESCRIPTION
This allows in more cases to take advantage of specific (possibly more optimized) impls of these methods, rather than the default one defined for all `Iterator`s.

I also wanted to do this for `&mut I` and `Box<I>`, but that didn’t compile for two reasons:

* To make the trait object-safe, generic methods (e.g. that take a closure parameter) have a `where Self: Sized` bound. But e.g. `Box<I>: Sized` does not imply `I: Sized`, and adding an additional bound in the impl is not allowed. Some for of specialization would be needed here.
* With e.g. a `F: FnMut(Self::Item) -> bool` bound and a `type Item = I::Item` associated types, I got errors like `F does not implement FnMut(I::Item) -> bool`. This looks like a limitation in the trait resolution system not recognizing that `Self::Item == I::Item` or "propagating" that fact to `FnMut` bounds.