### PR TITLE
Improve std::process module docs

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -10,28 +10,35 @@
 
 //! A module for working with processes.
 //!
-//! This module provides a [`Command`] struct that can be used to configure and
-//! spawn a process, as well as a [`Child`] struct that represents a running or
-//! terminated process.
+//! This module is mostly concerned with spawning and interacting with child
+//! processes, but it also provides [`abort`] and [`exit`] for terminating the
+//! current process.
 //!
-//! # Examples
+//! # Spawning a process
 //!
-//! Hello world, `std::process` edition:
+//! The [`Command`] struct is used to configure and spawn processes:
 //!
 //! ```
 //! use std::process::Command;
 //!
-//! // Note that by default, the output of the command will be sent to stdout
-//! let mut child = Command::new("echo")
-//!                         .arg("Hello world")
-//!                         .spawn()
-//!                         .expect("Failed to start process");
+//! let output = Command::new("echo")
+//!                      .arg("Hello world")
+//!                      .output()
+//!                      .expect("Failed to execute command");
 //!
-//! let ecode = child.wait()
-//!                  .expect("Failed to wait on child");
-//!
-//! assert!(ecode.success());
+//! assert_eq!(b"Hello world\n", output.stdout.as_slice());
 //! ```
+//!
+//! Several methods on [`Command`], such as [`spawn`] or [`output`], can be used
+//! to spawn a process. In particular, [`output`] spawns the child process and
+//! waits until the process terminates, while [`spawn`] will return a [`Child`]
+//! that represents the spawned child process.
+//!
+//! # Handling I/O
+//!
+//! TODO
+//!
+//! # Examples
 //!
 //! Piping output from one command into another command:
 //!
@@ -86,8 +93,15 @@
 //! assert_eq!(b"test", output.stdout.as_slice());
 //! ```
 //!
+//! [`abort`]: fn.abort.html
+//! [`exit`]: fn.exit.html
+//!
 //! [`Command`]: struct.Command.html
+//! [`spawn`]: struct.Command.html#method.spawn
+//! [`output`]: struct.Command.html#method.output
+//!
 //! [`Child`]: struct.Child.html
+//! [`Stdio`]: struct.Stdio.html
 
 #![stable(feature = "process", since = "1.0.0")]
 

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -36,11 +36,11 @@
 //!
 //! # Handling I/O
 //!
-//! TODO
-//!
-//! # Examples
-//!
-//! Piping output from one command into another command:
+//! The [`stdout`], [`stdin`], and [`stderr`] of a child process can be
+//! configured by passing an [`Stdio`] to the corresponding method on
+//! [`Command`]. Once spawned, they can be accessed from the [`Child`]. For
+//! example, piping output from one command into another command can be done
+//! like so:
 //!
 //! ```
 //! use std::process::{Command, Stdio};
@@ -68,9 +68,10 @@
 //! assert_eq!(b"Oh no, a typo!\n", output.stdout.as_slice());
 //! ```
 //!
-//! Calling a command with input and reading its output:
+//! Note that [`ChildStderr`] and [`ChildStdout`] implement [`Write`] and
+//! [`ChildStdin`] implements [`Read`]:
 //!
-//! ```no_run
+//! ```
 //! use std::process::{Command, Stdio};
 //! use std::io::Write;
 //!
@@ -101,7 +102,17 @@
 //! [`output`]: struct.Command.html#method.output
 //!
 //! [`Child`]: struct.Child.html
+//! [`ChildStdin`]: struct.ChildStdin.html
+//! [`ChildStdout`]: struct.ChildStdout.html
+//! [`ChildStderr`]: struct.ChildStderr.html
 //! [`Stdio`]: struct.Stdio.html
+//!
+//! [`stdout`]: struct.Command.html#method.stdout
+//! [`stdin`]: struct.Command.html#method.stdin
+//! [`stderr`]: struct.Command.html#method.stderr
+//!
+//! [`Write`]: ../io/trait.Write.html
+//! [`Read`]: ../io/trait.Read.html
 
 #![stable(feature = "process", since = "1.0.0")]
 

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -42,7 +42,7 @@
 //! example, piping output from one command into another command can be done
 //! like so:
 //!
-//! ```
+//! ```no_run
 //! use std::process::{Command, Stdio};
 //!
 //! // stdout must be configured with `Stdio::piped` in order to use
@@ -71,7 +71,7 @@
 //! Note that [`ChildStderr`] and [`ChildStdout`] implement [`Write`] and
 //! [`ChildStdin`] implements [`Read`]:
 //!
-//! ```
+//! ```no_run
 //! use std::process::{Command, Stdio};
 //! use std::io::Write;
 //!

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -22,7 +22,7 @@
 //! use std::process::Command;
 //!
 //! // Note that by default, the output of the command will be sent to stdout
-//! let child = Command::new("echo")
+//! let mut child = Command::new("echo")
 //!                         .arg("Hello world")
 //!                         .spawn()
 //!                         .expect("Failed to start process");

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -10,22 +10,55 @@
 
 //! A module for working with processes.
 //!
+//! This module provides a [`Command`] struct that can be used to configure and
+//! spawn a process, as well as a [`Child`] struct that represents a running or
+//! terminated process.
+//!
 //! # Examples
 //!
-//! Basic usage where we try to execute the `cat` shell command:
+//! Hello world, `std::process` edition:
 //!
-//! ```should_panic
-//! use std::process::Command;
+//! ```
+//! use std::process:Command;
 //!
-//! let mut child = Command::new("/bin/cat")
-//!                         .arg("file.txt")
+//! // Note that by default, the output of the command will be sent to stdout
+//! let child = Command::new("echo")
+//!                         .arg("Hello world")
 //!                         .spawn()
-//!                         .expect("failed to execute child");
+//!                         .expect("Failed to start process");
 //!
 //! let ecode = child.wait()
-//!                  .expect("failed to wait on child");
+//!                  .expect("Failed to wait on child");
 //!
 //! assert!(ecode.success());
+//! ```
+//!
+//! Piping output from one command into another command:
+//!
+//! ```
+//! use std::process::{Command, Stdio};
+//!
+//! // stdout must be configured with `Stdio::piped` in order to use
+//! // `echo_child.stdout`
+//! let echo_child = Command::new("echo")
+//!     .arg("Oh no, a tpyo!")
+//!     .stdout(Stdio::piped())
+//!     .spawn()
+//!     .expect("Failed to start echo process");
+//!
+//! // Note that `echo_child` is moved here, but we won't be needing
+//! // `echo_child` anymore
+//! let echo_out = echo_child.stdout.expect("Failed to open echo stdout");
+//!
+//! let mut sed_child = Command::new("sed")
+//!     .arg("s/tpyo/typo/")
+//!     .stdin(Stdio::from(echo_out))
+//!     .stdout(Stdio::piped())
+//!     .spawn()
+//!     .expect("Failed to start sed process");
+//!
+//! let output = sed_child.wait_with_output().expect("Failed to wait on sed");
+//! assert_eq!(b"Oh no, a typo!\n", output.stdout.as_slice());
 //! ```
 //!
 //! Calling a command with input and reading its output:
@@ -52,6 +85,9 @@
 //!
 //! assert_eq!(b"test", output.stdout.as_slice());
 //! ```
+//!
+//! [`Command`]: struct.Command.html
+//! [`Child`]: struct.Child.html
 
 #![stable(feature = "process", since = "1.0.0")]
 

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -19,7 +19,7 @@
 //! Hello world, `std::process` edition:
 //!
 //! ```
-//! use std::process:Command;
+//! use std::process::Command;
 //!
 //! // Note that by default, the output of the command will be sent to stdout
 //! let child = Command::new("echo")


### PR DESCRIPTION
Addresses part of #29370

I've changed the first `cat` example to a "Hello World" example involving echo, and I've also added another example showing how to pipe output. I'm still working on the module-level description.

For now, I'd like feedback on the examples.

r? @steveklabnik 