### PR TITLE
ci: Upgrade Android SDK/NDK and refactor to use sdkmanager/avdmanager.

### DIFF
--- a/src/ci/docker/arm-android/Dockerfile
+++ b/src/ci/docker/arm-android/Dockerfile
@@ -5,21 +5,27 @@ RUN sh /scripts/android-base-apt-get.sh
 
 COPY scripts/android-ndk.sh /scripts/
 RUN . /scripts/android-ndk.sh && \
-    download_and_make_toolchain android-ndk-r13b-linux-x86_64.zip arm 9
+    download_and_make_toolchain android-ndk-r15c-linux-x86_64.zip arm 14
 
+# Note:
+# Do not upgrade to `openjdk-9-jre-headless`, as it will cause certificate error
+# when installing the Android SDK (see PR #45193). This is unfortunate, but
+# every search result suggested either disabling HTTPS or replacing JDK 9 by
+# JDK 8 as the solution (e.g. https://stackoverflow.com/q/41421340). :|
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
   libgl1-mesa-glx \
   libpulse0 \
   libstdc++6:i386 \
-  openjdk-9-jre-headless \
+  openjdk-8-jre-headless \
   tzdata
 
 COPY scripts/android-sdk.sh /scripts/
 RUN . /scripts/android-sdk.sh && \
-    download_and_create_avd tools_r25.2.5-linux.zip armeabi-v7a 18
+    download_and_create_avd 4333796 armeabi-v7a 18
 
+ENV PATH=$PATH:/android/sdk/emulator
 ENV PATH=$PATH:/android/sdk/tools
 ENV PATH=$PATH:/android/sdk/platform-tools
 
@@ -27,7 +33,7 @@ ENV TARGETS=arm-linux-androideabi
 
 ENV RUST_CONFIGURE_ARGS \
       --target=$TARGETS \
-      --arm-linux-androideabi-ndk=/android/ndk/arm-9
+      --arm-linux-androideabi-ndk=/android/ndk/arm-14
 
 ENV SCRIPT python2.7 ../x.py test --target $TARGETS
 

--- a/src/ci/docker/disabled/dist-aarch64-android/Dockerfile
+++ b/src/ci/docker/disabled/dist-aarch64-android/Dockerfile
@@ -5,7 +5,7 @@ RUN sh /scripts/android-base-apt-get.sh
 
 COPY scripts/android-ndk.sh /scripts/
 RUN . /scripts/android-ndk.sh && \
-    download_and_make_toolchain android-ndk-r13b-linux-x86_64.zip arm64 21
+    download_and_make_toolchain android-ndk-r15c-linux-x86_64.zip arm64 21
 
 ENV PATH=$PATH:/android/ndk/arm64-21/bin
 

--- a/src/ci/docker/disabled/dist-armv7-android/Dockerfile
+++ b/src/ci/docker/disabled/dist-armv7-android/Dockerfile
@@ -5,17 +5,17 @@ RUN sh /scripts/android-base-apt-get.sh
 
 COPY scripts/android-ndk.sh /scripts/
 RUN . /scripts/android-ndk.sh && \
-    download_ndk android-ndk-r13b-linux-x86_64.zip && \
-    make_standalone_toolchain arm 9 && \
+    download_ndk android-ndk-r15c-linux-x86_64.zip && \
+    make_standalone_toolchain arm 14 && \
     make_standalone_toolchain arm 21 && \
     remove_ndk
 
 RUN chmod 777 /android/ndk && \
     ln -s /android/ndk/arm-21 /android/ndk/arm
 
-ENV PATH=$PATH:/android/ndk/arm-9/bin
+ENV PATH=$PATH:/android/ndk/arm-14/bin
 
-ENV DEP_Z_ROOT=/android/ndk/arm-9/sysroot/usr/
+ENV DEP_Z_ROOT=/android/ndk/arm-14/sysroot/usr/
 
 ENV HOSTS=armv7-linux-androideabi
 
@@ -27,18 +27,18 @@ ENV RUST_CONFIGURE_ARGS \
       --enable-extended \
       --enable-cargo-openssl-static
 
-# We support api level 9, but api level 21 is required to build llvm. To
+# We support api level 14, but api level 21 is required to build llvm. To
 # overcome this problem we use a ndk with api level 21 to build llvm and then
-# switch to a ndk with api level 9 to complete the build. When the linker is
+# switch to a ndk with api level 14 to complete the build. When the linker is
 # invoked there are missing symbols (like sigsetempty, not available with api
-# level 9), the default linker behavior is to generate an error, to allow the
+# level 14), the default linker behavior is to generate an error, to allow the
 # build to finish we use --warn-unresolved-symbols. Note that the missing
 # symbols does not affect std, only the compiler (llvm) and cargo (openssl).
 ENV SCRIPT \
   python2.7 ../x.py build src/llvm --host $HOSTS --target $HOSTS && \
   (export RUSTFLAGS="\"-C link-arg=-Wl,--warn-unresolved-symbols\""; \
     rm /android/ndk/arm && \
-    ln -s /android/ndk/arm-9 /android/ndk/arm && \
+    ln -s /android/ndk/arm-14 /android/ndk/arm && \
     python2.7 ../x.py dist --host $HOSTS --target $HOSTS)
 
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/docker/disabled/dist-i686-android/Dockerfile
+++ b/src/ci/docker/disabled/dist-i686-android/Dockerfile
@@ -5,17 +5,17 @@ RUN sh /scripts/android-base-apt-get.sh
 
 COPY scripts/android-ndk.sh /scripts/
 RUN . /scripts/android-ndk.sh && \
-    download_ndk android-ndk-r13b-linux-x86_64.zip && \
-    make_standalone_toolchain x86 9 && \
+    download_ndk android-ndk-r15c-linux-x86_64.zip && \
+    make_standalone_toolchain x86 14 && \
     make_standalone_toolchain x86 21 && \
     remove_ndk
 
 RUN chmod 777 /android/ndk && \
     ln -s /android/ndk/x86-21 /android/ndk/x86
 
-ENV PATH=$PATH:/android/ndk/x86-9/bin
+ENV PATH=$PATH:/android/ndk/x86-14/bin
 
-ENV DEP_Z_ROOT=/android/ndk/x86-9/sysroot/usr/
+ENV DEP_Z_ROOT=/android/ndk/x86-14/sysroot/usr/
 
 ENV HOSTS=i686-linux-android
 
@@ -27,18 +27,18 @@ ENV RUST_CONFIGURE_ARGS \
       --enable-extended \
       --enable-cargo-openssl-static
 
-# We support api level 9, but api level 21 is required to build llvm. To
+# We support api level 14, but api level 21 is required to build llvm. To
 # overcome this problem we use a ndk with api level 21 to build llvm and then
-# switch to a ndk with api level 9 to complete the build. When the linker is
+# switch to a ndk with api level 14 to complete the build. When the linker is
 # invoked there are missing symbols (like sigsetempty, not available with api
-# level 9), the default linker behavior is to generate an error, to allow the
+# level 14), the default linker behavior is to generate an error, to allow the
 # build to finish we use --warn-unresolved-symbols. Note that the missing
 # symbols does not affect std, only the compiler (llvm) and cargo (openssl).
 ENV SCRIPT \
   python2.7 ../x.py build src/llvm --host $HOSTS --target $HOSTS && \
   (export RUSTFLAGS="\"-C link-arg=-Wl,--warn-unresolved-symbols\""; \
     rm /android/ndk/x86 && \
-    ln -s /android/ndk/x86-9 /android/ndk/x86 && \
+    ln -s /android/ndk/x86-14 /android/ndk/x86 && \
     python2.7 ../x.py dist --host $HOSTS --target $HOSTS)
 
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/docker/disabled/dist-x86_64-android/Dockerfile
+++ b/src/ci/docker/disabled/dist-x86_64-android/Dockerfile
@@ -5,7 +5,7 @@ RUN sh /scripts/android-base-apt-get.sh
 
 COPY scripts/android-ndk.sh /scripts/
 RUN . /scripts/android-ndk.sh && \
-    download_and_make_toolchain android-ndk-r13b-linux-x86_64.zip x86_64 21
+    download_and_make_toolchain android-ndk-r15c-linux-x86_64.zip x86_64 21
 
 ENV PATH=$PATH:/android/ndk/x86_64-21/bin
 

--- a/src/ci/docker/dist-android/Dockerfile
+++ b/src/ci/docker/dist-android/Dockerfile
@@ -6,9 +6,9 @@ RUN sh /scripts/android-base-apt-get.sh
 # ndk
 COPY scripts/android-ndk.sh /scripts/
 RUN . /scripts/android-ndk.sh && \
-    download_ndk android-ndk-r13b-linux-x86_64.zip && \
-    make_standalone_toolchain arm 9 && \
-    make_standalone_toolchain x86 9 && \
+    download_ndk android-ndk-r15c-linux-x86_64.zip && \
+    make_standalone_toolchain arm 14 && \
+    make_standalone_toolchain x86 14 && \
     make_standalone_toolchain arm64 21 && \
     make_standalone_toolchain x86_64 21 && \
     remove_ndk
@@ -23,9 +23,9 @@ ENV TARGETS=$TARGETS,x86_64-linux-android
 ENV RUST_CONFIGURE_ARGS \
       --target=$TARGETS \
       --enable-extended \
-      --arm-linux-androideabi-ndk=/android/ndk/arm-9 \
-      --armv7-linux-androideabi-ndk=/android/ndk/arm-9 \
-      --i686-linux-android-ndk=/android/ndk/x86-9 \
+      --arm-linux-androideabi-ndk=/android/ndk/arm-14 \
+      --armv7-linux-androideabi-ndk=/android/ndk/arm-14 \
+      --i686-linux-android-ndk=/android/ndk/x86-14 \
       --aarch64-linux-android-ndk=/android/ndk/arm64-21 \
       --x86_64-linux-android-ndk=/android/ndk/x86_64-21
 

--- a/src/ci/docker/scripts/android-sdk.sh
+++ b/src/ci/docker/scripts/android-sdk.sh
@@ -10,40 +10,40 @@
 
 set -ex
 
-URL=https://dl.google.com/android/repository
+export ANDROID_HOME=/android/sdk
+PATH=$PATH:"${ANDROID_HOME}/tools/bin"
 
 download_sdk() {
-    mkdir -p /android/sdk
-    cd /android/sdk
-    curl -fO $URL/$1
-    unzip -q $1
-    rm -rf $1
+    mkdir -p /android
+    curl -fo sdk.zip "https://dl.google.com/android/repository/sdk-tools-linux-$1.zip"
+    unzip -q sdk.zip -d "$ANDROID_HOME"
+    rm -f sdk.zip
 }
 
 download_sysimage() {
-    # See https://developer.android.com/studio/tools/help/android.html
     abi=$1
     api=$2
 
-    filter="platform-tools,android-$api"
-    filter="$filter,sys-img-$abi-android-$api"
-
-    # Keep printing yes to accept the licenses
-    while true; do echo yes; sleep 10; done | \
-        /android/sdk/tools/android update sdk -a --no-ui \
-            --filter "$filter" --no-https
+    # See https://developer.android.com/studio/command-line/sdkmanager.html for
+    # usage of `sdkmanager`.
+    #
+    # The output from sdkmanager is so noisy that it will occupy all of the 4 MB
+    # log extremely quickly. Thus we must silence all output.
+    yes | sdkmanager --licenses > /dev/null
+    sdkmanager platform-tools emulator \
+        "platforms;android-$api" \
+        "system-images;android-$api;default;$abi" > /dev/null
 }
 
 create_avd() {
-    # See https://developer.android.com/studio/tools/help/android.html
     abi=$1
     api=$2
 
-    echo no | \
-        /android/sdk/tools/android create avd \
-            --name $abi-$api \
-            --target android-$api \
-            --abi $abi
+    # See https://developer.android.com/studio/command-line/avdmanager.html for
+    # usage of `avdmanager`.
+    echo no | avdmanager create avd \
+        -n "$abi-$api" \
+        -k "system-images;android-$api;default;$abi"
 }
 
 download_and_create_avd() {
@@ -51,3 +51,15 @@ download_and_create_avd() {
     download_sysimage $2 $3
     create_avd $2 $3
 }
+
+# Usage:
+#
+#       setup_android_sdk 4333796 armeabi-v7a 18
+#
+# 4333796 =>
+#   SDK tool version.
+#   Copy from https://developer.android.com/studio/index.html#command-tools
+# armeabi-v7a =>
+#   System image ABI
+# 18 =>
+#   Android API Level (18 = Android 4.3 = Jelly Bean MR2)


### PR DESCRIPTION
* SDK tools is upgraded to 27.0.0. 

* Stopped using the deprecated `android` tool, instead use the recommended `sdkmanager` and `avdmanager`.

* NDK is upgrade to r15c.

    The r15 series [dropped support for android-9](https://github.com/android-ndk/ndk/wiki/Changelog-r15) (2.3 / Gingerbread), the minimal supported version is now android-14 (4.0 / Ice Cream Sandwich).

r? @alexcrichton 

(WIP, haven't confirmed if the change really works yet)