### PR TITLE
Use expect for current_dir on librustc/session mod

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -776,7 +776,9 @@ pub fn build_session_(sopts: config::Options,
     let print_fuel_crate = sopts.debugging_opts.print_fuel.clone();
     let print_fuel = Cell::new(0);
 
-    let working_dir = env::current_dir().unwrap().to_string_lossy().into_owned();
+    let working_dir = env::current_dir()
+        .expect("Could not find current working directory")
+        .to_string_lossy().into_owned();
     let working_dir = file_path_mapping.map_prefix(working_dir);
 
     let sess = Session {

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -776,9 +776,10 @@ pub fn build_session_(sopts: config::Options,
     let print_fuel_crate = sopts.debugging_opts.print_fuel.clone();
     let print_fuel = Cell::new(0);
 
-    let working_dir = env::current_dir()
-        .expect("Could not find current working directory")
-        .to_string_lossy().into_owned();
+    let working_dir = match env::current_dir() {
+        Ok(dir) => dir.to_string_lossy().into_owned(),
+        Err(e) => panic!(p_s.span_diagnostic.fatal(&format!("Current directory is invalid: {}", e))),
+    };
     let working_dir = file_path_mapping.map_prefix(working_dir);
 
     let sess = Session {

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -778,7 +778,9 @@ pub fn build_session_(sopts: config::Options,
 
     let working_dir = match env::current_dir() {
         Ok(dir) => dir.to_string_lossy().into_owned(),
-        Err(e) => panic!(p_s.span_diagnostic.fatal(&format!("Current directory is invalid: {}", e))),
+        Err(e) => {
+            panic!(p_s.span_diagnostic.fatal(&format!("Current directory is invalid: {}", e)))
+        }
     };
     let working_dir = file_path_mapping.map_prefix(working_dir);
 


### PR DESCRIPTION
Reference bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=871638

Like described on the reference bug report:

~~~
$ mkdir dir
$ cd dir
$ rm -rf ../dir
$ RUST_BACKTRACE=1 rustc -C target-cpu=help
error: internal compiler error: unexpected panic

note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports

note: run with `RUST_BACKTRACE=1` for a backtrace

thread 'rustc' panicked at 'called `Result::unwrap()` on an `Err` value: Error { repr: Os { code: 2, message: "No such file or directory" } }', src/libcore/result.rs:837
stack backtrace:
   1:     0x7f7d23970dda - <unknown>
   2:     0x7f7d2398305f - <unknown>
   3:     0x7f7d2397f8a5 - <unknown>
   4:     0x7f7d2397ffc7 - std::panicking::rust_panic_with_hook::h109e116a3a861224
   5:     0x7f7d2397fe54 - <unknown>
   6:     0x7f7d2397fd79 - std::panicking::begin_panic_fmt::h26713cea9bce3ab0
   7:     0x7f7d2397fd07 - rust_begin_unwind
   8:     0x7f7d239cb41d - core::panicking::panic_fmt::hcfbb59eeb7f27f75
   9:     0x7f7d20be63d3 - <unknown>
  10:     0x7f7d20d6ebcc - rustc::session::build_session_::h7a3559f2373a5d05
  11:     0x7f7d20d6dd7e - rustc::session::build_session_with_codemap::h68bc7bcd2f34eee4
  12:     0x7f7d20d6d72c - rustc::session::build_session::h437fda3c327a8bde
  13:     0x7f7d23d26030 - <rustc_driver::RustcDefaultCalls as rustc_driver::CompilerCalls<'a>>::no_input::h8047df7741757d1c
  14:     0x7f7d23d21d27 - rustc_driver::run_compiler::hafe7bbfedf95a825
  15:     0x7f7d23c57378 - <unknown>
  16:     0x7f7d2398ae0a - __rust_maybe_catch_panic
  17:     0x7f7d23c76fa8 - <unknown>
  18:     0x7f7d2397eb74 - <unknown>
  19:     0x7f7d1ed4f493 - start_thread
  20:     0x7f7d23645afe - __clone
  21:                0x0 - <unknown>
~~~

With this patch this will give instead:

~~~
error: Current directory is invalid: No such file or directory (os error 2)
~~~