### PR TITLE
aarch64 is not whitelisted for ARM features

### DIFF
--- a/src/librustc_trans/llvm_util.rs
+++ b/src/librustc_trans/llvm_util.rs
@@ -73,6 +73,8 @@ unsafe fn configure_llvm(sess: &Session) {
 
 const ARM_WHITELIST: &'static [&'static str] = &["neon\0", "vfp2\0", "vfp3\0", "vfp4\0"];
 
+const AARCH64_WHITELIST: &'static [&'static str] = &["neon\0"];
+
 const X86_WHITELIST: &'static [&'static str] = &["avx\0", "avx2\0", "bmi\0", "bmi2\0", "sse\0",
                                                  "sse2\0", "sse3\0", "sse4.1\0", "sse4.2\0",
                                                  "ssse3\0", "tbm\0", "lzcnt\0", "popcnt\0",
@@ -89,7 +91,8 @@ pub fn target_features(sess: &Session) -> Vec<Symbol> {
     let target_machine = create_target_machine(sess);
 
     let whitelist = match &*sess.target.target.arch {
-        "arm" | "aarch64" => ARM_WHITELIST,
+        "arm" => ARM_WHITELIST,
+        "aarch64" => AARCH64_WHITELIST,
         "x86" | "x86_64" => X86_WHITELIST,
         "hexagon" => HEXAGON_WHITELIST,
         "powerpc" | "powerpc64" => POWERPC_WHITELIST,

--- a/src/librustc_trans/llvm_util.rs
+++ b/src/librustc_trans/llvm_util.rs
@@ -89,7 +89,7 @@ pub fn target_features(sess: &Session) -> Vec<Symbol> {
     let target_machine = create_target_machine(sess);
 
     let whitelist = match &*sess.target.target.arch {
-        "arm" => ARM_WHITELIST,
+        "arm" | "aarch64" => ARM_WHITELIST,
         "x86" | "x86_64" => X86_WHITELIST,
         "hexagon" => HEXAGON_WHITELIST,
         "powerpc" | "powerpc64" => POWERPC_WHITELIST,


### PR DESCRIPTION
This prevents the target feature `neon` from being enabled on aarch64.