### PR TITLE
Make the LocalKey facade of thread_local! inlineable cross-crate.

### DIFF
--- a/src/test/compile-fail/macro-local-data-key-priv.rs
+++ b/src/test/compile-fail/macro-local-data-key-priv.rs
@@ -16,5 +16,5 @@ mod bar {
 
 fn main() {
     bar::baz.with(|_| ());
-    //~^ ERROR static `baz` is private
+    //~^ ERROR `baz` is private
 }


### PR DESCRIPTION
Fixes (almost*) #25088 by changing the `LocalKey` `static` `thread_local!` generates to a `const`.
This can be done because a `LocalKey` value holds no actual TLS data, only function pointers to get at said data, and it could even be made `Copy` without any negative consequences.
The recent stabilization of rvalue promotion to `'static` allows doing this without changing the API.
r? @alexcrichton

*almost because we can't yet inline `__getit` because it breaks on MSVC, see https://github.com/rust-lang/rust/pull/43931#issuecomment-323534214