### PR TITLE
Fix rustdoc item summaries that are headers

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1819,7 +1819,9 @@ fn full_path(cx: &Context, item: &clean::Item) -> String {
 
 fn shorter<'a>(s: Option<&'a str>) -> String {
     match s {
-        Some(s) => s.lines().take_while(|line|{
+        Some(s) => s.lines()
+            .skip_while(|s| s.chars().all(|c| c.is_whitespace()))
+            .take_while(|line|{
             (*line).chars().any(|chr|{
                 !chr.is_whitespace()
             })

--- a/src/test/rustdoc/issue-46377.rs
+++ b/src/test/rustdoc/issue-46377.rs
@@ -1,0 +1,13 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// @has 'issue_46377/index.html' '//*[@class="docblock-short"]' 'Check out this struct!'
+/// # Check out this struct!
+pub struct SomeStruct;


### PR DESCRIPTION
Rustoc item summaries that are headers were not displayed at all because
they started with whitespace.

This PR fixes this and now removes the whitespace and then displays the
block.

I'm not sure if the rustdoc test is written correctly, if there's anything to improve, just let me know. :)

This fixes #46377.

This is how it looks when rendered out now:
![Rendered](https://i.imgur.com/7u8jUAM.png)