### PR TITLE
Tidy: track rustc_const_unstable feature gates as well

### DIFF
--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -351,6 +351,26 @@ fn map_lib_features(base_src_path: &Path,
                 }
             }
             becoming_feature = None;
+            if line.contains("rustc_const_unstable(") && line.contains("#[") {
+                // const fn features are handled specially
+                let feature_name = match find_attr_val(line, "feature") {
+                    Some(name) => name,
+                    None => err!("malformed stability attribute"),
+                };
+                let feature = Feature {
+                    level: Status::Unstable,
+                    since: "None".to_owned(),
+                    has_gate_test: false,
+                    // Whether there is a common tracking issue
+                    // for these feature gates remains an open question
+                    // https://github.com/rust-lang/rust/issues/24111#issuecomment-340283184
+                    // But we take 24111 otherwise they will be shown as
+                    // "internal to the compiler" which they are not.
+                    tracking_issue: Some(24111),
+                };
+                mf(Ok((feature_name, feature)), file, i + 1);
+                continue;
+            }
             let level = if line.contains("[unstable(") {
                 Status::Unstable
             } else if line.contains("[stable(") {

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -351,7 +351,7 @@ fn map_lib_features(base_src_path: &Path,
                 }
             }
             becoming_feature = None;
-            if line.contains("rustc_const_unstable(") && line.contains("#[") {
+            if line.contains("rustc_const_unstable(") {
                 // const fn features are handled specially
                 let feature_name = match find_attr_val(line, "feature") {
                     Some(name) => name,


### PR DESCRIPTION
This is important for the unstable book stub generation.