### PR TITLE
Hide private trait type params and show hidden items with document-private

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -470,7 +470,6 @@ where R: 'static + Send, F: 'static + Send + FnOnce(Output) -> R {
         default_passes = false;
 
         passes = vec![
-            String::from("strip-hidden"),
             String::from("collapse-docs"),
             String::from("unindent-comments"),
         ];

--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -184,6 +184,15 @@ impl<'a> fold::DocFolder for ImplStripper<'a> {
                     return None;
                 }
             }
+            if let Some(generics) = imp.trait_.as_ref().and_then(|t| t.generics()) {
+                for typaram in generics {
+                    if let Some(did) = typaram.def_id() {
+                        if did.is_local() && !self.retained.contains(&did) {
+                            return None;
+                        }
+                    }
+                }
+            }
         }
         self.fold_item_recur(i)
     }

--- a/src/test/rustdoc/issue-46380-2.rs
+++ b/src/test/rustdoc/issue-46380-2.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub trait PublicTrait<T> {}
+
+// @has issue_46380_2/struct.Public.html
+pub struct PublicStruct;
+
+// @!has - '//*[@class="impl"]' 'impl Add<Private> for Public'
+impl PublicTrait<PrivateStruct> for PublicStruct {}
+
+struct PrivateStruct;

--- a/src/test/rustdoc/issue-46380-2.rs
+++ b/src/test/rustdoc/issue-46380-2.rs
@@ -10,10 +10,10 @@
 
 pub trait PublicTrait<T> {}
 
-// @has issue_46380_2/struct.Public.html
+// @has issue_46380_2/struct.PublicStruct.html
 pub struct PublicStruct;
 
-// @!has - '//*[@class="impl"]' 'impl Add<Private> for Public'
+// @!has - '//*[@class="impl"]' 'impl PublicTrait<PrivateStruct> for PublicStruct'
 impl PublicTrait<PrivateStruct> for PublicStruct {}
 
 struct PrivateStruct;

--- a/src/test/rustdoc/issue-46380.rs
+++ b/src/test/rustdoc/issue-46380.rs
@@ -1,0 +1,15 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --document-private-items
+
+// @has issue_46380/struct.Hidden.html
+#[doc(hidden)]
+pub struct Hidden;


### PR DESCRIPTION
As discussed in #46380, this PR removes the `strip-hidden` pass from `--document-private-items` which allows showing `#[doc(hidden)]` with rustdoc.

The second commit removes the trait implementation from the docs if the trait's parameter is private.