### PR TITLE
rustc: Separately feature gate repr(i128)

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1599,9 +1599,12 @@ pub fn check_enum<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
     let repr_type_ty = def.repr.discr_type().to_ty(tcx);
     if repr_type_ty == tcx.types.i128 || repr_type_ty == tcx.types.u128 {
-        if !tcx.sess.features.borrow().i128_type {
+        if !tcx.sess.features.borrow().repr128 {
             emit_feature_err(&tcx.sess.parse_sess,
-                             "i128_type", sp, GateIssue::Language, "128-bit type is unstable");
+                             "repr128",
+                             sp,
+                             GateIssue::Language,
+                             "repr with 128-bit type is unstable");
         }
     }
 

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -312,6 +312,9 @@ declare_features! (
     // The `i128` type
     (active, i128_type, "1.16.0", Some(35118)),
 
+    // The `repr(i128)` annotation for enums
+    (active, repr128, "1.16.0", Some(35118)),
+
     // The `unadjusted` ABI. Perma unstable.
     (active, abi_unadjusted, "1.16.0", None),
 

--- a/src/test/compile-fail/feature-gate-repr128.rs
+++ b/src/test/compile-fail/feature-gate-repr128.rs
@@ -1,0 +1,17 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[repr(u128)]
+enum A { //~ ERROR repr with 128-bit type is unstable
+    //~| HELP: add #![feature(repr128)]
+    A(u64)
+}
+
+fn main() {}


### PR DESCRIPTION
Brought up during the discussion of #35118, the support for this is still
somewhat buggy and so stabilization likely wants to be considered independently
of the type itself.