### PR TITLE
Change const error message to use 'literal'

### DIFF
--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -796,7 +796,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Qualifier<'a, 'tcx, 'tcx> {
                     let (msg, note) = if let UnstableFeatures::Disallow =
                             self.tcx.sess.opts.unstable_features {
                         (format!("calls in {}s are limited to \
-                                  struct and enum constructors",
+                                  struct and enum literals",
                                  self.mode),
                          Some("a limited form of compile-time function \
                                evaluation is available on a nightly \
@@ -804,7 +804,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Qualifier<'a, 'tcx, 'tcx> {
                     } else {
                         (format!("calls in {}s are limited \
                                   to constant functions, \
-                                  struct and enum constructors",
+                                  struct and enum literals",
                                  self.mode),
                          None)
                     };


### PR DESCRIPTION
The verbiage for E0015 ("calls in constants are limited to...") gives "struct and enum constructors" as a suggestion. The word "constructor," while a good descriptor for a particular concept in Rust, also describes a special class of user-defined functions in other languages. This commit substitutes the word "literal" in place of the word "constructor" in an effort to allay potential confusion.

[Related issue here.](https://github.com/rust-lang/rust/issues/46336)