### PR TITLE
rustdoc: pretty-print Unevaluated expressions in types.

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -473,7 +473,7 @@ impl hir::print::PpAnn for InlinedConst {
     }
 }
 
-fn print_inlined_const(cx: &DocContext, did: DefId) -> String {
+pub fn print_inlined_const(cx: &DocContext, did: DefId) -> String {
     let body = cx.tcx.extern_const_body(did);
     let inlined = InlinedConst {
         nested_bodies: cx.tcx.item_body_nested_bodies(did)

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1793,6 +1793,12 @@ impl Clean<Type> for hir::Ty {
                 let n = cx.tcx.const_eval(param_env.and((def_id, substs))).unwrap();
                 let n = if let ConstVal::Integral(ConstInt::Usize(n)) = n.val {
                     n.to_string()
+                } else if let ConstVal::Unevaluated(def_id, _) = n.val {
+                    if let Some(node_id) = cx.tcx.hir.as_local_node_id(def_id) {
+                        print_const_expr(cx, cx.tcx.hir.body_owned_by(node_id))
+                    } else {
+                        inline::print_inlined_const(cx, def_id)
+                    }
                 } else {
                     format!("{:?}", n)
                 };
@@ -1909,6 +1915,12 @@ impl<'tcx> Clean<Type> for ty::Ty<'tcx> {
             ty::TyArray(ty, n) => {
                 let n = if let ConstVal::Integral(ConstInt::Usize(n)) = n.val {
                     n.to_string()
+                } else if let ConstVal::Unevaluated(def_id, _) = n.val {
+                    if let Some(node_id) = cx.tcx.hir.as_local_node_id(def_id) {
+                        print_const_expr(cx, cx.tcx.hir.body_owned_by(node_id))
+                    } else {
+                        inline::print_inlined_const(cx, def_id)
+                    }
                 } else {
                     format!("{:?}", n)
                 };


### PR DESCRIPTION
Fixes #44555.

r? @nikomatsakis