### PR TITLE
[auto-toolstate][1/8] Always ignore build failure of failable tools (rls, rustfmt, clippy)

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1083,7 +1083,8 @@ impl Step for Rls {
         let rls = builder.ensure(tool::Rls {
             compiler: builder.compiler(stage, build.build),
             target
-        }).expect("Rls to build: toolstate is testing");
+        }).or_else(|| { println!("Unable to build RLS, skipping dist"); None })?;
+
         install(&rls, &image.join("bin"), 0o755);
         let doc = image.join("share/doc/rls");
         install(&src.join("README.md"), &doc, 0o644);
@@ -1167,11 +1168,12 @@ impl Step for Rustfmt {
         let rustfmt = builder.ensure(tool::Rustfmt {
             compiler: builder.compiler(stage, build.build),
             target
-        }).expect("Rustfmt to build: toolstate is testing");
+        }).or_else(|| { println!("Unable to build Rustfmt, skipping dist"); None })?;
         let cargofmt = builder.ensure(tool::Cargofmt {
             compiler: builder.compiler(stage, build.build),
             target
-        }).expect("Cargofmt to build: toolstate is testing");
+        }).or_else(|| { println!("Unable to build Cargofmt, skipping dist"); None })?;
+
         install(&rustfmt, &image.join("bin"), 0o755);
         install(&cargofmt, &image.join("bin"), 0o755);
         let doc = image.join("share/doc/rustfmt");

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -11,7 +11,7 @@
 use std::fs;
 use std::env;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, exit};
 
 use Mode;
 use Compiler;
@@ -115,7 +115,14 @@ impl Step for ToolBuild {
         println!("Building stage{} tool {} ({})", compiler.stage, tool, target);
 
         let mut cargo = prepare_tool_cargo(builder, compiler, target, "build", path);
-        build.run_expecting(&mut cargo, expectation);
+        if !build.try_run(&mut cargo, expectation) {
+            if expectation == BuildExpectation::None {
+                exit(1);
+            } else {
+                return None;
+            }
+        }
+
         if expectation == BuildExpectation::Succeeding || expectation == BuildExpectation::None {
             let cargo_out = build.cargo_out(compiler, Mode::Tool, target)
                 .join(exe(tool, &compiler.host));


### PR DESCRIPTION
If build failed for these tools, they will be automatically skipped from distribution, and will not fail the whole build.

Test failures are *not* ignored, nor build failure of other tools (e.g. cargo). Therefore it should have no observable effect to the current CI system.

This is step 1/8 of automatic management of broken tools #45861. The purpose is concentrate all failure detection about tools into a single CI job for easy management, while keeping the ability to distribute these tools in the nightlies.

r? @Mark-Simulacrum 