### PR TITLE
Extended error message for mut borrow conflicts in loops

### DIFF
--- a/src/test/ui/borrowck/mut-borrow-in-loop.rs
+++ b/src/test/ui/borrowck/mut-borrow-in-loop.rs
@@ -1,0 +1,40 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// produce special borrowck message inside all kinds of loops
+
+struct FuncWrapper<'a, T : 'a> {
+    func : fn(&'a mut T) -> ()
+}
+
+impl<'a, T : 'a> FuncWrapper<'a, T> {
+    fn in_loop(self, arg : &'a mut T) {
+        loop {
+            (self.func)(arg)
+        }
+    }
+
+    fn in_while(self, arg : &'a mut T) {
+        while true {
+            (self.func)(arg)
+        }
+    }
+
+    fn in_for(self, arg : &'a mut T) {
+        let v : Vec<()> = vec![];
+        for _ in v.iter() {
+            (self.func)(arg)
+        }
+    }
+}
+
+fn main() {
+}
+

--- a/src/test/ui/borrowck/mut-borrow-in-loop.stderr
+++ b/src/test/ui/borrowck/mut-borrow-in-loop.stderr
@@ -1,0 +1,29 @@
+error[E0499]: cannot borrow `*arg` as mutable more than once at a time
+  --> $DIR/mut-borrow-in-loop.rs:20:25
+   |
+20 |             (self.func)(arg)
+   |                         ^^^ mutable borrow starts here in previous iteration of loop
+21 |         }
+22 |     }
+   |     - mutable borrow ends here
+
+error[E0499]: cannot borrow `*arg` as mutable more than once at a time
+  --> $DIR/mut-borrow-in-loop.rs:26:25
+   |
+26 |             (self.func)(arg)
+   |                         ^^^ mutable borrow starts here in previous iteration of loop
+27 |         }
+28 |     }
+   |     - mutable borrow ends here
+
+error[E0499]: cannot borrow `*arg` as mutable more than once at a time
+  --> $DIR/mut-borrow-in-loop.rs:33:25
+   |
+33 |             (self.func)(arg)
+   |                         ^^^ mutable borrow starts here in previous iteration of loop
+34 |         }
+35 |     }
+   |     - mutable borrow ends here
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/borrowck/mut-borrow-outside-loop.rs
+++ b/src/test/ui/borrowck/mut-borrow-outside-loop.rs
@@ -1,0 +1,26 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ensure borrowck messages are correct outside special case
+
+fn main() {
+    let mut void = ();
+
+    let first = &mut void;
+    let second = &mut void;
+
+    loop {
+        let mut inner_void = ();
+
+        let inner_first = &mut inner_void;
+        let inner_second = &mut inner_void;
+    }
+}
+

--- a/src/test/ui/borrowck/mut-borrow-outside-loop.stderr
+++ b/src/test/ui/borrowck/mut-borrow-outside-loop.stderr
@@ -1,0 +1,23 @@
+error[E0499]: cannot borrow `void` as mutable more than once at a time
+  --> $DIR/mut-borrow-outside-loop.rs:17:23
+   |
+16 |     let first = &mut void;
+   |                      ---- first mutable borrow occurs here
+17 |     let second = &mut void;
+   |                       ^^^^ second mutable borrow occurs here
+...
+25 | }
+   | - first borrow ends here
+
+error[E0499]: cannot borrow `inner_void` as mutable more than once at a time
+  --> $DIR/mut-borrow-outside-loop.rs:23:33
+   |
+22 |         let inner_first = &mut inner_void;
+   |                                ---------- first mutable borrow occurs here
+23 |         let inner_second = &mut inner_void;
+   |                                 ^^^^^^^^^^ second mutable borrow occurs here
+24 |     }
+   |     - first borrow ends here
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
RFC issue: https://github.com/rust-lang/rfcs/issues/2080

The error message for multiple mutable borrows on the same value over loop iterations now makes it clear that the conflict comes from the borrow outlasting the loop. The wording of the error is based on the special case of the moved-value error for a value moved in a loop. Following the example of that error, the code remains the same for the special case.

This is mainly because I felt the current message is confusing in the loop case : https://github.com/rust-lang/rust/issues/43437. It's not clear that the two conflicting borrows are in different iterations of the loop, and instead it just looks like the compiler has an issue with a single line.