### PR TITLE
Lint for the reserved ABI of bool

### DIFF
--- a/src/librustc_binaryen/lib.rs
+++ b/src/librustc_binaryen/lib.rs
@@ -15,6 +15,12 @@
 //! only supports one operation, creating a module from LLVM's assembly format
 //! and then serializing that module to a wasm module.
 
+#![deny(warnings)]
+
+// We are the compiler, so we can use anything for FFI.
+// Don't do this at home :)
+#![allow(improper_ctypes)]
+
 extern crate libc;
 
 use std::slice;

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -561,8 +561,13 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                            stable ABI")
             }
 
+            ty::TyBool => {
+                FfiUnsafe("found Rust type `bool` in foreign module, \
+                           while its ABI is reserved for future change")
+            }
+
             // Primitive types with a stable representation.
-            ty::TyBool | ty::TyInt(..) | ty::TyUint(..) | ty::TyFloat(..) | ty::TyNever => FfiSafe,
+            ty::TyInt(..) | ty::TyUint(..) | ty::TyFloat(..) | ty::TyNever => FfiSafe,
 
             ty::TySlice(_) => {
                 FfiUnsafe("found Rust slice type in foreign module, \

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -13,6 +13,10 @@
 #![allow(non_snake_case)]
 #![allow(dead_code)]
 
+// We are the compiler, so we can use anything for FFI.
+// Don't do this at home :)
+#![allow(improper_ctypes)]
+
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/")]

--- a/src/test/compile-fail/bool-abi-reserved.rs
+++ b/src/test/compile-fail/bool-abi-reserved.rs
@@ -1,0 +1,18 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(improper_ctypes)]
+#![allow(dead_code)]
+
+extern {
+   fn zf(x: bool); //~ ERROR found Rust type `bool` in foreign module
+}
+
+pub fn main() { }

--- a/src/test/ui/lint/unreachable_pub-pub_crate.stderr
+++ b/src/test/ui/lint/unreachable_pub-pub_crate.stderr
@@ -122,6 +122,14 @@ warning: unreachable `pub` item
    |
    = help: or consider exporting it for use by other crates
 
+warning: found Rust type `bool` in foreign module, while its ABI is reserved for future change
+  --> $DIR/unreachable_pub-pub_crate.rs:52:30
+   |
+52 |         pub fn catalyze() -> bool;
+   |                              ^^^^
+   |
+   = note: #[warn(improper_ctypes)] on by default
+
 warning: unreachable `pub` item
   --> $DIR/unreachable_pub-pub_crate.rs:52:9
    |

--- a/src/test/ui/lint/unreachable_pub.stderr
+++ b/src/test/ui/lint/unreachable_pub.stderr
@@ -122,6 +122,14 @@ warning: unreachable `pub` item
    |
    = help: or consider exporting it for use by other crates
 
+warning: found Rust type `bool` in foreign module, while its ABI is reserved for future change
+  --> $DIR/unreachable_pub.rs:47:30
+   |
+47 |         pub fn catalyze() -> bool;
+   |                              ^^^^
+   |
+   = note: #[warn(improper_ctypes)] on by default
+
 warning: unreachable `pub` item
   --> $DIR/unreachable_pub.rs:47:9
    |


### PR DESCRIPTION
The ABI of bool is reserved, see these links:

* https://github.com/rust-lang/rfcs/pull/954#issuecomment-83811006
* https://github.com/rust-lang/rust/pull/46156#issuecomment-346030957
* https://github.com/rust-lang/rfcs/issues/992

Currently the improper_ctypes lint is inconsistent
with that position by treating bools as if they had
a specified ABI.

To fix this inconsistency, this changes treatment of
bools by the lint.

This might break some code, so possibly it has to
be phased in slowly...