### PR TITLE
Use .expect rather than explicit panics in library code

### DIFF
--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -418,10 +418,8 @@ impl<T, A: Alloc> RawVec<T, A> {
 
             // Nothing we can really do about these checks :(
             let new_cap = used_cap.checked_add(needed_extra_cap).expect("capacity overflow");
-            let new_layout = match Layout::array::<T>(new_cap) {
-                Some(layout) => layout,
-                None => panic!("capacity overflow"),
-            };
+            let new_layout = Layout::array::<T>(new_cap)
+                .expect("capacity overflow");
             alloc_guard(new_layout.size());
             let res = match self.current_layout() {
                 Some(layout) => {
@@ -519,10 +517,8 @@ impl<T, A: Alloc> RawVec<T, A> {
 
             let new_cap = self.amortized_new_size(used_cap, needed_extra_cap);
 
-            let new_layout = match Layout::array::<T>(new_cap) {
-                Some(layout) => layout,
-                None => panic!("capacity overflow"),
-            };
+            let new_layout = Layout::array::<T>(new_cap)
+                .expect("capacity overflow");
             // FIXME: may crash and burn on over-reserve
             alloc_guard(new_layout.size());
             let res = match self.current_layout() {

--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -1081,10 +1081,8 @@ impl String {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn remove(&mut self, idx: usize) -> char {
-        let ch = match self[idx..].chars().next() {
-            Some(ch) => ch,
-            None => panic!("cannot remove a char from the end of a string"),
-        };
+        let ch = self[idx..].chars().next()
+            .expect("cannot remove a char from the end of a string");
 
         let next = idx + ch.len_utf8();
         let len = self.len();

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -330,10 +330,7 @@ impl<T> Option<T> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn unwrap(self) -> T {
-        match self {
-            Some(val) => val,
-            None => panic!("called `Option::unwrap()` on a `None` value"),
-        }
+        self.expect("called `Option::unwrap()` on a `None` value")
     }
 
     /// Returns the contained value or a default.


### PR DESCRIPTION
This reduces the size of code that can get inlined into user code.
