### PR TITLE
E0122: clarify wording

### DIFF
--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -1611,8 +1611,8 @@ static BAR: _ = "test"; // error, explicitly write out the type instead
 "##,
 
 E0122: r##"
-An attempt was made to add a generic constraint to a type alias. While Rust will
-allow this with a warning, it will not currently enforce the constraint.
+An attempt was made to add a generic constraint to a type alias. This constraint is
+entirely ignored. For backwards compatibility, Rust still allows this with a warning.
 Consider the example below:
 
 ```

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -1611,9 +1611,9 @@ static BAR: _ = "test"; // error, explicitly write out the type instead
 "##,
 
 E0122: r##"
-An attempt was made to add a generic constraint to a type alias. This constraint is
-entirely ignored. For backwards compatibility, Rust still allows this with a warning.
-Consider the example below:
+An attempt was made to add a generic constraint to a type alias. This constraint
+is entirely ignored. For backwards compatibility, Rust still allows this with a
+warning. Consider the example below:
 
 ```
 trait Foo{}


### PR DESCRIPTION
I *assume* the reason these constraints are not hard errors is backwards compatibility. If yes, I think the error explanation (at least the long form) should be clearer about that, which is what this PR does.

If not, the explanation should give some other suitable explanation.