### PR TITLE
Implement and forward more formatting traits for slices and arrays

### DIFF
--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -186,9 +186,11 @@ macro_rules! array_impls {
             #[stable(feature = "rust1", since = "1.0.0")]
             impl<T: fmt::Debug> fmt::Debug for [T; $N] {
                 fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                    fmt::Debug::fmt(&&self[..], f)
+                    fmt::Debug::fmt(&self[..], f)
                 }
             }
+
+            fmt_array_impls!($N, Octal, LowerHex, UpperHex, Pointer, Binary, LowerExp, UpperExp);
 
             #[stable(feature = "rust1", since = "1.0.0")]
             impl<'a, T> IntoIterator for &'a [T; $N] {
@@ -250,6 +252,20 @@ macro_rules! array_impls {
                 #[inline]
                 fn cmp(&self, other: &[T; $N]) -> Ordering {
                     Ord::cmp(&&self[..], &&other[..])
+                }
+            }
+        )+
+    }
+}
+
+macro_rules! fmt_array_impls {
+    ($N: expr, $( $Trait: ident ),+) => {
+        $(
+            #[unstable(feature = "slice_more_fmt_traits", issue = /* FIXME */ "0")]
+            impl<T: fmt::$Trait> fmt::$Trait for [T; $N] {
+                #[inline]
+                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    fmt::$Trait::fmt(&self[..], f)
                 }
             }
         )+

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1699,6 +1699,30 @@ impl<T: Debug> Debug for [T] {
     }
 }
 
+macro_rules! slice_impls {
+    ($( $Trait: ident ),+) => {
+        $(
+            #[unstable(feature = "slice_more_fmt_traits", issue = /* FIXME */ "0")]
+            impl<T: $Trait> $Trait for [T] {
+                fn fmt(&self, f: &mut Formatter) -> Result {
+                    f.write_char('[')?;
+                    let mut iter = self.iter();
+                    if let Some(item) = iter.next() {
+                        $Trait::fmt(item, f)?;
+                        for item in iter {
+                            f.write_str(", ")?;
+                            $Trait::fmt(item, f)?;
+                        }
+                    }
+                    f.write_char(']')
+                }
+            }
+        )+
+    }
+}
+
+slice_impls!(Octal, LowerHex, UpperHex, Pointer, Binary, LowerExp, UpperExp);
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Debug for () {
     fn fmt(&self, f: &mut Formatter) -> Result {

--- a/src/libcore/tests/fmt/mod.rs
+++ b/src/libcore/tests/fmt/mod.rs
@@ -38,3 +38,8 @@ fn test_estimated_capacity() {
     assert_eq!(format_args!("{}, hello!", "World").estimated_capacity(), 0);
     assert_eq!(format_args!("{}. 16-bytes piece", "World").estimated_capacity(), 32);
 }
+
+#[test]
+fn test_slice_hex() {
+    assert_eq!(format!("{:02X}", b"AZaz\0"), "[41, 5A, 61, 7A, 00]");
+}


### PR DESCRIPTION
For example:

```rust
impl<T: Octal> Octal for [T; 5] { /* … */ }
```

This is mostly useful for showing binary (non-text) data in hexadecimal.