### PR TITLE
Improve Try error messages

### DIFF
--- a/src/libcore/ops/try.rs
+++ b/src/libcore/ops/try.rs
@@ -14,6 +14,7 @@
 /// in terms of a success/failure dichotomy.  This trait allows both
 /// extracting those success or failure values from an existing instance and
 /// creating a new instance from a success or failure value.
+#[cfg_attr(not(stage0), lang = "try")]
 #[unstable(feature = "try_trait", issue = "42327")]
 #[rustc_on_unimplemented = "the `?` operator can only be used in a function that returns `Result` \
                             (or another type that implements `{Try}`)"]

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -320,6 +320,8 @@ language_item_table! {
 
     StrEqFnLangItem,                 "str_eq",                  str_eq_fn;
 
+    TryTraitLangItem,                "try",                     try_trait;
+
     // A number of panic-related lang items. The `panic` item corresponds to
     // divide-by-zero and various panic cases with `match`. The
     // `panic_bounds_check` item is for indexing arrays.

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -10,7 +10,7 @@
 
 use self::Destination::*;
 
-use syntax_pos::{DUMMY_SP, FileMap, Span, MultiSpan, CharPos};
+use syntax_pos::{DUMMY_SP, FileMap, Span, MultiSpan, CharPos, CompilerDesugaringKind};
 
 use {Level, CodeSuggestion, DiagnosticBuilder, SubDiagnostic, CodeMapper};
 use RenderSpan::*;
@@ -724,7 +724,9 @@ impl EmitterWriter {
 
             // First, find all the spans in <*macros> and point instead at their use site
             for sp in span.primary_spans() {
-                if *sp == DUMMY_SP {
+                if *sp == DUMMY_SP ||
+                    sp.is_compiler_desugaring(CompilerDesugaringKind::QuestionMark)
+                {
                     continue;
                 }
                 let call_sp = cm.call_span_if_macro(*sp);

--- a/src/test/ui/suggestions/try-operator-on-main.stderr
+++ b/src/test/ui/suggestions/try-operator-on-main.stderr
@@ -5,7 +5,6 @@ error[E0277]: the trait bound `(): std::ops::Try` is not satisfied
    |     ---------------------------
    |     |
    |     the `?` operator can only be used in a function that returns `Result` (or another type that implements `std::ops::Try`)
-   |     in this macro invocation
    |
    = help: the trait `std::ops::Try` is not implemented for `()`
    = note: required by `std::ops::Try::from_error`

--- a/src/test/ui/suggestions/try-unimplemented.rs
+++ b/src/test/ui/suggestions/try-unimplemented.rs
@@ -1,0 +1,22 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    source();
+    ret();
+}
+
+fn source() -> u32 {
+    3u32?
+}
+
+fn ret() {
+    Ok(3u32)?;
+}

--- a/src/test/ui/suggestions/try-unimplemented.stderr
+++ b/src/test/ui/suggestions/try-unimplemented.stderr
@@ -2,10 +2,7 @@ error[E0277]: the trait bound `u32: std::ops::Try` is not satisfied
   --> $DIR/try-unimplemented.rs:17:5
    |
 17 |     3u32?
-   |     -----
-   |     |
-   |     `?` cannot be applied to a value of type `u32`
-   |     in this macro invocation
+   |     ^^^^^ `?` cannot be applied to a value of type `u32`
    |
    = help: the trait `std::ops::Try` is not implemented for `u32`
    = note: required by `std::ops::Try::into_result`
@@ -14,10 +11,7 @@ error[E0277]: the trait bound `(): std::ops::Try` is not satisfied
   --> $DIR/try-unimplemented.rs:21:5
    |
 21 |     Ok(3u32)?;
-   |     ---------
-   |     |
-   |     cannot use the `?` operator in a function that returns `()`
-   |     in this macro invocation
+   |     ^^^^^^^^^ cannot use the `?` operator in a function that returns `()`
    |
    = help: the trait `std::ops::Try` is not implemented for `()`
    = note: required by `std::ops::Try::from_error`

--- a/src/test/ui/suggestions/try-unimplemented.stderr
+++ b/src/test/ui/suggestions/try-unimplemented.stderr
@@ -1,0 +1,26 @@
+error[E0277]: the trait bound `u32: std::ops::Try` is not satisfied
+  --> $DIR/try-unimplemented.rs:17:5
+   |
+17 |     3u32?
+   |     -----
+   |     |
+   |     `?` cannot be applied to a value of type `u32`
+   |     in this macro invocation
+   |
+   = help: the trait `std::ops::Try` is not implemented for `u32`
+   = note: required by `std::ops::Try::into_result`
+
+error[E0277]: the trait bound `(): std::ops::Try` is not satisfied
+  --> $DIR/try-unimplemented.rs:21:5
+   |
+21 |     Ok(3u32)?;
+   |     ---------
+   |     |
+   |     cannot use the `?` operator in a function that returns `()`
+   |     in this macro invocation
+   |
+   = help: the trait `std::ops::Try` is not implemented for `()`
+   = note: required by `std::ops::Try::from_error`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
This is a WIP. Fixing `ui/suggestions/try-operator-on-main.rs` requires implementing the `Return type does not implement Try` situation of [RFC 1859](https://github.com/rust-lang/rfcs/blob/master/text/1859-try-trait.md#error-messages). This is part of #35946.

How would I differentiate between the first two situations of the RFC?