### PR TITLE
[gitignore] Add compiler-rt and rust-installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,4 +102,6 @@ version.ml
 version.texi
 .cargo
 !src/vendor/**
+/src/compiler-rt/
+/src/rust-installer/
 /src/target/


### PR DESCRIPTION
After a fresh checkout and build, these two directories are left in the
repo without being ignored by git. Looks like they are only build
artifacts and it's safe to add them to `.gitignore`.