### PR TITLE
Add missing `!: Clone` impl

### DIFF
--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -165,6 +165,7 @@ clone_impl! { u128 }
 clone_impl! { f32 }
 clone_impl! { f64 }
 
+clone_impl! { ! }
 clone_impl! { () }
 clone_impl! { bool }
 clone_impl! { char }


### PR DESCRIPTION
Fixes #43296 

(untested because I'm having computer troubles, but a one-liner can't break anything right?)