### PR TITLE
Warn when assigning a block that doesn't have an implicit return

### DIFF
--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -431,6 +431,14 @@ impl Handler {
     pub fn span_warn<S: Into<MultiSpan>>(&self, sp: S, msg: &str) {
         self.emit(&sp.into(), msg, Warning);
     }
+    pub fn mut_span_warn<'a, S: Into<MultiSpan>>(&'a self,
+                                                 sp: S,
+                                                 msg: &str)
+                                                 -> DiagnosticBuilder<'a> {
+        let mut result = DiagnosticBuilder::new(self, Level::Warning, msg);
+        result.set_span(sp);
+        result
+    }
     pub fn span_warn_with_code<S: Into<MultiSpan>>(&self, sp: S, msg: &str, code: &str) {
         self.emit_with_code(&sp.into(), msg, code, Warning);
     }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -849,24 +849,23 @@ impl Expr {
     /// Wether this expression would be valid somewhere that expects a value, for example, an `if`
     /// condition.
     pub fn returns(&self) -> bool {
-        if let ExprKind::Block(ref block) = self.node {
-            match block.stmts.last().map(|last_stmt| &last_stmt.node) {
-                // implicit return
-                Some(&StmtKind::Expr(_)) => true,
-                Some(&StmtKind::Semi(ref expr)) => {
-                    if let ExprKind::Ret(_) = expr.node {
-                        // last statement is explicit return
-                        true
-                    } else {
-                        false
-                    }
+        match self.node {
+            ExprKind::Block(ref block) => {
+                match block.stmts.last().map(|last_stmt| &last_stmt.node) {
+                    // implicit return
+                    Some(&StmtKind::Expr(_)) => true,
+                    // This is a block that doesn't end in an implicit return
+                    _ => false,
                 }
-                // This is a block that doesn't end in either an implicit or explicit return
-                _ => false,
             }
-        } else {
-            // This is not a block, it is a value
-            true
+            ExprKind::Assign(..) |
+            ExprKind::AssignOp(..) |
+            ExprKind::Break(..) |
+            ExprKind::Continue(_) |
+            ExprKind::Loop(..) |
+            ExprKind::Ret(..) |
+            ExprKind::ForLoop(..) => false,
+            _ => true,
         }
     }
 }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1177,6 +1177,9 @@ impl<'a> Parser<'a> {
     pub fn span_warn(&self, sp: Span, m: &str) {
         self.sess.span_diagnostic.span_warn(sp, m)
     }
+    pub fn span_warn_diag(&self, sp: Span, m: &str) -> DiagnosticBuilder<'a> {
+        self.sess.span_diagnostic.mut_span_warn(sp, m)
+    }
     pub fn span_err(&self, sp: Span, m: &str) {
         self.sess.span_diagnostic.span_err(sp, m)
     }
@@ -2832,8 +2835,10 @@ impl<'a> Parser<'a> {
                     let binary = self.mk_binary(codemap::respan(cur_op_span, ast_op), lhs, rhs);
                     self.mk_expr(span, binary, ThinVec::new())
                 }
-                AssocOp::Assign =>
-                    self.mk_expr(span, ExprKind::Assign(lhs, rhs), ThinVec::new()),
+                AssocOp::Assign => {
+                    self.warn_returnless_block_assign(&rhs);
+                    self.mk_expr(span, ExprKind::Assign(lhs, rhs), ThinVec::new())
+                }
                 AssocOp::Inplace =>
                     self.mk_expr(span, ExprKind::InPlace(lhs, rhs), ThinVec::new()),
                 AssocOp::AssignOp(k) => {
@@ -3654,6 +3659,11 @@ impl<'a> Parser<'a> {
             None
         };
         let init = self.parse_initializer()?;
+
+        if let Some(ref init) = init {
+            self.warn_returnless_block_assign(init);
+        }
+
         Ok(P(ast::Local {
             ty,
             pat,
@@ -4185,6 +4195,36 @@ impl<'a> Parser<'a> {
 
         stmt.span = stmt.span.with_hi(self.prev_span.hi());
         Ok(Some(stmt))
+    }
+
+    /// Warn when assigning a block that doesn't have an implicit return.
+    ///
+    /// The following code is valid, but probably not what the writer intended, so we warn on it:
+    ///
+    /// ```rust
+    /// let x = { 2 + 2; };
+    /// //      ^^^^^^^-^^ assigning result of block that evaluates to `()`
+    /// //             |
+    /// //             help: consider removing this semicolon
+    /// ```
+    fn warn_returnless_block_assign(&self, expr: &P<Expr>) {
+        if let ExprKind::Block(ref block) = expr.node {
+            if !expr.returns() {
+                let mut diag = self.diagnostic()
+                    .mut_span_warn(expr.span, "assinging result of block that evaluates to `()`");
+
+                let last_stmt = block.stmts.last().map(|last_stmt| &last_stmt.node);
+                if let Some(&StmtKind::Semi(ref expr)) = last_stmt {
+                    // Suggest to remove `;` if the expression makes sense.
+                    if expr.returns() {
+                        diag.span_suggestion(expr.span.next_point(),
+                                             "consider removing this semicolon",
+                                             "".to_string());
+                    }
+                }
+                diag.emit();
+            }
+        }
     }
 
     fn warn_missing_semicolon(&self) {

--- a/src/test/ui/span/assigning-block.rs
+++ b/src/test/ui/span/assigning-block.rs
@@ -1,0 +1,32 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+
+    let x = {
+        println!("foo");
+        "bar";
+    };
+    println!("{:?}", x);
+
+    let mut y = (); // this is unlikely to happen, but it is caught too.
+    println!("{:?}", y);
+    y = {
+        println!("foo");
+        "bar";
+    };
+    println!("{:?}", y);
+
+    let z = {
+        println!("foo");
+        ()
+    };
+    println!("{:?}", z);
+}

--- a/src/test/ui/span/assigning-block.stderr
+++ b/src/test/ui/span/assigning-block.stderr
@@ -1,0 +1,22 @@
+warning: assinging result of block that evaluates to `()`
+  --> $DIR/assigning-block.rs:13:13
+   |
+13 |       let x = {
+   |  _____________^
+14 | |         println!("foo");
+15 | |         "bar";
+   | |              - help: consider removing this semicolon
+16 | |     };
+   | |_____^
+
+warning: assinging result of block that evaluates to `()`
+  --> $DIR/assigning-block.rs:21:9
+   |
+21 |       y = {
+   |  _________^
+22 | |         println!("foo");
+23 | |         "bar";
+   | |              - help: consider removing this semicolon
+24 | |     };
+   | |_____^
+


### PR DESCRIPTION
Fix #44173:

```
warning: assinging result of block that evaluates to `()`
  --> $DIR/assigning-block.rs:13:13
   |
13 |       let x = {
   |  _____________^
14 | |         println!("foo");
15 | |         "bar";
   | |              - help: consider removing this semicolon
16 | |     };
   | |_____^
```