### PR TITLE
Assume at least LLVM 3.9 in rustllvm and rustc_llvm

### DIFF
--- a/src/librustc_llvm/build.rs
+++ b/src/librustc_llvm/build.rs
@@ -17,27 +17,14 @@ use std::path::{PathBuf, Path};
 
 use build_helper::output;
 
-fn detect_llvm_link(major: u32, minor: u32, llvm_config: &Path)
-    -> (&'static str, Option<&'static str>) {
-    if major > 3 || (major == 3 && minor >= 9) {
-        // Force the link mode we want, preferring static by default, but
-        // possibly overridden by `configure --enable-llvm-link-shared`.
-        if env::var_os("LLVM_LINK_SHARED").is_some() {
-            return ("dylib", Some("--link-shared"));
-        } else {
-            return ("static", Some("--link-static"));
-        }
-    } else if major == 3 && minor == 8 {
-        // Find out LLVM's default linking mode.
-        let mut mode_cmd = Command::new(llvm_config);
-        mode_cmd.arg("--shared-mode");
-        if output(&mut mode_cmd).trim() == "shared" {
-            return ("dylib", None);
-        } else {
-            return ("static", None);
-        }
+fn detect_llvm_link() -> (&'static str, &'static str) {
+    // Force the link mode we want, preferring static by default, but
+    // possibly overridden by `configure --enable-llvm-link-shared`.
+    if env::var_os("LLVM_LINK_SHARED").is_some() {
+        ("dylib", "--link-shared")
+    } else {
+        ("static", "--link-static")
     }
-    ("static", None)
 }
 
 fn main() {
@@ -96,11 +83,11 @@ fn main() {
     let version_output = output(&mut version_cmd);
     let mut parts = version_output.split('.').take(2)
         .filter_map(|s| s.parse::<u32>().ok());
-    let (major, minor) =
+    let (major, _minor) =
         if let (Some(major), Some(minor)) = (parts.next(), parts.next()) {
             (major, minor)
         } else {
-            (3, 7)
+            (3, 9)
         };
 
     if major > 3 {
@@ -171,17 +158,13 @@ fn main() {
        .cpp_link_stdlib(None) // we handle this below
        .compile("librustllvm.a");
 
-    let (llvm_kind, llvm_link_arg) = detect_llvm_link(major, minor, &llvm_config);
+    let (llvm_kind, llvm_link_arg) = detect_llvm_link();
 
     // Link in all LLVM libraries, if we're uwring the "wrong" llvm-config then
     // we don't pick up system libs because unfortunately they're for the host
     // of llvm-config, not the target that we're attempting to link.
     let mut cmd = Command::new(&llvm_config);
-    cmd.arg("--libs");
-
-    if let Some(link_arg) = llvm_link_arg {
-        cmd.arg(link_arg);
-    }
+    cmd.arg(llvm_link_arg).arg("--libs");
 
     if !is_crossed {
         cmd.arg("--system-libs");
@@ -230,10 +213,7 @@ fn main() {
     // hack around this by replacing the host triple with the target and pray
     // that those -L directories are the same!
     let mut cmd = Command::new(&llvm_config);
-    if let Some(link_arg) = llvm_link_arg {
-        cmd.arg(link_arg);
-    }
-    cmd.arg("--ldflags");
+    cmd.arg(llvm_link_arg).arg("--ldflags");
     for lib in output(&mut cmd).split_whitespace() {
         if lib.starts_with("-LIBPATH:") {
             println!("cargo:rustc-link-search=native={}", &lib[9..]);

--- a/src/rustllvm/ArchiveWrapper.cpp
+++ b/src/rustllvm/ArchiveWrapper.cpp
@@ -24,11 +24,7 @@ struct RustArchiveMember {
 
   RustArchiveMember()
       : Filename(nullptr), Name(nullptr),
-#if LLVM_VERSION_GE(3, 8)
         Child(nullptr, nullptr, nullptr)
-#else
-        Child(nullptr, nullptr)
-#endif
   {
   }
   ~RustArchiveMember() {}
@@ -38,13 +34,9 @@ struct RustArchiveIterator {
   bool First;
   Archive::child_iterator Cur;
   Archive::child_iterator End;
-#if LLVM_VERSION_GE(3, 9)
   Error Err;
 
   RustArchiveIterator() : First(true), Err(Error::success()) {}
-#else
-  RustArchiveIterator() : First(true) {}
-#endif
 };
 
 enum class LLVMRustArchiveKind {
@@ -84,19 +76,11 @@ extern "C" LLVMRustArchiveRef LLVMRustOpenArchive(char *Path) {
     return nullptr;
   }
 
-#if LLVM_VERSION_LE(3, 8)
-  ErrorOr<std::unique_ptr<Archive>> ArchiveOr =
-#else
   Expected<std::unique_ptr<Archive>> ArchiveOr =
-#endif
       Archive::create(BufOr.get()->getMemBufferRef());
 
   if (!ArchiveOr) {
-#if LLVM_VERSION_LE(3, 8)
-    LLVMRustSetLastError(ArchiveOr.getError().message().c_str());
-#else
     LLVMRustSetLastError(toString(ArchiveOr.takeError()).c_str());
-#endif
     return nullptr;
   }
 
@@ -114,16 +98,12 @@ extern "C" LLVMRustArchiveIteratorRef
 LLVMRustArchiveIteratorNew(LLVMRustArchiveRef RustArchive) {
   Archive *Archive = RustArchive->getBinary();
   RustArchiveIterator *RAI = new RustArchiveIterator();
-#if LLVM_VERSION_LE(3, 8)
-  RAI->Cur = Archive->child_begin();
-#else
   RAI->Cur = Archive->child_begin(RAI->Err);
   if (RAI->Err) {
     LLVMRustSetLastError(toString(std::move(RAI->Err)).c_str());
     delete RAI;
     return nullptr;
   }
-#endif
   RAI->End = Archive->child_end();
   return RAI;
 }
@@ -141,12 +121,10 @@ LLVMRustArchiveIteratorNext(LLVMRustArchiveIteratorRef RAI) {
   // but instead advance it *before* fetching the child in all later calls.
   if (!RAI->First) {
     ++RAI->Cur;
-#if LLVM_VERSION_GE(3, 9)
     if (RAI->Err) {
       LLVMRustSetLastError(toString(std::move(RAI->Err)).c_str());
       return nullptr;
     }
-#endif
   } else {
     RAI->First = false;
   }
@@ -154,16 +132,7 @@ LLVMRustArchiveIteratorNext(LLVMRustArchiveIteratorRef RAI) {
   if (RAI->Cur == RAI->End)
     return nullptr;
 
-#if LLVM_VERSION_EQ(3, 8)
-  const ErrorOr<Archive::Child> *Cur = RAI->Cur.operator->();
-  if (!*Cur) {
-    LLVMRustSetLastError(Cur->getError().message().c_str());
-    return nullptr;
-  }
-  const Archive::Child &Child = Cur->get();
-#else
   const Archive::Child &Child = *RAI->Cur.operator->();
-#endif
   Archive::Child *Ret = new Archive::Child(Child);
 
   return Ret;
@@ -239,18 +208,13 @@ LLVMRustWriteArchive(char *Dst, size_t NumMembers,
                      const LLVMRustArchiveMemberRef *NewMembers,
                      bool WriteSymbtab, LLVMRustArchiveKind RustKind) {
 
-#if LLVM_VERSION_LE(3, 8)
-  std::vector<NewArchiveIterator> Members;
-#else
   std::vector<NewArchiveMember> Members;
-#endif
   auto Kind = fromRust(RustKind);
 
   for (size_t I = 0; I < NumMembers; I++) {
     auto Member = NewMembers[I];
     assert(Member->Name);
     if (Member->Filename) {
-#if LLVM_VERSION_GE(3, 9)
       Expected<NewArchiveMember> MOrErr =
           NewArchiveMember::getFile(Member->Filename, true);
       if (!MOrErr) {
@@ -261,15 +225,7 @@ LLVMRustWriteArchive(char *Dst, size_t NumMembers,
       MOrErr->MemberName = sys::path::filename(MOrErr->MemberName);
 #endif
       Members.push_back(std::move(*MOrErr));
-#elif LLVM_VERSION_EQ(3, 8)
-      Members.push_back(NewArchiveIterator(Member->Filename));
-#else
-      Members.push_back(NewArchiveIterator(Member->Filename, Member->Name));
-#endif
     } else {
-#if LLVM_VERSION_LE(3, 8)
-      Members.push_back(NewArchiveIterator(Member->Child, Member->Name));
-#else
       Expected<NewArchiveMember> MOrErr =
           NewArchiveMember::getOldMember(Member->Child, true);
       if (!MOrErr) {
@@ -277,14 +233,9 @@ LLVMRustWriteArchive(char *Dst, size_t NumMembers,
         return LLVMRustResult::Failure;
       }
       Members.push_back(std::move(*MOrErr));
-#endif
     }
   }
-#if LLVM_VERSION_GE(3, 8)
   auto Pair = writeArchive(Dst, Members, WriteSymbtab, Kind, true, false);
-#else
-  auto Pair = writeArchive(Dst, Members, WriteSymbtab, Kind, true);
-#endif
   if (!Pair.second)
     return LLVMRustResult::Success;
   LLVMRustSetLastError(Pair.second.message().c_str());

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -58,9 +58,6 @@ extern "C" void LLVMInitializePasses() {
   initializeVectorization(Registry);
   initializeIPO(Registry);
   initializeAnalysis(Registry);
-#if LLVM_VERSION_EQ(3, 7)
-  initializeIPA(Registry);
-#endif
   initializeTransformUtils(Registry);
   initializeInstCombine(Registry);
   initializeInstrumentation(Registry);
@@ -272,18 +269,10 @@ enum class LLVMRustRelocMode {
   ROPIRWPI,
 };
 
-#if LLVM_VERSION_LE(3, 8)
-static Reloc::Model fromRust(LLVMRustRelocMode RustReloc) {
-#else
 static Optional<Reloc::Model> fromRust(LLVMRustRelocMode RustReloc) {
-#endif
   switch (RustReloc) {
   case LLVMRustRelocMode::Default:
-#if LLVM_VERSION_LE(3, 8)
-    return Reloc::Default;
-#else
     return None;
-#endif
   case LLVMRustRelocMode::Static:
     return Reloc::Static;
   case LLVMRustRelocMode::PIC:
@@ -389,9 +378,6 @@ extern "C" LLVMTargetMachineRef LLVMRustCreateTargetMachine(
   }
 
   TargetOptions Options;
-#if LLVM_VERSION_LE(3, 8)
-  Options.PositionIndependentExecutable = PositionIndependentExecutable;
-#endif
 
   Options.FloatABIType = FloatABI::Default;
   if (UseSoftFloat) {
@@ -719,10 +705,6 @@ extern "C" void LLVMRustRunRestrictionPass(LLVMModuleRef M, char **Symbols,
                                            size_t Len) {
   llvm::legacy::PassManager passes;
 
-#if LLVM_VERSION_LE(3, 8)
-  ArrayRef<const char *> Ref(Symbols, Len);
-  passes.add(llvm::createInternalizePass(Ref));
-#else
   auto PreserveFunctions = [=](const GlobalValue &GV) {
     for (size_t I = 0; I < Len; I++) {
       if (GV.getName() == Symbols[I]) {
@@ -733,7 +715,6 @@ extern "C" void LLVMRustRunRestrictionPass(LLVMModuleRef M, char **Symbols,
   };
 
   passes.add(llvm::createInternalizePass(PreserveFunctions));
-#endif
 
   passes.run(*unwrap(M));
 }
@@ -769,9 +750,7 @@ extern "C" LLVMTargetDataRef LLVMRustGetModuleDataLayout(LLVMModuleRef M) {
 }
 
 extern "C" void LLVMRustSetModulePIELevel(LLVMModuleRef M) {
-#if LLVM_VERSION_GE(3, 9)
   unwrap(M)->setPIELevel(PIELevel::Level::Large);
-#endif
 }
 
 extern "C" bool

--- a/src/rustllvm/rustllvm.h
+++ b/src/rustllvm/rustllvm.h
@@ -57,11 +57,7 @@
 
 #define LLVM_VERSION_LT(major, minor) (!LLVM_VERSION_GE((major), (minor)))
 
-#if LLVM_VERSION_GE(3, 7)
 #include "llvm/IR/LegacyPassManager.h"
-#else
-#include "llvm/PassManager.h"
-#endif
 
 #if LLVM_VERSION_GE(4, 0)
 #include "llvm/Bitcode/BitcodeReader.h"


### PR DESCRIPTION
We bumped the minimum LLVM to 3.9 in #45326.  This just cleans up the conditional code in the `rustllvm` C++ wrappers to assume that minimum, and similarly cleans up the `rustc_llvm` build script.