### PR TITLE
Make `-Z borrowck-mir` imply that `EndRegion`'s should be emitted.

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -411,7 +411,8 @@ impl Session {
     }
     pub fn emit_end_regions(&self) -> bool {
         self.opts.debugging_opts.emit_end_regions ||
-            (self.opts.debugging_opts.mir_emit_validate > 0)
+            (self.opts.debugging_opts.mir_emit_validate > 0) ||
+            self.opts.debugging_opts.borrowck_mir
     }
     pub fn lto(&self) -> bool {
         self.opts.cg.lto


### PR DESCRIPTION
Before this change, the `-Z borrowck-mir` flag is useless if you do not also pass `-Z emit-end-regions`.

So, in the same spirit as f2892ad281cb11421ebae741d698e0af14d3ecf6, make `-Z borrowck-mir` also emit `EndRegion` statements. (This will hopefully avoid some initial speed bumps for new-comers helping out with NLL.)