### PR TITLE
Update reference link in doc's 404

### DIFF
--- a/src/doc/not_found.md
+++ b/src/doc/not_found.md
@@ -22,7 +22,7 @@ Some things that might be helpful to you though:
 # Reference
 
 * [The Rust official site](https://www.rust-lang.org)
-* [The Rust reference](https://doc.rust-lang.org/reference.html)
+* [The Rust reference](https://doc.rust-lang.org/reference/index.html)
 
 # Docs
 


### PR DESCRIPTION
It's currently linking to a page that says it's on the page I'm changing the link too.