### PR TITLE
generalize `expect`

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -146,7 +146,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use iter::{FromIterator, FusedIterator, TrustedLen};
-use {mem, ops};
+use {fmt, mem, ops};
 
 // Note that this is not a lang item per se, but it has a hidden dependency on
 // `Iterator`, which is one. The compiler assumes that the `next` method of
@@ -296,7 +296,7 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn expect(self, msg: &str) -> T {
+    pub fn expect<S: fmt::Display>(self, msg: S) -> T {
         match self {
             Some(val) => val,
             None => expect_failed(msg),
@@ -835,7 +835,7 @@ impl<T: Default> Option<T> {
 // This is a separate function to reduce the code size of .expect() itself.
 #[inline(never)]
 #[cold]
-fn expect_failed(msg: &str) -> ! {
+fn expect_failed<S: fmt::Display>(msg: S) -> ! {
     panic!("{}", msg)
 }
 

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -793,7 +793,7 @@ impl<T, E: fmt::Debug> Result<T, E> {
     /// ```
     #[inline]
     #[stable(feature = "result_expect", since = "1.4.0")]
-    pub fn expect(self, msg: &str) -> T {
+    pub fn expect<S: fmt::Display>(self, msg: S) -> T {
         match self {
             Ok(t) => t,
             Err(e) => unwrap_failed(msg, e),
@@ -853,7 +853,7 @@ impl<T: fmt::Debug, E> Result<T, E> {
     /// ```
     #[inline]
     #[stable(feature = "result_expect_err", since = "1.17.0")]
-    pub fn expect_err(self, msg: &str) -> E {
+    pub fn expect_err<S: fmt::Display>(self, msg: S) -> E {
         match self {
             Ok(t) => unwrap_failed(msg, t),
             Err(e) => e,
@@ -902,7 +902,7 @@ impl<T: Default, E> Result<T, E> {
 // This is a separate function to reduce the code size of the methods
 #[inline(never)]
 #[cold]
-fn unwrap_failed<E: fmt::Debug>(msg: &str, error: E) -> ! {
+fn unwrap_failed<S: fmt::Display, E: fmt::Debug>(msg: S, error: E) -> ! {
     panic!("{}: {:?}", msg, error)
 }
 


### PR DESCRIPTION
This is useful if one wants to show a `fmt::Arguments` (for example) and can't allocate.