### PR TITLE
Allow replacing HashMap entries

### DIFF
--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -2161,6 +2161,36 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     fn take_key(&mut self) -> Option<K> {
         self.key.take()
     }
+
+    /// Replaces the entry, returning the old key and value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    /// use std::collections::hash_map::Entry;
+    ///
+    /// let mut map: HashMap<String, u32> = HashMap::new();
+    /// map.insert(String::from("poneyland"), 15);
+    ///
+    /// if let Entry::Occupied(entry) = map.entry(String::from("poneyland")) {
+    ///     let (old_key, old_value): (String, u32) = entry.replace(16);
+    ///     assert_eq!(old_key, "poneyland");
+    ///     assert_eq!(old_value, 15);
+    /// }
+    ///
+    /// assert_eq!(map.get("poneyland"), Some(&16));
+    ///
+    /// ```
+    #[stable(feature = "rust1", since = "1.20.0")]
+    pub fn replace(mut self, value: V) -> (K, V) {
+        let (old_key, old_value) = self.elem.read_mut();
+
+        let old_key = mem::replace(old_key, self.key.unwrap());
+        let old_value = mem::replace(old_value, value);
+
+        (old_key, old_value)
+    }
 }
 
 impl<'a, K: 'a, V: 'a> VacantEntry<'a, K, V> {

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -2167,6 +2167,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// # Examples
     ///
     /// ```
+    /// # #![feature(map_entry_replace)]
     /// use std::collections::HashMap;
     /// use std::collections::hash_map::Entry;
     ///
@@ -2182,7 +2183,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// assert_eq!(map.get("poneyland"), Some(&16));
     ///
     /// ```
-    #[stable(feature = "rust1", since = "1.20.0")]
+    #[unstable(feature = "map_entry_replace", issue = "44286")]
     pub fn replace(mut self, value: V) -> (K, V) {
         let (old_key, old_value) = self.elem.read_mut();
 

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -2167,21 +2167,20 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(map_entry_replace)]
+    /// #![feature(map_entry_replace)]
     /// use std::collections::HashMap;
     /// use std::collections::hash_map::Entry;
     ///
     /// let mut map: HashMap<String, u32> = HashMap::new();
-    /// map.insert(String::from("poneyland"), 15);
+    /// map.insert("poneyland".to_string(), 15);
     ///
-    /// if let Entry::Occupied(entry) = map.entry(String::from("poneyland")) {
+    /// if let Entry::Occupied(entry) = map.entry("poneyland".to_string()) {
     ///     let (old_key, old_value): (String, u32) = entry.replace(16);
     ///     assert_eq!(old_key, "poneyland");
     ///     assert_eq!(old_value, 15);
     /// }
     ///
     /// assert_eq!(map.get("poneyland"), Some(&16));
-    ///
     /// ```
     #[unstable(feature = "map_entry_replace", issue = "44286")]
     pub fn replace(mut self, value: V) -> (K, V) {


### PR DESCRIPTION
This is an obvious API hole. At the moment the only way to retrieve an entry from a `HashMap` is to get an entry to it, remove it, and then insert a new entry. This PR allows entries to be replaced. 