### PR TITLE
Fix a bug in diagnostics for `x as usize < y`

### DIFF
--- a/src/test/ui/issue-22644.rs
+++ b/src/test/ui/issue-22644.rs
@@ -35,5 +35,7 @@ fn main() {
                    <
                    5);
 
+    println!("{}", a as usize << long_name);
+
     println!("{}", a: &mut 4);
 }

--- a/src/test/ui/issue-22644.stderr
+++ b/src/test/ui/issue-22644.stderr
@@ -76,9 +76,18 @@ help: try comparing the casted value
 33 | 
  ...
 
-error: expected type, found `4`
-  --> $DIR/issue-22644.rs:38:28
+error: `<` is interpreted as a start of generic arguments for `usize`, not a shift
+  --> $DIR/issue-22644.rs:38:31
    |
-38 |     println!("{}", a: &mut 4);
+38 |     println!("{}", a as usize << long_name);
+   |                    ---------- ^^ --------- interpreted as generic arguments
+   |                    |          |
+   |                    |          not interpreted as shift
+   |                    help: try shifting the casted value: `(a as usize)`
+
+error: expected type, found `4`
+  --> $DIR/issue-22644.rs:40:28
+   |
+40 |     println!("{}", a: &mut 4);
    |                            ^ expecting a type here because of type ascription
 

--- a/src/test/ui/issue-44406.rs
+++ b/src/test/ui/issue-44406.rs
@@ -1,0 +1,19 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! foo {
+    ($rest: tt) => {
+        bar(baz: $rest)
+    }
+}
+
+fn main() {
+    foo!(true);
+}

--- a/src/test/ui/issue-44406.stderr
+++ b/src/test/ui/issue-44406.stderr
@@ -1,0 +1,26 @@
+error: expected identifier, found keyword `true`
+  --> $DIR/issue-44406.rs:18:10
+   |
+18 |     foo!(true);
+   |          ^^^^
+
+error: expected type, found keyword `true`
+  --> $DIR/issue-44406.rs:18:10
+   |
+13 |         bar(baz: $rest)
+   |                - help: did you mean to use `;` here?
+...
+18 |     foo!(true);
+   |          ^^^^ expecting a type here because of type ascription
+
+error: expected one of `!`, `&&`, `&`, `(`, `*`, `.`, `;`, `<`, `?`, `[`, `_`, `extern`, `fn`, `for`, `impl`, `unsafe`, `}`, an operator, or lifetime, found `true`
+  --> $DIR/issue-44406.rs:18:10
+   |
+13 |         bar(baz: $rest)
+   |                 - expected one of 19 possible tokens here
+...
+18 |     foo!(true);
+   |          ^^^^ unexpected token
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Also improve diagnostics for `x as usize << y`.

Fixes https://github.com/rust-lang/rust/issues/44406
r? @estebank 