### PR TITLE
rustbuild: Fix a distribution bug with rustdoc

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -900,6 +900,7 @@ impl Step for PlainSourceTarball {
 fn install(src: &Path, dstdir: &Path, perms: u32) {
     let dst = dstdir.join(src.file_name().unwrap());
     t!(fs::create_dir_all(dstdir));
+    drop(fs::remove_file(&dst));
     {
         let mut s = t!(fs::File::open(&src));
         let mut d = t!(fs::File::create(&dst));


### PR DESCRIPTION
Apparently `File::create` was called when there was an existing hard link or the
like, causing an existing file to get accidentally truncated!

Closes #44487