### PR TITLE
Update old link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -336,7 +336,7 @@ will run all the tests on every platform we support. If it all works out,
 
 Speaking of tests, Rust has a comprehensive test suite. More information about
 it can be found
-[here](https://github.com/rust-lang/rust-wiki-backup/blob/master/Note-testsuite.md).
+[here](https://github.com/rust-lang/rust/blob/master/src/test/COMPILER_TESTS.md).
 
 ### External Dependencies
 [external-dependencies]: #external-dependencies


### PR DESCRIPTION
The CONTRIBUTING.md page currently links to an old wiki page in rust-lang/rust-wiki-backup. There is a more up-to-date page in-tree so I changed the link to point there so new contributors can find it more easily.