### PR TITLE
Detect unaligned fields via `aggregate.align < field.align`, instead of a `packed` flag.

### DIFF
--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -13,11 +13,10 @@ pub use self::error::{EvalError, EvalResult, EvalErrorKind};
 pub use self::value::{PrimVal, PrimValKind, Value, Pointer, bytes_to_f32, bytes_to_f64};
 
 use std::collections::BTreeMap;
-use ty::layout::HasDataLayout;
 use std::fmt;
-use ty::layout;
 use mir;
 use ty;
+use ty::layout::{self, Align, HasDataLayout};
 use middle::region;
 use std::iter;
 
@@ -166,7 +165,7 @@ pub struct Allocation {
     /// Denotes undefined memory. Reading from undefined memory is forbidden in miri
     pub undef_mask: UndefMask,
     /// The alignment of the allocation to detect unaligned reads.
-    pub align: u64,
+    pub align: Align,
 }
 
 impl Allocation {
@@ -177,7 +176,7 @@ impl Allocation {
             bytes: slice.to_owned(),
             relocations: BTreeMap::new(),
             undef_mask,
-            align: 1,
+            align: Align::from_bytes(1, 1).unwrap(),
         }
     }
 }

--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -10,7 +10,7 @@ mod value;
 
 pub use self::error::{EvalError, EvalResult, EvalErrorKind};
 
-pub use self::value::{PrimVal, PrimValKind, Value, Pointer, PtrAndAlign, bytes_to_f32, bytes_to_f64};
+pub use self::value::{PrimVal, PrimValKind, Value, Pointer, bytes_to_f32, bytes_to_f64};
 
 use std::collections::BTreeMap;
 use ty::layout::HasDataLayout;

--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -6,24 +6,6 @@ use super::{EvalResult, MemoryPointer, PointerArithmetic};
 use syntax::ast::FloatTy;
 use rustc_const_math::ConstFloat;
 
-#[derive(Copy, Clone, Debug)]
-pub struct PtrAndAlign {
-    pub ptr: Pointer,
-    pub align: Align,
-}
-
-impl PtrAndAlign {
-    pub fn to_ptr<'tcx>(self) -> EvalResult<'tcx, MemoryPointer> {
-        self.ptr.to_ptr()
-    }
-    pub fn offset<'tcx, C: HasDataLayout>(self, i: u64, cx: C) -> EvalResult<'tcx, Self> {
-        Ok(PtrAndAlign {
-            ptr: self.ptr.offset(i, cx)?,
-            align: self.align,
-        })
-    }
-}
-
 pub fn bytes_to_f32(bits: u128) -> ConstFloat {
     ConstFloat {
         bits,
@@ -49,7 +31,7 @@ pub fn bytes_to_f64(bits: u128) -> ConstFloat {
 /// operations and fat pointers. This idea was taken from rustc's trans.
 #[derive(Clone, Copy, Debug)]
 pub enum Value {
-    ByRef(PtrAndAlign),
+    ByRef(Pointer, Align),
     ByVal(PrimVal),
     ByValPair(PrimVal, PrimVal),
 }

--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -1,6 +1,6 @@
 #![allow(unknown_lints)]
 
-use ty::layout::HasDataLayout;
+use ty::layout::{Align, HasDataLayout};
 
 use super::{EvalResult, MemoryPointer, PointerArithmetic};
 use syntax::ast::FloatTy;
@@ -9,8 +9,7 @@ use rustc_const_math::ConstFloat;
 #[derive(Copy, Clone, Debug)]
 pub struct PtrAndAlign {
     pub ptr: Pointer,
-    /// Remember whether this place is *supposed* to be aligned.
-    pub aligned: bool,
+    pub align: Align,
 }
 
 impl PtrAndAlign {
@@ -20,7 +19,7 @@ impl PtrAndAlign {
     pub fn offset<'tcx, C: HasDataLayout>(self, i: u64, cx: C) -> EvalResult<'tcx, Self> {
         Ok(PtrAndAlign {
             ptr: self.ptr.offset(i, cx)?,
-            aligned: self.aligned,
+            align: self.align,
         })
     }
 }
@@ -180,13 +179,6 @@ pub enum PrimValKind {
     Ptr, FnPtr,
     Bool,
     Char,
-}
-
-impl<'a, 'tcx: 'a> Value {
-    #[inline]
-    pub fn by_ref(ptr: Pointer) -> Self {
-        Value::ByRef(PtrAndAlign { ptr, aligned: true })
-    }
 }
 
 impl<'tcx> PrimVal {

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -895,7 +895,7 @@ pub struct InterpretInterner<'tcx> {
     /// Allows checking whether a constant already has an allocation
     ///
     /// The pointers are to the beginning of an `alloc_by_id` allocation
-    alloc_cache: FxHashMap<interpret::GlobalId<'tcx>, interpret::PtrAndAlign>,
+    alloc_cache: FxHashMap<interpret::GlobalId<'tcx>, interpret::Pointer>,
 
     /// A cache for basic byte allocations keyed by their contents. This is used to deduplicate
     /// allocations for string and bytestring literals.
@@ -931,14 +931,14 @@ impl<'tcx> InterpretInterner<'tcx> {
     pub fn get_cached(
         &self,
         global_id: interpret::GlobalId<'tcx>,
-    ) -> Option<interpret::PtrAndAlign> {
+    ) -> Option<interpret::Pointer> {
         self.alloc_cache.get(&global_id).cloned()
     }
 
     pub fn cache(
         &mut self,
         global_id: interpret::GlobalId<'tcx>,
-        ptr: interpret::PtrAndAlign,
+        ptr: interpret::Pointer,
     ) {
         if let Some(old) = self.alloc_cache.insert(global_id, ptr) {
             bug!("tried to cache {:?}, but was already existing as {:#?}", global_id, old);

--- a/src/librustc_mir/interpret/const_eval.rs
+++ b/src/librustc_mir/interpret/const_eval.rs
@@ -66,7 +66,7 @@ pub fn eval_body<'a, 'tcx>(
         assert!(!layout.is_unsized());
         let ptr = ecx.memory.allocate(
             layout.size.bytes(),
-            layout.align.abi(),
+            layout.align,
             None,
         )?;
         tcx.interpret_interner.borrow_mut().cache(cid, ptr.into());
@@ -95,7 +95,7 @@ pub fn eval_body_as_integer<'a, 'tcx>(
     let ptr_ty = eval_body(tcx, instance, param_env);
     let (ptr, ty) = ptr_ty?;
     let ecx = mk_eval_cx(tcx, instance, param_env)?;
-    let prim = match ecx.try_read_value(ptr, ty)? {
+    let prim = match ecx.try_read_value(ptr, ecx.layout_of(ty)?.align, ty)? {
         Some(Value::ByVal(prim)) => prim.to_bytes()?,
         _ => return err!(TypeNotPrimitive(ty)),
     };

--- a/src/librustc_mir/interpret/const_eval.rs
+++ b/src/librustc_mir/interpret/const_eval.rs
@@ -12,8 +12,8 @@ use rustc_data_structures::indexed_vec::Idx;
 use syntax::ast::Mutability;
 use syntax::codemap::Span;
 
-use rustc::mir::interpret::{EvalResult, EvalError, EvalErrorKind, GlobalId, Value, Pointer, PrimVal, PtrAndAlign};
-use super::{Place, PlaceExtra, EvalContext, StackPopCleanup, ValTy, HasMemory};
+use rustc::mir::interpret::{EvalResult, EvalError, EvalErrorKind, GlobalId, Value, Pointer, PrimVal};
+use super::{Place, EvalContext, StackPopCleanup, ValTy};
 
 use rustc_const_math::ConstInt;
 
@@ -357,11 +357,9 @@ pub fn const_eval_provider<'a, 'tcx>(
             (_, Err(err)) => Err(err),
             (Ok((miri_val, miri_ty)), Ok(ctfe)) => {
                 let mut ecx = mk_eval_cx(tcx, instance, key.param_env).unwrap();
-                let miri_ptr = PtrAndAlign {
-                    ptr: miri_val,
-                    align: ecx.layout_of(miri_ty).unwrap().align
-                };
-                check_ctfe_against_miri(&mut ecx, miri_ptr, miri_ty, ctfe.val);
+                let layout = ecx.layout_of(miri_ty).unwrap();
+                let miri_place = Place::from_primval_ptr(miri_val, layout.align);
+                check_ctfe_against_miri(&mut ecx, miri_place, miri_ty, ctfe.val);
                 Ok(ctfe)
             }
         }
@@ -372,19 +370,20 @@ pub fn const_eval_provider<'a, 'tcx>(
 
 fn check_ctfe_against_miri<'a, 'tcx>(
     ecx: &mut EvalContext<'a, 'tcx, CompileTimeEvaluator>,
-    miri_val: PtrAndAlign,
+    miri_place: Place,
     miri_ty: Ty<'tcx>,
     ctfe: ConstVal<'tcx>,
 ) {
     use rustc::middle::const_val::ConstAggregate::*;
     use rustc_const_math::ConstFloat;
     use rustc::ty::TypeVariants::*;
+    let miri_val = ValTy {
+        value: ecx.read_place(miri_place).unwrap(),
+        ty: miri_ty
+    };
     match miri_ty.sty {
         TyInt(int_ty) => {
-            let value = ecx.read_with_align(miri_val.align, |ectx| {
-                ectx.try_read_value(miri_val.ptr, miri_ty)
-            });
-            let prim = get_prim(ecx, value);
+            let prim = get_prim(ecx, miri_val);
             let c = ConstInt::new_signed_truncating(prim as i128,
                                                     int_ty,
                                                     ecx.tcx.sess.target.isize_ty);
@@ -392,10 +391,7 @@ fn check_ctfe_against_miri<'a, 'tcx>(
             assert_eq!(c, ctfe, "miri evaluated to {:?}, but ctfe yielded {:?}", c, ctfe);
         },
         TyUint(uint_ty) => {
-            let value = ecx.read_with_align(miri_val.align, |ectx| {
-                ectx.try_read_value(miri_val.ptr, miri_ty)
-            });
-            let prim = get_prim(ecx, value);
+            let prim = get_prim(ecx, miri_val);
             let c = ConstInt::new_unsigned_truncating(prim,
                                                      uint_ty,
                                                      ecx.tcx.sess.target.usize_ty);
@@ -403,18 +399,12 @@ fn check_ctfe_against_miri<'a, 'tcx>(
             assert_eq!(c, ctfe, "miri evaluated to {:?}, but ctfe yielded {:?}", c, ctfe);
         },
         TyFloat(ty) => {
-            let value = ecx.read_with_align(miri_val.align, |ectx| {
-                ectx.try_read_value(miri_val.ptr, miri_ty)
-            });
-            let prim = get_prim(ecx, value);
+            let prim = get_prim(ecx, miri_val);
             let f = ConstVal::Float(ConstFloat { bits: prim, ty });
             assert_eq!(f, ctfe, "miri evaluated to {:?}, but ctfe yielded {:?}", f, ctfe);
         },
         TyBool => {
-            let value = ecx.read_with_align(miri_val.align, |ectx| {
-                ectx.try_read_value(miri_val.ptr, miri_ty)
-            });
-            let bits = get_prim(ecx, value);
+            let bits = get_prim(ecx, miri_val);
             if bits > 1 {
                 bug!("miri evaluated to {}, but expected a bool {:?}", bits, ctfe);
             }
@@ -422,10 +412,7 @@ fn check_ctfe_against_miri<'a, 'tcx>(
             assert_eq!(b, ctfe, "miri evaluated to {:?}, but ctfe yielded {:?}", b, ctfe);
         },
         TyChar => {
-            let value = ecx.read_with_align(miri_val.align, |ectx| {
-                ectx.try_read_value(miri_val.ptr, miri_ty)
-            });
-            let bits = get_prim(ecx, value);
+            let bits = get_prim(ecx, miri_val);
             if let Some(cm) = ::std::char::from_u32(bits as u32) {
                 assert_eq!(
                     ConstVal::Char(cm), ctfe,
@@ -436,10 +423,8 @@ fn check_ctfe_against_miri<'a, 'tcx>(
             }
         },
         TyStr => {
-            let value = ecx.read_with_align(miri_val.align, |ectx| {
-                ectx.try_read_value(miri_val.ptr, miri_ty)
-            });
-            if let Ok(Some(Value::ByValPair(PrimVal::Ptr(ptr), PrimVal::Bytes(len)))) = value {
+            let value = ecx.follow_by_ref_value(miri_val.value, miri_val.ty);
+            if let Ok(Value::ByValPair(PrimVal::Ptr(ptr), PrimVal::Bytes(len))) = value {
                 let bytes = ecx
                     .memory
                     .read_bytes(ptr.into(), len as u64)
@@ -463,7 +448,6 @@ fn check_ctfe_against_miri<'a, 'tcx>(
         },
         TyArray(elem_ty, n) => {
             let n = n.val.to_const_int().unwrap().to_u64().unwrap();
-            let size = ecx.layout_of(elem_ty).unwrap().size.bytes();
             let vec: Vec<(ConstVal, Ty<'tcx>)> = match ctfe {
                 ConstVal::ByteStr(arr) => arr.data.iter().map(|&b| {
                     (ConstVal::Integral(ConstInt::U8(b)), ecx.tcx.types.u8)
@@ -476,10 +460,12 @@ fn check_ctfe_against_miri<'a, 'tcx>(
                 },
                 _ => bug!("miri produced {:?}, but ctfe yielded {:?}", miri_ty, ctfe),
             };
+            let layout = ecx.layout_of(miri_ty).unwrap();
             for (i, elem) in vec.into_iter().enumerate() {
                 assert!((i as u64) < n);
-                let ptr = miri_val.offset(size * i as u64, &ecx).unwrap();
-                check_ctfe_against_miri(ecx, ptr, elem_ty, elem.0);
+                let (field_place, _) =
+                    ecx.place_field(miri_place, Field::new(i), layout).unwrap();
+                check_ctfe_against_miri(ecx, field_place, elem_ty, elem.0);
             }
         },
         TyTuple(..) => {
@@ -489,22 +475,22 @@ fn check_ctfe_against_miri<'a, 'tcx>(
             };
             let layout = ecx.layout_of(miri_ty).unwrap();
             for (i, elem) in vec.into_iter().enumerate() {
-                let offset = layout.fields.offset(i);
-                let ptr = miri_val.offset(offset.bytes(), &ecx).unwrap();
-                check_ctfe_against_miri(ecx, ptr, elem.ty, elem.val);
+                let (field_place, _) =
+                    ecx.place_field(miri_place, Field::new(i), layout).unwrap();
+                check_ctfe_against_miri(ecx, field_place, elem.ty, elem.val);
             }
         },
         TyAdt(def, _) => {
-            let (struct_variant, extra) = if def.is_enum() {
-                let discr = ecx.read_discriminant_value(
-                    Place::Ptr { ptr: miri_val, extra: PlaceExtra::None },
-                    miri_ty).unwrap();
+            let mut miri_place = miri_place;
+            let struct_variant = if def.is_enum() {
+                let discr = ecx.read_discriminant_value(miri_place, miri_ty).unwrap();
                 let variant = def.discriminants(ecx.tcx).position(|variant_discr| {
                     variant_discr.to_u128_unchecked() == discr
                 }).expect("miri produced invalid enum discriminant");
-                (&def.variants[variant], PlaceExtra::DowncastVariant(variant))
+                miri_place = ecx.place_downcast(miri_place, variant).unwrap();
+                &def.variants[variant]
             } else {
-                (def.struct_variant(), PlaceExtra::None)
+                def.struct_variant()
             };
             let vec = match ctfe {
                 ConstVal::Aggregate(Struct(v)) => v,
@@ -518,12 +504,9 @@ fn check_ctfe_against_miri<'a, 'tcx>(
             let layout = ecx.layout_of(miri_ty).unwrap();
             for &(name, elem) in vec.into_iter() {
                 let field = struct_variant.fields.iter().position(|f| f.name == name).unwrap();
-                let (place, _) = ecx.place_field(
-                    Place::Ptr { ptr: miri_val, extra },
-                    Field::new(field),
-                    layout,
-                ).unwrap();
-                check_ctfe_against_miri(ecx, place.to_ptr_align(), elem.ty, elem.val);
+                let (field_place, _) =
+                    ecx.place_field(miri_place, Field::new(field), layout).unwrap();
+                check_ctfe_against_miri(ecx, field_place, elem.ty, elem.val);
             }
         },
         TySlice(_) => bug!("miri produced a slice?"),
@@ -543,11 +526,9 @@ fn check_ctfe_against_miri<'a, 'tcx>(
         // should be fine
         TyFnDef(..) => {}
         TyFnPtr(_) => {
-            let value = ecx.read_with_align(miri_val.align, |ectx| {
-                ectx.try_read_value(miri_val.ptr, miri_ty)
-            });
+            let value = ecx.value_to_primval(miri_val);
             let ptr = match value {
-                Ok(Some(Value::ByVal(PrimVal::Ptr(ptr)))) => ptr,
+                Ok(PrimVal::Ptr(ptr)) => ptr,
                 value => bug!("expected fn ptr, got {:?}", value),
             };
             let inst = ecx.memory.get_fn(ptr).unwrap();
@@ -569,13 +550,10 @@ fn check_ctfe_against_miri<'a, 'tcx>(
 
 fn get_prim<'a, 'tcx>(
     ecx: &mut EvalContext<'a, 'tcx, CompileTimeEvaluator>,
-    res: Result<Option<Value>, EvalError<'tcx>>,
+    val: ValTy<'tcx>,
 ) -> u128 {
-    match res {
-        Ok(Some(Value::ByVal(prim))) => unwrap_miri(ecx, prim.to_bytes()),
-        Err(err) => unwrap_miri(ecx, Err(err)),
-        val => bug!("got {:?}", val),
-    }
+    let res = ecx.value_to_primval(val).and_then(|prim| prim.to_bytes());
+    unwrap_miri(ecx, res)
 }
 
 fn unwrap_miri<'a, 'tcx, T>(

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -1,7 +1,6 @@
 use byteorder::{ReadBytesExt, WriteBytesExt, LittleEndian, BigEndian};
 use std::collections::{btree_map, BTreeMap, HashMap, HashSet, VecDeque};
 use std::{ptr, mem, io};
-use std::cell::Cell;
 
 use rustc::ty::{Instance, TyCtxt};
 use rustc::ty::layout::{self, Align, TargetDataLayout};
@@ -51,11 +50,6 @@ pub struct Memory<'a, 'tcx: 'a, M: Machine<'tcx>> {
     /// Maximum number of virtual bytes that may be allocated.
     memory_size: u64,
 
-    /// To avoid having to pass flags to every single memory access, we have some global state saying how
-    /// alignment checking is currently enforced for read and/or write accesses.
-    read_align_override: Cell<Option<Align>>,
-    write_align_override: Cell<Option<Align>>,
-
     /// The current stack frame.  Used to check accesses against locks.
     pub cur_frame: usize,
 
@@ -72,8 +66,6 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
             tcx,
             memory_size: max_memory,
             memory_usage: 0,
-            read_align_override: Cell::new(None),
-            write_align_override: Cell::new(None),
             cur_frame: usize::max_value(),
         }
     }
@@ -98,12 +90,9 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
     pub fn allocate(
         &mut self,
         size: u64,
-        align: u64,
+        align: Align,
         kind: Option<MemoryKind<M::MemoryKinds>>,
     ) -> EvalResult<'tcx, MemoryPointer> {
-        assert_ne!(align, 0);
-        assert!(align.is_power_of_two());
-
         if self.memory_size - self.memory_usage < size {
             return err!(OutOfMemory {
                 allocation_size: size,
@@ -139,13 +128,11 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         &mut self,
         ptr: MemoryPointer,
         old_size: u64,
-        old_align: u64,
+        old_align: Align,
         new_size: u64,
-        new_align: u64,
+        new_align: Align,
         kind: MemoryKind<M::MemoryKinds>,
     ) -> EvalResult<'tcx, MemoryPointer> {
-        use std::cmp::min;
-
         if ptr.offset != 0 {
             return err!(ReallocateNonBasePtr);
         }
@@ -163,9 +150,10 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         let new_ptr = self.allocate(new_size, new_align, Some(kind))?;
         self.copy(
             ptr.into(),
+            old_align,
             new_ptr.into(),
-            min(old_size, new_size),
-            min(old_align, new_align),
+            new_align,
+            old_size.min(new_size),
             /*nonoverlapping*/
             true,
         )?;
@@ -190,7 +178,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
     pub fn deallocate(
         &mut self,
         ptr: MemoryPointer,
-        size_and_align: Option<(u64, u64)>,
+        size_and_align: Option<(u64, Align)>,
         kind: MemoryKind<M::MemoryKinds>,
     ) -> EvalResult<'tcx> {
         if ptr.offset != 0 {
@@ -236,7 +224,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         }
         if let Some((size, align)) = size_and_align {
             if size != alloc.bytes.len() as u64 || align != alloc.align {
-                return err!(IncorrectAllocationInformation(size, alloc.bytes.len(), align, alloc.align));
+                return err!(IncorrectAllocationInformation(size, alloc.bytes.len(), align.abi(), alloc.align.abi()));
             }
         }
 
@@ -255,7 +243,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
     }
 
     /// Check that the pointer is aligned AND non-NULL.
-    pub fn check_align(&self, ptr: Pointer, align: u64, access: Option<AccessKind>) -> EvalResult<'tcx> {
+    pub fn check_align(&self, ptr: Pointer, required_align: Align) -> EvalResult<'tcx> {
         // Check non-NULL/Undef, extract offset
         let (offset, alloc_align) = match ptr.into_inner_primval() {
             PrimVal::Ptr(ptr) => {
@@ -267,30 +255,24 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
                 if v == 0 {
                     return err!(InvalidNullPointerUsage);
                 }
-                (v, align) // the base address if the "integer allocation" is 0 and hence always aligned
+                // the base address if the "integer allocation" is 0 and hence always aligned
+                (v, required_align)
             }
             PrimVal::Undef => return err!(ReadUndefBytes),
         };
-        // See if alignment checking is disabled
-        let align_override = match access {
-            Some(AccessKind::Read) => self.read_align_override.get(),
-            Some(AccessKind::Write) => self.write_align_override.get(),
-            None => None,
-        };
-        let align = align_override.map_or(align, |o| o.abi().min(align));
         // Check alignment
-        if alloc_align < align {
+        if alloc_align.abi() < required_align.abi() {
             return err!(AlignmentCheckFailed {
-                has: alloc_align,
-                required: align,
+                has: alloc_align.abi(),
+                required: required_align.abi(),
             });
         }
-        if offset % align == 0 {
+        if offset % required_align.abi() == 0 {
             Ok(())
         } else {
             err!(AlignmentCheckFailed {
-                has: offset % align,
-                required: align,
+                has: offset % required_align.abi(),
+                required: required_align.abi(),
             })
         }
     }
@@ -435,7 +417,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
                 "{}({} bytes, alignment {}){}",
                 msg,
                 alloc.bytes.len(),
-                alloc.align,
+                alloc.align.abi(),
                 immutable
             );
 
@@ -480,10 +462,10 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         &self,
         ptr: MemoryPointer,
         size: u64,
-        align: u64,
+        align: Align,
     ) -> EvalResult<'tcx, &[u8]> {
         // Zero-sized accesses can use dangling pointers, but they still have to be aligned and non-NULL
-        self.check_align(ptr.into(), align, Some(AccessKind::Read))?;
+        self.check_align(ptr.into(), align)?;
         if size == 0 {
             return Ok(&[]);
         }
@@ -500,10 +482,10 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         &mut self,
         ptr: MemoryPointer,
         size: u64,
-        align: u64,
+        align: Align,
     ) -> EvalResult<'tcx, &mut [u8]> {
         // Zero-sized accesses can use dangling pointers, but they still have to be aligned and non-NULL
-        self.check_align(ptr.into(), align, Some(AccessKind::Write))?;
+        self.check_align(ptr.into(), align)?;
         if size == 0 {
             return Ok(&mut []);
         }
@@ -516,7 +498,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         Ok(&mut alloc.bytes[offset..offset + size as usize])
     }
 
-    fn get_bytes(&self, ptr: MemoryPointer, size: u64, align: u64) -> EvalResult<'tcx, &[u8]> {
+    fn get_bytes(&self, ptr: MemoryPointer, size: u64, align: Align) -> EvalResult<'tcx, &[u8]> {
         assert_ne!(size, 0);
         if self.relocations(ptr, size)?.count() != 0 {
             return err!(ReadPointerAsBytes);
@@ -529,7 +511,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         &mut self,
         ptr: MemoryPointer,
         size: u64,
-        align: u64,
+        align: Align,
     ) -> EvalResult<'tcx, &mut [u8]> {
         assert_ne!(size, 0);
         self.clear_relocations(ptr, size)?;
@@ -627,14 +609,15 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
     pub fn copy(
         &mut self,
         src: Pointer,
+        src_align: Align,
         dest: Pointer,
+        dest_align: Align,
         size: u64,
-        align: u64,
         nonoverlapping: bool,
     ) -> EvalResult<'tcx> {
         // Empty accesses don't need to be valid pointers, but they should still be aligned
-        self.check_align(src, align, Some(AccessKind::Read))?;
-        self.check_align(dest, align, Some(AccessKind::Write))?;
+        self.check_align(src, src_align)?;
+        self.check_align(dest, dest_align)?;
         if size == 0 {
             return Ok(());
         }
@@ -653,8 +636,8 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
             })
             .collect();
 
-        let src_bytes = self.get_bytes_unchecked(src, size, align)?.as_ptr();
-        let dest_bytes = self.get_bytes_mut(dest, size, align)?.as_mut_ptr();
+        let src_bytes = self.get_bytes_unchecked(src, size, src_align)?.as_ptr();
+        let dest_bytes = self.get_bytes_mut(dest, size, dest_align)?.as_mut_ptr();
 
         // SAFE: The above indexing would have panicked if there weren't at least `size` bytes
         // behind `src` and `dest`. Also, we use the overlapping-safe `ptr::copy` if `src` and
@@ -703,41 +686,44 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
 
     pub fn read_bytes(&self, ptr: Pointer, size: u64) -> EvalResult<'tcx, &[u8]> {
         // Empty accesses don't need to be valid pointers, but they should still be non-NULL
-        self.check_align(ptr, 1, Some(AccessKind::Read))?;
+        let align = Align::from_bytes(1, 1).unwrap();
+        self.check_align(ptr, align)?;
         if size == 0 {
             return Ok(&[]);
         }
-        self.get_bytes(ptr.to_ptr()?, size, 1)
+        self.get_bytes(ptr.to_ptr()?, size, align)
     }
 
     pub fn write_bytes(&mut self, ptr: Pointer, src: &[u8]) -> EvalResult<'tcx> {
         // Empty accesses don't need to be valid pointers, but they should still be non-NULL
-        self.check_align(ptr, 1, Some(AccessKind::Write))?;
+        let align = Align::from_bytes(1, 1).unwrap();
+        self.check_align(ptr, align)?;
         if src.is_empty() {
             return Ok(());
         }
-        let bytes = self.get_bytes_mut(ptr.to_ptr()?, src.len() as u64, 1)?;
+        let bytes = self.get_bytes_mut(ptr.to_ptr()?, src.len() as u64, align)?;
         bytes.clone_from_slice(src);
         Ok(())
     }
 
     pub fn write_repeat(&mut self, ptr: Pointer, val: u8, count: u64) -> EvalResult<'tcx> {
         // Empty accesses don't need to be valid pointers, but they should still be non-NULL
-        self.check_align(ptr, 1, Some(AccessKind::Write))?;
+        let align = Align::from_bytes(1, 1).unwrap();
+        self.check_align(ptr, align)?;
         if count == 0 {
             return Ok(());
         }
-        let bytes = self.get_bytes_mut(ptr.to_ptr()?, count, 1)?;
+        let bytes = self.get_bytes_mut(ptr.to_ptr()?, count, align)?;
         for b in bytes {
             *b = val;
         }
         Ok(())
     }
 
-    pub fn read_primval(&self, ptr: MemoryPointer, size: u64, signed: bool) -> EvalResult<'tcx, PrimVal> {
+    pub fn read_primval(&self, ptr: MemoryPointer, ptr_align: Align, size: u64, signed: bool) -> EvalResult<'tcx, PrimVal> {
         self.check_relocation_edges(ptr, size)?; // Make sure we don't read part of a pointer as a pointer
         let endianess = self.endianess();
-        let bytes = self.get_bytes_unchecked(ptr, size, self.int_align(size))?;
+        let bytes = self.get_bytes_unchecked(ptr, size, ptr_align.min(self.int_align(size)))?;
         // Undef check happens *after* we established that the alignment is correct.
         // We must not return Ok() for unaligned pointers!
         if self.check_defined(ptr, size).is_err() {
@@ -765,11 +751,11 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         Ok(PrimVal::Bytes(bytes))
     }
 
-    pub fn read_ptr_sized_unsigned(&self, ptr: MemoryPointer) -> EvalResult<'tcx, PrimVal> {
-        self.read_primval(ptr, self.pointer_size(), false)
+    pub fn read_ptr_sized_unsigned(&self, ptr: MemoryPointer, ptr_align: Align) -> EvalResult<'tcx, PrimVal> {
+        self.read_primval(ptr, ptr_align, self.pointer_size(), false)
     }
 
-    pub fn write_primval(&mut self, ptr: MemoryPointer, val: PrimVal, size: u64, signed: bool) -> EvalResult<'tcx> {
+    pub fn write_primval(&mut self, ptr: MemoryPointer, ptr_align: Align, val: PrimVal, size: u64, signed: bool) -> EvalResult<'tcx> {
         let endianess = self.endianess();
 
         let bytes = match val {
@@ -800,7 +786,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
 
         {
             let align = self.int_align(size);
-            let dst = self.get_bytes_mut(ptr, size, align)?;
+            let dst = self.get_bytes_mut(ptr, size, ptr_align.min(align))?;
             if signed {
                 write_target_int(endianess, dst, bytes as i128).unwrap();
             } else {
@@ -822,22 +808,23 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         Ok(())
     }
 
-    pub fn write_ptr_sized_unsigned(&mut self, ptr: MemoryPointer, val: PrimVal) -> EvalResult<'tcx> {
+    pub fn write_ptr_sized_unsigned(&mut self, ptr: MemoryPointer, ptr_align: Align, val: PrimVal) -> EvalResult<'tcx> {
         let ptr_size = self.pointer_size();
-        self.write_primval(ptr, val, ptr_size, false)
+        self.write_primval(ptr, ptr_align, val, ptr_size, false)
     }
 
-    fn int_align(&self, size: u64) -> u64 {
+    fn int_align(&self, size: u64) -> Align {
         // We assume pointer-sized integers have the same alignment as pointers.
         // We also assume signed and unsigned integers of the same size have the same alignment.
-        match size {
-            1 => self.tcx.data_layout.i8_align.abi(),
-            2 => self.tcx.data_layout.i16_align.abi(),
-            4 => self.tcx.data_layout.i32_align.abi(),
-            8 => self.tcx.data_layout.i64_align.abi(),
-            16 => self.tcx.data_layout.i128_align.abi(),
+        let ity = match size {
+            1 => layout::I8,
+            2 => layout::I16,
+            4 => layout::I32,
+            8 => layout::I64,
+            16 => layout::I128,
             _ => bug!("bad integer size: {}", size),
-        }
+        };
+        ity.align(self)
     }
 }
 
@@ -1002,43 +989,6 @@ pub trait HasMemory<'a, 'tcx: 'a, M: Machine<'tcx>> {
     fn memory_mut(&mut self) -> &mut Memory<'a, 'tcx, M>;
     fn memory(&self) -> &Memory<'a, 'tcx, M>;
 
-    // These are not supposed to be overriden.
-    fn read_with_align<F, T>(&self, align: Align, f: F) -> EvalResult<'tcx, T>
-    where
-        F: FnOnce(&Self) -> EvalResult<'tcx, T>,
-    {
-        let old = self.memory().read_align_override.get();
-        // Do alignment checking for the minimum align out of *all* nested calls.
-        self.memory().read_align_override.set(Some(old.map_or(align, |old| old.min(align))));
-        let t = f(self);
-        self.memory().read_align_override.set(old);
-        t
-    }
-
-    fn read_with_align_mut<F, T>(&mut self, align: Align, f: F) -> EvalResult<'tcx, T>
-    where
-        F: FnOnce(&mut Self) -> EvalResult<'tcx, T>,
-    {
-        let old = self.memory().read_align_override.get();
-        // Do alignment checking for the minimum align out of *all* nested calls.
-        self.memory().read_align_override.set(Some(old.map_or(align, |old| old.min(align))));
-        let t = f(self);
-        self.memory().read_align_override.set(old);
-        t
-    }
-
-    fn write_with_align_mut<F, T>(&mut self, align: Align, f: F) -> EvalResult<'tcx, T>
-    where
-        F: FnOnce(&mut Self) -> EvalResult<'tcx, T>,
-    {
-        let old = self.memory().write_align_override.get();
-        // Do alignment checking for the minimum align out of *all* nested calls.
-        self.memory().write_align_override.set(Some(old.map_or(align, |old| old.min(align))));
-        let t = f(self);
-        self.memory().write_align_override.set(old);
-        t
-    }
-
     /// Convert the value into a pointer (or a pointer-sized integer).  If the value is a ByRef,
     /// this may have to perform a load.
     fn into_ptr(
@@ -1047,7 +997,7 @@ pub trait HasMemory<'a, 'tcx: 'a, M: Machine<'tcx>> {
     ) -> EvalResult<'tcx, Pointer> {
         Ok(match value {
             Value::ByRef(ptr, align) => {
-                self.memory().read_with_align(align, |mem| mem.read_ptr_sized_unsigned(ptr.to_ptr()?))?
+                self.memory().read_ptr_sized_unsigned(ptr.to_ptr()?, align)?
             }
             Value::ByVal(ptr) |
             Value::ByValPair(ptr, _) => ptr,
@@ -1060,13 +1010,13 @@ pub trait HasMemory<'a, 'tcx: 'a, M: Machine<'tcx>> {
     ) -> EvalResult<'tcx, (Pointer, MemoryPointer)> {
         match value {
             Value::ByRef(ref_ptr, align) => {
-                self.memory().read_with_align(align, |mem| {
-                    let ptr = mem.read_ptr_sized_unsigned(ref_ptr.to_ptr()?)?.into();
-                    let vtable = mem.read_ptr_sized_unsigned(
-                        ref_ptr.offset(mem.pointer_size(), &mem.tcx.data_layout)?.to_ptr()?,
-                    )?.to_ptr()?;
-                    Ok((ptr, vtable))
-                })
+                let mem = self.memory();
+                let ptr = mem.read_ptr_sized_unsigned(ref_ptr.to_ptr()?, align)?.into();
+                let vtable = mem.read_ptr_sized_unsigned(
+                    ref_ptr.offset(mem.pointer_size(), &mem.tcx.data_layout)?.to_ptr()?,
+                    align
+                )?.to_ptr()?;
+                Ok((ptr, vtable))
             }
 
             Value::ByValPair(ptr, vtable) => Ok((ptr.into(), vtable.to_ptr()?)),
@@ -1082,13 +1032,13 @@ pub trait HasMemory<'a, 'tcx: 'a, M: Machine<'tcx>> {
     ) -> EvalResult<'tcx, (Pointer, u64)> {
         match value {
             Value::ByRef(ref_ptr, align) => {
-                self.memory().read_with_align(align, |mem| {
-                    let ptr = mem.read_ptr_sized_unsigned(ref_ptr.to_ptr()?)?.into();
-                    let len = mem.read_ptr_sized_unsigned(
-                        ref_ptr.offset(mem.pointer_size(), &mem.tcx.data_layout)?.to_ptr()?,
-                    )?.to_bytes()? as u64;
-                    Ok((ptr, len))
-                })
+                let mem = self.memory();
+                let ptr = mem.read_ptr_sized_unsigned(ref_ptr.to_ptr()?, align)?.into();
+                let len = mem.read_ptr_sized_unsigned(
+                    ref_ptr.offset(mem.pointer_size(), &mem.tcx.data_layout)?.to_ptr()?,
+                    align
+                )?.to_bytes()? as u64;
+                Ok((ptr, len))
             }
             Value::ByValPair(ptr, val) => {
                 let len = val.to_u128()?;

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -7,7 +7,7 @@ use rustc::ty::{Instance, TyCtxt};
 use rustc::ty::layout::{self, Align, TargetDataLayout};
 use syntax::ast::Mutability;
 
-use rustc::mir::interpret::{MemoryPointer, AllocId, Allocation, AccessKind, UndefMask, PtrAndAlign, Value, Pointer,
+use rustc::mir::interpret::{MemoryPointer, AllocId, Allocation, AccessKind, UndefMask, Value, Pointer,
                             EvalResult, PrimVal, EvalErrorKind};
 
 use super::{EvalContext, Machine};
@@ -1046,7 +1046,7 @@ pub trait HasMemory<'a, 'tcx: 'a, M: Machine<'tcx>> {
         value: Value,
     ) -> EvalResult<'tcx, Pointer> {
         Ok(match value {
-            Value::ByRef(PtrAndAlign { ptr, align }) => {
+            Value::ByRef(ptr, align) => {
                 self.memory().read_with_align(align, |mem| mem.read_ptr_sized_unsigned(ptr.to_ptr()?))?
             }
             Value::ByVal(ptr) |
@@ -1059,10 +1059,7 @@ pub trait HasMemory<'a, 'tcx: 'a, M: Machine<'tcx>> {
         value: Value,
     ) -> EvalResult<'tcx, (Pointer, MemoryPointer)> {
         match value {
-            Value::ByRef(PtrAndAlign {
-                      ptr: ref_ptr,
-                      align,
-                  }) => {
+            Value::ByRef(ref_ptr, align) => {
                 self.memory().read_with_align(align, |mem| {
                     let ptr = mem.read_ptr_sized_unsigned(ref_ptr.to_ptr()?)?.into();
                     let vtable = mem.read_ptr_sized_unsigned(
@@ -1084,10 +1081,7 @@ pub trait HasMemory<'a, 'tcx: 'a, M: Machine<'tcx>> {
         value: Value,
     ) -> EvalResult<'tcx, (Pointer, u64)> {
         match value {
-            Value::ByRef(PtrAndAlign {
-                      ptr: ref_ptr,
-                      align,
-                  }) => {
+            Value::ByRef(ref_ptr, align) => {
                 self.memory().read_with_align(align, |mem| {
                     let ptr = mem.read_ptr_sized_unsigned(ref_ptr.to_ptr()?)?.into();
                     let len = mem.read_ptr_sized_unsigned(

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -197,7 +197,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             instance,
             span,
             mir,
-            Place::from_ptr(ptr),
+            Place::from_ptr(ptr, layout.align),
             cleanup,
         )?;
         Ok(true)
@@ -273,7 +273,7 @@ impl<'a, 'b, 'tcx, M: Machine<'tcx>> Visitor<'tcx> for ConstantExtractor<'a, 'b,
                         this.instance,
                         constant.span,
                         mir,
-                        Place::from_ptr(ptr),
+                        Place::from_ptr(ptr, layout.align),
                         StackPopCleanup::MarkStatic(Mutability::Immutable),
                     )?;
                     Ok(true)

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -8,7 +8,7 @@ use rustc::mir;
 use rustc::ty::{self, Instance};
 use rustc::ty::layout::LayoutOf;
 use rustc::middle::const_val::ConstVal;
-use rustc::mir::interpret::{PtrAndAlign, GlobalId};
+use rustc::mir::interpret::GlobalId;
 
 use rustc::mir::interpret::{EvalResult, EvalErrorKind};
 use super::{EvalContext, StackPopCleanup, Place, Machine};
@@ -182,13 +182,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             layout.align.abi(),
             None,
         )?;
-        self.tcx.interpret_interner.borrow_mut().cache(
-            cid,
-            PtrAndAlign {
-                ptr: ptr.into(),
-                aligned: !layout.is_packed(),
-            },
-        );
+        self.tcx.interpret_interner.borrow_mut().cache(cid, ptr.into());
         let internally_mutable = !layout.ty.is_freeze(self.tcx, self.param_env, span);
         let mutability = if mutability == Mutability::Mutable || internally_mutable {
             Mutability::Mutable
@@ -273,13 +267,7 @@ impl<'a, 'b, 'tcx, M: Machine<'tcx>> Visitor<'tcx> for ConstantExtractor<'a, 'b,
                         layout.align.abi(),
                         None,
                     )?;
-                    this.ecx.tcx.interpret_interner.borrow_mut().cache(
-                        cid,
-                        PtrAndAlign {
-                            ptr: ptr.into(),
-                            aligned: !layout.is_packed(),
-                        },
-                    );
+                    this.ecx.tcx.interpret_interner.borrow_mut().cache(cid, ptr.into());
                     trace!("pushing stack frame for {:?}", index);
                     this.ecx.push_stack_frame(
                         this.instance,

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -179,7 +179,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         assert!(!layout.is_unsized());
         let ptr = self.memory.allocate(
             layout.size.bytes(),
-            layout.align.abi(),
+            layout.align,
             None,
         )?;
         self.tcx.interpret_interner.borrow_mut().cache(cid, ptr.into());
@@ -264,7 +264,7 @@ impl<'a, 'b, 'tcx, M: Machine<'tcx>> Visitor<'tcx> for ConstantExtractor<'a, 'b,
                     assert!(!layout.is_unsized());
                     let ptr = this.ecx.memory.allocate(
                         layout.size.bytes(),
-                        layout.align.abi(),
+                        layout.align,
                         None,
                     )?;
                     this.ecx.tcx.interpret_interner.borrow_mut().cache(cid, ptr.into());

--- a/src/librustc_mir/interpret/terminator/drop.rs
+++ b/src/librustc_mir/interpret/terminator/drop.rs
@@ -21,16 +21,19 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         let val = match self.force_allocation(place)? {
             Place::Ptr {
                 ptr,
+                align: _,
                 extra: PlaceExtra::Vtable(vtable),
-            } => ptr.ptr.to_value_with_vtable(vtable),
+            } => ptr.to_value_with_vtable(vtable),
             Place::Ptr {
                 ptr,
+                align: _,
                 extra: PlaceExtra::Length(len),
-            } => ptr.ptr.to_value_with_len(len),
+            } => ptr.to_value_with_len(len),
             Place::Ptr {
                 ptr,
+                align: _,
                 extra: PlaceExtra::None,
-            } => ptr.ptr.to_value(),
+            } => ptr.to_value(),
             _ => bug!("force_allocation broken"),
         };
         self.drop(val, instance, ty, span, target)

--- a/src/librustc_mir/interpret/terminator/mod.rs
+++ b/src/librustc_mir/interpret/terminator/mod.rs
@@ -400,9 +400,11 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             // cannot use the shim here, because that will only result in infinite recursion
             ty::InstanceDef::Virtual(_, idx) => {
                 let ptr_size = self.memory.pointer_size();
+                let ptr_align = self.tcx.data_layout.pointer_align;
                 let (ptr, vtable) = self.into_ptr_vtable_pair(args[0].value)?;
                 let fn_ptr = self.memory.read_ptr_sized_unsigned(
-                    vtable.offset(ptr_size * (idx as u64 + 3), &self)?
+                    vtable.offset(ptr_size * (idx as u64 + 3), &self)?,
+                    ptr_align
                 )?.to_ptr()?;
                 let instance = self.memory.get_fn(fn_ptr)?;
                 let mut args = args.to_vec();

--- a/src/librustc_mir/interpret/terminator/mod.rs
+++ b/src/librustc_mir/interpret/terminator/mod.rs
@@ -4,7 +4,7 @@ use rustc::ty::layout::LayoutOf;
 use syntax::codemap::Span;
 use syntax::abi::Abi;
 
-use rustc::mir::interpret::{PtrAndAlign, EvalResult, PrimVal, Value};
+use rustc::mir::interpret::{EvalResult, PrimVal, Value};
 use super::{EvalContext, eval_context,
             Place, Machine, ValTy};
 
@@ -327,14 +327,12 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                         if let ty::TyTuple(..) = args[1].ty.sty {
                             if self.frame().mir.args_iter().count() == layout.fields.count() + 1 {
                                 match args[1].value {
-                                    Value::ByRef(PtrAndAlign { ptr, align }) => {
+                                    Value::ByRef(ptr, align) => {
                                         for (i, arg_local) in arg_locals.enumerate() {
                                             let field = layout.field(&self, i)?;
                                             let offset = layout.fields.offset(i).bytes();
-                                            let arg = Value::ByRef(PtrAndAlign {
-                                                ptr: ptr.offset(offset, &self)?,
-                                                align: align.min(field.align)
-                                            });
+                                            let arg = Value::ByRef(ptr.offset(offset, &self)?,
+                                                                   align.min(field.align));
                                             let dest =
                                                 self.eval_place(&mir::Place::Local(arg_local))?;
                                             trace!(

--- a/src/librustc_mir/interpret/traits.rs
+++ b/src/librustc_mir/interpret/traits.rs
@@ -26,28 +26,29 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         let align = layout.align.abi();
 
         let ptr_size = self.memory.pointer_size();
+        let ptr_align = self.tcx.data_layout.pointer_align;
         let methods = self.tcx.vtable_methods(trait_ref);
         let vtable = self.memory.allocate(
             ptr_size * (3 + methods.len() as u64),
-            ptr_size,
+            ptr_align,
             None,
         )?;
 
         let drop = eval_context::resolve_drop_in_place(self.tcx, ty);
         let drop = self.memory.create_fn_alloc(drop);
-        self.memory.write_ptr_sized_unsigned(vtable, PrimVal::Ptr(drop))?;
+        self.memory.write_ptr_sized_unsigned(vtable, ptr_align, PrimVal::Ptr(drop))?;
 
         let size_ptr = vtable.offset(ptr_size, &self)?;
-        self.memory.write_ptr_sized_unsigned(size_ptr, PrimVal::Bytes(size as u128))?;
+        self.memory.write_ptr_sized_unsigned(size_ptr, ptr_align, PrimVal::Bytes(size as u128))?;
         let align_ptr = vtable.offset(ptr_size * 2, &self)?;
-        self.memory.write_ptr_sized_unsigned(align_ptr, PrimVal::Bytes(align as u128))?;
+        self.memory.write_ptr_sized_unsigned(align_ptr, ptr_align, PrimVal::Bytes(align as u128))?;
 
         for (i, method) in methods.iter().enumerate() {
             if let Some((def_id, substs)) = *method {
                 let instance = self.resolve(def_id, substs)?;
                 let fn_ptr = self.memory.create_fn_alloc(instance);
                 let method_ptr = vtable.offset(ptr_size * (3 + i as u64), &self)?;
-                self.memory.write_ptr_sized_unsigned(method_ptr, PrimVal::Ptr(fn_ptr))?;
+                self.memory.write_ptr_sized_unsigned(method_ptr, ptr_align, PrimVal::Ptr(fn_ptr))?;
             }
         }
 
@@ -64,7 +65,8 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         vtable: MemoryPointer,
     ) -> EvalResult<'tcx, Option<ty::Instance<'tcx>>> {
         // we don't care about the pointee type, we just want a pointer
-        match self.read_ptr(vtable, self.tcx.mk_nil_ptr())? {
+        let pointer_align = self.tcx.data_layout.pointer_align;
+        match self.read_ptr(vtable, pointer_align, self.tcx.mk_nil_ptr())? {
             // some values don't need to call a drop impl, so the value is null
             Value::ByVal(PrimVal::Bytes(0)) => Ok(None),
             Value::ByVal(PrimVal::Ptr(drop_fn)) => self.memory.get_fn(drop_fn).map(Some),
@@ -77,9 +79,11 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         vtable: MemoryPointer,
     ) -> EvalResult<'tcx, (Size, Align)> {
         let pointer_size = self.memory.pointer_size();
-        let size = self.memory.read_ptr_sized_unsigned(vtable.offset(pointer_size, self)?)?.to_bytes()? as u64;
+        let pointer_align = self.tcx.data_layout.pointer_align;
+        let size = self.memory.read_ptr_sized_unsigned(vtable.offset(pointer_size, self)?, pointer_align)?.to_bytes()? as u64;
         let align = self.memory.read_ptr_sized_unsigned(
-            vtable.offset(pointer_size * 2, self)?
+            vtable.offset(pointer_size * 2, self)?,
+            pointer_align
         )?.to_bytes()? as u64;
         Ok((Size::from_bytes(size), Align::from_bytes(align, align).unwrap()))
     }

--- a/src/librustc_trans/abi.rs
+++ b/src/librustc_trans/abi.rs
@@ -30,7 +30,7 @@ use cabi_sparc64;
 use cabi_nvptx;
 use cabi_nvptx64;
 use cabi_hexagon;
-use mir::place::{Alignment, PlaceRef};
+use mir::place::PlaceRef;
 use mir::operand::OperandValue;
 use type_::Type;
 use type_of::{LayoutLlvmExt, PointerKind};
@@ -561,7 +561,7 @@ impl<'a, 'tcx> ArgType<'tcx> {
         }
         let ccx = bcx.ccx;
         if self.is_indirect() {
-            OperandValue::Ref(val, Alignment::AbiAligned).store(bcx, dst)
+            OperandValue::Ref(val, self.layout.align).store(bcx, dst)
         } else if let PassMode::Cast(cast) = self.mode {
             // FIXME(eddyb): Figure out when the simpler Store is safe, clang
             // uses it for i16 -> {i8, i8}, but not for i24 -> {i8, i8, i8}.

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -316,7 +316,7 @@ pub fn coerce_unsized_into<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
 
                 if src_f.layout.ty == dst_f.layout.ty {
                     memcpy_ty(bcx, dst_f.llval, src_f.llval, src_f.layout,
-                        Some(src_f.align.min(dst_f.align)));
+                        src_f.align.min(dst_f.align));
                 } else {
                     coerce_unsized_into(bcx, src_f, dst_f);
                 }
@@ -430,14 +430,13 @@ pub fn memcpy_ty<'a, 'tcx>(
     dst: ValueRef,
     src: ValueRef,
     layout: TyLayout<'tcx>,
-    align: Option<Align>,
+    align: Align,
 ) {
     let size = layout.size.bytes();
     if size == 0 {
         return;
     }
 
-    let align = align.unwrap_or(layout.align);
     call_memcpy(bcx, dst, src, C_usize(bcx.ccx, size), align);
 }
 

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -316,7 +316,7 @@ pub fn coerce_unsized_into<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
 
                 if src_f.layout.ty == dst_f.layout.ty {
                     memcpy_ty(bcx, dst_f.llval, src_f.llval, src_f.layout,
-                        (src_f.alignment | dst_f.alignment).non_abi());
+                        Some(src_f.align.min(dst_f.align)));
                 } else {
                     coerce_unsized_into(bcx, src_f, dst_f);
                 }

--- a/src/librustc_trans/builder.rs
+++ b/src/librustc_trans/builder.rs
@@ -518,13 +518,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         }
     }
 
-    pub fn load(&self, ptr: ValueRef, align: Option<Align>) -> ValueRef {
+    pub fn load(&self, ptr: ValueRef, align: Align) -> ValueRef {
         self.count_insn("load");
         unsafe {
             let load = llvm::LLVMBuildLoad(self.llbuilder, ptr, noname());
-            if let Some(align) = align {
-                llvm::LLVMSetAlignment(load, align.abi() as c_uint);
-            }
+            llvm::LLVMSetAlignment(load, align.abi() as c_uint);
             load
         }
     }
@@ -573,16 +571,14 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         }
     }
 
-    pub fn store(&self, val: ValueRef, ptr: ValueRef, align: Option<Align>) -> ValueRef {
+    pub fn store(&self, val: ValueRef, ptr: ValueRef, align: Align) -> ValueRef {
         debug!("Store {:?} -> {:?}", Value(val), Value(ptr));
         assert!(!self.llbuilder.is_null());
         self.count_insn("store");
         let ptr = self.check_store(val, ptr);
         unsafe {
             let store = llvm::LLVMBuildStore(self.llbuilder, val, ptr);
-            if let Some(align) = align {
-                llvm::LLVMSetAlignment(store, align.abi() as c_uint);
-            }
+            llvm::LLVMSetAlignment(store, align.abi() as c_uint);
             store
         }
     }

--- a/src/librustc_trans/intrinsic.rs
+++ b/src/librustc_trans/intrinsic.rs
@@ -254,7 +254,7 @@ pub fn trans_intrinsic_call<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
                 bcx.volatile_store(b, dst.project_field(bcx, 1).llval);
             } else {
                 let val = if let OperandValue::Ref(ptr, align) = args[1].val {
-                    bcx.load(ptr, Some(align))
+                    bcx.load(ptr, align)
                 } else {
                     if dst.layout.is_zst() {
                         return;
@@ -330,9 +330,9 @@ pub fn trans_intrinsic_call<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
                             let overflow = bcx.zext(bcx.extract_value(pair, 1), Type::bool(ccx));
 
                             let dest = result.project_field(bcx, 0);
-                            bcx.store(val, dest.llval, dest.non_abi_align());
+                            bcx.store(val, dest.llval, dest.align);
                             let dest = result.project_field(bcx, 1);
-                            bcx.store(overflow, dest.llval, dest.non_abi_align());
+                            bcx.store(overflow, dest.llval, dest.align);
 
                             return;
                         },
@@ -473,9 +473,9 @@ pub fn trans_intrinsic_call<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
                         let success = bcx.zext(bcx.extract_value(pair, 1), Type::bool(bcx.ccx));
 
                         let dest = result.project_field(bcx, 0);
-                        bcx.store(val, dest.llval, dest.non_abi_align());
+                        bcx.store(val, dest.llval, dest.align);
                         let dest = result.project_field(bcx, 1);
-                        bcx.store(success, dest.llval, dest.non_abi_align());
+                        bcx.store(success, dest.llval, dest.align);
                         return;
                     } else {
                         return invalid_monomorphization(ty);
@@ -544,7 +544,7 @@ pub fn trans_intrinsic_call<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
             let tp_ty = substs.type_at(0);
             let dst = args[0].deref(bcx.ccx);
             let val = if let OperandValue::Ref(ptr, align) = args[1].val {
-                bcx.load(ptr, Some(align))
+                bcx.load(ptr, align)
             } else {
                 from_immediate(bcx, args[1].immediate())
             };
@@ -677,7 +677,7 @@ pub fn trans_intrinsic_call<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
                     for i in 0..elems.len() {
                         let dest = result.project_field(bcx, i);
                         let val = bcx.extract_value(val, i as u64);
-                        bcx.store(val, dest.llval, dest.non_abi_align());
+                        bcx.store(val, dest.llval, dest.align);
                     }
                     return;
                 }
@@ -688,8 +688,8 @@ pub fn trans_intrinsic_call<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
 
     if !fn_ty.ret.is_ignore() {
         if let PassMode::Cast(ty) = fn_ty.ret.mode {
-            let ptr = bcx.pointercast(llresult, ty.llvm_type(ccx).ptr_to());
-            bcx.store(llval, ptr, Some(ccx.align_of(ret_ty)));
+            let ptr = bcx.pointercast(result.llval, ty.llvm_type(ccx).ptr_to());
+            bcx.store(llval, ptr, result.align);
         } else {
             OperandRef::from_immediate_or_packed_pair(bcx, llval, result.layout)
                 .val.store(bcx, result);
@@ -758,7 +758,8 @@ fn try_intrinsic<'a, 'tcx>(
 ) {
     if bcx.sess().no_landing_pads() {
         bcx.call(func, &[data], None);
-        bcx.store(C_null(Type::i8p(&bcx.ccx)), dest, None);
+        let ptr_align = bcx.tcx().data_layout.pointer_align;
+        bcx.store(C_null(Type::i8p(&bcx.ccx)), dest, ptr_align);
     } else if wants_msvc_seh(bcx.sess()) {
         trans_msvc_try(bcx, ccx, func, data, local_ptr, dest);
     } else {
@@ -833,7 +834,8 @@ fn trans_msvc_try<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
         //
         // More information can be found in libstd's seh.rs implementation.
         let i64p = Type::i64(ccx).ptr_to();
-        let slot = bcx.alloca(i64p, "slot", ccx.data_layout().pointer_align);
+        let ptr_align = bcx.tcx().data_layout.pointer_align;
+        let slot = bcx.alloca(i64p, "slot", ptr_align);
         bcx.invoke(func, &[data], normal.llbb(), catchswitch.llbb(),
             None);
 
@@ -848,13 +850,15 @@ fn trans_msvc_try<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
             None => bug!("msvc_try_filter not defined"),
         };
         let tok = catchpad.catch_pad(cs, &[tydesc, C_i32(ccx, 0), slot]);
-        let addr = catchpad.load(slot, None);
-        let arg1 = catchpad.load(addr, None);
+        let addr = catchpad.load(slot, ptr_align);
+
+        let i64_align = bcx.tcx().data_layout.i64_align;
+        let arg1 = catchpad.load(addr, i64_align);
         let val1 = C_i32(ccx, 1);
-        let arg2 = catchpad.load(catchpad.inbounds_gep(addr, &[val1]), None);
+        let arg2 = catchpad.load(catchpad.inbounds_gep(addr, &[val1]), i64_align);
         let local_ptr = catchpad.bitcast(local_ptr, i64p);
-        catchpad.store(arg1, local_ptr, None);
-        catchpad.store(arg2, catchpad.inbounds_gep(local_ptr, &[val1]), None);
+        catchpad.store(arg1, local_ptr, i64_align);
+        catchpad.store(arg2, catchpad.inbounds_gep(local_ptr, &[val1]), i64_align);
         catchpad.catch_ret(tok, caught.llbb());
 
         caught.ret(C_i32(ccx, 1));
@@ -863,7 +867,8 @@ fn trans_msvc_try<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
     // Note that no invoke is used here because by definition this function
     // can't panic (that's what it's catching).
     let ret = bcx.call(llfn, &[func, data, local_ptr], None);
-    bcx.store(ret, dest, None);
+    let i32_align = bcx.tcx().data_layout.i32_align;
+    bcx.store(ret, dest, i32_align);
 }
 
 // Definition of the standard "try" function for Rust using the GNU-like model
@@ -923,14 +928,16 @@ fn trans_gnu_try<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
         let vals = catch.landing_pad(lpad_ty, bcx.ccx.eh_personality(), 1, catch.llfn());
         catch.add_clause(vals, C_null(Type::i8p(ccx)));
         let ptr = catch.extract_value(vals, 0);
-        catch.store(ptr, catch.bitcast(local_ptr, Type::i8p(ccx).ptr_to()), None);
+        let ptr_align = bcx.tcx().data_layout.pointer_align;
+        catch.store(ptr, catch.bitcast(local_ptr, Type::i8p(ccx).ptr_to()), ptr_align);
         catch.ret(C_i32(ccx, 1));
     });
 
     // Note that no invoke is used here because by definition this function
     // can't panic (that's what it's catching).
     let ret = bcx.call(llfn, &[func, data, local_ptr], None);
-    bcx.store(ret, dest, None);
+    let i32_align = bcx.tcx().data_layout.i32_align;
+    bcx.store(ret, dest, i32_align);
 }
 
 // Helper function to give a Block to a closure to translate a shim function.

--- a/src/librustc_trans/meth.rs
+++ b/src/librustc_trans/meth.rs
@@ -40,7 +40,8 @@ impl<'a, 'tcx> VirtualIndex {
         debug!("get_fn({:?}, {:?})", Value(llvtable), self);
 
         let llvtable = bcx.pointercast(llvtable, fn_ty.llvm_type(bcx.ccx).ptr_to().ptr_to());
-        let ptr = bcx.load(bcx.inbounds_gep(llvtable, &[C_usize(bcx.ccx, self.0)]), None);
+        let ptr_align = bcx.tcx().data_layout.pointer_align;
+        let ptr = bcx.load(bcx.inbounds_gep(llvtable, &[C_usize(bcx.ccx, self.0)]), ptr_align);
         bcx.nonnull_metadata(ptr);
         // Vtable loads are invariant
         bcx.set_invariant_load(ptr);
@@ -52,7 +53,8 @@ impl<'a, 'tcx> VirtualIndex {
         debug!("get_int({:?}, {:?})", Value(llvtable), self);
 
         let llvtable = bcx.pointercast(llvtable, Type::isize(bcx.ccx).ptr_to());
-        let ptr = bcx.load(bcx.inbounds_gep(llvtable, &[C_usize(bcx.ccx, self.0)]), None);
+        let usize_align = bcx.tcx().data_layout.pointer_align;
+        let ptr = bcx.load(bcx.inbounds_gep(llvtable, &[C_usize(bcx.ccx, self.0)]), usize_align);
         // Vtable loads are invariant
         bcx.set_invariant_load(ptr);
         ptr

--- a/src/librustc_trans/mir/block.rs
+++ b/src/librustc_trans/mir/block.rs
@@ -31,7 +31,7 @@ use syntax_pos::Pos;
 
 use super::{MirContext, LocalRef};
 use super::constant::Const;
-use super::place::{Alignment, PlaceRef};
+use super::place::PlaceRef;
 use super::operand::OperandRef;
 use super::operand::OperandValue::{Pair, Ref, Immediate};
 
@@ -216,7 +216,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                     PassMode::Direct(_) | PassMode::Pair(..) => {
                         let op = self.trans_consume(&bcx, &mir::Place::Local(mir::RETURN_PLACE));
                         if let Ref(llval, align) = op.val {
-                            bcx.load(llval, align.non_abi())
+                            bcx.load(llval, Some(align))
                         } else {
                             op.immediate_or_packed_pair(&bcx)
                         }
@@ -228,7 +228,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                             LocalRef::Operand(None) => bug!("use of return before def"),
                             LocalRef::Place(tr_place) => {
                                 OperandRef {
-                                    val: Ref(tr_place.llval, tr_place.alignment),
+                                    val: Ref(tr_place.llval, tr_place.align),
                                     layout: tr_place.layout
                                 }
                             }
@@ -240,7 +240,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                                 scratch.llval
                             }
                             Ref(llval, align) => {
-                                assert_eq!(align, Alignment::AbiAligned,
+                                assert_eq!(align.abi(), op.layout.align.abi(),
                                            "return place is unaligned!");
                                 llval
                             }
@@ -579,7 +579,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                         (&mir::Operand::Constant(_), Ref(..)) => {
                             let tmp = PlaceRef::alloca(&bcx, op.layout, "const");
                             op.val.store(&bcx, tmp);
-                            op.val = Ref(tmp.llval, tmp.alignment);
+                            op.val = Ref(tmp.llval, tmp.align);
                         }
                         _ => {}
                     }
@@ -639,38 +639,40 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                     PassMode::Indirect(_) | PassMode::Cast(_) => {
                         let scratch = PlaceRef::alloca(bcx, arg.layout, "arg");
                         op.val.store(bcx, scratch);
-                        (scratch.llval, Alignment::AbiAligned, true)
+                        (scratch.llval, scratch.align, true)
                     }
                     _ => {
-                        (op.immediate_or_packed_pair(bcx), Alignment::AbiAligned, false)
+                        (op.immediate_or_packed_pair(bcx), arg.layout.align, false)
                     }
                 }
             }
-            Ref(llval, align @ Alignment::Packed(_)) if arg.is_indirect() => {
-                // `foo(packed.large_field)`. We can't pass the (unaligned) field directly. I
-                // think that ATM (Rust 1.16) we only pass temporaries, but we shouldn't
-                // have scary latent bugs around.
+            Ref(llval, align) => {
+                if arg.is_indirect() && align.abi() < arg.layout.align.abi() {
+                    // `foo(packed.large_field)`. We can't pass the (unaligned) field directly. I
+                    // think that ATM (Rust 1.16) we only pass temporaries, but we shouldn't
+                    // have scary latent bugs around.
 
-                let scratch = PlaceRef::alloca(bcx, arg.layout, "arg");
-                base::memcpy_ty(bcx, scratch.llval, llval, op.layout, align.non_abi());
-                (scratch.llval, Alignment::AbiAligned, true)
+                    let scratch = PlaceRef::alloca(bcx, arg.layout, "arg");
+                    base::memcpy_ty(bcx, scratch.llval, llval, op.layout, Some(align));
+                    (scratch.llval, scratch.align, true)
+                } else {
+                    (llval, align, true)
+                }
             }
-            Ref(llval, align) => (llval, align, true)
         };
 
         if by_ref && !arg.is_indirect() {
             // Have to load the argument, maybe while casting it.
             if let PassMode::Cast(ty) = arg.mode {
                 llval = bcx.load(bcx.pointercast(llval, ty.llvm_type(bcx.ccx).ptr_to()),
-                                 (align | Alignment::Packed(arg.layout.align))
-                                    .non_abi());
+                                 Some(align.min(arg.layout.align)));
             } else {
                 // We can't use `PlaceRef::load` here because the argument
                 // may have a type we don't treat as immediate, but the ABI
                 // used for this call is passing it by-value. In that case,
                 // the load would just produce `OperandValue::Ref` instead
                 // of the `OperandValue::Immediate` we need for the call.
-                llval = bcx.load(llval, align.non_abi());
+                llval = bcx.load(llval, Some(align));
                 if let layout::Abi::Scalar(ref scalar) = arg.layout.abi {
                     if scalar.is_bool() {
                         bcx.range_metadata(llval, 0..2);
@@ -820,21 +822,17 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
             self.trans_place(bcx, dest)
         };
         if fn_ret.is_indirect() {
-            match dest.alignment {
-                Alignment::AbiAligned => {
-                    llargs.push(dest.llval);
-                    ReturnDest::Nothing
-                },
-                Alignment::Packed(_) => {
-                    // Currently, MIR code generation does not create calls
-                    // that store directly to fields of packed structs (in
-                    // fact, the calls it creates write only to temps),
-                    //
-                    // If someone changes that, please update this code path
-                    // to create a temporary.
-                    span_bug!(self.mir.span, "can't directly store to unaligned value");
-                }
+            if dest.align.abi() < dest.layout.align.abi() {
+                // Currently, MIR code generation does not create calls
+                // that store directly to fields of packed structs (in
+                // fact, the calls it creates write only to temps),
+                //
+                // If someone changes that, please update this code path
+                // to create a temporary.
+                span_bug!(self.mir.span, "can't directly store to unaligned value");
             }
+            llargs.push(dest.llval);
+            ReturnDest::Nothing
         } else {
             ReturnDest::Store(dest)
         }
@@ -874,8 +872,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
         let llty = src.layout.llvm_type(bcx.ccx);
         let cast_ptr = bcx.pointercast(dst.llval, llty.ptr_to());
         let align = src.layout.align.min(dst.layout.align);
-        src.val.store(bcx,
-            PlaceRef::new_sized(cast_ptr, src.layout, Alignment::Packed(align)));
+        src.val.store(bcx, PlaceRef::new_sized(cast_ptr, src.layout, align));
     }
 
 

--- a/src/librustc_trans/mir/constant.rs
+++ b/src/librustc_trans/mir/constant.rs
@@ -1134,12 +1134,14 @@ fn trans_const_adt<'a, 'tcx>(
             if let layout::FieldPlacement::Union(_) = l.fields {
                 assert_eq!(variant_index, 0);
                 assert_eq!(vals.len(), 1);
+                let (field_size, field_align) = ccx.size_and_align_of(vals[0].ty);
                 let contents = [
                     vals[0].llval,
-                    padding(ccx, l.size - ccx.size_of(vals[0].ty))
+                    padding(ccx, l.size - field_size)
                 ];
 
-                Const::new(C_struct(ccx, &contents, l.is_packed()), t)
+                let packed = l.align.abi() < field_align.abi();
+                Const::new(C_struct(ccx, &contents, packed), t)
             } else {
                 if let layout::Abi::Vector { .. } = l.abi {
                     if let layout::FieldPlacement::Array { .. } = l.fields {
@@ -1232,28 +1234,33 @@ fn build_const_struct<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     }
 
     // offset of current value
+    let mut packed = false;
     let mut offset = Size::from_bytes(0);
     let mut cfields = Vec::new();
     cfields.reserve(discr.is_some() as usize + 1 + layout.fields.count() * 2);
 
     if let Some(discr) = discr {
+        let (field_size, field_align) = ccx.size_and_align_of(discr.ty);
+        packed |= layout.align.abi() < field_align.abi();
         cfields.push(discr.llval);
-        offset = ccx.size_of(discr.ty);
+        offset = field_size;
     }
 
     let parts = layout.fields.index_by_increasing_offset().map(|i| {
         (vals[i], layout.fields.offset(i))
     });
     for (val, target_offset) in parts {
+        let (field_size, field_align) = ccx.size_and_align_of(val.ty);
+        packed |= layout.align.abi() < field_align.abi();
         cfields.push(padding(ccx, target_offset - offset));
         cfields.push(val.llval);
-        offset = target_offset + ccx.size_of(val.ty);
+        offset = target_offset + field_size;
     }
 
     // Pad to the size of the whole type, not e.g. the variant.
     cfields.push(padding(ccx, ccx.size_of(layout.ty) - offset));
 
-    Const::new(C_struct(ccx, &cfields, layout.is_packed()), layout.ty)
+    Const::new(C_struct(ccx, &cfields, packed), layout.ty)
 }
 
 fn padding(ccx: &CrateContext, size: Size) -> ValueRef {

--- a/src/librustc_trans/mir/constant.rs
+++ b/src/librustc_trans/mir/constant.rs
@@ -42,7 +42,6 @@ use syntax::ast;
 use std::fmt;
 use std::ptr;
 
-use super::place::Alignment;
 use super::operand::{OperandRef, OperandValue};
 use super::MirContext;
 
@@ -182,12 +181,12 @@ impl<'a, 'tcx> Const<'tcx> {
             let align = ccx.align_of(self.ty);
             let ptr = consts::addr_of(ccx, self.llval, align, "const");
             OperandValue::Ref(consts::ptrcast(ptr, layout.llvm_type(ccx).ptr_to()),
-                              Alignment::AbiAligned)
+                              layout.align)
         };
 
         OperandRef {
             val,
-            layout: ccx.layout_of(self.ty)
+            layout
         }
     }
 }

--- a/src/librustc_trans/mir/mod.rs
+++ b/src/librustc_trans/mir/mod.rs
@@ -35,7 +35,7 @@ use rustc_data_structures::indexed_vec::{IndexVec, Idx};
 pub use self::constant::trans_static_initializer;
 
 use self::analyze::CleanupKind;
-use self::place::{Alignment, PlaceRef};
+use self::place::PlaceRef;
 use rustc::mir::traversal;
 
 use self::operand::{OperandRef, OperandValue};
@@ -279,9 +279,7 @@ pub fn trans_mir<'a, 'tcx: 'a>(
                 if local == mir::RETURN_PLACE && mircx.fn_ty.ret.is_indirect() {
                     debug!("alloc: {:?} (return place) -> place", local);
                     let llretptr = llvm::get_param(llfn, 0);
-                    LocalRef::Place(PlaceRef::new_sized(llretptr,
-                                                          layout,
-                                                          Alignment::AbiAligned))
+                    LocalRef::Place(PlaceRef::new_sized(llretptr, layout, layout.align))
                 } else if memory_locals.contains(local.index()) {
                     debug!("alloc: {:?} -> place", local);
                     LocalRef::Place(PlaceRef::alloca(&bcx, layout, &format!("{:?}", local)))
@@ -474,7 +472,7 @@ fn arg_local_refs<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
             let llarg = llvm::get_param(bcx.llfn(), llarg_idx as c_uint);
             bcx.set_value_name(llarg, &name);
             llarg_idx += 1;
-            PlaceRef::new_sized(llarg, arg.layout, Alignment::AbiAligned)
+            PlaceRef::new_sized(llarg, arg.layout, arg.layout.align)
         } else {
             let tmp = PlaceRef::alloca(bcx, arg.layout, &name);
             arg.store_fn_arg(bcx, &mut llarg_idx, tmp);

--- a/src/librustc_trans/mir/mod.rs
+++ b/src/librustc_trans/mir/mod.rs
@@ -530,11 +530,11 @@ fn arg_local_refs<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
             // doesn't actually strip the offset when splitting the closure
             // environment into its components so it ends up out of bounds.
             let env_ptr = if !env_ref {
-                let alloc = PlaceRef::alloca(bcx,
+                let scratch = PlaceRef::alloca(bcx,
                     bcx.ccx.layout_of(tcx.mk_mut_ptr(arg.layout.ty)),
                     "__debuginfo_env_ptr");
-                bcx.store(place.llval, alloc.llval, None);
-                alloc.llval
+                bcx.store(place.llval, scratch.llval, scratch.align);
+                scratch.llval
             } else {
                 place.llval
             };

--- a/src/librustc_trans/mir/operand.rs
+++ b/src/librustc_trans/mir/operand.rs
@@ -10,7 +10,7 @@
 
 use llvm::ValueRef;
 use rustc::ty;
-use rustc::ty::layout::{self, LayoutOf, TyLayout};
+use rustc::ty::layout::{self, Align, LayoutOf, TyLayout};
 use rustc::mir;
 use rustc_data_structures::indexed_vec::Idx;
 
@@ -25,7 +25,7 @@ use std::fmt;
 use std::ptr;
 
 use super::{MirContext, LocalRef};
-use super::place::{Alignment, PlaceRef};
+use super::place::PlaceRef;
 
 /// The representation of a Rust value. The enum variant is in fact
 /// uniquely determined by the value's type, but is kept as a
@@ -34,7 +34,7 @@ use super::place::{Alignment, PlaceRef};
 pub enum OperandValue {
     /// A reference to the actual operand. The data is guaranteed
     /// to be valid for the operand's lifetime.
-    Ref(ValueRef, Alignment),
+    Ref(ValueRef, Align),
     /// A single LLVM value.
     Immediate(ValueRef),
     /// A pair of immediate LLVM values. Used by fat pointers too.
@@ -107,11 +107,12 @@ impl<'a, 'tcx> OperandRef<'tcx> {
             OperandValue::Pair(llptr, llextra) => (llptr, llextra),
             OperandValue::Ref(..) => bug!("Deref of by-Ref operand {:?}", self)
         };
+        let layout = ccx.layout_of(projected_ty);
         PlaceRef {
             llval: llptr,
             llextra,
-            layout: ccx.layout_of(projected_ty),
-            alignment: Alignment::AbiAligned,
+            layout,
+            align: layout.align,
         }
     }
 
@@ -222,9 +223,9 @@ impl<'a, 'tcx> OperandValue {
         match self {
             OperandValue::Ref(r, source_align) =>
                 base::memcpy_ty(bcx, dest.llval, r, dest.layout,
-                                (source_align | dest.alignment).non_abi()),
+                                Some(source_align.min(dest.align))),
             OperandValue::Immediate(s) => {
-                bcx.store(base::from_immediate(bcx, s), dest.llval, dest.alignment.non_abi());
+                bcx.store(base::from_immediate(bcx, s), dest.llval, dest.non_abi_align());
             }
             OperandValue::Pair(a, b) => {
                 for (i, &x) in [a, b].iter().enumerate() {
@@ -233,7 +234,7 @@ impl<'a, 'tcx> OperandValue {
                     if common::val_ty(x) == Type::i1(bcx.ccx) {
                         llptr = bcx.pointercast(llptr, Type::i8p(bcx.ccx));
                     }
-                    bcx.store(base::from_immediate(bcx, x), llptr, dest.alignment.non_abi());
+                    bcx.store(base::from_immediate(bcx, x), llptr, dest.non_abi_align());
                 }
             }
         }

--- a/src/librustc_trans/mir/operand.rs
+++ b/src/librustc_trans/mir/operand.rs
@@ -223,9 +223,9 @@ impl<'a, 'tcx> OperandValue {
         match self {
             OperandValue::Ref(r, source_align) =>
                 base::memcpy_ty(bcx, dest.llval, r, dest.layout,
-                                Some(source_align.min(dest.align))),
+                                source_align.min(dest.align)),
             OperandValue::Immediate(s) => {
-                bcx.store(base::from_immediate(bcx, s), dest.llval, dest.non_abi_align());
+                bcx.store(base::from_immediate(bcx, s), dest.llval, dest.align);
             }
             OperandValue::Pair(a, b) => {
                 for (i, &x) in [a, b].iter().enumerate() {
@@ -234,7 +234,7 @@ impl<'a, 'tcx> OperandValue {
                     if common::val_ty(x) == Type::i1(bcx.ccx) {
                         llptr = bcx.pointercast(llptr, Type::i8p(bcx.ccx));
                     }
-                    bcx.store(base::from_immediate(bcx, x), llptr, dest.non_abi_align());
+                    bcx.store(base::from_immediate(bcx, x), llptr, dest.align);
                 }
             }
         }

--- a/src/librustc_trans/mir/place.rs
+++ b/src/librustc_trans/mir/place.rs
@@ -24,49 +24,9 @@ use value::Value;
 use glue;
 
 use std::ptr;
-use std::ops;
 
 use super::{MirContext, LocalRef};
 use super::operand::{OperandRef, OperandValue};
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum Alignment {
-    Packed(Align),
-    AbiAligned,
-}
-
-impl ops::BitOr for Alignment {
-    type Output = Self;
-
-    fn bitor(self, rhs: Self) -> Self {
-        match (self, rhs) {
-            (Alignment::Packed(a), Alignment::Packed(b)) => {
-                Alignment::Packed(a.min(b))
-            }
-            (Alignment::Packed(x), _) | (_, Alignment::Packed(x)) => {
-                Alignment::Packed(x)
-            }
-            (Alignment::AbiAligned, Alignment::AbiAligned) => {
-                Alignment::AbiAligned
-            }
-        }
-    }
-}
-
-impl<'a> From<TyLayout<'a>> for Alignment {
-    fn from(layout: TyLayout) -> Self {
-        Alignment::Packed(layout.align)
-    }
-}
-
-impl Alignment {
-    pub fn non_abi(self) -> Option<Align> {
-        match self {
-            Alignment::Packed(x) => Some(x),
-            Alignment::AbiAligned => None,
-        }
-    }
-}
 
 #[derive(Copy, Clone, Debug)]
 pub struct PlaceRef<'tcx> {
@@ -79,20 +39,20 @@ pub struct PlaceRef<'tcx> {
     /// Monomorphized type of this place, including variant information
     pub layout: TyLayout<'tcx>,
 
-    /// Whether this place is known to be aligned according to its layout
-    pub alignment: Alignment,
+    /// What alignment we know for this place
+    pub align: Align,
 }
 
 impl<'a, 'tcx> PlaceRef<'tcx> {
     pub fn new_sized(llval: ValueRef,
                      layout: TyLayout<'tcx>,
-                     alignment: Alignment)
+                     align: Align)
                      -> PlaceRef<'tcx> {
         PlaceRef {
             llval,
             llextra: ptr::null_mut(),
             layout,
-            alignment
+            align
         }
     }
 
@@ -100,7 +60,7 @@ impl<'a, 'tcx> PlaceRef<'tcx> {
                   -> PlaceRef<'tcx> {
         debug!("alloca({:?}: {:?})", name, layout);
         let tmp = bcx.alloca(layout.llvm_type(bcx.ccx), name, layout.align);
-        Self::new_sized(tmp, layout, Alignment::AbiAligned)
+        Self::new_sized(tmp, layout, layout.align)
     }
 
     pub fn len(&self, ccx: &CrateContext<'a, 'tcx>) -> ValueRef {
@@ -119,6 +79,14 @@ impl<'a, 'tcx> PlaceRef<'tcx> {
 
     pub fn has_extra(&self) -> bool {
         !self.llextra.is_null()
+    }
+
+    pub fn non_abi_align(self) -> Option<Align> {
+        if self.align.abi() >= self.layout.align.abi() {
+            None
+        } else {
+            Some(self.align)
+        }
     }
 
     pub fn load(&self, bcx: &Builder<'a, 'tcx>) -> OperandRef<'tcx> {
@@ -167,7 +135,7 @@ impl<'a, 'tcx> PlaceRef<'tcx> {
             let llval = if !const_llval.is_null() {
                 const_llval
             } else {
-                let load = bcx.load(self.llval, self.alignment.non_abi());
+                let load = bcx.load(self.llval, self.non_abi_align());
                 if let layout::Abi::Scalar(ref scalar) = self.layout.abi {
                     scalar_load_metadata(load, scalar);
                 }
@@ -181,7 +149,7 @@ impl<'a, 'tcx> PlaceRef<'tcx> {
                 if scalar.is_bool() {
                     llptr = bcx.pointercast(llptr, Type::i8p(bcx.ccx));
                 }
-                let load = bcx.load(llptr, self.alignment.non_abi());
+                let load = bcx.load(llptr, self.non_abi_align());
                 scalar_load_metadata(load, scalar);
                 if scalar.is_bool() {
                     bcx.trunc(load, Type::i1(bcx.ccx))
@@ -191,7 +159,7 @@ impl<'a, 'tcx> PlaceRef<'tcx> {
             };
             OperandValue::Pair(load(0, a), load(1, b))
         } else {
-            OperandValue::Ref(self.llval, self.alignment)
+            OperandValue::Ref(self.llval, self.align)
         };
 
         OperandRef { val, layout: self.layout }
@@ -202,7 +170,7 @@ impl<'a, 'tcx> PlaceRef<'tcx> {
         let ccx = bcx.ccx;
         let field = self.layout.field(ccx, ix);
         let offset = self.layout.fields.offset(ix);
-        let alignment = self.alignment | Alignment::from(self.layout);
+        let align = self.align.min(self.layout.align).min(field.align);
 
         let simple = || {
             // Unions and newtypes only use an offset of 0.
@@ -224,7 +192,7 @@ impl<'a, 'tcx> PlaceRef<'tcx> {
                     ptr::null_mut()
                 },
                 layout: field,
-                alignment,
+                align,
             }
         };
 
@@ -271,7 +239,7 @@ impl<'a, 'tcx> PlaceRef<'tcx> {
         let unaligned_offset = C_usize(ccx, offset.bytes());
 
         // Get the alignment of the field
-        let (_, align) = glue::size_and_align_of_dst(bcx, field.ty, meta);
+        let (_, unsized_align) = glue::size_and_align_of_dst(bcx, field.ty, meta);
 
         // Bump the unaligned offset up to the appropriate alignment using the
         // following expression:
@@ -279,9 +247,9 @@ impl<'a, 'tcx> PlaceRef<'tcx> {
         //   (unaligned offset + (align - 1)) & -align
 
         // Calculate offset
-        let align_sub_1 = bcx.sub(align, C_usize(ccx, 1u64));
+        let align_sub_1 = bcx.sub(unsized_align, C_usize(ccx, 1u64));
         let offset = bcx.and(bcx.add(unaligned_offset, align_sub_1),
-        bcx.neg(align));
+        bcx.neg(unsized_align));
 
         debug!("struct_field_ptr: DST field offset: {:?}", Value(offset));
 
@@ -297,7 +265,7 @@ impl<'a, 'tcx> PlaceRef<'tcx> {
             llval: bcx.pointercast(byte_ptr, ll_fty.ptr_to()),
             llextra: self.llextra,
             layout: field,
-            alignment,
+            align,
         }
     }
 
@@ -370,7 +338,7 @@ impl<'a, 'tcx> PlaceRef<'tcx> {
                     .discriminant_for_variant(bcx.tcx(), variant_index)
                     .to_u128_unchecked() as u64;
                 bcx.store(C_int(ptr.layout.llvm_type(bcx.ccx), to as i64),
-                    ptr.llval, ptr.alignment.non_abi());
+                    ptr.llval, ptr.non_abi_align());
             }
             layout::Variants::NicheFilling {
                 dataful_variant,
@@ -414,7 +382,7 @@ impl<'a, 'tcx> PlaceRef<'tcx> {
             llval: bcx.inbounds_gep(self.llval, &[C_usize(bcx.ccx, 0), llindex]),
             llextra: ptr::null_mut(),
             layout: self.layout.field(bcx.ccx, 0),
-            alignment: self.alignment
+            align: self.align
         }
     }
 
@@ -463,9 +431,8 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
         let result = match *place {
             mir::Place::Local(_) => bug!(), // handled above
             mir::Place::Static(box mir::Static { def_id, ty }) => {
-                PlaceRef::new_sized(consts::get_static(ccx, def_id),
-                                     ccx.layout_of(self.monomorphize(&ty)),
-                                     Alignment::AbiAligned)
+                let layout = ccx.layout_of(self.monomorphize(&ty));
+                PlaceRef::new_sized(consts::get_static(ccx, def_id), layout, layout.align)
             },
             mir::Place::Projection(box mir::Projection {
                 ref base,

--- a/src/librustc_trans/mir/rvalue.rs
+++ b/src/librustc_trans/mir/rvalue.rs
@@ -104,9 +104,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 let start = dest.project_index(&bcx, C_usize(bcx.ccx, 0)).llval;
 
                 if let OperandValue::Immediate(v) = tr_elem.val {
-                    let align = dest.non_abi_align()
-                        .unwrap_or(tr_elem.layout.align);
-                    let align = C_i32(bcx.ccx, align.abi() as i32);
+                    let align = C_i32(bcx.ccx, dest.align.abi() as i32);
                     let size = C_usize(bcx.ccx, dest.layout.size.bytes());
 
                     // Use llvm.memset.p0i8.* to initialize all zero arrays

--- a/src/librustc_trans/mir/rvalue.rs
+++ b/src/librustc_trans/mir/rvalue.rs
@@ -104,7 +104,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 let start = dest.project_index(&bcx, C_usize(bcx.ccx, 0)).llval;
 
                 if let OperandValue::Immediate(v) = tr_elem.val {
-                    let align = dest.alignment.non_abi()
+                    let align = dest.non_abi_align()
                         .unwrap_or(tr_elem.layout.align);
                     let align = C_i32(bcx.ccx, align.abi() as i32);
                     let size = C_usize(bcx.ccx, dest.layout.size.bytes());
@@ -139,7 +139,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 header_bcx.cond_br(keep_going, body_bcx.llbb(), next_bcx.llbb());
 
                 tr_elem.val.store(&body_bcx,
-                    PlaceRef::new_sized(current, tr_elem.layout, dest.alignment));
+                    PlaceRef::new_sized(current, tr_elem.layout, dest.align));
 
                 let next = body_bcx.inbounds_gep(current, &[C_usize(bcx.ccx, 1)]);
                 body_bcx.br(header_bcx.llbb());

--- a/src/tools/toolstate.toml
+++ b/src/tools/toolstate.toml
@@ -23,7 +23,7 @@
 # Each tool has a list of people to ping
 
 # ping @oli-obk @RalfJung @eddyb
-miri = "Testing"
+miri = "Broken"
 
 # ping @Manishearth @llogiq @mcarton @oli-obk
 clippy = "Testing"


### PR DESCRIPTION
Closes #46423. cc @oli-obk