### PR TITLE
Disable jemalloc for sparcv9-sun-solaris

### DIFF
--- a/src/librustc_back/target/sparcv9_sun_solaris.rs
+++ b/src/librustc_back/target/sparcv9_sun_solaris.rs
@@ -17,6 +17,7 @@ pub fn target() -> TargetResult {
     // llvm calls this "v9"
     base.cpu = "v9".to_string();
     base.max_atomic_width = Some(64);
+    base.exe_allocation_crate = None;
 
     Ok(Target {
         llvm_target: "sparcv9-sun-solaris".to_string(),


### PR DESCRIPTION
Similar to #36994, rust programs segfault on SPARC64 Solaris machines.