### PR TITLE
Add an i128_lowering flag in TargetOptions

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1176,9 +1176,10 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
     saturating_float_casts: bool = (false, parse_bool, [TRACKED],
         "make float->int casts UB-free: numbers outside the integer type's range are clipped to \
          the max/min integer respectively, and NaN is mapped to 0"),
-    lower_128bit_ops: bool = (false, parse_bool, [TRACKED],
+    lower_128bit_ops: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "rewrite operators on i128 and u128 into lang item calls (typically provided \
-         by compiler-builtins) so translation doesn't need to support them"),
+         by compiler-builtins) so translation doesn't need to support them,
+         overriding the default for the current target"),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -453,6 +453,10 @@ pub struct TargetOptions {
     /// Whether library functions call lowering/optimization is disabled in LLVM
     /// for this target unconditionally.
     pub no_builtins: bool,
+
+    /// Whether to lower 128-bit operations to compiler_builtins calls.  Use if
+    /// your backend only supports 64-bit and smaller math.
+    pub i128_lowering: bool,
 }
 
 impl Default for TargetOptions {
@@ -521,6 +525,7 @@ impl Default for TargetOptions {
             requires_lto: false,
             singlethread: false,
             no_builtins: false,
+            i128_lowering: false,
         }
     }
 }

--- a/src/librustc_mir/transform/lower_128bit.rs
+++ b/src/librustc_mir/transform/lower_128bit.rs
@@ -25,7 +25,9 @@ impl MirPass for Lower128Bit {
                           tcx: TyCtxt<'a, 'tcx, 'tcx>,
                           _src: MirSource,
                           mir: &mut Mir<'tcx>) {
-        if !tcx.sess.opts.debugging_opts.lower_128bit_ops {
+        let debugging_override = tcx.sess.opts.debugging_opts.lower_128bit_ops;
+        let target_default = tcx.sess.host.options.i128_lowering;
+        if !debugging_override.unwrap_or(target_default) {
             return
         }
 

--- a/src/test/mir-opt/lower_128bit_debug_test.rs
+++ b/src/test/mir-opt/lower_128bit_debug_test.rs
@@ -13,7 +13,7 @@
 // ignore-asmjs
 // ignore-emscripten
 
-// compile-flags: -Z lower_128bit_ops -C debug_assertions=yes
+// compile-flags: -Z lower_128bit_ops=yes -C debug_assertions=yes
 
 #![feature(i128_type)]
 

--- a/src/test/mir-opt/lower_128bit_test.rs
+++ b/src/test/mir-opt/lower_128bit_test.rs
@@ -13,7 +13,7 @@
 // ignore-asmjs
 // ignore-emscripten
 
-// compile-flags: -Z lower_128bit_ops -C debug_assertions=no
+// compile-flags: -Z lower_128bit_ops=yes -C debug_assertions=no
 
 #![feature(i128_type)]
 


### PR DESCRIPTION
Not actually enabled by default anywhere yet.

r? @nagisa 

cc #45676 @est31