### PR TITLE
Thread local try with

### DIFF
--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -17,7 +17,7 @@ use io::{self, Initializer, BufReader, LineWriter};
 use sync::{Arc, Mutex, MutexGuard};
 use sys::stdio;
 use sys_common::remutex::{ReentrantMutex, ReentrantMutexGuard};
-use thread::{LocalKey, LocalKeyState};
+use thread::LocalKey;
 
 /// Stdout used by print! and println! macros
 thread_local! {
@@ -674,20 +674,14 @@ fn print_to<T>(args: fmt::Arguments,
                local_s: &'static LocalKey<RefCell<Option<Box<Write+Send>>>>,
                global_s: fn() -> T,
                label: &str) where T: Write {
-    let result = match local_s.state() {
-        LocalKeyState::Uninitialized |
-        LocalKeyState::Destroyed => global_s().write_fmt(args),
-        LocalKeyState::Valid => {
-            local_s.with(|s| {
-                if let Ok(mut borrowed) = s.try_borrow_mut() {
-                    if let Some(w) = borrowed.as_mut() {
-                        return w.write_fmt(args);
-                    }
-                }
-                global_s().write_fmt(args)
-            })
+    let result = local_s.try_with(|s| {
+        if let Ok(mut borrowed) = s.try_borrow_mut() {
+            if let Some(w) = borrowed.as_mut() {
+                return w.write_fmt(args);
+            }
         }
-    };
+        global_s().write_fmt(args)
+    }).unwrap_or_else(|_| global_s().write_fmt(args));
     if let Err(e) = result {
         panic!("failed printing to {}: {}", label, e);
     }

--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -284,15 +284,8 @@ impl<T: 'static> LocalKey<T> {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn with<F, R>(&'static self, f: F) -> R
                       where F: FnOnce(&T) -> R {
-        unsafe {
-            let slot = (self.inner)();
-            let slot = slot.expect("cannot access a TLS value during or \
-                                    after it is destroyed");
-            f(match *slot.get() {
-                Some(ref inner) => inner,
-                None => self.init(slot),
-            })
-        }
+        self.try_with(f).expect("cannot access a TLS value during or \
+                                 after it is destroyed")
     }
 
     unsafe fn init(&self, slot: &UnsafeCell<Option<T>>) -> &T {

--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -232,6 +232,32 @@ pub enum LocalKeyState {
     Destroyed,
 }
 
+/// An error returned by [`LocalKey::try_with`](struct.LocalKey.html#method.try_with).
+#[unstable(feature = "thread_local_state",
+           reason = "state querying was recently added",
+           issue = "27716")]
+pub struct AccessError {
+    _private: (),
+}
+
+#[unstable(feature = "thread_local_state",
+           reason = "state querying was recently added",
+           issue = "27716")]
+impl fmt::Debug for AccessError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("AccessError").finish()
+    }
+}
+
+#[unstable(feature = "thread_local_state",
+           reason = "state querying was recently added",
+           issue = "27716")]
+impl fmt::Display for AccessError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt("already destroyed", f)
+    }
+}
+
 impl<T: 'static> LocalKey<T> {
     #[doc(hidden)]
     #[unstable(feature = "thread_local_internals",
@@ -329,6 +355,32 @@ impl<T: 'static> LocalKey<T> {
                 }
                 None => LocalKeyState::Destroyed,
             }
+        }
+    }
+
+    /// Acquires a reference to the value in this TLS key.
+    ///
+    /// This will lazily initialize the value if this thread has not referenced
+    /// this key yet. If the key has been destroyed (which may happen if this is called
+    /// in a destructor), this function will return a ThreadLocalError.
+    ///
+    /// # Panics
+    ///
+    /// This function will still `panic!()` if the key is uninitialized and the
+    /// key's initializer panics.
+    #[unstable(feature = "thread_local_state",
+               reason = "state querying was recently added",
+               issue = "27716")]
+    pub fn try_with<F, R>(&'static self, f: F) -> Result<R, AccessError>
+                      where F: FnOnce(&T) -> R {
+        unsafe {
+            let slot = (self.inner)().ok_or(AccessError {
+                _private: (),
+            })?;
+            Ok(f(match *slot.get() {
+                Some(ref inner) => inner,
+                None => self.init(slot),
+            }))
         }
     }
 }

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -159,7 +159,7 @@ use time::Duration;
 #[macro_use] mod local;
 
 #[stable(feature = "rust1", since = "1.0.0")]
-pub use self::local::{LocalKey, LocalKeyState};
+pub use self::local::{LocalKey, LocalKeyState, AccessError};
 
 // The types used by the thread_local! macro to access TLS keys. Note that there
 // are two types, the "OS" type and the "fast" type. The OS thread local key

--- a/src/test/run-pass/tls-try-with.rs
+++ b/src/test/run-pass/tls-try-with.rs
@@ -14,6 +14,8 @@
 
 use std::thread;
 
+static mut DROP_RUN: bool = false;
+
 struct Foo;
 
 thread_local!(static FOO: Foo = Foo {});
@@ -21,6 +23,7 @@ thread_local!(static FOO: Foo = Foo {});
 impl Drop for Foo {
     fn drop(&mut self) {
         assert!(FOO.try_with(|_| panic!("`try_with` closure run")).is_err());
+        unsafe { DROP_RUN = true; }
     }
 }
 
@@ -30,4 +33,5 @@ fn main() {
             132
         }).expect("`try_with` failed"), 132);
     }).join().unwrap();
+    assert!(unsafe { DROP_RUN });
 }

--- a/src/test/run-pass/tls-try-with.rs
+++ b/src/test/run-pass/tls-try-with.rs
@@ -1,0 +1,33 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-emscripten no threads support
+
+#![feature(thread_local_state)]
+
+use std::thread;
+
+struct Foo;
+
+thread_local!(static FOO: Foo = Foo {});
+
+impl Drop for Foo {
+    fn drop(&mut self) {
+        assert!(FOO.try_with(|_| panic!("`try_with` closure run")).is_err());
+    }
+}
+
+fn main() {
+    thread::spawn(|| {
+        assert_eq!(FOO.try_with(|_| {
+            132
+        }).expect("`try_with` failed"), 132);
+    }).join().unwrap();
+}


### PR DESCRIPTION
https://github.com/rust-lang/rfcs/pull/2030 was turned into this PR (the RFC was closed, but it looks like just a PR should be good).

See also: state stabilization issue: #27716 

`try_with` is used in two places in std: stdio and thread_info. In stdio, it would be better if the result was passed to the closure, but in thread_info, it's better as is where the result is returned from the function call. I'm not sure which is better, but I prefer the current way as it better represents the scope.