### PR TITLE
Emphasise that these functions look at the disk, not just the path

### DIFF
--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -2237,7 +2237,7 @@ impl Path {
         fs::metadata(self).is_ok()
     }
 
-    /// Returns whether the path is pointing at a regular file.
+    /// Returns whether the path exists on disk and is pointing at a regular file.
     ///
     /// This function will traverse symbolic links to query information about the
     /// destination file. In case of broken symbolic links this will return `false`.
@@ -2266,7 +2266,7 @@ impl Path {
         fs::metadata(self).map(|m| m.is_file()).unwrap_or(false)
     }
 
-    /// Returns whether the path is pointing at a directory.
+    /// Returns whether the path exists on disk and is pointing at a directory.
     ///
     /// This function will traverse symbolic links to query information about the
     /// destination file. In case of broken symbolic links this will return `false`.


### PR DESCRIPTION
I thought that `PathBuf::new("foo/bar/").is_dir()` is always true, because the path ends in `/`. However, this is not what `is_dir()` function does. So I've updated the docs to make it clear.