### PR TITLE
Fix printing regions with -Z verbose

### DIFF
--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1208,14 +1208,11 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                     BorrowKind::Mut | BorrowKind::Unique => "mut ",
                 };
 
-                // When identifying regions, add trailing space if
-                // necessary.
-                let region = if ppaux::identify_regions() {
+                // When printing regions, add trailing space if necessary.
+                let region = {
                     let mut region = format!("{}", region);
                     if region.len() > 0 { region.push(' '); }
                     region
-                } else {
-                    "".to_owned()
                 };
                 write!(fmt, "&{}{}{:?}", region, kind_str, lv)
             }

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1209,10 +1209,13 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                 };
 
                 // When printing regions, add trailing space if necessary.
-                let region = {
+                let region = if ppaux::verbose() || ppaux::identify_regions() {
                     let mut region = format!("{}", region);
                     if region.len() > 0 { region.push(' '); }
                     region
+                } else {
+                    // Do not even print 'static
+                    "".to_owned()
                 };
                 write!(fmt, "&{}{}{:?}", region, kind_str, lv)
             }


### PR DESCRIPTION
When dumping MIR with `-Z verbose`, it would print regions on types, but not in the code. It seems the Rvalue printing code tried to be smart and guessed when the `Display` for `Region` would not possibly print anything.

This PR makes it no longer be smart, and just always use the `Display` like all the other code (e.g. printing types) does.
