### PR TITLE
Change "Types/modules" title of search tab to be more accurate

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -41,7 +41,7 @@
 
     // On the search screen, so you remain on the last tab you opened.
     //
-    // 0 for "Types/modules"
+    // 0 for "In name"
     // 1 for "As parameters"
     // 2 for "As return value"
     var currentTab = 0;
@@ -1093,7 +1093,7 @@
             output = '<h1>Results for ' + escape(query.query) +
                 (query.type ? ' (type: ' + escape(query.type) + ')' : '') + '</h1>' +
                 '<div id="titles">' +
-                makeTabHeader(0, "Types/modules", results['others'].length) +
+                makeTabHeader(0, "In name", results['others'].length) +
                 makeTabHeader(1, "As parameters", results['in_args'].length) +
                 makeTabHeader(2, "As return value", results['returned'].length) +
                 '</div><div id="results">';

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -41,9 +41,9 @@
 
     // On the search screen, so you remain on the last tab you opened.
     //
-    // 0 for "In name"
-    // 1 for "As parameters"
-    // 2 for "As return value"
+    // 0 for "In Names"
+    // 1 for "In Parameters"
+    // 2 for "In Return Types"
     var currentTab = 0;
 
     function hasClass(elem, className) {
@@ -1093,9 +1093,9 @@
             output = '<h1>Results for ' + escape(query.query) +
                 (query.type ? ' (type: ' + escape(query.type) + ')' : '') + '</h1>' +
                 '<div id="titles">' +
-                makeTabHeader(0, "In name", results['others'].length) +
-                makeTabHeader(1, "As parameters", results['in_args'].length) +
-                makeTabHeader(2, "As return value", results['returned'].length) +
+                makeTabHeader(0, "In Names", results['others'].length) +
+                makeTabHeader(1, "In Parameters", results['in_args'].length) +
+                makeTabHeader(2, "In Return Types", results['returned'].length) +
                 '</div><div id="results">';
 
             output += addTab(results['others'], query);


### PR DESCRIPTION
From issue #45787. Used "In name" as per suggestion from @Seeker14491.