### PR TITLE
Skip IPv{4,6} tests when IPv{4,6} loopback doesn't work (#39798)

### DIFF
--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -890,15 +890,15 @@ mod tests {
     use io::ErrorKind;
     use io::prelude::*;
     use net::*;
-    use net::test::{next_test_ip4, next_test_ip6};
+    use net::test::{test_ipv4_p, test_ipv6_p, next_test_ip4, next_test_ip6};
     use sync::mpsc::channel;
     use sys_common::AsInner;
     use time::{Instant, Duration};
     use thread;
 
     fn each_ip(f: &mut FnMut(SocketAddr)) {
-        f(next_test_ip4());
-        f(next_test_ip6());
+        if test_ipv4_p() { f(next_test_ip4()); }
+        if test_ipv6_p() { f(next_test_ip6()); }
     }
 
     macro_rules! t {
@@ -933,6 +933,8 @@ mod tests {
 
     #[test]
     fn listen_localhost() {
+        if !test_ipv4_p() { return; }
+
         let socket_addr = next_test_ip4();
         let listener = t!(TcpListener::bind(&socket_addr));
 
@@ -1457,6 +1459,8 @@ mod tests {
 
     #[test]
     fn debug() {
+        if !test_ipv4_p() { return; }
+
         let name = if cfg!(windows) {"socket"} else {"fd"};
         let socket_addr = next_test_ip4();
 
@@ -1483,6 +1487,8 @@ mod tests {
     #[cfg_attr(any(target_os = "bitrig", target_os = "netbsd", target_os = "openbsd"), ignore)]
     #[test]
     fn timeouts() {
+        if !test_ipv4_p() { return; }
+
         let addr = next_test_ip4();
         let listener = t!(TcpListener::bind(&addr));
 
@@ -1509,6 +1515,8 @@ mod tests {
 
     #[test]
     fn test_read_timeout() {
+        if !test_ipv4_p() { return; }
+
         let addr = next_test_ip4();
         let listener = t!(TcpListener::bind(&addr));
 
@@ -1525,6 +1533,8 @@ mod tests {
 
     #[test]
     fn test_read_with_timeout() {
+        if !test_ipv4_p() { return; }
+
         let addr = next_test_ip4();
         let listener = t!(TcpListener::bind(&addr));
 
@@ -1547,6 +1557,8 @@ mod tests {
 
     #[test]
     fn nodelay() {
+        if !test_ipv4_p() { return; }
+
         let addr = next_test_ip4();
         let _listener = t!(TcpListener::bind(&addr));
 
@@ -1561,6 +1573,8 @@ mod tests {
 
     #[test]
     fn ttl() {
+        if !test_ipv4_p() { return; }
+
         let ttl = 100;
 
         let addr = next_test_ip4();
@@ -1577,6 +1591,8 @@ mod tests {
 
     #[test]
     fn set_nonblocking() {
+        if !test_ipv4_p() { return; }
+
         let addr = next_test_ip4();
         let listener = t!(TcpListener::bind(&addr));
 

--- a/src/libstd/net/test.rs
+++ b/src/libstd/net/test.rs
@@ -11,8 +11,108 @@
 #![allow(warnings)] // not used on emscripten
 
 use env;
-use net::{SocketAddr, SocketAddrV4, SocketAddrV6, Ipv4Addr, Ipv6Addr, ToSocketAddrs};
+use net::{SocketAddr, SocketAddrV4, SocketAddrV6, Ipv4Addr, Ipv6Addr,
+          ToSocketAddrs, TcpListener};
 use sync::atomic::{AtomicUsize, Ordering};
+use sync::{Once, ONCE_INIT};
+use io::ErrorKind;
+
+// If the computer does not have a working IPv4 or v6 loopback address,
+// all of the v4 or v6 tests, respectively, should be skipped.
+// We let the user override our attempt to detect this automatically
+// by setting an environment variable.
+
+enum TestAddrFamily { No, Yes, Maybe }
+fn test_addr_family_env(var: &'static str) -> TestAddrFamily {
+    use self::TestAddrFamily::*;
+
+    match env::var_os(var) {
+        None      => Maybe,
+        Some(ref s) => {
+            if s == "1" {
+                Yes
+            } else if s == "0" {
+                No
+            } else {
+                eprintln!("warning: ignoring strange value for '{}'", var);
+                eprintln!("warning: understood values are 0 and 1");
+                Maybe
+            }
+        }
+    }
+}
+
+fn test_addr_family_auto(addr: SocketAddr) -> bool {
+    // An address family is assumed to be usable if it is possible to
+    // bind an OS-assigned port on that address family's loopback
+    // address, and to not be usable if the attempt fails with
+    // EADDRNOTAVAIL.  Other errors are treated as fatal.  (Caller is
+    // responsible for supplying an appropriate SocketAddr.)
+    match TcpListener::bind(addr) {
+        Ok(..) => true,
+        Err(e) => {
+            assert!(e.kind() == ErrorKind::AddrNotAvailable,
+                    "address family probe failure: {}", e);
+            false
+        }
+    }
+}
+
+pub fn test_ipv4_p() -> bool {
+    use self::TestAddrFamily::*;
+    static mut TEST_IPV4: bool = false;
+    static TEST_IPV4_INIT: Once = ONCE_INIT;
+
+    TEST_IPV4_INIT.call_once(|| {
+        let test_ipv4 = match test_addr_family_env("RUST_TEST_IPV4") {
+            Yes    => true,
+            No     => false,
+            Maybe  => test_addr_family_auto(sa4(
+                Ipv4Addr::new(127, 0, 0, 1), 0))
+        };
+        unsafe { TEST_IPV4 = test_ipv4 }
+    });
+    unsafe { TEST_IPV4 }
+}
+
+pub fn test_ipv6_p() -> bool {
+    use self::TestAddrFamily::*;
+    static mut TEST_IPV6: bool = false;
+    static TEST_IPV6_INIT: Once = ONCE_INIT;
+
+    TEST_IPV6_INIT.call_once(|| {
+        let test_ipv6 = match test_addr_family_env("RUST_TEST_IPV6") {
+            Yes    => true,
+            No     => false,
+            Maybe  => test_addr_family_auto(sa6(
+                Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 0))
+        };
+        unsafe { TEST_IPV6 = test_ipv6 }
+    });
+    unsafe { TEST_IPV6 }
+}
+
+// The bots run multiple builds at the same time, and these builds
+// all want to use ports. This function figures out which workspace
+// it is running in and assigns a port range based on it.
+fn base_port() -> u16 {
+    static mut BASE_PORT: u16 = 0;
+    static BASE_PORT_INIT: Once = ONCE_INIT;
+
+    BASE_PORT_INIT.call_once(|| {
+        let cwd_p = env::current_dir().unwrap();
+        let cwd = cwd_p.to_str().unwrap();
+        let dirs = ["32-opt", "32-nopt",
+                    "musl-64-opt", "cross-opt",
+                    "64-opt", "64-nopt", "64-opt-vg", "64-debug-opt",
+                    "all-opt", "snap3", "dist"];
+        let base_port = dirs.iter().enumerate().find(|&(_, dir)| {
+            cwd.contains(dir)
+        }).map(|p| p.0).unwrap_or(0) as u16 * 1000 + 19600;
+        unsafe { BASE_PORT = base_port }
+    });
+    unsafe { BASE_PORT }
+}
 
 static PORT: AtomicUsize = AtomicUsize::new(0);
 
@@ -40,18 +140,4 @@ pub fn tsa<A: ToSocketAddrs>(a: A) -> Result<Vec<SocketAddr>, String> {
         Ok(a) => Ok(a.collect()),
         Err(e) => Err(e.to_string()),
     }
-}
-
-// The bots run multiple builds at the same time, and these builds
-// all want to use ports. This function figures out which workspace
-// it is running in and assigns a port range based on it.
-fn base_port() -> u16 {
-    let cwd = env::current_dir().unwrap();
-    let dirs = ["32-opt", "32-nopt",
-                "musl-64-opt", "cross-opt",
-                "64-opt", "64-nopt", "64-opt-vg", "64-debug-opt",
-                "all-opt", "snap3", "dist"];
-    dirs.iter().enumerate().find(|&(_, dir)| {
-        cwd.to_str().unwrap().contains(dir)
-    }).map(|p| p.0).unwrap_or(0) as u16 * 1000 + 19600
 }

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -790,15 +790,15 @@ impl fmt::Debug for UdpSocket {
 mod tests {
     use io::ErrorKind;
     use net::*;
-    use net::test::{next_test_ip4, next_test_ip6};
+    use net::test::{test_ipv4_p, test_ipv6_p, next_test_ip4, next_test_ip6};
     use sync::mpsc::channel;
     use sys_common::AsInner;
     use time::{Instant, Duration};
     use thread;
 
     fn each_ip(f: &mut FnMut(SocketAddr, SocketAddr)) {
-        f(next_test_ip4(), next_test_ip4());
-        f(next_test_ip6(), next_test_ip6());
+        if test_ipv4_p() { f(next_test_ip4(), next_test_ip4()); }
+        if test_ipv6_p() { f(next_test_ip6(), next_test_ip6()); }
     }
 
     macro_rules! t {
@@ -953,6 +953,8 @@ mod tests {
 
     #[test]
     fn debug() {
+        if !test_ipv4_p() { return; }
+
         let name = if cfg!(windows) {"socket"} else {"fd"};
         let socket_addr = next_test_ip4();
 
@@ -968,6 +970,8 @@ mod tests {
     #[cfg_attr(any(target_os = "bitrig", target_os = "netbsd", target_os = "openbsd"), ignore)]
     #[test]
     fn timeouts() {
+        if !test_ipv4_p() { return; }
+
         let addr = next_test_ip4();
 
         let stream = t!(UdpSocket::bind(&addr));
@@ -992,6 +996,8 @@ mod tests {
 
     #[test]
     fn test_read_timeout() {
+        if !test_ipv4_p() { return; }
+
         let addr = next_test_ip4();
 
         let stream = t!(UdpSocket::bind(&addr));
@@ -1007,6 +1013,8 @@ mod tests {
 
     #[test]
     fn test_read_with_timeout() {
+        if !test_ipv4_p() { return; }
+
         let addr = next_test_ip4();
 
         let stream = t!(UdpSocket::bind(&addr));
@@ -1026,6 +1034,8 @@ mod tests {
 
     #[test]
     fn connect_send_recv() {
+        if !test_ipv4_p() { return; }
+
         let addr = next_test_ip4();
 
         let socket = t!(UdpSocket::bind(&addr));
@@ -1082,6 +1092,8 @@ mod tests {
 
     #[test]
     fn ttl() {
+        if !test_ipv4_p() { return; }
+
         let ttl = 100;
 
         let addr = next_test_ip4();


### PR DESCRIPTION
If the computer on which libstd tests are being run has been configured without support for IPv6 or IPv4, then all of the net::tcp and net::udp tests for that address family will fail.  This patch detects this condition and skips all of the affected tests.

The automatic detector works by attempting to bind a socket on the appropriate loopback address (::1 or 127.0.0.1).  If this succeeds, the tests are run; if it fails with EADDRNOTAVAIL, they are skipped. This is not exactly the same thing as "computer was configured without support for IPvX", but it _is_ the failing operation in most of the problem tests on my computer that doesn't do IPv6.

Because the automatic detector might not be perfectly accurate, and because one might _want_ the tests to fail if the computer has been configured incorrectly (this would be appropriate for the CI bots, for instance), it can be overridden with environment variables: set `RUST_TEST_IPV{4,6}=0` to skip the IPv{4,6} tests unconditionally, or `RUST_TEST_IPV{4,6}=1` to run them unconditionally.

While I was at it I tightened up some inefficient code in libstd/net/test.rs a bit: `base_port` no longer calls `getcwd` every time it's used.

Every test that directly calls `test_ipv4_p` should probably be adjusted to use `each_ip` but that would be a whole project in itself.