### PR TITLE
default binding modes: add pat_binding_modes

### DIFF
--- a/src/librustc/hir/pat_util.rs
+++ b/src/librustc/hir/pat_util.rs
@@ -87,7 +87,7 @@ impl hir::Pat {
     /// Call `f` on every "binding" in a pattern, e.g., on `a` in
     /// `match foo() { Some(a) => (), None => () }`
     pub fn each_binding<F>(&self, mut f: F)
-        where F: FnMut(hir::BindingMode, ast::NodeId, Span, &Spanned<ast::Name>),
+        where F: FnMut(hir::BindingAnnotation, ast::NodeId, Span, &Spanned<ast::Name>),
     {
         self.walk(|p| {
             if let PatKind::Binding(binding_mode, _, ref pth, _) = p.node {
@@ -130,12 +130,10 @@ impl hir::Pat {
 
     pub fn simple_name(&self) -> Option<ast::Name> {
         match self.node {
-            PatKind::Binding(hir::BindByValue(..), _, ref path1, None) => {
-                Some(path1.node)
-            }
-            _ => {
-                None
-            }
+            PatKind::Binding(hir::BindingAnnotation::Unannotated, _, ref path1, None) |
+            PatKind::Binding(hir::BindingAnnotation::Mutable, _, ref path1, None) =>
+                Some(path1.node),
+            _ => None,
         }
     }
 
@@ -163,16 +161,22 @@ impl hir::Pat {
     }
 
     /// Checks if the pattern contains any `ref` or `ref mut` bindings,
-    /// and if yes whether its containing mutable ones or just immutables ones.
-    pub fn contains_ref_binding(&self) -> Option<hir::Mutability> {
+    /// and if yes whether it contains mutable or just immutables ones.
+    ///
+    /// FIXME(tschottdorf): this is problematic as the HIR is being scraped,
+    /// but ref bindings may be implicit after #42640.
+    pub fn contains_explicit_ref_binding(&self) -> Option<hir::Mutability> {
         let mut result = None;
-        self.each_binding(|mode, _, _, _| {
-            if let hir::BindingMode::BindByRef(m) = mode {
-                // Pick Mutable as maximum
-                match result {
-                    None | Some(hir::MutImmutable) => result = Some(m),
-                    _ => (),
+        self.each_binding(|annotation, _, _, _| {
+            match annotation {
+                hir::BindingAnnotation::Ref => {
+                    match result {
+                        None | Some(hir::MutImmutable) => result = Some(hir::MutImmutable),
+                        _ => (),
+                    }
                 }
+                hir::BindingAnnotation::RefMut => result = Some(hir::MutMutable),
+                _ => (),
             }
         });
         result
@@ -182,9 +186,11 @@ impl hir::Pat {
 impl hir::Arm {
     /// Checks if the patterns for this arm contain any `ref` or `ref mut`
     /// bindings, and if yes whether its containing mutable ones or just immutables ones.
-    pub fn contains_ref_binding(&self) -> Option<hir::Mutability> {
+    pub fn contains_explicit_ref_binding(&self) -> Option<hir::Mutability> {
+        // FIXME(tschottdorf): contains_explicit_ref_binding() must be removed
+        // for #42640.
         self.pats.iter()
-                 .filter_map(|pat| pat.contains_ref_binding())
+                 .filter_map(|pat| pat.contains_explicit_ref_binding())
                  .max_by_key(|m| match *m {
                     hir::MutMutable => 1,
                     hir::MutImmutable => 0,

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -1651,12 +1651,16 @@ impl<'a> State<'a> {
             PatKind::Wild => self.s.word("_")?,
             PatKind::Binding(binding_mode, _, ref path1, ref sub) => {
                 match binding_mode {
-                    hir::BindByRef(mutbl) => {
+                    hir::BindingAnnotation::Ref => {
                         self.word_nbsp("ref")?;
-                        self.print_mutability(mutbl)?;
+                        self.print_mutability(hir::MutImmutable)?;
                     }
-                    hir::BindByValue(hir::MutImmutable) => {}
-                    hir::BindByValue(hir::MutMutable) => {
+                    hir::BindingAnnotation::RefMut => {
+                        self.word_nbsp("ref")?;
+                        self.print_mutability(hir::MutMutable)?;
+                    }
+                    hir::BindingAnnotation::Unannotated => {}
+                    hir::BindingAnnotation::Mutable => {
                         self.word_nbsp("mut")?;
                     }
                 }

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -442,9 +442,11 @@ impl_stable_hash_for!(struct hir::FieldPat {
     is_shorthand
 });
 
-impl_stable_hash_for!(enum hir::BindingMode {
-    BindByRef(mutability),
-    BindByValue(mutability)
+impl_stable_hash_for!(enum hir::BindingAnnotation {
+    Unannotated,
+    Mutable,
+    Ref,
+    RefMut
 });
 
 impl_stable_hash_for!(enum hir::RangeEnd {

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -617,6 +617,7 @@ for ty::TypeckTables<'tcx> {
             ref node_types,
             ref node_substs,
             ref adjustments,
+            ref pat_binding_modes,
             ref upvar_capture_map,
             ref closure_tys,
             ref closure_kinds,
@@ -637,6 +638,7 @@ for ty::TypeckTables<'tcx> {
             ich::hash_stable_nodemap(hcx, hasher, node_types);
             ich::hash_stable_nodemap(hcx, hasher, node_substs);
             ich::hash_stable_nodemap(hcx, hasher, adjustments);
+            ich::hash_stable_nodemap(hcx, hasher, pat_binding_modes);
             ich::hash_stable_hashmap(hcx, hasher, upvar_capture_map, |hcx, up_var_id| {
                 let ty::UpvarId {
                     var_id,

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -889,8 +889,32 @@ fn resolve_local<'a, 'tcx>(visitor: &mut RegionResolutionVisitor<'a, 'tcx>,
     ///        | ( ..., P&, ... )
     ///        | box P&
     fn is_binding_pat(pat: &hir::Pat) -> bool {
+        // Note that the code below looks for *explicit* refs only, that is, it won't
+        // know about *implicit* refs as introduced in #42640.
+        //
+        // This is not a problem. For example, consider
+        //
+        //      let (ref x, ref y) = (Foo { .. }, Bar { .. });
+        //
+        // Due to the explicit refs on the left hand side, the below code would signal
+        // that the temporary value on the right hand side should live until the end of
+        // the enclosing block (as opposed to being dropped after the let is complete).
+        //
+        // To create an implicit ref, however, you must have a borrowed value on the RHS
+        // already, as in this example (which won't compile before #42640):
+        //
+        //      let Foo { x, .. } = &Foo { x: ..., ... };
+        //
+        // in place of
+        //
+        //      let Foo { ref x, .. } = Foo { ... };
+        //
+        // In the former case (the implicit ref version), the temporary is created by the
+        // & expression, and its lifetime would be extended to the end of the block (due
+        // to a different rule, not the below code).
         match pat.node {
-            PatKind::Binding(hir::BindByRef(_), ..) => true,
+            PatKind::Binding(hir::BindingAnnotation::Ref, ..) |
+            PatKind::Binding(hir::BindingAnnotation::RefMut, ..) => true,
 
             PatKind::Struct(_, ref field_pats, _) => {
                 field_pats.iter().any(|fp| is_binding_pat(&fp.node.pat))

--- a/src/librustc/ty/binding.rs
+++ b/src/librustc/ty/binding.rs
@@ -1,0 +1,35 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use hir::BindingAnnotation::*;
+use hir::BindingAnnotation;
+use hir::Mutability;
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
+pub enum BindingMode {
+    BindByReference(Mutability),
+    BindByValue(Mutability),
+}
+
+impl BindingMode {
+    pub fn convert(ba: BindingAnnotation) -> BindingMode {
+        match ba {
+            Unannotated => BindingMode::BindByValue(Mutability::MutImmutable),
+            Mutable => BindingMode::BindByValue(Mutability::MutMutable),
+            Ref => BindingMode::BindByReference(Mutability::MutImmutable),
+            RefMut => BindingMode::BindByReference(Mutability::MutMutable),
+        }
+    }
+}
+
+impl_stable_hash_for!(enum self::BindingMode {
+    BindByReference(mutability),
+    BindByValue(mutability)
+});

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -40,6 +40,7 @@ use ty::layout::{Layout, TargetDataLayout};
 use ty::inhabitedness::DefIdForest;
 use ty::maps;
 use ty::steal::Steal;
+use ty::BindingMode;
 use util::nodemap::{NodeMap, NodeSet, DefIdSet};
 use util::nodemap::{FxHashMap, FxHashSet};
 use rustc_data_structures::accumulate_vec::AccumulateVec;
@@ -223,6 +224,9 @@ pub struct TypeckTables<'tcx> {
 
     pub adjustments: NodeMap<Vec<ty::adjustment::Adjustment<'tcx>>>,
 
+    // Stores the actual binding mode for all instances of hir::BindingAnnotation.
+    pub pat_binding_modes: NodeMap<BindingMode>,
+
     /// Borrows
     pub upvar_capture_map: ty::UpvarCaptureMap<'tcx>,
 
@@ -274,6 +278,7 @@ impl<'tcx> TypeckTables<'tcx> {
             node_types: FxHashMap(),
             node_substs: NodeMap(),
             adjustments: NodeMap(),
+            pat_binding_modes: NodeMap(),
             upvar_capture_map: FxHashMap(),
             closure_tys: NodeMap(),
             closure_kinds: NodeMap(),

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -74,6 +74,9 @@ pub use self::sty::InferTy::*;
 pub use self::sty::RegionKind::*;
 pub use self::sty::TypeVariants::*;
 
+pub use self::binding::BindingMode;
+pub use self::binding::BindingMode::*;
+
 pub use self::context::{TyCtxt, GlobalArenas, tls};
 pub use self::context::{Lift, TypeckTables};
 
@@ -84,6 +87,7 @@ pub use self::trait_def::TraitDef;
 pub use self::maps::queries;
 
 pub mod adjustment;
+pub mod binding;
 pub mod cast;
 pub mod error;
 pub mod fast_reject;

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -44,9 +44,13 @@ impl UnusedMut {
 
         let mut mutables = FxHashMap();
         for p in pats {
-            p.each_binding(|mode, id, _, path1| {
+            p.each_binding(|_, id, span, path1| {
+                let bm = match cx.tables.pat_binding_modes.get(&id) {
+                    Some(&bm) => bm,
+                    None => span_bug!(span, "missing binding mode"),
+                };
                 let name = path1.node;
-                if let hir::BindByValue(hir::MutMutable) = mode {
+                if let ty::BindByValue(hir::MutMutable) = bm {
                     if !name.as_str().starts_with("_") {
                         match mutables.entry(name) {
                             Vacant(entry) => {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2277,8 +2277,9 @@ impl<'a> Resolver<'a> {
                                                                       false, pat.span)
                                       .and_then(LexicalScopeBinding::item);
                     let resolution = binding.map(NameBinding::def).and_then(|def| {
+                        let ivmode = BindingMode::ByValue(Mutability::Immutable);
                         let always_binding = !pat_src.is_refutable() || opt_pat.is_some() ||
-                                             bmode != BindingMode::ByValue(Mutability::Immutable);
+                                             bmode != ivmode;
                         match def {
                             Def::StructCtor(_, CtorKind::Const) |
                             Def::VariantCtor(_, CtorKind::Const) |

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -410,6 +410,49 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         // is problematic as the HIR is being scraped, but ref bindings may be
         // implicit after #42640. We need to make sure that pat_adjustments
         // (once introduced) is populated by the time we get here.
+        //
+        // arielb1 [writes here in this comment thread][c] that there
+        // is certainly *some* potential danger, e.g. for an example
+        // like:
+        //
+        // [c]: https://github.com/rust-lang/rust/pull/43399#discussion_r130223956
+        //
+        // ```
+        // let Foo(x) = f()[0];
+        // ```
+        //
+        // Then if the pattern matches by reference, we want to match
+        // `f()[0]` as a lexpr, so we can't allow it to be
+        // coerced. But if the pattern matches by value, `f()[0]` is
+        // still syntactically a lexpr, but we *do* want to allow
+        // coercions.
+        //
+        // However, *likely* we are ok with allowing coercions to
+        // happen if there are no explicit ref mut patterns - all
+        // implicit ref mut patterns must occur behind a reference, so
+        // they will have the "correct" variance and lifetime.
+        //
+        // This does mean that the following pattern would be legal:
+        //
+        // ```
+        // struct Foo(Bar);
+        // struct Bar(u32);
+        // impl Deref for Foo {
+        //     type Target = Bar;
+        //     fn deref(&self) -> &Bar { &self.0 }
+        // }
+        // impl DerefMut for Foo {
+        //     fn deref_mut(&mut self) -> &mut Bar { &mut self.0 }
+        // }
+        // fn foo(x: &mut Foo) {
+        //     {
+        //         let Bar(z): &mut Bar = x;
+        //         *z = 42;
+        //     }
+        //     assert_eq!(foo.0.0, 42);
+        // }
+        // ```
+
         let contains_ref_bindings = arms.iter()
                                         .filter_map(|a| a.contains_explicit_ref_binding())
                                         .max_by_key(|m| match *m {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3999,7 +3999,9 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                   local: &'gcx hir::Local,
                                   init: &'gcx hir::Expr) -> Ty<'tcx>
     {
-        let ref_bindings = local.pat.contains_ref_binding();
+        // FIXME(tschottdorf): contains_explicit_ref_binding() must be removed
+        // for #42640.
+        let ref_bindings = local.pat.contains_explicit_ref_binding();
 
         let local_ty = self.local_ty(init.span, local.id);
         if let Some(m) = ref_bindings {

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -1196,9 +1196,13 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
             mc.cat_pattern(discr_cmt, root_pat, |sub_cmt, sub_pat| {
                 match sub_pat.node {
                     // `ref x` pattern
-                    PatKind::Binding(hir::BindByRef(mutbl), ..) => {
-                        self.link_region_from_node_type(sub_pat.span, sub_pat.id,
-                                                        mutbl, sub_cmt);
+                    PatKind::Binding(..) => {
+                        let bm = *mc.tables.pat_binding_modes.get(&sub_pat.id)
+                                                             .expect("missing binding mode");
+                        if let ty::BindByReference(mutbl) = bm {
+                            self.link_region_from_node_type(sub_pat.span, sub_pat.id,
+                                                            mutbl, sub_cmt);
+                        }
                     }
                     _ => {}
                 }

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -178,6 +178,15 @@ impl<'cx, 'gcx, 'tcx> Visitor<'gcx> for WritebackCx<'cx, 'gcx, 'tcx> {
     }
 
     fn visit_pat(&mut self, p: &'gcx hir::Pat) {
+        match p.node {
+            hir::PatKind::Binding(..) => {
+                let bm = *self.fcx.tables.borrow().pat_binding_modes.get(&p.id)
+                                                                    .expect("missing binding mode");
+                self.tables.pat_binding_modes.insert(p.id, bm);
+            }
+            _ => {}
+        };
+
         self.visit_node_id(p.span, p.id);
         intravisit::walk_pat(self, p);
     }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -867,13 +867,14 @@ mod tests {
                                     pat: P(ast::Pat {
                                         id: ast::DUMMY_NODE_ID,
                                         node: PatKind::Ident(
-                                            ast::BindingMode::ByValue(ast::Mutability::Immutable),
-                                                Spanned{
-                                                    span: sp(6,7),
-                                                    node: Ident::from_str("b")},
-                                                None
-                                                    ),
-                                            span: sp(6,7)
+                                            ast::BindingMode::ByValue(
+                                                ast::Mutability::Immutable),
+                                            Spanned{
+                                                span: sp(6,7),
+                                                node: Ident::from_str("b")},
+                                            None
+                                        ),
+                                        span: sp(6,7)
                                     }),
                                         id: ast::DUMMY_NODE_ID
                                     }],


### PR DESCRIPTION
This PR kicks off the implementation of the [default binding modes RFC][1] by
introducing the `pat_binding_modes` typeck table mentioned in the [mentoring
instructions][2].

It is a WIP because I wasn't able to avoid all uses of the binding modes as
not all call sites are close enough to the typeck tables. I added marker
comments to any line matching `BindByRef|BindByValue` so that reviewers
are aware of all of them.

I will look into changing the HIR (as suggested in [2]) to not carry a
`BindingMode` unless one was explicitly specified, but this PR is good for
a first round of comments.

The actual changes are quite small and CI will fail due to overlong lines
caused by the marker comments.

See #42640.

cc @nikomatsakis

[1]: https://github.com/rust-lang/rfcs/pull/2005
[2]: https://github.com/rust-lang/rust/issues/42640#issuecomment-313535089