### PR TITLE
Implement more traits for guard types

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -181,6 +181,7 @@
 
 use cmp::Ordering;
 use fmt::{self, Debug, Display};
+use hash::{Hash, Hasher};
 use marker::Unsize;
 use mem;
 use ops::{Deref, DerefMut, CoerceUnsized};
@@ -872,7 +873,7 @@ impl<T: ?Sized + Eq> Eq for RefCell<T> {}
 impl<T: ?Sized + PartialOrd> PartialOrd for RefCell<T> {
     #[inline]
     fn partial_cmp(&self, other: &RefCell<T>) -> Option<Ordering> {
-        self.borrow().partial_cmp(&*other.borrow())
+        self.borrow().partial_cmp(&other.borrow())
     }
 
     #[inline]
@@ -900,7 +901,7 @@ impl<T: ?Sized + PartialOrd> PartialOrd for RefCell<T> {
 impl<T: ?Sized + Ord> Ord for RefCell<T> {
     #[inline]
     fn cmp(&self, other: &RefCell<T>) -> Ordering {
-        self.borrow().cmp(&*other.borrow())
+        self.borrow().cmp(&other.borrow())
     }
 }
 
@@ -1032,6 +1033,61 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for Ref<'a, T> {
     }
 }
 
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + Hash> Hash for Ref<'a, T> {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.value.hash(state);
+    }
+}
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + PartialEq> PartialEq for Ref<'a, T> {
+    #[inline]
+    fn eq(&self, other: &Ref<T>) -> bool {
+        self.value == other.value
+    }
+}
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + Eq> Eq for Ref<'a, T> { }
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + Ord> Ord for Ref<'a, T> {
+    #[inline]
+    fn cmp(&self, other: &Ref<T>) -> Ordering {
+        self.value.cmp(other.value)
+    }
+}
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + PartialOrd> PartialOrd for Ref<'a, T> {
+    #[inline]
+    fn partial_cmp(&self, other: &Ref<T>) -> Option<Ordering> {
+        self.value.partial_cmp(&other.value)
+    }
+
+    #[inline]
+    fn lt(&self, other: &Ref<T>) -> bool {
+        self.value < other.value
+    }
+
+    #[inline]
+    fn le(&self, other: &Ref<T>) -> bool {
+        self.value <= other.value
+    }
+
+    #[inline]
+    fn gt(&self, other: &Ref<T>) -> bool {
+        self.value > other.value
+    }
+
+    #[inline]
+    fn ge(&self, other: &Ref<T>) -> bool {
+        self.value >= other.value
+    }
+}
+
 impl<'b, T: ?Sized> RefMut<'b, T> {
     /// Make a new `RefMut` for a component of the borrowed data, e.g. an enum
     /// variant.
@@ -1128,6 +1184,61 @@ impl<'b, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<RefMut<'b, U>> for RefM
 impl<'a, T: ?Sized + fmt::Display> fmt::Display for RefMut<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.value.fmt(f)
+    }
+}
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + Hash> Hash for RefMut<'a, T> {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.value.hash(state);
+    }
+}
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + PartialEq> PartialEq for RefMut<'a, T> {
+    #[inline]
+    fn eq(&self, other: &RefMut<T>) -> bool {
+        self.value == other.value
+    }
+}
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + Eq> Eq for RefMut<'a, T> { }
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + Ord> Ord for RefMut<'a, T> {
+    #[inline]
+    fn cmp(&self, other: &RefMut<T>) -> Ordering {
+        self.value.cmp(&other.value)
+    }
+}
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + PartialOrd> PartialOrd for RefMut<'a, T> {
+    #[inline]
+    fn partial_cmp(&self, other: &RefMut<T>) -> Option<Ordering> {
+        self.value.partial_cmp(&other.value)
+    }
+
+    #[inline]
+    fn lt(&self, other: &RefMut<T>) -> bool {
+        *self.value < *other.value
+    }
+
+    #[inline]
+    fn le(&self, other: &RefMut<T>) -> bool {
+        *self.value <= *other.value
+    }
+
+    #[inline]
+    fn gt(&self, other: &RefMut<T>) -> bool {
+        *self.value > *other.value
+    }
+
+    #[inline]
+    fn ge(&self, other: &RefMut<T>) -> bool {
+        *self.value >= *other.value
     }
 }
 

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1033,7 +1033,7 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for Ref<'a, T> {
     }
 }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + Hash> Hash for Ref<'a, T> {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -1041,7 +1041,7 @@ impl<'a, T: ?Sized + Hash> Hash for Ref<'a, T> {
     }
 }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + PartialEq> PartialEq for Ref<'a, T> {
     #[inline]
     fn eq(&self, other: &Ref<T>) -> bool {
@@ -1049,10 +1049,10 @@ impl<'a, T: ?Sized + PartialEq> PartialEq for Ref<'a, T> {
     }
 }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + Eq> Eq for Ref<'a, T> { }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + Ord> Ord for Ref<'a, T> {
     #[inline]
     fn cmp(&self, other: &Ref<T>) -> Ordering {
@@ -1060,7 +1060,7 @@ impl<'a, T: ?Sized + Ord> Ord for Ref<'a, T> {
     }
 }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + PartialOrd> PartialOrd for Ref<'a, T> {
     #[inline]
     fn partial_cmp(&self, other: &Ref<T>) -> Option<Ordering> {
@@ -1187,7 +1187,7 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for RefMut<'a, T> {
     }
 }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + Hash> Hash for RefMut<'a, T> {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -1195,7 +1195,7 @@ impl<'a, T: ?Sized + Hash> Hash for RefMut<'a, T> {
     }
 }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + PartialEq> PartialEq for RefMut<'a, T> {
     #[inline]
     fn eq(&self, other: &RefMut<T>) -> bool {
@@ -1203,10 +1203,10 @@ impl<'a, T: ?Sized + PartialEq> PartialEq for RefMut<'a, T> {
     }
 }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + Eq> Eq for RefMut<'a, T> { }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + Ord> Ord for RefMut<'a, T> {
     #[inline]
     fn cmp(&self, other: &RefMut<T>) -> Ordering {
@@ -1214,7 +1214,7 @@ impl<'a, T: ?Sized + Ord> Ord for RefMut<'a, T> {
     }
 }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + PartialOrd> PartialOrd for RefMut<'a, T> {
     #[inline]
     fn partial_cmp(&self, other: &RefMut<T>) -> Option<Ordering> {

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -9,7 +9,9 @@
 // except according to those terms.
 
 use cell::UnsafeCell;
+use cmp::{Ordering};
 use fmt;
+use hash::{Hash, Hasher};
 use mem;
 use ops::{Deref, DerefMut};
 use ptr;
@@ -444,6 +446,61 @@ impl<'a, T: ?Sized + fmt::Debug> fmt::Debug for MutexGuard<'a, T> {
 impl<'a, T: ?Sized + fmt::Display> fmt::Display for MutexGuard<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         (**self).fmt(f)
+    }
+}
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + Hash> Hash for MutexGuard<'a, T> {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        (**self).hash(state);
+    }
+}
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + PartialEq> PartialEq for MutexGuard<'a, T> {
+    #[inline]
+    fn eq(&self, other: &MutexGuard<T>) -> bool {
+        **self == **other
+    }
+}
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + Eq> Eq for MutexGuard<'a, T> { }
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + Ord> Ord for MutexGuard<'a, T> {
+    #[inline]
+    fn cmp(&self, other: &MutexGuard<T>) -> Ordering {
+        self.deref().cmp(&other.deref())
+    }
+}
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + PartialOrd> PartialOrd for MutexGuard<'a, T> {
+    #[inline]
+    fn partial_cmp(&self, other: &MutexGuard<T>) -> Option<Ordering> {
+        self.deref().partial_cmp(&other.deref())
+    }
+
+    #[inline]
+    fn lt(&self, other: &MutexGuard<T>) -> bool {
+        **self < **other
+    }
+
+    #[inline]
+    fn le(&self, other: &MutexGuard<T>) -> bool {
+        **self <= **other
+    }
+
+    #[inline]
+    fn gt(&self, other: &MutexGuard<T>) -> bool {
+        **self > **other
+    }
+
+    #[inline]
+    fn ge(&self, other: &MutexGuard<T>) -> bool {
+        **self >= **other
     }
 }
 

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -449,7 +449,7 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for MutexGuard<'a, T> {
     }
 }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + Hash> Hash for MutexGuard<'a, T> {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -457,7 +457,7 @@ impl<'a, T: ?Sized + Hash> Hash for MutexGuard<'a, T> {
     }
 }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + PartialEq> PartialEq for MutexGuard<'a, T> {
     #[inline]
     fn eq(&self, other: &MutexGuard<T>) -> bool {
@@ -465,10 +465,10 @@ impl<'a, T: ?Sized + PartialEq> PartialEq for MutexGuard<'a, T> {
     }
 }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + Eq> Eq for MutexGuard<'a, T> { }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + Ord> Ord for MutexGuard<'a, T> {
     #[inline]
     fn cmp(&self, other: &MutexGuard<T>) -> Ordering {
@@ -476,7 +476,7 @@ impl<'a, T: ?Sized + Ord> Ord for MutexGuard<'a, T> {
     }
 }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + PartialOrd> PartialOrd for MutexGuard<'a, T> {
     #[inline]
     fn partial_cmp(&self, other: &MutexGuard<T>) -> Option<Ordering> {

--- a/src/libstd/sync/rwlock.rs
+++ b/src/libstd/sync/rwlock.rs
@@ -379,7 +379,7 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for RwLockReadGuard<'a, T> {
     }
 }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + Hash> Hash for RwLockReadGuard<'a, T> {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -387,7 +387,7 @@ impl<'a, T: ?Sized + Hash> Hash for RwLockReadGuard<'a, T> {
     }
 }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + PartialEq> PartialEq for RwLockReadGuard<'a, T> {
     #[inline]
     fn eq(&self, other: &RwLockReadGuard<T>) -> bool {
@@ -395,10 +395,10 @@ impl<'a, T: ?Sized + PartialEq> PartialEq for RwLockReadGuard<'a, T> {
     }
 }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + Eq> Eq for RwLockReadGuard<'a, T> { }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + Ord> Ord for RwLockReadGuard<'a, T> {
     #[inline]
     fn cmp(&self, other: &RwLockReadGuard<T>) -> Ordering {
@@ -406,7 +406,7 @@ impl<'a, T: ?Sized + Ord> Ord for RwLockReadGuard<'a, T> {
     }
 }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + PartialOrd> PartialOrd for RwLockReadGuard<'a, T> {
     #[inline]
     fn partial_cmp(&self, other: &RwLockReadGuard<T>) -> Option<Ordering> {
@@ -450,7 +450,7 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for RwLockWriteGuard<'a, T> {
     }
 }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + Hash> Hash for RwLockWriteGuard<'a, T> {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -458,7 +458,7 @@ impl<'a, T: ?Sized + Hash> Hash for RwLockWriteGuard<'a, T> {
     }
 }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + PartialEq> PartialEq for RwLockWriteGuard<'a, T> {
     #[inline]
     fn eq(&self, other: &RwLockWriteGuard<T>) -> bool {
@@ -466,10 +466,10 @@ impl<'a, T: ?Sized + PartialEq> PartialEq for RwLockWriteGuard<'a, T> {
     }
 }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + Eq> Eq for RwLockWriteGuard<'a, T> { }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + Ord> Ord for RwLockWriteGuard<'a, T> {
     #[inline]
     fn cmp(&self, other: &RwLockWriteGuard<T>) -> Ordering {
@@ -477,7 +477,7 @@ impl<'a, T: ?Sized + Ord> Ord for RwLockWriteGuard<'a, T> {
     }
 }
 
-#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+#[stable(feature = "std_guard_impls_ext", since = "1.22.0")]
 impl<'a, T: ?Sized + PartialOrd> PartialOrd for RwLockWriteGuard<'a, T> {
     #[inline]
     fn partial_cmp(&self, other: &RwLockWriteGuard<T>) -> Option<Ordering> {

--- a/src/libstd/sync/rwlock.rs
+++ b/src/libstd/sync/rwlock.rs
@@ -9,7 +9,9 @@
 // except according to those terms.
 
 use cell::UnsafeCell;
+use cmp::Ordering;
 use fmt;
+use hash::{Hash, Hasher};
 use marker;
 use mem;
 use ops::{Deref, DerefMut};
@@ -377,6 +379,61 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for RwLockReadGuard<'a, T> {
     }
 }
 
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + Hash> Hash for RwLockReadGuard<'a, T> {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        (**self).hash(state);
+    }
+}
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + PartialEq> PartialEq for RwLockReadGuard<'a, T> {
+    #[inline]
+    fn eq(&self, other: &RwLockReadGuard<T>) -> bool {
+        **self == **other
+    }
+}
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + Eq> Eq for RwLockReadGuard<'a, T> { }
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + Ord> Ord for RwLockReadGuard<'a, T> {
+    #[inline]
+    fn cmp(&self, other: &RwLockReadGuard<T>) -> Ordering {
+        self.deref().cmp(&other.deref())
+    }
+}
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + PartialOrd> PartialOrd for RwLockReadGuard<'a, T> {
+    #[inline]
+    fn partial_cmp(&self, other: &RwLockReadGuard<T>) -> Option<Ordering> {
+        self.deref().partial_cmp(&other.deref())
+    }
+
+    #[inline]
+    fn lt(&self, other: &RwLockReadGuard<T>) -> bool {
+        **self < **other
+    }
+
+    #[inline]
+    fn le(&self, other: &RwLockReadGuard<T>) -> bool {
+        **self <= **other
+    }
+
+    #[inline]
+    fn gt(&self, other: &RwLockReadGuard<T>) -> bool {
+        **self > **other
+    }
+
+    #[inline]
+    fn ge(&self, other: &RwLockReadGuard<T>) -> bool {
+        **self >= **other
+    }
+}
+
 #[stable(feature = "std_debug", since = "1.16.0")]
 impl<'a, T: fmt::Debug> fmt::Debug for RwLockWriteGuard<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -390,6 +447,61 @@ impl<'a, T: fmt::Debug> fmt::Debug for RwLockWriteGuard<'a, T> {
 impl<'a, T: ?Sized + fmt::Display> fmt::Display for RwLockWriteGuard<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         (**self).fmt(f)
+    }
+}
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + Hash> Hash for RwLockWriteGuard<'a, T> {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        (**self).hash(state);
+    }
+}
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + PartialEq> PartialEq for RwLockWriteGuard<'a, T> {
+    #[inline]
+    fn eq(&self, other: &RwLockWriteGuard<T>) -> bool {
+        **self == **other
+    }
+}
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + Eq> Eq for RwLockWriteGuard<'a, T> { }
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + Ord> Ord for RwLockWriteGuard<'a, T> {
+    #[inline]
+    fn cmp(&self, other: &RwLockWriteGuard<T>) -> Ordering {
+        self.deref().cmp(&other.deref())
+    }
+}
+
+#[stable(feature = "std_guard_impls_ext", since = "1.23.0")]
+impl<'a, T: ?Sized + PartialOrd> PartialOrd for RwLockWriteGuard<'a, T> {
+    #[inline]
+    fn partial_cmp(&self, other: &RwLockWriteGuard<T>) -> Option<Ordering> {
+        self.deref().partial_cmp(&other.deref())
+    }
+
+    #[inline]
+    fn lt(&self, other: &RwLockWriteGuard<T>) -> bool {
+        **self < **other
+    }
+
+    #[inline]
+    fn le(&self, other: &RwLockWriteGuard<T>) -> bool {
+        **self <= **other
+    }
+
+    #[inline]
+    fn gt(&self, other: &RwLockWriteGuard<T>) -> bool {
+        **self > **other
+    }
+
+    #[inline]
+    fn ge(&self, other: &RwLockWriteGuard<T>) -> bool {
+        **self >= **other
     }
 }
 


### PR DESCRIPTION
Implements `Hash`, `PartialEq`, `Eq`, `PartialOrd`, and `Ord` for
`Ref`, `RefMut`, `MutexGuard`, `RwLockReadGuard`, `RwLockWriteGuard`.

Fixes #24372

Bit of a rust noob, quick questions:

Preferred style wrt `x.deref()` or `*x`? I went with `*` unless it was going to be something too weird like `&**`.

`hash::Hash` or `Hash`? I see that `fmt::Display` and `fmt::Debug` are used for the Display and Debug traits, should I prefer that syntax instead?

I saw all the other implementations use `#[inline]` and I just followed suit, any rules of thumb here, or is it just "use inline everywhere always?"

I didn't see anything in the issue that said exactly what types needed these traits, so I just went with all the types that got `Debug` and `Display` in this commit: 14df54989aecb437e9cf6f3e066553cfbc979e26, any more types that need these traits?