### PR TITLE
Fix broken CSS for book redirect pages

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -205,10 +205,12 @@ impl Step for TheBook {
     ///
     /// * Book (first edition)
     /// * Book (second edition)
+    /// * Version info and CSS
     /// * Index page
     /// * Redirect pages
     fn run(self, builder: &Builder) {
         let build = builder.build;
+        let compiler = self.compiler;
         let target = self.target;
         let name = self.name;
         // build book first edition
@@ -223,10 +225,16 @@ impl Step for TheBook {
             name: INTERNER.intern_string(format!("{}/second-edition", name)),
         });
 
+        // build the version info page and CSS
+        builder.ensure(Standalone {
+            compiler,
+            target,
+        });
+
         // build the index page
         let index = format!("{}/index.md", name);
         println!("Documenting book index ({})", target);
-        invoke_rustdoc(builder, self.compiler, target, &index);
+        invoke_rustdoc(builder, compiler, target, &index);
 
         // build the redirect pages
         println!("Documenting book redirect pages ({})", target);
@@ -235,7 +243,7 @@ impl Step for TheBook {
             let path = file.path();
             let path = path.to_str().unwrap();
 
-            invoke_rustdoc(builder, self.compiler, target, path);
+            invoke_rustdoc(builder, compiler, target, path);
         }
     }
 }
@@ -293,24 +301,11 @@ fn invoke_rustdoc(builder: &Builder, compiler: Compiler, target: Interned<String
 
     let favicon = build.src.join("src/doc/favicon.inc");
     let footer = build.src.join("src/doc/footer.inc");
-
-    let version_input = build.src.join("src/doc/version_info.html.template");
     let version_info = out.join("version_info.html");
-
-    if !up_to_date(&version_input, &version_info) {
-        let mut info = String::new();
-        t!(t!(File::open(&version_input)).read_to_string(&mut info));
-        let info = info.replace("VERSION", &build.rust_release())
-                       .replace("SHORT_HASH", build.rust_info.sha_short().unwrap_or(""))
-                       .replace("STAMP", build.rust_info.sha().unwrap_or(""));
-        t!(t!(File::create(&version_info)).write_all(info.as_bytes()));
-    }
 
     let mut cmd = builder.rustdoc_cmd(compiler.host);
 
     let out = out.join("book");
-
-    t!(fs::copy(build.src.join("src/doc/rust.css"), out.join("rust.css")));
 
     cmd.arg("--html-after-content").arg(&footer)
         .arg("--html-before-content").arg(&version_info)
@@ -320,7 +315,7 @@ fn invoke_rustdoc(builder: &Builder, compiler: Compiler, target: Interned<String
         .arg("-o").arg(&out)
         .arg(&path)
         .arg("--markdown-css")
-        .arg("rust.css");
+        .arg("../rust.css");
 
     build.run(&mut cmd);
 }


### PR DESCRIPTION
rust.css has to be next to the font files so we shouldn't copy it for
only the book redirect pages, instead just use the version that is
already there.

This also removes the duplicate code creating version_info.html.

Fixes: #45974