### PR TITLE
Reject '2' as a binary digit in internals of b: number formatting

### DIFF
--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -134,7 +134,7 @@ macro_rules! radix {
     }
 }
 
-radix! { Binary,    2, "0b", x @  0 ...  2 => b'0' + x }
+radix! { Binary,    2, "0b", x @  0 ...  1 => b'0' + x }
 radix! { Octal,     8, "0o", x @  0 ...  7 => b'0' + x }
 radix! { Decimal,  10, "",   x @  0 ...  9 => b'0' + x }
 radix! { LowerHex, 16, "0x", x @  0 ...  9 => b'0' + x,


### PR DESCRIPTION
The `radix!` macro generates an implementation of the private trait `GenericRadix`, and the code replaced changes Binary's implementation to no longer accept '2' as a valid digit to print.

Granted, this code is literally only ever called from another method in this private trait, and that method has logic to never hand a '2' to the printing function. Even given this, the code's there, I thought it would be best to fix this for clarity of anyone reading it.