### PR TITLE
rustdoc: Fix issues with cross-crate inlined associated items

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -332,74 +332,10 @@ pub fn build_impl(cx: &DocContext, did: DefId, ret: &mut Vec<clean::Item>) {
 
     let predicates = tcx.predicates_of(did);
     let trait_items = tcx.associated_items(did).filter_map(|item| {
-        match item.kind {
-            ty::AssociatedKind::Const => {
-                let default = if item.defaultness.has_value() {
-                    Some(print_inlined_const(cx, item.def_id))
-                } else {
-                    None
-                };
-                Some(clean::Item {
-                    name: Some(item.name.clean(cx)),
-                    inner: clean::AssociatedConstItem(
-                        tcx.type_of(item.def_id).clean(cx),
-                        default,
-                    ),
-                    source: tcx.def_span(item.def_id).clean(cx),
-                    attrs: clean::Attributes::default(),
-                    visibility: None,
-                    stability: tcx.lookup_stability(item.def_id).clean(cx),
-                    deprecation: tcx.lookup_deprecation(item.def_id).clean(cx),
-                    def_id: item.def_id
-                })
-            }
-            ty::AssociatedKind::Method => {
-                if item.vis != ty::Visibility::Public && associated_trait.is_none() {
-                    return None
-                }
-                let mut cleaned = item.clean(cx);
-                cleaned.inner = match cleaned.inner.clone() {
-                    clean::TyMethodItem(clean::TyMethod {
-                        unsafety, decl, generics, abi
-                    }) => {
-                        let constness = if tcx.is_const_fn(item.def_id) {
-                            hir::Constness::Const
-                        } else {
-                            hir::Constness::NotConst
-                        };
-
-                        clean::MethodItem(clean::Method {
-                            unsafety,
-                            constness,
-                            decl,
-                            generics,
-                            abi,
-                        })
-                    }
-                    ref r => panic!("not a tymethod: {:?}", r),
-                };
-                Some(cleaned)
-            }
-            ty::AssociatedKind::Type => {
-                let typedef = clean::Typedef {
-                    type_: tcx.type_of(item.def_id).clean(cx),
-                    generics: clean::Generics {
-                        lifetimes: vec![],
-                        type_params: vec![],
-                        where_predicates: vec![]
-                    }
-                };
-                Some(clean::Item {
-                    name: Some(item.name.clean(cx)),
-                    inner: clean::TypedefItem(typedef, true),
-                    source: tcx.def_span(item.def_id).clean(cx),
-                    attrs: clean::Attributes::default(),
-                    visibility: None,
-                    stability: tcx.lookup_stability(item.def_id).clean(cx),
-                    deprecation: tcx.lookup_deprecation(item.def_id).clean(cx),
-                    def_id: item.def_id
-                })
-            }
+        if associated_trait.is_some() || item.vis == ty::Visibility::Public {
+            Some(item.clean(cx))
+        } else {
+            None
         }
     }).collect::<Vec<_>>();
     let polarity = tcx.impl_polarity(did);

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2621,7 +2621,8 @@ fn assoc_const(w: &mut fmt::Formatter,
                ty: &clean::Type,
                _default: Option<&String>,
                link: AssocItemLink) -> fmt::Result {
-    write!(w, "const <a href='{}' class=\"constant\"><b>{}</b></a>: {}",
+    write!(w, "{}const <a href='{}' class=\"constant\"><b>{}</b></a>: {}",
+           VisSpace(&it.visibility),
            naive_assoc_href(it, link),
            it.name.as_ref().unwrap(),
            ty)?;

--- a/src/test/rustdoc/inline_cross/assoc-items.rs
+++ b/src/test/rustdoc/inline_cross/assoc-items.rs
@@ -1,0 +1,57 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:assoc-items.rs
+// build-aux-docs
+// ignore-cross-compile
+
+#![crate_name = "foo"]
+
+extern crate assoc_items;
+
+// @has foo/struct.MyStruct.html
+// @!has - 'PrivateConst'
+// @has - '//*[@id="associatedconstant.PublicConst"]' 'pub const PublicConst: u8'
+// @has - '//*[@class="docblock"]' 'PublicConst: u8 = 123'
+// @has - '//*[@class="docblock"]' 'docs for PublicConst'
+// @!has - 'private_method'
+// @has - '//*[@id="method.public_method"]' 'pub fn public_method()'
+// @has - '//*[@class="docblock"]' 'docs for public_method'
+// @has - '//*[@id="associatedconstant.ConstNoDefault"]' 'const ConstNoDefault: i16'
+// @has - '//*[@class="docblock"]' 'ConstNoDefault: i16 = -123'
+// @has - '//*[@class="docblock"]' 'dox for ConstNoDefault'
+// @has - '//*[@id="associatedconstant.ConstWithDefault"]' 'const ConstWithDefault: u16'
+// @has - '//*[@class="docblock"]' 'ConstWithDefault: u16 = 12345'
+// @has - '//*[@class="docblock"]' 'docs for ConstWithDefault'
+// @has - '//*[@id="associatedtype.TypeNoDefault"]' 'type TypeNoDefault = i32'
+// @has - '//*[@class="docblock"]' 'dox for TypeNoDefault'
+// @has - '//*[@id="associatedtype.TypeWithDefault"]' 'type TypeWithDefault = u32'
+// @has - '//*[@class="docblock"]' 'docs for TypeWithDefault'
+// @has - '//*[@id="method.method_no_default"]' 'fn method_no_default()'
+// @has - '//*[@class="docblock"]' 'dox for method_no_default'
+// @has - '//*[@id="method.method_with_default"]' 'fn method_with_default()'
+// @has - '//*[@class="docblock"]' 'docs for method_with_default'
+pub use assoc_items::MyStruct;
+
+// @has foo/trait.MyTrait.html
+// @has - '//*[@id="associatedconstant.ConstNoDefault"]' 'const ConstNoDefault: i16'
+// @has - '//*[@class="docblock"]' 'docs for ConstNoDefault'
+// @has - '//*[@id="associatedconstant.ConstWithDefault"]' 'const ConstWithDefault: u16'
+// @has - '//*[@class="docblock"]' 'ConstWithDefault: u16 = 12345'
+// @has - '//*[@class="docblock"]' 'docs for ConstWithDefault'
+// @has - '//*[@id="associatedtype.TypeNoDefault"]' 'type TypeNoDefault'
+// @has - '//*[@class="docblock"]' 'docs for TypeNoDefault'
+// @has - '//*[@id="associatedtype.TypeWithDefault"]' 'type TypeWithDefault = u32'
+// @has - '//*[@class="docblock"]' 'docs for TypeWithDefault'
+// @has - '//*[@id="tymethod.method_no_default"]' 'fn method_no_default()'
+// @has - '//*[@class="docblock"]' 'docs for method_no_default'
+// @has - '//*[@id="method.method_with_default"]' 'fn method_with_default()'
+// @has - '//*[@class="docblock"]' 'docs for method_with_default'
+pub use assoc_items::MyTrait;

--- a/src/test/rustdoc/inline_cross/auxiliary/assoc-items.rs
+++ b/src/test/rustdoc/inline_cross/auxiliary/assoc-items.rs
@@ -1,0 +1,48 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(associated_type_defaults)]
+
+pub struct MyStruct;
+
+impl MyStruct {
+    /// docs for PrivateConst
+    const PrivateConst: i8 = -123;
+    /// docs for PublicConst
+    pub const PublicConst: u8 = 123;
+    /// docs for private_method
+    fn private_method() {}
+    /// docs for public_method
+    pub fn public_method() {}
+}
+
+pub trait MyTrait {
+    /// docs for ConstNoDefault
+    const ConstNoDefault: i16;
+    /// docs for ConstWithDefault
+    const ConstWithDefault: u16 = 12345;
+    /// docs for TypeNoDefault
+    type TypeNoDefault;
+    /// docs for TypeWithDefault
+    type TypeWithDefault = u32;
+    /// docs for method_no_default
+    fn method_no_default();
+    /// docs for method_with_default
+    fn method_with_default() {}
+}
+
+impl MyTrait for MyStruct {
+    /// dox for ConstNoDefault
+    const ConstNoDefault: i16 = -12345;
+    /// dox for TypeNoDefault
+    type TypeNoDefault = i32;
+    /// dox for method_no_default
+    fn method_no_default() {}
+}


### PR DESCRIPTION
* Visibility was missing from impl items.
* Attributes and docs were missing from consts and types in impls.
* Const default values were missing from traits.

This unifies the code that handles associated items from impls and traits.