### PR TITLE
Compiletest libc dependency can be unix-only

### DIFF
--- a/src/tools/compiletest/Cargo.toml
+++ b/src/tools/compiletest/Cargo.toml
@@ -10,6 +10,8 @@ filetime = "0.1"
 getopts = "0.2"
 log = "0.3"
 rustc-serialize = "0.3"
+
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
In main.rs libc is imported as:

```rust
#[cfg(unix)]
extern crate libc;
```

This came up in https://github.com/laumann/compiletest-rs/pull/90.