### PR TITLE
Fix invalid link to lint_plugin_test.rs

### DIFF
--- a/src/doc/unstable-book/src/language-features/plugin.md
+++ b/src/doc/unstable-book/src/language-features/plugin.md
@@ -177,7 +177,7 @@ quasiquote as an ordinary plugin library.
 Plugins can extend [Rust's lint
 infrastructure](../reference/attributes.html#lint-check-attributes) with
 additional checks for code style, safety, etc. Now let's write a plugin
-[`lint_plugin_test.rs`](https://github.com/rust-lang/rust/blob/master/src/test/run-pass-fulldeps/auxiliary/lint_plugin_test.rs)
+[`lint_plugin_test.rs`](https://github.com/rust-lang/rust/blob/master/src/test/ui-fulldeps/auxiliary/lint_plugin_test.rs)
 that warns about any item named `lintme`.
 
 ```rust,ignore


### PR DESCRIPTION
The path to `lint_plugin_test.rs` was moved to `src/test/ui-fulldeps/`
from `src/test/run-pass-fulldeps/` in https://github.com/rust-lang/rust/commit/38ef85696dce84d5e6aff171cbf91d396678cbe0

This patch updates it in the docs.