### PR TITLE
Improved docs for CStr, CString, OsStr, OsString

### DIFF
--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -208,8 +208,13 @@ pub struct CStr {
 }
 
 /// An error returned from [`CString::new`] to indicate that a nul byte was found
-/// in the vector provided.
+/// in the vector provided.  While Rust strings may contain nul bytes in the middle,
+/// C strings can't, as that byte would effectively truncate the string.
 ///
+/// This `struct` is created by the [`new`][`CString::new`] method on
+/// [`CString`]. See its documentation for more.
+///
+/// [`CString`]: struct.CString.html
 /// [`CString::new`]: struct.CString.html#method.new
 ///
 /// # Examples
@@ -225,9 +230,15 @@ pub struct NulError(usize, Vec<u8>);
 
 /// An error returned from [`CStr::from_bytes_with_nul`] to indicate
 /// that a nul byte was found too early in the slice provided, or one
-/// wasn't found at all.  The slice used to create a `CStr` must have one
-/// and only one nul byte at the end of the slice.
+/// wasn't found at all for the nul terminator.  The slice used to
+/// create a `CStr` must have one and only one nul byte at the end of
+/// the slice.
 ///
+/// This `struct` is created by the
+/// [`from_bytes_with_nul`][`CStr::from_bytes_with_nul`] method on
+/// [`CStr`]. See its documentation for more.
+///
+/// [`CStr`]: struct.CStr.html
 /// [`CStr::from_bytes_with_nul`]: struct.CStr.html#method.from_bytes_with_nul
 ///
 /// # Examples
@@ -262,9 +273,17 @@ impl FromBytesWithNulError {
     }
 }
 
-/// An error returned from [`CString::into_string`] to indicate that a UTF-8 error
-/// was encountered during the conversion.
+/// An error returned from [`CString::into_string`] to indicate that a
+/// UTF-8 error was encountered during the conversion.  `CString` is
+/// just a wrapper over a buffer of bytes with a nul terminator;
+/// [`into_string`][`CString::into_string`] performs UTF-8 validation
+/// and may return this error.
 ///
+/// This `struct` is created by the
+/// [`into_string`][`CString::into_string`] method on [`CString`]. See
+/// its documentation for more.
+///
+/// [`CString`]: struct.CString.html
 /// [`CString::into_string`]: struct.CString.html#method.into_string
 #[derive(Clone, PartialEq, Eq, Debug)]
 #[stable(feature = "cstring_into", since = "1.7.0")]

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -23,10 +23,11 @@ use ptr;
 use slice;
 use str::{self, Utf8Error};
 
-/// A type representing an owned, C-compatible, UTF-8 string.
+/// A type representing an owned, C-compatible, nul-terminated string with no nul bytes in the
+/// middle.
 ///
 /// This type serves the purpose of being able to safely generate a
-/// C-compatible UTF-8 string from a Rust byte slice or vector. An instance of this
+/// C-compatible string from a Rust byte slice or vector. An instance of this
 /// type is a static guarantee that the underlying bytes contain no interior 0
 /// bytes ("nul characters") and that the final byte is 0 ("nul terminator").
 ///
@@ -443,7 +444,7 @@ impl CString {
         Box::into_raw(self.into_inner()) as *mut c_char
     }
 
-    /// Converts the `CString` into a [`String`] if it contains valid Unicode data.
+    /// Converts the `CString` into a [`String`] if it contains valid UTF-8 data.
     ///
     /// On failure, ownership of the original `CString` is returned.
     ///

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -49,7 +49,7 @@ use str::{self, Utf8Error};
 /// # Extracting a raw pointer to the whole C string
 ///
 /// `CString` implements a [`as_ptr`] method through the [`Deref`]
-/// trait.  This method will give you a `*const c_char` which you can
+/// trait. This method will give you a `*const c_char` which you can
 /// feed directly to extern functions that expect a nul-terminated
 /// string, like C's `strdup()`.
 ///
@@ -70,7 +70,7 @@ use str::{self, Utf8Error};
 /// Once you have the kind of slice you need (with or without a nul
 /// terminator), you can call the slice's own
 /// [`as_ptr`][slice.as_ptr] method to get a raw pointer to pass to
-/// extern functions.  See the documentation for that function for a
+/// extern functions. See the documentation for that function for a
 /// discussion on ensuring the lifetime of the raw pointer.
 ///
 /// [`Into`]: ../convert/trait.Into.html
@@ -130,8 +130,8 @@ pub struct CString {
 /// Representation of a borrowed C string.
 ///
 /// This type represents a borrowed reference to a nul-terminated
-/// array of bytes.  It can be constructed safely from a `&[`[`u8`]`]`
-/// slice, or unsafely from a raw `*const c_char`.  It can then be
+/// array of bytes. It can be constructed safely from a `&[`[`u8`]`]`
+/// slice, or unsafely from a raw `*const c_char`. It can then be
 /// converted to a Rust [`&str`] by performing UTF-8 validation, or
 /// into an owned [`CString`].
 ///
@@ -374,7 +374,7 @@ impl CString {
     /// to undefined behavior or allocator corruption.
     ///
     /// > **Note:** If you need to borrow a string that was allocated by
-    /// > foreign code, use [`CStr`].  If you need to take ownership of
+    /// > foreign code, use [`CStr`]. If you need to take ownership of
     /// > a string that was allocated by foreign code, you will need to
     /// > make your own provisions for freeing it appropriately, likely
     /// > with the foreign code's API to do that.
@@ -521,7 +521,7 @@ impl CString {
     ///
     /// The returned slice does **not** contain the trailing nul
     /// terminator, and it is guaranteed to not have any interior nul
-    /// bytes.  If you need the nul terminator, use
+    /// bytes. If you need the nul terminator, use
     /// [`as_bytes_with_nul`] instead.
     ///
     /// [`as_bytes_with_nul`]: #method.as_bytes_with_nul
@@ -1035,7 +1035,7 @@ impl CStr {
     /// Yields a [`&str`] slice if the `CStr` contains valid UTF-8.
     ///
     /// If the contents of the `CStr` are valid UTF-8 data, this
-    /// function will return the corresponding [`&str`] slice.  Otherwise,
+    /// function will return the corresponding [`&str`] slice. Otherwise,
     /// it will return an error with details of where UTF-8 validation failed.
     ///
     /// > **Note**: This method is currently implemented to check for validity
@@ -1066,7 +1066,7 @@ impl CStr {
     ///
     /// If the contents of the `CStr` are valid UTF-8 data, this
     /// function will return a [`Cow`]`::`[`Borrowed`]`(`[`&str`]`)`
-    /// with the the corresponding [`&str`] slice.  Otherwise, it will
+    /// with the the corresponding [`&str`] slice. Otherwise, it will
     /// replace any invalid UTF-8 sequences with `U+FFFD REPLACEMENT
     /// CHARACTER` and return a [`Cow`]`::`[`Owned`]`(`[`String`]`)`
     /// with the result.

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -208,11 +208,12 @@ pub struct CStr {
     inner: [c_char]
 }
 
-/// An error returned from [`CString::new`] to indicate that a nul byte was found
-/// in the vector provided.  While Rust strings may contain nul bytes in the middle,
-/// C strings can't, as that byte would effectively truncate the string.
+/// An error indicating that an interior nul byte was found.
 ///
-/// This `struct` is created by the [`new`][`CString::new`] method on
+/// While Rust strings may contain nul bytes in the middle, C strings
+/// can't, as that byte would effectively truncate the string.
+///
+/// This error is created by the [`new`][`CString::new`] method on
 /// [`CString`]. See its documentation for more.
 ///
 /// [`CString`]: struct.CString.html
@@ -229,13 +230,12 @@ pub struct CStr {
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct NulError(usize, Vec<u8>);
 
-/// An error returned from [`CStr::from_bytes_with_nul`] to indicate
-/// that a nul byte was found too early in the slice provided, or one
-/// wasn't found at all for the nul terminator.  The slice used to
-/// create a `CStr` must have one and only one nul byte at the end of
-/// the slice.
+/// An error indicating that a nul byte was not in the expected position.
 ///
-/// This `struct` is created by the
+/// The slice used to create a [`CStr`] must have one and only one nul
+/// byte at the end of the slice.
+///
+/// This error is created by the
 /// [`from_bytes_with_nul`][`CStr::from_bytes_with_nul`] method on
 /// [`CStr`]. See its documentation for more.
 ///
@@ -274,16 +274,17 @@ impl FromBytesWithNulError {
     }
 }
 
-/// An error returned from [`CString::into_string`] to indicate that a
-/// UTF-8 error was encountered during the conversion.  `CString` is
-/// just a wrapper over a buffer of bytes with a nul terminator;
-/// [`into_string`][`CString::into_string`] performs UTF-8 validation
-/// and may return this error.
+/// An error indicating invalid UTF-8 when converting a [`CString`] into a [`String`].
+///
+/// `CString` is just a wrapper over a buffer of bytes with a nul
+/// terminator; [`into_string`][`CString::into_string`] performs UTF-8
+/// validation on those bytes and may return this error.
 ///
 /// This `struct` is created by the
 /// [`into_string`][`CString::into_string`] method on [`CString`]. See
 /// its documentation for more.
 ///
+/// [`String`]: ../string/struct.String.html
 /// [`CString`]: struct.CString.html
 /// [`CString::into_string`]: struct.CString.html#method.into_string
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -297,10 +297,10 @@ pub struct IntoStringError {
 impl CString {
     /// Creates a new C-compatible string from a container of bytes.
     ///
-    /// This method will consume the provided data and use the
+    /// This function will consume the provided data and use the
     /// underlying bytes to construct a new string, ensuring that
-    /// there is a trailing 0 byte.  This trailing 0 byte will be
-    /// appended by this method; the provided data should *not*
+    /// there is a trailing 0 byte. This trailing 0 byte will be
+    /// appended by this function; the provided data should *not*
     /// contain any 0 bytes in it.
     ///
     /// # Examples

--- a/src/libstd/ffi/mod.rs
+++ b/src/libstd/ffi/mod.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! Utilities related to FFI bindings.
+//!
 //! This module provides utilities to handle data across non-Rust
 //! interfaces, like other programming languages and the underlying
 //! operating system.  It is mainly of use for FFI (Foreign Function

--- a/src/libstd/ffi/mod.rs
+++ b/src/libstd/ffi/mod.rs
@@ -12,24 +12,24 @@
 //!
 //! This module provides utilities to handle data across non-Rust
 //! interfaces, like other programming languages and the underlying
-//! operating system.  It is mainly of use for FFI (Foreign Function
+//! operating system. It is mainly of use for FFI (Foreign Function
 //! Interface) bindings and code that needs to exchange C-like strings
 //! with other languages.
 //!
 //! # Overview
 //!
 //! Rust represents owned strings with the [`String`] type, and
-//! borrowed slices of strings with the [`str`] primitive.  Both are
+//! borrowed slices of strings with the [`str`] primitive. Both are
 //! always in UTF-8 encoding, and may contain nul bytes in the middle,
 //! i.e. if you look at the bytes that make up the string, there may
-//! be a `\0` among them.  Both `String` and `str` store their length
+//! be a `\0` among them. Both `String` and `str` store their length
 //! explicitly; there are no nul terminators at the end of strings
 //! like in C.
 //!
 //! C strings are different from Rust strings:
 //!
 //! * **Encodings** - Rust strings are UTF-8, but C strings may use
-//! other encodings.  If you are using a string from C, you should
+//! other encodings. If you are using a string from C, you should
 //! check its encoding explicitly, rather than just assuming that it
 //! is UTF-8 like you can do in Rust.
 //!
@@ -37,22 +37,22 @@
 //! characters; please **note** that C's `char` is different from Rust's.
 //! The C standard leaves the actual sizes of those types open to
 //! interpretation, but defines different APIs for strings made up of
-//! each character type.  Rust strings are always UTF-8, so different
+//! each character type. Rust strings are always UTF-8, so different
 //! Unicode characters will be encoded in a variable number of bytes
-//! each.  The Rust type [`char`] represents a '[Unicode scalar
+//! each. The Rust type [`char`] represents a '[Unicode scalar
 //! value]', which is similar to, but not the same as, a '[Unicode
 //! code point]'.
 //!
 //! * **Nul terminators and implicit string lengths** - Often, C
 //! strings are nul-terminated, i.e. they have a `\0` character at the
-//! end.  The length of a string buffer is not stored, but has to be
+//! end. The length of a string buffer is not stored, but has to be
 //! calculated; to compute the length of a string, C code must
 //! manually call a function like `strlen()` for `char`-based strings,
-//! or `wcslen()` for `wchar_t`-based ones.  Those functions return
+//! or `wcslen()` for `wchar_t`-based ones. Those functions return
 //! the number of characters in the string excluding the nul
 //! terminator, so the buffer length is really `len+1` characters.
 //! Rust strings don't have a nul terminator; their length is always
-//! stored and does not need to be calculated.  While in Rust
+//! stored and does not need to be calculated. While in Rust
 //! accessing a string's length is a O(1) operation (becasue the
 //! length is stored); in C it is an O(length) operation because the
 //! length needs to be computed by scanning the string for the nul
@@ -61,7 +61,7 @@
 //! * **Internal nul characters** - When C strings have a nul
 //! terminator character, this usually means that they cannot have nul
 //! characters in the middle — a nul character would essentially
-//! truncate the string.  Rust strings *can* have nul characters in
+//! truncate the string. Rust strings *can* have nul characters in
 //! the middle, because nul does not have to mark the end of the
 //! string in Rust.
 //!
@@ -80,30 +80,30 @@
 //!
 //! * **From C to Rust:** [`CStr`] represents a borrowed C string; it
 //! is what you would use to wrap a raw `*const u8` that you got from
-//! a C function.  A `CStr` is guaranteed to be a nul-terminated array
-//! of bytes.  Once you have a `CStr`, you can convert it to a Rust
+//! a C function. A `CStr` is guaranteed to be a nul-terminated array
+//! of bytes. Once you have a `CStr`, you can convert it to a Rust
 //! `&str` if it's valid UTF-8, or lossily convert it by adding
 //! replacement characters.
 //!
 //! [`OsString`] and [`OsStr`] are useful when you need to transfer
 //! strings to and from the operating system itself, or when capturing
-//! the output of external commands.  Conversions between `OsString`,
+//! the output of external commands. Conversions between `OsString`,
 //! `OsStr` and Rust strings work similarly to those for [`CString`]
 //! and [`CStr`].
 //!
 //! * [`OsString`] represents an owned string in whatever
-//! representation the operating system prefers.  In the Rust standard
+//! representation the operating system prefers. In the Rust standard
 //! library, various APIs that transfer strings to/from the operating
-//! system use `OsString` instead of plain strings.  For example,
+//! system use `OsString` instead of plain strings. For example,
 //! [`env::var_os()`] is used to query environment variables; it
-//! returns an `Option<OsString>`.  If the environment variable exists
+//! returns an `Option<OsString>`. If the environment variable exists
 //! you will get a `Some(os_string)`, which you can *then* try to
-//! convert to a Rust string.  This yields a [`Result<>`], so that
+//! convert to a Rust string. This yields a [`Result<>`], so that
 //! your code can detect errors in case the environment variable did
 //! not in fact contain valid Unicode data.
 //!
 //! * [`OsStr`] represents a borrowed reference to a string in a
-//! format that can be passed to the operating system.  It can be
+//! format that can be passed to the operating system. It can be
 //! converted into an UTF-8 Rust string slice in a similar way to
 //! `OsString`.
 //!
@@ -125,12 +125,12 @@
 //!
 //! On Windows, [`OsStr`] implements the
 //! `std::os::windows::ffi::`[`OsStrExt`][windows.OsStrExt] trait,
-//! which provides an [`encode_wide`] method.  This provides an
+//! which provides an [`encode_wide`] method. This provides an
 //! iterator that can be [`collect`]ed into a vector of [`u16`].
 //!
 //! Additionally, on Windows [`OsString`] implements the
 //! `std::os::windows:ffi::`[`OsStringExt`][windows.OsStringExt]
-//! trait, which provides a [`from_wide`] method.  The result of this
+//! trait, which provides a [`from_wide`] method. The result of this
 //! method is an `OsString` which can be round-tripped to a Windows
 //! string losslessly.
 //!

--- a/src/libstd/ffi/mod.rs
+++ b/src/libstd/ffi/mod.rs
@@ -92,7 +92,7 @@
 //! your code can detect errors in case the environment variable did
 //! not in fact contain valid Unicode data.
 //!
-//! * [`OsStr`] represents a borrowed reference to a string in a format that
+//! * [`OsStr`] represents a borrowed string slice in a format that
 //! can be passed to the operating system.  It can be converted into
 //! an UTF-8 Rust string slice in a similar way to `OsString`.
 //!

--- a/src/libstd/ffi/mod.rs
+++ b/src/libstd/ffi/mod.rs
@@ -8,7 +8,106 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Utilities related to FFI bindings.
+//! This module provides utilities to handle C-like strings.  It is
+//! mainly of use for FFI (Foreign Function Interface) bindings and
+//! code that needs to exchange C-like strings with other languages.
+//!
+//! # Overview
+//!
+//! Rust represents owned strings with the [`String`] type, and
+//! borrowed slices of strings with the [`str`] primitive.  Both are
+//! always in UTF-8 encoding, and may contain nul bytes in the middle,
+//! i.e. if you look at the bytes that make up the string, there may
+//! be a `0` among them.  Both `String` and `str` know their length;
+//! there are no nul terminators at the end of strings like in C.
+//!
+//! C strings are different from Rust strings:
+//!
+//! * **Encodings** - C strings may have different encodings.  If
+//! you are bringing in strings from C APIs, you should check what
+//! encoding you are getting.  Rust strings are always UTF-8.
+//!
+//! * **Character width** - C strings may use "normal" or "wide"
+//! characters, i.e. `char` or `wchar_t`, respectively.  The C
+//! standard leaves the actual sizes of those types open to
+//! interpretation, but defines different APIs for strings made up of
+//! each character type.  Rust strings are always UTF-8, so different
+//! Unicode characters will be encoded in a variable number of bytes
+//! each.  The Rust type [`char`] represents a '[Unicode
+//! scalar value]', which is similar to, but not the same as, a
+//! '[Unicode code point]'.
+//!
+//! * **Nul terminators and implicit string lengths** - Often, C
+//! strings are nul-terminated, i.e. they have a `0` character at the
+//! end.  The length of a string buffer is not known *a priori*;
+//! instead, to compute the length of a string, C code must manually
+//! call a function like `strlen()` for `char`-based strings, or
+//! `wcslen()` for `wchar_t`-based ones.  Those functions return the
+//! number of characters in the string excluding the nul terminator,
+//! so the buffer length is really `len+1` characters.  Rust strings
+//! don't have a nul terminator, and they always know their length.
+//!
+//! * **No nul characters in the middle of the string** - When C
+//! strings have a nul terminator character, this usually means that
+//! they cannot have nul characters in the middle — a nul character
+//! would essentially truncate the string.  Rust strings *can* have
+//! nul characters in the middle, since they don't use nul
+//! terminators.
+//!
+//! # Representations of non-Rust strings
+//!
+//! [`CString`] and [`CStr`] are useful when you need to transfer
+//! UTF-8 strings to and from C, respectively:
+//!
+//! * **From Rust to C:** [`CString`] represents an owned, C-friendly
+//! UTF-8 string:  it is valid UTF-8, it is nul-terminated, and has no
+//! nul characters in the middle.  Rust code can create a `CString`
+//! out of a normal string (provided that the string doesn't have nul
+//! characters in the middle), and then use a variety of methods to
+//! obtain a raw `*mut u8` that can then be passed as an argument to C
+//! functions.
+//!
+//! * **From C to Rust:** [`CStr`] represents a borrowed C string; it
+//! is what you would use to wrap a raw `*const u8` that you got from
+//! a C function.  A `CStr` is just guaranteed to be a nul-terminated
+//! array of bytes; the UTF-8 validation step only happens when you
+//! request to convert it to a `&str`.
+//!
+//! [`OsString`] and [`OsStr`] are useful when you need to transfer
+//! strings to and from operating system calls.  If you need Rust
+//! strings out of them, they can take care of conversion to and from
+//! the operating system's preferred form for strings — of course, it
+//! may not be possible to convert all valid operating system strings
+//! into valid UTF-8; the `OsString` and `OsStr` functions let you know
+//! when this is the case.
+//!
+//! * [`OsString`] represents an owned string in whatever
+//! representation the operating system prefers.  In the Rust standard
+//! library, various APIs that transfer strings to/from the operating
+//! system use `OsString` instead of plain strings.  For example,
+//! [`env::var_os()`] is used to query environment variables; it
+//! returns an `Option<OsString>`.  If the environment variable exists
+//! you will get a `Some(os_string)`, which you can *then* try to
+//! convert to a Rust string.  This yields a [`Result<>`], so that
+//! your code can detect errors in case the environment variable did
+//! not in fact contain valid Unicode data.
+//!
+//! * [`OsStr`] represents a borrowed reference to a string in a format that
+//! can be passed to the operating system.  It can be converted into
+//! an UTF-8 Rust string slice in a similar way to `OsString`.
+//!
+//! [`String`]: ../string/struct.String.html
+//! [`str`]: ../primitive.str.html
+//! [`char`]: ../primitive.char.html
+//! [Unicode scalar value]: http://www.unicode.org/glossary/#unicode_scalar_value
+//! [Unicode code point]: http://www.unicode.org/glossary/#code_point
+//! [`CString`]: struct.CString.html
+//! [`CStr`]: struct.CStr.html
+//! [`OsString`]: struct.OsString.html
+//! [`OsStr`]: struct.OsStr.html
+//! [`env::set_var()`]: ../env/fn.set_var.html
+//! [`env::var_os()`]: ../env/fn.var_os.html
+//! [`Result<>`]: ../result/enum.Result.html
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libstd/ffi/mod.rs
+++ b/src/libstd/ffi/mod.rs
@@ -92,13 +92,40 @@
 //! your code can detect errors in case the environment variable did
 //! not in fact contain valid Unicode data.
 //!
-//! * [`OsStr`] represents a borrowed string slice in a format that
-//! can be passed to the operating system.  It can be converted into
-//! an UTF-8 Rust string slice in a similar way to `OsString`.
+//! * [`OsStr`] represents a borrowed reference to a string in a
+//! format that can be passed to the operating system.  It can be
+//! converted into an UTF-8 Rust string slice in a similar way to
+//! `OsString`.
+//!
+//! # Conversions
+//!
+//! ## On Unix
+//!
+//! On Unix, [`OsStr`] implements the `std::os::unix:ffi::`[`OsStrExt`][unix.OsStrExt] trait, which
+//! augments it with two methods, [`from_bytes`] and [`as_bytes`].  These do inexpensive conversions
+//! from and to UTF-8 byte slices.
+//!
+//! Additionally, on Unix [`OsString`] implements the
+//! `std::os::unix:ffi::`[`OsStringExt`][unix.OsStringExt] trait,
+//! which provides [`from_vec`] and [`into_vec`] methods that consume
+//! their arguments, and take or produce vectors of [`u8`].
+//!
+//! ## On Windows
+//!
+//! On Windows, [`OsStr`] implements the `std::os::windows::ffi::`[`OsStrExt`][windows.OsStrExt]
+//! trait, which provides an [`encode_wide`] method.  This provides an iterator that can be
+//! [`collect`]ed into a vector of [`u16`].
+//!
+//! Additionally, on Windows [`OsString`] implements the
+//! `std::os::windows:ffi::`[`OsStringExt`][windows.OsStringExt] trait, which provides a
+//! [`from_wide`] method.  The result of this method is an `OsString` which can be round-tripped to
+//! a Windows string losslessly.
 //!
 //! [`String`]: ../string/struct.String.html
 //! [`str`]: ../primitive.str.html
 //! [`char`]: ../primitive.char.html
+//! [`u8`]: ../primitive.u8.html
+//! [`u16`]: ../primitive.u16.html
 //! [Unicode scalar value]: http://www.unicode.org/glossary/#unicode_scalar_value
 //! [Unicode code point]: http://www.unicode.org/glossary/#code_point
 //! [`CString`]: struct.CString.html
@@ -108,6 +135,18 @@
 //! [`env::set_var()`]: ../env/fn.set_var.html
 //! [`env::var_os()`]: ../env/fn.var_os.html
 //! [`Result<>`]: ../result/enum.Result.html
+//! [unix.OsStringExt]: ../os/unix/ffi/trait.OsStringExt.html
+//! [`from_vec`]: ../os/unix/ffi/trait.OsStringExt.html#tymethod.from_vec
+//! [`into_vec`]: ../os/unix/ffi/trait.OsStringExt.html#tymethod.into_vec
+//! [unix.OsStrExt]: ../os/unix/ffi/trait.OsStrExt.html
+//! [`from_bytes`]: ../os/unix/ffi/trait.OsStrExt.html#tymethod.from_bytes
+//! [`as_bytes`]: ../os/unix/ffi/trait.OsStrExt.html#tymethod.as_bytes
+//! [`OsStrExt`]: ../os/unix/ffi/trait.OsStrExt.html
+//! [windows.OsStrExt]: ../os/windows/ffi/trait.OsStrExt.html
+//! [`encode_wide`]: ../os/windows/ffi/trait.OsStrExt.html#tymethod.encode_wide
+//! [`collect`]: ../iter/trait.Iterator.html#method.collect
+//! [windows.OsStringExt]: ../os/windows/ffi/trait.OsStringExt.html
+//! [`from_wide`]: ../os/windows/ffi/trait.OsStringExt.html#tymethod.from_wide
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -59,8 +59,8 @@ use sys_common::{AsInner, IntoInner, FromInner};
 ///
 /// # Conversions
 ///
-/// See the [module's toplevel documentation about conversions][conversions] for a discussion on the traits which
-/// `OsString` implements for conversions from/to native representations.
+/// See the [module's toplevel documentation about conversions][conversions] for a discussion on
+/// the traits which `OsString` implements for conversions from/to native representations.
 ///
 /// [`OsStr`]: struct.OsStr.html
 /// [`From`]: ../convert/trait.From.html
@@ -87,8 +87,8 @@ pub struct OsString {
 /// `OsStr` is to [`OsString`] as [`String`] is to [`&str`]: the former in each pair are borrowed
 /// references; the latter are owned strings.
 ///
-/// See the [module's toplevel documentation about conversions][conversions] for a discussion on the traits which
-/// `OsStr` implements for conversions from/to native representations.
+/// See the [module's toplevel documentation about conversions][conversions] for a discussion on
+/// the traits which `OsStr` implements for conversions from/to native representations.
 ///
 /// [`OsString`]: struct.OsString.html
 /// [conversions]: index.html#conversions

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -33,18 +33,65 @@ use sys_common::{AsInner, IntoInner, FromInner};
 ///
 /// `OsString` and [`OsStr`] bridge this gap by simultaneously representing Rust
 /// and platform-native string values, and in particular allowing a Rust string
-/// to be converted into an "OS" string with no cost.
+/// to be converted into an "OS" string with no cost if possible.
+///
+/// `OsString` is to [`OsStr`] as [`String`] is to [`&str`]: the former
+/// in each pair are owned strings; the latter are borrowed
+/// references.
+///
+/// # Creating an `OsString`
+///
+/// **From a Rust string**: `OsString` implements
+/// [`From`]`<`[`String`]`>`, so you can use `my_string.`[`from`] to
+/// create an `OsString` from a normal Rust string.
+///
+/// **From slices:** Just like you can start with an empty Rust
+/// [`String`] and then [`push_str`][String.push_str] `&str`
+/// sub-string slices into it, you can create an empty `OsString` with
+/// the [`new`] method and then push string slices into it with the
+/// [`push`] method.
+///
+/// # Extracting a borrowed reference to the whole OS string
+///
+/// You can use the [`as_os_str`] method to get an `&`[`OsStr`] from
+/// an `OsString`; this is effectively a borrowed reference to the
+/// whole string.
+///
+/// # Conversions
+///
+/// See the [module's toplevel documentation about conversions][conversions] for a discussion on the traits which
+/// `OsString` implements for conversions from/to native representations.
 ///
 /// [`OsStr`]: struct.OsStr.html
+/// [`From`]: ../convert/trait.From.html
+/// [`from`]: ../convert/trait.From.html#tymethod.from
+/// [`String`]: ../string/struct.String.html
+/// [`&str`]: ../primitive.str.html
+/// [`u8`]: ../primitive.u8.html
+/// [`u16`]: ../primitive.u16.html
+/// [String.push_str]: ../string/struct.String.html#method.push_str
+/// [`new`]: #struct.OsString.html#method.new
+/// [`push`]: #struct.OsString.html#method.push
+/// [`as_os_str`]: #struct.OsString.html#method.as_os_str
 #[derive(Clone)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct OsString {
     inner: Buf
 }
 
-/// Slices into OS strings (see [`OsString`]).
+/// Borrowed reference to an OS string (see [`OsString`]).
+///
+/// This type represents a borrowed reference to a string in the operating system's preferred
+/// representation.
+///
+/// `OsStr` is to [`OsString`] as [`String`] is to [`&str`]: the former in each pair are borrowed
+/// references; the latter are owned strings.
+///
+/// See the [module's toplevel documentation about conversions][conversions] for a discussion on the traits which
+/// `OsStr` implements for conversions from/to native representations.
 ///
 /// [`OsString`]: struct.OsString.html
+/// [conversions]: index.html#conversions
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct OsStr {
     inner: Slice

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -70,9 +70,9 @@ use sys_common::{AsInner, IntoInner, FromInner};
 /// [`u8`]: ../primitive.u8.html
 /// [`u16`]: ../primitive.u16.html
 /// [String.push_str]: ../string/struct.String.html#method.push_str
-/// [`new`]: #struct.OsString.html#method.new
-/// [`push`]: #struct.OsString.html#method.push
-/// [`as_os_str`]: #struct.OsString.html#method.as_os_str
+/// [`new`]: #method.new
+/// [`push`]: #method.push
+/// [`as_os_str`]: #method.as_os_str
 #[derive(Clone)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct OsString {

--- a/src/libstd/sys/windows/ext/ffi.rs
+++ b/src/libstd/sys/windows/ext/ffi.rs
@@ -9,6 +9,62 @@
 // except according to those terms.
 
 //! Windows-specific extensions to the primitives in the `std::ffi` module.
+//!
+//! # Overview
+//!
+//! For historical reasons, the Windows API uses a form of potentially
+//! ill-formed UTF-16 encoding for strings.  Specifically, the 16-bit
+//! code units in Windows strings may contain [isolated surrogate code
+//! points which are not paired together][ill-formed-utf-16].  The
+//! Unicode standard requires that surrogate code points (those in the
+//! range U+D800 to U+DFFF) always be *paired*, because in the UTF-16
+//! encoding a *surrogate code unit pair* is used to encode a single
+//! character.  For compatibility with code that does not enforce
+//! these pairings, Windows does not enforce them, either.
+//!
+//! While it is not always possible to convert such a string losslessly into
+//! a valid UTF-16 string (or even UTF-8), it is often desirable to be
+//! able to round-trip such a string from and to Windows APIs
+//! losslessly.  For example, some Rust code may be "bridging" some
+//! Windows APIs together, just passing `WCHAR` strings among those
+//! APIs without ever really looking into the strings.
+//!
+//! If Rust code *does* need to look into those strings, it can
+//! convert them to valid UTF-8, possibly lossily, by substituting
+//! invalid sequences with U+FFFD REPLACEMENT CHARACTER, as is
+//! conventionally done in other Rust APIs that deal with string
+//! encodings.
+//!
+//! # `OsStringExt` and `OsStrExt`
+//!
+//! [`OsString`] is the Rust wrapper for owned strings in the
+//! preferred representation of the operating system.  On Windows,
+//! this struct gets augmented with an implementation of the
+//! [`OsStringExt`] trait, which has a [`from_wide`] method.  This
+//! lets you create an [`OsString`] from a `&[u16]` slice; presumably
+//! you get such a slice out of a `WCHAR` Windows API.
+//!
+//! Similarly, [`OsStr`] is the Rust wrapper for borrowed strings from
+//! preferred representation of the operating system.  On Windows, the
+//! [`OsStrExt`] trait provides the [`encode_wide`] method, which
+//! outputs an [`EncodeWide`] iterator.  You can [`collect`] this
+//! iterator, for example, to obtain a `Vec<u16>`; you can later get a
+//! pointer to this vector's contents and feed it to Windows APIs.
+//!
+//! These traits, along with [`OsString`] and [`OsStr`], work in
+//! conjunction so that it is possible to **round-trip** strings from
+//! Windows and back, with no loss of data, even if the strings are
+//! ill-formed UTF-16.
+//!
+//! [ill-formed-utf-16]: https://simonsapin.github.io/wtf-8/#ill-formed-utf-16
+//! [`OsString`]: ../../../ffi/struct.OsString.html
+//! [`OsStr`]: ../../../ffi/struct.OsStr.html
+//! [`OsStringExt`]: trait.OsStringExt.html
+//! [`OsStrExt`]: trait.OsStrExt.html
+//! [`EncodeWide`]: struct.EncodeWide.html
+//! [`from_wide`]: trait.OsStringExt.html#tymethod.from_wide
+//! [`encode_wide`]: trait.OsStrExt.html#tymethod.encode_wide
+//! [`collect`]: ../../../iter/trait.Iterator.html#method.collect
 
 #![stable(feature = "rust1", since = "1.0.0")]
 


### PR DESCRIPTION
This expands the documentation for those structs and their corresponding traits, per https://github.com/rust-lang/rust/issues/29354