### PR TITLE
rustc: Add LLVM `nounwind` with `-C panic=abort`

### DIFF
--- a/src/librustc_trans/callee.rs
+++ b/src/librustc_trans/callee.rs
@@ -24,6 +24,7 @@ use rustc::hir::def_id::DefId;
 use rustc::ty::{self, TypeFoldable};
 use rustc::traits;
 use rustc::ty::subst::Substs;
+use rustc_back::PanicStrategy;
 use type_of;
 
 /// Translates a reference to a fn/method item, monomorphizing and
@@ -105,8 +106,10 @@ pub fn get_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         // *in Rust code* may unwind. Foreign items like `extern "C" {
         // fn foo(); }` are assumed not to unwind **unless** they have
         // a `#[unwind]` attribute.
-        if !tcx.is_foreign_item(instance_def_id) {
-            attributes::unwind(llfn, true);
+        if tcx.sess.panic_strategy() == PanicStrategy::Unwind {
+            if !tcx.is_foreign_item(instance_def_id) {
+                attributes::unwind(llfn, true);
+            }
         }
 
         // Apply an appropriate linkage/visibility value to our item that we

--- a/src/librustc_trans/declare.rs
+++ b/src/librustc_trans/declare.rs
@@ -24,6 +24,7 @@ use llvm::{self, ValueRef};
 use llvm::AttributePlace::Function;
 use rustc::ty::Ty;
 use rustc::session::config::Sanitizer;
+use rustc_back::PanicStrategy;
 use abi::{Abi, FnType};
 use attributes;
 use context::CrateContext;
@@ -96,6 +97,10 @@ fn declare_raw_fn(ccx: &CrateContext, name: &str, callconv: llvm::CallConv, ty: 
             llvm::Attribute::OptimizeForSize.apply_llfn(Function, llfn);
         },
         _ => {},
+    }
+
+    if ccx.tcx().sess.panic_strategy() != PanicStrategy::Unwind {
+        attributes::unwind(llfn, false);
     }
 
     llfn

--- a/src/test/codegen/auxiliary/nounwind.rs
+++ b/src/test/codegen/auxiliary/nounwind.rs
@@ -1,0 +1,13 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[no_mangle]
+pub fn bar() {
+}

--- a/src/test/codegen/nounwind.rs
+++ b/src/test/codegen/nounwind.rs
@@ -1,0 +1,26 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:nounwind.rs
+// compile-flags: -C no-prepopulate-passes -C panic=abort -C metadata=a
+// ignore-windows
+
+#![crate_type = "lib"]
+
+extern crate nounwind;
+
+#[no_mangle]
+pub fn foo() {
+    nounwind::bar();
+// CHECK: @foo() unnamed_addr #0
+// CHECK: @bar() unnamed_addr #0
+// CHECK: attributes #0 = { {{.*}}nounwind{{.*}} }
+}
+

--- a/src/test/codegen/panic-abort-windows.rs
+++ b/src/test/codegen/panic-abort-windows.rs
@@ -28,7 +28,7 @@
 
 #![crate_type = "lib"]
 
-// CHECK: Function Attrs: uwtable
+// CHECK: Function Attrs: nounwind uwtable
 // CHECK-NEXT: define void @normal_uwtable()
 #[no_mangle]
 pub fn normal_uwtable() {


### PR DESCRIPTION
This informs LLVM that functions can't unwind, which while it should typically
have already been inferred when necessary or otherwise not impact codegen is
apparently needed on targets like ARM to avoid references to unnecessary
symbols.

Closes #44992