### PR TITLE
Size snapshot

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -450,6 +450,8 @@ impl Read for File {
     }
 
     fn size_snapshot(&self) -> Option<usize> {
+        // Ignore I/O errors; we're just querying the size and position of an
+        // already-open file in preparation for reading from it.
         if let Ok(meta) = self.metadata() {
             let len = meta.len();
             if let Ok(position) = self.inner.seek(SeekFrom::Current(0)) {

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -799,6 +799,8 @@ impl Metadata {
 
     /// Returns the size of the file, in bytes, this metadata is for.
     ///
+    /// As a special case, a size of `0` indicates that the size is unknown.
+    ///
     /// # Examples
     ///
     /// ```

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -211,6 +211,15 @@ impl<R: Read> Read for BufReader<R> {
         Ok(nread)
     }
 
+    #[inline]
+    fn size_snapshot(&self) -> Option<usize> {
+        let buffered_len = self.cap - self.pos;
+        if let Some(size) = self.inner.size_snapshot() {
+            return buffered_len.checked_add(size);
+        }
+        None
+    }
+
     // we can't skip unconditionally because of the large buffer case in read.
     unsafe fn initializer(&self) -> Initializer {
         self.inner.initializer()

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -237,6 +237,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
         Ok(())
     }
 
+    fn size_snapshot(&self) -> Option<usize> {
+        if let Some(diff) = (self.inner.as_ref().len() as u64).checked_sub(self.pos) {
+            let size = diff as usize;
+            if size as u64 == diff {
+                return Some(size);
+            }
+        }
+        None
+    }
+
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()

--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -24,6 +24,11 @@ impl<'a, R: Read + ?Sized> Read for &'a mut R {
     }
 
     #[inline]
+    fn size_snapshot(&self) -> Option<usize> {
+        (**self).size_snapshot()
+    }
+
+    #[inline]
     unsafe fn initializer(&self) -> Initializer {
         (**self).initializer()
     }
@@ -90,6 +95,11 @@ impl<R: Read + ?Sized> Read for Box<R> {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         (**self).read(buf)
+    }
+
+    #[inline]
+    fn size_snapshot(&self) -> Option<usize> {
+        (**self).size_snapshot()
     }
 
     #[inline]
@@ -179,6 +189,11 @@ impl<'a> Read for &'a [u8] {
 
         *self = b;
         Ok(amt)
+    }
+
+    #[inline]
+    fn size_snapshot(&self) -> Option<usize> {
+        Some(self.len())
     }
 
     #[inline]


### PR DESCRIPTION
This introduces `Read::size_snapshot()` and it modifies `read_to_end` to allocate exactly the number of required bytes up front, and read exactly the number of bytes at once, when possible.

`size_snapshot()` is not treated as a hint. In the common case, this allows it to do a single read syscall (compared to two in #45928, with the second one to confirm that EOF is reached), which roughly makes up for doing an extra syscall to get the size, and to request exactly the right size buffer (compared to requesting the size + 1 in #45928).

The main downside of this patch compared to #45928 is that it is possible to observe subtle behavior differences due to obtaining the size up front rather than waiting until read returns 0 in some specialized cases. That said, they all involve `read_to_end` racing with some independent writer, and the new consequences are just that `read_to_end` might return more of the old data than it should, or less of the new data than it should, if one knows enough about the underlying OS to reason about what "should" be possible.

This patch also depends on `metadata()` being reliable and not memoized. On OS's I'm familiar with it's reliable (when the size isn't 0). And in the current codebase, it's not memoized.

EDITED: #45928 now requests `size_hint + 1` bytes, fixing the main performance difference.