### PR TITLE
Accept underscores in unicode escapes

### DIFF
--- a/src/test/parse-fail/issue-23620-invalid-escapes.rs
+++ b/src/test/parse-fail/issue-23620-invalid-escapes.rs
@@ -41,9 +41,8 @@ fn main() {
     //~^^^ ERROR incorrect unicode escape sequence
     //~^^^^ ERROR unicode escape sequences cannot be used as a byte or in a byte string
 
-    let _ = "\u{ffffff} \xf \u";
-    //~^ ERROR invalid unicode character escape
-    //~^^ ERROR invalid character in numeric character escape:
-    //~^^^ ERROR form of character escape may only be used with characters in the range [\x00-\x7f]
-    //~^^^^ ERROR incorrect unicode escape sequence
+    let _ = "\xf \u";
+    //~^ ERROR invalid character in numeric character escape:
+    //~^^ ERROR form of character escape may only be used with characters in the range [\x00-\x7f]
+    //~^^^ ERROR incorrect unicode escape sequence
 }

--- a/src/test/parse-fail/issue-43692.rs
+++ b/src/test/parse-fail/issue-43692.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,7 +10,6 @@
 
 // compile-flags: -Z parse-only
 
-pub fn main() {
-    let s1 = "\u{d805}"; //~ ERROR invalid unicode character escape
-    let s2 = "\u{ffffff}"; //~ ERROR invalid unicode character escape
+fn main() {
+    '\u{_10FFFF}'; //~ ERROR invalid start of unicode escape
 }

--- a/src/test/parse-fail/new-unicode-escapes-2.rs
+++ b/src/test/parse-fail/new-unicode-escapes-2.rs
@@ -11,5 +11,5 @@
 // compile-flags: -Z parse-only
 
 pub fn main() {
-    let s = "\u{260311111111}"; //~ ERROR overlong unicode escape (can have at most 6 hex digits)
+    let s = "\u{260311111111}"; //~ ERROR overlong unicode escape (must have at most 6 hex digits)
 }

--- a/src/test/parse-fail/new-unicode-escapes-4.rs
+++ b/src/test/parse-fail/new-unicode-escapes-4.rs
@@ -13,6 +13,4 @@
 pub fn main() {
     let s = "\u{lol}";
      //~^ ERROR invalid character in unicode escape: l
-     //~^^ ERROR invalid character in unicode escape: o
-     //~^^^ ERROR invalid character in unicode escape: l
 }

--- a/src/test/run-pass/issue-43692.rs
+++ b/src/test/run-pass/issue-43692.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,9 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
-
-pub fn main() {
-    let s1 = "\u{d805}"; //~ ERROR invalid unicode character escape
-    let s2 = "\u{ffffff}"; //~ ERROR invalid unicode character escape
+fn main() {
+    assert_eq!('\u{10__FFFF}', '\u{10FFFF}');
+    assert_eq!("\u{10_F0FF__}foo\u{1_0_0_0__}", "\u{10F0FF}foo\u{1000}");
 }


### PR DESCRIPTION
Fixes #43692.

I don't know if this need an RFC, but at least the impl is here!