### PR TITLE
rustbuild: Re-enable ThinLTO for MIPS

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -625,8 +625,7 @@ impl<'a> Builder<'a> {
 
             if mode != Mode::Libstd && // FIXME(#45320)
                self.config.rust_codegen_units.is_none() &&
-               self.build.is_rust_llvm(compiler.host) &&
-               !target.contains("mips") // FIXME(#45654)
+               self.build.is_rust_llvm(compiler.host)
             {
                 cargo.env("RUSTC_THINLTO", "1");
             }


### PR DESCRIPTION
Now that the upstream LLVM bug is now fixed this commit cherry-picks the commit
onto our LLVM and then re-enables the ThinLTO paths for MIPS.

Closes #45654