### PR TITLE
Use more convenient and UNIX-agnostic shebang

### DIFF
--- a/src/etc/test-float-parse/runtests.py
+++ b/src/etc/test-float-parse/runtests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python2.7
 #
 # Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at

--- a/src/test/ui/update-all-references.sh
+++ b/src/test/ui/update-all-references.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at

--- a/src/test/ui/update-references.sh
+++ b/src/test/ui/update-references.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at


### PR DESCRIPTION
When using bash-specific features, scripts using env to call bash
are more convenient, as bash be installed in different places
according the OS.