### PR TITLE
Fix destruction extent lookup during HIR -> HAIR translation

### DIFF
--- a/src/librustc_mir/hair/cx/block.rs
+++ b/src/librustc_mir/hair/cx/block.rs
@@ -22,10 +22,7 @@ impl<'tcx> Mirror<'tcx> for &'tcx hir::Block {
         // We have to eagerly translate the "spine" of the statements
         // in order to get the lexical scoping correctly.
         let stmts = mirror_stmts(cx, self.id, &*self.stmts);
-        let opt_def_id = cx.tcx.hir.opt_local_def_id(self.id);
-        let opt_destruction_extent = opt_def_id.and_then(|def_id| {
-            cx.tcx.region_maps(def_id).opt_destruction_extent(self.id)
-        });
+        let opt_destruction_extent = cx.region_maps.opt_destruction_extent(self.id);
         Block {
             targeted_by_break: self.targeted_by_break,
             extent: CodeExtent::Misc(self.id),
@@ -42,11 +39,8 @@ fn mirror_stmts<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                                 stmts: &'tcx [hir::Stmt])
                                 -> Vec<StmtRef<'tcx>> {
     let mut result = vec![];
-    let opt_def_id = cx.tcx.hir.opt_local_def_id(block_id);
     for (index, stmt) in stmts.iter().enumerate() {
-        let opt_dxn_ext = opt_def_id.and_then(|def_id| {
-            cx.tcx.region_maps(def_id).opt_destruction_extent(stmt.node.id())
-        });
+        let opt_dxn_ext = cx.region_maps.opt_destruction_extent(stmt.node.id());
         match stmt.node {
             hir::StmtExpr(ref expr, id) |
             hir::StmtSemi(ref expr, id) => {

--- a/src/test/mir-opt/issue-43457.rs
+++ b/src/test/mir-opt/issue-43457.rs
@@ -1,0 +1,55 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z identify_regions -Z span_free_formats
+// ignore-tidy-linelength
+
+// Regression test for #43457: an `EndRegion` was missing from output
+// because compiler was using a faulty means for region map lookup.
+
+use std::cell::RefCell;
+
+fn rc_refcell_test(r: RefCell<i32>) {
+    r.borrow_mut();
+}
+
+fn main() { }
+
+// END RUST SOURCE
+// START rustc.node5.SimplifyCfg-qualify-consts.after.mir
+//
+// fn rc_refcell_test(_1: std::cell::RefCell<i32>) -> () {
+//     let mut _0: ();
+//     scope 1 {
+//         let _2: std::cell::RefCell<i32>;
+//     }
+//     let mut _3: std::cell::RefMut<'17dce, i32>;
+//     let mut _4: &'17dce std::cell::RefCell<i32>;
+//
+//     bb0: {
+//         StorageLive(_2);
+//         _2 = _1;
+//         StorageLive(_4);
+//         _4 = &'17dce _2;
+//         _3 = const <std::cell::RefCell<T>>::borrow_mut(_4) -> bb1;
+//     }
+//
+//     bb1: {
+//         drop(_3) -> bb2;
+//     }
+//
+//     bb2: {
+//         StorageDead(_4);
+//         EndRegion('17dce);
+//         _0 = ();
+//         StorageDead(_2);
+//         return;
+//     }
+// }


### PR DESCRIPTION
My method for finding the destruction extent, if any, from cbed41a174aad44e069bec09bf1e502591c132ae (in #39409), was buggy in that it sometimes failed to find an extent that was nonetheless present.

This fixes that, and is cleaner code to boot.

Fix #43457