### PR TITLE
Count type aliases used in patterns as usage by dead_code lint

### DIFF
--- a/src/test/run-pass/dead-code-alias-in-pat.rs
+++ b/src/test/run-pass/dead-code-alias-in-pat.rs
@@ -1,0 +1,18 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(dead_code)]
+
+fn main() {
+    struct Foo<T> { x: T }
+    type Bar = Foo<u32>;
+    let spam = |Bar { x }| x != 0;
+    println!("{}", spam(Foo { x: 10 }));
+}


### PR DESCRIPTION
Fixes #45614.