### PR TITLE
Implement TryFrom for CString and CStr

### DIFF
--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -11,6 +11,7 @@
 use ascii;
 use borrow::{Cow, Borrow};
 use cmp::Ordering;
+use convert::TryFrom;
 use error::Error;
 use fmt::{self, Write};
 use io;
@@ -646,6 +647,24 @@ impl From<CString> for Vec<u8> {
     }
 }
 
+#[unstable(feature = "try_from", issue = "33417")]
+impl TryFrom<Vec<u8>> for CString {
+    type Error = NulError;
+
+    fn try_from(bytes: Vec<u8>) -> Result<CString, NulError> {
+        CString::_new(bytes)
+    }
+}
+
+#[unstable(feature = "try_from", issue = "33417")]
+impl TryFrom<CString> for String {
+    type Error = IntoStringError;
+
+    fn try_from(c_str: CString) -> Result<String, IntoStringError> {
+        c_str.into_string()
+    }
+}
+
 #[stable(feature = "cstr_debug", since = "1.3.0")]
 impl fmt::Debug for CStr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -654,6 +673,15 @@ impl fmt::Debug for CStr {
             f.write_char(byte as char)?;
         }
         write!(f, "\"")
+    }
+}
+
+#[unstable(feature = "try_from", issue = "33417")]
+impl<'a> TryFrom<&'a [u8]> for &'a CStr {
+    type Error = FromBytesWithNulError;
+
+    fn try_from(bytes: &[u8]) -> Result<&CStr, FromBytesWithNulError> {
+        CStr::from_bytes_with_nul(bytes)
     }
 }
 


### PR DESCRIPTION
Implements `TryFrom` by utilizing the available conversions.

This is a subset of #33417.

## Conversions

| From               | Into              | Kind           |
| :----------------- | :---------------- | :------------- |
| ~~`&{mut,} [u8]`~~ | ~~`&{mut,} str`~~ | ~~UTF-8~~      |
| ~~`Vec<u8>`~~      | ~~`String`~~      | ~~UTF-8~~      |
| ~~`&[u16]`~~       | ~~`String`~~      | ~~UTF-16~~     |
| `&[u8]`            | `&CStr`           | UTF-8 with nul |
| `CString`          | `String`          | UTF-8          |
| `Into<Vec<u8>>`    | `CString`         | UTF-8 with nul |

## Motivation
These types already have conversions that return `Result<Self, Error>`. This simply implements `TryFrom` for such types.