### PR TITLE
Adding `+` sign to static lifetime help message

### DIFF
--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -847,7 +847,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                                                "{} may not live long enough",
                                                labeled_user_string);
                 err.help(&format!("consider adding an explicit lifetime \
-                                   bound `{}: 'static`...",
+                                   bound `{}: 'static + `...",
                                   bound_kind));
                 err
             }


### PR DESCRIPTION
Hey guys,

First of all, this is my first contribution to Rust. I tried to read the guidelines and I think this PR conform to the rules. 

This simple change makes the help message of `static` lifetime a bit clearer. I believe the help message should say `T: 'static + ...` instead of `T: 'static ...`. 

Please let me know if you need me to add more details and sorry if this change sounds silly to you guys :) 