### PR TITLE
Implement a temp redirect for cargo docs

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -257,7 +257,7 @@ impl<'a> Builder<'a> {
             Kind::Bench => describe!(check::Crate, check::CrateLibrustc),
             Kind::Doc => describe!(doc::UnstableBook, doc::UnstableBookGen, doc::TheBook,
                 doc::Standalone, doc::Std, doc::Test, doc::Rustc, doc::ErrorIndex, doc::Nomicon,
-                doc::Reference, doc::Rustdoc),
+                doc::Reference, doc::Rustdoc, doc::CargoBook),
             Kind::Dist => describe!(dist::Docs, dist::Mingw, dist::Rustc, dist::DebuggerScripts,
                 dist::Std, dist::Analysis, dist::Src, dist::PlainSourceTarball, dist::Cargo,
                 dist::Rls, dist::Extended, dist::HashSign),

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -240,6 +240,51 @@ impl Step for TheBook {
     }
 }
 
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct CargoBook {
+    target: Interned<String>,
+}
+
+impl Step for CargoBook {
+    type Output = ();
+    const DEFAULT: bool = true;
+
+    fn should_run(run: ShouldRun) -> ShouldRun {
+        let builder = run.builder;
+        run.path("src/doc/cargo").default_condition(builder.build.config.docs)
+    }
+
+    fn make_run(run: RunConfig) {
+        run.builder.ensure(CargoBook {
+            target: run.target,
+        });
+    }
+
+    /// Create a placeholder for the cargo documentation so that doc.rust-lang.org/cargo will
+    /// redirect to doc.crates.io. We want to publish doc.rust-lang.org/cargo in the paper
+    /// version of the book, but we don't want to rush the process of switching cargo's docs
+    /// over to mdbook and deploying them. When the cargo book is ready, this implementation
+    /// should build the mdbook instead of this redirect page.
+    fn run(self, builder: &Builder) {
+        let build = builder.build;
+        let out = build.doc_out(self.target);
+
+        let cargo_dir = out.join("cargo");
+        t!(fs::create_dir_all(&cargo_dir));
+
+        let index = cargo_dir.join("index.html");
+        let redirect_html = r#"
+            <html>
+                <head>
+                    <meta http-equiv="refresh" content="0; URL='http://doc.crates.io'" />
+                </head>
+            </html>"#;
+
+        println!("Creating cargo book redirect page");
+        t!(t!(File::create(&index)).write_all(redirect_html.as_bytes()));
+    }
+}
+
 fn invoke_rustdoc(builder: &Builder, compiler: Compiler, target: Interned<String>, markdown: &str) {
     let build = builder.build;
     let out = build.doc_out(target);


### PR DESCRIPTION
As discussed in
https://github.com/rust-lang/cargo/issues/4040#issuecomment-321639074

This is a redirect meant to be replaced once cargo docs have been
converted to mdbook. We just want *a* URL to ride the trains for now so
that we can print doc.rust-lang.org/cargo in the paper book and
guarantee that it will go *somewhere* useful by the time the book is
printed.

Implemented as a meta redirect in HTML because we don't currently have
any google juice at doc.rust-lang.org/cargo to lose.

When I run `./x.py doc`, this creates a `build/x86_64-apple-darwin/doc/cargo/index.html` file that contains a meta redirect to doc.crates.io. As I understand rust-central-station to work, this should be what we need to make `doc.rust-lang.org/cargo` to work.

r? @alexcrichton and/or @steveklabnik 