### PR TITLE
Use HTTPS protocol for "chat.mibbit.com"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ hop on [#rust-internals][pound-rust-internals].
 
 As a reminder, all contributors are expected to follow our [Code of Conduct][coc].
 
-[pound-rust-internals]: http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
+[pound-rust-internals]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
 [internals]: https://internals.rust-lang.org
 [coc]: https://www.rust-lang.org/conduct.html
 


### PR DESCRIPTION
I changed the `http://` protocol to `https://` for the `chat.mibbit.com` website. :pencil:


--[**Suriyaa**](https://mozillians.org/de/u/suriyaakudo/) 🦊 

(*PS: Is somebody interested to vouch me at https://mozillians.org/de/u/suriyaakudo/?*)