### PR TITLE
Remove unfixable AsRef FIXMEs.

### DIFF
--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -382,14 +382,6 @@ impl<'a, T: ?Sized, U: ?Sized> AsRef<U> for &'a mut T where T: AsRef<U>
     }
 }
 
-// FIXME (#23442): replace the above impls for &/&mut with the following more general one:
-// // As lifts over Deref
-// impl<D: ?Sized + Deref, U: ?Sized> AsRef<U> for D where D::Target: AsRef<U> {
-//     fn as_ref(&self) -> &U {
-//         self.deref().as_ref()
-//     }
-// }
-
 // AsMut lifts over &mut
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T: ?Sized, U: ?Sized> AsMut<U> for &'a mut T where T: AsMut<U>
@@ -398,14 +390,6 @@ impl<'a, T: ?Sized, U: ?Sized> AsMut<U> for &'a mut T where T: AsMut<U>
         (*self).as_mut()
     }
 }
-
-// FIXME (#23442): replace the above impl for &mut with the following more general one:
-// // AsMut lifts over DerefMut
-// impl<D: ?Sized + Deref, U: ?Sized> AsMut<U> for D where D::Target: AsMut<U> {
-//     fn as_mut(&mut self) -> &mut U {
-//         self.deref_mut().as_mut()
-//     }
-// }
 
 // From implies Into
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
A long time ago, FIXMEs were left to implement
AsRef and AsRef for all types which implemented
Deref and DerefMut. This wasn't done at the time
because of #23442.

Unfortunately, it's not possible to add these
implementations backwards-compabily, since they
can cause conflicting implementation overlaps.

If anyone has any ideas about how we could add these in a backwards-compatible way, please say something! I'd really like to have these impls, as well as an `impl<T> AsRef<T> for T`. However, all of these impls cause overlaps with things like the `impl<T> AsRef<Vec<T>> for Vec<T>`.