### PR TITLE
ci: Fix broken link in `build-powerpc64le-toolchain.sh`

### DIFF
--- a/src/ci/docker/dist-powerpc64le-linux/build-powerpc64le-toolchain.sh
+++ b/src/ci/docker/dist-powerpc64le-linux/build-powerpc64le-toolchain.sh
@@ -23,9 +23,9 @@ SYSROOT=/usr/local/$TARGET/sysroot
 mkdir -p $SYSROOT
 pushd $SYSROOT
 
-centos_base=http://mirror.centos.org/altarch/7.3.1611/os/ppc64le/Packages
-glibc_v=2.17-157.el7
-kernel_v=3.10.0-514.el7
+centos_base=http://mirror.centos.org/altarch/7/os/ppc64le/Packages
+glibc_v=2.17-196.el7
+kernel_v=3.10.0-693.el7
 for package in glibc{,-devel,-headers}-$glibc_v kernel-headers-$kernel_v; do
   curl $centos_base/$package.ppc64le.rpm | \
     rpm2cpio - | cpio -idm


### PR DESCRIPTION
r? @rust-lang/infra 

This is just an emergency fix to keep bors running for another week. I think the numbers will be broken soon. Can we verify if this statement is still true later?

> First, download the CentOS7 glibc.ppc64le and relevant header files.
> (upstream ppc64le support wasn't added until 2.19, which el7 backported.)
