### PR TITLE
libproc_macro docs: fix brace and bracket mixup

### DIFF
--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -246,9 +246,9 @@ pub enum TokenNode {
 pub enum Delimiter {
     /// `( ... )`
     Parenthesis,
-    /// `[ ... ]`
-    Brace,
     /// `{ ... }`
+    Brace,
+    /// `[ ... ]`
     Bracket,
     /// An implicit delimiter, e.g. `$var`, where $var is  `...`.
     None,


### PR DESCRIPTION
The documentation indicates that brace is `[`.
Brace is mapped token::Brace which (expectedly) is `{`.
So the documentation is simply confusing brace and bracket there.

Even though it's just a very small issue, it can lead to quite some confusion.