### PR TITLE
Switch to begin_panic again

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -46,7 +46,7 @@ macro_rules! panic {
         panic!("explicit panic")
     });
     ($msg:expr) => ({
-        $crate::rt::begin_panic_new($msg, {
+        $crate::rt::begin_panic($msg, {
             // static requires less code at runtime, more constant data
             static _FILE_LINE_COL: (&'static str, u32, u32) = (file!(), line!(), column!());
             &_FILE_LINE_COL

--- a/src/libstd/rt.rs
+++ b/src/libstd/rt.rs
@@ -25,7 +25,9 @@
 
 
 // Reexport some of our utilities which are expected by other crates.
-pub use panicking::{begin_panic_new, begin_panic, begin_panic_fmt, update_panic_count};
+#[cfg(stage0)]
+pub use panicking::begin_panic_new;
+pub use panicking::{begin_panic, begin_panic_fmt, update_panic_count};
 
 #[cfg(not(test))]
 #[lang = "start"]

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -774,7 +774,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         let expr_loc_ptr = self.expr_addr_of(span, expr_loc_tuple);
         self.expr_call_global(
             span,
-            self.std_path(&["rt", "begin_panic_new"]),
+            self.std_path(&["rt", "begin_panic"]),
             vec![
                 self.expr_str(span, msg),
                 expr_loc_ptr])


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/42938 we made the compiler
emit a call to begin_panic_new in order to pass column info to it. Now
with stage0 updated (https://github.com/rust-lang/rust/pull/43320),
we can safely change begin_panic and start emitting calls for it again.