### PR TITLE
[LLVM] Fix an assertion when a weak symbol is defined in global_asm.

### DIFF
--- a/src/rustllvm/llvm-rebuild-trigger
+++ b/src/rustllvm/llvm-rebuild-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be (optionally) cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2017-07-12
+2017-07-18


### PR DESCRIPTION
This change will fix the issue from
https://github.com/japaric/svd2rust/pull/130

cc @japaric 
r? @alexcrichton 
