### PR TITLE
Document that call expressions also represent ADT constructors.

### DIFF
--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1054,7 +1054,9 @@ pub enum Expr_ {
     /// A function call
     ///
     /// The first field resolves to the function itself (usually an `ExprPath`),
-    /// and the second field is the list of arguments
+    /// and the second field is the list of arguments.
+    /// This also represents calling the constructor of
+    /// tuple-like ADTs such as tuple structs and enum variants.
     ExprCall(P<Expr>, HirVec<Expr>),
     /// A method call (`x.foo::<'static, Bar, Baz>(a, b, c, d)`)
     ///

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -901,7 +901,9 @@ pub enum ExprKind {
     /// A function call
     ///
     /// The first field resolves to the function itself,
-    /// and the second field is the list of arguments
+    /// and the second field is the list of arguments.
+    /// This also represents calling the constructor of
+    /// tuple-like ADTs such as tuple structs and enum variants.
     Call(P<Expr>, Vec<P<Expr>>),
     /// A method call (`x.foo::<'static, Bar, Baz>(a, b, c, d)`)
     ///


### PR DESCRIPTION
This is a rather obscure part of the language.