### PR TITLE
Avoid calling the column!() macro in panic

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -8,6 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[macro_export]
+// This stability attribute is totally useless.
+#[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(stage0)]
+macro_rules! __rust_unstable_column {
+    () => {
+        column!()
+    }
+}
+
 /// Entry point of thread panic, for details, see std::macros
 #[macro_export]
 #[allow_internal_unstable]
@@ -18,7 +28,7 @@ macro_rules! panic {
     );
     ($msg:expr) => ({
         static _MSG_FILE_LINE_COL: (&'static str, &'static str, u32, u32) =
-            ($msg, file!(), line!(), column!());
+            ($msg, file!(), line!(), __rust_unstable_column!());
         $crate::panicking::panic(&_MSG_FILE_LINE_COL)
     });
     ($fmt:expr, $($arg:tt)*) => ({
@@ -27,7 +37,7 @@ macro_rules! panic {
         // insufficient, since the user may have
         // `#[forbid(dead_code)]` and which cannot be overridden.
         static _MSG_FILE_LINE_COL: (&'static str, u32, u32) =
-            (file!(), line!(), column!());
+            (file!(), line!(), __rust_unstable_column!());
         $crate::panicking::panic_fmt(format_args!($fmt, $($arg)*), &_MSG_FILE_LINE_COL)
     });
 }

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -14,6 +14,16 @@
 //! library. Each macro is available for use when linking against the standard
 //! library.
 
+#[macro_export]
+// This stability attribute is totally useless.
+#[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(stage0)]
+macro_rules! __rust_unstable_column {
+    () => {
+        column!()
+    }
+}
+
 /// The entry point for panic of Rust threads.
 ///
 /// This macro is used to inject panic into a Rust thread, causing the thread to
@@ -48,7 +58,8 @@ macro_rules! panic {
     ($msg:expr) => ({
         $crate::rt::begin_panic($msg, {
             // static requires less code at runtime, more constant data
-            static _FILE_LINE_COL: (&'static str, u32, u32) = (file!(), line!(), column!());
+            static _FILE_LINE_COL: (&'static str, u32, u32) = (file!(), line!(),
+                __rust_unstable_column!());
             &_FILE_LINE_COL
         })
     });
@@ -58,7 +69,8 @@ macro_rules! panic {
             // used inside a dead function. Just `#[allow(dead_code)]` is
             // insufficient, since the user may have
             // `#[forbid(dead_code)]` and which cannot be overridden.
-            static _FILE_LINE_COL: (&'static str, u32, u32) = (file!(), line!(), column!());
+            static _FILE_LINE_COL: (&'static str, u32, u32) = (file!(), line!(),
+                __rust_unstable_column!());
             &_FILE_LINE_COL
         })
     });

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -52,6 +52,16 @@ pub fn expand_column(cx: &mut ExtCtxt, sp: Span, tts: &[tokenstream::TokenTree])
     base::MacEager::expr(cx.expr_u32(topmost, loc.col.to_usize() as u32))
 }
 
+/* __rust_unstable_column!(): expands to the current column number */
+pub fn expand_column_gated(cx: &mut ExtCtxt, sp: Span, tts: &[tokenstream::TokenTree])
+                  -> Box<base::MacResult+'static> {
+    if sp.allows_unstable() {
+        expand_column(cx, sp, tts)
+    } else {
+        cx.span_fatal(sp, "the __rust_unstable_column macro is unstable");
+    }
+}
+
 /// file!(): expands to the current filename */
 /// The filemap (`loc.file`) contains a bunch more information we could spit
 /// out if we wanted.

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -89,7 +89,7 @@ pub fn register_builtins(resolver: &mut syntax::ext::base::Resolver,
     use syntax::ext::source_util::*;
     register! {
         line: expand_line,
-        __rust_unstable_column: expand_column,
+        __rust_unstable_column: expand_column_gated,
         column: expand_column,
         file: expand_file,
         stringify: expand_stringify,

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -89,6 +89,7 @@ pub fn register_builtins(resolver: &mut syntax::ext::base::Resolver,
     use syntax::ext::source_util::*;
     register! {
         line: expand_line,
+        __rust_unstable_column: expand_column,
         column: expand_column,
         file: expand_file,
         stringify: expand_stringify,

--- a/src/test/compile-fail/rust-unstable-column-gated.rs
+++ b/src/test/compile-fail/rust-unstable-column-gated.rs
@@ -1,0 +1,14 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    println!("{}", __rust_unstable_column!());
+    //~^ERROR the __rust_unstable_column macro is unstable
+}

--- a/src/test/run-pass/issue-43057.rs
+++ b/src/test/run-pass/issue-43057.rs
@@ -1,0 +1,23 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(unused)]
+
+macro_rules! column {
+    ($i:ident) => {
+        $i
+    };
+}
+
+fn foo() -> ! {
+    panic!();
+}
+
+fn main() {}


### PR DESCRIPTION
Closes #43057

This "fix" adds a new macro called `__rust_unstable_column` and to use it instead of the `column` macro inside panic. The new macro can be shadowed as well as `column` can, but its very likely that there is no code that does this in practice.

There is no real way to make "unstable" macros that are usable by stable macros, so we do the next best thing and prefix the macro with `__rust_unstable` to make sure people recognize it is unstable.

r? @alexcrichton 