### PR TITLE
[beta] Bump 1.19 prerelease to .4

### DIFF
--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -28,7 +28,7 @@ pub const CFG_RELEASE_NUM: &'static str = "1.19.0";
 // An optional number to put after the label, e.g. '.2' -> '-beta.2'
 // Be sure to make this starts with a dot to conform to semver pre-release
 // versions (section 9)
-pub const CFG_PRERELEASE_VERSION: &'static str = ".3";
+pub const CFG_PRERELEASE_VERSION: &'static str = ".4";
 
 pub struct GitInfo {
     inner: Option<Info>,


### PR DESCRIPTION
I'm running a beta.3 cargobomb now, but it might be nice to get in another. Merge after

- https://github.com/rust-lang/rust/pull/43114
- https://github.com/rust-lang/rust/pull/43208
- https://github.com/rust-lang/rust/pull/43199