### PR TITLE
Return 0 as an exit status when no subcommand is given to bootstrap

### DIFF
--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -136,9 +136,12 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`");
         let subcommand = match subcommand {
             Some(s) => s,
             None => {
-                // No subcommand -- show the general usage and subcommand help
+                // No or an invalid subcommand -- show the general usage and subcommand help
+                // An exit code will be 0 when no subcommand is given, and 1 in case of an invalid
+                // subcommand.
                 println!("{}\n", subcommand_help);
-                process::exit(1);
+                let exit_code = if args.is_empty() { 0 } else { 1 };
+                process::exit(exit_code);
             }
         };
 


### PR DESCRIPTION
Running `./x.py` emits usage and error messages when no subcommand is given:
```
Usage: x.py <subcommand> [options] [<paths>...]

Subcommands:
    build       Compile either the compiler or libraries
    test        Build and run some test suites
    bench       Build and run some benchmarks
    doc         Build documentation
    clean       Clean out build directories
    dist        Build distribution artifacts
    install     Install distribution artifacts

To learn more about a subcommand, run `./x.py <subcommand> -h`

failed to run: /home/topecongiro/rust/build/bootstrap/debug/bootstrap
```
IMHO the last line is unnecessary. This PR removes it by changing the return code of `bootstrap` to 0 when no sub command is given.