### PR TITLE
Avoid repetition on “use of unstable library feature 'rustc_private'”

### DIFF
--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -598,29 +598,28 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                     None => format!("use of unstable library feature '{}'", &feature)
                 };
 
+
                 let msp: MultiSpan = span.into();
                 let cm = &self.sess.parse_sess.codemap();
-                let real_file_location =
+                let span_key =
                     msp.primary_span().and_then(|sp:Span|
                         if sp != DUMMY_SP {
                             let fname = cm.lookup_char_pos(sp.lo()).file.as_ref().name.clone();
                             if fname.starts_with("<") && fname.ends_with(" macros>") {
                                 None
                             } else {
-                                Some(fname)
+                                Some(span)
                             }
                         } else {
                             None
                         }
                     );
 
-                if let Some(_) = real_file_location {
-                    let tuple = (None, Some(span), msg.clone());
-                    let fresh = self.sess.one_time_diagnostics.borrow_mut().insert(tuple);
-                    if fresh {
-                        emit_feature_err(&self.sess.parse_sess, &feature.as_str(), span,
-                                         GateIssue::Library(Some(issue)), &msg);
-                    }
+                let tuple = (None, span_key, msg.clone());
+                let fresh = self.sess.one_time_diagnostics.borrow_mut().insert(tuple);
+                if fresh {
+                    emit_feature_err(&self.sess.parse_sess, &feature.as_str(), span,
+                                     GateIssue::Library(Some(issue)), &msg);
                 }
 
             }

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -18,6 +18,7 @@ use hir::def::Def;
 use hir::def_id::{CrateNum, CRATE_DEF_INDEX, DefId, LOCAL_CRATE};
 use ty::{self, TyCtxt};
 use middle::privacy::AccessLevels;
+use session::DiagnosticMessageId;
 use syntax::symbol::Symbol;
 use syntax_pos::{Span, MultiSpan, DUMMY_SP};
 use syntax::ast;
@@ -601,27 +602,25 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 
                 let msp: MultiSpan = span.into();
                 let cm = &self.sess.parse_sess.codemap();
-                let span_key =
-                    msp.primary_span().and_then(|sp:Span|
-                        if sp != DUMMY_SP {
-                            let fname = cm.lookup_char_pos(sp.lo()).file.as_ref().name.clone();
-                            if fname.starts_with("<") && fname.ends_with(" macros>") {
-                                None
-                            } else {
-                                Some(span)
-                            }
-                        } else {
+                let span_key = msp.primary_span().and_then(|sp: Span|
+                    if sp != DUMMY_SP {
+                        let file = cm.lookup_char_pos(sp.lo()).file;
+                        if file.name.starts_with("<") && file.name.ends_with(" macros>") {
                             None
+                        } else {
+                            Some(span)
                         }
-                    );
+                    } else {
+                        None
+                    }
+                );
 
-                let tuple = (None, span_key, msg.clone());
-                let fresh = self.sess.one_time_diagnostics.borrow_mut().insert(tuple);
+                let error_id = (DiagnosticMessageId::StabilityId(issue), span_key, msg.clone());
+                let fresh = self.sess.one_time_diagnostics.borrow_mut().insert(error_id);
                 if fresh {
                     emit_feature_err(&self.sess.parse_sess, &feature.as_str(), span,
                                      GateIssue::Library(Some(issue)), &msg);
                 }
-
             }
             Some(_) => {
                 // Stable APIs are always ok to call and deprecated APIs are

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -78,7 +78,7 @@ pub struct Session {
     /// Set of (LintId, Option<Span>, message) tuples tracking lint
     /// (sub)diagnostics that have been set once, but should not be set again,
     /// in order to avoid redundantly verbose output (Issue #24690).
-    pub one_time_diagnostics: RefCell<FxHashSet<(lint::LintId, Option<Span>, String)>>,
+    pub one_time_diagnostics: RefCell<FxHashSet<(Option<lint::LintId>, Option<Span>, String)>>,
     pub plugin_llvm_passes: RefCell<Vec<String>>,
     pub plugin_attributes: RefCell<Vec<(String, AttributeType)>>,
     pub crate_types: RefCell<Vec<config::CrateType>>,
@@ -361,7 +361,7 @@ impl Session {
             },
             _ => {
                 let lint_id = lint::LintId::of(lint);
-                let id_span_message = (lint_id, span, message.to_owned());
+                let id_span_message = (Some(lint_id), span, message.to_owned());
                 let fresh = self.one_time_diagnostics.borrow_mut().insert(id_span_message);
                 if fresh {
                     do_method()

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -367,8 +367,8 @@ impl Session {
                 do_method()
             },
             _ => {
-                let lint_id = lint::LintId::of(lint);
-                let id_span_message = (DiagnosticMessageId::LintId(lint_id), span, message.to_owned());
+                let lint_id = DiagnosticMessageId::LintId(lint::LintId::of(lint));
+                let id_span_message = (lint_id, span, message.to_owned());
                 let fresh = self.one_time_diagnostics.borrow_mut().insert(id_span_message);
                 if fresh {
                     do_method()

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -75,10 +75,10 @@ pub struct Session {
     pub working_dir: (String, bool),
     pub lint_store: RefCell<lint::LintStore>,
     pub buffered_lints: RefCell<Option<lint::LintBuffer>>,
-    /// Set of (LintId, Option<Span>, message) tuples tracking lint
+    /// Set of (DiagnosticId, Option<Span>, message) tuples tracking
     /// (sub)diagnostics that have been set once, but should not be set again,
-    /// in order to avoid redundantly verbose output (Issue #24690).
-    pub one_time_diagnostics: RefCell<FxHashSet<(Option<lint::LintId>, Option<Span>, String)>>,
+    /// in order to avoid redundantly verbose output (Issue #24690, #44953).
+    pub one_time_diagnostics: RefCell<FxHashSet<(DiagnosticMessageId, Option<Span>, String)>>,
     pub plugin_llvm_passes: RefCell<Vec<String>>,
     pub plugin_attributes: RefCell<Vec<(String, AttributeType)>>,
     pub crate_types: RefCell<Vec<config::CrateType>>,
@@ -162,6 +162,13 @@ enum DiagnosticBuilderMethod {
     Note,
     SpanNote,
     // add more variants as needed to support one-time diagnostics
+}
+
+/// Diagnostic message id - used in order to avoid emitting the same message more than once
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum DiagnosticMessageId {
+    LintId(lint::LintId),
+    StabilityId(u32)
 }
 
 impl Session {
@@ -361,7 +368,7 @@ impl Session {
             },
             _ => {
                 let lint_id = lint::LintId::of(lint);
-                let id_span_message = (Some(lint_id), span, message.to_owned());
+                let id_span_message = (DiagnosticMessageId::LintId(lint_id), span, message.to_owned());
                 let fresh = self.one_time_diagnostics.borrow_mut().insert(id_span_message);
                 if fresh {
                     do_method()


### PR DESCRIPTION
This PR fixes the error by only emitting it when the span contains a real file (is not inside a macro) - and making sure it's emitted only once per span. 
The first check was needed because spans-within-macros seem to differ a lot and "fixing" them to the real location is not trivial (and the method that does this is private to another module). It also feels like there always will be an error on import, with the real file name, so not sure there's a point to re-emit the same error at macro use.

Fix #44953.