### PR TITLE
Make fields of `Span` private

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -425,8 +425,7 @@ impl<'a> LoweringContext<'a> {
         Symbol::gensym(s)
     }
 
-    fn allow_internal_unstable(&self, reason: CompilerDesugaringKind, mut span: Span)
-        -> Span
+    fn allow_internal_unstable(&self, reason: CompilerDesugaringKind, span: Span) -> Span
     {
         let mark = Mark::fresh(Mark::root());
         mark.set_expn_info(codemap::ExpnInfo {
@@ -438,8 +437,7 @@ impl<'a> LoweringContext<'a> {
                 allow_internal_unsafe: false,
             },
         });
-        span.ctxt = SyntaxContext::empty().apply_mark(mark);
-        span
+        span.with_ctxt(SyntaxContext::empty().apply_mark(mark))
     }
 
     fn with_catch_scope<T, F>(&mut self, catch_id: NodeId, f: F) -> T
@@ -613,7 +611,7 @@ impl<'a> LoweringContext<'a> {
             TyKind::Slice(ref ty) => hir::TySlice(self.lower_ty(ty)),
             TyKind::Ptr(ref mt) => hir::TyPtr(self.lower_mt(mt)),
             TyKind::Rptr(ref region, ref mt) => {
-                let span = Span { hi: t.span.lo, ..t.span };
+                let span = t.span.with_hi(t.span.lo());
                 let lifetime = match *region {
                     Some(ref lt) => self.lower_lifetime(lt),
                     None => self.elided_lifetime(span)
@@ -1237,7 +1235,7 @@ impl<'a> LoweringContext<'a> {
             name: self.lower_ident(match f.ident {
                 Some(ident) => ident,
                 // FIXME(jseyfried) positional field hygiene
-                None => Ident { name: Symbol::intern(&index.to_string()), ctxt: f.span.ctxt },
+                None => Ident { name: Symbol::intern(&index.to_string()), ctxt: f.span.ctxt() },
             }),
             vis: self.lower_visibility(&f.vis, None),
             ty: self.lower_ty(&f.ty),

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -262,7 +262,7 @@ impl<'a> State<'a> {
                              indented: usize,
                              close_box: bool)
                              -> io::Result<()> {
-        self.maybe_print_comment(span.hi)?;
+        self.maybe_print_comment(span.hi())?;
         self.break_offset_if_not_bol(1, -(indented as isize))?;
         self.s.word("}")?;
         if close_box {
@@ -324,12 +324,12 @@ impl<'a> State<'a> {
         let len = elts.len();
         let mut i = 0;
         for elt in elts {
-            self.maybe_print_comment(get_span(elt).hi)?;
+            self.maybe_print_comment(get_span(elt).hi())?;
             op(self, elt)?;
             i += 1;
             if i < len {
                 self.s.word(",")?;
-                self.maybe_print_trailing_comment(get_span(elt), Some(get_span(&elts[i]).hi))?;
+                self.maybe_print_trailing_comment(get_span(elt), Some(get_span(&elts[i]).hi()))?;
                 self.space_if_not_bol()?;
             }
         }
@@ -368,7 +368,7 @@ impl<'a> State<'a> {
     }
 
     pub fn print_type(&mut self, ty: &hir::Ty) -> io::Result<()> {
-        self.maybe_print_comment(ty.span.lo)?;
+        self.maybe_print_comment(ty.span.lo())?;
         self.ibox(0)?;
         match ty.node {
             hir::TySlice(ref ty) => {
@@ -458,7 +458,7 @@ impl<'a> State<'a> {
 
     pub fn print_foreign_item(&mut self, item: &hir::ForeignItem) -> io::Result<()> {
         self.hardbreak_if_not_bol()?;
-        self.maybe_print_comment(item.span.lo)?;
+        self.maybe_print_comment(item.span.lo())?;
         self.print_outer_attributes(&item.attrs)?;
         match item.node {
             hir::ForeignItemFn(ref decl, ref arg_names, ref generics) => {
@@ -531,7 +531,7 @@ impl<'a> State<'a> {
     /// Pretty-print an item
     pub fn print_item(&mut self, item: &hir::Item) -> io::Result<()> {
         self.hardbreak_if_not_bol()?;
-        self.maybe_print_comment(item.span.lo)?;
+        self.maybe_print_comment(item.span.lo())?;
         self.print_outer_attributes(&item.attrs)?;
         self.ann.pre(self, NodeItem(item))?;
         match item.node {
@@ -797,7 +797,7 @@ impl<'a> State<'a> {
         self.bopen()?;
         for v in variants {
             self.space_if_not_bol()?;
-            self.maybe_print_comment(v.span.lo)?;
+            self.maybe_print_comment(v.span.lo())?;
             self.print_outer_attributes(&v.node.attrs)?;
             self.ibox(indent_unit)?;
             self.print_variant(v)?;
@@ -842,7 +842,7 @@ impl<'a> State<'a> {
             if struct_def.is_tuple() {
                 self.popen()?;
                 self.commasep(Inconsistent, struct_def.fields(), |s, field| {
-                    s.maybe_print_comment(field.span.lo)?;
+                    s.maybe_print_comment(field.span.lo())?;
                     s.print_outer_attributes(&field.attrs)?;
                     s.print_visibility(&field.vis)?;
                     s.print_type(&field.ty)
@@ -863,7 +863,7 @@ impl<'a> State<'a> {
 
             for field in struct_def.fields() {
                 self.hardbreak_if_not_bol()?;
-                self.maybe_print_comment(field.span.lo)?;
+                self.maybe_print_comment(field.span.lo())?;
                 self.print_outer_attributes(&field.attrs)?;
                 self.print_visibility(&field.vis)?;
                 self.print_name(field.name)?;
@@ -908,7 +908,7 @@ impl<'a> State<'a> {
     pub fn print_trait_item(&mut self, ti: &hir::TraitItem) -> io::Result<()> {
         self.ann.pre(self, NodeSubItem(ti.id))?;
         self.hardbreak_if_not_bol()?;
-        self.maybe_print_comment(ti.span.lo)?;
+        self.maybe_print_comment(ti.span.lo())?;
         self.print_outer_attributes(&ti.attrs)?;
         match ti.node {
             hir::TraitItemKind::Const(ref ty, default) => {
@@ -938,7 +938,7 @@ impl<'a> State<'a> {
     pub fn print_impl_item(&mut self, ii: &hir::ImplItem) -> io::Result<()> {
         self.ann.pre(self, NodeSubItem(ii.id))?;
         self.hardbreak_if_not_bol()?;
-        self.maybe_print_comment(ii.span.lo)?;
+        self.maybe_print_comment(ii.span.lo())?;
         self.print_outer_attributes(&ii.attrs)?;
         self.print_defaultness(ii.defaultness)?;
 
@@ -962,7 +962,7 @@ impl<'a> State<'a> {
     }
 
     pub fn print_stmt(&mut self, st: &hir::Stmt) -> io::Result<()> {
-        self.maybe_print_comment(st.span.lo)?;
+        self.maybe_print_comment(st.span.lo())?;
         match st.node {
             hir::StmtDecl(ref decl, _) => {
                 self.print_decl(&decl)?;
@@ -1017,7 +1017,7 @@ impl<'a> State<'a> {
             hir::PopUnsafeBlock(..) => self.word_space("pop_unsafe")?,
             hir::DefaultBlock => (),
         }
-        self.maybe_print_comment(blk.span.lo)?;
+        self.maybe_print_comment(blk.span.lo())?;
         self.ann.pre(self, NodeBlock(blk))?;
         self.bopen()?;
 
@@ -1030,7 +1030,7 @@ impl<'a> State<'a> {
             Some(ref expr) => {
                 self.space_if_not_bol()?;
                 self.print_expr(&expr)?;
-                self.maybe_print_trailing_comment(expr.span, Some(blk.span.hi))?;
+                self.maybe_print_trailing_comment(expr.span, Some(blk.span.hi()))?;
             }
             _ => (),
         }
@@ -1228,7 +1228,7 @@ impl<'a> State<'a> {
     }
 
     pub fn print_expr(&mut self, expr: &hir::Expr) -> io::Result<()> {
-        self.maybe_print_comment(expr.span.lo)?;
+        self.maybe_print_comment(expr.span.lo())?;
         self.print_outer_attributes(&expr.attrs)?;
         self.ibox(indent_unit)?;
         self.ann.pre(self, NodeExpr(expr))?;
@@ -1480,7 +1480,7 @@ impl<'a> State<'a> {
     }
 
     pub fn print_decl(&mut self, decl: &hir::Decl) -> io::Result<()> {
-        self.maybe_print_comment(decl.span.lo)?;
+        self.maybe_print_comment(decl.span.lo())?;
         match decl.node {
             hir::DeclLocal(ref loc) => {
                 self.space_if_not_bol()?;
@@ -1523,7 +1523,7 @@ impl<'a> State<'a> {
                       path: &hir::Path,
                       colons_before_params: bool)
                       -> io::Result<()> {
-        self.maybe_print_comment(path.span.lo)?;
+        self.maybe_print_comment(path.span.lo())?;
 
         for (i, segment) in path.segments.iter().enumerate() {
             if i > 0 {
@@ -1641,7 +1641,7 @@ impl<'a> State<'a> {
     }
 
     pub fn print_pat(&mut self, pat: &hir::Pat) -> io::Result<()> {
-        self.maybe_print_comment(pat.span.lo)?;
+        self.maybe_print_comment(pat.span.lo())?;
         self.ann.pre(self, NodePat(pat))?;
         // Pat isn't normalized, but the beauty of it
         // is that it doesn't matter
@@ -1897,7 +1897,7 @@ impl<'a> State<'a> {
         match decl.output {
             hir::Return(ref ty) => {
                 self.print_type(&ty)?;
-                self.maybe_print_comment(ty.span.lo)
+                self.maybe_print_comment(ty.span.lo())
             }
             hir::DefaultReturn(..) => unreachable!(),
         }
@@ -2074,7 +2074,7 @@ impl<'a> State<'a> {
         self.end()?;
 
         match decl.output {
-            hir::Return(ref output) => self.maybe_print_comment(output.span.lo),
+            hir::Return(ref output) => self.maybe_print_comment(output.span.lo()),
             _ => Ok(()),
         }
     }
@@ -2124,13 +2124,13 @@ impl<'a> State<'a> {
             if (*cmnt).style != comments::Trailing {
                 return Ok(());
             }
-            let span_line = cm.lookup_char_pos(span.hi);
+            let span_line = cm.lookup_char_pos(span.hi());
             let comment_line = cm.lookup_char_pos((*cmnt).pos);
             let mut next = (*cmnt).pos + BytePos(1);
             if let Some(p) = next_pos {
                 next = p;
             }
-            if span.hi < (*cmnt).pos && (*cmnt).pos < next &&
+            if span.hi() < (*cmnt).pos && (*cmnt).pos < next &&
                span_line.line == comment_line.line {
                 self.print_comment(cmnt)?;
             }

--- a/src/librustc/ich/hcx.rs
+++ b/src/librustc/ich/hcx.rs
@@ -253,17 +253,17 @@ impl<'a, 'gcx, 'tcx> HashStable<StableHashingContext<'a, 'gcx, 'tcx>> for Span {
         // If this is not an empty or invalid span, we want to hash the last
         // position that belongs to it, as opposed to hashing the first
         // position past it.
-        let span_hi = if self.hi > self.lo {
+        let span_hi = if self.hi() > self.lo() {
             // We might end up in the middle of a multibyte character here,
             // but that's OK, since we are not trying to decode anything at
             // this position.
-            self.hi - ::syntax_pos::BytePos(1)
+            self.hi() - ::syntax_pos::BytePos(1)
         } else {
-            self.hi
+            self.hi()
         };
 
         {
-            let loc1 = hcx.codemap().byte_pos_to_line_and_col(self.lo);
+            let loc1 = hcx.codemap().byte_pos_to_line_and_col(self.lo());
             let loc1 = loc1.as_ref()
                            .map(|&(ref fm, line, col)| (&fm.name[..], line, col.to_usize()))
                            .unwrap_or(("???", 0, 0));
@@ -296,7 +296,7 @@ impl<'a, 'gcx, 'tcx> HashStable<StableHashingContext<'a, 'gcx, 'tcx>> for Span {
             }
         }
 
-        if self.ctxt == SyntaxContext::empty() {
+        if self.ctxt() == SyntaxContext::empty() {
             0u8.hash_stable(hcx, hasher);
         } else {
             1u8.hash_stable(hcx, hasher);

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -118,7 +118,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         fn explain_span<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
                                         heading: &str, span: Span)
                                         -> (String, Option<Span>) {
-            let lo = tcx.sess.codemap().lookup_char_pos_adj(span.lo);
+            let lo = tcx.sess.codemap().lookup_char_pos_adj(span.lo());
             (format!("the {} at {}:{}", heading, lo.line, lo.col.to_usize() + 1),
              Some(span))
         }

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -180,7 +180,7 @@ impl CodeExtent {
                         // (This is the special case aluded to in the
                         // doc-comment for this method)
                         let stmt_span = blk.stmts[r.first_statement_index as usize].span;
-                        Some(Span { lo: stmt_span.hi, hi: blk.span.hi, ctxt: stmt_span.ctxt })
+                        Some(Span::new(stmt_span.hi(), blk.span.hi(), stmt_span.ctxt()))
                     }
                 }
             }

--- a/src/librustc_allocator/expand.rs
+++ b/src/librustc_allocator/expand.rs
@@ -82,10 +82,7 @@ impl<'a> Folder for ExpandAllocatorDirectives<'a> {
                 allow_internal_unsafe: false,
             }
         });
-        let span = Span {
-            ctxt: SyntaxContext::empty().apply_mark(mark),
-            ..item.span
-        };
+        let span = item.span.with_ctxt(SyntaxContext::empty().apply_mark(mark));
         let ecfg = ExpansionConfig::default(name.to_string());
         let mut f = AllocFnFactory {
             span,

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -183,8 +183,8 @@ impl EmitterWriter {
                     continue;
                 }
 
-                let lo = cm.lookup_char_pos(span_label.span.lo);
-                let mut hi = cm.lookup_char_pos(span_label.span.hi);
+                let lo = cm.lookup_char_pos(span_label.span.lo());
+                let mut hi = cm.lookup_char_pos(span_label.span.hi());
 
                 // Watch out for "empty spans". If we get a span like 6..6, we
                 // want to just display a `^` at 6, so convert that to
@@ -683,7 +683,7 @@ impl EmitterWriter {
         if let Some(ref cm) = self.cm {
             for primary_span in msp.primary_spans() {
                 if primary_span != &DUMMY_SP {
-                    let hi = cm.lookup_char_pos(primary_span.hi);
+                    let hi = cm.lookup_char_pos(primary_span.hi());
                     if hi.line > max {
                         max = hi.line;
                     }
@@ -691,7 +691,7 @@ impl EmitterWriter {
             }
             for span_label in msp.span_labels() {
                 if span_label.span != DUMMY_SP {
-                    let hi = cm.lookup_char_pos(span_label.span.hi);
+                    let hi = cm.lookup_char_pos(span_label.span.hi());
                     if hi.line > max {
                         max = hi.line;
                     }
@@ -914,7 +914,7 @@ impl EmitterWriter {
         let (primary_lo, cm) = if let (Some(cm), Some(ref primary_span)) =
             (self.cm.as_ref(), msp.primary_span().as_ref()) {
             if primary_span != &&DUMMY_SP {
-                (cm.lookup_char_pos(primary_span.lo), cm)
+                (cm.lookup_char_pos(primary_span.lo()), cm)
             } else {
                 emit_to_destination(&buffer.render(), level, &mut self.dst)?;
                 return Ok(());
@@ -1091,7 +1091,7 @@ impl EmitterWriter {
                                Some(Style::HeaderMsg));
 
             let suggestions = suggestion.splice_lines(cm.borrow());
-            let span_start_pos = cm.lookup_char_pos(primary_sub.span.lo);
+            let span_start_pos = cm.lookup_char_pos(primary_sub.span.lo());
             let line_start = span_start_pos.line;
             draw_col_separator_no_space(&mut buffer, 1, max_line_num_len + 1);
             let mut row_num = 2;

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -369,7 +369,7 @@ impl CrateStore for cstore::CStore {
         let source_name = format!("<{} macros>", name);
 
         let filemap = sess.parse_sess.codemap().new_filemap(source_name, def.body);
-        let local_span = Span { lo: filemap.start_pos, hi: filemap.end_pos, ctxt: NO_EXPANSION };
+        let local_span = Span::new(filemap.start_pos, filemap.end_pos, NO_EXPANSION);
         let body = filemap_to_stream(&sess.parse_sess, filemap, None);
 
         // Mark the attrs as used

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -242,7 +242,7 @@ impl<'a, 'tcx> SpecializedDecoder<Span> for DecodeContext<'a, 'tcx> {
         let sess = if let Some(sess) = self.sess {
             sess
         } else {
-            return Ok(Span { lo: lo, hi: hi, ctxt: NO_EXPANSION });
+            return Ok(Span::new(lo, hi, NO_EXPANSION));
         };
 
         let (lo, hi) = if lo > hi {
@@ -289,7 +289,7 @@ impl<'a, 'tcx> SpecializedDecoder<Span> for DecodeContext<'a, 'tcx> {
         let lo = (lo - filemap.original_start_pos) + filemap.translated_filemap.start_pos;
         let hi = (hi - filemap.original_start_pos) + filemap.translated_filemap.start_pos;
 
-        Ok(Span { lo: lo, hi: hi, ctxt: NO_EXPANSION })
+        Ok(Span::new(lo, hi, NO_EXPANSION))
     }
 }
 

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -364,7 +364,7 @@ fn construct_fn<'a, 'gcx, 'tcx, A>(hir: Cx<'a, 'gcx, 'tcx>,
             builder.args_and_body(block, &arguments, arg_extent, &body.value)
         }));
         // Attribute epilogue to function's closing brace
-        let fn_end = Span { lo: span.hi, ..span };
+        let fn_end = span.with_lo(span.hi());
         let source_info = builder.source_info(fn_end);
         let return_block = builder.return_block();
         builder.cfg.terminate(block, source_info,

--- a/src/librustc_mir/build/scope.rs
+++ b/src/librustc_mir/build/scope.rs
@@ -636,7 +636,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 let tcx = self.hir.tcx();
                 let extent_span = extent.span(&tcx.hir).unwrap();
                 // Attribute scope exit drops to scope's closing brace
-                let scope_end = Span { lo: extent_span.hi, .. extent_span};
+                let scope_end = extent_span.with_lo(extent_span.hi());
                 scope.drops.push(DropData {
                     span: scope_end,
                     location: lvalue.clone(),

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -477,7 +477,7 @@ struct NamePrivacyVisitor<'a, 'tcx: 'a> {
 impl<'a, 'tcx> NamePrivacyVisitor<'a, 'tcx> {
     // Checks that a field is accessible.
     fn check_field(&mut self, span: Span, def: &'tcx ty::AdtDef, field: &'tcx ty::FieldDef) {
-        let ident = Ident { ctxt: span.ctxt.modern(), ..keywords::Invalid.ident() };
+        let ident = Ident { ctxt: span.ctxt().modern(), ..keywords::Invalid.ident() };
         let def_id = self.tcx.adjust_ident(ident, def.did, self.current_item).1;
         if !def.is_enum() && !field.vis.is_accessible_from(def_id, self.tcx) {
             struct_span_err!(self.tcx.sess, span, E0451, "field `{}` of {} `{}` is private",

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -606,9 +606,7 @@ impl<'tcx> Visitor<'tcx> for UsePlacementFinder {
                     // don't suggest placing a use before the prelude
                     // import or other generated ones
                     if item.span == DUMMY_SP {
-                        let mut span = item.span;
-                        span.hi = span.lo;
-                        self.span = Some(span);
+                        self.span = Some(item.span.with_hi(item.span.lo()));
                         self.found_use = true;
                         return;
                     }
@@ -617,9 +615,7 @@ impl<'tcx> Visitor<'tcx> for UsePlacementFinder {
                 ItemKind::ExternCrate(_) => {}
                 // but place them before the first other item
                 _ => if self.span.map_or(true, |span| item.span < span ) {
-                    let mut span = item.span;
-                    span.hi = span.lo;
-                    self.span = Some(span);
+                    self.span = Some(item.span.with_hi(item.span.lo()));
                 },
             }
         }
@@ -1732,7 +1728,7 @@ impl<'a> Resolver<'a> {
 
     fn resolve_self(&mut self, ctxt: &mut SyntaxContext, module: Module<'a>) -> Module<'a> {
         let mut module = self.get_module(module.normal_ancestor_id);
-        while module.span.ctxt.modern() != *ctxt {
+        while module.span.ctxt().modern() != *ctxt {
             let parent = module.parent.unwrap_or_else(|| self.macro_def_scope(ctxt.remove_mark()));
             module = self.get_module(parent.normal_ancestor_id);
         }
@@ -2659,8 +2655,8 @@ impl<'a> Resolver<'a> {
                 sp = sp.next_point();
                 if let Ok(snippet) = cm.span_to_snippet(sp.to(sp.next_point())) {
                     debug!("snippet {:?}", snippet);
-                    let line_sp = cm.lookup_char_pos(sp.hi).line;
-                    let line_base_sp = cm.lookup_char_pos(base_span.lo).line;
+                    let line_sp = cm.lookup_char_pos(sp.hi()).line;
+                    let line_base_sp = cm.lookup_char_pos(base_span.lo()).line;
                     debug!("{:?} {:?}", line_sp, line_base_sp);
                     if snippet == ":" {
                         err.span_label(base_span,
@@ -3360,7 +3356,7 @@ impl<'a> Resolver<'a> {
         for &(trait_name, binding) in traits.as_ref().unwrap().iter() {
             let module = binding.module().unwrap();
             let mut ident = ident;
-            if ident.ctxt.glob_adjust(module.expansion, binding.span.ctxt.modern()).is_none() {
+            if ident.ctxt.glob_adjust(module.expansion, binding.span.ctxt().modern()).is_none() {
                 continue
             }
             if self.resolve_ident_in_module_unadjusted(module, ident, ns, false, false, module.span)
@@ -3586,7 +3582,7 @@ impl<'a> Resolver<'a> {
                        new_binding: &NameBinding,
                        old_binding: &NameBinding) {
         // Error on the second of two conflicting names
-        if old_binding.span.lo > new_binding.span.lo {
+        if old_binding.span.lo() > new_binding.span.lo() {
             return self.report_conflict(parent, ident, ns, old_binding, new_binding);
         }
 

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -237,7 +237,7 @@ impl<'a> Resolver<'a> {
             }
             let module = unwrap_or!(directive.imported_module.get(), return Err(Undetermined));
             let (orig_current_module, mut ident) = (self.current_module, ident.modern());
-            match ident.ctxt.glob_adjust(module.expansion, directive.span.ctxt.modern()) {
+            match ident.ctxt.glob_adjust(module.expansion, directive.span.ctxt().modern()) {
                 Some(Some(def)) => self.current_module = self.macro_def_scope(def),
                 Some(None) => {}
                 None => continue,
@@ -398,7 +398,7 @@ impl<'a> Resolver<'a> {
         for directive in module.glob_importers.borrow_mut().iter() {
             let mut ident = ident.modern();
             let scope = match ident.ctxt.reverse_glob_adjust(module.expansion,
-                                                             directive.span.ctxt.modern()) {
+                                                             directive.span.ctxt().modern()) {
                 Some(Some(def)) => self.macro_def_scope(def),
                 Some(None) => directive.parent,
                 None => continue,
@@ -800,7 +800,7 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
         }).collect::<Vec<_>>();
         for ((mut ident, ns), binding) in bindings {
             let scope = match ident.ctxt.reverse_glob_adjust(module.expansion,
-                                                             directive.span.ctxt.modern()) {
+                                                             directive.span.ctxt().modern()) {
                 Some(Some(def)) => self.macro_def_scope(def),
                 Some(None) => self.current_module,
                 None => continue,

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -91,13 +91,13 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
         use rls_span::{Row, Column};
 
         let cm = self.tcx.sess.codemap();
-        let start = cm.lookup_char_pos(span.lo);
-        let end = cm.lookup_char_pos(span.hi);
+        let start = cm.lookup_char_pos(span.lo());
+        let end = cm.lookup_char_pos(span.hi());
 
         SpanData {
             file_name: start.file.name.clone().into(),
-            byte_start: span.lo.0,
-            byte_end: span.hi.0,
+            byte_start: span.lo().0,
+            byte_end: span.hi().0,
             line_start: Row::new_one_indexed(start.line as u32),
             line_end: Row::new_one_indexed(end.line as u32),
             column_start: Column::new_one_indexed(start.col.0 as u32 + 1),
@@ -117,7 +117,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                     continue;
                 }
             };
-            let lo_loc = self.span_utils.sess.codemap().lookup_char_pos(span.lo);
+            let lo_loc = self.span_utils.sess.codemap().lookup_char_pos(span.lo());
             result.push(ExternalCrateData {
                 name: self.tcx.sess.cstore.crate_name(n).to_string(),
                 num: n.as_u32(),
@@ -999,7 +999,7 @@ fn escape(s: String) -> String {
 // Helper function to determine if a span came from a
 // macro expansion or syntax extension.
 fn generated_code(span: Span) -> bool {
-    span.ctxt != NO_EXPANSION || span == DUMMY_SP
+    span.ctxt() != NO_EXPANSION || span == DUMMY_SP
 }
 
 // DefId::index is a newtype and so the JSON serialisation is ugly. Therefore

--- a/src/librustc_save_analysis/span_utils.rs
+++ b/src/librustc_save_analysis/span_utils.rs
@@ -192,7 +192,7 @@ impl<'a> SpanUtils<'a> {
             prev = next;
         }
         if angle_count != 0 || bracket_count != 0 {
-            let loc = self.sess.codemap().lookup_char_pos(span.lo);
+            let loc = self.sess.codemap().lookup_char_pos(span.lo());
             span_bug!(span,
                       "Mis-counted brackets when breaking path? Parsing '{}' \
                        in {}, line {}",
@@ -319,7 +319,7 @@ impl<'a> SpanUtils<'a> {
         };
 
         //If the span comes from a fake filemap, filter it.
-        if !self.sess.codemap().lookup_char_pos(parent.lo).file.is_real_file() {
+        if !self.sess.codemap().lookup_char_pos(parent.lo()).file.is_real_file() {
             return true;
         }
 

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -1371,7 +1371,7 @@ fn assert_symbols_are_distinct<'a, 'tcx, I>(tcx: TyCtxt<'a, 'tcx, 'tcx>, trans_i
             // Deterministically select one of the spans for error reporting
             let span = match (span1, span2) {
                 (Some(span1), Some(span2)) => {
-                    Some(if span1.lo.0 > span2.lo.0 {
+                    Some(if span1.lo().0 > span2.lo().0 {
                         span1
                     } else {
                         span2

--- a/src/librustc_trans/debuginfo/utils.rs
+++ b/src/librustc_trans/debuginfo/utils.rs
@@ -49,7 +49,7 @@ pub fn create_DIArray(builder: DIBuilderRef, arr: &[DIDescriptor]) -> DIArray {
 
 /// Return syntax_pos::Loc corresponding to the beginning of the span
 pub fn span_start(cx: &CrateContext, span: Span) -> syntax_pos::Loc {
-    cx.sess().codemap().lookup_char_pos(span.lo)
+    cx.sess().codemap().lookup_char_pos(span.lo())
 }
 
 pub fn size_and_align_of(cx: &CrateContext, llvm_type: Type) -> (u64, u32) {

--- a/src/librustc_trans/mir/block.rs
+++ b/src/librustc_trans/mir/block.rs
@@ -330,7 +330,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 self.set_debug_loc(&bcx, terminator.source_info);
 
                 // Get the location information.
-                let loc = bcx.sess().codemap().lookup_char_pos(span.lo);
+                let loc = bcx.sess().codemap().lookup_char_pos(span.lo());
                 let filename = Symbol::intern(&loc.file.name).as_str();
                 let filename = C_str_slice(bcx.ccx, filename);
                 let line = C_u32(bcx.ccx, loc.line as u32);

--- a/src/librustc_trans/mir/mod.rs
+++ b/src/librustc_trans/mir/mod.rs
@@ -129,23 +129,23 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
         // In order to have a good line stepping behavior in debugger, we overwrite debug
         // locations of macro expansions with that of the outermost expansion site
         // (unless the crate is being compiled with `-Z debug-macros`).
-        if source_info.span.ctxt == NO_EXPANSION ||
+        if source_info.span.ctxt() == NO_EXPANSION ||
            self.ccx.sess().opts.debugging_opts.debug_macros {
-            let scope = self.scope_metadata_for_loc(source_info.scope, source_info.span.lo);
+            let scope = self.scope_metadata_for_loc(source_info.scope, source_info.span.lo());
             (scope, source_info.span)
         } else {
             // Walk up the macro expansion chain until we reach a non-expanded span.
             // We also stop at the function body level because no line stepping can occur
             // at the level above that.
             let mut span = source_info.span;
-            while span.ctxt != NO_EXPANSION && span.ctxt != self.mir.span.ctxt {
-                if let Some(info) = span.ctxt.outer().expn_info() {
+            while span.ctxt() != NO_EXPANSION && span.ctxt() != self.mir.span.ctxt() {
+                if let Some(info) = span.ctxt().outer().expn_info() {
                     span = info.call_site;
                 } else {
                     break;
                 }
             }
-            let scope = self.scope_metadata_for_loc(source_info.scope, span.lo);
+            let scope = self.scope_metadata_for_loc(source_info.scope, span.lo());
             // Use span of the outermost expansion site, while keeping the original lexical scope.
             (scope, span)
         }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2486,9 +2486,9 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 err.span_label(def_s, "defined here");
             }
             if sugg_unit {
-                let mut sugg_span = sp.end_point();
+                let sugg_span = sp.end_point();
                 // remove closing `)` from the span
-                sugg_span.hi = sugg_span.lo;
+                let sugg_span = sugg_span.with_hi(sugg_span.lo());
                 err.span_suggestion(
                     sugg_span,
                     "expected the unit value `()`. You can create one with a pair of parenthesis",
@@ -3137,7 +3137,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     debug!("tuple struct named {:?}",  base_t);
                     let ident = ast::Ident {
                         name: Symbol::intern(&idx.node.to_string()),
-                        ctxt: idx.span.ctxt.modern(),
+                        ctxt: idx.span.ctxt().modern(),
                     };
                     let (ident, def_scope) =
                         self.tcx.adjust_ident(ident, base_def.did, self.body_id);
@@ -4524,11 +4524,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             return;
         }
         let original_span = original_sp(last_stmt.span, blk.span);
-        let span_semi = Span {
-            lo: original_span.hi - BytePos(1),
-            hi: original_span.hi,
-            ctxt: original_span.ctxt,
-        };
+        let span_semi = original_span.with_lo(original_span.hi() - BytePos(1));
         err.span_suggestion(span_semi, "consider removing this semicolon", "".to_string());
     }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -457,8 +457,8 @@ impl Clean<Item> for doctree::Module {
         // the outer `mod` item for the source code.
         let whence = {
             let cm = cx.sess().codemap();
-            let outer = cm.lookup_char_pos(self.where_outer.lo);
-            let inner = cm.lookup_char_pos(self.where_inner.lo);
+            let outer = cm.lookup_char_pos(self.where_outer.lo());
+            let inner = cm.lookup_char_pos(self.where_inner.lo());
             if outer.file.start_pos == inner.file.start_pos {
                 // mod foo { ... }
                 self.where_outer
@@ -2251,8 +2251,8 @@ impl Clean<Span> for syntax_pos::Span {
 
         let cm = cx.sess().codemap();
         let filename = cm.span_to_filename(*self);
-        let lo = cm.lookup_char_pos(self.lo);
-        let hi = cm.lookup_char_pos(self.hi);
+        let lo = cm.lookup_char_pos(self.lo());
+        let hi = cm.lookup_char_pos(self.hi());
         Span {
             filename: filename.to_string(),
             loline: lo.line,

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -532,7 +532,7 @@ impl Collector {
 
     pub fn get_line(&self) -> usize {
         if let Some(ref codemap) = self.codemap {
-            let line = self.position.lo.to_usize();
+            let line = self.position.lo().to_usize();
             let line = codemap.lookup_char_pos(BytePos(line as u32)).line;
             if line > 0 { line - 1 } else { line }
         } else {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -134,7 +134,7 @@ impl PathSegment {
     }
     pub fn crate_root(span: Span) -> Self {
         PathSegment {
-            identifier: Ident { ctxt: span.ctxt, ..keywords::CrateRoot.ident() },
+            identifier: Ident { ctxt: span.ctxt(), ..keywords::CrateRoot.ident() },
             span,
             parameters: None,
         }

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -1059,7 +1059,7 @@ impl MetaItem {
     fn from_tokens<I>(tokens: &mut iter::Peekable<I>) -> Option<MetaItem>
         where I: Iterator<Item = TokenTree>,
     {
-        let (mut span, name) = match tokens.next() {
+        let (span, name) = match tokens.next() {
             Some(TokenTree::Token(span, Token::Ident(ident))) => (span, ident.name),
             Some(TokenTree::Token(_, Token::Interpolated(ref nt))) => match nt.0 {
                 token::Nonterminal::NtIdent(ident) => (ident.span, ident.node.name),
@@ -1068,17 +1068,17 @@ impl MetaItem {
             },
             _ => return None,
         };
-        let list_closing_paren_pos = tokens.peek().map(|tt| tt.span().hi);
+        let list_closing_paren_pos = tokens.peek().map(|tt| tt.span().hi());
         let node = match MetaItemKind::from_tokens(tokens) {
             Some(node) => node,
             _ => return None,
         };
-        span.hi = match node {
-            MetaItemKind::NameValue(ref lit) => lit.span.hi,
-            MetaItemKind::List(..) => list_closing_paren_pos.unwrap_or(span.hi),
-            _ => span.hi,
+        let hi = match node {
+            MetaItemKind::NameValue(ref lit) => lit.span.hi(),
+            MetaItemKind::List(..) => list_closing_paren_pos.unwrap_or(span.hi()),
+            _ => span.hi(),
         };
-        Some(MetaItem { name: name, span: span, node: node })
+        Some(MetaItem { name, node, span: span.with_hi(hi) })
     }
 }
 

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -14,7 +14,6 @@ use {fold, attr};
 use ast;
 use codemap::Spanned;
 use parse::{token, ParseSess};
-use syntax_pos::Span;
 
 use ptr::P;
 use util::small_vector::SmallVector;
@@ -89,10 +88,10 @@ impl<'a> StripUnconfigured<'a> {
             parser.expect(&token::OpenDelim(token::Paren))?;
             let cfg = parser.parse_meta_item()?;
             parser.expect(&token::Comma)?;
-            let lo = parser.span.lo;
+            let lo = parser.span.lo();
             let (path, tokens) = parser.parse_path_and_tokens()?;
             parser.expect(&token::CloseDelim(token::Paren))?;
-            Ok((cfg, path, tokens, Span { lo: lo, ..parser.prev_span }))
+            Ok((cfg, path, tokens, parser.prev_span.with_lo(lo)))
         }) {
             Ok(result) => result,
             Err(mut e) => {

--- a/src/libsyntax/diagnostics/metadata.rs
+++ b/src/libsyntax/diagnostics/metadata.rs
@@ -47,7 +47,7 @@ pub struct ErrorLocation {
 impl ErrorLocation {
     /// Create an error location from a span.
     pub fn from_span(ecx: &ExtCtxt, sp: Span) -> ErrorLocation {
-        let loc = ecx.codemap().lookup_char_pos_adj(sp.lo);
+        let loc = ecx.codemap().lookup_char_pos_adj(sp.lo());
         ErrorLocation {
             filename: loc.filename,
             line: loc.line

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -731,7 +731,7 @@ impl<'a> ExtCtxt<'a> {
                     // Stop going up the backtrace once include! is encountered
                     return None;
                 }
-                ctxt = info.call_site.ctxt;
+                ctxt = info.call_site.ctxt();
                 last_macro = Some(info.call_site);
                 Some(())
             }).is_none() {
@@ -837,7 +837,7 @@ pub fn expr_to_spanned_string(cx: &mut ExtCtxt, expr: P<ast::Expr>, err_msg: &st
                               -> Option<Spanned<(Symbol, ast::StrStyle)>> {
     // Update `expr.span`'s ctxt now in case expr is an `include!` macro invocation.
     let expr = expr.map(|mut expr| {
-        expr.span.ctxt = expr.span.ctxt.apply_mark(cx.current_expansion.mark);
+        expr.span = expr.span.with_ctxt(expr.span.ctxt().apply_mark(cx.current_expansion.mark));
         expr
     });
 

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -755,7 +755,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
 
     fn expr_fail(&self, span: Span, msg: Symbol) -> P<ast::Expr> {
-        let loc = self.codemap().lookup_char_pos(span.lo);
+        let loc = self.codemap().lookup_char_pos(span.lo());
         let expr_file = self.expr_str(span, Symbol::intern(&loc.file.name));
         let expr_line = self.expr_u32(span, loc.line as u32);
         let expr_col = self.expr_u32(span, loc.col.to_usize() as u32 + 1);

--- a/src/libsyntax/ext/derive.rs
+++ b/src/libsyntax/ext/derive.rs
@@ -68,7 +68,7 @@ pub fn add_derived_markers<T>(cx: &mut ExtCtxt, span: Span, traits: &[ast::Path]
         },
     });
 
-    let span = Span { ctxt: cx.backtrace(), ..span };
+    let span = span.with_ctxt(cx.backtrace());
     item.map_attrs(|mut attrs| {
         if names.contains(&Symbol::intern("Eq")) && names.contains(&Symbol::intern("PartialEq")) {
             let meta = cx.meta_word(span, Symbol::intern("structural_match"));

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -36,7 +36,7 @@ pub fn expand_line(cx: &mut ExtCtxt, sp: Span, tts: &[tokenstream::TokenTree])
     base::check_zero_tts(cx, sp, tts, "line!");
 
     let topmost = cx.expansion_cause().unwrap_or(sp);
-    let loc = cx.codemap().lookup_char_pos(topmost.lo);
+    let loc = cx.codemap().lookup_char_pos(topmost.lo());
 
     base::MacEager::expr(cx.expr_u32(topmost, loc.line as u32))
 }
@@ -47,7 +47,7 @@ pub fn expand_column(cx: &mut ExtCtxt, sp: Span, tts: &[tokenstream::TokenTree])
     base::check_zero_tts(cx, sp, tts, "column!");
 
     let topmost = cx.expansion_cause().unwrap_or(sp);
-    let loc = cx.codemap().lookup_char_pos(topmost.lo);
+    let loc = cx.codemap().lookup_char_pos(topmost.lo());
 
     base::MacEager::expr(cx.expr_u32(topmost, loc.col.to_usize() as u32))
 }
@@ -70,7 +70,7 @@ pub fn expand_file(cx: &mut ExtCtxt, sp: Span, tts: &[tokenstream::TokenTree])
     base::check_zero_tts(cx, sp, tts, "file!");
 
     let topmost = cx.expansion_cause().unwrap_or(sp);
-    let loc = cx.codemap().lookup_char_pos(topmost.lo);
+    let loc = cx.codemap().lookup_char_pos(topmost.lo());
     base::MacEager::expr(cx.expr_str(topmost, Symbol::intern(&loc.file.name)))
 }
 

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -329,7 +329,8 @@ fn inner_parse_loop(sess: &ParseSess,
                     // Only touch the binders we have actually bound
                     for idx in item.match_lo..item.match_hi {
                         let sub = item.matches[idx].clone();
-                        new_pos.push_match(idx, MatchedSeq(sub, Span { lo: item.sp_lo, ..span }));
+                        let span = span.with_lo(item.sp_lo);
+                        new_pos.push_match(idx, MatchedSeq(sub, span));
                     }
 
                     new_pos.match_cur = item.match_hi;
@@ -379,7 +380,7 @@ fn inner_parse_loop(sess: &ParseSess,
                         match_cur: item.match_cur,
                         match_hi: item.match_cur + seq.num_captures,
                         up: Some(item),
-                        sp_lo: sp.lo,
+                        sp_lo: sp.lo(),
                         top_elts: Tt(TokenTree::Sequence(sp, seq)),
                     }));
                 }
@@ -424,7 +425,7 @@ pub fn parse(sess: &ParseSess,
              recurse_into_modules: bool)
              -> NamedParseResult {
     let mut parser = Parser::new(sess, tts, directory, recurse_into_modules, true);
-    let mut cur_items = SmallVector::one(initial_matcher_pos(ms.to_owned(), parser.span.lo));
+    let mut cur_items = SmallVector::one(initial_matcher_pos(ms.to_owned(), parser.span.lo()));
     let mut next_items = Vec::new(); // or proceed normally
 
     loop {

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -130,7 +130,7 @@ fn generic_extension<'cx>(cx: &'cx mut ExtCtxt,
                     tts = tts.map_enumerated(|i, tt| {
                         let mut tt = tt.clone();
                         let mut sp = rhs_spans[i];
-                        sp.ctxt = tt.span().ctxt;
+                        sp = sp.with_ctxt(tt.span().ctxt());
                         tt.set_span(sp);
                         tt
                     });
@@ -161,7 +161,7 @@ fn generic_extension<'cx>(cx: &'cx mut ExtCtxt,
                     macro_ident: name
                 })
             }
-            Failure(sp, tok) => if sp.lo >= best_fail_spot.lo {
+            Failure(sp, tok) => if sp.lo() >= best_fail_spot.lo() {
                 best_fail_spot = sp;
                 best_fail_tok = Some(tok);
             },

--- a/src/libsyntax/ext/tt/quoted.rs
+++ b/src/libsyntax/ext/tt/quoted.rs
@@ -37,7 +37,7 @@ impl Delimited {
         let open_span = if span == DUMMY_SP {
             DUMMY_SP
         } else {
-            Span { hi: span.lo + BytePos(self.delim.len() as u32), ..span }
+            span.with_lo(span.lo() + BytePos(self.delim.len() as u32))
         };
         TokenTree::Token(open_span, self.open_token())
     }
@@ -46,7 +46,7 @@ impl Delimited {
         let close_span = if span == DUMMY_SP {
             DUMMY_SP
         } else {
-            Span { lo: span.hi - BytePos(self.delim.len() as u32), ..span }
+            span.with_lo(span.hi() - BytePos(self.delim.len() as u32))
         };
         TokenTree::Token(close_span, self.close_token())
     }
@@ -152,7 +152,7 @@ pub fn parse(input: tokenstream::TokenStream, expect_matchers: bool, sess: &Pars
                     Some(tokenstream::TokenTree::Token(span, token::Colon)) => match trees.next() {
                         Some(tokenstream::TokenTree::Token(end_sp, ref tok)) => match tok.ident() {
                             Some(kind) => {
-                                let span = Span { lo: start_sp.lo, ..end_sp };
+                                let span = end_sp.with_lo(start_sp.lo());
                                 result.push(TokenTree::MetaVarDecl(span, ident, kind));
                                 continue
                             }
@@ -198,7 +198,7 @@ fn parse_tree<I>(tree: tokenstream::TokenTree,
             }
             Some(tokenstream::TokenTree::Token(ident_span, ref token)) if token.is_ident() => {
                 let ident = token.ident().unwrap();
-                let span = Span { lo: span.lo, ..ident_span };
+                let span = ident_span.with_lo(span.lo());
                 if ident.name == keywords::Crate.name() {
                     let ident = ast::Ident { name: keywords::DollarCrate.name(), ..ident };
                     TokenTree::Token(span, token::Ident(ident))

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -155,7 +155,7 @@ pub fn transcribe(cx: &ExtCtxt,
                         if let NtTT(ref tt) = **nt {
                             result.push(tt.clone().into());
                         } else {
-                            sp.ctxt = sp.ctxt.apply_mark(cx.current_expansion.mark);
+                            sp = sp.with_ctxt(sp.ctxt().apply_mark(cx.current_expansion.mark));
                             let token = TokenTree::Token(sp, Token::interpolated((**nt).clone()));
                             result.push(token.into());
                         }
@@ -166,13 +166,13 @@ pub fn transcribe(cx: &ExtCtxt,
                 } else {
                     let ident =
                         Ident { ctxt: ident.ctxt.apply_mark(cx.current_expansion.mark), ..ident };
-                    sp.ctxt = sp.ctxt.apply_mark(cx.current_expansion.mark);
+                    sp = sp.with_ctxt(sp.ctxt().apply_mark(cx.current_expansion.mark));
                     result.push(TokenTree::Token(sp, token::Dollar).into());
                     result.push(TokenTree::Token(sp, token::Ident(ident)).into());
                 }
             }
             quoted::TokenTree::Delimited(mut span, delimited) => {
-                span.ctxt = span.ctxt.apply_mark(cx.current_expansion.mark);
+                span = span.with_ctxt(span.ctxt().apply_mark(cx.current_expansion.mark));
                 stack.push(Frame::Delimited { forest: delimited, idx: 0, span: span });
                 result_stack.push(mem::replace(&mut result, Vec::new()));
             }

--- a/src/libsyntax/json.rs
+++ b/src/libsyntax/json.rs
@@ -230,8 +230,8 @@ impl DiagnosticSpan {
                       mut backtrace: vec::IntoIter<MacroBacktrace>,
                       je: &JsonEmitter)
                       -> DiagnosticSpan {
-        let start = je.cm.lookup_char_pos(span.lo);
-        let end = je.cm.lookup_char_pos(span.hi);
+        let start = je.cm.lookup_char_pos(span.lo());
+        let end = je.cm.lookup_char_pos(span.hi());
         let backtrace_step = backtrace.next().map(|bt| {
             let call_site =
                 Self::from_span_full(bt.call_site,
@@ -256,8 +256,8 @@ impl DiagnosticSpan {
         });
         DiagnosticSpan {
             file_name: start.file.name.clone(),
-            byte_start: span.lo.0 - start.file.start_pos.0,
-            byte_end: span.hi.0 - start.file.start_pos.0,
+            byte_start: span.lo().0 - start.file.start_pos.0,
+            byte_end: span.hi().0 - start.file.start_pos.0,
             line_start: start.line,
             line_end: end.line,
             column_start: start.col.0 + 1,

--- a/src/libsyntax/parse/lexer/comments.rs
+++ b/src/libsyntax/parse/lexer/comments.rs
@@ -386,7 +386,7 @@ pub fn gather_comments_and_literals(sess: &ParseSess, path: String, srdr: &mut R
                 debug!("tok lit: {}", s);
                 literals.push(Literal {
                     lit: s.to_string(),
-                    pos: sp.lo,
+                    pos: sp.lo(),
                 });
             })
         } else {

--- a/src/libsyntax/parse/lexer/tokentrees.rs
+++ b/src/libsyntax/parse/lexer/tokentrees.rs
@@ -11,7 +11,6 @@
 use print::pprust::token_to_string;
 use parse::lexer::StringReader;
 use parse::{token, PResult};
-use syntax_pos::Span;
 use tokenstream::{Delimited, TokenStream, TokenTree};
 
 impl<'a> StringReader<'a> {
@@ -20,7 +19,7 @@ impl<'a> StringReader<'a> {
         let mut tts = Vec::new();
         while self.token != token::Eof {
             let tree = self.parse_token_tree()?;
-            let is_joint = tree.span().hi == self.span.lo && token::is_op(&self.token);
+            let is_joint = tree.span().hi() == self.span.lo() && token::is_op(&self.token);
             tts.push(if is_joint { tree.joint() } else { tree.into() });
         }
         Ok(TokenStream::concat(tts))
@@ -40,7 +39,7 @@ impl<'a> StringReader<'a> {
                     return TokenStream::concat(tts);
                 }
             };
-            let is_joint = tree.span().hi == self.span.lo && token::is_op(&self.token);
+            let is_joint = tree.span().hi() == self.span.lo() && token::is_op(&self.token);
             tts.push(if is_joint { tree.joint() } else { tree.into() });
         }
     }
@@ -69,7 +68,7 @@ impl<'a> StringReader<'a> {
                 let tts = self.parse_token_trees_until_close_delim();
 
                 // Expand to cover the entire delimited token tree
-                let span = Span { hi: self.span.hi, ..pre_span };
+                let span = pre_span.with_hi(self.span.hi());
 
                 match self.token {
                     // Correct delimiter.

--- a/src/libsyntax/parse/lexer/unicode_chars.rs
+++ b/src/libsyntax/parse/lexer/unicode_chars.rs
@@ -340,7 +340,7 @@ pub fn check_for_substitution<'a>(reader: &StringReader<'a>,
     .iter()
     .find(|&&(c, _, _)| c == ch)
     .map(|&(_, u_name, ascii_char)| {
-        let span = Span { lo: reader.pos, hi: reader.next_pos, ctxt: NO_EXPANSION };
+        let span = Span::new(reader.pos, reader.next_pos, NO_EXPANSION);
         match ASCII_ARRAY.iter().find(|&&(c, _)| c == ascii_char) {
             Some(&(ascii_char, ascii_name)) => {
                 let msg =

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -181,7 +181,7 @@ pub fn filemap_to_parser(sess: & ParseSess, filemap: Rc<FileMap>, ) -> Parser {
     let mut parser = stream_to_parser(sess, filemap_to_stream(sess, filemap, None));
 
     if parser.token == token::Eof && parser.span == syntax_pos::DUMMY_SP {
-        parser.span = Span { lo: end_pos, hi: end_pos, ctxt: NO_EXPANSION };
+        parser.span = Span::new(end_pos, end_pos, NO_EXPANSION);
     }
 
     parser
@@ -661,7 +661,7 @@ mod tests {
 
     // produce a syntax_pos::span
     fn sp(a: u32, b: u32) -> Span {
-        Span {lo: BytePos(a), hi: BytePos(b), ctxt: NO_EXPANSION}
+        Span::new(BytePos(a), BytePos(b), NO_EXPANSION)
     }
 
     fn str2seg(s: &str, lo: u32, hi: u32) -> ast::PathSegment {
@@ -976,7 +976,7 @@ mod tests {
 
         for &src in &srcs {
             let spans = get_spans_of_pat_idents(src);
-            let Span{ lo, hi, .. } = spans[0];
+            let (lo, hi) = (spans[0].lo(), spans[0].hi());
             assert!("self" == &src[lo.to_usize()..hi.to_usize()],
                     "\"{}\" != \"self\". src=\"{}\"",
                     &src[lo.to_usize()..hi.to_usize()], src)

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -603,8 +603,8 @@ pub trait PrintState<'a> {
     }
 
     fn print_literal(&mut self, lit: &ast::Lit) -> io::Result<()> {
-        self.maybe_print_comment(lit.span.lo)?;
-        if let Some(ltrl) = self.next_lit(lit.span.lo) {
+        self.maybe_print_comment(lit.span.lo())?;
+        if let Some(ltrl) = self.next_lit(lit.span.lo()) {
             return self.writer().word(&ltrl.lit);
         }
         match lit.node {
@@ -723,7 +723,7 @@ pub trait PrintState<'a> {
         if !is_inline {
             self.hardbreak_if_not_bol()?;
         }
-        self.maybe_print_comment(attr.span.lo)?;
+        self.maybe_print_comment(attr.span.lo())?;
         if attr.is_sugared_doc {
             self.writer().word(&attr.value_str().unwrap().as_str())?;
             self.writer().hardbreak()
@@ -892,7 +892,7 @@ impl<'a> State<'a> {
     }
     pub fn bclose_maybe_open(&mut self, span: syntax_pos::Span,
                              indented: usize, close_box: bool) -> io::Result<()> {
-        self.maybe_print_comment(span.hi)?;
+        self.maybe_print_comment(span.hi())?;
         self.break_offset_if_not_bol(1, -(indented as isize))?;
         self.s.word("}")?;
         if close_box {
@@ -950,13 +950,13 @@ impl<'a> State<'a> {
         let len = elts.len();
         let mut i = 0;
         for elt in elts {
-            self.maybe_print_comment(get_span(elt).hi)?;
+            self.maybe_print_comment(get_span(elt).hi())?;
             op(self, elt)?;
             i += 1;
             if i < len {
                 self.s.word(",")?;
                 self.maybe_print_trailing_comment(get_span(elt),
-                                                  Some(get_span(&elts[i]).hi))?;
+                                                  Some(get_span(&elts[i]).hi()))?;
                 self.space_if_not_bol()?;
             }
         }
@@ -996,7 +996,7 @@ impl<'a> State<'a> {
     }
 
     pub fn print_type(&mut self, ty: &ast::Ty) -> io::Result<()> {
-        self.maybe_print_comment(ty.span.lo)?;
+        self.maybe_print_comment(ty.span.lo())?;
         self.ibox(0)?;
         match ty.node {
             ast::TyKind::Slice(ref ty) => {
@@ -1094,7 +1094,7 @@ impl<'a> State<'a> {
     pub fn print_foreign_item(&mut self,
                               item: &ast::ForeignItem) -> io::Result<()> {
         self.hardbreak_if_not_bol()?;
-        self.maybe_print_comment(item.span.lo)?;
+        self.maybe_print_comment(item.span.lo())?;
         self.print_outer_attributes(&item.attrs)?;
         match item.node {
             ast::ForeignItemKind::Fn(ref decl, ref generics) => {
@@ -1163,7 +1163,7 @@ impl<'a> State<'a> {
     /// Pretty-print an item
     pub fn print_item(&mut self, item: &ast::Item) -> io::Result<()> {
         self.hardbreak_if_not_bol()?;
-        self.maybe_print_comment(item.span.lo)?;
+        self.maybe_print_comment(item.span.lo())?;
         self.print_outer_attributes(&item.attrs)?;
         self.ann.pre(self, NodeItem(item))?;
         match item.node {
@@ -1433,7 +1433,7 @@ impl<'a> State<'a> {
         self.bopen()?;
         for v in variants {
             self.space_if_not_bol()?;
-            self.maybe_print_comment(v.span.lo)?;
+            self.maybe_print_comment(v.span.lo())?;
             self.print_outer_attributes(&v.node.attrs)?;
             self.ibox(INDENT_UNIT)?;
             self.print_variant(v)?;
@@ -1481,7 +1481,7 @@ impl<'a> State<'a> {
                 self.commasep(
                     Inconsistent, struct_def.fields(),
                     |s, field| {
-                        s.maybe_print_comment(field.span.lo)?;
+                        s.maybe_print_comment(field.span.lo())?;
                         s.print_outer_attributes(&field.attrs)?;
                         s.print_visibility(&field.vis)?;
                         s.print_type(&field.ty)
@@ -1503,7 +1503,7 @@ impl<'a> State<'a> {
 
             for field in struct_def.fields() {
                 self.hardbreak_if_not_bol()?;
-                self.maybe_print_comment(field.span.lo)?;
+                self.maybe_print_comment(field.span.lo())?;
                 self.print_outer_attributes(&field.attrs)?;
                 self.print_visibility(&field.vis)?;
                 self.print_ident(field.ident.unwrap())?;
@@ -1548,7 +1548,7 @@ impl<'a> State<'a> {
                             -> io::Result<()> {
         self.ann.pre(self, NodeSubItem(ti.id))?;
         self.hardbreak_if_not_bol()?;
-        self.maybe_print_comment(ti.span.lo)?;
+        self.maybe_print_comment(ti.span.lo())?;
         self.print_outer_attributes(&ti.attrs)?;
         match ti.node {
             ast::TraitItemKind::Const(ref ty, ref default) => {
@@ -1590,7 +1590,7 @@ impl<'a> State<'a> {
     pub fn print_impl_item(&mut self, ii: &ast::ImplItem) -> io::Result<()> {
         self.ann.pre(self, NodeSubItem(ii.id))?;
         self.hardbreak_if_not_bol()?;
-        self.maybe_print_comment(ii.span.lo)?;
+        self.maybe_print_comment(ii.span.lo())?;
         self.print_outer_attributes(&ii.attrs)?;
         self.print_defaultness(ii.defaultness)?;
         match ii.node {
@@ -1622,7 +1622,7 @@ impl<'a> State<'a> {
     }
 
     pub fn print_stmt(&mut self, st: &ast::Stmt) -> io::Result<()> {
-        self.maybe_print_comment(st.span.lo)?;
+        self.maybe_print_comment(st.span.lo())?;
         match st.node {
             ast::StmtKind::Local(ref loc) => {
                 self.print_outer_attributes(&loc.attrs)?;
@@ -1705,7 +1705,7 @@ impl<'a> State<'a> {
             BlockCheckMode::Unsafe(..) => self.word_space("unsafe")?,
             BlockCheckMode::Default => ()
         }
-        self.maybe_print_comment(blk.span.lo)?;
+        self.maybe_print_comment(blk.span.lo())?;
         self.ann.pre(self, NodeBlock(blk))?;
         self.bopen()?;
 
@@ -1714,10 +1714,10 @@ impl<'a> State<'a> {
         for (i, st) in blk.stmts.iter().enumerate() {
             match st.node {
                 ast::StmtKind::Expr(ref expr) if i == blk.stmts.len() - 1 => {
-                    self.maybe_print_comment(st.span.lo)?;
+                    self.maybe_print_comment(st.span.lo())?;
                     self.space_if_not_bol()?;
                     self.print_expr_outer_attr_style(expr, false)?;
-                    self.maybe_print_trailing_comment(expr.span, Some(blk.span.hi))?;
+                    self.maybe_print_trailing_comment(expr.span, Some(blk.span.hi()))?;
                 }
                 _ => self.print_stmt(st)?,
             }
@@ -1988,7 +1988,7 @@ impl<'a> State<'a> {
     fn print_expr_outer_attr_style(&mut self,
                                   expr: &ast::Expr,
                                   is_inline: bool) -> io::Result<()> {
-        self.maybe_print_comment(expr.span.lo)?;
+        self.maybe_print_comment(expr.span.lo())?;
 
         let attrs = &expr.attrs;
         if is_inline {
@@ -2343,7 +2343,7 @@ impl<'a> State<'a> {
                   defaults_to_global: bool)
                   -> io::Result<()>
     {
-        self.maybe_print_comment(path.span.lo)?;
+        self.maybe_print_comment(path.span.lo())?;
 
         let mut segments = path.segments[..path.segments.len()-depth].iter();
         if defaults_to_global && path.is_global() {
@@ -2465,7 +2465,7 @@ impl<'a> State<'a> {
     }
 
     pub fn print_pat(&mut self, pat: &ast::Pat) -> io::Result<()> {
-        self.maybe_print_comment(pat.span.lo)?;
+        self.maybe_print_comment(pat.span.lo())?;
         self.ann.pre(self, NodePat(pat))?;
         /* Pat isn't normalized, but the beauty of it
          is that it doesn't matter */
@@ -2607,7 +2607,7 @@ impl<'a> State<'a> {
         }
         self.cbox(INDENT_UNIT)?;
         self.ibox(0)?;
-        self.maybe_print_comment(arm.pats[0].span.lo)?;
+        self.maybe_print_comment(arm.pats[0].span.lo())?;
         self.print_outer_attributes(&arm.attrs)?;
         let mut first = true;
         for p in &arm.pats {
@@ -2715,7 +2715,7 @@ impl<'a> State<'a> {
         match decl.output {
             ast::FunctionRetTy::Ty(ref ty) => {
                 self.print_type(ty)?;
-                self.maybe_print_comment(ty.span.lo)
+                self.maybe_print_comment(ty.span.lo())
             }
             ast::FunctionRetTy::Default(..) => unreachable!(),
         }
@@ -2971,7 +2971,7 @@ impl<'a> State<'a> {
         self.end()?;
 
         match decl.output {
-            ast::FunctionRetTy::Ty(ref output) => self.maybe_print_comment(output.span.lo),
+            ast::FunctionRetTy::Ty(ref output) => self.maybe_print_comment(output.span.lo()),
             _ => Ok(())
         }
     }
@@ -3017,10 +3017,10 @@ impl<'a> State<'a> {
         };
         if let Some(ref cmnt) = self.next_comment() {
             if cmnt.style != comments::Trailing { return Ok(()) }
-            let span_line = cm.lookup_char_pos(span.hi);
+            let span_line = cm.lookup_char_pos(span.hi());
             let comment_line = cm.lookup_char_pos(cmnt.pos);
             let next = next_pos.unwrap_or(cmnt.pos + BytePos(1));
-            if span.hi < cmnt.pos && cmnt.pos < next && span_line.line == comment_line.line {
+            if span.hi() < cmnt.pos && cmnt.pos < next && span_line.line == comment_line.line {
                 self.print_comment(cmnt)?;
             }
         }

--- a/src/libsyntax/std_inject.rs
+++ b/src/libsyntax/std_inject.rs
@@ -31,7 +31,7 @@ fn ignored_span(sp: Span) -> Span {
             allow_internal_unsafe: false,
         }
     });
-    Span { ctxt: SyntaxContext::empty().apply_mark(mark), ..sp }
+    sp.with_ctxt(SyntaxContext::empty().apply_mark(mark))
 }
 
 pub fn injected_crate_name(krate: &ast::Crate) -> Option<&'static str> {

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -306,7 +306,7 @@ fn generate_test_harness(sess: &ParseSess,
 /// call to codemap's `is_internal` check.
 /// The expanded code calls some unstable functions in the test crate.
 fn ignored_span(cx: &TestCtxt, sp: Span) -> Span {
-    Span { ctxt: cx.ctxt, ..sp }
+    sp.with_ctxt(cx.ctxt)
 }
 
 #[derive(PartialEq)]

--- a/src/libsyntax/test_snippet.rs
+++ b/src/libsyntax/test_snippet.rs
@@ -80,11 +80,7 @@ fn make_span(file_text: &str, start: &Position, end: &Position) -> Span {
     let start = make_pos(file_text, start);
     let end = make_pos(file_text, end) + end.string.len(); // just after matching thing ends
     assert!(start <= end);
-    Span {
-        lo: BytePos(start as u32),
-        hi: BytePos(end as u32),
-        ctxt: NO_EXPANSION,
-    }
+    Span::new(BytePos(start as u32), BytePos(end as u32), NO_EXPANSION)
 }
 
 fn make_pos(file_text: &str, pos: &Position) -> usize {

--- a/src/libsyntax/tokenstream.rs
+++ b/src/libsyntax/tokenstream.rs
@@ -59,7 +59,7 @@ impl Delimited {
         let open_span = if span == DUMMY_SP {
             DUMMY_SP
         } else {
-            Span { hi: span.lo + BytePos(self.delim.len() as u32), ..span }
+            span.with_hi(span.lo() + BytePos(self.delim.len() as u32))
         };
         TokenTree::Token(open_span, self.open_token())
     }
@@ -69,7 +69,7 @@ impl Delimited {
         let close_span = if span == DUMMY_SP {
             DUMMY_SP
         } else {
-            Span { lo: span.hi - BytePos(self.delim.len() as u32), ..span }
+            span.with_lo(span.hi() - BytePos(self.delim.len() as u32))
         };
         TokenTree::Token(close_span, self.close_token())
     }
@@ -602,11 +602,7 @@ mod tests {
     }
 
     fn sp(a: u32, b: u32) -> Span {
-        Span {
-            lo: BytePos(a),
-            hi: BytePos(b),
-            ctxt: NO_EXPANSION,
-        }
+        Span::new(BytePos(a), BytePos(b), NO_EXPANSION)
     }
 
     #[test]

--- a/src/libsyntax_ext/deriving/clone.rs
+++ b/src/libsyntax_ext/deriving/clone.rs
@@ -111,7 +111,7 @@ fn cs_clone_shallow(name: &str,
                         ty: P<ast::Ty>, span: Span, helper_name: &str) {
         // Generate statement `let _: helper_name<ty>;`,
         // set the expn ID so we can use the unstable struct.
-        let span = Span { ctxt: cx.backtrace(), ..span};
+        let span = span.with_ctxt(cx.backtrace());
         let assert_path = cx.path_all(span, true,
                                         cx.std_path(&["clone", helper_name]),
                                         vec![], vec![ty], vec![]);

--- a/src/libsyntax_ext/deriving/cmp/eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/eq.rs
@@ -58,7 +58,7 @@ fn cs_total_eq_assert(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure)
                         ty: P<ast::Ty>, span: Span, helper_name: &str) {
         // Generate statement `let _: helper_name<ty>;`,
         // set the expn ID so we can use the unstable struct.
-        let span = Span { ctxt: cx.backtrace(), ..span };
+        let span = span.with_ctxt(cx.backtrace());
         let assert_path = cx.path_all(span, true,
                                         cx.std_path(&["cmp", helper_name]),
                                         vec![], vec![ty], vec![]);

--- a/src/libsyntax_ext/deriving/debug.rs
+++ b/src/libsyntax_ext/deriving/debug.rs
@@ -67,7 +67,7 @@ fn show_substructure(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<E
     };
 
     // We want to make sure we have the ctxt set so that we can use unstable methods
-    let span = Span { ctxt: cx.backtrace(), ..span };
+    let span = span.with_ctxt(cx.backtrace());
     let name = cx.expr_lit(span, ast::LitKind::Str(ident.name, ast::StrStyle::Cooked));
     let builder = Ident::from_str("builder");
     let builder_expr = cx.expr_ident(span, builder.clone());

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -375,7 +375,7 @@ fn find_type_parameters(ty: &ast::Ty,
         }
 
         fn visit_mac(&mut self, mac: &ast::Mac) {
-            let span = Span { ctxt: self.span.ctxt, ..mac.span };
+            let span = mac.span.with_ctxt(self.span.ctxt());
             self.cx.span_err(span, "`derive` cannot be used on items with type macros");
         }
     }
@@ -1464,7 +1464,7 @@ impl<'a> MethodDef<'a> {
             .iter()
             .map(|v| {
                 let ident = v.node.name;
-                let sp = Span { ctxt: trait_.span.ctxt, ..v.span };
+                let sp = v.span.with_ctxt(trait_.span.ctxt());
                 let summary = trait_.summarise_struct(cx, &v.node.data);
                 (ident, sp, summary)
             })
@@ -1484,7 +1484,7 @@ impl<'a> TraitDef<'a> {
         let mut named_idents = Vec::new();
         let mut just_spans = Vec::new();
         for field in struct_def.fields() {
-            let sp = Span { ctxt: self.span.ctxt, ..field.span };
+            let sp = field.span.with_ctxt(self.span.ctxt());
             match field.ident {
                 Some(ident) => named_idents.push((ident, sp)),
                 _ => just_spans.push(sp),
@@ -1529,7 +1529,7 @@ impl<'a> TraitDef<'a> {
         let mut paths = Vec::new();
         let mut ident_exprs = Vec::new();
         for (i, struct_field) in struct_def.fields().iter().enumerate() {
-            let sp = Span { ctxt: self.span.ctxt, ..struct_field.span };
+            let sp = struct_field.span.with_ctxt(self.span.ctxt());
             let ident = cx.ident_of(&format!("{}_{}", prefix, i));
             paths.push(codemap::Spanned {
                 span: sp,
@@ -1550,7 +1550,7 @@ impl<'a> TraitDef<'a> {
                             cx.span_bug(sp, "a braced struct with unnamed fields in `derive`");
                         }
                         codemap::Spanned {
-                            span: Span { ctxt: self.span.ctxt, ..pat.span },
+                            span: pat.span.with_ctxt(self.span.ctxt()),
                             node: ast::FieldPat {
                                 ident: ident.unwrap(),
                                 pat,
@@ -1582,7 +1582,7 @@ impl<'a> TraitDef<'a> {
          mutbl: ast::Mutability)
          -> (P<ast::Pat>, Vec<(Span, Option<Ident>, P<Expr>, &'a [ast::Attribute])>) {
         let variant_ident = variant.node.name;
-        let sp = Span { ctxt: self.span.ctxt, ..variant.span };
+        let sp = variant.span.with_ctxt(self.span.ctxt());
         let variant_path = cx.path(sp, vec![enum_ident, variant_ident]);
         self.create_struct_pattern(cx, variant_path, &variant.node.data, prefix, mutbl)
     }

--- a/src/libsyntax_ext/deriving/mod.rs
+++ b/src/libsyntax_ext/deriving/mod.rs
@@ -158,13 +158,13 @@ fn call_intrinsic(cx: &ExtCtxt,
                   args: Vec<P<ast::Expr>>)
                   -> P<ast::Expr> {
     if cx.current_expansion.mark.expn_info().unwrap().callee.allow_internal_unstable {
-        span.ctxt = cx.backtrace();
+        span = span.with_ctxt(cx.backtrace());
     } else { // Avoid instability errors with user defined curstom derives, cc #36316
         let mut info = cx.current_expansion.mark.expn_info().unwrap();
         info.callee.allow_internal_unstable = true;
         let mark = Mark::fresh(Mark::root());
         mark.set_expn_info(info);
-        span.ctxt = SyntaxContext::empty().apply_mark(mark);
+        span = span.with_ctxt(SyntaxContext::empty().apply_mark(mark));
     }
     let path = cx.std_path(&["intrinsics", intrinsic]);
     let call = cx.expr_call_global(span, path, args);

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -558,10 +558,8 @@ impl<'a, 'b> Context<'a, 'b> {
         // passed to this function.
         for (i, e) in self.args.into_iter().enumerate() {
             let name = self.ecx.ident_of(&format!("__arg{}", i));
-            let span = Span {
-                ctxt: e.span.ctxt.apply_mark(self.ecx.current_expansion.mark),
-                ..DUMMY_SP
-            };
+            let span =
+                DUMMY_SP.with_ctxt(e.span.ctxt().apply_mark(self.ecx.current_expansion.mark));
             pats.push(self.ecx.pat_ident(span, name));
             for ref arg_ty in self.arg_unique_types[i].iter() {
                 locals.push(Context::format_arg(self.ecx, self.macsp, e.span, arg_ty, name));
@@ -642,7 +640,7 @@ impl<'a, 'b> Context<'a, 'b> {
                   ty: &ArgumentType,
                   arg: ast::Ident)
                   -> P<ast::Expr> {
-        sp.ctxt = sp.ctxt.apply_mark(ecx.current_expansion.mark);
+        sp = sp.with_ctxt(sp.ctxt().apply_mark(ecx.current_expansion.mark));
         let arg = ecx.expr_ident(sp, arg);
         let trait_ = match *ty {
             Placeholder(ref tyname) => {
@@ -679,7 +677,7 @@ pub fn expand_format_args<'cx>(ecx: &'cx mut ExtCtxt,
                                mut sp: Span,
                                tts: &[tokenstream::TokenTree])
                                -> Box<base::MacResult + 'cx> {
-    sp.ctxt = sp.ctxt.apply_mark(ecx.current_expansion.mark);
+    sp = sp.with_ctxt(sp.ctxt().apply_mark(ecx.current_expansion.mark));
     match parse_args(ecx, sp, tts) {
         Some((efmt, args, names)) => {
             MacEager::expr(expand_preparsed_format_args(ecx, sp, efmt, args, names))
@@ -701,7 +699,7 @@ pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt,
     let arg_types: Vec<_> = (0..args.len()).map(|_| Vec::new()).collect();
     let arg_unique_types: Vec<_> = (0..args.len()).map(|_| Vec::new()).collect();
     let mut macsp = ecx.call_site();
-    macsp.ctxt = macsp.ctxt.apply_mark(ecx.current_expansion.mark);
+    macsp = macsp.with_ctxt(macsp.ctxt().apply_mark(ecx.current_expansion.mark));
     let msg = "format argument must be a string literal.";
     let fmt = match expr_to_spanned_string(ecx, efmt, msg) {
         Some(fmt) => fmt,

--- a/src/libsyntax_ext/proc_macro_registrar.rs
+++ b/src/libsyntax_ext/proc_macro_registrar.rs
@@ -371,7 +371,7 @@ fn mk_registrar(cx: &mut ExtCtxt,
             allow_internal_unsafe: false,
         }
     });
-    let span = Span { ctxt: SyntaxContext::empty().apply_mark(mark), ..DUMMY_SP };
+    let span = DUMMY_SP.with_ctxt(SyntaxContext::empty().apply_mark(mark));
 
     let proc_macro = Ident::from_str("proc_macro");
     let krate = cx.item(span,

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -25,6 +25,7 @@
 #![feature(optin_builtin_traits)]
 #![allow(unused_attributes)]
 #![feature(specialization)]
+#![feature(staged_api)]
 
 use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
@@ -60,13 +61,20 @@ pub type FileName = String;
 /// range between files.
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Ord, PartialOrd)]
 pub struct Span {
-    lo: BytePos,
-    hi: BytePos,
+    #[unstable(feature = "rustc_private", issue = "27812")]
+    #[rustc_deprecated(since = "1.21", reason = "use getters/setters instead")]
+    pub lo: BytePos,
+    #[unstable(feature = "rustc_private", issue = "27812")]
+    #[rustc_deprecated(since = "1.21", reason = "use getters/setters instead")]
+    pub hi: BytePos,
     /// Information about where the macro came from, if this piece of
     /// code was created by a macro expansion.
-    ctxt: SyntaxContext,
+    #[unstable(feature = "rustc_private", issue = "27812")]
+    #[rustc_deprecated(since = "1.21", reason = "use getters/setters instead")]
+    pub ctxt: SyntaxContext,
 }
 
+#[allow(deprecated)]
 pub const DUMMY_SP: Span = Span { lo: BytePos(0), hi: BytePos(0), ctxt: NO_EXPANSION };
 
 /// A collection of spans. Spans have two orthogonal attributes:
@@ -82,11 +90,13 @@ pub struct MultiSpan {
 }
 
 impl Span {
+    #[allow(deprecated)]
     #[inline]
     pub fn new(lo: BytePos, hi: BytePos, ctxt: SyntaxContext) -> Self {
         if lo <= hi { Span { lo, hi, ctxt } } else { Span { lo: hi, hi: lo, ctxt } }
     }
 
+    #[allow(deprecated)]
     #[inline]
     pub fn lo(self) -> BytePos {
         self.lo
@@ -95,6 +105,7 @@ impl Span {
     pub fn with_lo(self, lo: BytePos) -> Span {
         Span::new(lo, self.hi(), self.ctxt())
     }
+    #[allow(deprecated)]
     #[inline]
     pub fn hi(self) -> BytePos {
         self.hi
@@ -103,6 +114,7 @@ impl Span {
     pub fn with_hi(self, hi: BytePos) -> Span {
         Span::new(self.lo(), hi, self.ctxt())
     }
+    #[allow(deprecated)]
     #[inline]
     pub fn ctxt(self) -> SyntaxContext {
         self.ctxt

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -84,7 +84,7 @@ pub struct MultiSpan {
 impl Span {
     #[inline]
     pub fn new(lo: BytePos, hi: BytePos, ctxt: SyntaxContext) -> Self {
-        Span { lo, hi, ctxt }
+        if lo <= hi { Span { lo, hi, ctxt } } else { Span { lo: hi, hi: lo, ctxt } }
     }
 
     #[inline]

--- a/src/test/run-pass/import-crate-with-invalid-spans/main.rs
+++ b/src/test/run-pass/import-crate-with-invalid-spans/main.rs
@@ -16,7 +16,7 @@ extern crate crate_with_invalid_spans;
 
 fn main() {
     // The AST of `exported_generic` stored in crate_with_invalid_spans's
-    // metadata should contain an invalid span where span.lo > span.hi.
+    // metadata should contain an invalid span where span.lo() > span.hi().
     // Let's make sure the compiler doesn't crash when encountering this.
     let _ = crate_with_invalid_spans::exported_generic(32u32, 7u32);
 }


### PR DESCRIPTION
I actually tried to intern spans and benchmark the result<sup>*</sup>, and this was a prerequisite.
This kind of encapsulation will be a prerequisite for any other attempt to compress span's representation, so I decided to submit this change alone.

The issue https://github.com/rust-lang/rust/issues/43088 seems relevant, but it looks like `SpanId` won't be able to reuse this interface, unless the tables are global (like interner that I tried) and are not a part of HIR.
r? @michaelwoerister anyway

<sup>*</sup> Interning means 2-3 times more space is required for a single span, but duplicates are free. In practice it turned out that duplicates are not *that* common, so more memory was wasted by interning rather than saved.