### PR TITLE
debuginfo-test: Fix #45086.

### DIFF
--- a/src/etc/lldb_batchmode.py
+++ b/src/etc/lldb_batchmode.py
@@ -81,7 +81,7 @@ def execute_command(command_interpreter, command):
 
     if res.Succeeded():
         if res.HasResult():
-            print(normalize_whitespace(res.GetOutput()), end='\n')
+            print(normalize_whitespace(res.GetOutput() or ''), end='\n')
 
         # If the command introduced any breakpoints, make sure to register
         # them with the breakpoint


### PR DESCRIPTION
Fixes #45086, where all debuginfo-lldb fails when using LLDB from Xcode 9.

