### PR TITLE
Better StorageLive / StorageDead placement for constants.

### DIFF
--- a/src/librustc/ty/maps.rs
+++ b/src/librustc/ty/maps.rs
@@ -31,6 +31,7 @@ use ty::fast_reject::SimplifiedType;
 use util::nodemap::{DefIdSet, NodeSet};
 use util::common::{profq_msg, ProfileQueriesMsg};
 
+use rustc_data_structures::indexed_set::IdxSetBuf;
 use rustc_data_structures::indexed_vec::IndexVec;
 use rustc_data_structures::fx::FxHashMap;
 use std::cell::{RefCell, RefMut, Cell};
@@ -1019,7 +1020,7 @@ define_maps! { <'tcx>
     /// Maps DefId's that have an associated Mir to the result
     /// of the MIR qualify_consts pass. The actual meaning of
     /// the value isn't known except to the pass itself.
-    [] fn mir_const_qualif: MirConstQualif(DefId) -> u8,
+    [] fn mir_const_qualif: MirConstQualif(DefId) -> (u8, Rc<IdxSetBuf<mir::Local>>),
 
     /// Fetch the MIR for a given def-id up till the point where it is
     /// ready for const evaluation.

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -38,6 +38,7 @@ use syntax::ext::base::SyntaxExtension;
 use syntax::parse::filemap_to_stream;
 use syntax::symbol::Symbol;
 use syntax_pos::{Span, NO_EXPANSION};
+use rustc_data_structures::indexed_set::IdxSetBuf;
 use rustc::hir::svh::Svh;
 use rustc::hir;
 
@@ -106,7 +107,9 @@ provide! { <'tcx> tcx, def_id, cdata,
         mir
     }
     generator_sig => { cdata.generator_sig(def_id.index, tcx) }
-    mir_const_qualif => { cdata.mir_const_qualif(def_id.index) }
+    mir_const_qualif => {
+        (cdata.mir_const_qualif(def_id.index), Rc::new(IdxSetBuf::new_empty(0)))
+    }
     typeck_tables_of => { cdata.item_body_tables(def_id.index, tcx) }
     closure_kind => { cdata.closure_kind(def_id.index) }
     fn_sig => { cdata.fn_sig(def_id.index, tcx) }

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -793,7 +793,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
         let kind = match impl_item.kind {
             ty::AssociatedKind::Const => {
                 EntryKind::AssociatedConst(container,
-                    self.tcx.at(ast_item.span).mir_const_qualif(def_id))
+                    self.tcx.at(ast_item.span).mir_const_qualif(def_id).0)
             }
             ty::AssociatedKind::Method => {
                 let fn_data = if let hir::ImplItemKind::Method(ref sig, body) = ast_item.node {
@@ -912,7 +912,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
             hir::ItemStatic(_, hir::MutMutable, _) => EntryKind::MutStatic,
             hir::ItemStatic(_, hir::MutImmutable, _) => EntryKind::ImmStatic,
             hir::ItemConst(..) => {
-                EntryKind::Const(tcx.at(item.span).mir_const_qualif(def_id))
+                EntryKind::Const(tcx.at(item.span).mir_const_qualif(def_id).0)
             }
             hir::ItemFn(_, _, constness, .., body) => {
                 let data = FnData {
@@ -1256,7 +1256,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
         let body = tcx.hir.body_owned_by(id);
 
         Entry {
-            kind: EntryKind::Const(tcx.mir_const_qualif(def_id)),
+            kind: EntryKind::Const(tcx.mir_const_qualif(def_id).0),
             visibility: self.lazy(&ty::Visibility::Public),
             span: self.lazy(&tcx.def_span(def_id)),
             attributes: LazySeq::empty(),

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -97,12 +97,12 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             ExprKind::Box { value } => {
                 let value = this.hir.mirror(value);
                 let result = this.temp(expr.ty, expr_span);
+                this.cfg.push(block, Statement {
+                    source_info,
+                    kind: StatementKind::StorageLive(result.clone())
+                });
                 if let Some(scope) = scope {
                     // schedule a shallow free of that memory, lest we unwind:
-                    this.cfg.push(block, Statement {
-                        source_info,
-                        kind: StatementKind::StorageLive(result.clone())
-                    });
                     this.schedule_drop(expr_span, scope, &result, value.ty);
                 }
 

--- a/src/librustc_mir/build/expr/as_temp.rs
+++ b/src/librustc_mir/build/expr/as_temp.rs
@@ -50,7 +50,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         let expr_ty = expr.ty.clone();
         let temp = this.temp(expr_ty.clone(), expr_span);
 
-        if !expr_ty.is_never() && temp_lifetime.is_some() {
+        if !expr_ty.is_never() {
             this.cfg.push(block, Statement {
                 source_info,
                 kind: StatementKind::StorageLive(temp.clone())


### PR DESCRIPTION
Fixes problems in miri (see https://github.com/solson/miri/pull/324#issuecomment-326555552) caused by the new scope rules in #43932.
What I've tried to do here is always have a `StorageLive` but no `StorageDead` for `'static` slots.
It might not work perfectly in all cases, but it should unblock miri.

r? @nikomatsakis cc @oli-obk 