### PR TITLE
Fix alloc_jemalloc debug feature

### DIFF
--- a/src/liballoc_jemalloc/build.rs
+++ b/src/liballoc_jemalloc/build.rs
@@ -111,7 +111,7 @@ fn main() {
         cmd.arg("--with-jemalloc-prefix=je_");
     }
 
-    if cfg!(feature = "debug-jemalloc") {
+    if cfg!(feature = "debug") {
         cmd.arg("--enable-debug");
     }
 

--- a/src/liballoc_jemalloc/build.rs
+++ b/src/liballoc_jemalloc/build.rs
@@ -111,9 +111,11 @@ fn main() {
         cmd.arg("--with-jemalloc-prefix=je_");
     }
 
-    if cfg!(feature = "debug") {
-        cmd.arg("--enable-debug");
-    }
+    // FIXME: building with jemalloc assertions is currently broken.
+    // See <https://github.com/rust-lang/rust/issues/44152>.
+    //if cfg!(feature = "debug") {
+    //    cmd.arg("--enable-debug");
+    //}
 
     cmd.arg(format!("--host={}", build_helper::gnu_target(&target)));
     cmd.arg(format!("--build={}", build_helper::gnu_target(&host)));


### PR DESCRIPTION
At least, I think that's how it should be.  'debug' is how the feature is called in liballoc_jemalloc/Cargo.toml and libstd/Cargo.toml. I verified this by making the build script panic rather than adding `--enable-debug`, and without this PR, the panic does not occur even when I set `debug-jemalloc = true` in config.toml. With the PR, the panic occurs as expected.

However, I actually have no idea what I am doing here.