### PR TITLE
Optimize drain_filter

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2691,7 +2691,8 @@ impl<'a, T, F> Iterator for DrainFilter<'a, T, F>
                     self.del += 1;
                     return Some(ptr::read(&v[i]));
                 } else if self.del > 0 {
-                    v.swap(i - self.del, i);
+                    let del = self.del;
+                    ptr::copy_nonoverlapping(self.vec.as_ptr().offset(i), self.vec.as_mut_ptr().offset(i - del), 1);
                 }
             }
             None

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2692,7 +2692,9 @@ impl<'a, T, F> Iterator for DrainFilter<'a, T, F>
                     return Some(ptr::read(&v[i]));
                 } else if self.del > 0 {
                     let del = self.del;
-                    ptr::copy_nonoverlapping(self.vec.as_ptr().offset(i), self.vec.as_mut_ptr().offset(i - del), 1);
+                    let src = self.vec.as_ptr().offset(i);
+                    let dst = self.vec.as_mut_ptr().offset(i - del);
+                    ptr::copy_nonoverlapping(src, dst, 1);
                 }
             }
             None

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2692,8 +2692,8 @@ impl<'a, T, F> Iterator for DrainFilter<'a, T, F>
                     return Some(ptr::read(&v[i]));
                 } else if self.del > 0 {
                     let del = self.del;
-                    let src = self.vec.as_ptr().offset(i);
-                    let dst = self.vec.as_mut_ptr().offset(i - del);
+                    let src: *const T = &v[i];
+                    let dst: *mut T = &mut v[i - del];
                     ptr::copy_nonoverlapping(src, dst, 1);
                 }
             }

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2694,6 +2694,9 @@ impl<'a, T, F> Iterator for DrainFilter<'a, T, F>
                     let del = self.del;
                     let src: *const T = &v[i];
                     let dst: *mut T = &mut v[i - del];
+                    // This is safe because self.vec has length 0
+                    // thus its elements will not have Drop::drop
+                    // called on them in the event of a panic.
                     ptr::copy_nonoverlapping(src, dst, 1);
                 }
             }


### PR DESCRIPTION
This PR cuts out two copies from each iteration of `drain_filter` by exchanging the swap operation for a copy_nonoverlapping function call instead.  Since the data being swapped is not needed anymore we can just overwrite it instead.