### PR TITLE
Rename C-like enum to Field-less enum

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -1647,8 +1647,8 @@ the size of the provided type. Such an enum can be cast to a value of the same
 type as well. In short, `#[repr(u8)]` makes the enum behave like an integer
 with a constrained set of allowed values.
 
-Only field-less enums can be cast to numerical primitives, so this attribute will
-not apply to structs.
+Only field-less enums can be cast to numerical primitives, so this attribute
+will not apply to structs.
 
 `#[repr(packed)]` reduces padding to make the struct size smaller. The
 representation of enums isn't strictly defined in Rust, and this attribute

--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -1642,7 +1642,7 @@ These attributes do not work on typedefs, since typedefs are just aliases.
 
 Representations like `#[repr(u8)]`, `#[repr(i64)]` are for selecting the
 discriminant size for enums with no data fields on any of the variants, e.g.
-`enum Color {Red, Blue, Green}`), effectively setting the size of the enum to
+`enum Color {Red, Blue, Green}`, effectively setting the size of the enum to
 the size of the provided type. Such an enum can be cast to a value of the same
 type as well. In short, `#[repr(u8)]` makes the enum behave like an integer
 with a constrained set of allowed values.

--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -1641,13 +1641,13 @@ impl Foo {
 These attributes do not work on typedefs, since typedefs are just aliases.
 
 Representations like `#[repr(u8)]`, `#[repr(i64)]` are for selecting the
-discriminant size for C-like enums (when there is no associated data, e.g.
+discriminant size for enums with no data fields on any of the variants, e.g.
 `enum Color {Red, Blue, Green}`), effectively setting the size of the enum to
 the size of the provided type. Such an enum can be cast to a value of the same
 type as well. In short, `#[repr(u8)]` makes the enum behave like an integer
 with a constrained set of allowed values.
 
-Only C-like enums can be cast to numerical primitives, so this attribute will
+Only field-less enums can be cast to numerical primitives, so this attribute will
 not apply to structs.
 
 `#[repr(packed)]` reduces padding to make the struct size smaller. The

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5891,7 +5891,7 @@ impl<'a> Parser<'a> {
         match any_disr {
             Some(disr_span) if !all_nullary =>
                 self.span_err(disr_span,
-                    "discriminator values can only be used with a c-like enum"),
+                    "discriminator values can only be used with a field-less enum"),
             _ => ()
         }
 

--- a/src/test/parse-fail/issue-17383.rs
+++ b/src/test/parse-fail/issue-17383.rs
@@ -12,7 +12,7 @@
 
 enum X {
     A =
-        b'a' //~ ERROR discriminator values can only be used with a c-like enum
+        b'a' //~ ERROR discriminator values can only be used with a field-less enum
     ,
     B(isize)
 }

--- a/src/test/parse-fail/tag-variant-disr-non-nullary.rs
+++ b/src/test/parse-fail/tag-variant-disr-non-nullary.rs
@@ -10,7 +10,7 @@
 
 // compile-flags: -Z parse-only
 
-//error-pattern: discriminator values can only be used with a c-like enum
+//error-pattern: discriminator values can only be used with a field-less enum
 
 enum color {
     red = 0xff0000,


### PR DESCRIPTION
There is no need to reference the C programming language to explain this concept.