### PR TITLE
libtest: add glob support to test name filters

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2425,6 +2425,7 @@ name = "test"
 version = "0.0.0"
 dependencies = [
  "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.0.0",
 ]
 

--- a/src/libtest/Cargo.toml
+++ b/src/libtest/Cargo.toml
@@ -10,4 +10,5 @@ crate-type = ["dylib", "rlib"]
 
 [dependencies]
 getopts = "0.2"
+glob = "0.2"
 term = { path = "../libterm" }

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -146,6 +146,9 @@ pub struct Config {
     /// Exactly match the filter, rather than a substring
     pub filter_exact: bool,
 
+    /// Match the test name using a glob
+    pub filter_glob: bool,
+
     /// Write out a parseable log of tests that were run
     pub logfile: Option<PathBuf>,
 

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -146,9 +146,6 @@ pub struct Config {
     /// Exactly match the filter, rather than a substring
     pub filter_exact: bool,
 
-    /// Match the test name using a glob
-    pub filter_glob: bool,
-
     /// Write out a parseable log of tests that were run
     pub logfile: Option<PathBuf>,
 

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -83,7 +83,6 @@ pub fn parse_config(args: Vec<String> ) -> Config {
                  run-pass-valgrind|pretty|debug-info|incremental|mir-opt)")
         .optflag("", "ignored", "run tests marked as ignored")
         .optflag("", "exact", "filters match exactly")
-        .optflag("", "glob", "match test names using a glob")
         .optopt("", "runtool", "supervisor program to run tests under \
                                 (eg. emulator, valgrind)", "PROGRAM")
         .optopt("", "host-rustcflags", "flags to pass to rustc for host", "FLAGS")
@@ -175,7 +174,6 @@ pub fn parse_config(args: Vec<String> ) -> Config {
         run_ignored: matches.opt_present("ignored"),
         filter: matches.free.first().cloned(),
         filter_exact: matches.opt_present("exact"),
-        filter_glob: matches.opt_present("glob"),
         logfile: matches.opt_str("logfile").map(|s| PathBuf::from(&s)),
         runtool: matches.opt_str("runtool"),
         host_rustcflags: matches.opt_str("host-rustcflags"),
@@ -229,7 +227,6 @@ pub fn log_config(config: &Config) {
                                    .as_ref()
                                    .map(|re| re.to_owned()))));
     logv(c, format!("filter_exact: {}", config.filter_exact));
-    logv(c, format!("filter_glob: {}", config.filter_glob));
     logv(c, format!("runtool: {}", opt_str(&config.runtool)));
     logv(c, format!("host-rustcflags: {}",
                     opt_str(&config.host_rustcflags)));
@@ -343,7 +340,6 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
         test::TestNamePattern::new(
             filter,
             config.filter_exact,
-            config.filter_glob
         )
     });
 

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -339,10 +339,16 @@ pub fn run_tests(config: &Config) {
 }
 
 pub fn test_opts(config: &Config) -> test::TestOpts {
+    let filter = config.filter.clone().map(|filter| {
+        test::TestNamePattern::new(
+            filter,
+            config.filter_exact,
+            config.filter_glob
+        )
+    });
+
     test::TestOpts {
-        filter: config.filter.clone(),
-        filter_exact: config.filter_exact,
-        filter_glob: config.filter_glob
+        filter: filter,
         run_ignored: config.run_ignored,
         quiet: config.quiet,
         logfile: config.logfile.clone(),

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -83,6 +83,7 @@ pub fn parse_config(args: Vec<String> ) -> Config {
                  run-pass-valgrind|pretty|debug-info|incremental|mir-opt)")
         .optflag("", "ignored", "run tests marked as ignored")
         .optflag("", "exact", "filters match exactly")
+        .optflag("", "glob", "match test names using a glob")
         .optopt("", "runtool", "supervisor program to run tests under \
                                 (eg. emulator, valgrind)", "PROGRAM")
         .optopt("", "host-rustcflags", "flags to pass to rustc for host", "FLAGS")
@@ -174,6 +175,7 @@ pub fn parse_config(args: Vec<String> ) -> Config {
         run_ignored: matches.opt_present("ignored"),
         filter: matches.free.first().cloned(),
         filter_exact: matches.opt_present("exact"),
+        filter_glob: matches.opt_present("glob"),
         logfile: matches.opt_str("logfile").map(|s| PathBuf::from(&s)),
         runtool: matches.opt_str("runtool"),
         host_rustcflags: matches.opt_str("host-rustcflags"),
@@ -227,6 +229,7 @@ pub fn log_config(config: &Config) {
                                    .as_ref()
                                    .map(|re| re.to_owned()))));
     logv(c, format!("filter_exact: {}", config.filter_exact));
+    logv(c, format!("filter_glob: {}", config.filter_glob));
     logv(c, format!("runtool: {}", opt_str(&config.runtool)));
     logv(c, format!("host-rustcflags: {}",
                     opt_str(&config.host_rustcflags)));
@@ -339,6 +342,7 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
     test::TestOpts {
         filter: config.filter.clone(),
         filter_exact: config.filter_exact,
+        filter_glob: config.filter_glob
         run_ignored: config.run_ignored,
         quiet: config.quiet,
         logfile: config.logfile.clone(),


### PR DESCRIPTION
Tests can currently only be filtered by substring or exact match. This makes it difficult to have finer-grained control over which tests to run (#46408), such as running only tests with a given suffix in a module, all tests without a given suffix, etc.

This PR adds support for [glob patterns](https://doc.rust-lang.org/glob/glob/struct.Pattern.html) in test name filters. When at least one of the special glob characters (`*`, `?`, or `[`) are present, the pattern is interpreted as a glob, and used to match against test names. These characters cannot appear in ordinary test names, so this should not cause unexpected results. This allows commands such as:

    mymod::*_fast

or

    foo --skip *_slow

Fixes #46408.