### PR TITLE
Fix ES5 regression with shorthand names.

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -596,9 +596,9 @@
             }
 
             return {
-                raw,
-                query,
-                type,
+                raw: raw,
+                query: query,
+                type: type,
                 id: query + type
             };
         }
@@ -837,7 +837,7 @@
 
                 searchWords.push(crate);
                 searchIndex.push({
-                    crate,
+                    crate: crate,
                     ty: 1, // == ExternCrate
                     name: crate,
                     path: "",


### PR DESCRIPTION
Reverts 1b6c9605e4.

I appreciate new features and syntax in Rust, but seriously, don't rewrite anything. Especially if this **breaks** documentation of language itself and every crate hosted at docs.rs.