### PR TITLE
compiletest: print the correct basename of the src dir

### DIFF
--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -517,7 +517,7 @@ pub fn make_test_name(config: &Config, testpaths: &TestPaths) -> test::TestName 
     //
     //    run-pass/foo/bar/baz.rs
     let path =
-        PathBuf::from(config.mode.to_string())
+        PathBuf::from(config.src_base.file_name().unwrap())
         .join(&testpaths.relative_dir)
         .join(&testpaths.file.file_name().unwrap());
     test::DynTestName(format!("[{}] {}", config.mode, path.display()))

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2174,8 +2174,6 @@ actual:\n\
     }
 
     fn run_ui_test(&self) {
-        println!("ui: {}", self.testpaths.file.display());
-
         let proc_res = self.compile_test();
 
         let expected_stderr_path = self.expected_output_path("stderr");


### PR DESCRIPTION
See <https://github.com/laumann/compiletest-rs/issues/76>.

Fixes #40712