### PR TITLE
Minor documentation improvements for StmtKind

### DIFF
--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -763,7 +763,7 @@ pub enum StmtKind {
     Expr(P<Expr>),
     /// Expr with a trailing semi-colon.
     Semi(P<Expr>),
-    /// Macro. 
+    /// Macro.
     Mac(P<(Mac, MacStmtStyle, ThinVec<Attribute>)>),
 }
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -761,9 +761,9 @@ pub enum StmtKind {
 
     /// Expr without trailing semi-colon.
     Expr(P<Expr>),
-
+    /// Expr with a trailing semi-colon.
     Semi(P<Expr>),
-
+    /// Macro. 
     Mac(P<(Mac, MacStmtStyle, ThinVec<Attribute>)>),
 }
 


### PR DESCRIPTION
Documentation for Semi and Marco StmtKinds.

Wasn't obvious to me what these were when writing a lint recently.