### PR TITLE
Add a message when a variable name collides with a function name

### DIFF
--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -231,6 +231,10 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                             err.span_note(span, "defined here");
                         }
                     }
+                    if let Def::Local(_) = def {
+                        err.help("it's better to pick different names between variables and \
+                                  functions");
+                    }
                 }
 
                 err.emit();

--- a/src/test/ui/variable-fn-name-collision.rs
+++ b/src/test/ui/variable-fn-name-collision.rs
@@ -1,0 +1,23 @@
+// Copyright 2013-2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Model { x: u32 }
+struct Foo;
+
+fn model(model: Model) -> Model {
+    model
+}
+
+fn main() {
+    let mut model = Model { x: 0 };
+    model = model(model);
+    Foo();
+}
+

--- a/src/test/ui/variable-fn-name-collision.stderr
+++ b/src/test/ui/variable-fn-name-collision.stderr
@@ -1,0 +1,27 @@
+error[E0618]: expected function, found `Model`
+  --> $DIR/variable-fn-name-collision.rs:20:13
+   |
+20 |     model = model(model);
+   |             ^^^^^^^^^^^^
+   |
+note: defined here
+  --> $DIR/variable-fn-name-collision.rs:19:9
+   |
+19 |     let mut model = Model { x: 0 };
+   |         ^^^^^^^^^
+   = help: it's better to pick different names between variables and functions
+
+error[E0618]: expected function, found `Foo`
+  --> $DIR/variable-fn-name-collision.rs:21:5
+   |
+21 |     Foo();
+   |     ^^^^^
+   |
+note: defined here
+  --> $DIR/variable-fn-name-collision.rs:12:1
+   |
+12 | struct Foo;
+   | ^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #43166.