### PR TITLE
Disable `mmap`  in `libbacktrace` on Apple platforms

### DIFF
--- a/src/libbacktrace/configure
+++ b/src/libbacktrace/configure
@@ -12323,6 +12323,12 @@ fi
 
   fi
 fi
+
+case "${host_os}" in
+darwin*)
+  have_mmap=no ;;
+esac
+
 if test "$have_mmap" = "no"; then
   VIEW_FILE=read.lo
   ALLOC_FILE=alloc.lo

--- a/src/libbacktrace/configure.ac
+++ b/src/libbacktrace/configure.ac
@@ -283,6 +283,12 @@ else
     AC_CHECK_FUNC(mmap, [have_mmap=yes], [have_mmap=no])
   fi
 fi
+
+case "${host_os}" in
+darwin*)
+  have_mmap=no ;;
+esac
+
 if test "$have_mmap" = "no"; then
   VIEW_FILE=read.lo
   ALLOC_FILE=alloc.lo

--- a/src/test/run-pass/issue-45731.rs
+++ b/src/test/run-pass/issue-45731.rs
@@ -1,0 +1,34 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:--test -g
+
+use std::{env, panic, fs};
+
+#[cfg(target_os = "macos")]
+#[test]
+fn simple_test() {
+    // Find our dSYM and replace the DWARF binary with an empty file
+    let mut dsym_path = env::current_exe().unwrap();
+    let executable_name = dsym_path.file_name().unwrap().to_str().unwrap().to_string();
+    assert!(dsym_path.pop()); // Pop executable
+    dsym_path.push(format!("{}.dSYM/Contents/Resources/DWARF/{0}", executable_name));
+    {
+        let file = fs::OpenOptions::new().read(false).write(true).truncate(true).create(false)
+            .open(&dsym_path).unwrap();
+    }
+
+    env::set_var("RUST_BACKTRACE", "1");
+
+    // We don't need to die of panic, just trigger a backtrace
+    let _ = panic::catch_unwind(|| {
+        assert!(false);
+    });
+}


### PR DESCRIPTION
Fixes #45731

libbacktrace uses mmap if available to map ranges of the files containing debug information. On macOS `mmap` will succeed even if the mapped range does not exist, and a SIGBUS (with an unusual EXC_BAD_ACCESS code 10) will occur when the program attempts to page in the memory. To combat this we force `libbacktrace` to be built with the simple `read` based fallback on Apple platforms.