### PR TITLE
rustbuild: Make double extra sure no-network builds work

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -1255,9 +1255,17 @@ impl Step for Distcheck {
         build.run(Command::new("./configure")
                          .args(&build.config.configure_args)
                          .arg("--enable-vendor")
+                         .arg("--enable-locked-deps")
+                         .arg("--enable-extended")
                          .current_dir(&dir));
         build.run(Command::new(build_helper::make(&build.build))
                          .arg("check")
+                         // Set a dummy value for `CARGO_HOME` to ensure that we
+                         // generate an error due to `--frozen` if Cargo
+                         // attempts to fill in this directory (it shouldn't
+                         // need to, we should have all vendored dependencies
+                         // available to us)
+                         .env("CARGO_HOME", dir.join("cargo-home"))
                          .current_dir(&dir));
 
         // Now make sure that rust-src has all of libstd's dependencies

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -260,11 +260,9 @@ for key in known_args:
             set(keyval[0], value)
         continue
 
-    # Ensure each option is only passed once
+    # Take the last value of multiple passed values as the source of truth
     arr = known_args[key]
-    if len(arr) > 1:
-        err("Option '{}' provided more than once".format(key))
-    option, value = arr[0]
+    option, value = arr[len(arr) - 1]
 
     # If we have a clear avenue to set our value in rustbuild, do so
     if option.rustbuild is not None:


### PR DESCRIPTION
In the distcheck step which executes will all vendored dependencies make sure we
pass in configure arguments to enable `--frozen` and such along with passing a
pristine `CARGO_HOME` to ensure Cargo doesn't use any preexisting caches.