### PR TITLE
rustbuild: Set ignore-git based on `channel`

### DIFF
--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -44,7 +44,7 @@ struct Info {
 impl GitInfo {
     pub fn new(config: &Config, dir: &Path) -> GitInfo {
         // See if this even begins to look like a git dir
-        if config.ignore_git || !dir.join(".git").exists() {
+        if config.ignore_git == Some(true) || !dir.join(".git").exists() {
             return GitInfo { inner: None }
         }
 

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -54,7 +54,7 @@ pub struct Config {
     pub extended: bool,
     pub sanitizers: bool,
     pub profiler: bool,
-    pub ignore_git: bool,
+    pub ignore_git: Option<bool>,
 
     pub run_host_only: bool,
 
@@ -296,7 +296,6 @@ impl Config {
         config.rust_codegen_units = 1;
         config.channel = "dev".to_string();
         config.codegen_tests = true;
-        config.ignore_git = false;
         config.rust_dist_src = true;
 
         config.on_fail = flags.on_fail;
@@ -419,7 +418,7 @@ impl Config {
             set(&mut config.use_jemalloc, rust.use_jemalloc);
             set(&mut config.backtrace, rust.backtrace);
             set(&mut config.channel, rust.channel.clone());
-            set(&mut config.ignore_git, rust.ignore_git);
+            config.ignore_git = rust.ignore_git;
             config.rustc_default_linker = rust.default_linker.clone();
             config.rustc_default_ar = rust.default_ar.clone();
             config.musl_root = rust.musl_root.clone().map(PathBuf::from);
@@ -476,6 +475,10 @@ impl Config {
         // compat with `./configure` while we're still using that
         if fs::metadata("config.mk").is_ok() {
             config.update_with_config_mk();
+        }
+
+        if config.channel == "dev" && config.ignore_git.is_none() {
+            config.ignore_git = Some(true);
         }
 
         config


### PR DESCRIPTION
This commit automatically sets `ignore-git` to `true` in configuration if the
configured channel is set to "dev" and otherwise no value for `ignore-git` has
been specified. This'll help rebuilds locally whenever a new commit is made by
ensuring that git information never makes its way to compiler crates in the
first place.

Closes #43771