### PR TITLE
Move reason for move to label

### DIFF
--- a/src/test/compile-fail/augmented-assignments.rs
+++ b/src/test/compile-fail/augmented-assignments.rs
@@ -20,16 +20,18 @@ impl AddAssign for Int {
 
 fn main() {
     let mut x = Int(1);
-    x   //~ error: use of moved value: `x`
-    //~^ value used here after move
-    //~| note: move occurs because `x` has type `Int`
+    x
+    //~^ error: use of moved value: `x`
+    //~| note: value used here after move
     +=
-    x;  //~ value moved here
+    x;
+    //~^ note: value moved here because it has type `Int`, which does not implement the `Copy`
 
     let y = Int(2);
-    //~^ consider changing this to `mut y`
-    y   //~ error: cannot borrow immutable local variable `y` as mutable
-        //~| cannot borrow
+    //~^ note: consider changing this to `mut y`
+    y
+    //~^ error: cannot borrow immutable local variable `y` as mutable
+    //~| note: cannot borrow mutably
     +=
     Int(1);
 }

--- a/src/test/compile-fail/borrowck/borrowck-box-insensitivity.rs
+++ b/src/test/compile-fail/borrowck/borrowck-box-insensitivity.rs
@@ -33,28 +33,25 @@ struct D {
 fn copy_after_move() {
     let a: Box<_> = box A { x: box 0, y: 1 };
     let _x = a.x;
-    //~^ value moved here
-    let _y = a.y; //~ ERROR use of moved
-    //~^ move occurs because `a.x` has type `std::boxed::Box<isize>`
-    //~| value used here after move
+    //~^ NOTE value moved here because it has type `std::boxed::Box<isize>`, which does not
+    let _y = a.y; //~ ERROR use of moved value
+    //~^ NOTE value used here after move
 }
 
 fn move_after_move() {
     let a: Box<_> = box B { x: box 0, y: box 1 };
     let _x = a.x;
-    //~^ value moved here
+    //~^ NOTE value moved here because it has type `std::boxed::Box<isize>`, which does not
     let _y = a.y; //~ ERROR use of moved
-    //~^ move occurs because `a.x` has type `std::boxed::Box<isize>`
-    //~| value used here after move
+    //~^ NOTE value used here after move
 }
 
 fn borrow_after_move() {
     let a: Box<_> = box A { x: box 0, y: 1 };
     let _x = a.x;
-    //~^ value moved here
+    //~^ NOTE value moved here because it has type `std::boxed::Box<isize>`, which does not
     let _y = &a.y; //~ ERROR use of moved
-    //~^ move occurs because `a.x` has type `std::boxed::Box<isize>`
-    //~| value used here after move
+    //~^ NOTE value used here after move
 }
 
 fn move_after_borrow() {
@@ -63,7 +60,7 @@ fn move_after_borrow() {
     //~^ NOTE borrow of `a.x` occurs here
     let _y = a.y;
     //~^ ERROR cannot move
-    //~| move out of
+    //~| NOTE move out of
 }
 
 fn copy_after_mut_borrow() {
@@ -80,7 +77,7 @@ fn move_after_mut_borrow() {
     //~^ NOTE borrow of `a.x` occurs here
     let _y = a.y;
     //~^ ERROR cannot move
-    //~| move out of
+    //~| NOTE move out of
 }
 
 fn borrow_after_mut_borrow() {
@@ -88,7 +85,7 @@ fn borrow_after_mut_borrow() {
     let _x = &mut a.x;
     //~^ NOTE mutable borrow occurs here (via `a.x`)
     let _y = &a.y; //~ ERROR cannot borrow
-    //~^ immutable borrow occurs here (via `a.y`)
+    //~^ NOTE immutable borrow occurs here (via `a.y`)
 }
 //~^ NOTE mutable borrow ends here
 
@@ -97,44 +94,41 @@ fn mut_borrow_after_borrow() {
     let _x = &a.x;
     //~^ NOTE immutable borrow occurs here (via `a.x`)
     let _y = &mut a.y; //~ ERROR cannot borrow
-    //~^ mutable borrow occurs here (via `a.y`)
+    //~^ NOTE mutable borrow occurs here (via `a.y`)
 }
 //~^ NOTE immutable borrow ends here
 
 fn copy_after_move_nested() {
     let a: Box<_> = box C { x: box A { x: box 0, y: 1 }, y: 2 };
     let _x = a.x.x;
-    //~^ value moved here
+    //~^ NOTE value moved here because it has type `std::boxed::Box<isize>`, which does not
     let _y = a.y; //~ ERROR use of collaterally moved
-    //~^ NOTE move occurs because `a.x.x` has type `std::boxed::Box<isize>`
-    //~| value used here after move
+    //~^ NOTE value used here after move
 }
 
 fn move_after_move_nested() {
     let a: Box<_> = box D { x: box A { x: box 0, y: 1 }, y: box 2 };
     let _x = a.x.x;
-    //~^ value moved here
+    //~^ NOTE value moved here because it has type `std::boxed::Box<isize>`, which does not
     let _y = a.y; //~ ERROR use of collaterally moved
-    //~^ NOTE move occurs because `a.x.x` has type `std::boxed::Box<isize>`
-    //~| value used here after move
+    //~^ NOTE value used here after move
 }
 
 fn borrow_after_move_nested() {
     let a: Box<_> = box C { x: box A { x: box 0, y: 1 }, y: 2 };
     let _x = a.x.x;
-    //~^ value moved here
+    //~^ NOTE value moved here because it has type `std::boxed::Box<isize>`, which does not
     let _y = &a.y; //~ ERROR use of collaterally moved
-    //~^ NOTE move occurs because `a.x.x` has type `std::boxed::Box<isize>`
-    //~| value used here after move
+    //~^ NOTE value used here after move
 }
 
 fn move_after_borrow_nested() {
     let a: Box<_> = box D { x: box A { x: box 0, y: 1 }, y: box 2 };
     let _x = &a.x.x;
-    //~^ borrow of `a.x.x` occurs here
+    //~^ NOTE borrow of `a.x.x` occurs here
     let _y = a.y;
     //~^ ERROR cannot move
-    //~| move out of
+    //~| NOTE move out of
 }
 
 fn copy_after_mut_borrow_nested() {
@@ -151,24 +145,24 @@ fn move_after_mut_borrow_nested() {
     //~^ NOTE borrow of `a.x.x` occurs here
     let _y = a.y;
     //~^ ERROR cannot move
-    //~| move out of
+    //~| NOTE move out of
 }
 
 fn borrow_after_mut_borrow_nested() {
     let mut a: Box<_> = box C { x: box A { x: box 0, y: 1 }, y: 2 };
     let _x = &mut a.x.x;
-    //~^ mutable borrow occurs here
+    //~^ NOTE mutable borrow occurs here
     let _y = &a.y; //~ ERROR cannot borrow
-    //~^ immutable borrow occurs here
+    //~^ NOTE immutable borrow occurs here
 }
 //~^ NOTE mutable borrow ends here
 
 fn mut_borrow_after_borrow_nested() {
     let mut a: Box<_> = box C { x: box A { x: box 0, y: 1 }, y: 2 };
     let _x = &a.x.x;
-    //~^ immutable borrow occurs here
+    //~^ NOTE immutable borrow occurs here
     let _y = &mut a.y; //~ ERROR cannot borrow
-    //~^ mutable borrow occurs here
+    //~^ NOTE mutable borrow occurs here
 }
 //~^ NOTE immutable borrow ends here
 

--- a/src/test/compile-fail/moves-based-on-type-distribute-copy-over-paren.rs
+++ b/src/test/compile-fail/moves-based-on-type-distribute-copy-over-paren.rs
@@ -17,17 +17,17 @@ fn touch<A>(_a: &A) {}
 fn f00() {
     let x = "hi".to_string();
     let _y = Foo { f:x };
-    //~^ value moved here
+    //~^ NOTE value moved here because it has type
     touch(&x); //~ ERROR use of moved value: `x`
-    //~^ value used here after move
-    //~| move occurs because `x` has type `std::string::String`
+    //~^ NOTE value used here after move
 }
 
 fn f05() {
     let x = "hi".to_string();
     let _y = Foo { f:(((x))) };
-    //~^ value moved here
+    //~^ NOTE value moved here because it has type
     touch(&x); //~ ERROR use of moved value: `x`
+    //~^ NOTE value used here after move
 }
 
 fn f10() {

--- a/src/test/compile-fail/moves-based-on-type-match-bindings.rs
+++ b/src/test/compile-fail/moves-based-on-type-match-bindings.rs
@@ -20,12 +20,12 @@ fn f10() {
     let x = Foo {f: "hi".to_string()};
 
     let y = match x {
-        Foo {f} => {} //~ NOTE moved here
+        Foo {f} => {}
+        //~^ NOTE value moved here because it has type `std::string::String`, which does not
     };
 
     touch(&x); //~ ERROR use of partially moved value: `x`
-    //~^ value used here after move
-    //~| move occurs because `x.f` has type `std::string::String`
+    //~^ NOTE value used here after move
 }
 
 fn main() {}

--- a/src/test/ui/borrowck/issue-41962.rs
+++ b/src/test/ui/borrowck/issue-41962.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct NoCopy;
-fn main() {
-   let x = NoCopy;
-   let f = move || { let y = x; };
-   //~^ NOTE value moved (into closure) here because it has type `NoCopy`, which does not
-   let z = x;
-   //~^ ERROR use of moved value: `x`
-   //~| NOTE value used here after move
+pub fn main(){
+    let maybe = Some(vec![true, true]);
+
+    loop {
+        if let Some(thing) = maybe {
+        }
+    }
 }

--- a/src/test/ui/borrowck/issue-41962.stderr
+++ b/src/test/ui/borrowck/issue-41962.stderr
@@ -1,0 +1,16 @@
+error[E0382]: use of partially moved value: `maybe`
+  --> $DIR/issue-41962.rs:15:30
+   |
+15 |         if let Some(thing) = maybe {
+   |                     -----    ^^^^^ value used here after move
+   |                     |
+   |                     value moved here because it has type `std::vec::Vec<bool>`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `(maybe as std::prelude::v1::Some).0`
+  --> $DIR/issue-41962.rs:15:21
+   |
+15 |         if let Some(thing) = maybe {
+   |                     ^^^^^ value moved here in previous iteration of loop because it has type `std::vec::Vec<bool>`, which does not implement the `Copy` trait
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Sidesteps part of the problem with #41962:

```
error[E0382]: use of partially moved value: `maybe`
 --> file.rs:5:30
  |
5 |         if let Some(thing) = maybe {
  |                     -----    ^^^^^ value used here after move
  |                     |
  |                     value moved here because it has type `std::vec::Vec<bool>`, which does not implement the `Copy` trait

error[E0382]: use of moved value: `(maybe as std::prelude::v1::Some).0`
 --> file.rs:5:21
  |
5 |         if let Some(thing) = maybe {
  |                     ^^^^^ value moved here in previous iteration of loop because it has type `std::vec::Vec<bool>`, which does not implement the `Copy` trait

error: aborting due to 2 previous errors
```