### PR TITLE
Better error for missing tuple pattern in args

### DIFF
--- a/src/test/ui/mismatched_types/closure-arg-count.rs
+++ b/src/test/ui/mismatched_types/closure-arg-count.rs
@@ -16,4 +16,6 @@ fn main() {
     [1, 2, 3].sort_by(|tuple| panic!());
     [1, 2, 3].sort_by(|(tuple, tuple2)| panic!());
     f(|| panic!());
+
+    let _it = vec![1, 2, 3].into_iter().enumerate().map(|i, x| i);
 }

--- a/src/test/ui/mismatched_types/closure-arg-count.rs
+++ b/src/test/ui/mismatched_types/closure-arg-count.rs
@@ -18,4 +18,6 @@ fn main() {
     f(|| panic!());
 
     let _it = vec![1, 2, 3].into_iter().enumerate().map(|i, x| i);
+    let _it = vec![1, 2, 3].into_iter().enumerate().map(|i: usize, x| i);
+    let _it = vec![1, 2, 3].into_iter().enumerate().map(|i, x, y| i);
 }

--- a/src/test/ui/mismatched_types/closure-arg-count.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-count.stderr
@@ -1,4 +1,4 @@
-error[E0593]: closure takes 0 arguments but 2 arguments are required
+error[E0593]: closure takes 0 arguments, but 2 arguments are required
   --> $DIR/closure-arg-count.rs:15:15
    |
 15 |     [1, 2, 3].sort_by(|| panic!());
@@ -6,7 +6,7 @@ error[E0593]: closure takes 0 arguments but 2 arguments are required
    |               |
    |               expected closure that takes 2 arguments
 
-error[E0593]: closure takes 1 argument but 2 arguments are required
+error[E0593]: closure takes 1 argument, but 2 arguments are required
   --> $DIR/closure-arg-count.rs:16:15
    |
 16 |     [1, 2, 3].sort_by(|tuple| panic!());
@@ -23,7 +23,7 @@ error[E0308]: mismatched types
    = note: expected type `&{integer}`
               found type `(_, _)`
 
-error[E0593]: closure takes 1 argument but 2 arguments are required
+error[E0593]: closure takes 1 argument, but 2 arguments are required
   --> $DIR/closure-arg-count.rs:17:15
    |
 17 |     [1, 2, 3].sort_by(|(tuple, tuple2)| panic!());
@@ -31,7 +31,7 @@ error[E0593]: closure takes 1 argument but 2 arguments are required
    |               |
    |               expected closure that takes 2 arguments
 
-error[E0593]: closure takes 0 arguments but 1 argument is required
+error[E0593]: closure takes 0 arguments, but 1 argument is required
   --> $DIR/closure-arg-count.rs:18:5
    |
 18 |     f(|| panic!());
@@ -41,13 +41,29 @@ error[E0593]: closure takes 0 arguments but 1 argument is required
    |
    = note: required by `f`
 
-error[E0593]: closure takes 2 arguments but a 2-tuple is required
+error[E0593]: closure takes multiple arguments, but a tuple argument is required
   --> $DIR/closure-arg-count.rs:20:53
    |
 20 |     let _it = vec![1, 2, 3].into_iter().enumerate().map(|i, x| i);
-   |                                                     ^^^ ------ takes 2 arguments
+   |                                                     ^^^ ------ help: consider changing to: `|(i, x)|`
    |                                                     |
-   |                                                     expected closure that takes a 2-tuple
+   |                                                     expected closure that takes 1 argument, a 2-tuple
 
-error: aborting due to 6 previous errors
+error[E0593]: closure takes multiple arguments, but a tuple argument is required
+  --> $DIR/closure-arg-count.rs:21:53
+   |
+21 |     let _it = vec![1, 2, 3].into_iter().enumerate().map(|i: usize, x| i);
+   |                                                     ^^^ ------------- help: consider changing to: `|(i, x): (usize, _)|`
+   |                                                     |
+   |                                                     expected closure that takes 1 argument, a 2-tuple
+
+error[E0593]: closure takes multiple arguments, but a tuple argument is required
+  --> $DIR/closure-arg-count.rs:22:53
+   |
+22 |     let _it = vec![1, 2, 3].into_iter().enumerate().map(|i, x, y| i);
+   |                                                     ^^^ --------- takes 3 arguments
+   |                                                     |
+   |                                                     expected closure that takes 1 argument, a 2-tuple
+
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/mismatched_types/closure-arg-count.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-count.stderr
@@ -45,25 +45,25 @@ error[E0593]: closure is expected to take a single tuple as argument, but it tak
   --> $DIR/closure-arg-count.rs:20:53
    |
 20 |     let _it = vec![1, 2, 3].into_iter().enumerate().map(|i, x| i);
-   |                                                     ^^^ ------ help: consider changing to: `|(i, x)|`
+   |                                                     ^^^ ------ help: consider changing the closure to accept a tuple: `|(i, x)|`
    |                                                     |
-   |                                                     expected closure that takes 1 argument, a 2-tuple
+   |                                                     expected closure that takes a single tuple as argument
 
 error[E0593]: closure is expected to take a single tuple as argument, but it takes 2 distinct arguments
   --> $DIR/closure-arg-count.rs:21:53
    |
 21 |     let _it = vec![1, 2, 3].into_iter().enumerate().map(|i: usize, x| i);
-   |                                                     ^^^ ------------- help: consider changing to: `|(i, x): (usize, _)|`
+   |                                                     ^^^ ------------- help: consider changing the closure to accept a tuple: `|(i, x): (usize, _)|`
    |                                                     |
-   |                                                     expected closure that takes 1 argument, a 2-tuple
+   |                                                     expected closure that takes a single tuple as argument
 
-error[E0593]: closure is expected to take a single tuple as argument, but it takes 3 distinct arguments
+error[E0593]: closure is expected to take a single 2-tuple as argument, but it takes 3 distinct arguments
   --> $DIR/closure-arg-count.rs:22:53
    |
 22 |     let _it = vec![1, 2, 3].into_iter().enumerate().map(|i, x, y| i);
    |                                                     ^^^ --------- takes 3 distinct arguments
    |                                                     |
-   |                                                     expected closure that takes 1 argument, a 2-tuple
+   |                                                     expected closure that takes a single 2-tuple as argument
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/mismatched_types/closure-arg-count.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-count.stderr
@@ -2,7 +2,7 @@ error[E0593]: closure takes 0 arguments but 2 arguments are required
   --> $DIR/closure-arg-count.rs:15:15
    |
 15 |     [1, 2, 3].sort_by(|| panic!());
-   |               ^^^^^^^ ----------- takes 0 arguments
+   |               ^^^^^^^ -- takes 0 arguments
    |               |
    |               expected closure that takes 2 arguments
 
@@ -10,7 +10,7 @@ error[E0593]: closure takes 1 argument but 2 arguments are required
   --> $DIR/closure-arg-count.rs:16:15
    |
 16 |     [1, 2, 3].sort_by(|tuple| panic!());
-   |               ^^^^^^^ ---------------- takes 1 argument
+   |               ^^^^^^^ ------- takes 1 argument
    |               |
    |               expected closure that takes 2 arguments
 
@@ -27,7 +27,7 @@ error[E0593]: closure takes 1 argument but 2 arguments are required
   --> $DIR/closure-arg-count.rs:17:15
    |
 17 |     [1, 2, 3].sort_by(|(tuple, tuple2)| panic!());
-   |               ^^^^^^^ -------------------------- takes 1 argument
+   |               ^^^^^^^ ----------------- takes 1 argument
    |               |
    |               expected closure that takes 2 arguments
 
@@ -35,11 +35,19 @@ error[E0593]: closure takes 0 arguments but 1 argument is required
   --> $DIR/closure-arg-count.rs:18:5
    |
 18 |     f(|| panic!());
-   |     ^ ----------- takes 0 arguments
+   |     ^ -- takes 0 arguments
    |     |
    |     expected closure that takes 1 argument
    |
    = note: required by `f`
 
-error: aborting due to 5 previous errors
+error[E0593]: closure takes 2 arguments but a 2-tuple is required
+  --> $DIR/closure-arg-count.rs:20:53
+   |
+20 |     let _it = vec![1, 2, 3].into_iter().enumerate().map(|i, x| i);
+   |                                                     ^^^ ------ takes 2 arguments
+   |                                                     |
+   |                                                     expected closure that takes a 2-tuple
+
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/mismatched_types/closure-arg-count.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-count.stderr
@@ -1,4 +1,4 @@
-error[E0593]: closure takes 0 arguments, but 2 arguments are required
+error[E0593]: closure is expected to take 2 arguments, but it takes 0 arguments
   --> $DIR/closure-arg-count.rs:15:15
    |
 15 |     [1, 2, 3].sort_by(|| panic!());
@@ -6,7 +6,7 @@ error[E0593]: closure takes 0 arguments, but 2 arguments are required
    |               |
    |               expected closure that takes 2 arguments
 
-error[E0593]: closure takes 1 argument, but 2 arguments are required
+error[E0593]: closure is expected to take 2 arguments, but it takes 1 argument
   --> $DIR/closure-arg-count.rs:16:15
    |
 16 |     [1, 2, 3].sort_by(|tuple| panic!());
@@ -23,7 +23,7 @@ error[E0308]: mismatched types
    = note: expected type `&{integer}`
               found type `(_, _)`
 
-error[E0593]: closure takes 1 argument, but 2 arguments are required
+error[E0593]: closure is expected to take 2 arguments, but it takes 1 argument
   --> $DIR/closure-arg-count.rs:17:15
    |
 17 |     [1, 2, 3].sort_by(|(tuple, tuple2)| panic!());
@@ -31,7 +31,7 @@ error[E0593]: closure takes 1 argument, but 2 arguments are required
    |               |
    |               expected closure that takes 2 arguments
 
-error[E0593]: closure takes 0 arguments, but 1 argument is required
+error[E0593]: closure is expected to take 1 argument, but it takes 0 arguments
   --> $DIR/closure-arg-count.rs:18:5
    |
 18 |     f(|| panic!());
@@ -41,7 +41,7 @@ error[E0593]: closure takes 0 arguments, but 1 argument is required
    |
    = note: required by `f`
 
-error[E0593]: closure takes multiple arguments, but a tuple argument is required
+error[E0593]: closure is expected to take a single tuple as argument, but it takes 2 distinct arguments
   --> $DIR/closure-arg-count.rs:20:53
    |
 20 |     let _it = vec![1, 2, 3].into_iter().enumerate().map(|i, x| i);
@@ -49,7 +49,7 @@ error[E0593]: closure takes multiple arguments, but a tuple argument is required
    |                                                     |
    |                                                     expected closure that takes 1 argument, a 2-tuple
 
-error[E0593]: closure takes multiple arguments, but a tuple argument is required
+error[E0593]: closure is expected to take a single tuple as argument, but it takes 2 distinct arguments
   --> $DIR/closure-arg-count.rs:21:53
    |
 21 |     let _it = vec![1, 2, 3].into_iter().enumerate().map(|i: usize, x| i);
@@ -57,11 +57,11 @@ error[E0593]: closure takes multiple arguments, but a tuple argument is required
    |                                                     |
    |                                                     expected closure that takes 1 argument, a 2-tuple
 
-error[E0593]: closure takes multiple arguments, but a tuple argument is required
+error[E0593]: closure is expected to take a single tuple as argument, but it takes 3 distinct arguments
   --> $DIR/closure-arg-count.rs:22:53
    |
 22 |     let _it = vec![1, 2, 3].into_iter().enumerate().map(|i, x, y| i);
-   |                                                     ^^^ --------- takes 3 arguments
+   |                                                     ^^^ --------- takes 3 distinct arguments
    |                                                     |
    |                                                     expected closure that takes 1 argument, a 2-tuple
 


### PR DESCRIPTION
#44150

Before:
```
error[E0593]: closure takes 2 arguments but 1 argument is required
 --> test.rs:5:40
  |
5 |     let it = v.into_iter().enumerate().map(|i, x| i);
  |                                        ^^^ -------- takes 2 arguments
  |                                        |
  |                                        expected closure that takes 1 argument
```

After:
```
error[E0593]: closure takes 2 arguments but a 2-tuple is required
 --> test.rs:5:40
  |
5 |     let it = v.into_iter().enumerate().map(|i, x| i);
  |                                        ^^^ ------ takes 2 arguments
  |                                        |
  |                                        expected closure that takes a 2-tuple
```