### PR TITLE
[libstd_unicode] Expose UnicodeVersion type

### DIFF
--- a/src/libstd_unicode/char.rs
+++ b/src/libstd_unicode/char.rs
@@ -47,7 +47,7 @@ pub use core::char::CharTryFromError;
 #[unstable(feature = "decode_utf8", issue = "33906")]
 pub use core::char::{DecodeUtf8, decode_utf8};
 #[unstable(feature = "unicode", issue = "27783")]
-pub use tables::UNICODE_VERSION;
+pub use tables::{UnicodeVersion, UNICODE_VERSION};
 
 /// Returns an iterator that yields the lowercase equivalent of a `char`.
 ///

--- a/src/test/run-pass/char_unicode.rs
+++ b/src/test/run-pass/char_unicode.rs
@@ -1,0 +1,22 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+#![feature(unicode)]
+
+
+/// Tests access to the internal Unicode Version type and value.
+pub fn main() {
+    check(std::char::UNICODE_VERSION);
+}
+
+pub fn check(unicode_version: std::char::UnicodeVersion) {
+    assert!(unicode_version.major >= 10);
+}


### PR DESCRIPTION
In <https://github.com/rust-lang/rust/pull/42998>, we added an
uninstantiable type for the internal `UNICODE_VERSION` value,
`UnicodeVersion`, but it was not made public to the outside of the
crate, resulting in the value becoming less useful. Here we make the
type accessible from the outside.

Also add a run-pass test to make sure the type and value can be accessed
as intended.