### PR TITLE
Fix release notes on associated constants

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,7 +3,7 @@ Version 1.20.0 (2017-08-31)
 
 Language
 --------
-- [Associated constants in traits is now stabilised.][42809]
+- [Associated constants are now stabilised.][42809]
 - [A lot of macro bugs are now fixed.][42913]
 
 Compiler


### PR DESCRIPTION
Associated constants seem to be stable everywhere, not just in traits