### PR TITLE
rustbuild: Update cross-compilers for FreeBSD

### DIFF
--- a/src/ci/docker/dist-i686-freebsd/build-toolchain.sh
+++ b/src/ci/docker/dist-i686-freebsd/build-toolchain.sh
@@ -13,7 +13,7 @@ set -ex
 
 ARCH=$1
 BINUTILS=2.25.1
-GCC=5.3.0
+GCC=6.4.0
 
 hide_output() {
   set +x
@@ -86,7 +86,7 @@ rm -rf freebsd
 # Finally, download and build gcc to target FreeBSD
 mkdir gcc
 cd gcc
-curl https://ftp.gnu.org/gnu/gcc/gcc-$GCC/gcc-$GCC.tar.bz2 | tar xjf -
+curl https://ftp.gnu.org/gnu/gcc/gcc-$GCC/gcc-$GCC.tar.gz | tar xzf -
 cd gcc-$GCC
 ./contrib/download_prerequisites
 

--- a/src/ci/docker/dist-x86_64-freebsd/build-toolchain.sh
+++ b/src/ci/docker/dist-x86_64-freebsd/build-toolchain.sh
@@ -13,7 +13,7 @@ set -ex
 
 ARCH=$1
 BINUTILS=2.25.1
-GCC=5.3.0
+GCC=6.4.0
 
 hide_output() {
   set +x
@@ -86,7 +86,7 @@ rm -rf freebsd
 # Finally, download and build gcc to target FreeBSD
 mkdir gcc
 cd gcc
-curl https://ftp.gnu.org/gnu/gcc/gcc-$GCC/gcc-$GCC.tar.bz2 | tar xjf -
+curl https://ftp.gnu.org/gnu/gcc/gcc-$GCC/gcc-$GCC.tar.gz | tar xzf -
 cd gcc-$GCC
 ./contrib/download_prerequisites
 


### PR DESCRIPTION
When working through bugs for the LLVM 5.0 upgrade it looks like the FreeBSD
cross compilers we're currently using are unable to build LLVM, failing with
references to the function `std::to_string` claiming it doesn't exist. I don't
actually know what this function is, but assuming that it was added in a more
recent version of a C++ standard I've updated the gcc versions for the
toolchains we're using. This made the error go away!