### PR TITLE
Add low-level APIs for converting integers to strings

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -22,7 +22,7 @@ use slice;
 use str;
 
 mod float;
-mod num;
+pub(crate) mod num;
 mod builders;
 
 #[unstable(feature = "fmt_flags_align", issue = "27726")]

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -209,7 +209,7 @@ macro_rules! impl_Display {
                 (!self.$conv_fn()).wrapping_add(1)
             };
             unsafe {
-                let mut buf: [u8; 39] = mem::uninitialized();
+                let mut buf: [u8; i128::MAX_STR_LEN] = mem::uninitialized();
                 f.pad_integral(is_nonnegative, "", n.to_str_unchecked(&mut buf, false))
             }
         }

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1315,6 +1315,25 @@ macro_rules! uint_impl {
             from_str_radix(src, radix)
         }
 
+        /// Writes the decimal representation in a pre-allocated buffer.
+        ///
+        /// The returned slice contains no leading zero or plus sign,
+        /// and is aligned to the *end* of `buffer`.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if `buffer` is too small.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// assert_eq!(0xFFFF_u32.to_str(&mut [0; 10]), "65635")
+        /// ```
+        #[unstable(feature = "int_to_str", issue = /* FIXME */ "0")]
+        pub fn to_str(self, buffer: &mut [u8]) -> &mut str {
+            fmt::num::UnsignedToStr::to_str(self as $ActualT, buffer)
+        }
+
         /// Returns the number of ones in the binary representation of `self`.
         ///
         /// # Examples

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -151,6 +151,66 @@ macro_rules! int_impl {
             from_str_radix(src, radix)
         }
 
+        /// Write the representation in a given base in a pre-allocated buffer.
+        ///
+        /// Digits are a subset (depending on `radix`) of `0-9A-Z`.
+        ///
+        /// The returned slice starts with a minus sign for negative values
+        /// but contains no leading zero or plus sign,
+        /// and is aligned to the *end* of `buffer`.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if `radix` is smaller than 2 or larger than 36,
+        /// or if `buffer` is too small.
+        /// As a conservative upper bound, `&mut [u8; 128]` is always large enough.
+        ///
+        /// # Safety
+        ///
+        /// `buffer` may be uninitialized.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_to_str)]
+        ///
+        /// assert_eq!((i16::min_value() + 1).to_uppercase_str_radix(&mut [0; 5], 16), "-7FFF")
+        /// ```
+        #[unstable(feature = "int_to_str", issue = /* FIXME */ "0")]
+        pub fn to_uppercase_str_radix(self, buffer: &mut [u8], radix: u32) -> &mut str {
+            fmt::num::SignedToStr::to_str_radix(self as $ActualT, buffer, radix, true)
+        }
+
+        /// Write the representation in a given base in a pre-allocated buffer.
+        ///
+        /// Digits are a subset (depending on `radix`) of `0-9a-z`.
+        ///
+        /// The returned slice starts with a minus sign for negative values
+        /// but contains no leading zero or plus sign,
+        /// and is aligned to the *end* of `buffer`.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if `radix` is smaller than 2 or larger than 36,
+        /// or if `buffer` is too small.
+        /// As a conservative upper bound, `&mut [u8; 128]` is always large enough.
+        ///
+        /// # Safety
+        ///
+        /// `buffer` may be uninitialized.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_to_str)]
+        ///
+        /// assert_eq!((i16::min_value() + 1).to_lowercase_str_radix(&mut [0; 5], 16), "-7fff")
+        /// ```
+        #[unstable(feature = "int_to_str", issue = /* FIXME */ "0")]
+        pub fn to_lowercase_str_radix(self, buffer: &mut [u8], radix: u32) -> &mut str {
+            fmt::num::SignedToStr::to_str_radix(self as $ActualT, buffer, radix, false)
+        }
+
         /// Writes the decimal representation in a pre-allocated buffer.
         ///
         /// The returned slice starts with a minus sign for negative values
@@ -162,6 +222,10 @@ macro_rules! int_impl {
         /// This function will panic if `buffer` is smaller than [`MAX_STR_LEN`].
         ///
         /// [`MAX_STR_LEN`]: #associatedconstant.MAX_STR_LEN
+        ///
+        /// # Safety
+        ///
+        /// `buffer` may be uninitialized.
         ///
         /// # Examples
         ///
@@ -1356,6 +1420,64 @@ macro_rules! uint_impl {
             from_str_radix(src, radix)
         }
 
+        /// Write the representation in a given base in a pre-allocated buffer.
+        ///
+        /// Digits are a subset (depending on `radix`) of `0-9A-F`.
+        ///
+        /// The returned slice contains no leading zero or plus sign,
+        /// and is aligned to the *end* of `buffer`.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if `radix` is smaller than 2 or larger than 36,
+        /// or if `buffer` is too small.
+        /// As a conservative upper bound, `&mut [u8; 128]` is always large enough.
+        ///
+        /// # Safety
+        ///
+        /// `buffer` may be uninitialized.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_to_str)]
+        ///
+        /// assert_eq!((std::char::MAX as u32).to_uppercase_str_radix(&mut [0; 8], 16), "10FFFF")
+        /// ```
+        #[unstable(feature = "int_to_str", issue = /* FIXME */ "0")]
+        pub fn to_uppercase_str_radix(self, buffer: &mut [u8], radix: u32) -> &mut str {
+            fmt::num::UnsignedToStr::to_str_radix(self as $ActualT, buffer, radix, true, false)
+        }
+
+        /// Write the representation in a given base in a pre-allocated buffer.
+        ///
+        /// Digits are a subset (depending on `radix`) of `0-9a-z`.
+        ///
+        /// The returned slice contains no leading zero or plus sign,
+        /// and is aligned to the *end* of `buffer`.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if `radix` is smaller than 2 or larger than 36,
+        /// or if `buffer` is too small.
+        /// As a conservative upper bound, `&mut [u8; 128]` is always large enough.
+        ///
+        /// # Safety
+        ///
+        /// `buffer` may be uninitialized.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_to_str)]
+        ///
+        /// assert_eq!((std::char::MAX as u32).to_lowercase_str_radix(&mut [0; 8], 16), "10ffff")
+        /// ```
+        #[unstable(feature = "int_to_str", issue = /* FIXME */ "0")]
+        pub fn to_lowercase_str_radix(self, buffer: &mut [u8], radix: u32) -> &mut str {
+            fmt::num::UnsignedToStr::to_str_radix(self as $ActualT, buffer, radix, false, false)
+        }
+
         /// Writes the decimal representation in a pre-allocated buffer.
         ///
         /// The returned slice contains no leading zero or plus sign,
@@ -1366,6 +1488,10 @@ macro_rules! uint_impl {
         /// This function will panic if `buffer` is smaller than [`MAX_STR_LEN`].
         ///
         /// [`MAX_STR_LEN`]: #associatedconstant.MAX_STR_LEN
+        ///
+        /// # Safety
+        ///
+        /// `buffer` may be uninitialized.
         ///
         /// # Examples
         ///

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -99,6 +99,7 @@ pub mod diy_float;
 // `Int` + `SignedInt` implemented for signed integers
 macro_rules! int_impl {
     ($SelfT:ty, $ActualT:ident, $UnsignedT:ty, $BITS:expr,
+     MAX_STR_LEN = $MAX_STR_LEN: expr,
      $add_with_overflow:path,
      $sub_with_overflow:path,
      $mul_with_overflow:path) => {
@@ -158,19 +159,28 @@ macro_rules! int_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `buffer` is too small.
+        /// This function will panic if `buffer` is smaller than [`MAX_STR_LEN`].
+        ///
+        /// [`MAX_STR_LEN`]: #associatedconstant.MAX_STR_LEN
         ///
         /// # Examples
         ///
         /// ```
         /// #![feature(int_to_str)]
         ///
-        /// assert_eq!(i16::min_value().to_str(&mut [0; 6]), "-32768")
+        /// assert_eq!(i16::min_value().to_str(&mut [0; i16::MAX_STR_LEN]), "-32768")
         /// ```
         #[unstable(feature = "int_to_str", issue = /* FIXME */ "0")]
         pub fn to_str(self, buffer: &mut [u8]) -> &mut str {
             fmt::num::SignedToStr::to_str(self as $ActualT, buffer)
         }
+
+        /// The maximum length of the decimal representation of a value of this type.
+        /// This is intended to be used together with [`to_str`].
+        ///
+        /// [`MAX_STR_LEN`]: #method.to_str
+        #[unstable(feature = "int_to_str", issue = /* FIXME */ "0")]
+        pub const MAX_STR_LEN: usize = $MAX_STR_LEN;
 
         /// Returns the number of ones in the binary representation of `self`.
         ///
@@ -1222,6 +1232,7 @@ macro_rules! int_impl {
 #[lang = "i8"]
 impl i8 {
     int_impl! { i8, i8, u8, 8,
+        MAX_STR_LEN = 4,  // i8::min_value().to_string().len()
         intrinsics::add_with_overflow,
         intrinsics::sub_with_overflow,
         intrinsics::mul_with_overflow }
@@ -1230,6 +1241,7 @@ impl i8 {
 #[lang = "i16"]
 impl i16 {
     int_impl! { i16, i16, u16, 16,
+        MAX_STR_LEN = 6,  // i16::min_value().to_string().len()
         intrinsics::add_with_overflow,
         intrinsics::sub_with_overflow,
         intrinsics::mul_with_overflow }
@@ -1238,6 +1250,7 @@ impl i16 {
 #[lang = "i32"]
 impl i32 {
     int_impl! { i32, i32, u32, 32,
+        MAX_STR_LEN = 11,  // i32::min_value().to_string().len()
         intrinsics::add_with_overflow,
         intrinsics::sub_with_overflow,
         intrinsics::mul_with_overflow }
@@ -1246,6 +1259,7 @@ impl i32 {
 #[lang = "i64"]
 impl i64 {
     int_impl! { i64, i64, u64, 64,
+        MAX_STR_LEN = 20,  // i64::min_value().to_string().len()
         intrinsics::add_with_overflow,
         intrinsics::sub_with_overflow,
         intrinsics::mul_with_overflow }
@@ -1254,6 +1268,7 @@ impl i64 {
 #[lang = "i128"]
 impl i128 {
     int_impl! { i128, i128, u128, 128,
+        MAX_STR_LEN = 40,  // i128::min_value().to_string().len()
         intrinsics::add_with_overflow,
         intrinsics::sub_with_overflow,
         intrinsics::mul_with_overflow }
@@ -1263,6 +1278,7 @@ impl i128 {
 #[lang = "isize"]
 impl isize {
     int_impl! { isize, i16, u16, 16,
+        MAX_STR_LEN = i16::MAX_STR_LEN,
         intrinsics::add_with_overflow,
         intrinsics::sub_with_overflow,
         intrinsics::mul_with_overflow }
@@ -1272,6 +1288,7 @@ impl isize {
 #[lang = "isize"]
 impl isize {
     int_impl! { isize, i32, u32, 32,
+        MAX_STR_LEN = i32::MAX_STR_LEN,
         intrinsics::add_with_overflow,
         intrinsics::sub_with_overflow,
         intrinsics::mul_with_overflow }
@@ -1281,6 +1298,7 @@ impl isize {
 #[lang = "isize"]
 impl isize {
     int_impl! { isize, i64, u64, 64,
+        MAX_STR_LEN = i64::MAX_STR_LEN,
         intrinsics::add_with_overflow,
         intrinsics::sub_with_overflow,
         intrinsics::mul_with_overflow }
@@ -1289,6 +1307,7 @@ impl isize {
 // `Int` + `UnsignedInt` implemented for unsigned integers
 macro_rules! uint_impl {
     ($SelfT:ty, $ActualT:ty, $BITS:expr,
+     MAX_STR_LEN = $MAX_STR_LEN: expr,
      $ctpop:path,
      $ctlz:path,
      $ctlz_nonzero:path,
@@ -1344,19 +1363,28 @@ macro_rules! uint_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `buffer` is too small.
+        /// This function will panic if `buffer` is smaller than [`MAX_STR_LEN`].
+        ///
+        /// [`MAX_STR_LEN`]: #associatedconstant.MAX_STR_LEN
         ///
         /// # Examples
         ///
         /// ```
         /// #![feature(int_to_str)]
         ///
-        /// assert_eq!(0xFFFF_u32.to_str(&mut [0; 10]), "65535")
+        /// assert_eq!(0xFFFF_u32.to_str(&mut [0; u32::MAX_STR_LEN]), "65535")
         /// ```
         #[unstable(feature = "int_to_str", issue = /* FIXME */ "0")]
         pub fn to_str(self, buffer: &mut [u8]) -> &mut str {
             fmt::num::UnsignedToStr::to_str(self as $ActualT, buffer)
         }
+
+        /// The maximum length of the decimal representation of a value of this type.
+        /// This is intended to be used together with [`to_str`].
+        ///
+        /// [`MAX_STR_LEN`]: #method.to_str
+        #[unstable(feature = "int_to_str", issue = /* FIXME */ "0")]
+        pub const MAX_STR_LEN: usize = $MAX_STR_LEN;
 
         /// Returns the number of ones in the binary representation of `self`.
         ///
@@ -2294,6 +2322,7 @@ macro_rules! uint_impl {
 #[lang = "u8"]
 impl u8 {
     uint_impl! { u8, u8, 8,
+        MAX_STR_LEN = 3,  // u8::min_value().to_string().len()
         intrinsics::ctpop,
         intrinsics::ctlz,
         intrinsics::ctlz_nonzero,
@@ -2848,6 +2877,7 @@ impl u8 {
 #[lang = "u16"]
 impl u16 {
     uint_impl! { u16, u16, 16,
+        MAX_STR_LEN = 5,  // u16::min_value().to_string().len()
         intrinsics::ctpop,
         intrinsics::ctlz,
         intrinsics::ctlz_nonzero,
@@ -2861,6 +2891,7 @@ impl u16 {
 #[lang = "u32"]
 impl u32 {
     uint_impl! { u32, u32, 32,
+        MAX_STR_LEN = 10,  // u32::min_value().to_string().len()
         intrinsics::ctpop,
         intrinsics::ctlz,
         intrinsics::ctlz_nonzero,
@@ -2874,6 +2905,7 @@ impl u32 {
 #[lang = "u64"]
 impl u64 {
     uint_impl! { u64, u64, 64,
+        MAX_STR_LEN = 20,  // u64::min_value().to_string().len()
         intrinsics::ctpop,
         intrinsics::ctlz,
         intrinsics::ctlz_nonzero,
@@ -2887,6 +2919,7 @@ impl u64 {
 #[lang = "u128"]
 impl u128 {
     uint_impl! { u128, u128, 128,
+        MAX_STR_LEN = 40,  // u128::min_value().to_string().len()
         intrinsics::ctpop,
         intrinsics::ctlz,
         intrinsics::ctlz_nonzero,
@@ -2901,6 +2934,7 @@ impl u128 {
 #[lang = "usize"]
 impl usize {
     uint_impl! { usize, u16, 16,
+        MAX_STR_LEN = u16::MAX_STR_LEN,
         intrinsics::ctpop,
         intrinsics::ctlz,
         intrinsics::ctlz_nonzero,
@@ -2914,6 +2948,7 @@ impl usize {
 #[lang = "usize"]
 impl usize {
     uint_impl! { usize, u32, 32,
+        MAX_STR_LEN = u32::MAX_STR_LEN,
         intrinsics::ctpop,
         intrinsics::ctlz,
         intrinsics::ctlz_nonzero,
@@ -2928,6 +2963,7 @@ impl usize {
 #[lang = "usize"]
 impl usize {
     uint_impl! { usize, u64, 64,
+        MAX_STR_LEN = u64::MAX_STR_LEN,
         intrinsics::ctpop,
         intrinsics::ctlz,
         intrinsics::ctlz_nonzero,

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1422,7 +1422,7 @@ macro_rules! uint_impl {
 
         /// Write the representation in a given base in a pre-allocated buffer.
         ///
-        /// Digits are a subset (depending on `radix`) of `0-9A-F`.
+        /// Digits are a subset (depending on `radix`) of `0-9A-Z`.
         ///
         /// The returned slice contains no leading zero or plus sign,
         /// and is aligned to the *end* of `buffer`.

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -150,6 +150,28 @@ macro_rules! int_impl {
             from_str_radix(src, radix)
         }
 
+        /// Writes the decimal representation in a pre-allocated buffer.
+        ///
+        /// The returned slice starts with a minus sign for negative values
+        /// but contains no leading zero or plus sign,
+        /// and is aligned to the *end* of `buffer`.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if `buffer` is too small.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_to_str)]
+        ///
+        /// assert_eq!(i16::min_value().to_str(&mut [0; 6]), "-32768")
+        /// ```
+        #[unstable(feature = "int_to_str", issue = /* FIXME */ "0")]
+        pub fn to_str(self, buffer: &mut [u8]) -> &mut str {
+            fmt::num::SignedToStr::to_str(self as $ActualT, buffer)
+        }
+
         /// Returns the number of ones in the binary representation of `self`.
         ///
         /// # Examples
@@ -1327,7 +1349,9 @@ macro_rules! uint_impl {
         /// # Examples
         ///
         /// ```
-        /// assert_eq!(0xFFFF_u32.to_str(&mut [0; 10]), "65635")
+        /// #![feature(int_to_str)]
+        ///
+        /// assert_eq!(0xFFFF_u32.to_str(&mut [0; 10]), "65535")
         /// ```
         #[unstable(feature = "int_to_str", issue = /* FIXME */ "0")]
         pub fn to_str(self, buffer: &mut [u8]) -> &mut str {


### PR DESCRIPTION
This adds the following new APIs on primitive integer types, unstable under the `int_to_str` feature gate:

```rust
impl $Int {
    pub fn to_uppercase_str_radix(self, buffer: &mut [u8], radix: u32) -> &mut str { /* … */ }
    pub fn to_lowercase_str_radix(self, buffer: &mut [u8], radix: u32) -> &mut str { /* … */ }
    pub fn to_str(self, buffer: &mut [u8]) -> &mut str { /* … */ }
    pub const MAX_STR_LEN: usize = /* … */;
}
```

They are the “mirror” APIs of `from_str` and `from_str_radix`.

The `&mut [u8] -> &mut str` pattern is the same as `char::encode_utf8`: take a (possibly stack-allocated) buffer, write into it, and return a slice of it. It is maximally flexible in terms of allocation/copying strategy.

`to_str` is equivalent to the existing impls of the `fmt::Display` trait (it uses the same optimized algorithm) but does not have the overhead of creating a `fmt::Formatter` and otherwise invoking the string formatting machinery. This overhead was deemed high enough to make a crate dedicated to avoiding it: https://github.com/dtolnay/itoa/

It always requires a buffer of at least `MAX_STR_LEN` bytes, even for values that would fit in a smaller buffer. This is to avoid adding bound checks to the algorithm. Alternatives are to add bound checks, or add them only for `to_str` and not `Display` with more (internal) generics magic.

`to_lowercase_str_radix` and `to_lowercase_str_radix` are similar to the existing impls of the `fmt::LowerHex`, `UpperHex`, `Octal`, and `Binary` traits; but they support more bases and behave differently for negative integers: they use a minus sign followed by the representation of the mathematically opposite integer, whereas the formatting traits use the two’s complement. For example:

```rust
assert_eq!(format!("{:X}", -26), "FFFFFFE6");
assert_eq!((-26).to_uppercase_str_radix(&mut [0; 8], 16), "-1A");
```

There’s two separate methods for upper v.s. lower case to avoid a `bool` parameter that wouldn’t be self-explanatory at call sites, or a dedicated enum that seems like more new API surface than is warranted. An alternative might be to pick one of upper or lower case and only provide that, but that seems arbitrary since neither is obviously superior IMO.