### PR TITLE
Correct misspelling in error text: re-assignment => reassignment

### DIFF
--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -744,7 +744,7 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
         let mut err = self.cannot_reassign_immutable(span,
                                                      &self.loan_path_to_string(lp),
                                                      Origin::Ast);
-        err.span_label(span, "re-assignment of immutable variable");
+        err.span_label(span, "cannot assign twice to immutable variable");
         if span != assign.span {
             err.span_label(assign.span, format!("first assignment to `{}`",
                                               self.loan_path_to_string(lp)));

--- a/src/librustc_mir/borrow_check.rs
+++ b/src/librustc_mir/borrow_check.rs
@@ -1161,7 +1161,7 @@ impl<'c, 'b, 'a: 'b+'c, 'gcx, 'tcx: 'a> MirBorrowckCtxt<'c, 'b, 'a, 'gcx, 'tcx> 
         self.tcx.cannot_reassign_immutable(span,
                                            &self.describe_lvalue(lvalue),
                                            Origin::Mir)
-                .span_label(span, "re-assignment of immutable variable")
+                .span_label(span, "cannot assign twice to immutable variable")
                 .span_label(assigned_span, format!("first assignment to `{}`",
                                                    self.describe_lvalue(lvalue)))
                 .emit();

--- a/src/librustc_mir/util/borrowck_errors.rs
+++ b/src/librustc_mir/util/borrowck_errors.rs
@@ -232,7 +232,7 @@ pub trait BorrowckErrors {
                                  -> DiagnosticBuilder
     {
         struct_span_err!(self, span, E0384,
-                         "re-assignment of immutable variable `{}`{OGN}",
+                         "cannot assign twice to immutable variable `{}`{OGN}",
                          desc, OGN=o)
     }
 

--- a/src/test/compile-fail/asm-out-assign-imm.rs
+++ b/src/test/compile-fail/asm-out-assign-imm.rs
@@ -27,8 +27,8 @@ pub fn main() {
     foo(x);
     unsafe {
         asm!("mov $1, $0" : "=r"(x) : "r"(5));
-        //~^ ERROR re-assignment of immutable variable `x`
-        //~| NOTE re-assignment of immutable
+        //~^ ERROR cannot assign twice to immutable variable `x`
+        //~| NOTE cannot assign twice to immutable
     }
     foo(x);
 }

--- a/src/test/compile-fail/assign-imm-local-twice.rs
+++ b/src/test/compile-fail/assign-imm-local-twice.rs
@@ -12,8 +12,8 @@ fn test() {
     let v: isize;
     v = 1; //~ NOTE first assignment
     println!("v={}", v);
-    v = 2; //~ ERROR re-assignment of immutable variable
-           //~| NOTE re-assignment of immutable
+    v = 2; //~ ERROR cannot assign twice to immutable variable
+           //~| NOTE cannot assign twice to immutable
     println!("v={}", v);
 }
 

--- a/src/test/compile-fail/borrowck/borrowck-match-binding-is-assignment.rs
+++ b/src/test/compile-fail/borrowck/borrowck-match-binding-is-assignment.rs
@@ -26,7 +26,7 @@ struct S {
 pub fn main() {
     match 1 {
         x => {
-            x += 1; //[ast]~ ERROR re-assignment of immutable variable `x`
+            x += 1; //[ast]~ ERROR cannot assign twice to immutable variable `x`
                     //[mir]~^ ERROR (Mir) [E0384]
                     //[mir]~| ERROR (Ast) [E0384]
         }
@@ -34,7 +34,7 @@ pub fn main() {
 
     match E::Foo(1) {
         E::Foo(x) => {
-            x += 1; //[ast]~ ERROR re-assignment of immutable variable `x`
+            x += 1; //[ast]~ ERROR cannot assign twice to immutable variable `x`
                     //[mir]~^ ERROR (Mir) [E0384]
                     //[mir]~| ERROR (Ast) [E0384]
         }
@@ -42,7 +42,7 @@ pub fn main() {
 
     match (S { bar: 1 }) {
         S { bar: x } => {
-            x += 1; //[ast]~ ERROR re-assignment of immutable variable `x`
+            x += 1; //[ast]~ ERROR cannot assign twice to immutable variable `x`
                     //[mir]~^ ERROR (Mir) [E0384]
                     //[mir]~| ERROR (Ast) [E0384]
         }
@@ -50,7 +50,7 @@ pub fn main() {
 
     match (1,) {
         (x,) => {
-            x += 1; //[ast]~ ERROR re-assignment of immutable variable `x`
+            x += 1; //[ast]~ ERROR cannot assign twice to immutable variable `x`
                     //[mir]~^ ERROR (Mir) [E0384]
                     //[mir]~| ERROR (Ast) [E0384]
         }
@@ -58,7 +58,7 @@ pub fn main() {
 
     match [1,2,3] {
         [x,_,_] => {
-            x += 1; //[ast]~ ERROR re-assignment of immutable variable `x`
+            x += 1; //[ast]~ ERROR cannot assign twice to immutable variable `x`
                     //[mir]~^ ERROR (Mir) [E0384]
                     //[mir]~| ERROR (Ast) [E0384]
         }

--- a/src/test/compile-fail/liveness-assign-imm-local-in-loop.rs
+++ b/src/test/compile-fail/liveness-assign-imm-local-in-loop.rs
@@ -11,8 +11,8 @@
 fn test() {
     let v: isize;
     loop {
-        v = 1; //~ ERROR re-assignment of immutable variable
-        //~^ NOTE re-assignment of immutable variable
+        v = 1; //~ ERROR cannot assign twice to immutable variable
+        //~^ NOTE cannot assign twice to immutable variable
         v.clone(); // just to prevent liveness warnings
     }
 }

--- a/src/test/compile-fail/liveness-assign-imm-local-in-op-eq.rs
+++ b/src/test/compile-fail/liveness-assign-imm-local-in-op-eq.rs
@@ -11,8 +11,8 @@
 fn test() {
     let v: isize;
     v = 2;  //~ NOTE first assignment
-    v += 1; //~ ERROR re-assignment of immutable variable
-            //~| NOTE re-assignment of immutable
+    v += 1; //~ ERROR cannot assign twice to immutable variable
+            //~| NOTE cannot assign twice to immutable
     v.clone();
 }
 

--- a/src/test/compile-fail/liveness-assign-imm-local-with-init.rs
+++ b/src/test/compile-fail/liveness-assign-imm-local-with-init.rs
@@ -11,8 +11,8 @@
 fn test() {
     let v: isize = 1; //~ NOTE first assignment
     v.clone();
-    v = 2; //~ ERROR re-assignment of immutable variable
-           //~| NOTE re-assignment of immutable
+    v = 2; //~ ERROR cannot assign twice to immutable variable
+           //~| NOTE cannot assign twice to immutable
     v.clone();
 }
 

--- a/src/test/compile-fail/mut-pattern-internal-mutability.rs
+++ b/src/test/compile-fail/mut-pattern-internal-mutability.rs
@@ -15,9 +15,9 @@ fn main() {
     let foo = &mut 1;
 
     let &mut x = foo;
-    x += 1; //[ast]~ ERROR re-assignment of immutable variable
-            //[mir]~^ ERROR re-assignment of immutable variable `x` (Ast)
-            //[mir]~| ERROR re-assignment of immutable variable `x` (Mir)
+    x += 1; //[ast]~ ERROR cannot assign twice to immutable variable
+            //[mir]~^ ERROR cannot assign twice to immutable variable `x` (Ast)
+            //[mir]~| ERROR cannot assign twice to immutable variable `x` (Mir)
 
     // explicitly mut-ify internals
     let &mut mut x = foo;


### PR DESCRIPTION
[reassignment is the correct spelling](https://www.thefreedictionary.com/reassignment) rather than re-assignment; this error message looks silly in the book next to text trying to be grammatically correct :-/

Will this cause any stability/backcompat type issues?