### PR TITLE
Ipv4Addr and Ipv6Addr convenience constructors.

### DIFF
--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -351,6 +351,7 @@ impl Ipv4Addr {
     ///
     /// let addr = Ipv4Addr::localhost();
     /// assert_eq!(addr, Ipv4Addr::new(127, 0, 0, 1));
+    /// ```
     pub fn localhost() -> Ipv4Addr {
         Ipv4Addr::new(127, 0, 0, 1)
     }
@@ -364,6 +365,7 @@ impl Ipv4Addr {
     ///
     /// let addr = Ipv4Addr::unspecified();
     /// assert_eq!(addr, Ipv4Addr::new(0, 0, 0, 0));
+    /// ```
     pub fn unspecified() -> Ipv4Addr {
         Ipv4Addr::new(0, 0, 0, 0)
     }
@@ -823,6 +825,7 @@ impl Ipv6Addr {
     ///
     /// let addr = Ipv6Addr::localhost();
     /// assert_eq!(addr, Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
+    /// ```
     pub fn localhost() -> Ipv6Addr {
         Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)
     }
@@ -836,6 +839,7 @@ impl Ipv6Addr {
     ///
     /// let addr = Ipv6Addr::unspecified();
     /// assert_eq!(addr, Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0));
+    /// ```
     pub fn unspecified() -> Ipv6Addr {
         Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)
     }
@@ -1748,7 +1752,7 @@ mod tests {
         assert_eq!(Ipv6Addr::unspecified(), Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0));
         assert!(Ipv6Addr::unspecified().is_unspecified());
     }
-        
+
     #[test]
     fn ipv4_from_octets() {
         assert_eq!(Ipv4Addr::from([127, 0, 0, 1]), Ipv4Addr::new(127, 0, 0, 1))

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -342,6 +342,32 @@ impl Ipv4Addr {
         }
     }
 
+    /// Creates a new IPv4 address with the address pointing to localhost: 127.0.0.1.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::net::Ipv4Addr;
+    ///
+    /// let addr = Ipv4Addr::localhost();
+    /// assert_eq!(addr, Ipv4Addr::new(127, 0, 0, 1));
+    pub fn localhost() -> Ipv4Addr {
+        Ipv4Addr::new(127, 0, 0, 1)
+    }
+
+    /// Creates a new IPv4 address representing an unspecified address: 0.0.0.0
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::net::Ipv4Addr;
+    ///
+    /// let addr = Ipv4Addr::unspecified();
+    /// assert_eq!(addr, Ipv4Addr::new(0, 0, 0, 0));
+    pub fn unspecified() -> Ipv4Addr {
+        Ipv4Addr::new(0, 0, 0, 0)
+    }
+
     /// Returns the four eight-bit integers that make up this address.
     ///
     /// # Examples
@@ -786,6 +812,32 @@ impl Ipv6Addr {
                         (g >> 8) as u8, g as u8,
                         (h >> 8) as u8, h as u8];
         Ipv6Addr { inner: addr }
+    }
+
+    /// Creates a new IPv6 address representing localhost: `::1`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::net::Ipv6Addr;
+    ///
+    /// let addr = Ipv6Addr::localhost();
+    /// assert_eq!(addr, Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
+    pub fn localhost() -> Ipv6Addr {
+        Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)
+    }
+
+    /// Creates a new IPv6 address representing the unspecified address: `::`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::net::Ipv6Addr;
+    ///
+    /// let addr = Ipv6Addr::unspecified();
+    /// assert_eq!(addr, Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0));
+    pub fn unspecified() -> Ipv6Addr {
+        Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)
     }
 
     /// Returns the eight 16-bit segments that make up this address.
@@ -1681,6 +1733,22 @@ mod tests {
         assert_eq!(Ipv6Addr::from(0x112233445566778899aabbccddeeff11u128), a);
     }
 
+    #[test]
+    fn ipv4_from_constructors() {
+        assert_eq!(Ipv4Addr::localhost(), Ipv4Addr::new(127, 0, 0, 1));
+        assert!(Ipv4Addr::localhost().is_loopback());
+        assert_eq!(Ipv4Addr::unspecified(), Ipv4Addr::new(0, 0, 0, 0));
+        assert!(Ipv4Addr::unspecified().is_unspecified());
+    }
+
+    #[test]
+    fn ipv6_from_contructors() {
+        assert_eq!(Ipv6Addr::localhost(), Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
+        assert!(Ipv6Addr::localhost().is_loopback());
+        assert_eq!(Ipv6Addr::unspecified(), Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0));
+        assert!(Ipv6Addr::unspecified().is_unspecified());
+    }
+        
     #[test]
     fn ipv4_from_octets() {
         assert_eq!(Ipv4Addr::from([127, 0, 0, 1]), Ipv4Addr::new(127, 0, 0, 1))

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -347,6 +347,7 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
+    /// #![feature(ip)]
     /// use std::net::Ipv4Addr;
     ///
     /// let addr = Ipv4Addr::localhost();
@@ -361,6 +362,7 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
+    /// #![feature(ip)]
     /// use std::net::Ipv4Addr;
     ///
     /// let addr = Ipv4Addr::unspecified();
@@ -821,6 +823,7 @@ impl Ipv6Addr {
     /// # Examples
     ///
     /// ```
+    /// #![feature(ip)]
     /// use std::net::Ipv6Addr;
     ///
     /// let addr = Ipv6Addr::localhost();
@@ -835,6 +838,7 @@ impl Ipv6Addr {
     /// # Examples
     ///
     /// ```
+    /// #![feature(ip)]
     /// use std::net::Ipv6Addr;
     ///
     /// let addr = Ipv6Addr::unspecified();

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -10,7 +10,7 @@
 
 #![unstable(feature = "ip", reason = "extra functionality has not been \
                                       scrutinized to the level that it should \
-                                      be stable",
+                                      be to be stable",
             issue = "27709")]
 
 use cmp::Ordering;
@@ -347,12 +347,15 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// #![feature(ip)]
+    /// #![feature(ip_constructors)]
     /// use std::net::Ipv4Addr;
     ///
     /// let addr = Ipv4Addr::localhost();
     /// assert_eq!(addr, Ipv4Addr::new(127, 0, 0, 1));
     /// ```
+    #[unstable(feature = "ip_constructors",
+               reason = "requires greater scrutiny before stabilization",
+               issue = "44582")]
     pub fn localhost() -> Ipv4Addr {
         Ipv4Addr::new(127, 0, 0, 1)
     }
@@ -362,12 +365,15 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// #![feature(ip)]
+    /// #![feature(ip_constructors)]
     /// use std::net::Ipv4Addr;
     ///
     /// let addr = Ipv4Addr::unspecified();
     /// assert_eq!(addr, Ipv4Addr::new(0, 0, 0, 0));
     /// ```
+    #[unstable(feature = "ip_constructors",
+               reason = "requires greater scrutiny before stabilization",
+               issue = "44582")]
     pub fn unspecified() -> Ipv4Addr {
         Ipv4Addr::new(0, 0, 0, 0)
     }
@@ -823,12 +829,15 @@ impl Ipv6Addr {
     /// # Examples
     ///
     /// ```
-    /// #![feature(ip)]
+    /// #![feature(ip_constructors)]
     /// use std::net::Ipv6Addr;
     ///
     /// let addr = Ipv6Addr::localhost();
     /// assert_eq!(addr, Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
     /// ```
+    #[unstable(feature = "ip_constructors",
+               reason = "requires greater scrutiny before stabilization",
+               issue = "44582")]
     pub fn localhost() -> Ipv6Addr {
         Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)
     }
@@ -838,12 +847,15 @@ impl Ipv6Addr {
     /// # Examples
     ///
     /// ```
-    /// #![feature(ip)]
+    /// #![feature(ip_constructors)]
     /// use std::net::Ipv6Addr;
     ///
     /// let addr = Ipv6Addr::unspecified();
     /// assert_eq!(addr, Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0));
     /// ```
+    #[unstable(feature = "ip_constructors",
+               reason = "requires greater scrutiny before stabilization",
+               issue = "44582")]
     pub fn unspecified() -> Ipv6Addr {
         Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)
     }


### PR DESCRIPTION
Introduce convenience constructors for common types.

This introduces the following constructors:

* Ipv6Addr::localhost()
* Ipv6Addr::unspecified()
* Ipv4Addr::localhost()
* Ipv4Addr::unspecified()

The recently added `From` implementations were nice for avoiding the fallibility of conversions from strings like `"127.0.0.1".parse().unwrap()`, and `"::1".parse().unwrap()`, but while the Ipv4 version is roughly comparable in verbosity, the Ipv6 version lacks zero-segment elision, which makes it significantly more awkward: `[0, 0, 0, 0, 0, 0, 0, 0].into()`.  While there isn't a clear way to introduce zero elision to type that can infallibly be converted into Ipv6 addresses, this PR resolves the problem for the two most commonly used addresses, which, incidentally, are the ones that suffer the most from the lack of zero-segment elision. 

This change is dead simple, and introduces no backwards incompatibility.

See also, [this topic on the inernals board](https://internals.rust-lang.org/t/pre-rfc-convenience-ip-address-constructors/5878)