### PR TITLE
Correctly format `extern crate` conflict resolution help

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3684,14 +3684,14 @@ impl<'a> Resolver<'a> {
                           container));
 
         err.span_label(span, format!("`{}` re{} here", name, new_participle));
-        if old_binding.span != syntax_pos::DUMMY_SP {
+        if old_binding.span != DUMMY_SP {
             err.span_label(old_binding.span, format!("previous {} of the {} `{}` here",
                                                       old_noun, old_kind, name));
         }
 
         // See https://github.com/rust-lang/rust/issues/32354
         if old_binding.is_import() || new_binding.is_import() {
-            let binding = if new_binding.is_import() {
+            let binding = if new_binding.is_import() && new_binding.span != DUMMY_SP {
                 new_binding
             } else {
                 old_binding

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5739,9 +5739,11 @@ impl<'a> Parser<'a> {
         } else {
             (None, crate_name)
         };
+
+        // We grab this before expecting the `;` so it's not a part of the span
+        let prev_span = self.prev_span;
         self.expect(&token::Semi)?;
 
-        let prev_span = self.prev_span;
         Ok(self.mk_item(lo.to(prev_span),
                         ident,
                         ItemKind::ExternCrate(maybe_path),

--- a/src/test/ui/suggestions/issue-45799-bad-extern-crate-rename-suggestion-formatting.rs
+++ b/src/test/ui/suggestions/issue-45799-bad-extern-crate-rename-suggestion-formatting.rs
@@ -1,0 +1,12 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate std;
+fn main() {}

--- a/src/test/ui/suggestions/issue-45799-bad-extern-crate-rename-suggestion-formatting.stderr
+++ b/src/test/ui/suggestions/issue-45799-bad-extern-crate-rename-suggestion-formatting.stderr
@@ -1,0 +1,14 @@
+error[E0259]: the name `std` is defined multiple times
+  --> $DIR/issue-45799-bad-extern-crate-rename-suggestion-formatting.rs:11:1
+   |
+11 | extern crate std;
+   | ^^^^^^^^^^^^^^^^ `std` reimported here
+   |
+   = note: `std` must be defined only once in the type namespace of this module
+help: You can use `as` to change the binding name of the import
+   |
+11 | extern crate std as Otherstd;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Closes #45799.

Following the advice given in the issue, I changed the parsing of `extern crate` statements to grab the span *before* it includes the semicolon, fixing the formatting issue. All of the UI tests, oddly enough, passed on the first run without any modification (hopefully CI tells the same story).

There was one small problem that I had to work around. If `extern crate std;` was placed on the *very first line* of the file, the outputted suggestion formatting was malformed. I solved this by checking to make sure that the `new_binding`'s span didn't equal `DUMMY_SP` when determining which binding to display the suggestion for. Note that, although unrelated to this particular PR, the output for line 1 vs. any other line still differs:

```
~/p/local-rust-dev-testing ❯❯❯ cargo +local-s1 build
   Compiling local-rust-dev-testing v0.1.0 (file:///home/cldfire/programming_projects/local-rust-dev-testing)
error[E0259]: the name `std` is defined multiple times
  |
  = note: `std` must be defined only once in the type namespace of this module
help: You can use `as` to change the binding name of the import
  |
1 | extern crate std as Otherstd;
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

```
~/p/local-rust-dev-testing ❯❯❯ cargo +local-s1 build
   Compiling local-rust-dev-testing v0.1.0 (file:///home/cldfire/programming_projects/local-rust-dev-testing)
error[E0259]: the name `std` is defined multiple times
 --> src/main.rs:2:1
  |
2 | extern crate std;
  | ^^^^^^^^^^^^^^^^ `std` reimported here
  |
  = note: `std` must be defined only once in the type namespace of this module
help: You can use `as` to change the binding name of the import
  |
2 | extern crate std as Otherstd;
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

It's an incredibly niche circumstance, though, so I don't think it's worth opening an issue about. If anyone believes otherwise, feel free to do so.