### PR TITLE
Add a missing verb to the description of std::process::ExitStatus::success()

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -799,8 +799,8 @@ impl From<fs::File> for Stdio {
 pub struct ExitStatus(imp::ExitStatus);
 
 impl ExitStatus {
-    /// Was termination successful? Signal termination not considered a success,
-    /// and success is defined as a zero exit status.
+    /// Was termination successful? Signal termination is not considered a
+    /// success, and success is defined as a zero exit status.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
"Signal termination not considered" -> "Signal termination **is** not considered"

The first line of the description was rewrapped so it fits into 80 characters.