### PR TITLE
Add hints when intercrate ambiguity causes overlap.

### DIFF
--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -28,9 +28,7 @@ use std::rc::Rc;
 use syntax::ast;
 use syntax_pos::{Span, DUMMY_SP};
 
-pub use self::coherence::orphan_check;
-pub use self::coherence::overlapping_impls;
-pub use self::coherence::OrphanCheckErr;
+pub use self::coherence::{orphan_check, overlapping_impls, OrphanCheckErr, OverlapResult};
 pub use self::fulfill::{FulfillmentContext, RegionObligation};
 pub use self::project::MismatchedProjectionTypes;
 pub use self::project::{normalize, normalize_projection_type, Normalized};
@@ -39,6 +37,7 @@ pub use self::object_safety::ObjectSafetyViolation;
 pub use self::object_safety::MethodViolationCode;
 pub use self::on_unimplemented::{OnUnimplementedDirective, OnUnimplementedNote};
 pub use self::select::{EvaluationCache, SelectionContext, SelectionCache};
+pub use self::select::IntercrateAmbiguityCause;
 pub use self::specialize::{OverlapError, specialization_graph, translate_substs};
 pub use self::specialize::{SpecializesCache, find_associated_item};
 pub use self::util::elaborate_predicates;

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -100,6 +100,26 @@ pub enum IntercrateAmbiguityCause {
     UpstreamCrateUpdate(DefId),
 }
 
+impl IntercrateAmbiguityCause {
+    /// Emits notes when the overlap is caused by complex intercrate ambiguities.
+    /// See #23980 for details.
+    pub fn add_intercrate_ambiguity_hint<'a, 'tcx>(&self,
+                                                   tcx: TyCtxt<'a, 'tcx, 'tcx>,
+                                                   err: &mut ::errors::DiagnosticBuilder) {
+        match self {
+            &IntercrateAmbiguityCause::DownstreamCrate(def_id) => {
+                err.note(&format!("downstream crates may implement `{}`",
+                                  tcx.item_path_str(def_id)));
+            }
+            &IntercrateAmbiguityCause::UpstreamCrateUpdate(def_id) => {
+                err.note(&format!("upstream crates may add new impl for `{}` \
+                                  in future versions",
+                                  tcx.item_path_str(def_id)));
+            }
+        }
+    }
+}
+
 // A stack that walks back up the stack frame.
 struct TraitObligationStack<'prev, 'tcx: 'prev> {
     obligation: &'prev TraitObligation<'tcx>,

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -31,7 +31,7 @@ use super::{VtableImplData, VtableObjectData, VtableBuiltinData, VtableGenerator
 use super::util;
 
 use dep_graph::{DepNodeIndex, DepKind};
-use hir::def_id::{DefId, LOCAL_CRATE};
+use hir::def_id::DefId;
 use infer;
 use infer::{InferCtxt, InferOk, TypeFreshener};
 use ty::subst::{Kind, Subst, Substs};
@@ -1075,9 +1075,8 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
                 } else {
                     None
                 };
-                let cause = if
-                    trait_ref.def_id.krate != LOCAL_CRATE &&
-                    !self.tcx().has_attr(trait_ref.def_id, "fundamental") {
+                let cause = if !coherence::trait_ref_is_local_or_fundamental(self.tcx(),
+                                                                             trait_ref) {
                     IntercrateAmbiguityCause::UpstreamCrateUpdate { trait_desc, self_desc }
                 } else {
                     IntercrateAmbiguityCause::DownstreamCrate { trait_desc, self_desc }
@@ -1205,7 +1204,7 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
         // ok to skip binder because of the nature of the
         // trait-ref-is-knowable check, which does not care about
         // bound regions
-        let trait_ref = &predicate.skip_binder().trait_ref;
+        let trait_ref = predicate.skip_binder().trait_ref;
 
         coherence::trait_ref_is_knowable(self.tcx(), trait_ref)
     }

--- a/src/librustc/traits/specialize/mod.rs
+++ b/src/librustc/traits/specialize/mod.rs
@@ -340,17 +340,7 @@ pub(super) fn specialization_graph_provider<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx
                 }
 
                 for cause in &overlap.intercrate_ambiguity_causes {
-                    match cause {
-                        &IntercrateAmbiguityCause::DownstreamCrate(def_id) => {
-                            err.note(&format!("downstream crates may implement `{}`",
-                                              tcx.item_path_str(def_id)));
-                        }
-                        &IntercrateAmbiguityCause::UpstreamCrateUpdate(def_id) => {
-                            err.note(&format!("upstream crates may add new impl for `{}` \
-                                              in future versions",
-                                              tcx.item_path_str(def_id)));
-                        }
-                    }
+                    cause.add_intercrate_ambiguity_hint(tcx, &mut err);
                 }
 
                 err.emit();

--- a/src/librustc/traits/specialize/mod.rs
+++ b/src/librustc/traits/specialize/mod.rs
@@ -342,11 +342,11 @@ pub(super) fn specialization_graph_provider<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx
                 for cause in &overlap.intercrate_ambiguity_causes {
                     match cause {
                         &IntercrateAmbiguityCause::DownstreamCrate(def_id) => {
-                            err.note(&format!("downstream crates may implement {}",
+                            err.note(&format!("downstream crates may implement `{}`",
                                               tcx.item_path_str(def_id)));
                         }
                         &IntercrateAmbiguityCause::UpstreamCrateUpdate(def_id) => {
-                            err.note(&format!("upstream crates may add new impl for {} \
+                            err.note(&format!("upstream crates may add new impl for `{}` \
                                               in future versions",
                                               tcx.item_path_str(def_id)));
                         }

--- a/src/librustc/traits/specialize/mod.rs
+++ b/src/librustc/traits/specialize/mod.rs
@@ -340,7 +340,7 @@ pub(super) fn specialization_graph_provider<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx
                 }
 
                 for cause in &overlap.intercrate_ambiguity_causes {
-                    cause.add_intercrate_ambiguity_hint(tcx, &mut err);
+                    cause.add_intercrate_ambiguity_hint(&mut err);
                 }
 
                 err.emit();

--- a/src/librustc/traits/specialize/specialization_graph.rs
+++ b/src/librustc/traits/specialize/specialization_graph.rs
@@ -113,7 +113,7 @@ impl<'a, 'gcx, 'tcx> Children {
                 let overlap = traits::overlapping_impls(&infcx,
                                                         possible_sibling,
                                                         impl_def_id);
-                if let Some(impl_header) = overlap {
+                if let Some(overlap) = overlap {
                     if tcx.impls_are_allowed_to_overlap(impl_def_id, possible_sibling) {
                         return Ok((false, false));
                     }
@@ -123,7 +123,7 @@ impl<'a, 'gcx, 'tcx> Children {
 
                     if le == ge {
                         // overlap, but no specialization; error out
-                        let trait_ref = impl_header.trait_ref.unwrap();
+                        let trait_ref = overlap.impl_header.trait_ref.unwrap();
                         let self_ty = trait_ref.self_ty();
                         Err(OverlapError {
                             with_impl: possible_sibling,
@@ -135,7 +135,8 @@ impl<'a, 'gcx, 'tcx> Children {
                                 Some(self_ty.to_string())
                             } else {
                                 None
-                            }
+                            },
+                            intercrate_ambiguity_causes: overlap.intercrate_ambiguity_causes,
                         })
                     } else {
                         Ok((le, ge))

--- a/src/librustc_typeck/coherence/inherent_impls_overlap.rs
+++ b/src/librustc_typeck/coherence/inherent_impls_overlap.rs
@@ -12,7 +12,6 @@ use rustc::hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use rustc::hir;
 use rustc::hir::itemlikevisit::ItemLikeVisitor;
 use rustc::traits;
-use rustc::traits::IntercrateAmbiguityCause;
 use rustc::ty::{self, TyCtxt};
 
 pub fn crate_inherent_impls_overlap_check<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
@@ -64,17 +63,7 @@ impl<'a, 'tcx> InherentOverlapChecker<'a, 'tcx> {
                                    format!("other definition for `{}`", name));
 
                     for cause in &overlap.intercrate_ambiguity_causes {
-                        match cause {
-                            &IntercrateAmbiguityCause::DownstreamCrate(def_id) => {
-                                err.note(&format!("downstream crates may implement `{}`",
-                                                  self.tcx.item_path_str(def_id)));
-                            }
-                            &IntercrateAmbiguityCause::UpstreamCrateUpdate(def_id) => {
-                                err.note(&format!("upstream crates may add new impl for `{}` \
-                                                  in future versions",
-                                                  self.tcx.item_path_str(def_id)));
-                            }
-                        }
+                        cause.add_intercrate_ambiguity_hint(self.tcx, &mut err);
                     }
 
                     err.emit();

--- a/src/librustc_typeck/coherence/inherent_impls_overlap.rs
+++ b/src/librustc_typeck/coherence/inherent_impls_overlap.rs
@@ -63,7 +63,7 @@ impl<'a, 'tcx> InherentOverlapChecker<'a, 'tcx> {
                                    format!("other definition for `{}`", name));
 
                     for cause in &overlap.intercrate_ambiguity_causes {
-                        cause.add_intercrate_ambiguity_hint(self.tcx, &mut err);
+                        cause.add_intercrate_ambiguity_hint(&mut err);
                     }
 
                     err.emit();

--- a/src/librustc_typeck/coherence/inherent_impls_overlap.rs
+++ b/src/librustc_typeck/coherence/inherent_impls_overlap.rs
@@ -66,11 +66,11 @@ impl<'a, 'tcx> InherentOverlapChecker<'a, 'tcx> {
                     for cause in &overlap.intercrate_ambiguity_causes {
                         match cause {
                             &IntercrateAmbiguityCause::DownstreamCrate(def_id) => {
-                                err.note(&format!("downstream crates may implement {}",
+                                err.note(&format!("downstream crates may implement `{}`",
                                                   self.tcx.item_path_str(def_id)));
                             }
                             &IntercrateAmbiguityCause::UpstreamCrateUpdate(def_id) => {
-                                err.note(&format!("upstream crates may add new impl for {} \
+                                err.note(&format!("upstream crates may add new impl for `{}` \
                                                   in future versions",
                                                   self.tcx.item_path_str(def_id)));
                             }

--- a/src/test/compile-fail/coherence-overlap-downstream-inherent.rs
+++ b/src/test/compile-fail/coherence-overlap-downstream-inherent.rs
@@ -1,0 +1,32 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests that we consider `T: Sugar + Fruit` to be ambiguous, even
+// though no impls are found.
+
+struct Sweet<X>(X);
+pub trait Sugar {}
+pub trait Fruit {}
+impl<T:Sugar> Sweet<T> { fn dummy(&self) { } }
+//~^ ERROR E0592
+//~| NOTE duplicate definitions for `dummy`
+impl<T:Fruit> Sweet<T> { fn dummy(&self) { } }
+//~^ NOTE other definition for `dummy`
+
+trait Bar<X> {}
+struct A<T, X>(T, X);
+impl<X, T> A<T, X> where T: Bar<X> { fn f(&self) {} }
+//~^ ERROR E0592
+//~| NOTE duplicate definitions for `f`
+//~| NOTE downstream crates may implement trait `Bar<_>` for type `i32`
+impl<X> A<i32, X> { fn f(&self) {} }
+//~^ NOTE other definition for `f`
+
+fn main() {}

--- a/src/test/compile-fail/coherence-overlap-downstream.rs
+++ b/src/test/compile-fail/coherence-overlap-downstream.rs
@@ -1,0 +1,32 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests that we consider `T: Sugar + Fruit` to be ambiguous, even
+// though no impls are found.
+
+pub trait Sugar {}
+pub trait Fruit {}
+pub trait Sweet {}
+impl<T:Sugar> Sweet for T { }
+//~^ NOTE first implementation here
+impl<T:Fruit> Sweet for T { }
+//~^ ERROR E0119
+//~| NOTE conflicting implementation
+
+pub trait Foo<X> {}
+pub trait Bar<X> {}
+impl<X, T> Foo<X> for T where T: Bar<X> {}
+//~^ NOTE first implementation here
+impl<X> Foo<X> for i32 {}
+//~^ ERROR E0119
+//~| NOTE conflicting implementation for `i32`
+//~| NOTE downstream crates may implement trait `Bar<_>` for type `i32`
+
+fn main() { }

--- a/src/test/compile-fail/coherence-overlap-issue-23516-inherent.rs
+++ b/src/test/compile-fail/coherence-overlap-issue-23516-inherent.rs
@@ -12,13 +12,15 @@
 // though we see no impl of `Sugar` for `Box`. Therefore, an overlap
 // error is reported for the following pair of impls (#23516).
 
-pub trait Sugar { fn dummy(&self) { } }
-pub trait Sweet { fn dummy(&self) { } }
-impl<T:Sugar> Sweet for T { }
-//~^ NOTE first implementation here
-impl<U:Sugar> Sweet for Box<U> { }
-//~^ ERROR E0119
-//~| NOTE conflicting implementation for `std::boxed::Box<_>`
+pub trait Sugar {}
+
+struct Cake<X>(X);
+
+impl<T:Sugar> Cake<T> { fn dummy(&self) { } }
+//~^ ERROR E0592
+//~| NOTE duplicate definitions for `dummy`
 //~| NOTE upstream crates may add new impl for `Sugar` in future versions
+impl<U:Sugar> Cake<Box<U>> { fn dummy(&self) { } }
+//~^ NOTE other definition for `dummy`
 
 fn main() { }

--- a/src/test/compile-fail/coherence-overlap-issue-23516-inherent.rs
+++ b/src/test/compile-fail/coherence-overlap-issue-23516-inherent.rs
@@ -19,7 +19,7 @@ struct Cake<X>(X);
 impl<T:Sugar> Cake<T> { fn dummy(&self) { } }
 //~^ ERROR E0592
 //~| NOTE duplicate definitions for `dummy`
-//~| NOTE upstream crates may add new impl of trait `Sugar` for type `std::boxed::Box<_>`
+//~| NOTE downstream crates may implement trait `Sugar` for type `std::boxed::Box<_>`
 impl<U:Sugar> Cake<Box<U>> { fn dummy(&self) { } }
 //~^ NOTE other definition for `dummy`
 

--- a/src/test/compile-fail/coherence-overlap-issue-23516-inherent.rs
+++ b/src/test/compile-fail/coherence-overlap-issue-23516-inherent.rs
@@ -19,7 +19,7 @@ struct Cake<X>(X);
 impl<T:Sugar> Cake<T> { fn dummy(&self) { } }
 //~^ ERROR E0592
 //~| NOTE duplicate definitions for `dummy`
-//~| NOTE upstream crates may add new impl for `Sugar` in future versions
+//~| NOTE upstream crates may add new impl of trait `Sugar` for type `std::boxed::Box<_>`
 impl<U:Sugar> Cake<Box<U>> { fn dummy(&self) { } }
 //~^ NOTE other definition for `dummy`
 

--- a/src/test/compile-fail/coherence-overlap-issue-23516.rs
+++ b/src/test/compile-fail/coherence-overlap-issue-23516.rs
@@ -19,6 +19,6 @@ impl<T:Sugar> Sweet for T { }
 impl<U:Sugar> Sweet for Box<U> { }
 //~^ ERROR E0119
 //~| NOTE conflicting implementation for `std::boxed::Box<_>`
-//~| NOTE upstream crates may add new impl of trait `Sugar` for type `std::boxed::Box<_>`
+//~| NOTE downstream crates may implement trait `Sugar` for type `std::boxed::Box<_>`
 
 fn main() { }

--- a/src/test/compile-fail/coherence-overlap-issue-23516.rs
+++ b/src/test/compile-fail/coherence-overlap-issue-23516.rs
@@ -19,6 +19,6 @@ impl<T:Sugar> Sweet for T { }
 impl<U:Sugar> Sweet for Box<U> { }
 //~^ ERROR E0119
 //~| NOTE conflicting implementation for `std::boxed::Box<_>`
-//~| NOTE upstream crates may add new impl for `Sugar` in future versions
+//~| NOTE upstream crates may add new impl of trait `Sugar` for type `std::boxed::Box<_>`
 
 fn main() { }

--- a/src/test/compile-fail/coherence-overlap-upstream-inherent.rs
+++ b/src/test/compile-fail/coherence-overlap-upstream-inherent.rs
@@ -1,0 +1,28 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests that we consider `i16: Remote` to be ambiguous, even
+// though the upstream crate doesn't implement it for now.
+
+// aux-build:coherence_lib.rs
+
+extern crate coherence_lib;
+
+use coherence_lib::Remote;
+
+struct A<X>(X);
+impl<T> A<T> where T: Remote { fn dummy(&self) { } }
+//~^ ERROR E0592
+//~| NOTE duplicate definitions for `dummy`
+//~| NOTE upstream crates may add new impl for `coherence_lib::Remote` in future versions
+impl A<i16> { fn dummy(&self) { } }
+//~^ NOTE other definition for `dummy`
+
+fn main() {}

--- a/src/test/compile-fail/coherence-overlap-upstream-inherent.rs
+++ b/src/test/compile-fail/coherence-overlap-upstream-inherent.rs
@@ -21,7 +21,7 @@ struct A<X>(X);
 impl<T> A<T> where T: Remote { fn dummy(&self) { } }
 //~^ ERROR E0592
 //~| NOTE duplicate definitions for `dummy`
-//~| NOTE upstream crates may add new impl for `coherence_lib::Remote` in future versions
+//~| NOTE upstream crates may add new impl of trait `coherence_lib::Remote` for type `i16`
 impl A<i16> { fn dummy(&self) { } }
 //~^ NOTE other definition for `dummy`
 

--- a/src/test/compile-fail/coherence-overlap-upstream.rs
+++ b/src/test/compile-fail/coherence-overlap-upstream.rs
@@ -23,6 +23,6 @@ impl<T> Foo for T where T: Remote {}
 impl Foo for i16 {}
 //~^ ERROR E0119
 //~| NOTE conflicting implementation for `i16`
-//~| NOTE upstream crates may add new impl for `coherence_lib::Remote` in future versions
+//~| NOTE upstream crates may add new impl of trait `coherence_lib::Remote` for type `i16`
 
 fn main() {}

--- a/src/test/compile-fail/coherence-overlap-upstream.rs
+++ b/src/test/compile-fail/coherence-overlap-upstream.rs
@@ -8,17 +8,21 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Tests that we consider `Box<U>: !Sugar` to be ambiguous, even
-// though we see no impl of `Sugar` for `Box`. Therefore, an overlap
-// error is reported for the following pair of impls (#23516).
+// Tests that we consider `i16: Remote` to be ambiguous, even
+// though the upstream crate doesn't implement it for now.
 
-pub trait Sugar { fn dummy(&self) { } }
-pub trait Sweet { fn dummy(&self) { } }
-impl<T:Sugar> Sweet for T { }
+// aux-build:coherence_lib.rs
+
+extern crate coherence_lib;
+
+use coherence_lib::Remote;
+
+trait Foo {}
+impl<T> Foo for T where T: Remote {}
 //~^ NOTE first implementation here
-impl<U:Sugar> Sweet for Box<U> { }
+impl Foo for i16 {}
 //~^ ERROR E0119
-//~| NOTE conflicting implementation for `std::boxed::Box<_>`
-//~| NOTE upstream crates may add new impl for `Sugar` in future versions
+//~| NOTE conflicting implementation for `i16`
+//~| NOTE upstream crates may add new impl for `coherence_lib::Remote` in future versions
 
-fn main() { }
+fn main() {}

--- a/src/test/ui/codemap_tests/overlapping_inherent_impls.stderr
+++ b/src/test/ui/codemap_tests/overlapping_inherent_impls.stderr
@@ -24,6 +24,7 @@ error[E0592]: duplicate definitions with name `baz`
 ...
 43 |     fn baz(&self) {}
    |     ---------------- other definition for `baz`
+   = note: upstream crates may add new impl for `std::marker::Copy` in future versions
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/codemap_tests/overlapping_inherent_impls.stderr
+++ b/src/test/ui/codemap_tests/overlapping_inherent_impls.stderr
@@ -25,7 +25,7 @@ error[E0592]: duplicate definitions with name `baz`
 43 |     fn baz(&self) {}
    |     ---------------- other definition for `baz`
    |
-   = note: upstream crates may add new impl for `std::marker::Copy` in future versions
+   = note: upstream crates may add new impl of trait `std::marker::Copy` for type `std::vec::Vec<_>` in future versions
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/codemap_tests/overlapping_inherent_impls.stderr
+++ b/src/test/ui/codemap_tests/overlapping_inherent_impls.stderr
@@ -24,6 +24,7 @@ error[E0592]: duplicate definitions with name `baz`
 ...
 43 |     fn baz(&self) {}
    |     ---------------- other definition for `baz`
+   |
    = note: upstream crates may add new impl for `std::marker::Copy` in future versions
 
 error: aborting due to 3 previous errors


### PR DESCRIPTION
I'm going to tackle #23980.

# Examples

## Trait impl overlap caused by possible downstream impl

```rust
trait Foo<X> {}
trait Bar<X> {}
impl<X, T> Foo<X> for T where T: Bar<X> {}
impl<X> Foo<X> for i32 {}

fn main() {}
```

```
error[E0119]: conflicting implementations of trait `Foo<_>` for type `i32`:
 --> test1.rs:4:1
  |
3 | impl<X, T> Foo<X> for T where T: Bar<X> {}
  | ------------------------------------------ first implementation here
4 | impl<X> Foo<X> for i32 {}
  | ^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `i32`
  |
  = note: downstream crates may implement Bar

error: aborting due to previous error
```

## Trait impl overlap caused by possible upstream update

```rust
trait Foo {}
impl<T> Foo for T where T: ::std::fmt::Octal {}
impl Foo for () {}

fn main() {}
```

```
error[E0119]: conflicting implementations of trait `Foo` for type `()`:
 --> test2.rs:3:1
  |
2 | impl<T> Foo for T where T: ::std::fmt::Octal {}
  | ----------------------------------------------- first implementation here
3 | impl Foo for () {}
  | ^^^^^^^^^^^^^^^^^^ conflicting implementation for `()`
  |
  = note: upstream crates may add new impl for std::fmt::Octal in future versions

error: aborting due to previous error
```

## Inherent impl overlap caused by possible downstream impl

```rust
trait Bar<X> {}

struct A<T, X>(T, X);
impl<X, T> A<T, X> where T: Bar<X> { fn f(&self) {} }
impl<X> A<i32, X> { fn f(&self) {} }

fn main() {}
```

```
error[E0592]: duplicate definitions with name `f`
 --> test3.rs:4:38
  |
4 | impl<X, T> A<T, X> where T: Bar<X> { fn f(&self) {} }
  |                                      ^^^^^^^^^^^^^^ duplicate definitions for `f`
5 | impl<X> A<i32, X> { fn f(&self) {} }
  |                     -------------- other definition for `f`
  |
  = note: downstream crates may implement Bar

error: aborting due to previous error
```

## Inherent impl overlap caused by possible upstream update

```rust
struct A<T>(T);

impl<T> A<T> where T: ::std::fmt::Octal { fn f(&self) {} }
impl A<()> { fn f(&self) {} }

fn main() {}
```

```
error[E0592]: duplicate definitions with name `f`
 --> test4.rs:3:43
  |
3 | impl<T> A<T> where T: ::std::fmt::Octal { fn f(&self) {} }
  |                                           ^^^^^^^^^^^^^^ duplicate definitions for `f`
4 | impl A<()> { fn f(&self) {} }
  |              -------------- other definition for `f`
  |
  = note: upstream crates may add new impl for std::fmt::Octal in future versions

error: aborting due to previous error
```