### PR TITLE
fix ItemKind::DefaultImpl doc comment

### DIFF
--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1927,9 +1927,9 @@ pub enum ItemKind {
     ///
     /// E.g. `trait Foo { .. }` or `trait Foo<T> { .. }`
     Trait(Unsafety, Generics, TyParamBounds, Vec<TraitItem>),
-    /// Default trait implementation.
+    /// Auto trait implementation.
     ///
-    /// E.g. `default impl Trait for .. {}` or `default impl<T> Trait<T> for .. {}`
+    /// E.g. `impl Trait for .. {}` or `impl<T> Trait<T> for .. {}`
     DefaultImpl(Unsafety, TraitRef),
     /// An implementation.
     ///

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1927,9 +1927,9 @@ pub enum ItemKind {
     ///
     /// E.g. `trait Foo { .. }` or `trait Foo<T> { .. }`
     Trait(Unsafety, Generics, TyParamBounds, Vec<TraitItem>),
-    // Default trait implementation.
+    /// Default trait implementation.
     ///
-    /// E.g. `impl Trait for .. {}` or `impl<T> Trait<T> for .. {}`
+    /// E.g. `default impl Trait for .. {}` or `default impl<T> Trait<T> for .. {}`
     DefaultImpl(Unsafety, TraitRef),
     /// An implementation.
     ///


### PR DESCRIPTION
Upgrade comment to doc comment.

...Is this actually used? If so, why does the `Impl` variant right below have a `Defaultness`?