### PR TITLE
Add `-Z skip-end-regions` as way to side-step EndRegion emission.

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -918,6 +918,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
         "when debug-printing compiler state, do not include spans"), // o/w tests have closure@path
     identify_regions: bool = (false, parse_bool, [UNTRACKED],
         "make unnamed regions display as '# (where # is some non-ident unique id)"),
+    skip_end_regions: bool = (false, parse_bool, [UNTRACKED],
+        "skip EndRegion emission in MIR, skip transforms that solely process EndRegion"),
     borrowck_mir: bool = (false, parse_bool, [UNTRACKED],
         "implicitly treat functions as if they have `#[rustc_mir_borrowck]` attribute"),
     time_passes: bool = (false, parse_bool, [UNTRACKED],

--- a/src/librustc_mir/build/cfg.rs
+++ b/src/librustc_mir/build/cfg.rs
@@ -16,6 +16,7 @@
 use build::CFG;
 use rustc::middle::region::CodeExtent;
 use rustc::mir::*;
+use rustc::ty;
 
 impl<'tcx> CFG<'tcx> {
     pub fn block_data(&self, blk: BasicBlock) -> &BasicBlockData<'tcx> {
@@ -44,14 +45,17 @@ impl<'tcx> CFG<'tcx> {
         self.block_data_mut(block).statements.push(statement);
     }
 
-    pub fn push_end_region(&mut self,
-                           block: BasicBlock,
-                           source_info: SourceInfo,
-                           extent: CodeExtent) {
-        self.push(block, Statement {
-            source_info,
-            kind: StatementKind::EndRegion(extent),
-        });
+    pub fn push_end_region<'a, 'gcx:'a+'tcx>(&mut self,
+                                             tcx: ty::TyCtxt<'a, 'gcx, 'tcx>,
+                                             block: BasicBlock,
+                                             source_info: SourceInfo,
+                                             extent: CodeExtent) {
+        if !tcx.sess.opts.debugging_opts.skip_end_regions {
+            self.push(block, Statement {
+                source_info,
+                kind: StatementKind::EndRegion(extent),
+            });
+        }
     }
 
     pub fn push_assign(&mut self,

--- a/src/librustc_mir/transform/clean_end_regions.rs
+++ b/src/librustc_mir/transform/clean_end_regions.rs
@@ -39,9 +39,11 @@ struct DeleteTrivialEndRegions<'a> {
 
 impl MirPass for CleanEndRegions {
     fn run_pass<'a, 'tcx>(&self,
-                          _tcx: TyCtxt<'a, 'tcx, 'tcx>,
+                          tcx: TyCtxt<'a, 'tcx, 'tcx>,
                           _source: MirSource,
                           mir: &mut Mir<'tcx>) {
+        if tcx.sess.opts.debugging_opts.skip_end_regions { return; }
+
         let mut gather = GatherBorrowedRegions {
             seen_regions: FxHashSet()
         };


### PR DESCRIPTION
Add `-Z skip-end-regions` as way to side-step EndRegion emission.

The main intent is to investigate cases where EndRegion emission is believed to be causing excess peak memory pressure.

It may also be of use to people inspecting the MIR output who find the EndRegions to be a distraction.