### PR TITLE
rustc: rename CodeExtent to Scope and RegionMaps to ScopeTree.

### DIFF
--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -395,7 +395,7 @@ define_dep_nodes!( <'tcx>
     [] WorkProduct(WorkProductId),
 
     // Represents different phases in the compiler.
-    [] RegionMaps(DefId),
+    [] RegionScopeTree(DefId),
     [] Coherence,
     [] CoherenceInherentImplOverlapCheck,
     [] Resolve,

--- a/src/librustc/ich/impls_mir.rs
+++ b/src/librustc/ich/impls_mir.rs
@@ -239,8 +239,8 @@ for mir::StatementKind<'gcx> {
             mir::StatementKind::StorageDead(ref lvalue) => {
                 lvalue.hash_stable(hcx, hasher);
             }
-            mir::StatementKind::EndRegion(ref extent) => {
-                extent.hash_stable(hcx, hasher);
+            mir::StatementKind::EndRegion(ref region_scope) => {
+                region_scope.hash_stable(hcx, hasher);
             }
             mir::StatementKind::Validate(ref op, ref lvalues) => {
                 op.hash_stable(hcx, hasher);
@@ -271,7 +271,7 @@ impl<'a, 'gcx, 'tcx, T> HashStable<StableHashingContext<'a, 'gcx, 'tcx>>
     }
 }
 
-impl_stable_hash_for!(enum mir::ValidationOp { Acquire, Release, Suspend(extent) });
+impl_stable_hash_for!(enum mir::ValidationOp { Acquire, Release, Suspend(region_scope) });
 
 impl<'a, 'gcx, 'tcx> HashStable<StableHashingContext<'a, 'gcx, 'tcx>> for mir::Lvalue<'gcx> {
     fn hash_stable<W: StableHasherResult>(&self,

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -17,6 +17,7 @@ use rustc_data_structures::stable_hasher::{HashStable, StableHasher,
 use std::hash as std_hash;
 use std::mem;
 use syntax_pos::symbol::InternedString;
+use middle::region;
 use ty;
 
 impl<'a, 'gcx, 'tcx, T> HashStable<StableHashingContext<'a, 'gcx, 'tcx>>
@@ -65,8 +66,8 @@ for ty::RegionKind {
                 index.hash_stable(hcx, hasher);
                 name.hash_stable(hcx, hasher);
             }
-            ty::ReScope(code_extent) => {
-                code_extent.hash_stable(hcx, hasher);
+            ty::ReScope(scope) => {
+                scope.hash_stable(hcx, hasher);
             }
             ty::ReFree(ref free_region) => {
                 free_region.hash_stable(hcx, hasher);
@@ -450,24 +451,22 @@ impl_stable_hash_for!(enum ty::cast::CastKind {
 });
 
 impl<'a, 'gcx, 'tcx> HashStable<StableHashingContext<'a, 'gcx, 'tcx>>
-for ::middle::region::CodeExtent
+for region::Scope
 {
     fn hash_stable<W: StableHasherResult>(&self,
                                           hcx: &mut StableHashingContext<'a, 'gcx, 'tcx>,
                                           hasher: &mut StableHasher<W>) {
-        use middle::region::CodeExtent;
-
         mem::discriminant(self).hash_stable(hcx, hasher);
         match *self {
-            CodeExtent::Misc(node_id) |
-            CodeExtent::DestructionScope(node_id) => {
+            region::Scope::Node(node_id) |
+            region::Scope::Destruction(node_id) => {
                 node_id.hash_stable(hcx, hasher);
             }
-            CodeExtent::CallSiteScope(body_id) |
-            CodeExtent::ParameterScope(body_id) => {
+            region::Scope::CallSite(body_id) |
+            region::Scope::Arguments(body_id) => {
                 body_id.hash_stable(hcx, hasher);
             }
-            CodeExtent::Remainder(block_remainder) => {
+            region::Scope::Remainder(block_remainder) => {
                 block_remainder.hash_stable(hcx, hasher);
             }
         }

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -20,7 +20,7 @@ pub use self::region_inference::{GenericKind, VerifyBound};
 
 use hir::def_id::DefId;
 use middle::free_region::{FreeRegionMap, RegionRelations};
-use middle::region::RegionMaps;
+use middle::region;
 use middle::lang_items;
 use mir::tcx::LvalueTy;
 use ty::subst::{Kind, Subst, Substs};
@@ -1070,7 +1070,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
 
     pub fn resolve_regions_and_report_errors(&self,
                                              region_context: DefId,
-                                             region_map: &RegionMaps,
+                                             region_map: &region::ScopeTree,
                                              free_regions: &FreeRegionMap<'tcx>) {
         let region_rels = RegionRelations::new(self.tcx,
                                                region_context,

--- a/src/librustc/infer/region_inference/mod.rs
+++ b/src/librustc/infer/region_inference/mod.rs
@@ -935,14 +935,14 @@ impl<'a, 'gcx, 'tcx> RegionVarBindings<'a, 'gcx, 'tcx> {
                 // reasonably compare free regions and scopes:
                 let fr_scope = match (a, b) {
                     (&ReEarlyBound(ref br), _) | (_, &ReEarlyBound(ref br)) => {
-                        region_rels.region_maps.early_free_extent(self.tcx, br)
+                        region_rels.region_scope_tree.early_free_scope(self.tcx, br)
                     }
                     (&ReFree(ref fr), _) | (_, &ReFree(ref fr)) => {
-                        region_rels.region_maps.free_extent(self.tcx, fr)
+                        region_rels.region_scope_tree.free_scope(self.tcx, fr)
                     }
                     _ => bug!()
                 };
-                let r_id = region_rels.region_maps.nearest_common_ancestor(fr_scope, s_id);
+                let r_id = region_rels.region_scope_tree.nearest_common_ancestor(fr_scope, s_id);
                 if r_id == fr_scope {
                     // if the free region's scope `fr.scope` is bigger than
                     // the scope region `s_id`, then the LUB is the free
@@ -963,7 +963,7 @@ impl<'a, 'gcx, 'tcx> RegionVarBindings<'a, 'gcx, 'tcx> {
                 // The region corresponding to an outer block is a
                 // subtype of the region corresponding to an inner
                 // block.
-                let lub = region_rels.region_maps.nearest_common_ancestor(a_id, b_id);
+                let lub = region_rels.region_scope_tree.nearest_common_ancestor(a_id, b_id);
                 self.tcx.mk_region(ReScope(lub))
             }
 

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -17,7 +17,7 @@ pub use self::ObligationCauseCode::*;
 
 use hir;
 use hir::def_id::DefId;
-use middle::region::RegionMaps;
+use middle::region;
 use middle::free_region::FreeRegionMap;
 use ty::subst::Substs;
 use ty::{self, AdtKind, Ty, TyCtxt, TypeFoldable, ToPredicate};
@@ -532,9 +532,9 @@ pub fn normalize_param_env_or_error<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         debug!("normalize_param_env_or_error: normalized predicates={:?}",
             predicates);
 
-        let region_maps = RegionMaps::default();
+        let region_scope_tree = region::ScopeTree::default();
         let free_regions = FreeRegionMap::new();
-        infcx.resolve_regions_and_report_errors(region_context, &region_maps, &free_regions);
+        infcx.resolve_regions_and_report_errors(region_context, &region_scope_tree, &free_regions);
         let predicates = match infcx.fully_resolve(&predicates) {
             Ok(predicates) => predicates,
             Err(fixup_err) => {

--- a/src/librustc/ty/maps.rs
+++ b/src/librustc/ty/maps.rs
@@ -17,7 +17,7 @@ use lint;
 use middle::const_val;
 use middle::cstore::{ExternCrate, LinkagePreference};
 use middle::privacy::AccessLevels;
-use middle::region::RegionMaps;
+use middle::region;
 use mir;
 use mir::transform::{MirSuite, MirPassIndex};
 use session::CompileResult;
@@ -1080,10 +1080,9 @@ define_maps! { <'tcx>
 
     [] fn reachable_set: reachability_dep_node(CrateNum) -> Rc<NodeSet>,
 
-    /// Per-function `RegionMaps`. The `DefId` should be the owner-def-id for the fn body;
-    /// in the case of closures or "inline" expressions, this will be redirected to the enclosing
-    /// fn item.
-    [] fn region_maps: RegionMaps(DefId) -> Rc<RegionMaps>,
+    /// Per-body `region::ScopeTree`. The `DefId` should be the owner-def-id for the body;
+    /// in the case of closures, this will be redirected to the enclosing function.
+    [] fn region_scope_tree: RegionScopeTree(DefId) -> Rc<region::ScopeTree>,
 
     [] fn mir_shims: mir_shim_dep_node(ty::InstanceDef<'tcx>) -> &'tcx mir::Mir<'tcx>,
 

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -213,8 +213,8 @@ pub enum TypeVariants<'tcx> {
 /// as extra type parameters? The reason for this design is that the
 /// upvar types can reference lifetimes that are internal to the
 /// creating function. In my example above, for example, the lifetime
-/// `'b` represents the extent of the closure itself; this is some
-/// subset of `foo`, probably just the extent of the call to the to
+/// `'b` represents the scope of the closure itself; this is some
+/// subset of `foo`, probably just the scope of the call to the to
 /// `do()`. If we just had the lifetime/type parameters from the
 /// enclosing function, we couldn't name this lifetime `'b`. Note that
 /// there can also be lifetimes in the types of the upvars themselves,
@@ -845,10 +845,10 @@ pub enum RegionKind {
     /// region parameters.
     ReFree(FreeRegion),
 
-    /// A concrete region naming some statically determined extent
+    /// A concrete region naming some statically determined scope
     /// (e.g. an expression or sequence of statements) within the
     /// current function.
-    ReScope(region::CodeExtent),
+    ReScope(region::Scope),
 
     /// Static data that has an "infinite" lifetime. Top in the region lattice.
     ReStatic,

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -10,7 +10,7 @@
 
 use hir::def_id::DefId;
 use hir::map::definitions::DefPathData;
-use middle::region::{CodeExtent, BlockRemainder};
+use middle::region::{self, BlockRemainder};
 use ty::subst::{self, Subst};
 use ty::{BrAnon, BrEnv, BrFresh, BrNamed};
 use ty::{TyBool, TyChar, TyAdt};
@@ -524,18 +524,18 @@ impl fmt::Display for ty::RegionKind {
             ty::ReSkolemized(_, br) => {
                 write!(f, "{}", br)
             }
-            ty::ReScope(code_extent) if identify_regions() => {
-                match code_extent {
-                    CodeExtent::Misc(id) =>
-                        write!(f, "'{}mce", id.as_usize()),
-                    CodeExtent::CallSiteScope(id) =>
-                        write!(f, "'{}cce", id.as_usize()),
-                    CodeExtent::ParameterScope(id) =>
-                        write!(f, "'{}pce", id.as_usize()),
-                    CodeExtent::DestructionScope(id) =>
-                        write!(f, "'{}dce", id.as_usize()),
-                    CodeExtent::Remainder(BlockRemainder { block, first_statement_index }) =>
-                        write!(f, "'{}_{}rce", block.as_usize(), first_statement_index),
+            ty::ReScope(scope) if identify_regions() => {
+                match scope {
+                    region::Scope::Node(id) =>
+                        write!(f, "'{}s", id.as_usize()),
+                    region::Scope::CallSite(id) =>
+                        write!(f, "'{}cs", id.as_usize()),
+                    region::Scope::Arguments(id) =>
+                        write!(f, "'{}as", id.as_usize()),
+                    region::Scope::Destruction(id) =>
+                        write!(f, "'{}ds", id.as_usize()),
+                    region::Scope::Remainder(BlockRemainder { block, first_statement_index }) =>
+                        write!(f, "'{}_{}rs", block.as_usize(), first_statement_index),
                 }
             }
             ty::ReVar(region_vid) if identify_regions() => {

--- a/src/librustc_borrowck/borrowck/gather_loans/lifetime.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/lifetime.rs
@@ -24,7 +24,7 @@ use syntax_pos::Span;
 type R = Result<(),()>;
 
 pub fn guarantee_lifetime<'a, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>,
-                                    item_scope: region::CodeExtent,
+                                    item_scope: region::Scope,
                                     span: Span,
                                     cause: euv::LoanCause,
                                     cmt: mc::cmt<'tcx>,
@@ -52,7 +52,7 @@ struct GuaranteeLifetimeContext<'a, 'tcx: 'a> {
     bccx: &'a BorrowckCtxt<'a, 'tcx>,
 
     // the scope of the function body for the enclosing item
-    item_scope: region::CodeExtent,
+    item_scope: region::Scope,
 
     span: Span,
     cause: euv::LoanCause,
@@ -117,7 +117,7 @@ impl<'a, 'tcx> GuaranteeLifetimeContext<'a, 'tcx> {
             Categorization::Local(local_id) => {
                 let hir_id = self.bccx.tcx.hir.node_to_hir_id(local_id);
                 self.bccx.tcx.mk_region(ty::ReScope(
-                    self.bccx.region_maps.var_scope(hir_id.local_id)))
+                    self.bccx.region_scope_tree.var_scope(hir_id.local_id)))
             }
             Categorization::StaticItem |
             Categorization::Deref(_, mc::UnsafePtr(..)) => {

--- a/src/librustc_const_eval/check_match.rs
+++ b/src/librustc_const_eval/check_match.rs
@@ -18,7 +18,7 @@ use rustc::middle::expr_use_visitor::{ConsumeMode, Delegate, ExprUseVisitor};
 use rustc::middle::expr_use_visitor::{LoanCause, MutateMode};
 use rustc::middle::expr_use_visitor as euv;
 use rustc::middle::mem_categorization::{cmt};
-use rustc::middle::region::RegionMaps;
+use rustc::middle::region;
 use rustc::session::Session;
 use rustc::ty::{self, Ty, TyCtxt};
 use rustc::ty::subst::Substs;
@@ -51,7 +51,7 @@ impl<'a, 'tcx> Visitor<'tcx> for OuterVisitor<'a, 'tcx> {
         MatchVisitor {
             tcx: self.tcx,
             tables: self.tcx.body_tables(b),
-            region_maps: &self.tcx.region_maps(def_id),
+            region_scope_tree: &self.tcx.region_scope_tree(def_id),
             param_env: self.tcx.param_env(def_id),
             identity_substs: Substs::identity_for_item(self.tcx, def_id),
         }.visit_body(self.tcx.hir.body(b));
@@ -72,7 +72,7 @@ struct MatchVisitor<'a, 'tcx: 'a> {
     tables: &'a ty::TypeckTables<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
     identity_substs: &'tcx Substs<'tcx>,
-    region_maps: &'a RegionMaps,
+    region_scope_tree: &'a region::ScopeTree,
 }
 
 impl<'a, 'tcx> Visitor<'tcx> for MatchVisitor<'a, 'tcx> {
@@ -526,7 +526,7 @@ fn check_for_mutation_in_guard(cx: &MatchVisitor, guard: &hir::Expr) {
     let mut checker = MutationChecker {
         cx,
     };
-    ExprUseVisitor::new(&mut checker, cx.tcx, cx.param_env, cx.region_maps, cx.tables)
+    ExprUseVisitor::new(&mut checker, cx.tcx, cx.param_env, cx.region_scope_tree, cx.tables)
         .walk_expr(guard);
 }
 

--- a/src/librustc_mir/borrow_check.rs
+++ b/src/librustc_mir/borrow_check.rs
@@ -603,7 +603,7 @@ impl<'c, 'b, 'a: 'b+'c, 'gcx, 'tcx: 'a> MirBorrowckCtxt<'c, 'b, 'a, 'gcx, 'tcx> 
         //
         // (Or if you prefer, all the *other* iterations over loans
         // only consider loans that are in scope of some given
-        // CodeExtent)
+        // region::Scope)
         //
         // The (currently skeletal) code here does not encode such a
         // distinction, which means it is almost certainly over

--- a/src/librustc_mir/build/cfg.rs
+++ b/src/librustc_mir/build/cfg.rs
@@ -14,7 +14,7 @@
 //! Routines for manipulating the control-flow graph.
 
 use build::CFG;
-use rustc::middle::region::CodeExtent;
+use rustc::middle::region;
 use rustc::mir::*;
 
 impl<'tcx> CFG<'tcx> {
@@ -47,10 +47,10 @@ impl<'tcx> CFG<'tcx> {
     pub fn push_end_region(&mut self,
                            block: BasicBlock,
                            source_info: SourceInfo,
-                           extent: CodeExtent) {
+                           region_scope: region::Scope) {
         self.push(block, Statement {
             source_info,
-            kind: StatementKind::EndRegion(extent),
+            kind: StatementKind::EndRegion(region_scope),
         });
     }
 

--- a/src/librustc_mir/build/expr/as_constant.rs
+++ b/src/librustc_mir/build/expr/as_constant.rs
@@ -29,7 +29,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         let Expr { ty, temp_lifetime: _, span, kind }
             = expr;
         match kind {
-            ExprKind::Scope { extent: _, value } =>
+            ExprKind::Scope { region_scope: _, value } =>
                 this.as_constant(value),
             ExprKind::Literal { literal } =>
                 Constant { span: span, ty: ty, literal: literal },

--- a/src/librustc_mir/build/expr/as_lvalue.rs
+++ b/src/librustc_mir/build/expr/as_lvalue.rs
@@ -39,8 +39,10 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         let expr_span = expr.span;
         let source_info = this.source_info(expr_span);
         match expr.kind {
-            ExprKind::Scope { extent, value } => {
-                this.in_scope((extent, source_info), block, |this| this.as_lvalue(block, value))
+            ExprKind::Scope { region_scope, value } => {
+                this.in_scope((region_scope, source_info), block, |this| {
+                    this.as_lvalue(block, value)
+                })
             }
             ExprKind::Field { lhs, name } => {
                 let lvalue = unpack!(block = this.as_lvalue(block, lhs));
@@ -56,7 +58,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 let (usize_ty, bool_ty) = (this.hir.usize_ty(), this.hir.bool_ty());
 
                 let slice = unpack!(block = this.as_lvalue(block, lhs));
-                // extent=None so lvalue indexes live forever. They are scalars so they
+                // region_scope=None so lvalue indexes live forever. They are scalars so they
                 // do not need storage annotations, and they are often copied between
                 // places.
                 let idx = unpack!(block = this.as_operand(block, None, index));

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -38,9 +38,9 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         let source_info = this.source_info(expr_span);
 
         match expr.kind {
-            ExprKind::Scope { extent, value } => {
-                let extent = (extent, source_info);
-                this.in_scope(extent, block, |this| this.into(destination, block, value))
+            ExprKind::Scope { region_scope, value } => {
+                let region_scope = (region_scope, source_info);
+                this.in_scope(region_scope, block, |this| this.into(destination, block, value))
             }
             ExprKind::Block { body: ast_block } => {
                 this.ast_block(destination, block, ast_block, source_info)

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -203,8 +203,8 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         let local_id = self.var_indices[&var];
         let var_ty = self.local_decls[local_id].ty;
         let hir_id = self.hir.tcx().hir.node_to_hir_id(var);
-        let extent = self.hir.region_maps.var_scope(hir_id.local_id);
-        self.schedule_drop(span, extent, &Lvalue::Local(local_id), var_ty);
+        let region_scope = self.hir.region_scope_tree.var_scope(hir_id.local_id);
+        self.schedule_drop(span, region_scope, &Lvalue::Local(local_id), var_ty);
     }
 
     pub fn visit_bindings<F>(&mut self, pattern: &Pattern<'tcx>, f: &mut F)

--- a/src/librustc_mir/build/scope.rs
+++ b/src/librustc_mir/build/scope.rs
@@ -12,7 +12,7 @@
 Managing the scope stack. The scopes are tied to lexical scopes, so as
 we descend the HAIR, we push a scope on the stack, translate ite
 contents, and then pop it off. Every scope is named by a
-`CodeExtent`.
+`region::Scope`.
 
 ### SEME Regions
 
@@ -23,7 +23,7 @@ via a `break` or `return` or just by fallthrough, that marks an exit
 from the scope. Each lexical scope thus corresponds to a single-entry,
 multiple-exit (SEME) region in the control-flow graph.
 
-For now, we keep a mapping from each `CodeExtent` to its
+For now, we keep a mapping from each `region::Scope` to its
 corresponding SEME region for later reference (see caveat in next
 paragraph). This is because region scopes are tied to
 them. Eventually, when we shift to non-lexical lifetimes, there should
@@ -88,7 +88,7 @@ should go to.
 */
 
 use build::{BlockAnd, BlockAndExtension, Builder, CFG};
-use rustc::middle::region::CodeExtent;
+use rustc::middle::region;
 use rustc::ty::Ty;
 use rustc::mir::*;
 use rustc::mir::transform::MirSource;
@@ -101,11 +101,11 @@ pub struct Scope<'tcx> {
     /// The visibility scope this scope was created in.
     visibility_scope: VisibilityScope,
 
-    /// the extent of this scope within source code.
-    extent: CodeExtent,
+    /// the region span of this scope within source code.
+    region_scope: region::Scope,
 
-    /// the span of that extent
-    extent_span: Span,
+    /// the span of that region_scope
+    region_scope_span: Span,
 
     /// Whether there's anything to do for the cleanup path, that is,
     /// when unwinding through this scope. This includes destructors,
@@ -125,7 +125,7 @@ pub struct Scope<'tcx> {
     drops: Vec<DropData<'tcx>>,
 
     /// The cache for drop chain on “normal” exit into a particular BasicBlock.
-    cached_exits: FxHashMap<(BasicBlock, CodeExtent), BasicBlock>,
+    cached_exits: FxHashMap<(BasicBlock, region::Scope), BasicBlock>,
 
     /// The cache for drop chain on "generator drop" exit.
     cached_generator_drop: Option<BasicBlock>,
@@ -165,8 +165,8 @@ enum DropKind {
 
 #[derive(Clone, Debug)]
 pub struct BreakableScope<'tcx> {
-    /// Extent of the loop
-    pub extent: CodeExtent,
+    /// Region scope of the loop
+    pub region_scope: region::Scope,
     /// Where the body of the loop begins. `None` if block
     pub continue_block: Option<BasicBlock>,
     /// Block to branch into when the loop or block terminates (either by being `break`-en out
@@ -269,9 +269,9 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                                     f: F) -> R
         where F: FnOnce(&mut Builder<'a, 'gcx, 'tcx>) -> R
     {
-        let extent = self.topmost_scope();
+        let region_scope = self.topmost_scope();
         let scope = BreakableScope {
-            extent,
+            region_scope,
             continue_block: loop_block,
             break_block,
             break_destination,
@@ -279,41 +279,41 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         self.breakable_scopes.push(scope);
         let res = f(self);
         let breakable_scope = self.breakable_scopes.pop().unwrap();
-        assert!(breakable_scope.extent == extent);
+        assert!(breakable_scope.region_scope == region_scope);
         res
     }
 
     pub fn in_opt_scope<F, R>(&mut self,
-                              opt_extent: Option<(CodeExtent, SourceInfo)>,
+                              opt_scope: Option<(region::Scope, SourceInfo)>,
                               mut block: BasicBlock,
                               f: F)
                               -> BlockAnd<R>
         where F: FnOnce(&mut Builder<'a, 'gcx, 'tcx>) -> BlockAnd<R>
     {
-        debug!("in_opt_scope(opt_extent={:?}, block={:?})", opt_extent, block);
-        if let Some(extent) = opt_extent { self.push_scope(extent); }
+        debug!("in_opt_scope(opt_scope={:?}, block={:?})", opt_scope, block);
+        if let Some(region_scope) = opt_scope { self.push_scope(region_scope); }
         let rv = unpack!(block = f(self));
-        if let Some(extent) = opt_extent {
-            unpack!(block = self.pop_scope(extent, block));
+        if let Some(region_scope) = opt_scope {
+            unpack!(block = self.pop_scope(region_scope, block));
         }
-        debug!("in_scope: exiting opt_extent={:?} block={:?}", opt_extent, block);
+        debug!("in_scope: exiting opt_scope={:?} block={:?}", opt_scope, block);
         block.and(rv)
     }
 
     /// Convenience wrapper that pushes a scope and then executes `f`
     /// to build its contents, popping the scope afterwards.
     pub fn in_scope<F, R>(&mut self,
-                          extent: (CodeExtent, SourceInfo),
+                          region_scope: (region::Scope, SourceInfo),
                           mut block: BasicBlock,
                           f: F)
                           -> BlockAnd<R>
         where F: FnOnce(&mut Builder<'a, 'gcx, 'tcx>) -> BlockAnd<R>
     {
-        debug!("in_scope(extent={:?}, block={:?})", extent, block);
-        self.push_scope(extent);
+        debug!("in_scope(region_scope={:?}, block={:?})", region_scope, block);
+        self.push_scope(region_scope);
         let rv = unpack!(block = f(self));
-        unpack!(block = self.pop_scope(extent, block));
-        debug!("in_scope: exiting extent={:?} block={:?}", extent, block);
+        unpack!(block = self.pop_scope(region_scope, block));
+        debug!("in_scope: exiting region_scope={:?} block={:?}", region_scope, block);
         block.and(rv)
     }
 
@@ -321,13 +321,13 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     /// scope and call `pop_scope` afterwards. Note that these two
     /// calls must be paired; using `in_scope` as a convenience
     /// wrapper maybe preferable.
-    pub fn push_scope(&mut self, extent: (CodeExtent, SourceInfo)) {
-        debug!("push_scope({:?})", extent);
+    pub fn push_scope(&mut self, region_scope: (region::Scope, SourceInfo)) {
+        debug!("push_scope({:?})", region_scope);
         let vis_scope = self.visibility_scope;
         self.scopes.push(Scope {
             visibility_scope: vis_scope,
-            extent: extent.0,
-            extent_span: extent.1.span,
+            region_scope: region_scope.0,
+            region_scope_span: region_scope.1.span,
             needs_cleanup: false,
             drops: vec![],
             cached_generator_drop: None,
@@ -335,14 +335,14 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         });
     }
 
-    /// Pops a scope, which should have extent `extent`, adding any
-    /// drops onto the end of `block` that are needed.  This must
-    /// match 1-to-1 with `push_scope`.
+    /// Pops a scope, which should have region scope `region_scope`,
+    /// adding any drops onto the end of `block` that are needed.
+    /// This must match 1-to-1 with `push_scope`.
     pub fn pop_scope(&mut self,
-                     extent: (CodeExtent, SourceInfo),
+                     region_scope: (region::Scope, SourceInfo),
                      mut block: BasicBlock)
                      -> BlockAnd<()> {
-        debug!("pop_scope({:?}, {:?})", extent, block);
+        debug!("pop_scope({:?}, {:?})", region_scope, block);
         // If we are emitting a `drop` statement, we need to have the cached
         // diverge cleanup pads ready in case that drop panics.
         let may_panic =
@@ -351,7 +351,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             self.diverge_cleanup();
         }
         let scope = self.scopes.pop().unwrap();
-        assert_eq!(scope.extent, extent.0);
+        assert_eq!(scope.region_scope, region_scope.0);
         unpack!(block = build_scope_drops(&mut self.cfg,
                                           &scope,
                                           &self.scopes,
@@ -359,25 +359,27 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                                           self.arg_count,
                                           false));
 
-        self.cfg.push_end_region(block, extent.1, scope.extent);
+        self.cfg.push_end_region(block, region_scope.1, scope.region_scope);
         block.unit()
     }
 
 
     /// Branch out of `block` to `target`, exiting all scopes up to
-    /// and including `extent`.  This will insert whatever drops are
+    /// and including `region_scope`.  This will insert whatever drops are
     /// needed, as well as tracking this exit for the SEME region. See
     /// module comment for details.
     pub fn exit_scope(&mut self,
                       span: Span,
-                      extent: (CodeExtent, SourceInfo),
+                      region_scope: (region::Scope, SourceInfo),
                       mut block: BasicBlock,
                       target: BasicBlock) {
-        debug!("exit_scope(extent={:?}, block={:?}, target={:?})", extent, block, target);
-        let scope_count = 1 + self.scopes.iter().rev().position(|scope| scope.extent == extent.0)
-                                                      .unwrap_or_else(||{
-            span_bug!(span, "extent {:?} does not enclose", extent)
-        });
+        debug!("exit_scope(region_scope={:?}, block={:?}, target={:?})",
+               region_scope, block, target);
+        let scope_count = 1 + self.scopes.iter().rev()
+            .position(|scope| scope.region_scope == region_scope.0)
+            .unwrap_or_else(|| {
+                span_bug!(span, "region_scope {:?} does not enclose", region_scope)
+            });
         let len = self.scopes.len();
         assert!(scope_count < len, "should not use `exit_scope` to pop ALL scopes");
 
@@ -393,7 +395,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         let mut rest = &mut self.scopes[(len - scope_count)..];
         while let Some((scope, rest_)) = {rest}.split_last_mut() {
             rest = rest_;
-            block = if let Some(&e) = scope.cached_exits.get(&(target, extent.0)) {
+            block = if let Some(&e) = scope.cached_exits.get(&(target, region_scope.0)) {
                 self.cfg.terminate(block, scope.source_info(span),
                                    TerminatorKind::Goto { target: e });
                 return;
@@ -401,7 +403,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 let b = self.cfg.start_new_block();
                 self.cfg.terminate(block, scope.source_info(span),
                                    TerminatorKind::Goto { target: b });
-                scope.cached_exits.insert((target, extent.0), b);
+                scope.cached_exits.insert((target, region_scope.0), b);
                 b
             };
             unpack!(block = build_scope_drops(&mut self.cfg,
@@ -412,7 +414,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                                               false));
 
             // End all regions for scopes out of which we are breaking.
-            self.cfg.push_end_region(block, extent.1, scope.extent);
+            self.cfg.push_end_region(block, region_scope.1, scope.region_scope);
         }
         }
         let scope = &self.scopes[len - scope_count];
@@ -461,7 +463,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                                               true));
 
             // End all regions for scopes out of which we are breaking.
-            self.cfg.push_end_region(block, src_info, scope.extent);
+            self.cfg.push_end_region(block, src_info, scope.region_scope);
         }
 
         self.cfg.terminate(block, src_info, TerminatorKind::GeneratorDrop);
@@ -486,12 +488,12 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     /// resolving `break` and `continue`.
     pub fn find_breakable_scope(&mut self,
                            span: Span,
-                           label: CodeExtent)
+                           label: region::Scope)
                            -> &mut BreakableScope<'tcx> {
         // find the loop-scope with the correct id
         self.breakable_scopes.iter_mut()
             .rev()
-            .filter(|breakable_scope| breakable_scope.extent == label)
+            .filter(|breakable_scope| breakable_scope.region_scope == label)
             .next()
             .unwrap_or_else(|| span_bug!(span, "no enclosing breakable scope found"))
     }
@@ -504,23 +506,23 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         }
     }
 
-    /// Returns the extent of the scope which should be exited by a
+    /// Returns the `region::Scope` of the scope which should be exited by a
     /// return.
-    pub fn extent_of_return_scope(&self) -> CodeExtent {
+    pub fn region_scope_of_return_scope(&self) -> region::Scope {
         // The outermost scope (`scopes[0]`) will be the `CallSiteScope`.
         // We want `scopes[1]`, which is the `ParameterScope`.
         assert!(self.scopes.len() >= 2);
-        assert!(match self.scopes[1].extent {
-            CodeExtent::ParameterScope(_) => true,
+        assert!(match self.scopes[1].region_scope {
+            region::Scope::Arguments(_) => true,
             _ => false,
         });
-        self.scopes[1].extent
+        self.scopes[1].region_scope
     }
 
     /// Returns the topmost active scope, which is known to be alive until
     /// the next scope expression.
-    pub fn topmost_scope(&self) -> CodeExtent {
-        self.scopes.last().expect("topmost_scope: no scopes present").extent
+    pub fn topmost_scope(&self) -> region::Scope {
+        self.scopes.last().expect("topmost_scope: no scopes present").region_scope
     }
 
     /// Returns the scope that we should use as the lifetime of an
@@ -545,7 +547,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     ///
     /// When building statics/constants, returns `None` since
     /// intermediate values do not have to be dropped in that case.
-    pub fn local_scope(&self) -> Option<CodeExtent> {
+    pub fn local_scope(&self) -> Option<region::Scope> {
         match self.hir.src {
             MirSource::Const(_) |
             MirSource::Static(..) =>
@@ -562,10 +564,10 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     // Scheduling drops
     // ================
     /// Indicates that `lvalue` should be dropped on exit from
-    /// `extent`.
+    /// `region_scope`.
     pub fn schedule_drop(&mut self,
                          span: Span,
-                         extent: CodeExtent,
+                         region_scope: region::Scope,
                          lvalue: &Lvalue<'tcx>,
                          lvalue_ty: Ty<'tcx>) {
         let needs_drop = self.hir.needs_drop(lvalue_ty);
@@ -580,7 +582,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         };
 
         for scope in self.scopes.iter_mut().rev() {
-            let this_scope = scope.extent == extent;
+            let this_scope = scope.region_scope == region_scope;
             // When building drops, we try to cache chains of drops in such a way so these drops
             // could be reused by the drops which would branch into the cached (already built)
             // blocks.  This, however, means that whenever we add a drop into a scope which already
@@ -633,9 +635,10 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 if let DropKind::Value { .. } = drop_kind {
                     scope.needs_cleanup = true;
                 }
-                let extent_span = extent.span(self.hir.tcx(), &self.hir.region_maps);
+                let region_scope_span = region_scope.span(self.hir.tcx(),
+                                                          &self.hir.region_scope_tree);
                 // Attribute scope exit drops to scope's closing brace
-                let scope_end = extent_span.with_lo(extent_span.hi());
+                let scope_end = region_scope_span.with_lo(region_scope_span.hi());
                 scope.drops.push(DropData {
                     span: scope_end,
                     location: lvalue.clone(),
@@ -644,7 +647,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 return;
             }
         }
-        span_bug!(span, "extent {:?} not in scope to drop {:?}", extent, lvalue);
+        span_bug!(span, "region scope {:?} not in scope to drop {:?}", region_scope, lvalue);
     }
 
     // Other
@@ -691,7 +694,8 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         };
 
         for scope in scopes.iter_mut() {
-            target = build_diverge_scope(cfg, scope.extent_span, scope, target, generator_drop);
+            target = build_diverge_scope(cfg, scope.region_scope_span,
+                                         scope, target, generator_drop);
         }
         Some(target)
     }
@@ -889,7 +893,7 @@ fn build_diverge_scope<'a, 'gcx, 'tcx>(cfg: &mut CFG<'tcx>,
     // becomes trivial goto after pass that removes all EndRegions.)
     {
         let block = cfg.start_new_cleanup_block();
-        cfg.push_end_region(block, source_info(span), scope.extent);
+        cfg.push_end_region(block, source_info(span), scope.region_scope);
         cfg.terminate(block, source_info(span), TerminatorKind::Goto { target: target });
         target = block
     }

--- a/src/librustc_mir/dataflow/impls/borrows.rs
+++ b/src/librustc_mir/dataflow/impls/borrows.rs
@@ -107,7 +107,7 @@ impl<'a, 'tcx> BitDenotation for Borrows<'a, 'tcx> {
         self.borrows.len()
     }
     fn start_block_effect(&self, _sets: &mut BlockSets<BorrowIndex>)  {
-        // no borrows of code extents have been taken prior to
+        // no borrows of code region_scopes have been taken prior to
         // function execution, so this method has no effect on
         // `_sets`.
     }
@@ -121,9 +121,9 @@ impl<'a, 'tcx> BitDenotation for Borrows<'a, 'tcx> {
             panic!("could not find statement at location {:?}");
         });
         match stmt.kind {
-            mir::StatementKind::EndRegion(extent) => {
-                let borrow_indexes = self.region_map.get(&ReScope(extent)).unwrap_or_else(|| {
-                    panic!("could not find BorrowIndexs for code-extent {:?}", extent);
+            mir::StatementKind::EndRegion(region_scope) => {
+                let borrow_indexes = self.region_map.get(&ReScope(region_scope)).unwrap_or_else(|| {
+                    panic!("could not find BorrowIndexs for region scope {:?}", region_scope);
                 });
 
                 for idx in borrow_indexes { sets.kill(&idx); }
@@ -153,7 +153,7 @@ impl<'a, 'tcx> BitDenotation for Borrows<'a, 'tcx> {
     fn terminator_effect(&self,
                          _sets: &mut BlockSets<BorrowIndex>,
                          _location: Location) {
-        // no terminators start nor end code extents.
+        // no terminators start nor end region scopes.
     }
 
     fn propagate_call_return(&self,
@@ -161,7 +161,7 @@ impl<'a, 'tcx> BitDenotation for Borrows<'a, 'tcx> {
                              _call_bb: mir::BasicBlock,
                              _dest_bb: mir::BasicBlock,
                              _dest_lval: &mir::Lvalue) {
-        // there are no effects on the extents from method calls.
+        // there are no effects on the region scopes from method calls.
     }
 }
 

--- a/src/librustc_mir/hair/cx/block.rs
+++ b/src/librustc_mir/hair/cx/block.rs
@@ -11,7 +11,7 @@
 use hair::*;
 use hair::cx::Cx;
 use hair::cx::to_ref::ToRef;
-use rustc::middle::region::{BlockRemainder, CodeExtent};
+use rustc::middle::region::{self, BlockRemainder};
 use rustc::hir;
 
 impl<'tcx> Mirror<'tcx> for &'tcx hir::Block {
@@ -21,11 +21,12 @@ impl<'tcx> Mirror<'tcx> for &'tcx hir::Block {
         // We have to eagerly translate the "spine" of the statements
         // in order to get the lexical scoping correctly.
         let stmts = mirror_stmts(cx, self.hir_id.local_id, &*self.stmts);
-        let opt_destruction_extent = cx.region_maps.opt_destruction_extent(self.hir_id.local_id);
+        let opt_destruction_scope =
+            cx.region_scope_tree.opt_destruction_scope(self.hir_id.local_id);
         Block {
             targeted_by_break: self.targeted_by_break,
-            extent: CodeExtent::Misc(self.hir_id.local_id),
-            opt_destruction_extent,
+            region_scope: region::Scope::Node(self.hir_id.local_id),
+            opt_destruction_scope,
             span: self.span,
             stmts,
             expr: self.expr.to_ref(),
@@ -40,16 +41,16 @@ fn mirror_stmts<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
     let mut result = vec![];
     for (index, stmt) in stmts.iter().enumerate() {
         let hir_id = cx.tcx.hir.node_to_hir_id(stmt.node.id());
-        let opt_dxn_ext = cx.region_maps.opt_destruction_extent(hir_id.local_id);
+        let opt_dxn_ext = cx.region_scope_tree.opt_destruction_scope(hir_id.local_id);
         match stmt.node {
             hir::StmtExpr(ref expr, _) |
             hir::StmtSemi(ref expr, _) => {
                 result.push(StmtRef::Mirror(Box::new(Stmt {
                     kind: StmtKind::Expr {
-                        scope: CodeExtent::Misc(hir_id.local_id),
+                        scope: region::Scope::Node(hir_id.local_id),
                         expr: expr.to_ref(),
                     },
-                    opt_destruction_extent: opt_dxn_ext,
+                    opt_destruction_scope: opt_dxn_ext,
                 })))
             }
             hir::StmtDecl(ref decl, _) => {
@@ -58,7 +59,7 @@ fn mirror_stmts<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                         // ignore for purposes of the MIR
                     }
                     hir::DeclLocal(ref local) => {
-                        let remainder_extent = CodeExtent::Remainder(BlockRemainder {
+                        let remainder_scope = region::Scope::Remainder(BlockRemainder {
                             block: block_id,
                             first_statement_index: index as u32,
                         });
@@ -69,12 +70,12 @@ fn mirror_stmts<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                                                         &local.pat);
                         result.push(StmtRef::Mirror(Box::new(Stmt {
                             kind: StmtKind::Let {
-                                remainder_scope: remainder_extent,
-                                init_scope: CodeExtent::Misc(hir_id.local_id),
+                                remainder_scope: remainder_scope,
+                                init_scope: region::Scope::Node(hir_id.local_id),
                                 pattern,
                                 initializer: local.init.to_ref(),
                             },
-                            opt_destruction_extent: opt_dxn_ext,
+                            opt_destruction_scope: opt_dxn_ext,
                         })));
                     }
                 }
@@ -88,7 +89,7 @@ pub fn to_expr_ref<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                                    block: &'tcx hir::Block)
                                    -> ExprRef<'tcx> {
     let block_ty = cx.tables().node_id_to_type(block.hir_id);
-    let temp_lifetime = cx.region_maps.temporary_scope(block.hir_id.local_id);
+    let temp_lifetime = cx.region_scope_tree.temporary_scope(block.hir_id.local_id);
     let expr = Expr {
         ty: block_ty,
         temp_lifetime,

--- a/src/librustc_mir/hair/cx/mod.rs
+++ b/src/librustc_mir/hair/cx/mod.rs
@@ -22,7 +22,7 @@ use rustc_const_eval::ConstContext;
 use rustc_data_structures::indexed_vec::Idx;
 use rustc::hir::def_id::DefId;
 use rustc::hir::map::blocks::FnLikeNode;
-use rustc::middle::region::RegionMaps;
+use rustc::middle::region;
 use rustc::infer::InferCtxt;
 use rustc::ty::subst::Subst;
 use rustc::ty::{self, Ty, TyCtxt};
@@ -42,7 +42,7 @@ pub struct Cx<'a, 'gcx: 'a + 'tcx, 'tcx: 'a> {
     /// Identity `Substs` for use with const-evaluation.
     pub identity_substs: &'gcx Substs<'gcx>,
 
-    pub region_maps: Rc<RegionMaps>,
+    pub region_scope_tree: Rc<region::ScopeTree>,
     pub tables: &'a ty::TypeckTables<'gcx>,
 
     /// This is `Constness::Const` if we are compiling a `static`,
@@ -92,7 +92,7 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
             infcx,
             param_env: tcx.param_env(src_def_id),
             identity_substs: Substs::identity_for_item(tcx.global_tcx(), src_def_id),
-            region_maps: tcx.region_maps(src_def_id),
+            region_scope_tree: tcx.region_scope_tree(src_def_id),
             tables: tcx.typeck_tables_of(src_def_id),
             constness,
             src,

--- a/src/librustc_mir/transform/add_validation.rs
+++ b/src/librustc_mir/transform/add_validation.rs
@@ -18,7 +18,7 @@ use rustc::ty::{self, TyCtxt, RegionKind};
 use rustc::hir;
 use rustc::mir::*;
 use rustc::mir::transform::{MirPass, MirSource};
-use rustc::middle::region::CodeExtent;
+use rustc::middle::region;
 
 pub struct AddValidation;
 
@@ -27,7 +27,7 @@ fn lval_context<'a, 'tcx, D>(
     lval: &Lvalue<'tcx>,
     local_decls: &D,
     tcx: TyCtxt<'a, 'tcx, 'tcx>
-) -> (Option<CodeExtent>, hir::Mutability)
+) -> (Option<region::Scope>, hir::Mutability)
     where D: HasLocalDecls<'tcx>
 {
     use rustc::mir::Lvalue::*;

--- a/src/librustc_mir/transform/clean_end_regions.rs
+++ b/src/librustc_mir/transform/clean_end_regions.rs
@@ -21,7 +21,7 @@
 
 use rustc_data_structures::fx::FxHashSet;
 
-use rustc::middle::region::CodeExtent;
+use rustc::middle::region;
 use rustc::mir::transform::{MirPass, MirSource};
 use rustc::mir::{BasicBlock, Location, Mir, Rvalue, Statement, StatementKind};
 use rustc::mir::visit::{MutVisitor, Visitor, Lookup};
@@ -30,11 +30,11 @@ use rustc::ty::{Ty, RegionKind, TyCtxt};
 pub struct CleanEndRegions;
 
 struct GatherBorrowedRegions {
-    seen_regions: FxHashSet<CodeExtent>,
+    seen_regions: FxHashSet<region::Scope>,
 }
 
 struct DeleteTrivialEndRegions<'a> {
-    seen_regions: &'a FxHashSet<CodeExtent>,
+    seen_regions: &'a FxHashSet<region::Scope>,
 }
 
 impl MirPass for CleanEndRegions {
@@ -84,8 +84,8 @@ impl<'a, 'tcx> MutVisitor<'tcx> for DeleteTrivialEndRegions<'a> {
                        location: Location) {
         let mut delete_it = false;
 
-        if let StatementKind::EndRegion(ref extent) = statement.kind {
-            if !self.seen_regions.contains(extent) {
+        if let StatementKind::EndRegion(ref region_scope) = statement.kind {
+            if !self.seen_regions.contains(region_scope) {
                 delete_it = true;
             }
         }

--- a/src/librustc_passes/consts.rs
+++ b/src/librustc_passes/consts.rs
@@ -143,8 +143,8 @@ impl<'a, 'tcx> Visitor<'tcx> for CheckCrateVisitor<'a, 'tcx> {
 
         let tcx = self.tcx;
         let param_env = self.param_env;
-        let region_maps = self.tcx.region_maps(item_def_id);
-        euv::ExprUseVisitor::new(self, tcx, param_env, &region_maps, self.tables)
+        let region_scope_tree = self.tcx.region_scope_tree(item_def_id);
+        euv::ExprUseVisitor::new(self, tcx, param_env, &region_scope_tree, self.tables)
             .consume_body(body);
 
         self.visit_body(body);

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -11,7 +11,7 @@
 use rustc::hir::{self, ImplItemKind, TraitItemKind};
 use rustc::infer::{self, InferOk};
 use rustc::middle::free_region::FreeRegionMap;
-use rustc::middle::region::RegionMaps;
+use rustc::middle::region;
 use rustc::ty::{self, TyCtxt};
 use rustc::traits::{self, ObligationCause, ObligationCauseCode, Reveal};
 use rustc::ty::error::{ExpectedFound, TypeError};
@@ -340,10 +340,12 @@ fn compare_predicate_entailment<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             // region obligations that get overlooked.  The right
             // thing to do is the code below. But we keep this old
             // pass around temporarily.
-            let region_maps = RegionMaps::default();
+            let region_scope_tree = region::ScopeTree::default();
             let mut free_regions = FreeRegionMap::new();
             free_regions.relate_free_regions_from_predicates(&param_env.caller_bounds);
-            infcx.resolve_regions_and_report_errors(impl_m.def_id, &region_maps, &free_regions);
+            infcx.resolve_regions_and_report_errors(impl_m.def_id,
+                                                    &region_scope_tree,
+                                                    &free_regions);
         } else {
             let fcx = FnCtxt::new(&inh, param_env, impl_m_node_id);
             fcx.regionck_item(impl_m_node_id, impl_m_span, &[]);

--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -13,7 +13,7 @@ use check::regionck::RegionCtxt;
 use hir::def_id::DefId;
 use middle::free_region::FreeRegionMap;
 use rustc::infer::{self, InferOk};
-use rustc::middle::region::{self, RegionMaps};
+use rustc::middle::region;
 use rustc::ty::subst::{Subst, Substs};
 use rustc::ty::{self, Ty, TyCtxt};
 use rustc::traits::{self, ObligationCause};
@@ -114,9 +114,9 @@ fn ensure_drop_params_and_item_params_correspond<'a, 'tcx>(
             return Err(ErrorReported);
         }
 
-        let region_maps = RegionMaps::default();
+        let region_scope_tree = region::ScopeTree::default();
         let free_regions = FreeRegionMap::new();
-        infcx.resolve_regions_and_report_errors(drop_impl_did, &region_maps, &free_regions);
+        infcx.resolve_regions_and_report_errors(drop_impl_did, &region_scope_tree, &free_regions);
         Ok(())
     })
 }
@@ -270,14 +270,14 @@ pub fn check_safety_of_destructor_if_necessary<'a, 'gcx, 'tcx>(
     rcx: &mut RegionCtxt<'a, 'gcx, 'tcx>,
     ty: ty::Ty<'tcx>,
     span: Span,
-    scope: region::CodeExtent)
+    scope: region::Scope)
     -> Result<(), ErrorReported>
 {
     debug!("check_safety_of_destructor_if_necessary typ: {:?} scope: {:?}",
            ty, scope);
 
 
-    let parent_scope = match rcx.region_maps.opt_encl_scope(scope) {
+    let parent_scope = match rcx.region_scope_tree.opt_encl_scope(scope) {
         Some(parent_scope) => parent_scope,
         // If no enclosing scope, then it must be the root scope
         // which cannot be outlived.

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -91,7 +91,7 @@ use hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use rustc_back::slice::ref_slice;
 use rustc::infer::{self, InferCtxt, InferOk, RegionVariableOrigin};
 use rustc::infer::type_variable::{TypeVariableOrigin};
-use rustc::middle::region::CodeExtent;
+use rustc::middle::region;
 use rustc::ty::subst::{Kind, Subst, Substs};
 use rustc::traits::{self, FulfillmentContext, ObligationCause, ObligationCauseCode};
 use rustc::ty::{ParamTy, LvaluePreference, NoPreference, PreferMutLvalue};
@@ -608,7 +608,7 @@ impl<'a, 'gcx, 'tcx> Inherited<'a, 'gcx, 'tcx> {
         let body_id = item_id.and_then(|id| tcx.hir.maybe_body_owned_by(id));
         let implicit_region_bound = body_id.map(|body_id| {
             let body = tcx.hir.body(body_id);
-            tcx.mk_region(ty::ReScope(CodeExtent::CallSiteScope(body.value.hir_id.local_id)))
+            tcx.mk_region(ty::ReScope(region::Scope::CallSite(body.value.hir_id.local_id)))
         });
 
         Inherited {

--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -152,7 +152,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
         {
             let body_owner_def_id = self.tcx.hir.body_owner_def_id(body.id());
-            let region_maps = &self.tcx.region_maps(body_owner_def_id);
+            let region_scope_tree = &self.tcx.region_scope_tree(body_owner_def_id);
             let mut delegate = InferBorrowKind {
                 fcx: self,
                 adjust_closure_kinds: FxHashMap(),
@@ -161,7 +161,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             euv::ExprUseVisitor::with_infer(&mut delegate,
                                             &self.infcx,
                                             self.param_env,
-                                            region_maps,
+                                            region_scope_tree,
                                             &self.tables.borrow())
                 .consume_body(body);
 

--- a/src/librustc_typeck/coherence/builtin.rs
+++ b/src/librustc_typeck/coherence/builtin.rs
@@ -12,7 +12,7 @@
 //! up data structures required by type-checking/translation.
 
 use rustc::middle::free_region::FreeRegionMap;
-use rustc::middle::region::RegionMaps;
+use rustc::middle::region;
 use rustc::middle::lang_items::UnsizeTraitLangItem;
 
 use rustc::traits::{self, ObligationCause};
@@ -390,10 +390,10 @@ pub fn coerce_unsized_info<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         }
 
         // Finally, resolve all regions.
-        let region_maps = RegionMaps::default();
+        let region_scope_tree = region::ScopeTree::default();
         let mut free_regions = FreeRegionMap::new();
         free_regions.relate_free_regions_from_predicates(&param_env.caller_bounds);
-        infcx.resolve_regions_and_report_errors(impl_did, &region_maps, &free_regions);
+        infcx.resolve_regions_and_report_errors(impl_did, &region_scope_tree, &free_regions);
 
         CoerceUnsizedInfo {
             custom_kind: kind

--- a/src/test/mir-opt/end_region_1.rs
+++ b/src/test/mir-opt/end_region_1.rs
@@ -22,16 +22,16 @@ fn main() {
 // START rustc.node4.SimplifyCfg-qualify-consts.after.mir
 //     let mut _0: ();
 //     let _1: i32;
-//     let _2: &'10_1rce i32;
+//     let _2: &'10_1rs i32;
 //
 //     bb0: {
 //         StorageLive(_1);
 //         _1 = const 3i32;
 //         StorageLive(_2);
-//         _2 = &'10_1rce _1;
+//         _2 = &'10_1rs _1;
 //         _0 = ();
 //         StorageDead(_2);
-//         EndRegion('10_1rce);
+//         EndRegion('10_1rs);
 //         StorageDead(_1);
 //         return;
 //     }

--- a/src/test/mir-opt/end_region_2.rs
+++ b/src/test/mir-opt/end_region_2.rs
@@ -27,8 +27,8 @@ fn main() {
 // START rustc.node4.SimplifyCfg-qualify-consts.after.mir
 //     let mut _0: ();
 //     let _2: bool;
-//     let _3: &'23_1rce bool;
-//     let _7: &'23_3rce bool;
+//     let _3: &'23_1rs bool;
+//     let _7: &'23_3rs bool;
 //     let mut _4: ();
 //     let mut _5: bool;
 //     bb0: {
@@ -38,7 +38,7 @@ fn main() {
 //         StorageLive(_2);
 //         _2 = const true;
 //         StorageLive(_3);
-//         _3 = &'23_1rce _2;
+//         _3 = &'23_1rs _2;
 //         StorageLive(_5);
 //         _5 = _2;
 //         switchInt(_5) -> [0u8: bb3, otherwise: bb2];
@@ -47,19 +47,19 @@ fn main() {
 //         _0 = ();
 //         StorageDead(_5);
 //         StorageDead(_3);
-//         EndRegion('23_1rce);
+//         EndRegion('23_1rs);
 //         StorageDead(_2);
 //         return;
 //     }
 //     bb3: {
 //         StorageDead(_5);
 //         StorageLive(_7);
-//         _7 = &'23_3rce _2;
+//         _7 = &'23_3rs _2;
 //         _1 = ();
 //         StorageDead(_7);
-//         EndRegion('23_3rce);
+//         EndRegion('23_3rs);
 //         StorageDead(_3);
-//         EndRegion('23_1rce);
+//         EndRegion('23_1rs);
 //         StorageDead(_2);
 //         goto -> bb1;
 //     }

--- a/src/test/mir-opt/end_region_3.rs
+++ b/src/test/mir-opt/end_region_3.rs
@@ -28,8 +28,8 @@ fn main() {
 // START rustc.node4.SimplifyCfg-qualify-consts.after.mir
 //     let mut _0: ();
 //     let mut _1: bool;
-//     let _3: &'26_1rce bool;
-//     let _7: &'26_3rce bool;
+//     let _3: &'26_1rs bool;
+//     let _7: &'26_3rs bool;
 //     let mut _2: ();
 //     let mut _4: ();
 //     let mut _5: bool;
@@ -41,7 +41,7 @@ fn main() {
 //     bb1: {
 //         _1 = const true;
 //         StorageLive(_3);
-//         _3 = &'26_1rce _1;
+//         _3 = &'26_1rs _1;
 //         StorageLive(_5);
 //         _5 = _1;
 //         switchInt(_5) -> [0u8: bb3, otherwise: bb2];
@@ -50,7 +50,7 @@ fn main() {
 //         _0 = ();
 //         StorageDead(_5);
 //         StorageDead(_3);
-//         EndRegion('26_1rce);
+//         EndRegion('26_1rs);
 //         StorageDead(_1);
 //         return;
 //     }
@@ -58,12 +58,12 @@ fn main() {
 //         _4 = ();
 //         StorageDead(_5);
 //         StorageLive(_7);
-//         _7 = &'26_3rce _1;
+//         _7 = &'26_3rs _1;
 //         _2 = ();
 //         StorageDead(_7);
-//         EndRegion('26_3rce);
+//         EndRegion('26_3rs);
 //         StorageDead(_3);
-//         EndRegion('26_1rce);
+//         EndRegion('26_1rs);
 //         goto -> bb1;
 //     }
 // END rustc.node4.SimplifyCfg-qualify-consts.after.mir

--- a/src/test/mir-opt/end_region_4.rs
+++ b/src/test/mir-opt/end_region_4.rs
@@ -33,8 +33,8 @@ fn foo(i: i32) {
 //     let mut _0: ();
 //     let _1: D;
 //     let _2: i32;
-//     let _3: &'26_2rce i32;
-//     let _6: &'26_4rce i32;
+//     let _3: &'26_2rs i32;
+//     let _6: &'26_4rs i32;
 //     let mut _4: ();
 //     let mut _5: i32;
 //     bb0: {
@@ -43,7 +43,7 @@ fn foo(i: i32) {
 //         StorageLive(_2);
 //         _2 = const 0i32;
 //         StorageLive(_3);
-//         _3 = &'26_2rce _2;
+//         _3 = &'26_2rs _2;
 //         StorageLive(_5);
 //         _5 = (*_3);
 //         _4 = const foo(_5) -> [return: bb1, unwind: bb3];
@@ -51,12 +51,12 @@ fn foo(i: i32) {
 //     bb1: {
 //         StorageDead(_5);
 //         StorageLive(_6);
-//         _6 = &'26_4rce _2;
+//         _6 = &'26_4rs _2;
 //         _0 = ();
 //         StorageDead(_6);
-//         EndRegion('26_4rce);
+//         EndRegion('26_4rs);
 //         StorageDead(_3);
-//         EndRegion('26_2rce);
+//         EndRegion('26_2rs);
 //         StorageDead(_2);
 //         drop(_1) -> bb4;
 //     }
@@ -64,7 +64,7 @@ fn foo(i: i32) {
 //         resume;
 //     }
 //     bb3: {
-//         EndRegion('26_2rce);
+//         EndRegion('26_2rs);
 //         drop(_1) -> bb2;
 //     }
 //     bb4: {

--- a/src/test/mir-opt/end_region_5.rs
+++ b/src/test/mir-opt/end_region_5.rs
@@ -31,21 +31,21 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 //     let mut _0: ();
 //     let _1: D;
 //     let mut _2: ();
-//     let mut _3: [closure@NodeId(18) d:&'14mce D];
-//     let mut _4: &'14mce D;
+//     let mut _3: [closure@NodeId(18) d:&'14s D];
+//     let mut _4: &'14s D;
 //     bb0: {
 //         StorageLive(_1);
 //         _1 = D::{{constructor}}(const 0i32,);
 //         StorageLive(_3);
 //         StorageLive(_4);
-//         _4 = &'14mce _1;
+//         _4 = &'14s _1;
 //         _3 = [closure@NodeId(18)] { d: _4 };
 //         StorageDead(_4);
 //         _2 = const foo(_3) -> [return: bb1, unwind: bb3];
 //     }
 //     bb1: {
 //         StorageDead(_3);
-//         EndRegion('14mce);
+//         EndRegion('14s);
 //         _0 = ();
 //         drop(_1) -> bb4;
 //     }
@@ -53,7 +53,7 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 //         resume;
 //     }
 //     bb3: {
-//         EndRegion('14mce);
+//         EndRegion('14s);
 //         drop(_1) -> bb2;
 //     }
 //     bb4: {
@@ -64,13 +64,13 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 // END rustc.node4.SimplifyCfg-qualify-consts.after.mir
 
 // START rustc.node18.SimplifyCfg-qualify-consts.after.mir
-// fn main::{{closure}}(_1: [closure@NodeId(18) d:&'14mce D]) -> i32 {
+// fn main::{{closure}}(_1: [closure@NodeId(18) d:&'14s D]) -> i32 {
 //    let mut _0: i32;
 //    let mut _2: i32;
 //
 //    bb0: {
 //        StorageLive(_2);
-//        _2 = ((*(_1.0: &'14mce D)).0: i32);
+//        _2 = ((*(_1.0: &'14s D)).0: i32);
 //        _0 = _2;
 //        StorageDead(_2);
 //        return;

--- a/src/test/mir-opt/end_region_6.rs
+++ b/src/test/mir-opt/end_region_6.rs
@@ -31,21 +31,21 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 //     let mut _0: ();
 //     let _1: D;
 //     let mut _2: ();
-//     let mut _3: [closure@NodeId(22) d:&'19mce D];
-//     let mut _4: &'19mce D;
+//     let mut _3: [closure@NodeId(22) d:&'19s D];
+//     let mut _4: &'19s D;
 //     bb0: {
 //         StorageLive(_1);
 //         _1 = D::{{constructor}}(const 0i32,);
 //         StorageLive(_3);
 //         StorageLive(_4);
-//         _4 = &'19mce _1;
+//         _4 = &'19s _1;
 //         _3 = [closure@NodeId(22)] { d: _4 };
 //         StorageDead(_4);
 //         _2 = const foo(_3) -> [return: bb1, unwind: bb3];
 //     }
 //     bb1: {
 //         StorageDead(_3);
-//         EndRegion('19mce);
+//         EndRegion('19s);
 //         _0 = ();
 //         drop(_1) -> bb4;
 //     }
@@ -53,7 +53,7 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 //         resume;
 //     }
 //     bb3: {
-//         EndRegion('19mce);
+//         EndRegion('19s);
 //         drop(_1) -> bb2;
 //     }
 //     bb4: {
@@ -63,20 +63,20 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 // END rustc.node4.SimplifyCfg-qualify-consts.after.mir
 
 // START rustc.node22.SimplifyCfg-qualify-consts.after.mir
-// fn main::{{closure}}(_1: [closure@NodeId(22) d:&'19mce D]) -> i32 {
+// fn main::{{closure}}(_1: [closure@NodeId(22) d:&'19s D]) -> i32 {
 //     let mut _0: i32;
-//     let _2: &'15_0rce D;
+//     let _2: &'15_0rs D;
 //     let mut _3: i32;
 //
 //     bb0: {
 //         StorageLive(_2);
-//         _2 = &'15_0rce (*(_1.0: &'19mce D));
+//         _2 = &'15_0rs (*(_1.0: &'19s D));
 //         StorageLive(_3);
 //         _3 = ((*_2).0: i32);
 //         _0 = _3;
 //         StorageDead(_3);
 //         StorageDead(_2);
-//         EndRegion('15_0rce);
+//         EndRegion('15_0rs);
 //         return;
 //     }
 // END rustc.node22.SimplifyCfg-qualify-consts.after.mir

--- a/src/test/mir-opt/end_region_7.rs
+++ b/src/test/mir-opt/end_region_7.rs
@@ -74,18 +74,18 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 // START rustc.node22.SimplifyCfg-qualify-consts.after.mir
 // fn main::{{closure}}(_1: [closure@NodeId(22) d:D]) -> i32 {
 //     let mut _0: i32;
-//     let _2: &'15_0rce D;
+//     let _2: &'15_0rs D;
 //     let mut _3: i32;
 //
 //     bb0: {
 //         StorageLive(_2);
-//         _2 = &'15_0rce (_1.0: D);
+//         _2 = &'15_0rs (_1.0: D);
 //         StorageLive(_3);
 //         _3 = ((*_2).0: i32);
 //         _0 = _3;
 //         StorageDead(_3);
 //         StorageDead(_2);
-//         EndRegion('15_0rce);
+//         EndRegion('15_0rs);
 //         drop(_1) -> bb1;
 //     }
 //     bb1: {

--- a/src/test/mir-opt/end_region_8.rs
+++ b/src/test/mir-opt/end_region_8.rs
@@ -31,15 +31,15 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 // fn main() -> () {
 //    let mut _0: ();
 //    let _1: D;
-//    let _2: &'21_1rce D;
+//    let _2: &'21_1rs D;
 //    let mut _3: ();
-//    let mut _4: [closure@NodeId(22) r:&'21_1rce D];
-//    let mut _5: &'21_1rce D;
+//    let mut _4: [closure@NodeId(22) r:&'21_1rs D];
+//    let mut _5: &'21_1rs D;
 //    bb0: {
 //        StorageLive(_1);
 //        _1 = D::{{constructor}}(const 0i32,);
 //        StorageLive(_2);
-//        _2 = &'21_1rce _1;
+//        _2 = &'21_1rs _1;
 //        StorageLive(_4);
 //        StorageLive(_5);
 //        _5 = _2;
@@ -51,14 +51,14 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 //        StorageDead(_4);
 //        _0 = ();
 //        StorageDead(_2);
-//        EndRegion('21_1rce);
+//        EndRegion('21_1rs);
 //        drop(_1) -> bb4;
 //    }
 //    bb2: {
 //        resume;
 //    }
 //    bb3: {
-//        EndRegion('21_1rce);
+//        EndRegion('21_1rs);
 //        drop(_1) -> bb2;
 //    }
 //    bb4: {
@@ -69,13 +69,13 @@ fn foo<F>(f: F) where F: FnOnce() -> i32 {
 // END rustc.node4.SimplifyCfg-qualify-consts.after.mir
 
 // START rustc.node22.SimplifyCfg-qualify-consts.after.mir
-// fn main::{{closure}}(_1: [closure@NodeId(22) r:&'21_1rce D]) -> i32 {
+// fn main::{{closure}}(_1: [closure@NodeId(22) r:&'21_1rs D]) -> i32 {
 //     let mut _0: i32;
 //     let mut _2: i32;
 //
 //     bb0: {
 //         StorageLive(_2);
-//         _2 = ((*(_1.0: &'21_1rce D)).0: i32);
+//         _2 = ((*(_1.0: &'21_1rs D)).0: i32);
 //         _0 = _2;
 //         StorageDead(_2);
 //         return;

--- a/src/test/mir-opt/end_region_9.rs
+++ b/src/test/mir-opt/end_region_9.rs
@@ -42,7 +42,7 @@ fn main() {
 //     let mut _0: ();
 //     let mut _1: bool;
 //     let _2: i32;
-//     let mut _4: &'13_0rce i32;
+//     let mut _4: &'13_0rs i32;
 //     let mut _3: ();
 //     let mut _5: !;
 //     let mut _6: ();
@@ -68,14 +68,14 @@ fn main() {
 //        _0 = ();
 //        StorageDead(_7);
 //        StorageDead(_4);
-//        EndRegion('13_0rce);
+//        EndRegion('13_0rs);
 //        StorageDead(_2);
 //        StorageDead(_1);
 //        return;
 //    }
 //
 //    bb3: {
-//        _4 = &'13_0rce _2;
+//        _4 = &'13_0rs _2;
 //        _6 = ();
 //        StorageDead(_7);
 //        _1 = const true;

--- a/src/test/mir-opt/issue-43457.rs
+++ b/src/test/mir-opt/issue-43457.rs
@@ -30,14 +30,14 @@ fn main() { }
 //     scope 1 {
 //         let _2: std::cell::RefCell<i32>;
 //     }
-//     let mut _3: std::cell::RefMut<'17dce, i32>;
-//     let mut _4: &'17dce std::cell::RefCell<i32>;
+//     let mut _3: std::cell::RefMut<'17ds, i32>;
+//     let mut _4: &'17ds std::cell::RefCell<i32>;
 //
 //     bb0: {
 //         StorageLive(_2);
 //         _2 = _1;
 //         StorageLive(_4);
-//         _4 = &'17dce _2;
+//         _4 = &'17ds _2;
 //         _3 = const <std::cell::RefCell<T>>::borrow_mut(_4) -> bb1;
 //     }
 //
@@ -47,7 +47,7 @@ fn main() { }
 //
 //     bb2: {
 //         StorageDead(_4);
-//         EndRegion('17dce);
+//         EndRegion('17ds);
 //         _0 = ();
 //         StorageDead(_2);
 //         return;

--- a/src/test/mir-opt/validate_1.rs
+++ b/src/test/mir-opt/validate_1.rs
@@ -37,19 +37,19 @@ fn main() {
 // START rustc.node23.EraseRegions.after.mir
 // fn main() -> () {
 //     bb0: {
-//         Validate(Suspend(ReScope(Misc(ItemLocalId(10)))), [_1: i32]);
+//         Validate(Suspend(ReScope(Node(ItemLocalId(10)))), [_1: i32]);
 //         _6 = &ReErased mut _1;
-//         Validate(Acquire, [(*_6): i32/ReScope(Misc(ItemLocalId(10)))]);
-//         Validate(Suspend(ReScope(Misc(ItemLocalId(10)))), [(*_6): i32/ReScope(Misc(ItemLocalId(10)))]);
+//         Validate(Acquire, [(*_6): i32/ReScope(Node(ItemLocalId(10)))]);
+//         Validate(Suspend(ReScope(Node(ItemLocalId(10)))), [(*_6): i32/ReScope(Node(ItemLocalId(10)))]);
 //         _5 = &ReErased mut (*_6);
-//         Validate(Acquire, [(*_5): i32/ReScope(Misc(ItemLocalId(10)))]);
-//         Validate(Release, [_2: (), _3: &ReScope(Misc(ItemLocalId(10))) Test, _5: &ReScope(Misc(ItemLocalId(10))) mut i32]);
+//         Validate(Acquire, [(*_5): i32/ReScope(Node(ItemLocalId(10)))]);
+//         Validate(Release, [_2: (), _3: &ReScope(Node(ItemLocalId(10))) Test, _5: &ReScope(Node(ItemLocalId(10))) mut i32]);
 //         _2 = const Test::foo(_3, _5) -> bb1;
 //     }
 //
 //     bb1: {
 //         Validate(Acquire, [_2: ()]);
-//         EndRegion(ReScope(Misc(ItemLocalId(10))));
+//         EndRegion(ReScope(Node(ItemLocalId(10))));
 //         return;
 //     }
 // }

--- a/src/test/mir-opt/validate_3.rs
+++ b/src/test/mir-opt/validate_3.rs
@@ -32,17 +32,17 @@ fn main() {
 // fn main() -> () {
 //     let mut _5: &ReErased i32;
 //     bb0: {
-//         Validate(Suspend(ReScope(Misc(ItemLocalId(17)))), [((*_2).0: i32): i32/ReScope(Remainder(BlockRemainder { block: ItemLocalId(19), first_statement_index: 3 })) (imm)]);
+//         Validate(Suspend(ReScope(Node(ItemLocalId(17)))), [((*_2).0: i32): i32/ReScope(Remainder(BlockRemainder { block: ItemLocalId(19), first_statement_index: 3 })) (imm)]);
 //         _5 = &ReErased ((*_2).0: i32);
-//         Validate(Acquire, [(*_5): i32/ReScope(Misc(ItemLocalId(17))) (imm)]);
-//         Validate(Suspend(ReScope(Misc(ItemLocalId(17)))), [(*_5): i32/ReScope(Misc(ItemLocalId(17))) (imm)]);
+//         Validate(Acquire, [(*_5): i32/ReScope(Node(ItemLocalId(17))) (imm)]);
+//         Validate(Suspend(ReScope(Node(ItemLocalId(17)))), [(*_5): i32/ReScope(Node(ItemLocalId(17))) (imm)]);
 //         _4 = &ReErased (*_5);
-//         Validate(Acquire, [(*_4): i32/ReScope(Misc(ItemLocalId(17))) (imm)]);
-//         Validate(Release, [_3: (), _4: &ReScope(Misc(ItemLocalId(17))) i32]);
+//         Validate(Acquire, [(*_4): i32/ReScope(Node(ItemLocalId(17))) (imm)]);
+//         Validate(Release, [_3: (), _4: &ReScope(Node(ItemLocalId(17))) i32]);
 //         _3 = const foo(_4) -> bb1;
 //     }
 //     bb1: {
-//         EndRegion(ReScope(Misc(ItemLocalId(17))));
+//         EndRegion(ReScope(Node(ItemLocalId(17))));
 //         EndRegion(ReScope(Remainder(BlockRemainder { block: ItemLocalId(19), first_statement_index: 3 })));
 //         return;
 //     }

--- a/src/test/mir-opt/validate_5.rs
+++ b/src/test/mir-opt/validate_5.rs
@@ -50,12 +50,12 @@ fn main() {
 //         _3 = _2;
 //         StorageLive(_4);
 //         StorageLive(_5);
-//         Validate(Suspend(ReScope(Misc(ItemLocalId(9)))), [(*_3): i32]);
+//         Validate(Suspend(ReScope(Node(ItemLocalId(9)))), [(*_3): i32]);
 //         _5 = &ReErased mut (*_3);
-//         Validate(Acquire, [(*_5): i32/ReScope(Misc(ItemLocalId(9)))]);
+//         Validate(Acquire, [(*_5): i32/ReScope(Node(ItemLocalId(9)))]);
 //         _4 = _5 as *mut i32 (Misc);
 //         StorageDead(_5);
-//         EndRegion(ReScope(Misc(ItemLocalId(9))));
+//         EndRegion(ReScope(Node(ItemLocalId(9))));
 //         Validate(Release, [_0: bool, _4: *mut i32]);
 //         _0 = const write_42(_4) -> bb1;
 //     }


### PR DESCRIPTION
r? @nikomatsakis