### PR TITLE
Unskip some tests on AArch64

### DIFF
--- a/src/test/run-pass/foreign-call-no-runtime.rs
+++ b/src/test/run-pass/foreign-call-no-runtime.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-aarch64
 // ignore-emscripten no threads support
 
 #![feature(libc)]

--- a/src/test/run-pass/issue-13304.rs
+++ b/src/test/run-pass/issue-13304.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-aarch64
 // ignore-emscripten
 #![feature(io, process_capture)]
 

--- a/src/test/run-pass/issue-16272.rs
+++ b/src/test/run-pass/issue-16272.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-aarch64
 // ignore-emscripten
 
 use std::process::Command;

--- a/src/test/run-pass/issue-20091.rs
+++ b/src/test/run-pass/issue-20091.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-aarch64
 // ignore-emscripten
 #![feature(std_misc, os)]
 

--- a/src/test/run-pass/process-spawn-with-unicode-params.rs
+++ b/src/test/run-pass/process-spawn-with-unicode-params.rs
@@ -16,7 +16,6 @@
 // non-ASCII characters.  The child process ensures all the strings are
 // intact.
 
-// ignore-aarch64
 // ignore-emscripten
 
 use std::io::prelude::*;

--- a/src/test/run-pass/sigpipe-should-be-ignored.rs
+++ b/src/test/run-pass/sigpipe-should-be-ignored.rs
@@ -11,7 +11,6 @@
 // Be sure that when a SIGPIPE would have been received that the entire process
 // doesn't die in a ball of fire, but rather it's gracefully handled.
 
-// ignore-aarch64
 // ignore-emscripten
 
 use std::env;


### PR DESCRIPTION
I've been running the test suite remotely on an Acer Chromebook R13 and natively on an ARM Juno developer board, both AArch64 devices. Most of the tests that are skipped on AArch64 are due to testing stdcall/fastcall/x86-specific code or the debugger, but I've found a few tests that could be enabled there.

These have been skipped previously due to failing on the `aarch64-linux-android` and `mac-android` buildbots, more than 2 years ago (#23471, #23695). It seems we don't test those platforms any more, but as they do work on AArch64 Linux, I'd like to propose re-enabling them. All of them pass on my devices.