### PR TITLE
Add read, read_string, and write functions to std::fs

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -244,7 +244,7 @@ pub struct DirBuilder {
 /// # Ok(())
 /// # }
 /// ```
-#[unstable(feature = "fs_read_write", issue = /* FIXME */ "0")]
+#[unstable(feature = "fs_read_write", issue = "46588")]
 pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
     let mut bytes = Vec::new();
     File::open(path)?.read_to_end(&mut bytes)?;
@@ -285,7 +285,7 @@ pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
 /// # Ok(())
 /// # }
 /// ```
-#[unstable(feature = "fs_read_write", issue = /* FIXME */ "0")]
+#[unstable(feature = "fs_read_write", issue = "46588")]
 pub fn read_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
     let mut string = String::new();
     File::open(path)?.read_to_string(&mut string)?;
@@ -315,7 +315,7 @@ pub fn read_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
 /// # Ok(())
 /// # }
 /// ```
-#[unstable(feature = "fs_read_write", issue = /* FIXME */ "0")]
+#[unstable(feature = "fs_read_write", issue = "46588")]
 pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result<()> {
     File::create(path)?.write_all(contents.as_ref())
 }

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -281,12 +281,12 @@ pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
 /// use std::net::SocketAddr;
 ///
 /// # fn foo() -> Result<(), Box<std::error::Error + 'static>> {
-/// let foo: SocketAddr = fs::read_utf8("address.txt")?.parse()?;
+/// let foo: SocketAddr = fs::read_string("address.txt")?.parse()?;
 /// # Ok(())
 /// # }
 /// ```
 #[unstable(feature = "fs_read_write", issue = /* FIXME */ "0")]
-pub fn read_utf8<P: AsRef<Path>>(path: P) -> io::Result<String> {
+pub fn read_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
     let mut string = String::new();
     File::open(path)?.read_to_string(&mut string)?;
     Ok(string)
@@ -3044,12 +3044,12 @@ mod tests {
         assert!(v == &bytes[..]);
 
         check!(fs::write(&tmpdir.join("not-utf8"), &[0xFF]));
-        error_contains!(fs::read_utf8(&tmpdir.join("not-utf8")),
+        error_contains!(fs::read_string(&tmpdir.join("not-utf8")),
                         "stream did not contain valid UTF-8");
 
         let s = "𐁁𐀓𐀠𐀴𐀍";
         check!(fs::write(&tmpdir.join("utf8"), s.as_bytes()));
-        let string = check!(fs::read_utf8(&tmpdir.join("utf8")));
+        let string = check!(fs::read_string(&tmpdir.join("utf8")));
         assert_eq!(string, s);
     }
 

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -316,8 +316,8 @@ pub fn read_utf8<P: AsRef<Path>>(path: P) -> io::Result<String> {
 /// # }
 /// ```
 #[unstable(feature = "fs_read_write", issue = /* FIXME */ "0")]
-pub fn write<P: AsRef<Path>>(path: P, contents: &[u8]) -> io::Result<()> {
-    File::create(path)?.write_all(contents)
+pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result<()> {
+    File::create(path)?.write_all(contents.as_ref())
 }
 
 impl File {
@@ -3039,7 +3039,7 @@ mod tests {
 
         let tmpdir = tmpdir();
 
-        check!(fs::write(&tmpdir.join("test"), &bytes));
+        check!(fs::write(&tmpdir.join("test"), &bytes[..]));
         let v = check!(fs::read(&tmpdir.join("test")));
         assert!(v == &bytes[..]);
 

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -262,6 +262,73 @@ impl File {
         OpenOptions::new().write(true).create(true).truncate(true).open(path.as_ref())
     }
 
+    /// Read the entire contents of a file into a bytes vector.
+    ///
+    /// This is a convenience function for using [`File::open`] and [`read_to_end`]
+    /// with fewer imports and without an intermediate variable.
+    ///
+    /// [`File::open`]: struct.File.html#method.open
+    /// [`read_to_end`]: ../io/trait.Read.html#method.read_to_end
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if `path` does not already exist.
+    /// Other errors may also be returned according to [`OpenOptions::open`].
+    ///
+    /// [`OpenOptions::open`]: struct.OpenOptions.html#method.open
+    ///
+    /// It will also return an error if it encounters while reading an error
+    /// of a kind other than [`ErrorKind::Interrupted`].
+    ///
+    /// [`ErrorKind::Interrupted`]: ../../std/io/enum.ErrorKind.html#variant.Interrupted
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(file_read_write_contents)]
+    ///
+    /// use std::fs::File;
+    ///
+    /// # fn foo() -> Result<(), Box<std::error::Error + 'static>> {
+    /// let foo = String::from_utf8(File::read_contents("foo.txt")?)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[unstable(feature = "file_read_write_contents", issue = /* FIXME */ "0")]
+    pub fn read_contents<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
+        let mut bytes = Vec::new();
+        File::open(path)?.read_to_end(&mut bytes)?;
+        Ok(bytes)
+    }
+
+    /// Write the give contents to a file.
+    ///
+    /// This function will create a file if it does not exist,
+    /// and will entirely replace its contents if it does.
+    ///
+    /// This is a convenience function for using [`File::create`] and [`write_all`]
+    /// with fewer imports.
+    ///
+    /// [`File::create`]: struct.File.html#method.create
+    /// [`write_all`]: ../io/trait.Write.html#method.write_all
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(file_read_write_contents)]
+    ///
+    /// use std::fs::File;
+    ///
+    /// # fn foo() -> std::io::Result<()> {
+    /// File::write_contents("foo.txt", b"Lorem ipsum")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[unstable(feature = "file_read_write_contents", issue = /* FIXME */ "0")]
+    pub fn write_contents<P: AsRef<Path>>(path: P, contents: &[u8]) -> io::Result<()> {
+        File::create(path)?.write_all(contents)
+    }
+
     /// Attempts to sync all OS-internal metadata to disk.
     ///
     /// This function will attempt to ensure that all in-core data reaches the
@@ -2918,6 +2985,18 @@ mod tests {
         check!(check!(File::create(&tmpdir.join("test"))).write(&bytes));
         let mut v = Vec::new();
         check!(check!(File::open(&tmpdir.join("test"))).read_to_end(&mut v));
+        assert!(v == &bytes[..]);
+    }
+
+    #[test]
+    fn write_contents_then_read_contents() {
+        let mut bytes = [0; 1024];
+        StdRng::new().unwrap().fill_bytes(&mut bytes);
+
+        let tmpdir = tmpdir();
+
+        check!(File::write_contents(&tmpdir.join("test"), &bytes));
+        let v = check!(File::read_contents(&tmpdir.join("test")));
         assert!(v == &bytes[..]);
     }
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -269,6 +269,7 @@
 #![feature(core_intrinsics)]
 #![feature(dropck_eyepatch)]
 #![feature(exact_size_is_empty)]
+#![feature(file_read_write_contents)]
 #![feature(fixed_size_array)]
 #![feature(float_from_str_radix)]
 #![feature(fn_traits)]

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -269,7 +269,7 @@
 #![feature(core_intrinsics)]
 #![feature(dropck_eyepatch)]
 #![feature(exact_size_is_empty)]
-#![feature(file_read_write_contents)]
+#![feature(fs_read_write)]
 #![feature(fixed_size_array)]
 #![feature(float_from_str_radix)]
 #![feature(fn_traits)]


### PR DESCRIPTION
New APIs in `std::fs`:

```rust
pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> { … }
pub fn read_string<P: AsRef<Path>>(path: P) -> io::Result<String> { … }
pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result<()> { ... }
```

(`read_string` is based on `read_to_string` and so returns an error on non-UTF-8 content.)

Before:

```rust
use std::fs::File;
use std::io::Read;

let mut bytes = Vec::new();
File::open(filename)?.read_to_end(&mut bytes)?;
do_something_with(bytes)
```

After:

```rust
use std::fs;

do_something_with(fs::read(filename)?)
```