### PR TITLE
Fix sanitizer tests on buggy kernels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: shell
 sudo: required
 dist: trusty
-# FIXME(#44398) shouldn't need to be here
-group: deprecated-2017Q3
 services:
   - docker
 

--- a/src/test/run-make/sanitizer-address/Makefile
+++ b/src/test/run-make/sanitizer-address/Makefile
@@ -1,5 +1,7 @@
 -include ../tools.mk
 
+LOG := $(TMPDIR)/log.txt
+
 # NOTE the address sanitizer only supports x86_64 linux and macOS
 
 ifeq ($(TARGET),x86_64-apple-darwin)
@@ -8,12 +10,21 @@ EXTRA_RUSTFLAG=-C rpath
 else
 ifeq ($(TARGET),x86_64-unknown-linux-gnu)
 ASAN_SUPPORT=$(SANITIZER_SUPPORT)
-EXTRA_RUSTFLAG=
+
+# Apparently there are very specific Linux kernels, notably the one that's
+# currently on Travis CI, which contain a buggy commit that triggers failures in
+# the ASan implementation, detailed at google/sanitizers#837. As noted in
+# google/sanitizers#856 the "fix" is to avoid using PIE binaries, so we pass a
+# different relocation model to avoid generating a PIE binary. Once Travis is no
+# longer running kernel 4.4.0-93 we can remove this and pass an empty set of
+# flags again.
+EXTRA_RUSTFLAG=-C relocation-model=dynamic-no-pic
 endif
 endif
 
 all:
 ifeq ($(ASAN_SUPPORT),1)
 	$(RUSTC) -g -Z sanitizer=address -Z print-link-args $(EXTRA_RUSTFLAG) overflow.rs | grep -q librustc_asan
-	$(TMPDIR)/overflow 2>&1 | grep -q stack-buffer-overflow
+	$(TMPDIR)/overflow 2>&1 | tee $(LOG)
+	grep -q stack-buffer-overflow $(LOG)
 endif

--- a/src/test/run-make/sanitizer-cdylib-link/Makefile
+++ b/src/test/run-make/sanitizer-cdylib-link/Makefile
@@ -1,5 +1,7 @@
 -include ../tools.mk
 
+LOG := $(TMPDIR)/log.txt
+
 # This test builds a shared object, then an executable that links it as a native
 # rust library (constrast to an rlib). The shared library and executable both
 # are compiled with address sanitizer, and we assert that a fault in the cdylib
@@ -7,13 +9,15 @@
 
 ifeq ($(TARGET),x86_64-unknown-linux-gnu)
 ASAN_SUPPORT=$(SANITIZER_SUPPORT)
-EXTRA_RUSTFLAG=
+
+# See comment in sanitizer-address/Makefile for why this is here
+EXTRA_RUSTFLAG=-C relocation-model=dynamic-no-pic
 endif
 
 all:
 ifeq ($(ASAN_SUPPORT),1)
-	$(RUSTC) -g -Z sanitizer=address --crate-type cdylib --target $(TARGET) library.rs
-	$(RUSTC) -g -Z sanitizer=address --crate-type bin --target $(TARGET) -llibrary program.rs
-	LD_LIBRARY_PATH=$(TMPDIR) $(TMPDIR)/program 2>&1 | grep -q stack-buffer-overflow
+	$(RUSTC) -g -Z sanitizer=address --crate-type cdylib --target $(TARGET) $(EXTRA_RUSTFLAG) library.rs
+	$(RUSTC) -g -Z sanitizer=address --crate-type bin --target $(TARGET) $(EXTRA_RUSTFLAG) -llibrary program.rs
+	LD_LIBRARY_PATH=$(TMPDIR) $(TMPDIR)/program 2>&1 | tee $(LOG)
+	grep -q stack-buffer-overflow $(LOG)
 endif
-

--- a/src/test/run-make/sanitizer-dylib-link/Makefile
+++ b/src/test/run-make/sanitizer-dylib-link/Makefile
@@ -1,5 +1,7 @@
 -include ../tools.mk
 
+LOG := $(TMPDIR)/log.txt
+
 # This test builds a shared object, then an executable that links it as a native
 # rust library (constrast to an rlib). The shared library and executable both
 # are compiled with address sanitizer, and we assert that a fault in the dylib
@@ -7,13 +9,15 @@
 
 ifeq ($(TARGET),x86_64-unknown-linux-gnu)
 ASAN_SUPPORT=$(SANITIZER_SUPPORT)
-EXTRA_RUSTFLAG=
+
+# See comment in sanitizer-address/Makefile for why this is here
+EXTRA_RUSTFLAG=-C relocation-model=dynamic-no-pic
 endif
 
 all:
 ifeq ($(ASAN_SUPPORT),1)
-	$(RUSTC) -g -Z sanitizer=address --crate-type dylib --target $(TARGET) library.rs
-	$(RUSTC) -g -Z sanitizer=address --crate-type bin --target $(TARGET) -llibrary program.rs
-	LD_LIBRARY_PATH=$(TMPDIR) $(TMPDIR)/program 2>&1 | grep -q stack-buffer-overflow
+	$(RUSTC) -g -Z sanitizer=address --crate-type dylib --target $(TARGET) $(EXTRA_RUSTFLAG) library.rs
+	$(RUSTC) -g -Z sanitizer=address --crate-type bin --target $(TARGET) $(EXTRA_RUSTFLAG) -llibrary program.rs
+	LD_LIBRARY_PATH=$(TMPDIR) $(TMPDIR)/program 2>&1 | tee $(LOG)
+	grep -q stack-buffer-overflow $(LOG)
 endif
-


### PR DESCRIPTION
Travis recently pushed an update to the Linux environments, namely the kernels
that we're running on. This in turn caused some of the sanitizer tests we run to
fail. We also apparently weren't the first to hit these failures! Detailed in
google/sanitizers#837 these tests were failing due to a specific commit in the
kernel which has since been backed out, but for now work around the buggy kernel
that's deployed on Travis and eventually we should be able to remove these
flags.