### PR TITLE
Fix `range_covered_by_constructor` for exclusive ranges.

### DIFF
--- a/src/librustc_const_eval/_match.rs
+++ b/src/librustc_const_eval/_match.rs
@@ -835,7 +835,7 @@ fn slice_pat_covered_by_constructor(_tcx: TyCtxt, _span: Span,
     Ok(true)
 }
 
-fn range_covered_by_constructor(tcx: TyCtxt, span: Span,
+fn constructor_covered_by_range(tcx: TyCtxt, span: Span,
                                 ctor: &Constructor,
                                 from: &ConstVal, to: &ConstVal,
                                 end: RangeEnd)
@@ -933,7 +933,7 @@ fn specialize<'p, 'a: 'p, 'tcx: 'a>(
                         "unexpected const-val {:?} with ctor {:?}", value, constructor)
                 },
                 _ => {
-                    match range_covered_by_constructor(
+                    match constructor_covered_by_range(
                         cx.tcx, pat.span, constructor, value, value, RangeEnd::Included
                             ) {
                         Ok(true) => Some(vec![]),
@@ -945,7 +945,7 @@ fn specialize<'p, 'a: 'p, 'tcx: 'a>(
         }
 
         PatternKind::Range { ref lo, ref hi, ref end } => {
-            match range_covered_by_constructor(
+            match constructor_covered_by_range(
                 cx.tcx, pat.span, constructor, lo, hi, end.clone()
             ) {
                 Ok(true) => Some(vec![]),

--- a/src/librustc_const_eval/_match.rs
+++ b/src/librustc_const_eval/_match.rs
@@ -845,14 +845,14 @@ fn range_covered_by_constructor(tcx: TyCtxt, span: Span,
     match *ctor {
         ConstantValue(ref value) => {
             let to = cmp_to(value)?;
-            let end = (to != Ordering::Greater) ||
-                      (end == RangeEnd::Excluded && to == Ordering::Equal);
+            let end = (to == Ordering::Less) ||
+                      (end == RangeEnd::Included && to == Ordering::Equal);
             Ok(cmp_from(value)? && end)
         },
         ConstantRange(ref from, ref to, RangeEnd::Included) => {
             let to = cmp_to(to)?;
-            let end = (to != Ordering::Greater) ||
-                      (end == RangeEnd::Excluded && to == Ordering::Equal);
+            let end = (to == Ordering::Less) ||
+                      (end == RangeEnd::Included && to == Ordering::Equal);
             Ok(cmp_from(from)? && end)
         },
         ConstantRange(ref from, ref to, RangeEnd::Excluded) => {

--- a/src/test/ui/check_match/issue-43253.rs
+++ b/src/test/ui/check_match/issue-43253.rs
@@ -1,0 +1,51 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(exclusive_range_pattern)]
+
+fn main() {
+    // These cases should generate no warning.
+    match 10 {
+        1..10 => {},
+        10 => {},
+        _ => {},
+    }
+
+    match 10 {
+        1..10 => {},
+        9...10 => {},
+        _ => {},
+    }
+
+    match 10 {
+        1..10 => {},
+        10...10 => {},
+        _ => {},
+    }
+
+    // These cases should generate an "unreachable pattern" warning.
+    match 10 {
+        1..10 => {},
+        9 => {},
+        _ => {},
+    }
+
+    match 10 {
+        1..10 => {},
+        8...9 => {},
+        _ => {},
+    }
+
+    match 10 {
+        1..10 => {},
+        9...9 => {},
+        _ => {},
+    }
+}

--- a/src/test/ui/check_match/issue-43253.stderr
+++ b/src/test/ui/check_match/issue-43253.stderr
@@ -1,0 +1,20 @@
+warning: unreachable pattern
+  --> $DIR/issue-43253.rs:36:9
+   |
+36 |         9 => {},
+   |         ^
+   |
+   = note: #[warn(unreachable_patterns)] on by default
+
+warning: unreachable pattern
+  --> $DIR/issue-43253.rs:42:9
+   |
+42 |         8...9 => {},
+   |         ^^^^^
+
+warning: unreachable pattern
+  --> $DIR/issue-43253.rs:48:9
+   |
+48 |         9...9 => {},
+   |         ^^^^^
+


### PR DESCRIPTION
This resolves #43253