### PR TITLE
disable jemalloc on executables for ios targets

### DIFF
--- a/src/librustc_back/target/apple_ios_base.rs
+++ b/src/librustc_back/target/apple_ios_base.rs
@@ -99,6 +99,9 @@ pub fn opts(arch: Arch) -> Result<TargetOptions, String> {
         executables: true,
         pre_link_args,
         has_elf_tls: false,
+        // The following line is a workaround for jemalloc 4.5 being broken on
+        // ios. jemalloc 5.0 is supposed to fix this.
+        // see https://github.com/rust-lang/rust/issues/45262
         exe_allocation_crate: None,
         .. super::apple_base::opts()
     })

--- a/src/librustc_back/target/apple_ios_base.rs
+++ b/src/librustc_back/target/apple_ios_base.rs
@@ -99,6 +99,7 @@ pub fn opts(arch: Arch) -> Result<TargetOptions, String> {
         executables: true,
         pre_link_args,
         has_elf_tls: false,
+        exe_allocation_crate: None,
         .. super::apple_base::opts()
     })
 }


### PR DESCRIPTION
This is a (temporary ?) workaround for issue #45262 