### PR TITLE
Add a nicer error message for missing  in for loop, fixes #40782.

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3183,7 +3183,7 @@ impl<'a> Parser<'a> {
                         let mut err = self.sess.span_diagnostic
                             .struct_span_err(in_span, "missing `in` in `for` loop");
                         err.span_label(in_span, "expected `in` here");
-                        err.span_suggestion_short(in_span, "try adding `in` here", "in".into());
+                        err.span_suggestion_short(in_span, "try adding `in` here", " in ".into());
                         Err(err)
                     }
                     Err(mut expr_err) => {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3158,7 +3158,6 @@ impl<'a> Parser<'a> {
             let in_span = self.prev_span.between(self.span);
             let mut err = self.sess.span_diagnostic
                 .struct_span_err(in_span, "missing `in` in `for` loop");
-            err.span_label(in_span, "expected `in` here");
             err.span_suggestion_short(in_span, "try adding `in` here", " in ".into());
             err.emit();
         }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3167,10 +3167,7 @@ impl<'a> Parser<'a> {
         attrs.extend(iattrs);
 
         let hi = self.prev_span;
-        Ok(self.mk_expr(
-            span_lo.to(hi),
-            ExprKind::ForLoop(pat, expr, loop_block, opt_ident),
-            attrs))
+        Ok(self.mk_expr(span_lo.to(hi), ExprKind::ForLoop(pat, expr, loop_block, opt_ident), attrs))
     }
 
     /// Parse a 'while' or 'while let' expression ('while' token already eaten)

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3194,8 +3194,7 @@ impl<'a> Parser<'a> {
                     }
                 }
             }
-
-            }
+        }
     }
 
     /// Parse a 'while' or 'while let' expression ('while' token already eaten)

--- a/src/test/ui/issue-40782.rs
+++ b/src/test/ui/issue-40782.rs
@@ -1,0 +1,15 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    for i 0..2 {
+    }
+}
+

--- a/src/test/ui/issue-40782.stderr
+++ b/src/test/ui/issue-40782.stderr
@@ -1,0 +1,11 @@
+error: missing `in` in `for` loop
+  --> $DIR/issue-40782.rs:12:11
+   |
+12 |     for i 0..2 {
+   |           ^
+   |           |
+   |           expected `in` here
+   |           help: try adding `in`: `for i in 0..2`
+
+error: aborting due to previous error
+

--- a/src/test/ui/issue-40782.stderr
+++ b/src/test/ui/issue-40782.stderr
@@ -1,11 +1,11 @@
 error: missing `in` in `for` loop
-  --> $DIR/issue-40782.rs:12:11
+  --> $DIR/issue-40782.rs:12:10
    |
 12 |     for i 0..2 {
-   |           ^
-   |           |
-   |           expected `in` here
-   |           help: try adding `in`: `for i in 0..2`
+   |          ^
+   |          |
+   |          expected `in` here
+   |          help: try adding `in` here
 
 error: aborting due to previous error
 

--- a/src/test/ui/issue-40782.stderr
+++ b/src/test/ui/issue-40782.stderr
@@ -2,10 +2,7 @@ error: missing `in` in `for` loop
   --> $DIR/issue-40782.rs:12:10
    |
 12 |     for i 0..2 {
-   |          ^
-   |          |
-   |          expected `in` here
-   |          help: try adding `in` here
+   |          ^ help: try adding `in` here
 
 error: aborting due to previous error
 


### PR DESCRIPTION
As suggested by @estebank in issue #40782, this works in the same way as #42578: if the in keyword is missing, we continue parsing the expression and if this works correctly an adapted error message is produced. Otherwise we return the old error.

A specific test case has also been added.
This is my first PR on rust-lang/rust so any feedback is very welcome.