### PR TITLE
add a lowercase suggestion to unknown_lints

### DIFF
--- a/src/test/ui/lint/not_found.rs
+++ b/src/test/ui/lint/not_found.rs
@@ -1,0 +1,21 @@
+// Copyright 2014–2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// this tests the `unknown_lint` lint, especially the suggestions
+
+// the suggestion only appears if a lint with the lowercase name exists
+#[allow(FOO_BAR)]
+// the suggestion appears on all-uppercase names
+#[warn(DEAD_CODE)]
+// the suggestion appears also on mixed-case names
+#[deny(Warnings)]
+fn main() {
+    unimplemented!();
+}

--- a/src/test/ui/lint/not_found.stderr
+++ b/src/test/ui/lint/not_found.stderr
@@ -1,0 +1,20 @@
+warning: unknown lint: `FOO_BAR`
+  --> $DIR/not_found.rs:14:9
+   |
+14 | #[allow(FOO_BAR)]
+   |         ^^^^^^^
+   |
+   = note: #[warn(unknown_lints)] on by default
+
+warning: unknown lint: `DEAD_CODE`
+  --> $DIR/not_found.rs:16:8
+   |
+16 | #[warn(DEAD_CODE)]
+   |        ^^^^^^^^^ help: lowercase the lint name: `dead_code`
+
+warning: unknown lint: `Warnings`
+  --> $DIR/not_found.rs:18:8
+   |
+18 | #[deny(Warnings)]
+   |        ^^^^^^^^ help: lowercase the lint name: `warnings`
+


### PR DESCRIPTION
I recently wrote some tests for a clippy lint, copied the (uppercase) lint name into my test file and forgot to toggle the case. This PR adds a suggestion that would have saved me 10 minutes of debugging, so it's likely a net win 🙂 . Also it adds a UI test for the `unknown_lints` lint.