### PR TITLE
Less confusing placeholder when RefCell is exclusively borrowed

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1700,8 +1700,18 @@ impl<T: ?Sized + Debug> Debug for RefCell<T> {
                     .finish()
             }
             Err(_) => {
+                // The RefCell is mutably borrowed so we can't look at its value
+                // here. Show a placeholder instead.
+                struct BorrowedPlaceholder;
+
+                impl Debug for BorrowedPlaceholder {
+                    fn fmt(&self, f: &mut Formatter) -> Result {
+                        f.write_str("<borrowed>")
+                    }
+                }
+
                 f.debug_struct("RefCell")
-                    .field("value", &"<borrowed>")
+                    .field("value", &BorrowedPlaceholder)
                     .finish()
             }
         }

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -13,6 +13,7 @@
 #![allow(unused_features)]
 #![feature(box_syntax)]
 
+use std::cell::RefCell;
 use std::fmt::{self, Write};
 use std::usize;
 
@@ -240,6 +241,8 @@ pub fn main() {
     // test that trailing commas are acceptable
     format!("{}", "test",);
     format!("{foo}", foo="test",);
+
+    test_refcell();
 }
 
 // Basic test to make sure that we can invoke the `write!` macro with an
@@ -318,4 +321,13 @@ fn test_once() {
     }
     assert_eq!(format!("{0} {0} {0} {a} {a} {a}", foo(), a=foo()),
                "1 1 1 2 2 2".to_string());
+}
+
+fn test_refcell() {
+    let refcell = RefCell::new(5);
+    assert_eq!(format!("{:?}", refcell), "RefCell { value: 5 }");
+    let borrow = refcell.borrow_mut();
+    assert_eq!(format!("{:?}", refcell), "RefCell { value: <borrowed> }");
+    drop(borrow);
+    assert_eq!(format!("{:?}", refcell), "RefCell { value: 5 }");
 }


### PR DESCRIPTION
Based on ExpHP's comment in [*RefCell.borrow_mut get strange result*](https://users.rust-lang.org/t/refcell-borrow-mut-get-strange-result/12994):

> it would perhaps be nicer if it didn't put something that could be misinterpreted as a valid string value

The previous Debug implementation would show:

    RefCell { value: "<borrowed>" }

The new one is:

    RefCell { value: <borrowed> }