### PR TITLE
ci: Start running wasm32 tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -161,8 +161,8 @@ matrix:
       if: branch = auto
     - env: IMAGE=i686-gnu-nopt
       if: branch = auto
-    # - env: IMAGE=wasm32 issue 42646
-    #   if: branch = auto
+    - env: IMAGE=wasm32-unknown
+      if: branch = auto
     - env: IMAGE=x86_64-gnu
       if: branch = auto
     - env: IMAGE=x86_64-gnu-full-bootstrap

--- a/src/ci/docker/wasm32-unknown/Dockerfile
+++ b/src/ci/docker/wasm32-unknown/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  g++ \
+  make \
+  file \
+  curl \
+  ca-certificates \
+  python \
+  git \
+  cmake \
+  sudo \
+  gdb \
+  xz-utils
+
+RUN curl -sL https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-x64.tar.xz | \
+    tar -xJ
+
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
+ENV TARGETS=wasm32-unknown-unknown
+
+ENV RUST_CONFIGURE_ARGS \
+  --target=$TARGETS \
+  --set build.nodejs=/node-v9.2.0-linux-x64/bin/node
+
+ENV SCRIPT python2.7 /checkout/x.py test --target $TARGETS \
+  src/test/ui \
+  src/test/run-pass \
+  src/test/compile-fail \
+  src/test/parse-fail \
+  src/test/mir-opt \
+  src/test/codegen-units \
+  src/libcore \
+  src/libstd_unicode/ \

--- a/src/etc/wasm32-shim.js
+++ b/src/etc/wasm32-shim.js
@@ -45,8 +45,8 @@ imports.env = {
   exp2f: function(x) { return Math.pow(2, x); },
   ldexp: function(x, y) { return x * Math.pow(2, y); },
   ldexpf: function(x, y) { return x * Math.pow(2, y); },
-  log10: function(x) { return Math.log10(x); },
-  log10f: function(x) { return Math.log10(x); },
+  log10: Math.log10,
+  log10f: Math.log10,
 
   // These are called in src/libstd/sys/wasm/stdio.rs and are used when
   // debugging is enabled.
@@ -71,14 +71,12 @@ imports.env = {
     return process.argv.length - 2;
   },
   rust_wasm_args_arg_size: function(i) {
-    return process.argv[i + 2].length;
+    return Buffer.byteLength(process.argv[i + 2]);
   },
   rust_wasm_args_arg_fill: function(idx, ptr) {
     let arg = process.argv[idx + 2];
     let view = new Uint8Array(memory.buffer);
-    for (var i = 0; i < arg.length; i++) {
-      view[ptr + i] = arg.charCodeAt(i);
-    }
+    Buffer.from(arg).copy(view, ptr);
   },
 
   // These are called in src/libstd/sys/wasm/os.rs and are used when
@@ -91,15 +89,13 @@ imports.env = {
     if (!(key in process.env)) {
       return -1;
     }
-    return process.env[key].length;
+    return Buffer.byteLength(process.env[key]);
   },
   rust_wasm_getenv_data: function(a, b, ptr) {
     let key = copystr(a, b);
     let value = process.env[key];
     let view = new Uint8Array(memory.buffer);
-    for (var i = 0; i < value.length; i++) {
-      view[ptr + i] = value.charCodeAt(i);
-    }
+    Buffer.from(value).copy(view, ptr);
   },
 };
 

--- a/src/test/compile-fail/auxiliary/issue_5844_aux.rs
+++ b/src/test/compile-fail/auxiliary/issue_5844_aux.rs
@@ -8,10 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(libc)]
-
-extern crate libc;
-
 extern "C" {
-    pub fn rand() -> libc::c_int;
+    pub fn rand() -> u32;
 }

--- a/src/test/compile-fail/issue-10755.rs
+++ b/src/test/compile-fail/issue-10755.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -C linker=llllll
+// compile-flags: -C linker=llllll -Z linker-flavor=ld
 // error-pattern: the linker `llllll`
 
 fn main() {

--- a/src/test/compile-fail/lint-ctypes.rs
+++ b/src/test/compile-fail/lint-ctypes.rs
@@ -52,8 +52,6 @@ extern {
     pub fn fn_type2(p: fn()); //~ ERROR found function pointer with Rust
     pub fn fn_contained(p: RustBadRet); //~ ERROR: found struct without
 
-    pub fn good1(size: *const libc::c_int);
-    pub fn good2(size: *const libc::c_uint);
     pub fn good3(fptr: Option<extern fn()>);
     pub fn good4(aptr: &[u8; 4 as usize]);
     pub fn good5(s: StructWithProjection);
@@ -64,6 +62,12 @@ extern {
     pub fn good10() -> CVoidRet;
     pub fn good11(size: isize);
     pub fn good12(size: usize);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+extern {
+    pub fn good1(size: *const libc::c_int);
+    pub fn good2(size: *const libc::c_uint);
 }
 
 fn main() {

--- a/src/test/compile-fail/lint-dead-code-3.rs
+++ b/src/test/compile-fail/lint-dead-code-3.rs
@@ -11,11 +11,9 @@
 #![allow(unused_variables)]
 #![allow(non_camel_case_types)]
 #![deny(dead_code)]
-#![feature(libc)]
 
 #![crate_type="lib"]
 
-extern crate libc;
 
 pub use extern_foo as x;
 extern {
@@ -54,14 +52,13 @@ pub fn pub_fn() {
 }
 
 mod blah {
-    use libc::size_t;
     // not warned because it's used in the parameter of `free` and return of
     // `malloc` below, which are also used.
     enum c_void {}
 
     extern {
         fn free(p: *const c_void);
-        fn malloc(size: size_t) -> *const c_void;
+        fn malloc(size: usize) -> *const c_void;
     }
 
     pub fn baz() {

--- a/src/test/compile-fail/nolink-with-link-args.rs
+++ b/src/test/compile-fail/nolink-with-link-args.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // error-pattern:aFdEfSeVEE
+// compile-flags: -Z linker-flavor=ld
 
 /* We're testing that link_args are indeed passed when nolink is specified.
 So we try to compile with junk link_args and make sure they are visible in

--- a/src/test/compile-fail/non-copyable-void.rs
+++ b/src/test/compile-fail/non-copyable-void.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-wasm32-bare no libc to test ffi with
+
 #![feature(libc)]
 
 extern crate libc;

--- a/src/test/compile-fail/panic-runtime/libtest-unwinds.rs
+++ b/src/test/compile-fail/panic-runtime/libtest-unwinds.rs
@@ -10,6 +10,7 @@
 
 // error-pattern:is not compiled with this crate's panic strategy `abort`
 // compile-flags:-C panic=abort
+// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(test)]
 

--- a/src/test/compile-fail/panic-runtime/transitive-link-a-bunch.rs
+++ b/src/test/compile-fail/panic-runtime/transitive-link-a-bunch.rs
@@ -14,6 +14,7 @@
 // aux-build:wants-panic-runtime-abort.rs
 // aux-build:panic-runtime-lang-items.rs
 // error-pattern: is not compiled with this crate's panic strategy `unwind`
+// ignore-wasm32-bare compiled with panic=abort by default
 
 #![no_std]
 

--- a/src/test/compile-fail/panic-runtime/want-unwind-got-abort.rs
+++ b/src/test/compile-fail/panic-runtime/want-unwind-got-abort.rs
@@ -11,6 +11,7 @@
 // error-pattern:is incompatible with this crate's strategy of `unwind`
 // aux-build:panic-runtime-abort.rs
 // aux-build:panic-runtime-lang-items.rs
+// ignore-wasm32-bare compiled with panic=abort by default
 
 #![no_std]
 

--- a/src/test/compile-fail/panic-runtime/want-unwind-got-abort2.rs
+++ b/src/test/compile-fail/panic-runtime/want-unwind-got-abort2.rs
@@ -12,6 +12,7 @@
 // aux-build:panic-runtime-abort.rs
 // aux-build:wants-panic-runtime-abort.rs
 // aux-build:panic-runtime-lang-items.rs
+// ignore-wasm32-bare compiled with panic=abort by default
 
 #![no_std]
 

--- a/src/test/compile-fail/static-mut-foreign-requires-unsafe.rs
+++ b/src/test/compile-fail/static-mut-foreign-requires-unsafe.rs
@@ -8,12 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(libc)]
-
-extern crate libc;
-
 extern {
-    static mut a: libc::c_int;
+    static mut a: i32;
 }
 
 fn main() {

--- a/src/test/compile-fail/unsupported-cast.rs
+++ b/src/test/compile-fail/unsupported-cast.rs
@@ -10,10 +10,8 @@
 
 // error-pattern:casting
 
-#![feature(libc)]
-
-extern crate libc;
+struct A;
 
 fn main() {
-  println!("{:?}", 1.0 as *const libc::FILE); // Can't cast float to foreign.
+  println!("{:?}", 1.0 as *const A); // Can't cast float to foreign.
 }

--- a/src/test/compile-fail/weak-lang-item.rs
+++ b/src/test/compile-fail/weak-lang-item.rs
@@ -11,6 +11,7 @@
 // aux-build:weak-lang-items.rs
 // error-pattern: language item required, but not found: `panic_fmt`
 // error-pattern: language item required, but not found: `eh_personality`
+// ignore-wasm32-bare compiled with panic=abort, personality not required
 
 #![no_std]
 

--- a/src/test/mir-opt/box_expr.rs
+++ b/src/test/mir-opt/box_expr.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-wasm32-bare compiled with panic=abort by default
+
 #![feature(box_syntax)]
 
 fn main() {

--- a/src/test/mir-opt/issue-41110.rs
+++ b/src/test/mir-opt/issue-41110.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-wasm32-bare compiled with panic=abort by default
+
 // check that we don't emit multiple drop flags when they are not needed.
 
 fn main() {

--- a/src/test/mir-opt/packed-struct-drop-aligned.rs
+++ b/src/test/mir-opt/packed-struct-drop-aligned.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-wasm32-bare compiled with panic=abort by default
+
 fn main() {
     let mut x = Packed(Aligned(Droppy(0)));
     x.0 = Aligned(Droppy(0));

--- a/src/test/run-pass/next-power-of-two-overflow-debug.rs
+++ b/src/test/run-pass/next-power-of-two-overflow-debug.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -C debug_assertions=yes
+// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(i128_type)]
 

--- a/src/test/run-pass/saturating-float-casts.rs
+++ b/src/test/run-pass/saturating-float-casts.rs
@@ -10,6 +10,7 @@
 
 // Tests saturating float->int casts. See u128-as-f32.rs for the opposite direction.
 // compile-flags: -Z saturating-float-casts
+// ignore-wasm32-bare FIXME(#46298) needs upstream llvm fixes
 
 #![feature(test, i128, i128_type, stmt_expr_attributes)]
 #![deny(overflowing_literals)]


### PR DESCRIPTION
This commit allocates a builder to running wasm32 tests on Travis. Not all test
suites pass right now so this is starting out with just the run-pass and the
libcore test suites. This'll hopefully give us a pretty broad set of coverage
for integration in rustc itself as well as a somewhat broad coverage of the llvm
backend itself through integration/unit tests.