### PR TITLE
incr compilation struct_defs.rs

### DIFF
--- a/src/test/incremental/hashes/struct_defs.rs
+++ b/src/test/incremental/hashes/struct_defs.rs
@@ -36,7 +36,15 @@ pub struct LayoutPacked;
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_dirty(label="HirBody", cfg="cfail2")]
+#[rustc_dirty(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 #[repr(packed)]
@@ -47,7 +55,15 @@ struct LayoutC;
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_dirty(label="HirBody", cfg="cfail2")]
+#[rustc_dirty(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 #[repr(C)]
@@ -61,9 +77,19 @@ struct TupleStructFieldType(i32);
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_dirty(label="HirBody", cfg="cfail2")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
+// Note that changing the type of a field does not change the type of the struct or enum, but
+// adding/removing fields or changing a fields name or visibility does.
 struct TupleStructFieldType(
     #[rustc_metadata_dirty(cfg="cfail2")]
     #[rustc_metadata_clean(cfg="cfail3")]
@@ -78,7 +104,15 @@ struct TupleStructAddField(i32);
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_dirty(label="HirBody", cfg="cfail2")]
+#[rustc_dirty(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 struct TupleStructAddField(
@@ -97,7 +131,15 @@ struct TupleStructFieldVisibility(char);
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_dirty(label="HirBody", cfg="cfail2")]
+#[rustc_dirty(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 struct TupleStructFieldVisibility(pub char);
@@ -110,9 +152,19 @@ struct RecordStructFieldType { x: f32 }
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_dirty(label="HirBody", cfg="cfail2")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
+// Note that changing the type of a field does not change the type of the struct or enum, but
+// adding/removing fields or changing a fields name or visibility does.
 struct RecordStructFieldType {
     #[rustc_metadata_dirty(cfg="cfail2")]
     #[rustc_metadata_clean(cfg="cfail3")]
@@ -127,7 +179,15 @@ struct RecordStructFieldName { x: f32 }
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_dirty(label="HirBody", cfg="cfail2")]
+#[rustc_dirty(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 struct RecordStructFieldName { y: f32 }
@@ -140,7 +200,15 @@ struct RecordStructAddField { x: f32 }
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_dirty(label="HirBody", cfg="cfail2")]
+#[rustc_dirty(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 struct RecordStructAddField {
@@ -158,7 +226,15 @@ struct RecordStructFieldVisibility { x: f32 }
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_dirty(label="HirBody", cfg="cfail2")]
+#[rustc_dirty(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 struct RecordStructFieldVisibility {
@@ -175,7 +251,15 @@ struct AddLifetimeParameter<'a>(&'a f32, &'a f64);
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_dirty(label="HirBody", cfg="cfail2")]
+#[rustc_dirty(label="TypeOfItem", cfg="cfail2")]
+#[rustc_dirty(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 struct AddLifetimeParameter<'a, 'b>(&'a f32, &'b f64);
@@ -188,7 +272,15 @@ struct AddLifetimeParameterBound<'a, 'b>(&'a f32, &'b f64);
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_dirty(label="HirBody", cfg="cfail2")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_dirty(label="PredicatesOfItem", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 struct AddLifetimeParameterBound<'a, 'b: 'a>(
@@ -205,7 +297,15 @@ struct AddLifetimeParameterBoundWhereClause<'a, 'b>(&'a f32, &'b f64);
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_dirty(label="HirBody", cfg="cfail2")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_dirty(label="PredicatesOfItem", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 struct AddLifetimeParameterBoundWhereClause<'a, 'b>(
@@ -225,7 +325,15 @@ struct AddTypeParameter<T1>(T1, T1);
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_dirty(label="HirBody", cfg="cfail2")]
+#[rustc_dirty(label="TypeOfItem", cfg="cfail2")]
+#[rustc_dirty(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_dirty(label="PredicatesOfItem", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 struct AddTypeParameter<T1, T2>(
@@ -247,7 +355,15 @@ struct AddTypeParameterBound<T>(T);
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_dirty(label="HirBody", cfg="cfail2")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_dirty(label="PredicatesOfItem", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 struct AddTypeParameterBound<T: Send>(
@@ -262,7 +378,15 @@ struct AddTypeParameterBoundWhereClause<T>(T);
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_dirty(label="HirBody", cfg="cfail2")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_dirty(label="PredicatesOfItem", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 struct AddTypeParameterBoundWhereClause<T>(
@@ -273,8 +397,20 @@ struct AddTypeParameterBoundWhereClause<T>(
 
 
 // Empty struct ----------------------------------------------------------------
-
+// Since we cannot change anything in this case, we just make sure that the
+// fingerprint is stable (i.e. that there are no random influences like memory
+// addresses taken into account by the hashing algorithm).
+// Note: there is no #[cfg(...)], so this is ALWAYS compiled
 #[rustc_clean(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="HirBody", cfg="cfail2")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 pub struct EmptyStruct;
 
@@ -286,13 +422,18 @@ struct Visibility;
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_dirty(label="HirBody", cfg="cfail2")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 pub struct Visibility;
-
-
-
 
 struct ReferencedType1;
 struct ReferencedType2;
@@ -305,7 +446,15 @@ mod tuple_struct_change_field_type_indirectly {
     use super::ReferencedType2 as FieldType;
 
     #[rustc_dirty(label="Hir", cfg="cfail2")]
+    #[rustc_dirty(label="HirBody", cfg="cfail2")]
+    #[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+    #[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+    #[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
     #[rustc_clean(label="Hir", cfg="cfail3")]
+    #[rustc_clean(label="HirBody", cfg="cfail3")]
+    #[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+    #[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+    #[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
     #[rustc_metadata_clean(cfg="cfail2")]
     #[rustc_metadata_clean(cfg="cfail3")]
     struct TupleStruct(
@@ -324,7 +473,15 @@ mod record_struct_change_field_type_indirectly {
     use super::ReferencedType2 as FieldType;
 
     #[rustc_dirty(label="Hir", cfg="cfail2")]
+    #[rustc_dirty(label="HirBody", cfg="cfail2")]
+    #[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+    #[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+    #[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
     #[rustc_clean(label="Hir", cfg="cfail3")]
+    #[rustc_clean(label="HirBody", cfg="cfail3")]
+    #[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+    #[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+    #[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
     #[rustc_metadata_clean(cfg="cfail2")]
     #[rustc_metadata_clean(cfg="cfail3")]
     struct RecordStruct {
@@ -348,7 +505,15 @@ mod change_trait_bound_indirectly {
     use super::ReferencedTrait2 as Trait;
 
     #[rustc_dirty(label="Hir", cfg="cfail2")]
+    #[rustc_dirty(label="HirBody", cfg="cfail2")]
+    #[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+    #[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+    #[rustc_dirty(label="PredicatesOfItem", cfg="cfail2")]
     #[rustc_clean(label="Hir", cfg="cfail3")]
+    #[rustc_clean(label="HirBody", cfg="cfail3")]
+    #[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+    #[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+    #[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
     #[rustc_metadata_dirty(cfg="cfail2")]
     #[rustc_metadata_clean(cfg="cfail3")]
     struct Struct<T: Trait>(T);
@@ -362,7 +527,15 @@ mod change_trait_bound_indirectly_in_where_clause {
     use super::ReferencedTrait2 as Trait;
 
     #[rustc_dirty(label="Hir", cfg="cfail2")]
+    #[rustc_dirty(label="HirBody", cfg="cfail2")]
+    #[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+    #[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+    #[rustc_dirty(label="PredicatesOfItem", cfg="cfail2")]
     #[rustc_clean(label="Hir", cfg="cfail3")]
+    #[rustc_clean(label="HirBody", cfg="cfail3")]
+    #[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+    #[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+    #[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
     #[rustc_metadata_dirty(cfg="cfail2")]
     #[rustc_metadata_clean(cfg="cfail3")]
     struct Struct<T>(T) where T : Trait;


### PR DESCRIPTION
I am prematurely openeing this as I need mentoring help from @michaelwoerister (also pinged @nikomatsakis)

First, is this the right approach for these changes?

Second, I'm a bit confused by the results so far.

- Changing `TupleStructFieldType(i32)` -> `...(u32)` changes only Hir and HirBody, not TypeOfItem
- Chaning `TupleStructAddField(i32)` -> `...(i32, u32)` *does* change TypeOfItem

This seems wrong. I feel like it should change TypeOfItem in both cases. Is this a bug in incr compilation or is it expected?