### PR TITLE
Undo the Sized specialization from Iterator::nth

### DIFF
--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -253,8 +253,12 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.spec_nth(n)
+    fn nth(&mut self, mut n: usize) -> Option<Self::Item> {
+        for x in self {
+            if n == 0 { return Some(x) }
+            n -= 1;
+        }
+        None
     }
 
     /// Creates an iterator starting at the same point, but stepping by
@@ -2380,28 +2384,4 @@ impl<'a, I: Iterator + ?Sized> Iterator for &'a mut I {
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         (**self).nth(n)
     }
-}
-
-
-trait SpecIterator : Iterator {
-    fn spec_nth(&mut self, n: usize) -> Option<Self::Item>;
-}
-
-impl<I: Iterator + ?Sized> SpecIterator for I {
-    default fn spec_nth(&mut self, mut n: usize) -> Option<Self::Item> {
-        for x in self {
-            if n == 0 { return Some(x) }
-            n -= 1;
-        }
-        None
-   }
-}
-
-impl<I: Iterator + Sized> SpecIterator for I {
-    fn spec_nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.try_fold(n, move |i, x| {
-            if i == 0 { LoopState::Break(x) }
-            else { LoopState::Continue(i - 1) }
-        }).break_value()
-   }
 }


### PR DESCRIPTION
I just added this as part of https://github.com/rust-lang/rust/pull/45595, but I'm now afraid there's a specialization issue with it, since I tried to add [another similar specialization](https://github.com/rust-lang/rust/compare/master...scottmcm:faster-iter-by-ref?expand=1#diff-1398f322bc563592215b583e9b0ba936R2390), and ended up getting really disturbing test failures like
```
thread 'iter::test_by_ref_folds' panicked at 'assertion failed: `(left == right)`
  left: `15`, 
 right: `15`', src\libcore\../libcore/tests\iter.rs:1720:4
```

So since this wasn't the most critical part of the change and a new beta is branching within a week, I think putting this part back to what it was before is the best option.