### PR TITLE
Implement <Rc<Any>>::downcast

### DIFF
--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -611,7 +611,7 @@ impl<T: Clone> Rc<T> {
 
 impl Rc<Any> {
     #[inline]
-    #[unstable(feature = "rc_downcast", issue = "0")]
+    #[unstable(feature = "rc_downcast", issue = "44608")]
     /// Attempt to downcast the `Rc<Any>` to a concrete type.
     ///
     /// # Examples


### PR DESCRIPTION
* Implement `<Rc<Any>>::downcast::<T>`
  * New unstable method. Works just like Box\<Any\>, but for Rc.
  * Any has two cases for its methods: Any and Any + Send; Rc is never Send, so that case is skipped for Rc.
  * Motivation for being a method with self is to match Box and there is no user-supplied type; the inner type is Any and downcast does not conflict with any method of Any.
* Arc was skipped because Any itself has no downcast for the case that makes most sense: Any + Send + Sync