### PR TITLE
Point at path segment on module not found

### DIFF
--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -19,6 +19,7 @@ use rustc::hir::map::{self, DefCollector};
 use rustc::{ty, lint};
 use syntax::ast::{self, Name, Ident};
 use syntax::attr::{self, HasAttrs};
+use syntax::codemap::respan;
 use syntax::errors::DiagnosticBuilder;
 use syntax::ext::base::{self, Annotatable, Determinacy, MultiModifier, MultiDecorator};
 use syntax::ext::base::{MacroKind, SyntaxExtension, Resolver as SyntaxResolver};
@@ -393,7 +394,7 @@ impl<'a> Resolver<'a> {
             return Err(Determinacy::Determined);
         }
 
-        let path: Vec<_> = segments.iter().map(|seg| seg.identifier).collect();
+        let path: Vec<_> = segments.iter().map(|seg| respan(seg.span, seg.identifier)).collect();
         let invocation = self.invocations[&scope];
         self.current_module = invocation.module.get();
 
@@ -418,16 +419,19 @@ impl<'a> Resolver<'a> {
                     Err(Determinacy::Determined)
                 },
             };
+            let path = path.iter().map(|p| p.node).collect::<Vec<_>>();
             self.current_module.nearest_item_scope().macro_resolutions.borrow_mut()
                 .push((path.into_boxed_slice(), span));
             return def;
         }
 
-        let legacy_resolution = self.resolve_legacy_scope(&invocation.legacy_scope, path[0], false);
+        let legacy_resolution = self.resolve_legacy_scope(&invocation.legacy_scope,
+                                                          path[0].node,
+                                                          false);
         let result = if let Some(MacroBinding::Legacy(binding)) = legacy_resolution {
             Ok(Def::Macro(binding.def_id, MacroKind::Bang))
         } else {
-            match self.resolve_lexical_macro_path_segment(path[0], MacroNS, false, span) {
+            match self.resolve_lexical_macro_path_segment(path[0].node, MacroNS, false, span) {
                 Ok(binding) => Ok(binding.binding().def_ignoring_ambiguity()),
                 Err(Determinacy::Undetermined) if !force => return Err(Determinacy::Undetermined),
                 Err(_) => {
@@ -438,7 +442,7 @@ impl<'a> Resolver<'a> {
         };
 
         self.current_module.nearest_item_scope().legacy_macro_resolutions.borrow_mut()
-            .push((scope, path[0], span, kind));
+            .push((scope, path[0].node, span, kind));
 
         result
     }
@@ -576,9 +580,10 @@ impl<'a> Resolver<'a> {
     pub fn finalize_current_module_macro_resolutions(&mut self) {
         let module = self.current_module;
         for &(ref path, span) in module.macro_resolutions.borrow().iter() {
-            match self.resolve_path(path, Some(MacroNS), true, span) {
+            let path = path.iter().map(|p| respan(span, *p)).collect::<Vec<_>>();
+            match self.resolve_path(&path, Some(MacroNS), true, span) {
                 PathResult::NonModule(_) => {},
-                PathResult::Failed(msg, _) => {
+                PathResult::Failed(span, msg, _) => {
                     resolve_error(self, span, ResolutionError::FailedToResolve(&msg));
                 }
                 _ => unreachable!(),
@@ -652,7 +657,7 @@ impl<'a> Resolver<'a> {
                 }
             };
             let ident = Ident::from_str(name);
-            self.lookup_typo_candidate(&vec![ident], MacroNS, is_macro, span)
+            self.lookup_typo_candidate(&vec![respan(span, ident)], MacroNS, is_macro, span)
         });
 
         if let Some(suggestion) = suggestion {

--- a/src/test/compile-fail/dollar-crate-is-keyword-2.rs
+++ b/src/test/compile-fail/dollar-crate-is-keyword-2.rs
@@ -13,7 +13,7 @@ mod a {}
 macro_rules! m {
     () => {
         use a::$crate; //~ ERROR unresolved import `a::$crate`
-        use a::$crate::b; //~ ERROR unresolved import `a::$crate::b`
+        use a::$crate::b; //~ ERROR unresolved import `a::$crate`
         type A = a::$crate; //~ ERROR cannot find type `$crate` in module `a`
     }
 }

--- a/src/test/compile-fail/import2.rs
+++ b/src/test/compile-fail/import2.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use baz::zed::bar; //~ ERROR unresolved import `baz::zed::bar` [E0432]
+use baz::zed::bar; //~ ERROR unresolved import `baz::zed` [E0432]
                    //~^ Could not find `zed` in `baz`
 
 mod baz {}

--- a/src/test/compile-fail/issue-1697.rs
+++ b/src/test/compile-fail/issue-1697.rs
@@ -10,7 +10,7 @@
 
 // Testing that we don't fail abnormally after hitting the errors
 
-use unresolved::*; //~ ERROR unresolved import `unresolved::*` [E0432]
+use unresolved::*; //~ ERROR unresolved import `unresolved` [E0432]
                    //~^ Maybe a missing `extern crate unresolved;`?
 
 fn main() {}

--- a/src/test/compile-fail/issue-33464.rs
+++ b/src/test/compile-fail/issue-33464.rs
@@ -11,13 +11,10 @@
 // Make sure that the spans of import errors are correct.
 
 use abc::one_el;
-//~^ ERROR 13:5: 13:16
+//~^ ERROR 13:5: 13:8
 use abc::{a, bbb, cccccc};
-//~^ ERROR 15:11: 15:12
-//~^^ ERROR 15:14: 15:17
-//~^^^ ERROR 15:19: 15:25
+//~^ ERROR 15:5: 15:8
 use a_very_long_name::{el, el2};
-//~^ ERROR 19:24: 19:26
-//~^^ ERROR 19:28: 19:31
+//~^ ERROR 17:5: 17:21
 
 fn main() {}

--- a/src/test/compile-fail/resolve_self_super_hint.rs
+++ b/src/test/compile-fail/resolve_self_super_hint.rs
@@ -13,19 +13,19 @@
 mod a {
     extern crate alloc;
     use alloc::HashMap;
-    //~^ ERROR unresolved import `alloc::HashMap` [E0432]
+    //~^ ERROR unresolved import `alloc` [E0432]
     //~| Did you mean `self::alloc`?
     mod b {
         use alloc::HashMap;
-        //~^ ERROR unresolved import `alloc::HashMap` [E0432]
+        //~^ ERROR unresolved import `alloc` [E0432]
         //~| Did you mean `a::alloc`?
         mod c {
             use alloc::HashMap;
-            //~^ ERROR unresolved import `alloc::HashMap` [E0432]
+            //~^ ERROR unresolved import `alloc` [E0432]
             //~| Did you mean `a::alloc`?
             mod d {
                 use alloc::HashMap;
-                //~^ ERROR unresolved import `alloc::HashMap` [E0432]
+                //~^ ERROR unresolved import `alloc` [E0432]
                 //~| Did you mean `a::alloc`?
             }
         }

--- a/src/test/compile-fail/super-at-top-level.rs
+++ b/src/test/compile-fail/super-at-top-level.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::f; //~ ERROR unresolved import `super::f` [E0432]
+use super::f; //~ ERROR unresolved import `super` [E0432]
               //~^ There are too many initial `super`s.
 
 fn main() {

--- a/src/test/compile-fail/unresolved-import.rs
+++ b/src/test/compile-fail/unresolved-import.rs
@@ -10,7 +10,7 @@
 
 // ignore-tidy-linelength
 
-use foo::bar; //~ ERROR unresolved import `foo::bar` [E0432]
+use foo::bar; //~ ERROR unresolved import `foo` [E0432]
               //~^ Maybe a missing `extern crate foo;`?
 
 use bar::Baz as x; //~ ERROR unresolved import `bar::Baz` [E0432]
@@ -41,7 +41,7 @@ mod m {
         MyVariant
     }
 
-    use MyEnum::*; //~ ERROR unresolved import `MyEnum::*` [E0432]
+    use MyEnum::*; //~ ERROR unresolved import `MyEnum` [E0432]
                    //~^ Did you mean `self::MyEnum`?
 }
 
@@ -50,7 +50,7 @@ mod items {
         Variant
     }
 
-    use Enum::*; //~ ERROR unresolved import `Enum::*` [E0432]
+    use Enum::*; //~ ERROR unresolved import `Enum` [E0432]
                  //~^ Did you mean `self::Enum`?
 
     fn item() {}

--- a/src/test/compile-fail/use-from-trait-xc.rs
+++ b/src/test/compile-fail/use-from-trait-xc.rs
@@ -22,13 +22,13 @@ use use_from_trait_xc::Trait::CONST;
 //~^ ERROR `CONST` is not directly importable
 
 use use_from_trait_xc::Foo::new; //~ ERROR struct `Foo` is private
-//~^ ERROR unresolved import `use_from_trait_xc::Foo::new`
+//~^ ERROR unresolved import `use_from_trait_xc::Foo`
 
 use use_from_trait_xc::Foo::C; //~ ERROR struct `Foo` is private
-//~^ ERROR unresolved import `use_from_trait_xc::Foo::C`
+//~^ ERROR unresolved import `use_from_trait_xc::Foo`
 
 use use_from_trait_xc::Bar::new as bnew;
-//~^ ERROR unresolved import `use_from_trait_xc::Bar::new`
+//~^ ERROR unresolved import `use_from_trait_xc::Bar`
 
 use use_from_trait_xc::Baz::new as baznew;
 //~^ ERROR unresolved import `use_from_trait_xc::Baz::new`

--- a/src/test/compile-fail/use-from-trait.rs
+++ b/src/test/compile-fail/use-from-trait.rs
@@ -17,11 +17,11 @@ use Trait::C;
 //~^ ERROR `C` is not directly importable
 
 use Foo::new;
-//~^ ERROR unresolved import `Foo::new` [E0432]
+//~^ ERROR unresolved import `Foo` [E0432]
 //~| Not a module `Foo`
 
 use Foo::C2;
-//~^ ERROR unresolved import `Foo::C2` [E0432]
+//~^ ERROR unresolved import `Foo` [E0432]
 //~| Not a module `Foo`
 
 pub trait Trait {

--- a/src/test/compile-fail/use-mod-4.rs
+++ b/src/test/compile-fail/use-mod-4.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use foo::self; //~ ERROR unresolved import `foo::self`
+use foo::self; //~ ERROR unresolved import `foo`
 //~^ ERROR `self` imports are only allowed within a { } list
 
 use std::mem::self;

--- a/src/test/ui/macros/macro_path_as_generic_bound.stderr
+++ b/src/test/ui/macros/macro_path_as_generic_bound.stderr
@@ -2,7 +2,7 @@ error[E0433]: failed to resolve. Use of undeclared type or module `m`
   --> $DIR/macro_path_as_generic_bound.rs:17:6
    |
 17 | foo!(m::m2::A);
-   |      ^^^^^^^^ Use of undeclared type or module `m`
+   |      ^ Use of undeclared type or module `m`
 
 error: cannot continue compilation due to previous error
 

--- a/src/test/ui/span/non-existing-module-import.rs
+++ b/src/test/ui/span/non-existing-module-import.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,15 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-type Alias = ();
-use Alias::*;
-//~^ ERROR unresolved import `Alias` [E0432]
-//~| Not a module `Alias`
-use std::io::Result::*;
-//~^ ERROR unresolved import `std::io::Result` [E0432]
-//~| Not a module `Result`
-
-trait T {}
-use T::*; //~ ERROR items in traits are not importable
+use std::bar::{foo1, foo2};
 
 fn main() {}

--- a/src/test/ui/span/non-existing-module-import.stderr
+++ b/src/test/ui/span/non-existing-module-import.stderr
@@ -1,0 +1,8 @@
+error[E0432]: unresolved import `std::bar`
+  --> $DIR/non-existing-module-import.rs:11:10
+   |
+11 | use std::bar::{foo1, foo2};
+   |          ^^^ Could not find `bar` in `std`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Point at the correct path segment on a import statement where a module
doesn't exist.

New output:

```rust
error[E0432]: unresolved import `std::bar`
 --> <anon>:1:10
  |
1 | use std::bar::{foo1, foo2};
  |          ^^^ Could not find `bar` in `std`
```

instead of:

```rust
error[E0432]: unresolved import `std::bar::foo1`
 --> <anon>:1:16
  |
1 | use std::bar::{foo1, foo2};
  |                ^^^^ Could not find `bar` in `std`

error[E0432]: unresolved import `std::bar::foo2`
 --> <anon>:1:22
  |
1 | use std::bar::{foo1, foo2};
  |                      ^^^^ Could not find `bar` in `std`
```

Fix #43040.