### PR TITLE
Optimize some span operations

### DIFF
--- a/src/librustc/ich/hcx.rs
+++ b/src/librustc/ich/hcx.rs
@@ -370,17 +370,18 @@ impl<'gcx> HashStable<StableHashingContext<'gcx>> for Span {
         // If this is not an empty or invalid span, we want to hash the last
         // position that belongs to it, as opposed to hashing the first
         // position past it.
-        let span_hi = if self.hi() > self.lo() {
+        let span = self.data();
+        let span_hi = if span.hi > span.lo {
             // We might end up in the middle of a multibyte character here,
             // but that's OK, since we are not trying to decode anything at
             // this position.
-            self.hi() - ::syntax_pos::BytePos(1)
+            span.hi - ::syntax_pos::BytePos(1)
         } else {
-            self.hi()
+            span.hi
         };
 
         {
-            let loc1 = hcx.codemap().byte_pos_to_line_and_col(self.lo());
+            let loc1 = hcx.codemap().byte_pos_to_line_and_col(span.lo);
             let loc1 = loc1.as_ref()
                            .map(|&(ref fm, line, col)| (&fm.name[..], line, col.to_usize()))
                            .unwrap_or(("???", 0, 0));
@@ -413,7 +414,7 @@ impl<'gcx> HashStable<StableHashingContext<'gcx>> for Span {
             }
         }
 
-        if self.ctxt() == SyntaxContext::empty() {
+        if span.ctxt == SyntaxContext::empty() {
             0u8.hash_stable(hcx, hasher);
         } else {
             1u8.hash_stable(hcx, hasher);


### PR DESCRIPTION
Do not decode span data twice/thrice/etc unnecessarily.
Applied to stable hashing and all methods in `impl Span`.

Follow up to https://github.com/rust-lang/rust/pull/44646
r? @michaelwoerister 