### PR TITLE
configure.py: fix --disable-option-checking and extra config paths

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -203,6 +203,16 @@
 # Where to install man pages in `prefix` above
 #mandir = "share/man"
 
+# Where to install data in `prefix` above (currently unused)
+#datadir = "share"
+
+# Where to install additional info in `prefix` above (currently unused)
+#infodir = "share/info"
+
+# Where to install local state (currently unused)
+# If this is a relative path, it will get installed in `prefix` above
+#localstatedir = "/var/lib"
+
 # =============================================================================
 # Options for compiling Rust code itself
 # =============================================================================

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -207,6 +207,11 @@ struct Install {
     bindir: Option<String>,
     libdir: Option<String>,
     mandir: Option<String>,
+
+    // standard paths, currently unused
+    datadir: Option<String>,
+    infodir: Option<String>,
+    localstatedir: Option<String>,
 }
 
 /// TOML representation of how the LLVM build is configured.

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -225,7 +225,12 @@ while i < len(sys.argv):
         unknown_args.append(arg)
 p("")
 
-if 'option-checking' not in known_args or known_args['option-checking'][1]:
+# Note: here and a few other places, we use [-1] to apply the *last* value
+# passed.  But if option-checking is enabled, then the known_args loop will
+# also assert that options are only passed once.
+option_checking = ('option-checking' not in known_args
+                   or known_args['option-checking'][-1][1])
+if option_checking:
     if len(unknown_args) > 0:
         err("Option '" + unknown_args[0] + "' is not recognized")
     if len(need_value_args) > 0:
@@ -238,7 +243,7 @@ config = {}
 
 def build():
     if 'build' in known_args:
-        return known_args['build'][0][1]
+        return known_args['build'][-1][1]
     return bootstrap.default_build_triple()
 
 
@@ -276,9 +281,9 @@ for key in known_args:
 
     # Ensure each option is only passed once
     arr = known_args[key]
-    if len(arr) > 1:
+    if option_checking and len(arr) > 1:
         err("Option '{}' provided more than once".format(key))
-    option, value = arr[0]
+    option, value = arr[-1]
 
     # If we have a clear avenue to set our value in rustbuild, do so
     if option.rustbuild is not None:


### PR DESCRIPTION
- indexing 'option-checking' out of `known_args` had a type error
- when option checking is disabled, don't error on duplicate args, just take the last
- add config.toml stubs for datadir, infodir, and localstatedir (which were already accepted, but broken)

---

This fixes a regression from 1.21 to beta, when the configure script was rewritten in python.