### PR TITLE
Updated docker images to share scripts 

### DIFF
--- a/src/ci/docker/arm-android/Dockerfile
+++ b/src/ci/docker/arm-android/Dockerfile
@@ -1,31 +1,15 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-  ca-certificates \
-  cmake \
-  curl \
-  file \
-  g++ \
-  git \
-  libssl-dev \
-  make \
-  pkg-config \
-  python2.7 \
-  sudo \
-  unzip \
-  xz-utils
+COPY scripts/android-base-apt-get.sh /scripts/
+RUN sh /scripts/android-base-apt-get.sh
 
-# dumb-init
 COPY scripts/dumb-init.sh /scripts/
 RUN sh /scripts/dumb-init.sh
 
-# ndk
 COPY scripts/android-ndk.sh /scripts/
 RUN . /scripts/android-ndk.sh && \
     download_and_make_toolchain android-ndk-r13b-linux-x86_64.zip arm 9
 
-# sdk
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -39,7 +23,6 @@ COPY scripts/android-sdk.sh /scripts/
 RUN . /scripts/android-sdk.sh && \
     download_and_create_avd tools_r25.2.5-linux.zip armeabi-v7a 18
 
-# env
 ENV PATH=$PATH:/android/sdk/tools
 ENV PATH=$PATH:/android/sdk/platform-tools
 
@@ -51,10 +34,8 @@ ENV RUST_CONFIGURE_ARGS \
 
 ENV SCRIPT python2.7 ../x.py test --target $TARGETS
 
-# sccache
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-# init
 COPY scripts/android-start-emulator.sh /scripts/
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/scripts/android-start-emulator.sh"]

--- a/src/ci/docker/armhf-gnu/Dockerfile
+++ b/src/ci/docker/armhf-gnu/Dockerfile
@@ -73,13 +73,12 @@ RUN arm-linux-gnueabihf-gcc addentropy.c -o rootfs/addentropy -static
 # TODO: What is this?!
 RUN curl -O http://ftp.nl.debian.org/debian/dists/jessie/main/installer-armhf/current/images/device-tree/vexpress-v2p-ca15-tc1.dtb
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 ENV RUST_CONFIGURE_ARGS \

--- a/src/ci/docker/asmjs/Dockerfile
+++ b/src/ci/docker/asmjs/Dockerfile
@@ -13,15 +13,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   gdb \
   xz-utils
 
-# dumb-init
 COPY scripts/dumb-init.sh /scripts/
 RUN sh /scripts/dumb-init.sh
 
-# emscripten
 COPY scripts/emscripten.sh /scripts/
 RUN bash /scripts/emscripten.sh
 
-# env
 ENV PATH=$PATH:/emsdk-portable
 ENV PATH=$PATH:/emsdk-portable/clang/e1.37.13_64bit/
 ENV PATH=$PATH:/emsdk-portable/emscripten/1.37.13/
@@ -36,9 +33,7 @@ ENV RUST_CONFIGURE_ARGS --target=$TARGETS
 
 ENV SCRIPT python2.7 ../x.py test --target $TARGETS
 
-# cache
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-# init
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/src/ci/docker/cross/Dockerfile
+++ b/src/ci/docker/cross/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libssl-dev \
   pkg-config
 
-# dumb-init
 COPY scripts/dumb-init.sh /scripts/
 RUN sh /scripts/dumb-init.sh
 
@@ -68,5 +67,4 @@ ENV SCRIPT python2.7 ../x.py dist --target $TARGETS
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-# init
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/src/ci/docker/disabled/dist-aarch64-android/Dockerfile
+++ b/src/ci/docker/disabled/dist-aarch64-android/Dockerfile
@@ -1,31 +1,15 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-  ca-certificates \
-  cmake \
-  curl \
-  file \
-  g++ \
-  git \
-  libssl-dev \
-  make \
-  pkg-config \
-  python2.7 \
-  sudo \
-  unzip \
-  xz-utils
+COPY scripts/android-base-apt-get.sh /scripts/
+RUN sh /scripts/android-base-apt-get.sh
 
-# dumb-init
 COPY scripts/dumb-init.sh /scripts/
 RUN sh /scripts/dumb-init.sh
 
-# ndk
 COPY scripts/android-ndk.sh /scripts/
 RUN . /scripts/android-ndk.sh && \
     download_and_make_toolchain android-ndk-r13b-linux-x86_64.zip arm64 21
 
-# env
 ENV PATH=$PATH:/android/ndk/arm64-21/bin
 
 ENV DEP_Z_ROOT=/android/ndk/arm64-21/sysroot/usr/
@@ -42,9 +26,7 @@ ENV RUST_CONFIGURE_ARGS \
 
 ENV SCRIPT python2.7 ../x.py dist --target $HOSTS --host $HOSTS
 
-# sccache
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-# init
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/src/ci/docker/disabled/dist-armv7-android/Dockerfile
+++ b/src/ci/docker/disabled/dist-armv7-android/Dockerfile
@@ -1,26 +1,11 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-  ca-certificates \
-  cmake \
-  curl \
-  file \
-  g++ \
-  git \
-  libssl-dev \
-  make \
-  pkg-config \
-  python2.7 \
-  sudo \
-  unzip \
-  xz-utils
+COPY scripts/android-base-apt-get.sh /scripts/
+RUN sh /scripts/android-base-apt-get.sh
 
-# dumb-init
 COPY scripts/dumb-init.sh /scripts/
 RUN sh /scripts/dumb-init.sh
 
-# ndk
 COPY scripts/android-ndk.sh /scripts/
 RUN . /scripts/android-ndk.sh && \
     download_ndk android-ndk-r13b-linux-x86_64.zip && \
@@ -31,7 +16,6 @@ RUN . /scripts/android-ndk.sh && \
 RUN chmod 777 /android/ndk && \
     ln -s /android/ndk/arm-21 /android/ndk/arm
 
-# env
 ENV PATH=$PATH:/android/ndk/arm-9/bin
 
 ENV DEP_Z_ROOT=/android/ndk/arm-9/sysroot/usr/
@@ -60,9 +44,7 @@ ENV SCRIPT \
     ln -s /android/ndk/arm-9 /android/ndk/arm && \
     python2.7 ../x.py dist --host $HOSTS --target $HOSTS)
 
-# sccache
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-# init
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/src/ci/docker/disabled/dist-i686-android/Dockerfile
+++ b/src/ci/docker/disabled/dist-i686-android/Dockerfile
@@ -1,26 +1,11 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-  ca-certificates \
-  cmake \
-  curl \
-  file \
-  g++ \
-  git \
-  libssl-dev \
-  make \
-  pkg-config \
-  python2.7 \
-  sudo \
-  unzip \
-  xz-utils
+COPY scripts/android-base-apt-get.sh /scripts/
+RUN sh /scripts/android-base-apt-get.sh
 
-# dumb-init
 COPY scripts/dumb-init.sh /scripts/
 RUN sh /scripts/dumb-init.sh
 
-# ndk
 COPY scripts/android-ndk.sh /scripts/
 RUN . /scripts/android-ndk.sh && \
     download_ndk android-ndk-r13b-linux-x86_64.zip && \
@@ -31,7 +16,6 @@ RUN . /scripts/android-ndk.sh && \
 RUN chmod 777 /android/ndk && \
     ln -s /android/ndk/x86-21 /android/ndk/x86
 
-# env
 ENV PATH=$PATH:/android/ndk/x86-9/bin
 
 ENV DEP_Z_ROOT=/android/ndk/x86-9/sysroot/usr/
@@ -60,9 +44,7 @@ ENV SCRIPT \
     ln -s /android/ndk/x86-9 /android/ndk/x86 && \
     python2.7 ../x.py dist --host $HOSTS --target $HOSTS)
 
-# sccache
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-# init
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/src/ci/docker/disabled/dist-x86_64-android/Dockerfile
+++ b/src/ci/docker/disabled/dist-x86_64-android/Dockerfile
@@ -1,31 +1,15 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-  ca-certificates \
-  cmake \
-  curl \
-  file \
-  g++ \
-  git \
-  libssl-dev \
-  make \
-  pkg-config \
-  python2.7 \
-  sudo \
-  unzip \
-  xz-utils
+COPY scripts/android-base-apt-get.sh /scripts/
+RUN sh /scripts/android-base-apt-get.sh
 
-# dumb-init
 COPY scripts/dumb-init.sh /scripts/
 RUN sh /scripts/dumb-init.sh
 
-# ndk
 COPY scripts/android-ndk.sh /scripts/
 RUN . /scripts/android-ndk.sh && \
     download_and_make_toolchain android-ndk-r13b-linux-x86_64.zip x86_64 21
 
-# env
 ENV PATH=$PATH:/android/ndk/x86_64-21/bin
 
 ENV DEP_Z_ROOT=/android/ndk/x86_64-21/sysroot/usr/
@@ -42,9 +26,7 @@ ENV RUST_CONFIGURE_ARGS \
 
 ENV SCRIPT python2.7 ../x.py dist --target $HOSTS --host $HOSTS
 
-# sccache
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-# init
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/src/ci/docker/disabled/wasm32/Dockerfile
+++ b/src/ci/docker/disabled/wasm32/Dockerfile
@@ -15,20 +15,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   jq \
   bzip2
 
-# dumb-init
 COPY scripts/dumb-init.sh /scripts/
 RUN sh /scripts/dumb-init.sh
 
-# emscripten
 COPY scripts/emscripten-wasm.sh /scripts/
 RUN bash /scripts/emscripten-wasm.sh
 COPY disabled/wasm32/node.sh /usr/local/bin/node
 
-# cache
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-# env
 ENV PATH=$PATH:/emsdk-portable
 ENV PATH=$PATH:/emsdk-portable/clang/e1.37.13_64bit/
 ENV PATH=$PATH:/emsdk-portable/emscripten/1.37.13/
@@ -42,5 +38,4 @@ ENV RUST_CONFIGURE_ARGS --target=$TARGETS --experimental-targets=WebAssembly
 
 ENV SCRIPT python2.7 ../x.py test --target $TARGETS
 
-# init
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/src/ci/docker/dist-aarch64-linux/Dockerfile
+++ b/src/ci/docker/dist-aarch64-linux/Dockerfile
@@ -1,58 +1,23 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  automake \
-  bison \
-  bzip2 \
-  ca-certificates \
-  cmake \
-  curl \
-  file \
-  flex \
-  g++ \
-  gawk \
-  gdb \
-  git \
-  gperf \
-  help2man \
-  libncurses-dev \
-  libtool-bin \
-  make \
-  patch \
-  python2.7 \
-  sudo \
-  texinfo \
-  wget \
-  xz-utils \
-  libssl-dev \
-  pkg-config
+COPY scripts/cross-apt-packages.sh /scripts/
+RUN sh /scripts/cross-apt-packages.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-# Ubuntu 16.04 (this contianer) ships with make 4, but something in the
+# Ubuntu 16.04 (this container) ships with make 4, but something in the
 # toolchains we build below chokes on that, so go back to make 3
-RUN curl https://ftp.gnu.org/gnu/make/make-3.81.tar.gz | tar xzf - && \
-      cd make-3.81 && \
-      ./configure --prefix=/usr && \
-      make && \
-      make install && \
-      cd .. && \
-      rm -rf make-3.81
+COPY scripts/make3.sh /scripts/
+RUN sh /scripts/make3.sh
 
-RUN curl http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.22.0.tar.bz2 | \
-      tar xjf - && \
-      cd crosstool-ng && \
-      ./configure --prefix=/usr/local && \
-      make -j$(nproc) && \
-      make install && \
-      cd .. && \
-      rm -rf crosstool-ng
+COPY scripts/crosstool-ng.sh /scripts/
+RUN sh /scripts/crosstool-ng.sh
 
-RUN groupadd -r rustbuild && useradd -m -r -g rustbuild rustbuild
-RUN mkdir /x-tools && chown rustbuild:rustbuild /x-tools
+COPY scripts/rustbuild-setup.sh /scripts/
+RUN sh /scripts/rustbuild-setup.sh
 USER rustbuild
 WORKDIR /tmp
 
@@ -61,9 +26,8 @@ RUN ./build-toolchains.sh
 
 USER root
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
 
 ENV PATH=$PATH:/x-tools/aarch64-unknown-linux-gnueabi/bin
 

--- a/src/ci/docker/dist-android/Dockerfile
+++ b/src/ci/docker/dist-android/Dockerfile
@@ -1,22 +1,8 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-  ca-certificates \
-  cmake \
-  curl \
-  file \
-  g++ \
-  git \
-  libssl-dev \
-  make \
-  pkg-config \
-  python2.7 \
-  sudo \
-  unzip \
-  xz-utils
+COPY scripts/android-base-apt-get.sh /scripts/
+RUN sh /scripts/android-base-apt-get.sh
 
-# dumb-init
 COPY scripts/dumb-init.sh /scripts/
 RUN sh /scripts/dumb-init.sh
 
@@ -48,9 +34,7 @@ ENV RUST_CONFIGURE_ARGS \
 
 ENV SCRIPT python2.7 ../x.py dist --target $TARGETS
 
-# cache
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-# init
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/src/ci/docker/dist-arm-linux/Dockerfile
+++ b/src/ci/docker/dist-arm-linux/Dockerfile
@@ -1,58 +1,23 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  automake \
-  bison \
-  bzip2 \
-  ca-certificates \
-  cmake \
-  curl \
-  file \
-  flex \
-  g++ \
-  gawk \
-  gdb \
-  git \
-  gperf \
-  help2man \
-  libncurses-dev \
-  libtool-bin \
-  make \
-  patch \
-  python2.7 \
-  sudo \
-  texinfo \
-  wget \
-  xz-utils \
-  libssl-dev \
-  pkg-config
+COPY scripts/cross-apt-packages.sh /scripts/
+RUN sh /scripts/cross-apt-packages.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-# Ubuntu 16.04 (this contianer) ships with make 4, but something in the
+# Ubuntu 16.04 (this container) ships with make 4, but something in the
 # toolchains we build below chokes on that, so go back to make 3
-RUN curl https://ftp.gnu.org/gnu/make/make-3.81.tar.gz | tar xzf - && \
-      cd make-3.81 && \
-      ./configure --prefix=/usr && \
-      make && \
-      make install && \
-      cd .. && \
-      rm -rf make-3.81
+COPY scripts/make3.sh /scripts/
+RUN sh /scripts/make3.sh
 
-RUN curl http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.22.0.tar.bz2 | \
-      tar xjf - && \
-      cd crosstool-ng && \
-      ./configure --prefix=/usr/local && \
-      make -j$(nproc) && \
-      make install && \
-      cd .. && \
-      rm -rf crosstool-ng
+COPY scripts/crosstool-ng.sh /scripts/
+RUN sh /scripts/crosstool-ng.sh
 
-RUN groupadd -r rustbuild && useradd -m -r -g rustbuild rustbuild
-RUN mkdir /x-tools && chown rustbuild:rustbuild /x-tools
+COPY scripts/rustbuild-setup.sh /scripts/
+RUN sh /scripts/rustbuild-setup.sh
 USER rustbuild
 WORKDIR /tmp
 
@@ -61,9 +26,8 @@ RUN ./build-toolchains.sh
 
 USER root
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
 
 ENV PATH=$PATH:/x-tools/arm-unknown-linux-gnueabi/bin
 

--- a/src/ci/docker/dist-armhf-linux/Dockerfile
+++ b/src/ci/docker/dist-armhf-linux/Dockerfile
@@ -1,58 +1,23 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  automake \
-  bison \
-  bzip2 \
-  ca-certificates \
-  cmake \
-  curl \
-  file \
-  flex \
-  g++ \
-  gawk \
-  gdb \
-  git \
-  gperf \
-  help2man \
-  libncurses-dev \
-  libtool-bin \
-  make \
-  patch \
-  python2.7 \
-  sudo \
-  texinfo \
-  wget \
-  xz-utils \
-  libssl-dev \
-  pkg-config
+COPY scripts/cross-apt-packages.sh /scripts/
+RUN sh /scripts/cross-apt-packages.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-# Ubuntu 16.04 (this contianer) ships with make 4, but something in the
+# Ubuntu 16.04 (this container) ships with make 4, but something in the
 # toolchains we build below chokes on that, so go back to make 3
-RUN curl https://ftp.gnu.org/gnu/make/make-3.81.tar.gz | tar xzf - && \
-      cd make-3.81 && \
-      ./configure --prefix=/usr && \
-      make && \
-      make install && \
-      cd .. && \
-      rm -rf make-3.81
+COPY scripts/make3.sh /scripts/
+RUN sh /scripts/make3.sh
 
-RUN curl http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.22.0.tar.bz2 | \
-      tar xjf - && \
-      cd crosstool-ng && \
-      ./configure --prefix=/usr/local && \
-      make -j$(nproc) && \
-      make install && \
-      cd .. && \
-      rm -rf crosstool-ng
+COPY scripts/crosstool-ng.sh /scripts/
+RUN sh /scripts/crosstool-ng.sh
 
-RUN groupadd -r rustbuild && useradd -m -r -g rustbuild rustbuild
-RUN mkdir /x-tools && chown rustbuild:rustbuild /x-tools
+COPY scripts/rustbuild-setup.sh /scripts/
+RUN sh /scripts/rustbuild-setup.sh
 USER rustbuild
 WORKDIR /tmp
 
@@ -61,9 +26,8 @@ RUN ./build-toolchains.sh
 
 USER root
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
 
 ENV PATH=$PATH:/x-tools/arm-unknown-linux-gnueabihf/bin
 

--- a/src/ci/docker/dist-armv7-linux/Dockerfile
+++ b/src/ci/docker/dist-armv7-linux/Dockerfile
@@ -1,58 +1,23 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  automake \
-  bison \
-  bzip2 \
-  ca-certificates \
-  cmake \
-  curl \
-  file \
-  flex \
-  g++ \
-  gawk \
-  gdb \
-  git \
-  gperf \
-  help2man \
-  libncurses-dev \
-  libtool-bin \
-  make \
-  patch \
-  python2.7 \
-  sudo \
-  texinfo \
-  wget \
-  xz-utils \
-  libssl-dev \
-  pkg-config
+COPY scripts/cross-apt-packages.sh /scripts/
+RUN sh /scripts/cross-apt-packages.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-# Ubuntu 16.04 (this contianer) ships with make 4, but something in the
+# Ubuntu 16.04 (this container) ships with make 4, but something in the
 # toolchains we build below chokes on that, so go back to make 3
-RUN curl https://ftp.gnu.org/gnu/make/make-3.81.tar.gz | tar xzf - && \
-      cd make-3.81 && \
-      ./configure --prefix=/usr && \
-      make && \
-      make install && \
-      cd .. && \
-      rm -rf make-3.81
+COPY scripts/make3.sh /scripts/
+RUN sh /scripts/make3.sh
 
-RUN curl http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.22.0.tar.bz2 | \
-      tar xjf - && \
-      cd crosstool-ng && \
-      ./configure --prefix=/usr/local && \
-      make -j$(nproc) && \
-      make install && \
-      cd .. && \
-      rm -rf crosstool-ng
+COPY scripts/crosstool-ng.sh /scripts/
+RUN sh /scripts/crosstool-ng.sh
 
-RUN groupadd -r rustbuild && useradd -m -r -g rustbuild rustbuild
-RUN mkdir /x-tools && chown rustbuild:rustbuild /x-tools
+COPY scripts/rustbuild-setup.sh /scripts/
+RUN sh /scripts/rustbuild-setup.sh
 USER rustbuild
 WORKDIR /tmp
 
@@ -61,9 +26,8 @@ RUN ./build-toolchains.sh
 
 USER root
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
 
 ENV PATH=$PATH:/x-tools/armv7-unknown-linux-gnueabihf/bin
 

--- a/src/ci/docker/dist-fuchsia/Dockerfile
+++ b/src/ci/docker/dist-fuchsia/Dockerfile
@@ -24,14 +24,13 @@ WORKDIR /tmp
 COPY dist-fuchsia/shared.sh dist-fuchsia/build-toolchain.sh dist-fuchsia/compiler-rt-dso-handle.patch /tmp/
 RUN /tmp/build-toolchain.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
 
 ENV \
     AR_x86_64_unknown_fuchsia=x86_64-unknown-fuchsia-ar \

--- a/src/ci/docker/dist-i586-gnu-i686-musl/Dockerfile
+++ b/src/ci/docker/dist-i586-gnu-i686-musl/Dockerfile
@@ -20,14 +20,13 @@ WORKDIR /build/
 COPY dist-i586-gnu-i686-musl/musl-libunwind-patch.patch dist-i586-gnu-i686-musl/build-musl.sh /build/
 RUN sh /build/build-musl.sh && rm -rf /build
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
 
 ENV RUST_CONFIGURE_ARGS \
       --target=i686-unknown-linux-musl,i586-unknown-linux-gnu \

--- a/src/ci/docker/dist-i686-freebsd/Dockerfile
+++ b/src/ci/docker/dist-i686-freebsd/Dockerfile
@@ -19,14 +19,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY dist-i686-freebsd/build-toolchain.sh /tmp/
 RUN /tmp/build-toolchain.sh i686
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
 
 ENV \
     AR_i686_unknown_freebsd=i686-unknown-freebsd10-ar \

--- a/src/ci/docker/dist-i686-linux/Dockerfile
+++ b/src/ci/docker/dist-i686-linux/Dockerfile
@@ -81,9 +81,8 @@ RUN curl -Lo /rustroot/dumb-init \
       chmod +x /rustroot/dumb-init
 ENTRYPOINT ["/rustroot/dumb-init", "--"]
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
 
 ENV HOSTS=i686-unknown-linux-gnu
 

--- a/src/ci/docker/dist-mips-linux/Dockerfile
+++ b/src/ci/docker/dist-mips-linux/Dockerfile
@@ -16,13 +16,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libssl-dev \
   pkg-config
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
+
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 ENV HOSTS=mips-unknown-linux-gnu

--- a/src/ci/docker/dist-mips64-linux/Dockerfile
+++ b/src/ci/docker/dist-mips64-linux/Dockerfile
@@ -16,13 +16,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libssl-dev \
   pkg-config
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 ENV HOSTS=mips64-unknown-linux-gnuabi64

--- a/src/ci/docker/dist-mips64el-linux/Dockerfile
+++ b/src/ci/docker/dist-mips64el-linux/Dockerfile
@@ -16,13 +16,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libssl-dev \
   pkg-config
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
+
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 ENV HOSTS=mips64el-unknown-linux-gnuabi64

--- a/src/ci/docker/dist-mipsel-linux/Dockerfile
+++ b/src/ci/docker/dist-mipsel-linux/Dockerfile
@@ -16,13 +16,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libssl-dev \
   pkg-config
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 ENV HOSTS=mipsel-unknown-linux-gnu

--- a/src/ci/docker/dist-powerpc-linux/Dockerfile
+++ b/src/ci/docker/dist-powerpc-linux/Dockerfile
@@ -1,58 +1,23 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  automake \
-  bison \
-  bzip2 \
-  ca-certificates \
-  cmake \
-  curl \
-  file \
-  flex \
-  g++ \
-  gawk \
-  gdb \
-  git \
-  gperf \
-  help2man \
-  libncurses-dev \
-  libtool-bin \
-  make \
-  patch \
-  python2.7 \
-  sudo \
-  texinfo \
-  wget \
-  xz-utils \
-  libssl-dev \
-  pkg-config
+COPY scripts/cross-apt-packages.sh /scripts/
+RUN sh /scripts/cross-apt-packages.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-# Ubuntu 16.04 (this contianer) ships with make 4, but something in the
+# Ubuntu 16.04 (this container) ships with make 4, but something in the
 # toolchains we build below chokes on that, so go back to make 3
-RUN curl https://ftp.gnu.org/gnu/make/make-3.81.tar.gz | tar xzf - && \
-      cd make-3.81 && \
-      ./configure --prefix=/usr && \
-      make && \
-      make install && \
-      cd .. && \
-      rm -rf make-3.81
+COPY scripts/make3.sh /scripts/
+RUN sh /scripts/make3.sh
 
-RUN curl http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.22.0.tar.bz2 | \
-      tar xjf - && \
-      cd crosstool-ng && \
-      ./configure --prefix=/usr/local && \
-      make -j$(nproc) && \
-      make install && \
-      cd .. && \
-      rm -rf crosstool-ng
+COPY scripts/crosstool-ng.sh /scripts/
+RUN sh /scripts/crosstool-ng.sh
 
-RUN groupadd -r rustbuild && useradd -m -r -g rustbuild rustbuild
-RUN mkdir /x-tools && chown rustbuild:rustbuild /x-tools
+COPY scripts/rustbuild-setup.sh /scripts/
+RUN sh /scripts/rustbuild-setup.sh
 USER rustbuild
 WORKDIR /tmp
 
@@ -62,9 +27,8 @@ RUN ./build-powerpc-toolchain.sh
 
 USER root
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
 
 ENV PATH=$PATH:/x-tools/powerpc-unknown-linux-gnu/bin
 

--- a/src/ci/docker/dist-powerpc64-linux/Dockerfile
+++ b/src/ci/docker/dist-powerpc64-linux/Dockerfile
@@ -1,58 +1,23 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  automake \
-  bison \
-  bzip2 \
-  ca-certificates \
-  cmake \
-  curl \
-  file \
-  flex \
-  g++ \
-  gawk \
-  gdb \
-  git \
-  gperf \
-  help2man \
-  libncurses-dev \
-  libtool-bin \
-  make \
-  patch \
-  python2.7 \
-  sudo \
-  texinfo \
-  wget \
-  xz-utils \
-  libssl-dev \
- pkg-config
+COPY scripts/cross-apt-packages.sh /scripts/
+RUN sh /scripts/cross-apt-packages.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-# Ubuntu 16.04 (this contianer) ships with make 4, but something in the
+# Ubuntu 16.04 (this container) ships with make 4, but something in the
 # toolchains we build below chokes on that, so go back to make 3
-RUN curl https://ftp.gnu.org/gnu/make/make-3.81.tar.gz | tar xzf - && \
-      cd make-3.81 && \
-      ./configure --prefix=/usr && \
-      make && \
-      make install && \
-      cd .. && \
-      rm -rf make-3.81
+COPY scripts/make3.sh /scripts/
+RUN sh /scripts/make3.sh
 
-RUN curl http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.22.0.tar.bz2 | \
-      tar xjf - && \
-      cd crosstool-ng && \
-      ./configure --prefix=/usr/local && \
-      make -j$(nproc) && \
-      make install && \
-      cd .. && \
-      rm -rf crosstool-ng
+COPY scripts/crosstool-ng.sh /scripts/
+RUN sh /scripts/crosstool-ng.sh
 
-RUN groupadd -r rustbuild && useradd -m -r -g rustbuild rustbuild
-RUN mkdir /x-tools && chown rustbuild:rustbuild /x-tools
+COPY scripts/rustbuild-setup.sh /scripts/
+RUN sh /scripts/rustbuild-setup.sh
 USER rustbuild
 WORKDIR /tmp
 
@@ -62,9 +27,8 @@ RUN ./build-powerpc64-toolchain.sh
 
 USER root
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
 
 ENV PATH=$PATH:/x-tools/powerpc64-unknown-linux-gnu/bin
 

--- a/src/ci/docker/dist-powerpc64le-linux/Dockerfile
+++ b/src/ci/docker/dist-powerpc64le-linux/Dockerfile
@@ -1,58 +1,23 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  automake \
-  bison \
-  bzip2 \
-  ca-certificates \
-  cmake \
-  curl \
-  file \
-  flex \
-  g++ \
-  gawk \
-  gdb \
-  git \
-  gperf \
-  help2man \
-  libncurses-dev \
-  libtool-bin \
-  make \
-  patch \
-  python2.7 \
-  sudo \
-  texinfo \
-  wget \
-  xz-utils \
-  libssl-dev \
- pkg-config
+COPY scripts/cross-apt-packages.sh /scripts/
+RUN sh /scripts/cross-apt-packages.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-# Ubuntu 16.04 (this contianer) ships with make 4, but something in the
+# Ubuntu 16.04 (this container) ships with make 4, but something in the
 # toolchains we build below chokes on that, so go back to make 3
-RUN curl https://ftp.gnu.org/gnu/make/make-3.81.tar.gz | tar xzf - && \
-      cd make-3.81 && \
-      ./configure --prefix=/usr && \
-      make && \
-      make install && \
-      cd .. && \
-      rm -rf make-3.81
+COPY scripts/make3.sh /scripts/
+RUN sh /scripts/make3.sh
 
-RUN curl http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.22.0.tar.bz2 | \
-      tar xjf - && \
-      cd crosstool-ng && \
-      ./configure --prefix=/usr/local && \
-      make -j$(nproc) && \
-      make install && \
-      cd .. && \
-      rm -rf crosstool-ng
+COPY scripts/crosstool-ng.sh /scripts/
+RUN sh /scripts/crosstool-ng.sh
 
-RUN groupadd -r rustbuild && useradd -m -r -g rustbuild rustbuild
-RUN mkdir /x-tools && chown rustbuild:rustbuild /x-tools
+COPY scripts/rustbuild-setup.sh /scripts/
+RUN sh /scripts/rustbuild-setup.sh
 USER rustbuild
 WORKDIR /tmp
 
@@ -62,9 +27,8 @@ RUN apt-get install -y --no-install-recommends rpm2cpio cpio
 COPY dist-powerpc64le-linux/shared.sh dist-powerpc64le-linux/build-powerpc64le-toolchain.sh /tmp/
 RUN ./build-powerpc64le-toolchain.sh
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
 
 ENV \
     AR_powerpc64le_unknown_linux_gnu=powerpc64le-linux-gnu-ar \

--- a/src/ci/docker/dist-s390x-linux/Dockerfile
+++ b/src/ci/docker/dist-s390x-linux/Dockerfile
@@ -1,58 +1,23 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  automake \
-  bison \
-  bzip2 \
-  ca-certificates \
-  cmake \
-  curl \
-  file \
-  flex \
-  g++ \
-  gawk \
-  gdb \
-  git \
-  gperf \
-  help2man \
-  libncurses-dev \
-  libtool-bin \
-  make \
-  patch \
-  python2.7 \
-  sudo \
-  texinfo \
-  wget \
-  xz-utils \
-  libssl-dev \
-  pkg-config
+COPY scripts/cross-apt-packages.sh /scripts/
+RUN sh /scripts/cross-apt-packages.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-# Ubuntu 16.04 (this contianer) ships with make 4, but something in the
+# Ubuntu 16.04 (this container) ships with make 4, but something in the
 # toolchains we build below chokes on that, so go back to make 3
-RUN curl https://ftp.gnu.org/gnu/make/make-3.81.tar.gz | tar xzf - && \
-      cd make-3.81 && \
-      ./configure --prefix=/usr && \
-      make && \
-      make install && \
-      cd .. && \
-      rm -rf make-3.81
+COPY scripts/make3.sh /scripts/
+RUN sh /scripts/make3.sh
 
-RUN curl http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.22.0.tar.bz2 | \
-      tar xjf - && \
-      cd crosstool-ng && \
-      ./configure --prefix=/usr/local && \
-      make -j$(nproc) && \
-      make install && \
-      cd .. && \
-      rm -rf crosstool-ng
+COPY scripts/crosstool-ng.sh /scripts/
+RUN sh /scripts/crosstool-ng.sh
 
-RUN groupadd -r rustbuild && useradd -m -r -g rustbuild rustbuild
-RUN mkdir /x-tools && chown rustbuild:rustbuild /x-tools
+COPY scripts/rustbuild-setup.sh /scripts/
+RUN sh /scripts/rustbuild-setup.sh
 USER rustbuild
 WORKDIR /tmp
 
@@ -62,9 +27,8 @@ RUN ./build-s390x-toolchain.sh
 
 USER root
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
 
 ENV PATH=$PATH:/x-tools/s390x-ibm-linux-gnu/bin
 

--- a/src/ci/docker/dist-x86_64-freebsd/Dockerfile
+++ b/src/ci/docker/dist-x86_64-freebsd/Dockerfile
@@ -19,14 +19,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY dist-x86_64-freebsd/build-toolchain.sh /tmp/
 RUN /tmp/build-toolchain.sh x86_64
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
 
 ENV \
     AR_x86_64_unknown_freebsd=x86_64-unknown-freebsd10-ar \

--- a/src/ci/docker/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/dist-x86_64-linux/Dockerfile
@@ -81,9 +81,8 @@ RUN curl -Lo /rustroot/dumb-init \
       chmod +x /rustroot/dumb-init
 ENTRYPOINT ["/rustroot/dumb-init", "--"]
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
 
 ENV HOSTS=x86_64-unknown-linux-gnu
 

--- a/src/ci/docker/dist-x86_64-musl/Dockerfile
+++ b/src/ci/docker/dist-x86_64-musl/Dockerfile
@@ -20,14 +20,13 @@ WORKDIR /build/
 COPY dist-x86_64-musl/build-musl.sh /build/
 RUN sh /build/build-musl.sh && rm -rf /build
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
 
 ENV RUST_CONFIGURE_ARGS \
       --target=x86_64-unknown-linux-musl \

--- a/src/ci/docker/dist-x86_64-netbsd/Dockerfile
+++ b/src/ci/docker/dist-x86_64-netbsd/Dockerfile
@@ -1,58 +1,23 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  automake \
-  bison \
-  bzip2 \
-  ca-certificates \
-  cmake \
-  curl \
-  file \
-  flex \
-  g++ \
-  gawk \
-  gdb \
-  git \
-  gperf \
-  help2man \
-  libncurses-dev \
-  libtool-bin \
-  make \
-  patch \
-  python2.7 \
-  sudo \
-  texinfo \
-  wget \
-  xz-utils \
-  libssl-dev \
-  pkg-config
+COPY scripts/cross-apt-packages.sh /scripts/
+RUN sh /scripts/cross-apt-packages.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-# Ubuntu 16.04 (this contianer) ships with make 4, but something in the
+# Ubuntu 16.04 (this container) ships with make 4, but something in the
 # toolchains we build below chokes on that, so go back to make 3
-RUN curl https://ftp.gnu.org/gnu/make/make-3.81.tar.gz | tar xzf - && \
-      cd make-3.81 && \
-      ./configure --prefix=/usr && \
-      make && \
-      make install && \
-      cd .. && \
-      rm -rf make-3.81
+COPY scripts/make3.sh /scripts/
+RUN sh /scripts/make3.sh
 
-RUN curl http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.22.0.tar.bz2 | \
-      tar xjf - && \
-      cd crosstool-ng && \
-      ./configure --prefix=/usr/local && \
-      make -j$(nproc) && \
-      make install && \
-      cd .. && \
-      rm -rf crosstool-ng
+COPY scripts/crosstool-ng.sh /scripts/
+RUN sh /scripts/crosstool-ng.sh
 
-RUN groupadd -r rustbuild && useradd -m -r -g rustbuild rustbuild
-RUN mkdir /x-tools && chown rustbuild:rustbuild /x-tools
+COPY scripts/rustbuild-setup.sh /scripts/
+RUN sh /scripts/rustbuild-setup.sh
 USER rustbuild
 WORKDIR /tmp
 
@@ -61,9 +26,8 @@ RUN ./build-netbsd-toolchain.sh
 
 USER root
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
 
 ENV PATH=$PATH:/x-tools/x86_64-unknown-netbsd/bin
 

--- a/src/ci/docker/i686-gnu-nopt/Dockerfile
+++ b/src/ci/docker/i686-gnu-nopt/Dockerfile
@@ -13,13 +13,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   gdb \
   xz-utils
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
+
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 ENV RUST_CONFIGURE_ARGS --build=i686-unknown-linux-gnu --disable-optimize-tests

--- a/src/ci/docker/i686-gnu/Dockerfile
+++ b/src/ci/docker/i686-gnu/Dockerfile
@@ -13,13 +13,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   gdb \
   xz-utils
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
+
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 ENV RUST_CONFIGURE_ARGS --build=i686-unknown-linux-gnu

--- a/src/ci/docker/scripts/android-base-apt-get.sh
+++ b/src/ci/docker/scripts/android-base-apt-get.sh
@@ -1,0 +1,27 @@
+# Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+set -ex
+
+apt-get update
+apt-get install -y --no-install-recommends \
+  ca-certificates \
+  cmake \
+  curl \
+  file \
+  g++ \
+  git \
+  libssl-dev \
+  make \
+  pkg-config \
+  python2.7 \
+  sudo \
+  unzip \
+  xz-utils

--- a/src/ci/docker/scripts/cross-apt-packages.sh
+++ b/src/ci/docker/scripts/cross-apt-packages.sh
@@ -1,0 +1,36 @@
+# Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+apt-get update && apt-get install -y --no-install-recommends \
+  automake \
+  bison \
+  bzip2 \
+  ca-certificates \
+  cmake \
+  curl \
+  file \
+  flex \
+  g++ \
+  gawk \
+  gdb \
+  git \
+  gperf \
+  help2man \
+  libncurses-dev \
+  libssl-dev \
+  libtool-bin \
+  make \
+  patch \
+  pkg-config \
+  python2.7 \
+  sudo \
+  texinfo \
+  wget \
+  xz-utils

--- a/src/ci/docker/scripts/crosstool-ng.sh
+++ b/src/ci/docker/scripts/crosstool-ng.sh
@@ -1,0 +1,20 @@
+# Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+set -ex
+
+url="http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.22.0.tar.bz2"
+curl $url | tar xjf -
+cd crosstool-ng
+./configure --prefix=/usr/local
+make -j$(nproc)
+make install
+cd ..
+rm -rf crosstool-ng

--- a/src/ci/docker/scripts/make3.sh
+++ b/src/ci/docker/scripts/make3.sh
@@ -1,0 +1,19 @@
+# Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+set -ex
+
+curl https://ftp.gnu.org/gnu/make/make-3.81.tar.gz | tar xzf -
+cd make-3.81
+./configure --prefix=/usr
+make
+make install
+cd ..
+rm -rf make-3.81

--- a/src/ci/docker/scripts/rustbuild-setup.sh
+++ b/src/ci/docker/scripts/rustbuild-setup.sh
@@ -1,0 +1,14 @@
+# Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+set -ex
+
+groupadd -r rustbuild && useradd -m -r -g rustbuild rustbuild
+mkdir /x-tools && chown rustbuild:rustbuild /x-tools

--- a/src/ci/docker/x86_64-gnu-aux/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-aux/Dockerfile
@@ -14,13 +14,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   xz-utils \
   pkg-config
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu

--- a/src/ci/docker/x86_64-gnu-debug/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-debug/Dockerfile
@@ -13,13 +13,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   gdb \
   xz-utils
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 ENV RUST_CONFIGURE_ARGS \

--- a/src/ci/docker/x86_64-gnu-distcheck/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-distcheck/Dockerfile
@@ -15,13 +15,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libssl-dev \
   pkg-config
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu

--- a/src/ci/docker/x86_64-gnu-full-bootstrap/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-full-bootstrap/Dockerfile
@@ -13,13 +13,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   gdb \
   xz-utils
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 ENV RUST_CONFIGURE_ARGS \

--- a/src/ci/docker/x86_64-gnu-incremental/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-incremental/Dockerfile
@@ -13,13 +13,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   gdb \
   xz-utils
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu

--- a/src/ci/docker/x86_64-gnu-llvm-3.7/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-llvm-3.7/Dockerfile
@@ -16,13 +16,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   zlib1g-dev \
   xz-utils
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 ENV RUST_CONFIGURE_ARGS \

--- a/src/ci/docker/x86_64-gnu-nopt/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-nopt/Dockerfile
@@ -13,13 +13,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   gdb \
   xz-utils
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu --disable-optimize-tests

--- a/src/ci/docker/x86_64-gnu/Dockerfile
+++ b/src/ci/docker/x86_64-gnu/Dockerfile
@@ -13,13 +13,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   gdb \
   xz-utils
 
-RUN curl -o /usr/local/bin/sccache \
-      https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl && \
-      chmod +x /usr/local/bin/sccache
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
 
-RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
-    dpkg -i dumb-init_*.deb && \
-    rm dumb-init_*.deb
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu --enable-sanitizers --enable-profiler


### PR DESCRIPTION
Attempts to resolve #42201. I managed to pull out five scripts (android-base-apt-get, ubuntu16-apt-get, make3, rustbuild-setup, and crosstool-ng). Let me know if there's more I can do or if I should change some names.
r? @malbarbo