### PR TITLE
Beta next

### DIFF
--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -29,7 +29,7 @@ pub const CFG_RELEASE_NUM: &str = "1.22.0";
 // An optional number to put after the label, e.g. '.2' -> '-beta.2'
 // Be sure to make this starts with a dot to conform to semver pre-release
 // versions (section 9)
-pub const CFG_PRERELEASE_VERSION: &str = ".2";
+pub const CFG_PRERELEASE_VERSION: &str = ".3";
 
 pub struct GitInfo {
     inner: Option<Info>,

--- a/src/libbacktrace/configure
+++ b/src/libbacktrace/configure
@@ -12323,6 +12323,12 @@ fi
 
   fi
 fi
+
+case "${host_os}" in
+darwin*)
+  have_mmap=no ;;
+esac
+
 if test "$have_mmap" = "no"; then
   VIEW_FILE=read.lo
   ALLOC_FILE=alloc.lo

--- a/src/libbacktrace/configure.ac
+++ b/src/libbacktrace/configure.ac
@@ -283,6 +283,12 @@ else
     AC_CHECK_FUNC(mmap, [have_mmap=yes], [have_mmap=no])
   fi
 fi
+
+case "${host_os}" in
+darwin*)
+  have_mmap=no ;;
+esac
+
 if test "$have_mmap" = "no"; then
   VIEW_FILE=read.lo
   ALLOC_FILE=alloc.lo

--- a/src/test/run-pass/issue-45731.rs
+++ b/src/test/run-pass/issue-45731.rs
@@ -1,0 +1,34 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:--test -g
+
+use std::{env, panic, fs};
+
+#[cfg(target_os = "macos")]
+#[test]
+fn simple_test() {
+    // Find our dSYM and replace the DWARF binary with an empty file
+    let mut dsym_path = env::current_exe().unwrap();
+    let executable_name = dsym_path.file_name().unwrap().to_str().unwrap().to_string();
+    assert!(dsym_path.pop()); // Pop executable
+    dsym_path.push(format!("{}.dSYM/Contents/Resources/DWARF/{0}", executable_name));
+    {
+        let file = fs::OpenOptions::new().read(false).write(true).truncate(true).create(false)
+            .open(&dsym_path).unwrap();
+    }
+
+    env::set_var("RUST_BACKTRACE", "1");
+
+    // We don't need to die of panic, just trigger a backtrace
+    let _ = panic::catch_unwind(|| {
+        assert!(false);
+    });
+}


### PR DESCRIPTION
This updates beta Cargo (brings https://github.com/rust-lang/cargo/pull/4716 and https://github.com/rust-lang/cargo/pull/4715), and also includes https://github.com/rust-lang/rust/pull/45866.

This PR also bumps beta to .3 so that we can get a beta release soon.