### PR TITLE
travis: Downgrade to previous images temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: shell
 sudo: required
 dist: trusty
+# FIXME(#44398) shouldn't need to be here
+group: deprecated-2017Q3
 services:
   - docker
 


### PR DESCRIPTION
Travis is in the process of [rolling out an update][update] but looks like our
tests are breaking, let's temporarily roll back to get the queue moving again.

[update]: https://blog.travis-ci.com/2017-08-29-trusty-image-updates