### PR TITLE
update let-expressions hash test to use `except`

### DIFF
--- a/src/test/incremental/hashes/let_expressions.rs
+++ b/src/test/incremental/hashes/let_expressions.rs
@@ -32,26 +32,9 @@ pub fn change_name() {
 }
 
 #[cfg(not(cfail1))]
-#[rustc_clean(label="Hir", cfg="cfail2")]
-#[rustc_clean(label="Hir", cfg="cfail3")]
-#[rustc_dirty(label="HirBody", cfg="cfail2")]
-#[rustc_clean(label="HirBody", cfg="cfail3")]
-#[rustc_metadata_clean(cfg="cfail2")]
-#[rustc_metadata_clean(cfg="cfail3")]
-#[rustc_dirty(label="MirValidated", cfg="cfail2")]
-#[rustc_clean(label="MirValidated", cfg="cfail3")]
-#[rustc_dirty(label="MirOptimized", cfg="cfail2")]
-#[rustc_clean(label="MirOptimized", cfg="cfail3")]
-#[rustc_clean(label="TypeckTables", cfg="cfail2")]
-#[rustc_clean(label="TypeckTables", cfg="cfail3")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
-#[rustc_clean(label="FnSignature", cfg="cfail2")]
-#[rustc_clean(label="FnSignature", cfg="cfail3")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
+#[rustc_clean(cfg="cfail2",
+    except="HirBody,MirValidated,MirOptimized")]
+#[rustc_clean(cfg="cfail3")]
 pub fn change_name() {
     let _y = 2u64;
 }
@@ -65,26 +48,11 @@ pub fn add_type() {
 }
 
 #[cfg(not(cfail1))]
-#[rustc_clean(label="Hir", cfg="cfail2")]
-#[rustc_clean(label="Hir", cfg="cfail3")]
-#[rustc_dirty(label="HirBody", cfg="cfail2")]
-#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(cfg="cfail2",
+    except="HirBody,TypeckTables")]
+#[rustc_clean(cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-#[rustc_clean(label="MirValidated", cfg="cfail2")]
-#[rustc_clean(label="MirValidated", cfg="cfail3")]
-#[rustc_clean(label="MirOptimized", cfg="cfail2")]
-#[rustc_clean(label="MirOptimized", cfg="cfail3")]
-#[rustc_dirty(label="TypeckTables", cfg="cfail2")]
-#[rustc_clean(label="TypeckTables", cfg="cfail3")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
-#[rustc_clean(label="FnSignature", cfg="cfail2")]
-#[rustc_clean(label="FnSignature", cfg="cfail3")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn add_type() {
     let _x: u32 = 2u32;
 }
@@ -98,26 +66,11 @@ pub fn change_type() {
 }
 
 #[cfg(not(cfail1))]
-#[rustc_clean(label="Hir", cfg="cfail2")]
-#[rustc_clean(label="Hir", cfg="cfail3")]
-#[rustc_dirty(label="HirBody", cfg="cfail2")]
-#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(cfg="cfail2",
+    except="HirBody,TypeckTables,MirValidated,MirOptimized")]
+#[rustc_clean(cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-#[rustc_dirty(label="MirValidated", cfg="cfail2")]
-#[rustc_clean(label="MirValidated", cfg="cfail3")]
-#[rustc_dirty(label="MirOptimized", cfg="cfail2")]
-#[rustc_clean(label="MirOptimized", cfg="cfail3")]
-#[rustc_dirty(label="TypeckTables", cfg="cfail2")]
-#[rustc_clean(label="TypeckTables", cfg="cfail3")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
-#[rustc_clean(label="FnSignature", cfg="cfail2")]
-#[rustc_clean(label="FnSignature", cfg="cfail3")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn change_type() {
     let _x: u8 = 2;
 }
@@ -131,26 +84,11 @@ pub fn change_mutability_of_reference_type() {
 }
 
 #[cfg(not(cfail1))]
-#[rustc_clean(label="Hir", cfg="cfail2")]
-#[rustc_clean(label="Hir", cfg="cfail3")]
-#[rustc_dirty(label="HirBody", cfg="cfail2")]
-#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(cfg="cfail2",
+    except="HirBody,TypeckTables,MirValidated")]
+#[rustc_clean(cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-#[rustc_dirty(label="MirValidated", cfg="cfail2")]
-#[rustc_clean(label="MirValidated", cfg="cfail3")]
-#[rustc_clean(label="MirOptimized", cfg="cfail2")]
-#[rustc_clean(label="MirOptimized", cfg="cfail3")]
-#[rustc_dirty(label="TypeckTables", cfg="cfail2")]
-#[rustc_clean(label="TypeckTables", cfg="cfail3")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
-#[rustc_clean(label="FnSignature", cfg="cfail2")]
-#[rustc_clean(label="FnSignature", cfg="cfail3")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn change_mutability_of_reference_type() {
     let _x: &mut u64;
 }
@@ -164,26 +102,11 @@ pub fn change_mutability_of_slot() {
 }
 
 #[cfg(not(cfail1))]
-#[rustc_clean(label="Hir", cfg="cfail2")]
-#[rustc_clean(label="Hir", cfg="cfail3")]
-#[rustc_dirty(label="HirBody", cfg="cfail2")]
-#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(cfg="cfail2",
+    except="HirBody,TypeckTables,MirValidated,MirOptimized")]
+#[rustc_clean(cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-#[rustc_dirty(label="MirValidated", cfg="cfail2")]
-#[rustc_clean(label="MirValidated", cfg="cfail3")]
-#[rustc_dirty(label="MirOptimized", cfg="cfail2")]
-#[rustc_clean(label="MirOptimized", cfg="cfail3")]
-#[rustc_dirty(label="TypeckTables", cfg="cfail2")]
-#[rustc_clean(label="TypeckTables", cfg="cfail3")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
-#[rustc_clean(label="FnSignature", cfg="cfail2")]
-#[rustc_clean(label="FnSignature", cfg="cfail3")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn change_mutability_of_slot() {
     let _x: u64 = 0;
 }
@@ -197,26 +120,11 @@ pub fn change_simple_binding_to_pattern() {
 }
 
 #[cfg(not(cfail1))]
-#[rustc_clean(label="Hir", cfg="cfail2")]
-#[rustc_clean(label="Hir", cfg="cfail3")]
-#[rustc_dirty(label="HirBody", cfg="cfail2")]
-#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(cfg="cfail2",
+    except="HirBody,TypeckTables,MirValidated,MirOptimized")]
+#[rustc_clean(cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-#[rustc_dirty(label="MirValidated", cfg="cfail2")]
-#[rustc_clean(label="MirValidated", cfg="cfail3")]
-#[rustc_dirty(label="MirOptimized", cfg="cfail2")]
-#[rustc_clean(label="MirOptimized", cfg="cfail3")]
-#[rustc_dirty(label="TypeckTables", cfg="cfail2")]
-#[rustc_clean(label="TypeckTables", cfg="cfail3")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
-#[rustc_clean(label="FnSignature", cfg="cfail2")]
-#[rustc_clean(label="FnSignature", cfg="cfail3")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn change_simple_binding_to_pattern() {
     let (_a, _b) = (0u8, 'x');
 }
@@ -230,26 +138,11 @@ pub fn change_name_in_pattern() {
 }
 
 #[cfg(not(cfail1))]
-#[rustc_clean(label="Hir", cfg="cfail2")]
-#[rustc_clean(label="Hir", cfg="cfail3")]
-#[rustc_dirty(label="HirBody", cfg="cfail2")]
-#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(cfg="cfail2",
+    except="HirBody,MirValidated,MirOptimized")]
+#[rustc_clean(cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-#[rustc_dirty(label="MirValidated", cfg="cfail2")]
-#[rustc_clean(label="MirValidated", cfg="cfail3")]
-#[rustc_dirty(label="MirOptimized", cfg="cfail2")]
-#[rustc_clean(label="MirOptimized", cfg="cfail3")]
-#[rustc_clean(label="TypeckTables", cfg="cfail2")]
-#[rustc_clean(label="TypeckTables", cfg="cfail3")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
-#[rustc_clean(label="FnSignature", cfg="cfail2")]
-#[rustc_clean(label="FnSignature", cfg="cfail3")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn change_name_in_pattern() {
     let (_a, _c) = (1u8, 'y');
 }
@@ -263,26 +156,11 @@ pub fn add_ref_in_pattern() {
 }
 
 #[cfg(not(cfail1))]
-#[rustc_clean(label="Hir", cfg="cfail2")]
-#[rustc_clean(label="Hir", cfg="cfail3")]
-#[rustc_dirty(label="HirBody", cfg="cfail2")]
-#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(cfg="cfail2",
+    except="HirBody,TypeckTables,MirValidated,MirOptimized")]
+#[rustc_clean(cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-#[rustc_dirty(label="MirValidated", cfg="cfail2")]
-#[rustc_clean(label="MirValidated", cfg="cfail3")]
-#[rustc_dirty(label="MirOptimized", cfg="cfail2")]
-#[rustc_clean(label="MirOptimized", cfg="cfail3")]
-#[rustc_dirty(label="TypeckTables", cfg="cfail2")]
-#[rustc_clean(label="TypeckTables", cfg="cfail3")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
-#[rustc_clean(label="FnSignature", cfg="cfail2")]
-#[rustc_clean(label="FnSignature", cfg="cfail3")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn add_ref_in_pattern() {
     let (ref _a, _b) = (1u8, 'y');
 }
@@ -296,18 +174,11 @@ pub fn add_amp_in_pattern() {
 }
 
 #[cfg(not(cfail1))]
-#[rustc_clean(label="Hir", cfg="cfail2")]
-#[rustc_clean(label="Hir", cfg="cfail3")]
-#[rustc_dirty(label="HirBody", cfg="cfail2")]
-#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(cfg="cfail2",
+    except="HirBody,TypeckTables,MirValidated,MirOptimized")]
+#[rustc_clean(cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-#[rustc_dirty(label="MirValidated", cfg="cfail2")]
-#[rustc_clean(label="MirValidated", cfg="cfail3")]
-#[rustc_dirty(label="MirOptimized", cfg="cfail2")]
-#[rustc_clean(label="MirOptimized", cfg="cfail3")]
-#[rustc_dirty(label="TypeckTables", cfg="cfail2")]
-#[rustc_clean(label="TypeckTables", cfg="cfail3")]
 pub fn add_amp_in_pattern() {
     let (&_a, _b) = (&1u8, 'y');
 }
@@ -321,26 +192,11 @@ pub fn change_mutability_of_binding_in_pattern() {
 }
 
 #[cfg(not(cfail1))]
-#[rustc_clean(label="Hir", cfg="cfail2")]
-#[rustc_clean(label="Hir", cfg="cfail3")]
-#[rustc_dirty(label="HirBody", cfg="cfail2")]
-#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(cfg="cfail2",
+    except="HirBody,TypeckTables,MirValidated,MirOptimized")]
+#[rustc_clean(cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-#[rustc_dirty(label="MirValidated", cfg="cfail2")]
-#[rustc_clean(label="MirValidated", cfg="cfail3")]
-#[rustc_dirty(label="MirOptimized", cfg="cfail2")]
-#[rustc_clean(label="MirOptimized", cfg="cfail3")]
-#[rustc_dirty(label="TypeckTables", cfg="cfail2")]
-#[rustc_clean(label="TypeckTables", cfg="cfail3")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
-#[rustc_clean(label="FnSignature", cfg="cfail2")]
-#[rustc_clean(label="FnSignature", cfg="cfail3")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn change_mutability_of_binding_in_pattern() {
     let (mut _a, _b) = (99u8, 'q');
 }
@@ -354,26 +210,11 @@ pub fn add_initializer() {
 }
 
 #[cfg(not(cfail1))]
-#[rustc_clean(label="Hir", cfg="cfail2")]
-#[rustc_clean(label="Hir", cfg="cfail3")]
-#[rustc_dirty(label="HirBody", cfg="cfail2")]
-#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(cfg="cfail2",
+    except="HirBody,TypeckTables,MirValidated,MirOptimized")]
+#[rustc_clean(cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-#[rustc_dirty(label="MirValidated", cfg="cfail2")]
-#[rustc_clean(label="MirValidated", cfg="cfail3")]
-#[rustc_dirty(label="MirOptimized", cfg="cfail2")]
-#[rustc_clean(label="MirOptimized", cfg="cfail3")]
-#[rustc_dirty(label="TypeckTables", cfg="cfail2")]
-#[rustc_clean(label="TypeckTables", cfg="cfail3")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
-#[rustc_clean(label="FnSignature", cfg="cfail2")]
-#[rustc_clean(label="FnSignature", cfg="cfail3")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn add_initializer() {
     let _x: i16 = 3i16;
 }
@@ -387,26 +228,11 @@ pub fn change_initializer() {
 }
 
 #[cfg(not(cfail1))]
-#[rustc_clean(label="Hir", cfg="cfail2")]
-#[rustc_clean(label="Hir", cfg="cfail3")]
-#[rustc_dirty(label="HirBody", cfg="cfail2")]
-#[rustc_clean(label="HirBody", cfg="cfail3")]
+#[rustc_clean(cfg="cfail2",
+    except="HirBody,MirValidated,MirOptimized")]
+#[rustc_clean(cfg="cfail3")]
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-#[rustc_dirty(label="MirValidated", cfg="cfail2")]
-#[rustc_clean(label="MirValidated", cfg="cfail3")]
-#[rustc_dirty(label="MirOptimized", cfg="cfail2")]
-#[rustc_clean(label="MirOptimized", cfg="cfail3")]
-#[rustc_clean(label="TypeckTables", cfg="cfail2")]
-#[rustc_clean(label="TypeckTables", cfg="cfail3")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail2")]
-#[rustc_clean(label="TypeOfItem", cfg="cfail3")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail2")]
-#[rustc_clean(label="GenericsOfItem", cfg="cfail3")]
-#[rustc_clean(label="FnSignature", cfg="cfail2")]
-#[rustc_clean(label="FnSignature", cfg="cfail3")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail2")]
-#[rustc_clean(label="PredicatesOfItem", cfg="cfail3")]
 pub fn change_initializer() {
     let _x = 5u16;
 }


### PR DESCRIPTION
A part of #44924, this PR updated let-expressions test using `except`.

cc @michaelwoerister 
r? @nikomatsakis 