### PR TITLE
Improve resolution of associated types in declarative macros 2.0

### DIFF
--- a/src/librustc/traits/project.rs
+++ b/src/librustc/traits/project.rs
@@ -29,7 +29,6 @@ use infer::{InferCtxt, InferOk};
 use infer::type_variable::TypeVariableOrigin;
 use middle::const_val::ConstVal;
 use rustc_data_structures::snapshot_map::{Snapshot, SnapshotMap};
-use syntax::ast;
 use syntax::symbol::Symbol;
 use ty::subst::{Subst, Substs};
 use ty::{self, ToPredicate, ToPolyTraitRef, Ty, TyCtxt};
@@ -1044,10 +1043,9 @@ fn assemble_candidates_from_impls<'cx, 'gcx, 'tcx>(
                 // In either case, we handle this by not adding a
                 // candidate for an impl if it contains a `default`
                 // type.
-                let item_name = selcx.tcx().associated_item(obligation.predicate.item_def_id).name;
                 let node_item = assoc_ty_def(selcx,
                                              impl_data.impl_def_id,
-                                             item_name);
+                                             obligation.predicate.item_def_id);
 
                 let is_default = if node_item.node.is_from_trait() {
                     // If true, the impl inherited a `type Foo = Bar`
@@ -1441,8 +1439,7 @@ fn confirm_impl_candidate<'cx, 'gcx, 'tcx>(
 
     let tcx = selcx.tcx();
     let param_env = obligation.param_env;
-    let assoc_ty = assoc_ty_def(selcx, impl_def_id,
-        tcx.associated_item(obligation.predicate.item_def_id).name);
+    let assoc_ty = assoc_ty_def(selcx, impl_def_id, obligation.predicate.item_def_id);
 
     let ty = if !assoc_ty.item.defaultness.has_value() {
         // This means that the impl is missing a definition for the
@@ -1471,10 +1468,11 @@ fn confirm_impl_candidate<'cx, 'gcx, 'tcx>(
 fn assoc_ty_def<'cx, 'gcx, 'tcx>(
     selcx: &SelectionContext<'cx, 'gcx, 'tcx>,
     impl_def_id: DefId,
-    assoc_ty_name: ast::Name)
+    assoc_ty_def_id: DefId)
     -> specialization_graph::NodeItem<ty::AssociatedItem>
 {
     let tcx = selcx.tcx();
+    let assoc_ty_name = tcx.associated_item(assoc_ty_def_id).name;
     let trait_def_id = tcx.impl_trait_ref(impl_def_id).unwrap().def_id;
     let trait_def = tcx.trait_def(trait_def_id);
 
@@ -1486,7 +1484,8 @@ fn assoc_ty_def<'cx, 'gcx, 'tcx>(
     // cycle error if the specialization graph is currently being built.
     let impl_node = specialization_graph::Node::Impl(impl_def_id);
     for item in impl_node.items(tcx) {
-        if item.kind == ty::AssociatedKind::Type && item.name == assoc_ty_name {
+        if item.kind == ty::AssociatedKind::Type &&
+                tcx.hygienic_eq(item.name, assoc_ty_name, trait_def_id) {
             return specialization_graph::NodeItem {
                 node: specialization_graph::Node::Impl(impl_def_id),
                 item,
@@ -1496,7 +1495,7 @@ fn assoc_ty_def<'cx, 'gcx, 'tcx>(
 
     if let Some(assoc_item) = trait_def
         .ancestors(tcx, impl_def_id)
-        .defs(tcx, assoc_ty_name, ty::AssociatedKind::Type)
+        .defs(tcx, assoc_ty_name, ty::AssociatedKind::Type, trait_def_id)
         .next() {
         assoc_item
     } else {

--- a/src/librustc/traits/specialize/mod.rs
+++ b/src/librustc/traits/specialize/mod.rs
@@ -125,7 +125,7 @@ pub fn find_associated_item<'a, 'tcx>(
     let trait_def = tcx.trait_def(trait_def_id);
 
     let ancestors = trait_def.ancestors(tcx, impl_data.impl_def_id);
-    match ancestors.defs(tcx, item.name, item.kind).next() {
+    match ancestors.defs(tcx, item.name, item.kind, trait_def_id).next() {
         Some(node_item) => {
             let substs = tcx.infer_ctxt().enter(|infcx| {
                 let param_env = ty::ParamEnv::empty(Reveal::All);

--- a/src/librustc/traits/specialize/specialization_graph.rs
+++ b/src/librustc/traits/specialize/specialization_graph.rs
@@ -346,11 +346,14 @@ impl<'a, 'gcx, 'tcx> Ancestors {
     /// Search the items from the given ancestors, returning each definition
     /// with the given name and the given kind.
     #[inline] // FIXME(#35870) Avoid closures being unexported due to impl Trait.
-    pub fn defs(self, tcx: TyCtxt<'a, 'gcx, 'tcx>, name: Name, kind: ty::AssociatedKind)
+    pub fn defs(self, tcx: TyCtxt<'a, 'gcx, 'tcx>, trait_item_name: Name,
+                trait_item_kind: ty::AssociatedKind, trait_def_id: DefId)
                 -> impl Iterator<Item = NodeItem<ty::AssociatedItem>> + 'a {
         self.flat_map(move |node| {
-            node.items(tcx).filter(move |item| item.kind == kind && item.name == name)
-                           .map(move |item| NodeItem { node: node, item: item })
+            node.items(tcx).filter(move |impl_item| {
+                impl_item.kind == trait_item_kind &&
+                tcx.hygienic_eq(impl_item.name, trait_item_name, trait_def_id)
+            }).map(move |item| NodeItem { node: node, item: item })
         })
     }
 }

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -596,9 +596,10 @@ impl<'a, 'tcx> ProjectionTy<'tcx> {
     pub fn from_ref_and_name(
         tcx: TyCtxt, trait_ref: ty::TraitRef<'tcx>, item_name: Name
     ) -> ProjectionTy<'tcx> {
-        let item_def_id = tcx.associated_items(trait_ref.def_id).find(
-            |item| item.name == item_name && item.kind == ty::AssociatedKind::Type
-        ).unwrap().def_id;
+        let item_def_id = tcx.associated_items(trait_ref.def_id).find(|item| {
+            item.kind == ty::AssociatedKind::Type &&
+            tcx.hygienic_eq(item_name, item.name, trait_ref.def_id)
+        }).unwrap().def_id;
 
         ProjectionTy {
             substs: trait_ref.substs,

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -373,7 +373,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
     /// and return it, or `None`, if no such item was defined there.
     pub fn associated_item(&self, def_id: DefId, item_name: ast::Name)
                            -> Option<ty::AssociatedItem> {
-        let ident = self.tcx.adjust(item_name, def_id, self.body_id).0;
-        self.tcx.associated_items(def_id).find(|item| item.name.to_ident() == ident)
+        self.tcx.associated_items(def_id)
+                .find(|item| self.tcx.hygienic_eq(item_name, item.name, def_id))
+
     }
 }

--- a/src/test/compile-fail/hygiene/assoc_item_ctxt.rs
+++ b/src/test/compile-fail/hygiene/assoc_item_ctxt.rs
@@ -1,0 +1,52 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-pretty pretty-printing is unhygienic
+
+#![feature(decl_macro)]
+#![allow(unused)]
+
+mod ok {
+    macro mac_trait_item($method: ident) {
+        fn $method();
+    }
+
+    trait Tr {
+        mac_trait_item!(method);
+    }
+
+    macro mac_trait_impl() {
+        impl Tr for u8 { // OK
+            fn method() {} // OK
+        }
+    }
+
+    mac_trait_impl!();
+}
+
+mod error {
+    macro mac_trait_item() {
+        fn method();
+    }
+
+    trait Tr {
+        mac_trait_item!();
+    }
+
+    macro mac_trait_impl() {
+        impl Tr for u8 { //~ ERROR not all trait items implemented, missing: `method`
+            fn method() {} //~ ERROR method `method` is not a member of trait `Tr`
+        }
+    }
+
+    mac_trait_impl!();
+}
+
+fn main() {}

--- a/src/test/compile-fail/hygiene/assoc_ty_bindings.rs
+++ b/src/test/compile-fail/hygiene/assoc_ty_bindings.rs
@@ -1,0 +1,49 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-pretty pretty-printing is unhygienic
+
+#![feature(decl_macro, associated_type_defaults)]
+#![feature(rustc_attrs)]
+
+trait Base {
+    type AssocTy;
+    fn f();
+}
+trait Derived: Base {
+    fn g();
+}
+
+macro mac() {
+    type A = Base<AssocTy = u8>;
+    type B = Derived<AssocTy = u8>;
+
+    impl Base for u8 {
+        type AssocTy = u8;
+        fn f() {
+            let _: Self::AssocTy;
+        }
+    }
+    impl Derived for u8 {
+        fn g() {
+            let _: Self::AssocTy;
+        }
+    }
+
+    fn h<T: Base, U: Derived>() {
+        let _: T::AssocTy;
+        let _: U::AssocTy;
+    }
+}
+
+mac!();
+
+#[rustc_error]
+fn main() {} //~ ERROR compilation successful

--- a/src/test/run-pass/hygiene/specialization.rs
+++ b/src/test/run-pass/hygiene/specialization.rs
@@ -1,0 +1,34 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-pretty pretty-printing is unhygienic
+
+#![feature(decl_macro)]
+
+trait Tr {
+    fn f(&self) -> &'static str {
+        "This shouldn't happen"
+    }
+}
+
+pub macro m($t:ty) {
+    impl Tr for $t {
+        fn f(&self) -> &'static str {
+            "Run me"
+        }
+    }
+}
+
+struct S;
+m!(S);
+
+fn main() {
+    assert_eq!(S.f(), "Run me");
+}


### PR DESCRIPTION
Make various identifier comparisons for associated types (and sometimes other associated items) hygienic.
Now declarative macros 2.0 can use `Self::AssocTy`, `TyParam::AssocTy`, `Trait<AssocTy = u8>` where `AssocTy` is an associated type of a trait `Trait` visible from the macro. Also, `Trait` can now be implemented inside the macro and specialization should work properly (fixes https://github.com/rust-lang/rust/pull/40847#issuecomment-310867299).

r? @jseyfried or @eddyb 