### PR TITLE
Split old and experimental wasm builders

### DIFF
--- a/src/ci/docker/disabled/wasm32-exp/Dockerfile
+++ b/src/ci/docker/disabled/wasm32-exp/Dockerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  g++ \
+  make \
+  file \
+  curl \
+  ca-certificates \
+  python \
+  git \
+  cmake \
+  sudo \
+  gdb \
+  xz-utils \
+  jq \
+  bzip2
+
+# dumb-init
+COPY scripts/dumb-init.sh /scripts/
+RUN sh /scripts/dumb-init.sh
+
+# emscripten
+COPY scripts/emscripten-wasm.sh /scripts/
+COPY disabled/wasm32-exp/node.sh /usr/local/bin/node
+RUN bash /scripts/emscripten-wasm.sh
+
+# cache
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
+# env
+ENV PATH=/wasm-install/emscripten:/wasm-install/bin:$PATH
+ENV EM_CONFIG=/root/.emscripten
+
+ENV TARGETS=wasm32-experimental-emscripten
+
+ENV RUST_CONFIGURE_ARGS --target=$TARGETS --experimental-targets=WebAssembly
+
+ENV SCRIPT python2.7 ../x.py test --target $TARGETS
+
+# init
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/src/ci/docker/disabled/wasm32-exp/node.sh
+++ b/src/ci/docker/disabled/wasm32-exp/node.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+path="$(dirname $1)"
+file="$(basename $1)"
+
+shift
+
+cd "$path"
+exec /node-v8.0.0-linux-x64/bin/node "$file" "$@"

--- a/src/ci/docker/disabled/wasm32/Dockerfile
+++ b/src/ci/docker/disabled/wasm32/Dockerfile
@@ -11,15 +11,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   cmake \
   sudo \
   gdb \
-  xz-utils \
-  jq \
-  bzip2
+  xz-utils
 
 COPY scripts/dumb-init.sh /scripts/
 RUN sh /scripts/dumb-init.sh
 
-COPY scripts/emscripten-wasm.sh /scripts/
-RUN bash /scripts/emscripten-wasm.sh
+# emscripten
+COPY scripts/emscripten.sh /scripts/
+RUN bash /scripts/emscripten.sh
 COPY disabled/wasm32/node.sh /usr/local/bin/node
 
 COPY scripts/sccache.sh /scripts/
@@ -32,9 +31,9 @@ ENV EMSCRIPTEN=/emsdk-portable/emscripten/1.37.13/
 ENV BINARYEN_ROOT=/emsdk-portable/clang/e1.37.13_64bit/binaryen/
 ENV EM_CONFIG=/emsdk-portable/.emscripten
 
-ENV TARGETS=wasm32-unknown-emscripten,wasm32-experimental-emscripten
+ENV TARGETS=wasm32-unknown-emscripten
 
-ENV RUST_CONFIGURE_ARGS --target=$TARGETS --experimental-targets=WebAssembly
+ENV RUST_CONFIGURE_ARGS --target=$TARGETS
 
 ENV SCRIPT python2.7 ../x.py test --target $TARGETS
 

--- a/src/ci/docker/scripts/emscripten-wasm.sh
+++ b/src/ci/docker/scripts/emscripten-wasm.sh
@@ -27,11 +27,6 @@ exit 1
   set -x
 }
 
-# Download emsdk
-cd /
-curl -L https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz | \
-    tar -xz
-
 # Download last known good emscripten from WebAssembly waterfall
 BUILD=$(curl -L https://storage.googleapis.com/wasm-llvm/builds/linux/lkgr.json | \
     jq '.build | tonumber')
@@ -43,22 +38,10 @@ cd /
 curl -L https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-x64.tar.xz | \
     tar -xJ
 
-cd /emsdk-portable
-./emsdk update
-hide_output ./emsdk install sdk-1.37.13-64bit
-./emsdk activate sdk-1.37.13-64bit
-
 # Make emscripten use wasm-ready node and LLVM tools
-echo "NODE_JS='/node-v8.0.0-linux-x64/bin/node'" >> /root/.emscripten
+echo "EMSCRIPTEN_ROOT = '/wasm-install/emscripten'" >> /root/.emscripten
+echo "NODE_JS='/usr/local/bin/node'" >> /root/.emscripten
 echo "LLVM_ROOT='/wasm-install/bin'" >> /root/.emscripten
-
-# Make emsdk usable by any user
-cp /root/.emscripten /emsdk-portable
-chmod a+rxw -R /emsdk-portable
-
-# Compile and cache libc
-source ./emsdk_env.sh
-echo "main(){}" > a.c
-HOME=/emsdk-portable/ emcc a.c
-HOME=/emsdk-portable/ emcc -s WASM=1 a.c
-rm -f a.*
+echo "BINARYEN_ROOT = '/wasm-install'" >> /root/.emscripten
+echo "COMPILER_ENGINE = NODE_JS" >> /root/.emscripten
+echo "JS_ENGINES = [NODE_JS]" >> /root/.emscripten


### PR DESCRIPTION
#42784 introduced configuration errors in the wasm builder by mixing different versions of the tools. This PR separates the wasm32-unknown-emscripten and wasm32-experimental-emscripten builders to resolve these errors.