### PR TITLE
Fix title heading overlap in rust doc

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -748,6 +748,7 @@ span.since {
 
 .docblock > .section-header:first-child {
 	margin-left: 15px;
+	margin-top: 0;
 }
 
 .docblock > .section-header:first-child:hover > a:before {

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -529,7 +529,8 @@ a {
 .content .search-results td:first-child { padding-right: 0; }
 .content .search-results td:first-child a { padding-right: 10px; }
 
-tr.result span.primitive::after { content: ' (primitive type)'; font-style: italic; color: black;
+tr.result span.primitive::after {
+	content: ' (primitive type)'; font-style: italic; color: black;
 }
 
 body.blur > :not(#help) {
@@ -743,6 +744,14 @@ span.since {
 	margin-left: 30px;
 	margin-bottom: 20px;
 	margin-top: 5px;
+}
+
+.docblock > .section-header:first-child {
+	margin-left: 15px;
+}
+
+.docblock > .section-header:first-child:hover > a:before {
+	left: -10px;
 }
 
 .enum > .collapsed, .struct > .collapsed {


### PR DESCRIPTION
Fixes #45158.

To be noted that this margin only appears when a title is the first element.

<img width="1440" alt="screen shot 2017-10-22 at 16 08 44" src="https://user-images.githubusercontent.com/3050060/31862746-6411070e-b743-11e7-9a75-4159e1f7f1d6.png">

r? @rust-lang/docs