### PR TITLE
rustc: Default 32 codegen units at O0

### DIFF
--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -509,7 +509,7 @@ fn link_rlib<'a>(sess: &'a Session,
                 // of when we do and don't keep .#module-name#.bc files around.
                 let user_wants_numbered_bitcode =
                         sess.opts.output_types.contains_key(&OutputType::Bitcode) &&
-                        sess.opts.cg.codegen_units > 1;
+                        sess.opts.codegen_units > 1;
                 if !sess.opts.cg.save_temps && !user_wants_numbered_bitcode {
                     remove(sess, &bc_filename);
                 }

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -939,10 +939,10 @@ fn produce_final_output_artifacts(sess: &Session,
         let needs_crate_object = crate_output.outputs.contains_key(&OutputType::Exe);
 
         let keep_numbered_bitcode = needs_crate_bitcode ||
-                (user_wants_bitcode && sess.opts.cg.codegen_units > 1);
+                (user_wants_bitcode && sess.opts.codegen_units > 1);
 
         let keep_numbered_objects = needs_crate_object ||
-                (user_wants_objects && sess.opts.cg.codegen_units > 1);
+                (user_wants_objects && sess.opts.codegen_units > 1);
 
         for module in compiled_modules.modules.iter() {
             let module_name = Some(&module.name[..]);
@@ -1520,6 +1520,11 @@ fn start_executing_work(tcx: TyCtxt,
                                     total_llvm_time);
         }
 
+        // Regardless of what order these modules completed in, report them to
+        // the backend in the same order every time to ensure that we're handing
+        // out deterministic results.
+        compiled_modules.sort_by(|a, b| a.name.cmp(&b.name));
+
         let compiled_metadata_module = compiled_metadata_module
             .expect("Metadata module not compiled?");
 
@@ -1853,7 +1858,7 @@ impl OngoingCrateTranslation {
 
         // FIXME: time_llvm_passes support - does this use a global context or
         // something?
-        if sess.opts.cg.codegen_units == 1 && sess.time_llvm_passes() {
+        if sess.opts.codegen_units == 1 && sess.time_llvm_passes() {
             unsafe { llvm::LLVMRustPrintPassTimings(); }
         }
 

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -1162,7 +1162,7 @@ fn collect_and_partition_translation_items<'a, 'tcx>(
     let strategy = if tcx.sess.opts.debugging_opts.incremental.is_some() {
         PartitioningStrategy::PerModule
     } else {
-        PartitioningStrategy::FixedUnitCount(tcx.sess.opts.cg.codegen_units)
+        PartitioningStrategy::FixedUnitCount(tcx.sess.opts.codegen_units)
     };
 
     let codegen_units = time(time_passes, "codegen unit partitioning", || {
@@ -1175,7 +1175,7 @@ fn collect_and_partition_translation_items<'a, 'tcx>(
             .collect::<Vec<_>>()
     });
 
-    assert!(tcx.sess.opts.cg.codegen_units == codegen_units.len() ||
+    assert!(tcx.sess.opts.codegen_units == codegen_units.len() ||
             tcx.sess.opts.debugging_opts.incremental.is_some());
 
     let translation_items: DefIdSet = items.iter().filter_map(|trans_item| {

--- a/src/test/run-make/codegen-options-parsing/Makefile
+++ b/src/test/run-make/codegen-options-parsing/Makefile
@@ -1,26 +1,28 @@
 -include ../tools.mk
 
+LOG = $(TMPDIR)/log.txt
+
 all:
 	#Option taking a number
-	$(RUSTC) -C codegen-units dummy.rs 2>&1 | \
-		grep 'codegen option `codegen-units` requires a number'
-	$(RUSTC) -C codegen-units= dummy.rs 2>&1 | \
-		grep 'incorrect value `` for codegen option `codegen-units` - a number was expected'
-	$(RUSTC) -C codegen-units=foo dummy.rs 2>&1 | \
-		grep 'incorrect value `foo` for codegen option `codegen-units` - a number was expected'
+	$(RUSTC) -C codegen-units dummy.rs 2>&1 | tee $(LOG)
+	grep 'codegen option `codegen-units` requires a number' $(LOG)
+	$(RUSTC) -C codegen-units= dummy.rs 2>&1 | tee $(LOG)
+	grep 'incorrect value `` for codegen option `codegen-units` - a number was expected' $(LOG)
+	$(RUSTC) -C codegen-units=foo dummy.rs 2>&1 | tee $(LOG)
+	grep 'incorrect value `foo` for codegen option `codegen-units` - a number was expected' $(LOG)
 	$(RUSTC) -C codegen-units=1 dummy.rs
 	#Option taking a string
-	$(RUSTC) -C extra-filename dummy.rs 2>&1 | \
-		grep 'codegen option `extra-filename` requires a string'
+	$(RUSTC) -C extra-filename dummy.rs 2>&1 | tee $(LOG)
+	grep 'codegen option `extra-filename` requires a string' $(LOG)
 	$(RUSTC) -C extra-filename= dummy.rs 2>&1
 	$(RUSTC) -C extra-filename=foo dummy.rs 2>&1
 	#Option taking no argument
-	$(RUSTC) -C lto= dummy.rs 2>&1 | \
-		grep 'codegen option `lto` takes no value'
-	$(RUSTC) -C lto=1 dummy.rs 2>&1 | \
-		grep 'codegen option `lto` takes no value'
-	$(RUSTC) -C lto=foo dummy.rs 2>&1 | \
-		grep 'codegen option `lto` takes no value'
+	$(RUSTC) -C lto= dummy.rs 2>&1 | tee $(LOG)
+	grep 'codegen option `lto` takes no value' $(LOG)
+	$(RUSTC) -C lto=1 dummy.rs 2>&1 | tee $(LOG)
+	grep 'codegen option `lto` takes no value' $(LOG)
+	$(RUSTC) -C lto=foo dummy.rs 2>&1 | tee $(LOG)
+	grep 'codegen option `lto` takes no value' $(LOG)
 	$(RUSTC) -C lto dummy.rs
 
 	# Should not link dead code...

--- a/src/test/run-make/llvm-phase/test.rs
+++ b/src/test/run-make/llvm-phase/test.rs
@@ -77,6 +77,7 @@ fn main() {
         .split(' ').map(|s| s.to_string()).collect();
     args.push("--out-dir".to_string());
     args.push(env::var("TMPDIR").unwrap());
+    args.push("-Ccodegen-units=1".to_string());
 
     let (result, _) = rustc_driver::run_compiler(
         &args, &mut JitCalls, Some(box JitLoader), None);


### PR DESCRIPTION
This commit changes the default of rustc to use 32 codegen units when compiling
in debug mode, typically an opt-level=0 compilation. Since their inception
codegen units have matured quite a bit, gaining features such as:

* Parallel translation and codegen enabling codegen units to get worked on even
  more quickly.
* Deterministic and reliable partitioning through the same infrastructure as
  incremental compilation.
* Global rate limiting through the `jobserver` crate to avoid overloading the
  system.

The largest benefit of codegen units has forever been faster compilation through
parallel processing of modules on the LLVM side of things, using all the cores
available on build machines that typically have many available. Some downsides
have been fixed through the features above, but the major downside remaining is
that using codegen units reduces opportunities for inlining and optimization.
This, however, doesn't matter much during debug builds!

In this commit the default number of codegen units for debug builds has been
raised from 1 to 32. This should enable most `cargo build` compiles that are
bottlenecked on translation and/or code generation to immediately see speedups
through parallelization on available cores.

Work is being done to *always* enable multiple codegen units (and therefore
parallel codegen) but it requires #44841 at least to be landed and stabilized,
but stay tuned if you're interested in that aspect!