### PR TITLE
Fix #18604: next_power_of_two should panic on overflow

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -2222,6 +2222,7 @@ macro_rules! uint_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
+        #[rustc_inherit_overflow_checks]
         pub fn next_power_of_two(self) -> Self {
             self.one_less_than_next_power_of_two() + 1
         }

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -15,6 +15,7 @@
 use convert::{Infallible, TryFrom};
 use fmt;
 use intrinsics;
+use ops;
 use str::FromStr;
 
 /// Provides intentionally-wrapped arithmetic on `T`.
@@ -2222,9 +2223,9 @@ macro_rules! uint_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        #[rustc_inherit_overflow_checks]
         pub fn next_power_of_two(self) -> Self {
-            self.one_less_than_next_power_of_two() + 1
+            // Call the trait to get overflow checks
+            ops::Add::add(self.one_less_than_next_power_of_two(), 1)
         }
 
         /// Returns the smallest power of two greater than or equal to `n`. If

--- a/src/test/run-pass/next-power-of-two-overflow-debug.rs
+++ b/src/test/run-pass/next-power-of-two-overflow-debug.rs
@@ -1,0 +1,36 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -C debug_assertions=yes
+
+#![feature(i128_type)]
+
+use std::panic;
+
+fn main() {
+    macro_rules! overflow_test {
+        ($t:ident) => (
+            let r = panic::catch_unwind(|| {
+                ($t::max_value()).next_power_of_two()
+            });
+            assert!(r.is_err());
+
+            let r = panic::catch_unwind(|| {
+                (($t::max_value() >> 1) + 2).next_power_of_two()
+            });
+            assert!(r.is_err());
+        )
+    }
+    overflow_test!(u8);
+    overflow_test!(u16);
+    overflow_test!(u32);
+    overflow_test!(u64);
+    overflow_test!(u128);
+}

--- a/src/test/run-pass/next-power-of-two-overflow-ndebug.rs
+++ b/src/test/run-pass/next-power-of-two-overflow-ndebug.rs
@@ -1,0 +1,24 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -C debug_assertions=no
+
+#![feature(i128_type)]
+
+fn main() {
+    for i in 129..256 {
+        assert_eq!((i as u8).next_power_of_two(), 0);
+    }
+
+    assert_eq!(((1u16 << 15) + 1).next_power_of_two(), 0);
+    assert_eq!(((1u32 << 31) + 1).next_power_of_two(), 0);
+    assert_eq!(((1u64 << 63) + 1).next_power_of_two(), 0);
+    assert_eq!(((1u128 << 127) + 1).next_power_of_two(), 0);
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/18604

Is it possible to write a test for this?  My experiments showed `x.py test` running in release mode, so my attempt at a `#[should_panic]` didn't work.