### PR TITLE
rustc: Make `CrateStore` private to `TyCtxt`

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1336,7 +1336,7 @@ dependencies = [
  "racer 2.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-analysis 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-data 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-rustc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-rustc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-vfs 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfmt-nightly 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "rls-rustc"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2544,7 +2544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum rls-analysis 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d2cb40c0371765897ae428b5706bb17135705ad4f6d1b8b6afbaabcf8c9b5cff"
 "checksum rls-data 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11d339f1888e33e74d8032de0f83c40b2bdaaaf04a8cfc03b32186c3481fb534"
-"checksum rls-rustc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5fa757c9d547d460427ceff01875f9cac5f5acd8fc6543946e9b0335ba29d537"
+"checksum rls-rustc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b21ea952e9bf1569929abf1bb920262cde04b7b1b26d8e0260286302807299d2"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
 "checksum rls-vfs 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd34691a510938bb67fe0444fb363103c73ffb31c121d1e16bc92d8945ea8ff"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -45,6 +45,7 @@ use hir::map::{Definitions, DefKey};
 use hir::def_id::{DefIndex, DefId, CRATE_DEF_INDEX};
 use hir::def::{Def, PathResolution};
 use lint::builtin::PARENTHESIZED_PARAMS_IN_TYPES_AND_MODULES;
+use middle::cstore::CrateStore;
 use rustc_data_structures::indexed_vec::IndexVec;
 use session::Session;
 use util::common::FN_OUTPUT_NAME;
@@ -73,6 +74,8 @@ pub struct LoweringContext<'a> {
 
     // Use to assign ids to hir nodes that do not directly correspond to an ast node
     sess: &'a Session,
+
+    cstore: &'a CrateStore,
 
     // As we walk the AST we must keep track of the current 'parent' def id (in
     // the form of a DefIndex) so that if we create a new node which introduces
@@ -118,6 +121,7 @@ pub trait Resolver {
 }
 
 pub fn lower_crate(sess: &Session,
+                   cstore: &CrateStore,
                    krate: &Crate,
                    resolver: &mut Resolver)
                    -> hir::Crate {
@@ -129,6 +133,7 @@ pub fn lower_crate(sess: &Session,
     LoweringContext {
         crate_root: std_inject::injected_crate_name(krate),
         sess,
+        cstore,
         parent_def: None,
         resolver,
         name_map: FxHashMap(),
@@ -534,7 +539,7 @@ impl<'a> LoweringContext<'a> {
         if id.is_local() {
             self.resolver.definitions().def_key(id.index)
         } else {
-            self.sess.cstore.def_key(id)
+            self.cstore.def_key(id)
         }
     }
 
@@ -786,7 +791,7 @@ impl<'a> LoweringContext<'a> {
                         return n;
                     }
                     assert!(!def_id.is_local());
-                    let n = self.sess.cstore.item_generics_cloned_untracked(def_id).regions.len();
+                    let n = self.cstore.item_generics_cloned_untracked(def_id).regions.len();
                     self.type_def_lifetime_params.insert(def_id, n);
                     n
                 });

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1953,13 +1953,12 @@ mod tests {
     use errors;
     use getopts;
     use lint;
-    use middle::cstore::{self, DummyCrateStore};
+    use middle::cstore;
     use session::config::{build_configuration, build_session_options_and_crate_config};
     use session::build_session;
     use std::collections::{BTreeMap, BTreeSet};
     use std::iter::FromIterator;
     use std::path::PathBuf;
-    use std::rc::Rc;
     use super::{OutputType, OutputTypes, Externs};
     use rustc_back::{PanicStrategy, RelroLevel};
     use syntax::symbol::Symbol;
@@ -1991,7 +1990,7 @@ mod tests {
             };
         let registry = errors::registry::Registry::new(&[]);
         let (sessopts, cfg) = build_session_options_and_crate_config(matches);
-        let sess = build_session(sessopts, &dep_graph, None, registry, Rc::new(DummyCrateStore));
+        let sess = build_session(sessopts, &dep_graph, None, registry);
         let cfg = build_configuration(&sess, cfg);
         assert!(cfg.contains(&(Symbol::intern("test"), None)));
     }
@@ -2010,8 +2009,7 @@ mod tests {
             };
         let registry = errors::registry::Registry::new(&[]);
         let (sessopts, cfg) = build_session_options_and_crate_config(matches);
-        let sess = build_session(sessopts, &dep_graph, None, registry,
-                                 Rc::new(DummyCrateStore));
+        let sess = build_session(sessopts, &dep_graph, None, registry);
         let cfg = build_configuration(&sess, cfg);
         let mut test_items = cfg.iter().filter(|&&(name, _)| name == "test");
         assert!(test_items.next().is_some());
@@ -2027,8 +2025,7 @@ mod tests {
             ]).unwrap();
             let registry = errors::registry::Registry::new(&[]);
             let (sessopts, _) = build_session_options_and_crate_config(&matches);
-            let sess = build_session(sessopts, &dep_graph, None, registry,
-                                     Rc::new(DummyCrateStore));
+            let sess = build_session(sessopts, &dep_graph, None, registry);
             assert!(!sess.diagnostic().can_emit_warnings);
         }
 
@@ -2039,8 +2036,7 @@ mod tests {
             ]).unwrap();
             let registry = errors::registry::Registry::new(&[]);
             let (sessopts, _) = build_session_options_and_crate_config(&matches);
-            let sess = build_session(sessopts, &dep_graph, None, registry,
-                                     Rc::new(DummyCrateStore));
+            let sess = build_session(sessopts, &dep_graph, None, registry);
             assert!(sess.diagnostic().can_emit_warnings);
         }
 
@@ -2050,8 +2046,7 @@ mod tests {
             ]).unwrap();
             let registry = errors::registry::Registry::new(&[]);
             let (sessopts, _) = build_session_options_and_crate_config(&matches);
-            let sess = build_session(sessopts, &dep_graph, None, registry,
-                                     Rc::new(DummyCrateStore));
+            let sess = build_session(sessopts, &dep_graph, None, registry);
             assert!(sess.diagnostic().can_emit_warnings);
         }
     }

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -15,7 +15,6 @@ use dep_graph::DepGraph;
 use hir::def_id::{CrateNum, DefIndex};
 
 use lint;
-use middle::cstore::CrateStore;
 use middle::allocator::AllocatorKind;
 use middle::dependency_format;
 use session::search_paths::PathKind;
@@ -63,7 +62,6 @@ pub struct Session {
     pub target: config::Config,
     pub host: Target,
     pub opts: config::Options,
-    pub cstore: Rc<CrateStore>,
     pub parse_sess: ParseSess,
     // For a library crate, this is always none
     pub entry_fn: RefCell<Option<(NodeId, Span)>>,
@@ -621,8 +619,7 @@ impl Session {
 pub fn build_session(sopts: config::Options,
                      dep_graph: &DepGraph,
                      local_crate_source_file: Option<PathBuf>,
-                     registry: errors::registry::Registry,
-                     cstore: Rc<CrateStore>)
+                     registry: errors::registry::Registry)
                      -> Session {
     let file_path_mapping = sopts.file_path_mapping();
 
@@ -630,7 +627,6 @@ pub fn build_session(sopts: config::Options,
                                dep_graph,
                                local_crate_source_file,
                                registry,
-                               cstore,
                                Rc::new(codemap::CodeMap::new(file_path_mapping)),
                                None)
 }
@@ -639,7 +635,6 @@ pub fn build_session_with_codemap(sopts: config::Options,
                                   dep_graph: &DepGraph,
                                   local_crate_source_file: Option<PathBuf>,
                                   registry: errors::registry::Registry,
-                                  cstore: Rc<CrateStore>,
                                   codemap: Rc<codemap::CodeMap>,
                                   emitter_dest: Option<Box<Write + Send>>)
                                   -> Session {
@@ -680,16 +675,14 @@ pub fn build_session_with_codemap(sopts: config::Options,
                    dep_graph,
                    local_crate_source_file,
                    diagnostic_handler,
-                   codemap,
-                   cstore)
+                   codemap)
 }
 
 pub fn build_session_(sopts: config::Options,
                       dep_graph: &DepGraph,
                       local_crate_source_file: Option<PathBuf>,
                       span_diagnostic: errors::Handler,
-                      codemap: Rc<codemap::CodeMap>,
-                      cstore: Rc<CrateStore>)
+                      codemap: Rc<codemap::CodeMap>)
                       -> Session {
     let host = match Target::search(config::host_triple()) {
         Ok(t) => t,
@@ -726,7 +719,6 @@ pub fn build_session_(sopts: config::Options,
         target: target_cfg,
         host,
         opts: sopts,
-        cstore,
         parse_sess: p_s,
         // For a library crate, this is always none
         entry_fn: RefCell::new(None),

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -21,7 +21,11 @@ use hir::map as hir_map;
 use hir::map::DefPathHash;
 use lint::{self, Lint};
 use ich::{self, StableHashingContext, NodeIdHashingMode};
+<<<<<<< 817e1b81e230d599585f860cdcad96c5ed83b93e
 use middle::const_val::ConstVal;
+=======
+use middle::cstore::CrateStore;
+>>>>>>> Remove the `cstore` reference from Session in order to prepare encapsulating CrateStore access in tcx.
 use middle::free_region::FreeRegionMap;
 use middle::lang_items;
 use middle::resolve_lifetime::{self, ObjectLifetimeDefault};
@@ -810,7 +814,10 @@ pub struct GlobalCtxt<'tcx> {
     global_arenas: &'tcx GlobalArenas<'tcx>,
     global_interners: CtxtInterners<'tcx>,
 
+    cstore: &'tcx CrateStore,
+
     pub sess: &'tcx Session,
+
 
     pub trans_trait_caches: traits::trans::TransTraitCaches<'tcx>,
 
@@ -908,6 +915,10 @@ impl<'tcx> GlobalCtxt<'tcx> {
 }
 
 impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
+    pub fn cstore_untracked(&self) -> &CrateStore {
+        &*self.cstore
+    }
+
     pub fn alloc_generics(self, generics: ty::Generics) -> &'gcx ty::Generics {
         self.global_arenas.generics.alloc(generics)
     }
@@ -1009,6 +1020,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     /// value (types, substs, etc.) can only be used while `ty::tls` has a valid
     /// reference to the context, to allow formatting values that need it.
     pub fn create_and_enter<F, R>(s: &'tcx Session,
+                                  cstore: &'tcx CrateStore,
                                   local_providers: ty::maps::Providers<'tcx>,
                                   extern_providers: ty::maps::Providers<'tcx>,
                                   mir_passes: Rc<Passes>,
@@ -1025,16 +1037,15 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         let interners = CtxtInterners::new(arena);
         let common_types = CommonTypes::new(&interners);
         let dep_graph = hir.dep_graph.clone();
-        let max_cnum = s.cstore.crates_untracked().iter().map(|c| c.as_usize()).max().unwrap_or(0);
+        let max_cnum = cstore.crates_untracked().iter().map(|c| c.as_usize()).max().unwrap_or(0);
         let mut providers = IndexVec::from_elem_n(extern_providers, max_cnum + 1);
         providers[LOCAL_CRATE] = local_providers;
 
         let def_path_hash_to_def_id = if s.opts.build_dep_graph() {
-            let upstream_def_path_tables: Vec<(CrateNum, Rc<_>)> = s
-                .cstore
+            let upstream_def_path_tables: Vec<(CrateNum, Rc<_>)> = cstore
                 .crates_untracked()
                 .iter()
-                .map(|&cnum| (cnum, s.cstore.def_path_table(cnum)))
+                .map(|&cnum| (cnum, cstore.def_path_table(cnum)))
                 .collect();
 
             let def_path_tables = || {
@@ -1093,6 +1104,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 
         tls::enter_global(GlobalCtxt {
             sess: s,
+            cstore,
             trans_trait_caches: traits::trans::TransTraitCaches::new(dep_graph.clone()),
             global_arenas: arenas,
             global_interners: interners,

--- a/src/librustc/ty/item_path.rs
+++ b/src/librustc/ty/item_path.rs
@@ -151,7 +151,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                 }
             }
 
-            cur_path.push(self.cstore_untracked().def_key(cur_def)
+            cur_path.push(self.def_key(cur_def)
                               .disambiguated_data.data.get_opt_name().unwrap_or_else(||
                 Symbol::intern("<unnamed>").as_str()));
             match visible_parent_map.get(&cur_def) {

--- a/src/librustc/ty/item_path.rs
+++ b/src/librustc/ty/item_path.rs
@@ -151,7 +151,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                 }
             }
 
-            cur_path.push(self.sess.cstore.def_key(cur_def)
+            cur_path.push(self.cstore_untracked().def_key(cur_def)
                               .disambiguated_data.data.get_opt_name().unwrap_or_else(||
                 Symbol::intern("<unnamed>").as_str()));
             match visible_parent_map.get(&cur_def) {

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2170,43 +2170,13 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         }
     }
 
-    pub fn def_key(self, id: DefId) -> hir_map::DefKey {
-        if id.is_local() {
-            self.hir.def_key(id)
-        } else {
-            self.cstore_untracked().def_key(id)
-        }
-    }
-
-    /// Convert a `DefId` into its fully expanded `DefPath` (every
-    /// `DefId` is really just an interned def-path).
-    ///
-    /// Note that if `id` is not local to this crate, the result will
-    ///  be a non-local `DefPath`.
-    pub fn def_path(self, id: DefId) -> hir_map::DefPath {
-        if id.is_local() {
-            self.hir.def_path(id)
-        } else {
-            self.cstore_untracked().def_path(id)
-        }
-    }
-
-    #[inline]
-    pub fn def_path_hash(self, def_id: DefId) -> hir_map::DefPathHash {
-        if def_id.is_local() {
-            self.hir.definitions().def_path_hash(def_id.index)
-        } else {
-            self.cstore_untracked().def_path_hash(def_id)
-        }
-    }
-
     pub fn item_name(self, id: DefId) -> InternedString {
         if let Some(id) = self.hir.as_local_node_id(id) {
             self.hir.name(id).as_str()
         } else if id.index == CRATE_DEF_INDEX {
             self.original_crate_name(id.krate).as_str()
         } else {
-            let def_key = self.cstore_untracked().def_key(id);
+            let def_key = self.def_key(id);
             // The name of a StructCtor is that of its struct parent.
             if let hir_map::DefPathData::StructCtor = def_key.disambiguated_data.data {
                 self.item_name(DefId {

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2174,7 +2174,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         if id.is_local() {
             self.hir.def_key(id)
         } else {
-            self.sess.cstore.def_key(id)
+            self.cstore_untracked().def_key(id)
         }
     }
 
@@ -2187,7 +2187,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         if id.is_local() {
             self.hir.def_path(id)
         } else {
-            self.sess.cstore.def_path(id)
+            self.cstore_untracked().def_path(id)
         }
     }
 
@@ -2196,7 +2196,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         if def_id.is_local() {
             self.hir.definitions().def_path_hash(def_id.index)
         } else {
-            self.sess.cstore.def_path_hash(def_id)
+            self.cstore_untracked().def_path_hash(def_id)
         }
     }
 
@@ -2206,7 +2206,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         } else if id.index == CRATE_DEF_INDEX {
             self.original_crate_name(id.krate).as_str()
         } else {
-            let def_key = self.sess.cstore.def_key(id);
+            let def_key = self.cstore_untracked().def_key(id);
             // The name of a StructCtor is that of its struct parent.
             if let hir_map::DefPathData::StructCtor = def_key.disambiguated_data.data {
                 self.item_name(DefId {

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -274,7 +274,7 @@ pub fn compile_input(sess: &Session,
                                 phase5_result);
         phase5_result?;
 
-        phase_6_link_output(sess, cstore, &trans, &outputs);
+        phase_6_link_output(sess, &trans, &outputs);
 
         // Now that we won't touch anything in the incremental compilation directory
         // any more, we can finalize it (which involves renaming it)
@@ -1153,12 +1153,10 @@ pub fn phase_5_run_llvm_passes(sess: &Session,
 /// This should produce either a finished executable or library.
 #[cfg(feature="llvm")]
 pub fn phase_6_link_output(sess: &Session,
-                           cstore: &CrateStore,
                            trans: &trans::CrateTranslation,
                            outputs: &OutputFilenames) {
     time(sess.time_passes(), "linking", || {
         ::rustc_trans::back::link::link_binary(sess,
-                                               cstore,
                                                trans,
                                                outputs,
                                                &trans.crate_name.as_str())

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -21,6 +21,7 @@ use rustc::session::config::{self, Input, OutputFilenames, OutputType};
 use rustc::session::search_paths::PathKind;
 use rustc::lint;
 use rustc::middle::{self, stability, reachable};
+use rustc::middle::cstore::CrateStore;
 use rustc::middle::privacy::AccessLevels;
 use rustc::mir::transform::{MIR_CONST, MIR_VALIDATED, MIR_OPTIMIZED, Passes};
 use rustc::ty::{self, TyCtxt, Resolutions, GlobalArenas};
@@ -200,6 +201,7 @@ pub fn compile_input(sess: &Session,
         };
 
         phase_3_run_analysis_passes(sess,
+                                    cstore,
                                     hir_map,
                                     analysis,
                                     resolutions,
@@ -272,7 +274,7 @@ pub fn compile_input(sess: &Session,
                                 phase5_result);
         phase5_result?;
 
-        phase_6_link_output(sess, &trans, &outputs);
+        phase_6_link_output(sess, cstore, &trans, &outputs);
 
         // Now that we won't touch anything in the incremental compilation directory
         // any more, we can finalize it (which involves renaming it)
@@ -385,7 +387,7 @@ pub struct CompileState<'a, 'tcx: 'a> {
     pub session: &'tcx Session,
     pub krate: Option<ast::Crate>,
     pub registry: Option<Registry<'a>>,
-    pub cstore: Option<&'a CStore>,
+    pub cstore: Option<&'tcx CStore>,
     pub crate_name: Option<&'a str>,
     pub output_filenames: Option<&'a OutputFilenames>,
     pub out_dir: Option<&'a Path>,
@@ -433,7 +435,7 @@ impl<'a, 'tcx> CompileState<'a, 'tcx> {
                          out_dir: &'a Option<PathBuf>,
                          out_file: &'a Option<PathBuf>,
                          krate: ast::Crate,
-                         cstore: &'a CStore)
+                         cstore: &'tcx CStore)
                          -> Self {
         CompileState {
             // Initialize the registry before moving `krate`
@@ -449,7 +451,7 @@ impl<'a, 'tcx> CompileState<'a, 'tcx> {
                           session: &'tcx Session,
                           out_dir: &'a Option<PathBuf>,
                           out_file: &'a Option<PathBuf>,
-                          cstore: &'a CStore,
+                          cstore: &'tcx CStore,
                           expanded_crate: &'a ast::Crate,
                           crate_name: &'a str)
                           -> Self {
@@ -468,7 +470,7 @@ impl<'a, 'tcx> CompileState<'a, 'tcx> {
                                 out_file: &'a Option<PathBuf>,
                                 arena: &'tcx DroplessArena,
                                 arenas: &'tcx GlobalArenas<'tcx>,
-                                cstore: &'a CStore,
+                                cstore: &'tcx CStore,
                                 hir_map: &'a hir_map::Map<'tcx>,
                                 analysis: &'a ty::CrateAnalysis,
                                 resolutions: &'a Resolutions,
@@ -696,6 +698,7 @@ pub fn phase_2_configure_and_expand<F>(sess: &Session,
     let mut crate_loader = CrateLoader::new(sess, &cstore, crate_name);
     let resolver_arenas = Resolver::arenas();
     let mut resolver = Resolver::new(sess,
+                                     cstore,
                                      &krate,
                                      crate_name,
                                      make_glob_map,
@@ -844,7 +847,7 @@ pub fn phase_2_configure_and_expand<F>(sess: &Session,
 
     // Lower ast -> hir.
     let hir_forest = time(time_passes, "lowering ast -> hir", || {
-        let hir_crate = lower_crate(sess, &krate, &mut resolver);
+        let hir_crate = lower_crate(sess, cstore, &krate, &mut resolver);
 
         if sess.opts.debugging_opts.hir_stats {
             hir_stats::print_hir_stats(&hir_crate);
@@ -886,6 +889,7 @@ pub fn phase_2_configure_and_expand<F>(sess: &Session,
 /// miscellaneous analysis passes on the crate. Return various
 /// structures carrying the results of the analysis.
 pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
+                                               cstore: &'tcx CrateStore,
                                                hir_map: hir_map::Map<'tcx>,
                                                mut analysis: ty::CrateAnalysis,
                                                resolutions: Resolutions,
@@ -915,7 +919,7 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
 
     let named_region_map = time(time_passes,
                                 "lifetime resolution",
-                                || middle::resolve_lifetime::krate(sess, &hir_map))?;
+                                || middle::resolve_lifetime::krate(sess, cstore, &hir_map))?;
 
     time(time_passes,
          "looking for entry point",
@@ -1012,6 +1016,7 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
     passes.push_pass(MIR_OPTIMIZED, mir::transform::dump_mir::Marker("PreTrans"));
 
     TyCtxt::create_and_enter(sess,
+                             cstore,
                              local_providers,
                              extern_providers,
                              Rc::new(passes),
@@ -1148,10 +1153,15 @@ pub fn phase_5_run_llvm_passes(sess: &Session,
 /// This should produce either a finished executable or library.
 #[cfg(feature="llvm")]
 pub fn phase_6_link_output(sess: &Session,
+                           cstore: &CrateStore,
                            trans: &trans::CrateTranslation,
                            outputs: &OutputFilenames) {
     time(sess.time_passes(), "linking", || {
-        ::rustc_trans::back::link::link_binary(sess, trans, outputs, &trans.crate_name.as_str())
+        ::rustc_trans::back::link::link_binary(sess,
+                                               cstore,
+                                               trans,
+                                               outputs,
+                                               &trans.crate_name.as_str())
     });
 }
 

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -21,6 +21,7 @@ use rustc::ty::{self, TyCtxt, GlobalArenas, Resolutions};
 use rustc::cfg;
 use rustc::cfg::graphviz::LabelledCFG;
 use rustc::dep_graph::DepGraph;
+use rustc::middle::cstore::CrateStore;
 use rustc::session::Session;
 use rustc::session::config::Input;
 use rustc_borrowck as borrowck;
@@ -198,6 +199,7 @@ impl PpSourceMode {
     }
     fn call_with_pp_support_hir<'tcx, A, F>(&self,
                                                sess: &'tcx Session,
+                                               cstore: &'tcx CrateStore,
                                                hir_map: &hir_map::Map<'tcx>,
                                                analysis: &ty::CrateAnalysis,
                                                resolutions: &Resolutions,
@@ -226,6 +228,7 @@ impl PpSourceMode {
             }
             PpmTyped => {
                 abort_on_err(driver::phase_3_run_analysis_passes(sess,
+                                                                 cstore,
                                                                  hir_map.clone(),
                                                                  analysis.clone(),
                                                                  resolutions.clone(),
@@ -875,6 +878,7 @@ pub fn print_after_parsing(sess: &Session,
 }
 
 pub fn print_after_hir_lowering<'tcx, 'a: 'tcx>(sess: &'a Session,
+                                                cstore: &'tcx CrateStore,
                                                 hir_map: &hir_map::Map<'tcx>,
                                                 analysis: &ty::CrateAnalysis,
                                                 resolutions: &Resolutions,
@@ -891,6 +895,7 @@ pub fn print_after_hir_lowering<'tcx, 'a: 'tcx>(sess: &'a Session,
 
     if ppm.needs_analysis() {
         print_with_analysis(sess,
+                            cstore,
                             hir_map,
                             analysis,
                             resolutions,
@@ -929,6 +934,7 @@ pub fn print_after_hir_lowering<'tcx, 'a: 'tcx>(sess: &'a Session,
             (PpmHir(s), None) => {
                 let out: &mut Write = &mut out;
                 s.call_with_pp_support_hir(sess,
+                                           cstore,
                                            hir_map,
                                            analysis,
                                            resolutions,
@@ -952,6 +958,7 @@ pub fn print_after_hir_lowering<'tcx, 'a: 'tcx>(sess: &'a Session,
             (PpmHir(s), Some(uii)) => {
                 let out: &mut Write = &mut out;
                 s.call_with_pp_support_hir(sess,
+                                           cstore,
                                            hir_map,
                                            analysis,
                                            resolutions,
@@ -993,6 +1000,7 @@ pub fn print_after_hir_lowering<'tcx, 'a: 'tcx>(sess: &'a Session,
 // with a different callback than the standard driver, so that isn't easy.
 // Instead, we call that function ourselves.
 fn print_with_analysis<'tcx, 'a: 'tcx>(sess: &'a Session,
+                                       cstore: &'a CrateStore,
                                        hir_map: &hir_map::Map<'tcx>,
                                        analysis: &ty::CrateAnalysis,
                                        resolutions: &Resolutions,
@@ -1013,6 +1021,7 @@ fn print_with_analysis<'tcx, 'a: 'tcx>(sess: &'a Session,
     let mut out = Vec::new();
 
     abort_on_err(driver::phase_3_run_analysis_passes(sess,
+                                                     cstore,
                                                      hir_map.clone(),
                                                      analysis.clone(),
                                                      resolutions.clone(),

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -109,8 +109,7 @@ fn test_env<F>(source_string: &str,
                                        &dep_graph,
                                        None,
                                        diagnostic_handler,
-                                       Rc::new(CodeMap::new(FilePathMapping::empty())),
-                                       cstore.clone());
+                                       Rc::new(CodeMap::new(FilePathMapping::empty())));
     rustc_trans::init(&sess);
     rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
     let input = config::Input::Str {
@@ -138,8 +137,9 @@ fn test_env<F>(source_string: &str,
     let hir_map = hir_map::map_crate(&mut hir_forest, defs);
 
     // run just enough stuff to build a tcx:
-    let named_region_map = resolve_lifetime::krate(&sess, &hir_map);
+    let named_region_map = resolve_lifetime::krate(&sess, &*cstore, &hir_map);
     TyCtxt::create_and_enter(&sess,
+                             &*cstore,
                              ty::maps::Providers::default(),
                              ty::maps::Providers::default(),
                              Rc::new(Passes::new()),

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -60,7 +60,7 @@ macro_rules! provide {
 
                 $tcx.dep_graph.read(dep_node);
 
-                let $cdata = $tcx.cstore_untracked().crate_data_as_rc_any($def_id.krate);
+                let $cdata = $tcx.crate_data_as_rc_any($def_id.krate);
                 let $cdata = $cdata.downcast_ref::<cstore::CrateMetadata>()
                     .expect("CrateStore crated ata is not a CrateMetadata");
                 $compute
@@ -275,15 +275,6 @@ pub fn provide_local<'tcx>(providers: &mut Providers<'tcx>) {
             assert_eq!(cnum, LOCAL_CRATE);
             Rc::new(link_args::collect(tcx))
         },
-        extern_mod_stmt_cnum: |tcx, id| {
-            let id = tcx.hir.as_local_node_id(id).unwrap();
-            tcx.cstore_untracked().extern_mod_stmt_cnum_untracked(id)
-        },
-
-        all_crate_nums: |tcx, cnum| {
-            assert_eq!(cnum, LOCAL_CRATE);
-            Rc::new(tcx.cstore_untracked().crates_untracked())
-        },
 
         // Returns a map from a sufficiently visible external item (i.e. an
         // external item that is visible from at least one local module) to a
@@ -340,11 +331,6 @@ pub fn provide_local<'tcx>(providers: &mut Providers<'tcx>) {
             }
 
             Rc::new(visible_parent_map)
-        },
-
-        postorder_cnums: |tcx, cnum| {
-            assert_eq!(cnum, LOCAL_CRATE);
-            Rc::new(tcx.cstore_untracked().postorder_cnums_untracked())
         },
 
         ..*providers

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -60,7 +60,7 @@ macro_rules! provide {
 
                 $tcx.dep_graph.read(dep_node);
 
-                let $cdata = $tcx.sess.cstore.crate_data_as_rc_any($def_id.krate);
+                let $cdata = $tcx.cstore_untracked().crate_data_as_rc_any($def_id.krate);
                 let $cdata = $cdata.downcast_ref::<cstore::CrateMetadata>()
                     .expect("CrateStore crated ata is not a CrateMetadata");
                 $compute
@@ -277,12 +277,12 @@ pub fn provide_local<'tcx>(providers: &mut Providers<'tcx>) {
         },
         extern_mod_stmt_cnum: |tcx, id| {
             let id = tcx.hir.as_local_node_id(id).unwrap();
-            tcx.sess.cstore.extern_mod_stmt_cnum_untracked(id)
+            tcx.cstore_untracked().extern_mod_stmt_cnum_untracked(id)
         },
 
         all_crate_nums: |tcx, cnum| {
             assert_eq!(cnum, LOCAL_CRATE);
-            Rc::new(tcx.sess.cstore.crates_untracked())
+            Rc::new(tcx.cstore_untracked().crates_untracked())
         },
 
         // Returns a map from a sufficiently visible external item (i.e. an
@@ -344,7 +344,7 @@ pub fn provide_local<'tcx>(providers: &mut Providers<'tcx>) {
 
         postorder_cnums: |tcx, cnum| {
             assert_eq!(cnum, LOCAL_CRATE);
-            Rc::new(tcx.sess.cstore.postorder_cnums_untracked())
+            Rc::new(tcx.cstore_untracked().postorder_cnums_untracked())
         },
 
         ..*providers

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -254,7 +254,7 @@ impl<'a> Resolver<'a> {
                 self.crate_loader.process_item(item, &self.definitions);
 
                 // n.b. we don't need to look at the path option here, because cstore already did
-                let crate_id = self.session.cstore.extern_mod_stmt_cnum_untracked(item.id).unwrap();
+                let crate_id = self.cstore.extern_mod_stmt_cnum_untracked(item.id).unwrap();
                 let module =
                     self.get_module(DefId { krate: crate_id, index: CRATE_DEF_INDEX });
                 self.populate_module_if_necessary(module);
@@ -450,7 +450,7 @@ impl<'a> Resolver<'a> {
         let ident = child.ident;
         let def = child.def;
         let def_id = def.def_id();
-        let vis = self.session.cstore.visibility_untracked(def_id);
+        let vis = self.cstore.visibility_untracked(def_id);
         let span = child.span;
         let expansion = Mark::root(); // FIXME(jseyfried) intercrate hygiene
         match def {
@@ -472,7 +472,7 @@ impl<'a> Resolver<'a> {
                 self.define(parent, ident, ValueNS, (def, vis, DUMMY_SP, expansion));
 
                 if let Some(struct_def_id) =
-                        self.session.cstore.def_key(def_id).parent
+                        self.cstore.def_key(def_id).parent
                             .map(|index| DefId { krate: def_id.krate, index: index }) {
                     self.struct_constructors.insert(struct_def_id, (def, vis));
                 }
@@ -486,12 +486,12 @@ impl<'a> Resolver<'a> {
                                              span);
                 self.define(parent, ident, TypeNS, (module, vis, DUMMY_SP, expansion));
 
-                for child in self.session.cstore.item_children_untracked(def_id, self.session) {
+                for child in self.cstore.item_children_untracked(def_id, self.session) {
                     let ns = if let Def::AssociatedTy(..) = child.def { TypeNS } else { ValueNS };
                     self.define(module, child.ident, ns,
                                 (child.def, ty::Visibility::Public, DUMMY_SP, expansion));
 
-                    if self.session.cstore.associated_item_cloned_untracked(child.def.def_id())
+                    if self.cstore.associated_item_cloned_untracked(child.def.def_id())
                            .method_has_self_argument {
                         self.has_self.insert(child.def.def_id());
                     }
@@ -502,7 +502,7 @@ impl<'a> Resolver<'a> {
                 self.define(parent, ident, TypeNS, (def, vis, DUMMY_SP, expansion));
 
                 // Record field names for error reporting.
-                let field_names = self.session.cstore.struct_field_names_untracked(def_id);
+                let field_names = self.cstore.struct_field_names_untracked(def_id);
                 self.insert_field_names(def_id, field_names);
             }
             Def::Macro(..) => {
@@ -517,15 +517,15 @@ impl<'a> Resolver<'a> {
             return self.module_map[&def_id]
         }
 
-        let macros_only = self.session.cstore.dep_kind_untracked(def_id.krate).macros_only();
+        let macros_only = self.cstore.dep_kind_untracked(def_id.krate).macros_only();
         if let Some(&module) = self.extern_module_map.get(&(def_id, macros_only)) {
             return module;
         }
 
         let (name, parent) = if def_id.index == CRATE_DEF_INDEX {
-            (self.session.cstore.crate_name_untracked(def_id.krate).as_str(), None)
+            (self.cstore.crate_name_untracked(def_id.krate).as_str(), None)
         } else {
-            let def_key = self.session.cstore.def_key(def_id);
+            let def_key = self.cstore.def_key(def_id);
             (def_key.disambiguated_data.data.get_opt_name().unwrap(),
              Some(self.get_module(DefId { index: def_key.parent.unwrap(), ..def_id })))
         };
@@ -559,7 +559,7 @@ impl<'a> Resolver<'a> {
             return ext.clone();
         }
 
-        let macro_def = match self.session.cstore.load_macro_untracked(def_id, &self.session) {
+        let macro_def = match self.cstore.load_macro_untracked(def_id, &self.session) {
             LoadedMacro::MacroDef(macro_def) => macro_def,
             LoadedMacro::ProcMacro(ext) => return ext,
         };
@@ -576,7 +576,7 @@ impl<'a> Resolver<'a> {
     pub fn populate_module_if_necessary(&mut self, module: Module<'a>) {
         if module.populated.get() { return }
         let def_id = module.def_id().unwrap();
-        for child in self.session.cstore.item_children_untracked(def_id, self.session) {
+        for child in self.cstore.item_children_untracked(def_id, self.session) {
             self.build_reduced_graph_for_external_crate_def(module, child);
         }
         module.populated.set(true)
@@ -607,7 +607,7 @@ impl<'a> Resolver<'a> {
             span_err!(self.session, item.span, E0468,
                       "an `extern crate` loading macros must be at the crate root");
         } else if !self.use_extern_macros && !used &&
-                  self.session.cstore.dep_kind_untracked(module.def_id().unwrap().krate)
+                  self.cstore.dep_kind_untracked(module.def_id().unwrap().krate)
                       .macros_only() {
             let msg = "proc macro crates and `#[no_link]` crates have no effect without \
                        `#[macro_use]`";
@@ -651,7 +651,7 @@ impl<'a> Resolver<'a> {
             }
         }
         for (name, span) in legacy_imports.reexports {
-            self.session.cstore.export_macros_untracked(module.def_id().unwrap().krate);
+            self.cstore.export_macros_untracked(module.def_id().unwrap().krate);
             let ident = Ident::with_empty_ctxt(name);
             let result = self.resolve_ident_in_module(module, ident, MacroNS, false, false, span);
             if let Ok(binding) = result {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -31,7 +31,7 @@ use self::RibKind::*;
 
 use rustc::hir::map::{Definitions, DefCollector};
 use rustc::hir::{self, PrimTy, TyBool, TyChar, TyFloat, TyInt, TyUint, TyStr};
-use rustc::middle::cstore::CrateLoader;
+use rustc::middle::cstore::{CrateStore, CrateLoader};
 use rustc::session::Session;
 use rustc::lint;
 use rustc::hir::def::*;
@@ -1176,6 +1176,7 @@ impl PrimitiveTypeTable {
 /// The main resolver class.
 pub struct Resolver<'a> {
     session: &'a Session,
+    cstore: &'a CrateStore,
 
     pub definitions: Definitions,
 
@@ -1343,7 +1344,7 @@ impl<'a, 'b: 'a> ty::DefIdTree for &'a Resolver<'b> {
     fn parent(self, id: DefId) -> Option<DefId> {
         match id.krate {
             LOCAL_CRATE => self.definitions.def_key(id.index).parent,
-            _ => self.session.cstore.def_key(id).parent,
+            _ => self.cstore.def_key(id).parent,
         }.map(|index| DefId { index: index, ..id })
     }
 }
@@ -1383,6 +1384,7 @@ impl<'a> hir::lowering::Resolver for Resolver<'a> {
 
 impl<'a> Resolver<'a> {
     pub fn new(session: &'a Session,
+               cstore: &'a CrateStore,
                krate: &Crate,
                crate_name: &str,
                make_glob_map: MakeGlobMap,
@@ -1413,6 +1415,8 @@ impl<'a> Resolver<'a> {
 
         Resolver {
             session,
+
+            cstore,
 
             definitions,
 

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -778,7 +778,7 @@ impl<'a> Resolver<'a> {
             _ => return,
         };
 
-        let crate_name = self.session.cstore.crate_name_untracked(krate);
+        let crate_name = self.cstore.crate_name_untracked(krate);
 
         self.session.struct_span_err(use_span, warn_msg)
             .help(&format!("instead, import the procedural macro like any other item: \

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -844,7 +844,7 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
                 let def = binding.def();
                 if def != Def::Err {
                     if !def.def_id().is_local() {
-                        self.session.cstore.export_macros_untracked(def.def_id().krate);
+                        self.cstore.export_macros_untracked(def.def_id().krate);
                     }
                     if let Def::Macro(..) = def {
                         if let Some(&span) = exported_macro_names.get(&ident.modern()) {

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -185,7 +185,11 @@ pub fn link_binary(sess: &Session,
            bug!("invalid output type `{:?}` for target os `{}`",
                 crate_type, sess.opts.target_triple);
         }
-        let mut out_files = link_binary_output(sess, trans, crate_type, outputs, crate_name);
+        let mut out_files = link_binary_output(sess,
+                                               trans,
+                                               crate_type,
+                                               outputs,
+                                               crate_name);
         out_filenames.append(&mut out_files);
     }
 
@@ -346,8 +350,8 @@ fn link_binary_output(sess: &Session,
                                tmpdir.path());
             }
             _ => {
-                link_natively(sess, crate_type, &objects, &out_filename, trans,
-                              outputs, tmpdir.path());
+                link_natively(sess, crate_type, &objects, &out_filename,
+                              trans, outputs, tmpdir.path());
             }
         }
         out_filenames.push(out_filename);

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -777,16 +777,13 @@ fn write_metadata<'a, 'gcx>(tcx: TyCtxt<'a, 'gcx, 'gcx>,
                 EncodedMetadataHashes::new());
     }
 
-    let cstore = tcx.cstore_untracked();
-    let (metadata, hashes) = cstore.encode_metadata(tcx,
-                                                    &link_meta,
-                                                    exported_symbols);
+    let (metadata, hashes) = tcx.encode_metadata(link_meta, exported_symbols);
     if kind == MetadataKind::Uncompressed {
         return (metadata_llcx, metadata_llmod, metadata, hashes);
     }
 
     assert!(kind == MetadataKind::Compressed);
-    let mut compressed = cstore.metadata_encoding_version().to_vec();
+    let mut compressed = tcx.metadata_encoding_version();
     DeflateEncoder::new(&mut compressed, Compression::Fast)
         .write_all(&metadata.raw_data).unwrap();
 

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -777,7 +777,7 @@ fn write_metadata<'a, 'gcx>(tcx: TyCtxt<'a, 'gcx, 'gcx>,
                 EncodedMetadataHashes::new());
     }
 
-    let cstore = &tcx.sess.cstore;
+    let cstore = tcx.cstore_untracked();
     let (metadata, hashes) = cstore.encode_metadata(tcx,
                                                     &link_meta,
                                                     exported_symbols);

--- a/src/librustdoc/build.rs
+++ b/src/librustdoc/build.rs
@@ -26,6 +26,7 @@ fn main() {
        .file("../rt/hoedown/src/version.c")
        .warnings(false)
        .include(src_dir)
+       .warnings(false)
        .compile("libhoedown.a");
 }
 

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -215,7 +215,7 @@ pub fn run_core(search_paths: SearchPaths,
         debug!("crate: {:?}", tcx.hir.krate());
 
         let krate = {
-            let mut v = RustdocVisitor::new(&ctxt);
+            let mut v = RustdocVisitor::new(&*cstore, &ctxt);
             v.visit(tcx.hir.krate());
             v.clean(&ctxt)
         };

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -148,7 +148,7 @@ pub fn run_core(search_paths: SearchPaths,
     let _ignore = dep_graph.in_ignore();
     let cstore = Rc::new(CStore::new(box rustc_trans::LlvmMetadataLoader));
     let mut sess = session::build_session_(
-        sessopts, &dep_graph, cpath, diagnostic_handler, codemap, cstore.clone()
+        sessopts, &dep_graph, cpath, diagnostic_handler, codemap
     );
     rustc_trans::init(&sess);
     rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
@@ -181,6 +181,7 @@ pub fn run_core(search_paths: SearchPaths,
     let hir_map = hir_map::map_crate(&mut hir_forest, defs);
 
     abort_on_err(driver::phase_3_run_analysis_passes(&sess,
+                                                     &*cstore,
                                                      hir_map,
                                                      analysis,
                                                      resolutions,

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -87,7 +87,7 @@ pub fn run(input: &str,
     let _ignore = dep_graph.in_ignore();
     let cstore = Rc::new(CStore::new(box rustc_trans::LlvmMetadataLoader));
     let mut sess = session::build_session_(
-        sessopts, &dep_graph, Some(input_path.clone()), handler, codemap.clone(), cstore.clone(),
+        sessopts, &dep_graph, Some(input_path.clone()), handler, codemap.clone()
     );
     rustc_trans::init(&sess);
     rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
@@ -240,7 +240,7 @@ fn run_test(test: &str, cratename: &str, filename: &str, cfgs: Vec<String>, libs
     let dep_graph = DepGraph::new(false);
     let cstore = Rc::new(CStore::new(box rustc_trans::LlvmMetadataLoader));
     let mut sess = session::build_session_(
-        sessopts, &dep_graph, None, diagnostic_handler, codemap, cstore.clone(),
+        sessopts, &dep_graph, None, diagnostic_handler, codemap
     );
     rustc_trans::init(&sess);
     rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));

--- a/src/test/run-make/issue-19371/foo.rs
+++ b/src/test/run-make/issue-19371/foo.rs
@@ -60,7 +60,7 @@ fn basic_sess(sysroot: PathBuf) -> (Session, Rc<CStore>) {
     let descriptions = Registry::new(&rustc::DIAGNOSTICS);
     let dep_graph = DepGraph::new(opts.build_dep_graph());
     let cstore = Rc::new(CStore::new(Box::new(rustc_trans::LlvmMetadataLoader)));
-    let sess = build_session(opts, &dep_graph, None, descriptions, cstore.clone());
+    let sess = build_session(opts, &dep_graph, None, descriptions);
     rustc_trans::init(&sess);
     rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
     (sess, cstore)

--- a/src/test/run-pass-fulldeps/compiler-calls.rs
+++ b/src/test/run-pass-fulldeps/compiler-calls.rs
@@ -21,6 +21,7 @@ extern crate rustc_driver;
 extern crate syntax;
 extern crate rustc_errors as errors;
 
+use rustc::middle::cstore::CrateStore;
 use rustc::session::Session;
 use rustc::session::config::{self, Input};
 use rustc_driver::{driver, CompilerCalls, Compilation};
@@ -47,6 +48,7 @@ impl<'a> CompilerCalls<'a> for TestCalls {
     fn late_callback(&mut self,
                      _: &getopts::Matches,
                      _: &Session,
+                     _: &CrateStore,
                      _: &Input,
                      _: &Option<PathBuf>,
                      _: &Option<PathBuf>)


### PR DESCRIPTION
This commit makes the `CrateStore` object private to the `ty/context.rs` module and also absent on the `Session` itself.

cc #44390
cc #44341 (initial commit pulled and rebased from here)