### PR TITLE
Fix android backtraces

### DIFF
--- a/src/test/run-pass/backtrace-debuginfo.rs
+++ b/src/test/run-pass/backtrace-debuginfo.rs
@@ -35,7 +35,6 @@ macro_rules! dump_and_die {
         // the macro span takes over the last frame's file/line.
         if cfg!(any(target_os = "macos",
                     target_os = "ios",
-                    target_os = "android",
                     all(target_os = "linux", target_arch = "arm"),
                     target_os = "freebsd",
                     target_os = "dragonfly",

--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-android FIXME #17520
 // ignore-emscripten spawning processes is not supported
 // ignore-openbsd no support for libbacktrace without filename
 // compile-flags:-g


### PR DESCRIPTION
Fixes #17520 

If `backtrace_syminfo` fails to return the symbol, attempt using backtrace_pcinfo to get it. For whatever reason, this fixes the backtraces on android with PIE.