### PR TITLE
Deploy builds both with asserts enabled and asserts disabled to CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       if: type = pull_request OR branch = auto
 
     - env: IMAGE=dist-x86_64-linux DEPLOY=1
-      if: branch = auto
+      if: branch = try OR branch = auto
 
     # "alternate" deployments, these are "nightlies" but don't have assertions
     # turned on, they're deployed to a different location primarily for projects
@@ -310,20 +310,6 @@ deploy:
       branch: auto
       condition: $DEPLOY = 1
 
-  - provider: s3
-    bucket: rust-lang-ci2
-    skip_cleanup: true
-    local_dir: deploy
-    upload_dir: rustc-builds-try
-    acl: public_read
-    region: us-west-1
-    access_key_id: AKIAJVBODR3IA4O72THQ
-    secret_access_key:
-      secure: "kUGd3t7JcVWFESgIlzvsM8viZgCA9Encs3creW0xLJaLSeI1iVjlJK4h/2/nO6y224AFrh/GUfsNr4/4AlxPuYb8OU5oC5Lv+Ff2JiRDYtuNpyQSKAQp+bRYytWMtrmhja91h118Mbm90cUfcLPwkdiINgJNTXhPKg5Cqu3VYn0="
-    on:
-      branch: try
-      condition: $DEPLOY_ALT = 1
-
   # this is the same as the above deployment provider except that it uploads to
   # a slightly different directory and has a different trigger
   - provider: s3
@@ -338,4 +324,35 @@ deploy:
       secure: "kUGd3t7JcVWFESgIlzvsM8viZgCA9Encs3creW0xLJaLSeI1iVjlJK4h/2/nO6y224AFrh/GUfsNr4/4AlxPuYb8OU5oC5Lv+Ff2JiRDYtuNpyQSKAQp+bRYytWMtrmhja91h118Mbm90cUfcLPwkdiINgJNTXhPKg5Cqu3VYn0="
     on:
       branch: auto
+      condition: $DEPLOY_ALT = 1
+
+  # These two providers are the same as the two above, except deploy on the
+  # try branch. Travis does not appear to provide a way to use "or" in these
+  # conditions.
+  - provider: s3
+    bucket: rust-lang-ci2
+    skip_cleanup: true
+    local_dir: deploy
+    upload_dir: rustc-builds
+    acl: public_read
+    region: us-west-1
+    access_key_id: AKIAJVBODR3IA4O72THQ
+    secret_access_key:
+      secure: "kUGd3t7JcVWFESgIlzvsM8viZgCA9Encs3creW0xLJaLSeI1iVjlJK4h/2/nO6y224AFrh/GUfsNr4/4AlxPuYb8OU5oC5Lv+Ff2JiRDYtuNpyQSKAQp+bRYytWMtrmhja91h118Mbm90cUfcLPwkdiINgJNTXhPKg5Cqu3VYn0="
+    on:
+      branch: try
+      condition: $DEPLOY = 1
+
+  - provider: s3
+    bucket: rust-lang-ci2
+    skip_cleanup: true
+    local_dir: deploy
+    upload_dir: rustc-builds-alt
+    acl: public_read
+    region: us-west-1
+    access_key_id: AKIAJVBODR3IA4O72THQ
+    secret_access_key:
+      secure: "kUGd3t7JcVWFESgIlzvsM8viZgCA9Encs3creW0xLJaLSeI1iVjlJK4h/2/nO6y224AFrh/GUfsNr4/4AlxPuYb8OU5oC5Lv+Ff2JiRDYtuNpyQSKAQp+bRYytWMtrmhja91h118Mbm90cUfcLPwkdiINgJNTXhPKg5Cqu3VYn0="
+    on:
+      branch: try
       condition: $DEPLOY_ALT = 1


### PR DESCRIPTION
This also removes uploads to the 'try' bucket, and instead dumps
everything into the two rustc-builds and rustc-builds-alt buckets. This
makes lives easier, as there is only one location for a given "type" of
build, and since we have the git commit hash in the filenames, this is
fine; we won't run into uploads of the same commit.

cc @aidanhs -- this will break crater's logic for downloading `try#xxx` commits since the try bucket won't be uploaded into 

r? @alexcrichton 