### PR TITLE
haiku/librustc_back: Remove incorrect no_integrated_as

### DIFF
--- a/src/librustc_back/target/haiku_base.rs
+++ b/src/librustc_back/target/haiku_base.rs
@@ -20,7 +20,6 @@ pub fn opts() -> TargetOptions {
         target_family: Some("unix".to_string()),
         relro_level: RelroLevel::Full,
         linker_is_gnu: true,
-        no_integrated_as: true,
         .. Default::default()
     }
 }


### PR DESCRIPTION
* Makes rust bootstrap incorrectly search for xxx.s vs xxx.0.s
* Not needed or incorrect fix for another issue.