### PR TITLE
explanatory error on `--print target-spec-json` without unstable options

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1615,8 +1615,15 @@ pub fn build_session_options_and_crate_config(matches: &getopts::Matches)
             "target-features" => PrintRequest::TargetFeatures,
             "relocation-models" => PrintRequest::RelocationModels,
             "code-models" => PrintRequest::CodeModels,
-            "target-spec-json" if nightly_options::is_unstable_enabled(matches)
-                => PrintRequest::TargetSpec,
+            "target-spec-json" => {
+                if nightly_options::is_unstable_enabled(matches) {
+                    PrintRequest::TargetSpec
+                } else {
+                    early_error(error_format,
+                                &format!("the `-Z unstable-options` flag must also be passed to \
+                                          enable the target-spec-json print option"));
+                }
+            },
             req => {
                 early_error(error_format, &format!("unknown print request `{}`", req))
             }


### PR DESCRIPTION
![unstable_target_spec](https://user-images.githubusercontent.com/1076988/28243342-9731a45c-697a-11e7-9852-bad7ca1802b7.png)

Resolves #41683.