### PR TITLE
Improve display of error E0308

### DIFF
--- a/src/test/ui/issue-35241.rs
+++ b/src/test/ui/issue-35241.rs
@@ -1,0 +1,15 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo(u32);
+
+fn test() -> Foo { Foo }
+
+fn main() {}

--- a/src/test/ui/issue-35241.stderr
+++ b/src/test/ui/issue-35241.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-35241.rs:13:20
+   |
+13 | fn test() -> Foo { Foo }
+   |              ---   ^^^
+   |              |     |
+   |              |     expected struct `Foo`, found fn item
+   |              |     did you mean `Foo(/* fields */)`?
+   |              expected `Foo` because of return type
+   |
+   = note: expected type `Foo`
+              found type `fn(u32) -> Foo {Foo::{{constructor}}}`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Ref. Forgetting to call a variant constructor causes a confusing error message #35241.

This PR modifies [`note_type_err`](https://github.com/rust-lang/rust/blob/b7041bfab3a83702a8026fb7a18d8ea7d54cc648/src/librustc/infer/error_reporting/mod.rs#L669-L674) to display a `help` message when a `TyFnPtr` or `TyFnDef` are found and the return type, of the function or function pointer, is the same as the type that is expected. 

The output of compiling

```rust
struct Foo(u32);

fn test() -> Foo { Foo }

fn main() {}
```

is now

```bash
$ rustc src/test/ui/issue-35241.rs
error[E0308]: mismatched types
  --> src/test/ui/issue-35241.rs:13:20
   |
13 | fn test() -> Foo { Foo }
   |              ---   ^^^ expected struct `Foo`, found fn item
   |              |
   |              expected `Foo` because of return type
   |
   = help: did you mean `Foo { /* fields */ }`?
   = note: expected type `Foo`
              found type `fn(u32) -> Foo {Foo::{{constructor}}}`

error: aborting due to previous error
```