### PR TITLE
Point out missing if conditional

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2968,7 +2968,12 @@ impl<'a> Parser<'a> {
         }
         let lo = self.prev_span;
         let cond = self.parse_expr_res(RESTRICTION_NO_STRUCT_LITERAL, None)?;
-        if self.eat_keyword(keywords::Else) {
+
+        // Verify that the parsed `if` condition makes sense as a condition. If it is a block, then
+        // verify that the last statement is either an implicit return (no `;`) or an explicit
+        // return. This won't catch blocks with an explicit `return`, but that would be caught by
+        // the dead code lint.
+        if self.eat_keyword(keywords::Else) || !cond.returns() {
             let sp = lo.next_point();
             let mut err = self.diagnostic()
                 .struct_span_err(sp, "missing condition for `if` statemement");

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2130,7 +2130,7 @@ impl<'a> Parser<'a> {
                     return self.parse_lambda_expr(lo, CaptureBy::Value, attrs);
                 }
                 if self.eat_keyword(keywords::If) {
-                    return self.parse_if_expr(attrs);
+                    return self.parse_if_expr(attrs, false);
                 }
                 if self.eat_keyword(keywords::For) {
                     let lo = self.prev_span;
@@ -2962,13 +2962,25 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse an 'if' or 'if let' expression ('if' token already eaten)
-    pub fn parse_if_expr(&mut self, attrs: ThinVec<Attribute>) -> PResult<'a, P<Expr>> {
+    pub fn parse_if_expr(&mut self, attrs: ThinVec<Attribute>,
+                         in_else: bool) -> PResult<'a, P<Expr>> {
         if self.check_keyword(keywords::Let) {
             return self.parse_if_let_expr(attrs);
         }
         let lo = self.prev_span;
         let cond = self.parse_expr_res(RESTRICTION_NO_STRUCT_LITERAL, None)?;
-        let thn = self.parse_block()?;
+        let thn = self.parse_block().map_err(|mut err| {
+            if in_else {
+                err.cancel();
+                let sp = lo.next_point();
+                let mut err = self.diagnostic()
+                    .struct_span_err(sp, "missing condition for `if` statemement");
+                err.span_label(sp, "expected if condition here");
+                err
+            } else {
+                err
+            }
+        })?;
         let mut els: Option<P<Expr>> = None;
         let mut hi = thn.span;
         if self.eat_keyword(keywords::Else) {
@@ -3025,7 +3037,7 @@ impl<'a> Parser<'a> {
     // `else` token already eaten
     pub fn parse_else_expr(&mut self) -> PResult<'a, P<Expr>> {
         if self.eat_keyword(keywords::If) {
-            return self.parse_if_expr(ThinVec::new());
+            return self.parse_if_expr(ThinVec::new(), true);
         } else {
             let blk = self.parse_block()?;
             return Ok(self.mk_expr(blk.span, ExprKind::Block(blk), ThinVec::new()));

--- a/src/test/ui/issue-13483.rs
+++ b/src/test/ui/issue-13483.rs
@@ -14,9 +14,3 @@ fn main() {
     } else {
     };
 }
-
-fn foo() {
-    if true {
-    } else if { //ERROR: MISSING CONDITIONAL
-    };
-}

--- a/src/test/ui/issue-13483.rs
+++ b/src/test/ui/issue-13483.rs
@@ -10,7 +10,16 @@
 
 fn main() {
     if true {
-    } else if { //ERROR: MISSING CONDITIONAL
+    } else if {
     } else {
-    };
+    }
 }
+
+fn foo() {
+    if true {
+    } else if {
+    }
+    bar();
+}
+
+fn bar() {}

--- a/src/test/ui/issue-13483.rs
+++ b/src/test/ui/issue-13483.rs
@@ -1,0 +1,22 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    if true {
+    } else if { //ERROR: MISSING CONDITIONAL
+    } else {
+    };
+}
+
+fn foo() {
+    if true {
+    } else if { //ERROR: MISSING CONDITIONAL
+    };
+}

--- a/src/test/ui/issue-13483.stderr
+++ b/src/test/ui/issue-13483.stderr
@@ -4,11 +4,5 @@ error: missing condition for `if` statemement
 13 |     } else if { //ERROR: MISSING CONDITIONAL
    |              ^ expected if condition here
 
-error: missing conditional
-  --> $DIR/issue-13483.rs:20:14
-   |
-20 |     } else if { //ERROR: MISSING CONDITIONAL
-   |              ^ expected if condition here
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 

--- a/src/test/ui/issue-13483.stderr
+++ b/src/test/ui/issue-13483.stderr
@@ -1,8 +1,14 @@
 error: missing condition for `if` statemement
   --> $DIR/issue-13483.rs:13:14
    |
-13 |     } else if { //ERROR: MISSING CONDITIONAL
+13 |     } else if {
    |              ^ expected if condition here
 
-error: aborting due to previous error
+error: missing condition for `if` statemement
+  --> $DIR/issue-13483.rs:20:14
+   |
+20 |     } else if {
+   |              ^ expected if condition here
+
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/issue-13483.stderr
+++ b/src/test/ui/issue-13483.stderr
@@ -1,0 +1,14 @@
+error: missing condition for `if` statemement
+  --> $DIR/issue-13483.rs:13:14
+   |
+13 |     } else if { //ERROR: MISSING CONDITIONAL
+   |              ^ expected if condition here
+
+error: missing conditional
+  --> $DIR/issue-13483.rs:20:14
+   |
+20 |     } else if { //ERROR: MISSING CONDITIONAL
+   |              ^ expected if condition here
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
On a case where an else conditional is missing, point this out
instead of the token immediately after the (incorrect) else block:

```
error: missing condition for `if` statemementt push fork -f

  --> $DIR/issue-13483.rs:16:5
   |
13 |    } else if {
   |             ^ expected if condition here
```

instead of

```
error: expected `{`, found `else`
  --> ../../src/test/ui/issue-13483.rs:14:7
   |
14 |     } else {
   |       ^^^^
```

Fix #13483.