### PR TITLE
Mobile sidebar improvements

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -764,17 +764,19 @@ span.since {
 	}
 
 	.sidebar {
-		height: 40px;
+		height: 45px;
 		min-height: 40px;
-		width: 100%;
-		margin: 0px;
-		padding: 0px;
+		width: calc(100% + 30px);
+		margin: 0;
+		margin-left: -15px;
+		padding: 0 15px;
 		position: static;
 	}
 
 	.sidebar .location {
 		float: right;
 		margin: 0px;
+		margin-top: 2px;
 		padding: 3px 10px 1px 10px;
 		min-height: 39px;
 		background: inherit;
@@ -789,7 +791,7 @@ span.since {
 	.sidebar img {
 		width: 35px;
 		margin-top: 5px;
-		margin-bottom: 0px;
+		margin-bottom: 5px;
 		float: left;
 	}
 


### PR DESCRIPTION
Very small changes, I just made the width of the sidebar of 100% and centered vertically both items a bit more:

<img width="1440" alt="screen shot 2017-10-12 at 20 00 47" src="https://user-images.githubusercontent.com/3050060/31511496-302bb474-af88-11e7-8dab-2c88799eafcc.png">

r? @rust-lang/docs