### PR TITLE
Improve enum variants display

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -677,6 +677,10 @@ span.since {
 	left: 0;
 }
 
+.variant + .toggle-wrapper + .docblock > p {
+	margin-top: 5px;
+}
+
 .variant + .toggle-wrapper > a {
 	margin-top: 5px;
 }


### PR DESCRIPTION
r? @rust-lang/docs 

Before:

<img width="1440" alt="screen shot 2017-08-11 at 00 22 54" src="https://user-images.githubusercontent.com/3050060/29194776-728ce0e2-7e2b-11e7-8299-8300cc0c168b.png">

After:

<img width="1440" alt="screen shot 2017-08-11 at 00 22 57" src="https://user-images.githubusercontent.com/3050060/29194783-78867558-7e2b-11e7-9226-1327fd20163a.png">

(The doc of the variant is more aligned with the "[-]" now).