### PR TITLE
 Add the libstd-modifications needed for the L4Re target

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -466,6 +466,7 @@ pub mod error;
 pub mod ffi;
 pub mod fs;
 pub mod io;
+#[cfg(not(target_os = "l4re"))]
 pub mod net;
 pub mod num;
 pub mod os;

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -466,7 +466,6 @@ pub mod error;
 pub mod ffi;
 pub mod fs;
 pub mod io;
-#[cfg(not(target_os = "l4re"))]
 pub mod net;
 pub mod num;
 pub mod os;

--- a/src/libstd/os/mod.rs
+++ b/src/libstd/os/mod.rs
@@ -27,7 +27,7 @@ pub use sys::unix_ext as unix;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use sys::windows_ext as windows;
 
-#[cfg(any(dox, target_os = "linux"))]
+#[cfg(any(dox, target_os = "linux", target_os = "l4re"))]
 #[doc(cfg(target_os = "linux"))]
 pub mod linux;
 

--- a/src/libstd/os/raw.rs
+++ b/src/libstd/os/raw.rs
@@ -21,6 +21,7 @@ use fmt;
                                        target_arch = "s390x")),
           all(target_os = "android", any(target_arch = "aarch64",
                                          target_arch = "arm")),
+          all(target_os = "l4re", target_arch = "x86_64"),
           all(target_os = "fuchsia", target_arch = "aarch64")))]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_char = u8;
 #[cfg(not(any(all(target_os = "linux", any(target_arch = "aarch64",
@@ -30,6 +31,7 @@ use fmt;
                                            target_arch = "s390x")),
               all(target_os = "android", any(target_arch = "aarch64",
                                              target_arch = "arm")),
+              all(target_os = "l4re", target_arch = "x86_64"),
               all(target_os = "fuchsia", target_arch = "aarch64"))))]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_char = i8;
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_schar = i8;

--- a/src/libstd/sys/redox/thread.rs
+++ b/src/libstd/sys/redox/thread.rs
@@ -16,6 +16,8 @@ use sys_common::thread::start_thread;
 use sys::{cvt, syscall};
 use time::Duration;
 
+pub const DEFAULT_MIN_STACK_SIZE: usize = 2 * 1024 * 1024;
+
 pub struct Thread {
     id: usize,
 }

--- a/src/libstd/sys/unix/args.rs
+++ b/src/libstd/sys/unix/args.rs
@@ -65,6 +65,7 @@ impl DoubleEndedIterator for Args {
           target_os = "solaris",
           target_os = "emscripten",
           target_os = "haiku",
+          target_os = "l4re",
           target_os = "fuchsia"))]
 mod imp {
     use os::unix::prelude::*;

--- a/src/libstd/sys/unix/condvar.rs
+++ b/src/libstd/sys/unix/condvar.rs
@@ -38,10 +38,16 @@ impl Condvar {
         Condvar { inner: UnsafeCell::new(libc::PTHREAD_COND_INITIALIZER) }
     }
 
-    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "android"))]
+    #[cfg(any(target_os = "macos",
+              target_os = "ios",
+              target_os = "l4re",
+              target_os = "android"))]
     pub unsafe fn init(&mut self) {}
 
-    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "android")))]
+    #[cfg(not(any(target_os = "macos",
+                  target_os = "ios",
+                  target_os = "l4re",
+                  target_os = "android")))]
     pub unsafe fn init(&mut self) {
         use mem;
         let mut attr: libc::pthread_condattr_t = mem::uninitialized();

--- a/src/libstd/sys/unix/env.rs
+++ b/src/libstd/sys/unix/env.rs
@@ -182,3 +182,14 @@ pub mod os {
     pub const EXE_SUFFIX: &'static str = "";
     pub const EXE_EXTENSION: &'static str = "";
 }
+
+#[cfg(target_os = "l4re")]
+pub mod os {
+    pub const FAMILY: &'static str = "unix";
+    pub const OS: &'static str = "l4re";
+    pub const DLL_PREFIX: &'static str = "lib";
+    pub const DLL_SUFFIX: &'static str = ".so";
+    pub const DLL_EXTENSION: &'static str = "so";
+    pub const EXE_SUFFIX: &'static str = "";
+    pub const EXE_EXTENSION: &'static str = "";
+}

--- a/src/libstd/sys/unix/ext/mod.rs
+++ b/src/libstd/sys/unix/ext/mod.rs
@@ -36,6 +36,7 @@ pub mod fs;
 pub mod process;
 pub mod raw;
 pub mod thread;
+#[cfg(not(target_os = "l4re"))]
 pub mod net;
 
 /// A prelude for conveniently writing platform-specific code.

--- a/src/libstd/sys/unix/ext/mod.rs
+++ b/src/libstd/sys/unix/ext/mod.rs
@@ -36,7 +36,6 @@ pub mod fs;
 pub mod process;
 pub mod raw;
 pub mod thread;
-#[cfg(not(target_os = "l4re"))]
 pub mod net;
 
 /// A prelude for conveniently writing platform-specific code.

--- a/src/libstd/sys/unix/fd.rs
+++ b/src/libstd/sys/unix/fd.rs
@@ -144,6 +144,7 @@ impl FileDesc {
                   target_os = "solaris",
                   target_os = "emscripten",
                   target_os = "fuchsia",
+                  target_os = "l4re",
                   target_os = "haiku")))]
     pub fn set_cloexec(&self) -> io::Result<()> {
         unsafe {
@@ -155,6 +156,7 @@ impl FileDesc {
               target_os = "solaris",
               target_os = "emscripten",
               target_os = "fuchsia",
+              target_os = "l4re",
               target_os = "haiku"))]
     pub fn set_cloexec(&self) -> io::Result<()> {
         unsafe {

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -23,19 +23,21 @@ use sys::time::SystemTime;
 use sys::{cvt, cvt_r};
 use sys_common::{AsInner, FromInner};
 
-#[cfg(any(target_os = "linux", target_os = "emscripten"))]
+#[cfg(any(target_os = "linux", target_os = "emscripten", target_os = "l4re"))]
 use libc::{stat64, fstat64, lstat64, off64_t, ftruncate64, lseek64, dirent64, readdir64_r, open64};
 #[cfg(target_os = "android")]
 use libc::{stat as stat64, fstat as fstat64, lstat as lstat64, lseek64,
            dirent as dirent64, open as open64};
 #[cfg(not(any(target_os = "linux",
               target_os = "emscripten",
+              target_os = "l4re",
               target_os = "android")))]
 use libc::{stat as stat64, fstat as fstat64, lstat as lstat64, off_t as off64_t,
            ftruncate as ftruncate64, lseek as lseek64, dirent as dirent64, open as open64};
 #[cfg(not(any(target_os = "linux",
               target_os = "emscripten",
               target_os = "solaris",
+              target_os = "l4re",
               target_os = "fuchsia")))]
 use libc::{readdir_r as readdir64_r};
 
@@ -316,6 +318,7 @@ impl DirEntry {
               target_os = "android",
               target_os = "solaris",
               target_os = "haiku",
+              target_os = "l4re",
               target_os = "fuchsia"))]
     pub fn ino(&self) -> u64 {
         self.entry.d_ino as u64
@@ -346,6 +349,7 @@ impl DirEntry {
     #[cfg(any(target_os = "android",
               target_os = "linux",
               target_os = "emscripten",
+              target_os = "l4re",
               target_os = "haiku"))]
     fn name_bytes(&self) -> &[u8] {
         unsafe {

--- a/src/libstd/sys/unix/l4re.rs
+++ b/src/libstd/sys/unix/l4re.rs
@@ -1,0 +1,441 @@
+// Copyright 2016-2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! unimpl {
+    () => (return Err(io::Error::new(io::ErrorKind::Other, "No networking available on L4Re."));)
+}
+
+pub mod net {
+    #![allow(warnings)]
+    use fmt;
+    use io;
+    use libc;
+    use net::{SocketAddr, Shutdown, Ipv4Addr, Ipv6Addr};
+    use sys_common::{AsInner, FromInner, IntoInner};
+    use sys::fd::FileDesc;
+    use time::Duration;
+
+
+    pub extern crate libc as netc;
+
+    pub struct Socket(FileDesc);
+    impl Socket {
+        pub fn new(_: &SocketAddr, _: libc::c_int) -> io::Result<Socket> {
+            unimpl!();
+        }
+
+        pub fn new_raw(_: libc::c_int, _: libc::c_int) -> io::Result<Socket> {
+            unimpl!();
+        }
+
+        pub fn new_pair(_: libc::c_int, _: libc::c_int) -> io::Result<(Socket, Socket)> {
+            unimpl!();
+        }
+
+        pub fn connect_timeout(&self, _: &SocketAddr, _: Duration) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn accept(&self, _: *mut libc::sockaddr, _: *mut libc::socklen_t)
+                  -> io::Result<Socket> {
+            unimpl!();
+        }
+
+        pub fn duplicate(&self) -> io::Result<Socket> {
+            unimpl!();
+        }
+
+        pub fn read(&self, _: &mut [u8]) -> io::Result<usize> {
+            unimpl!();
+        }
+
+        pub fn peek(&self, _: &mut [u8]) -> io::Result<usize> {
+            unimpl!();
+        }
+
+        pub fn recv_from(&self, _: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+            unimpl!();
+        }
+
+        pub fn peek_from(&self, _: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+            unimpl!();
+        }
+
+        pub fn write(&self, _: &[u8]) -> io::Result<usize> {
+            unimpl!();
+        }
+
+        pub fn set_timeout(&self, _: Option<Duration>, _: libc::c_int) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn timeout(&self, _: libc::c_int) -> io::Result<Option<Duration>> {
+            unimpl!();
+        }
+
+        pub fn shutdown(&self, _: Shutdown) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn set_nodelay(&self, _: bool) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn nodelay(&self) -> io::Result<bool> {
+            unimpl!();
+        }
+
+        pub fn set_nonblocking(&self, _: bool) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn take_error(&self) -> io::Result<Option<io::Error>> {
+            unimpl!();
+        }
+    }
+
+    impl AsInner<libc::c_int> for Socket {
+        fn as_inner(&self) -> &libc::c_int { self.0.as_inner() }
+    }
+    
+    impl FromInner<libc::c_int> for Socket {
+        fn from_inner(fd: libc::c_int) -> Socket { Socket(FileDesc::new(fd)) }
+    }
+    
+    impl IntoInner<libc::c_int> for Socket {
+        fn into_inner(self) -> libc::c_int { self.0.into_raw() }
+    }
+
+    pub struct TcpStream {
+        inner: Socket,
+    }
+
+    impl TcpStream {
+        pub fn connect(_: &SocketAddr) -> io::Result<TcpStream> {
+            unimpl!();
+        }
+
+        pub fn connect_timeout(_: &SocketAddr, _: Duration) -> io::Result<TcpStream> {
+            unimpl!();
+        }
+
+        pub fn socket(&self) -> &Socket { &self.inner }
+
+        pub fn into_socket(self) -> Socket { self.inner }
+
+        pub fn set_read_timeout(&self, _: Option<Duration>) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn set_write_timeout(&self, _: Option<Duration>) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn read_timeout(&self) -> io::Result<Option<Duration>> {
+            unimpl!();
+        }
+
+        pub fn write_timeout(&self) -> io::Result<Option<Duration>> {
+            unimpl!();
+        }
+
+        pub fn peek(&self, _: &mut [u8]) -> io::Result<usize> {
+            unimpl!();
+        }
+
+        pub fn read(&self, _: &mut [u8]) -> io::Result<usize> {
+            unimpl!();
+        }
+
+        pub fn write(&self, _: &[u8]) -> io::Result<usize> {
+            unimpl!();
+        }
+
+        pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+            unimpl!();
+        }
+
+        pub fn socket_addr(&self) -> io::Result<SocketAddr> {
+            unimpl!();
+        }
+
+        pub fn shutdown(&self, _: Shutdown) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn duplicate(&self) -> io::Result<TcpStream> {
+            unimpl!();
+        }
+
+        pub fn set_nodelay(&self, _: bool) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn nodelay(&self) -> io::Result<bool> {
+            unimpl!();
+        }
+
+        pub fn set_ttl(&self, _: u32) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn ttl(&self) -> io::Result<u32> {
+            unimpl!();
+        }
+
+        pub fn take_error(&self) -> io::Result<Option<io::Error>> {
+            unimpl!();
+        }
+
+        pub fn set_nonblocking(&self, _: bool) -> io::Result<()> {
+            unimpl!();
+        }
+    }
+
+    impl FromInner<Socket> for TcpStream {
+        fn from_inner(socket: Socket) -> TcpStream {
+            TcpStream { inner: socket }
+        }
+    }
+
+    impl fmt::Debug for TcpStream {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "No networking support available on L4Re")
+        }
+    }
+
+    pub struct TcpListener {
+        inner: Socket,
+    }
+
+    impl TcpListener {
+        pub fn bind(_: &SocketAddr) -> io::Result<TcpListener> {
+            unimpl!();
+        }
+
+        pub fn socket(&self) -> &Socket { &self.inner }
+
+        pub fn into_socket(self) -> Socket { self.inner }
+
+        pub fn socket_addr(&self) -> io::Result<SocketAddr> {
+            unimpl!();
+        }
+
+        pub fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
+            unimpl!();
+        }
+
+        pub fn duplicate(&self) -> io::Result<TcpListener> {
+            unimpl!();
+        }
+
+        pub fn set_ttl(&self, _: u32) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn ttl(&self) -> io::Result<u32> {
+            unimpl!();
+        }
+
+        pub fn set_only_v6(&self, _: bool) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn only_v6(&self) -> io::Result<bool> {
+            unimpl!();
+        }
+
+        pub fn take_error(&self) -> io::Result<Option<io::Error>> {
+            unimpl!();
+        }
+
+        pub fn set_nonblocking(&self, _: bool) -> io::Result<()> {
+            unimpl!();
+        }
+    }
+
+    impl FromInner<Socket> for TcpListener {
+        fn from_inner(socket: Socket) -> TcpListener {
+            TcpListener { inner: socket }
+        }
+    }
+
+    impl fmt::Debug for TcpListener {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "No networking support available on L4Re.")
+        }
+    }
+
+    pub struct UdpSocket {
+        inner: Socket,
+    }
+
+    impl UdpSocket {
+        pub fn bind(_: &SocketAddr) -> io::Result<UdpSocket> {
+            unimpl!();
+        }
+
+        pub fn socket(&self) -> &Socket { &self.inner }
+
+        pub fn into_socket(self) -> Socket { self.inner }
+
+        pub fn socket_addr(&self) -> io::Result<SocketAddr> {
+            unimpl!();
+        }
+
+        pub fn recv_from(&self, _: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+            unimpl!();
+        }
+
+        pub fn peek_from(&self, _: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+            unimpl!();
+        }
+
+        pub fn send_to(&self, _: &[u8], _: &SocketAddr) -> io::Result<usize> {
+            unimpl!();
+        }
+
+        pub fn duplicate(&self) -> io::Result<UdpSocket> {
+            unimpl!();
+        }
+
+        pub fn set_read_timeout(&self, _: Option<Duration>) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn set_write_timeout(&self, _: Option<Duration>) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn read_timeout(&self) -> io::Result<Option<Duration>> {
+            unimpl!();
+        }
+
+        pub fn write_timeout(&self) -> io::Result<Option<Duration>> {
+            unimpl!();
+        }
+
+        pub fn set_broadcast(&self, _: bool) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn broadcast(&self) -> io::Result<bool> {
+            unimpl!();
+        }
+
+        pub fn set_multicast_loop_v4(&self, _: bool) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn multicast_loop_v4(&self) -> io::Result<bool> {
+            unimpl!();
+        }
+
+        pub fn set_multicast_ttl_v4(&self, _: u32) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn multicast_ttl_v4(&self) -> io::Result<u32> {
+            unimpl!();
+        }
+
+        pub fn set_multicast_loop_v6(&self, _: bool) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn multicast_loop_v6(&self) -> io::Result<bool> {
+            unimpl!();
+        }
+
+        pub fn join_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr)
+                             -> io::Result<()> {
+                                 unimpl!();
+        }
+
+        pub fn join_multicast_v6(&self, _: &Ipv6Addr, _: u32)
+                             -> io::Result<()> {
+                                 unimpl!();
+        }
+
+        pub fn leave_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr)
+                              -> io::Result<()> {
+                                  unimpl!();
+        }
+
+        pub fn leave_multicast_v6(&self, _: &Ipv6Addr, _: u32)
+                              -> io::Result<()> {
+                                  unimpl!();
+        }
+
+        pub fn set_ttl(&self, _: u32) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn ttl(&self) -> io::Result<u32> {
+            unimpl!();
+        }
+
+        pub fn take_error(&self) -> io::Result<Option<io::Error>> {
+            unimpl!();
+        }
+
+        pub fn set_nonblocking(&self, _: bool) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn recv(&self, _: &mut [u8]) -> io::Result<usize> {
+            unimpl!();
+        }
+
+        pub fn peek(&self, _: &mut [u8]) -> io::Result<usize> {
+            unimpl!();
+        }
+
+        pub fn send(&self, _: &[u8]) -> io::Result<usize> {
+            unimpl!();
+        }
+
+        pub fn connect(&self, _: &SocketAddr) -> io::Result<()> {
+            unimpl!();
+        }
+    }
+
+    impl FromInner<Socket> for UdpSocket {
+        fn from_inner(socket: Socket) -> UdpSocket {
+            UdpSocket { inner: socket }
+        }
+    }
+
+    impl fmt::Debug for UdpSocket {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "No networking support on L4Re available.")
+        }
+    }
+
+    pub struct LookupHost {
+        original: *mut libc::addrinfo,
+        cur: *mut libc::addrinfo,
+    }
+
+    impl Iterator for LookupHost {
+        type Item = SocketAddr;
+        fn next(&mut self) -> Option<SocketAddr> {
+            None
+        }
+    }
+
+    unsafe impl Sync for LookupHost {}
+    unsafe impl Send for LookupHost {}
+
+    pub fn lookup_host(_: &str) -> io::Result<LookupHost> {
+        unimpl!();
+    }
+}
+

--- a/src/libstd/sys/unix/l4re.rs
+++ b/src/libstd/sys/unix/l4re.rs
@@ -104,11 +104,11 @@ pub mod net {
     impl AsInner<libc::c_int> for Socket {
         fn as_inner(&self) -> &libc::c_int { self.0.as_inner() }
     }
-    
+
     impl FromInner<libc::c_int> for Socket {
         fn from_inner(fd: libc::c_int) -> Socket { Socket(FileDesc::new(fd)) }
     }
-    
+
     impl IntoInner<libc::c_int> for Socket {
         fn into_inner(self) -> libc::c_int { self.0.into_raw() }
     }

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -47,6 +47,10 @@ pub mod memchr;
 pub mod mutex;
 #[cfg(not(target_os = "l4re"))]
 pub mod net;
+#[cfg(target_os = "l4re")]
+mod l4re;
+#[cfg(target_os = "l4re")]
+pub use self::l4re::net;
 pub mod os;
 pub mod os_str;
 pub mod path;

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -44,6 +44,7 @@ pub mod fd;
 pub mod fs;
 pub mod memchr;
 pub mod mutex;
+#[cfg(not(target_os = "l4re"))]
 pub mod net;
 pub mod os;
 pub mod os_str;

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -28,6 +28,7 @@ use libc;
 #[cfg(all(not(dox), target_os = "solaris"))]   pub use os::solaris as platform;
 #[cfg(all(not(dox), target_os = "emscripten"))] pub use os::emscripten as platform;
 #[cfg(all(not(dox), target_os = "fuchsia"))]   pub use os::fuchsia as platform;
+#[cfg(all(not(dox), target_os = "l4re"))]      pub use os::linux as platform;
 
 #[macro_use]
 pub mod weak;

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -38,7 +38,10 @@ static ENV_LOCK: Mutex = Mutex::new();
 
 extern {
     #[cfg(not(target_os = "dragonfly"))]
-    #[cfg_attr(any(target_os = "linux", target_os = "emscripten", target_os = "fuchsia"),
+    #[cfg_attr(any(target_os = "linux",
+                   target_os = "emscripten",
+                   target_os = "fuchsia",
+                   target_os = "l4re"),
                link_name = "__errno_location")]
     #[cfg_attr(any(target_os = "bitrig",
                    target_os = "netbsd",
@@ -346,10 +349,10 @@ pub fn current_exe() -> io::Result<PathBuf> {
     }
 }
 
-#[cfg(target_os = "fuchsia")]
+#[cfg(any(target_os = "fuchsia", target_os = "l4re"))]
 pub fn current_exe() -> io::Result<PathBuf> {
     use io::ErrorKind;
-    Err(io::Error::new(ErrorKind::Other, "Not yet implemented on fuchsia"))
+    Err(io::Error::new(ErrorKind::Other, "Not yet implemented!"))
 }
 
 pub struct Env {

--- a/src/libstd/sys/unix/process/process_unix.rs
+++ b/src/libstd/sys/unix/process/process_unix.rs
@@ -160,20 +160,22 @@ impl Command {
             t!(cvt_r(|| libc::dup2(fd, libc::STDERR_FILENO)));
         }
 
-        if let Some(u) = self.get_gid() {
-            t!(cvt(libc::setgid(u as gid_t)));
-        }
-        if let Some(u) = self.get_uid() {
-            // When dropping privileges from root, the `setgroups` call
-            // will remove any extraneous groups. If we don't call this,
-            // then even though our uid has dropped, we may still have
-            // groups that enable us to do super-user things. This will
-            // fail if we aren't root, so don't bother checking the
-            // return value, this is just done as an optimistic
-            // privilege dropping function.
-            let _ = libc::setgroups(0, ptr::null());
+        if cfg!(not(any(target_os = "l4re"))) {
+            if let Some(u) = self.get_gid() {
+                t!(cvt(libc::setgid(u as gid_t)));
+            }
+            if let Some(u) = self.get_uid() {
+                // When dropping privileges from root, the `setgroups` call
+                // will remove any extraneous groups. If we don't call this,
+                // then even though our uid has dropped, we may still have
+                // groups that enable us to do super-user things. This will
+                // fail if we aren't root, so don't bother checking the
+                // return value, this is just done as an optimistic
+                // privilege dropping function.
+                let _ = libc::setgroups(0, ptr::null());
 
-            t!(cvt(libc::setuid(u as uid_t)));
+                t!(cvt(libc::setuid(u as uid_t)));
+            }
         }
         if let Some(ref cwd) = *self.get_cwd() {
             t!(cvt(libc::chdir(cwd.as_ptr())));

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -53,10 +53,6 @@ impl Thread {
 
         let stack_size = cmp::max(stack, min_stack_size(&attr));
 
-        // L4Re only supports a maximum of 1Mb per default.
-        #[cfg(target_os = "l4re")]
-        let stack_size = cmp::min(stack_size, 1024 * 1024);
-
         match pthread_attr_setstacksize(&mut attr,
                                         stack_size) {
             0 => {}

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -20,6 +20,11 @@ use time::Duration;
 
 use sys_common::thread::*;
 
+#[cfg(not(target_os = "l4re"))]
+pub const DEFAULT_MIN_STACK_SIZE: usize = 2 * 1024 * 1024;
+#[cfg(target_os = "l4re")]
+pub const DEFAULT_MIN_STACK_SIZE: usize = 1024 * 1024;
+
 pub struct Thread {
     id: libc::pthread_t,
 }

--- a/src/libstd/sys/windows/thread.rs
+++ b/src/libstd/sys/windows/thread.rs
@@ -19,6 +19,8 @@ use sys::handle::Handle;
 use sys_common::thread::*;
 use time::Duration;
 
+pub const DEFAULT_MIN_STACK_SIZE: usize = 2 * 1024 * 1024;
+
 pub struct Thread {
     handle: Handle
 }

--- a/src/libstd/sys_common/mod.rs
+++ b/src/libstd/sys_common/mod.rs
@@ -44,7 +44,7 @@ pub mod thread_local;
 pub mod util;
 pub mod wtf8;
 
-#[cfg(target_os = "redox")]
+#[cfg(any(target_os = "redox", target_os = "l4re"))]
 pub use sys::net;
 
 #[cfg(not(any(target_os = "redox", target_os = "l4re")))]

--- a/src/libstd/sys_common/mod.rs
+++ b/src/libstd/sys_common/mod.rs
@@ -47,7 +47,7 @@ pub mod wtf8;
 #[cfg(target_os = "redox")]
 pub use sys::net;
 
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "l4re")))]
 pub mod net;
 
 #[cfg(feature = "backtrace")]

--- a/src/libstd/sys_common/net.rs
+++ b/src/libstd/sys_common/net.rs
@@ -24,22 +24,22 @@ use time::Duration;
 #[cfg(any(target_os = "dragonfly", target_os = "freebsd",
           target_os = "ios", target_os = "macos",
           target_os = "openbsd", target_os = "netbsd",
-          target_os = "solaris", target_os = "haiku"))]
+          target_os = "solaris", target_os = "haiku", target_os = "l4re"))]
 use sys::net::netc::IPV6_JOIN_GROUP as IPV6_ADD_MEMBERSHIP;
 #[cfg(not(any(target_os = "dragonfly", target_os = "freebsd",
               target_os = "ios", target_os = "macos",
               target_os = "openbsd", target_os = "netbsd",
-              target_os = "solaris", target_os = "haiku")))]
+              target_os = "solaris", target_os = "haiku", target_os = "l4re")))]
 use sys::net::netc::IPV6_ADD_MEMBERSHIP;
 #[cfg(any(target_os = "dragonfly", target_os = "freebsd",
           target_os = "ios", target_os = "macos",
           target_os = "openbsd", target_os = "netbsd",
-          target_os = "solaris", target_os = "haiku"))]
+          target_os = "solaris", target_os = "haiku", target_os = "l4re"))]
 use sys::net::netc::IPV6_LEAVE_GROUP as IPV6_DROP_MEMBERSHIP;
 #[cfg(not(any(target_os = "dragonfly", target_os = "freebsd",
               target_os = "ios", target_os = "macos",
               target_os = "openbsd", target_os = "netbsd",
-              target_os = "solaris", target_os = "haiku")))]
+              target_os = "solaris", target_os = "haiku", target_os = "l4re")))]
 use sys::net::netc::IPV6_DROP_MEMBERSHIP;
 
 #[cfg(any(target_os = "linux", target_os = "android",

--- a/src/libstd/sys_common/thread.rs
+++ b/src/libstd/sys_common/thread.rs
@@ -8,9 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use env;
 use alloc::boxed::FnBox;
 use libc;
+use sync::atomic::{self, Ordering};
 use sys::stack_overflow;
+use sys::thread as imp;
 
 pub unsafe fn start_thread(main: *mut libc::c_void) {
     // Next, set up our stack overflow handler which may get triggered if we run
@@ -19,4 +22,19 @@ pub unsafe fn start_thread(main: *mut libc::c_void) {
 
     // Finally, let's run some code.
     Box::from_raw(main as *mut Box<FnBox()>)()
+}
+
+pub fn min_stack() -> usize {
+    static MIN: atomic::AtomicUsize = atomic::AtomicUsize::new(0);
+    match MIN.load(Ordering::SeqCst) {
+        0 => {}
+        n => return n - 1,
+    }
+    let amt = env::var("RUST_MIN_STACK").ok().and_then(|s| s.parse().ok());
+    let amt = amt.unwrap_or(imp::DEFAULT_MIN_STACK_SIZE);
+
+    // 0 is our sentinel value, so ensure that we'll never see 0 after
+    // initialization has run
+    MIN.store(amt + 1, Ordering::SeqCst);
+    amt
 }

--- a/src/libstd/sys_common/util.rs
+++ b/src/libstd/sys_common/util.rs
@@ -22,7 +22,12 @@ pub fn min_stack() -> usize {
         n => return n - 1,
     }
     let amt = env::var("RUST_MIN_STACK").ok().and_then(|s| s.parse().ok());
+    #[cfg(not(target_os = "l4re"))]
     let amt = amt.unwrap_or(2 * 1024 * 1024);
+    // L4Re only supports a maximum of 1Mb per default.
+    #[cfg(target_os = "l4re")]
+    let amt = amt.unwrap_or(1024 * 1024);
+
     // 0 is our sentinel value, so ensure that we'll never see 0 after
     // initialization has run
     MIN.store(amt + 1, Ordering::SeqCst);

--- a/src/libstd/sys_common/util.rs
+++ b/src/libstd/sys_common/util.rs
@@ -8,31 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use env;
 use fmt;
 use io::prelude::*;
-use sync::atomic::{self, Ordering};
 use sys::stdio::Stderr;
 use thread;
-
-pub fn min_stack() -> usize {
-    static MIN: atomic::AtomicUsize = atomic::AtomicUsize::new(0);
-    match MIN.load(Ordering::SeqCst) {
-        0 => {}
-        n => return n - 1,
-    }
-    let amt = env::var("RUST_MIN_STACK").ok().and_then(|s| s.parse().ok());
-    #[cfg(not(target_os = "l4re"))]
-    let amt = amt.unwrap_or(2 * 1024 * 1024);
-    // L4Re only supports a maximum of 1Mb per default.
-    #[cfg(target_os = "l4re")]
-    let amt = amt.unwrap_or(1024 * 1024);
-
-    // 0 is our sentinel value, so ensure that we'll never see 0 after
-    // initialization has run
-    MIN.store(amt + 1, Ordering::SeqCst);
-    amt
-}
 
 pub fn dumb_print(args: fmt::Arguments) {
     let _ = Stderr::new().map(|mut stderr| stderr.write_fmt(args));

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -174,7 +174,7 @@ use sync::{Mutex, Condvar, Arc};
 use sys::thread as imp;
 use sys_common::mutex;
 use sys_common::thread_info;
-use sys_common::util;
+use sys_common::thread;
 use sys_common::{AsInner, IntoInner};
 use time::Duration;
 
@@ -374,7 +374,7 @@ impl Builder {
     {
         let Builder { name, stack_size } = self;
 
-        let stack_size = stack_size.unwrap_or_else(util::min_stack);
+        let stack_size = stack_size.unwrap_or_else(thread::min_stack);
 
         let my_thread = Thread::new(name);
         let their_thread = my_thread.clone();


### PR DESCRIPTION
This commit adds the needed modifications to compile the std crate for the L4 Runtime environment (L4Re).

A target for the L4Re was introduced in commit: c151220a84e40b65e45308cc0f3bbea4466d3acf

In many aspects implementations for linux also apply for the L4Re microkernel.

Some uncommon characteristics had to be resolved:
 * L4Re has no network funktionality
 * L4Re has a maximum stacksize of 1Mb for threads
 * L4Re has no uid or gid
    
Co-authored-by: Sebastian Humenda <sebastian.humenda@tu-dresden.de>