### PR TITLE
Implement CompilerDesugaringKind enum

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -397,11 +397,12 @@ impl<'a> LoweringContext<'a> {
     }
 
     fn allow_internal_unstable(&self, reason: &'static str, mut span: Span) -> Span {
+        let reason = codemap::CompilerDesugaringKind::from(reason);
         let mark = Mark::fresh(Mark::root());
         mark.set_expn_info(codemap::ExpnInfo {
             call_site: span,
             callee: codemap::NameAndSpan {
-                format: codemap::CompilerDesugaring(Symbol::intern(reason)),
+                format: codemap::CompilerDesugaring(reason),
                 span: Some(span),
                 allow_internal_unstable: true,
                 allow_internal_unsafe: false,

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -323,8 +323,8 @@ impl NameAndSpan {
     pub fn name(&self) -> Symbol {
         match self.format {
             ExpnFormat::MacroAttribute(s) |
-            ExpnFormat::MacroBang(s) |
-            ExpnFormat::CompilerDesugaring(s) => s,
+            ExpnFormat::MacroBang(s) => s,
+            ExpnFormat::CompilerDesugaring(ref kind) => kind.as_symbol(),
         }
     }
 }
@@ -337,7 +337,39 @@ pub enum ExpnFormat {
     /// e.g. `format!()`
     MacroBang(Symbol),
     /// Desugaring done by the compiler during HIR lowering.
-    CompilerDesugaring(Symbol)
+    CompilerDesugaring(CompilerDesugaringKind)
+}
+
+/// The kind of compiler desugaring.
+#[derive(Clone, Hash, Debug, PartialEq, Eq)]
+pub enum CompilerDesugaringKind {
+    BackArrow,
+    DotFill,
+    QuestionMark,
+}
+
+impl CompilerDesugaringKind {
+    pub fn as_symbol(&self) -> Symbol {
+        use CompilerDesugaringKind::*;
+        let s = match *self {
+            BackArrow => "<-",
+            DotFill => "...",
+            QuestionMark => "?",
+        };
+        Symbol::intern(s)
+    }
+}
+
+impl<'a> From<&'a str> for CompilerDesugaringKind {
+    fn from(s: &'a str) -> Self {
+        use CompilerDesugaringKind::*;
+        match s {
+            "<-" => BackArrow,
+            "..." => DotFill,
+            "?" => QuestionMark,
+            _ => panic!("Invalid compiler desugaring"),
+        }
+    }
 }
 
 impl Encodable for SyntaxContext {

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -360,18 +360,6 @@ impl CompilerDesugaringKind {
     }
 }
 
-impl<'a> From<&'a str> for CompilerDesugaringKind {
-    fn from(s: &'a str) -> Self {
-        use CompilerDesugaringKind::*;
-        match s {
-            "<-" => BackArrow,
-            "..." => DotFill,
-            "?" => QuestionMark,
-            _ => panic!("Invalid compiler desugaring"),
-        }
-    }
-}
-
 impl Encodable for SyntaxContext {
     fn encode<E: Encoder>(&self, _: &mut E) -> Result<(), E::Error> {
         Ok(()) // FIXME(jseyfried) intercrate hygiene

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -47,7 +47,7 @@ extern crate serialize;
 extern crate serialize as rustc_serialize; // used by deriving
 
 pub mod hygiene;
-pub use hygiene::{SyntaxContext, ExpnInfo, ExpnFormat, NameAndSpan};
+pub use hygiene::{SyntaxContext, ExpnInfo, ExpnFormat, NameAndSpan, CompilerDesugaringKind};
 
 pub mod symbol;
 
@@ -149,6 +149,17 @@ impl Span {
     pub fn allows_unstable(&self) -> bool {
         match self.ctxt.outer().expn_info() {
             Some(info) => info.callee.allow_internal_unstable,
+            None => false,
+        }
+    }
+
+    /// Check if this span arises from a compiler desugaring of kind `kind`.
+    pub fn is_compiler_desugaring(&self, kind: CompilerDesugaringKind) -> bool {
+        match self.ctxt.outer().expn_info() {
+            Some(info) => match info.callee.format {
+                ExpnFormat::CompilerDesugaring(k) => k == kind,
+                _ => false,
+            },
             None => false,
         }
     }


### PR DESCRIPTION
This is the first step outlined in #35946. I think that the variants of `CompilerDesugaringKind` should be changed, I didn't know what the official names for `...` and `<-` are.

I'm not to sure how tests for the compiler work, but I would imagine that tests should be added such that
`Symbol::intern(s) == CompilerDesugaringKind::from(s).as_symbol()` for valid `s`.