### PR TITLE
Improve diagnostics when attempting to match tuple enum variant with struct pattern

### DIFF
--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -787,11 +787,14 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             for field in variant.fields
                 .iter()
                 .filter(|field| !used_fields.contains_key(&field.name)) {
-                struct_span_err!(tcx.sess, span, E0027,
-                                "pattern does not mention field `{}`",
-                                field.name)
-                                .span_label(span, format!("missing field `{}`", field.name))
-                                .emit();
+                let mut diag = struct_span_err!(tcx.sess, span, E0027,
+                                                "pattern does not mention field `{}`",
+                                                field.name);
+                diag.span_label(span, format!("missing field `{}`", field.name));
+                if variant.ctor_kind == CtorKind::Fn {
+                    diag.note("trying to match a tuple variant with a struct variant pattern");
+                }
+                diag.emit();
             }
         }
     }

--- a/src/test/ui/type-check/issue-41314.rs
+++ b/src/test/ui/type-check/issue-41314.rs
@@ -1,0 +1,19 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum X {
+    Y(u32)
+}
+
+fn main() {
+    match X::Y(0) {
+        X::Y { number } => {}
+    }
+}

--- a/src/test/ui/type-check/issue-41314.stderr
+++ b/src/test/ui/type-check/issue-41314.stderr
@@ -1,0 +1,16 @@
+error[E0026]: variant `X::Y` does not have a field named `number`
+  --> $DIR/issue-41314.rs:17:16
+   |
+17 |         X::Y { number } => {}
+   |                ^^^^^^ variant `X::Y` does not have field `number`
+
+error[E0027]: pattern does not mention field `0`
+  --> $DIR/issue-41314.rs:17:9
+   |
+17 |         X::Y { number } => {}
+   |         ^^^^^^^^^^^^^^^ missing field `0`
+   |
+   = note: trying to match a tuple variant with a struct variant pattern
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Adds an extra note as below to explain that a tuple pattern was probably intended.

```
error[E0026]: variant `X::Y` does not have a field named `data`
  --> src/main.rs:18:16
   |
18 |         X::Y { data } => println!("The data is {}", data)
   |                ^^^^ variant `X::Y` does not have field `data`

error[E0027]: pattern does not mention field `0`
  --> src/main.rs:18:9
   |
18 |         X::Y { data } => println!("The data is {}", data)
   |         ^^^^^^^^^^^^^ missing field `0`
   |
   = note: trying to match a tuple variant with a struct variant pattern
```

Fixes #41314.