### PR TITLE
rustc_mir: don't move temporaries that are still used later.

### DIFF
--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1347,6 +1347,12 @@ impl<'tcx> Operand<'tcx> {
         })
     }
 
+    pub fn to_copy(&self) -> Self {
+        match *self {
+            Operand::Copy(_) | Operand::Constant(_) => self.clone(),
+            Operand::Move(ref place) => Operand::Copy(place.clone())
+        }
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -87,7 +87,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                     let is_min = this.temp(bool_ty, expr_span);
 
                     this.cfg.push_assign(block, source_info, &is_min,
-                                         Rvalue::BinaryOp(BinOp::Eq, arg.clone(), minval));
+                                         Rvalue::BinaryOp(BinOp::Eq, arg.to_copy(), minval));
 
                     let err = ConstMathErr::Overflow(Op::Neg);
                     block = this.assert(block, Operand::Move(is_min), false,
@@ -346,7 +346,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 let is_zero = self.temp(bool_ty, span);
                 let zero = self.zero_literal(span, ty);
                 self.cfg.push_assign(block, source_info, &is_zero,
-                                     Rvalue::BinaryOp(BinOp::Eq, rhs.clone(), zero));
+                                     Rvalue::BinaryOp(BinOp::Eq, rhs.to_copy(), zero));
 
                 block = self.assert(block, Operand::Move(is_zero), false,
                                     AssertMessage::Math(zero_err), span);
@@ -364,9 +364,9 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                     // this does (rhs == -1) & (lhs == MIN). It could short-circuit instead
 
                     self.cfg.push_assign(block, source_info, &is_neg_1,
-                                         Rvalue::BinaryOp(BinOp::Eq, rhs.clone(), neg_1));
+                                         Rvalue::BinaryOp(BinOp::Eq, rhs.to_copy(), neg_1));
                     self.cfg.push_assign(block, source_info, &is_min,
-                                         Rvalue::BinaryOp(BinOp::Eq, lhs.clone(), min));
+                                         Rvalue::BinaryOp(BinOp::Eq, lhs.to_copy(), min));
 
                     let is_neg_1 = Operand::Move(is_neg_1);
                     let is_min = Operand::Move(is_min);

--- a/src/test/run-pass/i128.rs
+++ b/src/test/run-pass/i128.rs
@@ -10,6 +10,8 @@
 
 // ignore-emscripten i128 doesn't work
 
+// compile-flags: -Z borrowck=compare
+
 #![feature(i128_type, test)]
 
 extern crate test;

--- a/src/test/run-pass/u128.rs
+++ b/src/test/run-pass/u128.rs
@@ -10,6 +10,8 @@
 
 // ignore-emscripten u128 not supported
 
+// compile-flags: -Z borrowck=compare
+
 #![feature(i128_type, test)]
 
 extern crate test;


### PR DESCRIPTION
This should unbreak using the MIR borrow-checker on `libcore` (assuming #46268 is merged).