### PR TITLE
Create NormalizeTy query

### DIFF
--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -635,6 +635,7 @@ define_dep_nodes!( <'tcx>
 
     // We use this for most things when incr. comp. is turned off.
     [] Null,
+    [] NormalizeTy,
 );
 
 trait DepNodeParams<'a, 'gcx: 'tcx + 'a, 'tcx: 'a> : fmt::Debug {

--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -632,10 +632,9 @@ define_dep_nodes!( <'tcx>
     [] CodegenUnit(InternedString),
     [] CompileCodegenUnit(InternedString),
     [] OutputFilenames,
-
+    [] NormalizeTy,
     // We use this for most things when incr. comp. is turned off.
     [] Null,
-    [] NormalizeTy,
 );
 
 trait DepNodeParams<'a, 'gcx: 'tcx + 'a, 'tcx: 'a> : fmt::Debug {

--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -632,7 +632,7 @@ define_dep_nodes!( <'tcx>
     [] CodegenUnit(InternedString),
     [] CompileCodegenUnit(InternedString),
     [] OutputFilenames,
-    [] NormalizeTy,
+    [anon] NormalizeTy,
     // We use this for most things when incr. comp. is turned off.
     [] Null,
 );

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -480,16 +480,16 @@ impl<'a, 'tcx> TyCtxt<'a, 'tcx, 'tcx> {
     {
         assert!(!value.needs_subst());
         let value = self.erase_late_bound_regions(value);
-        self.normalize_associated_type(&value)
+        self.normalize_associated_type_in(&value)
     }
 
     /// Fully normalizes any associated types in `value`, using an
     /// empty environment and `Reveal::All` mode (therefore, suitable
     /// only for monomorphized code during trans, basically).
-    pub fn normalize_associated_type<T>(self, value: &T) -> T
+    pub fn normalize_associated_type_in<T>(self, value: &T) -> T
         where T: TransNormalize<'tcx>
     {
-        debug!("normalize_associated_type(t={:?})", value);
+        debug!("normalize_associated_type_in(t={:?})", value);
 
         let param_env = ty::ParamEnv::empty(Reveal::All);
         let value = self.erase_regions(value);

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -480,16 +480,16 @@ impl<'a, 'tcx> TyCtxt<'a, 'tcx, 'tcx> {
     {
         assert!(!value.needs_subst());
         let value = self.erase_late_bound_regions(value);
-        self.normalize_associated_type_in(&value)
+        self.trans_normalize_associated_types_in(&value)
     }
 
     /// Fully normalizes any associated types in `value`, using an
     /// empty environment and `Reveal::All` mode (therefore, suitable
     /// only for monomorphized code during trans, basically).
-    pub fn normalize_associated_type_in<T>(self, value: &T) -> T
+    pub fn trans_normalize_associated_types_in<T>(self, value: &T) -> T
         where T: TransNormalize<'tcx>
     {
-        debug!("normalize_associated_type_in(t={:?})", value);
+        debug!("trans_normalize_associated_types_in(t={:?})", value);
 
         let param_env = ty::ParamEnv::empty(Reveal::All);
         let value = self.erase_regions(value);

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -480,16 +480,16 @@ impl<'a, 'tcx> TyCtxt<'a, 'tcx, 'tcx> {
     {
         assert!(!value.needs_subst());
         let value = self.erase_late_bound_regions(value);
-        self.trans_normalize_associated_types_in(&value)
+        self.fully_normalize_associated_types_in(&value)
     }
 
     /// Fully normalizes any associated types in `value`, using an
     /// empty environment and `Reveal::All` mode (therefore, suitable
     /// only for monomorphized code during trans, basically).
-    pub fn trans_normalize_associated_types_in<T>(self, value: &T) -> T
+    pub fn fully_normalize_associated_types_in<T>(self, value: &T) -> T
         where T: TransNormalize<'tcx>
     {
-        debug!("trans_normalize_associated_types_in(t={:?})", value);
+        debug!("fully_normalize_associated_types_in(t={:?})", value);
 
         let param_env = ty::ParamEnv::empty(Reveal::All);
         let value = self.erase_regions(value);

--- a/src/librustc/traits/trans/mod.rs
+++ b/src/librustc/traits/trans/mod.rs
@@ -129,7 +129,7 @@ impl<'a, 'gcx> TypeFolder<'gcx, 'gcx> for AssociatedTypeNormalizer<'a, 'gcx> {
             ty
         } else {
             debug!("AssociatedTypeNormalizer: ty={:?}", ty);
-            self.tcx.normalize_ty(ty)
+            self.tcx.fully_normalize_monormophic_ty(ty)
         }
     }
 }

--- a/src/librustc/traits/trans/mod.rs
+++ b/src/librustc/traits/trans/mod.rs
@@ -130,10 +130,8 @@ impl<'a, 'gcx> TypeFolder<'gcx, 'gcx> for AssociatedTypeNormalizer<'a, 'gcx> {
         if !ty.has_projections() {
             ty
         } else {
-            self.tcx.trans_trait_caches.project_cache.memoize(ty, || {
-                debug!("AssociatedTypeNormalizer: ty={:?}", ty);
-                self.tcx.normalize_associated_type(&ty)
-            })
+            debug!("AssociatedTypeNormalizer: ty={:?}", ty);
+            self.tcx.normalize_ty(ty)
         }
     }
 }

--- a/src/librustc/traits/trans/mod.rs
+++ b/src/librustc/traits/trans/mod.rs
@@ -13,16 +13,14 @@
 // seems likely that they should eventually be merged into more
 // general routines.
 
-use dep_graph::{DepGraph, DepKind, DepTrackingMap, DepTrackingMapConfig};
+use dep_graph::{DepKind, DepTrackingMapConfig};
 use infer::TransNormalize;
-use std::cell::RefCell;
 use std::marker::PhantomData;
 use syntax_pos::DUMMY_SP;
 use traits::{FulfillmentContext, Obligation, ObligationCause, SelectionContext, Vtable};
 use ty::{self, Ty, TyCtxt};
 use ty::subst::{Subst, Substs};
 use ty::fold::{TypeFoldable, TypeFolder};
-use util::common::MemoizationMap;
 
 /// Attempts to resolve an obligation to a vtable.. The result is
 /// a shallow vtable resolution -- meaning that we do not
@@ -132,20 +130,6 @@ impl<'a, 'gcx> TypeFolder<'gcx, 'gcx> for AssociatedTypeNormalizer<'a, 'gcx> {
         } else {
             debug!("AssociatedTypeNormalizer: ty={:?}", ty);
             self.tcx.normalize_ty(ty)
-        }
-    }
-}
-
-/// Specializes caches used in trans -- in particular, they assume all
-/// types are fully monomorphized and that free regions can be erased.
-pub struct TransTraitCaches<'tcx> {
-    project_cache: RefCell<DepTrackingMap<ProjectionCache<'tcx>>>,
-}
-
-impl<'tcx> TransTraitCaches<'tcx> {
-    pub fn new(graph: DepGraph) -> Self {
-        TransTraitCaches {
-            project_cache: RefCell::new(DepTrackingMap::new(graph)),
         }
     }
 }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -2322,4 +2322,7 @@ pub fn provide(providers: &mut ty::maps::Providers) {
         assert_eq!(cnum, LOCAL_CRATE);
         tcx.sess.features.borrow().clone_closures
     };
+    providers.normalize_ty = |tcx, ty| {
+        tcx.normalize_associated_type_in(&ty)
+    };
 }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -2318,7 +2318,7 @@ pub fn provide(providers: &mut ty::maps::Providers) {
         assert_eq!(cnum, LOCAL_CRATE);
         tcx.sess.features.borrow().clone_closures
     };
-    providers.normalize_ty = |tcx, ty| {
+    providers.fully_normalize_monormophic_ty = |tcx, ty| {
         tcx.fully_normalize_associated_types_in(&ty)
     };
 }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -2323,6 +2323,6 @@ pub fn provide(providers: &mut ty::maps::Providers) {
         tcx.sess.features.borrow().clone_closures
     };
     providers.normalize_ty = |tcx, ty| {
-        tcx.trans_normalize_associated_types_in(&ty)
+        tcx.fully_normalize_associated_types_in(&ty)
     };
 }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -2323,6 +2323,6 @@ pub fn provide(providers: &mut ty::maps::Providers) {
         tcx.sess.features.borrow().clone_closures
     };
     providers.normalize_ty = |tcx, ty| {
-        tcx.normalize_associated_type_in(&ty)
+        tcx.trans_normalize_associated_types_in(&ty)
     };
 }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -851,9 +851,6 @@ pub struct GlobalCtxt<'tcx> {
 
     pub sess: &'tcx Session,
 
-
-    pub trans_trait_caches: traits::trans::TransTraitCaches<'tcx>,
-
     pub dep_graph: DepGraph,
 
     /// Common types, pre-interned for your convenience.
@@ -1137,7 +1134,6 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         tls::enter_global(GlobalCtxt {
             sess: s,
             cstore,
-            trans_trait_caches: traits::trans::TransTraitCaches::new(dep_graph.clone()),
             global_arenas: arenas,
             global_interners: interners,
             dep_graph: dep_graph.clone(),

--- a/src/librustc/ty/maps/config.rs
+++ b/src/librustc/ty/maps/config.rs
@@ -533,7 +533,7 @@ impl<'tcx> QueryDescription for queries::has_copy_closures<'tcx> {
     }
 }
 
-impl<'tcx> QueryDescription for queries::normalize_ty<'tcx> {
+impl<'tcx> QueryDescription for queries::fully_normalize_monormophic_ty<'tcx> {
     fn describe(_tcx: TyCtxt, _: Ty) -> String {
         format!("normalizing types")
     }

--- a/src/librustc/ty/maps/config.rs
+++ b/src/librustc/ty/maps/config.rs
@@ -532,3 +532,9 @@ impl<'tcx> QueryDescription for queries::has_copy_closures<'tcx> {
         format!("seeing if the crate has enabled `Copy` closures")
     }
 }
+
+impl<'tcx> QueryDescription for queries::normalize_ty<'tcx> {
+    fn describe(_tcx: TyCtxt, _: Ty) -> String {
+        format!("normalising types")
+    }
+}

--- a/src/librustc/ty/maps/config.rs
+++ b/src/librustc/ty/maps/config.rs
@@ -535,6 +535,6 @@ impl<'tcx> QueryDescription for queries::has_copy_closures<'tcx> {
 
 impl<'tcx> QueryDescription for queries::normalize_ty<'tcx> {
     fn describe(_tcx: TyCtxt, _: Ty) -> String {
-        format!("normalising types")
+        format!("normalizing types")
     }
 }

--- a/src/librustc/ty/maps/mod.rs
+++ b/src/librustc/ty/maps/mod.rs
@@ -349,6 +349,7 @@ define_maps! { <'tcx>
     // Normally you would just use `tcx.erase_regions(&value)`,
     // however, which uses this query as a kind of cache.
     [] fn erase_regions_ty: erase_regions_ty(Ty<'tcx>) -> Ty<'tcx>,
+    [] fn normalize_ty: normalize_ty_node(Ty<'tcx>) -> Ty<'tcx>,
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -489,4 +490,7 @@ fn output_filenames_node<'tcx>(_: CrateNum) -> DepConstructor<'tcx> {
 
 fn vtable_methods_node<'tcx>(trait_ref: ty::PolyTraitRef<'tcx>) -> DepConstructor<'tcx> {
     DepConstructor::VtableMethods{ trait_ref }
+}
+fn normalize_ty_node<'tcx>(_: Ty<'tcx>) -> DepConstructor<'tcx> {
+    DepConstructor::NormalizeTy
 }

--- a/src/librustc/ty/maps/mod.rs
+++ b/src/librustc/ty/maps/mod.rs
@@ -349,7 +349,7 @@ define_maps! { <'tcx>
     // Normally you would just use `tcx.erase_regions(&value)`,
     // however, which uses this query as a kind of cache.
     [] fn erase_regions_ty: erase_regions_ty(Ty<'tcx>) -> Ty<'tcx>,
-    [] fn normalize_ty: normalize_ty_node(Ty<'tcx>) -> Ty<'tcx>,
+    [] fn fully_normalize_monormophic_ty: normalize_ty_node(Ty<'tcx>) -> Ty<'tcx>,
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/src/librustc/ty/maps/plumbing.rs
+++ b/src/librustc/ty/maps/plumbing.rs
@@ -697,6 +697,7 @@ pub fn force_from_dep_node<'a, 'gcx, 'lcx>(tcx: TyCtxt<'a, 'gcx, 'lcx>,
         DepKind::FulfillObligation |
         DepKind::VtableMethods |
         DepKind::EraseRegionsTy |
+        DepKind::NormalizeTy |
 
         // These are just odd
         DepKind::Null |

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -431,7 +431,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                         // fields are actually safe.
                         let mut all_phantom = true;
                         for field in &def.struct_variant().fields {
-                            let field_ty = cx.normalize_associated_type(&field.ty(cx, substs));
+                            let field_ty = cx.normalize_associated_type_in(&field.ty(cx, substs));
                             let r = self.check_type_for_ffi(cache, field_ty);
                             match r {
                                 FfiSafe => {
@@ -463,7 +463,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
 
                         let mut all_phantom = true;
                         for field in &def.struct_variant().fields {
-                            let field_ty = cx.normalize_associated_type(&field.ty(cx, substs));
+                            let field_ty = cx.normalize_associated_type_in(&field.ty(cx, substs));
                             let r = self.check_type_for_ffi(cache, field_ty);
                             match r {
                                 FfiSafe => {
@@ -516,7 +516,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                         // Check the contained variants.
                         for variant in &def.variants {
                             for field in &variant.fields {
-                                let arg = cx.normalize_associated_type(&field.ty(cx, substs));
+                                let arg = cx.normalize_associated_type_in(&field.ty(cx, substs));
                                 let r = self.check_type_for_ffi(cache, arg);
                                 match r {
                                     FfiSafe => {}
@@ -629,7 +629,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
     fn check_type_for_ffi_and_report_errors(&mut self, sp: Span, ty: Ty<'tcx>) {
         // it is only OK to use this function because extern fns cannot have
         // any generic types right now:
-        let ty = self.cx.tcx.normalize_associated_type(&ty);
+        let ty = self.cx.tcx.normalize_associated_type_in(&ty);
 
         match self.check_type_for_ffi(&mut FxHashSet(), ty) {
             FfiResult::FfiSafe => {}

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -431,7 +431,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                         // fields are actually safe.
                         let mut all_phantom = true;
                         for field in &def.struct_variant().fields {
-                            let field_ty = cx.trans_normalize_associated_types_in(
+                            let field_ty = cx.fully_normalize_associated_types_in(
                                 &field.ty(cx, substs)
                             );
                             let r = self.check_type_for_ffi(cache, field_ty);
@@ -465,7 +465,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
 
                         let mut all_phantom = true;
                         for field in &def.struct_variant().fields {
-                            let field_ty = cx.trans_normalize_associated_types_in(
+                            let field_ty = cx.fully_normalize_associated_types_in(
                                 &field.ty(cx, substs)
                             );
                             let r = self.check_type_for_ffi(cache, field_ty);
@@ -520,7 +520,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                         // Check the contained variants.
                         for variant in &def.variants {
                             for field in &variant.fields {
-                                let arg = cx.trans_normalize_associated_types_in(
+                                let arg = cx.fully_normalize_associated_types_in(
                                     &field.ty(cx, substs)
                                 );
                                 let r = self.check_type_for_ffi(cache, arg);
@@ -635,7 +635,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
     fn check_type_for_ffi_and_report_errors(&mut self, sp: Span, ty: Ty<'tcx>) {
         // it is only OK to use this function because extern fns cannot have
         // any generic types right now:
-        let ty = self.cx.tcx.trans_normalize_associated_types_in(&ty);
+        let ty = self.cx.tcx.fully_normalize_associated_types_in(&ty);
 
         match self.check_type_for_ffi(&mut FxHashSet(), ty) {
             FfiResult::FfiSafe => {}

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -431,7 +431,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                         // fields are actually safe.
                         let mut all_phantom = true;
                         for field in &def.struct_variant().fields {
-                            let field_ty = cx.normalize_associated_type_in(&field.ty(cx, substs));
+                            let field_ty = cx.trans_normalize_associated_types_in(&field.ty(cx, substs));
                             let r = self.check_type_for_ffi(cache, field_ty);
                             match r {
                                 FfiSafe => {
@@ -463,7 +463,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
 
                         let mut all_phantom = true;
                         for field in &def.struct_variant().fields {
-                            let field_ty = cx.normalize_associated_type_in(&field.ty(cx, substs));
+                            let field_ty = cx.trans_normalize_associated_types_in(&field.ty(cx, substs));
                             let r = self.check_type_for_ffi(cache, field_ty);
                             match r {
                                 FfiSafe => {
@@ -516,7 +516,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                         // Check the contained variants.
                         for variant in &def.variants {
                             for field in &variant.fields {
-                                let arg = cx.normalize_associated_type_in(&field.ty(cx, substs));
+                                let arg = cx.trans_normalize_associated_types_in(&field.ty(cx, substs));
                                 let r = self.check_type_for_ffi(cache, arg);
                                 match r {
                                     FfiSafe => {}
@@ -629,7 +629,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
     fn check_type_for_ffi_and_report_errors(&mut self, sp: Span, ty: Ty<'tcx>) {
         // it is only OK to use this function because extern fns cannot have
         // any generic types right now:
-        let ty = self.cx.tcx.normalize_associated_type_in(&ty);
+        let ty = self.cx.tcx.trans_normalize_associated_types_in(&ty);
 
         match self.check_type_for_ffi(&mut FxHashSet(), ty) {
             FfiResult::FfiSafe => {}

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -431,7 +431,9 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                         // fields are actually safe.
                         let mut all_phantom = true;
                         for field in &def.struct_variant().fields {
-                            let field_ty = cx.trans_normalize_associated_types_in(&field.ty(cx, substs));
+                            let field_ty = cx.trans_normalize_associated_types_in(
+                                &field.ty(cx, substs)
+                            );
                             let r = self.check_type_for_ffi(cache, field_ty);
                             match r {
                                 FfiSafe => {
@@ -463,7 +465,9 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
 
                         let mut all_phantom = true;
                         for field in &def.struct_variant().fields {
-                            let field_ty = cx.trans_normalize_associated_types_in(&field.ty(cx, substs));
+                            let field_ty = cx.trans_normalize_associated_types_in(
+                                &field.ty(cx, substs)
+                            );
                             let r = self.check_type_for_ffi(cache, field_ty);
                             match r {
                                 FfiSafe => {
@@ -516,7 +520,9 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                         // Check the contained variants.
                         for variant in &def.variants {
                             for field in &variant.fields {
-                                let arg = cx.trans_normalize_associated_types_in(&field.ty(cx, substs));
+                                let arg = cx.trans_normalize_associated_types_in(
+                                    &field.ty(cx, substs)
+                                );
                                 let r = self.check_type_for_ffi(cache, arg);
                                 match r {
                                     FfiSafe => {}

--- a/src/librustc_trans/adt.rs
+++ b/src/librustc_trans/adt.rs
@@ -80,7 +80,7 @@ pub fn compute_fields<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>,
         ty::TyGenerator(def_id, substs, _) => {
             if variant_index > 0 { bug!("{} is a generator, which only has one variant", t);}
             substs.field_tys(def_id, cx.tcx()).map(|t| {
-                cx.tcx().normalize_associated_type_in(&t)
+                cx.tcx().trans_normalize_associated_types_in(&t)
             }).collect()
         },
         _ => bug!("{} is not a type that can have fields.", t)

--- a/src/librustc_trans/adt.rs
+++ b/src/librustc_trans/adt.rs
@@ -80,7 +80,7 @@ pub fn compute_fields<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>,
         ty::TyGenerator(def_id, substs, _) => {
             if variant_index > 0 { bug!("{} is a generator, which only has one variant", t);}
             substs.field_tys(def_id, cx.tcx()).map(|t| {
-                cx.tcx().normalize_associated_type(&t)
+                cx.tcx().normalize_associated_type_in(&t)
             }).collect()
         },
         _ => bug!("{} is not a type that can have fields.", t)

--- a/src/librustc_trans/adt.rs
+++ b/src/librustc_trans/adt.rs
@@ -80,7 +80,7 @@ pub fn compute_fields<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>,
         ty::TyGenerator(def_id, substs, _) => {
             if variant_index > 0 { bug!("{} is a generator, which only has one variant", t);}
             substs.field_tys(def_id, cx.tcx()).map(|t| {
-                cx.tcx().trans_normalize_associated_types_in(&t)
+                cx.tcx().fully_normalize_associated_types_in(&t)
             }).collect()
         },
         _ => bug!("{} is not a type that can have fields.", t)

--- a/src/librustc_trans/context.rs
+++ b/src/librustc_trans/context.rs
@@ -642,7 +642,7 @@ impl<'a, 'tcx> LayoutTyper<'tcx> for &'a SharedCrateContext<'a, 'tcx> {
     }
 
     fn normalize_projections(self, ty: Ty<'tcx>) -> Ty<'tcx> {
-        self.tcx().trans_normalize_associated_types_in(&ty)
+        self.tcx().fully_normalize_associated_types_in(&ty)
     }
 }
 

--- a/src/librustc_trans/context.rs
+++ b/src/librustc_trans/context.rs
@@ -642,7 +642,7 @@ impl<'a, 'tcx> LayoutTyper<'tcx> for &'a SharedCrateContext<'a, 'tcx> {
     }
 
     fn normalize_projections(self, ty: Ty<'tcx>) -> Ty<'tcx> {
-        self.tcx().normalize_associated_type(&ty)
+        self.tcx().normalize_associated_type_in(&ty)
     }
 }
 

--- a/src/librustc_trans/context.rs
+++ b/src/librustc_trans/context.rs
@@ -642,7 +642,7 @@ impl<'a, 'tcx> LayoutTyper<'tcx> for &'a SharedCrateContext<'a, 'tcx> {
     }
 
     fn normalize_projections(self, ty: Ty<'tcx>) -> Ty<'tcx> {
-        self.tcx().normalize_associated_type_in(&ty)
+        self.tcx().trans_normalize_associated_types_in(&ty)
     }
 }
 

--- a/src/librustc_trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/debuginfo/metadata.rs
@@ -582,7 +582,7 @@ pub fn type_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         }
         ty::TyGenerator(def_id, substs, _) => {
             let upvar_tys : Vec<_> = substs.field_tys(def_id, cx.tcx()).map(|t| {
-                cx.tcx().normalize_associated_type(&t)
+                cx.tcx().normalize_associated_type_in(&t)
             }).collect();
             prepare_tuple_metadata(cx,
                                    t,

--- a/src/librustc_trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/debuginfo/metadata.rs
@@ -582,7 +582,7 @@ pub fn type_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         }
         ty::TyGenerator(def_id, substs, _) => {
             let upvar_tys : Vec<_> = substs.field_tys(def_id, cx.tcx()).map(|t| {
-                cx.tcx().trans_normalize_associated_types_in(&t)
+                cx.tcx().fully_normalize_associated_types_in(&t)
             }).collect();
             prepare_tuple_metadata(cx,
                                    t,

--- a/src/librustc_trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/debuginfo/metadata.rs
@@ -582,7 +582,7 @@ pub fn type_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         }
         ty::TyGenerator(def_id, substs, _) => {
             let upvar_tys : Vec<_> = substs.field_tys(def_id, cx.tcx()).map(|t| {
-                cx.tcx().normalize_associated_type_in(&t)
+                cx.tcx().trans_normalize_associated_types_in(&t)
             }).collect();
             prepare_tuple_metadata(cx,
                                    t,

--- a/src/librustc_trans/debuginfo/mod.rs
+++ b/src/librustc_trans/debuginfo/mod.rs
@@ -376,7 +376,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                 name_to_append_suffix_to.push_str(",");
             }
 
-            let actual_type = cx.tcx().normalize_associated_type(&actual_type);
+            let actual_type = cx.tcx().normalize_associated_type_in(&actual_type);
             // Add actual type name to <...> clause of function name
             let actual_type_name = compute_debuginfo_type_name(cx,
                                                                actual_type,
@@ -389,7 +389,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         let template_params: Vec<_> = if cx.sess().opts.debuginfo == FullDebugInfo {
             let names = get_type_parameter_names(cx, generics);
             substs.types().zip(names).map(|(ty, name)| {
-                let actual_type = cx.tcx().normalize_associated_type(&ty);
+                let actual_type = cx.tcx().normalize_associated_type_in(&ty);
                 let actual_type_metadata = type_metadata(cx, actual_type, syntax_pos::DUMMY_SP);
                 let name = CString::new(name.as_str().as_bytes()).unwrap();
                 unsafe {

--- a/src/librustc_trans/debuginfo/mod.rs
+++ b/src/librustc_trans/debuginfo/mod.rs
@@ -376,7 +376,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                 name_to_append_suffix_to.push_str(",");
             }
 
-            let actual_type = cx.tcx().trans_normalize_associated_types_in(&actual_type);
+            let actual_type = cx.tcx().fully_normalize_associated_types_in(&actual_type);
             // Add actual type name to <...> clause of function name
             let actual_type_name = compute_debuginfo_type_name(cx,
                                                                actual_type,
@@ -389,7 +389,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         let template_params: Vec<_> = if cx.sess().opts.debuginfo == FullDebugInfo {
             let names = get_type_parameter_names(cx, generics);
             substs.types().zip(names).map(|(ty, name)| {
-                let actual_type = cx.tcx().trans_normalize_associated_types_in(&ty);
+                let actual_type = cx.tcx().fully_normalize_associated_types_in(&ty);
                 let actual_type_metadata = type_metadata(cx, actual_type, syntax_pos::DUMMY_SP);
                 let name = CString::new(name.as_str().as_bytes()).unwrap();
                 unsafe {

--- a/src/librustc_trans/debuginfo/mod.rs
+++ b/src/librustc_trans/debuginfo/mod.rs
@@ -376,7 +376,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                 name_to_append_suffix_to.push_str(",");
             }
 
-            let actual_type = cx.tcx().normalize_associated_type_in(&actual_type);
+            let actual_type = cx.tcx().trans_normalize_associated_types_in(&actual_type);
             // Add actual type name to <...> clause of function name
             let actual_type_name = compute_debuginfo_type_name(cx,
                                                                actual_type,
@@ -389,7 +389,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         let template_params: Vec<_> = if cx.sess().opts.debuginfo == FullDebugInfo {
             let names = get_type_parameter_names(cx, generics);
             substs.types().zip(names).map(|(ty, name)| {
-                let actual_type = cx.tcx().normalize_associated_type_in(&ty);
+                let actual_type = cx.tcx().trans_normalize_associated_types_in(&ty);
                 let actual_type_metadata = type_metadata(cx, actual_type, syntax_pos::DUMMY_SP);
                 let name = CString::new(name.as_str().as_bytes()).unwrap();
                 unsafe {

--- a/src/librustc_trans_utils/monomorphize.rs
+++ b/src/librustc_trans_utils/monomorphize.rs
@@ -131,6 +131,6 @@ pub fn field_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                           f: &'tcx ty::FieldDef)
                           -> Ty<'tcx>
 {
-    tcx.normalize_associated_type(&f.ty(tcx, param_substs))
+    tcx.normalize_associated_type_in(&f.ty(tcx, param_substs))
 }
 

--- a/src/librustc_trans_utils/monomorphize.rs
+++ b/src/librustc_trans_utils/monomorphize.rs
@@ -131,6 +131,6 @@ pub fn field_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                           f: &'tcx ty::FieldDef)
                           -> Ty<'tcx>
 {
-    tcx.trans_normalize_associated_types_in(&f.ty(tcx, param_substs))
+    tcx.fully_normalize_associated_types_in(&f.ty(tcx, param_substs))
 }
 

--- a/src/librustc_trans_utils/monomorphize.rs
+++ b/src/librustc_trans_utils/monomorphize.rs
@@ -131,6 +131,6 @@ pub fn field_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                           f: &'tcx ty::FieldDef)
                           -> Ty<'tcx>
 {
-    tcx.normalize_associated_type_in(&f.ty(tcx, param_substs))
+    tcx.trans_normalize_associated_types_in(&f.ty(tcx, param_substs))
 }
 


### PR DESCRIPTION
As part of the effort to solve #44891,  I've created the normalize_ty query. 

As outlined in the issue this meant:

- renamed `normalize_associated_type()` to `normalize_associated_type_in()`
- created the `normalize_ty` query
- substituted the use of memoize with the query

This PR is not ready. While running tests, one of the incremental ones failed. [This](https://pastebin.com/vGhH6bv6) is the error I got. 