### PR TITLE
Limit the sidebar height

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -171,10 +171,11 @@ nav.sub {
 
 .sidebar {
 	width: 200px;
-	position: absolute;
+	position: fixed;
 	left: 0;
 	top: 0;
-	min-height: 100%;
+	height: 100vh;
+	overflow: auto;
 }
 
 .sidebar .current {


### PR DESCRIPTION
The sidebar is now fixed, which means its scrolling is independent of the main page now.

r? @rust-lang/docs