### PR TITLE
E0277: trait as return value

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -1137,6 +1137,7 @@ Rust only looks at the signature of the called function, as such it must
 already specify all requirements that will be used for every type parameter.
 
 Here's another erroneous code example:
+
 ```compile_fail,E0277
 trait A {}
 
@@ -1153,6 +1154,7 @@ fn foo(b: B) -> A {
 Here are two solutions to fix this issue:
 
 1. `Box` your returned value
+
 ```rust
 # use std::boxed::Box;
 # use std::borrow::Borrow;
@@ -1168,6 +1170,7 @@ Here are two solutions to fix this issue:
 fn foo(b: B) -> Box<A> {
     Box::new(b) // The `Sized` trait bound has been removed.
 }
+
 // Once this value was returned, it can be used as follow:
 // `A` trait must implement `Debug`, of course.
 let boxed_object: Box<A> = foo(B);
@@ -1175,6 +1178,7 @@ println!("{:?}", boxed_object); // prints B
 ```
 
 2. Add a generic data type
+
 ```rust
 # use std::fmt::Debug;
 #

--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -1135,6 +1135,63 @@ fn main() {
 
 Rust only looks at the signature of the called function, as such it must
 already specify all requirements that will be used for every type parameter.
+
+Here's another erroneous code example:
+```compile_fail,E0277
+trait A {}
+
+struct B;
+
+impl A for B {}
+
+// Let's assume that you would like to return a trait like below:
+fn foo(b: B) -> A {
+    b // won't compile
+}
+```
+
+Here are two solutions to fix this issue:
+
+1. `Box` your returned value
+```rust
+# use std::boxed::Box;
+# use std::borrow::Borrow;
+# use std::fmt::Debug;
+#
+# trait A: Debug {}
+#
+# #[derive(Debug)]
+# struct B;
+#
+# impl A for B {}
+#
+fn foo(b: B) -> Box<A> {
+    Box::new(b) // The `Sized` trait bound has been removed.
+}
+// Once this value was returned, it can be used as follow:
+// `A` trait must implement `Debug`, of course.
+let boxed_object: Box<A> = foo(B);
+println!("{:?}", boxed_object); // prints B
+```
+
+2. Add a generic data type
+```rust
+# use std::fmt::Debug;
+#
+# trait A: Debug {}
+#
+# #[derive(Debug)]
+# struct B;
+#
+# impl A for B {}
+#
+fn foo<T: A>(b: T) -> T {
+    b // returns all `A` trait implementors.
+}
+
+let generic_object = foo(B); // inferred type
+println!("{:?}", generic_object); // prints B
+```
 "##,
 
 E0281: r##"

--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -1147,7 +1147,7 @@ impl A for B {}
 
 // Let's assume that you would like to return a trait like below:
 fn foo(b: B) -> A {
-    b // won't compile
+    b // error[E0277]: the trait bound `A + 'static: std::marker::Sized` is not satisfied
 }
 ```
 


### PR DESCRIPTION
Some examples was added to return a trait implementor properly.

This PR is linked to #44227.

cc @GuillaumeGomez 