### PR TITLE
Allow rustdoc to get compiled with debuginfo

### DIFF
--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -304,6 +304,11 @@ impl Step for Rustdoc {
                                            target,
                                            "build",
                                            "src/tools/rustdoc");
+
+        // Most tools don't get debuginfo, but rustdoc should.
+        cargo.env("RUSTC_DEBUGINFO", builder.config.rust_debuginfo.to_string())
+             .env("RUSTC_DEBUGINFO_LINES", builder.config.rust_debuginfo_lines.to_string());
+
         build.run(&mut cargo);
         // Cargo adds a number of paths to the dylib search path on windows, which results in
         // the wrong rustdoc being executed. To avoid the conflicting rustdocs, we name the "tool"


### PR DESCRIPTION
Fixes #44810

cc @QuietMisdreavus 
r? @alexcrichton 