### PR TITLE
Remove librustdoc dependency on env_logger

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1966,7 +1966,6 @@ version = "0.0.0"
 dependencies = [
  "build_helper 0.1.0",
  "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "html-diff 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -11,7 +11,6 @@ path = "lib.rs"
 doctest = false
 
 [dependencies]
-env_logger = { version = "0.4", default-features = false }
 log = "0.3"
 pulldown-cmark = { version = "0.1.0", default-features = false }
 html-diff = "0.0.5"


### PR DESCRIPTION
We want librustdoc to pickup the env_logger dependency from
the sysroot. This ensures that the same copy of env_logger is used
for both internal crates (e.g. librustc_driver, libsyntax) and
librustdoc

Closes #46383