### PR TITLE
core: derive Clone for result::IntoIter

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -1060,7 +1060,7 @@ unsafe impl<'a, A> TrustedLen for IterMut<'a, A> {}
 /// [`Result`]: enum.Result.html
 /// [`into_iter`]: ../iter/trait.IntoIterator.html#tymethod.into_iter
 /// [`IntoIterator`]: ../iter/trait.IntoIterator.html
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct IntoIter<T> { inner: Option<T> }
 


### PR DESCRIPTION
It appears to be a simple oversight that `result::IntoIter<T>` doesn't
implement `Clone` (where `T: Clone`).  We do already have `Clone` for
`result::Iter`, as well as the similar `option::IntoIter` and `Iter`.