### PR TITLE
Put `intrinsics::unreachable` on a possible path to stabilization

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -629,10 +629,12 @@ extern "rust-intrinsic" {
     /// Aborts the execution of the process.
     pub fn abort() -> !;
 
-    /// Tells LLVM that this point in the code is not reachable,
-    /// enabling further optimizations.
+    /// Tells LLVM that this point in the code is not reachable, enabling
+    /// further optimizations.
     ///
-    /// NB: This is very different from the `unreachable!()` macro!
+    /// NB: This is very different from the `unreachable!()` macro: Unlike the
+    /// macro, which panics when it is executed, it is *undefined behavior* to
+    /// reach code marked with this function.
     pub fn unreachable() -> !;
 
     /// Informs the optimizer that a condition is always true.

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -949,6 +949,7 @@ impl<T: ::fmt::Debug> ::fmt::Debug for ManuallyDrop<T> {
 /// NB: This is very different from the `unreachable!()` macro: Unlike the
 /// macro, which panics when it is executed, it is *undefined behavior* to
 /// reach code marked with this function.
+#[inline]
 #[unstable(feature = "unreachable", issue = "43751")]
 pub unsafe fn unreachable() -> ! {
     intrinsics::unreachable()

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -949,7 +949,7 @@ impl<T: ::fmt::Debug> ::fmt::Debug for ManuallyDrop<T> {
 /// NB: This is very different from the `unreachable!()` macro: Unlike the
 /// macro, which panics when it is executed, it is *undefined behavior* to
 /// reach code marked with this function.
-#[unstable(feature = "unreachable", issue = "0")]
+#[unstable(feature = "unreachable", issue = "43751")]
 pub unsafe fn unreachable() -> ! {
     intrinsics::unreachable()
 }

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -942,3 +942,14 @@ impl<T: ::fmt::Debug> ::fmt::Debug for ManuallyDrop<T> {
         }
     }
 }
+
+/// Tells LLVM that this point in the code is not reachable, enabling further
+/// optimizations.
+///
+/// NB: This is very different from the `unreachable!()` macro: Unlike the
+/// macro, which panics when it is executed, it is *undefined behavior* to
+/// reach code marked with this function.
+#[unstable(feature = "unreachable", issue = "0")]
+pub unsafe fn unreachable() -> ! {
+    intrinsics::unreachable()
+}


### PR DESCRIPTION
Mark it with the `unreachable` feature and put it into the `mem` module.
This is a pretty straight-forward API that can already be simulated in
stable Rust by using `transmute` to create an uninhabited enum that can
be matched.