### PR TITLE
Fix ICE with elided lifetimes in return type of foreign functions

### DIFF
--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -1081,20 +1081,8 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                 Some(body)
             }
 
-            // `fn(...) -> R` and `Trait(...) -> R` (both types and bounds).
-            hir::map::NodeTy(_) | hir::map::NodeTraitRef(_) => None,
-
-            // Foreign `fn` decls are terrible because we messed up,
-            // and their return types get argument type elision.
-            // And now too much code out there is abusing this rule.
-            hir::map::NodeForeignItem(_) => {
-                let arg_scope = Scope::Elision {
-                    elide: arg_elide,
-                    s: self.scope
-                };
-                self.with(arg_scope, |_, this| this.visit_ty(output));
-                return;
-            }
+            // Foreign functions, `fn(...) -> R` and `Trait(...) -> R` (both types and bounds).
+            hir::map::NodeForeignItem(_) | hir::map::NodeTy(_) | hir::map::NodeTraitRef(_) => None,
 
             // Everything else (only closures?) doesn't
             // actually enjoy elision in return types.

--- a/src/test/compile-fail/foreign-fn-return-lifetime.rs
+++ b/src/test/compile-fail/foreign-fn-return-lifetime.rs
@@ -1,0 +1,16 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern "C" {
+    fn g(_: &u8) -> &u8; // OK
+    fn f() -> &u8; //~ ERROR missing lifetime specifier
+}
+
+fn main() {}


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/issues/43567

This is for a preliminary crater/cargobomb run.
Lifetime elision in foreign functions now works exactly like in other functions or function-like entities.

If the breakage is significant, I'll have to partially revert https://github.com/rust-lang/rust/pull/43543 (all the stuff that was required for dealing with late bound lifetimes in this position).

r? @eddyb 