### PR TITLE
Implement From<RecvError> for TryRecvError and RecvTimeoutError

### DIFF
--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -1677,6 +1677,15 @@ impl error::Error for TryRecvError {
     }
 }
 
+#[stable(feature = "mpsc_recv_error_from", since = "1.23.0")]
+impl From<RecvError> for TryRecvError {
+    fn from(err: RecvError) -> TryRecvError {
+        match err {
+            RecvError => TryRecvError::Disconnected,
+        }
+    }
+}
+
 #[stable(feature = "mpsc_recv_timeout_error", since = "1.15.0")]
 impl fmt::Display for RecvTimeoutError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -1706,6 +1715,15 @@ impl error::Error for RecvTimeoutError {
 
     fn cause(&self) -> Option<&error::Error> {
         None
+    }
+}
+
+#[stable(feature = "mpsc_recv_error_from", since = "1.23.0")]
+impl From<RecvError> for RecvTimeoutError {
+    fn from(err: RecvError) -> RecvTimeoutError {
+        match err {
+            RecvError => RecvTimeoutError::Disconnected,
+        }
     }
 }
 

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -1625,6 +1625,15 @@ impl<T: Send> error::Error for TrySendError<T> {
     }
 }
 
+#[stable(feature = "mpsc_error_conversions", since = "1.23.0")]
+impl<T> From<SendError<T>> for TrySendError<T> {
+    fn from(err: SendError<T>) -> TrySendError<T> {
+        match err {
+            SendError(t) => TrySendError::Disconnected(t),
+        }
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Display for RecvError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -1677,7 +1686,7 @@ impl error::Error for TryRecvError {
     }
 }
 
-#[stable(feature = "mpsc_recv_error_from", since = "1.23.0")]
+#[stable(feature = "mpsc_error_conversions", since = "1.23.0")]
 impl From<RecvError> for TryRecvError {
     fn from(err: RecvError) -> TryRecvError {
         match err {
@@ -1718,7 +1727,7 @@ impl error::Error for RecvTimeoutError {
     }
 }
 
-#[stable(feature = "mpsc_recv_error_from", since = "1.23.0")]
+#[stable(feature = "mpsc_error_conversions", since = "1.23.0")]
 impl From<RecvError> for RecvTimeoutError {
     fn from(err: RecvError) -> RecvTimeoutError {
         match err {


### PR DESCRIPTION
According to the documentation, it looks to me that `TryRecvError` and `RecvTimeoutError` are strict extensions of `RecvError`. As such, it makes sense to allow conversion from the latter type to the two former types without constraining future developments.

This permits to write `input.recv()?` and `input.recv_timeout(timeout)?` in the same function for example.