### PR TITLE
Require +thumb-mode to generate thumb2 code for Android/armv7-a

### DIFF
--- a/src/librustc_back/target/armv7_linux_androideabi.rs
+++ b/src/librustc_back/target/armv7_linux_androideabi.rs
@@ -16,7 +16,7 @@ use target::{Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::android_base::opts();
-    base.features = "+v7,+thumb2,+vfp3,+d16,-neon".to_string();
+    base.features = "+v7,+thumb-mode,+thumb2,+vfp3,+d16,-neon".to_string();
     base.max_atomic_width = Some(64);
     base.pre_link_args
         .get_mut(&LinkerFlavor::Gcc).unwrap().push("-march=armv7-a".to_string());


### PR DESCRIPTION
I am investigating rust's code generation into Gecko by https://bugzilla.mozilla.org/show_bug.cgi?id=1399337.

armv7-linux-androideabi target uses `+v7,+thumb2,+vfp3,+d16,-neon` as target-feature.  But `+thumb2` only doesn't generate thumb2 code.  To generate thumb2 code, it requires `+thumb-mode`.  So we should add it for armv7-linux-androideabi.

r? @alexcrichton