### PR TITLE
Fix overflowing_literals lint for large f32s

### DIFF
--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -10,8 +10,7 @@
 
 //! Operations and constants for 32-bits floats (`f32` type)
 
-// FIXME: MIN_VALUE and MAX_VALUE literals are parsed as -inf and inf #14353
-#![allow(overflowing_literals)]
+#![cfg_attr(stage0, allow(overflowing_literals))]
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -10,9 +10,6 @@
 
 //! Operations and constants for 64-bits floats (`f64` type)
 
-// FIXME: MIN_VALUE and MAX_VALUE literals are parsed as -inf and inf #14353
-#![allow(overflowing_literals)]
-
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use intrinsics;

--- a/src/test/compile-fail/lint-type-overflow2.rs
+++ b/src/test/compile-fail/lint-type-overflow2.rs
@@ -17,8 +17,8 @@ fn main() {
     let x2: i8 = --128; //~ error: literal out of range for i8
     //~^ error: attempt to negate with overflow
 
-    let x = -3.40282348e+38_f32; //~ error: literal out of range for f32
-    let x =  3.40282348e+38_f32; //~ error: literal out of range for f32
+    let x = -3.40282357e+38_f32; //~ error: literal out of range for f32
+    let x =  3.40282357e+38_f32; //~ error: literal out of range for f32
     let x = -1.7976931348623159e+308_f64; //~ error: literal out of range for f64
     let x =  1.7976931348623159e+308_f64; //~ error: literal out of range for f64
 }

--- a/src/test/run-pass/big-literals.rs
+++ b/src/test/run-pass/big-literals.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
-#![feature(core)]
-
 // Catch mistakes in the overflowing literals lint.
 #![deny(overflowing_literals)]
 
@@ -21,4 +18,9 @@ pub fn main() {
     assert_eq!(18446744073709551615, (!0 as u64));
 
     assert_eq!((-2147483648i32).wrapping_sub(1), 2147483647);
+
+    assert_eq!(-3.40282356e+38_f32, ::std::f32::MIN);
+    assert_eq!(3.40282356e+38_f32, ::std::f32::MAX);
+    assert_eq!(-1.7976931348623158e+308_f64, ::std::f64::MIN);
+    assert_eq!(1.7976931348623158e+308_f64, ::std::f64::MAX);
 }


### PR DESCRIPTION
Float literals need to be parsed as the correct type so they can be
rounded correctly.