### PR TITLE
add -Zunpretty=hir-tree

### DIFF
--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -77,6 +77,7 @@ pub enum PpFlowGraphMode {
 pub enum PpMode {
     PpmSource(PpSourceMode),
     PpmHir(PpSourceMode),
+    PpmHirTree(PpSourceMode),
     PpmFlowGraph(PpFlowGraphMode),
     PpmMir,
     PpmMirCFG,
@@ -93,6 +94,7 @@ impl PpMode {
             PpmSource(PpmExpandedIdentified) |
             PpmSource(PpmExpandedHygiene) |
             PpmHir(_) |
+            PpmHirTree(_) |
             PpmMir |
             PpmMirCFG |
             PpmFlowGraph(_) => true,
@@ -125,6 +127,7 @@ pub fn parse_pretty(sess: &Session,
         ("hir", true) => PpmHir(PpmNormal),
         ("hir,identified", true) => PpmHir(PpmIdentified),
         ("hir,typed", true) => PpmHir(PpmTyped),
+        ("hir-tree", true) => PpmHirTree(PpmNormal),
         ("mir", true) => PpmMir,
         ("mir-cfg", true) => PpmMirCFG,
         ("flowgraph", true) => PpmFlowGraph(PpFlowGraphMode::Default),
@@ -969,6 +972,23 @@ pub fn print_after_hir_lowering<'tcx, 'a: 'tcx>(sess: &'a Session,
                 })
             }
 
+            (PpmHirTree(s), None) => {
+                let out: &mut Write = &mut out;
+                s.call_with_pp_support_hir(sess,
+                                           cstore,
+                                           hir_map,
+                                           analysis,
+                                           resolutions,
+                                           arena,
+                                           arenas,
+                                           output_filenames,
+                                           crate_name,
+                                           move |_annotation, krate| {
+                    debug!("pretty printing source code {:?}", s);
+                    write!(out, "{:#?}", krate)
+                })
+            }
+
             (PpmHir(s), Some(uii)) => {
                 let out: &mut Write = &mut out;
                 s.call_with_pp_support_hir(sess,
@@ -1003,6 +1023,28 @@ pub fn print_after_hir_lowering<'tcx, 'a: 'tcx>(sess: &'a Session,
                     pp_state.s.eof()
                 })
             }
+
+            (PpmHirTree(s), Some(uii)) => {
+                let out: &mut Write = &mut out;
+                s.call_with_pp_support_hir(sess,
+                                           cstore,
+                                           hir_map,
+                                           analysis,
+                                           resolutions,
+                                           arena,
+                                           arenas,
+                                           output_filenames,
+                                           crate_name,
+                                           move |_annotation, _krate| {
+                    debug!("pretty printing source code {:?}", s);
+                    for node_id in uii.all_matching_node_ids(hir_map) {
+                        let node = hir_map.get(node_id);
+                        write!(out, "{:#?}", node)?;
+                    }
+                    Ok(())
+                })
+            }
+
             _ => unreachable!(),
         }
         .unwrap();

--- a/src/test/run-make/hir-tree/Makefile
+++ b/src/test/run-make/hir-tree/Makefile
@@ -1,0 +1,9 @@
+-include ../tools.mk
+
+# Test that hir-tree output doens't crash and includes
+# the string constant we would expect to see.
+
+all:
+	$(RUSTC) -o $(TMPDIR)/input.hir -Z unstable-options \
+		--unpretty=hir-tree input.rs
+	grep '"Hello, Rustaceans!\\n"' $(TMPDIR)/input.hir

--- a/src/test/run-make/hir-tree/input.rs
+++ b/src/test/run-make/hir-tree/input.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    println!("Hello, Rustaceans!");
+}


### PR DESCRIPTION
This uses the debug impls to dump the raw HIR. Particularly useful when
learning how the compiler works.

cc @qmx 