### PR TITLE
Replace most call to grep in run-make by a script that cat the input.

### DIFF
--- a/src/etc/cat-and-grep.sh
+++ b/src/etc/cat-and-grep.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+set -eu
+
+# Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+# Performs `cat` and `grep` simultaneously for `run-make` tests in the Rust CI.
+#
+# This program will read lines from stdin and print them to stdout immediately.
+# At the same time, it will check if the input line contains the substring or
+# regex specified in the command line. If any match is found, the program will
+# set the exit code to 0, otherwise 1.
+#
+# This is written to simplify debugging runmake tests. Since `grep` swallows all
+# output, when a test involving `grep` failed, it is impossible to know the
+# reason just by reading the failure log. While it is possible to `tee` the
+# output into another stream, it becomes pretty annoying to do this for all test
+# cases.
+
+USAGE='
+cat-and-grep.sh [-v] [-e] [-i] s1 s2 s3 ... < input.txt
+
+Prints the stdin, and exits successfully only if all of `sN` can be found in
+some lines of the input.
+
+Options:
+    -v      Invert match, exits successfully only if all of `sN` cannot be found
+    -e      Regex search, search using extended Regex instead of fixed string
+    -i      Case insensitive search.
+'
+
+GREPPER=fgrep
+INVERT=0
+GREPFLAGS='q'
+while getopts ':vieh' OPTION; do
+    case "$OPTION" in
+        v)
+            INVERT=1
+            ERROR_MSG='should not be found'
+            ;;
+        i)
+            GREPFLAGS="i$GREPFLAGS"
+            ;;
+        e)
+            GREPPER=egrep
+            ;;
+        h)
+            echo "$USAGE"
+            exit 2
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+shift $((OPTIND - 1))
+
+LOG=$(mktemp -t cgrep.XXXXXX)
+trap "rm -f $LOG" EXIT
+
+printf "[[[ begin stdout ]]]\n\033[90m"
+tee "$LOG"
+echo >> "$LOG"   # ensure at least 1 line of output, otherwise `grep -v` may unconditionally fail.
+printf "\033[0m\n[[[ end stdout ]]]\n"
+
+HAS_ERROR=0
+for MATCH in "$@"; do
+    if "$GREPPER" "-$GREPFLAGS" -- "$MATCH" "$LOG"; then
+        if [ "$INVERT" = 1 ]; then
+            printf "\033[1;31mError: should not match: %s\033[0m\n" "$MATCH"
+            HAS_ERROR=1
+        fi
+    else
+        if [ "$INVERT" = 0 ]; then
+            printf "\033[1;31mError: cannot match: %s\033[0m\n" "$MATCH"
+            HAS_ERROR=1
+        fi
+    fi
+done
+
+exit "$HAS_ERROR"

--- a/src/test/run-make/atomic-lock-free/Makefile
+++ b/src/test/run-make/atomic-lock-free/Makefile
@@ -7,36 +7,36 @@ all:
 ifeq ($(UNAME),Linux)
 ifeq ($(filter x86,$(LLVM_COMPONENTS)),x86)
 	$(RUSTC) --target=i686-unknown-linux-gnu atomic_lock_free.rs
-	nm "$(TMPDIR)/libatomic_lock_free.rlib" | grep -vq __atomic_fetch_add
+	nm "$(TMPDIR)/libatomic_lock_free.rlib" | $(CGREP) -v __atomic_fetch_add
 	$(RUSTC) --target=x86_64-unknown-linux-gnu atomic_lock_free.rs
-	nm "$(TMPDIR)/libatomic_lock_free.rlib" | grep -vq __atomic_fetch_add
+	nm "$(TMPDIR)/libatomic_lock_free.rlib" | $(CGREP) -v __atomic_fetch_add
 endif
 ifeq ($(filter arm,$(LLVM_COMPONENTS)),arm)
 	$(RUSTC) --target=arm-unknown-linux-gnueabi atomic_lock_free.rs
-	nm "$(TMPDIR)/libatomic_lock_free.rlib" | grep -vq __atomic_fetch_add
+	nm "$(TMPDIR)/libatomic_lock_free.rlib" | $(CGREP) -v __atomic_fetch_add
 	$(RUSTC) --target=arm-unknown-linux-gnueabihf atomic_lock_free.rs
-	nm "$(TMPDIR)/libatomic_lock_free.rlib" | grep -vq __atomic_fetch_add
+	nm "$(TMPDIR)/libatomic_lock_free.rlib" | $(CGREP) -v __atomic_fetch_add
 	$(RUSTC) --target=armv7-unknown-linux-gnueabihf atomic_lock_free.rs
-	nm "$(TMPDIR)/libatomic_lock_free.rlib" | grep -vq __atomic_fetch_add
+	nm "$(TMPDIR)/libatomic_lock_free.rlib" | $(CGREP) -v __atomic_fetch_add
 endif
 ifeq ($(filter aarch64,$(LLVM_COMPONENTS)),aarch64)
 	$(RUSTC) --target=aarch64-unknown-linux-gnu atomic_lock_free.rs
-	nm "$(TMPDIR)/libatomic_lock_free.rlib" | grep -vq __atomic_fetch_add
+	nm "$(TMPDIR)/libatomic_lock_free.rlib" | $(CGREP) -v __atomic_fetch_add
 endif
 ifeq ($(filter mips,$(LLVM_COMPONENTS)),mips)
 	$(RUSTC) --target=mips-unknown-linux-gnu atomic_lock_free.rs
-	nm "$(TMPDIR)/libatomic_lock_free.rlib" | grep -vq __atomic_fetch_add
+	nm "$(TMPDIR)/libatomic_lock_free.rlib" | $(CGREP) -v __atomic_fetch_add
 	$(RUSTC) --target=mipsel-unknown-linux-gnu atomic_lock_free.rs
-	nm "$(TMPDIR)/libatomic_lock_free.rlib" | grep -vq __atomic_fetch_add
+	nm "$(TMPDIR)/libatomic_lock_free.rlib" | $(CGREP) -v __atomic_fetch_add
 endif
 ifeq ($(filter powerpc,$(LLVM_COMPONENTS)),powerpc)
 	$(RUSTC) --target=powerpc-unknown-linux-gnu atomic_lock_free.rs
-	nm "$(TMPDIR)/libatomic_lock_free.rlib" | grep -vq __atomic_fetch_add
+	nm "$(TMPDIR)/libatomic_lock_free.rlib" | $(CGREP) -v __atomic_fetch_add
 	$(RUSTC) --target=powerpc64-unknown-linux-gnu atomic_lock_free.rs
-	nm "$(TMPDIR)/libatomic_lock_free.rlib" | grep -vq __atomic_fetch_add
+	nm "$(TMPDIR)/libatomic_lock_free.rlib" | $(CGREP) -v __atomic_fetch_add
 	$(RUSTC) --target=powerpc64le-unknown-linux-gnu atomic_lock_free.rs
-	nm "$(TMPDIR)/libatomic_lock_free.rlib" | grep -vq __atomic_fetch_add
+	nm "$(TMPDIR)/libatomic_lock_free.rlib" | $(CGREP) -v __atomic_fetch_add
 	$(RUSTC) --target=s390x-unknown-linux-gnu atomic_lock_free.rs
-	nm "$(TMPDIR)/libatomic_lock_free.rlib" | grep -vq __atomic_fetch_add
+	nm "$(TMPDIR)/libatomic_lock_free.rlib" | $(CGREP) -v __atomic_fetch_add
 endif
 endif

--- a/src/test/run-make/cat-and-grep-sanity-check/Makefile
+++ b/src/test/run-make/cat-and-grep-sanity-check/Makefile
@@ -1,0 +1,46 @@
+-include ../tools.mk
+
+all:
+	echo a | $(CGREP) a
+	! echo b | $(CGREP) a
+	echo xyz | $(CGREP) x y z
+	! echo abc | $(CGREP) b c d
+	printf "x\ny\nz" | $(CGREP) x y z
+
+	echo AbCd | $(CGREP) -i a b C D
+	! echo AbCd | $(CGREP) a b C D
+
+	true | $(CGREP) -v nothing
+	! echo nothing | $(CGREP) -v nothing
+	! echo xyz | $(CGREP) -v w x y
+	! echo xyz | $(CGREP) -v x y z
+	echo xyz | $(CGREP) -v a b c
+
+	! echo 'foo bar baz' | $(CGREP) 'foo baz'
+	echo 'foo bar baz' | $(CGREP) foo baz
+	echo 'x a `b` c y z' | $(CGREP) 'a `b` c'
+
+	echo baaac | $(CGREP) -e 'ba*c'
+	echo bc | $(CGREP) -e 'ba*c'
+	! echo aaac | $(CGREP) -e 'ba*c'
+
+	echo aaa | $(CGREP) -e 'a+'
+	! echo bbb | $(CGREP) -e 'a+'
+
+	echo abc | $(CGREP) -e 'a|e|i|o|u'
+	! echo fgh | $(CGREP) -e 'a|e|i|o|u'
+	echo abc | $(CGREP) -e '[aeiou]'
+	! echo fgh | $(CGREP) -e '[aeiou]'
+	! echo abc | $(CGREP) -e '[^aeiou]{3}'
+	echo fgh | $(CGREP) -e '[^aeiou]{3}'
+	echo ab cd ef gh | $(CGREP) -e '\bcd\b'
+	! echo abcdefgh | $(CGREP) -e '\bcd\b'
+	echo xyz | $(CGREP) -e '...'
+	! echo xy | $(CGREP) -e '...'
+	! echo xyz | $(CGREP) -e '\.\.\.'
+	echo ... | $(CGREP) -e '\.\.\.'
+
+	echo foo bar baz | $(CGREP) -e 'foo.*baz'
+	! echo foo bar baz | $(CGREP) -ve 'foo.*baz'
+	! echo foo bar baz | $(CGREP) -e 'baz.*foo'
+	echo foo bar baz | $(CGREP) -ve 'baz.*foo'

--- a/src/test/run-make/cdylib-fewer-symbols/Makefile
+++ b/src/test/run-make/cdylib-fewer-symbols/Makefile
@@ -9,9 +9,5 @@ all:
 else
 all:
 	$(RUSTC) foo.rs
-	nm -g "$(call DYLIB,foo)"
-	nm -g "$(call DYLIB,foo)" | grep -vq __rdl_
-	nm -g "$(call DYLIB,foo)" | grep -vq __rde_
-	nm -g "$(call DYLIB,foo)" | grep -vq __rg_
-	nm -g "$(call DYLIB,foo)" | grep -vq __rust_
+	nm -g "$(call DYLIB,foo)" | $(CGREP) -v __rdl_ __rde_ __rg_ __rust_
 endif

--- a/src/test/run-make/cdylib-fewer-symbols/Makefile
+++ b/src/test/run-make/cdylib-fewer-symbols/Makefile
@@ -3,7 +3,9 @@
 
 -include ../tools.mk
 
-ifdef IS_MSVC
+# FIXME: The __rdl_ and __rust_ symbol still remains, no matter using MSVC or GNU
+# See https://github.com/rust-lang/rust/pull/46207#issuecomment-347561753
+ifdef IS_WINDOWS
 all:
 	true
 else

--- a/src/test/run-make/codegen-options-parsing/Makefile
+++ b/src/test/run-make/codegen-options-parsing/Makefile
@@ -1,33 +1,31 @@
 -include ../tools.mk
 
-LOG = $(TMPDIR)/log.txt
-
 all:
 	#Option taking a number
-	$(RUSTC) -C codegen-units dummy.rs 2>&1 | tee $(LOG)
-	grep 'codegen option `codegen-units` requires a number' $(LOG)
-	$(RUSTC) -C codegen-units= dummy.rs 2>&1 | tee $(LOG)
-	grep 'incorrect value `` for codegen option `codegen-units` - a number was expected' $(LOG)
-	$(RUSTC) -C codegen-units=foo dummy.rs 2>&1 | tee $(LOG)
-	grep 'incorrect value `foo` for codegen option `codegen-units` - a number was expected' $(LOG)
+	$(RUSTC) -C codegen-units dummy.rs 2>&1 | \
+		$(CGREP) 'codegen option `codegen-units` requires a number'
+	$(RUSTC) -C codegen-units= dummy.rs 2>&1 | \
+		$(CGREP) 'incorrect value `` for codegen option `codegen-units` - a number was expected'
+	$(RUSTC) -C codegen-units=foo dummy.rs 2>&1 | \
+		$(CGREP) 'incorrect value `foo` for codegen option `codegen-units` - a number was expected'
 	$(RUSTC) -C codegen-units=1 dummy.rs
 	#Option taking a string
-	$(RUSTC) -C extra-filename dummy.rs 2>&1 | tee $(LOG)
-	grep 'codegen option `extra-filename` requires a string' $(LOG)
+	$(RUSTC) -C extra-filename dummy.rs 2>&1 | \
+		$(CGREP) 'codegen option `extra-filename` requires a string'
 	$(RUSTC) -C extra-filename= dummy.rs 2>&1
 	$(RUSTC) -C extra-filename=foo dummy.rs 2>&1
 	#Option taking no argument
-	$(RUSTC) -C lto= dummy.rs 2>&1 | tee $(LOG)
-	grep 'codegen option `lto` takes no value' $(LOG)
-	$(RUSTC) -C lto=1 dummy.rs 2>&1 | tee $(LOG)
-	grep 'codegen option `lto` takes no value' $(LOG)
-	$(RUSTC) -C lto=foo dummy.rs 2>&1 | tee $(LOG)
-	grep 'codegen option `lto` takes no value' $(LOG)
+	$(RUSTC) -C lto= dummy.rs 2>&1 | \
+		$(CGREP) 'codegen option `lto` takes no value'
+	$(RUSTC) -C lto=1 dummy.rs 2>&1 | \
+		$(CGREP) 'codegen option `lto` takes no value'
+	$(RUSTC) -C lto=foo dummy.rs 2>&1 | \
+		$(CGREP) 'codegen option `lto` takes no value'
 	$(RUSTC) -C lto dummy.rs
 
 	# Should not link dead code...
 	$(RUSTC) -Z print-link-args dummy.rs 2>&1 | \
-		grep -e '--gc-sections' -e '-z[^ ]* [^ ]*\<ignore\>' -e '-dead_strip' -e '/OPT:REF'
+		$(CGREP) -e '--gc-sections|-z[^ ]* [^ ]*<ignore>|-dead_strip|/OPT:REF'
 	# ... unless you specifically ask to keep it
 	$(RUSTC) -Z print-link-args -C link-dead-code dummy.rs 2>&1 | \
-		(! grep -e '--gc-sections' -e '-z[^ ]* [^ ]*\<ignore\>' -e '-dead_strip' -e '/OPT:REF')
+		$(CGREP) -ve '--gc-sections|-z[^ ]* [^ ]*<ignore>|-dead_strip|/OPT:REF'

--- a/src/test/run-make/error-found-staticlib-instead-crate/Makefile
+++ b/src/test/run-make/error-found-staticlib-instead-crate/Makefile
@@ -2,4 +2,4 @@
 
 all:
 	$(RUSTC) foo.rs --crate-type staticlib
-	$(RUSTC) bar.rs 2>&1 | grep "found staticlib"
+	$(RUSTC) bar.rs 2>&1 | $(CGREP) "found staticlib"

--- a/src/test/run-make/error-writing-dependencies/Makefile
+++ b/src/test/run-make/error-writing-dependencies/Makefile
@@ -3,6 +3,6 @@
 all:
 	# Let's get a nice error message
 	$(BARE_RUSTC) foo.rs --emit dep-info --out-dir foo/bar/baz 2>&1 | \
-		grep "error writing dependencies"
+		$(CGREP) "error writing dependencies"
 	# Make sure the filename shows up
-	$(BARE_RUSTC) foo.rs --emit dep-info --out-dir foo/bar/baz 2>&1 | grep "baz"
+	$(BARE_RUSTC) foo.rs --emit dep-info --out-dir foo/bar/baz 2>&1 | $(CGREP) "baz"

--- a/src/test/run-make/hir-tree/Makefile
+++ b/src/test/run-make/hir-tree/Makefile
@@ -6,4 +6,4 @@
 all:
 	$(RUSTC) -o $(TMPDIR)/input.hir -Z unstable-options \
 		--unpretty=hir-tree input.rs
-	grep '"Hello, Rustaceans!\\n"' $(TMPDIR)/input.hir
+	$(CGREP) '"Hello, Rustaceans!\n"' < $(TMPDIR)/input.hir

--- a/src/test/run-make/include_bytes_deps/Makefile
+++ b/src/test/run-make/include_bytes_deps/Makefile
@@ -8,8 +8,7 @@ ifneq ($(shell uname),FreeBSD)
 ifndef IS_WINDOWS
 all:
 	$(RUSTC) --emit dep-info main.rs
-	grep "input.txt" $(TMPDIR)/main.d
-	grep "input.bin" $(TMPDIR)/main.d
+	$(CGREP) "input.txt" "input.bin" < $(TMPDIR)/main.d
 else
 all:
 

--- a/src/test/run-make/inline-always-many-cgu/Makefile
+++ b/src/test/run-make/inline-always-many-cgu/Makefile
@@ -2,7 +2,7 @@
 
 all:
 	$(RUSTC) foo.rs --emit llvm-ir -C codegen-units=2
-	if grep -w call $(TMPDIR)/*.ll; then \
+	if cat $(TMPDIR)/*.ll | $(CGREP) -e '\bcall\b'; then \
 		echo "found call instruction when one wasn't expected"; \
 		exit 1; \
 	fi

--- a/src/test/run-make/invalid-library/Makefile
+++ b/src/test/run-make/invalid-library/Makefile
@@ -3,4 +3,4 @@
 all:
 	touch $(TMPDIR)/rust.metadata.bin
 	$(AR) crus $(TMPDIR)/libfoo-ffffffff-1.0.rlib $(TMPDIR)/rust.metadata.bin
-	$(RUSTC) foo.rs 2>&1 | grep "can't find crate for"
+	$(RUSTC) foo.rs 2>&1 | $(CGREP) "can't find crate for"

--- a/src/test/run-make/invalid-staticlib/Makefile
+++ b/src/test/run-make/invalid-staticlib/Makefile
@@ -2,4 +2,4 @@
 
 all:
 	touch $(TMPDIR)/libfoo.a
-	echo | $(RUSTC) - --crate-type=rlib -lstatic=foo 2>&1 | grep "failed to add native library"
+	echo | $(RUSTC) - --crate-type=rlib -lstatic=foo 2>&1 | $(CGREP) "failed to add native library"

--- a/src/test/run-make/issue-14698/Makefile
+++ b/src/test/run-make/issue-14698/Makefile
@@ -1,4 +1,4 @@
 -include ../tools.mk
 
 all:
-	TMP=fake TMPDIR=fake $(RUSTC) foo.rs 2>&1 | grep "couldn't create a temp dir:"
+	TMP=fake TMPDIR=fake $(RUSTC) foo.rs 2>&1 | $(CGREP) "couldn't create a temp dir:"

--- a/src/test/run-make/issue-22131/Makefile
+++ b/src/test/run-make/issue-22131/Makefile
@@ -4,4 +4,4 @@ all: foo.rs
 	$(RUSTC) --cfg 'feature="bar"' --crate-type lib foo.rs
 	$(RUSTDOC) --test --cfg 'feature="bar"' \
 		-L $(TMPDIR) foo.rs |\
-		grep -q 'foo.rs - foo (line 11) ... ok'
+		$(CGREP) 'foo.rs - foo (line 11) ... ok'

--- a/src/test/run-make/issue-26092/Makefile
+++ b/src/test/run-make/issue-26092/Makefile
@@ -1,5 +1,4 @@
 -include ../tools.mk
 
 all:
-		$(RUSTC) -o "" blank.rs 2>&1 | \
-			grep -i 'No such file or directory'
+	$(RUSTC) -o "" blank.rs 2>&1 | $(CGREP) -i 'No such file or directory'

--- a/src/test/run-make/issue-33329/Makefile
+++ b/src/test/run-make/issue-33329/Makefile
@@ -1,5 +1,5 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) --target x86_64_unknown-linux-musl main.rs 2>&1 | \
-		grep "error: Error loading target specification: Could not find specification for target"
+	$(RUSTC) --target x86_64_unknown-linux-musl main.rs 2>&1 | $(CGREP) \
+		"error: Error loading target specification: Could not find specification for target"

--- a/src/test/run-make/issue-35164/Makefile
+++ b/src/test/run-make/issue-35164/Makefile
@@ -1,4 +1,4 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) main.rs --error-format json 2>&1 | grep -q '"byte_start":490.*"byte_end":496'
+	$(RUSTC) main.rs --error-format json 2>&1 | $(CGREP) -e '"byte_start":490\b' '"byte_end":496\b'

--- a/src/test/run-make/issue-40535/Makefile
+++ b/src/test/run-make/issue-40535/Makefile
@@ -1,11 +1,13 @@
+-include ../tools.mk
+
 # The ICE occurred in the following situation:
 # * `foo` declares `extern crate bar, baz`, depends only on `bar` (forgetting `baz` in `Cargo.toml`)
 # * `bar` declares and depends on `extern crate baz`
 # * All crates built in metadata-only mode (`cargo check`)
 all:
 	# cc https://github.com/rust-lang/rust/issues/40623
-	$(RUSTC) baz.rs --emit=metadata --out-dir=$(TMPDIR)
-	$(RUSTC) bar.rs --emit=metadata --extern baz=$(TMPDIR)/libbaz.rmeta --out-dir=$(TMPDIR)
-	$(RUSTC) foo.rs --emit=metadata --extern bar=$(TMPDIR)/libbar.rmeta --out-dir=$(TMPDIR) 2>&1 | \
-	grep -vq "unexpectedly panicked"
+	$(RUSTC) baz.rs --emit=metadata
+	$(RUSTC) bar.rs --emit=metadata --extern baz=$(TMPDIR)/libbaz.rmeta
+	$(RUSTC) foo.rs --emit=metadata --extern bar=$(TMPDIR)/libbar.rmeta 2>&1 | \
+		$(CGREP) -v "unexpectedly panicked"
 	# ^ Succeeds if it doesn't find the ICE message

--- a/src/test/run-make/link-arg/Makefile
+++ b/src/test/run-make/link-arg/Makefile
@@ -2,4 +2,4 @@
 RUSTC_FLAGS = -C link-arg="-lfoo" -C link-arg="-lbar" -Z print-link-args
 
 all:
-	$(RUSTC) $(RUSTC_FLAGS) empty.rs | grep lfoo | grep lbar
+	$(RUSTC) $(RUSTC_FLAGS) empty.rs | $(CGREP) lfoo lbar

--- a/src/test/run-make/link-cfg/Makefile
+++ b/src/test/run-make/link-cfg/Makefile
@@ -2,7 +2,7 @@
 
 all: $(call DYLIB,return1) $(call DYLIB,return2) $(call NATIVE_STATICLIB,return3)
 	ls $(TMPDIR)
-	$(RUSTC) --print cfg --target x86_64-unknown-linux-musl | grep crt-static
+	$(RUSTC) --print cfg --target x86_64-unknown-linux-musl | $(CGREP) crt-static
 
 	$(RUSTC) no-deps.rs --cfg foo
 	$(call RUN,no-deps)

--- a/src/test/run-make/linker-output-non-utf8/Makefile
+++ b/src/test/run-make/linker-output-non-utf8/Makefile
@@ -19,6 +19,6 @@ all:
 	$(RUSTC) library.rs
 	mkdir $(bad_dir)
 	mv $(TMPDIR)/liblibrary.a $(bad_dir)
-	LIBRARY_PATH=$(bad_dir) $(RUSTC) exec.rs 2>&1 | grep this_symbol_not_defined
+	LIBRARY_PATH=$(bad_dir) $(RUSTC) exec.rs 2>&1 | $(CGREP) this_symbol_not_defined
 
 endif

--- a/src/test/run-make/many-crates-but-no-match/Makefile
+++ b/src/test/run-make/many-crates-but-no-match/Makefile
@@ -27,7 +27,10 @@ all:
 	mv $(TMPDIR)/$(call RLIB_GLOB,crateA) $(A3)
 	# Ensure crateC fails to compile since A1 is "missing" and A2/A3 hashes do not match
 	$(RUSTC) -L $(A2) -L $(A3) crateC.rs >$(LOG) 2>&1 || true
-	grep "found possibly newer version of crate \`crateA\` which \`crateB\` depends on" $(LOG)
-	grep "note: perhaps that crate needs to be recompiled?" $(LOG)
-	grep "crate \`crateA\`:" $(LOG)  # this will match two entries
-	grep "crate \`crateB\`:" $(LOG)
+	$(CGREP) \
+		'found possibly newer version of crate `crateA` which `crateB` depends on' \
+		'note: perhaps that crate needs to be recompiled?' \
+		'crate `crateA`:' \
+		'crate `crateB`:' \
+		< $(LOG)
+	# the 'crate `crateA`' will match two entries.

--- a/src/test/run-make/mismatching-target-triples/Makefile
+++ b/src/test/run-make/mismatching-target-triples/Makefile
@@ -8,4 +8,4 @@
 all:
 	$(RUSTC) foo.rs --target=i686-unknown-linux-gnu
 	$(RUSTC) bar.rs --target=x86_64-unknown-linux-gnu 2>&1 \
-		| grep "couldn't find crate .foo. with expected target triple x86_64-unknown-linux-gnu"
+		| $(CGREP) 'couldn'"'"'t find crate `foo` with expected target triple x86_64-unknown-linux-gnu'

--- a/src/test/run-make/missing-crate-dependency/Makefile
+++ b/src/test/run-make/missing-crate-dependency/Makefile
@@ -6,4 +6,4 @@ all:
 	$(call REMOVE_RLIBS,crateA)
 	# Ensure crateC fails to compile since dependency crateA is missing
 	$(RUSTC) crateC.rs 2>&1 | \
-		grep "can't find crate for \`crateA\` which \`crateB\` depends on"
+		$(CGREP) 'can'"'"'t find crate for `crateA` which `crateB` depends on'

--- a/src/test/run-make/no-builtins-lto/Makefile
+++ b/src/test/run-make/no-builtins-lto/Makefile
@@ -6,4 +6,4 @@ all:
 	# Build an executable that depends on that crate using LTO. The no_builtins crate doesn't
 	# participate in LTO, so its rlib must be explicitly linked into the final binary. Verify this by
 	# grepping the linker arguments.
-	$(RUSTC) main.rs -C lto -Z print-link-args | grep 'libno_builtins.rlib'
+	$(RUSTC) main.rs -C lto -Z print-link-args | $(CGREP) 'libno_builtins.rlib'

--- a/src/test/run-make/print-cfg/Makefile
+++ b/src/test/run-make/print-cfg/Makefile
@@ -1,16 +1,16 @@
 -include ../tools.mk
 
 all: default
-	$(RUSTC) --target x86_64-pc-windows-gnu --print cfg | grep windows
-	$(RUSTC) --target x86_64-pc-windows-gnu --print cfg | grep x86_64
-	$(RUSTC) --target i686-pc-windows-msvc --print cfg | grep msvc
-	$(RUSTC) --target i686-apple-darwin --print cfg | grep macos
-	$(RUSTC) --target i686-unknown-linux-gnu --print cfg | grep gnu
+	$(RUSTC) --target x86_64-pc-windows-gnu --print cfg | $(CGREP) windows
+	$(RUSTC) --target x86_64-pc-windows-gnu --print cfg | $(CGREP) x86_64
+	$(RUSTC) --target i686-pc-windows-msvc --print cfg | $(CGREP) msvc
+	$(RUSTC) --target i686-apple-darwin --print cfg | $(CGREP) macos
+	$(RUSTC) --target i686-unknown-linux-gnu --print cfg | $(CGREP) gnu
 
 ifdef IS_WINDOWS
 default:
-	$(RUSTC) --print cfg | grep windows
+	$(RUSTC) --print cfg | $(CGREP) windows
 else
 default:
-	$(RUSTC) --print cfg | grep unix
+	$(RUSTC) --print cfg | $(CGREP) unix
 endif

--- a/src/test/run-make/rustc-macro-dep-files/Makefile
+++ b/src/test/run-make/rustc-macro-dep-files/Makefile
@@ -8,5 +8,5 @@ else
 all:
 	$(RUSTC) foo.rs
 	$(RUSTC) bar.rs --emit dep-info
-	grep "proc-macro source" $(TMPDIR)/bar.d && exit 1 || exit 0
+	$(CGREP) -v "proc-macro source" < $(TMPDIR)/bar.d
 endif

--- a/src/test/run-make/sanitizer-address/Makefile
+++ b/src/test/run-make/sanitizer-address/Makefile
@@ -24,7 +24,6 @@ endif
 
 all:
 ifeq ($(ASAN_SUPPORT),1)
-	$(RUSTC) -g -Z sanitizer=address -Z print-link-args $(EXTRA_RUSTFLAG) overflow.rs | grep -q librustc_asan
-	$(TMPDIR)/overflow 2>&1 | tee $(LOG)
-	grep -q stack-buffer-overflow $(LOG)
+	$(RUSTC) -g -Z sanitizer=address -Z print-link-args $(EXTRA_RUSTFLAG) overflow.rs | $(CGREP) librustc_asan
+	$(TMPDIR)/overflow 2>&1 | $(CGREP) stack-buffer-overflow
 endif

--- a/src/test/run-make/sanitizer-cdylib-link/Makefile
+++ b/src/test/run-make/sanitizer-cdylib-link/Makefile
@@ -18,6 +18,5 @@ all:
 ifeq ($(ASAN_SUPPORT),1)
 	$(RUSTC) -g -Z sanitizer=address --crate-type cdylib --target $(TARGET) $(EXTRA_RUSTFLAG) library.rs
 	$(RUSTC) -g -Z sanitizer=address --crate-type bin --target $(TARGET) $(EXTRA_RUSTFLAG) -llibrary program.rs
-	LD_LIBRARY_PATH=$(TMPDIR) $(TMPDIR)/program 2>&1 | tee $(LOG)
-	grep -q stack-buffer-overflow $(LOG)
+	LD_LIBRARY_PATH=$(TMPDIR) $(TMPDIR)/program 2>&1 | $(CGREP) stack-buffer-overflow
 endif

--- a/src/test/run-make/sanitizer-dylib-link/Makefile
+++ b/src/test/run-make/sanitizer-dylib-link/Makefile
@@ -18,6 +18,5 @@ all:
 ifeq ($(ASAN_SUPPORT),1)
 	$(RUSTC) -g -Z sanitizer=address --crate-type dylib --target $(TARGET) $(EXTRA_RUSTFLAG) library.rs
 	$(RUSTC) -g -Z sanitizer=address --crate-type bin --target $(TARGET) $(EXTRA_RUSTFLAG) -llibrary program.rs
-	LD_LIBRARY_PATH=$(TMPDIR) $(TMPDIR)/program 2>&1 | tee $(LOG)
-	grep -q stack-buffer-overflow $(LOG)
+	LD_LIBRARY_PATH=$(TMPDIR) $(TMPDIR)/program 2>&1 | $(CGREP) stack-buffer-overflow
 endif

--- a/src/test/run-make/sanitizer-invalid-cratetype/Makefile
+++ b/src/test/run-make/sanitizer-invalid-cratetype/Makefile
@@ -14,5 +14,5 @@ endif
 
 all:
 ifeq ($(ASAN_SUPPORT),1)
-	$(RUSTC) -Z sanitizer=address --crate-type proc-macro --target $(TARGET) hello.rs 2>&1 | grep -q -- '-Z sanitizer'
+	$(RUSTC) -Z sanitizer=address --crate-type proc-macro --target $(TARGET) hello.rs 2>&1 | $(CGREP) '-Z sanitizer'
 endif

--- a/src/test/run-make/sanitizer-invalid-target/Makefile
+++ b/src/test/run-make/sanitizer-invalid-target/Makefile
@@ -1,4 +1,5 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) -Z sanitizer=leak --target i686-unknown-linux-gnu hello.rs 2>&1 | grep -q 'LeakSanitizer only works with the `x86_64-unknown-linux-gnu` target'
+	$(RUSTC) -Z sanitizer=leak --target i686-unknown-linux-gnu hello.rs 2>&1 | \
+		$(CGREP) 'LeakSanitizer only works with the `x86_64-unknown-linux-gnu` target'

--- a/src/test/run-make/sanitizer-leak/Makefile
+++ b/src/test/run-make/sanitizer-leak/Makefile
@@ -1,15 +1,12 @@
 -include ../tools.mk
 
-LOG := $(TMPDIR)/log.txt
-
 # FIXME(#46126) ThinLTO for libstd broke this test
 ifeq (1,0)
 all:
 ifeq ($(TARGET),x86_64-unknown-linux-gnu)
 ifdef SANITIZER_SUPPORT
-	$(RUSTC) -C opt-level=1 -g -Z sanitizer=leak -Z print-link-args leak.rs | grep -q librustc_lsan
-	$(TMPDIR)/leak 2>&1 | tee $(LOG)
-	grep -q 'detected memory leaks' $(LOG)
+	$(RUSTC) -C opt-level=1 -g -Z sanitizer=leak -Z print-link-args leak.rs | $(CGREP) librustc_lsan
+	$(TMPDIR)/leak 2>&1 | $(CGREP) 'detected memory leaks'
 endif
 endif
 

--- a/src/test/run-make/sanitizer-memory/Makefile
+++ b/src/test/run-make/sanitizer-memory/Makefile
@@ -3,10 +3,8 @@
 all:
 ifeq ($(TARGET),x86_64-unknown-linux-gnu)
 ifdef SANITIZER_SUPPORT
-	$(RUSTC) -g -Z sanitizer=memory -Z print-link-args uninit.rs | tee $(TMPDIR)/out
-	grep -q librustc_msan $(TMPDIR)/out
-	$(TMPDIR)/uninit 2>&1 | tee $(TMPDIR)/out
-	grep -q use-of-uninitialized-value $(TMPDIR)/out
+	$(RUSTC) -g -Z sanitizer=memory -Z print-link-args uninit.rs | $(CGREP) librustc_msan
+	$(TMPDIR)/uninit 2>&1 | $(CGREP) use-of-uninitialized-value
 endif
 endif
 

--- a/src/test/run-make/sanitizer-staticlib-link/Makefile
+++ b/src/test/run-make/sanitizer-staticlib-link/Makefile
@@ -13,6 +13,6 @@ all:
 ifeq ($(ASAN_SUPPORT),1)
 	$(RUSTC) -g -Z sanitizer=address --crate-type staticlib --target $(TARGET) library.rs
 	$(CC) program.c $(call STATICLIB,library) $(call OUT_EXE,program) $(EXTRACFLAGS) $(EXTRACXXFLAGS)
-	LD_LIBRARY_PATH=$(TMPDIR) $(TMPDIR)/program 2>&1 | grep -q stack-buffer-overflow
+	LD_LIBRARY_PATH=$(TMPDIR) $(TMPDIR)/program 2>&1 | $(CGREP) stack-buffer-overflow
 endif
 

--- a/src/test/run-make/static-nobundle/Makefile
+++ b/src/test/run-make/static-nobundle/Makefile
@@ -9,13 +9,13 @@ all: $(call NATIVE_STATICLIB,aaa)
 	$(RUSTC) bbb.rs --crate-type=rlib
 
 	# Check that bbb does NOT contain the definition of `native_func`
-	nm $(TMPDIR)/libbbb.rlib | (! grep "T _*native_func")
-	nm $(TMPDIR)/libbbb.rlib | grep "U _*native_func"
+	nm $(TMPDIR)/libbbb.rlib | $(CGREP) -ve "T _*native_func"
+	nm $(TMPDIR)/libbbb.rlib | $(CGREP) -e "U _*native_func"
 
 	# Check that aaa gets linked (either as `-l aaa` or `aaa.lib`) when building ccc.
-	$(RUSTC) ccc.rs -C prefer-dynamic --crate-type=dylib -Z print-link-args | grep -e "-l[\" ]*aaa" -e "aaa.lib"
+	$(RUSTC) ccc.rs -C prefer-dynamic --crate-type=dylib -Z print-link-args | $(CGREP) -e '-l[" ]*aaa|aaa\.lib'
 
 	# Check that aaa does NOT get linked when building ddd.
-	$(RUSTC) ddd.rs -Z print-link-args | (! grep -e "-l[\" ]*aaa" -e "aaa.lib")
+	$(RUSTC) ddd.rs -Z print-link-args | $(CGREP) -ve '-l[" ]*aaa|aaa\.lib'
 
 	$(call RUN,ddd)

--- a/src/test/run-make/symbols-are-reasonable/Makefile
+++ b/src/test/run-make/symbols-are-reasonable/Makefile
@@ -10,6 +10,4 @@ OUT=$(TMPDIR)/lib.s
 all:
 	$(RUSTC) lib.rs --emit=asm --crate-type=staticlib
 	# just check for symbol declarations with the names we're expecting.
-	grep 'str.[0-9][0-9]*:' $(OUT)
-	grep 'byte_str.[0-9][0-9]*:' $(OUT)
-	grep 'vtable.[0-9][0-9]*' $(OUT)
+	$(CGREP) -e 'str\.[0-9]+:' 'byte_str\.[0-9]+:' 'vtable\.[0-9]+' < $(OUT)

--- a/src/test/run-make/symbols-include-type-name/Makefile
+++ b/src/test/run-make/symbols-include-type-name/Makefile
@@ -6,4 +6,4 @@ OUT=$(TMPDIR)/lib.s
 
 all:
 	$(RUSTC) --crate-type staticlib --emit asm lib.rs
-	grep Def $(OUT)
+	$(CGREP) Def < $(OUT)

--- a/src/test/run-make/target-specs/Makefile
+++ b/src/test/run-make/target-specs/Makefile
@@ -1,9 +1,9 @@
 -include ../tools.mk
 all:
 	$(RUSTC) foo.rs --target=my-awesome-platform.json --crate-type=lib --emit=asm
-	grep -q -v morestack < $(TMPDIR)/foo.s
-	$(RUSTC) foo.rs --target=my-invalid-platform.json 2>&1 | grep -q "Error loading target specification"
-	$(RUSTC) foo.rs --target=my-incomplete-platform.json 2>&1 | grep 'Field llvm-target'
+	$(CGREP) -v morestack < $(TMPDIR)/foo.s
+	$(RUSTC) foo.rs --target=my-invalid-platform.json 2>&1 | $(CGREP) "Error loading target specification"
+	$(RUSTC) foo.rs --target=my-incomplete-platform.json 2>&1 | $(CGREP) 'Field llvm-target'
 	RUST_TARGET_PATH=. $(RUSTC) foo.rs --target=my-awesome-platform --crate-type=lib --emit=asm
 	RUST_TARGET_PATH=. $(RUSTC) foo.rs --target=my-x86_64-unknown-linux-gnu-platform --crate-type=lib --emit=asm
 	$(RUSTC) -Z unstable-options --target=my-awesome-platform.json --print target-spec-json > $(TMPDIR)/test-platform.json && $(RUSTC) -Z unstable-options --target=$(TMPDIR)/test-platform.json --print target-spec-json | diff -q $(TMPDIR)/test-platform.json -

--- a/src/test/run-make/target-without-atomics/Makefile
+++ b/src/test/run-make/target-without-atomics/Makefile
@@ -2,4 +2,4 @@
 
 # The target used below doesn't support atomic operations. Verify that's the case
 all:
-	$(RUSTC) --print cfg --target thumbv6m-none-eabi | grep -qv target_has_atomic
+	$(RUSTC) --print cfg --target thumbv6m-none-eabi | $(CGREP) -v target_has_atomic

--- a/src/test/run-make/test-harness/Makefile
+++ b/src/test/run-make/test-harness/Makefile
@@ -3,7 +3,6 @@
 all:
 	# check that #[cfg_attr(..., ignore)] does the right thing.
 	$(RUSTC) --test test-ignore-cfg.rs --cfg ignorecfg
-	$(call RUN,test-ignore-cfg) | grep 'shouldnotignore ... ok'
-	$(call RUN,test-ignore-cfg) | grep 'shouldignore ... ignored'
-	$(call RUN,test-ignore-cfg --quiet) | grep "^i\.$$"
-	$(call RUN,test-ignore-cfg --quiet) | grep -v 'should'
+	$(call RUN,test-ignore-cfg) | $(CGREP) 'shouldnotignore ... ok' 'shouldignore ... ignored'
+	$(call RUN,test-ignore-cfg --quiet) | $(CGREP) -e "^i\.$$"
+	$(call RUN,test-ignore-cfg --quiet) | $(CGREP) -v 'should'

--- a/src/test/run-make/tools.mk
+++ b/src/test/run-make/tools.mk
@@ -16,6 +16,7 @@ RUSTDOC := $(RUSTDOC) --linker $(RUSTC_LINKER) -Z unstable-options
 endif
 #CC := $(CC) -L $(TMPDIR)
 HTMLDOCCK := $(PYTHON) $(S)/src/etc/htmldocck.py
+CGREP := "$(S)/src/etc/cat-and-grep.sh"
 
 # This is the name of the binary we will generate and run; use this
 # e.g. for `$(CC) -o $(RUN_BINFILE)`.

--- a/src/test/run-make/treat-err-as-bug/Makefile
+++ b/src/test/run-make/treat-err-as-bug/Makefile
@@ -2,4 +2,4 @@
 
 all:
 	$(RUSTC) err.rs -Z treat-err-as-bug 2>&1 \
-	    | grep -q "panicked at 'encountered error with .-Z treat_err_as_bug'"
+	    | $(CGREP) "panicked at 'encountered error with \`-Z treat_err_as_bug'"

--- a/src/test/run-make/type-mismatch-same-crate-name/Makefile
+++ b/src/test/run-make/type-mismatch-same-crate-name/Makefile
@@ -8,12 +8,12 @@ all:
 	$(RUSTC) --crate-type=rlib crateB.rs --extern crateA=$(TMPDIR)/libcrateA-1.rlib
 	# make crateC depend on version 2 of crateA
 	$(RUSTC) crateC.rs --extern crateA=$(TMPDIR)/libcrateA-2.rlib 2>&1 | \
-		tr -d '\r\n' | grep \
+		tr -d '\r\n' | $(CGREP) -e \
 	"mismatched types.*\
-	crateB::try_foo(foo2);.*\
+	crateB::try_foo\(foo2\);.*\
 	expected struct \`crateA::foo::Foo\`, found struct \`crateA::Foo\`.*\
 	different versions of crate \`crateA\`.*\
 	mismatched types.*\
-	crateB::try_bar(bar2);.*\
+	crateB::try_bar\(bar2\);.*\
 	expected trait \`crateA::bar::Bar\`, found trait \`crateA::Bar\`.*\
 	different versions of crate \`crateA\`"

--- a/src/test/run-make/used/Makefile
+++ b/src/test/run-make/used/Makefile
@@ -7,5 +7,5 @@ all:
 else
 all:
 	$(RUSTC) -C opt-level=3 --emit=obj used.rs
-	nm $(TMPDIR)/used.o | grep FOO
+	nm $(TMPDIR)/used.o | $(CGREP) FOO
 endif

--- a/src/test/run-make/volatile-intrinsics/Makefile
+++ b/src/test/run-make/volatile-intrinsics/Makefile
@@ -6,5 +6,4 @@ all:
 	$(call RUN,main)
 	# ... and the loads/stores must not be optimized out.
 	$(RUSTC) main.rs --emit=llvm-ir
-	grep "load volatile"  $(TMPDIR)/main.ll
-	grep "store volatile" $(TMPDIR)/main.ll
+	$(CGREP) "load volatile" "store volatile" < $(TMPDIR)/main.ll

--- a/src/test/run-make/weird-output-filenames/Makefile
+++ b/src/test/run-make/weird-output-filenames/Makefile
@@ -3,13 +3,13 @@
 all:
 	cp foo.rs $(TMPDIR)/.foo.rs
 	$(RUSTC) $(TMPDIR)/.foo.rs 2>&1 \
-		| grep "invalid character.*in crate name:"
+		| $(CGREP) -e "invalid character.*in crate name:"
 	cp foo.rs $(TMPDIR)/.foo.bar
 	$(RUSTC) $(TMPDIR)/.foo.bar 2>&1 \
-		| grep "invalid character.*in crate name:"
+		| $(CGREP) -e "invalid character.*in crate name:"
 	cp foo.rs $(TMPDIR)/+foo+bar
 	$(RUSTC) $(TMPDIR)/+foo+bar 2>&1 \
-		| grep "invalid character.*in crate name:"
+		| $(CGREP) -e "invalid character.*in crate name:"
 	cp foo.rs $(TMPDIR)/-foo.rs
 	$(RUSTC) $(TMPDIR)/-foo.rs 2>&1 \
-		| grep 'crate names cannot start with a `-`'
+		| $(CGREP) 'crate names cannot start with a `-`'


### PR DESCRIPTION
Introduced a new `src/etc/cat-and-grep.sh` script (called in run-make as `$(CGREP)`), which prints the input and do a grep simultaneously. This is mainly used to debug spurious failures in run-make, such as the spurious error in #45810, as well as real errors such as #46126.

(cc #40713)

Some `grep` still remains, mainly the `grep -c` calls that count the number of matches and print the result to stdout.