### PR TITLE
rustc: Handle some libstd symbole exports better

### DIFF
--- a/src/liballoc_jemalloc/lib.rs
+++ b/src/liballoc_jemalloc/lib.rs
@@ -107,7 +107,7 @@ mod contents {
     // ABI
 
     #[no_mangle]
-    #[linkage = "external"]
+    #[rustc_std_internal_symbol]
     pub unsafe extern fn __rde_alloc(size: usize,
                                      align: usize,
                                      err: *mut u8) -> *mut u8 {
@@ -122,13 +122,13 @@ mod contents {
     }
 
     #[no_mangle]
-    #[linkage = "external"]
+    #[rustc_std_internal_symbol]
     pub unsafe extern fn __rde_oom(err: *const u8) -> ! {
         System.oom((*(err as *const AllocErr)).clone())
     }
 
     #[no_mangle]
-    #[linkage = "external"]
+    #[rustc_std_internal_symbol]
     pub unsafe extern fn __rde_dealloc(ptr: *mut u8,
                                        size: usize,
                                        align: usize) {
@@ -137,7 +137,7 @@ mod contents {
     }
 
     #[no_mangle]
-    #[linkage = "external"]
+    #[rustc_std_internal_symbol]
     pub unsafe extern fn __rde_usable_size(layout: *const u8,
                                            min: *mut usize,
                                            max: *mut usize) {
@@ -153,7 +153,7 @@ mod contents {
     }
 
     #[no_mangle]
-    #[linkage = "external"]
+    #[rustc_std_internal_symbol]
     pub unsafe extern fn __rde_realloc(ptr: *mut u8,
                                        _old_size: usize,
                                        old_align: usize,
@@ -177,7 +177,7 @@ mod contents {
     }
 
     #[no_mangle]
-    #[linkage = "external"]
+    #[rustc_std_internal_symbol]
     pub unsafe extern fn __rde_alloc_zeroed(size: usize,
                                             align: usize,
                                             err: *mut u8) -> *mut u8 {
@@ -196,7 +196,7 @@ mod contents {
     }
 
     #[no_mangle]
-    #[linkage = "external"]
+    #[rustc_std_internal_symbol]
     pub unsafe extern fn __rde_alloc_excess(size: usize,
                                             align: usize,
                                             excess: *mut usize,
@@ -210,7 +210,7 @@ mod contents {
     }
 
     #[no_mangle]
-    #[linkage = "external"]
+    #[rustc_std_internal_symbol]
     pub unsafe extern fn __rde_realloc_excess(ptr: *mut u8,
                                               old_size: usize,
                                               old_align: usize,
@@ -227,7 +227,7 @@ mod contents {
     }
 
     #[no_mangle]
-    #[linkage = "external"]
+    #[rustc_std_internal_symbol]
     pub unsafe extern fn __rde_grow_in_place(ptr: *mut u8,
                                              old_size: usize,
                                              old_align: usize,
@@ -237,7 +237,7 @@ mod contents {
     }
 
     #[no_mangle]
-    #[linkage = "external"]
+    #[rustc_std_internal_symbol]
     pub unsafe extern fn __rde_shrink_in_place(ptr: *mut u8,
                                                _old_size: usize,
                                                old_align: usize,

--- a/src/librustc_allocator/expand.rs
+++ b/src/librustc_allocator/expand.rs
@@ -177,9 +177,13 @@ impl<'a> AllocFnFactory<'a> {
 
         let no_mangle = Symbol::intern("no_mangle");
         let no_mangle = self.cx.meta_word(self.span, no_mangle);
+
+        let special = Symbol::intern("rustc_std_internal_symbol");
+        let special = self.cx.meta_word(self.span, special);
         vec![
             self.cx.attribute(self.span, linkage),
             self.cx.attribute(self.span, no_mangle),
+            self.cx.attribute(self.span, special),
         ]
     }
 

--- a/src/libstd/heap.rs
+++ b/src/libstd/heap.rs
@@ -17,6 +17,7 @@ pub use alloc_system::System;
 
 #[cfg(not(test))]
 #[doc(hidden)]
+#[allow(unused_attributes)]
 pub mod __default_lib_allocator {
     use super::{System, Layout, Alloc, AllocErr};
     use ptr;
@@ -28,6 +29,7 @@ pub mod __default_lib_allocator {
     // ABI
 
     #[no_mangle]
+    #[rustc_std_internal_symbol]
     pub unsafe extern fn __rdl_alloc(size: usize,
                                      align: usize,
                                      err: *mut u8) -> *mut u8 {
@@ -42,11 +44,13 @@ pub mod __default_lib_allocator {
     }
 
     #[no_mangle]
+    #[rustc_std_internal_symbol]
     pub unsafe extern fn __rdl_oom(err: *const u8) -> ! {
         System.oom((*(err as *const AllocErr)).clone())
     }
 
     #[no_mangle]
+    #[rustc_std_internal_symbol]
     pub unsafe extern fn __rdl_dealloc(ptr: *mut u8,
                                        size: usize,
                                        align: usize) {
@@ -54,6 +58,7 @@ pub mod __default_lib_allocator {
     }
 
     #[no_mangle]
+    #[rustc_std_internal_symbol]
     pub unsafe extern fn __rdl_usable_size(layout: *const u8,
                                            min: *mut usize,
                                            max: *mut usize) {
@@ -63,6 +68,7 @@ pub mod __default_lib_allocator {
     }
 
     #[no_mangle]
+    #[rustc_std_internal_symbol]
     pub unsafe extern fn __rdl_realloc(ptr: *mut u8,
                                        old_size: usize,
                                        old_align: usize,
@@ -81,6 +87,7 @@ pub mod __default_lib_allocator {
     }
 
     #[no_mangle]
+    #[rustc_std_internal_symbol]
     pub unsafe extern fn __rdl_alloc_zeroed(size: usize,
                                             align: usize,
                                             err: *mut u8) -> *mut u8 {
@@ -95,6 +102,7 @@ pub mod __default_lib_allocator {
     }
 
     #[no_mangle]
+    #[rustc_std_internal_symbol]
     pub unsafe extern fn __rdl_alloc_excess(size: usize,
                                             align: usize,
                                             excess: *mut usize,
@@ -113,6 +121,7 @@ pub mod __default_lib_allocator {
     }
 
     #[no_mangle]
+    #[rustc_std_internal_symbol]
     pub unsafe extern fn __rdl_realloc_excess(ptr: *mut u8,
                                               old_size: usize,
                                               old_align: usize,
@@ -135,6 +144,7 @@ pub mod __default_lib_allocator {
     }
 
     #[no_mangle]
+    #[rustc_std_internal_symbol]
     pub unsafe extern fn __rdl_grow_in_place(ptr: *mut u8,
                                              old_size: usize,
                                              old_align: usize,
@@ -149,6 +159,7 @@ pub mod __default_lib_allocator {
     }
 
     #[no_mangle]
+    #[rustc_std_internal_symbol]
     pub unsafe extern fn __rdl_shrink_in_place(ptr: *mut u8,
                                                old_size: usize,
                                                old_align: usize,

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -917,6 +917,12 @@ pub const BUILTIN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeG
                                  "allow_fail attribute is currently unstable",
                                  cfg_fn!(allow_fail))),
 
+    ("rustc_std_internal_symbol", Whitelisted, Gated(Stability::Unstable,
+                                     "rustc_attrs",
+                                     "this is an internal attribute that will \
+                                      never be stable",
+                                     cfg_fn!(rustc_attrs))),
+
     // Crate level attributes
     ("crate_name", CrateLevel, Ungated),
     ("crate_type", CrateLevel, Ungated),

--- a/src/test/run-make/cdylib-fewer-symbols/Makefile
+++ b/src/test/run-make/cdylib-fewer-symbols/Makefile
@@ -1,0 +1,17 @@
+# Test that allocator-related symbols don't show up as exported from a cdylib as
+# they're internal to Rust and not part of the public ABI.
+
+-include ../tools.mk
+
+ifdef IS_MSVC
+all:
+	true
+else
+all:
+	$(RUSTC) foo.rs
+	nm -g "$(call DYLIB,foo)"
+	nm -g "$(call DYLIB,foo)" | grep -vq __rdl_
+	nm -g "$(call DYLIB,foo)" | grep -vq __rde_
+	nm -g "$(call DYLIB,foo)" | grep -vq __rg_
+	nm -g "$(call DYLIB,foo)" | grep -vq __rust_
+endif

--- a/src/test/run-make/cdylib-fewer-symbols/foo.rs
+++ b/src/test/run-make/cdylib-fewer-symbols/foo.rs
@@ -1,0 +1,16 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "cdylib"]
+
+#[no_mangle]
+pub extern fn foo() -> u32 {
+    3
+}


### PR DESCRIPTION
Right now symbol exports, particularly in a cdylib, are handled by
assuming that `pub extern` combined with `#[no_mangle]` means "export
this". This isn't actually what we want for some symbols that the
standard library uses to implement itself, for example symbols related
to allocation. Additionally other special symbols like
`rust_eh_personallity` have no need to be exported from cdylib crate
types (only needed in dylib crate types).

This commit updates how rustc handles these special symbols by adding to
the hardcoded logic of symbols like `rust_eh_personallity` but also
adding a new attribute, `#[rustc_std_internal_symbol]`, which forces the
export level to be considered the same as all other Rust functions
instead of looking like a C function.

The eventual goal here is to prevent functions like `__rdl_alloc` from
showing up as part of a Rust cdylib as it's just an internal
implementation detail. This then further allows such symbols to get gc'd
by the linker when creating a cdylib.