### PR TITLE
Document default values for primitive types

### DIFF
--- a/src/libcore/default.rs
+++ b/src/libcore/default.rs
@@ -136,23 +136,23 @@ macro_rules! default_impl {
     }
 }
 
-default_impl! { (), (), "Defaults to `()`" }
-default_impl! { bool, false, "Defaults to `false`" }
-default_impl! { char, '\x00', "Defaults to `\\x00`" }
+default_impl! { (), (), "Returns the default value of `()`" }
+default_impl! { bool, false, "Returns the default value of `false`" }
+default_impl! { char, '\x00', "Returns the default value of `\\x00`" }
 
-default_impl! { usize, 0, "Defaults to `0`" }
-default_impl! { u8, 0, "Defaults to `0`" }
-default_impl! { u16, 0, "Defaults to `0`" }
-default_impl! { u32, 0, "Defaults to `0`" }
-default_impl! { u64, 0, "Defaults to `0`" }
-default_impl! { u128, 0, "Defaults to `0`" }
+default_impl! { usize, 0, "Returns the default value of `0`" }
+default_impl! { u8, 0, "Returns the default value of `0`" }
+default_impl! { u16, 0, "Returns the default value of `0`" }
+default_impl! { u32, 0, "Returns the default value of `0`" }
+default_impl! { u64, 0, "Returns the default value of `0`" }
+default_impl! { u128, 0, "Returns the default value of `0`" }
 
-default_impl! { isize, 0, "Defaults to `0`" }
-default_impl! { i8, 0, "Defaults to `0`" }
-default_impl! { i16, 0, "Defaults to `0`" }
-default_impl! { i32, 0, "Defaults to `0`" }
-default_impl! { i64, 0, "Defaults to `0`" }
-default_impl! { i128, 0, "Defaults to `0`" }
+default_impl! { isize, 0, "Returns the default value of `0`" }
+default_impl! { i8, 0, "Returns the default value of `0`" }
+default_impl! { i16, 0, "Returns the default value of `0`" }
+default_impl! { i32, 0, "Returns the default value of `0`" }
+default_impl! { i64, 0, "Returns the default value of `0`" }
+default_impl! { i128, 0, "Returns the default value of `0`" }
 
-default_impl! { f32, 0.0f32, "Defaults to `0.0`" }
-default_impl! { f64, 0.0f64, "Defaults to `0.0`" }
+default_impl! { f32, 0.0f32, "Returns the default value of `0.0`" }
+default_impl! { f64, 0.0f64, "Returns the default value of `0.0`" }

--- a/src/libcore/default.rs
+++ b/src/libcore/default.rs
@@ -126,32 +126,33 @@ pub trait Default: Sized {
 }
 
 macro_rules! default_impl {
-    ($t:ty, $v:expr) => {
+    ($t:ty, $v:expr, $doc:expr) => {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl Default for $t {
             #[inline]
+            #[doc = $doc]
             fn default() -> $t { $v }
         }
     }
 }
 
-default_impl! { (), () }
-default_impl! { bool, false }
-default_impl! { char, '\x00' }
+default_impl! { (), (), "Defaults to `()`" }
+default_impl! { bool, false, "Defaults to `false`" }
+default_impl! { char, '\x00', "Defaults to `\\x00`" }
 
-default_impl! { usize, 0 }
-default_impl! { u8, 0 }
-default_impl! { u16, 0 }
-default_impl! { u32, 0 }
-default_impl! { u64, 0 }
-default_impl! { u128, 0 }
+default_impl! { usize, 0, "Defaults to `0`" }
+default_impl! { u8, 0, "Defaults to `0`" }
+default_impl! { u16, 0, "Defaults to `0`" }
+default_impl! { u32, 0, "Defaults to `0`" }
+default_impl! { u64, 0, "Defaults to `0`" }
+default_impl! { u128, 0, "Defaults to `0`" }
 
-default_impl! { isize, 0 }
-default_impl! { i8, 0 }
-default_impl! { i16, 0 }
-default_impl! { i32, 0 }
-default_impl! { i64, 0 }
-default_impl! { i128, 0 }
+default_impl! { isize, 0, "Defaults to `0`" }
+default_impl! { i8, 0, "Defaults to `0`" }
+default_impl! { i16, 0, "Defaults to `0`" }
+default_impl! { i32, 0, "Defaults to `0`" }
+default_impl! { i64, 0, "Defaults to `0`" }
+default_impl! { i128, 0, "Defaults to `0`" }
 
-default_impl! { f32, 0.0f32 }
-default_impl! { f64, 0.0f64 }
+default_impl! { f32, 0.0f32, "Defaults to `0.0`" }
+default_impl! { f64, 0.0f64, "Defaults to `0.0`" }


### PR DESCRIPTION
All primitive types implement the `Default` trait but the documentation just says `Returns the "default value" for a type.` and doesn't give a hint about the actual default value. I think it would be good to document the default values in a proper way.
I changed the `default_impl` macro to accept a doc string as a third parameter and use this string to overwrite the documentation of `default()` for each primitive type.
The generated documentation now looks like this:
![Documentation of default() on the bool primitive](https://i.imgur.com/nK6TApo.png)