### PR TITLE
rustbuild: Avoid some extraneous rustc compiles on cross builds

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -669,11 +669,6 @@ impl Step for ErrorIndex {
         let build = builder.build;
         let target = self.target;
 
-        builder.ensure(compile::Rustc {
-            compiler: builder.compiler(0, build.build),
-            target,
-        });
-
         println!("Documenting error index ({})", target);
         let out = build.doc_out(target);
         t!(fs::create_dir_all(&out));

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -718,7 +718,7 @@ impl Build {
     fn force_use_stage1(&self, compiler: Compiler, target: Interned<String>) -> bool {
         !self.config.full_bootstrap &&
             compiler.stage >= 2 &&
-            self.hosts.iter().any(|h| *h == target)
+            (self.hosts.iter().any(|h| *h == target) || target == self.build)
     }
 
     /// Returns the directory that OpenSSL artifacts are compiled into if


### PR DESCRIPTION
This tweaks a few locations here and there to avoid compiling rustc too many times on our cross-builders on CI.

Closes https://github.com/rust-lang/rust/issues/44132