### PR TITLE
rustc: add item name to deprecated lint warning

### DIFF
--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -516,11 +516,13 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             return;
         }
 
-        let lint_deprecated = |note: Option<Symbol>| {
+        let lint_deprecated = |def_id: DefId, note: Option<Symbol>| {
+            let path = self.item_path_str(def_id);
+
             let msg = if let Some(note) = note {
-                format!("use of deprecated item: {}", note)
+                format!("use of deprecated item '{}': {}", path, note)
             } else {
-                format!("use of deprecated item")
+                format!("use of deprecated item '{}'", path)
             };
 
             self.lint_node(lint::builtin::DEPRECATED, id, span, &msg);
@@ -538,7 +540,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             };
 
             if !skip {
-                lint_deprecated(depr_entry.attr.note);
+                lint_deprecated(def_id, depr_entry.attr.note);
             }
         }
 
@@ -557,7 +559,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         if let Some(&Stability{rustc_depr: Some(attr::RustcDeprecation { reason, .. }), ..})
                 = stability {
             if id != ast::DUMMY_NODE_ID {
-                lint_deprecated(Some(reason));
+                lint_deprecated(def_id, Some(reason));
             }
         }
 

--- a/src/test/compile-fail/auxiliary/deprecation-lint.rs
+++ b/src/test/compile-fail/auxiliary/deprecation-lint.rs
@@ -52,6 +52,24 @@ pub enum Enum {
 #[deprecated(since = "1.0.0", note = "text")]
 pub struct DeprecatedTupleStruct(pub isize);
 
+pub mod nested {
+    #[deprecated(since = "1.0.0", note = "text")]
+    pub struct DeprecatedStruct {
+        pub i: isize
+    }
+
+    #[deprecated(since = "1.0.0", note = "text")]
+    pub struct DeprecatedUnitStruct;
+
+    pub enum Enum {
+        #[deprecated(since = "1.0.0", note = "text")]
+        DeprecatedVariant,
+    }
+
+    #[deprecated(since = "1.0.0", note = "text")]
+    pub struct DeprecatedTupleStruct(pub isize);
+}
+
 pub struct Stable {
     #[deprecated(since = "1.0.0", note = "text")]
     pub override2: u8,

--- a/src/test/compile-fail/deprecation-lint.rs
+++ b/src/test/compile-fail/deprecation-lint.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:deprecation-lint.rs
+// ignore-tidy-linelength
 
 #![deny(deprecated)]
 #![allow(warnings)]
@@ -23,76 +24,86 @@ mod cross_crate {
         type Foo = MethodTester;
         let foo = MethodTester;
 
-        deprecated(); //~ ERROR use of deprecated item
-        foo.method_deprecated(); //~ ERROR use of deprecated item
-        Foo::method_deprecated(&foo); //~ ERROR use of deprecated item
-        <Foo>::method_deprecated(&foo); //~ ERROR use of deprecated item
-        foo.trait_deprecated(); //~ ERROR use of deprecated item
-        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated item
-        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated item
-        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated item
+        deprecated(); //~ ERROR use of deprecated item 'deprecation_lint::deprecated'
+        foo.method_deprecated(); //~ ERROR use of deprecated item 'deprecation_lint::MethodTester::method_deprecated'
+        Foo::method_deprecated(&foo); //~ ERROR use of deprecated item 'deprecation_lint::MethodTester::method_deprecated'
+        <Foo>::method_deprecated(&foo); //~ ERROR use of deprecated item 'deprecation_lint::MethodTester::method_deprecated'
+        foo.trait_deprecated(); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated'
+        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated'
+        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated'
+        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated'
 
-        deprecated_text(); //~ ERROR use of deprecated item: text
-        foo.method_deprecated_text(); //~ ERROR use of deprecated item: text
-        Foo::method_deprecated_text(&foo); //~ ERROR use of deprecated item: text
-        <Foo>::method_deprecated_text(&foo); //~ ERROR use of deprecated item: text
-        foo.trait_deprecated_text(); //~ ERROR use of deprecated item: text
-        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated item: text
-        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item: text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item: text
+        deprecated_text(); //~ ERROR use of deprecated item 'deprecation_lint::deprecated_text': text
+        foo.method_deprecated_text(); //~ ERROR use of deprecated item 'deprecation_lint::MethodTester::method_deprecated_text': text
+        Foo::method_deprecated_text(&foo); //~ ERROR use of deprecated item 'deprecation_lint::MethodTester::method_deprecated_text': text
+        <Foo>::method_deprecated_text(&foo); //~ ERROR use of deprecated item 'deprecation_lint::MethodTester::method_deprecated_text': text
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
+        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
+        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
 
-        let _ = DeprecatedStruct { //~ ERROR use of deprecated item
-            i: 0 //~ ERROR use of deprecated item
+        let _ = DeprecatedStruct { //~ ERROR use of deprecated item 'deprecation_lint::DeprecatedStruct': text
+            i: 0 //~ ERROR use of deprecated item 'deprecation_lint::DeprecatedStruct::i': text
         };
 
-        let _ = DeprecatedUnitStruct; //~ ERROR use of deprecated item
+        let _ = DeprecatedUnitStruct; //~ ERROR use of deprecated item 'deprecation_lint::DeprecatedUnitStruct': text
 
-        let _ = Enum::DeprecatedVariant; //~ ERROR use of deprecated item
+        let _ = Enum::DeprecatedVariant; //~ ERROR use of deprecated item 'deprecation_lint::Enum::DeprecatedVariant': text
 
-        let _ = DeprecatedTupleStruct (1); //~ ERROR use of deprecated item
+        let _ = DeprecatedTupleStruct (1); //~ ERROR use of deprecated item 'deprecation_lint::DeprecatedTupleStruct': text
+
+        let _ = nested::DeprecatedStruct { //~ ERROR use of deprecated item 'deprecation_lint::nested::DeprecatedStruct': text
+            i: 0 //~ ERROR use of deprecated item 'deprecation_lint::nested::DeprecatedStruct::i': text
+        };
+
+        let _ = nested::DeprecatedUnitStruct; //~ ERROR use of deprecated item 'deprecation_lint::nested::DeprecatedUnitStruct': text
+
+        let _ = nested::Enum::DeprecatedVariant; //~ ERROR use of deprecated item 'deprecation_lint::nested::Enum::DeprecatedVariant': text
+
+        let _ = nested::DeprecatedTupleStruct (1); //~ ERROR use of deprecated item 'deprecation_lint::nested::DeprecatedTupleStruct': text
 
         // At the moment, the lint checker only checks stability in
         // in the arguments of macros.
         // Eventually, we will want to lint the contents of the
         // macro in the module *defining* it. Also, stability levels
         // on macros themselves are not yet linted.
-        macro_test_arg!(deprecated_text()); //~ ERROR use of deprecated item: text
-        macro_test_arg!(macro_test_arg!(deprecated_text())); //~ ERROR use of deprecated item: text
+        macro_test_arg!(deprecated_text()); //~ ERROR use of deprecated item 'deprecation_lint::deprecated_text': text
+        macro_test_arg!(macro_test_arg!(deprecated_text())); //~ ERROR use of deprecated item 'deprecation_lint::deprecated_text': text
     }
 
     fn test_method_param<Foo: Trait>(foo: Foo) {
-        foo.trait_deprecated(); //~ ERROR use of deprecated item
-        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated item
-        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated item
-        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated item
-        foo.trait_deprecated_text(); //~ ERROR use of deprecated item: text
-        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated item: text
-        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item: text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item: text
+        foo.trait_deprecated(); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated'
+        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated'
+        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated'
+        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated'
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
+        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
+        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
     }
 
     fn test_method_object(foo: &Trait) {
-        foo.trait_deprecated(); //~ ERROR use of deprecated item
-        foo.trait_deprecated_text(); //~ ERROR use of deprecated item: text
+        foo.trait_deprecated(); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated'
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
     }
 
     struct S;
 
-    impl DeprecatedTrait for S {} //~ ERROR use of deprecated item: text
-    trait LocalTrait : DeprecatedTrait { } //~ ERROR use of deprecated item: text
+    impl DeprecatedTrait for S {} //~ ERROR use of deprecated item 'deprecation_lint::DeprecatedTrait': text
+    trait LocalTrait : DeprecatedTrait { } //~ ERROR use of deprecated item 'deprecation_lint::DeprecatedTrait': text
 
     pub fn foo() {
         let x = Stable {
             override2: 3,
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated item 'deprecation_lint::Stable::override2': text
         };
 
         let _ = x.override2;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated item 'deprecation_lint::Stable::override2': text
 
         let Stable {
             override2: _
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated item 'deprecation_lint::Stable::override2': text
         } = x;
         // all fine
         let Stable { .. } = x;
@@ -100,56 +111,56 @@ mod cross_crate {
         let x = Stable2(1, 2, 3);
 
         let _ = x.2;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated item 'deprecation_lint::Stable2::2': text
 
         let Stable2(_,
                    _,
                    _)
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated item 'deprecation_lint::Stable2::2': text
             = x;
         // all fine
         let Stable2(..) = x;
 
         let x = Deprecated {
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated': text
             inherit: 1,
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated::inherit': text
         };
 
         let _ = x.inherit;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated::inherit': text
 
         let Deprecated {
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated': text
             inherit: _,
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated::inherit': text
         } = x;
 
         let Deprecated
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated': text
             { .. } = x;
 
         let x = Deprecated2(1, 2, 3);
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated2': text
 
         let _ = x.0;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated2::0': text
         let _ = x.1;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated2::1': text
         let _ = x.2;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated2::2': text
 
         let Deprecated2
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated2': text
             (_,
-             //~^ ERROR use of deprecated item
+             //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated2::0': text
              _,
-             //~^ ERROR use of deprecated item
+             //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated2::1': text
              _)
-             //~^ ERROR use of deprecated item
+             //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated2::2': text
             = x;
         let Deprecated2
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated2': text
             // the patterns are all fine:
             (..) = x;
     }
@@ -159,7 +170,7 @@ mod inheritance {
     use deprecation_lint::*;
 
     fn test_inheritance() {
-        deprecated_mod::deprecated(); //~ ERROR use of deprecated item
+        deprecated_mod::deprecated(); //~ ERROR use of deprecated item 'deprecation_lint::deprecated_mod::deprecated': text
     }
 }
 
@@ -209,7 +220,27 @@ mod this_crate {
     #[deprecated(since = "1.0.0", note = "text")]
     pub struct DeprecatedTupleStruct(isize);
 
+    mod nested {
+        #[deprecated(since = "1.0.0", note = "text")]
+        pub struct DeprecatedStruct {
+            i: isize
+        }
+
+        #[deprecated(since = "1.0.0", note = "text")]
+        pub struct DeprecatedUnitStruct;
+
+        pub enum Enum {
+            #[deprecated(since = "1.0.0", note = "text")]
+            DeprecatedVariant,
+        }
+
+        #[deprecated(since = "1.0.0", note = "text")]
+        pub struct DeprecatedTupleStruct(pub isize);
+    }
+
     fn test() {
+        use self::nested;
+
         // Only the deprecated cases of the following should generate
         // errors, because other stability attributes now have meaning
         // only *across* crates, not within a single crate.
@@ -217,56 +248,75 @@ mod this_crate {
         type Foo = MethodTester;
         let foo = MethodTester;
 
-        deprecated(); //~ ERROR use of deprecated item
-        foo.method_deprecated(); //~ ERROR use of deprecated item
-        Foo::method_deprecated(&foo); //~ ERROR use of deprecated item
-        <Foo>::method_deprecated(&foo); //~ ERROR use of deprecated item
-        foo.trait_deprecated(); //~ ERROR use of deprecated item
-        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated item
-        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated item
-        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated item
+        deprecated(); //~ ERROR use of deprecated item 'this_crate::deprecated'
+        foo.method_deprecated(); //~ ERROR use of deprecated item 'this_crate::MethodTester::method_deprecated'
+        Foo::method_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::MethodTester::method_deprecated'
+        <Foo>::method_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::MethodTester::method_deprecated'
+        foo.trait_deprecated(); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
+        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
+        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
+        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
 
-        deprecated_text(); //~ ERROR use of deprecated item: text
-        foo.method_deprecated_text(); //~ ERROR use of deprecated item: text
-        Foo::method_deprecated_text(&foo); //~ ERROR use of deprecated item: text
-        <Foo>::method_deprecated_text(&foo); //~ ERROR use of deprecated item: text
-        foo.trait_deprecated_text(); //~ ERROR use of deprecated item: text
-        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated item: text
-        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item: text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item: text
+        deprecated_text(); //~ ERROR use of deprecated item 'this_crate::deprecated_text': text
+        foo.method_deprecated_text(); //~ ERROR use of deprecated item 'this_crate::MethodTester::method_deprecated_text': text
+        Foo::method_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::MethodTester::method_deprecated_text': text
+        <Foo>::method_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::MethodTester::method_deprecated_text': text
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
 
         let _ = DeprecatedStruct {
-            //~^ ERROR use of deprecated item
-            i: 0 //~ ERROR use of deprecated item
+            //~^ ERROR use of deprecated item 'this_crate::DeprecatedStruct': text
+            i: 0 //~ ERROR use of deprecated item 'this_crate::DeprecatedStruct::i': text
         };
 
-        let _ = DeprecatedUnitStruct; //~ ERROR use of deprecated item
+        let _ = DeprecatedUnitStruct; //~ ERROR use of deprecated item 'this_crate::DeprecatedUnitStruct': text
 
-        let _ = Enum::DeprecatedVariant; //~ ERROR use of deprecated item
+        let _ = Enum::DeprecatedVariant; //~ ERROR use of deprecated item 'this_crate::Enum::DeprecatedVariant': text
 
-        let _ = DeprecatedTupleStruct (1); //~ ERROR use of deprecated item
+        let _ = DeprecatedTupleStruct (1); //~ ERROR use of deprecated item 'this_crate::DeprecatedTupleStruct': text
+
+        let _ = nested::DeprecatedStruct {
+            //~^ ERROR use of deprecated item 'this_crate::nested::DeprecatedStruct': text
+            i: 0 //~ ERROR use of deprecated item 'this_crate::nested::DeprecatedStruct::i': text
+        };
+
+        let _ = nested::DeprecatedUnitStruct; //~ ERROR use of deprecated item 'this_crate::nested::DeprecatedUnitStruct': text
+
+        let _ = nested::Enum::DeprecatedVariant; //~ ERROR use of deprecated item 'this_crate::nested::Enum::DeprecatedVariant': text
+
+        let _ = nested::DeprecatedTupleStruct (1); //~ ERROR use of deprecated item 'this_crate::nested::DeprecatedTupleStruct': text
     }
 
     fn test_method_param<Foo: Trait>(foo: Foo) {
-        foo.trait_deprecated(); //~ ERROR use of deprecated item
-        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated item
-        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated item
-        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated item
-        foo.trait_deprecated_text(); //~ ERROR use of deprecated item: text
-        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated item: text
-        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item: text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item: text
+        foo.trait_deprecated(); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
+        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
+        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
+        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
     }
 
     fn test_method_object(foo: &Trait) {
-        foo.trait_deprecated(); //~ ERROR use of deprecated item
-        foo.trait_deprecated_text(); //~ ERROR use of deprecated item: text
+        foo.trait_deprecated(); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
     }
 
     #[deprecated(since = "1.0.0", note = "text")]
     fn test_fn_body() {
         fn fn_in_body() {}
         fn_in_body();
+    }
+
+    fn test_fn_closure_body() {
+        let _ = || {
+            #[deprecated]
+            fn bar() { }
+            bar(); //~ ERROR use of deprecated item 'this_crate::test_fn_closure_body::{{closure}}::bar'
+        };
     }
 
     impl MethodTester {
@@ -284,9 +334,9 @@ mod this_crate {
 
     struct S;
 
-    impl DeprecatedTrait for S { } //~ ERROR use of deprecated item
+    impl DeprecatedTrait for S { } //~ ERROR use of deprecated item 'this_crate::DeprecatedTrait': text
 
-    trait LocalTrait : DeprecatedTrait { } //~ ERROR use of deprecated item
+    trait LocalTrait : DeprecatedTrait { } //~ ERROR use of deprecated item 'this_crate::DeprecatedTrait': text
 }
 
 mod this_crate2 {
@@ -312,15 +362,15 @@ mod this_crate2 {
     pub fn foo() {
         let x = Stable {
             override2: 3,
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated item 'this_crate2::Stable::override2': text
         };
 
         let _ = x.override2;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated item 'this_crate2::Stable::override2': text
 
         let Stable {
             override2: _
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated item 'this_crate2::Stable::override2': text
         } = x;
         // all fine
         let Stable { .. } = x;
@@ -328,57 +378,57 @@ mod this_crate2 {
         let x = Stable2(1, 2, 3);
 
         let _ = x.2;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated item 'this_crate2::Stable2::2': text
 
         let Stable2(_,
                    _,
                    _)
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated item 'this_crate2::Stable2::2': text
             = x;
         // all fine
         let Stable2(..) = x;
 
         let x = Deprecated {
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated item 'this_crate2::Deprecated': text
             inherit: 1,
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated item 'this_crate2::Deprecated::inherit': text
         };
 
         let _ = x.inherit;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated item 'this_crate2::Deprecated::inherit': text
 
         let Deprecated {
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated item 'this_crate2::Deprecated': text
             inherit: _,
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated item 'this_crate2::Deprecated::inherit': text
         } = x;
 
         let Deprecated
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated item 'this_crate2::Deprecated': text
             // the patterns are all fine:
             { .. } = x;
 
         let x = Deprecated2(1, 2, 3);
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated item 'this_crate2::Deprecated2': text
 
         let _ = x.0;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated item 'this_crate2::Deprecated2::0': text
         let _ = x.1;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated item 'this_crate2::Deprecated2::1': text
         let _ = x.2;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated item 'this_crate2::Deprecated2::2': text
 
         let Deprecated2
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated item 'this_crate2::Deprecated2': text
             (_,
-             //~^ ERROR use of deprecated item
+             //~^ ERROR use of deprecated item 'this_crate2::Deprecated2::0': text
              _,
-             //~^ ERROR use of deprecated item
+             //~^ ERROR use of deprecated item 'this_crate2::Deprecated2::1': text
              _)
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated item 'this_crate2::Deprecated2::2': text
             = x;
         let Deprecated2
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated item 'this_crate2::Deprecated2': text
             // the patterns are all fine:
             (..) = x;
     }

--- a/src/test/compile-fail/lint-output-format-2.rs
+++ b/src/test/compile-fail/lint-output-format-2.rs
@@ -18,13 +18,13 @@
 
 extern crate lint_output_format;
 use lint_output_format::{foo, bar};
-//~^ WARNING use of deprecated item: text
+//~^ WARNING use of deprecated item 'lint_output_format::foo': text
 //~| NOTE #[warn(deprecated)] on by default
 
 #[rustc_error]
 fn main() { //~ ERROR: compilation successful
     let _x = foo();
-    //~^ WARNING use of deprecated item: text
+    //~^ WARNING use of deprecated item 'lint_output_format::foo': text
     //~| NOTE #[warn(deprecated)] on by default
     let _y = bar();
 }

--- a/src/test/compile-fail/lint-stability-deprecated.rs
+++ b/src/test/compile-fail/lint-stability-deprecated.rs
@@ -12,6 +12,7 @@
 // aux-build:inherited_stability.rs
 // aux-build:stability_cfg1.rs
 // aux-build:stability_cfg2.rs
+// ignore-tidy-linelength
 
 #![warn(deprecated)]
 #![allow(dead_code, unused_extern_crates)]
@@ -32,41 +33,41 @@ mod cross_crate {
         type Foo = MethodTester;
         let foo = MethodTester;
 
-        deprecated(); //~ WARN use of deprecated item
-        foo.method_deprecated(); //~ WARN use of deprecated item
-        Foo::method_deprecated(&foo); //~ WARN use of deprecated item
-        <Foo>::method_deprecated(&foo); //~ WARN use of deprecated item
-        foo.trait_deprecated(); //~ WARN use of deprecated item
-        Trait::trait_deprecated(&foo); //~ WARN use of deprecated item
-        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated item
-        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated item
+        deprecated(); //~ WARN use of deprecated item 'lint_stability::deprecated'
+        foo.method_deprecated(); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated'
+        Foo::method_deprecated(&foo); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated'
+        <Foo>::method_deprecated(&foo); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated'
+        foo.trait_deprecated(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated'
+        Trait::trait_deprecated(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated'
+        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated'
+        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated'
 
-        deprecated_text(); //~ WARN use of deprecated item: text
-        foo.method_deprecated_text(); //~ WARN use of deprecated item: text
-        Foo::method_deprecated_text(&foo); //~ WARN use of deprecated item: text
-        <Foo>::method_deprecated_text(&foo); //~ WARN use of deprecated item: text
-        foo.trait_deprecated_text(); //~ WARN use of deprecated item: text
-        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated item: text
-        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated item: text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated item: text
+        deprecated_text(); //~ WARN use of deprecated item 'lint_stability::deprecated_text': text
+        foo.method_deprecated_text(); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated_text': text
+        Foo::method_deprecated_text(&foo); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated_text': text
+        <Foo>::method_deprecated_text(&foo); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated_text': text
+        foo.trait_deprecated_text(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
+        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
+        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
 
-        deprecated_unstable(); //~ WARN use of deprecated item
-        foo.method_deprecated_unstable(); //~ WARN use of deprecated item
-        Foo::method_deprecated_unstable(&foo); //~ WARN use of deprecated item
-        <Foo>::method_deprecated_unstable(&foo); //~ WARN use of deprecated item
-        foo.trait_deprecated_unstable(); //~ WARN use of deprecated item
-        Trait::trait_deprecated_unstable(&foo); //~ WARN use of deprecated item
-        <Foo>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated item
-        <Foo as Trait>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated item
+        deprecated_unstable(); //~ WARN use of deprecated item 'lint_stability::deprecated_unstable'
+        foo.method_deprecated_unstable(); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated_unstable'
+        Foo::method_deprecated_unstable(&foo); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated_unstable'
+        <Foo>::method_deprecated_unstable(&foo); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated_unstable'
+        foo.trait_deprecated_unstable(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable'
+        Trait::trait_deprecated_unstable(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable'
+        <Foo>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable'
+        <Foo as Trait>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable'
 
-        deprecated_unstable_text(); //~ WARN use of deprecated item: text
-        foo.method_deprecated_unstable_text(); //~ WARN use of deprecated item: text
-        Foo::method_deprecated_unstable_text(&foo); //~ WARN use of deprecated item: text
-        <Foo>::method_deprecated_unstable_text(&foo); //~ WARN use of deprecated item: text
-        foo.trait_deprecated_unstable_text(); //~ WARN use of deprecated item: text
-        Trait::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated item: text
-        <Foo>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated item: text
-        <Foo as Trait>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated item: text
+        deprecated_unstable_text(); //~ WARN use of deprecated item 'lint_stability::deprecated_unstable_text': text
+        foo.method_deprecated_unstable_text(); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated_unstable_text': text
+        Foo::method_deprecated_unstable_text(&foo); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated_unstable_text': text
+        <Foo>::method_deprecated_unstable_text(&foo); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated_unstable_text': text
+        foo.trait_deprecated_unstable_text(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
+        Trait::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
+        <Foo>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
+        <Foo as Trait>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
 
         unstable();
         foo.method_unstable();
@@ -106,30 +107,30 @@ mod cross_crate {
 
         struct S1<T: TraitWithAssociatedTypes>(T::TypeUnstable);
         struct S2<T: TraitWithAssociatedTypes>(T::TypeDeprecated);
-        //~^ WARN use of deprecated item
+        //~^ WARN use of deprecated item 'lint_stability::TraitWithAssociatedTypes::TypeDeprecated': text
 
-        let _ = DeprecatedStruct { //~ WARN use of deprecated item
-            i: 0 //~ WARN use of deprecated item
+        let _ = DeprecatedStruct { //~ WARN use of deprecated item 'lint_stability::DeprecatedStruct'
+            i: 0 //~ WARN use of deprecated item 'lint_stability::DeprecatedStruct::i'
         };
         let _ = DeprecatedUnstableStruct {
-            //~^ WARN use of deprecated item
-            i: 0 //~ WARN use of deprecated item
+            //~^ WARN use of deprecated item 'lint_stability::DeprecatedUnstableStruct'
+            i: 0 //~ WARN use of deprecated item 'lint_stability::DeprecatedUnstableStruct::i'
         };
         let _ = UnstableStruct { i: 0 };
         let _ = StableStruct { i: 0 };
 
-        let _ = DeprecatedUnitStruct; //~ WARN use of deprecated item
-        let _ = DeprecatedUnstableUnitStruct; //~ WARN use of deprecated item
+        let _ = DeprecatedUnitStruct; //~ WARN use of deprecated item 'lint_stability::DeprecatedUnitStruct'
+        let _ = DeprecatedUnstableUnitStruct; //~ WARN use of deprecated item 'lint_stability::DeprecatedUnstableUnitStruct'
         let _ = UnstableUnitStruct;
         let _ = StableUnitStruct;
 
-        let _ = Enum::DeprecatedVariant; //~ WARN use of deprecated item
-        let _ = Enum::DeprecatedUnstableVariant; //~ WARN use of deprecated item
+        let _ = Enum::DeprecatedVariant; //~ WARN use of deprecated item 'lint_stability::Enum::DeprecatedVariant'
+        let _ = Enum::DeprecatedUnstableVariant; //~ WARN use of deprecated item 'lint_stability::Enum::DeprecatedUnstableVariant'
         let _ = Enum::UnstableVariant;
         let _ = Enum::StableVariant;
 
-        let _ = DeprecatedTupleStruct (1); //~ WARN use of deprecated item
-        let _ = DeprecatedUnstableTupleStruct (1); //~ WARN use of deprecated item
+        let _ = DeprecatedTupleStruct (1); //~ WARN use of deprecated item 'lint_stability::DeprecatedTupleStruct'
+        let _ = DeprecatedUnstableTupleStruct (1); //~ WARN use of deprecated item 'lint_stability::DeprecatedUnstableTupleStruct'
         let _ = UnstableTupleStruct (1);
         let _ = StableTupleStruct (1);
 
@@ -138,28 +139,28 @@ mod cross_crate {
         // Eventually, we will want to lint the contents of the
         // macro in the module *defining* it. Also, stability levels
         // on macros themselves are not yet linted.
-        macro_test_arg!(deprecated_text()); //~ WARN use of deprecated item: text
-        macro_test_arg!(deprecated_unstable_text()); //~ WARN use of deprecated item: text
-        macro_test_arg!(macro_test_arg!(deprecated_text())); //~ WARN use of deprecated item: text
+        macro_test_arg!(deprecated_text()); //~ WARN use of deprecated item 'lint_stability::deprecated_text': text
+        macro_test_arg!(deprecated_unstable_text()); //~ WARN use of deprecated item 'lint_stability::deprecated_unstable_text': text
+        macro_test_arg!(macro_test_arg!(deprecated_text())); //~ WARN use of deprecated item 'lint_stability::deprecated_text': text
     }
 
     fn test_method_param<Foo: Trait>(foo: Foo) {
-        foo.trait_deprecated(); //~ WARN use of deprecated item
-        Trait::trait_deprecated(&foo); //~ WARN use of deprecated item
-        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated item
-        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated item
-        foo.trait_deprecated_text(); //~ WARN use of deprecated item: text
-        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated item: text
-        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated item: text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated item: text
-        foo.trait_deprecated_unstable(); //~ WARN use of deprecated item
-        Trait::trait_deprecated_unstable(&foo); //~ WARN use of deprecated item
-        <Foo>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated item
-        <Foo as Trait>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated item
-        foo.trait_deprecated_unstable_text(); //~ WARN use of deprecated item: text
-        Trait::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated item: text
-        <Foo>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated item: text
-        <Foo as Trait>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated item: text
+        foo.trait_deprecated(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated'
+        Trait::trait_deprecated(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated'
+        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated'
+        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated'
+        foo.trait_deprecated_text(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
+        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
+        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
+        foo.trait_deprecated_unstable(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable'
+        Trait::trait_deprecated_unstable(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable'
+        <Foo>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable'
+        <Foo as Trait>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable'
+        foo.trait_deprecated_unstable_text(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
+        Trait::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
+        <Foo>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
+        <Foo as Trait>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
         foo.trait_unstable();
         Trait::trait_unstable(&foo);
         <Foo>::trait_unstable(&foo);
@@ -175,10 +176,10 @@ mod cross_crate {
     }
 
     fn test_method_object(foo: &Trait) {
-        foo.trait_deprecated(); //~ WARN use of deprecated item
-        foo.trait_deprecated_text(); //~ WARN use of deprecated item: text
-        foo.trait_deprecated_unstable(); //~ WARN use of deprecated item
-        foo.trait_deprecated_unstable_text(); //~ WARN use of deprecated item: text
+        foo.trait_deprecated(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated'
+        foo.trait_deprecated_text(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
+        foo.trait_deprecated_unstable(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable'
+        foo.trait_deprecated_unstable_text(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
         foo.trait_unstable();
         foo.trait_unstable_text();
         foo.trait_stable();
@@ -187,9 +188,9 @@ mod cross_crate {
     struct S;
 
     impl UnstableTrait for S { }
-    impl DeprecatedTrait for S {} //~ WARN use of deprecated item: text
+    impl DeprecatedTrait for S {} //~ WARN use of deprecated item 'lint_stability::DeprecatedTrait': text
     trait LocalTrait : UnstableTrait { }
-    trait LocalTrait2 : DeprecatedTrait { } //~ WARN use of deprecated item: text
+    trait LocalTrait2 : DeprecatedTrait { } //~ WARN use of deprecated item 'lint_stability::DeprecatedTrait': text
 
     impl Trait for S {
         fn trait_stable(&self) {}
@@ -208,7 +209,7 @@ mod inheritance {
         stable_mod::unstable();
         stable_mod::stable();
 
-        unstable_mod::deprecated(); //~ WARN use of deprecated item
+        unstable_mod::deprecated(); //~ WARN use of deprecated item 'inheritance::inherited_stability::unstable_mod::deprecated': text
         unstable_mod::unstable();
 
         let _ = Unstable::UnstableVariant;
@@ -330,23 +331,23 @@ mod this_crate {
         type Foo = MethodTester;
         let foo = MethodTester;
 
-        deprecated(); //~ WARN use of deprecated item
-        foo.method_deprecated(); //~ WARN use of deprecated item
-        Foo::method_deprecated(&foo); //~ WARN use of deprecated item
-        <Foo>::method_deprecated(&foo); //~ WARN use of deprecated item
-        foo.trait_deprecated(); //~ WARN use of deprecated item
-        Trait::trait_deprecated(&foo); //~ WARN use of deprecated item
-        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated item
-        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated item
+        deprecated(); //~ WARN use of deprecated item 'this_crate::deprecated'
+        foo.method_deprecated(); //~ WARN use of deprecated item 'this_crate::MethodTester::method_deprecated'
+        Foo::method_deprecated(&foo); //~ WARN use of deprecated item 'this_crate::MethodTester::method_deprecated'
+        <Foo>::method_deprecated(&foo); //~ WARN use of deprecated item 'this_crate::MethodTester::method_deprecated'
+        foo.trait_deprecated(); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated'
+        Trait::trait_deprecated(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated'
+        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated'
+        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated'
 
-        deprecated_text(); //~ WARN use of deprecated item: text
-        foo.method_deprecated_text(); //~ WARN use of deprecated item: text
-        Foo::method_deprecated_text(&foo); //~ WARN use of deprecated item: text
-        <Foo>::method_deprecated_text(&foo); //~ WARN use of deprecated item: text
-        foo.trait_deprecated_text(); //~ WARN use of deprecated item: text
-        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated item: text
-        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated item: text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated item: text
+        deprecated_text(); //~ WARN use of deprecated item 'this_crate::deprecated_text': text
+        foo.method_deprecated_text(); //~ WARN use of deprecated item 'this_crate::MethodTester::method_deprecated_text': text
+        Foo::method_deprecated_text(&foo); //~ WARN use of deprecated item 'this_crate::MethodTester::method_deprecated_text': text
+        <Foo>::method_deprecated_text(&foo); //~ WARN use of deprecated item 'this_crate::MethodTester::method_deprecated_text': text
+        foo.trait_deprecated_text(); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
 
         unstable();
         foo.method_unstable();
@@ -385,34 +386,34 @@ mod this_crate {
         <Foo as Trait>::trait_stable_text(&foo);
 
         let _ = DeprecatedStruct {
-            //~^ WARN use of deprecated item
-            i: 0 //~ WARN use of deprecated item
+            //~^ WARN use of deprecated item 'this_crate::DeprecatedStruct'
+            i: 0 //~ WARN use of deprecated item 'this_crate::DeprecatedStruct::i'
         };
         let _ = UnstableStruct { i: 0 };
         let _ = StableStruct { i: 0 };
 
-        let _ = DeprecatedUnitStruct; //~ WARN use of deprecated item
+        let _ = DeprecatedUnitStruct; //~ WARN use of deprecated item 'this_crate::DeprecatedUnitStruct'
         let _ = UnstableUnitStruct;
         let _ = StableUnitStruct;
 
-        let _ = Enum::DeprecatedVariant; //~ WARN use of deprecated item
+        let _ = Enum::DeprecatedVariant; //~ WARN use of deprecated item 'this_crate::Enum::DeprecatedVariant'
         let _ = Enum::UnstableVariant;
         let _ = Enum::StableVariant;
 
-        let _ = DeprecatedTupleStruct (1); //~ WARN use of deprecated item
+        let _ = DeprecatedTupleStruct (1); //~ WARN use of deprecated item 'this_crate::DeprecatedTupleStruct'
         let _ = UnstableTupleStruct (1);
         let _ = StableTupleStruct (1);
     }
 
     fn test_method_param<Foo: Trait>(foo: Foo) {
-        foo.trait_deprecated(); //~ WARN use of deprecated item
-        Trait::trait_deprecated(&foo); //~ WARN use of deprecated item
-        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated item
-        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated item
-        foo.trait_deprecated_text(); //~ WARN use of deprecated item: text
-        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated item: text
-        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated item: text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated item: text
+        foo.trait_deprecated(); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated'
+        Trait::trait_deprecated(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated'
+        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated'
+        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated'
+        foo.trait_deprecated_text(); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
         foo.trait_unstable();
         Trait::trait_unstable(&foo);
         <Foo>::trait_unstable(&foo);
@@ -428,8 +429,8 @@ mod this_crate {
     }
 
     fn test_method_object(foo: &Trait) {
-        foo.trait_deprecated(); //~ WARN use of deprecated item
-        foo.trait_deprecated_text(); //~ WARN use of deprecated item: text
+        foo.trait_deprecated(); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated'
+        foo.trait_deprecated_text(); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
         foo.trait_unstable();
         foo.trait_unstable_text();
         foo.trait_stable();
@@ -439,7 +440,7 @@ mod this_crate {
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     fn test_fn_body() {
         fn fn_in_body() {}
-        fn_in_body(); //~ WARN use of deprecated item: text
+        fn_in_body(); //~ WARN use of deprecated item 'this_crate::test_fn_body::fn_in_body': text
     }
 
     impl MethodTester {
@@ -447,7 +448,7 @@ mod this_crate {
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         fn test_method_body(&self) {
             fn fn_in_body() {}
-            fn_in_body(); //~ WARN use of deprecated item: text
+            fn_in_body(); //~ WARN use of deprecated item 'this_crate::MethodTester::test_method_body::fn_in_body': text
         }
     }
 
@@ -459,9 +460,9 @@ mod this_crate {
 
     struct S;
 
-    impl DeprecatedTrait for S { } //~ WARN use of deprecated item
+    impl DeprecatedTrait for S { } //~ WARN use of deprecated item 'this_crate::DeprecatedTrait'
 
-    trait LocalTrait : DeprecatedTrait { } //~ WARN use of deprecated item
+    trait LocalTrait : DeprecatedTrait { } //~ WARN use of deprecated item 'this_crate::DeprecatedTrait'
 }
 
 #[rustc_error] fn main() {} //~ ERROR: compilation successful


### PR DESCRIPTION
It can sometimes be difficult to know what is actually deprecated when you have `foo.bar()` and `bar` comes from a trait in another crate.