### PR TITLE
WIP: reintroduce expansion info for proc macros 1.1

### DIFF
--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -57,6 +57,7 @@ use syntax::symbol::Symbol;
 use syntax::tokenstream;
 use syntax_pos::DUMMY_SP;
 use syntax_pos::SyntaxContext;
+use syntax_pos::hygiene::Mark;
 
 /// The main type provided by this crate, representing an abstract stream of
 /// tokens.
@@ -86,8 +87,17 @@ impl FromStr for TokenStream {
         __internal::with_sess(|(sess, mark)| {
             let src = src.to_string();
             let name = "<proc-macro source code>".to_string();
-            let call_site = mark.expn_info().unwrap().call_site;
-            let stream = parse::parse_stream_from_source_str(name, src, sess, Some(call_site));
+            let mut expn_info = mark.expn_info().unwrap();
+            let call_site = expn_info.call_site;
+            // notify the expansion info that it is unhygienic
+            expn_info.callee.is_hygienic = false;
+            let mark = Mark::fresh(mark);
+            mark.set_expn_info(expn_info);
+            let span = syntax_pos::Span {
+                ctxt: SyntaxContext::empty().apply_mark(mark),
+                ..call_site
+            };
+            let stream = parse::parse_stream_from_source_str(name, src, sess, Some(span));
             Ok(__internal::token_stream_wrap(stream))
         })
     }

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -402,6 +402,7 @@ impl<'a> LoweringContext<'a> {
             call_site: span,
             callee: codemap::NameAndSpan {
                 format: codemap::CompilerDesugaring(Symbol::intern(reason)),
+                is_hygienic: true,
                 span: Some(span),
                 allow_internal_unstable: true,
             },

--- a/src/librustc_allocator/expand.rs
+++ b/src/librustc_allocator/expand.rs
@@ -77,6 +77,7 @@ impl<'a> Folder for ExpandAllocatorDirectives<'a> {
             call_site: DUMMY_SP,
             callee: NameAndSpan {
                 format: MacroAttribute(Symbol::intern(name)),
+                is_hygienic: true,
                 span: None,
                 allow_internal_unstable: true,
             }

--- a/src/libsyntax/ext/derive.rs
+++ b/src/libsyntax/ext/derive.rs
@@ -62,6 +62,7 @@ pub fn add_derived_markers<T>(cx: &mut ExtCtxt, span: Span, traits: &[ast::Path]
         call_site: span,
         callee: NameAndSpan {
             format: ExpnFormat::MacroAttribute(Symbol::intern(&pretty_name)),
+            is_hygienic: true,
             span: None,
             allow_internal_unstable: true,
         },

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -408,6 +408,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             call_site: attr.span,
             callee: NameAndSpan {
                 format: MacroAttribute(Symbol::intern(&format!("{}", attr.path))),
+                is_hygienic: true,
                 span: None,
                 allow_internal_unstable: false,
             }
@@ -465,6 +466,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                 call_site: span,
                 callee: NameAndSpan {
                     format: MacroBang(Symbol::intern(&format!("{}", path))),
+                    is_hygienic: true,
                     span: def_site_span,
                     allow_internal_unstable: allow_internal_unstable,
                 },
@@ -502,6 +504,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                     call_site: span,
                     callee: NameAndSpan {
                         format: MacroBang(Symbol::intern(&format!("{}", path))),
+                        is_hygienic: true,
                         span: tt_span,
                         allow_internal_unstable: allow_internal_unstable,
                     }
@@ -534,6 +537,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                     call_site: span,
                     callee: NameAndSpan {
                         format: MacroBang(Symbol::intern(&format!("{}", path))),
+                        is_hygienic: true,
                         // FIXME procedural macros do not have proper span info
                         // yet, when they do, we should use it here.
                         span: None,
@@ -575,6 +579,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             call_site: span,
             callee: NameAndSpan {
                 format: MacroAttribute(pretty_name),
+                is_hygienic: true,
                 span: None,
                 allow_internal_unstable: false,
             }

--- a/src/libsyntax/std_inject.rs
+++ b/src/libsyntax/std_inject.rs
@@ -26,6 +26,7 @@ fn ignored_span(sp: Span) -> Span {
         call_site: DUMMY_SP,
         callee: NameAndSpan {
             format: MacroAttribute(Symbol::intern("std_inject")),
+            is_hygienic: true,
             span: None,
             allow_internal_unstable: true,
         }

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -287,6 +287,7 @@ fn generate_test_harness(sess: &ParseSess,
         call_site: DUMMY_SP,
         callee: NameAndSpan {
             format: MacroAttribute(Symbol::intern("test")),
+            is_hygienic: true,
             span: None,
             allow_internal_unstable: true,
         }

--- a/src/libsyntax_ext/proc_macro_registrar.rs
+++ b/src/libsyntax_ext/proc_macro_registrar.rs
@@ -366,6 +366,7 @@ fn mk_registrar(cx: &mut ExtCtxt,
         call_site: DUMMY_SP,
         callee: NameAndSpan {
             format: MacroAttribute(Symbol::intern("proc_macro")),
+            is_hygienic: true,
             span: None,
             allow_internal_unstable: true,
         }


### PR DESCRIPTION
**This is completely broken**

I get backtraces like

```
thread '<unnamed>' panicked at 'proc_macro::__internal::with_sess() called before set_parse_sess()!', src/libproc_macro/lib.rs:679:8
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
stack backtrace:
   0: std::sys::imp::backtrace::tracing::imp::unwind_backtrace
             at src/libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:71
   2: std::panicking::default_hook::{{closure}}
             at src/libstd/sys_common/backtrace.rs:60
             at src/libstd/panicking.rs:380
   3: std::panicking::default_hook
             at src/libstd/panicking.rs:396
   4: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:611
   5: std::panicking::begin_panic_new
             at ./src/libstd/panicking.rs:553
   6: <proc_macro::TokenStream as core::str::FromStr>::from_str
             at src/libproc_macro/lib.rs:679
             at src/libproc_macro/lib.rs:87
   7: derive_b::derive_b
   8: std::panicking::try::do_call
             at src/libsyntax_ext/deriving/custom.rs:79
             at ./src/libstd/panic.rs:296
             at ./src/libstd/panicking.rs:479
   9: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:98
  10: <syntax_ext::deriving::custom::ProcMacroDerive as syntax::ext::base::MultiItemModifier>::expand
             at ./src/libstd/panicking.rs:458
             at ./src/libstd/panic.rs:361
             at src/libsyntax_ext/deriving/custom.rs:79
             at ./src/libproc_macro/lib.rs:671
             at ./src/libstd/thread/local.rs:265
             at ./src/libproc_macro/lib.rs:668
             at src/libsyntax_ext/deriving/custom.rs:77
  11: syntax::ext::expand::MacroExpander::expand_invoc
             at src/libsyntax/ext/expand.rs:597
             at src/libsyntax/ext/expand.rs:380
  12: syntax::ext::expand::MacroExpander::expand
             at src/libsyntax/ext/expand.rs:281
  13: syntax::ext::expand::MacroExpander::expand_crate
             at src/libsyntax/ext/expand.rs:219
  14: rustc_driver::driver::phase_2_configure_and_expand::{{closure}}
             at src/librustc_driver/driver.rs:706
  15: rustc_driver::driver::phase_2_configure_and_expand
             at ./src/librustc/util/common.rs:50
             at src/librustc_driver/driver.rs:665
  16: rustc_driver::driver::compile_input
             at src/librustc_driver/driver.rs:120
  17: rustc_driver::run_compiler
             at src/librustc_driver/lib.rs:218
fatal runtime error: failed to initiate panic, error 5
```

Note especially the `fatal runtime error: failed to initiate panic, error 5`.

I'm completely baffled at how my changes can trigger the panic at all (The backtrace shows that the error happens *before* the code ever reaches my changes, "my changes" being inside `TokenStream::from_str`). Even crazier that the panic appears to do something completely bogus, like not getting processed.

r? @jseyfried