### PR TITLE
Disable big-endian simd in swap_nonoverlapping_bytes

### DIFF
--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -160,7 +160,10 @@ unsafe fn swap_nonoverlapping_bytes(x: *mut u8, y: *mut u8, len: usize) {
     // #[repr(simd)], even if we don't actually use this struct directly.
     //
     // FIXME repr(simd) broken on emscripten and redox
-    #[cfg_attr(not(any(target_os = "emscripten", target_os = "redox")), repr(simd))]
+    // It's also broken on big-endian powerpc64 and s390x.  #42778
+    #[cfg_attr(not(any(target_os = "emscripten", target_os = "redox",
+                       target_endian = "big")),
+               repr(simd))]
     struct Block(u64, u64, u64, u64);
     struct UnalignedBlock(u64, u64, u64, u64);
 


### PR DESCRIPTION
This is a workaround for #42778, which was git-bisected to #40454's
optimizations to `mem::swap`, later moved to `ptr` in #42819.  Natively
compiled rustc couldn't even compile stage1 libcore on powerpc64 and
s390x, but they work fine without this `repr(simd)`.  Since powerpc64le
works OK, it seems probably related to being big-endian.

The underlying problem is not yet known, but this at least makes those
architectures functional again in the meantime.

cc @arielb1