### PR TITLE
Add clippy as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,3 +33,6 @@
 [submodule "src/libcompiler_builtins"]
 	path = src/libcompiler_builtins
 	url = https://github.com/rust-lang-nursery/compiler-builtins
+[submodule "src/tools/clippy"]
+	path = src/tools/clippy
+	url = https://github.com/rust-lang-nursery/rust-clippy.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -298,6 +298,31 @@ Speaking of tests, Rust has a comprehensive test suite. More information about
 it can be found
 [here](https://github.com/rust-lang/rust-wiki-backup/blob/master/Note-testsuite.md).
 
+### External Dependencies
+
+Currently building Rust will also build the following external projects:
+
+* [clippy](https://github.com/rust-lang-nursery/rust-clippy)
+
+If your changes break one of these projects, you need to fix them by opening
+a pull request against the broken project. When you have opened a pull request,
+you can point the submodule at your pull request by calling
+
+```
+git checkout pulls/$id_of_your_pr/head
+```
+
+within the submodule's directory. Don't forget to also add your changes with
+
+```
+git add path/to/submodule
+```
+
+outside the submodule.
+
+It can also be more convenient during development to set `submodules = false`
+in the `config.toml` to prevent `x.py` from resetting to the original branch.
+
 ## Writing Documentation
 
 Documentation improvements are very welcome. The source of `doc.rust-lang.org`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -309,8 +309,8 @@ a pull request against the broken project. When you have opened a pull request,
 you can point the submodule at your pull request by calling
 
 ```
-git fetch origin pull/$id_of_your_pr/head
-git checkout pull/$id_of_your_pr/head
+git fetch origin pull/$id_of_your_pr/head:my_pr
+git checkout my_pr
 ```
 
 within the submodule's directory. Don't forget to also add your changes with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -309,7 +309,8 @@ a pull request against the broken project. When you have opened a pull request,
 you can point the submodule at your pull request by calling
 
 ```
-git checkout pulls/$id_of_your_pr/head
+git fetch origin pull/$id_of_your_pr/head
+git checkout pull/$id_of_your_pr/head
 ```
 
 within the submodule's directory. Don't forget to also add your changes with

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -248,7 +248,7 @@ impl<'a> Builder<'a> {
                 compile::StartupObjects, tool::BuildManifest, tool::Rustbook, tool::ErrorIndex,
                 tool::UnstableBookGen, tool::Tidy, tool::Linkchecker, tool::CargoTest,
                 tool::Compiletest, tool::RemoteTestServer, tool::RemoteTestClient,
-                tool::RustInstaller, tool::Cargo, tool::Rls, tool::Rustdoc,
+                tool::RustInstaller, tool::Cargo, tool::Rls, tool::Rustdoc, tool::Clippy,
                 native::Llvm),
             Kind::Test => describe!(check::Tidy, check::Bootstrap, check::DefaultCompiletest,
                 check::HostCompiletest, check::Crate, check::CrateLibrustc, check::Linkcheck,

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -341,6 +341,44 @@ impl Step for Cargo {
 }
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct Clippy {
+    pub compiler: Compiler,
+    pub target: Interned<String>,
+}
+
+impl Step for Clippy {
+    type Output = PathBuf;
+    const DEFAULT: bool = true;
+    const ONLY_HOSTS: bool = true;
+
+    fn should_run(run: ShouldRun) -> ShouldRun {
+        run.path("src/tools/clippy")
+    }
+
+    fn make_run(run: RunConfig) {
+        run.builder.ensure(Clippy {
+            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.build),
+            target: run.target,
+        });
+    }
+
+    fn run(self, builder: &Builder) -> PathBuf {
+        // Clippy depends on procedural macros (serde), which requires a full host
+        // compiler to be available, so we need to depend on that.
+        builder.ensure(compile::Rustc {
+            compiler: self.compiler,
+            target: builder.build.build,
+        });
+        builder.ensure(ToolBuild {
+            compiler: self.compiler,
+            target: self.target,
+            tool: "clippy",
+            mode: Mode::Librustc,
+        })
+    }
+}
+
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Rls {
     pub compiler: Compiler,
     pub target: Interned<String>,

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -348,7 +348,7 @@ pub struct Clippy {
 
 impl Step for Clippy {
     type Output = PathBuf;
-    const DEFAULT: bool = true;
+    const DEFAULT: bool = false;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -62,6 +62,7 @@ fn filter_dirs(path: &Path) -> bool {
         "src/rt/hoedown",
         "src/tools/cargo",
         "src/tools/rls",
+        "src/tools/clippy",
         "src/tools/rust-installer",
     ];
     skip.iter().any(|p| path.ends_with(p))


### PR DESCRIPTION
~~This builds clippy as part of `./x.py build` (locally and in CI).~~

This allows building clippy with `./x.py build src/tools/clippy`

~~Needs https://github.com/nrc/dev-tools-team/issues/18#issuecomment-322456461 to be resolved before it can be merged.~~ Contributers can simply open a PR to clippy and point the submodule at the `pull/$pr_number/head` branch.

This does **not** build clippy or test the clippy test suite at all as per https://github.com/nrc/dev-tools-team/issues/18#issuecomment-321411418 

r? @nrc 

cc @Manishearth @llogiq @mcarton @alexcrichton 