### PR TITLE
Add short doc examples for str::from_utf8_mut

### DIFF
--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -318,7 +318,7 @@ pub fn from_utf8(v: &[u8]) -> Result<&str, Utf8Error> {
 ///
 /// assert_eq!("Hello, Rust!", outstr);
 /// ```
-/// 
+///
 /// Incorrect bytes:
 ///
 /// ```
@@ -331,6 +331,8 @@ pub fn from_utf8(v: &[u8]) -> Result<&str, Utf8Error> {
 /// ```
 /// See the docs for [`Utf8Error`][error] for more details on the kinds of
 /// errors that can be returned.
+///
+/// [error]: struct.Utf8Error.html
 #[stable(feature = "str_mut_extras", since = "1.20.0")]
 pub fn from_utf8_mut(v: &mut [u8]) -> Result<&mut str, Utf8Error> {
     run_utf8_validation(v)?;

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -331,7 +331,6 @@ pub fn from_utf8(v: &[u8]) -> Result<&str, Utf8Error> {
 /// ```
 /// See the docs for [`Utf8Error`][error] for more details on the kinds of
 /// errors that can be returned.
-///
 #[stable(feature = "str_mut_extras", since = "1.20.0")]
 pub fn from_utf8_mut(v: &mut [u8]) -> Result<&mut str, Utf8Error> {
     run_utf8_validation(v)?;

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -319,7 +319,7 @@ pub fn from_utf8(v: &[u8]) -> Result<&str, Utf8Error> {
 /// assert_eq!("Hello, Rust!", outstr);
 /// ```
 /// 
-/// # Incorrect bytes:
+/// Incorrect bytes:
 ///
 /// ```
 /// use std::str;

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -302,6 +302,36 @@ pub fn from_utf8(v: &[u8]) -> Result<&str, Utf8Error> {
 }
 
 /// Converts a mutable slice of bytes to a mutable string slice.
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```
+/// use std::str;
+///
+/// // "Hello, Rust!" as a mutable vector
+/// let mut hellorust = vec![72, 101, 108, 108, 111, 44, 32, 82, 117, 115, 116, 33];
+///
+/// // As we know these bytes are valid, we can use `unwrap()`
+/// let outstr = str::from_utf8_mut(&mut hellorust).unwrap();
+///
+/// assert_eq!("Hello, Rust!", outstr);
+/// ```
+/// 
+/// # Incorrect bytes:
+///
+/// ```
+/// use std::str;
+/// 
+/// // Some invalid bytes in a mutable vector
+/// let mut invalid = vec![128, 223];
+///
+/// assert!(str::from_utf8_mut(&mut invalid).is_err());
+/// ```
+/// See the docs for [`Utf8Error`][error] for more details on the kinds of
+/// errors that can be returned.
+///
 #[stable(feature = "str_mut_extras", since = "1.20.0")]
 pub fn from_utf8_mut(v: &mut [u8]) -> Result<&mut str, Utf8Error> {
     run_utf8_validation(v)?;

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -323,7 +323,7 @@ pub fn from_utf8(v: &[u8]) -> Result<&str, Utf8Error> {
 ///
 /// ```
 /// use std::str;
-/// 
+///
 /// // Some invalid bytes in a mutable vector
 /// let mut invalid = vec![128, 223];
 ///


### PR DESCRIPTION
Fixes #44462 

