### PR TITLE
Parse nested closure with two consecutive parameter lists properly

### DIFF
--- a/src/test/run-pass/closure-returning-closure.rs
+++ b/src/test/run-pass/closure-returning-closure.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let f = |_||x, y| x+y;
+    assert_eq!(f(())(1, 2), 3);
+}


### PR DESCRIPTION
This is a followup of #44332.

---

Currently, in nightly, this does not compile:

```rust
fn main() {
    let f = |_||x, y| x+y;
    println!("{}", f(())(1, 2)); // should print 3
}
```

`|_||x, y| x+y` should be parsed as `|_| (|x, y| x+y)`, but the parser didn't accept `||` between `_` and `x`. This patch fixes the problem.

r? @petrochenkov 