### PR TITLE
[auto-toolstate][2+3/8] Move external tools tests into its own job with --no-fail-fast

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -168,7 +168,7 @@ matrix:
       if: branch = auto
     - env: IMAGE=x86_64-gnu-aux
       if: branch = auto
-    - env: IMAGE=x86_64-gnu-cargotest
+    - env: IMAGE=x86_64-gnu-tools
       if: branch = auto
     - env: IMAGE=x86_64-gnu-debug
       if: branch = auto

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,9 +25,14 @@ environment:
     RUST_CHECK_TARGET: check-aux
     RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc
 
-  # MSVC cargotest
+  # MSVC tools tests
   - MSYS_BITS: 64
-    SCRIPT: python x.py test src/tools/cargotest
+    SCRIPT: >
+      python x.py test --no-fail-fast
+        src/tools/rls
+        src/tools/rustfmt
+        src/tools/miri
+        src/tools/clippy
     RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc
 
   # 32/64-bit MinGW builds.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,13 +27,8 @@ environment:
 
   # MSVC tools tests
   - MSYS_BITS: 64
-    SCRIPT: >
-      python x.py test --no-fail-fast
-        src/tools/rls
-        src/tools/rustfmt
-        src/tools/miri
-        src/tools/clippy
-    RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc
+    SCRIPT: src/ci/docker/x86_64-gnu-tools/checktools.sh x.py toolstates.json
+    RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --save-toolstates=toolstates.json
 
   # 32/64-bit MinGW builds.
   #

--- a/config.toml.example
+++ b/config.toml.example
@@ -301,6 +301,10 @@
 # As a side-effect also generates MIR for all libraries.
 #test-miri = false
 
+# After building or testing extended tools (e.g. clippy and rustfmt), append the
+# result (broken, compiling, testing) into this JSON file.
+#save-toolstates = "/path/to/toolstates.json"
+
 # =============================================================================
 # Options for specific targets
 #

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -112,6 +112,8 @@ pub struct Config {
     pub channel: String,
     pub quiet_tests: bool,
     pub test_miri: bool,
+    pub save_toolstates: Option<PathBuf>,
+
     // Fallback musl-root for all targets
     pub musl_root: Option<PathBuf>,
     pub prefix: Option<PathBuf>,
@@ -279,6 +281,7 @@ struct Rust {
     dist_src: Option<bool>,
     quiet_tests: Option<bool>,
     test_miri: Option<bool>,
+    save_toolstates: Option<String>,
 }
 
 /// TOML representation of how each build target is configured.
@@ -473,6 +476,7 @@ impl Config {
             set(&mut config.test_miri, rust.test_miri);
             config.rustc_default_linker = rust.default_linker.clone();
             config.musl_root = rust.musl_root.clone().map(PathBuf::from);
+            config.save_toolstates = rust.save_toolstates.clone().map(PathBuf::from);
 
             match rust.codegen_units {
                 Some(0) => config.rust_codegen_units = Some(num_cpus::get() as u32),

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -77,6 +77,7 @@ o("debuginfo", "rust.debuginfo", "build with debugger metadata")
 o("debuginfo-lines", "rust.debuginfo-lines", "build with line number debugger metadata")
 o("debuginfo-only-std", "rust.debuginfo-only-std", "build only libstd with debugging information")
 o("debug-jemalloc", "rust.debug-jemalloc", "build jemalloc with --enable-debug --enable-fill")
+v("save-toolstates", "rust.save-toolstates", "save build and test status of external tools into this file")
 
 v("prefix", "install.prefix", "set installation prefix")
 v("localstatedir", "install.localstatedir", "local state directory")

--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -53,9 +53,7 @@ check:
 check-aux:
 	$(Q)$(BOOTSTRAP) test \
 		src/tools/cargo \
-		src/tools/rls \
-		src/tools/rustfmt \
-		src/tools/miri \
+		src/tools/cargotest \
 		src/test/pretty \
 		src/test/run-pass/pretty \
 		src/test/run-fail/pretty \

--- a/src/bootstrap/toolstate.rs
+++ b/src/bootstrap/toolstate.rs
@@ -10,7 +10,7 @@
 
 use build_helper::BuildExpectation;
 
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 /// Whether a tool can be compiled, tested or neither
 pub enum ToolState {
     /// The tool compiles successfully, but the test suite fails

--- a/src/ci/docker/x86_64-gnu-aux/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-aux/Dockerfile
@@ -12,7 +12,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libssl-dev \
   sudo \
   xz-utils \
-  pkg-config
+  pkg-config \
+  libgl1-mesa-dev \
+  llvm-dev \
+  libfreetype6-dev \
+  libexpat1-dev
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/ci/docker/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-tools/Dockerfile
@@ -12,14 +12,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libssl-dev \
   sudo \
   xz-utils \
-  pkg-config \
-  libgl1-mesa-dev \
-  llvm-dev \
-  libfreetype6-dev \
-  libexpat1-dev
+  pkg-config
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu
-ENV SCRIPT python2.7 ../x.py test src/tools/cargotest
+ENV SCRIPT python2.7 ../x.py --no-fail-fast \
+  src/tools/rls \
+  src/tools/rustfmt \
+  src/tools/miri \
+  src/tools/clippy

--- a/src/ci/docker/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-tools/Dockerfile
@@ -17,9 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu
-ENV SCRIPT python2.7 ../x.py --no-fail-fast \
-  src/tools/rls \
-  src/tools/rustfmt \
-  src/tools/miri \
-  src/tools/clippy
+COPY x86_64-gnu-tools/checktools.sh /tmp/
+
+ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu --save-toolstates=/tmp/toolstates.json
+ENV SCRIPT /tmp/checktools.sh ../x.py /tmp/toolstates.json

--- a/src/ci/docker/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/x86_64-gnu-tools/checktools.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+set -eu
+
+X_PY="$1"
+TOOLSTATE_FILE="$2"
+
+touch "$TOOLSTATE_FILE"
+
+set +e
+python2.7 "$X_PY" test --no-fail-fast \
+    src/tools/rls \
+    src/tools/rustfmt \
+    src/tools/miri \
+    src/tools/clippy
+TEST_RESULT=$?
+set -e
+
+# FIXME: Upload this file to the repository.
+cat "$TOOLSTATE_FILE"
+
+# FIXME: After we can properly inform dev-tool maintainers about failure,
+#        comment out the `exit 0` below.
+if [ "$RUST_RELEASE_CHANNEL" = nightly ]; then
+    # exit 0
+    true
+fi
+
+exit $TEST_RESULT

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -42,8 +42,9 @@ fi
 #
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
+export RUST_RELEASE_CHANNEL=nightly
 if [ "$DEPLOY$DEPLOY_ALT" != "" ]; then
-  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=nightly"
+  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=$RUST_RELEASE_CHANNEL"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"
 
   if [ "$NO_LLVM_ASSERTIONS" = "1" ]; then


### PR DESCRIPTION
This PR performs these  things:

1. The `aux` job now performs "cargotest" and "pretty" tests. The clippy/rustfmt/rls/miri tests are moved into its own job.
2. These tests are run with `--no-fail-fast`, so that we can get the maximum number of failures of all tools from a single CI run.
3. The test results are stored into a JSON file, ready to be uploaded in the future.

This is step 2 and 3/8 of automatic management of broken tools #45861. 

