### PR TITLE
Implement From<&str> for Symbol.

### DIFF
--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -115,6 +115,12 @@ impl Symbol {
     }
 }
 
+impl<'a> From<&'a str> for Symbol {
+    fn from(string: &'a str) -> Symbol {
+        Symbol::intern(string)
+    }
+}
+
 impl fmt::Debug for Symbol {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}({})", self, self.0)


### PR DESCRIPTION
This lets us have `fn foo<S: Into<Symbol>>` bounds and accept both `&str` and existing `Symbol`s.

r? @jseyfried 