### PR TITLE
Make Solaris builder compatible with Solaris 10 retry

### DIFF
--- a/src/ci/docker/cross2/build-solaris-toolchain.sh
+++ b/src/ci/docker/cross2/build-solaris-toolchain.sh
@@ -38,37 +38,38 @@ cd solaris
 
 dpkg --add-architecture $APT_ARCH
 apt-get update
-apt-get download           \
-  libc:$APT_ARCH           \
+apt-get download $(apt-cache depends --recurse --no-replaces \
   libc-dev:$APT_ARCH       \
-  libm:$APT_ARCH           \
   libm-dev:$APT_ARCH       \
-  libpthread:$APT_ARCH     \
   libpthread-dev:$APT_ARCH \
-  libresolv:$APT_ARCH      \
   libresolv-dev:$APT_ARCH  \
-  librt:$APT_ARCH          \
   librt-dev:$APT_ARCH      \
-  libsocket:$APT_ARCH      \
   libsocket-dev:$APT_ARCH  \
   system-crt:$APT_ARCH     \
-  system-header:$APT_ARCH
+  system-header:$APT_ARCH  \
+  | grep "^\w")
 
 for deb in *$APT_ARCH.deb; do
   dpkg -x $deb .
 done
 
-# Strip Solaris 11 functions that are optionally used by libbacktrace.
+# Remove Solaris 11 functions that are optionally used by libbacktrace.
 # This is for Solaris 10 compatibility.
-$ARCH-sun-solaris2.10-strip -N dl_iterate_phdr -N strnlen lib/$LIB_ARCH/libc.so
+rm usr/include/link.h
+patch -p0  << 'EOF'
+--- usr/include/string.h	2017-10-09 03:15:04.000000000 +0200
++++ usr/include/string10.h	2017-10-16 11:27:26.498764422 +0200
+@@ -93 +92,0 @@
+-extern size_t strnlen(const char *, size_t);
+EOF
 
 mkdir                  /usr/local/$ARCH-sun-solaris2.10/usr
 mv usr/include         /usr/local/$ARCH-sun-solaris2.10/usr/include
 mv usr/lib/$LIB_ARCH/* /usr/local/$ARCH-sun-solaris2.10/lib
 mv     lib/$LIB_ARCH/* /usr/local/$ARCH-sun-solaris2.10/lib
 
-ln -s /usr/local/$ARCH-sun-solaris2.10/usr/include /usr/local/$ARCH-sun-solaris2.10/sys-include
-ln -s /usr/local/$ARCH-sun-solaris2.10/usr/include /usr/local/$ARCH-sun-solaris2.10/include
+ln -s usr/include /usr/local/$ARCH-sun-solaris2.10/sys-include
+ln -s usr/include /usr/local/$ARCH-sun-solaris2.10/include
 
 cd ..
 rm -rf solaris
@@ -97,8 +98,7 @@ hide_output ../gcc-$GCC/configure \
   --disable-libada                \
   --disable-libsanitizer          \
   --disable-libquadmath-support   \
-  --disable-lto                   \
-  --with-sysroot=/usr/local/$ARCH-sun-solaris2.10
+  --disable-lto
 
 hide_output make -j10
 hide_output make install

--- a/src/ci/docker/cross2/build-solaris-toolchain.sh
+++ b/src/ci/docker/cross2/build-solaris-toolchain.sh
@@ -57,8 +57,8 @@ done
 # This is for Solaris 10 compatibility.
 rm usr/include/link.h
 patch -p0  << 'EOF'
---- usr/include/string.h	2017-10-09 03:15:04.000000000 +0200
-+++ usr/include/string10.h	2017-10-16 11:27:26.498764422 +0200
+--- usr/include/string.h
++++ usr/include/string10.h
 @@ -93 +92,0 @@
 -extern size_t strnlen(const char *, size_t);
 EOF


### PR DESCRIPTION
Unfortunately, #45255 does not quite cut it,
so use a different approach to have Solaris 10 compatibility
by tricking libbacktrace's autoconf tests.
The sysroot download routine is slightly changed, too.