### PR TITLE
ci: Update musl with new release

### DIFF
--- a/src/ci/docker/cross/build-arm-musl.sh
+++ b/src/ci/docker/cross/build-arm-musl.sh
@@ -11,7 +11,7 @@
 
 set -ex
 
-MUSL=1.1.16
+MUSL=1.1.17
 
 hide_output() {
   set +x

--- a/src/ci/docker/dist-i586-gnu-i686-musl/build-musl.sh
+++ b/src/ci/docker/dist-i586-gnu-i686-musl/build-musl.sh
@@ -15,7 +15,7 @@ set -ex
 export CFLAGS="-fPIC -Wa,-mrelax-relocations=no"
 export CXXFLAGS="-Wa,-mrelax-relocations=no"
 
-MUSL=musl-1.1.16
+MUSL=musl-1.1.17
 curl https://www.musl-libc.org/releases/$MUSL.tar.gz | tar xzf -
 cd $MUSL
 CC=gcc \

--- a/src/ci/docker/dist-x86_64-musl/build-musl.sh
+++ b/src/ci/docker/dist-x86_64-musl/build-musl.sh
@@ -15,7 +15,7 @@ set -ex
 export CFLAGS="-fPIC -Wa,-mrelax-relocations=no"
 export CXXFLAGS="-Wa,-mrelax-relocations=no"
 
-MUSL=musl-1.1.16
+MUSL=musl-1.1.17
 curl https://www.musl-libc.org/releases/$MUSL.tar.gz | tar xzf -
 cd $MUSL
 ./configure --prefix=/musl-x86_64 --disable-shared


### PR DESCRIPTION
Apparently there's at least one CVE fixed in the new version of musl, and
because we're distributing it seems like a good opportunity to update!

Unfortunately it looks like #38618 still hasn't been fixed.