### PR TITLE
incr.comp.: Load cached diagnostics lazily and allow more things in the cache.

### DIFF
--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -461,10 +461,10 @@ impl DepGraph {
         self.data.as_ref().and_then(|data| data.colors.borrow().get(dep_node).cloned())
     }
 
-    pub fn try_mark_green<'a, 'tcx>(&self,
-                                    tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                                    dep_node: &DepNode)
-                                    -> Option<DepNodeIndex> {
+    pub fn try_mark_green<'tcx>(&self,
+                                tcx: TyCtxt<'_, 'tcx, 'tcx>,
+                                dep_node: &DepNode)
+                                -> Option<DepNodeIndex> {
         debug!("try_mark_green({:?}) - BEGIN", dep_node);
         let data = self.data.as_ref().unwrap();
 

--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -461,10 +461,10 @@ impl DepGraph {
         self.data.as_ref().and_then(|data| data.colors.borrow().get(dep_node).cloned())
     }
 
-    pub fn try_mark_green(&self,
-                          tcx: TyCtxt,
-                          dep_node: &DepNode)
-                          -> Option<DepNodeIndex> {
+    pub fn try_mark_green<'a, 'tcx>(&self,
+                                    tcx: TyCtxt<'a, 'tcx, 'tcx>,
+                                    dep_node: &DepNode)
+                                    -> Option<DepNodeIndex> {
         debug!("try_mark_green({:?}) - BEGIN", dep_node);
         let data = self.data.as_ref().unwrap();
 
@@ -621,7 +621,7 @@ impl DepGraph {
         // ... emitting any stored diagnostic ...
         {
             let diagnostics = tcx.on_disk_query_result_cache
-                                 .load_diagnostics(prev_dep_node_index);
+                                 .load_diagnostics(tcx, prev_dep_node_index);
 
             if diagnostics.len() > 0 {
                 let handle = tcx.sess.diagnostic();

--- a/src/librustc/ich/hcx.rs
+++ b/src/librustc/ich/hcx.rs
@@ -419,7 +419,7 @@ impl<'gcx> HashStable<StableHashingContext<'gcx>> for Span {
             0u8.hash_stable(hcx, hasher);
         } else {
             1u8.hash_stable(hcx, hasher);
-            self.source_callsite().hash_stable(hcx, hasher);
+            span.ctxt.outer().expn_info().hash_stable(hcx, hasher);
         }
     }
 }

--- a/src/librustc/ich/hcx.rs
+++ b/src/librustc/ich/hcx.rs
@@ -28,7 +28,7 @@ use syntax::attr;
 use syntax::codemap::CodeMap;
 use syntax::ext::hygiene::SyntaxContext;
 use syntax::symbol::Symbol;
-use syntax_pos::Span;
+use syntax_pos::{Span, DUMMY_SP};
 
 use rustc_data_structures::stable_hasher::{HashStable, StableHashingContextProvider,
                                            StableHasher, StableHasherResult,
@@ -362,63 +362,52 @@ impl<'gcx> HashStable<StableHashingContext<'gcx>> for Span {
     fn hash_stable<W: StableHasherResult>(&self,
                                           hcx: &mut StableHashingContext<'gcx>,
                                           hasher: &mut StableHasher<W>) {
-        use syntax_pos::Pos;
+        const TAG_VALID_SPAN: u8 = 0;
+        const TAG_INVALID_SPAN: u8 = 1;
+        const TAG_EXPANSION: u8 = 0;
+        const TAG_NO_EXPANSION: u8 = 1;
 
         if !hcx.hash_spans {
             return
+        }
+
+        if *self == DUMMY_SP {
+            return std_hash::Hash::hash(&TAG_INVALID_SPAN, hasher);
         }
 
         // If this is not an empty or invalid span, we want to hash the last
         // position that belongs to it, as opposed to hashing the first
         // position past it.
         let span = self.data();
-        let span_hi = if span.hi > span.lo {
-            // We might end up in the middle of a multibyte character here,
-            // but that's OK, since we are not trying to decode anything at
-            // this position.
-            span.hi - ::syntax_pos::BytePos(1)
-        } else {
-            span.hi
-        };
 
-        {
-            let loc1 = hcx.codemap().byte_pos_to_line_and_col(span.lo);
-            let loc1 = loc1.as_ref()
-                           .map(|&(ref fm, line, col)| (&fm.name[..], line, col.to_usize()))
-                           .unwrap_or(("???", 0, 0));
-
-            let loc2 = hcx.codemap().byte_pos_to_line_and_col(span_hi);
-            let loc2 = loc2.as_ref()
-                           .map(|&(ref fm, line, col)| (&fm.name[..], line, col.to_usize()))
-                           .unwrap_or(("???", 0, 0));
-
-            if loc1.0 == loc2.0 {
-                std_hash::Hash::hash(&0u8, hasher);
-
-                std_hash::Hash::hash(loc1.0, hasher);
-                std_hash::Hash::hash(&loc1.1, hasher);
-                std_hash::Hash::hash(&loc1.2, hasher);
-
-                // Do not hash the file name twice
-                std_hash::Hash::hash(&loc2.1, hasher);
-                std_hash::Hash::hash(&loc2.2, hasher);
-            } else {
-                std_hash::Hash::hash(&1u8, hasher);
-
-                std_hash::Hash::hash(loc1.0, hasher);
-                std_hash::Hash::hash(&loc1.1, hasher);
-                std_hash::Hash::hash(&loc1.2, hasher);
-
-                std_hash::Hash::hash(loc2.0, hasher);
-                std_hash::Hash::hash(&loc2.1, hasher);
-                std_hash::Hash::hash(&loc2.2, hasher);
-            }
+        if span.hi < span.lo {
+            return std_hash::Hash::hash(&TAG_INVALID_SPAN, hasher);
         }
 
+        let (file_lo, line_lo, col_lo) = match hcx.codemap()
+                                                  .byte_pos_to_line_and_col(span.lo) {
+            Some(pos) => pos,
+            None => {
+                return std_hash::Hash::hash(&TAG_INVALID_SPAN, hasher);
+            }
+        };
+
+        if !file_lo.contains(span.hi) {
+            return std_hash::Hash::hash(&TAG_INVALID_SPAN, hasher);
+        }
+
+        let len = span.hi - span.lo;
+
+        std_hash::Hash::hash(&TAG_VALID_SPAN, hasher);
+        std_hash::Hash::hash(&file_lo.name, hasher);
+        std_hash::Hash::hash(&line_lo, hasher);
+        std_hash::Hash::hash(&col_lo, hasher);
+        std_hash::Hash::hash(&len, hasher);
+
         if span.ctxt == SyntaxContext::empty() {
-            0u8.hash_stable(hcx, hasher);
+            TAG_NO_EXPANSION.hash_stable(hcx, hasher);
         } else {
-            1u8.hash_stable(hcx, hasher);
+            TAG_EXPANSION.hash_stable(hcx, hasher);
             span.ctxt.outer().expn_info().hash_stable(hcx, hasher);
         }
     }

--- a/src/librustc/ich/impls_syntax.rs
+++ b/src/librustc/ich/impls_syntax.rs
@@ -347,6 +347,30 @@ impl_stable_hash_for!(enum ::syntax::ast::MetaItemKind {
     NameValue(lit)
 });
 
+impl_stable_hash_for!(struct ::syntax_pos::hygiene::ExpnInfo {
+    call_site,
+    callee
+});
+
+impl_stable_hash_for!(struct ::syntax_pos::hygiene::NameAndSpan {
+    format,
+    allow_internal_unstable,
+    allow_internal_unsafe,
+    span
+});
+
+impl_stable_hash_for!(enum ::syntax_pos::hygiene::ExpnFormat {
+    MacroAttribute(sym),
+    MacroBang(sym),
+    CompilerDesugaring(kind)
+});
+
+impl_stable_hash_for!(enum ::syntax_pos::hygiene::CompilerDesugaringKind {
+    BackArrow,
+    DotFill,
+    QuestionMark
+});
+
 impl<'gcx> HashStable<StableHashingContext<'gcx>> for FileMap {
     fn hash_stable<W: StableHasherResult>(&self,
                                           hcx: &mut StableHashingContext<'gcx>,

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1235,7 +1235,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                                            -> Result<(), E::Error>
         where E: ty::codec::TyEncoder
     {
-        self.on_disk_query_result_cache.serialize(self.global_tcx(), self.cstore, encoder)
+        self.on_disk_query_result_cache.serialize(self.global_tcx(), encoder)
     }
 
 }

--- a/src/librustc/ty/maps/config.rs
+++ b/src/librustc/ty/maps/config.rs
@@ -31,9 +31,9 @@ pub(super) trait QueryDescription<'tcx>: QueryConfig {
         false
     }
 
-    fn load_from_disk<'a>(_: TyCtxt<'a, 'tcx, 'tcx>,
-                          _: SerializedDepNodeIndex)
-                          -> Self::Value {
+    fn try_load_from_disk<'a>(_: TyCtxt<'a, 'tcx, 'tcx>,
+                              _: SerializedDepNodeIndex)
+                              -> Option<Self::Value> {
         bug!("QueryDescription::load_from_disk() called for unsupport query.")
     }
 }
@@ -556,12 +556,14 @@ impl<'tcx> QueryDescription<'tcx> for queries::typeck_tables_of<'tcx> {
         def_id.is_local()
     }
 
-    fn load_from_disk<'a>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                          id: SerializedDepNodeIndex)
-                          -> Self::Value {
-        let typeck_tables: ty::TypeckTables<'tcx> = tcx.on_disk_query_result_cache
-                                                       .load_query_result(tcx, id);
-        tcx.alloc_tables(typeck_tables)
+    fn try_load_from_disk<'a>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
+                              id: SerializedDepNodeIndex)
+                              -> Option<Self::Value> {
+        let typeck_tables: Option<ty::TypeckTables<'tcx>> = tcx
+            .on_disk_query_result_cache
+            .try_load_query_result(tcx, id);
+
+        typeck_tables.map(|tables| tcx.alloc_tables(tables))
     }
 }
 

--- a/src/librustc/ty/maps/config.rs
+++ b/src/librustc/ty/maps/config.rs
@@ -31,9 +31,9 @@ pub(super) trait QueryDescription<'tcx>: QueryConfig {
         false
     }
 
-    fn try_load_from_disk<'a>(_: TyCtxt<'a, 'tcx, 'tcx>,
-                              _: SerializedDepNodeIndex)
-                              -> Option<Self::Value> {
+    fn try_load_from_disk(_: TyCtxt<'_, 'tcx, 'tcx>,
+                          _: SerializedDepNodeIndex)
+                          -> Option<Self::Value> {
         bug!("QueryDescription::load_from_disk() called for unsupport query.")
     }
 }
@@ -556,9 +556,9 @@ impl<'tcx> QueryDescription<'tcx> for queries::typeck_tables_of<'tcx> {
         def_id.is_local()
     }
 
-    fn try_load_from_disk<'a>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                              id: SerializedDepNodeIndex)
-                              -> Option<Self::Value> {
+    fn try_load_from_disk(tcx: TyCtxt<'_, 'tcx, 'tcx>,
+                          id: SerializedDepNodeIndex)
+                          -> Option<Self::Value> {
         let typeck_tables: Option<ty::TypeckTables<'tcx>> = tcx
             .on_disk_query_result_cache
             .try_load_query_result(tcx, id);

--- a/src/librustc/ty/maps/on_disk_cache.rs
+++ b/src/librustc/ty/maps/on_disk_cache.rs
@@ -15,7 +15,6 @@ use hir::def_id::{CrateNum, DefIndex, DefId, LocalDefId,
                   RESERVED_FOR_INCR_COMP_CACHE, LOCAL_CRATE};
 use hir::map::definitions::DefPathHash;
 use ich::CachingCodemapView;
-use middle::cstore::CrateStore;
 use mir;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::indexed_vec::{IndexVec, Idx};

--- a/src/librustc/ty/maps/on_disk_cache.rs
+++ b/src/librustc/ty/maps/on_disk_cache.rs
@@ -289,21 +289,18 @@ impl<'sess> OnDiskCache<'sess> {
         debug_assert!(prev.is_none());
     }
 
-    pub fn load_query_result<'a, 'tcx, T>(&self,
-                                          tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                                          dep_node_index: SerializedDepNodeIndex)
-                                          -> T
+    /// Returns the cached query result if there is something in the cache for
+    /// the given SerializedDepNodeIndex. Otherwise returns None.
+    pub fn try_load_query_result<'a, 'tcx, T>(&self,
+                                              tcx: TyCtxt<'a, 'tcx, 'tcx>,
+                                              dep_node_index: SerializedDepNodeIndex)
+                                              -> Option<T>
         where T: Decodable
     {
-        let result = self.load_indexed(tcx,
-                                       dep_node_index,
-                                       &self.query_result_index,
-                                       "query result");
-        if let Some(result) = result {
-            result
-        } else {
-            bug!("Could not find query result for key {:?}", dep_node_index)
-        }
+        self.load_indexed(tcx,
+                          dep_node_index,
+                          &self.query_result_index,
+                          "query result")
     }
 
     /// Store a diagnostic emitted during computation of an anonymous query.

--- a/src/librustc/ty/maps/on_disk_cache.rs
+++ b/src/librustc/ty/maps/on_disk_cache.rs
@@ -27,7 +27,8 @@ use std::collections::BTreeMap;
 use std::mem;
 use syntax::ast::NodeId;
 use syntax::codemap::{CodeMap, StableFilemapId};
-use syntax_pos::{BytePos, Span, NO_EXPANSION, DUMMY_SP};
+use syntax_pos::{BytePos, Span, DUMMY_SP};
+use syntax_pos::hygiene::{Mark, SyntaxContext, ExpnInfo};
 use ty;
 use ty::codec::{self as ty_codec, TyDecoder, TyEncoder};
 use ty::context::TyCtxt;
@@ -39,6 +40,10 @@ const QUERY_RESULT_INDEX_TAG: u64 = 0x1234_5678_C3C3_C3C3;
 
 const TAG_CLEAR_CROSS_CRATE_CLEAR: u8 = 0;
 const TAG_CLEAR_CROSS_CRATE_SET: u8 = 1;
+
+const TAG_NO_EXPANSION_INFO: u8 = 0;
+const TAG_EXPANSION_INFO_SHORTHAND: u8 = 1;
+const TAG_EXPANSION_INFO_INLINE: u8 = 2;
 
 /// `OnDiskCache` provides an interface to incr. comp. data cached from the
 /// previous compilation session. This data will eventually include the results
@@ -61,6 +66,7 @@ pub struct OnDiskCache<'sess> {
 
     prev_filemap_starts: BTreeMap<BytePos, StableFilemapId>,
     codemap: &'sess CodeMap,
+    synthetic_expansion_infos: RefCell<FxHashMap<usize, SyntaxContext>>,
 
     // A map from dep-node to the position of the cached query result in
     // `serialized_data`.
@@ -90,6 +96,8 @@ impl<'sess> OnDiskCache<'sess> {
             (header, decoder.position())
         };
 
+        let mut synthetic_expansion_infos = FxHashMap();
+
         let (prev_diagnostics, query_result_index) = {
             let mut decoder = CacheDecoder {
                 tcx: None,
@@ -97,6 +105,7 @@ impl<'sess> OnDiskCache<'sess> {
                 codemap: sess.codemap(),
                 prev_filemap_starts: &header.prev_filemap_starts,
                 cnum_map: &IndexVec::new(),
+                synthetic_expansion_infos: &mut synthetic_expansion_infos,
             };
 
             // Decode Diagnostics
@@ -135,6 +144,7 @@ impl<'sess> OnDiskCache<'sess> {
             codemap: sess.codemap(),
             current_diagnostics: RefCell::new(FxHashMap()),
             query_result_index: query_result_index.into_iter().collect(),
+            synthetic_expansion_infos: RefCell::new(synthetic_expansion_infos),
         }
     }
 
@@ -148,6 +158,7 @@ impl<'sess> OnDiskCache<'sess> {
             codemap,
             current_diagnostics: RefCell::new(FxHashMap()),
             query_result_index: FxHashMap(),
+            synthetic_expansion_infos: RefCell::new(FxHashMap()),
         }
     }
 
@@ -166,6 +177,7 @@ impl<'sess> OnDiskCache<'sess> {
             encoder,
             type_shorthands: FxHashMap(),
             predicate_shorthands: FxHashMap(),
+            expn_info_shorthands: FxHashMap(),
         };
 
 
@@ -269,12 +281,15 @@ impl<'sess> OnDiskCache<'sess> {
             *cnum_map = Some(Self::compute_cnum_map(tcx, &self.prev_cnums[..]));
         }
 
+        let mut synthetic_expansion_infos = self.synthetic_expansion_infos.borrow_mut();
+
         let mut decoder = CacheDecoder {
             tcx: Some(tcx),
             opaque: opaque::Decoder::new(&self.serialized_data[..], pos),
             codemap: self.codemap,
             prev_filemap_starts: &self.prev_filemap_starts,
             cnum_map: cnum_map.as_ref().unwrap(),
+            synthetic_expansion_infos: &mut *synthetic_expansion_infos,
         };
 
         match decode_tagged(&mut decoder, dep_node_index) {
@@ -350,6 +365,7 @@ struct CacheDecoder<'a, 'tcx: 'a, 'x> {
     codemap: &'x CodeMap,
     prev_filemap_starts: &'x BTreeMap<BytePos, StableFilemapId>,
     cnum_map: &'x IndexVec<CrateNum, Option<CrateNum>>,
+    synthetic_expansion_infos: &'x mut FxHashMap<usize, SyntaxContext>,
 }
 
 impl<'a, 'tcx, 'x> CacheDecoder<'a, 'tcx, 'x> {
@@ -457,7 +473,39 @@ impl<'a, 'tcx, 'x> SpecializedDecoder<Span> for CacheDecoder<'a, 'tcx, 'x> {
             if let Some(current_filemap) = self.codemap.filemap_by_stable_id(filemap_id) {
                 let lo = (lo + current_filemap.start_pos) - prev_filemap_start;
                 let hi = (hi + current_filemap.start_pos) - prev_filemap_start;
-                return Ok(Span::new(lo, hi, NO_EXPANSION));
+
+                let expn_info_tag = u8::decode(self)?;
+
+                let ctxt = match expn_info_tag {
+                    TAG_NO_EXPANSION_INFO => {
+                        SyntaxContext::empty()
+                    }
+                    TAG_EXPANSION_INFO_INLINE => {
+                        let pos = self.position();
+                        let expn_info: ExpnInfo = Decodable::decode(self)?;
+                        let ctxt = SyntaxContext::allocate_directly(expn_info);
+                        self.synthetic_expansion_infos.insert(pos, ctxt);
+                        ctxt
+                    }
+                    TAG_EXPANSION_INFO_SHORTHAND => {
+                        let pos = usize::decode(self)?;
+                        if let Some(ctxt) = self.synthetic_expansion_infos.get(&pos).cloned() {
+                            ctxt
+                        } else {
+                            let expn_info = self.with_position(pos, |this| {
+                                 ExpnInfo::decode(this)
+                            })?;
+                            let ctxt = SyntaxContext::allocate_directly(expn_info);
+                            self.synthetic_expansion_infos.insert(pos, ctxt);
+                            ctxt
+                        }
+                    }
+                    _ => {
+                        unreachable!()
+                    }
+                };
+
+                return Ok(Span::new(lo, hi, ctxt));
             }
         }
 
@@ -479,6 +527,7 @@ impl<'a, 'tcx, 'x> SpecializedDecoder<DefIndex> for CacheDecoder<'a, 'tcx, 'x> {
 // compilation sessions. We use the DefPathHash, which is stable across
 // sessions, to map the old DefId to the new one.
 impl<'a, 'tcx, 'x> SpecializedDecoder<DefId> for CacheDecoder<'a, 'tcx, 'x> {
+    #[inline]
     fn specialized_decode(&mut self) -> Result<DefId, Self::Error> {
         // Load the DefPathHash which is was we encoded the DefId as.
         let def_path_hash = DefPathHash::decode(self)?;
@@ -489,6 +538,7 @@ impl<'a, 'tcx, 'x> SpecializedDecoder<DefId> for CacheDecoder<'a, 'tcx, 'x> {
 }
 
 impl<'a, 'tcx, 'x> SpecializedDecoder<LocalDefId> for CacheDecoder<'a, 'tcx, 'x> {
+    #[inline]
     fn specialized_decode(&mut self) -> Result<LocalDefId, Self::Error> {
         Ok(LocalDefId::from_def_id(DefId::decode(self)?))
     }
@@ -558,6 +608,7 @@ struct CacheEncoder<'enc, 'a, 'tcx, E>
     encoder: &'enc mut E,
     type_shorthands: FxHashMap<ty::Ty<'tcx>, usize>,
     predicate_shorthands: FxHashMap<ty::Predicate<'tcx>, usize>,
+    expn_info_shorthands: FxHashMap<Mark, usize>,
 }
 
 impl<'enc, 'a, 'tcx, E> CacheEncoder<'enc, 'a, 'tcx, E>
@@ -581,6 +632,37 @@ impl<'enc, 'a, 'tcx, E> CacheEncoder<'enc, 'a, 'tcx, E>
 
         let end_pos = self.position();
         ((end_pos - start_pos) as u64).encode(self)
+    }
+}
+
+impl<'enc, 'a, 'tcx, E> SpecializedEncoder<Span> for CacheEncoder<'enc, 'a, 'tcx, E>
+    where E: 'enc + ty_codec::TyEncoder
+{
+    fn specialized_encode(&mut self, span: &Span) -> Result<(), Self::Error> {
+        let span_data = span.data();
+
+        span_data.lo.encode(self)?;
+        span_data.hi.encode(self)?;
+
+        if span_data.ctxt == SyntaxContext::empty() {
+            TAG_NO_EXPANSION_INFO.encode(self)
+        } else {
+            let mark = span_data.ctxt.outer();
+
+            if let Some(expn_info) = mark.expn_info() {
+                if let Some(pos) = self.expn_info_shorthands.get(&mark).cloned() {
+                    TAG_EXPANSION_INFO_SHORTHAND.encode(self)?;
+                    pos.encode(self)
+                } else {
+                    TAG_EXPANSION_INFO_INLINE.encode(self)?;
+                    let pos = self.position();
+                    self.expn_info_shorthands.insert(mark, pos);
+                    expn_info.encode(self)
+                }
+            } else {
+                TAG_NO_EXPANSION_INFO.encode(self)
+            }
+        }
     }
 }
 

--- a/src/librustc/ty/maps/on_disk_cache.rs
+++ b/src/librustc/ty/maps/on_disk_cache.rs
@@ -291,10 +291,10 @@ impl<'sess> OnDiskCache<'sess> {
 
     /// Returns the cached query result if there is something in the cache for
     /// the given SerializedDepNodeIndex. Otherwise returns None.
-    pub fn try_load_query_result<'a, 'tcx, T>(&self,
-                                              tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                                              dep_node_index: SerializedDepNodeIndex)
-                                              -> Option<T>
+    pub fn try_load_query_result<'tcx, T>(&self,
+                                          tcx: TyCtxt<'_, 'tcx, 'tcx>,
+                                          dep_node_index: SerializedDepNodeIndex)
+                                          -> Option<T>
         where T: Decodable
     {
         self.load_indexed(tcx,
@@ -319,13 +319,13 @@ impl<'sess> OnDiskCache<'sess> {
         x.extend(diagnostics.into_iter());
     }
 
-    fn load_indexed<'a, 'tcx, T>(&self,
-                                 tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                                 dep_node_index: SerializedDepNodeIndex,
-                                 index: &FxHashMap<SerializedDepNodeIndex,
-                                                   AbsoluteBytePos>,
-                                 debug_tag: &'static str)
-                                 -> Option<T>
+    fn load_indexed<'tcx, T>(&self,
+                             tcx: TyCtxt<'_, 'tcx, 'tcx>,
+                             dep_node_index: SerializedDepNodeIndex,
+                             index: &FxHashMap<SerializedDepNodeIndex,
+                                               AbsoluteBytePos>,
+                             debug_tag: &'static str)
+                             -> Option<T>
         where T: Decodable
     {
         let pos = if let Some(&pos) = index.get(&dep_node_index) {

--- a/src/librustc/ty/maps/plumbing.rs
+++ b/src/librustc/ty/maps/plumbing.rs
@@ -392,12 +392,31 @@ macro_rules! define_maps {
             {
                 debug_assert!(tcx.dep_graph.is_green(dep_node_index));
 
-                let result = if tcx.sess.opts.debugging_opts.incremental_queries &&
-                                Self::cache_on_disk(key) {
+                // First we try to load the result from the on-disk cache
+                let result = if Self::cache_on_disk(key) &&
+                                tcx.sess.opts.debugging_opts.incremental_queries {
                     let prev_dep_node_index =
                         tcx.dep_graph.prev_dep_node_index_of(dep_node);
-                    Self::load_from_disk(tcx.global_tcx(), prev_dep_node_index)
+                    let result = Self::try_load_from_disk(tcx.global_tcx(),
+                                                          prev_dep_node_index);
+
+                    // We always expect to find a cached result for things that
+                    // can be forced from DepNode.
+                    debug_assert!(!dep_node.kind.can_reconstruct_query_key() ||
+                                  result.is_some(),
+                                  "Missing on-disk cache entry for {:?}",
+                                  dep_node);
+                    result
                 } else {
+                    // Some things are never cached on disk.
+                    None
+                };
+
+                let result = if let Some(result) = result {
+                    result
+                } else {
+                    // We could not load a result from the on-disk cache, so
+                    // recompute.
                     let (result, _ ) = tcx.cycle_check(span, Query::$name(key), || {
                         // The diagnostics for this query have already been
                         // promoted to the current session during

--- a/src/librustc/ty/maps/plumbing.rs
+++ b/src/librustc/ty/maps/plumbing.rs
@@ -145,7 +145,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                 if !self.dep_graph.is_fully_enabled() {
                     return None;
                 }
-                match self.dep_graph.try_mark_green(self, &dep_node) {
+                match self.dep_graph.try_mark_green(self.global_tcx(), &dep_node) {
                     Some(dep_node_index) => {
                         debug_assert!(self.dep_graph.is_green(dep_node_index));
                         self.dep_graph.read_index(dep_node_index);

--- a/src/libserialize/opaque.rs
+++ b/src/libserialize/opaque.rs
@@ -162,6 +162,10 @@ impl<'a> Decoder<'a> {
         self.position
     }
 
+    pub fn set_position(&mut self, pos: usize) {
+        self.position = pos
+    }
+
     pub fn advance(&mut self, bytes: usize) {
         self.position += bytes;
     }

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -105,7 +105,7 @@ impl FileLoader for RealFileLoader {
 // This is a FileMap identifier that is used to correlate FileMaps between
 // subsequent compilation sessions (which is something we need to do during
 // incremental compilation).
-#[derive(Copy, Clone, PartialEq, Eq, Hash, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, RustcEncodable, RustcDecodable, Debug)]
 pub struct StableFilemapId(u128);
 
 impl StableFilemapId {

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -931,6 +931,11 @@ impl FileMap {
             (lines[line_index], lines[line_index + 1])
         }
     }
+
+    #[inline]
+    pub fn contains(&self, byte_pos: BytePos) -> bool {
+        byte_pos >= self.start_pos && byte_pos <= self.end_pos
+    }
 }
 
 /// Remove utf-8 BOM if any.


### PR DESCRIPTION
This PR implements makes two changes:
1. Diagnostics are loaded lazily from the incr. comp. cache now. This turned out to be necessary for correctness because diagnostics contain `Span` values and deserializing those requires that the source file they point to is still around in the current compilation session. Obviously this isn't always the case. Loading them lazily allows for never touching diagnostics that are not valid anymore.
2. The compiler can now deal with there being no cache entry for a given query invocation. Before, all query results of a cacheable query were always expected to be present in the cache. Now, the compiler can fall back to re-computing the result if there is no cache entry found. This allows for caching things that we cannot force from dep-node (like the `symbol_name` query). In such a case we'll just have a "best effort" caching strategy.

~~This PR is based on https://github.com/rust-lang/rust/pull/46301 (=first 2 commits), so please don't merge until that has landed. The rest of the commits are ready for review though.~~

r? @nikomatsakis 