### PR TITLE
Fix docs: BufReader/File doesn't need to be mut

### DIFF
--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -37,7 +37,7 @@ use memchr;
 /// use std::fs::File;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// let mut f = File::open("log.txt")?;
+/// let f = File::open("log.txt")?;
 /// let mut reader = BufReader::new(f);
 ///
 /// let mut line = String::new();
@@ -64,8 +64,8 @@ impl<R: Read> BufReader<R> {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut f = File::open("log.txt")?;
-    /// let mut reader = BufReader::new(f);
+    /// let f = File::open("log.txt")?;
+    /// let reader = BufReader::new(f);
     /// # Ok(())
     /// # }
     /// ```
@@ -85,8 +85,8 @@ impl<R: Read> BufReader<R> {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut f = File::open("log.txt")?;
-    /// let mut reader = BufReader::with_capacity(10, f);
+    /// let f = File::open("log.txt")?;
+    /// let reader = BufReader::with_capacity(10, f);
     /// # Ok(())
     /// # }
     /// ```
@@ -116,8 +116,8 @@ impl<R: Read> BufReader<R> {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut f1 = File::open("log.txt")?;
-    /// let mut reader = BufReader::new(f1);
+    /// let f1 = File::open("log.txt")?;
+    /// let reader = BufReader::new(f1);
     ///
     /// let f2 = reader.get_ref();
     /// # Ok(())
@@ -137,7 +137,7 @@ impl<R: Read> BufReader<R> {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut f1 = File::open("log.txt")?;
+    /// let f1 = File::open("log.txt")?;
     /// let mut reader = BufReader::new(f1);
     ///
     /// let f2 = reader.get_mut();
@@ -158,8 +158,8 @@ impl<R: Read> BufReader<R> {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut f1 = File::open("log.txt")?;
-    /// let mut reader = BufReader::new(f1);
+    /// let f1 = File::open("log.txt")?;
+    /// let reader = BufReader::new(f1);
     ///
     /// let f2 = reader.into_inner();
     /// # Ok(())


### PR DESCRIPTION
Neither `BufReader` nor `File` need to be declared `mut` for most of these examples. The cookbook example using `BufReader` doesn't declare them as `mut` either (https://brson.github.io/rust-cookbook/basics.html#ex-std-read-lines).