### PR TITLE
Make last structs indexes definitions use newtype_index macro

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1834,6 +1834,7 @@ dependencies = [
  "arena 0.0.0",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc 0.0.0",
+ "rustc_data_structures 0.0.0",
  "rustc_errors 0.0.0",
  "syntax 0.0.0",
  "syntax_pos 0.0.0",

--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -45,25 +45,10 @@ pub struct DepGraph {
 }
 
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct DepNodeIndex {
-    index: u32,
-}
-
-impl Idx for DepNodeIndex {
-    fn new(idx: usize) -> Self {
-        debug_assert!((idx & 0xFFFF_FFFF) == idx);
-        DepNodeIndex { index: idx as u32 }
-    }
-    fn index(self) -> usize {
-        self.index as usize
-    }
-}
+newtype_index!(DepNodeIndex);
 
 impl DepNodeIndex {
-    const INVALID: DepNodeIndex = DepNodeIndex {
-        index: ::std::u32::MAX,
-    };
+    const INVALID: DepNodeIndex = DepNodeIndex(::std::u32::MAX);
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/librustc/hir/def_id.rs
+++ b/src/librustc/hir/def_id.rs
@@ -86,20 +86,17 @@ impl serialize::UseSpecializedDecodable for CrateNum {
 ///
 /// Since the DefIndex is mostly treated as an opaque ID, you probably
 /// don't have to care about these ranges.
-#[derive(Clone, Eq, Ord, PartialOrd, PartialEq, RustcEncodable,
-           RustcDecodable, Hash, Copy)]
-pub struct DefIndex(u32);
+newtype_index!(DefIndex
+    {
+        DEBUG_FORMAT = custom,
 
-impl Idx for DefIndex {
-    fn new(value: usize) -> Self {
-        assert!(value < (u32::MAX) as usize);
-        DefIndex(value as u32)
-    }
+        /// The start of the "high" range of DefIndexes.
+        const DEF_INDEX_HI_START = 1 << 31,
 
-    fn index(self) -> usize {
-        self.0 as usize
-    }
-}
+        /// The crate root is always assigned index 0 by the AST Map code,
+        /// thanks to `NodeCollector::new`.
+        const CRATE_DEF_INDEX = 0,
+    });
 
 impl fmt::Debug for DefIndex {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -111,12 +108,6 @@ impl fmt::Debug for DefIndex {
 }
 
 impl DefIndex {
-    #[inline]
-    pub fn new(x: usize) -> DefIndex {
-        assert!(x < (u32::MAX as usize));
-        DefIndex(x as u32)
-    }
-
     #[inline]
     pub fn from_u32(x: u32) -> DefIndex {
         DefIndex(x)
@@ -154,13 +145,6 @@ impl DefIndex {
         DefIndex::new(address_space.start() + i)
     }
 }
-
-/// The start of the "high" range of DefIndexes.
-const DEF_INDEX_HI_START: DefIndex = DefIndex(1 << 31);
-
-/// The crate root is always assigned index 0 by the AST Map code,
-/// thanks to `NodeCollector::new`.
-pub const CRATE_DEF_INDEX: DefIndex = DefIndex(0);
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub enum DefIndexAddressSpace {

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -19,7 +19,7 @@ use hir::def_id::{CrateNum, DefId, DefIndex, LOCAL_CRATE, DefIndexAddressSpace,
                   CRATE_DEF_INDEX};
 use ich::Fingerprint;
 use rustc_data_structures::fx::FxHashMap;
-use rustc_data_structures::indexed_vec::IndexVec;
+use rustc_data_structures::indexed_vec::{IndexVec, Idx};
 use rustc_data_structures::stable_hasher::StableHasher;
 use serialize::{Encodable, Decodable, Encoder, Decoder};
 use session::CrateDisambiguator;

--- a/src/librustc/infer/region_inference/graphviz.rs
+++ b/src/librustc/infer/region_inference/graphviz.rs
@@ -19,6 +19,7 @@
 use graphviz as dot;
 
 use hir::def_id::DefIndex;
+use rustc_data_structures::indexed_vec::Idx;
 use ty;
 use middle::free_region::RegionRelations;
 use middle::region;

--- a/src/librustc_data_structures/indexed_vec.rs
+++ b/src/librustc_data_structures/indexed_vec.rs
@@ -68,7 +68,7 @@ macro_rules! newtype_index {
      @pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$max:expr]
-     @debug_format [$debug_format:expr]) => (
+     @debug_format [$debug_format:tt]) => (
         #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, $($derives),*)]
         pub struct $type($($pub)* u32);
 
@@ -100,7 +100,7 @@ macro_rules! newtype_index {
     (@handle_debug
      @derives      []
      @type         [$type:ident]
-     @debug_format [$debug_format:expr]) => (
+     @debug_format [$debug_format:tt]) => (
         impl ::std::fmt::Debug for $type {
             fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 write!(fmt, $debug_format, self.0)
@@ -112,13 +112,13 @@ macro_rules! newtype_index {
     (@handle_debug
      @derives      [Debug, $($derives:ident,)*]
      @type         [$type:ident]
-     @debug_format [$debug_format:expr]) => ();
+     @debug_format [$debug_format:tt]) => ();
 
     // It's not Debug, so just pop it off the front of the derives stack and check the rest.
     (@handle_debug
      @derives      [$_derive:ident, $($derives:ident,)*]
      @type         [$type:ident]
-     @debug_format [$debug_format:expr]) => (
+     @debug_format [$debug_format:tt]) => (
         newtype_index!(
             @handle_debug
             @derives      [$($derives,)*]
@@ -129,7 +129,7 @@ macro_rules! newtype_index {
     // Handle the case where someone wants to make the internal field public
     (@type         [$type:ident]
      @max          [$max:expr]
-     @debug_format [$debug_format:expr]
+     @debug_format [$debug_format:tt]
                    pub idx
                    $($tokens:tt)*) => (
         newtype_index!(
@@ -143,7 +143,7 @@ macro_rules! newtype_index {
     // The default case is that the internal field is private
     (@type         [$type:ident]
      @max          [$max:expr]
-     @debug_format [$debug_format:expr]
+     @debug_format [$debug_format:tt]
                    $($tokens:tt)*) => (
         newtype_index!(
             @pub          []
@@ -157,7 +157,7 @@ macro_rules! newtype_index {
     (@pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$max:expr]
-     @debug_format [$debug_format:expr]
+     @debug_format [$debug_format:tt]
                    derive [$($derives:ident),*]
                    $($tokens:tt)*) => (
         newtype_index!(
@@ -174,7 +174,7 @@ macro_rules! newtype_index {
     (@pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$max:expr]
-     @debug_format [$debug_format:expr]
+     @debug_format [$debug_format:tt]
                    derive [$($derives:ident,)+]
                    ENCODABLE = custom
                    $($tokens:tt)*) => (
@@ -192,7 +192,7 @@ macro_rules! newtype_index {
     (@pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$max:expr]
-     @debug_format [$debug_format:expr]
+     @debug_format [$debug_format:tt]
                    derive [$($derives:ident,)+]
                    $($tokens:tt)*) => (
         newtype_index!(
@@ -209,7 +209,7 @@ macro_rules! newtype_index {
     (@pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$max:expr]
-     @debug_format [$debug_format:expr]
+     @debug_format [$debug_format:tt]
                    ENCODABLE = custom
                    $($tokens:tt)*) => (
         newtype_index!(
@@ -225,7 +225,7 @@ macro_rules! newtype_index {
     (@pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$max:expr]
-     @debug_format [$debug_format:expr]
+     @debug_format [$debug_format:tt]
                    $($tokens:tt)*) => (
         newtype_index!(
             @derives      [RustcDecodable, RustcEncodable,]
@@ -241,7 +241,7 @@ macro_rules! newtype_index {
      @pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$max:expr]
-     @debug_format [$debug_format:expr]
+     @debug_format [$debug_format:tt]
                    $name:ident = $constant:expr) => (
         newtype_index!(
             @derives      [$($derives,)*]
@@ -257,7 +257,7 @@ macro_rules! newtype_index {
      @pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$_max:expr]
-     @debug_format [$debug_format:expr]
+     @debug_format [$debug_format:tt]
                    $(#[doc = $doc:expr])*
                    const $name:ident = $constant:expr) => (
         newtype_index!(
@@ -274,7 +274,7 @@ macro_rules! newtype_index {
      @pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$_max:expr]
-     @debug_format [$debug_format:expr]
+     @debug_format [$debug_format:tt]
                    MAX = $max:expr,
                    $($tokens:tt)*) => (
         newtype_index!(
@@ -291,8 +291,8 @@ macro_rules! newtype_index {
      @pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$max:expr]
-     @debug_format [$_debug_format:expr]
-                   DEBUG_FORMAT = $debug_format:expr,
+     @debug_format [$_debug_format:tt]
+                   DEBUG_FORMAT = $debug_format:tt,
                    $($tokens:tt)*) => (
         newtype_index!(
             @derives      [$($derives,)*]
@@ -308,7 +308,7 @@ macro_rules! newtype_index {
      @pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$max:expr]
-     @debug_format [$debug_format:expr]
+     @debug_format [$debug_format:tt]
                    $(#[doc = $doc:expr])*
                    const $name:ident = $constant:expr,
                    $($tokens:tt)*) => (

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -41,6 +41,7 @@ use std::str;
 use std::u32;
 
 use rustc_serialize::{Decodable, Decoder, SpecializedDecoder, opaque};
+use rustc_data_structures::indexed_vec::Idx;
 use syntax::attr;
 use syntax::ast::{self, Ident};
 use syntax::codemap;

--- a/src/librustc_resolve/Cargo.toml
+++ b/src/librustc_resolve/Cargo.toml
@@ -16,3 +16,4 @@ rustc = { path = "../librustc" }
 arena = { path = "../libarena" }
 rustc_errors = { path = "../librustc_errors" }
 syntax_pos = { path = "../libsyntax_pos" }
+rustc_data_structures = { path = "../librustc_data_structures" }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -24,6 +24,7 @@ extern crate rustc_errors as errors;
 extern crate arena;
 #[macro_use]
 extern crate rustc;
+extern crate rustc_data_structures;
 
 use self::Namespace::*;
 use self::TypeParameters::*;

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -13,6 +13,7 @@ use {Module, ModuleKind, NameBinding, NameBindingKind, PathResult};
 use Namespace::{self, MacroNS};
 use build_reduced_graph::BuildReducedGraphVisitor;
 use resolve_imports::ImportResolver;
+use rustc_data_structures::indexed_vec::Idx;
 use rustc::hir::def_id::{DefId, BUILTIN_MACROS_CRATE, CRATE_DEF_INDEX, DefIndex};
 use rustc::hir::def::{Def, Export};
 use rustc::hir::map::{self, DefCollector};


### PR DESCRIPTION
This PR makes the last two index structs not using newtype_index macro to use it and also fixes this https://github.com/rust-lang/rust/issues/45763 issue.