### PR TITLE
de-orphan extended information

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1207,6 +1207,10 @@ pub fn diagnostics_registry() -> errors::registry::Registry {
     all_errors.extend_from_slice(&rustc_trans::DIAGNOSTICS);
     all_errors.extend_from_slice(&rustc_const_eval::DIAGNOSTICS);
     all_errors.extend_from_slice(&rustc_metadata::DIAGNOSTICS);
+    all_errors.extend_from_slice(&rustc_passes::DIAGNOSTICS);
+    all_errors.extend_from_slice(&rustc_plugin::DIAGNOSTICS);
+    all_errors.extend_from_slice(&rustc_mir::DIAGNOSTICS);
+    all_errors.extend_from_slice(&syntax::DIAGNOSTICS);
 
     Registry::new(&all_errors)
 }

--- a/src/librustc_mir/diagnostics.rs
+++ b/src/librustc_mir/diagnostics.rs
@@ -122,10 +122,8 @@ On the other hand, static and constant pointers can point either to
 a known numeric address or to the address of a symbol.
 
 ```
+static MY_STATIC: u32 = 42;
 static MY_STATIC_ADDR: &'static u32 = &MY_STATIC;
-// ... and also
-static MY_STATIC_ADDR2: *const u32 = &MY_STATIC;
-
 const CONST_ADDR: *const u8 = 0x5f3759df as *const u8;
 ```
 
@@ -160,6 +158,16 @@ Remember: you can't use a function call inside a const's initialization
 expression! However, you can totally use it anywhere else:
 
 ```
+enum Test {
+    V1
+}
+
+impl Test {
+    fn func(&self) -> i32 {
+        12
+    }
+}
+
 fn main() {
     const FOO: Test = Test::V1;
 

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -57,3 +57,5 @@ pub fn provide(providers: &mut Providers) {
     shim::provide(providers);
     transform::provide(providers);
 }
+
+__build_diagnostic_array! { librustc_mir, DIAGNOSTICS }

--- a/src/librustc_passes/diagnostics.rs
+++ b/src/librustc_passes/diagnostics.rs
@@ -221,7 +221,7 @@ while break {}
 
 To fix this, add a label specifying which loop is being broken out of:
 ```
-`foo: while break `foo {}
+'foo: while break 'foo {}
 ```
 "##
 }

--- a/src/librustc_passes/lib.rs
+++ b/src/librustc_passes/lib.rs
@@ -45,3 +45,5 @@ pub mod loops;
 pub mod mir_stats;
 pub mod no_asm;
 pub mod static_recursion;
+
+__build_diagnostic_array! { librustc_passes, DIAGNOSTICS }

--- a/src/librustc_plugin/lib.rs
+++ b/src/librustc_plugin/lib.rs
@@ -84,3 +84,5 @@ pub mod diagnostics;
 pub mod registry;
 pub mod load;
 pub mod build;
+
+__build_diagnostic_array! { librustc_plugin, DIAGNOSTICS }

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -4709,7 +4709,7 @@ register_diagnostics! {
            // between structures with the same definition
     E0521, // redundant default implementations of trait
     E0533, // `{}` does not name a unit variant, unit struct or a constant
-    E0563, // cannot determine a type for this `impl Trait`: {}
+//  E0563, // cannot determine a type for this `impl Trait`: {} // removed in 6383de15
     E0564, // only named lifetimes are allowed in `impl Trait`,
            // but `{}` was found in the type `{}`
     E0567, // auto traits can not have type parameters

--- a/src/libsyntax/diagnostic_list.rs
+++ b/src/libsyntax/diagnostic_list.rs
@@ -42,7 +42,7 @@ The `inline` attribute was malformed.
 
 Erroneous code example:
 
-```compile_fail,E0534
+```ignore (compile_fail not working here; see Issue #43707)
 #[inline()] // error: expected one argument
 pub fn something() {}
 
@@ -80,7 +80,7 @@ An unknown argument was given to the `inline` attribute.
 
 Erroneous code example:
 
-```compile_fail,E0535
+```ignore (compile_fail not working here; see Issue #43707)
 #[inline(unknown)] // error: invalid argument
 pub fn something() {}
 
@@ -190,7 +190,9 @@ A literal was used in an attribute that doesn't support literals.
 
 Erroneous code example:
 
-```compile_fail,E0565
+```ignore (compile_fail not working here; see Issue #43707)
+#![feature(attr_literals)]
+
 #[inline("always")] // error: unsupported literal
 pub fn something() {}
 ```
@@ -209,7 +211,7 @@ A file wasn't found for an out-of-line module.
 
 Erroneous code example:
 
-```compile_fail,E0583
+```ignore (compile_fail not working here; see Issue #43707)
 mod file_that_doesnt_exist; // error: file not found for module
 
 fn main() {}
@@ -251,23 +253,33 @@ An inclusive range was used with no end.
 Erroneous code example:
 
 ```compile_fail,E0586
-let tmp = vec![0, 1, 2, 3, 4, 4, 3, 3, 2, 1];
-let x = &tmp[1...]; // error: inclusive range was used with no end
+#![feature(inclusive_range_syntax)]
+
+fn main() {
+    let tmp = vec![0, 1, 2, 3, 4, 4, 3, 3, 2, 1];
+    let x = &tmp[1...]; // error: inclusive range was used with no end
+}
 ```
 
 An inclusive range needs an end in order to *include* it. If you just need a
 start and no end, use a non-inclusive range (with `..`):
 
 ```
-let tmp = vec![0, 1, 2, 3, 4, 4, 3, 3, 2, 1];
-let x = &tmp[1..]; // ok!
+fn main() {
+    let tmp = vec![0, 1, 2, 3, 4, 4, 3, 3, 2, 1];
+    let x = &tmp[1..]; // ok!
+}
 ```
 
 Or put an end to your inclusive range:
 
 ```
-let tmp = vec![0, 1, 2, 3, 4, 4, 3, 3, 2, 1];
-let x = &tmp[1...3]; // ok!
+#![feature(inclusive_range_syntax)]
+
+fn main() {
+    let tmp = vec![0, 1, 2, 3, 4, 4, 3, 3, 2, 1];
+    let x = &tmp[1...3]; // ok!
+}
 ```
 "##,
 

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -148,4 +148,4 @@ pub mod ext {
 #[cfg(test)]
 mod test_snippet;
 
-// __build_diagnostic_array! { libsyntax, DIAGNOSTICS }
+__build_diagnostic_array! { libsyntax, DIAGNOSTICS }


### PR DESCRIPTION
Bizarrely, librustc_passes, librustc_plugin, librustc_mir, and libsyntax [weren't getting their error explanations registered](https://github.com/rust-lang/rust/issues/35284) (leaving _several_ error codes absent from [the index](https://doc.rust-lang.org/nightly/error-index.html) and `--explain`). This surfaced a few latent doctest failures that were fixed where readily possible and ignored (with a recorded excuse) if not.

Also, we don't issue E0563 anymore.

r? @GuillaumeGomez 