### PR TITLE
[WIP] ci: Enable RUST_BACKTRACE=1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,7 @@ matrix:
         RUSTC_RETRY_LINKER_ON_SEGFAULT=1
         SCCACHE_ERROR_LOG=/tmp/sccache.log
         MACOSX_DEPLOYMENT_TARGET=10.7
+        NO_DEBUG_ASSERTIONS=1
       os: osx
       osx_image: xcode7.3
       # if: branch = auto
@@ -100,6 +101,7 @@ matrix:
         RUSTC_RETRY_LINKER_ON_SEGFAULT=1
         SCCACHE_ERROR_LOG=/tmp/sccache.log
         MACOSX_DEPLOYMENT_TARGET=10.7
+        NO_DEBUG_ASSERTIONS=1
       os: osx
       osx_image: xcode7.3
       # if: branch = auto

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ matrix:
         NO_DEBUG_ASSERTIONS=1
       os: osx
       osx_image: xcode8.3
-      if: branch = auto
+      # if: branch = auto
 
     # OSX builders producing releases. These do not run the full test suite and
     # just produce a bunch of artifacts.
@@ -88,11 +88,9 @@ matrix:
         RUSTC_RETRY_LINKER_ON_SEGFAULT=1
         SCCACHE_ERROR_LOG=/tmp/sccache.log
         MACOSX_DEPLOYMENT_TARGET=10.7
-        NO_LLVM_ASSERTIONS=1
-        NO_DEBUG_ASSERTIONS=1
       os: osx
       osx_image: xcode7.3
-      if: branch = auto
+      # if: branch = auto
 
     - env: >
         RUST_CHECK_TARGET=dist
@@ -102,11 +100,9 @@ matrix:
         RUSTC_RETRY_LINKER_ON_SEGFAULT=1
         SCCACHE_ERROR_LOG=/tmp/sccache.log
         MACOSX_DEPLOYMENT_TARGET=10.7
-        NO_LLVM_ASSERTIONS=1
-        NO_DEBUG_ASSERTIONS=1
       os: osx
       osx_image: xcode7.3
-      if: branch = auto
+      # if: branch = auto
 
     # Linux builders, remaining docker images
     - env: IMAGE=arm-android
@@ -148,7 +144,7 @@ matrix:
     - env: IMAGE=dist-powerpc64le-linux DEPLOY=1
       if: branch = auto
     - env: IMAGE=dist-s390x-linux DEPLOY=1
-      if: branch = auto
+      # if: branch = auto
     - env: IMAGE=dist-x86_64-freebsd DEPLOY=1
       if: branch = auto
     - env: IMAGE=dist-x86_64-musl DEPLOY=1
@@ -166,7 +162,7 @@ matrix:
     - env: IMAGE=x86_64-gnu
       if: branch = auto
     - env: IMAGE=x86_64-gnu-full-bootstrap
-      if: branch = auto
+      # if: branch = auto
     - env: IMAGE=x86_64-gnu-aux
       if: branch = auto
     - env: IMAGE=x86_64-gnu-cargotest

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,7 @@ matrix:
         RUSTC_RETRY_LINKER_ON_SEGFAULT=1
         SCCACHE_ERROR_LOG=/tmp/sccache.log
         MACOSX_DEPLOYMENT_TARGET=10.7
+        NO_LLVM_ASSERTIONS=1
         NO_DEBUG_ASSERTIONS=1
       os: osx
       osx_image: xcode7.3
@@ -101,6 +102,7 @@ matrix:
         RUSTC_RETRY_LINKER_ON_SEGFAULT=1
         SCCACHE_ERROR_LOG=/tmp/sccache.log
         MACOSX_DEPLOYMENT_TARGET=10.7
+        NO_LLVM_ASSERTIONS=1
         NO_DEBUG_ASSERTIONS=1
       os: osx
       osx_image: xcode7.3
@@ -108,7 +110,7 @@ matrix:
 
     # Linux builders, remaining docker images
     - env: IMAGE=arm-android
-      if: branch = auto
+      # if: branch = auto
     - env: IMAGE=armhf-gnu
       if: branch = auto
     - env: IMAGE=cross DEPLOY=1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,71 +25,71 @@ environment:
     RUST_CHECK_TARGET: check-aux
     RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc
 
-  # MSVC cargotest
-  - MSYS_BITS: 64
-    SCRIPT: python x.py test src/tools/cargotest
-    RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc
+  # # MSVC cargotest
+  # - MSYS_BITS: 64
+  #   SCRIPT: python x.py test src/tools/cargotest
+  #   RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc
 
-  # 32/64-bit MinGW builds.
-  #
-  # We are using MinGW with posix threads since LLVM does not compile with
-  # the win32 threads version due to missing support for C++'s std::thread.
-  #
-  # Instead of relying on the MinGW version installed on appveryor we download
-  # and install one ourselves so we won't be surprised by changes to appveyor's
-  # build image.
-  #
-  # Finally, note that the downloads below are all in the `rust-lang-ci` S3
-  # bucket, but they cleraly didn't originate there! The downloads originally
-  # came from the mingw-w64 SourceForge download site. Unfortunately
-  # SourceForge is notoriously flaky, so we mirror it on our own infrastructure.
-  - MSYS_BITS: 32
-    RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
-    SCRIPT: python x.py test
-    MINGW_URL: https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror
-    MINGW_ARCHIVE: i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
-    MINGW_DIR: mingw32
-  - MSYS_BITS: 64
-    SCRIPT: python x.py test
-    RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu
-    MINGW_URL: https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror
-    MINGW_ARCHIVE: x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z
-    MINGW_DIR: mingw64
+  # # 32/64-bit MinGW builds.
+  # #
+  # # We are using MinGW with posix threads since LLVM does not compile with
+  # # the win32 threads version due to missing support for C++'s std::thread.
+  # #
+  # # Instead of relying on the MinGW version installed on appveryor we download
+  # # and install one ourselves so we won't be surprised by changes to appveyor's
+  # # build image.
+  # #
+  # # Finally, note that the downloads below are all in the `rust-lang-ci` S3
+  # # bucket, but they cleraly didn't originate there! The downloads originally
+  # # came from the mingw-w64 SourceForge download site. Unfortunately
+  # # SourceForge is notoriously flaky, so we mirror it on our own infrastructure.
+  # - MSYS_BITS: 32
+  #   RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
+  #   SCRIPT: python x.py test
+  #   MINGW_URL: https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror
+  #   MINGW_ARCHIVE: i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
+  #   MINGW_DIR: mingw32
+  # - MSYS_BITS: 64
+  #   SCRIPT: python x.py test
+  #   RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu
+  #   MINGW_URL: https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror
+  #   MINGW_ARCHIVE: x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z
+  #   MINGW_DIR: mingw64
 
-  # 32/64 bit MSVC and GNU deployment
-  - RUST_CONFIGURE_ARGS: >
-      --build=x86_64-pc-windows-msvc
-      --enable-extended
-      --enable-profiler
-    SCRIPT: python x.py dist
-    DEPLOY: 1
-  - RUST_CONFIGURE_ARGS: >
-      --build=i686-pc-windows-msvc
-      --target=i586-pc-windows-msvc
-      --enable-extended
-      --enable-profiler
-    SCRIPT: python x.py dist
-    DEPLOY: 1
-  - MSYS_BITS: 32
-    RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu --enable-extended
-    SCRIPT: python x.py dist
-    MINGW_URL: https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror
-    MINGW_ARCHIVE: i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
-    MINGW_DIR: mingw32
-    DEPLOY: 1
-  - MSYS_BITS: 64
-    SCRIPT: python x.py dist
-    RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu --enable-extended
-    MINGW_URL: https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror
-    MINGW_ARCHIVE: x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z
-    MINGW_DIR: mingw64
-    DEPLOY: 1
+  # # 32/64 bit MSVC and GNU deployment
+  # - RUST_CONFIGURE_ARGS: >
+  #     --build=x86_64-pc-windows-msvc
+  #     --enable-extended
+  #     --enable-profiler
+  #   SCRIPT: python x.py dist
+  #   DEPLOY: 1
+  # - RUST_CONFIGURE_ARGS: >
+  #     --build=i686-pc-windows-msvc
+  #     --target=i586-pc-windows-msvc
+  #     --enable-extended
+  #     --enable-profiler
+  #   SCRIPT: python x.py dist
+  #   DEPLOY: 1
+  # - MSYS_BITS: 32
+  #   RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu --enable-extended
+  #   SCRIPT: python x.py dist
+  #   MINGW_URL: https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror
+  #   MINGW_ARCHIVE: i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
+  #   MINGW_DIR: mingw32
+  #   DEPLOY: 1
+  # - MSYS_BITS: 64
+  #   SCRIPT: python x.py dist
+  #   RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu --enable-extended
+  #   MINGW_URL: https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror
+  #   MINGW_ARCHIVE: x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z
+  #   MINGW_DIR: mingw64
+  #   DEPLOY: 1
 
-  # "alternate" deployment, see .travis.yml for more info
-  - MSYS_BITS: 64
-    RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-extended --enable-profiler
-    SCRIPT: python x.py dist
-    DEPLOY_ALT: 1
+  # # "alternate" deployment, see .travis.yml for more info
+  # - MSYS_BITS: 64
+  #   RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-extended --enable-profiler
+  #   SCRIPT: python x.py dist
+  #   DEPLOY_ALT: 1
 
 matrix:
   fast_finish: true
@@ -175,9 +175,9 @@ test_script:
 on_failure:
   - cat %CD%\sccache.log || exit 0
 
-branches:
-  only:
-    - auto
+# branches:
+#   only:
+#     - auto
 
 before_deploy:
   - ps: |

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -73,7 +73,7 @@ travis_time_finish
 
 travis_fold start make-prepare
 travis_time_start
-retry make prepare
+RUST_BACKTRACE=1 retry make prepare
 travis_fold end make-prepare
 travis_time_finish
 
@@ -90,6 +90,12 @@ else
 fi
 
 if [ ! -z "$SCRIPT" ]; then
+  # RUST_BACKTRACE=1 can slow down tests a lot.
+  # Thus we don't enable it for jobs that are running tests.
+  # (ref: https://mozilla.logbot.info/rust-infra/20170923#c26921)
+  if [[ ! "$SCRIPT" =~ " test" ]]; then
+    export RUST_BACKTRACE=1
+  fi
   sh -x -c "$SCRIPT"
 else
   do_make() {
@@ -103,7 +109,7 @@ else
     return $retval
   }
 
-  do_make tidy
-  do_make all
+  RUST_BACKTRACE=1 do_make tidy
+  RUST_BACKTRACE=1 do_make all
   do_make "$RUST_CHECK_TARGET"
 fi


### PR DESCRIPTION
1. Enable RUST_BACKTRACE=1 when building (but not testing).
2. Re-enable debug and LLVM assertions for macOS `dist` builds (they remain disabled in `check` builds).

WIP — checking if slowdown is within acceptable range (≤2 hours to complete).
