### PR TITLE
Lambda expressions honor no struct literal restriction

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3073,7 +3073,10 @@ impl<'a> Parser<'a> {
         let decl = self.parse_fn_block_decl()?;
         let decl_hi = self.prev_span;
         let body = match decl.output {
-            FunctionRetTy::Default(_) => self.parse_expr()?,
+            FunctionRetTy::Default(_) => {
+                let restrictions = self.restrictions - RESTRICTION_STMT_EXPR;
+                self.parse_expr_res(restrictions, None)?
+            },
             _ => {
                 // If an explicit return type is given, require a
                 // block to appear (RFC 968).

--- a/src/test/parse-fail/struct-literal-restrictions-in-lamda.rs
+++ b/src/test/parse-fail/struct-literal-restrictions-in-lamda.rs
@@ -1,0 +1,29 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z parse-only
+
+struct Foo {
+    x: isize,
+}
+
+impl Foo {
+    fn hi(&self) -> bool {
+        true
+    }
+}
+
+fn main() {
+    while || Foo {
+        x: 3    //~ ERROR expected type, found `3`
+    }.hi() { //~ ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `{`
+        println!("yo");
+    }
+}

--- a/src/test/run-pass/semistatement-in-lambda.rs
+++ b/src/test/run-pass/semistatement-in-lambda.rs
@@ -1,0 +1,19 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+pub fn main() {
+    // Test that lambdas behave as unary expressions with block-like expressions
+    -if true { 1 } else { 2 } * 3;
+    || if true { 1 } else { 2 } * 3;
+
+    // The following is invalid and parses as `if true { 1 } else { 2 }; *3`
+    // if true { 1 } else { 2 } * 3
+}


### PR DESCRIPTION
This is a fix for #43412 if we decide that it is indeed a bug :) 


closes #43412