### PR TITLE
Show src button and function version on mobile version

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -820,8 +820,8 @@ span.since {
 		width: 100%;
 	}
 
-	.content .out-of-band {
-		display: none;
+	.content h4 > .out-of-band {
+		position: inherit;
 	}
 
 	.toggle-wrapper > .collapse-toggle {
@@ -834,6 +834,10 @@ span.since {
 
 	#search {
 		margin-left: 0;
+	}
+
+	.content .impl-items .method, .content .impl-items > .type, .impl-items > .associatedconstant {
+		display: flex;
 	}
 }
 


### PR DESCRIPTION
Fixes #45498.

<img width="1440" alt="screen shot 2017-10-24 at 22 36 09" src="https://user-images.githubusercontent.com/3050060/31966689-c0070404-b90b-11e7-8810-810fa0491eda.png">

r? @rust-lang/docs 