### PR TITLE
Fail ./x.py on invalid command

### DIFF
--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -136,7 +136,7 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`");
             None => {
                 // No subcommand -- show the general usage and subcommand help
                 println!("{}\n", subcommand_help);
-                process::exit(0);
+                process::exit(1);
             }
         };
 


### PR DESCRIPTION
Make the ./x.py script fail when run with an invalid command, like:

```    
./x.py nonsense
```
    
This helps in case of chaining multiple runs, eg.:
    
```
./x.py biuld && ./x.py test
```