### PR TITLE
rustbuild: Don't build with ThinLTO on MIPS

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -617,14 +617,16 @@ impl<'a> Builder<'a> {
         if self.is_very_verbose() {
             cargo.arg("-v");
         }
-        // FIXME: cargo bench does not accept `--release`
-        if self.config.rust_optimize && cmd != "bench" {
-            cargo.arg("--release");
+        if self.config.rust_optimize {
+            // FIXME: cargo bench does not accept `--release`
+            if cmd != "bench" {
+                cargo.arg("--release");
+            }
 
-            if mode != Mode::Libstd &&
+            if mode != Mode::Libstd && // FIXME(#45320)
                self.config.rust_codegen_units.is_none() &&
-               self.build.is_rust_llvm(compiler.host)
-
+               self.build.is_rust_llvm(compiler.host) &&
+               !target.contains("mips") // FIXME(#45654)
             {
                 cargo.env("RUSTC_THINLTO", "1");
             }


### PR DESCRIPTION
Discovered in #45529 it looks like cross-module TLS imports aren't quite working
today, especially with `hidden` visibility which mostly comes up with multiple
codegen units. As a result this completely disables compiling with ThinLTO and
multiple codegen units on MIPS when bootstrapping.

cc #45654, the tracking issue for this