### PR TITLE
windows::fs::symlink_dir: fix example to actually use symlink_dir

### DIFF
--- a/src/libstd/sys/windows/ext/fs.rs
+++ b/src/libstd/sys/windows/ext/fs.rs
@@ -477,7 +477,7 @@ pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q)
 /// use std::os::windows::fs;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// fs::symlink_file("a", "b")?;
+/// fs::symlink_dir("a", "b")?;
 /// # Ok(())
 /// # }
 /// ```


### PR DESCRIPTION
I don't have a windows machine, so I couldn't test if this doctest still works -- but it looks trivial enough. (I know, famous last words.)