### PR TITLE
[beta] More removal of rls packaging

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -152,7 +152,6 @@ macro_rules! t {
 struct Builder {
     rust_release: String,
     cargo_release: String,
-    rls_release: String,
     input: PathBuf,
     output: PathBuf,
     gpg_passphrase: String,
@@ -161,7 +160,6 @@ struct Builder {
     date: String,
     rust_version: String,
     cargo_version: String,
-    rls_version: String,
 }
 
 fn main() {
@@ -171,7 +169,6 @@ fn main() {
     let date = args.next().unwrap();
     let rust_release = args.next().unwrap();
     let cargo_release = args.next().unwrap();
-    let rls_release = args.next().unwrap();
     let s3_address = args.next().unwrap();
     let mut passphrase = String::new();
     t!(io::stdin().read_to_string(&mut passphrase));
@@ -179,7 +176,6 @@ fn main() {
     Builder {
         rust_release: rust_release,
         cargo_release: cargo_release,
-        rls_release: rls_release,
         input: input,
         output: output,
         gpg_passphrase: passphrase,
@@ -188,7 +184,6 @@ fn main() {
         date: date,
         rust_version: String::new(),
         cargo_version: String::new(),
-        rls_version: String::new(),
     }.build();
 }
 
@@ -196,7 +191,6 @@ impl Builder {
     fn build(&mut self) {
         self.rust_version = self.version("rust", "x86_64-unknown-linux-gnu");
         self.cargo_version = self.version("cargo", "x86_64-unknown-linux-gnu");
-        self.rls_version = self.version("rls", "x86_64-unknown-linux-gnu");
 
         self.digest_and_sign();
         let Manifest { manifest_version, date, pkg } = self.build_manifest();
@@ -246,7 +240,6 @@ impl Builder {
         self.package("rust-std", &mut manifest.pkg, TARGETS);
         self.package("rust-docs", &mut manifest.pkg, TARGETS);
         self.package("rust-src", &mut manifest.pkg, &["*"]);
-        // self.package("rls", &mut manifest.pkg, HOSTS);
         self.package("rust-analysis", &mut manifest.pkg, TARGETS);
 
         let mut pkg = Package {
@@ -282,10 +275,6 @@ impl Builder {
                 });
             }
 
-            // extensions.push(Component {
-            //     pkg: "rls".to_string(),
-            //     target: host.to_string(),
-            // });
             extensions.push(Component {
                 pkg: "rust-analysis".to_string(),
                 target: host.to_string(),
@@ -360,8 +349,6 @@ impl Builder {
             format!("rust-src-{}.tar.gz", self.rust_release)
         } else if component == "cargo" {
             format!("cargo-{}-{}.tar.gz", self.cargo_release, target)
-        } else if component == "rls" {
-            format!("rls-{}-{}.tar.gz", self.rls_release, target)
         } else {
             format!("{}-{}-{}.tar.gz", component, self.rust_release, target)
         }
@@ -370,8 +357,6 @@ impl Builder {
     fn cached_version(&self, component: &str) -> &str {
         if component == "cargo" {
             &self.cargo_version
-        } else if component == "rls" {
-            &self.rls_version
         } else {
             &self.rust_version
         }


### PR DESCRIPTION
Beta right now unfortunately can't get released due to the `build-manifest`
program failing, and I believe it's due to the expectation that a `rls` package
exists but it doesn't currently on the beta branch.