### PR TITLE
Accept interpolated patterns in trait method parameters

### DIFF
--- a/src/librustc_passes/diagnostics.rs
+++ b/src/librustc_passes/diagnostics.rs
@@ -264,4 +264,5 @@ register_diagnostics! {
     E0226, // only a single explicit lifetime bound is permitted
     E0472, // asm! is unsupported on this target
     E0561, // patterns aren't allowed in function pointer types
+    E0642, // patterns aren't allowed in methods without bodies
 }

--- a/src/test/compile-fail/no-patterns-in-args-2.rs
+++ b/src/test/compile-fail/no-patterns-in-args-2.rs
@@ -14,7 +14,6 @@ trait Tr {
     fn f1(mut arg: u8); //~ ERROR patterns aren't allowed in methods without bodies
                         //~^ WARN was previously accepted
     fn f2(&arg: u8); //~ ERROR patterns aren't allowed in methods without bodies
-                     //~^ WARN was previously accepted
     fn g1(arg: u8); // OK
     fn g2(_: u8); // OK
     #[allow(anonymous_parameters)]

--- a/src/test/compile-fail/no-patterns-in-args-macro.rs
+++ b/src/test/compile-fail/no-patterns-in-args-macro.rs
@@ -30,8 +30,7 @@ mod bad_pat {
     m!((bad, pat));
     //~^ ERROR patterns aren't allowed in function pointer types
     //~| ERROR patterns aren't allowed in foreign function declarations
-    //~| WARN patterns aren't allowed in methods without bodies
-    //~| WARN this was previously accepted
+    //~| ERROR patterns aren't allowed in methods without bodies
 }
 
 fn main() {}

--- a/src/test/compile-fail/no-patterns-in-args-macro.rs
+++ b/src/test/compile-fail/no-patterns-in-args-macro.rs
@@ -1,0 +1,37 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! m {
+    ($pat: pat) => {
+        trait Tr {
+            fn trait_method($pat: u8);
+        }
+
+        type A = fn($pat: u8);
+
+        extern {
+            fn foreign_fn($pat: u8);
+        }
+    }
+}
+
+mod good_pat {
+    m!(good_pat); // OK
+}
+
+mod bad_pat {
+    m!((bad, pat));
+    //~^ ERROR patterns aren't allowed in function pointer types
+    //~| ERROR patterns aren't allowed in foreign function declarations
+    //~| WARN patterns aren't allowed in methods without bodies
+    //~| WARN this was previously accepted
+}
+
+fn main() {}

--- a/src/test/compile-fail/no-patterns-in-args.rs
+++ b/src/test/compile-fail/no-patterns-in-args.rs
@@ -11,21 +11,17 @@
 extern {
     fn f1(mut arg: u8); //~ ERROR patterns aren't allowed in foreign function declarations
                         //~^ NOTE pattern not allowed in foreign function
-                        //~| NOTE this is a recent error
     fn f2(&arg: u8); //~ ERROR patterns aren't allowed in foreign function declarations
                      //~^ NOTE pattern not allowed in foreign function
     fn f3(arg @ _: u8); //~ ERROR patterns aren't allowed in foreign function declarations
                         //~^ NOTE pattern not allowed in foreign function
-                        //~| NOTE this is a recent error
     fn g1(arg: u8); // OK
     fn g2(_: u8); // OK
     // fn g3(u8); // Not yet
 }
 
 type A1 = fn(mut arg: u8); //~ ERROR patterns aren't allowed in function pointer types
-                           //~^ NOTE this is a recent error
 type A2 = fn(&arg: u8); //~ ERROR patterns aren't allowed in function pointer types
-                        //~^ NOTE this is a recent error
 type B1 = fn(arg: u8); // OK
 type B2 = fn(_: u8); // OK
 type B3 = fn(u8); // OK


### PR DESCRIPTION
Permit this, basically
```rust
macro_rules! m {
    ($pat: pat) => {
        trait Tr {
            fn f($pat: u8) {}
        }
    }
}
```
it previously caused a parsing error during expansion because trait methods accept only very restricted set of patterns during parsing due to ambiguities caused by [anonymous parameters](https://github.com/rust-lang/rust/issues/41686), and this set didn't include interpolated patterns.

Some outdated messages from "no patterns allowed" errors are also removed.

Addresses https://github.com/rust-lang/rust/issues/35203#issuecomment-341937159