### PR TITLE
[WIP] Add lint for int to ptr cast

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1245,23 +1245,20 @@ impl LintPass for IntToPtrCast {
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for IntToPtrCast {
     fn check_expr(&mut self, ctx: &LateContext, expr: &hir::Expr) {
         if let hir::ExprCast(ref source, _) = expr.node {
-            match ctx.tables.cast_kinds.get(&source.id) {
-                Some(&CastKind::AddrPtrCast) => {
-                    let source_ty = &ctx.tables.expr_ty(&source).sty;
-                    match source_ty {
-                        &ty::TyInt(ast::IntTy::Is) |
-                        &ty::TyUint(ast::UintTy::Us) => {},
-                        &ty::TyInt(_) |
-                        &ty::TyUint(_) => {
-                            ctx.span_lint(
-                                INT_TO_PTR_CAST,
-                                expr.span,
-                                "casting from a different-size integer to a pointer");
-                        },
-                        _ => {},
-                    };
-                },
-                _ => {},
+            if let Some(&CastKind::AddrPtrCast) = ctx.tables.cast_kinds.get(&source.id) {
+                let source_ty = &ctx.tables.expr_ty(&source).sty;
+                match source_ty {
+                    &ty::TyInt(ast::IntTy::Is) |
+                    &ty::TyUint(ast::UintTy::Us) => {},
+                    &ty::TyInt(_) |
+                    &ty::TyUint(_) => {
+                        ctx.span_lint(
+                            INT_TO_PTR_CAST,
+                            expr.span,
+                            "casting from a different-size integer to a pointer");
+                    },
+                    _ => {},
+                };
             }
         }
     }

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -141,6 +141,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
                  PluginAsLibrary,
                  MutableTransmutes,
                  UnionsWithDropFields,
+                 IntToPtrCast,
                  );
 
     add_builtin_with_new!(sess,

--- a/src/libstd/sys/windows/backtrace/mod.rs
+++ b/src/libstd/sys/windows/backtrace/mod.rs
@@ -95,8 +95,8 @@ pub fn unwind_backtrace(frames: &mut [Frame])
                frame.AddrReturn.Offset == 0 { break }
 
             frames[i] = Frame {
-                symbol_addr: (addr - 1) as *const c_void,
-                exact_position: (addr - 1) as *const c_void,
+                symbol_addr: (addr - 1) as usize as *const c_void,
+                exact_position: (addr - 1) as usize as *const c_void,
             };
             i += 1;
         }

--- a/src/libstd/sys/windows/net.rs
+++ b/src/libstd/sys/windows/net.rs
@@ -282,7 +282,7 @@ impl Socket {
 
     fn set_no_inherit(&self) -> io::Result<()> {
         sys::cvt(unsafe {
-            c::SetHandleInformation(self.0 as c::HANDLE,
+            c::SetHandleInformation(self.0 as usize as c::HANDLE,
                                     c::HANDLE_FLAG_INHERIT, 0)
         }).map(|_| ())
     }

--- a/src/libstd/sys_common/at_exit_imp.rs
+++ b/src/libstd/sys_common/at_exit_imp.rs
@@ -48,7 +48,7 @@ pub fn cleanup() {
         unsafe {
             LOCK.lock();
             let queue = QUEUE;
-            QUEUE = if i == ITERS - 1 {1} else {0} as *mut _;
+            QUEUE = if i == ITERS - 1 {1usize} else {0usize} as *mut _;
             LOCK.unlock();
 
             // make sure we're not recursively cleaning up


### PR DESCRIPTION
Fixes #42915 

First commit adds the lint, the second commit fixes the lint warnings in the compiler on Windows. More sure to follow for other platforms.

[WIP] because we should wait for the decision about https://github.com/rust-lang/rust/issues/43291 to determine what message we use. Specifically, if it's decided that those strange casts can't/won't be fixed, the message should warn that these casts don't sign-extend as expected unless you go through {u,i}size.

Edit: Also we should consider the interaction this lint can/should have with the [portability lint RFC](https://github.com/rust-lang/rfcs/pull/1868) (unimplemented right now), and if it requires an RFC of its own like https://github.com/rust-lang/rfcs/pull/1782. I hadn't considered that adding a lint would require an RFC.

If #43291 does get fixed, we may want this lint to only apply to {i,u}8 as those cases are much more likely to be bugs than false positives compared to the other integer types.

I should also probably add a `NOTE: try {expr} as usize as *const`
