### PR TITLE
Add `TargetOptions::min_global_align`, with s390x at 16-bit

### DIFF
--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -425,6 +425,9 @@ pub struct TargetOptions {
 
     /// Whether or not stack probes (__rust_probestack) are enabled
     pub stack_probes: bool,
+
+    /// The minimum alignment for global symbols.
+    pub min_global_align: Option<u64>,
 }
 
 impl Default for TargetOptions {
@@ -486,6 +489,7 @@ impl Default for TargetOptions {
             crt_static_default: false,
             crt_static_respected: false,
             stack_probes: false,
+            min_global_align: None,
         }
     }
 }
@@ -724,6 +728,7 @@ impl Target {
         key!(crt_static_default, bool);
         key!(crt_static_respected, bool);
         key!(stack_probes, bool);
+        key!(min_global_align, Option<u64>);
 
         if let Some(array) = obj.find("abi-blacklist").and_then(Json::as_array) {
             for name in array.iter().filter_map(|abi| abi.as_string()) {
@@ -914,6 +919,7 @@ impl ToJson for Target {
         target_option_val!(crt_static_default);
         target_option_val!(crt_static_respected);
         target_option_val!(stack_probes);
+        target_option_val!(min_global_align);
 
         if default.abi_blacklist != self.options.abi_blacklist {
             d.insert("abi-blacklist".to_string(), self.options.abi_blacklist.iter()

--- a/src/librustc_back/target/s390x_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/s390x_unknown_linux_gnu.rs
@@ -22,6 +22,7 @@ pub fn target() -> TargetResult {
     base.max_atomic_width = Some(64);
     // see #36994
     base.exe_allocation_crate = None;
+    base.min_global_align = Some(16);
 
     Ok(Target {
         llvm_target: "s390x-unknown-linux-gnu".to_string(),

--- a/src/test/run-make/min-global-align/Makefile
+++ b/src/test/run-make/min-global-align/Makefile
@@ -1,0 +1,22 @@
+-include ../tools.mk
+
+# This tests ensure that global variables respect the target minimum alignment.
+# The three bools `STATIC_BOOL`, `STATIC_MUT_BOOL`, and `CONST_BOOL` all have
+# type-alignment of 1, but some targets require greater global alignment.
+
+SRC = min_global_align.rs
+LL = $(TMPDIR)/min_global_align.ll
+
+all:
+ifeq ($(UNAME),Linux)
+# Most targets are happy with default alignment -- take i686 for example.
+ifeq ($(filter x86,$(LLVM_COMPONENTS)),x86)
+	$(RUSTC) --target=i686-unknown-linux-gnu --emit=llvm-ir $(SRC)
+	[ "$$(grep -c 'align 1' "$(LL)")" -eq "3" ]
+endif
+# SystemZ requires even alignment for PC-relative addressing.
+ifeq ($(filter systemz,$(LLVM_COMPONENTS)),systemz)
+	$(RUSTC) --target=s390x-unknown-linux-gnu --emit=llvm-ir $(SRC)
+	[ "$$(grep -c 'align 2' "$(LL)")" -eq "3" ]
+endif
+endif

--- a/src/test/run-make/min-global-align/min_global_align.rs
+++ b/src/test/run-make/min-global-align/min_global_align.rs
@@ -1,0 +1,38 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(no_core, lang_items)]
+#![crate_type="rlib"]
+#![no_core]
+
+pub static STATIC_BOOL: bool = true;
+
+pub static mut STATIC_MUT_BOOL: bool = true;
+
+const CONST_BOOL: bool = true;
+pub static CONST_BOOL_REF: &'static bool = &CONST_BOOL;
+
+
+#[lang = "sized"]
+trait Sized {}
+
+#[lang = "copy"]
+trait Copy {}
+
+#[lang = "freeze"]
+trait Freeze {}
+
+#[lang = "sync"]
+trait Sync {}
+impl Sync for bool {}
+impl Sync for &'static bool {}
+
+#[lang="drop_in_place"]
+pub unsafe fn drop_in_place<T: ?Sized>(_: *mut T) { }


### PR DESCRIPTION
The SystemZ `LALR` instruction provides PC-relative addressing for globals,
but only to *even* addresses, so other compilers make sure that such
globals are always 2-byte aligned.  In Clang, this is modeled with
`TargetInfo::MinGlobalAlign`, and `TargetOptions::min_global_align` now
serves the same purpose for rustc.

In Clang, the only targets that set this are SystemZ, Lanai, and NVPTX, and
the latter two don't have targets in rust master.

Fixes #44411.
r? @eddyb