### PR TITLE
Redox: correct is_absolute() and has_root()

### DIFF
--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -327,14 +327,7 @@ unsafe fn u8_slice_as_os_str(s: &[u8]) -> &OsStr {
 #[inline]
 #[allow(unused_variables)]
 fn has_scheme(s: &[u8]) -> bool {
-    #[cfg(target_os = "redox")]
-    {
-        s.split(|b| *b == b'/').next().unwrap_or(b"").contains(&b':')
-    }
-    #[cfg(not(target_os = "redox"))]
-    {
-        false
-    }
+    cfg!(target_os = "redox") && s.split(|b| *b == b'/').next().unwrap_or(b"").contains(&b':')
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1702,12 +1695,9 @@ impl Path {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[allow(deprecated)]
     pub fn is_absolute(&self) -> bool {
-        #[cfg(not(target_os = "redox"))]
-        {
+        if !cfg!(target_os = "redox") {
             self.has_root() && (cfg!(unix) || self.prefix().is_some())
-        }
-        #[cfg(target_os = "redox")]
-        {
+        } else {
             // FIXME: Allow Redox prefixes
             has_scheme(self.as_u8_slice())
         }

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1685,8 +1685,16 @@ impl Path {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[allow(deprecated)]
     pub fn is_absolute(&self) -> bool {
-        // FIXME: Remove target_os = "redox" and allow Redox prefixes
-        self.has_root() && (cfg!(unix) || cfg!(target_os = "redox") || self.prefix().is_some())
+        #[cfg(not(target_os = "redox"))]
+        {
+            self.has_root() && (cfg!(unix) || self.prefix().is_some())
+        }
+        #[cfg(target_os = "redox")]
+        {
+            // FIXME: Allow Redox prefixes
+            use os::unix::ffi::OsStrExt;
+            self.as_os_str().as_bytes().split(|b| *b == b'/').next().unwrap_or(b"").contains(&b':')
+        }
     }
 
     /// Returns `true` if the `Path` is relative, i.e. not absolute.


### PR DESCRIPTION
This is awkward, but representing schemes properly in `Components` is not easily possible without breaking backwards compatibility, as discussed earlier in https://github.com/rust-lang/rust/pull/37702.

But these methods can be corrected anyway.