### PR TITLE
Revert #46360, re-enable macOS dist images.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ matrix:
     - env: IMAGE=dist-x86_64-linux DEPLOY_ALT=1
       if: branch = try OR branch = auto
 
-    # FIXME: The macOS dist images are temporarily disabled until Travis bug is fixed
-    # https://github.com/travis-ci/travis-ci/issues/8821
     - env: >
         RUST_CHECK_TARGET=dist
         RUST_CONFIGURE_ARGS="--enable-extended --enable-profiler"
@@ -39,7 +37,7 @@ matrix:
         NO_DEBUG_ASSERTIONS=1
       os: osx
       osx_image: xcode7.3
-      if: branch = disabled
+      if: branch = auto
 
     # macOS builders. These are placed near the beginning because they are very
     # slow to run.
@@ -94,7 +92,7 @@ matrix:
         NO_DEBUG_ASSERTIONS=1
       os: osx
       osx_image: xcode7.3
-      if: branch = disabled
+      if: branch = auto
 
     - env: >
         RUST_CHECK_TARGET=dist
@@ -108,7 +106,7 @@ matrix:
         NO_DEBUG_ASSERTIONS=1
       os: osx
       osx_image: xcode7.3
-      if: branch = disabled
+      if: branch = auto
 
     # Linux builders, remaining docker images
     - env: IMAGE=arm-android


### PR DESCRIPTION
This PR reverts #46360, which disabled all macOS dist images to workaround travis-ci/travis-ci#8821. 

This PR should be merged as soon as the Travis bug has been fixed.

Closes #46357.

cc @rust-lang/infra 