### PR TITLE
examples in Cow::into_owned don't need to wrap result in Cows

### DIFF
--- a/src/liballoc/borrow.rs
+++ b/src/liballoc/borrow.rs
@@ -232,7 +232,7 @@ impl<'a, B: ?Sized> Cow<'a, B>
     ///
     /// assert_eq!(
     ///   cow.into_owned(),
-    ///   Cow::Owned(String::from(s))
+    ///   String::from(s)
     /// );
     /// ```
     ///
@@ -246,7 +246,7 @@ impl<'a, B: ?Sized> Cow<'a, B>
     ///
     /// assert_eq!(
     ///   cow.into_owned(),
-    ///   Cow::Owned(String::from(s))
+    ///   String::from(s)
     /// );
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
This totally confused me until i triple-checked the actual return value and opened the examples in the playground myself.

r? @rust-lang/docs 