### PR TITLE
Make sure crates not opting in to staged_api don't use staged_api

### DIFF
--- a/src/librustc_plugin/lib.rs
+++ b/src/librustc_plugin/lib.rs
@@ -69,6 +69,7 @@
 #![deny(warnings)]
 
 #![feature(rustc_diagnostic_macros)]
+#![feature(staged_api)]
 
 #[macro_use] extern crate syntax;
 

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -37,6 +37,7 @@
 #![feature(libc)]
 #![feature(set_stdio)]
 #![feature(panic_unwind)]
+#![feature(staged_api)]
 
 extern crate getopts;
 extern crate term;

--- a/src/test/compile-fail/stability-attribute-non-staged-force-unstable.rs
+++ b/src/test/compile-fail/stability-attribute-non-staged-force-unstable.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:-Zforce-unstable-if-unmarked
+
+#[unstable] //~ ERROR: stability attributes may not be used
+#[stable] //~ ERROR: stability attributes may not be used
+#[rustc_deprecated] //~ ERROR: stability attributes may not be used
+fn main() { }

--- a/src/test/run-pass/deprecation-in-force-unstable.rs
+++ b/src/test/run-pass/deprecation-in-force-unstable.rs
@@ -1,0 +1,14 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:-Zforce-unstable-if-unmarked
+
+#[deprecated] // should work even with -Zforce-unstable-if-unmarked
+fn main() { }


### PR DESCRIPTION
This also fixes the problem that with `-Zforce-unstable-if-unmarked` set, crates could not use `#[deprecated]`.

If you prefer, I can instead submit another version which just fixes this problem, but still allows the staged API attributes for all crates when  `-Zforce-unstable-if-unmarked` is set. I have prepared that at <https://github.com/RalfJung/rust/tree/staged2>. As yet another alternative, @alexcrichton suggested to turn this error into a lint, but that seems to be much more work, so is it worth it?

Cc @alexcrichton #43975