### PR TITLE
rustdoc: print associated types in traits "implementors" section

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2235,6 +2235,13 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                 _ => false,
             };
             fmt_impl_for_trait_page(&implementor.impl_, w, use_absolute)?;
+            for it in &implementor.impl_.items {
+                if let clean::TypedefItem(ref tydef, _) = it.inner {
+                    write!(w, "<span class=\"where fmt-newline\">  ")?;
+                    assoc_type(w, it, &vec![], Some(&tydef.type_), AssocItemLink::Anchor(None))?;
+                    write!(w, ";</span>")?;
+                }
+            }
             writeln!(w, "</code></li>")?;
         }
     }


### PR DESCRIPTION
When viewing a trait's implementors, they won't show anything about the implementation other than any bounds on the generics. You can see the full implementation details on the page for the type, but if the type is external (e.g. it's an extension trait being implemented for primitives), then you'll never be able to see the details of the implementation without opening the source code. This doesn't solve everything about that, but it does still show an incredibly useful piece of information: the associated types. This can help immensely for traits like `Deref` or `IntoIterator` in libstd, and also for traits like `IntoFuture` outside the standard library.

Fixes #24200

🚨 BIKESHED ALERT 🚨 The indentation and sizing of the types is suspect. I put it in the small text so it wouldn't blend in with the next impl line. (It shares a CSS class with the where clauses, as you can see in the following image.) However, the indentation is nonstandard. I initially tried with no indentation (looked awkward and blended too well with the surrounding impls) and with 4-space indentation (too easy to confuse with where clauses), before settling on the 2-space indentation seen below. It's... okay, i guess. Open to suggestions.

![snippet of the implementors of IntoIterator, showing the associated types](https://user-images.githubusercontent.com/5217170/28697456-a4e01a12-7301-11e7-868e-2a6441d6c9e0.png)