### PR TITLE
Fix typo in unicode char definition

### DIFF
--- a/src/libsyntax/parse/lexer/unicode_chars.rs
+++ b/src/libsyntax/parse/lexer/unicode_chars.rs
@@ -264,7 +264,7 @@ const UNICODE_ARRAY: &'static [(char, &'static str, char)] = &[
     ('ꝸ', "Latin Small Letter Um", '&'),
     ('＆', "Fullwidth Ampersand", '&'),
 
-    ('᛭', "Runic Cros Punctuation", '+'),
+    ('᛭', "Runic Cross Punctuation", '+'),
     ('➕', "Heavy Plus Sign", '+'),
     ('𐊛', "Lycian Letter H", '+'),
     ('﬩', "Hebrew Letter Alternative Plus Sign", '+'),


### PR DESCRIPTION
Reference: http://www.fileformat.info/info/unicode/char/16ed/index.htm