### PR TITLE
impl From for Mutex and RwLock

### DIFF
--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -382,6 +382,17 @@ unsafe impl<#[may_dangle] T: ?Sized> Drop for Mutex<T> {
     }
 }
 
+#[stable(feature = "mutex_from", since = "1.22.0")]
+impl<T> From<T> for Mutex<T> {
+    /// Creates a new mutex in an unlocked state ready for use.
+    /// This is equivalent to [`Mutex::new`].
+    ///
+    /// [`Mutex::new`]: #method.new
+    fn from(t: T) -> Self {
+        Mutex::new(t)
+    }
+}
+
 #[stable(feature = "mutex_default", since = "1.10.0")]
 impl<T: ?Sized + Default> Default for Mutex<T> {
     /// Creates a `Mutex<T>`, with the `Default` value for T.

--- a/src/libstd/sync/rwlock.rs
+++ b/src/libstd/sync/rwlock.rs
@@ -457,6 +457,17 @@ impl<T: Default> Default for RwLock<T> {
     }
 }
 
+#[stable(feature = "rw_lock_from", since = "1.22.0")]
+impl<T> From<T> for RwLock<T> {
+    /// Creates a new instance of an `RwLock<T>` which is unlocked.
+    /// This is equivalent to [`RwLock::new`].
+    ///
+    /// [`RwLock::new`]: #method.new
+    fn from(t: T) -> Self {
+        RwLock::new(t)
+    }
+}
+
 impl<'rwlock, T: ?Sized> RwLockReadGuard<'rwlock, T> {
     unsafe fn new(lock: &'rwlock RwLock<T>)
                   -> LockResult<RwLockReadGuard<'rwlock, T>> {


### PR DESCRIPTION
I felt that these implementations were missing, because doing `x.into()` works for other smart containers (such as `RefCell`), and in general I would say that the conversion makes sense.