### PR TITLE
Add clippy to `toolstate.toml`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,23 +330,11 @@ it can be found
 Currently building Rust will also build the following external projects:
 
 * [clippy](https://github.com/rust-lang-nursery/rust-clippy)
+* [miri](https://github.com/solson/miri)
 
 If your changes break one of these projects, you need to fix them by opening
 a pull request against the broken project. When you have opened a pull request,
-you can point the submodule at your pull request by calling
-
-```
-git fetch origin pull/$id_of_your_pr/head:my_pr
-git checkout my_pr
-```
-
-within the submodule's directory. Don't forget to also add your changes with
-
-```
-git add path/to/submodule
-```
-
-outside the submodule.
+you can disable the tool via `src/tools/toolstate.toml`.
 
 It can also be more convenient during development to set `submodules = false`
 in the `config.toml` to prevent `x.py` from resetting to the original branch.

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -254,7 +254,7 @@ impl<'a> Builder<'a> {
             Kind::Test => describe!(check::Tidy, check::Bootstrap, check::DefaultCompiletest,
                 check::HostCompiletest, check::Crate, check::CrateLibrustc, check::Rustdoc,
                 check::Linkcheck, check::Cargotest, check::Cargo, check::Rls, check::Docs,
-                check::ErrorIndex, check::Distcheck, check::Rustfmt, check::Miri),
+                check::ErrorIndex, check::Distcheck, check::Rustfmt, check::Miri, check::Clippy),
             Kind::Bench => describe!(check::Crate, check::CrateLibrustc),
             Kind::Doc => describe!(doc::UnstableBook, doc::UnstableBookGen, doc::TheBook,
                 doc::Standalone, doc::Std, doc::Test, doc::Rustc, doc::ErrorIndex, doc::Nomicon,

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -378,7 +378,7 @@ pub struct Clippy {
 
 impl Step for Clippy {
     type Output = PathBuf;
-    const DEFAULT: bool = false;
+    const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
@@ -405,7 +405,7 @@ impl Step for Clippy {
             tool: "clippy",
             mode: Mode::Librustc,
             path: "src/tools/clippy",
-            expectation: BuildExpectation::None,
+            expectation: builder.build.config.toolstate.clippy.passes(ToolState::Compiling),
         })
     }
 }

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -378,7 +378,7 @@ pub struct Clippy {
 
 impl Step for Clippy {
     type Output = PathBuf;
-    const DEFAULT: bool = true;
+    const DEFAULT: bool = false;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {

--- a/src/bootstrap/toolstate.rs
+++ b/src/bootstrap/toolstate.rs
@@ -45,4 +45,5 @@ impl Default for ToolState {
 /// This is created from `toolstate.toml`.
 pub struct ToolStates {
     pub miri: ToolState,
+    pub clippy: ToolState,
 }

--- a/src/tools/toolstate.toml
+++ b/src/tools/toolstate.toml
@@ -10,15 +10,20 @@
 # configures whether the tool is included in the Rust distribution.
 #
 # If a tool was working before your PR but is broken now, consider
-# updating the tool within your PR. How to do that is described in
+# opening a PR against the tool so that it works with your changes.
+# If the tool stops compiling, change its state to `Broken`. If it
+# still builds, change it to `Compiling`.
+# How to do that is described in
 # "CONTRIBUTING.md#External Dependencies". If the effort required is not
 # warranted (e.g. due to the tool abusing some API that you changed, and
-# fixing the tool would mean a significant refactoring), you can disable
-# the tool here, by changing its state to `Broken`. Remember to ping
-# the tool authors if you do not fix their tool, so they can proactively
-# fix it, instead of being surprised by the breakage.
+# fixing the tool would mean a significant refactoring) remember to ping
+# the tool authors, so they can fix it, instead of being surprised by the
+# breakage.
 #
 # Each tool has a list of people to ping
 
 # ping @oli-obk @RalfJung @eddyb
 miri = "Testing"
+
+# ping @Manishearth @llogiq @mcarton @oli-obk
+clippy = "Broken"


### PR DESCRIPTION
r? @alexcrichton 

cc @Manishearth 

I have no idea how to get clippy working... it needs proc macros, and I think I did everything right (I just did what the cargo step is doing), but it's not working:

```
error: libproc_macro-6210e4b46662ec28.so: cannot open shared object file: No such file or directory
  --> src/tools/clippy/clippy_lints/src/lib.rs:47:1
   |
47 | extern crate serde_derive;
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^

error: libproc_macro-6210e4b46662ec28.so: cannot open shared object file: No such file or directory
  --> src/tools/clippy/clippy_lints/src/lib.rs:47:1
   |
47 | extern crate serde_derive;
   | ^
```

It's especially weird since it used to work

Anyway. Fixing it can be left for a future PR, this one adds it to CI, but marks it as "broken"