### PR TITLE
Move type_needs_drop to tyctxt

### DIFF
--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1243,6 +1243,10 @@ impl<'a, 'tcx> TyCtxt<'a, 'tcx, 'tcx> {
     {
         self.cstore.encode_metadata(self, link_meta, reachable)
     }
+
+    pub fn type_needs_drop(self, ty: Ty<'tcx>) -> bool {
+        ty.needs_drop(self, ty::ParamEnv::empty(traits::Reveal::All))
+    }
 }
 
 impl<'gcx: 'tcx, 'tcx> GlobalCtxt<'gcx> {

--- a/src/librustc_trans/monomorphize.rs
+++ b/src/librustc_trans/monomorphize.rs
@@ -187,7 +187,7 @@ pub fn resolve<'a, 'tcx>(
             _ => {
                 if Some(def_id) == tcx.lang_items().drop_in_place_fn() {
                     let ty = substs.type_at(0);
-                    if type_needs_drop(tcx, ty) {
+                    if tcx.type_needs_drop(ty) {
                         debug!(" => nontrivial drop glue");
                         ty::InstanceDef::DropGlue(def_id, Some(ty))
                     } else {


### PR DESCRIPTION
as groundwork for #44389 I'm gradually moving stuff out of trans to librustc.

the end goal is moving https://github.com/rust-lang/rust/blob/master/src/librustc_trans/monomorphize.rs#L162-L208 to librustc 