### PR TITLE
Create manifests for applications by default on Windows. Also opt in to long path support by default.

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -216,6 +216,11 @@ impl Step for StdLink {
         let libdir = builder.sysroot_libdir(target_compiler, target);
         add_to_sysroot(&libdir, &libstd_stamp(build, compiler, target));
 
+        if target.contains("windows") {
+            copy(&build.src.join("src/etc/longPathAware.manifest"),
+                 &libdir.join("longPathAware.manifest"));
+        }
+
         if build.config.sanitizers && compiler.stage != 0 && target == "x86_64-apple-darwin" {
             // The sanitizers are only built in stage1 or above, so the dylibs will
             // be missing in stage0 and causes panic. See the `std()` function above

--- a/src/etc/longPathAware.manifest
+++ b/src/etc/longPathAware.manifest
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -843,6 +843,7 @@ fn link_args(cmd: &mut Linker,
 
     if crate_type == config::CrateTypeExecutable &&
        sess.target.target.options.is_like_windows {
+        cmd.application_manifest();
         if let Some(ref s) = trans.windows_subsystem {
             cmd.subsystem(s);
         }

--- a/src/librustc_trans/back/linker.rs
+++ b/src/librustc_trans/back/linker.rs
@@ -21,6 +21,7 @@ use back::symbol_export;
 use rustc::hir::def_id::{LOCAL_CRATE, CrateNum};
 use rustc::middle::dependency_format::Linkage;
 use rustc::session::Session;
+use rustc::session::search_paths::PathKind;
 use rustc::session::config::{self, CrateType, OptLevel, DebugInfoLevel};
 use rustc::ty::TyCtxt;
 use rustc_back::LinkerFlavor;
@@ -112,6 +113,7 @@ pub trait Linker {
     fn args(&mut self, args: &[String]);
     fn export_symbols(&mut self, tmpdir: &Path, crate_type: CrateType);
     fn subsystem(&mut self, subsystem: &str);
+    fn application_manifest(&mut self);
     // Should have been finalize(self), but we don't support self-by-value on trait objects (yet?).
     fn finalize(&mut self) -> Command;
 }
@@ -370,6 +372,10 @@ impl<'a> Linker for GccLinker<'a> {
         self.linker_arg(&format!("--subsystem,{}", subsystem));
     }
 
+    fn application_manifest(&mut self) {
+        // noop
+    }
+
     fn finalize(&mut self) -> Command {
         self.hint_dynamic(); // Reset to default before returning the composed command line.
         let mut cmd = Command::new("");
@@ -587,6 +593,16 @@ impl<'a> Linker for MsvcLinker<'a> {
         }
     }
 
+    fn application_manifest(&mut self) {
+        self.cmd.arg("/MANIFEST:EMBED");
+        self.cmd.arg("/MANIFESTUAC");
+        let mut arg = OsString::from("/MANIFESTINPUT:");
+        let mut manifest = self.sess.target_filesearch(PathKind::All).get_lib_path();
+        manifest.push("longPathAware.manifest");
+        arg.push(manifest);
+        self.cmd.arg(arg);
+    }
+
     fn finalize(&mut self) -> Command {
         let mut cmd = Command::new("");
         ::std::mem::swap(&mut cmd, &mut self.cmd);
@@ -734,6 +750,10 @@ impl<'a> Linker for EmLinker<'a> {
     }
 
     fn subsystem(&mut self, _subsystem: &str) {
+        // noop
+    }
+
+    fn application_manifest(&mut self) {
         // noop
     }
 


### PR DESCRIPTION
cc @retep998