### PR TITLE
Fix logic error in test guarding prototype MIR borrowck code.

### DIFF
--- a/src/librustc_mir/borrow_check.rs
+++ b/src/librustc_mir/borrow_check.rs
@@ -50,7 +50,7 @@ fn mir_borrowck<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) {
     debug!("run query mir_borrowck: {}", tcx.node_path_str(src.item_id()));
 
     let mir: &Mir<'tcx> = &mir.borrow();
-    if !tcx.has_attr(def_id, "rustc_mir_borrowck") || !tcx.sess.opts.debugging_opts.borrowck_mir {
+    if !tcx.has_attr(def_id, "rustc_mir_borrowck") && !tcx.sess.opts.debugging_opts.borrowck_mir {
         return;
     }
 


### PR DESCRIPTION
Fix logic error in test guarding prototype MIR borrowck code.

tl;dr: :facepalm: 

(This crept in during the shift from a transform to a query (#44009); I didn't notice because my muscle memory was still always passing `-Z mir-borrowck`, while my test cases *also* had the `#[rustc_mir_borrowck]` attribute attached to them.)