### PR TITLE
include Cargo.{toml,lock} in rust-src tarball

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -725,7 +725,6 @@ impl Step for Src {
         t!(fs::create_dir_all(&dst_src));
 
         let src_files = [
-            "src/Cargo.toml",
             "src/Cargo.lock",
         ];
         // This is the reduced set of paths which will become the rust-src component

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -724,6 +724,10 @@ impl Step for Src {
         let dst_src = dst.join("rust");
         t!(fs::create_dir_all(&dst_src));
 
+        let src_files = [
+            "src/Cargo.toml",
+            "src/Cargo.lock",
+        ];
         // This is the reduced set of paths which will become the rust-src component
         // (essentially libstd and all of its path dependencies)
         let std_src_dirs = [
@@ -759,6 +763,9 @@ impl Step for Src {
         ];
 
         copy_src_dirs(build, &std_src_dirs[..], &std_src_dirs_exclude[..], &dst_src);
+        for file in src_files.iter() {
+            copy(&build.src.join(file), &dst_src.join(file));
+        }
 
         // Create source tarball in rust-installer format
         let mut cmd = rust_installer(builder);


### PR DESCRIPTION
The lock file is interesting because e.g. xargo could use it to build libstd against the same dependencies that were used for the main build. More generally speaking, just documenting in this form which exact dependencies should be used IMHO makes lots of sense.

I added the Cargo.toml mostly because having the lock without the toml feels odd. Of course, the toml contains references to paths that don't actually exist in the rust-src tarball. Not sure if that is considered a problem.