### PR TITLE
rustbuild: Fix a typo with the Cargo book

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -159,7 +159,7 @@ impl Step for CargoBook {
 
         let target = self.target;
         let name = self.name;
-        let src = PathBuf::from("src/tools/cargo/src/doc/book");
+        let src = build.src.join("src/tools/cargo/src/doc/book");
 
         let out = build.doc_out(target);
         t!(fs::create_dir_all(&out));


### PR DESCRIPTION
The usage of `Path::new` prevented out-of-tree builds (like the bots do) from
working by accident!

Closes #46195