### PR TITLE
Elaborate trait obligations when typechecking impls

### DIFF
--- a/src/librustc/ty/wf.rs
+++ b/src/librustc/ty/wf.rs
@@ -141,6 +141,17 @@ impl<'a, 'gcx, 'tcx> WfPredicates<'a, 'gcx, 'tcx> {
 
         let cause = self.cause(traits::MiscObligation);
         let param_env = self.param_env;
+
+        let implied_obligations = traits::elaborate_predicates(self.infcx.tcx, vec![
+            ty::Predicate::Trait(ty::Binder(
+                ty::TraitPredicate { trait_ref: *trait_ref }
+            ))
+        ]);
+        let implied_obligations = implied_obligations.map(|pred| {
+            traits::Obligation::new(cause.clone(), param_env, pred)
+        });
+        self.out.extend(implied_obligations);
+
         self.out.extend(
             trait_ref.substs.types()
                             .filter(|ty| !ty.has_escaping_regions())

--- a/src/librustc/ty/wf.rs
+++ b/src/librustc/ty/wf.rs
@@ -198,7 +198,7 @@ impl<'a, 'gcx, 'tcx> WfPredicates<'a, 'gcx, 'tcx> {
         // WF and (b) the trait-ref holds.  (It may also be
         // normalizable and be WF that way.)
         let trait_ref = data.trait_ref(self.infcx.tcx);
-        self.compute_trait_ref(&trait_ref, Elaborate::All);
+        self.compute_trait_ref(&trait_ref, Elaborate::None);
 
         if !data.has_escaping_regions() {
             let predicate = trait_ref.to_predicate();

--- a/src/test/compile-fail/issue-43784-associated-type.rs
+++ b/src/test/compile-fail/issue-43784-associated-type.rs
@@ -1,0 +1,25 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub trait Partial<X: ?Sized>: Copy {
+}
+
+pub trait Complete {
+    type Assoc: Partial<Self>;
+}
+
+impl<T> Partial<T> for T::Assoc where
+    T: Complete
+{
+}
+
+impl<T> Complete for T { //~ ERROR the trait bound `T: std::marker::Copy` is not satisfied
+    type Assoc = T;
+}

--- a/src/test/compile-fail/issue-43784-supertrait.rs
+++ b/src/test/compile-fail/issue-43784-supertrait.rs
@@ -1,0 +1,18 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub trait Partial: Copy {
+}
+
+pub trait Complete: Partial {
+}
+
+impl<T> Partial for T where T: Complete {}
+impl<T> Complete for T {} //~ ERROR the trait bound `T: std::marker::Copy` is not satisfied


### PR DESCRIPTION
When typechecking trait impl declarations, we only checked that bounds explictly written on the trait declaration hold.

We now also check that bounds which would have been implied by the trait reference do hold.

Fixes #43784.