### PR TITLE
Re-enable rustfmt testing

### DIFF
--- a/src/tools/toolstate.toml
+++ b/src/tools/toolstate.toml
@@ -32,4 +32,4 @@ clippy = "Broken"
 rls = "Broken"
 
 # ping @nrc
-rustfmt = "Broken"
+rustfmt = "Testing"


### PR DESCRIPTION
Since rustfmt has merge the [PR](https://github.com/rust-lang-nursery/rustfmt/pull/2074), it can re-enable testing again.

r? @nrc