### PR TITLE
[beta] Boostrap from released compilers

### DIFF
--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -29,7 +29,7 @@ pub const CFG_RELEASE_NUM: &str = "1.21.0";
 // An optional number to put after the label, e.g. '.2' -> '-beta.2'
 // Be sure to make this starts with a dot to conform to semver pre-release
 // versions (section 9)
-pub const CFG_PRERELEASE_VERSION: &str = ".1";
+pub const CFG_PRERELEASE_VERSION: &str = ".2";
 
 pub struct GitInfo {
     inner: Option<Info>,

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -123,7 +123,6 @@ extern crate build_helper;
 extern crate serde_derive;
 #[macro_use]
 extern crate lazy_static;
-extern crate serde;
 extern crate serde_json;
 extern crate cmake;
 extern crate filetime;

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -198,7 +198,7 @@ tool!(
     Linkchecker, "src/tools/linkchecker", "linkchecker", Mode::Libstd;
     CargoTest, "src/tools/cargotest", "cargotest", Mode::Libstd;
     Compiletest, "src/tools/compiletest", "compiletest", Mode::Libtest;
-    BuildManifest, "src/tools/build-manifest", "build-manifest", Mode::Librustc;
+    BuildManifest, "src/tools/build-manifest", "build-manifest", Mode::Libstd;
     RemoteTestClient, "src/tools/remote-test-client", "remote-test-client", Mode::Libstd;
     RustInstaller, "src/tools/rust-installer", "rust-installer", Mode::Libstd;
 );

--- a/src/liballoc/allocator.rs
+++ b/src/liballoc/allocator.rs
@@ -464,6 +464,29 @@ impl fmt::Display for CannotReallocInPlace {
 ///  * if a layout `k` fits a memory block (denoted by `ptr`)
 ///    currently allocated via an allocator `a`, then it is legal to
 ///    use that layout to deallocate it, i.e. `a.dealloc(ptr, k);`.
+///
+/// # Unsafety
+///
+/// The `Alloc` trait is an `unsafe` trait for a number of reasons, and
+/// implementors must ensure that they adhere to these contracts:
+///
+/// * Pointers returned from allocation functions must point to valid memory and
+///   retain their validity until at least the instance of `Alloc` is dropped
+///   itself.
+///
+/// * It's undefined behavior if global allocators unwind.  This restriction may
+///   be lifted in the future, but currently a panic from any of these
+///   functions may lead to memory unsafety. Note that as of the time of this
+///   writing allocators *not* intending to be global allocators can still panic
+///   in their implementation without violating memory safety.
+///
+/// * `Layout` queries and calculations in general must be correct. Callers of
+///   this trait are allowed to rely on the contracts defined on each method,
+///   and implementors must ensure such contracts remain true.
+///
+/// Note that this list may get tweaked over time as clarifications are made in
+/// the future. Additionally global allocators may gain unique requirements for
+/// how to safely implement one in the future as well.
 pub unsafe trait Alloc {
 
     // (Note: existing allocators have unspecified but well-defined

--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -27,24 +27,32 @@ pub mod __core {
 
 extern "Rust" {
     #[allocator]
+    #[rustc_allocator_nounwind]
     fn __rust_alloc(size: usize, align: usize, err: *mut u8) -> *mut u8;
     #[cold]
+    #[rustc_allocator_nounwind]
     fn __rust_oom(err: *const u8) -> !;
+    #[rustc_allocator_nounwind]
     fn __rust_dealloc(ptr: *mut u8, size: usize, align: usize);
+    #[rustc_allocator_nounwind]
     fn __rust_usable_size(layout: *const u8,
                           min: *mut usize,
                           max: *mut usize);
+    #[rustc_allocator_nounwind]
     fn __rust_realloc(ptr: *mut u8,
                       old_size: usize,
                       old_align: usize,
                       new_size: usize,
                       new_align: usize,
                       err: *mut u8) -> *mut u8;
+    #[rustc_allocator_nounwind]
     fn __rust_alloc_zeroed(size: usize, align: usize, err: *mut u8) -> *mut u8;
+    #[rustc_allocator_nounwind]
     fn __rust_alloc_excess(size: usize,
                            align: usize,
                            excess: *mut usize,
                            err: *mut u8) -> *mut u8;
+    #[rustc_allocator_nounwind]
     fn __rust_realloc_excess(ptr: *mut u8,
                              old_size: usize,
                              old_align: usize,
@@ -52,11 +60,13 @@ extern "Rust" {
                              new_align: usize,
                              excess: *mut usize,
                              err: *mut u8) -> *mut u8;
+    #[rustc_allocator_nounwind]
     fn __rust_grow_in_place(ptr: *mut u8,
                             old_size: usize,
                             old_align: usize,
                             new_size: usize,
                             new_align: usize) -> u8;
+    #[rustc_allocator_nounwind]
     fn __rust_shrink_in_place(ptr: *mut u8,
                               old_size: usize,
                               old_align: usize,

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -105,6 +105,7 @@
 #![feature(pattern)]
 #![feature(placement_in_syntax)]
 #![feature(placement_new_protocol)]
+#![feature(rustc_attrs)]
 #![feature(shared)]
 #![feature(slice_get_slice)]
 #![feature(slice_patterns)]

--- a/src/librustc_trans/attributes.rs
+++ b/src/librustc_trans/attributes.rs
@@ -119,6 +119,8 @@ pub fn from_fn_attrs(ccx: &CrateContext, attrs: &[ast::Attribute], llfn: ValueRe
                 llvm::AttributePlace::ReturnValue(), llfn);
         } else if attr.check_name("unwind") {
             unwind(llfn, true);
+        } else if attr.check_name("rustc_allocator_nounwind") {
+            unwind(llfn, false);
         }
     }
     if !target_features.is_empty() {

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,7 +12,7 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2017-08-27
+date: 2017-08-31
 rustc: 1.20.0
 cargo: 0.21.0
 
@@ -34,4 +34,4 @@ cargo: 0.21.0
 # looking at a beta source tarball and it's uncommented we'll shortly comment it
 # out.
 
-dev: 1
+#dev: 1

--- a/src/test/codegen/dealloc-no-unwind.rs
+++ b/src/test/codegen/dealloc-no-unwind.rs
@@ -1,0 +1,32 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+// no-system-llvm
+// compile-flags: -O
+
+#![crate_type="lib"]
+
+struct A;
+
+impl Drop for A {
+    fn drop(&mut self) {
+        extern { fn foo(); }
+        unsafe { foo(); }
+    }
+}
+
+#[no_mangle]
+pub fn a(a: Box<i32>) {
+    // CHECK-LABEL: define void @a
+    // CHECK: call void @__rust_dealloc
+    // CHECK-NEXT: call void @foo
+    let _a = A;
+    drop(a);
+}


### PR DESCRIPTION
No need to use dev any more!

Also contains backports for:

* https://github.com/rust-lang/rust/pull/44049
* https://github.com/rust-lang/rust/pull/44121
* https://github.com/rust-lang/rust/pull/44144