### PR TITLE
Add [T]::swap_with_slice

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -121,7 +121,7 @@
 #![feature(unsize)]
 #![feature(allocator_internals)]
 
-#![cfg_attr(not(test), feature(fused, fn_traits, placement_new_protocol))]
+#![cfg_attr(not(test), feature(fused, fn_traits, placement_new_protocol, swap_with_slice))]
 #![cfg_attr(test, feature(test, box_heap))]
 
 // Allow testing this library

--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -1461,6 +1461,31 @@ impl<T> [T] {
         core_slice::SliceExt::copy_from_slice(self, src)
     }
 
+    /// Swaps all elements in `self` with those in `src`.
+    ///
+    /// The length of `src` must be the same as `self`.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the two slices have different lengths.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #![feature(swap_with_slice)]
+    ///
+    /// let mut src = [1, 2, 3];
+    /// let mut dst = [7, 8, 9];
+    ///
+    /// src.swap_with_slice(&mut dst);
+    /// assert_eq!(src, [7, 8, 9]);
+    /// assert_eq!(dst, [1, 2, 3]);
+    /// ```
+    #[unstable(feature = "swap_with_slice", issue = "44030")]
+    pub fn swap_with_slice(&mut self, src: &mut [T]) {
+        core_slice::SliceExt::swap_with_slice(self, src)
+    }
+
     /// Copies `self` into a new `Vec`.
     ///
     /// # Examples

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -212,6 +212,9 @@ pub trait SliceExt {
     #[stable(feature = "copy_from_slice", since = "1.9.0")]
     fn copy_from_slice(&mut self, src: &[Self::Item]) where Self::Item: Copy;
 
+    #[unstable(feature = "swap_with_slice", issue = "44030")]
+    fn swap_with_slice(&mut self, src: &mut [Self::Item]);
+
     #[stable(feature = "sort_unstable", since = "1.20.0")]
     fn sort_unstable(&mut self)
         where Self::Item: Ord;
@@ -670,6 +673,16 @@ impl<T> SliceExt for [T] {
         unsafe {
             ptr::copy_nonoverlapping(
                 src.as_ptr(), self.as_mut_ptr(), self.len());
+        }
+    }
+
+    #[inline]
+    fn swap_with_slice(&mut self, src: &mut [T]) {
+        assert!(self.len() == src.len(),
+                "destination and source slices have different lengths");
+        unsafe {
+            ptr::swap_nonoverlapping(
+                self.as_mut_ptr(), src.as_mut_ptr(), self.len());
         }
     }
 


### PR DESCRIPTION
The safe version of a method from `ptr`, like `[T]::copy_from_slice` is.

Tracking issue: https://github.com/rust-lang/rust/issues/44030