### PR TITLE
bootstrap: Add missing cputype matching for sparc64

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -294,7 +294,7 @@ def default_build_triple():
             raise ValueError('unknown byteorder: {}'.format(sys.byteorder))
         # only the n64 ABI is supported, indicate it
         ostype += 'abi64'
-    elif cputype == 'sparcv9':
+    elif cputype == 'sparcv9' or cputype == 'sparc64':
         pass
     else:
         err = "unknown cpu type: {}".format(cputype)


### PR DESCRIPTION
Trying to configure rust natively on sparc64-unknown-linux-gnu currently fails with:

```
root@deb4g:/local_scratch/glaubitz/rust/rust# ./configure --host=sparc64-unknown-linux-gnu --enable-local-rust --local-rust-root=/usr/local
configure: processing command line
configure: 
configure: build.host           := ['sparc64-unknown-linux-gnu']
configure: build.rustc          := /usr/local/bin/rustc
configure: build.cargo          := /usr/local/bin/cargo
configure: build.rustc          := /usr/local/bin/rustc
configure: build.cargo          := /usr/local/bin/cargo
configure: build.configure-args := ['--host=sparc64-unknown-linux-gnu', '--enable ...
unknown cpu type: sparc64
root@deb4g:/local_scratch/glaubitz/rust/rust#
```

This is trivially fixed by defining sparc64 as a valid cputype.