### PR TITLE
DT_RUNPATH is a Linuxism, only use it there.

### DIFF
--- a/src/librustc_trans/back/rpath.rs
+++ b/src/librustc_trans/back/rpath.rs
@@ -41,7 +41,7 @@ pub fn get_rpath_flags(config: &mut RPathConfig) -> Vec<String> {
     flags.extend_from_slice(&rpaths_to_flags(&rpaths));
 
     // Use DT_RUNPATH instead of DT_RPATH if available
-    if config.linker_is_gnu {
+    if config.linker_is_gnu && target.target_os == "linux" {
         flags.push("-Wl,--enable-new-dtags".to_string());
     }
 

--- a/src/librustc_trans/back/rpath.rs
+++ b/src/librustc_trans/back/rpath.rs
@@ -40,9 +40,11 @@ pub fn get_rpath_flags(config: &mut RPathConfig) -> Vec<String> {
     let rpaths = get_rpaths(config, &libs);
     flags.extend_from_slice(&rpaths_to_flags(&rpaths));
 
-    // Use DT_RUNPATH instead of DT_RPATH if available
-    if config.linker_is_gnu && target.target_os == "linux" {
-        flags.push("-Wl,--enable-new-dtags".to_string());
+    if cfg!(target_os = "linux") {
+        // Use DT_RUNPATH instead of DT_RPATH if available
+        if config.linker_is_gnu {
+            flags.push("-Wl,--enable-new-dtags".to_string());
+        }
     }
 
     flags


### PR DESCRIPTION
Other operating systems have working DT_RPATH, but still may
use the gnu linker.