### PR TITLE
libstd: remove redundant & from &Path::new(...)

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -2346,17 +2346,17 @@ mod tests {
 
     #[test]
     fn recursive_mkdir_slash() {
-        check!(fs::create_dir_all(&Path::new("/")));
+        check!(fs::create_dir_all(Path::new("/")));
     }
 
     #[test]
     fn recursive_mkdir_dot() {
-        check!(fs::create_dir_all(&Path::new(".")));
+        check!(fs::create_dir_all(Path::new(".")));
     }
 
     #[test]
     fn recursive_mkdir_empty() {
-        check!(fs::create_dir_all(&Path::new("")));
+        check!(fs::create_dir_all(Path::new("")));
     }
 
     #[test]

--- a/src/libstd/sys/redox/net/tcp.rs
+++ b/src/libstd/sys/redox/net/tcp.rs
@@ -29,7 +29,7 @@ impl TcpStream {
         let mut options = OpenOptions::new();
         options.read(true);
         options.write(true);
-        Ok(TcpStream(File::open(&Path::new(path.as_str()), &options)?))
+        Ok(TcpStream(File::open(Path::new(path.as_str()), &options)?))
     }
 
     pub fn connect_timeout(_addr: &SocketAddr, _timeout: Duration) -> Result<TcpStream> {
@@ -177,7 +177,7 @@ impl TcpListener {
         let mut options = OpenOptions::new();
         options.read(true);
         options.write(true);
-        Ok(TcpListener(File::open(&Path::new(path.as_str()), &options)?))
+        Ok(TcpListener(File::open(Path::new(path.as_str()), &options)?))
     }
 
     pub fn accept(&self) -> Result<(TcpStream, SocketAddr)> {

--- a/src/libstd/sys/redox/net/udp.rs
+++ b/src/libstd/sys/redox/net/udp.rs
@@ -30,7 +30,7 @@ impl UdpSocket {
         let mut options = OpenOptions::new();
         options.read(true);
         options.write(true);
-        Ok(UdpSocket(File::open(&Path::new(path.as_str()), &options)?, UnsafeCell::new(None)))
+        Ok(UdpSocket(File::open(Path::new(path.as_str()), &options)?, UnsafeCell::new(None)))
     }
 
     fn get_conn(&self) -> &mut Option<SocketAddr> {

--- a/src/libstd/sys/redox/process.rs
+++ b/src/libstd/sys/redox/process.rs
@@ -393,7 +393,7 @@ impl Stdio {
                 let mut opts = OpenOptions::new();
                 opts.read(readable);
                 opts.write(!readable);
-                let fd = File::open(&Path::new("null:"), &opts)?;
+                let fd = File::open(Path::new("null:"), &opts)?;
                 Ok((ChildStdio::Owned(fd.into_fd()), None))
             }
         }


### PR DESCRIPTION
```rust
fn Path::new<S: AsRef ...>(s: &S) -> &Path
```

* https://doc.rust-lang.org/std/path/struct.Path.html#method.new