### PR TITLE
Codeblock color

### DIFF
--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -22,7 +22,6 @@
 
 use html::escape::Escape;
 
-use std::collections::HashMap;
 use std::fmt::Display;
 use std::io;
 use std::io::prelude::*;
@@ -36,7 +35,7 @@ use syntax_pos::Span;
 /// Highlights `src`, returning the HTML output.
 pub fn render_with_highlighting(src: &str, class: Option<&str>, id: Option<&str>,
                                 extension: Option<&str>,
-                                extras: Option<HashMap<String, String>>) -> String {
+                                tooltip: Option<(&str, &str)>) -> String {
     debug!("highlighting: ================\n{}\n==============", src);
     let sess = parse::ParseSess::new(FilePathMapping::empty());
     let fm = sess.codemap().new_filemap("<stdin>".to_string(), src.to_string());
@@ -396,17 +395,11 @@ impl Class {
 
 fn write_header(class: Option<&str>,
                 id: Option<&str>,
-                out: &mut Write,
-                extras: Option<HashMap<String, String>>)
+                out: &mut Write)
                 -> io::Result<()> {
     write!(out, "<pre ")?;
     if let Some(id) = id {
         write!(out, "id='{}' ", id)?;
-    }
-    if let Some(extras) = extras {
-        for (key, value) in &extras {
-            write!(out, "{}=\"{}\" ", key, value)?;
-        }
     }
     write!(out, "class=\"rust {}\">\n", class.unwrap_or(""))
 }

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -225,16 +225,10 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for CodeBlocks<'a, I> {
                     url, test_escaped, channel
                 ))
             });
-            let title = if ignore {
-                let mut tmp = HashMap::new();
-                tmp.insert("title".to_owned(),
-                           "Be careful when using this code, it's not being tested!".to_owned());
-                Some(tmp)
+            let tooltip = if ignore {
+                Some(("Be careful when using this code, it's not being tested!", "ignore"))
             } else if compile_fail {
-                let mut tmp = HashMap::new();
-                tmp.insert("title".to_owned(),
-                           "This code doesn't compile so be extra careful!".to_owned());
-                Some(tmp)
+                Some(("This code doesn't compile so be extra careful!", "compile_fail"))
             } else {
                 None
             };
@@ -246,7 +240,7 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for CodeBlocks<'a, I> {
                                       else { "" })),
                         None,
                         playground_button.as_ref().map(String::as_str),
-                        title));
+                        tooltip));
             Some(Event::Html(s.into()))
         })
     }
@@ -642,18 +636,10 @@ pub fn render(w: &mut fmt::Formatter,
                         url, test_escaped, channel
                     ))
                 });
-                let title = if ignore {
-                    let mut tmp = HashMap::new();
-                    tmp.insert("title".to_owned(),
-                               "Be careful when using this code, it's not being \
-                                tested!".to_owned());
-                    Some(tmp)
+                let tooltip = if ignore {
+                    Some(("Be careful when using this code, it's not being tested!", "ignore"))
                 } else if compile_fail {
-                    let mut tmp = HashMap::new();
-                    tmp.insert("title".to_owned(),
-                               "This code doesn't compile so be extra \
-                                careful!".to_owned());
-                    Some(tmp)
+                    Some(("This code doesn't compile so be extra careful!", "compile_fail"))
                 } else {
                     None
                 };
@@ -665,7 +651,7 @@ pub fn render(w: &mut fmt::Formatter,
                                              else { "" })),
                                None,
                                playground_button.as_ref().map(String::as_str),
-                               title));
+                               tooltip));
                 hoedown_buffer_put(ob, s.as_ptr(), s.len());
             })
         }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -3679,7 +3679,8 @@ impl<'a> fmt::Display for Source<'a> {
             write!(fmt, "<span id=\"{0}\">{0:1$}</span>\n", i, cols)?;
         }
         write!(fmt, "</pre>")?;
-        write!(fmt, "{}", highlight::render_with_highlighting(s, None, None, None, None))?;
+        write!(fmt, "{}",
+               highlight::render_with_highlighting(s, None, None, None, None))?;
         Ok(())
     }
 }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1839,6 +1839,7 @@ fn render_assoc_const_value(item: &clean::Item) -> String {
                 None,
                 None,
                 None,
+                None,
             )
         }
         _ => String::new(),
@@ -3678,7 +3679,7 @@ impl<'a> fmt::Display for Source<'a> {
             write!(fmt, "<span id=\"{0}\">{0:1$}</span>\n", i, cols)?;
         }
         write!(fmt, "</pre>")?;
-        write!(fmt, "{}", highlight::render_with_highlighting(s, None, None, None))?;
+        write!(fmt, "{}", highlight::render_with_highlighting(s, None, None, None, None))?;
         Ok(())
     }
 }
@@ -3687,6 +3688,7 @@ fn item_macro(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
               t: &clean::Macro) -> fmt::Result {
     w.write_str(&highlight::render_with_highlighting(&t.source,
                                                      Some("macro"),
+                                                     None,
                                                      None,
                                                      None))?;
     document(w, cx, it)

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1296,6 +1296,24 @@
             collapseDocs(i_e.previousSibling.childNodes[0]);
         });
     });
+
+    onEach(document.getElementsByClassName('rust-example-rendered'), function(e) {
+        if (hasClass(e, 'compile_fail')) {
+            e.addEventListener("mouseover", function(event) {
+                e.previousElementSibling.childNodes[0].style.color = '#f00';
+            });
+            e.addEventListener("mouseout", function(event) {
+                e.previousElementSibling.childNodes[0].style.color = '';
+            });
+        } else if (hasClass(e, 'ignore')) {
+            e.addEventListener("mouseover", function(event) {
+                e.previousElementSibling.childNodes[0].style.color = '#ff9200';
+            });
+            e.addEventListener("mouseout", function(event) {
+                e.previousElementSibling.childNodes[0].style.color = '';
+            });
+        }
+    });
 }());
 
 // Sets the focus on the search bar at the top of the page

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -612,7 +612,6 @@ pre.rust .question-mark {
 	font-weight: bold;
 }
 
-pre.rust { position: relative; }
 a.test-arrow {
 	display: inline-block;
 	position: absolute;
@@ -812,4 +811,45 @@ span.since {
 	nav.sub, .content .out-of-band, .collapse-toggle {
 		display: none;
 	}
+}
+
+.information {
+	position: absolute;
+	left: -1px;
+	margin-top: 7px;
+}
+
+.tooltip {
+	position: relative;
+	display: inline-block;
+	cursor: pointer;
+}
+
+.tooltip .tooltiptext {
+	width: 120px;
+	display: none;
+	background-color: black;
+	color: #fff;
+	text-align: center;
+	padding: 5px 3px;
+	border-radius: 6px;
+	margin-left: 5px;
+	top: -5px;
+	left: 105%;
+	z-index: 1;
+}
+
+.tooltip:hover .tooltiptext {
+	display: inline;
+}
+
+.tooltip .tooltiptext::after {
+	content: " ";
+	position: absolute;
+	top: 50%;
+	left: 11px;
+	margin-top: -5px;
+	border-width: 5px;
+	border-style: solid;
+	border-color: transparent black transparent transparent;
 }

--- a/src/librustdoc/html/static/styles/main.css
+++ b/src/librustdoc/html/static/styles/main.css
@@ -205,9 +205,33 @@ a.test-arrow:hover{
 }
 
 pre.compile_fail {
-	box-shadow: -6px 0 5px -3px #f00;
+	border-left: 2px solid rgba(255,0,0,.4);
+}
+
+pre.compile_fail:hover, .information:hover + pre.compile_fail {
+	border-left: 2px solid #f00;
 }
 
 pre.ignore {
-	box-shadow: -6px 0 5px -3px #ff9200;
+	border-left: 2px solid rgba(255,142,0,.4);
+}
+
+pre.ignore:hover, .information:hover + pre.ignore {
+	border-left: 2px solid #ff9200;
+}
+
+.tooltip.compile_fail {
+	color: rgba(255,0,0,.3);
+}
+
+.information > .compile_fail:hover {
+	color: #f00;
+}
+
+.tooltip.ignore {
+	color: rgba(255,142,0,.3);
+}
+
+.information > .ignore:hover {
+	color: rgba(255,142,0,1);
 }

--- a/src/librustdoc/html/static/styles/main.css
+++ b/src/librustdoc/html/static/styles/main.css
@@ -203,3 +203,11 @@ a.test-arrow:hover{
 :target > code {
 	background: #FDFFD3;
 }
+
+pre.compile_fail {
+	box-shadow: -6px 0 5px -3px #f00;
+}
+
+pre.ignore {
+	box-shadow: -6px 0 5px -3px #ff9200;
+}

--- a/src/test/rustdoc/codeblock-title.rs
+++ b/src/test/rustdoc/codeblock-title.rs
@@ -1,0 +1,31 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "foo"]
+
+// ignore-tidy-linelength
+
+// @has foo/fn.bar.html '//*[@class="tooltip compile_fail"]/span' "This code doesn't compile so be extra careful!"
+// @has foo/fn.bar.html '//*[@class="tooltip ignore"]/span' "Be careful when using this code, it's not being tested!"
+
+/// foo
+///
+/// ```compile_fail
+/// foo();
+/// ```
+///
+/// ```ignore (tidy)
+/// goo();
+/// ```
+///
+/// ```
+/// let x = 0;
+/// ```
+pub fn bar() -> usize { 2 }


### PR DESCRIPTION
<img width="1440" alt="screen shot 2017-09-07 at 21 53 58" src="https://user-images.githubusercontent.com/3050060/30183045-4319108e-9419-11e7-98da-da54952cab37.png">

This screenshot has been generated from:

```rust
/// foo
///
/// ```compile_fail
/// foo();
/// ```
///
/// ```ignore
/// goo();
/// ```
///
/// ```
/// let x = 0;
/// ```
pub fn bar() -> usize { 2 }
```


r? @QuietMisdreavus 
cc @rust-lang/docs 