### PR TITLE
check_unsafety: fix unused unsafe block duplication

### DIFF
--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -128,7 +128,6 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
                     let UnsafetyCheckResult {
                         violations, unsafe_blocks
                     } = self.tcx.unsafety_check_result(def_id);
-                    self.inherited_blocks.extend(unsafe_blocks.iter().cloned());
                     self.register_violations(&violations, &unsafe_blocks);
                 }
             }

--- a/src/test/ui/issue-45107-unnecessary-unsafe-in-closure.stderr
+++ b/src/test/ui/issue-45107-unnecessary-unsafe-in-closure.stderr
@@ -36,15 +36,16 @@ error: unnecessary `unsafe` block
    | |_________________^ unnecessary `unsafe` block
    |
 note: because it's nested under this `unsafe` block
-  --> $DIR/issue-45107-unnecessary-unsafe-in-closure.rs:17:13
+  --> $DIR/issue-45107-unnecessary-unsafe-in-closure.rs:15:5
    |
-17 | /             unsafe {
+15 | /     unsafe {
+16 | |         let f = |v: &mut Vec<_>| {
+17 | |             unsafe {
 18 | |                 v.set_len(24);
-19 | |                 |w: &mut Vec<u32>| { unsafe {
-20 | |                     w.set_len(32);
-21 | |                 } };
-22 | |             }
-   | |_____________^
+...  |
+29 | |         f(&mut v);
+30 | |     }
+   | |_____^
 
 error: unnecessary `unsafe` block
   --> $DIR/issue-45107-unnecessary-unsafe-in-closure.rs:23:34
@@ -67,5 +68,5 @@ note: because it's nested under this `unsafe` block
 30 | |     }
    | |_____^
 
-error: aborting due to 6 previous errors
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
The duplicate error message is later removed by error message
deduplication, but it still appears on beta and is still a bug.

r? @eddyb