### PR TITLE
Fix some E-needstest issues.

### DIFF
--- a/src/test/compile-fail/issue-30355.rs
+++ b/src/test/compile-fail/issue-30355.rs
@@ -8,22 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// aux-build:attr-on-trait.rs
-// ignore-stage1
+pub struct X([u8]);
 
-#![feature(proc_macro)]
+pub static Y: &'static X = {
+    const Y: &'static [u8] = b"";
+    &X(*Y)
+    //~^ ERROR cannot move out
+    //~^^ ERROR cannot move a
+    //~^^^ ERROR cannot move a
+};
 
-extern crate attr_on_trait;
-
-trait Foo {
-    #[attr_on_trait::foo]
-    fn foo() {}
-}
-
-impl Foo for i32 {
-    fn foo(&self) {}
-}
-
-fn main() {
-    3i32.foo();
-}
+fn main() {}

--- a/src/test/compile-fail/issue-33241.rs
+++ b/src/test/compile-fail/issue-33241.rs
@@ -8,22 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// aux-build:attr-on-trait.rs
-// ignore-stage1
+#![feature(rustc_attrs)]
 
-#![feature(proc_macro)]
+use std::fmt;
 
-extern crate attr_on_trait;
+// CoerceUnsized is not implemented for tuples. You can still create
+// an unsized tuple by transmuting a trait object.
+fn any<T>() -> T { unreachable!() }
 
-trait Foo {
-    #[attr_on_trait::foo]
-    fn foo() {}
-}
-
-impl Foo for i32 {
-    fn foo(&self) {}
-}
-
-fn main() {
-    3i32.foo();
+#[rustc_error]
+fn main() { //~ ERROR compilation successful
+    let t: &(u8, fmt::Debug) = any();
+    println!("{:?}", &t.1);
 }

--- a/src/test/compile-fail/issue-37887.rs
+++ b/src/test/compile-fail/issue-37887.rs
@@ -8,22 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// aux-build:attr-on-trait.rs
-// ignore-stage1
-
-#![feature(proc_macro)]
-
-extern crate attr_on_trait;
-
-trait Foo {
-    #[attr_on_trait::foo]
-    fn foo() {}
-}
-
-impl Foo for i32 {
-    fn foo(&self) {}
-}
-
 fn main() {
-    3i32.foo();
+    extern crate libc; //~ ERROR use of unstable
+    use libc::*; //~ ERROR unresolved import
 }

--- a/src/test/compile-fail/issue-44578.rs
+++ b/src/test/compile-fail/issue-44578.rs
@@ -8,22 +8,27 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// aux-build:attr-on-trait.rs
-// ignore-stage1
-
-#![feature(proc_macro)]
-
-extern crate attr_on_trait;
-
 trait Foo {
-    #[attr_on_trait::foo]
-    fn foo() {}
+    const AMT: usize;
 }
 
-impl Foo for i32 {
-    fn foo(&self) {}
+enum Bar<A, B> {
+    First(A),
+    Second(B),
+}
+
+impl<A: Foo, B: Foo> Foo for Bar<A, B> {
+    const AMT: usize = [A::AMT][(A::AMT > B::AMT) as usize]; //~ ERROR constant evaluation
+}
+
+impl Foo for u8 {
+    const AMT: usize = 1;
+}
+
+impl Foo for u16 {
+    const AMT: usize = 2;
 }
 
 fn main() {
-    3i32.foo();
+    println!("{}", <Bar<u16, u8> as Foo>::AMT);
 }

--- a/src/test/ui/issue-36400.rs
+++ b/src/test/ui/issue-36400.rs
@@ -8,22 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// aux-build:attr-on-trait.rs
-// ignore-stage1
-
-#![feature(proc_macro)]
-
-extern crate attr_on_trait;
-
-trait Foo {
-    #[attr_on_trait::foo]
-    fn foo() {}
-}
-
-impl Foo for i32 {
-    fn foo(&self) {}
-}
+fn f(x: &mut u32) {}
 
 fn main() {
-    3i32.foo();
+    let x = Box::new(3);
+    f(&mut *x);
 }

--- a/src/test/ui/issue-36400.stderr
+++ b/src/test/ui/issue-36400.stderr
@@ -1,0 +1,10 @@
+error[E0596]: cannot borrow immutable `Box` content `*x` as mutable
+  --> $DIR/issue-36400.rs:15:12
+   |
+14 |     let x = Box::new(3);
+   |         - consider changing this to `mut x`
+15 |     f(&mut *x);
+   |            ^^ cannot borrow as mutable
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Also ignore `attr-on-trait` test on stage-1 to keep `./x.py test --stage 1` successful.

Fixes #30355.
Fixes #33241.
Fixes #36400.
Fixes #37887.
Fixes #44578.