### PR TITLE
Fix drain_filter doctest.

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1969,16 +1969,19 @@ impl<T> Vec<T> {
     /// Using this method is equivalent to the following code:
     ///
     /// ```
-    /// # let some_predicate = |x: &mut i32| { *x == 2 };
-    /// # let mut vec = vec![1, 2, 3, 4, 5];
+    /// # let some_predicate = |x: &mut i32| { *x == 2 || *x == 3 || *x == 6 };
+    /// # let mut vec = vec![1, 2, 3, 4, 5, 6];
     /// let mut i = 0;
     /// while i != vec.len() {
     ///     if some_predicate(&mut vec[i]) {
     ///         let val = vec.remove(i);
     ///         // your code here
+    ///     } else {
+    ///         i += 1;
     ///     }
-    ///     i += 1;
     /// }
+    ///
+    /// # assert_eq!(vec, vec![1, 4, 5]);
     /// ```
     ///
     /// But `drain_filter` is easier to use. `drain_filter` is also more efficient,


### PR DESCRIPTION
Fixes #44499.

Also change some of the hidden logic in the doctest as a regression test; two bugs in the original would now cause test failure.