### PR TITLE
mention nightly in -Z external-macro-backtrace note

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -798,7 +798,8 @@ impl EmitterWriter {
                 level: Level::Note,
                 message: vec![
                     (["this error originates in a macro outside of the current crate",
-                      "(run with -Z external-macro-backtrace for more info)"].join(" "),
+                      "(in Nightly builds, run with -Z external-macro-backtrace for more info)"]
+                      .join(" "),
                      Style::NoStyle),
                 ],
                 span: MultiSpan::new(),

--- a/src/test/ui-fulldeps/issue-44953/issue-44953.stderr
+++ b/src/test/ui-fulldeps/issue-44953/issue-44953.stderr
@@ -13,7 +13,7 @@ error: use of unstable library feature 'rustc_private': this crate is being load
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(rustc_private)] to the crate attributes to enable
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/codemap_tests/bad-format-args.stderr
+++ b/src/test/ui/codemap_tests/bad-format-args.stderr
@@ -4,7 +4,7 @@ error: requires at least a format string argument
 12 |     format!();
    |     ^^^^^^^^^^
    |
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: expected token: `,`
   --> $DIR/bad-format-args.rs:13:5
@@ -12,7 +12,7 @@ error: expected token: `,`
 13 |     format!("" 1);
    |     ^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: expected token: `,`
   --> $DIR/bad-format-args.rs:14:5
@@ -20,7 +20,7 @@ error: expected token: `,`
 14 |     format!("", 1 1);
    |     ^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/codemap_tests/issue-28308.stderr
+++ b/src/test/ui/codemap_tests/issue-28308.stderr
@@ -4,7 +4,7 @@ error[E0600]: cannot apply unary operator `!` to type `&'static str`
 12 |     assert!("foo");
    |     ^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/cross-crate-macro-backtrace/main.stderr
+++ b/src/test/ui/cross-crate-macro-backtrace/main.stderr
@@ -4,7 +4,7 @@ error: 1 positional argument in format string, but no arguments were given
 18 |     myprintln!("{}");
    |     ^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/fmt/format-string-error.stderr
+++ b/src/test/ui/fmt/format-string-error.stderr
@@ -5,7 +5,7 @@ error: invalid format string: expected `'}'` but string was terminated
    |     ^^^^^^^^^^^^^^
    |
    = note: if you intended to print `{`, you can escape it using `{{`
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: invalid format string: unmatched `}` found
   --> $DIR/format-string-error.rs:14:5
@@ -14,7 +14,7 @@ error: invalid format string: unmatched `}` found
    |     ^^^^^^^^^^^^^^
    |
    = note: if you intended to print `}`, you can escape it using `}}`
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/lifetimes/borrowck-let-suggestion.stderr
+++ b/src/test/ui/lifetimes/borrowck-let-suggestion.stderr
@@ -9,7 +9,7 @@ error[E0597]: borrowed value does not live long enough
    | - temporary value needs to live until here
    |
    = note: consider using a `let` binding to increase its lifetime
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/format-foreign.stderr
+++ b/src/test/ui/macros/format-foreign.stderr
@@ -11,7 +11,7 @@ error: multiple unused formatting arguments
    = help: `%.*3$s` should be written as `{:.2$}`
    = help: `%s` should be written as `{}`
    = note: printf formatting not supported; see the documentation for `std::fmt`
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: argument never used
   --> $DIR/format-foreign.rs:13:29

--- a/src/test/ui/macros/format-unused-lables.stderr
+++ b/src/test/ui/macros/format-unused-lables.stderr
@@ -8,7 +8,7 @@ error: multiple unused formatting arguments
    |                      |    unused
    |                      unused
    |
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: multiple unused formatting arguments
   --> $DIR/format-unused-lables.rs:14:5
@@ -23,7 +23,7 @@ error: multiple unused formatting arguments
 18 | |     );
    | |______^
    |
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: named argument never used
   --> $DIR/format-unused-lables.rs:20:35
@@ -47,7 +47,7 @@ error: multiple unused formatting arguments
    |
    = help: `$STUFF` should be written as `{STUFF}`
    = note: shell formatting not supported; see the documentation for `std::fmt`
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/reachable/expr_again.stderr
+++ b/src/test/ui/reachable/expr_again.stderr
@@ -9,7 +9,7 @@ note: lint level defined here
    |
 13 | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_block.stderr
+++ b/src/test/ui/reachable/expr_block.stderr
@@ -16,7 +16,7 @@ error: unreachable statement
 36 |         println!("foo");
    |         ^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/reachable/expr_if.stderr
+++ b/src/test/ui/reachable/expr_if.stderr
@@ -9,7 +9,7 @@ note: lint level defined here
    |
 14 | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_loop.stderr
+++ b/src/test/ui/reachable/expr_loop.stderr
@@ -9,7 +9,7 @@ note: lint level defined here
    |
 14 | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: unreachable statement
   --> $DIR/expr_loop.rs:31:5
@@ -17,7 +17,7 @@ error: unreachable statement
 31 |     println!("I am dead.");
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: unreachable statement
   --> $DIR/expr_loop.rs:41:5
@@ -25,7 +25,7 @@ error: unreachable statement
 41 |     println!("I am dead.");
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/reachable/expr_match.stderr
+++ b/src/test/ui/reachable/expr_match.stderr
@@ -16,7 +16,7 @@ error: unreachable statement
 25 |     println!("I am dead");
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: unreachable statement
   --> $DIR/expr_match.rs:35:5
@@ -24,7 +24,7 @@ error: unreachable statement
 35 |     println!("I am dead");
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/reachable/expr_while.stderr
+++ b/src/test/ui/reachable/expr_while.stderr
@@ -9,7 +9,7 @@ note: lint level defined here
    |
 14 | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: unreachable statement
   --> $DIR/expr_while.rs:33:9
@@ -17,7 +17,7 @@ error: unreachable statement
 33 |         println!("I am dead.");
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: unreachable statement
   --> $DIR/expr_while.rs:35:5
@@ -25,7 +25,7 @@ error: unreachable statement
 35 |     println!("I am, too.");
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/span/coerce-suggestions.stderr
+++ b/src/test/ui/span/coerce-suggestions.stderr
@@ -53,7 +53,7 @@ error[E0308]: mismatched types
    = note: expected type `&mut std::string::String`
               found type `std::string::String`
    = help: try with `&mut format!("foo")`
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/span/issue-33884.stderr
+++ b/src/test/ui/span/issue-33884.stderr
@@ -6,7 +6,7 @@ error[E0308]: mismatched types
    |
    = note: expected type `std::fmt::Arguments<'_>`
               found type `std::string::String`
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/issue-40157.stderr
+++ b/src/test/ui/span/issue-40157.stderr
@@ -8,7 +8,7 @@ error[E0597]: `foo` does not live long enough
    |      |                                              borrow occurs here
    |      borrowed value needs to live until here
    |
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/slice-borrow.stderr
+++ b/src/test/ui/span/slice-borrow.stderr
@@ -9,7 +9,7 @@ error[E0597]: borrowed value does not live long enough
 19 | }
    | - temporary value needs to live until here
    |
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-check/cannot_infer_local_or_vec.stderr
+++ b/src/test/ui/type-check/cannot_infer_local_or_vec.stderr
@@ -6,7 +6,7 @@ error[E0282]: type annotations needed
    |         |
    |         consider giving `x` a type
    |
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-check/cannot_infer_local_or_vec_in_tuples.stderr
+++ b/src/test/ui/type-check/cannot_infer_local_or_vec_in_tuples.stderr
@@ -6,7 +6,7 @@ error[E0282]: type annotations needed
    |         |
    |         consider giving the pattern a type
    |
-   = note: this error originates in a macro outside of the current crate (run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fix #46167 by mentioning that you need nightly in the message that tells you to pass `-Z external-macro-backtrace`.

Rationale:

1. The reason for having this message is to increase discoverability of the functionality. If the message is only shown on nightly it's less disoverable.
2. The same approach is taken if you call a const fn in const context without its feature gate (previously, if you called it without `#![feature(const_fn)]`).

cc @kennytm