### PR TITLE
Add missing Debug impls to std_unicode

### DIFF
--- a/src/libstd_unicode/char.rs
+++ b/src/libstd_unicode/char.rs
@@ -57,6 +57,7 @@ pub use tables::{UnicodeVersion, UNICODE_VERSION};
 /// [`to_lowercase`]: ../../std/primitive.char.html#method.to_lowercase
 /// [`char`]: ../../std/primitive.char.html
 #[stable(feature = "rust1", since = "1.0.0")]
+#[derive(Debug)]
 pub struct ToLowercase(CaseMappingIter);
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -78,6 +79,7 @@ impl FusedIterator for ToLowercase {}
 /// [`to_uppercase`]: ../../std/primitive.char.html#method.to_uppercase
 /// [`char`]: ../../std/primitive.char.html
 #[stable(feature = "rust1", since = "1.0.0")]
+#[derive(Debug)]
 pub struct ToUppercase(CaseMappingIter);
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -91,6 +93,7 @@ impl Iterator for ToUppercase {
 #[unstable(feature = "fused", issue = "35602")]
 impl FusedIterator for ToUppercase {}
 
+#[derive(Debug)]
 enum CaseMappingIter {
     Three(char, char, char),
     Two(char, char),
@@ -1450,7 +1453,7 @@ impl char {
 
 /// An iterator that decodes UTF-16 encoded code points from an iterator of `u16`s.
 #[stable(feature = "decode_utf16", since = "1.9.0")]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DecodeUtf16<I>
     where I: Iterator<Item = u16>
 {

--- a/src/libstd_unicode/lib.rs
+++ b/src/libstd_unicode/lib.rs
@@ -28,6 +28,7 @@
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
        test(no_crate_inject, attr(allow(unused_variables), deny(warnings))))]
 #![deny(warnings)]
+#![deny(missing_debug_implementations)]
 #![no_std]
 
 #![feature(ascii_ctype)]

--- a/src/libstd_unicode/lossy.rs
+++ b/src/libstd_unicode/lossy.rs
@@ -38,6 +38,7 @@ impl Utf8Lossy {
 
 /// Iterator over lossy UTF-8 string
 #[unstable(feature = "str_internals", issue = "0")]
+#[allow(missing_debug_implementations)]
 pub struct Utf8LossyChunksIter<'a> {
     source: &'a [u8],
 }

--- a/src/libstd_unicode/u_str.rs
+++ b/src/libstd_unicode/u_str.rs
@@ -76,6 +76,7 @@ impl UnicodeStr for str {
 
 /// Iterator adaptor for encoding `char`s to UTF-16.
 #[derive(Clone)]
+#[allow(missing_debug_implementations)]
 pub struct Utf16Encoder<I> {
     chars: I,
     extra: u16,


### PR DESCRIPTION
Also adds `#![deny(missing_debug_implementations)]` so they don't get missed again.

cc #31869