### PR TITLE
Add method `String::retain`

### DIFF
--- a/src/doc/unstable-book/src/library-features/string-retain.md
+++ b/src/doc/unstable-book/src/library-features/string-retain.md
@@ -1,0 +1,23 @@
+# `string_retain`
+
+The tracking issue for this feature is: [#43874]
+
+[#43874]: https://github.com/rust-lang/rust/issues/43874
+
+------------------------
+
+Retains only the characters specified by the predicate.
+
+In other words, remove all characters `c` such that `f(c)` returns `false`.
+This method operates in place and preserves the order of the retained
+characters.
+
+```rust
+#![feature(string_retain)]
+
+let mut s = String::from("f_o_ob_ar");
+
+s.retain(|c| c != '_');
+
+assert_eq!(s, "foobar");
+```

--- a/src/liballoc/tests/lib.rs
+++ b/src/liballoc/tests/lib.rs
@@ -26,6 +26,7 @@
 #![feature(splice)]
 #![feature(str_checked_slicing)]
 #![feature(str_escape)]
+#![feature(string_retain)]
 #![feature(test)]
 #![feature(unboxed_closures)]
 #![feature(unicode)]

--- a/src/liballoc/tests/string.rs
+++ b/src/liballoc/tests/string.rs
@@ -333,6 +333,26 @@ fn remove_bad() {
 }
 
 #[test]
+fn test_retain() {
+    let mut s = String::from("α_β_γ");
+
+    s.retain(|_| true);
+    assert_eq!(s, "α_β_γ");
+
+    s.retain(|c| c != '_');
+    assert_eq!(s, "αβγ");
+
+    s.retain(|c| c != 'β');
+    assert_eq!(s, "αγ");
+
+    s.retain(|c| c == 'α');
+    assert_eq!(s, "α");
+
+    s.retain(|_| false);
+    assert_eq!(s, "");
+}
+
+#[test]
 fn insert() {
     let mut s = "foobar".to_string();
     s.insert(0, 'ệ');


### PR DESCRIPTION
Behaves like `Vec::retain`, accepting a predicate `FnMut(char) -> bool`
and reducing the string to only characters for which the predicate
returns `true`.