### PR TITLE
Point "deref coercions" links to new book

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -203,7 +203,7 @@
 //! [`use`]: ../book/first-edition/crates-and-modules.html#importing-modules-with-use
 //! [crate root]: ../book/first-edition/crates-and-modules.html#basic-terminology-crates-and-modules
 //! [crates.io]: https://crates.io
-//! [deref coercions]: ../book/first-edition/deref-coercions.html
+//! [deref coercions]: ../book/second-edition/ch15-02-deref.html#implicit-deref-coercions-with-functions-and-methods
 //! [files]: fs/struct.File.html
 //! [multithreading]: thread/index.html
 //! [other]: #what-is-in-the-standard-library-documentation

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -80,8 +80,8 @@
 //!
 //! Note the documentation for the primitives [`str`] and [`[T]`][slice] (also
 //! called 'slice'). Many method calls on [`String`] and [`Vec<T>`] are actually
-//! calls to methods on [`str`] and [`[T]`][slice] respectively, via [deref
-//! coercions].
+//! calls to methods on [`str`] and [`[T]`][slice] respectively, via
+//! [deref-coercions].
 //!
 //! Third, the standard library defines [The Rust Prelude], a small collection
 //! of items - mostly traits - that are imported into every module of every
@@ -203,7 +203,7 @@
 //! [`use`]: ../book/first-edition/crates-and-modules.html#importing-modules-with-use
 //! [crate root]: ../book/first-edition/crates-and-modules.html#basic-terminology-crates-and-modules
 //! [crates.io]: https://crates.io
-//! [deref coercions]: ../book/second-edition/ch15-02-deref.html#implicit-deref-coercions-with-functions-and-methods
+//! [deref-coercions]: ../book/second-edition/ch15-02-deref.html#implicit-deref-coercions-with-functions-and-methods
 //! [files]: fs/struct.File.html
 //! [multithreading]: thread/index.html
 //! [other]: #what-is-in-the-standard-library-documentation

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -80,8 +80,8 @@
 //!
 //! Note the documentation for the primitives [`str`] and [`[T]`][slice] (also
 //! called 'slice'). Many method calls on [`String`] and [`Vec<T>`] are actually
-//! calls to methods on [`str`] and [`[T]`][slice] respectively, via
-//! [deref-coercions].
+//! calls to methods on [`str`] and [`[T]`][slice] respectively, via [deref
+//! coercions][deref-coercions].
 //!
 //! Third, the standard library defines [The Rust Prelude], a small collection
 //! of items - mostly traits - that are imported into every module of every


### PR DESCRIPTION
Currently the link on doc.rust-lang.org is semi-broken; it links to a page that links to the exact page in the first edition in the book, or to the index of the second edition of the book. If the second editions
is the recommended one now, we should point the links at that one. (In the mean time, the links have been updated to point directly to the first edition of the book, but that hasn't made it onto
the stable channel yet.) By the time this commit makes it onto the stable channel, the second edition of the book should be complete enough. At least the part about deref coercions is.

r? @steveklabnik 