### PR TITLE
This makes the stringified assertion into a `fmt` argument...

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -81,7 +81,7 @@ macro_rules! panic {
 macro_rules! assert {
     ($cond:expr) => (
         if !$cond {
-            panic!(concat!("assertion failed: ", stringify!($cond)))
+            panic!("{}", concat!("assertion failed: ", stringify!($cond)))
         }
     );
     ($cond:expr, $($arg:tt)+) => (


### PR DESCRIPTION
 ...so it won't get interpolated.

Although this is unlikely to cause actual problems in normal settings, it causes clippy to lint on the stringified expression, finding a wrong pair of brackets if your assertion contains struct object literals (e.g. `S { a: 0 }`).

There is no test here. We cannot easily find out if the wrong expansion happens because the stringification usually puts spaces between brackets and the wrong format specifier is silently ignored (unless you use clippy).