### PR TITLE
MIR-borrowck: immutable unique closure upvars can be mutated

### DIFF
--- a/src/librustc/ich/impls_mir.rs
+++ b/src/librustc/ich/impls_mir.rs
@@ -31,7 +31,7 @@ impl_stable_hash_for!(struct mir::LocalDecl<'tcx> {
     lexical_scope,
     is_user_variable
 });
-impl_stable_hash_for!(struct mir::UpvarDecl { debug_name, by_ref });
+impl_stable_hash_for!(struct mir::UpvarDecl { debug_name, by_ref, mutability });
 impl_stable_hash_for!(struct mir::BasicBlockData<'tcx> { statements, terminator, is_cleanup });
 impl_stable_hash_for!(struct mir::UnsafetyViolation { source_info, description, kind });
 impl_stable_hash_for!(struct mir::UnsafetyCheckResult { violations, unsafe_blocks });

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -554,7 +554,9 @@ pub struct UpvarDecl {
     pub debug_name: Name,
 
     /// If true, the capture is behind a reference.
-    pub by_ref: bool
+    pub by_ref: bool,
+
+    pub mutability: Mutability,
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -581,7 +581,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             }
 
             self.local_decls.push(LocalDecl {
-                mutability: Mutability::Not,
+                mutability: Mutability::Mut,
                 ty,
                 source_info: SourceInfo {
                     scope: ARGUMENT_VISIBILITY_SCOPE,

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -443,10 +443,20 @@ fn construct_fn<'a, 'gcx, 'tcx, A>(hir: Cx<'a, 'gcx, 'tcx>,
             let mut decl = UpvarDecl {
                 debug_name: keywords::Invalid.name(),
                 by_ref,
+                mutability: Mutability::Not,
             };
             if let Some(hir::map::NodeBinding(pat)) = tcx.hir.find(var_id) {
                 if let hir::PatKind::Binding(_, _, ref ident, _) = pat.node {
                     decl.debug_name = ident.node;
+
+                    let bm = *hir.tables.pat_binding_modes()
+                                        .get(pat.hir_id)
+                                        .expect("missing binding mode");
+                    if bm == ty::BindByValue(hir::MutMutable) {
+                        decl.mutability = Mutability::Mut;
+                    } else {
+                        decl.mutability = Mutability::Not;
+                    }
                 }
             }
             decl

--- a/src/test/compile-fail/issue-46023.rs
+++ b/src/test/compile-fail/issue-46023.rs
@@ -1,0 +1,22 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// revisions: ast mir
+//[mir]compile-flags: -Z emit-end-regions -Z borrowck=mir
+
+fn main() {
+    let x = 0;
+
+    (move || {
+        x = 1;
+        //[mir]~^ ERROR cannot assign to immutable item `x` [E0594]
+        //[ast]~^^ ERROR cannot assign to captured outer variable in an `FnMut` closure [E0594]
+    })()
+}

--- a/src/test/run-pass/issue-16671.rs
+++ b/src/test/run-pass/issue-16671.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//compile-flags: -Z borrowck=compare -Z emit-end-regions
+
 #![deny(warnings)]
 
 fn foo<F: FnOnce()>(_f: F) { }


### PR DESCRIPTION
Fixes #46023 and #46160 (see [this comment](https://github.com/rust-lang/rust/pull/46236#issuecomment-347204874)).