### PR TITLE
Privileged in docker run isn't necessary

### DIFF
--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -82,7 +82,6 @@ exec docker \
   --env TRAVIS_BRANCH \
   --volume "$HOME/.cargo:/cargo" \
   --volume "$HOME/rustsrc:$HOME/rustsrc" \
-  --privileged \
   --rm \
   rust-ci \
   /checkout/src/ci/run.sh


### PR DESCRIPTION
Added relatively recently in https://github.com/rust-lang/rust/pull/40199/files#diff-71609a365528e4649836825d8250c241R57, but I don't see anything in that PR that requires it. If it's not strictly necessary, we shouldn't use it.

(if this lands I'll make a PR against libc which also uses privileged)

r? @alexcrichton 