### PR TITLE
std: Fix a segfault on OSX with backtraces

### DIFF
--- a/src/libstd/sys/unix/backtrace/printing/dladdr.rs
+++ b/src/libstd/sys/unix/backtrace/printing/dladdr.rs
@@ -22,7 +22,8 @@ pub fn resolve_symname<F>(frame: Frame,
 {
     unsafe {
         let mut info: Dl_info = intrinsics::init();
-        let symname = if dladdr(frame.exact_position, &mut info) == 0 {
+        let symname = if dladdr(frame.exact_position, &mut info) == 0 ||
+                         info.dli_sname.is_null() {
             None
         } else {
             CStr::from_ptr(info.dli_sname).to_str().ok()


### PR DESCRIPTION
Apparently `dladdr` can succeed but still give you NULL pointers!

Closes #44379