### PR TITLE
un-regress behavior of `unused_results` lint for booleans

### DIFF
--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -182,7 +182,14 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
         }
 
         if !(ty_warned || fn_warned) {
-            cx.span_lint(UNUSED_RESULTS, s.span, "unused result");
+            match t.sty {
+                // Historically, booleans have not been considered unused
+                // results. (See Issue #44119.)
+                ty::TyBool => return,
+                _ => {
+                    cx.span_lint(UNUSED_RESULTS, s.span, "unused result");
+                }
+            }
         }
 
         fn check_must_use(cx: &LateContext, def_id: DefId, sp: Span, describe_path: &str) -> bool {

--- a/src/test/compile-fail/unused-result.rs
+++ b/src/test/compile-fail/unused-result.rs
@@ -42,6 +42,9 @@ fn main() {
     foo::<MustUse>(); //~ ERROR: unused `MustUse` which must be used
     foo::<MustUseMsg>(); //~ ERROR: unused `MustUseMsg` which must be used: some message
 
+    // as an exceptional case, booleans are not considered unused
+    foo::<bool>();
+
     let _ = foo::<isize>();
     let _ = foo::<MustUse>();
     let _ = foo::<MustUseMsg>();


### PR DESCRIPTION
Resolves #44119.