### PR TITLE
[beta] Bump prerelease version

### DIFF
--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -28,7 +28,7 @@ pub const CFG_RELEASE_NUM: &'static str = "1.19.0";
 // An optional number to put after the label, e.g. '.2' -> '-beta.2'
 // Be sure to make this starts with a dot to conform to semver pre-release
 // versions (section 9)
-pub const CFG_PRERELEASE_VERSION: &'static str = ".2";
+pub const CFG_PRERELEASE_VERSION: &'static str = ".3";
 
 pub struct GitInfo {
     inner: Option<Info>,


### PR DESCRIPTION
There are some more backports left to do, but I figure it's best to get this bump in so we can release [this massive set of backports](https://github.com/rust-lang/rust/pull/42927).

r? @Mark-Simulacrum 

p=1 maybe