### PR TITLE
Use #!/usr/bin/env as shebang for Bash scripts

### DIFF
--- a/src/ci/docker/cross/build-arm-musl.sh
+++ b/src/ci/docker/cross/build-arm-musl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/cross/build-rumprun.sh
+++ b/src/ci/docker/cross/build-rumprun.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/cross/install-x86_64-redox.sh
+++ b/src/ci/docker/cross/install-x86_64-redox.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/cross2/build-fuchsia-toolchain.sh
+++ b/src/ci/docker/cross2/build-fuchsia-toolchain.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/cross2/build-solaris-toolchain.sh
+++ b/src/ci/docker/cross2/build-solaris-toolchain.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/disabled/dist-x86_64-dragonfly/build-toolchain.sh
+++ b/src/ci/docker/disabled/dist-x86_64-dragonfly/build-toolchain.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/disabled/dist-x86_64-haiku/build-toolchain.sh
+++ b/src/ci/docker/disabled/dist-x86_64-haiku/build-toolchain.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/disabled/dist-x86_64-haiku/fetch-packages.sh
+++ b/src/ci/docker/disabled/dist-x86_64-haiku/fetch-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/disabled/wasm32-exp/node.sh
+++ b/src/ci/docker/disabled/wasm32-exp/node.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-aarch64-linux/build-toolchains.sh
+++ b/src/ci/docker/dist-aarch64-linux/build-toolchains.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-arm-linux/build-toolchains.sh
+++ b/src/ci/docker/dist-arm-linux/build-toolchains.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-armhf-linux/build-toolchains.sh
+++ b/src/ci/docker/dist-armhf-linux/build-toolchains.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-armv7-linux/build-toolchains.sh
+++ b/src/ci/docker/dist-armv7-linux/build-toolchains.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-i686-freebsd/build-toolchain.sh
+++ b/src/ci/docker/dist-i686-freebsd/build-toolchain.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-i686-linux/build-binutils.sh
+++ b/src/ci/docker/dist-i686-linux/build-binutils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-i686-linux/build-cmake.sh
+++ b/src/ci/docker/dist-i686-linux/build-cmake.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-i686-linux/build-curl.sh
+++ b/src/ci/docker/dist-i686-linux/build-curl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-i686-linux/build-gcc.sh
+++ b/src/ci/docker/dist-i686-linux/build-gcc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-i686-linux/build-git.sh
+++ b/src/ci/docker/dist-i686-linux/build-git.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-i686-linux/build-headers.sh
+++ b/src/ci/docker/dist-i686-linux/build-headers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-i686-linux/build-openssl.sh
+++ b/src/ci/docker/dist-i686-linux/build-openssl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-i686-linux/build-python.sh
+++ b/src/ci/docker/dist-i686-linux/build-python.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-powerpc-linux/build-powerpc-toolchain.sh
+++ b/src/ci/docker/dist-powerpc-linux/build-powerpc-toolchain.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-powerpc64-linux/build-powerpc64-toolchain.sh
+++ b/src/ci/docker/dist-powerpc64-linux/build-powerpc64-toolchain.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-powerpc64le-linux/build-powerpc64le-toolchain.sh
+++ b/src/ci/docker/dist-powerpc64le-linux/build-powerpc64le-toolchain.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-s390x-linux/build-s390x-toolchain.sh
+++ b/src/ci/docker/dist-s390x-linux/build-s390x-toolchain.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-x86_64-freebsd/build-toolchain.sh
+++ b/src/ci/docker/dist-x86_64-freebsd/build-toolchain.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-x86_64-linux/build-binutils.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-binutils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-x86_64-linux/build-cmake.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-cmake.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-x86_64-linux/build-curl.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-curl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-x86_64-linux/build-gcc.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-gcc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-x86_64-linux/build-git.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-git.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-x86_64-linux/build-headers.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-headers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-x86_64-linux/build-openssl.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-openssl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-x86_64-linux/build-python.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-python.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/docker/dist-x86_64-netbsd/build-netbsd-toolchain.sh
+++ b/src/ci/docker/dist-x86_64-netbsd/build-netbsd-toolchain.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.
@@ -64,12 +64,12 @@ cd ../..
 rm -rf usr
 
 cat > /x-tools/x86_64-unknown-netbsd/bin/x86_64--netbsd-gcc-sysroot <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 exec /x-tools/x86_64-unknown-netbsd/bin/x86_64--netbsd-gcc --sysroot=/x-tools/x86_64-unknown-netbsd/sysroot "$@"
 EOF
 
 cat > /x-tools/x86_64-unknown-netbsd/bin/x86_64--netbsd-g++-sysroot <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 exec /x-tools/x86_64-unknown-netbsd/bin/x86_64--netbsd-g++ --sysroot=/x-tools/x86_64-unknown-netbsd/sysroot "$@"
 EOF
 

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/init_repo.sh
+++ b/src/ci/init_repo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.


### PR DESCRIPTION
On some systems, the bash command could be available in another
directory than /bin. As such, to offer an env shebang is more
convenient.

This make sense even for docker scripts, as you can use Docker
on FreeBSD or SmartOS for example.