### PR TITLE
rustbuild: Fix test "test rustdoc" invocation

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -1118,10 +1118,11 @@ impl Step for Rustdoc {
         let compiler = builder.compiler(builder.top_stage, self.host);
         let target = compiler.host;
 
-        builder.ensure(RemoteCopyLibs { compiler, target });
-
-        let mut cargo = builder.cargo(compiler, Mode::Librustc, target, test_kind.subcommand());
-        compile::rustc_cargo(build, &compiler, target, &mut cargo);
+        let mut cargo = tool::prepare_tool_cargo(builder,
+                                                 compiler,
+                                                 target,
+                                                 test_kind.subcommand(),
+                                                 "src/tools/rustdoc");
         let _folder = build.fold_output(|| {
             format!("{}_stage{}-rustdoc", test_kind.subcommand(), compiler.stage)
         });

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -94,20 +94,21 @@ impl Step for ToolBuild {
         let _folder = build.fold_output(|| format!("stage{}-{}", compiler.stage, tool));
         println!("Building stage{} tool {} ({})", compiler.stage, tool, target);
 
-        let mut cargo = prepare_tool_cargo(builder, compiler, target, path);
+        let mut cargo = prepare_tool_cargo(builder, compiler, target, "build", path);
         build.run(&mut cargo);
         build.cargo_out(compiler, Mode::Tool, target).join(exe(tool, &compiler.host))
     }
 }
 
-fn prepare_tool_cargo(
+pub fn prepare_tool_cargo(
     builder: &Builder,
     compiler: Compiler,
     target: Interned<String>,
+    command: &'static str,
     path: &'static str,
 ) -> Command {
     let build = builder.build;
-    let mut cargo = builder.cargo(compiler, Mode::Tool, target, "build");
+    let mut cargo = builder.cargo(compiler, Mode::Tool, target, command);
     let dir = build.src.join(path);
     cargo.arg("--manifest-path").arg(dir.join("Cargo.toml"));
 
@@ -283,6 +284,7 @@ impl Step for Rustdoc {
         let mut cargo = prepare_tool_cargo(builder,
                                            build_compiler,
                                            target,
+                                           "build",
                                            "src/tools/rustdoc");
         build.run(&mut cargo);
         // Cargo adds a number of paths to the dylib search path on windows, which results in


### PR DESCRIPTION
Previously it would use the librustc output directory which would cause rustdoc
to get entirely recompiled, whereas the intention is that it uses the
already-compiled artifacts from building rustdoc itself, using the tool output
directory