### PR TITLE
Add nested groups in imports

### DIFF
--- a/src/doc/unstable-book/src/language-features/use-nested-groups.md
+++ b/src/doc/unstable-book/src/language-features/use-nested-groups.md
@@ -1,0 +1,90 @@
+# `use_nested_groups`
+
+The tracking issue for this feature is: [#44494]
+
+[#44494]: https://github.com/rust-lang/rust/issues/44494
+
+------------------------
+
+The `use_nested_groups` feature allows you to import multiple items from a
+complex module tree easily, by nesting different imports in the same
+declaration. For example:
+
+```rust
+#![feature(use_nested_groups)]
+# #![allow(unused_imports, dead_code)]
+#
+# mod foo {
+#     pub mod bar {
+#         pub type Foo = ();
+#     }
+#     pub mod baz {
+#         pub mod quux {
+#             pub type Bar = ();
+#         }
+#     }
+# }
+
+use foo::{
+    bar::{self, Foo},
+    baz::{*, quux::Bar},
+};
+#
+# fn main() {}
+```
+
+## Snippet for the book's new features appendix
+
+When stabilizing, add this to
+`src/doc/book/second-edition/src/appendix-07-newest-features.md`:
+
+### Nested groups in `use` declarations
+
+If you have a complex module tree with many different submodules and you need
+to import a few items from each one, it might be useful to group all the
+imports in the same declaration to keep your code clean and avoid repeating the
+base modules' name.
+
+The `use` declaration supports nesting to help you in those cases, both with
+simple imports and glob ones. For example this snippets imports `bar`, `Foo`,
+all the items in `baz` and `Bar`:
+
+```rust
+# #![feature(use_nested_groups)]
+# #![allow(unused_imports, dead_code)]
+#
+# mod foo {
+#     pub mod bar {
+#         pub type Foo = ();
+#     }
+#     pub mod baz {
+#         pub mod quux {
+#             pub type Bar = ();
+#         }
+#     }
+# }
+#
+use foo::{
+    bar::{self, Foo},
+    baz::{*, quux::Bar},
+};
+#
+# fn main() {}
+```
+
+## Updated reference
+
+When stabilizing, replace the shortcut list in
+`src/doc/reference/src/items/use-declarations.md` with this updated one:
+
+* Simultaneously binding a list of paths with a common prefix, using the
+  glob-like brace syntax `use a::b::{c, d, e::f, g::h::i};`
+* Simultaneously binding a list of paths with a common prefix and their common
+  parent module, using the `self` keyword, such as `use a::b::{self, c, d::e};`
+* Rebinding the target name as a new local name, using the syntax `use p::q::r
+  as x;`. This can also be used with the last two features:
+  `use a::b::{self as ab, c as abc}`.
+* Binding all paths matching a given prefix, using the asterisk wildcard syntax
+  `use a::b::*;`.
+* Nesting groups of the previous features multiple times, such as
+  `use a::b::{self as ab, c d::{*, e::f}};`

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -981,12 +981,6 @@ impl<'a> ast_visit::Visitor<'a> for EarlyContext<'a> {
         ast_visit::walk_path(self, p);
     }
 
-    fn visit_path_list_item(&mut self, prefix: &'a ast::Path, item: &'a ast::PathListItem) {
-        run_lints!(self, check_path_list_item, early_passes, item);
-        self.check_id(item.node.id);
-        ast_visit::walk_path_list_item(self, prefix, item);
-    }
-
     fn visit_attribute(&mut self, attr: &'a ast::Attribute) {
         run_lints!(self, check_attribute, early_passes, attr);
     }

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -248,7 +248,6 @@ pub trait EarlyLintPass: LintPass {
     fn check_lifetime(&mut self, _: &EarlyContext, _: &ast::Lifetime) { }
     fn check_lifetime_def(&mut self, _: &EarlyContext, _: &ast::LifetimeDef) { }
     fn check_path(&mut self, _: &EarlyContext, _: &ast::Path, _: ast::NodeId) { }
-    fn check_path_list_item(&mut self, _: &EarlyContext, _: &ast::PathListItem) { }
     fn check_attribute(&mut self, _: &EarlyContext, _: &ast::Attribute) { }
 
     /// Called when entering a syntax node that can have lint attributes such

--- a/src/librustc_passes/hir_stats.rs
+++ b/src/librustc_passes/hir_stats.rs
@@ -358,13 +358,6 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
         self.record("Mac", Id::None, mac);
     }
 
-    fn visit_path_list_item(&mut self,
-                            prefix: &'v ast::Path,
-                            item: &'v ast::PathListItem) {
-        self.record("PathListItem", Id::None, item);
-        ast_visit::walk_path_list_item(self, prefix, item)
-    }
-
     fn visit_path_segment(&mut self,
                           path_span: Span,
                           path_segment: &'v ast::PathSegment) {

--- a/src/librustc_resolve/check_unused.rs
+++ b/src/librustc_resolve/check_unused.rs
@@ -26,7 +26,7 @@ use resolve_imports::ImportDirectiveSubclass;
 
 use rustc::{lint, ty};
 use rustc::util::nodemap::NodeMap;
-use syntax::ast::{self, ViewPathGlob, ViewPathList, ViewPathSimple};
+use syntax::ast;
 use syntax::visit::{self, Visitor};
 use syntax_pos::{Span, MultiSpan, DUMMY_SP};
 
@@ -35,6 +35,8 @@ struct UnusedImportCheckVisitor<'a, 'b: 'a> {
     resolver: &'a mut Resolver<'b>,
     /// All the (so far) unused imports, grouped path list
     unused_imports: NodeMap<NodeMap<Span>>,
+    base_id: ast::NodeId,
+    item_span: Span,
 }
 
 // Deref and DerefMut impls allow treating UnusedImportCheckVisitor as Resolver.
@@ -77,40 +79,41 @@ impl<'a, 'b> UnusedImportCheckVisitor<'a, 'b> {
 
 impl<'a, 'b> Visitor<'a> for UnusedImportCheckVisitor<'a, 'b> {
     fn visit_item(&mut self, item: &'a ast::Item) {
-        visit::walk_item(self, item);
+        self.item_span = item.span;
+
         // Ignore is_public import statements because there's no way to be sure
         // whether they're used or not. Also ignore imports with a dummy span
         // because this means that they were generated in some fashion by the
         // compiler and we don't need to consider them.
-        if item.vis == ast::Visibility::Public || item.span.source_equal(&DUMMY_SP) {
-            return;
-        }
-
-        match item.node {
-            ast::ItemKind::Use(ref p) => {
-                match p.node {
-                    ViewPathSimple(..) => {
-                        self.check_import(item.id, item.id, p.span)
-                    }
-
-                    ViewPathList(_, ref list) => {
-                        if list.len() == 0 {
-                            self.unused_imports
-                                .entry(item.id)
-                                .or_insert_with(NodeMap)
-                                .insert(item.id, item.span);
-                        }
-                        for i in list {
-                            self.check_import(item.id, i.node.id, i.span);
-                        }
-                    }
-                    ViewPathGlob(_) => {
-                        self.check_import(item.id, item.id, p.span);
-                    }
-                }
+        if let ast::ItemKind::Use(..) = item.node {
+            if item.vis == ast::Visibility::Public || item.span.source_equal(&DUMMY_SP) {
+                return;
             }
-            _ => {}
         }
+
+        visit::walk_item(self, item);
+    }
+
+    fn visit_use_tree(&mut self, use_tree: &'a ast::UseTree, id: ast::NodeId, nested: bool) {
+        // Use the base UseTree's NodeId as the item id
+        // This allows the grouping of all the lints in the same item
+        if !nested {
+            self.base_id = id;
+        }
+
+        if let ast::UseTreeKind::Nested(ref items) = use_tree.kind {
+            if items.len() == 0 {
+                self.unused_imports
+                    .entry(self.base_id)
+                    .or_insert_with(NodeMap)
+                    .insert(id, self.item_span);
+            }
+        } else {
+            let base_id = self.base_id;
+            self.check_import(base_id, id, use_tree.span);
+        }
+
+        visit::walk_use_tree(self, use_tree, id);
     }
 }
 
@@ -135,6 +138,8 @@ pub fn check_crate(resolver: &mut Resolver, krate: &ast::Crate) {
     let mut visitor = UnusedImportCheckVisitor {
         resolver,
         unused_imports: NodeMap(),
+        base_id: ast::DUMMY_NODE_ID,
+        item_span: DUMMY_SP,
     };
     visit::walk_crate(&mut visitor, krate);
 

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -428,6 +428,9 @@ declare_features! (
 
     // In-band lifetime bindings (e.g. `fn foo(x: &'a u8) -> &'a u8`)
     (active, in_band_lifetimes, "1.23.0", Some(44524)),
+
+    // Nested groups in `use` (RFC 2128)
+    (active, use_nested_groups, "1.23.0", Some(44494)),
 );
 
 declare_features! (
@@ -1659,6 +1662,29 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
         }
 
         visit::walk_path(self, path);
+    }
+
+    fn visit_use_tree(&mut self, use_tree: &'a ast::UseTree, id: NodeId, nested: bool) {
+        if nested {
+            match use_tree.kind {
+                ast::UseTreeKind::Simple(_) => {
+                    if use_tree.prefix.segments.len() != 1 {
+                        gate_feature_post!(&self, use_nested_groups, use_tree.span,
+                                           "paths in `use` groups are experimental");
+                    }
+                }
+                ast::UseTreeKind::Glob => {
+                    gate_feature_post!(&self, use_nested_groups, use_tree.span,
+                                       "glob imports in `use` groups are experimental");
+                }
+                ast::UseTreeKind::Nested(_) => {
+                    gate_feature_post!(&self, use_nested_groups, use_tree.span,
+                                       "nested groups in `use` are experimental");
+                }
+            }
+        }
+
+        visit::walk_use_tree(self, use_tree, id);
     }
 
     fn visit_vis(&mut self, vis: &'a ast::Visibility) {

--- a/src/libsyntax/std_inject.rs
+++ b/src/libsyntax/std_inject.rs
@@ -13,7 +13,7 @@ use attr;
 use ext::hygiene::{Mark, SyntaxContext};
 use symbol::{Symbol, keywords};
 use syntax_pos::{DUMMY_SP, Span};
-use codemap::{self, ExpnInfo, NameAndSpan, MacroAttribute};
+use codemap::{ExpnInfo, NameAndSpan, MacroAttribute};
 use ptr::P;
 use tokenstream::TokenStream;
 
@@ -75,12 +75,16 @@ pub fn maybe_inject_crates_ref(mut krate: ast::Crate, alt_std_name: Option<Strin
             span,
         }],
         vis: ast::Visibility::Inherited,
-        node: ast::ItemKind::Use(P(codemap::dummy_spanned(ast::ViewPathGlob(ast::Path {
-            segments: ["{{root}}", name, "prelude", "v1"].into_iter().map(|name| {
-                ast::PathSegment::from_ident(ast::Ident::from_str(name), DUMMY_SP)
-            }).collect(),
+        node: ast::ItemKind::Use(P(ast::UseTree {
+            prefix: ast::Path {
+                segments: ["{{root}}", name, "prelude", "v1"].into_iter().map(|name| {
+                    ast::PathSegment::from_ident(ast::Ident::from_str(name), DUMMY_SP)
+                }).collect(),
+                span,
+            },
+            kind: ast::UseTreeKind::Glob,
             span,
-        })))),
+        })),
         id: ast::DUMMY_NODE_ID,
         ident: keywords::Invalid.ident(),
         span,

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -455,9 +455,11 @@ fn mk_std(cx: &TestCtxt) -> P<ast::Item> {
     let id_test = Ident::from_str("test");
     let sp = ignored_span(cx, DUMMY_SP);
     let (vi, vis, ident) = if cx.is_libtest {
-        (ast::ItemKind::Use(
-            P(nospan(ast::ViewPathSimple(id_test,
-                                         path_node(vec![id_test]))))),
+        (ast::ItemKind::Use(P(ast::UseTree {
+            span: DUMMY_SP,
+            prefix: path_node(vec![id_test]),
+            kind: ast::UseTreeKind::Simple(id_test),
+        })),
          ast::Visibility::Public, keywords::Invalid.ident())
     } else {
         (ast::ItemKind::ExternCrate(None), ast::Visibility::Inherited, id_test)
@@ -547,9 +549,11 @@ fn mk_test_module(cx: &mut TestCtxt) -> (P<ast::Item>, Option<P<ast::Item>>) {
         // building `use <ident> = __test::main`
         let reexport_ident = Ident::with_empty_ctxt(s);
 
-        let use_path =
-            nospan(ast::ViewPathSimple(reexport_ident,
-                                       path_node(vec![mod_ident, Ident::from_str("main")])));
+        let use_path = ast::UseTree {
+            span: DUMMY_SP,
+            prefix: path_node(vec![mod_ident, Ident::from_str("main")]),
+            kind: ast::UseTreeKind::Simple(reexport_ident),
+        };
 
         expander.fold_item(P(ast::Item {
             id: ast::DUMMY_NODE_ID,

--- a/src/libsyntax/util/node_count.rs
+++ b/src/libsyntax/util/node_count.rs
@@ -133,9 +133,9 @@ impl<'ast> Visitor<'ast> for NodeCounter {
         self.count += 1;
         walk_path(self, path)
     }
-    fn visit_path_list_item(&mut self, prefix: &Path, item: &PathListItem) {
+    fn visit_use_tree(&mut self, use_tree: &UseTree, id: NodeId, _nested: bool) {
         self.count += 1;
-        walk_path_list_item(self, prefix, item)
+        walk_use_tree(self, use_tree, id)
     }
     fn visit_path_parameters(&mut self, path_span: Span, path_parameters: &PathParameters) {
         self.count += 1;

--- a/src/test/compile-fail/absolute-paths-in-nested-use-groups.rs
+++ b/src/test/compile-fail/absolute-paths-in-nested-use-groups.rs
@@ -8,12 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-mod x {
-    pub struct A;
-    pub struct B;
-}
+#![feature(use_nested_groups)]
+#![allow(unused_imports)]
 
-// `.` is similar to `,` so list parsing should continue to closing `}`
-use x::{A. B}; //~ ERROR expected one of `,`, `::`, or `as`, found `.`
+mod foo {}
+
+use foo::{
+    ::bar,       //~ ERROR crate root in paths can only be used in start position
+    super::bar,  //~ ERROR `super` in paths can only be used in start position
+    self::bar,   //~ ERROR `self` in paths can only be used in start position
+};
 
 fn main() {}

--- a/src/test/compile-fail/feature-gate-use_nested_groups.rs
+++ b/src/test/compile-fail/feature-gate-use_nested_groups.rs
@@ -8,12 +8,24 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-mod x {
-    pub struct A;
-    pub struct B;
+#![allow(unused_imports, dead_code)]
+
+mod a {
+    pub enum B {}
+    pub enum C {}
+
+    pub mod d {
+        pub enum E {}
+        pub enum F {}
+
+        pub mod g {
+            pub enum H {}
+        }
+    }
 }
 
-// `.` is similar to `,` so list parsing should continue to closing `}`
-use x::{A. B}; //~ ERROR expected one of `,`, `::`, or `as`, found `.`
+use a::{B, d::{*, g::H}};  //~ ERROR glob imports in `use` groups are experimental
+                           //~^ ERROR nested groups in `use` are experimental
+                           //~^^ ERROR paths in `use` groups are experimental
 
 fn main() {}

--- a/src/test/run-pass/use-nested-groups.rs
+++ b/src/test/run-pass/use-nested-groups.rs
@@ -8,12 +8,28 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-mod x {
-    pub struct A;
-    pub struct B;
+#![feature(use_nested_groups)]
+
+mod a {
+    pub enum B {}
+
+    pub mod d {
+        pub enum E {}
+        pub enum F {}
+
+        pub mod g {
+            pub enum H {}
+            pub enum I {}
+        }
+    }
 }
 
-// `.` is similar to `,` so list parsing should continue to closing `}`
-use x::{A. B}; //~ ERROR expected one of `,`, `::`, or `as`, found `.`
+use a::{B, d::{self, *, g::H}};
 
-fn main() {}
+fn main() {
+    let _: B;
+    let _: E;
+    let _: F;
+    let _: H;
+    let _: d::g::I;
+}

--- a/src/test/ui/owl-import-generates-unused-import-lint.rs
+++ b/src/test/ui/owl-import-generates-unused-import-lint.rs
@@ -8,12 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-mod x {
-    pub struct A;
-    pub struct B;
+#![feature(use_nested_groups)]
+#![deny(unused_imports)]
+
+mod foo {
+    pub enum Bar {}
 }
 
-// `.` is similar to `,` so list parsing should continue to closing `}`
-use x::{A. B}; //~ ERROR expected one of `,`, `::`, or `as`, found `.`
+use foo::{*, *}; //~ ERROR unused import: `*`
 
-fn main() {}
+fn main() {
+    let _: Bar;
+}

--- a/src/test/ui/owl-import-generates-unused-import-lint.stderr
+++ b/src/test/ui/owl-import-generates-unused-import-lint.stderr
@@ -1,0 +1,14 @@
+error: unused import: `*`
+  --> $DIR/owl-import-generates-unused-import-lint.rs:18:14
+   |
+18 | use foo::{*, *}; //~ ERROR unused import: `*`
+   |              ^
+   |
+note: lint level defined here
+  --> $DIR/owl-import-generates-unused-import-lint.rs:12:9
+   |
+12 | #![deny(unused_imports)]
+   |         ^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/similar-tokens.stderr
+++ b/src/test/ui/similar-tokens.stderr
@@ -1,8 +1,8 @@
-error: expected one of `,` or `as`, found `.`
+error: expected one of `,`, `::`, or `as`, found `.`
   --> $DIR/similar-tokens.rs:17:10
    |
-17 | use x::{A. B}; //~ ERROR expected one of `,` or `as`, found `.`
-   |          ^ expected one of `,` or `as` here
+17 | use x::{A. B}; //~ ERROR expected one of `,`, `::`, or `as`, found `.`
+   |          ^ expected one of `,`, `::`, or `as` here
 
 error: aborting due to previous error
 

--- a/src/tools/toolstate.toml
+++ b/src/tools/toolstate.toml
@@ -29,7 +29,7 @@ miri = "Broken"
 clippy = "Broken"
 
 # ping @nrc
-rls = "Testing"
+rls = "Broken"
 
 # ping @nrc
-rustfmt = "Testing"
+rustfmt = "Broken"


### PR DESCRIPTION
This PR adds support for nested groups in imports (rust-lang/rfcs#2128, tracking issue #44494).

r? @petrochenkov 