### PR TITLE
Fix typos & us spellings

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -444,7 +444,7 @@ impl Build {
     }
 
     /// Returns the root output directory for all Cargo output in a given stage,
-    /// running a particular compiler, wehther or not we're building the
+    /// running a particular compiler, whether or not we're building the
     /// standard library, and targeting the specified architecture.
     fn cargo_out(&self,
                  compiler: Compiler,

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -11,7 +11,7 @@
 //! Compilation of native dependencies like LLVM.
 //!
 //! Native projects like LLVM unfortunately aren't suited just yet for
-//! compilation in build scripts that Cargo has. This is because thie
+//! compilation in build scripts that Cargo has. This is because the
 //! compilation takes a *very* long time but also because we don't want to
 //! compile LLVM 3 times as part of a normal bootstrap (we want it cached).
 //!

--- a/src/liballoc/allocator.rs
+++ b/src/liballoc/allocator.rs
@@ -293,7 +293,7 @@ impl Layout {
     /// Creates a layout describing the record for `self` followed by
     /// `next` with no additional padding between the two. Since no
     /// padding is inserted, the alignment of `next` is irrelevant,
-    /// and is not incoporated *at all* into the resulting layout.
+    /// and is not incorporated *at all* into the resulting layout.
     ///
     /// Returns `(k, offset)`, where `k` is layout of the concatenated
     /// record and `offset` is the relative location, in bytes, of the
@@ -528,7 +528,7 @@ pub unsafe trait Alloc {
     ///   to allocate that block of memory.
     unsafe fn dealloc(&mut self, ptr: *mut u8, layout: Layout);
 
-    /// Allocator-specific method for signalling an out-of-memory
+    /// Allocator-specific method for signaling an out-of-memory
     /// condition.
     ///
     /// `oom` aborts the thread or process, optionally performing
@@ -539,7 +539,7 @@ pub unsafe trait Alloc {
     /// unsatisfied allocation request (signaled by an error such as
     /// `AllocErr::Exhausted`), and wish to abandon computation rather
     /// than attempt to recover locally. Such clients should pass the
-    /// signalling error value back into `oom`, where the allocator
+    /// signaling error value back into `oom`, where the allocator
     /// may incorporate that error value into its diagnostic report
     /// before aborting.
     ///

--- a/src/liballoc/btree/node.rs
+++ b/src/liballoc/btree/node.rs
@@ -763,7 +763,7 @@ impl<Node: Copy, Type> Clone for Handle<Node, Type> {
 }
 
 impl<Node, Type> Handle<Node, Type> {
-    /// Retrieves the node that contains the edge of key/value pair this handle pointes to.
+    /// Retrieves the node that contains the edge of key/value pair this handle points to.
     pub fn into_node(self) -> Node {
         self.node
     }

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -544,12 +544,12 @@ impl<T, A: Alloc> RawVec<T, A> {
     /// Attempts to ensure that the buffer contains at least enough space to hold
     /// `used_cap + needed_extra_cap` elements. If it doesn't already have
     /// enough capacity, will reallocate in place enough space plus comfortable slack
-    /// space to get amortized `O(1)` behaviour. Will limit this behaviour
+    /// space to get amortized `O(1)` behavior. Will limit this behaviour
     /// if it would needlessly cause itself to panic.
     ///
     /// If `used_cap` exceeds `self.cap()`, this may fail to actually allocate
     /// the requested space. This is not really unsafe, but the unsafe
-    /// code *you* write that relies on the behaviour of this function may break.
+    /// code *you* write that relies on the behavior of this function may break.
     ///
     /// Returns true if the reallocation attempt has succeeded, or false otherwise.
     ///

--- a/src/libcore/num/dec2flt/rawfp.rs
+++ b/src/libcore/num/dec2flt/rawfp.rs
@@ -102,10 +102,10 @@ pub trait RawFloat : Float + Copy + Debug + LowerExp
     /// The number of bits in the exponent.
     const EXP_BITS: u8;
 
-    /// The number of bits in the singificand, *including* the hidden bit.
+    /// The number of bits in the significand, *including* the hidden bit.
     const SIG_BITS: u8;
 
-    /// The number of bits in the singificand, *excluding* the hidden bit.
+    /// The number of bits in the significand, *excluding* the hidden bit.
     const EXPLICIT_SIG_BITS: u8;
 
     /// The maximum legal exponent in fractional representation.
@@ -123,7 +123,7 @@ pub trait RawFloat : Float + Copy + Debug + LowerExp
     /// `MIN_EXP` for integral representation, i.e., with the shift applied.
     const MIN_EXP_INT: i16;
 
-    /// The maximum normalized singificand in integral representation.
+    /// The maximum normalized significand in integral representation.
     const MAX_SIG: u64;
 
     /// The minimal normalized significand in integral representation.

--- a/src/libcore/ops/try.rs
+++ b/src/libcore/ops/try.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-/// A trait for customizing the behaviour of the `?` operator.
+/// A trait for customizing the behavior of the `?` operator.
 ///
 /// A type implementing `Try` is one that has a canonical way to view it
 /// in terms of a success/failure dichotomy.  This trait allows both

--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -1632,7 +1632,7 @@ unsafe fn atomic_xor<T>(dst: *mut T, val: T, order: Ordering) -> T {
 ///
 ///     pub fn lock(&self) {
 ///         while !self.flag.compare_and_swap(false, true, Ordering::Relaxed) {}
-///         // This fence syncronizes-with store in `unlock`.
+///         // This fence synchronizes-with store in `unlock`.
 ///         fence(Ordering::Acquire);
 ///     }
 ///

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -11,7 +11,7 @@
 //! Generate files suitable for use with [Graphviz](http://www.graphviz.org/)
 //!
 //! The `render` function generates output (e.g. an `output.dot` file) for
-//! use with [Graphviz](http://www.graphviz.org/) by walking a labelled
+//! use with [Graphviz](http://www.graphviz.org/) by walking a labeled
 //! graph. (Graphviz can then automatically lay out the nodes and edges
 //! of the graph, and also optionally render the graph as an image or
 //! other [output formats](
@@ -150,7 +150,7 @@
 //!
 //! The output from this example renders four nodes that make up the
 //! Hasse-diagram for the subsets of the set `{x, y}`. Each edge is
-//! labelled with the &sube; character (specified using the HTML character
+//! labeled with the &sube; character (specified using the HTML character
 //! entity `&sube`).
 //!
 //! ```rust
@@ -789,7 +789,7 @@ mod tests {
     }
 
     struct LabelledGraph {
-        /// The name for this graph. Used for labelling generated `digraph`.
+        /// The name for this graph. Used for labeling generated `digraph`.
         name: &'static str,
 
         /// Each node is an index into `node_labels`; these labels are

--- a/src/librand/distributions/gamma.rs
+++ b/src/librand/distributions/gamma.rs
@@ -254,7 +254,7 @@ impl IndependentSample<f64> for ChiSquared {
 
 /// The Fisher F distribution `F(m, n)`.
 ///
-/// This distribution is equivalent to the ratio of two normalised
+/// This distribution is equivalent to the ratio of two normalized
 /// chi-squared distributions, that is, `F(m,n) = (χ²(m)/m) /
 /// (χ²(n)/n)`.
 pub struct FisherF {

--- a/src/librand/isaac.rs
+++ b/src/librand/isaac.rs
@@ -76,7 +76,7 @@ impl IsaacRng {
         rng
     }
 
-    /// Initialises `self`. If `use_rsl` is true, then use the current value
+    /// Initializes `self`. If `use_rsl` is true, then use the current value
     /// of `rsl` as a seed, otherwise construct one algorithmically (not
     /// randomly).
     fn init(&mut self, use_rsl: bool) {
@@ -367,7 +367,7 @@ impl Isaac64Rng {
         rng
     }
 
-    /// Initialises `self`. If `use_rsl` is true, then use the current value
+    /// Initializes `self`. If `use_rsl` is true, then use the current value
     /// of `rsl` as a seed, otherwise construct one algorithmically (not
     /// randomly).
     fn init(&mut self, use_rsl: bool) {

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -180,7 +180,7 @@ pub trait Rng: Sized {
     /// This method does *not* have a requirement to bear any fixed
     /// relationship to the other methods, for example, it does *not*
     /// have to result in the same output as progressively filling
-    /// `dest` with `self.gen::<u8>()`, and any such behaviour should
+    /// `dest` with `self.gen::<u8>()`, and any such behavior should
     /// not be relied upon.
     ///
     /// This method should guarantee that `dest` is entirely filled

--- a/src/librand/reseeding.rs
+++ b/src/librand/reseeding.rs
@@ -24,7 +24,7 @@ pub struct ReseedingRng<R, Rsdr> {
     rng: R,
     generation_threshold: usize,
     bytes_generated: usize,
-    /// Controls the behaviour when reseeding the RNG.
+    /// Controls the behavior when reseeding the RNG.
     pub reseeder: Rsdr,
 }
 

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -731,7 +731,7 @@ impl<'hir> Map<'hir> {
 
     /// Returns the nearest enclosing scope. A scope is an item or block.
     /// FIXME it is not clear to me that all items qualify as scopes - statics
-    /// and associated types probably shouldn't, for example. Behaviour in this
+    /// and associated types probably shouldn't, for example. Behavior in this
     /// regard should be expected to be highly unstable.
     pub fn get_enclosing_scope(&self, id: NodeId) -> Option<NodeId> {
         match self.walk_parent_nodes(id, |node| match *node {

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -24,7 +24,7 @@
 //! a span, but also more information so that we can generate a meaningful
 //! error message.
 //!
-//! Having a catalogue of all the different reasons an error can arise is
+//! Having a catalog of all the different reasons an error can arise is
 //! also useful for other reasons, like cross-referencing FAQs etc, though
 //! we are not really taking advantage of this yet.
 //!

--- a/src/librustc/infer/resolve.rs
+++ b/src/librustc/infer/resolve.rs
@@ -46,7 +46,7 @@ impl<'a, 'gcx, 'tcx> TypeFolder<'gcx, 'tcx> for OpportunisticTypeResolver<'a, 'g
 }
 
 /// The opportunistic type and region resolver is similar to the
-/// opportunistic type resolver, but also opportunistly resolves
+/// opportunistic type resolver, but also opportunistically resolves
 /// regions. It is useful for canonicalization.
 pub struct OpportunisticTypeAndRegionResolver<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
     infcx: &'a InferCtxt<'a, 'gcx, 'tcx>,

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -101,7 +101,7 @@ pub struct FutureIncompatibleInfo {
     pub reference: &'static str // e.g., a URL for an issue/PR/RFC or error code
 }
 
-/// The targed of the `by_name` map, which accounts for renaming/deprecation.
+/// The target of the `by_name` map, which accounts for renaming/deprecation.
 enum TargetLint {
     /// A direct lint target
     Id(LintId),

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -72,7 +72,7 @@ use mir::transform::MirSource;
 ///  (M1.): Misc extent of the whole `let a = ...;` statement.
 ///  (M2.): Misc extent of the `f()` expression.
 ///  (M3.): Misc extent of the `f().g(..)` expression.
-///  (M4.): Misc extent of the block labelled `'b:`.
+///  (M4.): Misc extent of the block labeled `'b:`.
 ///  (M5.): Misc extent of the `let x = d();` statement
 ///  (D6.): DestructionScope for temporaries created during M5.
 ///  (R7.): Remainder extent for block `'b:`, stmt 0 (let x = ...).

--- a/src/librustc/mir/traversal.rs
+++ b/src/librustc/mir/traversal.rs
@@ -216,7 +216,7 @@ impl<'a, 'tcx> Iterator for Postorder<'a, 'tcx> {
 ///
 /// Reverse postorder is the reverse order of a postorder traversal.
 /// This is different to a preorder traversal and represents a natural
-/// linearisation of control-flow.
+/// linearization of control-flow.
 ///
 /// ```text
 ///

--- a/src/librustc/traits/fulfill.rs
+++ b/src/librustc/traits/fulfill.rs
@@ -37,7 +37,7 @@ impl<'tcx> ForestObligation for PendingPredicateObligation<'tcx> {
 /// consists of a list of obligations that must be (eventually)
 /// satisfied. The job is to track which are satisfied, which yielded
 /// errors, and which are still pending. At any point, users can call
-/// `select_where_possible`, and the fulfilment context will try to do
+/// `select_where_possible`, and the fulfillment context will try to do
 /// selection, retaining only those obligations that remain
 /// ambiguous. This may be helpful in pushing type inference
 /// along. Once all type inference constraints have been generated, the

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -851,7 +851,7 @@ pub struct GlobalCtxt<'tcx> {
 
     /// A vector of every trait accessible in the whole crate
     /// (i.e. including those from subcrates). This is used only for
-    /// error reporting, and so is lazily initialised and generally
+    /// error reporting, and so is lazily initialized and generally
     /// shouldn't taint the common path (hence the RefCell).
     pub all_traits: RefCell<Option<Vec<DefId>>>,
 }

--- a/src/librustc/ty/inhabitedness/def_id_forest.rs
+++ b/src/librustc/ty/inhabitedness/def_id_forest.rs
@@ -26,7 +26,7 @@ pub struct DefIdForest {
     /// The minimal set of DefIds required to represent the whole set.
     /// If A and B are DefIds in the DefIdForest, and A is a descendant
     /// of B, then only B will be in root_ids.
-    /// We use a SmallVec here because (for its use for cacheing inhabitedness)
+    /// We use a SmallVec here because (for its use for caching inhabitedness)
     /// its rare that this will contain even two ids.
     root_ids: SmallVec<[DefId; 1]>,
 }

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -739,7 +739,7 @@ pub type Region<'tcx> = &'tcx RegionKind;
 ///
 /// The process of doing that is called "skolemization". The bound regions
 /// are replaced by skolemized markers, which don't satisfy any relation
-/// not explicity provided.
+/// not explicitly provided.
 ///
 /// There are 2 kinds of skolemized regions in rustc: `ReFree` and
 /// `ReSkolemized`. When checking an item's body, `ReFree` is supposed

--- a/src/librustc_data_structures/accumulate_vec.rs
+++ b/src/librustc_data_structures/accumulate_vec.rs
@@ -13,7 +13,7 @@
 //! Space for up to N elements is provided on the stack.  If more elements are collected, Vec is
 //! used to store the values on the heap.
 //!
-//! The N above is determined by Array's implementor, by way of an associatated constant.
+//! The N above is determined by Array's implementor, by way of an associated constant.
 
 use std::ops::{Deref, DerefMut};
 use std::iter::{self, IntoIterator, FromIterator};

--- a/src/librustc_data_structures/ivar.rs
+++ b/src/librustc_data_structures/ivar.rs
@@ -14,7 +14,7 @@ use std::cell::Cell;
 /// A write-once variable. When constructed, it is empty, and
 /// can only be set once.
 ///
-/// Ivars ensure that data that can only be initialised once. A full
+/// Ivars ensure that data that can only be initialized once. A full
 /// implementation is used for concurrency and blocks on a read of an
 /// unfulfilled value. This implementation is more minimal and panics
 /// if you attempt to read the value before it has been set. It is also

--- a/src/librustc_data_structures/small_vec.rs
+++ b/src/librustc_data_structures/small_vec.rs
@@ -14,7 +14,7 @@
 //! used to store the values on the heap. SmallVec is similar to AccumulateVec, but adds
 //! the ability to push elements.
 //!
-//! The N above is determined by Array's implementor, by way of an associatated constant.
+//! The N above is determined by Array's implementor, by way of an associated constant.
 
 use std::ops::{Deref, DerefMut};
 use std::iter::{IntoIterator, FromIterator};

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -306,7 +306,7 @@ pub fn source_name(input: &Input) -> String {
     }
 }
 
-/// CompileController is used to customise compilation, it allows compilation to
+/// CompileController is used to customize compilation, it allows compilation to
 /// be stopped and/or to call arbitrary code at various points in compilation.
 /// It also allows for various flags to be set to influence what information gets
 /// collected during compilation.

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -93,9 +93,9 @@ impl Diagnostic {
     }
 
     /// Cancel the diagnostic (a structured diagnostic must either be emitted or
-    /// cancelled or it will panic when dropped).
+    /// canceled or it will panic when dropped).
     /// BEWARE: if this DiagnosticBuilder is an error, then creating it will
-    /// bump the error count on the Handler and cancelling it won't undo that.
+    /// bump the error count on the Handler and canceling it won't undo that.
     /// If you want to decrement the error count you should use `Handler::cancel`.
     pub fn cancel(&mut self) {
         self.level = Level::Cancelled;

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -198,7 +198,7 @@ impl<'a> Debug for DiagnosticBuilder<'a> {
     }
 }
 
-/// Destructor bomb - a `DiagnosticBuilder` must be either emitted or cancelled
+/// Destructor bomb - a `DiagnosticBuilder` must be either emitted or canceled
 /// or we emit a bug.
 impl<'a> Drop for DiagnosticBuilder<'a> {
     fn drop(&mut self) {

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -822,7 +822,7 @@ impl EmitterWriter {
             .map(|_| " ")
             .collect::<String>();
 
-        /// Return wether `style`, or the override if present and the style is `NoStyle`.
+        /// Return whether `style`, or the override if present and the style is `NoStyle`.
         fn style_or_override(style: Style, override_style: Option<Style>) -> Style {
             if let Some(o) = override_style {
                 if style == Style::NoStyle {

--- a/src/librustc_errors/snippet.rs
+++ b/src/librustc_errors/snippet.rs
@@ -141,7 +141,7 @@ pub struct Annotation {
 }
 
 impl Annotation {
-    /// Wether this annotation is a vertical line placeholder.
+    /// Whether this annotation is a vertical line placeholder.
     pub fn is_line(&self) -> bool {
         if let AnnotationType::MultilineLine(_) = self.annotation_type {
             true

--- a/src/librustc_incremental/persist/preds/compress/construct.rs
+++ b/src/librustc_incremental/persist/preds/compress/construct.rs
@@ -14,7 +14,7 @@
 //! representation of the DAG):
 //!
 //! - SCCs, in the form of a union-find repr that can convert each node to
-//!   its *cycle head* (an arbitrarly chosen representative from the cycle)
+//!   its *cycle head* (an arbitrarily chosen representative from the cycle)
 //! - a vector of *leaf nodes*, just a convenience
 //! - a vector of *parents* for each node (in some cases, nodes have no parents,
 //!   or their parent is another member of same cycle; in that case, the vector

--- a/src/librustc_trans/attributes.rs
+++ b/src/librustc_trans/attributes.rs
@@ -47,7 +47,7 @@ pub fn unwind(val: ValueRef, can_unwind: bool) {
     Attribute::NoUnwind.toggle_llfn(Function, val, !can_unwind);
 }
 
-/// Tell LLVM whether it should optimise function for size.
+/// Tell LLVM whether it should optimize function for size.
 #[inline]
 #[allow(dead_code)] // possibly useful function
 pub fn set_optimize_for_size(val: ValueRef, optimize: bool) {

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -664,7 +664,7 @@ fn check_for_rustc_errors_attr(tcx: TyCtxt) {
     }
 }
 
-/// Create the `main` function which will initialise the rust runtime and call
+/// Create the `main` function which will initialize the rust runtime and call
 /// users main function.
 fn maybe_create_entry_wrapper(ccx: &CrateContext) {
     let (main_def_id, span) = match *ccx.sess().entry_fn.borrow() {

--- a/src/librustc_trans/debuginfo/doc.rs
+++ b/src/librustc_trans/debuginfo/doc.rs
@@ -92,7 +92,7 @@
 //! encounters a recursive reference, it will hit the cache and does not try to
 //! describe the type anew.
 //!
-//! This behaviour is encapsulated in the 'RecursiveTypeDescription' enum,
+//! This behavior is encapsulated in the 'RecursiveTypeDescription' enum,
 //! which represents a kind of continuation, storing all state needed to
 //! continue traversal at the type members after the type has been registered
 //! with the cache. (This implementation approach might be a tad over-
@@ -156,13 +156,13 @@
 //! (2) Structs, enums and traits have a multipart identifier
 //!
 //!     (1) The first part is the SVH (strict version hash) of the crate they
-//!          wereoriginally defined in
+//!          were originally defined in
 //!
 //!     (2) The second part is the ast::NodeId of the definition in their
-//!          originalcrate
+//!          original crate
 //!
 //!     (3) The final part is a concatenation of the type IDs of their concrete
-//!          typearguments if they are generic types.
+//!          type arguments if they are generic types.
 //!
 //! (3) Tuple-, pointer and function types are structurally identified, which
 //!     means that they are equivalent if their component types are equivalent

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -106,7 +106,7 @@ pub enum Class {
 }
 
 /// Trait that controls writing the output of syntax highlighting. Users should
-/// implement this trait to customise writing output.
+/// implement this trait to customize writing output.
 ///
 /// The classifier will call into the `Writer` implementation as it finds spans
 /// of text to highlight. Exactly how that text should be highlighted is up to

--- a/src/librustdoc/html/toc.rs
+++ b/src/librustdoc/html/toc.rs
@@ -95,7 +95,7 @@ impl TocBuilder {
     /// self.top_level, D is in C.children, and C, E, F, G are in
     /// self.chain.
     ///
-    /// When we attempt to push H, we realise that first G is not the
+    /// When we attempt to push H, we realize that first G is not the
     /// parent (level is too high) so it is popped from chain and put
     /// into F.children, then F isn't the parent (level is equal, aka
     /// sibling), so it's also popped and put into E.children.

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -400,7 +400,7 @@ pub fn main_args(args: &[String]) -> isize {
     })
 }
 
-/// Prints an uniformised error message on the standard error output
+/// Prints an uniformized error message on the standard error output
 fn print_error<T>(error_message: T) where T: Display {
     writeln!(
         &mut io::stderr(),

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -830,7 +830,7 @@ impl CStr {
     ///
     /// It is your responsibility to make sure that the underlying memory is not
     /// freed too early. For example, the following code will cause undefined
-    /// behaviour when `ptr` is used inside the `unsafe` block:
+    /// behavior when `ptr` is used inside the `unsafe` block:
     ///
     /// ```no_run
     /// use std::ffi::{CString};

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -123,7 +123,7 @@ impl OsString {
 
     /// Creates a new `OsString` with the given capacity.
     ///
-    /// The string will be able to hold exactly `capacity` lenth units of other
+    /// The string will be able to hold exactly `capacity` length units of other
     /// OS strings without reallocating. If `capacity` is 0, the string will not
     /// allocate.
     ///

--- a/src/libstd/sync/once.rs
+++ b/src/libstd/sync/once.rs
@@ -387,7 +387,7 @@ impl Drop for Finish {
 impl OnceState {
     /// Returns whether the associated [`Once`] has been poisoned.
     ///
-    /// Once an initalization routine for a [`Once`] has panicked it will forever
+    /// Once an initialization routine for a [`Once`] has panicked it will forever
     /// indicate to future forced initialization routines that it is poisoned.
     ///
     /// [`Once`]: struct.Once.html

--- a/src/libstd/sys/redox/args.rs
+++ b/src/libstd/sys/redox/args.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Global initialization and retreival of command line arguments.
+//! Global initialization and retrieval of command line arguments.
 //!
 //! On some platforms these are stored during runtime startup,
 //! and on some they are retrieved from the system on demand.

--- a/src/libstd/sys/unix/args.rs
+++ b/src/libstd/sys/unix/args.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Global initialization and retreival of command line arguments.
+//! Global initialization and retrieval of command line arguments.
 //!
 //! On some platforms these are stored during runtime startup,
 //! and on some they are retrieved from the system on demand.

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -560,7 +560,7 @@ pub fn current() -> Thread {
 /// implementing low-level shared resources or synchronization primitives.
 ///
 /// However programmers will usually prefer to use, [`channel`]s, [`Condvar`]s,
-/// [`Mutex`]es or [`join`] for their synchronisation routines, as they avoid
+/// [`Mutex`]es or [`join`] for their synchronization routines, as they avoid
 /// thinking about thread scheduling.
 ///
 /// Note that [`channel`]s for example are implemented using this primitive.

--- a/src/libstd/time/mod.rs
+++ b/src/libstd/time/mod.rs
@@ -112,7 +112,7 @@ pub struct Instant(time::Instant);
 ///            println!("{}", elapsed.as_secs());
 ///        }
 ///        Err(e) => {
-///            // an error occured!
+///            // an error occurred!
 ///            println!("Error: {:?}", e);
 ///        }
 ///    }

--- a/src/libsyntax/json.rs
+++ b/src/libsyntax/json.rs
@@ -11,7 +11,7 @@
 //! A JSON emitter for errors.
 //!
 //! This works by converting errors to a simplified structural format (see the
-//! structs at the start of the file) and then serialising them. These should
+//! structs at the start of the file) and then serializing them. These should
 //! contain as much information about the error as possible.
 //!
 //! The format of the JSON output should be considered *unstable*. For now the

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -23,7 +23,7 @@
 //!   and lifetimes for methods.)
 //! - Additional bounds on the type parameters (`TraitDef.additional_bounds`)
 //!
-//! The most important thing for implementers is the `Substructure` and
+//! The most important thing for implementors is the `Substructure` and
 //! `SubstructureFields` objects. The latter groups 5 possibilities of the
 //! arguments:
 //!


### PR DESCRIPTION
Fixing some typos and non en-US spellings. 

(Update of PR https://github.com/rust-lang/rust/pull/42812 )