### PR TITLE
Fix include! in doc tests

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -191,8 +191,8 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for CodeBlocks<'a, I> {
                     .map(|l| map_line(l).for_code())
                     .collect::<Vec<&str>>().join("\n");
                 let krate = krate.as_ref().map(|s| &**s);
-                let test = test::maketest(&test, krate, false,
-                                        &Default::default());
+                let test = test::make_test(&test, krate, false,
+                                           &Default::default());
                 let channel = if test.contains("#![feature(") {
                     "&amp;version=nightly"
                 } else {
@@ -585,8 +585,8 @@ pub fn render(w: &mut fmt::Formatter,
                         .map(|l| map_line(l).for_code())
                         .collect::<Vec<&str>>().join("\n");
                     let krate = krate.as_ref().map(|s| &**s);
-                    let test = test::maketest(&test, krate, false,
-                                              &Default::default());
+                    let test = test::make_test(&test, krate, false,
+                                               &Default::default());
                     let channel = if test.contains("#![feature(") {
                         "&amp;version=nightly"
                     } else {

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -167,16 +167,16 @@ fn scrape_test_config(krate: &::rustc::hir::Crate) -> TestOptions {
     opts
 }
 
-fn runtest(test: &str, cratename: &str, cfgs: Vec<String>, libs: SearchPaths,
-           externs: Externs,
-           should_panic: bool, no_run: bool, as_test_harness: bool,
-           compile_fail: bool, mut error_codes: Vec<String>, opts: &TestOptions,
-           maybe_sysroot: Option<PathBuf>) {
+fn run_test(test: &str, cratename: &str, filename: &str, cfgs: Vec<String>, libs: SearchPaths,
+            externs: Externs,
+            should_panic: bool, no_run: bool, as_test_harness: bool,
+            compile_fail: bool, mut error_codes: Vec<String>, opts: &TestOptions,
+            maybe_sysroot: Option<PathBuf>) {
     // the test harness wants its own `main` & top level functions, so
     // never wrap the test in `fn main() { ... }`
-    let test = maketest(test, Some(cratename), as_test_harness, opts);
+    let test = make_test(test, Some(cratename), as_test_harness, opts);
     let input = config::Input::Str {
-        name: driver::anon_src(),
+        name: filename.to_owned(),
         input: test.to_owned(),
     };
     let outputs = OutputTypes::new(&[(OutputType::Exe, None)]);
@@ -313,8 +313,11 @@ fn runtest(test: &str, cratename: &str, cfgs: Vec<String>, libs: SearchPaths,
     }
 }
 
-pub fn maketest(s: &str, cratename: Option<&str>, dont_insert_main: bool,
-                opts: &TestOptions) -> String {
+pub fn make_test(s: &str,
+                 cratename: Option<&str>,
+                 dont_insert_main: bool,
+                 opts: &TestOptions)
+                 -> String {
     let (crate_attrs, everything_else) = partition_source(s);
 
     let mut prog = String::new();
@@ -498,18 +501,19 @@ impl Collector {
                     rustc_driver::in_rustc_thread(move || {
                         io::set_panic(panic);
                         io::set_print(print);
-                        runtest(&test,
-                                &cratename,
-                                cfgs,
-                                libs,
-                                externs,
-                                should_panic,
-                                no_run,
-                                as_test_harness,
-                                compile_fail,
-                                error_codes,
-                                &opts,
-                                maybe_sysroot)
+                        run_test(&test,
+                                 &cratename,
+                                 &filename,
+                                 cfgs,
+                                 libs,
+                                 externs,
+                                 should_panic,
+                                 no_run,
+                                 as_test_harness,
+                                 compile_fail,
+                                 error_codes,
+                                 &opts,
+                                 maybe_sysroot)
                     })
                 } {
                     Ok(()) => (),

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -183,13 +183,14 @@ pub fn expand_include_bytes(cx: &mut ExtCtxt, sp: Span, tts: &[tokenstream::Toke
 // resolve a file-system path to an absolute file-system path (if it
 // isn't already)
 fn res_rel_file(cx: &mut ExtCtxt, sp: syntax_pos::Span, arg: &Path) -> PathBuf {
-    // NB: relative paths are resolved relative to the compilation unit
+    // Relative paths are resolved relative to the file in which they are found
+    // after macro expansion (that is, they are unhygienic).
     if !arg.is_absolute() {
         let callsite = sp.source_callsite();
-        let mut cu = PathBuf::from(&cx.codemap().span_to_filename(callsite));
-        cu.pop();
-        cu.push(arg);
-        cu
+        let mut path = PathBuf::from(&cx.codemap().span_to_filename(callsite));
+        path.pop();
+        path.push(arg);
+        path
     } else {
         arg.to_path_buf()
     }

--- a/src/test/rustdoc/issue-43153.rs
+++ b/src/test/rustdoc/issue-43153.rs
@@ -1,0 +1,20 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that `include!` in a doc test searches relative to the directory in
+// which the test is declared.
+
+// compile-flags:--test
+
+/// ```rust
+/// include!("auxiliary/empty.rs");
+/// fn main() {}
+/// ```
+pub struct Foo;


### PR DESCRIPTION
By making the path relative to the current file.

Fixes #43153

[breaking-change] - if you use `include!` inside a doc test, you'll need to change the path to be relative to the current file rather than relative to the working directory.