### PR TITLE
configure.py: fix --disable-option-checking

### DIFF
--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -225,7 +225,7 @@ while i < len(sys.argv):
         unknown_args.append(arg)
 p("")
 
-if 'option-checking' not in known_args or known_args['option-checking'][1]:
+if 'option-checking' not in known_args or known_args['option-checking'][0][1]:
     if len(unknown_args) > 0:
         err("Option '" + unknown_args[0] + "' is not recognized")
     if len(need_value_args) > 0:


### PR DESCRIPTION
Getting the value of this option needs another level of indirection,
`known_args['option-checking'][0][1]` (map, list, tuple).