### PR TITLE
[stable] Prepare the 1.19.0 stable release

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -44,7 +44,7 @@ fi
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
 if [ "$DEPLOY$DEPLOY_ALT" != "" ]; then
-  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=beta"
+  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=stable"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"
 
   if [ "$NO_LLVM_ASSERTIONS" = "1" ]; then


### PR DESCRIPTION
This prepares the tree for the 1.19.0 stable release. The `cargo` submodule is
already updated to the tip of rust-1.19.0 so this just updates the channel we're
built in.