### PR TITLE
rustbuild: update the rust-src filter for compiler-rt

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -757,7 +757,7 @@ impl Step for Src {
             "src/libprofiler_builtins",
         ];
         let std_src_dirs_exclude = [
-            "src/compiler-rt/test",
+            "src/libcompiler_builtins/compiler-rt/test",
             "src/jemalloc/test/unit",
         ];
 


### PR DESCRIPTION
We wanted `src/compiler-rt/test` filtered from the `rust-src` package,
but that path is now `src/libcompiler_builtins/compiler-rt/test`.  This
saves over half of the installed rust-src size. (50MB -> 22MB)