### PR TITLE
Fix Rustbuild linking on Illumos

### DIFF
--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -41,6 +41,10 @@ fn main() {
     } else if target.contains("dragonfly") || target.contains("bitrig") ||
               target.contains("netbsd") || target.contains("openbsd") {
         println!("cargo:rustc-link-lib=pthread");
+    } else if target.contains("solaris") {
+        println!("cargo:rustc-link-lib=socket");
+        println!("cargo:rustc-link-lib=posix4");
+        println!("cargo:rustc-link-lib=pthread");
     } else if target.contains("apple-darwin") {
         println!("cargo:rustc-link-lib=System");
 


### PR DESCRIPTION
Illumos (an OpenSolaris fork) expects to get several extra library references for some system functions used by Rust standard library. This commit adds required linker options to rustbuild, which is currently doesn't work on Illumos-based operating systems.