### PR TITLE
Suggest renaming import if names clash

### DIFF
--- a/src/test/ui/suggestions/issue-32354-suggest-import-rename.rs
+++ b/src/test/ui/suggestions/issue-32354-suggest-import-rename.rs
@@ -1,0 +1,22 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub mod extension1 {
+    pub trait ConstructorExtension {}
+}
+
+pub mod extension2 {
+    pub trait ConstructorExtension {}
+}
+
+use extension1::ConstructorExtension;
+use extension2::ConstructorExtension;
+
+fn main() {}

--- a/src/test/ui/suggestions/issue-32354-suggest-import-rename.stderr
+++ b/src/test/ui/suggestions/issue-32354-suggest-import-rename.stderr
@@ -1,0 +1,16 @@
+error[E0252]: the name `ConstructorExtension` is defined multiple times
+  --> $DIR/issue-32354-suggest-import-rename.rs:20:5
+   |
+19 | use extension1::ConstructorExtension;
+   |     -------------------------------- previous import of the trait `ConstructorExtension` here
+20 | use extension2::ConstructorExtension;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ConstructorExtension` reimported here
+   |
+   = note: `ConstructorExtension` must be defined only once in the type namespace of this module
+help: You can use `as` to change the binding name of the import
+   |
+20 | use extension2::ConstructorExtension as OtherConstructorExtension;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/32354.

The output for the example in the issue looks like this:

```
~/p/local-rust-dev-testing ❯❯❯ cargo +local-s1 build
   Compiling local-rust-dev-testing v0.1.0 (file:///home/cldfire/programming_projects/local-rust-dev-testing)
error[E0252]: the name `ConstructorExtension` is defined multiple times
  --> src/main.rs:49:5
   |
48 | use extension1::ConstructorExtension;
   |     -------------------------------- previous import of the trait `ConstructorExtension` here
49 | use extension2::ConstructorExtension;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ConstructorExtension` reimported here
   |
   = note: `ConstructorExtension` must be defined only once in the type namespace of this module
help: You can use `as` to change the binding name of the import
   |
49 | use extension2::ConstructorExtension as OtherConstructorExtension;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

...
```

This is my first PR that touches the compiler in any way, so if there's something else I need to do here (e.g. add a test), please let me know :).