### PR TITLE
Add links to headers in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 # Contributing to Rust
+[contributing-to-rust]: #contributing-to-rust
 
 Thank you for your interest in contributing to Rust! There are many ways to
 contribute, and we appreciate all of them. This document is a bit long, so here's
@@ -23,6 +24,7 @@ As a reminder, all contributors are expected to follow our [Code of Conduct][coc
 [coc]: https://www.rust-lang.org/conduct.html
 
 ## Feature Requests
+[feature-requests]: #feature-requests
 
 To request a change to the way that the Rust language works, please open an
 issue in the [RFCs repository](https://github.com/rust-lang/rfcs/issues/new)
@@ -30,6 +32,7 @@ rather than this one. New features and other significant language changes
 must go through the RFC process.
 
 ## Bug Reports
+[bug-reports]: #bug-reports
 
 While bugs are unfortunate, they're a reality in software. We can't fix what we
 don't know about, so please report liberally. If you're not sure if something
@@ -80,6 +83,7 @@ $ RUST_BACKTRACE=1 rustc ...
 ```
 
 ## The Build System
+[the-build-system]: #the-build-system
 
 Rust's build system allows you to bootstrap the compiler, run tests &
 benchmarks, generate documentation, install a fresh build of Rust, and more.
@@ -94,6 +98,7 @@ system internals, try asking in [`#rust-internals`][pound-rust-internals].
 [bootstrap]: https://github.com/rust-lang/rust/tree/master/src/bootstrap/
 
 ### Configuration
+[configuration]: #configuration
 
 Before you can start building the compiler you need to configure the build for
 your system. In most cases, that will just mean using the defaults provided
@@ -125,6 +130,11 @@ file. If you still have a `config.mk` file in your directory - from
 `./configure` - you may need to delete it for `config.toml` to work.
 
 ### Building
+[building]: #building
+
+Dependencies
+- [build dependencies](README.md#building-from-source)
+- `gdb` 6.2.0 minimum, 7.1 or later recommended for test builds
 
 The build system uses the `x.py` script to control the build process. This script
 is used to build, test, and document various parts of the compiler. You can
@@ -194,6 +204,7 @@ Note: Previously `./configure` and `make` were used to build this project.
 They are still available, but `x.py` is the recommended build system.
 
 ### Useful commands
+[useful-commands]: #useful-commands
 
 Some common invocations of `x.py` are:
 
@@ -234,6 +245,7 @@ Some common invocations of `x.py` are:
   code.
 
 ### Using your local build
+[using-local-build]: #using-local-build
 
 If you use Rustup to manage your rust install, it has a feature called ["custom
 toolchains"][toolchain-link] that you can use to access your newly-built compiler
@@ -262,6 +274,7 @@ stage 1. `python x.py build --stage 1 src/libstd src/tools/rustdoc` will build
 rustdoc and libstd, which will allow rustdoc to be run with that toolchain.)
 
 ## Pull Requests
+[pull-requests]: #pull-requests
 
 Pull requests are the primary mechanism we use to change Rust. GitHub itself
 has some [great documentation][pull-requests] on using the Pull Request feature.
@@ -326,6 +339,7 @@ it can be found
 [here](https://github.com/rust-lang/rust-wiki-backup/blob/master/Note-testsuite.md).
 
 ### External Dependencies
+[external-dependencies]: #external-dependencies
 
 Currently building Rust will also build the following external projects:
 
@@ -340,6 +354,7 @@ It can also be more convenient during development to set `submodules = false`
 in the `config.toml` to prevent `x.py` from resetting to the original branch.
 
 ## Writing Documentation
+[writing-documentation]: #writing-documentation
 
 Documentation improvements are very welcome. The source of `doc.rust-lang.org`
 is located in `src/doc` in the tree, and standard API documentation is generated
@@ -370,6 +385,7 @@ reference to `doc/reference.html`. The CSS might be messed up, but you can
 verify that the HTML is right.
 
 ## Issue Triage
+[issue-triage]: #issue-triage
 
 Sometimes, an issue will stay open, even though the bug has been fixed. And
 sometimes, the original bug may go stale because something has changed in the
@@ -437,6 +453,7 @@ If you're looking for somewhere to start, check out the [E-easy][eeasy] tag.
 [rfcbot]: https://github.com/dikaiosune/rust-dashboard/blob/master/RFCBOT.md
 
 ## Out-of-tree Contributions
+[out-of-tree-contributions]: #out-of-tree-contributions
 
 There are a number of other ways to contribute to Rust that don't deal with
 this repository.
@@ -456,6 +473,7 @@ valuable!
 [community-library]: https://github.com/rust-lang/rfcs/labels/A-community-library
 
 ## Helpful Links and Information
+[helpful-info]: #helpful-info
 
 For people new to Rust, and just starting to contribute, or even for
 more seasoned developers, some useful places to look for information

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ standard library, and documentation.
 [Rust]: https://www.rust-lang.org
 
 ## Quick Start
+[quick-start]: #quick-start
 
 Read ["Installation"] from [The Book].
 
@@ -13,6 +14,7 @@ Read ["Installation"] from [The Book].
 [The Book]: https://doc.rust-lang.org/book/index.html
 
 ## Building from Source
+[building-from-source]: #building-from-source
 
 1. Make sure you have installed the dependencies:
 
@@ -52,6 +54,7 @@ Read ["Installation"] from [The Book].
 [Cargo]: https://github.com/rust-lang/cargo
 
 ### Building on Windows
+[building-on-windows]: #building-on-windows
 
 There are two prominent ABIs in use on Windows: the native (MSVC) ABI used by
 Visual Studio, and the GNU ABI used by the GCC toolchain. Which version of Rust
@@ -61,6 +64,7 @@ for interop with GNU software built using the MinGW/MSYS2 toolchain use the GNU
 build.
 
 #### MinGW
+[windows-mingw]: #windows-mingw
 
 [MSYS2][msys2] can be used to easily build Rust on Windows:
 
@@ -101,6 +105,7 @@ build.
    ```
 
 #### MSVC
+[windows-msvc]: #windows-msvc
 
 MSVC builds of Rust additionally require an installation of Visual Studio 2013
 (or later) so `rustc` can use its linker. Make sure to check the “C++ tools”
@@ -124,6 +129,7 @@ python x.py build
 ```
 
 #### Specifying an ABI
+[specifying-an-abi]: #specifying-an-abi
 
 Each specific ABI can also be used from either environment (for example, using
 the GNU ABI in powershell) by using an explicit build triple. The available
@@ -141,6 +147,7 @@ in Building From Source), and modifying the `build` option under the `[build]`
 section.
 
 ### Configure and Make
+[configure-and-make]: #configure-and-make
 
 While it's not the recommended build system, this project also provides a
 configure script and makefile (the latter of which just invokes `x.py`).
@@ -155,6 +162,7 @@ When using the configure script, the generated `config.mk` file may override the
 `config.mk` file.
 
 ## Building Documentation
+[building-documentation]: #building-documentation
 
 If you’d like to build the documentation, it’s almost the same:
 
@@ -167,6 +175,7 @@ the ABI used. I.e., if the ABI was `x86_64-pc-windows-msvc`, the directory will 
 `build\x86_64-pc-windows-msvc\doc`.
 
 ## Notes
+[notes]: #notes
 
 Since the Rust compiler is written in Rust, it must be built by a
 precompiled "snapshot" version of itself (made in an earlier state of
@@ -192,6 +201,7 @@ There is more advice about hacking on Rust in [CONTRIBUTING.md].
 [CONTRIBUTING.md]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md
 
 ## Getting Help
+[getting-help]: #getting-help
 
 The Rust community congregates in a few places:
 
@@ -204,6 +214,7 @@ The Rust community congregates in a few places:
 [users.rust-lang.org]: https://users.rust-lang.org/
 
 ## Contributing
+[contributing]: #contributing
 
 To contribute to Rust, please see [CONTRIBUTING](CONTRIBUTING.md).
 
@@ -217,6 +228,7 @@ Rust. And a good place to ask for help would be [#rust-beginners].
 [#rust-beginners]: irc://irc.mozilla.org/rust-beginners
 
 ## License
+[license]: #license
 
 Rust is primarily distributed under the terms of both the MIT license
 and the Apache License (Version 2.0), with portions covered by various


### PR DESCRIPTION
this also adds dependencies to CONTRIBUTING

I'm just getting started building the rust compiler and noticed this information/ability was missing.

It was also missing the gdb dependency for running tests. I pulled the information out of `appveyor.yml` and recommended later than 7.1 because that is what [apt ships](https://packages.ubuntu.com/search?suite=trusty&keywords=gdb). Feel free to tell me something different!