### PR TITLE
added examples of closures for str::find

### DIFF
--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -966,8 +966,8 @@ impl str {
     ///
     /// assert_eq!(s.find(char::is_whitespace), Some(5));
     /// assert_eq!(s.find(char::is_lowercase), Some(1));
-    /// assert_eq!(s.find(|c: char| c.is_whitespace()), Some(5));
-    /// assert_eq!(s.find(|c: char| c.is_lowercase()), Some(1));
+    /// assert_eq!(s.find(|c: char| c.is_whitespace() || c.is_lowercase()), Some(1));
+    /// assert_eq!(s.find(|c: char| (c < 'o') && (c > 'a')), Some(4));
     /// ```
     ///
     /// Not finding the pattern:

--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -959,13 +959,15 @@ impl str {
     /// assert_eq!(s.find("Léopard"), Some(13));
     /// ```
     ///
-    /// More complex patterns with closures:
+    /// More complex patterns using point-free style and closures:
     ///
     /// ```
     /// let s = "Löwe 老虎 Léopard";
     ///
     /// assert_eq!(s.find(char::is_whitespace), Some(5));
     /// assert_eq!(s.find(char::is_lowercase), Some(1));
+    /// assert_eq!(s.find(|c: char| c.is_whitespace()), Some(5));
+    /// assert_eq!(s.find(|c: char| c.is_lowercase()), Some(1));
     /// ```
     ///
     /// Not finding the pattern:


### PR DESCRIPTION
This is an attempt to fix https://github.com/rust-lang/rust/issues/45327

r? @steveklabnik