### PR TITLE
Trait object debug

### DIFF
--- a/src/librustc_trans/debuginfo/mod.rs
+++ b/src/librustc_trans/debuginfo/mod.rs
@@ -56,6 +56,7 @@ mod source_loc;
 pub use self::create_scope_map::{create_mir_scopes, MirDebugScope};
 pub use self::source_loc::start_emitting_source_locations;
 pub use self::metadata::create_global_var_metadata;
+pub use self::metadata::create_vtable_metadata;
 pub use self::metadata::extend_scope_to_file;
 pub use self::source_loc::set_source_location;
 

--- a/src/librustc_trans/meth.rs
+++ b/src/librustc_trans/meth.rs
@@ -18,6 +18,7 @@ use monomorphize;
 use type_::Type;
 use value::Value;
 use rustc::ty::{self, Ty};
+use debuginfo;
 
 #[derive(Copy, Clone, Debug)]
 pub struct VirtualIndex(usize);
@@ -98,6 +99,8 @@ pub fn get_vtable<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     let vtable_const = C_struct(ccx, &components, false);
     let align = machine::llalign_of_pref(ccx, val_ty(vtable_const));
     let vtable = consts::addr_of(ccx, vtable_const, align, "vtable");
+
+    debuginfo::create_vtable_metadata(ccx, ty, vtable);
 
     ccx.vtables().borrow_mut().insert((ty, trait_ref), vtable);
     vtable

--- a/src/test/codegen/vtabletype.rs
+++ b/src/test/codegen/vtabletype.rs
@@ -1,0 +1,33 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This test depends on a patch that was committed to upstream LLVM
+// after 5.0, then backported to the Rust LLVM fork.
+
+// ignore-tidy-linelength
+// ignore-windows
+// ignore-macos
+// min-system-llvm-version 5.1
+
+// compile-flags: -g -C no-prepopulate-passes
+
+// CHECK-LABEL: @main
+// CHECK: {{.*}}DICompositeType{{.*}}name: "vtable",{{.*}}vtableHolder:{{.*}}
+
+pub trait T {
+}
+
+impl T for f64 {
+}
+
+pub fn main() {
+    let d = 23.0f64;
+    let td = &d as &T;
+}

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -150,6 +150,14 @@ impl EarlyProps {
                     // Ignore if actual version is smaller the minimum required
                     // version
                     &actual_version[..] < min_version
+                } else if line.starts_with("min-system-llvm-version") {
+                    let min_version = line.trim_right()
+                        .rsplit(' ')
+                        .next()
+                        .expect("Malformed llvm version directive");
+                    // Ignore if using system LLVM and actual version
+                    // is smaller the minimum required version
+                    !(config.system_llvm && &actual_version[..] < min_version)
                 } else {
                     false
                 }


### PR DESCRIPTION
This enables better debugging of trait objects.  See the individual commits for explanations.  This required an LLVM bump.