### PR TITLE
Add L4Re Support in librustc_back

### DIFF
--- a/src/librustc_back/target/l4re_base.rs
+++ b/src/librustc_back/target/l4re_base.rs
@@ -1,0 +1,32 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use PanicStrategy;
+use LinkerFlavor;
+use target::{LinkArgs, TargetOptions};
+use std::default::Default;
+
+pub fn opts() -> TargetOptions {
+    let mut pre_link_args = LinkArgs::new();
+    pre_link_args.insert(LinkerFlavor::Ld, vec![
+            "-nostdlib".to_string(),
+    ]);
+
+    TargetOptions {
+        executables: true,
+        has_elf_tls: false,
+        exe_allocation_crate: Some("alloc_system".to_string()),
+        panic_strategy: PanicStrategy::Abort,
+        linker: "ld".to_string(),
+        pre_link_args: pre_link_args,
+        target_family: Some("unix".to_string()),
+        .. Default::default()
+    }
+}

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -69,6 +69,7 @@ mod solaris_base;
 mod windows_base;
 mod windows_msvc_base;
 mod thumb_base;
+mod l4re_base;
 mod fuchsia_base;
 mod redox_base;
 
@@ -192,6 +193,8 @@ supported_targets! {
 
     ("aarch64-unknown-fuchsia", aarch64_unknown_fuchsia),
     ("x86_64-unknown-fuchsia", x86_64_unknown_fuchsia),
+
+    ("x86_64-unknown-l4re-uclibc", x86_64_unknown_l4re_uclibc),
 
     ("x86_64-unknown-redox", x86_64_unknown_redox),
 

--- a/src/librustc_back/target/x86_64_unknown_l4re_uclibc.rs
+++ b/src/librustc_back/target/x86_64_unknown_l4re_uclibc.rs
@@ -1,0 +1,31 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use LinkerFlavor;
+use target::{Target, TargetResult};
+
+pub fn target() -> TargetResult {
+    let mut base = super::l4re_base::opts();
+    base.cpu = "x86-64".to_string();
+    base.max_atomic_width = Some(64);
+
+    Ok(Target {
+        llvm_target: "x86_64-unknown-l4re-uclibc".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "64".to_string(),
+        data_layout: "e-m:e-i64:64-f80:128-n8:16:32:64-S128".to_string(),
+        arch: "x86_64".to_string(),
+        target_os: "l4re".to_string(),
+        target_env: "uclibc".to_string(),
+        target_vendor: "unknown".to_string(),
+        linker_flavor: LinkerFlavor::Ld,
+        options: base,
+    })
+}


### PR DESCRIPTION
Add experimental support for x86_64-unknown-l4re-uclibc target, which covers the L4 Runtime Environment.

This pull request contains the changes that have to be made to librustc_back. It follows the changes humenda made in pull request https://github.com/rust-lang/libc/pull/591 to libc.

Next steps will be the modifications to the needed libraries. (libstd,  liballoc_system, libpanic_abort, libunwind)

Thanks to humenda for reviewing.