### PR TITLE
compiletest: Fix a couple of test re-run issues

### DIFF
--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -491,6 +491,7 @@ fn stamp(config: &Config, testpaths: &TestPaths) -> PathBuf {
                              config.stage_id);
     config.build_base.canonicalize()
           .unwrap_or_else(|_| config.build_base.clone())
+          .join(&testpaths.relative_dir)
           .join(stamp_name)
 }
 
@@ -521,6 +522,10 @@ fn up_to_date(config: &Config, testpaths: &TestPaths, props: &EarlyProps) -> boo
     for lib in config.run_lib_path.read_dir().unwrap() {
         let lib = lib.unwrap();
         inputs.push(mtime(&lib.path()));
+    }
+    if let Some(ref rustdoc_path) = config.rustdoc_path {
+        inputs.push(mtime(&rustdoc_path));
+        inputs.push(mtime(&rust_src_dir.join("src/etc/htmldocck.py")));
     }
     inputs.iter().any(|input| *input > stamp)
 }


### PR DESCRIPTION
* Re-run rustdoc tests if rustdoc or htmldocck.py was updated.
* Put stamp files in the correct subdirectories to avoid clashes when
the file names match but the subdirectory doesn't.