### PR TITLE
Add display of cfg in rustdoc

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2710,7 +2710,8 @@ const ATTRIBUTE_WHITELIST: &'static [&'static str] = &[
     "must_use",
     "no_mangle",
     "repr",
-    "unsafe_destructor_blind_to_params"
+    "unsafe_destructor_blind_to_params",
+    "cfg"
 ];
 
 fn render_attributes(w: &mut fmt::Formatter, it: &clean::Item) -> fmt::Result {


### PR DESCRIPTION
It's been a question since a while now. Should we display `cfg` flags or not? An example of the output:

<img width="1440" alt="screen shot 2017-08-29 at 22 04 18" src="https://user-images.githubusercontent.com/3050060/29841530-05c79800-8d06-11e7-8a09-140c270eb8e8.png">

If yes, should we display it like this or in another way?

cc @rust-lang/docs 