### PR TITLE
rustc: don't unpack newtypes of scalar-pairs with mismatched alignment.

### DIFF
--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -1079,7 +1079,9 @@ impl<'a, 'tcx> LayoutDetails {
                         // We have exactly one non-ZST field.
                         (Some((i, field)), None, None) => {
                             // Field fills the struct and it has a scalar or scalar pair ABI.
-                            if offsets[i].bytes() == 0 && size == field.size {
+                            if offsets[i].bytes() == 0 &&
+                               align.abi() == field.align.abi() &&
+                               size == field.size {
                                 match field.abi {
                                     // For plain scalars we can't unpack newtypes
                                     // for `#[repr(C)]`, as that affects C ABIs.

--- a/src/test/codegen/packed.rs
+++ b/src/test/codegen/packed.rs
@@ -57,3 +57,14 @@ pub fn pkd_pair(pair1: &mut PackedPair, pair2: &mut PackedPair) {
 // CHECK: call void @llvm.memcpy.{{.*}}(i8* %{{.*}}, i8* %{{.*}}, i{{[0-9]+}} 5, i32 1, i1 false)
     *pair2 = *pair1;
 }
+
+#[repr(packed)]
+#[derive(Copy, Clone)]
+pub struct PackedNestedPair((u32, u32));
+
+// CHECK-LABEL: @pkd_nested_pair
+#[no_mangle]
+pub fn pkd_nested_pair(pair1: &mut PackedNestedPair, pair2: &mut PackedNestedPair) {
+// CHECK: call void @llvm.memcpy.{{.*}}(i8* %{{.*}}, i8* %{{.*}}, i{{[0-9]+}} 8, i32 1, i1 false)
+    *pair2 = *pair1;
+}


### PR DESCRIPTION
This PR fixes a potential problem where a packed newtype of a pair was also considered a pair, even though it didn't have the required alignment of the pair.
cc @oli-obk It's possible miri hit something like this, with an unstable feature, but it's more general.