### PR TITLE
Update docs for process::abort

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1142,7 +1142,7 @@ pub fn exit(code: i32) -> ! {
 /// }
 /// ```
 ///
-/// The [`abort`] function terminates the process, so the destructor will not
+/// The `abort` function terminates the process, so the destructor will not
 /// get run on the example below:
 ///
 /// ```no_run

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1129,7 +1129,8 @@ pub fn exit(code: i32) -> ! {
 /// This is in contrast to the default behaviour of [`panic!`] which unwinds
 /// the current thread's stack and calls all destructors.
 /// When `panic="abort"` is set, either as an argument to `rustc` or in a
-/// crate's Cargo.toml, [`panic!`] and `abort` are equivalent.
+/// crate's Cargo.toml, [`panic!`] and `abort` are similar. However,
+/// [`panic!`] will still call the [panic hook] while `abort` will not.
 ///
 /// If a clean shutdown is needed it is recommended to only call
 /// this function at a known point where there are no more destructors left
@@ -1171,6 +1172,7 @@ pub fn exit(code: i32) -> ! {
 /// ```
 ///
 /// [`panic!`]: ../../std/macro.panic.html
+/// [panic hook]: ../../std/panic/fn.set_hook.html
 #[stable(feature = "process_abort", since = "1.17.0")]
 pub fn abort() -> ! {
     unsafe { ::sys::abort_internal() };

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1124,7 +1124,14 @@ pub fn exit(code: i32) -> ! {
 ///
 /// Note that because this function never returns, and that it terminates the
 /// process, no destructors on the current stack or any other thread's stack
-/// will be run. If a clean shutdown is needed it is recommended to only call
+/// will be run.
+///
+/// This is in contrast to the default behaviour of [`panic!`] which unwinds
+/// the current thread's stack and calls all destructors.
+/// When `panic="abort"` is set, either as an argument to `rustc` or in a
+/// crate's Cargo.toml, [`panic!`] and `abort` are equivalent.
+///
+/// If a clean shutdown is needed it is recommended to only call
 /// this function at a known point where there are no more destructors left
 /// to run.
 ///
@@ -1162,6 +1169,8 @@ pub fn exit(code: i32) -> ! {
 ///     // the destructor implemented for HasDrop will never get run
 /// }
 /// ```
+///
+/// [`panic!`]: ../../std/macro.panic.html
 #[stable(feature = "process_abort", since = "1.17.0")]
 pub fn abort() -> ! {
     unsafe { ::sys::abort_internal() };


### PR DESCRIPTION
Remove a typo and explain the relationship to `panic!`.

Part of #29370 

r? @steveklabnik