### PR TITLE
Fix variable name reference

### DIFF
--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -378,7 +378,7 @@ def configure_section(lines, config):
 for section_key in config:
     section_config = config[section_key]
     if not section_key in sections:
-        raise RuntimeError("config key {} not in sections".format(key))
+        raise RuntimeError("config key {} not in sections".format(section_key))
 
     if section_key == 'target':
         for target in section_config:


### PR DESCRIPTION
As best I can tell, this was a typo due to how similar it looks to the function above it. PyCharm found this as a unbound local variable.