### PR TITLE
Filter lifetimes from impl trait parent generics

### DIFF
--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -345,6 +345,7 @@ impl<'a, 'gcx, 'tcx> HashStable<StableHashingContext<'a, 'gcx, 'tcx>> for ty::Ge
             // Reverse map to each `TypeParameterDef`'s `index` field, from
             // `def_id.index` (`def_id.krate` is the same as the item's).
             type_param_to_index: _, // Don't hash this
+            region_param_to_index: _, // Don't hash this either
             has_self,
             has_late_bound_regions,
         } = *self;

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -716,6 +716,10 @@ pub struct Generics {
     pub regions: Vec<RegionParameterDef>,
     pub types: Vec<TypeParameterDef>,
 
+    /// Reverse map to each `RegionParameterDef`'s `index` field.
+    /// Currently only appears for an `impl Trait` type's `ty::Generics`
+    pub region_param_to_index: Option<BTreeMap<DefIndex, u32>>,
+
     /// Reverse map to each `TypeParameterDef`'s `index` field, from
     /// `def_id.index` (`def_id.krate` is the same as the item's).
     pub type_param_to_index: BTreeMap<DefIndex, u32>,

--- a/src/test/run-pass/impl-trait/example-st.rs
+++ b/src/test/run-pass/impl-trait/example-st.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test
+
 #![feature(conservative_impl_trait)]
 
 struct State;

--- a/src/test/run-pass/impl-trait/lifetime-generic-scoping.rs
+++ b/src/test/run-pass/impl-trait/lifetime-generic-scoping.rs
@@ -1,0 +1,28 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(conservative_impl_trait)]
+
+use std::fmt::Debug;
+
+fn foo<'a>(x: &'a u32) -> impl Debug { *x }
+fn foo_elided(x: &u32) -> impl Debug { *x }
+
+fn main() {
+    // Make sure that the lifetime parameter of `foo` isn't included in `foo`'s return type:
+    let _ = {
+        let x = 5;
+        foo(&x)
+    };
+    let _ = {
+        let x = 5;
+        foo_elided(&x)
+    };
+}


### PR DESCRIPTION
Also temporarily breaks late-bound lifetimes, since @eddyb wasn't sure what I should do about those.