### PR TITLE
Fix a typo in ToSocketAddrs documentation

### DIFF
--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -759,7 +759,7 @@ impl hash::Hash for SocketAddrV6 {
 /// ```
 ///
 /// [`TcpStream::connect`] is an example of an function that utilizes
-/// `ToSocketsAddr` as a trait bound on its parameter in order to accept
+/// `ToSocketAddrs` as a trait bound on its parameter in order to accept
 /// different types:
 ///
 /// ```no_run


### PR DESCRIPTION
Fix a typo in `ToSocketAddrs` documentation: s/ToSocketsAddr/ToSocketAddrs