### PR TITLE
Changing E0623 error message - both anonymous lifetime regions

### DIFF
--- a/src/librustc/infer/error_reporting/anon_anon_conflict.rs
+++ b/src/librustc/infer/error_reporting/anon_anon_conflict.rs
@@ -77,10 +77,10 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
 
             struct_span_err!(self.tcx.sess, span, E0623, "lifetime mismatch")
                 .span_label(ty1.span,
-                            format!("these references must have the same lifetime"))
+                            format!("these references are not declared with the same lifetime..."))
                 .span_label(ty2.span, format!(""))
                 .span_label(span,
-                            format!("data{}flows{}here", span_label_var1, span_label_var2))
+                            format!("...but data{}flows{}here", span_label_var1, span_label_var2))
                 .emit();
         } else {
             return false;

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-2.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-2.stderr
@@ -2,9 +2,9 @@ error[E0623]: lifetime mismatch
   --> $DIR/ex3-both-anon-regions-2.rs:12:9
    |
 11 | fn foo((v, w): (&u8, &u8), x: &u8) {
-   |                 ---           --- these references must have the same lifetime
+   |                 ---           --- these references are not declared with the same lifetime...
 12 |     v = x;
-   |         ^ data from `x` flows here
+   |         ^ ...but data from `x` flows here
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-3.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-3.stderr
@@ -2,9 +2,9 @@ error[E0623]: lifetime mismatch
   --> $DIR/ex3-both-anon-regions-3.rs:12:9
    |
 11 | fn foo((v, w): (&u8, &u8), (x, y): (&u8, &u8)) {
-   |                 ---                 --- these references must have the same lifetime
+   |                 ---                 --- these references are not declared with the same lifetime...
 12 |     v = x;
-   |         ^ data flows here
+   |         ^ ...but data flows here
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-4.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-4.stderr
@@ -4,17 +4,17 @@ error[E0623]: lifetime mismatch
   --> $DIR/ex3-both-anon-regions-4.rs:12:13
    |
 11 | fn foo(z: &mut Vec<(&u8,&u8)>, (x, y): (&u8, &u8)) {
-   |                     ---                 --- these references must have the same lifetime
+   |                     ---                 --- these references are not declared with the same lifetime...
 12 |     z.push((x,y));
-   |             ^ data flows into `z` here
+   |             ^ ...but data flows into `z` here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ex3-both-anon-regions-4.rs:12:15
    |
 11 | fn foo(z: &mut Vec<(&u8,&u8)>, (x, y): (&u8, &u8)) {
-   |                         ---                  --- these references must have the same lifetime
+   |                         ---                  --- these references are not declared with the same lifetime...
 12 |     z.push((x,y));
-   |               ^ data flows into `z` here
+   |               ^ ...but data flows into `z` here
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions.stderr
@@ -2,9 +2,9 @@ error[E0623]: lifetime mismatch
   --> $DIR/ex3-both-anon-regions.rs:12:12
    |
 11 | fn foo(x: &mut Vec<&u8>, y: &u8) {
-   |                    ---      --- these references must have the same lifetime
+   |                    ---      --- these references are not declared with the same lifetime...
 12 |     x.push(y);
-   |            ^ data from `y` flows into `x` here
+   |            ^ ...but data from `y` flows into `x` here
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Changing the error message to
```
error[E0623]: lifetime mismatch
  --> $DIR/ex3-both-anon-regions.rs:12:12
   |
11 | fn foo(x: &mut Vec<&u8>, y: &u8) {
   |                    ---      --- these references are not declared with the same lifetime...
12 |     x.push(y);
   |            ^ ...but data from `y` flows into `x` here

error: aborting due to previous error
```
cc @nikomatsakis @aturon @jonathandturner 

r? @nikomatsakis 