### PR TITLE
Suggest syntax when finding method on array

### DIFF
--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -757,7 +757,7 @@ impl fmt::Debug for Stmt {
 }
 
 
-#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash)]
 pub enum StmtKind {
     /// A local (let) binding.
     Local(P<Local>),

--- a/src/test/ui/suggestions/associated-item-from-array.rs
+++ b/src/test/ui/suggestions/associated-item-from-array.rs
@@ -1,0 +1,14 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let a = [1, 2, 3];
+    let _ = [i32; 3]::clone(&a);
+}

--- a/src/test/ui/suggestions/associated-item-from-array.stderr
+++ b/src/test/ui/suggestions/associated-item-from-array.stderr
@@ -1,0 +1,11 @@
+error: expected one of `.`, `;`, `?`, or an operator, found `::`
+  --> $DIR/associated-item-from-array.rs:13:21
+   |
+13 |     let _ = [i32; 3]::clone(&a);
+   |             --------^^
+   |             |       |
+   |             |       expected one of `.`, `;`, `?`, or an operator here
+   |             help: did you mean to use an associated type?: `<[i32; 3]>::`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
On a file like the following:

```rust
fn main() {
    let a = [1, 2, 3];
    let _ = [i32; 3]::clone(&a);
}
```

it is a fair assumption that what was meant was to use an associated
type on an array, so we suggest the correct syntax:

```
error: expected one of `.`, `;`, `?`, or an operator, found `::`
 --> file.rs:3:21
  |
3 |     let _ = [i32; 3]::clone(&a);
  |             --------^^
  |             |       |
  |             |       expected one of `.`, `;`, `?`, or an operator here
  |             help: did you mean to use an associated type?: `<[i32; 3]>::`
```

Fix #42187.