### PR TITLE
Refer to types using the local identifier

### DIFF
--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -176,7 +176,7 @@ pub struct LifetimeDef {
 }
 
 /// A "Path" is essentially Rust's notion of a name; for instance:
-/// std::cmp::PartialEq  .  It's represented as a sequence of identifiers,
+/// `std::cmp::PartialEq`.  It's represented as a sequence of identifiers,
 /// along with a bunch of supporting information.
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash)]
 pub struct Path {

--- a/src/librustc/middle/const_val.rs
+++ b/src/librustc/middle/const_val.rs
@@ -76,6 +76,10 @@ impl<'tcx> ConstVal<'tcx> {
             _ => None
         }
     }
+
+    pub fn to_usize(&self) -> Option<usize> {
+        self.to_const_int().and_then(|i| i.to_usize())
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1179,6 +1179,10 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         self.all_crate_nums(LOCAL_CRATE)
     }
 
+    pub fn cstore(&self) -> &CrateStore {
+        self.cstore
+    }
+
     pub fn def_key(self, id: DefId) -> hir_map::DefKey {
         if id.is_local() {
             self.hir.def_key(id)

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1469,4 +1469,10 @@ pub struct Const<'tcx> {
     pub val: ConstVal<'tcx>,
 }
 
+impl<'tcx> Const<'tcx> {
+    pub fn usize_val(&self) -> usize {
+        self.val.to_usize().unwrap_or(0)
+    }
+}
+
 impl<'tcx> serialize::UseSpecializedDecodable for &'tcx Const<'tcx> {}

--- a/src/librustc_const_math/int.rs
+++ b/src/librustc_const_math/int.rs
@@ -188,6 +188,15 @@ impl ConstInt {
         })
     }
 
+    /// Converts the value to a `usize` if it's in the range 0...std::usize::MAX
+    pub fn to_usize(&self) -> Option<usize> {
+        self.to_u128().and_then(|v| if v <= usize::max_value() as u128 {
+            Some(v as usize)
+        } else {
+            None
+        })
+    }
+
     /// Converts the value to a `u128` if it's in the range 0...std::u128::MAX
     pub fn to_u128(&self) -> Option<u128> {
         match *self {

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -36,7 +36,7 @@ pub struct SubDiagnostic {
     pub render_span: Option<RenderSpan>,
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct DiagnosticStyledString(pub Vec<StringPart>);
 
 impl DiagnosticStyledString {
@@ -62,7 +62,7 @@ impl DiagnosticStyledString {
     }
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum StringPart {
     Normal(String),
     Highlighted(String),

--- a/src/test/compile-fail/bad-const-type.rs
+++ b/src/test/compile-fail/bad-const-type.rs
@@ -10,7 +10,7 @@
 
 static i: String = 10;
 //~^ ERROR mismatched types
-//~| expected type `std::string::String`
+//~| expected type `String`
 //~| found type `{integer}`
 //~| expected struct `std::string::String`, found integral variable
 fn main() { println!("{}", i); }

--- a/src/test/compile-fail/cross-borrow-trait.rs
+++ b/src/test/compile-fail/cross-borrow-trait.rs
@@ -19,5 +19,5 @@ pub fn main() {
     let x: Box<Trait> = Box::new(Foo);
     let _y: &Trait = x; //~ ERROR E0308
                         //~| expected type `&Trait`
-                        //~| found type `std::boxed::Box<Trait>`
+                        //~| found type `Box<Trait>`
 }

--- a/src/test/compile-fail/destructure-trait-ref.rs
+++ b/src/test/compile-fail/destructure-trait-ref.rs
@@ -51,5 +51,5 @@ fn main() {
     let box box x = box 1isize as Box<T>;
     //~^ ERROR mismatched types
     //~| expected type `T`
-    //~| found type `std::boxed::Box<_>`
+    //~| found type `Box<_>`
 }

--- a/src/test/compile-fail/fn-trait-formatting.rs
+++ b/src/test/compile-fail/fn-trait-formatting.rs
@@ -16,15 +16,15 @@ fn main() {
     let _: () = (box |_: isize| {}) as Box<FnOnce(isize)>;
     //~^ ERROR mismatched types
     //~| expected type `()`
-    //~| found type `std::boxed::Box<std::ops::FnOnce(isize)>`
+    //~| found type `Box<std::ops::FnOnce(isize)>`
     let _: () = (box |_: isize, isize| {}) as Box<Fn(isize, isize)>;
     //~^ ERROR mismatched types
     //~| expected type `()`
-    //~| found type `std::boxed::Box<std::ops::Fn(isize, isize)>`
+    //~| found type `Box<std::ops::Fn(isize, isize)>`
     let _: () = (box || -> isize { unimplemented!() }) as Box<FnMut() -> isize>;
     //~^ ERROR mismatched types
     //~| expected type `()`
-    //~| found type `std::boxed::Box<std::ops::FnMut() -> isize>`
+    //~| found type `Box<std::ops::FnMut() -> isize>`
 
     needs_fn(1);
     //~^ ERROR : std::ops::Fn<(isize,)>`

--- a/src/test/compile-fail/fully-qualified-type-name4.rs
+++ b/src/test/compile-fail/fully-qualified-type-name4.rs
@@ -15,7 +15,7 @@ use std::option::Option;
 fn bar(x: usize) -> Option<usize> {
     return x;
     //~^ ERROR mismatched types
-    //~| expected type `std::option::Option<usize>`
+    //~| expected type `Option<usize>`
     //~| found type `usize`
     //~| expected enum `std::option::Option`, found usize
 }

--- a/src/test/compile-fail/generic-type-params-name-repr.rs
+++ b/src/test/compile-fail/generic-type-params-name-repr.rs
@@ -36,12 +36,12 @@ fn main() {
     // Including cases where the default is using previous type params.
     let _: HashMap<String, isize> = ();
     //~^ ERROR mismatched types
-    //~| expected type `HashMap<std::string::String, isize>`
+    //~| expected type `HashMap<String, isize>`
     //~| found type `()`
     //~| expected struct `HashMap`, found ()
     let _: HashMap<String, isize, Hash<String>> = ();
     //~^ ERROR mismatched types
-    //~| expected type `HashMap<std::string::String, isize>`
+    //~| expected type `HashMap<String, isize>`
     //~| found type `()`
     //~| expected struct `HashMap`, found ()
 

--- a/src/test/compile-fail/issue-13466.rs
+++ b/src/test/compile-fail/issue-13466.rs
@@ -17,14 +17,14 @@ pub fn main() {
     let _x: usize = match Some(1) {
         Ok(u) => u,
         //~^ ERROR mismatched types
-        //~| expected type `std::option::Option<{integer}>`
-        //~| found type `std::result::Result<_, _>`
+        //~| expected type `Option<{integer}>`
+        //~| found type `Result<_, _>`
         //~| expected enum `std::option::Option`, found enum `std::result::Result`
 
         Err(e) => panic!(e)
         //~^ ERROR mismatched types
-        //~| expected type `std::option::Option<{integer}>`
-        //~| found type `std::result::Result<_, _>`
+        //~| expected type `Option<{integer}>`
+        //~| found type `Result<_, _>`
         //~| expected enum `std::option::Option`, found enum `std::result::Result`
     };
 }

--- a/src/test/compile-fail/issue-15783.rs
+++ b/src/test/compile-fail/issue-15783.rs
@@ -17,8 +17,8 @@ fn main() {
     let x = Some(&[name]);
     let msg = foo(x);
 //~^ ERROR mismatched types
-//~| expected type `std::option::Option<&[&str]>`
-//~| found type `std::option::Option<&[&str; 1]>`
+//~| expected type `Option<&[&str]>`
+//~| found type `Option<&[&str; 1]>`
 //~| expected slice, found array of 1 elements
     assert_eq!(msg, 3);
 }

--- a/src/test/compile-fail/issue-3680.rs
+++ b/src/test/compile-fail/issue-3680.rs
@@ -12,8 +12,8 @@ fn main() {
     match None {
         Err(_) => ()
         //~^ ERROR mismatched types
-        //~| expected type `std::option::Option<_>`
-        //~| found type `std::result::Result<_, _>`
+        //~| expected type `Option<_>`
+        //~| found type `Result<_, _>`
         //~| expected enum `std::option::Option`, found enum `std::result::Result`
     }
 }

--- a/src/test/compile-fail/issue-40749.rs
+++ b/src/test/compile-fail/issue-40749.rs
@@ -12,5 +12,5 @@ fn main() {
     [0; ..10];
     //~^ ERROR mismatched types
     //~| expected type `usize`
-    //~| found type `std::ops::RangeTo<{integer}>`
+    //~| found type `RangeTo<{integer}>`
 }

--- a/src/test/compile-fail/issue-5100.rs
+++ b/src/test/compile-fail/issue-5100.rs
@@ -43,7 +43,7 @@ fn main() {
         box (true, false) => ()
 //~^ ERROR mismatched types
 //~| expected type `(bool, bool)`
-//~| found type `std::boxed::Box<_>`
+//~| found type `Box<_>`
     }
 
     match (true, false) {

--- a/src/test/compile-fail/issue-7061.rs
+++ b/src/test/compile-fail/issue-7061.rs
@@ -13,7 +13,7 @@ struct BarStruct;
 impl<'a> BarStruct {
     fn foo(&'a mut self) -> Box<BarStruct> { self }
     //~^ ERROR mismatched types
-    //~| expected type `std::boxed::Box<BarStruct>`
+    //~| expected type `Box<BarStruct>`
     //~| found type `&'a mut BarStruct`
 }
 

--- a/src/test/compile-fail/issue-7092.rs
+++ b/src/test/compile-fail/issue-7092.rs
@@ -16,7 +16,7 @@ fn foo(x: Whatever) {
         Some(field) =>
 //~^ ERROR mismatched types
 //~| expected type `Whatever`
-//~| found type `std::option::Option<_>`
+//~| found type `Option<_>`
 //~| expected enum `Whatever`, found enum `std::option::Option`
             field.access(),
     }

--- a/src/test/compile-fail/issue-7867.rs
+++ b/src/test/compile-fail/issue-7867.rs
@@ -25,13 +25,13 @@ fn main() {
     match &Some(42) {
         Some(x) => (),
         //~^ ERROR mismatched types
-        //~| expected type `&std::option::Option<{integer}>`
-        //~| found type `std::option::Option<_>`
+        //~| expected type `&Option<{integer}>`
+        //~| found type `Option<_>`
         //~| expected reference, found enum `std::option::Option`
         None => ()
         //~^ ERROR mismatched types
-        //~| expected type `&std::option::Option<{integer}>`
-        //~| found type `std::option::Option<_>`
+        //~| expected type `&Option<{integer}>`
+        //~| found type `Option<_>`
         //~| expected reference, found enum `std::option::Option`
     }
 }

--- a/src/test/compile-fail/noexporttypeexe.rs
+++ b/src/test/compile-fail/noexporttypeexe.rs
@@ -20,6 +20,6 @@ fn main() {
   let x: isize = noexporttypelib::foo();
     //~^ ERROR mismatched types
     //~| expected type `isize`
-    //~| found type `std::option::Option<isize>`
+    //~| found type `Option<isize>`
     //~| expected isize, found enum `std::option::Option`
 }

--- a/src/test/compile-fail/occurs-check-2.rs
+++ b/src/test/compile-fail/occurs-check-2.rs
@@ -17,6 +17,6 @@ fn main() {
     f = box g;
     //~^  ERROR mismatched types
     //~| expected type `_`
-    //~| found type `std::boxed::Box<_>`
+    //~| found type `Box<_>`
     //~| cyclic type of infinite size
 }

--- a/src/test/compile-fail/occurs-check.rs
+++ b/src/test/compile-fail/occurs-check.rs
@@ -15,6 +15,6 @@ fn main() {
     f = box f;
     //~^ ERROR mismatched types
     //~| expected type `_`
-    //~| found type `std::boxed::Box<_>`
+    //~| found type `Box<_>`
     //~| cyclic type of infinite size
 }

--- a/src/test/compile-fail/regions-infer-paramd-indirect.rs
+++ b/src/test/compile-fail/regions-infer-paramd-indirect.rs
@@ -32,8 +32,8 @@ impl<'a> set_f<'a> for c<'a> {
     fn set_f_bad(&mut self, b: Box<b>) {
         self.f = b;
         //~^ ERROR mismatched types
-        //~| expected type `std::boxed::Box<std::boxed::Box<&'a isize>>`
-        //~| found type `std::boxed::Box<std::boxed::Box<&isize>>`
+        //~| expected type `Box<Box<&'a isize>>`
+        //~| found type `Box<Box<&isize>>`
         //~| lifetime mismatch
     }
 }

--- a/src/test/compile-fail/tag-that-dare-not-speak-its-name.rs
+++ b/src/test/compile-fail/tag-that-dare-not-speak-its-name.rs
@@ -22,6 +22,6 @@ fn main() {
     let x : char = last(y);
     //~^ ERROR mismatched types
     //~| expected type `char`
-    //~| found type `std::option::Option<_>`
+    //~| found type `Option<_>`
     //~| expected char, found enum `std::option::Option`
 }

--- a/src/test/compile-fail/terr-sorts.rs
+++ b/src/test/compile-fail/terr-sorts.rs
@@ -20,7 +20,7 @@ fn want_foo(f: foo) {}
 fn have_bar(b: bar) {
     want_foo(b); //~  ERROR mismatched types
                  //~| expected type `foo`
-                 //~| found type `std::boxed::Box<foo>`
+                 //~| found type `Box<foo>`
 }
 
 fn main() {}

--- a/src/test/compile-fail/type-mismatch-same-crate-name.rs
+++ b/src/test/compile-fail/type-mismatch-same-crate-name.rs
@@ -33,7 +33,7 @@ fn main() {
         //~^ ERROR mismatched types
         //~| Perhaps two different versions of crate `crate_a1`
         //~| expected trait `main::a::Bar`
-        //~| expected type `std::boxed::Box<main::a::Bar + 'static>`
-        //~| found type `std::boxed::Box<main::a::Bar>`
+        //~| expected type `Box<main::a::Bar + 'static>`
+        //~| found type `Box<main::a::Bar>`
     }
 }

--- a/src/test/ui/block-result/consider-removing-last-semi.stderr
+++ b/src/test/ui/block-result/consider-removing-last-semi.stderr
@@ -9,7 +9,7 @@ error[E0308]: mismatched types
 14 | | }
    | |_^ expected struct `std::string::String`, found ()
    |
-   = note: expected type `std::string::String`
+   = note: expected type `String`
               found type `()`
 
 error[E0308]: mismatched types
@@ -23,7 +23,7 @@ error[E0308]: mismatched types
 19 | | }
    | |_^ expected struct `std::string::String`, found ()
    |
-   = note: expected type `std::string::String`
+   = note: expected type `String`
               found type `()`
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/block-result/issue-13428.stderr
+++ b/src/test/ui/block-result/issue-13428.stderr
@@ -12,7 +12,7 @@ error[E0308]: mismatched types
 19 | | }
    | |_^ expected struct `std::string::String`, found ()
    |
-   = note: expected type `std::string::String`
+   = note: expected type `String`
               found type `()`
 
 error[E0308]: mismatched types
@@ -26,7 +26,7 @@ error[E0308]: mismatched types
 24 | | }
    | |_^ expected struct `std::string::String`, found ()
    |
-   = note: expected type `std::string::String`
+   = note: expected type `String`
               found type `()`
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coercion-missing-tail-expected-type.stderr
+++ b/src/test/ui/coercion-missing-tail-expected-type.stderr
@@ -21,7 +21,7 @@ error[E0308]: mismatched types
 19 | | }
    | |_^ expected enum `std::result::Result`, found ()
    |
-   = note: expected type `std::result::Result<u8, u64>`
+   = note: expected type `Result<u8, u64>`
               found type `()`
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/lifetime-errors/ex2d-push-inference-variable-2.stderr
+++ b/src/test/ui/lifetime-errors/ex2d-push-inference-variable-2.stderr
@@ -27,7 +27,7 @@ note: but, the lifetime must be valid for the lifetime 'b as defined on the func
 18 | |     a.push(b);
 19 | | }
    | |_^
-note: ...so that expression is assignable (expected &mut std::vec::Vec<Ref<'_, i32>>, found &mut std::vec::Vec<Ref<'b, i32>>)
+note: ...so that expression is assignable (expected &mut Vec<Ref<'_, i32>>, found &mut Vec<Ref<'b, i32>>)
   --> $DIR/ex2d-push-inference-variable-2.rs:16:33
    |
 16 |     let a: &mut Vec<Ref<i32>> = x;

--- a/src/test/ui/lifetime-errors/ex2e-push-inference-variable-3.stderr
+++ b/src/test/ui/lifetime-errors/ex2e-push-inference-variable-3.stderr
@@ -27,7 +27,7 @@ note: but, the lifetime must be valid for the lifetime 'b as defined on the func
 18 | |     Vec::push(a, b);
 19 | | }
    | |_^
-note: ...so that expression is assignable (expected &mut std::vec::Vec<Ref<'_, i32>>, found &mut std::vec::Vec<Ref<'b, i32>>)
+note: ...so that expression is assignable (expected &mut Vec<Ref<'_, i32>>, found &mut Vec<Ref<'b, i32>>)
   --> $DIR/ex2e-push-inference-variable-3.rs:16:33
    |
 16 |     let a: &mut Vec<Ref<i32>> = x;

--- a/src/test/ui/local-ident.rs
+++ b/src/test/ui/local-ident.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,13 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test that we use fully-qualified type names in error messages.
+use Mod1::S;
+use Mod2::*;
 
 fn main() {
-    let x: Option<usize>;
-    x = 5;
-    //~^ ERROR mismatched types
-    //~| expected type `Option<usize>`
-    //~| found type `{integer}`
-    //~| expected enum `std::option::Option`, found integral variable
+    let x: X = S;
+    let y: Option<usize> = Ok(2);
+}
+
+mod Mod1 {
+    pub struct S;
+}
+
+mod Mod2 {
+    pub struct X;
 }

--- a/src/test/ui/local-ident.stderr
+++ b/src/test/ui/local-ident.stderr
@@ -1,0 +1,24 @@
+error[E0308]: mismatched types
+  --> $DIR/local-ident.rs:15:16
+   |
+15 |     let x: X = S;
+   |                ^ expected struct `Mod2::X`, found struct `Mod1::S`
+   |
+   = note: expected type `X`
+              found type `S`
+
+error[E0308]: mismatched types
+  --> $DIR/local-ident.rs:16:28
+   |
+16 |     let y: Option<usize> = Ok(2);
+   |                            ^^^^^ expected enum `std::option::Option`, found enum `std::result::Result`
+   |
+   = note: expected type `Option<usize>`
+              found type `Result<{integer}, _>`
+   = help: here are some functions which might fulfill your needs:
+           - .err()
+           - .ok()
+           - .unwrap_err()
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/mismatched_types/abridged.stderr
+++ b/src/test/ui/mismatched_types/abridged.stderr
@@ -7,7 +7,7 @@ error[E0308]: mismatched types
    |     ^^^^^^^^^^^^^^^^^^^^ expected struct `Foo`, found enum `std::option::Option`
    |
    = note: expected type `Foo`
-              found type `std::option::Option<Foo>`
+              found type `Option<Foo>`
 
 error[E0308]: mismatched types
   --> $DIR/abridged.rs:30:5
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
    |     ^^^^^^^^^^^^^^^^^ expected struct `Foo`, found enum `std::result::Result`
    |
    = note: expected type `Foo`
-              found type `std::result::Result<Foo, _>`
+              found type `Result<Foo, _>`
 
 error[E0308]: mismatched types
   --> $DIR/abridged.rs:34:5
@@ -28,7 +28,7 @@ error[E0308]: mismatched types
 34 |     Foo { bar: 1 }
    |     ^^^^^^^^^^^^^^ expected enum `std::option::Option`, found struct `Foo`
    |
-   = note: expected type `std::option::Option<Foo>`
+   = note: expected type `Option<Foo>`
               found type `Foo`
 
 error[E0308]: mismatched types
@@ -39,7 +39,7 @@ error[E0308]: mismatched types
 38 |     Foo { bar: 1 }
    |     ^^^^^^^^^^^^^^ expected enum `std::result::Result`, found struct `Foo`
    |
-   = note: expected type `std::result::Result<Foo, Bar>`
+   = note: expected type `Result<Foo, Bar>`
               found type `Foo`
 
 error[E0308]: mismatched types
@@ -51,7 +51,7 @@ error[E0308]: mismatched types
 49 |     x
    |     ^ expected struct `std::string::String`, found integral variable
    |
-   = note: expected type `X<X<_, std::string::String>, std::string::String>`
+   = note: expected type `X<X<_, String>, String>`
               found type `X<X<_, {integer}>, {integer}>`
 
 error[E0308]: mismatched types
@@ -63,7 +63,7 @@ error[E0308]: mismatched types
 60 |     x
    |     ^ expected struct `std::string::String`, found integral variable
    |
-   = note: expected type `X<X<_, std::string::String>, _>`
+   = note: expected type `X<X<_, String>, _>`
               found type `X<X<_, {integer}>, _>`
 
 error: aborting due to 6 previous errors

--- a/src/test/ui/mismatched_types/trait-bounds-cant-coerce.stderr
+++ b/src/test/ui/mismatched_types/trait-bounds-cant-coerce.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 24 |     a(x); //~ ERROR mismatched types [E0308]
    |       ^ expected trait `Foo + std::marker::Send`, found trait `Foo`
    |
-   = note: expected type `std::boxed::Box<Foo + std::marker::Send + 'static>`
-              found type `std::boxed::Box<Foo + 'static>`
+   = note: expected type `Box<Foo + std::marker::Send + 'static>`
+              found type `Box<Foo + 'static>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/resolve/token-error-correct-3.stderr
+++ b/src/test/ui/resolve/token-error-correct-3.stderr
@@ -40,7 +40,7 @@ error[E0308]: mismatched types
    |             expected (), found enum `std::result::Result`
    |
    = note: expected type `()`
-              found type `std::result::Result<bool, std::io::Error>`
+              found type `Result<bool, Error>`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/span/coerce-suggestions.stderr
+++ b/src/test/ui/span/coerce-suggestions.stderr
@@ -5,7 +5,7 @@ error[E0308]: mismatched types
    |                    ^^^^^^^^^^^^^ expected usize, found struct `std::string::String`
    |
    = note: expected type `usize`
-              found type `std::string::String`
+              found type `String`
    = help: here are some functions which might fulfill your needs:
            - .capacity()
            - .len()
@@ -17,7 +17,7 @@ error[E0308]: mismatched types
    |                   ^^^^^^^^^^^^^ expected &str, found struct `std::string::String`
    |
    = note: expected type `&str`
-              found type `std::string::String`
+              found type `String`
    = help: try with `&String::new()`
 
 error[E0308]: mismatched types
@@ -26,8 +26,8 @@ error[E0308]: mismatched types
 30 |     test(&y);
    |          ^^ types differ in mutability
    |
-   = note: expected type `&mut std::string::String`
-              found type `&std::string::String`
+   = note: expected type `&mut String`
+              found type `&String`
 
 error[E0308]: mismatched types
   --> $DIR/coerce-suggestions.rs:35:11
@@ -36,7 +36,7 @@ error[E0308]: mismatched types
    |           ^^ types differ in mutability
    |
    = note: expected type `&mut i32`
-              found type `&std::string::String`
+              found type `&String`
 
 error[E0308]: mismatched types
   --> $DIR/coerce-suggestions.rs:41:9
@@ -45,7 +45,7 @@ error[E0308]: mismatched types
    |         ^^^^^ cyclic type of infinite size
    |
    = note: expected type `_`
-              found type `std::boxed::Box<_>`
+              found type `Box<_>`
 
 error[E0308]: mismatched types
   --> $DIR/coerce-suggestions.rs:48:9
@@ -53,8 +53,8 @@ error[E0308]: mismatched types
 48 |     s = format!("foo");
    |         ^^^^^^^^^^^^^^ expected mutable reference, found struct `std::string::String`
    |
-   = note: expected type `&mut std::string::String`
-              found type `std::string::String`
+   = note: expected type `&mut String`
+              found type `String`
    = help: try with `&mut format!("foo")`
    = note: this error originates in a macro outside of the current crate
 

--- a/src/test/ui/span/issue-33884.stderr
+++ b/src/test/ui/span/issue-33884.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 16 |     stream.write_fmt(format!("message received"))
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `std::fmt::Arguments`, found struct `std::string::String`
    |
-   = note: expected type `std::fmt::Arguments<'_>`
-              found type `std::string::String`
+   = note: expected type `Arguments<'_>`
+              found type `String`
    = note: this error originates in a macro outside of the current crate
 
 error: aborting due to previous error

--- a/src/test/ui/suggestions/issue-43420-no-over-suggest.stderr
+++ b/src/test/ui/suggestions/issue-43420-no-over-suggest.stderr
@@ -5,7 +5,7 @@ error[E0308]: mismatched types
    |         ^^ expected slice, found struct `std::vec::Vec`
    |
    = note: expected type `&[u16]`
-              found type `&std::vec::Vec<u8>`
+              found type `&Vec<u8>`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
On type errors, refer to types using the locally available name when
they have been imported into scope instead of the fully qualified path.

```
error[E0308]: mismatched types
 --> file.rs:7:24
  |
7 |     let y: Option<X> = Ok(());
  |                        ^^^^^^ expected enum `std::option::Option`, found enum `std::result::Result`
  |
  = note: expected type `Option<X>`
             found type `Result<(), _>`
  = help: here are some functions which might fulfill your needs:
          - .err()
          - .unwrap_err()
```

Re: #21934.