### PR TITLE
Better error message for comma after base struct

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2314,6 +2314,7 @@ impl<'a> Parser<'a> {
 
         while self.token != token::CloseDelim(token::Brace) {
             if self.eat(&token::DotDot) {
+                let exp_span = self.prev_span;
                 match self.parse_expr() {
                     Ok(e) => {
                         base = Some(e);
@@ -2322,6 +2323,16 @@ impl<'a> Parser<'a> {
                         e.emit();
                         self.recover_stmt();
                     }
+                }
+                if self.token == token::Comma {
+                    let mut err = self.sess.span_diagnostic.mut_span_err(
+                        exp_span.to(self.prev_span),
+                        "cannot use a comma after the base struct",
+                    );
+                    err.span_suggestion_short(self.span, "remove this comma", "".to_owned());
+                    err.note("the base struct must always be the last field");
+                    err.emit();
+                    self.recover_stmt();
                 }
                 break;
             }

--- a/src/test/ui/struct-field-init-syntax.rs
+++ b/src/test/ui/struct-field-init-syntax.rs
@@ -1,0 +1,27 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z parse-only
+
+// issue #41834
+
+fn main() {
+    let foo = Foo {
+        one: 111,
+        ..Foo::default(),
+        //~^ ERROR cannot use a comma after struct expansion
+    };
+
+    let foo = Foo {
+        ..Foo::default(),
+        //~^ ERROR cannot use a comma after struct expansion
+        one: 111,
+    };
+}

--- a/src/test/ui/struct-field-init-syntax.stderr
+++ b/src/test/ui/struct-field-init-syntax.stderr
@@ -1,0 +1,18 @@
+error: cannot use a comma after the base struct
+  --> $DIR/struct-field-init-syntax.rs:18:9
+   |
+18 |         ..Foo::default(),
+   |         ^^^^^^^^^^^^^^^^- help: remove this comma
+   |
+   = note: the base struct must always be the last field
+
+error: cannot use a comma after the base struct
+  --> $DIR/struct-field-init-syntax.rs:23:9
+   |
+23 |         ..Foo::default(),
+   |         ^^^^^^^^^^^^^^^^- help: remove this comma
+   |
+   = note: the base struct must always be the last field
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
#41834 

This adds a better error for commas after the base struct:
```
let foo = Foo {
    one: 111,
    ..Foo::default(), // This comma is a syntax error
};
```

The current error is a generic `expected one of ...` which isn't beginner-friendly. My error looks like this:

```
error: cannot use a comma after the base struct
  --> tmp/example.rs:26:9
   |
26 |         ..Foo::default(),
   |         ^^^^^^^^^^^^^^^^- help: remove this comma
   |
   = note: the base struct expansion must always be the last field
```

I even added a note for people who don't know why this isn't allowed.