### PR TITLE
powerpc: Ignore the stack-probes test

### DIFF
--- a/src/test/codegen/stack-probes.rs
+++ b/src/test/codegen/stack-probes.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-arm
+// ignore-powerpc
 // ignore-wasm
 // ignore-emscripten
 // ignore-windows


### PR DESCRIPTION
One little step further to have the test working fine on power8 :)