### PR TITLE
Add process::parent_id

### DIFF
--- a/src/libstd/sys/redox/os.rs
+++ b/src/libstd/sys/redox/os.rs
@@ -213,3 +213,7 @@ pub fn exit(code: i32) -> ! {
 pub fn getpid() -> u32 {
     syscall::getpid().unwrap() as u32
 }
+
+pub fn getppid() -> u32 {
+    syscall::getppid().unwrap() as u32
+}

--- a/src/libstd/sys/unix/ext/process.rs
+++ b/src/libstd/sys/unix/ext/process.rs
@@ -191,3 +191,9 @@ impl IntoRawFd for process::ChildStderr {
         self.into_inner().into_fd().into_raw()
     }
 }
+
+/// Returns the OS-assigned process identifier associated with this process's parent.
+#[unstable(feature = "unix_ppid", issue = "46104")]
+pub fn parent_id() -> u32 {
+    ::sys::os::getppid()
+}

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -515,3 +515,7 @@ pub fn exit(code: i32) -> ! {
 pub fn getpid() -> u32 {
     unsafe { libc::getpid() as u32 }
 }
+
+pub fn getppid() -> u32 {
+    unsafe { libc::getppid() as u32 }
+}


### PR DESCRIPTION
I have this as a Unix-only API since it seems like Windows doesn't have
a similar API.

r? @alexcrichton 