### PR TITLE
Copyright/license headers

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -6,16 +6,17 @@ terms.
 
 Longer version:
 
-The Rust Project is copyright 2010, The Rust Project
-Developers.
+Copyrights in the Rust project are retained by their contributors. No
+copyright assignment is required to contribute to the Rust project.
 
-Licensed under the Apache License, Version 2.0
-<LICENSE-APACHE or
-http://www.apache.org/licenses/LICENSE-2.0> or the MIT
-license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
-at your option. All files in the project carrying such
-notice may not be copied, modified, or distributed except
-according to those terms.
+Some files include explicit copyright notices and/or license notices.
+For full authorship information, see AUTHORS.txt and the version control
+history.
+
+Except as otherwise noted (below and/or in individual files), Rust is
+licensed under the Apache License, Version 2.0 <LICENSE-APACHE> or
+<http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+<LICENSE-MIT> or <http://opensource.org/licenses/MIT>, at your option.
 
 
 The Rust Project includes packages written by third parties.
@@ -282,25 +283,3 @@ their own copyright notices and license terms:
     NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
     USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
     OF SUCH DAMAGE.
-
-* Additional copyright may be retained by contributors other
-  than Mozilla, the Rust Project Developers, or the parties
-  enumerated in this file. Such copyright can be determined
-  on a case-by-case basis by examining the author of each
-  portion of a file in the revision-control commit records
-  of the project, or by consulting representative comments
-  claiming copyright ownership for a file.
-
-  For example, the text:
-
-      "Copyright (c) 2011 Google Inc."
-
-  appears in some files, and these files thereby denote
-  that their author and copyright-holder is Google Inc.
-
-  In all such cases, the absence of explicit licensing text
-  indicates that the contributor chose to license their work
-  for distribution under identical terms to those Mozilla
-  has chosen for the collective work, enumerated at the top
-  of this file. The only difference is the retention of
-  copyright itself, held by the contributor.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,5 +1,3 @@
-Copyright (c) 2010 The Rust Project Developers
-
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
 documentation files (the "Software"), to deal in the


### PR DESCRIPTION
(As discussed with @aturon and @est31. CC @rust-lang/core.)

Currently, rust-lang/rust includes notices that say things like
```
The Rust Project is copyright 2010, The Rust Project
Developers.
```
or
```
Copyright (c) 2010 The Rust Project Developers
```
or
```
// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
// file at the top-level directory of this distribution and at
// http://rust-lang.org/COPYRIGHT.
```

These notices aren't accurate. "Copyright YYYY Some Name" has a specific legal meaning, and "The Rust Project Developers" isn't a legal entity. In practice, the actual legal structure is that all Rust contributors retain their copyrights when contributing to Rust, and just license them under MIT/Apache-2.0. Our legal notices should reflect that.

This came up because of RFC 2044, which proposed fixing this for the RFC repository. That effort started out by copying the rust-lang/rust notices, propagating this issue.

Based on discussion with @aturon, the two of us propose the following:

- Delete the per-file notices entirely, for any files licensed under the standard terms. (Keep notices for anything that's *not* MIT/Apache-2.0.)
  - An alternative to that would be to just delete the first paragraph of the standard notice, and keep the second paragraph that points to the MIT and Apache 2.0 licenses.
- Delete the first paragraph of LICENSE-MIT (the inaccurate pseudo-copyright line), leaving only the text of the MIT license.
- Edit the COPYRIGHT file to more accurately describe the situation (changing the pseudo-copyright line immediately under "longer version", and editing the text that starts with "additional copyright may be ...", to just always state that copyrights are retained by the Rust contributors, and licensed under MIT/Apache-2.0 (with the exceptions to that explicitly noted in that file).

If @rust-lang/core is fine with this proposal, I'd be happy to provide a pull request with the proposed fixes.