### PR TITLE
Improve diagnostics when list of tokens has incorrect separators

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1033,7 +1033,23 @@ impl<'a> Parser<'a> {
                 } else {
                     if let Err(e) = self.expect(t) {
                         fe(e);
-                        break;
+                        // Attempt to keep parsing if it was a similar separator
+                        if let Some(ref tokens) = t.similar_tokens() {
+                            if tokens.contains(&self.token) {
+                                self.bump();
+                            }
+                        }
+                        // Attempt to keep parsing if it was an omitted separator
+                        match f(self) {
+                            Ok(t) => {
+                                v.push(t);
+                                continue;
+                            },
+                            Err(mut e) => {
+                                e.cancel();
+                                break;
+                            }
+                        }
                     }
                 }
             }

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -433,6 +433,16 @@ impl Token {
         })
     }
 
+    /// Returns tokens that are likely to be typed accidentally instead of the current token.
+    /// Enables better error recovery when the wrong token is found.
+    pub fn similar_tokens(&self) -> Option<Vec<Token>> {
+        match *self {
+            Comma => Some(vec![Dot, Lt]),
+            Semi => Some(vec![Colon]),
+            _ => None
+        }
+    }
+
     /// Returns `true` if the token is either a special identifier or a keyword.
     pub fn is_reserved_ident(&self) -> bool {
         self.is_special_ident() || self.is_used_keyword() || self.is_unused_keyword()

--- a/src/test/compile-fail/privacy/restricted/tuple-struct-fields/test2.rs
+++ b/src/test/compile-fail/privacy/restricted/tuple-struct-fields/test2.rs
@@ -14,7 +14,6 @@ macro_rules! define_struct {
         struct S2(pub (in foo) ());
         struct S3(pub $t ());
         //~^ ERROR expected `,`, found `(`
-        //~| ERROR expected one of `;` or `where`, found `(`
     }
 }
 

--- a/src/test/compile-fail/privacy/restricted/tuple-struct-fields/test3.rs
+++ b/src/test/compile-fail/privacy/restricted/tuple-struct-fields/test3.rs
@@ -14,7 +14,6 @@ macro_rules! define_struct {
         struct S2(pub (in foo) ());
         struct S3(pub($t) ());
         //~^ ERROR expected `,`, found `(`
-        //~| ERROR expected one of `;` or `where`, found `(`
     }
 }
 

--- a/src/test/ui/similar-tokens.rs
+++ b/src/test/ui/similar-tokens.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-mod foo {
-    type T = ();
-    struct S1(pub(in foo) (), pub(T), pub(crate) (), pub(((), T)));
-    struct S2(pub((foo)) ());
-    //~^ ERROR expected `,`, found `(`
-    //~| ERROR cannot find type `foo` in this scope
+mod x {
+    pub struct A;
+    pub struct B;
 }
+
+// `.` is similar to `,` so list parsing should continue to closing `}`
+use x::{A. B};
+
+fn main() {}

--- a/src/test/ui/similar-tokens.stderr
+++ b/src/test/ui/similar-tokens.stderr
@@ -1,0 +1,8 @@
+error: expected one of `,` or `as`, found `.`
+  --> $DIR/similar-tokens.rs:17:10
+   |
+17 | use x::{A. B};
+   |          ^ expected one of `,` or `as` here
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Make `parse_seq_to_before_tokens` more resilient to error conditions. Where possible it is better if it can consume up to the final bracket before returning. This change improves the diagnostics in a couple of situations:

```
struct S(pub () ()); // omitted separator
use std::{foo. bar}; // used a similar but wrong separator
```

Fixes #44339 
r? @petrochenkov 