### PR TITLE
Don't glob-import overlapping variant names in test/codegen/match-optimizes-away.rs.

### DIFF
--- a/src/test/codegen/match-optimizes-away.rs
+++ b/src/test/codegen/match-optimizes-away.rs
@@ -12,11 +12,9 @@
 // compile-flags: -O
 #![crate_type="lib"]
 
-pub enum Three { First, Second, Third }
-use Three::*;
+pub enum Three { A, B, C }
 
-pub enum Four { First, Second, Third, Fourth }
-use Four::*;
+pub enum Four { A, B, C, D }
 
 #[no_mangle]
 pub fn three_valued(x: Three) -> Three {
@@ -24,9 +22,9 @@ pub fn three_valued(x: Three) -> Three {
     // CHECK-NEXT: {{^.*:$}}
     // CHECK-NEXT: ret i8 %0
     match x {
-        First => First,
-        Second => Second,
-        Third => Third,
+        Three::A => Three::A,
+        Three::B => Three::B,
+        Three::C => Three::C,
     }
 }
 
@@ -36,9 +34,9 @@ pub fn four_valued(x: Four) -> Four {
     // CHECK-NEXT: {{^.*:$}}
     // CHECK-NEXT: ret i8 %0
     match x {
-        First => First,
-        Second => Second,
-        Third => Third,
-        Fourth => Fourth,
+        Four::A => Four::A,
+        Four::B => Four::B,
+        Four::C => Four::C,
+        Four::D => Four::D,
     }
 }


### PR DESCRIPTION
The test added in #45821 wasn't really testing anything because of an overlap between glob imports of enum variants, so it was actually doing `match x { y => y }`, alongside triggering warnings.