### PR TITLE
Fix MIR inlining panic in generic function

### DIFF
--- a/src/librustc/ty/instance.rs
+++ b/src/librustc/ty/instance.rs
@@ -144,7 +144,7 @@ impl<'a, 'b, 'tcx> Instance<'tcx> {
             resolve_associated_item(tcx, &item, param_env, trait_def_id, substs)
         } else {
             let ty = tcx.type_of(def_id);
-            let item_type = tcx.trans_apply_param_substs(substs, &ty);
+            let item_type = tcx.trans_apply_param_substs_env(substs, param_env, &ty);
 
             let def = match item_type.sty {
                 ty::TyFnDef(..) if {

--- a/src/test/run-pass/mir-inlining/ice-issue-45493.rs
+++ b/src/test/run-pass/mir-inlining/ice-issue-45493.rs
@@ -1,0 +1,26 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:-Zmir-opt-level=2
+
+trait Array {
+    type Item;
+}
+
+fn foo<A: Array>() {
+    let _: *mut A::Item = std::ptr::null_mut();
+}
+
+struct Foo;
+impl Array for Foo { type Item = i32; }
+
+fn main() {
+    foo::<Foo>();
+}


### PR DESCRIPTION
MIR inlining calls `Instance::resolve` with a substs containing param, and `trans_apply_param_substs` panics. ~~This PR fixes it by making `Instance::resolve` return `None` if `substs.has_param_types()`, though I'm not sure if this is a right fix.~~

Fixes #45493.