### PR TITLE
syntax: Refactor `quote` macro

### DIFF
--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -235,7 +235,7 @@ pub fn compile(sess: &ParseSess, features: &RefCell<Features>, def: &ast::Item) 
             s.iter().map(|m| {
                 if let MatchedNonterminal(ref nt) = *m {
                     if let NtTT(ref tt) = **nt {
-                        let tt = quoted::parse(tt.clone().into(), true, sess).pop().unwrap();
+                        let tt = quoted::parse(tt.clone().into(), true, sess, true).pop().unwrap();
                         valid &= check_lhs_nt_follows(sess, features, &def.attrs, &tt);
                         return tt;
                     }
@@ -251,7 +251,7 @@ pub fn compile(sess: &ParseSess, features: &RefCell<Features>, def: &ast::Item) 
             s.iter().map(|m| {
                 if let MatchedNonterminal(ref nt) = *m {
                     if let NtTT(ref tt) = **nt {
-                        return quoted::parse(tt.clone().into(), false, sess).pop().unwrap();
+                        return quoted::parse(tt.clone().into(), false, sess, true).pop().unwrap();
                     }
                 }
                 sess.span_diagnostic.span_bug(def.span, "wrong-structured lhs")

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -49,7 +49,8 @@ pub mod proc_macro_impl;
 
 use std::rc::Rc;
 use syntax::ast;
-use syntax::ext::base::{MacroExpanderFn, NormalTT, NamedSyntaxExtension};
+use syntax::ext::base::{MacroExpanderFn, NormalTT, TTMacroExpander, NamedSyntaxExtension};
+use syntax::ext::quote::QuoteMacroExpander;
 use syntax::symbol::Symbol;
 
 pub fn register_builtins(resolver: &mut syntax::ext::base::Resolver,
@@ -68,21 +69,27 @@ pub fn register_builtins(resolver: &mut syntax::ext::base::Resolver,
         )* }
     }
 
+    macro_rules! register_with_trait_object {
+        ($( $name:ident: $f:expr, )*) => { $(
+            register(Symbol::intern(stringify!($name)),
+                     NormalTT(Box::new($f) as Box<TTMacroExpander>, None, false));
+        )* }
+    }
+
     if enable_quotes {
-        use syntax::ext::quote::*;
-        register! {
-            quote_tokens: expand_quote_tokens,
-            quote_expr: expand_quote_expr,
-            quote_ty: expand_quote_ty,
-            quote_item: expand_quote_item,
-            quote_pat: expand_quote_pat,
-            quote_arm: expand_quote_arm,
-            quote_stmt: expand_quote_stmt,
-            quote_attr: expand_quote_attr,
-            quote_arg: expand_quote_arg,
-            quote_block: expand_quote_block,
-            quote_meta_item: expand_quote_meta_item,
-            quote_path: expand_quote_path,
+        register_with_trait_object! {
+            quote_tokens: QuoteMacroExpander::Tokens,
+            quote_expr: QuoteMacroExpander::Expr,
+            quote_ty: QuoteMacroExpander::Ty,
+            quote_item: QuoteMacroExpander::Item,
+            quote_pat: QuoteMacroExpander::Pat,
+            quote_arm: QuoteMacroExpander::Arm,
+            quote_stmt: QuoteMacroExpander::Stmt,
+            quote_attr: QuoteMacroExpander::Attr,
+            quote_arg: QuoteMacroExpander::Arg,
+            quote_block: QuoteMacroExpander::Block,
+            quote_meta_item: QuoteMacroExpander::MetaItem,
+            quote_path: QuoteMacroExpander::Path,
         }
     }
 

--- a/src/test/run-pass-fulldeps/auxiliary/procedural_mbe_matching.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/procedural_mbe_matching.rs
@@ -35,7 +35,7 @@ fn expand_mbe_matches(cx: &mut ExtCtxt, _: Span, args: &[TokenTree])
         -> Box<MacResult + 'static> {
 
     let mbe_matcher = quote_tokens!(cx, $$matched:expr, $$($$pat:pat)|+);
-    let mbe_matcher = quoted::parse(mbe_matcher.into_iter().collect(), true, cx.parse_sess);
+    let mbe_matcher = quoted::parse(mbe_matcher.into_iter().collect(), true, cx.parse_sess, false);
     let map = match TokenTree::parse(cx, &mbe_matcher, args.iter().cloned().collect()) {
         Success(map) => map,
         Failure(_, tok) => {

--- a/src/test/run-pass-fulldeps/qquote.rs
+++ b/src/test/run-pass-fulldeps/qquote.rs
@@ -94,4 +94,9 @@ fn main() {
 
     let attr = quote_attr!(cx, #![$meta]);
     check!(attribute_to_string, attr; r#"#![cfg(foo = "bar")]"#);
+
+    // quote_tokens!
+
+    let tokens = quote_tokens!(cx, $($$x),+);
+    check!(tts_to_string, tokens, quote_tokens!(cx, $tokens); "$ ( $ x ) , +");
 }


### PR DESCRIPTION
The code for `quote` macro expansion works with `quote::TokenTree`s.

`quote::parse` has a new `strict` parameter -- if true, it will forbid interpolation syntax that is incomplete, for example `$ $foo` is a fragment with missing identifier followed by another fragment that is correct.