### PR TITLE
test: Update Emscripten failures/passing

### DIFF
--- a/src/ci/docker/asmjs/Dockerfile
+++ b/src/ci/docker/asmjs/Dockerfile
@@ -16,6 +16,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/emscripten.sh /scripts/
 RUN bash /scripts/emscripten.sh
 
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
 ENV PATH=$PATH:/emsdk-portable
 ENV PATH=$PATH:/emsdk-portable/clang/e1.37.13_64bit/
 ENV PATH=$PATH:/emsdk-portable/emscripten/1.37.13/
@@ -28,7 +31,4 @@ ENV TARGETS=asmjs-unknown-emscripten
 
 ENV RUST_CONFIGURE_ARGS --target=$TARGETS
 
-ENV SCRIPT python2.7 ../x.py test --target $TARGETS
-
-COPY scripts/sccache.sh /scripts/
-RUN sh /scripts/sccache.sh
+ENV SCRIPT python2.7 ../x.py test --target $TARGETS src/test/run-pass

--- a/src/test/compile-fail/macro-expanded-include/test.rs
+++ b/src/test/compile-fail/macro-expanded-include/test.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no asm! support
 
 #![feature(asm, rustc_attrs)]
 #![allow(unused)]

--- a/src/test/run-pass/asm-concat-src.rs
+++ b/src/test/run-pass/asm-concat-src.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // pretty-expanded FIXME #23616
-// ignore-emscripten
+// ignore-emscripten no asm
 
 #![feature(asm)]
 

--- a/src/test/run-pass/command-before-exec.rs
+++ b/src/test/run-pass/command-before-exec.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-windows - this is a unix-specific test
-// ignore-emscripten
+// ignore-emscripten no processes
 
 #![feature(process_exec, libc)]
 

--- a/src/test/run-pass/command-exec.rs
+++ b/src/test/run-pass/command-exec.rs
@@ -10,7 +10,8 @@
 
 // ignore-windows - this is a unix-specific test
 // ignore-pretty issue #37199
-// ignore-emscripten
+// ignore-emscripten no processes
+
 #![feature(process_exec)]
 
 use std::env;

--- a/src/test/run-pass/core-run-destroy.rs
+++ b/src/test/run-pass/core-run-destroy.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:--test
-// ignore-emscripten
+// ignore-emscripten no processes
 
 // NB: These tests kill child processes. Valgrind sees these children as leaking
 // memory, which makes for some *confusing* logs. That's why these are here

--- a/src/test/run-pass/env-args-reverse-iterator.rs
+++ b/src/test/run-pass/env-args-reverse-iterator.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no processes
 
 use std::env::args;
 use std::process::Command;

--- a/src/test/run-pass/env-funky-keys.rs
+++ b/src/test/run-pass/env-funky-keys.rs
@@ -12,7 +12,7 @@
 
 // ignore-android
 // ignore-windows
-// ignore-emscripten
+// ignore-emscripten no execve
 // no-prefer-dynamic
 
 #![feature(libc)]

--- a/src/test/run-pass/env-home-dir.rs
+++ b/src/test/run-pass/env-home-dir.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten env vars don't work?
 
 #![feature(path)]
 

--- a/src/test/run-pass/extern-pass-empty.rs
+++ b/src/test/run-pass/extern-pass-empty.rs
@@ -12,7 +12,7 @@
 
 // pretty-expanded FIXME #23616
 // ignore-msvc
-// ignore-emscripten
+// ignore-emscripten emcc asserts on an empty struct as an argument
 
 #[repr(C)]
 struct TwoU8s {

--- a/src/test/run-pass/fds-are-cloexec.rs
+++ b/src/test/run-pass/fds-are-cloexec.rs
@@ -10,7 +10,7 @@
 
 // ignore-windows
 // ignore-android
-// ignore-emscripten
+// ignore-emscripten no processes
 // ignore-haiku
 
 #![feature(libc)]

--- a/src/test/run-pass/format-no-std.rs
+++ b/src/test/run-pass/format-no-std.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten missing rust_begin_unwind
+// ignore-emscripten no no_std executables
 
 #![feature(lang_items, start, alloc)]
 #![no_std]

--- a/src/test/run-pass/generator/smoke.rs
+++ b/src/test/run-pass/generator/smoke.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no threads support
 // compile-flags: --test
 
 #![feature(generators, generator_trait)]

--- a/src/test/run-pass/i128.rs
+++ b/src/test/run-pass/i128.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten i128 doesn't work
 
 #![feature(i128_type, test)]
 

--- a/src/test/run-pass/issue-10626.rs
+++ b/src/test/run-pass/issue-10626.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no processes
 
 // Make sure that if a process doesn't have its stdio/stderr descriptors set up
 // that we don't die in a large ball of fire

--- a/src/test/run-pass/issue-13304.rs
+++ b/src/test/run-pass/issue-13304.rs
@@ -8,7 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no processes
+
 #![feature(io, process_capture)]
 
 use std::env;

--- a/src/test/run-pass/issue-14456.rs
+++ b/src/test/run-pass/issue-14456.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no processes
 
 #![feature(io, process_capture)]
 

--- a/src/test/run-pass/issue-14940.rs
+++ b/src/test/run-pass/issue-14940.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no processes
 
 use std::env;
 use std::process::Command;

--- a/src/test/run-pass/issue-16272.rs
+++ b/src/test/run-pass/issue-16272.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no processes
 
 use std::process::Command;
 use std::env;

--- a/src/test/run-pass/issue-20091.rs
+++ b/src/test/run-pass/issue-20091.rs
@@ -8,7 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no processes
+
 #![feature(std_misc, os)]
 
 #[cfg(unix)]

--- a/src/test/run-pass/issue-2190-1.rs
+++ b/src/test/run-pass/issue-2190-1.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // pretty-expanded FIXME #23616
-// ignore-emscripten
+// ignore-emscripten no threads
 
 use std::thread::Builder;
 

--- a/src/test/run-pass/issue-24313.rs
+++ b/src/test/run-pass/issue-24313.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no threads
 
 use std::thread;
 use std::env;

--- a/src/test/run-pass/issue-28950.rs
+++ b/src/test/run-pass/issue-28950.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no threads
 // compile-flags: -O
 
 // Tests that the `vec!` macro does not overflow the stack when it is

--- a/src/test/run-pass/issue-29485.rs
+++ b/src/test/run-pass/issue-29485.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:issue-29485.rs
-// ignore-emscripten
+// ignore-emscripten no threads
 
 #[feature(recover)]
 

--- a/src/test/run-pass/issue-29663.rs
+++ b/src/test/run-pass/issue-29663.rs
@@ -10,8 +10,6 @@
 
 // write_volatile causes an LLVM assert with composite types
 
-// ignore-emscripten See #41299: probably a bad optimization
-
 #![feature(volatile)]
 use std::ptr::{read_volatile, write_volatile};
 

--- a/src/test/run-pass/issue-30490.rs
+++ b/src/test/run-pass/issue-30490.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no processes
 
 // Previously libstd would set stdio descriptors of a child process
 // by `dup`ing the requested descriptors to inherit directly into the

--- a/src/test/run-pass/issue-33770.rs
+++ b/src/test/run-pass/issue-33770.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no processes
 
 use std::process::{Command, Stdio};
 use std::env;

--- a/src/test/run-pass/linkage1.rs
+++ b/src/test/run-pass/linkage1.rs
@@ -10,7 +10,7 @@
 
 // ignore-windows
 // ignore-macos
-// ignore-emscripten
+// ignore-emscripten doesn't support this linkage
 // aux-build:linkage1.rs
 
 #![feature(linkage)]

--- a/src/test/run-pass/multi-panic.rs
+++ b/src/test/run-pass/multi-panic.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no processes
 
 fn check_for_no_backtrace(test: std::process::Output) {
     assert!(!test.status.success());

--- a/src/test/run-pass/no-stdio.rs
+++ b/src/test/run-pass/no-stdio.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no processes
 // ignore-android
 
 #![feature(libc)]

--- a/src/test/run-pass/out-of-stack.rs
+++ b/src/test/run-pass/out-of-stack.rs
@@ -10,7 +10,7 @@
 
 // ignore-android: FIXME (#20004)
 // ignore-musl
-// ignore-emscripten
+// ignore-emscripten no processes
 
 #![feature(asm)]
 #![feature(libc)]

--- a/src/test/run-pass/packed-struct-layout.rs
+++ b/src/test/run-pass/packed-struct-layout.rs
@@ -7,8 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-// ignore-emscripten Not sure what's happening here.
-
 
 use std::mem;
 

--- a/src/test/run-pass/packed-tuple-struct-layout.rs
+++ b/src/test/run-pass/packed-tuple-struct-layout.rs
@@ -7,8 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-// ignore-emscripten
-
 
 use std::mem;
 

--- a/src/test/run-pass/panic-runtime/abort-link-to-unwinding-crates.rs
+++ b/src/test/run-pass/panic-runtime/abort-link-to-unwinding-crates.rs
@@ -11,7 +11,7 @@
 // compile-flags:-C panic=abort
 // aux-build:exit-success-if-unwind.rs
 // no-prefer-dynamic
-// ignore-emscripten Function not implemented
+// ignore-emscripten no processes
 
 extern crate exit_success_if_unwind;
 

--- a/src/test/run-pass/panic-runtime/abort.rs
+++ b/src/test/run-pass/panic-runtime/abort.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-C panic=abort
 // no-prefer-dynamic
-// ignore-emscripten Function not implemented.
+// ignore-emscripten no processes
 
 use std::process::Command;
 use std::env;

--- a/src/test/run-pass/panic-runtime/lto-abort.rs
+++ b/src/test/run-pass/panic-runtime/lto-abort.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-C lto -C panic=abort
 // no-prefer-dynamic
-// ignore-emscripten Function not implemented.
+// ignore-emscripten no processes
 
 use std::process::Command;
 use std::env;

--- a/src/test/run-pass/panic-runtime/lto-unwind.rs
+++ b/src/test/run-pass/panic-runtime/lto-unwind.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-C lto -C panic=unwind
 // no-prefer-dynamic
-// ignore-emscripten Function not implemented.
+// ignore-emscripten no processes
 
 use std::process::Command;
 use std::env;

--- a/src/test/run-pass/process-envs.rs
+++ b/src/test/run-pass/process-envs.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no processes
 
 use std::process::Command;
 use std::env;

--- a/src/test/run-pass/process-exit.rs
+++ b/src/test/run-pass/process-exit.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no processes
 
 use std::env;
 use std::process::{self, Command, Stdio};

--- a/src/test/run-pass/process-remove-from-env.rs
+++ b/src/test/run-pass/process-remove-from-env.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no processes
 
 use std::process::Command;
 use std::env;

--- a/src/test/run-pass/process-spawn-with-unicode-params.rs
+++ b/src/test/run-pass/process-spawn-with-unicode-params.rs
@@ -16,7 +16,7 @@
 // non-ASCII characters.  The child process ensures all the strings are
 // intact.
 
-// ignore-emscripten
+// ignore-emscripten no processes
 
 use std::io::prelude::*;
 use std::io;

--- a/src/test/run-pass/process-status-inherits-stdin.rs
+++ b/src/test/run-pass/process-status-inherits-stdin.rs
@@ -7,7 +7,8 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-// ignore-emscripten Function not implemented.
+
+// ignore-emscripten no processes
 
 use std::env;
 use std::io;

--- a/src/test/run-pass/running-with-no-runtime.rs
+++ b/src/test/run-pass/running-with-no-runtime.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten spawning processes is not supported
 
 #![feature(start)]
 

--- a/src/test/run-pass/signal-exit-status.rs
+++ b/src/test/run-pass/signal-exit-status.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-windows
-// ignore-emscripten
+// ignore-emscripten no processes
 
 use std::env;
 use std::process::Command;

--- a/src/test/run-pass/sigpipe-should-be-ignored.rs
+++ b/src/test/run-pass/sigpipe-should-be-ignored.rs
@@ -11,7 +11,7 @@
 // Be sure that when a SIGPIPE would have been received that the entire process
 // doesn't die in a ball of fire, but rather it's gracefully handled.
 
-// ignore-emscripten
+// ignore-emscripten no processes
 
 use std::env;
 use std::io::prelude::*;

--- a/src/test/run-pass/simd-intrinsic-generic-cast.rs
+++ b/src/test/run-pass/simd-intrinsic-generic-cast.rs
@@ -7,7 +7,8 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-// ignore-emscripten linking with emcc failed
+
+// ignore-emscripten FIXME(#45351) hits an LLVM assert
 
 #![feature(repr_simd, platform_intrinsics, concat_idents, test)]
 #![allow(non_camel_case_types)]

--- a/src/test/run-pass/stack-probes-lto.rs
+++ b/src/test/run-pass/stack-probes-lto.rs
@@ -11,7 +11,7 @@
 // ignore-arm
 // ignore-aarch64
 // ignore-wasm
-// ignore-emscripten
+// ignore-emscripten no processes
 // ignore-musl FIXME #31506
 // ignore-pretty
 // no-system-llvm

--- a/src/test/run-pass/stack-probes.rs
+++ b/src/test/run-pass/stack-probes.rs
@@ -11,7 +11,7 @@
 // ignore-arm
 // ignore-aarch64
 // ignore-wasm
-// ignore-emscripten
+// ignore-emscripten no processes
 // ignore-musl FIXME #31506
 // no-system-llvm
 

--- a/src/test/run-pass/stdio-is-blocking.rs
+++ b/src/test/run-pass/stdio-is-blocking.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no processes
 
 use std::env;
 use std::io::prelude::*;

--- a/src/test/run-pass/thinlto/thin-lto-inlines.rs
+++ b/src/test/run-pass/thinlto/thin-lto-inlines.rs
@@ -10,7 +10,7 @@
 
 // compile-flags: -Z thinlto -C codegen-units=8 -O
 // min-llvm-version 4.0
-// ignore-emscripten
+// ignore-emscripten can't inspect instructions on emscripten
 
 // We want to assert here that ThinLTO will inline across codegen units. There's
 // not really a great way to do that in general so we sort of hack around it by

--- a/src/test/run-pass/thinlto/thin-lto-inlines2.rs
+++ b/src/test/run-pass/thinlto/thin-lto-inlines2.rs
@@ -12,7 +12,7 @@
 // aux-build:thin-lto-inlines-aux.rs
 // min-llvm-version 4.0
 // no-prefer-dynamic
-// ignore-emscripten
+// ignore-emscripten can't inspect instructions on emscripten
 
 // We want to assert here that ThinLTO will inline across codegen units. There's
 // not really a great way to do that in general so we sort of hack around it by

--- a/src/test/run-pass/try-wait.rs
+++ b/src/test/run-pass/try-wait.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no processes
 
 #![feature(process_try_wait)]
 

--- a/src/test/run-pass/u128.rs
+++ b/src/test/run-pass/u128.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten u128 not supported
 
 #![feature(i128_type, test)]
 

--- a/src/test/run-pass/vec-macro-no-std.rs
+++ b/src/test/run-pass/vec-macro-no-std.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten missing rust_begin_unwind
+// ignore-emscripten no no_std executables
 
 #![feature(lang_items, start, libc, alloc)]
 #![no_std]

--- a/src/test/run-pass/wait-forked-but-failed-child.rs
+++ b/src/test/run-pass/wait-forked-but-failed-child.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-emscripten
+// ignore-emscripten no processes
 
 #![feature(libc)]
 


### PR DESCRIPTION
All tests should now have annotation for *why* they're ignored on emscripten. A
few tests no longer need such an annotation as well!

Closes #41299