### PR TITLE
First implementation of Thread::set_name(&str)

### DIFF
--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -110,6 +110,7 @@ impl Thread {
     #[cfg(any(target_os = "linux",
               target_os = "android"))]
     pub fn get_name() -> CString {
+        // maybe use weak!{ ... } for older glibc
         unsafe {
             const max_len: usize = 255;
             let name = [0u8; max_len];

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -127,7 +127,7 @@ impl Thread {
               target_os = "dragonfly",
               target_os = "bitrig",
               target_os = "openbsd"))]
-    pub fn set_name(name: &CStr) {
+    pub fn set_name(name: &OsStr) {
         unsafe {
             libc::pthread_set_name_np(libc::pthread_self(), name.as_ptr());
         }

--- a/src/libstd/sys/windows/c.rs
+++ b/src/libstd/sys/windows/c.rs
@@ -1185,6 +1185,10 @@ compat_fn! {
     pub fn SetThreadStackGuarantee(_size: *mut c_ulong) -> BOOL {
         SetLastError(ERROR_CALL_NOT_IMPLEMENTED as DWORD); 0
     }
+    pub fn GetThreadDescription(hThread: HANDLE,
+                                lpThreadDescription: *mut PWSTR) -> HRESULT {
+        SetLastError(ERROR_CALL_NOT_IMPLEMENTED as DWORD); E_NOTIMPL
+    }
     pub fn SetThreadDescription(hThread: HANDLE,
                                 lpThreadDescription: LPCWSTR) -> HRESULT {
         SetLastError(ERROR_CALL_NOT_IMPLEMENTED as DWORD); E_NOTIMPL

--- a/src/libstd/sys/windows/thread.rs
+++ b/src/libstd/sys/windows/thread.rs
@@ -57,12 +57,12 @@ impl Thread {
         }
     }
 
-    pub fn set_name(name: &CStr) {
-        if let Ok(utf8) = name.to_str() {
+    pub fn set_name(name: &OsStr) {
+        //if let Ok(utf8) = name.to_str() {
             if let Ok(utf16) = to_u16s(utf8) {
                 unsafe { c::SetThreadDescription(c::GetCurrentThread(), utf16.as_ptr()); };
             };
-        };
+        //};
     }
 
     pub fn join(self) {

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -1067,6 +1067,34 @@ impl Thread {
     fn cname(&self) -> Option<&CStr> {
         self.inner.name.as_ref().map(|s| &**s)
     }
+
+    /// Change the name of a thread
+    ///
+    /// ```
+    /// use std::thread;
+    ///
+    /// let builder = thread::Builder::new()
+    ///     .name("foo".into());
+    ///
+    /// let handler = builder.spawn(|| {
+    ///     assert_eq!(thread::current().name(), Some("foo"));
+    ///     thread::current().set_name("bar");
+    ///     assert_eq!(thread::current().name(), Some("bar"));
+    /// }).unwrap();
+    ///
+    /// handler.join().unwrap();
+    /// ```
+    #[unstable(feature = "thread_rename", reason = "the compiler threw an error at me ;)",
+               issue = "27802")]
+    pub fn set_name(&mut self, name: &str) {
+        let cname = CString::new(name).expect("thread name may not contain interior null bytes");
+        imp::Thread::set_name(&cname);
+        let target: *const Option<CString> = &self.inner.name;
+        unsafe {
+            let target = ::mem::transmute::<*const Option<CString>, &mut Option<CString>>(target);
+            *target = Some(cname);
+        }
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -1101,10 +1101,8 @@ impl Thread {
     /// ```
     #[unstable(feature = "libstd_thread_rename", issue = "44258")]
     pub fn os_name(&self) -> String {
-        let name = unsafe {
-            imp::Thread::get_name()
-        };
-        String::from_utf8_lossy(name)
+        let name = imp::Thread::get_name();
+        name.into()
     }
 }
 

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -164,7 +164,7 @@
 
 use any::Any;
 use cell::UnsafeCell;
-use ffi::{CStr, CString};
+use ffi::{OsStr, OsString};
 use fmt;
 use io;
 use panic;
@@ -856,8 +856,8 @@ pub fn park_timeout(dur: Duration) {
 /// Current blockers macOS, redox
 #[unstable(feature = "libstd_thread_rename", issue = "44258")]
 pub fn set_os_name(name: &str) {
-    let cname = CString::new(name).expect("thread name must not contain interior null bytes");
-    imp::Thread::set_name(&cname);
+    let os_name = OsString::new(name).expect("thread name must not contain interior null bytes");
+    imp::Thread::set_name(&os_name);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -922,7 +922,6 @@ impl ThreadId {
 
 /// The internal representation of a `Thread` handle
 struct Inner {
-    name: Option<CString>,      // Guaranteed to be UTF-8
     id: ThreadId,
     lock: Mutex<bool>,          // true when there is a buffered unpark
     cvar: Condvar,
@@ -962,7 +961,7 @@ impl Thread {
     // Panics if the name contains nulls.
     pub(crate) fn new(name: Option<String>) -> Thread {
         let cname = name.map(|n| {
-            CString::new(n).expect("thread name may not contain interior null bytes")
+            OsString::new(n).expect("thread name may not contain interior null bytes")
         });
         Thread {
             inner: Arc::new(Inner {
@@ -1077,7 +1076,7 @@ impl Thread {
         self.cname().map(|s| unsafe { str::from_utf8_unchecked(s.to_bytes()) } )
     }
 
-    fn cname(&self) -> Option<&CStr> {
+    fn cname(&self) -> Option<&OsStr> {
         self.inner.name.as_ref().map(|s| &**s)
     }
 
@@ -1100,9 +1099,10 @@ impl Thread {
     /// handler.join().unwrap();
     /// ```
     #[unstable(feature = "libstd_thread_rename", issue = "44258")]
-    pub fn os_name(&self) -> String {
+    pub fn os_name(&self) -> Result<String> {
+        // TODO check if the thread is still alive
         let name = imp::Thread::get_name();
-        name.into()
+        Ok(name.into())
     }
 }
 


### PR DESCRIPTION
I would like to be able to rename threads in the [threadpool crate](https://github.com/rust-threadpool/rust-threadpool/pull/83) without restarting the worker-threads.

This is my first PR with unsafe code, so I improvised a little to get it to compile.
Ideas for improvement are very appreciated.