### PR TITLE
Fix warning position in rustdoc code blocks

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -815,7 +815,7 @@ span.since {
 
 .information {
 	position: absolute;
-	left: -1px;
+	left: -20px;
 	margin-top: 7px;
 }
 


### PR DESCRIPTION
Before:

<img width="1440" alt="screen shot 2017-09-23 at 14 07 08" src="https://user-images.githubusercontent.com/3050060/30773382-b9649288-a06f-11e7-94ec-faa3c3ed999b.png">

After:

<img width="1440" alt="screen shot 2017-09-23 at 14 58 31" src="https://user-images.githubusercontent.com/3050060/30773384-bdfc9f3e-a06f-11e7-9030-9fb8a5308668.png">

r? @QuietMisdreavus 