### PR TITLE
bootstrap: Add openssl configuration for sparc64-unknown-linux-gnu

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -446,6 +446,7 @@ impl Step for Openssl {
             "powerpc64-unknown-linux-gnu" => "linux-ppc64",
             "powerpc64le-unknown-linux-gnu" => "linux-ppc64le",
             "s390x-unknown-linux-gnu" => "linux64-s390x",
+            "sparc64-unknown-linux-gnu" => "linux64-sparcv9",
             "sparc64-unknown-netbsd" => "BSD-sparc64",
             "x86_64-apple-darwin" => "darwin64-x86_64-cc",
             "x86_64-linux-android" => "linux-x86_64",


### PR DESCRIPTION
Hi!

This adds the target missing mapping for sparc64-unknown-linux-gnu.

See: https://github.com/rust-lang/rust/issues/45456

Thanks