### PR TITLE
std::thread::LocalKey: Document limitation with initializers

### DIFF
--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -31,6 +31,10 @@ use mem;
 /// within a thread, and values that implement [`Drop`] get destructed when a
 /// thread exits. Some caveats apply, which are explained below.
 ///
+/// A `LocalKey`'s initializer cannot recursively depend on itself, and using
+/// a `LocalKey` in this way will cause the initializer to infinitely recurse
+/// on the first call to `with`.
+///
 /// # Examples
 ///
 /// ```


### PR DESCRIPTION
Document that if a `LocalKey`'s initializer recursively depends on itself, initialization will result in infinite recursion.