### PR TITLE
Avoid hashing when creating a DepNode from a HirId

### DIFF
--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -62,7 +62,7 @@
 
 use hir::def_id::{CrateNum, DefId};
 use hir::map::DefPathHash;
-use hir::HirId;
+use hir::{HirId, ItemLocalId};
 
 use ich::Fingerprint;
 use ty::{TyCtxt, Instance, InstanceDef};
@@ -635,6 +635,25 @@ impl<'a, 'gcx: 'tcx + 'a, 'tcx: 'a> DepNodeParams<'a, 'gcx, 'tcx> for (DefIdList
         write!(&mut s, "]").unwrap();
 
         s
+    }
+}
+
+impl<'a, 'gcx: 'tcx + 'a, 'tcx: 'a> DepNodeParams<'a, 'gcx, 'tcx> for (HirId,) {
+    const CAN_RECONSTRUCT_QUERY_KEY: bool = false;
+
+    // We actually would not need to specialize the implementation of this
+    // method but it's faster to combine the hashes than to instantiate a full
+    // hashing context and stable-hashing state.
+    fn to_fingerprint(&self, tcx: TyCtxt) -> Fingerprint {
+        let (HirId {
+            owner,
+            local_id: ItemLocalId(local_id),
+        },) = *self;
+
+        let def_path_hash = tcx.def_path_hash(DefId::local(owner));
+        let local_id = Fingerprint::from_smaller_hash(local_id as u64);
+
+        def_path_hash.0.combine(local_id)
     }
 }
 


### PR DESCRIPTION
Instead, combine the already-present DefPathHash with the 32-bit
ItemLocalIndex.

Should fix #44323.

r? @alexcrichton