### PR TITLE
Implement display_hint in gdb pretty printers

### DIFF
--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -248,7 +248,10 @@ class RustStringSlicePrinter(object):
     def to_string(self):
         (length, data_ptr) = rustpp.extract_length_and_ptr_from_slice(self.__val)
         raw_ptr = data_ptr.get_wrapped_value()
-        return '"%s"' % raw_ptr.string(encoding="utf-8", length=length)
+        return raw_ptr.lazy_string(encoding="utf-8", length=length)
+
+    def display_hint(self):
+        return "string"
 
 
 class RustStdVecPrinter(object):
@@ -278,9 +281,11 @@ class RustStdStringPrinter(object):
     def to_string(self):
         vec = self.__val.get_child_at_index(0)
         (length, data_ptr, cap) = rustpp.extract_length_ptr_and_cap_from_std_vec(vec)
-        return '"%s"' % data_ptr.get_wrapped_value().string(encoding="utf-8",
-                                                            length=length)
+        return data_ptr.get_wrapped_value().lazy_string(encoding="utf-8",
+                                                        length=length)
 
+    def display_hint(self):
+        return "string"
 
 class RustOsStringPrinter(object):
     def __init__(self, val):
@@ -294,8 +299,10 @@ class RustOsStringPrinter(object):
 
         (length, data_ptr, cap) = rustpp.extract_length_ptr_and_cap_from_std_vec(
             vec)
-        return '"%s"' % data_ptr.get_wrapped_value().string(length=length)
+        return data_ptr.get_wrapped_value().lazy_string(length=length)
 
+    def display_hint(self):
+        return "string"
 
 class RustCStyleVariantPrinter(object):
     def __init__(self, val):

--- a/src/test/debuginfo/pretty-std.rs
+++ b/src/test/debuginfo/pretty-std.rs
@@ -44,6 +44,10 @@
 // gdb-command: print some_string
 // gdb-check:$8 = Some = {"IAMA optional string!"}
 
+// gdb-command: set print length 5
+// gdb-command: print some_string
+// gdb-check:$8 = Some = {"IAMA "...}
+
 
 // === LLDB TESTS ==================================================================================
 


### PR DESCRIPTION
A few pretty-printers were returning a quoted string from their
to_string method.  It's preferable in gdb to return a lazy string and to
let gdb handle the display by having a "display_hint" method that
returns "string" -- it lets gdb settings (like "set print ...") work, it
handles corrupted strings a bit better, and it passes the information
along to IDEs.