### PR TITLE
Compile `compiler_builtins` with `abort` panic strategy

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -150,7 +150,12 @@ fn main() {
         // This... is a bit of a hack how we detect this. Ideally this
         // information should be encoded in the crate I guess? Would likely
         // require an RFC amendment to RFC 1513, however.
-        if crate_name == "panic_abort" {
+        //
+        // `compiler_builtins` are unconditionally compiled with panic=abort to
+        // workaround undefined references to `rust_eh_unwind_resume` generated
+        // otherwise, see issue https://github.com/rust-lang/rust/issues/43095.
+        if crate_name == "panic_abort" ||
+           crate_name == "compiler_builtins" && stage != "0" {
             cmd.arg("-C").arg("panic=abort");
         }
 

--- a/src/librustc/middle/dependency_format.rs
+++ b/src/librustc/middle/dependency_format.rs
@@ -396,7 +396,8 @@ fn verify_ok<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, list: &[Linkage]) {
             }
             let cnum = CrateNum::new(i + 1);
             let found_strategy = sess.cstore.panic_strategy(cnum);
-            if desired_strategy == found_strategy {
+            let is_compiler_builtins = sess.cstore.is_compiler_builtins(cnum);
+            if is_compiler_builtins || desired_strategy == found_strategy {
                 continue
             }
 


### PR DESCRIPTION
A workaround for https://github.com/rust-lang/rust/issues/43095

In case this causes unexpected consequences, I use a simpler workaround locally:
```diff
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -175,7 +175,9 @@ fn main() {
         }

         if let Ok(s) = env::var("RUSTC_CODEGEN_UNITS") {
-            cmd.arg("-C").arg(format!("codegen-units={}", s));
+            if crate_name != "compiler_builtins" {
+                cmd.arg("-C").arg(format!("codegen-units={}", s));
+            }
         }

         // Emit save-analysis info.
```

r? @alexcrichton 