### PR TITLE
MIR-borrowck: Adding notes to E0506

### DIFF
--- a/src/librustc_mir/borrow_check.rs
+++ b/src/librustc_mir/borrow_check.rs
@@ -412,7 +412,7 @@ impl<'c, 'b, 'a: 'b+'c, 'gcx, 'tcx: 'a> MirBorrowckCtxt<'c, 'b, 'a, 'gcx, 'tcx> 
                             WriteKind::StorageDead |
                             WriteKind::Mutate =>
                                 this.report_illegal_mutation_of_borrowed(
-                                    context, lvalue_span),
+                                    context, lvalue_span, borrow),
                             WriteKind::Move =>
                                 this.report_move_out_while_borrowed(
                                     context, lvalue_span, borrow),
@@ -975,7 +975,10 @@ impl<'c, 'b, 'a: 'b+'c, 'gcx, 'tcx: 'a> MirBorrowckCtxt<'c, 'b, 'a, 'gcx, 'tcx> 
         err.emit();
     }
 
-    fn report_illegal_mutation_of_borrowed(&mut self, _: Context, (lvalue, span): (&Lvalue, Span)) {
+    fn report_illegal_mutation_of_borrowed(&mut self,
+                                           _: Context,
+                                           (lvalue, span): (&Lvalue, Span),
+                                           loan: &BorrowData) {
         let mut err = self.tcx.cannot_assign_to_borrowed(
             span, &self.describe_lvalue(lvalue), Origin::Mir);
         // FIXME: add span labels for borrow and assignment points

--- a/src/librustc_mir/borrow_check.rs
+++ b/src/librustc_mir/borrow_check.rs
@@ -979,9 +979,15 @@ impl<'c, 'b, 'a: 'b+'c, 'gcx, 'tcx: 'a> MirBorrowckCtxt<'c, 'b, 'a, 'gcx, 'tcx> 
                                            _: Context,
                                            (lvalue, span): (&Lvalue, Span),
                                            loan: &BorrowData) {
+        let describe_lvalue = self.describe_lvalue(lvalue);
+        let borrow_span = self.retrieve_borrow_span(loan);
+
         let mut err = self.tcx.cannot_assign_to_borrowed(
             span, &self.describe_lvalue(lvalue), Origin::Mir);
-        // FIXME: add span labels for borrow and assignment points
+
+        err.span_label(borrow_span, format!("borrow of `{}` occurs here", describe_lvalue));
+        err.span_label(span, format!("assignment to borrowed `{}` occurs here", describe_lvalue));
+
         err.emit();
     }
 

--- a/src/test/compile-fail/E0506.rs
+++ b/src/test/compile-fail/E0506.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// revisions: ast mir
+//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+
 struct FancyNum {
     num: u8,
 }
@@ -15,7 +18,9 @@ struct FancyNum {
 fn main() {
     let mut fancy_num = FancyNum { num: 5 };
     let fancy_ref = &fancy_num;
-    fancy_num = FancyNum { num: 6 }; //~ ERROR E0506
+    fancy_num = FancyNum { num: 6 }; //[ast]~ ERROR E0506
+                                     //[mir]~^ ERROR (Mir) [E0506]
+                                     //[mir]~| ERROR (Ast) [E0506]
 
     println!("Num: {}, Ref: {}", fancy_num.num, fancy_ref.num);
 }

--- a/src/test/compile-fail/borrowck/borrowck-assign-comp.rs
+++ b/src/test/compile-fail/borrowck/borrowck-assign-comp.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// revisions: ast mir
+//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+
 struct point { x: isize, y: isize }
 
 fn a() {
@@ -17,7 +20,9 @@ fn a() {
     // This assignment is illegal because the field x is not
     // inherently mutable; since `p` was made immutable, `p.x` is now
     // immutable.  Otherwise the type of &_q.x (&isize) would be wrong.
-    p.x = 5; //~ ERROR cannot assign to `p.x`
+    p.x = 5; //[ast]~ ERROR cannot assign to `p.x`
+             //[mir]~^ ERROR cannot assign to `p.x` because it is borrowed (Ast)
+             //[mir]~| ERROR cannot assign to `p.0` because it is borrowed (Mir)
     q.x;
 }
 
@@ -27,7 +32,9 @@ fn c() {
 
     let mut p = point {x: 3, y: 4};
     let q = &p.y;
-    p = point {x: 5, y: 7};//~ ERROR cannot assign to `p`
+    p = point {x: 5, y: 7};//[ast]~ ERROR cannot assign to `p`
+                           //[mir]~^ ERROR cannot assign to `p` because it is borrowed (Ast)
+                           //[mir]~| ERROR cannot assign to `p` because it is borrowed (Mir)
     p.x; // silence warning
     *q; // stretch loan
 }
@@ -38,7 +45,9 @@ fn d() {
 
     let mut p = point {x: 3, y: 4};
     let q = &p.y;
-    p.y = 5; //~ ERROR cannot assign to `p.y`
+    p.y = 5; //[ast]~ ERROR cannot assign to `p.y`
+             //[mir]~^ ERROR cannot assign to `p.y` because it is borrowed (Ast)
+             //[mir]~| ERROR cannot assign to `p.1` because it is borrowed (Mir)
     *q;
 }
 

--- a/src/test/compile-fail/borrowck/borrowck-imm-ref-to-mut-rec-field-issue-3162-c.rs
+++ b/src/test/compile-fail/borrowck/borrowck-imm-ref-to-mut-rec-field-issue-3162-c.rs
@@ -8,11 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// revisions: ast mir
+//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+
 fn main() {
     let mut _a = 3;
     let _b = &mut _a;
     {
         let _c = &*_b;
-        _a = 4; //~ ERROR cannot assign to `_a`
+        _a = 4; //[ast]~ ERROR cannot assign to `_a`
+                //[mir]~^ ERROR cannot assign to `_a` because it is borrowed (Ast)
+                //[mir]~| ERROR cannot assign to `_a` because it is borrowed (Mir)
     }
 }

--- a/src/test/compile-fail/borrowck/borrowck-lend-flow-match.rs
+++ b/src/test/compile-fail/borrowck/borrowck-lend-flow-match.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// revisions: ast mir
+//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+
 #![allow(unused_variables)]
 #![allow(unused_assignments)]
 
@@ -22,7 +25,9 @@ fn separate_arms() {
             x = Some(0);
         }
         Some(ref __isize) => {
-            x = Some(1); //~ ERROR cannot assign
+            x = Some(1); //[ast]~ ERROR cannot assign
+                         //[mir]~^ ERROR cannot assign to `x` because it is borrowed (Ast)
+                         //[mir]~| ERROR cannot assign to `x` because it is borrowed (Mir)
         }
     }
     x.clone(); // just to prevent liveness warnings

--- a/src/test/compile-fail/borrowck/borrowck-overloaded-index-and-overloaded-deref.rs
+++ b/src/test/compile-fail/borrowck/borrowck-overloaded-index-and-overloaded-deref.rs
@@ -13,6 +13,9 @@
 // operator. The accounting of the all the implicit things going on
 // here is rather subtle. Issue #20232.
 
+// revisions: ast mir
+//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+
 use std::ops::{Deref, Index};
 
 struct MyVec<T> { x: T }
@@ -39,7 +42,9 @@ fn main() {
     let mut v = MyVec { x: MyPtr { x: Foo { f: 22 } } };
     let i = &v[0].f;
     v = MyVec { x: MyPtr { x: Foo { f: 23 } } };
-    //~^ ERROR cannot assign to `v`
+    //[ast]~^ ERROR cannot assign to `v`
+    //[mir]~^^ ERROR cannot assign to `v` because it is borrowed (Ast)
+    //[mir]~| ERROR cannot assign to `v` because it is borrowed (Mir)
     read(*i);
 }
 

--- a/src/test/compile-fail/borrowck/borrowck-pat-reassign-binding.rs
+++ b/src/test/compile-fail/borrowck/borrowck-pat-reassign-binding.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// revisions: ast mir
+//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+
 fn main() {
     let mut x: Option<isize> = None;
     match x {
@@ -17,7 +20,9 @@ fn main() {
       }
       Some(ref i) => {
           // But on this branch, `i` is an outstanding borrow
-          x = Some(*i+1); //~ ERROR cannot assign to `x`
+          x = Some(*i+1); //[ast]~ ERROR cannot assign to `x`
+                          //[mir]~^ ERROR cannot assign to `x` because it is borrowed (Ast)
+                          //[mir]~| ERROR cannot assign to `x` because it is borrowed (Mir)
       }
     }
     x.clone(); // just to prevent liveness warnings

--- a/src/test/compile-fail/borrowck/borrowck-union-borrow.rs
+++ b/src/test/compile-fail/borrowck/borrowck-union-borrow.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
+// revisions: ast mir
+//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
 
 #[derive(Clone, Copy)]
 union U {
@@ -30,11 +32,15 @@ fn main() {
         }
         {
             let ra = &u.a;
-            let rma = &mut u.a; //~ ERROR cannot borrow `u.a` as mutable because it is also borrowed as immutable
+            let rma = &mut u.a; //[ast]~ ERROR cannot borrow `u.a` as mutable because it is also borrowed as immutable
+                                //[mir]~^ ERROR cannot borrow `u.a` as mutable because it is also borrowed as immutable (Ast)
+                                //[mir]~| ERROR cannot borrow `u.0` as mutable because it is also borrowed as immutable (Mir)
         }
         {
             let ra = &u.a;
-            u.a = 1; //~ ERROR cannot assign to `u.a` because it is borrowed
+            u.a = 1; //[ast]~ ERROR cannot assign to `u.a` because it is borrowed
+                     //[mir]~^ ERROR cannot assign to `u.a` because it is borrowed (Ast)
+                     //[mir]~| ERROR cannot assign to `u.0` because it is borrowed (Mir)
         }
         // Imm borrow, other field
         {
@@ -47,45 +53,65 @@ fn main() {
         }
         {
             let ra = &u.a;
-            let rmb = &mut u.b; //~ ERROR cannot borrow `u` (via `u.b`) as mutable because `u` is also borrowed as immutable (via `u.a`)
+            let rmb = &mut u.b; //[ast]~ ERROR cannot borrow `u` (via `u.b`) as mutable because `u` is also borrowed as immutable (via `u.a`)
+                                //[mir]~^ ERROR cannot borrow `u` (via `u.b`) as mutable because `u` is also borrowed as immutable (via `u.a`) (Ast)
+                                // FIXME Error for MIR (needs support for union)
         }
         {
             let ra = &u.a;
-            u.b = 1; //~ ERROR cannot assign to `u.b` because it is borrowed
+            u.b = 1; //[ast]~ ERROR cannot assign to `u.b` because it is borrowed
+                     //[mir]~^ ERROR cannot assign to `u.b` because it is borrowed (Ast)
+                     // FIXME Error for MIR (needs support for union)
         }
         // Mut borrow, same field
         {
             let rma = &mut u.a;
-            let ra = &u.a; //~ ERROR cannot borrow `u.a` as immutable because it is also borrowed as mutable
+            let ra = &u.a; //[ast]~ ERROR cannot borrow `u.a` as immutable because it is also borrowed as mutable
+                         //[mir]~^ ERROR cannot borrow `u.a` as immutable because it is also borrowed as mutable (Ast)
+                         //[mir]~| ERROR cannot borrow `u.0` as immutable because it is also borrowed as mutable (Mir)
         }
         {
             let ra = &mut u.a;
-            let a = u.a; //~ ERROR cannot use `u.a` because it was mutably borrowed
+            let a = u.a; //[ast]~ ERROR cannot use `u.a` because it was mutably borrowed
+                         //[mir]~^ ERROR cannot use `u.a` because it was mutably borrowed (Ast)
+                         //[mir]~| ERROR cannot use `u.0` because it was mutably borrowed (Mir)
         }
         {
             let rma = &mut u.a;
-            let rma2 = &mut u.a; //~ ERROR cannot borrow `u.a` as mutable more than once at a time
+            let rma2 = &mut u.a; //[ast]~ ERROR cannot borrow `u.a` as mutable more than once at a time
+                                 //[mir]~^ ERROR cannot borrow `u.a` as mutable more than once at a time (Ast)
+                                 //[mir]~| ERROR cannot borrow `u.0` as mutable more than once at a time (Mir)
         }
         {
             let rma = &mut u.a;
-            u.a = 1; //~ ERROR cannot assign to `u.a` because it is borrowed
+            u.a = 1; //[ast]~ ERROR cannot assign to `u.a` because it is borrowed
+                     //[mir]~^ ERROR cannot assign to `u.a` because it is borrowed (Ast)
+                     //[mir]~| ERROR cannot assign to `u.0` because it is borrowed (Mir)
         }
         // Mut borrow, other field
         {
             let rma = &mut u.a;
-            let rb = &u.b; //~ ERROR cannot borrow `u` (via `u.b`) as immutable because `u` is also borrowed as mutable (via `u.a`)
+            let rb = &u.b; //[ast]~ ERROR cannot borrow `u` (via `u.b`) as immutable because `u` is also borrowed as mutable (via `u.a`)
+                           //[mir]~^ ERROR cannot borrow `u` (via `u.b`) as immutable because `u` is also borrowed as mutable (via `u.a`) (Ast)
+                           // FIXME Error for MIR (needs support for union)
         }
         {
             let ra = &mut u.a;
-            let b = u.b; //~ ERROR cannot use `u.b` because it was mutably borrowed
+            let b = u.b; //[ast]~ ERROR cannot use `u.b` because it was mutably borrowed
+                         //[mir]~^ ERROR cannot use `u.b` because it was mutably borrowed (Ast)
+                         // FIXME Error for MIR (needs support for union)
         }
         {
             let rma = &mut u.a;
-            let rmb2 = &mut u.b; //~ ERROR cannot borrow `u` (via `u.b`) as mutable more than once at a time
+            let rmb2 = &mut u.b; //[ast]~ ERROR cannot borrow `u` (via `u.b`) as mutable more than once at a time
+                                 //[mir]~^ ERROR cannot borrow `u` (via `u.b`) as mutable more than once at a time (Ast)
+                                 // FIXME Error for MIR (needs support for union)
         }
         {
             let rma = &mut u.a;
-            u.b = 1; //~ ERROR cannot assign to `u.b` because it is borrowed
+            u.b = 1; //[ast]~ ERROR cannot assign to `u.b` because it is borrowed
+                     //[mir]~^ ERROR cannot assign to `u.b` because it is borrowed (Ast)
+                     // FIXME Error for MIR (needs support for union)
         }
     }
 }

--- a/src/test/compile-fail/borrowck/borrowck-vec-pattern-move-tail.rs
+++ b/src/test/compile-fail/borrowck/borrowck-vec-pattern-move-tail.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// revisions: ast mir
+//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+
 #![feature(slice_patterns)]
 
 fn main() {
@@ -17,7 +20,9 @@ fn main() {
         _ => unreachable!()
     };
     println!("t[0]: {}", t[0]);
-    a[2] = 0; //~ ERROR cannot assign to `a[..]` because it is borrowed
+    a[2] = 0; //[ast]~ ERROR cannot assign to `a[..]` because it is borrowed
+              //[mir]~^ ERROR cannot assign to `a[..]` because it is borrowed (Ast)
+              // FIXME Error for MIR (error missed)
     println!("t[0]: {}", t[0]);
     t[0];
 }

--- a/src/test/compile-fail/coerce-overloaded-autoderef.rs
+++ b/src/test/compile-fail/coerce-overloaded-autoderef.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// revisions: ast mir
+//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+
 fn borrow_mut<T>(x: &mut T) -> &mut T { x }
 fn borrow<T>(x: &T) -> &T { x }
 
@@ -17,24 +20,32 @@ fn borrow2<T>(_: &mut T, _: &T) {}
 fn double_mut_borrow<T>(x: &mut Box<T>) {
     let y = borrow_mut(x);
     let z = borrow_mut(x);
-    //~^ ERROR cannot borrow `*x` as mutable more than once at a time
+    //[ast]~^ ERROR cannot borrow `*x` as mutable more than once at a time
+    //[mir]~^^ ERROR cannot borrow `*x` as mutable more than once at a time (Ast)
+    //[mir]~| ERROR cannot borrow `(*x)` as mutable more than once at a time (Mir)
 }
 
 fn double_imm_borrow(x: &mut Box<i32>) {
     let y = borrow(x);
     let z = borrow(x);
     **x += 1;
-    //~^ ERROR cannot assign to `**x` because it is borrowed
+    //[ast]~^ ERROR cannot assign to `**x` because it is borrowed
+    //[mir]~^^ ERROR cannot assign to `**x` because it is borrowed (Ast)
+    //[mir]~| ERROR cannot assign to `(*(*x))` because it is borrowed (Mir)
 }
 
 fn double_mut_borrow2<T>(x: &mut Box<T>) {
     borrow_mut2(x, x);
-    //~^ ERROR cannot borrow `*x` as mutable more than once at a time
+    //[ast]~^ ERROR cannot borrow `*x` as mutable more than once at a time
+    //[mir]~^^ ERROR cannot borrow `*x` as mutable more than once at a time (Ast)
+    //[mir]~| ERROR cannot borrow `(*x)` as mutable more than once at a time (Mir)
 }
 
 fn double_borrow2<T>(x: &mut Box<T>) {
     borrow2(x, x);
-    //~^ ERROR cannot borrow `*x` as immutable because it is also borrowed as mutable
+    //[ast]~^ ERROR cannot borrow `*x` as immutable because it is also borrowed as mutable
+    //[mir]~^^ ERROR cannot borrow `*x` as immutable because it is also borrowed as mutable (Ast)
+    //[mir]~| ERROR cannot borrow `(*x)` as immutable because it is also borrowed as mutable (Mir)
 }
 
 pub fn main() {}

--- a/src/test/compile-fail/hrtb-identity-fn-borrows.rs
+++ b/src/test/compile-fail/hrtb-identity-fn-borrows.rs
@@ -11,6 +11,9 @@
 // Test that the `'a` in the where clause correctly links the region
 // of the output to the region of the input.
 
+// revisions: ast mir
+//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+
 trait FnLike<A,R> {
     fn call(&self, arg: A) -> R;
 }
@@ -21,7 +24,9 @@ fn call_repeatedly<F>(f: F)
     // Result is stored: cannot re-assign `x`
     let mut x = 3;
     let y = f.call(&x);
-    x = 5; //~ ERROR cannot assign
+    x = 5; //[ast]~ ERROR cannot assign
+           //[mir]~^ ERROR cannot assign to `x` because it is borrowed (Ast)
+           //[mir]~| ERROR cannot assign to `x` because it is borrowed (Mir)
 
     // Result is not stored: can re-assign `x`
     let mut x = 3;

--- a/src/test/compile-fail/mut-pattern-internal-mutability.rs
+++ b/src/test/compile-fail/mut-pattern-internal-mutability.rs
@@ -8,11 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// revisions: ast mir
+//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+
 fn main() {
     let foo = &mut 1;
 
     let &mut x = foo;
-    x += 1; //~ ERROR re-assignment of immutable variable
+    x += 1; //[ast]~ ERROR re-assignment of immutable variable
+            //[mir]~^ ERROR re-assignment of immutable variable `x` (Ast)
+            //[mir]~| ERROR re-assignment of immutable variable `x` (Mir)
 
     // explicitly mut-ify internals
     let &mut mut x = foo;
@@ -20,5 +25,7 @@ fn main() {
 
     // check borrowing is detected successfully
     let &mut ref x = foo;
-    *foo += 1; //~ ERROR cannot assign to `*foo` because it is borrowed
+    *foo += 1; //[ast]~ ERROR cannot assign to `*foo` because it is borrowed
+               //[mir]~^ ERROR cannot assign to `*foo` because it is borrowed (Ast)
+               //[mir]~| ERROR cannot assign to `(*foo)` because it is borrowed (Mir)
 }

--- a/src/test/compile-fail/regions-pattern-typing-issue-19997.rs
+++ b/src/test/compile-fail/regions-pattern-typing-issue-19997.rs
@@ -8,13 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// revisions: ast mir
+//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+
 fn main() {
     let a0 = 0;
     let f = 1;
     let mut a1 = &a0;
     match (&a1,) {
         (&ref b0,) => {
-            a1 = &f; //~ ERROR cannot assign
+            a1 = &f; //[ast]~ ERROR cannot assign
+                     //[mir]~^ ERROR cannot assign to `a1` because it is borrowed (Ast)
+                     //[mir]~| ERROR cannot assign to `a1` because it is borrowed (Mir)
         }
     }
 }


### PR DESCRIPTION
This PR adds notes to the MIR borrowck error E0506.

Part of #44596