### PR TITLE
dead code lint to say "never constructed" for variants

### DIFF
--- a/src/test/compile-fail/lint-dead-code-1.rs
+++ b/src/test/compile-fail/lint-dead-code-1.rs
@@ -74,7 +74,7 @@ pub enum pub_enum3 {
 enum priv_enum { foo2, bar2 } //~ ERROR: enum is never used
 enum used_enum {
     foo3,
-    bar3 //~ ERROR variant is never used
+    bar3 //~ ERROR variant is never constructed
 }
 
 fn f<T>() {}

--- a/src/test/compile-fail/lint-dead-code-4.rs
+++ b/src/test/compile-fail/lint-dead-code-4.rs
@@ -22,8 +22,8 @@ fn field_read(f: Foo) -> usize {
 }
 
 enum XYZ {
-    X, //~ ERROR variant is never used
-    Y { //~ ERROR variant is never used
+    X, //~ ERROR variant is never constructed
+    Y { //~ ERROR variant is never constructed
         a: String,
         b: i32,
         c: i32,
@@ -43,13 +43,13 @@ enum ABC { //~ ERROR enum is never used
 
 // ensure struct variants get warning for their fields
 enum IJK {
-    I, //~ ERROR variant is never used
+    I, //~ ERROR variant is never constructed
     J {
         a: String,
         b: i32, //~ ERROR field is never used
         c: i32, //~ ERROR field is never used
     },
-    K //~ ERROR variant is never used
+    K //~ ERROR variant is never constructed
 
 }
 

--- a/src/test/compile-fail/lint-dead-code-5.rs
+++ b/src/test/compile-fail/lint-dead-code-5.rs
@@ -13,15 +13,15 @@
 
 enum Enum1 {
     Variant1(isize),
-    Variant2 //~ ERROR: variant is never used
+    Variant2 //~ ERROR: variant is never constructed
 }
 
 enum Enum2 {
     Variant3(bool),
     #[allow(dead_code)]
     Variant4(isize),
-    Variant5 { _x: isize }, //~ ERROR: variant is never used: `Variant5`
-    Variant6(isize), //~ ERROR: variant is never used: `Variant6`
+    Variant5 { _x: isize }, //~ ERROR: variant is never constructed: `Variant5`
+    Variant6(isize), //~ ERROR: variant is never constructed: `Variant6`
     _Variant7,
 }
 

--- a/src/test/compile-fail/lint-dead-code-variant.rs
+++ b/src/test/compile-fail/lint-dead-code-variant.rs
@@ -12,7 +12,7 @@
 
 #[derive(Clone)]
 enum Enum {
-    Variant1, //~ ERROR: variant is never used
+    Variant1, //~ ERROR: variant is never constructed
     Variant2,
 }
 


### PR DESCRIPTION
As reported in #19140, #44083, and #44565, some users were confused when
the dead-code lint reported an enum variant to be "unused" when it was
matched on (but not constructed). This wording change makes it clearer
that the lint is in fact checking for construction.

We continue to say "used" for all other items (it's tempting to say
"called" for functions and methods, but this turns out not to be
correct: functions can be passed as arguments and the dead-code lint
isn't special-casing that or anything).

Resolves #19140.

r? @pnkfelix