### PR TITLE
MIR: should not inline trait method

### DIFF
--- a/src/librustc_mir/transform/inline.rs
+++ b/src/librustc_mir/transform/inline.rs
@@ -88,12 +88,22 @@ impl<'a, 'tcx> Inliner<'a, 'tcx> {
                 if let TerminatorKind::Call {
                     func: Operand::Constant(ref f), .. } = terminator.kind {
                     if let ty::TyFnDef(callee_def_id, substs) = f.ty.sty {
-                        callsites.push_back(CallSite {
-                            callee: callee_def_id,
-                            substs,
-                            bb,
-                            location: terminator.source_info
-                        });
+                        let should_inline = match self.tcx.opt_associated_item(callee_def_id) {
+                            Some(item) => match item.container {
+                               ty::AssociatedItemContainer::ImplContainer(_) => true,
+                               ty::AssociatedItemContainer::TraitContainer(_) => false,
+                            },
+                            None => true
+                        };
+
+                        if should_inline {
+                            callsites.push_back(CallSite {
+                                callee: callee_def_id,
+                                substs,
+                                bb,
+                                location: terminator.source_info
+                            });
+                        }
                     }
                 }
             }

--- a/src/librustc_mir/transform/inline.rs
+++ b/src/librustc_mir/transform/inline.rs
@@ -88,15 +88,7 @@ impl<'a, 'tcx> Inliner<'a, 'tcx> {
                 if let TerminatorKind::Call {
                     func: Operand::Constant(ref f), .. } = terminator.kind {
                     if let ty::TyFnDef(callee_def_id, substs) = f.ty.sty {
-                        let should_inline = match self.tcx.opt_associated_item(callee_def_id) {
-                            Some(item) => match item.container {
-                               ty::AssociatedItemContainer::ImplContainer(_) => true,
-                               ty::AssociatedItemContainer::TraitContainer(_) => false,
-                            },
-                            None => true
-                        };
-
-                        if should_inline {
+                        if self.tcx.trait_of_item(callee_def_id).is_none() {
                             callsites.push_back(CallSite {
                                 callee: callee_def_id,
                                 substs,

--- a/src/test/run-pass/mir-inlining/no-trait-method-issue-40473.rs
+++ b/src/test/run-pass/mir-inlining/no-trait-method-issue-40473.rs
@@ -17,6 +17,8 @@ impl Foo for () {
     fn bar(&self) -> usize { 3 }
 }
 
+// Test a case where MIR would inline the default trait method
+// instead of bailing out. Issue #40473.
 fn main() {
     let result = ().bar();
     assert_eq!(result, 3);

--- a/src/test/run-pass/mir-inlining/no-trait-method-issue-40473.rs
+++ b/src/test/run-pass/mir-inlining/no-trait-method-issue-40473.rs
@@ -1,0 +1,23 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:-Zmir-opt-level=2
+pub trait Foo {
+    fn bar(&self) -> usize { 2 }
+}
+
+impl Foo for () {
+    fn bar(&self) -> usize { 3 }
+}
+
+fn main() {
+    let result = ().bar();
+    assert_eq!(result, 3);
+}


### PR DESCRIPTION
Fixes #40473.

The idea here is bailing out of inlining if we're talking about a trait method.