### PR TITLE
Highlight code on diagnostics when underlined

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -553,7 +553,12 @@ impl EmitterWriter {
                                code_offset + annotation.start_col,
                                style);
                 }
-                _ => (),
+                _ => {
+                    buffer.set_style_range(line_offset,
+                                           code_offset + annotation.start_col,
+                                           code_offset + annotation.end_col,
+                                           Style::Highlight);
+               }
             }
         }
 

--- a/src/librustc_errors/styled_buffer.rs
+++ b/src/librustc_errors/styled_buffer.rs
@@ -133,4 +133,22 @@ impl StyledBuffer {
     pub fn num_lines(&self) -> usize {
         self.text.len()
     }
+
+    pub fn set_style_range(&mut self,
+                           line: usize,
+                           col_start: usize,
+                           col_end: usize,
+                           style: Style) {
+        for col in col_start..col_end {
+            self.set_style(line, col, style);
+        }
+    }
+
+    pub fn set_style(&mut self, line: usize, col: usize, style: Style) {
+        if let Some(ref mut line) = self.styles.get_mut(line) {
+            if let Some(s) = line.get_mut(col) {
+                *s = style;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Highlight the label's span by bolding the corresponding code:

<img width="691" alt="" src="https://user-images.githubusercontent.com/1606434/32411126-5536f124-c190-11e7-92ae-1b0a82b9d7ae.png">

Fix #42112.

r? @nikomatsakis (alternative to #45752 without coloring, only highlighting)