### PR TITLE
rustdoc: add [src] links to associated functions inside an impl block

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2939,7 +2939,15 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
                     write!(w, "<code>")?;
                     render_assoc_item(w, item, link.anchor(&id), ItemType::Impl)?;
                     write!(w, "</code>")?;
-                    render_stability_since_raw(w, item.stable_since(), outer_version)?;
+                    if let Some(l) = (Item { cx, item }).src_href() {
+                        write!(w, "</span><span class='out-of-band'>")?;
+                        write!(w, "<div class='ghost'></div>")?;
+                        render_stability_since_raw(w, item.stable_since(), outer_version)?;
+                        write!(w, "<a class='srclink' href='{}' title='{}'>[src]</a>",
+                               l, "goto source code")?;
+                    } else {
+                        render_stability_since_raw(w, item.stable_since(), outer_version)?;
+                    }
                     write!(w, "</span></h4>\n")?;
                 }
             }

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -297,6 +297,10 @@ h3.impl > .out-of-band {
 	font-size: 21px;
 }
 
+h4.method > .out-of-band {
+	font-size: 19px;
+}
+
 h4 > code, h3 > code, .invisible > code {
 	position: inherit;
 }


### PR DESCRIPTION
While impl blocks currently have a `[src]` link to show the source for the impl block as a whole, individual methods inside that impl block do not. This can pose a problem for structs with a lot of methods, like many in libstd. This change adds little `[src]` links to individual methods that point directly to the function in the bundled source.

fixes #12932

![methods on HashMap, showing the new src links](https://user-images.githubusercontent.com/5217170/28686066-9e7a19de-72cf-11e7-8e6b-b7d60fa33032.png)
