### PR TITLE
make compiler_builtins_shim version number match the one in src/compiler_builtins

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "core 0.0.0",
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1986,7 +1986,7 @@ dependencies = [
  "alloc_system 0.0.0",
  "build_helper 0.1.0",
  "collections 0.0.0",
- "compiler_builtins 0.0.0",
+ "compiler_builtins 0.1.0",
  "core 0.0.0",
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.0.0",

--- a/src/rustc/compiler_builtins_shim/Cargo.toml
+++ b/src/rustc/compiler_builtins_shim/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "compiler_builtins"
 authors = ["The Rust Project Developers"]
-version = "0.0.0"
+version = "0.1.0"
 build = "../../libcompiler_builtins/build.rs"
 
 [lib]


### PR DESCRIPTION
This fixes a Xargo issue: <https://github.com/japaric/xargo/issues/167>.