### PR TITLE
Ignore panic functions in backtraces. Print inlined functions on Windows

### DIFF
--- a/src/libcore/panicking.rs
+++ b/src/libcore/panicking.rs
@@ -48,25 +48,38 @@ pub fn panic(expr_file_line_col: &(&'static str, &'static str, u32, u32)) -> ! {
     // Arguments::new_v1 may allow the compiler to omit Formatter::pad from the
     // output binary, saving up to a few kilobytes.
     let (expr, file, line, col) = *expr_file_line_col;
-    panic_fmt(fmt::Arguments::new_v1(&[expr], &[]), &(file, line, col))
+    panic_dispatch(fmt::Arguments::new_v1(&[expr], &[]), &(file, line, col), &(panic as usize))
 }
 
 #[cold] #[inline(never)]
 #[lang = "panic_bounds_check"]
 fn panic_bounds_check(file_line_col: &(&'static str, u32, u32),
-                     index: usize, len: usize) -> ! {
-    panic_fmt(format_args!("index out of bounds: the len is {} but the index is {}",
-                           len, index), file_line_col)
+                      index: usize, len: usize) -> ! {
+    panic_dispatch(format_args!("index out of bounds: the len is {} but the index is {}",
+                                len, index),
+                   file_line_col,
+                   &(panic_bounds_check as usize))
 }
 
 #[cold] #[inline(never)]
 pub fn panic_fmt(fmt: fmt::Arguments, file_line_col: &(&'static str, u32, u32)) -> ! {
+    panic_dispatch(fmt, file_line_col, &(panic_fmt as usize));
+}
+
+#[cold]
+fn panic_dispatch(fmt: fmt::Arguments,
+                 file_line_col: &(&'static str, u32, u32),
+                 entry_point: &usize) -> ! {
     #[allow(improper_ctypes)]
     extern {
         #[lang = "panic_fmt"]
         #[unwind]
-        fn panic_impl(fmt: fmt::Arguments, file: &'static str, line: u32, col: u32) -> !;
+        fn panic_impl(fmt: fmt::Arguments,
+                      file: &'static str,
+                      line: u32,
+                      col: u32,
+                      entry_point: &usize) -> !;
     }
     let (file, line, col) = *file_line_col;
-    unsafe { panic_impl(fmt, file, line, col) }
+    unsafe { panic_impl(fmt, file, line, col, entry_point) }
 }

--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -554,9 +554,9 @@ pub fn begin_panic<M: Any + Send>(msg: M, file_line_col: &(&'static str, u32, u3
 /// run panic hooks, and then delegate to the actual implementation of panics.
 #[inline(never)]
 #[cold]
-pub(crate) fn rust_panic_with_hook(msg: Box<Any + Send>,
-                                   file_line_col: &(&'static str, u32, u32),
-                                   entry_point: &usize) -> ! {
+fn rust_panic_with_hook(msg: Box<Any + Send>,
+                        file_line_col: &(&'static str, u32, u32),
+                        entry_point: &usize) -> ! {
     let (file, line, col) = *file_line_col;
 
     let panics = update_panic_count(1);

--- a/src/libstd/rt.rs
+++ b/src/libstd/rt.rs
@@ -56,7 +56,8 @@ fn lang_start(main: fn(), argc: isize, argv: *const *const u8) -> isize {
         // Let's run some code!
         #[cfg(feature = "backtrace")]
         let res = panic::catch_unwind(|| {
-            ::sys_common::backtrace::__rust_begin_short_backtrace(main)
+            let mut main = main;
+            ::sys_common::backtrace::mark_start(&mut main)
         });
         #[cfg(not(feature = "backtrace"))]
         let res = panic::catch_unwind(mem::transmute::<_, fn()>(main));

--- a/src/libstd/rt.rs
+++ b/src/libstd/rt.rs
@@ -26,6 +26,14 @@
 // Reexport some of our utilities which are expected by other crates.
 pub use panicking::{begin_panic, begin_panic_fmt, update_panic_count};
 
+#[cfg(feature = "backtrace")]
+pub use sys_common::backtrace::mark_start as mark_backtrace_start;
+
+#[cfg(not(feature = "backtrace"))]
+pub fn mark_backtrace_start(f: &mut FnMut()) {
+    f();
+}
+
 #[cfg(not(test))]
 #[lang = "start"]
 fn lang_start(main: fn(), argc: isize, argv: *const *const u8) -> isize {

--- a/src/libstd/sys/unix/backtrace/printing/dladdr.rs
+++ b/src/libstd/sys/unix/backtrace/printing/dladdr.rs
@@ -18,17 +18,17 @@ use sys_common::backtrace::Frame;
 pub fn resolve_symname<F>(frame: Frame,
                           callback: F,
                           _: &BacktraceContext) -> io::Result<()>
-    where F: FnOnce(Option<&str>) -> io::Result<()>
+    where F: FnOnce(Option<(&str, usize)>) -> io::Result<()>
 {
     unsafe {
         let mut info: Dl_info = intrinsics::init();
-        let symname = if dladdr(frame.exact_position as *mut _, &mut info) == 0 ||
+        let symninfo = if dladdr(frame.exact_position as *mut _, &mut info) == 0 ||
                          info.dli_sname.is_null() {
             None
         } else {
-            CStr::from_ptr(info.dli_sname).to_str().ok()
+            CStr::from_ptr(info.dli_sname).to_str().ok().map(|s| (s, info.dli_saddr as usize))
         };
-        callback(symname)
+        callback(syminfo)
     }
 }
 

--- a/src/libstd/sys/unix/backtrace/printing/dladdr.rs
+++ b/src/libstd/sys/unix/backtrace/printing/dladdr.rs
@@ -22,7 +22,7 @@ pub fn resolve_symname<F>(frame: Frame,
 {
     unsafe {
         let mut info: Dl_info = intrinsics::init();
-        let symninfo = if dladdr(frame.exact_position as *mut _, &mut info) == 0 ||
+        let syminfo = if dladdr(frame.exact_position as *mut _, &mut info) == 0 ||
                          info.dli_sname.is_null() {
             None
         } else {

--- a/src/libstd/sys/unix/backtrace/printing/mod.rs
+++ b/src/libstd/sys/unix/backtrace/printing/mod.rs
@@ -31,11 +31,11 @@ pub use sys_common::gnu::libbacktrace::foreach_symbol_fileline;
 #[cfg(not(target_os = "emscripten"))]
 pub fn resolve_symname<F>(frame: Frame, callback: F, bc: &BacktraceContext) -> io::Result<()>
 where
-    F: FnOnce(Option<&str>) -> io::Result<()>
+    F: FnOnce(Option<(&str, usize)>) -> io::Result<()>
 {
-    ::sys_common::gnu::libbacktrace::resolve_symname(frame, |symname| {
-        if symname.is_some() {
-            callback(symname)
+    ::sys_common::gnu::libbacktrace::resolve_symname(frame, |syminfo| {
+        if syminfo.is_some() {
+            callback(syminfo)
         } else {
             dladdr::resolve_symname(frame, callback, bc)
         }

--- a/src/libstd/sys/unix/backtrace/tracing/gcc_s.rs
+++ b/src/libstd/sys/unix/backtrace/tracing/gcc_s.rs
@@ -98,6 +98,7 @@ extern fn trace_fn(ctx: *mut uw::_Unwind_Context,
         cx.frames[cx.idx] = Frame {
             symbol_addr: symaddr as *mut u8,
             exact_position: ip as *mut u8,
+            inline_context: 0,
         };
         cx.idx += 1;
     }

--- a/src/libstd/sys/windows/backtrace/printing/msvc.rs
+++ b/src/libstd/sys/windows/backtrace/printing/msvc.rs
@@ -12,16 +12,17 @@ use ffi::CStr;
 use io;
 use libc::{c_ulong, c_char};
 use mem;
+use ptr;
 use sys::c;
 use sys::backtrace::BacktraceContext;
 use sys_common::backtrace::Frame;
 
-type SymFromAddrFn =
-    unsafe extern "system" fn(c::HANDLE, u64, *mut u64,
-                              *mut c::SYMBOL_INFO) -> c::BOOL;
-type SymGetLineFromAddr64Fn =
-    unsafe extern "system" fn(c::HANDLE, u64, *mut u32,
-                              *mut c::IMAGEHLP_LINE64) -> c::BOOL;
+type SymFromInlineContextFn =
+    unsafe extern "system" fn(c::HANDLE, u64, c::DWORD,
+                              *mut u64, *mut c::SYMBOL_INFO) -> c::BOOL;
+type SymGetLineFromInlineContextFn =
+    unsafe extern "system" fn(c::HANDLE, u64, c::DWORD, c::HMODULE,
+                              *mut u32, *mut c::IMAGEHLP_LINE64) -> c::BOOL;
 
 /// Converts a pointer to symbol to its string value.
 pub fn resolve_symname<F>(frame: Frame,
@@ -29,7 +30,9 @@ pub fn resolve_symname<F>(frame: Frame,
                           context: &BacktraceContext) -> io::Result<()>
     where F: FnOnce(Option<(&str, usize)>) -> io::Result<()>
 {
-    let SymFromAddr = sym!(&context.dbghelp, "SymFromAddr", SymFromAddrFn)?;
+    let SymFromInlineContext = sym!(&context.dbghelp,
+                                    "SymFromInlineContext",
+                                    SymFromInlineContextFn)?;
 
     unsafe {
         let mut info: c::SYMBOL_INFO = mem::zeroed();
@@ -40,15 +43,25 @@ pub fn resolve_symname<F>(frame: Frame,
         info.SizeOfStruct = 88;
 
         let mut displacement = 0u64;
-        let ret = SymFromAddr(context.handle,
-                              frame.symbol_addr as u64,
-                              &mut displacement,
-                              &mut info);
-
-        let syminfo = if ret == c::TRUE {
+        let ret = SymFromInlineContext(context.handle,
+                                       frame.symbol_addr as u64,
+                                       frame.inline_context,
+                                       &mut displacement,
+                                       &mut info);
+        let valid_range = if ret == c::TRUE &&
+                             frame.symbol_addr as usize >= info.Address as usize {
+            if info.Size != 0 {
+                (frame.symbol_addr as usize) < info.Address as usize + info.Size as usize
+            } else {
+                true
+            }
+        } else {
+            false
+        };
+        let syminfo = if valid_range {
             let ptr = info.Name.as_ptr() as *const c_char;
             CStr::from_ptr(ptr).to_str().ok().map(|s| {
-                (s, (frame.symbol_addr as usize).wrapping_sub(displacement as usize))
+                (s, info.Address as usize)
             })
         } else {
             None
@@ -63,19 +76,21 @@ pub fn foreach_symbol_fileline<F>(frame: Frame,
     -> io::Result<bool>
     where F: FnMut(&[u8], u32) -> io::Result<()>
 {
-    let SymGetLineFromAddr64 = sym!(&context.dbghelp,
-                                    "SymGetLineFromAddr64",
-                                    SymGetLineFromAddr64Fn)?;
+    let SymGetLineFromInlineContext = sym!(&context.dbghelp,
+                                    "SymGetLineFromInlineContext",
+                                    SymGetLineFromInlineContextFn)?;
 
     unsafe {
         let mut line: c::IMAGEHLP_LINE64 = mem::zeroed();
         line.SizeOfStruct = ::mem::size_of::<c::IMAGEHLP_LINE64>() as u32;
 
         let mut displacement = 0u32;
-        let ret = SymGetLineFromAddr64(context.handle,
-                                       frame.exact_position as u64,
-                                       &mut displacement,
-                                       &mut line);
+        let ret = SymGetLineFromInlineContext(context.handle,
+                                              frame.exact_position as u64,
+                                              frame.inline_context,
+                                              ptr::null_mut(),
+                                              &mut displacement,
+                                              &mut line);
         if ret == c::TRUE {
             let name = CStr::from_ptr(line.Filename).to_bytes();
             f(name, line.LineNumber as u32)?;

--- a/src/libstd/sys/windows/c.rs
+++ b/src/libstd/sys/windows/c.rs
@@ -624,7 +624,7 @@ pub struct ADDRESS64 {
 
 #[repr(C)]
 #[cfg(feature = "backtrace")]
-pub struct STACKFRAME64 {
+pub struct STACKFRAME_EX {
     pub AddrPC: ADDRESS64,
     pub AddrReturn: ADDRESS64,
     pub AddrFrame: ADDRESS64,
@@ -636,6 +636,8 @@ pub struct STACKFRAME64 {
     pub Virtual: BOOL,
     pub Reserved: [u64; 3],
     pub KdHelp: KDHELP64,
+    pub StackFrameSize: DWORD,
+    pub InlineFrameContext: DWORD,
 }
 
 #[repr(C)]

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -403,7 +403,13 @@ impl Builder {
                 thread_info::set(imp::guard::current(), their_thread);
                 #[cfg(feature = "backtrace")]
                 let try_result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-                    ::sys_common::backtrace::__rust_begin_short_backtrace(f)
+                    let mut f = Some(f);
+                    let mut r = None;
+                    ::sys_common::backtrace::mark_start(&mut || {
+                        let f = f.take().unwrap();
+                        r = Some(f());
+                    });
+                    r.unwrap()
                 }));
                 #[cfg(not(feature = "backtrace"))]
                 let try_result = panic::catch_unwind(panic::AssertUnwindSafe(f));

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1452,7 +1452,6 @@ pub fn run_test(opts: &TestOpts,
 }
 
 /// Clean the backtrace by using std::rt::mark_backtrace_start
-#[inline(always)]
 fn begin_short_backtrace<F: FnOnce()>(f: F) {
     let mut f = Some(f);
     let mut r = None;

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1453,7 +1453,10 @@ pub fn run_test(opts: &TestOpts,
 /// Fixed frame used to clean the backtrace with `RUST_BACKTRACE=1`.
 #[inline(never)]
 fn __rust_begin_short_backtrace<F: FnOnce()>(f: F) {
-    f()
+    f();
+    unsafe {
+        asm!("" ::: "memory" : "volatile"); // A dummy statement to prevent tail call optimization
+    }
 }
 
 fn calc_result(desc: &TestDesc, task_result: Result<(), Box<Any + Send>>) -> TestResult {

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -40,6 +40,7 @@
 #![feature(set_stdio)]
 #![feature(panic_unwind)]
 #![feature(staged_api)]
+#![feature(rt)]
 
 extern crate getopts;
 extern crate term;
@@ -1331,14 +1332,14 @@ pub fn convert_benchmarks_to_tests(tests: Vec<TestDescAndFn>) -> Vec<TestDescAnd
             DynBenchFn(bench) => {
                 DynTestFn(Box::new(move || {
                     bench::run_once(|b| {
-                        __rust_begin_short_backtrace(|| bench.run(b))
+                        begin_short_backtrace(|| bench.run(b))
                     })
                 }))
             }
             StaticBenchFn(benchfn) => {
                 DynTestFn(Box::new(move || {
                     bench::run_once(|b| {
-                        __rust_begin_short_backtrace(|| benchfn(b))
+                        begin_short_backtrace(|| benchfn(b))
                     })
                 }))
             }
@@ -1440,23 +1441,26 @@ pub fn run_test(opts: &TestOpts,
         }
         DynTestFn(f) => {
             let cb = move || {
-                __rust_begin_short_backtrace(f)
+                begin_short_backtrace(f)
             };
             run_test_inner(desc, monitor_ch, opts.nocapture, Box::new(cb))
         }
         StaticTestFn(f) =>
             run_test_inner(desc, monitor_ch, opts.nocapture,
-                           Box::new(move || __rust_begin_short_backtrace(f))),
+                           Box::new(move || begin_short_backtrace(f))),
     }
 }
 
-/// Fixed frame used to clean the backtrace with `RUST_BACKTRACE=1`.
-#[inline(never)]
-fn __rust_begin_short_backtrace<F: FnOnce()>(f: F) {
-    f();
-    unsafe {
-        asm!("" ::: "memory" : "volatile"); // A dummy statement to prevent tail call optimization
-    }
+/// Clean the backtrace by using std::rt::mark_backtrace_start
+#[inline(always)]
+fn begin_short_backtrace<F: FnOnce()>(f: F) {
+    let mut f = Some(f);
+    let mut r = None;
+    std::rt::mark_backtrace_start(&mut || {
+        let f = f.take().unwrap();
+        r = Some(f());
+    });
+    r.unwrap()
 }
 
 fn calc_result(desc: &TestDesc, task_result: Result<(), Box<Any + Send>>) -> TestResult {


### PR DESCRIPTION
For the following program,
```rust
fn main() {
    panic!("hello world");
}
```
we now get this stack trace:
```
thread 'main' panicked at 'hello world', test.rs:2:4
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
stack backtrace:
   0: test::main
             at .\test.rs:2
```
instead of this one:
```
thread 'main' panicked at 'hello world', test.rs:2:4
stack backtrace:
   0: std::sys_common::backtrace::_print
             at C:\projects\rust\src\libstd\sys_common\backtrace.rs:92
   1: std::panicking::default_hook::{{closure}}
             at C:\projects\rust\src\libstd\panicking.rs:380
   2: std::panicking::default_hook
             at C:\projects\rust\src\libstd\panicking.rs:397
   3: std::panicking::rust_panic_with_hook
             at C:\projects\rust\src\libstd\panicking.rs:577
   4: std::panicking::begin_panic<str*>
             at C:\projects\rust\src\libstd\panicking.rs:538
   5: test::main
             at .\test.rs:2
   6: panic_unwind::__rust_maybe_catch_panic
             at C:\projects\rust\src\libpanic_unwind\lib.rs:99
   7: std::rt::lang_start
             at C:\projects\rust\src\libstd\rt.rs:52
   8: __scrt_common_main_seh
             at f:\dd\vctools\crt\vcstartup\src\startup\exe_common.inl:283
   9: BaseThreadInitThunk
```

This introduces a `str` macro fragment used to redirect `panic!` called with string literals to a non-generic function. This redirection is also an optimization (and matches what libcore does).