### PR TITLE
Don't even try to build branches other than auto and try

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ dist: trusty
 services:
   - docker
 
+branches:
+  except:
+  - master
+
 git:
   depth: 1
   submodules: false


### PR DESCRIPTION
Although we have an environment variable which quickly exits the builders, I'm pretty sure that even putting master into the queue after every merge (https://travis-ci.org/rust-lang/rust/builds) causes a bit of a delay because the VMs have to be spun up.

Not sure if limiting to try and auto will exclude PRs, let's find out.

r? @alexcrichton 