### PR TITLE
Ignore tests that fail on stage1

### DIFF
--- a/src/test/compile-fail-fulldeps/proc-macro/attribute-with-error.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/attribute-with-error.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:attribute-with-error.rs
+// ignore-stage1
 
 #![feature(proc_macro)]
 

--- a/src/test/compile-fail-fulldeps/proc-macro/attributes-included.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/attributes-included.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:attributes-included.rs
+// ignore-stage1
 
 #![feature(proc_macro, rustc_attrs)]
 

--- a/src/test/compile-fail-fulldeps/proc-macro/derive-bad.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/derive-bad.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:derive-bad.rs
+// ignore-stage1
 
 #[macro_use]
 extern crate derive_bad;

--- a/src/test/compile-fail-fulldeps/proc-macro/expand-to-unstable-2.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/expand-to-unstable-2.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:derive-unstable-2.rs
+// ignore-stage1
 
 #![allow(warnings)]
 

--- a/src/test/compile-fail-fulldeps/proc-macro/expand-to-unstable.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/expand-to-unstable.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:derive-unstable.rs
+// ignore-stage1
 
 #![allow(warnings)]
 

--- a/src/test/compile-fail-fulldeps/proc-macro/issue-38586.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/issue-38586.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:issue_38586.rs
+// ignore-stage1
 
 #![feature(proc_macro)]
 

--- a/src/test/compile-fail-fulldeps/proc-macro/item-error.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/item-error.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:derive-b.rs
+// ignore-stage1
 
 #![allow(warnings)]
 

--- a/src/test/compile-fail-fulldeps/proc-macro/lints_in_proc_macros.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/lints_in_proc_macros.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:bang_proc_macro2.rs
+// ignore-stage1
 
 #![feature(proc_macro)]
 #![allow(unused_macros)]

--- a/src/test/compile-fail-fulldeps/proc-macro/proc-macro-attributes.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/proc-macro-attributes.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:derive-b.rs
+// ignore-stage1
 
 #![allow(warnings)]
 

--- a/src/test/run-make/issue-37839/Makefile
+++ b/src/test/run-make/issue-37839/Makefile
@@ -1,6 +1,12 @@
 -include ../tools.mk
 
+ifeq ($(findstring stage1,$(RUST_BUILD_STAGE)),stage1)
+# ignore stage1
+all:
+
+else
 all:
 	$(RUSTC) a.rs && $(RUSTC) b.rs
 	$(BARE_RUSTC) c.rs -L dependency=$(TMPDIR) --extern b=$(TMPDIR)/libb.rlib \
 		--out-dir=$(TMPDIR)
+endif

--- a/src/test/run-make/issue-37893/Makefile
+++ b/src/test/run-make/issue-37893/Makefile
@@ -1,4 +1,10 @@
 -include ../tools.mk
 
+ifeq ($(findstring stage1,$(RUST_BUILD_STAGE)),stage1)
+# ignore stage1
+all:
+
+else
 all:
 	$(RUSTC) a.rs && $(RUSTC) b.rs && $(RUSTC) c.rs
+endif

--- a/src/test/run-make/issue-38237/Makefile
+++ b/src/test/run-make/issue-38237/Makefile
@@ -1,5 +1,11 @@
 -include ../tools.mk
 
+ifeq ($(findstring stage1,$(RUST_BUILD_STAGE)),stage1)
+# ignore stage1
+all:
+
+else
 all:
 	$(RUSTC) foo.rs; $(RUSTC) bar.rs
 	$(RUSTDOC) baz.rs -L $(TMPDIR) -o $(TMPDIR)
+endif

--- a/src/test/run-make/llvm-pass/Makefile
+++ b/src/test/run-make/llvm-pass/Makefile
@@ -1,5 +1,10 @@
 -include ../tools.mk
 
+ifeq ($(findstring stage1,$(RUST_BUILD_STAGE)),stage1)
+# ignore stage1
+all:
+
+else
 # Windows doesn't correctly handle include statements with escaping paths,
 # so this test will not get run on Windows.
 ifdef IS_WINDOWS
@@ -14,4 +19,6 @@ $(TMPDIR)/libllvm-function-pass.o:
 
 $(TMPDIR)/libllvm-module-pass.o:
 	$(CXX) $(CFLAGS) $(LLVM_CXXFLAGS) -c llvm-module-pass.so.cc -o $(TMPDIR)/libllvm-module-pass.o
+endif
+
 endif

--- a/src/test/run-make/rustc-macro-dep-files/Makefile
+++ b/src/test/run-make/rustc-macro-dep-files/Makefile
@@ -1,6 +1,12 @@
 -include ../tools.mk
 
+ifeq ($(findstring stage1,$(RUST_BUILD_STAGE)),stage1)
+# ignore stage1
+all:
+
+else
 all:
 	$(RUSTC) foo.rs
 	$(RUSTC) bar.rs --emit dep-info
 	grep "proc-macro source" $(TMPDIR)/bar.d && exit 1 || exit 0
+endif

--- a/src/test/run-pass-fulldeps/issue-40663.rs
+++ b/src/test/run-pass-fulldeps/issue-40663.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:custom_derive_plugin.rs
+// ignore-stage1
 
 #![feature(plugin, custom_derive)]
 #![plugin(custom_derive_plugin)]

--- a/src/test/run-pass-fulldeps/proc-macro/add-impl.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/add-impl.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:add-impl.rs
+// ignore-stage1
 
 #[macro_use]
 extern crate add_impl;

--- a/src/test/run-pass-fulldeps/proc-macro/append-impl.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/append-impl.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:append-impl.rs
+// ignore-stage1
 
 #![allow(warnings)]
 

--- a/src/test/run-pass-fulldeps/proc-macro/attr-args.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/attr-args.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:attr-args.rs
+// ignore-stage1
 
 #![allow(warnings)]
 #![feature(proc_macro)]

--- a/src/test/run-pass-fulldeps/proc-macro/bang-macro.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/bang-macro.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:bang-macro.rs
+// ignore-stage1
 
 #![feature(proc_macro)]
 

--- a/src/test/run-pass-fulldeps/proc-macro/count_compound_ops.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/count_compound_ops.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:count_compound_ops.rs
+// ignore-stage1
 
 #![feature(proc_macro)]
 

--- a/src/test/run-pass-fulldeps/proc-macro/crate-var.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/crate-var.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:double.rs
+// ignore-stage1
 
 #![allow(unused)]
 

--- a/src/test/run-pass-fulldeps/proc-macro/derive-same-struct.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/derive-same-struct.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:derive-same-struct.rs
+// ignore-stage1
 
 #[macro_use]
 extern crate derive_same_struct;

--- a/src/test/run-pass-fulldeps/proc-macro/hygiene_example.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/hygiene_example.rs
@@ -10,6 +10,7 @@
 
 // aux-build:hygiene_example_codegen.rs
 // aux-build:hygiene_example.rs
+// ignore-stage1
 
 #![feature(proc_macro)]
 

--- a/src/test/run-pass-fulldeps/proc-macro/issue-39889.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/issue-39889.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:issue-39889.rs
+// ignore-stage1
 
 #![feature(proc_macro)]
 #![allow(unused)]

--- a/src/test/run-pass-fulldeps/proc-macro/issue-40001.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/issue-40001.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:issue-40001-plugin.rs
+// ignore-stage1
 
 #![feature(proc_macro, plugin)]
 #![plugin(issue_40001_plugin)]

--- a/src/test/run-pass-fulldeps/proc-macro/load-two.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/load-two.rs
@@ -10,6 +10,7 @@
 
 // aux-build:derive-atob.rs
 // aux-build:derive-ctod.rs
+// ignore-stage1
 
 #[macro_use]
 extern crate derive_atob;

--- a/src/test/run-pass-fulldeps/proc-macro/use-reexport.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/use-reexport.rs
@@ -10,6 +10,7 @@
 
 // aux-build:derive-a.rs
 // aux-build:derive-reexport.rs
+// ignore-stage1
 
 #[macro_use]
 extern crate derive_reexport;


### PR DESCRIPTION
That makes `./x.py test --stage 1` work on `x86_64-unknown-linux-gnu`.