### PR TITLE
Improve checking of conflicting packed and align representation hints on structs and unions.

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -2025,5 +2025,4 @@ register_diagnostics! {
     E0490, // a value of type `..` is borrowed for too long
     E0495, // cannot infer an appropriate lifetime due to conflicting requirements
     E0566, // conflicting representation hints
-    E0587, // conflicting packed and align representation hints
 }

--- a/src/librustc/hir/check_attr.rs
+++ b/src/librustc/hir/check_attr.rs
@@ -76,8 +76,6 @@ impl<'a> CheckAttrVisitor<'a> {
         };
 
         let mut conflicting_reprs = 0;
-        let mut found_packed = false;
-        let mut found_align = false;
 
         for word in words {
 
@@ -106,7 +104,6 @@ impl<'a> CheckAttrVisitor<'a> {
                                 ("attribute should be applied to struct or union",
                                  "a struct or union")
                     } else {
-                        found_packed = true;
                         continue
                     }
                 }
@@ -120,7 +117,6 @@ impl<'a> CheckAttrVisitor<'a> {
                     }
                 }
                 "align" => {
-                    found_align = true;
                     if target != Target::Struct &&
                             target != Target::Union {
                         ("attribute should be applied to struct or union",
@@ -149,10 +145,6 @@ impl<'a> CheckAttrVisitor<'a> {
         if conflicting_reprs > 1 {
             span_warn!(self.sess, attr.span, E0566,
                        "conflicting representation hints");
-        }
-        if found_align && found_packed {
-            struct_span_err!(self.sess, attr.span, E0587,
-                             "conflicting packed and align representation hints").emit();
         }
     }
 }

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -4663,6 +4663,7 @@ register_diagnostics! {
            // but `{}` was found in the type `{}`
     E0567, // auto traits can not have type parameters
     E0568, // auto-traits can not have predicates,
+    E0587, // struct has conflicting packed and align representation hints
     E0588, // packed struct cannot transitively contain a `[repr(align)]` struct
     E0592, // duplicate definitions with name `{}`
 //  E0613, // Removed (merged with E0609)

--- a/src/test/compile-fail/conflicting-repr-hints.rs
+++ b/src/test/compile-fail/conflicting-repr-hints.rs
@@ -27,7 +27,15 @@ enum D { D }
 #[repr(C, packed)]
 struct E(i32);
 
-#[repr(packed, align(8))] //~ ERROR conflicting packed and align representation hints
-struct F(i32);
+#[repr(packed, align(8))]
+struct F(i32); //~ ERROR struct has conflicting packed and align representation hints
+
+#[repr(packed)]
+#[repr(align(8))]
+struct G(i32); //~ ERROR struct has conflicting packed and align representation hints
+
+#[repr(align(8))]
+#[repr(packed)]
+struct H(i32); //~ ERROR struct has conflicting packed and align representation hints
 
 fn main() {}

--- a/src/test/compile-fail/conflicting-repr-hints.rs
+++ b/src/test/compile-fail/conflicting-repr-hints.rs
@@ -28,14 +28,31 @@ enum D { D }
 struct E(i32);
 
 #[repr(packed, align(8))]
-struct F(i32); //~ ERROR struct has conflicting packed and align representation hints
+struct F(i32); //~ ERROR type has conflicting packed and align representation hints
 
 #[repr(packed)]
 #[repr(align(8))]
-struct G(i32); //~ ERROR struct has conflicting packed and align representation hints
+struct G(i32); //~ ERROR type has conflicting packed and align representation hints
 
 #[repr(align(8))]
 #[repr(packed)]
-struct H(i32); //~ ERROR struct has conflicting packed and align representation hints
+struct H(i32); //~ ERROR type has conflicting packed and align representation hints
+
+#[repr(packed, align(8))]
+union X { //~ ERROR type has conflicting packed and align representation hints
+    i: i32
+}
+
+#[repr(packed)]
+#[repr(align(8))]
+union Y { //~ ERROR type has conflicting packed and align representation hints
+    i: i32
+}
+
+#[repr(align(8))]
+#[repr(packed)]
+union Z { //~ ERROR type has conflicting packed and align representation hints
+    i: i32
+}
 
 fn main() {}

--- a/src/test/compile-fail/repr-packed-contains-align.rs
+++ b/src/test/compile-fail/repr-packed-contains-align.rs
@@ -9,17 +9,53 @@
 // except according to those terms.
 #![feature(attr_literals)]
 #![feature(repr_align)]
+#![feature(untagged_unions)]
 #![allow(dead_code)]
 
 #[repr(align(16))]
-struct A(i32);
+struct SA(i32);
 
-struct B(A);
+struct SB(SA);
+
+#[repr(align(16))]
+union UA {
+    i: i32
+}
+
+union UB {
+    a: UA
+}
 
 #[repr(packed)]
-struct C(A); //~ ERROR: packed struct cannot transitively contain a `[repr(align)]` struct
+struct SC(SA); //~ ERROR: packed type cannot transitively contain a `[repr(align)]` type
 
 #[repr(packed)]
-struct D(B); //~ ERROR: packed struct cannot transitively contain a `[repr(align)]` struct
+struct SD(SB); //~ ERROR: packed type cannot transitively contain a `[repr(align)]` type
+
+#[repr(packed)]
+struct SE(UA); //~ ERROR: packed type cannot transitively contain a `[repr(align)]` type
+
+#[repr(packed)]
+struct SF(UB); //~ ERROR: packed type cannot transitively contain a `[repr(align)]` type
+
+#[repr(packed)]
+union UC { //~ ERROR: packed type cannot transitively contain a `[repr(align)]` type
+    a: UA
+}
+
+#[repr(packed)]
+union UD { //~ ERROR: packed type cannot transitively contain a `[repr(align)]` type
+    n: UB
+}
+
+#[repr(packed)]
+union UE { //~ ERROR: packed type cannot transitively contain a `[repr(align)]` type
+    a: SA
+}
+
+#[repr(packed)]
+union UF { //~ ERROR: packed type cannot transitively contain a `[repr(align)]` type
+    n: SB
+}
 
 fn main() {}


### PR DESCRIPTION
Fixes #43317 and improves #33626.