### PR TITLE
"avoid" is a better word here than "disable"

### DIFF
--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1487,12 +1487,12 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                     self.ir.tcx.lint_node_note(lint::builtin::UNUSED_VARIABLES, id, sp,
                         &format!("variable `{}` is assigned to, but never used",
                                  name),
-                        &format!("to disable this warning, consider using `_{}` instead",
+                        &format!("to avoid this warning, consider using `_{}` instead",
                                  name));
                 } else if name != "self" {
                     self.ir.tcx.lint_node_note(lint::builtin::UNUSED_VARIABLES, id, sp,
                         &format!("unused variable: `{}`", name),
-                        &format!("to disable this warning, consider using `_{}` instead",
+                        &format!("to avoid this warning, consider using `_{}` instead",
                                  name));
                 }
             }

--- a/src/test/ui/span/issue-24690.stderr
+++ b/src/test/ui/span/issue-24690.stderr
@@ -10,7 +10,7 @@ note: lint level defined here
 18 | #![warn(unused)]
    |         ^^^^^^
    = note: #[warn(unused_variables)] implied by #[warn(unused)]
-   = note: to disable this warning, consider using `_theOtherTwo` instead
+   = note: to avoid this warning, consider using `_theOtherTwo` instead
 
 warning: variable `theTwo` should have a snake case name such as `the_two`
   --> $DIR/issue-24690.rs:22:9


### PR DESCRIPTION
You don't "disable" the warning really, you just avoid it (as a conscious action).