### PR TITLE
Redox: Use futex timeout to implement CondVar::wait_timeout

### DIFF
--- a/src/libstd/sys/redox/condvar.rs
+++ b/src/libstd/sys/redox/condvar.rs
@@ -9,12 +9,12 @@
 // except according to those terms.
 
 use cell::UnsafeCell;
-use intrinsics::{atomic_cxchg, atomic_xadd, atomic_xchg};
+use intrinsics::{atomic_cxchg, atomic_load, atomic_xadd, atomic_xchg};
 use ptr;
 use time::Duration;
 
 use sys::mutex::{mutex_unlock, Mutex};
-use sys::syscall::{futex, FUTEX_WAIT, FUTEX_WAKE, FUTEX_REQUEUE};
+use sys::syscall::{futex, TimeSpec, FUTEX_WAIT, FUTEX_WAKE, FUTEX_REQUEUE};
 
 pub struct Condvar {
     lock: UnsafeCell<*mut i32>,
@@ -63,33 +63,50 @@ impl Condvar {
     }
 
     #[inline]
+    unsafe fn wait_inner(&self, mutex: &Mutex, timeout_ptr: *const TimeSpec) -> bool {
+        let lock = self.lock.get();
+        let seq = self.seq.get();
+
+        if *lock != mutex.lock.get() {
+            if *lock != ptr::null_mut() {
+                panic!("Condvar used with more than one Mutex");
+            }
+
+            atomic_cxchg(lock as *mut usize, 0, mutex.lock.get() as usize);
+        }
+
+        mutex_unlock(*lock);
+
+        let seq_before = atomic_load(seq);
+
+        let _ = futex(seq, FUTEX_WAIT, seq_before, timeout_ptr as usize, ptr::null_mut());
+
+        let seq_after = atomic_load(seq);
+
+        while atomic_xchg(*lock, 2) != 0 {
+            let _ = futex(*lock, FUTEX_WAIT, 2, 0, ptr::null_mut());
+        }
+
+        seq_before != seq_after
+    }
+
+    #[inline]
     pub fn wait(&self, mutex: &Mutex) {
         unsafe {
-            let lock = self.lock.get();
-            let seq = self.seq.get();
-
-            if *lock != mutex.lock.get() {
-                if *lock != ptr::null_mut() {
-                    panic!("Condvar used with more than one Mutex");
-                }
-
-                atomic_cxchg(lock as *mut usize, 0, mutex.lock.get() as usize);
-            }
-
-            mutex_unlock(*lock);
-
-            let _ = futex(seq, FUTEX_WAIT, *seq, 0, ptr::null_mut());
-
-            while atomic_xchg(*lock, 2) != 0 {
-                let _ = futex(*lock, FUTEX_WAIT, 2, 0, ptr::null_mut());
-            }
+            assert!(self.wait_inner(mutex, ptr::null()));
         }
     }
 
     #[inline]
-    pub fn wait_timeout(&self, _mutex: &Mutex, _dur: Duration) -> bool {
-        ::sys_common::util::dumb_print(format_args!("condvar wait_timeout\n"));
-        unimplemented!();
+    pub fn wait_timeout(&self, mutex: &Mutex, dur: Duration) -> bool {
+        unsafe {
+            let timeout = TimeSpec {
+                tv_sec: dur.as_secs() as i64,
+                tv_nsec: dur.subsec_nanos() as i32
+            };
+
+            self.wait_inner(mutex, &timeout as *const TimeSpec)
+        }
     }
 
     #[inline]

--- a/src/libstd/sys/redox/fs.rs
+++ b/src/libstd/sys/redox/fs.rs
@@ -437,8 +437,7 @@ pub fn symlink(src: &Path, dst: &Path) -> io::Result<()> {
 }
 
 pub fn link(_src: &Path, _dst: &Path) -> io::Result<()> {
-    ::sys_common::util::dumb_print(format_args!("Link\n"));
-    unimplemented!();
+    Err(Error::from_raw_os_error(syscall::ENOSYS))
 }
 
 pub fn stat(p: &Path) -> io::Result<FileAttr> {


### PR DESCRIPTION
`CondVar::wait_timeout` is implemented by supplying a `TimeSpec` pointer to `futex`. In addition, all calls to `unimplemented!()` have been removed from the Redox `sys` module.

Related to https://github.com/rust-lang/rust/pull/45892