### PR TITLE
Explicitly pass -no-pie

### DIFF
--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -1016,8 +1016,9 @@ fn link_args(cmd: &mut Linker,
 
     let used_link_args = sess.cstore.used_link_args();
 
+    let mut pie = false;
     if crate_type == config::CrateTypeExecutable &&
-       t.options.position_independent_executables {
+        t.options.position_independent_executables {
         let empty_vec = Vec::new();
         let args = sess.opts.cg.link_args.as_ref().unwrap_or(&empty_vec);
         let more_args = &sess.opts.cg.link_arg;
@@ -1025,8 +1026,13 @@ fn link_args(cmd: &mut Linker,
 
         if get_reloc_model(sess) == llvm::RelocMode::PIC
             && !args.any(|x| *x == "-static") {
-            cmd.position_independent_executable();
+            pie = true
         }
+    }
+    if pie {
+        cmd.position_independent_executable();
+    } else {
+        cmd.no_position_independent_executable();
     }
 
     let relro_level = match sess.opts.debugging_opts.relro_level {

--- a/src/librustc_trans/back/linker.rs
+++ b/src/librustc_trans/back/linker.rs
@@ -104,6 +104,7 @@ pub trait Linker {
     fn add_object(&mut self, path: &Path);
     fn gc_sections(&mut self, keep_metadata: bool);
     fn position_independent_executable(&mut self);
+    fn no_position_independent_executable(&mut self);
     fn partial_relro(&mut self);
     fn full_relro(&mut self);
     fn optimize(&mut self);
@@ -177,6 +178,7 @@ impl<'a> Linker for GccLinker<'a> {
     fn output_filename(&mut self, path: &Path) { self.cmd.arg("-o").arg(path); }
     fn add_object(&mut self, path: &Path) { self.cmd.arg(path); }
     fn position_independent_executable(&mut self) { self.cmd.arg("-pie"); }
+    fn no_position_independent_executable(&mut self) { self.cmd.arg("-no-pie"); }
     fn partial_relro(&mut self) { self.linker_arg("-z,relro"); }
     fn full_relro(&mut self) { self.linker_arg("-z,relro,-z,now"); }
     fn args(&mut self, args: &[String]) { self.cmd.args(args); }
@@ -432,6 +434,10 @@ impl<'a> Linker for MsvcLinker<'a> {
         // noop
     }
 
+    fn no_position_independent_executable(&mut self) {
+        // noop
+    }
+
     fn partial_relro(&mut self) {
         // noop
     }
@@ -625,6 +631,10 @@ impl<'a> Linker for EmLinker<'a> {
     }
 
     fn position_independent_executable(&mut self) {
+        // noop
+    }
+
+    fn no_position_independent_executable(&mut self) {
         // noop
     }
 


### PR DESCRIPTION
Some linkers (e.g. Debian and Arch's) that are configured to make PIEs
by default will make dynamically linked executables that don't actually
dynamically link to anything. Fix that by explicitly passing -no-pie in
those cases.

Closes #43647 

I wasn't able to test this out manually - is there an easy way to make a suitable musl root?