### PR TITLE
rustdoc: put auto-hidden docblock labels in line with the toggle

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1271,7 +1271,7 @@
                     e.innerHTML = labelForToggleButton(true);
                 });
                 onEach(toggle.getElementsByClassName('toggle-label'), function(e) {
-                    e.style.display = 'block';
+                    e.style.display = 'inline-block';
                 });
             }
         }


### PR DESCRIPTION
before:

![image](https://user-images.githubusercontent.com/5217170/29279951-0cf21d86-80df-11e7-86d5-bfd76c5df429.png)

after:

![image](https://user-images.githubusercontent.com/5217170/29279962-18479ce2-80df-11e7-952a-d22cb03965e5.png)

(images taken from `std::heap::AllocErr`)