### PR TITLE
std/time: Give an example to get UNIX_EPOCH in seconds

### DIFF
--- a/src/libstd/time/mod.rs
+++ b/src/libstd/time/mod.rs
@@ -382,6 +382,15 @@ impl fmt::Debug for SystemTime {
 /// [`SystemTime`] instance to represent another fixed point in time.
 ///
 /// [`SystemTime`]: ../../std/time/struct.SystemTime.html
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::time::{SystemTime,UNIX_EPOCH};
+///
+/// let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+/// println!("1970-01-01 00:00:00 UTC was {} seconds ago!", now);
+/// ```
 #[stable(feature = "time2", since = "1.8.0")]
 pub const UNIX_EPOCH: SystemTime = SystemTime(time::UNIX_EPOCH);
 

--- a/src/libstd/time/mod.rs
+++ b/src/libstd/time/mod.rs
@@ -386,10 +386,14 @@ impl fmt::Debug for SystemTime {
 /// # Examples
 ///
 /// ```no_run
-/// use std::time::{SystemTime,UNIX_EPOCH};
+/// use std::time::{SystemTime, UNIX_EPOCH};
 ///
-/// let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
-/// println!("1970-01-01 00:00:00 UTC was {} seconds ago!", now);
+/// let now = match SystemTime::now().duration_since(UNIX_EPOCH) {
+///     Ok(n) => n,
+///     Err(_) => panic!("SystemTime before UNIX EPOCH!"),
+/// };
+/// println!("1970-01-01 00:00:00 UTC was {} seconds ago!", now.as_secs());
+
 /// ```
 #[stable(feature = "time2", since = "1.8.0")]
 pub const UNIX_EPOCH: SystemTime = SystemTime(time::UNIX_EPOCH);

--- a/src/libstd/time/mod.rs
+++ b/src/libstd/time/mod.rs
@@ -393,7 +393,6 @@ impl fmt::Debug for SystemTime {
 ///     Err(_) => panic!("SystemTime before UNIX EPOCH!"),
 /// };
 /// println!("1970-01-01 00:00:00 UTC was {} seconds ago!", now.as_secs());
-
 /// ```
 #[stable(feature = "time2", since = "1.8.0")]
 pub const UNIX_EPOCH: SystemTime = SystemTime(time::UNIX_EPOCH);


### PR DESCRIPTION
A tiny doc improvement.  I always end up looking for EPOCH and always find obtaining it less-than-obvious from the docs.