### PR TITLE
Fix typo in MIR "cannot move out of borrowed content"

### DIFF
--- a/src/librustc_mir/borrow_check.rs
+++ b/src/librustc_mir/borrow_check.rs
@@ -90,7 +90,7 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(infcx: &InferCtxt<'a, 'gcx, 'tcx>,
                     IllegalMoveOriginKind::Static =>
                         tcx.cannot_move_out_of(span, "static item", origin),
                     IllegalMoveOriginKind::BorrowedContent =>
-                        tcx.cannot_move_out_of(span, "borrowed_content", origin),
+                        tcx.cannot_move_out_of(span, "borrowed content", origin),
                     IllegalMoveOriginKind::InteriorOfTypeWithDestructor { container_ty: ty } =>
                         tcx.cannot_move_out_of_interior_of_drop(span, ty, origin),
                     IllegalMoveOriginKind::InteriorOfSliceOrArray { ty, is_index } =>


### PR DESCRIPTION
I believe this all we need to change (#46018). Anyway, do let me know if there is anything else that needs to changed as well!