### PR TITLE
Add `isize` and `usize` constructors to Literal

### DIFF
--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -303,7 +303,7 @@ impl Literal {
         Literal(token::Literal(token::Lit::Integer(Symbol::intern(&n.to_string())), None))
     }
 
-    int_literals!(u8, i8, u16, i16, u32, i32, u64, i64);
+    int_literals!(u8, i8, u16, i16, u32, i32, u64, i64, usize, isize);
     fn typed_integer(n: i128, kind: &'static str) -> Literal {
         Literal(token::Literal(token::Lit::Integer(Symbol::intern(&n.to_string())),
                                Some(Symbol::intern(kind))))


### PR DESCRIPTION
This commit fills out the remaining integer literal constructors on the
`proc_macro::Literal` type with `isize` and `usize`. (I think these were just
left out by accident)