### PR TITLE
Fix capacity comparison in reserve

### DIFF
--- a/src/liballoc/vec_deque.rs
+++ b/src/liballoc/vec_deque.rs
@@ -558,7 +558,7 @@ impl<T> VecDeque<T> {
             .and_then(|needed_cap| needed_cap.checked_next_power_of_two())
             .expect("capacity overflow");
 
-        if new_cap > self.capacity() {
+        if new_cap > old_cap {
             self.buf.reserve_exact(used_cap, new_cap - used_cap);
             unsafe {
                 self.handle_cap_increase(old_cap);

--- a/src/test/run-pass-valgrind/issue-44800.rs
+++ b/src/test/run-pass-valgrind/issue-44800.rs
@@ -1,0 +1,25 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(global_allocator, alloc_system, allocator_api)]
+extern crate alloc_system;
+
+use std::collections::VecDeque;
+use alloc_system::System;
+
+#[global_allocator]
+static ALLOCATOR: System = System;
+
+fn main() {
+    let mut deque = VecDeque::with_capacity(32);
+    deque.push_front(0);
+    deque.reserve(31);
+    deque.push_back(0);
+}


### PR DESCRIPTION
You can otherwise end up in a situation where you don't actually resize
but still call into handle_cap_increase which then corrupts head/tail.

Closes #44800

Not totally sure the right way to write a test for this - there are some debug asserts the old bad behavior will hit but we don't build the stdlib with debug assertions by default.

r? @Gankro 
