### PR TITLE
add a built-in MSP430 target

### DIFF
--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -220,6 +220,8 @@ supported_targets! {
     ("thumbv7m-none-eabi", thumbv7m_none_eabi),
     ("thumbv7em-none-eabi", thumbv7em_none_eabi),
     ("thumbv7em-none-eabihf", thumbv7em_none_eabihf),
+
+    ("msp430-none-elf", msp430_none_elf),
 }
 
 /// Everything `rustc` knows about how to compile for a specific target.

--- a/src/librustc_back/target/msp430_none_elf.rs
+++ b/src/librustc_back/target/msp430_none_elf.rs
@@ -1,0 +1,53 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use {LinkerFlavor, PanicStrategy};
+use target::{Target, TargetOptions, TargetResult};
+
+pub fn target() -> TargetResult {
+    Ok(Target {
+        llvm_target: "msp430-none-elf".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "16".to_string(),
+        data_layout: "e-m:e-p:16:16-i32:16-i64:16-f32:16-f64:16-a:8-n8:16-S16".to_string(),
+        arch: "msp430".to_string(),
+        target_os: "none".to_string(),
+        target_env: "".to_string(),
+        target_vendor: "".to_string(),
+        linker_flavor: LinkerFlavor::Gcc,
+
+        options: TargetOptions {
+            executables: true,
+
+            // The LLVM backend currently can't generate object files. To
+            // workaround this LLVM generates assembly files which then we feed
+            // to gcc to get object files. For this reason we have a hard
+            // dependency on this specific gcc.
+            asm_args: vec!["-mcpu=msp430".to_string()],
+            linker: "msp430-elf-gcc".to_string(),
+            no_integrated_as: true,
+
+            // There are no atomic instructions available in the MSP430
+            // instruction set
+            max_atomic_width: Some(0),
+
+            // Because these devices have very little resources having an
+            // unwinder is too onerous so we default to "abort" because the
+            // "unwind" strategy is very rare.
+            panic_strategy: PanicStrategy::Abort,
+
+            // Similarly, one almost always never wants to use relocatable
+            // code because of the extra costs it involves.
+            relocation_model: "static".to_string(),
+
+            .. Default::default( )
+        }
+    })
+}


### PR DESCRIPTION
the MSP430 backend has been enabled for a while but no target was added to rustc
to encourage out of tree experimentation.

We believe the out of tree (custom) target has been iterated long enough and is
stable enough for inclusion in the compiler. Kudos to @pftbest and @awygle for
fixing several LLVM / codegen bugs this target had!

The target name chosen is a slight variation of the triple gcc uses, which is
simply `msp430-elf`. We picked `msp430-none-elf` to leave room for custom
targets that target some embedded OS running on MSP430 devices. (cf. the
custom `thumbv7m-tockos-eabi` target TockOS uses vs the built-in
`thumbv7m-none-eabi`).

There's one expected change in the specification of the proposed target: the
`asm_args` and `no_integrated_as` fields will change to their default values.
Once the LLVM backend gains the ability to directly produce MSP430 object files
we can stop depending on `msp430-elf-gcc` for producing object files; when that
occurs the `asm` related fields will change. This change won't break existing
user code.

r? @alexcrichton
cc @brson