### PR TITLE
Fix quadratic performance with lots of use statements

### DIFF
--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -561,8 +561,9 @@ impl CodeMapper for CodeMap {
         sp
     }
     fn ensure_filemap_source_present(&self, file_map: Rc<FileMap>) -> bool {
-        let src = self.file_loader.read_file(Path::new(&file_map.name)).ok();
-        return file_map.add_external_src(src)
+        file_map.add_external_src(
+            || self.file_loader.read_file(Path::new(&file_map.name)).ok()
+        )
     }
 }
 

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -618,8 +618,11 @@ impl FileMap {
     /// If the hash of the input doesn't match or no input is supplied via None,
     /// it is interpreted as an error and the corresponding enum variant is set.
     /// The return value signifies whether some kind of source is present.
-    pub fn add_external_src(&self, src: Option<String>) -> bool {
+    pub fn add_external_src<F>(&self, get_src: F) -> bool
+        where F: FnOnce() -> Option<String>
+    {
         if *self.external_src.borrow() == ExternalSource::AbsentOk {
+            let src = get_src();
             let mut external_src = self.external_src.borrow_mut();
             if let Some(src) = src {
                 let mut hasher: StableHasher<u128> = StableHasher::new();


### PR DESCRIPTION
This fixes 2 problems that caused quadratic performance when lots of use-statements were present. After this patch, performance is linear (and very fast) even with 1M uses.

Fixes #43572.
Fixes #43573.

r? @eddyb 