### PR TITLE
rustdoc: add unions to whitelist of sidebar types

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1065,6 +1065,7 @@
         block("macro", "Macros");
         block("struct", "Structs");
         block("enum", "Enums");
+        block("union", "Unions");
         block("constant", "Constants");
         block("static", "Statics");
         block("trait", "Traits");


### PR DESCRIPTION
This resolves #43405.