### PR TITLE
Use the `bitflags!` macro to implement FlagV1

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -323,7 +323,9 @@ dependencies = [
 name = "core"
 version = "0.0.0"
 dependencies = [
+ "bitflags 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.0.0",
+ "rustc_cratesio_shim 0.0.0",
 ]
 
 [[package]]

--- a/src/libcore/Cargo.toml
+++ b/src/libcore/Cargo.toml
@@ -9,6 +9,10 @@ path = "lib.rs"
 test = false
 bench = false
 
+[dependencies]
+bitflags = "1.0"
+rustc_cratesio_shim = { path = "../librustc_cratesio_shim" }
+
 [dev-dependencies]
 rand = { path = "../librand" }
 

--- a/src/libcore/fmt/builders.rs
+++ b/src/libcore/fmt/builders.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use fmt::{self, FlagV1};
+use fmt;
 
 struct PadAdapter<'a, 'b: 'a> {
     fmt: &'a mut fmt::Formatter<'b>,
@@ -140,7 +140,7 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
     }
 
     fn is_pretty(&self) -> bool {
-        self.fmt.flags() & (1 << (FlagV1::Alternate as usize)) != 0
+        self.fmt.alternate()
     }
 }
 
@@ -233,7 +233,7 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     }
 
     fn is_pretty(&self) -> bool {
-        self.fmt.flags() & (1 << (FlagV1::Alternate as usize)) != 0
+        self.fmt.alternate()
     }
 }
 
@@ -277,7 +277,7 @@ impl<'a, 'b: 'a> DebugInner<'a, 'b> {
     }
 
     fn is_pretty(&self) -> bool {
-        self.fmt.flags() & (1 << (FlagV1::Alternate as usize)) != 0
+        self.fmt.alternate()
     }
 }
 
@@ -519,6 +519,6 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     }
 
     fn is_pretty(&self) -> bool {
-        self.fmt.flags() & (1 << (FlagV1::Alternate as usize)) != 0
+        self.fmt.alternate()
     }
 }

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1275,7 +1275,7 @@ impl<'a> Formatter<'a> {
         write(self.buf, fmt)
     }
 
-    /// Flags for formatting (packed version of rt::Flag)
+    /// Flags for formatting
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn flags(&self) -> u32 { self.flags }
 

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -322,7 +322,6 @@ impl<'a> ArgumentV1<'a> {
 
 // flags available in the v1 format of format_args
 #[derive(Copy, Clone)]
-#[allow(dead_code)] // SignMinus isn't currently used
 enum FlagV1 { SignPlus, SignMinus, Alternate, SignAwareZeroPad, }
 
 impl<'a> Arguments<'a> {

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -109,6 +109,13 @@
 #![cfg_attr(not(stage0), feature(const_cell_new))]
 #![cfg_attr(not(stage0), feature(const_nonzero_new))]
 
+// See librustc_cratesio_shim/Cargo.toml for a comment explaining this.
+#[allow(unused_extern_crates)]
+extern crate rustc_cratesio_shim;
+
+#[macro_use]
+extern crate bitflags;
+
 #[prelude_import]
 #[allow(unused)]
 use prelude::v1::*;


### PR DESCRIPTION
Closes #15738.

This currently doesn't compile, and I don't really understand why:
```
error[E0463]: can't find crate for `core`

error: aborting due to previous error

error: Could not compile `bitflags`.
```
Sorry @alexcrichton, I think you're probably still the most knowledgable person on this :(

Full log:
```
$ ./x.py --incremental --stage 0 build src/libcore --verbose
Updating submodules
running: git submodule -q sync
running: git submodule update --init --recursive src/llvm src/rt/hoedown src/jemalloc src/tools/rust-installer src/liblibc src/doc/nomicon src/tools/cargo src/doc/reference src/doc/book src/tools/rls src/libcompiler_builtins src/tools/clippy src/tools/rustfmt src/tools/miri
running: git submodule -q foreach git reset -q --hard
running: git submodule -q foreach git clean -qdfx
running: /Users/tamird/src/rust/build/x86_64-apple-darwin/stage0/bin/cargo build --manifest-path /Users/tamird/src/rust/src/bootstrap/Cargo.toml --verbose
       Fresh cc v1.0.0
       Fresh quote v0.3.15
       Fresh serde v1.0.15
       Fresh unicode-xid v0.0.4
       Fresh itoa v0.3.4
       Fresh num-traits v0.1.40
       Fresh dtoa v0.4.2
       Fresh getopts v0.2.15
       Fresh lazy_static v0.2.8
       Fresh libc v0.2.31
       Fresh cmake v0.1.26
       Fresh toml v0.4.5
       Fresh synom v0.11.3
       Fresh serde_json v1.0.3
       Fresh num_cpus v1.6.2
       Fresh filetime v0.1.12
       Fresh syn v0.11.11
       Fresh build_helper v0.1.0 (file:///Users/tamird/src/rust/src/build_helper)
       Fresh serde_derive_internals v0.16.0
       Fresh serde_derive v1.0.15
       Fresh bootstrap v0.0.0 (file:///Users/tamird/src/rust/src/bootstrap)
    Finished dev [unoptimized] target(s) in 0.0 secs
running: /Users/tamird/src/rust/build/bootstrap/debug/bootstrap --incremental --stage 0 build src/libcore --verbose
finding compilers
CC_x86_64-apple-darwin = "cc"
AR_x86_64-apple-darwin = "ar"
CC_x86_64-apple-darwin = "cc"
AR_x86_64-apple-darwin = "ar"
CC_x86_64-apple-darwin = "cc"
AR_x86_64-apple-darwin = "ar"
CXX_x86_64-apple-darwin = "c++"
CXX_x86_64-apple-darwin = "c++"
running sanity check
learning about cargo
> Assemble { target_compiler: Compiler { stage: 0, host: "x86_64-apple-darwin" } }
< Assemble { target_compiler: Compiler { stage: 0, host: "x86_64-apple-darwin" } }
> Std { target: "x86_64-apple-darwin", compiler: Compiler { stage: 0, host: "x86_64-apple-darwin" } }
  > StartupObjects { compiler: Compiler { stage: 0, host: "x86_64-apple-darwin" }, target: "x86_64-apple-darwin" }
  < StartupObjects { compiler: Compiler { stage: 0, host: "x86_64-apple-darwin" }, target: "x86_64-apple-darwin" }
Building stage0 std artifacts (x86_64-apple-darwin -> x86_64-apple-darwin)
  > Sysroot { compiler: Compiler { stage: 0, host: "x86_64-apple-darwin" } }
  < Sysroot { compiler: Compiler { stage: 0, host: "x86_64-apple-darwin" } }
running: "/Users/tamird/src/rust/build/x86_64-apple-darwin/stage0/bin/cargo" "build" "--target" "x86_64-apple-darwin" "-j" "4" "-v" "--release" "--features" "panic-unwind jemalloc backtrace" "--manifest-path" "/Users/tamird/src/rust/src/libstd/Cargo.toml" "--message-format" "json"
       Fresh cc v1.0.0
   Compiling bitflags v1.0.0
       Fresh libc v0.2.31
     Running `/Users/tamird/src/rust/build/bootstrap/debug/rustc --crate-name bitflags /Users/tamird/.cargo/registry/src/github.com-1ecc6299db9ec823/bitflags-1.0.0/src/lib.rs --error-format json --crate-type lib --emit=dep-info,link -C opt-level=2 --cfg 'feature="default"' --cfg 'feature="example_generated"' -C metadata=c9c6946b58ad8fa6 -C extra-filename=-c9c6946b58ad8fa6 --out-dir /Users/tamird/src/rust/build/x86_64-apple-darwin/stage0-std/x86_64-apple-darwin/release/deps --target x86_64-apple-darwin -L dependency=/Users/tamird/src/rust/build/x86_64-apple-darwin/stage0-std/x86_64-apple-darwin/release/deps -L dependency=/Users/tamird/src/rust/build/x86_64-apple-darwin/stage0-std/release/deps --cap-lints allow`
       Fresh cmake v0.1.26
       Fresh filetime v0.1.12
       Fresh build_helper v0.1.0 (file:///Users/tamird/src/rust/src/build_helper)
error[E0463]: can't find crate for `core`

error: aborting due to previous error

error: Could not compile `bitflags`.

Caused by:
  process didn't exit successfully: `/Users/tamird/src/rust/build/bootstrap/debug/rustc --crate-name bitflags /Users/tamird/.cargo/registry/src/github.com-1ecc6299db9ec823/bitflags-1.0.0/src/lib.rs --error-format json --crate-type lib --emit=dep-info,link -C opt-level=2 --cfg feature="default" --cfg feature="example_generated" -C metadata=c9c6946b58ad8fa6 -C extra-filename=-c9c6946b58ad8fa6 --out-dir /Users/tamird/src/rust/build/x86_64-apple-darwin/stage0-std/x86_64-apple-darwin/release/deps --target x86_64-apple-darwin -L dependency=/Users/tamird/src/rust/build/x86_64-apple-darwin/stage0-std/x86_64-apple-darwin/release/deps -L dependency=/Users/tamird/src/rust/build/x86_64-apple-darwin/stage0-std/release/deps --cap-lints allow` (exit code: 101)
thread 'main' panicked at 'command did not execute successfully: "/Users/tamird/src/rust/build/x86_64-apple-darwin/stage0/bin/cargo" "build" "--target" "x86_64-apple-darwin" "-j" "4" "-v" "--release" "--features" "panic-unwind jemalloc backtrace" "--manifest-path" "/Users/tamird/src/rust/src/libstd/Cargo.toml" "--message-format" "json"
expected success, got: exit code: 101', src/bootstrap/compile.rs:883:8
note: Run with `RUST_BACKTRACE=1` for a backtrace.
Traceback (most recent call last):
  File "./x.py", line 20, in <module>
    bootstrap.main()
  File "/Users/tamird/src/rust/src/bootstrap/bootstrap.py", line 756, in main
    bootstrap()
  File "/Users/tamird/src/rust/src/bootstrap/bootstrap.py", line 747, in bootstrap
    run(args, env=env, verbose=build.verbose)
  File "/Users/tamird/src/rust/src/bootstrap/bootstrap.py", line 148, in run
    raise RuntimeError(err)
RuntimeError: failed to run: /Users/tamird/src/rust/build/bootstrap/debug/bootstrap --incremental --stage 0 build src/libcore --verbose
```