### PR TITLE
rustbuild: Fix `no output generated` error for next bootstrap cargo.

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -860,10 +860,18 @@ fn run_cargo(build: &Build, cargo: &mut Command, stamp: &Path) {
             // have a hash in the name, but there's a version of this file in
             // the `deps` folder which *does* have a hash in the name. That's
             // the one we'll want to we'll probe for it later.
-            toplevel.push((filename.file_stem().unwrap()
-                                    .to_str().unwrap().to_string(),
-                            filename.extension().unwrap().to_owned()
-                                    .to_str().unwrap().to_string()));
+            //
+            // We do not use `Path::file_stem` or `Path::extension` here,
+            // because some generated files may have multiple extensions e.g.
+            // `std-<hash>.dll.lib` on Windows. The aforementioned methods only
+            // split the file name by the last extension (`.lib`) while we need
+            // to split by all extensions (`.dll.lib`).
+            let filename = filename.file_name().unwrap().to_str().unwrap();
+            let mut parts = filename.splitn(2, '.');
+            let file_stem = parts.next().unwrap().to_owned();
+            let extension = parts.next().unwrap().to_owned();
+
+            toplevel.push((file_stem, extension));
         }
     }
 


### PR DESCRIPTION
Due to rust-lang/cargo#4570, a `*.dll.lib` file is uplifted when building dynamic libraries on Windows. The current bootstrap code does not understand files with multiple extensions, and will instead assume `xxxx.dll` is the file name. This caused a `no output generated` error because it tries to search for `xxxx.dll-hash.lib` inside the `deps/` folder, while it should check for `xxxx-hash.dll.lib` instead.

This PR is blocking #45285, see https://github.com/rust-lang/rust/pull/45285#issuecomment-338454149 and the rest of the comments for detail.
