### PR TITLE
Fix rustbuild --color conflict when building on Travis outside of Docker

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -29,7 +29,7 @@ use build_helper::{output, mtime, up_to_date};
 use filetime::FileTime;
 use serde_json;
 
-use util::{exe, libdir, is_dylib, copy, read_stamp_file};
+use util::{exe, libdir, is_dylib, copy, read_stamp_file, CiEnv};
 use {Build, Compiler, Mode};
 use native;
 use tool;
@@ -792,7 +792,7 @@ fn run_cargo(build: &Build, cargo: &mut Command, stamp: &Path) {
     cargo.arg("--message-format").arg("json")
          .stdout(Stdio::piped());
 
-    if stderr_isatty() {
+    if stderr_isatty() && build.ci_env == CiEnv::None {
         // since we pass message-format=json to cargo, we need to tell the rustc
         // wrapper to give us colored output if necessary. This is because we
         // only want Cargo's JSON output, not rustcs.


### PR DESCRIPTION
When trying to build rust on Travis without using `stamp` or `docker`, both `RUSTC_COLOR=1` and `TRAVIS=true` will separately pass `--color always` to the command line. This causes the build to fail due to "*Option 'color' given more than once*". 

In this PR, the `RUSTC_COLOR=1` will not be passed in the CI environment.