### PR TITLE
Allow remote testing remotely when `TEST_DEVICE_ADDR` is set

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -920,7 +920,8 @@ impl Build {
     /// Returns whether the target will be tested using the `remote-test-client`
     /// and `remote-test-server` binaries.
     fn remote_tested(&self, target: &str) -> bool {
-        self.qemu_rootfs(target).is_some() || target.contains("android")
+        self.qemu_rootfs(target).is_some() || target.contains("android") ||
+        env::var_os("TEST_DEVICE_ADDR").is_some()
     }
 
     /// Returns the root of the "rootfs" image that this target will be using,


### PR DESCRIPTION
Remote testing was added in #41268, but at the moment it's only enabled if QEMU is also available or we're testing Android. This patch also allows remote testing if the environment variable `TEST_DEVICE_ADDR` is set, as required by `remote-test-client` [[1](https://github.com/rust-lang/rust/blob/master/src/tools/remote-test-client/src/main.rs#L28), [2](https://github.com/rust-lang/rust/blob/master/src/tools/remote-test-client/src/main.rs#L61)]