### PR TITLE
edit and fix bad spacing of inner-attribute-not-allowed note

### DIFF
--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -105,11 +105,10 @@ impl<'a> Parser<'a> {
                         let span = self.span;
                         self.diagnostic()
                             .struct_span_err(span, reason)
-                            .note("inner attributes and doc comments, like `#![no_std]` or \
-                                   `//! My crate`, annotate the item enclosing them, and are \
-                                   usually found at the beginning of source files. Outer \
-                                   attributes and doc comments, like `#[test]` and
-                                   `/// My function`, annotate the item following them.")
+                            .note("inner attributes, like `#![no_std]`, annotate the item \
+                                   enclosing them, and are usually found at the beginning of \
+                                   source files. Outer attributes, like `#[test]`, annotate the \
+                                   item following them.")
                             .emit()
                     }
                     ast::AttrStyle::Inner

--- a/src/test/ui/issue-45296.stderr
+++ b/src/test/ui/issue-45296.stderr
@@ -4,8 +4,7 @@ error: an inner attribute is not permitted in this context
 14 |     #![allow(unused_variables)]
    |       ^
    |
-   = note: inner attributes and doc comments, like `#![no_std]` or `//! My crate`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes and doc comments, like `#[test]` and
-                                              `/// My function`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This multiline string literal was missing a backslash, leaving an awkward
newline and 35 spaces in the middle of the message.

But while we're here, the existing message seems kind of long in comparison to
similar notes: to cut it down, we excise the mentions of doc comments, which
seems sensible because we know that this erroneous attribute is not a doc
comment (notice the `is_sugared_doc: false` at the end of the function; if it
had been a doc comment, that error would get set in the `token::DocComment`
match branch of `parse_outer_attributes`).