### PR TITLE
Constrain the layout of Blake2bCtx for proper SPARC compilation

### DIFF
--- a/src/librustc_data_structures/blake2b.rs
+++ b/src/librustc_data_structures/blake2b.rs
@@ -23,6 +23,7 @@
 use std::mem;
 use std::slice;
 
+#[repr(C)]
 pub struct Blake2bCtx {
     b: [u8; 128],
     h: [u64; 8],


### PR DESCRIPTION
On SPARC, optimization fuel ends up emitting incorrect load and store
instructions for the transmute() call in blake2b_compress().  If we
force Blake2bCtx to be repr(C), the problem disappears.

Fixes #43346