### PR TITLE
Improve SubSupConflict with a named and an anonymous lifetime parameter #42701

### DIFF
--- a/src/librustc/infer/error_reporting/different_lifetimes.rs
+++ b/src/librustc/infer/error_reporting/different_lifetimes.rs
@@ -60,6 +60,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     pub fn try_report_anon_anon_conflict(&self, error: &RegionResolutionError<'tcx>) -> bool {
         let (span, sub, sup) = match *error {
             ConcreteFailure(ref origin, sub, sup) => (origin.span(), sub, sup),
+            SubSupConflict(_, ref origin, sub, _, sup) => (origin.span(), sub, sup),
             _ => return false, // inapplicable
         };
 

--- a/src/librustc/infer/error_reporting/named_anon_conflict.rs
+++ b/src/librustc/infer/error_reporting/named_anon_conflict.rs
@@ -21,6 +21,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     pub fn try_report_named_anon_conflict(&self, error: &RegionResolutionError<'tcx>) -> bool {
         let (span, sub, sup) = match *error {
             ConcreteFailure(ref origin, sub, sup) => (origin.span(), sub, sup),
+            SubSupConflict(_, ref origin, sub, _, sup) => (origin.span(), sub, sup),
             _ => return false, // inapplicable
         };
 

--- a/src/librustc/infer/region_inference/graphviz.rs
+++ b/src/librustc/infer/region_inference/graphviz.rs
@@ -30,6 +30,7 @@ use util::nodemap::{FxHashMap, FxHashSet};
 
 use std::borrow::Cow;
 use std::collections::hash_map::Entry::Vacant;
+use std::collections::btree_map::BTreeMap;
 use std::env;
 use std::fs::File;
 use std::io;
@@ -124,7 +125,7 @@ pub fn maybe_print_constraints_for<'a, 'gcx, 'tcx>(
 struct ConstraintGraph<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
     graph_name: String,
     region_rels: &'a RegionRelations<'a, 'gcx, 'tcx>,
-    map: &'a FxHashMap<Constraint<'tcx>, SubregionOrigin<'tcx>>,
+    map: &'a BTreeMap<Constraint<'tcx>, SubregionOrigin<'tcx>>,
     node_ids: FxHashMap<Node, usize>,
 }
 
@@ -264,7 +265,7 @@ impl<'a, 'gcx, 'tcx> dot::GraphWalk<'a> for ConstraintGraph<'a, 'gcx, 'tcx> {
     }
 }
 
-pub type ConstraintMap<'tcx> = FxHashMap<Constraint<'tcx>, SubregionOrigin<'tcx>>;
+pub type ConstraintMap<'tcx> = BTreeMap<Constraint<'tcx>, SubregionOrigin<'tcx>>;
 
 fn dump_region_constraints_to<'a, 'gcx, 'tcx>(region_rels: &RegionRelations<'a, 'gcx, 'tcx>,
                                               map: &ConstraintMap<'tcx>,

--- a/src/librustc/infer/region_inference/mod.rs
+++ b/src/librustc/infer/region_inference/mod.rs
@@ -28,6 +28,7 @@ use ty::{Region, RegionVid};
 use ty::{ReEmpty, ReStatic, ReFree, ReEarlyBound, ReErased};
 use ty::{ReLateBound, ReScope, ReVar, ReSkolemized, BrFresh};
 
+use std::collections::BTreeMap;
 use std::cell::{Cell, RefCell};
 use std::fmt;
 use std::mem;
@@ -36,7 +37,7 @@ use std::u32;
 mod graphviz;
 
 /// A constraint that influences the inference process.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
 pub enum Constraint<'tcx> {
     /// One region variable is subregion of another
     ConstrainVarSubVar(RegionVid, RegionVid),
@@ -186,7 +187,7 @@ pub struct RegionVarBindings<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
     /// Constraints of the form `A <= B` introduced by the region
     /// checker.  Here at least one of `A` and `B` must be a region
     /// variable.
-    constraints: RefCell<FxHashMap<Constraint<'tcx>, SubregionOrigin<'tcx>>>,
+    constraints: RefCell<BTreeMap<Constraint<'tcx>, SubregionOrigin<'tcx>>>,
 
     /// A "verify" is something that we need to verify after inference is
     /// done, but which does not directly affect inference in any way.
@@ -357,7 +358,7 @@ impl<'a, 'gcx, 'tcx> RegionVarBindings<'a, 'gcx, 'tcx> {
             tcx,
             var_origins: RefCell::new(Vec::new()),
             values: RefCell::new(None),
-            constraints: RefCell::new(FxHashMap()),
+            constraints: RefCell::new(BTreeMap::new()),
             verifys: RefCell::new(Vec::new()),
             givens: RefCell::new(FxHashSet()),
             lubs: RefCell::new(FxHashMap()),

--- a/src/librustc/infer/region_inference/mod.rs
+++ b/src/librustc/infer/region_inference/mod.rs
@@ -188,10 +188,10 @@ pub struct RegionVarBindings<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
     /// checker.  Here at least one of `A` and `B` must be a region
     /// variable.
     ///
-    /// Using `BTreeMap` because the order in which we iterate over 
-    /// these constraints can affect the way we build the region graph, 
-    /// which in turn affects the way that region errors are reported, 
-    /// leading to small variations in error output across runs and 
+    /// Using `BTreeMap` because the order in which we iterate over
+    /// these constraints can affect the way we build the region graph,
+    /// which in turn affects the way that region errors are reported,
+    /// leading to small variations in error output across runs and
     /// platforms.
     constraints: RefCell<BTreeMap<Constraint<'tcx>, SubregionOrigin<'tcx>>>,
 

--- a/src/librustc/infer/region_inference/mod.rs
+++ b/src/librustc/infer/region_inference/mod.rs
@@ -187,6 +187,12 @@ pub struct RegionVarBindings<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
     /// Constraints of the form `A <= B` introduced by the region
     /// checker.  Here at least one of `A` and `B` must be a region
     /// variable.
+    ///
+    /// Using `BTreeMap` because the order in which we iterate over 
+    /// these constraints can affect the way we build the region graph, 
+    /// which in turn affects the way that region errors are reported, 
+    /// leading to small variations in error output across runs and 
+    /// platforms.
     constraints: RefCell<BTreeMap<Constraint<'tcx>, SubregionOrigin<'tcx>>>,
 
     /// A "verify" is something that we need to verify after inference is

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -760,7 +760,7 @@ impl<'a, 'gcx, 'tcx> ParamTy {
 /// is the outer fn.
 ///
 /// [dbi]: http://en.wikipedia.org/wiki/De_Bruijn_index
-#[derive(Clone, PartialEq, Eq, Hash, RustcEncodable, RustcDecodable, Debug, Copy)]
+#[derive(Clone, PartialEq, Eq, Hash, RustcEncodable, RustcDecodable, Debug, Copy, PartialOrd, Ord)]
 pub struct DebruijnIndex {
     /// We maintain the invariant that this is never 0. So 1 indicates
     /// the innermost binder. To ensure this, create with `DebruijnIndex::new`.
@@ -825,7 +825,7 @@ pub type Region<'tcx> = &'tcx RegionKind;
 ///
 /// [1] http://smallcultfollowing.com/babysteps/blog/2013/10/29/intermingled-parameter-lists/
 /// [2] http://smallcultfollowing.com/babysteps/blog/2013/11/04/intermingled-parameter-lists/
-#[derive(Clone, PartialEq, Eq, Hash, Copy, RustcEncodable, RustcDecodable)]
+#[derive(Clone, PartialEq, Eq, Hash, Copy, RustcEncodable, RustcDecodable, PartialOrd, Ord)]
 pub enum RegionKind {
     // Region bound in a type or fn declaration which will be
     // substituted 'early' -- that is, at the same time when type
@@ -871,7 +871,7 @@ pub enum RegionKind {
 
 impl<'tcx> serialize::UseSpecializedDecodable for Region<'tcx> {}
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, RustcEncodable, RustcDecodable, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, RustcEncodable, RustcDecodable, Debug, PartialOrd, Ord)]
 pub struct EarlyBoundRegion {
     pub def_id: DefId,
     pub index: u32,
@@ -893,12 +893,12 @@ pub struct FloatVid {
     pub index: u32,
 }
 
-#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Copy)]
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Copy, PartialOrd, Ord)]
 pub struct RegionVid {
     pub index: u32,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, RustcEncodable, RustcDecodable)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, RustcEncodable, RustcDecodable, PartialOrd, Ord)]
 pub struct SkolemizedRegionVid {
     pub index: u32,
 }

--- a/src/test/compile-fail/associated-types-project-from-hrtb-in-fn-body.rs
+++ b/src/test/compile-fail/associated-types-project-from-hrtb-in-fn-body.rs
@@ -30,7 +30,7 @@ fn bar<'a, 'b, I : for<'x> Foo<&'x isize>>(
 {
     // x and y here have two distinct lifetimes:
     let z: I::A = if cond { x } else { y };
-    //~^ ERROR cannot infer
+    //~^ ERROR lifetime mismatch
 }
 
 pub fn main() {}

--- a/src/test/compile-fail/associated-types/cache/project-fn-ret-contravariant.rs
+++ b/src/test/compile-fail/associated-types/cache/project-fn-ret-contravariant.rs
@@ -50,9 +50,10 @@ fn baz<'a,'b>(x: &'a u32) -> &'static u32 {
 
 #[cfg(krisskross)] // two instantiations, mixing and matching: BAD
 fn transmute<'a,'b>(x: &'a u32, y: &'b u32) -> (&'a u32, &'b u32) {
-   let a = bar(foo, y); //[krisskross]~ ERROR E0495
-   let b = bar(foo, x); //[krisskross]~ ERROR E0495
-   (a, b)
+   let a = bar(foo, y);
+   let b = bar(foo, x);
+   (a, b) //[krisskross]~ ERROR 55:5: 55:6: lifetime mismatch [E0623]
+   //[krisskross]~^ ERROR 55:8: 55:9: lifetime mismatch [E0623]
 }
 
 #[rustc_error]

--- a/src/test/compile-fail/associated-types/cache/project-fn-ret-invariant.rs
+++ b/src/test/compile-fail/associated-types/cache/project-fn-ret-invariant.rs
@@ -45,9 +45,9 @@ fn baz<'a,'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {
 #[cfg(oneuse)] // one instantiation: BAD
 fn baz<'a,'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {
    let f = foo; // <-- No consistent type can be inferred for `f` here.
-   let a = bar(f, x); //[oneuse]~^ ERROR E0495
+   let a = bar(f, x);
    let b = bar(f, y);
-   (a, b)
+   (a, b) //[oneuse]~ ERROR E0623
 }
 
 #[cfg(transmute)] // one instantiations: BAD
@@ -60,9 +60,10 @@ fn baz<'a,'b>(x: Type<'a>) -> Type<'static> {
 
 #[cfg(krisskross)] // two instantiations, mixing and matching: BAD
 fn transmute<'a,'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {
-   let a = bar(foo, y); //[krisskross]~ ERROR E0495
-   let b = bar(foo, x); //[krisskross]~ ERROR E0495
-   (a, b)
+   let a = bar(foo, y);
+   let b = bar(foo, x);
+   (a, b) //[krisskross]~ ERROR E0623
+   //[krisskross]~^ ERROR E0623
 }
 
 #[rustc_error]

--- a/src/test/compile-fail/associated-types/cache/project-fn-ret-invariant.rs
+++ b/src/test/compile-fail/associated-types/cache/project-fn-ret-invariant.rs
@@ -60,8 +60,8 @@ fn baz<'a,'b>(x: Type<'a>) -> Type<'static> {
 
 #[cfg(krisskross)] // two instantiations, mixing and matching: BAD
 fn transmute<'a,'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {
-   let a = bar(foo, y);
-   let b = bar(foo, x); //[krisskross]~ ERROR E0623
+   let a = bar(foo, y); //[krisskross]~ ERROR E0623
+   let b = bar(foo, x);
    (a, b) //[krisskross]~ ERROR E0623
 }
 

--- a/src/test/compile-fail/associated-types/cache/project-fn-ret-invariant.rs
+++ b/src/test/compile-fail/associated-types/cache/project-fn-ret-invariant.rs
@@ -61,9 +61,8 @@ fn baz<'a,'b>(x: Type<'a>) -> Type<'static> {
 #[cfg(krisskross)] // two instantiations, mixing and matching: BAD
 fn transmute<'a,'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {
    let a = bar(foo, y);
-   let b = bar(foo, x);
+   let b = bar(foo, x); //[krisskross]~ ERROR E0623
    (a, b) //[krisskross]~ ERROR E0623
-   //[krisskross]~^ ERROR E0623
 }
 
 #[rustc_error]

--- a/src/test/compile-fail/associated-types/cache/project-fn-ret-invariant.rs
+++ b/src/test/compile-fail/associated-types/cache/project-fn-ret-invariant.rs
@@ -46,8 +46,8 @@ fn baz<'a,'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {
 fn baz<'a,'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {
    let f = foo; // <-- No consistent type can be inferred for `f` here.
    let a = bar(f, x);
-   let b = bar(f, y);
-   (a, b) //[oneuse]~ ERROR E0623
+   let b = bar(f, y); //[oneuse]~ ERROR 49:19: 49:20: lifetime mismatch [E0623]
+   (a, b)
 }
 
 #[cfg(transmute)] // one instantiations: BAD

--- a/src/test/compile-fail/borrowck/borrowck-reborrow-from-shorter-lived-andmut.rs
+++ b/src/test/compile-fail/borrowck/borrowck-reborrow-from-shorter-lived-andmut.rs
@@ -17,7 +17,7 @@ struct S<'a> {
 
 fn copy_borrowed_ptr<'a,'b>(p: &'a mut S<'b>) -> S<'b> {
     S { pointer: &mut *p.pointer }
-    //~^ ERROR cannot infer
+    //~^ ERROR lifetime mismatch
 }
 
 fn main() {

--- a/src/test/compile-fail/issue-13058.rs
+++ b/src/test/compile-fail/issue-13058.rs
@@ -22,7 +22,7 @@ impl<'r> Itble<'r, usize, Range<usize>> for (usize, usize) {
 fn check<'r, I: Iterator<Item=usize>, T: Itble<'r, usize, I>>(cont: &T) -> bool
 {
     let cont_iter = cont.iter();
-//~^ ERROR cannot infer an appropriate lifetime for autoref due to conflicting requirements
+//~^ ERROR 24:26: 24:30: explicit lifetime required in the type of `cont` [E0621]
     let result = cont_iter.fold(Some(0), |state, val| {
         state.map_or(None, |mask| {
             let bit = 1 << val;

--- a/src/test/compile-fail/issue-14285.rs
+++ b/src/test/compile-fail/issue-14285.rs
@@ -19,7 +19,7 @@ impl Foo for A {}
 struct B<'a>(&'a (Foo+'a));
 
 fn foo<'a>(a: &Foo) -> B<'a> {
-    B(a)    //~ ERROR cannot infer an appropriate lifetime
+    B(a)    //~ ERROR 22:5: 22:9: explicit lifetime required in the type of `a` [E0621]
 }
 
 fn main() {

--- a/src/test/compile-fail/issue-15034.rs
+++ b/src/test/compile-fail/issue-15034.rs
@@ -25,7 +25,7 @@ struct Parser<'a> {
 impl<'a> Parser<'a> {
     pub fn new(lexer: &'a mut Lexer) -> Parser<'a> {
         Parser { lexer: lexer }
-        //~^ ERROR cannot infer an appropriate lifetime
+        //~^ ERROR 27:25: 27:30: explicit lifetime required in the type of `lexer` [E0621]
     }
 }
 

--- a/src/test/compile-fail/issue-17728.rs
+++ b/src/test/compile-fail/issue-17728.rs
@@ -21,9 +21,9 @@ trait TraversesWorld {
     fn attemptTraverse(&self, room: &Room, directionStr: &str) -> Result<&Room, &str> {
         let direction = str_to_direction(directionStr);
         let maybe_room = room.direction_to_room.get(&direction);
-        //~^ ERROR cannot infer an appropriate lifetime for autoref due to conflicting requirements
         match maybe_room {
             Some(entry) => Ok(entry),
+            //~^ ERROR 25:28: 25:37: lifetime mismatch [E0623]
             _ => Err("Direction does not exist in room.")
         }
     }

--- a/src/test/compile-fail/issue-3154.rs
+++ b/src/test/compile-fail/issue-3154.rs
@@ -13,7 +13,7 @@ struct thing<'a, Q:'a> {
 }
 
 fn thing<'a,Q>(x: &Q) -> thing<'a,Q> {
-    thing{ x: x } //~ ERROR cannot infer
+    thing{ x: x } //~ ERROR 16:5: 16:18: explicit lifetime required in the type of `x` [E0621]
 }
 
 fn main() {

--- a/src/test/compile-fail/issue-40288-2.rs
+++ b/src/test/compile-fail/issue-40288-2.rs
@@ -12,12 +12,12 @@ fn prove_static<T: 'static + ?Sized>(_: &'static T) {}
 
 fn lifetime_transmute_slice<'a, T: ?Sized>(x: &'a T, y: &T) -> &'a T {
     let mut out = [x];
-    //~^ ERROR cannot infer an appropriate lifetime due to conflicting requirements
     {
         let slice: &mut [_] = &mut out;
         slice[0] = y;
     }
     out[0]
+    //~^ ERROR 19:5: 19:11: explicit lifetime required in the type of `y` [E0621]
 }
 
 struct Struct<T, U: ?Sized> {
@@ -27,12 +27,12 @@ struct Struct<T, U: ?Sized> {
 
 fn lifetime_transmute_struct<'a, T: ?Sized>(x: &'a T, y: &T) -> &'a T {
     let mut out = Struct { head: x, _tail: [()] };
-    //~^ ERROR cannot infer an appropriate lifetime due to conflicting requirements
     {
         let dst: &mut Struct<_, [()]> = &mut out;
         dst.head = y;
     }
     out.head
+    //~^ ERROR 34:5: 34:13: explicit lifetime required in the type of `y` [E0621]
 }
 
 fn main() {

--- a/src/test/compile-fail/object-lifetime-default-from-box-error.rs
+++ b/src/test/compile-fail/object-lifetime-default-from-box-error.rs
@@ -38,7 +38,7 @@ fn store(ss: &mut SomeStruct, b: Box<SomeTrait>) {
 fn store1<'b>(ss: &mut SomeStruct, b: Box<SomeTrait+'b>) {
     // Here we override the lifetimes explicitly, and so naturally we get an error.
 
-    ss.r = b; //~ ERROR cannot infer an appropriate lifetime
+    ss.r = b; //~ ERROR 41:12: 41:13: explicit lifetime required in the type of `ss` [E0621]
 }
 
 fn main() {

--- a/src/test/compile-fail/region-lifetime-bounds-on-fns-where-clause.rs
+++ b/src/test/compile-fail/region-lifetime-bounds-on-fns-where-clause.rs
@@ -21,7 +21,7 @@ fn b<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) {
 fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
     // Here we try to call `foo` but do not know that `'a` and `'b` are
     // related as required.
-    a(x, y); //~ ERROR cannot infer
+    a(x, y); //~ ERROR 24:7: 24:8: lifetime mismatch [E0623]
 }
 
 fn d() {

--- a/src/test/compile-fail/region-multiple-lifetime-bounds-on-fns-where-clause.rs
+++ b/src/test/compile-fail/region-multiple-lifetime-bounds-on-fns-where-clause.rs
@@ -23,7 +23,7 @@ fn b<'a, 'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {
 fn c<'a,'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {
     // Here we try to call `foo` but do not know that `'a` and `'b` are
     // related as required.
-    a(x, y, z); //~ ERROR cannot infer
+    a(x, y, z); //~ ERROR 26:7: 26:8: lifetime mismatch [E0623]
 }
 
 fn d() {

--- a/src/test/compile-fail/regions-bounded-method-type-parameters-cross-crate.rs
+++ b/src/test/compile-fail/regions-bounded-method-type-parameters-cross-crate.rs
@@ -27,7 +27,7 @@ fn call_into_maybe_owned<'x,F:IntoMaybeOwned<'x>>(f: F) {
 
 fn call_bigger_region<'x, 'y>(a: Inv<'x>, b: Inv<'y>) {
     // Here the value provided for 'y is 'y, and hence 'y:'x does not hold.
-    a.bigger_region(b) //~ ERROR cannot infer
+    a.bigger_region(b) //~ ERROR 30:7: 30:20: lifetime mismatch [E0623]
 }
 
 fn main() { }

--- a/src/test/compile-fail/regions-bounded-method-type-parameters-trait-bound.rs
+++ b/src/test/compile-fail/regions-bounded-method-type-parameters-trait-bound.rs
@@ -27,7 +27,7 @@ fn caller1<'a,'b,F:Foo<'a>>(a: Inv<'a>, b: Inv<'b>, f: F) {
 
 fn caller2<'a,'b,F:Foo<'a>>(a: Inv<'a>, b: Inv<'b>, f: F) {
     // Here the value provided for 'y is 'b, and hence 'b:'a does not hold.
-    f.method(b); //~ ERROR cannot infer
+    f.method(b); //~ ERROR 30:7: 30:13: lifetime mismatch [E0623]
 }
 
 fn caller3<'a,'b:'a,F:Foo<'a>>(a: Inv<'a>, b: Inv<'b>, f: F) {

--- a/src/test/compile-fail/regions-free-region-ordering-callee.rs
+++ b/src/test/compile-fail/regions-free-region-ordering-callee.rs
@@ -20,13 +20,13 @@ fn ordering1<'a, 'b>(x: &'a &'b usize) -> &'a usize {
 
 fn ordering2<'a, 'b>(x: &'a &'b usize, y: &'a usize) -> &'b usize {
     // However, it is not safe to assume that 'b <= 'a
-    &*y //~ ERROR cannot infer
+    &*y //~ ERROR 23:5: 23:8: lifetime mismatch [E0623]
 }
 
 fn ordering3<'a, 'b>(x: &'a usize, y: &'b usize) -> &'a &'b usize {
     // Do not infer an ordering from the return value.
     let z: &'b usize = &*x;
-    //~^ ERROR cannot infer
+    //~^ ERROR 28:24: 28:27: lifetime mismatch [E0623]
     panic!();
 }
 

--- a/src/test/compile-fail/regions-glb-free-free.rs
+++ b/src/test/compile-fail/regions-glb-free-free.rs
@@ -22,7 +22,7 @@ mod argparse {
 
     impl<'a> Flag<'a> {
         pub fn set_desc(self, s: &str) -> Flag<'a> {
-            Flag { //~ ERROR cannot infer
+            Flag { //~ ERROR 25:13: 30:14: explicit lifetime required in the type of `s` [E0621]
                 name: self.name,
                 desc: s,
                 max_count: self.max_count,

--- a/src/test/compile-fail/regions-lifetime-bounds-on-fns.rs
+++ b/src/test/compile-fail/regions-lifetime-bounds-on-fns.rs
@@ -21,7 +21,7 @@ fn b<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) {
 fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
     // Here we try to call `foo` but do not know that `'a` and `'b` are
     // related as required.
-    a(x, y); //~ ERROR E0495
+    a(x, y); //~ ERROR 24:7: 24:8: lifetime mismatch [E0623]
 }
 
 fn d() {

--- a/src/test/compile-fail/regions-reborrow-from-shorter-mut-ref-mut-ref.rs
+++ b/src/test/compile-fail/regions-reborrow-from-shorter-mut-ref-mut-ref.rs
@@ -11,7 +11,7 @@
 // Issue #8624. Test for reborrowing with 3 levels, not just two.
 
 fn copy_borrowed_ptr<'a, 'b, 'c>(p: &'a mut &'b mut &'c mut isize) -> &'b mut isize {
-    &mut ***p //~ ERROR cannot infer
+    &mut ***p //~ ERROR 14:5: 14:14: lifetime mismatch [E0623]
 }
 
 fn main() {

--- a/src/test/compile-fail/regions-reborrow-from-shorter-mut-ref.rs
+++ b/src/test/compile-fail/regions-reborrow-from-shorter-mut-ref.rs
@@ -13,7 +13,7 @@
 // for `'a` (which must be a sublifetime of `'b`).
 
 fn copy_borrowed_ptr<'a, 'b>(p: &'a mut &'b mut isize) -> &'b mut isize {
-    &mut **p //~ ERROR cannot infer
+    &mut **p //~ ERROR 16:5: 16:13: lifetime mismatch [E0623]
 }
 
 fn main() {

--- a/src/test/compile-fail/variance-trait-matching.rs
+++ b/src/test/compile-fail/variance-trait-matching.rs
@@ -31,7 +31,7 @@ fn get<'a, G>(get: &G) -> i32
     // This fails to type-check because, without variance, we can't
     // use `G : Get<&'a i32>` as evidence that `G : Get<&'b i32>`,
     // even if `'a : 'b`.
-    pick(get, &22) //~ ERROR cannot infer
+    pick(get, &22) //~ ERROR 34:5: 34:9: explicit lifetime required in the type of `get` [E0621]
 }
 
 fn pick<'b, G>(get: &'b G, if_odd: &'b i32) -> i32

--- a/src/test/ui/lifetime-errors/42701_one_named_and_one_anonymous.rs
+++ b/src/test/ui/lifetime-errors/42701_one_named_and_one_anonymous.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,14 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum ast<'a> {
-    num(usize),
-    add(&'a ast<'a>, &'a ast<'a>)
+struct Foo {
+    field: i32,
 }
 
-fn mk_add_bad1<'a,'b>(x: &'a ast<'a>, y: &'b ast<'b>) -> ast<'a> {
-    ast::add(x, y) //~ ERROR 17:5: 17:19: lifetime mismatch [E0623]
+fn foo2<'a>(a: &'a Foo, x: &i32) -> &'a i32 {
+    if true {
+        let p: &i32 = &a.field;
+        &*p
+    } else {
+        &*x
+    }
 }
 
-fn main() {
-}
+fn main() { }

--- a/src/test/ui/lifetime-errors/42701_one_named_and_one_anonymous.stderr
+++ b/src/test/ui/lifetime-errors/42701_one_named_and_one_anonymous.stderr
@@ -1,0 +1,11 @@
+error[E0621]: explicit lifetime required in the type of `x`
+  --> $DIR/42701_one_named_and_one_anonymous.rs:20:9
+   |
+15 | fn foo2<'a>(a: &'a Foo, x: &i32) -> &'a i32 {
+   |                         - consider changing the type of `x` to `&'a i32`
+...
+20 |         &*x
+   |         ^^^ lifetime `'a` required
+
+error: aborting due to previous error
+

--- a/src/test/ui/lifetime-errors/ex2c-push-inference-variable.stderr
+++ b/src/test/ui/lifetime-errors/ex2c-push-inference-variable.stderr
@@ -1,35 +1,11 @@
-error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
-  --> $DIR/ex2c-push-inference-variable.rs:16:13
-   |
-16 |     let z = Ref { data: y.data };
-   |             ^^^
-   |
-note: first, the lifetime cannot outlive the lifetime 'c as defined on the function body at 15:1...
-  --> $DIR/ex2c-push-inference-variable.rs:15:1
-   |
-15 | / fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
-16 | |     let z = Ref { data: y.data };
-17 | |     x.push(z);
-18 | | }
-   | |_^
-note: ...so that reference does not outlive borrowed content
-  --> $DIR/ex2c-push-inference-variable.rs:16:25
-   |
-16 |     let z = Ref { data: y.data };
-   |                         ^^^^^^
-note: but, the lifetime must be valid for the lifetime 'b as defined on the function body at 15:1...
-  --> $DIR/ex2c-push-inference-variable.rs:15:1
-   |
-15 | / fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
-16 | |     let z = Ref { data: y.data };
-17 | |     x.push(z);
-18 | | }
-   | |_^
-note: ...so that expression is assignable (expected Ref<'b, _>, found Ref<'_, _>)
+error[E0623]: lifetime mismatch
   --> $DIR/ex2c-push-inference-variable.rs:17:12
    |
+15 | fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
+   |                                   ------------      ------------ these two types are declared with different lifetimes...
+16 |     let z = Ref { data: y.data };
 17 |     x.push(z);
-   |            ^
+   |            ^ ...but data from `y` flows into `x` here
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex2d-push-inference-variable-2.stderr
+++ b/src/test/ui/lifetime-errors/ex2d-push-inference-variable-2.stderr
@@ -1,37 +1,10 @@
-error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
-  --> $DIR/ex2d-push-inference-variable-2.rs:17:13
-   |
-17 |     let b = Ref { data: y.data };
-   |             ^^^
-   |
-note: first, the lifetime cannot outlive the lifetime 'c as defined on the function body at 15:1...
-  --> $DIR/ex2d-push-inference-variable-2.rs:15:1
-   |
-15 | / fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
-16 | |     let a: &mut Vec<Ref<i32>> = x;
-17 | |     let b = Ref { data: y.data };
-18 | |     a.push(b);
-19 | | }
-   | |_^
-note: ...so that reference does not outlive borrowed content
-  --> $DIR/ex2d-push-inference-variable-2.rs:17:25
-   |
-17 |     let b = Ref { data: y.data };
-   |                         ^^^^^^
-note: but, the lifetime must be valid for the lifetime 'b as defined on the function body at 15:1...
-  --> $DIR/ex2d-push-inference-variable-2.rs:15:1
-   |
-15 | / fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
-16 | |     let a: &mut Vec<Ref<i32>> = x;
-17 | |     let b = Ref { data: y.data };
-18 | |     a.push(b);
-19 | | }
-   | |_^
-note: ...so that expression is assignable (expected &mut std::vec::Vec<Ref<'_, i32>>, found &mut std::vec::Vec<Ref<'b, i32>>)
+error[E0623]: lifetime mismatch
   --> $DIR/ex2d-push-inference-variable-2.rs:16:33
    |
+15 | fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
+   |                                   ------------      ------------ these two types are declared with different lifetimes...
 16 |     let a: &mut Vec<Ref<i32>> = x;
-   |                                 ^
+   |                                 ^ ...but data from `y` flows into `x` here
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex2e-push-inference-variable-3.stderr
+++ b/src/test/ui/lifetime-errors/ex2e-push-inference-variable-3.stderr
@@ -1,37 +1,10 @@
-error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
-  --> $DIR/ex2e-push-inference-variable-3.rs:17:13
-   |
-17 |     let b = Ref { data: y.data };
-   |             ^^^
-   |
-note: first, the lifetime cannot outlive the lifetime 'c as defined on the function body at 15:1...
-  --> $DIR/ex2e-push-inference-variable-3.rs:15:1
-   |
-15 | / fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
-16 | |     let a: &mut Vec<Ref<i32>> = x;
-17 | |     let b = Ref { data: y.data };
-18 | |     Vec::push(a, b);
-19 | | }
-   | |_^
-note: ...so that reference does not outlive borrowed content
-  --> $DIR/ex2e-push-inference-variable-3.rs:17:25
-   |
-17 |     let b = Ref { data: y.data };
-   |                         ^^^^^^
-note: but, the lifetime must be valid for the lifetime 'b as defined on the function body at 15:1...
-  --> $DIR/ex2e-push-inference-variable-3.rs:15:1
-   |
-15 | / fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
-16 | |     let a: &mut Vec<Ref<i32>> = x;
-17 | |     let b = Ref { data: y.data };
-18 | |     Vec::push(a, b);
-19 | | }
-   | |_^
-note: ...so that expression is assignable (expected &mut std::vec::Vec<Ref<'_, i32>>, found &mut std::vec::Vec<Ref<'b, i32>>)
+error[E0623]: lifetime mismatch
   --> $DIR/ex2e-push-inference-variable-3.rs:16:33
    |
+15 | fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
+   |                                   ------------      ------------ these two types are declared with different lifetimes...
 16 |     let a: &mut Vec<Ref<i32>> = x;
-   |                                 ^
+   |                                 ^ ...but data from `y` flows into `x` here
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Hello!

This fixes #42701.

## UPDATE 01
Tests are producing different results between different env builds.
This inconsistency might take a long time to investigate and fix. So, be patient

## UPDATE 02
Changed an `FxHashMap` with a `BTreeMap`. Inconsistency seems to be resolved for now.
