### PR TITLE
build_helper: destination file can't be up to date when not exists

### DIFF
--- a/src/build_helper/lib.rs
+++ b/src/build_helper/lib.rs
@@ -190,6 +190,9 @@ pub fn mtime(path: &Path) -> FileTime {
 ///
 /// Uses last-modified time checks to verify this.
 pub fn up_to_date(src: &Path, dst: &Path) -> bool {
+    if !dst.exists() {
+        return false;
+    }
     let threshold = mtime(dst);
     let meta = match fs::metadata(src) {
         Ok(meta) => meta,


### PR DESCRIPTION
Function "up_to_date" return incorrect result if mtime for all fetched sources is set to epoch time. Add existence check to function.

This fix required for a [Guix](https://www.gnu.org/software/guix/) package because a Nix builder set mtime of all sources to epoch time. 