### PR TITLE
 impl Hasher for {&mut Hasher, Box<Hasher>}

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -62,7 +62,7 @@ use core::any::Any;
 use core::borrow;
 use core::cmp::Ordering;
 use core::fmt;
-use core::hash::{self, Hash};
+use core::hash::{self, Hash, Hasher};
 use core::iter::FusedIterator;
 use core::marker::{self, Unsize};
 use core::mem;
@@ -453,6 +453,52 @@ impl<T: ?Sized + Eq> Eq for Box<T> {}
 impl<T: ?Sized + Hash> Hash for Box<T> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         (**self).hash(state);
+    }
+}
+
+#[stable(feature = "indirect_hasher_impl", since = "1.22.0")]
+impl<T: ?Sized + Hasher> Hasher for Box<T> {
+    fn finish(&self) -> u64 {
+        (**self).finish()
+    }
+    fn write(&mut self, bytes: &[u8]) {
+        (**self).write(bytes)
+    }
+    fn write_u8(&mut self, i: u8) {
+        (**self).write_u8(i)
+    }
+    fn write_u16(&mut self, i: u16) {
+        (**self).write_u16(i)
+    }
+    fn write_u32(&mut self, i: u32) {
+        (**self).write_u32(i)
+    }
+    fn write_u64(&mut self, i: u64) {
+        (**self).write_u64(i)
+    }
+    fn write_u128(&mut self, i: u128) {
+        (**self).write_u128(i)
+    }
+    fn write_usize(&mut self, i: usize) {
+        (**self).write_usize(i)
+    }
+    fn write_i8(&mut self, i: i8) {
+        (**self).write_i8(i)
+    }
+    fn write_i16(&mut self, i: i16) {
+        (**self).write_i16(i)
+    }
+    fn write_i32(&mut self, i: i32) {
+        (**self).write_i32(i)
+    }
+    fn write_i64(&mut self, i: i64) {
+        (**self).write_i64(i)
+    }
+    fn write_i128(&mut self, i: i128) {
+        (**self).write_i128(i)
+    }
+    fn write_isize(&mut self, i: isize) {
+        (**self).write_isize(i)
     }
 }
 

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -121,7 +121,7 @@
 #![feature(unsize)]
 #![feature(allocator_internals)]
 
-#![cfg_attr(not(test), feature(fused, fn_traits, placement_new_protocol, swap_with_slice))]
+#![cfg_attr(not(test), feature(fused, fn_traits, placement_new_protocol, swap_with_slice, i128))]
 #![cfg_attr(test, feature(test, box_heap))]
 
 // Allow testing this library

--- a/src/liballoc/tests/lib.rs
+++ b/src/liballoc/tests/lib.rs
@@ -51,6 +51,9 @@ fn hash<T: Hash>(t: &T) -> u64 {
     s.finish()
 }
 
+// FIXME: Instantiated functions with i128 in the signature is not supported in Emscripten.
+// See https://github.com/kripken/emscripten-fastcomp/issues/169
+#[cfg(not(target_os = "emscripten"))]
 #[test]
 fn test_boxed_hasher() {
     let ordinary_hash = hash(&5u32);

--- a/src/liballoc/tests/lib.rs
+++ b/src/liballoc/tests/lib.rs
@@ -50,3 +50,16 @@ fn hash<T: Hash>(t: &T) -> u64 {
     t.hash(&mut s);
     s.finish()
 }
+
+#[test]
+fn test_boxed_hasher() {
+    let ordinary_hash = hash(&5u32);
+
+    let mut hasher_1 = Box::new(DefaultHasher::new());
+    5u32.hash(&mut hasher_1);
+    assert_eq!(ordinary_hash, hasher_1.finish());
+
+    let mut hasher_2 = Box::new(DefaultHasher::new()) as Box<Hasher>;
+    5u32.hash(&mut hasher_2);
+    assert_eq!(ordinary_hash, hasher_2.finish());
+}

--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -359,6 +359,52 @@ pub trait Hasher {
     }
 }
 
+#[stable(feature = "indirect_hasher_impl", since = "1.22.0")]
+impl<'a, H: Hasher + ?Sized> Hasher for &'a mut H {
+    fn finish(&self) -> u64 {
+        (**self).finish()
+    }
+    fn write(&mut self, bytes: &[u8]) {
+        (**self).write(bytes)
+    }
+    fn write_u8(&mut self, i: u8) {
+        (**self).write_u8(i)
+    }
+    fn write_u16(&mut self, i: u16) {
+        (**self).write_u16(i)
+    }
+    fn write_u32(&mut self, i: u32) {
+        (**self).write_u32(i)
+    }
+    fn write_u64(&mut self, i: u64) {
+        (**self).write_u64(i)
+    }
+    fn write_u128(&mut self, i: u128) {
+        (**self).write_u128(i)
+    }
+    fn write_usize(&mut self, i: usize) {
+        (**self).write_usize(i)
+    }
+    fn write_i8(&mut self, i: i8) {
+        (**self).write_i8(i)
+    }
+    fn write_i16(&mut self, i: i16) {
+        (**self).write_i16(i)
+    }
+    fn write_i32(&mut self, i: i32) {
+        (**self).write_i32(i)
+    }
+    fn write_i64(&mut self, i: i64) {
+        (**self).write_i64(i)
+    }
+    fn write_i128(&mut self, i: i128) {
+        (**self).write_i128(i)
+    }
+    fn write_isize(&mut self, i: isize) {
+        (**self).write_isize(i)
+    }
+}
+
 /// A trait for creating instances of [`Hasher`].
 ///
 /// A `BuildHasher` is typically used (e.g. by [`HashMap`]) to create

--- a/src/libcore/tests/hash/mod.rs
+++ b/src/libcore/tests/hash/mod.rs
@@ -109,3 +109,13 @@ fn test_custom_state() {
 
     assert_eq!(hash(&Custom { hash: 5 }), 5);
 }
+
+#[test]
+fn test_indirect_hasher() {
+    let mut hasher = MyHasher { hash: 0 };
+    {
+        let mut indirect_hasher: &mut Hasher = &mut hasher;
+        5u32.hash(&mut indirect_hasher);
+    }
+    assert_eq!(hasher.hash, 5);
+}

--- a/src/libcore/tests/hash/mod.rs
+++ b/src/libcore/tests/hash/mod.rs
@@ -110,6 +110,9 @@ fn test_custom_state() {
     assert_eq!(hash(&Custom { hash: 5 }), 5);
 }
 
+// FIXME: Instantiated functions with i128 in the signature is not supported in Emscripten.
+// See https://github.com/kripken/emscripten-fastcomp/issues/169
+#[cfg(not(target_os = "emscripten"))]
 #[test]
 fn test_indirect_hasher() {
     let mut hasher = MyHasher { hash: 0 };

--- a/src/tools/tidy/src/pal.rs
+++ b/src/tools/tidy/src/pal.rs
@@ -76,6 +76,7 @@ const EXCEPTION_PATHS: &'static [&'static str] = &[
 
     // std testing crates, ok for now at least
     "src/libcore/tests",
+    "src/liballoc/tests/lib.rs",
 
     // non-std crates
     "src/test",


### PR DESCRIPTION
**Rationale:** The `Hash` trait has `fn hash<H: Hasher>(&self, state: &mut H)`, which can only accept a `Sized` hasher, even if the `Hasher` trait is object-safe. We cannot retroactively add the `?Sized` bound without breaking stability, thus implementing `Hasher` to a trait object reference is the next best solution.

**Warning:** These `impl` are insta-stable, and should need an FCP. I don't think a full RFC is necessary.