### PR TITLE
Add full git commit hash to release channel manifests

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -846,6 +846,8 @@ impl Step for PlainSourceTarball {
 
         // Create the version file
         write_file(&plain_dst_src.join("version"), build.rust_version().as_bytes());
+        let sha = build.rust_sha().unwrap_or("");
+        write_file(&plain_dst_src.join("git-commit-hash"), sha.as_bytes());
 
         // If we're building from git sources, we need to vendor a complete distribution.
         if build.rust_info.is_git() {
@@ -1158,7 +1160,9 @@ impl Step for Extended {
         install(&build.src.join("LICENSE-APACHE"), &overlay, 0o644);
         install(&build.src.join("LICENSE-MIT"), &overlay, 0o644);
         let version = build.rust_version();
+        let sha = build.rust_sha().unwrap_or("");
         t!(t!(File::create(overlay.join("version"))).write_all(version.as_bytes()));
+        t!(t!(File::create(overlay.join("git-commit-hash"))).write_all(sha.as_bytes()));
         install(&etc.join("README.md"), &overlay, 0o644);
 
         // When rust-std package split from rustc, we needed to ensure that during

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -364,7 +364,9 @@ impl Step for Rustc {
         cp("README.md");
         // tiny morsel of metadata is used by rust-packaging
         let version = build.rust_version();
+        let sha = build.rust_sha().unwrap_or("");
         t!(t!(File::create(overlay.join("version"))).write_all(version.as_bytes()));
+        t!(t!(File::create(overlay.join("git-commit-hash"))).write_all(sha.as_bytes()));
 
         // On MinGW we've got a few runtime DLL dependencies that we need to
         // include. The first argument to this script is where to put these DLLs

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -364,9 +364,10 @@ impl Step for Rustc {
         cp("README.md");
         // tiny morsel of metadata is used by rust-packaging
         let version = build.rust_version();
-        let sha = build.rust_sha().unwrap_or("");
         t!(t!(File::create(overlay.join("version"))).write_all(version.as_bytes()));
-        t!(t!(File::create(overlay.join("git-commit-hash"))).write_all(sha.as_bytes()));
+        if let Some(sha) = build.rust_sha() {
+            t!(t!(File::create(overlay.join("git-commit-hash"))).write_all(sha.as_bytes()));
+        }
 
         // On MinGW we've got a few runtime DLL dependencies that we need to
         // include. The first argument to this script is where to put these DLLs
@@ -846,8 +847,9 @@ impl Step for PlainSourceTarball {
 
         // Create the version file
         write_file(&plain_dst_src.join("version"), build.rust_version().as_bytes());
-        let sha = build.rust_sha().unwrap_or("");
-        write_file(&plain_dst_src.join("git-commit-hash"), sha.as_bytes());
+        if let Some(sha) = build.rust_sha() {
+            write_file(&plain_dst_src.join("git-commit-hash"), sha.as_bytes());
+        }
 
         // If we're building from git sources, we need to vendor a complete distribution.
         if build.rust_info.is_git() {
@@ -1160,9 +1162,10 @@ impl Step for Extended {
         install(&build.src.join("LICENSE-APACHE"), &overlay, 0o644);
         install(&build.src.join("LICENSE-MIT"), &overlay, 0o644);
         let version = build.rust_version();
-        let sha = build.rust_sha().unwrap_or("");
         t!(t!(File::create(overlay.join("version"))).write_all(version.as_bytes()));
-        t!(t!(File::create(overlay.join("git-commit-hash"))).write_all(sha.as_bytes()));
+        if let Some(sha) = build.rust_sha() {
+            t!(t!(File::create(overlay.join("git-commit-hash"))).write_all(sha.as_bytes()));
+        }
         install(&etc.join("README.md"), &overlay, 0o644);
 
         // When rust-std package split from rustc, we needed to ensure that during

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -797,6 +797,11 @@ impl Build {
         self.rust_info.version(self, channel::CFG_RELEASE_NUM)
     }
 
+    /// Return the full commit hash
+    fn rust_sha(&self) -> Option<&str> {
+        self.rust_info.sha()
+    }
+
     /// Returns the `a.b.c` version that the given package is at.
     fn release_num(&self, package: &str) -> String {
         let mut toml = String::new();


### PR DESCRIPTION
The full hash is necessary to build the download URL for "alternate" compiler builds. This is a first step for https://github.com/rust-lang-nursery/rustup.rs/issues/1099.