### PR TITLE
Allow passing a path with tilde to the configure script

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -532,7 +532,7 @@ class RustBuild(object):
         """
         config = self.get_toml(program)
         if config:
-            return config
+            return os.path.expanduser(config)
         return os.path.join(self.bin_root(), "bin", "{}{}".format(
             program, self.exe_suffix()))
 


### PR DESCRIPTION
Currently `./configure --local-rust-root=~/.cargo --enable-local-rebuild` fails with
 ```
Exception: no cargo executable found at `~/.cargo//bin/cargo`
```
