### PR TITLE
Combine "this expression will panic at run-time" warnings into `const_err` lint.

### DIFF
--- a/src/librustc_passes/consts.rs
+++ b/src/librustc_passes/consts.rs
@@ -312,6 +312,10 @@ impl<'a, 'tcx> Visitor<'tcx> for CheckCrateVisitor<'a, 'tcx> {
                 Err(ConstEvalErr {
                     kind: LayoutError(ty::layout::LayoutError::Unknown(_)), ..
                 }) => {}
+                Err(ConstEvalErr { kind: Math(_), .. }) if self.tcx.sess.overflow_checks() => {}
+                // ^ Disable overflow errors since they will be emitted again in librustc_trans
+                //   so we avoid double-linting the same expression (the one in librustc_trans is
+                //   more accurate).
                 Err(msg) => {
                     self.tcx.lint_node(CONST_ERR,
                                        ex.id,

--- a/src/librustc_trans/mir/mod.rs
+++ b/src/librustc_trans/mir/mod.rs
@@ -18,6 +18,7 @@ use rustc::mir::tcx::LvalueTy;
 use rustc::ty::subst::Substs;
 use rustc::infer::TransNormalize;
 use rustc::session::config::FullDebugInfo;
+use rustc::hir::def_id::DefIndex;
 use base;
 use builder::Builder;
 use common::{self, CrateContext, Funclet};
@@ -45,6 +46,8 @@ use self::operand::{OperandRef, OperandValue};
 /// Master context for translating MIR.
 pub struct MirContext<'a, 'tcx:'a> {
     mir: &'a mir::Mir<'tcx>,
+
+    instance_def_index: DefIndex,
 
     debug_context: debuginfo::FunctionDebugContext,
 
@@ -229,6 +232,7 @@ pub fn trans_mir<'a, 'tcx: 'a>(
 
     let mut mircx = MirContext {
         mir,
+        instance_def_index: instance.def_id().index,
         llfn,
         fn_ty,
         ccx,

--- a/src/test/compile-fail/const-err.rs
+++ b/src/test/compile-fail/const-err.rs
@@ -8,10 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Zforce-overflow-checks=on
+// compile-flags: -Coverflow-checks=on
 
 // these errors are not actually "const_err", they occur in trans/consts
-// and are unconditional warnings that can't be denied or allowed
 
 #![allow(exceeding_bitshifts)]
 #![allow(const_err)]
@@ -25,23 +24,19 @@ const FOO: u8 = [5u8][1];
 //~^ ERROR constant evaluation error
 //~| index out of bounds: the len is 1 but the index is 1
 
+#[warn(const_err)]
 fn main() {
     let a = -std::i8::MIN;
-    //~^ WARN this expression will panic at run-time
-    //~| attempt to negate with overflow
+    //~^ WARN attempt to negate with overflow
     let b = 200u8 + 200u8 + 200u8;
-    //~^ WARN this expression will panic at run-time
-    //~^^ WARN this expression will panic at run-time
-    //~| attempt to add with overflow
+    //~^ WARN attempt to add with overflow
+    //~^^ WARN attempt to add with overflow
     let c = 200u8 * 4;
-    //~^ WARN this expression will panic at run-time
-    //~| attempt to multiply with overflow
+    //~^ WARN attempt to multiply with overflow
     let d = 42u8 - (42u8 + 1);
-    //~^ WARN this expression will panic at run-time
-    //~| attempt to subtract with overflow
+    //~^ WARN attempt to subtract with overflow
     let _e = [5u8][1];
-    //~^ WARN this expression will panic at run-time
-    //~| index out of bounds: the len is 1 but the index is 1
+    //~^ WARN index out of bounds: the len is 1 but the index is 1
     black_box(a);
     black_box(b);
     black_box(c);

--- a/src/test/compile-fail/const-err2.rs
+++ b/src/test/compile-fail/const-err2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Coverflow-checks=off
+
 #![feature(rustc_attrs)]
 #![allow(exceeding_bitshifts)]
 #![deny(const_err)]

--- a/src/test/ui/issue-45850-with-overflow-checks.rs
+++ b/src/test/ui/issue-45850-with-overflow-checks.rs
@@ -1,0 +1,63 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Coverflow-checks=on
+
+#![allow(exceeding_bitshifts)]
+#![feature(generators, generator_trait)]
+
+use std::ops::Generator;
+
+#[deny(const_err)]
+fn a() -> u8 {
+    [b'a'][1]
+}
+
+#[allow(const_err)]
+fn b() -> u8 {
+    [b'b'][1]
+}
+
+fn c() -> u8 {
+    [b'c'][1]
+}
+
+fn d() -> u8 {
+    [b'd'][1]
+}
+
+// Make sure the const_err are only emitted **once**
+fn check_emit_only_once() {
+    let _ = 200u8 + 200u8;
+    let _ = 23u8 << 19;
+    let _ = 17 / 0;
+}
+
+#[allow(const_err)]
+mod m {
+    pub fn d() -> u8 {
+        [b'D'][1]
+    }
+
+    #[deny(const_err)]
+    pub fn e() -> u8 {
+        [b'E'][1]
+    }
+}
+
+fn main() {
+    a();
+    b();
+    c();
+    d();
+    m::d();
+    m::e();
+    check_emit_only_once();
+}

--- a/src/test/ui/issue-45850-with-overflow-checks.stderr
+++ b/src/test/ui/issue-45850-with-overflow-checks.stderr
@@ -1,0 +1,58 @@
+error: index out of bounds: the len is 1 but the index is 1
+  --> $DIR/issue-45850-with-overflow-checks.rs:20:5
+   |
+20 |     [b'a'][1]
+   |     ^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/issue-45850-with-overflow-checks.rs:18:8
+   |
+18 | #[deny(const_err)]
+   |        ^^^^^^^^^
+
+warning: index out of bounds: the len is 1 but the index is 1
+  --> $DIR/issue-45850-with-overflow-checks.rs:29:5
+   |
+29 |     [b'c'][1]
+   |     ^^^^^^^^^
+   |
+   = note: #[warn(const_err)] on by default
+
+warning: index out of bounds: the len is 1 but the index is 1
+  --> $DIR/issue-45850-with-overflow-checks.rs:33:5
+   |
+33 |     [b'd'][1]
+   |     ^^^^^^^^^
+
+warning: attempt to add with overflow
+  --> $DIR/issue-45850-with-overflow-checks.rs:38:13
+   |
+38 |     let _ = 200u8 + 200u8;
+   |             ^^^^^^^^^^^^^
+
+warning: attempt to shift left with overflow
+  --> $DIR/issue-45850-with-overflow-checks.rs:39:13
+   |
+39 |     let _ = 23u8 << 19;
+   |             ^^^^^^^^^^
+
+warning: attempt to divide by zero
+  --> $DIR/issue-45850-with-overflow-checks.rs:40:13
+   |
+40 |     let _ = 17 / 0;
+   |             ^^^^^^
+
+error: index out of bounds: the len is 1 but the index is 1
+  --> $DIR/issue-45850-with-overflow-checks.rs:51:9
+   |
+51 |         [b'E'][1]
+   |         ^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/issue-45850-with-overflow-checks.rs:49:12
+   |
+49 |     #[deny(const_err)]
+   |            ^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/issue-45850-without-overflow-checks.rs
+++ b/src/test/ui/issue-45850-without-overflow-checks.rs
@@ -1,0 +1,63 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Coverflow-checks=off
+
+#![allow(exceeding_bitshifts)]
+#![feature(generators, generator_trait)]
+
+use std::ops::Generator;
+
+#[deny(const_err)]
+fn a() -> u8 {
+    [b'a'][1]
+}
+
+#[allow(const_err)]
+fn b() -> u8 {
+    [b'b'][1]
+}
+
+fn c() -> u8 {
+    [b'c'][1]
+}
+
+fn d() -> u8 {
+    [b'd'][1]
+}
+
+// Make sure the const_err are only emitted **once**
+fn check_emit_only_once() {
+    let _ = 200u8 + 200u8;
+    let _ = 23u8 << 19;
+    let _ = 17 / 0;
+}
+
+#[allow(const_err)]
+mod m {
+    pub fn d() -> u8 {
+        [b'D'][1]
+    }
+
+    #[deny(const_err)]
+    pub fn e() -> u8 {
+        [b'E'][1]
+    }
+}
+
+fn main() {
+    a();
+    b();
+    c();
+    d();
+    m::d();
+    m::e();
+    check_emit_only_once();
+}

--- a/src/test/ui/issue-45850-without-overflow-checks.stderr
+++ b/src/test/ui/issue-45850-without-overflow-checks.stderr
@@ -1,0 +1,52 @@
+warning: attempt to add with overflow
+  --> $DIR/issue-45850-without-overflow-checks.rs:38:13
+   |
+38 |     let _ = 200u8 + 200u8;
+   |             ^^^^^^^^^^^^^
+   |
+   = note: #[warn(const_err)] on by default
+
+warning: attempt to divide by zero
+  --> $DIR/issue-45850-without-overflow-checks.rs:40:13
+   |
+40 |     let _ = 17 / 0;
+   |             ^^^^^^
+
+error: index out of bounds: the len is 1 but the index is 1
+  --> $DIR/issue-45850-without-overflow-checks.rs:20:5
+   |
+20 |     [b'a'][1]
+   |     ^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/issue-45850-without-overflow-checks.rs:18:8
+   |
+18 | #[deny(const_err)]
+   |        ^^^^^^^^^
+
+warning: index out of bounds: the len is 1 but the index is 1
+  --> $DIR/issue-45850-without-overflow-checks.rs:29:5
+   |
+29 |     [b'c'][1]
+   |     ^^^^^^^^^
+
+warning: index out of bounds: the len is 1 but the index is 1
+  --> $DIR/issue-45850-without-overflow-checks.rs:33:5
+   |
+33 |     [b'd'][1]
+   |     ^^^^^^^^^
+
+error: index out of bounds: the len is 1 but the index is 1
+  --> $DIR/issue-45850-without-overflow-checks.rs:51:9
+   |
+51 |         [b'E'][1]
+   |         ^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/issue-45850-without-overflow-checks.rs:49:12
+   |
+49 |     #[deny(const_err)]
+   |            ^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
**Known issue**: The lint can only be suppressed at function level. Attributed blocks cannot be used to adjust the lint level.

Closes #45850.