### PR TITLE
extend config.toml doc for debug-assertions

### DIFF
--- a/src/bootstrap/config.toml.example
+++ b/src/bootstrap/config.toml.example
@@ -203,7 +203,7 @@
 #codegen-units = 1
 
 # Whether or not debug assertions are enabled for the compiler and standard
-# library
+# library. Also enables compilation of debug! and trace! logging macros.
 #debug-assertions = false
 
 # Whether or not debuginfo is emitted


### PR DESCRIPTION
Even after I knew that I had to change config.toml to get any printing from debug! and trace!, going over the entire fail did not make it clear to me that `debug-assertions` is the option controlling that.