### PR TITLE
Fix typo in libsyntax/parse/lexer/unicode_chars.rs

### DIFF
--- a/src/libsyntax/parse/lexer/unicode_chars.rs
+++ b/src/libsyntax/parse/lexer/unicode_chars.rs
@@ -144,7 +144,7 @@ const UNICODE_ARRAY: &'static [(char, &'static str, char)] = &[
     ('‵', "Reversed Prime", '\''),
     ('՚', "Armenian Apostrophe", '\''),
     ('׳', "Hebrew Punctuation Geresh", '\''),
-    ('`', "Greek Accent", '\''),
+    ('`', "Grave Accent", '\''),
     ('`', "Greek Varia", '\''),
     ('｀', "Fullwidth Grave Accent", '\''),
     ('´', "Acute Accent", '\''),


### PR DESCRIPTION
`` ` `` (U+0060) should be the "grave" accent, not "Greek" accent.