### PR TITLE
[stable] Update cargo to fix breakage on macOS High Sierra; Update version to 1.22.1.

### DIFF
--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -24,7 +24,7 @@ use Build;
 use config::Config;
 
 // The version number
-pub const CFG_RELEASE_NUM: &str = "1.22.0";
+pub const CFG_RELEASE_NUM: &str = "1.22.1";
 
 // An optional number to put after the label, e.g. '.2' -> '-beta.2'
 // Be sure to make this starts with a dot to conform to semver pre-release


### PR DESCRIPTION
This backport includes rust-lang/cargo#4739, required for building projects in debug mode with Cargo on macOS High Sierra (see the Cargo PR for details).

