### PR TITLE
fix linking error on i586

### DIFF
--- a/src/ci/docker/dist-i586-gnu-i686-musl/Dockerfile
+++ b/src/ci/docker/dist-i586-gnu-i686-musl/Dockerfile
@@ -34,6 +34,7 @@ ENV RUST_CONFIGURE_ARGS \
 #
 # See: https://github.com/rust-lang/rust/issues/34978
 ENV CFLAGS_i686_unknown_linux_musl=-Wa,-mrelax-relocations=no
+ENV CFLAGS_i586_unknown_linux_gnu=-Wa,-mrelax-relocations=no
 
 ENV SCRIPT \
       python2.7 ../x.py test \


### PR DESCRIPTION
Try to fix this linking error on i586 in cross: 

https://travis-ci.org/japaric/cross/builds/302095949#L8670

The problem is that `std` is built in Ubuntu 16.04 and `cross` uses a linker from 12.04.

Currently this fix solves the problem for `i686-musl`  making it "supercompatible", this PR applies the fix to `i586` as well. 

The cross PR is here: https://github.com/japaric/cross/pull/157