### PR TITLE
don't suggest placing `use` statements into expanded code

### DIFF
--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -10,7 +10,7 @@ error[E0423]: expected value, found struct `Z`
    |
 help: possible better candidate is found in another module, you can import it into scope
    |
-16 |     use m::n::Z;
+22 |     use m::n::Z;
    |
 
 error[E0423]: expected value, found struct `S`
@@ -24,7 +24,7 @@ error[E0423]: expected value, found struct `S`
    |
 help: possible better candidate is found in another module, you can import it into scope
    |
-15 | use m::S;
+32 | use m::S;
    |
 
 error[E0423]: expected value, found struct `xcrate::S`
@@ -38,7 +38,7 @@ error[E0423]: expected value, found struct `xcrate::S`
    |
 help: possible better candidate is found in another module, you can import it into scope
    |
-15 | use m::S;
+32 | use m::S;
    |
 
 error[E0603]: tuple struct `Z` is private

--- a/src/test/ui/resolve/use_suggestion_placement.rs
+++ b/src/test/ui/resolve/use_suggestion_placement.rs
@@ -16,6 +16,15 @@ mod m {
     pub const A: i32 = 0;
 }
 
+mod foo {
+    #[derive(Debug)]
+    pub struct Foo;
+
+    // test whether the use suggestion isn't
+    // placed into the expansion of `#[derive(Debug)]
+    type Bar = Path;
+}
+
 fn main() {
     y!();
     let _ = A;

--- a/src/test/ui/resolve/use_suggestion_placement.stderr
+++ b/src/test/ui/resolve/use_suggestion_placement.stderr
@@ -6,7 +6,7 @@ error[E0412]: cannot find type `Path` in this scope
    |
 help: possible candidate is found in another module, you can import it into scope
    |
-20 |     #[derive(use std::path::Path;
+21 |     use std::path::Path;
    |
 
 error[E0425]: cannot find value `A` in this scope

--- a/src/test/ui/resolve/use_suggestion_placement.stderr
+++ b/src/test/ui/resolve/use_suggestion_placement.stderr
@@ -1,7 +1,18 @@
-error[E0425]: cannot find value `A` in this scope
-  --> $DIR/use_suggestion_placement.rs:21:13
+error[E0412]: cannot find type `Path` in this scope
+  --> $DIR/use_suggestion_placement.rs:25:16
    |
-21 |     let _ = A;
+25 |     type Bar = Path;
+   |                ^^^^ not found in this scope
+   |
+help: possible candidate is found in another module, you can import it into scope
+   |
+20 |     #[derive(use std::path::Path;
+   |
+
+error[E0425]: cannot find value `A` in this scope
+  --> $DIR/use_suggestion_placement.rs:30:13
+   |
+30 |     let _ = A;
    |             ^ not found in this scope
    |
 help: possible candidate is found in another module, you can import it into scope
@@ -10,9 +21,9 @@ help: possible candidate is found in another module, you can import it into scop
    |
 
 error[E0412]: cannot find type `HashMap` in this scope
-  --> $DIR/use_suggestion_placement.rs:26:23
+  --> $DIR/use_suggestion_placement.rs:35:23
    |
-26 |     type Dict<K, V> = HashMap<K, V>;
+35 |     type Dict<K, V> = HashMap<K, V>;
    |                       ^^^^^^^ not found in this scope
    |
 help: possible candidates are found in other modules, you can import them into scope
@@ -23,16 +34,16 @@ help: possible candidates are found in other modules, you can import them into s
    |
 
 error[E0091]: type parameter `K` is unused
-  --> $DIR/use_suggestion_placement.rs:26:15
+  --> $DIR/use_suggestion_placement.rs:35:15
    |
-26 |     type Dict<K, V> = HashMap<K, V>;
+35 |     type Dict<K, V> = HashMap<K, V>;
    |               ^ unused type parameter
 
 error[E0091]: type parameter `V` is unused
-  --> $DIR/use_suggestion_placement.rs:26:18
+  --> $DIR/use_suggestion_placement.rs:35:18
    |
-26 |     type Dict<K, V> = HashMap<K, V>;
+35 |     type Dict<K, V> = HashMap<K, V>;
    |                  ^ unused type parameter
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 

--- a/src/test/ui/span/issue-35987.stderr
+++ b/src/test/ui/span/issue-35987.stderr
@@ -6,7 +6,7 @@ error[E0404]: expected trait, found type parameter `Add`
    |
 help: possible better candidate is found in another module, you can import it into scope
    |
-11 | use std::ops::Add;
+13 | use std::ops::Add;
    |
 
 error[E0601]: main function not found


### PR DESCRIPTION
r? @nrc

fixes #44210

```rust
#[derive(Debug)]
struct Foo;

type X = Path;
```

will try to place `use std::path::Path;` between `#[derive(Debug)]` and `struct Foo;`

I am not sure how to obtain a span before the first attribute, because derive attributes are removed during expansion.

It would be trivial to detect this case and place the `use` after the item, but that would be somewhat weird I think.