### PR TITLE
Fix incorrect `into_inner` link in docs.

### DIFF
--- a/src/libstd/sys_common/poison.rs
+++ b/src/libstd/sys_common/poison.rs
@@ -98,7 +98,7 @@ pub enum TryLockError<T> {
 ///
 /// [`Ok`]: ../../std/result/enum.Result.html#variant.Ok
 /// [`Err`]: ../../std/result/enum.Result.html#variant.Err
-/// [`into_inner`]: ../../std/sync/struct.Mutex.html#method.into_inner
+/// [`into_inner`]: ../../std/sync/struct.PoisonError.html#method.into_inner
 #[stable(feature = "rust1", since = "1.0.0")]
 pub type LockResult<Guard> = Result<Guard, PoisonError<Guard>>;
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/42373.