### PR TITLE
Render cfg(feature) requirements in documentation

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -61,7 +61,7 @@ use rustc::hir;
 use rustc::util::nodemap::{FxHashMap, FxHashSet};
 use rustc_data_structures::flock;
 
-use clean::{self, AttributesExt, GetDefId, SelfTy, Mutability, Span};
+use clean::{self, AttributesExt, GetDefId, SelfTy, Mutability, Span, ConfigFeatureMap};
 use doctree;
 use fold::DocFolder;
 use html::escape::Escape;
@@ -255,6 +255,10 @@ pub struct Cache {
     // non-reachable while local items aren't. This is because we're reusing
     // the access levels from crateanalysis.
     pub access_levels: Arc<AccessLevels<DefId>>,
+
+    /// This map contains information about which #[cfg(feature)]'s are required
+    /// to be active for a given item to be included in the crate.
+    pub cfg_feature_map: ConfigFeatureMap,
 
     // Private fields only used when initially crawling a crate to build a cache
 
@@ -541,6 +545,7 @@ pub fn run(mut krate: clean::Crate,
         owned_box_did,
         masked_crates: mem::replace(&mut krate.masked_crates, FxHashSet()),
         typarams: external_typarams,
+        cfg_feature_map: mem::replace(&mut krate.cfg_feature_map, Default::default()),
     };
 
     // Cache where all our extern crates are located
@@ -1695,6 +1700,7 @@ impl<'a> fmt::Display for Item<'a> {
 
         write!(fmt, "</span>")?; // in-band
         write!(fmt, "<span class='out-of-band'>")?;
+        render_all_cfg_features(fmt, self.item.def_id)?;
         if let Some(version) = self.item.stable_since() {
             write!(fmt, "<span class='since' title='Stable since Rust version {0}'>{0}</span>",
                    version)?;
@@ -2071,6 +2077,9 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
                     _ => "",
                 };
 
+                let mut features = String::new();
+                render_introduced_cfg_features(&mut features, myitem.def_id)?;
+
                 let doc_value = myitem.doc_value().unwrap_or("");
                 write!(w, "
                        <tr class='{stab} module-item'>
@@ -2078,6 +2087,9 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
                                   title='{title_type} {title}'>{name}</a>{unsafety_flag}</td>
                            <td class='docblock-short'>
                                {stab_docs} {docs}
+                               <span class='out-of-band'>
+                                   {features}
+                               </span>
                            </td>
                        </tr>",
                        name = *myitem.name.as_ref().unwrap(),
@@ -2089,6 +2101,7 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
                        } else {
                            format!("{}", MarkdownSummaryLine(doc_value))
                        },
+                       features = features,
                        class = myitem.type_(),
                        stab = myitem.stability_class().unwrap_or("".to_string()),
                        unsafety_flag = unsafety_flag,
@@ -2362,6 +2375,9 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                ns_id = ns_id)?;
         render_assoc_item(w, m, AssocItemLink::Anchor(Some(&id)), ItemType::Impl)?;
         write!(w, "</code>")?;
+        write!(w, "<span class='out-of-band'>")?;
+        render_introduced_cfg_features(w, m.def_id)?;
+        write!(w, "</span>")?;
         render_stability_since(w, m, t)?;
         write!(w, "</span></h3>")?;
         document(w, cx, m)?;
@@ -2502,7 +2518,9 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                     write!(w, ";</span>")?;
                 }
             }
-            writeln!(w, "</code></li>")?;
+            writeln!(w, "</code><span class='out-of-band'>")?;
+            render_all_cfg_features(w, implementor.def_id)?;
+            writeln!(w, "</span></li>")?;
         }
     } else {
         // even without any implementations to write in, we still want the heading and list, so the
@@ -2581,6 +2599,40 @@ fn render_stability_since_raw<'a>(w: &mut fmt::Formatter,
                    v)?
         }
     }
+    Ok(())
+}
+
+fn render_all_cfg_features(w: &mut fmt::Write, def_id: DefId) -> fmt::Result {
+    let cache = cache();
+
+    let cfg_features = cache.cfg_feature_map.all(def_id);
+    if !cfg_features.is_empty() {
+        let s = if cfg_features.len() == 1 { "" } else { "s" };
+        let mut features = cfg_features.fold(String::new(), |acc, f| acc + f + ", ");
+        features.pop();
+        features.pop();
+        write!(w,
+            "<div class='cfg-feature' title='Requires feature{0} {1}'>{1}</div>",
+            s, features)?;
+    }
+
+    Ok(())
+}
+
+fn render_introduced_cfg_features(w: &mut fmt::Write, def_id: DefId) -> fmt::Result {
+    let cache = cache();
+
+    let introduced = cache.cfg_feature_map.introduced(def_id);
+    if !introduced.is_empty() {
+        let s = if introduced.len() == 1 { "" } else { "s" };
+        let mut features = introduced.fold(String::new(), |acc, f| acc + f + ", ");
+        features.pop();
+        features.pop();
+        write!(w,
+            "<div class='cfg-feature cfg-feature-introduced' title='Requires feature{0} {1}'>{1}</div>",
+            s, features)?;
+    }
+
     Ok(())
 }
 
@@ -2708,13 +2760,15 @@ fn item_struct(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                 write!(w, "<span id=\"{id}\" class=\"{item_type} small-section-header\">
                            <a href=\"#{id}\" class=\"anchor field\"></a>
                            <span id=\"{ns_id}\" class='invisible'>
-                           <code>{name}: {ty}</code>
-                           </span></span>",
+                           <code>{name}: {ty}</code>",
                        item_type = ItemType::StructField,
                        id = id,
                        ns_id = ns_id,
                        name = field.name.as_ref().unwrap(),
                        ty = ty)?;
+                write!(w, "<span class='out-of-band'>")?;
+                render_introduced_cfg_features(w, field.def_id)?;
+                write!(w, "</span></span></span>")?;
                 if let Some(stability_class) = field.stability_class() {
                     write!(w, "<span class='stab {stab}'></span>",
                         stab = stability_class)?;
@@ -2816,6 +2870,7 @@ fn item_enum(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
         write!(w, "}}")?;
     }
     write!(w, "</pre>")?;
+    render_introduced_cfg_features(w, it.def_id)?;
 
     document(w, cx, it)?;
     if !e.variants.is_empty() {
@@ -2886,6 +2941,7 @@ fn item_enum(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                 write!(w, "</table></span>")?;
             }
             render_stability_since(w, variant, it)?;
+            render_introduced_cfg_features(w, variant.def_id)?;
         }
     }
     render_assoc_items(w, cx, it, it.def_id, AssocItemRender::All)?;
@@ -3180,10 +3236,12 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
         if let Some(l) = (Item { item: &i.impl_item, cx: cx }).src_href() {
             write!(w, "<div class='ghost'></div>")?;
             render_stability_since_raw(w, since, outer_version)?;
+            render_introduced_cfg_features(w, i.impl_item.def_id)?;
             write!(w, "<a class='srclink' href='{}' title='{}'>[src]</a>",
                    l, "goto source code")?;
         } else {
             render_stability_since_raw(w, since, outer_version)?;
+            render_introduced_cfg_features(w, i.impl_item.def_id)?;
         }
         write!(w, "</span>")?;
         write!(w, "</h3>\n")?;
@@ -3238,6 +3296,9 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
                     write!(w, "<code>")?;
                     render_assoc_item(w, item, link.anchor(&id), ItemType::Impl)?;
                     write!(w, "</code>")?;
+                    write!(w, "<span class='out-of-band'>")?;
+                    render_introduced_cfg_features(w, item.def_id)?;
+                    write!(w, "</span>")?;
                     if let Some(l) = (Item { cx, item }).src_href() {
                         write!(w, "</span><span class='out-of-band'>")?;
                         write!(w, "<div class='ghost'></div>")?;
@@ -3697,6 +3758,7 @@ fn item_macro(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                                                      None,
                                                      None,
                                                      None))?;
+    render_introduced_cfg_features(w, it.def_id)?;
     document(w, cx, it)
 }
 

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2629,7 +2629,8 @@ fn render_introduced_cfg_features(w: &mut fmt::Write, def_id: DefId) -> fmt::Res
         features.pop();
         features.pop();
         write!(w,
-            "<div class='cfg-feature cfg-feature-introduced' title='Requires feature{0} {1}'>{1}</div>",
+            "<div class='cfg-feature cfg-feature-introduced' \
+                title='Requires feature{0} {1}'>{1}</div>",
             s, features)?;
     }
 

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -598,6 +598,19 @@ body.blur > :not(#help) {
 	top: 0;
 }
 
+.cfg-feature {
+	padding-left: 10px;
+	font-family: "Comic Sans MS", monospace;
+	font-weight: normal;
+	font-size: initial;
+	color: purple;
+	display: inline-block;
+}
+
+.cfg-feature-introduced {
+	color: red;
+}
+
 .variants_table {
 	width: 100%;
 }
@@ -699,9 +712,18 @@ h3 > .collapse-toggle, h4 > .collapse-toggle {
 	height: 12px;
 }
 
+.cfg-feature + .srclink {
+	padding-left: 10px;
+}
+
 span.since {
 	position: initial;
 	font-size: 20px;
+	margin-right: 5px;
+}
+
+span.cfg-feature {
+	position: initial;
 	margin-right: 5px;
 }
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -24,6 +24,8 @@
 #![feature(unicode)]
 #![feature(vec_remove_item)]
 #![feature(ascii_ctype)]
+#![feature(conservative_impl_trait)]
+#![feature(exact_size_is_empty)]
 
 extern crate arena;
 extern crate getopts;

--- a/src/librustdoc/passes/cfg_features.rs
+++ b/src/librustdoc/passes/cfg_features.rs
@@ -1,0 +1,94 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::mem;
+
+use rustc::util::nodemap::FxHashSet;
+use syntax::ast::{LitKind, MetaItem, MetaItemKind};
+use syntax::symbol::InternedString;
+
+use clean::{self, Item, AttributesExt, ConfigFeatureMap};
+use fold::{self, DocFolder as Underscore};
+use plugins;
+
+pub fn cfg_features(krate: clean::Crate) -> plugins::PluginResult {
+    let mut folder = DocFolder::new();
+    let mut krate = folder.fold_crate(krate);
+    krate.cfg_feature_map = folder.map;
+    krate
+}
+
+struct DocFolder {
+    map: ConfigFeatureMap,
+    current: FxHashSet<InternedString>,
+}
+
+impl DocFolder {
+    fn new() -> DocFolder {
+        let map = ConfigFeatureMap::default();
+        let set = FxHashSet::default();
+        DocFolder {
+            map: map,
+            current: set,
+        }
+    }
+}
+
+impl fold::DocFolder for DocFolder {
+    fn fold_item(&mut self, item: Item) -> Option<Item> {
+        let previous = self.current.clone();
+        let introduced = {
+            get_cfg_features_from_item(&item)
+                .filter(|s| !self.current.contains(s))
+                .collect::<FxHashSet<_>>()
+        };
+        self.current.extend(introduced.iter().cloned());
+        let item = self.fold_item_recur(item);
+        let current = mem::replace(&mut self.current, previous);
+        if let Some(ref item) = item {
+            if item.def_id.index.as_u32() != 0 {
+                self.map.set_all(item.def_id, current);
+                self.map.set_introduced(item.def_id, introduced);
+            }
+        }
+        item
+    }
+}
+
+fn get_cfg_features_from_item<'a>(item: &'a Item) -> impl Iterator<Item=InternedString> {
+    let mut cfg_features = Vec::default();
+    for attr in item.attrs.lists("cfg") {
+        let attr = attr.meta_item().unwrap();
+        get_cfg_features_from_attr(attr, &mut cfg_features);
+    }
+    cfg_features.into_iter()
+}
+
+/// Parses features out of the inner part of a cfg attr,
+/// i.e. the `feature = "blah"` part of `#[cfg(feature = "blah")]`
+///
+/// Only handles simple cases and (recursively) `all` cases, anything using
+/// `any` is ignored as it's unlikely to happen and give a useful result in
+/// normal usage.
+fn get_cfg_features_from_attr<'a>(attr: &'a MetaItem, cfg_features: &mut Vec<InternedString>) {
+    match attr.node {
+        MetaItemKind::List(ref attrs) if attr.name == "all" => {
+            for attr in attrs.iter().filter_map(|a| a.meta_item()) {
+                get_cfg_features_from_attr(attr, cfg_features);
+            }
+        }
+        MetaItemKind::NameValue(ref value) if attr.name == "feature" => {
+            if let LitKind::Str(ref value, _) = value.node {
+                cfg_features.push(value.as_str());
+            }
+        }
+        _ => (),
+    }
+}

--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -36,11 +36,16 @@ pub use self::unindent_comments::unindent_comments;
 mod propagate_doc_cfg;
 pub use self::propagate_doc_cfg::propagate_doc_cfg;
 
+pub mod cfg_features;
+pub use self::cfg_features::cfg_features;
+
 type Pass = (&'static str,                                      // name
              fn(clean::Crate) -> plugins::PluginResult,         // fn
              &'static str);                                     // description
 
 pub const PASSES: &'static [Pass] = &[
+    ("cfg-features", cfg_features,
+     "indexes all cfg(feature) required for an item"),
     ("strip-hidden", strip_hidden,
      "strips all doc(hidden) items from the output"),
     ("unindent-comments", unindent_comments,
@@ -57,6 +62,7 @@ pub const PASSES: &'static [Pass] = &[
 ];
 
 pub const DEFAULT_PASSES: &'static [&'static str] = &[
+    "cfg-features",
     "strip-hidden",
     "strip-private",
     "collapse-docs",


### PR DESCRIPTION
Was based on #35903 when I implemented this almost a year ago, that's been closed since in favour of #1998, but since this is very much a special case for `cfg(feature)` I don't think it makes sense to update the issue id.

You can see the current output for diesel at https://nemo157.com/rustdoc-features-example/diesel-impl2/diesel/index.html, there is definitely some work on the HTML/CSS that needs to happen (e.g. [the implementors section has some really bad alignment issues](https://nemo157.com/rustdoc-features-example/diesel-impl2/diesel/types/trait.ToSql.html#implementors) but getting some feedback on the general structure + ideas about nicer ways to render the details into the docs would be great.