### PR TITLE
rustbuild: Install rustfmt as part of extended build

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -264,7 +264,7 @@ impl<'a> Builder<'a> {
                 dist::Rls, dist::Rustfmt, dist::Extended, dist::HashSign,
                 dist::DontDistWithMiriEnabled),
             Kind::Install => describe!(install::Docs, install::Std, install::Cargo, install::Rls,
-                install::Analysis, install::Src, install::Rustc),
+                install::Rustfmt, install::Analysis, install::Src, install::Rustc),
         }
     }
 

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -39,6 +39,10 @@ pub fn install_rls(builder: &Builder, stage: u32, host: Interned<String>) {
     install_sh(builder, "rls", "rls", stage, Some(host));
 }
 
+pub fn install_rustfmt(builder: &Builder, stage: u32, host: Interned<String>) {
+    install_sh(builder, "rustfmt", "rustfmt", stage, Some(host));
+}
+
 pub fn install_analysis(builder: &Builder, stage: u32, host: Interned<String>) {
     install_sh(builder, "analysis", "rust-analysis", stage, Some(host));
 }
@@ -190,6 +194,13 @@ install!((self, builder, _config),
             install_rls(builder, self.stage, self.target);
         } else {
             println!("skipping Install RLS stage{} ({})", self.stage, self.target);
+        }
+    };
+    Rustfmt, "rustfmt", _config.extended, only_hosts: true, {
+        if builder.ensure(dist::Rustfmt { stage: self.stage, target: self.target }).is_some() {
+            install_rustfmt(builder, self.stage, self.target);
+        } else {
+            println!("skipping Install Rustfmt stage{} ({})", self.stage, self.target);
         }
     };
     Analysis, "analysis", _config.extended, only_hosts: false, {


### PR DESCRIPTION
Now that we distribute it, this allows `./x.py install` to install it too