### PR TITLE
Revert servo to upstream in cargotest

### DIFF
--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -60,8 +60,8 @@ const TEST_REPOS: &'static [Test] = &[
     },
     Test {
         name: "servo",
-        repo: "https://github.com/eddyb/servo",
-        sha: "6031de9a397e2feba4ff98725991825f62b68518",
+        repo: "https://github.com/servo/servo",
+        sha: "17e97b9320fdb7cdb33bbc5f4d0fde0653bbf2e4",
         lock: None,
         // Only test Stylo a.k.a. Quantum CSS, the parts of Servo going into Firefox.
         // This takes much less time to build than all of Servo and supports stable Rust.


### PR DESCRIPTION
This is a follow-up to https://github.com/rust-lang/rust/pull/45225#issuecomment-345503017 now that upstream has adjusted: https://github.com/servo/servo/pull/19316