### PR TITLE
Enable building clippy in CI

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -358,6 +358,7 @@ impl Step for Miri {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Clippy {
+    stage: u32,
     host: Interned<String>,
 }
 
@@ -372,6 +373,7 @@ impl Step for Clippy {
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(Clippy {
+            stage: run.builder.top_stage,
             host: run.target,
         });
     }
@@ -379,10 +381,11 @@ impl Step for Clippy {
     /// Runs `cargo test` for clippy.
     fn run(self, builder: &Builder) {
         let build = builder.build;
+        let stage = self.stage;
         let host = self.host;
-        let compiler = builder.compiler(1, host);
+        let compiler = builder.compiler(stage, host);
 
-        let _clippy = builder.ensure(tool::Clippy { compiler, target: self.host });
+        let clippy = builder.ensure(tool::Clippy { compiler, target: self.host });
         let mut cargo = builder.cargo(compiler, Mode::Tool, host, "test");
         cargo.arg("--manifest-path").arg(build.src.join("src/tools/clippy/Cargo.toml"));
 
@@ -390,6 +393,8 @@ impl Step for Clippy {
         cargo.env("RUSTC_NO_PREFER_DYNAMIC", "1");
         // clippy tests need to know about the stage sysroot
         cargo.env("SYSROOT", builder.sysroot(compiler));
+        // clippy tests need to find the driver
+        cargo.env("CLIPPY_DRIVER_PATH", clippy);
 
         builder.add_rustc_lib_path(compiler, &mut cargo);
 

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -387,7 +387,7 @@ pub struct Clippy {
 
 impl Step for Clippy {
     type Output = PathBuf;
-    const DEFAULT: bool = false;
+    const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
@@ -411,7 +411,7 @@ impl Step for Clippy {
         builder.ensure(ToolBuild {
             compiler: self.compiler,
             target: self.target,
-            tool: "clippy",
+            tool: "clippy-driver",
             mode: Mode::Librustc,
             path: "src/tools/clippy",
             expectation: builder.build.config.toolstate.clippy.passes(ToolState::Compiling),

--- a/src/tools/toolstate.toml
+++ b/src/tools/toolstate.toml
@@ -3,7 +3,7 @@
 #
 # There are three states a tool can be in:
 # 1. Broken: The tool doesn't build
-# 2. Building: The tool builds but its tests are failing
+# 2. Compiling: The tool builds but its tests are failing
 # 3. Testing: The tool builds and its tests are passing
 #
 # In the future there will be further states like "Distributing", which
@@ -26,7 +26,7 @@
 miri = "Broken"
 
 # ping @Manishearth @llogiq @mcarton @oli-obk
-clippy = "Building"
+clippy = "Compiling"
 
 # ping @nrc
 rls = "Testing"

--- a/src/tools/toolstate.toml
+++ b/src/tools/toolstate.toml
@@ -26,7 +26,7 @@
 miri = "Broken"
 
 # ping @Manishearth @llogiq @mcarton @oli-obk
-clippy = "Broken"
+clippy = "Building"
 
 # ping @nrc
 rls = "Testing"


### PR DESCRIPTION
r? @alexcrichton 

As discussed at Rustfest. Measured additional time is 4 minutes on my machine if no dependencies are shared with other tools. In reality most dependencies are shared (especially the slow to compile ones like serde).

cc @Manishearth 

Does not run clippy's test suite, since

a) it is nontrivial in the rustc build system
b) it breaks more frequently but the breakage is negligible

If clippy breaks, the procedure to follow is documented under https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#external-dependencies