### PR TITLE
rustc: Fix `unknown_lints` next to an unknown lint

### DIFF
--- a/src/test/run-pass/lint-unknown-lints-at-crate-level.rs
+++ b/src/test/run-pass/lint-unknown-lints-at-crate-level.rs
@@ -1,0 +1,16 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -D warnings -D unknown-lints
+
+#![allow(unknown_lints)]
+#![allow(random_lint_name)]
+
+fn main() {}


### PR DESCRIPTION
The lint refactoring in #43522 didn't account for `#[allow(unknown_lints)]`
happening at the same node as an unknown lint itself, so this commit updates the
handling to ensure that the local set of lint configuration being built is
queried before looking at the chain of lint levels.

Closes #43809