### PR TITLE
Ignore borrowck for static lvalues and allow assignment to static muts

### DIFF
--- a/src/librustc_mir/borrow_check.rs
+++ b/src/librustc_mir/borrow_check.rs
@@ -640,10 +640,12 @@ impl<'c, 'b, 'a: 'b+'c, 'gcx, 'tcx: 'a> MirBorrowckCtxt<'c, 'b, 'a, 'gcx, 'tcx> 
                         Mutability::Mut => return,
                     }
                 }
-                Lvalue::Static(_) => {
+                Lvalue::Static(ref static_) => {
                     // mutation of non-mut static is always illegal,
                     // independent of dataflow.
-                    self.report_assignment_to_static(context, (lvalue, span));
+                    if !self.tcx.is_static_mut(static_.def_id) {
+                        self.report_assignment_to_static(context, (lvalue, span));
+                    }
                     return;
                 }
             }

--- a/src/test/compile-fail/borrowck/borrowck-describe-lvalue.rs
+++ b/src/test/compile-fail/borrowck/borrowck-describe-lvalue.rs
@@ -46,12 +46,6 @@ impl Baz {
     }
 }
 
-static mut sfoo : Foo = Foo{x: 23 };
-static mut sbar : Bar = Bar(23);
-static mut stuple : (i32, i32) = (24, 25);
-static mut senum : Baz = Baz::X(26);
-static mut sunion : U = U { a: 0 };
-
 fn main() {
     // Local and field from struct
     {
@@ -95,34 +89,6 @@ fn main() {
         u.a; //[ast]~ ERROR cannot use `u.a` because it was mutably borrowed
              //[mir]~^ ERROR cannot use `u.a` because it was mutably borrowed (Ast)
              //[mir]~| ERROR cannot use `u.a` because it was mutably borrowed (Mir)
-    }
-    // Static and field from struct
-    unsafe {
-        let _x = sfoo.x();
-        sfoo.x; //[mir]~ ERROR cannot use `sfoo.x` because it was mutably borrowed (Mir)
-    }
-    // Static and field from tuple-struct
-    unsafe {
-        let _0 = sbar.x();
-        sbar.0; //[mir]~ ERROR cannot use `sbar.0` because it was mutably borrowed (Mir)
-    }
-    // Static and field from tuple
-    unsafe {
-        let _0 = &mut stuple.0;
-        stuple.0; //[mir]~ ERROR cannot use `stuple.0` because it was mutably borrowed (Mir)
-    }
-    // Static and field from enum
-    unsafe {
-        let _e0 = senum.x();
-        match senum {
-            Baz::X(value) => value
-            //[mir]~^ ERROR cannot use `senum.0` because it was mutably borrowed (Mir)
-        };
-    }
-    // Static and field from union
-    unsafe {
-        let _ra = &mut sunion.a;
-        sunion.a; //[mir]~ ERROR cannot use `sunion.a` because it was mutably borrowed (Mir)
     }
     // Deref and field from struct
     {

--- a/src/test/run-pass/borrowck/borrowck-assignment-to-static-mut.rs
+++ b/src/test/run-pass/borrowck/borrowck-assignment-to-static-mut.rs
@@ -1,0 +1,23 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test taken from #45641 (https://github.com/rust-lang/rust/issues/45641)
+
+// ignore-tidy-linelength
+// revisions: ast mir
+//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+
+static mut Y: u32 = 0;
+
+unsafe fn should_ok() {
+    Y = 1;
+}
+
+fn main() {}

--- a/src/test/run-pass/borrowck/borrowck-unsafe-static-mutable-borrows.rs
+++ b/src/test/run-pass/borrowck/borrowck-unsafe-static-mutable-borrows.rs
@@ -1,0 +1,31 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// revisions: ast mir
+//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+
+// Test file taken from issue 45129 (https://github.com/rust-lang/rust/issues/45129)
+
+struct Foo { x: [usize; 2] }
+
+static mut SFOO: Foo = Foo { x: [23, 32] };
+
+impl Foo {
+    fn x(&mut self) -> &mut usize { &mut self.x[0] }
+}
+
+fn main() {
+    unsafe {
+        let sfoo: *mut Foo = &mut SFOO;
+        let x = (*sfoo).x();
+        (*sfoo).x[1] += 1;
+        *x += 1;
+    }
+}


### PR DESCRIPTION
Fixes #45129.
Fixes #45641.