### PR TITLE
Make rustdoc not include self-by-value methods from Deref target

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -3221,18 +3221,19 @@ fn should_render_item(item: &clean::Item, deref_mut_: bool) -> bool {
     };
 
     if let Some(self_ty) = self_type_opt {
-        let (by_mut_ref, by_box) = match self_ty {
+        let (by_mut_ref, by_box, by_value) = match self_ty {
             SelfTy::SelfBorrowed(_, mutability) |
             SelfTy::SelfExplicit(clean::BorrowedRef { mutability, .. }) => {
-                (mutability == Mutability::Mutable, false)
+                (mutability == Mutability::Mutable, false, false)
             },
             SelfTy::SelfExplicit(clean::ResolvedPath { did, .. }) => {
-                (false, Some(did) == cache().owned_box_did)
+                (false, Some(did) == cache().owned_box_did, false)
             },
-            _ => (false, false),
+            SelfTy::SelfValue => (false, false, true),
+            _ => (false, false, false),
         };
 
-        (deref_mut_ || !by_mut_ref) && !by_box
+        (deref_mut_ || !by_mut_ref) && !by_box && !by_value
     } else {
         false
     }

--- a/src/test/rustdoc/auxiliary/issue-19190-3.rs
+++ b/src/test/rustdoc/auxiliary/issue-19190-3.rs
@@ -15,8 +15,8 @@ use std::ops::Deref;
 pub struct Foo;
 
 impl Deref for Foo {
-    type Target = i32;
-    fn deref(&self) -> &i32 { loop {} }
+    type Target = String;
+    fn deref(&self) -> &String { loop {} }
 }
 
 pub struct Bar;

--- a/src/test/rustdoc/issue-19190-2.rs
+++ b/src/test/rustdoc/issue-19190-2.rs
@@ -13,10 +13,10 @@ use std::ops::Deref;
 pub struct Bar;
 
 impl Deref for Bar {
-    type Target = i32;
-    fn deref(&self) -> &i32 { loop {} }
+    type Target = String;
+    fn deref(&self) -> &String { loop {} }
 }
 
 // @has issue_19190_2/struct.Bar.html
-// @has - '//*[@id="method.count_ones"]' 'fn count_ones(self) -> u32'
-// @!has - '//*[@id="method.min_value"]' 'fn min_value() -> i32'
+// @!has - '//*[@id="method.new"]' 'fn new() -> String'
+// @has - '//*[@id="method.as_str"]' 'fn as_str(&self) -> &str'

--- a/src/test/rustdoc/issue-19190-3.rs
+++ b/src/test/rustdoc/issue-19190-3.rs
@@ -17,8 +17,8 @@ use std::ops::Deref;
 use issue_19190_3::Baz;
 
 // @has issue_19190_3/struct.Foo.html
-// @has - '//*[@id="method.count_ones"]' 'fn count_ones(self) -> u32'
-// @!has - '//*[@id="method.min_value"]' 'fn min_value() -> i32'
+// @has - '//*[@id="method.as_str"]' 'fn as_str(&self) -> &str'
+// @!has - '//*[@id="method.new"]' 'fn new() -> String'
 pub use issue_19190_3::Foo;
 
 // @has issue_19190_3/struct.Bar.html


### PR DESCRIPTION
Fixes #39550