### PR TITLE
incr.comp.: Properly incorporate symbol linkage and visibility into CGU hash.

### DIFF
--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -1172,7 +1172,7 @@ pub fn trans_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
         let cgu_name = String::from(cgu.name());
         let cgu_id = cgu.work_product_id();
-        let symbol_name_hash = cgu.compute_symbol_name_hash(scx, &exported_symbols);
+        let symbol_name_hash = cgu.compute_symbol_name_hash(scx);
 
         // Check whether there is a previous work-product we can
         // re-use.  Not only must the file exist, and the inputs not


### PR DESCRIPTION
This PR fixes the way the CGU hash for incr. comp. is computed. The CGU hash represents which `TransItems` are emitted into which codegen unit with which linkage and visibility. Before the new, LLVM-independent symbol internalizer the CGU hash did not accurately contain `TransItem` linkage and visibility because we would not enable symbol internalization in incremental mode anyway. The new internalizer is also run in incremental mode which uncovered the inaccuracy of CGU hashing. Luckily, the fix is rather simple.

r? @eddyb 
cc @nikomatsakis 