### PR TITLE
Redesign the std::iter::Step trait, tweak related iterator impls for ranges

### DIFF
--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -425,12 +425,15 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        // NOTE: the safety of `unsafe impl TrustedLen` depends on this being correct!
-
+        // This seems redundant with a similar comparison that `Step::steps_between`
+        // implementations need to do, but it separates the `start > end` case from `start == end`.
+        // `steps_between` returns `Some(0)` in both of these cases, but we only want to add 1
+        // in the latter.
         if !(self.start <= self.end) {
             return (0, Some(0));
         }
 
+        // NOTE: the safety of `unsafe impl TrustedLen` depends on this being correct!
         match Step::steps_between(&self.start, &self.end) {
             Some(hint) => (hint.saturating_add(1), hint.checked_add(1)),
             None => (usize::MAX, None),

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -61,6 +61,8 @@ macro_rules! step_integer_impls {
             impl Step for $narrower_unsigned {
                 #[inline]
                 fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+                    // NOTE: the safety of `unsafe impl TrustedLen` depends on
+                    // this being correct!
                     if *start < *end {
                         // This relies on $narrower_unsigned <= usize
                         Some((*end - *start) as usize)
@@ -92,6 +94,8 @@ macro_rules! step_integer_impls {
             impl Step for $narrower_signed {
                 #[inline]
                 fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+                    // NOTE: the safety of `unsafe impl TrustedLen` depends on
+                    // this being correct!
                     if *start < *end {
                         // This relies on $narrower_signed <= usize
                         //
@@ -156,6 +160,8 @@ macro_rules! step_integer_impls {
             impl Step for $wider_unsigned {
                 #[inline]
                 fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+                    // NOTE: the safety of `unsafe impl TrustedLen` depends on
+                    // this being correct!
                     if *start < *end {
                         usize::try_from(*end - *start).ok()
                     } else {
@@ -180,6 +186,8 @@ macro_rules! step_integer_impls {
             impl Step for $wider_signed {
                 #[inline]
                 fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+                    // NOTE: the safety of `unsafe impl TrustedLen` depends on
+                    // this being correct!
                     if *start < *end {
                         match end.checked_sub(*start) {
                             Some(diff) => usize::try_from(diff).ok(),
@@ -274,6 +282,7 @@ impl<A: Step> Iterator for ops::Range<A> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
+        // NOTE: the safety of `unsafe impl TrustedLen` depends on this being correct!
         match Step::steps_between(&self.start, &self.end) {
             Some(hint) => (hint, Some(hint)),
             None => (0, None)
@@ -306,8 +315,14 @@ range_incl_exact_iter_impl!(u8 u16 i8 i16);
 //
 // They need to guarantee that .size_hint() is either exact, or that
 // the upper bound is None when it does not fit the type limits.
-range_trusted_len_impl!(usize isize u8 i8 u16 i16 u32 i32 i64 u64);
-range_incl_trusted_len_impl!(usize isize u8 i8 u16 i16 u32 i32 i64 u64);
+range_trusted_len_impl! {
+    usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+}
+range_incl_trusted_len_impl! {
+    usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A: Step> DoubleEndedIterator for ops::Range<A> {
@@ -387,6 +402,8 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
+        // NOTE: the safety of `unsafe impl TrustedLen` depends on this being correct!
+
         if !(self.start <= self.end) {
             return (0, Some(0));
         }

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -285,7 +285,7 @@ impl<A: Step> Iterator for ops::Range<A> {
         // NOTE: the safety of `unsafe impl TrustedLen` depends on this being correct!
         match Step::steps_between(&self.start, &self.end) {
             Some(hint) => (hint, Some(hint)),
-            None => (0, None)
+            None => (usize::MAX, None)
         }
     }
 
@@ -410,7 +410,7 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
 
         match Step::steps_between(&self.start, &self.end) {
             Some(hint) => (hint.saturating_add(1), hint.checked_add(1)),
-            None => (0, None),
+            None => (usize::MAX, None),
         }
     }
 

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -312,7 +312,8 @@ impl<A: Step> Iterator for ops::Range<A> {
 //   For integer types in `RangeInclusive<_>`
 //   this is the case for types *strictly narrower* than `usize`
 //   since e.g. `(0...u64::MAX).len()` would be `u64::MAX + 1`.
-// * It hurts portability to have APIs (including `impl`s) that are only available on some platforms,
+// * It hurts portability to have APIs (including `impl`s)
+//   that are only available on some platforms,
 //   so only `impl`s that are always valid should exist, regardless of the current target platform.
 //   (NOTE: https://github.com/rust-lang/rust/issues/41619 might change this.)
 // * Support exists in-tree for MSP430: https://forge.rust-lang.org/platform-support.html#tier-3
@@ -496,7 +497,8 @@ impl<A: Step> DoubleEndedIterator for ops::RangeInclusive<A> {
                     last = self.end.clone();
                     // `start == end`, and `start - 1` underflowed.
                     // `end + 1` overflowing would imply a type with only one valid value?
-                    self.start = self.start.forward(1).expect("overflow in RangeInclusive::next_back");
+                    self.start =
+                        self.start.forward(1).expect("overflow in RangeInclusive::next_back");
                 }
                 Some(last)
             },

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1080,20 +1080,41 @@ fn test_range() {
 fn test_range_inclusive_exhaustion() {
     let mut r = 10...10;
     assert_eq!(r.next(), Some(10));
-    assert_eq!(r, 1...0);
+    assert_eq!(r, 11...10);
+    assert_eq!(r.next(), None);
+    assert_eq!(r, 11...10);
 
     let mut r = 10...10;
     assert_eq!(r.next_back(), Some(10));
+    assert_eq!(r, 10...9);
+    assert_eq!(r.next_back(), None);
+    assert_eq!(r, 10...9);
+
+    let mut r = 0_u32...0;
+    assert_eq!(r.next_back(), Some(0));
+    assert_eq!(r, 1...0);
+    assert_eq!(r.next_back(), None);
     assert_eq!(r, 1...0);
 
     let mut r = 10...12;
     assert_eq!(r.nth(2), Some(12));
-    assert_eq!(r, 1...0);
+    assert_eq!(r, 13...12);
 
     let mut r = 10...12;
     assert_eq!(r.nth(5), None);
-    assert_eq!(r, 1...0);
+    assert_eq!(r, 13...12);
 
+    let mut r = 127_i8...127;
+    assert_eq!(r.next(), Some(127));
+    assert_eq!(r, 127...126);
+    assert_eq!(r.next(), None);
+    assert_eq!(r, 127...126);
+
+    let mut r = 255_u8...255;
+    assert_eq!(r.next(), Some(255));
+    assert_eq!(r, 255...254);
+    assert_eq!(r.next(), None);
+    assert_eq!(r, 255...254);
 }
 
 #[test]
@@ -1142,7 +1163,7 @@ fn test_range_inclusive_nth() {
     assert_eq!(r.is_empty(), false);
     assert_eq!(r.nth(10), None);
     assert_eq!(r.is_empty(), true);
-    assert_eq!(r, 1...0);  // We may not want to document/promise this detail
+    assert_eq!(r, 21...20);
 }
 
 #[test]
@@ -1263,40 +1284,6 @@ fn test_chain_fold() {
 }
 
 #[test]
-fn test_step_replace_unsigned() {
-    let mut x = 4u32;
-    let y = x.replace_zero();
-    assert_eq!(x, 0);
-    assert_eq!(y, 4);
-
-    x = 5;
-    let y = x.replace_one();
-    assert_eq!(x, 1);
-    assert_eq!(y, 5);
-}
-
-#[test]
-fn test_step_replace_signed() {
-    let mut x = 4i32;
-    let y = x.replace_zero();
-    assert_eq!(x, 0);
-    assert_eq!(y, 4);
-
-    x = 5;
-    let y = x.replace_one();
-    assert_eq!(x, 1);
-    assert_eq!(y, 5);
-}
-
-#[test]
-fn test_step_replace_no_between() {
-    let mut x = 4u128;
-    let y = x.replace_zero();
-    assert_eq!(x, 0);
-    assert_eq!(y, 4);
-
-    x = 5;
-    let y = x.replace_one();
-    assert_eq!(x, 1);
-    assert_eq!(y, 5);
+fn test_step_add_usize() {
+    assert_eq!((-120_i8).add_usize(200), Some(80));
 }

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1284,6 +1284,16 @@ fn test_chain_fold() {
 }
 
 #[test]
-fn test_step_add_usize() {
-    assert_eq!((-120_i8).add_usize(200), Some(80));
+fn test_steps_between() {
+    assert_eq!(Step::steps_between(&-120_i8, &80_i8), Some(200_usize));
+}
+
+#[test]
+fn test_step_forward() {
+    assert_eq!((-120_i8).forward(200_usize), Some(80_i8));
+}
+
+#[test]
+fn test_step_backward() {
+    assert_eq!((120_i8).backward(200_usize), Some(-80_i8));
 }

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1324,7 +1324,8 @@ fn test_steps_between() {
     }
     assert_eq!(Step::steps_between(&20_u128, &0x1_0000_0000_0000_0020_u128), None);
     assert_eq!(Step::steps_between(&20_i128, &0x1_0000_0000_0000_0020_i128), None);
-    assert_eq!(Step::steps_between(&-0x1_0000_0000_0000_0000_i128, &0x1_0000_0000_0000_0000_i128), None);
+    assert_eq!(Step::steps_between(&-0x1_0000_0000_0000_0000_i128, &0x1_0000_0000_0000_0000_i128),
+               None);
 }
 
 #[test]
@@ -1346,9 +1347,11 @@ fn test_step_forward() {
 
     assert_eq!((10_u128).forward(70_000_usize), Some(70_010_u128));
     assert_eq!((10_i128).forward(70_030_usize), Some(70_020_i128));
-    assert_eq!((0xffff_ffff_ffff_ffff__ffff_ffff_ffff_ff00_u128).forward(0xff_usize), Some(u128::MAX));
+    assert_eq!((0xffff_ffff_ffff_ffff__ffff_ffff_ffff_ff00_u128).forward(0xff_usize),
+               Some(u128::MAX));
     assert_eq!((0xffff_ffff_ffff_ffff__ffff_ffff_ffff_ff00_u128).forward(0x100_usize), None);
-    assert_eq!((0x7fff_ffff_ffff_ffff__ffff_ffff_ffff_ff00_i128).forward(0xff_usize), Some(i128::MAX));
+    assert_eq!((0x7fff_ffff_ffff_ffff__ffff_ffff_ffff_ff00_i128).forward(0xff_usize),
+               Some(i128::MAX));
     assert_eq!((0x7fff_ffff_ffff_ffff__ffff_ffff_ffff_ff00_i128).forward(0x100_usize), None);
 }
 
@@ -1373,6 +1376,8 @@ fn test_step_backward() {
     assert_eq!((70_020_i128).backward(70_030_usize), Some(10_i128));
     assert_eq!((10_u128).backward(7_usize), Some(3_u128));
     assert_eq!((10_u128).backward(11_usize), None);
-    assert_eq!((-0x7fff_ffff_ffff_ffff__ffff_ffff_ffff_ff00_i128).backward(0xfe_usize), Some(i128::MIN));
-    assert_eq!((-0x7fff_ffff_ffff_ffff__ffff_ffff_ffff_ff00_i128).backward(0xff_usize), Some(i128::MIN));
+    assert_eq!((-0x7fff_ffff_ffff_ffff__ffff_ffff_ffff_ff00_i128).backward(0xfe_usize),
+               Some(i128::MIN));
+    assert_eq!((-0x7fff_ffff_ffff_ffff__ffff_ffff_ffff_ff00_i128).backward(0xff_usize),
+               Some(i128::MIN));
 }

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1166,6 +1166,24 @@ fn test_range_inclusive_nth() {
 }
 
 #[test]
+fn test_range_len() {
+    assert_eq!((0..10_u8).len(), 10);
+    assert_eq!((9..10_u8).len(), 1);
+    assert_eq!((10..10_u8).len(), 0);
+    assert_eq!((11..10_u8).len(), 0);
+    assert_eq!((100..10_u8).len(), 0);
+}
+
+#[test]
+fn test_range_inclusive_len() {
+    assert_eq!((0...10_u8).len(), 11);
+    assert_eq!((9...10_u8).len(), 2);
+    assert_eq!((10...10_u8).len(), 1);
+    assert_eq!((11...10_u8).len(), 0);
+    assert_eq!((100...10_u8).len(), 0);
+}
+
+#[test]
 fn test_range_step() {
     #![allow(deprecated)]
 

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1169,6 +1169,18 @@ fn test_range_step() {
 }
 
 #[test]
+#[should_panic]
+fn test_range_from_next_overflow() {
+    (255u8..).next();
+}
+
+#[test]
+#[should_panic]
+fn test_range_from_nth_overflow() {
+    (200u8..).nth(55);
+}
+
+#[test]
 fn test_repeat() {
     let mut it = repeat(42);
     assert_eq!(it.next(), Some(42));

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -23,6 +23,7 @@
 #![feature(flt2dec)]
 #![feature(fmt_internals)]
 #![feature(iterator_step_by)]
+#![feature(i128)]
 #![feature(i128_type)]
 #![feature(inclusive_range)]
 #![feature(inclusive_range_syntax)]

--- a/src/test/run-pass/impl-trait/example-calendar.rs
+++ b/src/test/run-pass/impl-trait/example-calendar.rs
@@ -161,7 +161,7 @@ impl<'a, 'b> std::ops::Add<&'b NaiveDate> for &'a NaiveDate {
     }
 }
 
-impl std::iter::Step for NaiveDate {
+unsafe impl std::iter::Step for NaiveDate {
     fn steps_between(_: &Self, _: &Self) -> Option<usize> {
         unimplemented!()
     }

--- a/src/test/run-pass/impl-trait/example-calendar.rs
+++ b/src/test/run-pass/impl-trait/example-calendar.rs
@@ -166,23 +166,15 @@ impl std::iter::Step for NaiveDate {
         unimplemented!()
     }
 
-    fn replace_one(&mut self) -> Self {
-        mem::replace(self, NaiveDate(0, 0, 1))
+    fn forward(&self, step_count: usize) -> Option<Self> {
+        let mut result = *self;
+        for _ in 0..step_count {
+            result = result.succ();
+        }
+        Some(result)
     }
 
-    fn replace_zero(&mut self) -> Self {
-        mem::replace(self, NaiveDate(0, 0, 0))
-    }
-
-    fn add_one(&self) -> Self {
-        self.succ()
-    }
-
-    fn sub_one(&self) -> Self {
-        unimplemented!()
-    }
-
-    fn add_usize(&self, _: usize) -> Option<Self> {
+    fn backward(&self, _step_count: usize) -> Option<Self> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
CC https://github.com/rust-lang/rust/issues/42168

The trait is now:

```rust
/// Objects that have a notion of *successor* and *predecessor*
/// for the purpose of range iterators.
///
/// This trait is `unsafe` because implementations of the `unsafe` trait `TrustedLen`
/// depend on its implementations being correct.
#[unstable(feature = "step_trait",
           reason = "recently redesigned",
           issue = "42168")]
pub unsafe trait Step: Clone + PartialOrd + Sized {
    /// Returns the number of *successor* steps needed to get from `start` to `end`.
    ///
    /// Returns `None` if that number would overflow `usize`
    /// (or is infinite, if `end` would never be reached).
    ///
    /// This must hold for any `a`, `b`, and `n`:
    ///
    /// * `steps_between(&a, &b) == Some(0)` if and only if `a >= b`.
    /// * `steps_between(&a, &b) == Some(n)` if and only if `a.forward(n) == Some(b)`
    /// * `steps_between(&a, &b) == Some(n)` if and only if `b.backward(n) == Some(a)`
    fn steps_between(start: &Self, end: &Self) -> Option<usize>;

    /// Returns the value that would be obtained by taking the *successor* of `self`,
    /// `step_count` times.
    ///
    /// Returns `None` if this would overflow the range of values supported by the type `Self`.
    ///
    /// Note: `step_count == 1` is a common case,
    /// used for example in `Iterator::next` for ranges.
    ///
    /// This must hold for any `a`, `n`, and `m` where `n + m` doesn’t overflow:
    ///
    /// * `a.forward(n).and_then(|x| x.forward(m)) == a.forward(n + m)`
    fn forward(&self, step_count: usize) -> Option<Self>;

    /// Returns the value that would be obtained by taking the *predecessor* of `self`,
    /// `step_count` times.
    ///
    /// Returns `None` if this would overflow the range of values supported by the type `Self`.
    ///
    /// Note: `step_count == 1` is a common case,
    /// used for example in `Iterator::next_back` for ranges.
    ///
    /// This must hold for any `a`, `n`, and `m` where `n + m` doesn’t overflow:
    ///
    /// * `a.backward(n).and_then(|x| x.backward(m)) == a.backward(n + m)`
    fn backward(&self, step_count: usize) -> Option<Self>;
}
```

Arithmetic and overflow handling with multiple integer types of different widths and signedness is tricky, careful review would be appreciated.

Other changes:

* The unsafe trait `TrustedLen` is now implemented for ranges of <s>all integer types</s> all `T: Step` types. `Step` is now an `unsafe trait` as a consequence.
* Check for overflow everywhere. If it turns out the optimizer doesn’t manage to elide some of the checks that could be removed I’ll leave it to someone else to carefully optimize this, preferably without changing behavior. CC https://github.com/rust-lang/rust/issues/43064
* Remove `ExactSizeIterator` impls for `RangeInclusive<u16>` and `RangeInclusive<i16>` as they are incorrect on 16-bit platforms. CC https://github.com/rust-lang/rust/pull/43086#issuecomment-313872797
* Don’t reset inclusive ranges to `1...0` after the last iteration. Instead increment or decrement similarly to other iterations. If that would cause overflow, decrement/increment the other bound instead.
* Return `(usize::MAX, None)` instead of `(0, None)` in `size_hint` when the exact result would overflow `usize`.