### PR TITLE
Skip passing /natvis to lld-link until supported.

### DIFF
--- a/src/librustc_trans/back/linker.rs
+++ b/src/librustc_trans/back/linker.rs
@@ -498,6 +498,18 @@ impl<'a> Linker for MsvcLinker<'a> {
         let sysroot = self.sess.sysroot();
         let natvis_dir_path = sysroot.join("lib\\rustlib\\etc");
         if let Ok(natvis_dir) = fs::read_dir(&natvis_dir_path) {
+            // LLVM 5.0.0's lld-link frontend doesn't yet recognize, and chokes
+            // on, the /NATVIS:... flags.  LLVM 6 (or earlier) should at worst ignore
+            // them, eventually mooting this workaround, per this landed patch:
+            // https://github.com/llvm-mirror/lld/commit/27b9c4285364d8d76bb43839daa100
+            if let Some(ref linker_path) = self.sess.opts.cg.linker {
+                if let Some(linker_name) = Path::new(&linker_path).file_stem() {
+                    if linker_name.to_str().unwrap().to_lowercase() == "lld-link" {
+                        self.sess.warn("not embedding natvis: lld-link may not support the flag");
+                        return;
+                    }
+                }
+            }
             for entry in natvis_dir {
                 match entry {
                     Ok(entry) => {


### PR DESCRIPTION
### Overview

Teaching rustc about MSVC's undocumented linker flag, /NATVIS, broke rustc's compatability with LLVM's `lld-link` frontend, as it does not recognize the flag.  This pull request works around the problem by excluding `lld-link` by name.  @retep998 discovered this regression.

### Possible Issues

- Other linkers that try to be compatible with the MSVC linker flavor may also be broken and in need of workarounds.
- Warning about the workaround may be overkill for a minor reduction in debug functionality.
- Depending on how long this workaround sticks around, it may eventually be preferred to version check `lld-link` instead of assuming all versions are incompatible.

### Relevant issues
* Broke in https://github.com/rust-lang/rust/pull/43221 Embed MSVC .natvis files into .pdbs and mangle debuginfo for &str, *T, and [T].
* LLVM patched in https://github.com/llvm-mirror/lld/commit/27b9c4285364d8d76bb43839daa100c2f80f8329 to ignore the flag instead of erroring.

r? @michaelwoerister