### PR TITLE
trans: Internalize symbols without relying on LLVM

### DIFF
--- a/src/librustc_trans/back/linker.rs
+++ b/src/librustc_trans/back/linker.rs
@@ -19,7 +19,7 @@ use std::process::Command;
 use context::SharedCrateContext;
 
 use back::archive;
-use back::symbol_export::{self, ExportedSymbols};
+use back::symbol_export::ExportedSymbols;
 use rustc::middle::dependency_format::Linkage;
 use rustc::hir::def_id::{LOCAL_CRATE, CrateNum};
 use rustc_back::LinkerFlavor;
@@ -687,10 +687,8 @@ fn exported_symbols(scx: &SharedCrateContext,
                     exported_symbols: &ExportedSymbols,
                     crate_type: CrateType)
                     -> Vec<String> {
-    let export_threshold = symbol_export::crate_export_threshold(crate_type);
-
     let mut symbols = Vec::new();
-    exported_symbols.for_each_exported_symbol(LOCAL_CRATE, export_threshold, |name, _| {
+    exported_symbols.for_each_exported_symbol(LOCAL_CRATE, |name, _, _| {
         symbols.push(name.to_owned());
     });
 
@@ -702,7 +700,7 @@ fn exported_symbols(scx: &SharedCrateContext,
         // For each dependency that we are linking to statically ...
         if *dep_format == Linkage::Static {
             // ... we add its symbol list to our export list.
-            exported_symbols.for_each_exported_symbol(cnum, export_threshold, |name, _| {
+            exported_symbols.for_each_exported_symbol(cnum, |name, _, _| {
                 symbols.push(name.to_owned());
             })
         }

--- a/src/librustc_trans/back/lto.rs
+++ b/src/librustc_trans/back/lto.rs
@@ -66,7 +66,7 @@ pub fn run(cgcx: &CodegenContext,
     let export_threshold =
         symbol_export::crates_export_threshold(&cgcx.crate_types);
 
-    let symbol_filter = &|&(ref name, level): &(String, _)| {
+    let symbol_filter = &|&(ref name, _, level): &(String, _, _)| {
         if symbol_export::is_below_threshold(level, export_threshold) {
             let mut bytes = Vec::with_capacity(name.len() + 1);
             bytes.extend(name.bytes());

--- a/src/librustc_trans/back/symbol_export.rs
+++ b/src/librustc_trans/back/symbol_export.rs
@@ -8,10 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use context::SharedCrateContext;
 use monomorphize::Instance;
-use rustc::util::nodemap::FxHashMap;
-use rustc::hir::def_id::{DefId, CrateNum, LOCAL_CRATE};
+use rustc::util::nodemap::{FxHashMap, NodeSet};
+use rustc::hir::def_id::{DefId, CrateNum, LOCAL_CRATE, INVALID_CRATE, CRATE_DEF_INDEX};
 use rustc::session::config;
 use rustc::ty::TyCtxt;
 use syntax::attr;
@@ -28,59 +27,87 @@ pub enum SymbolExportLevel {
 }
 
 /// The set of symbols exported from each crate in the crate graph.
+#[derive(Debug)]
 pub struct ExportedSymbols {
-    exports: FxHashMap<CrateNum, Vec<(String, SymbolExportLevel)>>,
+    pub export_threshold: SymbolExportLevel,
+    exports: FxHashMap<CrateNum, Vec<(String, DefId, SymbolExportLevel)>>,
+    local_exports: NodeSet,
 }
 
 impl ExportedSymbols {
     pub fn empty() -> ExportedSymbols {
         ExportedSymbols {
+            export_threshold: SymbolExportLevel::C,
             exports: FxHashMap(),
+            local_exports: NodeSet(),
         }
     }
 
-    pub fn compute<'a, 'tcx>(scx: &SharedCrateContext<'a, 'tcx>) -> ExportedSymbols {
-        let mut local_crate: Vec<_> = scx
-            .exported_symbols()
+    pub fn compute<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
+                             local_exported_symbols: &NodeSet)
+                             -> ExportedSymbols {
+        let export_threshold = crates_export_threshold(&tcx.sess.crate_types.borrow());
+
+        let mut local_crate: Vec<_> = local_exported_symbols
             .iter()
             .map(|&node_id| {
-                scx.tcx().hir.local_def_id(node_id)
+                tcx.hir.local_def_id(node_id)
             })
             .map(|def_id| {
-                let name = scx.tcx().symbol_name(Instance::mono(scx.tcx(), def_id));
-                let export_level = export_level(scx, def_id);
+                let name = tcx.symbol_name(Instance::mono(tcx, def_id));
+                let export_level = export_level(tcx, def_id);
                 debug!("EXPORTED SYMBOL (local): {} ({:?})", name, export_level);
-                (str::to_owned(&name), export_level)
+                (str::to_owned(&name), def_id, export_level)
             })
             .collect();
 
-        if scx.sess().entry_fn.borrow().is_some() {
-            local_crate.push(("main".to_string(), SymbolExportLevel::C));
+        let mut local_exports = local_crate
+            .iter()
+            .filter_map(|&(_, def_id, level)| {
+                if is_below_threshold(level, export_threshold) {
+                    tcx.hir.as_local_node_id(def_id)
+                } else {
+                    None
+                }
+            })
+            .collect::<NodeSet>();
+
+        const INVALID_DEF_ID: DefId = DefId {
+            krate: INVALID_CRATE,
+            index: CRATE_DEF_INDEX,
+        };
+
+        if let Some(_) = *tcx.sess.entry_fn.borrow() {
+            local_crate.push(("main".to_string(),
+                              INVALID_DEF_ID,
+                              SymbolExportLevel::C));
         }
 
-        if let Some(id) = scx.sess().derive_registrar_fn.get() {
-            let def_id = scx.tcx().hir.local_def_id(id);
+        if let Some(id) = tcx.sess.derive_registrar_fn.get() {
+            let def_id = tcx.hir.local_def_id(id);
             let idx = def_id.index;
-            let disambiguator = scx.sess().local_crate_disambiguator();
-            let registrar = scx.sess().generate_derive_registrar_symbol(disambiguator, idx);
-            local_crate.push((registrar, SymbolExportLevel::C));
+            let disambiguator = tcx.sess.local_crate_disambiguator();
+            let registrar = tcx.sess.generate_derive_registrar_symbol(disambiguator, idx);
+            local_crate.push((registrar, def_id, SymbolExportLevel::C));
+            local_exports.insert(id);
         }
 
-        if scx.sess().crate_types.borrow().contains(&config::CrateTypeDylib) {
-            local_crate.push((metadata_symbol_name(scx.tcx()),
+        if tcx.sess.crate_types.borrow().contains(&config::CrateTypeDylib) {
+            local_crate.push((metadata_symbol_name(tcx),
+                              INVALID_DEF_ID,
                               SymbolExportLevel::Rust));
         }
 
         let mut exports = FxHashMap();
         exports.insert(LOCAL_CRATE, local_crate);
 
-        for cnum in scx.sess().cstore.crates() {
+        for cnum in tcx.sess.cstore.crates() {
             debug_assert!(cnum != LOCAL_CRATE);
 
             // If this crate is a plugin and/or a custom derive crate, then
             // we're not even going to link those in so we skip those crates.
-            if scx.sess().cstore.plugin_registrar_fn(cnum).is_some() ||
-               scx.sess().cstore.derive_registrar_fn(cnum).is_some() {
+            if tcx.sess.cstore.plugin_registrar_fn(cnum).is_some() ||
+               tcx.sess.cstore.derive_registrar_fn(cnum).is_some() {
                 continue;
             }
 
@@ -92,16 +119,16 @@ impl ExportedSymbols {
             // Down below we'll hardwire all of the symbols to the `Rust` export
             // level instead.
             let special_runtime_crate =
-                scx.tcx().is_panic_runtime(cnum.as_def_id()) ||
-                scx.sess().cstore.is_compiler_builtins(cnum);
+                tcx.is_panic_runtime(cnum.as_def_id()) ||
+                tcx.sess.cstore.is_compiler_builtins(cnum);
 
-            let crate_exports = scx
-                .sess()
+            let crate_exports = tcx
+                .sess
                 .cstore
                 .exported_symbols(cnum)
                 .iter()
                 .map(|&def_id| {
-                    let name = scx.tcx().symbol_name(Instance::mono(scx.tcx(), def_id));
+                    let name = tcx.symbol_name(Instance::mono(tcx, def_id));
                     let export_level = if special_runtime_crate {
                         // We can probably do better here by just ensuring that
                         // it has hidden visibility rather than public
@@ -118,10 +145,10 @@ impl ExportedSymbols {
                             SymbolExportLevel::Rust
                         }
                     } else {
-                        export_level(scx, def_id)
+                        export_level(tcx, def_id)
                     };
                     debug!("EXPORTED SYMBOL (re-export): {} ({:?})", name, export_level);
-                    (str::to_owned(&name), export_level)
+                    (str::to_owned(&name), def_id, export_level)
                 })
                 .collect();
 
@@ -129,14 +156,16 @@ impl ExportedSymbols {
         }
 
         return ExportedSymbols {
-            exports: exports
+            export_threshold,
+            exports,
+            local_exports,
         };
 
-        fn export_level(scx: &SharedCrateContext,
+        fn export_level(tcx: TyCtxt,
                         sym_def_id: DefId)
                         -> SymbolExportLevel {
-            let attrs = scx.tcx().get_attrs(sym_def_id);
-            if attr::contains_extern_indicator(scx.sess().diagnostic(), &attrs) {
+            let attrs = tcx.get_attrs(sym_def_id);
+            if attr::contains_extern_indicator(tcx.sess.diagnostic(), &attrs) {
                 SymbolExportLevel::C
             } else {
                 SymbolExportLevel::Rust
@@ -144,9 +173,13 @@ impl ExportedSymbols {
         }
     }
 
+    pub fn local_exports(&self) -> &NodeSet {
+        &self.local_exports
+    }
+
     pub fn exported_symbols(&self,
                             cnum: CrateNum)
-                            -> &[(String, SymbolExportLevel)] {
+                            -> &[(String, DefId, SymbolExportLevel)] {
         match self.exports.get(&cnum) {
             Some(exports) => exports,
             None => &[]
@@ -155,13 +188,12 @@ impl ExportedSymbols {
 
     pub fn for_each_exported_symbol<F>(&self,
                                        cnum: CrateNum,
-                                       export_threshold: SymbolExportLevel,
                                        mut f: F)
-        where F: FnMut(&str, SymbolExportLevel)
+        where F: FnMut(&str, DefId, SymbolExportLevel)
     {
-        for &(ref name, export_level) in self.exported_symbols(cnum) {
-            if is_below_threshold(export_level, export_threshold) {
-                f(&name, export_level)
+        for &(ref name, def_id, export_level) in self.exported_symbols(cnum) {
+            if is_below_threshold(export_level, self.export_threshold) {
+                f(&name, def_id, export_level)
             }
         }
     }

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -1301,7 +1301,9 @@ fn collect_and_partition_translation_items<'a, 'tcx>(scx: &SharedCrateContext<'a
 
     let (items, inlining_map) =
         time(time_passes, "translation item collection", || {
-            collector::collect_crate_translation_items(&scx, collection_mode)
+            collector::collect_crate_translation_items(&scx,
+                                                       exported_symbols,
+                                                       collection_mode)
     });
 
     assert_symbols_are_distinct(scx.tcx(), items.iter());

--- a/src/librustc_trans/collector.rs
+++ b/src/librustc_trans/collector.rs
@@ -243,21 +243,19 @@ impl<'tcx> InliningMap<'tcx> {
 
     fn record_accesses<I>(&mut self,
                           source: TransItem<'tcx>,
-                          targets: I)
-        where I: Iterator<Item=(TransItem<'tcx>, bool)>
+                          new_targets: I)
+        where I: Iterator<Item=(TransItem<'tcx>, bool)> + ExactSizeIterator
     {
         assert!(!self.index.contains_key(&source));
 
         let start_index = self.targets.len();
-        let (targets_size_hint, targets_size_hint_max) = targets.size_hint();
-        debug_assert_eq!(targets_size_hint_max, Some(targets_size_hint));
-        let new_items_count = targets_size_hint;
+        let new_items_count = new_targets.len();
         let new_items_count_total = new_items_count + self.targets.len();
 
         self.targets.reserve(new_items_count);
         self.inlines.grow(new_items_count_total);
 
-        for (i, (target, inline)) in targets.enumerate() {
+        for (i, (target, inline)) in new_targets.enumerate() {
             self.targets.push(target);
             if inline {
                 self.inlines.insert(i + start_index);

--- a/src/librustc_trans/debuginfo/utils.rs
+++ b/src/librustc_trans/debuginfo/utils.rs
@@ -37,7 +37,7 @@ pub fn is_node_local_to_unit(cx: &CrateContext, node_id: ast::NodeId) -> bool
     // visible). It might better to use the `exported_items` set from
     // `driver::CrateAnalysis` in the future, but (atm) this set is not
     // available in the translation pass.
-    !cx.shared().exported_symbols().contains(&node_id)
+    !cx.exported_symbols().local_exports().contains(&node_id)
 }
 
 #[allow(non_snake_case)]

--- a/src/librustc_trans/partitioning.rs
+++ b/src/librustc_trans/partitioning.rs
@@ -576,7 +576,7 @@ fn internalize_symbols<'a, 'tcx>(_tcx: TyCtxt<'a, 'tcx, 'tcx>,
             cgu_name: cgu.name.clone()
         };
 
-        for (accessee, &mut (ref mut linkage, _)) in &mut cgu.items {
+        for (accessee, linkage_and_visibility) in &mut cgu.items {
             if !partitioning.internalization_candidates.contains(accessee) {
                 // This item is no candidate for internalizing, so skip it.
                 continue
@@ -599,7 +599,7 @@ fn internalize_symbols<'a, 'tcx>(_tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
             // If we got here, we did not find any accesses from other CGUs,
             // so it's fine to make this translation item internal.
-            *linkage = llvm::InternalLinkage;
+            *linkage_and_visibility = (llvm::InternalLinkage, llvm::Visibility::Default);
         }
     }
 }

--- a/src/librustc_trans/partitioning.rs
+++ b/src/librustc_trans/partitioning.rs
@@ -102,6 +102,7 @@
 //! source-level module, functions from the same module will be available for
 //! inlining, even when they are not marked #[inline].
 
+use back::symbol_export::ExportedSymbols;
 use collector::InliningMap;
 use common;
 use context::SharedCrateContext;
@@ -110,14 +111,15 @@ use rustc::dep_graph::{DepNode, WorkProductId};
 use rustc::hir::def_id::DefId;
 use rustc::hir::map::DefPathData;
 use rustc::session::config::NUMBERED_CODEGEN_UNIT_MARKER;
-use rustc::ty::{self, TyCtxt};
+use rustc::ty::{self, TyCtxt, InstanceDef};
 use rustc::ty::item_path::characteristic_def_id_of_type;
+use rustc::util::nodemap::{FxHashMap, FxHashSet};
 use rustc_incremental::IchHasher;
+use std::collections::hash_map::Entry;
 use std::hash::Hash;
 use syntax::ast::NodeId;
 use syntax::symbol::{Symbol, InternedString};
 use trans_item::{TransItem, InstantiationMode};
-use rustc::util::nodemap::{FxHashMap, FxHashSet};
 
 pub enum PartitioningStrategy {
     /// Generate one codegen unit per source-level module.
@@ -134,16 +136,16 @@ pub struct CodegenUnit<'tcx> {
     /// as well as the crate name and disambiguator.
     name: InternedString,
 
-    items: FxHashMap<TransItem<'tcx>, llvm::Linkage>,
+    items: FxHashMap<TransItem<'tcx>, (llvm::Linkage, llvm::Visibility)>,
 }
 
 impl<'tcx> CodegenUnit<'tcx> {
     pub fn new(name: InternedString,
-               items: FxHashMap<TransItem<'tcx>, llvm::Linkage>)
+               items: FxHashMap<TransItem<'tcx>, (llvm::Linkage, llvm::Visibility)>)
                -> Self {
         CodegenUnit {
-            name: name,
-            items: items,
+            name,
+            items,
         }
     }
 
@@ -159,7 +161,7 @@ impl<'tcx> CodegenUnit<'tcx> {
         &self.name
     }
 
-    pub fn items(&self) -> &FxHashMap<TransItem<'tcx>, llvm::Linkage> {
+    pub fn items(&self) -> &FxHashMap<TransItem<'tcx>, (llvm::Linkage, llvm::Visibility)> {
         &self.items
     }
 
@@ -172,10 +174,11 @@ impl<'tcx> CodegenUnit<'tcx> {
     }
 
     pub fn compute_symbol_name_hash<'a>(&self,
-                                        scx: &SharedCrateContext<'a, 'tcx>)
+                                        scx: &SharedCrateContext<'a, 'tcx>,
+                                        exported_symbols: &ExportedSymbols)
                                         -> u64 {
         let mut state = IchHasher::new();
-        let exported_symbols = scx.exported_symbols();
+        let exported_symbols = exported_symbols.local_exports();
         let all_items = self.items_in_deterministic_order(scx.tcx());
         for (item, _) in all_items {
             let symbol_name = item.symbol_name(scx.tcx());
@@ -200,7 +203,8 @@ impl<'tcx> CodegenUnit<'tcx> {
 
     pub fn items_in_deterministic_order<'a>(&self,
                                             tcx: TyCtxt<'a, 'tcx, 'tcx>)
-                                            -> Vec<(TransItem<'tcx>, llvm::Linkage)> {
+                                            -> Vec<(TransItem<'tcx>,
+                                                   (llvm::Linkage, llvm::Visibility))> {
         // The codegen tests rely on items being process in the same order as
         // they appear in the file, so for local items, we sort by node_id first
         #[derive(PartialEq, Eq, PartialOrd, Ord)]
@@ -233,7 +237,8 @@ const FALLBACK_CODEGEN_UNIT: &'static str = "__rustc_fallback_codegen_unit";
 pub fn partition<'a, 'tcx, I>(scx: &SharedCrateContext<'a, 'tcx>,
                               trans_items: I,
                               strategy: PartitioningStrategy,
-                              inlining_map: &InliningMap<'tcx>)
+                              inlining_map: &InliningMap<'tcx>,
+                              exported_symbols: &ExportedSymbols)
                               -> Vec<CodegenUnit<'tcx>>
     where I: Iterator<Item = TransItem<'tcx>>
 {
@@ -243,6 +248,7 @@ pub fn partition<'a, 'tcx, I>(scx: &SharedCrateContext<'a, 'tcx>,
     // respective 'home' codegen unit. Regular translation items are all
     // functions and statics defined in the local crate.
     let mut initial_partitioning = place_root_translation_items(scx,
+                                                                exported_symbols,
                                                                 trans_items);
 
     debug_dump(tcx, "INITIAL PARTITONING:", initial_partitioning.codegen_units.iter());
@@ -259,13 +265,22 @@ pub fn partition<'a, 'tcx, I>(scx: &SharedCrateContext<'a, 'tcx>,
     // translation items have to go into each codegen unit. These additional
     // translation items can be drop-glue, functions from external crates, and
     // local functions the definition of which is marked with #[inline].
-    let post_inlining = place_inlined_translation_items(initial_partitioning,
-                                                        inlining_map);
+    let mut post_inlining = place_inlined_translation_items(initial_partitioning,
+                                                            inlining_map);
 
-    debug_dump(tcx, "POST INLINING:", post_inlining.0.iter());
+    debug_dump(tcx, "POST INLINING:", post_inlining.codegen_units.iter());
+
+    // Next we try to make as many symbols "internal" as possible, so LLVM has
+    // more freedom to optimize.
+    internalize_symbols(tcx, &mut post_inlining, inlining_map);
 
     // Finally, sort by codegen unit name, so that we get deterministic results
-    let mut result = post_inlining.0;
+    let PostInliningPartitioning {
+        codegen_units: mut result,
+        trans_item_placements: _,
+        internalization_candidates: _,
+    } = post_inlining;
+
     result.sort_by(|cgu1, cgu2| {
         (&cgu1.name[..]).cmp(&cgu2.name[..])
     });
@@ -284,19 +299,37 @@ pub fn partition<'a, 'tcx, I>(scx: &SharedCrateContext<'a, 'tcx>,
 struct PreInliningPartitioning<'tcx> {
     codegen_units: Vec<CodegenUnit<'tcx>>,
     roots: FxHashSet<TransItem<'tcx>>,
+    internalization_candidates: FxHashSet<TransItem<'tcx>>,
 }
 
-struct PostInliningPartitioning<'tcx>(Vec<CodegenUnit<'tcx>>);
+/// For symbol internalization, we need to know whether a symbol/trans-item is
+/// accessed from outside the codegen unit it is defined in. This type is used
+/// to keep track of that.
+#[derive(Clone, PartialEq, Eq, Debug)]
+enum TransItemPlacement {
+    SingleCgu { cgu_name: InternedString },
+    MultipleCgus,
+}
+
+struct PostInliningPartitioning<'tcx> {
+    codegen_units: Vec<CodegenUnit<'tcx>>,
+    trans_item_placements: FxHashMap<TransItem<'tcx>, TransItemPlacement>,
+    internalization_candidates: FxHashSet<TransItem<'tcx>>,
+}
 
 fn place_root_translation_items<'a, 'tcx, I>(scx: &SharedCrateContext<'a, 'tcx>,
+                                             exported_symbols: &ExportedSymbols,
                                              trans_items: I)
                                              -> PreInliningPartitioning<'tcx>
     where I: Iterator<Item = TransItem<'tcx>>
 {
     let tcx = scx.tcx();
+    let exported_symbols = exported_symbols.local_exports();
+
     let mut roots = FxHashSet();
     let mut codegen_units = FxHashMap();
     let is_incremental_build = tcx.sess.opts.incremental.is_some();
+    let mut internalization_candidates = FxHashSet();
 
     for trans_item in trans_items {
         let is_root = trans_item.instantiation_mode(tcx) == InstantiationMode::GloballyShared;
@@ -318,18 +351,52 @@ fn place_root_translation_items<'a, 'tcx, I>(scx: &SharedCrateContext<'a, 'tcx>,
             let mut codegen_unit = codegen_units.entry(codegen_unit_name.clone())
                                                 .or_insert_with(make_codegen_unit);
 
-            let linkage = match trans_item.explicit_linkage(tcx) {
-                Some(explicit_linkage) => explicit_linkage,
+            let (linkage, visibility) = match trans_item.explicit_linkage(tcx) {
+                Some(explicit_linkage) => (explicit_linkage, llvm::Visibility::Default),
                 None => {
                     match trans_item {
-                        TransItem::Fn(..) |
-                        TransItem::Static(..) |
-                        TransItem::GlobalAsm(..) => llvm::ExternalLinkage,
+                        TransItem::Fn(ref instance) => {
+                            let visibility = match instance.def {
+                                InstanceDef::Item(def_id) => {
+                                    if let Some(node_id) = tcx.hir.as_local_node_id(def_id) {
+                                        if exported_symbols.contains(&node_id) {
+                                            llvm::Visibility::Default
+                                        } else {
+                                            internalization_candidates.insert(trans_item);
+                                            llvm::Visibility::Hidden
+                                        }
+                                    } else {
+                                        internalization_candidates.insert(trans_item);
+                                        llvm::Visibility::Hidden
+                                    }
+                                }
+                                InstanceDef::FnPtrShim(..) |
+                                InstanceDef::Virtual(..) |
+                                InstanceDef::Intrinsic(..) |
+                                InstanceDef::ClosureOnceShim { .. } |
+                                InstanceDef::DropGlue(..) => {
+                                    bug!("partitioning: Encountered unexpected
+                                          root translation item: {:?}",
+                                          trans_item)
+                                }
+                            };
+                            (llvm::ExternalLinkage, visibility)
+                        }
+                        TransItem::Static(node_id) |
+                        TransItem::GlobalAsm(node_id) => {
+                            let visibility = if exported_symbols.contains(&node_id) {
+                                llvm::Visibility::Default
+                            } else {
+                                internalization_candidates.insert(trans_item);
+                                llvm::Visibility::Hidden
+                            };
+                            (llvm::ExternalLinkage, visibility)
+                        }
                     }
                 }
             };
 
-            codegen_unit.items.insert(trans_item, linkage);
+            codegen_unit.items.insert(trans_item, (linkage, visibility));
             roots.insert(trans_item);
         }
     }
@@ -338,15 +405,16 @@ fn place_root_translation_items<'a, 'tcx, I>(scx: &SharedCrateContext<'a, 'tcx>,
     // crate with just types (for example), we could wind up with no CGU
     if codegen_units.is_empty() {
         let codegen_unit_name = Symbol::intern(FALLBACK_CODEGEN_UNIT).as_str();
-        codegen_units.entry(codegen_unit_name.clone())
-                     .or_insert_with(|| CodegenUnit::empty(codegen_unit_name.clone()));
+        codegen_units.insert(codegen_unit_name.clone(),
+                             CodegenUnit::empty(codegen_unit_name.clone()));
     }
 
     PreInliningPartitioning {
         codegen_units: codegen_units.into_iter()
                                     .map(|(_, codegen_unit)| codegen_unit)
                                     .collect(),
-        roots: roots,
+        roots,
+        internalization_candidates,
     }
 }
 
@@ -388,37 +456,75 @@ fn place_inlined_translation_items<'tcx>(initial_partitioning: PreInliningPartit
                                          inlining_map: &InliningMap<'tcx>)
                                          -> PostInliningPartitioning<'tcx> {
     let mut new_partitioning = Vec::new();
+    let mut trans_item_placements = FxHashMap();
 
-    for codegen_unit in &initial_partitioning.codegen_units[..] {
+    let PreInliningPartitioning {
+        codegen_units: initial_cgus,
+        roots,
+        internalization_candidates,
+    } = initial_partitioning;
+
+    let single_codegen_unit = initial_cgus.len() == 1;
+
+    for old_codegen_unit in initial_cgus {
         // Collect all items that need to be available in this codegen unit
         let mut reachable = FxHashSet();
-        for root in codegen_unit.items.keys() {
+        for root in old_codegen_unit.items.keys() {
             follow_inlining(*root, inlining_map, &mut reachable);
         }
 
-        let mut new_codegen_unit =
-            CodegenUnit::empty(codegen_unit.name.clone());
+        let mut new_codegen_unit = CodegenUnit {
+            name: old_codegen_unit.name,
+            items: FxHashMap(),
+        };
 
         // Add all translation items that are not already there
         for trans_item in reachable {
-            if let Some(linkage) = codegen_unit.items.get(&trans_item) {
+            if let Some(linkage) = old_codegen_unit.items.get(&trans_item) {
                 // This is a root, just copy it over
                 new_codegen_unit.items.insert(trans_item, *linkage);
             } else {
-                if initial_partitioning.roots.contains(&trans_item) {
+                if roots.contains(&trans_item) {
                     bug!("GloballyShared trans-item inlined into other CGU: \
                           {:?}", trans_item);
                 }
 
                 // This is a cgu-private copy
-                new_codegen_unit.items.insert(trans_item, llvm::InternalLinkage);
+                new_codegen_unit.items.insert(trans_item,
+                                              (llvm::InternalLinkage, llvm::Visibility::Default));
+            }
+
+            if !single_codegen_unit {
+                // If there is more than one codegen unit, we need to keep track
+                // in which codegen units each translation item is placed:
+                match trans_item_placements.entry(trans_item) {
+                    Entry::Occupied(e) => {
+                        let placement = e.into_mut();
+                        debug_assert!(match *placement {
+                            TransItemPlacement::SingleCgu { ref cgu_name } => {
+                                *cgu_name != new_codegen_unit.name
+                            }
+                            TransItemPlacement::MultipleCgus => true,
+                        });
+                        *placement = TransItemPlacement::MultipleCgus;
+                    }
+                    Entry::Vacant(e) => {
+                        e.insert(TransItemPlacement::SingleCgu {
+                            cgu_name: new_codegen_unit.name.clone()
+                        });
+                    }
+                }
             }
         }
 
         new_partitioning.push(new_codegen_unit);
     }
 
-    return PostInliningPartitioning(new_partitioning);
+    return PostInliningPartitioning {
+        codegen_units: new_partitioning,
+        trans_item_placements,
+        internalization_candidates,
+    };
 
     fn follow_inlining<'tcx>(trans_item: TransItem<'tcx>,
                              inlining_map: &InliningMap<'tcx>,
@@ -430,6 +536,72 @@ fn place_inlined_translation_items<'tcx>(initial_partitioning: PreInliningPartit
         inlining_map.with_inlining_candidates(trans_item, |target| {
             follow_inlining(target, inlining_map, visited);
         });
+    }
+}
+
+fn internalize_symbols<'a, 'tcx>(_tcx: TyCtxt<'a, 'tcx, 'tcx>,
+                                 partitioning: &mut PostInliningPartitioning<'tcx>,
+                                 inlining_map: &InliningMap<'tcx>) {
+    if partitioning.codegen_units.len() == 1 {
+        // Fast path for when there is only one codegen unit. In this case we
+        // can internalize all candidates, since there is nowhere else they
+        // could be accessed from.
+        for cgu in &mut partitioning.codegen_units {
+            for candidate in &partitioning.internalization_candidates {
+                cgu.items.insert(*candidate, (llvm::InternalLinkage,
+                                              llvm::Visibility::Default));
+            }
+        }
+
+        return;
+    }
+
+    // Build a map from every translation item to all the translation items that
+    // reference it.
+    let mut accessor_map: FxHashMap<TransItem<'tcx>, Vec<TransItem<'tcx>>> = FxHashMap();
+    inlining_map.iter_accesses(|accessor, accessees| {
+        for accessee in accessees {
+            accessor_map.entry(*accessee)
+                        .or_insert(Vec::new())
+                        .push(accessor);
+        }
+    });
+
+    let trans_item_placements = &partitioning.trans_item_placements;
+
+    // For each internalization candidates in each codegen unit, check if it is
+    // accessed from outside its defining codegen unit.
+    for cgu in &mut partitioning.codegen_units {
+        let home_cgu = TransItemPlacement::SingleCgu {
+            cgu_name: cgu.name.clone()
+        };
+
+        'item:
+        for (accessee, &mut (ref mut linkage, _)) in &mut cgu.items {
+            if !partitioning.internalization_candidates.contains(accessee) {
+                // This item is no candidate for internalizing, so skip it.
+                continue
+            }
+            debug_assert_eq!(trans_item_placements[accessee], home_cgu);
+
+            if let Some(accessors) = accessor_map.get(accessee) {
+                if accessors.iter()
+                            .filter_map(|accessor| {
+                                // Some accessors might not have been
+                                // instantiated. We can safely ignore those.
+                                trans_item_placements.get(accessor)
+                            })
+                            .any(|placement| *placement != home_cgu) {
+                    // Found an accessor from another CGU, so skip to the next
+                    // item without marking this one as internal.
+                    continue 'item;
+                }
+            }
+
+            // If we got here, we did not find any accesses from other CGUs,
+            // so it's fine to make this translation item internal.
+            *linkage = llvm::InternalLinkage;
+        }
     }
 }
 

--- a/src/librustc_trans/partitioning.rs
+++ b/src/librustc_trans/partitioning.rs
@@ -576,7 +576,6 @@ fn internalize_symbols<'a, 'tcx>(_tcx: TyCtxt<'a, 'tcx, 'tcx>,
             cgu_name: cgu.name.clone()
         };
 
-        'item:
         for (accessee, &mut (ref mut linkage, _)) in &mut cgu.items {
             if !partitioning.internalization_candidates.contains(accessee) {
                 // This item is no candidate for internalizing, so skip it.
@@ -594,7 +593,7 @@ fn internalize_symbols<'a, 'tcx>(_tcx: TyCtxt<'a, 'tcx, 'tcx>,
                             .any(|placement| *placement != home_cgu) {
                     // Found an accessor from another CGU, so skip to the next
                     // item without marking this one as internal.
-                    continue 'item;
+                    continue
                 }
             }
 

--- a/src/test/codegen-units/partitioning/extern-drop-glue.rs
+++ b/src/test/codegen-units/partitioning/extern-drop-glue.rs
@@ -24,7 +24,7 @@ extern crate cgu_extern_drop_glue;
 
 struct LocalStruct(cgu_extern_drop_glue::Struct);
 
-//~ TRANS_ITEM fn extern_drop_glue::user[0] @@ extern_drop_glue[External]
+//~ TRANS_ITEM fn extern_drop_glue::user[0] @@ extern_drop_glue[Internal]
 fn user()
 {
     //~ TRANS_ITEM fn core::ptr[0]::drop_in_place[0]<extern_drop_glue::LocalStruct[0]> @@ extern_drop_glue[Internal]
@@ -36,7 +36,7 @@ mod mod1 {
 
     struct LocalStruct(cgu_extern_drop_glue::Struct);
 
-    //~ TRANS_ITEM fn extern_drop_glue::mod1[0]::user[0] @@ extern_drop_glue-mod1[External]
+    //~ TRANS_ITEM fn extern_drop_glue::mod1[0]::user[0] @@ extern_drop_glue-mod1[Internal]
     fn user()
     {
         //~ TRANS_ITEM fn core::ptr[0]::drop_in_place[0]<extern_drop_glue::mod1[0]::LocalStruct[0]> @@ extern_drop_glue-mod1[Internal]

--- a/src/test/codegen-units/partitioning/extern-generic.rs
+++ b/src/test/codegen-units/partitioning/extern-generic.rs
@@ -19,7 +19,7 @@
 // aux-build:cgu_generic_function.rs
 extern crate cgu_generic_function;
 
-//~ TRANS_ITEM fn extern_generic::user[0] @@ extern_generic[External]
+//~ TRANS_ITEM fn extern_generic::user[0] @@ extern_generic[Internal]
 fn user() {
     let _ = cgu_generic_function::foo("abc");
 }
@@ -27,7 +27,7 @@ fn user() {
 mod mod1 {
     use cgu_generic_function;
 
-    //~ TRANS_ITEM fn extern_generic::mod1[0]::user[0] @@ extern_generic-mod1[External]
+    //~ TRANS_ITEM fn extern_generic::mod1[0]::user[0] @@ extern_generic-mod1[Internal]
     fn user() {
         let _ = cgu_generic_function::foo("abc");
     }
@@ -35,7 +35,7 @@ mod mod1 {
     mod mod1 {
         use cgu_generic_function;
 
-        //~ TRANS_ITEM fn extern_generic::mod1[0]::mod1[0]::user[0] @@ extern_generic-mod1-mod1[External]
+        //~ TRANS_ITEM fn extern_generic::mod1[0]::mod1[0]::user[0] @@ extern_generic-mod1-mod1[Internal]
         fn user() {
             let _ = cgu_generic_function::foo("abc");
         }
@@ -45,18 +45,18 @@ mod mod1 {
 mod mod2 {
     use cgu_generic_function;
 
-    //~ TRANS_ITEM fn extern_generic::mod2[0]::user[0] @@ extern_generic-mod2[External]
+    //~ TRANS_ITEM fn extern_generic::mod2[0]::user[0] @@ extern_generic-mod2[Internal]
     fn user() {
         let _ = cgu_generic_function::foo("abc");
     }
 }
 
 mod mod3 {
-    //~ TRANS_ITEM fn extern_generic::mod3[0]::non_user[0] @@ extern_generic-mod3[External]
+    //~ TRANS_ITEM fn extern_generic::mod3[0]::non_user[0] @@ extern_generic-mod3[Internal]
     fn non_user() {}
 }
 
 // Make sure the two generic functions from the extern crate get instantiated
 // once for the current crate
 //~ TRANS_ITEM fn cgu_generic_function::foo[0]<&str> @@ cgu_generic_function.volatile[External]
-//~ TRANS_ITEM fn cgu_generic_function::bar[0]<&str> @@ cgu_generic_function.volatile[External]
+//~ TRANS_ITEM fn cgu_generic_function::bar[0]<&str> @@ cgu_generic_function.volatile[Internal]

--- a/src/test/codegen-units/partitioning/inlining-from-extern-crate.rs
+++ b/src/test/codegen-units/partitioning/inlining-from-extern-crate.rs
@@ -37,7 +37,7 @@ pub fn user()
 mod mod1 {
     use cgu_explicit_inlining;
 
-    //~ TRANS_ITEM fn inlining_from_extern_crate::mod1[0]::user[0] @@ inlining_from_extern_crate-mod1[External]
+    //~ TRANS_ITEM fn inlining_from_extern_crate::mod1[0]::user[0] @@ inlining_from_extern_crate-mod1[Internal]
     pub fn user()
     {
         cgu_explicit_inlining::inlined();
@@ -50,7 +50,7 @@ mod mod1 {
 mod mod2 {
     use cgu_explicit_inlining;
 
-    //~ TRANS_ITEM fn inlining_from_extern_crate::mod2[0]::user[0] @@ inlining_from_extern_crate-mod2[External]
+    //~ TRANS_ITEM fn inlining_from_extern_crate::mod2[0]::user[0] @@ inlining_from_extern_crate-mod2[Internal]
     pub fn user()
     {
         cgu_explicit_inlining::always_inlined();

--- a/src/test/codegen-units/partitioning/local-drop-glue.rs
+++ b/src/test/codegen-units/partitioning/local-drop-glue.rs
@@ -31,7 +31,7 @@ struct Outer {
     _a: Struct
 }
 
-//~ TRANS_ITEM fn local_drop_glue::user[0] @@ local_drop_glue[External]
+//~ TRANS_ITEM fn local_drop_glue::user[0] @@ local_drop_glue[Internal]
 fn user()
 {
     let _ = Outer {
@@ -52,7 +52,7 @@ mod mod1
         _b: (u32, Struct),
     }
 
-    //~ TRANS_ITEM fn local_drop_glue::mod1[0]::user[0] @@ local_drop_glue-mod1[External]
+    //~ TRANS_ITEM fn local_drop_glue::mod1[0]::user[0] @@ local_drop_glue-mod1[Internal]
     fn user()
     {
         let _ = Struct2 {

--- a/src/test/codegen-units/partitioning/local-generic.rs
+++ b/src/test/codegen-units/partitioning/local-generic.rs
@@ -22,7 +22,7 @@
 //~ TRANS_ITEM fn local_generic::generic[0]<&str> @@ local_generic.volatile[External]
 pub fn generic<T>(x: T) -> T { x }
 
-//~ TRANS_ITEM fn local_generic::user[0] @@ local_generic[External]
+//~ TRANS_ITEM fn local_generic::user[0] @@ local_generic[Internal]
 fn user() {
     let _ = generic(0u32);
 }
@@ -30,7 +30,7 @@ fn user() {
 mod mod1 {
     pub use super::generic;
 
-    //~ TRANS_ITEM fn local_generic::mod1[0]::user[0] @@ local_generic-mod1[External]
+    //~ TRANS_ITEM fn local_generic::mod1[0]::user[0] @@ local_generic-mod1[Internal]
     fn user() {
         let _ = generic(0u64);
     }
@@ -38,7 +38,7 @@ mod mod1 {
     mod mod1 {
         use super::generic;
 
-        //~ TRANS_ITEM fn local_generic::mod1[0]::mod1[0]::user[0] @@ local_generic-mod1-mod1[External]
+        //~ TRANS_ITEM fn local_generic::mod1[0]::mod1[0]::user[0] @@ local_generic-mod1-mod1[Internal]
         fn user() {
             let _ = generic('c');
         }
@@ -48,7 +48,7 @@ mod mod1 {
 mod mod2 {
     use super::generic;
 
-    //~ TRANS_ITEM fn local_generic::mod2[0]::user[0] @@ local_generic-mod2[External]
+    //~ TRANS_ITEM fn local_generic::mod2[0]::user[0] @@ local_generic-mod2[Internal]
     fn user() {
         let _ = generic("abc");
     }

--- a/src/test/codegen-units/partitioning/local-inlining.rs
+++ b/src/test/codegen-units/partitioning/local-inlining.rs
@@ -30,7 +30,7 @@ mod inline {
 mod user1 {
     use super::inline;
 
-    //~ TRANS_ITEM fn local_inlining::user1[0]::foo[0] @@ local_inlining-user1[External]
+    //~ TRANS_ITEM fn local_inlining::user1[0]::foo[0] @@ local_inlining-user1[Internal]
     fn foo() {
         inline::inlined_function();
     }
@@ -39,7 +39,7 @@ mod user1 {
 mod user2 {
     use super::inline;
 
-    //~ TRANS_ITEM fn local_inlining::user2[0]::bar[0] @@ local_inlining-user2[External]
+    //~ TRANS_ITEM fn local_inlining::user2[0]::bar[0] @@ local_inlining-user2[Internal]
     fn bar() {
         inline::inlined_function();
     }
@@ -47,7 +47,7 @@ mod user2 {
 
 mod non_user {
 
-    //~ TRANS_ITEM fn local_inlining::non_user[0]::baz[0] @@ local_inlining-non_user[External]
+    //~ TRANS_ITEM fn local_inlining::non_user[0]::baz[0] @@ local_inlining-non_user[Internal]
     fn baz() {
 
     }

--- a/src/test/codegen-units/partitioning/local-transitive-inlining.rs
+++ b/src/test/codegen-units/partitioning/local-transitive-inlining.rs
@@ -39,7 +39,7 @@ mod direct_user {
 mod indirect_user {
     use super::direct_user;
 
-    //~ TRANS_ITEM fn local_transitive_inlining::indirect_user[0]::bar[0] @@ local_transitive_inlining-indirect_user[External]
+    //~ TRANS_ITEM fn local_transitive_inlining::indirect_user[0]::bar[0] @@ local_transitive_inlining-indirect_user[Internal]
     fn bar() {
         direct_user::foo();
     }
@@ -47,7 +47,7 @@ mod indirect_user {
 
 mod non_user {
 
-    //~ TRANS_ITEM fn local_transitive_inlining::non_user[0]::baz[0] @@ local_transitive_inlining-non_user[External]
+    //~ TRANS_ITEM fn local_transitive_inlining::non_user[0]::baz[0] @@ local_transitive_inlining-non_user[Internal]
     fn baz() {
 
     }

--- a/src/test/codegen-units/partitioning/regular-modules.rs
+++ b/src/test/codegen-units/partitioning/regular-modules.rs
@@ -16,67 +16,67 @@
 #![allow(dead_code)]
 #![crate_type="lib"]
 
-//~ TRANS_ITEM fn regular_modules::foo[0] @@ regular_modules[External]
+//~ TRANS_ITEM fn regular_modules::foo[0] @@ regular_modules[Internal]
 fn foo() {}
 
-//~ TRANS_ITEM fn regular_modules::bar[0] @@ regular_modules[External]
+//~ TRANS_ITEM fn regular_modules::bar[0] @@ regular_modules[Internal]
 fn bar() {}
 
-//~ TRANS_ITEM static regular_modules::BAZ[0] @@ regular_modules[External]
+//~ TRANS_ITEM static regular_modules::BAZ[0] @@ regular_modules[Internal]
 static BAZ: u64 = 0;
 
 mod mod1 {
 
-    //~ TRANS_ITEM fn regular_modules::mod1[0]::foo[0] @@ regular_modules-mod1[External]
+    //~ TRANS_ITEM fn regular_modules::mod1[0]::foo[0] @@ regular_modules-mod1[Internal]
     fn foo() {}
-    //~ TRANS_ITEM fn regular_modules::mod1[0]::bar[0] @@ regular_modules-mod1[External]
+    //~ TRANS_ITEM fn regular_modules::mod1[0]::bar[0] @@ regular_modules-mod1[Internal]
     fn bar() {}
-    //~ TRANS_ITEM static regular_modules::mod1[0]::BAZ[0] @@ regular_modules-mod1[External]
+    //~ TRANS_ITEM static regular_modules::mod1[0]::BAZ[0] @@ regular_modules-mod1[Internal]
     static BAZ: u64 = 0;
 
     mod mod1 {
-        //~ TRANS_ITEM fn regular_modules::mod1[0]::mod1[0]::foo[0] @@ regular_modules-mod1-mod1[External]
+        //~ TRANS_ITEM fn regular_modules::mod1[0]::mod1[0]::foo[0] @@ regular_modules-mod1-mod1[Internal]
         fn foo() {}
-        //~ TRANS_ITEM fn regular_modules::mod1[0]::mod1[0]::bar[0] @@ regular_modules-mod1-mod1[External]
+        //~ TRANS_ITEM fn regular_modules::mod1[0]::mod1[0]::bar[0] @@ regular_modules-mod1-mod1[Internal]
         fn bar() {}
-        //~ TRANS_ITEM static regular_modules::mod1[0]::mod1[0]::BAZ[0] @@ regular_modules-mod1-mod1[External]
+        //~ TRANS_ITEM static regular_modules::mod1[0]::mod1[0]::BAZ[0] @@ regular_modules-mod1-mod1[Internal]
         static BAZ: u64 = 0;
     }
 
     mod mod2 {
-        //~ TRANS_ITEM fn regular_modules::mod1[0]::mod2[0]::foo[0] @@ regular_modules-mod1-mod2[External]
+        //~ TRANS_ITEM fn regular_modules::mod1[0]::mod2[0]::foo[0] @@ regular_modules-mod1-mod2[Internal]
         fn foo() {}
-        //~ TRANS_ITEM fn regular_modules::mod1[0]::mod2[0]::bar[0] @@ regular_modules-mod1-mod2[External]
+        //~ TRANS_ITEM fn regular_modules::mod1[0]::mod2[0]::bar[0] @@ regular_modules-mod1-mod2[Internal]
         fn bar() {}
-        //~ TRANS_ITEM static regular_modules::mod1[0]::mod2[0]::BAZ[0] @@ regular_modules-mod1-mod2[External]
+        //~ TRANS_ITEM static regular_modules::mod1[0]::mod2[0]::BAZ[0] @@ regular_modules-mod1-mod2[Internal]
         static BAZ: u64 = 0;
     }
 }
 
 mod mod2 {
 
-    //~ TRANS_ITEM fn regular_modules::mod2[0]::foo[0] @@ regular_modules-mod2[External]
+    //~ TRANS_ITEM fn regular_modules::mod2[0]::foo[0] @@ regular_modules-mod2[Internal]
     fn foo() {}
-    //~ TRANS_ITEM fn regular_modules::mod2[0]::bar[0] @@ regular_modules-mod2[External]
+    //~ TRANS_ITEM fn regular_modules::mod2[0]::bar[0] @@ regular_modules-mod2[Internal]
     fn bar() {}
-    //~ TRANS_ITEM static regular_modules::mod2[0]::BAZ[0] @@ regular_modules-mod2[External]
+    //~ TRANS_ITEM static regular_modules::mod2[0]::BAZ[0] @@ regular_modules-mod2[Internal]
     static BAZ: u64 = 0;
 
     mod mod1 {
-        //~ TRANS_ITEM fn regular_modules::mod2[0]::mod1[0]::foo[0] @@ regular_modules-mod2-mod1[External]
+        //~ TRANS_ITEM fn regular_modules::mod2[0]::mod1[0]::foo[0] @@ regular_modules-mod2-mod1[Internal]
         fn foo() {}
-        //~ TRANS_ITEM fn regular_modules::mod2[0]::mod1[0]::bar[0] @@ regular_modules-mod2-mod1[External]
+        //~ TRANS_ITEM fn regular_modules::mod2[0]::mod1[0]::bar[0] @@ regular_modules-mod2-mod1[Internal]
         fn bar() {}
-        //~ TRANS_ITEM static regular_modules::mod2[0]::mod1[0]::BAZ[0] @@ regular_modules-mod2-mod1[External]
+        //~ TRANS_ITEM static regular_modules::mod2[0]::mod1[0]::BAZ[0] @@ regular_modules-mod2-mod1[Internal]
         static BAZ: u64 = 0;
     }
 
     mod mod2 {
-        //~ TRANS_ITEM fn regular_modules::mod2[0]::mod2[0]::foo[0] @@ regular_modules-mod2-mod2[External]
+        //~ TRANS_ITEM fn regular_modules::mod2[0]::mod2[0]::foo[0] @@ regular_modules-mod2-mod2[Internal]
         fn foo() {}
-        //~ TRANS_ITEM fn regular_modules::mod2[0]::mod2[0]::bar[0] @@ regular_modules-mod2-mod2[External]
+        //~ TRANS_ITEM fn regular_modules::mod2[0]::mod2[0]::bar[0] @@ regular_modules-mod2-mod2[Internal]
         fn bar() {}
-        //~ TRANS_ITEM static regular_modules::mod2[0]::mod2[0]::BAZ[0] @@ regular_modules-mod2-mod2[External]
+        //~ TRANS_ITEM static regular_modules::mod2[0]::mod2[0]::BAZ[0] @@ regular_modules-mod2-mod2[Internal]
         static BAZ: u64 = 0;
     }
 }

--- a/src/test/codegen-units/partitioning/statics.rs
+++ b/src/test/codegen-units/partitioning/statics.rs
@@ -15,34 +15,34 @@
 
 #![crate_type="lib"]
 
-//~ TRANS_ITEM static statics::FOO[0] @@ statics[External]
+//~ TRANS_ITEM static statics::FOO[0] @@ statics[Internal]
 static FOO: u32 = 0;
 
-//~ TRANS_ITEM static statics::BAR[0] @@ statics[External]
+//~ TRANS_ITEM static statics::BAR[0] @@ statics[Internal]
 static BAR: u32 = 0;
 
-//~ TRANS_ITEM fn statics::function[0] @@ statics[External]
+//~ TRANS_ITEM fn statics::function[0] @@ statics[Internal]
 fn function() {
-    //~ TRANS_ITEM static statics::function[0]::FOO[0] @@ statics[External]
+    //~ TRANS_ITEM static statics::function[0]::FOO[0] @@ statics[Internal]
     static FOO: u32 = 0;
 
-    //~ TRANS_ITEM static statics::function[0]::BAR[0] @@ statics[External]
+    //~ TRANS_ITEM static statics::function[0]::BAR[0] @@ statics[Internal]
     static BAR: u32 = 0;
 }
 
 mod mod1 {
-    //~ TRANS_ITEM static statics::mod1[0]::FOO[0] @@ statics-mod1[External]
+    //~ TRANS_ITEM static statics::mod1[0]::FOO[0] @@ statics-mod1[Internal]
     static FOO: u32 = 0;
 
-    //~ TRANS_ITEM static statics::mod1[0]::BAR[0] @@ statics-mod1[External]
+    //~ TRANS_ITEM static statics::mod1[0]::BAR[0] @@ statics-mod1[Internal]
     static BAR: u32 = 0;
 
-    //~ TRANS_ITEM fn statics::mod1[0]::function[0] @@ statics-mod1[External]
+    //~ TRANS_ITEM fn statics::mod1[0]::function[0] @@ statics-mod1[Internal]
     fn function() {
-        //~ TRANS_ITEM static statics::mod1[0]::function[0]::FOO[0] @@ statics-mod1[External]
+        //~ TRANS_ITEM static statics::mod1[0]::function[0]::FOO[0] @@ statics-mod1[Internal]
         static FOO: u32 = 0;
 
-        //~ TRANS_ITEM static statics::mod1[0]::function[0]::BAR[0] @@ statics-mod1[External]
+        //~ TRANS_ITEM static statics::mod1[0]::function[0]::BAR[0] @@ statics-mod1[Internal]
         static BAR: u32 = 0;
     }
 }

--- a/src/test/codegen-units/partitioning/vtable-through-const.rs
+++ b/src/test/codegen-units/partitioning/vtable-through-const.rs
@@ -67,7 +67,7 @@ mod mod1 {
     pub const ID_I64: fn(i64) -> i64 = id::<i64>;
 }
 
-//~ TRANS_ITEM fn vtable_through_const::main[0] @@ vtable_through_const[External]
+//~ TRANS_ITEM fn vtable_through_const::main[0] @@ vtable_through_const[Internal]
 fn main() {
     //~ TRANS_ITEM fn core::ptr[0]::drop_in_place[0]<u32> @@ vtable_through_const[Internal]
 


### PR DESCRIPTION
This PR makes the compiler use the information gather by the trans collector in order to determine which symbols/trans-items can be made internal. This has the advantages:
+ of being LLVM independent, 
+ of also working in incremental mode, and
+ of allowing to not keep all LLVM modules in memory at the same time.

This is in preparation for fixing issue #39280.

cc @rust-lang/compiler 