### PR TITLE
Add Read::size_hint and pre-allocate in read_to_end

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -449,6 +449,13 @@ impl Read for File {
         self.inner.read(buf)
     }
 
+    fn size_hint(&self) -> usize {
+        match self.metadata() {
+            Ok(meta) => meta.len() as usize,
+            Err(_) => 0,
+        }
+    }
+
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
@@ -471,6 +478,10 @@ impl Seek for File {
 impl<'a> Read for &'a File {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.inner.read(buf)
+    }
+
+    fn size_hint(&self) -> usize {
+        (**self).size_hint()
     }
 
     #[inline]

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -449,11 +449,8 @@ impl Read for File {
         self.inner.read(buf)
     }
 
-    fn size_hint(&self) -> usize {
-        match self.metadata() {
-            Ok(meta) => meta.len() as usize,
-            Err(_) => 0,
-        }
+    fn size_hint(&self) -> io::Result<usize> {
+        Ok(self.metadata()?.len() as usize)
     }
 
     #[inline]
@@ -480,7 +477,7 @@ impl<'a> Read for &'a File {
         self.inner.read(buf)
     }
 
-    fn size_hint(&self) -> usize {
+    fn size_hint(&self) -> io::Result<usize> {
         (**self).size_hint()
     }
 

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -450,7 +450,8 @@ impl Read for File {
     }
 
     fn size_hint(&self) -> io::Result<usize> {
-        Ok(self.metadata()?.len() as usize)
+        let position = self.inner.seek(SeekFrom::Current(0))?;
+        Ok(self.metadata()?.len().saturating_sub(position) as usize)
     }
 
     #[inline]

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -211,6 +211,12 @@ impl<R: Read> Read for BufReader<R> {
         Ok(nread)
     }
 
+    #[inline]
+    fn size_hint(&self) -> usize {
+        let buffered_len = self.cap - self.pos;
+        buffered_len.saturating_add(self.inner.size_hint())
+    }
+
     // we can't skip unconditionally because of the large buffer case in read.
     unsafe fn initializer(&self) -> Initializer {
         self.inner.initializer()

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -212,9 +212,9 @@ impl<R: Read> Read for BufReader<R> {
     }
 
     #[inline]
-    fn size_hint(&self) -> usize {
+    fn size_hint(&self) -> io::Result<usize> {
         let buffered_len = self.cap - self.pos;
-        buffered_len.saturating_add(self.inner.size_hint())
+        Ok(buffered_len.saturating_add(self.inner.size_hint()?))
     }
 
     // we can't skip unconditionally because of the large buffer case in read.

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -230,8 +230,8 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
         Ok(n)
     }
 
-    fn size_hint(&self) -> usize {
-        (self.inner.as_ref().len() as u64).saturating_sub(self.pos) as usize
+    fn size_hint(&self) -> io::Result<usize> {
+        Ok((self.inner.as_ref().len() as u64).saturating_sub(self.pos) as usize)
     }
 
     #[inline]

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -230,6 +230,10 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
         Ok(n)
     }
 
+    fn size_hint(&self) -> usize {
+        (self.inner.as_ref().len() as u64).saturating_sub(self.pos) as usize
+    }
+
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()

--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -24,7 +24,7 @@ impl<'a, R: Read + ?Sized> Read for &'a mut R {
     }
 
     #[inline]
-    fn size_hint(&self) -> usize {
+    fn size_hint(&self) -> io::Result<usize> {
         (**self).size_hint()
     }
 
@@ -98,7 +98,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
     }
 
     #[inline]
-    fn size_hint(&self) -> usize {
+    fn size_hint(&self) -> io::Result<usize> {
         (**self).size_hint()
     }
 
@@ -192,8 +192,8 @@ impl<'a> Read for &'a [u8] {
     }
 
     #[inline]
-    fn size_hint(&self) -> usize {
-        self.len()
+    fn size_hint(&self) -> io::Result<usize> {
+        Ok(self.len())
     }
 
     #[inline]

--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -24,6 +24,11 @@ impl<'a, R: Read + ?Sized> Read for &'a mut R {
     }
 
     #[inline]
+    fn size_hint(&self) -> usize {
+        (**self).size_hint()
+    }
+
+    #[inline]
     unsafe fn initializer(&self) -> Initializer {
         (**self).initializer()
     }
@@ -90,6 +95,11 @@ impl<R: Read + ?Sized> Read for Box<R> {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         (**self).read(buf)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> usize {
+        (**self).size_hint()
     }
 
     #[inline]
@@ -179,6 +189,11 @@ impl<'a> Read for &'a [u8] {
 
         *self = b;
         Ok(amt)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> usize {
+        self.len()
     }
 
     #[inline]

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -370,7 +370,7 @@ fn read_to_end<R: Read + ?Sized>(r: &mut R, buf: &mut Vec<u8>) -> Result<usize> 
     let size_hint = r.size_hint();
     if size_hint > 0 {
         unsafe {
-            g.buf.reserve(size_hint);
+            g.buf.reserve(size_hint.saturating_add(1));
             let capacity = g.buf.capacity();
             g.buf.set_len(capacity);
             r.initializer().initialize(&mut g.buf[g.len..]);

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -366,6 +366,17 @@ fn append_to_string<F>(buf: &mut String, f: F) -> Result<usize>
 fn read_to_end<R: Read + ?Sized>(r: &mut R, buf: &mut Vec<u8>) -> Result<usize> {
     let start_len = buf.len();
     let mut g = Guard { len: buf.len(), buf: buf };
+
+    let size_hint = r.size_hint();
+    if size_hint > 0 {
+        unsafe {
+            g.buf.reserve(size_hint);
+            let capacity = g.buf.capacity();
+            g.buf.set_len(capacity);
+            r.initializer().initialize(&mut g.buf[g.len..]);
+        }
+    }
+
     loop {
         if g.len == g.buf.len() {
             unsafe {

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -366,7 +366,6 @@ fn append_to_string<F>(buf: &mut String, f: F) -> Result<usize>
 fn read_to_end<R: Read + ?Sized>(r: &mut R, buf: &mut Vec<u8>) -> Result<usize> {
     let start_len = buf.len();
     let mut g = Guard { len: buf.len(), buf: buf };
-    let ret;
     loop {
         if g.len == g.buf.len() {
             unsafe {
@@ -378,20 +377,12 @@ fn read_to_end<R: Read + ?Sized>(r: &mut R, buf: &mut Vec<u8>) -> Result<usize> 
         }
 
         match r.read(&mut g.buf[g.len..]) {
-            Ok(0) => {
-                ret = Ok(g.len - start_len);
-                break;
-            }
+            Ok(0) => return Ok(g.len - start_len),
             Ok(n) => g.len += n,
             Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
-            Err(e) => {
-                ret = Err(e);
-                break;
-            }
+            Err(e) => return Err(e),
         }
     }
-
-    ret
 }
 
 /// The `Read` trait allows for reading bytes from a source.


### PR DESCRIPTION
Many `FromIterator` implementations rely on `Iterator::size_hint` to pre-allocate memory. This is a prototype of what something equivalent for `std::io::Read` could look like. An alternative would be to not add any public API but use an private specialization trait, like `ZipImpl` in libcore.

This came up in https://github.com/rust-lang/rust/pull/45837 in the case of reading from a file. I’ve measured `File::read_to_end` with a vector created with `Vec::with_capacity(file.metadata().len() as usize)`, compared to `Vec::new()`. On my linux desktop with an SSD (though everything is probably in filesystem cache here), pre-allocating + reading take 3% more time to 43% less time depending on file size.

```rust
     Running target/release/deps/read_to_end_bench-9122fdf004b0166c

running 24 tests
test a_read_128::vec_new            ... bench:       1,380 ns/iter (+/- 49) = 92 MB/s
test a_read_128::vec_with_capacity  ... bench:       1,416 ns/iter (+/- 107) = 90 MB/s
test b_read_512::vec_new            ... bench:       1,690 ns/iter (+/- 78) = 302 MB/s
test b_read_512::vec_with_capacity  ... bench:       1,736 ns/iter (+/- 52) = 294 MB/s
test c_read_2k::vec_new             ... bench:       2,085 ns/iter (+/- 113) = 982 MB/s
test c_read_2k::vec_with_capacity   ... bench:       2,015 ns/iter (+/- 72) = 1016 MB/s
test d_read_8k::vec_new             ... bench:       2,778 ns/iter (+/- 131) = 2948 MB/s
test d_read_8k::vec_with_capacity   ... bench:       2,516 ns/iter (+/- 89) = 3255 MB/s
test e_read_32k::vec_new            ... bench:       5,107 ns/iter (+/- 103) = 6416 MB/s
test e_read_32k::vec_with_capacity  ... bench:       4,404 ns/iter (+/- 81) = 7440 MB/s
test f_read_128k::vec_new           ... bench:      16,232 ns/iter (+/- 106) = 8074 MB/s
test f_read_128k::vec_with_capacity ... bench:      12,223 ns/iter (+/- 103) = 10723 MB/s
test g_read_512k::vec_new           ... bench:      39,179 ns/iter (+/- 210) = 13381 MB/s
test g_read_512k::vec_with_capacity ... bench:      31,704 ns/iter (+/- 98) = 16536 MB/s
test h_read_1m::vec_new             ... bench:     463,119 ns/iter (+/- 2,354) = 2264 MB/s
test h_read_1m::vec_with_capacity   ... bench:     251,983 ns/iter (+/- 3,072) = 4161 MB/s
test i_read_2m::vec_new             ... bench:     668,742 ns/iter (+/- 8,317) = 3135 MB/s
test i_read_2m::vec_with_capacity   ... bench:     383,879 ns/iter (+/- 1,269) = 5463 MB/s
test j_read_4m::vec_new             ... bench:   1,188,553 ns/iter (+/- 13,409) = 3528 MB/s
test j_read_4m::vec_with_capacity   ... bench:     857,714 ns/iter (+/- 8,254) = 4890 MB/s
test k_read_8m::vec_new             ... bench:   2,302,201 ns/iter (+/- 15,746) = 3643 MB/s
test k_read_8m::vec_with_capacity   ... bench:   1,947,089 ns/iter (+/- 10,942) = 4308 MB/s
test l_read_32m::vec_new            ... bench:   8,990,230 ns/iter (+/- 18,718) = 3732 MB/s
test l_read_32m::vec_with_capacity  ... bench:   8,648,669 ns/iter (+/- 23,157) = 3879 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 24 measured; 0 filtered out
```
```rust
#![feature(test)]
extern crate test;
extern crate tempdir;

use std::fs::File;
use std::io::{Write, Read};
use test::Bencher;

fn run<F>(bencher: &mut Bencher, size: usize, new_buffer: F)
    where F: Fn(&File) -> Vec<u8>
{
    let dir = tempdir::TempDir::new("bench").unwrap();
    let path = dir.path().join("something");
    File::create(&path).unwrap().write_all(&vec![42; size]).unwrap();
    bencher.bytes = size as u64;
    bencher.iter(|| {
        let mut file = File::open(&path).unwrap();
        let mut buffer = new_buffer(&file);
        file.read_to_end(&mut buffer).unwrap();
    })
}

macro_rules! sizes {
    ($( $name: ident  $size: expr )+) => {
        $(
            mod $name {
                use super::*;

                #[bench]
                fn vec_new(bencher: &mut Bencher) {
                    run(bencher, $size, |_| Vec::new())
                }

                #[bench]
                fn vec_with_capacity(bencher: &mut Bencher) {
                    run(bencher, $size, |file| {
                        Vec::with_capacity(file.metadata().unwrap().len() as usize)
                    })
                }
            }
        )+
    }
}

sizes! {
    a_read_128 128
    b_read_512 512
    c_read_2k 2 * 1024
    d_read_8k 8 * 1024
    e_read_32k 32 * 1024
    f_read_128k 128 * 1024
    g_read_512k 512 * 1024
    h_read_1m 1024 * 1024
    i_read_2m 2 * 1024 * 1024
    j_read_4m 4 * 1024 * 1024
    k_read_8m 8 * 1024 * 1024
    l_read_32m 32 * 1024 * 1024
}
```