### PR TITLE
Fix unused_result lint triggering when a function returns `()`, `!` or an empty enum

### DIFF
--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -146,6 +146,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
 
         let t = cx.tables.expr_ty(&expr);
         let ty_warned = match t.sty {
+            ty::TyTuple(ref tys, _) if tys.is_empty() => return,
+            ty::TyNever => return,
             ty::TyAdt(def, _) => check_must_use(cx, def.did, s.span, ""),
             _ => false,
         };

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -148,7 +148,13 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
         let ty_warned = match t.sty {
             ty::TyTuple(ref tys, _) if tys.is_empty() => return,
             ty::TyNever => return,
-            ty::TyAdt(def, _) => check_must_use(cx, def.did, s.span, ""),
+            ty::TyAdt(def, _) => {
+                if def.variants.is_empty() {
+                    return;
+                } else {
+                    check_must_use(cx, def.did, s.span, "")
+                }
+            },
             _ => false,
         };
 

--- a/src/test/ui/issue-43806.rs
+++ b/src/test/ui/issue-43806.rs
@@ -12,15 +12,22 @@
 
 #![deny(unused_results)]
 
+enum Void {}
+
 fn foo() {}
 
 fn bar() -> ! {
     loop {}
 }
 
+fn baz() -> Void {
+    loop {}
+}
+
 fn qux() {
     foo();
     bar();
+    baz();
 }
 
 fn main() {}

--- a/src/test/ui/issue-43806.rs
+++ b/src/test/ui/issue-43806.rs
@@ -1,0 +1,26 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-pass
+
+#![deny(unused_results)]
+
+fn foo() {}
+
+fn bar() -> ! {
+    loop {}
+}
+
+fn qux() {
+    foo();
+    bar();
+}
+
+fn main() {}


### PR DESCRIPTION
Also added a test to prevent this from happening again.

Fixes #43806