### PR TITLE
Fix TcpStream::connect_timeout tracking issue number

### DIFF
--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -147,7 +147,7 @@ impl TcpStream {
     /// connection request.
     ///
     /// [`SocketAddr`]: ../../std/net/enum.SocketAddr.html
-    #[unstable(feature = "tcpstream_connect_timeout", issue = "43709")]
+    #[unstable(feature = "tcpstream_connect_timeout", issue = "43079")]
     pub fn connect_timeout(addr: &SocketAddr, timeout: Duration) -> io::Result<TcpStream> {
         net_imp::TcpStream::connect_timeout(addr, timeout).map(TcpStream)
     }


### PR DESCRIPTION
Before: https://github.com/rust-lang/rust/pull/43709
After: https://github.com/rust-lang/rust/issues/43079

r? @sfackler 