### PR TITLE
MIR-borrowck: emit "`foo` does not live long enough" instead of borrow errors 

### DIFF
--- a/src/librustc_mir/borrow_check.rs
+++ b/src/librustc_mir/borrow_check.rs
@@ -25,7 +25,7 @@ use rustc_data_structures::indexed_set::{self, IdxSetBuf};
 use rustc_data_structures::indexed_vec::{Idx};
 
 use syntax::ast::{self};
-use syntax_pos::{DUMMY_SP, Span, MultiSpan};
+use syntax_pos::{DUMMY_SP, Span};
 
 use dataflow::{do_dataflow};
 use dataflow::{MoveDataParamEnv};
@@ -1525,9 +1525,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
             _ => span
         };
 
-        let mut err = self.tcx.path_does_not_live_long_enough(proper_span,
-                                                              "borrowed value", Origin::Mir);
-        err.span = MultiSpan::from_span(proper_span);
+        let mut err = self.tcx.path_does_not_live_long_enough(span, "borrowed value", Origin::Mir);
         err.span_label(proper_span, "temporary value created here");
         err.span_label(span, "temporary value dropped here while still borrowed");
         err.note("consider using a `let` binding to increase its lifetime");

--- a/src/test/compile-fail/issue-36082.rs
+++ b/src/test/compile-fail/issue-36082.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// revisions: ast mir
+//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+
 use std::cell::RefCell;
 
 fn main() {
@@ -16,10 +19,20 @@ fn main() {
     let x = RefCell::new((&mut r,s));
 
     let val: &_ = x.borrow().0;
-    //~^ ERROR borrowed value does not live long enough
-    //~| temporary value dropped here while still borrowed
-    //~| temporary value created here
-    //~| consider using a `let` binding to increase its lifetime
+    //[ast]~^ ERROR borrowed value does not live long enough [E0597]
+    //[ast]~| NOTE temporary value dropped here while still borrowed
+    //[ast]~| NOTE temporary value created here
+    //[ast]~| NOTE consider using a `let` binding to increase its lifetime
+    //[mir]~^^^^^ ERROR borrowed value does not live long enough (Ast) [E0597]
+    //[mir]~| NOTE temporary value dropped here while still borrowed
+    //[mir]~| NOTE temporary value created here
+    //[mir]~| NOTE consider using a `let` binding to increase its lifetime
+    //[mir]~| ERROR borrowed value does not live long enough (Mir) [E0597]
+    //[mir]~| NOTE temporary value dropped here while still borrowed
+    //[mir]~| NOTE temporary value created here
+    //[mir]~| NOTE consider using a `let` binding to increase its lifetime
     println!("{}", val);
 }
-//~^ temporary value needs to live until here
+//[ast]~^ NOTE temporary value needs to live until here
+//[mir]~^^ NOTE temporary value needs to live until here
+//[mir]~| NOTE temporary value needs to live until here


### PR DESCRIPTION
Fixes #45360. As of writing, contains deduplication of existing errors.

r? @nikomatsakis 