### PR TITLE
Add read_to_end implementation to &[u8]'s Read impl

### DIFF
--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -206,6 +206,14 @@ impl<'a> Read for &'a [u8] {
         *self = b;
         Ok(())
     }
+
+    #[inline]
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        buf.extend_from_slice(*self);
+        let len = self.len();
+        *self = &self[len..];
+        Ok(len)
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
The default impl for read_to_end does a bunch of bookkeeping
that isn't necessary for slices and is about 4 times slower
on my machine.

The following benchmark takes about 30 ns before this change and about 7 ns after:

```
#[bench]
fn bench_read_std(b: &mut Bencher) {
    let data = vec![0u8; 100];
    let mut v = Vec::with_capacity(200);
    b.iter(|| {
        let mut s = data.as_slice();
        v.clear();         
        s.read_to_end(&mut v).unwrap();
    });
}
```

This solves the easy part of  https://github.com/rust-lang/rust/issues/44819 (I think extending this to `Take<&[u8]> `would require specialization)