### PR TITLE
Remove new and index methods already implement for Idx

### DIFF
--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -569,20 +569,6 @@ pub(super) struct DepNodeIndexNew {
 }
 
 impl Idx for DepNodeIndexNew {
-    fn new(idx: usize) -> Self {
-        DepNodeIndexNew::new(idx)
-    }
-    fn index(self) -> usize {
-        self.index()
-    }
-}
-
-impl DepNodeIndexNew {
-
-    const INVALID: DepNodeIndexNew = DepNodeIndexNew {
-        index: ::std::u32::MAX,
-    };
-
     fn new(v: usize) -> DepNodeIndexNew {
         assert!((v & 0xFFFF_FFFF) == v);
         DepNodeIndexNew { index: v as u32 }
@@ -591,6 +577,12 @@ impl DepNodeIndexNew {
     fn index(self) -> usize {
         self.index as usize
     }
+}
+
+impl DepNodeIndexNew {
+    const INVALID: DepNodeIndexNew = DepNodeIndexNew {
+        index: ::std::u32::MAX,
+    };
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/librustc/dep_graph/serialized.rs
+++ b/src/librustc/dep_graph/serialized.rs
@@ -19,14 +19,6 @@ use rustc_data_structures::indexed_vec::{IndexVec, Idx};
          RustcEncodable, RustcDecodable)]
 pub struct SerializedDepNodeIndex(pub u32);
 
-impl SerializedDepNodeIndex {
-    #[inline]
-    pub fn new(idx: usize) -> SerializedDepNodeIndex {
-        assert!(idx <= ::std::u32::MAX as usize);
-        SerializedDepNodeIndex(idx as u32)
-    }
-}
-
 impl Idx for SerializedDepNodeIndex {
     #[inline]
     fn new(idx: usize) -> Self {


### PR DESCRIPTION
These are the rest of the repeated implementations for new and index methods. Follow up of https://github.com/rust-lang/rust/pull/44889