### PR TITLE
Remove useless help part

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2944,8 +2944,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             type_error_struct!(self.tcx().sess, field.span, expr_t, E0615,
                               "attempted to take value of method `{}` on type `{}`",
                               field.node, expr_t)
-                .help("maybe a `()` to call it is missing? \
-                       If not, try an anonymous function")
+                .help("maybe a `()` to call it is missing?")
                 .emit();
             self.tcx().types.err
         } else {


### PR DESCRIPTION
Part of #32658.

I think this error should be splitted into two parts, each more specific (`anonymous function` vs `type method`).