### PR TITLE
rustc: Flag {i,u}128 as unsafe for FFI

### DIFF
--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -543,6 +543,18 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                            `u32` or `libc::wchar_t` should be used")
             }
 
+            ty::TyInt(ast::IntTy::I128) => {
+                FfiUnsafe("found Rust type `i128` in foreign module, but \
+                           128-bit integers don't currently have a known \
+                           stable ABI")
+            }
+
+            ty::TyUint(ast::UintTy::U128) => {
+                FfiUnsafe("found Rust type `u128` in foreign module, but \
+                           128-bit integers don't currently have a known \
+                           stable ABI")
+            }
+
             // Primitive types with a stable representation.
             ty::TyBool | ty::TyInt(..) | ty::TyUint(..) | ty::TyFloat(..) | ty::TyNever => FfiSafe,
 

--- a/src/test/compile-fail/lint-ctypes.rs
+++ b/src/test/compile-fail/lint-ctypes.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #![deny(improper_ctypes)]
-#![feature(libc)]
+#![feature(libc, i128_type)]
 
 extern crate libc;
 
@@ -39,6 +39,8 @@ extern {
     pub fn str_type(p: &str); //~ ERROR: found Rust type
     pub fn box_type(p: Box<u32>); //~ ERROR found struct without
     pub fn char_type(p: char); //~ ERROR found Rust type
+    pub fn i128_type(p: i128); //~ ERROR found Rust type
+    pub fn u128_type(p: u128); //~ ERROR found Rust type
     pub fn trait_type(p: &Clone); //~ ERROR found Rust trait type
     pub fn tuple_type(p: (i32, i32)); //~ ERROR found Rust tuple type
     pub fn tuple_type2(p: I32Pair); //~ ERROR found Rust tuple type


### PR DESCRIPTION
These don't appear to have a stable ABI as noted in #41799 and the work in
compiler-builtins definitely seems to be confirming it!