### PR TITLE
Use identity operator `is` when comparing to None

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -498,7 +498,7 @@ class RustBuild(object):
 
         If the key does not exists, the result is None:
 
-        >>> rb.get_toml("key3") == None
+        >>> rb.get_toml("key3") is None
         True
         """
         for line in self.config_toml.splitlines():


### PR DESCRIPTION
This is very minor, but idiomatic Python code uses `is` for comparisons to `None`. This is because semantically we want to compare to the "identity" of `None`, not its value.

See [PEP8 for details](https://www.python.org/dev/peps/pep-0008/#programming-recommendations).