### PR TITLE
std: Disable usage of mmap allocator in libbacktrace

### DIFF
--- a/src/libbacktrace/configure
+++ b/src/libbacktrace/configure
@@ -12338,7 +12338,7 @@ else
 
 _ACEOF
 if ac_fn_c_try_cpp "$LINENO"; then :
-  ALLOC_FILE=mmap.lo
+  ALLOC_FILE=alloc.lo
 else
   ALLOC_FILE=alloc.lo
 fi


### PR DESCRIPTION
This is sort of a long overdue change from the investigation in #29293
and #37477. The released binaries of rustc don't have debug information and so
don't actively suffer this problem but this can hit local development of rustc
and also larger programs compiled against libstd generating backtraces.

The main purpose of the mmap allocator in libacktrace is to be usable from a
signal handler, but we don't do that, so the normal allocator using malloc/free
should work well for us.