### PR TITLE
Fix path to x.py in bootstrap/configure.py script

### DIFF
--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -407,11 +407,6 @@ with open('Makefile', 'w') as f:
     contents = contents.replace("$(CFG_PYTHON)", sys.executable)
     f.write(contents)
 
-# Finally, clean up with a bit of a help message
-relpath = os.path.dirname(__file__)
-if relpath == '':
-    relpath = '.'
-
 p("")
-p("run `python {}/x.py --help`".format(relpath))
+p("run `python {}/x.py --help`".format(rust_dir))
 p("")


### PR DESCRIPTION
We may see a help message in the end of the output of the ./configure script:

```
$ ./configure
configure: processing command line
configure:
configure: build.configure-args := []
configure:
configure: writing `config.toml` in current directory
configure:
configure: run `python ./src/bootstrap/x.py --help`
configure:
```

but the `x.py` script is actually in the rust root directory and
executing of such help string will give us error:

```
$ python ./src/bootstrap/x.py --help
python: can't open file './src/bootstrap/x.py': [Errno 2] No such file
or directory
```

This patch fixes path to the x.py script in the output of the ./configure