### PR TITLE
enable strict alignment (+strict-align) on ARMv6

### DIFF
--- a/src/librustc_back/target/arm_linux_androideabi.rs
+++ b/src/librustc_back/target/arm_linux_androideabi.rs
@@ -14,7 +14,7 @@ use target::{Target, TargetOptions, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::android_base::opts();
     // https://developer.android.com/ndk/guides/abis.html#armeabi
-    base.features = "+v5te".to_string();
+    base.features = "+strict-align,+v5te".to_string();
     base.max_atomic_width = Some(64);
 
     Ok(Target {

--- a/src/librustc_back/target/arm_unknown_linux_gnueabi.rs
+++ b/src/librustc_back/target/arm_unknown_linux_gnueabi.rs
@@ -27,7 +27,7 @@ pub fn target() -> TargetResult {
         linker_flavor: LinkerFlavor::Gcc,
 
         options: TargetOptions {
-            features: "+v6".to_string(),
+            features: "+strict-align,+v6".to_string(),
             abi_blacklist: super::arm_base::abi_blacklist(),
             .. base
         },

--- a/src/librustc_back/target/arm_unknown_linux_gnueabihf.rs
+++ b/src/librustc_back/target/arm_unknown_linux_gnueabihf.rs
@@ -27,7 +27,7 @@ pub fn target() -> TargetResult {
         linker_flavor: LinkerFlavor::Gcc,
 
         options: TargetOptions {
-            features: "+v6,+vfp2".to_string(),
+            features: "+strict-align,+v6,+vfp2".to_string(),
             abi_blacklist: super::arm_base::abi_blacklist(),
             .. base
         }

--- a/src/librustc_back/target/arm_unknown_linux_musleabi.rs
+++ b/src/librustc_back/target/arm_unknown_linux_musleabi.rs
@@ -16,7 +16,7 @@ pub fn target() -> TargetResult {
 
     // Most of these settings are copied from the arm_unknown_linux_gnueabi
     // target.
-    base.features = "+v6".to_string();
+    base.features = "+strict-align,+v6".to_string();
     base.max_atomic_width = Some(64);
     Ok(Target {
         // It's important we use "gnueabi" and not "musleabi" here. LLVM uses it

--- a/src/librustc_back/target/arm_unknown_linux_musleabihf.rs
+++ b/src/librustc_back/target/arm_unknown_linux_musleabihf.rs
@@ -16,7 +16,7 @@ pub fn target() -> TargetResult {
 
     // Most of these settings are copied from the arm_unknown_linux_gnueabihf
     // target.
-    base.features = "+v6,+vfp2".to_string();
+    base.features = "+strict-align,+v6,+vfp2".to_string();
     base.max_atomic_width = Some(64);
     Ok(Target {
         // It's important we use "gnueabihf" and not "musleabihf" here. LLVM


### PR DESCRIPTION
As discovered in #44538 ARMv6 devices may or may not support unaligned memory accesses. ARMv6
Linux *seems* to have no problem with unaligned accesses but this is because the kernel is stepping
in to fix each unaligned memory access -- this incurs in a performance penalty.

This commit enforces aligned memory accesses on all our in-tree ARM targets that may be used with
ARMv6 devices. This should improve performance of Rust programs on ARMv6 devices. For the record,
clang also applies this attribute when targeting ARMv6 devices that are not running Darwin or
NetBSD.

closes #44538
r? @alexcrichton