### PR TITLE
rustdoc: shrink headings in non-top-level docblocks

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -274,9 +274,13 @@ nav.sub {
 	border-bottom: 1px solid;
 }
 
-.docblock h1 { font-size: 1.3em; }
-.docblock h2 { font-size: 1.15em; }
-.docblock h3, .docblock h4, .docblock h5 { font-size: 1em; }
+#main > .docblock h1 { font-size: 1.3em; }
+#main > .docblock h2 { font-size: 1.15em; }
+#main > .docblock h3, #main > .docblock h4, #main > .docblock h5 { font-size: 1em; }
+
+.docblock h1 { font-size: 1em; }
+.docblock h2 { font-size: 0.95em; }
+.docblock h3, .docblock h4, .docblock h5 { font-size: 0.9em; }
 
 .docblock {
 	margin-left: 24px;


### PR DESCRIPTION
Headings in per-method docs are often bigger than the function names/signatures themselves, so this tones those down to accentuate the methods.

![screenshot of this change on Vec::swap_remove](https://user-images.githubusercontent.com/5217170/28849380-6116a830-76dc-11e7-8ce2-04433d09463a.png)

Fixes #17193 