### PR TITLE
Don't highlight # which does not start an attribute in rustdoc

### DIFF
--- a/src/test/rustdoc/issue-41783.rs
+++ b/src/test/rustdoc/issue-41783.rs
@@ -12,8 +12,10 @@
 // @!has - 'space'
 // @!has - 'comment'
 // @has - '# <span class="ident">single'
-// @has - '#<span class="attribute"># <span class="ident">double</span>'
-// @has - '#<span class="attribute">#<span class="attribute"># <span class="ident">triple</span>'
+// @has - '## <span class="ident">double</span>'
+// @has - '### <span class="ident">triple</span>'
+// @has - '<span class="attribute">#[<span class="ident">outer</span>]</span>'
+// @has - '<span class="attribute">#![<span class="ident">inner</span>]</span>'
 
 /// ```no_run
 /// # # space
@@ -21,5 +23,7 @@
 /// ## single
 /// ### double
 /// #### triple
+/// ##[outer]
+/// ##![inner]
 /// ```
 pub struct Foo;


### PR DESCRIPTION
Currently when we highlight some macros for rustdoc (e.g. `quote!` from https://github.com/dtolnay/quote), we get really bad syntax highlighting, because we assume that every token between a `#` character and the next `]` in the source must be an attribute.

This patch improves that highlighting behavior to instead only highlight after finding the `[` token after the `#` token.

(NOTE: I've only run this patch against https://github.com/nrc/rustdoc-highlight so if it doesn't build on travis that's why - I don't have a recent rustc build on this laptop)

I'm guessing r? @steveklabnik