### PR TITLE
Fix raising a bare str as an exception in configure.py

### DIFF
--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -360,7 +360,7 @@ def to_toml(value):
     elif isinstance(value, str):
         return "'" + value + "'"
     else:
-        raise 'no toml'
+        raise RuntimeError('no toml')
 
 def configure_section(lines, config):
     for key in config:


### PR DESCRIPTION
Raising a bare `str` has been [deprecated since Python 2.5](https://docs.python.org/2/whatsnew/2.5.html#pep-352-exceptions-as-new-style-classes).

On Python 2.7 it produces the following error:

```
TypeError: exceptions must be old-style classes or derived from BaseException, not str
```

For maximum compatibility with Python 2.7 and 3.x, we wrap the error message in `RuntimeError` which derives from `Exception`.