### PR TITLE
Provide positional information when visiting ty, substs and closure_substs in MIR

### DIFF
--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -17,7 +17,7 @@ use rustc::hir::def_id::DefId;
 use rustc::middle::region::CodeExtent;
 use rustc::mir::*;
 use rustc::mir::transform::MirSource;
-use rustc::mir::visit::MutVisitor;
+use rustc::mir::visit::{MutVisitor, PositionalInfo};
 use rustc::ty::{self, Ty, TyCtxt};
 use rustc::ty::subst::Substs;
 use rustc::util::nodemap::NodeMap;
@@ -143,7 +143,7 @@ struct GlobalizeMir<'a, 'gcx: 'a> {
 }
 
 impl<'a, 'gcx: 'tcx, 'tcx> MutVisitor<'tcx> for GlobalizeMir<'a, 'gcx> {
-    fn visit_ty(&mut self, ty: &mut Ty<'tcx>) {
+    fn visit_ty(&mut self, ty: &mut Ty<'tcx>, _: PositionalInfo) {
         if let Some(lifted) = self.tcx.lift(ty) {
             *ty = lifted;
         } else {
@@ -153,7 +153,7 @@ impl<'a, 'gcx: 'tcx, 'tcx> MutVisitor<'tcx> for GlobalizeMir<'a, 'gcx> {
         }
     }
 
-    fn visit_substs(&mut self, substs: &mut &'tcx Substs<'tcx>) {
+    fn visit_substs(&mut self, substs: &mut &'tcx Substs<'tcx>, _: Location) {
         if let Some(lifted) = self.tcx.lift(substs) {
             *substs = lifted;
         } else {

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -17,7 +17,7 @@ use rustc::hir::def_id::DefId;
 use rustc::middle::region::CodeExtent;
 use rustc::mir::*;
 use rustc::mir::transform::MirSource;
-use rustc::mir::visit::{MutVisitor, PositionalInfo};
+use rustc::mir::visit::{MutVisitor, Lookup};
 use rustc::ty::{self, Ty, TyCtxt};
 use rustc::ty::subst::Substs;
 use rustc::util::nodemap::NodeMap;
@@ -143,7 +143,7 @@ struct GlobalizeMir<'a, 'gcx: 'a> {
 }
 
 impl<'a, 'gcx: 'tcx, 'tcx> MutVisitor<'tcx> for GlobalizeMir<'a, 'gcx> {
-    fn visit_ty(&mut self, ty: &mut Ty<'tcx>, _: PositionalInfo) {
+    fn visit_ty(&mut self, ty: &mut Ty<'tcx>, _: Lookup) {
         if let Some(lifted) = self.tcx.lift(ty) {
             *ty = lifted;
         } else {

--- a/src/librustc_mir/transform/erase_regions.rs
+++ b/src/librustc_mir/transform/erase_regions.rs
@@ -15,7 +15,7 @@
 use rustc::ty::subst::Substs;
 use rustc::ty::{Ty, TyCtxt, ClosureSubsts};
 use rustc::mir::*;
-use rustc::mir::visit::MutVisitor;
+use rustc::mir::visit::{MutVisitor, PositionalInfo};
 use rustc::mir::transform::{MirPass, MirSource};
 
 struct EraseRegionsVisitor<'a, 'tcx: 'a> {
@@ -31,12 +31,12 @@ impl<'a, 'tcx> EraseRegionsVisitor<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> MutVisitor<'tcx> for EraseRegionsVisitor<'a, 'tcx> {
-    fn visit_ty(&mut self, ty: &mut Ty<'tcx>) {
+    fn visit_ty(&mut self, ty: &mut Ty<'tcx>, _: PositionalInfo) {
         let old_ty = *ty;
         *ty = self.tcx.erase_regions(&old_ty);
     }
 
-    fn visit_substs(&mut self, substs: &mut &'tcx Substs<'tcx>) {
+    fn visit_substs(&mut self, substs: &mut &'tcx Substs<'tcx>, _: Location) {
         *substs = self.tcx.erase_regions(&{*substs});
     }
 
@@ -62,7 +62,8 @@ impl<'a, 'tcx> MutVisitor<'tcx> for EraseRegionsVisitor<'a, 'tcx> {
     }
 
     fn visit_closure_substs(&mut self,
-                            substs: &mut ClosureSubsts<'tcx>) {
+                            substs: &mut ClosureSubsts<'tcx>,
+                            _: Location) {
         *substs = self.tcx.erase_regions(substs);
     }
 

--- a/src/librustc_mir/transform/erase_regions.rs
+++ b/src/librustc_mir/transform/erase_regions.rs
@@ -15,7 +15,7 @@
 use rustc::ty::subst::Substs;
 use rustc::ty::{Ty, TyCtxt, ClosureSubsts};
 use rustc::mir::*;
-use rustc::mir::visit::{MutVisitor, PositionalInfo};
+use rustc::mir::visit::{MutVisitor, Lookup};
 use rustc::mir::transform::{MirPass, MirSource};
 
 struct EraseRegionsVisitor<'a, 'tcx: 'a> {
@@ -31,7 +31,7 @@ impl<'a, 'tcx> EraseRegionsVisitor<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> MutVisitor<'tcx> for EraseRegionsVisitor<'a, 'tcx> {
-    fn visit_ty(&mut self, ty: &mut Ty<'tcx>, _: PositionalInfo) {
+    fn visit_ty(&mut self, ty: &mut Ty<'tcx>, _: Lookup) {
         let old_ty = *ty;
         *ty = self.tcx.erase_regions(&old_ty);
     }

--- a/src/librustc_passes/mir_stats.rs
+++ b/src/librustc_passes/mir_stats.rs
@@ -279,7 +279,8 @@ impl<'a, 'tcx> mir_visit::Visitor<'tcx> for StatCollector<'a, 'tcx> {
     }
 
     fn visit_closure_substs(&mut self,
-                            substs: &ClosureSubsts<'tcx>) {
+                            substs: &ClosureSubsts<'tcx>,
+                            _: Location) {
         self.record("ClosureSubsts", substs);
         self.super_closure_substs(substs);
     }


### PR DESCRIPTION
This will enable the region renumbering portion of #43234 (non-lexical lifetimes). @nikomatsakis's current plan [here](https://gist.github.com/nikomatsakis/dfc27b28cd024eb25054b52bb11082f2) shows that we need spans of the original code to create new region variables, e.g. `self.infcx.next_region_var(infer::MiscVariable(span))`. The current visitor impls did not pass positional information (`Location` in some, `Span` and `SourceInfo` for others) for all types. I did not expand this to all visits, just the ones necessary for the above-mentioned plan.