### PR TITLE
rustc: Don't create empty codegen units

### DIFF
--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -1178,9 +1178,6 @@ fn collect_and_partition_translation_items<'a, 'tcx>(
             .collect::<Vec<_>>()
     });
 
-    assert!(tcx.sess.opts.codegen_units == codegen_units.len() ||
-            tcx.sess.opts.debugging_opts.incremental.is_some());
-
     let translation_items: DefIdSet = items.iter().filter_map(|trans_item| {
         match *trans_item {
             TransItem::Fn(ref instance) => Some(instance.def_id()),

--- a/src/librustc_trans/partitioning.rs
+++ b/src/librustc_trans/partitioning.rs
@@ -407,15 +407,6 @@ fn merge_codegen_units<'tcx>(initial_partitioning: &mut PreInliningPartitioning<
     for (index, cgu) in codegen_units.iter_mut().enumerate() {
         cgu.set_name(numbered_codegen_unit_name(crate_name, index));
     }
-
-    // If the initial partitioning contained less than target_cgu_count to begin
-    // with, we won't have enough codegen units here, so add a empty units until
-    // we reach the target count
-    while codegen_units.len() < target_cgu_count {
-        let index = codegen_units.len();
-        let name = numbered_codegen_unit_name(crate_name, index);
-        codegen_units.push(CodegenUnit::new(name));
-    }
 }
 
 fn place_inlined_translation_items<'tcx>(initial_partitioning: PreInliningPartitioning<'tcx>,


### PR DESCRIPTION
This'll end up just creating a bunch of object files that otherwise wouldn't
exist, so skip that extra work if possible.