### PR TITLE
MIR-borrowck: don't ICE for cannot move from array error

### DIFF
--- a/src/librustc_mir/borrow_check.rs
+++ b/src/librustc_mir/borrow_check.rs
@@ -95,9 +95,7 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(infcx: &InferCtxt<'a, 'gcx, 'tcx>,
                         tcx.cannot_move_out_of(span, "borrowed_content", origin),
                     IllegalMoveOriginKind::InteriorOfTypeWithDestructor { container_ty: ty } =>
                         tcx.cannot_move_out_of_interior_of_drop(span, ty, origin),
-                    IllegalMoveOriginKind::InteriorOfSlice { elem_ty: ty, is_index } =>
-                        tcx.cannot_move_out_of_interior_noncopy(span, ty, is_index, origin),
-                    IllegalMoveOriginKind::InteriorOfArray { elem_ty: ty, is_index } =>
+                    IllegalMoveOriginKind::InteriorOfSliceOrArray { ty, is_index } =>
                         tcx.cannot_move_out_of_interior_noncopy(span, ty, is_index, origin),
                 };
                 err.emit();

--- a/src/librustc_mir/dataflow/move_paths/builder.rs
+++ b/src/librustc_mir/dataflow/move_paths/builder.rs
@@ -137,21 +137,21 @@ impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
             // move out of union - always move the entire union
             ty::TyAdt(adt, _) if adt.is_union() =>
                 return Err(MoveError::UnionMove { path: base }),
-            ty::TySlice(elem_ty) =>
+            ty::TySlice(_) =>
                 return Err(MoveError::cannot_move_out_of(
                     mir.source_info(self.loc).span,
-                    InteriorOfSlice {
-                        elem_ty, is_index: match proj.elem {
+                    InteriorOfSliceOrArray {
+                        ty: lv_ty, is_index: match proj.elem {
                             ProjectionElem::Index(..) => true,
                             _ => false
                         },
                     })),
-            ty::TyArray(elem_ty, _num_elems) => match proj.elem {
+            ty::TyArray(..) => match proj.elem {
                 ProjectionElem::Index(..) =>
                     return Err(MoveError::cannot_move_out_of(
                         mir.source_info(self.loc).span,
-                        InteriorOfArray {
-                            elem_ty, is_index: true
+                        InteriorOfSliceOrArray {
+                            ty: lv_ty, is_index: true
                         })),
                 _ => {
                     // FIXME: still badly broken

--- a/src/librustc_mir/dataflow/move_paths/mod.rs
+++ b/src/librustc_mir/dataflow/move_paths/mod.rs
@@ -239,8 +239,7 @@ pub(crate) enum IllegalMoveOriginKind<'tcx> {
     Static,
     BorrowedContent,
     InteriorOfTypeWithDestructor { container_ty: ty::Ty<'tcx> },
-    InteriorOfSlice { elem_ty: ty::Ty<'tcx>, is_index: bool, },
-    InteriorOfArray { elem_ty: ty::Ty<'tcx>, is_index: bool, },
+    InteriorOfSliceOrArray { ty: ty::Ty<'tcx>, is_index: bool, },
 }
 
 #[derive(Debug)]

--- a/src/test/compile-fail/E0508.rs
+++ b/src/test/compile-fail/E0508.rs
@@ -8,9 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// revisions: ast mir
+//[mir]compile-flags: -Zborrowck-mir
+
 struct NonCopy;
 
 fn main() {
     let array = [NonCopy; 1];
-    let _value = array[0]; //~ ERROR E0508
+    let _value = array[0];  //[ast]~ ERROR E0508
+                            //[mir]~^ ERROR (Ast) [E0508]
+                            //[mir]~| ERROR (Mir) [E0508]
 }


### PR DESCRIPTION
Closes #45694
compile-fail test E0508 now gives
```text
error[E0508]: cannot move out of type `[NonCopy; 1]`, a non-copy array (Ast)
  --> .\src\test\compile-fail\E0508.rs:18:18
   |
18 |     let _value = array[0];  //[ast]~ ERROR E0508
   |                  ^^^^^^^^
   |                  |
   |                  cannot move out of here
   |                  help: consider using a reference instead: `&array[0]`

error[E0508]: cannot move out of type `[NonCopy; 1]`, a non-copy array (Mir)
  --> .\src\test\compile-fail\E0508.rs:18:18
   |
18 |     let _value = array[0];  //[ast]~ ERROR E0508
   |                  ^^^^^^^^ cannot move out of here

error: aborting due to 2 previous errors
```
