### PR TITLE
rustc: Remove `Session::dep_graph`

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -40,6 +40,7 @@
 //! get confused if the spans from leaf AST nodes occur in multiple places
 //! in the HIR, especially for multiple identifiers.
 
+use dep_graph::DepGraph;
 use hir;
 use hir::map::{Definitions, DefKey};
 use hir::def_id::{DefIndex, DefId, CRATE_DEF_INDEX};
@@ -122,13 +123,14 @@ pub trait Resolver {
 
 pub fn lower_crate(sess: &Session,
                    cstore: &CrateStore,
+                   dep_graph: &DepGraph,
                    krate: &Crate,
                    resolver: &mut Resolver)
                    -> hir::Crate {
     // We're constructing the HIR here; we don't care what we will
     // read, since we haven't even constructed the *input* to
     // incr. comp. yet.
-    let _ignore = sess.dep_graph.in_ignore();
+    let _ignore = dep_graph.in_ignore();
 
     LoweringContext {
         crate_root: std_inject::injected_crate_name(krate),

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1949,7 +1949,6 @@ mod dep_tracking {
 
 #[cfg(test)]
 mod tests {
-    use dep_graph::DepGraph;
     use errors;
     use getopts;
     use lint;
@@ -1982,7 +1981,6 @@ mod tests {
     // When the user supplies --test we should implicitly supply --cfg test
     #[test]
     fn test_switch_implies_cfg_test() {
-        let dep_graph = DepGraph::new(false);
         let matches =
             &match optgroups().parse(&["--test".to_string()]) {
               Ok(m) => m,
@@ -1990,7 +1988,7 @@ mod tests {
             };
         let registry = errors::registry::Registry::new(&[]);
         let (sessopts, cfg) = build_session_options_and_crate_config(matches);
-        let sess = build_session(sessopts, &dep_graph, None, registry);
+        let sess = build_session(sessopts, None, registry);
         let cfg = build_configuration(&sess, cfg);
         assert!(cfg.contains(&(Symbol::intern("test"), None)));
     }
@@ -1999,7 +1997,6 @@ mod tests {
     // another --cfg test
     #[test]
     fn test_switch_implies_cfg_test_unless_cfg_test() {
-        let dep_graph = DepGraph::new(false);
         let matches =
             &match optgroups().parse(&["--test".to_string(), "--cfg=test".to_string()]) {
               Ok(m) => m,
@@ -2009,7 +2006,7 @@ mod tests {
             };
         let registry = errors::registry::Registry::new(&[]);
         let (sessopts, cfg) = build_session_options_and_crate_config(matches);
-        let sess = build_session(sessopts, &dep_graph, None, registry);
+        let sess = build_session(sessopts, None, registry);
         let cfg = build_configuration(&sess, cfg);
         let mut test_items = cfg.iter().filter(|&&(name, _)| name == "test");
         assert!(test_items.next().is_some());
@@ -2018,14 +2015,13 @@ mod tests {
 
     #[test]
     fn test_can_print_warnings() {
-        let dep_graph = DepGraph::new(false);
         {
             let matches = optgroups().parse(&[
                 "-Awarnings".to_string()
             ]).unwrap();
             let registry = errors::registry::Registry::new(&[]);
             let (sessopts, _) = build_session_options_and_crate_config(&matches);
-            let sess = build_session(sessopts, &dep_graph, None, registry);
+            let sess = build_session(sessopts, None, registry);
             assert!(!sess.diagnostic().can_emit_warnings);
         }
 
@@ -2036,7 +2032,7 @@ mod tests {
             ]).unwrap();
             let registry = errors::registry::Registry::new(&[]);
             let (sessopts, _) = build_session_options_and_crate_config(&matches);
-            let sess = build_session(sessopts, &dep_graph, None, registry);
+            let sess = build_session(sessopts, None, registry);
             assert!(sess.diagnostic().can_emit_warnings);
         }
 
@@ -2046,7 +2042,7 @@ mod tests {
             ]).unwrap();
             let registry = errors::registry::Registry::new(&[]);
             let (sessopts, _) = build_session_options_and_crate_config(&matches);
-            let sess = build_session(sessopts, &dep_graph, None, registry);
+            let sess = build_session(sessopts, None, registry);
             assert!(sess.diagnostic().can_emit_warnings);
         }
     }

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -11,7 +11,6 @@
 //! # Standalone Tests for the Inference Module
 
 use driver;
-use rustc::dep_graph::DepGraph;
 use rustc_lint;
 use rustc_resolve::MakeGlobMap;
 use rustc_trans;
@@ -102,11 +101,8 @@ fn test_env<F>(source_string: &str,
     options.unstable_features = UnstableFeatures::Allow;
     let diagnostic_handler = errors::Handler::with_emitter(true, false, emitter);
 
-    let dep_graph = DepGraph::new(false);
-    let _ignore = dep_graph.in_ignore();
     let cstore = Rc::new(CStore::new(box ::MetadataLoader));
     let sess = session::build_session_(options,
-                                       &dep_graph,
                                        None,
                                        diagnostic_handler,
                                        Rc::new(CodeMap::new(FilePathMapping::empty())));
@@ -130,7 +126,6 @@ fn test_env<F>(source_string: &str,
                                              |_| Ok(()))
             .expect("phase 2 aborted")
     };
-    let _ignore = dep_graph.in_ignore();
 
     let arena = DroplessArena::new();
     let arenas = ty::GlobalArenas::new();

--- a/src/librustc_incremental/lib.rs
+++ b/src/librustc_incremental/lib.rs
@@ -40,4 +40,5 @@ pub use persist::save_dep_graph;
 pub use persist::save_trans_partition;
 pub use persist::save_work_products;
 pub use persist::in_incr_comp_dir;
+pub use persist::prepare_session_directory;
 pub use persist::finalize_session_directory;

--- a/src/librustc_incremental/persist/fs.rs
+++ b/src/librustc_incremental/persist/fs.rs
@@ -114,7 +114,7 @@
 //! unsupported file system and emit a warning in that case. This is not yet
 //! implemented.
 
-use rustc::hir::def_id::{CrateNum, LOCAL_CRATE};
+use rustc::hir::def_id::CrateNum;
 use rustc::hir::svh::Svh;
 use rustc::session::Session;
 use rustc::ty::TyCtxt;
@@ -193,13 +193,21 @@ pub fn in_incr_comp_dir(incr_comp_session_dir: &Path, file_name: &str) -> PathBu
 /// a dep-graph and work products from a previous session.
 /// If the call fails, the fn may leave behind an invalid session directory.
 /// The garbage collection will take care of it.
-pub fn prepare_session_directory(tcx: TyCtxt) -> Result<bool, ()> {
+pub fn prepare_session_directory(sess: &Session,
+                                 crate_name: &str,
+                                 crate_disambiguator: &str) {
+    if sess.opts.incremental.is_none() {
+        return
+    }
+
     debug!("prepare_session_directory");
 
     // {incr-comp-dir}/{crate-name-and-disambiguator}
-    let crate_dir = crate_path_tcx(tcx, LOCAL_CRATE);
+    let crate_dir = crate_path(sess, crate_name, crate_disambiguator);
     debug!("crate-dir: {}", crate_dir.display());
-    try!(create_dir(tcx.sess, &crate_dir, "crate"));
+    if create_dir(sess, &crate_dir, "crate").is_err() {
+        return
+    }
 
     // Hack: canonicalize the path *after creating the directory*
     // because, on windows, long paths can cause problems;
@@ -208,9 +216,9 @@ pub fn prepare_session_directory(tcx: TyCtxt) -> Result<bool, ()> {
     let crate_dir = match crate_dir.canonicalize() {
         Ok(v) => v,
         Err(err) => {
-            tcx.sess.err(&format!("incremental compilation: error canonicalizing path `{}`: {}",
-                                  crate_dir.display(), err));
-            return Err(());
+            sess.err(&format!("incremental compilation: error canonicalizing path `{}`: {}",
+                              crate_dir.display(), err));
+            return
         }
     };
 
@@ -225,11 +233,16 @@ pub fn prepare_session_directory(tcx: TyCtxt) -> Result<bool, ()> {
 
         // Lock the new session directory. If this fails, return an
         // error without retrying
-        let (directory_lock, lock_file_path) = try!(lock_directory(tcx.sess, &session_dir));
+        let (directory_lock, lock_file_path) = match lock_directory(sess, &session_dir) {
+            Ok(e) => e,
+            Err(_) => return,
+        };
 
         // Now that we have the lock, we can actually create the session
         // directory
-        try!(create_dir(tcx.sess, &session_dir, "session"));
+        if create_dir(sess, &session_dir, "session").is_err() {
+            return
+        }
 
         // Find a suitable source directory to copy from. Ignore those that we
         // have already tried before.
@@ -243,14 +256,14 @@ pub fn prepare_session_directory(tcx: TyCtxt) -> Result<bool, ()> {
             debug!("no source directory found. Continuing with empty session \
                     directory.");
 
-            tcx.sess.init_incr_comp_session(session_dir, directory_lock);
-            return Ok(false)
+            sess.init_incr_comp_session(session_dir, directory_lock, false);
+            return
         };
 
         debug!("attempting to copy data from source: {}",
                source_directory.display());
 
-        let print_file_copy_stats = tcx.sess.opts.debugging_opts.incremental_info;
+        let print_file_copy_stats = sess.opts.debugging_opts.incremental_info;
 
         // Try copying over all files from the source directory
         if let Ok(allows_links) = copy_files(&session_dir, &source_directory,
@@ -259,7 +272,7 @@ pub fn prepare_session_directory(tcx: TyCtxt) -> Result<bool, ()> {
                    source_directory.display());
 
             if !allows_links {
-                tcx.sess.warn(&format!("Hard linking files in the incremental \
+                sess.warn(&format!("Hard linking files in the incremental \
                                         compilation cache failed. Copying files \
                                         instead. Consider moving the cache \
                                         directory to a file system which supports \
@@ -268,8 +281,8 @@ pub fn prepare_session_directory(tcx: TyCtxt) -> Result<bool, ()> {
                     );
             }
 
-            tcx.sess.init_incr_comp_session(session_dir, directory_lock);
-            return Ok(true)
+            sess.init_incr_comp_session(session_dir, directory_lock, true);
+            return
         } else {
              debug!("copying failed - trying next directory");
 
@@ -280,13 +293,13 @@ pub fn prepare_session_directory(tcx: TyCtxt) -> Result<bool, ()> {
             // Try to remove the session directory we just allocated. We don't
             // know if there's any garbage in it from the failed copy action.
             if let Err(err) = safe_remove_dir_all(&session_dir) {
-                tcx.sess.warn(&format!("Failed to delete partly initialized \
-                                        session dir `{}`: {}",
-                                       session_dir.display(),
-                                       err));
+                sess.warn(&format!("Failed to delete partly initialized \
+                                    session dir `{}`: {}",
+                                   session_dir.display(),
+                                   err));
             }
 
-            delete_session_dir_lock_file(tcx.sess, &lock_file_path);
+            delete_session_dir_lock_file(sess, &lock_file_path);
             mem::drop(directory_lock);
         }
     }

--- a/src/librustc_incremental/persist/load.rs
+++ b/src/librustc_incremental/persist/load.rs
@@ -42,30 +42,10 @@ pub type DirtyNodes = FxHashMap<DepNodeIndex, DepNodeIndex>;
 /// more general overview.
 pub fn load_dep_graph<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                 incremental_hashes_map: &IncrementalHashesMap) {
-    if tcx.sess.opts.incremental.is_none() {
-        return;
+    if tcx.sess.incr_session_load_dep_graph() {
+        let _ignore = tcx.dep_graph.in_ignore();
+        load_dep_graph_if_exists(tcx, incremental_hashes_map);
     }
-
-    match prepare_session_directory(tcx) {
-        Ok(true) => {
-            // We successfully allocated a session directory and there is
-            // something in it to load, so continue
-        }
-        Ok(false) => {
-            // We successfully allocated a session directory, but there is no
-            // dep-graph data in it to load (because this is the first
-            // compilation session with this incr. comp. dir.)
-            return
-        }
-        Err(()) => {
-            // Something went wrong while trying to allocate the session
-            // directory. Don't try to use it any further.
-            return
-        }
-    }
-
-    let _ignore = tcx.dep_graph.in_ignore();
-    load_dep_graph_if_exists(tcx, incremental_hashes_map);
 }
 
 fn load_dep_graph_if_exists<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,

--- a/src/librustc_incremental/persist/mod.rs
+++ b/src/librustc_incremental/persist/mod.rs
@@ -22,6 +22,7 @@ mod save;
 mod work_product;
 mod file_format;
 
+pub use self::fs::prepare_session_directory;
 pub use self::fs::finalize_session_directory;
 pub use self::fs::in_incr_comp_dir;
 pub use self::load::load_dep_graph;

--- a/src/librustc_incremental/persist/work_product.rs
+++ b/src/librustc_incremental/persist/work_product.rs
@@ -11,7 +11,7 @@
 //! This module contains files for saving intermediate work-products.
 
 use persist::fs::*;
-use rustc::dep_graph::{WorkProduct, WorkProductId};
+use rustc::dep_graph::{WorkProduct, WorkProductId, DepGraph};
 use rustc::session::Session;
 use rustc::session::config::OutputType;
 use rustc::util::fs::link_or_copy;
@@ -19,6 +19,7 @@ use std::path::PathBuf;
 use std::fs as std_fs;
 
 pub fn save_trans_partition(sess: &Session,
+                            dep_graph: &DepGraph,
                             cgu_name: &str,
                             partition_hash: u64,
                             files: &[(OutputType, PathBuf)]) {
@@ -60,7 +61,7 @@ pub fn save_trans_partition(sess: &Session,
         saved_files,
     };
 
-    sess.dep_graph.insert_work_product(&work_product_id, work_product);
+    dep_graph.insert_work_product(&work_product_id, work_product);
 }
 
 pub fn delete_workproduct_files(sess: &Session, work_product: &WorkProduct) {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -11,7 +11,6 @@
 use rustc_lint;
 use rustc_driver::{driver, target_features, abort_on_err};
 use rustc_driver::pretty::ReplaceBodyWithLoop;
-use rustc::dep_graph::DepGraph;
 use rustc::session::{self, config};
 use rustc::hir::def_id::DefId;
 use rustc::hir::def::Def;
@@ -144,11 +143,9 @@ pub fn run_core(search_paths: SearchPaths,
                                                                false,
                                                                Some(codemap.clone()));
 
-    let dep_graph = DepGraph::new(false);
-    let _ignore = dep_graph.in_ignore();
     let cstore = Rc::new(CStore::new(box rustc_trans::LlvmMetadataLoader));
     let mut sess = session::build_session_(
-        sessopts, &dep_graph, cpath, diagnostic_handler, codemap
+        sessopts, cpath, diagnostic_handler, codemap,
     );
     rustc_trans::init(&sess);
     rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));

--- a/src/test/run-make/issue-19371/foo.rs
+++ b/src/test/run-make/issue-19371/foo.rs
@@ -58,9 +58,8 @@ fn basic_sess(sysroot: PathBuf) -> (Session, Rc<CStore>) {
     opts.maybe_sysroot = Some(sysroot);
 
     let descriptions = Registry::new(&rustc::DIAGNOSTICS);
-    let dep_graph = DepGraph::new(opts.build_dep_graph());
     let cstore = Rc::new(CStore::new(Box::new(rustc_trans::LlvmMetadataLoader)));
-    let sess = build_session(opts, &dep_graph, None, descriptions);
+    let sess = build_session(opts, None, descriptions);
     rustc_trans::init(&sess);
     rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
     (sess, cstore)


### PR DESCRIPTION
This commit removes the `dep_graph` field from the `Session` type according to
issue #44390. Most of the fallout here was relatively straightforward and the
`prepare_session_directory` function was rejiggered a bit to reuse the results
in the later-called `load_dep_graph` function.

Closes #44390