### PR TITLE
Mir Borrowck: Parity with Ast for E0384 (Cannot assign twice to immutable)

### DIFF
--- a/src/librustc_mir/borrow_check.rs
+++ b/src/librustc_mir/borrow_check.rs
@@ -31,7 +31,7 @@ use dataflow::{do_dataflow};
 use dataflow::{MoveDataParamEnv};
 use dataflow::{BitDenotation, BlockSets, DataflowResults, DataflowResultsConsumer};
 use dataflow::{MaybeInitializedLvals, MaybeUninitializedLvals};
-use dataflow::{MovingOutStatements};
+use dataflow::{MovingOutStatements, EverInitializedLvals};
 use dataflow::{Borrows, BorrowData, BorrowIndex};
 use dataflow::move_paths::{MoveError, IllegalMoveOriginKind};
 use dataflow::move_paths::{HasMoveData, MoveData, MovePathIndex, LookupResult, MoveOutIndex};
@@ -130,6 +130,9 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(infcx: &InferCtxt<'a, 'gcx, 'tcx>,
     let flow_move_outs = do_dataflow(tcx, mir, id, &attributes, &dead_unwinds,
                                      MovingOutStatements::new(tcx, mir, &mdpe),
                                      |bd, i| &bd.move_data().moves[i]);
+    let flow_ever_inits = do_dataflow(tcx, mir, id, &attributes, &dead_unwinds,
+                                     EverInitializedLvals::new(tcx, mir, &mdpe),
+                                     |bd, i| &bd.move_data().inits[i]);
 
     let mut mbcx = MirBorrowckCtxt {
         tcx: tcx,
@@ -143,7 +146,8 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(infcx: &InferCtxt<'a, 'gcx, 'tcx>,
     let mut state = InProgress::new(flow_borrows,
                                     flow_inits,
                                     flow_uninits,
-                                    flow_move_outs);
+                                    flow_move_outs,
+                                    flow_ever_inits);
 
     mbcx.analyze_results(&mut state); // entry point for DataflowResultsConsumer
 }
@@ -167,6 +171,7 @@ pub struct InProgress<'b, 'gcx: 'tcx, 'tcx: 'b> {
     inits: FlowInProgress<MaybeInitializedLvals<'b, 'gcx, 'tcx>>,
     uninits: FlowInProgress<MaybeUninitializedLvals<'b, 'gcx, 'tcx>>,
     move_outs: FlowInProgress<MovingOutStatements<'b, 'gcx, 'tcx>>,
+    ever_inits: FlowInProgress<EverInitializedLvals<'b, 'gcx, 'tcx>>,
 }
 
 struct FlowInProgress<BD> where BD: BitDenotation {
@@ -190,7 +195,8 @@ impl<'cx, 'gcx, 'tcx> DataflowResultsConsumer<'cx, 'tcx> for MirBorrowckCtxt<'cx
         flow_state.each_flow(|b| b.reset_to_entry_of(bb),
                              |i| i.reset_to_entry_of(bb),
                              |u| u.reset_to_entry_of(bb),
-                             |m| m.reset_to_entry_of(bb));
+                             |m| m.reset_to_entry_of(bb),
+                             |e| e.reset_to_entry_of(bb));
     }
 
     fn reconstruct_statement_effect(&mut self,
@@ -199,7 +205,8 @@ impl<'cx, 'gcx, 'tcx> DataflowResultsConsumer<'cx, 'tcx> for MirBorrowckCtxt<'cx
         flow_state.each_flow(|b| b.reconstruct_statement_effect(location),
                              |i| i.reconstruct_statement_effect(location),
                              |u| u.reconstruct_statement_effect(location),
-                             |m| m.reconstruct_statement_effect(location));
+                             |m| m.reconstruct_statement_effect(location),
+                             |e| e.reconstruct_statement_effect(location));
     }
 
     fn apply_local_effect(&mut self,
@@ -208,7 +215,8 @@ impl<'cx, 'gcx, 'tcx> DataflowResultsConsumer<'cx, 'tcx> for MirBorrowckCtxt<'cx
         flow_state.each_flow(|b| b.apply_local_effect(),
                              |i| i.apply_local_effect(),
                              |u| u.apply_local_effect(),
-                             |m| m.apply_local_effect());
+                             |m| m.apply_local_effect(),
+                             |e| e.apply_local_effect());
     }
 
     fn reconstruct_terminator_effect(&mut self,
@@ -217,7 +225,8 @@ impl<'cx, 'gcx, 'tcx> DataflowResultsConsumer<'cx, 'tcx> for MirBorrowckCtxt<'cx
         flow_state.each_flow(|b| b.reconstruct_terminator_effect(location),
                              |i| i.reconstruct_terminator_effect(location),
                              |u| u.reconstruct_terminator_effect(location),
-                             |m| m.reconstruct_terminator_effect(location));
+                             |m| m.reconstruct_terminator_effect(location),
+                             |e| e.reconstruct_terminator_effect(location));
     }
 
     fn visit_block_entry(&mut self,
@@ -750,22 +759,13 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         }
 
         if let Some(mpi) = self.move_path_for_lvalue(lvalue) {
-            if flow_state.inits.curr_state.contains(&mpi) {
-                // may already be assigned before reaching this statement;
-                // report error.
-                // FIXME: Not ideal, it only finds the assignment that lexically comes first
-                let assigned_lvalue = &move_data.move_paths[mpi].lvalue;
-                let assignment_stmt = self.mir.basic_blocks().iter().filter_map(|bb| {
-                    bb.statements.iter().find(|stmt| {
-                        if let StatementKind::Assign(ref lv, _) = stmt.kind {
-                            *lv == *assigned_lvalue
-                        } else {
-                            false
-                        }
-                    })
-                }).next().unwrap();
-                self.report_illegal_reassignment(
-                    context, (lvalue, span), assignment_stmt.source_info.span);
+            for ii in &move_data.init_path_map[mpi] {
+                if flow_state.ever_inits.curr_state.contains(ii) {
+                    let first_assign_span = self.move_data.inits[*ii].span;
+                    self.report_illegal_reassignment(
+                        context, (lvalue, span), first_assign_span);
+                    break;
+                }
             }
         }
     }
@@ -1852,30 +1852,35 @@ impl<'b, 'gcx, 'tcx> InProgress<'b, 'gcx, 'tcx> {
     pub(super) fn new(borrows: DataflowResults<Borrows<'b, 'gcx, 'tcx>>,
                       inits: DataflowResults<MaybeInitializedLvals<'b, 'gcx, 'tcx>>,
                       uninits: DataflowResults<MaybeUninitializedLvals<'b, 'gcx, 'tcx>>,
-                      move_out: DataflowResults<MovingOutStatements<'b, 'gcx, 'tcx>>)
+                      move_out: DataflowResults<MovingOutStatements<'b, 'gcx, 'tcx>>,
+                      ever_inits: DataflowResults<EverInitializedLvals<'b, 'gcx, 'tcx>>)
                       -> Self {
         InProgress {
             borrows: FlowInProgress::new(borrows),
             inits: FlowInProgress::new(inits),
             uninits: FlowInProgress::new(uninits),
-            move_outs: FlowInProgress::new(move_out)
+            move_outs: FlowInProgress::new(move_out),
+            ever_inits: FlowInProgress::new(ever_inits)
         }
     }
 
-    fn each_flow<XB, XI, XU, XM>(&mut self,
+    fn each_flow<XB, XI, XU, XM, XE>(&mut self,
                                  mut xform_borrows: XB,
                                  mut xform_inits: XI,
                                  mut xform_uninits: XU,
-                                 mut xform_move_outs: XM) where
+                                 mut xform_move_outs: XM,
+                                 mut xform_ever_inits: XE) where
         XB: FnMut(&mut FlowInProgress<Borrows<'b, 'gcx, 'tcx>>),
         XI: FnMut(&mut FlowInProgress<MaybeInitializedLvals<'b, 'gcx, 'tcx>>),
         XU: FnMut(&mut FlowInProgress<MaybeUninitializedLvals<'b, 'gcx, 'tcx>>),
         XM: FnMut(&mut FlowInProgress<MovingOutStatements<'b, 'gcx, 'tcx>>),
+        XE: FnMut(&mut FlowInProgress<EverInitializedLvals<'b, 'gcx, 'tcx>>),
     {
         xform_borrows(&mut self.borrows);
         xform_inits(&mut self.inits);
         xform_uninits(&mut self.uninits);
         xform_move_outs(&mut self.move_outs);
+        xform_ever_inits(&mut self.ever_inits);
     }
 
     fn summary(&self) -> String {
@@ -1931,6 +1936,17 @@ impl<'b, 'gcx, 'tcx> InProgress<'b, 'gcx, 'tcx> {
             let move_out =
                 &self.move_outs.base_results.operator().move_data().moves[mpi_move_out];
             s.push_str(&format!("{:?}", move_out));
+        });
+        s.push_str("] ");
+
+        s.push_str("ever_init: [");
+        let mut saw_one = false;
+        self.ever_inits.each_state_bit(|mpi_ever_init| {
+            if saw_one { s.push_str(", "); };
+            saw_one = true;
+            let ever_init =
+                &self.ever_inits.base_results.operator().move_data().inits[mpi_ever_init];
+            s.push_str(&format!("{:?}", ever_init));
         });
         s.push_str("]");
 

--- a/src/librustc_mir/borrow_check.rs
+++ b/src/librustc_mir/borrow_check.rs
@@ -1586,13 +1586,15 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                                    _context: Context,
                                    (lvalue, span): (&Lvalue<'tcx>, Span),
                                    assigned_span: Span) {
-        self.tcx.cannot_reassign_immutable(span,
+        let mut err = self.tcx.cannot_reassign_immutable(span,
                                            &self.describe_lvalue(lvalue),
-                                           Origin::Mir)
-                .span_label(span, "cannot assign twice to immutable variable")
-                .span_label(assigned_span, format!("first assignment to `{}`",
-                                                   self.describe_lvalue(lvalue)))
-                .emit();
+                                           Origin::Mir);
+        err.span_label(span, "cannot assign twice to immutable variable");
+        if span != assigned_span {
+            err.span_label(assigned_span, format!("first assignment to `{}`",
+                                              self.describe_lvalue(lvalue)));
+        }
+        err.emit();
     }
 
     fn report_assignment_to_static(&mut self,

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -27,6 +27,7 @@ use std::usize;
 pub use self::impls::{MaybeStorageLive};
 pub use self::impls::{MaybeInitializedLvals, MaybeUninitializedLvals};
 pub use self::impls::{DefinitelyInitializedLvals, MovingOutStatements};
+pub use self::impls::EverInitializedLvals;
 pub use self::impls::borrows::{Borrows, BorrowData, BorrowIndex};
 pub(crate) use self::drop_flag_effects::*;
 

--- a/src/librustc_mir/dataflow/move_paths/builder.rs
+++ b/src/librustc_mir/dataflow/move_paths/builder.rs
@@ -22,7 +22,7 @@ use std::mem;
 use super::abs_domain::Lift;
 
 use super::{LocationMap, MoveData, MovePath, MovePathLookup, MovePathIndex, MoveOut, MoveOutIndex};
-use super::{MoveError};
+use super::{MoveError, InitIndex, Init, LookupResult, InitKind};
 use super::IllegalMoveOriginKind::*;
 
 struct MoveDataBuilder<'a, 'gcx: 'tcx, 'tcx: 'a> {
@@ -40,6 +40,7 @@ impl<'a, 'gcx, 'tcx> MoveDataBuilder<'a, 'gcx, 'tcx> {
            -> Self {
         let mut move_paths = IndexVec::new();
         let mut path_map = IndexVec::new();
+        let mut init_path_map = IndexVec::new();
 
         MoveDataBuilder {
             mir,
@@ -51,18 +52,28 @@ impl<'a, 'gcx, 'tcx> MoveDataBuilder<'a, 'gcx, 'tcx> {
                 loc_map: LocationMap::new(mir),
                 rev_lookup: MovePathLookup {
                     locals: mir.local_decls.indices().map(Lvalue::Local).map(|v| {
-                        Self::new_move_path(&mut move_paths, &mut path_map, None, v)
+                        Self::new_move_path(
+                            &mut move_paths,
+                            &mut path_map,
+                            &mut init_path_map,
+                            None,
+                            v,
+                        )
                     }).collect(),
                     projections: FxHashMap(),
                 },
                 move_paths,
                 path_map,
+                inits: IndexVec::new(),
+                init_loc_map: LocationMap::new(mir),
+                init_path_map,
             }
         }
     }
 
     fn new_move_path(move_paths: &mut IndexVec<MovePathIndex, MovePath<'tcx>>,
                      path_map: &mut IndexVec<MovePathIndex, Vec<MoveOutIndex>>,
+                     init_path_map: &mut IndexVec<MovePathIndex, Vec<InitIndex>>,
                      parent: Option<MovePathIndex>,
                      lvalue: Lvalue<'tcx>)
                      -> MovePathIndex
@@ -82,6 +93,10 @@ impl<'a, 'gcx, 'tcx> MoveDataBuilder<'a, 'gcx, 'tcx> {
 
         let path_map_ent = path_map.push(vec![]);
         assert_eq!(path_map_ent, move_path);
+
+        let init_path_map_ent = init_path_map.push(vec![]);
+        assert_eq!(init_path_map_ent, move_path);
+
         move_path
     }
 }
@@ -165,6 +180,7 @@ impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
                 let path = MoveDataBuilder::new_move_path(
                     &mut self.builder.data.move_paths,
                     &mut self.builder.data.path_map,
+                    &mut self.builder.data.init_path_map,
                     Some(base),
                     lval.clone()
                 );
@@ -204,6 +220,8 @@ pub(super) fn gather_moves<'a, 'gcx, 'tcx>(mir: &Mir<'tcx>,
                                                      (MoveData<'tcx>, Vec<MoveError<'tcx>>)> {
     let mut builder = MoveDataBuilder::new(mir, tcx, param_env);
 
+    builder.gather_args();
+
     for (bb, block) in mir.basic_blocks().iter_enumerated() {
         for (i, stmt) in block.statements.iter().enumerate() {
             let source = Location { block: bb, statement_index: i };
@@ -221,6 +239,22 @@ pub(super) fn gather_moves<'a, 'gcx, 'tcx>(mir: &Mir<'tcx>,
 }
 
 impl<'a, 'gcx, 'tcx> MoveDataBuilder<'a, 'gcx, 'tcx> {
+    fn gather_args(&mut self) {
+        for arg in self.mir.args_iter() {
+            let path = self.data.rev_lookup.locals[arg];
+            let span = self.mir.local_decls[arg].source_info.span;
+
+            let init = self.data.inits.push(Init {
+                path, span, kind: InitKind::Deep
+            });
+
+            debug!("gather_args: adding init {:?} of {:?} for argument {:?}",
+                init, path, arg);
+
+            self.data.init_path_map[path].push(init);
+        }
+    }
+
     fn gather_statement(&mut self, loc: Location, stmt: &Statement<'tcx>) {
         debug!("gather_statement({:?}, {:?})", loc, stmt);
         (Gatherer { builder: self, loc }).gather_statement(stmt);
@@ -247,6 +281,9 @@ impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
                     // move-path for the interior so it will be separate from
                     // the exterior.
                     self.create_move_path(&lval.clone().deref());
+                    self.gather_init(lval, InitKind::Shallow);
+                } else {
+                    self.gather_init(lval, InitKind::Deep);
                 }
                 self.gather_rvalue(rval);
             }
@@ -329,6 +366,7 @@ impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
             TerminatorKind::DropAndReplace { ref location, ref value, .. } => {
                 self.create_move_path(location);
                 self.gather_operand(value);
+                self.gather_init(location, InitKind::Deep);
             }
             TerminatorKind::Call { ref func, ref args, ref destination, cleanup: _ } => {
                 self.gather_operand(func);
@@ -337,6 +375,7 @@ impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
                 }
                 if let Some((ref destination, _bb)) = *destination {
                     self.create_move_path(destination);
+                    self.gather_init(destination, InitKind::NonPanicPathOnly);
                 }
             }
         }
@@ -377,5 +416,23 @@ impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
 
         self.builder.data.path_map[path].push(move_out);
         self.builder.data.loc_map[self.loc].push(move_out);
+    }
+
+    fn gather_init(&mut self, lval: &Lvalue<'tcx>, kind: InitKind) {
+        debug!("gather_init({:?}, {:?})", self.loc, lval);
+
+        if let LookupResult::Exact(path) = self.builder.data.rev_lookup.find(lval) {
+            let init = self.builder.data.inits.push(Init {
+                span: self.builder.mir.source_info(self.loc).span,
+                path,
+                kind,
+            });
+
+            debug!("gather_init({:?}, {:?}): adding init {:?} of {:?}",
+               self.loc, lval, init, path);
+
+            self.builder.data.init_path_map[path].push(init);
+            self.builder.data.init_loc_map[self.loc].push(init);
+        }
     }
 }

--- a/src/librustc_mir/dataflow/move_paths/mod.rs
+++ b/src/librustc_mir/dataflow/move_paths/mod.rs
@@ -60,12 +60,16 @@ pub(crate) mod indexes {
     /// Index into MoveData.moves.
     new_index!(MoveOutIndex, "mo");
 
+    /// Index into MoveData.inits.
+    new_index!(InitIndex, "in");
+
     /// Index into Borrows.locations
     new_index!(BorrowIndex, "bw");
 }
 
 pub use self::indexes::MovePathIndex;
 pub use self::indexes::MoveOutIndex;
+pub use self::indexes::InitIndex;
 
 impl MoveOutIndex {
     pub fn move_path_index(&self, move_data: &MoveData) -> MovePathIndex {
@@ -126,6 +130,11 @@ pub struct MoveData<'tcx> {
     pub loc_map: LocationMap<Vec<MoveOutIndex>>,
     pub path_map: IndexVec<MovePathIndex, Vec<MoveOutIndex>>,
     pub rev_lookup: MovePathLookup<'tcx>,
+    pub inits: IndexVec<InitIndex, Init>,
+    /// Each Location `l` is mapped to the Inits that are effects
+    /// of executing the code at `l`.
+    pub init_loc_map: LocationMap<Vec<InitIndex>>,
+    pub init_path_map: IndexVec<MovePathIndex, Vec<InitIndex>>,
 }
 
 pub trait HasMoveData<'tcx> {
@@ -179,6 +188,34 @@ pub struct MoveOut {
 impl fmt::Debug for MoveOut {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "{:?}@{:?}", self.path, self.source)
+    }
+}
+
+/// `Init` represents a point in a program that initializes some L-value;
+#[derive(Copy, Clone)]
+pub struct Init {
+    /// path being initialized
+    pub path: MovePathIndex,
+    /// span of initialization
+    pub span: Span,
+    /// Extra information about this initialization
+    pub kind: InitKind,
+}
+
+/// Additional information about the initialization.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum InitKind {
+    /// Deep init, even on panic
+    Deep,
+    /// Only does a shallow init
+    Shallow,
+    /// This doesn't initialize the variabe on panic (and a panic is possible).
+    NonPanicPathOnly,
+}
+
+impl fmt::Debug for Init {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{:?}@{:?} ({:?})", self.path, self.span, self.kind)
     }
 }
 

--- a/src/test/compile-fail/assign-imm-local-twice.rs
+++ b/src/test/compile-fail/assign-imm-local-twice.rs
@@ -8,12 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// revisions: ast mir
+//[mir]compile-flags: -Zborrowck=mir
+
 fn test() {
     let v: isize;
-    v = 1; //~ NOTE first assignment
+    v = 1; //[ast]~ NOTE first assignment
+           //[mir]~^ NOTE first assignment
     println!("v={}", v);
-    v = 2; //~ ERROR cannot assign twice to immutable variable
-           //~| NOTE cannot assign twice to immutable
+    v = 2; //[ast]~ ERROR cannot assign twice to immutable variable
+           //[mir]~^ ERROR cannot assign twice to immutable variable `v`
+           //[ast]~| NOTE cannot assign twice to immutable
+           //[mir]~| NOTE cannot assign twice to immutable
     println!("v={}", v);
 }
 

--- a/src/test/compile-fail/borrowck/borrowck-storage-dead.rs
+++ b/src/test/compile-fail/borrowck/borrowck-storage-dead.rs
@@ -16,6 +16,12 @@ fn ok() {
     }
 }
 
+fn also_ok() {
+    loop {
+        let _x = String::new();
+    }
+}
+
 fn fail() {
     loop {
         let x: i32;
@@ -26,5 +32,6 @@ fn fail() {
 
 fn main() {
     ok();
+    also_ok();
     fail();
 }

--- a/src/test/compile-fail/issue-45199.rs
+++ b/src/test/compile-fail/issue-45199.rs
@@ -1,0 +1,41 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// revisions: ast mir
+//[mir]compile-flags: -Zborrowck=mir
+
+fn test_drop_replace() {
+    let b: Box<isize>;
+    b = Box::new(1);    //[ast]~ NOTE first assignment
+                        //[mir]~^ NOTE first assignment
+    b = Box::new(2);    //[ast]~ ERROR cannot assign twice to immutable variable
+                        //[mir]~^ ERROR cannot assign twice to immutable variable `b`
+                        //[ast]~| NOTE cannot assign twice to immutable
+                        //[mir]~| NOTE cannot assign twice to immutable
+}
+
+fn test_call() {
+    let b = Box::new(1);    //[ast]~ NOTE first assignment
+                            //[mir]~^ NOTE first assignment
+    b = Box::new(2);        //[ast]~ ERROR cannot assign twice to immutable variable
+                            //[mir]~^ ERROR cannot assign twice to immutable variable `b`
+                            //[ast]~| NOTE cannot assign twice to immutable
+                            //[mir]~| NOTE cannot assign twice to immutable
+}
+
+fn test_args(b: Box<i32>) {  //[ast]~ NOTE first assignment
+                                //[mir]~^ NOTE first assignment
+    b = Box::new(2);            //[ast]~ ERROR cannot assign twice to immutable variable
+                                //[mir]~^ ERROR cannot assign twice to immutable variable `b`
+                                //[ast]~| NOTE cannot assign twice to immutable
+                                //[mir]~| NOTE cannot assign twice to immutable
+}
+
+fn main() {}

--- a/src/test/compile-fail/liveness-assign-imm-local-in-loop.rs
+++ b/src/test/compile-fail/liveness-assign-imm-local-in-loop.rs
@@ -8,11 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// revisions: ast mir
+//[mir]compile-flags: -Zborrowck=mir
+
 fn test() {
     let v: isize;
     loop {
-        v = 1; //~ ERROR cannot assign twice to immutable variable
-        //~^ NOTE cannot assign twice to immutable variable
+        v = 1; //[ast]~ ERROR cannot assign twice to immutable variable
+               //[mir]~^ ERROR cannot assign twice to immutable variable `v`
+               //[ast]~| NOTE cannot assign twice to immutable variable
+               //[mir]~| NOTE cannot assign twice to immutable variable
         v.clone(); // just to prevent liveness warnings
     }
 }

--- a/src/test/compile-fail/liveness-assign-imm-local-with-drop.rs
+++ b/src/test/compile-fail/liveness-assign-imm-local-with-drop.rs
@@ -12,14 +12,14 @@
 //[mir]compile-flags: -Zborrowck=mir
 
 fn test() {
-    let v: isize;
-    v = 2;  //[ast]~ NOTE first assignment
-            //[mir]~^ NOTE first assignment
-    v += 1; //[ast]~ ERROR cannot assign twice to immutable variable
-            //[mir]~^ ERROR cannot assign twice to immutable variable `v`
-            //[ast]~| NOTE cannot assign twice to immutable
-            //[mir]~| NOTE cannot assign twice to immutable
-    v.clone();
+    let b = Box::new(1); //[ast]~ NOTE first assignment
+                         //[mir]~^ NOTE first assignment
+    drop(b);
+    b = Box::new(2); //[ast]~ ERROR cannot assign twice to immutable variable
+                     //[mir]~^ ERROR cannot assign twice to immutable variable `b`
+                     //[ast]~| NOTE cannot assign twice to immutable
+                     //[mir]~| NOTE cannot assign twice to immutable
+    drop(b);
 }
 
 fn main() {

--- a/src/test/compile-fail/liveness-assign-imm-local-with-init.rs
+++ b/src/test/compile-fail/liveness-assign-imm-local-with-init.rs
@@ -8,11 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// revisions: ast mir
+//[mir]compile-flags: -Zborrowck=mir
+
 fn test() {
-    let v: isize = 1; //~ NOTE first assignment
+    let v: isize = 1; //[ast]~ NOTE first assignment
+                      //[mir]~^ NOTE first assignment
     v.clone();
-    v = 2; //~ ERROR cannot assign twice to immutable variable
-           //~| NOTE cannot assign twice to immutable
+    v = 2; //[ast]~ ERROR cannot assign twice to immutable variable
+           //[mir]~^ ERROR cannot assign twice to immutable variable `v`
+           //[ast]~| NOTE cannot assign twice to immutable
+           //[mir]~| NOTE cannot assign twice to immutable
     v.clone();
 }
 

--- a/src/test/ui/lifetime-errors/liveness-assign-imm-local-notes.rs
+++ b/src/test/ui/lifetime-errors/liveness-assign-imm-local-notes.rs
@@ -1,0 +1,54 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// FIXME: Change to UI Test
+// Check notes are placed on an assignment that can actually preceed the current assigmnent
+// Don't emmit a first assignment for assignment in a loop.
+
+// compile-flags: -Zborrowck=compare
+
+fn test() {
+    let x;
+    if true {
+        x = 1;
+    } else {
+        x = 2;
+        x = 3;      //~ ERROR (Ast) [E0384]
+                    //~^ ERROR (Mir) [E0384]
+    }
+}
+
+fn test_in_loop() {
+    loop {
+        let x;
+        if true {
+            x = 1;
+        } else {
+            x = 2;
+            x = 3;      //~ ERROR (Ast) [E0384]
+                        //~^ ERROR (Mir) [E0384]
+        }
+    }
+}
+
+fn test_using_loop() {
+    let x;
+    loop {
+        if true {
+            x = 1;      //~ ERROR (Ast) [E0384]
+                        //~^ ERROR (Mir) [E0384]
+        } else {
+            x = 2;      //~ ERROR (Ast) [E0384]
+                        //~^ ERROR (Mir) [E0384]
+        }
+    }
+}
+
+fn main() {}

--- a/src/test/ui/lifetime-errors/liveness-assign-imm-local-notes.stderr
+++ b/src/test/ui/lifetime-errors/liveness-assign-imm-local-notes.stderr
@@ -1,0 +1,64 @@
+error[E0384]: cannot assign twice to immutable variable `x` (Ast)
+  --> $DIR/liveness-assign-imm-local-notes.rs:23:9
+   |
+22 |         x = 2;
+   |         ----- first assignment to `x`
+23 |         x = 3;      //~ ERROR (Ast) [E0384]
+   |         ^^^^^ cannot assign twice to immutable variable
+
+error[E0384]: cannot assign twice to immutable variable `x` (Ast)
+  --> $DIR/liveness-assign-imm-local-notes.rs:35:13
+   |
+34 |             x = 2;
+   |             ----- first assignment to `x`
+35 |             x = 3;      //~ ERROR (Ast) [E0384]
+   |             ^^^^^ cannot assign twice to immutable variable
+
+error[E0384]: cannot assign twice to immutable variable `x` (Ast)
+  --> $DIR/liveness-assign-imm-local-notes.rs:45:13
+   |
+45 |             x = 1;      //~ ERROR (Ast) [E0384]
+   |             ^^^^^ cannot assign twice to immutable variable
+
+error[E0384]: cannot assign twice to immutable variable `x` (Ast)
+  --> $DIR/liveness-assign-imm-local-notes.rs:48:13
+   |
+45 |             x = 1;      //~ ERROR (Ast) [E0384]
+   |             ----- first assignment to `x`
+...
+48 |             x = 2;      //~ ERROR (Ast) [E0384]
+   |             ^^^^^ cannot assign twice to immutable variable
+
+error[E0384]: cannot assign twice to immutable variable `x` (Mir)
+  --> $DIR/liveness-assign-imm-local-notes.rs:23:9
+   |
+22 |         x = 2;
+   |         ----- first assignment to `x`
+23 |         x = 3;      //~ ERROR (Ast) [E0384]
+   |         ^^^^^ cannot assign twice to immutable variable
+
+error[E0384]: cannot assign twice to immutable variable `x` (Mir)
+  --> $DIR/liveness-assign-imm-local-notes.rs:35:13
+   |
+34 |             x = 2;
+   |             ----- first assignment to `x`
+35 |             x = 3;      //~ ERROR (Ast) [E0384]
+   |             ^^^^^ cannot assign twice to immutable variable
+
+error[E0384]: cannot assign twice to immutable variable `x` (Mir)
+  --> $DIR/liveness-assign-imm-local-notes.rs:45:13
+   |
+45 |             x = 1;      //~ ERROR (Ast) [E0384]
+   |             ^^^^^ cannot assign twice to immutable variable
+
+error[E0384]: cannot assign twice to immutable variable `x` (Mir)
+  --> $DIR/liveness-assign-imm-local-notes.rs:48:13
+   |
+45 |             x = 1;      //~ ERROR (Ast) [E0384]
+   |             ----- first assignment to `x`
+...
+48 |             x = 2;      //~ ERROR (Ast) [E0384]
+   |             ^^^^^ cannot assign twice to immutable variable
+
+error: aborting due to 8 previous errors
+


### PR DESCRIPTION
- Closes #45199 
- Don't allow assigning to dropped immutable variables
- Show the "first assignment" note on the first assignment that can actually come before the second assignment.
- Make "first assignment" notes point to function parameters if needed.
- Don't show a "first assignment" note if the first and second assignment have the same span (in a loop). This matches ast borrowck for now, but maybe this we should add "in previous loop iteration" as with some other borrowck errors. (Commit 2)
- Use revisions to check mir borrowck for the existing tests for this error. (Commit 3)

~~Still working on a less ad-hoc way to get 'first assignment' notes to show on the correct assignment. Also need to check mutating function arguments.~~ Now using a new dataflow pass.