### PR TITLE
Remove unused DefPathTable::retrace_path()

### DIFF
--- a/src/librustc/hir/def_id.rs
+++ b/src/librustc/hir/def_id.rs
@@ -136,6 +136,10 @@ impl DefIndex {
     pub fn as_array_index(&self) -> usize {
         (self.0 & !DEF_INDEX_HI_START.0) as usize
     }
+
+    pub fn from_array_index(i: usize, address_space: DefIndexAddressSpace) -> DefIndex {
+        DefIndex::new(address_space.start() + i)
+    }
 }
 
 /// The start of the "high" range of DefIndexes.

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -17,7 +17,7 @@ pub use self::definitions::{Definitions, DefKey, DefPath, DefPathData,
 
 use dep_graph::{DepGraph, DepNode, DepKind};
 
-use hir::def_id::{CRATE_DEF_INDEX, DefId, DefIndex, DefIndexAddressSpace};
+use hir::def_id::{CRATE_DEF_INDEX, DefId, DefIndexAddressSpace};
 
 use syntax::abi::Abi;
 use syntax::ast::{self, Name, NodeId, CRATE_NODE_ID};
@@ -375,10 +375,6 @@ impl<'hir> Map<'hir> {
     pub fn def_path(&self, def_id: DefId) -> DefPath {
         assert!(def_id.is_local());
         self.definitions.def_path(def_id.index)
-    }
-
-    pub fn def_index_for_def_key(&self, def_key: DefKey) -> Option<DefIndex> {
-        self.definitions.def_index_for_def_key(def_key)
     }
 
     pub fn local_def_id(&self, node: NodeId) -> DefId {

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -25,8 +25,7 @@
 use hir::def;
 use hir::def_id::{CrateNum, DefId, DefIndex};
 use hir::map as hir_map;
-use hir::map::definitions::{Definitions, DefKey, DisambiguatedDefPathData,
-                            DefPathTable};
+use hir::map::definitions::{Definitions, DefKey, DefPathTable};
 use hir::svh::Svh;
 use ich;
 use middle::lang_items;
@@ -269,10 +268,6 @@ pub trait CrateStore {
     fn is_no_builtins(&self, cnum: CrateNum) -> bool;
 
     // resolve
-    fn retrace_path(&self,
-                    cnum: CrateNum,
-                    path_data: &[DisambiguatedDefPathData])
-                    -> Option<DefId>;
     fn def_key(&self, def: DefId) -> DefKey;
     fn def_path(&self, def: DefId) -> hir_map::DefPath;
     fn def_path_hash(&self, def: DefId) -> hir_map::DefPathHash;
@@ -392,13 +387,6 @@ impl CrateStore for DummyCrateStore {
     fn is_no_builtins(&self, cnum: CrateNum) -> bool { bug!("is_no_builtins") }
 
     // resolve
-    fn retrace_path(&self,
-                    cnum: CrateNum,
-                    path_data: &[DisambiguatedDefPathData])
-                    -> Option<DefId> {
-        None
-    }
-
     fn def_key(&self, def: DefId) -> DefKey { bug!("def_key") }
     fn def_path(&self, def: DefId) -> hir_map::DefPath {
         bug!("relative_def_path")

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -18,7 +18,7 @@ use hir::TraitMap;
 use hir::def::{Def, ExportMap};
 use hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use hir::map as hir_map;
-use hir::map::{DisambiguatedDefPathData, DefPathHash};
+use hir::map::DefPathHash;
 use middle::free_region::FreeRegionMap;
 use middle::lang_items;
 use middle::resolve_lifetime;
@@ -567,23 +567,6 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             self.sess.local_crate_disambiguator()
         } else {
             self.sess.cstore.crate_disambiguator(cnum)
-        }
-    }
-
-    pub fn retrace_path(self,
-                        krate: CrateNum,
-                        path_data: &[DisambiguatedDefPathData])
-                        -> Option<DefId> {
-        debug!("retrace_path(path={:?}, krate={:?})", path_data, self.crate_name(krate));
-
-        if krate == LOCAL_CRATE {
-            self.hir
-                .definitions()
-                .def_path_table()
-                .retrace_path(path_data)
-                .map(|def_index| DefId { krate: krate, index: def_index })
-        } else {
-            self.sess.cstore.retrace_path(krate, path_data)
         }
     }
 

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -22,7 +22,7 @@ use rustc::session::Session;
 use rustc::ty::{self, TyCtxt};
 use rustc::ty::maps::Providers;
 use rustc::hir::def_id::{CrateNum, DefId, DefIndex, CRATE_DEF_INDEX, LOCAL_CRATE};
-use rustc::hir::map::{DefKey, DefPath, DisambiguatedDefPathData, DefPathHash};
+use rustc::hir::map::{DefKey, DefPath, DefPathHash};
 use rustc::hir::map::blocks::FnLikeNode;
 use rustc::hir::map::definitions::{DefPathTable, GlobalMetaDataKind};
 use rustc::util::nodemap::{NodeSet, DefIdMap};
@@ -305,16 +305,6 @@ impl CrateStore for cstore::CStore {
 
     fn is_no_builtins(&self, cnum: CrateNum) -> bool {
         self.get_crate_data(cnum).is_no_builtins(&self.dep_graph)
-    }
-
-    fn retrace_path(&self,
-                    cnum: CrateNum,
-                    path: &[DisambiguatedDefPathData])
-                    -> Option<DefId> {
-        let cdata = self.get_crate_data(cnum);
-        cdata.def_path_table
-             .retrace_path(&path)
-             .map(|index| DefId { krate: cnum, index: index })
     }
 
     /// Returns the `DefKey` for a given `DefId`. This indicates the


### PR DESCRIPTION
`DefPathTable::retrace_path()` is not used anymore for a while now and removing it also removes the need to build the costly `DefPathTable::key_to_index` map for every upstream crate.

cc #43300 

r? @eddyb 