### PR TITLE
Support arbitrary token streams in list attributes.

### DIFF
--- a/src/librustc/ich/impls_syntax.rs
+++ b/src/librustc/ich/impls_syntax.rs
@@ -344,7 +344,8 @@ impl_stable_hash_for!(struct ::syntax::ast::MetaItem {
 impl_stable_hash_for!(enum ::syntax::ast::MetaItemKind {
     Word,
     List(nested_items),
-    NameValue(lit)
+    NameValue(lit),
+    TokenStream(stream)
 });
 
 impl<'gcx> HashStable<StableHashingContext<'gcx>> for FileMap {

--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -99,6 +99,10 @@ impl Cfg {
                     }),
                 }
             }
+            MetaItemKind::TokenStream(_) => Err(InvalidCfgError {
+                msg: "invalid cfg pattern",
+                span: cfg.span,
+            })
         }
     }
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -443,10 +443,12 @@ pub enum MetaItemKind {
     ///
     /// E.g. `test` as in `#[test]`
     Word,
-    /// List meta item.
+    /// List meta item containing only literals or nested meta items.
     ///
     /// E.g. `derive(..)` as in `#[derive(..)]`
     List(Vec<NestedMetaItem>),
+    /// List meta item contain an arbitrary token stream.
+    TokenStream(TokenStream),
     /// Name value meta item.
     ///
     /// E.g. `feature = "foo"` as in `#[feature = "foo"]`

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -589,8 +589,9 @@ pub fn eval_condition<F>(cfg: &ast::MetaItem, sess: &ParseSess, eval: &mut F)
                          -> bool
     where F: FnMut(&ast::MetaItem) -> bool
 {
+    use ast::MetaItemKind::*;
     match cfg.node {
-        ast::MetaItemKind::List(ref mis) => {
+        List(ref mis) => {
             for mi in mis.iter() {
                 if !mi.is_meta_item() {
                     handle_errors(&sess.span_diagnostic, mi.span, AttrError::UnsupportedLiteral);
@@ -621,7 +622,7 @@ pub fn eval_condition<F>(cfg: &ast::MetaItem, sess: &ParseSess, eval: &mut F)
                 }
             }
         },
-        ast::MetaItemKind::Word | ast::MetaItemKind::NameValue(..) | ast::MetaItemKind::TokenStream(..) => {
+        Word | NameValue(..) | TokenStream(..) => {
             eval(cfg)
         }
     }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -1243,6 +1243,7 @@ fn contains_novel_literal(item: &ast::MetaItem) -> bool {
                 Literal(_) => true,
             }
         }),
+        TokenStream(_) => false,
     }
 }
 
@@ -1276,6 +1277,11 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
             gate_feature_post!(&self, attr_literals, attr.span,
                                "non-string literals in attributes, or string \
                                literals in top-level positions, are experimental");
+        }
+
+        if let ast::MetaItemKind::TokenStream(_) = meta.node {
+            gate_feature_post!(&self, attr_literals, attr.span,
+                               "arbitrary tokens in attributes are experimental");
         }
     }
 

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -551,6 +551,7 @@ pub fn noop_fold_meta_item<T: Folder>(mi: MetaItem, fld: &mut T) -> MetaItem {
                 MetaItemKind::List(mis.move_map(|e| fld.fold_meta_list_item(e)))
             },
             MetaItemKind::NameValue(s) => MetaItemKind::NameValue(s),
+            MetaItemKind::TokenStream(tts) => MetaItemKind::TokenStream(fld.fold_tts(tts)),
         },
         span: fld.new_span(mi.span)
     }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -773,6 +773,12 @@ pub trait PrintState<'a> {
                               |s, i| s.print_meta_list_item(i))?;
                 self.pclose()?;
             }
+            ast::MetaItemKind::TokenStream(ref stream) => {
+                self.writer().word(&item.name.as_str())?;
+                self.popen()?;
+                self.print_tts(stream.clone())?;
+                self.pclose()?;
+            }
         }
         self.end()
     }

--- a/src/test/run-pass/arbitrary-attr.rs
+++ b/src/test/run-pass/arbitrary-attr.rs
@@ -1,0 +1,17 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(custom_attribute, attr_literal, test)]
+
+#[foo(bar as baz + 7 =>)]
+extern crate test;
+
+pub fn main() {
+}


### PR DESCRIPTION
With this feature, given an attribute `#[foo(..)]`, the `..` can be an
arbitrary token stream.