### PR TITLE
redox: Correct error on exec when file is not found

### DIFF
--- a/src/libstd/sys/redox/process.rs
+++ b/src/libstd/sys/redox/process.rs
@@ -336,7 +336,7 @@ impl Command {
                 panic!("return from exec without err");
             }
         } else {
-            io::Error::new(io::ErrorKind::NotFound, "")
+            io::Error::from_raw_os_error(syscall::ENOENT)
         }
     }
 


### PR DESCRIPTION
`.raw_os_error()` (called in `spawn()`) returned None, so this produced an incorrect error.