### PR TITLE
Fix #38878 again — restart linker when seeing SIGBUS in additional to SIGSEGV.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -254,11 +254,11 @@ after_failure:
   # Random attempt at debugging currently. Just poking around in here to see if
   # anything shows up.
   - ls -lat $HOME/Library/Logs/DiagnosticReports/
-  - find $HOME/Library/Logs/DiagnosticReports/ ! \(
-      -name '*.stage2-*.crash'
-      -name 'com.apple.CoreSimulator.CoreSimulatorService-*.crash'
-    \)
-      -exec echo -e travis_fold":start:crashlog\n\033[31;1m" {} "\033[0m" \;
+  - find $HOME/Library/Logs/DiagnosticReports
+      -type f
+      -not -name '*.stage2-*.crash'
+      -not -name 'com.apple.CoreSimulator.CoreSimulatorService-*.crash'
+      -exec printf travis_fold":start:crashlog\n\033[31;1m%s\033[0m\n" {} \;
       -exec head -750 {} \;
       -exec echo travis_fold":"end:crashlog \;
 

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -644,9 +644,9 @@ fn link_natively(sess: &Session,
         let mut out = output.stderr.clone();
         out.extend(&output.stdout);
         let out = String::from_utf8_lossy(&out);
-        let msg = "clang: error: unable to execute command: \
-                   Segmentation fault: 11";
-        if !out.contains(msg) {
+        let msg_segv = "clang: error: unable to execute command: Segmentation fault: 11";
+        let msg_bus  = "clang: error: unable to execute command: Bus error: 10";
+        if !(out.contains(msg_segv) || out.contains(msg_bus)) {
             break
         }
 


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/45985#issuecomment-344586645 we see a linker crashed due to Bus Error (signal 10) on macOS. The error was not caught by #40422 since the PR only handles Segmentation Fault (signal 11). The crash log indicates the problem is the same as #38878, so we just amend #40422 to include SIGBUS as well.

(Additionally, modified how the crash logs are printed so that irrelevant logs are truly filtered out.)