### PR TITLE
rustdoc: Fix broken CSS in search results

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -695,7 +695,7 @@ span.since {
 	margin-bottom: 25px;
 }
 
-.enum .variant, .struct .structfield, .union .structfield {
+#main > .variant, #main > .structfield {
 	display: block;
 }
 


### PR DESCRIPTION
The layout is currently broken for struct/union fields and enum variants
in the search results when searching from a struct, union or enum page.

Some examples:
https://doc.rust-lang.org/nightly/std/ops/struct.RangeInclusive.html?search=start
https://doc.rust-lang.org/nightly/std/option/enum.Option.html?search=some

 #34477 was an incomplete fix