### PR TITLE
MIR: change "lvalue" terminology to "place".

### DIFF
--- a/src/librustc/ich/impls_mir.rs
+++ b/src/librustc/ich/impls_mir.rs
@@ -318,19 +318,19 @@ impl<'gcx, T> HashStable<StableHashingContext<'gcx>>
 
 impl_stable_hash_for!(enum mir::ValidationOp { Acquire, Release, Suspend(region_scope) });
 
-impl<'gcx> HashStable<StableHashingContext<'gcx>> for mir::Lvalue<'gcx> {
+impl<'gcx> HashStable<StableHashingContext<'gcx>> for mir::Place<'gcx> {
     fn hash_stable<W: StableHasherResult>(&self,
                                           hcx: &mut StableHashingContext<'gcx>,
                                           hasher: &mut StableHasher<W>) {
         mem::discriminant(self).hash_stable(hcx, hasher);
         match *self {
-            mir::Lvalue::Local(ref local) => {
+            mir::Place::Local(ref local) => {
                 local.hash_stable(hcx, hasher);
             }
-            mir::Lvalue::Static(ref statik) => {
+            mir::Place::Static(ref statik) => {
                 statik.hash_stable(hcx, hasher);
             }
-            mir::Lvalue::Projection(ref lvalue_projection) => {
+            mir::Place::Projection(ref lvalue_projection) => {
                 lvalue_projection.hash_stable(hcx, hasher);
             }
         }

--- a/src/librustc/ich/impls_mir.rs
+++ b/src/librustc/ich/impls_mir.rs
@@ -272,24 +272,24 @@ for mir::StatementKind<'gcx> {
         mem::discriminant(self).hash_stable(hcx, hasher);
 
         match *self {
-            mir::StatementKind::Assign(ref lvalue, ref rvalue) => {
-                lvalue.hash_stable(hcx, hasher);
+            mir::StatementKind::Assign(ref place, ref rvalue) => {
+                place.hash_stable(hcx, hasher);
                 rvalue.hash_stable(hcx, hasher);
             }
-            mir::StatementKind::SetDiscriminant { ref lvalue, variant_index } => {
-                lvalue.hash_stable(hcx, hasher);
+            mir::StatementKind::SetDiscriminant { ref place, variant_index } => {
+                place.hash_stable(hcx, hasher);
                 variant_index.hash_stable(hcx, hasher);
             }
-            mir::StatementKind::StorageLive(ref lvalue) |
-            mir::StatementKind::StorageDead(ref lvalue) => {
-                lvalue.hash_stable(hcx, hasher);
+            mir::StatementKind::StorageLive(ref place) |
+            mir::StatementKind::StorageDead(ref place) => {
+                place.hash_stable(hcx, hasher);
             }
             mir::StatementKind::EndRegion(ref region_scope) => {
                 region_scope.hash_stable(hcx, hasher);
             }
-            mir::StatementKind::Validate(ref op, ref lvalues) => {
+            mir::StatementKind::Validate(ref op, ref places) => {
                 op.hash_stable(hcx, hasher);
-                lvalues.hash_stable(hcx, hasher);
+                places.hash_stable(hcx, hasher);
             }
             mir::StatementKind::Nop => {}
             mir::StatementKind::InlineAsm { ref asm, ref outputs, ref inputs } => {
@@ -309,7 +309,7 @@ impl<'gcx, T> HashStable<StableHashingContext<'gcx>>
                                           hcx: &mut StableHashingContext<'gcx>,
                                           hasher: &mut StableHasher<W>)
     {
-        self.lval.hash_stable(hcx, hasher);
+        self.place.hash_stable(hcx, hasher);
         self.ty.hash_stable(hcx, hasher);
         self.re.hash_stable(hcx, hasher);
         self.mutbl.hash_stable(hcx, hasher);
@@ -330,8 +330,8 @@ impl<'gcx> HashStable<StableHashingContext<'gcx>> for mir::Place<'gcx> {
             mir::Place::Static(ref statik) => {
                 statik.hash_stable(hcx, hasher);
             }
-            mir::Place::Projection(ref lvalue_projection) => {
-                lvalue_projection.hash_stable(hcx, hasher);
+            mir::Place::Projection(ref place_projection) => {
+                place_projection.hash_stable(hcx, hasher);
             }
         }
     }
@@ -420,11 +420,11 @@ impl<'gcx> HashStable<StableHashingContext<'gcx>> for mir::Operand<'gcx> {
         mem::discriminant(self).hash_stable(hcx, hasher);
 
         match *self {
-            mir::Operand::Copy(ref lvalue) => {
-                lvalue.hash_stable(hcx, hasher);
+            mir::Operand::Copy(ref place) => {
+                place.hash_stable(hcx, hasher);
             }
-            mir::Operand::Move(ref lvalue) => {
-                lvalue.hash_stable(hcx, hasher);
+            mir::Operand::Move(ref place) => {
+                place.hash_stable(hcx, hasher);
             }
             mir::Operand::Constant(ref constant) => {
                 constant.hash_stable(hcx, hasher);
@@ -447,13 +447,13 @@ impl<'gcx> HashStable<StableHashingContext<'gcx>> for mir::Rvalue<'gcx> {
                 operand.hash_stable(hcx, hasher);
                 val.hash_stable(hcx, hasher);
             }
-            mir::Rvalue::Ref(region, borrow_kind, ref lvalue) => {
+            mir::Rvalue::Ref(region, borrow_kind, ref place) => {
                 region.hash_stable(hcx, hasher);
                 borrow_kind.hash_stable(hcx, hasher);
-                lvalue.hash_stable(hcx, hasher);
+                place.hash_stable(hcx, hasher);
             }
-            mir::Rvalue::Len(ref lvalue) => {
-                lvalue.hash_stable(hcx, hasher);
+            mir::Rvalue::Len(ref place) => {
+                place.hash_stable(hcx, hasher);
             }
             mir::Rvalue::Cast(cast_kind, ref operand, ty) => {
                 cast_kind.hash_stable(hcx, hasher);
@@ -470,8 +470,8 @@ impl<'gcx> HashStable<StableHashingContext<'gcx>> for mir::Rvalue<'gcx> {
                 op.hash_stable(hcx, hasher);
                 operand.hash_stable(hcx, hasher);
             }
-            mir::Rvalue::Discriminant(ref lvalue) => {
-                lvalue.hash_stable(hcx, hasher);
+            mir::Rvalue::Discriminant(ref place) => {
+                place.hash_stable(hcx, hasher);
             }
             mir::Rvalue::NullaryOp(op, ty) => {
                 op.hash_stable(hcx, hasher);

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -21,7 +21,7 @@ use hir::def_id::DefId;
 use middle::free_region::{FreeRegionMap, RegionRelations};
 use middle::region;
 use middle::lang_items;
-use mir::tcx::LvalueTy;
+use mir::tcx::PlaceTy;
 use ty::subst::{Kind, Subst, Substs};
 use ty::{TyVid, IntVid, FloatVid};
 use ty::{self, Ty, TyCtxt};
@@ -518,15 +518,15 @@ impl_trans_normalize!('gcx,
     ty::ExistentialTraitRef<'gcx>
 );
 
-impl<'gcx> TransNormalize<'gcx> for LvalueTy<'gcx> {
+impl<'gcx> TransNormalize<'gcx> for PlaceTy<'gcx> {
     fn trans_normalize<'a, 'tcx>(&self,
                                  infcx: &InferCtxt<'a, 'gcx, 'tcx>,
                                  param_env: ty::ParamEnv<'tcx>)
                                  -> Self {
         match *self {
-            LvalueTy::Ty { ty } => LvalueTy::Ty { ty: ty.trans_normalize(infcx, param_env) },
-            LvalueTy::Downcast { adt_def, substs, variant_index } => {
-                LvalueTy::Downcast {
+            PlaceTy::Ty { ty } => PlaceTy::Ty { ty: ty.trans_normalize(infcx, param_env) },
+            PlaceTy::Downcast { adt_def, substs, variant_index } => {
+                PlaceTy::Downcast {
                     adt_def,
                     substs: substs.trans_normalize(infcx, param_env),
                     variant_index,

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -139,7 +139,7 @@ impl<'tcx> Mir<'tcx> {
                upvar_decls: Vec<UpvarDecl>,
                span: Span) -> Self
     {
-        // We need `arg_count` locals, and one for the return pointer
+        // We need `arg_count` locals, and one for the return place
         assert!(local_decls.len() >= arg_count + 1,
             "expected at least {} locals, got {}", arg_count + 1, local_decls.len());
 
@@ -200,7 +200,7 @@ impl<'tcx> Mir<'tcx> {
         let index = local.0 as usize;
         if index == 0 {
             debug_assert!(self.local_decls[local].mutability == Mutability::Mut,
-                          "return pointer should be mutable");
+                          "return place should be mutable");
 
             LocalKind::ReturnPointer
         } else if index < self.arg_count + 1 {
@@ -249,7 +249,7 @@ impl<'tcx> Mir<'tcx> {
     }
 
     /// Returns an iterator over all user-defined variables and compiler-generated temporaries (all
-    /// locals that are neither arguments nor the return pointer).
+    /// locals that are neither arguments nor the return place).
     #[inline]
     pub fn vars_and_temps_iter(&self) -> impl Iterator<Item=Local> {
         let arg_count = self.arg_count;
@@ -280,7 +280,7 @@ impl<'tcx> Mir<'tcx> {
 
     /// Return the return type, it always return first element from `local_decls` array
     pub fn return_ty(&self) -> Ty<'tcx> {
-        self.local_decls[RETURN_POINTER].ty
+        self.local_decls[RETURN_PLACE].ty
     }
 }
 
@@ -417,7 +417,7 @@ pub enum BorrowKind {
 newtype_index!(Local
     {
         DEBUG_FORMAT = "_{}",
-        const RETURN_POINTER = 0,
+        const RETURN_PLACE = 0,
     });
 
 /// Classifies locals into categories. See `Mir::local_kind`.
@@ -436,12 +436,12 @@ pub enum LocalKind {
 /// A MIR local.
 ///
 /// This can be a binding declared by the user, a temporary inserted by the compiler, a function
-/// argument, or the return pointer.
+/// argument, or the return place.
 #[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
 pub struct LocalDecl<'tcx> {
     /// `let mut x` vs `let x`.
     ///
-    /// Temporaries and the return pointer are always mutable.
+    /// Temporaries and the return place are always mutable.
     pub mutability: Mutability,
 
     /// True if this corresponds to a user-declared local variable.
@@ -520,11 +520,11 @@ impl<'tcx> LocalDecl<'tcx> {
         }
     }
 
-    /// Builds a `LocalDecl` for the return pointer.
+    /// Builds a `LocalDecl` for the return place.
     ///
     /// This must be inserted into the `local_decls` list as the first local.
     #[inline]
-    pub fn new_return_pointer(return_ty: Ty, span: Span) -> LocalDecl {
+    pub fn new_return_place(return_ty: Ty, span: Span) -> LocalDecl {
         LocalDecl {
             mutability: Mutability::Mut,
             ty: return_ty,
@@ -634,8 +634,8 @@ pub enum TerminatorKind<'tcx> {
     /// continue. Emitted by build::scope::diverge_cleanup.
     Resume,
 
-    /// Indicates a normal return. The return pointer lvalue should
-    /// have been filled in by now. This should occur at most once.
+    /// Indicates a normal return. The return place should have
+    /// been filled in by now. This should occur at most once.
     Return,
 
     /// Indicates a terminator that can never be reached.
@@ -650,7 +650,7 @@ pub enum TerminatorKind<'tcx> {
 
     /// Drop the Place and assign the new value over it. This ensures
     /// that the assignment to LV occurs *even if* the destructor for
-    /// lvalue unwinds. Its semantics are best explained by by the
+    /// place unwinds. Its semantics are best explained by by the
     /// elaboration:
     ///
     /// ```
@@ -878,7 +878,7 @@ impl<'tcx> TerminatorKind<'tcx> {
         use self::TerminatorKind::*;
         match *self {
             Goto { .. } => write!(fmt, "goto"),
-            SwitchInt { discr: ref lv, .. } => write!(fmt, "switchInt({:?})", lv),
+            SwitchInt { discr: ref place, .. } => write!(fmt, "switchInt({:?})", place),
             Return => write!(fmt, "return"),
             GeneratorDrop => write!(fmt, "generator_drop"),
             Resume => write!(fmt, "resume"),
@@ -1006,7 +1006,7 @@ pub enum StatementKind<'tcx> {
     Assign(Place<'tcx>, Rvalue<'tcx>),
 
     /// Write the discriminant for a variant to the enum Place.
-    SetDiscriminant { lvalue: Place<'tcx>, variant_index: usize },
+    SetDiscriminant { place: Place<'tcx>, variant_index: usize },
 
     /// Start a live range for the storage of the local.
     StorageLive(Local),
@@ -1021,7 +1021,7 @@ pub enum StatementKind<'tcx> {
         inputs: Vec<Operand<'tcx>>
     },
 
-    /// Assert the given lvalues to be valid inhabitants of their type.  These statements are
+    /// Assert the given places to be valid inhabitants of their type.  These statements are
     /// currently only interpreted by miri and only generated when "-Z mir-emit-validate" is passed.
     /// See <https://internals.rust-lang.org/t/types-as-contracts/5562/73> for more details.
     Validate(ValidationOp, Vec<ValidationOperand<'tcx, Place<'tcx>>>),
@@ -1038,9 +1038,9 @@ pub enum StatementKind<'tcx> {
 /// `Validate` statement.
 #[derive(Copy, Clone, RustcEncodable, RustcDecodable, PartialEq, Eq)]
 pub enum ValidationOp {
-    /// Recursively traverse the lvalue following the type and validate that all type
+    /// Recursively traverse the place following the type and validate that all type
     /// invariants are maintained.  Furthermore, acquire exclusive/read-only access to the
-    /// memory reachable from the lvalue.
+    /// memory reachable from the place.
     Acquire,
     /// Recursive traverse the *mutable* part of the type and relinquish all exclusive
     /// access.
@@ -1065,7 +1065,7 @@ impl Debug for ValidationOp {
 // This is generic so that it can be reused by miri
 #[derive(Clone, RustcEncodable, RustcDecodable)]
 pub struct ValidationOperand<'tcx, T> {
-    pub lval: T,
+    pub place: T,
     pub ty: Ty<'tcx>,
     pub re: Option<region::Scope>,
     pub mutbl: hir::Mutability,
@@ -1073,7 +1073,7 @@ pub struct ValidationOperand<'tcx, T> {
 
 impl<'tcx, T: Debug> Debug for ValidationOperand<'tcx, T> {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-        write!(fmt, "{:?}: {:?}", self.lval, self.ty)?;
+        write!(fmt, "{:?}: {:?}", self.place, self.ty)?;
         if let Some(ce) = self.re {
             // (reuse lifetime rendering policy from ppaux.)
             write!(fmt, "/{}", ty::ReScope(ce))?;
@@ -1089,14 +1089,14 @@ impl<'tcx> Debug for Statement<'tcx> {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
         use self::StatementKind::*;
         match self.kind {
-            Assign(ref lv, ref rv) => write!(fmt, "{:?} = {:?}", lv, rv),
+            Assign(ref place, ref rv) => write!(fmt, "{:?} = {:?}", place, rv),
             // (reuse lifetime rendering policy from ppaux.)
             EndRegion(ref ce) => write!(fmt, "EndRegion({})", ty::ReScope(*ce)),
-            Validate(ref op, ref lvalues) => write!(fmt, "Validate({:?}, {:?})", op, lvalues),
-            StorageLive(ref lv) => write!(fmt, "StorageLive({:?})", lv),
-            StorageDead(ref lv) => write!(fmt, "StorageDead({:?})", lv),
-            SetDiscriminant{lvalue: ref lv, variant_index: index} => {
-                write!(fmt, "discriminant({:?}) = {:?}", lv, index)
+            Validate(ref op, ref places) => write!(fmt, "Validate({:?}, {:?})", op, places),
+            StorageLive(ref place) => write!(fmt, "StorageLive({:?})", place),
+            StorageDead(ref place) => write!(fmt, "StorageDead({:?})", place),
+            SetDiscriminant { ref place, variant_index } => {
+                write!(fmt, "discriminant({:?}) = {:?}", place, variant_index)
             },
             InlineAsm { ref asm, ref outputs, ref inputs } => {
                 write!(fmt, "asm!({:?} : {:?} : {:?})", asm, outputs, inputs)
@@ -1119,7 +1119,7 @@ pub enum Place<'tcx> {
     /// static or static mut variable
     Static(Box<Static<'tcx>>),
 
-    /// projection out of an lvalue (access a field, deref a pointer, etc)
+    /// projection out of a place (access a field, deref a pointer, etc)
     Projection(Box<PlaceProjection<'tcx>>),
 }
 
@@ -1184,11 +1184,11 @@ pub enum ProjectionElem<'tcx, V, T> {
     Downcast(&'tcx AdtDef, usize),
 }
 
-/// Alias for projections as they appear in lvalues, where the base is an lvalue
+/// Alias for projections as they appear in places, where the base is a place
 /// and the index is a local.
 pub type PlaceProjection<'tcx> = Projection<'tcx, Place<'tcx>, Local, Ty<'tcx>>;
 
-/// Alias for projections as they appear in lvalues, where the base is an lvalue
+/// Alias for projections as they appear in places, where the base is a place
 /// and the index is a local.
 pub type PlaceElem<'tcx> = ProjectionElem<'tcx, Local, Ty<'tcx>>;
 
@@ -1273,13 +1273,13 @@ pub struct VisibilityScopeData {
 // Operands
 
 /// These are values that can appear inside an rvalue (or an index
-/// lvalue). They are intentionally limited to prevent rvalues from
+/// place). They are intentionally limited to prevent rvalues from
 /// being nested in one another.
 #[derive(Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub enum Operand<'tcx> {
     /// Copy: The value must be available for use afterwards.
     ///
-    /// This implies that the type of the lvalue must be `Copy`; this is true
+    /// This implies that the type of the place must be `Copy`; this is true
     /// by construction during build, but also checked by the MIR type checker.
     Copy(Place<'tcx>),
     /// Move: The value (including old borrows of it) will not be used again.
@@ -1296,8 +1296,8 @@ impl<'tcx> Debug for Operand<'tcx> {
         use self::Operand::*;
         match *self {
             Constant(ref a) => write!(fmt, "{:?}", a),
-            Copy(ref lv) => write!(fmt, "{:?}", lv),
-            Move(ref lv) => write!(fmt, "move {:?}", lv),
+            Copy(ref place) => write!(fmt, "{:?}", place),
+            Move(ref place) => write!(fmt, "move {:?}", place),
         }
     }
 }
@@ -1470,18 +1470,20 @@ impl<'tcx> Debug for Rvalue<'tcx> {
         use self::Rvalue::*;
 
         match *self {
-            Use(ref lvalue) => write!(fmt, "{:?}", lvalue),
+            Use(ref place) => write!(fmt, "{:?}", place),
             Repeat(ref a, ref b) => write!(fmt, "[{:?}; {:?}]", a, b),
             Len(ref a) => write!(fmt, "Len({:?})", a),
-            Cast(ref kind, ref lv, ref ty) => write!(fmt, "{:?} as {:?} ({:?})", lv, ty, kind),
+            Cast(ref kind, ref place, ref ty) => {
+                write!(fmt, "{:?} as {:?} ({:?})", place, ty, kind)
+            }
             BinaryOp(ref op, ref a, ref b) => write!(fmt, "{:?}({:?}, {:?})", op, a, b),
             CheckedBinaryOp(ref op, ref a, ref b) => {
                 write!(fmt, "Checked{:?}({:?}, {:?})", op, a, b)
             }
             UnaryOp(ref op, ref a) => write!(fmt, "{:?}({:?})", op, a),
-            Discriminant(ref lval) => write!(fmt, "discriminant({:?})", lval),
+            Discriminant(ref place) => write!(fmt, "discriminant({:?})", place),
             NullaryOp(ref op, ref t) => write!(fmt, "{:?}({:?})", op, t),
-            Ref(region, borrow_kind, ref lv) => {
+            Ref(region, borrow_kind, ref place) => {
                 let kind_str = match borrow_kind {
                     BorrowKind::Shared => "",
                     BorrowKind::Mut | BorrowKind::Unique => "mut ",
@@ -1496,26 +1498,26 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                     // Do not even print 'static
                     "".to_owned()
                 };
-                write!(fmt, "&{}{}{:?}", region, kind_str, lv)
+                write!(fmt, "&{}{}{:?}", region, kind_str, place)
             }
 
-            Aggregate(ref kind, ref lvs) => {
-                fn fmt_tuple(fmt: &mut Formatter, lvs: &[Operand]) -> fmt::Result {
+            Aggregate(ref kind, ref places) => {
+                fn fmt_tuple(fmt: &mut Formatter, places: &[Operand]) -> fmt::Result {
                     let mut tuple_fmt = fmt.debug_tuple("");
-                    for lv in lvs {
-                        tuple_fmt.field(lv);
+                    for place in places {
+                        tuple_fmt.field(place);
                     }
                     tuple_fmt.finish()
                 }
 
                 match **kind {
-                    AggregateKind::Array(_) => write!(fmt, "{:?}", lvs),
+                    AggregateKind::Array(_) => write!(fmt, "{:?}", places),
 
                     AggregateKind::Tuple => {
-                        match lvs.len() {
+                        match places.len() {
                             0 => write!(fmt, "()"),
-                            1 => write!(fmt, "({:?},)", lvs[0]),
-                            _ => fmt_tuple(fmt, lvs),
+                            1 => write!(fmt, "({:?},)", places[0]),
+                            _ => fmt_tuple(fmt, places),
                         }
                     }
 
@@ -1526,11 +1528,11 @@ impl<'tcx> Debug for Rvalue<'tcx> {
 
                         match variant_def.ctor_kind {
                             CtorKind::Const => Ok(()),
-                            CtorKind::Fn => fmt_tuple(fmt, lvs),
+                            CtorKind::Fn => fmt_tuple(fmt, places),
                             CtorKind::Fictive => {
                                 let mut struct_fmt = fmt.debug_struct("");
-                                for (field, lv) in variant_def.fields.iter().zip(lvs) {
-                                    struct_fmt.field(&field.name.as_str(), lv);
+                                for (field, place) in variant_def.fields.iter().zip(places) {
+                                    struct_fmt.field(&field.name.as_str(), place);
                                 }
                                 struct_fmt.finish()
                             }
@@ -1547,9 +1549,9 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                             let mut struct_fmt = fmt.debug_struct(&name);
 
                             tcx.with_freevars(node_id, |freevars| {
-                                for (freevar, lv) in freevars.iter().zip(lvs) {
+                                for (freevar, place) in freevars.iter().zip(places) {
                                     let var_name = tcx.hir.name(freevar.var_id());
-                                    struct_fmt.field(&var_name.as_str(), lv);
+                                    struct_fmt.field(&var_name.as_str(), place);
                                 }
                             });
 
@@ -1565,14 +1567,14 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                             let mut struct_fmt = fmt.debug_struct(&name);
 
                             tcx.with_freevars(node_id, |freevars| {
-                                for (freevar, lv) in freevars.iter().zip(lvs) {
+                                for (freevar, place) in freevars.iter().zip(places) {
                                     let var_name = tcx.hir.name(freevar.var_id());
-                                    struct_fmt.field(&var_name.as_str(), lv);
+                                    struct_fmt.field(&var_name.as_str(), place);
                                 }
-                                struct_fmt.field("$state", &lvs[freevars.len()]);
-                                for i in (freevars.len() + 1)..lvs.len() {
+                                struct_fmt.field("$state", &places[freevars.len()]);
+                                for i in (freevars.len() + 1)..places.len() {
                                     struct_fmt.field(&format!("${}", i - freevars.len() - 1),
-                                                     &lvs[i]);
+                                                     &places[i]);
                                 }
                             });
 
@@ -1831,7 +1833,7 @@ impl<'tcx> TypeFoldable<'tcx> for BasicBlockData<'tcx> {
 impl<'tcx> TypeFoldable<'tcx> for ValidationOperand<'tcx, Place<'tcx>> {
     fn super_fold_with<'gcx: 'tcx, F: TypeFolder<'gcx, 'tcx>>(&self, folder: &mut F) -> Self {
         ValidationOperand {
-            lval: self.lval.fold_with(folder),
+            place: self.place.fold_with(folder),
             ty: self.ty.fold_with(folder),
             re: self.re,
             mutbl: self.mutbl,
@@ -1839,7 +1841,7 @@ impl<'tcx> TypeFoldable<'tcx> for ValidationOperand<'tcx, Place<'tcx>> {
     }
 
     fn super_visit_with<V: TypeVisitor<'tcx>>(&self, visitor: &mut V) -> bool {
-        self.lval.visit_with(visitor) || self.ty.visit_with(visitor)
+        self.place.visit_with(visitor) || self.ty.visit_with(visitor)
     }
 }
 
@@ -1848,9 +1850,9 @@ impl<'tcx> TypeFoldable<'tcx> for Statement<'tcx> {
         use mir::StatementKind::*;
 
         let kind = match self.kind {
-            Assign(ref lval, ref rval) => Assign(lval.fold_with(folder), rval.fold_with(folder)),
-            SetDiscriminant { ref lvalue, variant_index } => SetDiscriminant {
-                lvalue: lvalue.fold_with(folder),
+            Assign(ref place, ref rval) => Assign(place.fold_with(folder), rval.fold_with(folder)),
+            SetDiscriminant { ref place, variant_index } => SetDiscriminant {
+                place: place.fold_with(folder),
                 variant_index,
             },
             StorageLive(ref local) => StorageLive(local.fold_with(folder)),
@@ -1867,9 +1869,9 @@ impl<'tcx> TypeFoldable<'tcx> for Statement<'tcx> {
             // trait with a `fn fold_scope`.
             EndRegion(ref region_scope) => EndRegion(region_scope.clone()),
 
-            Validate(ref op, ref lvals) =>
+            Validate(ref op, ref places) =>
                 Validate(op.clone(),
-                         lvals.iter().map(|operand| operand.fold_with(folder)).collect()),
+                         places.iter().map(|operand| operand.fold_with(folder)).collect()),
 
             Nop => Nop,
         };
@@ -1883,8 +1885,8 @@ impl<'tcx> TypeFoldable<'tcx> for Statement<'tcx> {
         use mir::StatementKind::*;
 
         match self.kind {
-            Assign(ref lval, ref rval) => { lval.visit_with(visitor) || rval.visit_with(visitor) }
-            SetDiscriminant { ref lvalue, .. } => lvalue.visit_with(visitor),
+            Assign(ref place, ref rval) => { place.visit_with(visitor) || rval.visit_with(visitor) }
+            SetDiscriminant { ref place, .. } => place.visit_with(visitor),
             StorageLive(ref local) |
             StorageDead(ref local) => local.visit_with(visitor),
             InlineAsm { ref outputs, ref inputs, .. } =>
@@ -1896,8 +1898,8 @@ impl<'tcx> TypeFoldable<'tcx> for Statement<'tcx> {
             // trait with a `fn visit_scope`.
             EndRegion(ref _scope) => false,
 
-            Validate(ref _op, ref lvalues) =>
-                lvalues.iter().any(|ty_and_lvalue| ty_and_lvalue.visit_with(visitor)),
+            Validate(ref _op, ref places) =>
+                places.iter().any(|ty_and_place| ty_and_place.visit_with(visitor)),
 
             Nop => false,
         }
@@ -2035,15 +2037,16 @@ impl<'tcx> TypeFoldable<'tcx> for Rvalue<'tcx> {
         match *self {
             Use(ref op) => Use(op.fold_with(folder)),
             Repeat(ref op, len) => Repeat(op.fold_with(folder), len),
-            Ref(region, bk, ref lval) => Ref(region.fold_with(folder), bk, lval.fold_with(folder)),
-            Len(ref lval) => Len(lval.fold_with(folder)),
+            Ref(region, bk, ref place) =>
+                Ref(region.fold_with(folder), bk, place.fold_with(folder)),
+            Len(ref place) => Len(place.fold_with(folder)),
             Cast(kind, ref op, ty) => Cast(kind, op.fold_with(folder), ty.fold_with(folder)),
             BinaryOp(op, ref rhs, ref lhs) =>
                 BinaryOp(op, rhs.fold_with(folder), lhs.fold_with(folder)),
             CheckedBinaryOp(op, ref rhs, ref lhs) =>
                 CheckedBinaryOp(op, rhs.fold_with(folder), lhs.fold_with(folder)),
             UnaryOp(op, ref val) => UnaryOp(op, val.fold_with(folder)),
-            Discriminant(ref lval) => Discriminant(lval.fold_with(folder)),
+            Discriminant(ref place) => Discriminant(place.fold_with(folder)),
             NullaryOp(op, ty) => NullaryOp(op, ty.fold_with(folder)),
             Aggregate(ref kind, ref fields) => {
                 let kind = box match **kind {
@@ -2068,14 +2071,14 @@ impl<'tcx> TypeFoldable<'tcx> for Rvalue<'tcx> {
         match *self {
             Use(ref op) => op.visit_with(visitor),
             Repeat(ref op, _) => op.visit_with(visitor),
-            Ref(region, _, ref lval) => region.visit_with(visitor) || lval.visit_with(visitor),
-            Len(ref lval) => lval.visit_with(visitor),
+            Ref(region, _, ref place) => region.visit_with(visitor) || place.visit_with(visitor),
+            Len(ref place) => place.visit_with(visitor),
             Cast(_, ref op, ty) => op.visit_with(visitor) || ty.visit_with(visitor),
             BinaryOp(_, ref rhs, ref lhs) |
             CheckedBinaryOp(_, ref rhs, ref lhs) =>
                 rhs.visit_with(visitor) || lhs.visit_with(visitor),
             UnaryOp(_, ref val) => val.visit_with(visitor),
-            Discriminant(ref lval) => lval.visit_with(visitor),
+            Discriminant(ref place) => place.visit_with(visitor),
             NullaryOp(_, ty) => ty.visit_with(visitor),
             Aggregate(ref kind, ref fields) => {
                 (match **kind {
@@ -2094,16 +2097,16 @@ impl<'tcx> TypeFoldable<'tcx> for Rvalue<'tcx> {
 impl<'tcx> TypeFoldable<'tcx> for Operand<'tcx> {
     fn super_fold_with<'gcx: 'tcx, F: TypeFolder<'gcx, 'tcx>>(&self, folder: &mut F) -> Self {
         match *self {
-            Operand::Copy(ref lval) => Operand::Copy(lval.fold_with(folder)),
-            Operand::Move(ref lval) => Operand::Move(lval.fold_with(folder)),
+            Operand::Copy(ref place) => Operand::Copy(place.fold_with(folder)),
+            Operand::Move(ref place) => Operand::Move(place.fold_with(folder)),
             Operand::Constant(ref c) => Operand::Constant(c.fold_with(folder)),
         }
     }
 
     fn super_visit_with<V: TypeVisitor<'tcx>>(&self, visitor: &mut V) -> bool {
         match *self {
-            Operand::Copy(ref lval) |
-            Operand::Move(ref lval) => lval.visit_with(visitor),
+            Operand::Copy(ref place) |
+            Operand::Move(ref place) => place.visit_with(visitor),
             Operand::Constant(ref c) => c.visit_with(visitor)
         }
     }

--- a/src/librustc/mir/tcx.rs
+++ b/src/librustc/mir/tcx.rs
@@ -151,11 +151,11 @@ impl<'tcx> Rvalue<'tcx> {
             Rvalue::Repeat(ref operand, count) => {
                 tcx.mk_array_const_usize(operand.ty(local_decls, tcx), count)
             }
-            Rvalue::Ref(reg, bk, ref lv) => {
-                let lv_ty = lv.ty(local_decls, tcx).to_ty(tcx);
+            Rvalue::Ref(reg, bk, ref place) => {
+                let place_ty = place.ty(local_decls, tcx).to_ty(tcx);
                 tcx.mk_ref(reg,
                     ty::TypeAndMut {
-                        ty: lv_ty,
+                        ty: place_ty,
                         mutbl: bk.to_mutbl_lossy()
                     }
                 )
@@ -177,8 +177,8 @@ impl<'tcx> Rvalue<'tcx> {
             Rvalue::UnaryOp(UnOp::Neg, ref operand) => {
                 operand.ty(local_decls, tcx)
             }
-            Rvalue::Discriminant(ref lval) => {
-                let ty = lval.ty(local_decls, tcx).to_ty(tcx);
+            Rvalue::Discriminant(ref place) => {
+                let ty = place.ty(local_decls, tcx).to_ty(tcx);
                 if let ty::TyAdt(adt_def, _) = ty.sty {
                     adt_def.repr.discr_type().to_ty(tcx)
                 } else {

--- a/src/librustc_mir/borrow_check.rs
+++ b/src/librustc_mir/borrow_check.rs
@@ -247,17 +247,17 @@ impl<'cx, 'gcx, 'tcx> DataflowResultsConsumer<'cx, 'tcx> for MirBorrowckCtxt<'cx
                 // NOTE: NLL RFC calls for *shallow* write; using Deep
                 // for short-term compat w/ AST-borrowck. Also, switch
                 // to shallow requires to dataflow: "if this is an
-                // assignment `lv = <rvalue>`, then any loan for some
-                // path P of which `lv` is a prefix is killed."
-                self.mutate_lvalue(ContextKind::AssignLhs.new(location),
+                // assignment `place = <rvalue>`, then any loan for some
+                // path P of which `place` is a prefix is killed."
+                self.mutate_place(ContextKind::AssignLhs.new(location),
                                    (lhs, span), Deep, JustWrite, flow_state);
 
                 self.consume_rvalue(ContextKind::AssignRhs.new(location),
                                     (rhs, span), location, flow_state);
             }
-            StatementKind::SetDiscriminant { ref lvalue, variant_index: _ } => {
-                self.mutate_lvalue(ContextKind::SetDiscrim.new(location),
-                                   (lvalue, span),
+            StatementKind::SetDiscriminant { ref place, variant_index: _ } => {
+                self.mutate_place(ContextKind::SetDiscrim.new(location),
+                                   (place, span),
                                    Shallow(Some(ArtificialField::Discriminant)),
                                    JustWrite,
                                    flow_state);
@@ -267,8 +267,8 @@ impl<'cx, 'gcx, 'tcx> DataflowResultsConsumer<'cx, 'tcx> for MirBorrowckCtxt<'cx
                 for (o, output) in asm.outputs.iter().zip(outputs) {
                     if o.is_indirect {
                         // FIXME(eddyb) indirect inline asm outputs should
-                        // be encoeded through MIR lvalue derefs instead.
-                        self.access_lvalue(context,
+                        // be encoeded through MIR place derefs instead.
+                        self.access_place(context,
                                            (output, span),
                                            (Deep, Read(ReadKind::Copy)),
                                            LocalMutationIsAllowed::No,
@@ -276,7 +276,7 @@ impl<'cx, 'gcx, 'tcx> DataflowResultsConsumer<'cx, 'tcx> for MirBorrowckCtxt<'cx
                         self.check_if_path_is_moved(context, InitializationRequiringAction::Use,
                                                     (output, span), flow_state);
                     } else {
-                        self.mutate_lvalue(context,
+                        self.mutate_place(context,
                                            (output, span),
                                            Deep,
                                            if o.is_rw { WriteAndRead } else { JustWrite },
@@ -299,7 +299,7 @@ impl<'cx, 'gcx, 'tcx> DataflowResultsConsumer<'cx, 'tcx> for MirBorrowckCtxt<'cx
             }
 
             StatementKind::StorageDead(local) => {
-                self.access_lvalue(ContextKind::StorageDead.new(location),
+                self.access_place(ContextKind::StorageDead.new(location),
                     (&Place::Local(local), span),
                     (Shallow(None), Write(WriteKind::StorageDeadOrDrop)),
                     LocalMutationIsAllowed::Yes,
@@ -321,19 +321,19 @@ impl<'cx, 'gcx, 'tcx> DataflowResultsConsumer<'cx, 'tcx> for MirBorrowckCtxt<'cx
                 self.consume_operand(ContextKind::SwitchInt.new(loc),
                                      (discr, span), flow_state);
             }
-            TerminatorKind::Drop { location: ref drop_lvalue, target: _, unwind: _ } => {
-                self.access_lvalue(ContextKind::Drop.new(loc),
-                                   (drop_lvalue, span),
+            TerminatorKind::Drop { location: ref drop_place, target: _, unwind: _ } => {
+                self.access_place(ContextKind::Drop.new(loc),
+                                   (drop_place, span),
                                    (Deep, Write(WriteKind::StorageDeadOrDrop)),
                                    LocalMutationIsAllowed::Yes,
                                    flow_state);
             }
-            TerminatorKind::DropAndReplace { location: ref drop_lvalue,
+            TerminatorKind::DropAndReplace { location: ref drop_place,
                                              value: ref new_value,
                                              target: _,
                                              unwind: _ } => {
-                self.mutate_lvalue(ContextKind::DropAndReplace.new(loc),
-                                   (drop_lvalue, span),
+                self.mutate_place(ContextKind::DropAndReplace.new(loc),
+                                   (drop_place, span),
                                    Deep,
                                    JustWrite,
                                    flow_state);
@@ -348,7 +348,7 @@ impl<'cx, 'gcx, 'tcx> DataflowResultsConsumer<'cx, 'tcx> for MirBorrowckCtxt<'cx
                                          (arg, span), flow_state);
                 }
                 if let Some((ref dest, _/*bb*/)) = *destination {
-                    self.mutate_lvalue(ContextKind::CallDest.new(loc),
+                    self.mutate_place(ContextKind::CallDest.new(loc),
                                        (dest, span),
                                        Deep,
                                        JustWrite,
@@ -385,24 +385,24 @@ impl<'cx, 'gcx, 'tcx> DataflowResultsConsumer<'cx, 'tcx> for MirBorrowckCtxt<'cx
                 // so this "extra check" serves as a kind of backup.
                 let domain = flow_state.borrows.base_results.operator();
                 for borrow in domain.borrows() {
-                    let root_lvalue = self.prefixes(
-                        &borrow.lvalue,
+                    let root_place = self.prefixes(
+                        &borrow.place,
                         PrefixSet::All
                     ).last().unwrap();
-                    match root_lvalue {
+                    match root_place {
                         Place::Static(_) => {
-                            self.access_lvalue(
+                            self.access_place(
                                 ContextKind::StorageDead.new(loc),
-                                (&root_lvalue, self.mir.source_info(borrow.location).span),
+                                (&root_place, self.mir.source_info(borrow.location).span),
                                 (Deep, Write(WriteKind::StorageDeadOrDrop)),
                                 LocalMutationIsAllowed::Yes,
                                 flow_state
                             );
                         }
                         Place::Local(_) => {
-                            self.access_lvalue(
+                            self.access_place(
                                 ContextKind::StorageDead.new(loc),
-                                (&root_lvalue, self.mir.source_info(borrow.location).span),
+                                (&root_place, self.mir.source_info(borrow.location).span),
                                 (Shallow(None), Write(WriteKind::StorageDeadOrDrop)),
                                 LocalMutationIsAllowed::Yes,
                                 flow_state
@@ -446,7 +446,7 @@ enum ShallowOrDeep {
     Shallow(Option<ArtificialField>),
 
     /// From the RFC: "A *deep* access means that all data reachable
-    /// through the given lvalue may be invalidated or accesses by
+    /// through the given place may be invalidated or accesses by
     /// this action."
     Deep,
 }
@@ -483,8 +483,8 @@ enum WriteKind {
     Move,
 }
 
-/// When checking permissions for an lvalue access, this flag is used to indicate that an immutable
-/// local lvalue can be mutated.
+/// When checking permissions for a place access, this flag is used to indicate that an immutable
+/// local place can be mutated.
 ///
 /// FIXME: @nikomatsakis suggested that this flag could be removed with the following modifications:
 /// - Merge `check_access_permissions()` and `check_if_reassignment_to_immutable_state()`
@@ -526,21 +526,21 @@ impl InitializationRequiringAction {
 }
 
 impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
-    /// Checks an access to the given lvalue to see if it is allowed. Examines the set of borrows
+    /// Checks an access to the given place to see if it is allowed. Examines the set of borrows
     /// that are in scope, as well as which paths have been initialized, to ensure that (a) the
-    /// lvalue is initialized and (b) it is not borrowed in some way that would prevent this
+    /// place is initialized and (b) it is not borrowed in some way that would prevent this
     /// access.
     ///
     /// Returns true if an error is reported, false otherwise.
-    fn access_lvalue(&mut self,
+    fn access_place(&mut self,
                      context: Context,
-                     lvalue_span: (&Place<'tcx>, Span),
+                     place_span: (&Place<'tcx>, Span),
                      kind: (ShallowOrDeep, ReadOrWrite),
                      is_local_mutation_allowed: LocalMutationIsAllowed,
                      flow_state: &InProgress<'cx, 'gcx, 'tcx>) {
         let (sd, rw) = kind;
 
-        let storage_dead_or_drop_local = match (lvalue_span.0, rw) {
+        let storage_dead_or_drop_local = match (place_span.0, rw) {
             (&Place::Local(local), Write(WriteKind::StorageDeadOrDrop)) => Some(local),
             _ => None
         };
@@ -553,12 +553,12 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         }
 
         // Check permissions
-        let mut error_reported = self.check_access_permissions(lvalue_span,
+        let mut error_reported = self.check_access_permissions(place_span,
                                                                rw,
                                                                is_local_mutation_allowed);
 
         self.each_borrow_involving_path(
-            context, (sd, lvalue_span.0), flow_state, |this, _index, borrow, common_prefix| {
+            context, (sd, place_span.0), flow_state, |this, _index, borrow, common_prefix| {
                 match (rw, borrow.kind) {
                     (Read(_), BorrowKind::Shared) => {
                         Control::Continue
@@ -569,7 +569,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                             ReadKind::Copy => {
                                 error_reported = true;
                                 this.report_use_while_mutably_borrowed(
-                                    context, lvalue_span, borrow)
+                                    context, place_span, borrow)
                             },
                             ReadKind::Borrow(bk) => {
                                 let end_issued_loan_span =
@@ -577,7 +577,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                                         &borrow.region);
                                 error_reported = true;
                                 this.report_conflicting_borrow(
-                                    context, common_prefix, lvalue_span, bk,
+                                    context, common_prefix, place_span, bk,
                                     &borrow, end_issued_loan_span)
                             }
                         }
@@ -591,7 +591,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                                         &borrow.region);
                                 error_reported = true;
                                 this.report_conflicting_borrow(
-                                    context, common_prefix, lvalue_span, bk,
+                                    context, common_prefix, place_span, bk,
                                     &borrow, end_issued_loan_span)
                             }
                              WriteKind::StorageDeadOrDrop => {
@@ -600,17 +600,17 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                                         &borrow.region);
                                 error_reported = true;
                                 this.report_borrowed_value_does_not_live_long_enough(
-                                    context, lvalue_span, end_span)
+                                    context, place_span, end_span)
                             },
                             WriteKind::Mutate => {
                                 error_reported = true;
                                 this.report_illegal_mutation_of_borrowed(
-                                    context, lvalue_span, borrow)
+                                    context, place_span, borrow)
                             },
                             WriteKind::Move => {
                                 error_reported = true;
                                 this.report_move_out_while_borrowed(
-                                    context, lvalue_span, &borrow)
+                                    context, place_span, &borrow)
                             },
                         }
                         Control::Break
@@ -625,9 +625,9 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         }
     }
 
-    fn mutate_lvalue(&mut self,
+    fn mutate_place(&mut self,
                      context: Context,
-                     lvalue_span: (&Place<'tcx>, Span),
+                     place_span: (&Place<'tcx>, Span),
                      kind: ShallowOrDeep,
                      mode: MutateMode,
                      flow_state: &InProgress<'cx, 'gcx, 'tcx>) {
@@ -635,21 +635,21 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         match mode {
             MutateMode::WriteAndRead => {
                 self.check_if_path_is_moved(context, InitializationRequiringAction::Update,
-                                            lvalue_span, flow_state);
+                                            place_span, flow_state);
             }
             MutateMode::JustWrite => {
-                self.check_if_assigned_path_is_moved(context, lvalue_span, flow_state);
+                self.check_if_assigned_path_is_moved(context, place_span, flow_state);
             }
         }
 
-        self.access_lvalue(context,
-                           lvalue_span,
+        self.access_place(context,
+                           place_span,
                            (kind, Write(WriteKind::Mutate)),
                            LocalMutationIsAllowed::Yes,
                            flow_state);
 
         // check for reassignments to immutable local variables
-        self.check_if_reassignment_to_immutable_state(context, lvalue_span, flow_state);
+        self.check_if_reassignment_to_immutable_state(context, place_span, flow_state);
     }
 
     fn consume_rvalue(&mut self,
@@ -658,19 +658,19 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                       _location: Location,
                       flow_state: &InProgress<'cx, 'gcx, 'tcx>) {
         match *rvalue {
-            Rvalue::Ref(_/*rgn*/, bk, ref lvalue) => {
+            Rvalue::Ref(_/*rgn*/, bk, ref place) => {
                 let access_kind = match bk {
                     BorrowKind::Shared => (Deep, Read(ReadKind::Borrow(bk))),
                     BorrowKind::Unique |
                     BorrowKind::Mut => (Deep, Write(WriteKind::MutableBorrow(bk))),
                 };
-                self.access_lvalue(context,
-                                   (lvalue, span),
+                self.access_place(context,
+                                   (place, span),
                                    access_kind,
                                    LocalMutationIsAllowed::No,
                                    flow_state);
                 self.check_if_path_is_moved(context, InitializationRequiringAction::Borrow,
-                                            (lvalue, span), flow_state);
+                                            (place, span), flow_state);
             }
 
             Rvalue::Use(ref operand) |
@@ -680,20 +680,20 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                 self.consume_operand(context, (operand, span), flow_state)
             }
 
-            Rvalue::Len(ref lvalue) |
-            Rvalue::Discriminant(ref lvalue) => {
+            Rvalue::Len(ref place) |
+            Rvalue::Discriminant(ref place) => {
                 let af = match *rvalue {
                     Rvalue::Len(..) => ArtificialField::ArrayLength,
                     Rvalue::Discriminant(..) => ArtificialField::Discriminant,
                     _ => unreachable!(),
                 };
-                self.access_lvalue(context,
-                                   (lvalue, span),
+                self.access_place(context,
+                                   (place, span),
                                    (Shallow(Some(af)), Read(ReadKind::Copy)),
                                    LocalMutationIsAllowed::No,
                                    flow_state);
                 self.check_if_path_is_moved(context, InitializationRequiringAction::Use,
-                                            (lvalue, span), flow_state);
+                                            (place, span), flow_state);
             }
 
             Rvalue::BinaryOp(_bin_op, ref operand1, ref operand2) |
@@ -723,30 +723,30 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                        (operand, span): (&Operand<'tcx>, Span),
                        flow_state: &InProgress<'cx, 'gcx, 'tcx>) {
         match *operand {
-            Operand::Copy(ref lvalue) => {
-                // copy of lvalue: check if this is "copy of frozen path"
+            Operand::Copy(ref place) => {
+                // copy of place: check if this is "copy of frozen path"
                 // (FIXME: see check_loans.rs)
-                self.access_lvalue(context,
-                                   (lvalue, span),
+                self.access_place(context,
+                                   (place, span),
                                    (Deep, Read(ReadKind::Copy)),
                                    LocalMutationIsAllowed::No,
                                    flow_state);
 
                 // Finally, check if path was already moved.
                 self.check_if_path_is_moved(context, InitializationRequiringAction::Use,
-                                            (lvalue, span), flow_state);
+                                            (place, span), flow_state);
             }
-            Operand::Move(ref lvalue) => {
-                // move of lvalue: check if this is move of already borrowed path
-                self.access_lvalue(context,
-                                   (lvalue, span),
+            Operand::Move(ref place) => {
+                // move of place: check if this is move of already borrowed path
+                self.access_place(context,
+                                   (place, span),
                                    (Deep, Write(WriteKind::Move)),
                                    LocalMutationIsAllowed::Yes,
                                    flow_state);
 
                 // Finally, check if path was already moved.
                 self.check_if_path_is_moved(context, InitializationRequiringAction::Use,
-                                            (lvalue, span), flow_state);
+                                            (place, span), flow_state);
             }
             Operand::Constant(_) => {}
         }
@@ -756,32 +756,32 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
 impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
     fn check_if_reassignment_to_immutable_state(&mut self,
                                                 context: Context,
-                                                (lvalue, span): (&Place<'tcx>, Span),
+                                                (place, span): (&Place<'tcx>, Span),
                                                 flow_state: &InProgress<'cx, 'gcx, 'tcx>) {
         let move_data = self.move_data;
 
         // determine if this path has a non-mut owner (and thus needs checking).
-        if let Ok(()) = self.is_mutable(lvalue, LocalMutationIsAllowed::No) {
+        if let Ok(()) = self.is_mutable(place, LocalMutationIsAllowed::No) {
             return;
         }
 
-        if let Err(_) = self.is_mutable(lvalue, LocalMutationIsAllowed::Yes) {
+        if let Err(_) = self.is_mutable(place, LocalMutationIsAllowed::Yes) {
             return;
         }
 
-        match self.move_path_closest_to(lvalue) {
+        match self.move_path_closest_to(place) {
             Ok(mpi) => {
                 for ii in &move_data.init_path_map[mpi] {
                     if flow_state.ever_inits.curr_state.contains(ii) {
                         let first_assign_span = self.move_data.inits[*ii].span;
                         self.report_illegal_reassignment(
-                            context, (lvalue, span), first_assign_span);
+                            context, (place, span), first_assign_span);
                         break;
                     }
                 }
             },
             Err(NoMovePathFound::ReachedStatic) => {
-                let item_msg = match self.describe_lvalue(lvalue) {
+                let item_msg = match self.describe_place(place) {
                     Some(name) => format!("immutable static item `{}`", name),
                     None => "immutable static item".to_owned()
                 };
@@ -795,11 +795,11 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
     fn check_if_path_is_moved(&mut self,
                               context: Context,
                               desired_action: InitializationRequiringAction,
-                              lvalue_span: (&Place<'tcx>, Span),
+                              place_span: (&Place<'tcx>, Span),
                               flow_state: &InProgress<'cx, 'gcx, 'tcx>) {
-        // FIXME: analogous code in check_loans first maps `lvalue` to
+        // FIXME: analogous code in check_loans first maps `place` to
         // its base_path ... but is that what we want here?
-        let lvalue = self.base_path(lvalue_span.0);
+        let place = self.base_path(place_span.0);
 
         let maybe_uninits = &flow_state.uninits;
         let curr_move_outs = &flow_state.move_outs.curr_state;
@@ -836,16 +836,16 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
 
         // Therefore, if we seek out the *closest* prefix for which we
         // have a MovePath, that should capture the initialization
-        // state for the lvalue scenario.
+        // state for the place scenario.
         //
         // This code covers scenarios 1, 2, and 4.
 
-        debug!("check_if_path_is_moved part1 lvalue: {:?}", lvalue);
-        match self.move_path_closest_to(lvalue) {
+        debug!("check_if_path_is_moved part1 place: {:?}", place);
+        match self.move_path_closest_to(place) {
             Ok(mpi) => {
                 if maybe_uninits.curr_state.contains(&mpi) {
                     self.report_use_of_moved_or_uninitialized(context, desired_action,
-                                                              lvalue_span, mpi,
+                                                              place_span, mpi,
                                                               curr_move_outs);
                     return; // don't bother finding other problems.
                 }
@@ -862,40 +862,40 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
             // to do such a query based on partial-init feature-gate.)
         }
 
-        // A move of any shallow suffix of `lvalue` also interferes
-        // with an attempt to use `lvalue`. This is scenario 3 above.
+        // A move of any shallow suffix of `place` also interferes
+        // with an attempt to use `place`. This is scenario 3 above.
         //
         // (Distinct from handling of scenarios 1+2+4 above because
-        // `lvalue` does not interfere with suffixes of its prefixes,
+        // `place` does not interfere with suffixes of its prefixes,
         // e.g. `a.b.c` does not interfere with `a.b.d`)
 
-        debug!("check_if_path_is_moved part2 lvalue: {:?}", lvalue);
-        if let Some(mpi) = self.move_path_for_lvalue(lvalue) {
+        debug!("check_if_path_is_moved part2 place: {:?}", place);
+        if let Some(mpi) = self.move_path_for_place(place) {
             if let Some(child_mpi) = maybe_uninits.has_any_child_of(mpi) {
                 self.report_use_of_moved_or_uninitialized(context, desired_action,
-                                                          lvalue_span, child_mpi,
+                                                          place_span, child_mpi,
                                                           curr_move_outs);
                 return; // don't bother finding other problems.
             }
         }
     }
 
-    /// Currently MoveData does not store entries for all lvalues in
+    /// Currently MoveData does not store entries for all places in
     /// the input MIR. For example it will currently filter out
-    /// lvalues that are Copy; thus we do not track lvalues of shared
-    /// reference type. This routine will walk up an lvalue along its
-    /// prefixes, searching for a foundational lvalue that *is*
+    /// places that are Copy; thus we do not track places of shared
+    /// reference type. This routine will walk up a place along its
+    /// prefixes, searching for a foundational place that *is*
     /// tracked in the MoveData.
     ///
     /// An Err result includes a tag indicated why the search failed.
-    /// Currenly this can only occur if the lvalue is built off of a
+    /// Currenly this can only occur if the place is built off of a
     /// static variable, as we do not track those in the MoveData.
-    fn move_path_closest_to(&mut self, lvalue: &Place<'tcx>)
+    fn move_path_closest_to(&mut self, place: &Place<'tcx>)
                             -> Result<MovePathIndex, NoMovePathFound>
     {
-        let mut last_prefix = lvalue;
-        for prefix in self.prefixes(lvalue, PrefixSet::All) {
-            if let Some(mpi) = self.move_path_for_lvalue(prefix) {
+        let mut last_prefix = place;
+        for prefix in self.prefixes(place, PrefixSet::All) {
+            if let Some(mpi) = self.move_path_for_place(prefix) {
                 return Ok(mpi);
             }
             last_prefix = prefix;
@@ -907,15 +907,15 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         }
     }
 
-    fn move_path_for_lvalue(&mut self,
-                            lvalue: &Place<'tcx>)
+    fn move_path_for_place(&mut self,
+                            place: &Place<'tcx>)
                             -> Option<MovePathIndex>
     {
         // If returns None, then there is no move path corresponding
-        // to a direct owner of `lvalue` (which means there is nothing
+        // to a direct owner of `place` (which means there is nothing
         // that borrowck tracks for its analysis).
 
-        match self.move_data.rev_lookup.find(lvalue) {
+        match self.move_data.rev_lookup.find(place) {
             LookupResult::Parent(_) => None,
             LookupResult::Exact(mpi) => Some(mpi),
         }
@@ -923,12 +923,12 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
 
     fn check_if_assigned_path_is_moved(&mut self,
                                        context: Context,
-                                       (lvalue, span): (&Place<'tcx>, Span),
+                                       (place, span): (&Place<'tcx>, Span),
                                        flow_state: &InProgress<'cx, 'gcx, 'tcx>) {
-        // recur down lvalue; dispatch to check_if_path_is_moved when necessary
-        let mut lvalue = lvalue;
+        // recur down place; dispatch to check_if_path_is_moved when necessary
+        let mut place = place;
         loop {
-            match *lvalue {
+            match *place {
                 Place::Local(_) | Place::Static(_) => {
                     // assigning to `x` does not require `x` be initialized.
                     break;
@@ -977,35 +977,35 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                         }
                     }
 
-                    lvalue = base;
+                    place = base;
                     continue;
                 }
             }
         }
     }
 
-    /// Check the permissions for the given lvalue and read or write kind
+    /// Check the permissions for the given place and read or write kind
     ///
     /// Returns true if an error is reported, false otherwise.
     fn check_access_permissions(&self,
-                                (lvalue, span): (&Place<'tcx>, Span),
+                                (place, span): (&Place<'tcx>, Span),
                                 kind: ReadOrWrite,
                                 is_local_mutation_allowed: LocalMutationIsAllowed)
                                 -> bool {
         debug!("check_access_permissions({:?}, {:?}, {:?})",
-               lvalue, kind, is_local_mutation_allowed);
+               place, kind, is_local_mutation_allowed);
         let mut error_reported = false;
         match kind {
             Write(WriteKind::MutableBorrow(BorrowKind::Unique)) => {
-                if let Err(_lvalue_err) = self.is_unique(lvalue) {
-                    span_bug!(span, "&unique borrow for {:?} should not fail", lvalue);
+                if let Err(_place_err) = self.is_unique(place) {
+                    span_bug!(span, "&unique borrow for {:?} should not fail", place);
                 }
             },
             Write(WriteKind::MutableBorrow(BorrowKind::Mut)) => {
-                if let Err(lvalue_err) = self.is_mutable(lvalue, is_local_mutation_allowed) {
+                if let Err(place_err) = self.is_mutable(place, is_local_mutation_allowed) {
                     error_reported = true;
 
-                    let item_msg = match self.describe_lvalue(lvalue) {
+                    let item_msg = match self.describe_place(place) {
                         Some(name) => format!("immutable item `{}`", name),
                         None => "immutable item".to_owned()
                     };
@@ -1015,8 +1015,8 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                         Origin::Mir);
                     err.span_label(span, "cannot borrow as mutable");
 
-                    if lvalue != lvalue_err {
-                        if let Some(name) = self.describe_lvalue(lvalue_err) {
+                    if place != place_err {
+                        if let Some(name) = self.describe_place(place_err) {
                             err.note(&format!("Value not mutable causing this error: `{}`", name));
                         }
                     }
@@ -1025,10 +1025,10 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                 }
             },
             Write(WriteKind::Mutate) => {
-                if let Err(lvalue_err) = self.is_mutable(lvalue, is_local_mutation_allowed) {
+                if let Err(place_err) = self.is_mutable(place, is_local_mutation_allowed) {
                     error_reported = true;
 
-                    let item_msg = match self.describe_lvalue(lvalue) {
+                    let item_msg = match self.describe_place(place) {
                         Some(name) => format!("immutable item `{}`", name),
                         None => "immutable item".to_owned()
                     };
@@ -1038,8 +1038,8 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                         Origin::Mir);
                     err.span_label(span, "cannot mutate");
 
-                    if lvalue != lvalue_err {
-                        if let Some(name) = self.describe_lvalue(lvalue_err) {
+                    if place != place_err {
+                        if let Some(name) = self.describe_place(place_err) {
                             err.note(&format!("Value not mutable causing this error: `{}`", name));
                         }
                     }
@@ -1050,10 +1050,10 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
             Write(WriteKind::Move) |
             Write(WriteKind::StorageDeadOrDrop) |
             Write(WriteKind::MutableBorrow(BorrowKind::Shared)) => {
-                if let Err(_lvalue_err) = self.is_mutable(lvalue, is_local_mutation_allowed) {
+                if let Err(_place_err) = self.is_mutable(place, is_local_mutation_allowed) {
                     self.tcx.sess.delay_span_bug(span,
                         &format!("Accessing `{:?}` with the kind `{:?}` shouldn't be possible",
-                            lvalue,
+                            place,
                             kind));
                 }
             },
@@ -1068,24 +1068,24 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
 
     /// Can this value be written or borrowed mutably
     fn is_mutable<'d>(&self,
-                      lvalue: &'d Place<'tcx>,
+                      place: &'d Place<'tcx>,
                       is_local_mutation_allowed: LocalMutationIsAllowed)
                       -> Result<(), &'d Place<'tcx>> {
-        match *lvalue {
+        match *place {
             Place::Local(local) => {
                 let local = &self.mir.local_decls[local];
                 match local.mutability {
                     Mutability::Not =>
                         match is_local_mutation_allowed {
                             LocalMutationIsAllowed::Yes => Ok(()),
-                            LocalMutationIsAllowed::No => Err(lvalue),
+                            LocalMutationIsAllowed::No => Err(place),
                         },
                     Mutability::Mut => Ok(())
                 }
             },
             Place::Static(ref static_) => {
                 if !self.tcx.is_static_mut(static_.def_id) {
-                    Err(lvalue)
+                    Err(place)
                 } else {
                     Ok(())
                 }
@@ -1100,7 +1100,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                             ty::TyRef(_, tnm) => {
                                 match tnm.mutbl {
                                     // Shared borrowed data is never mutable
-                                    hir::MutImmutable => Err(lvalue),
+                                    hir::MutImmutable => Err(place),
                                     // Mutably borrowed data is mutable, but only if we have a
                                     // unique path to the `&mut`
                                     hir::MutMutable => {
@@ -1115,7 +1115,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                             ty::TyRawPtr(tnm) => {
                                 match tnm.mutbl {
                                     // `*const` raw pointers are not mutable
-                                    hir::MutImmutable => Err(lvalue),
+                                    hir::MutImmutable => Err(place),
                                     // `*mut` raw pointers are always mutable, regardless of context
                                     // The users have to check by themselve.
                                     hir::MutMutable => Ok(()),
@@ -1135,14 +1135,14 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                     ProjectionElem::ConstantIndex{..} |
                     ProjectionElem::Subslice{..} |
                     ProjectionElem::Downcast(..) => {
-                        let field_projection = self.is_upvar_field_projection(lvalue);
+                        let field_projection = self.is_upvar_field_projection(place);
 
                         if let Some(field) = field_projection {
                             let decl = &self.mir.upvar_decls[field.index()];
 
                             return match decl.mutability {
                                 Mutability::Mut => self.is_unique(&proj.base),
-                                Mutability::Not => Err(lvalue),
+                                Mutability::Not => Err(place),
                             };
                         }
 
@@ -1153,16 +1153,16 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         }
     }
 
-    /// Does this lvalue have a unique path
-    fn is_unique<'d>(&self, lvalue: &'d Place<'tcx>) -> Result<(), &'d Place<'tcx>> {
-        match *lvalue {
+    /// Does this place have a unique path
+    fn is_unique<'d>(&self, place: &'d Place<'tcx>) -> Result<(), &'d Place<'tcx>> {
+        match *place {
             Place::Local(..) => {
                 // Local variables are unique
                 Ok(())
             },
             Place::Static(..) => {
                 // Static variables are not
-                Err(lvalue)
+                Err(place)
             },
             Place::Projection(ref proj) => {
                 match proj.elem {
@@ -1178,8 +1178,8 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                         match base_ty.sty {
                             ty::TyRef(_, tnm) => {
                                 match tnm.mutbl {
-                                    // lvalue represent an aliased location
-                                    hir::MutImmutable => Err(lvalue),
+                                    // place represent an aliased location
+                                    hir::MutImmutable => Err(place),
                                     // `&mut T` is as unique as the context in which it is found
                                     hir::MutMutable => self.is_unique(&proj.base),
                                 }
@@ -1217,14 +1217,14 @@ enum NoMovePathFound {
 impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
     fn each_borrow_involving_path<F>(&mut self,
                                      _context: Context,
-                                     access_lvalue: (ShallowOrDeep, &Place<'tcx>),
+                                     access_place: (ShallowOrDeep, &Place<'tcx>),
                                      flow_state: &InProgress<'cx, 'gcx, 'tcx>,
                                      mut op: F)
         where F: FnMut(&mut Self, BorrowIndex, &BorrowData<'tcx>, &Place<'tcx>) -> Control
     {
-        let (access, lvalue) = access_lvalue;
+        let (access, place) = access_place;
 
-        // FIXME: analogous code in check_loans first maps `lvalue` to
+        // FIXME: analogous code in check_loans first maps `place` to
         // its base_path.
 
         let domain = flow_state.borrows.base_results.operator();
@@ -1235,21 +1235,21 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         'next_borrow: for i in flow_state.borrows.elems_incoming() {
             let borrowed = &data[i];
 
-            // Is `lvalue` (or a prefix of it) already borrowed? If
+            // Is `place` (or a prefix of it) already borrowed? If
             // so, that's relevant.
             //
             // FIXME: Differs from AST-borrowck; includes drive-by fix
             // to #38899. Will probably need back-compat mode flag.
-            for accessed_prefix in self.prefixes(lvalue, PrefixSet::All) {
-                if *accessed_prefix == borrowed.lvalue {
+            for accessed_prefix in self.prefixes(place, PrefixSet::All) {
+                if *accessed_prefix == borrowed.place {
                     // FIXME: pass in enum describing case we are in?
                     let ctrl = op(self, i, borrowed, accessed_prefix);
                     if ctrl == Control::Break { return; }
                 }
             }
 
-            // Is `lvalue` a prefix (modulo access type) of the
-            // `borrowed.lvalue`? If so, that's relevant.
+            // Is `place` a prefix (modulo access type) of the
+            // `borrowed.place`? If so, that's relevant.
 
             let prefix_kind = match access {
                 Shallow(Some(ArtificialField::Discriminant)) |
@@ -1258,7 +1258,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                     // additional fields on the type; they do not
                     // overlap any existing data there. Furthermore,
                     // they cannot actually be a prefix of any
-                    // borrowed lvalue (at least in MIR as it is
+                    // borrowed place (at least in MIR as it is
                     // currently.)
                     continue 'next_borrow;
                 }
@@ -1266,8 +1266,8 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                 Deep => PrefixSet::Supporting,
             };
 
-            for borrowed_prefix in self.prefixes(&borrowed.lvalue, prefix_kind) {
-                if borrowed_prefix == lvalue {
+            for borrowed_prefix in self.prefixes(&borrowed.place, prefix_kind) {
+                if borrowed_prefix == place {
                     // FIXME: pass in enum describing case we are in?
                     let ctrl = op(self, i, borrowed, borrowed_prefix);
                     if ctrl == Control::Break { return; }
@@ -1280,7 +1280,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
 use self::prefixes::PrefixSet;
 
 /// From the NLL RFC: "The deep [aka 'supporting'] prefixes for an
-/// lvalue are formed by stripping away fields and derefs, except that
+/// place are formed by stripping away fields and derefs, except that
 /// we stop when we reach the deref of a shared reference. [...] "
 ///
 /// "Shallow prefixes are found by stripping away fields, but stop at
@@ -1337,15 +1337,15 @@ mod prefixes {
     }
 
     impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
-        /// Returns an iterator over the prefixes of `lvalue`
+        /// Returns an iterator over the prefixes of `place`
         /// (inclusive) from longest to smallest, potentially
         /// terminating the iteration early based on `kind`.
         pub(super) fn prefixes(&self,
-                               lvalue: &'cx Place<'tcx>,
+                               place: &'cx Place<'tcx>,
                                kind: PrefixSet)
                                -> Prefixes<'cx, 'gcx, 'tcx>
         {
-            Prefixes { next: Some(lvalue), kind, mir: self.mir, tcx: self.tcx }
+            Prefixes { next: Some(place), kind, mir: self.mir, tcx: self.tcx }
         }
     }
 
@@ -1354,11 +1354,11 @@ mod prefixes {
         fn next(&mut self) -> Option<Self::Item> {
             let mut cursor = match self.next {
                 None => return None,
-                Some(lvalue) => lvalue,
+                Some(place) => place,
             };
 
-            // Post-processing `lvalue`: Enqueue any remaining
-            // work. Also, `lvalue` may not be a prefix itself, but
+            // Post-processing `place`: Enqueue any remaining
+            // work. Also, `place` may not be a prefix itself, but
             // may hold one further down (e.g. we never return
             // downcasts here, but may return a base of a downcast).
 
@@ -1447,7 +1447,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
     fn report_use_of_moved_or_uninitialized(&mut self,
                            _context: Context,
                            desired_action: InitializationRequiringAction,
-                           (lvalue, span): (&Place<'tcx>, Span),
+                           (place, span): (&Place<'tcx>, Span),
                            mpi: MovePathIndex,
                            curr_move_out: &IdxSetBuf<MoveOutIndex>) {
 
@@ -1455,13 +1455,13 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
             |moi| curr_move_out.contains(moi)).collect::<Vec<_>>();
 
         if mois.is_empty() {
-            let item_msg = match self.describe_lvalue(lvalue) {
+            let item_msg = match self.describe_place(place) {
                 Some(name) => format!("`{}`", name),
                 None => "value".to_owned()
             };
             self.tcx.cannot_act_on_uninitialized_variable(span,
                                                           desired_action.as_noun(),
-                                                          &self.describe_lvalue(lvalue)
+                                                          &self.describe_place(place)
                                                             .unwrap_or("_".to_owned()),
                                                           Origin::Mir)
                     .span_label(span, format!("use of possibly uninitialized {}", item_msg))
@@ -1472,7 +1472,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
             let mut err = self.tcx.cannot_act_on_moved_value(span,
                                                              desired_action.as_noun(),
                                                              msg,
-                                                             &self.describe_lvalue(lvalue)
+                                                             &self.describe_place(place)
                                                                 .unwrap_or("_".to_owned()),
                                                              Origin::Mir);
 
@@ -1496,18 +1496,18 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
 
     fn report_move_out_while_borrowed(&mut self,
                                       _context: Context,
-                                      (lvalue, span): (&Place<'tcx>, Span),
+                                      (place, span): (&Place<'tcx>, Span),
                                       borrow: &BorrowData<'tcx>) {
-        let value_msg = match self.describe_lvalue(lvalue) {
+        let value_msg = match self.describe_place(place) {
             Some(name) => format!("`{}`", name),
             None => "value".to_owned()
         };
-        let borrow_msg = match self.describe_lvalue(&borrow.lvalue) {
+        let borrow_msg = match self.describe_place(&borrow.place) {
             Some(name) => format!("`{}`", name),
             None => "value".to_owned()
         };
         self.tcx.cannot_move_when_borrowed(span,
-                                           &self.describe_lvalue(lvalue).unwrap_or("_".to_owned()),
+                                           &self.describe_place(place).unwrap_or("_".to_owned()),
                                            Origin::Mir)
                 .span_label(self.retrieve_borrow_span(borrow),
                             format!("borrow of {} occurs here", borrow_msg))
@@ -1517,14 +1517,14 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
 
     fn report_use_while_mutably_borrowed(&mut self,
                                          _context: Context,
-                                         (lvalue, span): (&Place<'tcx>, Span),
+                                         (place, span): (&Place<'tcx>, Span),
                                          borrow : &BorrowData<'tcx>) {
 
         let mut err = self.tcx.cannot_use_when_mutably_borrowed(
             span,
-            &self.describe_lvalue(lvalue).unwrap_or("_".to_owned()),
+            &self.describe_place(place).unwrap_or("_".to_owned()),
             self.retrieve_borrow_span(borrow),
-            &self.describe_lvalue(&borrow.lvalue).unwrap_or("_".to_owned()),
+            &self.describe_place(&borrow.place).unwrap_or("_".to_owned()),
             Origin::Mir);
 
         err.emit();
@@ -1555,9 +1555,9 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                 break;
             }
 
-            if let StatementKind::Assign(_, Rvalue::Aggregate(ref kind, ref lvs)) = stmt.kind {
+            if let StatementKind::Assign(_, Rvalue::Aggregate(ref kind, ref places)) = stmt.kind {
                 if let AggregateKind::Closure(def_id, _) = **kind {
-                    debug!("find_closure_span: found closure {:?}", lvs);
+                    debug!("find_closure_span: found closure {:?}", places);
 
                     return if let Some(node_id) = self.tcx.hir.as_local_node_id(def_id) {
                         let args_span = if let ExprClosure(_, _, _, span, _) =
@@ -1569,8 +1569,8 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                         };
 
                         self.tcx.with_freevars(node_id, |freevars| {
-                            for (v, lv) in freevars.iter().zip(lvs) {
-                                match *lv {
+                            for (v, place) in freevars.iter().zip(places) {
+                                match *place {
                                     Operand::Copy(Place::Local(l)) |
                                     Operand::Move(Place::Local(l)) if local == l => {
                                         debug!(
@@ -1597,14 +1597,14 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
     fn report_conflicting_borrow(&mut self,
                                  context: Context,
                                  common_prefix: &Place<'tcx>,
-                                 (lvalue, span): (&Place<'tcx>, Span),
+                                 (place, span): (&Place<'tcx>, Span),
                                  gen_borrow_kind: BorrowKind,
                                  issued_borrow: &BorrowData,
                                  end_issued_loan_span: Option<Span>) {
         use self::prefixes::IsPrefixOf;
 
-        assert!(common_prefix.is_prefix_of(lvalue));
-        assert!(common_prefix.is_prefix_of(&issued_borrow.lvalue));
+        assert!(common_prefix.is_prefix_of(place));
+        assert!(common_prefix.is_prefix_of(&issued_borrow.place));
 
         let issued_span = self.retrieve_borrow_span(issued_borrow);
 
@@ -1613,7 +1613,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         let old_closure_span = self.find_closure_span(issued_span, issued_borrow.location);
         let issued_span = old_closure_span.map(|(args, _)| args).unwrap_or(issued_span);
 
-        let desc_lvalue = self.describe_lvalue(lvalue).unwrap_or("_".to_owned());
+        let desc_place = self.describe_place(place).unwrap_or("_".to_owned());
 
         // FIXME: supply non-"" `opt_via` when appropriate
         let mut err = match (gen_borrow_kind, "immutable", "mutable",
@@ -1621,27 +1621,27 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
             (BorrowKind::Shared, lft, _, BorrowKind::Mut, _, rgt) |
             (BorrowKind::Mut, _, lft, BorrowKind::Shared, rgt, _) =>
                 self.tcx.cannot_reborrow_already_borrowed(
-                    span, &desc_lvalue, "", lft, issued_span,
+                    span, &desc_place, "", lft, issued_span,
                     "it", rgt, "", end_issued_loan_span, Origin::Mir),
 
             (BorrowKind::Mut, _, _, BorrowKind::Mut, _, _) =>
                 self.tcx.cannot_mutably_borrow_multiply(
-                    span, &desc_lvalue, "", issued_span,
+                    span, &desc_place, "", issued_span,
                     "", end_issued_loan_span, Origin::Mir),
 
             (BorrowKind::Unique, _, _, BorrowKind::Unique, _, _) =>
                 self.tcx.cannot_uniquely_borrow_by_two_closures(
-                    span, &desc_lvalue, issued_span,
+                    span, &desc_place, issued_span,
                     end_issued_loan_span, Origin::Mir),
 
             (BorrowKind::Unique, _, _, _, _, _) =>
                 self.tcx.cannot_uniquely_borrow_by_one_closure(
-                    span, &desc_lvalue, "",
+                    span, &desc_place, "",
                     issued_span, "it", "", end_issued_loan_span, Origin::Mir),
 
             (_, _, _, BorrowKind::Unique, _, _) =>
                 self.tcx.cannot_reborrow_already_uniquely_borrowed(
-                    span, &desc_lvalue, "it", "",
+                    span, &desc_place, "it", "",
                     issued_span, "", end_issued_loan_span, Origin::Mir),
 
             (BorrowKind::Shared, _, _, BorrowKind::Shared, _, _) =>
@@ -1651,14 +1651,14 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         if let Some((_, var_span)) = old_closure_span {
             err.span_label(
                 var_span,
-                format!("previous borrow occurs due to use of `{}` in closure", desc_lvalue),
+                format!("previous borrow occurs due to use of `{}` in closure", desc_place),
             );
         }
 
         if let Some((_, var_span)) = new_closure_span {
             err.span_label(
                 var_span,
-                format!("borrow occurs due to use of `{}` in closure", desc_lvalue),
+                format!("borrow occurs due to use of `{}` in closure", desc_place),
             );
         }
 
@@ -1667,9 +1667,9 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
 
     fn report_borrowed_value_does_not_live_long_enough(&mut self,
                                                        _: Context,
-                                                       (lvalue, span): (&Place, Span),
+                                                       (place, span): (&Place, Span),
                                                        end_span: Option<Span>) {
-        let proper_span = match *lvalue {
+        let proper_span = match *place {
             Place::Local(local) => self.mir.local_decls[local].source_info.span,
             _ => span
         };
@@ -1688,12 +1688,12 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
 
     fn report_illegal_mutation_of_borrowed(&mut self,
                                            _: Context,
-                                           (lvalue, span): (&Place<'tcx>, Span),
+                                           (place, span): (&Place<'tcx>, Span),
                                            loan: &BorrowData) {
         let mut err = self.tcx.cannot_assign_to_borrowed(
             span,
             self.retrieve_borrow_span(loan),
-            &self.describe_lvalue(lvalue).unwrap_or("_".to_owned()),
+            &self.describe_place(place).unwrap_or("_".to_owned()),
             Origin::Mir);
 
         err.emit();
@@ -1701,14 +1701,14 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
 
     fn report_illegal_reassignment(&mut self,
                                    _context: Context,
-                                   (lvalue, span): (&Place<'tcx>, Span),
+                                   (place, span): (&Place<'tcx>, Span),
                                    assigned_span: Span) {
         let mut err = self.tcx.cannot_reassign_immutable(span,
-                                           &self.describe_lvalue(lvalue).unwrap_or("_".to_owned()),
+                                           &self.describe_place(place).unwrap_or("_".to_owned()),
                                            Origin::Mir);
         err.span_label(span, "cannot assign twice to immutable variable");
         if span != assigned_span {
-            let value_msg = match self.describe_lvalue(lvalue) {
+            let value_msg = match self.describe_place(place) {
                 Some(name) => format!("`{}`", name),
                 None => "value".to_owned()
             };
@@ -1719,11 +1719,11 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
 }
 
 impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
-    // End-user visible description of `lvalue` if one can be found. If the
-    // lvalue is a temporary for instance, None will be returned.
-    fn describe_lvalue(&self, lvalue: &Place<'tcx>) -> Option<String> {
+    // End-user visible description of `place` if one can be found. If the
+    // place is a temporary for instance, None will be returned.
+    fn describe_place(&self, place: &Place<'tcx>) -> Option<String> {
         let mut buf = String::new();
-        match self.append_lvalue_to_string(lvalue, &mut buf, false) {
+        match self.append_place_to_string(place, &mut buf, false) {
             Ok(()) => Some(buf),
             Err(()) => None
         }
@@ -1733,8 +1733,8 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
     /// then returns the index of the field being projected. Note that this closure will always
     /// be `self` in the current MIR, because that is the only time we directly access the fields
     /// of a closure type.
-    fn is_upvar_field_projection(&self, lvalue: &Place<'tcx>) -> Option<Field> {
-        match *lvalue {
+    fn is_upvar_field_projection(&self, place: &Place<'tcx>) -> Option<Field> {
+        match *place {
             Place::Projection(ref proj) => {
                 match proj.elem {
                     ProjectionElem::Field(field, _ty) => {
@@ -1754,12 +1754,12 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         }
     }
 
-    // Appends end-user visible description of `lvalue` to `buf`.
-    fn append_lvalue_to_string(&self,
-                               lvalue: &Place<'tcx>,
+    // Appends end-user visible description of `place` to `buf`.
+    fn append_place_to_string(&self,
+                               place: &Place<'tcx>,
                                buf: &mut String,
                                mut autoderef: bool) -> Result<(), ()> {
-        match *lvalue {
+        match *place {
             Place::Local(local) => {
                 self.append_local_to_string(local, buf,)?;
             }
@@ -1779,33 +1779,33 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                             }
                         } else {
                             if autoderef {
-                                self.append_lvalue_to_string(&proj.base, buf, autoderef)?;
+                                self.append_place_to_string(&proj.base, buf, autoderef)?;
                             } else {
                                 buf.push_str(&"*");
-                                self.append_lvalue_to_string(&proj.base, buf, autoderef)?;
+                                self.append_place_to_string(&proj.base, buf, autoderef)?;
                             }
                         }
                     },
                     ProjectionElem::Downcast(..) => {
-                        self.append_lvalue_to_string(&proj.base, buf, autoderef)?;
+                        self.append_place_to_string(&proj.base, buf, autoderef)?;
                     },
                     ProjectionElem::Field(field, _ty) => {
                         autoderef = true;
 
-                        if let Some(field) = self.is_upvar_field_projection(lvalue) {
+                        if let Some(field) = self.is_upvar_field_projection(place) {
                             let var_index = field.index();
                             let name = self.mir.upvar_decls[var_index].debug_name.to_string();
                             buf.push_str(&name);
                         } else {
                             let field_name = self.describe_field(&proj.base, field);
-                            self.append_lvalue_to_string(&proj.base, buf, autoderef)?;
+                            self.append_place_to_string(&proj.base, buf, autoderef)?;
                             buf.push_str(&format!(".{}", field_name));
                         }
                     },
                     ProjectionElem::Index(index) => {
                         autoderef = true;
 
-                        self.append_lvalue_to_string(&proj.base, buf, autoderef)?;
+                        self.append_place_to_string(&proj.base, buf, autoderef)?;
                         buf.push_str("[");
                         if let Err(_) = self.append_local_to_string(index, buf) {
                             buf.push_str("..");
@@ -1817,7 +1817,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                         // Since it isn't possible to borrow an element on a particular index and
                         // then use another while the borrow is held, don't output indices details
                         // to avoid confusing the end-user
-                        self.append_lvalue_to_string(&proj.base, buf, autoderef)?;
+                        self.append_place_to_string(&proj.base, buf, autoderef)?;
                         buf.push_str(&"[..]");
                     },
                 };
@@ -1827,7 +1827,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         Ok(())
     }
 
-    // Appends end-user visible description of the `local` lvalue to `buf`. If `local` doesn't have
+    // Appends end-user visible description of the `local` place to `buf`. If `local` doesn't have
     // a name, then `Err` is returned
     fn append_local_to_string(&self, local_index: Local, buf: &mut String) -> Result<(), ()> {
         let local = &self.mir.local_decls[local_index];
@@ -1923,20 +1923,20 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
     // moves out of a Box. They should be removed when/if we stop
     // treating Box specially (e.g. when/if DerefMove is added...)
 
-    fn base_path<'d>(&self, lvalue: &'d Place<'tcx>) -> &'d Place<'tcx> {
+    fn base_path<'d>(&self, place: &'d Place<'tcx>) -> &'d Place<'tcx> {
         //! Returns the base of the leftmost (deepest) dereference of an
-        //! Box in `lvalue`. If there is no dereference of an Box
-        //! in `lvalue`, then it just returns `lvalue` itself.
+        //! Box in `place`. If there is no dereference of an Box
+        //! in `place`, then it just returns `place` itself.
 
-        let mut cursor = lvalue;
-        let mut deepest = lvalue;
+        let mut cursor = place;
+        let mut deepest = place;
         loop {
             let proj = match *cursor {
                 Place::Local(..) | Place::Static(..) => return deepest,
                 Place::Projection(ref proj) => proj,
             };
             if proj.elem == ProjectionElem::Deref &&
-                lvalue.ty(self.mir, self.tcx).to_ty(self.tcx).is_box()
+                place.ty(self.mir, self.tcx).to_ty(self.tcx).is_box()
             {
                 deepest = &proj.base;
             }

--- a/src/librustc_mir/build/block.rs
+++ b/src/librustc_mir/build/block.rs
@@ -16,7 +16,7 @@ use syntax_pos::Span;
 
 impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     pub fn ast_block(&mut self,
-                     destination: &Lvalue<'tcx>,
+                     destination: &Place<'tcx>,
                      block: BasicBlock,
                      ast_block: &'tcx hir::Block,
                      source_info: SourceInfo)
@@ -53,7 +53,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     }
 
     fn ast_block_stmts(&mut self,
-                       destination: &Lvalue<'tcx>,
+                       destination: &Place<'tcx>,
                        mut block: BasicBlock,
                        span: Span,
                        stmts: Vec<StmtRef<'tcx>>,

--- a/src/librustc_mir/build/cfg.rs
+++ b/src/librustc_mir/build/cfg.rs
@@ -61,7 +61,7 @@ impl<'tcx> CFG<'tcx> {
     pub fn push_assign(&mut self,
                        block: BasicBlock,
                        source_info: SourceInfo,
-                       lvalue: &Lvalue<'tcx>,
+                       lvalue: &Place<'tcx>,
                        rvalue: Rvalue<'tcx>) {
         self.push(block, Statement {
             source_info,
@@ -72,7 +72,7 @@ impl<'tcx> CFG<'tcx> {
     pub fn push_assign_constant(&mut self,
                                 block: BasicBlock,
                                 source_info: SourceInfo,
-                                temp: &Lvalue<'tcx>,
+                                temp: &Place<'tcx>,
                                 constant: Constant<'tcx>) {
         self.push_assign(block, source_info, temp,
                          Rvalue::Use(Operand::Constant(box constant)));
@@ -81,7 +81,7 @@ impl<'tcx> CFG<'tcx> {
     pub fn push_assign_unit(&mut self,
                             block: BasicBlock,
                             source_info: SourceInfo,
-                            lvalue: &Lvalue<'tcx>) {
+                            lvalue: &Place<'tcx>) {
         self.push_assign(block, source_info, lvalue, Rvalue::Aggregate(
             box AggregateKind::Tuple, vec![]
         ));

--- a/src/librustc_mir/build/cfg.rs
+++ b/src/librustc_mir/build/cfg.rs
@@ -61,11 +61,11 @@ impl<'tcx> CFG<'tcx> {
     pub fn push_assign(&mut self,
                        block: BasicBlock,
                        source_info: SourceInfo,
-                       lvalue: &Place<'tcx>,
+                       place: &Place<'tcx>,
                        rvalue: Rvalue<'tcx>) {
         self.push(block, Statement {
             source_info,
-            kind: StatementKind::Assign(lvalue.clone(), rvalue)
+            kind: StatementKind::Assign(place.clone(), rvalue)
         });
     }
 
@@ -81,8 +81,8 @@ impl<'tcx> CFG<'tcx> {
     pub fn push_assign_unit(&mut self,
                             block: BasicBlock,
                             source_info: SourceInfo,
-                            lvalue: &Place<'tcx>) {
-        self.push_assign(block, source_info, lvalue, Rvalue::Aggregate(
+                            place: &Place<'tcx>) {
+        self.push_assign(block, source_info, place, Rvalue::Aggregate(
             box AggregateKind::Tuple, vec![]
         ));
     }

--- a/src/librustc_mir/build/expr/as_operand.rs
+++ b/src/librustc_mir/build/expr/as_operand.rs
@@ -32,7 +32,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     }
 
     /// Compile `expr` into a value that can be used as an operand.
-    /// If `expr` is an lvalue like `x`, this will introduce a
+    /// If `expr` is a place like `x`, this will introduce a
     /// temporary `tmp = x`, so that we capture the value of `x` at
     /// this time.
     ///

--- a/src/librustc_mir/build/expr/as_operand.rs
+++ b/src/librustc_mir/build/expr/as_operand.rs
@@ -70,11 +70,11 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 let constant = this.as_constant(expr);
                 block.and(Operand::Constant(box constant))
             }
-            Category::Lvalue |
+            Category::Place |
             Category::Rvalue(..) => {
                 let operand =
                     unpack!(block = this.as_temp(block, scope, expr));
-                block.and(Operand::Move(Lvalue::Local(operand)))
+                block.and(Operand::Move(Place::Local(operand)))
             }
         }
     }

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -68,8 +68,8 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 block.and(Rvalue::Repeat(value_operand, count))
             }
             ExprKind::Borrow { region, borrow_kind, arg } => {
-                let arg_lvalue = unpack!(block = this.as_lvalue(block, arg));
-                block.and(Rvalue::Ref(region, borrow_kind, arg_lvalue))
+                let arg_place = unpack!(block = this.as_place(block, arg));
+                block.and(Rvalue::Ref(region, borrow_kind, arg_place))
             }
             ExprKind::Binary { op, lhs, rhs } => {
                 let lhs = unpack!(block = this.as_operand(block, scope, lhs));
@@ -229,7 +229,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 let field_names = this.hir.all_fields(adt_def, variant_index);
 
                 let fields = if let Some(FruInfo { base, field_types }) = base {
-                    let base = unpack!(block = this.as_lvalue(block, base));
+                    let base = unpack!(block = this.as_place(block, base));
 
                     // MIR does not natively support FRU, so for each
                     // base-supplied field, generate an operand that

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -108,16 +108,16 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 });
                 if let Some(scope) = scope {
                     // schedule a shallow free of that memory, lest we unwind:
-                    this.schedule_drop(expr_span, scope, &Lvalue::Local(result), value.ty);
+                    this.schedule_drop(expr_span, scope, &Place::Local(result), value.ty);
                 }
 
                 // malloc some memory of suitable type (thus far, uninitialized):
                 let box_ = Rvalue::NullaryOp(NullOp::Box, value.ty);
-                this.cfg.push_assign(block, source_info, &Lvalue::Local(result), box_);
+                this.cfg.push_assign(block, source_info, &Place::Local(result), box_);
 
                 // initialize the box contents:
-                unpack!(block = this.into(&Lvalue::Local(result).deref(), block, value));
-                block.and(Rvalue::Use(Operand::Move(Lvalue::Local(result))))
+                unpack!(block = this.into(&Place::Local(result).deref(), block, value));
+                block.and(Rvalue::Use(Operand::Move(Place::Local(result))))
             }
             ExprKind::Cast { source } => {
                 let source = this.hir.mirror(source);

--- a/src/librustc_mir/build/expr/as_temp.rs
+++ b/src/librustc_mir/build/expr/as_temp.rs
@@ -58,16 +58,16 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         }
 
         // Careful here not to cause an infinite cycle. If we always
-        // called `into`, then for lvalues like `x.f`, it would
+        // called `into`, then for places like `x.f`, it would
         // eventually fallback to us, and we'd loop. There's a reason
         // for this: `as_temp` is the point where we bridge the "by
-        // reference" semantics of `as_lvalue` with the "by value"
+        // reference" semantics of `as_place` with the "by value"
         // semantics of `into`, `as_operand`, `as_rvalue`, and (of
         // course) `as_temp`.
         match Category::of(&expr.kind).unwrap() {
             Category::Place => {
-                let lvalue = unpack!(block = this.as_lvalue(block, expr));
-                let rvalue = Rvalue::Use(this.consume_by_copy_or_move(lvalue));
+                let place = unpack!(block = this.as_place(block, expr));
+                let rvalue = Rvalue::Use(this.consume_by_copy_or_move(place));
                 this.cfg.push_assign(block, source_info, &Place::Local(temp), rvalue);
             }
             _ => {

--- a/src/librustc_mir/build/expr/as_temp.rs
+++ b/src/librustc_mir/build/expr/as_temp.rs
@@ -65,13 +65,13 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         // semantics of `into`, `as_operand`, `as_rvalue`, and (of
         // course) `as_temp`.
         match Category::of(&expr.kind).unwrap() {
-            Category::Lvalue => {
+            Category::Place => {
                 let lvalue = unpack!(block = this.as_lvalue(block, expr));
                 let rvalue = Rvalue::Use(this.consume_by_copy_or_move(lvalue));
-                this.cfg.push_assign(block, source_info, &Lvalue::Local(temp), rvalue);
+                this.cfg.push_assign(block, source_info, &Place::Local(temp), rvalue);
             }
             _ => {
-                unpack!(block = this.into(&Lvalue::Local(temp), block, expr));
+                unpack!(block = this.into(&Place::Local(temp), block, expr));
             }
         }
 
@@ -79,7 +79,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         // anything because no values with a destructor can be created in
         // a constant at this time, even if the type may need dropping.
         if let Some(temp_lifetime) = temp_lifetime {
-            this.schedule_drop(expr_span, temp_lifetime, &Lvalue::Local(temp), expr_ty);
+            this.schedule_drop(expr_span, temp_lifetime, &Place::Local(temp), expr_ty);
         }
 
         block.and(temp)

--- a/src/librustc_mir/build/expr/category.rs
+++ b/src/librustc_mir/build/expr/category.rs
@@ -15,7 +15,7 @@ pub enum Category {
     // An assignable memory location like `x`, `x.f`, `foo()[3]`, that
     // sort of thing. Something that could appear on the LHS of an `=`
     // sign.
-    Lvalue,
+    Place,
 
     // A literal like `23` or `"foo"`. Does not include constant
     // expressions like `3 + 5`.
@@ -51,7 +51,7 @@ impl Category {
             ExprKind::SelfRef |
             ExprKind::VarRef { .. } |
             ExprKind::StaticRef { .. } =>
-                Some(Category::Lvalue),
+                Some(Category::Place),
 
             ExprKind::LogicalOp { .. } |
             ExprKind::If { .. } |

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -22,7 +22,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     /// Compile `expr`, storing the result into `destination`, which
     /// is assumed to be uninitialized.
     pub fn into_expr(&mut self,
-                     destination: &Lvalue<'tcx>,
+                     destination: &Place<'tcx>,
                      mut block: BasicBlock,
                      expr: Expr<'tcx>)
                      -> BlockAnd<()>
@@ -241,7 +241,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                         internal: true,
                         is_user_variable: false
                     });
-                    let ptr_temp = Lvalue::Local(ptr_temp);
+                    let ptr_temp = Place::Local(ptr_temp);
                     let block = unpack!(this.into(&ptr_temp, block, ptr));
                     this.into(&ptr_temp.deref(), block, val)
                 } else {

--- a/src/librustc_mir/build/expr/mod.rs
+++ b/src/librustc_mir/build/expr/mod.rs
@@ -24,13 +24,13 @@
 //! - `as_operand` -- evaluates the value and yields an `Operand`,
 //!   suitable for use as an argument to an `Rvalue`
 //! - `as_temp` -- evaluates into a temporary; this is similar to `as_operand`
-//!   except it always returns a fresh lvalue, even for constants
+//!   except it always returns a fresh place, even for constants
 //! - `as_rvalue` -- yields an `Rvalue`, suitable for use in an assignment;
 //!   as of this writing, never needed outside of the `expr` module itself
 //!
 //! Sometimes though want the expression's *location*. An example
 //! would be during a match statement, or the operand of the `&`
-//! operator. In that case, you want `as_lvalue`. This will create a
+//! operator. In that case, you want `as_place`. This will create a
 //! temporary if necessary.
 //!
 //! Finally, if it's a constant you seek, then call
@@ -46,7 +46,7 @@
 //! struct expression (or other expression that creates a new value)
 //! is typically easiest to write in terms of `as_rvalue` or `into`,
 //! whereas a reference to a field is easiest to write in terms of
-//! `as_lvalue`. (The exception to this is scope and paren
+//! `as_place`. (The exception to this is scope and paren
 //! expressions, which have no category.)
 //!
 //! Therefore, the various functions above make use of one another in
@@ -54,12 +54,12 @@
 //! the most suitable spot to implement it, and then just let the
 //! other fns cycle around. The handoff works like this:
 //!
-//! - `into(lv)` -> fallback is to create a rvalue with `as_rvalue` and assign it to `lv`
+//! - `into(place)` -> fallback is to create a rvalue with `as_rvalue` and assign it to `place`
 //! - `as_rvalue` -> fallback is to create an Operand with `as_operand` and use `Rvalue::use`
 //! - `as_operand` -> either invokes `as_constant` or `as_temp`
 //! - `as_constant` -> (no fallback)
-//! - `as_temp` -> creates a temporary and either calls `as_lvalue` or `into`
-//! - `as_lvalue` -> for rvalues, falls back to `as_temp` and returns that
+//! - `as_temp` -> creates a temporary and either calls `as_place` or `into`
+//! - `as_place` -> for rvalues, falls back to `as_temp` and returns that
 //!
 //! As you can see, there is a cycle where `into` can (in theory) fallback to `as_temp`
 //! which can fallback to `into`. So if one of the `ExprKind` variants is not, in fact,
@@ -68,10 +68,10 @@
 //! Of those fallbacks, the most interesting one is `as_temp`, because
 //! it discriminates based on the category of the expression. This is
 //! basically the point where the "by value" operations are bridged
-//! over to the "by reference" mode (`as_lvalue`).
+//! over to the "by reference" mode (`as_place`).
 
 mod as_constant;
-mod as_lvalue;
+mod as_place;
 mod as_rvalue;
 mod as_operand;
 mod as_temp;

--- a/src/librustc_mir/build/expr/stmt.rs
+++ b/src/librustc_mir/build/expr/stmt.rs
@@ -107,12 +107,12 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             ExprKind::Return { value } => {
                 block = match value {
                     Some(value) => {
-                        unpack!(this.into(&Lvalue::Local(RETURN_POINTER), block, value))
+                        unpack!(this.into(&Place::Local(RETURN_POINTER), block, value))
                     }
                     None => {
                         this.cfg.push_assign_unit(block,
                                                   source_info,
-                                                  &Lvalue::Local(RETURN_POINTER));
+                                                  &Place::Local(RETURN_POINTER));
                         block
                     }
                 };

--- a/src/librustc_mir/build/expr/stmt.rs
+++ b/src/librustc_mir/build/expr/stmt.rs
@@ -41,14 +41,14 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 // dropped.
                 if this.hir.needs_drop(lhs.ty) {
                     let rhs = unpack!(block = this.as_local_operand(block, rhs));
-                    let lhs = unpack!(block = this.as_lvalue(block, lhs));
+                    let lhs = unpack!(block = this.as_place(block, lhs));
                     unpack!(block = this.build_drop_and_replace(
                         block, lhs_span, lhs, rhs
                     ));
                     block.unit()
                 } else {
                     let rhs = unpack!(block = this.as_local_rvalue(block, rhs));
-                    let lhs = unpack!(block = this.as_lvalue(block, lhs));
+                    let lhs = unpack!(block = this.as_place(block, lhs));
                     this.cfg.push_assign(block, source_info, &lhs, rhs);
                     block.unit()
                 }
@@ -67,7 +67,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
 
                 // As above, RTL.
                 let rhs = unpack!(block = this.as_local_operand(block, rhs));
-                let lhs = unpack!(block = this.as_lvalue(block, lhs));
+                let lhs = unpack!(block = this.as_place(block, lhs));
 
                 // we don't have to drop prior contents or anything
                 // because AssignOp is only legal for Copy types
@@ -107,12 +107,12 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             ExprKind::Return { value } => {
                 block = match value {
                     Some(value) => {
-                        unpack!(this.into(&Place::Local(RETURN_POINTER), block, value))
+                        unpack!(this.into(&Place::Local(RETURN_PLACE), block, value))
                     }
                     None => {
                         this.cfg.push_assign_unit(block,
                                                   source_info,
-                                                  &Place::Local(RETURN_POINTER));
+                                                  &Place::Local(RETURN_PLACE));
                         block
                     }
                 };
@@ -123,7 +123,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             }
             ExprKind::InlineAsm { asm, outputs, inputs } => {
                 let outputs = outputs.into_iter().map(|output| {
-                    unpack!(block = this.as_lvalue(block, output))
+                    unpack!(block = this.as_place(block, output))
                 }).collect();
                 let inputs = inputs.into_iter().map(|input| {
                     unpack!(block = this.as_local_operand(block, input))

--- a/src/librustc_mir/build/into.rs
+++ b/src/librustc_mir/build/into.rs
@@ -21,14 +21,14 @@ use rustc::mir::*;
 pub(in build) trait EvalInto<'tcx> {
     fn eval_into<'a, 'gcx>(self,
                            builder: &mut Builder<'a, 'gcx, 'tcx>,
-                           destination: &Lvalue<'tcx>,
+                           destination: &Place<'tcx>,
                            block: BasicBlock)
                            -> BlockAnd<()>;
 }
 
 impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     pub fn into<E>(&mut self,
-                   destination: &Lvalue<'tcx>,
+                   destination: &Place<'tcx>,
                    block: BasicBlock,
                    expr: E)
                    -> BlockAnd<()>
@@ -41,7 +41,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
 impl<'tcx> EvalInto<'tcx> for ExprRef<'tcx> {
     fn eval_into<'a, 'gcx>(self,
                            builder: &mut Builder<'a, 'gcx, 'tcx>,
-                           destination: &Lvalue<'tcx>,
+                           destination: &Place<'tcx>,
                            block: BasicBlock)
                            -> BlockAnd<()> {
         let expr = builder.hir.mirror(self);
@@ -52,7 +52,7 @@ impl<'tcx> EvalInto<'tcx> for ExprRef<'tcx> {
 impl<'tcx> EvalInto<'tcx> for Expr<'tcx> {
     fn eval_into<'a, 'gcx>(self,
                            builder: &mut Builder<'a, 'gcx, 'tcx>,
-                           destination: &Lvalue<'tcx>,
+                           destination: &Place<'tcx>,
                            block: BasicBlock)
                            -> BlockAnd<()> {
         builder.into_expr(destination, block, self)

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -30,7 +30,7 @@ mod util;
 
 impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     pub fn match_expr(&mut self,
-                      destination: &Lvalue<'tcx>,
+                      destination: &Place<'tcx>,
                       span: Span,
                       mut block: BasicBlock,
                       discriminant: ExprRef<'tcx>,
@@ -154,7 +154,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     pub fn lvalue_into_pattern(&mut self,
                                mut block: BasicBlock,
                                irrefutable_pat: Pattern<'tcx>,
-                               initializer: &Lvalue<'tcx>)
+                               initializer: &Place<'tcx>)
                                -> BlockAnd<()> {
         // create a dummy candidate
         let mut candidate = Candidate {
@@ -223,7 +223,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     }
 
     pub fn storage_live_binding(&mut self, block: BasicBlock, var: NodeId, span: Span)
-                            -> Lvalue<'tcx>
+                            -> Place<'tcx>
     {
         let local_id = self.var_indices[&var];
         let source_info = self.source_info(span);
@@ -231,7 +231,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             source_info,
             kind: StatementKind::StorageLive(local_id)
         });
-        Lvalue::Local(local_id)
+        Place::Local(local_id)
     }
 
     pub fn schedule_drop_for_binding(&mut self, var: NodeId, span: Span) {
@@ -239,7 +239,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         let var_ty = self.local_decls[local_id].ty;
         let hir_id = self.hir.tcx().hir.node_to_hir_id(var);
         let region_scope = self.hir.region_scope_tree.var_scope(hir_id.local_id);
-        self.schedule_drop(span, region_scope, &Lvalue::Local(local_id), var_ty);
+        self.schedule_drop(span, region_scope, &Place::Local(local_id), var_ty);
     }
 
     pub fn visit_bindings<F>(&mut self, pattern: &Pattern<'tcx>, f: &mut F)
@@ -305,7 +305,7 @@ pub struct Candidate<'pat, 'tcx:'pat> {
 #[derive(Clone, Debug)]
 struct Binding<'tcx> {
     span: Span,
-    source: Lvalue<'tcx>,
+    source: Place<'tcx>,
     name: Name,
     var_id: NodeId,
     var_ty: Ty<'tcx>,
@@ -316,7 +316,7 @@ struct Binding<'tcx> {
 #[derive(Clone, Debug)]
 pub struct MatchPair<'pat, 'tcx:'pat> {
     // this lvalue...
-    lvalue: Lvalue<'tcx>,
+    lvalue: Place<'tcx>,
 
     // ... must match this pattern.
     pattern: &'pat Pattern<'tcx>,

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -109,7 +109,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     }
 
     pub fn add_cases_to_switch<'pat>(&mut self,
-                                     test_lvalue: &Lvalue<'tcx>,
+                                     test_lvalue: &Place<'tcx>,
                                      candidate: &Candidate<'pat, 'tcx>,
                                      switch_ty: Ty<'tcx>,
                                      options: &mut Vec<&'tcx ty::Const<'tcx>>,
@@ -150,7 +150,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     }
 
     pub fn add_variants_to_switch<'pat>(&mut self,
-                                        test_lvalue: &Lvalue<'tcx>,
+                                        test_lvalue: &Place<'tcx>,
                                         candidate: &Candidate<'pat, 'tcx>,
                                         variants: &mut BitVector)
                                         -> bool
@@ -177,7 +177,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     /// Generates the code to perform a test.
     pub fn perform_test(&mut self,
                         block: BasicBlock,
-                        lvalue: &Lvalue<'tcx>,
+                        lvalue: &Place<'tcx>,
                         test: &Test<'tcx>)
                         -> Vec<BasicBlock> {
         let source_info = self.source_info(test.span);
@@ -430,7 +430,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     /// not apply to this candidate, but it might be we can get
     /// tighter match code if we do something a bit different.
     pub fn sort_candidate<'pat>(&mut self,
-                                test_lvalue: &Lvalue<'tcx>,
+                                test_lvalue: &Place<'tcx>,
                                 test: &Test<'tcx>,
                                 candidate: &Candidate<'pat, 'tcx>,
                                 resulting_candidates: &mut [Vec<Candidate<'pat, 'tcx>>])

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -109,21 +109,21 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     }
 
     pub fn add_cases_to_switch<'pat>(&mut self,
-                                     test_lvalue: &Place<'tcx>,
+                                     test_place: &Place<'tcx>,
                                      candidate: &Candidate<'pat, 'tcx>,
                                      switch_ty: Ty<'tcx>,
                                      options: &mut Vec<&'tcx ty::Const<'tcx>>,
                                      indices: &mut FxHashMap<&'tcx ty::Const<'tcx>, usize>)
                                      -> bool
     {
-        let match_pair = match candidate.match_pairs.iter().find(|mp| mp.lvalue == *test_lvalue) {
+        let match_pair = match candidate.match_pairs.iter().find(|mp| mp.place == *test_place) {
             Some(match_pair) => match_pair,
             _ => { return false; }
         };
 
         match *match_pair.pattern.kind {
             PatternKind::Constant { value } => {
-                // if the lvalues match, the type should match
+                // if the places match, the type should match
                 assert_eq!(match_pair.pattern.ty, switch_ty);
 
                 indices.entry(value)
@@ -150,12 +150,12 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     }
 
     pub fn add_variants_to_switch<'pat>(&mut self,
-                                        test_lvalue: &Place<'tcx>,
+                                        test_place: &Place<'tcx>,
                                         candidate: &Candidate<'pat, 'tcx>,
                                         variants: &mut BitVector)
                                         -> bool
     {
-        let match_pair = match candidate.match_pairs.iter().find(|mp| mp.lvalue == *test_lvalue) {
+        let match_pair = match candidate.match_pairs.iter().find(|mp| mp.place == *test_place) {
             Some(match_pair) => match_pair,
             _ => { return false; }
         };
@@ -177,7 +177,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     /// Generates the code to perform a test.
     pub fn perform_test(&mut self,
                         block: BasicBlock,
-                        lvalue: &Place<'tcx>,
+                        place: &Place<'tcx>,
                         test: &Test<'tcx>)
                         -> Vec<BasicBlock> {
         let source_info = self.source_info(test.span);
@@ -212,7 +212,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 let discr_ty = adt_def.repr.discr_type().to_ty(tcx);
                 let discr = self.temp(discr_ty, test.span);
                 self.cfg.push_assign(block, source_info, &discr,
-                                     Rvalue::Discriminant(lvalue.clone()));
+                                     Rvalue::Discriminant(place.clone()));
                 assert_eq!(values.len() + 1, targets.len());
                 self.cfg.terminate(block, source_info, TerminatorKind::SwitchInt {
                     discr: Operand::Move(discr),
@@ -233,7 +233,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                         ConstVal::Bool(false) => vec![false_bb, true_bb],
                         v => span_bug!(test.span, "expected boolean value but got {:?}", v)
                     };
-                    (ret, TerminatorKind::if_(self.hir.tcx(), Operand::Copy(lvalue.clone()),
+                    (ret, TerminatorKind::if_(self.hir.tcx(), Operand::Copy(place.clone()),
                                               true_bb, false_bb))
                 } else {
                     // The switch may be inexhaustive so we
@@ -248,7 +248,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                         v.val.to_const_int().expect("switching on integral")
                     ).collect();
                     (targets.clone(), TerminatorKind::SwitchInt {
-                        discr: Operand::Copy(lvalue.clone()),
+                        discr: Operand::Copy(place.clone()),
                         switch_ty,
                         values: From::from(values),
                         targets,
@@ -259,14 +259,14 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             }
 
             TestKind::Eq { value, mut ty } => {
-                let mut val = Operand::Copy(lvalue.clone());
+                let mut val = Operand::Copy(place.clone());
 
                 // If we're using b"..." as a pattern, we need to insert an
                 // unsizing coercion, as the byte string has the type &[u8; N].
                 let expect = if let ConstVal::ByteStr(bytes) = value.val {
                     let tcx = self.hir.tcx();
 
-                    // Unsize the lvalue to &[u8], too, if necessary.
+                    // Unsize the place to &[u8], too, if necessary.
                     if let ty::TyRef(region, mt) = ty.sty {
                         if let ty::TyArray(_, _) = mt.ty.sty {
                             ty = tcx.mk_imm_ref(region, tcx.mk_slice(tcx.types.u8));
@@ -335,7 +335,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 // Test `val` by computing `lo <= val && val <= hi`, using primitive comparisons.
                 let lo = self.literal_operand(test.span, ty.clone(), lo.clone());
                 let hi = self.literal_operand(test.span, ty.clone(), hi.clone());
-                let val = Operand::Copy(lvalue.clone());
+                let val = Operand::Copy(place.clone());
 
                 let fail = self.cfg.start_new_block();
                 let block = self.compare(block, fail, test.span, BinOp::Le, lo, val.clone());
@@ -352,9 +352,9 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 let (actual, result) = (self.temp(usize_ty, test.span),
                                         self.temp(bool_ty, test.span));
 
-                // actual = len(lvalue)
+                // actual = len(place)
                 self.cfg.push_assign(block, source_info,
-                                     &actual, Rvalue::Len(lvalue.clone()));
+                                     &actual, Rvalue::Len(place.clone()));
 
                 // expected = <N>
                 let expected = self.push_usize(block, source_info, len);
@@ -399,7 +399,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         target_block
     }
 
-    /// Given that we are performing `test` against `test_lvalue`,
+    /// Given that we are performing `test` against `test_place`,
     /// this job sorts out what the status of `candidate` will be
     /// after the test. The `resulting_candidates` vector stores, for
     /// each possible outcome of `test`, a vector of the candidates
@@ -430,12 +430,12 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     /// not apply to this candidate, but it might be we can get
     /// tighter match code if we do something a bit different.
     pub fn sort_candidate<'pat>(&mut self,
-                                test_lvalue: &Place<'tcx>,
+                                test_place: &Place<'tcx>,
                                 test: &Test<'tcx>,
                                 candidate: &Candidate<'pat, 'tcx>,
                                 resulting_candidates: &mut [Vec<Candidate<'pat, 'tcx>>])
                                 -> bool {
-        // Find the match_pair for this lvalue (if any). At present,
+        // Find the match_pair for this place (if any). At present,
         // afaik, there can be at most one. (In the future, if we
         // adopted a more general `@` operator, there might be more
         // than one, but it'd be very unusual to have two sides that
@@ -443,12 +443,12 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         // away.)
         let tested_match_pair = candidate.match_pairs.iter()
                                                      .enumerate()
-                                                     .filter(|&(_, mp)| mp.lvalue == *test_lvalue)
+                                                     .filter(|&(_, mp)| mp.place == *test_place)
                                                      .next();
         let (match_pair_index, match_pair) = match tested_match_pair {
             Some(pair) => pair,
             None => {
-                // We are not testing this lvalue. Therefore, this
+                // We are not testing this place. Therefore, this
                 // candidate applies to ALL outcomes.
                 return false;
             }
@@ -614,7 +614,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             self.candidate_without_match_pair(match_pair_index, candidate);
         self.prefix_slice_suffix(
             &mut new_candidate.match_pairs,
-            &candidate.match_pairs[match_pair_index].lvalue,
+            &candidate.match_pairs[match_pair_index].place,
             prefix,
             opt_slice,
             suffix);
@@ -635,15 +635,15 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         // we want to create a set of derived match-patterns like
         // `(x as Variant).0 @ P1` and `(x as Variant).1 @ P1`.
         let elem = ProjectionElem::Downcast(adt_def, variant_index);
-        let downcast_lvalue = match_pair.lvalue.clone().elem(elem); // `(x as Variant)`
+        let downcast_place = match_pair.place.clone().elem(elem); // `(x as Variant)`
         let consequent_match_pairs =
             subpatterns.iter()
                        .map(|subpattern| {
                            // e.g., `(x as Variant).0`
-                           let lvalue = downcast_lvalue.clone().field(subpattern.field,
+                           let place = downcast_place.clone().field(subpattern.field,
                                                                       subpattern.pattern.ty);
                            // e.g., `(x as Variant).0 @ P1`
-                           MatchPair::new(lvalue, &subpattern.pattern)
+                           MatchPair::new(place, &subpattern.pattern)
                        });
 
         // In addition, we need all the other match pairs from the old candidate.

--- a/src/librustc_mir/build/matches/util.rs
+++ b/src/librustc_mir/build/matches/util.rs
@@ -16,21 +16,21 @@ use std::u32;
 
 impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     pub fn field_match_pairs<'pat>(&mut self,
-                                   lvalue: Place<'tcx>,
+                                   place: Place<'tcx>,
                                    subpatterns: &'pat [FieldPattern<'tcx>])
                                    -> Vec<MatchPair<'pat, 'tcx>> {
         subpatterns.iter()
                    .map(|fieldpat| {
-                       let lvalue = lvalue.clone().field(fieldpat.field,
+                       let place = place.clone().field(fieldpat.field,
                                                          fieldpat.pattern.ty);
-                       MatchPair::new(lvalue, &fieldpat.pattern)
+                       MatchPair::new(place, &fieldpat.pattern)
                    })
                    .collect()
     }
 
     pub fn prefix_slice_suffix<'pat>(&mut self,
                                      match_pairs: &mut Vec<MatchPair<'pat, 'tcx>>,
-                                     lvalue: &Place<'tcx>,
+                                     place: &Place<'tcx>,
                                      prefix: &'pat [Pattern<'tcx>],
                                      opt_slice: Option<&'pat Pattern<'tcx>>,
                                      suffix: &'pat [Pattern<'tcx>]) {
@@ -47,13 +47,13 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                           min_length,
                           from_end: false,
                       };
-                      let lvalue = lvalue.clone().elem(elem);
-                      MatchPair::new(lvalue, subpattern)
+                      let place = place.clone().elem(elem);
+                      MatchPair::new(place, subpattern)
                   })
         );
 
         if let Some(subslice_pat) = opt_slice {
-            let subslice = lvalue.clone().elem(ProjectionElem::Subslice {
+            let subslice = place.clone().elem(ProjectionElem::Subslice {
                 from: prefix.len() as u32,
                 to: suffix.len() as u32
             });
@@ -70,17 +70,17 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                           min_length,
                           from_end: true,
                       };
-                      let lvalue = lvalue.clone().elem(elem);
-                      MatchPair::new(lvalue, subpattern)
+                      let place = place.clone().elem(elem);
+                      MatchPair::new(place, subpattern)
                   })
         );
     }
 }
 
 impl<'pat, 'tcx> MatchPair<'pat, 'tcx> {
-    pub fn new(lvalue: Place<'tcx>, pattern: &'pat Pattern<'tcx>) -> MatchPair<'pat, 'tcx> {
+    pub fn new(place: Place<'tcx>, pattern: &'pat Pattern<'tcx>) -> MatchPair<'pat, 'tcx> {
         MatchPair {
-            lvalue,
+            place,
             pattern,
             slice_len_checked: false,
         }

--- a/src/librustc_mir/build/matches/util.rs
+++ b/src/librustc_mir/build/matches/util.rs
@@ -16,7 +16,7 @@ use std::u32;
 
 impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     pub fn field_match_pairs<'pat>(&mut self,
-                                   lvalue: Lvalue<'tcx>,
+                                   lvalue: Place<'tcx>,
                                    subpatterns: &'pat [FieldPattern<'tcx>])
                                    -> Vec<MatchPair<'pat, 'tcx>> {
         subpatterns.iter()
@@ -30,7 +30,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
 
     pub fn prefix_slice_suffix<'pat>(&mut self,
                                      match_pairs: &mut Vec<MatchPair<'pat, 'tcx>>,
-                                     lvalue: &Lvalue<'tcx>,
+                                     lvalue: &Place<'tcx>,
                                      prefix: &'pat [Pattern<'tcx>],
                                      opt_slice: Option<&'pat Pattern<'tcx>>,
                                      suffix: &'pat [Pattern<'tcx>]) {
@@ -78,7 +78,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
 }
 
 impl<'pat, 'tcx> MatchPair<'pat, 'tcx> {
-    pub fn new(lvalue: Lvalue<'tcx>, pattern: &'pat Pattern<'tcx>) -> MatchPair<'pat, 'tcx> {
+    pub fn new(lvalue: Place<'tcx>, pattern: &'pat Pattern<'tcx>) -> MatchPair<'pat, 'tcx> {
         MatchPair {
             lvalue,
             pattern,

--- a/src/librustc_mir/build/misc.rs
+++ b/src/librustc_mir/build/misc.rs
@@ -29,10 +29,10 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     /// call `schedule_drop` once the temporary is initialized.
     pub fn temp(&mut self, ty: Ty<'tcx>, span: Span) -> Place<'tcx> {
         let temp = self.local_decls.push(LocalDecl::new_temp(ty, span));
-        let lvalue = Place::Local(temp);
+        let place = Place::Local(temp);
         debug!("temp: created temp {:?} with type {:?}",
-               lvalue, self.local_decls[temp].ty);
-        lvalue
+               place, self.local_decls[temp].ty);
+        place
     }
 
     pub fn literal_operand(&mut self,
@@ -134,13 +134,13 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         temp
     }
 
-    pub fn consume_by_copy_or_move(&self, lvalue: Place<'tcx>) -> Operand<'tcx> {
+    pub fn consume_by_copy_or_move(&self, place: Place<'tcx>) -> Operand<'tcx> {
         let tcx = self.hir.tcx();
-        let ty = lvalue.ty(&self.local_decls, tcx).to_ty(tcx);
+        let ty = place.ty(&self.local_decls, tcx).to_ty(tcx);
         if self.hir.type_moves_by_default(ty, DUMMY_SP) {
-            Operand::Move(lvalue)
+            Operand::Move(place)
         } else {
-            Operand::Copy(lvalue)
+            Operand::Copy(place)
         }
     }
 }

--- a/src/librustc_mir/build/misc.rs
+++ b/src/librustc_mir/build/misc.rs
@@ -27,9 +27,9 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     ///
     /// NB: **No cleanup is scheduled for this temporary.** You should
     /// call `schedule_drop` once the temporary is initialized.
-    pub fn temp(&mut self, ty: Ty<'tcx>, span: Span) -> Lvalue<'tcx> {
+    pub fn temp(&mut self, ty: Ty<'tcx>, span: Span) -> Place<'tcx> {
         let temp = self.local_decls.push(LocalDecl::new_temp(ty, span));
-        let lvalue = Lvalue::Local(temp);
+        let lvalue = Place::Local(temp);
         debug!("temp: created temp {:?} with type {:?}",
                lvalue, self.local_decls[temp].ty);
         lvalue
@@ -121,7 +121,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                       block: BasicBlock,
                       source_info: SourceInfo,
                       value: u64)
-                      -> Lvalue<'tcx> {
+                      -> Place<'tcx> {
         let usize_ty = self.hir.usize_ty();
         let temp = self.temp(usize_ty, source_info.span);
         self.cfg.push_assign_constant(
@@ -134,7 +134,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         temp
     }
 
-    pub fn consume_by_copy_or_move(&self, lvalue: Lvalue<'tcx>) -> Operand<'tcx> {
+    pub fn consume_by_copy_or_move(&self, lvalue: Place<'tcx>) -> Operand<'tcx> {
         let tcx = self.hir.tcx();
         let ty = lvalue.ty(&self.local_decls, tcx).to_ty(tcx);
         if self.hir.type_moves_by_default(ty, DUMMY_SP) {

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -309,7 +309,7 @@ struct Builder<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
     /// Maps node ids of variable bindings to the `Local`s created for them.
     var_indices: NodeMap<Local>,
     local_decls: IndexVec<Local, LocalDecl<'tcx>>,
-    unit_temp: Option<Lvalue<'tcx>>,
+    unit_temp: Option<Place<'tcx>>,
 
     /// cached block with the RESUME terminator; this is created
     /// when first set of cleanups are built.
@@ -480,7 +480,7 @@ fn construct_const<'a, 'gcx, 'tcx>(hir: Cx<'a, 'gcx, 'tcx>,
 
     let mut block = START_BLOCK;
     let expr = builder.hir.mirror(ast_expr);
-    unpack!(block = builder.into_expr(&Lvalue::Local(RETURN_POINTER), block, expr));
+    unpack!(block = builder.into_expr(&Place::Local(RETURN_POINTER), block, expr));
 
     let source_info = builder.source_info(span);
     builder.cfg.terminate(block, source_info, TerminatorKind::Return);
@@ -599,7 +599,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         for (index, &(ty, pattern)) in arguments.iter().enumerate() {
             // Function arguments always get the first Local indices after the return pointer
             let local = Local::new(index + 1);
-            let lvalue = Lvalue::Local(local);
+            let lvalue = Place::Local(local);
 
             if let Some(pattern) = pattern {
                 let pattern = self.hir.pattern_from_hir(pattern);
@@ -630,10 +630,10 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         }
 
         let body = self.hir.mirror(ast_body);
-        self.into(&Lvalue::Local(RETURN_POINTER), block, body)
+        self.into(&Place::Local(RETURN_POINTER), block, body)
     }
 
-    fn get_unit_temp(&mut self) -> Lvalue<'tcx> {
+    fn get_unit_temp(&mut self) -> Place<'tcx> {
         match self.unit_temp {
             Some(ref tmp) => tmp.clone(),
             None => {

--- a/src/librustc_mir/dataflow/drop_flag_effects.rs
+++ b/src/librustc_mir/dataflow/drop_flag_effects.rs
@@ -24,7 +24,7 @@ pub fn move_path_children_matching<'tcx, F>(move_data: &MoveData<'tcx>,
 {
     let mut next_child = move_data.move_paths[path].first_child;
     while let Some(child_index) = next_child {
-        match move_data.move_paths[child_index].lvalue {
+        match move_data.move_paths[child_index].place {
             mir::Place::Projection(ref proj) => {
                 if cond(proj) {
                     return Some(child_index)
@@ -56,19 +56,19 @@ pub fn move_path_children_matching<'tcx, F>(move_data: &MoveData<'tcx>,
 /// is no need to maintain separate drop flags to track such state.
 ///
 /// FIXME: we have to do something for moving slice patterns.
-fn lvalue_contents_drop_state_cannot_differ<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
+fn place_contents_drop_state_cannot_differ<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
                                                             mir: &Mir<'tcx>,
-                                                            lv: &mir::Place<'tcx>) -> bool {
-    let ty = lv.ty(mir, tcx).to_ty(tcx);
+                                                            place: &mir::Place<'tcx>) -> bool {
+    let ty = place.ty(mir, tcx).to_ty(tcx);
     match ty.sty {
         ty::TyArray(..) | ty::TySlice(..) | ty::TyRef(..) | ty::TyRawPtr(..) => {
-            debug!("lvalue_contents_drop_state_cannot_differ lv: {:?} ty: {:?} refd => true",
-                   lv, ty);
+            debug!("place_contents_drop_state_cannot_differ place: {:?} ty: {:?} refd => true",
+                   place, ty);
             true
         }
         ty::TyAdt(def, _) if (def.has_dtor(tcx) && !def.is_box()) || def.is_union() => {
-            debug!("lvalue_contents_drop_state_cannot_differ lv: {:?} ty: {:?} Drop => true",
-                   lv, ty);
+            debug!("place_contents_drop_state_cannot_differ place: {:?} ty: {:?} Drop => true",
+                   place, ty);
             true
         }
         _ => {
@@ -109,8 +109,8 @@ pub(crate) fn on_all_children_bits<'a, 'gcx, 'tcx, F>(
         move_data: &MoveData<'tcx>,
         path: MovePathIndex) -> bool
     {
-        lvalue_contents_drop_state_cannot_differ(
-            tcx, mir, &move_data.move_paths[path].lvalue)
+        place_contents_drop_state_cannot_differ(
+            tcx, mir, &move_data.move_paths[path].place)
     }
 
     fn on_all_children_bits<'a, 'gcx, 'tcx, F>(
@@ -145,9 +145,9 @@ pub(crate) fn on_all_drop_children_bits<'a, 'gcx, 'tcx, F>(
     where F: FnMut(MovePathIndex)
 {
     on_all_children_bits(tcx, mir, &ctxt.move_data, path, |child| {
-        let lvalue = &ctxt.move_data.move_paths[path].lvalue;
-        let ty = lvalue.ty(mir, tcx).to_ty(tcx);
-        debug!("on_all_drop_children_bits({:?}, {:?} : {:?})", path, lvalue, ty);
+        let place = &ctxt.move_data.move_paths[path].place;
+        let ty = place.ty(mir, tcx).to_ty(tcx);
+        debug!("on_all_drop_children_bits({:?}, {:?} : {:?})", path, place, ty);
 
         let gcx = tcx.global_tcx();
         let erased_ty = gcx.lift(&tcx.erase_regions(&ty)).unwrap();
@@ -168,8 +168,8 @@ pub(crate) fn drop_flag_effects_for_function_entry<'a, 'gcx, 'tcx, F>(
 {
     let move_data = &ctxt.move_data;
     for arg in mir.args_iter() {
-        let lvalue = mir::Place::Local(arg);
-        let lookup_result = move_data.rev_lookup.find(&lvalue);
+        let place = mir::Place::Local(arg);
+        let lookup_result = move_data.rev_lookup.find(&place);
         on_lookup_result_bits(tcx, mir, move_data,
                               lookup_result,
                               |mpi| callback(mpi, DropFlagState::Present));

--- a/src/librustc_mir/dataflow/impls/borrows.rs
+++ b/src/librustc_mir/dataflow/impls/borrows.rs
@@ -50,7 +50,7 @@ pub struct BorrowData<'tcx> {
     pub(crate) location: Location,
     pub(crate) kind: mir::BorrowKind,
     pub(crate) region: Region<'tcx>,
-    pub(crate) lvalue: mir::Lvalue<'tcx>,
+    pub(crate) lvalue: mir::Place<'tcx>,
 }
 
 impl<'tcx> fmt::Display for BorrowData<'tcx> {
@@ -269,7 +269,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for Borrows<'a, 'gcx, 'tcx> {
                              _in_out: &mut IdxSet<BorrowIndex>,
                              _call_bb: mir::BasicBlock,
                              _dest_bb: mir::BasicBlock,
-                             _dest_lval: &mir::Lvalue) {
+                             _dest_lval: &mir::Place) {
         // there are no effects on the region scopes from method calls.
     }
 }
@@ -291,9 +291,9 @@ impl<'a, 'gcx, 'tcx> DataflowOperator for Borrows<'a, 'gcx, 'tcx> {
 fn is_unsafe_lvalue<'a, 'gcx: 'tcx, 'tcx: 'a>(
     tcx: TyCtxt<'a, 'gcx, 'tcx>,
     mir: &'a Mir<'tcx>,
-    lvalue: &mir::Lvalue<'tcx>
+    lvalue: &mir::Place<'tcx>
 ) -> bool {
-    use self::mir::Lvalue::*;
+    use self::mir::Place::*;
     use self::mir::ProjectionElem;
 
     match *lvalue {

--- a/src/librustc_mir/dataflow/impls/borrows.rs
+++ b/src/librustc_mir/dataflow/impls/borrows.rs
@@ -42,7 +42,7 @@ pub struct Borrows<'a, 'gcx: 'tcx, 'tcx: 'a> {
 }
 
 // temporarily allow some dead fields: `kind` and `region` will be
-// needed by borrowck; `lvalue` will probably be a MovePathIndex when
+// needed by borrowck; `place` will probably be a MovePathIndex when
 // that is extended to include borrowed data paths.
 #[allow(dead_code)]
 #[derive(Debug)]
@@ -50,7 +50,7 @@ pub struct BorrowData<'tcx> {
     pub(crate) location: Location,
     pub(crate) kind: mir::BorrowKind,
     pub(crate) region: Region<'tcx>,
-    pub(crate) lvalue: mir::Place<'tcx>,
+    pub(crate) place: mir::Place<'tcx>,
 }
 
 impl<'tcx> fmt::Display for BorrowData<'tcx> {
@@ -62,7 +62,7 @@ impl<'tcx> fmt::Display for BorrowData<'tcx> {
         };
         let region = format!("{}", self.region);
         let region = if region.len() > 0 { format!("{} ", region) } else { region };
-        write!(w, "&{}{}{:?}", region, kind, self.lvalue)
+        write!(w, "&{}{}{:?}", region, kind, self.place)
     }
 }
 
@@ -101,11 +101,11 @@ impl<'a, 'gcx, 'tcx> Borrows<'a, 'gcx, 'tcx> {
             fn visit_rvalue(&mut self,
                             rvalue: &mir::Rvalue<'tcx>,
                             location: mir::Location) {
-                if let mir::Rvalue::Ref(region, kind, ref lvalue) = *rvalue {
-                    if is_unsafe_lvalue(self.tcx, self.mir, lvalue) { return; }
+                if let mir::Rvalue::Ref(region, kind, ref place) = *rvalue {
+                    if is_unsafe_place(self.tcx, self.mir, place) { return; }
 
                     let borrow = BorrowData {
-                        location: location, kind: kind, region: region, lvalue: lvalue.clone(),
+                        location: location, kind: kind, region: region, place: place.clone(),
                     };
                     let idx = self.idx_vec.push(borrow);
                     self.location_map.insert(location, idx);
@@ -206,8 +206,8 @@ impl<'a, 'gcx, 'tcx> BitDenotation for Borrows<'a, 'gcx, 'tcx> {
             }
 
             mir::StatementKind::Assign(_, ref rhs) => {
-                if let mir::Rvalue::Ref(region, _, ref lvalue) = *rhs {
-                    if is_unsafe_lvalue(self.tcx, self.mir, lvalue) { return; }
+                if let mir::Rvalue::Ref(region, _, ref place) = *rhs {
+                    if is_unsafe_place(self.tcx, self.mir, place) { return; }
                     let index = self.location_map.get(&location).unwrap_or_else(|| {
                         panic!("could not find BorrowIndex for location {:?}", location);
                     });
@@ -269,7 +269,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for Borrows<'a, 'gcx, 'tcx> {
                              _in_out: &mut IdxSet<BorrowIndex>,
                              _call_bb: mir::BasicBlock,
                              _dest_bb: mir::BasicBlock,
-                             _dest_lval: &mir::Place) {
+                             _dest_place: &mir::Place) {
         // there are no effects on the region scopes from method calls.
     }
 }
@@ -288,15 +288,15 @@ impl<'a, 'gcx, 'tcx> DataflowOperator for Borrows<'a, 'gcx, 'tcx> {
     }
 }
 
-fn is_unsafe_lvalue<'a, 'gcx: 'tcx, 'tcx: 'a>(
+fn is_unsafe_place<'a, 'gcx: 'tcx, 'tcx: 'a>(
     tcx: TyCtxt<'a, 'gcx, 'tcx>,
     mir: &'a Mir<'tcx>,
-    lvalue: &mir::Place<'tcx>
+    place: &mir::Place<'tcx>
 ) -> bool {
     use self::mir::Place::*;
     use self::mir::ProjectionElem;
 
-    match *lvalue {
+    match *place {
         Local(_) => false,
         Static(ref static_) => tcx.is_static_mut(static_.def_id),
         Projection(ref proj) => {
@@ -306,13 +306,13 @@ fn is_unsafe_lvalue<'a, 'gcx: 'tcx, 'tcx: 'a>(
                 ProjectionElem::Subslice { .. } |
                 ProjectionElem::ConstantIndex { .. } |
                 ProjectionElem::Index(_) => {
-                    is_unsafe_lvalue(tcx, mir, &proj.base)
+                    is_unsafe_place(tcx, mir, &proj.base)
                 }
                 ProjectionElem::Deref => {
                     let ty = proj.base.ty(mir, tcx).to_ty(tcx);
                     match ty.sty {
                         ty::TyRawPtr(..) => true,
-                        _ => is_unsafe_lvalue(tcx, mir, &proj.base),
+                        _ => is_unsafe_place(tcx, mir, &proj.base),
                     }
                 }
             }

--- a/src/librustc_mir/dataflow/impls/mod.rs
+++ b/src/librustc_mir/dataflow/impls/mod.rs
@@ -368,11 +368,11 @@ impl<'a, 'gcx, 'tcx> BitDenotation for MaybeInitializedLvals<'a, 'gcx, 'tcx> {
                              in_out: &mut IdxSet<MovePathIndex>,
                              _call_bb: mir::BasicBlock,
                              _dest_bb: mir::BasicBlock,
-                             dest_lval: &mir::Place) {
+                             dest_place: &mir::Place) {
         // when a call returns successfully, that means we need to set
-        // the bits for that dest_lval to 1 (initialized).
+        // the bits for that dest_place to 1 (initialized).
         on_lookup_result_bits(self.tcx, self.mir, self.move_data(),
-                              self.move_data().rev_lookup.find(dest_lval),
+                              self.move_data().rev_lookup.find(dest_place),
                               |mpi| { in_out.add(&mpi); });
     }
 }
@@ -384,7 +384,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for MaybeUninitializedLvals<'a, 'gcx, 'tcx> {
         self.move_data().move_paths.len()
     }
 
-    // sets on_entry bits for Arg lvalues
+    // sets on_entry bits for Arg places
     fn start_block_effect(&self, sets: &mut BlockSets<MovePathIndex>) {
         // set all bits to 1 (uninit) before gathering counterevidence
         for e in sets.on_entry.words_mut() { *e = !0; }
@@ -423,11 +423,11 @@ impl<'a, 'gcx, 'tcx> BitDenotation for MaybeUninitializedLvals<'a, 'gcx, 'tcx> {
                              in_out: &mut IdxSet<MovePathIndex>,
                              _call_bb: mir::BasicBlock,
                              _dest_bb: mir::BasicBlock,
-                             dest_lval: &mir::Place) {
+                             dest_place: &mir::Place) {
         // when a call returns successfully, that means we need to set
-        // the bits for that dest_lval to 0 (initialized).
+        // the bits for that dest_place to 0 (initialized).
         on_lookup_result_bits(self.tcx, self.mir, self.move_data(),
-                              self.move_data().rev_lookup.find(dest_lval),
+                              self.move_data().rev_lookup.find(dest_place),
                               |mpi| { in_out.remove(&mpi); });
     }
 }
@@ -439,7 +439,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for DefinitelyInitializedLvals<'a, 'gcx, 'tcx
         self.move_data().move_paths.len()
     }
 
-    // sets on_entry bits for Arg lvalues
+    // sets on_entry bits for Arg places
     fn start_block_effect(&self, sets: &mut BlockSets<MovePathIndex>) {
         for e in sets.on_entry.words_mut() { *e = 0; }
 
@@ -477,11 +477,11 @@ impl<'a, 'gcx, 'tcx> BitDenotation for DefinitelyInitializedLvals<'a, 'gcx, 'tcx
                              in_out: &mut IdxSet<MovePathIndex>,
                              _call_bb: mir::BasicBlock,
                              _dest_bb: mir::BasicBlock,
-                             dest_lval: &mir::Place) {
+                             dest_place: &mir::Place) {
         // when a call returns successfully, that means we need to set
-        // the bits for that dest_lval to 1 (initialized).
+        // the bits for that dest_place to 1 (initialized).
         on_lookup_result_bits(self.tcx, self.mir, self.move_data(),
-                              self.move_data().rev_lookup.find(dest_lval),
+                              self.move_data().rev_lookup.find(dest_place),
                               |mpi| { in_out.add(&mpi); });
     }
 }
@@ -561,7 +561,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for MovingOutStatements<'a, 'gcx, 'tcx> {
                              in_out: &mut IdxSet<MoveOutIndex>,
                              _call_bb: mir::BasicBlock,
                              _dest_bb: mir::BasicBlock,
-                             dest_lval: &mir::Place) {
+                             dest_place: &mir::Place) {
         let move_data = self.move_data();
         let bits_per_block = self.bits_per_block();
 
@@ -569,7 +569,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for MovingOutStatements<'a, 'gcx, 'tcx> {
         on_lookup_result_bits(self.tcx,
                               self.mir,
                               move_data,
-                              move_data.rev_lookup.find(dest_lval),
+                              move_data.rev_lookup.find(dest_place),
                               |mpi| for moi in &path_map[mpi] {
                                   assert!(moi.index() < bits_per_block);
                                   in_out.remove(&moi);
@@ -647,7 +647,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for EverInitializedLvals<'a, 'gcx, 'tcx> {
                              in_out: &mut IdxSet<InitIndex>,
                              call_bb: mir::BasicBlock,
                              _dest_bb: mir::BasicBlock,
-                             _dest_lval: &mir::Place) {
+                             _dest_place: &mir::Place) {
         let move_data = self.move_data();
         let bits_per_block = self.bits_per_block();
         let init_loc_map = &move_data.init_loc_map;

--- a/src/librustc_mir/dataflow/impls/mod.rs
+++ b/src/librustc_mir/dataflow/impls/mod.rs
@@ -368,7 +368,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for MaybeInitializedLvals<'a, 'gcx, 'tcx> {
                              in_out: &mut IdxSet<MovePathIndex>,
                              _call_bb: mir::BasicBlock,
                              _dest_bb: mir::BasicBlock,
-                             dest_lval: &mir::Lvalue) {
+                             dest_lval: &mir::Place) {
         // when a call returns successfully, that means we need to set
         // the bits for that dest_lval to 1 (initialized).
         on_lookup_result_bits(self.tcx, self.mir, self.move_data(),
@@ -423,7 +423,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for MaybeUninitializedLvals<'a, 'gcx, 'tcx> {
                              in_out: &mut IdxSet<MovePathIndex>,
                              _call_bb: mir::BasicBlock,
                              _dest_bb: mir::BasicBlock,
-                             dest_lval: &mir::Lvalue) {
+                             dest_lval: &mir::Place) {
         // when a call returns successfully, that means we need to set
         // the bits for that dest_lval to 0 (initialized).
         on_lookup_result_bits(self.tcx, self.mir, self.move_data(),
@@ -477,7 +477,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for DefinitelyInitializedLvals<'a, 'gcx, 'tcx
                              in_out: &mut IdxSet<MovePathIndex>,
                              _call_bb: mir::BasicBlock,
                              _dest_bb: mir::BasicBlock,
-                             dest_lval: &mir::Lvalue) {
+                             dest_lval: &mir::Place) {
         // when a call returns successfully, that means we need to set
         // the bits for that dest_lval to 1 (initialized).
         on_lookup_result_bits(self.tcx, self.mir, self.move_data(),
@@ -561,7 +561,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for MovingOutStatements<'a, 'gcx, 'tcx> {
                              in_out: &mut IdxSet<MoveOutIndex>,
                              _call_bb: mir::BasicBlock,
                              _dest_bb: mir::BasicBlock,
-                             dest_lval: &mir::Lvalue) {
+                             dest_lval: &mir::Place) {
         let move_data = self.move_data();
         let bits_per_block = self.bits_per_block();
 
@@ -612,7 +612,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for EverInitializedLvals<'a, 'gcx, 'tcx> {
             mir::StatementKind::StorageDead(local) => {
                 // End inits for StorageDead, so that an immutable variable can
                 // be reinitialized on the next iteration of the loop.
-                if let LookupResult::Exact(mpi) = rev_lookup.find(&mir::Lvalue::Local(local)) {
+                if let LookupResult::Exact(mpi) = rev_lookup.find(&mir::Place::Local(local)) {
                     debug!("stmt {:?} at loc {:?} clears the ever initialized status of {:?}",
                         stmt, location, &init_path_map[mpi]);
                     for ii in &init_path_map[mpi] {
@@ -647,7 +647,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for EverInitializedLvals<'a, 'gcx, 'tcx> {
                              in_out: &mut IdxSet<InitIndex>,
                              call_bb: mir::BasicBlock,
                              _dest_bb: mir::BasicBlock,
-                             _dest_lval: &mir::Lvalue) {
+                             _dest_lval: &mir::Place) {
         let move_data = self.move_data();
         let bits_per_block = self.bits_per_block();
         let init_loc_map = &move_data.init_loc_map;

--- a/src/librustc_mir/dataflow/impls/storage_liveness.rs
+++ b/src/librustc_mir/dataflow/impls/storage_liveness.rs
@@ -62,7 +62,7 @@ impl<'a, 'tcx> BitDenotation for MaybeStorageLive<'a, 'tcx> {
                              _in_out: &mut IdxSet<Local>,
                              _call_bb: mir::BasicBlock,
                              _dest_bb: mir::BasicBlock,
-                             _dest_lval: &mir::Lvalue) {
+                             _dest_lval: &mir::Place) {
         // Nothing to do when a call returns successfully
     }
 }

--- a/src/librustc_mir/dataflow/impls/storage_liveness.rs
+++ b/src/librustc_mir/dataflow/impls/storage_liveness.rs
@@ -62,7 +62,7 @@ impl<'a, 'tcx> BitDenotation for MaybeStorageLive<'a, 'tcx> {
                              _in_out: &mut IdxSet<Local>,
                              _call_bb: mir::BasicBlock,
                              _dest_bb: mir::BasicBlock,
-                             _dest_lval: &mir::Place) {
+                             _dest_place: &mir::Place) {
         // Nothing to do when a call returns successfully
     }
 }

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -610,7 +610,7 @@ pub trait BitDenotation: DataflowOperator {
                              in_out: &mut IdxSet<Self::Idx>,
                              call_bb: mir::BasicBlock,
                              dest_bb: mir::BasicBlock,
-                             dest_lval: &mir::Place);
+                             dest_place: &mir::Place);
 }
 
 impl<'a, 'gcx, 'tcx: 'a, D> DataflowAnalysis<'a, 'tcx, D> where D: BitDenotation
@@ -714,11 +714,11 @@ impl<'a, 'tcx: 'a, D> DataflowAnalysis<'a, 'tcx, D> where D: BitDenotation
                         self.propagate_bits_into_entry_set_for(in_out, changed, unwind);
                     }
                 }
-                if let Some((ref dest_lval, ref dest_bb)) = *destination {
+                if let Some((ref dest_place, ref dest_bb)) = *destination {
                     // N.B.: This must be done *last*, after all other
                     // propagation, as documented in comment above.
                     self.flow_state.operator.propagate_call_return(
-                        in_out, bb, *dest_bb, dest_lval);
+                        in_out, bb, *dest_bb, dest_place);
                     self.propagate_bits_into_entry_set_for(in_out, changed, dest_bb);
                 }
             }

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -610,7 +610,7 @@ pub trait BitDenotation: DataflowOperator {
                              in_out: &mut IdxSet<Self::Idx>,
                              call_bb: mir::BasicBlock,
                              dest_bb: mir::BasicBlock,
-                             dest_lval: &mir::Lvalue);
+                             dest_lval: &mir::Place);
 }
 
 impl<'a, 'gcx, 'tcx: 'a, D> DataflowAnalysis<'a, 'tcx, D> where D: BitDenotation

--- a/src/librustc_mir/dataflow/move_paths/abs_domain.rs
+++ b/src/librustc_mir/dataflow/move_paths/abs_domain.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 //! The move-analysis portion of borrowck needs to work in an abstract
-//! domain of lifted Lvalues.  Most of the Lvalue variants fall into a
+//! domain of lifted Places.  Most of the Place variants fall into a
 //! one-to-one mapping between the concrete and abstract (e.g. a
 //! field-deref on a local-variable, `x.field`, has the same meaning
 //! in both domains). Indexed-Projections are the exception: `a[x]`
@@ -21,7 +21,7 @@
 //! `a[x]` would still overlap them both. But that is not this
 //! representation does today.)
 
-use rustc::mir::{Local, LvalueElem, Operand, ProjectionElem};
+use rustc::mir::{Local, PlaceElem, Operand, ProjectionElem};
 use rustc::ty::Ty;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
@@ -47,7 +47,7 @@ impl<'tcx> Lift for Ty<'tcx> {
     type Abstract = AbstractType;
     fn lift(&self) -> Self::Abstract { AbstractType }
 }
-impl<'tcx> Lift for LvalueElem<'tcx> {
+impl<'tcx> Lift for PlaceElem<'tcx> {
     type Abstract = AbstractElem<'tcx>;
     fn lift(&self) -> Self::Abstract {
         match *self {

--- a/src/librustc_mir/dataflow/move_paths/builder.rs
+++ b/src/librustc_mir/dataflow/move_paths/builder.rs
@@ -68,14 +68,14 @@ impl<'a, 'gcx, 'tcx> MoveDataBuilder<'a, 'gcx, 'tcx> {
                      path_map: &mut IndexVec<MovePathIndex, Vec<MoveOutIndex>>,
                      init_path_map: &mut IndexVec<MovePathIndex, Vec<InitIndex>>,
                      parent: Option<MovePathIndex>,
-                     lvalue: Place<'tcx>)
+                     place: Place<'tcx>)
                      -> MovePathIndex
     {
         let move_path = move_paths.push(MovePath {
             next_sibling: None,
             first_child: None,
             parent,
-            lvalue,
+            place,
         });
 
         if let Some(parent) = parent {
@@ -95,52 +95,52 @@ impl<'a, 'gcx, 'tcx> MoveDataBuilder<'a, 'gcx, 'tcx> {
 }
 
 impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
-    /// This creates a MovePath for a given lvalue, returning an `MovePathError`
-    /// if that lvalue can't be moved from.
+    /// This creates a MovePath for a given place, returning an `MovePathError`
+    /// if that place can't be moved from.
     ///
-    /// NOTE: lvalues behind references *do not* get a move path, which is
+    /// NOTE: places behind references *do not* get a move path, which is
     /// problematic for borrowck.
     ///
     /// Maybe we should have separate "borrowck" and "moveck" modes.
-    fn move_path_for(&mut self, lval: &Place<'tcx>)
+    fn move_path_for(&mut self, place: &Place<'tcx>)
                      -> Result<MovePathIndex, MoveError<'tcx>>
     {
-        debug!("lookup({:?})", lval);
-        match *lval {
+        debug!("lookup({:?})", place);
+        match *place {
             Place::Local(local) => Ok(self.builder.data.rev_lookup.locals[local]),
             Place::Static(..) => {
                 let span = self.builder.mir.source_info(self.loc).span;
                 Err(MoveError::cannot_move_out_of(span, Static))
             }
             Place::Projection(ref proj) => {
-                self.move_path_for_projection(lval, proj)
+                self.move_path_for_projection(place, proj)
             }
         }
     }
 
-    fn create_move_path(&mut self, lval: &Place<'tcx>) {
+    fn create_move_path(&mut self, place: &Place<'tcx>) {
         // This is an assignment, not a move, so this not being a valid
         // move path is OK.
-        let _ = self.move_path_for(lval);
+        let _ = self.move_path_for(place);
     }
 
     fn move_path_for_projection(&mut self,
-                                lval: &Place<'tcx>,
+                                place: &Place<'tcx>,
                                 proj: &PlaceProjection<'tcx>)
                                 -> Result<MovePathIndex, MoveError<'tcx>>
     {
         let base = try!(self.move_path_for(&proj.base));
         let mir = self.builder.mir;
         let tcx = self.builder.tcx;
-        let lv_ty = proj.base.ty(mir, tcx).to_ty(tcx);
-        match lv_ty.sty {
+        let place_ty = proj.base.ty(mir, tcx).to_ty(tcx);
+        match place_ty.sty {
             ty::TyRef(..) | ty::TyRawPtr(..) =>
                 return Err(MoveError::cannot_move_out_of(mir.source_info(self.loc).span,
                                                          BorrowedContent)),
             ty::TyAdt(adt, _) if adt.has_dtor(tcx) && !adt.is_box() =>
                 return Err(MoveError::cannot_move_out_of(mir.source_info(self.loc).span,
                                                          InteriorOfTypeWithDestructor {
-                    container_ty: lv_ty
+                    container_ty: place_ty
                 })),
             // move out of union - always move the entire union
             ty::TyAdt(adt, _) if adt.is_union() =>
@@ -149,7 +149,7 @@ impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
                 return Err(MoveError::cannot_move_out_of(
                     mir.source_info(self.loc).span,
                     InteriorOfSliceOrArray {
-                        ty: lv_ty, is_index: match proj.elem {
+                        ty: place_ty, is_index: match proj.elem {
                             ProjectionElem::Index(..) => true,
                             _ => false
                         },
@@ -159,7 +159,7 @@ impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
                     return Err(MoveError::cannot_move_out_of(
                         mir.source_info(self.loc).span,
                         InteriorOfSliceOrArray {
-                            ty: lv_ty, is_index: true
+                            ty: place_ty, is_index: true
                         })),
                 _ => {
                     // FIXME: still badly broken
@@ -175,7 +175,7 @@ impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
                     &mut self.builder.data.path_map,
                     &mut self.builder.data.init_path_map,
                     Some(base),
-                    lval.clone()
+                    place.clone()
                 );
                 ent.insert(path);
                 Ok(path)
@@ -265,16 +265,16 @@ struct Gatherer<'b, 'a: 'b, 'gcx: 'tcx, 'tcx: 'a> {
 impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
     fn gather_statement(&mut self, stmt: &Statement<'tcx>) {
         match stmt.kind {
-            StatementKind::Assign(ref lval, ref rval) => {
-                self.create_move_path(lval);
+            StatementKind::Assign(ref place, ref rval) => {
+                self.create_move_path(place);
                 if let RvalueInitializationState::Shallow = rval.initialization_state() {
                     // Box starts out uninitialized - need to create a separate
                     // move-path for the interior so it will be separate from
                     // the exterior.
-                    self.create_move_path(&lval.clone().deref());
-                    self.gather_init(lval, InitKind::Shallow);
+                    self.create_move_path(&place.clone().deref());
+                    self.gather_init(place, InitKind::Shallow);
                 } else {
-                    self.gather_init(lval, InitKind::Deep);
+                    self.gather_init(place, InitKind::Deep);
                 }
                 self.gather_rvalue(rval);
             }
@@ -318,7 +318,7 @@ impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
             Rvalue::NullaryOp(NullOp::Box, _) => {
                 // This returns an rvalue with uninitialized contents. We can't
                 // move out of it here because it is an rvalue - assignments always
-                // completely initialize their lvalue.
+                // completely initialize their place.
                 //
                 // However, this does not matter - MIR building is careful to
                 // only emit a shallow free for the partially-initialized
@@ -339,7 +339,7 @@ impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
             TerminatorKind::Unreachable => { }
 
             TerminatorKind::Return => {
-                self.gather_move(&Place::Local(RETURN_POINTER));
+                self.gather_move(&Place::Local(RETURN_PLACE));
             }
 
             TerminatorKind::Assert { .. } |
@@ -376,16 +376,16 @@ impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
         match *operand {
             Operand::Constant(..) |
             Operand::Copy(..) => {} // not-a-move
-            Operand::Move(ref lval) => { // a move
-                self.gather_move(lval);
+            Operand::Move(ref place) => { // a move
+                self.gather_move(place);
             }
         }
     }
 
-    fn gather_move(&mut self, lval: &Place<'tcx>) {
-        debug!("gather_move({:?}, {:?})", self.loc, lval);
+    fn gather_move(&mut self, place: &Place<'tcx>) {
+        debug!("gather_move({:?}, {:?})", self.loc, place);
 
-        let path = match self.move_path_for(lval) {
+        let path = match self.move_path_for(place) {
             Ok(path) | Err(MoveError::UnionMove { path }) => path,
             Err(error @ MoveError::IllegalMove { .. }) => {
                 self.builder.errors.push(error);
@@ -395,16 +395,16 @@ impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
         let move_out = self.builder.data.moves.push(MoveOut { path: path, source: self.loc });
 
         debug!("gather_move({:?}, {:?}): adding move {:?} of {:?}",
-               self.loc, lval, move_out, path);
+               self.loc, place, move_out, path);
 
         self.builder.data.path_map[path].push(move_out);
         self.builder.data.loc_map[self.loc].push(move_out);
     }
 
-    fn gather_init(&mut self, lval: &Place<'tcx>, kind: InitKind) {
-        debug!("gather_init({:?}, {:?})", self.loc, lval);
+    fn gather_init(&mut self, place: &Place<'tcx>, kind: InitKind) {
+        debug!("gather_init({:?}, {:?})", self.loc, place);
 
-        if let LookupResult::Exact(path) = self.builder.data.rev_lookup.find(lval) {
+        if let LookupResult::Exact(path) = self.builder.data.rev_lookup.find(place) {
             let init = self.builder.data.inits.push(Init {
                 span: self.builder.mir.source_info(self.loc).span,
                 path,
@@ -412,7 +412,7 @@ impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
             });
 
             debug!("gather_init({:?}, {:?}): adding init {:?} of {:?}",
-               self.loc, lval, init, path);
+               self.loc, place, init, path);
 
             self.builder.data.init_path_map[path].push(init);
             self.builder.data.init_loc_map[self.loc].push(init);

--- a/src/librustc_mir/dataflow/move_paths/mod.rs
+++ b/src/librustc_mir/dataflow/move_paths/mod.rs
@@ -94,7 +94,7 @@ pub struct MovePath<'tcx> {
     pub next_sibling: Option<MovePathIndex>,
     pub first_child: Option<MovePathIndex>,
     pub parent: Option<MovePathIndex>,
-    pub lvalue: Lvalue<'tcx>,
+    pub lvalue: Place<'tcx>,
 }
 
 impl<'tcx> fmt::Debug for MovePath<'tcx> {
@@ -246,11 +246,11 @@ impl<'tcx> MovePathLookup<'tcx> {
     // alternative will *not* create a MovePath on the fly for an
     // unknown l-value, but will rather return the nearest available
     // parent.
-    pub fn find(&self, lval: &Lvalue<'tcx>) -> LookupResult {
+    pub fn find(&self, lval: &Place<'tcx>) -> LookupResult {
         match *lval {
-            Lvalue::Local(local) => LookupResult::Exact(self.locals[local]),
-            Lvalue::Static(..) => LookupResult::Parent(None),
-            Lvalue::Projection(ref proj) => {
+            Place::Local(local) => LookupResult::Exact(self.locals[local]),
+            Place::Static(..) => LookupResult::Parent(None),
+            Place::Projection(ref proj) => {
                 match self.find(&proj.base) {
                     LookupResult::Exact(base_path) => {
                         match self.projections.get(&(base_path, proj.elem.lift())) {

--- a/src/librustc_mir/dataflow/move_paths/mod.rs
+++ b/src/librustc_mir/dataflow/move_paths/mod.rs
@@ -94,7 +94,7 @@ pub struct MovePath<'tcx> {
     pub next_sibling: Option<MovePathIndex>,
     pub first_child: Option<MovePathIndex>,
     pub parent: Option<MovePathIndex>,
-    pub lvalue: Place<'tcx>,
+    pub place: Place<'tcx>,
 }
 
 impl<'tcx> fmt::Debug for MovePath<'tcx> {
@@ -109,13 +109,13 @@ impl<'tcx> fmt::Debug for MovePath<'tcx> {
         if let Some(next_sibling) = self.next_sibling {
             write!(w, " next_sibling: {:?}", next_sibling)?;
         }
-        write!(w, " lvalue: {:?} }}", self.lvalue)
+        write!(w, " place: {:?} }}", self.place)
     }
 }
 
 impl<'tcx> fmt::Display for MovePath<'tcx> {
     fn fmt(&self, w: &mut fmt::Formatter) -> fmt::Result {
-        write!(w, "{:?}", self.lvalue)
+        write!(w, "{:?}", self.place)
     }
 }
 
@@ -224,11 +224,11 @@ impl fmt::Debug for Init {
 pub struct MovePathLookup<'tcx> {
     locals: IndexVec<Local, MovePathIndex>,
 
-    /// projections are made from a base-lvalue and a projection
-    /// elem. The base-lvalue will have a unique MovePathIndex; we use
+    /// projections are made from a base-place and a projection
+    /// elem. The base-place will have a unique MovePathIndex; we use
     /// the latter as the index into the outer vector (narrowing
     /// subsequent search so that it is solely relative to that
-    /// base-lvalue). For the remaining lookup, we map the projection
+    /// base-place). For the remaining lookup, we map the projection
     /// elem to the associated MovePathIndex.
     projections: FxHashMap<(MovePathIndex, AbstractElem<'tcx>), MovePathIndex>
 }
@@ -246,8 +246,8 @@ impl<'tcx> MovePathLookup<'tcx> {
     // alternative will *not* create a MovePath on the fly for an
     // unknown l-value, but will rather return the nearest available
     // parent.
-    pub fn find(&self, lval: &Place<'tcx>) -> LookupResult {
-        match *lval {
+    pub fn find(&self, place: &Place<'tcx>) -> LookupResult {
+        match *place {
             Place::Local(local) => LookupResult::Exact(self.locals[local]),
             Place::Static(..) => LookupResult::Parent(None),
             Place::Projection(ref proj) => {

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -216,7 +216,7 @@ fn build_drop_shim<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 tcx,
                 param_env
             };
-            let dropee = Lvalue::Local(Local::new(1+0)).deref();
+            let dropee = Place::Local(Local::new(1+0)).deref();
             let resume_block = elaborator.patch.resume_block();
             elaborate_drops::elaborate_drop(
                 &mut elaborator,
@@ -381,19 +381,19 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
     }
 
     fn copy_shim(&mut self) {
-        let rcvr = Lvalue::Local(Local::new(1+0)).deref();
+        let rcvr = Place::Local(Local::new(1+0)).deref();
         let ret_statement = self.make_statement(
             StatementKind::Assign(
-                Lvalue::Local(RETURN_POINTER),
+                Place::Local(RETURN_POINTER),
                 Rvalue::Use(Operand::Copy(rcvr))
             )
         );
         self.block(vec![ret_statement], TerminatorKind::Return, false);
     }
 
-    fn make_lvalue(&mut self, mutability: Mutability, ty: Ty<'tcx>) -> Lvalue<'tcx> {
+    fn make_lvalue(&mut self, mutability: Mutability, ty: Ty<'tcx>) -> Place<'tcx> {
         let span = self.span;
-        Lvalue::Local(
+        Place::Local(
             self.local_decls.push(temp_decl(mutability, ty, span))
         )
     }
@@ -401,10 +401,10 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
     fn make_clone_call(
         &mut self,
         ty: Ty<'tcx>,
-        rcvr_field: Lvalue<'tcx>,
+        rcvr_field: Place<'tcx>,
         next: BasicBlock,
         cleanup: BasicBlock
-    ) -> Lvalue<'tcx> {
+    ) -> Place<'tcx> {
         let tcx = self.tcx;
 
         let substs = Substs::for_item(
@@ -458,8 +458,8 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
 
     fn loop_header(
         &mut self,
-        beg: Lvalue<'tcx>,
-        end: Lvalue<'tcx>,
+        beg: Place<'tcx>,
+        end: Place<'tcx>,
         loop_body: BasicBlock,
         loop_end: BasicBlock,
         is_cleanup: bool
@@ -499,7 +499,7 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
     fn array_shim(&mut self, ty: Ty<'tcx>, len: u64) {
         let tcx = self.tcx;
         let span = self.span;
-        let rcvr = Lvalue::Local(Local::new(1+0)).deref();
+        let rcvr = Place::Local(Local::new(1+0)).deref();
 
         let beg = self.local_decls.push(temp_decl(Mutability::Mut, tcx.types.usize, span));
         let end = self.make_lvalue(Mutability::Not, tcx.types.usize);
@@ -512,7 +512,7 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
         let inits = vec![
             self.make_statement(
                 StatementKind::Assign(
-                    Lvalue::Local(beg),
+                    Place::Local(beg),
                     Rvalue::Use(Operand::Constant(self.make_usize(0)))
                 )
             ),
@@ -530,7 +530,7 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
         //     BB #3;
         // }
         // BB #4;
-        self.loop_header(Lvalue::Local(beg), end, BasicBlock::new(2), BasicBlock::new(4), false);
+        self.loop_header(Place::Local(beg), end, BasicBlock::new(2), BasicBlock::new(4), false);
 
         // BB #2
         // `let cloned = Clone::clone(rcvr[beg])`;
@@ -552,10 +552,10 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
             ),
             self.make_statement(
                 StatementKind::Assign(
-                    Lvalue::Local(beg),
+                    Place::Local(beg),
                     Rvalue::BinaryOp(
                         BinOp::Add,
-                        Operand::Copy(Lvalue::Local(beg)),
+                        Operand::Copy(Place::Local(beg)),
                         Operand::Constant(self.make_usize(1))
                     )
                 )
@@ -567,7 +567,7 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
         // `return ret;`
         let ret_statement = self.make_statement(
             StatementKind::Assign(
-                Lvalue::Local(RETURN_POINTER),
+                Place::Local(RETURN_POINTER),
                 Rvalue::Use(Operand::Move(ret.clone())),
             )
         );
@@ -581,7 +581,7 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
         let beg = self.local_decls.push(temp_decl(Mutability::Mut, tcx.types.usize, span));
         let init = self.make_statement(
             StatementKind::Assign(
-                Lvalue::Local(beg),
+                Place::Local(beg),
                 Rvalue::Use(Operand::Constant(self.make_usize(0)))
             )
         );
@@ -592,7 +592,7 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
         //     BB #8;
         // }
         // BB #9;
-        self.loop_header(Lvalue::Local(beg), Lvalue::Local(end),
+        self.loop_header(Place::Local(beg), Place::Local(end),
                          BasicBlock::new(7), BasicBlock::new(9), true);
 
         // BB #7 (cleanup)
@@ -608,10 +608,10 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
         // `goto #6;`
         let statement = self.make_statement(
             StatementKind::Assign(
-                Lvalue::Local(beg),
+                Place::Local(beg),
                 Rvalue::BinaryOp(
                     BinOp::Add,
-                    Operand::Copy(Lvalue::Local(beg)),
+                    Operand::Copy(Place::Local(beg)),
                     Operand::Constant(self.make_usize(1))
                 )
             )
@@ -628,7 +628,7 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
             _ => bug!("only tuples and closures are accepted"),
         };
 
-        let rcvr = Lvalue::Local(Local::new(1+0)).deref();
+        let rcvr = Place::Local(Local::new(1+0)).deref();
 
         let mut returns = Vec::new();
         for (i, ity) in tys.iter().enumerate() {
@@ -663,7 +663,7 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
         // `return kind(returns[0], returns[1], ..., returns[tys.len() - 1]);`
         let ret_statement = self.make_statement(
             StatementKind::Assign(
-                Lvalue::Local(RETURN_POINTER),
+                Place::Local(RETURN_POINTER),
                 Rvalue::Aggregate(
                     box kind,
                     returns.into_iter().map(Operand::Move).collect()
@@ -701,7 +701,7 @@ fn build_call_shim<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let source_info = SourceInfo { span, scope: ARGUMENT_VISIBILITY_SCOPE };
 
     let rcvr_arg = Local::new(1+0);
-    let rcvr_l = Lvalue::Local(rcvr_arg);
+    let rcvr_l = Place::Local(rcvr_arg);
     let mut statements = vec![];
 
     let rcvr = match rcvr_adjustment {
@@ -720,11 +720,11 @@ fn build_call_shim<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             statements.push(Statement {
                 source_info,
                 kind: StatementKind::Assign(
-                    Lvalue::Local(ref_rcvr),
+                    Place::Local(ref_rcvr),
                     Rvalue::Ref(tcx.types.re_erased, BorrowKind::Mut, rcvr_l)
                 )
             });
-            Operand::Move(Lvalue::Local(ref_rcvr))
+            Operand::Move(Place::Local(ref_rcvr))
         }
     };
 
@@ -749,12 +749,12 @@ fn build_call_shim<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
     if let Some(untuple_args) = untuple_args {
         args.extend(untuple_args.iter().enumerate().map(|(i, ity)| {
-            let arg_lv = Lvalue::Local(Local::new(1+1));
+            let arg_lv = Place::Local(Local::new(1+1));
             Operand::Move(arg_lv.field(Field::new(i), *ity))
         }));
     } else {
         args.extend((1..sig.inputs().len()).map(|i| {
-            Operand::Move(Lvalue::Local(Local::new(1+i)))
+            Operand::Move(Place::Local(Local::new(1+i)))
         }));
     }
 
@@ -771,7 +771,7 @@ fn build_call_shim<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     block(&mut blocks, statements, TerminatorKind::Call {
         func: callee,
         args,
-        destination: Some((Lvalue::Local(RETURN_POINTER),
+        destination: Some((Place::Local(RETURN_POINTER),
                            BasicBlock::new(1))),
         cleanup: if let Adjustment::RefMut = rcvr_adjustment {
             Some(BasicBlock::new(3))
@@ -783,7 +783,7 @@ fn build_call_shim<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     if let Adjustment::RefMut = rcvr_adjustment {
         // BB #1 - drop for Self
         block(&mut blocks, vec![], TerminatorKind::Drop {
-            location: Lvalue::Local(rcvr_arg),
+            location: Place::Local(rcvr_arg),
             target: BasicBlock::new(2),
             unwind: None
         }, false);
@@ -793,7 +793,7 @@ fn build_call_shim<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     if let Adjustment::RefMut = rcvr_adjustment {
         // BB #3 - drop if closure panics
         block(&mut blocks, vec![], TerminatorKind::Drop {
-            location: Lvalue::Local(rcvr_arg),
+            location: Place::Local(rcvr_arg),
             target: BasicBlock::new(4),
             unwind: None
         }, true);
@@ -864,11 +864,11 @@ pub fn build_adt_ctor<'a, 'gcx, 'tcx>(infcx: &infer::InferCtxt<'a, 'gcx, 'tcx>,
         statements: vec![Statement {
             source_info,
             kind: StatementKind::Assign(
-                Lvalue::Local(RETURN_POINTER),
+                Place::Local(RETURN_POINTER),
                 Rvalue::Aggregate(
                     box AggregateKind::Adt(adt_def, variant_no, substs, None),
                     (1..sig.inputs().len()+1).map(|i| {
-                        Operand::Move(Lvalue::Local(Local::new(i)))
+                        Operand::Move(Place::Local(Local::new(i)))
                     }).collect()
                 )
             )

--- a/src/librustc_mir/transform/add_moves_for_packed_drops.rs
+++ b/src/librustc_mir/transform/add_moves_for_packed_drops.rs
@@ -131,10 +131,10 @@ fn add_move_for_packed_drop<'a, 'tcx>(
 
     patch.add_statement(
         loc, StatementKind::StorageLive(temp));
-    patch.add_assign(loc, Lvalue::Local(temp),
+    patch.add_assign(loc, Place::Local(temp),
                      Rvalue::Use(Operand::Move(location.clone())));
     patch.patch_terminator(loc.block, TerminatorKind::Drop {
-        location: Lvalue::Local(temp),
+        location: Place::Local(temp),
         target: storage_dead_block,
         unwind
     });

--- a/src/librustc_mir/transform/add_validation.rs
+++ b/src/librustc_mir/transform/add_validation.rs
@@ -22,9 +22,9 @@ use transform::{MirPass, MirSource};
 
 pub struct AddValidation;
 
-/// Determine the "context" of the lval: Mutability and region.
-fn lval_context<'a, 'tcx, D>(
-    lval: &Place<'tcx>,
+/// Determine the "context" of the place: Mutability and region.
+fn place_context<'a, 'tcx, D>(
+    place: &Place<'tcx>,
     local_decls: &D,
     tcx: TyCtxt<'a, 'tcx, 'tcx>
 ) -> (Option<region::Scope>, hir::Mutability)
@@ -32,7 +32,7 @@ fn lval_context<'a, 'tcx, D>(
 {
     use rustc::mir::Place::*;
 
-    match *lval {
+    match *place {
         Local { .. } => (None, hir::MutMutable),
         Static(_) => (None, hir::MutImmutable),
         Projection(ref proj) => {
@@ -66,7 +66,7 @@ fn lval_context<'a, 'tcx, D>(
                         // This is already as restricted as it gets, no need to even recurse
                         context
                     } else {
-                        let base_context = lval_context(&proj.base, local_decls, tcx);
+                        let base_context = place_context(&proj.base, local_decls, tcx);
                         // The region of the outermost Deref is always most restrictive.
                         let re = context.0.or(base_context.0);
                         let mutbl = context.1.and(base_context.1);
@@ -74,7 +74,7 @@ fn lval_context<'a, 'tcx, D>(
                     }
 
                 }
-                _ => lval_context(&proj.base, local_decls, tcx),
+                _ => place_context(&proj.base, local_decls, tcx),
             }
         }
     }
@@ -198,11 +198,11 @@ impl MirPass for AddValidation {
         let restricted_validation = emit_validate == 1 && fn_contains_unsafe(tcx, src);
         let local_decls = mir.local_decls.clone(); // FIXME: Find a way to get rid of this clone.
 
-        // Convert an lvalue to a validation operand.
-        let lval_to_operand = |lval: Place<'tcx>| -> ValidationOperand<'tcx, Place<'tcx>> {
-            let (re, mutbl) = lval_context(&lval, &local_decls, tcx);
-            let ty = lval.ty(&local_decls, tcx).to_ty(tcx);
-            ValidationOperand { lval, ty, re, mutbl }
+        // Convert a place to a validation operand.
+        let place_to_operand = |place: Place<'tcx>| -> ValidationOperand<'tcx, Place<'tcx>> {
+            let (re, mutbl) = place_context(&place, &local_decls, tcx);
+            let ty = place.ty(&local_decls, tcx).to_ty(tcx);
+            ValidationOperand { place, ty, re, mutbl }
         };
 
         // Emit an Acquire at the beginning of the given block.  If we are in restricted emission
@@ -237,7 +237,7 @@ impl MirPass for AddValidation {
             };
             // Gather all arguments, skip return value.
             let operands = mir.local_decls.iter_enumerated().skip(1).take(mir.arg_count)
-                    .map(|(local, _)| lval_to_operand(Place::Local(local))).collect();
+                    .map(|(local, _)| place_to_operand(Place::Local(local))).collect();
             emit_acquire(&mut mir.basic_blocks_mut()[START_BLOCK], source_info, operands);
         }
 
@@ -256,13 +256,13 @@ impl MirPass for AddValidation {
                         let release_stmt = Statement {
                             source_info,
                             kind: StatementKind::Validate(ValidationOp::Release,
-                                destination.iter().map(|dest| lval_to_operand(dest.0.clone()))
+                                destination.iter().map(|dest| place_to_operand(dest.0.clone()))
                                 .chain(
                                     args.iter().filter_map(|op| {
                                         match op {
-                                            &Operand::Copy(ref lval) |
-                                            &Operand::Move(ref lval) =>
-                                                Some(lval_to_operand(lval.clone())),
+                                            &Operand::Copy(ref place) |
+                                            &Operand::Move(ref place) =>
+                                                Some(place_to_operand(place.clone())),
                                             &Operand::Constant(..) => { None },
                                         }
                                     })
@@ -275,16 +275,16 @@ impl MirPass for AddValidation {
                         returns.push((source_info, destination.0.clone(), destination.1));
                     }
                 }
-                Some(Terminator { kind: TerminatorKind::Drop { location: ref lval, .. },
+                Some(Terminator { kind: TerminatorKind::Drop { location: ref place, .. },
                                   source_info }) |
-                Some(Terminator { kind: TerminatorKind::DropAndReplace { location: ref lval, .. },
+                Some(Terminator { kind: TerminatorKind::DropAndReplace { location: ref place, .. },
                                   source_info }) => {
                     // Before the call: Release all arguments
                     if !restricted_validation {
                         let release_stmt = Statement {
                             source_info,
                             kind: StatementKind::Validate(ValidationOp::Release,
-                                    vec![lval_to_operand(lval.clone())]),
+                                    vec![place_to_operand(place.clone())]),
                         };
                         block_data.statements.push(release_stmt);
                     }
@@ -296,11 +296,11 @@ impl MirPass for AddValidation {
             }
         }
         // Now we go over the returns we collected to acquire the return values.
-        for (source_info, dest_lval, dest_block) in returns {
+        for (source_info, dest_place, dest_block) in returns {
             emit_acquire(
                 &mut mir.basic_blocks_mut()[dest_block],
                 source_info,
-                vec![lval_to_operand(dest_lval)]
+                vec![place_to_operand(dest_place)]
             );
         }
 
@@ -321,22 +321,20 @@ impl MirPass for AddValidation {
                     StatementKind::Assign(_, Rvalue::Ref(_, _, _)) => {
                         // Due to a lack of NLL; we can't capture anything directly here.
                         // Instead, we have to re-match and clone there.
-                        let (dest_lval, re, src_lval) = match block_data.statements[i].kind {
-                            StatementKind::Assign(ref dest_lval,
-                                                  Rvalue::Ref(re, _, ref src_lval)) => {
-                                (dest_lval.clone(), re, src_lval.clone())
+                        let (dest_place, re, src_place) = match block_data.statements[i].kind {
+                            StatementKind::Assign(ref dest_place,
+                                                  Rvalue::Ref(re, _, ref src_place)) => {
+                                (dest_place.clone(), re, src_place.clone())
                             },
                             _ => bug!("We already matched this."),
                         };
                         // So this is a ref, and we got all the data we wanted.
                         // Do an acquire of the result -- but only what it points to, so add a Deref
                         // projection.
-                        let dest_lval = Projection { base: dest_lval, elem: ProjectionElem::Deref };
-                        let dest_lval = Place::Projection(Box::new(dest_lval));
                         let acquire_stmt = Statement {
                             source_info: block_data.statements[i].source_info,
                             kind: StatementKind::Validate(ValidationOp::Acquire,
-                                    vec![lval_to_operand(dest_lval)]),
+                                    vec![place_to_operand(dest_place.deref())]),
                         };
                         block_data.statements.insert(i+1, acquire_stmt);
 
@@ -349,7 +347,7 @@ impl MirPass for AddValidation {
                         };
                         let release_stmt = Statement {
                             source_info: block_data.statements[i].source_info,
-                            kind: StatementKind::Validate(op, vec![lval_to_operand(src_lval)]),
+                            kind: StatementKind::Validate(op, vec![place_to_operand(src_place)]),
                         };
                         block_data.statements.insert(i, release_stmt);
                     }
@@ -360,13 +358,13 @@ impl MirPass for AddValidation {
                     {
                         // Due to a lack of NLL; we can't capture anything directly here.
                         // Instead, we have to re-match and clone there.
-                        let (dest_lval, src_lval) = match block_data.statements[i].kind {
-                            StatementKind::Assign(ref dest_lval,
-                                    Rvalue::Cast(_, Operand::Copy(ref src_lval), _)) |
-                            StatementKind::Assign(ref dest_lval,
-                                    Rvalue::Cast(_, Operand::Move(ref src_lval), _)) =>
+                        let (dest_place, src_place) = match block_data.statements[i].kind {
+                            StatementKind::Assign(ref dest_place,
+                                    Rvalue::Cast(_, Operand::Copy(ref src_place), _)) |
+                            StatementKind::Assign(ref dest_place,
+                                    Rvalue::Cast(_, Operand::Move(ref src_place), _)) =>
                             {
-                                (dest_lval.clone(), src_lval.clone())
+                                (dest_place.clone(), src_place.clone())
                             },
                             _ => bug!("We already matched this."),
                         };
@@ -375,7 +373,7 @@ impl MirPass for AddValidation {
                         let acquire_stmt = Statement {
                             source_info: block_data.statements[i].source_info,
                             kind: StatementKind::Validate(ValidationOp::Acquire,
-                                    vec![lval_to_operand(dest_lval)]),
+                                    vec![place_to_operand(dest_place)]),
                         };
                         block_data.statements.insert(i+1, acquire_stmt);
 
@@ -383,7 +381,7 @@ impl MirPass for AddValidation {
                         let release_stmt = Statement {
                             source_info: block_data.statements[i].source_info,
                             kind: StatementKind::Validate(ValidationOp::Release,
-                                                            vec![lval_to_operand(src_lval)]),
+                                                            vec![place_to_operand(src_place)]),
                         };
                         block_data.statements.insert(i, release_stmt);
                     }

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -135,12 +135,12 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
         self.super_rvalue(rvalue, location);
     }
 
-    fn visit_lvalue(&mut self,
-                    lvalue: &Place<'tcx>,
+    fn visit_place(&mut self,
+                    place: &Place<'tcx>,
                     context: PlaceContext<'tcx>,
                     location: Location) {
         if let PlaceContext::Borrow { .. } = context {
-            if util::is_disaligned(self.tcx, self.mir, self.param_env, lvalue) {
+            if util::is_disaligned(self.tcx, self.mir, self.param_env, place) {
                 let source_info = self.source_info;
                 let lint_root =
                     self.visibility_scope_info[source_info.scope].lint_root;
@@ -152,7 +152,7 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
             }
         }
 
-        match lvalue {
+        match place {
             &Place::Projection(box Projection {
                 ref base, ref elem
             }) => {
@@ -180,7 +180,7 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
                                     _ => span_bug!(
                                         self.source_info.span,
                                         "non-field projection {:?} from union?",
-                                        lvalue)
+                                        place)
                                 };
                                 if elem_ty.moves_by_default(self.tcx, self.param_env,
                                                             self.source_info.span) {
@@ -216,7 +216,7 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
                 }
             }
         };
-        self.super_lvalue(lvalue, context, location);
+        self.super_place(place, context, location);
     }
 }
 

--- a/src/librustc_mir/transform/deaggregator.rs
+++ b/src/librustc_mir/transform/deaggregator.rs
@@ -68,7 +68,7 @@ impl MirPass for Deaggregator {
                     let rhs = Rvalue::Use(op.clone());
 
                     let lhs_cast = if adt_def.is_enum() {
-                        Lvalue::Projection(Box::new(LvalueProjection {
+                        Place::Projection(Box::new(PlaceProjection {
                             base: lhs.clone(),
                             elem: ProjectionElem::Downcast(adt_def, variant),
                         }))
@@ -76,7 +76,7 @@ impl MirPass for Deaggregator {
                         lhs.clone()
                     };
 
-                    let lhs_proj = Lvalue::Projection(Box::new(LvalueProjection {
+                    let lhs_proj = Place::Projection(Box::new(PlaceProjection {
                         base: lhs_cast,
                         elem: ProjectionElem::Field(Field::new(i), ty),
                     }));

--- a/src/librustc_mir/transform/deaggregator.rs
+++ b/src/librustc_mir/transform/deaggregator.rs
@@ -92,7 +92,7 @@ impl MirPass for Deaggregator {
                 if adt_def.is_enum() {
                     let set_discriminant = Statement {
                         kind: StatementKind::SetDiscriminant {
-                            lvalue: lhs.clone(),
+                            place: lhs.clone(),
                             variant_index: variant,
                         },
                         source_info: src_info,

--- a/src/librustc_mir/transform/elaborate_drops.rs
+++ b/src/librustc_mir/transform/elaborate_drops.rs
@@ -322,8 +322,8 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
         });
     }
 
-    fn drop_flag(&mut self, index: MovePathIndex) -> Option<Lvalue<'tcx>> {
-        self.drop_flags.get(&index).map(|t| Lvalue::Local(*t))
+    fn drop_flag(&mut self, index: MovePathIndex) -> Option<Place<'tcx>> {
+        self.drop_flags.get(&index).map(|t| Place::Local(*t))
     }
 
     /// create a patch that elaborates all drops in the input
@@ -451,7 +451,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
     fn elaborate_replace(
         &mut self,
         loc: Location,
-        location: &Lvalue<'tcx>,
+        location: &Place<'tcx>,
         value: &Operand<'tcx>,
         target: BasicBlock,
         unwind: Option<BasicBlock>)
@@ -538,7 +538,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
         if let Some(&flag) = self.drop_flags.get(&path) {
             let span = self.patch.source_info_for_location(self.mir, loc).span;
             let val = self.constant_bool(span, val.value());
-            self.patch.add_assign(loc, Lvalue::Local(flag), val);
+            self.patch.add_assign(loc, Place::Local(flag), val);
         }
     }
 
@@ -547,7 +547,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
         let span = self.patch.source_info_for_location(self.mir, loc).span;
         let false_ = self.constant_bool(span, false);
         for flag in self.drop_flags.values() {
-            self.patch.add_assign(loc, Lvalue::Local(*flag), false_.clone());
+            self.patch.add_assign(loc, Place::Local(*flag), false_.clone());
         }
     }
 

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -63,7 +63,7 @@ use rustc::hir;
 use rustc::hir::def_id::DefId;
 use rustc::middle::const_val::ConstVal;
 use rustc::mir::*;
-use rustc::mir::visit::{LvalueContext, Visitor, MutVisitor};
+use rustc::mir::visit::{PlaceContext, Visitor, MutVisitor};
 use rustc::ty::{self, TyCtxt, AdtDef, Ty, GeneratorInterior};
 use rustc::ty::subst::{Kind, Substs};
 use util::dump_mir;
@@ -90,7 +90,7 @@ struct RenameLocalVisitor {
 impl<'tcx> MutVisitor<'tcx> for RenameLocalVisitor {
     fn visit_local(&mut self,
                    local: &mut Local,
-                   _: LvalueContext<'tcx>,
+                   _: PlaceContext<'tcx>,
                    _: Location) {
         if *local == self.from {
             *local = self.to;
@@ -103,17 +103,17 @@ struct DerefArgVisitor;
 impl<'tcx> MutVisitor<'tcx> for DerefArgVisitor {
     fn visit_local(&mut self,
                    local: &mut Local,
-                   _: LvalueContext<'tcx>,
+                   _: PlaceContext<'tcx>,
                    _: Location) {
         assert_ne!(*local, self_arg());
     }
 
     fn visit_lvalue(&mut self,
-                    lvalue: &mut Lvalue<'tcx>,
-                    context: LvalueContext<'tcx>,
+                    lvalue: &mut Place<'tcx>,
+                    context: PlaceContext<'tcx>,
                     location: Location) {
-        if *lvalue == Lvalue::Local(self_arg()) {
-            *lvalue = Lvalue::Projection(Box::new(Projection {
+        if *lvalue == Place::Local(self_arg()) {
+            *lvalue = Place::Projection(Box::new(Projection {
                 base: lvalue.clone(),
                 elem: ProjectionElem::Deref,
             }));
@@ -162,14 +162,14 @@ impl<'a, 'tcx> TransformVisitor<'a, 'tcx> {
         Rvalue::Aggregate(box adt, vec![val])
     }
 
-    // Create a Lvalue referencing a generator struct field
-    fn make_field(&self, idx: usize, ty: Ty<'tcx>) -> Lvalue<'tcx> {
-        let base = Lvalue::Local(self_arg());
+    // Create a Place referencing a generator struct field
+    fn make_field(&self, idx: usize, ty: Ty<'tcx>) -> Place<'tcx> {
+        let base = Place::Local(self_arg());
         let field = Projection {
             base: base,
             elem: ProjectionElem::Field(Field::new(idx), ty),
         };
-        Lvalue::Projection(Box::new(field))
+        Place::Projection(Box::new(field))
     }
 
     // Create a statement which changes the generator state
@@ -195,16 +195,16 @@ impl<'a, 'tcx> TransformVisitor<'a, 'tcx> {
 impl<'a, 'tcx> MutVisitor<'tcx> for TransformVisitor<'a, 'tcx> {
     fn visit_local(&mut self,
                    local: &mut Local,
-                   _: LvalueContext<'tcx>,
+                   _: PlaceContext<'tcx>,
                    _: Location) {
         assert_eq!(self.remap.get(local), None);
     }
 
     fn visit_lvalue(&mut self,
-                    lvalue: &mut Lvalue<'tcx>,
-                    context: LvalueContext<'tcx>,
+                    lvalue: &mut Place<'tcx>,
+                    context: PlaceContext<'tcx>,
                     location: Location) {
-        if let Lvalue::Local(l) = *lvalue {
+        if let Place::Local(l) = *lvalue {
             // Replace an Local in the remap with a generator struct access
             if let Some(&(ty, idx)) = self.remap.get(&l) {
                 *lvalue = self.make_field(idx, ty);
@@ -230,7 +230,7 @@ impl<'a, 'tcx> MutVisitor<'tcx> for TransformVisitor<'a, 'tcx> {
         let ret_val = match data.terminator().kind {
             TerminatorKind::Return => Some((1,
                 None,
-                Operand::Move(Lvalue::Local(self.new_ret_local)),
+                Operand::Move(Place::Local(self.new_ret_local)),
                 None)),
             TerminatorKind::Yield { ref value, resume, drop } => Some((0,
                 Some(resume),
@@ -244,7 +244,7 @@ impl<'a, 'tcx> MutVisitor<'tcx> for TransformVisitor<'a, 'tcx> {
             // We must assign the value first in case it gets declared dead below
             data.statements.push(Statement {
                 source_info,
-                kind: StatementKind::Assign(Lvalue::Local(RETURN_POINTER),
+                kind: StatementKind::Assign(Place::Local(RETURN_POINTER),
                     self.make_state(state_idx, v)),
             });
             let state = if let Some(resume) = resume { // Yield
@@ -494,7 +494,7 @@ fn elaborate_generator_drops<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             &Terminator {
                 source_info,
                 kind: TerminatorKind::Drop {
-                    location: Lvalue::Local(local),
+                    location: Place::Local(local),
                     target,
                     unwind
                 }
@@ -516,7 +516,7 @@ fn elaborate_generator_drops<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             elaborate_drop(
                 &mut elaborator,
                 source_info,
-                &Lvalue::Local(gen),
+                &Place::Local(gen),
                 (),
                 target,
                 unwind,
@@ -691,7 +691,7 @@ fn insert_clean_drop<'a, 'tcx>(mir: &mut Mir<'tcx>) -> BasicBlock {
     // Create a block to destroy an unresumed generators. This can only destroy upvars.
     let drop_clean = BasicBlock::new(mir.basic_blocks().len());
     let term = TerminatorKind::Drop {
-        location: Lvalue::Local(self_arg()),
+        location: Place::Local(self_arg()),
         target: return_block,
         unwind: None,
     };
@@ -794,7 +794,7 @@ impl MirPass for StateTransform {
 
         let state_field = mir.upvar_decls.len();
 
-        // Run the transformation which converts Lvalues from Local to generator struct
+        // Run the transformation which converts Places from Local to generator struct
         // accesses for locals in `remap`.
         // It also rewrites `return x` and `yield y` as writing a new generator state and returning
         // GeneratorState::Complete(x) and GeneratorState::Yielded(y) respectively.

--- a/src/librustc_mir/transform/inline.rs
+++ b/src/librustc_mir/transform/inline.rs
@@ -404,12 +404,12 @@ impl<'a, 'tcx> Inliner<'a, 'tcx> {
 
                 // If the call is something like `a[*i] = f(i)`, where
                 // `i : &mut usize`, then just duplicating the `a[*i]`
-                // Lvalue could result in two different locations if `f`
+                // Place could result in two different locations if `f`
                 // writes to `i`. To prevent this we need to create a temporary
                 // borrow of the lvalue and pass the destination as `*temp` instead.
-                fn dest_needs_borrow(lval: &Lvalue) -> bool {
+                fn dest_needs_borrow(lval: &Place) -> bool {
                     match *lval {
-                        Lvalue::Projection(ref p) => {
+                        Place::Projection(ref p) => {
                             match p.elem {
                                 ProjectionElem::Deref |
                                 ProjectionElem::Index(_) => true,
@@ -418,7 +418,7 @@ impl<'a, 'tcx> Inliner<'a, 'tcx> {
                         }
                         // Static variables need a borrow because the callee
                         // might modify the same static.
-                        Lvalue::Static(_) => true,
+                        Place::Static(_) => true,
                         _ => false
                     }
                 }
@@ -435,7 +435,7 @@ impl<'a, 'tcx> Inliner<'a, 'tcx> {
                     let temp = LocalDecl::new_temp(ty, callsite.location.span);
 
                     let tmp = caller_mir.local_decls.push(temp);
-                    let tmp = Lvalue::Local(tmp);
+                    let tmp = Place::Local(tmp);
 
                     let stmt = Statement {
                         source_info: callsite.location,
@@ -508,7 +508,7 @@ impl<'a, 'tcx> Inliner<'a, 'tcx> {
         }
     }
 
-    fn cast_box_free_arg(&self, arg: Lvalue<'tcx>, ptr_ty: Ty<'tcx>,
+    fn cast_box_free_arg(&self, arg: Place<'tcx>, ptr_ty: Ty<'tcx>,
                          callsite: &CallSite<'tcx>, caller_mir: &mut Mir<'tcx>) -> Local {
         let arg = Rvalue::Ref(
             self.tcx.types.re_erased,
@@ -518,7 +518,7 @@ impl<'a, 'tcx> Inliner<'a, 'tcx> {
         let ty = arg.ty(caller_mir, self.tcx);
         let ref_tmp = LocalDecl::new_temp(ty, callsite.location.span);
         let ref_tmp = caller_mir.local_decls.push(ref_tmp);
-        let ref_tmp = Lvalue::Local(ref_tmp);
+        let ref_tmp = Place::Local(ref_tmp);
 
         let ref_stmt = Statement {
             source_info: callsite.location,
@@ -542,7 +542,7 @@ impl<'a, 'tcx> Inliner<'a, 'tcx> {
 
         let cast_stmt = Statement {
             source_info: callsite.location,
-            kind: StatementKind::Assign(Lvalue::Local(cast_tmp), raw_ptr)
+            kind: StatementKind::Assign(Place::Local(cast_tmp), raw_ptr)
         };
 
         caller_mir[callsite.bb]
@@ -588,7 +588,7 @@ impl<'a, 'tcx> Inliner<'a, 'tcx> {
             let tuple = self.create_temp_if_necessary(args.next().unwrap(), callsite, caller_mir);
             assert!(args.next().is_none());
 
-            let tuple = Lvalue::Local(tuple);
+            let tuple = Place::Local(tuple);
             let tuple_tys = if let ty::TyTuple(s, _) = tuple.ty(caller_mir, tcx).to_ty(tcx).sty {
                 s
             } else {
@@ -627,7 +627,7 @@ impl<'a, 'tcx> Inliner<'a, 'tcx> {
         // FIXME: Analysis of the usage of the arguments to avoid
         // unnecessary temporaries.
 
-        if let Operand::Move(Lvalue::Local(local)) = arg {
+        if let Operand::Move(Place::Local(local)) = arg {
             if caller_mir.local_kind(local) == LocalKind::Temp {
                 // Reuse the operand if it's a temporary already
                 return local;
@@ -645,7 +645,7 @@ impl<'a, 'tcx> Inliner<'a, 'tcx> {
 
         let stmt = Statement {
             source_info: callsite.location,
-            kind: StatementKind::Assign(Lvalue::Local(arg_tmp), arg),
+            kind: StatementKind::Assign(Place::Local(arg_tmp), arg),
         };
         caller_mir[callsite.bb].statements.push(stmt);
         arg_tmp
@@ -696,7 +696,7 @@ struct Integrator<'a, 'tcx: 'a> {
     scope_map: IndexVec<VisibilityScope, VisibilityScope>,
     promoted_map: IndexVec<Promoted, Promoted>,
     _callsite: CallSite<'tcx>,
-    destination: Lvalue<'tcx>,
+    destination: Place<'tcx>,
     return_block: BasicBlock,
     cleanup_block: Option<BasicBlock>,
     in_cleanup_block: bool,
@@ -713,11 +713,11 @@ impl<'a, 'tcx> Integrator<'a, 'tcx> {
 impl<'a, 'tcx> MutVisitor<'tcx> for Integrator<'a, 'tcx> {
     fn visit_local(&mut self,
                    local: &mut Local,
-                   _ctxt: LvalueContext<'tcx>,
+                   _ctxt: PlaceContext<'tcx>,
                    _location: Location) {
         if *local == RETURN_POINTER {
             match self.destination {
-                Lvalue::Local(l) => {
+                Place::Local(l) => {
                     *local = l;
                     return;
                 },
@@ -733,10 +733,10 @@ impl<'a, 'tcx> MutVisitor<'tcx> for Integrator<'a, 'tcx> {
     }
 
     fn visit_lvalue(&mut self,
-                    lvalue: &mut Lvalue<'tcx>,
-                    _ctxt: LvalueContext<'tcx>,
+                    lvalue: &mut Place<'tcx>,
+                    _ctxt: PlaceContext<'tcx>,
                     _location: Location) {
-        if let Lvalue::Local(RETURN_POINTER) = *lvalue {
+        if let Place::Local(RETURN_POINTER) = *lvalue {
             // Return pointer; update the lvalue itself
             *lvalue = self.destination.clone();
         } else {

--- a/src/librustc_mir/transform/instcombine.rs
+++ b/src/librustc_mir/transform/instcombine.rs
@@ -10,7 +10,7 @@
 
 //! Performs various peephole optimizations.
 
-use rustc::mir::{Constant, Literal, Location, Lvalue, Mir, Operand, ProjectionElem, Rvalue, Local};
+use rustc::mir::{Constant, Literal, Location, Place, Mir, Operand, ProjectionElem, Rvalue, Local};
 use rustc::mir::visit::{MutVisitor, Visitor};
 use rustc::ty::{TyCtxt, TypeVariants};
 use rustc::util::nodemap::{FxHashMap, FxHashSet};
@@ -32,7 +32,7 @@ impl MirPass for InstCombine {
 
         // First, find optimization opportunities. This is done in a pre-pass to keep the MIR
         // read-only so that we can do global analyses on the MIR in the process (e.g.
-        // `Lvalue::ty()`).
+        // `Place::ty()`).
         let optimizations = {
             let mut optimization_finder = OptimizationFinder::new(mir, tcx);
             optimization_finder.visit_mir(mir);
@@ -53,9 +53,9 @@ impl<'tcx> MutVisitor<'tcx> for InstCombineVisitor<'tcx> {
         if self.optimizations.and_stars.remove(&location) {
             debug!("Replacing `&*`: {:?}", rvalue);
             let new_lvalue = match *rvalue {
-                Rvalue::Ref(_, _, Lvalue::Projection(ref mut projection)) => {
+                Rvalue::Ref(_, _, Place::Projection(ref mut projection)) => {
                     // Replace with dummy
-                    mem::replace(&mut projection.base, Lvalue::Local(Local::new(0)))
+                    mem::replace(&mut projection.base, Place::Local(Local::new(0)))
                 }
                 _ => bug!("Detected `&*` but didn't find `&*`!"),
             };
@@ -90,7 +90,7 @@ impl<'b, 'a, 'tcx:'b> OptimizationFinder<'b, 'a, 'tcx> {
 
 impl<'b, 'a, 'tcx> Visitor<'tcx> for OptimizationFinder<'b, 'a, 'tcx> {
     fn visit_rvalue(&mut self, rvalue: &Rvalue<'tcx>, location: Location) {
-        if let Rvalue::Ref(_, _, Lvalue::Projection(ref projection)) = *rvalue {
+        if let Rvalue::Ref(_, _, Place::Projection(ref projection)) = *rvalue {
             if let ProjectionElem::Deref = projection.elem {
                 if projection.base.ty(self.mir, self.tcx).to_ty(self.tcx).is_region_ptr() {
                     self.optimizations.and_stars.insert(location);

--- a/src/librustc_mir/transform/lower_128bit.rs
+++ b/src/librustc_mir/transform/lower_128bit.rs
@@ -75,19 +75,19 @@ impl Lower128Bit {
                 };
 
                 let bin_statement = block.statements.pop().unwrap();
-                let (source_info, lvalue, lhs, mut rhs) = match bin_statement {
+                let (source_info, place, lhs, mut rhs) = match bin_statement {
                     Statement {
                         source_info,
                         kind: StatementKind::Assign(
-                            lvalue,
+                            place,
                             Rvalue::BinaryOp(_, lhs, rhs))
-                    } => (source_info, lvalue, lhs, rhs),
+                    } => (source_info, place, lhs, rhs),
                     Statement {
                         source_info,
                         kind: StatementKind::Assign(
-                            lvalue,
+                            place,
                             Rvalue::CheckedBinaryOp(_, lhs, rhs))
-                    } => (source_info, lvalue, lhs, rhs),
+                    } => (source_info, place, lhs, rhs),
                     _ => bug!("Statement doesn't match pattern any more?"),
                 };
 
@@ -109,7 +109,7 @@ impl Lower128Bit {
                 }
 
                 let call_did = check_lang_item_type(
-                    lang_item, &lvalue, &lhs, &rhs, local_decls, tcx);
+                    lang_item, &place, &lhs, &rhs, local_decls, tcx);
 
                 let bb = BasicBlock::new(cur_len + new_blocks.len());
                 new_blocks.push(after_call);
@@ -121,7 +121,7 @@ impl Lower128Bit {
                             func: Operand::function_handle(tcx, call_did,
                                 Slice::empty(), source_info.span),
                             args: vec![lhs, rhs],
-                            destination: Some((lvalue, bb)),
+                            destination: Some((place, bb)),
                             cleanup: None,
                         },
                     });
@@ -134,7 +134,7 @@ impl Lower128Bit {
 
 fn check_lang_item_type<'a, 'tcx, D>(
     lang_item: LangItem,
-    lvalue: &Place<'tcx>,
+    place: &Place<'tcx>,
     lhs: &Operand<'tcx>,
     rhs: &Operand<'tcx>,
     local_decls: &D,
@@ -147,8 +147,8 @@ fn check_lang_item_type<'a, 'tcx, D>(
     let sig = tcx.no_late_bound_regions(&poly_sig).unwrap();
     let lhs_ty = lhs.ty(local_decls, tcx);
     let rhs_ty = rhs.ty(local_decls, tcx);
-    let lvalue_ty = lvalue.ty(local_decls, tcx).to_ty(tcx);
-    let expected = [lhs_ty, rhs_ty, lvalue_ty];
+    let place_ty = place.ty(local_decls, tcx).to_ty(tcx);
+    let expected = [lhs_ty, rhs_ty, place_ty];
     assert_eq!(sig.inputs_and_output[..], expected,
         "lang item {}", tcx.def_symbol_name(did));
     did

--- a/src/librustc_mir/transform/lower_128bit.rs
+++ b/src/librustc_mir/transform/lower_128bit.rs
@@ -99,13 +99,13 @@ impl Lower128Bit {
                     block.statements.push(Statement {
                         source_info: source_info,
                         kind: StatementKind::Assign(
-                            Lvalue::Local(local),
+                            Place::Local(local),
                             Rvalue::Cast(
                                 CastKind::Misc,
                                 rhs,
                                 rhs_override_ty.unwrap())),
                     });
-                    rhs = Operand::Move(Lvalue::Local(local));
+                    rhs = Operand::Move(Place::Local(local));
                 }
 
                 let call_did = check_lang_item_type(
@@ -134,7 +134,7 @@ impl Lower128Bit {
 
 fn check_lang_item_type<'a, 'tcx, D>(
     lang_item: LangItem,
-    lvalue: &Lvalue<'tcx>,
+    lvalue: &Place<'tcx>,
     lhs: &Operand<'tcx>,
     rhs: &Operand<'tcx>,
     local_decls: &D,

--- a/src/librustc_mir/transform/nll/constraint_generation.rs
+++ b/src/librustc_mir/transform/nll/constraint_generation.rs
@@ -189,9 +189,9 @@ impl<'cx, 'gcx, 'tcx> ConstraintGeneration<'cx, 'gcx, 'tcx> {
         &mut self,
         location: Location,
         borrow_region: ty::Region<'tcx>,
-        borrowed_lv: &Place<'tcx>,
+        borrowed_place: &Place<'tcx>,
     ) {
-        if let Projection(ref proj) = *borrowed_lv {
+        if let Projection(ref proj) = *borrowed_place {
             let PlaceProjection { ref base, ref elem } = **proj;
 
             if let ProjectionElem::Deref = *elem {
@@ -232,8 +232,8 @@ impl<'cx, 'gcx, 'tcx> Visitor<'tcx> for ConstraintGeneration<'cx, 'gcx, 'tcx> {
         // where L is the path that is borrowed. In that case, we have
         // to add the reborrow constraints (which don't fall out
         // naturally from the type-checker).
-        if let Rvalue::Ref(region, _bk, ref borrowed_lv) = *rvalue {
-            self.add_reborrow_constraint(location, region, borrowed_lv);
+        if let Rvalue::Ref(region, _bk, ref borrowed_place) = *rvalue {
+            self.add_reborrow_constraint(location, region, borrowed_place);
         }
 
         self.super_rvalue(rvalue, location);

--- a/src/librustc_mir/transform/nll/constraint_generation.rs
+++ b/src/librustc_mir/transform/nll/constraint_generation.rs
@@ -9,10 +9,10 @@
 // except according to those terms.
 
 use rustc::hir;
-use rustc::mir::{Location, Lvalue, Mir, Rvalue};
+use rustc::mir::{Location, Place, Mir, Rvalue};
 use rustc::mir::visit::Visitor;
-use rustc::mir::Lvalue::Projection;
-use rustc::mir::{LvalueProjection, ProjectionElem};
+use rustc::mir::Place::Projection;
+use rustc::mir::{PlaceProjection, ProjectionElem};
 use rustc::infer::InferCtxt;
 use rustc::traits::{self, ObligationCause};
 use rustc::ty::{self, Ty};
@@ -189,10 +189,10 @@ impl<'cx, 'gcx, 'tcx> ConstraintGeneration<'cx, 'gcx, 'tcx> {
         &mut self,
         location: Location,
         borrow_region: ty::Region<'tcx>,
-        borrowed_lv: &Lvalue<'tcx>,
+        borrowed_lv: &Place<'tcx>,
     ) {
         if let Projection(ref proj) = *borrowed_lv {
-            let LvalueProjection { ref base, ref elem } = **proj;
+            let PlaceProjection { ref base, ref elem } = **proj;
 
             if let ProjectionElem::Deref = *elem {
                 let tcx = self.infcx.tcx;

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -316,7 +316,7 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
             statement_index: usize::MAX
         });
 
-        self.assign(RETURN_POINTER, rvalue, span);
+        self.assign(RETURN_PLACE, rvalue, span);
         self.source.promoted.push(self.promoted);
     }
 }
@@ -373,8 +373,8 @@ pub fn promote_candidates<'a, 'tcx>(mir: &mut Mir<'tcx>,
             }
         };
 
-        // Declare return pointer local
-        let initial_locals = iter::once(LocalDecl::new_return_pointer(ty, span))
+        // Declare return place local
+        let initial_locals = iter::once(LocalDecl::new_return_place(ty, span))
             .collect();
 
         let mut promoter = Promoter {

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -23,7 +23,7 @@
 //! move analysis runs after promotion on broken MIR.
 
 use rustc::mir::*;
-use rustc::mir::visit::{LvalueContext, MutVisitor, Visitor};
+use rustc::mir::visit::{PlaceContext, MutVisitor, Visitor};
 use rustc::mir::traversal::ReversePostorder;
 use rustc::ty::TyCtxt;
 use syntax_pos::Span;
@@ -85,7 +85,7 @@ struct TempCollector<'tcx> {
 impl<'tcx> Visitor<'tcx> for TempCollector<'tcx> {
     fn visit_local(&mut self,
                    &index: &Local,
-                   context: LvalueContext<'tcx>,
+                   context: PlaceContext<'tcx>,
                    location: Location) {
         // We're only interested in temporaries
         if self.mir.local_kind(index) != LocalKind::Temp {
@@ -102,8 +102,8 @@ impl<'tcx> Visitor<'tcx> for TempCollector<'tcx> {
         let temp = &mut self.temps[index];
         if *temp == TempState::Undefined {
             match context {
-                LvalueContext::Store |
-                LvalueContext::Call => {
+                PlaceContext::Store |
+                PlaceContext::Call => {
                     *temp = TempState::Defined {
                         location,
                         uses: 0
@@ -116,7 +116,7 @@ impl<'tcx> Visitor<'tcx> for TempCollector<'tcx> {
             // We always allow borrows, even mutable ones, as we need
             // to promote mutable borrows of some ZSTs e.g. `&mut []`.
             let allowed_use = match context {
-                LvalueContext::Borrow {..} => true,
+                PlaceContext::Borrow {..} => true,
                 _ => context.is_nonmutating_use()
             };
             if allowed_use {
@@ -179,7 +179,7 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
                 span,
                 scope: ARGUMENT_VISIBILITY_SCOPE
             },
-            kind: StatementKind::Assign(Lvalue::Local(dest), rvalue)
+            kind: StatementKind::Assign(Place::Local(dest), rvalue)
         });
     }
 
@@ -268,7 +268,7 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
                             func,
                             args,
                             cleanup: None,
-                            destination: Some((Lvalue::Local(new_temp), new_target))
+                            destination: Some((Place::Local(new_temp), new_target))
                         },
                         ..terminator
                     };
@@ -325,7 +325,7 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
 impl<'a, 'tcx> MutVisitor<'tcx> for Promoter<'a, 'tcx> {
     fn visit_local(&mut self,
                    local: &mut Local,
-                   _: LvalueContext<'tcx>,
+                   _: PlaceContext<'tcx>,
                    _: Location) {
         if self.source.local_kind(*local) == LocalKind::Temp {
             *local = self.promote_temp(*local);
@@ -350,7 +350,7 @@ pub fn promote_candidates<'a, 'tcx>(mir: &mut Mir<'tcx>,
                                   "expected assignment to promote");
                     }
                 };
-                if let Lvalue::Local(index) = *dest {
+                if let Place::Local(index) = *dest {
                     if temps[index] == TempState::PromotedOut {
                         // Already promoted.
                         continue;
@@ -404,7 +404,7 @@ pub fn promote_candidates<'a, 'tcx>(mir: &mut Mir<'tcx>,
     for block in mir.basic_blocks_mut() {
         block.statements.retain(|statement| {
             match statement.kind {
-                StatementKind::Assign(Lvalue::Local(index), _) |
+                StatementKind::Assign(Place::Local(index), _) |
                 StatementKind::StorageLive(index) |
                 StatementKind::StorageDead(index) => {
                     !promoted(index)
@@ -414,7 +414,7 @@ pub fn promote_candidates<'a, 'tcx>(mir: &mut Mir<'tcx>,
         });
         let terminator = block.terminator_mut();
         match terminator.kind {
-            TerminatorKind::Drop { location: Lvalue::Local(index), target, .. } => {
+            TerminatorKind::Drop { location: Place::Local(index), target, .. } => {
                 if promoted(index) {
                     terminator.kind = TerminatorKind::Goto {
                         target,

--- a/src/librustc_mir/transform/rustc_peek.rs
+++ b/src/librustc_mir/transform/rustc_peek.rs
@@ -124,8 +124,8 @@ fn each_block<'a, 'tcx, O>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     };
     assert!(args.len() == 1);
     let peek_arg_lval = match args[0] {
-        mir::Operand::Copy(ref lval @ mir::Lvalue::Local(_)) |
-        mir::Operand::Move(ref lval @ mir::Lvalue::Local(_)) => Some(lval),
+        mir::Operand::Copy(ref lval @ mir::Place::Local(_)) |
+        mir::Operand::Move(ref lval @ mir::Place::Local(_)) => Some(lval),
         _ => None,
     };
 

--- a/src/librustc_mir/transform/rustc_peek.rs
+++ b/src/librustc_mir/transform/rustc_peek.rs
@@ -123,13 +123,13 @@ fn each_block<'a, 'tcx, O>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         None => return,
     };
     assert!(args.len() == 1);
-    let peek_arg_lval = match args[0] {
-        mir::Operand::Copy(ref lval @ mir::Place::Local(_)) |
-        mir::Operand::Move(ref lval @ mir::Place::Local(_)) => Some(lval),
+    let peek_arg_place = match args[0] {
+        mir::Operand::Copy(ref place @ mir::Place::Local(_)) |
+        mir::Operand::Move(ref place @ mir::Place::Local(_)) => Some(place),
         _ => None,
     };
 
-    let peek_arg_lval = match peek_arg_lval {
+    let peek_arg_place = match peek_arg_place {
         Some(arg) => arg,
         None => {
             tcx.sess.diagnostic().span_err(
@@ -143,8 +143,8 @@ fn each_block<'a, 'tcx, O>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let mut kill = results.0.sets.kill_set_for(bb.index()).to_owned();
 
     // Emulate effect of all statements in the block up to (but not
-    // including) the borrow within `peek_arg_lval`. Do *not* include
-    // call to `peek_arg_lval` itself (since we are peeking the state
+    // including) the borrow within `peek_arg_place`. Do *not* include
+    // call to `peek_arg_place` itself (since we are peeking the state
     // of the argument at time immediate preceding Call to
     // `rustc_peek`).
 
@@ -154,9 +154,9 @@ fn each_block<'a, 'tcx, O>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
     for (j, stmt) in statements.iter().enumerate() {
         debug!("rustc_peek: ({:?},{}) {:?}", bb, j, stmt);
-        let (lvalue, rvalue) = match stmt.kind {
-            mir::StatementKind::Assign(ref lvalue, ref rvalue) => {
-                (lvalue, rvalue)
+        let (place, rvalue) = match stmt.kind {
+            mir::StatementKind::Assign(ref place, ref rvalue) => {
+                (place, rvalue)
             }
             mir::StatementKind::StorageLive(_) |
             mir::StatementKind::StorageDead(_) |
@@ -169,14 +169,14 @@ fn each_block<'a, 'tcx, O>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                           "sanity_check should run before Deaggregator inserts SetDiscriminant"),
         };
 
-        if lvalue == peek_arg_lval {
-            if let mir::Rvalue::Ref(_, mir::BorrowKind::Shared, ref peeking_at_lval) = *rvalue {
+        if place == peek_arg_place {
+            if let mir::Rvalue::Ref(_, mir::BorrowKind::Shared, ref peeking_at_place) = *rvalue {
                 // Okay, our search is over.
-                match move_data.rev_lookup.find(peeking_at_lval) {
+                match move_data.rev_lookup.find(peeking_at_place) {
                     LookupResult::Exact(peek_mpi) => {
                         let bit_state = sets.on_entry.contains(&peek_mpi);
                         debug!("rustc_peek({:?} = &{:?}) bit_state: {}",
-                               lvalue, peeking_at_lval, bit_state);
+                               place, peeking_at_place, bit_state);
                         if !bit_state {
                             tcx.sess.span_err(span, "rustc_peek: bit not set");
                         }
@@ -196,10 +196,10 @@ fn each_block<'a, 'tcx, O>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             }
         }
 
-        let lhs_mpi = move_data.rev_lookup.find(lvalue);
+        let lhs_mpi = move_data.rev_lookup.find(place);
 
-        debug!("rustc_peek: computing effect on lvalue: {:?} ({:?}) in stmt: {:?}",
-               lvalue, lhs_mpi, stmt);
+        debug!("rustc_peek: computing effect on place: {:?} ({:?}) in stmt: {:?}",
+               place, lhs_mpi, stmt);
         // reset GEN and KILL sets before emulating their effect.
         for e in sets.gen_set.words_mut() { *e = 0; }
         for e in sets.kill_set.words_mut() { *e = 0; }

--- a/src/librustc_mir/transform/simplify.rs
+++ b/src/librustc_mir/transform/simplify.rs
@@ -41,7 +41,7 @@ use rustc_data_structures::bitvec::BitVector;
 use rustc_data_structures::indexed_vec::{Idx, IndexVec};
 use rustc::ty::TyCtxt;
 use rustc::mir::*;
-use rustc::mir::visit::{MutVisitor, Visitor, LvalueContext};
+use rustc::mir::visit::{MutVisitor, Visitor, PlaceContext};
 use std::borrow::Cow;
 use transform::{MirPass, MirSource};
 
@@ -352,9 +352,9 @@ struct DeclMarker {
 }
 
 impl<'tcx> Visitor<'tcx> for DeclMarker {
-    fn visit_local(&mut self, local: &Local, ctx: LvalueContext<'tcx>, _: Location) {
+    fn visit_local(&mut self, local: &Local, ctx: PlaceContext<'tcx>, _: Location) {
         // ignore these altogether, they get removed along with their otherwise unused decls.
-        if ctx != LvalueContext::StorageLive && ctx != LvalueContext::StorageDead {
+        if ctx != PlaceContext::StorageLive && ctx != PlaceContext::StorageDead {
             self.locals.insert(local.index());
         }
     }
@@ -377,7 +377,7 @@ impl<'tcx> MutVisitor<'tcx> for LocalUpdater {
         });
         self.super_basic_block_data(block, data);
     }
-    fn visit_local(&mut self, l: &mut Local, _: LvalueContext<'tcx>, _: Location) {
+    fn visit_local(&mut self, l: &mut Local, _: PlaceContext<'tcx>, _: Location) {
         *l = Local::new(self.map[l.index()]);
     }
 }

--- a/src/librustc_mir/util/alignment.rs
+++ b/src/librustc_mir/util/alignment.rs
@@ -18,7 +18,7 @@ use rustc::mir::*;
 pub fn is_disaligned<'a, 'tcx, L>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                   local_decls: &L,
                                   param_env: ty::ParamEnv<'tcx>,
-                                  lvalue: &Lvalue<'tcx>)
+                                  lvalue: &Place<'tcx>)
                                   -> bool
     where L: HasLocalDecls<'tcx>
 {
@@ -45,12 +45,12 @@ pub fn is_disaligned<'a, 'tcx, L>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
 fn is_within_packed<'a, 'tcx, L>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                  local_decls: &L,
-                                 lvalue: &Lvalue<'tcx>)
+                                 lvalue: &Place<'tcx>)
                                  -> bool
     where L: HasLocalDecls<'tcx>
 {
     let mut lvalue = lvalue;
-    while let &Lvalue::Projection(box Projection {
+    while let &Place::Projection(box Projection {
         ref base, ref elem
     }) = lvalue {
         match *elem {

--- a/src/librustc_mir/util/alignment.rs
+++ b/src/librustc_mir/util/alignment.rs
@@ -12,32 +12,32 @@
 use rustc::ty::{self, TyCtxt};
 use rustc::mir::*;
 
-/// Return `true` if this lvalue is allowed to be less aligned
+/// Return `true` if this place is allowed to be less aligned
 /// than its containing struct (because it is within a packed
 /// struct).
 pub fn is_disaligned<'a, 'tcx, L>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                   local_decls: &L,
                                   param_env: ty::ParamEnv<'tcx>,
-                                  lvalue: &Place<'tcx>)
+                                  place: &Place<'tcx>)
                                   -> bool
     where L: HasLocalDecls<'tcx>
 {
-    debug!("is_disaligned({:?})", lvalue);
-    if !is_within_packed(tcx, local_decls, lvalue) {
-        debug!("is_disaligned({:?}) - not within packed", lvalue);
+    debug!("is_disaligned({:?})", place);
+    if !is_within_packed(tcx, local_decls, place) {
+        debug!("is_disaligned({:?}) - not within packed", place);
         return false
     }
 
-    let ty = lvalue.ty(local_decls, tcx).to_ty(tcx);
+    let ty = place.ty(local_decls, tcx).to_ty(tcx);
     match tcx.layout_raw(param_env.and(ty)) {
         Ok(layout) if layout.align.abi() == 1 => {
             // if the alignment is 1, the type can't be further
             // disaligned.
-            debug!("is_disaligned({:?}) - align = 1", lvalue);
+            debug!("is_disaligned({:?}) - align = 1", place);
             false
         }
         _ => {
-            debug!("is_disaligned({:?}) - true", lvalue);
+            debug!("is_disaligned({:?}) - true", place);
             true
         }
     }
@@ -45,14 +45,14 @@ pub fn is_disaligned<'a, 'tcx, L>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
 fn is_within_packed<'a, 'tcx, L>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                  local_decls: &L,
-                                 lvalue: &Place<'tcx>)
+                                 place: &Place<'tcx>)
                                  -> bool
     where L: HasLocalDecls<'tcx>
 {
-    let mut lvalue = lvalue;
+    let mut place = place;
     while let &Place::Projection(box Projection {
         ref base, ref elem
-    }) = lvalue {
+    }) = place {
         match *elem {
             // encountered a Deref, which is ABI-aligned
             ProjectionElem::Deref => break,
@@ -67,7 +67,7 @@ fn is_within_packed<'a, 'tcx, L>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             }
             _ => {}
         }
-        lvalue = base;
+        place = base;
     }
 
     false

--- a/src/librustc_mir/util/def_use.rs
+++ b/src/librustc_mir/util/def_use.rs
@@ -64,10 +64,10 @@ impl<'tcx> DefUseAnalysis<'tcx> {
                                where F: for<'a> FnMut(&'a mut Local,
                                                       PlaceContext<'tcx>,
                                                       Location) {
-        for lvalue_use in &self.info[local].defs_and_uses {
+        for place_use in &self.info[local].defs_and_uses {
             MutateUseVisitor::new(local,
                                   &mut callback,
-                                  mir).visit_location(mir, lvalue_use.location)
+                                  mir).visit_location(mir, place_use.location)
         }
     }
 
@@ -108,7 +108,7 @@ impl<'tcx> Info<'tcx> {
     }
 
     pub fn def_count(&self) -> usize {
-        self.defs_and_uses.iter().filter(|lvalue_use| lvalue_use.context.is_mutating_use()).count()
+        self.defs_and_uses.iter().filter(|place_use| place_use.context.is_mutating_use()).count()
     }
 
     pub fn def_count_not_including_drop(&self) -> usize {
@@ -118,14 +118,14 @@ impl<'tcx> Info<'tcx> {
     pub fn defs_not_including_drop(
         &self,
     ) -> iter::Filter<slice::Iter<Use<'tcx>>, fn(&&Use<'tcx>) -> bool> {
-        self.defs_and_uses.iter().filter(|lvalue_use| {
-            lvalue_use.context.is_mutating_use() && !lvalue_use.context.is_drop()
+        self.defs_and_uses.iter().filter(|place_use| {
+            place_use.context.is_mutating_use() && !place_use.context.is_drop()
         })
     }
 
     pub fn use_count(&self) -> usize {
-        self.defs_and_uses.iter().filter(|lvalue_use| {
-            lvalue_use.context.is_nonmutating_use()
+        self.defs_and_uses.iter().filter(|place_use| {
+            place_use.context.is_nonmutating_use()
         }).count()
     }
 }

--- a/src/librustc_mir/util/def_use.rs
+++ b/src/librustc_mir/util/def_use.rs
@@ -11,7 +11,7 @@
 //! Def-use analysis.
 
 use rustc::mir::{Local, Location, Mir};
-use rustc::mir::visit::{LvalueContext, MutVisitor, Visitor};
+use rustc::mir::visit::{PlaceContext, MutVisitor, Visitor};
 use rustc_data_structures::indexed_vec::IndexVec;
 use std::marker::PhantomData;
 use std::mem;
@@ -29,7 +29,7 @@ pub struct Info<'tcx> {
 
 #[derive(Clone)]
 pub struct Use<'tcx> {
-    pub context: LvalueContext<'tcx>,
+    pub context: PlaceContext<'tcx>,
     pub location: Location,
 }
 
@@ -62,7 +62,7 @@ impl<'tcx> DefUseAnalysis<'tcx> {
 
     fn mutate_defs_and_uses<F>(&self, local: Local, mir: &mut Mir<'tcx>, mut callback: F)
                                where F: for<'a> FnMut(&'a mut Local,
-                                                      LvalueContext<'tcx>,
+                                                      PlaceContext<'tcx>,
                                                       Location) {
         for lvalue_use in &self.info[local].defs_and_uses {
             MutateUseVisitor::new(local,
@@ -87,7 +87,7 @@ struct DefUseFinder<'tcx> {
 impl<'tcx> Visitor<'tcx> for DefUseFinder<'tcx> {
     fn visit_local(&mut self,
                    &local: &Local,
-                   context: LvalueContext<'tcx>,
+                   context: PlaceContext<'tcx>,
                    location: Location) {
         self.info[local].defs_and_uses.push(Use {
             context,
@@ -139,7 +139,7 @@ struct MutateUseVisitor<'tcx, F> {
 impl<'tcx, F> MutateUseVisitor<'tcx, F> {
     fn new(query: Local, callback: F, _: &Mir<'tcx>)
            -> MutateUseVisitor<'tcx, F>
-           where F: for<'a> FnMut(&'a mut Local, LvalueContext<'tcx>, Location) {
+           where F: for<'a> FnMut(&'a mut Local, PlaceContext<'tcx>, Location) {
         MutateUseVisitor {
             query,
             callback,
@@ -149,10 +149,10 @@ impl<'tcx, F> MutateUseVisitor<'tcx, F> {
 }
 
 impl<'tcx, F> MutVisitor<'tcx> for MutateUseVisitor<'tcx, F>
-              where F: for<'a> FnMut(&'a mut Local, LvalueContext<'tcx>, Location) {
+              where F: for<'a> FnMut(&'a mut Local, PlaceContext<'tcx>, Location) {
     fn visit_local(&mut self,
                     local: &mut Local,
-                    context: LvalueContext<'tcx>,
+                    context: PlaceContext<'tcx>,
                     location: Location) {
         if *local == self.query {
             (self.callback)(local, context, location)

--- a/src/librustc_mir/util/elaborate_drops.rs
+++ b/src/librustc_mir/util/elaborate_drops.rs
@@ -105,7 +105,7 @@ struct DropCtxt<'l, 'b: 'l, 'tcx: 'b, D>
 
     source_info: SourceInfo,
 
-    lvalue: &'l Lvalue<'tcx>,
+    lvalue: &'l Place<'tcx>,
     path: D::Path,
     succ: BasicBlock,
     unwind: Unwind,
@@ -114,7 +114,7 @@ struct DropCtxt<'l, 'b: 'l, 'tcx: 'b, D>
 pub fn elaborate_drop<'b, 'tcx, D>(
     elaborator: &mut D,
     source_info: SourceInfo,
-    lvalue: &Lvalue<'tcx>,
+    lvalue: &Place<'tcx>,
     path: D::Path,
     succ: BasicBlock,
     unwind: Unwind,
@@ -129,7 +129,7 @@ pub fn elaborate_drop<'b, 'tcx, D>(
 impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
     where D: DropElaborator<'b, 'tcx>
 {
-    fn lvalue_ty(&self, lvalue: &Lvalue<'tcx>) -> Ty<'tcx> {
+    fn lvalue_ty(&self, lvalue: &Place<'tcx>) -> Ty<'tcx> {
         lvalue.ty(self.elaborator.mir(), self.tcx()).to_ty(self.tcx())
     }
 
@@ -194,11 +194,11 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
     /// Return the lvalue and move path for each field of `variant`,
     /// (the move path is `None` if the field is a rest field).
     fn move_paths_for_fields(&self,
-                             base_lv: &Lvalue<'tcx>,
+                             base_lv: &Place<'tcx>,
                              variant_path: D::Path,
                              variant: &'tcx ty::VariantDef,
                              substs: &'tcx Substs<'tcx>)
-                             -> Vec<(Lvalue<'tcx>, Option<D::Path>)>
+                             -> Vec<(Place<'tcx>, Option<D::Path>)>
     {
         variant.fields.iter().enumerate().map(|(i, f)| {
             let field = Field::new(i);
@@ -214,7 +214,7 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
     }
 
     fn drop_subpath(&mut self,
-                    lvalue: &Lvalue<'tcx>,
+                    lvalue: &Place<'tcx>,
                     path: Option<D::Path>,
                     succ: BasicBlock,
                     unwind: Unwind)
@@ -251,7 +251,7 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
     fn drop_halfladder(&mut self,
                        unwind_ladder: &[Unwind],
                        mut succ: BasicBlock,
-                       fields: &[(Lvalue<'tcx>, Option<D::Path>)])
+                       fields: &[(Place<'tcx>, Option<D::Path>)])
                        -> Vec<BasicBlock>
     {
         Some(succ).into_iter().chain(
@@ -294,7 +294,7 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
     /// NOTE: this does not clear the master drop flag, so you need
     /// to point succ/unwind on a `drop_ladder_bottom`.
     fn drop_ladder<'a>(&mut self,
-                       fields: Vec<(Lvalue<'tcx>, Option<D::Path>)>,
+                       fields: Vec<(Place<'tcx>, Option<D::Path>)>,
                        succ: BasicBlock,
                        unwind: Unwind)
                        -> (BasicBlock, Unwind)
@@ -491,7 +491,7 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
         // discriminant after it is free-ed, because that
         // way lies only trouble.
         let discr_ty = adt.repr.discr_type().to_ty(self.tcx());
-        let discr = Lvalue::Local(self.new_temp(discr_ty));
+        let discr = Place::Local(self.new_temp(discr_ty));
         let discr_rv = Rvalue::Discriminant(self.lvalue.clone());
         let switch_block = BasicBlockData {
             statements: vec![self.assign(&discr, discr_rv)],
@@ -525,18 +525,18 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
             mutbl: hir::Mutability::MutMutable
         });
         let ref_lvalue = self.new_temp(ref_ty);
-        let unit_temp = Lvalue::Local(self.new_temp(tcx.mk_nil()));
+        let unit_temp = Place::Local(self.new_temp(tcx.mk_nil()));
 
         let result = BasicBlockData {
             statements: vec![self.assign(
-                &Lvalue::Local(ref_lvalue),
+                &Place::Local(ref_lvalue),
                 Rvalue::Ref(tcx.types.re_erased, BorrowKind::Mut, self.lvalue.clone())
             )],
             terminator: Some(Terminator {
                 kind: TerminatorKind::Call {
                     func: Operand::function_handle(tcx, drop_fn.def_id, substs,
                                                    self.source_info.span),
-                    args: vec![Operand::Move(Lvalue::Local(ref_lvalue))],
+                    args: vec![Operand::Move(Place::Local(ref_lvalue))],
                     destination: Some((unit_temp, succ)),
                     cleanup: unwind.into_option(),
                 },
@@ -566,39 +566,39 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
     fn drop_loop(&mut self,
                  succ: BasicBlock,
                  cur: Local,
-                 length_or_end: &Lvalue<'tcx>,
+                 length_or_end: &Place<'tcx>,
                  ety: Ty<'tcx>,
                  unwind: Unwind,
                  ptr_based: bool)
                  -> BasicBlock
     {
-        let copy = |lv: &Lvalue<'tcx>| Operand::Copy(lv.clone());
-        let move_ = |lv: &Lvalue<'tcx>| Operand::Move(lv.clone());
+        let copy = |lv: &Place<'tcx>| Operand::Copy(lv.clone());
+        let move_ = |lv: &Place<'tcx>| Operand::Move(lv.clone());
         let tcx = self.tcx();
 
         let ref_ty = tcx.mk_ref(tcx.types.re_erased, ty::TypeAndMut {
             ty: ety,
             mutbl: hir::Mutability::MutMutable
         });
-        let ptr = &Lvalue::Local(self.new_temp(ref_ty));
-        let can_go = &Lvalue::Local(self.new_temp(tcx.types.bool));
+        let ptr = &Place::Local(self.new_temp(ref_ty));
+        let can_go = &Place::Local(self.new_temp(tcx.types.bool));
 
         let one = self.constant_usize(1);
         let (ptr_next, cur_next) = if ptr_based {
-            (Rvalue::Use(copy(&Lvalue::Local(cur))),
-             Rvalue::BinaryOp(BinOp::Offset, copy(&Lvalue::Local(cur)), one))
+            (Rvalue::Use(copy(&Place::Local(cur))),
+             Rvalue::BinaryOp(BinOp::Offset, copy(&Place::Local(cur)), one))
         } else {
             (Rvalue::Ref(
                  tcx.types.re_erased,
                  BorrowKind::Mut,
                  self.lvalue.clone().index(cur)),
-             Rvalue::BinaryOp(BinOp::Add, copy(&Lvalue::Local(cur)), one))
+             Rvalue::BinaryOp(BinOp::Add, copy(&Place::Local(cur)), one))
         };
 
         let drop_block = BasicBlockData {
             statements: vec![
                 self.assign(ptr, ptr_next),
-                self.assign(&Lvalue::Local(cur), cur_next)
+                self.assign(&Place::Local(cur), cur_next)
             ],
             is_cleanup: unwind.is_cleanup(),
             terminator: Some(Terminator {
@@ -612,7 +612,7 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
         let loop_block = BasicBlockData {
             statements: vec![
                 self.assign(can_go, Rvalue::BinaryOp(BinOp::Eq,
-                                                     copy(&Lvalue::Local(cur)),
+                                                     copy(&Place::Local(cur)),
                                                      copy(length_or_end)))
             ],
             is_cleanup: unwind.is_cleanup(),
@@ -643,9 +643,9 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
 
         let tcx = self.tcx();
 
-        let move_ = |lv: &Lvalue<'tcx>| Operand::Move(lv.clone());
-        let size = &Lvalue::Local(self.new_temp(tcx.types.usize));
-        let size_is_zero = &Lvalue::Local(self.new_temp(tcx.types.bool));
+        let move_ = |lv: &Place<'tcx>| Operand::Move(lv.clone());
+        let size = &Place::Local(self.new_temp(tcx.types.usize));
+        let size_is_zero = &Place::Local(self.new_temp(tcx.types.bool));
         let base_block = BasicBlockData {
             statements: vec![
                 self.assign(size, Rvalue::NullaryOp(NullOp::SizeOf, ety)),
@@ -680,9 +680,9 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
         };
 
         let cur = self.new_temp(iter_ty);
-        let length = Lvalue::Local(self.new_temp(tcx.types.usize));
+        let length = Place::Local(self.new_temp(tcx.types.usize));
         let length_or_end = if ptr_based {
-            Lvalue::Local(self.new_temp(iter_ty))
+            Place::Local(self.new_temp(iter_ty))
         } else {
             length.clone()
         };
@@ -705,13 +705,13 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
             unwind,
             ptr_based);
 
-        let cur = Lvalue::Local(cur);
+        let cur = Place::Local(cur);
         let zero = self.constant_usize(0);
         let mut drop_block_stmts = vec![];
         drop_block_stmts.push(self.assign(&length, Rvalue::Len(self.lvalue.clone())));
         if ptr_based {
             let tmp_ty = tcx.mk_mut_ptr(self.lvalue_ty(self.lvalue));
-            let tmp = Lvalue::Local(self.new_temp(tmp_ty));
+            let tmp = Place::Local(self.new_temp(tmp_ty));
             // tmp = &LV;
             // cur = tmp as *mut T;
             // end = Offset(cur, len);
@@ -849,7 +849,7 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
         unwind: Unwind
     ) -> BasicBlock {
         let tcx = self.tcx();
-        let unit_temp = Lvalue::Local(self.new_temp(tcx.mk_nil()));
+        let unit_temp = Place::Local(self.new_temp(tcx.mk_nil()));
         let free_func = tcx.require_lang_item(lang_items::BoxFreeFnLangItem);
         let substs = tcx.mk_substs(iter::once(Kind::from(ty)));
 
@@ -932,7 +932,7 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
         })
     }
 
-    fn assign(&self, lhs: &Lvalue<'tcx>, rhs: Rvalue<'tcx>) -> Statement<'tcx> {
+    fn assign(&self, lhs: &Place<'tcx>, rhs: Rvalue<'tcx>) -> Statement<'tcx> {
         Statement {
             source_info: self.source_info,
             kind: StatementKind::Assign(lhs.clone(), rhs)

--- a/src/librustc_mir/util/elaborate_drops.rs
+++ b/src/librustc_mir/util/elaborate_drops.rs
@@ -105,7 +105,7 @@ struct DropCtxt<'l, 'b: 'l, 'tcx: 'b, D>
 
     source_info: SourceInfo,
 
-    lvalue: &'l Place<'tcx>,
+    place: &'l Place<'tcx>,
     path: D::Path,
     succ: BasicBlock,
     unwind: Unwind,
@@ -114,7 +114,7 @@ struct DropCtxt<'l, 'b: 'l, 'tcx: 'b, D>
 pub fn elaborate_drop<'b, 'tcx, D>(
     elaborator: &mut D,
     source_info: SourceInfo,
-    lvalue: &Place<'tcx>,
+    place: &Place<'tcx>,
     path: D::Path,
     succ: BasicBlock,
     unwind: Unwind,
@@ -122,15 +122,15 @@ pub fn elaborate_drop<'b, 'tcx, D>(
     where D: DropElaborator<'b, 'tcx>
 {
     DropCtxt {
-        elaborator, source_info, lvalue, path, succ, unwind
+        elaborator, source_info, place, path, succ, unwind
     }.elaborate_drop(bb)
 }
 
 impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
     where D: DropElaborator<'b, 'tcx>
 {
-    fn lvalue_ty(&self, lvalue: &Place<'tcx>) -> Ty<'tcx> {
-        lvalue.ty(self.elaborator.mir(), self.tcx()).to_ty(self.tcx())
+    fn place_ty(&self, place: &Place<'tcx>) -> Ty<'tcx> {
+        place.ty(self.elaborator.mir(), self.tcx()).to_ty(self.tcx())
     }
 
     fn tcx(&self) -> TyCtxt<'b, 'tcx, 'tcx> {
@@ -169,7 +169,7 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
                 let loc = self.terminator_loc(bb);
                 self.elaborator.clear_drop_flag(loc, self.path, DropFlagMode::Deep);
                 self.elaborator.patch().patch_terminator(bb, TerminatorKind::Drop {
-                    location: self.lvalue.clone(),
+                    location: self.place.clone(),
                     target: self.succ,
                     unwind: self.unwind.into_option(),
                 });
@@ -191,10 +191,10 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
         }
     }
 
-    /// Return the lvalue and move path for each field of `variant`,
+    /// Return the place and move path for each field of `variant`,
     /// (the move path is `None` if the field is a rest field).
     fn move_paths_for_fields(&self,
-                             base_lv: &Place<'tcx>,
+                             base_place: &Place<'tcx>,
                              variant_path: D::Path,
                              variant: &'tcx ty::VariantDef,
                              substs: &'tcx Substs<'tcx>)
@@ -209,32 +209,32 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
                     &f.ty(self.tcx(), substs),
                     self.elaborator.param_env()
                 );
-            (base_lv.clone().field(field, field_ty), subpath)
+            (base_place.clone().field(field, field_ty), subpath)
         }).collect()
     }
 
     fn drop_subpath(&mut self,
-                    lvalue: &Place<'tcx>,
+                    place: &Place<'tcx>,
                     path: Option<D::Path>,
                     succ: BasicBlock,
                     unwind: Unwind)
                     -> BasicBlock
     {
         if let Some(path) = path {
-            debug!("drop_subpath: for std field {:?}", lvalue);
+            debug!("drop_subpath: for std field {:?}", place);
 
             DropCtxt {
                 elaborator: self.elaborator,
                 source_info: self.source_info,
-                path, lvalue, succ, unwind,
+                path, place, succ, unwind,
             }.elaborated_drop_block()
         } else {
-            debug!("drop_subpath: for rest field {:?}", lvalue);
+            debug!("drop_subpath: for rest field {:?}", place);
 
             DropCtxt {
                 elaborator: self.elaborator,
                 source_info: self.source_info,
-                lvalue, succ, unwind,
+                place, succ, unwind,
                 // Using `self.path` here to condition the drop on
                 // our own drop flag.
                 path: self.path
@@ -256,8 +256,8 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
     {
         Some(succ).into_iter().chain(
             fields.iter().rev().zip(unwind_ladder)
-                .map(|(&(ref lv, path), &unwind_succ)| {
-                    succ = self.drop_subpath(lv, path, succ, unwind_succ);
+                .map(|(&(ref place, path), &unwind_succ)| {
+                    succ = self.drop_subpath(place, path, succ, unwind_succ);
                     succ
                 })
         ).collect()
@@ -302,8 +302,8 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
         debug!("drop_ladder({:?}, {:?})", self, fields);
 
         let mut fields = fields;
-        fields.retain(|&(ref lvalue, _)| {
-            self.lvalue_ty(lvalue).needs_drop(self.tcx(), self.elaborator.param_env())
+        fields.retain(|&(ref place, _)| {
+            self.place_ty(place).needs_drop(self.tcx(), self.elaborator.param_env())
         });
 
         debug!("drop_ladder - fields needing drop: {:?}", fields);
@@ -328,7 +328,7 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
         debug!("open_drop_for_tuple({:?}, {:?})", self, tys);
 
         let fields = tys.iter().enumerate().map(|(i, &ty)| {
-            (self.lvalue.clone().field(Field::new(i), ty),
+            (self.place.clone().field(Field::new(i), ty),
              self.elaborator.field_subpath(self.path, Field::new(i)))
         }).collect();
 
@@ -340,7 +340,7 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
     {
         debug!("open_drop_for_box({:?}, {:?})", self, ty);
 
-        let interior = self.lvalue.clone().deref();
+        let interior = self.place.clone().deref();
         let interior_path = self.elaborator.deref_subpath(self.path);
 
         let succ = self.succ; // FIXME(#6393)
@@ -386,7 +386,7 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
         let (succ, unwind) = self.drop_ladder_bottom();
         if !adt.is_enum() {
             let fields = self.move_paths_for_fields(
-                self.lvalue,
+                self.place,
                 self.path,
                 &adt.variants[0],
                 substs
@@ -416,11 +416,11 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
             let subpath = self.elaborator.downcast_subpath(
                 self.path, variant_index);
             if let Some(variant_path) = subpath {
-                let base_lv = self.lvalue.clone().elem(
+                let base_place = self.place.clone().elem(
                     ProjectionElem::Downcast(adt, variant_index)
                         );
                 let fields = self.move_paths_for_fields(
-                    &base_lv,
+                    &base_place,
                     variant_path,
                     &adt.variants[variant_index],
                     substs);
@@ -492,7 +492,7 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
         // way lies only trouble.
         let discr_ty = adt.repr.discr_type().to_ty(self.tcx());
         let discr = Place::Local(self.new_temp(discr_ty));
-        let discr_rv = Rvalue::Discriminant(self.lvalue.clone());
+        let discr_rv = Rvalue::Discriminant(self.place.clone());
         let switch_block = BasicBlockData {
             statements: vec![self.assign(&discr, discr_rv)],
             terminator: Some(Terminator {
@@ -517,26 +517,26 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
         let tcx = self.tcx();
         let drop_trait = tcx.lang_items().drop_trait().unwrap();
         let drop_fn = tcx.associated_items(drop_trait).next().unwrap();
-        let ty = self.lvalue_ty(self.lvalue);
+        let ty = self.place_ty(self.place);
         let substs = tcx.mk_substs(iter::once(Kind::from(ty)));
 
         let ref_ty = tcx.mk_ref(tcx.types.re_erased, ty::TypeAndMut {
             ty,
             mutbl: hir::Mutability::MutMutable
         });
-        let ref_lvalue = self.new_temp(ref_ty);
+        let ref_place = self.new_temp(ref_ty);
         let unit_temp = Place::Local(self.new_temp(tcx.mk_nil()));
 
         let result = BasicBlockData {
             statements: vec![self.assign(
-                &Place::Local(ref_lvalue),
-                Rvalue::Ref(tcx.types.re_erased, BorrowKind::Mut, self.lvalue.clone())
+                &Place::Local(ref_place),
+                Rvalue::Ref(tcx.types.re_erased, BorrowKind::Mut, self.place.clone())
             )],
             terminator: Some(Terminator {
                 kind: TerminatorKind::Call {
                     func: Operand::function_handle(tcx, drop_fn.def_id, substs,
                                                    self.source_info.span),
-                    args: vec![Operand::Move(Place::Local(ref_lvalue))],
+                    args: vec![Operand::Move(Place::Local(ref_place))],
                     destination: Some((unit_temp, succ)),
                     cleanup: unwind.into_option(),
                 },
@@ -572,8 +572,8 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
                  ptr_based: bool)
                  -> BasicBlock
     {
-        let copy = |lv: &Place<'tcx>| Operand::Copy(lv.clone());
-        let move_ = |lv: &Place<'tcx>| Operand::Move(lv.clone());
+        let copy = |place: &Place<'tcx>| Operand::Copy(place.clone());
+        let move_ = |place: &Place<'tcx>| Operand::Move(place.clone());
         let tcx = self.tcx();
 
         let ref_ty = tcx.mk_ref(tcx.types.re_erased, ty::TypeAndMut {
@@ -591,7 +591,7 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
             (Rvalue::Ref(
                  tcx.types.re_erased,
                  BorrowKind::Mut,
-                 self.lvalue.clone().index(cur)),
+                 self.place.clone().index(cur)),
              Rvalue::BinaryOp(BinOp::Add, copy(&Place::Local(cur)), one))
         };
 
@@ -643,7 +643,7 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
 
         let tcx = self.tcx();
 
-        let move_ = |lv: &Place<'tcx>| Operand::Move(lv.clone());
+        let move_ = |place: &Place<'tcx>| Operand::Move(place.clone());
         let size = &Place::Local(self.new_temp(tcx.types.usize));
         let size_is_zero = &Place::Local(self.new_temp(tcx.types.bool));
         let base_block = BasicBlockData {
@@ -667,7 +667,7 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
         self.elaborator.patch().new_block(base_block)
     }
 
-    // create a pair of drop-loops of `lvalue`, which drops its contents
+    // create a pair of drop-loops of `place`, which drops its contents
     // even in the case of 1 panic. If `ptr_based`, create a pointer loop,
     // otherwise create an index loop.
     fn drop_loop_pair(&mut self, ety: Ty<'tcx>, ptr_based: bool) -> BasicBlock {
@@ -708,15 +708,15 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
         let cur = Place::Local(cur);
         let zero = self.constant_usize(0);
         let mut drop_block_stmts = vec![];
-        drop_block_stmts.push(self.assign(&length, Rvalue::Len(self.lvalue.clone())));
+        drop_block_stmts.push(self.assign(&length, Rvalue::Len(self.place.clone())));
         if ptr_based {
-            let tmp_ty = tcx.mk_mut_ptr(self.lvalue_ty(self.lvalue));
+            let tmp_ty = tcx.mk_mut_ptr(self.place_ty(self.place));
             let tmp = Place::Local(self.new_temp(tmp_ty));
             // tmp = &LV;
             // cur = tmp as *mut T;
             // end = Offset(cur, len);
             drop_block_stmts.push(self.assign(&tmp, Rvalue::Ref(
-                tcx.types.re_erased, BorrowKind::Mut, self.lvalue.clone()
+                tcx.types.re_erased, BorrowKind::Mut, self.place.clone()
             )));
             drop_block_stmts.push(self.assign(&cur, Rvalue::Cast(
                 CastKind::Misc, Operand::Move(tmp.clone()), iter_ty
@@ -752,7 +752,7 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
     /// This creates a "drop ladder" that drops the needed fields of the
     /// ADT, both in the success case or if one of the destructors fail.
     fn open_drop<'a>(&mut self) -> BasicBlock {
-        let ty = self.lvalue_ty(self.lvalue);
+        let ty = self.place_ty(self.place);
         match ty.sty {
             ty::TyClosure(def_id, substs) |
             // Note that `elaborate_drops` only drops the upvars of a generator,
@@ -786,13 +786,13 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
         }
     }
 
-    /// Return a basic block that drop an lvalue using the context
+    /// Return a basic block that drop a place using the context
     /// and path in `c`. If `mode` is something, also clear `c`
     /// according to it.
     ///
     /// if FLAG(self.path)
     ///     if let Some(mode) = mode: FLAG(self.path)[mode] = false
-    ///     drop(self.lv)
+    ///     drop(self.place)
     fn complete_drop<'a>(&mut self,
                          drop_mode: Option<DropFlagMode>,
                          succ: BasicBlock,
@@ -855,7 +855,7 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
 
         let call = TerminatorKind::Call {
             func: Operand::function_handle(tcx, free_func, substs, self.source_info.span),
-            args: vec![Operand::Move(self.lvalue.clone())],
+            args: vec![Operand::Move(self.place.clone())],
             destination: Some((unit_temp, target)),
             cleanup: None
         }; // FIXME(#6393)
@@ -868,7 +868,7 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
 
     fn drop_block<'a>(&mut self, target: BasicBlock, unwind: Unwind) -> BasicBlock {
         let block = TerminatorKind::Drop {
-            location: self.lvalue.clone(),
+            location: self.place.clone(),
             target,
             unwind: unwind.into_option()
         };

--- a/src/librustc_mir/util/graphviz.rs
+++ b/src/librustc_mir/util/graphviz.rs
@@ -147,7 +147,7 @@ fn write_graph_label<'a, 'gcx, 'tcx, W: Write>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
         if i > 0 {
             write!(w, ", ")?;
         }
-        write!(w, "{:?}: {}", Lvalue::Local(arg), escape(&mir.local_decls[arg].ty))?;
+        write!(w, "{:?}: {}", Place::Local(arg), escape(&mir.local_decls[arg].ty))?;
     }
 
     write!(w, ") -&gt; {}", escape(mir.return_ty()))?;
@@ -163,10 +163,10 @@ fn write_graph_label<'a, 'gcx, 'tcx, W: Write>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
 
         if let Some(name) = decl.name {
             write!(w, r#"{:?}: {}; // {}<br align="left"/>"#,
-                   Lvalue::Local(local), escape(&decl.ty), name)?;
+                   Place::Local(local), escape(&decl.ty), name)?;
         } else {
             write!(w, r#"let mut {:?}: {};<br align="left"/>"#,
-                   Lvalue::Local(local), escape(&decl.ty))?;
+                   Place::Local(local), escape(&decl.ty))?;
         }
     }
 

--- a/src/librustc_mir/util/patch.rs
+++ b/src/librustc_mir/util/patch.rs
@@ -127,8 +127,8 @@ impl<'tcx> MirPatch<'tcx> {
         self.new_statements.push((loc, stmt));
     }
 
-    pub fn add_assign(&mut self, loc: Location, lv: Place<'tcx>, rv: Rvalue<'tcx>) {
-        self.add_statement(loc, StatementKind::Assign(lv, rv));
+    pub fn add_assign(&mut self, loc: Location, place: Place<'tcx>, rv: Rvalue<'tcx>) {
+        self.add_statement(loc, StatementKind::Assign(place, rv));
     }
 
     pub fn apply(self, mir: &mut Mir<'tcx>) {

--- a/src/librustc_mir/util/patch.rs
+++ b/src/librustc_mir/util/patch.rs
@@ -127,7 +127,7 @@ impl<'tcx> MirPatch<'tcx> {
         self.new_statements.push((loc, stmt));
     }
 
-    pub fn add_assign(&mut self, loc: Location, lv: Lvalue<'tcx>, rv: Rvalue<'tcx>) {
+    pub fn add_assign(&mut self, loc: Location, lv: Place<'tcx>, rv: Rvalue<'tcx>) {
         self.add_statement(loc, StatementKind::Assign(lv, rv));
     }
 

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -389,7 +389,7 @@ fn write_mir_sig(tcx: TyCtxt, src: MirSource, mir: &Mir, w: &mut Write)
                 if i != 0 {
                     write!(w, ", ")?;
                 }
-                write!(w, "{:?}: {}", Lvalue::Local(arg), mir.local_decls[arg].ty)?;
+                write!(w, "{:?}: {}", Place::Local(arg), mir.local_decls[arg].ty)?;
             }
 
             write!(w, ") -> {}", mir.return_ty())

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -344,12 +344,12 @@ pub fn write_mir_intro<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
         }
     }
 
-    // Print return pointer
+    // Print return place
     let indented_retptr = format!("{}let mut {:?}: {};",
                                   INDENT,
-                                  RETURN_POINTER,
-                                  mir.local_decls[RETURN_POINTER].ty);
-    writeln!(w, "{0:1$} // return pointer",
+                                  RETURN_PLACE,
+                                  mir.local_decls[RETURN_PLACE].ty);
+    writeln!(w, "{0:1$} // return place",
              indented_retptr,
              ALIGN)?;
 

--- a/src/librustc_passes/mir_stats.rs
+++ b/src/librustc_passes/mir_stats.rs
@@ -188,41 +188,41 @@ impl<'a, 'tcx> mir_visit::Visitor<'tcx> for StatCollector<'a, 'tcx> {
         self.super_operand(operand, location);
     }
 
-    fn visit_lvalue(&mut self,
-                    lvalue: &Place<'tcx>,
+    fn visit_place(&mut self,
+                    place: &Place<'tcx>,
                     context: mir_visit::PlaceContext<'tcx>,
                     location: Location) {
-        self.record("Place", lvalue);
-        self.record(match *lvalue {
+        self.record("Place", place);
+        self.record(match *place {
             Place::Local(..) => "Place::Local",
             Place::Static(..) => "Place::Static",
             Place::Projection(..) => "Place::Projection",
-        }, lvalue);
-        self.super_lvalue(lvalue, context, location);
+        }, place);
+        self.super_place(place, context, location);
     }
 
     fn visit_projection(&mut self,
-                        lvalue: &PlaceProjection<'tcx>,
+                        place: &PlaceProjection<'tcx>,
                         context: mir_visit::PlaceContext<'tcx>,
                         location: Location) {
-        self.record("PlaceProjection", lvalue);
-        self.super_projection(lvalue, context, location);
+        self.record("PlaceProjection", place);
+        self.super_projection(place, context, location);
     }
 
     fn visit_projection_elem(&mut self,
-                             lvalue: &PlaceElem<'tcx>,
+                             place: &PlaceElem<'tcx>,
                              context: mir_visit::PlaceContext<'tcx>,
                              location: Location) {
-        self.record("PlaceElem", lvalue);
-        self.record(match *lvalue {
+        self.record("PlaceElem", place);
+        self.record(match *place {
             ProjectionElem::Deref => "PlaceElem::Deref",
             ProjectionElem::Subslice { .. } => "PlaceElem::Subslice",
             ProjectionElem::Field(..) => "PlaceElem::Field",
             ProjectionElem::Index(..) => "PlaceElem::Index",
             ProjectionElem::ConstantIndex { .. } => "PlaceElem::ConstantIndex",
             ProjectionElem::Downcast(..) => "PlaceElem::Downcast",
-        }, lvalue);
-        self.super_projection_elem(lvalue, context, location);
+        }, place);
+        self.super_projection_elem(place, context, location);
     }
 
     fn visit_constant(&mut self,

--- a/src/librustc_passes/mir_stats.rs
+++ b/src/librustc_passes/mir_stats.rs
@@ -15,7 +15,7 @@
 use rustc_const_math::{ConstUsize};
 use rustc::mir::{AggregateKind, AssertMessage, BasicBlock, BasicBlockData};
 use rustc::mir::{Constant, Literal, Location, Local, LocalDecl};
-use rustc::mir::{Lvalue, LvalueElem, LvalueProjection};
+use rustc::mir::{Place, PlaceElem, PlaceProjection};
 use rustc::mir::{Mir, Operand, ProjectionElem};
 use rustc::mir::{Rvalue, SourceInfo, Statement, StatementKind};
 use rustc::mir::{Terminator, TerminatorKind, VisibilityScope, VisibilityScopeData};
@@ -189,38 +189,38 @@ impl<'a, 'tcx> mir_visit::Visitor<'tcx> for StatCollector<'a, 'tcx> {
     }
 
     fn visit_lvalue(&mut self,
-                    lvalue: &Lvalue<'tcx>,
-                    context: mir_visit::LvalueContext<'tcx>,
+                    lvalue: &Place<'tcx>,
+                    context: mir_visit::PlaceContext<'tcx>,
                     location: Location) {
-        self.record("Lvalue", lvalue);
+        self.record("Place", lvalue);
         self.record(match *lvalue {
-            Lvalue::Local(..) => "Lvalue::Local",
-            Lvalue::Static(..) => "Lvalue::Static",
-            Lvalue::Projection(..) => "Lvalue::Projection",
+            Place::Local(..) => "Place::Local",
+            Place::Static(..) => "Place::Static",
+            Place::Projection(..) => "Place::Projection",
         }, lvalue);
         self.super_lvalue(lvalue, context, location);
     }
 
     fn visit_projection(&mut self,
-                        lvalue: &LvalueProjection<'tcx>,
-                        context: mir_visit::LvalueContext<'tcx>,
+                        lvalue: &PlaceProjection<'tcx>,
+                        context: mir_visit::PlaceContext<'tcx>,
                         location: Location) {
-        self.record("LvalueProjection", lvalue);
+        self.record("PlaceProjection", lvalue);
         self.super_projection(lvalue, context, location);
     }
 
     fn visit_projection_elem(&mut self,
-                             lvalue: &LvalueElem<'tcx>,
-                             context: mir_visit::LvalueContext<'tcx>,
+                             lvalue: &PlaceElem<'tcx>,
+                             context: mir_visit::PlaceContext<'tcx>,
                              location: Location) {
-        self.record("LvalueElem", lvalue);
+        self.record("PlaceElem", lvalue);
         self.record(match *lvalue {
-            ProjectionElem::Deref => "LvalueElem::Deref",
-            ProjectionElem::Subslice { .. } => "LvalueElem::Subslice",
-            ProjectionElem::Field(..) => "LvalueElem::Field",
-            ProjectionElem::Index(..) => "LvalueElem::Index",
-            ProjectionElem::ConstantIndex { .. } => "LvalueElem::ConstantIndex",
-            ProjectionElem::Downcast(..) => "LvalueElem::Downcast",
+            ProjectionElem::Deref => "PlaceElem::Deref",
+            ProjectionElem::Subslice { .. } => "PlaceElem::Subslice",
+            ProjectionElem::Field(..) => "PlaceElem::Field",
+            ProjectionElem::Index(..) => "PlaceElem::Index",
+            ProjectionElem::ConstantIndex { .. } => "PlaceElem::ConstantIndex",
+            ProjectionElem::Downcast(..) => "PlaceElem::Downcast",
         }, lvalue);
         self.super_projection_elem(lvalue, context, location);
     }

--- a/src/librustc_trans/abi.rs
+++ b/src/librustc_trans/abi.rs
@@ -30,7 +30,7 @@ use cabi_sparc64;
 use cabi_nvptx;
 use cabi_nvptx64;
 use cabi_hexagon;
-use mir::lvalue::{Alignment, PlaceRef};
+use mir::place::{Alignment, PlaceRef};
 use mir::operand::OperandValue;
 use type_::Type;
 use type_of::{LayoutLlvmExt, PointerKind};
@@ -545,14 +545,14 @@ impl<'a, 'tcx> ArgType<'tcx> {
         self.mode == PassMode::Ignore
     }
 
-    /// Get the LLVM type for an lvalue of the original Rust type of
+    /// Get the LLVM type for an place of the original Rust type of
     /// this argument/return, i.e. the result of `type_of::type_of`.
     pub fn memory_ty(&self, ccx: &CrateContext<'a, 'tcx>) -> Type {
         self.layout.llvm_type(ccx)
     }
 
     /// Store a direct/indirect value described by this ArgType into a
-    /// lvalue for the original Rust type of this argument/return.
+    /// place for the original Rust type of this argument/return.
     /// Can be used for both storing formal arguments into Rust variables
     /// or results of call/invoke instructions into their destinations.
     pub fn store(&self, bcx: &Builder<'a, 'tcx>, val: ValueRef, dst: PlaceRef<'tcx>) {

--- a/src/librustc_trans/abi.rs
+++ b/src/librustc_trans/abi.rs
@@ -30,7 +30,7 @@ use cabi_sparc64;
 use cabi_nvptx;
 use cabi_nvptx64;
 use cabi_hexagon;
-use mir::lvalue::{Alignment, LvalueRef};
+use mir::lvalue::{Alignment, PlaceRef};
 use mir::operand::OperandValue;
 use type_::Type;
 use type_of::{LayoutLlvmExt, PointerKind};
@@ -555,7 +555,7 @@ impl<'a, 'tcx> ArgType<'tcx> {
     /// lvalue for the original Rust type of this argument/return.
     /// Can be used for both storing formal arguments into Rust variables
     /// or results of call/invoke instructions into their destinations.
-    pub fn store(&self, bcx: &Builder<'a, 'tcx>, val: ValueRef, dst: LvalueRef<'tcx>) {
+    pub fn store(&self, bcx: &Builder<'a, 'tcx>, val: ValueRef, dst: PlaceRef<'tcx>) {
         if self.is_ignore() {
             return;
         }
@@ -606,7 +606,7 @@ impl<'a, 'tcx> ArgType<'tcx> {
         }
     }
 
-    pub fn store_fn_arg(&self, bcx: &Builder<'a, 'tcx>, idx: &mut usize, dst: LvalueRef<'tcx>) {
+    pub fn store_fn_arg(&self, bcx: &Builder<'a, 'tcx>, idx: &mut usize, dst: PlaceRef<'tcx>) {
         if self.pad.is_some() {
             *idx += 1;
         }

--- a/src/librustc_trans/asm.rs
+++ b/src/librustc_trans/asm.rs
@@ -18,7 +18,7 @@ use builder::Builder;
 
 use rustc::hir;
 
-use mir::lvalue::PlaceRef;
+use mir::place::PlaceRef;
 use mir::operand::OperandValue;
 
 use std::ffi::CString;
@@ -37,15 +37,15 @@ pub fn trans_inline_asm<'a, 'tcx>(
 
     // Prepare the output operands
     let mut indirect_outputs = vec![];
-    for (i, (out, lvalue)) in ia.outputs.iter().zip(&outputs).enumerate() {
+    for (i, (out, place)) in ia.outputs.iter().zip(&outputs).enumerate() {
         if out.is_rw {
-            inputs.push(lvalue.load(bcx).immediate());
+            inputs.push(place.load(bcx).immediate());
             ext_constraints.push(i.to_string());
         }
         if out.is_indirect {
-            indirect_outputs.push(lvalue.load(bcx).immediate());
+            indirect_outputs.push(place.load(bcx).immediate());
         } else {
-            output_types.push(lvalue.layout.llvm_type(bcx.ccx));
+            output_types.push(place.layout.llvm_type(bcx.ccx));
         }
     }
     if !indirect_outputs.is_empty() {
@@ -100,9 +100,9 @@ pub fn trans_inline_asm<'a, 'tcx>(
 
     // Again, based on how many outputs we have
     let outputs = ia.outputs.iter().zip(&outputs).filter(|&(ref o, _)| !o.is_indirect);
-    for (i, (_, &lvalue)) in outputs.enumerate() {
+    for (i, (_, &place)) in outputs.enumerate() {
         let v = if num_outputs == 1 { r } else { bcx.extract_value(r, i as u64) };
-        OperandValue::Immediate(v).store(bcx, lvalue);
+        OperandValue::Immediate(v).store(bcx, place);
     }
 
     // Store mark in a metadata node so we can map LLVM errors

--- a/src/librustc_trans/asm.rs
+++ b/src/librustc_trans/asm.rs
@@ -18,7 +18,7 @@ use builder::Builder;
 
 use rustc::hir;
 
-use mir::lvalue::LvalueRef;
+use mir::lvalue::PlaceRef;
 use mir::operand::OperandValue;
 
 use std::ffi::CString;
@@ -29,7 +29,7 @@ use libc::{c_uint, c_char};
 pub fn trans_inline_asm<'a, 'tcx>(
     bcx: &Builder<'a, 'tcx>,
     ia: &hir::InlineAsm,
-    outputs: Vec<LvalueRef<'tcx>>,
+    outputs: Vec<PlaceRef<'tcx>>,
     mut inputs: Vec<ValueRef>
 ) {
     let mut ext_constraints = vec![];

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -50,7 +50,7 @@ use rustc::session::config::{self, NoDebugInfo};
 use rustc::session::Session;
 use rustc_incremental;
 use allocator;
-use mir::lvalue::LvalueRef;
+use mir::lvalue::PlaceRef;
 use attributes;
 use builder::Builder;
 use callee;
@@ -272,8 +272,8 @@ pub fn unsize_thin_ptr<'a, 'tcx>(
 /// Coerce `src`, which is a reference to a value of type `src_ty`,
 /// to a value of type `dst_ty` and store the result in `dst`
 pub fn coerce_unsized_into<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
-                                     src: LvalueRef<'tcx>,
-                                     dst: LvalueRef<'tcx>) {
+                                     src: PlaceRef<'tcx>,
+                                     dst: PlaceRef<'tcx>) {
     let src_ty = src.layout.ty;
     let dst_ty = dst.layout.ty;
     let coerce_ptr = || {

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -50,7 +50,7 @@ use rustc::session::config::{self, NoDebugInfo};
 use rustc::session::Session;
 use rustc_incremental;
 use allocator;
-use mir::lvalue::PlaceRef;
+use mir::place::PlaceRef;
 use attributes;
 use builder::Builder;
 use callee;

--- a/src/librustc_trans/intrinsic.rs
+++ b/src/librustc_trans/intrinsic.rs
@@ -14,7 +14,7 @@ use intrinsics::{self, Intrinsic};
 use llvm;
 use llvm::{ValueRef};
 use abi::{Abi, FnType, PassMode};
-use mir::lvalue::{LvalueRef, Alignment};
+use mir::lvalue::{PlaceRef, Alignment};
 use mir::operand::{OperandRef, OperandValue};
 use base::*;
 use common::*;
@@ -106,7 +106,7 @@ pub fn trans_intrinsic_call<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
     let name = &*tcx.item_name(def_id);
 
     let llret_ty = ccx.layout_of(ret_ty).llvm_type(ccx);
-    let result = LvalueRef::new_sized(llresult, fn_ty.ret.layout, Alignment::AbiAligned);
+    let result = PlaceRef::new_sized(llresult, fn_ty.ret.layout, Alignment::AbiAligned);
 
     let simple = get_simple_intrinsic(ccx, name);
     let llval = match name {
@@ -625,7 +625,7 @@ pub fn trans_intrinsic_call<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
                             OperandValue::Ref(ptr, align) => (ptr, align),
                             _ => bug!()
                         };
-                        let arg = LvalueRef::new_sized(ptr, arg.layout, align);
+                        let arg = PlaceRef::new_sized(ptr, arg.layout, align);
                         (0..contents.len()).map(|i| {
                             arg.project_field(bcx, i).load(bcx).immediate()
                         }).collect()

--- a/src/librustc_trans/intrinsic.rs
+++ b/src/librustc_trans/intrinsic.rs
@@ -14,7 +14,7 @@ use intrinsics::{self, Intrinsic};
 use llvm;
 use llvm::{ValueRef};
 use abi::{Abi, FnType, PassMode};
-use mir::lvalue::{PlaceRef, Alignment};
+use mir::place::{PlaceRef, Alignment};
 use mir::operand::{OperandRef, OperandValue};
 use base::*;
 use common::*;

--- a/src/librustc_trans/mir/block.rs
+++ b/src/librustc_trans/mir/block.rs
@@ -31,7 +31,7 @@ use syntax_pos::Pos;
 
 use super::{MirContext, LocalRef};
 use super::constant::Const;
-use super::lvalue::{Alignment, LvalueRef};
+use super::lvalue::{Alignment, PlaceRef};
 use super::operand::OperandRef;
 use super::operand::OperandValue::{Pair, Ref, Immediate};
 
@@ -214,7 +214,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                     }
 
                     PassMode::Direct(_) | PassMode::Pair(..) => {
-                        let op = self.trans_consume(&bcx, &mir::Lvalue::Local(mir::RETURN_POINTER));
+                        let op = self.trans_consume(&bcx, &mir::Place::Local(mir::RETURN_POINTER));
                         if let Ref(llval, align) = op.val {
                             bcx.load(llval, align.non_abi())
                         } else {
@@ -226,7 +226,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                         let op = match self.locals[mir::RETURN_POINTER] {
                             LocalRef::Operand(Some(op)) => op,
                             LocalRef::Operand(None) => bug!("use of return before def"),
-                            LocalRef::Lvalue(tr_lvalue) => {
+                            LocalRef::Place(tr_lvalue) => {
                                 OperandRef {
                                     val: Ref(tr_lvalue.llval, tr_lvalue.alignment),
                                     layout: tr_lvalue.layout
@@ -235,7 +235,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                         };
                         let llslot = match op.val {
                             Immediate(_) | Pair(..) => {
-                                let scratch = LvalueRef::alloca(&bcx, self.fn_ty.ret.layout, "ret");
+                                let scratch = PlaceRef::alloca(&bcx, self.fn_ty.ret.layout, "ret");
                                 op.val.store(&bcx, scratch);
                                 scratch.llval
                             }
@@ -577,7 +577,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                     match (arg, op.val) {
                         (&mir::Operand::Copy(_), Ref(..)) |
                         (&mir::Operand::Constant(_), Ref(..)) => {
-                            let tmp = LvalueRef::alloca(&bcx, op.layout, "const");
+                            let tmp = PlaceRef::alloca(&bcx, op.layout, "const");
                             op.val.store(&bcx, tmp);
                             op.val = Ref(tmp.llval, tmp.alignment);
                         }
@@ -637,7 +637,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
             Immediate(_) | Pair(..) => {
                 match arg.mode {
                     PassMode::Indirect(_) | PassMode::Cast(_) => {
-                        let scratch = LvalueRef::alloca(bcx, arg.layout, "arg");
+                        let scratch = PlaceRef::alloca(bcx, arg.layout, "arg");
                         op.val.store(bcx, scratch);
                         (scratch.llval, Alignment::AbiAligned, true)
                     }
@@ -651,7 +651,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 // think that ATM (Rust 1.16) we only pass temporaries, but we shouldn't
                 // have scary latent bugs around.
 
-                let scratch = LvalueRef::alloca(bcx, arg.layout, "arg");
+                let scratch = PlaceRef::alloca(bcx, arg.layout, "arg");
                 base::memcpy_ty(bcx, scratch.llval, llval, op.layout, align.non_abi());
                 (scratch.llval, Alignment::AbiAligned, true)
             }
@@ -665,7 +665,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                                  (align | Alignment::Packed(arg.layout.align))
                                     .non_abi());
             } else {
-                // We can't use `LvalueRef::load` here because the argument
+                // We can't use `PlaceRef::load` here because the argument
                 // may have a type we don't treat as immediate, but the ABI
                 // used for this call is passing it by-value. In that case,
                 // the load would just produce `OperandValue::Ref` instead
@@ -693,7 +693,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
 
         // Handle both by-ref and immediate tuples.
         if let Ref(llval, align) = tuple.val {
-            let tuple_ptr = LvalueRef::new_sized(llval, tuple.layout, align);
+            let tuple_ptr = PlaceRef::new_sized(llval, tuple.layout, align);
             for i in 0..tuple.layout.fields.count() {
                 let field_ptr = tuple_ptr.project_field(bcx, i);
                 self.trans_argument(bcx, field_ptr.load(bcx), llargs, &args[i]);
@@ -707,7 +707,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
         }
     }
 
-    fn get_personality_slot(&mut self, bcx: &Builder<'a, 'tcx>) -> LvalueRef<'tcx> {
+    fn get_personality_slot(&mut self, bcx: &Builder<'a, 'tcx>) -> PlaceRef<'tcx> {
         let ccx = bcx.ccx;
         if let Some(slot) = self.personality_slot {
             slot
@@ -716,7 +716,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 ccx.tcx().mk_mut_ptr(ccx.tcx().types.u8),
                 ccx.tcx().types.i32
             ], false));
-            let slot = LvalueRef::alloca(bcx, layout, "personalityslot");
+            let slot = PlaceRef::alloca(bcx, layout, "personalityslot");
             self.personality_slot = Some(slot);
             slot
         }
@@ -781,23 +781,23 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
     }
 
     fn make_return_dest(&mut self, bcx: &Builder<'a, 'tcx>,
-                        dest: &mir::Lvalue<'tcx>, fn_ret: &ArgType<'tcx>,
+                        dest: &mir::Place<'tcx>, fn_ret: &ArgType<'tcx>,
                         llargs: &mut Vec<ValueRef>, is_intrinsic: bool)
                         -> ReturnDest<'tcx> {
         // If the return is ignored, we can just return a do-nothing ReturnDest
         if fn_ret.is_ignore() {
             return ReturnDest::Nothing;
         }
-        let dest = if let mir::Lvalue::Local(index) = *dest {
+        let dest = if let mir::Place::Local(index) = *dest {
             match self.locals[index] {
-                LocalRef::Lvalue(dest) => dest,
+                LocalRef::Place(dest) => dest,
                 LocalRef::Operand(None) => {
                     // Handle temporary lvalues, specifically Operand ones, as
                     // they don't have allocas
                     return if fn_ret.is_indirect() {
                         // Odd, but possible, case, we have an operand temporary,
                         // but the calling convention has an indirect return.
-                        let tmp = LvalueRef::alloca(bcx, fn_ret.layout, "tmp_ret");
+                        let tmp = PlaceRef::alloca(bcx, fn_ret.layout, "tmp_ret");
                         tmp.storage_live(bcx);
                         llargs.push(tmp.llval);
                         ReturnDest::IndirectOperand(tmp, index)
@@ -805,7 +805,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                         // Currently, intrinsics always need a location to store
                         // the result. so we create a temporary alloca for the
                         // result
-                        let tmp = LvalueRef::alloca(bcx, fn_ret.layout, "tmp_ret");
+                        let tmp = PlaceRef::alloca(bcx, fn_ret.layout, "tmp_ret");
                         tmp.storage_live(bcx);
                         ReturnDest::IndirectOperand(tmp, index)
                     } else {
@@ -842,14 +842,14 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
 
     fn trans_transmute(&mut self, bcx: &Builder<'a, 'tcx>,
                        src: &mir::Operand<'tcx>,
-                       dst: &mir::Lvalue<'tcx>) {
-        if let mir::Lvalue::Local(index) = *dst {
+                       dst: &mir::Place<'tcx>) {
+        if let mir::Place::Local(index) = *dst {
             match self.locals[index] {
-                LocalRef::Lvalue(lvalue) => self.trans_transmute_into(bcx, src, lvalue),
+                LocalRef::Place(lvalue) => self.trans_transmute_into(bcx, src, lvalue),
                 LocalRef::Operand(None) => {
                     let dst_layout = bcx.ccx.layout_of(self.monomorphized_lvalue_ty(dst));
                     assert!(!dst_layout.ty.has_erasable_regions());
-                    let lvalue = LvalueRef::alloca(bcx, dst_layout, "transmute_temp");
+                    let lvalue = PlaceRef::alloca(bcx, dst_layout, "transmute_temp");
                     lvalue.storage_live(bcx);
                     self.trans_transmute_into(bcx, src, lvalue);
                     let op = lvalue.load(bcx);
@@ -869,13 +869,13 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
 
     fn trans_transmute_into(&mut self, bcx: &Builder<'a, 'tcx>,
                             src: &mir::Operand<'tcx>,
-                            dst: LvalueRef<'tcx>) {
+                            dst: PlaceRef<'tcx>) {
         let src = self.trans_operand(bcx, src);
         let llty = src.layout.llvm_type(bcx.ccx);
         let cast_ptr = bcx.pointercast(dst.llval, llty.ptr_to());
         let align = src.layout.align.min(dst.layout.align);
         src.val.store(bcx,
-            LvalueRef::new_sized(cast_ptr, src.layout, Alignment::Packed(align)));
+            PlaceRef::new_sized(cast_ptr, src.layout, Alignment::Packed(align)));
     }
 
 
@@ -898,7 +898,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
             DirectOperand(index) => {
                 // If there is a cast, we have to store and reload.
                 let op = if let PassMode::Cast(_) = ret_ty.mode {
-                    let tmp = LvalueRef::alloca(bcx, ret_ty.layout, "tmp_ret");
+                    let tmp = PlaceRef::alloca(bcx, ret_ty.layout, "tmp_ret");
                     tmp.storage_live(bcx);
                     ret_ty.store(bcx, llval, tmp);
                     let op = tmp.load(bcx);
@@ -917,9 +917,9 @@ enum ReturnDest<'tcx> {
     // Do nothing, the return value is indirect or ignored
     Nothing,
     // Store the return value to the pointer
-    Store(LvalueRef<'tcx>),
+    Store(PlaceRef<'tcx>),
     // Stores an indirect return value to an operand local lvalue
-    IndirectOperand(LvalueRef<'tcx>, mir::Local),
+    IndirectOperand(PlaceRef<'tcx>, mir::Local),
     // Stores a direct return value to an operand local lvalue
     DirectOperand(mir::Local)
 }

--- a/src/librustc_trans/mir/lvalue.rs
+++ b/src/librustc_trans/mir/lvalue.rs
@@ -12,7 +12,7 @@ use llvm::{self, ValueRef};
 use rustc::ty::{self, Ty};
 use rustc::ty::layout::{self, Align, TyLayout, LayoutOf};
 use rustc::mir;
-use rustc::mir::tcx::LvalueTy;
+use rustc::mir::tcx::PlaceTy;
 use rustc_data_structures::indexed_vec::Idx;
 use base;
 use builder::Builder;
@@ -73,7 +73,7 @@ impl Alignment {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub struct LvalueRef<'tcx> {
+pub struct PlaceRef<'tcx> {
     /// Pointer to the contents of the lvalue
     pub llval: ValueRef,
 
@@ -87,12 +87,12 @@ pub struct LvalueRef<'tcx> {
     pub alignment: Alignment,
 }
 
-impl<'a, 'tcx> LvalueRef<'tcx> {
+impl<'a, 'tcx> PlaceRef<'tcx> {
     pub fn new_sized(llval: ValueRef,
                      layout: TyLayout<'tcx>,
                      alignment: Alignment)
-                     -> LvalueRef<'tcx> {
-        LvalueRef {
+                     -> PlaceRef<'tcx> {
+        PlaceRef {
             llval,
             llextra: ptr::null_mut(),
             layout,
@@ -101,7 +101,7 @@ impl<'a, 'tcx> LvalueRef<'tcx> {
     }
 
     pub fn alloca(bcx: &Builder<'a, 'tcx>, layout: TyLayout<'tcx>, name: &str)
-                  -> LvalueRef<'tcx> {
+                  -> PlaceRef<'tcx> {
         debug!("alloca({:?}: {:?})", name, layout);
         let tmp = bcx.alloca(layout.llvm_type(bcx.ccx), name, layout.align);
         Self::new_sized(tmp, layout, Alignment::AbiAligned)
@@ -117,7 +117,7 @@ impl<'a, 'tcx> LvalueRef<'tcx> {
                 C_usize(ccx, count)
             }
         } else {
-            bug!("unexpected layout `{:#?}` in LvalueRef::len", self.layout)
+            bug!("unexpected layout `{:#?}` in PlaceRef::len", self.layout)
         }
     }
 
@@ -126,7 +126,7 @@ impl<'a, 'tcx> LvalueRef<'tcx> {
     }
 
     pub fn load(&self, bcx: &Builder<'a, 'tcx>) -> OperandRef<'tcx> {
-        debug!("LvalueRef::load: {:?}", self);
+        debug!("PlaceRef::load: {:?}", self);
 
         assert!(!self.has_extra());
 
@@ -202,7 +202,7 @@ impl<'a, 'tcx> LvalueRef<'tcx> {
     }
 
     /// Access a field, at a point when the value's case is known.
-    pub fn project_field(self, bcx: &Builder<'a, 'tcx>, ix: usize) -> LvalueRef<'tcx> {
+    pub fn project_field(self, bcx: &Builder<'a, 'tcx>, ix: usize) -> PlaceRef<'tcx> {
         let ccx = bcx.ccx;
         let field = self.layout.field(ccx, ix);
         let offset = self.layout.fields.offset(ix);
@@ -219,7 +219,7 @@ impl<'a, 'tcx> LvalueRef<'tcx> {
             } else {
                 bcx.struct_gep(self.llval, self.layout.llvm_field_index(ix))
             };
-            LvalueRef {
+            PlaceRef {
                 // HACK(eddyb) have to bitcast pointers until LLVM removes pointee types.
                 llval: bcx.pointercast(llval, field.llvm_type(ccx).ptr_to()),
                 llextra: if ccx.shared().type_has_metadata(field.ty) {
@@ -295,7 +295,7 @@ impl<'a, 'tcx> LvalueRef<'tcx> {
         let ll_fty = field.llvm_type(ccx);
         debug!("struct_field_ptr: Field type is {:?}", ll_fty);
 
-        LvalueRef {
+        PlaceRef {
             llval: bcx.pointercast(byte_ptr, ll_fty.ptr_to()),
             llextra: self.llextra,
             layout: field,
@@ -413,8 +413,8 @@ impl<'a, 'tcx> LvalueRef<'tcx> {
     }
 
     pub fn project_index(&self, bcx: &Builder<'a, 'tcx>, llindex: ValueRef)
-                         -> LvalueRef<'tcx> {
-        LvalueRef {
+                         -> PlaceRef<'tcx> {
+        PlaceRef {
             llval: bcx.inbounds_gep(self.llval, &[C_usize(bcx.ccx, 0), llindex]),
             llextra: ptr::null_mut(),
             layout: self.layout.field(bcx.ccx, 0),
@@ -423,7 +423,7 @@ impl<'a, 'tcx> LvalueRef<'tcx> {
     }
 
     pub fn project_downcast(&self, bcx: &Builder<'a, 'tcx>, variant_index: usize)
-                            -> LvalueRef<'tcx> {
+                            -> PlaceRef<'tcx> {
         let mut downcast = *self;
         downcast.layout = self.layout.for_variant(bcx.ccx, variant_index);
 
@@ -446,16 +446,16 @@ impl<'a, 'tcx> LvalueRef<'tcx> {
 impl<'a, 'tcx> MirContext<'a, 'tcx> {
     pub fn trans_lvalue(&mut self,
                         bcx: &Builder<'a, 'tcx>,
-                        lvalue: &mir::Lvalue<'tcx>)
-                        -> LvalueRef<'tcx> {
+                        lvalue: &mir::Place<'tcx>)
+                        -> PlaceRef<'tcx> {
         debug!("trans_lvalue(lvalue={:?})", lvalue);
 
         let ccx = bcx.ccx;
         let tcx = ccx.tcx();
 
-        if let mir::Lvalue::Local(index) = *lvalue {
+        if let mir::Place::Local(index) = *lvalue {
             match self.locals[index] {
-                LocalRef::Lvalue(lvalue) => {
+                LocalRef::Place(lvalue) => {
                     return lvalue;
                 }
                 LocalRef::Operand(..) => {
@@ -465,20 +465,20 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
         }
 
         let result = match *lvalue {
-            mir::Lvalue::Local(_) => bug!(), // handled above
-            mir::Lvalue::Static(box mir::Static { def_id, ty }) => {
-                LvalueRef::new_sized(consts::get_static(ccx, def_id),
+            mir::Place::Local(_) => bug!(), // handled above
+            mir::Place::Static(box mir::Static { def_id, ty }) => {
+                PlaceRef::new_sized(consts::get_static(ccx, def_id),
                                      ccx.layout_of(self.monomorphize(&ty)),
                                      Alignment::AbiAligned)
             },
-            mir::Lvalue::Projection(box mir::Projection {
+            mir::Place::Projection(box mir::Projection {
                 ref base,
                 elem: mir::ProjectionElem::Deref
             }) => {
                 // Load the pointer from its location.
                 self.trans_consume(bcx, base).deref(bcx.ccx)
             }
-            mir::Lvalue::Projection(ref projection) => {
+            mir::Place::Projection(ref projection) => {
                 let tr_base = self.trans_lvalue(bcx, &projection.base);
 
                 match projection.elem {
@@ -487,7 +487,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                         tr_base.project_field(bcx, field.index())
                     }
                     mir::ProjectionElem::Index(index) => {
-                        let index = &mir::Operand::Copy(mir::Lvalue::Local(index));
+                        let index = &mir::Operand::Copy(mir::Place::Local(index));
                         let index = self.trans_operand(bcx, index);
                         let llindex = index.immediate();
                         tr_base.project_index(bcx, llindex)
@@ -509,7 +509,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                     mir::ProjectionElem::Subslice { from, to } => {
                         let mut subslice = tr_base.project_index(bcx,
                             C_usize(bcx.ccx, from as u64));
-                        let projected_ty = LvalueTy::Ty { ty: tr_base.layout.ty }
+                        let projected_ty = PlaceTy::Ty { ty: tr_base.layout.ty }
                             .projection_ty(tcx, &projection.elem).to_ty(bcx.tcx());
                         subslice.layout = bcx.ccx.layout_of(self.monomorphize(&projected_ty));
 
@@ -536,7 +536,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
         result
     }
 
-    pub fn monomorphized_lvalue_ty(&self, lvalue: &mir::Lvalue<'tcx>) -> Ty<'tcx> {
+    pub fn monomorphized_lvalue_ty(&self, lvalue: &mir::Place<'tcx>) -> Ty<'tcx> {
         let tcx = self.ccx.tcx();
         let lvalue_ty = lvalue.ty(self.mir, tcx);
         self.monomorphize(&lvalue_ty.to_ty(tcx))

--- a/src/librustc_trans/mir/rvalue.rs
+++ b/src/librustc_trans/mir/rvalue.rs
@@ -32,7 +32,7 @@ use value::Value;
 use super::{MirContext, LocalRef};
 use super::constant::const_scalar_checked_binop;
 use super::operand::{OperandRef, OperandValue};
-use super::lvalue::PlaceRef;
+use super::place::PlaceRef;
 
 impl<'a, 'tcx> MirContext<'a, 'tcx> {
     pub fn trans_rvalue(&mut self,
@@ -334,17 +334,17 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 })
             }
 
-            mir::Rvalue::Ref(_, bk, ref lvalue) => {
-                let tr_lvalue = self.trans_lvalue(&bcx, lvalue);
+            mir::Rvalue::Ref(_, bk, ref place) => {
+                let tr_place = self.trans_place(&bcx, place);
 
-                let ty = tr_lvalue.layout.ty;
+                let ty = tr_place.layout.ty;
 
-                // Note: lvalues are indirect, so storing the `llval` into the
+                // Note: places are indirect, so storing the `llval` into the
                 // destination effectively creates a reference.
                 let val = if !bcx.ccx.shared().type_has_metadata(ty) {
-                    OperandValue::Immediate(tr_lvalue.llval)
+                    OperandValue::Immediate(tr_place.llval)
                 } else {
-                    OperandValue::Pair(tr_lvalue.llval, tr_lvalue.llextra)
+                    OperandValue::Pair(tr_place.llval, tr_place.llextra)
                 };
                 (bcx, OperandRef {
                     val,
@@ -355,8 +355,8 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 })
             }
 
-            mir::Rvalue::Len(ref lvalue) => {
-                let size = self.evaluate_array_len(&bcx, lvalue);
+            mir::Rvalue::Len(ref place) => {
+                let size = self.evaluate_array_len(&bcx, place);
                 let operand = OperandRef {
                     val: OperandValue::Immediate(size),
                     layout: bcx.ccx.layout_of(bcx.tcx().types.usize),
@@ -424,9 +424,9 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 })
             }
 
-            mir::Rvalue::Discriminant(ref lvalue) => {
+            mir::Rvalue::Discriminant(ref place) => {
                 let discr_ty = rvalue.ty(&*self.mir, bcx.tcx());
-                let discr =  self.trans_lvalue(&bcx, lvalue)
+                let discr =  self.trans_place(&bcx, place)
                     .trans_get_discr(&bcx, discr_ty);
                 (bcx, OperandRef {
                     val: OperandValue::Immediate(discr),
@@ -486,11 +486,11 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
 
     fn evaluate_array_len(&mut self,
                           bcx: &Builder<'a, 'tcx>,
-                          lvalue: &mir::Place<'tcx>) -> ValueRef
+                          place: &mir::Place<'tcx>) -> ValueRef
     {
         // ZST are passed as operands and require special handling
-        // because trans_lvalue() panics if Local is operand.
-        if let mir::Place::Local(index) = *lvalue {
+        // because trans_place() panics if Local is operand.
+        if let mir::Place::Local(index) = *place {
             if let LocalRef::Operand(Some(op)) = self.locals[index] {
                 if let ty::TyArray(_, n) = op.layout.ty.sty {
                     let n = n.val.to_const_int().unwrap().to_u64().unwrap();
@@ -499,7 +499,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
             }
         }
         // use common size calculation for non zero-sized types
-        let tr_value = self.trans_lvalue(&bcx, lvalue);
+        let tr_value = self.trans_place(&bcx, place);
         return tr_value.len(bcx.ccx);
     }
 

--- a/src/librustc_trans/mir/statement.rs
+++ b/src/librustc_trans/mir/statement.rs
@@ -25,8 +25,8 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
 
         self.set_debug_loc(&bcx, statement.source_info);
         match statement.kind {
-            mir::StatementKind::Assign(ref lvalue, ref rvalue) => {
-                if let mir::Place::Local(index) = *lvalue {
+            mir::StatementKind::Assign(ref place, ref rvalue) => {
+                if let mir::Place::Local(index) = *place {
                     match self.locals[index] {
                         LocalRef::Place(tr_dest) => {
                             self.trans_rvalue(bcx, tr_dest, rvalue)
@@ -49,30 +49,30 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                         }
                     }
                 } else {
-                    let tr_dest = self.trans_lvalue(&bcx, lvalue);
+                    let tr_dest = self.trans_place(&bcx, place);
                     self.trans_rvalue(bcx, tr_dest, rvalue)
                 }
             }
-            mir::StatementKind::SetDiscriminant{ref lvalue, variant_index} => {
-                self.trans_lvalue(&bcx, lvalue)
+            mir::StatementKind::SetDiscriminant{ref place, variant_index} => {
+                self.trans_place(&bcx, place)
                     .trans_set_discr(&bcx, variant_index);
                 bcx
             }
             mir::StatementKind::StorageLive(local) => {
-                if let LocalRef::Place(tr_lval) = self.locals[local] {
-                    tr_lval.storage_live(&bcx);
+                if let LocalRef::Place(tr_place) = self.locals[local] {
+                    tr_place.storage_live(&bcx);
                 }
                 bcx
             }
             mir::StatementKind::StorageDead(local) => {
-                if let LocalRef::Place(tr_lval) = self.locals[local] {
-                    tr_lval.storage_dead(&bcx);
+                if let LocalRef::Place(tr_place) = self.locals[local] {
+                    tr_place.storage_dead(&bcx);
                 }
                 bcx
             }
             mir::StatementKind::InlineAsm { ref asm, ref outputs, ref inputs } => {
                 let outputs = outputs.iter().map(|output| {
-                    self.trans_lvalue(&bcx, output)
+                    self.trans_place(&bcx, output)
                 }).collect();
 
                 let input_vals = inputs.iter().map(|input| {

--- a/src/librustc_trans/mir/statement.rs
+++ b/src/librustc_trans/mir/statement.rs
@@ -26,9 +26,9 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
         self.set_debug_loc(&bcx, statement.source_info);
         match statement.kind {
             mir::StatementKind::Assign(ref lvalue, ref rvalue) => {
-                if let mir::Lvalue::Local(index) = *lvalue {
+                if let mir::Place::Local(index) = *lvalue {
                     match self.locals[index] {
-                        LocalRef::Lvalue(tr_dest) => {
+                        LocalRef::Place(tr_dest) => {
                             self.trans_rvalue(bcx, tr_dest, rvalue)
                         }
                         LocalRef::Operand(None) => {
@@ -59,13 +59,13 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 bcx
             }
             mir::StatementKind::StorageLive(local) => {
-                if let LocalRef::Lvalue(tr_lval) = self.locals[local] {
+                if let LocalRef::Place(tr_lval) = self.locals[local] {
                     tr_lval.storage_live(&bcx);
                 }
                 bcx
             }
             mir::StatementKind::StorageDead(local) => {
-                if let LocalRef::Lvalue(tr_lval) = self.locals[local] {
+                if let LocalRef::Place(tr_lval) = self.locals[local] {
                     tr_lval.storage_dead(&bcx);
                 }
                 bcx

--- a/src/librustc_trans/type_of.rs
+++ b/src/librustc_trans/type_of.rs
@@ -227,7 +227,7 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyLayout<'tcx> {
     }
 
     /// Get the LLVM type corresponding to a Rust type, i.e. `rustc::ty::Ty`.
-    /// The pointee type of the pointer in `LvalueRef` is always this type.
+    /// The pointee type of the pointer in `PlaceRef` is always this type.
     /// For sized types, it is also the right LLVM type for an `alloca`
     /// containing a value of that type, and most immediates (except `bool`).
     /// Unsized types, however, are represented by a "minimal unit", e.g.

--- a/src/librustc_trans_utils/collector.rs
+++ b/src/librustc_trans_utils/collector.rs
@@ -639,7 +639,7 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirNeighborCollector<'a, 'tcx> {
 
     fn visit_static(&mut self,
                     static_: &mir::Static<'tcx>,
-                    context: mir::visit::LvalueContext<'tcx>,
+                    context: mir::visit::PlaceContext<'tcx>,
                     location: Location) {
         debug!("visiting static {:?} @ {:?}", static_.def_id, location);
 


### PR DESCRIPTION
As pointed out elsewhere, "lvalue" vs "rvalue" is a misleading/obscure distinction and several other choices have been proposed, the one I prefer being "place" vs "value".

This PR only touches the "lvalue" side, and only in MIR-related code, as it's already a lot and could rot.