### PR TITLE
Indicate how ChildStd{in,out,err} FDs are closed.

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -153,8 +153,12 @@ impl fmt::Debug for Child {
 ///
 /// This struct is used in the [`stdin`] field on [`Child`].
 ///
+/// When an instance of `ChildStdin` is [dropped], the `ChildStdin`'s underlying
+/// file handle will be closed.
+///
 /// [`Child`]: struct.Child.html
 /// [`stdin`]: struct.Child.html#structfield.stdin
+/// [dropped]: ../ops/trait.Drop.html
 #[stable(feature = "process", since = "1.0.0")]
 pub struct ChildStdin {
     inner: AnonPipe
@@ -196,8 +200,12 @@ impl fmt::Debug for ChildStdin {
 ///
 /// This struct is used in the [`stdout`] field on [`Child`].
 ///
+/// When an instance of `ChildStdout` is [dropped], the `ChildStdout`'s
+/// underlying file handle will be closed.
+///
 /// [`Child`]: struct.Child.html
 /// [`stdout`]: struct.Child.html#structfield.stdout
+/// [dropped]: ../ops/trait.Drop.html
 #[stable(feature = "process", since = "1.0.0")]
 pub struct ChildStdout {
     inner: AnonPipe
@@ -239,8 +247,12 @@ impl fmt::Debug for ChildStdout {
 ///
 /// This struct is used in the [`stderr`] field on [`Child`].
 ///
+/// When an instance of `ChildStderr` is [dropped], the `ChildStderr`'s
+/// underlying file handle will be closed.
+///
 /// [`Child`]: struct.Child.html
 /// [`stderr`]: struct.Child.html#structfield.stderr
+/// [dropped]: ../ops/trait.Drop.html
 #[stable(feature = "process", since = "1.0.0")]
 pub struct ChildStderr {
     inner: AnonPipe

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -549,8 +549,7 @@ impl Command {
         self
     }
 
-    /// Configuration for the child process's standard input (stdin) handle
-    /// (file descriptor 0).
+    /// Configuration for the child process's standard input (stdin) handle.
     ///
     /// # Examples
     ///
@@ -570,8 +569,7 @@ impl Command {
         self
     }
 
-    /// Configuration for the child process's standard output (stdout) handle
-    /// (file descriptor 1).
+    /// Configuration for the child process's standard output (stdout) handle.
     ///
     /// # Examples
     ///
@@ -591,8 +589,7 @@ impl Command {
         self
     }
 
-    /// Configuration for the child process's standard error (stderr) handle
-    /// (file descriptor 2).
+    /// Configuration for the child process's standard error (stderr) handle.
     ///
     /// # Examples
     ///

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -157,7 +157,8 @@ impl fmt::Debug for Child {
 /// This struct is used in the [`stdin`] field on [`Child`].
 ///
 /// When an instance of `ChildStdin` is [dropped], the `ChildStdin`'s underlying
-/// file handle will be closed.
+/// file handle will be closed. If the child process was blocked on input prior
+/// to being dropped, it will become unblocked after dropping.
 ///
 /// [`Child`]: struct.Child.html
 /// [`stdin`]: struct.Child.html#structfield.stdin

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -106,15 +106,18 @@ use sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 pub struct Child {
     handle: imp::Process,
 
-    /// The handle for writing to the child's stdin, if it has been captured
+    /// The handle for writing to the child's standard input (stdin), if it has
+    /// been captured.
     #[stable(feature = "process", since = "1.0.0")]
     pub stdin: Option<ChildStdin>,
 
-    /// The handle for reading from the child's stdout, if it has been captured
+    /// The handle for reading from the child's standard output (stdout), if it
+    /// has been captured.
     #[stable(feature = "process", since = "1.0.0")]
     pub stdout: Option<ChildStdout>,
 
-    /// The handle for reading from the child's stderr, if it has been captured
+    /// The handle for reading from the child's standard error (stderr), if it
+    /// has been captured.
     #[stable(feature = "process", since = "1.0.0")]
     pub stderr: Option<ChildStderr>,
 }
@@ -149,7 +152,7 @@ impl fmt::Debug for Child {
     }
 }
 
-/// A handle to a child process's stdin.
+/// A handle to a child process's standard input (stdin).
 ///
 /// This struct is used in the [`stdin`] field on [`Child`].
 ///
@@ -196,7 +199,7 @@ impl fmt::Debug for ChildStdin {
     }
 }
 
-/// A handle to a child process's stdout.
+/// A handle to a child process's standard output (stdout).
 ///
 /// This struct is used in the [`stdout`] field on [`Child`].
 ///
@@ -546,7 +549,8 @@ impl Command {
         self
     }
 
-    /// Configuration for the child process's stdin handle (file descriptor 0).
+    /// Configuration for the child process's standard input (stdin) handle
+    /// (file descriptor 0).
     ///
     /// # Examples
     ///
@@ -566,7 +570,8 @@ impl Command {
         self
     }
 
-    /// Configuration for the child process's stdout handle (file descriptor 1).
+    /// Configuration for the child process's standard output (stdout) handle
+    /// (file descriptor 1).
     ///
     /// # Examples
     ///
@@ -586,7 +591,8 @@ impl Command {
         self
     }
 
-    /// Configuration for the child process's stderr handle (file descriptor 2).
+    /// Configuration for the child process's standard error (stderr) handle
+    /// (file descriptor 2).
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/41452.