### PR TITLE
Point at signature on unused lint

### DIFF
--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -553,9 +553,22 @@ impl<'a, 'tcx> Visitor<'tcx> for DeadVisitor<'a, 'tcx> {
 
     fn visit_item(&mut self, item: &'tcx hir::Item) {
         if self.should_warn_about_item(item) {
+            // For items that have a definition with a signature followed by a
+            // block, point only at the signature.
+            let span = match item.node {
+                hir::ItemFn(..) |
+                hir::ItemMod(..) |
+                hir::ItemEnum(..) |
+                hir::ItemStruct(..) |
+                hir::ItemUnion(..) |
+                hir::ItemTrait(..) |
+                hir::ItemDefaultImpl(..) |
+                hir::ItemImpl(..) => self.tcx.sess.codemap().def_span(item.span),
+                _ => item.span,
+            };
             self.warn_dead_code(
                 item.id,
-                item.span,
+                span,
                 item.name,
                 item.node.descriptive_variant()
             );
@@ -570,8 +583,7 @@ impl<'a, 'tcx> Visitor<'tcx> for DeadVisitor<'a, 'tcx> {
                      g: &'tcx hir::Generics,
                      id: ast::NodeId) {
         if self.should_warn_about_variant(&variant.node) {
-            self.warn_dead_code(variant.node.data.id(), variant.span,
-                                variant.node.name, "variant");
+            self.warn_dead_code(variant.node.data.id(), variant.span, variant.node.name, "variant");
         } else {
             intravisit::walk_variant(self, variant, g, id);
         }
@@ -596,15 +608,17 @@ impl<'a, 'tcx> Visitor<'tcx> for DeadVisitor<'a, 'tcx> {
         match impl_item.node {
             hir::ImplItemKind::Const(_, body_id) => {
                 if !self.symbol_is_live(impl_item.id, None) {
-                    self.warn_dead_code(impl_item.id, impl_item.span,
-                                        impl_item.name, "associated const");
+                    self.warn_dead_code(impl_item.id,
+                                        impl_item.span,
+                                        impl_item.name,
+                                        "associated const");
                 }
                 self.visit_nested_body(body_id)
             }
             hir::ImplItemKind::Method(_, body_id) => {
                 if !self.symbol_is_live(impl_item.id, None) {
-                    self.warn_dead_code(impl_item.id, impl_item.span,
-                                        impl_item.name, "method");
+                    let span = self.tcx.sess.codemap().def_span(impl_item.span);
+                    self.warn_dead_code(impl_item.id, span, impl_item.name, "method");
                 }
                 self.visit_nested_body(body_id)
             }

--- a/src/test/ui-fulldeps/lint-plugin-cmdline-allow.stderr
+++ b/src/test/ui-fulldeps/lint-plugin-cmdline-allow.stderr
@@ -2,7 +2,7 @@ warning: function is never used: `lintme`
   --> $DIR/lint-plugin-cmdline-allow.rs:20:1
    |
 20 | fn lintme() { }
-   | ^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^
    |
 note: lint level defined here
   --> $DIR/lint-plugin-cmdline-allow.rs:17:9

--- a/src/test/ui/path-lookahead.stderr
+++ b/src/test/ui/path-lookahead.stderr
@@ -9,10 +9,8 @@ warning: unnecessary parentheses around `return` value
 warning: function is never used: `with_parens`
   --> $DIR/path-lookahead.rs:17:1
    |
-17 | / fn with_parens<T: ToString>(arg: T) -> String { //~WARN function is never used: `with_parens`
-18 | |   return (<T as ToString>::to_string(&arg)); //~WARN unnecessary parentheses around `return` value
-19 | | }
-   | |_^
+17 | fn with_parens<T: ToString>(arg: T) -> String { //~WARN function is never used: `with_parens`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: lint level defined here
   --> $DIR/path-lookahead.rs:13:9
@@ -24,8 +22,6 @@ note: lint level defined here
 warning: function is never used: `no_parens`
   --> $DIR/path-lookahead.rs:21:1
    |
-21 | / fn no_parens<T: ToString>(arg: T) -> String { //~WARN function is never used: `no_parens`
-22 | |   return <T as ToString>::to_string(&arg);
-23 | | }
-   | |_^
+21 | fn no_parens<T: ToString>(arg: T) -> String { //~WARN function is never used: `no_parens`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/test/ui/span/unused-warning-point-at-signature.rs
+++ b/src/test/ui/span/unused-warning-point-at-signature.rs
@@ -1,0 +1,40 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-pass
+
+#![warn(unused)]
+
+enum Enum {
+    A,
+    B,
+    C,
+    D,
+}
+
+struct Struct {
+    a: usize,
+    b: usize,
+    c: usize,
+    d: usize,
+}
+
+fn func() -> usize {
+    3
+}
+
+fn
+func_complete_span()
+-> usize
+{
+    3
+}
+
+fn main() {}

--- a/src/test/ui/span/unused-warning-point-at-signature.stderr
+++ b/src/test/ui/span/unused-warning-point-at-signature.stderr
@@ -1,0 +1,36 @@
+warning: enum is never used: `Enum`
+  --> $DIR/unused-warning-point-at-signature.rs:15:1
+   |
+15 | enum Enum {
+   | ^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/unused-warning-point-at-signature.rs:13:9
+   |
+13 | #![warn(unused)]
+   |         ^^^^^^
+   = note: #[warn(dead_code)] implied by #[warn(unused)]
+
+warning: struct is never used: `Struct`
+  --> $DIR/unused-warning-point-at-signature.rs:22:1
+   |
+22 | struct Struct {
+   | ^^^^^^^^^^^^^
+
+warning: function is never used: `func`
+  --> $DIR/unused-warning-point-at-signature.rs:29:1
+   |
+29 | fn func() -> usize {
+   | ^^^^^^^^^^^^^^^^^^
+
+warning: function is never used: `func_complete_span`
+  --> $DIR/unused-warning-point-at-signature.rs:33:1
+   |
+33 | / fn
+34 | | func_complete_span()
+35 | | -> usize
+36 | | {
+37 | |     3
+38 | | }
+   | |_^
+


### PR DESCRIPTION
```
warning: struct is never used: `Struct`
  --> $DIR/unused-warning-point-at-signature.rs:22:1
   |
22 | struct Struct {
   | ^^^^^^^^^^^^^
```

Fix #33961.