### PR TITLE
Let HasAttrs return attributes for StmtKind::Item

### DIFF
--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -1291,7 +1291,7 @@ impl HasAttrs for StmtKind {
     fn attrs(&self) -> &[Attribute] {
         match *self {
             StmtKind::Local(ref local) => local.attrs(),
-            StmtKind::Item(..) => &[],
+            StmtKind::Item(ref item) => item.attrs(),
             StmtKind::Expr(ref expr) | StmtKind::Semi(ref expr) => expr.attrs(),
             StmtKind::Mac(ref mac) => {
                 let (_, _, ref attrs) = **mac;
@@ -1303,7 +1303,7 @@ impl HasAttrs for StmtKind {
     fn map_attrs<F: FnOnce(Vec<Attribute>) -> Vec<Attribute>>(self, f: F) -> Self {
         match self {
             StmtKind::Local(local) => StmtKind::Local(local.map_attrs(f)),
-            StmtKind::Item(..) => self,
+            StmtKind::Item(item) => StmtKind::Item(item.map_attrs(f)),
             StmtKind::Expr(expr) => StmtKind::Expr(expr.map_attrs(f)),
             StmtKind::Semi(expr) => StmtKind::Semi(expr.map_attrs(f)),
             StmtKind::Mac(mac) => StmtKind::Mac(mac.map(|(mac, style, attrs)| {


### PR DESCRIPTION
Fixes `HasAttrs` ignoring attributes from item statements.