### PR TITLE
bootstrap: remove unneeded extern crate

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -123,7 +123,6 @@ extern crate build_helper;
 extern crate serde_derive;
 #[macro_use]
 extern crate lazy_static;
-extern crate serde;
 extern crate serde_json;
 extern crate cmake;
 extern crate filetime;


### PR DESCRIPTION
The crate itself is internally referenced by serde_derive.