### PR TITLE
incr.comp.: Assert that no DepNode is re-opened (see issue #42298).

### DIFF
--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -394,6 +394,7 @@ define_dep_nodes!( <'tcx>
     // Represents different phases in the compiler.
     [] RegionMaps(DefId),
     [] Coherence,
+    [] CoherenceInherentImplOverlapCheck,
     [] Resolve,
     [] CoherenceCheckTrait(DefId),
     [] PrivacyAccessLevels(CrateNum),

--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -66,7 +66,6 @@ use hir::map::DefPathHash;
 use ich::Fingerprint;
 use ty::{TyCtxt, Instance, InstanceDef};
 use ty::fast_reject::SimplifiedType;
-use ty::subst::Substs;
 use rustc_data_structures::stable_hasher::{StableHasher, HashStable};
 use ich::StableHashingContext;
 use std::fmt;
@@ -104,6 +103,8 @@ macro_rules! define_dep_nodes {
                 match *self {
                     $(
                         DepKind :: $variant => {
+                            $(return !anon_attr_to_bool!($anon);)*
+
                             // tuple args
                             $({
                                 return <( $($tuple_arg,)* ) as DepNodeParams>
@@ -112,6 +113,7 @@ macro_rules! define_dep_nodes {
 
                             // struct args
                             $({
+
                                 return <( $($struct_arg_ty,)* ) as DepNodeParams>
                                     ::CAN_RECONSTRUCT_QUERY_KEY;
                             })*
@@ -445,17 +447,17 @@ define_dep_nodes!( <'tcx>
     [] TypeckBodiesKrate,
     [] TypeckTables(DefId),
     [] HasTypeckTables(DefId),
-    [] ConstEval { def_id: DefId, substs: &'tcx Substs<'tcx> },
+    [anon] ConstEval,
     [] SymbolName(DefId),
     [] InstanceSymbolName { instance: Instance<'tcx> },
     [] SpecializationGraph(DefId),
     [] ObjectSafety(DefId),
 
-    [anon] IsCopy(DefId),
-    [anon] IsSized(DefId),
-    [anon] IsFreeze(DefId),
-    [anon] NeedsDrop(DefId),
-    [anon] Layout(DefId),
+    [anon] IsCopy,
+    [anon] IsSized,
+    [anon] IsFreeze,
+    [anon] NeedsDrop,
+    [anon] Layout,
 
     // The set of impls for a given trait.
     [] TraitImpls(DefId),

--- a/src/librustc/ty/maps.rs
+++ b/src/librustc/ty/maps.rs
@@ -931,7 +931,7 @@ define_maps! { <'tcx>
     /// Checks all types in the krate for overlap in their inherent impls. Reports errors.
     /// Not meant to be used directly outside of coherence.
     /// (Defined only for LOCAL_CRATE)
-    [] crate_inherent_impls_overlap_check: crate_inherent_impls_dep_node(CrateNum) -> (),
+    [] crate_inherent_impls_overlap_check: inherent_impls_overlap_check_dep_node(CrateNum) -> (),
 
     /// Results of evaluating const items or constants embedded in
     /// other items (such as enum variant explicit discriminants).
@@ -1012,6 +1012,10 @@ fn coherent_trait_dep_node<'tcx>((_, def_id): (CrateNum, DefId)) -> DepConstruct
 
 fn crate_inherent_impls_dep_node<'tcx>(_: CrateNum) -> DepConstructor<'tcx> {
     DepConstructor::Coherence
+}
+
+fn inherent_impls_overlap_check_dep_node<'tcx>(_: CrateNum) -> DepConstructor<'tcx> {
+    DepConstructor::CoherenceInherentImplOverlapCheck
 }
 
 fn reachability_dep_node<'tcx>(_: CrateNum) -> DepConstructor<'tcx> {

--- a/src/librustc/ty/maps.rs
+++ b/src/librustc/ty/maps.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use dep_graph::{DepConstructor, DepNode, DepNodeIndex};
-use hir::def_id::{CrateNum, CRATE_DEF_INDEX, DefId, LOCAL_CRATE};
+use hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use hir::def::Def;
 use hir;
 use middle::const_val;
@@ -1036,10 +1036,9 @@ fn typeck_item_bodies_dep_node<'tcx>(_: CrateNum) -> DepConstructor<'tcx> {
     DepConstructor::TypeckBodiesKrate
 }
 
-fn const_eval_dep_node<'tcx>(key: ty::ParamEnvAnd<'tcx, (DefId, &'tcx Substs<'tcx>)>)
+fn const_eval_dep_node<'tcx>(_: ty::ParamEnvAnd<'tcx, (DefId, &'tcx Substs<'tcx>)>)
                              -> DepConstructor<'tcx> {
-    let (def_id, substs) = key.value;
-    DepConstructor::ConstEval { def_id, substs }
+    DepConstructor::ConstEval
 }
 
 fn mir_keys<'tcx>(_: CrateNum) -> DepConstructor<'tcx> {
@@ -1054,32 +1053,22 @@ fn relevant_trait_impls_for<'tcx>((def_id, t): (DefId, SimplifiedType)) -> DepCo
     DepConstructor::RelevantTraitImpls(def_id, t)
 }
 
-fn is_copy_dep_node<'tcx>(key: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> DepConstructor<'tcx> {
-    let def_id = ty::item_path::characteristic_def_id_of_type(key.value)
-        .unwrap_or(DefId::local(CRATE_DEF_INDEX));
-    DepConstructor::IsCopy(def_id)
+fn is_copy_dep_node<'tcx>(_: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> DepConstructor<'tcx> {
+    DepConstructor::IsCopy
 }
 
-fn is_sized_dep_node<'tcx>(key: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> DepConstructor<'tcx> {
-    let def_id = ty::item_path::characteristic_def_id_of_type(key.value)
-        .unwrap_or(DefId::local(CRATE_DEF_INDEX));
-    DepConstructor::IsSized(def_id)
+fn is_sized_dep_node<'tcx>(_: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> DepConstructor<'tcx> {
+    DepConstructor::IsSized
 }
 
-fn is_freeze_dep_node<'tcx>(key: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> DepConstructor<'tcx> {
-    let def_id = ty::item_path::characteristic_def_id_of_type(key.value)
-        .unwrap_or(DefId::local(CRATE_DEF_INDEX));
-    DepConstructor::IsFreeze(def_id)
+fn is_freeze_dep_node<'tcx>(_: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> DepConstructor<'tcx> {
+    DepConstructor::IsFreeze
 }
 
-fn needs_drop_dep_node<'tcx>(key: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> DepConstructor<'tcx> {
-    let def_id = ty::item_path::characteristic_def_id_of_type(key.value)
-        .unwrap_or(DefId::local(CRATE_DEF_INDEX));
-    DepConstructor::NeedsDrop(def_id)
+fn needs_drop_dep_node<'tcx>(_: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> DepConstructor<'tcx> {
+    DepConstructor::NeedsDrop
 }
 
-fn layout_dep_node<'tcx>(key: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> DepConstructor<'tcx> {
-    let def_id = ty::item_path::characteristic_def_id_of_type(key.value)
-        .unwrap_or(DefId::local(CRATE_DEF_INDEX));
-    DepConstructor::Layout(def_id)
+fn layout_dep_node<'tcx>(_: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> DepConstructor<'tcx> {
+    DepConstructor::Layout
 }


### PR DESCRIPTION
This PR removes the last occurrence of DepNode re-opening and adds an assertion that prevents our doing so in the future too. The DepGraph should now be guaranteed to be cycle free.

r? @nikomatsakis 

EDIT: Closes https://github.com/rust-lang/rust/issues/42298