### PR TITLE
Use memalign instead of posix_memalign for Solaris

### DIFF
--- a/src/liballoc_system/lib.rs
+++ b/src/liballoc_system/lib.rs
@@ -221,7 +221,7 @@ mod platform {
         }
     }
 
-    #[cfg(any(target_os = "android", target_os = "redox"))]
+    #[cfg(any(target_os = "android", target_os = "redox", target_os = "solaris"))]
     #[inline]
     unsafe fn aligned_malloc(layout: &Layout) -> *mut u8 {
         // On android we currently target API level 9 which unfortunately
@@ -244,7 +244,7 @@ mod platform {
         libc::memalign(layout.align(), layout.size()) as *mut u8
     }
 
-    #[cfg(not(any(target_os = "android", target_os = "redox")))]
+    #[cfg(not(any(target_os = "android", target_os = "redox", target_os = "solaris")))]
     #[inline]
     unsafe fn aligned_malloc(layout: &Layout) -> *mut u8 {
         let mut out = ptr::null_mut();


### PR DESCRIPTION
As pointed out in https://github.com/rust-lang/libc/commit/deb61c8,
Solaris 10 does not support posix_memalign.
Use memalign for all Solaris versions instead.
With this change applied I am able to cross-build rustc for Solaris 10.