### PR TITLE
configure: allow distros to disable debuginfo-only-std

### DIFF
--- a/configure
+++ b/configure
@@ -560,8 +560,8 @@ case "$CFG_RELEASE_CHANNEL" in
           *-pc-windows-gnu)
             ;;
           *)
-            CFG_ENABLE_DEBUGINFO_LINES=1
-            CFG_ENABLE_DEBUGINFO_ONLY_STD=1
+            enable_if_not_disabled debuginfo-lines
+            enable_if_not_disabled debuginfo-only-std
             ;;
         esac
 
@@ -572,8 +572,8 @@ case "$CFG_RELEASE_CHANNEL" in
           *-pc-windows-gnu)
             ;;
           *)
-            CFG_ENABLE_DEBUGINFO_LINES=1
-            CFG_ENABLE_DEBUGINFO_ONLY_STD=1
+            enable_if_not_disabled debuginfo-lines
+            enable_if_not_disabled debuginfo-only-std
             ;;
         esac
 	;;


### PR DESCRIPTION
This allows builders to generate debugging information for everything, even in a stable release build. This is useful for distros like Fedora (already carrying a [similar patch](https://src.fedoraproject.org/cgit/rpms/rust.git/tree/rust-1.16.0-configure-no-override.patch)) and Debian that automatically put all debuginfo in separate "debug symbol" packages.

This commit preserves the default behaviour of switching these on when a non-dev channel is selected, but allows the user to override this via the `./configure` command line.

In theory, one could also do this via `bootstrap/config.toml` but it doesn't work currently due to #43295.
