### PR TITLE
Fix "Mis-calculated spans" errors from `-Z save-analysis` + refactoring

### DIFF
--- a/src/test/run-make/issues-41478-43796/Makefile
+++ b/src/test/run-make/issues-41478-43796/Makefile
@@ -1,0 +1,8 @@
+-include ../tools.mk
+
+all:
+	# Work in /tmp, because we need to create the `save-analysis-temp` folder.
+	cp a.rs $(TMPDIR)/
+	cd $(TMPDIR) && $(RUSTC) -Zsave-analysis $(TMPDIR)/a.rs 2> $(TMPDIR)/stderr.txt || ( cat $(TMPDIR)/stderr.txt && exit 1 )
+	[ ! -s $(TMPDIR)/stderr.txt ] || ( cat $(TMPDIR)/stderr.txt && exit 1 )
+	[ -f $(TMPDIR)/save-analysis/liba.json ] || ( ls -la $(TMPDIR) && exit 1 )

--- a/src/test/run-make/issues-41478-43796/a.rs
+++ b/src/test/run-make/issues-41478-43796/a.rs
@@ -1,0 +1,19 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "lib"]
+pub struct V<S>(S);
+pub trait An {
+    type U;
+}
+pub trait F<A> {
+}
+impl<A: An> F<A> for V<<A as An>::U> {
+}


### PR DESCRIPTION
Removed the path span extraction methods from `SpanUtils`:

* spans_with_brackets
* spans_for_path_segments
* spans_for_ty_params

Use the `span` fields in `PathSegment` and `TyParam` instead.

(Note that since it processes `ast::Path` not a qualified path (`hir::QPath` / `ast::QSelf`), UFCS path will be flattened: `<Foo as a::b::c::Trait>::D::E::F::g` will be seen as `a::b::c::Trait::D::E::F::g`.)

Fix #43796. Close #41478.

r? @nrc 