### PR TITLE
Derive `Hash` on `AssociatedKind`.

### DIFF
--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -174,7 +174,7 @@ pub struct AssociatedItem {
     pub method_has_self_argument: bool,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, RustcEncodable, RustcDecodable)]
 pub enum AssociatedKind {
     Const,
     Method,


### PR DESCRIPTION
This is a trivial change useful in downstream code poking in rustc's
innards, in particular the semver verification tool I'm currently working on.

r? @eddyb 