### PR TITLE
rustc_mir: don't build unused unwind cleanup blocks

### DIFF
--- a/src/librustc_mir/build/block.rs
+++ b/src/librustc_mir/build/block.rs
@@ -86,7 +86,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                     let tcx = this.hir.tcx();
 
                     // Enter the remainder scope, i.e. the bindings' destruction scope.
-                    this.push_scope(remainder_scope);
+                    this.push_scope((remainder_scope, source_info));
                     let_extent_stack.push(remainder_scope);
 
                     // Declare the bindings, which may create a visibility scope.

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -237,7 +237,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                             .collect();
 
                     let success = this.cfg.start_new_block();
-                    let cleanup = this.diverge_cleanup(expr_span);
+                    let cleanup = this.diverge_cleanup();
                     this.cfg.terminate(block, source_info, TerminatorKind::Call {
                         func: fun,
                         args: args,

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -306,7 +306,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                     let bool_ty = self.hir.bool_ty();
                     let eq_result = self.temp(bool_ty, test.span);
                     let eq_block = self.cfg.start_new_block();
-                    let cleanup = self.diverge_cleanup(test.span);
+                    let cleanup = self.diverge_cleanup();
                     self.cfg.terminate(block, source_info, TerminatorKind::Call {
                         func: Operand::Constant(box Constant {
                             span: test.span,

--- a/src/librustc_mir/build/scope.rs
+++ b/src/librustc_mir/build/scope.rs
@@ -386,8 +386,8 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
 
         // If we are emitting a `drop` statement, we need to have the cached
         // diverge cleanup pads ready in case that drop panics.
-        let may_panic =
-            self.scopes[(len - scope_count)..].iter().any(|s| s.drops.iter().any(|s| s.kind.may_panic()));
+        let may_panic = self.scopes[(len - scope_count)..].iter()
+            .any(|s| s.drops.iter().any(|s| s.kind.may_panic()));
         if may_panic {
             self.diverge_cleanup();
         }

--- a/src/librustc_mir/transform/simplify.rs
+++ b/src/librustc_mir/transform/simplify.rs
@@ -105,6 +105,8 @@ impl<'a, 'tcx: 'a> CfgSimplifier<'a, 'tcx> {
     }
 
     pub fn simplify(mut self) {
+        self.strip_nops();
+
         loop {
             let mut changed = false;
 
@@ -141,8 +143,6 @@ impl<'a, 'tcx: 'a> CfgSimplifier<'a, 'tcx> {
 
             if !changed { break }
         }
-
-        self.strip_nops()
     }
 
     // Collapse a goto chain starting from `start`

--- a/src/test/mir-opt/basic_assignment.rs
+++ b/src/test/mir-opt/basic_assignment.rs
@@ -47,39 +47,39 @@ fn main() {
 //         StorageDead(_3);
 //         StorageLive(_4);
 //         _4 = std::option::Option<std::boxed::Box<u32>>::None;
+//         StorageLive(_5);
 //         StorageLive(_6);
-//         StorageLive(_7);
-//         _7 = _4;
-//         replace(_6 <- _7) -> [return: bb6, unwind: bb7];
+//         _6 = _4;
+//         replace(_5 <- _6) -> [return: bb1, unwind: bb7];
 //     }
 //     bb1: {
-//         resume;
+//         drop(_6) -> [return: bb8, unwind: bb5];
 //     }
 //     bb2: {
-//         drop(_4) -> bb1;
+//         resume;
 //     }
 //     bb3: {
-//         goto -> bb2;
+//         drop(_4) -> bb2;
 //     }
 //     bb4: {
-//         drop(_6) -> bb3;
+//         goto -> bb3;
 //     }
 //     bb5: {
-//         goto -> bb4;
+//         drop(_5) -> bb4;
 //     }
 //     bb6: {
-//         drop(_7) -> [return: bb8, unwind: bb4];
+//         goto -> bb5;
 //     }
 //     bb7: {
-//         drop(_7) -> bb5;
+//         drop(_6) -> bb6;
 //     }
 //     bb8: {
-//         StorageDead(_7);
+//         StorageDead(_6);
 //         _0 = ();
-//         drop(_6) -> [return: bb9, unwind: bb2];
+//         drop(_5) -> [return: bb9, unwind: bb3];
 //     }
 //     bb9: {
-//         StorageDead(_6);
+//         StorageDead(_5);
 //         drop(_4) -> bb10;
 //     }
 //     bb10: {

--- a/src/test/mir-opt/basic_assignment.rs
+++ b/src/test/mir-opt/basic_assignment.rs
@@ -50,10 +50,10 @@ fn main() {
 //         StorageLive(_5);
 //         StorageLive(_6);
 //         _6 = _4;
-//         replace(_5 <- _6) -> [return: bb1, unwind: bb7];
+//         replace(_5 <- _6) -> [return: bb1, unwind: bb5];
 //     }
 //     bb1: {
-//         drop(_6) -> [return: bb8, unwind: bb5];
+//         drop(_6) -> [return: bb6, unwind: bb4];
 //     }
 //     bb2: {
 //         resume;
@@ -62,27 +62,21 @@ fn main() {
 //         drop(_4) -> bb2;
 //     }
 //     bb4: {
-//         goto -> bb3;
+//         drop(_5) -> bb3;
 //     }
 //     bb5: {
-//         drop(_5) -> bb4;
+//         drop(_6) -> bb4;
 //     }
 //     bb6: {
-//         goto -> bb5;
-//     }
-//     bb7: {
-//         drop(_6) -> bb6;
-//     }
-//     bb8: {
 //         StorageDead(_6);
 //         _0 = ();
-//         drop(_5) -> [return: bb9, unwind: bb3];
+//         drop(_5) -> [return: bb7, unwind: bb3];
 //     }
-//     bb9: {
+//     bb7: {
 //         StorageDead(_5);
-//         drop(_4) -> bb10;
+//         drop(_4) -> bb8;
 //     }
-//     bb10: {
+//     bb8: {
 //         StorageDead(_4);
 //         StorageDead(_2);
 //         StorageDead(_1);

--- a/src/test/mir-opt/end_region_4.rs
+++ b/src/test/mir-opt/end_region_4.rs
@@ -32,41 +32,41 @@ fn foo(i: i32) {
 // START rustc.node4.SimplifyCfg-qualify-consts.after.mir
 //     let mut _0: ();
 //     let _1: D;
-//     let _3: i32;
-//     let _4: &'6_2rce i32;
+//     let _2: i32;
+//     let _3: &'6_2rce i32;
 //     let _7: &'6_4rce i32;
-//     let mut _5: ();
-//     let mut _6: i32;
-//
+//     let mut _4: ();
+//     let mut _5: i32;
+//     let mut _6: ();
 //     bb0: {
 //         StorageLive(_1);
 //         _1 = D::{{constructor}}(const 0i32,);
+//         StorageLive(_2);
+//         _2 = const 0i32;
 //         StorageLive(_3);
-//         _3 = const 0i32;
-//         StorageLive(_4);
-//         _4 = &'6_2rce _3;
-//         StorageLive(_6);
-//         _6 = (*_4);
-//         _5 = const foo(_6) -> [return: bb2, unwind: bb3];
+//         _3 = &'6_2rce _2;
+//         StorageLive(_5);
+//         _5 = (*_3);
+//         _4 = const foo(_5) -> [return: bb1, unwind: bb3];
 //     }
 //     bb1: {
-//         resume;
-//     }
-//     bb2: {
-//         StorageDead(_6);
+//         StorageDead(_5);
 //         StorageLive(_7);
-//         _7 = &'6_4rce _3;
+//         _7 = &'6_4rce _2;
 //         _0 = ();
 //         StorageDead(_7);
 //         EndRegion('6_4rce);
-//         StorageDead(_4);
-//         EndRegion('6_2rce);
 //         StorageDead(_3);
+//         EndRegion('6_2rce);
+//         StorageDead(_2);
 //         drop(_1) -> bb4;
+//     }
+//     bb2: {
+//         resume;
 //     }
 //     bb3: {
 //         EndRegion('6_2rce);
-//         drop(_1) -> bb1;
+//         drop(_1) -> bb2;
 //     }
 //     bb4: {
 //         StorageDead(_1);

--- a/src/test/mir-opt/end_region_5.rs
+++ b/src/test/mir-opt/end_region_5.rs
@@ -31,32 +31,31 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 //     let mut _0: ();
 //     let _1: D;
 //     let mut _2: ();
-//     let mut _3: ();
-//     let mut _4: [closure@NodeId(18) d: &'19mce D];
-//     let mut _5: &'19mce D;
-//
+//     let mut _3: [closure@NodeId(18) d:&'19mce D];
+//     let mut _4: &'19mce D;
+//     let mut _5: ();
 //     bb0: {
 //         StorageLive(_1);
 //         _1 = D::{{constructor}}(const 0i32,);
+//         StorageLive(_3);
 //         StorageLive(_4);
-//         StorageLive(_5);
-//         _5 = &'19mce _1;
-//         _4 = [closure@NodeId(18)] { d: _5 };
-//         StorageDead(_5);
-//         _3 = const foo(_4) -> [return: bb2, unwind: bb3];
+//         _4 = &'19mce _1;
+//         _3 = [closure@NodeId(18)] { d: _4 };
+//         StorageDead(_4);
+//         _2 = const foo(_3) -> [return: bb1, unwind: bb3];
 //     }
 //     bb1: {
-//         resume;
-//     }
-//     bb2: {
-//         StorageDead(_4);
+//         StorageDead(_3);
 //         EndRegion('19mce);
 //         _0 = ();
 //         drop(_1) -> bb4;
 //     }
+//     bb2: {
+//         resume;
+//     }
 //     bb3: {
 //         EndRegion('19mce);
-//         drop(_1) -> bb1;
+//         drop(_1) -> bb2;
 //     }
 //     bb4: {
 //         StorageDead(_1);

--- a/src/test/mir-opt/end_region_6.rs
+++ b/src/test/mir-opt/end_region_6.rs
@@ -27,35 +27,35 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 
 // END RUST SOURCE
 // START rustc.node4.SimplifyCfg-qualify-consts.after.mir
+// fn main() -> () {
 //     let mut _0: ();
 //     let _1: D;
 //     let mut _2: ();
-//     let mut _3: ();
-//     let mut _4: [closure@NodeId(22) d:&'23mce D];
-//     let mut _5: &'23mce D;
-//
+//     let mut _3: [closure@NodeId(22) d:&'23mce D];
+//     let mut _4: &'23mce D;
+//     let mut _5: ();
 //     bb0: {
 //         StorageLive(_1);
 //         _1 = D::{{constructor}}(const 0i32,);
+//         StorageLive(_3);
 //         StorageLive(_4);
-//         StorageLive(_5);
-//         _5 = &'23mce _1;
-//         _4 = [closure@NodeId(22)] { d: _5 };
-//         StorageDead(_5);
-//         _3 = const foo(_4) -> [return: bb2, unwind: bb3];
+//         _4 = &'23mce _1;
+//         _3 = [closure@NodeId(22)] { d: _4 };
+//         StorageDead(_4);
+//         _2 = const foo(_3) -> [return: bb1, unwind: bb3];
 //     }
 //     bb1: {
-//         resume;
-//     }
-//     bb2: {
-//         StorageDead(_4);
+//         StorageDead(_3);
 //         EndRegion('23mce);
 //         _0 = ();
 //         drop(_1) -> bb4;
 //     }
+//     bb2: {
+//         resume;
+//     }
 //     bb3: {
 //         EndRegion('23mce);
-//         drop(_1) -> bb1;
+//         drop(_1) -> bb2;
 //     }
 //     bb4: {
 //         StorageDead(_1);

--- a/src/test/mir-opt/end_region_7.rs
+++ b/src/test/mir-opt/end_region_7.rs
@@ -31,18 +31,18 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 //     let mut _0: ();
 //     let _1: D;
 //     let mut _2: ();
-//     let mut _3: ();
-//     let mut _4: [closure@NodeId(22) d:D];
-//     let mut _5: D;
+//     let mut _3: [closure@NodeId(22) d:D];
+//     let mut _4: D;
+//     let mut _5: ();
 //
 //     bb0: {
 //         StorageLive(_1);
 //         _1 = D::{{constructor}}(const 0i32,);
+//         StorageLive(_3);
 //         StorageLive(_4);
-//         StorageLive(_5);
-//         _5 = _1;
-//         _4 = [closure@NodeId(22)] { d: _5 };
-//         drop(_5) -> [return: bb4, unwind: bb3];
+//         _4 = _1;
+//         _3 = [closure@NodeId(22)] { d: _4 };
+//         drop(_4) -> [return: bb4, unwind: bb3];
 //     }
 //     bb1: {
 //         resume;
@@ -51,17 +51,17 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 //         drop(_1) -> bb1;
 //     }
 //     bb3: {
-//         drop(_4) -> bb2;
+//         drop(_3) -> bb2;
 //     }
 //     bb4: {
-//         StorageDead(_5);
-//         _3 = const foo(_4) -> [return: bb5, unwind: bb3];
+//         StorageDead(_4);
+//         _2 = const foo(_3) -> [return: bb5, unwind: bb3];
 //     }
 //     bb5: {
-//         drop(_4) -> [return: bb6, unwind: bb2];
+//         drop(_3) -> [return: bb6, unwind: bb2];
 //     }
 //     bb6: {
-//         StorageDead(_4);
+//         StorageDead(_3);
 //         _0 = ();
 //         drop(_1) -> bb7;
 //     }
@@ -76,16 +76,16 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 // fn main::{{closure}}(_1: [closure@NodeId(22) d:D]) -> i32 {
 //     let mut _0: i32;
 //     let _2: &'14_0rce D;
-//     let mut _3: ();
-//     let mut _4: i32;
+//     let mut _3: i32;
+//     let mut _4: ();
 //
 //     bb0: {
 //         StorageLive(_2);
 //         _2 = &'14_0rce (_1.0: D);
-//         StorageLive(_4);
-//         _4 = ((*_2).0: i32);
-//         _0 = _4;
-//         StorageDead(_4);
+//         StorageLive(_3);
+//         _3 = ((*_2).0: i32);
+//         _0 = _3;
+//         StorageDead(_3);
 //         StorageDead(_2);
 //         EndRegion('14_0rce);
 //         drop(_1) -> bb1;

--- a/src/test/mir-opt/end_region_8.rs
+++ b/src/test/mir-opt/end_region_8.rs
@@ -29,44 +29,43 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 // END RUST SOURCE
 // START rustc.node4.SimplifyCfg-qualify-consts.after.mir
 // fn main() -> () {
-//     let mut _0: ();
-//     let _1: D;
-//     let _3: &'6_1rce D;
-//     let mut _2: ();
-//     let mut _4: ();
-//     let mut _5: [closure@NodeId(22) r:&'6_1rce D];
-//     let mut _6: &'6_1rce D;
-//
-//     bb0: {
-//         StorageLive(_1);
-//         _1 = D::{{constructor}}(const 0i32,);
-//         StorageLive(_3);
-//         _3 = &'6_1rce _1;
-//         StorageLive(_5);
-//         StorageLive(_6);
-//         _6 = _3;
-//         _5 = [closure@NodeId(22)] { r: _6 };
-//         StorageDead(_6);
-//         _4 = const foo(_5) -> [return: bb2, unwind: bb3];
-//     }
-//     bb1: {
-//         resume;
-//     }
-//     bb2: {
-//         StorageDead(_5);
-//         _0 = ();
-//         StorageDead(_3);
-//         EndRegion('6_1rce);
-//         drop(_1) -> bb4;
-//     }
-//     bb3: {
-//         EndRegion('6_1rce);
-//         drop(_1) -> bb1;
-//     }
-//     bb4: {
-//         StorageDead(_1);
-//         return;
-//     }
+//    let mut _0: ();
+//    let _1: D;
+//    let _2: &'6_1rce D;
+//    let mut _3: ();
+//    let mut _4: [closure@NodeId(22) r:&'6_1rce D];
+//    let mut _5: &'6_1rce D;
+//    let mut _6: ();
+//    bb0: {
+//        StorageLive(_1);
+//        _1 = D::{{constructor}}(const 0i32,);
+//        StorageLive(_2);
+//        _2 = &'6_1rce _1;
+//        StorageLive(_4);
+//        StorageLive(_5);
+//        _5 = _2;
+//        _4 = [closure@NodeId(22)] { r: _5 };
+//        StorageDead(_5);
+//        _3 = const foo(_4) -> [return: bb1, unwind: bb3];
+//    }
+//    bb1: {
+//        StorageDead(_4);
+//        _0 = ();
+//        StorageDead(_2);
+//        EndRegion('6_1rce);
+//        drop(_1) -> bb4;
+//    }
+//    bb2: {
+//        resume;
+//    }
+//    bb3: {
+//        EndRegion('6_1rce);
+//        drop(_1) -> bb2;
+//    }
+//    bb4: {
+//        StorageDead(_1);
+//        return;
+//    }
 // }
 // END rustc.node4.SimplifyCfg-qualify-consts.after.mir
 

--- a/src/test/mir-opt/issue-41110.rs
+++ b/src/test/mir-opt/issue-41110.rs
@@ -34,18 +34,23 @@ impl S {
 
 // END RUST SOURCE
 // START rustc.node4.ElaborateDrops.after.mir
+//    let mut _0: ();
+//    let _1: ();
 //    let mut _2: S;
-//    let mut _3: ();
+//    let mut _3: S;
 //    let mut _4: S;
-//    let mut _5: S;
+//    let mut _5: ();
 //    let mut _6: bool;
 //
 //    bb0: {
 // END rustc.node4.ElaborateDrops.after.mir
 // START rustc.node13.ElaborateDrops.after.mir
-//    let mut _2: ();
-//    let mut _4: ();
-//    let mut _5: S;
+//    let mut _0: ();
+//    let _1: S;
+//    let mut _2: S;
+//    let mut _3: ();
+//    let mut _4: S;
+//    let mut _5: ();
 //    let mut _6: S;
 //    let mut _7: bool;
 //


### PR DESCRIPTION
When building a scope exit, don't build unwind cleanup blocks unless they will actually be used by the unwind path of a drop - the unused blocks are removed by SimplifyCfg, but they can cause a significant performance slowdown before they are removed. That fixes #43511.

Also a few other small MIR cleanups & optimizations.

r? @eddyb 
