### PR TITLE
Pass debugging arguments to emcc

### DIFF
--- a/src/librustc_back/target/wasm32_experimental_emscripten.rs
+++ b/src/librustc_back/target/wasm32_experimental_emscripten.rs
@@ -18,7 +18,10 @@ pub fn target() -> Result<Target, String> {
                           vec!["-s".to_string(),
                                "WASM=1".to_string(),
                                "-s".to_string(),
-                               "ERROR_ON_UNDEFINED_SYMBOLS=1".to_string()]);
+                               "ASSERTIONS=1".to_string(),
+                               "-s".to_string(),
+                               "ERROR_ON_UNDEFINED_SYMBOLS=1".to_string(),
+                               "-g3".to_string()]);
 
     let opts = TargetOptions {
         linker: cmd("emcc"),


### PR DESCRIPTION
Tells emcc to enable assertions and debugging information for
wasm32-experimental-emscripten. This makes the codegen issues caused by
LLVM bug 33824 manifest more frequently at runtime and improves the wasm
debugging experience.