### PR TITLE
impl Debug for SplitWhitespace.

### DIFF
--- a/src/libstd_unicode/u_str.rs
+++ b/src/libstd_unicode/u_str.rs
@@ -26,7 +26,7 @@ use core::str::Split;
 /// [`split_whitespace`]: ../../std/primitive.str.html#method.split_whitespace
 /// [`str`]: ../../std/primitive.str.html
 #[stable(feature = "split_whitespace", since = "1.1.0")]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SplitWhitespace<'a> {
     inner: Filter<Split<'a, IsWhitespace>, IsNotEmpty>,
 }


### PR DESCRIPTION
This one got missed because `libstd_unicode` doesn't have a `deny(missing_debug_implementations)` like `libstd` and `libcore`. I think that perhaps this lint should check for items exported from other crates too.