### PR TITLE
Remove `T: Sized` on pointer `as_ref()` and `as_mut()`

### DIFF
--- a/src/libcore/nonzero.rs
+++ b/src/libcore/nonzero.rs
@@ -28,8 +28,7 @@ macro_rules! impl_zeroable_for_pointer_types {
             unsafe impl<T: ?Sized> Zeroable for $Ptr {
                 #[inline]
                 fn is_zero(&self) -> bool {
-                    // Cast because `is_null` is only available on thin pointers
-                    (*self as *mut u8).is_null()
+                    (*self).is_null()
                 }
             }
         )+

--- a/src/libcore/nonzero.rs
+++ b/src/libcore/nonzero.rs
@@ -28,7 +28,8 @@ macro_rules! impl_zeroable_for_pointer_types {
             unsafe impl<T: ?Sized> Zeroable for $Ptr {
                 #[inline]
                 fn is_zero(&self) -> bool {
-                    (*self).is_null()
+                    // Cast because `is_null` is only available on thin pointers
+                    (*self as *mut u8).is_null()
                 }
             }
         )+

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -476,11 +476,6 @@ pub unsafe fn write_volatile<T>(dst: *mut T, src: T) {
 impl<T: ?Sized> *const T {
     /// Returns `true` if the pointer is null.
     ///
-    /// Note that unsized types have many possible null pointers, as only the
-    /// raw data pointer is considered, not their length, vtable, etc.
-    /// Therefore, two pointers that are null may still not compare equal to
-    /// each other.
-    ///
     /// # Examples
     ///
     /// Basic usage:
@@ -492,10 +487,8 @@ impl<T: ?Sized> *const T {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    pub fn is_null(self) -> bool {
-        // Compare via a cast to a thin pointer, so fat pointers are only
-        // considering their "data" part for null-ness.
-        (self as *const u8) == null()
+    pub fn is_null(self) -> bool where T: Sized {
+        self == null()
     }
 
     /// Returns `None` if the pointer is null, or else returns a reference to
@@ -527,7 +520,9 @@ impl<T: ?Sized> *const T {
     #[stable(feature = "ptr_as_ref", since = "1.9.0")]
     #[inline]
     pub unsafe fn as_ref<'a>(self) -> Option<&'a T> {
-        if self.is_null() {
+        // Check for null via a cast to a thin pointer, so fat pointers are only
+        // considering their "data" part for null-ness.
+        if (self as *const u8).is_null() {
             None
         } else {
             Some(&*self)
@@ -1114,11 +1109,6 @@ impl<T: ?Sized> *const T {
 impl<T: ?Sized> *mut T {
     /// Returns `true` if the pointer is null.
     ///
-    /// Note that unsized types have many possible null pointers, as only the
-    /// raw data pointer is considered, not their length, vtable, etc.
-    /// Therefore, two pointers that are null may still not compare equal to
-    /// each other.
-    ///
     /// # Examples
     ///
     /// Basic usage:
@@ -1130,10 +1120,8 @@ impl<T: ?Sized> *mut T {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    pub fn is_null(self) -> bool {
-        // Compare via a cast to a thin pointer, so fat pointers are only
-        // considering their "data" part for null-ness.
-        (self as *mut u8) == null_mut()
+    pub fn is_null(self) -> bool where T: Sized {
+        self == null_mut()
     }
 
     /// Returns `None` if the pointer is null, or else returns a reference to
@@ -1165,7 +1153,9 @@ impl<T: ?Sized> *mut T {
     #[stable(feature = "ptr_as_ref", since = "1.9.0")]
     #[inline]
     pub unsafe fn as_ref<'a>(self) -> Option<&'a T> {
-        if self.is_null() {
+        // Check for null via a cast to a thin pointer, so fat pointers are only
+        // considering their "data" part for null-ness.
+        if (self as *const u8).is_null() {
             None
         } else {
             Some(&*self)
@@ -1289,7 +1279,9 @@ impl<T: ?Sized> *mut T {
     #[stable(feature = "ptr_as_ref", since = "1.9.0")]
     #[inline]
     pub unsafe fn as_mut<'a>(self) -> Option<&'a mut T> {
-        if self.is_null() {
+        // Check for null via a cast to a thin pointer, so fat pointers are only
+        // considering their "data" part for null-ness.
+        if (self as *mut u8).is_null() {
             None
         } else {
             Some(&mut *self)

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -476,6 +476,11 @@ pub unsafe fn write_volatile<T>(dst: *mut T, src: T) {
 impl<T: ?Sized> *const T {
     /// Returns `true` if the pointer is null.
     ///
+    /// Note that unsized types have many possible null pointers, as only the
+    /// raw data pointer is considered, not their length, vtable, etc.
+    /// Therefore, two pointers that are null may still not compare equal to
+    /// each other.
+    ///
     /// # Examples
     ///
     /// Basic usage:
@@ -1108,6 +1113,11 @@ impl<T: ?Sized> *const T {
 #[lang = "mut_ptr"]
 impl<T: ?Sized> *mut T {
     /// Returns `true` if the pointer is null.
+    ///
+    /// Note that unsized types have many possible null pointers, as only the
+    /// raw data pointer is considered, not their length, vtable, etc.
+    /// Therefore, two pointers that are null may still not compare equal to
+    /// each other.
     ///
     /// # Examples
     ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -487,8 +487,10 @@ impl<T: ?Sized> *const T {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    pub fn is_null(self) -> bool where T: Sized {
-        self == null()
+    pub fn is_null(self) -> bool {
+        // Compare via a cast to a thin pointer, so fat pointers are only
+        // considering their "data" part for null-ness.
+        (self as *const u8) == null()
     }
 
     /// Returns `None` if the pointer is null, or else returns a reference to
@@ -519,7 +521,7 @@ impl<T: ?Sized> *const T {
     /// ```
     #[stable(feature = "ptr_as_ref", since = "1.9.0")]
     #[inline]
-    pub unsafe fn as_ref<'a>(self) -> Option<&'a T> where T: Sized {
+    pub unsafe fn as_ref<'a>(self) -> Option<&'a T> {
         if self.is_null() {
             None
         } else {
@@ -1118,8 +1120,10 @@ impl<T: ?Sized> *mut T {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    pub fn is_null(self) -> bool where T: Sized {
-        self == null_mut()
+    pub fn is_null(self) -> bool {
+        // Compare via a cast to a thin pointer, so fat pointers are only
+        // considering their "data" part for null-ness.
+        (self as *mut u8) == null_mut()
     }
 
     /// Returns `None` if the pointer is null, or else returns a reference to
@@ -1150,7 +1154,7 @@ impl<T: ?Sized> *mut T {
     /// ```
     #[stable(feature = "ptr_as_ref", since = "1.9.0")]
     #[inline]
-    pub unsafe fn as_ref<'a>(self) -> Option<&'a T> where T: Sized {
+    pub unsafe fn as_ref<'a>(self) -> Option<&'a T> {
         if self.is_null() {
             None
         } else {
@@ -1274,7 +1278,7 @@ impl<T: ?Sized> *mut T {
     /// ```
     #[stable(feature = "ptr_as_ref", since = "1.9.0")]
     #[inline]
-    pub unsafe fn as_mut<'a>(self) -> Option<&'a mut T> where T: Sized {
+    pub unsafe fn as_mut<'a>(self) -> Option<&'a mut T> {
         if self.is_null() {
             None
         } else {

--- a/src/libcore/tests/ptr.rs
+++ b/src/libcore/tests/ptr.rs
@@ -62,39 +62,6 @@ fn test_is_null() {
 
     let mq = unsafe { mp.offset(1) };
     assert!(!mq.is_null());
-
-    // Pointers to unsized types -- slices
-    let s: &mut [u8] = &mut [1, 2, 3];
-    let cs: *const [u8] = s;
-    assert!(!cs.is_null());
-
-    let ms: *mut [u8] = s;
-    assert!(!ms.is_null());
-
-    let cz: *const [u8] = &[];
-    assert!(!cz.is_null());
-
-    let mz: *mut [u8] = &mut [];
-    assert!(!mz.is_null());
-
-    let ncs: *const [u8] = null::<[u8; 3]>();
-    assert!(ncs.is_null());
-
-    let nms: *mut [u8] = null_mut::<[u8; 3]>();
-    assert!(nms.is_null());
-
-    // Pointers to unsized types -- trait objects
-    let ci: *const ToString = &3;
-    assert!(!ci.is_null());
-
-    let mi: *mut ToString = &mut 3;
-    assert!(!mi.is_null());
-
-    let nci: *const ToString = null::<isize>();
-    assert!(nci.is_null());
-
-    let nmi: *mut ToString = null_mut::<isize>();
-    assert!(nmi.is_null());
 }
 
 #[test]

--- a/src/libcore/tests/ptr.rs
+++ b/src/libcore/tests/ptr.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use core::ptr::*;
+use core::slice;
 use core::cell::RefCell;
 
 #[test]
@@ -62,6 +63,28 @@ fn test_is_null() {
 
     let mq = unsafe { mp.offset(1) };
     assert!(!mq.is_null());
+
+    // Pointers to unsized types
+    let s: &mut [u8] = &mut [1, 2, 3];
+    let cs: *const [u8] = s;
+    assert!(!cs.is_null());
+
+    let ms: *mut [u8] = s;
+    assert!(!ms.is_null());
+
+    let cz: *const [u8] = &[];
+    assert!(!cz.is_null());
+
+    let mz: *mut [u8] = &mut [];
+    assert!(!mz.is_null());
+
+    unsafe {
+        let ncs: *const [u8] = slice::from_raw_parts(null(), 0);
+        assert!(ncs.is_null());
+
+        let nms: *mut [u8] = slice::from_raw_parts_mut(null_mut(), 0);
+        assert!(nms.is_null());
+    }
 }
 
 #[test]
@@ -85,6 +108,26 @@ fn test_as_ref() {
             let p = &u as *const isize;
             assert_eq!(p.as_ref().unwrap(), &2);
         }
+
+        // Pointers to unsized types
+        let s: &mut [u8] = &mut [1, 2, 3];
+        let cs: *const [u8] = s;
+        assert_eq!(cs.as_ref(), Some(&*s));
+
+        let ms: *mut [u8] = s;
+        assert_eq!(ms.as_ref(), Some(&*s));
+
+        let cz: *const [u8] = &[];
+        assert_eq!(cz.as_ref(), Some(&[][..]));
+
+        let mz: *mut [u8] = &mut [];
+        assert_eq!(mz.as_ref(), Some(&[][..]));
+
+        let ncs: *const [u8] = slice::from_raw_parts(null(), 0);
+        assert_eq!(ncs.as_ref(), None);
+
+        let nms: *mut [u8] = slice::from_raw_parts_mut(null_mut(), 0);
+        assert_eq!(nms.as_ref(), None);
     }
 }
 
@@ -103,6 +146,17 @@ fn test_as_mut() {
             let p = &mut u as *mut isize;
             assert!(p.as_mut().unwrap() == &mut 2);
         }
+
+        // Pointers to unsized types
+        let s: &mut [u8] = &mut [1, 2, 3];
+        let ms: *mut [u8] = s;
+        assert_eq!(ms.as_mut(), Some(s));
+
+        let mz: *mut [u8] = &mut [];
+        assert_eq!(mz.as_mut(), Some(&mut [][..]));
+
+        let nms: *mut [u8] = slice::from_raw_parts_mut(null_mut(), 0);
+        assert_eq!(nms.as_mut(), None);
     }
 }
 


### PR DESCRIPTION
`NonZero::is_zero()` was already casting all pointers to thin `*mut u8` to check for null.  The same test on unsized fat pointers can also be used with `as_ref()` and `as_mut()` to get fat references.

(This PR formerly changed `is_null()` too, but checking just the data pointer is not obviously correct for trait objects, especially if `*const self` sorts of methods are ever allowed.)