### PR TITLE
Hint correct extern constant syntax

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -6007,7 +6007,9 @@ impl<'a> Parser<'a> {
         }
 
         if self.check_keyword(keywords::Const) {
-            return Err(self.span_fatal(self.span, "extern items cannot be `const`"));
+            let mut err = self.span_fatal(self.span, "extern items cannot be `const`");
+            err.help("use `static` instead");
+            return Err(err);
         }
 
         // FIXME #5668: this will occur for a macro invocation:

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -6002,7 +6002,8 @@ impl<'a> Parser<'a> {
             if self.token.is_keyword(keywords::Const) {
                 self.diagnostic()
                     .struct_span_err(self.span, "extern items cannot be `const`")
-                    .span_label(self.span, "use `static` instead").emit();
+                    .span_suggestion(self.span, "instead try using", "static".to_owned())
+                    .emit();
             }
             self.bump(); // `static` or `const`
             return Ok(Some(self.parse_item_foreign_static(visibility, lo, attrs)?));

--- a/src/test/ui/extern-const.rs
+++ b/src/test/ui/extern-const.rs
@@ -1,0 +1,19 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z continue-parse-after-error
+
+extern "C" {
+    const C: u8; //~ ERROR extern items cannot be `const`
+}
+
+fn main() {
+    let x = C;
+}

--- a/src/test/ui/extern-const.stderr
+++ b/src/test/ui/extern-const.stderr
@@ -1,0 +1,8 @@
+error: extern items cannot be `const`
+  --> $DIR/extern-const.rs:14:5
+   |
+14 |     const C: u8; //~ ERROR extern items cannot be `const`
+   |     ^^^^^ use `static` instead
+
+error: aborting due to previous error
+

--- a/src/test/ui/extern-const.stderr
+++ b/src/test/ui/extern-const.stderr
@@ -2,7 +2,7 @@ error: extern items cannot be `const`
   --> $DIR/extern-const.rs:14:5
    |
 14 |     const C: u8; //~ ERROR extern items cannot be `const`
-   |     ^^^^^ use `static` instead
+   |     ^^^^^ help: instead try using: `static`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Error message for `extern "C" { const …}` is terse, and the right syntax is hard to guess given unfortunate difference between meaning of `static` in C and Rust. 

I've added a hint for the right syntax.