### PR TITLE
update .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -6,6 +6,7 @@
 #
 
 Aaron Todd <github@opprobrio.us>
+Aaron Power <theaaronepower@gmail.com>
 Abhishek Chanda <abhishek.becs@gmail.com> Abhishek Chanda <abhishek@cloudscaling.com>
 Adolfo Ochagavía <aochagavia92@gmail.com>
 Adrien Tétar <adri-from-59@hotmail.fr>
@@ -56,6 +57,7 @@ Corey Richardson <corey@octayn.net> Elaine "See More" Nemo <corey@octayn.net>
 Cyryl Płotnicki <cyplo@cyplo.net>
 Damien Schoof <damien.schoof@gmail.com>
 Daniel Ramos <dan@daramos.com>
+Daniel J Rollins <drollins@financialforce.com>
 David Klein <david.klein@baesystemsdetica.com>
 David Manescu <david.manescu@gmail.com> <dman2626@uni.sydney.edu.au>
 David Ross <daboross@daboross.net>
@@ -63,11 +65,12 @@ Derek Chiang <derekchiang93@gmail.com> Derek Chiang (Enchi Jiang) <derekchiang93
 Diggory Hardy <diggory.hardy@gmail.com> Diggory Hardy <github@dhardy.name>
 Dylan Braithwaite <dylanbraithwaite1@gmail.com> <mail@dylanb.me>
 Dzmitry Malyshau <kvarkus@gmail.com>
+E. Dunham <edunham@mozilla.com> edunham <edunham@mozilla.com>
 Eduardo Bautista <me@eduardobautista.com> <=>
 Eduardo Bautista <me@eduardobautista.com> <mail@eduardobautista.com>
+Eduard-Mihai Burtescu <edy.burt@gmail.com>
 Elliott Slaughter <elliottslaughter@gmail.com> <eslaughter@mozilla.com>
 Elly Fong-Jones <elly@leptoquark.net>
-Emily Dunham <edunham@mozilla.com> edunham <edunham@mozilla.com>
 Eric Holk <eric.holk@gmail.com> <eholk@cs.indiana.edu>
 Eric Holk <eric.holk@gmail.com> <eholk@mozilla.com>
 Eric Holmes <eric@ejholmes.net>
@@ -83,6 +86,8 @@ Gareth Daniel Smith <garethdanielsmith@gmail.com> Gareth Smith <garethdanielsmit
 Georges Dubus <georges.dubus@gmail.com> <georges.dubus@compiletoi.net>
 Graham Fawcett <graham.fawcett@gmail.com> Graham Fawcett <fawcett@uwindsor.ca>
 Graydon Hoare <graydon@pobox.com> Graydon Hoare <graydon@mozilla.com>
+Guillaume Gomez <guillaume1.gomez@gmail.com>
+Guillaume Gomez <guillaume1.gomez@gmail.com> ggomez <ggomez@ggo.ifr.lan>
 Guillaume Gomez <guillaume1.gomez@gmail.com> Guillaume Gomez <ggomez@ggo.ifr.lan>
 Heather <heather@cynede.net> <Cynede@Gentoo.org>
 Heather <heather@cynede.net> <Heather@cynede.net>
@@ -114,6 +119,7 @@ John Kåre Alsaker <john.kare.alsaker@gmail.com>
 John Talling <inrustwetrust@users.noreply.github.com>
 Jonathan Bailey <jbailey@mozilla.com> <jbailey@jbailey-20809.local>
 Jonathan S <gereeter@gmail.com> Jonathan S <gereeter+code@gmail.com>
+Jonathan Turner <probata@hotmail.com>
 Jorge Aparicio <japaric@linux.com> <japaricious@gmail.com>
 Joseph Martin <pythoner6@gmail.com>
 João Oliveira <hello@jxs.pt> joaoxsouls <joaoxsouls@gmail.com>
@@ -136,6 +142,7 @@ NAKASHIMA, Makoto <makoto.nksm+github@gmail.com> <makoto.nksm@gmail.com>
 NAKASHIMA, Makoto <makoto.nksm+github@gmail.com> <makoto.nksm+github@gmail.com>
 Marcell Pardavi <marcell.pardavi@gmail.com>
 Margaret Meyerhofer <mmeyerho@andrew.cmu.edu> <mmeyerho@andrew>
+Mark Simulacrum <mark.simulacrum@gmail.com>
 Mark Sinclair <mark.edward.x@gmail.com>
 Mark Sinclair <mark.edward.x@gmail.com> =Mark Sinclair <=125axel125@gmail.com>
 Markus Westerlind <marwes91@gmail.com> Markus <marwes91@gmail.com>
@@ -171,6 +178,7 @@ Peter Zotov <whitequark@whitequark.org>
 Phil Dawes <phil@phildawes.net> Phil Dawes <pdawes@drw.com>
 Philipp Brüschweiler <blei42@gmail.com> <blei42@gmail.com>
 Philipp Brüschweiler <blei42@gmail.com> <bruphili@student.ethz.ch>
+Philipp Matthias Schäfer <philipp.matthias.schaefer@posteo.de>
 Przemysław Wesołek <jest@go.art.pl> Przemek Wesołek <jest@go.art.pl>
 Rafael Ávila de Espíndola <respindola@mozilla.com> Rafael Avila de Espindola <espindola@dream.(none)>
 Ralph Giles <giles@thaumas.net> Ralph Giles <giles@mozilla.com>
@@ -189,11 +197,13 @@ S Pradeep Kumar <gohanpra@gmail.com>
 Scott Olson <scott@solson.me> Scott Olson <scott@scott-olson.org>
 Sean Gillespie <sean.william.g@gmail.com> swgillespie <sean.william.g@gmail.com>
 Seonghyun Kim <sh8281.kim@samsung.com>
+Shyam Sundar B <shyambaskaran@outlook.com>
 Simon Barber-Dueck <sbarberdueck@gmail.com> Simon BD <simon@server>
 Simon Sapin <simon@exyr.org> <simon.sapin@exyr.org>
 Simonas Kazlauskas <git@kazlauskas.me> Simonas Kazlauskas <github@kazlauskas.me>
 startling <tdixon51793@gmail.com>
 Stepan Koltsov <stepan.koltsov@gmail.com> Stepan Koltsov <nga@yandex-team.ru>
+Steve Klabnik <steve@steveklabnik.com>
 Steven Fackler <sfackler@gmail.com> <sfackler@palantir.com>
 Steven Stewart-Gallus <sstewartgallus00@langara.bc.ca> <sstewartgallus00@mylangara.bc.ca>
 Stuart Pernsteiner <stuart@pernsteiner.org> Stuart Pernsteiner <spernsteiner@mozilla.com>


### PR DESCRIPTION
It's nice to have an up-to-date .mailmap so that contributor listings (like those provided by `git shortlog` or http://thanks.rust-lang.org/) don't split the same author's contributions across two or more variations of their name.

Affected contributors—

@Aaronepower (3 commits as "Aaron Power", 1 as "Aaronepower")
@djrollins (5 commits as "Daniel J Rollins", 1 as "Daniel Rollins")
@eddyb (345 commits as "Eduard-Mihai Burtescu", 678 as "Eduard Burtescu", assuming former is canonical based on recency and GitHub profile display name)
@edunham (1 more recent commit contradicts existing .mailmap entry)
@GuillaumeGomez (942 commits as "Guillaume Gomez", 55 commits as "ggomez", 22 commits as "GuillaumeGomez")
@jonathandturner (362 commits as "Jonathan Turner", 1 as "jonathandturner")
@Mark-Simulacrum (248 commits as "Mark Simulacrum", 97 "Mark-Simulacrum")
@fiveop (1 commit each as "Philipp Matthias Schäfer" and "Philipp Matthias Schaefer", assuming former is canonical based on GitHub profile display name)
@shyaamsundhar (1 commit as "Shyam Sundar B", 3 as ShyamSundarB, assuming former is canonical based on recency) 
@steveklabnik (1634 commits as "Steve Klabnik", 41 as "steveklabnik")
