### PR TITLE
rustc_trans: don't apply noalias on returned references.

### DIFF
--- a/src/librustc_trans/abi.rs
+++ b/src/librustc_trans/abi.rs
@@ -792,7 +792,8 @@ impl<'a, 'tcx> FnType<'tcx> {
                     // dependencies rather than pointer equality
                     let no_alias = match kind {
                         PointerKind::Shared => false,
-                        PointerKind::Frozen | PointerKind::UniqueOwned => true,
+                        PointerKind::UniqueOwned => true,
+                        PointerKind::Frozen |
                         PointerKind::UniqueBorrowed => !is_return
                     };
                     if no_alias {

--- a/src/test/run-make/issue-46239/Makefile
+++ b/src/test/run-make/issue-46239/Makefile
@@ -1,0 +1,5 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) main.rs -C opt-level=1
+	$(call RUN,main)

--- a/src/test/run-make/issue-46239/main.rs
+++ b/src/test/run-make/issue-46239/main.rs
@@ -1,0 +1,18 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn project<T>(x: &(T,)) -> &T { &x.0 }
+
+fn dummy() {}
+
+fn main() {
+    let f = (dummy as fn(),);
+    (*project(&f))();
+}


### PR DESCRIPTION
In #45225 frozen returned `&T` were accidentally maked `noalias`, unlike `&mut T`.
Return value `noalias` is only sound for functions that return dynamic allocations, e.g. `Box`, and using it on anything else can lead to miscompilation, as LLVM assumes certain usage patterns.
Fixes #46239.