### PR TITLE
Fix some raw types in std to match what's in libc

### DIFF
--- a/src/libstd/os/solaris/raw.rs
+++ b/src/libstd/os/solaris/raw.rs
@@ -21,18 +21,18 @@
 use os::raw::c_long;
 use os::unix::raw::{uid_t, gid_t};
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i32;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = i32;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
 #[stable(feature = "pthread_t", since = "1.8.0")]
-pub type pthread_t = usize;
+pub type pthread_t = u32;
 
 #[repr(C)]
 #[derive(Clone)]


### PR DESCRIPTION
The pthread_t type, in particular, causes failures when building cargo 0.20.0 after rust-lang/libc@8304e06b5.