### PR TITLE
Point at immutable outer variable

### DIFF
--- a/src/test/ui/suggestions/closure-immutable-outer-variable.rs
+++ b/src/test/ui/suggestions/closure-immutable-outer-variable.rs
@@ -1,0 +1,20 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Point at the captured immutable outer variable
+
+fn foo(mut f: Box<FnMut()>) {
+    f();
+}
+
+fn main() {
+    let y = true;
+    foo(Box::new(move || y = false) as Box<_>);
+}

--- a/src/test/ui/suggestions/closure-immutable-outer-variable.stderr
+++ b/src/test/ui/suggestions/closure-immutable-outer-variable.stderr
@@ -1,0 +1,10 @@
+error[E0594]: cannot assign to captured outer variable in an `FnMut` closure
+  --> $DIR/closure-immutable-outer-variable.rs:19:26
+   |
+18 |     let y = true;
+   |         - help: consider making `y` mutable: `mut y`
+19 |     foo(Box::new(move || y = false) as Box<_>);
+   |                          ^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
When attempting to mutate an immutable outer variable from a closure,
point at the outer variable and suggest making it mutable.

Fix #41790.