### PR TITLE
Fix invalid docs path for compiler plugins

### DIFF
--- a/src/test/run-pass-fulldeps/auxiliary/roman_numerals.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/roman_numerals.rs
@@ -29,8 +29,8 @@ use rustc_plugin::Registry;
 // WARNING WARNING WARNING WARNING WARNING
 // =======================================
 //
-// This code also appears in src/doc/guide-plugin.md. Please keep
-// the two copies in sync!  FIXME: have rustdoc read this file
+// This code also appears in src/doc/unstable-book/src/language-features/plugin.md.
+// Please keep the two copies in sync!  FIXME: have rustdoc read this file
 
 fn expand_rn(cx: &mut ExtCtxt, sp: Span, args: &[TokenTree])
         -> Box<MacResult + 'static> {


### PR DESCRIPTION
The path to the docs `src/doc/guide-plugin.md` moved to
`src/doc/unstable-book/src/language-features/plugin.md`.

This patch updates it in the comment of WARNING message of the test
code.