### PR TITLE
Optimize initialization of arrays using repeat expressions

### DIFF
--- a/src/librustc_trans/common.rs
+++ b/src/librustc_trans/common.rs
@@ -372,7 +372,7 @@ pub fn const_to_uint(v: ValueRef) -> u64 {
     }
 }
 
-fn is_const_integral(v: ValueRef) -> bool {
+pub fn is_const_integral(v: ValueRef) -> bool {
     unsafe {
         !llvm::LLVMIsAConstantInt(v).is_null()
     }

--- a/src/librustc_trans/mir/rvalue.rs
+++ b/src/librustc_trans/mir/rvalue.rs
@@ -122,8 +122,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                     if common::val_ty(v) == Type::i8(bcx.ccx) {
                         let align = align.unwrap_or_else(|| bcx.ccx.align_of(tr_elem.ty));
                         let align = C_i32(bcx.ccx, align as i32);
-                        let fill = tr_elem.immediate();
-                        base::call_memset(&bcx, base, fill, size, align, false);
+                        base::call_memset(&bcx, base, v, size, align, false);
                         return bcx;
                     }
                 }

--- a/src/librustc_trans/tvec.rs
+++ b/src/librustc_trans/tvec.rs
@@ -30,8 +30,8 @@ pub fn slice_for_each<'a, 'tcx, F>(
     };
 
     let body_bcx = bcx.build_sibling_block("slice_loop_body");
-    let next_bcx = bcx.build_sibling_block("slice_loop_next");
     let header_bcx = bcx.build_sibling_block("slice_loop_header");
+    let next_bcx = bcx.build_sibling_block("slice_loop_next");
 
     let start = if zst {
         C_uint(bcx.ccx, 0usize)

--- a/src/test/codegen/slice-init.rs
+++ b/src/test/codegen/slice-init.rs
@@ -1,0 +1,74 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -C no-prepopulate-passes
+
+#![crate_type = "lib"]
+
+// CHECK-LABEL: @zero_sized_elem
+#[no_mangle]
+pub fn zero_sized_elem() {
+    // CHECK-NOT: br label %slice_loop_header{{.*}}
+    // CHECK-NOT: call void @llvm.memset.p0i8
+    let x = [(); 4];
+    drop(&x);
+}
+
+// CHECK-LABEL: @zero_len_array
+#[no_mangle]
+pub fn zero_len_array() {
+    // CHECK-NOT: br label %slice_loop_header{{.*}}
+    // CHECK-NOT: call void @llvm.memset.p0i8
+    let x = [4; 0];
+    drop(&x);
+}
+
+// CHECK-LABEL: @byte_array
+#[no_mangle]
+pub fn byte_array() {
+    // CHECK: call void @llvm.memset.p0i8.i{{[0-9]+}}(i8* {{.*}}, i8 7, i64 4
+    // CHECK-NOT: br label %slice_loop_header{{.*}}
+    let x = [7u8; 4];
+    drop(&x);
+}
+
+#[allow(dead_code)]
+#[derive(Copy, Clone)]
+enum Init {
+    Loop,
+    Memset,
+}
+
+// CHECK-LABEL: @byte_enum_array
+#[no_mangle]
+pub fn byte_enum_array() {
+    // CHECK: call void @llvm.memset.p0i8.i{{[0-9]+}}(i8* {{.*}}, i8 {{.*}}, i64 4
+    // CHECK-NOT: br label %slice_loop_header{{.*}}
+    let x = [Init::Memset; 4];
+    drop(&x);
+}
+
+// CHECK-LABEL: @zeroed_integer_array
+#[no_mangle]
+pub fn zeroed_integer_array() {
+    // CHECK: call void @llvm.memset.p0i8.i{{[0-9]+}}(i8* {{.*}}, i8 0, i64 16
+    // CHECK-NOT: br label %slice_loop_header{{.*}}
+    let x = [0u32; 4];
+    drop(&x);
+}
+
+// CHECK-LABEL: @nonzero_integer_array
+#[no_mangle]
+pub fn nonzero_integer_array() {
+    // CHECK: br label %slice_loop_header{{.*}}
+    // CHECK-NOT: call void @llvm.memset.p0i8
+    let x = [0x1a_2b_3c_4d_u32; 4];
+    drop(&x);
+}

--- a/src/test/codegen/slice-init.rs
+++ b/src/test/codegen/slice-init.rs
@@ -33,7 +33,7 @@ pub fn zero_len_array() {
 // CHECK-LABEL: @byte_array
 #[no_mangle]
 pub fn byte_array() {
-    // CHECK: call void @llvm.memset.p0i8.i{{[0-9]+}}(i8* {{.*}}, i8 7, i64 4
+    // CHECK: call void @llvm.memset.p0i8.i[[WIDTH:[0-9]+]](i8* {{.*}}, i8 7, i[[WIDTH]] 4
     // CHECK-NOT: br label %slice_loop_header{{.*}}
     let x = [7u8; 4];
     drop(&x);
@@ -49,7 +49,7 @@ enum Init {
 // CHECK-LABEL: @byte_enum_array
 #[no_mangle]
 pub fn byte_enum_array() {
-    // CHECK: call void @llvm.memset.p0i8.i{{[0-9]+}}(i8* {{.*}}, i8 {{.*}}, i64 4
+    // CHECK: call void @llvm.memset.p0i8.i[[WIDTH:[0-9]+]](i8* {{.*}}, i8 {{.*}}, i[[WIDTH]] 4
     // CHECK-NOT: br label %slice_loop_header{{.*}}
     let x = [Init::Memset; 4];
     drop(&x);
@@ -58,7 +58,7 @@ pub fn byte_enum_array() {
 // CHECK-LABEL: @zeroed_integer_array
 #[no_mangle]
 pub fn zeroed_integer_array() {
-    // CHECK: call void @llvm.memset.p0i8.i{{[0-9]+}}(i8* {{.*}}, i8 0, i64 16
+    // CHECK: call void @llvm.memset.p0i8.i[[WIDTH:[0-9]+]](i8* {{.*}}, i8 0, i[[WIDTH]] 16
     // CHECK-NOT: br label %slice_loop_header{{.*}}
     let x = [0u32; 4];
     drop(&x);


### PR DESCRIPTION
This PR was inspired by [this thread](https://www.reddit.com/r/rust/comments/6o8ok9/understanding_rust_performances_a_newbie_question/) on Reddit.
It tries to bring array initialization in the same ballpark as `Vec::from_elem()` for unoptimized builds.
For optimized builds this should relieve LLVM of having to figure out the construct we generate is in fact a `memset()`.

To that end this emits `llvm.memset()` when:
* the array is of integer type and all elements are zero (`Vec::from_elem()` also explicitly optimizes for this case)
* the array elements are byte sized

If the array is zero-sized initialization is omitted entirely.