### PR TITLE
Run translation and LLVM in parallel when compiling with multiple CGUs

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1517,11 +1517,11 @@ dependencies = [
 name = "rustc_trans"
 version = "0.0.0"
 dependencies = [
- "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "jobserver 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc 0.0.0",
  "rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -50,7 +50,7 @@ pub use self::NativeLibraryKind::*;
 
 // lonely orphan structs and enums looking for a better home
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Copy)]
 pub struct LinkMeta {
     pub crate_hash: Svh,
 }
@@ -161,15 +161,13 @@ pub struct ExternCrate {
 }
 
 pub struct EncodedMetadata {
-    pub raw_data: Vec<u8>,
-    pub hashes: EncodedMetadataHashes,
+    pub raw_data: Vec<u8>
 }
 
 impl EncodedMetadata {
     pub fn new() -> EncodedMetadata {
         EncodedMetadata {
             raw_data: Vec::new(),
-            hashes: EncodedMetadataHashes::new(),
         }
     }
 }
@@ -294,7 +292,7 @@ pub trait CrateStore {
                                  tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                  link_meta: &LinkMeta,
                                  reachable: &NodeSet)
-                                 -> EncodedMetadata;
+                                 -> (EncodedMetadata, EncodedMetadataHashes);
     fn metadata_encoding_version(&self) -> &[u8];
 }
 
@@ -424,7 +422,7 @@ impl CrateStore for DummyCrateStore {
                                  tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                  link_meta: &LinkMeta,
                                  reachable: &NodeSet)
-                                 -> EncodedMetadata {
+                                 -> (EncodedMetadata, EncodedMetadataHashes) {
         bug!("encode_metadata")
     }
     fn metadata_encoding_version(&self) -> &[u8] { bug!("metadata_encoding_version") }

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1059,6 +1059,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
         "choose which RELRO level to use"),
     nll: bool = (false, parse_bool, [UNTRACKED],
                  "run the non-lexical lifetimes MIR pass"),
+    trans_time_graph: bool = (false, parse_bool, [UNTRACKED],
+        "generate a graphical HTML report of time spent in trans and LLVM"),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1053,7 +1053,7 @@ pub fn phase_4_translate_to_llvm<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                            analysis: ty::CrateAnalysis,
                                            incremental_hashes_map: &IncrementalHashesMap,
                                            output_filenames: &OutputFilenames)
-                                           -> trans::OngoingCrateTranslation {
+                                           -> write::OngoingCrateTranslation {
     let time_passes = tcx.sess.time_passes();
 
     time(time_passes,
@@ -1071,7 +1071,7 @@ pub fn phase_4_translate_to_llvm<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 /// Run LLVM itself, producing a bitcode file, assembly file or object file
 /// as a side effect.
 pub fn phase_5_run_llvm_passes(sess: &Session,
-                               trans: trans::OngoingCrateTranslation,
+                               trans: write::OngoingCrateTranslation,
                                outputs: &OutputFilenames)
                                -> (CompileResult, trans::CrateTranslation) {
     let trans = trans.join(sess, outputs);

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -15,8 +15,7 @@ use rustc_data_structures::stable_hasher::StableHasher;
 use rustc_mir as mir;
 use rustc::session::{Session, CompileResult};
 use rustc::session::CompileIncomplete;
-use rustc::session::config::{self, Input, OutputFilenames, OutputType,
-                             OutputTypes};
+use rustc::session::config::{self, Input, OutputFilenames, OutputType};
 use rustc::session::search_paths::PathKind;
 use rustc::lint;
 use rustc::middle::{self, dependency_format, stability, reachable};
@@ -26,7 +25,6 @@ use rustc::ty::{self, TyCtxt, Resolutions, GlobalArenas};
 use rustc::traits;
 use rustc::util::common::{ErrorReported, time};
 use rustc::util::nodemap::NodeSet;
-use rustc::util::fs::rename_or_copy_remove;
 use rustc_allocator as allocator;
 use rustc_borrowck as borrowck;
 use rustc_incremental::{self, IncrementalHashesMap};
@@ -231,7 +229,7 @@ pub fn compile_input(sess: &Session,
         sess.code_stats.borrow().print_type_sizes();
     }
 
-    let phase5_result = phase_5_run_llvm_passes(sess, &trans, &outputs);
+    let (phase5_result, trans) = phase_5_run_llvm_passes(sess, trans, &outputs);
 
     controller_entry_point!(after_llvm,
                             sess,
@@ -1057,7 +1055,7 @@ pub fn phase_4_translate_to_llvm<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                            analysis: ty::CrateAnalysis,
                                            incremental_hashes_map: &IncrementalHashesMap,
                                            output_filenames: &OutputFilenames)
-                                           -> trans::CrateTranslation {
+                                           -> trans::OngoingCrateTranslation {
     let time_passes = tcx.sess.time_passes();
 
     time(time_passes,
@@ -1069,61 +1067,26 @@ pub fn phase_4_translate_to_llvm<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
              "translation",
              move || trans::trans_crate(tcx, analysis, &incremental_hashes_map, output_filenames));
 
-    time(time_passes,
-         "assert dep graph",
-         || rustc_incremental::assert_dep_graph(tcx));
-
-    time(time_passes,
-         "serialize dep graph",
-         || rustc_incremental::save_dep_graph(tcx,
-                                              &incremental_hashes_map,
-                                              &translation.metadata.hashes,
-                                              translation.link.crate_hash));
     translation
 }
 
 /// Run LLVM itself, producing a bitcode file, assembly file or object file
 /// as a side effect.
 pub fn phase_5_run_llvm_passes(sess: &Session,
-                               trans: &trans::CrateTranslation,
-                               outputs: &OutputFilenames) -> CompileResult {
-    if sess.opts.cg.no_integrated_as ||
-        (sess.target.target.options.no_integrated_as &&
-         (outputs.outputs.contains_key(&OutputType::Object) ||
-          outputs.outputs.contains_key(&OutputType::Exe)))
-    {
-        let output_types = OutputTypes::new(&[(OutputType::Assembly, None)]);
-        time(sess.time_passes(),
-             "LLVM passes",
-             || write::run_passes(sess, trans, &output_types, outputs));
+                               trans: trans::OngoingCrateTranslation,
+                               outputs: &OutputFilenames)
+                               -> (CompileResult, trans::CrateTranslation) {
+    let trans = trans.join(sess, outputs);
 
-        write::run_assembler(sess, outputs);
-
-        // HACK the linker expects the object file to be named foo.0.o but
-        // `run_assembler` produces an object named just foo.o. Rename it if we
-        // are going to build an executable
-        if sess.opts.output_types.contains_key(&OutputType::Exe) {
-            let f = outputs.path(OutputType::Object);
-            rename_or_copy_remove(&f,
-                     f.with_file_name(format!("{}.0.o",
-                                              f.file_stem().unwrap().to_string_lossy()))).unwrap();
-        }
-
-        // Remove assembly source, unless --save-temps was specified
-        if !sess.opts.cg.save_temps {
-            fs::remove_file(&outputs.temp_path(OutputType::Assembly, None)).unwrap();
-        }
-    } else {
-        time(sess.time_passes(),
-             "LLVM passes",
-             || write::run_passes(sess, trans, &sess.opts.output_types, outputs));
+    if sess.opts.debugging_opts.incremental_info {
+        write::dump_incremental_data(&trans);
     }
 
     time(sess.time_passes(),
          "serialize work products",
          move || rustc_incremental::save_work_products(sess));
 
-    sess.compile_status()
+    (sess.compile_status(), trans)
 }
 
 /// Run the linker on any artifacts that resulted from the LLVM run.

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -206,7 +206,7 @@ pub fn compile_input(sess: &Session,
                 println!("Pre-trans");
                 tcx.print_debug_stats();
             }
-            let trans = phase_4_translate_to_llvm(tcx, analysis, &incremental_hashes_map,
+            let trans = phase_4_translate_to_llvm(tcx, analysis, incremental_hashes_map,
                                                   &outputs);
 
             if log_enabled!(::log::LogLevel::Info) {
@@ -1051,7 +1051,7 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
 /// be discarded.
 pub fn phase_4_translate_to_llvm<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                            analysis: ty::CrateAnalysis,
-                                           incremental_hashes_map: &IncrementalHashesMap,
+                                           incremental_hashes_map: IncrementalHashesMap,
                                            output_filenames: &OutputFilenames)
                                            -> write::OngoingCrateTranslation {
     let time_passes = tcx.sess.time_passes();
@@ -1063,7 +1063,7 @@ pub fn phase_4_translate_to_llvm<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let translation =
         time(time_passes,
              "translation",
-             move || trans::trans_crate(tcx, analysis, &incremental_hashes_map, output_filenames));
+             move || trans::trans_crate(tcx, analysis, incremental_hashes_map, output_filenames));
 
     translation
 }

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -229,7 +229,7 @@ pub fn compile_input(sess: &Session,
         sess.code_stats.borrow().print_type_sizes();
     }
 
-    let (phase5_result, trans) = phase_5_run_llvm_passes(sess, trans, &outputs);
+    let (phase5_result, trans) = phase_5_run_llvm_passes(sess, trans);
 
     controller_entry_point!(after_llvm,
                             sess,
@@ -1071,10 +1071,9 @@ pub fn phase_4_translate_to_llvm<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 /// Run LLVM itself, producing a bitcode file, assembly file or object file
 /// as a side effect.
 pub fn phase_5_run_llvm_passes(sess: &Session,
-                               trans: write::OngoingCrateTranslation,
-                               outputs: &OutputFilenames)
+                               trans: write::OngoingCrateTranslation)
                                -> (CompileResult, trans::CrateTranslation) {
-    let trans = trans.join(sess, outputs);
+    let trans = trans.join(sess);
 
     if sess.opts.debugging_opts.incremental_info {
         write::dump_incremental_data(&trans);

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -237,8 +237,6 @@ pub fn compile_input(sess: &Session,
                             phase5_result);
     phase5_result?;
 
-    write::cleanup_llvm(&trans);
-
     phase_6_link_output(sess, &trans, &outputs);
 
     // Now that we won't touch anything in the incremental compilation directory

--- a/src/librustc_incremental/persist/save.rs
+++ b/src/librustc_incremental/persist/save.rs
@@ -34,7 +34,7 @@ use super::file_format;
 use super::work_product;
 
 pub fn save_dep_graph<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                                incremental_hashes_map: &IncrementalHashesMap,
+                                incremental_hashes_map: IncrementalHashesMap,
                                 metadata_hashes: &EncodedMetadataHashes,
                                 svh: Svh) {
     debug!("save_dep_graph()");
@@ -51,7 +51,7 @@ pub fn save_dep_graph<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         eprintln!("incremental: {} edges in dep-graph", query.graph.len_edges());
     }
 
-    let mut hcx = HashContext::new(tcx, incremental_hashes_map);
+    let mut hcx = HashContext::new(tcx, &incremental_hashes_map);
     let preds = Predecessors::new(&query, &mut hcx);
     let mut current_metadata_hashes = FxHashMap();
 

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -15,7 +15,8 @@ use schema;
 use rustc::ty::maps::QueryConfig;
 use rustc::middle::cstore::{CrateStore, CrateSource, LibSource, DepKind,
                             NativeLibrary, MetadataLoader, LinkMeta,
-                            LinkagePreference, LoadedMacro, EncodedMetadata};
+                            LinkagePreference, LoadedMacro, EncodedMetadata,
+                            EncodedMetadataHashes};
 use rustc::hir::def;
 use rustc::middle::lang_items;
 use rustc::session::Session;
@@ -443,7 +444,7 @@ impl CrateStore for cstore::CStore {
                                  tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                  link_meta: &LinkMeta,
                                  reachable: &NodeSet)
-                                 -> EncodedMetadata
+                                 -> (EncodedMetadata, EncodedMetadataHashes)
     {
         encoder::encode_metadata(tcx, link_meta, reachable)
     }

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -1638,7 +1638,7 @@ impl<'a, 'tcx, 'v> ItemLikeVisitor<'v> for ImplVisitor<'a, 'tcx> {
 pub fn encode_metadata<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                  link_meta: &LinkMeta,
                                  exported_symbols: &NodeSet)
-                                 -> EncodedMetadata
+                                 -> (EncodedMetadata, EncodedMetadataHashes)
 {
     let mut cursor = Cursor::new(vec![]);
     cursor.write_all(METADATA_HEADER).unwrap();
@@ -1681,10 +1681,7 @@ pub fn encode_metadata<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     result[header + 2] = (pos >> 8) as u8;
     result[header + 3] = (pos >> 0) as u8;
 
-    EncodedMetadata {
-        raw_data: result,
-        hashes: metadata_hashes,
-    }
+    (EncodedMetadata { raw_data: result }, metadata_hashes)
 }
 
 pub fn get_repr_options<'a, 'tcx, 'gcx>(tcx: &TyCtxt<'a, 'tcx, 'gcx>, did: DefId) -> ReprOptions {

--- a/src/librustc_trans/Cargo.toml
+++ b/src/librustc_trans/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["dylib"]
 test = false
 
 [dependencies]
-crossbeam = "0.2"
+num_cpus = "1.0"
 flate2 = "0.2"
 jobserver = "0.1.5"
 log = "0.3"

--- a/src/librustc_trans/assert_module_sources.rs
+++ b/src/librustc_trans/assert_module_sources.rs
@@ -37,11 +37,22 @@ use rustc::ich::{ATTR_PARTITION_REUSED, ATTR_PARTITION_TRANSLATED};
 const MODULE: &'static str = "module";
 const CFG: &'static str = "cfg";
 
-#[derive(Debug, PartialEq)]
-enum Disposition { Reused, Translated }
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum Disposition { Reused, Translated }
+
+impl ModuleTranslation {
+    pub fn disposition(&self) -> (String, Disposition) {
+        let disposition = match self.source {
+            ModuleSource::Preexisting(_) => Disposition::Reused,
+            ModuleSource::Translated(_) => Disposition::Translated,
+        };
+
+        (self.name.clone(), disposition)
+    }
+}
 
 pub(crate) fn assert_module_sources<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                                              modules: &[ModuleTranslation]) {
+                                              modules: &[(String, Disposition)]) {
     let _ignore = tcx.dep_graph.in_ignore();
 
     if tcx.sess.opts.incremental.is_none() {
@@ -56,7 +67,7 @@ pub(crate) fn assert_module_sources<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
 struct AssertModuleSource<'a, 'tcx: 'a> {
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
-    modules: &'a [ModuleTranslation],
+    modules: &'a [(String, Disposition)],
 }
 
 impl<'a, 'tcx> AssertModuleSource<'a, 'tcx> {
@@ -75,15 +86,15 @@ impl<'a, 'tcx> AssertModuleSource<'a, 'tcx> {
         }
 
         let mname = self.field(attr, MODULE);
-        let mtrans = self.modules.iter().find(|mtrans| *mtrans.name == *mname.as_str());
+        let mtrans = self.modules.iter().find(|&&(ref name, _)| name == mname.as_str());
         let mtrans = match mtrans {
             Some(m) => m,
             None => {
                 debug!("module name `{}` not found amongst:", mname);
-                for mtrans in self.modules {
+                for &(ref name, ref disposition) in self.modules {
                     debug!("module named `{}` with disposition {:?}",
-                           mtrans.name,
-                           self.disposition(mtrans));
+                           name,
+                           disposition);
                 }
 
                 self.tcx.sess.span_err(
@@ -93,7 +104,7 @@ impl<'a, 'tcx> AssertModuleSource<'a, 'tcx> {
             }
         };
 
-        let mtrans_disposition = self.disposition(mtrans);
+        let mtrans_disposition = mtrans.1;
         if disposition != mtrans_disposition {
             self.tcx.sess.span_err(
                 attr.span,
@@ -101,13 +112,6 @@ impl<'a, 'tcx> AssertModuleSource<'a, 'tcx> {
                          mname,
                          disposition,
                          mtrans_disposition));
-        }
-    }
-
-    fn disposition(&self, mtrans: &ModuleTranslation) -> Disposition {
-        match mtrans.source {
-            ModuleSource::Preexisting(_) => Disposition::Reused,
-            ModuleSource::Translated(_) => Disposition::Translated,
         }
     }
 

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -665,7 +665,6 @@ pub fn run_passes(sess: &Session,
                   modules: Vec<ModuleTranslation>,
                   metadata_module: ModuleTranslation,
                   allocator_module: Option<ModuleTranslation>,
-                  output_types_override: &OutputTypes,
                   crate_output: &OutputFilenames,
 
                   crate_name: Symbol,
@@ -689,6 +688,12 @@ pub fn run_passes(sess: &Session,
         // LLVM context, so they can't easily be combined.
         sess.fatal("can't perform LTO when using multiple codegen units");
     }
+
+    let output_types_override = if no_integrated_as {
+        OutputTypes::new(&[(OutputType::Assembly, None)])
+    } else {
+        sess.opts.output_types.clone()
+    };
 
     // Sanity check
     assert!(modules.len() == sess.opts.cg.codegen_units ||

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -678,7 +678,6 @@ pub fn run_passes(sess: &Session,
     };
 
     // Figure out what we actually need to build.
-
     let mut modules_config = ModuleConfig::new(sess, sess.opts.cg.passes.clone());
     let mut metadata_config = ModuleConfig::new(sess, vec![]);
     let mut allocator_config = ModuleConfig::new(sess, vec![]);
@@ -1614,5 +1613,9 @@ impl OngoingCrateTranslation {
 
     pub fn signal_translation_done(&self) {
         drop(self.coordinator_send.send(Message::TranslationDone));
+    }
+
+    pub fn check_for_errors(&self, sess: &Session) {
+        self.shared_emitter_main.check(sess, false);
     }
 }

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -673,19 +673,6 @@ pub fn run_passes(sess: &Session,
                   linker_info: LinkerInfo,
                   no_integrated_as: bool)
                   -> OngoingCrateTranslation {
-    // It's possible that we have `codegen_units > 1` but only one item in
-    // `trans.modules`.  We could theoretically proceed and do LTO in that
-    // case, but it would be confusing to have the validity of
-    // `-Z lto -C codegen-units=2` depend on details of the crate being
-    // compiled, so we complain regardless.
-    if sess.lto() && sess.opts.cg.codegen_units > 1 {
-        // This case is impossible to handle because LTO expects to be able
-        // to combine the entire crate and all its dependencies into a
-        // single compilation unit, but each codegen unit is in a separate
-        // LLVM context, so they can't easily be combined.
-        sess.fatal("can't perform LTO when using multiple codegen units");
-    }
-
     let output_types_override = if no_integrated_as {
         OutputTypes::new(&[(OutputType::Assembly, None)])
     } else {

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -341,7 +341,7 @@ pub struct CodegenContext {
     // compiling incrementally
     pub incr_comp_session_dir: Option<PathBuf>,
     // Channel back to the main control thread to send messages to
-    pub coordinator_send: Sender<Message>,
+    coordinator_send: Sender<Message>,
 }
 
 impl CodegenContext {
@@ -660,17 +660,17 @@ fn need_crate_bitcode_for_rlib(sess: &Session) -> bool {
     sess.opts.output_types.contains_key(&OutputType::Exe)
 }
 
-pub fn run_passes(sess: &Session,
-                  crate_output: &OutputFilenames,
-                  crate_name: Symbol,
-                  link: LinkMeta,
-                  metadata: EncodedMetadata,
-                  exported_symbols: Arc<ExportedSymbols>,
-                  no_builtins: bool,
-                  windows_subsystem: Option<String>,
-                  linker_info: LinkerInfo,
-                  no_integrated_as: bool)
-                  -> OngoingCrateTranslation {
+pub fn start_async_translation(sess: &Session,
+                               crate_output: &OutputFilenames,
+                               crate_name: Symbol,
+                               link: LinkMeta,
+                               metadata: EncodedMetadata,
+                               exported_symbols: Arc<ExportedSymbols>,
+                               no_builtins: bool,
+                               windows_subsystem: Option<String>,
+                               linker_info: LinkerInfo,
+                               no_integrated_as: bool)
+                               -> OngoingCrateTranslation {
     let output_types_override = if no_integrated_as {
         OutputTypes::new(&[(OutputType::Assembly, None)])
     } else {
@@ -1061,7 +1061,7 @@ fn execute_work_item(cgcx: &CodegenContext, work_item: WorkItem)
 }
 
 #[derive(Debug)]
-pub enum Message {
+enum Message {
     Token(io::Result<Acquired>),
     Done { result: Result<CompiledModule, ()> },
     WorkItem(WorkItem),
@@ -1069,8 +1069,7 @@ pub enum Message {
     TranslationDone,
 }
 
-
-pub struct Diagnostic {
+struct Diagnostic {
     msg: String,
     code: Option<String>,
     lvl: Level,
@@ -1519,14 +1518,14 @@ impl SharedEmitterMain {
 }
 
 pub struct OngoingCrateTranslation {
-    pub crate_name: Symbol,
-    pub link: LinkMeta,
-    pub metadata: EncodedMetadata,
-    pub exported_symbols: Arc<ExportedSymbols>,
-    pub no_builtins: bool,
-    pub windows_subsystem: Option<String>,
-    pub linker_info: LinkerInfo,
-    pub no_integrated_as: bool,
+    crate_name: Symbol,
+    link: LinkMeta,
+    metadata: EncodedMetadata,
+    exported_symbols: Arc<ExportedSymbols>,
+    no_builtins: bool,
+    windows_subsystem: Option<String>,
+    linker_info: LinkerInfo,
+    no_integrated_as: bool,
 
     output_filenames: OutputFilenames,
     regular_module_config: ModuleConfig,

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -44,7 +44,7 @@ use rustc::dep_graph::AssertDepGraphSafe;
 use rustc::middle::cstore::LinkMeta;
 use rustc::hir::map as hir_map;
 use rustc::util::common::time;
-use rustc::session::config::{self, NoDebugInfo, OutputFilenames, OutputType, OutputTypes};
+use rustc::session::config::{self, NoDebugInfo, OutputFilenames, OutputType};
 use rustc::session::Session;
 use rustc_incremental::{self, IncrementalHashesMap};
 use abi;
@@ -967,7 +967,6 @@ pub fn trans_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                  vec![],
                                  metadata_module,
                                  None,
-                                 &output_filenames.outputs,
                                  output_filenames,
 
                                  tcx.crate_name(LOCAL_CRATE),
@@ -1237,44 +1236,22 @@ pub fn trans_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                               link_meta.crate_hash));
     // ---
 
-    if no_integrated_as {
-        let output_types = OutputTypes::new(&[(OutputType::Assembly, None)]);
-        time(sess.time_passes(),
-             "LLVM passes",
-             || write::run_passes(sess,
-                                  modules,
-                                  metadata_module,
-                                  allocator_module,
-                                  &output_types,
-                                  outputs,
+    time(sess.time_passes(),
+         "LLVM passes",
+         || write::run_passes(sess,
+                              modules,
+                              metadata_module,
+                              allocator_module,
+                              outputs,
 
-                                  tcx.crate_name(LOCAL_CRATE),
-                                  link_meta,
-                                  metadata,
-                                  exported_symbols,
-                                  no_builtins,
-                                  windows_subsystem,
-                                  linker_info,
-                                  no_integrated_as))
-    } else {
-        time(sess.time_passes(),
-             "LLVM passes",
-             || write::run_passes(sess,
-                                  modules,
-                                  metadata_module,
-                                  allocator_module,
-                                  &sess.opts.output_types,
-                                  outputs,
-
-                                  tcx.crate_name(LOCAL_CRATE),
-                                  link_meta,
-                                  metadata,
-                                  exported_symbols,
-                                  no_builtins,
-                                  windows_subsystem,
-                                  linker_info,
-                                  no_integrated_as))
-    }
+                              tcx.crate_name(LOCAL_CRATE),
+                              link_meta,
+                              metadata,
+                              exported_symbols,
+                              no_builtins,
+                              windows_subsystem,
+                              linker_info,
+                              no_integrated_as))
 }
 
 #[inline(never)] // give this a place in the profiler

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -962,7 +962,7 @@ pub fn trans_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
        !tcx.sess.opts.output_types.should_trans() {
         let empty_exported_symbols = ExportedSymbols::empty();
         let linker_info = LinkerInfo::new(&shared_ccx, &empty_exported_symbols);
-        let ongoing_translation = write::run_passes(
+        let ongoing_translation = write::start_async_translation(
             tcx.sess,
             output_filenames,
             tcx.crate_name(LOCAL_CRATE),
@@ -1012,7 +1012,7 @@ pub fn trans_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
          (output_filenames.outputs.contains_key(&OutputType::Object) ||
           output_filenames.outputs.contains_key(&OutputType::Exe)));
 
-    let ongoing_translation = write::run_passes(
+    let ongoing_translation = write::start_async_translation(
         tcx.sess,
         output_filenames,
         tcx.crate_name(LOCAL_CRATE),

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -23,7 +23,6 @@
 //!     but one TypeRef corresponds to many `Ty`s; for instance, tup(int, int,
 //!     int) and rec(x=int, y=int, z=int) will have the same TypeRef.
 
-use super::OngoingCrateTranslation;
 use super::ModuleLlvm;
 use super::ModuleSource;
 use super::ModuleTranslation;
@@ -33,6 +32,7 @@ use assert_module_sources;
 use back::link;
 use back::linker::LinkerInfo;
 use back::symbol_export::{self, ExportedSymbols};
+use back::write::OngoingCrateTranslation;
 use llvm::{ContextRef, Linkage, ModuleRef, ValueRef, Vector, get_param};
 use llvm;
 use metadata;

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -966,7 +966,6 @@ pub fn trans_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         let ongoing_translation = write::run_passes(
             tcx.sess,
             output_filenames,
-            1,
             tcx.crate_name(LOCAL_CRATE),
             link_meta,
             metadata,
@@ -977,6 +976,7 @@ pub fn trans_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             false);
 
         ongoing_translation.submit_translated_module_to_llvm(tcx.sess, metadata_module);
+        ongoing_translation.signal_translation_done();
 
         return ongoing_translation;
     }
@@ -1237,14 +1237,9 @@ pub fn trans_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                               &metadata.hashes,
                                               link_meta.crate_hash));
     // ---
-
-    let total_module_count = modules.len() + 1 +
-        if allocator_module.is_some() { 1 } else { 0 };
-
     let ongoing_translation = write::run_passes(
         sess,
         outputs,
-        total_module_count,
         tcx.crate_name(LOCAL_CRATE),
         link_meta,
         metadata,
@@ -1263,6 +1258,8 @@ pub fn trans_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     if let Some(allocator_module) = allocator_module {
         ongoing_translation.submit_translated_module_to_llvm(sess, allocator_module);
     }
+
+    ongoing_translation.signal_translation_done();
 
     ongoing_translation
 }

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -35,11 +35,7 @@
 #![feature(conservative_impl_trait)]
 
 use rustc::dep_graph::WorkProduct;
-use rustc::session::Session;
-use rustc::session::config::{OutputType, OutputFilenames};
-use rustc::util::fs::rename_or_copy_remove;
 use syntax_pos::symbol::Symbol;
-use std::fs;
 use std::sync::Arc;
 
 extern crate flate2;
@@ -227,65 +223,6 @@ pub struct CrateTranslation {
     pub no_builtins: bool,
     pub windows_subsystem: Option<String>,
     pub linker_info: back::linker::LinkerInfo
-}
-
-pub struct OngoingCrateTranslation {
-    pub crate_name: Symbol,
-    pub link: rustc::middle::cstore::LinkMeta,
-    pub metadata: rustc::middle::cstore::EncodedMetadata,
-    pub exported_symbols: Arc<back::symbol_export::ExportedSymbols>,
-    pub no_builtins: bool,
-    pub windows_subsystem: Option<String>,
-    pub linker_info: back::linker::LinkerInfo,
-    pub no_integrated_as: bool,
-
-    // This will be replaced by a Future.
-    pub result: ::std::cell::RefCell<Option<back::write::CompiledModules>>,
-}
-
-impl OngoingCrateTranslation {
-    pub fn join(self,
-                sess: &Session,
-                outputs: &OutputFilenames)
-                -> CrateTranslation {
-
-        let result = self.result.borrow_mut().take().unwrap();
-
-        let trans = CrateTranslation {
-            crate_name: self.crate_name,
-            link: self.link,
-            metadata: self.metadata,
-            exported_symbols: self.exported_symbols,
-            no_builtins: self.no_builtins,
-            windows_subsystem: self.windows_subsystem,
-            linker_info: self.linker_info,
-
-            modules: result.modules,
-            metadata_module: result.metadata_module,
-            allocator_module: result.allocator_module,
-        };
-
-        if self.no_integrated_as {
-            back::write::run_assembler(sess, outputs);
-
-            // HACK the linker expects the object file to be named foo.0.o but
-            // `run_assembler` produces an object named just foo.o. Rename it if we
-            // are going to build an executable
-            if sess.opts.output_types.contains_key(&OutputType::Exe) {
-                let f = outputs.path(OutputType::Object);
-                rename_or_copy_remove(&f,
-                         f.with_file_name(format!("{}.0.o",
-                                                  f.file_stem().unwrap().to_string_lossy()))).unwrap();
-            }
-
-            // Remove assembly source, unless --save-temps was specified
-            if !sess.opts.cg.save_temps {
-                fs::remove_file(&outputs.temp_path(OutputType::Assembly, None)).unwrap();
-            }
-        }
-
-        trans
-    }
 }
 
 __build_diagnostic_array! { librustc_trans, DIAGNOSTICS }

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -125,6 +125,7 @@ mod mir;
 mod monomorphize;
 mod partitioning;
 mod symbol_names_test;
+mod time_graph;
 mod trans_item;
 mod tvec;
 mod type_;

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -188,10 +188,8 @@ pub struct OngoingCrateTranslation {
     pub linker_info: back::linker::LinkerInfo,
     pub no_integrated_as: bool,
 
-    // These will be replaced by a Future.
-    pub modules: Vec<ModuleTranslation>,
-    pub metadata_module: ModuleTranslation,
-    pub allocator_module: Option<ModuleTranslation>,
+    // This will be replaced by a Future.
+    pub result: ::std::cell::RefCell<Option<back::write::RunLLVMPassesResult>>,
 }
 
 impl OngoingCrateTranslation {
@@ -199,6 +197,8 @@ impl OngoingCrateTranslation {
                 sess: &Session,
                 outputs: &OutputFilenames)
                 -> CrateTranslation {
+
+        let result = self.result.borrow_mut().take().unwrap();
 
         let trans = CrateTranslation {
             crate_name: self.crate_name,
@@ -209,9 +209,9 @@ impl OngoingCrateTranslation {
             windows_subsystem: self.windows_subsystem,
             linker_info: self.linker_info,
 
-            modules: self.modules,
-            metadata_module: self.metadata_module,
-            allocator_module: self.allocator_module,
+            modules: result.modules,
+            metadata_module: result.metadata_module,
+            allocator_module: result.allocator_module,
         };
 
         if self.no_integrated_as {

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -39,7 +39,6 @@ use syntax_pos::symbol::Symbol;
 use std::sync::Arc;
 
 extern crate flate2;
-extern crate crossbeam;
 extern crate libc;
 extern crate owning_ref;
 #[macro_use] extern crate rustc;
@@ -55,6 +54,7 @@ extern crate rustc_const_math;
 extern crate rustc_bitflags;
 extern crate rustc_demangle;
 extern crate jobserver;
+extern crate num_cpus;
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate syntax;

--- a/src/librustc_trans/time_graph.rs
+++ b/src/librustc_trans/time_graph.rs
@@ -1,0 +1,181 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+use std::io::prelude::*;
+use std::fs::File;
+
+const OUTPUT_WIDTH_IN_PX: u64 = 1000;
+const TIME_LINE_HEIGHT_IN_PX: u64 = 7;
+const TIME_LINE_HEIGHT_STRIDE_IN_PX: usize = 10;
+
+#[derive(Clone)]
+struct Timing {
+    start: Instant,
+    end: Instant,
+    work_package_kind: WorkPackageKind,
+}
+
+#[derive(Clone, Copy, Hash, Eq, PartialEq, Debug)]
+pub struct TimelineId(pub usize);
+
+#[derive(Clone)]
+struct PerThread {
+    timings: Vec<Timing>,
+    open_work_package: Option<(Instant, WorkPackageKind)>,
+}
+
+#[derive(Clone)]
+pub struct TimeGraph {
+    data: Arc<Mutex<HashMap<TimelineId, PerThread>>>,
+}
+
+#[derive(Clone, Copy)]
+pub struct WorkPackageKind(pub &'static [&'static str]);
+
+pub struct RaiiToken {
+    graph: TimeGraph,
+    timeline: TimelineId,
+    // The token must not be Send:
+    _marker: PhantomData<*const ()>
+}
+
+
+impl Drop for RaiiToken {
+    fn drop(&mut self) {
+        self.graph.end(self.timeline);
+    }
+}
+
+impl TimeGraph {
+    pub fn new() -> TimeGraph {
+        TimeGraph {
+            data: Arc::new(Mutex::new(HashMap::new()))
+        }
+    }
+
+    pub fn start(&self,
+                 timeline: TimelineId,
+                 work_package_kind: WorkPackageKind) -> RaiiToken {
+        {
+            let mut table = self.data.lock().unwrap();
+
+            let mut data = table.entry(timeline).or_insert(PerThread {
+                timings: Vec::new(),
+                open_work_package: None,
+            });
+
+            assert!(data.open_work_package.is_none());
+            data.open_work_package = Some((Instant::now(), work_package_kind));
+        }
+
+        RaiiToken {
+            graph: self.clone(),
+            timeline,
+            _marker: PhantomData,
+        }
+    }
+
+    fn end(&self, timeline: TimelineId) {
+        let end = Instant::now();
+
+        let mut table = self.data.lock().unwrap();
+        let mut data = table.get_mut(&timeline).unwrap();
+
+        if let Some((start, work_package_kind)) = data.open_work_package {
+            data.timings.push(Timing {
+                start,
+                end,
+                work_package_kind,
+            });
+        } else {
+            bug!("end timing without start?")
+        }
+
+        data.open_work_package = None;
+    }
+
+    pub fn dump(&self, output_filename: &str) {
+        let table = self.data.lock().unwrap();
+
+        for data in table.values() {
+            assert!(data.open_work_package.is_none());
+        }
+
+        let mut timelines: Vec<PerThread> =
+            table.values().map(|data| data.clone()).collect();
+
+        timelines.sort_by_key(|timeline| timeline.timings[0].start);
+
+        let earliest_instant = timelines[0].timings[0].start;
+        let latest_instant = timelines.iter()
+                                       .map(|timeline| timeline.timings
+                                                               .last()
+                                                               .unwrap()
+                                                               .end)
+                                       .max()
+                                       .unwrap();
+        let max_distance = distance(earliest_instant, latest_instant);
+
+        let mut file = File::create(format!("{}.html", output_filename)).unwrap();
+
+        writeln!(file, "<html>").unwrap();
+        writeln!(file, "<head></head>").unwrap();
+        writeln!(file, "<body>").unwrap();
+
+        let mut color = 0;
+
+        for (line_index, timeline) in timelines.iter().enumerate() {
+            let line_top = line_index * TIME_LINE_HEIGHT_STRIDE_IN_PX;
+
+            for span in &timeline.timings {
+                let start = distance(earliest_instant, span.start);
+                let end = distance(earliest_instant, span.end);
+
+                let start = normalize(start, max_distance, OUTPUT_WIDTH_IN_PX);
+                let end = normalize(end, max_distance, OUTPUT_WIDTH_IN_PX);
+
+                let colors = span.work_package_kind.0;
+
+                writeln!(file, "<div style='position:absolute; \
+                                            top:{}px; \
+                                            left:{}px; \
+                                            width:{}px; \
+                                            height:{}px; \
+                                            background:{};'></div>",
+                    line_top,
+                    start,
+                    end - start,
+                    TIME_LINE_HEIGHT_IN_PX,
+                    colors[color % colors.len()]
+                    ).unwrap();
+
+                color += 1;
+            }
+        }
+
+        writeln!(file, "</body>").unwrap();
+        writeln!(file, "</html>").unwrap();
+    }
+}
+
+fn distance(zero: Instant, x: Instant) -> u64 {
+
+    let duration = x.duration_since(zero);
+    (duration.as_secs() * 1_000_000_000 + duration.subsec_nanos() as u64) // / div
+}
+
+fn normalize(distance: u64, max: u64, max_pixels: u64) -> u64 {
+    (max_pixels * distance) / max
+}
+

--- a/src/test/run-make/llvm-phase/test.rs
+++ b/src/test/run-make/llvm-phase/test.rs
@@ -54,11 +54,7 @@ impl<'a> CompilerCalls<'a> for JitCalls {
             state.session.abort_if_errors();
             let trans = state.trans.unwrap();
             assert_eq!(trans.modules.len(), 1);
-            let rs_llmod = match trans.modules[0].source {
-                ModuleSource::Preexisting(_) => unimplemented!(),
-                ModuleSource::Translated(llvm) => llvm.llmod,
-            };
-            unsafe { rustc_llvm::LLVMDumpModule(rs_llmod) };
+            println!("name of compiled module = {}", trans.modules[0].name);
         });
         cc
     }


### PR DESCRIPTION
This is still a work in progress but the bulk of the implementation is done, so I thought it would be good to get it in front of more eyes.

This PR makes the compiler start running LLVM while translation is still in progress, effectively allowing for more parallelism towards the end of the compilation pipeline. It also allows the main thread to switch between either translation or running LLVM, which allows to reduce peak memory usage since not all LLVM module have to be kept in memory until linking. This is especially good for incr. comp. but it works just as well when running with `-Ccodegen-units=N`.

In order to help tuning and debugging the work scheduler, the PR adds the `-Ztrans-time-graph` flag which spits out html files that show how work packages where scheduled:
![Building regex](https://user-images.githubusercontent.com/1825894/28679272-f6752bd8-72f2-11e7-8a6c-56207855ce95.png)
(red is translation, green is llvm)

One side effect here is that `-Ztime-passes` might show something not quite correct because trans and LLVM are not strictly separated anymore. I plan to have some special handling there that will try to produce useful output.

One open question is how to determine whether the trans-thread should switch to intermediate LLVM processing.

TODO:
- [x] Restore `-Z time-passes` output for LLVM.
- [x] Update documentation, esp. for work package scheduling.
- [x] Tune the scheduling algorithm.

cc @alexcrichton @rust-lang/compiler 