### PR TITLE
incr.comp.: Don't include span information in the ICH of type definitions

### DIFF
--- a/src/librustc_trans/debuginfo/utils.rs
+++ b/src/librustc_trans/debuginfo/utils.rs
@@ -73,13 +73,7 @@ pub fn DIB(cx: &CrateContext) -> DIBuilderRef {
     cx.dbg_cx().as_ref().unwrap().builder
 }
 
-pub fn get_namespace_and_span_for_item(cx: &CrateContext, def_id: DefId)
-                                   -> (DIScope, Span) {
-    let containing_scope = item_namespace(cx, cx.tcx().parent(def_id)
-        .expect("get_namespace_and_span_for_item: missing parent?"));
-
-    // Try to get some span information, if we have an inlined item.
-    let definition_span = cx.tcx().def_span(def_id);
-
-    (containing_scope, definition_span)
+pub fn get_namespace_for_item(cx: &CrateContext, def_id: DefId) -> DIScope {
+    item_namespace(cx, cx.tcx().parent(def_id)
+        .expect("get_namespace_for_item: missing parent?"))
 }

--- a/src/test/incremental/spans_in_type_debuginfo.rs
+++ b/src/test/incremental/spans_in_type_debuginfo.rs
@@ -1,0 +1,63 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that moving a type definition within a source file does not affect
+// re-compilation.
+
+// revisions:rpass1 rpass2
+// compile-flags: -Z query-dep-graph -g
+
+#![rustc_partition_reused(module="spans_in_type_debuginfo", cfg="rpass2")]
+#![rustc_partition_reused(module="spans_in_type_debuginfo-structs", cfg="rpass2")]
+#![rustc_partition_reused(module="spans_in_type_debuginfo-enums", cfg="rpass2")]
+
+#![feature(rustc_attrs)]
+
+mod structs {
+    #[cfg(rpass1)]
+    pub struct X {
+        pub x: u32,
+    }
+
+    #[cfg(rpass2)]
+    pub struct X {
+        pub x: u32,
+    }
+
+    pub fn foo(x: X) -> u32 {
+        x.x
+    }
+}
+
+mod enums {
+    #[cfg(rpass1)]
+    pub enum X {
+        A { x: u32 },
+        B(u32),
+    }
+
+    #[cfg(rpass2)]
+    pub enum X {
+        A { x: u32 },
+        B(u32),
+    }
+
+    pub fn foo(x: X) -> u32 {
+        match x {
+            X::A { x } => x,
+            X::B(x) => x,
+        }
+    }
+}
+
+pub fn main() {
+    let _ = structs::foo(structs::X { x: 1 });
+    let _ = enums::foo(enums::X::A { x: 2 });
+}


### PR DESCRIPTION
This should improve some of the `regex` tests on perf.rlo. Not including spans into the ICH is harmless until we also cache warnings. To really solve the problem, we need to do more refactoring (see #43088).

r? @nikomatsakis 