### PR TITLE
Don't set the linkage_name for static variables

### DIFF
--- a/src/librustc_trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/debuginfo/metadata.rs
@@ -42,7 +42,7 @@ use std::ffi::CString;
 use std::fmt::Write;
 use std::ptr;
 use std::path::{Path, PathBuf};
-use syntax::ast;
+use syntax::{ast, attr};
 use syntax::symbol::{Interner, InternedString, Symbol};
 use syntax_pos::{self, Span, FileName};
 
@@ -1643,8 +1643,10 @@ pub fn create_global_var_metadata(cx: &CrateContext,
     }
 
     let tcx = cx.tcx();
-
     let node_def_id = tcx.hir.local_def_id(node_id);
+    let no_mangle = attr::contains_name(&tcx.get_attrs(node_def_id), "no_mangle");
+    // We may want to remove the namespace scope if we're in an extern block, see:
+    // https://github.com/rust-lang/rust/pull/46457#issuecomment-351750952
     let var_scope = get_namespace_for_item(cx, node_def_id);
     let span = cx.tcx().def_span(node_def_id);
 
@@ -1659,10 +1661,13 @@ pub fn create_global_var_metadata(cx: &CrateContext,
     let variable_type = common::def_ty(cx.tcx(), node_def_id, Substs::empty());
     let type_metadata = type_metadata(cx, variable_type, span);
     let var_name = tcx.item_name(node_def_id).to_string();
-    let linkage_name = mangled_name_of_item(cx, node_def_id, "");
-
     let var_name = CString::new(var_name).unwrap();
-    let linkage_name = CString::new(linkage_name).unwrap();
+    let linkage_name = if no_mangle {
+        None
+    } else {
+        let linkage_name = mangled_name_of_item(cx, node_def_id, "");
+        Some(CString::new(linkage_name).unwrap())
+    };
 
     let global_align = cx.align_of(variable_type);
 
@@ -1670,7 +1675,10 @@ pub fn create_global_var_metadata(cx: &CrateContext,
         llvm::LLVMRustDIBuilderCreateStaticVariable(DIB(cx),
                                                     var_scope,
                                                     var_name.as_ptr(),
-                                                    linkage_name.as_ptr(),
+                                                    // If null, linkage_name field is omitted,
+                                                    // which is what we want for no_mangle statics
+                                                    linkage_name.as_ref()
+                                                     .map_or(ptr::null(), |name| name.as_ptr()),
                                                     file_metadata,
                                                     line_number,
                                                     type_metadata,


### PR DESCRIPTION
For `no_mangle` statics:

1. Linkage_name no longer set
2. The static variable also no longer has a dwarf namespace scope

This matches C++ output, which does not set the linkage_name and is not scoped:

e.g. c++:

```
0x000000b6:   DW_TAG_base_type [8]  
                DW_AT_name [DW_FORM_strp]       ( .debug_str[0x00000077] = "long int")
                DW_AT_encoding [DW_FORM_data1]  (DW_ATE_signed)
                DW_AT_byte_size [DW_FORM_data1] (0x08)

0x000000bd:   DW_TAG_variable [9]  
                DW_AT_name [DW_FORM_strp]       ( .debug_str[0x00000053] = "TEST")
                DW_AT_type [DW_FORM_ref4]       (cu + 0x0048 => {0x00000048})
                DW_AT_external [DW_FORM_flag_present]   (true)
                DW_AT_decl_file [DW_FORM_data1] ("/home/m4b/tmp/bad_debug/test.cpp")
                DW_AT_decl_line [DW_FORM_data1] (14)
                DW_AT_location [DW_FORM_exprloc]        (<0x9> 03 40 10 20 00 00 00 00 00 )

0x000000d2:   DW_TAG_namespace [2] *
                DW_AT_name [DW_FORM_strp]       ( .debug_str[0x0000009d] = "std")

```

and (now) Rust:

```
0x0000002a:   DW_TAG_variable [2]  
                DW_AT_name [DW_FORM_strp]       ( .debug_str[0x00000046] = "TEST")
                DW_AT_type [DW_FORM_ref4]       (cu + 0x0045 => {0x00000045})
                DW_AT_external [DW_FORM_flag_present]   (true)
                DW_AT_decl_file [DW_FORM_data1] ("/tmp/test.rs")
                DW_AT_decl_line [DW_FORM_data1] (8)
                DW_AT_alignment [DW_FORM_udata] (1)
                DW_AT_location [DW_FORM_exprloc]        (<0x9> 03 c0 4d 06 00 00 00 00 00 )

0x00000040:   DW_TAG_namespace [3] *
                DW_AT_name [DW_FORM_strp]       ( .debug_str[0x0000004b] = "test")
```