### PR TITLE
Extend E0623 for LateBound and EarlyBound Regions

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -1433,7 +1433,7 @@ outlives another using a `where` clause:
 fn make_child<'tree, 'human>(
   x: &'human i32,
   y: &'tree i32
-) -> &'tree i32
+) -> &'human i32
 where
   'tree: 'human
 {

--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -1389,30 +1389,66 @@ A lifetime of reference outlives lifetime of borrowed content.
 Erroneous code example:
 
 ```compile_fail,E0312
-fn make_child<'human, 'elve>(x: &mut &'human isize, y: &mut &'elve isize) {
-    *x = *y;
-    // error: lifetime of reference outlives lifetime of borrowed content
+fn make_child<'tree, 'human>(
+  x: &'human i32,
+  y: &'tree i32
+) -> &'human i32 {
+    if x > y
+       { x }
+    else
+       { y }
+       // error: lifetime of reference outlives lifetime of borrowed content
 }
 ```
 
-The compiler cannot determine if the `human` lifetime will live long enough
-to keep up on the elve one. To solve this error, you have to give an
-explicit lifetime hierarchy:
+The function declares that it returns a reference with the `'human`
+lifetime, but it may return data with the `'tree` lifetime. As neither
+lifetime is declared longer than the other, this results in an
+error. Sometimes, this error is because the function *body* is
+incorrect -- that is, maybe you did not *mean* to return data from
+`y`. In that case, you should fix the function body.
+
+Often, however, the body is correct. In that case, the function
+signature needs to be altered to match the body, so that the caller
+understands that data from either `x` or `y` may be returned. The
+simplest way to do this is to give both function parameters the *same*
+named lifetime:
 
 ```
-fn make_child<'human, 'elve: 'human>(x: &mut &'human isize,
-                                     y: &mut &'elve isize) {
-    *x = *y; // ok!
+fn make_child<'human>(
+  x: &'human i32,
+  y: &'human i32
+) -> &'human i32 {
+    if x > y
+       { x }
+    else
+       { y } // ok!
 }
 ```
 
-Or use the same lifetime for every variable:
+However, in some cases, you may prefer to explicitly declare that one lifetime
+outlives another using a `where` clause:
 
 ```
-fn make_child<'elve>(x: &mut &'elve isize, y: &mut &'elve isize) {
-    *x = *y; // ok!
+fn make_child<'tree, 'human>(
+  x: &'human i32,
+  y: &'tree i32
+) -> &'tree i32
+where
+  'tree: 'human
+{
+    if x > y
+       { x }
+    else
+       { y } // ok!
 }
 ```
+
+Here, the where clause `'tree: 'human` can be read as "the lifetime
+'tree outlives the lifetime 'human" -- meaning, references with the
+`'tree` lifetime live *at least as long as* references with the
+`'human` lifetime. Therefore, it is safe to return data with lifetime
+`'tree` when data with the lifetime `'human` is needed.
 "##,
 
 E0317: r##"

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -79,7 +79,7 @@ mod need_type_info;
 mod named_anon_conflict;
 #[macro_use]
 mod util;
-mod anon_anon_conflict;
+mod different_lifetimes;
 
 impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     pub fn note_and_explain_region(self,

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1041,19 +1041,6 @@ impl RegionKind {
 
         flags
     }
-
-    // This method returns whether the given Region is Named
-    pub fn is_named_region(&self) -> bool {
-        match *self {
-            ty::ReFree(ref free_region) => {
-                match free_region.bound_region {
-                    ty::BrNamed(..) => true,
-                    _ => false,
-                }
-            }
-            _ => false,
-        }
-    }
 }
 
 /// Type utilities

--- a/src/test/compile-fail/associated-types-subtyping-1.rs
+++ b/src/test/compile-fail/associated-types-subtyping-1.rs
@@ -31,7 +31,7 @@ fn method2<'a,'b,T>(x: &'a T, y: &'b T)
     // Note that &'static T <: &'a T.
     let a: <T as Trait<'a>>::Type = loop { };
     let b: <T as Trait<'b>>::Type = loop { };
-    let _: <T as Trait<'b>>::Type = a; //~ ERROR mismatched types
+    let _: <T as Trait<'b>>::Type = a; //~ ERROR E0623
 }
 
 fn method3<'a,'b,T>(x: &'a T, y: &'b T)
@@ -40,7 +40,7 @@ fn method3<'a,'b,T>(x: &'a T, y: &'b T)
     // Note that &'static T <: &'a T.
     let a: <T as Trait<'a>>::Type = loop { };
     let b: <T as Trait<'b>>::Type = loop { };
-    let _: <T as Trait<'a>>::Type = b; //~ ERROR mismatched types
+    let _: <T as Trait<'a>>::Type = b; //~ ERROR E0623
 }
 
 fn method4<'a,'b,T>(x: &'a T, y: &'b T)

--- a/src/test/compile-fail/region-lifetime-bounds-on-fns-where-clause.rs
+++ b/src/test/compile-fail/region-lifetime-bounds-on-fns-where-clause.rs
@@ -15,7 +15,7 @@ fn a<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) where 'b: 'a {
 
 fn b<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) {
     // Illegal now because there is no `'b:'a` declaration.
-    *x = *y; //~ ERROR E0312
+    *x = *y; //~ ERROR E0623
 }
 
 fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {

--- a/src/test/compile-fail/region-multiple-lifetime-bounds-on-fns-where-clause.rs
+++ b/src/test/compile-fail/region-multiple-lifetime-bounds-on-fns-where-clause.rs
@@ -16,8 +16,8 @@ fn a<'a, 'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) where 
 
 fn b<'a, 'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {
     // Illegal now because there is no `'b:'a` declaration.
-    *x = *y; //~ ERROR E0312
-    *z = *y; //~ ERROR E0312
+    *x = *y; //~ ERROR E0623
+    *z = *y; //~ ERROR E0623
 }
 
 fn c<'a,'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {

--- a/src/test/compile-fail/regions-free-region-ordering-caller.rs
+++ b/src/test/compile-fail/regions-free-region-ordering-caller.rs
@@ -15,20 +15,16 @@
 struct Paramd<'a> { x: &'a usize }
 
 fn call2<'a, 'b>(a: &'a usize, b: &'b usize) {
-    let z: Option<&'b &'a usize> = None;
-    //~^ ERROR reference has a longer lifetime than the data it references
+    let z: Option<&'b &'a usize> = None;//~ ERROR E0623
 }
 
 fn call3<'a, 'b>(a: &'a usize, b: &'b usize) {
     let y: Paramd<'a> = Paramd { x: a };
-    let z: Option<&'b Paramd<'a>> = None;
-    //~^ ERROR reference has a longer lifetime than the data it references
+    let z: Option<&'b Paramd<'a>> = None;//~ ERROR E0623
 }
 
 fn call4<'a, 'b>(a: &'a usize, b: &'b usize) {
-    let z: Option<&'a &'b usize> = None;
-    //~^ ERROR reference has a longer lifetime than the data it references
+    let z: Option<&'a &'b usize> = None;//~ ERROR E0623
 }
-
 
 fn main() {}

--- a/src/test/compile-fail/regions-infer-contravariance-due-to-decl.rs
+++ b/src/test/compile-fail/regions-infer-contravariance-due-to-decl.rs
@@ -32,7 +32,7 @@ fn use_<'short,'long>(c: Contravariant<'short>,
     // 'short <= 'long, this would be true if the Contravariant type were
     // covariant with respect to its parameter 'a.
 
-    let _: Contravariant<'long> = c; //~ ERROR mismatched types
+    let _: Contravariant<'long> = c; //~ ERROR E0623
 }
 
 fn main() {}

--- a/src/test/compile-fail/regions-infer-covariance-due-to-decl.rs
+++ b/src/test/compile-fail/regions-infer-covariance-due-to-decl.rs
@@ -29,7 +29,7 @@ fn use_<'short,'long>(c: Covariant<'long>,
     // 'short <= 'long, this would be true if the Covariant type were
     // contravariant with respect to its parameter 'a.
 
-    let _: Covariant<'short> = c; //~ ERROR mismatched types
+    let _: Covariant<'short> = c; //~ ERROR E0623
 }
 
 fn main() {}

--- a/src/test/compile-fail/regions-lifetime-bounds-on-fns.rs
+++ b/src/test/compile-fail/regions-lifetime-bounds-on-fns.rs
@@ -15,7 +15,7 @@ fn a<'a, 'b:'a>(x: &mut &'a isize, y: &mut &'b isize) {
 
 fn b<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) {
     // Illegal now because there is no `'b:'a` declaration.
-    *x = *y; //~ ERROR E0312
+    *x = *y; //~ ERROR E0623
 }
 
 fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {

--- a/src/test/compile-fail/regions-variance-contravariant-use-covariant-in-second-position.rs
+++ b/src/test/compile-fail/regions-variance-contravariant-use-covariant-in-second-position.rs
@@ -32,7 +32,7 @@ fn use_<'short,'long>(c: S<'long, 'short>,
     // 'short <= 'long, this would be true if the Contravariant type were
     // covariant with respect to its parameter 'a.
 
-    let _: S<'long, 'long> = c; //~ ERROR mismatched types
+    let _: S<'long, 'long> = c; //~ ERROR E0623
 }
 
 fn main() {}

--- a/src/test/compile-fail/regions-variance-contravariant-use-covariant.rs
+++ b/src/test/compile-fail/regions-variance-contravariant-use-covariant.rs
@@ -30,7 +30,7 @@ fn use_<'short,'long>(c: Contravariant<'short>,
     // 'short <= 'long, this would be true if the Contravariant type were
     // covariant with respect to its parameter 'a.
 
-    let _: Contravariant<'long> = c; //~ ERROR mismatched types
+    let _: Contravariant<'long> = c; //~ ERROR E0623
 }
 
 fn main() {}

--- a/src/test/compile-fail/regions-variance-covariant-use-contravariant.rs
+++ b/src/test/compile-fail/regions-variance-covariant-use-contravariant.rs
@@ -30,7 +30,7 @@ fn use_<'short,'long>(c: Covariant<'long>,
     // 'short <= 'long, this would be true if the Covariant type were
     // contravariant with respect to its parameter 'a.
 
-    let _: Covariant<'short> = c; //~ ERROR mismatched types
+    let _: Covariant<'short> = c; //~ ERROR E0623
 }
 
 fn main() {}

--- a/src/test/compile-fail/regions-variance-invariant-use-contravariant.rs
+++ b/src/test/compile-fail/regions-variance-invariant-use-contravariant.rs
@@ -27,7 +27,7 @@ fn use_<'short,'long>(c: Invariant<'long>,
     // 'short <= 'long, this would be true if the Invariant type were
     // contravariant with respect to its parameter 'a.
 
-    let _: Invariant<'short> = c; //~ ERROR mismatched types
+    let _: Invariant<'short> = c; //~ ERROR E0623
 }
 
 fn main() { }

--- a/src/test/compile-fail/variance-cell-is-invariant.rs
+++ b/src/test/compile-fail/variance-cell-is-invariant.rs
@@ -21,7 +21,7 @@ fn use_<'short,'long>(c: Foo<'short>,
                       s: &'short isize,
                       l: &'long isize,
                       _where:Option<&'short &'long ()>) {
-    let _: Foo<'long> = c; //~ ERROR mismatched types
+    let _: Foo<'long> = c; //~ ERROR E0623
 }
 
 fn main() {

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-earlybound-regions.rs
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-earlybound-regions.rs
@@ -1,0 +1,21 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+trait Foo<'a> {}
+impl<'a, T> Foo<'a> for T {}
+
+fn baz<'a, 'b, T>(x: &mut Vec<&'a T>, y: &T)
+    where i32: Foo<'a>,
+          u32: Foo<'b>
+{
+    x.push(y);
+}
+fn main() {
+let x = baz;
+}

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-earlybound-regions.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-earlybound-regions.stderr
@@ -1,0 +1,11 @@
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-earlybound-regions.rs:17:12
+   |
+13 | fn baz<'a, 'b, T>(x: &mut Vec<&'a T>, y: &T)
+   |                               -----      -- these two types are declared with different lifetimes...
+...
+17 |     x.push(y);
+   |            ^ ...but data from `y` flows into `x` here
+
+error: aborting due to previous error
+

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-latebound-regions.rs
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-latebound-regions.rs
@@ -1,0 +1,15 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn foo<'a,'b>(x: &mut Vec<&'a u8>, y: &'b u8) {
+    x.push(y);
+}
+
+fn main() { }

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-latebound-regions.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-latebound-regions.stderr
@@ -1,0 +1,10 @@
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-latebound-regions.rs:12:12
+   |
+11 | fn foo<'a,'b>(x: &mut Vec<&'a u8>, y: &'b u8) {
+   |                           ------      ------ these two types are declared with different lifetimes...
+12 |     x.push(y);
+   |            ^ ...but data from `y` flows into `x` here
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This is a fix for #43882 
```
fn foo<'a,'b>(x: &mut Vec<&'a u8>, y: &'b u8) {
    x.push(y);
}
```
now gives

```
error[E0623]: lifetime mismatch
  --> $DIR/ex3-both-anon-regions-latebound-regions.rs:12:12
   |
11 | fn foo<'a,'b>(x: &mut Vec<&'a u8>, y: &'b u8) {
   |                           ------      ------ these two types are declared with different lifetimes...
12 |     x.push(y);
   |            ^ ...but data from `y` flows into `x` here
```
cc @nikomatsakis @arielb1 

Please ignore the second commit. It will be merged in a separate PR.

