### PR TITLE
Rename `Span::default` -> `Span::def_site`

### DIFF
--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -177,9 +177,10 @@ impl TokenStream {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Span(syntax_pos::Span);
 
-#[unstable(feature = "proc_macro", issue = "38356")]
-impl Default for Span {
-    fn default() -> Span {
+impl Span {
+    /// A span that resolves at the macro definition site.
+    #[unstable(feature = "proc_macro", issue = "38356")]
+    pub fn def_site() -> Span {
         ::__internal::with_sess(|(_, mark)| {
             let call_site = mark.expn_info().unwrap().call_site;
             Span(call_site.with_ctxt(SyntaxContext::empty().apply_mark(mark)))
@@ -351,7 +352,7 @@ pub struct TokenTree {
 #[unstable(feature = "proc_macro", issue = "38356")]
 impl From<TokenNode> for TokenTree {
     fn from(kind: TokenNode) -> TokenTree {
-        TokenTree { span: Span::default(), kind: kind }
+        TokenTree { span: Span::def_site(), kind: kind }
     }
 }
 

--- a/src/libproc_macro/quote.rs
+++ b/src/libproc_macro/quote.rs
@@ -168,7 +168,7 @@ impl Quote for Term {
 
 impl Quote for Span {
     fn quote(self) -> TokenStream {
-        quote!(::Span::default())
+        quote!(::Span::def_site())
     }
 }
 

--- a/src/test/ui-fulldeps/proc-macro/auxiliary/three-equals.rs
+++ b/src/test/ui-fulldeps/proc-macro/auxiliary/three-equals.rs
@@ -18,7 +18,7 @@ use proc_macro::{TokenStream, TokenNode, Span, Diagnostic};
 
 fn parse(input: TokenStream) -> Result<(), Diagnostic> {
     let mut count = 0;
-    let mut last_span = Span::default();
+    let mut last_span = Span::def_site();
     for tree in input {
         let span = tree.span;
         if count >= 3 {
@@ -37,7 +37,7 @@ fn parse(input: TokenStream) -> Result<(), Diagnostic> {
     }
 
     if count < 3 {
-        return Err(Span::default()
+        return Err(Span::def_site()
                        .error(format!("found {} equal signs, need exactly 3", count))
                        .help("input must be: `===`"))
     }


### PR DESCRIPTION
I think the explicitness here is warranted.
c.f. #45934
r? @nrc 