### PR TITLE
rustdoc: add a primitive page for "unit"

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -614,7 +614,7 @@ fn fmt_type(t: &clean::Type, f: &mut fmt::Formatter, use_absolute: bool) -> fmt:
         }
         clean::Tuple(ref typs) => {
             match &typs[..] {
-                &[] => primitive_link(f, PrimitiveType::Tuple, "()"),
+                &[] => primitive_link(f, PrimitiveType::Unit, "()"),
                 &[ref one] => {
                     primitive_link(f, PrimitiveType::Tuple, "(")?;
                     //carry f.alternate() into this display w/o branching manually


### PR DESCRIPTION
In `src/libstd/primitive_docs.rs`, a `#[doc(primitive = "unit")]`
section has sat long neglected.  This patch teaches rustdoc to recognize
"unit", and steals its trait implementations away from the tuple page.