### PR TITLE
Use similar compression settings as before updating to use flate2

### DIFF
--- a/src/librustc_metadata/locator.rs
+++ b/src/librustc_metadata/locator.rs
@@ -242,7 +242,7 @@ use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-use flate2::read::ZlibDecoder;
+use flate2::read::DeflateDecoder;
 use owning_ref::{ErasedBoxRef, OwningRef};
 
 pub struct CrateMismatch {
@@ -862,7 +862,7 @@ fn get_metadata_section_imp(target: &Target,
             let compressed_bytes = &buf[header_len..];
             debug!("inflating {} bytes of compressed metadata", compressed_bytes.len());
             let mut inflated = Vec::new();
-            match ZlibDecoder::new(compressed_bytes).read_to_end(&mut inflated) {
+            match DeflateDecoder::new(compressed_bytes).read_to_end(&mut inflated) {
                 Ok(_) => {
                     let buf = unsafe { OwningRef::new_assert_stable_address(inflated) };
                     buf.map_owner_box().erase_owner()

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -43,7 +43,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str;
 use flate2::Compression;
-use flate2::write::ZlibEncoder;
+use flate2::write::DeflateEncoder;
 use syntax::ast;
 use syntax::attr;
 use syntax_pos::Span;
@@ -622,7 +622,7 @@ fn link_rlib<'a>(sess: &'a Session,
                 }
 
                 let mut bc_data_deflated = Vec::new();
-                ZlibEncoder::new(&mut bc_data_deflated, Compression::Default)
+                DeflateEncoder::new(&mut bc_data_deflated, Compression::Fast)
                     .write_all(&bc_data).unwrap();
 
                 let mut bc_file_deflated = match fs::File::create(&bc_deflated_filename) {

--- a/src/librustc_trans/back/lto.rs
+++ b/src/librustc_trans/back/lto.rs
@@ -22,7 +22,7 @@ use rustc::hir::def_id::LOCAL_CRATE;
 use back::write::{ModuleConfig, with_llvm_pmb, CodegenContext};
 
 use libc;
-use flate2::read::ZlibDecoder;
+use flate2::read::DeflateDecoder;
 
 use std::io::Read;
 use std::ffi::CString;
@@ -111,7 +111,7 @@ pub fn run(cgcx: &CodegenContext,
                             (link::RLIB_BYTECODE_OBJECT_V1_DATA_OFFSET + data_size as usize)];
 
                         let mut inflated = Vec::new();
-                        let res = ZlibDecoder::new(compressed_data)
+                        let res = DeflateDecoder::new(compressed_data)
                             .read_to_end(&mut inflated);
                         if res.is_err() {
                             let msg = format!("failed to decompress bc of `{}`",
@@ -131,7 +131,7 @@ pub fn run(cgcx: &CodegenContext,
                     // simply inflate everything and let LLVM decide if it can
                     // make sense of it
                     let mut inflated = Vec::new();
-                    let res = ZlibDecoder::new(bc_encoded)
+                    let res = DeflateDecoder::new(bc_encoded)
                         .read_to_end(&mut inflated);
                     if res.is_err() {
                         let msg = format!("failed to decompress bc of `{}`",

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -730,7 +730,7 @@ fn write_metadata<'a, 'gcx>(tcx: TyCtxt<'a, 'gcx, 'gcx>,
                             -> (ContextRef, ModuleRef, EncodedMetadata) {
     use std::io::Write;
     use flate2::Compression;
-    use flate2::write::ZlibEncoder;
+    use flate2::write::DeflateEncoder;
 
     let (metadata_llcx, metadata_llmod) = unsafe {
         context::create_context_and_module(tcx.sess, "metadata")
@@ -770,7 +770,7 @@ fn write_metadata<'a, 'gcx>(tcx: TyCtxt<'a, 'gcx, 'gcx>,
 
     assert!(kind == MetadataKind::Compressed);
     let mut compressed = cstore.metadata_encoding_version().to_vec();
-    ZlibEncoder::new(&mut compressed, Compression::Default)
+    DeflateEncoder::new(&mut compressed, Compression::Fast)
         .write_all(&metadata.raw_data).unwrap();
 
     let llmeta = C_bytes_in_context(metadata_llcx, &compressed);


### PR DESCRIPTION
Fixes #42879 

(My first PR to rust-lang yay)

This changes the compression settings back to how they were before the change to use the flate2 crate rather than the in-tree flate library. The specific changes are to use the `Fast` compression level (which should be equivialent to what was used before), and use a raw deflate stream rather than wrapping the stream in a zlib wrapper. The [zlib](https://tools.ietf.org/html/rfc1950) wrapper adds an extra 2 bytes of header data, and 4 bytes for a checksum at the end. The change to use a faster compression level did give some compile speedups in the past (see #37298). Having to calculate a checksum also added a small overhead, which didn't exist before the change to flate2.

r? @alexcrichton 