### PR TITLE
Do not assume libunwind.a is available on musl

### DIFF
--- a/src/libunwind/lib.rs
+++ b/src/libunwind/lib.rs
@@ -30,7 +30,7 @@ mod libunwind;
 #[cfg(not(target_env = "msvc"))]
 pub use libunwind::*;
 
-#[cfg(target_env = "musl")]
-#[link(name = "unwind", kind = "static-nobundle", cfg(target_feature = "crt-static"))]
+#[cfg(all(target_env = "musl", not(target_arch = "mips")))]
+#[link(name = "unwind", kind = "static", cfg(target_feature = "crt-static"))]
 #[link(name = "gcc_s", cfg(not(target_feature = "crt-static")))]
 extern {}


### PR DESCRIPTION
Fixes #40113, #44069, and clux/muslrust#16.

libunwind.a is not copied from musl_root, so it must be integrated into the unwind crate.