### PR TITLE
Fix invalid display of enum sub-fields docs

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -658,11 +658,13 @@ h3 > .collapse-toggle, h4 > .collapse-toggle {
 
 .toggle-wrapper {
 	position: relative;
+	margin-top: 5px;
 }
 
 .toggle-wrapper.collapsed {
-	height: 1em;
+	height: 25px;
 	transition: height .2s;
+	margin-bottom: .6em;
 }
 
 .collapse-toggle > .inner {
@@ -704,12 +706,14 @@ span.since {
 	margin-top: 5px;
 }
 
-.variant + .toggle-wrapper > a {
-	margin-top: 5px;
-}
-
 .sub-variant, .sub-variant > h3 {
 	margin-top: 0 !important;
+}
+
+.toggle-label {
+	display: inline-block;
+	margin-left: 4px;
+	margin-top: 3px;
 }
 
 .enum > .toggle-wrapper + .docblock, .struct > .toggle-wrapper + .docblock {


### PR DESCRIPTION
Before:

<img width="1440" alt="screen shot 2017-08-30 at 23 17 00" src="https://user-images.githubusercontent.com/3050060/29895433-61f2bf8c-8dd9-11e7-83e8-cf1dca878100.png">

After:

<img width="1440" alt="screen shot 2017-08-30 at 23 16 48" src="https://user-images.githubusercontent.com/3050060/29895441-66dea042-8dd9-11e7-9576-11b0c770c70b.png">

cc @nox @rust-lang/docs 
