### PR TITLE
For box expressions, use NZ drop instead of a free block

### DIFF
--- a/src/librustc/mir/tcx.rs
+++ b/src/librustc/mir/tcx.rs
@@ -135,6 +135,11 @@ impl<'tcx> Lvalue<'tcx> {
     }
 }
 
+pub enum RvalueInitializationState {
+    Shallow,
+    Deep
+}
+
 impl<'tcx> Rvalue<'tcx> {
     pub fn ty<'a, 'gcx, D>(&self, local_decls: &D, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Ty<'tcx>
         where D: HasLocalDecls<'tcx>
@@ -204,6 +209,16 @@ impl<'tcx> Rvalue<'tcx> {
                     }
                 }
             }
+        }
+    }
+
+    #[inline]
+    /// Returns whether this rvalue is deeply initialized (most rvalues) or
+    /// whether its only shallowly initialized (`Rvalue::Box`).
+    pub fn initialization_state(&self) -> RvalueInitializationState {
+        match *self {
+            Rvalue::NullaryOp(NullOp::Box, _) => RvalueInitializationState::Shallow,
+            _ => RvalueInitializationState::Deep
         }
     }
 }

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -559,7 +559,6 @@ fn make_mirror_unadjusted<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
         hir::ExprBox(ref value) => {
             ExprKind::Box {
                 value: value.to_ref(),
-                value_extents: CodeExtent::Misc(value.id),
             }
         }
         hir::ExprArray(ref fields) => ExprKind::Array { fields: fields.to_ref() },

--- a/src/librustc_mir/hair/mod.rs
+++ b/src/librustc_mir/hair/mod.rs
@@ -116,7 +116,6 @@ pub enum ExprKind<'tcx> {
     },
     Box {
         value: ExprRef<'tcx>,
-        value_extents: CodeExtent,
     },
     Call {
         ty: ty::Ty<'tcx>,

--- a/src/test/mir-opt/end_region_4.rs
+++ b/src/test/mir-opt/end_region_4.rs
@@ -34,10 +34,9 @@ fn foo(i: i32) {
 //     let _1: D;
 //     let _2: i32;
 //     let _3: &'6_2rce i32;
-//     let _7: &'6_4rce i32;
+//     let _6: &'6_4rce i32;
 //     let mut _4: ();
 //     let mut _5: i32;
-//     let mut _6: ();
 //     bb0: {
 //         StorageLive(_1);
 //         _1 = D::{{constructor}}(const 0i32,);
@@ -51,10 +50,10 @@ fn foo(i: i32) {
 //     }
 //     bb1: {
 //         StorageDead(_5);
-//         StorageLive(_7);
-//         _7 = &'6_4rce _2;
+//         StorageLive(_6);
+//         _6 = &'6_4rce _2;
 //         _0 = ();
-//         StorageDead(_7);
+//         StorageDead(_6);
 //         EndRegion('6_4rce);
 //         StorageDead(_3);
 //         EndRegion('6_2rce);

--- a/src/test/mir-opt/end_region_5.rs
+++ b/src/test/mir-opt/end_region_5.rs
@@ -33,7 +33,6 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 //     let mut _2: ();
 //     let mut _3: [closure@NodeId(18) d:&'19mce D];
 //     let mut _4: &'19mce D;
-//     let mut _5: ();
 //     bb0: {
 //         StorageLive(_1);
 //         _1 = D::{{constructor}}(const 0i32,);

--- a/src/test/mir-opt/end_region_6.rs
+++ b/src/test/mir-opt/end_region_6.rs
@@ -33,7 +33,6 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 //     let mut _2: ();
 //     let mut _3: [closure@NodeId(22) d:&'23mce D];
 //     let mut _4: &'23mce D;
-//     let mut _5: ();
 //     bb0: {
 //         StorageLive(_1);
 //         _1 = D::{{constructor}}(const 0i32,);

--- a/src/test/mir-opt/end_region_7.rs
+++ b/src/test/mir-opt/end_region_7.rs
@@ -33,7 +33,6 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 //     let mut _2: ();
 //     let mut _3: [closure@NodeId(22) d:D];
 //     let mut _4: D;
-//     let mut _5: ();
 //
 //     bb0: {
 //         StorageLive(_1);
@@ -77,7 +76,6 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 //     let mut _0: i32;
 //     let _2: &'14_0rce D;
 //     let mut _3: i32;
-//     let mut _4: ();
 //
 //     bb0: {
 //         StorageLive(_2);

--- a/src/test/mir-opt/end_region_8.rs
+++ b/src/test/mir-opt/end_region_8.rs
@@ -35,7 +35,6 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 //    let mut _3: ();
 //    let mut _4: [closure@NodeId(22) r:&'6_1rce D];
 //    let mut _5: &'6_1rce D;
-//    let mut _6: ();
 //    bb0: {
 //        StorageLive(_1);
 //        _1 = D::{{constructor}}(const 0i32,);

--- a/src/test/mir-opt/issue-41110.rs
+++ b/src/test/mir-opt/issue-41110.rs
@@ -39,8 +39,7 @@ impl S {
 //    let mut _2: S;
 //    let mut _3: S;
 //    let mut _4: S;
-//    let mut _5: ();
-//    let mut _6: bool;
+//    let mut _5: bool;
 //
 //    bb0: {
 // END rustc.node4.ElaborateDrops.after.mir
@@ -50,9 +49,8 @@ impl S {
 //    let mut _2: S;
 //    let mut _3: ();
 //    let mut _4: S;
-//    let mut _5: ();
-//    let mut _6: S;
-//    let mut _7: bool;
+//    let mut _5: S;
+//    let mut _6: bool;
 //
 //    bb0: {
 // END rustc.node13.ElaborateDrops.after.mir

--- a/src/test/run-pass/dynamic-drop.rs
+++ b/src/test/run-pass/dynamic-drop.rs
@@ -161,6 +161,11 @@ fn vec_simple(a: &Allocator) {
     let _x = vec![a.alloc(), a.alloc(), a.alloc(), a.alloc()];
 }
 
+#[allow(unreachable_code)]
+fn vec_unreachable(a: &Allocator) {
+    let _x = vec![a.alloc(), a.alloc(), a.alloc(), return];
+}
+
 fn run_test<F>(mut f: F)
     where F: FnMut(&Allocator)
 {
@@ -209,6 +214,7 @@ fn main() {
 
     run_test(|a| array_simple(a));
     run_test(|a| vec_simple(a));
+    run_test(|a| vec_unreachable(a));
 
     run_test(|a| struct_dynamic_drop(a, false, false, false));
     run_test(|a| struct_dynamic_drop(a, false, false, true));


### PR DESCRIPTION
This falls naturally out of making drop elaboration work with `box`
expressions, which is probably required for sane MIR borrow-checking.
This is a pure refactoring with no intentional functional effects.

r? @nagisa 