### PR TITLE
Improve panic docs for Instant::duration_since

### DIFF
--- a/src/libstd/time/mod.rs
+++ b/src/libstd/time/mod.rs
@@ -163,10 +163,7 @@ impl Instant {
     ///
     /// # Panics
     ///
-    /// This function will panic if `earlier` is later than `self`, which should
-    /// only be possible if `earlier` was created after `self`. Because
-    /// `Instant` is monotonic, the only time that this should happen should be
-    /// a bug.
+    /// This function will panic if `earlier` is later than `self`.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
The docs for Instant::duration_since has a confusing section on panicking. It's
much more clear without the second two sentences of description.