### PR TITLE
Fix stage 2 builds with a custom libdir.

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -405,8 +405,9 @@ pub fn std(build: &Build, compiler: &Compiler, target: &str) {
 
     let dst = image.join("lib/rustlib").join(target);
     t!(fs::create_dir_all(&dst));
-    let src = build.sysroot(compiler).join("lib/rustlib");
-    cp_r(&src.join(target), &dst);
+    let mut src = build.sysroot_libdir(compiler, target);
+    src.pop(); // Remove the trailing /lib folder from the sysroot_libdir
+    cp_r(&src, &dst);
 
     let mut cmd = rust_installer(build);
     cmd.arg("generate")

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -645,8 +645,14 @@ impl Build {
     /// Returns the libdir where the standard library and other artifacts are
     /// found for a compiler's sysroot.
     fn sysroot_libdir(&self, compiler: &Compiler, target: &str) -> PathBuf {
-        self.sysroot(compiler).join("lib").join("rustlib")
-            .join(target).join("lib")
+        if compiler.stage >= 2 {
+            if let Some(ref libdir_relative) = self.config.libdir_relative {
+                return self.sysroot(compiler).join(libdir_relative)
+                    .join("rustlib").join(target).join("lib")
+            }
+        }
+       self.sysroot(compiler).join("lib").join("rustlib")
+           .join(target).join("lib")
     }
 
     /// Returns the root directory for all output generated in a particular


### PR DESCRIPTION
When copying libstd for the stage 2 compiler, the builder ignores the
configured libdir/libdir_relative configuration parameters.  This causes
the compiler to fail to find libstd, which cause any tools built with the
stage 2 compiler to fail.

To fix this, make the copy steps of rustbuild aware of the libdir_relative
parameter when the stage >= 2.  Also update the dist target to be aware of
the new location of libstd.