### PR TITLE
macros: fix regression involving identifiers in `macro_rules!` patterns.

### DIFF
--- a/src/libsyntax/ext/tt/quoted.rs
+++ b/src/libsyntax/ext/tt/quoted.rs
@@ -196,7 +196,8 @@ fn parse_tree<I>(tree: tokenstream::TokenTree,
                     num_captures: name_captures,
                 }))
             }
-            Some(tokenstream::TokenTree::Token(ident_span, token::Ident(ident))) => {
+            Some(tokenstream::TokenTree::Token(ident_span, ref token)) if token.is_ident() => {
+                let ident = token.ident().unwrap();
                 let span = Span { lo: span.lo, ..ident_span };
                 if ident.name == keywords::Crate.name() {
                     let ident = ast::Ident { name: keywords::DollarCrate.name(), ..ident };

--- a/src/test/run-pass/issue-40847.rs
+++ b/src/test/run-pass/issue-40847.rs
@@ -1,0 +1,26 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! gen {
+    ($name:ident ( $($dol:tt $var:ident)* ) $($body:tt)*) => {
+        macro_rules! $name {
+            ($($dol $var:ident)*) => {
+                $($body)*
+            }
+        }
+    }
+}
+
+gen!(m($var) $var);
+
+fn main() {
+    let x = 1;
+    assert_eq!(m!(x), 1);
+}


### PR DESCRIPTION
Fixes #42019.
r? @nrc 