### PR TITLE
rustbuild: Build libstd with ThinLTO

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -623,8 +623,7 @@ impl<'a> Builder<'a> {
                 cargo.arg("--release");
             }
 
-            if mode != Mode::Libstd && // FIXME(#45320)
-               self.config.rust_codegen_units.is_none() &&
+            if self.config.rust_codegen_units.is_none() &&
                self.build.is_rust_llvm(compiler.host) &&
                !target.contains("mips") // FIXME(#45654)
             {


### PR DESCRIPTION
This commit moves the standard library to get compiled with multiple codegen
units and ThinLTO like the compiler itself. This I would hope is the last major
step towards closing out #45320