### PR TITLE
Implement fs::rename in sys::redox

### DIFF
--- a/src/libstd/sys/redox/fs.rs
+++ b/src/libstd/sys/redox/fs.rs
@@ -383,7 +383,7 @@ pub fn unlink(p: &Path) -> io::Result<()> {
     Ok(())
 }
 
-pub fn rename(_old: &Path, _new: &Path) -> io::Result<()> {
+pub fn rename(old: &Path, new: &Path) -> io::Result<()> {
     copy(old, new)?;
     unlink(old)?;
     Ok(())

--- a/src/libstd/sys/redox/fs.rs
+++ b/src/libstd/sys/redox/fs.rs
@@ -384,8 +384,9 @@ pub fn unlink(p: &Path) -> io::Result<()> {
 }
 
 pub fn rename(_old: &Path, _new: &Path) -> io::Result<()> {
-    ::sys_common::util::dumb_print(format_args!("Rename\n"));
-    unimplemented!();
+    copy(old, new)?;
+    unlink(old)?;
+    Ok(())
 }
 
 pub fn set_perm(p: &Path, perm: FilePermissions) -> io::Result<()> {


### PR DESCRIPTION
This uses a simple implementation of copy + unlink. Redox does not have a rename or link system call for a faster implementation.