### PR TITLE
`EndRegion` do not always correspond to borrow-data entries

### DIFF
--- a/src/librustc_mir/dataflow/impls/borrows.rs
+++ b/src/librustc_mir/dataflow/impls/borrows.rs
@@ -122,11 +122,11 @@ impl<'a, 'tcx> BitDenotation for Borrows<'a, 'tcx> {
         });
         match stmt.kind {
             mir::StatementKind::EndRegion(region_scope) => {
-                let borrow_indexes = self.region_map.get(&ReScope(region_scope)).unwrap_or_else(|| {
-                    panic!("could not find BorrowIndexs for region scope {:?}", region_scope);
-                });
-
-                for idx in borrow_indexes { sets.kill(&idx); }
+                if let Some(borrow_indexes) = self.region_map.get(&ReScope(region_scope)) {
+                    for idx in borrow_indexes { sets.kill(&idx); }
+                } else {
+                    // (if there is no entry, then there are no borrows to be tracked)
+                }
             }
 
             mir::StatementKind::Assign(_, ref rhs) => {


### PR DESCRIPTION
Remove assertion that the argument to every `EndRegion` correspond to some dataflow-tracked borrow-data entry.

Fix #44828

(The comment thread on the aforementioned issue discusses why its best to just remove this assertion.)