### PR TITLE
Add Box::leak<'a>(Box<T>) -> &'a mut T where T: 'a

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -365,8 +365,8 @@ impl<T: ?Sized> Box<T> {
         unsafe { mem::transmute(b) }
     }
 
-    /// Consumes and leaks the `Box`, returning a static mutable reference,
-    /// `&'static mut T`.
+    /// Consumes and leaks the `Box`, returning a mutable reference,
+    /// `&'a mut T`. Here, the lifetime `'a` may be chosen to be `'static`.
     ///
     /// This function is mainly useful for data that lives for the remainder of
     /// the program's life. Dropping the returned reference will cause a memory

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -409,7 +409,7 @@ impl<T: ?Sized> Box<T> {
     /// }
     /// ```
     #[unstable(feature = "box_leak", reason = "needs an FCP to stabilize",
-               issue = "0")]
+               issue = "46179")]
     #[inline]
     pub fn leak<'a>(b: Box<T>) -> &'a mut T
     where

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -390,7 +390,7 @@ impl<T: ?Sized> Box<T> {
     ///
     /// fn main() {
     ///     let x = Box::new(41);
-    ///     let static_ref = Box::leak(x);
+    ///     let static_ref: &'static mut usize = Box::leak(x);
     ///     *static_ref += 1;
     ///     assert_eq!(*static_ref, 42);
     /// }
@@ -411,7 +411,7 @@ impl<T: ?Sized> Box<T> {
     #[unstable(feature = "box_leak", reason = "needs an FCP to stabilize",
                issue = "0")]
     #[inline]
-    pub fn leak(b: Box<T>) -> &'static mut T {
+    pub fn leak<'a, T: 'a>(b: Box<T>) -> &'a mut T {
         unsafe { &mut *Box::into_raw(b) }
     }
 }

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -411,7 +411,10 @@ impl<T: ?Sized> Box<T> {
     #[unstable(feature = "box_leak", reason = "needs an FCP to stabilize",
                issue = "0")]
     #[inline]
-    pub fn leak<'a, T: 'a>(b: Box<T>) -> &'a mut T {
+    pub fn leak<'a>(b: Box<T>) -> &'a mut T
+    where
+        T: 'a // Technically not needed, but kept to be explicit.
+    {
         unsafe { &mut *Box::into_raw(b) }
     }
 }

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -365,14 +365,15 @@ impl<T: ?Sized> Box<T> {
         unsafe { mem::transmute(b) }
     }
 
-    /// Consumes and leaks the `Box`, returning a static reference,
-    /// `&'static T`.
+    /// Consumes and leaks the `Box`, returning a static mutable reference,
+    /// `&'static mut T`.
     ///
     /// This function is mainly useful for data that lives for the remainder of
-    /// the programs life. Dropping the returned reference will cause a memory
+    /// the program's life. Dropping the returned reference will cause a memory
     /// leak. If this is not acceptable, the reference should first be wrapped
-    /// with the [`Box::from_raw`] function producing a `Box` which can then be
-    /// dropped which will properly destroy `T` and release the memory.
+    /// with the [`Box::from_raw`] function producing a `Box`. This `Box` can
+    /// then be dropped which will properly destroy `T` and release the
+    /// allocated memory.
     ///
     /// Note: this is an associated function, which means that you have
     /// to call it as `Box::leak(b)` instead of `b.leak()`. This

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -386,19 +386,27 @@ impl<T: ?Sized> Box<T> {
     /// Simple usage:
     ///
     /// ```
-    /// let x = Box::new(41);
-    /// let static_ref = Box::leak(x);
-    /// *static_ref += 1;
-    /// assert_eq!(*static_ref, 42);
+    /// #![feature(box_leak)]
+    ///
+    /// fn main() {
+    ///     let x = Box::new(41);
+    ///     let static_ref = Box::leak(x);
+    ///     *static_ref += 1;
+    ///     assert_eq!(*static_ref, 42);
+    /// }
     /// ```
     ///
     /// Unsized data:
     ///
     /// ```
-    /// let x = vec![1, 2, 3].into_boxed_slice();
-    /// let static_ref = Box::leak(x);
-    /// static_ref[0] = 4;
-    /// assert_eq!(*static_ref, [4, 2, 3]);
+    /// #![feature(box_leak)]
+    ///
+    /// fn main() {
+    ///     let x = vec![1, 2, 3].into_boxed_slice();
+    ///     let static_ref = Box::leak(x);
+    ///     static_ref[0] = 4;
+    ///     assert_eq!(*static_ref, [4, 2, 3]);
+    /// }
     /// ```
     #[unstable(feature = "box_leak", reason = "needs an FCP to stabilize",
                issue = "0")]


### PR DESCRIPTION
Adds:

```rust
impl<T: ?Sized> Box<T> {
    pub fn leak<'a>(b: Box<T>) -> &'a mut T where T: 'a {
        unsafe { &mut *Box::into_raw(b) }
    }
}
```

which is useful for when you just want to put some stuff on the heap and then have a reference to it for the remainder of the program.

r? @sfackler 
cc @durka