### PR TITLE
make non_snake_case lint allow extern no-mangle functions

### DIFF
--- a/src/librustc_lint/bad_style.rs
+++ b/src/librustc_lint/bad_style.rs
@@ -13,6 +13,7 @@ use rustc::ty;
 use lint::{LateContext, LintContext, LintArray};
 use lint::{LintPass, LateLintPass};
 
+use syntax::abi::Abi;
 use syntax::ast;
 use syntax::attr;
 use syntax_pos::Span;
@@ -250,7 +251,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
                     _ => (),
                 }
             }
-            FnKind::ItemFn(name, ..) => {
+            FnKind::ItemFn(name, _, _, _, abi, _, attrs) => {
+                // Skip foreign-ABI #[no_mangle] functions (Issue #31924)
+                if abi != Abi::Rust && attr::find_by_name(attrs, "no_mangle").is_some() {
+                    return;
+                }
                 self.check_snake_case(cx, "function", &name.as_str(), Some(span))
             }
             FnKind::Closure(_) => (),

--- a/src/test/compile-fail/issue-31924-non-snake-ffi.rs
+++ b/src/test/compile-fail/issue-31924-non-snake-ffi.rs
@@ -1,0 +1,18 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs)]
+#![deny(non_snake_case)]
+
+#[no_mangle]
+pub extern "C" fn SparklingGenerationForeignFunctionInterface() {}
+
+#[rustc_error]
+fn main() {} //~ ERROR compilation successful


### PR DESCRIPTION
Resolves #31924.

r? @sfackler 