### PR TITLE
Ship the rustdoc book

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -266,7 +266,7 @@ impl<'a> Builder<'a> {
             Kind::Bench => describe!(check::Crate, check::CrateLibrustc),
             Kind::Doc => describe!(doc::UnstableBook, doc::UnstableBookGen, doc::TheBook,
                 doc::Standalone, doc::Std, doc::Test, doc::Rustc, doc::ErrorIndex, doc::Nomicon,
-                doc::Reference),
+                doc::Reference, doc::Rustdoc),
             Kind::Dist => describe!(dist::Docs, dist::Mingw, dist::Rustc, dist::DebuggerScripts,
                 dist::Std, dist::Analysis, dist::Src, dist::PlainSourceTarball, dist::Cargo,
                 dist::Rls, dist::Extended, dist::HashSign),

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -68,6 +68,7 @@ macro_rules! book {
 book!(
     Nomicon, "src/doc/book", "nomicon";
     Reference, "src/doc/reference", "reference";
+    Rustdoc, "src/doc/rustdoc", "rustdoc";
 );
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -31,6 +31,7 @@ nicknamed 'The Rust Bookshelf.'
 * [The Unstable Book][unstable-book] has documentation for unstable features.
 * [The Rustonomicon][nomicon] is your guidebook to the dark arts of unsafe Rust.
 * [The Reference][ref] is not a formal spec, but is more detailed and comprehensive than the book.
+* [The Rustdoc Book][rustdoc-book] describes our documentation tool, `rustdoc`.
 
 Initially, documentation lands in the Unstable Book, and then, as part of the
 stabilization process, is moved into the Book, Nomicon, or Reference.
@@ -51,4 +52,5 @@ before this policy was put into place. That work is being tracked
 [book]: book/index.html
 [nomicon]: nomicon/index.html
 [unstable-book]: unstable-book/index.html
+[rustdoc-book]: rustdoc/index.html
 

--- a/src/doc/rustdoc/src/SUMMARY.md
+++ b/src/doc/rustdoc/src/SUMMARY.md
@@ -4,5 +4,4 @@
 - [Command-line arguments](command-line-arguments.md)
 - [In-source directives](in-source-directives.md)
 - [Documentation tests](documentation-tests.md)
-- [Plugins](plugins.md)
 - [Passes](passes.md)

--- a/src/doc/rustdoc/src/command-line-arguments.md
+++ b/src/doc/rustdoc/src/command-line-arguments.md
@@ -141,20 +141,6 @@ Similar to `--library-path`, `--extern` is about specifying the location
 of a dependency. `--library-path` provides directories to search in, `--extern`
 instead lets you specify exactly which dependency is located where.
 
-
-## `--plugin-path`: loading plugins
-
-Using this flag looks like this:
-
-```bash
-$ rustdoc src/lib.rs --plugin-path=/path/to/plugins
-```
-
-Similar to `--library-path`, but for plugins. For more, see
-the [chapter on plugins](plugins.html).
-
-See also: `--plugins`.
-
 ## `--passes`: add more rustdoc passes
 
 Using this flag looks like this:
@@ -170,18 +156,6 @@ arguments will be the name of which passes to run in addition to the defaults.
 For more details on passes, see [the chapter on them](passes.html).
 
 See also `--no-defaults`.
-
-## `--plugins`: 
-
-Using this flag looks like this:
-
-```bash
-$ rustdoc src/lib.rs --plugins foo bar
-```
-
-For more, see the [chapter on plugins](plugins.html).
-
-See also: `--plugin-path`.
 
 ## `--no-defaults`: don't run default passes
 

--- a/src/doc/rustdoc/src/plugins.md
+++ b/src/doc/rustdoc/src/plugins.md
@@ -1,3 +1,0 @@
-# Plugins
-
-Coming soon!


### PR DESCRIPTION
Fixes #42322, as it's the last step.

Blocked on https://github.com/rust-lang/rust/pull/43790, though they will not conflict.

r? @rust-lang/docs 