### PR TITLE
rustc: Add some more compatibility with AVX-512

### DIFF
--- a/src/librustc_trans/cabi_x86_64.rs
+++ b/src/librustc_trans/cabi_x86_64.rs
@@ -27,8 +27,8 @@ enum Class {
 #[derive(Clone, Copy, Debug)]
 struct Memory;
 
-// Currently supported vector size (AVX).
-const LARGEST_VECTOR_SIZE: usize = 256;
+// Currently supported vector size (AVX-512).
+const LARGEST_VECTOR_SIZE: usize = 512;
 const MAX_EIGHTBYTES: usize = LARGEST_VECTOR_SIZE / 64;
 
 fn classify_arg<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, arg: &ArgType<'tcx>)

--- a/src/librustc_trans/llvm_util.rs
+++ b/src/librustc_trans/llvm_util.rs
@@ -80,7 +80,12 @@ const X86_WHITELIST: &'static [&'static str] = &["avx\0", "avx2\0", "bmi\0", "bm
                                                  "ssse3\0", "tbm\0", "lzcnt\0", "popcnt\0",
                                                  "sse4a\0", "rdrnd\0", "rdseed\0", "fma\0",
                                                  "xsave\0", "xsaveopt\0", "xsavec\0",
-                                                 "xsaves\0"];
+                                                 "xsaves\0",
+                                                 "avx512bw\0", "avx512cd\0",
+                                                 "avx512dq\0", "avx512er\0",
+                                                 "avx512f\0", "avx512ifma\0",
+                                                 "avx512pf\0", "avx512vbmi\0",
+                                                 "avx512vl\0", "avx512vpopcntdq\0"];
 
 const HEXAGON_WHITELIST: &'static [&'static str] = &["hvx\0", "hvx-double\0"];
 


### PR DESCRIPTION
* Increase the maximum vector size in the ABI calculations to ensure that
  AVX-512 operands are immediates.
* Add a few more `target_feature` matchings for AVX-512 features