### PR TITLE
add a note to Vec's Extend<&T> impl about its slice specialization

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1962,6 +1962,12 @@ impl<T> Vec<T> {
 
 }
 
+/// Extend implementation that copies elements out of references before pushing them onto the Vec.
+///
+/// This implementation is specialized for slice iterators, where it uses [`copy_from_slice`] to
+/// append the entire slice at once.
+///
+/// [`copy_from_slice`]: ../../std/primitive.slice.html#method.copy_from_slice
 #[stable(feature = "extend_ref", since = "1.2.0")]
 impl<'a, T: 'a + Copy> Extend<&'a T> for Vec<T> {
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {


### PR DESCRIPTION
From the regular documentation view, it's not at all apparent that [this specialization](https://github.com/rust-lang/rust/blob/5669c9988f50788b5ab5dee2d4538519d4e5663d/src/liballoc/vec.rs#L1879-L1891) exists for `slice::Iter`. This adds a documentation blurb to the Extend impl itself to note that this optimization exists.