### PR TITLE
rustdoc: fix layout of Fields section in documentation for unions

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -691,7 +691,7 @@ span.since {
 	margin-bottom: 25px;
 }
 
-.enum .variant, .struct .structfield {
+.enum .variant, .struct .structfield, .union .structfield {
 	display: block;
 }
 


### PR DESCRIPTION
Previously, the union fields would all render on the same line with
hideous spacing; comparison to the analogous section for structs makes
it undoubtable that `display: block` is the true intent.

Concisely and definitively resolves #43404 and its perfidious
malignancy.