### PR TITLE
incr.comp.: Incorporate the stable commandline arg hash and SVHs of upstream crates into the SVH.

### DIFF
--- a/src/librustc/hir/map/collector.rs
+++ b/src/librustc/hir/map/collector.rs
@@ -12,6 +12,7 @@ use super::*;
 
 use dep_graph::{DepGraph, DepKind, DepNodeIndex};
 use hir::intravisit::{Visitor, NestedVisitorMap};
+use middle::cstore::CrateStore;
 use session::CrateDisambiguator;
 use std::iter::repeat;
 use syntax::ast::{NodeId, CRATE_NODE_ID};
@@ -119,7 +120,9 @@ impl<'a, 'hir> NodeCollector<'a, 'hir> {
     }
 
     pub(super) fn finalize_and_compute_crate_hash(self,
-                                                  crate_disambiguator: CrateDisambiguator)
+                                                  crate_disambiguator: CrateDisambiguator,
+                                                  cstore: &CrateStore,
+                                                  commandline_args_hash: u64)
                                                   -> Vec<MapEntry<'hir>> {
         let mut node_hashes: Vec<_> = self
             .hir_body_nodes
@@ -132,9 +135,23 @@ impl<'a, 'hir> NodeCollector<'a, 'hir> {
 
         node_hashes.sort_unstable_by(|&(ref d1, _), &(ref d2, _)| d1.cmp(d2));
 
+        let mut upstream_crates: Vec<_> = cstore.crates_untracked().iter().map(|&cnum| {
+            let name = cstore.crate_name_untracked(cnum).as_str();
+            let disambiguator = cstore.crate_disambiguator_untracked(cnum)
+                                      .to_fingerprint();
+            let hash = cstore.crate_hash_untracked(cnum);
+            (name, disambiguator, hash)
+        }).collect();
+
+        upstream_crates.sort_unstable_by(|&(name1, dis1, _), &(name2, dis2, _)| {
+            (name1, dis1).cmp(&(name2, dis2))
+        });
+
         self.dep_graph.with_task(DepNode::new_no_params(DepKind::Krate),
                                  &self.hcx,
-                                 (node_hashes, crate_disambiguator.to_fingerprint()),
+                                 ((node_hashes, upstream_crates),
+                                  (commandline_args_hash,
+                                   crate_disambiguator.to_fingerprint())),
                                  identity_fn);
         self.map
     }

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -1059,7 +1059,10 @@ pub fn map_crate<'hir>(sess: &::session::Session,
         intravisit::walk_crate(&mut collector, &forest.krate);
 
         let crate_disambiguator = sess.local_crate_disambiguator();
-        collector.finalize_and_compute_crate_hash(crate_disambiguator)
+        let cmdline_args = sess.opts.dep_tracking_hash();
+        collector.finalize_and_compute_crate_hash(crate_disambiguator,
+                                                  cstore,
+                                                  cmdline_args)
     };
 
     if log_enabled!(::log::LogLevel::Debug) {


### PR DESCRIPTION
So far the SVH detected changes in the HIR, which is already very sensitive, but in order for `eval_always` queries to also be sensitive to changes in upstream crates, the SVH also needs to capture changes there.

This PR fixes [rust-icci/crossbeam](https://travis-ci.org/rust-icci/crossbeam/builds/308936448), but I have not yet been able to come up with a minimal regression test.

r? @nikomatsakis 