### PR TITLE
Embed MSVC .natvis files into .pdbs and mangle debuginfo for &str, *T, and [T].

### DIFF
--- a/src/etc/natvis/intrinsic.natvis
+++ b/src/etc/natvis/intrinsic.natvis
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="str">
+    <DisplayString>{data_ptr,[length]}</DisplayString>
+    <StringView>data_ptr,[length]</StringView>
+    <Expand>
+      <Item Name="[size]" ExcludeView="simple">length</Item>
+      <ArrayItems>
+        <Size>length</Size>
+        <ValuePointer>data_ptr</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+  <Type Name="slice&lt;*&gt;">
+    <DisplayString>{{ length={length} }}</DisplayString>
+    <Expand>
+      <Item Name="[size]" ExcludeView="simple">length</Item>
+      <ArrayItems>
+        <Size>length</Size>
+        <ValuePointer>data_ptr</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+</AutoVisualizer>

--- a/src/etc/natvis/intrinsic.natvis
+++ b/src/etc/natvis/intrinsic.natvis
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
   <Type Name="str">
-    <DisplayString>{data_ptr,[length]}</DisplayString>
-    <StringView>data_ptr,[length]</StringView>
+    <DisplayString>{data_ptr,[length]s8}</DisplayString>
+    <StringView>data_ptr,[length]s8</StringView>
     <Expand>
       <Item Name="[size]" ExcludeView="simple">length</Item>
       <ArrayItems>

--- a/src/etc/natvis/liballoc.natvis
+++ b/src/etc/natvis/liballoc.natvis
@@ -42,8 +42,8 @@
     </Expand>
   </Type>
   <Type Name="alloc::string::String">
-    <DisplayString>{*(char**)this,[vec.len]}</DisplayString>
-    <StringView>*(char**)this,[vec.len]</StringView>
+    <DisplayString>{*(char**)this,[vec.len]s8}</DisplayString>
+    <StringView>*(char**)this,[vec.len]s8</StringView>
     <Expand>
       <Item Name="[size]" ExcludeView="simple">vec.len</Item>
       <Item Name="[capacity]" ExcludeView="simple">vec.buf.cap</Item>

--- a/src/librustc_trans/back/linker.rs
+++ b/src/librustc_trans/back/linker.rs
@@ -484,14 +484,10 @@ impl<'a> Linker for MsvcLinker<'a> {
                 match entry {
                     Ok(entry) => {
                         let path = entry.path();
-                        if let Some(ext) = path.extension() {
-                            if ext == OsStr::new("natvis") {
-                                if let Some(natvis_path_str) = path.to_str() {
-                                    self.cmd.arg(&format!("/NATVIS:{}",natvis_path_str));
-                                } else {
-                                    self.sess.warn(&format!("natvis path not unicode: {:?}", path));
-                                }
-                            }
+                        if path.extension() == Some("natvis".as_ref()) {
+                            let mut arg = OsString::from("/NATVIS:");
+                            arg.push(path);
+                            self.cmd.arg(arg);
                         }
                     },
                     Err(err) => {

--- a/src/librustc_trans/debuginfo/type_names.rs
+++ b/src/librustc_trans/debuginfo/type_names.rs
@@ -36,6 +36,10 @@ pub fn push_debuginfo_type_name<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                                           t: Ty<'tcx>,
                                           qualified: bool,
                                           output: &mut String) {
+    // When targeting MSVC, emit C++ style type names for compatability with
+    // .natvis visualizers (and perhaps other existing native debuggers?)
+    let cpp_like_names = cx.sess().target.target.options.is_like_msvc;
+
     match t.sty {
         ty::TyBool => output.push_str("bool"),
         ty::TyChar => output.push_str("char"),
@@ -61,27 +65,33 @@ pub fn push_debuginfo_type_name<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             output.push(')');
         },
         ty::TyRawPtr(ty::TypeAndMut { ty: inner_type, mutbl } ) => {
-            let is_like_msvc = cx.sess().target.target.options.is_like_msvc;
-
-            if !is_like_msvc {output.push('*');}
+            if !cpp_like_names {
+                output.push('*');
+            }
             match mutbl {
                 hir::MutImmutable => output.push_str("const "),
                 hir::MutMutable => output.push_str("mut "),
             }
 
             push_debuginfo_type_name(cx, inner_type, true, output);
-            if is_like_msvc {output.push('*');}
+
+            if cpp_like_names {
+                output.push('*');
+            }
         },
         ty::TyRef(_, ty::TypeAndMut { ty: inner_type, mutbl }) => {
-            let is_like_msvc = cx.sess().target.target.options.is_like_msvc;
-
-            if !is_like_msvc {output.push('&');}
+            if !cpp_like_names {
+                output.push('&');
+            }
             if mutbl == hir::MutMutable {
                 output.push_str("mut ");
             }
 
             push_debuginfo_type_name(cx, inner_type, true, output);
-            if is_like_msvc {output.push('*');}
+
+            if cpp_like_names {
+                output.push('*');
+            }
         },
         ty::TyArray(inner_type, len) => {
             output.push('[');
@@ -90,10 +100,19 @@ pub fn push_debuginfo_type_name<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             output.push(']');
         },
         ty::TySlice(inner_type) => {
-            let is_like_msvc = cx.sess().target.target.options.is_like_msvc;
-            output.push_str(if is_like_msvc {"slice<"} else {"["});
+            if cpp_like_names {
+                output.push_str("slice<");
+            } else {
+                output.push('[');
+            }
+
             push_debuginfo_type_name(cx, inner_type, true, output);
-            output.push(if is_like_msvc {'>'} else {']'});
+
+            if cpp_like_names {
+                output.push('>');
+            } else {
+                output.push(']');
+            }
         },
         ty::TyDynamic(ref trait_data, ..) => {
             if let Some(principal) = trait_data.principal() {


### PR DESCRIPTION
No idea if these changes are reasonable - please feel free to suggest changes/rewrites.  And these are some of my first real commits to any rust codebase - *don't* be gentle, and nitpick away, I need to learn! ;)

### Overview
Embedding `.natvis` files into `.pdb`s allows MSVC (and potentially other debuggers) to automatically pick up the visualizers without having to do any additional configuration (other than to perhaps add the relevant .pdb paths to symbol search paths.)

The native debug engine for MSVC parses the type names, making various C++ish assumptions about what they mean and adding various limitations to valid type names.  `&str` cannot be matched against a visualizer, but if we emit `str&` instead, it'll be recognized as a reference to a `str`, solving the problem.  `[T]` is similarly problematic, but emitting `slice<T>` instead works fine as it looks like a template.  I've been unable to get e.g. `slice<u32>&` to match visualizers in VS2015u3, so I've gone with `str*` and `slice<u32>*` instead.

### Possible Issues
* I'm not sure if `slice<T>` is a great mangling for `[T]` or if I should worry about name collisions.
* I'm not sure if `linker.rs` is the right place to be enumerating natvis files.
* I'm not sure if these type name mangling changes should actually be MSVC specific.  I recall seeing gdb visualizer tests that might be broken if made more general?  I'm hesitant to mess with them without a gdb install.  But perhaps I'm just wracking up technical debt.
  Should I try `pacman -S mingw-w64-x86_64-gdb` and to make things consistent?
* I haven't touched `const` / `mut` yet, and I'm worried MSVC might trip up on `mut` or their placement.
* I may like terse oneliners too much.
* I don't know if there's broader implications for messing with debug type names here.
* I may have been mistaken about bellow test failures being ignorable / unrelated to this changelist.

### Test Failures on `x86_64-pc-windows-gnu`

```
---- [debuginfo-gdb] debuginfo-gdb\associated-types.rs stdout ----
        thread '[debuginfo-gdb] debuginfo-gdb\associated-types.rs' panicked at 'gdb not available but debuginfo gdb debuginfo test requested', src\tools\compiletest\src\runtest.rs:48:16
note: Run with `RUST_BACKTRACE=1` for a backtrace.

[...identical panic causes omitted...]

---- [debuginfo-gdb] debuginfo-gdb\vec.rs stdout ----
        thread '[debuginfo-gdb] debuginfo-gdb\vec.rs' panicked at 'gdb not available but debuginfo gdb debuginfo test requested', src\tools\compiletest\src\runtest.rs:48:16
```

### Relevant Issues
* https://github.com/rust-lang/rust/issues/40460 Metaissue for Visual Studio debugging Rust
* https://github.com/rust-lang/rust/issues/36503 Investigate natvis for improved msvc debugging
* https://github.com/PistonDevelopers/VisualRust/issues/160 Debug visualization of Rust data structures

### Pretty Pictures
![Collapsed Watch Window](https://user-images.githubusercontent.com/75894/28180998-e44c7516-67bb-11e7-8b48-d4f9605973ae.png)
![Expanded Watch Window](https://user-images.githubusercontent.com/75894/28181000-e8da252e-67bb-11e7-96b8-d613310c04dc.png)
