### PR TITLE
Evaluate fixed-length array length expressions lazily.

### DIFF
--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -611,7 +611,7 @@ pub enum BindingAnnotation {
   RefMut,
 }
 
-#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub enum RangeEnd {
     Included,
     Excluded,

--- a/src/librustc/ich/impls_mir.rs
+++ b/src/librustc/ich/impls_mir.rs
@@ -493,10 +493,6 @@ impl<'a, 'gcx, 'tcx> HashStable<StableHashingContext<'a, 'gcx, 'tcx>> for mir::L
                                           hasher: &mut StableHasher<W>) {
         mem::discriminant(self).hash_stable(hcx, hasher);
         match *self {
-            mir::Literal::Item { def_id, substs } => {
-                def_id.hash_stable(hcx, hasher);
-                substs.hash_stable(hcx, hasher);
-            }
             mir::Literal::Value { ref value } => {
                 value.hash_stable(hcx, hasher);
             }

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -235,6 +235,10 @@ impl<'a, 'gcx, 'tcx> HashStable<StableHashingContext<'a, 'gcx, 'tcx>> for ty::Pr
                 def_id.hash_stable(hcx, hasher);
                 closure_kind.hash_stable(hcx, hasher);
             }
+            ty::Predicate::ConstEvaluatable(def_id, substs) => {
+                def_id.hash_stable(hcx, hasher);
+                substs.hash_stable(hcx, hasher);
+            }
         }
     }
 }
@@ -316,6 +320,10 @@ for ::middle::const_val::ConstVal<'gcx> {
             Aggregate(Repeat(ref value, times)) => {
                 value.hash_stable(hcx, hasher);
                 times.hash_stable(hcx, hasher);
+            }
+            Unevaluated(def_id, substs) => {
+                def_id.hash_stable(hcx, hasher);
+                substs.hash_stable(hcx, hasher);
             }
         }
     }

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -277,10 +277,10 @@ for ::middle::const_val::ConstVal<'gcx> {
         mem::discriminant(self).hash_stable(hcx, hasher);
 
         match *self {
-            Float(ref value) => {
+            Integral(ref value) => {
                 value.hash_stable(hcx, hasher);
             }
-            Integral(ref value) => {
+            Float(ref value) => {
                 value.hash_stable(hcx, hasher);
             }
             Str(ref value) => {
@@ -323,6 +323,11 @@ for ::middle::const_val::ConstVal<'gcx> {
 
 impl_stable_hash_for!(struct ::middle::const_val::ByteArray<'tcx> {
     data
+});
+
+impl_stable_hash_for!(struct ty::Const<'tcx> {
+    ty,
+    val
 });
 
 impl_stable_hash_for!(struct ty::ClosureSubsts<'tcx> { substs });

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -442,6 +442,7 @@ macro_rules! impl_trans_normalize {
 
 impl_trans_normalize!('gcx,
     Ty<'gcx>,
+    &'gcx ty::Const<'gcx>,
     &'gcx Substs<'gcx>,
     ty::FnSig<'gcx>,
     ty::PolyFnSig<'gcx>,
@@ -493,7 +494,7 @@ impl<'a, 'tcx> TyCtxt<'a, 'tcx, 'tcx> {
         let param_env = ty::ParamEnv::empty(Reveal::All);
         let value = self.erase_regions(value);
 
-        if !value.has_projection_types() {
+        if !value.has_projections() {
             return value;
         }
 
@@ -515,7 +516,7 @@ impl<'a, 'tcx> TyCtxt<'a, 'tcx, 'tcx> {
 
         let value = self.erase_regions(value);
 
-        if !value.has_projection_types() {
+        if !value.has_projections() {
             return value;
         }
 

--- a/src/librustc/middle/const_val.rs
+++ b/src/librustc/middle/const_val.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use self::ConstVal::*;
-use self::ConstAggregate::*;
 pub use rustc_const_math::ConstInt;
 
 use hir;
@@ -73,23 +71,6 @@ impl<'tcx> Decodable for ConstAggregate<'tcx> {
 }
 
 impl<'tcx> ConstVal<'tcx> {
-    pub fn description(&self) -> &'static str {
-        match *self {
-            Float(f) => f.description(),
-            Integral(i) => i.description(),
-            Str(_) => "string literal",
-            ByteStr(_) => "byte string literal",
-            Bool(_) => "boolean",
-            Char(..) => "char",
-            Variant(_) => "enum variant",
-            Aggregate(Struct(_)) => "struct",
-            Aggregate(Tuple(_)) => "tuple",
-            Function(..) => "function definition",
-            Aggregate(Array(..)) => "array",
-            Aggregate(Repeat(..)) => "repeat",
-        }
-    }
-
     pub fn to_const_int(&self) -> Option<ConstInt> {
         match *self {
             ConstVal::Integral(i) => Some(i),
@@ -110,8 +91,6 @@ pub struct ConstEvalErr<'tcx> {
 pub enum ErrKind<'tcx> {
     CannotCast,
     MissingStructField,
-    NegateOn(ConstVal<'tcx>),
-    NotOn(ConstVal<'tcx>),
 
     NonConstPath,
     UnimplementedConstVal(&'static str),
@@ -170,9 +149,6 @@ impl<'a, 'gcx, 'tcx> ConstEvalErr<'tcx> {
 
         match self.kind {
             CannotCast => simple!("can't cast this type"),
-            NegateOn(ref const_val) => simple!("negate on {}", const_val.description()),
-            NotOn(ref const_val) => simple!("not on {}", const_val.description()),
-
             MissingStructField  => simple!("nonexistent struct field"),
             NonConstPath        => simple!("non-constant path in constant expression"),
             UnimplementedConstVal(what) =>

--- a/src/librustc/middle/free_region.rs
+++ b/src/librustc/middle/free_region.rs
@@ -147,7 +147,8 @@ impl<'tcx> FreeRegionMap<'tcx> {
                 ty::Predicate::WellFormed(..) |
                 ty::Predicate::ObjectSafe(..) |
                 ty::Predicate::ClosureKind(..) |
-                ty::Predicate::TypeOutlives(..) => {
+                ty::Predicate::TypeOutlives(..) |
+                ty::Predicate::ConstEvaluatable(..) => {
                     // No region bounds here
                 }
                 ty::Predicate::RegionOutlives(ty::Binder(ty::OutlivesPredicate(r_a, r_b))) => {

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -876,7 +876,7 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
 
         // Always promote `[T; 0]` (even when e.g. borrowed mutably).
         let promotable = match expr_ty.sty {
-            ty::TyArray(_, 0) => true,
+            ty::TyArray(_, len) if len.as_u64() == 0 => true,
             _ => promotable,
         };
 

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -876,7 +876,8 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
 
         // Always promote `[T; 0]` (even when e.g. borrowed mutably).
         let promotable = match expr_ty.sty {
-            ty::TyArray(_, len) if len.val.to_const_int().unwrap().to_u64().unwrap() == 0 => true,
+            ty::TyArray(_, len) if
+                len.val.to_const_int().and_then(|i| i.to_u64()) == Some(0) => true,
             _ => promotable,
         };
 

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -876,7 +876,7 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
 
         // Always promote `[T; 0]` (even when e.g. borrowed mutably).
         let promotable = match expr_ty.sty {
-            ty::TyArray(_, len) if len.as_u64() == 0 => true,
+            ty::TyArray(_, len) if len.val.to_const_int().unwrap().to_u64().unwrap() == 0 => true,
             _ => promotable,
         };
 

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1535,6 +1535,7 @@ fn fmt_const_val<W: Write>(fmt: &mut W, const_val: &ConstVal) -> fmt::Result {
         Variant(def_id) |
         Function(def_id, _) => write!(fmt, "{}", item_path_str(def_id)),
         Aggregate(_) => bug!("`ConstVal::{:?}` should not be in MIR", const_val),
+        Unevaluated(..) => write!(fmt, "{:?}", const_val)
     }
 }
 

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1190,7 +1190,9 @@ impl<'tcx> Operand<'tcx> {
         Operand::Constant(box Constant {
             span,
             ty: tcx.type_of(def_id).subst(tcx, substs),
-            literal: Literal::Value { value: ConstVal::Function(def_id, substs) },
+            literal: Literal::Value {
+                value: tcx.mk_const(ConstVal::Function(def_id, substs))
+            },
         })
     }
 
@@ -1478,7 +1480,7 @@ pub enum Literal<'tcx> {
         substs: &'tcx Substs<'tcx>,
     },
     Value {
-        value: ConstVal<'tcx>,
+        value: &'tcx ConstVal<'tcx>,
     },
     Promoted {
         // Index into the `promoted` vector of `Mir`.
@@ -1516,9 +1518,9 @@ fn fmt_const_val<W: Write>(fmt: &mut W, const_val: &ConstVal) -> fmt::Result {
     match *const_val {
         Float(f) => write!(fmt, "{:?}", f),
         Integral(n) => write!(fmt, "{}", n),
-        Str(ref s) => write!(fmt, "{:?}", s),
-        ByteStr(ref bytes) => {
-            let escaped: String = bytes
+        Str(s) => write!(fmt, "{:?}", s),
+        ByteStr(bytes) => {
+            let escaped: String = bytes.data
                 .iter()
                 .flat_map(|&ch| ascii::escape_default(ch).map(|c| c as char))
                 .collect();
@@ -1528,8 +1530,7 @@ fn fmt_const_val<W: Write>(fmt: &mut W, const_val: &ConstVal) -> fmt::Result {
         Char(c) => write!(fmt, "{:?}", c),
         Variant(def_id) |
         Function(def_id, _) => write!(fmt, "{}", item_path_str(def_id)),
-        Struct(_) | Tuple(_) | Array(_) | Repeat(..) =>
-            bug!("ConstVal `{:?}` should not be in MIR", const_val),
+        Aggregate(_) => bug!("`ConstVal::{:?}` should not be in MIR", const_val),
     }
 }
 

--- a/src/librustc/mir/tcx.rs
+++ b/src/librustc/mir/tcx.rs
@@ -70,7 +70,8 @@ impl<'a, 'gcx, 'tcx> LvalueTy<'tcx> {
                 LvalueTy::Ty {
                     ty: match ty.sty {
                         ty::TyArray(inner, size) => {
-                            let len = size.as_u64() - (from as u64) - (to as u64);
+                            let size = size.val.to_const_int().unwrap().to_u64().unwrap();
+                            let len = size - (from as u64) - (to as u64);
                             tcx.mk_array(inner, len)
                         }
                         ty::TySlice(..) => ty,
@@ -148,7 +149,7 @@ impl<'tcx> Rvalue<'tcx> {
         match *self {
             Rvalue::Use(ref operand) => operand.ty(local_decls, tcx),
             Rvalue::Repeat(ref operand, count) => {
-                tcx.mk_array(operand.ty(local_decls, tcx), count.as_u64())
+                tcx.mk_array_const_usize(operand.ty(local_decls, tcx), count)
             }
             Rvalue::Ref(reg, bk, ref lv) => {
                 let lv_ty = lv.ty(local_decls, tcx).to_ty(tcx);

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -233,7 +233,7 @@ macro_rules! make_mir_visitor {
             }
 
             fn visit_const_val(&mut self,
-                               const_val: & $($mutability)* ConstVal,
+                               const_val: & $($mutability)* &'tcx ConstVal<'tcx>,
                                _: Location) {
                 self.super_const_val(const_val);
             }
@@ -760,7 +760,7 @@ macro_rules! make_mir_visitor {
                                     _substs: & $($mutability)* ClosureSubsts<'tcx>) {
             }
 
-            fn super_const_val(&mut self, _const_val: & $($mutability)* ConstVal) {
+            fn super_const_val(&mut self, _const_val: & $($mutability)* &'tcx ConstVal<'tcx>) {
             }
 
             fn super_const_int(&mut self, _const_int: &ConstInt) {

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -724,11 +724,6 @@ macro_rules! make_mir_visitor {
                              literal: & $($mutability)* Literal<'tcx>,
                              location: Location) {
                 match *literal {
-                    Literal::Item { ref $($mutability)* def_id,
-                                    ref $($mutability)* substs } => {
-                        self.visit_def_id(def_id, location);
-                        self.visit_substs(substs, location);
-                    }
                     Literal::Value { ref $($mutability)* value } => {
                         self.visit_const(value, location);
                     }

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -48,8 +48,8 @@ use std::path::PathBuf;
 
 pub struct Config {
     pub target: Target,
-    pub int_type: IntTy,
-    pub uint_type: UintTy,
+    pub isize_ty: IntTy,
+    pub usize_ty: UintTy,
 }
 
 #[derive(Clone, Hash, Debug)]
@@ -1149,7 +1149,7 @@ pub fn build_target_config(opts: &Options, sp: &Handler) -> Config {
         }
     };
 
-    let (int_type, uint_type) = match &target.target_pointer_width[..] {
+    let (isize_ty, usize_ty) = match &target.target_pointer_width[..] {
         "16" => (ast::IntTy::I16, ast::UintTy::U16),
         "32" => (ast::IntTy::I32, ast::UintTy::U32),
         "64" => (ast::IntTy::I64, ast::UintTy::U64),
@@ -1159,8 +1159,8 @@ pub fn build_target_config(opts: &Options, sp: &Handler) -> Config {
 
     Config {
         target,
-        int_type,
-        uint_type,
+        isize_ty,
+        usize_ty,
     }
 }
 

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -19,6 +19,7 @@ use super::{
     OnUnimplementedNote,
     OutputTypeParameterMismatch,
     TraitNotObjectSafe,
+    ConstEvalFailure,
     PredicateObligation,
     Reveal,
     SelectionContext,
@@ -31,6 +32,7 @@ use hir;
 use hir::def_id::DefId;
 use infer::{self, InferCtxt};
 use infer::type_variable::TypeVariableOrigin;
+use middle::const_val;
 use rustc::lint::builtin::EXTRA_REQUIREMENT_IN_IMPL;
 use std::fmt;
 use syntax::ast;
@@ -698,6 +700,14 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                         // (which may fail).
                         span_bug!(span, "WF predicate not satisfied for {:?}", ty);
                     }
+
+                    ty::Predicate::ConstEvaluatable(..) => {
+                        // Errors for `ConstEvaluatable` predicates show up as
+                        // `SelectionError::ConstEvalFailure`,
+                        // not `Unimplemented`.
+                        span_bug!(span,
+                            "const-evaluatable requirement gave wrong error: `{:?}`", obligation)
+                    }
                 }
             }
 
@@ -761,6 +771,13 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                 let violations = self.tcx.object_safety_violations(did);
                 self.tcx.report_object_safety_error(span, did,
                                                     violations)
+            }
+
+            ConstEvalFailure(ref err) => {
+                if let const_val::ErrKind::TypeckError = err.kind {
+                    return;
+                }
+                err.struct_error(self.tcx, span, "constant expression")
             }
         };
         self.note_obligation_cause(&mut err, obligation);

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -17,6 +17,7 @@ pub use self::ObligationCauseCode::*;
 
 use hir;
 use hir::def_id::DefId;
+use middle::const_val::ConstEvalErr;
 use middle::region;
 use middle::free_region::FreeRegionMap;
 use ty::subst::Substs;
@@ -218,6 +219,7 @@ pub enum SelectionError<'tcx> {
                                 ty::PolyTraitRef<'tcx>,
                                 ty::error::TypeError<'tcx>),
     TraitNotObjectSafe(DefId),
+    ConstEvalFailure(ConstEvalErr<'tcx>),
 }
 
 pub struct FulfillmentError<'tcx> {

--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -169,7 +169,8 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                     ty::Predicate::RegionOutlives(..) |
                     ty::Predicate::ClosureKind(..) |
                     ty::Predicate::Subtype(..) |
-                    ty::Predicate::Equate(..) => {
+                    ty::Predicate::Equate(..) |
+                    ty::Predicate::ConstEvaluatable(..) => {
                         false
                     }
                 }
@@ -203,7 +204,8 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                     ty::Predicate::WellFormed(..) |
                     ty::Predicate::ObjectSafe(..) |
                     ty::Predicate::ClosureKind(..) |
-                    ty::Predicate::TypeOutlives(..) => {
+                    ty::Predicate::TypeOutlives(..) |
+                    ty::Predicate::ConstEvaluatable(..) => {
                         false
                     }
                 }

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -732,6 +732,21 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
                     }
                 }
             }
+
+            ty::Predicate::ConstEvaluatable(def_id, substs) => {
+                match self.tcx().lift_to_global(&(obligation.param_env, substs)) {
+                    Some((param_env, substs)) => {
+                        match self.tcx().const_eval(param_env.and((def_id, substs))) {
+                            Ok(_) => EvaluatedToOk,
+                            Err(_) => EvaluatedToErr
+                        }
+                    }
+                    None => {
+                        // Inference variables still left in param_env or substs.
+                        EvaluatedToAmbig
+                    }
+                }
+            }
         }
     }
 

--- a/src/librustc/traits/structural_impls.rs
+++ b/src/librustc/traits/structural_impls.rs
@@ -173,6 +173,9 @@ impl<'a, 'tcx> Lift<'tcx> for traits::SelectionError<'a> {
             super::TraitNotObjectSafe(def_id) => {
                 Some(super::TraitNotObjectSafe(def_id))
             }
+            super::ConstEvalFailure(ref err) => {
+                tcx.lift(err).map(super::ConstEvalFailure)
+            }
         }
     }
 }

--- a/src/librustc/traits/trans/mod.rs
+++ b/src/librustc/traits/trans/mod.rs
@@ -120,7 +120,7 @@ impl<'a, 'gcx> AssociatedTypeNormalizer<'a, 'gcx> {
     }
 
     fn fold<T:TypeFoldable<'gcx>>(&mut self, value: &T) -> T {
-        if !value.has_projection_types() {
+        if !value.has_projections() {
             value.clone()
         } else {
             value.fold_with(self)
@@ -134,7 +134,7 @@ impl<'a, 'gcx> TypeFolder<'gcx, 'gcx> for AssociatedTypeNormalizer<'a, 'gcx> {
     }
 
     fn fold_ty(&mut self, ty: Ty<'gcx>) -> Ty<'gcx> {
-        if !ty.has_projection_types() {
+        if !ty.has_projections() {
             ty
         } else {
             self.tcx.trans_trait_caches.project_cache.memoize(ty, || {

--- a/src/librustc/traits/util.rs
+++ b/src/librustc/traits/util.rs
@@ -48,6 +48,9 @@ fn anonymize_predicate<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
 
         ty::Predicate::Subtype(ref data) =>
             ty::Predicate::Subtype(tcx.anonymize_late_bound_regions(data)),
+
+        ty::Predicate::ConstEvaluatable(def_id, substs) =>
+            ty::Predicate::ConstEvaluatable(def_id, substs),
     }
 }
 
@@ -174,6 +177,10 @@ impl<'cx, 'gcx, 'tcx> Elaborator<'cx, 'gcx, 'tcx> {
             }
             ty::Predicate::ClosureKind(..) => {
                 // Nothing to elaborate when waiting for a closure's kind to be inferred.
+            }
+            ty::Predicate::ConstEvaluatable(..) => {
+                // Currently, we do not elaborate const-evaluatable
+                // predicates.
             }
 
             ty::Predicate::RegionOutlives(..) => {

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -21,6 +21,7 @@ use hir::map as hir_map;
 use hir::map::DefPathHash;
 use lint::{self, Lint};
 use ich::{self, StableHashingContext, NodeIdHashingMode};
+use middle::const_val::ConstVal;
 use middle::free_region::FreeRegionMap;
 use middle::lang_items;
 use middle::resolve_lifetime::{self, ObjectLifetimeDefault};
@@ -49,7 +50,7 @@ use rustc_data_structures::stable_hasher::{HashStable, StableHasher,
                                            StableHasherResult};
 
 use arena::{TypedArena, DroplessArena};
-use rustc_const_math::ConstUsize;
+use rustc_const_math::{ConstInt, ConstUsize};
 use rustc_data_structures::indexed_vec::IndexVec;
 use std::borrow::Borrow;
 use std::cell::{Cell, RefCell};
@@ -1757,7 +1758,14 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 
     pub fn mk_array(self, ty: Ty<'tcx>, n: u64) -> Ty<'tcx> {
         let n = ConstUsize::new(n, self.sess.target.usize_ty).unwrap();
-        self.mk_ty(TyArray(ty, n))
+        self.mk_array_const_usize(ty, n)
+    }
+
+    pub fn mk_array_const_usize(self, ty: Ty<'tcx>, n: ConstUsize) -> Ty<'tcx> {
+        self.mk_ty(TyArray(ty, self.mk_const(ty::Const {
+            val: ConstVal::Integral(ConstInt::Usize(n)),
+            ty: self.types.usize
+        })))
     }
 
     pub fn mk_slice(self, ty: Ty<'tcx>) -> Ty<'tcx> {

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1190,18 +1190,6 @@ pub trait Lift<'tcx> {
     fn lift_to_tcx<'a, 'gcx>(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Option<Self::Lifted>;
 }
 
-impl<'a, 'tcx> Lift<'tcx> for ty::ParamEnv<'a> {
-    type Lifted = ty::ParamEnv<'tcx>;
-    fn lift_to_tcx<'b, 'gcx>(&self, tcx: TyCtxt<'b, 'gcx, 'tcx>) -> Option<ty::ParamEnv<'tcx>> {
-        self.caller_bounds.lift_to_tcx(tcx).and_then(|caller_bounds| {
-            Some(ty::ParamEnv {
-                reveal: self.reveal,
-                caller_bounds,
-            })
-        })
-    }
-}
-
 impl<'a, 'tcx> Lift<'tcx> for Ty<'a> {
     type Lifted = Ty<'tcx>;
     fn lift_to_tcx<'b, 'gcx>(&self, tcx: TyCtxt<'b, 'gcx, 'tcx>) -> Option<Ty<'tcx>> {

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -49,6 +49,7 @@ use rustc_data_structures::stable_hasher::{HashStable, StableHasher,
                                            StableHasherResult};
 
 use arena::{TypedArena, DroplessArena};
+use rustc_const_math::ConstUsize;
 use rustc_data_structures::indexed_vec::IndexVec;
 use std::borrow::Borrow;
 use std::cell::{Cell, RefCell};
@@ -1754,7 +1755,8 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         self.mk_imm_ptr(self.mk_nil())
     }
 
-    pub fn mk_array(self, ty: Ty<'tcx>, n: usize) -> Ty<'tcx> {
+    pub fn mk_array(self, ty: Ty<'tcx>, n: u64) -> Ty<'tcx> {
+        let n = ConstUsize::new(n, self.sess.target.usize_ty).unwrap();
         self.mk_ty(TyArray(ty, n))
     }
 

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -21,7 +21,6 @@ use hir::map as hir_map;
 use hir::map::DefPathHash;
 use lint::{self, Lint};
 use ich::{self, StableHashingContext, NodeIdHashingMode};
-use middle::const_val::ConstVal;
 use middle::free_region::FreeRegionMap;
 use middle::lang_items;
 use middle::resolve_lifetime::{self, ObjectLifetimeDefault};
@@ -33,7 +32,7 @@ use ty::ReprOptions;
 use traits;
 use ty::{self, Ty, TypeAndMut};
 use ty::{TyS, TypeVariants, Slice};
-use ty::{AdtKind, AdtDef, ClosureSubsts, GeneratorInterior, Region};
+use ty::{AdtKind, AdtDef, ClosureSubsts, GeneratorInterior, Region, Const};
 use ty::{PolyFnSig, InferTy, ParamTy, ProjectionTy, ExistentialPredicate, Predicate};
 use ty::RegionKind;
 use ty::{TyVar, TyVid, IntVar, IntVid, FloatVar, FloatVid};
@@ -109,7 +108,7 @@ pub struct CtxtInterners<'tcx> {
     region: RefCell<FxHashSet<Interned<'tcx, RegionKind>>>,
     existential_predicates: RefCell<FxHashSet<Interned<'tcx, Slice<ExistentialPredicate<'tcx>>>>>,
     predicates: RefCell<FxHashSet<Interned<'tcx, Slice<Predicate<'tcx>>>>>,
-    const_: RefCell<FxHashSet<Interned<'tcx, ConstVal<'tcx>>>>,
+    const_: RefCell<FxHashSet<Interned<'tcx, Const<'tcx>>>>,
 }
 
 impl<'gcx: 'tcx, 'tcx> CtxtInterners<'tcx> {
@@ -945,21 +944,21 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         }
     }
 
-    pub fn alloc_constval_slice(self, values: &[&'tcx ConstVal<'gcx>])
-                                -> &'gcx [&'tcx ConstVal<'gcx>] {
+    pub fn alloc_const_slice(self, values: &[&'tcx ty::Const<'tcx>])
+                             -> &'tcx [&'tcx ty::Const<'tcx>] {
         if values.is_empty() {
             &[]
         } else {
-            self.global_interners.arena.alloc_slice(values)
+            self.interners.arena.alloc_slice(values)
         }
     }
 
-    pub fn alloc_name_constval_slice(self, values: &[(ast::Name, &'tcx ConstVal<'gcx>)])
-                                     -> &'gcx [(ast::Name, &'tcx ConstVal<'gcx>)] {
+    pub fn alloc_name_const_slice(self, values: &[(ast::Name, &'tcx ty::Const<'tcx>)])
+                                  -> &'tcx [(ast::Name, &'tcx ty::Const<'tcx>)] {
         if values.is_empty() {
             &[]
         } else {
-            self.global_interners.arena.alloc_slice(values)
+            self.interners.arena.alloc_slice(values)
         }
     }
 
@@ -1216,13 +1215,10 @@ impl<'a, 'tcx> Lift<'tcx> for Ty<'a> {
     }
 }
 
-impl<'a, 'tcx> Lift<'tcx> for &'a Substs<'a> {
-    type Lifted = &'tcx Substs<'tcx>;
-    fn lift_to_tcx<'b, 'gcx>(&self, tcx: TyCtxt<'b, 'gcx, 'tcx>) -> Option<&'tcx Substs<'tcx>> {
-        if self.len() == 0 {
-            return Some(Slice::empty());
-        }
-        if tcx.interners.arena.in_arena(&self[..] as *const _) {
+impl<'a, 'tcx> Lift<'tcx> for Region<'a> {
+    type Lifted = Region<'tcx>;
+    fn lift_to_tcx<'b, 'gcx>(&self, tcx: TyCtxt<'b, 'gcx, 'tcx>) -> Option<Region<'tcx>> {
+        if tcx.interners.arena.in_arena(*self as *const _) {
             return Some(unsafe { mem::transmute(*self) });
         }
         // Also try in the global tcx if we're not that.
@@ -1234,10 +1230,28 @@ impl<'a, 'tcx> Lift<'tcx> for &'a Substs<'a> {
     }
 }
 
-impl<'a, 'tcx> Lift<'tcx> for Region<'a> {
-    type Lifted = Region<'tcx>;
-    fn lift_to_tcx<'b, 'gcx>(&self, tcx: TyCtxt<'b, 'gcx, 'tcx>) -> Option<Region<'tcx>> {
+impl<'a, 'tcx> Lift<'tcx> for &'a Const<'a> {
+    type Lifted = &'tcx Const<'tcx>;
+    fn lift_to_tcx<'b, 'gcx>(&self, tcx: TyCtxt<'b, 'gcx, 'tcx>) -> Option<&'tcx Const<'tcx>> {
         if tcx.interners.arena.in_arena(*self as *const _) {
+            return Some(unsafe { mem::transmute(*self) });
+        }
+        // Also try in the global tcx if we're not that.
+        if !tcx.is_global() {
+            self.lift_to_tcx(tcx.global_tcx())
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a, 'tcx> Lift<'tcx> for &'a Substs<'a> {
+    type Lifted = &'tcx Substs<'tcx>;
+    fn lift_to_tcx<'b, 'gcx>(&self, tcx: TyCtxt<'b, 'gcx, 'tcx>) -> Option<&'tcx Substs<'tcx>> {
+        if self.len() == 0 {
+            return Some(Slice::empty());
+        }
+        if tcx.interners.arena.in_arena(&self[..] as *const _) {
             return Some(unsafe { mem::transmute(*self) });
         }
         // Also try in the global tcx if we're not that.
@@ -1536,8 +1550,8 @@ impl<'tcx: 'lcx, 'lcx> Borrow<[Predicate<'lcx>]>
     }
 }
 
-impl<'tcx: 'lcx, 'lcx> Borrow<ConstVal<'lcx>> for Interned<'tcx, ConstVal<'tcx>> {
-    fn borrow<'a>(&'a self) -> &'a ConstVal<'lcx> {
+impl<'tcx: 'lcx, 'lcx> Borrow<Const<'lcx>> for Interned<'tcx, Const<'tcx>> {
+    fn borrow<'a>(&'a self) -> &'a Const<'lcx> {
         &self.0
     }
 }
@@ -1623,7 +1637,7 @@ direct_interners!('tcx,
             _ => false
         }
     }) -> RegionKind,
-    const_: mk_const(/*|c: &Const| keep_local(&c.ty)*/ |_| false) -> ConstVal<'tcx>
+    const_: mk_const(|c: &Const| keep_local(&c.ty) || keep_local(&c.val)) -> Const<'tcx>
 );
 
 macro_rules! slice_interners {

--- a/src/librustc/ty/error.rs
+++ b/src/librustc/ty/error.rs
@@ -18,6 +18,8 @@ use syntax::ast;
 use errors::DiagnosticBuilder;
 use syntax_pos::Span;
 
+use rustc_const_math::ConstUsize;
+
 use hir;
 
 #[derive(Clone, Copy, Debug)]
@@ -34,7 +36,7 @@ pub enum TypeError<'tcx> {
     AbiMismatch(ExpectedFound<abi::Abi>),
     Mutability,
     TupleSize(ExpectedFound<usize>),
-    FixedArraySize(ExpectedFound<usize>),
+    FixedArraySize(ExpectedFound<ConstUsize>),
     ArgCount,
 
     RegionsDoesNotOutlive(Region<'tcx>, Region<'tcx>),

--- a/src/librustc/ty/flags.rs
+++ b/src/librustc/ty/flags.rs
@@ -235,6 +235,10 @@ impl FlagComputation {
             ConstVal::Aggregate(ConstAggregate::Repeat(v, _)) => {
                 self.add_const(v);
             }
+            ConstVal::Unevaluated(_, substs) => {
+                self.add_flags(TypeFlags::HAS_PROJECTION);
+                self.add_substs(substs);
+            }
         }
     }
 

--- a/src/librustc/ty/inhabitedness/mod.rs
+++ b/src/librustc/ty/inhabitedness/mod.rs
@@ -205,7 +205,7 @@ impl<'a, 'gcx, 'tcx> TyS<'tcx> {
                 }))
             },
             TyArray(ty, len) => {
-                if len == 0 {
+                if len.as_u64() == 0 {
                     DefIdForest::empty()
                 } else {
                     ty.uninhabited_from(visited, tcx)

--- a/src/librustc/ty/inhabitedness/mod.rs
+++ b/src/librustc/ty/inhabitedness/mod.rs
@@ -205,7 +205,7 @@ impl<'a, 'gcx, 'tcx> TyS<'tcx> {
                 }))
             },
             TyArray(ty, len) => {
-                if len.as_u64() == 0 {
+                if len.val.to_const_int().unwrap().to_u64().unwrap() == 0 {
                     DefIdForest::empty()
                 } else {
                     ty.uninhabited_from(visited, tcx)

--- a/src/librustc/ty/inhabitedness/mod.rs
+++ b/src/librustc/ty/inhabitedness/mod.rs
@@ -205,7 +205,7 @@ impl<'a, 'gcx, 'tcx> TyS<'tcx> {
                 }))
             },
             TyArray(ty, len) => {
-                if len.val.to_const_int().unwrap().to_u64().unwrap() == 0 {
+                if len.val.to_const_int().and_then(|i| i.to_u64()) == Some(0) {
                     DefIdForest::empty()
                 } else {
                     ty.uninhabited_from(visited, tcx)

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -837,12 +837,22 @@ impl<'a, 'tcx> Struct {
 
             // Is this a fixed-size array of something non-zero
             // with at least one element?
-            (_, &ty::TyArray(ety, d)) if d.val.to_const_int().unwrap().to_u64().unwrap() != 0 => {
-                Struct::non_zero_field_paths(
-                    tcx,
-                    param_env,
-                    Some(ety).into_iter(),
-                    None)
+            (_, &ty::TyArray(ety, mut count)) => {
+                if count.has_projections() {
+                    count = tcx.normalize_associated_type_in_env(&count, param_env);
+                    if count.has_projections() {
+                        return Err(LayoutError::Unknown(ty));
+                    }
+                }
+                if count.val.to_const_int().unwrap().to_u64().unwrap() != 0 {
+                    Struct::non_zero_field_paths(
+                        tcx,
+                        param_env,
+                        Some(ety).into_iter(),
+                        None)
+                } else {
+                    Ok(None)
+                }
             }
 
             (_, &ty::TyProjection(_)) | (_, &ty::TyAnon(..)) => {
@@ -1174,7 +1184,14 @@ impl<'a, 'tcx> Layout {
             }
 
             // Arrays and slices.
-            ty::TyArray(element, count) => {
+            ty::TyArray(element, mut count) => {
+                if count.has_projections() {
+                    count = tcx.normalize_associated_type_in_env(&count, param_env);
+                    if count.has_projections() {
+                        return Err(LayoutError::Unknown(ty));
+                    }
+                }
+
                 let element = element.layout(tcx, param_env)?;
                 let element_size = element.size(dl);
                 let count = count.val.to_const_int().unwrap().to_u64().unwrap();

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -837,7 +837,7 @@ impl<'a, 'tcx> Struct {
 
             // Is this a fixed-size array of something non-zero
             // with at least one element?
-            (_, &ty::TyArray(ety, d)) if d.as_u64() > 0 => {
+            (_, &ty::TyArray(ety, d)) if d.val.to_const_int().unwrap().to_u64().unwrap() != 0 => {
                 Struct::non_zero_field_paths(
                     tcx,
                     param_env,
@@ -1177,7 +1177,7 @@ impl<'a, 'tcx> Layout {
             ty::TyArray(element, count) => {
                 let element = element.layout(tcx, param_env)?;
                 let element_size = element.size(dl);
-                let count = count.as_u64();
+                let count = count.val.to_const_int().unwrap().to_u64().unwrap();
                 if element_size.checked_mul(count, dl).is_none() {
                     return Err(LayoutError::SizeOverflow(ty));
                 }

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -837,7 +837,7 @@ impl<'a, 'tcx> Struct {
 
             // Is this a fixed-size array of something non-zero
             // with at least one element?
-            (_, &ty::TyArray(ety, d)) if d > 0 => {
+            (_, &ty::TyArray(ety, d)) if d.as_u64() > 0 => {
                 Struct::non_zero_field_paths(
                     tcx,
                     param_env,
@@ -1177,9 +1177,7 @@ impl<'a, 'tcx> Layout {
             ty::TyArray(element, count) => {
                 let element = element.layout(tcx, param_env)?;
                 let element_size = element.size(dl);
-                // FIXME(eddyb) Don't use host `usize` for array lengths.
-                let usize_count: usize = count;
-                let count = usize_count as u64;
+                let count = count.as_u64();
                 if element_size.checked_mul(count, dl).is_none() {
                     return Err(LayoutError::SizeOverflow(ty));
                 }

--- a/src/librustc/ty/maps.rs
+++ b/src/librustc/ty/maps.rs
@@ -159,12 +159,21 @@ impl Key for (MirSuite, MirPassIndex, DefId) {
     }
 }
 
-impl<'tcx, T: Clone + Hash + Eq + Debug> Key for ty::ParamEnvAnd<'tcx, T> {
+impl<'tcx> Key for Ty<'tcx> {
     fn map_crate(&self) -> CrateNum {
         LOCAL_CRATE
     }
     fn default_span(&self, _: TyCtxt) -> Span {
         DUMMY_SP
+    }
+}
+
+impl<'tcx, T: Key> Key for ty::ParamEnvAnd<'tcx, T> {
+    fn map_crate(&self) -> CrateNum {
+        self.value.map_crate()
+    }
+    fn default_span(&self, tcx: TyCtxt) -> Span {
+        self.value.default_span(tcx)
     }
 }
 

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1601,7 +1601,7 @@ impl<'a, 'gcx, 'tcx> AdtDef {
             if let VariantDiscr::Explicit(expr_did) = v.discr {
                 let substs = Substs::identity_for_item(tcx.global_tcx(), expr_did);
                 match tcx.const_eval(param_env.and((expr_did, substs))) {
-                    Ok(ConstVal::Integral(v)) => {
+                    Ok(&ConstVal::Integral(v)) => {
                         discr = v;
                     }
                     err => {
@@ -1641,7 +1641,7 @@ impl<'a, 'gcx, 'tcx> AdtDef {
                 ty::VariantDiscr::Explicit(expr_did) => {
                     let substs = Substs::identity_for_item(tcx.global_tcx(), expr_did);
                     match tcx.const_eval(param_env.and((expr_did, substs))) {
-                        Ok(ConstVal::Integral(v)) => {
+                        Ok(&ConstVal::Integral(v)) => {
                             explicit_value = v;
                             break;
                         }

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -64,7 +64,7 @@ pub use self::sty::{InferTy, ParamTy, ProjectionTy, ExistentialPredicate};
 pub use self::sty::{ClosureSubsts, GeneratorInterior, TypeAndMut};
 pub use self::sty::{TraitRef, TypeVariants, PolyTraitRef};
 pub use self::sty::{ExistentialTraitRef, PolyExistentialTraitRef};
-pub use self::sty::{ExistentialProjection, PolyExistentialProjection};
+pub use self::sty::{ExistentialProjection, PolyExistentialProjection, Const};
 pub use self::sty::{BoundRegion, EarlyBoundRegion, FreeRegion, Region};
 pub use self::sty::RegionKind;
 pub use self::sty::{TyVid, IntVid, FloatVid, RegionVid, SkolemizedRegionVid};
@@ -1601,7 +1601,7 @@ impl<'a, 'gcx, 'tcx> AdtDef {
             if let VariantDiscr::Explicit(expr_did) = v.discr {
                 let substs = Substs::identity_for_item(tcx.global_tcx(), expr_did);
                 match tcx.const_eval(param_env.and((expr_did, substs))) {
-                    Ok(&ConstVal::Integral(v)) => {
+                    Ok(&ty::Const { val: ConstVal::Integral(v), .. }) => {
                         discr = v;
                     }
                     err => {
@@ -1641,7 +1641,7 @@ impl<'a, 'gcx, 'tcx> AdtDef {
                 ty::VariantDiscr::Explicit(expr_did) => {
                     let substs = Substs::identity_for_item(tcx.global_tcx(), expr_did);
                     match tcx.const_eval(param_env.and((expr_did, substs))) {
-                        Ok(&ConstVal::Integral(v)) => {
+                        Ok(&ty::Const { val: ConstVal::Integral(v), .. }) => {
                             explicit_value = v;
                             break;
                         }

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1665,11 +1665,11 @@ impl<'a, 'gcx, 'tcx> AdtDef {
         match repr_type {
             attr::UnsignedInt(ty) => {
                 ConstInt::new_unsigned_truncating(discr, ty,
-                                                  tcx.sess.target.uint_type)
+                                                  tcx.sess.target.usize_ty)
             }
             attr::SignedInt(ty) => {
                 ConstInt::new_signed_truncating(discr as i128, ty,
-                                                tcx.sess.target.int_type)
+                                                tcx.sess.target.isize_ty)
             }
         }
     }

--- a/src/librustc/ty/relate.rs
+++ b/src/librustc/ty/relate.rs
@@ -429,7 +429,7 @@ pub fn super_relate_tys<'a, 'gcx, 'tcx, R>(relation: &mut R,
         {
             let t = relation.relate(&a_t, &b_t)?;
             if sz_a == sz_b {
-                Ok(tcx.mk_array(t, sz_a))
+                Ok(tcx.mk_array(t, sz_a.as_u64()))
             } else {
                 Err(TypeError::FixedArraySize(expected_found(relation, &sz_a, &sz_b)))
             }

--- a/src/librustc/ty/relate.rs
+++ b/src/librustc/ty/relate.rs
@@ -428,10 +428,14 @@ pub fn super_relate_tys<'a, 'gcx, 'tcx, R>(relation: &mut R,
         (&ty::TyArray(a_t, sz_a), &ty::TyArray(b_t, sz_b)) =>
         {
             let t = relation.relate(&a_t, &b_t)?;
-            if sz_a == sz_b {
-                Ok(tcx.mk_array(t, sz_a.as_u64()))
+            assert_eq!(sz_a.ty, tcx.types.usize);
+            assert_eq!(sz_b.ty, tcx.types.usize);
+            let sz_a_u64 = sz_a.val.to_const_int().unwrap().to_u64().unwrap();
+            let sz_b_u64 = sz_b.val.to_const_int().unwrap().to_u64().unwrap();
+            if sz_a_u64 == sz_b_u64 {
+                Ok(tcx.mk_ty(ty::TyArray(t, sz_a)))
             } else {
-                Err(TypeError::FixedArraySize(expected_found(relation, &sz_a, &sz_b)))
+                Err(TypeError::FixedArraySize(expected_found(relation, &sz_a_u64, &sz_b_u64)))
             }
         }
 

--- a/src/librustc/ty/structural_impls.rs
+++ b/src/librustc/ty/structural_impls.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use infer::type_variable;
-use middle::const_val::{ConstVal, ConstAggregate};
+use middle::const_val::{self, ConstVal, ConstAggregate, ConstEvalErr};
 use ty::{self, Lift, Ty, TyCtxt};
 use ty::fold::{TypeFoldable, TypeFolder, TypeVisitor};
 use rustc_data_structures::accumulate_vec::AccumulateVec;
@@ -56,6 +56,13 @@ impl<'tcx, T: Lift<'tcx>, E: Lift<'tcx>> Lift<'tcx> for Result<T, E> {
             Ok(ref x) => tcx.lift(x).map(Ok),
             Err(ref e) => tcx.lift(e).map(Err)
         }
+    }
+}
+
+impl<'tcx, T: Lift<'tcx>> Lift<'tcx> for Box<T> {
+    type Lifted = Box<T::Lifted>;
+    fn lift_to_tcx<'a, 'gcx>(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Option<Self::Lifted> {
+        tcx.lift(&**self).map(Box::new)
     }
 }
 
@@ -210,6 +217,11 @@ impl<'a, 'tcx> Lift<'tcx> for ty::Predicate<'a> {
             ty::Predicate::ObjectSafe(trait_def_id) => {
                 Some(ty::Predicate::ObjectSafe(trait_def_id))
             }
+            ty::Predicate::ConstEvaluatable(def_id, substs) => {
+                tcx.lift(&substs).map(|substs| {
+                    ty::Predicate::ConstEvaluatable(def_id, substs)
+                })
+            }
         }
     }
 }
@@ -218,6 +230,32 @@ impl<'tcx, T: Lift<'tcx>> Lift<'tcx> for ty::Binder<T> {
     type Lifted = ty::Binder<T::Lifted>;
     fn lift_to_tcx<'a, 'gcx>(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Option<Self::Lifted> {
         tcx.lift(&self.0).map(|x| ty::Binder(x))
+    }
+}
+
+impl<'a, 'tcx> Lift<'tcx> for ty::ParamEnv<'a> {
+    type Lifted = ty::ParamEnv<'tcx>;
+    fn lift_to_tcx<'b, 'gcx>(&self, tcx: TyCtxt<'b, 'gcx, 'tcx>) -> Option<Self::Lifted> {
+        tcx.lift(&self.caller_bounds).map(|caller_bounds| {
+            ty::ParamEnv {
+                reveal: self.reveal,
+                caller_bounds,
+            }
+        })
+    }
+}
+
+impl<'a, 'tcx, T: Lift<'tcx>> Lift<'tcx> for ty::ParamEnvAnd<'a, T> {
+    type Lifted = ty::ParamEnvAnd<'tcx, T::Lifted>;
+    fn lift_to_tcx<'b, 'gcx>(&self, tcx: TyCtxt<'b, 'gcx, 'tcx>) -> Option<Self::Lifted> {
+        tcx.lift(&self.param_env).and_then(|param_env| {
+            tcx.lift(&self.value).map(|value| {
+                ty::ParamEnvAnd {
+                    param_env,
+                    value,
+                }
+            })
+        })
     }
 }
 
@@ -395,6 +433,64 @@ impl<'a, 'tcx> Lift<'tcx> for ty::error::TypeError<'a> {
     }
 }
 
+impl<'a, 'tcx> Lift<'tcx> for ConstEvalErr<'a> {
+    type Lifted = ConstEvalErr<'tcx>;
+    fn lift_to_tcx<'b, 'gcx>(&self, tcx: TyCtxt<'b, 'gcx, 'tcx>) -> Option<Self::Lifted> {
+        tcx.lift(&self.kind).map(|kind| {
+            ConstEvalErr {
+                span: self.span,
+                kind,
+            }
+        })
+    }
+}
+
+impl<'a, 'tcx> Lift<'tcx> for const_val::ErrKind<'a> {
+    type Lifted = const_val::ErrKind<'tcx>;
+    fn lift_to_tcx<'b, 'gcx>(&self, tcx: TyCtxt<'b, 'gcx, 'tcx>) -> Option<Self::Lifted> {
+        use middle::const_val::ErrKind::*;
+
+        Some(match *self {
+            CannotCast => CannotCast,
+            MissingStructField => MissingStructField,
+            NonConstPath => NonConstPath,
+            UnimplementedConstVal(s) => UnimplementedConstVal(s),
+            ExpectedConstTuple => ExpectedConstTuple,
+            ExpectedConstStruct => ExpectedConstStruct,
+            IndexedNonVec => IndexedNonVec,
+            IndexNotUsize => IndexNotUsize,
+            IndexOutOfBounds { len, index } => IndexOutOfBounds { len, index },
+            MiscBinaryOp => MiscBinaryOp,
+            MiscCatchAll => MiscCatchAll,
+            IndexOpFeatureGated => IndexOpFeatureGated,
+            Math(ref e) => Math(e.clone()),
+
+            LayoutError(ref e) => {
+                return tcx.lift(e).map(LayoutError)
+            }
+            ErroneousReferencedConstant(ref e) => {
+                return tcx.lift(e).map(ErroneousReferencedConstant)
+            }
+
+            TypeckError => TypeckError,
+        })
+    }
+}
+
+impl<'a, 'tcx> Lift<'tcx> for ty::layout::LayoutError<'a> {
+    type Lifted = ty::layout::LayoutError<'tcx>;
+    fn lift_to_tcx<'b, 'gcx>(&self, tcx: TyCtxt<'b, 'gcx, 'tcx>) -> Option<Self::Lifted> {
+        match *self {
+            ty::layout::LayoutError::Unknown(ref ty) => {
+                tcx.lift(ty).map(ty::layout::LayoutError::Unknown)
+            }
+            ty::layout::LayoutError::SizeOverflow(ref ty) => {
+                tcx.lift(ty).map(ty::layout::LayoutError::SizeOverflow)
+            }
+        }
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////
 // TypeFoldable implementations.
 //
@@ -409,6 +505,13 @@ impl<'a, 'tcx> Lift<'tcx> for ty::error::TypeError<'a> {
 macro_rules! CopyImpls {
     ($($ty:ty),+) => {
         $(
+            impl<'tcx> Lift<'tcx> for $ty {
+                type Lifted = Self;
+                fn lift_to_tcx<'a, 'gcx>(&self, _: TyCtxt<'a, 'gcx, 'tcx>) -> Option<Self> {
+                    Some(*self)
+                }
+            }
+
             impl<'tcx> TypeFoldable<'tcx> for $ty {
                 fn super_fold_with<'gcx: 'tcx, F: TypeFolder<'gcx, 'tcx>>(&self, _: &mut F) -> $ty {
                     *self
@@ -866,6 +969,8 @@ impl<'tcx> TypeFoldable<'tcx> for ty::Predicate<'tcx> {
                 ty::Predicate::ClosureKind(closure_def_id, kind),
             ty::Predicate::ObjectSafe(trait_def_id) =>
                 ty::Predicate::ObjectSafe(trait_def_id),
+            ty::Predicate::ConstEvaluatable(def_id, substs) =>
+                ty::Predicate::ConstEvaluatable(def_id, substs.fold_with(folder)),
         }
     }
 
@@ -880,6 +985,7 @@ impl<'tcx> TypeFoldable<'tcx> for ty::Predicate<'tcx> {
             ty::Predicate::WellFormed(data) => data.visit_with(visitor),
             ty::Predicate::ClosureKind(_closure_def_id, _kind) => false,
             ty::Predicate::ObjectSafe(_trait_def_id) => false,
+            ty::Predicate::ConstEvaluatable(_def_id, substs) => substs.visit_with(visitor),
         }
     }
 }
@@ -1153,6 +1259,9 @@ impl<'tcx> TypeFoldable<'tcx> for ConstVal<'tcx> {
                 let v = v.fold_with(folder);
                 ConstVal::Aggregate(ConstAggregate::Repeat(v, count))
             }
+            ConstVal::Unevaluated(def_id, substs) => {
+                ConstVal::Unevaluated(def_id, substs.fold_with(folder))
+            }
         }
     }
 
@@ -1176,6 +1285,7 @@ impl<'tcx> TypeFoldable<'tcx> for ConstVal<'tcx> {
             ConstVal::Aggregate(ConstAggregate::Repeat(v, _)) => {
                 v.visit_with(visitor)
             }
+            ConstVal::Unevaluated(_, substs) => substs.visit_with(visitor),
         }
     }
 }
@@ -1190,7 +1300,15 @@ impl<'tcx> TypeFoldable<'tcx> for &'tcx ty::Const<'tcx> {
         })
     }
 
+    fn fold_with<'gcx: 'tcx, F: TypeFolder<'gcx, 'tcx>>(&self, folder: &mut F) -> Self {
+        folder.fold_const(*self)
+    }
+
     fn super_visit_with<V: TypeVisitor<'tcx>>(&self, visitor: &mut V) -> bool {
         self.ty.visit_with(visitor) || self.val.visit_with(visitor)
+    }
+
+    fn visit_with<V: TypeVisitor<'tcx>>(&self, visitor: &mut V) -> bool {
+        visitor.visit_const(self)
     }
 }

--- a/src/librustc/ty/structural_impls.rs
+++ b/src/librustc/ty/structural_impls.rs
@@ -552,7 +552,7 @@ impl<'tcx> TypeFoldable<'tcx> for Ty<'tcx> {
     fn super_fold_with<'gcx: 'tcx, F: TypeFolder<'gcx, 'tcx>>(&self, folder: &mut F) -> Self {
         let sty = match self.sty {
             ty::TyRawPtr(tm) => ty::TyRawPtr(tm.fold_with(folder)),
-            ty::TyArray(typ, sz) => ty::TyArray(typ.fold_with(folder), sz),
+            ty::TyArray(typ, sz) => ty::TyArray(typ.fold_with(folder), sz.fold_with(folder)),
             ty::TySlice(typ) => ty::TySlice(typ.fold_with(folder)),
             ty::TyAdt(tid, substs) => ty::TyAdt(tid, substs.fold_with(folder)),
             ty::TyDynamic(ref trait_ty, ref region) =>
@@ -590,7 +590,7 @@ impl<'tcx> TypeFoldable<'tcx> for Ty<'tcx> {
     fn super_visit_with<V: TypeVisitor<'tcx>>(&self, visitor: &mut V) -> bool {
         match self.sty {
             ty::TyRawPtr(ref tm) => tm.visit_with(visitor),
-            ty::TyArray(typ, _sz) => typ.visit_with(visitor),
+            ty::TyArray(typ, sz) => typ.visit_with(visitor) || sz.visit_with(visitor),
             ty::TySlice(typ) => typ.visit_with(visitor),
             ty::TyAdt(_, substs) => substs.visit_with(visitor),
             ty::TyDynamic(ref trait_ty, ref reg) =>

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -12,6 +12,7 @@
 
 use hir::def_id::DefId;
 
+use middle::const_val::ConstVal;
 use middle::region;
 use ty::subst::{Substs, Subst};
 use ty::{self, AdtDef, TypeFlags, Ty, TyCtxt, TypeFoldable};
@@ -1458,3 +1459,14 @@ impl<'a, 'gcx, 'tcx> TyS<'tcx> {
         }
     }
 }
+
+/// Typed constant value.
+#[derive(Copy, Clone, Debug, Hash, RustcEncodable, RustcDecodable, Eq, PartialEq)]
+pub struct Const<'tcx> {
+    pub ty: Ty<'tcx>,
+
+    // FIXME(eddyb) Replace this with a miri value.
+    pub val: ConstVal<'tcx>,
+}
+
+impl<'tcx> serialize::UseSpecializedDecodable for &'tcx Const<'tcx> {}

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -27,8 +27,6 @@ use syntax::ast::{self, Name};
 use syntax::symbol::keywords;
 use util::nodemap::FxHashMap;
 
-use rustc_const_math::ConstUsize;
-
 use serialize;
 
 use hir;
@@ -112,7 +110,7 @@ pub enum TypeVariants<'tcx> {
     TyStr,
 
     /// An array with the given length. Written as `[T; n]`.
-    TyArray(Ty<'tcx>, ConstUsize),
+    TyArray(Ty<'tcx>, &'tcx ty::Const<'tcx>),
 
     /// The pointee of an array slice.  Written as `[T]`.
     TySlice(Ty<'tcx>),

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -27,6 +27,8 @@ use syntax::ast::{self, Name};
 use syntax::symbol::keywords;
 use util::nodemap::FxHashMap;
 
+use rustc_const_math::ConstUsize;
+
 use serialize;
 
 use hir;
@@ -110,7 +112,7 @@ pub enum TypeVariants<'tcx> {
     TyStr,
 
     /// An array with the given length. Written as `[T; n]`.
-    TyArray(Ty<'tcx>, usize),
+    TyArray(Ty<'tcx>, ConstUsize),
 
     /// The pointee of an array slice.  Written as `[T]`.
     TySlice(Ty<'tcx>),

--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -53,7 +53,7 @@ macro_rules! typed_literal {
             SignedInt(ast::IntTy::I32)   => ConstInt::I32($lit),
             SignedInt(ast::IntTy::I64)   => ConstInt::I64($lit),
             SignedInt(ast::IntTy::I128)   => ConstInt::I128($lit),
-            SignedInt(ast::IntTy::Is) => match $tcx.sess.target.int_type {
+            SignedInt(ast::IntTy::Is) => match $tcx.sess.target.isize_ty {
                 ast::IntTy::I16 => ConstInt::Isize(ConstIsize::Is16($lit)),
                 ast::IntTy::I32 => ConstInt::Isize(ConstIsize::Is32($lit)),
                 ast::IntTy::I64 => ConstInt::Isize(ConstIsize::Is64($lit)),
@@ -64,7 +64,7 @@ macro_rules! typed_literal {
             UnsignedInt(ast::UintTy::U32) => ConstInt::U32($lit),
             UnsignedInt(ast::UintTy::U64) => ConstInt::U64($lit),
             UnsignedInt(ast::UintTy::U128) => ConstInt::U128($lit),
-            UnsignedInt(ast::UintTy::Us) => match $tcx.sess.target.uint_type {
+            UnsignedInt(ast::UintTy::Us) => match $tcx.sess.target.usize_ty {
                 ast::UintTy::U16 => ConstInt::Usize(ConstUsize::Us16($lit)),
                 ast::UintTy::U32 => ConstInt::Usize(ConstUsize::Us32($lit)),
                 ast::UintTy::U64 => ConstInt::Usize(ConstUsize::Us64($lit)),
@@ -638,7 +638,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     }
 
     pub fn const_usize(&self, val: u16) -> ConstInt {
-        match self.sess.target.uint_type {
+        match self.sess.target.usize_ty {
             ast::UintTy::U16 => ConstInt::Usize(ConstUsize::Us16(val as u16)),
             ast::UintTy::U32 => ConstInt::Usize(ConstUsize::Us32(val as u32)),
             ast::UintTy::U64 => ConstInt::Usize(ConstUsize::Us64(val as u64)),

--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -697,7 +697,9 @@ impl<'a, 'gcx, 'tcx, W> TypeVisitor<'tcx> for TypeIdHasher<'a, 'gcx, 'tcx, W>
             TyInt(i) => self.hash(i),
             TyUint(u) => self.hash(u),
             TyFloat(f) => self.hash(f),
-            TyArray(_, n) => self.hash(n),
+            TyArray(_, n) => {
+                self.hash(n.val.to_const_int().unwrap().to_u64().unwrap())
+            }
             TyRawPtr(m) |
             TyRef(_, m) => self.hash(m.mutbl),
             TyClosure(def_id, _) |

--- a/src/librustc/ty/walk.rs
+++ b/src/librustc/ty/walk.rs
@@ -160,6 +160,9 @@ fn push_const<'tcx>(stack: &mut TypeWalkerStack<'tcx>, constant: &'tcx ty::Const
         ConstVal::Aggregate(ConstAggregate::Repeat(v, _)) => {
             push_const(stack, v);
         }
+        ConstVal::Unevaluated(_, substs) => {
+            stack.extend(substs.types().rev());
+        }
     }
     stack.push(constant.ty);
 }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -10,6 +10,7 @@
 
 use hir::def_id::DefId;
 use hir::map::definitions::DefPathData;
+use middle::const_val::ConstVal;
 use middle::region::{self, BlockRemainder};
 use ty::subst::{self, Subst};
 use ty::{BrAnon, BrEnv, BrFresh, BrNamed};
@@ -24,6 +25,7 @@ use std::cell::Cell;
 use std::fmt;
 use std::usize;
 
+use rustc_const_math::ConstInt;
 use syntax::abi::Abi;
 use syntax::ast::CRATE_NODE_ID;
 use syntax::symbol::Symbol;
@@ -886,7 +888,18 @@ impl<'tcx> fmt::Display for ty::TypeVariants<'tcx> {
 
                 write!(f, "]")
             }),
-            TyArray(ty, sz) => write!(f, "[{}; {}]",  ty, sz),
+            TyArray(ty, sz) => {
+                write!(f, "[{}; ", ty)?;
+                match sz.val {
+                    ConstVal::Integral(ConstInt::Usize(sz)) => {
+                        write!(f, "{}", sz)?;
+                    }
+                    _ => {
+                        write!(f, "{:?}", sz)?;
+                    }
+                }
+                write!(f, "]")
+            }
             TySlice(ty) => write!(f, "[{}]",  ty)
         }
     }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -430,6 +430,9 @@ impl<'tcx> fmt::Debug for ty::Predicate<'tcx> {
             ty::Predicate::ClosureKind(closure_def_id, kind) => {
                 write!(f, "ClosureKind({:?}, {:?})", closure_def_id, kind)
             }
+            ty::Predicate::ConstEvaluatable(def_id, substs) => {
+                write!(f, "ConstEvaluatable({:?}, {:?})", def_id, substs)
+            }
         }
     }
 }
@@ -894,6 +897,9 @@ impl<'tcx> fmt::Display for ty::TypeVariants<'tcx> {
                     ConstVal::Integral(ConstInt::Usize(sz)) => {
                         write!(f, "{}", sz)?;
                     }
+                    ConstVal::Unevaluated(_def_id, substs) => {
+                        write!(f, "<unevaluated{:?}>", &substs[..])?;
+                    }
                     _ => {
                         write!(f, "{:?}", sz)?;
                     }
@@ -1048,6 +1054,11 @@ impl<'tcx> fmt::Display for ty::Predicate<'tcx> {
                     write!(f, "the closure `{}` implements the trait `{}`",
                            tcx.item_path_str(closure_def_id), kind)
                 }),
+            ty::Predicate::ConstEvaluatable(def_id, substs) => {
+                write!(f, "the constant `")?;
+                parameterized(f, substs, def_id, &[])?;
+                write!(f, "` can be evaluated")
+            }
         }
     }
 }

--- a/src/librustc_const_eval/check_match.rs
+++ b/src/librustc_const_eval/check_match.rs
@@ -140,7 +140,7 @@ impl<'a, 'tcx> MatchVisitor<'a, 'tcx> {
     fn check_match(
         &self,
         scrut: &hir::Expr,
-        arms: &[hir::Arm],
+        arms: &'tcx [hir::Arm],
         source: hir::MatchSource)
     {
         for arm in arms {
@@ -231,7 +231,7 @@ impl<'a, 'tcx> MatchVisitor<'a, 'tcx> {
         }
     }
 
-    fn check_irrefutable(&self, pat: &Pat, origin: &str) {
+    fn check_irrefutable(&self, pat: &'tcx Pat, origin: &str) {
         let module = self.tcx.hir.get_module_parent(pat.id);
         MatchCheckCtxt::create_and_enter(self.tcx, module, |ref mut cx| {
             let mut patcx = PatternContext::new(self.tcx,

--- a/src/librustc_const_eval/diagnostics.rs
+++ b/src/librustc_const_eval/diagnostics.rs
@@ -565,7 +565,7 @@ See also https://github.com/rust-lang/rust/issues/14587
 
 
 register_diagnostics! {
-    E0298, // cannot compare constants
+//  E0298, // cannot compare constants
 //  E0299, // mismatched types between arms
 //  E0471, // constant evaluation error (in pattern)
 }

--- a/src/librustc_const_eval/eval.rs
+++ b/src/librustc_const_eval/eval.rs
@@ -334,7 +334,8 @@ fn eval_const_expr_partial<'a, 'tcx>(cx: &ConstContext<'a, 'tcx>,
 
           if tcx.fn_sig(def_id).abi() == Abi::RustIntrinsic {
             let layout_of = |ty: Ty<'tcx>| {
-                ty.layout(tcx, cx.param_env).map_err(|err| {
+                let ty = tcx.erase_regions(&ty);
+                tcx.at(e.span).layout_raw(cx.param_env.reveal_all().and(ty)).map_err(|err| {
                     ConstEvalErr { span: e.span, kind: LayoutError(err) }
                 })
             };

--- a/src/librustc_const_eval/pattern.rs
+++ b/src/librustc_const_eval/pattern.rs
@@ -537,7 +537,8 @@ impl<'a, 'tcx> PatternContext<'a, 'tcx> {
 
             ty::TyArray(_, len) => {
                 // fixed-length array
-                assert!(len.as_u64() >= prefix.len() as u64 + suffix.len() as u64);
+                let len = len.val.to_const_int().unwrap().to_u64().unwrap();
+                assert!(len >= prefix.len() as u64 + suffix.len() as u64);
                 PatternKind::Array { prefix: prefix, slice: slice, suffix: suffix }
             }
 

--- a/src/librustc_const_eval/pattern.rs
+++ b/src/librustc_const_eval/pattern.rs
@@ -83,12 +83,12 @@ pub enum PatternKind<'tcx> {
     },
 
     Constant {
-        value: &'tcx ConstVal<'tcx>,
+        value: &'tcx ty::Const<'tcx>,
     },
 
     Range {
-        lo: &'tcx ConstVal<'tcx>,
-        hi: &'tcx ConstVal<'tcx>,
+        lo: &'tcx ty::Const<'tcx>,
+        hi: &'tcx ty::Const<'tcx>,
         end: RangeEnd,
     },
 
@@ -228,15 +228,15 @@ impl<'tcx> fmt::Display for Pattern<'tcx> {
                 write!(f, "{}", subpattern)
             }
             PatternKind::Constant { value } => {
-                print_const_val(value, f)
+                print_const_val(&value.val, f)
             }
             PatternKind::Range { lo, hi, end } => {
-                print_const_val(lo, f)?;
+                print_const_val(&lo.val, f)?;
                 match end {
                     RangeEnd::Included => write!(f, "...")?,
                     RangeEnd::Excluded => write!(f, "..")?,
                 }
-                print_const_val(hi, f)
+                print_const_val(&hi.val, f)
             }
             PatternKind::Slice { ref prefix, ref slice, ref suffix } |
             PatternKind::Array { ref prefix, ref slice, ref suffix } => {
@@ -634,7 +634,7 @@ impl<'a, 'tcx> PatternContext<'a, 'tcx> {
                                                self.tables);
         match const_cx.eval(expr) {
             Ok(value) => {
-                if let ConstVal::Variant(def_id) = *value {
+                if let ConstVal::Variant(def_id) = value.val {
                     let ty = self.tables.expr_ty(expr);
                     self.lower_variant_or_leaf(Def::Variant(def_id), ty, vec![])
                 } else {
@@ -816,7 +816,7 @@ macro_rules! CloneImpls {
 }
 
 CloneImpls!{ <'tcx>
-    Span, Field, Mutability, ast::Name, ast::NodeId, usize, &'tcx ConstVal<'tcx>,
+    Span, Field, Mutability, ast::Name, ast::NodeId, usize, &'tcx ty::Const<'tcx>,
     Region<'tcx>, Ty<'tcx>, BindingMode<'tcx>, &'tcx AdtDef,
     &'tcx Substs<'tcx>, &'tcx Kind<'tcx>
 }

--- a/src/librustc_const_eval/pattern.rs
+++ b/src/librustc_const_eval/pattern.rs
@@ -537,7 +537,7 @@ impl<'a, 'tcx> PatternContext<'a, 'tcx> {
 
             ty::TyArray(_, len) => {
                 // fixed-length array
-                assert!(len >= prefix.len() + suffix.len());
+                assert!(len.as_u64() >= prefix.len() as u64 + suffix.len() as u64);
                 PatternKind::Array { prefix: prefix, slice: slice, suffix: suffix }
             }
 

--- a/src/librustc_const_eval/pattern.rs
+++ b/src/librustc_const_eval/pattern.rs
@@ -117,7 +117,8 @@ fn print_const_val(value: &ConstVal, f: &mut fmt::Formatter) -> fmt::Result {
         ConstVal::Char(c) => write!(f, "{:?}", c),
         ConstVal::Variant(_) |
         ConstVal::Function(..) |
-        ConstVal::Aggregate(_) => bug!("{:?} not printable in a pattern", value)
+        ConstVal::Aggregate(_) |
+        ConstVal::Unevaluated(..) => bug!("{:?} not printable in a pattern", value)
     }
 }
 

--- a/src/librustc_const_math/int.rs
+++ b/src/librustc_const_math/int.rs
@@ -311,17 +311,13 @@ impl ::std::fmt::Display for ConstInt {
             I32(i) => write!(fmt, "{}i32", i),
             I64(i) => write!(fmt, "{}i64", i),
             I128(i) => write!(fmt, "{}i128", i),
-            Isize(ConstIsize::Is64(i)) => write!(fmt, "{}isize", i),
-            Isize(ConstIsize::Is32(i)) => write!(fmt, "{}isize", i),
-            Isize(ConstIsize::Is16(i)) => write!(fmt, "{}isize", i),
+            Isize(i) => write!(fmt, "{}isize", i),
             U8(i) => write!(fmt, "{}u8", i),
             U16(i) => write!(fmt, "{}u16", i),
             U32(i) => write!(fmt, "{}u32", i),
             U64(i) => write!(fmt, "{}u64", i),
             U128(i) => write!(fmt, "{}u128", i),
-            Usize(ConstUsize::Us64(i)) => write!(fmt, "{}usize", i),
-            Usize(ConstUsize::Us32(i)) => write!(fmt, "{}usize", i),
-            Usize(ConstUsize::Us16(i)) => write!(fmt, "{}usize", i),
+            Usize(i) => write!(fmt, "{}usize", i),
         }
     }
 }

--- a/src/librustc_const_math/is.rs
+++ b/src/librustc_const_math/is.rs
@@ -21,18 +21,22 @@ pub enum ConstIsize {
 }
 pub use self::ConstIsize::*;
 
+impl ::std::fmt::Display for ConstIsize {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+        write!(fmt, "{}", self.as_i64())
+    }
+}
+
 impl ConstIsize {
-    pub fn as_i64(self, target_int_ty: ast::IntTy) -> i64 {
-        match (self, target_int_ty) {
-            (Is16(i), ast::IntTy::I16) => i as i64,
-            (Is32(i), ast::IntTy::I32) => i as i64,
-            (Is64(i), ast::IntTy::I64) => i,
-            _ => panic!("unable to convert self ({:?}) to target isize ({:?})",
-                        self, target_int_ty),
+    pub fn as_i64(self) -> i64 {
+        match self {
+            Is16(i) => i as i64,
+            Is32(i) => i as i64,
+            Is64(i) => i,
         }
     }
-    pub fn new(i: i64, target_int_ty: ast::IntTy) -> Result<Self, ConstMathErr> {
-        match target_int_ty {
+    pub fn new(i: i64, isize_ty: ast::IntTy) -> Result<Self, ConstMathErr> {
+        match isize_ty {
             ast::IntTy::I16 if i as i16 as i64 == i => Ok(Is16(i as i16)),
             ast::IntTy::I16 => Err(LitOutOfRange(ast::IntTy::Is)),
             ast::IntTy::I32 if i as i32 as i64 == i => Ok(Is32(i as i32)),
@@ -41,8 +45,8 @@ impl ConstIsize {
             _ => unreachable!(),
         }
     }
-    pub fn new_truncating(i: i128, target_int_ty: ast::IntTy) -> Self {
-        match target_int_ty {
+    pub fn new_truncating(i: i128, isize_ty: ast::IntTy) -> Self {
+        match isize_ty {
             ast::IntTy::I16 => Is16(i as i16),
             ast::IntTy::I32 => Is32(i as i32),
             ast::IntTy::I64 => Is64(i as i64),

--- a/src/librustc_const_math/us.rs
+++ b/src/librustc_const_math/us.rs
@@ -21,18 +21,22 @@ pub enum ConstUsize {
 }
 pub use self::ConstUsize::*;
 
+impl ::std::fmt::Display for ConstUsize {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+        write!(fmt, "{}", self.as_u64())
+    }
+}
+
 impl ConstUsize {
-    pub fn as_u64(self, target_uint_ty: ast::UintTy) -> u64 {
-        match (self, target_uint_ty) {
-            (Us16(i), ast::UintTy::U16) => i as u64,
-            (Us32(i), ast::UintTy::U32) => i as u64,
-            (Us64(i), ast::UintTy::U64) => i,
-            _ => panic!("unable to convert self ({:?}) to target usize ({:?})",
-                        self, target_uint_ty),
+    pub fn as_u64(self) -> u64 {
+        match self {
+            Us16(i) => i as u64,
+            Us32(i) => i as u64,
+            Us64(i) => i,
         }
     }
-    pub fn new(i: u64, target_uint_ty: ast::UintTy) -> Result<Self, ConstMathErr> {
-        match target_uint_ty {
+    pub fn new(i: u64, usize_ty: ast::UintTy) -> Result<Self, ConstMathErr> {
+        match usize_ty {
             ast::UintTy::U16 if i as u16 as u64 == i => Ok(Us16(i as u16)),
             ast::UintTy::U16 => Err(ULitOutOfRange(ast::UintTy::Us)),
             ast::UintTy::U32 if i as u32 as u64 == i => Ok(Us32(i as u32)),
@@ -41,8 +45,8 @@ impl ConstUsize {
             _ => unreachable!(),
         }
     }
-    pub fn new_truncating(i: u128, target_uint_ty: ast::UintTy) -> Self {
-        match target_uint_ty {
+    pub fn new_truncating(i: u128, usize_ty: ast::UintTy) -> Self {
+        match usize_ty {
             ast::UintTy::U16 => Us16(i as u16),
             ast::UintTy::U32 => Us32(i as u32),
             ast::UintTy::U64 => Us64(i as u64),

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -801,13 +801,13 @@ fn walk_ty() {
     test_env(EMPTY_SOURCE_STR, errors(&[]), |env| {
         let tcx = env.infcx.tcx;
         let int_ty = tcx.types.isize;
-        let uint_ty = tcx.types.usize;
-        let tup1_ty = tcx.intern_tup(&[int_ty, uint_ty, int_ty, uint_ty], false);
-        let tup2_ty = tcx.intern_tup(&[tup1_ty, tup1_ty, uint_ty], false);
+        let usize_ty = tcx.types.usize;
+        let tup1_ty = tcx.intern_tup(&[int_ty, usize_ty, int_ty, usize_ty], false);
+        let tup2_ty = tcx.intern_tup(&[tup1_ty, tup1_ty, usize_ty], false);
         let walked: Vec<_> = tup2_ty.walk().collect();
         assert_eq!(walked,
-                   [tup2_ty, tup1_ty, int_ty, uint_ty, int_ty, uint_ty, tup1_ty, int_ty,
-                    uint_ty, int_ty, uint_ty, uint_ty]);
+                   [tup2_ty, tup1_ty, int_ty, usize_ty, int_ty, usize_ty, tup1_ty, int_ty,
+                    usize_ty, int_ty, usize_ty, usize_ty]);
     })
 }
 
@@ -816,20 +816,20 @@ fn walk_ty_skip_subtree() {
     test_env(EMPTY_SOURCE_STR, errors(&[]), |env| {
         let tcx = env.infcx.tcx;
         let int_ty = tcx.types.isize;
-        let uint_ty = tcx.types.usize;
-        let tup1_ty = tcx.intern_tup(&[int_ty, uint_ty, int_ty, uint_ty], false);
-        let tup2_ty = tcx.intern_tup(&[tup1_ty, tup1_ty, uint_ty], false);
+        let usize_ty = tcx.types.usize;
+        let tup1_ty = tcx.intern_tup(&[int_ty, usize_ty, int_ty, usize_ty], false);
+        let tup2_ty = tcx.intern_tup(&[tup1_ty, tup1_ty, usize_ty], false);
 
         // types we expect to see (in order), plus a boolean saying
         // whether to skip the subtree.
         let mut expected = vec![(tup2_ty, false),
                                 (tup1_ty, false),
                                 (int_ty, false),
-                                (uint_ty, false),
+                                (usize_ty, false),
                                 (int_ty, false),
-                                (uint_ty, false),
+                                (usize_ty, false),
                                 (tup1_ty, true), // skip the isize/usize/isize/usize
-                                (uint_ty, false)];
+                                (usize_ty, false)];
         expected.reverse();
 
         let mut walker = tup2_ty.walk();

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -93,8 +93,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
 
                 if binop.node.is_shift() {
                     let opt_ty_bits = match cx.tables.node_id_to_type(l.hir_id).sty {
-                        ty::TyInt(t) => Some(int_ty_bits(t, cx.sess().target.int_type)),
-                        ty::TyUint(t) => Some(uint_ty_bits(t, cx.sess().target.uint_type)),
+                        ty::TyInt(t) => Some(int_ty_bits(t, cx.sess().target.isize_ty)),
+                        ty::TyUint(t) => Some(uint_ty_bits(t, cx.sess().target.usize_ty)),
                         _ => None,
                     };
 
@@ -141,7 +141,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
                             ast::LitKind::Int(v, ast::LitIntType::Signed(_)) |
                             ast::LitKind::Int(v, ast::LitIntType::Unsuffixed) => {
                                 let int_type = if let ast::IntTy::Is = t {
-                                    cx.sess().target.int_type
+                                    cx.sess().target.isize_ty
                                 } else {
                                     t
                                 };
@@ -164,7 +164,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
                     }
                     ty::TyUint(t) => {
                         let uint_type = if let ast::UintTy::Us = t {
-                            cx.sess().target.uint_type
+                            cx.sess().target.usize_ty
                         } else {
                             t
                         };
@@ -250,9 +250,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
             }
         }
 
-        fn int_ty_bits(int_ty: ast::IntTy, target_int_ty: ast::IntTy) -> u64 {
+        fn int_ty_bits(int_ty: ast::IntTy, isize_ty: ast::IntTy) -> u64 {
             match int_ty {
-                ast::IntTy::Is => int_ty_bits(target_int_ty, target_int_ty),
+                ast::IntTy::Is => int_ty_bits(isize_ty, isize_ty),
                 ast::IntTy::I8 => 8,
                 ast::IntTy::I16 => 16 as u64,
                 ast::IntTy::I32 => 32,
@@ -261,9 +261,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
             }
         }
 
-        fn uint_ty_bits(uint_ty: ast::UintTy, target_uint_ty: ast::UintTy) -> u64 {
+        fn uint_ty_bits(uint_ty: ast::UintTy, usize_ty: ast::UintTy) -> u64 {
             match uint_ty {
-                ast::UintTy::Us => uint_ty_bits(target_uint_ty, target_uint_ty),
+                ast::UintTy::Us => uint_ty_bits(usize_ty, usize_ty),
                 ast::UintTy::U8 => 8,
                 ast::UintTy::U16 => 16,
                 ast::UintTy::U32 => 32,

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -76,7 +76,7 @@ impl LintPass for TypeLimits {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
-    fn check_expr(&mut self, cx: &LateContext, e: &hir::Expr) {
+    fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx hir::Expr) {
         match e.node {
             hir::ExprUnary(hir::UnNeg, ref expr) => {
                 // propagate negation, if the negation itself isn't negated
@@ -117,7 +117,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
                                                              cx.param_env.and(substs),
                                                              cx.tables);
                             match const_cx.eval(&r) {
-                                Ok(ConstVal::Integral(i)) => {
+                                Ok(&ConstVal::Integral(i)) => {
                                     i.is_negative() ||
                                     i.to_u64()
                                         .map(|i| i >= bits)

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -117,7 +117,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
                                                              cx.param_env.and(substs),
                                                              cx.tables);
                             match const_cx.eval(&r) {
-                                Ok(&ConstVal::Integral(i)) => {
+                                Ok(&ty::Const { val: ConstVal::Integral(i), .. }) => {
                                     i.is_negative() ||
                                     i.to_u64()
                                         .map(|i| i >= bits)

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -16,6 +16,7 @@ use schema::*;
 use rustc::hir::map::{DefKey, DefPath, DefPathData, DefPathHash};
 use rustc::hir;
 
+use rustc::middle::const_val::{ByteArray, ConstVal};
 use rustc::middle::cstore::LinkagePreference;
 use rustc::hir::def::{self, Def, CtorKind};
 use rustc::hir::def_id::{CrateNum, DefId, DefIndex, CRATE_DEF_INDEX, LOCAL_CRATE};
@@ -374,6 +375,20 @@ impl<'a, 'tcx> SpecializedDecoder<&'tcx ty::Slice<ty::ExistentialPredicate<'tcx>
         -> Result<&'tcx ty::Slice<ty::ExistentialPredicate<'tcx>>, Self::Error> {
         Ok(self.tcx().mk_existential_predicates((0..self.read_usize()?)
                                                 .map(|_| Decodable::decode(self)))?)
+    }
+}
+
+impl<'a, 'tcx> SpecializedDecoder<ByteArray<'tcx>> for DecodeContext<'a, 'tcx> {
+    fn specialized_decode(&mut self) -> Result<ByteArray<'tcx>, Self::Error> {
+        Ok(ByteArray {
+            data: self.tcx().alloc_byte_array(&Vec::decode(self)?)
+        })
+    }
+}
+
+impl<'a, 'tcx> SpecializedDecoder<&'tcx ConstVal<'tcx>> for DecodeContext<'a, 'tcx> {
+    fn specialized_decode(&mut self) -> Result<&'tcx ConstVal<'tcx>, Self::Error> {
+        Ok(self.tcx().mk_const(Decodable::decode(self)?))
     }
 }
 

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -16,7 +16,7 @@ use schema::*;
 use rustc::hir::map::{DefKey, DefPath, DefPathData, DefPathHash};
 use rustc::hir;
 
-use rustc::middle::const_val::{ByteArray, ConstVal};
+use rustc::middle::const_val::ByteArray;
 use rustc::middle::cstore::LinkagePreference;
 use rustc::hir::def::{self, Def, CtorKind};
 use rustc::hir::def_id::{CrateNum, DefId, DefIndex, CRATE_DEF_INDEX, LOCAL_CRATE};
@@ -386,8 +386,8 @@ impl<'a, 'tcx> SpecializedDecoder<ByteArray<'tcx>> for DecodeContext<'a, 'tcx> {
     }
 }
 
-impl<'a, 'tcx> SpecializedDecoder<&'tcx ConstVal<'tcx>> for DecodeContext<'a, 'tcx> {
-    fn specialized_decode(&mut self) -> Result<&'tcx ConstVal<'tcx>, Self::Error> {
+impl<'a, 'tcx> SpecializedDecoder<&'tcx ty::Const<'tcx>> for DecodeContext<'a, 'tcx> {
+    fn specialized_decode(&mut self) -> Result<&'tcx ty::Const<'tcx>, Self::Error> {
         Ok(self.tcx().mk_const(Decodable::decode(self)?))
     }
 }

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -1521,9 +1521,16 @@ impl<'a, 'b, 'tcx> IndexBuilder<'a, 'b, 'tcx> {
     }
 
     fn encode_info_for_ty(&mut self, ty: &hir::Ty) {
-        if let hir::TyImplTrait(_) = ty.node {
-            let def_id = self.tcx.hir.local_def_id(ty.id);
-            self.record(def_id, IsolatedEncoder::encode_info_for_anon_ty, def_id);
+        match ty.node {
+            hir::TyImplTrait(_) => {
+                let def_id = self.tcx.hir.local_def_id(ty.id);
+                self.record(def_id, IsolatedEncoder::encode_info_for_anon_ty, def_id);
+            }
+            hir::TyArray(_, len) => {
+                let def_id = self.tcx.hir.body_owner_def_id(len);
+                self.record(def_id, IsolatedEncoder::encode_info_for_embedded_const, def_id);
+            }
+            _ => {}
         }
     }
 

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -197,7 +197,10 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                         span: expr_span,
                         ty: this.hir.tcx().types.u32,
                         literal: Literal::Value {
-                            value: this.hir.tcx().mk_const(ConstVal::Integral(ConstInt::U32(0))),
+                            value: this.hir.tcx().mk_const(ty::Const {
+                                val: ConstVal::Integral(ConstInt::U32(0)),
+                                ty: this.hir.tcx().types.u32
+                            }),
                         },
                     }));
                     box AggregateKind::Generator(closure_id, substs, interior)
@@ -392,7 +395,10 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 };
 
                 Literal::Value {
-                    value: self.hir.tcx().mk_const(ConstVal::Integral(val))
+                    value: self.hir.tcx().mk_const(ty::Const {
+                        val: ConstVal::Integral(val),
+                        ty
+                    })
                 }
             }
             _ => {
@@ -427,7 +433,10 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 };
 
                 Literal::Value {
-                    value: self.hir.tcx().mk_const(ConstVal::Integral(val))
+                    value: self.hir.tcx().mk_const(ty::Const {
+                        val: ConstVal::Integral(val),
+                        ty
+                    })
                 }
             }
             _ => {

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -388,7 +388,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                     ast::IntTy::I64 => ConstInt::I64(-1),
                     ast::IntTy::I128 => ConstInt::I128(-1),
                     ast::IntTy::Is => {
-                        let int_ty = self.hir.tcx().sess.target.int_type;
+                        let int_ty = self.hir.tcx().sess.target.isize_ty;
                         let val = ConstIsize::new(-1, int_ty).unwrap();
                         ConstInt::Isize(val)
                     }
@@ -420,7 +420,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                     ast::IntTy::I64 => ConstInt::I64(i64::min_value()),
                     ast::IntTy::I128 => ConstInt::I128(i128::min_value()),
                     ast::IntTy::Is => {
-                        let int_ty = self.hir.tcx().sess.target.int_type;
+                        let int_ty = self.hir.tcx().sess.target.isize_ty;
                         let min = match int_ty {
                             ast::IntTy::I16 => std::i16::MIN as i64,
                             ast::IntTy::I32 => std::i32::MIN as i64,

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -197,7 +197,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                         span: expr_span,
                         ty: this.hir.tcx().types.u32,
                         literal: Literal::Value {
-                            value: ConstVal::Integral(ConstInt::U32(0)),
+                            value: this.hir.tcx().mk_const(ConstVal::Integral(ConstInt::U32(0))),
                         },
                     }));
                     box AggregateKind::Generator(closure_id, substs, interior)
@@ -391,7 +391,9 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                     }
                 };
 
-                Literal::Value { value: ConstVal::Integral(val) }
+                Literal::Value {
+                    value: self.hir.tcx().mk_const(ConstVal::Integral(val))
+                }
             }
             _ => {
                 span_bug!(span, "Invalid type for neg_1_literal: `{:?}`", ty)
@@ -424,7 +426,9 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                     }
                 };
 
-                Literal::Value { value: ConstVal::Integral(val) }
+                Literal::Value {
+                    value: self.hir.tcx().mk_const(ConstVal::Integral(val))
+                }
             }
             _ => {
                 span_bug!(span, "Invalid type for minval_literal: `{:?}`", ty)

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -301,13 +301,13 @@ enum TestKind<'tcx> {
     // test the branches of enum
     SwitchInt {
         switch_ty: Ty<'tcx>,
-        options: Vec<ConstVal<'tcx>>,
-        indices: FxHashMap<ConstVal<'tcx>, usize>,
+        options: Vec<&'tcx ConstVal<'tcx>>,
+        indices: FxHashMap<&'tcx ConstVal<'tcx>, usize>,
     },
 
     // test for equality
     Eq {
-        value: ConstVal<'tcx>,
+        value: &'tcx ConstVal<'tcx>,
         ty: Ty<'tcx>,
     },
 

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -16,8 +16,7 @@
 use build::{BlockAnd, BlockAndExtension, Builder};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::bitvec::BitVector;
-use rustc::middle::const_val::ConstVal;
-use rustc::ty::{AdtDef, Ty};
+use rustc::ty::{self, Ty};
 use rustc::mir::*;
 use rustc::hir;
 use hair::*;
@@ -294,20 +293,20 @@ pub struct MatchPair<'pat, 'tcx:'pat> {
 enum TestKind<'tcx> {
     // test the branches of enum
     Switch {
-        adt_def: &'tcx AdtDef,
+        adt_def: &'tcx ty::AdtDef,
         variants: BitVector,
     },
 
     // test the branches of enum
     SwitchInt {
         switch_ty: Ty<'tcx>,
-        options: Vec<&'tcx ConstVal<'tcx>>,
-        indices: FxHashMap<&'tcx ConstVal<'tcx>, usize>,
+        options: Vec<&'tcx ty::Const<'tcx>>,
+        indices: FxHashMap<&'tcx ty::Const<'tcx>, usize>,
     },
 
     // test for equality
     Eq {
-        value: &'tcx ConstVal<'tcx>,
+        value: &'tcx ty::Const<'tcx>,
         ty: Ty<'tcx>,
     },
 

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -279,7 +279,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
 
                     assert!(ty.is_slice());
 
-                    let array_ty = tcx.mk_array(tcx.types.u8, bytes.data.len());
+                    let array_ty = tcx.mk_array(tcx.types.u8, bytes.data.len() as u64);
                     let array_ref = tcx.mk_imm_ref(tcx.types.re_static, array_ty);
                     let array = self.literal_operand(test.span, array_ref, Literal::Value {
                         value

--- a/src/librustc_mir/build/misc.rs
+++ b/src/librustc_mir/build/misc.rs
@@ -61,7 +61,10 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             }
             ty::TyChar => {
                 Literal::Value {
-                    value: self.hir.tcx().mk_const(ConstVal::Char('\0'))
+                    value: self.hir.tcx().mk_const(ty::Const {
+                        val: ConstVal::Char('\0'),
+                        ty
+                    })
                 }
             }
             ty::TyUint(ity) => {
@@ -79,7 +82,10 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 };
 
                 Literal::Value {
-                    value: self.hir.tcx().mk_const(ConstVal::Integral(val))
+                    value: self.hir.tcx().mk_const(ty::Const {
+                        val: ConstVal::Integral(val),
+                        ty
+                    })
                 }
             }
             ty::TyInt(ity) => {
@@ -97,7 +103,10 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 };
 
                 Literal::Value {
-                    value: self.hir.tcx().mk_const(ConstVal::Integral(val))
+                    value: self.hir.tcx().mk_const(ty::Const {
+                        val: ConstVal::Integral(val),
+                        ty
+                    })
                 }
             }
             _ => {

--- a/src/librustc_mir/build/misc.rs
+++ b/src/librustc_mir/build/misc.rs
@@ -75,7 +75,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                     ast::UintTy::U64 => ConstInt::U64(0),
                     ast::UintTy::U128 => ConstInt::U128(0),
                     ast::UintTy::Us => {
-                        let uint_ty = self.hir.tcx().sess.target.uint_type;
+                        let uint_ty = self.hir.tcx().sess.target.usize_ty;
                         let val = ConstUsize::new(0, uint_ty).unwrap();
                         ConstInt::Usize(val)
                     }
@@ -96,7 +96,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                     ast::IntTy::I64 => ConstInt::I64(0),
                     ast::IntTy::I128 => ConstInt::I128(0),
                     ast::IntTy::Is => {
-                        let int_ty = self.hir.tcx().sess.target.int_type;
+                        let int_ty = self.hir.tcx().sess.target.isize_ty;
                         let val = ConstIsize::new(0, int_ty).unwrap();
                         ConstInt::Isize(val)
                     }

--- a/src/librustc_mir/build/misc.rs
+++ b/src/librustc_mir/build/misc.rs
@@ -59,7 +59,11 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             ty::TyBool => {
                 self.hir.false_literal()
             }
-            ty::TyChar => Literal::Value { value: ConstVal::Char('\0') },
+            ty::TyChar => {
+                Literal::Value {
+                    value: self.hir.tcx().mk_const(ConstVal::Char('\0'))
+                }
+            }
             ty::TyUint(ity) => {
                 let val = match ity {
                     ast::UintTy::U8  => ConstInt::U8(0),
@@ -74,7 +78,9 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                     }
                 };
 
-                Literal::Value { value: ConstVal::Integral(val) }
+                Literal::Value {
+                    value: self.hir.tcx().mk_const(ConstVal::Integral(val))
+                }
             }
             ty::TyInt(ity) => {
                 let val = match ity {
@@ -90,7 +96,9 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                     }
                 };
 
-                Literal::Value { value: ConstVal::Integral(val) }
+                Literal::Value {
+                    value: self.hir.tcx().mk_const(ConstVal::Integral(val))
+                }
             }
             _ => {
                 span_bug!(span, "Invalid type for zero_literal: `{:?}`", ty)

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -11,7 +11,6 @@
 
 use build;
 use hair::cx::Cx;
-use hair::Pattern;
 use rustc::hir;
 use rustc::hir::def_id::DefId;
 use rustc::middle::region;
@@ -537,10 +536,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             let lvalue = Lvalue::Local(Local::new(index + 1));
 
             if let Some(pattern) = pattern {
-                let pattern = Pattern::from_hir(self.hir.tcx().global_tcx(),
-                                                self.hir.param_env.and(self.hir.identity_substs),
-                                                self.hir.tables(),
-                                                pattern);
+                let pattern = self.hir.pattern_from_hir(pattern);
                 scope = self.declare_bindings(scope, ast_body.span, &pattern);
                 unpack!(block = self.lvalue_into_pattern(block, pattern, &lvalue));
             }

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -166,6 +166,26 @@ impl<'a, 'gcx: 'tcx, 'tcx> MutVisitor<'tcx> for GlobalizeMir<'a, 'gcx> {
         }
     }
 
+    fn visit_region(&mut self, region: &mut ty::Region<'tcx>, _: Location) {
+        if let Some(lifted) = self.tcx.lift(region) {
+            *region = lifted;
+        } else {
+            span_bug!(self.span,
+                      "found region `{:?}` with inference types/regions in MIR",
+                      region);
+        }
+    }
+
+    fn visit_const(&mut self, constant: &mut &'tcx ty::Const<'tcx>, _: Location) {
+        if let Some(lifted) = self.tcx.lift(constant) {
+            *constant = lifted;
+        } else {
+            span_bug!(self.span,
+                      "found constant `{:?}` with inference types/regions in MIR",
+                      constant);
+        }
+    }
+
     fn visit_substs(&mut self, substs: &mut &'tcx Substs<'tcx>, _: Location) {
         if let Some(lifted) = self.tcx.lift(substs) {
             *substs = lifted;

--- a/src/librustc_mir/hair/cx/block.rs
+++ b/src/librustc_mir/hair/cx/block.rs
@@ -64,10 +64,7 @@ fn mirror_stmts<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                             first_statement_index: index as u32,
                         });
 
-                        let pattern = Pattern::from_hir(cx.tcx.global_tcx(),
-                                                        cx.param_env.and(cx.identity_substs),
-                                                        cx.tables(),
-                                                        &local.pat);
+                        let pattern = cx.pattern_from_hir(&local.pat);
                         result.push(StmtRef::Mirror(Box::new(Stmt {
                             kind: StmtKind::Let {
                                 remainder_scope: remainder_scope,

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -643,9 +643,11 @@ fn convert_path_expr<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
 
         Def::Const(def_id) |
         Def::AssociatedConst(def_id) => ExprKind::Literal {
-            literal: Literal::Item {
-                def_id,
-                substs,
+            literal: Literal::Value {
+                value: cx.tcx.mk_const(ty::Const {
+                    val: ConstVal::Unevaluated(def_id, substs),
+                    ty: cx.tables().node_id_to_type(expr.hir_id)
+                }),
             },
         },
 

--- a/src/librustc_mir/hair/cx/mod.rs
+++ b/src/librustc_mir/hair/cx/mod.rs
@@ -115,7 +115,10 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
         match ConstUsize::new(value, self.tcx.sess.target.uint_type) {
             Ok(val) => {
                 Literal::Value {
-                    value: self.tcx.mk_const(ConstVal::Integral(ConstInt::Usize(val)))
+                    value: self.tcx.mk_const(ty::Const {
+                        val: ConstVal::Integral(ConstInt::Usize(val)),
+                        ty: self.tcx.types.usize
+                    })
                 }
             }
             Err(_) => bug!("usize literal out of range for target"),
@@ -131,11 +134,21 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
     }
 
     pub fn true_literal(&mut self) -> Literal<'tcx> {
-        Literal::Value { value: self.tcx.mk_const(ConstVal::Bool(true)) }
+        Literal::Value {
+            value: self.tcx.mk_const(ty::Const {
+                val: ConstVal::Bool(true),
+                ty: self.tcx.types.bool
+            })
+        }
     }
 
     pub fn false_literal(&mut self) -> Literal<'tcx> {
-        Literal::Value { value: self.tcx.mk_const(ConstVal::Bool(false)) }
+        Literal::Value {
+            value: self.tcx.mk_const(ty::Const {
+                val: ConstVal::Bool(false),
+                ty: self.tcx.types.bool
+            })
+        }
     }
 
     pub fn const_eval_literal(&mut self, e: &hir::Expr) -> Literal<'tcx> {
@@ -186,7 +199,10 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
                 let method_ty = method_ty.subst(self.tcx, substs);
                 return (method_ty,
                         Literal::Value {
-                            value: self.tcx.mk_const(ConstVal::Function(item.def_id, substs)),
+                            value: self.tcx.mk_const(ty::Const {
+                                val: ConstVal::Function(item.def_id, substs),
+                                ty: method_ty
+                            }),
                         });
             }
         }

--- a/src/librustc_mir/hair/cx/mod.rs
+++ b/src/librustc_mir/hair/cx/mod.rs
@@ -113,7 +113,11 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
 
     pub fn usize_literal(&mut self, value: u64) -> Literal<'tcx> {
         match ConstUsize::new(value, self.tcx.sess.target.uint_type) {
-            Ok(val) => Literal::Value { value: ConstVal::Integral(ConstInt::Usize(val)) },
+            Ok(val) => {
+                Literal::Value {
+                    value: self.tcx.mk_const(ConstVal::Integral(ConstInt::Usize(val)))
+                }
+            }
             Err(_) => bug!("usize literal out of range for target"),
         }
     }
@@ -127,11 +131,11 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
     }
 
     pub fn true_literal(&mut self) -> Literal<'tcx> {
-        Literal::Value { value: ConstVal::Bool(true) }
+        Literal::Value { value: self.tcx.mk_const(ConstVal::Bool(true)) }
     }
 
     pub fn false_literal(&mut self) -> Literal<'tcx> {
-        Literal::Value { value: ConstVal::Bool(false) }
+        Literal::Value { value: self.tcx.mk_const(ConstVal::Bool(false)) }
     }
 
     pub fn const_eval_literal(&mut self, e: &hir::Expr) -> Literal<'tcx> {
@@ -139,10 +143,22 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
         let const_cx = ConstContext::new(tcx,
                                          self.param_env.and(self.identity_substs),
                                          self.tables());
-        match const_cx.eval(e) {
-            Ok(value) => Literal::Value { value: value },
+        match const_cx.eval(tcx.hir.expect_expr(e.id)) {
+            Ok(value) => Literal::Value { value },
             Err(s) => self.fatal_const_eval_err(&s, e.span, "expression")
         }
+    }
+
+    pub fn pattern_from_hir(&mut self, p: &hir::Pat) -> Pattern<'tcx> {
+        let tcx = self.tcx.global_tcx();
+        let p = match tcx.hir.get(p.id) {
+            hir::map::NodePat(p) | hir::map::NodeBinding(p) => p,
+            node => bug!("pattern became {:?}", node)
+        };
+        Pattern::from_hir(tcx,
+                          self.param_env.and(self.identity_substs),
+                          self.tables(),
+                          p)
     }
 
     pub fn fatal_const_eval_err(&mut self,
@@ -170,7 +186,7 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
                 let method_ty = method_ty.subst(self.tcx, substs);
                 return (method_ty,
                         Literal::Value {
-                            value: ConstVal::Function(item.def_id, substs),
+                            value: self.tcx.mk_const(ConstVal::Function(item.def_id, substs)),
                         });
             }
         }

--- a/src/librustc_mir/hair/cx/mod.rs
+++ b/src/librustc_mir/hair/cx/mod.rs
@@ -112,7 +112,7 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
     }
 
     pub fn usize_literal(&mut self, value: u64) -> Literal<'tcx> {
-        match ConstUsize::new(value, self.tcx.sess.target.uint_type) {
+        match ConstUsize::new(value, self.tcx.sess.target.usize_ty) {
             Ok(val) => {
                 Literal::Value {
                     value: self.tcx.mk_const(ty::Const {

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -292,7 +292,10 @@ fn build_clone_shim<'a, 'tcx>(tcx: ty::TyCtxt<'a, 'tcx, 'tcx>,
 
     match self_ty.sty {
         _ if is_copy => builder.copy_shim(),
-        ty::TyArray(ty, len) => builder.array_shim(ty, len.as_u64()),
+        ty::TyArray(ty, len) => {
+            let len = len.val.to_const_int().unwrap().to_u64().unwrap();
+            builder.array_shim(ty, len)
+        }
         ty::TyTuple(tys, _) => builder.tuple_shim(tys),
         _ => {
             bug!("clone shim for `{:?}` which is not `Copy` and is not an aggregate", self_ty);

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -292,7 +292,7 @@ fn build_clone_shim<'a, 'tcx>(tcx: ty::TyCtxt<'a, 'tcx, 'tcx>,
 
     match self_ty.sty {
         _ if is_copy => builder.copy_shim(),
-        ty::TyArray(ty, len) => builder.array_shim(ty, len),
+        ty::TyArray(ty, len) => builder.array_shim(ty, len.as_u64()),
         ty::TyTuple(tys, _) => builder.tuple_shim(tys),
         _ => {
             bug!("clone shim for `{:?}` which is not `Copy` and is not an aggregate", self_ty);
@@ -470,8 +470,8 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
         );
     }
 
-    fn make_usize(&self, value: usize) -> Box<Constant<'tcx>> {
-        let value = ConstUsize::new(value as u64, self.tcx.sess.target.uint_type).unwrap();
+    fn make_usize(&self, value: u64) -> Box<Constant<'tcx>> {
+        let value = ConstUsize::new(value, self.tcx.sess.target.usize_ty).unwrap();
         box Constant {
             span: self.span,
             ty: self.tcx.types.usize,
@@ -484,7 +484,7 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
         }
     }
 
-    fn array_shim(&mut self, ty: ty::Ty<'tcx>, len: usize) {
+    fn array_shim(&mut self, ty: ty::Ty<'tcx>, len: u64) {
         let tcx = self.tcx;
         let span = self.span;
         let rcvr = Lvalue::Local(Local::new(1+0)).deref();

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -407,7 +407,7 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
             span: self.span,
             ty: tcx.mk_fn_def(self.def_id, substs),
             literal: Literal::Value {
-                value: ConstVal::Function(self.def_id, substs),
+                value: tcx.mk_const(ConstVal::Function(self.def_id, substs)),
             },
         });
 
@@ -472,7 +472,7 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
             span: self.span,
             ty: self.tcx.types.usize,
             literal: Literal::Value {
-                value: ConstVal::Integral(ConstInt::Usize(value))
+                value: self.tcx.mk_const(ConstVal::Integral(ConstInt::Usize(value)))
             }
         }
     }
@@ -711,8 +711,8 @@ fn build_call_shim<'a, 'tcx>(tcx: ty::TyCtxt<'a, 'tcx, 'tcx>,
                 span,
                 ty: tcx.type_of(def_id),
                 literal: Literal::Value {
-                    value: ConstVal::Function(def_id,
-                        Substs::identity_for_item(tcx, def_id)),
+                    value: tcx.mk_const(ConstVal::Function(def_id,
+                        Substs::identity_for_item(tcx, def_id))),
                 },
             }),
             vec![rcvr]

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -403,11 +403,15 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
         );
 
         // `func == Clone::clone(&ty) -> ty`
+        let func_ty = tcx.mk_fn_def(self.def_id, substs);
         let func = Operand::Constant(box Constant {
             span: self.span,
-            ty: tcx.mk_fn_def(self.def_id, substs),
+            ty: func_ty,
             literal: Literal::Value {
-                value: tcx.mk_const(ConstVal::Function(self.def_id, substs)),
+                value: tcx.mk_const(ty::Const {
+                    val: ConstVal::Function(self.def_id, substs),
+                    ty: func_ty
+                }),
             },
         });
 
@@ -472,7 +476,10 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
             span: self.span,
             ty: self.tcx.types.usize,
             literal: Literal::Value {
-                value: self.tcx.mk_const(ConstVal::Integral(ConstInt::Usize(value)))
+                value: self.tcx.mk_const(ty::Const {
+                    val: ConstVal::Integral(ConstInt::Usize(value)),
+                    ty: self.tcx.types.usize,
+                })
             }
         }
     }
@@ -706,17 +713,21 @@ fn build_call_shim<'a, 'tcx>(tcx: ty::TyCtxt<'a, 'tcx, 'tcx>,
 
     let (callee, mut args) = match call_kind {
         CallKind::Indirect => (rcvr, vec![]),
-        CallKind::Direct(def_id) => (
-            Operand::Constant(box Constant {
+        CallKind::Direct(def_id) => {
+            let ty = tcx.type_of(def_id);
+            (Operand::Constant(box Constant {
                 span,
-                ty: tcx.type_of(def_id),
+                ty,
                 literal: Literal::Value {
-                    value: tcx.mk_const(ConstVal::Function(def_id,
-                        Substs::identity_for_item(tcx, def_id))),
+                    value: tcx.mk_const(ty::Const {
+                        val: ConstVal::Function(def_id,
+                            Substs::identity_for_item(tcx, def_id)),
+                        ty
+                    }),
                 },
-            }),
-            vec![rcvr]
-        )
+             }),
+             vec![rcvr])
+        }
     };
 
     if let Some(untuple_args) = untuple_args {

--- a/src/librustc_mir/transform/elaborate_drops.rs
+++ b/src/librustc_mir/transform/elaborate_drops.rs
@@ -521,7 +521,10 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
             span,
             ty: self.tcx.types.bool,
             literal: Literal::Value {
-                value: self.tcx.mk_const(ConstVal::Bool(val))
+                value: self.tcx.mk_const(ty::Const {
+                    val: ConstVal::Bool(val),
+                    ty: self.tcx.types.bool
+                })
             }
         })))
     }

--- a/src/librustc_mir/transform/elaborate_drops.rs
+++ b/src/librustc_mir/transform/elaborate_drops.rs
@@ -520,7 +520,9 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
         Rvalue::Use(Operand::Constant(Box::new(Constant {
             span,
             ty: self.tcx.types.bool,
-            literal: Literal::Value { value: ConstVal::Bool(val) }
+            literal: Literal::Value {
+                value: self.tcx.mk_const(ConstVal::Bool(val))
+            }
         })))
     }
 

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -175,7 +175,7 @@ impl<'a, 'tcx> TransformVisitor<'a, 'tcx> {
             span: source_info.span,
             ty: self.tcx.types.u32,
             literal: Literal::Value {
-                value: ConstVal::Integral(ConstInt::U32(state_disc)),
+                value: self.tcx.mk_const(ConstVal::Integral(ConstInt::U32(state_disc))),
             },
         });
         Statement {
@@ -553,7 +553,7 @@ fn insert_panic_on_resume_after_return<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             span: mir.span,
             ty: tcx.types.bool,
             literal: Literal::Value {
-                value: ConstVal::Bool(false),
+                value: tcx.mk_const(ConstVal::Bool(false)),
             },
         }),
         expected: true,
@@ -603,7 +603,7 @@ fn create_generator_resume_function<'a, 'tcx>(
             span: mir.span,
             ty: tcx.types.bool,
             literal: Literal::Value {
-                value: ConstVal::Bool(false),
+                value: tcx.mk_const(ConstVal::Bool(false)),
             },
         }),
         expected: true,

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -175,7 +175,10 @@ impl<'a, 'tcx> TransformVisitor<'a, 'tcx> {
             span: source_info.span,
             ty: self.tcx.types.u32,
             literal: Literal::Value {
-                value: self.tcx.mk_const(ConstVal::Integral(ConstInt::U32(state_disc))),
+                value: self.tcx.mk_const(ty::Const {
+                    val: ConstVal::Integral(ConstInt::U32(state_disc)),
+                    ty: self.tcx.types.u32
+                }),
             },
         });
         Statement {
@@ -553,7 +556,10 @@ fn insert_panic_on_resume_after_return<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             span: mir.span,
             ty: tcx.types.bool,
             literal: Literal::Value {
-                value: tcx.mk_const(ConstVal::Bool(false)),
+                value: tcx.mk_const(ty::Const {
+                    val: ConstVal::Bool(false),
+                    ty: tcx.types.bool
+                }),
             },
         }),
         expected: true,
@@ -603,7 +609,10 @@ fn create_generator_resume_function<'a, 'tcx>(
             span: mir.span,
             ty: tcx.types.bool,
             literal: Literal::Value {
-                value: tcx.mk_const(ConstVal::Bool(false)),
+                value: tcx.mk_const(ty::Const {
+                    val: ConstVal::Bool(false),
+                    ty: tcx.types.bool
+                }),
             },
         }),
         expected: true,

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -695,8 +695,8 @@ impl<'a, 'tcx> Visitor<'tcx> for Qualifier<'a, 'tcx, 'tcx> {
                             }
                             _ => false
                         }
-                    } else if let ty::TyArray(_, 0) = ty.sty {
-                        self.mode == Mode::Fn
+                    } else if let ty::TyArray(_, len) = ty.sty {
+                        len.as_u64() == 0 && self.mode == Mode::Fn
                     } else {
                         false
                     };

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -696,7 +696,8 @@ impl<'a, 'tcx> Visitor<'tcx> for Qualifier<'a, 'tcx, 'tcx> {
                             _ => false
                         }
                     } else if let ty::TyArray(_, len) = ty.sty {
-                        len.as_u64() == 0 && self.mode == Mode::Fn
+                        len.val.to_const_int().unwrap().to_u64().unwrap() == 0 &&
+                            self.mode == Mode::Fn
                     } else {
                         false
                     };

--- a/src/librustc_mir/transform/simplify_branches.rs
+++ b/src/librustc_mir/transform/simplify_branches.rs
@@ -56,7 +56,7 @@ impl MirPass for SimplifyBranches {
                 },
                 TerminatorKind::Assert { target, cond: Operand::Constant(box Constant {
                     literal: Literal::Value {
-                        value: ConstVal::Bool(cond)
+                        value: &ConstVal::Bool(cond)
                     }, ..
                 }), expected, .. } if cond == expected => {
                     TerminatorKind::Goto { target: target }

--- a/src/librustc_mir/transform/simplify_branches.rs
+++ b/src/librustc_mir/transform/simplify_branches.rs
@@ -10,7 +10,7 @@
 
 //! A pass that simplifies branches when their condition is known.
 
-use rustc::ty::TyCtxt;
+use rustc::ty::{self, TyCtxt};
 use rustc::middle::const_val::ConstVal;
 use rustc::mir::transform::{MirPass, MirSource};
 use rustc::mir::*;
@@ -40,7 +40,7 @@ impl MirPass for SimplifyBranches {
                 TerminatorKind::SwitchInt { discr: Operand::Constant(box Constant {
                     literal: Literal::Value { ref value }, ..
                 }), ref values, ref targets, .. } => {
-                    if let Some(ref constint) = value.to_const_int() {
+                    if let Some(ref constint) = value.val.to_const_int() {
                         let (otherwise, targets) = targets.split_last().unwrap();
                         let mut ret = TerminatorKind::Goto { target: *otherwise };
                         for (v, t) in values.iter().zip(targets.iter()) {
@@ -56,7 +56,7 @@ impl MirPass for SimplifyBranches {
                 },
                 TerminatorKind::Assert { target, cond: Operand::Constant(box Constant {
                     literal: Literal::Value {
-                        value: &ConstVal::Bool(cond)
+                        value: &ty::Const { val: ConstVal::Bool(cond), .. }
                     }, ..
                 }), expected, .. } if cond == expected => {
                     TerminatorKind::Goto { target: target }

--- a/src/librustc_mir/transform/type_check.rs
+++ b/src/librustc_mir/transform/type_check.rs
@@ -209,7 +209,8 @@ impl<'a, 'b, 'gcx, 'tcx> TypeVerifier<'a, 'b, 'gcx, 'tcx> {
                 LvalueTy::Ty {
                     ty: match base_ty.sty {
                         ty::TyArray(inner, size) => {
-                            let min_size = (from as usize) + (to as usize);
+                            let size = size.as_u64();
+                            let min_size = (from as u64) + (to as u64);
                             if let Some(rest_size) = size.checked_sub(min_size) {
                                 tcx.mk_array(inner, rest_size)
                             } else {

--- a/src/librustc_mir/transform/type_check.rs
+++ b/src/librustc_mir/transform/type_check.rs
@@ -209,7 +209,7 @@ impl<'a, 'b, 'gcx, 'tcx> TypeVerifier<'a, 'b, 'gcx, 'tcx> {
                 LvalueTy::Ty {
                     ty: match base_ty.sty {
                         ty::TyArray(inner, size) => {
-                            let size = size.as_u64();
+                            let size = size.val.to_const_int().unwrap().to_u64().unwrap();
                             let min_size = (from as u64) + (to as u64);
                             if let Some(rest_size) = size.checked_sub(min_size) {
                                 tcx.mk_array(inner, rest_size)

--- a/src/librustc_mir/transform/type_check.rs
+++ b/src/librustc_mir/transform/type_check.rs
@@ -572,7 +572,7 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
         match operand {
             &Operand::Constant(box Constant {
                 literal: Literal::Value {
-                    value: &ConstVal::Function(def_id, _), ..
+                    value: &ty::Const { val: ConstVal::Function(def_id, _), .. }, ..
                 }, ..
             }) => {
                 Some(def_id) == self.tcx().lang_items().box_free_fn()

--- a/src/librustc_mir/transform/type_check.rs
+++ b/src/librustc_mir/transform/type_check.rs
@@ -572,7 +572,7 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
         match operand {
             &Operand::Constant(box Constant {
                 literal: Literal::Value {
-                    value: ConstVal::Function(def_id, _), ..
+                    value: &ConstVal::Function(def_id, _), ..
                 }, ..
             }) => {
                 Some(def_id) == self.tcx().lang_items().box_free_fn()

--- a/src/librustc_mir/util/elaborate_drops.rs
+++ b/src/librustc_mir/util/elaborate_drops.rs
@@ -923,7 +923,10 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
             span: self.source_info.span,
             ty: self.tcx().types.usize,
             literal: Literal::Value {
-                value: self.tcx().mk_const(ConstVal::Integral(self.tcx().const_usize(val)))
+                value: self.tcx().mk_const(ty::Const {
+                    val: ConstVal::Integral(self.tcx().const_usize(val)),
+                    ty: self.tcx().types.usize
+                })
             }
         })
     }

--- a/src/librustc_mir/util/elaborate_drops.rs
+++ b/src/librustc_mir/util/elaborate_drops.rs
@@ -922,7 +922,9 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
         Operand::Constant(box Constant {
             span: self.source_info.span,
             ty: self.tcx().types.usize,
-            literal: Literal::Value { value: ConstVal::Integral(self.tcx().const_usize(val)) }
+            literal: Literal::Value {
+                value: self.tcx().mk_const(ConstVal::Integral(self.tcx().const_usize(val)))
+            }
         })
     }
 

--- a/src/librustc_passes/mir_stats.rs
+++ b/src/librustc_passes/mir_stats.rs
@@ -257,7 +257,7 @@ impl<'a, 'tcx> mir_visit::Visitor<'tcx> for StatCollector<'a, 'tcx> {
     }
 
     fn visit_const_val(&mut self,
-                       const_val: &ConstVal,
+                       const_val: &&'tcx ConstVal<'tcx>,
                        _: Location) {
         self.record("ConstVal", const_val);
         self.super_const_val(const_val);

--- a/src/librustc_passes/mir_stats.rs
+++ b/src/librustc_passes/mir_stats.rs
@@ -235,7 +235,6 @@ impl<'a, 'tcx> mir_visit::Visitor<'tcx> for StatCollector<'a, 'tcx> {
                      location: Location) {
         self.record("Literal", literal);
         self.record(match *literal {
-            Literal::Item { .. } => "Literal::Item",
             Literal::Value { .. } => "Literal::Value",
             Literal::Promoted { .. } => "Literal::Promoted",
         }, literal);

--- a/src/librustc_passes/mir_stats.rs
+++ b/src/librustc_passes/mir_stats.rs
@@ -13,7 +13,6 @@
 // completely accurate (some things might be counted twice, others missed).
 
 use rustc_const_math::{ConstUsize};
-use rustc::middle::const_val::{ConstVal};
 use rustc::mir::{AggregateKind, AssertMessage, BasicBlock, BasicBlockData};
 use rustc::mir::{Constant, Literal, Location, LocalDecl};
 use rustc::mir::{Lvalue, LvalueElem, LvalueProjection};
@@ -21,7 +20,7 @@ use rustc::mir::{Mir, Operand, ProjectionElem};
 use rustc::mir::{Rvalue, SourceInfo, Statement, StatementKind};
 use rustc::mir::{Terminator, TerminatorKind, VisibilityScope, VisibilityScopeData};
 use rustc::mir::visit as mir_visit;
-use rustc::ty::{ClosureSubsts, TyCtxt};
+use rustc::ty::{self, ClosureSubsts, TyCtxt};
 use rustc::util::nodemap::{FxHashMap};
 
 struct NodeData {
@@ -256,11 +255,11 @@ impl<'a, 'tcx> mir_visit::Visitor<'tcx> for StatCollector<'a, 'tcx> {
         self.super_closure_substs(substs);
     }
 
-    fn visit_const_val(&mut self,
-                       const_val: &&'tcx ConstVal<'tcx>,
-                       _: Location) {
-        self.record("ConstVal", const_val);
-        self.super_const_val(const_val);
+    fn visit_const(&mut self,
+                   constant: &&'tcx ty::Const<'tcx>,
+                   _: Location) {
+        self.record("Const", constant);
+        self.super_const(constant);
     }
 
     fn visit_const_usize(&mut self,

--- a/src/librustc_trans/abi.rs
+++ b/src/librustc_trans/abi.rs
@@ -11,7 +11,7 @@
 use llvm::{self, ValueRef, AttributePlace};
 use base;
 use builder::Builder;
-use common::{instance_ty, ty_fn_sig, type_is_fat_ptr, C_uint};
+use common::{instance_ty, ty_fn_sig, type_is_fat_ptr, C_usize};
 use context::CrateContext;
 use cabi_x86;
 use cabi_x86_64;
@@ -527,7 +527,7 @@ impl<'a, 'tcx> ArgType<'tcx> {
         }
         let ccx = bcx.ccx;
         if self.is_indirect() {
-            let llsz = C_uint(ccx, self.layout.size(ccx).bytes());
+            let llsz = C_usize(ccx, self.layout.size(ccx).bytes());
             let llalign = self.layout.align(ccx).abi();
             base::call_memcpy(bcx, dst, val, llsz, llalign as u32);
         } else if let Some(ty) = self.cast {
@@ -564,7 +564,7 @@ impl<'a, 'tcx> ArgType<'tcx> {
                 base::call_memcpy(bcx,
                                   bcx.pointercast(dst, Type::i8p(ccx)),
                                   bcx.pointercast(llscratch, Type::i8p(ccx)),
-                                  C_uint(ccx, self.layout.size(ccx).bytes()),
+                                  C_usize(ccx, self.layout.size(ccx).bytes()),
                                   cmp::min(self.layout.align(ccx).abi() as u32,
                                            llalign_of_min(ccx, ty)));
 

--- a/src/librustc_trans/adt.rs
+++ b/src/librustc_trans/adt.rs
@@ -397,11 +397,11 @@ pub fn trans_set_discr<'a, 'tcx>(bcx: &Builder<'a, 'tcx>, t: Ty<'tcx>, val: Valu
     match *l {
         layout::CEnum{ discr, min, max, .. } => {
             assert_discr_in_range(min, max, to);
-            bcx.store(C_integral(Type::from_integer(bcx.ccx, discr), to, true),
+            bcx.store(C_int(Type::from_integer(bcx.ccx, discr), to as i64),
                   val, None);
         }
         layout::General{ discr, .. } => {
-            bcx.store(C_integral(Type::from_integer(bcx.ccx, discr), to, true),
+            bcx.store(C_int(Type::from_integer(bcx.ccx, discr), to as i64),
                   bcx.struct_gep(val, 0), None);
         }
         layout::Univariant { .. }
@@ -423,7 +423,7 @@ pub fn trans_set_discr<'a, 'tcx>(bcx: &Builder<'a, 'tcx>, t: Ty<'tcx>, val: Valu
                     // than storing null to single target field.
                     let llptr = bcx.pointercast(val, Type::i8(bcx.ccx).ptr_to());
                     let fill_byte = C_u8(bcx.ccx, 0);
-                    let size = C_uint(bcx.ccx, nonnull.stride().bytes());
+                    let size = C_usize(bcx.ccx, nonnull.stride().bytes());
                     let align = C_i32(bcx.ccx, nonnull.align.abi() as i32);
                     base::call_memset(bcx, llptr, fill_byte, size, align, false);
                 } else {

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -201,7 +201,9 @@ pub fn unsized_info<'ccx, 'tcx>(ccx: &CrateContext<'ccx, 'tcx>,
                                 -> ValueRef {
     let (source, target) = ccx.tcx().struct_lockstep_tails(source, target);
     match (&source.sty, &target.sty) {
-        (&ty::TyArray(_, len), &ty::TySlice(_)) => C_usize(ccx, len.as_u64()),
+        (&ty::TyArray(_, len), &ty::TySlice(_)) => {
+            C_usize(ccx, len.val.to_const_int().unwrap().to_u64().unwrap())
+        }
         (&ty::TyDynamic(..), &ty::TyDynamic(..)) => {
             // For now, upcasts are limited to changes in marker
             // traits, and hence never actually require an actual

--- a/src/librustc_trans/context.rs
+++ b/src/librustc_trans/context.rs
@@ -136,7 +136,7 @@ pub struct LocalCrateContext<'a, 'tcx: 'a> {
     used_statics: RefCell<Vec<ValueRef>>,
 
     lltypes: RefCell<FxHashMap<Ty<'tcx>, Type>>,
-    int_type: Type,
+    isize_ty: Type,
     opaque_vec_type: Type,
     str_slice_type: Type,
 
@@ -398,7 +398,7 @@ impl<'a, 'tcx> LocalCrateContext<'a, 'tcx> {
                 statics_to_rauw: RefCell::new(Vec::new()),
                 used_statics: RefCell::new(Vec::new()),
                 lltypes: RefCell::new(FxHashMap()),
-                int_type: Type::from_ref(ptr::null_mut()),
+                isize_ty: Type::from_ref(ptr::null_mut()),
                 opaque_vec_type: Type::from_ref(ptr::null_mut()),
                 str_slice_type: Type::from_ref(ptr::null_mut()),
                 dbg_cx,
@@ -410,23 +410,23 @@ impl<'a, 'tcx> LocalCrateContext<'a, 'tcx> {
                 placeholder: PhantomData,
             };
 
-            let (int_type, opaque_vec_type, str_slice_ty, mut local_ccx) = {
+            let (isize_ty, opaque_vec_type, str_slice_ty, mut local_ccx) = {
                 // Do a little dance to create a dummy CrateContext, so we can
                 // create some things in the LLVM module of this codegen unit
                 let mut local_ccxs = vec![local_ccx];
-                let (int_type, opaque_vec_type, str_slice_ty) = {
+                let (isize_ty, opaque_vec_type, str_slice_ty) = {
                     let dummy_ccx = LocalCrateContext::dummy_ccx(shared,
                                                                  local_ccxs.as_mut_slice());
                     let mut str_slice_ty = Type::named_struct(&dummy_ccx, "str_slice");
                     str_slice_ty.set_struct_body(&[Type::i8p(&dummy_ccx),
-                                                   Type::int(&dummy_ccx)],
+                                                   Type::isize(&dummy_ccx)],
                                                  false);
-                    (Type::int(&dummy_ccx), Type::opaque_vec(&dummy_ccx), str_slice_ty)
+                    (Type::isize(&dummy_ccx), Type::opaque_vec(&dummy_ccx), str_slice_ty)
                 };
-                (int_type, opaque_vec_type, str_slice_ty, local_ccxs.pop().unwrap())
+                (isize_ty, opaque_vec_type, str_slice_ty, local_ccxs.pop().unwrap())
             };
 
-            local_ccx.int_type = int_type;
+            local_ccx.isize_ty = isize_ty;
             local_ccx.opaque_vec_type = opaque_vec_type;
             local_ccx.str_slice_type = str_slice_ty;
 
@@ -549,8 +549,8 @@ impl<'b, 'tcx> CrateContext<'b, 'tcx> {
         &self.local().stats
     }
 
-    pub fn int_type(&self) -> Type {
-        self.local().int_type
+    pub fn isize_ty(&self) -> Type {
+        self.local().isize_ty
     }
 
     pub fn str_slice_type(&self) -> Type {

--- a/src/librustc_trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/debuginfo/metadata.rs
@@ -366,7 +366,7 @@ fn vec_slice_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                                          -> bool {
         member_llvm_types.len() == 2 &&
         member_llvm_types[0] == type_of::type_of(cx, element_type).ptr_to() &&
-        member_llvm_types[1] == cx.int_type()
+        member_llvm_types[1] == cx.isize_ty()
     }
 }
 
@@ -530,7 +530,7 @@ pub fn type_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             MetadataCreationResult::new(basic_type_metadata(cx, t), false)
         }
         ty::TyArray(typ, len) => {
-            fixed_vec_metadata(cx, unique_type_id, typ, Some(len as u64), usage_site_span)
+            fixed_vec_metadata(cx, unique_type_id, typ, Some(len.as_u64()), usage_site_span)
         }
         ty::TySlice(typ) => {
             fixed_vec_metadata(cx, unique_type_id, typ, None, usage_site_span)

--- a/src/librustc_trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/debuginfo/metadata.rs
@@ -530,7 +530,8 @@ pub fn type_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             MetadataCreationResult::new(basic_type_metadata(cx, t), false)
         }
         ty::TyArray(typ, len) => {
-            fixed_vec_metadata(cx, unique_type_id, typ, Some(len.as_u64()), usage_site_span)
+            let len = len.val.to_const_int().unwrap().to_u64().unwrap();
+            fixed_vec_metadata(cx, unique_type_id, typ, Some(len), usage_site_span)
         }
         ty::TySlice(typ) => {
             fixed_vec_metadata(cx, unique_type_id, typ, None, usage_site_span)

--- a/src/librustc_trans/debuginfo/type_names.rs
+++ b/src/librustc_trans/debuginfo/type_names.rs
@@ -96,7 +96,7 @@ pub fn push_debuginfo_type_name<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         ty::TyArray(inner_type, len) => {
             output.push('[');
             push_debuginfo_type_name(cx, inner_type, true, output);
-            output.push_str(&format!("; {}", len));
+            output.push_str(&format!("; {}", len.val.to_const_int().unwrap().to_u64().unwrap()));
             output.push(']');
         },
         ty::TySlice(inner_type) => {

--- a/src/librustc_trans/machine.rs
+++ b/src/librustc_trans/machine.rs
@@ -48,7 +48,7 @@ pub fn llsize_of(cx: &CrateContext, ty: Type) -> ValueRef {
     // there's no need for that contrivance.  The instruction
     // selection DAG generator would flatten that GEP(1) node into a
     // constant of the type's alloc size, so let's save it some work.
-    return C_uint(cx, llsize_of_alloc(cx, ty));
+    return C_usize(cx, llsize_of_alloc(cx, ty));
 }
 
 // Returns the preferred alignment of the given type for the current target.

--- a/src/librustc_trans/meth.rs
+++ b/src/librustc_trans/meth.rs
@@ -46,7 +46,7 @@ impl<'a, 'tcx> VirtualIndex {
         // Load the data pointer from the object.
         debug!("get_int({:?}, {:?})", Value(llvtable), self);
 
-        let llvtable = bcx.pointercast(llvtable, Type::int(bcx.ccx).ptr_to());
+        let llvtable = bcx.pointercast(llvtable, Type::isize(bcx.ccx).ptr_to());
         let ptr = bcx.load(bcx.gepi(llvtable, &[self.0]), None);
         // Vtable loads are invariant
         bcx.set_invariant_load(ptr);
@@ -81,8 +81,8 @@ pub fn get_vtable<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
 
     let mut components: Vec<_> = [
         callee::get_fn(ccx, monomorphize::resolve_drop_in_place(ccx.shared(), ty)),
-        C_uint(ccx, ccx.size_of(ty)),
-        C_uint(ccx, ccx.align_of(ty))
+        C_usize(ccx, ccx.size_of(ty)),
+        C_usize(ccx, ccx.align_of(ty) as u64)
     ].iter().cloned().collect();
 
     if let Some(trait_ref) = trait_ref {

--- a/src/librustc_trans/mir/analyze.rs
+++ b/src/librustc_trans/mir/analyze.rs
@@ -17,6 +17,7 @@ use rustc::middle::const_val::ConstVal;
 use rustc::mir::{self, Location, TerminatorKind, Literal};
 use rustc::mir::visit::{Visitor, LvalueContext};
 use rustc::mir::traversal;
+use rustc::ty;
 use common;
 use super::MirContext;
 
@@ -110,7 +111,7 @@ impl<'mir, 'a, 'tcx> Visitor<'tcx> for LocalAnalyzer<'mir, 'a, 'tcx> {
             mir::TerminatorKind::Call {
                 func: mir::Operand::Constant(box mir::Constant {
                     literal: Literal::Value {
-                        value: &ConstVal::Function(def_id, _), ..
+                        value: &ty::Const { val: ConstVal::Function(def_id, _), .. }, ..
                     }, ..
                 }),
                 ref args, ..

--- a/src/librustc_trans/mir/analyze.rs
+++ b/src/librustc_trans/mir/analyze.rs
@@ -110,7 +110,7 @@ impl<'mir, 'a, 'tcx> Visitor<'tcx> for LocalAnalyzer<'mir, 'a, 'tcx> {
             mir::TerminatorKind::Call {
                 func: mir::Operand::Constant(box mir::Constant {
                     literal: Literal::Value {
-                        value: ConstVal::Function(def_id, _), ..
+                        value: &ConstVal::Function(def_id, _), ..
                     }, ..
                 }),
                 ref args, ..

--- a/src/librustc_trans/mir/constant.rs
+++ b/src/librustc_trans/mir/constant.rs
@@ -103,7 +103,8 @@ impl<'tcx> Const<'tcx> {
             ConstVal::Char(c) => C_uint(Type::char(ccx), c as u64),
             ConstVal::Function(..) => C_null(type_of::type_of(ccx, ty)),
             ConstVal::Variant(_) |
-            ConstVal::Aggregate(..) => {
+            ConstVal::Aggregate(..) |
+            ConstVal::Unevaluated(..) => {
                 bug!("MIR must not use `{:?}` (aggregates are expanded to MIR rvalues)", cv)
             }
         };

--- a/src/librustc_trans/mir/constant.rs
+++ b/src/librustc_trans/mir/constant.rs
@@ -522,7 +522,7 @@ impl<'a, 'tcx> MirConstContext<'a, 'tcx> {
                         MirConstContext::new(self.ccx, mir, self.substs, IndexVec::new()).trans()
                     }
                     mir::Literal::Value { value } => {
-                        Ok(Const::from_constval(self.ccx, value, ty))
+                        Ok(Const::from_constval(self.ccx, &value.val, ty))
                     }
                 }
             }
@@ -971,7 +971,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 MirConstContext::new(bcx.ccx, mir, self.param_substs, IndexVec::new()).trans()
             }
             mir::Literal::Value { value } => {
-                Ok(Const::from_constval(bcx.ccx, value, ty))
+                Ok(Const::from_constval(bcx.ccx, &value.val, ty))
             }
         };
 

--- a/src/librustc_trans/mir/constant.rs
+++ b/src/librustc_trans/mir/constant.rs
@@ -200,7 +200,9 @@ impl<'tcx> ConstLvalue<'tcx> {
 
     pub fn len<'a>(&self, ccx: &CrateContext<'a, 'tcx>) -> ValueRef {
         match self.ty.sty {
-            ty::TyArray(_, n) => C_usize(ccx, n.as_u64()),
+            ty::TyArray(_, n) => {
+                C_usize(ccx, n.val.to_const_int().unwrap().to_u64().unwrap())
+            }
             ty::TySlice(_) | ty::TyStr => {
                 assert!(self.llextra != ptr::null_mut());
                 self.llextra

--- a/src/librustc_trans/mir/lvalue.rs
+++ b/src/librustc_trans/mir/lvalue.rs
@@ -106,7 +106,9 @@ impl<'a, 'tcx> LvalueRef<'tcx> {
     pub fn len(&self, ccx: &CrateContext<'a, 'tcx>) -> ValueRef {
         let ty = self.ty.to_ty(ccx.tcx());
         match ty.sty {
-            ty::TyArray(_, n) => common::C_usize(ccx, n.as_u64()),
+            ty::TyArray(_, n) => {
+                common::C_usize(ccx, n.val.to_const_int().unwrap().to_u64().unwrap())
+            }
             ty::TySlice(_) | ty::TyStr => {
                 assert!(self.llextra != ptr::null_mut());
                 self.llextra

--- a/src/librustc_trans/mir/rvalue.rs
+++ b/src/librustc_trans/mir/rvalue.rs
@@ -521,7 +521,8 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
             if let LocalRef::Operand(Some(op)) = self.locals[index] {
                 if common::type_is_zero_size(bcx.ccx, op.ty) {
                     if let ty::TyArray(_, n) = op.ty.sty {
-                        return common::C_usize(bcx.ccx, n.as_u64());
+                        let n = n.val.to_const_int().unwrap().to_u64().unwrap();
+                        return common::C_usize(bcx.ccx, n);
                     }
                 }
             }

--- a/src/librustc_trans/trans_item.rs
+++ b/src/librustc_trans/trans_item.rs
@@ -446,7 +446,8 @@ impl<'a, 'tcx> DefPathBasedNames<'a, 'tcx> {
             ty::TyArray(inner_type, len) => {
                 output.push('[');
                 self.push_type_name(inner_type, output);
-                write!(output, "; {}", len).unwrap();
+                write!(output, "; {}",
+                    len.val.to_const_int().unwrap().to_u64().unwrap()).unwrap();
                 output.push(']');
             },
             ty::TySlice(inner_type) => {

--- a/src/librustc_trans/tvec.rs
+++ b/src/librustc_trans/tvec.rs
@@ -34,7 +34,7 @@ pub fn slice_for_each<'a, 'tcx, F>(
     let next_bcx = bcx.build_sibling_block("slice_loop_next");
 
     let start = if zst {
-        C_uint(bcx.ccx, 0usize)
+        C_usize(bcx.ccx, 1)
     } else {
         data_ptr
     };
@@ -46,7 +46,7 @@ pub fn slice_for_each<'a, 'tcx, F>(
     let keep_going = header_bcx.icmp(llvm::IntNE, current, end);
     header_bcx.cond_br(keep_going, body_bcx.llbb(), next_bcx.llbb());
 
-    let next = add(&body_bcx, current, C_uint(bcx.ccx, 1usize));
+    let next = add(&body_bcx, current, C_usize(bcx.ccx, 1));
     f(&body_bcx, if zst { data_ptr } else { current }, header_bcx.llbb());
     header_bcx.add_incoming_to_phi(current, next, body_bcx.llbb());
     next_bcx

--- a/src/librustc_trans/type_.rs
+++ b/src/librustc_trans/type_.rs
@@ -131,7 +131,7 @@ impl Type {
         Type::i8_llcx(llcx).ptr_to()
     }
 
-    pub fn int(ccx: &CrateContext) -> Type {
+    pub fn isize(ccx: &CrateContext) -> Type {
         match &ccx.tcx().sess.target.target.target_pointer_width[..] {
             "16" => Type::i16(ccx),
             "32" => Type::i32(ccx),
@@ -142,7 +142,7 @@ impl Type {
 
     pub fn int_from_ty(ccx: &CrateContext, t: ast::IntTy) -> Type {
         match t {
-            ast::IntTy::Is => ccx.int_type(),
+            ast::IntTy::Is => ccx.isize_ty(),
             ast::IntTy::I8 => Type::i8(ccx),
             ast::IntTy::I16 => Type::i16(ccx),
             ast::IntTy::I32 => Type::i32(ccx),
@@ -153,7 +153,7 @@ impl Type {
 
     pub fn uint_from_ty(ccx: &CrateContext, t: ast::UintTy) -> Type {
         match t {
-            ast::UintTy::Us => ccx.int_type(),
+            ast::UintTy::Us => ccx.isize_ty(),
             ast::UintTy::U8 => Type::i8(ccx),
             ast::UintTy::U16 => Type::i16(ccx),
             ast::UintTy::U32 => Type::i32(ccx),
@@ -207,7 +207,7 @@ impl Type {
 
     pub fn vec(ccx: &CrateContext, ty: &Type) -> Type {
         Type::struct_(ccx,
-            &[Type::array(ty, 0), Type::int(ccx)],
+            &[Type::array(ty, 0), Type::isize(ccx)],
         false)
     }
 

--- a/src/librustc_trans/type_of.rs
+++ b/src/librustc_trans/type_of.rs
@@ -148,9 +148,8 @@ pub fn in_memory_type_of<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>) -> 
       }
 
       ty::TyArray(ty, size) => {
-          let size = size as u64;
           let llty = in_memory_type_of(cx, ty);
-          Type::array(&llty, size)
+          Type::array(&llty, size.as_u64())
       }
 
       // Unsized slice types (and str) have the type of their element, and

--- a/src/librustc_trans/type_of.rs
+++ b/src/librustc_trans/type_of.rs
@@ -149,7 +149,8 @@ pub fn in_memory_type_of<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>) -> 
 
       ty::TyArray(ty, size) => {
           let llty = in_memory_type_of(cx, ty);
-          Type::array(&llty, size.as_u64())
+          let size = size.val.to_const_int().unwrap().to_u64().unwrap();
+          Type::array(&llty, size)
       }
 
       // Unsized slice types (and str) have the type of their element, and

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1083,7 +1083,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
             }
             hir::TyArray(ref ty, length) => {
                 if let Ok(length) = eval_length(tcx, length, "array length") {
-                    tcx.mk_array(self.ast_ty_to_ty(&ty), length)
+                    tcx.mk_array(self.ast_ty_to_ty(&ty), length.as_u64())
                 } else {
                     self.tcx().types.err
                 }

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1083,7 +1083,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
             }
             hir::TyArray(ref ty, length) => {
                 if let Ok(length) = eval_length(tcx, length, "array length") {
-                    tcx.mk_array(self.ast_ty_to_ty(&ty), length.as_u64())
+                    tcx.mk_ty(ty::TyArray(self.ast_ty_to_ty(&ty), length))
                 } else {
                     self.tcx().types.err
                 }

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -264,7 +264,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 let expected_ty = self.structurally_resolved_type(pat.span, expected);
                 let (inner_ty, slice_ty) = match expected_ty.sty {
                     ty::TyArray(inner_ty, size) => {
-                        let min_len = before.len() + after.len();
+                        let size = size.as_u64();
+                        let min_len = before.len() as u64 + after.len() as u64;
                         if slice.is_none() {
                             if min_len != size {
                                 struct_span_err!(

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -264,7 +264,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 let expected_ty = self.structurally_resolved_type(pat.span, expected);
                 let (inner_ty, slice_ty) = match expected_ty.sty {
                     ty::TyArray(inner_ty, size) => {
-                        let size = size.as_u64();
+                        let size = size.val.to_const_int().unwrap().to_u64().unwrap();
                         let min_len = before.len() as u64 + after.len() as u64;
                         if slice.is_none() {
                             if min_len != size {

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -192,6 +192,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     ty::Predicate::TypeOutlives(..) => None,
                     ty::Predicate::WellFormed(..) => None,
                     ty::Predicate::ObjectSafe(..) => None,
+                    ty::Predicate::ConstEvaluatable(..) => None,
 
                     // NB: This predicate is created by breaking down a
                     // `ClosureType: FnFoo()` predicate, where

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -360,7 +360,7 @@ pub fn check_platform_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             match name["simd_shuffle".len()..].parse() {
                 Ok(n) => {
                     let params = vec![param(0), param(0),
-                                      tcx.mk_ty(ty::TyArray(tcx.types.u32, n))];
+                                      tcx.mk_array(tcx.types.u32, n)];
                     (2, params, param(1))
                 }
                 Err(_) => {

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -590,7 +590,8 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
                     ty::Predicate::WellFormed(..) |
                     ty::Predicate::ObjectSafe(..) |
                     ty::Predicate::ClosureKind(..) |
-                    ty::Predicate::TypeOutlives(..) => None,
+                    ty::Predicate::TypeOutlives(..) |
+                    ty::Predicate::ConstEvaluatable(..) => None,
                 }
             })
             .collect();

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3923,7 +3923,10 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             };
 
             if let Ok(count) = count {
-                if count.as_u64() > 1 {
+                let zero_or_one = count.val.to_const_int().and_then(|count| {
+                    count.to_u64().map(|count| count <= 1)
+                }).unwrap_or(false);
+                if !zero_or_one {
                     // For [foo, ..n] where n > 1, `foo` must have
                     // Copy type:
                     let lang_item = self.tcx.require_lang_item(lang_items::CopyTraitLangItem);

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -511,7 +511,8 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
                             ty::Predicate::Subtype(..) |
                             ty::Predicate::Projection(..) |
                             ty::Predicate::ClosureKind(..) |
-                            ty::Predicate::ObjectSafe(..) =>
+                            ty::Predicate::ObjectSafe(..) |
+                            ty::Predicate::ConstEvaluatable(..) =>
                                 vec![],
 
                             ty::Predicate::WellFormed(subty) => {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -572,7 +572,7 @@ fn convert_enum_variant_types<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             }
 
             match result {
-                Ok(ConstVal::Integral(x)) => Some(x),
+                Ok(&ConstVal::Integral(x)) => Some(x),
                 _ => None
             }
         } else if let Some(discr) = repr_type.disr_incr(tcx, prev_discr) {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -572,7 +572,7 @@ fn convert_enum_variant_types<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             }
 
             match result {
-                Ok(&ConstVal::Integral(x)) => Some(x),
+                Ok(&ty::Const { val: ConstVal::Integral(x), .. }) => Some(x),
                 _ => None
             }
         } else if let Some(discr) = repr_type.disr_incr(tcx, prev_discr) {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1555,7 +1555,7 @@ pub enum Type {
     BareFunction(Box<BareFunctionDecl>),
     Tuple(Vec<Type>),
     Slice(Box<Type>),
-    Array(Box<Type>, usize),
+    Array(Box<Type>, String),
     Never,
     Unique(Box<Type>),
     RawPointer(Mutability, Box<Type>),
@@ -1785,7 +1785,7 @@ impl Clean<Type> for hir::Ty {
             TyArray(ref ty, length) => {
                 use rustc::middle::const_val::eval_length;
                 let n = eval_length(cx.tcx, length, "array length").unwrap();
-                Array(box ty.clean(cx), n)
+                Array(box ty.clean(cx), n.to_string())
             },
             TyTup(ref tys) => Tuple(tys.clean(cx)),
             TyPath(hir::QPath::Resolved(None, ref path)) => {
@@ -1895,7 +1895,7 @@ impl<'tcx> Clean<Type> for ty::Ty<'tcx> {
             ty::TyFloat(float_ty) => Primitive(float_ty.into()),
             ty::TyStr => Primitive(PrimitiveType::Str),
             ty::TySlice(ty) => Slice(box ty.clean(cx)),
-            ty::TyArray(ty, n) => Array(box ty.clean(cx), n),
+            ty::TyArray(ty, n) => Array(box ty.clean(cx), n.to_string()),
             ty::TyRawPtr(mt) => RawPointer(mt.mutbl.clean(cx), box mt.ty.clean(cx)),
             ty::TyRef(r, mt) => BorrowedRef {
                 lifetime: r.clean(cx),

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -633,7 +633,7 @@ fn fmt_type(t: &clean::Type, f: &mut fmt::Formatter, use_absolute: bool) -> fmt:
             fmt::Display::fmt(t, f)?;
             primitive_link(f, PrimitiveType::Slice, "]")
         }
-        clean::Array(ref t, n) => {
+        clean::Array(ref t, ref n) => {
             primitive_link(f, PrimitiveType::Array, "[")?;
             fmt::Display::fmt(t, f)?;
             primitive_link(f, PrimitiveType::Array, &format!("; {}]", n))

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -32,6 +32,7 @@ extern crate html_diff;
 extern crate libc;
 extern crate rustc;
 extern crate rustc_data_structures;
+extern crate rustc_const_math;
 extern crate rustc_trans;
 extern crate rustc_driver;
 extern crate rustc_resolve;

--- a/src/test/compile-fail/const-block-non-item-statement-3.rs
+++ b/src/test/compile-fail/const-block-non-item-statement-3.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,22 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-trait Dim {
-    fn dim() -> usize;
-}
+type Array = [u32; {  let x = 2; 5 }];
+//~^ ERROR: blocks in constants are limited to items and tail expressions
+//~^^ ERROR: blocks in constants are limited to items and tail expressions
 
-enum Dim3 {}
-
-impl Dim for Dim3 {
-    fn dim() -> usize {
-        3
-    }
-}
-
-pub struct Vector<T, D: Dim> {
-    entries: [T; D::dim()],
-    //~^ ERROR no function or associated item named `dim` found for type `D` in the current scope
-    _dummy: D,
-}
-
-fn main() {}
+pub fn main() {}

--- a/src/test/compile-fail/const-block-non-item-statement.rs
+++ b/src/test/compile-fail/const-block-non-item-statement.rs
@@ -14,8 +14,4 @@ enum Foo {
     //~^^ ERROR: blocks in constants are limited to items and tail expressions
 }
 
-type Array = [u32; {  let x = 2; 5 }];
-//~^ ERROR: blocks in constants are limited to items and tail expressions
-//~^^ ERROR: blocks in constants are limited to items and tail expressions
-
 pub fn main() {}

--- a/src/test/compile-fail/const-fn-error.rs
+++ b/src/test/compile-fail/const-fn-error.rs
@@ -23,5 +23,5 @@ const fn f(x: usize) -> usize {
 
 #[allow(unused_variables)]
 fn main() {
-    let a : [i32; f(X)]; //~ NOTE for array length here
+    let a : [i32; f(X)]; //~ NOTE for constant expression here
 }

--- a/src/test/compile-fail/const-len-underflow-separate-spans.rs
+++ b/src/test/compile-fail/const-len-underflow-separate-spans.rs
@@ -20,5 +20,5 @@ const LEN: usize = ONE - TWO;
 
 fn main() {
     let a: [i8; LEN] = unimplemented!();
-    //~^ NOTE for array length here
+    //~^ NOTE for constant expression here
 }

--- a/src/test/compile-fail/const-size_of-cycle.rs
+++ b/src/test/compile-fail/const-size_of-cycle.rs
@@ -8,11 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// error-pattern: unsupported cyclic reference between types/traits detected
+
 #![feature(const_fn)]
 
 struct Foo {
     bytes: [u8; std::mem::size_of::<Foo>()]
-    //~^ ERROR unsupported cyclic reference between types/traits detected
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-22933-2.rs
+++ b/src/test/compile-fail/issue-22933-2.rs
@@ -15,7 +15,4 @@ enum Delicious {
     //~^ ERROR no associated item named `PIE` found for type `Delicious`
 }
 
-const FOO: [u32; u8::MIN as usize] = [];
-//~^ ERROR no associated item named `MIN` found for type `u8`
-
 fn main() {}

--- a/src/test/compile-fail/issue-22933-3.rs
+++ b/src/test/compile-fail/issue-22933-3.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,22 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-trait Dim {
-    fn dim() -> usize;
-}
-
-enum Dim3 {}
-
-impl Dim for Dim3 {
-    fn dim() -> usize {
-        3
-    }
-}
-
-pub struct Vector<T, D: Dim> {
-    entries: [T; D::dim()],
-    //~^ ERROR no function or associated item named `dim` found for type `D` in the current scope
-    _dummy: D,
-}
+const FOO: [u32; u8::MIN as usize] = [];
+//~^ ERROR no associated item named `MIN` found for type `u8`
 
 fn main() {}

--- a/src/test/ui/issue-38875/issue_38875.stderr
+++ b/src/test/ui/issue-38875/issue_38875.stderr
@@ -4,7 +4,7 @@ error[E0080]: constant evaluation error
 11 | pub const FOO: usize = *&0;
    |                        ^^^ unimplemented constant expression: deref operation
    |
-note: for repeat count here
+note: for constant expression here
   --> $DIR/issue_38875.rs:16:22
    |
 16 |     let test_x = [0; issue_38875_b::FOO];


### PR DESCRIPTION
This is in preparation for polymorphic array lengths (aka `[T; T::A]`) and const generics.
We need deferred const-evaluation to break cycles when array types show up in positions which require knowing the array type to typeck the array length, e.g. the array type is in a `where` clause.

The final step - actually passing bounds in scope to array length expressions from the parent - is not done because it still produces cycles when *normalizing* `ParamEnv`s, and @nikomatsakis' in-progress lazy normalization work is needed to deal with that uniformly.

However, the changes here are still useful to unlock work on const generics, which @EpicatSupercell manifested interest in, and I might be mentoring them for that, but we need this baseline first.

r? @nikomatsakis cc @oli-obk