### PR TITLE
Normalize spaces in lang attributes.

### DIFF
--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -122,7 +122,7 @@ pub trait Sized {
 /// [RFC982]: https://github.com/rust-lang/rfcs/blob/master/text/0982-dst-coercion.md
 /// [nomicon-coerce]: ../../nomicon/coercions.html
 #[unstable(feature = "unsize", issue = "27732")]
-#[lang="unsize"]
+#[lang = "unsize"]
 pub trait Unsize<T: ?Sized> {
     // Empty.
 }

--- a/src/libcore/ops/unsize.rs
+++ b/src/libcore/ops/unsize.rs
@@ -42,7 +42,7 @@ use marker::Unsize;
 /// [unsize]: ../marker/trait.Unsize.html
 /// [nomicon-coerce]: ../../nomicon/coercions.html
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-#[lang="coerce_unsized"]
+#[lang = "coerce_unsized"]
 pub trait CoerceUnsized<T> {
     // Empty.
 }

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -56,7 +56,7 @@ pub use intrinsics::write_bytes;
 /// This has all the same safety problems as `ptr::read` with respect to
 /// invalid pointers, types, and double drops.
 #[stable(feature = "drop_in_place", since = "1.8.0")]
-#[lang="drop_in_place"]
+#[lang = "drop_in_place"]
 #[allow(unconditional_recursion)]
 pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T) {
     // Code here does not matter - this is replaced by the

--- a/src/rtstartup/rsbegin.rs
+++ b/src/rtstartup/rsbegin.rs
@@ -38,7 +38,7 @@ trait Copy {}
 trait Freeze {}
 impl Freeze for .. {}
 
-#[lang="drop_in_place"]
+#[lang = "drop_in_place"]
 #[inline]
 #[allow(unconditional_recursion)]
 pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T) {

--- a/src/rtstartup/rsend.rs
+++ b/src/rtstartup/rsend.rs
@@ -25,7 +25,7 @@ trait Copy {}
 trait Freeze {}
 impl Freeze for .. {}
 
-#[lang="drop_in_place"]
+#[lang = "drop_in_place"]
 #[inline]
 #[allow(unconditional_recursion)]
 pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T) {


### PR DESCRIPTION
So, like, I grepped for all `lang` attributes for *reasons* and I noticed that they all share the same spacing of `#[lang = "item_name"]` except these five instances. So I decided to fix that. So enjoy this PR of exactly ten spaces.