### PR TITLE
ci: Fix installing the Android SDK

### DIFF
--- a/src/ci/docker/scripts/android-sdk.sh
+++ b/src/ci/docker/scripts/android-sdk.sh
@@ -31,7 +31,7 @@ download_sysimage() {
     # Keep printing yes to accept the licenses
     while true; do echo yes; sleep 10; done | \
         /android/sdk/tools/android update sdk -a --no-ui \
-            --filter "$filter"
+            --filter "$filter" --no-https
 }
 
 create_avd() {


### PR DESCRIPTION
Apparently the https urls are broken due to some certificate validation
whatnots, and so far the least intrusive solution I've found is to just disable
that.