### PR TITLE
rustdoc: tweak notes on ignore/compile_fail examples

### DIFF
--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -42,7 +42,7 @@ pub fn render_with_highlighting(src: &str, class: Option<&str>, id: Option<&str>
 
     let mut out = Vec::new();
     if let Some((tooltip, class)) = tooltip {
-        write!(out, "<div class='information'><div class='tooltip {}'>⚠<span \
+        write!(out, "<div class='information'><div class='tooltip {}'>ⓘ<span \
                      class='tooltiptext'>{}</span></div></div>",
                class, tooltip).unwrap();
     }

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -228,9 +228,9 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for CodeBlocks<'a, I> {
                 ))
             });
             let tooltip = if ignore {
-                Some(("Be careful when using this code, it's not being tested!", "ignore"))
+                Some(("This example is not tested", "ignore"))
             } else if compile_fail {
-                Some(("This code doesn't compile so be extra careful!", "compile_fail"))
+                Some(("This example deliberately fails to compile", "compile_fail"))
             } else {
                 None
             };
@@ -639,9 +639,9 @@ pub fn render(w: &mut fmt::Formatter,
                     ))
                 });
                 let tooltip = if ignore {
-                    Some(("Be careful when using this code, it's not being tested!", "ignore"))
+                    Some(("This example is not tested", "ignore"))
                 } else if compile_fail {
-                    Some(("This code doesn't compile so be extra careful!", "compile_fail"))
+                    Some(("This example deliberately fails to compile", "compile_fail"))
                 } else {
                     None
                 };

--- a/src/test/rustdoc/codeblock-title.rs
+++ b/src/test/rustdoc/codeblock-title.rs
@@ -12,8 +12,8 @@
 
 // ignore-tidy-linelength
 
-// @has foo/fn.bar.html '//*[@class="tooltip compile_fail"]/span' "This code doesn't compile so be extra careful!"
-// @has foo/fn.bar.html '//*[@class="tooltip ignore"]/span' "Be careful when using this code, it's not being tested!"
+// @has foo/fn.bar.html '//*[@class="tooltip compile_fail"]/span' "This example deliberately fails to compile"
+// @has foo/fn.bar.html '//*[@class="tooltip ignore"]/span' "This example is not tested"
 
 /// foo
 ///


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/44927

This is a softening of these notices to mention *why* a given example has a given callout, rather then telling viewers to be careful with an example. It also changes the character used for these samples from a warning logo to a circle-i/information logo.

![image](https://user-images.githubusercontent.com/5217170/32464361-5fbb5d9e-c305-11e7-8482-ce71b97a54df.png)
