### PR TITLE
rustbuild: Use Cargo's "target runner"

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1417,8 +1417,19 @@ mod tests {
         let output = String::from_utf8(result.stdout).unwrap();
 
         for (ref k, ref v) in env::vars() {
-            // don't check android RANDOM variables
-            if cfg!(target_os = "android") && *k == "RANDOM" {
+            // Don't check android RANDOM variable which seems to change
+            // whenever the shell runs, and our `env_cmd` is indeed running a
+            // shell which means it'll get a different RANDOM than we probably
+            // have.
+            //
+            // Also skip env vars with `-` in the name on android because, well,
+            // I'm not sure. It appears though that the `set` command above does
+            // not print env vars with `-` in the name, so we just skip them
+            // here as we won't find them in the output. Note that most env vars
+            // use `_` instead of `-`, but our build system sets a few env vars
+            // with `-` in the name.
+            if cfg!(target_os = "android") &&
+               (*k == "RANDOM" || k.contains("-")) {
                 continue
             }
 


### PR DESCRIPTION
This commit leverages a relatively new feature in Cargo to execute
cross-compiled tests, the `target.$target.runner` configuration. We configure it
through environment variables in rustbuild and this avoids the need for us to
locate and run tests after-the-fact, instead relying on Cargo to do all that
execution for us.