### PR TITLE
Instant is monotonically nondecreasing

### DIFF
--- a/src/libstd/time/mod.rs
+++ b/src/libstd/time/mod.rs
@@ -33,10 +33,10 @@ pub use self::duration::Duration;
 
 mod duration;
 
-/// A measurement of a monotonically increasing clock.
+/// A measurement of a monotonically nondecreasing clock.
 /// Opaque and useful only with `Duration`.
 ///
-/// Instants are always guaranteed to be greater than any previously measured
+/// Instants are always guaranteed to no less than any previously measured
 /// instant when created, and are often useful for tasks such as measuring
 /// benchmarks or timing how long an operation takes.
 ///

--- a/src/libstd/time/mod.rs
+++ b/src/libstd/time/mod.rs
@@ -36,7 +36,7 @@ mod duration;
 /// A measurement of a monotonically nondecreasing clock.
 /// Opaque and useful only with `Duration`.
 ///
-/// Instants are always guaranteed to no less than any previously measured
+/// Instants are always guaranteed to be no less than any previously measured
 /// instant when created, and are often useful for tasks such as measuring
 /// benchmarks or timing how long an operation takes.
 ///


### PR DESCRIPTION
We don't want to guarantee that `Instant::now() != Instant::now()` is
always true since that depends on the speed of the processor and the
resolution of the clock.