### PR TITLE
Workaround "Quasi-quoting is inefficient" warning in incremental rustbuild introduced in #43252.

### DIFF
--- a/src/libcore/default.rs
+++ b/src/libcore/default.rs
@@ -126,7 +126,7 @@ pub trait Default: Sized {
 }
 
 macro_rules! default_impl {
-    ($t:ty, $v:expr, $doc:expr) => {
+    ($t:ty, $v:expr, $doc:tt) => {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl Default for $t {
             #[inline]


### PR DESCRIPTION
After #43252 is merged, building stage0 libcore with `-i` (`--incremental`) flag will cause 17 "Quasi-quoting might make incremental compilation very inefficient: NtExpr(..)" warnings, as in #40946.

```
warning: Quasi-quoting might make incremental compilation very inefficient: NtExpr(..)
   --> src/libcore/default.rs:133:21
    |
133 |             #[doc = $doc]
    |                     ^^^^
...
139 | default_impl! { (), (), "Returns the default value of `()`" }
    | ------------------------------------------------------------- in this macro invocation
(× 17)
```

True fix for #40946 will take at least 12 weeks from now to make into the next stage0, so it is quicker to workaround it in libcore instead.

cc @vbrandl @jseyfried 