### PR TITLE
rustbuild: Remove `--enable-llvm-clean-rebuild`

### DIFF
--- a/configure
+++ b/configure
@@ -437,7 +437,6 @@ opt local-rust 0 "use an installed rustc rather than downloading a snapshot"
 opt local-rebuild 0 "assume local-rust matches the current version, for rebuilds; implies local-rust, and is implied if local-rust already matches the current version"
 opt llvm-static-stdcpp 0 "statically link to libstdc++ for LLVM"
 opt llvm-link-shared 0 "prefer shared linking to LLVM (llvm-config --link-shared)"
-opt llvm-clean-rebuild 0 "delete LLVM build directory on rebuild"
 opt rpath 1 "build rpaths into rustc itself"
 opt stage0-landing-pads 1 "enable landing pads during bootstrap with stage0"
 # This is used by the automation to produce single-target nightlies

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -62,7 +62,6 @@ pub struct Config {
     pub llvm_targets: Option<String>,
     pub llvm_experimental_targets: Option<String>,
     pub llvm_link_jobs: Option<u32>,
-    pub llvm_clean_rebuild: bool,
 
     // rust codegen options
     pub rust_optimize: bool,
@@ -203,7 +202,6 @@ struct Llvm {
     targets: Option<String>,
     experimental_targets: Option<String>,
     link_jobs: Option<u32>,
-    clean_rebuild: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Clone)]
@@ -352,7 +350,6 @@ impl Config {
             set(&mut config.llvm_release_debuginfo, llvm.release_debuginfo);
             set(&mut config.llvm_version_check, llvm.version_check);
             set(&mut config.llvm_static_stdcpp, llvm.static_libstdcpp);
-            set(&mut config.llvm_clean_rebuild, llvm.clean_rebuild);
             config.llvm_targets = llvm.targets.clone();
             config.llvm_experimental_targets = llvm.experimental_targets.clone();
             config.llvm_link_jobs = llvm.link_jobs;
@@ -477,7 +474,6 @@ impl Config {
                 ("LLVM_VERSION_CHECK", self.llvm_version_check),
                 ("LLVM_STATIC_STDCPP", self.llvm_static_stdcpp),
                 ("LLVM_LINK_SHARED", self.llvm_link_shared),
-                ("LLVM_CLEAN_REBUILD", self.llvm_clean_rebuild),
                 ("OPTIMIZE", self.rust_optimize),
                 ("DEBUG_ASSERTIONS", self.rust_debug_assertions),
                 ("DEBUGINFO", self.rust_debuginfo),

--- a/src/bootstrap/config.toml.example
+++ b/src/bootstrap/config.toml.example
@@ -69,11 +69,6 @@
 # controlled by rustbuild's -j parameter.
 #link-jobs = 0
 
-# Delete LLVM build directory on LLVM rebuild.
-# This option defaults to `false` for local development, but CI may want to
-# always perform clean full builds (possibly accelerated by (s)ccache).
-#clean-rebuild = false
-
 # =============================================================================
 # General build configuration options
 # =============================================================================

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -80,9 +80,6 @@ impl Step for Llvm {
                 return
             }
         }
-        if build.config.llvm_clean_rebuild {
-            drop(fs::remove_dir_all(&out_dir));
-        }
 
         let _folder = build.fold_output(|| "llvm");
         println!("Building LLVM for {}", target);

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -31,7 +31,6 @@ RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-sccache"
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-manage-submodules"
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-locked-deps"
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-cargo-openssl-static"
-RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-clean-rebuild"
 
 if [ "$DIST_SRC" = "" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-dist-src"


### PR DESCRIPTION
This was intended for bots back in the day where we'd persist caches of LLVM
builds across runs, but nowadays we don't do that on any of the bots so this
option is no longer necessary