### PR TITLE
Allow filtering analysis by reachability

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1499,6 +1499,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rls-data"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rls-rustc"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,7 +1863,7 @@ name = "rustc_save_analysis"
 version = "0.0.0"
 dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-data 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-data 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc 0.0.0",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2721,6 +2730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum rls-analysis 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5b961e7270b2084839ede4d2788167086b24bc9cf09c9e955cc851afaf116054"
 "checksum rls-data 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "48257ceade23c2e01a3ca8d2fc4226101b107f6a3c868f829cf3fd2f204a1fe6"
+"checksum rls-data 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff85bb3a0daf9f64207a5530d90ae1c10f5515cef064c88b6821090678382b44"
 "checksum rls-rustc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b21ea952e9bf1569929abf1bb920262cde04b7b1b26d8e0260286302807299d2"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
 "checksum rls-vfs 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd34691a510938bb67fe0444fb363103c73ffb31c121d1e16bc92d8945ea8ff"

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -183,7 +183,8 @@ fn main() {
         if env::var("RUSTC_SAVE_ANALYSIS") == Ok("api".to_string()) {
             cmd.arg("-Zsave-analysis");
             cmd.env("RUST_SAVE_ANALYSIS_CONFIG",
-                    "{\"output_file\": null,\"full_docs\": false,\"pub_only\": true,\
+                    "{\"output_file\": null,\"full_docs\": false,\
+                     \"pub_only\": true,\"reachable_only\": false,\
                      \"distro_crate\": true,\"signatures\": false,\"borrow_data\": false}");
         }
 

--- a/src/librustc_save_analysis/Cargo.toml
+++ b/src/librustc_save_analysis/Cargo.toml
@@ -15,7 +15,7 @@ rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_typeck = { path = "../librustc_typeck" }
 syntax = { path = "../libsyntax" }
 syntax_pos = { path = "../libsyntax_pos" }
-rls-data = "0.12"
+rls-data = "0.13"
 rls-span = "0.4"
 # FIXME(#40527) should move rustc serialize out of tree
 rustc-serialize = "0.3"

--- a/src/librustc_save_analysis/json_dumper.rs
+++ b/src/librustc_save_analysis/json_dumper.rs
@@ -17,6 +17,12 @@ use rls_data::{self, Analysis, CratePreludeData, Def, DefKind, Import, MacroRef,
 use rls_data::config::Config;
 use rls_span::{Column, Row};
 
+#[derive(Debug)]
+pub struct Access {
+    pub reachable: bool,
+    pub public: bool,
+}
+
 pub struct JsonDumper<O: DumpOutput> {
     result: Analysis,
     config: Config,
@@ -84,33 +90,35 @@ impl<'b, O: DumpOutput + 'b> JsonDumper<O> {
     }
 
     pub fn macro_use(&mut self, data: MacroRef) {
-        if self.config.pub_only {
+        if self.config.pub_only || self.config.reachable_only {
             return;
         }
         self.result.macro_refs.push(data);
     }
 
-    pub fn import(&mut self, public: bool, import: Import) {
-        if !public && self.config.pub_only {
+    pub fn import(&mut self, access: &Access, import: Import) {
+        if !access.public && self.config.pub_only
+            || !access.reachable && self.config.reachable_only {
             return;
         }
         self.result.imports.push(import);
     }
 
     pub fn dump_ref(&mut self, data: Ref) {
-        if self.config.pub_only {
+        if self.config.pub_only || self.config.reachable_only {
             return;
         }
         self.result.refs.push(data);
     }
 
-    pub fn dump_def(&mut self, public: bool, mut data: Def) {
-        if !public && self.config.pub_only {
+    pub fn dump_def(&mut self, access: &Access, mut data: Def) {
+        if !access.public && self.config.pub_only
+            || !access.reachable && self.config.reachable_only {
             return;
         }
         if data.kind == DefKind::Mod && data.span.file_name.to_str().unwrap() != data.value {
-            // If the module is an out-of-line defintion, then we'll make the
-            // definition the first character in the module's file and turn the
+            // If the module is an out-of-line definition, then we'll make the
+            // definition the first character in the module's file and turn
             // the declaration into a reference to it.
             let rf = Ref {
                 kind: RefKind::Mod,


### PR DESCRIPTION
Fixes #43521.
Fixes https://github.com/nrc/rls-analysis/issues/79.

This PR allows a user to filter items present in the save-analysis data by setting the `reachable_only` config option. This option is intended for use by the new rustdoc. The PR isn't quite finished, because it's dependent on a new release of rls-data, but I want to make sure that the approach is valid.

https://github.com/nrc/rls-analysis/issues/79 mentions that `pub use` might need to be handled, but my thinking is that the consumer of the analysis data would be able to infer which imports are `pub use`, and which items are only reachable through `pub use`, so that doesn't need to be handled here.

r? @nrc 