### PR TITLE
rustbuild: Disable ThinLTO for libtest

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -624,6 +624,7 @@ impl<'a> Builder<'a> {
             }
 
             if mode != Mode::Libstd && // FIXME(#45320)
+               mode != Mode::Libtest && // FIXME(#45511)
                self.config.rust_codegen_units.is_none() &&
                self.build.is_rust_llvm(compiler.host) &&
                !target.contains("mips") // FIXME(#45654)


### PR DESCRIPTION
Right now ThinLTO is generating bad dwarf which is tracked by #45511, but this
is causing issues on OSX (#45768) where `dsymutil` is segfaulting and failing to
produce output.

Closes #45768