### PR TITLE
Catch IOError in bootstrap.py when loading config.toml

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -682,7 +682,7 @@ def bootstrap():
     try:
         with open(args.config or 'config.toml') as config:
             build.config_toml = config.read()
-    except OSError:
+    except (OSError, IOError):
         pass
 
     if '\nverbose = 2' in build.config_toml:


### PR DESCRIPTION
When I pulled this repo and tried to build using the command in the readme, I got an error about a missing `config.toml`.

If config.toml doesn't exist, then an `IOError` will be raised the `with open(...)` line. Prior to e788fa7b6cf07860eb0ff3e90ff32fc4f9d26cae, this was caught because the `except` clause didn't specify what exceptions it caught, so both `IOError` and `OSError` were caught.

First time contributing, so please let me know if I'm doing anything wrong.