### PR TITLE
Gate LLVMRustHasFeature on LLVM_RUSTLLVM

### DIFF
--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -178,10 +178,10 @@ GEN_SUBTARGETS
 
 extern "C" bool LLVMRustHasFeature(LLVMTargetMachineRef TM,
                                    const char *Feature) {
+#if LLVM_RUSTLLVM
   TargetMachine *Target = unwrap(TM);
   const MCSubtargetInfo *MCInfo = Target->getMCSubtargetInfo();
   const FeatureBitset &Bits = MCInfo->getFeatureBits();
-#if LLVM_VERSION_GE(4, 0)
   const ArrayRef<SubtargetFeatureKV> FeatTable = MCInfo->getFeatureTable();
 
   for (auto &FeatureEntry : FeatTable)


### PR DESCRIPTION
Commit c4710203c098b in #43492 make `LLVMRustHasFeature` "more robust"
by using `getFeatureTable()`.  However, this function is specific to
Rust's own LLVM fork, not upstream LLVM-4.0, so we need to use
`#if LLVM_RUSTLLVM` to guard this call.

Closes #43555.