### PR TITLE
Run MIR passes on promoted temporaries again.

### DIFF
--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -148,6 +148,14 @@ fn run_suite<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
         pass.run_pass(tcx, source, mir);
 
+        for (index, promoted_mir) in mir.promoted.iter_enumerated_mut() {
+            let promoted_source = MirSource::Promoted(source.item_id(), index);
+            pass.run_pass(tcx, promoted_source, promoted_mir);
+
+            // Let's make sure we don't miss any nested instances
+            assert!(promoted_mir.promoted.is_empty());
+        }
+
         for hook in tcx.mir_passes.hooks() {
             hook.on_mir_pass(tcx, suite, pass_num, &pass.name(), source, &mir, true);
         }


### PR DESCRIPTION
This seems to have been broken some time in the past (maybe here: https://github.com/rust-lang/rust/commit/9c154a67bf5c6841c39afdb90388cc3ba36dc70c#diff-2f8e8805126c84b2be3f0967ffa0af28L162). 

r? @arielb1 