### PR TITLE
incr.comp.: Remove an unnecessary HIR access which enables hashing spans for type definitions.

### DIFF
--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -884,13 +884,13 @@ impl<'gcx> HashStable<StableHashingContext<'gcx>> for hir::Item {
     fn hash_stable<W: StableHasherResult>(&self,
                                           hcx: &mut StableHashingContext<'gcx>,
                                           hasher: &mut StableHasher<W>) {
-        let (is_const, hash_spans) = match self.node {
+        let is_const = match self.node {
             hir::ItemStatic(..)      |
             hir::ItemConst(..)       => {
-                (true, hcx.hash_spans())
+                true
             }
             hir::ItemFn(_, _, constness, ..) => {
-                (constness == hir::Constness::Const, hcx.hash_spans())
+                constness == hir::Constness::Const
             }
             hir::ItemUse(..)         |
             hir::ItemExternCrate(..) |
@@ -904,7 +904,7 @@ impl<'gcx> HashStable<StableHashingContext<'gcx>> for hir::Item {
             hir::ItemEnum(..)        |
             hir::ItemStruct(..)      |
             hir::ItemUnion(..)       => {
-                (false, false)
+                false
             }
         };
 
@@ -919,13 +919,11 @@ impl<'gcx> HashStable<StableHashingContext<'gcx>> for hir::Item {
         } = *self;
 
         hcx.hash_hir_item_like(attrs, is_const, |hcx| {
-            hcx.while_hashing_spans(hash_spans, |hcx| {
-                name.hash_stable(hcx, hasher);
-                attrs.hash_stable(hcx, hasher);
-                node.hash_stable(hcx, hasher);
-                vis.hash_stable(hcx, hasher);
-                span.hash_stable(hcx, hasher);
-            });
+            name.hash_stable(hcx, hasher);
+            attrs.hash_stable(hcx, hasher);
+            node.hash_stable(hcx, hasher);
+            vis.hash_stable(hcx, hasher);
+            span.hash_stable(hcx, hasher);
         });
     }
 }

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2302,9 +2302,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     }
 
     pub fn item_name(self, id: DefId) -> InternedString {
-        if let Some(id) = self.hir.as_local_node_id(id) {
-            self.hir.name(id).as_str()
-        } else if id.index == CRATE_DEF_INDEX {
+        if id.index == CRATE_DEF_INDEX {
             self.original_crate_name(id.krate).as_str()
         } else {
             let def_key = self.def_key(id);


### PR DESCRIPTION
r? @nikomatsakis 