### PR TITLE
incr.comp.: Don't crash in DepGraph::try_mark_green() when encountering a removed input node.

### DIFF
--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -524,14 +524,22 @@ impl DepGraph {
                             current_deps.push(node_index);
                             continue;
                         }
-                    } else if cfg!(debug_assertions) {
+                    } else {
                         match dep_dep_node.kind {
                             DepKind::Hir |
                             DepKind::HirBody |
                             DepKind::CrateMetadata => {
-                                assert!(dep_dep_node.extract_def_id(tcx).is_none(),
-                                    "Input {:?} should have been pre-allocated but wasn't.",
-                                    dep_dep_node);
+                                if dep_node.extract_def_id(tcx).is_none() {
+                                    // If the node does not exist anymore, we
+                                    // just fail to mark green.
+                                    return None
+                                } else {
+                                    // If the node does exist, it should have
+                                    // been pre-allocated.
+                                    bug!("DepNode {:?} should have been \
+                                          pre-allocated but wasn't.",
+                                          dep_dep_node)
+                                }
                             }
                             _ => {
                                 // For other kinds of inputs it's OK to be

--- a/src/librustc/ty/maps/plumbing.rs
+++ b/src/librustc/ty/maps/plumbing.rs
@@ -723,7 +723,7 @@ pub fn force_from_dep_node<'a, 'gcx, 'lcx>(tcx: TyCtxt<'a, 'gcx, 'lcx>,
 
         // This one should never occur in this context
         DepKind::Null => {
-            bug!("force_from_dep_node() - Encountered {:?}", dep_node.kind)
+            bug!("force_from_dep_node() - Encountered {:?}", dep_node)
         }
 
         // These are not queries

--- a/src/test/incremental/remove_crate/auxiliary/extern_crate.rs
+++ b/src/test/incremental/remove_crate/auxiliary/extern_crate.rs
@@ -1,0 +1,13 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn foo(_: u8) {
+
+}

--- a/src/test/incremental/remove_crate/main.rs
+++ b/src/test/incremental/remove_crate/main.rs
@@ -1,0 +1,34 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that removing an upstream crate does not cause any trouble.
+
+// revisions:rpass1 rpass2
+// aux-build:extern_crate.rs
+
+#[cfg(rpass1)]
+extern crate extern_crate;
+
+pub fn main() {
+    #[cfg(rpass1)]
+    {
+        extern_crate::foo(1);
+    }
+
+    #[cfg(rpass2)]
+    {
+        foo(1);
+    }
+}
+
+#[cfg(rpass2)]
+pub fn foo(_: u8) {
+
+}


### PR DESCRIPTION
Fixes a small regression that was introduced in #45867.

r? @nikomatsakis 