### PR TITLE
Fix feature gate for `#[link_args(..)]` attribute

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -552,7 +552,12 @@ pub const BUILTIN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeG
     ("ignore", Normal, Ungated),
     ("no_implicit_prelude", Normal, Ungated),
     ("reexport_test_harness_main", Normal, Ungated),
-    ("link_args", Normal, Ungated),
+    ("link_args", Normal, Gated(Stability::Unstable,
+                                "link_args",
+                                "the `link_args` attribute is experimental and not \
+                                 portable across platforms, it is recommended to \
+                                 use `#[link(name = \"foo\")] instead",
+                                cfg_fn!(link_args))),
     ("macro_escape", Normal, Ungated),
 
     // RFC #1445.
@@ -1185,12 +1190,6 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
             }
 
             ast::ItemKind::ForeignMod(ref foreign_module) => {
-                if attr::contains_name(&i.attrs[..], "link_args") {
-                    gate_feature_post!(&self, link_args, i.span,
-                                      "the `link_args` attribute is not portable \
-                                       across platforms, it is recommended to \
-                                       use `#[link(name = \"foo\")]` instead")
-                }
                 self.check_abi(foreign_module.abi, i.span);
             }
 

--- a/src/test/compile-fail/gated-link-args.rs
+++ b/src/test/compile-fail/gated-link-args.rs
@@ -9,12 +9,22 @@
 // except according to those terms.
 
 // Test that `#[link_args]` attribute is gated by `link_args`
-// feature gate.
+// feature gate, both when it occurs where expected (atop
+// `extern { }` blocks) and where unexpected.
 
 // gate-test-link_args
 
-#[link_args = "aFdEfSeVEEE"]
-extern {}
-//~^ ERROR the `link_args` attribute is not portable across platforms
+// sidestep warning (which is correct, but misleading for
+// purposes of this test)
+#![allow(unused_attributes)]
 
-fn main() { }
+#![link_args = "-l unexpected_use_as_inner_attr_on_mod"]
+//~^ ERROR the `link_args` attribute is experimental
+
+#[link_args = "-l expected_use_case"]
+//~^ ERROR the `link_args` attribute is experimental
+extern {}
+
+#[link_args = "-l unexected_use_on_non_extern_item"]
+//~^ ERROR: the `link_args` attribute is experimental
+fn main() {}


### PR DESCRIPTION
Fix feature gate for `#[link_args(..)]` attribute so that it will fire regardless of context of attribute.

See also #29596 and #43106  