### PR TITLE
mir-opt tests: add ability to match lines that contain the filename

### DIFF
--- a/src/test/mir-opt/README.md
+++ b/src/test/mir-opt/README.md
@@ -21,9 +21,10 @@ The test format is:
 All the test information is in comments so the test is runnable.
 
 For each $file_name, compiletest expects [$expected_line_0, ...,
-$expected_line_N] to appear in the dumped MIR in order.  Currently it allows
-other non-matched lines before, after and in-between. Note that this includes
-lines that end basic blocks or begin new ones; it is good practice
+$expected_line_N] to appear in the dumped MIR in order. Every occurrence of `$FILE`
+in the expected line is replaced with the file name of the source code before
+matching.  Currently it allows other non-matched lines before, after and in-between.
+Note that this includes lines that end basic blocks or begin new ones; it is good practice
 in your tests to include the terminator for each of your basic blocks as an
 internal sanity check guarding against a test like:
 

--- a/src/test/mir-opt/filename.rs
+++ b/src/test/mir-opt/filename.rs
@@ -1,0 +1,22 @@
+// Copyright 2012-2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that we can write tests for lines that contain the filename of the test
+
+fn main() {
+    let closure = |x: i32| x+x;
+    closure(21);
+}
+
+// END RUST SOURCE
+// START rustc.node15.EraseRegions.after.mir
+// fn main::{{closure}}(_1: &[closure@$FILE:14:19: 14:31], _2: i32) -> i32 {
+// }
+// END rustc.node15.EraseRegions.after.mir

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2300,6 +2300,7 @@ actual:\n\
                                                    .read_to_string(&mut test_file_contents)
                                                    .unwrap();
         if let Some(idx) =  test_file_contents.find("// END RUST SOURCE") {
+            let filename = self.testpaths.file.to_str().unwrap();
             let (_, tests_text) = test_file_contents.split_at(idx + "// END_RUST SOURCE".len());
             let tests_text_str = String::from(tests_text);
             let mut curr_test : Option<&str> = None;
@@ -2321,7 +2322,7 @@ actual:\n\
                     // ignore
                 } else if l.starts_with("// ") {
                     let (_, test_content) = l.split_at("// ".len());
-                    curr_test_contents.push(test_content);
+                    curr_test_contents.push(test_content.replace("$FILE", filename));
                 }
             }
         }
@@ -2339,7 +2340,7 @@ actual:\n\
         }
     }
 
-    fn compare_mir_test_output(&self, test_name: &str, expected_content: &[&str]) {
+    fn compare_mir_test_output(&self, test_name: &str, expected_content: &[String]) {
         let mut output_file = PathBuf::new();
         output_file.push(self.get_mir_dump_dir());
         output_file.push(test_name);


### PR DESCRIPTION
As part of https://github.com/rust-lang/rust/pull/43403, I wanted to write mir-opt tests that check lines that contain types which involve the name of the file was was compiled (this is because with closures, that filename leaks into the name of the type as printed). It is currently not possible to write such a test as the filename is not stable.

So, this PR introduces the magic variable `$FILE` that can be used in mir-opt tests to refer to the name of the current file, so that it can be used to test against.