### PR TITLE
MIR borrowck: move span_label to `borrowck_errors.rs`

### DIFF
--- a/src/librustc_borrowck/borrowck/check_loans.rs
+++ b/src/librustc_borrowck/borrowck/check_loans.rs
@@ -865,13 +865,7 @@ impl<'a, 'tcx> CheckLoanCtxt<'a, 'tcx> {
                                    loan_path: &LoanPath<'tcx>,
                                    loan: &Loan) {
         self.bccx.cannot_assign_to_borrowed(
-            span, &self.bccx.loan_path_to_string(loan_path), Origin::Ast)
-            .span_label(loan.span,
-                       format!("borrow of `{}` occurs here",
-                               self.bccx.loan_path_to_string(loan_path)))
-            .span_label(span,
-                       format!("assignment to borrowed `{}` occurs here",
-                               self.bccx.loan_path_to_string(loan_path)))
+            span, loan.span, &self.bccx.loan_path_to_string(loan_path), Origin::Ast)
             .emit();
     }
 }

--- a/src/librustc_borrowck/borrowck/check_loans.rs
+++ b/src/librustc_borrowck/borrowck/check_loans.rs
@@ -640,14 +640,10 @@ impl<'a, 'tcx> CheckLoanCtxt<'a, 'tcx> {
             UseOk => { }
             UseWhileBorrowed(loan_path, loan_span) => {
                 let desc = self.bccx.loan_path_to_string(copy_path);
-                self.bccx.cannot_use_when_mutably_borrowed(span, &desc, Origin::Ast)
-                    .span_label(loan_span,
-                               format!("borrow of `{}` occurs here",
-                                       &self.bccx.loan_path_to_string(&loan_path))
-                               )
-                    .span_label(span,
-                               format!("use of borrowed `{}`",
-                                        &self.bccx.loan_path_to_string(&loan_path)))
+                self.bccx.cannot_use_when_mutably_borrowed(
+                        span, &desc,
+                        loan_span, &self.bccx.loan_path_to_string(&loan_path),
+                        Origin::Ast)
                     .emit();
             }
         }

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -759,11 +759,7 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
 
                 let mut db = match err.cause {
                     MutabilityViolation => {
-                        struct_span_err!(self.tcx.sess,
-                                         error_span,
-                                         E0594,
-                                         "cannot assign to {}",
-                                         descr)
+                        self.cannot_assign(error_span, &descr, Origin::Ast)
                     }
                     BorrowViolation(euv::ClosureCapture(_)) => {
                         struct_span_err!(self.tcx.sess, error_span, E0595,

--- a/src/librustc_borrowck/diagnostics.rs
+++ b/src/librustc_borrowck/diagnostics.rs
@@ -742,6 +742,5 @@ b.resume();
 
 register_diagnostics! {
 //    E0385, // {} in an aliasable location
-    E0594, // cannot assign to {}
     E0598, // lifetime of {} is too short to guarantee its contents can be...
 }

--- a/src/librustc_mir/borrow_check.rs
+++ b/src/librustc_mir/borrow_check.rs
@@ -931,14 +931,11 @@ impl<'c, 'b, 'a: 'b+'c, 'gcx, 'tcx: 'a> MirBorrowckCtxt<'c, 'b, 'a, 'gcx, 'tcx> 
                                          _context: Context,
                                          (lvalue, span): (&Lvalue, Span),
                                          borrow : &BorrowData) {
-        let described_lvalue = self.describe_lvalue(lvalue);
-        let borrow_span = self.retrieve_borrow_span(borrow);
 
         let mut err = self.tcx.cannot_use_when_mutably_borrowed(
-            span, &described_lvalue, Origin::Mir);
-
-        err.span_label(borrow_span, format!("borrow of `{}` occurs here", described_lvalue));
-        err.span_label(span, format!("use of borrowed `{}`", described_lvalue));
+            span, &self.describe_lvalue(lvalue),
+            self.retrieve_borrow_span(borrow), &self.describe_lvalue(&borrow.lvalue),
+            Origin::Mir);
 
         err.emit();
     }

--- a/src/librustc_mir/borrow_check.rs
+++ b/src/librustc_mir/borrow_check.rs
@@ -1010,7 +1010,6 @@ impl<'c, 'b, 'a: 'b+'c, 'gcx, 'tcx: 'a> MirBorrowckCtxt<'c, 'b, 'a, 'gcx, 'tcx> 
     fn report_assignment_to_static(&mut self, _context: Context, (lvalue, span): (&Lvalue, Span)) {
         let mut err = self.tcx.cannot_assign_static(
             span, &self.describe_lvalue(lvalue), Origin::Mir);
-        // FIXME: add span labels for borrow and assignment points
         err.emit();
     }
 }

--- a/src/librustc_mir/borrow_check.rs
+++ b/src/librustc_mir/borrow_check.rs
@@ -991,14 +991,8 @@ impl<'c, 'b, 'a: 'b+'c, 'gcx, 'tcx: 'a> MirBorrowckCtxt<'c, 'b, 'a, 'gcx, 'tcx> 
                                            _: Context,
                                            (lvalue, span): (&Lvalue, Span),
                                            loan: &BorrowData) {
-        let describe_lvalue = self.describe_lvalue(lvalue);
-        let borrow_span = self.retrieve_borrow_span(loan);
-
         let mut err = self.tcx.cannot_assign_to_borrowed(
-            span, &self.describe_lvalue(lvalue), Origin::Mir);
-
-        err.span_label(borrow_span, format!("borrow of `{}` occurs here", describe_lvalue));
-        err.span_label(span, format!("assignment to borrowed `{}` occurs here", describe_lvalue));
+            span, self.retrieve_borrow_span(loan), &self.describe_lvalue(lvalue), Origin::Mir);
 
         err.emit();
     }

--- a/src/librustc_mir/diagnostics.rs
+++ b/src/librustc_mir/diagnostics.rs
@@ -1005,5 +1005,6 @@ register_diagnostics! {
     E0493, // destructors cannot be evaluated at compile-time
     E0524, // two closures require unique access to `..` at the same time
     E0526, // shuffle indices are not constant
+    E0594, // cannot assign to {}
     E0625, // thread-local statics cannot be accessed at compile-time
 }

--- a/src/librustc_mir/util/borrowck_errors.rs
+++ b/src/librustc_mir/util/borrowck_errors.rs
@@ -140,12 +140,17 @@ pub trait BorrowckErrors {
                          desc_new, msg_new, kind_new, noun_old, kind_old, msg_old, OGN=o)
     }
 
-    fn cannot_assign_to_borrowed(&self, span: Span, desc: &str, o: Origin)
+    fn cannot_assign_to_borrowed(&self, span: Span, borrow_span: Span, desc: &str, o: Origin)
                                  -> DiagnosticBuilder
     {
-        struct_span_err!(self, span, E0506,
+        let mut err = struct_span_err!(self, span, E0506,
                          "cannot assign to `{}` because it is borrowed{OGN}",
-                         desc, OGN=o)
+                         desc, OGN=o);
+
+        err.span_label(borrow_span, format!("borrow of `{}` occurs here", desc));
+        err.span_label(span, format!("assignment to borrowed `{}` occurs here", desc));
+
+        err
     }
 
     fn cannot_move_into_closure(&self, span: Span, desc: &str, o: Origin)

--- a/src/librustc_mir/util/borrowck_errors.rs
+++ b/src/librustc_mir/util/borrowck_errors.rs
@@ -179,11 +179,17 @@ pub trait BorrowckErrors {
                          desc, OGN=o)
     }
 
+    fn cannot_assign(&self, span: Span, desc: &str, o: Origin) -> DiagnosticBuilder
+    {
+        struct_span_err!(self, span, E0594,
+                         "cannot assign to {}{OGN}",
+                         desc, OGN=o)
+    }
+
     fn cannot_assign_static(&self, span: Span, desc: &str, o: Origin)
                             -> DiagnosticBuilder
     {
-        self.struct_span_err(span, &format!("cannot assign to immutable static item {}{OGN}",
-                                            desc, OGN=o))
+        self.cannot_assign(span, &format!("immutable static item `{}`", desc), o)
     }
 }
 

--- a/src/librustc_mir/util/borrowck_errors.rs
+++ b/src/librustc_mir/util/borrowck_errors.rs
@@ -57,12 +57,22 @@ pub trait BorrowckErrors {
                          desc, OGN=o)
     }
 
-    fn cannot_use_when_mutably_borrowed(&self, span: Span, desc: &str, o: Origin)
+    fn cannot_use_when_mutably_borrowed(&self,
+                                        span: Span,
+                                        desc: &str,
+                                        borrow_span: Span,
+                                        borrow_desc: &str,
+                                        o: Origin)
                                         -> DiagnosticBuilder
     {
-        struct_span_err!(self, span, E0503,
+        let mut err = struct_span_err!(self, span, E0503,
                          "cannot use `{}` because it was mutably borrowed{OGN}",
-                         desc, OGN=o)
+                         desc, OGN=o);
+
+        err.span_label(borrow_span, format!("borrow of `{}` occurs here", borrow_desc));
+        err.span_label(span, format!("use of borrowed `{}`", borrow_desc));
+
+        err
     }
 
     fn cannot_act_on_uninitialized_variable(&self,

--- a/src/test/compile-fail/E0594.rs
+++ b/src/test/compile-fail/E0594.rs
@@ -1,4 +1,4 @@
-// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -11,15 +11,10 @@
 // revisions: ast mir
 //[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
 
-struct TrieMapIterator<'a> {
-    node: &'a usize
-}
+static NUM: i32 = 18;
 
 fn main() {
-    let a = 5;
-    let _iter = TrieMapIterator{node: &a};
-    _iter.node = & //[ast]~ ERROR cannot assign to immutable field
-                   //[mir]~^ ERROR cannot assign to immutable field `_iter.node` (Ast)
-                   // FIXME Error for MIR
-    panic!()
+    NUM = 20; //[ast]~ ERROR E0594
+              //[mir]~^ ERROR cannot assign to immutable static item (Ast)
+              //[mir]~| ERROR cannot assign to immutable static item `NUM` (Mir)
 }

--- a/src/test/compile-fail/borrowck/borrowck-assign-to-constants.rs
+++ b/src/test/compile-fail/borrowck/borrowck-assign-to-constants.rs
@@ -8,9 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// revisions: ast mir
+//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+
 static foo: isize = 5;
 
 fn main() {
     // assigning to various global constants
-    foo = 6; //~ ERROR cannot assign to immutable static item
+    foo = 6; //[ast]~ ERROR cannot assign to immutable static item
+             //[mir]~^ ERROR cannot assign to immutable static item (Ast)
+             //[mir]~| ERROR cannot assign to immutable static item `foo` (Mir)
 }

--- a/src/test/compile-fail/borrowck/borrowck-overloaded-index-ref-index.rs
+++ b/src/test/compile-fail/borrowck/borrowck-overloaded-index-ref-index.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// revisions: ast mir
+//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+
 use std::ops::{Index, IndexMut};
 
 struct Foo {
@@ -57,12 +60,18 @@ fn main() {
     let mut s = "hello".to_string();
     let rs = &mut s;
     println!("{}", f[&s]);
-    //~^ ERROR cannot borrow `s` as immutable because it is also borrowed as mutable
+    //[ast]~^ ERROR cannot borrow `s` as immutable because it is also borrowed as mutable
+    //[mir]~^^ ERROR cannot borrow `s` as immutable because it is also borrowed as mutable (Ast)
+    //[mir]~| ERROR cannot borrow `s` as immutable because it is also borrowed as mutable (Mir)
     f[&s] = 10;
-    //~^ ERROR cannot borrow `s` as immutable because it is also borrowed as mutable
+    //[ast]~^ ERROR cannot borrow `s` as immutable because it is also borrowed as mutable
+    //[mir]~^^ ERROR cannot borrow `s` as immutable because it is also borrowed as mutable (Ast)
+    //[mir]~| ERROR cannot borrow `s` as immutable because it is also borrowed as mutable (Mir)
     let s = Bar {
         x: 1,
     };
     s[2] = 20;
-    //~^ ERROR cannot assign to immutable indexed content
+    //[ast]~^ ERROR cannot assign to immutable indexed content
+    //[mir]~^^ ERROR cannot assign to immutable indexed content
+    // FIXME Error for MIR
 }


### PR DESCRIPTION
The calls to `span_label` are moved and factorized for: 
* E0503 (`cannot_use_when_mutably_borrowed()`)
* E0506 (`cannot_assign_to_borrowed()`)

Additionnally, the error E0594 (`cannot_assign_static()`) has been factorized between `check_loan.rs` and `borrowc_check.rs`.

Part of #44596 