### PR TITLE
Update the libcompiler_builtins submodule

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -290,8 +290,8 @@ dependencies = [
 name = "compiler_builtins"
 version = "0.0.0"
 dependencies = [
+ "cc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core 0.0.0",
- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -584,11 +584,6 @@ dependencies = [
 [[package]]
 name = "futures"
 version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "gcc"
-version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2521,7 +2516,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fs2 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9ab76cfd2aaa59b7bf6688ad9ba15bbae64bff97f04ea02144cfd3443e5c2866"
 "checksum futf 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "51f93f3de6ba1794dcd5810b3546d004600a59a98266487c8407bc4b24e398f3"
 "checksum futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "05a23db7bd162d4e8265968602930c476f688f0c180b44bdaf55e0cb2c687558"
-"checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "65922871abd2f101a2eb0eaebadc66668e54a87ad9c3dd82520b5f86ede5eff9"
 "checksum git2 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0c1c0203d653f4140241da0c1375a404f0a397249ec818cd2076c6280c50f6fa"
 "checksum git2-curl 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "68676bc784bf0bef83278898929bf64a251e87c0340723d0b93fa096c9c5bf8e"

--- a/src/rustc/compiler_builtins_shim/Cargo.toml
+++ b/src/rustc/compiler_builtins_shim/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 core = { path = "../../libcore" }
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"
 
 [features]
 c = []


### PR DESCRIPTION
Pulls in the latest changes from libcompiler_builtins.

It should work, but it would be best if this wouldn't get put into a rollup so that bisecting is possible if there is a regression.

r? @alexcrichton 