### PR TITLE
For small types, just swap directly

### DIFF
--- a/src/libcore/tests/mem.rs
+++ b/src/libcore/tests/mem.rs
@@ -89,6 +89,13 @@ fn test_swap() {
     swap(&mut x, &mut y);
     assert_eq!(x, 42);
     assert_eq!(y, 31337);
+
+    // A bigger one to hit the SIMD loop
+    let mut x = [1u64, 2, 3, 4, 5, 6, 7, 8];
+    let mut y = [11, 12, 13, 14, 15, 16, 17, 18];
+    swap(&mut x, &mut y);
+    assert_eq!(x, [11, 12, 13, 14, 15, 16, 17, 18]);
+    assert_eq!(y, [1, 2, 3, 4, 5, 6, 7, 8]);
 }
 
 #[test]


### PR DESCRIPTION
In `mem::swap`, don't `ptr::swap_nonoverlapping` for things smaller than its block size.  That lets debug mode not run the simd loop and means the load/store instructions in release are generated with full alignment information.  (Swap on u64 in stable has align 8, but [in nightly it has align 1](https://play.rust-lang.org/?gist=10ca383a1737fac699a1a820e34dfe59&version=nightly).)

Inspired by @oyvindln in https://github.com/rust-lang/rust/issues/43299#issuecomment-316222855.