### PR TITLE
Detect relative urls in tidy check

### DIFF
--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -79,7 +79,7 @@ fn line_is_url(line: &str) -> bool {
                 => state = EXP_URL,
 
             (EXP_LINK_LABEL_OR_URL, w)
-                if w.starts_with("http://") || w.starts_with("https://") || w.starts_with("../")
+                if w.starts_with("http://") || w.starts_with("https://")
                 => state = EXP_END,
 
             (EXP_URL, w)

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -79,11 +79,11 @@ fn line_is_url(line: &str) -> bool {
                 => state = EXP_URL,
 
             (EXP_LINK_LABEL_OR_URL, w)
-                if w.starts_with("http://") || w.starts_with("https://")
+                if w.starts_with("http://") || w.starts_with("https://") || w.starts_with("../")
                 => state = EXP_END,
 
             (EXP_URL, w)
-                if w.starts_with("http://") || w.starts_with("https://")
+                if w.starts_with("http://") || w.starts_with("https://") || w.starts_with("../")
                 => state = EXP_END,
 
             (_, _) => return false,


### PR DESCRIPTION
This came up in #43631: there can be long relative urls in Markdown comments, that do not start with `http://` or `https://`, so the tidy check will not detect them as urls and complain about the line length. This PR adds detection of relative urls starting with `../`.