### PR TITLE
Ensure that generic arguments don't end up in attribute paths.

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1776,7 +1776,13 @@ impl<'a> Parser<'a> {
 
     pub fn parse_path_common(&mut self, style: PathStyle, enable_warning: bool)
                              -> PResult<'a, ast::Path> {
-        maybe_whole!(self, NtPath, |x| x);
+        maybe_whole!(self, NtPath, |path| {
+            if style == PathStyle::Mod &&
+               path.segments.iter().any(|segment| segment.parameters.is_some()) {
+                self.diagnostic().span_err(path.span, "unexpected generic arguments in path");
+            }
+            path
+        });
 
         let lo = self.meta_var_span.unwrap_or(self.span);
         let mut segments = Vec::new();

--- a/src/test/compile-fail/issue-43424.rs
+++ b/src/test/compile-fail/issue-43424.rs
@@ -1,0 +1,22 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(unused)]
+
+macro_rules! m {
+    ($attr_path: path) => {
+        #[$attr_path]
+        fn f() {}
+    }
+}
+
+m!(inline<u8>); //~ ERROR: unexpected generic arguments in path
+
+fn main() {}

--- a/src/test/ui/span/import-ty-params.rs
+++ b/src/test/ui/span/import-ty-params.rs
@@ -21,10 +21,10 @@ macro_rules! import {
 }
 
 fn f1() {
-    import! { a::b::c::S<u8> } //~ ERROR generic arguments in import path
+    import! { a::b::c::S<u8> } //~ ERROR unexpected generic arguments in path
 }
 fn f2() {
-    import! { a::b::c::S<> } //~ ERROR generic arguments in import path
+    import! { a::b::c::S<> } //~ ERROR unexpected generic arguments in path
 }
 
 fn main() {}

--- a/src/test/ui/span/import-ty-params.stderr
+++ b/src/test/ui/span/import-ty-params.stderr
@@ -1,14 +1,14 @@
-error: generic arguments in import path
-  --> $DIR/import-ty-params.rs:24:25
+error: unexpected generic arguments in path
+  --> $DIR/import-ty-params.rs:24:15
    |
-24 |     import! { a::b::c::S<u8> } //~ ERROR generic arguments in import path
-   |                         ^^^^
+24 |     import! { a::b::c::S<u8> } //~ ERROR unexpected generic arguments in path
+   |               ^^^^^^^^^^^^^^
 
-error: generic arguments in import path
-  --> $DIR/import-ty-params.rs:27:25
+error: unexpected generic arguments in path
+  --> $DIR/import-ty-params.rs:27:15
    |
-27 |     import! { a::b::c::S<> } //~ ERROR generic arguments in import path
-   |                         ^^
+27 |     import! { a::b::c::S<> } //~ ERROR unexpected generic arguments in path
+   |               ^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/macro-ty-params.rs
+++ b/src/test/ui/span/macro-ty-params.rs
@@ -16,16 +16,6 @@ macro_rules! m {
 
 fn main() {
     foo::<T>!();
-    //~^ ERROR generic arguments in macro path
-    //~| ERROR generic arguments in macro path
-    //~| ERROR generic arguments in macro path
     foo::<>!();
-    //~^ ERROR generic arguments in macro path
-    //~| ERROR generic arguments in macro path
-    //~| ERROR generic arguments in macro path
     m!(MyTrait<>);
-    //~^ ERROR generic arguments in macro path
-    //~| ERROR generic arguments in macro path
-    //~| ERROR generic arguments in macro path
-    //~| ERROR generic arguments in macro path
 }

--- a/src/test/ui/span/macro-ty-params.stderr
+++ b/src/test/ui/span/macro-ty-params.stderr
@@ -1,3 +1,15 @@
+error: unexpected generic arguments in path
+  --> $DIR/macro-ty-params.rs:20:8
+   |
+20 |     m!(MyTrait<>);
+   |        ^^^^^^^^^
+
+error: unexpected generic arguments in path
+  --> $DIR/macro-ty-params.rs:20:8
+   |
+20 |     m!(MyTrait<>);
+   |        ^^^^^^^^^
+
 error: generic arguments in macro path
   --> $DIR/macro-ty-params.rs:18:8
    |
@@ -5,16 +17,16 @@ error: generic arguments in macro path
    |        ^^^^^
 
 error: generic arguments in macro path
-  --> $DIR/macro-ty-params.rs:22:8
+  --> $DIR/macro-ty-params.rs:19:8
    |
-22 |     foo::<>!();
+19 |     foo::<>!();
    |        ^^^^
 
 error: generic arguments in macro path
-  --> $DIR/macro-ty-params.rs:26:15
+  --> $DIR/macro-ty-params.rs:20:15
    |
-26 |     m!(MyTrait<>);
+20 |     m!(MyTrait<>);
    |               ^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 5 previous errors
 

--- a/src/test/ui/span/visibility-ty-params.rs
+++ b/src/test/ui/span/visibility-ty-params.rs
@@ -13,11 +13,11 @@ macro_rules! m {
 }
 
 struct S<T>(T);
-m!{ S<u8> } //~ ERROR generic arguments in visibility path
+m!{ S<u8> } //~ ERROR unexpected generic arguments in path
 //~^ ERROR expected module, found struct `S`
 
 mod m {
-    m!{ m<> } //~ ERROR generic arguments in visibility path
+    m!{ m<> } //~ ERROR unexpected generic arguments in path
 }
 
 fn main() {}

--- a/src/test/ui/span/visibility-ty-params.stderr
+++ b/src/test/ui/span/visibility-ty-params.stderr
@@ -1,22 +1,14 @@
-error: generic arguments in visibility path
-  --> $DIR/visibility-ty-params.rs:16:6
-   |
-16 | m!{ S<u8> } //~ ERROR generic arguments in visibility path
-   |      ^^^^
-
-error: generic arguments in visibility path
-  --> $DIR/visibility-ty-params.rs:20:10
-   |
-20 |     m!{ m<> } //~ ERROR generic arguments in visibility path
-   |          ^^
-
-error[E0577]: expected module, found struct `S`
+error: unexpected generic arguments in path
   --> $DIR/visibility-ty-params.rs:16:5
    |
-16 | m!{ S<u8> } //~ ERROR generic arguments in visibility path
-   |     -^^^^
-   |     |
-   |     did you mean `m`?
+16 | m!{ S<u8> } //~ ERROR unexpected generic arguments in path
+   |     ^^^^^
 
-error: aborting due to 3 previous errors
+error: unexpected generic arguments in path
+  --> $DIR/visibility-ty-params.rs:20:9
+   |
+20 |     m!{ m<> } //~ ERROR unexpected generic arguments in path
+   |         ^^^
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Fixes #43424.
r? @petrochenkov or @nrc