### PR TITLE
rustbook: remove dead test functions

### DIFF
--- a/src/tools/rustbook/src/main.rs
+++ b/src/tools/rustbook/src/main.rs
@@ -41,7 +41,6 @@ fn main() {
     // Check which subcomamnd the user ran...
     let res = match matches.subcommand() {
         ("build", Some(sub_matches)) => build(sub_matches),
-        ("test", Some(sub_matches)) => test(sub_matches),
         (_, _) => unreachable!(),
     };
 
@@ -61,14 +60,6 @@ fn build(args: &ArgMatches) -> Result<(), Box<Error>> {
     };
 
     try!(book.build());
-
-    Ok(())
-}
-
-fn test(args: &ArgMatches) -> Result<(), Box<Error>> {
-    let mut book = build_mdbook_struct(args);
-
-    try!(book.test());
 
     Ok(())
 }


### PR DESCRIPTION
There is no "test" subcommand added to the `clap::App`, so this is all dead code.

Cc @steveklabnik -- your [commit](https://github.com/RalfJung/rust/commit/a076961fd0e3d8a68f8b047460b8f5191d203b08) introducing this stated the intention of having both commands, but it seems nobody has missed the `test` command since February.