### PR TITLE
Display `\t` in diagnostics code as four spaces

### DIFF
--- a/src/librustc_errors/styled_buffer.rs
+++ b/src/librustc_errors/styled_buffer.rs
@@ -27,10 +27,21 @@ impl StyledBuffer {
     }
 
     fn replace_tabs(&mut self) {
-        for line in self.text.iter_mut() {
-            for c in line.iter_mut() {
+        for (line_pos, line) in self.text.iter_mut().enumerate() {
+            let mut tab_pos = vec![];
+            for (pos, c) in line.iter().enumerate() {
                 if *c == '\t' {
-                    *c = ' ';
+                    tab_pos.push(pos);
+                }
+            }
+            // start with the tabs at the end of the line to replace them with 4 space chars
+            for pos in tab_pos.iter().rev() {
+                assert_eq!(line.remove(*pos), '\t');
+                // fix the position of the style to match up after replacing the tabs
+                let s = self.styles[line_pos].remove(*pos);
+                for _ in 0..4 {
+                    line.insert(*pos, ' ');
+                    self.styles[line_pos].insert(*pos, s);
                 }
             }
         }

--- a/src/test/ui/codemap_tests/tab.stderr
+++ b/src/test/ui/codemap_tests/tab.stderr
@@ -1,16 +1,16 @@
 error[E0425]: cannot find value `bar` in this scope
   --> $DIR/tab.rs:14:2
    |
-14 |  bar; //~ ERROR cannot find value `bar`
-   |  ^^^ not found in this scope
+14 |     bar; //~ ERROR cannot find value `bar`
+   |     ^^^ not found in this scope
 
 error[E0308]: mismatched types
   --> $DIR/tab.rs:18:2
    |
 17 | fn foo() {
    |          - help: try adding a return type: `-> &'static str `
-18 |  "bar   boo" //~ ERROR mismatched types
-   |  ^^^^^^^^^^^ expected (), found reference
+18 |     "bar            boo" //~ ERROR mismatched types
+   |     ^^^^^^^^^^^^^^^^^^^^ expected (), found reference
    |
    = note: expected type `()`
               found type `&'static str`

--- a/src/test/ui/codemap_tests/tab_2.stderr
+++ b/src/test/ui/codemap_tests/tab_2.stderr
@@ -1,8 +1,8 @@
 error: unterminated double quote string
   --> $DIR/tab_2.rs:14:7
    |
-14 |       """; //~ ERROR unterminated double quote
-   |  _______^
+14 |                   """; //~ ERROR unterminated double quote
+   |  ___________________^
 15 | | }
    | |__^
 

--- a/src/test/ui/codemap_tests/tab_3.stderr
+++ b/src/test/ui/codemap_tests/tab_3.stderr
@@ -1,11 +1,11 @@
 error[E0382]: use of moved value: `some_vec`
   --> $DIR/tab_3.rs:17:20
    |
-15 |  some_vec.into_iter();
-   |  -------- value moved here
-16 |  {
-17 |   println!("{:?}", some_vec); //~ ERROR use of moved
-   |                    ^^^^^^^^ value used here after move
+15 |     some_vec.into_iter();
+   |     -------- value moved here
+16 |     {
+17 |         println!("{:?}", some_vec); //~ ERROR use of moved
+   |                          ^^^^^^^^ value used here after move
    |
    = note: move occurs because `some_vec` has type `std::vec::Vec<&str>`, which does not implement the `Copy` trait
 


### PR DESCRIPTION
Follow up to #44386 using the unicode variable width machinery from #45711 to replace tabs in the source code when displaying a diagnostic error with four spaces (instead of only one), while properly accounting for this when calculating underlines.

Partly addresses #44618.