### PR TITLE
Add support for full RELRO

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -881,8 +881,6 @@ options! {CodegenOptions, CodegenSetter, basic_codegen_options,
         "disable the use of the redzone"),
     relocation_model: Option<String> = (None, parse_opt_string, [TRACKED],
          "choose the relocation model to use (rustc --print relocation-models for details)"),
-    relro_level: Option<RelroLevel> = (None, parse_relro_level, [TRACKED],
-        "choose which RELRO level to use"),
     code_model: Option<String> = (None, parse_opt_string, [TRACKED],
          "choose the code model to use (rustc --print code-models for details)"),
     metadata: Vec<String> = (Vec::new(), parse_list, [TRACKED],
@@ -1057,6 +1055,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
         "extra arguments to prepend to the linker invocation (space separated)"),
     profile: bool = (false, parse_bool, [TRACKED],
                      "insert profiling code"),
+    relro_level: Option<RelroLevel> = (None, parse_relro_level, [TRACKED],
+        "choose which RELRO level to use"),
 }
 
 pub fn default_lib_output() -> CrateType {
@@ -2451,10 +2451,6 @@ mod tests {
         assert!(reference.dep_tracking_hash() != opts.dep_tracking_hash());
 
         opts = reference.clone();
-        opts.cg.relro_level = Some(RelroLevel::Full);
-        assert!(reference.dep_tracking_hash() != opts.dep_tracking_hash());
-
-        opts = reference.clone();
         opts.cg.code_model = Some(String::from("code model"));
         assert!(reference.dep_tracking_hash() != opts.dep_tracking_hash());
 
@@ -2601,6 +2597,10 @@ mod tests {
 
         opts = reference.clone();
         opts.debugging_opts.mir_opt_level = 3;
+        assert!(reference.dep_tracking_hash() != opts.dep_tracking_hash());
+
+        opts = reference.clone();
+        opts.debugging_opts.relro_level = Some(RelroLevel::Full);
         assert!(reference.dep_tracking_hash() != opts.dep_tracking_hash());
     }
 }

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -790,9 +790,12 @@ macro_rules! options {
 
         fn parse_relro_level(slot: &mut Option<RelroLevel>, v: Option<&str>) -> bool {
             match v {
-                Some("full") => *slot = Some(RelroLevel::Full),
-                Some("partial") => *slot = Some(RelroLevel::Partial),
-                Some("off") => *slot = Some(RelroLevel::Off),
+                Some(s) => {
+                    match s.parse::<RelroLevel>() {
+                        Ok(level) => *slot = Some(level),
+                        _ => return false
+                    }
+                },
                 _ => return false
             }
             true

--- a/src/librustc_back/lib.rs
+++ b/src/librustc_back/lib.rs
@@ -114,3 +114,30 @@ impl ToJson for PanicStrategy {
         }
     }
 }
+
+#[derive(Clone, Copy, Debug, PartialEq, Hash, RustcEncodable, RustcDecodable)]
+pub enum RelroLevel {
+    Full,
+    Partial,
+    Off,
+}
+
+impl RelroLevel {
+    pub fn desc(&self) -> &str {
+        match *self {
+            RelroLevel::Full => "full",
+            RelroLevel::Partial => "partial",
+            RelroLevel::Off => "off",
+        }
+    }
+}
+
+impl ToJson for RelroLevel {
+    fn to_json(&self) -> Json {
+        match *self {
+            RelroLevel::Full => "full".to_json(),
+            RelroLevel::Partial => "partial".to_json(),
+            RelroLevel::Off => "off".to_json(),
+        }
+    }
+}

--- a/src/librustc_back/lib.rs
+++ b/src/librustc_back/lib.rs
@@ -47,6 +47,8 @@ pub mod target;
 pub mod slice;
 pub mod dynamic_lib;
 
+use std::str::FromStr;
+
 use serialize::json::{Json, ToJson};
 
 macro_rules! linker_flavor {
@@ -128,6 +130,19 @@ impl RelroLevel {
             RelroLevel::Full => "full",
             RelroLevel::Partial => "partial",
             RelroLevel::Off => "off",
+        }
+    }
+}
+
+impl FromStr for RelroLevel {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<RelroLevel, ()> {
+        match s {
+            "full" => Ok(RelroLevel::Full),
+            "partial" => Ok(RelroLevel::Partial),
+            "off" => Ok(RelroLevel::Off),
+            _ => Err(()),
         }
     }
 }

--- a/src/librustc_back/target/bitrig_base.rs
+++ b/src/librustc_back/target/bitrig_base.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use target::TargetOptions;
+use target::{TargetOptions, RelroLevel};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {
@@ -19,7 +19,7 @@ pub fn opts() -> TargetOptions {
         linker_is_gnu: true,
         has_rpath: true,
         position_independent_executables: true,
-        full_relro: true,
+        relro_level: RelroLevel::Full,
 
         .. Default::default()
     }

--- a/src/librustc_back/target/bitrig_base.rs
+++ b/src/librustc_back/target/bitrig_base.rs
@@ -19,6 +19,7 @@ pub fn opts() -> TargetOptions {
         linker_is_gnu: true,
         has_rpath: true,
         position_independent_executables: true,
+        full_relro: true,
 
         .. Default::default()
     }

--- a/src/librustc_back/target/dragonfly_base.rs
+++ b/src/librustc_back/target/dragonfly_base.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use LinkerFlavor;
-use target::{LinkArgs, TargetOptions};
+use target::{LinkArgs, TargetOptions, RelroLevel};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {
@@ -33,7 +33,7 @@ pub fn opts() -> TargetOptions {
         has_rpath: true,
         pre_link_args: args,
         position_independent_executables: true,
-        full_relro: true,
+        relro_level: RelroLevel::Full,
         exe_allocation_crate: super::maybe_jemalloc(),
         .. Default::default()
     }

--- a/src/librustc_back/target/dragonfly_base.rs
+++ b/src/librustc_back/target/dragonfly_base.rs
@@ -33,6 +33,7 @@ pub fn opts() -> TargetOptions {
         has_rpath: true,
         pre_link_args: args,
         position_independent_executables: true,
+        full_relro: true,
         exe_allocation_crate: super::maybe_jemalloc(),
         .. Default::default()
     }

--- a/src/librustc_back/target/freebsd_base.rs
+++ b/src/librustc_back/target/freebsd_base.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use LinkerFlavor;
-use target::{LinkArgs, TargetOptions};
+use target::{LinkArgs, TargetOptions, RelroLevel};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {
@@ -33,7 +33,7 @@ pub fn opts() -> TargetOptions {
         has_rpath: true,
         pre_link_args: args,
         position_independent_executables: true,
-        full_relro: true,
+        relro_level: RelroLevel::Full,
         exe_allocation_crate: super::maybe_jemalloc(),
         .. Default::default()
     }

--- a/src/librustc_back/target/freebsd_base.rs
+++ b/src/librustc_back/target/freebsd_base.rs
@@ -33,6 +33,7 @@ pub fn opts() -> TargetOptions {
         has_rpath: true,
         pre_link_args: args,
         position_independent_executables: true,
+        full_relro: true,
         exe_allocation_crate: super::maybe_jemalloc(),
         .. Default::default()
     }

--- a/src/librustc_back/target/haiku_base.rs
+++ b/src/librustc_back/target/haiku_base.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use target::TargetOptions;
+use target::{TargetOptions, RelroLevel};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {
@@ -18,7 +18,7 @@ pub fn opts() -> TargetOptions {
         executables: true,
         has_rpath: false,
         target_family: Some("unix".to_string()),
-        full_relro: true,
+        relro_level: RelroLevel::Full,
         linker_is_gnu: true,
         no_integrated_as: true,
         .. Default::default()

--- a/src/librustc_back/target/haiku_base.rs
+++ b/src/librustc_back/target/haiku_base.rs
@@ -18,6 +18,7 @@ pub fn opts() -> TargetOptions {
         executables: true,
         has_rpath: false,
         target_family: Some("unix".to_string()),
+        full_relro: true,
         linker_is_gnu: true,
         no_integrated_as: true,
         .. Default::default()

--- a/src/librustc_back/target/linux_base.rs
+++ b/src/librustc_back/target/linux_base.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use LinkerFlavor;
-use target::{LinkArgs, TargetOptions};
+use target::{LinkArgs, TargetOptions, RelroLevel};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {
@@ -36,7 +36,7 @@ pub fn opts() -> TargetOptions {
         has_rpath: true,
         pre_link_args: args,
         position_independent_executables: true,
-        full_relro: true,
+        relro_level: RelroLevel::Full,
         exe_allocation_crate: super::maybe_jemalloc(),
         has_elf_tls: true,
         .. Default::default()

--- a/src/librustc_back/target/linux_base.rs
+++ b/src/librustc_back/target/linux_base.rs
@@ -36,6 +36,7 @@ pub fn opts() -> TargetOptions {
         has_rpath: true,
         pre_link_args: args,
         position_independent_executables: true,
+        full_relro: true,
         exe_allocation_crate: super::maybe_jemalloc(),
         has_elf_tls: true,
         .. Default::default()

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -367,6 +367,9 @@ pub struct TargetOptions {
     /// the functions in the executable are not randomized and can be used
     /// during an exploit of a vulnerability in any code.
     pub position_independent_executables: bool,
+    /// Full RELRO makes the dynamic linker resolve all symbols at startup and marks the GOT
+    /// read-only before starting the program, preventing overwriting the GOT.
+    pub full_relro: bool,
     /// Format that archives should be emitted in. This affects whether we use
     /// LLVM to assemble an archive or fall back to the system linker, and
     /// currently only "gnu" is used to fall into LLVM. Unknown strings cause
@@ -454,6 +457,7 @@ impl Default for TargetOptions {
             has_rpath: false,
             no_default_libraries: true,
             position_independent_executables: false,
+            full_relro: false,
             pre_link_objects_exe: Vec::new(),
             pre_link_objects_dll: Vec::new(),
             post_link_objects: Vec::new(),
@@ -683,6 +687,7 @@ impl Target {
         key!(has_rpath, bool);
         key!(no_default_libraries, bool);
         key!(position_independent_executables, bool);
+        key!(full_relro, bool);
         key!(archive_format);
         key!(allow_asm, bool);
         key!(custom_unwind_resume, bool);
@@ -870,6 +875,7 @@ impl ToJson for Target {
         target_option_val!(has_rpath);
         target_option_val!(no_default_libraries);
         target_option_val!(position_independent_executables);
+        target_option_val!(full_relro);
         target_option_val!(archive_format);
         target_option_val!(allow_asm);
         target_option_val!(custom_unwind_resume);

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -588,10 +588,8 @@ impl Target {
             ($key_name:ident, RelroLevel) => ( {
                 let name = (stringify!($key_name)).replace("_", "-");
                 obj.find(&name[..]).and_then(|o| o.as_string().and_then(|s| {
-                    match s {
-                        "full" => base.options.$key_name = RelroLevel::Full,
-                        "partial" => base.options.$key_name = RelroLevel::Partial,
-                        "off" => base.options.$key_name = RelroLevel::Off,
+                    match s.parse::<RelroLevel>() {
+                        Ok(level) => base.options.$key_name = level,
                         _ => return Some(Err(format!("'{}' is not a valid value for \
                                                       relro-level. Use 'full', 'partial, or 'off'.",
                                                       s))),

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -50,7 +50,7 @@ use std::default::Default;
 use std::io::prelude::*;
 use syntax::abi::{Abi, lookup as lookup_abi};
 
-use {LinkerFlavor, PanicStrategy};
+use {LinkerFlavor, PanicStrategy, RelroLevel};
 
 mod android_base;
 mod apple_base;
@@ -367,9 +367,10 @@ pub struct TargetOptions {
     /// the functions in the executable are not randomized and can be used
     /// during an exploit of a vulnerability in any code.
     pub position_independent_executables: bool,
-    /// Full RELRO makes the dynamic linker resolve all symbols at startup and marks the GOT
-    /// read-only before starting the program, preventing overwriting the GOT.
-    pub full_relro: bool,
+    /// Either partial, full, or off. Full RELRO makes the dynamic linker
+    /// resolve all symbols at startup and marks the GOT read-only before
+    /// starting the program, preventing overwriting the GOT.
+    pub relro_level: RelroLevel,
     /// Format that archives should be emitted in. This affects whether we use
     /// LLVM to assemble an archive or fall back to the system linker, and
     /// currently only "gnu" is used to fall into LLVM. Unknown strings cause
@@ -457,7 +458,7 @@ impl Default for TargetOptions {
             has_rpath: false,
             no_default_libraries: true,
             position_independent_executables: false,
-            full_relro: false,
+            relro_level: RelroLevel::Off,
             pre_link_objects_exe: Vec::new(),
             pre_link_objects_dll: Vec::new(),
             post_link_objects: Vec::new(),
@@ -584,6 +585,20 @@ impl Target {
                 Some(Ok(()))
             })).unwrap_or(Ok(()))
             } );
+            ($key_name:ident, RelroLevel) => ( {
+                let name = (stringify!($key_name)).replace("_", "-");
+                obj.find(&name[..]).and_then(|o| o.as_string().and_then(|s| {
+                    match s {
+                        "full" => base.options.$key_name = RelroLevel::Full,
+                        "partial" => base.options.$key_name = RelroLevel::Partial,
+                        "off" => base.options.$key_name = RelroLevel::Off,
+                        _ => return Some(Err(format!("'{}' is not a valid value for \
+                                                      relro-level. Use 'full', 'partial, or 'off'.",
+                                                      s))),
+                    }
+                    Some(Ok(()))
+                })).unwrap_or(Ok(()))
+            } );
             ($key_name:ident, list) => ( {
                 let name = (stringify!($key_name)).replace("_", "-");
                 obj.find(&name[..]).map(|o| o.as_array()
@@ -687,7 +702,7 @@ impl Target {
         key!(has_rpath, bool);
         key!(no_default_libraries, bool);
         key!(position_independent_executables, bool);
-        key!(full_relro, bool);
+        try!(key!(relro_level, RelroLevel));
         key!(archive_format);
         key!(allow_asm, bool);
         key!(custom_unwind_resume, bool);
@@ -875,7 +890,7 @@ impl ToJson for Target {
         target_option_val!(has_rpath);
         target_option_val!(no_default_libraries);
         target_option_val!(position_independent_executables);
-        target_option_val!(full_relro);
+        target_option_val!(relro_level);
         target_option_val!(archive_format);
         target_option_val!(allow_asm);
         target_option_val!(custom_unwind_resume);

--- a/src/librustc_back/target/netbsd_base.rs
+++ b/src/librustc_back/target/netbsd_base.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use LinkerFlavor;
-use target::{LinkArgs, TargetOptions};
+use target::{LinkArgs, TargetOptions, RelroLevel};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {
@@ -33,7 +33,7 @@ pub fn opts() -> TargetOptions {
         has_rpath: true,
         pre_link_args: args,
         position_independent_executables: true,
-        full_relro: true,
+        relro_level: RelroLevel::Full,
         .. Default::default()
     }
 }

--- a/src/librustc_back/target/netbsd_base.rs
+++ b/src/librustc_back/target/netbsd_base.rs
@@ -33,6 +33,7 @@ pub fn opts() -> TargetOptions {
         has_rpath: true,
         pre_link_args: args,
         position_independent_executables: true,
+        full_relro: true,
         .. Default::default()
     }
 }

--- a/src/librustc_back/target/openbsd_base.rs
+++ b/src/librustc_back/target/openbsd_base.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use LinkerFlavor;
-use target::{LinkArgs, TargetOptions};
+use target::{LinkArgs, TargetOptions, RelroLevel};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {
@@ -34,7 +34,7 @@ pub fn opts() -> TargetOptions {
         is_like_openbsd: true,
         pre_link_args: args,
         position_independent_executables: true,
-        full_relro: true,
+        relro_level: RelroLevel::Full,
         .. Default::default()
     }
 }

--- a/src/librustc_back/target/openbsd_base.rs
+++ b/src/librustc_back/target/openbsd_base.rs
@@ -34,6 +34,7 @@ pub fn opts() -> TargetOptions {
         is_like_openbsd: true,
         pre_link_args: args,
         position_independent_executables: true,
+        full_relro: true,
         .. Default::default()
     }
 }

--- a/src/librustc_back/target/powerpc64_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/powerpc64_unknown_linux_gnu.rs
@@ -9,13 +9,17 @@
 // except according to those terms.
 
 use LinkerFlavor;
-use target::{Target, TargetResult};
+use target::{Target, TargetResult, RelroLevel};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();
     base.cpu = "ppc64".to_string();
     base.pre_link_args.get_mut(&LinkerFlavor::Gcc).unwrap().push("-m64".to_string());
     base.max_atomic_width = Some(64);
+
+    // ld.so in at least RHEL6 on ppc64 has a bug related to BIND_NOW, so only enable partial RELRO
+    // for now. https://github.com/rust-lang/rust/pull/43170#issuecomment-315411474
+    base.relro_level = RelroLevel::Partial;
 
     // see #36994
     base.exe_allocation_crate = None;

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -1029,6 +1029,10 @@ fn link_args(cmd: &mut Linker,
         }
     }
 
+    if t.options.full_relro {
+        cmd.full_relro();
+    }
+
     // Pass optimization flags down to the linker.
     cmd.optimize();
 

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -1029,7 +1029,7 @@ fn link_args(cmd: &mut Linker,
         }
     }
 
-    let relro_level = match sess.opts.cg.relro_level {
+    let relro_level = match sess.opts.debugging_opts.relro_level {
         Some(level) => level,
         None => t.options.relro_level,
     };

--- a/src/librustc_trans/back/linker.rs
+++ b/src/librustc_trans/back/linker.rs
@@ -104,6 +104,7 @@ pub trait Linker {
     fn add_object(&mut self, path: &Path);
     fn gc_sections(&mut self, keep_metadata: bool);
     fn position_independent_executable(&mut self);
+    fn full_relro(&mut self);
     fn optimize(&mut self);
     fn debuginfo(&mut self);
     fn no_default_libraries(&mut self);
@@ -175,6 +176,7 @@ impl<'a> Linker for GccLinker<'a> {
     fn output_filename(&mut self, path: &Path) { self.cmd.arg("-o").arg(path); }
     fn add_object(&mut self, path: &Path) { self.cmd.arg(path); }
     fn position_independent_executable(&mut self) { self.cmd.arg("-pie"); }
+    fn full_relro(&mut self) { self.linker_arg("-z,relro,-z,now"); }
     fn args(&mut self, args: &[String]) { self.cmd.args(args); }
 
     fn link_rust_dylib(&mut self, lib: &str, _path: &Path) {
@@ -428,6 +430,10 @@ impl<'a> Linker for MsvcLinker<'a> {
         // noop
     }
 
+    fn full_relro(&mut self) {
+        // noop
+    }
+
     fn no_default_libraries(&mut self) {
         // Currently we don't pass the /NODEFAULTLIB flag to the linker on MSVC
         // as there's been trouble in the past of linking the C++ standard
@@ -592,6 +598,10 @@ impl<'a> Linker for EmLinker<'a> {
     }
 
     fn position_independent_executable(&mut self) {
+        // noop
+    }
+
+    fn full_relro(&mut self) {
         // noop
     }
 

--- a/src/librustc_trans/back/linker.rs
+++ b/src/librustc_trans/back/linker.rs
@@ -104,6 +104,7 @@ pub trait Linker {
     fn add_object(&mut self, path: &Path);
     fn gc_sections(&mut self, keep_metadata: bool);
     fn position_independent_executable(&mut self);
+    fn partial_relro(&mut self);
     fn full_relro(&mut self);
     fn optimize(&mut self);
     fn debuginfo(&mut self);
@@ -176,6 +177,7 @@ impl<'a> Linker for GccLinker<'a> {
     fn output_filename(&mut self, path: &Path) { self.cmd.arg("-o").arg(path); }
     fn add_object(&mut self, path: &Path) { self.cmd.arg(path); }
     fn position_independent_executable(&mut self) { self.cmd.arg("-pie"); }
+    fn partial_relro(&mut self) { self.linker_arg("-z,relro"); }
     fn full_relro(&mut self) { self.linker_arg("-z,relro,-z,now"); }
     fn args(&mut self, args: &[String]) { self.cmd.args(args); }
 
@@ -430,6 +432,10 @@ impl<'a> Linker for MsvcLinker<'a> {
         // noop
     }
 
+    fn partial_relro(&mut self) {
+        // noop
+    }
+
     fn full_relro(&mut self) {
         // noop
     }
@@ -598,6 +604,10 @@ impl<'a> Linker for EmLinker<'a> {
     }
 
     fn position_independent_executable(&mut self) {
+        // noop
+    }
+
+    fn partial_relro(&mut self) {
         // noop
     }
 


### PR DESCRIPTION
This commit adds support for full RELRO, and enables it for the
platforms I know have support for it.

Full RELRO makes the PLT+GOT data read-only on startup, preventing it
from being overwritten.

http://tk-blog.blogspot.com/2009/02/relro-not-so-well-known-memory.html

Fixes rust-lang/rust#29877.

---

I'm not entirely certain if this is the best way to do it, but I figured mimicking the way it's done for PIE seemed like a good start at least.  I'm not sure whether we want to have it enabled by default globally and then disabling it explicitly for targets that don't support it though.  I'm also not sure whether the `full_relro` function should call `bug!()` or something like it for linkers that don't support it rather than no-opping.