### PR TITLE
don't issue "expected statement after outer attr." after inner attr.

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4088,11 +4088,11 @@ impl<'a> Parser<'a> {
                     node: StmtKind::Item(i),
                 },
                 None => {
-                    let unused_attrs = |attrs: &[_], s: &mut Self| {
+                    let unused_attrs = |attrs: &[Attribute], s: &mut Self| {
                         if !attrs.is_empty() {
                             if s.prev_token_kind == PrevTokenKind::DocComment {
                                 s.span_fatal_err(s.prev_span, Error::UselessDocComment).emit();
-                            } else {
+                            } else if attrs.iter().any(|a| a.style == AttrStyle::Outer) {
                                 s.span_err(s.span, "expected statement after outer attribute");
                             }
                         }

--- a/src/test/ui/issue-45296.rs
+++ b/src/test/ui/issue-45296.rs
@@ -1,0 +1,15 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let unused = ();
+
+    #![allow(unused_variables)]
+}

--- a/src/test/ui/issue-45296.stderr
+++ b/src/test/ui/issue-45296.stderr
@@ -1,0 +1,11 @@
+error: an inner attribute is not permitted in this context
+  --> $DIR/issue-45296.rs:14:7
+   |
+14 |     #![allow(unused_variables)]
+   |       ^
+   |
+   = note: inner attributes and doc comments, like `#![no_std]` or `//! My crate`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes and doc comments, like `#[test]` and
+                                              `/// My function`, annotate the item following them.
+
+error: aborting due to previous error
+


### PR DESCRIPTION
While an inner attribute here is in fact erroneous, that error ("inner
attribute is not permitted in this context") successfully gets set earlier;
this further admonition is nonsensical.

Resolves #45296.