### PR TITLE
rustc: Fix proc_macro expansions on trait methods

### DIFF
--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -402,7 +402,8 @@ impl<'a> Resolver<'a> {
         let ast::Path { ref segments, span } = *path;
         let path: Vec<_> = segments.iter().map(|seg| respan(seg.span, seg.identifier)).collect();
         let invocation = self.invocations[&scope];
-        self.current_module = invocation.module.get();
+        let module = invocation.module.get();
+        self.current_module = if module.is_trait() { module.parent.unwrap() } else { module };
 
         if path.len() > 1 {
             if !self.use_extern_macros && self.gated_errors.insert(span) {

--- a/src/test/run-pass-fulldeps/proc-macro/attr-on-trait.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/attr-on-trait.rs
@@ -1,0 +1,28 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:attr-on-trait.rs
+
+#![feature(proc_macro)]
+
+extern crate attr_on_trait;
+
+trait Foo {
+    #[attr_on_trait::foo]
+    fn foo() {}
+}
+
+impl Foo for i32 {
+    fn foo(&self) {}
+}
+
+fn main() {
+    3i32.foo();
+}

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/attr-on-trait.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/attr-on-trait.rs
@@ -1,0 +1,25 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![feature(proc_macro)]
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn foo(attr: TokenStream, item: TokenStream) -> TokenStream {
+    drop(attr);
+    assert_eq!(item.to_string(), "fn foo() { }");
+    "fn foo(&self);".parse().unwrap()
+}


### PR DESCRIPTION
This commit fixes procedural macro attributes being attached to trait methods,
ensuring that they get resolved and expanded as other procedural macro
attributes. The bug here was that `current_module` on the resolver was
accidentally set to be a trait when it's otherwise only ever expecting a
`mod`/block module. The actual fix here came from @jseyfried, I'm just helping
to land it in the compiler!

Closes #42493