### PR TITLE
Fix mispositioned error indicators

### DIFF
--- a/src/librustc_errors/styled_buffer.rs
+++ b/src/librustc_errors/styled_buffer.rs
@@ -26,14 +26,11 @@ impl StyledBuffer {
         }
     }
 
-    pub fn copy_tabs(&mut self, row: usize) {
-        if row < self.text.len() {
-            for i in row + 1..self.text.len() {
-                for j in 0..self.text[i].len() {
-                    if self.text[row].len() > j && self.text[row][j] == '\t' &&
-                       self.text[i][j] == ' ' {
-                        self.text[i][j] = '\t';
-                    }
+    fn replace_tabs(&mut self) {
+        for line in self.text.iter_mut() {
+            for c in line.iter_mut() {
+                if *c == '\t' {
+                    *c = ' ';
                 }
             }
         }
@@ -43,8 +40,8 @@ impl StyledBuffer {
         let mut output: Vec<Vec<StyledString>> = vec![];
         let mut styled_vec: Vec<StyledString> = vec![];
 
-        // before we render, do a little patch-up work to support tabs
-        self.copy_tabs(3);
+        // before we render, replace tabs with spaces
+        self.replace_tabs();
 
         for (row, row_style) in self.text.iter().zip(&self.styles) {
             let mut current_style = Style::NoStyle;

--- a/src/test/ui/codemap_tests/tab.stderr
+++ b/src/test/ui/codemap_tests/tab.stderr
@@ -1,8 +1,19 @@
 error[E0425]: cannot find value `bar` in this scope
   --> $DIR/tab.rs:14:2
    |
-14 | \tbar;
-   | \t^^^ not found in this scope
+14 |  bar;
+   |  ^^^ not found in this scope
 
-error: aborting due to previous error
+error[E0308]: mismatched types
+  --> $DIR/tab.rs:18:2
+   |
+17 | fn foo() {
+   |          - help: try adding a return type: `-> &'static str `
+18 |  "bar   boo"
+   |  ^^^^^^^^^^^ expected (), found reference
+   |
+   = note: expected type `()`
+              found type `&'static str`
+
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/codemap_tests/tab_2.rs
+++ b/src/test/ui/codemap_tests/tab_2.rs
@@ -11,9 +11,5 @@
 // ignore-tidy-tab
 
 fn main() {
-	bar;
-}
-
-fn foo() {
-	"bar			boo"
+				""";
 }

--- a/src/test/ui/codemap_tests/tab_2.stderr
+++ b/src/test/ui/codemap_tests/tab_2.stderr
@@ -1,0 +1,10 @@
+error: unterminated double quote string
+  --> $DIR/tab_2.rs:14:7
+   |
+14 |       """;
+   |  _______^
+15 | | }
+   | |__^
+
+error: aborting due to previous error
+

--- a/src/test/ui/codemap_tests/tab_3.rs
+++ b/src/test/ui/codemap_tests/tab_3.rs
@@ -11,9 +11,9 @@
 // ignore-tidy-tab
 
 fn main() {
-	bar;
-}
-
-fn foo() {
-	"bar			boo"
+	let some_vec = vec!["hi"];
+	some_vec.into_iter();
+	{
+		println!("{:?}", some_vec);
+	}
 }

--- a/src/test/ui/codemap_tests/tab_3.stderr
+++ b/src/test/ui/codemap_tests/tab_3.stderr
@@ -1,0 +1,13 @@
+error[E0382]: use of moved value: `some_vec`
+  --> $DIR/tab_3.rs:17:20
+   |
+15 |  some_vec.into_iter();
+   |  -------- value moved here
+16 |  {
+17 |   println!("{:?}", some_vec);
+   |                    ^^^^^^^^ value used here after move
+   |
+   = note: move occurs because `some_vec` has type `std::vec::Vec<&str>`, which does not implement the `Copy` trait
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #38384

Most of the Rust community uses 4 spaces for indentation,
but there are also tab users of Rust (including myself!).

This patch fixes a bug in error printing which mispositions
error indicators when near code with tabs.

The code attempted to fix the issue by replacing spaces
with tabs, but it sadly wasn't enough, as sometimes
you may not print spaces but _ or ^ instead.

This patch employs the reverse strategy: it replaces each
tab with a space, so that the number of _ and ^ and spaces
in error indicators below the code snippet line up
perfectly.

In a study [1] preceeding this patch, we could see that
this strategy is also chosen by gcc version 6.3.0.

Its not perfect, as the output is not beautiful, but its
the easiest to implement. If anyone wants to improve on
this, be my guest! This patch is meant as improvement of
the status quo, not as perfect end status. It fixes the
actual issue of mispositioning error indicators.

[1]: https://github.com/rust-lang/rust/issues/38384#issuecomment-326813710