### PR TITLE
Thread through the original error when opening archives

### DIFF
--- a/src/librustc_llvm/archive_ro.rs
+++ b/src/librustc_llvm/archive_ro.rs
@@ -39,14 +39,14 @@ impl ArchiveRO {
     ///
     /// If this archive is used with a mutable method, then an error will be
     /// raised.
-    pub fn open(dst: &Path) -> Option<ArchiveRO> {
+    pub fn open(dst: &Path) -> Result<ArchiveRO, String> {
         return unsafe {
             let s = path2cstr(dst);
             let ar = ::LLVMRustOpenArchive(s.as_ptr());
             if ar.is_null() {
-                None
+                Err(::last_error().unwrap_or("failed to open archive".to_string()))
             } else {
-                Some(ArchiveRO { ptr: ar })
+                Ok(ArchiveRO { ptr: ar })
             }
         };
 

--- a/src/librustc_trans/back/archive.rs
+++ b/src/librustc_trans/back/archive.rs
@@ -126,7 +126,7 @@ impl<'a> ArchiveBuilder<'a> {
             Some(ref src) => src,
             None => return None,
         };
-        self.src_archive = Some(ArchiveRO::open(src));
+        self.src_archive = Some(ArchiveRO::open(src).ok());
         self.src_archive.as_ref().unwrap().as_ref()
     }
 
@@ -186,9 +186,8 @@ impl<'a> ArchiveBuilder<'a> {
         where F: FnMut(&str) -> bool + 'static
     {
         let archive = match ArchiveRO::open(archive) {
-            Some(ar) => ar,
-            None => return Err(io::Error::new(io::ErrorKind::Other,
-                                              "failed to open archive")),
+            Ok(ar) => ar,
+            Err(e) => return Err(io::Error::new(io::ErrorKind::Other, e)),
         };
         self.additions.push(Addition::Archive {
             archive: archive,


### PR DESCRIPTION
This updates the management of opening archives to thread through the original
piece of error information from LLVM over to the end consumer, trans.