### PR TITLE
Update let-expressions.rs with DepNode labels

### DIFF
--- a/src/test/incremental/hashes/let_expressions.rs
+++ b/src/test/incremental/hashes/let_expressions.rs
@@ -38,6 +38,20 @@ pub fn change_name() {
 #[rustc_clean(label="HirBody", cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
+#[rustc_dirty(label="MirValidated", cfg="cfail2")]
+#[rustc_clean(label="MirValidated", cfg="cfail3")]
+#[rustc_dirty(label="MirOptimized", cfg="cfail2")]
+#[rustc_clean(label="MirOptimized", cfg="cfail3")]
+#[rustc_clean(label="TypeckTables", cfg="cfail2")]
+#[rustc_clean(label="TypeckTables", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="FnSignature", cfg="cfail2")]
+#[rustc_clean(label="FnSignature", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn change_name() {
     let _y = 2u64;
 }
@@ -57,6 +71,20 @@ pub fn add_type() {
 #[rustc_clean(label="HirBody", cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
+#[rustc_clean(label="MirValidated", cfg="cfail2")]
+#[rustc_clean(label="MirValidated", cfg="cfail3")]
+#[rustc_clean(label="MirOptimized", cfg="cfail2")]
+#[rustc_clean(label="MirOptimized", cfg="cfail3")]
+#[rustc_dirty(label="TypeckTables", cfg="cfail2")]
+#[rustc_clean(label="TypeckTables", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="FnSignature", cfg="cfail2")]
+#[rustc_clean(label="FnSignature", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn add_type() {
     let _x: u32 = 2u32;
 }
@@ -76,6 +104,20 @@ pub fn change_type() {
 #[rustc_clean(label="HirBody", cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
+#[rustc_dirty(label="MirValidated", cfg="cfail2")]
+#[rustc_clean(label="MirValidated", cfg="cfail3")]
+#[rustc_dirty(label="MirOptimized", cfg="cfail2")]
+#[rustc_clean(label="MirOptimized", cfg="cfail3")]
+#[rustc_dirty(label="TypeckTables", cfg="cfail2")]
+#[rustc_clean(label="TypeckTables", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="FnSignature", cfg="cfail2")]
+#[rustc_clean(label="FnSignature", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn change_type() {
     let _x: u8 = 2;
 }
@@ -95,6 +137,20 @@ pub fn change_mutability_of_reference_type() {
 #[rustc_clean(label="HirBody", cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
+#[rustc_dirty(label="MirValidated", cfg="cfail2")]
+#[rustc_clean(label="MirValidated", cfg="cfail3")]
+#[rustc_clean(label="MirOptimized", cfg="cfail2")]
+#[rustc_clean(label="MirOptimized", cfg="cfail3")]
+#[rustc_dirty(label="TypeckTables", cfg="cfail2")]
+#[rustc_clean(label="TypeckTables", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="FnSignature", cfg="cfail2")]
+#[rustc_clean(label="FnSignature", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn change_mutability_of_reference_type() {
     let _x: &mut u64;
 }
@@ -114,6 +170,20 @@ pub fn change_mutability_of_slot() {
 #[rustc_clean(label="HirBody", cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
+#[rustc_dirty(label="MirValidated", cfg="cfail2")]
+#[rustc_clean(label="MirValidated", cfg="cfail3")]
+#[rustc_dirty(label="MirOptimized", cfg="cfail2")]
+#[rustc_clean(label="MirOptimized", cfg="cfail3")]
+#[rustc_dirty(label="TypeckTables", cfg="cfail2")]
+#[rustc_clean(label="TypeckTables", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="FnSignature", cfg="cfail2")]
+#[rustc_clean(label="FnSignature", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn change_mutability_of_slot() {
     let _x: u64 = 0;
 }
@@ -133,6 +203,20 @@ pub fn change_simple_binding_to_pattern() {
 #[rustc_clean(label="HirBody", cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
+#[rustc_dirty(label="MirValidated", cfg="cfail2")]
+#[rustc_clean(label="MirValidated", cfg="cfail3")]
+#[rustc_dirty(label="MirOptimized", cfg="cfail2")]
+#[rustc_clean(label="MirOptimized", cfg="cfail3")]
+#[rustc_dirty(label="TypeckTables", cfg="cfail2")]
+#[rustc_clean(label="TypeckTables", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="FnSignature", cfg="cfail2")]
+#[rustc_clean(label="FnSignature", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn change_simple_binding_to_pattern() {
     let (_a, _b) = (0u8, 'x');
 }
@@ -152,6 +236,20 @@ pub fn change_name_in_pattern() {
 #[rustc_clean(label="HirBody", cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
+#[rustc_dirty(label="MirValidated", cfg="cfail2")]
+#[rustc_clean(label="MirValidated", cfg="cfail3")]
+#[rustc_dirty(label="MirOptimized", cfg="cfail2")]
+#[rustc_clean(label="MirOptimized", cfg="cfail3")]
+#[rustc_clean(label="TypeckTables", cfg="cfail2")]
+#[rustc_clean(label="TypeckTables", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="FnSignature", cfg="cfail2")]
+#[rustc_clean(label="FnSignature", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn change_name_in_pattern() {
     let (_a, _c) = (1u8, 'y');
 }
@@ -171,6 +269,20 @@ pub fn add_ref_in_pattern() {
 #[rustc_clean(label="HirBody", cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
+#[rustc_dirty(label="MirValidated", cfg="cfail2")]
+#[rustc_clean(label="MirValidated", cfg="cfail3")]
+#[rustc_dirty(label="MirOptimized", cfg="cfail2")]
+#[rustc_clean(label="MirOptimized", cfg="cfail3")]
+#[rustc_dirty(label="TypeckTables", cfg="cfail2")]
+#[rustc_clean(label="TypeckTables", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="FnSignature", cfg="cfail2")]
+#[rustc_clean(label="FnSignature", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn add_ref_in_pattern() {
     let (ref _a, _b) = (1u8, 'y');
 }
@@ -190,6 +302,12 @@ pub fn add_amp_in_pattern() {
 #[rustc_clean(label="HirBody", cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
+#[rustc_dirty(label="MirValidated", cfg="cfail2")]
+#[rustc_clean(label="MirValidated", cfg="cfail3")]
+#[rustc_dirty(label="MirOptimized", cfg="cfail2")]
+#[rustc_clean(label="MirOptimized", cfg="cfail3")]
+#[rustc_dirty(label="TypeckTables", cfg="cfail2")]
+#[rustc_clean(label="TypeckTables", cfg="cfail3")]
 pub fn add_amp_in_pattern() {
     let (&_a, _b) = (&1u8, 'y');
 }
@@ -209,6 +327,20 @@ pub fn change_mutability_of_binding_in_pattern() {
 #[rustc_clean(label="HirBody", cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
+#[rustc_dirty(label="MirValidated", cfg="cfail2")]
+#[rustc_clean(label="MirValidated", cfg="cfail3")]
+#[rustc_dirty(label="MirOptimized", cfg="cfail2")]
+#[rustc_clean(label="MirOptimized", cfg="cfail3")]
+#[rustc_dirty(label="TypeckTables", cfg="cfail2")]
+#[rustc_clean(label="TypeckTables", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="FnSignature", cfg="cfail2")]
+#[rustc_clean(label="FnSignature", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn change_mutability_of_binding_in_pattern() {
     let (mut _a, _b) = (99u8, 'q');
 }
@@ -228,6 +360,20 @@ pub fn add_initializer() {
 #[rustc_clean(label="HirBody", cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
+#[rustc_dirty(label="MirValidated", cfg="cfail2")]
+#[rustc_clean(label="MirValidated", cfg="cfail3")]
+#[rustc_dirty(label="MirOptimized", cfg="cfail2")]
+#[rustc_clean(label="MirOptimized", cfg="cfail3")]
+#[rustc_dirty(label="TypeckTables", cfg="cfail2")]
+#[rustc_clean(label="TypeckTables", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="FnSignature", cfg="cfail2")]
+#[rustc_clean(label="FnSignature", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn add_initializer() {
     let _x: i16 = 3i16;
 }
@@ -247,6 +393,20 @@ pub fn change_initializer() {
 #[rustc_clean(label="HirBody", cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
+#[rustc_dirty(label="MirValidated", cfg="cfail2")]
+#[rustc_clean(label="MirValidated", cfg="cfail3")]
+#[rustc_dirty(label="MirOptimized", cfg="cfail2")]
+#[rustc_clean(label="MirOptimized", cfg="cfail3")]
+#[rustc_clean(label="TypeckTables", cfg="cfail2")]
+#[rustc_clean(label="TypeckTables", cfg="cfail3")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
+#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
+#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
+#[rustc_clean(label="FnSignature", cfg="cfail2")]
+#[rustc_clean(label="FnSignature", cfg="cfail3")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
+#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn change_initializer() {
     let _x = 5u16;
 }


### PR DESCRIPTION
As a part of #44924, the PR has tests verified for the following dependency nodes for **let-expressions**
```
- MirValidated
- MirOptimized
- TypeCheckTables
- TypeOfItem
- GenericsOfItem
- PredicatesOfItem
- FnSignature
```

As we are more concerned with the function body,  the following fingerprints do not change over compilation sessions.
```- TypeOfItem
- GenericsOfItem
- PredicatesOfItem
- FnSignature
```

r? @nikomatsakis 
cc @michaelwoerister 

P.S. Will add more tests as and when possible :)