### PR TITLE
Add #[derive(Clone)] to TokenTreeIter

### DIFF
--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -375,6 +375,7 @@ impl Literal {
 }
 
 /// An iterator over `TokenTree`s.
+#[derive(Clone)]
 #[unstable(feature = "proc_macro", issue = "38356")]
 pub struct TokenTreeIter {
     cursor: tokenstream::Cursor,


### PR DESCRIPTION
I've found this useful for writing backtracking parsers.

The underlying `Cursor` implements `Clone` already, so it's just a matter of adding `#[derive(Clone)]` to the type.

r? @jseyfried