### PR TITLE
Mention that HashMap::new and HashSet::new do not allocate

### DIFF
--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -588,6 +588,9 @@ impl<K, V, S> HashMap<K, V, S>
 impl<K: Hash + Eq, V> HashMap<K, V, RandomState> {
     /// Creates an empty `HashMap`.
     ///
+    /// The hash map is initially created with a capacity of 0, so it will not allocate until it
+    /// is first inserted into.
+    ///
     /// # Examples
     ///
     /// ```

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -125,6 +125,9 @@ pub struct HashSet<T, S = RandomState> {
 impl<T: Hash + Eq> HashSet<T, RandomState> {
     /// Creates an empty `HashSet`.
     ///
+    /// The hash set is initially created with a capacity of 0, so it will not allocate until it
+    /// is first inserted into.
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
The docs for `HashMap::with_capacity` and `HashSet::with_capacity` already say that
> If `capacity` is 0, the hash map/set will not allocate.

However, the docs for `::new` do not say that the initial capacity is 0, and thus promise that a call to `::new` alone does not allocate. This PR fixes that.