### PR TITLE
Clarify that VecDeque::swap can panic

### DIFF
--- a/src/liballoc/vec_deque.rs
+++ b/src/liballoc/vec_deque.rs
@@ -459,9 +459,11 @@ impl<T> VecDeque<T> {
     ///
     /// `i` and `j` may be equal.
     ///
-    /// Fails if there is no element with either index.
-    ///
     /// Element at index 0 is the front of the queue.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either index is out of bounds.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
The previous documentation mentioned this, but ambiguously used the term "fail".

This clarifies that the function will panic if the index is out of bounds, instead of silently failing and not doing anything.

If there's anything else I can do to improve this PR, I'd be happy to do so! Just saw this when reading through the docs in passing - it was slightly unclear what "fail" meant.