### PR TITLE
Include rustc in the default `./x.py install`

### DIFF
--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -200,7 +200,7 @@ install!((self, builder, _config),
         builder.ensure(dist::Src);
         install_src(builder, self.stage);
     }, ONLY_BUILD;
-    Rustc, "src/librustc", _config.extended, only_hosts: true, {
+    Rustc, "src/librustc", true, only_hosts: true, {
         builder.ensure(dist::Rustc {
             compiler: builder.compiler(self.stage, self.target),
         });


### PR DESCRIPTION
The default install used to include rustc, rust-std, and rust-docs, but
the refactoring in commit 6b3413d825fa6 make rustc only default in
extended builds.  This commit makes rustc installed by default again.