### PR TITLE
rustc_driver: expose a way to override query providers in CompileController.

### DIFF
--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -842,14 +842,3 @@ pub fn provide(providers: &mut ty::maps::Providers) {
         ..*providers
     };
 }
-
-pub fn provide_extern(providers: &mut ty::maps::Providers) {
-    *providers = ty::maps::Providers {
-        is_object_safe: object_safety::is_object_safe_provider,
-        specialization_graph_of: specialize::specialization_graph_provider,
-        specializes: specialize::specializes,
-        trans_fulfill_obligation: trans::trans_fulfill_obligation,
-        vtable_methods,
-        ..*providers
-    };
-}

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2605,17 +2605,6 @@ pub fn provide(providers: &mut ty::maps::Providers) {
     };
 }
 
-pub fn provide_extern(providers: &mut ty::maps::Providers) {
-    *providers = ty::maps::Providers {
-        adt_sized_constraint,
-        adt_dtorck_constraint,
-        trait_impls_of: trait_def::trait_impls_of_provider,
-        param_env,
-        ..*providers
-    };
-}
-
-
 /// A map for the local crate mapping each type to a vector of its
 /// inherent impls. This is not meant to be used outside of coherence;
 /// rather, you should request the vector for a specific type via

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -207,7 +207,8 @@ pub fn compile_input(sess: &Session,
             None
         };
 
-        phase_3_run_analysis_passes(sess,
+        phase_3_run_analysis_passes(control,
+                                    sess,
                                     cstore,
                                     hir_map,
                                     analysis,
@@ -348,6 +349,13 @@ pub struct CompileController<'a> {
     pub keep_ast: bool,
     // -Zcontinue-parse-after-error
     pub continue_parse_after_error: bool,
+
+    /// Allows overriding default rustc query providers,
+    /// after `default_provide` has installed them.
+    pub provide: Box<Fn(&mut ty::maps::Providers) + 'a>,
+    /// Same as `provide`, but only for non-local crates,
+    /// applied after `default_provide_extern`.
+    pub provide_extern: Box<Fn(&mut ty::maps::Providers) + 'a>,
 }
 
 impl<'a> CompileController<'a> {
@@ -362,6 +370,8 @@ impl<'a> CompileController<'a> {
             make_glob_map: MakeGlobMap::No,
             keep_ast: false,
             continue_parse_after_error: false,
+            provide: box |_| {},
+            provide_extern: box |_| {},
         }
     }
 }
@@ -907,10 +917,33 @@ pub fn phase_2_configure_and_expand<F>(sess: &Session,
     })
 }
 
+pub fn default_provide(providers: &mut ty::maps::Providers) {
+    borrowck::provide(providers);
+    mir::provide(providers);
+    reachable::provide(providers);
+    rustc_privacy::provide(providers);
+    DefaultTransCrate::provide(providers);
+    typeck::provide(providers);
+    ty::provide(providers);
+    traits::provide(providers);
+    reachable::provide(providers);
+    rustc_const_eval::provide(providers);
+    rustc_passes::provide(providers);
+    middle::region::provide(providers);
+    cstore::provide(providers);
+    lint::provide(providers);
+}
+
+pub fn default_provide_extern(providers: &mut ty::maps::Providers) {
+    cstore::provide_extern(providers);
+    DefaultTransCrate::provide_extern(providers);
+}
+
 /// Run the resolution, typechecking, region checking and other
 /// miscellaneous analysis passes on the crate. Return various
 /// structures carrying the results of the analysis.
-pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
+pub fn phase_3_run_analysis_passes<'tcx, F, R>(control: &CompileController,
+                                               sess: &'tcx Session,
                                                cstore: &'tcx CrateStore,
                                                hir_map: hir_map::Map<'tcx>,
                                                mut analysis: ty::CrateAnalysis,
@@ -966,24 +999,12 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
               || static_recursion::check_crate(sess, &hir_map))?;
 
     let mut local_providers = ty::maps::Providers::default();
-    borrowck::provide(&mut local_providers);
-    mir::provide(&mut local_providers);
-    reachable::provide(&mut local_providers);
-    rustc_privacy::provide(&mut local_providers);
-    DefaultTransCrate::provide(&mut local_providers);
-    typeck::provide(&mut local_providers);
-    ty::provide(&mut local_providers);
-    traits::provide(&mut local_providers);
-    reachable::provide(&mut local_providers);
-    rustc_const_eval::provide(&mut local_providers);
-    rustc_passes::provide(&mut local_providers);
-    middle::region::provide(&mut local_providers);
-    cstore::provide(&mut local_providers);
-    lint::provide(&mut local_providers);
+    default_provide(&mut local_providers);
+    (control.provide)(&mut local_providers);
 
     let mut extern_providers = local_providers;
-    cstore::provide_extern(&mut extern_providers);
-    DefaultTransCrate::provide_extern(&mut extern_providers);
+    default_provide_extern(&mut extern_providers);
+    (control.provide_extern)(&mut extern_providers);
 
     // Setup the MIR passes that we want to run.
     let mut passes = Passes::new();

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -970,7 +970,7 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
     mir::provide(&mut local_providers);
     reachable::provide(&mut local_providers);
     rustc_privacy::provide(&mut local_providers);
-    DefaultTransCrate::provide_local(&mut local_providers);
+    DefaultTransCrate::provide(&mut local_providers);
     typeck::provide(&mut local_providers);
     ty::provide(&mut local_providers);
     traits::provide(&mut local_providers);
@@ -978,16 +978,12 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
     rustc_const_eval::provide(&mut local_providers);
     rustc_passes::provide(&mut local_providers);
     middle::region::provide(&mut local_providers);
-    cstore::provide_local(&mut local_providers);
+    cstore::provide(&mut local_providers);
     lint::provide(&mut local_providers);
 
-    let mut extern_providers = ty::maps::Providers::default();
-    cstore::provide(&mut extern_providers);
+    let mut extern_providers = local_providers;
+    cstore::provide_extern(&mut extern_providers);
     DefaultTransCrate::provide_extern(&mut extern_providers);
-    ty::provide_extern(&mut extern_providers);
-    traits::provide_extern(&mut extern_providers);
-    // FIXME(eddyb) get rid of this once we replace const_eval with miri.
-    rustc_const_eval::provide(&mut extern_providers);
 
     // Setup the MIR passes that we want to run.
     let mut passes = Passes::new();

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -227,7 +227,9 @@ impl PpSourceMode {
                 f(&annotation, hir_map.forest.krate())
             }
             PpmTyped => {
-                abort_on_err(driver::phase_3_run_analysis_passes(sess,
+                let control = &driver::CompileController::basic();
+                abort_on_err(driver::phase_3_run_analysis_passes(control,
+                                                                 sess,
                                                                  cstore,
                                                                  hir_map.clone(),
                                                                  analysis.clone(),
@@ -1036,7 +1038,9 @@ fn print_with_analysis<'tcx, 'a: 'tcx>(sess: &'a Session,
 
     let mut out = Vec::new();
 
-    abort_on_err(driver::phase_3_run_analysis_passes(sess,
+    let control = &driver::CompileController::basic();
+    abort_on_err(driver::phase_3_run_analysis_passes(control,
+                                                     sess,
                                                      cstore,
                                                      hir_map.clone(),
                                                      analysis.clone(),

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -34,7 +34,7 @@ pub use rustc::middle::cstore::{NativeLibrary, NativeLibraryKind, LinkagePrefere
 pub use rustc::middle::cstore::NativeLibraryKind::*;
 pub use rustc::middle::cstore::{CrateSource, LibSource};
 
-pub use cstore_impl::{provide, provide_local};
+pub use cstore_impl::{provide, provide_extern};
 
 // A map from external crate numbers (as decoded from some crate file) to
 // local crate numbers (as generated during this session). Each external

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -45,7 +45,7 @@ use rustc::hir;
 macro_rules! provide {
     (<$lt:tt> $tcx:ident, $def_id:ident, $other:ident, $cdata:ident,
       $($name:ident => $compute:block)*) => {
-        pub fn provide<$lt>(providers: &mut Providers<$lt>) {
+        pub fn provide_extern<$lt>(providers: &mut Providers<$lt>) {
             $(fn $name<'a, $lt:$lt, T>($tcx: TyCtxt<'a, $lt, $lt>, def_id_arg: T)
                                     -> <ty::queries::$name<$lt> as
                                         QueryConfig>::Value
@@ -243,7 +243,7 @@ provide! { <'tcx> tcx, def_id, other, cdata,
     has_clone_closures => { cdata.has_clone_closures(tcx.sess) }
 }
 
-pub fn provide_local<'tcx>(providers: &mut Providers<'tcx>) {
+pub fn provide<'tcx>(providers: &mut Providers<'tcx>) {
     fn is_const_fn<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> bool {
         let node_id = tcx.hir.as_local_node_id(def_id)
                              .expect("Non-local call to local provider is_const_fn");

--- a/src/librustc_trans/back/symbol_export.rs
+++ b/src/librustc_trans/back/symbol_export.rs
@@ -60,7 +60,7 @@ pub fn crates_export_threshold(crate_types: &[config::CrateType])
     }
 }
 
-pub fn provide_local(providers: &mut Providers) {
+pub fn provide(providers: &mut Providers) {
     providers.exported_symbol_ids = |tcx, cnum| {
         let export_threshold = threshold(tcx);
         Rc::new(tcx.exported_symbols(cnum)

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -1384,7 +1384,7 @@ fn compile_codegen_unit<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     }
 }
 
-pub fn provide_local(providers: &mut Providers) {
+pub fn provide(providers: &mut Providers) {
     providers.collect_and_partition_translation_items =
         collect_and_partition_translation_items;
 
@@ -1398,10 +1398,6 @@ pub fn provide_local(providers: &mut Providers) {
             .expect(&format!("failed to find cgu with name {:?}", name))
     };
     providers.compile_codegen_unit = compile_codegen_unit;
-}
-
-pub fn provide_extern(providers: &mut Providers) {
-    providers.is_translated_function = is_translated_function;
 }
 
 pub fn linkage_to_llvm(linkage: Linkage) -> llvm::Linkage {

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -81,7 +81,6 @@ use rustc::middle::cstore::MetadataLoader;
 use rustc::middle::cstore::{NativeLibrary, CrateSource, LibSource};
 use rustc::session::Session;
 use rustc::session::config::{OutputFilenames, OutputType};
-use rustc::ty::maps::Providers;
 use rustc::ty::{self, TyCtxt};
 use rustc::util::nodemap::{FxHashSet, FxHashMap};
 
@@ -167,12 +166,14 @@ impl rustc_trans_utils::trans_crate::TransCrate for LlvmTransCrate {
         box metadata::LlvmMetadataLoader
     }
 
-    fn provide_local(providers: &mut ty::maps::Providers) {
-        provide_local(providers);
+    fn provide(providers: &mut ty::maps::Providers) {
+        back::symbol_names::provide(providers);
+        back::symbol_export::provide(providers);
+        base::provide(providers);
     }
 
     fn provide_extern(providers: &mut ty::maps::Providers) {
-        provide_extern(providers);
+        back::symbol_export::provide_extern(providers);
     }
 
     fn trans_crate<'a, 'tcx>(
@@ -332,15 +333,3 @@ pub struct CrateInfo {
 }
 
 __build_diagnostic_array! { librustc_trans, DIAGNOSTICS }
-
-pub fn provide_local(providers: &mut Providers) {
-    back::symbol_names::provide(providers);
-    back::symbol_export::provide_local(providers);
-    base::provide_local(providers);
-}
-
-pub fn provide_extern(providers: &mut Providers) {
-    back::symbol_names::provide(providers);
-    back::symbol_export::provide_extern(providers);
-    base::provide_extern(providers);
-}

--- a/src/librustc_trans_utils/trans_crate.rs
+++ b/src/librustc_trans_utils/trans_crate.rs
@@ -51,7 +51,7 @@ pub trait TransCrate {
     type TranslatedCrate;
 
     fn metadata_loader() -> Box<MetadataLoaderTrait>;
-    fn provide_local(_providers: &mut Providers);
+    fn provide(_providers: &mut Providers);
     fn provide_extern(_providers: &mut Providers);
     fn trans_crate<'a, 'tcx>(
         tcx: TyCtxt<'a, 'tcx, 'tcx>,
@@ -77,8 +77,8 @@ impl TransCrate for DummyTransCrate {
         box DummyMetadataLoader(())
     }
 
-    fn provide_local(_providers: &mut Providers) {
-        bug!("DummyTransCrate::provide_local");
+    fn provide(_providers: &mut Providers) {
+        bug!("DummyTransCrate::provide");
     }
 
     fn provide_extern(_providers: &mut Providers) {
@@ -185,7 +185,7 @@ impl TransCrate for MetadataOnlyTransCrate {
         box NoLlvmMetadataLoader
     }
 
-    fn provide_local(_providers: &mut Providers) {}
+    fn provide(_providers: &mut Providers) {}
     fn provide_extern(_providers: &mut Providers) {}
 
     fn trans_crate<'a, 'tcx>(

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -154,9 +154,9 @@ pub fn run_core(search_paths: SearchPaths,
     target_features::add_configuration(&mut cfg, &sess);
     sess.parse_sess.config = cfg;
 
-    let krate = panictry!(driver::phase_1_parse_input(&driver::CompileController::basic(),
-                                                      &sess,
-                                                      &input));
+    let control = &driver::CompileController::basic();
+
+    let krate = panictry!(driver::phase_1_parse_input(control, &sess, &input));
     let krate = ReplaceBodyWithLoop::new().fold_crate(krate);
 
     let name = link::find_crate_name(Some(&sess), &krate.attrs, &input);
@@ -182,7 +182,8 @@ pub fn run_core(search_paths: SearchPaths,
                                                           &[],
                                                           &sess);
 
-    abort_on_err(driver::phase_3_run_analysis_passes(&sess,
+    abort_on_err(driver::phase_3_run_analysis_passes(control,
+                                                     &sess,
                                                      &*cstore,
                                                      hir_map,
                                                      analysis,


### PR DESCRIPTION
This API has been a long-time coming and will probably become the main method for custom drivers (that is, binaries other than `rustc` itself that use `librustc_driver`) to adapt the compiler's behavior.