### PR TITLE
Stop testing `i586-pc-windows-msvc` on AppVeyor.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
     RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-profiler
     SCRIPT: python x.py test
   - MSYS_BITS: 32
-    RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc --target=i586-pc-windows-msvc
+    RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc --target=i686-pc-windows-msvc
     SCRIPT: python x.py test --host i686-pc-windows-msvc --target i686-pc-windows-msvc
 
   # MSVC aux tests


### PR DESCRIPTION
Fixes #43881. Reduces AppVeyor test time back to ~2 hours on average.

The i586 libstd was never tested before Aug 13th, so this PR brings the situation back to the previous status-quo.
