### PR TITLE
Point at `:` when using it instead of `;`

### DIFF
--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -209,6 +209,22 @@ impl Diagnostic {
         self
     }
 
+    /// Prints out a message with a suggested edit of the code. If the suggestion is presented
+    /// inline it will only show the text message and not the text.
+    ///
+    /// See `diagnostic::CodeSuggestion` for more information.
+    pub fn span_suggestion_short(&mut self, sp: Span, msg: &str, suggestion: String) -> &mut Self {
+        self.suggestions.push(CodeSuggestion {
+            substitution_parts: vec![Substitution {
+                span: sp,
+                substitutions: vec![suggestion],
+            }],
+            msg: msg.to_owned(),
+            show_code_when_inline: false,
+        });
+        self
+    }
+
     /// Prints out a message with a suggested edit of the code.
     ///
     /// See `diagnostic::CodeSuggestion` for more information.
@@ -219,6 +235,7 @@ impl Diagnostic {
                 substitutions: vec![suggestion],
             }],
             msg: msg.to_owned(),
+            show_code_when_inline: true,
         });
         self
     }
@@ -230,6 +247,7 @@ impl Diagnostic {
                 substitutions: suggestions,
             }],
             msg: msg.to_owned(),
+            show_code_when_inline: true,
         });
         self
     }

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -146,6 +146,11 @@ impl<'a> DiagnosticBuilder<'a> {
                                                   sp: S,
                                                   msg: &str)
                                                   -> &mut Self);
+    forward!(pub fn span_suggestion_short(&mut self,
+                                          sp: Span,
+                                          msg: &str,
+                                          suggestion: String)
+                                          -> &mut Self);
     forward!(pub fn span_suggestion(&mut self,
                                     sp: Span,
                                     msg: &str,

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -47,8 +47,9 @@ impl Emitter for EmitterWriter {
                // don't display multiline suggestions as labels
                sugg.substitution_parts[0].substitutions[0].find('\n').is_none() {
                 let substitution = &sugg.substitution_parts[0].substitutions[0];
-                let msg = if substitution.len() == 0 {
-                    // This substitution is only removal, don't show it
+                let msg = if substitution.len() == 0 || !sugg.show_code_when_inline {
+                    // This substitution is only removal or we explicitely don't want to show the
+                    // code inline, don't show it
                     format!("help: {}", sugg.msg)
                 } else {
                     format!("help: {} `{}`", sugg.msg, substitution)

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -84,6 +84,7 @@ pub struct CodeSuggestion {
     /// ```
     pub substitution_parts: Vec<Substitution>,
     pub msg: String,
+    pub show_code_when_inline: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2798,7 +2798,22 @@ impl<'a> Parser<'a> {
                 lhs = self.parse_assoc_op_cast(lhs, lhs_span, ExprKind::Cast)?;
                 continue
             } else if op == AssocOp::Colon {
-                lhs = self.parse_assoc_op_cast(lhs, lhs_span, ExprKind::Type)?;
+                lhs = match self.parse_assoc_op_cast(lhs, lhs_span, ExprKind::Type) {
+                    Ok(lhs) => lhs,
+                    Err(mut err) => {
+                        err.span_label(self.span,
+                                       "expecting a type here because of type ascription");
+                        let cm = self.sess.codemap();
+                        let cur_pos = cm.lookup_char_pos(self.span.lo);
+                        let op_pos = cm.lookup_char_pos(cur_op_span.hi);
+                        if cur_pos.line != op_pos.line {
+                            err.span_suggestion(cur_op_span,
+                                                "did you mean to end the statement here instead?",
+                                                ";".to_string());
+                        }
+                        return Err(err);
+                    }
+                };
                 continue
             } else if op == AssocOp::DotDot || op == AssocOp::DotDotDot {
                 // If we didn’t have to handle `x..`/`x...`, it would be pretty easy to

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2807,9 +2807,9 @@ impl<'a> Parser<'a> {
                         let cur_pos = cm.lookup_char_pos(self.span.lo);
                         let op_pos = cm.lookup_char_pos(cur_op_span.hi);
                         if cur_pos.line != op_pos.line {
-                            err.span_suggestion(cur_op_span,
-                                                "did you mean to end the statement here instead?",
-                                                ";".to_string());
+                            err.span_suggestion_short(cur_op_span,
+                                                      "did you mean to use `;` here?",
+                                                      ";".to_string());
                         }
                         return Err(err);
                     }

--- a/src/test/ui/issue-22644.stderr
+++ b/src/test/ui/issue-22644.stderr
@@ -100,5 +100,5 @@ error: expected type, found `4`
   --> $DIR/issue-22644.rs:38:28
    |
 38 |     println!("{}", a: &mut 4);
-   |                            ^
+   |                            ^ expecting a type here because of type ascription
 

--- a/src/test/ui/suggestions/type-ascription-instead-of-statement-end.rs
+++ b/src/test/ui/suggestions/type-ascription-instead-of-statement-end.rs
@@ -1,0 +1,20 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(type_ascription)]
+
+fn main() {
+    println!("test"):
+    0;
+}
+
+fn foo() {
+    println!("test"): 0;
+}

--- a/src/test/ui/suggestions/type-ascription-instead-of-statement-end.stderr
+++ b/src/test/ui/suggestions/type-ascription-instead-of-statement-end.stderr
@@ -2,7 +2,7 @@ error: expected type, found `0`
   --> $DIR/type-ascription-instead-of-statement-end.rs:15:5
    |
 14 |     println!("test"):
-   |                     - help: did you mean to end the statement here instead? `;`
+   |                     - help: did you mean to use `;` here?
 15 |     0;
    |     ^ expecting a type here because of type ascription
 

--- a/src/test/ui/suggestions/type-ascription-instead-of-statement-end.stderr
+++ b/src/test/ui/suggestions/type-ascription-instead-of-statement-end.stderr
@@ -1,0 +1,16 @@
+error: expected type, found `0`
+  --> $DIR/type-ascription-instead-of-statement-end.rs:15:5
+   |
+14 |     println!("test"):
+   |                     - help: did you mean to end the statement here instead? `;`
+15 |     0;
+   |     ^ expecting a type here because of type ascription
+
+error: expected type, found `0`
+  --> $DIR/type-ascription-instead-of-statement-end.rs:19:23
+   |
+19 |     println!("test"): 0;
+   |                       ^ expecting a type here because of type ascription
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/suggestions/type-ascription-with-fn-call.rs
+++ b/src/test/ui/suggestions/type-ascription-with-fn-call.rs
@@ -1,0 +1,18 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(type_ascription)]
+
+fn main() {
+    f()  :
+    f();
+}
+
+fn f() {}

--- a/src/test/ui/suggestions/type-ascription-with-fn-call.stderr
+++ b/src/test/ui/suggestions/type-ascription-with-fn-call.stderr
@@ -1,0 +1,13 @@
+error[E0573]: expected type, found function `f`
+  --> $DIR/type-ascription-with-fn-call.rs:15:5
+   |
+14 |     f()  :
+   |          - help: did you mean to use `;` here instead?
+15 |     f();
+   |     ^^^
+   |     |
+   |     not a type
+   |     expecting a type here because of type ascription
+
+error: aborting due to previous error
+


### PR DESCRIPTION
When triggering type ascription in such a way that we can infer a
statement end was intended, add a suggestion for the change. Always
point out the reason for the expectation of a type is due to type
ascription.

Fix #42057, #41928.