### PR TITLE
Clarify stdin behavior of `Command::output`.

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -712,8 +712,10 @@ impl Command {
     /// Executes the command as a child process, waiting for it to finish and
     /// collecting all of its output.
     ///
-    /// By default, stdin, stdout and stderr are captured (and used to
-    /// provide the resulting output).
+    /// By default, stdout and stderr are captured (and used to provide the
+    /// resulting output). Stdin is not inherited from the parent and any
+    /// attempt by the child process to read from the stdin stream will result
+    /// in the stream immediately closing.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Fixes #44929.