### PR TITLE
rustc: Avoid HashStable for DefIndex queries

### DIFF
--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -645,6 +645,18 @@ impl<'a, 'gcx: 'tcx + 'a, 'tcx: 'a> DepNodeParams<'a, 'gcx, 'tcx> for (DefIndex,
     }
 }
 
+impl<'a, 'gcx: 'tcx + 'a, 'tcx: 'a> DepNodeParams<'a, 'gcx, 'tcx> for (DefIndex,) {
+    const CAN_RECONSTRUCT_QUERY_KEY: bool = true;
+
+    fn to_fingerprint(&self, tcx: TyCtxt) -> Fingerprint {
+        tcx.hir.definitions().def_path_hash(self.0).0
+    }
+
+    fn to_debug_str(&self, _tcx: TyCtxt<'a, 'gcx, 'tcx>) -> String {
+        format!("{:?}", *self)
+    }
+}
+
 impl<'a, 'gcx: 'tcx + 'a, 'tcx: 'a> DepNodeParams<'a, 'gcx, 'tcx> for (DefId, DefId) {
     const CAN_RECONSTRUCT_QUERY_KEY: bool = false;
 


### PR DESCRIPTION
I'm not 100% familiar with this trait and this location, but it looks like
there's a default implementation of `DepNodeParams` for anything that implements
`HashStable`, but types like `DefId` which have precalculated hashes bypass this
default implementation for a speedier one.

This commit applies what I believe is the same optimization to `DefIndex`,
looking up the local hash for it rather than going through the full `HashStable`
rigamarole

cc #44575