### PR TITLE
Add empty MIR pass for non-lexical lifetimes

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1060,6 +1060,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
                      "insert profiling code"),
     relro_level: Option<RelroLevel> = (None, parse_relro_level, [TRACKED],
         "choose which RELRO level to use"),
+    nll: bool = (false, parse_bool, [UNTRACKED],
+                 "run the non-lexical lifetimes MIR pass"),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -938,6 +938,7 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
     passes.push_pass(MIR_VALIDATED,
                      mir::transform::simplify_branches::SimplifyBranches::new("initial"));
     passes.push_pass(MIR_VALIDATED, mir::transform::simplify::SimplifyCfg::new("qualify-consts"));
+    passes.push_pass(MIR_VALIDATED, mir::transform::nll::NLL);
 
     // Optimizations begin.
     passes.push_pass(MIR_OPTIMIZED, mir::transform::no_landing_pads::NoLandingPads);

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -40,6 +40,7 @@ pub mod deaggregator;
 pub mod instcombine;
 pub mod copy_prop;
 pub mod inline;
+pub mod nll;
 
 pub(crate) fn provide(providers: &mut Providers) {
     self::qualify_consts::provide(providers);

--- a/src/librustc_mir/transform/nll.rs
+++ b/src/librustc_mir/transform/nll.rs
@@ -1,0 +1,47 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use rustc::ty::TyCtxt;
+use rustc::mir::Mir;
+use rustc::mir::visit::MutVisitor;
+use rustc::mir::transform::{MirPass, MirSource};
+
+#[allow(dead_code)]
+struct NLLVisitor<'a, 'tcx: 'a> {
+    tcx: TyCtxt<'a, 'tcx, 'tcx>,
+}
+
+impl<'a, 'tcx> NLLVisitor<'a, 'tcx> {
+    pub fn new(tcx: TyCtxt<'a, 'tcx, 'tcx>) -> Self {
+        NLLVisitor {
+            tcx: tcx
+        }
+    }
+}
+
+impl<'a, 'tcx> MutVisitor<'tcx> for NLLVisitor<'a, 'tcx> {
+    // FIXME: Nashenas88: implement me!
+}
+
+// MIR Pass for non-lexical lifetimes
+pub struct NLL;
+
+impl MirPass for NLL {
+    fn run_pass<'a, 'tcx>(&self,
+                          tcx: TyCtxt<'a, 'tcx, 'tcx>,
+                          _: MirSource,
+                          mir: &mut Mir<'tcx>) {
+        if tcx.sess.opts.debugging_opts.nll {
+            // Clone mir so we can mutate it without disturbing the rest
+            // of the compiler
+            NLLVisitor::new(tcx).visit_mir(&mut mir.clone());
+        }
+    }
+}


### PR DESCRIPTION
This is the first step for #43234.