### PR TITLE
rustbuild: Tweak how we cross-compile LLVM

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -154,6 +154,14 @@ impl Step for Llvm {
             let host = build.llvm_out(build.build).join("bin/llvm-tblgen");
             cfg.define("CMAKE_CROSSCOMPILING", "True")
                .define("LLVM_TABLEGEN", &host);
+
+            if target.contains("netbsd") {
+               cfg.define("CMAKE_SYSTEM_NAME", "NetBSD");
+            } else if target.contains("freebsd") {
+               cfg.define("CMAKE_SYSTEM_NAME", "FreeBSD");
+            }
+
+            cfg.define("LLVM_NATIVE_BUILD", build.llvm_out(build.build).join("build"));
         }
 
         let sanitize_cc = |cc: &Path| {


### PR DESCRIPTION
In preparation for upgrading to LLVM 5.0 it looks like we need to tweak how we
cross compile LLVM slightly. It's using `CMAKE_SYSTEM_NAME` to infer whether to
build libFuzzer which only works on some platforms, and then once we configure
that it needs to apparently reach into the host build area to try to compile
`llvm-config` as well. Once these are both configured, though, it looks like we
can successfully cross-compile LLVM.