### PR TITLE
Add a MIR-borrowck-only output mode

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1778,7 +1778,7 @@ pub fn build_session_options_and_crate_config(matches: &getopts::Matches)
         Some("mir") => BorrowckMode::Mir,
         Some("compare") => BorrowckMode::Compare,
         Some(m) => {
-            early_error(error_format, &format!("unknown borrowchk mode `{}`", m))
+            early_error(error_format, &format!("unknown borrowck mode `{}`", m))
         },
     };
 

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -362,6 +362,9 @@ top_level_options!(
 
         debugging_opts: DebuggingOptions [TRACKED],
         prints: Vec<PrintRequest> [UNTRACKED],
+        // Determines which borrow checker(s) to run. This is the parsed, sanitized
+        // version of `debugging_opts.borrowck`, which is just a plain string.
+        borrowck_mode: BorrowckMode [UNTRACKED],
         cg: CodegenOptions [TRACKED],
         // FIXME(mw): We track this for now but it actually doesn't make too
         //            much sense: The value of this option can stay the same
@@ -399,6 +402,32 @@ pub enum PrintRequest {
     TlsModels,
     TargetSpec,
     NativeStaticLibs,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BorrowckMode {
+    Ast,
+    Mir,
+    Compare,
+}
+
+impl BorrowckMode {
+    /// Should we emit the AST-based borrow checker errors?
+    pub fn use_ast(self) -> bool {
+        match self {
+            BorrowckMode::Ast => true,
+            BorrowckMode::Compare => true,
+            BorrowckMode::Mir => false,
+        }
+    }
+    /// Should we emit the MIR-based borrow checker errors?
+    pub fn use_mir(self) -> bool {
+        match self {
+            BorrowckMode::Ast => false,
+            BorrowckMode::Compare => true,
+            BorrowckMode::Mir => true,
+        }
+    }
 }
 
 pub enum Input {
@@ -526,6 +555,7 @@ pub fn basic_options() -> Options {
         incremental: None,
         debugging_opts: basic_debugging_options(),
         prints: Vec::new(),
+        borrowck_mode: BorrowckMode::Ast,
         cg: basic_codegen_options(),
         error_format: ErrorOutputType::default(),
         externs: Externs(BTreeMap::new()),
@@ -973,8 +1003,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
         "make unnamed regions display as '# (where # is some non-ident unique id)"),
     emit_end_regions: bool = (false, parse_bool, [UNTRACKED],
         "emit EndRegion as part of MIR; enable transforms that solely process EndRegion"),
-    borrowck_mir: bool = (false, parse_bool, [UNTRACKED],
-        "implicitly treat functions as if they have `#[rustc_mir_borrowck]` attribute"),
+    borrowck: Option<String> = (None, parse_opt_string, [UNTRACKED],
+        "select which borrowck is used (`ast`, `mir`, or `compare`)"),
     time_passes: bool = (false, parse_bool, [UNTRACKED],
         "measure time of each rustc pass"),
     count_llvm_insns: bool = (false, parse_bool,
@@ -1743,6 +1773,15 @@ pub fn build_session_options_and_crate_config(matches: &getopts::Matches)
         }
     }));
 
+    let borrowck_mode = match debugging_opts.borrowck.as_ref().map(|s| &s[..]) {
+        None | Some("ast") => BorrowckMode::Ast,
+        Some("mir") => BorrowckMode::Mir,
+        Some("compare") => BorrowckMode::Compare,
+        Some(m) => {
+            early_error(error_format, &format!("unknown borrowchk mode `{}`", m))
+        },
+    };
+
     if !cg.remark.is_empty() && debuginfo == NoDebugInfo {
         early_warn(error_format, "-C remark will not show source locations without \
                                 --debuginfo");
@@ -1784,6 +1823,7 @@ pub fn build_session_options_and_crate_config(matches: &getopts::Matches)
         incremental,
         debugging_opts,
         prints,
+        borrowck_mode,
         cg,
         error_format,
         externs: Externs(externs),

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -416,7 +416,7 @@ impl Session {
     pub fn emit_end_regions(&self) -> bool {
         self.opts.debugging_opts.emit_end_regions ||
             (self.opts.debugging_opts.mir_emit_validate > 0) ||
-            self.opts.debugging_opts.borrowck_mir
+            self.opts.borrowck_mode.use_mir()
     }
     pub fn lto(&self) -> bool {
         self.opts.cg.lto || self.target.target.options.requires_lto

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -269,6 +269,17 @@ impl<'b, 'tcx: 'b> BorrowckErrors for BorrowckCtxt<'b, 'tcx> {
     {
         self.tcx.sess.struct_span_err(sp, msg)
     }
+
+    fn cancel_if_wrong_origin<'a>(&'a self,
+                                mut diag: DiagnosticBuilder<'a>,
+                                o: Origin)
+                                -> DiagnosticBuilder<'a>
+    {
+        if !o.should_emit_errors(self.tcx.sess.opts.borrowck_mode) {
+            self.tcx.sess.diagnostic().cancel(&mut diag);
+        }
+        diag
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/librustc_mir/borrow_check.rs
+++ b/src/librustc_mir/borrow_check.rs
@@ -54,7 +54,7 @@ fn mir_borrowck<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) {
 
     if {
         !tcx.has_attr(def_id, "rustc_mir_borrowck") &&
-            !tcx.sess.opts.debugging_opts.borrowck_mir &&
+            !tcx.sess.opts.borrowck_mode.use_mir() &&
             !tcx.sess.opts.debugging_opts.nll
     } {
         return;

--- a/src/librustc_mir/util/borrowck_errors.rs
+++ b/src/librustc_mir/util/borrowck_errors.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use rustc::ty::{self, TyCtxt};
+use rustc::session::config::BorrowckMode;
 use rustc_errors::{DiagnosticBuilder, DiagnosticId};
 use syntax_pos::{MultiSpan, Span};
 
@@ -19,20 +20,34 @@ pub enum Origin { Ast, Mir }
 
 impl fmt::Display for Origin {
     fn fmt(&self, w: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Origin::Mir => write!(w, " (Mir)"),
-            Origin::Ast => ty::tls::with_opt(|opt_tcx| {
-                // If user passed `-Z borrowck-mir`, then include an
-                // AST origin as part of the error report
-                if let Some(tcx) = opt_tcx {
-                    if tcx.sess.opts.debugging_opts.borrowck_mir {
-                        return write!(w, " (Ast)");
-                    }
-                }
-                // otherwise, do not include the origin (i.e., print
-                // nothing at all)
-                Ok(())
-            }),
+        // If the user passed `-Z borrowck=compare`, then include
+        // origin info as part of the error report,
+        // otherwise
+        let display_origin = ty::tls::with_opt(|opt_tcx| {
+            if let Some(tcx) = opt_tcx {
+                tcx.sess.opts.borrowck_mode == BorrowckMode::Compare
+            } else {
+                false
+            }
+        });
+        if display_origin {
+            match *self {
+                Origin::Mir => write!(w, " (Mir)"),
+                Origin::Ast => write!(w, " (Ast)"),
+            }
+        } else {
+            // Print no origin info
+            Ok(())
+        }
+    }
+}
+
+impl Origin {
+    /// Whether we should emit errors for the origin in the given mode
+    pub fn should_emit_errors(self, mode: BorrowckMode) -> bool {
+        match self {
+            Origin::Ast => mode.use_ast(),
+            Origin::Mir => mode.use_mir(),
         }
     }
 }
@@ -49,12 +64,23 @@ pub trait BorrowckErrors {
                                                msg: &str)
                                                -> DiagnosticBuilder<'a>;
 
+    /// Cancels the given error if we shouldn't emit errors for a given
+    /// origin in the current mode.
+    ///
+    /// Always make sure that the error gets passed through this function
+    /// before you return it.
+    fn cancel_if_wrong_origin<'a>(&'a self,
+                                diag: DiagnosticBuilder<'a>,
+                                o: Origin)
+                                -> DiagnosticBuilder<'a>;
+
     fn cannot_move_when_borrowed(&self, span: Span, desc: &str, o: Origin)
                                  -> DiagnosticBuilder
     {
-        struct_span_err!(self, span, E0505,
-                         "cannot move out of `{}` because it is borrowed{OGN}",
-                         desc, OGN=o)
+        let err = struct_span_err!(self, span, E0505,
+                                   "cannot move out of `{}` because it is borrowed{OGN}",
+                                   desc, OGN=o);
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_use_when_mutably_borrowed(&self,
@@ -72,7 +98,7 @@ pub trait BorrowckErrors {
         err.span_label(borrow_span, format!("borrow of `{}` occurs here", borrow_desc));
         err.span_label(span, format!("use of borrowed `{}`", borrow_desc));
 
-        err
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_act_on_uninitialized_variable(&self,
@@ -82,9 +108,10 @@ pub trait BorrowckErrors {
                                             o: Origin)
                                             -> DiagnosticBuilder
     {
-        struct_span_err!(self, span, E0381,
-                         "{} of possibly uninitialized variable: `{}`{OGN}",
-                         verb, desc, OGN=o)
+        let err = struct_span_err!(self, span, E0381,
+                                   "{} of possibly uninitialized variable: `{}`{OGN}",
+                                   verb, desc, OGN=o);
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_mutably_borrow_multiply(&self,
@@ -118,7 +145,7 @@ pub trait BorrowckErrors {
                 err.span_label(old_load_end_span, "first borrow ends here");
             }
         }
-        err
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_uniquely_borrow_by_two_closures(&self,
@@ -143,7 +170,7 @@ pub trait BorrowckErrors {
                 old_load_end_span,
                 "borrow from first closure ends here");
         }
-        err
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_uniquely_borrow_by_one_closure(&self,
@@ -167,7 +194,7 @@ pub trait BorrowckErrors {
         if let Some(previous_end_span) = previous_end_span {
             err.span_label(previous_end_span, "borrow ends here");
         }
-        err
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_reborrow_already_uniquely_borrowed(&self,
@@ -192,7 +219,7 @@ pub trait BorrowckErrors {
         if let Some(previous_end_span) = previous_end_span {
             err.span_label(previous_end_span, "borrow from closure ends here");
         }
-        err
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_reborrow_already_borrowed(&self,
@@ -216,7 +243,7 @@ pub trait BorrowckErrors {
         if let Some(old_load_end_span) = old_load_end_span {
             err.span_label(old_load_end_span, format!("{} borrow ends here", kind_old));
         }
-        err
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_assign_to_borrowed(&self, span: Span, borrow_span: Span, desc: &str, o: Origin)
@@ -229,30 +256,35 @@ pub trait BorrowckErrors {
         err.span_label(borrow_span, format!("borrow of `{}` occurs here", desc));
         err.span_label(span, format!("assignment to borrowed `{}` occurs here", desc));
 
-        err
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_move_into_closure(&self, span: Span, desc: &str, o: Origin)
                                 -> DiagnosticBuilder
     {
-        struct_span_err!(self, span, E0504,
-                         "cannot move `{}` into closure because it is borrowed{OGN}",
-                         desc, OGN=o)
+        let err = struct_span_err!(self, span, E0504,
+                                   "cannot move `{}` into closure because it is borrowed{OGN}",
+                                   desc, OGN=o);
+
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_reassign_immutable(&self, span: Span, desc: &str, o: Origin)
                                  -> DiagnosticBuilder
     {
-        struct_span_err!(self, span, E0384,
-                         "cannot assign twice to immutable variable `{}`{OGN}",
-                         desc, OGN=o)
+        let err = struct_span_err!(self, span, E0384,
+                                   "cannot assign twice to immutable variable `{}`{OGN}",
+                                   desc, OGN=o);
+
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_assign(&self, span: Span, desc: &str, o: Origin) -> DiagnosticBuilder
     {
-        struct_span_err!(self, span, E0594,
-                         "cannot assign to {}{OGN}",
-                         desc, OGN=o)
+        let err = struct_span_err!(self, span, E0594,
+                                  "cannot assign to {}{OGN}",
+                                  desc, OGN=o);
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_assign_static(&self, span: Span, desc: &str, o: Origin)
@@ -270,7 +302,8 @@ pub trait BorrowckErrors {
         err.span_label(
             move_from_span,
             format!("cannot move out of {}", move_from_desc));
-        err
+
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_move_out_of_interior_noncopy(&self,
@@ -290,7 +323,8 @@ pub trait BorrowckErrors {
                                         a non-copy {}{OGN}",
                                        ty, type_name, OGN=o);
         err.span_label(move_from_span, "cannot move out of here");
-        err
+
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_move_out_of_interior_of_drop(&self,
@@ -304,7 +338,8 @@ pub trait BorrowckErrors {
                                         which implements the `Drop` trait{OGN}",
                                        container_ty, OGN=o);
         err.span_label(move_from_span, "cannot move out of here");
-        err
+
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_act_on_moved_value(&self,
@@ -318,7 +353,8 @@ pub trait BorrowckErrors {
         let err = struct_span_err!(self, use_span, E0382,
                                    "{} of {}moved value: `{}`{OGN}",
                                    verb, optional_adverb_for_moved, moved_path, OGN=o);
-        err
+
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_partially_reinit_an_uninit_struct(&self,
@@ -332,7 +368,8 @@ pub trait BorrowckErrors {
                                    E0383,
                                    "partial reinitialization of uninitialized structure `{}`{OGN}",
                                    uninit_path, OGN=o);
-        err
+
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn closure_cannot_assign_to_borrowed(&self,
@@ -343,7 +380,8 @@ pub trait BorrowckErrors {
     {
         let err = struct_span_err!(self, span, E0595, "closure cannot assign to {}{OGN}",
                                    descr, OGN=o);
-        err
+
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_borrow_path_as_mutable(&self,
@@ -354,7 +392,8 @@ pub trait BorrowckErrors {
     {
         let err = struct_span_err!(self, span, E0596, "cannot borrow {} as mutable{OGN}",
                                    path, OGN=o);
-        err
+
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_borrow_across_generator_yield(&self,
@@ -369,7 +408,8 @@ pub trait BorrowckErrors {
                                        "borrow may still be in use when generator yields{OGN}",
                                        OGN=o);
         err.span_label(yield_span, "possible yield occurs here");
-        err
+
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn path_does_not_live_long_enough(&self,
@@ -380,7 +420,8 @@ pub trait BorrowckErrors {
     {
         let err = struct_span_err!(self, span, E0597, "{} does not live long enough{OGN}",
                                    path, OGN=o);
-        err
+
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn lifetime_too_short_for_reborrow(&self,
@@ -393,7 +434,8 @@ pub trait BorrowckErrors {
                                    "lifetime of {} is too short to guarantee \
                                     its contents can be safely reborrowed{OGN}",
                                    path, OGN=o);
-        err
+
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_act_on_capture_in_sharable_fn(&self,
@@ -408,7 +450,8 @@ pub trait BorrowckErrors {
                                        "{} in a captured outer variable in an `Fn` closure{OGN}",
                                        bad_thing, OGN=o);
         err.span_help(help_span, help_msg);
-        err
+
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_assign_into_immutable_reference(&self,
@@ -420,7 +463,8 @@ pub trait BorrowckErrors {
         let mut err = struct_span_err!(self, span, E0389, "{} in a `&` reference{OGN}",
                                        bad_thing, OGN=o);
         err.span_label(span, "assignment into an immutable reference");
-        err
+
+        self.cancel_if_wrong_origin(err, o)
     }
 
     fn cannot_capture_in_long_lived_closure(&self,
@@ -437,7 +481,8 @@ pub trait BorrowckErrors {
                                        borrowed_path, OGN=o);
         err.span_label(capture_span, format!("{} is borrowed here", borrowed_path))
             .span_label(closure_span, format!("may outlive borrowed value {}", borrowed_path));
-        err
+
+        self.cancel_if_wrong_origin(err, o)
     }
 }
 
@@ -457,5 +502,16 @@ impl<'b, 'gcx, 'tcx> BorrowckErrors for TyCtxt<'b, 'gcx, 'tcx> {
                                                -> DiagnosticBuilder<'a>
     {
         self.sess.struct_span_err(sp, msg)
+    }
+
+    fn cancel_if_wrong_origin<'a>(&'a self,
+                                mut diag: DiagnosticBuilder<'a>,
+                                o: Origin)
+                                -> DiagnosticBuilder<'a>
+    {
+        if !o.should_emit_errors(self.sess.opts.borrowck_mode) {
+            self.sess.diagnostic().cancel(&mut diag);
+        }
+        diag
     }
 }

--- a/src/test/compile-fail/E0506.rs
+++ b/src/test/compile-fail/E0506.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 struct FancyNum {
     num: u8,
@@ -19,8 +19,7 @@ fn main() {
     let mut fancy_num = FancyNum { num: 5 };
     let fancy_ref = &fancy_num;
     fancy_num = FancyNum { num: 6 }; //[ast]~ ERROR E0506
-                                     //[mir]~^ ERROR (Mir) [E0506]
-                                     //[mir]~| ERROR (Ast) [E0506]
+                                     //[mir]~^ ERROR [E0506]
 
     println!("Num: {}, Ref: {}", fancy_num.num, fancy_ref.num);
 }

--- a/src/test/compile-fail/E0508.rs
+++ b/src/test/compile-fail/E0508.rs
@@ -9,13 +9,12 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Zborrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 struct NonCopy;
 
 fn main() {
     let array = [NonCopy; 1];
-    let _value = array[0];  //[ast]~ ERROR E0508
-                            //[mir]~^ ERROR (Ast) [E0508]
-                            //[mir]~| ERROR (Mir) [E0508]
+    let _value = array[0];  //[ast]~ ERROR [E0508]
+                            //[mir]~^ ERROR [E0508]
 }

--- a/src/test/compile-fail/E0594.rs
+++ b/src/test/compile-fail/E0594.rs
@@ -9,12 +9,11 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 static NUM: i32 = 18;
 
 fn main() {
     NUM = 20; //[ast]~ ERROR E0594
-              //[mir]~^ ERROR cannot assign to immutable static item (Ast)
-              //[mir]~| ERROR cannot assign to immutable static item `NUM` (Mir)
+              //[mir]~^ ERROR cannot assign to immutable static item
 }

--- a/src/test/compile-fail/E0596.rs
+++ b/src/test/compile-fail/E0596.rs
@@ -9,11 +9,10 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 fn main() {
     let x = 1;
     let y = &mut x; //[ast]~ ERROR [E0596]
-                    //[mir]~^ ERROR (Ast) [E0596]
-                    //[mir]~| ERROR (Mir) [E0596]
+                    //[mir]~^ ERROR [E0596]
 }

--- a/src/test/compile-fail/borrowck/borrowck-access-permissions.rs
+++ b/src/test/compile-fail/borrowck/borrowck-access-permissions.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 static static_x : i32 = 1;
 static mut static_x_mut : i32 = 1;
@@ -20,15 +20,13 @@ fn main() {
 
     { // borrow of local
         let _y1 = &mut x; //[ast]~ ERROR [E0596]
-                          //[mir]~^ ERROR (Ast) [E0596]
-                          //[mir]~| ERROR (Mir) [E0596]
+                          //[mir]~^ ERROR [E0596]
         let _y2 = &mut x_mut; // No error
     }
 
     { // borrow of static
         let _y1 = &mut static_x; //[ast]~ ERROR [E0596]
-                                 //[mir]~^ ERROR (Ast) [E0596]
-                                 //[mir]~| ERROR (Mir) [E0596]
+                                 //[mir]~^ ERROR [E0596]
         unsafe { let _y2 = &mut static_x_mut; } // No error
     }
 
@@ -37,8 +35,7 @@ fn main() {
         let mut box_x_mut = Box::new(1);
 
         let _y1 = &mut *box_x; //[ast]~ ERROR [E0596]
-                              //[mir]~^ ERROR (Ast) [E0596]
-                              //[mir]~| ERROR (Mir) [E0596]
+                               //[mir]~^ ERROR [E0596]
         let _y2 = &mut *box_x_mut; // No error
     }
 
@@ -47,8 +44,7 @@ fn main() {
         let ref_x_mut = &mut x_mut;
 
         let _y1 = &mut *ref_x; //[ast]~ ERROR [E0596]
-                              //[mir]~^ ERROR (Ast) [E0596]
-                              //[mir]~| ERROR (Mir) [E0596]
+                               //[mir]~^ ERROR [E0596]
         let _y2 = &mut *ref_x_mut; // No error
     }
 
@@ -58,8 +54,7 @@ fn main() {
 
         unsafe {
             let _y1 = &mut *ptr_x; //[ast]~ ERROR [E0596]
-                                  //[mir]~^ ERROR (Ast) [E0596]
-                                  //[mir]~| ERROR (Mir) [E0596]
+                                   //[mir]~^ ERROR [E0596]
             let _y2 = &mut *ptr_mut_x; // No error
         }
     }
@@ -69,8 +64,7 @@ fn main() {
         let mut foo = Foo { f: &mut x_mut, g: &x };
         let foo_ref = &foo;
         let _y = &mut *foo_ref.f; //[ast]~ ERROR [E0389]
-                                 //[mir]~^ ERROR (Ast) [E0389]
-                                 //[mir]~| ERROR (Mir) [E0596]
-                                 // FIXME: Wrong error in MIR
+                                  //[mir]~^ ERROR [E0596]
+                                  // FIXME: Wrong error in MIR
     }
 }

--- a/src/test/compile-fail/borrowck/borrowck-assign-comp.rs
+++ b/src/test/compile-fail/borrowck/borrowck-assign-comp.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 struct point { x: isize, y: isize }
 
@@ -21,8 +21,7 @@ fn a() {
     // inherently mutable; since `p` was made immutable, `p.x` is now
     // immutable.  Otherwise the type of &_q.x (&isize) would be wrong.
     p.x = 5; //[ast]~ ERROR cannot assign to `p.x`
-             //[mir]~^ ERROR cannot assign to `p.x` because it is borrowed (Ast)
-             //[mir]~| ERROR cannot assign to `p.x` because it is borrowed (Mir)
+             //[mir]~^ ERROR cannot assign to `p.x` because it is borrowed
     q.x;
 }
 
@@ -33,8 +32,7 @@ fn c() {
     let mut p = point {x: 3, y: 4};
     let q = &p.y;
     p = point {x: 5, y: 7};//[ast]~ ERROR cannot assign to `p`
-                           //[mir]~^ ERROR cannot assign to `p` because it is borrowed (Ast)
-                           //[mir]~| ERROR cannot assign to `p` because it is borrowed (Mir)
+                           //[mir]~^ ERROR cannot assign to `p` because it is borrowed
     p.x; // silence warning
     *q; // stretch loan
 }
@@ -46,8 +44,7 @@ fn d() {
     let mut p = point {x: 3, y: 4};
     let q = &p.y;
     p.y = 5; //[ast]~ ERROR cannot assign to `p.y`
-             //[mir]~^ ERROR cannot assign to `p.y` because it is borrowed (Ast)
-             //[mir]~| ERROR cannot assign to `p.y` because it is borrowed (Mir)
+             //[mir]~^ ERROR cannot assign to `p.y` because it is borrowed
     *q;
 }
 

--- a/src/test/compile-fail/borrowck/borrowck-assign-to-constants.rs
+++ b/src/test/compile-fail/borrowck/borrowck-assign-to-constants.rs
@@ -9,13 +9,12 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 static foo: isize = 5;
 
 fn main() {
     // assigning to various global constants
     foo = 6; //[ast]~ ERROR cannot assign to immutable static item
-             //[mir]~^ ERROR cannot assign to immutable static item (Ast)
-             //[mir]~| ERROR cannot assign to immutable static item `foo` (Mir)
+             //[mir]~^ ERROR cannot assign to immutable static item `foo`
 }

--- a/src/test/compile-fail/borrowck/borrowck-closures-mut-and-imm.rs
+++ b/src/test/compile-fail/borrowck/borrowck-closures-mut-and-imm.rs
@@ -13,7 +13,7 @@
 
 // ignore-tidy-linelength
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 #![feature(box_syntax)]
 
@@ -29,48 +29,42 @@ fn a() {
     let mut x = 3;
     let c1 = || x = 4;
     let c2 = || x * 5; //[ast]~ ERROR cannot borrow `x`
-                       //[mir]~^ ERROR cannot borrow `x` as immutable because it is also borrowed as mutable (Ast)
-                       //[mir]~| ERROR cannot borrow `x` as immutable because it is also borrowed as mutable (Mir)
+                       //[mir]~^ ERROR cannot borrow `x` as immutable because it is also borrowed as mutable
 }
 
 fn b() {
     let mut x = 3;
     let c1 = || set(&mut x);
     let c2 = || get(&x); //[ast]~ ERROR cannot borrow `x`
-                         //[mir]~^ ERROR cannot borrow `x` as immutable because it is also borrowed as mutable (Ast)
-                         //[mir]~| ERROR cannot borrow `x` as immutable because it is also borrowed as mutable (Mir)
+                         //[mir]~^ ERROR cannot borrow `x` as immutable because it is also borrowed as mutable
 }
 
 fn c() {
     let mut x = 3;
     let c1 = || set(&mut x);
     let c2 = || x * 5; //[ast]~ ERROR cannot borrow `x`
-                       //[mir]~^ ERROR cannot borrow `x` as immutable because it is also borrowed as mutable (Ast)
-                       //[mir]~| ERROR cannot borrow `x` as immutable because it is also borrowed as mutable (Mir)
+                       //[mir]~^ ERROR cannot borrow `x` as immutable because it is also borrowed as mutable
 }
 
 fn d() {
     let mut x = 3;
     let c2 = || x * 5;
     x = 5; //[ast]~ ERROR cannot assign
-           //[mir]~^ ERROR cannot assign to `x` because it is borrowed (Ast)
-           //[mir]~| ERROR cannot assign to `x` because it is borrowed (Mir)
+           //[mir]~^ ERROR cannot assign to `x` because it is borrowed
 }
 
 fn e() {
     let mut x = 3;
     let c1 = || get(&x);
     x = 5; //[ast]~ ERROR cannot assign
-           //[mir]~^ ERROR cannot assign to `x` because it is borrowed (Ast)
-           //[mir]~| ERROR cannot assign to `x` because it is borrowed (Mir)
+           //[mir]~^ ERROR cannot assign to `x` because it is borrowed
 }
 
 fn f() {
     let mut x: Box<_> = box 3;
     let c1 = || get(&*x);
-    *x = 5; //[ast]~ ERROR cannot assign
-            //[mir]~^ ERROR cannot assign to `*x` because it is borrowed (Ast)
-            //[mir]~| ERROR cannot assign to `*x` because it is borrowed (Mir)
+    *x = 5; //[ast]~ ERROR cannot assign to `*x`
+            //[mir]~^ ERROR cannot assign to `*x` because it is borrowed
 }
 
 fn g() {
@@ -81,8 +75,7 @@ fn g() {
     let mut x: Box<_> = box Foo { f: box 3 };
     let c1 = || get(&*x.f);
     *x.f = 5; //[ast]~ ERROR cannot assign to `*x.f`
-              //[mir]~^ ERROR cannot assign to `*x.f` because it is borrowed (Ast)
-              //[mir]~| ERROR cannot assign to `*x.f` because it is borrowed (Mir)
+              //[mir]~^ ERROR cannot assign to `*x.f` because it is borrowed
 }
 
 fn h() {
@@ -93,8 +86,7 @@ fn h() {
     let mut x: Box<_> = box Foo { f: box 3 };
     let c1 = || get(&*x.f);
     let c2 = || *x.f = 5; //[ast]~ ERROR cannot borrow `x` as mutable
-                          //[mir]~^ ERROR cannot borrow `x` as mutable because it is also borrowed as immutable (Ast)
-                          //[mir]~| ERROR cannot borrow `x` as mutable because it is also borrowed as immutable (Mir)
+                          //[mir]~^ ERROR cannot borrow `x` as mutable because it is also borrowed as immutable
 }
 
 fn main() {

--- a/src/test/compile-fail/borrowck/borrowck-describe-lvalue.rs
+++ b/src/test/compile-fail/borrowck/borrowck-describe-lvalue.rs
@@ -10,7 +10,7 @@
 
 // ignore-tidy-linelength
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 #![feature(slice_patterns)]
 #![feature(advanced_slice_patterns)]
@@ -52,24 +52,21 @@ fn main() {
         let mut f = Foo { x: 22 };
         let _x = f.x();
         f.x; //[ast]~ ERROR cannot use `f.x` because it was mutably borrowed
-             //[mir]~^ ERROR cannot use `f.x` because it was mutably borrowed (Ast)
-             //[mir]~| ERROR cannot use `f.x` because it was mutably borrowed (Mir)
+             //[mir]~^ ERROR cannot use `f.x` because it was mutably borrowed
     }
     // Local and field from tuple-struct
     {
         let mut g = Bar(22);
         let _0 = g.x();
         g.0; //[ast]~ ERROR cannot use `g.0` because it was mutably borrowed
-             //[mir]~^ ERROR cannot use `g.0` because it was mutably borrowed (Ast)
-             //[mir]~| ERROR cannot use `g.0` because it was mutably borrowed (Mir)
+             //[mir]~^ ERROR cannot use `g.0` because it was mutably borrowed
     }
     // Local and field from tuple
     {
         let mut h = (22, 23);
         let _0 = &mut h.0;
         h.0; //[ast]~ ERROR cannot use `h.0` because it was mutably borrowed
-             //[mir]~^ ERROR cannot use `h.0` because it was mutably borrowed (Ast)
-             //[mir]~| ERROR cannot use `h.0` because it was mutably borrowed (Mir)
+             //[mir]~^ ERROR cannot use `h.0` because it was mutably borrowed
     }
     // Local and field from enum
     {
@@ -78,8 +75,7 @@ fn main() {
         match e {
             Baz::X(value) => value
             //[ast]~^ ERROR cannot use `e.0` because it was mutably borrowed
-            //[mir]~^^ ERROR cannot use `e.0` because it was mutably borrowed (Ast)
-            //[mir]~| ERROR cannot use `e.0` because it was mutably borrowed (Mir)
+            //[mir]~^^ ERROR cannot use `e.0` because it was mutably borrowed
         };
     }
     // Local and field from union
@@ -87,32 +83,28 @@ fn main() {
         let mut u = U { b: 0 };
         let _ra = &mut u.a;
         u.a; //[ast]~ ERROR cannot use `u.a` because it was mutably borrowed
-             //[mir]~^ ERROR cannot use `u.a` because it was mutably borrowed (Ast)
-             //[mir]~| ERROR cannot use `u.a` because it was mutably borrowed (Mir)
+             //[mir]~^ ERROR cannot use `u.a` because it was mutably borrowed
     }
     // Deref and field from struct
     {
         let mut f = Box::new(Foo { x: 22 });
         let _x = f.x();
         f.x; //[ast]~ ERROR cannot use `f.x` because it was mutably borrowed
-             //[mir]~^ ERROR cannot use `f.x` because it was mutably borrowed (Ast)
-             //[mir]~| ERROR cannot use `f.x` because it was mutably borrowed (Mir)
+             //[mir]~^ ERROR cannot use `f.x` because it was mutably borrowed
     }
     // Deref and field from tuple-struct
     {
         let mut g = Box::new(Bar(22));
         let _0 = g.x();
         g.0; //[ast]~ ERROR cannot use `g.0` because it was mutably borrowed
-             //[mir]~^ ERROR cannot use `g.0` because it was mutably borrowed (Ast)
-             //[mir]~| ERROR cannot use `g.0` because it was mutably borrowed (Mir)
+             //[mir]~^ ERROR cannot use `g.0` because it was mutably borrowed
     }
     // Deref and field from tuple
     {
         let mut h = Box::new((22, 23));
         let _0 = &mut h.0;
         h.0; //[ast]~ ERROR cannot use `h.0` because it was mutably borrowed
-             //[mir]~^ ERROR cannot use `h.0` because it was mutably borrowed (Ast)
-             //[mir]~| ERROR cannot use `h.0` because it was mutably borrowed (Mir)
+             //[mir]~^ ERROR cannot use `h.0` because it was mutably borrowed
     }
     // Deref and field from enum
     {
@@ -121,8 +113,7 @@ fn main() {
         match *e {
             Baz::X(value) => value
             //[ast]~^ ERROR cannot use `e.0` because it was mutably borrowed
-            //[mir]~^^ ERROR cannot use `e.0` because it was mutably borrowed (Ast)
-            //[mir]~| ERROR cannot use `e.0` because it was mutably borrowed (Mir)
+            //[mir]~^^ ERROR cannot use `e.0` because it was mutably borrowed
         };
     }
     // Deref and field from union
@@ -130,8 +121,7 @@ fn main() {
         let mut u = Box::new(U { b: 0 });
         let _ra = &mut u.a;
         u.a; //[ast]~ ERROR cannot use `u.a` because it was mutably borrowed
-             //[mir]~^ ERROR cannot use `u.a` because it was mutably borrowed (Ast)
-             //[mir]~| ERROR cannot use `u.a` because it was mutably borrowed (Mir)
+             //[mir]~^ ERROR cannot use `u.a` because it was mutably borrowed
     }
     // Constant index
     {
@@ -140,29 +130,25 @@ fn main() {
         match v {
             &[x, _, .., _, _] => println!("{}", x),
                 //[ast]~^ ERROR cannot use `v[..]` because it was mutably borrowed
-                //[mir]~^^ ERROR cannot use `v[..]` because it was mutably borrowed (Ast)
-                //[mir]~| ERROR cannot use `v[..]` because it was mutably borrowed (Mir)
+                //[mir]~^^ ERROR cannot use `v[..]` because it was mutably borrowed
                             _ => panic!("other case"),
         }
         match v {
             &[_, x, .., _, _] => println!("{}", x),
                 //[ast]~^ ERROR cannot use `v[..]` because it was mutably borrowed
-                //[mir]~^^ ERROR cannot use `v[..]` because it was mutably borrowed (Ast)
-                //[mir]~| ERROR cannot use `v[..]` because it was mutably borrowed (Mir)
+                //[mir]~^^ ERROR cannot use `v[..]` because it was mutably borrowed
                             _ => panic!("other case"),
         }
         match v {
             &[_, _, .., x, _] => println!("{}", x),
                 //[ast]~^ ERROR cannot use `v[..]` because it was mutably borrowed
-                //[mir]~^^ ERROR cannot use `v[..]` because it was mutably borrowed (Ast)
-                //[mir]~| ERROR cannot use `v[..]` because it was mutably borrowed (Mir)
+                //[mir]~^^ ERROR cannot use `v[..]` because it was mutably borrowed
                             _ => panic!("other case"),
         }
         match v {
             &[_, _, .., _, x] => println!("{}", x),
                 //[ast]~^ ERROR cannot use `v[..]` because it was mutably borrowed
-                //[mir]~^^ ERROR cannot use `v[..]` because it was mutably borrowed (Ast)
-                //[mir]~| ERROR cannot use `v[..]` because it was mutably borrowed (Mir)
+                //[mir]~^^ ERROR cannot use `v[..]` because it was mutably borrowed
                             _ => panic!("other case"),
         }
     }
@@ -173,29 +159,25 @@ fn main() {
         match v {
             &[x..] => println!("{:?}", x),
                 //[ast]~^ ERROR cannot use `v[..]` because it was mutably borrowed
-                //[mir]~^^ ERROR cannot use `v[..]` because it was mutably borrowed (Ast)
-                //[mir]~| ERROR cannot use `v[..]` because it was mutably borrowed (Mir)
+                //[mir]~^^ ERROR cannot use `v[..]` because it was mutably borrowed
             _ => panic!("other case"),
         }
         match v {
             &[_, x..] => println!("{:?}", x),
                 //[ast]~^ ERROR cannot use `v[..]` because it was mutably borrowed
-                //[mir]~^^ ERROR cannot use `v[..]` because it was mutably borrowed (Ast)
-                //[mir]~| ERROR cannot use `v[..]` because it was mutably borrowed (Mir)
+                //[mir]~^^ ERROR cannot use `v[..]` because it was mutably borrowed
             _ => panic!("other case"),
         }
         match v {
             &[x.., _] => println!("{:?}", x),
                 //[ast]~^ ERROR cannot use `v[..]` because it was mutably borrowed
-                //[mir]~^^ ERROR cannot use `v[..]` because it was mutably borrowed (Ast)
-                //[mir]~| ERROR cannot use `v[..]` because it was mutably borrowed (Mir)
+                //[mir]~^^ ERROR cannot use `v[..]` because it was mutably borrowed
             _ => panic!("other case"),
         }
         match v {
             &[_, x.., _] => println!("{:?}", x),
                 //[ast]~^ ERROR cannot use `v[..]` because it was mutably borrowed
-                //[mir]~^^ ERROR cannot use `v[..]` because it was mutably borrowed (Ast)
-                //[mir]~| ERROR cannot use `v[..]` because it was mutably borrowed (Mir)
+                //[mir]~^^ ERROR cannot use `v[..]` because it was mutably borrowed
             _ => panic!("other case"),
         }
     }
@@ -208,14 +190,12 @@ fn main() {
         match e {
             E::A(ref ax) =>
                 //[ast]~^ ERROR cannot borrow `e.0` as immutable because `e` is also borrowed as mutable
-                //[mir]~^^ ERROR cannot borrow `e.0` as immutable because `e` is also borrowed as mutable (Ast)
-                //[mir]~| ERROR cannot borrow `e.0` as immutable because it is also borrowed as mutable (Mir)
-                //[mir]~| ERROR cannot use `e` because it was mutably borrowed (Mir)
+                //[mir]~^^ ERROR cannot borrow `e.0` as immutable because it is also borrowed as mutable
+                //[mir]~| ERROR cannot use `e` because it was mutably borrowed
                 println!("e.ax: {:?}", ax),
             E::B { x: ref bx } =>
                 //[ast]~^ ERROR cannot borrow `e.x` as immutable because `e` is also borrowed as mutable
-                //[mir]~^^ ERROR cannot borrow `e.x` as immutable because `e` is also borrowed as mutable (Ast)
-                //[mir]~| ERROR cannot borrow `e.x` as immutable because it is also borrowed as mutable (Mir)
+                //[mir]~^^ ERROR cannot borrow `e.x` as immutable because it is also borrowed as mutable
                 println!("e.bx: {:?}", bx),
         }
     }
@@ -228,16 +208,14 @@ fn main() {
         match s {
             S  { y: (ref y0, _), .. } =>
                 //[ast]~^ ERROR cannot borrow `s.y.0` as immutable because `s` is also borrowed as mutable
-                //[mir]~^^ ERROR cannot borrow `s.y.0` as immutable because `s` is also borrowed as mutable (Ast)
-                //[mir]~| ERROR cannot borrow `s.y.0` as immutable because it is also borrowed as mutable (Mir)
+                //[mir]~^^ ERROR cannot borrow `s.y.0` as immutable because it is also borrowed as mutable
                 println!("y0: {:?}", y0),
             _ => panic!("other case"),
         }
         match s {
             S  { x: F { y: ref x0, .. }, .. } =>
                 //[ast]~^ ERROR cannot borrow `s.x.y` as immutable because `s` is also borrowed as mutable
-                //[mir]~^^ ERROR cannot borrow `s.x.y` as immutable because `s` is also borrowed as mutable (Ast)
-                //[mir]~| ERROR cannot borrow `s.x.y` as immutable because it is also borrowed as mutable (Mir)
+                //[mir]~^^ ERROR cannot borrow `s.x.y` as immutable because it is also borrowed as mutable
                 println!("x0: {:?}", x0),
             _ => panic!("other case"),
         }
@@ -252,7 +230,7 @@ fn main() {
         fn bump<'a>(mut block: &mut Block<'a>) {
             let x = &mut block;
             let p: &'a u8 = &*block.current;
-            //[mir]~^ ERROR cannot borrow `*block.current` as immutable because it is also borrowed as mutable (Mir)
+            //[mir]~^ ERROR cannot borrow `*block.current` as immutable because it is also borrowed as mutable
             // No errors in AST because of issue rust#38899
         }
     }
@@ -266,7 +244,7 @@ fn main() {
         unsafe fn bump2(mut block: *mut Block2) {
             let x = &mut block;
             let p : *const u8 = &*(*block).current;
-            //[mir]~^ ERROR cannot borrow `*block.current` as immutable because it is also borrowed as mutable (Mir)
+            //[mir]~^ ERROR cannot borrow `*block.current` as immutable because it is also borrowed as mutable
             // No errors in AST because of issue rust#38899
         }
     }
@@ -277,9 +255,8 @@ fn main() {
         let _v = &mut v;
         v[0].y;
         //[ast]~^ ERROR cannot use `v[..].y` because it was mutably borrowed
-        //[mir]~^^ ERROR cannot use `v[..].y` because it was mutably borrowed (Ast)
-        //[mir]~| ERROR cannot use `v[..].y` because it was mutably borrowed (Mir)
-        //[mir]~| ERROR cannot use `*v` because it was mutably borrowed (Mir)
+        //[mir]~^^ ERROR cannot use `v[..].y` because it was mutably borrowed
+        //[mir]~| ERROR cannot use `*v` because it was mutably borrowed
     }
     // Field of constant index
     {
@@ -288,7 +265,7 @@ fn main() {
         let _v = &mut v;
         match v {
             &[_, F {x: ref xf, ..}] => println!("{}", xf),
-            //[mir]~^ ERROR cannot borrow `v[..].x` as immutable because it is also borrowed as mutable (Mir)
+            //[mir]~^ ERROR cannot borrow `v[..].x` as immutable because it is also borrowed as mutable
             // No errors in AST
             _ => panic!("other case")
         }
@@ -299,8 +276,7 @@ fn main() {
         || {
             let y = &mut x;
             &mut x; //[ast]~ ERROR cannot borrow `**x` as mutable more than once at a time
-                    //[mir]~^ ERROR cannot borrow `**x` as mutable more than once at a time (Ast)
-                    //[mir]~| ERROR cannot borrow `x` as mutable more than once at a time (Mir)
+                    //[mir]~^ ERROR cannot borrow `x` as mutable more than once at a time
             *y = 1;
         };
     }
@@ -311,8 +287,7 @@ fn main() {
                || {
                 let y = &mut x;
                 &mut x; //[ast]~ ERROR cannot borrow `**x` as mutable more than once at a time
-                        //[mir]~^ ERROR cannot borrow `**x` as mutable more than once at a time (Ast)
-                        //[mir]~| ERROR cannot borrow `x` as mutable more than once at a time (Mir)
+                        //[mir]~^ ERROR cannot borrow `x` as mutable more than once at a time
                 *y = 1;
                 }
            };
@@ -322,8 +297,7 @@ fn main() {
             let c = || {
                 drop(x);
                 drop(x); //[ast]~ ERROR use of moved value: `x`
-                         //[mir]~^ ERROR use of moved value: `x` (Ast)
-                         //[mir]~| ERROR use of moved value: `x` (Mir)
+                         //[mir]~^ ERROR use of moved value: `x`
             };
             c();
         }

--- a/src/test/compile-fail/borrowck/borrowck-drop-from-guard.rs
+++ b/src/test/compile-fail/borrowck/borrowck-drop-from-guard.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 
-//compile-flags: -Z emit-end-regions -Z borrowck-mir
+//compile-flags: -Z borrowck=mir
 
 fn foo(_:String) {}
 
@@ -19,6 +19,6 @@ fn main()
     match Some(42) {
         Some(_) if { drop(my_str); false } => {}
         Some(_) => {}
-        None => { foo(my_str); } //~ ERROR (Mir) [E0382]
+        None => { foo(my_str); } //~ ERROR [E0382]
     }
 }

--- a/src/test/compile-fail/borrowck/borrowck-fn-in-const-a.rs
+++ b/src/test/compile-fail/borrowck/borrowck-fn-in-const-a.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 // Check that we check fns appearing in constant declarations.
 // Issue #22382.
@@ -17,8 +17,7 @@
 const MOVE: fn(&String) -> String = {
     fn broken(x: &String) -> String {
         return *x //[ast]~ ERROR cannot move out of borrowed content [E0507]
-                  //[mir]~^ ERROR (Ast) [E0507]
-                  //[mir]~| ERROR (Mir) [E0507]
+                  //[mir]~^ ERROR [E0507]
     }
     broken
 };

--- a/src/test/compile-fail/borrowck/borrowck-imm-ref-to-mut-rec-field-issue-3162-c.rs
+++ b/src/test/compile-fail/borrowck/borrowck-imm-ref-to-mut-rec-field-issue-3162-c.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 fn main() {
     let mut _a = 3;
@@ -17,7 +17,6 @@ fn main() {
     {
         let _c = &*_b;
         _a = 4; //[ast]~ ERROR cannot assign to `_a`
-                //[mir]~^ ERROR cannot assign to `_a` because it is borrowed (Ast)
-                //[mir]~| ERROR cannot assign to `_a` because it is borrowed (Mir)
+                //[mir]~^ ERROR cannot assign to `_a` because it is borrowed
     }
 }

--- a/src/test/compile-fail/borrowck/borrowck-init-in-fru.rs
+++ b/src/test/compile-fail/borrowck/borrowck-init-in-fru.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 #[derive(Clone)]
 struct point {
@@ -21,7 +21,6 @@ fn main() {
     let mut origin: point;
     origin = point {x: 10,.. origin};
     //[ast]~^ ERROR use of possibly uninitialized variable: `origin.y` [E0381]
-    //[mir]~^^ ERROR (Ast) [E0381]
-    //[mir]~|  ERROR (Mir) [E0381]
+    //[mir]~^^ ERROR [E0381]
     origin.clone();
 }

--- a/src/test/compile-fail/borrowck/borrowck-lend-flow-match.rs
+++ b/src/test/compile-fail/borrowck/borrowck-lend-flow-match.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 #![allow(unused_variables)]
 #![allow(unused_assignments)]
@@ -26,8 +26,7 @@ fn separate_arms() {
         }
         Some(ref __isize) => {
             x = Some(1); //[ast]~ ERROR cannot assign
-                         //[mir]~^ ERROR cannot assign to `x` because it is borrowed (Ast)
-                         //[mir]~| ERROR cannot assign to `x` because it is borrowed (Mir)
+                         //[mir]~^ ERROR cannot assign to `x` because it is borrowed
         }
     }
     x.clone(); // just to prevent liveness warnings

--- a/src/test/compile-fail/borrowck/borrowck-local-borrow-outlives-fn.rs
+++ b/src/test/compile-fail/borrowck/borrowck-local-borrow-outlives-fn.rs
@@ -9,12 +9,11 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 fn cplusplus_mode(x: isize) -> &'static isize {
     &x //[ast]~ ERROR `x` does not live long enough
-       //[mir]~^ ERROR `x` does not live long enough (Ast)
-       //[mir]~| ERROR borrowed value does not live long enough (Mir)
+       //[mir]~^ ERROR borrowed value does not live long enough
 }
 
 fn main() {}

--- a/src/test/compile-fail/borrowck/borrowck-match-already-borrowed.rs
+++ b/src/test/compile-fail/borrowck/borrowck-match-already-borrowed.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 enum Foo {
     A(i32),
@@ -20,11 +20,10 @@ fn match_enum() {
     let mut foo = Foo::B;
     let p = &mut foo;
     let _ = match foo {
-        Foo::B => 1, //[mir]~ ERROR (Mir) [E0503]
+        Foo::B => 1, //[mir]~ ERROR [E0503]
         _ => 2,
         Foo::A(x) => x //[ast]~ ERROR [E0503]
-                       //[mir]~^ ERROR (Ast) [E0503]
-                       //[mir]~| ERROR (Mir) [E0503]
+                       //[mir]~^ ERROR [E0503]
     };
 }
 
@@ -33,11 +32,9 @@ fn main() {
     let mut x = 1;
     let _x = &mut x;
     let _ = match x {
-        x => x + 1, //[ast]~ ERROR E0503
-                    //[mir]~^ ERROR (Mir) [E0503]
-                    //[mir]~| ERROR (Ast) [E0503]
+        x => x + 1, //[ast]~ ERROR [E0503]
+                    //[mir]~^ ERROR [E0503]
         y => y + 2, //[ast]~ ERROR [E0503]
-                    //[mir]~^ ERROR (Mir) [E0503]
-                    //[mir]~| ERROR (Ast) [E0503]
+                    //[mir]~^ ERROR [E0503]
     };
 }

--- a/src/test/compile-fail/borrowck/borrowck-match-binding-is-assignment.rs
+++ b/src/test/compile-fail/borrowck/borrowck-match-binding-is-assignment.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Zemit-end-regions -Zborrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 // Test that immutable pattern bindings cannot be reassigned.
 
@@ -27,40 +27,35 @@ pub fn main() {
     match 1 {
         x => {
             x += 1; //[ast]~ ERROR cannot assign twice to immutable variable `x`
-                    //[mir]~^ ERROR (Mir) [E0384]
-                    //[mir]~| ERROR (Ast) [E0384]
+                    //[mir]~^ ERROR [E0384]
         }
     }
 
     match E::Foo(1) {
         E::Foo(x) => {
             x += 1; //[ast]~ ERROR cannot assign twice to immutable variable `x`
-                    //[mir]~^ ERROR (Mir) [E0384]
-                    //[mir]~| ERROR (Ast) [E0384]
+                    //[mir]~^ ERROR [E0384]
         }
     }
 
     match (S { bar: 1 }) {
         S { bar: x } => {
             x += 1; //[ast]~ ERROR cannot assign twice to immutable variable `x`
-                    //[mir]~^ ERROR (Mir) [E0384]
-                    //[mir]~| ERROR (Ast) [E0384]
+                    //[mir]~^ ERROR [E0384]
         }
     }
 
     match (1,) {
         (x,) => {
             x += 1; //[ast]~ ERROR cannot assign twice to immutable variable `x`
-                    //[mir]~^ ERROR (Mir) [E0384]
-                    //[mir]~| ERROR (Ast) [E0384]
+                    //[mir]~^ ERROR [E0384]
         }
     }
 
     match [1,2,3] {
         [x,_,_] => {
             x += 1; //[ast]~ ERROR cannot assign twice to immutable variable `x`
-                    //[mir]~^ ERROR (Mir) [E0384]
-                    //[mir]~| ERROR (Ast) [E0384]
+                    //[mir]~^ ERROR [E0384]
         }
     }
 }

--- a/src/test/compile-fail/borrowck/borrowck-move-in-irrefut-pat.rs
+++ b/src/test/compile-fail/borrowck/borrowck-move-in-irrefut-pat.rs
@@ -9,27 +9,24 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 fn with<F>(f: F) where F: FnOnce(&String) {}
 
 fn arg_item(&_x: &String) {}
     //[ast]~^ ERROR cannot move out of borrowed content [E0507]
-    //[mir]~^^ ERROR (Ast) [E0507]
-    //[mir]~|  ERROR (Mir) [E0507]
+    //[mir]~^^ ERROR [E0507]
 
 fn arg_closure() {
     with(|&_x| ())
     //[ast]~^ ERROR cannot move out of borrowed content [E0507]
-    //[mir]~^^ ERROR (Ast) [E0507]
-    //[mir]~|  ERROR (Mir) [E0507]
+    //[mir]~^^ ERROR [E0507]
 }
 
 fn let_pat() {
     let &_x = &"hi".to_string();
     //[ast]~^ ERROR cannot move out of borrowed content [E0507]
-    //[mir]~^^ ERROR (Ast) [E0507]
-    //[mir]~|  ERROR (Mir) [E0507]
+    //[mir]~^^ ERROR [E0507]
 }
 
 pub fn main() {}

--- a/src/test/compile-fail/borrowck/borrowck-move-out-of-overloaded-auto-deref.rs
+++ b/src/test/compile-fail/borrowck/borrowck-move-out-of-overloaded-auto-deref.rs
@@ -9,13 +9,12 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 use std::rc::Rc;
 
 pub fn main() {
     let _x = Rc::new(vec![1, 2]).into_iter();
     //[ast]~^ ERROR cannot move out of borrowed content [E0507]
-    //[mir]~^^ ERROR (Ast) [E0507]
-    //[mir]~|  ERROR (Mir) [E0507]
+    //[mir]~^^ ERROR [E0507]
 }

--- a/src/test/compile-fail/borrowck/borrowck-move-out-of-static-item.rs
+++ b/src/test/compile-fail/borrowck/borrowck-move-out-of-static-item.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 // Ensure that moves out of static items is forbidden
 
@@ -26,6 +26,5 @@ fn test(f: Foo) {
 
 fn main() {
     test(BAR); //[ast]~ ERROR cannot move out of static item [E0507]
-               //[mir]~^ ERROR (Ast) [E0507]
-               //[mir]~| ERROR (Mir) [E0507]
+               //[mir]~^ ERROR [E0507]
 }

--- a/src/test/compile-fail/borrowck/borrowck-move-out-of-struct-with-dtor.rs
+++ b/src/test/compile-fail/borrowck/borrowck-move-out-of-struct-with-dtor.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 struct S {f:String}
 impl Drop for S {
@@ -20,22 +20,19 @@ fn move_in_match() {
     match (S {f:"foo".to_string()}) {
         S {f:_s} => {}
         //[ast]~^ ERROR cannot move out of type `S`, which implements the `Drop` trait [E0509]
-        //[mir]~^^ ERROR (Ast) [E0509]
-        //[mir]~|  ERROR (Mir) [E0509]
+        //[mir]~^^ ERROR [E0509]
     }
 }
 
 fn move_in_let() {
     let S {f:_s} = S {f:"foo".to_string()};
     //[ast]~^ ERROR cannot move out of type `S`, which implements the `Drop` trait [E0509]
-    //[mir]~^^ ERROR (Ast) [E0509]
-    //[mir]~|  ERROR (Mir) [E0509]
+    //[mir]~^^ ERROR [E0509]
 }
 
 fn move_in_fn_arg(S {f:_s}: S) {
     //[ast]~^ ERROR cannot move out of type `S`, which implements the `Drop` trait [E0509]
-    //[mir]~^^ ERROR (Ast) [E0509]
-    //[mir]~|  ERROR (Mir) [E0509]
+    //[mir]~^^ ERROR [E0509]
 }
 
 fn main() {}

--- a/src/test/compile-fail/borrowck/borrowck-mut-borrow-linear-errors.rs
+++ b/src/test/compile-fail/borrowck/borrowck-mut-borrow-linear-errors.rs
@@ -13,7 +13,7 @@
 // down to O(n) errors (for n problem lines), instead of O(n^2) errors.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 fn main() {
     let mut x = 1;
@@ -21,18 +21,15 @@ fn main() {
     loop {
         match 1 {
             1 => { addr = &mut x; } //[ast]~ ERROR [E0499]
-            //[mir]~^ ERROR (Ast) [E0499]
-            //[mir]~| ERROR (Mir) [E0499]
+            //[mir]~^ ERROR [E0499]
             2 => { addr = &mut x; } //[ast]~ ERROR [E0499]
-            //[mir]~^ ERROR (Ast) [E0499]
-            //[mir]~| ERROR (Mir) [E0506]
-            //[mir]~| ERROR (Mir) [E0499]
-            //[mir]~| ERROR (Mir) [E0499]
+            //[mir]~^ ERROR [E0506]
+            //[mir]~| ERROR [E0499]
+            //[mir]~| ERROR [E0499]
             _ => { addr = &mut x; } //[ast]~ ERROR [E0499]
-            //[mir]~^ ERROR (Ast) [E0499]
-            //[mir]~| ERROR (Mir) [E0506]
-            //[mir]~| ERROR (Mir) [E0499]
-            //[mir]~| ERROR (Mir) [E0499]
+            //[mir]~^ ERROR [E0506]
+            //[mir]~| ERROR [E0499]
+            //[mir]~| ERROR [E0499]
         }
     }
 }

--- a/src/test/compile-fail/borrowck/borrowck-overloaded-index-and-overloaded-deref.rs
+++ b/src/test/compile-fail/borrowck/borrowck-overloaded-index-and-overloaded-deref.rs
@@ -14,7 +14,7 @@
 // here is rather subtle. Issue #20232.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 use std::ops::{Deref, Index};
 
@@ -43,8 +43,7 @@ fn main() {
     let i = &v[0].f;
     v = MyVec { x: MyPtr { x: Foo { f: 23 } } };
     //[ast]~^ ERROR cannot assign to `v`
-    //[mir]~^^ ERROR cannot assign to `v` because it is borrowed (Ast)
-    //[mir]~| ERROR cannot assign to `v` because it is borrowed (Mir)
+    //[mir]~^^ ERROR cannot assign to `v` because it is borrowed
     read(*i);
 }
 

--- a/src/test/compile-fail/borrowck/borrowck-overloaded-index-ref-index.rs
+++ b/src/test/compile-fail/borrowck/borrowck-overloaded-index-ref-index.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 use std::ops::{Index, IndexMut};
 
@@ -61,17 +61,14 @@ fn main() {
     let rs = &mut s;
     println!("{}", f[&s]);
     //[ast]~^ ERROR cannot borrow `s` as immutable because it is also borrowed as mutable
-    //[mir]~^^ ERROR cannot borrow `s` as immutable because it is also borrowed as mutable (Ast)
-    //[mir]~| ERROR cannot borrow `s` as immutable because it is also borrowed as mutable (Mir)
+    //[mir]~^^ ERROR cannot borrow `s` as immutable because it is also borrowed as mutable
     f[&s] = 10;
     //[ast]~^ ERROR cannot borrow `s` as immutable because it is also borrowed as mutable
-    //[mir]~^^ ERROR cannot borrow `s` as immutable because it is also borrowed as mutable (Ast)
-    //[mir]~| ERROR cannot borrow `s` as immutable because it is also borrowed as mutable (Mir)
+    //[mir]~^^ ERROR cannot borrow `s` as immutable because it is also borrowed as mutable
     let s = Bar {
         x: 1,
     };
     s[2] = 20;
     //[ast]~^ ERROR cannot assign to immutable indexed content
-    //[mir]~^^ ERROR cannot assign to immutable indexed content
     // FIXME Error for MIR
 }

--- a/src/test/compile-fail/borrowck/borrowck-pat-reassign-binding.rs
+++ b/src/test/compile-fail/borrowck/borrowck-pat-reassign-binding.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 fn main() {
     let mut x: Option<isize> = None;
@@ -21,8 +21,7 @@ fn main() {
       Some(ref i) => {
           // But on this branch, `i` is an outstanding borrow
           x = Some(*i+1); //[ast]~ ERROR cannot assign to `x`
-                          //[mir]~^ ERROR cannot assign to `x` because it is borrowed (Ast)
-                          //[mir]~| ERROR cannot assign to `x` because it is borrowed (Mir)
+                          //[mir]~^ ERROR cannot assign to `x` because it is borrowed
       }
     }
     x.clone(); // just to prevent liveness warnings

--- a/src/test/compile-fail/borrowck/borrowck-storage-dead.rs
+++ b/src/test/compile-fail/borrowck/borrowck-storage-dead.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z emit-end-regions -Z borrowck-mir
+// compile-flags: -Z borrowck=compare
 
 fn ok() {
     loop {

--- a/src/test/compile-fail/borrowck/borrowck-struct-update-with-dtor.rs
+++ b/src/test/compile-fail/borrowck/borrowck-struct-update-with-dtor.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 // Issue 4691: Ensure that functional-struct-update can only copy, not
 // move, when the struct implements Drop.
@@ -24,15 +24,13 @@ impl Drop for T { fn drop(&mut self) { } }
 fn f(s0:S) {
     let _s2 = S{a: 2, ..s0};
     //[ast]~^ error: cannot move out of type `S`, which implements the `Drop` trait
-    //[mir]~^^ ERROR (Ast) [E0509]
-    //[mir]~|  ERROR (Mir) [E0509]
+    //[mir]~^^ ERROR [E0509]
 }
 
 fn g(s0:T) {
     let _s2 = T{a: 2, ..s0};
     //[ast]~^ error: cannot move out of type `T`, which implements the `Drop` trait
-    //[mir]~^^ ERROR (Ast) [E0509]
-    //[mir]~|  ERROR (Mir) [E0509]
+    //[mir]~^^ ERROR [E0509]
 }
 
 fn main() { }

--- a/src/test/compile-fail/borrowck/borrowck-thread-local-static-borrow-outlives-fn.rs
+++ b/src/test/compile-fail/borrowck/borrowck-thread-local-static-borrow-outlives-fn.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 #![feature(thread_local)]
 
@@ -19,6 +19,5 @@ static FOO: u8 = 3;
 fn assert_static(_t: &'static u8) {}
 fn main() {
      assert_static(&FOO); //[ast]~ ERROR [E0597]
-                          //[mir]~^ ERROR (Ast) [E0597]
-                          //[mir]~| ERROR (Mir) [E0597]
+                          //[mir]~^ ERROR [E0597]
 }

--- a/src/test/compile-fail/borrowck/borrowck-unary-move.rs
+++ b/src/test/compile-fail/borrowck/borrowck-unary-move.rs
@@ -10,13 +10,12 @@
 
 // ignore-tidy-linelength
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 fn foo(x: Box<isize>) -> isize {
     let y = &*x;
     free(x); //[ast]~ ERROR cannot move out of `x` because it is borrowed
-    //[mir]~^ ERROR cannot move out of `x` because it is borrowed (Ast)
-    //[mir]~| ERROR cannot move out of `x` because it is borrowed (Mir)
+    //[mir]~^ ERROR cannot move out of `x` because it is borrowed
     *y
 }
 

--- a/src/test/compile-fail/borrowck/borrowck-uninit-field-access.rs
+++ b/src/test/compile-fail/borrowck/borrowck-uninit-field-access.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 // Check that do not allow access to fields of uninitialized or moved
 // structs.
@@ -32,18 +32,15 @@ impl Line { fn consume(self) { } }
 fn main() {
     let mut a: Point;
     let _ = a.x + 1; //[ast]~ ERROR use of possibly uninitialized variable: `a.x`
-                     //[mir]~^ ERROR       [E0381]
-                     //[mir]~| ERROR (Mir) [E0381]
+                     //[mir]~^ ERROR [E0381]
 
     let mut line1 = Line::default();
     let _moved = line1.origin;
     let _ = line1.origin.x + 1; //[ast]~ ERROR use of collaterally moved value: `line1.origin.x`
-                                //[mir]~^       [E0382]
-                                //[mir]~| (Mir) [E0382]
+                                //[mir]~^ [E0382]
 
     let mut line2 = Line::default();
     let _moved = (line2.origin, line2.middle);
     line2.consume(); //[ast]~ ERROR use of partially moved value: `line2` [E0382]
-                     //[mir]~^       [E0382]
-                     //[mir]~| (Mir) [E0382]
+                     //[mir]~^ [E0382]
 }

--- a/src/test/compile-fail/borrowck/borrowck-uninit-ref-chain.rs
+++ b/src/test/compile-fail/borrowck/borrowck-uninit-ref-chain.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 struct S<X, Y> {
     x: X,
@@ -19,42 +19,35 @@ struct S<X, Y> {
 fn main() {
     let x: &&Box<i32>;
     let _y = &**x; //[ast]~ ERROR use of possibly uninitialized variable: `**x` [E0381]
-                   //[mir]~^ (Ast) [E0381]
-                   //[mir]~| (Mir) [E0381]
+                   //[mir]~^ [E0381]
 
     let x: &&S<i32, i32>;
     let _y = &**x; //[ast]~ ERROR use of possibly uninitialized variable: `**x` [E0381]
-                   //[mir]~^ (Ast) [E0381]
-                   //[mir]~| (Mir) [E0381]
+                   //[mir]~^ [E0381]
 
     let x: &&i32;
     let _y = &**x; //[ast]~ ERROR use of possibly uninitialized variable: `**x` [E0381]
-                   //[mir]~^ (Ast) [E0381]
-                   //[mir]~| (Mir) [E0381]
+                   //[mir]~^ [E0381]
 
 
     let mut a: S<i32, i32>;
     a.x = 0;
     let _b = &a.x; //[ast]~ ERROR use of possibly uninitialized variable: `a.x` [E0381]
-                   //[mir]~^ ERROR (Ast) [E0381]
                    // (deliberately *not* an error under MIR-borrowck)
 
     let mut a: S<&&i32, &&i32>;
     a.x = &&0;
     let _b = &**a.x; //[ast]~ ERROR use of possibly uninitialized variable: `**a.x` [E0381]
-                     //[mir]~^ ERROR (Ast) [E0381]
                      // (deliberately *not* an error under MIR-borrowck)
 
 
     let mut a: S<i32, i32>;
     a.x = 0;
     let _b = &a.y; //[ast]~ ERROR use of possibly uninitialized variable: `a.y` [E0381]
-                   //[mir]~^ ERROR (Ast) [E0381]
-                   //[mir]~| ERROR (Mir) [E0381]
+                   //[mir]~^ ERROR [E0381]
 
     let mut a: S<&&i32, &&i32>;
     a.x = &&0;
     let _b = &**a.y; //[ast]~ ERROR use of possibly uninitialized variable: `**a.y` [E0381]
-                     //[mir]~^ ERROR (Ast) [E0381]
-                     //[mir]~| ERROR (Mir) [E0381]
+                     //[mir]~^ ERROR [E0381]
 }

--- a/src/test/compile-fail/borrowck/borrowck-union-borrow.rs
+++ b/src/test/compile-fail/borrowck/borrowck-union-borrow.rs
@@ -10,7 +10,7 @@
 
 // ignore-tidy-linelength
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 #[derive(Clone, Copy)]
 union U {
@@ -33,14 +33,12 @@ fn main() {
         {
             let ra = &u.a;
             let rma = &mut u.a; //[ast]~ ERROR cannot borrow `u.a` as mutable because it is also borrowed as immutable
-                                //[mir]~^ ERROR cannot borrow `u.a` as mutable because it is also borrowed as immutable (Ast)
-                                //[mir]~| ERROR cannot borrow `u.a` as mutable because it is also borrowed as immutable (Mir)
+                                //[mir]~^ ERROR cannot borrow `u.a` as mutable because it is also borrowed as immutable
         }
         {
             let ra = &u.a;
             u.a = 1; //[ast]~ ERROR cannot assign to `u.a` because it is borrowed
-                     //[mir]~^ ERROR cannot assign to `u.a` because it is borrowed (Ast)
-                     //[mir]~| ERROR cannot assign to `u.a` because it is borrowed (Mir)
+                     //[mir]~^ ERROR cannot assign to `u.a` because it is borrowed
         }
         // Imm borrow, other field
         {
@@ -54,63 +52,53 @@ fn main() {
         {
             let ra = &u.a;
             let rmb = &mut u.b; //[ast]~ ERROR cannot borrow `u` (via `u.b`) as mutable because `u` is also borrowed as immutable (via `u.a`)
-                                //[mir]~^ ERROR cannot borrow `u` (via `u.b`) as mutable because `u` is also borrowed as immutable (via `u.a`) (Ast)
                                 // FIXME Error for MIR (needs support for union)
         }
         {
             let ra = &u.a;
             u.b = 1; //[ast]~ ERROR cannot assign to `u.b` because it is borrowed
-                     //[mir]~^ ERROR cannot assign to `u.b` because it is borrowed (Ast)
                      // FIXME Error for MIR (needs support for union)
         }
         // Mut borrow, same field
         {
             let rma = &mut u.a;
             let ra = &u.a; //[ast]~ ERROR cannot borrow `u.a` as immutable because it is also borrowed as mutable
-                         //[mir]~^ ERROR cannot borrow `u.a` as immutable because it is also borrowed as mutable (Ast)
-                         //[mir]~| ERROR cannot borrow `u.a` as immutable because it is also borrowed as mutable (Mir)
+                         //[mir]~^ ERROR cannot borrow `u.a` as immutable because it is also borrowed as mutable
         }
         {
             let ra = &mut u.a;
             let a = u.a; //[ast]~ ERROR cannot use `u.a` because it was mutably borrowed
-                         //[mir]~^ ERROR cannot use `u.a` because it was mutably borrowed (Ast)
-                         //[mir]~| ERROR cannot use `u.a` because it was mutably borrowed (Mir)
+                         //[mir]~^ ERROR cannot use `u.a` because it was mutably borrowed
         }
         {
             let rma = &mut u.a;
             let rma2 = &mut u.a; //[ast]~ ERROR cannot borrow `u.a` as mutable more than once at a time
-                                 //[mir]~^ ERROR cannot borrow `u.a` as mutable more than once at a time (Ast)
-                                 //[mir]~| ERROR cannot borrow `u.a` as mutable more than once at a time (Mir)
+                                 //[mir]~^ ERROR cannot borrow `u.a` as mutable more than once at a time
         }
         {
             let rma = &mut u.a;
             u.a = 1; //[ast]~ ERROR cannot assign to `u.a` because it is borrowed
-                     //[mir]~^ ERROR cannot assign to `u.a` because it is borrowed (Ast)
-                     //[mir]~| ERROR cannot assign to `u.a` because it is borrowed (Mir)
+                     //[mir]~^ ERROR cannot assign to `u.a` because it is borrowed
         }
         // Mut borrow, other field
         {
             let rma = &mut u.a;
             let rb = &u.b; //[ast]~ ERROR cannot borrow `u` (via `u.b`) as immutable because `u` is also borrowed as mutable (via `u.a`)
-                           //[mir]~^ ERROR cannot borrow `u` (via `u.b`) as immutable because `u` is also borrowed as mutable (via `u.a`) (Ast)
                            // FIXME Error for MIR (needs support for union)
         }
         {
             let ra = &mut u.a;
             let b = u.b; //[ast]~ ERROR cannot use `u.b` because it was mutably borrowed
-                         //[mir]~^ ERROR cannot use `u.b` because it was mutably borrowed (Ast)
                          // FIXME Error for MIR (needs support for union)
         }
         {
             let rma = &mut u.a;
             let rmb2 = &mut u.b; //[ast]~ ERROR cannot borrow `u` (via `u.b`) as mutable more than once at a time
-                                 //[mir]~^ ERROR cannot borrow `u` (via `u.b`) as mutable more than once at a time (Ast)
                                  // FIXME Error for MIR (needs support for union)
         }
         {
             let rma = &mut u.a;
             u.b = 1; //[ast]~ ERROR cannot assign to `u.b` because it is borrowed
-                     //[mir]~^ ERROR cannot assign to `u.b` because it is borrowed (Ast)
                      // FIXME Error for MIR (needs support for union)
         }
     }

--- a/src/test/compile-fail/borrowck/borrowck-use-in-index-lvalue.rs
+++ b/src/test/compile-fail/borrowck/borrowck-use-in-index-lvalue.rs
@@ -9,18 +9,16 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 fn test() {
     let w: &mut [isize];
     w[5] = 0; //[ast]~ ERROR use of possibly uninitialized variable: `*w` [E0381]
-              //[mir]~^ ERROR (Ast) [E0381]
-              //[mir]~| ERROR (Mir) [E0381]
+              //[mir]~^ ERROR [E0381]
 
     let mut w: &mut [isize];
     w[5] = 0; //[ast]~ ERROR use of possibly uninitialized variable: `*w` [E0381]
-              //[mir]~^ ERROR (Ast) [E0381]
-              //[mir]~| ERROR (Mir) [E0381]
+              //[mir]~^ ERROR [E0381]
 }
 
 fn main() { test(); }

--- a/src/test/compile-fail/borrowck/borrowck-use-uninitialized-in-cast-trait.rs
+++ b/src/test/compile-fail/borrowck/borrowck-use-uninitialized-in-cast-trait.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 // Variation on `borrowck-use-uninitialized-in-cast` in which we do a
 // trait cast from an uninitialized source. Issue #20791.
@@ -20,6 +20,5 @@ impl Foo for i32 { }
 fn main() {
     let x: &i32;
     let y = x as *const Foo; //[ast]~ ERROR use of possibly uninitialized variable: `*x`
-                             //[mir]~^ ERROR (Ast) [E0381]
-                             //[mir]~| ERROR (Mir) [E0381]
+                             //[mir]~^ ERROR [E0381]
 }

--- a/src/test/compile-fail/borrowck/borrowck-use-uninitialized-in-cast.rs
+++ b/src/test/compile-fail/borrowck/borrowck-use-uninitialized-in-cast.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 // Check that we detect unused values that are cast to other things.
 // The problem was specified to casting to `*`, as creating unsafe
@@ -18,6 +18,5 @@
 fn main() {
     let x: &i32;
     let y = x as *const i32; //[ast]~ ERROR use of possibly uninitialized variable: `*x` [E0381]
-                             //[mir]~^ ERROR (Ast) [E0381]
-                             //[mir]~| ERROR (Mir) [E0381]
+                             //[mir]~^ ERROR [E0381]
 }

--- a/src/test/compile-fail/borrowck/borrowck-vec-pattern-move-tail.rs
+++ b/src/test/compile-fail/borrowck/borrowck-vec-pattern-move-tail.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+// revisions: ast cmp
+//[cmp]compile-flags: -Z borrowck=compare
 
 #![feature(slice_patterns)]
 
@@ -21,7 +21,7 @@ fn main() {
     };
     println!("t[0]: {}", t[0]);
     a[2] = 0; //[ast]~ ERROR cannot assign to `a[..]` because it is borrowed
-              //[mir]~^ ERROR cannot assign to `a[..]` because it is borrowed (Ast)
+              //[cmp]~^ ERROR cannot assign to `a[..]` because it is borrowed (Ast)
               // FIXME Error for MIR (error missed)
     println!("t[0]: {}", t[0]);
     t[0];

--- a/src/test/compile-fail/borrowck/move-in-static-initializer-issue-38520.rs
+++ b/src/test/compile-fail/borrowck/move-in-static-initializer-issue-38520.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 // Regression test for #38520. Check that moves of `Foo` are not
 // permitted as `Foo` is not copy (even in a static/const
@@ -25,11 +25,9 @@ const fn get(x: Foo) -> usize {
 
 const X: Foo = Foo(22);
 static Y: usize = get(*&X); //[ast]~ ERROR E0507
-                            //[mir]~^ ERROR (Ast) [E0507]
-                            //[mir]~| ERROR (Mir) [E0507]
+                            //[mir]~^ ERROR [E0507]
 const Z: usize = get(*&X); //[ast]~ ERROR E0507
-                           //[mir]~^ ERROR (Ast) [E0507]
-                           //[mir]~| ERROR (Mir) [E0507]
+                           //[mir]~^ ERROR [E0507]
 
 fn main() {
 }

--- a/src/test/compile-fail/coerce-overloaded-autoderef.rs
+++ b/src/test/compile-fail/coerce-overloaded-autoderef.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 fn borrow_mut<T>(x: &mut T) -> &mut T { x }
 fn borrow<T>(x: &T) -> &T { x }
@@ -21,8 +21,7 @@ fn double_mut_borrow<T>(x: &mut Box<T>) {
     let y = borrow_mut(x);
     let z = borrow_mut(x);
     //[ast]~^ ERROR cannot borrow `*x` as mutable more than once at a time
-    //[mir]~^^ ERROR cannot borrow `*x` as mutable more than once at a time (Ast)
-    //[mir]~| ERROR cannot borrow `*x` as mutable more than once at a time (Mir)
+    //[mir]~^^ ERROR cannot borrow `*x` as mutable more than once at a time
 }
 
 fn double_imm_borrow(x: &mut Box<i32>) {
@@ -30,22 +29,19 @@ fn double_imm_borrow(x: &mut Box<i32>) {
     let z = borrow(x);
     **x += 1;
     //[ast]~^ ERROR cannot assign to `**x` because it is borrowed
-    //[mir]~^^ ERROR cannot assign to `**x` because it is borrowed (Ast)
-    //[mir]~| ERROR cannot assign to `**x` because it is borrowed (Mir)
+    //[mir]~^^ ERROR cannot assign to `**x` because it is borrowed
 }
 
 fn double_mut_borrow2<T>(x: &mut Box<T>) {
     borrow_mut2(x, x);
     //[ast]~^ ERROR cannot borrow `*x` as mutable more than once at a time
-    //[mir]~^^ ERROR cannot borrow `*x` as mutable more than once at a time (Ast)
-    //[mir]~| ERROR cannot borrow `*x` as mutable more than once at a time (Mir)
+    //[mir]~^^ ERROR cannot borrow `*x` as mutable more than once at a time
 }
 
 fn double_borrow2<T>(x: &mut Box<T>) {
     borrow2(x, x);
     //[ast]~^ ERROR cannot borrow `*x` as immutable because it is also borrowed as mutable
-    //[mir]~^^ ERROR cannot borrow `*x` as immutable because it is also borrowed as mutable (Ast)
-    //[mir]~| ERROR cannot borrow `*x` as immutable because it is also borrowed as mutable (Mir)
+    //[mir]~^^ ERROR cannot borrow `*x` as immutable because it is also borrowed as mutable
 }
 
 pub fn main() {}

--- a/src/test/compile-fail/hrtb-identity-fn-borrows.rs
+++ b/src/test/compile-fail/hrtb-identity-fn-borrows.rs
@@ -12,7 +12,7 @@
 // of the output to the region of the input.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 trait FnLike<A,R> {
     fn call(&self, arg: A) -> R;
@@ -25,8 +25,7 @@ fn call_repeatedly<F>(f: F)
     let mut x = 3;
     let y = f.call(&x);
     x = 5; //[ast]~ ERROR cannot assign
-           //[mir]~^ ERROR cannot assign to `x` because it is borrowed (Ast)
-           //[mir]~| ERROR cannot assign to `x` because it is borrowed (Mir)
+           //[mir]~^ ERROR cannot assign to `x` because it is borrowed
 
     // Result is not stored: can re-assign `x`
     let mut x = 3;

--- a/src/test/compile-fail/issue-25579.rs
+++ b/src/test/compile-fail/issue-25579.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 enum Sexpression {
     Num(()),
@@ -20,15 +20,13 @@ fn causes_ice(mut l: &mut Sexpression) {
     loop { match l {
         &mut Sexpression::Num(ref mut n) => {},
         &mut Sexpression::Cons(ref mut expr) => { //[ast]~ ERROR [E0499]
-                                                  //[mir]~^ ERROR (Ast) [E0499]
-                                                  //[mir]~| ERROR (Mir) [E0506]
-                                                  //[mir]~| ERROR (Mir) [E0499]
+                                                  //[mir]~^ ERROR [E0506]
+                                                  //[mir]~| ERROR [E0499]
             l = &mut **expr; //[ast]~ ERROR [E0506]
-                             //[mir]~^ ERROR (Ast) [E0506]
-                             //[mir]~| ERROR (Mir) [E0506]
-                             //[mir]~| ERROR (Mir) [E0506]
-                             //[mir]~| ERROR (Mir) [E0499]
-                             //[mir]~| ERROR (Mir) [E0499]
+                             //[mir]~^ ERROR [E0506]
+                             //[mir]~| ERROR [E0506]
+                             //[mir]~| ERROR [E0499]
+                             //[mir]~| ERROR [E0499]
         }
     }}
 }

--- a/src/test/compile-fail/issue-36082.rs
+++ b/src/test/compile-fail/issue-36082.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 use std::cell::RefCell;
 
@@ -23,11 +23,7 @@ fn main() {
     //[ast]~| NOTE temporary value dropped here while still borrowed
     //[ast]~| NOTE temporary value created here
     //[ast]~| NOTE consider using a `let` binding to increase its lifetime
-    //[mir]~^^^^^ ERROR borrowed value does not live long enough (Ast) [E0597]
-    //[mir]~| NOTE temporary value dropped here while still borrowed
-    //[mir]~| NOTE temporary value created here
-    //[mir]~| NOTE consider using a `let` binding to increase its lifetime
-    //[mir]~| ERROR borrowed value does not live long enough (Mir) [E0597]
+    //[mir]~^^^^^ ERROR borrowed value does not live long enough [E0597]
     //[mir]~| NOTE temporary value dropped here while still borrowed
     //[mir]~| NOTE temporary value created here
     //[mir]~| NOTE consider using a `let` binding to increase its lifetime
@@ -35,4 +31,3 @@ fn main() {
 }
 //[ast]~^ NOTE temporary value needs to live until here
 //[mir]~^^ NOTE temporary value needs to live until here
-//[mir]~| NOTE temporary value needs to live until here

--- a/src/test/compile-fail/issue-5500-1.rs
+++ b/src/test/compile-fail/issue-5500-1.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=compare
 
 struct TrieMapIterator<'a> {
     node: &'a usize
@@ -18,7 +18,7 @@ struct TrieMapIterator<'a> {
 fn main() {
     let a = 5;
     let _iter = TrieMapIterator{node: &a};
-    _iter.node = & //[ast]~ ERROR cannot assign to immutable field
+    _iter.node = & //[ast]~ ERROR cannot assign to immutable field `_iter.node`
                    //[mir]~^ ERROR cannot assign to immutable field `_iter.node` (Ast)
                    // FIXME Error for MIR
     panic!()

--- a/src/test/compile-fail/mut-pattern-internal-mutability.rs
+++ b/src/test/compile-fail/mut-pattern-internal-mutability.rs
@@ -9,15 +9,14 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 fn main() {
     let foo = &mut 1;
 
     let &mut x = foo;
     x += 1; //[ast]~ ERROR cannot assign twice to immutable variable
-            //[mir]~^ ERROR cannot assign twice to immutable variable `x` (Ast)
-            //[mir]~| ERROR cannot assign twice to immutable variable `x` (Mir)
+            //[mir]~^ ERROR cannot assign twice to immutable variable `x`
 
     // explicitly mut-ify internals
     let &mut mut x = foo;
@@ -26,6 +25,5 @@ fn main() {
     // check borrowing is detected successfully
     let &mut ref x = foo;
     *foo += 1; //[ast]~ ERROR cannot assign to `*foo` because it is borrowed
-               //[mir]~^ ERROR cannot assign to `*foo` because it is borrowed (Ast)
-               //[mir]~| ERROR cannot assign to `*foo` because it is borrowed (Mir)
+               //[mir]~^ ERROR cannot assign to `*foo` because it is borrowed
 }

--- a/src/test/compile-fail/nll/loan_ends_mid_block_pair.rs
+++ b/src/test/compile-fail/nll/loan_ends_mid_block_pair.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 
-// compile-flags:-Zborrowck-mir -Znll
+// compile-flags:-Zborrowck=compare -Znll
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]

--- a/src/test/compile-fail/nll/loan_ends_mid_block_vec.rs
+++ b/src/test/compile-fail/nll/loan_ends_mid_block_vec.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 
-// compile-flags:-Zborrowck-mir -Znll
+// compile-flags:-Zborrowck=compare -Znll
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]

--- a/src/test/compile-fail/nll/reference-carried-through-struct-field.rs
+++ b/src/test/compile-fail/nll/reference-carried-through-struct-field.rs
@@ -7,8 +7,9 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
 //revisions: ast mir
-//[mir] compile-flags: -Z emit-end-regions -Z borrowck-mir -Z nll
+//[mir] compile-flags: -Z borrowck=mir -Z nll
 
 #![allow(unused_assignments)]
 
@@ -18,9 +19,8 @@ fn foo() {
     let mut x = 22;
     let wrapper = Wrap { w: &mut x };
     x += 1; //[ast]~ ERROR cannot assign to `x` because it is borrowed [E0506]
-    //[mir]~^ ERROR cannot assign to `x` because it is borrowed (Ast) [E0506]
-    //[mir]~^^ ERROR cannot assign to `x` because it is borrowed (Mir) [E0506]
-    //[mir]~^^^ ERROR cannot use `x` because it was mutably borrowed (Mir) [E0503]
+    //[mir]~^ ERROR cannot assign to `x` because it is borrowed [E0506]
+    //[mir]~^^ ERROR cannot use `x` because it was mutably borrowed [E0503]
     *wrapper.w += 1;
 }
 

--- a/src/test/compile-fail/nll/region-ends-after-if-condition.rs
+++ b/src/test/compile-fail/nll/region-ends-after-if-condition.rs
@@ -12,7 +12,7 @@
 // in the type of `p` includes the points after `&v[0]` up to (but not
 // including) the call to `use_x`. The `else` branch is not included.
 
-// compile-flags:-Zborrowck-mir -Znll
+// compile-flags:-Zborrowck=compare -Znll
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]

--- a/src/test/compile-fail/nll/return_from_loop.rs
+++ b/src/test/compile-fail/nll/return_from_loop.rs
@@ -12,7 +12,7 @@
 // in the type of `p` includes the points after `&v[0]` up to (but not
 // including) the call to `use_x`. The `else` branch is not included.
 
-// compile-flags:-Zborrowck-mir -Znll
+// compile-flags:-Zborrowck=compare -Znll
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]

--- a/src/test/compile-fail/regions-pattern-typing-issue-19997.rs
+++ b/src/test/compile-fail/regions-pattern-typing-issue-19997.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 fn main() {
     let a0 = 0;
@@ -18,8 +18,7 @@ fn main() {
     match (&a1,) {
         (&ref b0,) => {
             a1 = &f; //[ast]~ ERROR cannot assign
-                     //[mir]~^ ERROR cannot assign to `a1` because it is borrowed (Ast)
-                     //[mir]~| ERROR cannot assign to `a1` because it is borrowed (Mir)
+                     //[mir]~^ ERROR cannot assign to `a1` because it is borrowed
         }
     }
 }

--- a/src/test/mir-opt/end_region_5.rs
+++ b/src/test/mir-opt/end_region_5.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 // compile-flags: -Z identify_regions -Z span_free_formats -Z emit-end-regions
-// ignore-tidy-linelength
 
 // Unwinding should EndRegion for in-scope borrows: Borrowing via by-ref closure.
 

--- a/src/test/mir-opt/match_false_edges.rs
+++ b/src/test/mir-opt/match_false_edges.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z emit-end-regions -Z borrowck-mir
+// compile-flags: -Z borrowck=mir
 
 fn guard() -> bool {
     false

--- a/src/test/run-fail/borrowck-local-borrow.rs
+++ b/src/test/run-fail/borrowck-local-borrow.rs
@@ -10,7 +10,7 @@
 // error-pattern:panic 1
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 fn main() {
     let x = 2;

--- a/src/test/run-pass/borrowck/borrowck-assignment-to-static-mut.rs
+++ b/src/test/run-pass/borrowck/borrowck-assignment-to-static-mut.rs
@@ -10,9 +10,8 @@
 
 // Test taken from #45641 (https://github.com/rust-lang/rust/issues/45641)
 
-// ignore-tidy-linelength
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 static mut Y: u32 = 0;
 

--- a/src/test/run-pass/borrowck/borrowck-unsafe-static-mutable-borrows.rs
+++ b/src/test/run-pass/borrowck/borrowck-unsafe-static-mutable-borrows.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: ast mir
-//[mir]compile-flags: -Z emit-end-regions -Z borrowck-mir
+//[mir]compile-flags: -Z borrowck=mir
 
 // Test file taken from issue 45129 (https://github.com/rust-lang/rust/issues/45129)
 

--- a/src/test/ui/borrowck/borrowck-closures-two-mut.rs
+++ b/src/test/ui/borrowck/borrowck-closures-two-mut.rs
@@ -12,7 +12,7 @@
 // access to the variable, whether that mutable access be used
 // for direct assignment or for taking mutable ref. Issue #6801.
 
-// compile-flags: -Z emit-end-regions -Z borrowck-mir
+// compile-flags: -Z borrowck=compare
 
 #![feature(box_syntax)]
 

--- a/src/test/ui/borrowck/borrowck-reinit.rs
+++ b/src/test/ui/borrowck/borrowck-reinit.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z borrowck-mir -Z emit-end-regions
+// compile-flags: -Z borrowck=compare
 
 fn main() {
     let mut x = Box::new(0);

--- a/src/test/ui/nll/get_default.rs
+++ b/src/test/ui/nll/get_default.rs
@@ -13,7 +13,7 @@
 // a variety of errors from the older, AST-based machinery (notably
 // borrowck), and then we get the NLL error at the end.
 
-// compile-flags:-Znll -Zborrowck-mir
+// compile-flags:-Znll -Zborrowck=compare
 
 struct Map {
 }


### PR DESCRIPTION
Removes the `-Z borrowck-mir` flag in favour of a `-Z borrowck=mode` flag where mode can be `mir`, `ast`, or `compare`.

* The `ast` mode represents the current default, passing `-Z borrowck=ast` is equivalent to not passing it at all.
* The `compare` mode outputs both the output of the MIR borrow checker and the AST borrow checker, each error with `(Ast)` and `(Mir)` appended. This mode has the same behaviour as `-Z borrowck-mir` had before this commit.
* The `mir` mode only outputs the results of the MIR borrow checker, while suppressing the errors of the ast borrow checker

The PR also updates the tests to use the new flags.

closes  #46097 