### PR TITLE
On type errors, show closure signature

### DIFF
--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1440,8 +1440,13 @@ pub struct Ty {
 
 impl fmt::Debug for Ty {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "type({})",
-               print::to_string(print::NO_ANN, |s| s.print_type(self)))
+        write!(f, "type({})", print::to_string(print::NO_ANN, |s| s.print_type(self)))
+    }
+}
+
+impl fmt::Display for Ty {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", print::to_string(print::NO_ANN, |s| s.print_type(self)))
     }
 }
 

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -588,6 +588,28 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             s.push_normal(format!("{}", tnm.ty));
         }
 
+        fn push_closure<'tcx>(capture: &hir::CaptureClause,
+                              fn_decl: &hir::FnDecl,
+                              s: &mut DiagnosticStyledString) {
+            let args = fn_decl.inputs.iter()
+                .map(|arg| format!("{}", arg))
+                .collect::<Vec<String>>()
+                .join(", ");
+            s.push_highlighted(
+                format!("{}|{}| -> {}",
+                        if capture == &hir::CaptureByValue {
+                            "move "
+                        } else {
+                            ""
+                        },
+                        args,
+                        if let hir::Return(ref r_ty) = fn_decl.output {
+                            format!("{}", r_ty)
+                        } else {
+                            "_".to_string()
+                        }));
+        }
+
         match (&t1.sty, &t2.sty) {
             (&ty::TyAdt(def1, sub1), &ty::TyAdt(def2, sub2)) => {
                 let mut values = (DiagnosticStyledString::new(), DiagnosticStyledString::new());
@@ -728,35 +750,62 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                 values
             }
             // When comparing against a closure, print its signature without location
+            (&ty::TyClosure(did1, _), &ty::TyClosure(did2, _)) => {
+                let mut values = (DiagnosticStyledString::new(), DiagnosticStyledString::new());
+                let mut success = false;
+                if let Some(node_id) = self.tcx.hir.as_local_node_id(did1) {
+                    if let Some(hir::map::NodeExpr(expr)) = self.tcx.hir.find(node_id) {
+                        if let hir::ExprClosure(capture, ref fn_decl, _, _, _) = expr.node {
+                            push_closure(&capture, fn_decl, &mut values.0);
+                            success = true;
+                        }
+                    }
+                }
+                if !success { // fallback
+                    values.0.push_highlighted(format!("{}", t1));
+                }
+                success = false;
+                if let Some(node_id) = self.tcx.hir.as_local_node_id(did2) {
+                    if let Some(hir::map::NodeExpr(expr)) = self.tcx.hir.find(node_id) {
+                        if let hir::ExprClosure(capture, ref fn_decl, _, _, _) = expr.node {
+                            push_closure(&capture, fn_decl, &mut values.1);
+                            success = true;
+                        }
+                    }
+                }
+                if !success { // fallback
+                    values.1.push_highlighted(format!("{}", t2));
+                }
+                values
+            }
             (_, &ty::TyClosure(did, _)) => {
                 let mut values = (DiagnosticStyledString::highlighted(format!("{}", t1)),
                                   DiagnosticStyledString::new());
                 if let Some(node_id) = self.tcx.hir.as_local_node_id(did) {
                     if let Some(hir::map::NodeExpr(expr)) = self.tcx.hir.find(node_id) {
                         if let hir::ExprClosure(capture, ref fn_decl, _, _, _) = expr.node {
-                            let args = fn_decl.inputs.iter()
-                                .map(|arg| format!("{}", arg))
-                                .collect::<Vec<String>>()
-                                .join(", ");
-                            values.1.push_highlighted(
-                                format!("{}fn({}) -> {}",
-                                        if capture == hir::CaptureByValue {
-                                            "move "
-                                        } else {
-                                            ""
-                                        },
-                                        args,
-                                        if let hir::Return(ref r_ty) = fn_decl.output {
-                                            format!("{}", r_ty)
-                                        } else {
-                                            "_".to_string()
-                                        }));
+                            push_closure(&capture, fn_decl, &mut values.1);
                             return values;
                         }
                     }
                 }
                 // fallback
                 values.1.push_highlighted(format!("{}", t2));
+                values
+            }
+            (&ty::TyClosure(did, _), _) => {
+                let mut values = (DiagnosticStyledString::new(),
+                                  DiagnosticStyledString::highlighted(format!("{}", t2)));
+                if let Some(node_id) = self.tcx.hir.as_local_node_id(did) {
+                    if let Some(hir::map::NodeExpr(expr)) = self.tcx.hir.find(node_id) {
+                        if let hir::ExprClosure(capture, ref fn_decl, _, _, _) = expr.node {
+                            push_closure(&capture, fn_decl, &mut values.0);
+                            return values;
+                        }
+                    }
+                }
+                // fallback
+                values.0.push_highlighted(format!("{}", t1));
                 values
             }
 

--- a/src/test/compile-fail/issue-24036.rs
+++ b/src/test/compile-fail/issue-24036.rs
@@ -16,7 +16,7 @@ fn closure_to_loc() {
     //~| HELP consider boxing your closure and/or using it as a trait object
     //~| expected closure, found a different closure
     //~| expected type `[closure
-    //~| found type `[closure
+    //~| found type `fn(_) -> _`
 }
 
 fn closure_from_match() {
@@ -31,7 +31,7 @@ fn closure_from_match() {
     //~| HELP consider boxing your closure and/or using it as a trait object
     //~| expected closure, found a different closure
     //~| expected type `[closure
-    //~| found type `[closure
+    //~| found type `fn(_) -> _`
 }
 
 fn main() { }

--- a/src/test/compile-fail/issue-24036.rs
+++ b/src/test/compile-fail/issue-24036.rs
@@ -10,28 +10,29 @@
 
 fn closure_to_loc() {
     let mut x = |c| c + 1;
+    //~^ NOTE this closure was expected
     x = |c| c + 1;
     //~^ ERROR mismatched types
     //~| NOTE no two closures, even if identical, have the same type
     //~| HELP consider boxing your closure and/or using it as a trait object
     //~| expected closure, found a different closure
-    //~| expected type `[closure
-    //~| found type `fn(_) -> _`
+    //~| expected type `|_| -> _`
+    //~| found type `|_| -> _`
 }
 
 fn closure_from_match() {
     let x = match 1usize {
+        //~^ ERROR match arms have incompatible types
+        //~| NOTE no two closures, even if identical, have the same type
+        //~| HELP consider boxing your closure and/or using it as a trait object
+        //~| NOTE expected closure, found a different closure
+        //~| NOTE expected type `|_| -> _` (closure)
         1 => |c| c + 1,
+        //~^ NOTE this closure was expected
         2 => |c| c - 1,
         //~^ NOTE match arm with an incompatible type
         _ => |c| c - 1
     };
-    //~^^^^^^ ERROR match arms have incompatible types
-    //~| NOTE no two closures, even if identical, have the same type
-    //~| HELP consider boxing your closure and/or using it as a trait object
-    //~| expected closure, found a different closure
-    //~| expected type `[closure
-    //~| found type `fn(_) -> _`
 }
 
 fn main() { }

--- a/src/test/ui/block-result/issue-20862.stderr
+++ b/src/test/ui/block-result/issue-20862.stderr
@@ -7,7 +7,7 @@ error[E0308]: mismatched types
    |     ^^^^^^^^^ expected (), found closure
    |
    = note: expected type `()`
-              found type `fn(_) -> _`
+              found type `|_| -> _`
 
 error[E0618]: expected function, found `()`
   --> $DIR/issue-20862.rs:17:13

--- a/src/test/ui/block-result/issue-20862.stderr
+++ b/src/test/ui/block-result/issue-20862.stderr
@@ -7,7 +7,7 @@ error[E0308]: mismatched types
    |     ^^^^^^^^^ expected (), found closure
    |
    = note: expected type `()`
-              found type `[closure@$DIR/issue-20862.rs:12:5: 12:14 x:_]`
+              found type `fn(_) -> _`
 
 error[E0618]: expected function, found `()`
   --> $DIR/issue-20862.rs:17:13

--- a/src/test/ui/span/move-closure.stderr
+++ b/src/test/ui/span/move-closure.stderr
@@ -5,7 +5,7 @@ error[E0308]: mismatched types
    |                 ^^^^^^^^^^ expected (), found closure
    |
    = note: expected type `()`
-              found type `[closure@$DIR/move-closure.rs:15:17: 15:27]`
+              found type `move fn() -> _`
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/move-closure.stderr
+++ b/src/test/ui/span/move-closure.stderr
@@ -5,7 +5,7 @@ error[E0308]: mismatched types
    |                 ^^^^^^^^^^ expected (), found closure
    |
    = note: expected type `()`
-              found type `move fn() -> _`
+              found type `move || -> _`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Instead of referring to closures with their span, format their signature.

r? @nikomatsakis 

Fix #19939.