### PR TITLE
Add test for wrong code generation for HashSet creation on arm cpu

### DIFF
--- a/src/test/run-pass/wrong-hashset-issue-42918.rs
+++ b/src/test/run-pass/wrong-hashset-issue-42918.rs
@@ -1,0 +1,38 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+// compile-flags: -O
+
+use std::collections::HashSet;
+
+#[derive(PartialEq, Debug, Hash, Eq, Clone, PartialOrd, Ord)]
+enum MyEnum {
+    E0,
+
+    E1,
+
+    E2,
+    E3,
+    E4,
+
+    E5,
+    E6,
+    E7,
+}
+
+
+fn main() {
+    use MyEnum::*;
+    let s: HashSet<_> = [E4, E1].iter().cloned().collect();
+    let mut v: Vec<_> = s.into_iter().collect();
+    v.sort();
+
+    assert_eq!([E1, E4], &v[..]);
+}


### PR DESCRIPTION
This is test for #42918.
To reproduce bug you need machine with arm cpu and compile with optimization.
I tried with rustc 1.19.0-nightly (3d5b8c626 2017-06-09),
if compile test with -C opt-level=3 for target=arm-linux-androideabi
and run on "Qualcomm MSM 8974 arm cpu" then assert fails,
if compile and run with -C opt-level=2 it gives segmentation fault.
So I add `compile-flags: -O`.
With rustc 1.19.0 (0ade33941 2017-07-17) all works fine.
Closes #42918