### PR TITLE
Modify message for keyword as identifier name

### DIFF
--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -22,9 +22,9 @@ use syntax::ast::*;
 use syntax::attr;
 use syntax::codemap::Spanned;
 use syntax::parse::token;
+use syntax::symbol::keywords;
 use syntax::visit::{self, Visitor};
 use syntax_pos::Span;
-use syntax_pos::symbol::keywords;
 use errors;
 
 struct AstValidator<'a> {

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -14,7 +14,7 @@ use codemap::{CodeMap, FilePathMapping};
 use errors::{FatalError, DiagnosticBuilder};
 use parse::{token, ParseSess};
 use str::char_at;
-use symbol::{Symbol, keywords};
+use symbol::{Symbol};
 use std_unicode::property::Pattern_White_Space;
 
 use std::borrow::Cow;
@@ -1295,18 +1295,6 @@ impl<'a> StringReader<'a> {
                     let ident = self.with_str_from(start, |lifetime_name| {
                         self.mk_ident(&format!("'{}", lifetime_name))
                     });
-
-                    // Conjure up a "keyword checking ident" to make sure that
-                    // the lifetime name is not a keyword.
-                    let keyword_checking_ident = self.with_str_from(start, |lifetime_name| {
-                        self.mk_ident(lifetime_name)
-                    });
-                    let keyword_checking_token = &token::Ident(keyword_checking_ident);
-                    let last_bpos = self.pos;
-                    if keyword_checking_token.is_reserved_ident() &&
-                       !keyword_checking_token.is_keyword(keywords::Static) {
-                        self.err_span_(start, last_bpos, "lifetimes cannot use keyword names");
-                    }
 
                     return Ok(token::Lifetime(ident));
                 }

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -14,7 +14,7 @@ use codemap::{CodeMap, FilePathMapping};
 use errors::{FatalError, DiagnosticBuilder};
 use parse::{token, ParseSess};
 use str::char_at;
-use symbol::{Symbol};
+use symbol::Symbol;
 use std_unicode::property::Pattern_White_Space;
 
 use std::borrow::Cow;

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -364,18 +364,12 @@ impl Token {
 
     /// Returns `true` if the token is a keyword used in the language.
     pub fn is_used_keyword(&self) -> bool {
-        match self.ident() {
-            Some(id) => id.name >= keywords::As.name() && id.name <= keywords::While.name(),
-            _ => false,
-        }
+        self.ident().map(|id| id.name.is_used_keyword()).unwrap_or(false)
     }
 
     /// Returns `true` if the token is a keyword reserved for possible future use.
     pub fn is_unused_keyword(&self) -> bool {
-        match self.ident() {
-            Some(id) => id.name >= keywords::Abstract.name() && id.name <= keywords::Yield.name(),
-            _ => false,
-        }
+        self.ident().map(|id| id.name.is_unused_keyword()).unwrap_or(false)
     }
 
     pub fn glue(self, joint: Token) -> Option<Token> {

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -364,12 +364,18 @@ impl Token {
 
     /// Returns `true` if the token is a keyword used in the language.
     pub fn is_used_keyword(&self) -> bool {
-        self.ident().map(|id| id.name.is_used_keyword()).unwrap_or(false)
+        match self.ident() {
+            Some(id) => id.name >= keywords::As.name() && id.name <= keywords::While.name(),
+            _ => false,
+        }
     }
 
     /// Returns `true` if the token is a keyword reserved for possible future use.
     pub fn is_unused_keyword(&self) -> bool {
-        self.ident().map(|id| id.name.is_unused_keyword()).unwrap_or(false)
+        match self.ident() {
+            Some(id) => id.name >= keywords::Abstract.name() && id.name <= keywords::Yield.name(),
+            _ => false,
+        }
     }
 
     pub fn glue(self, joint: Token) -> Option<Token> {

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -434,26 +434,6 @@ mod tests {
     }
 
     #[test]
-    fn is_used_keyword_test() {
-        let s = Symbol(5);
-        assert_eq!(s.is_used_keyword(), true);
-    }
-
-    #[test]
-    fn is_unused_keyword_test() {
-        let s = Symbol(40);
-        assert_eq!(s.is_unused_keyword(), true);
-    }
-
-    #[test]
-    fn is_valid_test() {
-        let i = Ident { name: Symbol(40), ctxt: SyntaxContext(0) };
-        assert_eq!(i.is_valid(), false);
-        let i = Ident { name: Symbol(61), ctxt: SyntaxContext(0) };
-        assert_eq!(i.is_valid(), true);
-    }
-
-    #[test]
     fn without_first_quote_test() {
         let i = Ident::from_str("'break");
         assert_eq!(i.without_first_quote().name, keywords::Break.name());

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -42,10 +42,6 @@ impl Ident {
     pub fn modern(self) -> Ident {
         Ident { name: self.name, ctxt: self.ctxt.modern() }
     }
-
-    pub fn is_valid(&self) -> bool {
-        !self.name.is_used_keyword() && !self.name.is_unused_keyword()
-    }
 }
 
 impl fmt::Debug for Ident {
@@ -120,20 +116,6 @@ impl Symbol {
 
     pub fn as_u32(self) -> u32 {
         self.0
-    }
-
-    /// Returns `true` if the token is a keyword used in the language.
-    pub fn is_used_keyword(&self) -> bool {
-        self >= &keywords::As.name() && self <= &keywords::While.name()
-    }
-
-    /// Returns `true` if the token is a keyword reserved for possible future use.
-    pub fn is_unused_keyword(&self) -> bool {
-        self >= &keywords::Abstract.name() && self <= &keywords::Yield.name()
-    }
-
-    pub fn is_static_keyword(&self) -> bool {
-        self == &keywords::StaticLifetime.name()
     }
 
     pub fn without_first_quote(&self) -> Symbol {

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -36,7 +36,7 @@ impl Ident {
     }
 
     pub fn without_first_quote(&self) -> Ident {
-        Ident { name: self.name.without_first_quote(), ctxt: self.ctxt }
+        Ident { name: Symbol::from(self.name.as_str().trim_left_matches('\'')), ctxt: self.ctxt }
     }
 
     pub fn modern(self) -> Ident {
@@ -116,10 +116,6 @@ impl Symbol {
 
     pub fn as_u32(self) -> u32 {
         self.0
-    }
-
-    pub fn without_first_quote(&self) -> Symbol {
-        Symbol::from(self.as_str().trim_left_matches('\''))
     }
 }
 

--- a/src/test/compile-fail/issue-10412.rs
+++ b/src/test/compile-fail/issue-10412.rs
@@ -9,21 +9,17 @@
 // except according to those terms.
 
 trait Serializable<'self, T> { //~ ERROR lifetimes cannot use keyword names
-    fn serialize(val : &'self T) -> Vec<u8>;
-    //~^ ERROR lifetimes cannot use keyword names
-    fn deserialize(repr : &[u8]) -> &'self T;
-    //~^ ERROR lifetimes cannot use keyword names
+    fn serialize(val : &'self T) -> Vec<u8>; //~ ERROR lifetimes cannot use keyword names
+    fn deserialize(repr : &[u8]) -> &'self T; //~ ERROR lifetimes cannot use keyword names
 }
 
 impl<'self> Serializable<str> for &'self str { //~ ERROR lifetimes cannot use keyword names
     //~^ ERROR lifetimes cannot use keyword names
     //~| ERROR missing lifetime specifier
-    fn serialize(val : &'self str) -> Vec<u8> {
-    //~^ ERROR lifetimes cannot use keyword names
+    fn serialize(val : &'self str) -> Vec<u8> { //~ ERROR lifetimes cannot use keyword names
         vec![1]
     }
-    fn deserialize(repr: &[u8]) -> &'self str {
-    //~^ ERROR lifetimes cannot use keyword names
+    fn deserialize(repr: &[u8]) -> &'self str { //~ ERROR lifetimes cannot use keyword names
         "hi"
     }
 }

--- a/src/test/compile-fail/issue-10412.rs
+++ b/src/test/compile-fail/issue-10412.rs
@@ -8,20 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only -Z continue-parse-after-error
-
-
 trait Serializable<'self, T> { //~ ERROR lifetimes cannot use keyword names
-    fn serialize(val : &'self T) -> Vec<u8> ; //~ ERROR lifetimes cannot use keyword names
-    fn deserialize(repr : &[u8]) -> &'self T; //~ ERROR lifetimes cannot use keyword names
+    fn serialize(val : &'self T) -> Vec<u8> ;
+    fn deserialize(repr : &[u8]) -> &'self T;
 }
 
-impl<'self> Serializable<str> for &'self str { //~ ERROR lifetimes cannot use keyword names
+impl<'self> Serializable<str> for &'self str {
     //~^ ERROR lifetimes cannot use keyword names
-    fn serialize(val : &'self str) -> Vec<u8> { //~ ERROR lifetimes cannot use keyword names
+    //~| ERROR missing lifetime specifier
+    fn serialize(val : &'self str) -> Vec<u8> {
         vec![1]
     }
-    fn deserialize(repr: &[u8]) -> &'self str { //~ ERROR lifetimes cannot use keyword names
+    fn deserialize(repr: &[u8]) -> &'self str {
         "hi"
     }
 }

--- a/src/test/compile-fail/issue-10412.rs
+++ b/src/test/compile-fail/issue-10412.rs
@@ -9,17 +9,21 @@
 // except according to those terms.
 
 trait Serializable<'self, T> { //~ ERROR lifetimes cannot use keyword names
-    fn serialize(val : &'self T) -> Vec<u8> ;
+    fn serialize(val : &'self T) -> Vec<u8>;
+    //~^ ERROR lifetimes cannot use keyword names
     fn deserialize(repr : &[u8]) -> &'self T;
+    //~^ ERROR lifetimes cannot use keyword names
 }
 
-impl<'self> Serializable<str> for &'self str {
+impl<'self> Serializable<str> for &'self str { //~ ERROR lifetimes cannot use keyword names
     //~^ ERROR lifetimes cannot use keyword names
     //~| ERROR missing lifetime specifier
     fn serialize(val : &'self str) -> Vec<u8> {
+    //~^ ERROR lifetimes cannot use keyword names
         vec![1]
     }
     fn deserialize(repr: &[u8]) -> &'self str {
+    //~^ ERROR lifetimes cannot use keyword names
         "hi"
     }
 }

--- a/src/test/compile-fail/issue-46311.rs
+++ b/src/test/compile-fail/issue-46311.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,11 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only -Z continue-parse-after-error
-
-fn foo<'a>(a: &'a isize) { }
-fn bar(a: &'static isize) { }
-fn baz(a: &'let isize) { } //~ ERROR lifetimes cannot use keyword names
-fn zab(a: &'self isize) { } //~ ERROR lifetimes cannot use keyword names
-
-fn main() { }
+fn main() {
+    'break: loop { //~ ERROR invalid label name `'break`
+    }
+}

--- a/src/test/compile-fail/lifetime-no-keyword.rs
+++ b/src/test/compile-fail/lifetime-no-keyword.rs
@@ -11,6 +11,7 @@
 fn foo<'a>(a: &'a isize) { }
 fn bar(a: &'static isize) { }
 fn baz<'let>(a: &'let isize) { } //~ ERROR lifetimes cannot use keyword names
+//~^ ERROR lifetimes cannot use keyword names
 fn zab<'self>(a: &'self isize) { } //~ ERROR lifetimes cannot use keyword names
-
+//~^ ERROR lifetimes cannot use keyword names
 fn main() { }

--- a/src/test/compile-fail/lifetime-no-keyword.rs
+++ b/src/test/compile-fail/lifetime-no-keyword.rs
@@ -1,0 +1,16 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn foo<'a>(a: &'a isize) { }
+fn bar(a: &'static isize) { }
+fn baz<'let>(a: &'let isize) { } //~ ERROR lifetimes cannot use keyword names
+fn zab<'self>(a: &'self isize) { } //~ ERROR lifetimes cannot use keyword names
+
+fn main() { }


### PR DESCRIPTION
This is a temporary solution to #46311.

The message is generic enough to cover both cases and is probably a fine enough solution to the specific problem described in the task. However, the underlying reason for this to be wrong is that `next_token_inner` returns `Lifetime` even if the token is a label. That's not simple, as the syntax for both can be quite similar and it may need to take a look to the next token to make a decision. I'm not sure I have enough knowledge about the project to be able to solve that (yet!), so I thought I'll fix the immediate problem first.