### PR TITLE
Expect pipe symbol after closure parameter list

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4699,7 +4699,7 @@ impl<'a> Parser<'a> {
                     SeqSep::trailing_allowed(token::Comma),
                     |p| p.parse_fn_block_arg()
                 );
-                self.bump();
+                self.expect(&token::BinOp(token::Or))?;
                 args
             }
         };

--- a/src/test/compile-fail/issue-44021.rs
+++ b/src/test/compile-fail/issue-44021.rs
@@ -1,0 +1,16 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct MyStruct;
+impl MyStruct {
+    fn f() {|x, y} //~ ERROR expected one of `:`, `@`, or `|`, found `}`
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #44021.

---

Originally, the parser just called `bump` to discard following token after parsing closure parameter list, because it assumes `|` is following. However, the following code breaks the assumption:

```rust
struct MyStruct;
impl MyStruct {
   fn f() {|x, y}
}
```

Here, the parameter list is `x, y` and the following token is `}`. The parser discards `}`, and then we have a curly bracket mismatch.

Indeed, this code has a syntax error. On current nightly, the compiler emits an syntax error, but with incorrect message and span, followed by an ICE.

```
error: expected expression, found `}`
 --> 44021.rs:4:1
  |
4 | }
  | ^

error: internal compiler error: unexpected panic
```

Even worse, on current stable(1.20.0), the compiler falls into an infinite loop.

This pull request fixes this problem. Now the compiler emits correct error message and span, and does not ICE.

```
error: expected one of `:`, `@`, or `|`, found `}`
 --> 44021.rs:3:20
  |
3 |     fn foo() {|x, y}
  |                    ^ expected one of `:`, `@`, or `|` here
```