### PR TITLE
ci: Disable rustc debug assertions on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
         SCCACHE_ERROR_LOG=/tmp/sccache.log
         MACOSX_DEPLOYMENT_TARGET=10.7
         NO_LLVM_ASSERTIONS=1
+        NO_DEBUG_ASSERTIONS=1
       os: osx
       osx_image: xcode7
 
@@ -48,6 +49,7 @@ matrix:
         MACOSX_DEPLOYMENT_TARGET=10.8
         MACOSX_STD_DEPLOYMENT_TARGET=10.7
         NO_LLVM_ASSERTIONS=1
+        NO_DEBUG_ASSERTIONS=1
       os: osx
       osx_image: xcode8.2
     - env: >
@@ -59,6 +61,7 @@ matrix:
         MACOSX_DEPLOYMENT_TARGET=10.8
         MACOSX_STD_DEPLOYMENT_TARGET=10.7
         NO_LLVM_ASSERTIONS=1
+        NO_DEBUG_ASSERTIONS=1
       os: osx
       osx_image: xcode8.2
 
@@ -77,6 +80,7 @@ matrix:
         SCCACHE_ERROR_LOG=/tmp/sccache.log
         MACOSX_DEPLOYMENT_TARGET=10.7
         NO_LLVM_ASSERTIONS=1
+        NO_DEBUG_ASSERTIONS=1
       os: osx
       osx_image: xcode7
     - env: >
@@ -88,6 +92,7 @@ matrix:
         SCCACHE_ERROR_LOG=/tmp/sccache.log
         MACOSX_DEPLOYMENT_TARGET=10.7
         NO_LLVM_ASSERTIONS=1
+        NO_DEBUG_ASSERTIONS=1
       os: osx
       osx_image: xcode7
 

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -52,7 +52,11 @@ if [ "$DEPLOY$DEPLOY_ALT" != "" ]; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-llvm-assertions"
   fi
 else
-  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-debug-assertions"
+  # We almost always want debug assertions enabled, but sometimes this takes too
+  # long for too little benefit, so we just turn them off.
+  if [ "$NO_DEBUG_ASSERTIONS" = "" ]; then
+    RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-debug-assertions"
+  fi
 
   # In general we always want to run tests with LLVM assertions enabled, but not
   # all platforms currently support that, so we have an option to disable.


### PR DESCRIPTION
This commit disables debug assertions for OSX in an effort to improve cycle time
on OSX. It looks like #44610 didn't shave off quite as much time as desired so
let's see how much this helps.