### PR TITLE
Less verbose output for unused arguments 

### DIFF
--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -798,9 +798,13 @@ pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt,
             } else {
                 let mut diag = cx.ecx.struct_span_err(cx.fmtsp,
                     "multiple unused formatting arguments");
-                for (sp, msg) in errs {
-                    diag.span_note(sp, msg);
+
+                // Ignoring message, as it gets repetitive
+                // Then use MultiSpan to not clutter up errors
+                for (sp, _) in errs {
+                    diag.span_label(sp, "unused");
                 }
+
                 diag
             }
         };

--- a/src/test/ui/macros/format-foreign.stderr
+++ b/src/test/ui/macros/format-foreign.stderr
@@ -2,23 +2,12 @@ error: multiple unused formatting arguments
   --> $DIR/format-foreign.rs:12:5
    |
 12 |     println!("%.*3$s %s!/n", "Hello,", "World", 4);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^--------^^-------^^-^^
+   |                              |         |        |
+   |                              |         |        unused
+   |                              |         unused
+   |                              unused
    |
-note: argument never used
-  --> $DIR/format-foreign.rs:12:30
-   |
-12 |     println!("%.*3$s %s!/n", "Hello,", "World", 4);
-   |                              ^^^^^^^^
-note: argument never used
-  --> $DIR/format-foreign.rs:12:40
-   |
-12 |     println!("%.*3$s %s!/n", "Hello,", "World", 4);
-   |                                        ^^^^^^^
-note: argument never used
-  --> $DIR/format-foreign.rs:12:49
-   |
-12 |     println!("%.*3$s %s!/n", "Hello,", "World", 4);
-   |                                                 ^
    = help: `%.*3$s` should be written as `{:.2$}`
    = help: `%s` should be written as `{}`
    = note: printf formatting not supported; see the documentation for `std::fmt`

--- a/src/test/ui/macros/format-unused-lables.rs
+++ b/src/test/ui/macros/format-unused-lables.rs
@@ -1,0 +1,27 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    println!("Test", 123, 456, 789);
+
+    println!("Test2",
+        123,
+        456,
+        789
+    );
+
+    println!("Some stuff", UNUSED="args");
+
+    println!("Some more $STUFF",
+        "woo!",
+            STUFF=
+       "things"
+             , UNUSED="args");
+}

--- a/src/test/ui/macros/format-unused-lables.stderr
+++ b/src/test/ui/macros/format-unused-lables.stderr
@@ -1,0 +1,53 @@
+error: multiple unused formatting arguments
+  --> $DIR/format-unused-lables.rs:12:5
+   |
+12 |     println!("Test", 123, 456, 789);
+   |     ^^^^^^^^^^^^^^^^^---^^---^^---^^
+   |                      |    |    |
+   |                      |    |    unused
+   |                      |    unused
+   |                      unused
+   |
+   = note: this error originates in a macro outside of the current crate
+
+error: multiple unused formatting arguments
+  --> $DIR/format-unused-lables.rs:14:5
+   |
+14 | /     println!("Test2",
+15 | |         123,
+   | |         --- unused
+16 | |         456,
+   | |         --- unused
+17 | |         789
+   | |         --- unused
+18 | |     );
+   | |______^
+   |
+   = note: this error originates in a macro outside of the current crate
+
+error: named argument never used
+  --> $DIR/format-unused-lables.rs:20:35
+   |
+20 |     println!("Some stuff", UNUSED="args");
+   |                                   ^^^^^^
+
+error: multiple unused formatting arguments
+  --> $DIR/format-unused-lables.rs:22:5
+   |
+22 | /     println!("Some more $STUFF",
+23 | |         "woo!",
+   | |         ------ unused
+24 | |             STUFF=
+25 | |        "things"
+   | |        -------- unused
+26 | |              , UNUSED="args");
+   | |_______________________------_^
+   |                         |
+   |                         unused
+   |
+   = help: `$STUFF` should be written as `{STUFF}`
+   = note: shell formatting not supported; see the documentation for `std::fmt`
+   = note: this error originates in a macro outside of the current crate
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Closes #37718 

This is my first contribution to rust, so sorry if I'm missing anything!

The output now looks like this:
<img width="831" alt="screen shot 2017-07-18 at 5 01 32 pm" src="https://user-images.githubusercontent.com/12972285/28347566-dbfa9962-6c05-11e7-8730-c2e8062a04cc.png">

It's not the prettiest, but whenever #41850 gets resolved, this should be able to be improved.

**EDIT:** This also does not seem
r? @Mark-Simulacrum