### PR TITLE
Allow unsized closures in iterator adaptors

### DIFF
--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1288,3 +1288,16 @@ fn test_step_replace_no_between() {
     assert_eq!(x, 1);
     assert_eq!(y, 5);
 }
+
+#[test]
+fn test_unsized_closures_in_map_etc() {
+    fn an_iterator<I: Iterator + ?Sized>(iter: &mut I) { let _ = iter.next(); }
+
+    an_iterator::<Filter<_, FnMut(&_) -> _>>(&mut (0..10).filter(|_| true));
+    an_iterator::<FilterMap<_, FnMut(_) -> _>>(&mut (0..10).filter_map(|i| Some(i)));
+    an_iterator::<FlatMap<_, _, FnMut(_) -> _>>(&mut (0..10).flat_map(|i| 0..i));
+    an_iterator::<Inspect<_, FnMut(&_)>>(&mut (0..10).inspect(|_| {}));
+    an_iterator::<Map<_, FnMut(_) -> _>>(&mut (0..10).map(|x| x + 1));
+    an_iterator::<SkipWhile<_, FnMut(&_) -> _>>(&mut (0..10).skip_while(|_| true));
+    an_iterator::<TakeWhile<_, FnMut(&_) -> _>>(&mut (0..10).take_while(|_| true));
+}


### PR DESCRIPTION
For example, `Map<I, F>` can be generalized to `Map<I, F: ?Sized>`,
which allows for example the type `Map<I, FnMut(Foo) -> Bar>` as an
iterator.

Generalize `filter, filter_map, flat_map, inspect, map, skip_while, take_while`
like this.

A struct can only have one unsizeable field, so we have to pick either
unsizing the iterator or closure parameter for all of these, but it
seems right to pick the closure parameter. The whole struct itself can
already coerce to the `Iterator` type.

Fixes #38133

Extra Remarks

1. My first idea that specialization was required for `Map::fold` here was
   mistaken (and trying that finds a type inference bug). Instead the remaining
   blemish is that we have to use `&mut self.f` in `Map::fold`. The compiler
   doesn't understand that `Self: Sized` implies `F: Sized` there.
2. I don't have a particular motivation goal with this change, just was curious
   about this and it is technically correct.