### PR TITLE
Remove --enable-rustbuild config option from an example

### DIFF
--- a/src/bootstrap/README.md
+++ b/src/bootstrap/README.md
@@ -129,14 +129,14 @@ configure your directory to use this build, like so:
 # configure to use local rust instead of downloading a beta.
 # `--local-rust-root` is optional here. If elided, we will
 # use whatever rustc we find on your PATH.
-> configure --local-rust-root=~/.cargo/ --enable-local-rebuild
+> ./configure --local-rust-root=~/.cargo/ --enable-local-rebuild
 ```
 
 After that, you can use the `--incremental` flag to actually do
 incremental builds:
 
 ```
-> ../x.py build --incremental
+> ./x.py build --incremental
 ```
 
 The `--incremental` flag will store incremental compilation artifacts

--- a/src/bootstrap/README.md
+++ b/src/bootstrap/README.md
@@ -129,7 +129,7 @@ configure your directory to use this build, like so:
 # configure to use local rust instead of downloading a beta.
 # `--local-rust-root` is optional here. If elided, we will
 # use whatever rustc we find on your PATH.
-> configure --enable-rustbuild --local-rust-root=~/.cargo/ --enable-local-rebuild
+> configure --local-rust-root=~/.cargo/ --enable-local-rebuild
 ```
 
 After that, you can use the `--incremental` flag to actually do


### PR DESCRIPTION
`--enable-rustbuild` is no longer recognized by the configure script. Also I think we should use `./configure` and `./x.py` instead of `configure` and `../x.py`.