### PR TITLE
Suggest using slice when encountering `let x = ""[..];`

### DIFF
--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -244,23 +244,6 @@ impl Path {
     pub fn is_global(&self) -> bool {
         !self.segments.is_empty() && self.segments[0].name == keywords::CrateRoot.name()
     }
-
-    /// Wether this path is any of `::std::ops::{Range, RangeTo, RangeFrom}`.
-    pub fn is_range(&self) -> bool {
-        let mut base = ["{{root}}", "std", "ops"].iter().map(|p| p.to_string()).collect::<Vec<_>>();
-        let range_paths = ["Range", "RangeTo", "RangeFrom"];
-        let segments = self.segments.iter()
-            .map(|segment| format!("{}", segment.name))
-            .collect::<Vec<String>>();
-        for path in &range_paths {
-            base.push(path.to_string());
-            if base == segments {
-                return true;
-            }
-            base.pop();
-        }
-        false
-    }
 }
 
 impl fmt::Debug for Path {

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -244,6 +244,23 @@ impl Path {
     pub fn is_global(&self) -> bool {
         !self.segments.is_empty() && self.segments[0].name == keywords::CrateRoot.name()
     }
+
+    /// Wether this path is any of `::std::ops::{Range, RangeTo, RangeFrom}`.
+    pub fn is_range(&self) -> bool {
+        let mut base = ["{{root}}", "std", "ops"].iter().map(|p| p.to_string()).collect::<Vec<_>>();
+        let range_paths = ["Range", "RangeTo", "RangeFrom"];
+        let segments = self.segments.iter()
+            .map(|segment| format!("{}", segment.name))
+            .collect::<Vec<String>>();
+        for path in &range_paths {
+            base.push(path.to_string());
+            if base == segments {
+                return true;
+            }
+            base.pop();
+        }
+        false
+    }
 }
 
 impl fmt::Debug for Path {

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -581,6 +581,8 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                                                      trait_ref.self_ty()));
                         }
 
+                        self.suggest_borrow_on_unsized_slice(&obligation.cause.code, &mut err);
+
                         // Try to report a help message
                         if !trait_ref.has_infer_types() &&
                             self.predicate_can_apply(obligation.param_env, trait_ref) {
@@ -819,6 +821,33 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         };
         self.note_obligation_cause(&mut err, obligation);
         err.emit();
+    }
+
+    /// When encountering an assignment of an unsized trait, like `let x = ""[..];`, provide a
+    /// suggestion to borrow the initializer in order to use have a slice instead.
+    fn suggest_borrow_on_unsized_slice(&self,
+                                       code: &ObligationCauseCode<'tcx>,
+                                       err: &mut DiagnosticBuilder<'tcx>) {
+        if let &ObligationCauseCode::VariableType(node_id) = code {
+            let parent_node = self.tcx.hir.get_parent_node(node_id);
+            if let Some(hir::map::NodeLocal(ref local)) = self.tcx.hir.find(parent_node) {
+                if let Some(ref expr) = local.init {
+                    if let hir::ExprIndex(_, ref index) = expr.node {
+                        if let hir::ExprStruct(hir::QPath::Resolved(None, ref path),
+                                               ..) = index.node {
+                            if let (Ok(snippet), true) = (
+                                self.tcx.sess.codemap().span_to_snippet(expr.span),
+                                path.is_range()
+                            ) {
+                                err.span_suggestion(expr.span,
+                                                    "consider a slice instead",
+                                                    format!("&{}", snippet));
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     fn report_arg_count_mismatch(

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -832,17 +832,11 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             let parent_node = self.tcx.hir.get_parent_node(node_id);
             if let Some(hir::map::NodeLocal(ref local)) = self.tcx.hir.find(parent_node) {
                 if let Some(ref expr) = local.init {
-                    if let hir::ExprIndex(_, ref index) = expr.node {
-                        if let hir::ExprStruct(hir::QPath::Resolved(None, ref path),
-                                               ..) = index.node {
-                            if let (Ok(snippet), true) = (
-                                self.tcx.sess.codemap().span_to_snippet(expr.span),
-                                path.is_range()
-                            ) {
-                                err.span_suggestion(expr.span,
-                                                    "consider a slice instead",
-                                                    format!("&{}", snippet));
-                            }
+                    if let hir::ExprIndex(_, _) = expr.node {
+                        if let Ok(snippet) = self.tcx.sess.codemap().span_to_snippet(expr.span) {
+                            err.span_suggestion(expr.span,
+                                                "consider a slice instead",
+                                                format!("&{}", snippet));
                         }
                     }
                 }

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -835,7 +835,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                     if let hir::ExprIndex(_, _) = expr.node {
                         if let Ok(snippet) = self.tcx.sess.codemap().span_to_snippet(expr.span) {
                             err.span_suggestion(expr.span,
-                                                "consider a slice instead",
+                                                "consider borrowing here",
                                                 format!("&{}", snippet));
                         }
                     }

--- a/src/test/ui/suggestions/str-array-assignment.rs
+++ b/src/test/ui/suggestions/str-array-assignment.rs
@@ -20,7 +20,7 @@ fn main() { //~ NOTE expected `()` because of default return type
   //~| NOTE expected type
   let v = s[..2];
   //~^ ERROR the trait bound `str: std::marker::Sized` is not satisfied
-  //~| NOTE consider a slice instead
+  //~| HELP consider a slice instead
   //~| NOTE `str` does not have a constant size known at compile-time
   //~| HELP the trait `std::marker::Sized` is not implemented for `str`
   //~| NOTE all local variables must have a statically known size

--- a/src/test/ui/suggestions/str-array-assignment.rs
+++ b/src/test/ui/suggestions/str-array-assignment.rs
@@ -20,7 +20,7 @@ fn main() { //~ NOTE expected `()` because of default return type
   //~| NOTE expected type
   let v = s[..2];
   //~^ ERROR the trait bound `str: std::marker::Sized` is not satisfied
-  //~| HELP consider a slice instead
+  //~| HELP consider borrowing here
   //~| NOTE `str` does not have a constant size known at compile-time
   //~| HELP the trait `std::marker::Sized` is not implemented for `str`
   //~| NOTE all local variables must have a statically known size

--- a/src/test/ui/suggestions/str-array-assignment.rs
+++ b/src/test/ui/suggestions/str-array-assignment.rs
@@ -1,0 +1,17 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+  let s = "abc";
+  let t = if true { s[..2] } else { s };
+  let u: &str = if true { s[..2] } else { s };
+  let v = s[..2];
+  let w: &str = s[..2];
+}

--- a/src/test/ui/suggestions/str-array-assignment.rs
+++ b/src/test/ui/suggestions/str-array-assignment.rs
@@ -8,10 +8,25 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn main() {
+fn main() { //~ NOTE expected `()` because of default return type
   let s = "abc";
   let t = if true { s[..2] } else { s };
+  //~^ ERROR if and else have incompatible types
+  //~| NOTE expected str, found &str
+  //~| NOTE expected type
   let u: &str = if true { s[..2] } else { s };
+  //~^ ERROR mismatched types
+  //~| NOTE expected &str, found str
+  //~| NOTE expected type
   let v = s[..2];
+  //~^ ERROR the trait bound `str: std::marker::Sized` is not satisfied
+  //~| NOTE consider a slice instead
+  //~| NOTE `str` does not have a constant size known at compile-time
+  //~| HELP the trait `std::marker::Sized` is not implemented for `str`
+  //~| NOTE all local variables must have a statically known size
   let w: &str = s[..2];
+  //~^ ERROR mismatched types
+  //~| NOTE expected &str, found str
+  //~| NOTE expected type
+  //~| HELP try with `&s[..2]`
 }

--- a/src/test/ui/suggestions/str-array-assignment.stderr
+++ b/src/test/ui/suggestions/str-array-assignment.stderr
@@ -8,21 +8,21 @@ error[E0308]: if and else have incompatible types
               found type `&str`
 
 error[E0308]: mismatched types
-  --> $DIR/str-array-assignment.rs:14:27
+  --> $DIR/str-array-assignment.rs:17:27
    |
-11 | fn main() {
+11 | fn main() { //~ NOTE expected `()` because of default return type
    |           - expected `()` because of default return type
 ...
-14 |   let u: &str = if true { s[..2] } else { s };
+17 |   let u: &str = if true { s[..2] } else { s };
    |                           ^^^^^^ expected &str, found str
    |
    = note: expected type `&str`
               found type `str`
 
 error[E0277]: the trait bound `str: std::marker::Sized` is not satisfied
-  --> $DIR/str-array-assignment.rs:15:7
+  --> $DIR/str-array-assignment.rs:21:7
    |
-15 |   let v = s[..2];
+21 |   let v = s[..2];
    |       ^   ------ help: consider a slice instead: `&s[..2]`
    |       |
    |       `str` does not have a constant size known at compile-time
@@ -31,9 +31,9 @@ error[E0277]: the trait bound `str: std::marker::Sized` is not satisfied
    = note: all local variables must have a statically known size
 
 error[E0308]: mismatched types
-  --> $DIR/str-array-assignment.rs:16:17
+  --> $DIR/str-array-assignment.rs:27:17
    |
-16 |   let w: &str = s[..2];
+27 |   let w: &str = s[..2];
    |                 ^^^^^^ expected &str, found str
    |
    = note: expected type `&str`

--- a/src/test/ui/suggestions/str-array-assignment.stderr
+++ b/src/test/ui/suggestions/str-array-assignment.stderr
@@ -1,0 +1,44 @@
+error[E0308]: if and else have incompatible types
+  --> $DIR/str-array-assignment.rs:13:11
+   |
+13 |   let t = if true { s[..2] } else { s };
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected str, found &str
+   |
+   = note: expected type `str`
+              found type `&str`
+
+error[E0308]: mismatched types
+  --> $DIR/str-array-assignment.rs:14:27
+   |
+11 | fn main() {
+   |           - expected `()` because of default return type
+...
+14 |   let u: &str = if true { s[..2] } else { s };
+   |                           ^^^^^^ expected &str, found str
+   |
+   = note: expected type `&str`
+              found type `str`
+
+error[E0277]: the trait bound `str: std::marker::Sized` is not satisfied
+  --> $DIR/str-array-assignment.rs:15:7
+   |
+15 |   let v = s[..2];
+   |       ^   ------ help: consider a slice instead: `&s[..2]`
+   |       |
+   |       `str` does not have a constant size known at compile-time
+   |
+   = help: the trait `std::marker::Sized` is not implemented for `str`
+   = note: all local variables must have a statically known size
+
+error[E0308]: mismatched types
+  --> $DIR/str-array-assignment.rs:16:17
+   |
+16 |   let w: &str = s[..2];
+   |                 ^^^^^^ expected &str, found str
+   |
+   = note: expected type `&str`
+              found type `str`
+   = help: try with `&s[..2]`
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/suggestions/str-array-assignment.stderr
+++ b/src/test/ui/suggestions/str-array-assignment.stderr
@@ -23,7 +23,7 @@ error[E0277]: the trait bound `str: std::marker::Sized` is not satisfied
   --> $DIR/str-array-assignment.rs:21:7
    |
 21 |   let v = s[..2];
-   |       ^   ------ help: consider a slice instead: `&s[..2]`
+   |       ^   ------ help: consider borrowing here: `&s[..2]`
    |       |
    |       `str` does not have a constant size known at compile-time
    |


### PR DESCRIPTION
Fix #26319.