### PR TITLE
Use multiline text for crate conflict diagnostics

### DIFF
--- a/src/librustc_metadata/locator.rs
+++ b/src/librustc_metadata/locator.rs
@@ -311,35 +311,80 @@ impl<'a> Context<'a> {
             &None => String::new(),
             &Some(ref r) => format!(" which `{}` depends on", r.ident),
         };
+        let mut msg = "the following crate versions were found:".to_string();
         let mut err = if !self.rejected_via_hash.is_empty() {
-            struct_span_err!(self.sess,
-                             self.span,
-                             E0460,
-                             "found possibly newer version of crate `{}`{}",
-                             self.ident,
-                             add)
+            let mut err = struct_span_err!(self.sess,
+                                           self.span,
+                                           E0460,
+                                           "found possibly newer version of crate `{}`{}",
+                                           self.ident,
+                                           add);
+            err.note("perhaps that crate needs to be recompiled?");
+            let mismatches = self.rejected_via_hash.iter();
+            for &CrateMismatch { ref path, .. } in mismatches {
+                msg.push_str(&format!("\ncrate `{}`: {}", self.ident, path.display()));
+            }
+            match self.root {
+                &None => {}
+                &Some(ref r) => {
+                    for path in r.paths().iter() {
+                        msg.push_str(&format!("\ncrate `{}`: {}", r.ident, path.display()));
+                    }
+                }
+            }
+            err.note(&msg);
+            err
         } else if !self.rejected_via_triple.is_empty() {
-            struct_span_err!(self.sess,
-                             self.span,
-                             E0461,
-                             "couldn't find crate `{}` with expected target triple {}{}",
-                             self.ident,
-                             self.triple,
-                             add)
+            let mut err = struct_span_err!(self.sess,
+                                           self.span,
+                                           E0461,
+                                           "couldn't find crate `{}` \
+                                            with expected target triple {}{}",
+                                           self.ident,
+                                           self.triple,
+                                           add);
+            let mismatches = self.rejected_via_triple.iter();
+            for &CrateMismatch { ref path, ref got } in mismatches {
+                msg.push_str(&format!("\ncrate `{}`, target triple {}: {}",
+                                      self.ident,
+                                      got,
+                                      path.display()));
+            }
+            err.note(&msg);
+            err
         } else if !self.rejected_via_kind.is_empty() {
-            struct_span_err!(self.sess,
-                             self.span,
-                             E0462,
-                             "found staticlib `{}` instead of rlib or dylib{}",
-                             self.ident,
-                             add)
+            let mut err = struct_span_err!(self.sess,
+                                           self.span,
+                                           E0462,
+                                           "found staticlib `{}` instead of rlib or dylib{}",
+                                           self.ident,
+                                           add);
+            err.help("please recompile that crate using --crate-type lib");
+            let mismatches = self.rejected_via_kind.iter();
+            for &CrateMismatch { ref path, .. } in mismatches {
+                msg.push_str(&format!("\ncrate `{}`: {}", self.ident, path.display()));
+            }
+            err.note(&msg);
+            err
         } else if !self.rejected_via_version.is_empty() {
-            struct_span_err!(self.sess,
-                             self.span,
-                             E0514,
-                             "found crate `{}` compiled by an incompatible version of rustc{}",
-                             self.ident,
-                             add)
+            let mut err = struct_span_err!(self.sess,
+                                           self.span,
+                                           E0514,
+                                           "found crate `{}` compiled by an incompatible version \
+                                            of rustc{}",
+                                           self.ident,
+                                           add);
+            err.help(&format!("please recompile that crate using this compiler ({})",
+                              rustc_version()));
+            let mismatches = self.rejected_via_version.iter();
+            for &CrateMismatch { ref path, ref got } in mismatches {
+                msg.push_str(&format!("\ncrate `{}` compiled by {}: {}",
+                                      self.ident,
+                                      got,
+                                      path.display()));
+            }
+            err.note(&msg);
+            err
         } else {
             let mut err = struct_span_err!(self.sess,
                                            self.span,
@@ -356,53 +401,6 @@ impl<'a> Context<'a> {
             err
         };
 
-        if !self.rejected_via_triple.is_empty() {
-            let mismatches = self.rejected_via_triple.iter();
-            for (i, &CrateMismatch { ref path, ref got }) in mismatches.enumerate() {
-                err.note(&format!("crate `{}`, path #{}, triple {}: {}",
-                                  self.ident,
-                                  i + 1,
-                                  got,
-                                  path.display()));
-            }
-        }
-        if !self.rejected_via_hash.is_empty() {
-            err.note("perhaps that crate needs to be recompiled?");
-            let mismatches = self.rejected_via_hash.iter();
-            for (i, &CrateMismatch { ref path, .. }) in mismatches.enumerate() {
-                err.note(&format!("crate `{}` path #{}: {}", self.ident, i + 1, path.display()));
-            }
-            match self.root {
-                &None => {}
-                &Some(ref r) => {
-                    for (i, path) in r.paths().iter().enumerate() {
-                        err.note(&format!("crate `{}` path #{}: {}",
-                                          r.ident,
-                                          i + 1,
-                                          path.display()));
-                    }
-                }
-            }
-        }
-        if !self.rejected_via_kind.is_empty() {
-            err.help("please recompile that crate using --crate-type lib");
-            let mismatches = self.rejected_via_kind.iter();
-            for (i, &CrateMismatch { ref path, .. }) in mismatches.enumerate() {
-                err.note(&format!("crate `{}` path #{}: {}", self.ident, i + 1, path.display()));
-            }
-        }
-        if !self.rejected_via_version.is_empty() {
-            err.help(&format!("please recompile that crate using this compiler ({})",
-                              rustc_version()));
-            let mismatches = self.rejected_via_version.iter();
-            for (i, &CrateMismatch { ref path, ref got }) in mismatches.enumerate() {
-                err.note(&format!("crate `{}` path #{}: {} compiled by {:?}",
-                                  self.ident,
-                                  i + 1,
-                                  path.display(),
-                                  got));
-            }
-        }
         if !self.rejected_via_filename.is_empty() {
             let dylibname = self.dylibname();
             let mismatches = self.rejected_via_filename.iter();
@@ -534,16 +532,23 @@ impl<'a> Context<'a> {
                                                E0464,
                                                "multiple matching crates for `{}`",
                                                self.crate_name);
-                err.note("candidates:");
-                for (_, lib) in libraries {
-                    if let Some((ref p, _)) = lib.dylib {
-                        err.note(&format!("path: {}", p.display()));
+                let candidates = libraries.iter().filter_map(|(_, lib)| {
+                    let crate_name = &lib.metadata.get_root().name.as_str();
+                    match &(&lib.dylib, &lib.rlib) {
+                        &(&Some((ref pd, _)), &Some((ref pr, _))) => {
+                            Some(format!("\ncrate `{}`: {}\n{:>padding$}",
+                                         crate_name,
+                                         pd.display(),
+                                         pr.display(),
+                                         padding=8 + crate_name.len()))
+                        }
+                        &(&Some((ref p, _)), &None) | &(&None, &Some((ref p, _))) => {
+                            Some(format!("\ncrate `{}`: {}", crate_name, p.display()))
+                        }
+                        &(&None, &None) => None,
                     }
-                    if let Some((ref p, _)) = lib.rlib {
-                        err.note(&format!("path: {}", p.display()));
-                    }
-                    note_crate_name(&mut err, &lib.metadata.get_root().name.as_str());
-                }
+                }).collect::<String>();
+                err.note(&format!("candidates:{}", candidates));
                 err.emit();
                 None
             }
@@ -813,10 +818,6 @@ impl<'a> Context<'a> {
             None => None,
         }
     }
-}
-
-pub fn note_crate_name(err: &mut DiagnosticBuilder, name: &str) {
-    err.note(&format!("crate name: {}", name));
 }
 
 // Just a small wrapper to time how long reading metadata takes.

--- a/src/test/compile-fail/changing-crates.rs
+++ b/src/test/compile-fail/changing-crates.rs
@@ -17,8 +17,7 @@
 
 extern crate a;
 extern crate b; //~ ERROR: found possibly newer version of crate `a` which `b` depends on
+//~| NOTE: the following crate versions were found
 //~| NOTE: perhaps that crate needs to be recompiled
-//~| NOTE: crate `a` path #1:
-//~| NOTE: crate `b` path #1:
 
 fn main() {}

--- a/src/test/compile-fail/svh-change-lit.rs
+++ b/src/test/compile-fail/svh-change-lit.rs
@@ -18,8 +18,7 @@
 extern crate a;
 extern crate b; //~ ERROR: found possibly newer version of crate `a` which `b` depends on
 //~| NOTE: perhaps that crate needs to be recompiled
-//~| NOTE: crate `a` path #1:
-//~| NOTE: crate `b` path #1:
+//~| NOTE: the following crate versions were found:
 
 fn main() {
     b::foo()

--- a/src/test/compile-fail/svh-change-significant-cfg.rs
+++ b/src/test/compile-fail/svh-change-significant-cfg.rs
@@ -18,8 +18,7 @@
 extern crate a;
 extern crate b; //~ ERROR: found possibly newer version of crate `a` which `b` depends on
 //~| NOTE: perhaps that crate needs to be recompiled
-//~| NOTE: crate `a` path #1:
-//~| NOTE: crate `b` path #1:
+//~| NOTE: the following crate versions were found:
 
 fn main() {
     b::foo()

--- a/src/test/compile-fail/svh-change-trait-bound.rs
+++ b/src/test/compile-fail/svh-change-trait-bound.rs
@@ -18,8 +18,7 @@
 extern crate a;
 extern crate b; //~ ERROR: found possibly newer version of crate `a` which `b` depends on
 //~| NOTE: perhaps that crate needs to be recompiled
-//~| NOTE: crate `a` path #1:
-//~| NOTE: crate `b` path #1:
+//~| NOTE: the following crate versions were found:
 
 fn main() {
     b::foo()

--- a/src/test/compile-fail/svh-change-type-arg.rs
+++ b/src/test/compile-fail/svh-change-type-arg.rs
@@ -18,8 +18,7 @@
 extern crate a;
 extern crate b; //~ ERROR: found possibly newer version of crate `a` which `b` depends on
 //~| NOTE: perhaps that crate needs to be recompiled
-//~| NOTE: crate `a` path #1:
-//~| NOTE: crate `b` path #1:
+//~| NOTE: the following crate versions were found:
 
 fn main() {
     b::foo()

--- a/src/test/compile-fail/svh-change-type-ret.rs
+++ b/src/test/compile-fail/svh-change-type-ret.rs
@@ -18,8 +18,7 @@
 extern crate a;
 extern crate b; //~ ERROR: found possibly newer version of crate `a` which `b` depends on
 //~| NOTE: perhaps that crate needs to be recompiled
-//~| NOTE: crate `a` path #1:
-//~| NOTE: crate `b` path #1:
+//~| NOTE: the following crate versions were found:
 
 fn main() {
     b::foo()

--- a/src/test/compile-fail/svh-change-type-static.rs
+++ b/src/test/compile-fail/svh-change-type-static.rs
@@ -18,8 +18,7 @@
 extern crate a;
 extern crate b; //~ ERROR: found possibly newer version of crate `a` which `b` depends on
 //~| NOTE: perhaps that crate needs to be recompiled
-//~| NOTE: crate `a` path #1:
-//~| NOTE: crate `b` path #1:
+//~| NOTE: the following crate versions were found:
 
 fn main() {
     b::foo()

--- a/src/test/compile-fail/svh-use-trait.rs
+++ b/src/test/compile-fail/svh-use-trait.rs
@@ -23,8 +23,7 @@
 extern crate uta;
 extern crate utb; //~ ERROR: found possibly newer version of crate `uta` which `utb` depends
 //~| NOTE: perhaps that crate needs to be recompiled?
-//~| NOTE: crate `uta` path #1:
-//~| NOTE: crate `utb` path #1:
+//~| NOTE: the following crate versions were found:
 
 fn main() {
     utb::foo()

--- a/src/test/run-make/many-crates-but-no-match/Makefile
+++ b/src/test/run-make/many-crates-but-no-match/Makefile
@@ -29,6 +29,5 @@ all:
 	$(RUSTC) -L $(A2) -L $(A3) crateC.rs >$(LOG) 2>&1 || true
 	grep "found possibly newer version of crate \`crateA\` which \`crateB\` depends on" $(LOG)
 	grep "note: perhaps that crate needs to be recompiled?" $(LOG)
-	grep "note: crate \`crateA\` path #1:" $(LOG)
-	grep "note: crate \`crateA\` path #2:" $(LOG)
-	grep "note: crate \`crateB\` path #1:" $(LOG)
+	grep "crate \`crateA\`:" $(LOG)  # this will match two entries
+	grep "crate \`crateB\`:" $(LOG)


### PR DESCRIPTION
After:
```
error[E0464]: multiple matching crates for `libc`
 --> /checkout/src/rustc/dlmalloc_shim/../../dlmalloc/src/linux.rs:1:1
  |
1 | extern crate libc;
  | ^^^^^^^^^^^^^^^^^^
  |
  = note: candidates:
          crate `libc`: /checkout/obj/build/x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-gnu/lib/liblibc-658d35794c10b003.rlib
          crate `libc`: /checkout/obj/build/x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-gnu/lib/liblibc-f32a17a3111b01aa.rlib
```
Before:
```
error[E0464]: multiple matching crates for `libc`
 --> /checkout/src/rustc/dlmalloc_shim/../../dlmalloc/src/linux.rs:1:1
  |
1 | extern crate libc;
  | ^^^^^^^^^^^^^^^^^^
  |
  = note: candidates:
  = note: path: /checkout/obj/build/x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-gnu/lib/liblibc-658d35794c10b003.rlib
  = note: crate name: libc
  = note: path: /checkout/obj/build/x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-gnu/lib/liblibc-f32a17a3111b01aa.rlib
  = note: crate name: libc
```