### PR TITLE
fix an incorrect assertion in the doc example for `std::io::copy`

### DIFF
--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -40,9 +40,10 @@ use mem;
 ///
 /// io::copy(&mut reader, &mut writer)?;
 ///
-/// assert_eq!(reader, &writer[..]);
+/// assert_eq!(&b"hello"[..], &writer[..]);
 /// # Ok(())
 /// # }
+/// # foo().unwrap();
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn copy<R: ?Sized, W: ?Sized>(reader: &mut R, writer: &mut W) -> io::Result<u64>


### PR DESCRIPTION
I think this wasn't caught by CI because the `foo` wrapper function was only defined and not called. This seems to be the norm for doc examples that define a `foo` function. Is that on purpose?