### PR TITLE
Ignore stack probe tests on AArch64

### DIFF
--- a/src/test/codegen/stack-probes.rs
+++ b/src/test/codegen/stack-probes.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-arm
+// ignore-aarch64
 // ignore-powerpc
 // ignore-wasm
 // ignore-emscripten

--- a/src/test/run-pass/stack-probes-lto.rs
+++ b/src/test/run-pass/stack-probes-lto.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-arm
+// ignore-aarch64
 // ignore-wasm
 // ignore-emscripten
 // ignore-musl FIXME #31506

--- a/src/test/run-pass/stack-probes.rs
+++ b/src/test/run-pass/stack-probes.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-arm
+// ignore-aarch64
 // ignore-wasm
 // ignore-emscripten
 // ignore-musl FIXME #31506


### PR DESCRIPTION
Stack probes are only implemented for x86, and as such currently fail on AArch64. This patch ignores those tests on this architecture.

Fixes #43356.

r? @alexcrichton 