### PR TITLE
Adding `eprint*!` to the list of macros in the `format!` family

### DIFF
--- a/src/liballoc/fmt.rs
+++ b/src/liballoc/fmt.rs
@@ -236,6 +236,8 @@
 //! writeln!     // same as write but appends a newline
 //! print!       // the format string is printed to the standard output
 //! println!     // same as print but appends a newline
+//! eprint!      // the format string is printed to the standard error
+//! eprintln!    // same as eprint but appends a newline
 //! format_args! // described below.
 //! ```
 //!
@@ -264,6 +266,11 @@
 //! print!("Hello {}!", "world");
 //! println!("I have a newline {}", "character at the end");
 //! ```
+//! ### `eprint!`
+//!
+//! The [`eprint!`] and [`eprintln!`] macros are identical to
+//! [`print!`] and [`println!`], respectively, except they emit their
+//! output to stderr.
 //!
 //! ### `format_args!`
 //!
@@ -490,7 +497,10 @@
 //! [`writeln!`]: ../../std/macro.writeln.html
 //! [`write_fmt`]: ../../std/io/trait.Write.html#method.write_fmt
 //! [`std::io::Write`]: ../../std/io/trait.Write.html
+//! [`print!`]: ../../std/macro.print.html
 //! [`println!`]: ../../std/macro.println.html
+//! [`eprint!`]: ../../std/macro.eprint.html
+//! [`eprintln!`]: ../../std/macro.eprintln.html
 //! [`write!`]: ../../std/macro.write.html
 //! [`format_args!`]: ../../std/macro.format_args.html
 //! [`fmt::Arguments`]: struct.Arguments.html


### PR DESCRIPTION
The `eprint!` and `eprintln!` macros were added in 7612727. The `std::fmt` documentation does not mention these macros next to `print!` and `println!` in the [Related macros](https://doc.rust-lang.org/std/fmt/#related-macros) section, and I did not find evidence that this omission was deliberate. This PR adds such documentation.

The first modification is to add `eprint!` and `eprintln!` to the list of related macros in the `format!` family. This is how it appears with this change:

![image](https://user-images.githubusercontent.com/933552/33159527-67056caa-cfc8-11e7-8b7d-4224ef2fce4e.png)

The second modification adds a sub-section for `eprint!` and `eprintln!`. Here is how the new section appears:

![image](https://user-images.githubusercontent.com/933552/33159541-97d03bee-cfc8-11e7-8b95-4d3632b5ab7b.png)
