### PR TITLE
Make a disable-jemalloc build work

### DIFF
--- a/src/librustc_trans/back/symbol_export.rs
+++ b/src/librustc_trans/back/symbol_export.rs
@@ -13,6 +13,7 @@ use rustc::util::nodemap::{FxHashMap, NodeSet};
 use rustc::hir::def_id::{DefId, CrateNum, LOCAL_CRATE, INVALID_CRATE, CRATE_DEF_INDEX};
 use rustc::session::config;
 use rustc::ty::TyCtxt;
+use rustc_allocator::ALLOCATOR_METHODS;
 use syntax::attr;
 
 /// The SymbolExportLevel of a symbols specifies from which kinds of crates
@@ -81,6 +82,14 @@ impl ExportedSymbols {
             local_crate.push(("main".to_string(),
                               INVALID_DEF_ID,
                               SymbolExportLevel::C));
+        }
+
+        if tcx.sess.allocator_kind.get().is_some() {
+            for method in ALLOCATOR_METHODS {
+                local_crate.push((format!("__rust_{}", method.name),
+                                  INVALID_DEF_ID,
+                                  SymbolExportLevel::Rust));
+            }
         }
 
         if let Some(id) = tcx.sess.derive_registrar_fn.get() {

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -319,12 +319,18 @@
 #![default_lib_allocator]
 
 // Always use alloc_system during stage0 since we don't know if the alloc_*
-// crate the stage0 compiler will pick by default is available (most
-// obviously, if the user has disabled jemalloc in `./configure`).
+// crate the stage0 compiler will pick by default is enabled (e.g.
+// if the user has disabled jemalloc in `./configure`).
 // `force_alloc_system` is *only* intended as a workaround for local rebuilds
 // with a rustc without jemalloc.
-#![cfg_attr(any(stage0, feature = "force_alloc_system"), feature(global_allocator))]
-#[cfg(any(stage0, feature = "force_alloc_system"))]
+// The not(stage0+msvc) gates will only last until the next stage0 bump
+#![cfg_attr(all(
+        not(all(stage0, target_env = "msvc")),
+        any(stage0, feature = "force_alloc_system")),
+    feature(global_allocator))]
+#[cfg(all(
+    not(all(stage0, target_env = "msvc")),
+    any(stage0, feature = "force_alloc_system")))]
 #[global_allocator]
 static ALLOC: alloc_system::System = alloc_system::System;
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -318,6 +318,16 @@
 
 #![default_lib_allocator]
 
+// Always use alloc_system during stage0 since we don't know if the alloc_*
+// crate the stage0 compiler will pick by default is available (most
+// obviously, if the user has disabled jemalloc in `./configure`).
+// `force_alloc_system` is *only* intended as a workaround for local rebuilds
+// with a rustc without jemalloc.
+#![cfg_attr(any(stage0, feature = "force_alloc_system"), feature(global_allocator))]
+#[cfg(any(stage0, feature = "force_alloc_system"))]
+#[global_allocator]
+static ALLOC: alloc_system::System = alloc_system::System;
+
 // Explicitly import the prelude. The compiler uses this same unstable attribute
 // to import the prelude implicitly when building crates that depend on std.
 #[prelude_import]

--- a/src/tools/tidy/src/pal.rs
+++ b/src/tools/tidy/src/pal.rs
@@ -69,6 +69,7 @@ const EXCEPTION_PATHS: &'static [&'static str] = &[
     "src/libstd/path.rs",
     "src/libstd/f32.rs",
     "src/libstd/f64.rs",
+    "src/libstd/lib.rs", // Until next stage0 snapshot bump
     "src/libstd/sys_common/mod.rs",
     "src/libstd/sys_common/net.rs",
     "src/libterm", // Not sure how to make this crate portable, but test needs it


### PR DESCRIPTION
Fixes #43510. I've tested this up to building a stage1 compiler.

r? @alexcrichton 

cc @cuviper @vorner

@cuviper your fix was almost correct, you just had a stray `!` in there which caused the second error you saw.