### PR TITLE
Move mir passes into CompilerCalls

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -74,8 +74,8 @@ pub fn compile_input(sess: &Session,
                      outdir: &Option<PathBuf>,
                      output: &Option<PathBuf>,
                      addl_plugins: Option<Vec<String>>,
-                     mir_passes: Rc<Passes>,
-                     control: &CompileController) -> CompileResult {
+                     control: &CompileController,
+                     mir_passes: Rc<Passes>) -> CompileResult {
     use rustc::session::config::CrateType;
 
     macro_rules! controller_entry_point {

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -401,7 +401,8 @@ pub trait CompilerCalls<'a> {
         // What we need to run borrowck etc.
 
         passes.push_pass(MIR_VALIDATED, mir::transform::qualify_consts::QualifyAndPromoteConstants);
-        passes.push_pass(MIR_VALIDATED, mir::transform::simplify::SimplifyCfg::new("qualify-consts"));
+        passes.push_pass(MIR_VALIDATED,
+                         mir::transform::simplify::SimplifyCfg::new("qualify-consts"));
         passes.push_pass(MIR_VALIDATED, mir::transform::nll::NLL);
 
         // borrowck runs between MIR_VALIDATED and MIR_OPTIMIZED.
@@ -418,7 +419,8 @@ pub trait CompilerCalls<'a> {
         // an AllCallEdges pass right before it.
         passes.push_pass(MIR_OPTIMIZED, mir::transform::add_call_guards::AllCallEdges);
         passes.push_pass(MIR_OPTIMIZED, mir::transform::add_validation::AddValidation);
-        passes.push_pass(MIR_OPTIMIZED, mir::transform::simplify::SimplifyCfg::new("elaborate-drops"));
+        passes.push_pass(MIR_OPTIMIZED,
+                         mir::transform::simplify::SimplifyCfg::new("elaborate-drops"));
         // No lifetime analysis based on borrowing can be done from here on out.
 
         // From here on out, regions are gone.

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -254,8 +254,8 @@ pub fn run_compiler<'a>(args: &[String],
                            &odir,
                            &ofile,
                            Some(plugins),
-                           callbacks.mir_passes(),
-                           &control),
+                           &control,
+                           callbacks.mir_passes()),
      Some(sess))
 }
 

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -76,6 +76,7 @@ use rustc_metadata::locator;
 use rustc_metadata::cstore::CStore;
 use rustc::util::common::{time, ErrorReported};
 use rustc_trans_utils::trans_crate::TransCrate;
+use rustc::mir::transform::Passes;
 
 use serialize::json::ToJson;
 
@@ -253,6 +254,7 @@ pub fn run_compiler<'a>(args: &[String],
                            &odir,
                            &ofile,
                            Some(plugins),
+                           callbacks.mir_passes(),
                            &control),
      Some(sess))
 }
@@ -378,6 +380,62 @@ pub trait CompilerCalls<'a> {
     // Create a CompilController struct for controlling the behaviour of
     // compilation.
     fn build_controller(&mut self, _: &Session, _: &getopts::Matches) -> CompileController<'a>;
+
+    fn mir_passes(&mut self) -> Rc<Passes>{
+        use rustc::mir::transform::{MIR_CONST, MIR_VALIDATED, MIR_OPTIMIZED};
+        use rustc_mir as mir;
+        // Setup the MIR passes that we want to run.
+        let mut passes = Passes::new();
+        passes.push_hook(mir::transform::dump_mir::DumpMir);
+
+        // Remove all `EndRegion` statements that are not involved in borrows.
+        passes.push_pass(MIR_CONST, mir::transform::clean_end_regions::CleanEndRegions);
+
+        // What we need to do constant evaluation.
+        passes.push_pass(MIR_CONST, mir::transform::simplify::SimplifyCfg::new("initial"));
+        passes.push_pass(MIR_CONST, mir::transform::type_check::TypeckMir);
+        passes.push_pass(MIR_CONST, mir::transform::rustc_peek::SanityCheck);
+
+        // We compute "constant qualifications" between MIR_CONST and MIR_VALIDATED.
+
+        // What we need to run borrowck etc.
+
+        passes.push_pass(MIR_VALIDATED, mir::transform::qualify_consts::QualifyAndPromoteConstants);
+        passes.push_pass(MIR_VALIDATED, mir::transform::simplify::SimplifyCfg::new("qualify-consts"));
+        passes.push_pass(MIR_VALIDATED, mir::transform::nll::NLL);
+
+        // borrowck runs between MIR_VALIDATED and MIR_OPTIMIZED.
+
+        passes.push_pass(MIR_OPTIMIZED, mir::transform::no_landing_pads::NoLandingPads);
+        passes.push_pass(MIR_OPTIMIZED,
+                         mir::transform::simplify_branches::SimplifyBranches::new("initial"));
+
+        // These next passes must be executed together
+        passes.push_pass(MIR_OPTIMIZED, mir::transform::add_call_guards::CriticalCallEdges);
+        passes.push_pass(MIR_OPTIMIZED, mir::transform::elaborate_drops::ElaborateDrops);
+        passes.push_pass(MIR_OPTIMIZED, mir::transform::no_landing_pads::NoLandingPads);
+        // AddValidation needs to run after ElaborateDrops and before EraseRegions, and it needs
+        // an AllCallEdges pass right before it.
+        passes.push_pass(MIR_OPTIMIZED, mir::transform::add_call_guards::AllCallEdges);
+        passes.push_pass(MIR_OPTIMIZED, mir::transform::add_validation::AddValidation);
+        passes.push_pass(MIR_OPTIMIZED, mir::transform::simplify::SimplifyCfg::new("elaborate-drops"));
+        // No lifetime analysis based on borrowing can be done from here on out.
+
+        // From here on out, regions are gone.
+        passes.push_pass(MIR_OPTIMIZED, mir::transform::erase_regions::EraseRegions);
+
+        // Optimizations begin.
+        passes.push_pass(MIR_OPTIMIZED, mir::transform::inline::Inline);
+        passes.push_pass(MIR_OPTIMIZED, mir::transform::instcombine::InstCombine);
+        passes.push_pass(MIR_OPTIMIZED, mir::transform::deaggregator::Deaggregator);
+        passes.push_pass(MIR_OPTIMIZED, mir::transform::copy_prop::CopyPropagation);
+        passes.push_pass(MIR_OPTIMIZED, mir::transform::simplify::SimplifyLocals);
+
+        passes.push_pass(MIR_OPTIMIZED, mir::transform::generator::StateTransform);
+        passes.push_pass(MIR_OPTIMIZED, mir::transform::add_call_guards::CriticalCallEdges);
+        passes.push_pass(MIR_OPTIMIZED, mir::transform::dump_mir::Marker("PreTrans"));
+        Rc::new(passes)
+    }
 }
 
 // CompilerCalls instance for a regular rustc build.
@@ -559,6 +617,7 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
 
         if let Some((ppm, opt_uii)) = parse_pretty(sess, matches) {
             if ppm.needs_ast_map(&opt_uii) {
+                let mir_passes = self.mir_passes();
                 control.after_hir_lowering.stop = Compilation::Stop;
 
                 control.after_parse.callback = box move |state| {
@@ -578,7 +637,8 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
                                                      state.arenas.unwrap(),
                                                      state.output_filenames.unwrap(),
                                                      opt_uii.clone(),
-                                                     state.out_file);
+                                                     state.out_file,
+                                                     mir_passes.clone());
                 };
             } else {
                 control.after_parse.stop = Compilation::Stop;

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -12,6 +12,7 @@ use rustc_lint;
 use rustc_driver::{driver, target_features, abort_on_err};
 use rustc_driver::pretty::ReplaceBodyWithLoop;
 use rustc::session::{self, config};
+use rustc::mir::transform::Passes;
 use rustc::hir::def_id::DefId;
 use rustc::hir::def::Def;
 use rustc::middle::privacy::AccessLevels;
@@ -182,6 +183,7 @@ pub fn run_core(search_paths: SearchPaths,
                                                           &[],
                                                           &sess);
 
+    let mir_passes = Rc::new(Passes::new());
     abort_on_err(driver::phase_3_run_analysis_passes(&sess,
                                                      &*cstore,
                                                      hir_map,
@@ -191,6 +193,7 @@ pub fn run_core(search_paths: SearchPaths,
                                                      &arenas,
                                                      &name,
                                                      &output_filenames,
+                                                     mir_passes,
                                                      |tcx, analysis, _, result| {
         if let Err(_) = result {
             sess.fatal("Compilation failed, aborting rustdoc");

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -23,6 +23,7 @@ use std::sync::{Arc, Mutex};
 use testing;
 use rustc_lint;
 use rustc::hir;
+use rustc::mir::transform::Passes;
 use rustc::hir::intravisit;
 use rustc::session::{self, CompileIncomplete, config};
 use rustc::session::config::{OutputType, OutputTypes, Externs};
@@ -259,8 +260,9 @@ fn run_test(test: &str, cratename: &str, filename: &str, cfgs: Vec<String>, libs
         control.after_analysis.stop = Compilation::Stop;
     }
 
+    let mir_passes = Rc::new(Passes::new());
     let res = panic::catch_unwind(AssertUnwindSafe(|| {
-        driver::compile_input(&sess, &cstore, &input, &out, &None, None, &control)
+        driver::compile_input(&sess, &cstore, &input, &out, &None, None, &control, mir_passes)
     }));
 
     let compile_result = match res {


### PR DESCRIPTION
It is an unfinished PR and tries to solve https://github.com/rust-lang/rust/issues/45130

Essentially I just moved the mir passes into `CompilerCalls`. Currently, it is a default trait function but it should probably move into `RustcDefaultCalls`.

The change wasn't as trivial as I expected because `phase_3_run_analysis_passes` is also used in some rustdoc tests and it is also used for pretty printing.

Also `mir_passes` currently borrows mutably and has no parameters. This should probably change.

What are your thoughts?