### PR TITLE
Fix arrow display

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -97,9 +97,9 @@ r##"<!DOCTYPE html>
                     <dd>Show this help dialog</dd>
                     <dt>S</dt>
                     <dd>Focus the search field</dd>
-                    <dt>&larrb;</dt>
+                    <dt>↑</dt>
                     <dd>Move up in search results</dd>
-                    <dt>&rarrb;</dt>
+                    <dt>↓</dt>
                     <dd>Move down in search results</dd>
                     <dt>&#9166;</dt>
                     <dd>Go to active search result</dd>


### PR DESCRIPTION
Before:

<img width="1440" alt="screen shot 2017-10-14 at 18 36 18" src="https://user-images.githubusercontent.com/3050060/31577437-a81510e8-b10e-11e7-8249-cf074bb0f59a.png">

After:

<img width="1440" alt="screen shot 2017-10-14 at 18 36 12" src="https://user-images.githubusercontent.com/3050060/31577436-a7fc0eea-b10e-11e7-96d7-6dc2916ef72f.png">

r? @rust-lang/docs 