### PR TITLE
Ensure std::mem::Discriminant is Send + Sync

### DIFF
--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -836,7 +836,7 @@ pub unsafe fn transmute_copy<T, U>(src: &T) -> U {
 ///
 /// See the `discriminant` function in this module for more information.
 #[stable(feature = "discriminant_value", since = "1.21.0")]
-pub struct Discriminant<T>(u64, PhantomData<*const T>);
+pub struct Discriminant<T>(u64, PhantomData<fn() -> T>);
 
 // N.B. These trait implementations cannot be derived because we don't want any bounds on T.
 

--- a/src/libcore/tests/mem.rs
+++ b/src/libcore/tests/mem.rs
@@ -121,3 +121,19 @@ fn test_transmute() {
     }
 }
 
+#[test]
+#[allow(dead_code)]
+fn test_discriminant_send_sync() {
+    enum Regular {
+        A,
+        B(i32)
+    }
+    enum NotSendSync {
+        A(*const i32)
+    }
+
+    fn is_send_sync<T: Send + Sync>() { }
+
+    is_send_sync::<Discriminant<Regular>>();
+    is_send_sync::<Discriminant<NotSendSync>>();
+}


### PR DESCRIPTION
`PhantomData<*const T>` has the implication of Send / Syncness following
the *const T type, but the discriminant should always be Send and Sync.

Use `PhantomData<fn() -> T>` which has the same variance in T, but is Send + Sync