### PR TITLE
rustdoc: make major section headers self-links

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2141,7 +2141,9 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
 
     if !types.is_empty() {
         write!(w, "
-            <h2 id='associated-types'>Associated Types</h2>
+            <h2 id='associated-types' class='section-header'>
+              <a href='#associated-types'>Associated Types</a>
+            </h2>
             <div class='methods'>
         ")?;
         for t in &types {
@@ -2152,7 +2154,9 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
 
     if !consts.is_empty() {
         write!(w, "
-            <h2 id='associated-const'>Associated Constants</h2>
+            <h2 id='associated-const' class='section-header'>
+              <a href='#associated-const'>Associated Constants</a>
+            </h2>
             <div class='methods'>
         ")?;
         for t in &consts {
@@ -2164,7 +2168,9 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
     // Output the documentation for each function individually
     if !required.is_empty() {
         write!(w, "
-            <h2 id='required-methods'>Required Methods</h2>
+            <h2 id='required-methods' class='section-header'>
+              <a href='#required-methods'>Required Methods</a>
+            </h2>
             <div class='methods'>
         ")?;
         for m in &required {
@@ -2174,7 +2180,9 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
     }
     if !provided.is_empty() {
         write!(w, "
-            <h2 id='provided-methods'>Provided Methods</h2>
+            <h2 id='provided-methods' class='section-header'>
+              <a href='#provided-methods'>Provided Methods</a>
+            </h2>
             <div class='methods'>
         ")?;
         for m in &provided {
@@ -2188,7 +2196,9 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
 
     let cache = cache();
     write!(w, "
-        <h2 id='implementors'>Implementors</h2>
+        <h2 id='implementors' class='section-header'>
+          <a href='#implementors'>Implementors</a>
+        </h2>
         <ul class='item-list' id='implementors-list'>
     ")?;
     if let Some(implementors) = cache.implementors.get(&it.def_id) {
@@ -2419,7 +2429,8 @@ fn item_struct(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
     }).peekable();
     if let doctree::Plain = s.struct_type {
         if fields.peek().is_some() {
-            write!(w, "<h2 id='fields' class='fields'>Fields</h2>")?;
+            write!(w, "<h2 id='fields' class='fields section-header'>
+                       <a href='#fields'>Fields</a></h2>")?;
             for (field, ty) in fields {
                 let id = derive_id(format!("{}.{}",
                                            ItemType::StructField,
@@ -2467,7 +2478,8 @@ fn item_union(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
         }
     }).peekable();
     if fields.peek().is_some() {
-        write!(w, "<h2 id='fields' class='fields'>Fields</h2>")?;
+        write!(w, "<h2 id='fields' class='fields section-header'>
+                   <a href='#fields'>Fields</a></h2>")?;
         for (field, ty) in fields {
             write!(w, "<span id='{shortty}.{name}' class=\"{shortty}\"><code>{name}: {ty}</code>
                        </span>",
@@ -2539,7 +2551,8 @@ fn item_enum(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
 
     document(w, cx, it)?;
     if !e.variants.is_empty() {
-        write!(w, "<h2 id='variants' class='variants'>Variants</h2>\n")?;
+        write!(w, "<h2 id='variants' class='variants section-header'>
+                   <a href='#variants'>Variants</a></h2>\n")?;
         for variant in &e.variants {
             let id = derive_id(format!("{}.{}",
                                        ItemType::Variant,
@@ -2810,12 +2823,19 @@ fn render_assoc_items(w: &mut fmt::Formatter,
     if !non_trait.is_empty() {
         let render_mode = match what {
             AssocItemRender::All => {
-                write!(w, "<h2 id='methods'>Methods</h2>")?;
+                write!(w, "
+                    <h2 id='methods' class='section-header'>
+                      <a href='#methods'>Methods</a>
+                    </h2>
+                ")?;
                 RenderMode::Normal
             }
             AssocItemRender::DerefFor { trait_, type_, deref_mut_ } => {
-                write!(w, "<h2 id='deref-methods'>Methods from \
-                               {}&lt;Target = {}&gt;</h2>", trait_, type_)?;
+                write!(w, "
+                    <h2 id='deref-methods' class='section-header'>
+                      <a href='#deref-methods'>Methods from {}&lt;Target = {}&gt;</a>
+                    </h2>
+                ", trait_, type_)?;
                 RenderMode::ForDeref { mut_: deref_mut_ }
             }
         };
@@ -2837,8 +2857,11 @@ fn render_assoc_items(w: &mut fmt::Formatter,
             }).is_some();
             render_deref_methods(w, cx, impl_, containing_item, has_deref_mut)?;
         }
-        write!(w, "<h2 id='implementations'>Trait \
-                   Implementations</h2>")?;
+        write!(w, "
+            <h2 id='implementations' class='section-header'>
+              <a href='#implementations'>Trait Implementations</a>
+            </h2>
+        ")?;
         for i in &traits {
             let did = i.trait_did().unwrap();
             let assoc_link = AssocItemLink::GotoSource(did, &i.inner_impl().provided_trait_methods);


### PR DESCRIPTION
The sidebar already has links to these h2's ids, but for convenience,
the h2 itself should also be a link (retaining its present appearance).

![doc_sec_self-links](https://user-images.githubusercontent.com/1076988/28503806-cdce4e00-6fc1-11e7-832a-2ed1fc62808f.png)

This should address most of #24484.