### PR TITLE
Optimize allocation paths in RawVec

### DIFF
--- a/src/liballoc/allocator.rs
+++ b/src/liballoc/allocator.rs
@@ -354,15 +354,19 @@ pub enum AllocErr {
 }
 
 impl AllocErr {
+    #[inline]
     pub fn invalid_input(details: &'static str) -> Self {
         AllocErr::Unsupported { details: details }
     }
+    #[inline]
     pub fn is_memory_exhausted(&self) -> bool {
         if let AllocErr::Exhausted { .. } = *self { true } else { false }
     }
+    #[inline]
     pub fn is_request_unsupported(&self) -> bool {
         if let AllocErr::Unsupported { .. } = *self { true } else { false }
     }
+    #[inline]
     pub fn description(&self) -> &str {
         match *self {
             AllocErr::Exhausted { .. } => "allocator memory exhausted",

--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -28,6 +28,7 @@ pub mod __core {
 extern "Rust" {
     #[allocator]
     fn __rust_alloc(size: usize, align: usize, err: *mut u8) -> *mut u8;
+    #[cold]
     fn __rust_oom(err: *const u8) -> !;
     fn __rust_dealloc(ptr: *mut u8, size: usize, align: usize);
     fn __rust_usable_size(layout: *const u8,
@@ -81,6 +82,7 @@ unsafe impl Alloc for Heap {
     }
 
     #[inline]
+    #[cold]
     fn oom(&mut self, err: AllocErr) -> ! {
         unsafe {
             __rust_oom(&err as *const AllocErr as *const u8)


### PR DESCRIPTION
Since the `Alloc` trait was introduced (https://github.com/rust-lang/rust/pull/42313) and it was integrated everywhere (https://github.com/rust-lang/rust/pull/42727) there's been some slowdowns and regressions that have slipped through. The intention of this PR is to try to tackle at least some of them, but they've been very difficult to quantify up to this point so it probably doesn't solve everything.

This PR primarily targets the `RawVec` type, specifically the `double` function. The codegen for this function is now much closer to what it was before #42313 landed as many runtime checks have been elided.