### PR TITLE
Test src/doc once more

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -334,13 +334,18 @@ pub fn docs(build: &Build, compiler: &Compiler) {
 
     while let Some(p) = stack.pop() {
         if p.is_dir() {
-            stack.extend(t!(p.read_dir()).map(|p| t!(p).path()).filter(|p| {
-                p.extension().and_then(|s| s.to_str()) == Some("md") &&
-                // The nostarch directory in the book is for no starch, and so isn't guaranteed to
-                // build. We don't care if it doesn't build, so skip it.
-                p.to_str().map_or(true, |p| !p.contains("nostarch"))
-            }));
+            stack.extend(t!(p.read_dir()).map(|p| t!(p).path()));
             continue
+        }
+
+        if p.extension().and_then(|s| s.to_str()) != Some("md") {
+            continue;
+        }
+
+        // The nostarch directory in the book is for no starch, and so isn't
+        // guaranteed to build. We don't care if it doesn't build, so skip it.
+        if p.to_str().map_or(false, |p| p.contains("nostarch")) {
+            continue;
         }
 
         markdown_test(build, compiler, &p);

--- a/src/doc/unstable-book/src/language-features/compile-error.md
+++ b/src/doc/unstable-book/src/language-features/compile-error.md
@@ -11,7 +11,7 @@ error with the specified error message.
 
 ## Examples
 
-```rust
+```rust,compile_fail
 #![feature(compile_error)]
 
 fn main() {

--- a/src/doc/unstable-book/src/language-features/global-allocator.md
+++ b/src/doc/unstable-book/src/language-features/global-allocator.md
@@ -27,7 +27,7 @@ looks like:
 [RFC 1974]: https://github.com/rust-lang/rfcs/pull/1974
 
 ```rust
-#![feature(global_allocator, heap_api)]
+#![feature(global_allocator, allocator_api, heap_api)]
 
 use std::heap::{Alloc, System, Layout, AllocErr};
 

--- a/src/doc/unstable-book/src/language-features/unsized-tuple-coercion.md
+++ b/src/doc/unstable-book/src/language-features/unsized-tuple-coercion.md
@@ -8,7 +8,7 @@ The tracking issue for this feature is: [#42877]
 
 This is a part of [RFC0401]. According to the RFC, there should be an implementation like this:
 
-```rust
+```rust,ignore
 impl<..., T, U: ?Sized> Unsized<(..., U)> for (..., T) where T: Unsized<U> {}
 ```
 


### PR DESCRIPTION
This was accidentally broken in https://github.com/rust-lang/rust/pull/42437 since we filtered too early to recurse into sub-directories.

In theory, @bors p=10

r? @alexcrichton 