### PR TITLE
Get `allow(unused_mut)` to work on `let` bindings

### DIFF
--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -85,20 +85,12 @@ impl LintPass for UnusedMut {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedMut {
-    fn check_expr(&mut self, cx: &LateContext, e: &hir::Expr) {
-        if let hir::ExprMatch(_, ref arms, _) = e.node {
-            for a in arms {
-                self.check_unused_mut_pat(cx, &a.pats)
-            }
-        }
+    fn check_arm(&mut self, cx: &LateContext, a: &hir::Arm) {
+        self.check_unused_mut_pat(cx, &a.pats)
     }
 
-    fn check_stmt(&mut self, cx: &LateContext, s: &hir::Stmt) {
-        if let hir::StmtDecl(ref d, _) = s.node {
-            if let hir::DeclLocal(ref l) = d.node {
-                self.check_unused_mut_pat(cx, slice::ref_slice(&l.pat));
-            }
-        }
+    fn check_local(&mut self, cx: &LateContext, l: &hir::Local) {
+        self.check_unused_mut_pat(cx, slice::ref_slice(&l.pat));
     }
 
     fn check_fn(&mut self,

--- a/src/test/compile-fail/lint-unused-mut-variables.rs
+++ b/src/test/compile-fail/lint-unused-mut-variables.rs
@@ -110,3 +110,11 @@ fn foo(mut a: isize) {
     let mut a = 3;
     let mut b = vec![2];
 }
+
+// make sure the lint attribute can be turned off on let statements
+#[deny(unused_mut)]
+fn bar() {
+    #[allow(unused_mut)]
+    let mut a = 3;
+    let mut b = vec![2]; //~ ERROR: variable does not need to be mutable
+}


### PR DESCRIPTION
fixes #40491