### PR TITLE
[beta] ci: Fix broken link in `build-powerpc64le-toolchain.sh` 

### DIFF
--- a/src/ci/docker/dist-powerpc64le-linux/build-powerpc64le-toolchain.sh
+++ b/src/ci/docker/dist-powerpc64le-linux/build-powerpc64le-toolchain.sh
@@ -23,7 +23,7 @@ SYSROOT=/usr/local/$TARGET/sysroot
 mkdir -p $SYSROOT
 pushd $SYSROOT
 
-centos_base=http://mirror.centos.org/altarch/7.3.1611/os/ppc64le/Packages
+centos_base=http://vault.centos.org/altarch/7.3.1611/os/ppc64le/Packages
 glibc_v=2.17-157.el7
 kernel_v=3.10.0-514.el7
 for package in glibc{,-devel,-headers}-$glibc_v kernel-headers-$kernel_v; do


### PR DESCRIPTION
This is almost a backport of #45734, but uses vault.centos.org instead for better longevity.

r? @alexcrichton cc @cuviper 