### PR TITLE
librustc_driver: Remove -Z option from usage on stable compiler

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -795,7 +795,12 @@ fn usage(verbose: bool, include_unstable_options: bool) {
         (option.apply)(&mut options);
     }
     let message = format!("Usage: rustc [OPTIONS] INPUT");
-    let extra_help = if verbose {
+    let nightly_help = if nightly_options::is_nightly_build() {
+        "\n    -Z help             Print internal options for debugging rustc"
+    } else {
+        ""
+    };
+    let verbose_help = if verbose {
         ""
     } else {
         "\n    --help -v           Print the full set of options rustc accepts"
@@ -803,11 +808,10 @@ fn usage(verbose: bool, include_unstable_options: bool) {
     println!("{}\nAdditional help:
     -C help             Print codegen options
     -W help             \
-              Print 'lint' options and default settings
-    -Z help             Print internal \
-              options for debugging rustc{}\n",
+              Print 'lint' options and default settings{}{}\n",
              options.usage(&message),
-             extra_help);
+             nightly_help,
+             verbose_help);
 }
 
 fn describe_lints(lint_store: &lint::LintStore, loaded_plugins: bool) {


### PR DESCRIPTION
The `-Z` flag has been disabled since Rust 1.19 stable, but it still shows in `rustc --help`.

This PR addresses the inconsistency by removing the message on the stable channel.