### PR TITLE
Warn about lack of args glob expansion in Windows shell

### DIFF
--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -671,6 +671,10 @@ pub struct ArgsOs { inner: sys::args::Args }
 /// set to arbitrary text, and may not even exist. This means this property should
 /// not be relied upon for security purposes.
 ///
+/// On Unix systems shell usually expands unquoted arguments with glob patterns
+/// (such as `*` and `?`). On Windows this is not done, and such arguments are
+/// passed as-is.
+///
 /// # Panics
 ///
 /// The returned iterator will panic during iteration if any argument to the


### PR DESCRIPTION
Because all shells on Linux/macOS expand globs, and even MinGW on Windows emulates this behavior, it's easy to forget that Windows by itself doesn't support glob expansion. This PR documents this cross-platform difference.