### PR TITLE
Generate builtin impls for `Clone`

### DIFF
--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -124,6 +124,7 @@ macro_rules! array_impls {
             }
 
             #[stable(feature = "rust1", since = "1.0.0")]
+            #[cfg(stage0)]
             impl<T:Copy> Clone for [T; $N] {
                 fn clone(&self) -> [T; $N] {
                     *self

--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -88,6 +88,7 @@
 /// }
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg_attr(not(stage0), lang = "clone")]
 pub trait Clone : Sized {
     /// Returns a copy of the value.
     ///
@@ -131,6 +132,7 @@ pub struct AssertParamIsClone<T: Clone + ?Sized> { _field: ::marker::PhantomData
 pub struct AssertParamIsCopy<T: Copy + ?Sized> { _field: ::marker::PhantomData<T> }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(stage0)]
 impl<'a, T: ?Sized> Clone for &'a T {
     /// Returns a shallow copy of the reference.
     #[inline]
@@ -140,6 +142,7 @@ impl<'a, T: ?Sized> Clone for &'a T {
 macro_rules! clone_impl {
     ($t:ty) => {
         #[stable(feature = "rust1", since = "1.0.0")]
+        #[cfg(stage0)]
         impl Clone for $t {
             /// Returns a deep copy of the value.
             #[inline]

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -876,6 +876,7 @@ pub fn eq<T: ?Sized>(a: *const T, b: *const T) -> bool {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(stage0)]
 impl<T: ?Sized> Clone for *const T {
     #[inline]
     fn clone(&self) -> *const T {
@@ -884,6 +885,7 @@ impl<T: ?Sized> Clone for *const T {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(stage0)]
 impl<T: ?Sized> Clone for *mut T {
     #[inline]
     fn clone(&self) -> *mut T {
@@ -895,6 +897,7 @@ impl<T: ?Sized> Clone for *mut T {
 macro_rules! fnptr_impls_safety_abi {
     ($FnTy: ty, $($Arg: ident),*) => {
         #[stable(feature = "rust1", since = "1.0.0")]
+        #[cfg(stage0)]
         impl<Ret, $($Arg),*> Clone for $FnTy {
             #[inline]
             fn clone(&self) -> Self {

--- a/src/libcore/tuple.rs
+++ b/src/libcore/tuple.rs
@@ -22,6 +22,7 @@ macro_rules! tuple_impls {
     )+) => {
         $(
             #[stable(feature = "rust1", since = "1.0.0")]
+            #[cfg(stage0)]
             impl<$($T:Clone),+> Clone for ($($T,)+) {
                 fn clone(&self) -> ($($T,)+) {
                     ($(self.$idx.clone(),)+)

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -721,7 +721,7 @@ impl<'a, 'gcx, 'tcx> HashStable<StableHashingContext<'a, 'gcx, 'tcx>> for ty::In
                 def_id.hash_stable(hcx, hasher);
                 t.hash_stable(hcx, hasher);
             }
-            ty::InstanceDef::BuiltinShim(def_id, t) => {
+            ty::InstanceDef::CloneShim(def_id, t) => {
                 def_id.hash_stable(hcx, hasher);
                 t.hash_stable(hcx, hasher);
             }

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -721,6 +721,10 @@ impl<'a, 'gcx, 'tcx> HashStable<StableHashingContext<'a, 'gcx, 'tcx>> for ty::In
                 def_id.hash_stable(hcx, hasher);
                 t.hash_stable(hcx, hasher);
             }
+            ty::InstanceDef::BuiltinShim(def_id, t) => {
+                def_id.hash_stable(hcx, hasher);
+                t.hash_stable(hcx, hasher);
+            }
         }
     }
 }

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -274,6 +274,7 @@ language_item_table! {
     SizedTraitLangItem,              "sized",                   sized_trait;
     UnsizeTraitLangItem,             "unsize",                  unsize_trait;
     CopyTraitLangItem,               "copy",                    copy_trait;
+    CloneTraitLangItem,              "clone",                   clone_trait;
     SyncTraitLangItem,               "sync",                    sync_trait;
     FreezeTraitLangItem,             "freeze",                  freeze_trait;
 
@@ -319,6 +320,9 @@ language_item_table! {
     OrdTraitLangItem,                "ord",                     ord_trait;
 
     StrEqFnLangItem,                 "str_eq",                  str_eq_fn;
+
+    CloneMethodLangItem,             "clone_method",            clone_method;
+    CloneFromMethodLangItem,         "clone_from_method",       clone_from_method;
 
     // A number of panic-related lang items. The `panic` item corresponds to
     // divide-by-zero and various panic cases with `match`. The

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -321,9 +321,6 @@ language_item_table! {
 
     StrEqFnLangItem,                 "str_eq",                  str_eq_fn;
 
-    CloneMethodLangItem,             "clone_method",            clone_method;
-    CloneFromMethodLangItem,         "clone_from_method",       clone_from_method;
-
     // A number of panic-related lang items. The `panic` item corresponds to
     // divide-by-zero and various panic cases with `match`. The
     // `panic_bounds_check` item is for indexing arrays.

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -301,7 +301,7 @@ pub enum Vtable<'tcx, N> {
     VtableObject(VtableObjectData<'tcx, N>),
 
     /// Successful resolution for a builtin trait.
-    VtableBuiltin(VtableBuiltinData<N>),
+    VtableBuiltin(VtableBuiltinData<'tcx, N>),
 
     /// Vtable automatically generated for a closure. The def ID is the ID
     /// of the closure expression. This is a `VtableImpl` in spirit, but the
@@ -345,7 +345,9 @@ pub struct VtableDefaultImplData<N> {
 }
 
 #[derive(Clone)]
-pub struct VtableBuiltinData<N> {
+pub struct VtableBuiltinData<'tcx, N> {
+    /// `ty` can be used for generating shim for builtin implementations like `Clone::clone`.
+    pub ty: ty::Ty<'tcx>,
     pub nested: Vec<N>
 }
 
@@ -769,6 +771,7 @@ impl<'tcx, N> Vtable<'tcx, N> {
             }),
             VtableParam(n) => VtableParam(n.into_iter().map(f).collect()),
             VtableBuiltin(i) => VtableBuiltin(VtableBuiltinData {
+                ty: i.ty,
                 nested: i.nested.into_iter().map(f).collect(),
             }),
             VtableObject(o) => VtableObject(VtableObjectData {

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -301,7 +301,7 @@ pub enum Vtable<'tcx, N> {
     VtableObject(VtableObjectData<'tcx, N>),
 
     /// Successful resolution for a builtin trait.
-    VtableBuiltin(VtableBuiltinData<'tcx, N>),
+    VtableBuiltin(VtableBuiltinData<N>),
 
     /// Vtable automatically generated for a closure. The def ID is the ID
     /// of the closure expression. This is a `VtableImpl` in spirit, but the
@@ -345,9 +345,7 @@ pub struct VtableDefaultImplData<N> {
 }
 
 #[derive(Clone)]
-pub struct VtableBuiltinData<'tcx, N> {
-    /// `ty` can be used for generating shim for builtin implementations like `Clone::clone`.
-    pub ty: ty::Ty<'tcx>,
+pub struct VtableBuiltinData<N> {
     pub nested: Vec<N>
 }
 
@@ -771,7 +769,6 @@ impl<'tcx, N> Vtable<'tcx, N> {
             }),
             VtableParam(n) => VtableParam(n.into_iter().map(f).collect()),
             VtableBuiltin(i) => VtableBuiltin(VtableBuiltinData {
-                ty: i.ty,
                 nested: i.nested.into_iter().map(f).collect(),
             }),
             VtableObject(o) => VtableObject(VtableObjectData {

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -2265,7 +2265,7 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
     fn confirm_builtin_candidate(&mut self,
                                  obligation: &TraitObligation<'tcx>,
                                  has_nested: bool)
-                                 -> VtableBuiltinData<'tcx, PredicateObligation<'tcx>>
+                                 -> VtableBuiltinData<PredicateObligation<'tcx>>
     {
         debug!("confirm_builtin_candidate({:?}, {:?})",
                obligation, has_nested);
@@ -2303,8 +2303,7 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
         debug!("confirm_builtin_candidate: obligations={:?}",
                obligations);
 
-        let self_ty = self.infcx.shallow_resolve(obligation.predicate.skip_binder().self_ty());
-        VtableBuiltinData { ty: self_ty, nested: obligations }
+        VtableBuiltinData { nested: obligations }
     }
 
     /// This handles the case where a `impl Foo for ..` impl is being used.
@@ -2611,7 +2610,7 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
 
     fn confirm_builtin_unsize_candidate(&mut self,
                                         obligation: &TraitObligation<'tcx>,)
-        -> Result<VtableBuiltinData<'tcx, PredicateObligation<'tcx>>, SelectionError<'tcx>>
+        -> Result<VtableBuiltinData<PredicateObligation<'tcx>>, SelectionError<'tcx>>
     {
         let tcx = self.tcx();
 
@@ -2814,7 +2813,7 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
             _ => bug!()
         };
 
-        Ok(VtableBuiltinData { ty: source, nested: nested })
+        Ok(VtableBuiltinData { nested: nested })
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/librustc/traits/structural_impls.rs
+++ b/src/librustc/traits/structural_impls.rs
@@ -86,9 +86,9 @@ impl<'tcx, N: fmt::Debug> fmt::Debug for traits::VtableClosureData<'tcx, N> {
     }
 }
 
-impl<'tcx, N: fmt::Debug> fmt::Debug for traits::VtableBuiltinData<'tcx, N> {
+impl<'tcx, N: fmt::Debug> fmt::Debug for traits::VtableBuiltinData<N> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "VtableBuiltin(ty={:?}, nested={:?})", self.ty, self.nested)
+        write!(f, "VtableBuiltin(nested={:?})", self.nested)
     }
 }
 
@@ -300,14 +300,7 @@ impl<'a, 'tcx> Lift<'tcx> for traits::Vtable<'a, ()> {
                 })
             }
             traits::VtableParam(n) => Some(traits::VtableParam(n)),
-            traits::VtableBuiltin(traits::VtableBuiltinData { ty, nested }) => {
-                tcx.lift(&ty).map(|ty| {
-                    traits::VtableBuiltin(traits::VtableBuiltinData {
-                        ty,
-                        nested,
-                    })
-                })
-            }
+            traits::VtableBuiltin(n) => Some(traits::VtableBuiltin(n)),
             traits::VtableObject(traits::VtableObjectData {
                 upcast_trait_ref,
                 vtable_base,
@@ -385,10 +378,9 @@ impl<'tcx, N: TypeFoldable<'tcx>> TypeFoldable<'tcx> for traits::VtableDefaultIm
     }
 }
 
-impl<'tcx, N: TypeFoldable<'tcx>> TypeFoldable<'tcx> for traits::VtableBuiltinData<'tcx, N> {
+impl<'tcx, N: TypeFoldable<'tcx>> TypeFoldable<'tcx> for traits::VtableBuiltinData<N> {
     fn super_fold_with<'gcx: 'tcx, F: TypeFolder<'gcx, 'tcx>>(&self, folder: &mut F) -> Self {
         traits::VtableBuiltinData {
-            ty: self.ty.fold_with(folder),
             nested: self.nested.fold_with(folder),
         }
     }

--- a/src/librustc/ty/instance.rs
+++ b/src/librustc/ty/instance.rs
@@ -24,15 +24,22 @@ pub struct Instance<'tcx> {
 pub enum InstanceDef<'tcx> {
     Item(DefId),
     Intrinsic(DefId),
-    // <fn() as FnTrait>::call_*
-    // def-id is FnTrait::call_*
+
+    /// <fn() as FnTrait>::call_*
+    /// def-id is FnTrait::call_*
     FnPtrShim(DefId, Ty<'tcx>),
-    // <Trait as Trait>::fn
+
+    /// <Trait as Trait>::fn
     Virtual(DefId, usize),
-    // <[mut closure] as FnOnce>::call_once
+
+    /// <[mut closure] as FnOnce>::call_once
     ClosureOnceShim { call_once: DefId },
-    // drop_in_place::<T>; None for empty drop glue.
+
+    /// drop_in_place::<T>; None for empty drop glue.
     DropGlue(DefId, Option<Ty<'tcx>>),
+
+    /// Builtin method implementation, e.g. `Clone::clone`.
+    BuiltinShim(DefId, Ty<'tcx>),
 }
 
 impl<'tcx> InstanceDef<'tcx> {
@@ -43,9 +50,9 @@ impl<'tcx> InstanceDef<'tcx> {
             InstanceDef::FnPtrShim(def_id, _) |
             InstanceDef::Virtual(def_id, _) |
             InstanceDef::Intrinsic(def_id, ) |
-            InstanceDef::ClosureOnceShim { call_once: def_id }
-                => def_id,
-            InstanceDef::DropGlue(def_id, _) => def_id
+            InstanceDef::ClosureOnceShim { call_once: def_id } |
+            InstanceDef::DropGlue(def_id, _) |
+            InstanceDef::BuiltinShim(def_id, _) => def_id
         }
     }
 
@@ -78,6 +85,9 @@ impl<'tcx> fmt::Display for Instance<'tcx> {
                 write!(f, " - shim")
             }
             InstanceDef::DropGlue(_, ty) => {
+                write!(f, " - shim({:?})", ty)
+            }
+            InstanceDef::BuiltinShim(_, ty) => {
                 write!(f, " - shim({:?})", ty)
             }
         }

--- a/src/librustc/ty/instance.rs
+++ b/src/librustc/ty/instance.rs
@@ -39,7 +39,7 @@ pub enum InstanceDef<'tcx> {
     DropGlue(DefId, Option<Ty<'tcx>>),
 
     /// Builtin method implementation, e.g. `Clone::clone`.
-    BuiltinShim(DefId, Ty<'tcx>),
+    CloneShim(DefId, Ty<'tcx>),
 }
 
 impl<'tcx> InstanceDef<'tcx> {
@@ -52,7 +52,7 @@ impl<'tcx> InstanceDef<'tcx> {
             InstanceDef::Intrinsic(def_id, ) |
             InstanceDef::ClosureOnceShim { call_once: def_id } |
             InstanceDef::DropGlue(def_id, _) |
-            InstanceDef::BuiltinShim(def_id, _) => def_id
+            InstanceDef::CloneShim(def_id, _) => def_id
         }
     }
 
@@ -87,7 +87,7 @@ impl<'tcx> fmt::Display for Instance<'tcx> {
             InstanceDef::DropGlue(_, ty) => {
                 write!(f, " - shim({:?})", ty)
             }
-            InstanceDef::BuiltinShim(_, ty) => {
+            InstanceDef::CloneShim(_, ty) => {
                 write!(f, " - shim({:?})", ty)
             }
         }

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2228,7 +2228,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             ty::InstanceDef::Virtual(..) |
             ty::InstanceDef::ClosureOnceShim { .. } |
             ty::InstanceDef::DropGlue(..) |
-            ty::InstanceDef::BuiltinShim(..) => {
+            ty::InstanceDef::CloneShim(..) => {
                 self.mir_shims(instance)
             }
         }

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2227,7 +2227,8 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             ty::InstanceDef::FnPtrShim(..) |
             ty::InstanceDef::Virtual(..) |
             ty::InstanceDef::ClosureOnceShim { .. } |
-            ty::InstanceDef::DropGlue(..) => {
+            ty::InstanceDef::DropGlue(..) |
+            ty::InstanceDef::BuiltinShim(..) => {
                 self.mir_shims(instance)
             }
         }

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -275,7 +275,7 @@ impl<'a, 'tcx> DropElaborator<'a, 'tcx> for DropShimElaborator<'a, 'tcx> {
 /// Build a `Clone::clone` shim for `recvr_ty`. Here, `def_id` is `Clone::clone`.
 fn build_clone_shim<'a, 'tcx>(tcx: ty::TyCtxt<'a, 'tcx, 'tcx>,
                               def_id: DefId,
-                              recvr_ty: ty::Ty<'tcx>)
+                              rcvr_ty: ty::Ty<'tcx>)
                               -> Mir<'tcx>
 {
     let sig = tcx.fn_sig(def_id);
@@ -348,7 +348,7 @@ fn build_clone_shim<'a, 'tcx>(tcx: ty::TyCtxt<'a, 'tcx, 'tcx>,
         loc
     };
 
-    match recvr_ty.sty {
+    match rcvr_ty.sty {
         ty::TyArray(ty, len) => {
             let mut returns = Vec::new();
             for i in 0..len {
@@ -374,7 +374,7 @@ fn build_clone_shim<'a, 'tcx>(tcx: ty::TyCtxt<'a, 'tcx, 'tcx>,
                     Lvalue::Local(RETURN_POINTER),
                     Rvalue::Aggregate(
                         box AggregateKind::Array(ty),
-                        returns.into_iter().map(|loc| Operand::Consume(loc)).collect()
+                        returns.into_iter().map(Operand::Consume).collect()
                     )
                 )
             };
@@ -396,7 +396,7 @@ fn build_clone_shim<'a, 'tcx>(tcx: ty::TyCtxt<'a, 'tcx, 'tcx>,
                     Lvalue::Local(RETURN_POINTER),
                     Rvalue::Aggregate(
                         box AggregateKind::Tuple,
-                        returns.into_iter().map(|loc| Operand::Consume(loc)).collect()
+                        returns.into_iter().map(Operand::Consume).collect()
                     )
                 )
             };

--- a/src/librustc_trans/collector.rs
+++ b/src/librustc_trans/collector.rs
@@ -700,7 +700,7 @@ fn visit_instance_use<'a, 'tcx>(scx: &SharedCrateContext<'a, 'tcx>,
         ty::InstanceDef::ClosureOnceShim { .. } |
         ty::InstanceDef::Item(..) |
         ty::InstanceDef::FnPtrShim(..) |
-        ty::InstanceDef::BuiltinShim(..) => {
+        ty::InstanceDef::CloneShim(..) => {
             output.push(create_fn_trans_item(instance));
         }
     }
@@ -718,7 +718,7 @@ fn should_trans_locally<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, instance: &Instan
         ty::InstanceDef::FnPtrShim(..) |
         ty::InstanceDef::DropGlue(..) |
         ty::InstanceDef::Intrinsic(_) |
-        ty::InstanceDef::BuiltinShim(..) => return true
+        ty::InstanceDef::CloneShim(..) => return true
     };
     match tcx.hir.get_if_local(def_id) {
         Some(hir_map::NodeForeignItem(..)) => {

--- a/src/librustc_trans/collector.rs
+++ b/src/librustc_trans/collector.rs
@@ -699,7 +699,8 @@ fn visit_instance_use<'a, 'tcx>(scx: &SharedCrateContext<'a, 'tcx>,
         }
         ty::InstanceDef::ClosureOnceShim { .. } |
         ty::InstanceDef::Item(..) |
-        ty::InstanceDef::FnPtrShim(..) => {
+        ty::InstanceDef::FnPtrShim(..) |
+        ty::InstanceDef::BuiltinShim(..) => {
             output.push(create_fn_trans_item(instance));
         }
     }
@@ -716,7 +717,8 @@ fn should_trans_locally<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, instance: &Instan
         ty::InstanceDef::Virtual(..) |
         ty::InstanceDef::FnPtrShim(..) |
         ty::InstanceDef::DropGlue(..) |
-        ty::InstanceDef::Intrinsic(_) => return true
+        ty::InstanceDef::Intrinsic(_) |
+        ty::InstanceDef::BuiltinShim(..) => return true
     };
     match tcx.hir.get_if_local(def_id) {
         Some(hir_map::NodeForeignItem(..)) => {

--- a/src/librustc_trans/monomorphize.rs
+++ b/src/librustc_trans/monomorphize.rs
@@ -143,6 +143,12 @@ fn resolve_associated_item<'a, 'tcx>(
                 substs: rcvr_substs
             }
         }
+        traits::VtableBuiltin(ref data) => {
+            Instance {
+                def: ty::InstanceDef::BuiltinShim(def_id, data.ty),
+                substs: rcvr_substs
+            }
+        }
         _ => {
             bug!("static call to invalid vtable: {:?}", vtbl)
         }

--- a/src/librustc_trans/monomorphize.rs
+++ b/src/librustc_trans/monomorphize.rs
@@ -143,9 +143,9 @@ fn resolve_associated_item<'a, 'tcx>(
                 substs: rcvr_substs
             }
         }
-        traits::VtableBuiltin(..) => {
+        traits::VtableBuiltin(..) if Some(trait_id) == tcx.lang_items.clone_trait() => {
             Instance {
-                def: ty::InstanceDef::BuiltinShim(def_id, trait_ref.self_ty()),
+                def: ty::InstanceDef::CloneShim(def_id, trait_ref.self_ty()),
                 substs: rcvr_substs
             }
         }

--- a/src/librustc_trans/monomorphize.rs
+++ b/src/librustc_trans/monomorphize.rs
@@ -143,9 +143,9 @@ fn resolve_associated_item<'a, 'tcx>(
                 substs: rcvr_substs
             }
         }
-        traits::VtableBuiltin(ref data) => {
+        traits::VtableBuiltin(..) => {
             Instance {
-                def: ty::InstanceDef::BuiltinShim(def_id, data.ty),
+                def: ty::InstanceDef::BuiltinShim(def_id, trait_ref.self_ty()),
                 substs: rcvr_substs
             }
         }

--- a/src/librustc_trans/partitioning.rs
+++ b/src/librustc_trans/partitioning.rs
@@ -361,7 +361,8 @@ fn place_root_translation_items<'a, 'tcx, I>(scx: &SharedCrateContext<'a, 'tcx>,
                                 InstanceDef::Virtual(..) |
                                 InstanceDef::Intrinsic(..) |
                                 InstanceDef::ClosureOnceShim { .. } |
-                                InstanceDef::DropGlue(..) => {
+                                InstanceDef::DropGlue(..) |
+                                InstanceDef::BuiltinShim(..) => {
                                     bug!("partitioning: Encountered unexpected
                                           root translation item: {:?}",
                                           trans_item)
@@ -603,7 +604,8 @@ fn characteristic_def_id_of_trans_item<'a, 'tcx>(scx: &SharedCrateContext<'a, 't
                 ty::InstanceDef::ClosureOnceShim { .. } |
                 ty::InstanceDef::Intrinsic(..) |
                 ty::InstanceDef::DropGlue(..) |
-                ty::InstanceDef::Virtual(..) => return None
+                ty::InstanceDef::Virtual(..) |
+                ty::InstanceDef::BuiltinShim(..) => return None
             };
 
             // If this is a method, we want to put it into the same module as

--- a/src/librustc_trans/partitioning.rs
+++ b/src/librustc_trans/partitioning.rs
@@ -362,7 +362,7 @@ fn place_root_translation_items<'a, 'tcx, I>(scx: &SharedCrateContext<'a, 'tcx>,
                                 InstanceDef::Intrinsic(..) |
                                 InstanceDef::ClosureOnceShim { .. } |
                                 InstanceDef::DropGlue(..) |
-                                InstanceDef::BuiltinShim(..) => {
+                                InstanceDef::CloneShim(..) => {
                                     bug!("partitioning: Encountered unexpected
                                           root translation item: {:?}",
                                           trans_item)
@@ -605,7 +605,7 @@ fn characteristic_def_id_of_trans_item<'a, 'tcx>(scx: &SharedCrateContext<'a, 't
                 ty::InstanceDef::Intrinsic(..) |
                 ty::InstanceDef::DropGlue(..) |
                 ty::InstanceDef::Virtual(..) |
-                ty::InstanceDef::BuiltinShim(..) => return None
+                ty::InstanceDef::CloneShim(..) => return None
             };
 
             // If this is a method, we want to put it into the same module as

--- a/src/test/run-pass/builtin-clone-unwind.rs
+++ b/src/test/run-pass/builtin-clone-unwind.rs
@@ -1,0 +1,65 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that builtin implementations of `Clone` cleanup everything
+// in case of unwinding.
+
+use std::thread;
+use std::sync::Arc;
+
+struct S(Arc<()>);
+
+impl Clone for S {
+    fn clone(&self) -> Self {
+        if Arc::strong_count(&self.0) == 7 {
+            panic!("oops");
+        }
+
+        S(self.0.clone())
+    }
+}
+
+fn main() {
+    let counter = Arc::new(());
+
+    // Unwinding with tuples...
+    let ccounter = counter.clone();
+    let child = thread::spawn(move || {
+        let _ = (
+            S(ccounter.clone()),
+            S(ccounter.clone()),
+            S(ccounter.clone()),
+            S(ccounter)
+        ).clone();
+    });
+
+    assert!(child.join().is_err());
+    assert_eq!(
+        1,
+        Arc::strong_count(&counter)
+    );
+
+    // ... and with arrays.
+    let ccounter = counter.clone();
+    let child = thread::spawn(move || {
+        let _ = [
+            S(ccounter.clone()),
+            S(ccounter.clone()),
+            S(ccounter.clone()),
+            S(ccounter)
+        ].clone();
+    });
+
+    assert!(child.join().is_err());
+    assert_eq!(
+        1,
+        Arc::strong_count(&counter)
+    );
+}

--- a/src/test/run-pass/builtin-clone.rs
+++ b/src/test/run-pass/builtin-clone.rs
@@ -1,0 +1,54 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that `Clone` is correctly implemented for builtin types.
+// Also test that cloning an array or a tuple is done right, i.e.
+// each component is cloned.
+
+fn test_clone<T: Clone>(arg: T) {
+    let _ = arg.clone();
+}
+
+fn foo() { }
+
+#[derive(Debug, PartialEq, Eq)]
+struct S(i32);
+
+impl Clone for S {
+    fn clone(&self) -> Self {
+        S(self.0 + 1)
+    }
+}
+
+fn main() {
+    test_clone(foo);
+    test_clone([1; 56]);
+    test_clone((1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1));
+
+    let a = [S(0), S(1), S(2)];
+    let b = [S(1), S(2), S(3)];
+    assert_eq!(b, a.clone());
+
+    let a = (
+        (S(1), S(0)),
+        (
+            (S(0), S(0), S(1)),
+            S(0)
+        )
+    );
+    let b = (
+        (S(2), S(1)),
+        (
+            (S(1), S(1), S(2)),
+            S(1)
+        )
+    );
+    assert_eq!(b, a.clone());
+}

--- a/src/test/run-pass/builtin-clone.rs
+++ b/src/test/run-pass/builtin-clone.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/test/run-pass/issue-37725.rs
+++ b/src/test/run-pass/issue-37725.rs
@@ -8,7 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub fn foo<'a>(s: &'a mut ()) where &'a mut (): Clone {
-    s.clone();
+trait Foo {
+    fn foo(&self);
+}
+
+fn foo<'a>(s: &'a mut ()) where &'a mut (): Foo {
+    s.foo();
 }
 fn main() {}


### PR DESCRIPTION
This fixes a long-standing ICE and limitation where some builtin types implement `Copy` but not `Clone` (whereas `Clone` is a super trait of `Copy`).

However, this PR has a few side-effects:
* `Clone` is now marked as a lang item.
* `[T; N]` is now `Clone` if `T: Clone` (currently, only if `T: Copy` and for `N <= 32`).
* `fn foo<'a>() where &'a mut (): Clone { }` won't compile anymore because of how bounds for builtin traits are handled (e.g. same thing currently if you replace `Clone` by `Copy` in this example). Of course this function is unusable anyway, an error would pop as soon as it is called.

Hence, I'm wondering wether this PR would need an RFC...
Also, cc-ing @nikomatsakis, @arielb1.

Related issues: #28229, #24000.