### PR TITLE
Fix some typos

### DIFF
--- a/src/liballoc/allocator.rs
+++ b/src/liballoc/allocator.rs
@@ -40,7 +40,7 @@ fn size_align<T>() -> (usize, usize) {
 ///
 /// (Note however that layouts are *not* required to have positive
 /// size, even though many allocators require that all memory
-/// requeusts have positive size. A caller to the `Alloc::alloc`
+/// requests have positive size. A caller to the `Alloc::alloc`
 /// method must either ensure that conditions like this are met, or
 /// use specific allocators with looser requirements.)
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/liballoc/btree/node.rs
+++ b/src/liballoc/btree/node.rs
@@ -132,7 +132,7 @@ impl<K, V> InternalNode<K, V> {
 
 /// An owned pointer to a node. This basically is either `Box<LeafNode<K, V>>` or
 /// `Box<InternalNode<K, V>>`. However, it contains no information as to which of the two types
-/// of nodes is acutally behind the box, and, partially due to this lack of information, has no
+/// of nodes is actually behind the box, and, partially due to this lack of information, has no
 /// destructor.
 struct BoxedNode<K, V> {
     ptr: Unique<LeafNode<K, V>>
@@ -264,7 +264,7 @@ impl<K, V> Root<K, V> {
 // correct variance.
 /// A reference to a node.
 ///
-/// This type has a number of paramaters that controls how it acts:
+/// This type has a number of parameters that controls how it acts:
 /// - `BorrowType`: This can be `Immut<'a>` or `Mut<'a>` for some `'a` or `Owned`.
 ///    When this is `Immut<'a>`, the `NodeRef` acts roughly like `&'a Node`,
 ///    when this is `Mut<'a>`, the `NodeRef` acts roughly like `&'a mut Node`,

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -1035,7 +1035,7 @@ unsafe impl<A, B> TrustedLen for Zip<A, B>
 /// Now consider this twist where we add a call to `rev`. This version will
 /// print `('c', 1), ('b', 2), ('a', 3)`. Note that the letters are reversed,
 /// but the values of the counter still go in order. This is because `map()` is
-/// still being called lazilly on each item, but we are popping items off the
+/// still being called lazily on each item, but we are popping items off the
 /// back of the vector now, instead of shifting them from the front.
 ///
 /// ```rust

--- a/src/libcore/iter/traits.rs
+++ b/src/libcore/iter/traits.rs
@@ -345,7 +345,7 @@ pub trait Extend<A> {
 /// In a similar fashion to the [`Iterator`] protocol, once a
 /// `DoubleEndedIterator` returns `None` from a `next_back()`, calling it again
 /// may or may not ever return `Some` again. `next()` and `next_back()` are
-/// interchangable for this purpose.
+/// interchangeable for this purpose.
 ///
 /// [`Iterator`]: trait.Iterator.html
 ///

--- a/src/libcore/num/dec2flt/algorithm.rs
+++ b/src/libcore/num/dec2flt/algorithm.rs
@@ -336,7 +336,7 @@ pub fn algorithm_m<T: RawFloat>(f: &Big, e: i16) -> T {
     round_by_remainder(v, rem, q, z)
 }
 
-/// Skip over most AlgorithmM iterations by checking the bit length.
+/// Skip over most Algorithm M iterations by checking the bit length.
 fn quick_start<T: RawFloat>(u: &mut Big, v: &mut Big, k: &mut i16) {
     // The bit length is an estimate of the base two logarithm, and log(u / v) = log(u) - log(v).
     // The estimate is off by at most 1, but always an under-estimate, so the error on log(u)

--- a/src/libcore/ops/unsize.rs
+++ b/src/libcore/ops/unsize.rs
@@ -24,7 +24,7 @@ use marker::Unsize;
 /// Such an impl can only be written if `Foo<T>` has only a single non-phantomdata
 /// field involving `T`. If the type of that field is `Bar<T>`, an implementation
 /// of `CoerceUnsized<Bar<U>> for Bar<T>` must exist. The coercion will work by
-/// by coercing the `Bar<T>` field into `Bar<U>` and filling in the rest of the fields
+/// coercing the `Bar<T>` field into `Bar<U>` and filling in the rest of the fields
 /// from `Foo<T>` to create a `Foo<U>`. This will effectively drill down to a pointer
 /// field and coerce that.
 ///

--- a/src/libcore/tests/num/mod.rs
+++ b/src/libcore/tests/num/mod.rs
@@ -566,7 +566,7 @@ assume_usize_width! {
     );
 }
 
-/// Conversinos where neither the min nor the max of $source can be represented by
+/// Conversions where neither the min nor the max of $source can be represented by
 /// $target, but max/min of the target can be represented by the source.
 macro_rules! test_impl_try_from_signed_to_unsigned_err {
     ($fn_name:ident, $source:ty, $target:ty) => {

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -111,7 +111,7 @@ impl fmt::Display for TokenStream {
 
 /// `quote!(..)` accepts arbitrary tokens and expands into a `TokenStream` describing the input.
 /// For example, `quote!(a + b)` will produce a expression, that, when evaluated, constructs
-/// constructs the `TokenStream` `[Word("a"), Op('+', Alone), Word("b")]`.
+/// the `TokenStream` `[Word("a"), Op('+', Alone), Word("b")]`.
 ///
 /// Unquoting is done with `$`, and works by taking the single next ident as the unquoted term.
 /// To quote `$` itself, use `$$`.

--- a/src/librustc/traits/specialize/specialization_graph.rs
+++ b/src/librustc/traits/specialize/specialization_graph.rs
@@ -31,7 +31,7 @@ use util::nodemap::{DefIdMap, FxHashMap};
 ///
 /// - Parent extraction. In particular, the graph can give you the *immediate*
 ///   parents of a given specializing impl, which is needed for extracting
-///   default items amongst other thigns. In the simple "chain" rule, every impl
+///   default items amongst other things. In the simple "chain" rule, every impl
 ///   has at most one parent.
 pub struct Graph {
     // all impls have a parent; the "root" impls have as their parent the def_id

--- a/src/librustc/ty/adjustment.rs
+++ b/src/librustc/ty/adjustment.rs
@@ -29,7 +29,7 @@ use ty::subst::Substs;
 /// by `autoref`, to either a raw or borrowed pointer. In these cases unsize is
 /// `false`.
 ///
-/// 2. A thin-to-fat coercon involves unsizing the underlying data. We start
+/// 2. A thin-to-fat coercion involves unsizing the underlying data. We start
 /// with a thin pointer, deref a number of times, unsize the underlying data,
 /// then autoref. The 'unsize' phase may change a fixed length array to a
 /// dynamically sized one, a concrete object to a trait object, or statically
@@ -52,7 +52,7 @@ use ty::subst::Substs;
 /// that case, we have the pointer we need coming in, so there are no
 /// autoderefs, and no autoref. Instead we just do the `Unsize` transformation.
 /// At some point, of course, `Box` should move out of the compiler, in which
-/// case this is analogous to transformating a struct. E.g., Box<[i32; 4]> ->
+/// case this is analogous to transforming a struct. E.g., Box<[i32; 4]> ->
 /// Box<[i32]> is an `Adjust::Unsize` with the target `Box<[i32]>`.
 #[derive(Clone, RustcEncodable, RustcDecodable)]
 pub struct Adjustment<'tcx> {

--- a/src/librustc_data_structures/stable_hasher.rs
+++ b/src/librustc_data_structures/stable_hasher.rs
@@ -193,7 +193,7 @@ impl<W> Hasher for StableHasher<W> {
 
 
 /// Something that implements `HashStable<CTX>` can be hashed in a way that is
-/// stable across multiple compiliation sessions.
+/// stable across multiple compilation sessions.
 pub trait HashStable<CTX> {
     fn hash_stable<W: StableHasherResult>(&self,
                                           hcx: &mut CTX,

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -282,7 +282,7 @@ pub fn source_name(input: &Input) -> String {
 /// This is a somewhat higher level controller than a Session - the Session
 /// controls what happens in each phase, whereas the CompileController controls
 /// whether a phase is run at all and whether other code (from outside the
-/// the compiler) is run between phases.
+/// compiler) is run between phases.
 ///
 /// Note that if compilation is set to stop and a callback is provided for a
 /// given entry point, the callback is called before compilation is stopped.

--- a/src/librustc_mir/dataflow/impls/mod.rs
+++ b/src/librustc_mir/dataflow/impls/mod.rs
@@ -212,7 +212,7 @@ impl<'a, 'tcx: 'a> HasMoveData<'tcx> for DefinitelyInitializedLvals<'a, 'tcx> {
 /// you if an l-value *might* be uninitialized at a given point in the
 /// control flow. But `MovingOutStatements` also includes the added
 /// data of *which* particular statement causing the deinitialization
-/// that the borrow checker's error meessage may need to report.
+/// that the borrow checker's error message may need to report.
 #[allow(dead_code)]
 pub struct MovingOutStatements<'a, 'tcx: 'a> {
     tcx: TyCtxt<'a, 'tcx, 'tcx>,

--- a/src/librustc_mir/hair/mod.rs
+++ b/src/librustc_mir/hair/mod.rs
@@ -80,7 +80,7 @@ pub enum StmtKind<'tcx> {
 
 /// The Hair trait implementor translates their expressions (`&'tcx H::Expr`)
 /// into instances of this `Expr` enum. This translation can be done
-/// basically as lazilly or as eagerly as desired: every recursive
+/// basically as lazily or as eagerly as desired: every recursive
 /// reference to an expression in this enum is an `ExprRef<'tcx>`, which
 /// may in turn be another instance of this enum (boxed), or else an
 /// untranslated `&'tcx H::Expr`. Note that instances of `Expr` are very

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -191,7 +191,7 @@ pub fn compare_simd_types<'a, 'tcx>(
 /// adjustment.
 ///
 /// The `old_info` argument is a bit funny. It is intended for use
-/// in an upcast, where the new vtable for an object will be drived
+/// in an upcast, where the new vtable for an object will be derived
 /// from the old one.
 pub fn unsized_info<'ccx, 'tcx>(ccx: &CrateContext<'ccx, 'tcx>,
                                 source: Ty<'tcx>,

--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -22,7 +22,7 @@ use util::nodemap::FxHashSet;
 
 use syntax_pos::Span;
 
-/// check_drop_impl confirms that the Drop implementation identfied by
+/// check_drop_impl confirms that the Drop implementation identified by
 /// `drop_impl_did` is not any more specialized than the type it is
 /// attached to (Issue #8142).
 ///

--- a/src/librustc_typeck/constrained_type_params.rs
+++ b/src/librustc_typeck/constrained_type_params.rs
@@ -98,7 +98,7 @@ pub fn identify_constrained_type_params<'tcx>(tcx: ty::TyCtxt,
 
 /// Order the predicates in `predicates` such that each parameter is
 /// constrained before it is used, if that is possible, and add the
-/// paramaters so constrained to `input_parameters`. For example,
+/// parameters so constrained to `input_parameters`. For example,
 /// imagine the following impl:
 ///
 ///     impl<T: Debug, U: Iterator<Item=T>> Trait for U

--- a/src/librustc_typeck/variance/constraints.rs
+++ b/src/librustc_typeck/variance/constraints.rs
@@ -51,7 +51,7 @@ pub struct Constraint<'a> {
     pub variance: &'a VarianceTerm<'a>,
 }
 
-/// To build constriants, we visit one item (type, trait) at a time
+/// To build constraints, we visit one item (type, trait) at a time
 /// and look at its contents. So e.g. if we have
 ///
 ///     struct Foo<T> {

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -495,7 +495,7 @@ fn build_static(cx: &DocContext, did: DefId, mutable: bool) -> clean::Static {
 
 /// A trait's generics clause actually contains all of the predicates for all of
 /// its associated types as well. We specifically move these clauses to the
-/// associated types instead when displaying, so when we're genering the
+/// associated types instead when displaying, so when we're generating the
 /// generics for the trait itself we need to be sure to remove them.
 /// We also need to remove the implied "recursive" Self: Trait bound.
 ///

--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -37,7 +37,7 @@ pub use panicking::{take_hook, set_hook, PanicInfo, Location};
 /// In Rust a function can "return" early if it either panics or calls a
 /// function which transitively panics. This sort of control flow is not always
 /// anticipated, and has the possibility of causing subtle bugs through a
-/// combination of two cricial components:
+/// combination of two criticial components:
 ///
 /// 1. A data structure is in a temporarily invalid state when the thread
 ///    panics.

--- a/src/libstd/sys/redox/syscall/call.rs
+++ b/src/libstd/sys/redox/syscall/call.rs
@@ -40,7 +40,7 @@ pub unsafe fn brk(addr: usize) -> Result<usize> {
 ///
 /// * `EACCES` - permission is denied for one of the components of `path`, or `path`
 /// * `EFAULT` - `path` does not point to the process's addressible memory
-/// * `EIO` - an I/O error occured
+/// * `EIO` - an I/O error occurred
 /// * `ENOENT` - `path` does not exit
 /// * `ENOTDIR` - `path` is not a directory
 pub fn chdir(path: &str) -> Result<usize> {
@@ -290,7 +290,7 @@ pub fn waitpid(pid: usize, status: &mut usize, options: usize) -> Result<usize> 
 /// * `EAGAIN` - the file descriptor was opened with `O_NONBLOCK` and writing would block
 /// * `EBADF` - the file descriptor is not valid or is not open for writing
 /// * `EFAULT` - `buf` does not point to the process's addressible memory
-/// * `EIO` - an I/O error occured
+/// * `EIO` - an I/O error occurred
 /// * `ENOSPC` - the device containing the file descriptor has no room for data
 /// * `EPIPE` - the file descriptor refers to a pipe or socket whose reading end is closed
 pub fn write(fd: usize, buf: &[u8]) -> Result<usize> {

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -531,7 +531,7 @@ pub fn current() -> Thread {
 ///
 /// However programmers will usually prefer to use, [`channel`]s, [`Condvar`]s,
 /// [`Mutex`]es or [`join`] for their synchronisation routines, as they avoid
-/// thinking about thread schedulling.
+/// thinking about thread scheduling.
 ///
 /// Note that [`channel`]s for example are implemented using this primitive.
 /// Indeed when you call `send` or `recv`, which are blocking, they will yield

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -435,7 +435,7 @@ pub fn mk_attr_inner(span: Span, id: AttrId, item: MetaItem) -> Attribute {
     mk_spanned_attr_inner(span, id, item)
 }
 
-/// Returns an innter attribute with the given value and span.
+/// Returns an inner attribute with the given value and span.
 pub fn mk_spanned_attr_inner(sp: Span, id: AttrId, item: MetaItem) -> Attribute {
     Attribute {
         id: id,

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -124,7 +124,7 @@ pub fn parse_expr_from_source_str(name: String, source: String, sess: &ParseSess
 
 /// Parses an item.
 ///
-/// Returns `Ok(Some(item))` when successful, `Ok(None)` when no item was found, and`Err`
+/// Returns `Ok(Some(item))` when successful, `Ok(None)` when no item was found, and `Err`
 /// when a syntax error occurred.
 pub fn parse_item_from_source_str(name: String, source: String, sess: &ParseSess)
                                       -> PResult<Option<P<ast::Item>>> {


### PR DESCRIPTION
I wrote a really naive script and found those typos in the documentation.