### PR TITLE
incr.comp.: Bring back output of -Zincremental-info.

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -131,10 +131,6 @@ fn main() {
         // Pass down incremental directory, if any.
         if let Ok(dir) = env::var("RUSTC_INCREMENTAL") {
             cmd.arg(format!("-Zincremental={}", dir));
-
-            if verbose > 0 {
-                cmd.arg("-Zincremental-info");
-            }
         }
 
         let crate_name = args.windows(2)

--- a/src/librustc_incremental/persist/file_format.rs
+++ b/src/librustc_incremental/persist/file_format.rs
@@ -117,7 +117,7 @@ fn report_format_mismatch(sess: &Session, file: &Path, message: &str) {
     debug!("read_file: {}", message);
 
     if sess.opts.debugging_opts.incremental_info {
-        eprintln!("incremental: ignoring cache artifact `{}`: {}",
+        println!("[incremental] ignoring cache artifact `{}`: {}",
                   file.file_name().unwrap().to_string_lossy(),
                   message);
     }

--- a/src/librustc_incremental/persist/fs.rs
+++ b/src/librustc_incremental/persist/fs.rs
@@ -256,11 +256,12 @@ pub fn prepare_session_directory(sess: &Session,
         debug!("attempting to copy data from source: {}",
                source_directory.display());
 
-        let print_file_copy_stats = sess.opts.debugging_opts.incremental_info;
+
 
         // Try copying over all files from the source directory
-        if let Ok(allows_links) = copy_files(&session_dir, &source_directory,
-                                             print_file_copy_stats) {
+        if let Ok(allows_links) = copy_files(sess,
+                                             &session_dir,
+                                             &source_directory) {
             debug!("successfully copied data from: {}",
                    source_directory.display());
 
@@ -390,9 +391,9 @@ pub fn delete_all_session_dir_contents(sess: &Session) -> io::Result<()> {
     Ok(())
 }
 
-fn copy_files(target_dir: &Path,
-              source_dir: &Path,
-              print_stats_on_success: bool)
+fn copy_files(sess: &Session,
+              target_dir: &Path,
+              source_dir: &Path)
               -> Result<bool, ()> {
     // We acquire a shared lock on the lock file of the directory, so that
     // nobody deletes it out from under us while we are reading from it.
@@ -440,9 +441,11 @@ fn copy_files(target_dir: &Path,
         }
     }
 
-    if print_stats_on_success {
-        eprintln!("incremental: session directory: {} files hard-linked", files_linked);
-        eprintln!("incremental: session directory: {} files copied", files_copied);
+    if sess.opts.debugging_opts.incremental_info {
+        println!("[incremental] session directory: \
+                  {} files hard-linked", files_linked);
+        println!("[incremental] session directory: \
+                 {} files copied", files_copied);
     }
 
     Ok(files_linked > 0 || files_copied == 0)

--- a/src/librustc_incremental/persist/load.rs
+++ b/src/librustc_incremental/persist/load.rs
@@ -177,8 +177,8 @@ pub fn load_dep_graph(sess: &Session) -> PreviousDepGraph {
 
         if prev_commandline_args_hash != sess.opts.dep_tracking_hash() {
             if sess.opts.debugging_opts.incremental_info {
-                eprintln!("incremental: completely ignoring cache because of \
-                           differing commandline arguments");
+                println!("[incremental] completely ignoring cache because of \
+                          differing commandline arguments");
             }
             // We can't reuse the cache, purge it.
             debug!("load_dep_graph_new: differing commandline arg hashes");

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -1045,13 +1045,9 @@ fn produce_final_output_artifacts(sess: &Session,
 }
 
 pub fn dump_incremental_data(trans: &CrateTranslation) {
-    let mut reuse = 0;
-    for mtrans in trans.modules.iter() {
-        if mtrans.pre_existing {
-            reuse += 1;
-        }
-    }
-    eprintln!("incremental: re-using {} out of {} modules", reuse, trans.modules.len());
+    println!("[incremental] Re-using {} out of {} modules",
+              trans.modules.iter().filter(|m| m.pre_existing).count(),
+              trans.modules.len());
 }
 
 enum WorkItem {

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2036,7 +2036,6 @@ actual:\n\
         // Add an extra flag pointing at the incremental directory.
         let mut revision_props = self.props.clone();
         revision_props.incremental_dir = Some(incremental_dir);
-        revision_props.compile_flags.push(String::from("-Zincremental-info"));
 
         let revision_cx = TestCx {
             config: self.config,


### PR DESCRIPTION
This got kind lost during the transition to red/green.

I also switched back from `eprintln!()` to `println!()` since the former never actually produced any output. I suspect this has to do with `libterm` somehow monopolizing `stderr`.

r? @nikomatsakis 