### PR TITLE
float_bits_conv made it into 1.20

### DIFF
--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -1094,7 +1094,7 @@ impl f32 {
     /// assert_eq!((12.5f32).to_bits(), 0x41480000);
     ///
     /// ```
-    #[stable(feature = "float_bits_conv", since = "1.21.0")]
+    #[stable(feature = "float_bits_conv", since = "1.20.0")]
     #[inline]
     pub fn to_bits(self) -> u32 {
         unsafe { ::mem::transmute(self) }
@@ -1125,7 +1125,7 @@ impl f32 {
     /// let snan = 0x7F800001;
     /// assert_ne!(f32::from_bits(snan).to_bits(), snan);
     /// ```
-    #[stable(feature = "float_bits_conv", since = "1.21.0")]
+    #[stable(feature = "float_bits_conv", since = "1.20.0")]
     #[inline]
     pub fn from_bits(mut v: u32) -> Self {
         const EXP_MASK: u32   = 0x7F800000;

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -1009,7 +1009,7 @@ impl f64 {
     /// assert_eq!((12.5f64).to_bits(), 0x4029000000000000);
     ///
     /// ```
-    #[stable(feature = "float_bits_conv", since = "1.21.0")]
+    #[stable(feature = "float_bits_conv", since = "1.20.0")]
     #[inline]
     pub fn to_bits(self) -> u64 {
         unsafe { ::mem::transmute(self) }
@@ -1040,7 +1040,7 @@ impl f64 {
     /// let snan = 0x7FF0000000000001;
     /// assert_ne!(f64::from_bits(snan).to_bits(), snan);
     /// ```
-    #[stable(feature = "float_bits_conv", since = "1.21.0")]
+    #[stable(feature = "float_bits_conv", since = "1.20.0")]
     #[inline]
     pub fn from_bits(mut v: u64) -> Self {
         const EXP_MASK: u64   = 0x7FF0000000000000;


### PR DESCRIPTION
It seems that my PR to stabilize the `float_bits_conv` feature got merged before beta branched, which means I'm lucky, and the stabilization makes it into Rust 1.20. As it was against my expectations, the version number has to be corrected from 1.21 to 1.20.

Please also apply this PR to the beta branch.