### PR TITLE
Implement in-band lifetime bindings

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -2051,4 +2051,6 @@ register_diagnostics! {
     E0631, // type mismatch in closure arguments
     E0637, // "'_" is not a valid lifetime bound
     E0657, // `impl Trait` can only capture lifetimes bound at the fn level
+    E0687, // in-band lifetimes cannot be used in `fn`/`Fn` syntax
+    E0688, // in-band lifetimes cannot be mixed with explicit lifetime binders
 }

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -222,6 +222,10 @@ pub struct LifetimeDef {
     pub lifetime: Lifetime,
     pub bounds: HirVec<Lifetime>,
     pub pure_wrt_drop: bool,
+    // Indicates that the lifetime definition was synthetically added
+    // as a result of an in-band lifetime usage like
+    // `fn foo(x: &'a u8) -> &'a u8 { x }`
+    pub in_band: bool,
 }
 
 /// A "Path" is essentially Rust's notion of a name; for instance:

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -157,7 +157,8 @@ impl_stable_hash_for!(struct hir::Lifetime {
 impl_stable_hash_for!(struct hir::LifetimeDef {
     lifetime,
     bounds,
-    pure_wrt_drop
+    pure_wrt_drop,
+    in_band
 });
 
 impl_stable_hash_for!(struct hir::Path {

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -493,10 +493,15 @@ for ::middle::resolve_lifetime::Set1<T>
     }
 }
 
+impl_stable_hash_for!(enum ::middle::resolve_lifetime::LifetimeDefOrigin {
+    Explicit,
+    InBand
+});
+
 impl_stable_hash_for!(enum ::middle::resolve_lifetime::Region {
     Static,
-    EarlyBound(index, decl),
-    LateBound(db_index, decl),
+    EarlyBound(index, decl, is_in_band),
+    LateBound(db_index, decl, is_in_band),
     LateBoundAnon(db_index, anon_index),
     Free(call_site_scope_data, decl)
 });

--- a/src/librustc/infer/error_reporting/different_lifetimes.rs
+++ b/src/librustc/infer/error_reporting/different_lifetimes.rs
@@ -281,7 +281,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for FindNestedTypeVisitor<'a, 'gcx, 'tcx> {
                     // Find the index of the named region that was part of the
                     // error. We will then search the function parameters for a bound
                     // region at the right depth with the same index
-                    (Some(rl::Region::EarlyBound(_, id)), ty::BrNamed(def_id, _)) => {
+                    (Some(rl::Region::EarlyBound(_, id, _)), ty::BrNamed(def_id, _)) => {
                         debug!("EarlyBound self.infcx.tcx.hir.local_def_id(id)={:?} \
                                         def_id={:?}", id, def_id);
                         if id == def_id {
@@ -293,7 +293,10 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for FindNestedTypeVisitor<'a, 'gcx, 'tcx> {
                     // Find the index of the named region that was part of the
                     // error. We will then search the function parameters for a bound
                     // region at the right depth with the same index
-                    (Some(rl::Region::LateBound(debruijn_index, id)), ty::BrNamed(def_id, _)) => {
+                    (
+                     Some(rl::Region::LateBound(debruijn_index, id, _)),
+                     ty::BrNamed(def_id, _)
+                    ) => {
                         debug!("FindNestedTypeVisitor::visit_ty: LateBound depth = {:?}",
                                debruijn_index.depth);
                         debug!("self.infcx.tcx.hir.local_def_id(id)={:?}", id);
@@ -306,8 +309,8 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for FindNestedTypeVisitor<'a, 'gcx, 'tcx> {
 
                     (Some(rl::Region::Static), _) |
                     (Some(rl::Region::Free(_, _)), _) |
-                    (Some(rl::Region::EarlyBound(_, _)), _) |
-                    (Some(rl::Region::LateBound(_, _)), _) |
+                    (Some(rl::Region::EarlyBound(_, _, _)), _) |
+                    (Some(rl::Region::LateBound(_, _, _)), _) |
                     (Some(rl::Region::LateBoundAnon(_, _)), _) |
                     (None, _) => {
                         debug!("no arg found");
@@ -368,7 +371,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for TyPathVisitor<'a, 'gcx, 'tcx> {
                 }
             }
 
-            (Some(rl::Region::EarlyBound(_, id)), ty::BrNamed(def_id, _)) => {
+            (Some(rl::Region::EarlyBound(_, id, _)), ty::BrNamed(def_id, _)) => {
                 debug!("EarlyBound self.infcx.tcx.hir.local_def_id(id)={:?} \
                                         def_id={:?}", id, def_id);
                 if id == def_id {
@@ -377,7 +380,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for TyPathVisitor<'a, 'gcx, 'tcx> {
                 }
             }
 
-            (Some(rl::Region::LateBound(debruijn_index, id)), ty::BrNamed(def_id, _)) => {
+            (Some(rl::Region::LateBound(debruijn_index, id, _)), ty::BrNamed(def_id, _)) => {
                 debug!("FindNestedTypeVisitor::visit_ty: LateBound depth = {:?}",
                        debruijn_index.depth);
                 debug!("id={:?}", id);
@@ -389,8 +392,8 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for TyPathVisitor<'a, 'gcx, 'tcx> {
             }
 
             (Some(rl::Region::Static), _) |
-            (Some(rl::Region::EarlyBound(_, _)), _) |
-            (Some(rl::Region::LateBound(_, _)), _) |
+            (Some(rl::Region::EarlyBound(_, _, _)), _) |
+            (Some(rl::Region::LateBound(_, _, _)), _) |
             (Some(rl::Region::LateBoundAnon(_, _)), _) |
             (Some(rl::Region::Free(_, _)), _) |
             (None, _) => {

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -110,7 +110,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
                 tcx.types.re_static
             }
 
-            Some(rl::Region::LateBound(debruijn, id)) => {
+            Some(rl::Region::LateBound(debruijn, id, _)) => {
                 let name = lifetime_name(id);
                 tcx.mk_region(ty::ReLateBound(debruijn,
                     ty::BrNamed(id, name)))
@@ -120,7 +120,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
                 tcx.mk_region(ty::ReLateBound(debruijn, ty::BrAnon(index)))
             }
 
-            Some(rl::Region::EarlyBound(index, id)) => {
+            Some(rl::Region::EarlyBound(index, id, _)) => {
                 let name = lifetime_name(id);
                 tcx.mk_region(ty::ReEarlyBound(ty::EarlyBoundRegion {
                     def_id: id,

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -55,6 +55,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
         wbcx.tables.tainted_by_errors = self.is_tainted_by_errors();
 
+        debug!("writeback: tables for {:?} are {:#?}", item_def_id, wbcx.tables);
+
         self.tcx.alloc_tables(wbcx.tables)
     }
 }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -784,7 +784,7 @@ fn has_late_bound_regions<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             let hir_id = self.tcx.hir.node_to_hir_id(lt.id);
             match self.tcx.named_region(hir_id) {
                 Some(rl::Region::Static) | Some(rl::Region::EarlyBound(..)) => {}
-                Some(rl::Region::LateBound(debruijn, _)) |
+                Some(rl::Region::LateBound(debruijn, _, _)) |
                 Some(rl::Region::LateBoundAnon(debruijn, _))
                     if debruijn.depth < self.binder_depth => {}
                 _ => self.has_late_bound_regions = Some(lt.span),

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1008,8 +1008,8 @@ impl Clean<Lifetime> for hir::Lifetime {
         let hir_id = cx.tcx.hir.node_to_hir_id(self.id);
         let def = cx.tcx.named_region(hir_id);
         match def {
-            Some(rl::Region::EarlyBound(_, node_id)) |
-            Some(rl::Region::LateBound(_, node_id)) |
+            Some(rl::Region::EarlyBound(_, node_id, _)) |
+            Some(rl::Region::LateBound(_, node_id, _)) |
             Some(rl::Region::Free(_, node_id)) => {
                 if let Some(lt) = cx.lt_substs.borrow().get(&node_id).cloned() {
                     return lt;

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -425,6 +425,9 @@ declare_features! (
 
     // `crate` in paths
     (active, crate_in_paths, "1.23.0", Some(45477)),
+
+    // In-band lifetime bindings (e.g. `fn foo(x: &'a u8) -> &'a u8`)
+    (active, in_band_lifetimes, "1.23.0", Some(44524)),
 );
 
 declare_features! (

--- a/src/test/compile-fail/feature-gate-in_band_lifetimes.rs
+++ b/src/test/compile-fail/feature-gate-in_band_lifetimes.rs
@@ -1,0 +1,72 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(warnings)]
+
+fn foo(x: &'x u8) -> &'x u8 { x }
+//~^ ERROR use of undeclared lifetime name
+//~^^ ERROR use of undeclared lifetime name
+
+struct X<'a>(&'a u8);
+
+impl<'a> X<'a> {
+    fn inner(&self) -> &'a u8 {
+        self.0
+    }
+}
+
+impl<'a> X<'b> {
+//~^ ERROR use of undeclared lifetime name
+    fn inner_2(&self) -> &'b u8 {
+    //~^ ERROR use of undeclared lifetime name
+        self.0
+    }
+}
+
+impl X<'b> {
+//~^ ERROR use of undeclared lifetime name
+    fn inner_3(&self) -> &'b u8 {
+    //~^ ERROR use of undeclared lifetime name
+        self.0
+    }
+}
+
+struct Y<T>(T);
+
+impl Y<&'a u8> {
+    //~^ ERROR use of undeclared lifetime name
+    fn inner(&self) -> &'a u8 {
+    //~^ ERROR use of undeclared lifetime name
+        self.0
+    }
+}
+
+trait MyTrait<'a> {
+    fn my_lifetime(&self) -> &'a u8;
+    fn any_lifetime() -> &'b u8;
+    //~^ ERROR use of undeclared lifetime name
+    fn borrowed_lifetime(&'b self) -> &'b u8;
+    //~^ ERROR use of undeclared lifetime name
+    //~^^ ERROR use of undeclared lifetime name
+}
+
+impl MyTrait<'a> for Y<&'a u8> {
+//~^ ERROR use of undeclared lifetime name
+//~^^ ERROR use of undeclared lifetime name
+    fn my_lifetime(&self) -> &'a u8 { self.0 }
+    //~^ ERROR use of undeclared lifetime name
+    fn any_lifetime() -> &'b u8 { &0 }
+    //~^ ERROR use of undeclared lifetime name
+    fn borrowed_lifetime(&'b self) -> &'b u8 { &*self.0 }
+    //~^ ERROR use of undeclared lifetime name
+    //~^^ ERROR use of undeclared lifetime name
+}
+
+fn main() {}

--- a/src/test/incremental/hashes/inherent_impls.rs
+++ b/src/test/incremental/hashes/inherent_impls.rs
@@ -370,7 +370,16 @@ impl Foo {
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2", except="Hir,HirBody,TypeckTables")]
+    // Warning: Note that `TypeckTables` are coming up clean here.
+    // The addition or removal of lifetime parameters that don't
+    // appear in the arguments or fn body in any way does not, in
+    // fact, affect the `TypeckTables` in any semantic way (at least
+    // as of this writing). **However,** altering the order of
+    // lowering **can** cause it appear to affect the `TypeckTables`:
+    // if we lower generics before the body, then the `HirId` for
+    // things in the body will be affected. So if you start to see
+    // `TypeckTables` appear dirty, that might be the cause. -nmatsakis
+    #[rustc_clean(cfg="cfail2", except="Hir,HirBody")]
     #[rustc_clean(cfg="cfail3")]
     #[rustc_metadata_clean(cfg="cfail2")]
     #[rustc_metadata_clean(cfg="cfail3")]
@@ -391,9 +400,18 @@ impl Foo {
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 impl Foo {
+    // Warning: Note that `TypeckTables` are coming up clean here.
+    // The addition or removal of type parameters that don't appear in
+    // the arguments or fn body in any way does not, in fact, affect
+    // the `TypeckTables` in any semantic way (at least as of this
+    // writing). **However,** altering the order of lowering **can**
+    // cause it appear to affect the `TypeckTables`: if we lower
+    // generics before the body, then the `HirId` for things in the
+    // body will be affected. So if you start to see `TypeckTables`
+    // appear dirty, that might be the cause. -nmatsakis
     #[rustc_clean(
         cfg="cfail2",
-        except="Hir,HirBody,GenericsOfItem,PredicatesOfItem,TypeOfItem,TypeckTables",
+        except="Hir,HirBody,GenericsOfItem,PredicatesOfItem,TypeOfItem",
     )]
     #[rustc_clean(cfg="cfail3")]
     #[rustc_metadata_dirty(cfg="cfail2")]
@@ -439,8 +457,17 @@ impl Foo {
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 impl Foo {
+    // Warning: Note that `TypeckTables` are coming up clean here.
+    // The addition or removal of bounds that don't appear in the
+    // arguments or fn body in any way does not, in fact, affect the
+    // `TypeckTables` in any semantic way (at least as of this
+    // writing). **However,** altering the order of lowering **can**
+    // cause it appear to affect the `TypeckTables`: if we lower
+    // generics before the body, then the `HirId` for things in the
+    // body will be affected. So if you start to see `TypeckTables`
+    // appear dirty, that might be the cause. -nmatsakis
     #[rustc_clean(cfg="cfail2", except="Hir,HirBody,GenericsOfItem,PredicatesOfItem,\
-                                        TypeOfItem,TypeckTables")]
+                                        TypeOfItem")]
     #[rustc_clean(cfg="cfail3")]
     #[rustc_metadata_dirty(cfg="cfail2")]
     #[rustc_metadata_clean(cfg="cfail3")]
@@ -461,7 +488,16 @@ impl Foo {
 #[rustc_metadata_clean(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2", except="Hir,HirBody,PredicatesOfItem,TypeckTables")]
+    // Warning: Note that `TypeckTables` are coming up clean here.
+    // The addition or removal of bounds that don't appear in the
+    // arguments or fn body in any way does not, in fact, affect the
+    // `TypeckTables` in any semantic way (at least as of this
+    // writing). **However,** altering the order of lowering **can**
+    // cause it appear to affect the `TypeckTables`: if we lower
+    // generics before the body, then the `HirId` for things in the
+    // body will be affected. So if you start to see `TypeckTables`
+    // appear dirty, that might be the cause. -nmatsakis
+    #[rustc_clean(cfg="cfail2", except="Hir,HirBody,PredicatesOfItem")]
     #[rustc_clean(cfg="cfail3")]
     #[rustc_metadata_dirty(cfg="cfail2")]
     #[rustc_metadata_clean(cfg="cfail3")]

--- a/src/test/run-pass/in-band-lifetimes.rs
+++ b/src/test/run-pass/in-band-lifetimes.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #![allow(warnings)]
-#![feature(in_band_lifetimes, universal_impl_trait)]
+#![feature(in_band_lifetimes, universal_impl_trait, conservative_impl_trait)]
 
 fn foo(x: &'x u8) -> &'x u8 { x }
 fn foo2(x: &'a u8, y: &u8) -> &'a u8 { x }
@@ -80,5 +80,25 @@ fn reference_in_band_from_locals(x: &'test u32) -> &'test u32 {
 fn in_generics_in_band<T: MyTrait<'a>>(x: &T) {}
 fn where_clause_in_band<T>(x: &T) where T: MyTrait<'a> {}
 fn impl_trait_in_band(x: &impl MyTrait<'a>) {}
+
+// Tests around using in-band lifetimes within existential traits.
+
+trait FunkyTrait<'a> { }
+impl<'a, T> FunkyTrait<'a> for T { }
+fn existential_impl_trait_in_band_outlives(x: &'a u32) -> impl ::std::fmt::Debug + 'a {
+    x
+}
+fn existential_impl_trait_in_band_param(x: &'a u32) -> impl FunkyTrait<'a> {
+    x
+}
+fn existential_impl_trait_in_band_param_static(x: &'a u32) -> impl FunkyTrait<'static> + 'a {
+    x
+}
+fn existential_impl_trait_in_band_param_outlives(x: &'a u32) -> impl FunkyTrait<'a> + 'a {
+    x
+}
+fn existential_impl_trait_in_band_higher_ranked(x: &'a u32) -> impl for<'b> FunkyTrait<'b> + 'a {
+    x
+}
 
 fn main() {}

--- a/src/test/run-pass/in-band-lifetimes.rs
+++ b/src/test/run-pass/in-band-lifetimes.rs
@@ -1,0 +1,84 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(warnings)]
+#![feature(in_band_lifetimes, universal_impl_trait)]
+
+fn foo(x: &'x u8) -> &'x u8 { x }
+fn foo2(x: &'a u8, y: &u8) -> &'a u8 { x }
+
+fn check_in_band_can_be_late_bound() {
+    let _: for<'x> fn(&'x u8, &u8) -> &'x u8 = foo2;
+}
+
+struct ForInherentNoParams;
+
+impl ForInherentNoParams {
+    fn foo(x: &'a u32, y: &u32) -> &'a u32 { x }
+}
+
+struct X<'a>(&'a u8);
+
+impl<'a> X<'a> {
+    fn inner(&self) -> &'a u8 {
+        self.0
+    }
+
+    fn same_lifetime_as_parameter(&mut self, x: &'a u8) {
+        self.0 = x;
+    }
+}
+
+impl X<'b> {
+    fn inner_2(&self) -> &'b u8 {
+        self.0
+    }
+
+    fn reference_already_introduced_in_band_from_method_with_explicit_binders<'a>(
+        &'b self, x: &'a u32
+    ) {}
+}
+
+struct Y<T>(T);
+
+impl Y<&'a u8> {
+    fn inner(&self) -> &'a u8 {
+        self.0
+    }
+}
+
+trait MyTrait<'a> {
+    fn my_lifetime(&self) -> &'a u8;
+    fn any_lifetime() -> &'b u8;
+    fn borrowed_lifetime(&'b self) -> &'b u8;
+    fn default_impl(&self, x: &'b u32, y: &u32) -> &'b u32 { x }
+    fn in_band_def_explicit_impl(&self, x: &'b u8);
+}
+
+impl MyTrait<'a> for Y<&'a u8> {
+    fn my_lifetime(&self) -> &'a u8 { self.0 }
+    fn any_lifetime() -> &'b u8 { &0 }
+    fn borrowed_lifetime(&'b self) -> &'b u8 { &*self.0 }
+    fn in_band_def_explicit_impl<'b>(&self, x: &'b u8) {}
+}
+
+fn test_hrtb_defined_lifetime_where<F>(_: F) where for<'a> F: Fn(&'a u8) {}
+fn test_hrtb_defined_lifetime_polytraitref<F>(_: F) where F: for<'a> Fn(&'a u8) {}
+
+fn reference_in_band_from_locals(x: &'test u32) -> &'test u32 {
+    let y: &'test u32 = x;
+    y
+}
+
+fn in_generics_in_band<T: MyTrait<'a>>(x: &T) {}
+fn where_clause_in_band<T>(x: &T) where T: MyTrait<'a> {}
+fn impl_trait_in_band(x: &impl MyTrait<'a>) {}
+
+fn main() {}

--- a/src/test/ui/in-band-lifetimes/E0687.rs
+++ b/src/test/ui/in-band-lifetimes/E0687.rs
@@ -1,0 +1,26 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(warnings)]
+#![feature(in_band_lifetimes)]
+
+fn foo(x: fn(&'a u32)) {}
+
+fn bar(x: &Fn(&'a u32)) {}
+
+fn baz(x: fn(&'a u32), y: &'a u32) {}
+
+struct Foo<'a> { x: &'a u32 }
+
+impl Foo<'a> {
+    fn bar(&self, x: fn(&'a u32)) {}
+}
+
+fn main() {}

--- a/src/test/ui/in-band-lifetimes/E0687.stderr
+++ b/src/test/ui/in-band-lifetimes/E0687.stderr
@@ -1,0 +1,26 @@
+error[E0687]: lifetimes used in `fn` or `Fn` syntax must be explicitly declared using `<...>` binders
+  --> $DIR/E0687.rs:14:15
+   |
+14 | fn foo(x: fn(&'a u32)) {}
+   |               ^^ in-band lifetime definition
+
+error[E0687]: lifetimes used in `fn` or `Fn` syntax must be explicitly declared using `<...>` binders
+  --> $DIR/E0687.rs:16:16
+   |
+16 | fn bar(x: &Fn(&'a u32)) {}
+   |                ^^ in-band lifetime definition
+
+error[E0687]: lifetimes used in `fn` or `Fn` syntax must be explicitly declared using `<...>` binders
+  --> $DIR/E0687.rs:18:15
+   |
+18 | fn baz(x: fn(&'a u32), y: &'a u32) {}
+   |               ^^ in-band lifetime definition
+
+error[E0687]: lifetimes used in `fn` or `Fn` syntax must be explicitly declared using `<...>` binders
+  --> $DIR/E0687.rs:23:26
+   |
+23 |     fn bar(&self, x: fn(&'a u32)) {}
+   |                          ^^ in-band lifetime definition
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/in-band-lifetimes/E0687_where.rs
+++ b/src/test/ui/in-band-lifetimes/E0687_where.rs
@@ -1,0 +1,18 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(warnings)]
+#![feature(in_band_lifetimes, universal_impl_trait)]
+
+fn bar<F>(x: &F) where F: Fn(&'a u32) {}
+
+fn baz(x: &impl Fn(&'a u32)) {}
+
+fn main() {}

--- a/src/test/ui/in-band-lifetimes/E0687_where.stderr
+++ b/src/test/ui/in-band-lifetimes/E0687_where.stderr
@@ -1,0 +1,14 @@
+error[E0687]: lifetimes used in `fn` or `Fn` syntax must be explicitly declared using `<...>` binders
+  --> $DIR/E0687_where.rs:14:31
+   |
+14 | fn bar<F>(x: &F) where F: Fn(&'a u32) {}
+   |                               ^^ in-band lifetime definition
+
+error[E0687]: lifetimes used in `fn` or `Fn` syntax must be explicitly declared using `<...>` binders
+  --> $DIR/E0687_where.rs:16:21
+   |
+16 | fn baz(x: &impl Fn(&'a u32)) {}
+   |                     ^^ in-band lifetime definition
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/in-band-lifetimes/E0688.rs
+++ b/src/test/ui/in-band-lifetimes/E0688.rs
@@ -1,0 +1,26 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(warnings)]
+#![feature(in_band_lifetimes)]
+
+fn foo<'a>(x: &'a u32, y: &'b u32) {}
+
+struct Foo<'a> { x: &'a u32 }
+
+impl Foo<'a> {
+    fn bar<'b>(x: &'a u32, y: &'b u32, z: &'c u32) {}
+}
+
+impl<'b> Foo<'a> {
+    fn baz() {}
+}
+
+fn main() {}

--- a/src/test/ui/in-band-lifetimes/E0688.stderr
+++ b/src/test/ui/in-band-lifetimes/E0688.stderr
@@ -1,0 +1,26 @@
+error[E0688]: cannot mix in-band and explicit lifetime definitions
+  --> $DIR/E0688.rs:14:28
+   |
+14 | fn foo<'a>(x: &'a u32, y: &'b u32) {}
+   |        --                  ^^ in-band lifetime definition here
+   |        |
+   |        explicit lifetime definition here
+
+error[E0688]: cannot mix in-band and explicit lifetime definitions
+  --> $DIR/E0688.rs:19:44
+   |
+19 |     fn bar<'b>(x: &'a u32, y: &'b u32, z: &'c u32) {}
+   |            --                              ^^ in-band lifetime definition here
+   |            |
+   |            explicit lifetime definition here
+
+error[E0688]: cannot mix in-band and explicit lifetime definitions
+  --> $DIR/E0688.rs:22:14
+   |
+22 | impl<'b> Foo<'a> {
+   |      --      ^^ in-band lifetime definition here
+   |      |
+   |      explicit lifetime definition here
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/in-band-lifetimes/mismatched.rs
+++ b/src/test/ui/in-band-lifetimes/mismatched.rs
@@ -1,0 +1,18 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(warnings)]
+#![feature(in_band_lifetimes)]
+
+fn foo(x: &'a u32, y: &u32) -> &'a u32 { y }
+
+fn foo2(x: &'a u32, y: &'b u32) -> &'a u32 { y }
+
+fn main() {}

--- a/src/test/ui/in-band-lifetimes/mismatched.stderr
+++ b/src/test/ui/in-band-lifetimes/mismatched.stderr
@@ -1,0 +1,18 @@
+error[E0621]: explicit lifetime required in the type of `y`
+  --> $DIR/mismatched.rs:14:42
+   |
+14 | fn foo(x: &'a u32, y: &u32) -> &'a u32 { y }
+   |                    -                     ^ lifetime `'a` required
+   |                    |
+   |                    consider changing the type of `y` to `&'a u32`
+
+error[E0623]: lifetime mismatch
+  --> $DIR/mismatched.rs:16:46
+   |
+16 | fn foo2(x: &'a u32, y: &'b u32) -> &'a u32 { y }
+   |                        -------     -------   ^ ...but data from `y` is returned here
+   |                        |
+   |                        this parameter and the return type are declared with different lifetimes...
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/in-band-lifetimes/mismatched_trait.rs
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait.rs
@@ -1,0 +1,20 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(warnings)]
+#![feature(in_band_lifetimes)]
+
+trait Get {
+    fn baz(&self, x: &'a u32, y: &u32) -> &'a u32 {
+        y
+    }
+}
+
+fn main() {}

--- a/src/test/ui/in-band-lifetimes/mismatched_trait.stderr
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait.stderr
@@ -1,0 +1,10 @@
+error[E0621]: explicit lifetime required in the type of `y`
+  --> $DIR/mismatched_trait.rs:16:9
+   |
+15 |     fn baz(&self, x: &'a u32, y: &u32) -> &'a u32 {
+   |                               - consider changing the type of `y` to `&'a u32`
+16 |         y
+   |         ^ lifetime `'a` required
+
+error: aborting due to previous error
+

--- a/src/test/ui/in-band-lifetimes/mismatched_trait_impl.rs
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait_impl.rs
@@ -1,0 +1,24 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(warnings)]
+#![feature(in_band_lifetimes)]
+
+trait Get {
+    fn foo(&self, x: &'a u32, y: &u32) -> &'a u32;
+}
+
+impl Get for i32 {
+    fn foo(&self, x: &u32, y: &'a u32) -> &'a u32 {
+        x
+    }
+}
+
+fn main() {}

--- a/src/test/ui/in-band-lifetimes/mismatched_trait_impl.stderr
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait_impl.stderr
@@ -1,0 +1,39 @@
+error[E0495]: cannot infer an appropriate lifetime for lifetime parameter 'a in generic type due to conflicting requirements
+  --> $DIR/mismatched_trait_impl.rs:19:5
+   |
+19 | /     fn foo(&self, x: &u32, y: &'a u32) -> &'a u32 {
+20 | |         x
+21 | |     }
+   | |_____^
+   |
+note: first, the lifetime cannot outlive the anonymous lifetime #2 defined on the method body at 19:5...
+  --> $DIR/mismatched_trait_impl.rs:19:5
+   |
+19 | /     fn foo(&self, x: &u32, y: &'a u32) -> &'a u32 {
+20 | |         x
+21 | |     }
+   | |_____^
+note: ...so that method type is compatible with trait (expected fn(&i32, &'a u32, &u32) -> &'a u32, found fn(&i32, &u32, &u32) -> &u32)
+  --> $DIR/mismatched_trait_impl.rs:19:5
+   |
+19 | /     fn foo(&self, x: &u32, y: &'a u32) -> &'a u32 {
+20 | |         x
+21 | |     }
+   | |_____^
+note: but, the lifetime must be valid for the lifetime 'a as defined on the method body at 19:5...
+  --> $DIR/mismatched_trait_impl.rs:19:5
+   |
+19 | /     fn foo(&self, x: &u32, y: &'a u32) -> &'a u32 {
+20 | |         x
+21 | |     }
+   | |_____^
+note: ...so that method type is compatible with trait (expected fn(&i32, &'a u32, &u32) -> &'a u32, found fn(&i32, &u32, &u32) -> &u32)
+  --> $DIR/mismatched_trait_impl.rs:19:5
+   |
+19 | /     fn foo(&self, x: &u32, y: &'a u32) -> &'a u32 {
+20 | |         x
+21 | |     }
+   | |_____^
+
+error: aborting due to previous error
+

--- a/src/test/ui/in-band-lifetimes/mut_while_borrow.rs
+++ b/src/test/ui/in-band-lifetimes/mut_while_borrow.rs
@@ -1,0 +1,21 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(warnings)]
+#![feature(in_band_lifetimes)]
+
+fn foo(x: &'a u32) -> &'a u32 { x }
+
+fn main() {
+    let mut p = 3;
+    let r = foo(&p);
+    p += 1;
+    println!("{}", r);
+}

--- a/src/test/ui/in-band-lifetimes/mut_while_borrow.stderr
+++ b/src/test/ui/in-band-lifetimes/mut_while_borrow.stderr
@@ -1,0 +1,10 @@
+error[E0506]: cannot assign to `p` because it is borrowed
+  --> $DIR/mut_while_borrow.rs:19:5
+   |
+18 |     let r = foo(&p);
+   |                  - borrow of `p` occurs here
+19 |     p += 1;
+   |     ^^^^^^ assignment to borrowed `p` occurs here
+
+error: aborting due to previous error
+

--- a/src/test/ui/in-band-lifetimes/no_in_band_in_struct.rs
+++ b/src/test/ui/in-band-lifetimes/no_in_band_in_struct.rs
@@ -1,0 +1,22 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(warnings)]
+#![feature(in_band_lifetimes)]
+
+struct Foo {
+    x: &'test u32,
+}
+
+enum Bar {
+    Baz(&'test u32),
+}
+
+fn main() {}

--- a/src/test/ui/in-band-lifetimes/no_in_band_in_struct.stderr
+++ b/src/test/ui/in-band-lifetimes/no_in_band_in_struct.stderr
@@ -1,0 +1,14 @@
+error[E0261]: use of undeclared lifetime name `'test`
+  --> $DIR/no_in_band_in_struct.rs:15:9
+   |
+15 |     x: &'test u32,
+   |         ^^^^^ undeclared lifetime
+
+error[E0261]: use of undeclared lifetime name `'test`
+  --> $DIR/no_in_band_in_struct.rs:19:10
+   |
+19 |     Baz(&'test u32),
+   |          ^^^^^ undeclared lifetime
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/in-band-lifetimes/no_introducing_in_band_in_locals.rs
+++ b/src/test/ui/in-band-lifetimes/no_introducing_in_band_in_locals.rs
@@ -1,0 +1,23 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(warnings)]
+#![feature(in_band_lifetimes)]
+
+fn foo(x: &u32) {
+    let y: &'test u32 = x;
+}
+
+fn foo2(x: &u32) {}
+fn bar() {
+    let y: fn(&'test u32) = foo2;
+}
+
+fn main() {}

--- a/src/test/ui/in-band-lifetimes/no_introducing_in_band_in_locals.stderr
+++ b/src/test/ui/in-band-lifetimes/no_introducing_in_band_in_locals.stderr
@@ -1,0 +1,14 @@
+error[E0261]: use of undeclared lifetime name `'test`
+  --> $DIR/no_introducing_in_band_in_locals.rs:15:13
+   |
+15 |     let y: &'test u32 = x;
+   |             ^^^^^ undeclared lifetime
+
+error[E0261]: use of undeclared lifetime name `'test`
+  --> $DIR/no_introducing_in_band_in_locals.rs:20:16
+   |
+20 |     let y: fn(&'test u32) = foo2;
+   |                ^^^^^ undeclared lifetime
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/in-band-lifetimes/shadow.rs
+++ b/src/test/ui/in-band-lifetimes/shadow.rs
@@ -1,0 +1,21 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(warnings)]
+#![feature(in_band_lifetimes)]
+
+struct Foo<T>(T);
+
+impl Foo<&'s u8> {
+    fn bar<'s>(&self, x: &'s u8) {}
+    fn baz(x: for<'s> fn(&'s u32)) {}
+}
+
+fn main() {}

--- a/src/test/ui/in-band-lifetimes/shadow.stderr
+++ b/src/test/ui/in-band-lifetimes/shadow.stderr
@@ -1,0 +1,19 @@
+error[E0496]: lifetime name `'s` shadows a lifetime name that is already in scope
+  --> $DIR/shadow.rs:17:12
+   |
+16 | impl Foo<&'s u8> {
+   |           -- first declared here
+17 |     fn bar<'s>(&self, x: &'s u8) {}
+   |            ^^ lifetime 's already in scope
+
+error[E0496]: lifetime name `'s` shadows a lifetime name that is already in scope
+  --> $DIR/shadow.rs:18:19
+   |
+16 | impl Foo<&'s u8> {
+   |           -- first declared here
+17 |     fn bar<'s>(&self, x: &'s u8) {}
+18 |     fn baz(x: for<'s> fn(&'s u32)) {}
+   |                   ^^ lifetime 's already in scope
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
TODO (perhaps in a future PR): Should we ban explicit instantiation of generics with in-band lifetimes, or is it uncontroversial to just append them to the end of the lifetimes list?

Fixes #46042, cc #44524.

r? @nikomatsakis 