### PR TITLE
Clarify RAM usage during build in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Snapshot binaries are currently built and tested on several platforms:
 You may find that other platforms work, but these are our officially
 supported build environments that are most likely to work.
 
-Rust currently needs between 600MiB and 1.5GiB to build, depending on platform.
+Rust currently needs between 600MiB and 1.5GiB of RAM to build, depending on platform.
 If it hits swap, it will take a very long time to build.
 
 There is more advice about hacking on Rust in [CONTRIBUTING.md].


### PR DESCRIPTION
The sentence wasn't immediately clear if it meant RAM or disk space before reading the next sentence.

I think this helps clarify it.