### PR TITLE
incr.comp.: Move macro-export test case to src/test/incremental.

### DIFF
--- a/src/test/incremental/macro_export.rs
+++ b/src/test/incremental/macro_export.rs
@@ -8,9 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Zincremental=tmp/cfail-tests/incr_comp_with_macro_export
+// revisions: cfail1 cfail2 cfail3
 // must-compile-successfully
-
 
 // This test case makes sure that we can compile with incremental compilation
 // enabled when there are macros exported from this crate. (See #37756)


### PR DESCRIPTION
`compile-fail/incr_comp_with_macro_export.rs` was trying to role its own incremental compilation setup. This started to cause problems. There's no reason to not just make this a regular `src/test/incremental` test.

Fixes #45062.

