### PR TITLE
Fix a byte/char confusion issue in the error emitter

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -311,7 +311,9 @@ impl EmitterWriter {
         if line.annotations.len() == 1 {
             if let Some(ref ann) = line.annotations.get(0) {
                 if let AnnotationType::MultilineStart(depth) = ann.annotation_type {
-                    if source_string[0..ann.start_col].trim() == "" {
+                    if source_string.chars()
+                                    .take(ann.start_col)
+                                    .all(|c| c.is_whitespace()) {
                         let style = if ann.is_primary {
                             Style::UnderlinePrimary
                         } else {

--- a/src/test/ui/issue-44023.rs
+++ b/src/test/ui/issue-44023.rs
@@ -1,0 +1,16 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(non_ascii_idents)]
+
+pub fn main () {}
+
+fn საჭმელად_გემრიელი_სადილი ( ) -> isize {
+}

--- a/src/test/ui/issue-44023.stderr
+++ b/src/test/ui/issue-44023.stderr
@@ -1,0 +1,13 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-44023.rs:15:42
+   |
+15 |   fn საჭმელად_გემრიელი_სადილი ( ) -> isize {
+   |  __________________________________________^
+16 | | }
+   | |_^ expected isize, found ()
+   |
+   = note: expected type `isize`
+              found type `()`
+
+error: aborting due to previous error
+

--- a/src/test/ui/issue-44078.rs
+++ b/src/test/ui/issue-44078.rs
@@ -1,0 +1,13 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    "😊"";
+}

--- a/src/test/ui/issue-44078.stderr
+++ b/src/test/ui/issue-44078.stderr
@@ -1,0 +1,10 @@
+error: unterminated double quote string
+  --> $DIR/issue-44078.rs:12:8
+   |
+12 |       "😊"";
+   |  ________^
+13 | | }
+   | |__^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #44078. Fixes #44023.

The start_col member is given in chars, while the code previously assumed it was given in bytes.

The more basic issue #44080 doesn't get fixed.