### PR TITLE
Remove deprecated lang items

### DIFF
--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -327,14 +327,6 @@ language_item_table! {
 
     PhantomDataItem,                 "phantom_data",            phantom_data;
 
-    // Deprecated:
-    CovariantTypeItem,               "covariant_type",          covariant_type;
-    ContravariantTypeItem,           "contravariant_type",      contravariant_type;
-    InvariantTypeItem,               "invariant_type",          invariant_type;
-    CovariantLifetimeItem,           "covariant_lifetime",      covariant_lifetime;
-    ContravariantLifetimeItem,       "contravariant_lifetime",  contravariant_lifetime;
-    InvariantLifetimeItem,           "invariant_lifetime",      invariant_lifetime;
-
     NonZeroItem,                     "non_zero",                non_zero;
 
     DebugTraitLangItem,              "debug_trait",             debug_trait;

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -78,19 +78,12 @@ impl LanguageItems {
     }
 
     pub fn fn_trait_kind(&self, id: DefId) -> Option<ty::ClosureKind> {
-        let def_id_kinds = [
-            (self.fn_trait(), ty::ClosureKind::Fn),
-            (self.fn_mut_trait(), ty::ClosureKind::FnMut),
-            (self.fn_once_trait(), ty::ClosureKind::FnOnce),
-            ];
-
-        for &(opt_def_id, kind) in &def_id_kinds {
-            if Some(id) == opt_def_id {
-                return Some(kind);
-            }
+        match Some(id) {
+            x if x == self.fn_trait() => Some(ty::ClosureKind::Fn),
+            x if x == self.fn_mut_trait() => Some(ty::ClosureKind::FnMut),
+            x if x == self.fn_once_trait() =>  Some(ty::ClosureKind::FnOnce),
+            _ => None
         }
-
-        None
     }
 
     $(

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -83,10 +83,6 @@ impl LanguageItems {
         }
     }
 
-    pub fn require_owned_box(&self) -> Result<DefId, String> {
-        self.require(OwnedBoxLangItem)
-    }
-
     pub fn fn_trait_kind(&self, id: DefId) -> Option<ty::ClosureKind> {
         let def_id_kinds = [
             (self.fn_trait(), ty::ClosureKind::Fn),

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -74,14 +74,14 @@ impl LanguageItems {
     }
 
     pub fn require(&self, it: LangItem) -> Result<DefId, String> {
-        self.items[it as usize].ok_or(format!("requires `{}` lang_item", it.name()))
+        self.items[it as usize].ok_or_else(|| format!("requires `{}` lang_item", it.name()))
     }
 
     pub fn fn_trait_kind(&self, id: DefId) -> Option<ty::ClosureKind> {
         match Some(id) {
             x if x == self.fn_trait() => Some(ty::ClosureKind::Fn),
             x if x == self.fn_mut_trait() => Some(ty::ClosureKind::FnMut),
-            x if x == self.fn_once_trait() =>  Some(ty::ClosureKind::FnOnce),
+            x if x == self.fn_once_trait() => Some(ty::ClosureKind::FnOnce),
             _ => None
         }
     }

--- a/src/librustc_typeck/variance/terms.rs
+++ b/src/librustc_typeck/variance/terms.rs
@@ -98,15 +98,6 @@ fn lang_items(tcx: TyCtxt) -> Vec<(ast::NodeId, Vec<ty::Variance>)> {
     let all = vec![
         (lang_items.phantom_data(), vec![ty::Covariant]),
         (lang_items.unsafe_cell_type(), vec![ty::Invariant]),
-
-        // Deprecated:
-        (lang_items.covariant_type(), vec![ty::Covariant]),
-        (lang_items.contravariant_type(), vec![ty::Contravariant]),
-        (lang_items.invariant_type(), vec![ty::Invariant]),
-        (lang_items.covariant_lifetime(), vec![ty::Covariant]),
-        (lang_items.contravariant_lifetime(), vec![ty::Contravariant]),
-        (lang_items.invariant_lifetime(), vec![ty::Invariant]),
-
         ];
 
     all.into_iter() // iterating over (Option<DefId>, Variance)


### PR DESCRIPTION
They have been deprecated for years and there is no trace left of them in the compiler. Also removed `require_owned_box` which is dead code and other small refactorings.