### PR TITLE
Make sure to clear out the stageN-{rustc,std,tools} directories.

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -612,7 +612,7 @@ impl<'a> Builder<'a> {
         // Set this for all builds to make sure doc builds also get it.
         cargo.env("CFG_RELEASE_CHANNEL", &self.build.config.channel);
 
-        if self.is_verbose() {
+        if self.is_very_verbose() {
             cargo.arg("-v");
         }
         // FIXME: cargo bench does not accept `--release`

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1073,10 +1073,12 @@ impl Step for Rls {
         t!(fs::create_dir_all(&image));
 
         // Prepare the image directory
+        // We expect RLS to build, because we've exited this step above if tool
+        // state for RLS isn't testing.
         let rls = builder.ensure(tool::Rls {
             compiler: builder.compiler(stage, build.build),
             target
-        });
+        }).expect("Rls to build: toolstate is testing");
         install(&rls, &image.join("bin"), 0o755);
         let doc = image.join("share/doc/rls");
         install(&src.join("README.md"), &doc, 0o644);


### PR DESCRIPTION
We copy built tool binaries into a dedicated directory to avoid deleting them,
stageN-tools-bin.  These aren't ever cleared out by code, since there should be
no reason to do so, and we'll simply overwrite them as necessary.

When clearing out the stageN-{std,rustc,tools} directories, make sure to delete
both Cargo directories -- per-target and build scripts. This ensures that
changing libstd doesn't cause problems due to build scripts not being rebuilt,
even though they should be.

Fixes https://github.com/rust-lang/rust/issues/44739.