### PR TITLE
Link LLVM tools dynamically

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -125,10 +125,18 @@ impl Step for Llvm {
            .define("WITH_POLLY", "OFF")
            .define("LLVM_ENABLE_TERMINFO", "OFF")
            .define("LLVM_ENABLE_LIBEDIT", "OFF")
-           .define("LLVM_LINK_LLVM_DYLIB", "ON")
            .define("LLVM_PARALLEL_COMPILE_JOBS", build.jobs().to_string())
            .define("LLVM_TARGET_ARCH", target.split('-').next().unwrap())
            .define("LLVM_DEFAULT_TARGET_TRIPLE", target);
+
+
+        // This setting makes the LLVM tools link to the dynamic LLVM library,
+        // which saves both memory during parallel links and overall disk space
+        // for the tools.  We don't distribute any of those tools, so this is
+        // just a local concern.  However, this doesn't seem to work on Windows.
+        if !target.contains("windows") {
+           cfg.define("LLVM_LINK_LLVM_DYLIB", "ON");
+        }
 
         if target.contains("msvc") {
             cfg.define("LLVM_USE_CRT_DEBUG", "MT");

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -133,8 +133,8 @@ impl Step for Llvm {
         // This setting makes the LLVM tools link to the dynamic LLVM library,
         // which saves both memory during parallel links and overall disk space
         // for the tools.  We don't distribute any of those tools, so this is
-        // just a local concern.  However, this doesn't seem to work on Windows.
-        if !target.contains("windows") {
+        // just a local concern.  However, it doesn't work well everywhere.
+        if target.contains("linux-gnu") || target.contains("apple-darwin") {
            cfg.define("LLVM_LINK_LLVM_DYLIB", "ON");
         }
 

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -125,6 +125,7 @@ impl Step for Llvm {
            .define("WITH_POLLY", "OFF")
            .define("LLVM_ENABLE_TERMINFO", "OFF")
            .define("LLVM_ENABLE_LIBEDIT", "OFF")
+           .define("LLVM_LINK_LLVM_DYLIB", "ON")
            .define("LLVM_PARALLEL_COMPILE_JOBS", build.jobs().to_string())
            .define("LLVM_TARGET_ARCH", target.split('-').next().unwrap())
            .define("LLVM_DEFAULT_TARGET_TRIPLE", target);


### PR DESCRIPTION
Set `LLVM_LINK_LLVM_DYLIB=ON` -- "If enabled, tools will be linked with
the libLLVM shared library."  Rust doesn't ship any of the LLVM tools,
and only needs a few at all for some test cases, so statically linking
the tools is just a waste of space.  I've also had memory issues on
slower machines with LLVM debuginfo enabled, when several tools start
linking in parallel consuming several GBs each.

With the default configuration, `build/x86_64-unknown-linux-gnu/llvm`
was 1.5GB before, now down to 731MB.  The difference is more drastic
with `--enable-llvm-release-debuginfo`, from 28GB to "only" 13GB.

This does not change the linking behavior of `rustc_llvm`.