### PR TITLE
rustc: Add `Local` to the HIR map of parents

### DIFF
--- a/src/librustc/hir/map/collector.rs
+++ b/src/librustc/hir/map/collector.rs
@@ -138,7 +138,7 @@ impl<'hir> Visitor<'hir> for NodeCollector<'hir> {
 
     fn visit_pat(&mut self, pat: &'hir Pat) {
         let node = if let PatKind::Binding(..) = pat.node {
-            NodeLocal(pat)
+            NodeBinding(pat)
         } else {
             NodePat(pat)
         };

--- a/src/librustc/hir/map/collector.rs
+++ b/src/librustc/hir/map/collector.rs
@@ -195,6 +195,13 @@ impl<'hir> Visitor<'hir> for NodeCollector<'hir> {
         });
     }
 
+    fn visit_local(&mut self, l: &'hir Local) {
+        self.insert(l.id, NodeLocal(l));
+        self.with_parent(l.id, |this| {
+            intravisit::walk_local(this, l)
+        })
+    }
+
     fn visit_lifetime(&mut self, lifetime: &'hir Lifetime) {
         self.insert(lifetime.id, NodeLifetime(lifetime));
     }

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -53,7 +53,7 @@ pub enum Node<'hir> {
     NodeStmt(&'hir Stmt),
     NodeTy(&'hir Ty),
     NodeTraitRef(&'hir TraitRef),
-    NodeLocal(&'hir Pat),
+    NodeBinding(&'hir Pat),
     NodePat(&'hir Pat),
     NodeBlock(&'hir Block),
 
@@ -83,7 +83,7 @@ enum MapEntry<'hir> {
     EntryStmt(NodeId, &'hir Stmt),
     EntryTy(NodeId, &'hir Ty),
     EntryTraitRef(NodeId, &'hir TraitRef),
-    EntryLocal(NodeId, &'hir Pat),
+    EntryBinding(NodeId, &'hir Pat),
     EntryPat(NodeId, &'hir Pat),
     EntryBlock(NodeId, &'hir Block),
     EntryStructCtor(NodeId, &'hir VariantData),
@@ -114,7 +114,7 @@ impl<'hir> MapEntry<'hir> {
             NodeStmt(n) => EntryStmt(p, n),
             NodeTy(n) => EntryTy(p, n),
             NodeTraitRef(n) => EntryTraitRef(p, n),
-            NodeLocal(n) => EntryLocal(p, n),
+            NodeBinding(n) => EntryBinding(p, n),
             NodePat(n) => EntryPat(p, n),
             NodeBlock(n) => EntryBlock(p, n),
             NodeStructCtor(n) => EntryStructCtor(p, n),
@@ -136,7 +136,7 @@ impl<'hir> MapEntry<'hir> {
             EntryStmt(id, _) => id,
             EntryTy(id, _) => id,
             EntryTraitRef(id, _) => id,
-            EntryLocal(id, _) => id,
+            EntryBinding(id, _) => id,
             EntryPat(id, _) => id,
             EntryBlock(id, _) => id,
             EntryStructCtor(id, _) => id,
@@ -161,7 +161,7 @@ impl<'hir> MapEntry<'hir> {
             EntryStmt(_, n) => NodeStmt(n),
             EntryTy(_, n) => NodeTy(n),
             EntryTraitRef(_, n) => NodeTraitRef(n),
-            EntryLocal(_, n) => NodeLocal(n),
+            EntryBinding(_, n) => NodeBinding(n),
             EntryPat(_, n) => NodePat(n),
             EntryBlock(_, n) => NodeBlock(n),
             EntryStructCtor(_, n) => NodeStructCtor(n),
@@ -319,7 +319,7 @@ impl<'hir> Map<'hir> {
                 EntryStmt(p, _) |
                 EntryTy(p, _) |
                 EntryTraitRef(p, _) |
-                EntryLocal(p, _) |
+                EntryBinding(p, _) |
                 EntryPat(p, _) |
                 EntryBlock(p, _) |
                 EntryStructCtor(p, _) |
@@ -589,7 +589,7 @@ impl<'hir> Map<'hir> {
     /// immediate parent is an item or a closure.
     pub fn is_argument(&self, id: NodeId) -> bool {
         match self.find(id) {
-            Some(NodeLocal(_)) => (),
+            Some(NodeBinding(_)) => (),
             _ => return false,
         }
         match self.find(self.get_parent_node(id)) {
@@ -856,7 +856,7 @@ impl<'hir> Map<'hir> {
             NodeField(f) => f.name,
             NodeLifetime(lt) => lt.name,
             NodeTyParam(tp) => tp.name,
-            NodeLocal(&Pat { node: PatKind::Binding(_,_,l,_), .. }) => l.node,
+            NodeBinding(&Pat { node: PatKind::Binding(_,_,l,_), .. }) => l.node,
             NodeStructCtor(_) => self.name(self.get_parent(id)),
             _ => bug!("no name for {}", self.node_to_string(id))
         }
@@ -915,7 +915,7 @@ impl<'hir> Map<'hir> {
             Some(EntryStmt(_, stmt)) => stmt.span,
             Some(EntryTy(_, ty)) => ty.span,
             Some(EntryTraitRef(_, tr)) => tr.path.span,
-            Some(EntryLocal(_, pat)) => pat.span,
+            Some(EntryBinding(_, pat)) => pat.span,
             Some(EntryPat(_, pat)) => pat.span,
             Some(EntryBlock(_, block)) => block.span,
             Some(EntryStructCtor(_, _)) => self.expect_item(self.get_parent(id)).span,
@@ -1112,7 +1112,7 @@ impl<'a> print::State<'a> {
             NodeStmt(a)        => self.print_stmt(&a),
             NodeTy(a)          => self.print_type(&a),
             NodeTraitRef(a)    => self.print_trait_ref(&a),
-            NodeLocal(a)       |
+            NodeBinding(a)       |
             NodePat(a)         => self.print_pat(&a),
             NodeBlock(a)       => {
                 use syntax::print::pprust::PrintState;
@@ -1223,7 +1223,7 @@ fn node_id_to_string(map: &Map, id: NodeId, include_id: bool) -> String {
         Some(NodeTraitRef(_)) => {
             format!("trait_ref {}{}", map.node_to_pretty_string(id), id_str)
         }
-        Some(NodeLocal(_)) => {
+        Some(NodeBinding(_)) => {
             format!("local {}{}", map.node_to_pretty_string(id), id_str)
         }
         Some(NodePat(_)) => {

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -332,7 +332,7 @@ impl MutabilityCategory {
 
     fn from_local(tcx: TyCtxt, tables: &ty::TypeckTables, id: ast::NodeId) -> MutabilityCategory {
         let ret = match tcx.hir.get(id) {
-            hir_map::NodeLocal(p) => match p.node {
+            hir_map::NodeBinding(p) => match p.node {
                 PatKind::Binding(..) => {
                     let bm = *tables.pat_binding_modes()
                                     .get(p.hir_id)

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1971,7 +1971,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 
     pub fn local_var_name_str(self, id: NodeId) -> InternedString {
         match self.hir.find(id) {
-            Some(hir_map::NodeLocal(pat)) => {
+            Some(hir_map::NodeBinding(pat)) => {
                 match pat.node {
                     hir::PatKind::Binding(_, _, ref path1, _) => path1.node.as_str(),
                     _ => {

--- a/src/librustc_borrowck/borrowck/gather_loans/gather_moves.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/gather_moves.rs
@@ -68,19 +68,7 @@ fn get_pattern_source<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, pat: &Pat) -> Patte
                     });
             PatternSource::MatchExpr(e)
         }
-        NodeStmt(ref s) => {
-            // the enclosing statement must be a `let` or something else
-            match s.node {
-                StmtDecl(ref decl, _) => {
-                    match decl.node {
-                        DeclLocal(ref local) => PatternSource::LetDecl(local),
-                        _ => return PatternSource::Other,
-                    }
-                }
-                _ => return PatternSource::Other,
-            }
-        }
-
+        NodeLocal(local) => PatternSource::LetDecl(local),
         _ => return PatternSource::Other,
 
     }

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -916,7 +916,7 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
 
     fn local_binding_mode(&self, node_id: ast::NodeId) -> ty::BindingMode {
         let pat = match self.tcx.hir.get(node_id) {
-            hir_map::Node::NodeLocal(pat) => pat,
+            hir_map::Node::NodeBinding(pat) => pat,
             node => bug!("bad node for local: {:?}", node)
         };
 

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -382,7 +382,7 @@ fn construct_fn<'a, 'gcx, 'tcx, A>(hir: Cx<'a, 'gcx, 'tcx>,
                 debug_name: keywords::Invalid.name(),
                 by_ref,
             };
-            if let Some(hir::map::NodeLocal(pat)) = tcx.hir.find(var_node_id) {
+            if let Some(hir::map::NodeBinding(pat)) = tcx.hir.find(var_node_id) {
                 if let hir::PatKind::Binding(_, _, ref ident, _) = pat.node {
                     decl.debug_name = ident.node;
                 }

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -591,7 +591,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                 self.tables.qpath_def(qpath, hir_id)
             }
 
-            Node::NodeLocal(&hir::Pat { node: hir::PatKind::Binding(_, def_id, ..), .. }) => {
+            Node::NodeBinding(&hir::Pat { node: hir::PatKind::Binding(_, def_id, ..), .. }) => {
                 HirDef::Local(def_id)
             }
 

--- a/src/test/run-pass/issue-43910.rs
+++ b/src/test/run-pass/issue-43910.rs
@@ -1,0 +1,16 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(unused_variables)]
+
+fn main() {
+    #[allow(unused_variables)]
+    let x = 12;
+}


### PR DESCRIPTION
When walking parents for lints we want to be sure to hit `let` statements which
can have attributes, so hook up these statements in the HIR map.

Closes #43910