### PR TITLE
Update RLS and deps

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1140,8 +1140,8 @@ dependencies = [
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "racer 2.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-analysis 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-data 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-analysis 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-data 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-vfs 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfmt-nightly 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1155,21 +1155,12 @@ dependencies = [
 
 [[package]]
 name = "rls-analysis"
-version = "0.4.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "derive-new 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-data 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rls-data"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
+ "rls-data 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1181,6 +1172,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2228,9 +2221,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
-"checksum rls-analysis 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0127cfae9c726461facbbbc8327e782adf8afd61f7fcc6adf8ea9ad8fc428ed0"
+"checksum rls-analysis 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca5b4d890953b9cc60c8c97f196921d02edf75798ccab930604aa3b4f890616d"
 "checksum rls-data 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11d339f1888e33e74d8032de0f83c40b2bdaaaf04a8cfc03b32186c3481fb534"
-"checksum rls-data 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f274ec7f966337dc2601fe9bde060b551d1293c277af782dc65cd7200ca070c0"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
 "checksum rls-vfs 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd34691a510938bb67fe0444fb363103c73ffb31c121d1e16bc92d8945ea8ff"
 "checksum rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3058a43ada2c2d0b92b3ae38007a2d0fa5e9db971be260e0171408a4ff471c95"

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1175,6 +1175,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rls-data"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rls-span"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,7 +1513,7 @@ name = "rustc_save_analysis"
 version = "0.0.0"
 dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-data 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-data 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc 0.0.0",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2220,6 +2229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum rls-analysis 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0127cfae9c726461facbbbc8327e782adf8afd61f7fcc6adf8ea9ad8fc428ed0"
+"checksum rls-data 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11d339f1888e33e74d8032de0f83c40b2bdaaaf04a8cfc03b32186c3481fb534"
 "checksum rls-data 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f274ec7f966337dc2601fe9bde060b551d1293c277af782dc65cd7200ca070c0"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
 "checksum rls-vfs 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd34691a510938bb67fe0444fb363103c73ffb31c121d1e16bc92d8945ea8ff"

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -188,7 +188,7 @@ fn main() {
             cmd.arg("-Zsave-analysis");
             cmd.env("RUST_SAVE_ANALYSIS_CONFIG",
                     "{\"output_file\": null,\"full_docs\": false,\"pub_only\": true,\
-                     \"signatures\": false,\"borrow_data\": false}");
+                     \"distro_crate\": true,\"signatures\": false,\"borrow_data\": false}");
         }
 
         // Dealing with rpath here is a little special, so let's go into some

--- a/src/librustc_save_analysis/Cargo.toml
+++ b/src/librustc_save_analysis/Cargo.toml
@@ -15,7 +15,7 @@ rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_typeck = { path = "../librustc_typeck" }
 syntax = { path = "../libsyntax" }
 syntax_pos = { path = "../libsyntax_pos" }
-rls-data = "0.9"
+rls-data = "0.10"
 rls-span = "0.4"
 # FIXME(#40527) should move rustc serialize out of tree
 rustc-serialize = "0.3"

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -561,17 +561,18 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> DumpVisitor<'l, 'tcx, 'll, O> {
             if let ast::ItemKind::Struct(ast::VariantData::Struct(ref fields, _), _) = item.node
         {
             let include_priv_fields = !self.save_ctxt.config.pub_only;
-            let fields_str = fields.iter()
-                                   .enumerate()
-                                   .filter_map(|(i, f)| {
-                                        if include_priv_fields || f.vis == ast::Visibility::Public {
-                                            f.ident.map(|i| i.to_string()).or_else(|| Some(i.to_string()))
-                                        } else {
-                                            None
-                                        }
-                                   })
-                                   .collect::<Vec<_>>()
-                                   .join(", ");
+            let fields_str = fields
+                .iter()
+                .enumerate()
+                .filter_map(|(i, f)| {
+                     if include_priv_fields || f.vis == ast::Visibility::Public {
+                         f.ident.map(|i| i.to_string()).or_else(|| Some(i.to_string()))
+                     } else {
+                         None
+                     }
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
             let value = format!("{} {{ {} }}", name, fields_str);
             (value, fields.iter().map(|f| ::id_from_node_id(f.id, &self.save_ctxt)).collect())
         } else {

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -560,14 +560,20 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> DumpVisitor<'l, 'tcx, 'll, O> {
         let (value, fields) =
             if let ast::ItemKind::Struct(ast::VariantData::Struct(ref fields, _), _) = item.node
         {
+            let include_priv_fields = !self.save_ctxt.config.pub_only;
             let fields_str = fields.iter()
                                    .enumerate()
-                                   .map(|(i, f)| f.ident.map(|i| i.to_string())
-                                                  .unwrap_or(i.to_string()))
+                                   .filter_map(|(i, f)| {
+                                        if include_priv_fields || f.vis == ast::Visibility::Public {
+                                            f.ident.map(|i| i.to_string()).or_else(|| Some(i.to_string()))
+                                        } else {
+                                            None
+                                        }
+                                   })
                                    .collect::<Vec<_>>()
                                    .join(", ");
-            (format!("{} {{ {} }}", name, fields_str),
-             fields.iter().map(|f| ::id_from_node_id(f.id, &self.save_ctxt)).collect())
+            let value = format!("{} {{ {} }}", name, fields_str);
+            (value, fields.iter().map(|f| ::id_from_node_id(f.id, &self.save_ctxt)).collect())
         } else {
             (String::new(), vec![])
         };

--- a/src/librustc_save_analysis/json_dumper.rs
+++ b/src/librustc_save_analysis/json_dumper.rs
@@ -51,7 +51,11 @@ impl<'b> DumpOutput for CallbackOutput<'b> {
 
 impl<'b, W: Write> JsonDumper<WriteOutput<'b, W>> {
     pub fn new(writer: &'b mut W, config: Config) -> JsonDumper<WriteOutput<'b, W>> {
-        JsonDumper { output: WriteOutput { output: writer }, config, result: Analysis::new() }
+        JsonDumper {
+            output: WriteOutput { output: writer },
+            config: config.clone(),
+            result: Analysis::new(config)
+        }
     }
 }
 
@@ -61,8 +65,8 @@ impl<'b> JsonDumper<CallbackOutput<'b>> {
                          -> JsonDumper<CallbackOutput<'b>> {
         JsonDumper {
             output: CallbackOutput { callback: callback },
-            config,
-            result: Analysis::new(),
+            config: config.clone(),
+            result: Analysis::new(config),
         }
     }
 }


### PR DESCRIPTION
This PR further moves towards configuring save-analysis using the rls-data Config struct. We remove completely the concept of api_crate. Updates the RLS so the client is expecting these changes and which pulls in a commit re-enabling all RLS tests (been disabled due to a span error for a while).