### PR TITLE
Fix checking for missing stability annotations

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -244,10 +244,10 @@ mod std {
 pub enum Bound<T> {
     /// An inclusive bound.
     #[stable(feature = "collections_bound", since = "1.17.0")]
-    Included(T),
+    Included(#[stable(feature = "collections_bound", since = "1.17.0")] T),
     /// An exclusive bound.
     #[stable(feature = "collections_bound", since = "1.17.0")]
-    Excluded(T),
+    Excluded(#[stable(feature = "collections_bound", since = "1.17.0")] T),
     /// An infinite endpoint. Indicates that there is no bound in this direction.
     #[stable(feature = "collections_bound", since = "1.17.0")]
     Unbounded,

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -51,7 +51,6 @@
 #![deny(missing_docs)]
 #![deny(warnings)]
 
-#![feature(staged_api)]
 #![cfg_attr(windows, feature(libc))]
 // Handle rustfmt skips
 #![feature(custom_attribute)]

--- a/src/test/compile-fail-fulldeps/explore-issue-38412.rs
+++ b/src/test/compile-fail-fulldeps/explore-issue-38412.rs
@@ -10,7 +10,6 @@
 
 // aux-build:pub_and_stability.rs
 
-#![feature(staged_api)]
 #![feature(unused_feature)]
 
 // A big point of this test is that we *declare* `unstable_declared`,

--- a/src/test/compile-fail/stability-attribute-issue-43027.rs
+++ b/src/test/compile-fail/stability-attribute-issue-43027.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -F deprecated
+#![feature(staged_api)]
+#![stable(feature = "test", since = "0")]
 
-#[allow(deprecated)] //~ ERROR allow(deprecated) overruled by outer forbid(deprecated)
+#[stable(feature = "test", since = "0")]
+pub struct Reverse<T>(pub T); //~ ERROR This node does not have a stability attribute
+
 fn main() {
+    // Make sure the field is used to fill the stability cache
+    Reverse(0).0;
 }


### PR DESCRIPTION
This was a regression from https://github.com/rust-lang/rust/pull/37676 causing "unmarked API" ICEs like https://github.com/rust-lang/rust/issues/43027.

r? @alexcrichton 