### PR TITLE
Add unstable 128 bit SipHash version for internal use in the compiler.

### DIFF
--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -103,6 +103,10 @@ pub use self::sip::SipHasher;
 #[allow(deprecated)]
 pub use self::sip::{SipHasher13, SipHasher24};
 
+#[unstable(feature = "sip_hash_128", issue = "9999999")]
+#[doc(hidden)]
+pub use self::sip::SipHasher24_128;
+
 mod sip;
 
 /// A hashable type.


### PR DESCRIPTION
Discussion in #41215 seems to show that a 128 bit SipHash is the best compromise between hash quality and performance. This PR adds an unstable, hidden 128 bit variant to the SipHash implementation in libstd for use solely within the compiler. A future PR would then switch `StableHasher` to use this implementation.

What do you say, @rust-lang/libs? Acceptable? 

r? @alexcrichton 