### PR TITLE
Remove terribly useless and problematic margin when searching on mobile

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -831,6 +831,10 @@ span.since {
 	.toggle-wrapper {
 		height: 1.5em;
 	}
+
+	#search {
+		margin-left: 0;
+	}
 }
 
 @media print {


### PR DESCRIPTION
Before:

<img width="1440" alt="screen shot 2017-10-14 at 15 56 09" src="https://user-images.githubusercontent.com/3050060/31576308-54af4e48-b0f8-11e7-9e2e-375febbb87b2.png">

After:

<img width="1440" alt="screen shot 2017-10-14 at 15 55 52" src="https://user-images.githubusercontent.com/3050060/31576304-5216ae74-b0f8-11e7-88a0-f53f293f5499.png">

r? @rust-lang/docs