### PR TITLE
Better compile error output when using arguments instead of types 

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2947,6 +2947,7 @@ impl<'a> Parser<'a> {
                 {                                  //     Foo<Bar<Baz<Qux, ()>>>
                     err.help(
                         "use `::<...>` instead of `<...>` if you meant to specify type arguments");
+                    err.help("or use `(...)` if you meant to specify fn arguments");
                 }
                 err.emit();
             }

--- a/src/test/parse-fail/require-parens-for-chained-comparison.rs
+++ b/src/test/parse-fail/require-parens-for-chained-comparison.rs
@@ -21,5 +21,6 @@ fn main() {
 
     f<X>();
     //~^ ERROR: chained comparison operators require parentheses
-    //~^^ HELP: use `::<...>` instead of `<...>`
+    //~| HELP: use `::<...>` instead of `<...>`
+    //~| HELP: or use `(...)`
 }

--- a/src/test/ui/did_you_mean/issue-40396.stderr
+++ b/src/test/ui/did_you_mean/issue-40396.stderr
@@ -5,6 +5,7 @@ error: chained comparison operators require parentheses
    |                                     ^^^^^^^^
    |
    = help: use `::<...>` instead of `<...>` if you meant to specify type arguments
+   = help: or use `(...)` if you meant to specify fn arguments
 
 error: chained comparison operators require parentheses
   --> $DIR/issue-40396.rs:16:25
@@ -13,6 +14,7 @@ error: chained comparison operators require parentheses
    |                         ^^^^^^^
    |
    = help: use `::<...>` instead of `<...>` if you meant to specify type arguments
+   = help: or use `(...)` if you meant to specify fn arguments
 
 error: chained comparison operators require parentheses
   --> $DIR/issue-40396.rs:20:37
@@ -21,6 +23,7 @@ error: chained comparison operators require parentheses
    |                                     ^^^^^^^^
    |
    = help: use `::<...>` instead of `<...>` if you meant to specify type arguments
+   = help: or use `(...)` if you meant to specify fn arguments
 
 error: chained comparison operators require parentheses
   --> $DIR/issue-40396.rs:20:41
@@ -29,6 +32,7 @@ error: chained comparison operators require parentheses
    |                                         ^^^^^^
    |
    = help: use `::<...>` instead of `<...>` if you meant to specify type arguments
+   = help: or use `(...)` if you meant to specify fn arguments
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Following @estebank sugestion on issue https://github.com/rust-lang/rust/issues/18945#issuecomment-331251436