### PR TITLE
Use `rustc_on_unimplemented`'s trait name argument in `try`

### DIFF
--- a/src/libcore/ops/try.rs
+++ b/src/libcore/ops/try.rs
@@ -16,7 +16,7 @@
 /// creating a new instance from a success or failure value.
 #[unstable(feature = "try_trait", issue = "42327")]
 #[rustc_on_unimplemented = "the `?` operator can only be used in a function that returns `Result` \
-                            (or another type that implements `std::ops::Try`)"]
+                            (or another type that implements `{Try}`)"]
 pub trait Try {
     /// The type of this value when viewed as successful.
     #[unstable(feature = "try_trait", issue = "42327")]


### PR DESCRIPTION
Follow up to #43000 and #43001. Fix #42694.