### PR TITLE
get() example should use get() not get_mut()

### DIFF
--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -363,16 +363,16 @@ impl str {
     /// # Examples
     ///
     /// ```
-    /// let mut v = String::from("🗻∈🌏");
+    /// let v = String::from("🗻∈🌏");
     ///
     /// assert_eq!(Some("🗻"), v.get(0..4));
     ///
     /// // indices not on UTF-8 sequence boundaries
-    /// assert!(v.get_mut(1..).is_none());
-    /// assert!(v.get_mut(..8).is_none());
+    /// assert!(v.get(1..).is_none());
+    /// assert!(v.get(..8).is_none());
     ///
     /// // out of bounds
-    /// assert!(v.get_mut(..42).is_none());
+    /// assert!(v.get(..42).is_none());
     /// ```
     #[stable(feature = "str_checked_slicing", since = "1.20.0")]
     #[inline]


### PR DESCRIPTION
I'm really new to Rust, this is the first thing I've ever actually pushed to github in a rust project, so please double check that it's correct.  I noticed that the in-doc example for the string's get() function was referring to get_mut().  Looks like a copy/paste issue.

```rust
fn main() {
    let v = String::from("🗻∈🌏");

    assert_eq!(Some("🗻"), v.get(0..4));

    // indices not on UTF-8 sequence boundaries
    assert!(v.get(1..).is_none());
    assert!(v.get(..8).is_none());

    // out of bounds
    assert!(v.get(..42).is_none());
}
```
results in:
```
jhford-work:~/rust/redish $ cat get-example.rs
fn main() {
    let v = String::from("🗻∈🌏");

    assert_eq!(Some("🗻"), v.get(0..4));

    // indices not on UTF-8 sequence boundaries
    assert!(v.get(1..).is_none());
    assert!(v.get(..8).is_none());

    // out of bounds
    assert!(v.get(..42).is_none());
}
jhford-work:~/rust/redish $ rustc get-example.rs
jhford-work:~/rust/redish $ ./get-example ; echo $?
0
```

I did not build an entire rust toolchain as I'm not totally sure how to do that.