### PR TITLE
Explicitly pass -no-pie

### DIFF
--- a/src/librustc_trans/back/linker.rs
+++ b/src/librustc_trans/back/linker.rs
@@ -104,6 +104,7 @@ pub trait Linker {
     fn add_object(&mut self, path: &Path);
     fn gc_sections(&mut self, keep_metadata: bool);
     fn position_independent_executable(&mut self);
+    fn no_position_independent_executable(&mut self);
     fn partial_relro(&mut self);
     fn full_relro(&mut self);
     fn optimize(&mut self);
@@ -178,6 +179,7 @@ impl<'a> Linker for GccLinker<'a> {
     fn output_filename(&mut self, path: &Path) { self.cmd.arg("-o").arg(path); }
     fn add_object(&mut self, path: &Path) { self.cmd.arg(path); }
     fn position_independent_executable(&mut self) { self.cmd.arg("-pie"); }
+    fn no_position_independent_executable(&mut self) { self.cmd.arg("-no-pie"); }
     fn partial_relro(&mut self) { self.linker_arg("-z,relro"); }
     fn full_relro(&mut self) { self.linker_arg("-z,relro,-z,now"); }
     fn build_static_executable(&mut self) { self.cmd.arg("-static"); }
@@ -438,6 +440,10 @@ impl<'a> Linker for MsvcLinker<'a> {
         // noop
     }
 
+    fn no_position_independent_executable(&mut self) {
+        // noop
+    }
+
     fn partial_relro(&mut self) {
         // noop
     }
@@ -631,6 +637,10 @@ impl<'a> Linker for EmLinker<'a> {
     }
 
     fn position_independent_executable(&mut self) {
+        // noop
+    }
+
+    fn no_position_independent_executable(&mut self) {
         // noop
     }
 


### PR DESCRIPTION
Some linkers (e.g. Debian and Arch's) that are configured to make PIEs
by default will make dynamically linked executables that don't actually
dynamically link to anything. Fix that by explicitly passing -no-pie in
those cases.

Closes #43647

r? @alexcrichton 