### PR TITLE
Use hir::ItemLocalId as keys in TypeckTables.

### DIFF
--- a/src/librustc/hir/def_id.rs
+++ b/src/librustc/hir/def_id.rs
@@ -201,4 +201,11 @@ impl DefId {
     pub fn is_local(&self) -> bool {
         self.krate == LOCAL_CRATE
     }
+
+    pub fn invalid() -> DefId {
+        DefId {
+            krate: INVALID_CRATE,
+            index: CRATE_DEF_INDEX,
+        }
+    }
 }

--- a/src/librustc/hir/def_id.rs
+++ b/src/librustc/hir/def_id.rs
@@ -201,11 +201,4 @@ impl DefId {
     pub fn is_local(&self) -> bool {
         self.krate == LOCAL_CRATE
     }
-
-    pub fn invalid() -> DefId {
-        DefId {
-            krate: INVALID_CRATE,
-            index: CRATE_DEF_INDEX,
-        }
-    }
 }

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -155,6 +155,11 @@ enum ParamMode {
     Optional
 }
 
+struct LoweredNodeId {
+    node_id: NodeId,
+    hir_id: hir::HirId,
+}
+
 impl<'a> LoweringContext<'a> {
     fn lower_crate(mut self, c: &Crate) -> hir::Crate {
         /// Full-crate AST visitor that inserts into a fresh
@@ -278,11 +283,14 @@ impl<'a> LoweringContext<'a> {
     fn lower_node_id_generic<F>(&mut self,
                                 ast_node_id: NodeId,
                                 alloc_hir_id: F)
-                                -> NodeId
+                                -> LoweredNodeId
         where F: FnOnce(&mut Self) -> hir::HirId
     {
         if ast_node_id == DUMMY_NODE_ID {
-            return ast_node_id;
+            return LoweredNodeId {
+                node_id: DUMMY_NODE_ID,
+                hir_id: hir::DUMMY_HIR_ID,
+            }
         }
 
         let min_size = ast_node_id.as_usize() + 1;
@@ -291,12 +299,22 @@ impl<'a> LoweringContext<'a> {
             self.node_id_to_hir_id.resize(min_size, hir::DUMMY_HIR_ID);
         }
 
-        if self.node_id_to_hir_id[ast_node_id] == hir::DUMMY_HIR_ID {
-            // Generate a new HirId
-            self.node_id_to_hir_id[ast_node_id] = alloc_hir_id(self);
-        }
+        let existing_hir_id = self.node_id_to_hir_id[ast_node_id];
 
-        ast_node_id
+        if existing_hir_id == hir::DUMMY_HIR_ID {
+            // Generate a new HirId
+            let hir_id = alloc_hir_id(self);
+            self.node_id_to_hir_id[ast_node_id] = hir_id;
+            LoweredNodeId {
+                node_id: ast_node_id,
+                hir_id,
+            }
+        } else {
+            LoweredNodeId {
+                node_id: ast_node_id,
+                hir_id: existing_hir_id,
+            }
+        }
     }
 
     fn with_hir_id_owner<F>(&mut self, owner: NodeId, f: F)
@@ -323,7 +341,7 @@ impl<'a> LoweringContext<'a> {
     /// actually used in the HIR, as that would trigger an assertion in the
     /// HirIdValidator later on, which makes sure that all NodeIds got mapped
     /// properly. Calling the method twice with the same NodeId is fine though.
-    fn lower_node_id(&mut self, ast_node_id: NodeId) -> NodeId {
+    fn lower_node_id(&mut self, ast_node_id: NodeId) -> LoweredNodeId {
         self.lower_node_id_generic(ast_node_id, |this| {
             let &mut (def_index, ref mut local_id_counter) = this.current_hir_id_owner
                                                                  .last_mut()
@@ -340,7 +358,7 @@ impl<'a> LoweringContext<'a> {
     fn lower_node_id_with_owner(&mut self,
                                 ast_node_id: NodeId,
                                 owner: NodeId)
-                                -> NodeId {
+                                -> LoweredNodeId {
         self.lower_node_id_generic(ast_node_id, |this| {
             let local_id_counter = this.item_local_id_counters
                                        .get_mut(&owner)
@@ -375,7 +393,7 @@ impl<'a> LoweringContext<'a> {
         id
     }
 
-    fn next_id(&mut self) -> NodeId {
+    fn next_id(&mut self) -> LoweredNodeId {
         self.lower_node_id(self.sess.next_node_id())
     }
 
@@ -517,7 +535,7 @@ impl<'a> LoweringContext<'a> {
         match destination {
             Some((id, label_ident)) => {
                 let target = if let Def::Label(loop_id) = self.expect_full_def(id) {
-                    hir::LoopIdResult::Ok(self.lower_node_id(loop_id))
+                    hir::LoopIdResult::Ok(self.lower_node_id(loop_id).node_id)
                 } else {
                     hir::LoopIdResult::Err(hir::LoopIdError::UnresolvedLabel)
                 };
@@ -534,7 +552,7 @@ impl<'a> LoweringContext<'a> {
                 hir::Destination {
                     ident: None,
                     target_id: hir::ScopeTarget::Loop(
-                        loop_id.map(|id| Ok(self.lower_node_id(id)))
+                        loop_id.map(|id| Ok(self.lower_node_id(id).node_id))
                                .unwrap_or(Err(hir::LoopIdError::OutsideLoopScope))
                                .into())
                 }
@@ -557,7 +575,7 @@ impl<'a> LoweringContext<'a> {
 
     fn lower_ty_binding(&mut self, b: &TypeBinding) -> hir::TypeBinding {
         hir::TypeBinding {
-            id: self.lower_node_id(b.id),
+            id: self.lower_node_id(b.id).node_id,
             name: self.lower_ident(b.ident),
             ty: self.lower_ty(&b.ty),
             span: b.span,
@@ -594,7 +612,7 @@ impl<'a> LoweringContext<'a> {
                 return self.lower_ty(ty);
             }
             TyKind::Path(ref qself, ref path) => {
-                let id = self.lower_node_id(t.id);
+                let id = self.lower_node_id(t.id).node_id;
                 let qpath = self.lower_qpath(t.id, qself, path, ParamMode::Explicit);
                 return self.ty_path(id, t.span, qpath);
             }
@@ -645,7 +663,7 @@ impl<'a> LoweringContext<'a> {
         };
 
         P(hir::Ty {
-            id: self.lower_node_id(t.id),
+            id: self.lower_node_id(t.id).node_id,
             node: kind,
             span: t.span,
         })
@@ -758,7 +776,7 @@ impl<'a> LoweringContext<'a> {
             // Otherwise, the base path is an implicit `Self` type path,
             // e.g. `Vec` in `Vec::new` or `<I as Iterator>::Item` in
             // `<I as Iterator>::Item::default`.
-            let new_id = self.next_id();
+            let new_id = self.next_id().node_id;
             self.ty_path(new_id, p.span, hir::QPath::Resolved(qself, path))
         };
 
@@ -782,7 +800,7 @@ impl<'a> LoweringContext<'a> {
             }
 
             // Wrap the associated extension in another type node.
-            let new_id = self.next_id();
+            let new_id = self.next_id().node_id;
             ty = self.ty_path(new_id, p.span, qpath);
         }
 
@@ -887,7 +905,7 @@ impl<'a> LoweringContext<'a> {
 
     fn lower_local(&mut self, l: &Local) -> P<hir::Local> {
         P(hir::Local {
-            id: self.lower_node_id(l.id),
+            id: self.lower_node_id(l.id).node_id,
             ty: l.ty.as_ref().map(|t| self.lower_ty(t)),
             pat: self.lower_pat(&l.pat),
             init: l.init.as_ref().map(|e| P(self.lower_expr(e))),
@@ -905,8 +923,10 @@ impl<'a> LoweringContext<'a> {
     }
 
     fn lower_arg(&mut self, arg: &Arg) -> hir::Arg {
+        let LoweredNodeId { node_id, hir_id } = self.lower_node_id(arg.id);
         hir::Arg {
-            id: self.lower_node_id(arg.id),
+            id: node_id,
+            hir_id,
             pat: self.lower_pat(&arg.pat),
         }
     }
@@ -969,7 +989,7 @@ impl<'a> LoweringContext<'a> {
         }
 
         hir::TyParam {
-            id: self.lower_node_id(tp.id),
+            id: self.lower_node_id(tp.id).node_id,
             name,
             bounds,
             default: tp.default.as_ref().map(|x| self.lower_ty(x)),
@@ -987,7 +1007,7 @@ impl<'a> LoweringContext<'a> {
 
     fn lower_lifetime(&mut self, l: &Lifetime) -> hir::Lifetime {
         hir::Lifetime {
-            id: self.lower_node_id(l.id),
+            id: self.lower_node_id(l.id).node_id,
             name: self.lower_ident(l.ident),
             span: l.span,
         }
@@ -1059,7 +1079,7 @@ impl<'a> LoweringContext<'a> {
 
     fn lower_where_clause(&mut self, wc: &WhereClause) -> hir::WhereClause {
         hir::WhereClause {
-            id: self.lower_node_id(wc.id),
+            id: self.lower_node_id(wc.id).node_id,
             predicates: wc.predicates
                           .iter()
                           .map(|predicate| self.lower_where_predicate(predicate))
@@ -1098,7 +1118,7 @@ impl<'a> LoweringContext<'a> {
                                                           ref rhs_ty,
                                                           span}) => {
                 hir::WherePredicate::EqPredicate(hir::WhereEqPredicate {
-                    id: self.lower_node_id(id),
+                    id: self.lower_node_id(id).node_id,
                     lhs_ty: self.lower_ty(lhs_ty),
                     rhs_ty: self.lower_ty(rhs_ty),
                     span,
@@ -1114,16 +1134,16 @@ impl<'a> LoweringContext<'a> {
                                                .enumerate()
                                                .map(|f| self.lower_struct_field(f))
                                                .collect(),
-                                         self.lower_node_id(id))
+                                         self.lower_node_id(id).node_id)
             }
             VariantData::Tuple(ref fields, id) => {
                 hir::VariantData::Tuple(fields.iter()
                                               .enumerate()
                                               .map(|f| self.lower_struct_field(f))
                                               .collect(),
-                                        self.lower_node_id(id))
+                                        self.lower_node_id(id).node_id)
             }
-            VariantData::Unit(id) => hir::VariantData::Unit(self.lower_node_id(id)),
+            VariantData::Unit(id) => hir::VariantData::Unit(self.lower_node_id(id).node_id),
         }
     }
 
@@ -1134,7 +1154,7 @@ impl<'a> LoweringContext<'a> {
         };
         hir::TraitRef {
             path,
-            ref_id: self.lower_node_id(p.ref_id),
+            ref_id: self.lower_node_id(p.ref_id).node_id,
         }
     }
 
@@ -1149,7 +1169,7 @@ impl<'a> LoweringContext<'a> {
     fn lower_struct_field(&mut self, (index, f): (usize, &StructField)) -> hir::StructField {
         hir::StructField {
             span: f.span,
-            id: self.lower_node_id(f.id),
+            id: self.lower_node_id(f.id).node_id,
             name: self.lower_ident(match f.ident {
                 Some(ident) => ident,
                 // FIXME(jseyfried) positional field hygiene
@@ -1198,8 +1218,11 @@ impl<'a> LoweringContext<'a> {
             }
         }
 
+        let LoweredNodeId { node_id, hir_id } = self.lower_node_id(b.id);
+
         P(hir::Block {
-            id: self.lower_node_id(b.id),
+            id: node_id,
+            hir_id,
             stmts: stmts.into(),
             expr,
             rules: self.lower_block_check_mode(&b.rules),
@@ -1249,7 +1272,7 @@ impl<'a> LoweringContext<'a> {
                                         hir::Visibility::Restricted {
                                             path: path.clone(),
                                             // We are allocating a new NodeId here
-                                            id: this.next_id(),
+                                            id: this.next_id().node_id,
                                         }
                                     }
                                 };
@@ -1387,7 +1410,7 @@ impl<'a> LoweringContext<'a> {
     fn lower_trait_item(&mut self, i: &TraitItem) -> hir::TraitItem {
         self.with_parent_def(i.id, |this| {
             hir::TraitItem {
-                id: this.lower_node_id(i.id),
+                id: this.lower_node_id(i.id).node_id,
                 name: this.lower_ident(i.ident),
                 attrs: this.lower_attrs(&i.attrs),
                 node: match i.node {
@@ -1448,7 +1471,7 @@ impl<'a> LoweringContext<'a> {
     fn lower_impl_item(&mut self, i: &ImplItem) -> hir::ImplItem {
         self.with_parent_def(i.id, |this| {
             hir::ImplItem {
-                id: this.lower_node_id(i.id),
+                id: this.lower_node_id(i.id).node_id,
                 name: this.lower_ident(i.ident),
                 attrs: this.lower_attrs(&i.attrs),
                 vis: this.lower_visibility(&i.vis, None),
@@ -1540,7 +1563,7 @@ impl<'a> LoweringContext<'a> {
         });
 
         Some(hir::Item {
-            id: self.lower_node_id(i.id),
+            id: self.lower_node_id(i.id).node_id,
             name,
             attrs,
             node,
@@ -1552,7 +1575,7 @@ impl<'a> LoweringContext<'a> {
     fn lower_foreign_item(&mut self, i: &ForeignItem) -> hir::ForeignItem {
         self.with_parent_def(i.id, |this| {
             hir::ForeignItem {
-                id: this.lower_node_id(i.id),
+                id: this.lower_node_id(i.id).node_id,
                 name: i.ident.name,
                 attrs: this.lower_attrs(&i.attrs),
                 node: match i.node {
@@ -1630,8 +1653,11 @@ impl<'a> LoweringContext<'a> {
     }
 
     fn lower_pat(&mut self, p: &Pat) -> P<hir::Pat> {
+        let LoweredNodeId { node_id, hir_id } = self.lower_node_id(p.id);
+
         P(hir::Pat {
-            id: self.lower_node_id(p.id),
+            id: node_id,
+            hir_id,
             node: match p.node {
                 PatKind::Wild => hir::PatKind::Wild,
                 PatKind::Ident(ref binding_mode, pth1, ref sub) => {
@@ -1813,7 +1839,7 @@ impl<'a> LoweringContext<'a> {
                     let call_move_val_init =
                         hir::StmtSemi(
                             make_call(self, &move_val_init, hir_vec![ptr, pop_unsafe_expr]),
-                            self.next_id());
+                            self.next_id().node_id);
                     let call_move_val_init = respan(e.span, call_move_val_init);
 
                     let place = self.expr_ident(e.span, place_ident, place_binding);
@@ -1883,11 +1909,15 @@ impl<'a> LoweringContext<'a> {
                             // wrap the if-let expr in a block
                             let span = els.span;
                             let els = P(self.lower_expr(els));
-                            let id = self.next_id();
+                            let LoweredNodeId {
+                                node_id,
+                                hir_id,
+                            } = self.next_id();
                             let blk = P(hir::Block {
                                 stmts: hir_vec![],
                                 expr: Some(els),
-                                id,
+                                id: node_id,
+                                hir_id,
                                 rules: hir::DefaultBlock,
                                 span,
                                 targeted_by_break: false,
@@ -1986,8 +2016,11 @@ impl<'a> LoweringContext<'a> {
                 let struct_path = self.std_path(unstable_span, &struct_path, is_unit);
                 let struct_path = hir::QPath::Resolved(None, P(struct_path));
 
+                let LoweredNodeId { node_id, hir_id } = self.lower_node_id(e.id);
+
                 return hir::Expr {
-                    id: self.lower_node_id(e.id),
+                    id: node_id,
+                    hir_id,
                     node: if is_unit {
                         hir::ExprPath(struct_path)
                     } else {
@@ -2234,7 +2267,7 @@ impl<'a> LoweringContext<'a> {
                                                hir::MatchSource::ForLoopDesugar),
                                 ThinVec::new()))
                 };
-                let match_stmt = respan(e.span, hir::StmtExpr(match_expr, self.next_id()));
+                let match_stmt = respan(e.span, hir::StmtExpr(match_expr, self.next_id().node_id));
 
                 let next_expr = P(self.expr_ident(e.span, next_ident, next_pat.id));
 
@@ -2254,7 +2287,7 @@ impl<'a> LoweringContext<'a> {
                 let body_block = self.with_loop_scope(e.id,
                                                         |this| this.lower_block(body, false));
                 let body_expr = P(self.expr_block(body_block, ThinVec::new()));
-                let body_stmt = respan(e.span, hir::StmtExpr(body_expr, self.next_id()));
+                let body_stmt = respan(e.span, hir::StmtExpr(body_expr, self.next_id().node_id));
 
                 let loop_block = P(self.block_all(e.span,
                                                   hir_vec![next_let,
@@ -2266,8 +2299,10 @@ impl<'a> LoweringContext<'a> {
                 // `[opt_ident]: loop { ... }`
                 let loop_expr = hir::ExprLoop(loop_block, self.lower_opt_sp_ident(opt_ident),
                                               hir::LoopSource::ForLoop);
+                let LoweredNodeId { node_id, hir_id } = self.lower_node_id(e.id);
                 let loop_expr = P(hir::Expr {
-                    id: self.lower_node_id(e.id),
+                    id: node_id,
+                    hir_id,
                     node: loop_expr,
                     span: e.span,
                     attrs: ThinVec::new(),
@@ -2406,8 +2441,11 @@ impl<'a> LoweringContext<'a> {
             ExprKind::Mac(_) => panic!("Shouldn't exist here"),
         };
 
+        let LoweredNodeId { node_id, hir_id } = self.lower_node_id(e.id);
+
         hir::Expr {
-            id: self.lower_node_id(e.id),
+            id: node_id,
+            hir_id,
             node: kind,
             span: e.span,
             attrs: e.attrs.clone(),
@@ -2420,7 +2458,7 @@ impl<'a> LoweringContext<'a> {
                 node: hir::StmtDecl(P(Spanned {
                     node: hir::DeclLocal(self.lower_local(l)),
                     span: s.span,
-                }), self.lower_node_id(s.id)),
+                }), self.lower_node_id(s.id).node_id),
                 span: s.span,
             },
             StmtKind::Item(ref it) => {
@@ -2431,22 +2469,22 @@ impl<'a> LoweringContext<'a> {
                         node: hir::DeclItem(item_id),
                         span: s.span,
                     }), id.take()
-                          .map(|id| self.lower_node_id(id))
-                          .unwrap_or_else(|| self.next_id())),
+                          .map(|id| self.lower_node_id(id).node_id)
+                          .unwrap_or_else(|| self.next_id().node_id)),
                     span: s.span,
                 }).collect();
             }
             StmtKind::Expr(ref e) => {
                 Spanned {
                     node: hir::StmtExpr(P(self.lower_expr(e)),
-                                          self.lower_node_id(s.id)),
+                                          self.lower_node_id(s.id).node_id),
                     span: s.span,
                 }
             }
             StmtKind::Semi(ref e) => {
                 Spanned {
                     node: hir::StmtSemi(P(self.lower_expr(e)),
-                                          self.lower_node_id(s.id)),
+                                          self.lower_node_id(s.id).node_id),
                     span: s.span,
                 }
             }
@@ -2477,9 +2515,9 @@ impl<'a> LoweringContext<'a> {
                 hir::Visibility::Restricted {
                     path: P(self.lower_path(id, path, ParamMode::Explicit, true)),
                     id: if let Some(owner) = explicit_owner {
-                        self.lower_node_id_with_owner(id, owner)
+                        self.lower_node_id_with_owner(id, owner).node_id
                     } else {
-                        self.lower_node_id(id)
+                        self.lower_node_id(id).node_id
                     }
                 }
             }
@@ -2621,8 +2659,10 @@ impl<'a> LoweringContext<'a> {
     }
 
     fn expr(&mut self, span: Span, node: hir::Expr_, attrs: ThinVec<Attribute>) -> hir::Expr {
+        let LoweredNodeId { node_id, hir_id } = self.next_id();
         hir::Expr {
-            id: self.next_id(),
+            id: node_id,
+            hir_id,
             node,
             span,
             attrs,
@@ -2639,13 +2679,13 @@ impl<'a> LoweringContext<'a> {
             pat,
             ty: None,
             init: ex,
-            id: self.next_id(),
+            id: self.next_id().node_id,
             span: sp,
             attrs: ThinVec::new(),
             source,
         });
         let decl = respan(sp, hir::DeclLocal(local));
-        respan(sp, hir::StmtDecl(P(decl), self.next_id()))
+        respan(sp, hir::StmtDecl(P(decl), self.next_id().node_id))
     }
 
     fn stmt_let(&mut self, sp: Span, mutbl: bool, ident: Name, ex: P<hir::Expr>)
@@ -2665,10 +2705,13 @@ impl<'a> LoweringContext<'a> {
 
     fn block_all(&mut self, span: Span, stmts: hir::HirVec<hir::Stmt>, expr: Option<P<hir::Expr>>)
                  -> hir::Block {
+        let LoweredNodeId { node_id, hir_id } = self.next_id();
+
         hir::Block {
             stmts,
             expr,
-            id: self.next_id(),
+            id: node_id,
+            hir_id,
             rules: hir::DefaultBlock,
             span,
             targeted_by_break: false,
@@ -2712,18 +2755,22 @@ impl<'a> LoweringContext<'a> {
 
     fn pat_ident_binding_mode(&mut self, span: Span, name: Name, bm: hir::BindingAnnotation)
                               -> P<hir::Pat> {
-        let id = self.next_id();
+        let LoweredNodeId { node_id, hir_id } = self.next_id();
         let parent_def = self.parent_def.unwrap();
         let def_id = {
             let defs = self.resolver.definitions();
             let def_path_data = DefPathData::Binding(name);
-            let def_index = defs
-                .create_def_with_parent(parent_def, id, def_path_data, REGULAR_SPACE, Mark::root());
+            let def_index = defs.create_def_with_parent(parent_def,
+                                                        node_id,
+                                                        def_path_data,
+                                                        REGULAR_SPACE,
+                                                        Mark::root());
             DefId::local(def_index)
         };
 
         P(hir::Pat {
-            id,
+            id: node_id,
+            hir_id,
             node: hir::PatKind::Binding(bm,
                                         def_id,
                                         Spanned {
@@ -2740,8 +2787,10 @@ impl<'a> LoweringContext<'a> {
     }
 
     fn pat(&mut self, span: Span, pat: hir::PatKind) -> P<hir::Pat> {
+        let LoweredNodeId { node_id, hir_id } = self.next_id();
         P(hir::Pat {
-            id: self.next_id(),
+            id: node_id,
+            hir_id,
             node: pat,
             span,
         })
@@ -2770,11 +2819,13 @@ impl<'a> LoweringContext<'a> {
                          rule: hir::BlockCheckMode,
                          attrs: ThinVec<Attribute>)
                          -> hir::Expr {
-        let id = self.next_id();
+        let LoweredNodeId { node_id, hir_id } = self.next_id();
+
         let block = P(hir::Block {
             rules: rule,
             span,
-            id,
+            id: node_id,
+            hir_id,
             stmts,
             expr: Some(expr),
             targeted_by_break: false,
@@ -2799,7 +2850,7 @@ impl<'a> LoweringContext<'a> {
 
                     // The original ID is taken by the `PolyTraitRef`,
                     // so the `Ty` itself needs a different one.
-                    id = self.next_id();
+                    id = self.next_id().node_id;
 
                     hir::TyTraitObject(hir_vec![principal], self.elided_lifetime(span))
                 } else {
@@ -2813,7 +2864,7 @@ impl<'a> LoweringContext<'a> {
 
     fn elided_lifetime(&mut self, span: Span) -> hir::Lifetime {
         hir::Lifetime {
-            id: self.next_id(),
+            id: self.next_id().node_id,
             span,
             name: keywords::Invalid.name()
         }

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -904,8 +904,10 @@ impl<'a> LoweringContext<'a> {
     }
 
     fn lower_local(&mut self, l: &Local) -> P<hir::Local> {
+        let LoweredNodeId { node_id, hir_id } = self.lower_node_id(l.id);
         P(hir::Local {
-            id: self.lower_node_id(l.id).node_id,
+            id: node_id,
+            hir_id,
             ty: l.ty.as_ref().map(|t| self.lower_ty(t)),
             pat: self.lower_pat(&l.pat),
             init: l.init.as_ref().map(|e| P(self.lower_expr(e))),
@@ -2675,11 +2677,14 @@ impl<'a> LoweringContext<'a> {
                     pat: P<hir::Pat>,
                     source: hir::LocalSource)
                     -> hir::Stmt {
+        let LoweredNodeId { node_id, hir_id } = self.next_id();
+
         let local = P(hir::Local {
             pat,
             ty: None,
             init: ex,
-            id: self.next_id().node_id,
+            id: node_id,
+            hir_id,
             span: sp,
             attrs: ThinVec::new(),
             source,

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -466,7 +466,11 @@ impl Definitions {
     }
 
     pub fn find_node_for_hir_id(&self, hir_id: hir::HirId) -> ast::NodeId {
-        self.node_to_hir_id.binary_search(&hir_id).unwrap()
+        self.node_to_hir_id
+            .iter()
+            .position(|x| *x == hir_id)
+            .map(|idx| ast::NodeId::new(idx))
+            .unwrap()
     }
 
     /// Add a definition with a parent definition.

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -465,6 +465,10 @@ impl Definitions {
         self.node_to_hir_id[node_id]
     }
 
+    pub fn find_node_for_hir_id(&self, hir_id: hir::HirId) -> ast::NodeId {
+        self.node_to_hir_id.binary_search(&hir_id).unwrap()
+    }
+
     /// Add a definition with a parent definition.
     pub fn create_root_def(&mut self,
                            crate_name: &str,

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -434,18 +434,22 @@ impl Definitions {
         DefPath::make(LOCAL_CRATE, index, |p| self.def_key(p))
     }
 
+    #[inline]
     pub fn opt_def_index(&self, node: ast::NodeId) -> Option<DefIndex> {
         self.node_to_def_index.get(&node).cloned()
     }
 
+    #[inline]
     pub fn opt_local_def_id(&self, node: ast::NodeId) -> Option<DefId> {
         self.opt_def_index(node).map(DefId::local)
     }
 
+    #[inline]
     pub fn local_def_id(&self, node: ast::NodeId) -> DefId {
         self.opt_local_def_id(node).unwrap()
     }
 
+    #[inline]
     pub fn as_local_node_id(&self, def_id: DefId) -> Option<ast::NodeId> {
         if def_id.krate == LOCAL_CRATE {
             let space_index = def_id.index.address_space().index();
@@ -461,6 +465,7 @@ impl Definitions {
         }
     }
 
+    #[inline]
     pub fn node_to_hir_id(&self, node_id: ast::NodeId) -> hir::HirId {
         self.node_to_hir_id[node_id]
     }
@@ -471,6 +476,14 @@ impl Definitions {
             .position(|x| *x == hir_id)
             .map(|idx| ast::NodeId::new(idx))
             .unwrap()
+    }
+
+    #[inline]
+    pub fn def_index_to_hir_id(&self, def_index: DefIndex) -> hir::HirId {
+        let space_index = def_index.address_space().index();
+        let array_index = def_index.as_array_index();
+        let node_id = self.def_index_to_node[space_index][array_index];
+        self.node_to_hir_id[node_id]
     }
 
     /// Add a definition with a parent definition.

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -401,6 +401,16 @@ impl<'hir> Map<'hir> {
         self.definitions.node_to_hir_id(node_id)
     }
 
+    #[inline]
+    pub fn def_index_to_hir_id(&self, def_index: DefIndex) -> HirId {
+        self.definitions.def_index_to_hir_id(def_index)
+    }
+
+    #[inline]
+    pub fn def_index_to_node_id(&self, def_index: DefIndex) -> NodeId {
+        self.definitions.as_local_node_id(DefId::local(def_index)).unwrap()
+    }
+
     fn entry_count(&self) -> usize {
         self.map.len()
     }

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -357,6 +357,7 @@ impl<'hir> Map<'hir> {
         }
     }
 
+    #[inline]
     pub fn definitions(&self) -> &Definitions {
         &self.definitions
     }
@@ -377,6 +378,7 @@ impl<'hir> Map<'hir> {
         self.definitions.def_path(def_id.index)
     }
 
+    #[inline]
     pub fn local_def_id(&self, node: NodeId) -> DefId {
         self.opt_local_def_id(node).unwrap_or_else(|| {
             bug!("local_def_id: no entry for `{}`, which has a map of `{:?}`",
@@ -384,12 +386,19 @@ impl<'hir> Map<'hir> {
         })
     }
 
+    #[inline]
     pub fn opt_local_def_id(&self, node: NodeId) -> Option<DefId> {
         self.definitions.opt_local_def_id(node)
     }
 
+    #[inline]
     pub fn as_local_node_id(&self, def_id: DefId) -> Option<NodeId> {
         self.definitions.as_local_node_id(def_id)
+    }
+
+    #[inline]
+    pub fn node_to_hir_id(&self, node_id: NodeId) -> HirId {
+        self.definitions.node_to_hir_id(node_id)
     }
 
     fn entry_count(&self) -> usize {

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -901,6 +901,7 @@ pub struct Local {
     /// Initializer expression to set the value, if any
     pub init: Option<P<Expr>>,
     pub id: NodeId,
+    pub hir_id: HirId,
     pub span: Span,
     pub attrs: ThinVec<Attribute>,
     pub source: LocalSource,

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -129,8 +129,10 @@ pub const CRATE_HIR_ID: HirId = HirId {
 
 pub const DUMMY_HIR_ID: HirId = HirId {
     owner: CRATE_DEF_INDEX,
-    local_id: ItemLocalId(!0)
+    local_id: DUMMY_ITEM_LOCAL_ID,
 };
+
+pub const DUMMY_ITEM_LOCAL_ID: ItemLocalId = ItemLocalId(!0);
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Copy)]
 pub struct Lifetime {
@@ -547,6 +549,7 @@ pub struct Block {
     /// without a semicolon, if any
     pub expr: Option<P<Expr>>,
     pub id: NodeId,
+    pub hir_id: HirId,
     /// Distinguishes between `unsafe { ... }` and `{ ... }`
     pub rules: BlockCheckMode,
     pub span: Span,
@@ -560,6 +563,7 @@ pub struct Block {
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash)]
 pub struct Pat {
     pub id: NodeId,
+    pub hir_id: HirId,
     pub node: PatKind,
     pub span: Span,
 }
@@ -986,6 +990,7 @@ pub struct Expr {
     pub span: Span,
     pub node: Expr_,
     pub attrs: ThinVec<Attribute>,
+    pub hir_id: HirId,
 }
 
 impl fmt::Debug for Expr {
@@ -1423,6 +1428,7 @@ pub struct InlineAsm {
 pub struct Arg {
     pub pat: P<Pat>,
     pub id: NodeId,
+    pub hir_id: HirId,
 }
 
 /// Represents the header (not the body) of a function declaration

--- a/src/librustc/ich/hcx.rs
+++ b/src/librustc/ich/hcx.rs
@@ -14,7 +14,7 @@ use hir::map::DefPathHash;
 use ich::{self, CachingCodemapView};
 use session::config::DebugInfoLevel::NoDebugInfo;
 use ty;
-use util::nodemap::NodeMap;
+use util::nodemap::{NodeMap, ItemLocalMap};
 
 use std::hash as std_hash;
 use std::collections::{HashMap, HashSet, BTreeMap};
@@ -355,6 +355,18 @@ pub fn hash_stable_nodemap<'a, 'tcx, 'gcx, V, W>(
 {
     hash_stable_hashmap(hcx, hasher, map, |hcx, node_id| {
         hcx.tcx.hir.definitions().node_to_hir_id(*node_id).local_id
+    });
+}
+
+pub fn hash_stable_itemlocalmap<'a, 'tcx, 'gcx, V, W>(
+    hcx: &mut StableHashingContext<'a, 'gcx, 'tcx>,
+    hasher: &mut StableHasher<W>,
+    map: &ItemLocalMap<V>)
+    where V: HashStable<StableHashingContext<'a, 'gcx, 'tcx>>,
+          W: StableHasherResult,
+{
+    hash_stable_hashmap(hcx, hasher, map, |_, local_id| {
+        *local_id
     });
 }
 

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -359,6 +359,7 @@ impl<'a, 'gcx, 'tcx> HashStable<StableHashingContext<'a, 'gcx, 'tcx>> for hir::B
             ref stmts,
             ref expr,
             id,
+            hir_id: _,
             rules,
             span,
             targeted_by_break,
@@ -423,6 +424,7 @@ impl<'a, 'gcx, 'tcx> HashStable<StableHashingContext<'a, 'gcx, 'tcx>> for hir::P
 
         let hir::Pat {
             id,
+            hir_id: _,
             ref node,
             ref span
         } = *self;
@@ -551,6 +553,7 @@ impl<'a, 'gcx, 'tcx> HashStable<StableHashingContext<'a, 'gcx, 'tcx>> for hir::E
         hcx.while_hashing_hir_bodies(true, |hcx| {
             let hir::Expr {
                 id,
+                hir_id: _,
                 ref span,
                 ref node,
                 ref attrs
@@ -1021,7 +1024,8 @@ impl_stable_hash_for!(enum hir::Stmt_ {
 
 impl_stable_hash_for!(struct hir::Arg {
     pat,
-    id
+    id,
+    hir_id
 });
 
 impl_stable_hash_for!(struct hir::Body {

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -506,6 +506,7 @@ impl_stable_hash_for!(struct hir::Local {
     ty,
     init,
     id,
+    hir_id,
     span,
     attrs,
     source

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -11,6 +11,7 @@
 //! This module contains `HashStable` implementations for various data types
 //! from rustc::ty in no particular order.
 
+use hir::def_id::DefId;
 use ich::{self, StableHashingContext, NodeIdHashingMode};
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher,
                                            StableHasherResult};
@@ -618,7 +619,7 @@ for ty::TypeckTables<'gcx> {
                                           hcx: &mut StableHashingContext<'a, 'gcx, 'tcx>,
                                           hasher: &mut StableHasher<W>) {
         let ty::TypeckTables {
-            local_id_root: _,
+            local_id_root,
             ref type_dependent_defs,
             ref node_types,
             ref node_substs,
@@ -649,8 +650,14 @@ for ty::TypeckTables<'gcx> {
                     closure_expr_id
                 } = *up_var_id;
 
-                let var_def_id = hcx.tcx().hir.local_def_id(var_id);
-                let closure_def_id = hcx.tcx().hir.local_def_id(closure_expr_id);
+                let var_def_id = DefId {
+                    krate: local_id_root.krate,
+                    index: var_id,
+                };
+                let closure_def_id = DefId {
+                    krate: local_id_root.krate,
+                    index: closure_expr_id,
+                };
                 (hcx.def_path_hash(var_def_id), hcx.def_path_hash(closure_def_id))
             });
 

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -642,7 +642,7 @@ for ty::TypeckTables<'gcx> {
             ich::hash_stable_itemlocalmap(hcx, hasher, node_types);
             ich::hash_stable_itemlocalmap(hcx, hasher, node_substs);
             ich::hash_stable_itemlocalmap(hcx, hasher, adjustments);
-            ich::hash_stable_nodemap(hcx, hasher, pat_binding_modes);
+            ich::hash_stable_itemlocalmap(hcx, hasher, pat_binding_modes);
             ich::hash_stable_hashmap(hcx, hasher, upvar_capture_map, |hcx, up_var_id| {
                 let ty::UpvarId {
                     var_id,

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -618,6 +618,7 @@ for ty::TypeckTables<'gcx> {
                                           hcx: &mut StableHashingContext<'a, 'gcx, 'tcx>,
                                           hasher: &mut StableHasher<W>) {
         let ty::TypeckTables {
+            local_id_root: _,
             ref type_dependent_defs,
             ref node_types,
             ref node_substs,
@@ -637,7 +638,9 @@ for ty::TypeckTables<'gcx> {
         } = *self;
 
         hcx.with_node_id_hashing_mode(NodeIdHashingMode::HashDefPath, |hcx| {
-            ich::hash_stable_nodemap(hcx, hasher, type_dependent_defs);
+            ich::hash_stable_hashmap(hcx, hasher, type_dependent_defs, |_, item_local_id| {
+                *item_local_id
+            });
             ich::hash_stable_nodemap(hcx, hasher, node_types);
             ich::hash_stable_nodemap(hcx, hasher, node_substs);
             ich::hash_stable_nodemap(hcx, hasher, adjustments);

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -654,8 +654,8 @@ for ty::TypeckTables<'gcx> {
                 (hcx.def_path_hash(var_def_id), hcx.def_path_hash(closure_def_id))
             });
 
-            ich::hash_stable_nodemap(hcx, hasher, closure_tys);
-            ich::hash_stable_nodemap(hcx, hasher, closure_kinds);
+            ich::hash_stable_itemlocalmap(hcx, hasher, closure_tys);
+            ich::hash_stable_itemlocalmap(hcx, hasher, closure_kinds);
             ich::hash_stable_nodemap(hcx, hasher, liberated_fn_sigs);
             ich::hash_stable_nodemap(hcx, hasher, fru_field_types);
             ich::hash_stable_nodemap(hcx, hasher, cast_kinds);

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -638,12 +638,10 @@ for ty::TypeckTables<'gcx> {
         } = *self;
 
         hcx.with_node_id_hashing_mode(NodeIdHashingMode::HashDefPath, |hcx| {
-            ich::hash_stable_hashmap(hcx, hasher, type_dependent_defs, |_, item_local_id| {
-                *item_local_id
-            });
-            ich::hash_stable_nodemap(hcx, hasher, node_types);
-            ich::hash_stable_nodemap(hcx, hasher, node_substs);
-            ich::hash_stable_nodemap(hcx, hasher, adjustments);
+            ich::hash_stable_itemlocalmap(hcx, hasher, type_dependent_defs);
+            ich::hash_stable_itemlocalmap(hcx, hasher, node_types);
+            ich::hash_stable_itemlocalmap(hcx, hasher, node_substs);
+            ich::hash_stable_itemlocalmap(hcx, hasher, adjustments);
             ich::hash_stable_nodemap(hcx, hasher, pat_binding_modes);
             ich::hash_stable_hashmap(hcx, hasher, upvar_capture_map, |hcx, up_var_id| {
                 let ty::UpvarId {

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -657,7 +657,7 @@ for ty::TypeckTables<'gcx> {
             ich::hash_stable_itemlocalmap(hcx, hasher, closure_tys);
             ich::hash_stable_itemlocalmap(hcx, hasher, closure_kinds);
             ich::hash_stable_itemlocalmap(hcx, hasher, liberated_fn_sigs);
-            ich::hash_stable_nodemap(hcx, hasher, fru_field_types);
+            ich::hash_stable_itemlocalmap(hcx, hasher, fru_field_types);
             ich::hash_stable_nodemap(hcx, hasher, cast_kinds);
 
             ich::hash_stable_hashset(hcx, hasher, used_trait_imports, |hcx, def_id| {

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -11,8 +11,7 @@
 //! This module contains `HashStable` implementations for various data types
 //! from rustc::ty in no particular order.
 
-use hir::def_id::DefId;
-use ich::{self, StableHashingContext, NodeIdHashingMode};
+use ich::StableHashingContext;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher,
                                            StableHasherResult};
 use std::hash as std_hash;
@@ -611,71 +610,6 @@ impl_stable_hash_for!(struct ty::ExistentialProjection<'tcx> {
     substs,
     ty
 });
-
-
-impl<'a, 'gcx, 'tcx> HashStable<StableHashingContext<'a, 'gcx, 'tcx>>
-for ty::TypeckTables<'gcx> {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a, 'gcx, 'tcx>,
-                                          hasher: &mut StableHasher<W>) {
-        let ty::TypeckTables {
-            local_id_root,
-            ref type_dependent_defs,
-            ref node_types,
-            ref node_substs,
-            ref adjustments,
-            ref pat_binding_modes,
-            ref upvar_capture_map,
-            ref closure_tys,
-            ref closure_kinds,
-            ref liberated_fn_sigs,
-            ref fru_field_types,
-
-            ref cast_kinds,
-
-            ref used_trait_imports,
-            tainted_by_errors,
-            ref free_region_map,
-        } = *self;
-
-        hcx.with_node_id_hashing_mode(NodeIdHashingMode::HashDefPath, |hcx| {
-            ich::hash_stable_itemlocalmap(hcx, hasher, type_dependent_defs);
-            ich::hash_stable_itemlocalmap(hcx, hasher, node_types);
-            ich::hash_stable_itemlocalmap(hcx, hasher, node_substs);
-            ich::hash_stable_itemlocalmap(hcx, hasher, adjustments);
-            ich::hash_stable_itemlocalmap(hcx, hasher, pat_binding_modes);
-            ich::hash_stable_hashmap(hcx, hasher, upvar_capture_map, |hcx, up_var_id| {
-                let ty::UpvarId {
-                    var_id,
-                    closure_expr_id
-                } = *up_var_id;
-
-                let var_def_id = DefId {
-                    krate: local_id_root.krate,
-                    index: var_id,
-                };
-                let closure_def_id = DefId {
-                    krate: local_id_root.krate,
-                    index: closure_expr_id,
-                };
-                (hcx.def_path_hash(var_def_id), hcx.def_path_hash(closure_def_id))
-            });
-
-            ich::hash_stable_itemlocalmap(hcx, hasher, closure_tys);
-            ich::hash_stable_itemlocalmap(hcx, hasher, closure_kinds);
-            ich::hash_stable_itemlocalmap(hcx, hasher, liberated_fn_sigs);
-            ich::hash_stable_itemlocalmap(hcx, hasher, fru_field_types);
-            ich::hash_stable_itemlocalmap(hcx, hasher, cast_kinds);
-
-            ich::hash_stable_hashset(hcx, hasher, used_trait_imports, |hcx, def_id| {
-                hcx.def_path_hash(*def_id)
-            });
-
-            tainted_by_errors.hash_stable(hcx, hasher);
-            free_region_map.hash_stable(hcx, hasher);
-        })
-    }
-}
 
 impl_stable_hash_for!(enum ty::fast_reject::SimplifiedType {
     BoolSimplifiedType,

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -658,7 +658,7 @@ for ty::TypeckTables<'gcx> {
             ich::hash_stable_itemlocalmap(hcx, hasher, closure_kinds);
             ich::hash_stable_itemlocalmap(hcx, hasher, liberated_fn_sigs);
             ich::hash_stable_itemlocalmap(hcx, hasher, fru_field_types);
-            ich::hash_stable_nodemap(hcx, hasher, cast_kinds);
+            ich::hash_stable_itemlocalmap(hcx, hasher, cast_kinds);
 
             ich::hash_stable_hashset(hcx, hasher, used_trait_imports, |hcx, def_id| {
                 hcx.def_path_hash(*def_id)

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -656,7 +656,7 @@ for ty::TypeckTables<'gcx> {
 
             ich::hash_stable_itemlocalmap(hcx, hasher, closure_tys);
             ich::hash_stable_itemlocalmap(hcx, hasher, closure_kinds);
-            ich::hash_stable_nodemap(hcx, hasher, liberated_fn_sigs);
+            ich::hash_stable_itemlocalmap(hcx, hasher, liberated_fn_sigs);
             ich::hash_stable_nodemap(hcx, hasher, fru_field_types);
             ich::hash_stable_nodemap(hcx, hasher, cast_kinds);
 

--- a/src/librustc/ich/mod.rs
+++ b/src/librustc/ich/mod.rs
@@ -14,7 +14,7 @@ pub use self::fingerprint::Fingerprint;
 pub use self::caching_codemap_view::CachingCodemapView;
 pub use self::hcx::{StableHashingContext, NodeIdHashingMode, hash_stable_hashmap,
                     hash_stable_hashset, hash_stable_nodemap,
-                    hash_stable_btreemap};
+                    hash_stable_btreemap, hash_stable_itemlocalmap};
 mod fingerprint;
 mod caching_codemap_view;
 mod hcx;

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -913,7 +913,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             }
             infer::UpvarRegion(ref upvar_id, _) => {
                 format!(" for capture of `{}` by closure",
-                        self.tcx.local_var_name_str(upvar_id.var_id).to_string())
+                        self.tcx.local_var_name_str_def_index(upvar_id.var_id))
             }
         };
 

--- a/src/librustc/infer/error_reporting/note.rs
+++ b/src/librustc/infer/error_reporting/note.rs
@@ -45,8 +45,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                 err.span_note(span,
                               &format!("...so that closure can access `{}`",
                                        self.tcx
-                                           .local_var_name_str(upvar_id.var_id)
-                                           .to_string()));
+                                           .local_var_name_str_def_index(upvar_id.var_id)));
             }
             infer::InfStackClosure(span) => {
                 err.span_note(span, "...so that closure does not outlive its stack frame");
@@ -176,18 +175,19 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                                                E0313,
                                                "lifetime of borrowed pointer outlives lifetime \
                                                 of captured variable `{}`...",
-                                               self.tcx.local_var_name_str(upvar_id.var_id));
+                                               self.tcx
+                                                   .local_var_name_str_def_index(upvar_id.var_id));
                 self.tcx.note_and_explain_region(&mut err,
                                                  "...the borrowed pointer is valid for ",
                                                  sub,
                                                  "...");
                 self.tcx
-                    .note_and_explain_region(&mut err,
-                                             &format!("...but `{}` is only valid for ",
-                                                      self.tcx
-                                                          .local_var_name_str(upvar_id.var_id)),
-                                             sup,
-                                             "");
+                    .note_and_explain_region(
+                      &mut err,
+                      &format!("...but `{}` is only valid for ",
+                               self.tcx.local_var_name_str_def_index(upvar_id.var_id)),
+                      sup,
+                      "");
                 err
             }
             infer::InfStackClosure(span) => {

--- a/src/librustc/infer/error_reporting/util.rs
+++ b/src/librustc/infer/error_reporting/util.rs
@@ -46,7 +46,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                             .iter()
                             .enumerate()
                             .filter_map(|(index, arg)| {
-                                let ty = tables.borrow().node_id_to_type(arg.id);
+                                let ty = tables.borrow().node_id_to_type(arg.hir_id);
                                 let mut found_anon_region = false;
                                 let new_arg_ty = self.tcx
                                     .fold_regions(&ty, &mut false, |r, _| if *r == *anon_region {

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -1331,9 +1331,11 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     {
         if let Some(tables) = self.in_progress_tables {
             if let Some(id) = self.tcx.hir.as_local_node_id(def_id) {
-                return tables.borrow()
-                             .closure_kinds
-                             .get(&id)
+                let tables = tables.borrow();
+                let hir_id = self.tcx.hir.node_to_hir_id(id);
+                tables.validate_hir_id(hir_id);
+                return tables.closure_kinds
+                             .get(&hir_id.local_id)
                              .cloned()
                              .map(|(kind, _)| kind);
             }
@@ -1353,7 +1355,10 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     pub fn fn_sig(&self, def_id: DefId) -> ty::PolyFnSig<'tcx> {
         if let Some(tables) = self.in_progress_tables {
             if let Some(id) = self.tcx.hir.as_local_node_id(def_id) {
-                if let Some(&ty) = tables.borrow().closure_tys.get(&id) {
+                let tables = tables.borrow();
+                let hir_id = self.tcx.hir.node_to_hir_id(id);
+                tables.validate_hir_id(hir_id);
+                if let Some(&ty) = tables.closure_tys.get(&hir_id.local_id) {
                     return ty;
                 }
             }

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -359,7 +359,7 @@ impl<'a, 'gcx, 'tcx> InferCtxtBuilder<'a, 'gcx, 'tcx> {
     /// Used only by `rustc_typeck` during body type-checking/inference,
     /// will initialize `in_progress_tables` with fresh `TypeckTables`.
     pub fn with_fresh_in_progress_tables(mut self, table_owner: DefId) -> Self {
-        self.fresh_tables = Some(RefCell::new(ty::TypeckTables::empty(table_owner)));
+        self.fresh_tables = Some(RefCell::new(ty::TypeckTables::empty(Some(table_owner))));
         self
     }
 

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -358,8 +358,8 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'gcx> {
 impl<'a, 'gcx, 'tcx> InferCtxtBuilder<'a, 'gcx, 'tcx> {
     /// Used only by `rustc_typeck` during body type-checking/inference,
     /// will initialize `in_progress_tables` with fresh `TypeckTables`.
-    pub fn with_fresh_in_progress_tables(mut self) -> Self {
-        self.fresh_tables = Some(RefCell::new(ty::TypeckTables::empty()));
+    pub fn with_fresh_in_progress_tables(mut self, table_owner: DefId) -> Self {
+        self.fresh_tables = Some(RefCell::new(ty::TypeckTables::empty(table_owner)));
         self
     }
 

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -1331,11 +1331,10 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     {
         if let Some(tables) = self.in_progress_tables {
             if let Some(id) = self.tcx.hir.as_local_node_id(def_id) {
-                let tables = tables.borrow();
                 let hir_id = self.tcx.hir.node_to_hir_id(id);
-                tables.validate_hir_id(hir_id);
-                return tables.closure_kinds
-                             .get(&hir_id.local_id)
+                return tables.borrow()
+                             .closure_kinds()
+                             .get(hir_id)
                              .cloned()
                              .map(|(kind, _)| kind);
             }
@@ -1355,10 +1354,8 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     pub fn fn_sig(&self, def_id: DefId) -> ty::PolyFnSig<'tcx> {
         if let Some(tables) = self.in_progress_tables {
             if let Some(id) = self.tcx.hir.as_local_node_id(def_id) {
-                let tables = tables.borrow();
                 let hir_id = self.tcx.hir.node_to_hir_id(id);
-                tables.validate_hir_id(hir_id);
-                if let Some(&ty) = tables.closure_tys.get(&hir_id.local_id) {
+                if let Some(&ty) = tables.borrow().closure_tys().get(hir_id) {
                     return ty;
                 }
             }

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -43,7 +43,7 @@ use syntax::ast;
 use syntax_pos::{MultiSpan, Span};
 use errors::DiagnosticBuilder;
 use hir;
-use hir::def_id::LOCAL_CRATE;
+use hir::def_id::{DefId, LOCAL_CRATE};
 use hir::intravisit as hir_visit;
 use syntax::visit as ast_visit;
 
@@ -986,7 +986,7 @@ pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
 
     let mut cx = LateContext {
         tcx,
-        tables: &ty::TypeckTables::empty(),
+        tables: &ty::TypeckTables::empty(DefId::invalid()),
         param_env: ty::ParamEnv::empty(Reveal::UserFacing),
         access_levels,
         lint_sess: LintSession::new(&tcx.sess.lint_store),

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -43,7 +43,7 @@ use syntax::ast;
 use syntax_pos::{MultiSpan, Span};
 use errors::DiagnosticBuilder;
 use hir;
-use hir::def_id::{DefId, LOCAL_CRATE};
+use hir::def_id::LOCAL_CRATE;
 use hir::intravisit as hir_visit;
 use syntax::visit as ast_visit;
 
@@ -986,7 +986,7 @@ pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
 
     let mut cx = LateContext {
         tcx,
-        tables: &ty::TypeckTables::empty(DefId::invalid()),
+        tables: &ty::TypeckTables::empty(None),
         param_env: ty::ParamEnv::empty(Reveal::UserFacing),
         access_levels,
         lint_sess: LintSession::new(&tcx.sess.lint_store),

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -119,8 +119,6 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
 
     fn handle_field_pattern_match(&mut self, lhs: &hir::Pat, def: Def,
                                   pats: &[codemap::Spanned<hir::FieldPat>]) {
-
-
         let variant = match self.tables.node_id_to_type(lhs.hir_id).sty {
             ty::TyAdt(adt, _) => adt.variant_of_def(def),
             _ => span_bug!(lhs.span, "non-ADT in struct pattern")

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -94,8 +94,8 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
         }
     }
 
-    fn lookup_and_handle_method(&mut self, id: hir::ItemLocalId) {
-        self.check_def_id(self.tables.type_dependent_defs[&id].def_id());
+    fn lookup_and_handle_method(&mut self, id: hir::HirId) {
+        self.check_def_id(self.tables.type_dependent_defs()[id].def_id());
     }
 
     fn handle_field_access(&mut self, lhs: &hir::Expr, name: ast::Name) {
@@ -241,7 +241,7 @@ impl<'a, 'tcx> Visitor<'tcx> for MarkSymbolVisitor<'a, 'tcx> {
                 self.handle_definition(def);
             }
             hir::ExprMethodCall(..) => {
-                self.lookup_and_handle_method(expr.hir_id.local_id);
+                self.lookup_and_handle_method(expr.hir_id);
             }
             hir::ExprField(ref lhs, ref name) => {
                 self.handle_field_access(&lhs, name.node);

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -427,7 +427,7 @@ fn find_live<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let mut symbol_visitor = MarkSymbolVisitor {
         worklist,
         tcx,
-        tables: &ty::TypeckTables::empty(DefId::invalid()),
+        tables: &ty::TypeckTables::empty(None),
         live_symbols: box FxHashSet(),
         struct_has_extern_repr: false,
         ignore_non_const_paths: false,

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -121,7 +121,7 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
                                   pats: &[codemap::Spanned<hir::FieldPat>]) {
 
 
-        let variant = match self.tables.node_id_to_type(lhs.id).sty {
+        let variant = match self.tables.node_id_to_type(lhs.hir_id).sty {
             ty::TyAdt(adt, _) => adt.variant_of_def(def),
             _ => span_bug!(lhs.span, "non-ADT in struct pattern")
         };

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -94,7 +94,7 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
         }
     }
 
-    fn lookup_and_handle_method(&mut self, id: ast::NodeId) {
+    fn lookup_and_handle_method(&mut self, id: hir::ItemLocalId) {
         self.check_def_id(self.tables.type_dependent_defs[&id].def_id());
     }
 
@@ -119,6 +119,8 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
 
     fn handle_field_pattern_match(&mut self, lhs: &hir::Pat, def: Def,
                                   pats: &[codemap::Spanned<hir::FieldPat>]) {
+
+
         let variant = match self.tables.node_id_to_type(lhs.id).sty {
             ty::TyAdt(adt, _) => adt.variant_of_def(def),
             _ => span_bug!(lhs.span, "non-ADT in struct pattern")
@@ -235,11 +237,11 @@ impl<'a, 'tcx> Visitor<'tcx> for MarkSymbolVisitor<'a, 'tcx> {
     fn visit_expr(&mut self, expr: &'tcx hir::Expr) {
         match expr.node {
             hir::ExprPath(ref qpath @ hir::QPath::TypeRelative(..)) => {
-                let def = self.tables.qpath_def(qpath, expr.id);
+                let def = self.tables.qpath_def(qpath, expr.hir_id);
                 self.handle_definition(def);
             }
             hir::ExprMethodCall(..) => {
-                self.lookup_and_handle_method(expr.id);
+                self.lookup_and_handle_method(expr.hir_id.local_id);
             }
             hir::ExprField(ref lhs, ref name) => {
                 self.handle_field_access(&lhs, name.node);
@@ -282,7 +284,7 @@ impl<'a, 'tcx> Visitor<'tcx> for MarkSymbolVisitor<'a, 'tcx> {
                 self.handle_field_pattern_match(pat, path.def, fields);
             }
             PatKind::Path(ref qpath @ hir::QPath::TypeRelative(..)) => {
-                let def = self.tables.qpath_def(qpath, pat.id);
+                let def = self.tables.qpath_def(qpath, pat.hir_id);
                 self.handle_definition(def);
             }
             _ => ()
@@ -425,7 +427,7 @@ fn find_live<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let mut symbol_visitor = MarkSymbolVisitor {
         worklist,
         tcx,
-        tables: &ty::TypeckTables::empty(),
+        tables: &ty::TypeckTables::empty(DefId::invalid()),
         live_symbols: box FxHashSet(),
         struct_has_extern_repr: false,
         ignore_non_const_paths: false,

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -166,7 +166,7 @@ impl<'a, 'tcx> Visitor<'tcx> for EffectCheckVisitor<'a, 'tcx> {
     fn visit_expr(&mut self, expr: &'tcx hir::Expr) {
         match expr.node {
             hir::ExprMethodCall(..) => {
-                let def_id = self.tables.type_dependent_defs[&expr.hir_id.local_id].def_id();
+                let def_id = self.tables.type_dependent_defs()[expr.hir_id].def_id();
                 let sig = self.tcx.fn_sig(def_id);
                 debug!("effect: method call case, signature is {:?}",
                         sig);

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -19,7 +19,6 @@ use syntax::ast;
 use syntax_pos::Span;
 use hir::{self, PatKind};
 use hir::def::Def;
-use hir::def_id::DefId;
 use hir::intravisit::{self, FnKind, Visitor, NestedVisitorMap};
 
 #[derive(Copy, Clone)]
@@ -263,7 +262,7 @@ impl<'a, 'tcx> Visitor<'tcx> for EffectCheckVisitor<'a, 'tcx> {
 pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     let mut visitor = EffectCheckVisitor {
         tcx,
-        tables: &ty::TypeckTables::empty(DefId::invalid()),
+        tables: &ty::TypeckTables::empty(None),
         body_id: hir::BodyId { node_id: ast::CRATE_NODE_ID },
         unsafe_context: UnsafeContext::new(SafeContext),
     };

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -19,6 +19,7 @@ use syntax::ast;
 use syntax_pos::Span;
 use hir::{self, PatKind};
 use hir::def::Def;
+use hir::def_id::DefId;
 use hir::intravisit::{self, FnKind, Visitor, NestedVisitorMap};
 
 #[derive(Copy, Clone)]
@@ -165,7 +166,7 @@ impl<'a, 'tcx> Visitor<'tcx> for EffectCheckVisitor<'a, 'tcx> {
     fn visit_expr(&mut self, expr: &'tcx hir::Expr) {
         match expr.node {
             hir::ExprMethodCall(..) => {
-                let def_id = self.tables.type_dependent_defs[&expr.id].def_id();
+                let def_id = self.tables.type_dependent_defs[&expr.hir_id.local_id].def_id();
                 let sig = self.tcx.fn_sig(def_id);
                 debug!("effect: method call case, signature is {:?}",
                         sig);
@@ -262,7 +263,7 @@ impl<'a, 'tcx> Visitor<'tcx> for EffectCheckVisitor<'a, 'tcx> {
 pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     let mut visitor = EffectCheckVisitor {
         tcx,
-        tables: &ty::TypeckTables::empty(),
+        tables: &ty::TypeckTables::empty(DefId::invalid()),
         body_id: hir::BodyId { node_id: ast::CRATE_NODE_ID },
         unsafe_context: UnsafeContext::new(SafeContext),
     };

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -537,7 +537,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
             }
             ty::TyError => { }
             _ => {
-                let def_id = self.mc.tables.type_dependent_defs[&call.id].def_id();
+                let def_id = self.mc.tables.type_dependent_defs[&call.hir_id.local_id].def_id();
                 match OverloadedCallType::from_method_id(self.tcx(), def_id) {
                     FnMutOverloadedCall => {
                         let call_scope_r = self.tcx().node_scope_region(call.id);
@@ -863,7 +863,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                 PatKind::Struct(ref qpath, ..) => qpath,
                 _ => return
             };
-            let def = mc.tables.qpath_def(qpath, pat.id);
+            let def = mc.tables.qpath_def(qpath, pat.hir_id);
             match def {
                 Def::Variant(variant_did) |
                 Def::VariantCtor(variant_did, ..) => {

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -537,7 +537,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
             }
             ty::TyError => { }
             _ => {
-                let def_id = self.mc.tables.type_dependent_defs[&call.hir_id.local_id].def_id();
+                let def_id = self.mc.tables.type_dependent_defs()[call.hir_id].def_id();
                 match OverloadedCallType::from_method_id(self.tcx(), def_id) {
                     FnMutOverloadedCall => {
                         let call_scope_r = self.tcx().node_scope_region(call.id);
@@ -797,8 +797,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                pat);
         return_if_err!(self.mc.cat_pattern(cmt_discr, pat, |cmt_pat, pat| {
             if let PatKind::Binding(..) = pat.node {
-                self.mc.tables.validate_hir_id(pat.hir_id);
-                let bm = *self.mc.tables.pat_binding_modes.get(&pat.hir_id.local_id)
+                let bm = *self.mc.tables.pat_binding_modes().get(pat.hir_id)
                                                           .expect("missing binding mode");
                 match bm {
                     ty::BindByReference(..) =>
@@ -824,8 +823,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
         return_if_err!(mc.cat_pattern(cmt_discr.clone(), pat, |cmt_pat, pat| {
             if let PatKind::Binding(_, def_id, ..) = pat.node {
                 debug!("binding cmt_pat={:?} pat={:?} match_mode={:?}", cmt_pat, pat, match_mode);
-                mc.tables.validate_hir_id(pat.hir_id);
-                let bm = *mc.tables.pat_binding_modes.get(&pat.hir_id.local_id)
+                let bm = *mc.tables.pat_binding_modes().get(pat.hir_id)
                                                      .expect("missing binding mode");
 
                 // pat_ty: the type of the binding being produced.

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -797,7 +797,8 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                pat);
         return_if_err!(self.mc.cat_pattern(cmt_discr, pat, |cmt_pat, pat| {
             if let PatKind::Binding(..) = pat.node {
-                let bm = *self.mc.tables.pat_binding_modes.get(&pat.id)
+                self.mc.tables.validate_hir_id(pat.hir_id);
+                let bm = *self.mc.tables.pat_binding_modes.get(&pat.hir_id.local_id)
                                                           .expect("missing binding mode");
                 match bm {
                     ty::BindByReference(..) =>
@@ -823,7 +824,9 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
         return_if_err!(mc.cat_pattern(cmt_discr.clone(), pat, |cmt_pat, pat| {
             if let PatKind::Binding(_, def_id, ..) = pat.node {
                 debug!("binding cmt_pat={:?} pat={:?} match_mode={:?}", cmt_pat, pat, match_mode);
-                let bm = *mc.tables.pat_binding_modes.get(&pat.id).expect("missing binding mode");
+                mc.tables.validate_hir_id(pat.hir_id);
+                let bm = *mc.tables.pat_binding_modes.get(&pat.hir_id.local_id)
+                                                     .expect("missing binding mode");
 
                 // pat_ty: the type of the binding being produced.
                 let pat_ty = return_if_err!(mc.node_ty(pat.hir_id));

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -296,7 +296,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
         debug!("consume_body(body={:?})", body);
 
         for arg in &body.arguments {
-            let arg_ty = return_if_err!(self.mc.node_ty(arg.pat.id));
+            let arg_ty = return_if_err!(self.mc.node_ty(arg.pat.hir_id));
 
             let fn_body_scope_r = self.tcx().node_scope_region(body.value.id);
             let arg_cmt = self.mc.cat_rvalue(
@@ -826,7 +826,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                 let bm = *mc.tables.pat_binding_modes.get(&pat.id).expect("missing binding mode");
 
                 // pat_ty: the type of the binding being produced.
-                let pat_ty = return_if_err!(mc.node_ty(pat.id));
+                let pat_ty = return_if_err!(mc.node_ty(pat.hir_id));
 
                 // Each match binding is effectively an assignment to the
                 // binding being produced.
@@ -923,8 +923,9 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                         -> mc::McResult<mc::cmt<'tcx>> {
         // Create the cmt for the variable being borrowed, from the
         // caller's perspective
-        let var_id = self.tcx().hir.as_local_node_id(upvar_def.def_id()).unwrap();
-        let var_ty = self.mc.node_ty(var_id)?;
+        let var_node_id = self.tcx().hir.as_local_node_id(upvar_def.def_id()).unwrap();
+        let var_hir_id = self.tcx().hir.node_to_hir_id(var_node_id);
+        let var_ty = self.mc.node_ty(var_hir_id)?;
         self.mc.cat_def(closure_id, closure_span, var_ty, upvar_def)
     }
 }

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -890,10 +890,13 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
 
         self.tcx().with_freevars(closure_expr.id, |freevars| {
             for freevar in freevars {
-                let def_id = freevar.def.def_id();
-                let id_var = self.tcx().hir.as_local_node_id(def_id).unwrap();
-                let upvar_id = ty::UpvarId { var_id: id_var,
-                                             closure_expr_id: closure_expr.id };
+                let var_def_id = freevar.def.def_id();
+                debug_assert!(var_def_id.is_local());
+                let closure_def_id = self.tcx().hir.local_def_id(closure_expr.id);
+                let upvar_id = ty::UpvarId {
+                    var_id: var_def_id.index,
+                    closure_expr_id: closure_def_id.index
+                };
                 let upvar_capture = self.mc.tables.upvar_capture(upvar_id);
                 let cmt_var = return_if_err!(self.cat_captured_var(closure_expr.id,
                                                                    fn_decl_span,

--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -152,7 +152,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
         };
         if let Def::Fn(did) = def {
             if self.def_id_is_transmute(did) {
-                let typ = self.tables.node_id_to_type(expr.id);
+                let typ = self.tables.node_id_to_type(expr.hir_id);
                 let sig = typ.fn_sig(self.tcx);
                 let from = sig.inputs().skip_binder()[0];
                 let to = *sig.output().skip_binder();

--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -146,7 +146,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
 
     fn visit_expr(&mut self, expr: &'tcx hir::Expr) {
         let def = if let hir::ExprPath(ref qpath) = expr.node {
-            self.tables.qpath_def(qpath, expr.id)
+            self.tables.qpath_def(qpath, expr.hir_id)
         } else {
             Def::Err
         };

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -604,7 +604,7 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
           }
 
           hir::ExprPath(ref qpath) => {
-            let def = self.tables.qpath_def(qpath, expr.id);
+            let def = self.tables.qpath_def(qpath, expr.hir_id);
             self.cat_def(expr.id, expr.span, expr_ty, def)
           }
 
@@ -1124,7 +1124,7 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
 
         match pat.node {
           PatKind::TupleStruct(ref qpath, ref subpats, ddpos) => {
-            let def = self.tables.qpath_def(qpath, pat.id);
+            let def = self.tables.qpath_def(qpath, pat.hir_id);
             let (cmt, expected_len) = match def {
                 Def::Err => {
                     debug!("access to unresolvable pattern {:?}", pat);
@@ -1161,7 +1161,7 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
 
           PatKind::Struct(ref qpath, ref field_pats, _) => {
             // {f1: p1, ..., fN: pN}
-            let def = self.tables.qpath_def(qpath, pat.id);
+            let def = self.tables.qpath_def(qpath, pat.hir_id);
             let cmt = match def {
                 Def::Err => {
                     debug!("access to unresolvable pattern {:?}", pat);

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -697,6 +697,9 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
                  fn_node_id: ast::NodeId)
                  -> McResult<cmt<'tcx>>
     {
+        let fn_hir_id = self.tcx.hir.node_to_hir_id(fn_node_id);
+        self.tables.validate_hir_id(fn_hir_id);
+
         // An upvar can have up to 3 components. We translate first to a
         // `Categorization::Upvar`, which is itself a fiction -- it represents the reference to the
         // field from the environment.
@@ -720,7 +723,7 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
         // FnMut          | copied -> &'env mut  | upvar -> &'env mut -> &'up bk
         // FnOnce         | copied               | upvar -> &'up bk
 
-        let kind = match self.tables.closure_kinds.get(&fn_node_id) {
+        let kind = match self.tables.closure_kinds.get(&fn_hir_id.local_id) {
             Some(&(kind, _)) => kind,
             None => span_bug!(span, "missing closure kind")
         };

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -334,10 +334,8 @@ impl MutabilityCategory {
         let ret = match tcx.hir.get(id) {
             hir_map::NodeLocal(p) => match p.node {
                 PatKind::Binding(..) => {
-
-                    tables.validate_hir_id(p.hir_id);
-                    let bm = *tables.pat_binding_modes
-                                    .get(&p.hir_id.local_id)
+                    let bm = *tables.pat_binding_modes()
+                                    .get(p.hir_id)
                                     .expect("missing binding mode");
                     if bm == ty::BindByValue(hir::MutMutable) {
                         McDeclared
@@ -485,10 +483,9 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
         // fundamental fix to this conflated use of the node id.
         let ret_ty = match pat.node {
             PatKind::Binding(..) => {
-                self.tables.validate_hir_id(pat.hir_id);
                 let bm = *self.tables
-                              .pat_binding_modes
-                              .get(&pat.hir_id.local_id)
+                              .pat_binding_modes()
+                              .get(pat.hir_id)
                               .expect("missing binding mode");
 
                 if let ty::BindByReference(_) = bm {
@@ -698,7 +695,6 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
                  -> McResult<cmt<'tcx>>
     {
         let fn_hir_id = self.tcx.hir.node_to_hir_id(fn_node_id);
-        self.tables.validate_hir_id(fn_hir_id);
 
         // An upvar can have up to 3 components. We translate first to a
         // `Categorization::Upvar`, which is itself a fiction -- it represents the reference to the
@@ -723,7 +719,7 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
         // FnMut          | copied -> &'env mut  | upvar -> &'env mut -> &'up bk
         // FnOnce         | copied               | upvar -> &'up bk
 
-        let kind = match self.tables.closure_kinds.get(&fn_hir_id.local_id) {
+        let kind = match self.tables.closure_kinds().get(fn_hir_id) {
             Some(&(kind, _)) => kind,
             None => span_bug!(span, "missing closure kind")
         };

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -334,7 +334,11 @@ impl MutabilityCategory {
         let ret = match tcx.hir.get(id) {
             hir_map::NodeLocal(p) => match p.node {
                 PatKind::Binding(..) => {
-                    let bm = *tables.pat_binding_modes.get(&p.id).expect("missing binding mode");
+
+                    tables.validate_hir_id(p.hir_id);
+                    let bm = *tables.pat_binding_modes
+                                    .get(&p.hir_id.local_id)
+                                    .expect("missing binding mode");
                     if bm == ty::BindByValue(hir::MutMutable) {
                         McDeclared
                     } else {
@@ -481,7 +485,12 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
         // fundamental fix to this conflated use of the node id.
         let ret_ty = match pat.node {
             PatKind::Binding(..) => {
-                let bm = *self.tables.pat_binding_modes.get(&pat.id).expect("missing binding mode");
+                self.tables.validate_hir_id(pat.hir_id);
+                let bm = *self.tables
+                              .pat_binding_modes
+                              .get(&pat.hir_id.local_id)
+                              .expect("missing binding mode");
+
                 if let ty::BindByReference(_) = bm {
                     // a bind-by-ref means that the base_ty will be the type of the ident itself,
                     // but what we want here is the type of the underlying value being borrowed.

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -107,10 +107,10 @@ impl<'a, 'tcx> Visitor<'tcx> for ReachableContext<'a, 'tcx> {
     fn visit_expr(&mut self, expr: &'tcx hir::Expr) {
         let def = match expr.node {
             hir::ExprPath(ref qpath) => {
-                Some(self.tables.qpath_def(qpath, expr.id))
+                Some(self.tables.qpath_def(qpath, expr.hir_id))
             }
             hir::ExprMethodCall(..) => {
-                Some(self.tables.type_dependent_defs[&expr.id])
+                Some(self.tables.type_dependent_defs[&expr.hir_id.local_id])
             }
             _ => None
         };
@@ -375,7 +375,7 @@ fn reachable_set<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, crate_num: CrateNum) -> 
     });
     let mut reachable_context = ReachableContext {
         tcx,
-        tables: &ty::TypeckTables::empty(),
+        tables: &ty::TypeckTables::empty(DefId::invalid()),
         reachable_symbols: NodeSet(),
         worklist: Vec::new(),
         any_library,

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -110,7 +110,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ReachableContext<'a, 'tcx> {
                 Some(self.tables.qpath_def(qpath, expr.hir_id))
             }
             hir::ExprMethodCall(..) => {
-                Some(self.tables.type_dependent_defs[&expr.hir_id.local_id])
+                Some(self.tables.type_dependent_defs()[expr.hir_id])
             }
             _ => None
         };

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -375,7 +375,7 @@ fn reachable_set<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, crate_num: CrateNum) -> 
     });
     let mut reachable_context = ReachableContext {
         tcx,
-        tables: &ty::TypeckTables::empty(DefId::invalid()),
+        tables: &ty::TypeckTables::empty(None),
         reachable_symbols: NodeSet(),
         worklist: Vec::new(),
         any_library,

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -682,7 +682,10 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                         // Additional context information explaining why the closure only implements
                         // a particular trait.
                         if let Some(tables) = self.in_progress_tables {
-                            match tables.borrow().closure_kinds.get(&node_id) {
+                            let tables = tables.borrow();
+                            let closure_hir_id = self.tcx.hir.node_to_hir_id(node_id);
+                            tables.validate_hir_id(closure_hir_id);
+                            match tables.closure_kinds.get(&closure_hir_id.local_id) {
                                 Some(&(ty::ClosureKind::FnOnce, Some((span, name)))) => {
                                     err.span_note(span, &format!(
                                         "closure is `FnOnce` because it moves the \

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -684,8 +684,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                         if let Some(tables) = self.in_progress_tables {
                             let tables = tables.borrow();
                             let closure_hir_id = self.tcx.hir.node_to_hir_id(node_id);
-                            tables.validate_hir_id(closure_hir_id);
-                            match tables.closure_kinds.get(&closure_hir_id.local_id) {
+                            match tables.closure_kinds().get(closure_hir_id) {
                                 Some(&(ty::ClosureKind::FnOnce, Some((span, name)))) => {
                                     err.span_note(span, &format!(
                                         "closure is `FnOnce` because it moves the \

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -257,7 +257,7 @@ pub struct TypeckTables<'tcx> {
 
     /// Maps a cast expression to its kind. This is keyed on the
     /// *from* expression of the cast, not the cast itself.
-    pub cast_kinds: NodeMap<ty::cast::CastKind>,
+    pub cast_kinds: ItemLocalMap<ty::cast::CastKind>,
 
     /// Set of trait imports actually used in the method resolution.
     /// This is used for warning unused imports.
@@ -287,7 +287,8 @@ impl<'tcx> TypeckTables<'tcx> {
             closure_kinds: ItemLocalMap(),
             liberated_fn_sigs: ItemLocalMap(),
             fru_field_types: ItemLocalMap(),
-            cast_kinds: NodeMap(),
+            cast_kinds: ItemLocalMap(),
+            lints: lint::LintTable::new(),
             used_trait_imports: DefIdSet(),
             tainted_by_errors: false,
             free_region_map: FreeRegionMap::new(),

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -226,8 +226,7 @@ pub struct LocalTableInContext<'a, V: 'a> {
 fn validate_hir_id_for_typeck_tables(local_id_root: Option<DefId>,
                                      hir_id: hir::HirId,
                                      mut_access: bool) {
-    #[cfg(debug_assertions)]
-    {
+    if cfg!(debug_assertions) {
         if let Some(local_id_root) = local_id_root {
             if hir_id.owner != local_id_root.index {
                 ty::tls::with(|tcx| {

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -236,11 +236,11 @@ pub struct TypeckTables<'tcx> {
     pub upvar_capture_map: ty::UpvarCaptureMap<'tcx>,
 
     /// Records the type of each closure.
-    pub closure_tys: NodeMap<ty::PolyFnSig<'tcx>>,
+    pub closure_tys: ItemLocalMap<ty::PolyFnSig<'tcx>>,
 
     /// Records the kind of each closure and the span and name of the variable
     /// that caused the closure to be this kind.
-    pub closure_kinds: NodeMap<(ty::ClosureKind, Option<(Span, ast::Name)>)>,
+    pub closure_kinds: ItemLocalMap<(ty::ClosureKind, Option<(Span, ast::Name)>)>,
 
     /// For each fn, records the "liberated" types of its arguments
     /// and return type. Liberated means that all bound regions
@@ -283,8 +283,8 @@ impl<'tcx> TypeckTables<'tcx> {
             adjustments: ItemLocalMap(),
             pat_binding_modes: ItemLocalMap(),
             upvar_capture_map: FxHashMap(),
-            closure_tys: NodeMap(),
-            closure_kinds: NodeMap(),
+            closure_tys: ItemLocalMap(),
+            closure_kinds: ItemLocalMap(),
             liberated_fn_sigs: NodeMap(),
             fru_field_types: NodeMap(),
             cast_kinds: NodeMap(),

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -230,7 +230,7 @@ pub struct TypeckTables<'tcx> {
     pub adjustments: ItemLocalMap<Vec<ty::adjustment::Adjustment<'tcx>>>,
 
     // Stores the actual binding mode for all instances of hir::BindingAnnotation.
-    pub pat_binding_modes: NodeMap<BindingMode>,
+    pub pat_binding_modes: ItemLocalMap<BindingMode>,
 
     /// Borrows
     pub upvar_capture_map: ty::UpvarCaptureMap<'tcx>,
@@ -281,7 +281,7 @@ impl<'tcx> TypeckTables<'tcx> {
             node_types: ItemLocalMap(),
             node_substs: ItemLocalMap(),
             adjustments: ItemLocalMap(),
-            pat_binding_modes: NodeMap(),
+            pat_binding_modes: ItemLocalMap(),
             upvar_capture_map: FxHashMap(),
             closure_tys: NodeMap(),
             closure_kinds: NodeMap(),

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -247,7 +247,7 @@ pub struct TypeckTables<'tcx> {
     /// (including late-bound regions) are replaced with free
     /// equivalents. This table is not used in trans (since regions
     /// are erased there) and hence is not serialized to metadata.
-    pub liberated_fn_sigs: NodeMap<ty::FnSig<'tcx>>,
+    pub liberated_fn_sigs: ItemLocalMap<ty::FnSig<'tcx>>,
 
     /// For each FRU expression, record the normalized types of the fields
     /// of the struct - this is needed because it is non-trivial to
@@ -285,7 +285,7 @@ impl<'tcx> TypeckTables<'tcx> {
             upvar_capture_map: FxHashMap(),
             closure_tys: ItemLocalMap(),
             closure_kinds: ItemLocalMap(),
-            liberated_fn_sigs: NodeMap(),
+            liberated_fn_sigs: ItemLocalMap(),
             fru_field_types: NodeMap(),
             cast_kinds: NodeMap(),
             used_trait_imports: DefIdSet(),

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -396,8 +396,16 @@ impl<'tcx> TypeckTables<'tcx> {
         self.upvar_capture_map[&upvar_id]
     }
 
-    /// Validate that a NodeId can safely be converted to an ItemLocalId for
-    /// this table.
+    /// Validate that the given HirId (respectively its `local_id` part) can be
+    /// safely used as a key in the tables of this TypeckTable. For that to be
+    /// the case, the HirId must have the same `owner` as all the other IDs in
+    /// this table (signified by the `local_id_root` field). Otherwise the HirId
+    /// would be in a different frame of reference and using its `local_id`
+    /// would result in lookup errors, or worse, in silently wrong data being
+    /// stored/returned.
+    ///
+    /// Therefore it is advised to call this method anytime before using a given
+    /// HirId::local_id as a key.
     #[inline]
     pub fn validate_hir_id(&self, hir_id: hir::HirId) {
         #[cfg(debug_assertions)]

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -285,7 +285,6 @@ pub struct LocalTableInContextMut<'a, V: 'a> {
 }
 
 impl<'a, V> LocalTableInContextMut<'a, V> {
-
     pub fn get_mut(&mut self, id: hir::HirId) -> Option<&mut V> {
         validate_hir_id_for_typeck_tables(self.local_id_root, id, true);
         self.data.get_mut(&id.local_id)

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -253,7 +253,7 @@ pub struct TypeckTables<'tcx> {
     /// of the struct - this is needed because it is non-trivial to
     /// normalize while preserving regions. This table is used only in
     /// MIR construction and hence is not serialized to metadata.
-    pub fru_field_types: NodeMap<Vec<Ty<'tcx>>>,
+    pub fru_field_types: ItemLocalMap<Vec<Ty<'tcx>>>,
 
     /// Maps a cast expression to its kind. This is keyed on the
     /// *from* expression of the cast, not the cast itself.
@@ -286,7 +286,7 @@ impl<'tcx> TypeckTables<'tcx> {
             closure_tys: ItemLocalMap(),
             closure_kinds: ItemLocalMap(),
             liberated_fn_sigs: ItemLocalMap(),
-            fru_field_types: NodeMap(),
+            fru_field_types: ItemLocalMap(),
             cast_kinds: NodeMap(),
             used_trait_imports: DefIdSet(),
             tainted_by_errors: false,

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -572,8 +572,8 @@ impl<T> Slice<T> {
 /// by the upvar) and the id of the closure expression.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, RustcEncodable, RustcDecodable)]
 pub struct UpvarId {
-    pub var_id: NodeId,
-    pub closure_expr_id: NodeId,
+    pub var_id: DefIndex,
+    pub closure_expr_id: DefIndex,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug, RustcEncodable, RustcDecodable, Copy)]
@@ -1981,6 +1981,11 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             },
             r => bug!("Variable id {} maps to {:?}, not local", id, r),
         }
+    }
+
+    pub fn local_var_name_str_def_index(self, def_index: DefIndex) -> InternedString {
+        let node_id = self.hir.as_local_node_id(DefId::local(def_index)).unwrap();
+        self.local_var_name_str(node_id)
     }
 
     pub fn expr_is_lval(self, expr: &hir::Expr) -> bool {

--- a/src/librustc/util/nodemap.rs
+++ b/src/librustc/util/nodemap.rs
@@ -13,6 +13,7 @@
 #![allow(non_snake_case)]
 
 use hir::def_id::DefId;
+use hir::ItemLocalId;
 use syntax::ast;
 
 pub use rustc_data_structures::fx::FxHashMap;
@@ -20,12 +21,14 @@ pub use rustc_data_structures::fx::FxHashSet;
 
 pub type NodeMap<T> = FxHashMap<ast::NodeId, T>;
 pub type DefIdMap<T> = FxHashMap<DefId, T>;
+pub type ItemLocalMap<T> = FxHashMap<ItemLocalId, T>;
 
 pub type NodeSet = FxHashSet<ast::NodeId>;
 pub type DefIdSet = FxHashSet<DefId>;
 
 pub fn NodeMap<T>() -> NodeMap<T> { FxHashMap() }
 pub fn DefIdMap<T>() -> DefIdMap<T> { FxHashMap() }
+pub fn ItemLocalMap<T>() -> ItemLocalMap<T> { FxHashMap() }
 pub fn NodeSet() -> NodeSet { FxHashSet() }
 pub fn DefIdSet() -> DefIdSet { FxHashSet() }
 

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -864,9 +864,9 @@ impl<'tcx> fmt::Display for ty::TyS<'tcx> {
 
 impl fmt::Debug for ty::UpvarId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "UpvarId({};`{}`;{})",
+        write!(f, "UpvarId({:?};`{}`;{:?})",
                self.var_id,
-               ty::tls::with(|tcx| tcx.local_var_name_str(self.var_id)),
+               ty::tls::with(|tcx| tcx.local_var_name_str_def_index(self.var_id)),
                self.closure_expr_id)
     }
 }

--- a/src/librustc_borrowck/borrowck/gather_loans/mod.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/mod.rs
@@ -155,7 +155,9 @@ impl<'a, 'tcx> euv::Delegate<'tcx> for GatherLoanCtxt<'a, 'tcx> {
     }
 
     fn decl_without_init(&mut self, id: ast::NodeId, _span: Span) {
-        let ty = self.bccx.tables.node_id_to_type(id);
+        let ty = self.bccx
+                     .tables
+                     .node_id_to_type(self.bccx.tcx.hir.node_to_hir_id(id));
         gather_moves::gather_decl(self.bccx, &self.move_data, id, ty);
     }
 }

--- a/src/librustc_borrowck/borrowck/gather_loans/mod.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/mod.rs
@@ -449,7 +449,8 @@ impl<'a, 'tcx> GatherLoanCtxt<'a, 'tcx> {
                     }
                     None
                 }
-                LpUpvar(ty::UpvarId{ var_id: local_id, closure_expr_id: _ }) => {
+                LpUpvar(ty::UpvarId{ var_id, closure_expr_id: _ }) => {
+                    let local_id = self.tcx().hir.def_index_to_node_id(var_id);
                     self.tcx().used_mut_nodes.borrow_mut().insert(local_id);
                     None
                 }

--- a/src/librustc_borrowck/borrowck/gather_loans/move_error.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/move_error.rs
@@ -93,11 +93,11 @@ fn report_move_errors<'a, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>, errors: &Vec<Move
             }
         }
         if let NoteClosureEnv(upvar_id) = error.move_from.note {
-            err.span_label(bccx.tcx.hir.span(upvar_id.var_id),
+            let var_node_id = bccx.tcx.hir.def_index_to_node_id(upvar_id.var_id);
+            err.span_label(bccx.tcx.hir.span(var_node_id),
                            "captured outer variable");
         }
         err.emit();
-
     }
 }
 

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -598,8 +598,10 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                 let need_note = match lp.ty.sty {
                     ty::TypeVariants::TyClosure(id, _) => {
                         let node_id = self.tcx.hir.as_local_node_id(id).unwrap();
+                        let hir_id = self.tcx.hir.node_to_hir_id(node_id);
+                        self.tables.validate_hir_id(hir_id);
                         if let Some(&(ty::ClosureKind::FnOnce, Some((span, name)))) =
-                            self.tables.closure_kinds.get(&node_id)
+                            self.tables.closure_kinds.get(&hir_id.local_id)
                         {
                             err.span_note(span, &format!(
                                 "closure cannot be invoked more than once because \

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -899,8 +899,13 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
         };
 
         match pat.node {
-            hir::PatKind::Binding(..) =>
-                *self.tables.pat_binding_modes.get(&pat.id).expect("missing binding mode"),
+            hir::PatKind::Binding(..) => {
+                self.tables.validate_hir_id(pat.hir_id);
+                *self.tables
+                     .pat_binding_modes
+                     .get(&pat.hir_id.local_id)
+                     .expect("missing binding mode")
+            }
             _ => bug!("local is not a binding: {:?}", pat)
         }
     }

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -600,9 +600,8 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                     ty::TypeVariants::TyClosure(id, _) => {
                         let node_id = self.tcx.hir.as_local_node_id(id).unwrap();
                         let hir_id = self.tcx.hir.node_to_hir_id(node_id);
-                        self.tables.validate_hir_id(hir_id);
                         if let Some(&(ty::ClosureKind::FnOnce, Some((span, name)))) =
-                            self.tables.closure_kinds.get(&hir_id.local_id)
+                            self.tables.closure_kinds().get(hir_id)
                         {
                             err.span_note(span, &format!(
                                 "closure cannot be invoked more than once because \
@@ -904,10 +903,9 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
 
         match pat.node {
             hir::PatKind::Binding(..) => {
-                self.tables.validate_hir_id(pat.hir_id);
                 *self.tables
-                     .pat_binding_modes
-                     .get(&pat.hir_id.local_id)
+                     .pat_binding_modes()
+                     .get(pat.hir_id)
                      .expect("missing binding mode")
             }
             _ => bug!("local is not a binding: {:?}", pat)

--- a/src/librustc_const_eval/check_match.rs
+++ b/src/librustc_const_eval/check_match.rs
@@ -269,7 +269,12 @@ impl<'a, 'tcx> MatchVisitor<'a, 'tcx> {
 fn check_for_bindings_named_the_same_as_variants(cx: &MatchVisitor, pat: &Pat) {
     pat.walk(|p| {
         if let PatKind::Binding(_, _, name, None) = p.node {
-            let bm = *cx.tables.pat_binding_modes.get(&p.id).expect("missing binding mode");
+            cx.tables.validate_hir_id(p.hir_id);
+            let bm = *cx.tables
+                        .pat_binding_modes
+                        .get(&p.hir_id.local_id)
+                        .expect("missing binding mode");
+
             if bm != ty::BindByValue(hir::MutImmutable) {
                 // Nothing to check.
                 return true;
@@ -458,7 +463,12 @@ fn check_legality_of_move_bindings(cx: &MatchVisitor,
     let mut by_ref_span = None;
     for pat in pats {
         pat.each_binding(|_, id, span, _path| {
-            let bm = *cx.tables.pat_binding_modes.get(&id).expect("missing binding mode");
+            let hir_id = cx.tcx.hir.node_to_hir_id(id);
+            cx.tables.validate_hir_id(hir_id);
+            let bm = *cx.tables
+                        .pat_binding_modes
+                        .get(&hir_id.local_id)
+                        .expect("missing binding mode");
             if let ty::BindByReference(..) = bm {
                 by_ref_span = Some(span);
             }
@@ -491,7 +501,11 @@ fn check_legality_of_move_bindings(cx: &MatchVisitor,
     for pat in pats {
         pat.walk(|p| {
             if let PatKind::Binding(_, _, _, ref sub) = p.node {
-                let bm = *cx.tables.pat_binding_modes.get(&p.id).expect("missing binding mode");
+                cx.tables.validate_hir_id(p.hir_id);
+                let bm = *cx.tables
+                            .pat_binding_modes
+                            .get(&p.hir_id.local_id)
+                            .expect("missing binding mode");
                 match bm {
                     ty::BindByValue(..) => {
                         let pat_ty = cx.tables.node_id_to_type(p.hir_id);

--- a/src/librustc_const_eval/check_match.rs
+++ b/src/librustc_const_eval/check_match.rs
@@ -188,7 +188,7 @@ impl<'a, 'tcx> MatchVisitor<'a, 'tcx> {
 
             // Then, if the match has no arms, check whether the scrutinee
             // is uninhabited.
-            let pat_ty = self.tables.node_id_to_type(scrut.id);
+            let pat_ty = self.tables.node_id_to_type(scrut.hir_id);
             let module = self.tcx.hir.get_module_parent(scrut.id);
             if inlined_arms.is_empty() {
                 let scrutinee_is_uninhabited = if self.tcx.sess.features.borrow().never_type {
@@ -217,7 +217,7 @@ impl<'a, 'tcx> MatchVisitor<'a, 'tcx> {
                 .flat_map(|arm| &arm.0)
                 .map(|pat| vec![pat.0])
                 .collect();
-            let scrut_ty = self.tables.node_id_to_type(scrut.id);
+            let scrut_ty = self.tables.node_id_to_type(scrut.hir_id);
             check_exhaustive(cx, scrut_ty, scrut.span, &matrix);
         })
     }
@@ -494,7 +494,7 @@ fn check_legality_of_move_bindings(cx: &MatchVisitor,
                 let bm = *cx.tables.pat_binding_modes.get(&p.id).expect("missing binding mode");
                 match bm {
                     ty::BindByValue(..) => {
-                        let pat_ty = cx.tables.node_id_to_type(p.id);
+                        let pat_ty = cx.tables.node_id_to_type(p.hir_id);
                         if pat_ty.moves_by_default(cx.tcx, cx.param_env, pat.span) {
                             check_move(p, sub.as_ref().map(|p| &**p));
                         }

--- a/src/librustc_const_eval/check_match.rs
+++ b/src/librustc_const_eval/check_match.rs
@@ -269,10 +269,9 @@ impl<'a, 'tcx> MatchVisitor<'a, 'tcx> {
 fn check_for_bindings_named_the_same_as_variants(cx: &MatchVisitor, pat: &Pat) {
     pat.walk(|p| {
         if let PatKind::Binding(_, _, name, None) = p.node {
-            cx.tables.validate_hir_id(p.hir_id);
             let bm = *cx.tables
-                        .pat_binding_modes
-                        .get(&p.hir_id.local_id)
+                        .pat_binding_modes()
+                        .get(p.hir_id)
                         .expect("missing binding mode");
 
             if bm != ty::BindByValue(hir::MutImmutable) {
@@ -464,10 +463,9 @@ fn check_legality_of_move_bindings(cx: &MatchVisitor,
     for pat in pats {
         pat.each_binding(|_, id, span, _path| {
             let hir_id = cx.tcx.hir.node_to_hir_id(id);
-            cx.tables.validate_hir_id(hir_id);
             let bm = *cx.tables
-                        .pat_binding_modes
-                        .get(&hir_id.local_id)
+                        .pat_binding_modes()
+                        .get(hir_id)
                         .expect("missing binding mode");
             if let ty::BindByReference(..) = bm {
                 by_ref_span = Some(span);
@@ -501,10 +499,9 @@ fn check_legality_of_move_bindings(cx: &MatchVisitor,
     for pat in pats {
         pat.walk(|p| {
             if let PatKind::Binding(_, _, _, ref sub) = p.node {
-                cx.tables.validate_hir_id(p.hir_id);
                 let bm = *cx.tables
-                            .pat_binding_modes
-                            .get(&p.hir_id.local_id)
+                            .pat_binding_modes()
+                            .get(p.hir_id)
                             .expect("missing binding mode");
                 match bm {
                     ty::BindByValue(..) => {

--- a/src/librustc_const_eval/eval.rs
+++ b/src/librustc_const_eval/eval.rs
@@ -275,7 +275,7 @@ fn eval_const_expr_partial<'a, 'tcx>(cx: &ConstContext<'a, 'tcx>,
         }
       }
       hir::ExprPath(ref qpath) => {
-        let substs = cx.tables.node_substs(e.id).subst(tcx, cx.substs);
+        let substs = cx.tables.node_substs(e.hir_id).subst(tcx, cx.substs);
           match cx.tables.qpath_def(qpath, e.hir_id) {
               Def::Const(def_id) |
               Def::AssociatedConst(def_id) => {

--- a/src/librustc_const_eval/eval.rs
+++ b/src/librustc_const_eval/eval.rs
@@ -276,7 +276,7 @@ fn eval_const_expr_partial<'a, 'tcx>(cx: &ConstContext<'a, 'tcx>,
       }
       hir::ExprPath(ref qpath) => {
         let substs = cx.tables.node_substs(e.id).subst(tcx, cx.substs);
-          match cx.tables.qpath_def(qpath, e.id) {
+          match cx.tables.qpath_def(qpath, e.hir_id) {
               Def::Const(def_id) |
               Def::AssociatedConst(def_id) => {
                     match tcx.at(e.span).const_eval(cx.param_env.and((def_id, substs))) {

--- a/src/librustc_const_eval/pattern.rs
+++ b/src/librustc_const_eval/pattern.rs
@@ -381,8 +381,8 @@ impl<'a, 'tcx> PatternContext<'a, 'tcx> {
                     ty::TyRef(r, _) => Some(r),
                     _ => None,
                 };
-                let bm = *self.tables.pat_binding_modes.get(&pat.hir_id.local_id)
-                                                       .expect("missing binding mode");
+                let bm = *self.tables.pat_binding_modes().get(pat.hir_id)
+                                                         .expect("missing binding mode");
                 let (mutability, mode) = match bm {
                     ty::BindByValue(hir::MutMutable) =>
                         (Mutability::Mut, BindingMode::ByValue),

--- a/src/librustc_const_eval/pattern.rs
+++ b/src/librustc_const_eval/pattern.rs
@@ -381,7 +381,7 @@ impl<'a, 'tcx> PatternContext<'a, 'tcx> {
                     ty::TyRef(r, _) => Some(r),
                     _ => None,
                 };
-                let bm = *self.tables.pat_binding_modes.get(&pat.id)
+                let bm = *self.tables.pat_binding_modes.get(&pat.hir_id.local_id)
                                                        .expect("missing binding mode");
                 let (mutability, mode) = match bm {
                     ty::BindByValue(hir::MutMutable) =>

--- a/src/librustc_data_structures/indexed_vec.rs
+++ b/src/librustc_data_structures/indexed_vec.rs
@@ -196,6 +196,16 @@ impl<I: Idx, T: Clone> IndexVec<I, T> {
     }
 }
 
+impl<I: Idx, T: Ord> IndexVec<I, T> {
+    #[inline]
+    pub fn binary_search(&self, value: &T) -> Result<I, I> {
+        match self.raw.binary_search(value) {
+            Ok(i) => Ok(Idx::new(i)),
+            Err(i) => Err(Idx::new(i)),
+        }
+    }
+}
+
 impl<I: Idx, T> Index<I> for IndexVec<I, T> {
     type Output = T;
 

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -45,6 +45,7 @@ use std::option;
 use std::path::Path;
 use std::str::FromStr;
 
+use rustc::hir::def_id::DefId;
 use rustc::hir::map as hir_map;
 use rustc::hir::map::blocks;
 use rustc::hir;
@@ -232,7 +233,7 @@ impl PpSourceMode {
                                                                  arenas,
                                                                  id,
                                                                  |tcx, _, _, _| {
-                    let empty_tables = ty::TypeckTables::empty();
+                    let empty_tables = ty::TypeckTables::empty(DefId::invalid());
                     let annotation = TypedAnnotation {
                         tcx: tcx,
                         tables: Cell::new(&empty_tables)

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -45,7 +45,6 @@ use std::option;
 use std::path::Path;
 use std::str::FromStr;
 
-use rustc::hir::def_id::DefId;
 use rustc::hir::map as hir_map;
 use rustc::hir::map::blocks;
 use rustc::hir;
@@ -233,7 +232,7 @@ impl PpSourceMode {
                                                                  arenas,
                                                                  id,
                                                                  |tcx, _, _, _| {
-                    let empty_tables = ty::TypeckTables::empty(DefId::invalid());
+                    let empty_tables = ty::TypeckTables::empty(None);
                     let annotation = TypedAnnotation {
                         tcx: tcx,
                         tables: Cell::new(&empty_tables)

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -139,7 +139,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BoxPointers {
     }
 
     fn check_expr(&mut self, cx: &LateContext, e: &hir::Expr) {
-        let ty = cx.tables.node_id_to_type(e.id);
+        let ty = cx.tables.node_id_to_type(e.hir_id);
         self.check_heap_type(cx, e.span, ty);
     }
 }
@@ -934,9 +934,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnconditionalRecursion {
 
             // Check for method calls and overloaded operators.
             if cx.tables.is_method_call(expr) {
-                let local_id = cx.tcx.hir.definitions().node_to_hir_id(id).local_id;
-                let def_id = cx.tables.type_dependent_defs[&local_id].def_id();
-                let substs = cx.tables.node_substs(id);
+                let hir_id = cx.tcx.hir.definitions().node_to_hir_id(id);
+                let def_id = cx.tables.type_dependent_defs[&hir_id.local_id].def_id();
+                let substs = cx.tables.node_substs(hir_id);
                 if method_call_refers_to_method(cx, method, def_id, substs, id) {
                     return true;
                 }
@@ -952,7 +952,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnconditionalRecursion {
                     };
                     match def {
                         Def::Method(def_id) => {
-                            let substs = cx.tables.node_substs(callee.id);
+                            let substs = cx.tables.node_substs(callee.hir_id);
                             method_call_refers_to_method(cx, method, def_id, substs, id)
                         }
                         _ => false,
@@ -1188,7 +1188,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MutableTransmutes {
                 if !def_id_is_transmute(cx, did) {
                     return None;
                 }
-                let sig = cx.tables.node_id_to_type(expr.id).fn_sig(cx.tcx);
+                let sig = cx.tables.node_id_to_type(expr.hir_id).fn_sig(cx.tcx);
                 let from = sig.inputs().skip_binder()[0];
                 let to = *sig.output().skip_binder();
                 return Some((&from.sty, &to.sty));

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -935,7 +935,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnconditionalRecursion {
             // Check for method calls and overloaded operators.
             if cx.tables.is_method_call(expr) {
                 let hir_id = cx.tcx.hir.definitions().node_to_hir_id(id);
-                let def_id = cx.tables.type_dependent_defs[&hir_id.local_id].def_id();
+                let def_id = cx.tables.type_dependent_defs()[hir_id].def_id();
                 let substs = cx.tables.node_substs(hir_id);
                 if method_call_refers_to_method(cx, method, def_id, substs, id) {
                     return true;

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -896,7 +896,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnconditionalRecursion {
             match cx.tcx.hir.get(id) {
                 hir_map::NodeExpr(&hir::Expr { node: hir::ExprCall(ref callee, _), .. }) => {
                     let def = if let hir::ExprPath(ref qpath) = callee.node {
-                        cx.tables.qpath_def(qpath, callee.id)
+                        cx.tables.qpath_def(qpath, callee.hir_id)
                     } else {
                         return false;
                     };
@@ -934,7 +934,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnconditionalRecursion {
 
             // Check for method calls and overloaded operators.
             if cx.tables.is_method_call(expr) {
-                let def_id = cx.tables.type_dependent_defs[&id].def_id();
+                let local_id = cx.tcx.hir.definitions().node_to_hir_id(id).local_id;
+                let def_id = cx.tables.type_dependent_defs[&local_id].def_id();
                 let substs = cx.tables.node_substs(id);
                 if method_call_refers_to_method(cx, method, def_id, substs, id) {
                     return true;
@@ -945,7 +946,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnconditionalRecursion {
             match expr.node {
                 hir::ExprCall(ref callee, _) => {
                     let def = if let hir::ExprPath(ref qpath) = callee.node {
-                        cx.tables.qpath_def(qpath, callee.id)
+                        cx.tables.qpath_def(qpath, callee.hir_id)
                     } else {
                         return false;
                     };
@@ -1179,7 +1180,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MutableTransmutes {
              expr: &hir::Expr)
              -> Option<(&'tcx ty::TypeVariants<'tcx>, &'tcx ty::TypeVariants<'tcx>)> {
             let def = if let hir::ExprPath(ref qpath) = expr.node {
-                cx.tables.qpath_def(qpath, expr.id)
+                cx.tables.qpath_def(qpath, expr.hir_id)
             } else {
                 return None;
             };

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -92,7 +92,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
                 }
 
                 if binop.node.is_shift() {
-                    let opt_ty_bits = match cx.tables.node_id_to_type(l.id).sty {
+                    let opt_ty_bits = match cx.tables.node_id_to_type(l.hir_id).sty {
                         ty::TyInt(t) => Some(int_ty_bits(t, cx.sess().target.int_type)),
                         ty::TyUint(t) => Some(uint_ty_bits(t, cx.sess().target.uint_type)),
                         _ => None,
@@ -135,7 +135,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
                 }
             }
             hir::ExprLit(ref lit) => {
-                match cx.tables.node_id_to_type(e.id).sty {
+                match cx.tables.node_id_to_type(e.hir_id).sty {
                     ty::TyInt(t) => {
                         match lit.node {
                             ast::LitKind::Int(v, ast::LitIntType::Signed(_)) |
@@ -285,7 +285,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
             // Normalize the binop so that the literal is always on the RHS in
             // the comparison
             let norm_binop = if swap { rev_binop(binop) } else { binop };
-            match cx.tables.node_id_to_type(expr.id).sty {
+            match cx.tables.node_id_to_type(expr.hir_id).sty {
                 ty::TyInt(int_ty) => {
                     let (min, max) = int_ty_range(int_ty);
                     let lit_val: i128 = match lit.node {

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -155,12 +155,12 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
         let maybe_def = match expr.node {
             hir::ExprCall(ref callee, _) => {
                 match callee.node {
-                    hir::ExprPath(ref qpath) => Some(cx.tables.qpath_def(qpath, callee.id)),
+                    hir::ExprPath(ref qpath) => Some(cx.tables.qpath_def(qpath, callee.hir_id)),
                     _ => None
                 }
             },
             hir::ExprMethodCall(..) => {
-                cx.tables.type_dependent_defs.get(&expr.id).cloned()
+                cx.tables.type_dependent_defs().get(expr.hir_id).cloned()
             },
             _ => { None }
         };

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -45,7 +45,9 @@ impl UnusedMut {
         let mut mutables = FxHashMap();
         for p in pats {
             p.each_binding(|_, id, span, path1| {
-                let bm = match cx.tables.pat_binding_modes.get(&id) {
+                let hir_id = cx.tcx.hir.node_to_hir_id(id);
+                cx.tables.validate_hir_id(hir_id);
+                let bm = match cx.tables.pat_binding_modes.get(&hir_id.local_id) {
                     Some(&bm) => bm,
                     None => span_bug!(span, "missing binding mode"),
                 };

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -46,8 +46,7 @@ impl UnusedMut {
         for p in pats {
             p.each_binding(|_, id, span, path1| {
                 let hir_id = cx.tcx.hir.node_to_hir_id(id);
-                cx.tables.validate_hir_id(hir_id);
-                let bm = match cx.tables.pat_binding_modes.get(&hir_id.local_id) {
+                let bm = match cx.tables.pat_binding_modes().get(hir_id) {
                     Some(&bm) => bm,
                     None => span_bug!(span, "missing binding mode"),
                 };

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -90,7 +90,9 @@ pub fn mir_build<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> Mir<'t
         } else if let MirSource::Fn(id) = src {
             // fetch the fully liberated fn signature (that is, all bound
             // types/lifetimes replaced)
-            let fn_sig = cx.tables().liberated_fn_sigs[&id].clone();
+            let fn_hir_id = tcx.hir.node_to_hir_id(id);
+            cx.tables().validate_hir_id(fn_hir_id);
+            let fn_sig = cx.tables().liberated_fn_sigs[&fn_hir_id.local_id].clone();
 
             let ty = tcx.type_of(tcx.hir.local_def_id(id));
             let mut abi = fn_sig.abi;

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -368,10 +368,12 @@ fn construct_fn<'a, 'gcx, 'tcx, A>(hir: Cx<'a, 'gcx, 'tcx>,
     // Gather the upvars of a closure, if any.
     let upvar_decls: Vec<_> = tcx.with_freevars(fn_id, |freevars| {
         freevars.iter().map(|fv| {
-            let var_id = tcx.hir.as_local_node_id(fv.def.def_id()).unwrap();
+            let var_def_id = fv.def.def_id();
+            let var_node_id = tcx.hir.as_local_node_id(var_def_id).unwrap();
+            let closure_expr_id = tcx.hir.local_def_id(fn_id).index;
             let capture = hir.tables().upvar_capture(ty::UpvarId {
-                var_id: var_id,
-                closure_expr_id: fn_id
+                var_id: var_def_id.index,
+                closure_expr_id,
             });
             let by_ref = match capture {
                 ty::UpvarCapture::ByValue => false,
@@ -381,7 +383,7 @@ fn construct_fn<'a, 'gcx, 'tcx, A>(hir: Cx<'a, 'gcx, 'tcx>,
                 debug_name: keywords::Invalid.name(),
                 by_ref: by_ref
             };
-            if let Some(hir::map::NodeLocal(pat)) = tcx.hir.find(var_id) {
+            if let Some(hir::map::NodeLocal(pat)) = tcx.hir.find(var_node_id) {
                 if let hir::PatKind::Binding(_, _, ref ident, _) = pat.node {
                     decl.debug_name = ident.node;
                 }

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -91,8 +91,7 @@ pub fn mir_build<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> Mir<'t
             // fetch the fully liberated fn signature (that is, all bound
             // types/lifetimes replaced)
             let fn_hir_id = tcx.hir.node_to_hir_id(id);
-            cx.tables().validate_hir_id(fn_hir_id);
-            let fn_sig = cx.tables().liberated_fn_sigs[&fn_hir_id.local_id].clone();
+            let fn_sig = cx.tables().liberated_fn_sigs()[fn_hir_id].clone();
 
             let ty = tcx.type_of(tcx.hir.local_def_id(id));
             let mut abi = fn_sig.abi;

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -202,7 +202,8 @@ fn closure_self_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                              closure_expr_id: ast::NodeId,
                              body_id: hir::BodyId)
                              -> Ty<'tcx> {
-    let closure_ty = tcx.body_tables(body_id).node_id_to_type(closure_expr_id);
+    let closure_expr_hir_id = tcx.hir.node_to_hir_id(closure_expr_id);
+    let closure_ty = tcx.body_tables(body_id).node_id_to_type(closure_expr_hir_id);
 
     let closure_def_id = tcx.hir.local_def_id(closure_expr_id);
     let region = ty::ReFree(ty::FreeRegion {

--- a/src/librustc_mir/hair/cx/block.rs
+++ b/src/librustc_mir/hair/cx/block.rs
@@ -95,7 +95,7 @@ fn mirror_stmts<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
 pub fn to_expr_ref<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                                    block: &'tcx hir::Block)
                                    -> ExprRef<'tcx> {
-    let block_ty = cx.tables().node_id_to_type(block.id);
+    let block_ty = cx.tables().node_id_to_type(block.hir_id);
     let temp_lifetime = cx.region_maps.temporary_scope(block.id);
     let expr = Expr {
         ty: block_ty,

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -387,11 +387,10 @@ fn make_mirror_unadjusted<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                                 substs: substs,
                                 fields: field_refs,
                                 base: base.as_ref().map(|base| {
-                                    cx.tables().validate_hir_id(expr.hir_id);
                                     FruInfo {
                                         base: base.to_ref(),
                                         field_types: cx.tables()
-                                                       .fru_field_types[&expr.hir_id.local_id]
+                                                       .fru_field_types()[expr.hir_id]
                                                        .clone(),
                                     }
                                 }),
@@ -551,10 +550,9 @@ fn make_mirror_unadjusted<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
         hir::ExprCast(ref source, _) => {
             // Check to see if this cast is a "coercion cast", where the cast is actually done
             // using a coercion (or is a no-op).
-            cx.tables().validate_hir_id(source.hir_id);
             if let Some(&TyCastKind::CoercionCast) = cx.tables()
-                                                       .cast_kinds
-                                                       .get(&source.hir_id.local_id) {
+                                                       .cast_kinds()
+                                                       .get(source.hir_id) {
                 // Convert the lexpr to a vexpr.
                 ExprKind::Use { source: source.to_ref() }
             } else {
@@ -586,8 +584,7 @@ fn method_callee<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                                  -> Expr<'tcx> {
     let temp_lifetime = cx.region_maps.temporary_scope(expr.id);
     let (def_id, substs) = custom_callee.unwrap_or_else(|| {
-        cx.tables().validate_hir_id(expr.hir_id);
-        (cx.tables().type_dependent_defs[&expr.hir_id.local_id].def_id(),
+        (cx.tables().type_dependent_defs()[expr.hir_id].def_id(),
          cx.tables().node_substs(expr.hir_id))
     });
     Expr {

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -387,9 +387,12 @@ fn make_mirror_unadjusted<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                                 substs: substs,
                                 fields: field_refs,
                                 base: base.as_ref().map(|base| {
+                                    cx.tables().validate_hir_id(expr.hir_id);
                                     FruInfo {
                                         base: base.to_ref(),
-                                        field_types: cx.tables().fru_field_types[&expr.id].clone(),
+                                        field_types: cx.tables()
+                                                       .fru_field_types[&expr.hir_id.local_id]
+                                                       .clone(),
                                     }
                                 }),
                             }

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -551,7 +551,10 @@ fn make_mirror_unadjusted<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
         hir::ExprCast(ref source, _) => {
             // Check to see if this cast is a "coercion cast", where the cast is actually done
             // using a coercion (or is a no-op).
-            if let Some(&TyCastKind::CoercionCast) = cx.tables().cast_kinds.get(&source.id) {
+            cx.tables().validate_hir_id(source.hir_id);
+            if let Some(&TyCastKind::CoercionCast) = cx.tables()
+                                                       .cast_kinds
+                                                       .get(&source.hir_id.local_id) {
                 // Convert the lexpr to a vexpr.
                 ExprKind::Use { source: source.to_ref() }
             } else {

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -450,7 +450,7 @@ fn make_mirror_unadjusted<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
         }
 
         hir::ExprPath(ref qpath) => {
-            let def = cx.tables().qpath_def(qpath, expr.id);
+            let def = cx.tables().qpath_def(qpath, expr.hir_id);
             convert_path_expr(cx, expr, def)
         }
 
@@ -580,7 +580,8 @@ fn method_callee<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                                  -> Expr<'tcx> {
     let temp_lifetime = cx.region_maps.temporary_scope(expr.id);
     let (def_id, substs) = custom_callee.unwrap_or_else(|| {
-        (cx.tables().type_dependent_defs[&expr.id].def_id(),
+        cx.tables().validate_hir_id(expr.hir_id);
+        (cx.tables().type_dependent_defs[&expr.hir_id.local_id].def_id(),
          cx.tables().node_substs(expr.id))
     });
     Expr {

--- a/src/librustc_passes/consts.rs
+++ b/src/librustc_passes/consts.rs
@@ -219,7 +219,7 @@ impl<'a, 'tcx> Visitor<'tcx> for CheckCrateVisitor<'a, 'tcx> {
         let outer = self.promotable;
         self.promotable = true;
 
-        let node_ty = self.tables.node_id_to_type(ex.id);
+        let node_ty = self.tables.node_id_to_type(ex.hir_id);
         check_expr(self, ex, node_ty);
         check_adjustments(self, ex);
 
@@ -297,7 +297,7 @@ fn check_expr<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>, e: &hir::Expr, node
             v.promotable = false;
         }
         hir::ExprUnary(op, ref inner) => {
-            match v.tables.node_id_to_type(inner.id).sty {
+            match v.tables.node_id_to_type(inner.hir_id).sty {
                 ty::TyRawPtr(_) => {
                     assert!(op == hir::UnDeref);
 
@@ -307,7 +307,7 @@ fn check_expr<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>, e: &hir::Expr, node
             }
         }
         hir::ExprBinary(op, ref lhs, _) => {
-            match v.tables.node_id_to_type(lhs.id).sty {
+            match v.tables.node_id_to_type(lhs.hir_id).sty {
                 ty::TyRawPtr(_) => {
                     assert!(op.node == hir::BiEq || op.node == hir::BiNe ||
                             op.node == hir::BiLe || op.node == hir::BiLt ||

--- a/src/librustc_passes/consts.rs
+++ b/src/librustc_passes/consts.rs
@@ -320,8 +320,7 @@ fn check_expr<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>, e: &hir::Expr, node
         }
         hir::ExprCast(ref from, _) => {
             debug!("Checking const cast(id={})", from.id);
-            v.tables.validate_hir_id(from.hir_id);
-            match v.tables.cast_kinds.get(&from.hir_id.local_id) {
+            match v.tables.cast_kinds().get(from.hir_id) {
                 None => span_bug!(e.span, "no kind for cast"),
                 Some(&CastKind::PtrAddrCast) | Some(&CastKind::FnPtrAddrCast) => {
                     v.promotable = false;
@@ -388,8 +387,7 @@ fn check_expr<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>, e: &hir::Expr, node
             }
         }
         hir::ExprMethodCall(..) => {
-            v.tables.validate_hir_id(e.hir_id);
-            let def_id = v.tables.type_dependent_defs[&e.hir_id.local_id].def_id();
+            let def_id = v.tables.type_dependent_defs()[e.hir_id].def_id();
             match v.tcx.associated_item(def_id).container {
                 ty::ImplContainer(_) => v.handle_const_fn_call(def_id, node_ty),
                 ty::TraitContainer(_) => v.promotable = false

--- a/src/librustc_passes/consts.rs
+++ b/src/librustc_passes/consts.rs
@@ -320,7 +320,8 @@ fn check_expr<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>, e: &hir::Expr, node
         }
         hir::ExprCast(ref from, _) => {
             debug!("Checking const cast(id={})", from.id);
-            match v.tables.cast_kinds.get(&from.id) {
+            v.tables.validate_hir_id(from.hir_id);
+            match v.tables.cast_kinds.get(&from.hir_id.local_id) {
                 None => span_bug!(e.span, "no kind for cast"),
                 Some(&CastKind::PtrAddrCast) | Some(&CastKind::FnPtrAddrCast) => {
                     v.promotable = false;

--- a/src/librustc_passes/consts.rs
+++ b/src/librustc_passes/consts.rs
@@ -329,7 +329,7 @@ fn check_expr<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>, e: &hir::Expr, node
             }
         }
         hir::ExprPath(ref qpath) => {
-            let def = v.tables.qpath_def(qpath, e.id);
+            let def = v.tables.qpath_def(qpath, e.hir_id);
             match def {
                 Def::VariantCtor(..) | Def::StructCtor(..) |
                 Def::Fn(..) | Def::Method(..) => {}
@@ -365,7 +365,7 @@ fn check_expr<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>, e: &hir::Expr, node
             }
             // The callee is an arbitrary expression, it doesn't necessarily have a definition.
             let def = if let hir::ExprPath(ref qpath) = callee.node {
-                v.tables.qpath_def(qpath, callee.id)
+                v.tables.qpath_def(qpath, callee.hir_id)
             } else {
                 Def::Err
             };
@@ -387,7 +387,8 @@ fn check_expr<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>, e: &hir::Expr, node
             }
         }
         hir::ExprMethodCall(..) => {
-            let def_id = v.tables.type_dependent_defs[&e.id].def_id();
+            v.tables.validate_hir_id(e.hir_id);
+            let def_id = v.tables.type_dependent_defs[&e.hir_id.local_id].def_id();
             match v.tcx.associated_item(def_id).container {
                 ty::ImplContainer(_) => v.handle_const_fn_call(def_id, node_ty),
                 ty::TraitContainer(_) => v.promotable = false
@@ -471,7 +472,7 @@ fn check_adjustments<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>, e: &hir::Exp
 pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     tcx.hir.krate().visit_all_item_likes(&mut CheckCrateVisitor {
         tcx: tcx,
-        tables: &ty::TypeckTables::empty(),
+        tables: &ty::TypeckTables::empty(DefId::invalid()),
         in_fn: false,
         promotable: false,
         mut_rvalue_borrows: NodeSet(),

--- a/src/librustc_passes/consts.rs
+++ b/src/librustc_passes/consts.rs
@@ -471,7 +471,7 @@ fn check_adjustments<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>, e: &hir::Exp
 pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     tcx.hir.krate().visit_all_item_likes(&mut CheckCrateVisitor {
         tcx: tcx,
-        tables: &ty::TypeckTables::empty(DefId::invalid()),
+        tables: &ty::TypeckTables::empty(None),
         in_fn: false,
         promotable: false,
         mut_rvalue_borrows: NodeSet(),

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -1656,7 +1656,7 @@ fn privacy_access_levels<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
     let krate = tcx.hir.krate();
 
-    let empty_tables = ty::TypeckTables::empty(DefId::invalid());
+    let empty_tables = ty::TypeckTables::empty(None);
 
 
     // Check privacy of names not checked in previous compilation stages.

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -649,7 +649,7 @@ impl<'a, 'tcx> TypePrivacyVisitor<'a, 'tcx> {
         if self.tables.node_substs(id).visit_with(self) {
             return true;
         }
-        if let Some(adjustments) = self.tables.adjustments.get(&id.local_id) {
+        if let Some(adjustments) = self.tables.adjustments().get(id) {
             for adjustment in adjustments {
                 if adjustment.target.visit_with(self) {
                     return true;
@@ -748,8 +748,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypePrivacyVisitor<'a, 'tcx> {
             }
             hir::ExprMethodCall(_, span, _) => {
                 // Method calls have to be checked specially.
-                self.tables.validate_hir_id(expr.hir_id);
-                let def_id = self.tables.type_dependent_defs[&expr.hir_id.local_id].def_id();
+                let def_id = self.tables.type_dependent_defs()[expr.hir_id].def_id();
                 self.span = span;
                 if self.tcx.type_of(def_id).visit_with(self) {
                     return;
@@ -766,8 +765,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypePrivacyVisitor<'a, 'tcx> {
         // we have to check it additionally.
         if let hir::QPath::TypeRelative(..) = *qpath {
             let hir_id = self.tcx.hir.node_to_hir_id(id);
-            self.tables.validate_hir_id(hir_id);
-            if let Some(def) = self.tables.type_dependent_defs.get(&hir_id.local_id).cloned() {
+            if let Some(def) = self.tables.type_dependent_defs().get(hir_id).cloned() {
                 if let Some(assoc_item) = self.tcx.opt_associated_item(def.def_id()) {
                     if let ty::ImplContainer(impl_def_id) = assoc_item.container {
                         if self.tcx.type_of(impl_def_id).visit_with(self) {

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -1655,9 +1655,7 @@ fn privacy_access_levels<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     assert_eq!(krate, LOCAL_CRATE);
 
     let krate = tcx.hir.krate();
-
     let empty_tables = ty::TypeckTables::empty(None);
-
 
     // Check privacy of names not checked in previous compilation stages.
     let mut visitor = NamePrivacyVisitor {

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -500,12 +500,14 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> DumpVisitor<'l, 'tcx, 'll, O> {
                                     item: &'l ast::Item,
                                     typ: &'l ast::Ty,
                                     expr: &'l ast::Expr) {
-        if let Some(var_data) = self.save_ctxt.get_item_data(item) {
-            down_cast_data!(var_data, DefData, item.span);
-            self.dumper.dump_def(item.vis == ast::Visibility::Public, var_data);
-        }
-        self.visit_ty(&typ);
-        self.visit_expr(expr);
+        self.nest_tables(item.id, |v| {
+            if let Some(var_data) = v.save_ctxt.get_item_data(item) {
+                down_cast_data!(var_data, DefData, item.span);
+                v.dumper.dump_def(item.vis == ast::Visibility::Public, var_data);
+            }
+            v.visit_ty(&typ);
+            v.visit_expr(expr);
+        });
     }
 
     fn process_assoc_const(&mut self,

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -345,7 +345,8 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> DumpVisitor<'l, 'tcx, 'll, O> {
             collector.visit_pat(&arg.pat);
             let span_utils = self.span.clone();
             for &(id, ref p, ..) in &collector.collected_paths {
-                let typ = match self.save_ctxt.tables.node_types.get(&id) {
+                let hir_id = self.tcx.hir.node_to_hir_id(id);
+                let typ = match self.save_ctxt.tables.node_id_to_type_opt(hir_id) {
                     Some(s) => s.to_string(),
                     None => continue,
                 };
@@ -893,7 +894,8 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> DumpVisitor<'l, 'tcx, 'll, O> {
         match p.node {
             PatKind::Struct(ref _path, ref fields, _) => {
                 // FIXME do something with _path?
-                let adt = match self.save_ctxt.tables.node_id_to_type_opt(p.id) {
+                let hir_id = self.tcx.hir.node_to_hir_id(p.id);
+                let adt = match self.save_ctxt.tables.node_id_to_type_opt(hir_id) {
                     Some(ty) => ty.ty_adt_def().unwrap(),
                     None => {
                         visit::walk_pat(self, p);
@@ -935,7 +937,8 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> DumpVisitor<'l, 'tcx, 'll, O> {
                 ast::Mutability::Immutable => value.to_string(),
                 _ => String::new(),
             };
-            let typ = match self.save_ctxt.tables.node_types.get(&id) {
+            let hir_id = self.tcx.hir.node_to_hir_id(id);
+            let typ = match self.save_ctxt.tables.node_id_to_type_opt(hir_id) {
                 Some(typ) => {
                     let typ = typ.to_string();
                     if !value.is_empty() {
@@ -1466,8 +1469,12 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> Visitor<'l> for DumpVisitor<'l, 'tc
                     } else {
                         "<mutable>".to_string()
                     };
-                    let typ = self.save_ctxt.tables.node_types
-                                  .get(&id).map(|t| t.to_string()).unwrap_or(String::new());
+                    let hir_id = self.tcx.hir.node_to_hir_id(id);
+                    let typ = self.save_ctxt
+                                  .tables
+                                  .node_id_to_type_opt(hir_id)
+                                  .map(|t| t.to_string())
+                                  .unwrap_or(String::new());
                     value.push_str(": ");
                     value.push_str(&typ);
 

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -550,8 +550,8 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                 }
             }
             ast::ExprKind::MethodCall(..) => {
-                let local_id = self.tcx.hir.definitions().node_to_hir_id(expr.id).local_id;
-                let method_id = self.tables.type_dependent_defs[&local_id].def_id();
+                let expr_hir_id = self.tcx.hir.definitions().node_to_hir_id(expr.id);
+                let method_id = self.tables.type_dependent_defs()[expr_hir_id].def_id();
                 let (def_id, decl_id) = match self.tcx.associated_item(method_id).container {
                     ty::ImplContainer(_) => (Some(method_id), None),
                     ty::TraitContainer(_) => (None, Some(method_id)),

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -977,7 +977,7 @@ pub fn process_crate<'l, 'tcx, H: SaveHandler>(tcx: TyCtxt<'l, 'tcx, 'tcx>,
 
     let save_ctxt = SaveContext {
         tcx: tcx,
-        tables: &ty::TypeckTables::empty(DefId::invalid()),
+        tables: &ty::TypeckTables::empty(None),
         analysis: analysis,
         span_utils: SpanUtils::new(&tcx.sess),
         config: find_config(config),

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -118,11 +118,11 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 // identical to what could be scraped from the HIR, but this will change with
                 // default binding modes (#42640).
                 let bm = ty::BindingMode::convert(ba);
-                {
-                    let mut inh_tables = self.inh.tables.borrow_mut();
-                    inh_tables.validate_hir_id(pat.hir_id);
-                    inh_tables.pat_binding_modes.insert(pat.hir_id.local_id, bm);
-                }
+                self.inh
+                    .tables
+                    .borrow_mut()
+                    .pat_binding_modes_mut()
+                    .insert(pat.hir_id, bm);
                 let typ = self.local_ty(pat.span, pat.id);
                 match bm {
                     ty::BindByReference(mutbl) => {

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -323,7 +323,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             }
         };
 
-        self.write_ty(pat.id, ty);
+        self.write_ty(pat.hir_id, ty);
 
         // (*) In most of the cases above (literals and constants being
         // the exception), we relate types using strict equality, evewn

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -118,8 +118,11 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 // identical to what could be scraped from the HIR, but this will change with
                 // default binding modes (#42640).
                 let bm = ty::BindingMode::convert(ba);
-                self.inh.tables.borrow_mut().pat_binding_modes.insert(pat.id, bm);
-
+                {
+                    let mut inh_tables = self.inh.tables.borrow_mut();
+                    inh_tables.validate_hir_id(pat.hir_id);
+                    inh_tables.pat_binding_modes.insert(pat.hir_id.local_id, bm);
+                }
                 let typ = self.local_ty(pat.span, pat.id);
                 match bm {
                     ty::BindByReference(mutbl) => {

--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -222,7 +222,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
                 if let hir::ExprCall(ref expr, _) = call_expr.node {
                     let def = if let hir::ExprPath(ref qpath) = expr.node {
-                        self.tables.borrow().qpath_def(qpath, expr.id)
+                        self.tables.borrow().qpath_def(qpath, expr.hir_id)
                     } else {
                         Def::Err
                     };
@@ -314,7 +314,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                                            TupleArgumentsFlag::TupleArguments,
                                                            expected);
 
-        self.write_method_call(call_expr.id, method_callee);
+        self.write_method_call((call_expr.id, call_expr.hir_id), method_callee);
         output_type
     }
 }
@@ -364,7 +364,8 @@ impl<'a, 'gcx, 'tcx> DeferredCallResolution<'gcx, 'tcx> {
                 adjustments.extend(autoref);
                 fcx.apply_adjustments(self.callee_expr, adjustments);
 
-                fcx.write_method_call(self.call_expr.id, method_callee);
+                fcx.write_method_call((self.call_expr.id, self.call_expr.hir_id),
+                                      method_callee);
             }
             None => {
                 span_bug!(self.call_expr.span,

--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -314,7 +314,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                                            TupleArgumentsFlag::TupleArguments,
                                                            expected);
 
-        self.write_method_call((call_expr.id, call_expr.hir_id), method_callee);
+        self.write_method_call(call_expr.hir_id, method_callee);
         output_type
     }
 }
@@ -364,7 +364,7 @@ impl<'a, 'gcx, 'tcx> DeferredCallResolution<'gcx, 'tcx> {
                 adjustments.extend(autoref);
                 fcx.apply_adjustments(self.callee_expr, adjustments);
 
-                fcx.write_method_call((self.call_expr.id, self.call_expr.hir_id),
+                fcx.write_method_call(self.call_expr.hir_id,
                                       method_callee);
             }
             None => {

--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -330,16 +330,13 @@ impl<'a, 'gcx, 'tcx> CastCheck<'tcx> {
         } else if self.try_coercion_cast(fcx) {
             self.trivial_cast_lint(fcx);
             debug!(" -> CoercionCast");
-            let mut tables = fcx.tables.borrow_mut();
-            tables.validate_hir_id(self.expr.hir_id);
-            tables.cast_kinds.insert(self.expr.hir_id.local_id, CastKind::CoercionCast);
+            fcx.tables.borrow_mut().cast_kinds_mut().insert(self.expr.hir_id,
+                                                            CastKind::CoercionCast);
         } else {
             match self.do_check(fcx) {
                 Ok(k) => {
                     debug!(" -> {:?}", k);
-                    let mut tables = fcx.tables.borrow_mut();
-                    tables.validate_hir_id(self.expr.hir_id);
-                    tables.cast_kinds.insert(self.expr.hir_id.local_id, k);
+                    fcx.tables.borrow_mut().cast_kinds_mut().insert(self.expr.hir_id, k);
                 }
                 Err(e) => self.report_cast_error(fcx, e),
             };

--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -330,12 +330,16 @@ impl<'a, 'gcx, 'tcx> CastCheck<'tcx> {
         } else if self.try_coercion_cast(fcx) {
             self.trivial_cast_lint(fcx);
             debug!(" -> CoercionCast");
-            fcx.tables.borrow_mut().cast_kinds.insert(self.expr.id, CastKind::CoercionCast);
+            let mut tables = fcx.tables.borrow_mut();
+            tables.validate_hir_id(self.expr.hir_id);
+            tables.cast_kinds.insert(self.expr.hir_id.local_id, CastKind::CoercionCast);
         } else {
             match self.do_check(fcx) {
                 Ok(k) => {
                     debug!(" -> {:?}", k);
-                    fcx.tables.borrow_mut().cast_kinds.insert(self.expr.id, k);
+                    let mut tables = fcx.tables.borrow_mut();
+                    tables.validate_hir_id(self.expr.hir_id);
+                    tables.cast_kinds.insert(self.expr.hir_id.local_id, k);
                 }
                 Err(e) => self.report_cast_error(fcx, e),
             };

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -102,12 +102,16 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                sig,
                opt_kind);
 
-        self.tables.borrow_mut().closure_tys.insert(expr.id, sig);
-        match opt_kind {
-            Some(kind) => {
-                self.tables.borrow_mut().closure_kinds.insert(expr.id, (kind, None));
+        {
+            let mut tables = self.tables.borrow_mut();
+            tables.validate_hir_id(expr.hir_id);
+            tables.closure_tys.insert(expr.hir_id.local_id, sig);
+            match opt_kind {
+                Some(kind) => {
+                    tables.closure_kinds.insert(expr.hir_id.local_id, (kind, None));
+                }
+                None => {}
             }
-            None => {}
         }
 
         closure_type

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -104,11 +104,10 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
         {
             let mut tables = self.tables.borrow_mut();
-            tables.validate_hir_id(expr.hir_id);
-            tables.closure_tys.insert(expr.hir_id.local_id, sig);
+            tables.closure_tys_mut().insert(expr.hir_id, sig);
             match opt_kind {
                 Some(kind) => {
-                    tables.closure_kinds.insert(expr.hir_id.local_id, (kind, None));
+                    tables.closure_kinds_mut().insert(expr.hir_id, (kind, None));
                 }
                 None => {}
             }

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -844,7 +844,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         // First try to coerce the new expression to the type of the previous ones,
         // but only if the new expression has no coercion already applied to it.
         let mut first_error = None;
-        if !self.tables.borrow().adjustments.contains_key(&new.id) {
+        if !self.tables.borrow().adjustments.contains_key(&new.hir_id.local_id) {
             let result = self.commit_if_ok(|_| coerce.coerce(new_ty, prev_ty));
             match result {
                 Ok(ok) => {
@@ -866,7 +866,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     Adjustment { kind: Adjust::Deref(_), .. },
                     Adjustment { kind: Adjust::Borrow(AutoBorrow::Ref(_, mutbl_adj)), .. }
                 ] => {
-                    match self.node_ty(expr.id).sty {
+                    match self.node_ty(expr.hir_id).sty {
                         ty::TyRef(_, mt_orig) => {
                             // Reborrow that we can safely ignore, because
                             // the next adjustment can only be a Deref

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -844,7 +844,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         // First try to coerce the new expression to the type of the previous ones,
         // but only if the new expression has no coercion already applied to it.
         let mut first_error = None;
-        if !self.tables.borrow().adjustments.contains_key(&new.hir_id.local_id) {
+        if !self.tables.borrow().adjustments().contains_key(new.hir_id) {
             let result = self.commit_if_ok(|_| coerce.coerce(new_ty, prev_ty));
             match result {
                 Ok(ok) => {

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -513,7 +513,7 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
             None => return self.tcx.sess.delay_span_bug(expr.span, "re-trying op failed")
         };
         debug!("convert_lvalue_op_to_mutable: method={:?}", method);
-        self.write_method_call(expr.id, method);
+        self.write_method_call((expr.id, expr.hir_id), method);
 
         let (region, mutbl) = if let ty::TyRef(r, mt) = method.sig.inputs()[0].sty {
             (r, mt.mutbl)

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -445,11 +445,14 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
             // Fix up the autoderefs. Autorefs can only occur immediately preceding
             // overloaded lvalue ops, and will be fixed by them in order to get
             // the correct region.
-            let mut source = self.node_ty(expr.id);
+            let mut source = self.node_ty(expr.hir_id);
             // Do not mutate adjustments in place, but rather take them,
             // and replace them after mutating them, to avoid having the
             // tables borrowed during (`deref_mut`) method resolution.
-            let previous_adjustments = self.tables.borrow_mut().adjustments.remove(&expr.id);
+            let previous_adjustments = self.tables
+                                           .borrow_mut()
+                                           .adjustments
+                                           .remove(&expr.hir_id.local_id);
             if let Some(mut adjustments) = previous_adjustments {
                 let pref = LvaluePreference::PreferMutLvalue;
                 for adjustment in &mut adjustments {
@@ -466,12 +469,12 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
                     }
                     source = adjustment.target;
                 }
-                self.tables.borrow_mut().adjustments.insert(expr.id, adjustments);
+                self.tables.borrow_mut().adjustments.insert(expr.hir_id.local_id, adjustments);
             }
 
             match expr.node {
                 hir::ExprIndex(ref base_expr, ref index_expr) => {
-                    let index_expr_ty = self.node_ty(index_expr.id);
+                    let index_expr_ty = self.node_ty(index_expr.hir_id);
                     self.convert_lvalue_op_to_mutable(
                         LvalueOp::Index, expr, base_expr, &[index_expr_ty]);
                 }
@@ -498,7 +501,7 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
         }
 
         let base_ty = self.tables.borrow().expr_adjustments(base_expr).last()
-            .map_or_else(|| self.node_ty(expr.id), |adj| adj.target);
+            .map_or_else(|| self.node_ty(expr.hir_id), |adj| adj.target);
         let base_ty = self.resolve_type_vars_if_possible(&base_ty);
 
         // Need to deref because overloaded lvalue ops take self by-reference.
@@ -513,7 +516,7 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
             None => return self.tcx.sess.delay_span_bug(expr.span, "re-trying op failed")
         };
         debug!("convert_lvalue_op_to_mutable: method={:?}", method);
-        self.write_method_call((expr.id, expr.hir_id), method);
+        self.write_method_call(expr.hir_id, method);
 
         let (region, mutbl) = if let ty::TyRef(r, mt) = method.sig.inputs()[0].sty {
             (r, mt.mutbl)
@@ -523,8 +526,11 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
 
         // Convert the autoref in the base expr to mutable with the correct
         // region and mutability.
-        let base_expr_ty = self.node_ty(base_expr.id);
-        if let Some(adjustments) = self.tables.borrow_mut().adjustments.get_mut(&base_expr.id) {
+        let base_expr_ty = self.node_ty(base_expr.hir_id);
+        if let Some(adjustments) = self.tables
+                                       .borrow_mut()
+                                       .adjustments
+                                       .get_mut(&base_expr.hir_id.local_id) {
             let mut source = base_expr_ty;
             for adjustment in &mut adjustments[..] {
                 if let Adjust::Borrow(AutoBorrow::Ref(..)) = adjustment.kind {

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -451,8 +451,8 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
             // tables borrowed during (`deref_mut`) method resolution.
             let previous_adjustments = self.tables
                                            .borrow_mut()
-                                           .adjustments
-                                           .remove(&expr.hir_id.local_id);
+                                           .adjustments_mut()
+                                           .remove(expr.hir_id);
             if let Some(mut adjustments) = previous_adjustments {
                 let pref = LvaluePreference::PreferMutLvalue;
                 for adjustment in &mut adjustments {
@@ -469,7 +469,7 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
                     }
                     source = adjustment.target;
                 }
-                self.tables.borrow_mut().adjustments.insert(expr.hir_id.local_id, adjustments);
+                self.tables.borrow_mut().adjustments_mut().insert(expr.hir_id, adjustments);
             }
 
             match expr.node {
@@ -529,8 +529,8 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
         let base_expr_ty = self.node_ty(base_expr.hir_id);
         if let Some(adjustments) = self.tables
                                        .borrow_mut()
-                                       .adjustments
-                                       .get_mut(&base_expr.hir_id.local_id) {
+                                       .adjustments_mut()
+                                       .get_mut(base_expr.hir_id) {
             let mut source = base_expr_ty;
             for adjustment in &mut adjustments[..] {
                 if let Adjust::Borrow(AutoBorrow::Ref(..)) = adjustment.kind {

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -829,9 +829,7 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
             };
 
             let closure_kind = {
-                let tables = self.tables.borrow();
-                tables.validate_hir_id(closure_id);
-                match tables.closure_kinds.get(&closure_id.local_id) {
+                match self.tables.borrow().closure_kinds().get(closure_id) {
                     Some(&(k, _)) => k,
                     None => {
                         return Err(MethodError::ClosureAmbiguity(trait_def_id));

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1028,7 +1028,12 @@ fn check_fn<'a, 'gcx, 'tcx>(inherited: &'a Inherited<'a, 'gcx, 'tcx>,
         fcx.write_ty(arg.hir_id, arg_ty);
     }
 
-    inherited.tables.borrow_mut().liberated_fn_sigs.insert(fn_id, fn_sig);
+    {
+        let mut inh_tables = inherited.tables.borrow_mut();
+        let fn_hir_id = fcx.tcx.hir.node_to_hir_id(fn_id);
+        inh_tables.validate_hir_id(fn_hir_id);
+        inh_tables.liberated_fn_sigs.insert(fn_hir_id.local_id, fn_sig);
+    }
 
     fcx.check_return_expr(&body.value);
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -901,7 +901,7 @@ fn typeck_tables_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     // Consistency check our TypeckTables instance can hold all ItemLocalIds
     // it will need to hold.
     assert_eq!(tables.local_id_root,
-               DefId::local(tcx.hir.definitions().node_to_hir_id(id).owner));
+               Some(DefId::local(tcx.hir.definitions().node_to_hir_id(id).owner)));
     tables
 }
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3407,7 +3407,10 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     let fru_field_types = adt.struct_variant().fields.iter().map(|f| {
                         self.normalize_associated_types_in(expr.span, &f.ty(self.tcx, substs))
                     }).collect();
-                    self.tables.borrow_mut().fru_field_types.insert(expr.id, fru_field_types);
+
+                    let mut tables = self.tables.borrow_mut();
+                    tables.validate_hir_id(expr.hir_id);
+                    tables.fru_field_types.insert(expr.hir_id.local_id, fru_field_types);
                 }
                 _ => {
                     span_err!(self.tcx.sess, base_expr.span, E0436,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -743,7 +743,8 @@ fn closure_kind<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                           def_id: DefId)
                           -> ty::ClosureKind {
     let node_id = tcx.hir.as_local_node_id(def_id).unwrap();
-    tcx.typeck_tables_of(def_id).closure_kinds[&node_id].0
+    let hir_id = tcx.hir.node_to_hir_id(node_id);
+    tcx.typeck_tables_of(def_id).closure_kinds[&hir_id.local_id].0
 }
 
 fn adt_destructor<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -210,11 +210,13 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         // some cases applied on the RHS, on top of which we need
                         // to autoref, which is not allowed by apply_adjustments.
                         // self.apply_adjustments(rhs_expr, vec![autoref]);
-                        self.tables.borrow_mut().adjustments.entry(rhs_expr.id)
+                        let mut tables = self.tables.borrow_mut();
+                        tables.validate_hir_id(rhs_expr.hir_id);
+                        tables.adjustments.entry(rhs_expr.hir_id.local_id)
                             .or_insert(vec![]).push(autoref);
                     }
                 }
-                self.write_method_call((expr.id, expr.hir_id), method);
+                self.write_method_call(expr.hir_id, method);
 
                 method.sig.output()
             }
@@ -340,7 +342,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         assert!(op.is_by_value());
         match self.lookup_op_method(operand_ty, &[], Op::Unary(op, ex.span)) {
             Ok(method) => {
-                self.write_method_call((ex.id, ex.hir_id), method);
+                self.write_method_call(ex.hir_id, method);
                 method.sig.output()
             }
             Err(()) => {

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -210,10 +210,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         // some cases applied on the RHS, on top of which we need
                         // to autoref, which is not allowed by apply_adjustments.
                         // self.apply_adjustments(rhs_expr, vec![autoref]);
-                        let mut tables = self.tables.borrow_mut();
-                        tables.validate_hir_id(rhs_expr.hir_id);
-                        tables.adjustments.entry(rhs_expr.hir_id.local_id)
-                            .or_insert(vec![]).push(autoref);
+                        self.tables
+                            .borrow_mut()
+                            .adjustments_mut()
+                            .entry(rhs_expr.hir_id)
+                            .or_insert(vec![])
+                            .push(autoref);
                     }
                 }
                 self.write_method_call(expr.hir_id, method);

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -214,7 +214,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                             .or_insert(vec![]).push(autoref);
                     }
                 }
-                self.write_method_call(expr.id, method);
+                self.write_method_call((expr.id, expr.hir_id), method);
 
                 method.sig.output()
             }
@@ -340,7 +340,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         assert!(op.is_by_value());
         match self.lookup_op_method(operand_ty, &[], Op::Unary(op, ex.span)) {
             Ok(method) => {
-                self.write_method_call(ex.id, method);
+                self.write_method_call((ex.id, ex.hir_id), method);
                 method.sig.output()
             }
             Err(()) => {

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -309,8 +309,10 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
         let old_call_site_scope = self.set_call_site_scope(Some(call_site));
 
         let fn_sig = {
-            let fn_sig_map = &self.tables.borrow().liberated_fn_sigs;
-            match fn_sig_map.get(&id) {
+            let tables = self.tables.borrow();
+            let fn_hir_id = self.tcx.hir.node_to_hir_id(id);
+            tables.validate_hir_id(fn_hir_id);
+            match tables.liberated_fn_sigs.get(&fn_hir_id.local_id) {
                 Some(f) => f.clone(),
                 None => {
                     bug!("No fn-sig entry for id={}", id);

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -284,7 +284,7 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
     }
 
     /// Try to resolve the type for the given node.
-    fn resolve_node_type(&self, id: ast::NodeId) -> Ty<'tcx> {
+    fn resolve_node_type(&self, id: hir::HirId) -> Ty<'tcx> {
         let t = self.node_ty(id);
         self.resolve_type(t)
     }
@@ -338,8 +338,9 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
         debug!("visit_fn_body body.id {:?} call_site_scope: {:?}",
                body.id(), call_site_scope);
         let call_site_region = self.tcx.mk_region(ty::ReScope(call_site_scope));
+        let body_hir_id = self.tcx.hir.node_to_hir_id(body_id.node_id);
         self.type_of_node_must_outlive(infer::CallReturn(span),
-                                       body_id.node_id,
+                                       body_hir_id,
                                        call_site_region);
 
         self.region_bound_pairs.truncate(old_region_bounds_pairs_len);
@@ -613,9 +614,10 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
             let var_region = self.tcx.mk_region(ty::ReScope(var_scope));
 
             let origin = infer::BindingTypeIsNotValidAtDecl(span);
-            self.type_of_node_must_outlive(origin, id, var_region);
+            let hir_id = self.tcx.hir.node_to_hir_id(id);
+            self.type_of_node_must_outlive(origin, hir_id, var_region);
 
-            let typ = self.resolve_node_type(id);
+            let typ = self.resolve_node_type(hir_id);
             let _ = dropck::check_safety_of_destructor_if_necessary(
                 self, typ, span, var_scope);
         })
@@ -664,7 +666,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for RegionCtxt<'a, 'gcx, 'tcx> {
 
         // No matter what, the type of each expression must outlive the
         // scope of that expression. This also guarantees basic WF.
-        let expr_ty = self.resolve_node_type(expr.id);
+        let expr_ty = self.resolve_node_type(expr.hir_id);
         // the region corresponding to this expression
         let expr_region = self.tcx.node_scope_region(expr.id);
         self.type_must_outlive(infer::ExprTypeIsNotInScope(expr_ty, expr.span),
@@ -686,7 +688,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for RegionCtxt<'a, 'gcx, 'tcx> {
                     infer::ParameterOrigin::OverloadedOperator
             };
 
-            let substs = self.tables.borrow().node_substs(expr.id);
+            let substs = self.tables.borrow().node_substs(expr.hir_id);
             self.substs_wf_in_scope(origin, substs, expr.span, expr_region);
             // Arguments (sub-expressions) are checked via `constrain_call`, below.
         }
@@ -709,7 +711,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for RegionCtxt<'a, 'gcx, 'tcx> {
                expr, self.repeating_scope);
         match expr.node {
             hir::ExprPath(_) => {
-                let substs = self.tables.borrow().node_substs(expr.id);
+                let substs = self.tables.borrow().node_substs(expr.hir_id);
                 let origin = infer::ParameterOrigin::Path;
                 self.substs_wf_in_scope(origin, substs, expr.span, expr_region);
             }
@@ -718,7 +720,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for RegionCtxt<'a, 'gcx, 'tcx> {
                 if is_method_call {
                     self.constrain_call(expr, Some(&callee), args.iter().map(|e| &*e));
                 } else {
-                    self.constrain_callee(callee.id, expr, &callee);
+                    self.constrain_callee(&callee);
                     self.constrain_call(expr, None, args.iter().map(|e| &*e));
                 }
 
@@ -812,7 +814,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for RegionCtxt<'a, 'gcx, 'tcx> {
                 // adjustments*.
                 //
                 // FIXME(#6268) nested method calls requires that this rule change
-                let ty0 = self.resolve_node_type(expr.id);
+                let ty0 = self.resolve_node_type(expr.hir_id);
                 self.type_must_outlive(infer::AddrOf(expr.span), ty0, expr_region);
                 intravisit::walk_expr(self, expr);
             }
@@ -849,7 +851,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for RegionCtxt<'a, 'gcx, 'tcx> {
                        ret_expr.id, call_site_scope);
                 let call_site_region = self.tcx.mk_region(ty::ReScope(call_site_scope.unwrap()));
                 self.type_of_node_must_outlive(infer::CallReturn(ret_expr.span),
-                                               ret_expr.id,
+                                               ret_expr.hir_id,
                                                call_site_region);
                 intravisit::walk_expr(self, expr);
             }
@@ -870,8 +872,8 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
                cast_expr,
                source_expr);
 
-        let source_ty = self.resolve_node_type(source_expr.id);
-        let target_ty = self.resolve_node_type(cast_expr.id);
+        let source_ty = self.resolve_node_type(source_expr.hir_id);
+        let target_ty = self.resolve_node_type(cast_expr.hir_id);
 
         self.walk_cast(cast_expr, source_ty, target_ty);
     }
@@ -915,11 +917,8 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
         self.set_repeating_scope(repeating_scope);
     }
 
-    fn constrain_callee(&mut self,
-                        callee_id: ast::NodeId,
-                        _call_expr: &hir::Expr,
-                        _callee_expr: &hir::Expr) {
-        let callee_ty = self.resolve_node_type(callee_id);
+    fn constrain_callee(&mut self, callee_expr: &hir::Expr) {
+        let callee_ty = self.resolve_node_type(callee_expr.hir_id);
         match callee_ty.sty {
             ty::TyFnDef(..) | ty::TyFnPtr(_) => { }
             _ => {
@@ -962,14 +961,16 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
             // ensure that any regions appearing in the argument type are
             // valid for at least the lifetime of the function:
             self.type_of_node_must_outlive(infer::CallArg(arg_expr.span),
-                                           arg_expr.id, callee_region);
+                                           arg_expr.hir_id,
+                                           callee_region);
         }
 
         // as loop above, but for receiver
         if let Some(r) = receiver {
             debug!("receiver: {:?}", r);
             self.type_of_node_must_outlive(infer::CallRcvr(r.span),
-                                           r.id, callee_region);
+                                           r.hir_id,
+                                           callee_region);
         }
     }
 
@@ -1038,7 +1039,8 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
                 //
                 // FIXME(#6268) remove to support nested method calls
                 self.type_of_node_must_outlive(infer::AutoBorrow(expr.span),
-                                               expr.id, expr_region);
+                                               expr.hir_id,
+                                               expr_region);
             }
 
             cmt = self.with_mc(|mc| mc.cat_expr_adjusted(expr, cmt, &adjustment))?;
@@ -1109,21 +1111,27 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
     /// adjustments) are valid for at least `minimum_lifetime`
     fn type_of_node_must_outlive(&mut self,
         origin: infer::SubregionOrigin<'tcx>,
-        id: ast::NodeId,
+        hir_id: hir::HirId,
         minimum_lifetime: ty::Region<'tcx>)
     {
         // Try to resolve the type.  If we encounter an error, then typeck
         // is going to fail anyway, so just stop here and let typeck
         // report errors later on in the writeback phase.
-        let ty0 = self.resolve_node_type(id);
-        let ty = self.tables.borrow().adjustments.get(&id)
-            .and_then(|adj| adj.last())
-            .map_or(ty0, |adj| adj.target);
+        let ty0 = self.resolve_node_type(hir_id);
+
+        let ty = {
+            let tables = self.tables.borrow();
+            tables.validate_hir_id(hir_id);
+            tables.adjustments
+                  .get(&hir_id.local_id)
+                  .and_then(|adj| adj.last())
+                  .map_or(ty0, |adj| adj.target)
+        };
         let ty = self.resolve_type(ty);
         debug!("constrain_regions_in_type_of_node(\
-                ty={}, ty0={}, id={}, minimum_lifetime={:?})",
+                ty={}, ty0={}, id={:?}, minimum_lifetime={:?})",
                 ty,  ty0,
-               id, minimum_lifetime);
+                hir_id, minimum_lifetime);
         self.type_must_outlive(origin, ty, minimum_lifetime);
     }
 
@@ -1137,7 +1145,7 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
 
         debug!("link_addr_of: cmt={:?}", cmt);
 
-        self.link_region_from_node_type(expr.span, expr.id, mutability, cmt);
+        self.link_region_from_node_type(expr.span, expr.hir_id, mutability, cmt);
     }
 
     /// Computes the guarantors for any ref bindings in a `let` and
@@ -1173,7 +1181,7 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
     fn link_fn_args(&self, body_scope: CodeExtent, args: &[hir::Arg]) {
         debug!("regionck::link_fn_args(body_scope={:?})", body_scope);
         for arg in args {
-            let arg_ty = self.node_ty(arg.id);
+            let arg_ty = self.node_ty(arg.hir_id);
             let re_scope = self.tcx.mk_region(ty::ReScope(body_scope));
             let arg_cmt = self.with_mc(|mc| {
                 mc.cat_rvalue(arg.id, arg.pat.span, re_scope, arg_ty)
@@ -1200,7 +1208,7 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
                         let bm = *mc.tables.pat_binding_modes.get(&sub_pat.id)
                                                              .expect("missing binding mode");
                         if let ty::BindByReference(mutbl) = bm {
-                            self.link_region_from_node_type(sub_pat.span, sub_pat.id,
+                            self.link_region_from_node_type(sub_pat.span, sub_pat.hir_id,
                                                             mutbl, sub_cmt);
                         }
                     }
@@ -1236,7 +1244,7 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
     /// which must be some reference (`&T`, `&str`, etc).
     fn link_region_from_node_type(&self,
                                   span: Span,
-                                  id: ast::NodeId,
+                                  id: hir::HirId,
                                   mutbl: hir::Mutability,
                                   cmt_borrowed: mc::cmt<'tcx>) {
         debug!("link_region_from_node_type(id={:?}, mutbl={:?}, cmt_borrowed={:?})",

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -1205,7 +1205,8 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
                 match sub_pat.node {
                     // `ref x` pattern
                     PatKind::Binding(..) => {
-                        let bm = *mc.tables.pat_binding_modes.get(&sub_pat.id)
+                        mc.tables.validate_hir_id(sub_pat.hir_id);
+                        let bm = *mc.tables.pat_binding_modes.get(&sub_pat.hir_id.local_id)
                                                              .expect("missing binding mode");
                         if let ty::BindByReference(mutbl) = bm {
                             self.link_region_from_node_type(sub_pat.span, sub_pat.hir_id,

--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -103,8 +103,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
         let infer_kind = match self.tables
                                    .borrow_mut()
-                                   .closure_kinds
-                                   .entry(closure_hir_id.local_id) {
+                                   .closure_kinds_mut()
+                                   .entry(closure_hir_id) {
             Entry::Occupied(_) => false,
             Entry::Vacant(entry) => {
                 debug!("check_closure: adding closure {:?} as Fn", closure_node_id);
@@ -162,8 +162,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                             .remove(&closure_def_id.index) {
                     self.tables
                         .borrow_mut()
-                        .closure_kinds
-                        .insert(closure_hir_id.local_id, kind);
+                        .closure_kinds_mut()
+                        .insert(closure_hir_id, kind);
                 }
             }
             self.tables.borrow_mut().upvar_capture_map.extend(
@@ -482,9 +482,7 @@ impl<'a, 'gcx, 'tcx> InferBorrowKind<'a, 'gcx, 'tcx> {
         let closure_kind = self.adjust_closure_kinds.get(&closure_id).cloned()
             .or_else(|| {
                 let closure_id = self.fcx.tcx.hir.def_index_to_hir_id(closure_id);
-                let fcx_tables = self.fcx.tables.borrow();
-                fcx_tables.validate_hir_id(closure_id);
-                fcx_tables.closure_kinds.get(&closure_id.local_id).cloned()
+                self.fcx.tables.borrow().closure_kinds().get(closure_id).cloned()
             });
 
         if let Some((existing_kind, _)) = closure_kind {

--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -50,8 +50,9 @@ use rustc::infer::UpvarRegion;
 use syntax::ast;
 use syntax_pos::Span;
 use rustc::hir;
+use rustc::hir::def_id::DefIndex;
 use rustc::hir::intravisit::{self, Visitor, NestedVisitorMap};
-use rustc::util::nodemap::NodeMap;
+use rustc::util::nodemap::FxHashMap;
 
 use std::collections::hash_map::Entry;
 
@@ -90,7 +91,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for InferBorrowKindVisitor<'a, 'gcx, 'tcx> {
 
 impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
     fn analyze_closure(&self,
-                       (id, hir_id): (ast::NodeId, hir::HirId),
+                       (closure_node_id, closure_hir_id): (ast::NodeId, hir::HirId),
                        span: Span,
                        body: &hir::Body,
                        capture_clause: hir::CaptureClause) {
@@ -98,23 +99,29 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
          * Analysis starting point.
          */
 
-        debug!("analyze_closure(id={:?}, body.id={:?})", id, body.id());
+        debug!("analyze_closure(id={:?}, body.id={:?})", closure_node_id, body.id());
 
-        let infer_kind = match self.tables.borrow_mut().closure_kinds.entry(hir_id.local_id) {
+        let infer_kind = match self.tables
+                                   .borrow_mut()
+                                   .closure_kinds
+                                   .entry(closure_hir_id.local_id) {
             Entry::Occupied(_) => false,
             Entry::Vacant(entry) => {
-                debug!("check_closure: adding closure {:?} as Fn", id);
+                debug!("check_closure: adding closure {:?} as Fn", closure_node_id);
                 entry.insert((ty::ClosureKind::Fn, None));
                 true
             }
         };
 
-        self.tcx.with_freevars(id, |freevars| {
+        let closure_def_id = self.tcx.hir.local_def_id(closure_node_id);
+
+        self.tcx.with_freevars(closure_node_id, |freevars| {
             for freevar in freevars {
-                let def_id = freevar.def.def_id();
-                let var_node_id = self.tcx.hir.as_local_node_id(def_id).unwrap();
-                let upvar_id = ty::UpvarId { var_id: var_node_id,
-                                             closure_expr_id: id };
+                let var_def_id = freevar.def.def_id();
+                let upvar_id = ty::UpvarId {
+                    var_id: var_def_id.index,
+                    closure_expr_id: closure_def_id.index,
+                };
                 debug!("seed upvar_id {:?}", upvar_id);
 
                 let capture_kind = match capture_clause {
@@ -139,7 +146,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             let region_maps = &self.tcx.region_maps(body_owner_def_id);
             let mut delegate = InferBorrowKind {
                 fcx: self,
-                adjust_closure_kinds: NodeMap(),
+                adjust_closure_kinds: FxHashMap(),
                 adjust_upvar_captures: ty::UpvarCaptureMap::default(),
             };
             euv::ExprUseVisitor::with_infer(&mut delegate,
@@ -151,8 +158,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
             // Write the adjusted values back into the main tables.
             if infer_kind {
-                if let Some(kind) = delegate.adjust_closure_kinds.remove(&id) {
-                    self.tables.borrow_mut().closure_kinds.insert(hir_id.local_id, kind);
+                if let Some(kind) = delegate.adjust_closure_kinds
+                                            .remove(&closure_def_id.index) {
+                    self.tables
+                        .borrow_mut()
+                        .closure_kinds
+                        .insert(closure_hir_id.local_id, kind);
                 }
             }
             self.tables.borrow_mut().upvar_capture_map.extend(
@@ -172,20 +183,20 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         // inference algorithm will reject it).
 
         // Extract the type variables UV0...UVn.
-        let (def_id, closure_substs) = match self.node_ty(hir_id).sty {
+        let (def_id, closure_substs) = match self.node_ty(closure_hir_id).sty {
             ty::TyClosure(def_id, substs) => (def_id, substs),
             ref t => {
                 span_bug!(
                     span,
                     "type of closure expr {:?} is not a closure {:?}",
-                    id, t);
+                    closure_node_id, t);
             }
         };
 
         // Equate the type variables with the actual types.
-        let final_upvar_tys = self.final_upvar_tys(id);
+        let final_upvar_tys = self.final_upvar_tys(closure_node_id);
         debug!("analyze_closure: id={:?} closure_substs={:?} final_upvar_tys={:?}",
-               id, closure_substs, final_upvar_tys);
+               closure_node_id, closure_substs, final_upvar_tys);
         for (upvar_ty, final_upvar_ty) in
             closure_substs.upvar_tys(def_id, self.tcx).zip(final_upvar_tys)
         {
@@ -195,7 +206,6 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         // If we are also inferred the closure kind here,
         // process any deferred resolutions.
         if infer_kind {
-            let closure_def_id = self.tcx.hir.local_def_id(id);
             let deferred_call_resolutions =
                 self.remove_deferred_call_resolutions(closure_def_id);
             for deferred_call_resolution in deferred_call_resolutions {
@@ -212,19 +222,21 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         // This may change if abstract return types of some sort are
         // implemented.
         let tcx = self.tcx;
+        let closure_def_index = tcx.hir.local_def_id(closure_id).index;
+
         tcx.with_freevars(closure_id, |freevars| {
             freevars.iter().map(|freevar| {
-                let def_id = freevar.def.def_id();
-                let var_id = tcx.hir.as_local_node_id(def_id).unwrap();
-                let freevar_ty = self.node_ty(tcx.hir.node_to_hir_id(var_id));
+                let var_def_id = freevar.def.def_id();
+                let var_node_id = tcx.hir.as_local_node_id(var_def_id).unwrap();
+                let freevar_ty = self.node_ty(tcx.hir.node_to_hir_id(var_node_id));
                 let upvar_id = ty::UpvarId {
-                    var_id: var_id,
-                    closure_expr_id: closure_id
+                    var_id: var_def_id.index,
+                    closure_expr_id: closure_def_index,
                 };
                 let capture = self.tables.borrow().upvar_capture(upvar_id);
 
                 debug!("var_id={:?} freevar_ty={:?} capture={:?}",
-                       var_id, freevar_ty, capture);
+                       var_node_id, freevar_ty, capture);
 
                 match capture {
                     ty::UpvarCapture::ByValue => freevar_ty,
@@ -242,7 +254,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
 struct InferBorrowKind<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
     fcx: &'a FnCtxt<'a, 'gcx, 'tcx>,
-    adjust_closure_kinds: NodeMap<(ty::ClosureKind, Option<(Span, ast::Name)>)>,
+    adjust_closure_kinds: FxHashMap<DefIndex, (ty::ClosureKind, Option<(Span, ast::Name)>)>,
     adjust_upvar_captures: ty::UpvarCaptureMap<'tcx>,
 }
 
@@ -281,7 +293,7 @@ impl<'a, 'gcx, 'tcx> InferBorrowKind<'a, 'gcx, 'tcx> {
                         self.adjust_closure_kind(upvar_id.closure_expr_id,
                                                  ty::ClosureKind::FnOnce,
                                                  guarantor.span,
-                                                 tcx.hir.name(upvar_id.var_id));
+                                                 var_name(tcx, upvar_id.var_id));
 
                         self.adjust_upvar_captures.insert(upvar_id, ty::UpvarCapture::ByValue);
                     }
@@ -295,7 +307,7 @@ impl<'a, 'gcx, 'tcx> InferBorrowKind<'a, 'gcx, 'tcx> {
                         self.adjust_closure_kind(upvar_id.closure_expr_id,
                                                  ty::ClosureKind::FnOnce,
                                                  guarantor.span,
-                                                 tcx.hir.name(upvar_id.var_id));
+                                                 var_name(tcx, upvar_id.var_id));
                     }
                     mc::NoteNone => {
                     }
@@ -400,7 +412,7 @@ impl<'a, 'gcx, 'tcx> InferBorrowKind<'a, 'gcx, 'tcx> {
                 self.adjust_closure_kind(upvar_id.closure_expr_id,
                                          ty::ClosureKind::FnMut,
                                          cmt.span,
-                                         tcx.hir.name(upvar_id.var_id));
+                                         var_name(tcx, upvar_id.var_id));
 
                 true
             }
@@ -411,7 +423,7 @@ impl<'a, 'gcx, 'tcx> InferBorrowKind<'a, 'gcx, 'tcx> {
                 self.adjust_closure_kind(upvar_id.closure_expr_id,
                                          ty::ClosureKind::FnMut,
                                          cmt.span,
-                                         tcx.hir.name(upvar_id.var_id));
+                                         var_name(tcx, upvar_id.var_id));
 
                 true
             }
@@ -460,23 +472,23 @@ impl<'a, 'gcx, 'tcx> InferBorrowKind<'a, 'gcx, 'tcx> {
     }
 
     fn adjust_closure_kind(&mut self,
-                           closure_id: ast::NodeId,
+                           closure_id: DefIndex,
                            new_kind: ty::ClosureKind,
                            upvar_span: Span,
                            var_name: ast::Name) {
-        debug!("adjust_closure_kind(closure_id={}, new_kind={:?}, upvar_span={:?}, var_name={})",
+        debug!("adjust_closure_kind(closure_id={:?}, new_kind={:?}, upvar_span={:?}, var_name={})",
                closure_id, new_kind, upvar_span, var_name);
 
         let closure_kind = self.adjust_closure_kinds.get(&closure_id).cloned()
             .or_else(|| {
-                let closure_id = self.fcx.tcx.hir.node_to_hir_id(closure_id);
+                let closure_id = self.fcx.tcx.hir.def_index_to_hir_id(closure_id);
                 let fcx_tables = self.fcx.tables.borrow();
                 fcx_tables.validate_hir_id(closure_id);
                 fcx_tables.closure_kinds.get(&closure_id.local_id).cloned()
             });
 
         if let Some((existing_kind, _)) = closure_kind {
-            debug!("adjust_closure_kind: closure_id={}, existing_kind={:?}, new_kind={:?}",
+            debug!("adjust_closure_kind: closure_id={:?}, existing_kind={:?}, new_kind={:?}",
                    closure_id, existing_kind, new_kind);
 
             match (existing_kind, new_kind) {
@@ -565,4 +577,9 @@ impl<'a, 'gcx, 'tcx> euv::Delegate<'tcx> for InferBorrowKind<'a, 'gcx, 'tcx> {
 
         self.adjust_upvar_borrow_kind_for_mut(assignee_cmt);
     }
+}
+
+fn var_name(tcx: ty::TyCtxt, var_def_index: DefIndex) -> ast::Name {
+    let var_node_id = tcx.hir.def_index_to_node_id(var_def_index);
+    tcx.hir.name(var_node_id)
 }

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -348,9 +348,16 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
     }
 
     fn visit_liberated_fn_sigs(&mut self) {
-        for (&node_id, fn_sig) in self.fcx.tables.borrow().liberated_fn_sigs.iter() {
-            let fn_sig = self.resolve(fn_sig, &node_id);
-            self.tables.liberated_fn_sigs.insert(node_id, fn_sig.clone());
+        let fcx_tables = self.fcx.tables.borrow();
+        debug_assert_eq!(fcx_tables.local_id_root, self.tables.local_id_root);
+
+        for (&local_id, fn_sig) in fcx_tables.liberated_fn_sigs.iter() {
+            let hir_id = hir::HirId {
+                owner: fcx_tables.local_id_root.index,
+                local_id,
+            };
+            let fn_sig = self.resolve(fn_sig, &hir_id);
+            self.tables.liberated_fn_sigs.insert(local_id, fn_sig.clone());
         }
     }
 

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -186,9 +186,14 @@ impl<'cx, 'gcx, 'tcx> Visitor<'gcx> for WritebackCx<'cx, 'gcx, 'tcx> {
     fn visit_pat(&mut self, p: &'gcx hir::Pat) {
         match p.node {
             hir::PatKind::Binding(..) => {
-                let bm = *self.fcx.tables.borrow().pat_binding_modes.get(&p.id)
-                                                                    .expect("missing binding mode");
-                self.tables.pat_binding_modes.insert(p.id, bm);
+                let bm = {
+                    let fcx_tables = self.fcx.tables.borrow();
+                    fcx_tables.validate_hir_id(p.hir_id);
+                    *fcx_tables.pat_binding_modes.get(&p.hir_id.local_id)
+                                                 .expect("missing binding mode")
+                };
+                self.tables.validate_hir_id(p.hir_id);
+                self.tables.pat_binding_modes.insert(p.hir_id.local_id, bm);
             }
             _ => {}
         };

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -362,9 +362,16 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
     }
 
     fn visit_fru_field_types(&mut self) {
-        for (&node_id, ftys) in self.fcx.tables.borrow().fru_field_types.iter() {
-            let ftys = self.resolve(ftys, &node_id);
-            self.tables.fru_field_types.insert(node_id, ftys);
+        let fcx_tables = self.fcx.tables.borrow();
+        debug_assert_eq!(fcx_tables.local_id_root, self.tables.local_id_root);
+
+        for (&local_id, ftys) in fcx_tables.fru_field_types.iter() {
+            let hir_id = hir::HirId {
+                owner: fcx_tables.local_id_root.index,
+                local_id,
+            };
+            let ftys = self.resolve(ftys, &hir_id);
+            self.tables.fru_field_types.insert(local_id, ftys);
         }
     }
 

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -81,7 +81,7 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
 
         WritebackCx {
             fcx: fcx,
-            tables: ty::TypeckTables::empty(DefId::local(owner.owner)),
+            tables: ty::TypeckTables::empty(Some(DefId::local(owner.owner))),
             body: body
         }
     }
@@ -229,10 +229,11 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
     fn visit_closures(&mut self) {
         let fcx_tables = self.fcx.tables.borrow();
         debug_assert_eq!(fcx_tables.local_id_root, self.tables.local_id_root);
+        let common_local_id_root = fcx_tables.local_id_root.unwrap();
 
         for (&id, closure_ty) in fcx_tables.closure_tys().iter() {
             let hir_id = hir::HirId {
-                owner: fcx_tables.local_id_root.index,
+                owner: common_local_id_root.index,
                 local_id: id,
             };
             let closure_ty = self.resolve(closure_ty, &hir_id);
@@ -241,7 +242,7 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
 
         for (&id, &closure_kind) in fcx_tables.closure_kinds().iter() {
             let hir_id = hir::HirId {
-                owner: fcx_tables.local_id_root.index,
+                owner: common_local_id_root.index,
                 local_id: id,
             };
             self.tables.closure_kinds_mut().insert(hir_id, closure_kind);
@@ -251,11 +252,13 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
     fn visit_cast_types(&mut self) {
         let fcx_tables = self.fcx.tables.borrow();
         let fcx_cast_kinds = fcx_tables.cast_kinds();
+        debug_assert_eq!(fcx_tables.local_id_root, self.tables.local_id_root);
         let mut self_cast_kinds = self.tables.cast_kinds_mut();
+        let common_local_id_root = fcx_tables.local_id_root.unwrap();
 
         for (&local_id, &cast_kind) in fcx_cast_kinds.iter() {
             let hir_id = hir::HirId {
-                owner: fcx_tables.local_id_root.index,
+                owner: common_local_id_root.index,
                 local_id,
             };
             self_cast_kinds.insert(hir_id, cast_kind);
@@ -357,10 +360,11 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
     fn visit_liberated_fn_sigs(&mut self) {
         let fcx_tables = self.fcx.tables.borrow();
         debug_assert_eq!(fcx_tables.local_id_root, self.tables.local_id_root);
+        let common_local_id_root = fcx_tables.local_id_root.unwrap();
 
         for (&local_id, fn_sig) in fcx_tables.liberated_fn_sigs().iter() {
             let hir_id = hir::HirId {
-                owner: fcx_tables.local_id_root.index,
+                owner: common_local_id_root.index,
                 local_id,
             };
             let fn_sig = self.resolve(fn_sig, &hir_id);
@@ -371,10 +375,11 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
     fn visit_fru_field_types(&mut self) {
         let fcx_tables = self.fcx.tables.borrow();
         debug_assert_eq!(fcx_tables.local_id_root, self.tables.local_id_root);
+        let common_local_id_root = fcx_tables.local_id_root.unwrap();
 
         for (&local_id, ftys) in fcx_tables.fru_field_types().iter() {
             let hir_id = hir::HirId {
-                owner: fcx_tables.local_id_root.index,
+                owner: common_local_id_root.index,
                 local_id,
             };
             let ftys = self.resolve(ftys, &hir_id);

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -14,6 +14,7 @@
 
 use check::FnCtxt;
 use rustc::hir;
+use rustc::hir::def_id::DefId;
 use rustc::hir::intravisit::{self, Visitor, NestedVisitorMap};
 use rustc::infer::{InferCtxt};
 use rustc::ty::{self, Ty, TyCtxt};
@@ -34,7 +35,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
         let mut wbcx = WritebackCx::new(self, body);
         for arg in &body.arguments {
-            wbcx.visit_node_id(arg.pat.span, arg.id);
+            wbcx.visit_node_id(arg.pat.span, (arg.id, arg.hir_id));
         }
         wbcx.visit_body(body);
         wbcx.visit_upvar_borrow_map();
@@ -74,10 +75,13 @@ struct WritebackCx<'cx, 'gcx: 'cx+'tcx, 'tcx: 'cx> {
 
 impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
     fn new(fcx: &'cx FnCtxt<'cx, 'gcx, 'tcx>, body: &'gcx hir::Body)
-        -> WritebackCx<'cx, 'gcx, 'tcx> {
+        -> WritebackCx<'cx, 'gcx, 'tcx>
+    {
+        let owner = fcx.tcx.hir.definitions().node_to_hir_id(body.id().node_id);
+
         WritebackCx {
             fcx: fcx,
-            tables: ty::TypeckTables::empty(),
+            tables: ty::TypeckTables::empty(DefId::local(owner.owner)),
             body: body
         }
     }
@@ -105,7 +109,8 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
 
                 if inner_ty.is_scalar() {
                     let mut tables = self.fcx.tables.borrow_mut();
-                    tables.type_dependent_defs.remove(&e.id);
+                    tables.validate_hir_id(e.hir_id);
+                    tables.type_dependent_defs.remove(&e.hir_id.local_id);
                     tables.node_substs.remove(&e.id);
                 }
             }
@@ -119,7 +124,8 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
 
                 if lhs_ty.is_scalar() && rhs_ty.is_scalar() {
                     let mut tables = self.fcx.tables.borrow_mut();
-                    tables.type_dependent_defs.remove(&e.id);
+                    tables.validate_hir_id(e.hir_id);
+                    tables.type_dependent_defs.remove(&e.hir_id.local_id);
                     tables.node_substs.remove(&e.id);
 
                     match e.node {
@@ -157,12 +163,12 @@ impl<'cx, 'gcx, 'tcx> Visitor<'gcx> for WritebackCx<'cx, 'gcx, 'tcx> {
     fn visit_expr(&mut self, e: &'gcx hir::Expr) {
         self.fix_scalar_builtin_expr(e);
 
-        self.visit_node_id(e.span, e.id);
+        self.visit_node_id(e.span, (e.id, e.hir_id));
 
         if let hir::ExprClosure(_, _, body, _) = e.node {
             let body = self.fcx.tcx.hir.body(body);
             for arg in &body.arguments {
-                self.visit_node_id(e.span, arg.id);
+                self.visit_node_id(e.span, (arg.id, arg.hir_id));
             }
 
             self.visit_body(body);
@@ -172,7 +178,7 @@ impl<'cx, 'gcx, 'tcx> Visitor<'gcx> for WritebackCx<'cx, 'gcx, 'tcx> {
     }
 
     fn visit_block(&mut self, b: &'gcx hir::Block) {
-        self.visit_node_id(b.span, b.id);
+        self.visit_node_id(b.span, (b.id, b.hir_id));
         intravisit::walk_block(self, b);
     }
 
@@ -186,7 +192,7 @@ impl<'cx, 'gcx, 'tcx> Visitor<'gcx> for WritebackCx<'cx, 'gcx, 'tcx> {
             _ => {}
         };
 
-        self.visit_node_id(p.span, p.id);
+        self.visit_node_id(p.span, (p.id, p.hir_id));
         intravisit::walk_pat(self, p);
     }
 
@@ -277,10 +283,17 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
         }
     }
 
-    fn visit_node_id(&mut self, span: Span, node_id: ast::NodeId) {
-        // Export associated path extensions and method resultions.
-        if let Some(def) = self.fcx.tables.borrow_mut().type_dependent_defs.remove(&node_id) {
-            self.tables.type_dependent_defs.insert(node_id, def);
+    fn visit_node_id(&mut self,
+                     span: Span,
+                     (node_id, hir_id): (ast::NodeId, hir::HirId)) {
+        {
+            let mut fcx_tables = self.fcx.tables.borrow_mut();
+            fcx_tables.validate_hir_id(hir_id);
+            // Export associated path extensions and method resultions.
+            if let Some(def) = fcx_tables.type_dependent_defs.remove(&hir_id.local_id) {
+                self.tables.validate_hir_id(hir_id);
+                self.tables.type_dependent_defs.insert(hir_id.local_id, def);
+            }
         }
 
         // Resolve any borrowings for the node with id `node_id`

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -14,7 +14,7 @@
 
 use check::FnCtxt;
 use rustc::hir;
-use rustc::hir::def_id::DefId;
+use rustc::hir::def_id::{DefId, DefIndex};
 use rustc::hir::intravisit::{self, Visitor, NestedVisitorMap};
 use rustc::infer::{InferCtxt};
 use rustc::ty::{self, Ty, TyCtxt};
@@ -399,6 +399,13 @@ impl Locatable for Span {
 
 impl Locatable for ast::NodeId {
     fn to_span(&self, tcx: &TyCtxt) -> Span { tcx.hir.span(*self) }
+}
+
+impl Locatable for DefIndex {
+    fn to_span(&self, tcx: &TyCtxt) -> Span {
+        let node_id = tcx.hir.def_index_to_node_id(*self);
+        tcx.hir.span(node_id)
+    }
 }
 
 impl Locatable for hir::HirId {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1240,9 +1240,7 @@ fn fn_sig<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         }
 
         NodeExpr(&hir::Expr { node: hir::ExprClosure(..), hir_id, .. }) => {
-            let tables = tcx.typeck_tables_of(def_id);
-            tables.validate_hir_id(hir_id);
-            tables.closure_tys[&hir_id.local_id]
+            tcx.typeck_tables_of(def_id).closure_tys()[hir_id]
         }
 
         x => {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1187,7 +1187,8 @@ fn type_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
         NodeTy(&hir::Ty { node: TyImplTrait(..), .. }) => {
             let owner = tcx.hir.get_parent_did(node_id);
-            tcx.typeck_tables_of(owner).node_id_to_type(node_id)
+            let hir_id = tcx.hir.node_to_hir_id(node_id);
+            tcx.typeck_tables_of(owner).node_id_to_type(hir_id)
         }
 
         x => {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1239,8 +1239,10 @@ fn fn_sig<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             ))
         }
 
-        NodeExpr(&hir::Expr { node: hir::ExprClosure(..), .. }) => {
-            tcx.typeck_tables_of(def_id).closure_tys[&node_id]
+        NodeExpr(&hir::Expr { node: hir::ExprClosure(..), hir_id, .. }) => {
+            let tables = tcx.typeck_tables_of(def_id);
+            tables.validate_hir_id(hir_id);
+            tables.closure_tys[&hir_id.local_id]
         }
 
         x => {


### PR DESCRIPTION
This PR makes `TypeckTables` use `ItemLocalId` instead of `NodeId` as key. This is needed for incremental compilation -- for stable hashing and for being able to persist and reload these tables. The PR implements the most important part of https://github.com/rust-lang/rust/issues/40303. 

Some notes on the implementation:
* The PR adds the `HirId` to HIR nodes where needed (`Expr`, `Local`, `Block`, `Pat`) which obviates the need to store a `NodeId -> HirId` mapping in crate metadata. Thanks @eddyb for the suggestion! In the future the `HirId` should completely replace the `NodeId` in HIR nodes.
* Before something is read or stored in one of the various `TypeckTables` subtables, the entry's key is validated via the new `TypeckTables::validate_hir_id()` method. This makes sure that we are not mixing information from different items in a single table.

That last part could be made a bit nicer by either (a) new-typing the table-key and making `validate_hir_id()` the only way to convert a `HirId` to the new-typed key, or (b) just encapsulate sub-table access a little better. This PR, however, contents itself with not making things significantly worse.

Also, there's quite a bit of switching around between `NodeId`, `HirId`, and `DefIndex`. These conversions are cheap except for `HirId -> NodeId`, so if the valued reviewer finds such an instance in a performance critical place, please let me know. 

Ideally we convert more and more code from `NodeId` to `HirId` in the future so that there are no more `NodeId`s after HIR lowering anywhere. Then the amount of switching should be minimal again.

r? @eddyb, maybe?