### PR TITLE
Cleanup for "Support compiling rustc without LLVM (try 2)"

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -618,12 +618,6 @@ impl Step for Compiletest {
         if let Some(ref dir) = build.lldb_python_dir {
             cmd.arg("--lldb-python-dir").arg(dir);
         }
-        let llvm_config = build.llvm_config(target);
-        let llvm_version = output(Command::new(&llvm_config).arg("--version"));
-        cmd.arg("--llvm-version").arg(llvm_version);
-        if !build.is_rust_llvm(target) {
-            cmd.arg("--system-llvm");
-        }
 
         cmd.args(&build.flags.cmd.test_args());
 
@@ -635,17 +629,32 @@ impl Step for Compiletest {
             cmd.arg("--quiet");
         }
 
-        // Only pass correct values for these flags for the `run-make` suite as it
-        // requires that a C++ compiler was configured which isn't always the case.
-        if suite == "run-make" {
-            let llvm_components = output(Command::new(&llvm_config).arg("--components"));
-            let llvm_cxxflags = output(Command::new(&llvm_config).arg("--cxxflags"));
-            cmd.arg("--cc").arg(build.cc(target))
-               .arg("--cxx").arg(build.cxx(target).unwrap())
-               .arg("--cflags").arg(build.cflags(target).join(" "))
-               .arg("--llvm-components").arg(llvm_components.trim())
-               .arg("--llvm-cxxflags").arg(llvm_cxxflags.trim());
-        } else {
+        if build.config.llvm_enabled {
+            let llvm_config = build.llvm_config(target);
+            let llvm_version = output(Command::new(&llvm_config).arg("--version"));
+            cmd.arg("--llvm-version").arg(llvm_version);
+            if !build.is_rust_llvm(target) {
+                cmd.arg("--system-llvm");
+            }
+
+            // Only pass correct values for these flags for the `run-make` suite as it
+            // requires that a C++ compiler was configured which isn't always the case.
+            if suite == "run-make" {
+                let llvm_components = output(Command::new(&llvm_config).arg("--components"));
+                let llvm_cxxflags = output(Command::new(&llvm_config).arg("--cxxflags"));
+                cmd.arg("--cc").arg(build.cc(target))
+                .arg("--cxx").arg(build.cxx(target).unwrap())
+                .arg("--cflags").arg(build.cflags(target).join(" "))
+                .arg("--llvm-components").arg(llvm_components.trim())
+                .arg("--llvm-cxxflags").arg(llvm_cxxflags.trim());
+            }
+        }
+        if suite == "run-make" && !build.config.llvm_enabled {
+            println!("Ignoring run-make test suite");
+            return;
+        }
+
+        if suite != "run-make" {
             cmd.arg("--cc").arg("")
                .arg("--cxx").arg("")
                .arg("--cflags").arg("")

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -650,7 +650,7 @@ impl Step for Compiletest {
             }
         }
         if suite == "run-make" && !build.config.llvm_enabled {
-            println!("Ignoring run-make test suite");
+            println!("Ignoring run-make test suite as they generally dont work without LLVM");
             return;
         }
 

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -246,8 +246,7 @@ pub fn compile_input(sess: &Session,
         })??
     };
 
-    #[cfg(not(feature="llvm"))]
-    {
+    if cfg!(not(feature="llvm")) {
         let (_, _) = (outputs, trans);
         sess.fatal("LLVM is not supported by this rustc");
     }

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -95,7 +95,7 @@ pub fn compile_input(sess: &Session,
 
         if sess.opts.crate_types.iter().all(|&t|{
             t != CrateType::CrateTypeRlib && t != CrateType::CrateTypeExecutable
-        }) {
+        }) && !sess.opts.crate_types.is_empty() {
             sess.err(
                 "LLVM is not supported by this rustc, so non rlib libraries are not supported"
             );

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -107,7 +107,7 @@ pub fn compile_input(sess: &Session,
     // We need nested scopes here, because the intermediate results can keep
     // large chunks of memory alive and we want to free them as soon as
     // possible to keep the peak memory usage low
-    let (outputs, trans): (OutputFilenames, write::OngoingCrateTranslation) = {
+    let (outputs, trans): (OutputFilenames, OngoingCrateTranslation) = {
         let krate = match phase_1_parse_input(control, sess, input) {
             Ok(krate) => krate,
             Err(mut parse_error) => {

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -73,10 +73,7 @@ pub fn compile_input(sess: &Session,
                      output: &Option<PathBuf>,
                      addl_plugins: Option<Vec<String>>,
                      control: &CompileController) -> CompileResult {
-    #[cfg(feature="llvm")]
     use rustc_trans::back::write::OngoingCrateTranslation;
-    #[cfg(not(feature="llvm"))]
-    type OngoingCrateTranslation = ();
 
     macro_rules! controller_entry_point {
         ($point: ident, $tsess: expr, $make_state: expr, $phase_result: expr) => {{
@@ -393,7 +390,6 @@ pub struct CompileState<'a, 'tcx: 'a> {
     pub resolutions: Option<&'a Resolutions>,
     pub analysis: Option<&'a ty::CrateAnalysis>,
     pub tcx: Option<TyCtxt<'a, 'tcx, 'tcx>>,
-    #[cfg(feature="llvm")]
     pub trans: Option<&'a trans::CrateTranslation>,
 }
 
@@ -420,7 +416,6 @@ impl<'a, 'tcx> CompileState<'a, 'tcx> {
             resolutions: None,
             analysis: None,
             tcx: None,
-            #[cfg(feature="llvm")]
             trans: None,
         }
     }
@@ -942,7 +937,6 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
     mir::provide(&mut local_providers);
     reachable::provide(&mut local_providers);
     rustc_privacy::provide(&mut local_providers);
-    #[cfg(feature="llvm")]
     trans::provide(&mut local_providers);
     typeck::provide(&mut local_providers);
     ty::provide(&mut local_providers);
@@ -955,7 +949,6 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
 
     let mut extern_providers = ty::maps::Providers::default();
     cstore::provide(&mut extern_providers);
-    #[cfg(feature="llvm")]
     trans::provide(&mut extern_providers);
     ty::provide_extern(&mut extern_providers);
     traits::provide_extern(&mut extern_providers);

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -71,6 +71,7 @@ pub fn compile_input(sess: &Session,
                      output: &Option<PathBuf>,
                      addl_plugins: Option<Vec<String>>,
                      control: &CompileController) -> CompileResult {
+    use rustc_trans::back::write::OngoingCrateTranslation;
     macro_rules! controller_entry_point {
         ($point: ident, $tsess: expr, $make_state: expr, $phase_result: expr) => {{
             let state = &mut $make_state;

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -157,28 +157,36 @@ pub use no_llvm_metadata_loader::NoLLvmMetadataLoader as MetadataLoader;
 pub use rustc_trans::LlvmMetadataLoader as MetadataLoader;
 
 #[cfg(not(feature="llvm"))]
-mod no_llvm_metadata_loader{
+mod no_llvm_metadata_loader {
     extern crate ar;
     extern crate owning_ref;
-    
+
     use rustc::middle::cstore::MetadataLoader as MetadataLoaderTrait;
     use rustc_back::target::Target;
     use std::io;
     use std::fs::File;
     use std::path::Path;
-    
+
     use self::ar::Archive;
     use self::owning_ref::{OwningRef, ErasedBoxRef};
 
     pub struct NoLLvmMetadataLoader;
 
     impl MetadataLoaderTrait for NoLLvmMetadataLoader {
-        fn get_rlib_metadata(&self, _: &Target, filename: &Path) -> Result<ErasedBoxRef<[u8]>, String> {
-            let file = File::open(filename).map_err(|e|format!("metadata file open err: {:?}", e))?;
+        fn get_rlib_metadata(
+            &self,
+            _: &Target,
+            filename: &Path
+        ) -> Result<ErasedBoxRef<[u8]>, String> {
+            let file = File::open(filename).map_err(|e| {
+                format!("metadata file open err: {:?}", e)
+            })?;
             let mut archive = Archive::new(file);
 
             while let Some(entry_result) = archive.next_entry() {
-                let mut entry = entry_result.map_err(|e|format!("metadata section read err: {:?}", e))?;
+                let mut entry = entry_result.map_err(|e| {
+                    format!("metadata section read err: {:?}", e)
+                })?;
                 if entry.header().identifier() == "rust.metadata.bin" {
                     let mut buf = Vec::new();
                     io::copy(&mut entry, &mut buf).unwrap();

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -14,7 +14,6 @@ use driver;
 use rustc::dep_graph::DepGraph;
 use rustc_lint;
 use rustc_resolve::MakeGlobMap;
-#[cfg(feature="llvm")]
 use rustc_trans;
 use rustc::middle::lang_items;
 use rustc::middle::free_region::FreeRegionMap;

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -114,7 +114,6 @@ fn test_env<F>(source_string: &str,
                                        diagnostic_handler,
                                        Rc::new(CodeMap::new(FilePathMapping::empty())),
                                        cstore.clone());
-    #[cfg(feature="llvm")]
     rustc_trans::init(&sess);
     rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
     let input = config::Input::Str {

--- a/src/librustc_trans_utils/link.rs
+++ b/src/librustc_trans_utils/link.rs
@@ -8,34 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use rustc::session::config::{self, /*NoDebugInfo,*/ OutputFilenames, Input, OutputType};
-/*use rustc::session::filesearch;
-use rustc::session::search_paths::PathKind;
-*/use rustc::session::Session;
-use rustc::middle::cstore;/*::{self, LinkMeta, NativeLibrary, LibSource, LinkagePreference,
-                            NativeLibraryKind};*/
-/*use rustc::middle::dependency_format::Linkage;
-use rustc::util::common::time;
-use rustc::util::fs::fix_windows_verbatim_for_gcc;
-use rustc::dep_graph::{DepKind, DepNode};
-use rustc::hir::def_id::CrateNum;
-use rustc::hir::svh::Svh;
-use rustc_back::tempdir::TempDir;
-use rustc_back::{PanicStrategy, RelroLevel};
-use rustc_incremental::IncrementalHashesMap;*/
-
-/*use std::ascii;
-use std::char;
-use std::env;
-use std::ffi::OsString;
-use std::fs;
-use std::io::{self, Read, Write};
-use std::mem;
-*/use std::path::PathBuf;/*{Path, PathBuf};
-use std::process::Command;
-use std::str;*/
+use rustc::session::config::{self, OutputFilenames, Input, OutputType};
+use rustc::session::Session;
+use rustc::middle::cstore;
+use std::path::PathBuf;
 use syntax::ast;
-//use syntax::attr;
 use syntax_pos::Span;
 
 pub fn find_crate_name(sess: Option<&Session>,


### PR DESCRIPTION
This includes a small patch to allow running tests without llvm. Also check if you are not trying to compile a dylib.

cc #42932
r? @alexcrichton