### PR TITLE
wasm: Update LLVM to fix a test

### DIFF
--- a/src/test/run-pass/saturating-float-casts.rs
+++ b/src/test/run-pass/saturating-float-casts.rs
@@ -10,7 +10,6 @@
 
 // Tests saturating float->int casts. See u128-as-f32.rs for the opposite direction.
 // compile-flags: -Z saturating-float-casts
-// ignore-wasm32-bare FIXME(#46298) needs upstream llvm fixes
 
 #![feature(test, i128, i128_type, stmt_expr_attributes)]
 #![deny(overflowing_literals)]


### PR DESCRIPTION
This commit updates LLVM with some tweaks to the integer <-> floating point
conversion instructions to ensure that `as` in Rust doesn't trap.

Closes #46298