### PR TITLE
travis: Make a few `curl` invocations more resilient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,9 +64,9 @@ matrix:
       os: osx
       osx_image: xcode8.2
       install: &osx_install_sccache >
-        travis_retry curl -o /usr/local/bin/sccache https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-apple-darwin &&
+        travis_retry curl -fo /usr/local/bin/sccache https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-apple-darwin &&
           chmod +x /usr/local/bin/sccache &&
-        travis_retry curl -o /usr/local/bin/stamp https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-03-17-stamp-x86_64-apple-darwin &&
+        travis_retry curl -fo /usr/local/bin/stamp https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-03-17-stamp-x86_64-apple-darwin &&
           chmod +x /usr/local/bin/stamp
     - env: >
         RUST_CHECK_TARGET=check
@@ -144,7 +144,7 @@ env:
 
 # Note that this is overridden on OSX builders
 install: >
-  travis_retry curl -o $HOME/stamp https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-03-17-stamp-x86_64-unknown-linux-musl &&
+  travis_retry curl -fo $HOME/stamp https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-03-17-stamp-x86_64-unknown-linux-musl &&
     chmod +x $HOME/stamp &&
     export PATH=$PATH:$HOME
 
@@ -183,10 +183,10 @@ before_script:
 # clock drift. Timezones don't matter since relative deltas give all the necessary info.
 script:
   - >
-      date && curl -s --head https://google.com | grep ^Date: | sed 's/Date: //g'
+      date && (curl -fs --head https://google.com | grep ^Date: | sed 's/Date: //g' || true)
   - stamp sh -x -c "$RUN_SCRIPT"
   - >
-      date && curl -s --head https://google.com | grep ^Date: | sed 's/Date: //g'
+      date && (curl -fs --head https://google.com | grep ^Date: | sed 's/Date: //g' || true)
 
 after_success:
   - >

--- a/src/ci/docker/scripts/android-ndk.sh
+++ b/src/ci/docker/scripts/android-ndk.sh
@@ -15,7 +15,7 @@ URL=https://dl.google.com/android/repository
 download_ndk() {
     mkdir -p /android/ndk
     cd /android/ndk
-    curl -O $URL/$1
+    curl -sO $URL/$1
     unzip -q $1
     rm $1
     mv android-ndk-* ndk

--- a/src/ci/docker/scripts/android-sdk.sh
+++ b/src/ci/docker/scripts/android-sdk.sh
@@ -15,7 +15,7 @@ URL=https://dl.google.com/android/repository
 download_sdk() {
     mkdir -p /android/sdk
     cd /android/sdk
-    curl -O $URL/$1
+    curl -sO $URL/$1
     unzip -q $1
     rm -rf $1
 }

--- a/src/ci/docker/scripts/crosstool-ng.sh
+++ b/src/ci/docker/scripts/crosstool-ng.sh
@@ -11,7 +11,7 @@
 set -ex
 
 url="http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.22.0.tar.bz2"
-curl $url | tar xjf -
+curl -s $url | tar xjf -
 cd crosstool-ng
 ./configure --prefix=/usr/local
 make -j$(nproc)

--- a/src/ci/docker/scripts/dumb-init.sh
+++ b/src/ci/docker/scripts/dumb-init.sh
@@ -10,6 +10,6 @@
 
 set -ex
 
-curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb
+curl -sOL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb
 dpkg -i dumb-init_*.deb
 rm dumb-init_*.deb

--- a/src/ci/docker/scripts/emscripten-wasm.sh
+++ b/src/ci/docker/scripts/emscripten-wasm.sh
@@ -28,14 +28,14 @@ exit 1
 }
 
 # Download last known good emscripten from WebAssembly waterfall
-BUILD=$(curl -L https://storage.googleapis.com/wasm-llvm/builds/linux/lkgr.json | \
+BUILD=$(curl -sL https://storage.googleapis.com/wasm-llvm/builds/linux/lkgr.json | \
     jq '.build | tonumber')
-curl -L https://storage.googleapis.com/wasm-llvm/builds/linux/$BUILD/wasm-binaries.tbz2 | \
+curl -sL https://storage.googleapis.com/wasm-llvm/builds/linux/$BUILD/wasm-binaries.tbz2 | \
     hide_output tar xvkj
 
 # node 8 is required to run wasm
 cd /
-curl -L https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-x64.tar.xz | \
+curl -sL https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-x64.tar.xz | \
     tar -xJ
 
 # Make emscripten use wasm-ready node and LLVM tools

--- a/src/ci/docker/scripts/emscripten.sh
+++ b/src/ci/docker/scripts/emscripten.sh
@@ -28,7 +28,7 @@ exit 1
 }
 
 cd /
-curl -L https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz | \
+curl -sL https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz | \
     tar -xz
 
 cd /emsdk-portable
@@ -49,5 +49,5 @@ chmod a+rxw -R /emsdk-portable
 
 # node 8 is required to run wasm
 cd /
-curl -L https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-x64.tar.xz | \
+curl -sL https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-x64.tar.xz | \
   tar -xJ

--- a/src/ci/docker/scripts/make3.sh
+++ b/src/ci/docker/scripts/make3.sh
@@ -10,7 +10,7 @@
 
 set -ex
 
-curl https://ftp.gnu.org/gnu/make/make-3.81.tar.gz | tar xzf -
+curl -s https://ftp.gnu.org/gnu/make/make-3.81.tar.gz | tar xzf -
 cd make-3.81
 ./configure --prefix=/usr
 make

--- a/src/ci/docker/scripts/sccache.sh
+++ b/src/ci/docker/scripts/sccache.sh
@@ -10,7 +10,7 @@
 
 set -ex
 
-curl -o /usr/local/bin/sccache \
+curl -so /usr/local/bin/sccache \
   https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-05-12-sccache-x86_64-unknown-linux-musl
 
 chmod +x /usr/local/bin/sccache


### PR DESCRIPTION
Use the `-f` flag to indicate that, for example, a 500 response code is to be
considered a failure, triggering the normal retry logic. Also ignore errors
where we check the date from google.com, as a failure there shouldn't fail the
build.