### PR TITLE
Mark closures returned via impl-trait as reachable.

### DIFF
--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -296,6 +296,9 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
                     hir::ImplItemKind::Type(_) => {}
                 }
             }
+            hir_map::NodeExpr(&hir::Expr { node: hir::ExprClosure(.., body, _), .. }) => {
+                self.visit_nested_body(body);
+            }
             // Nothing to recurse on for these
             hir_map::NodeForeignItem(_) |
             hir_map::NodeVariant(_) |

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -448,6 +448,7 @@ impl<'b, 'a, 'tcx> TypeVisitor<'tcx> for ReachEverythingInTheInterfaceVisitor<'b
             ty::TyDynamic(ref obj, ..) => obj.principal().map(|p| p.def_id()),
             ty::TyProjection(ref proj) => Some(proj.item_def_id),
             ty::TyFnDef(def_id, ..) |
+            ty::TyClosure(def_id, ..) |
             ty::TyAnon(def_id, _) => Some(def_id),
             _ => None
         };

--- a/src/test/run-pass/impl-trait/auxiliary/xcrate.rs
+++ b/src/test/run-pass/impl-trait/auxiliary/xcrate.rs
@@ -13,3 +13,14 @@
 pub fn fourway_add(a: i32) -> impl Fn(i32) -> impl Fn(i32) -> impl Fn(i32) -> i32 {
     move |b| move |c| move |d| a + b + c + d
 }
+
+fn some_internal_fn() -> u32 {
+    1
+}
+
+// See #40839
+pub fn return_closure_accessing_internal_fn() -> impl Fn() -> u32 {
+    || {
+        some_internal_fn() + 1
+    }
+}

--- a/src/test/run-pass/impl-trait/xcrate.rs
+++ b/src/test/run-pass/impl-trait/xcrate.rs
@@ -14,4 +14,5 @@ extern crate xcrate;
 
 fn main() {
     assert_eq!(xcrate::fourway_add(1)(2)(3)(4), 10);
+    xcrate::return_closure_accessing_internal_fn()();
 }


### PR DESCRIPTION
This should fix some of the open `impl trait` issues, like #40839, #43135, and #35870. 

r? @eddyb 