### PR TITLE
On FreeBSD, link against libc++ instead of libstdc++

### DIFF
--- a/src/librustc_llvm/build.rs
+++ b/src/librustc_llvm/build.rs
@@ -253,6 +253,8 @@ fn main() {
     let stdcppname = if target.contains("openbsd") {
         // OpenBSD has a particular C++ runtime library name
         "estdc++"
+    } else if target.contains("freebsd") {
+        "c++"
     } else if target.contains("netbsd") && llvm_static_stdcpp.is_some() {
         // NetBSD uses a separate library when relocation is required
         "stdc++_pic"


### PR DESCRIPTION
Submitted by: Jean-Sébastien Pédron <dumbbell@FreeBSD.org>