### PR TITLE
Remove librustdoc dependency on log

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2015,7 +2015,6 @@ dependencies = [
  "build_helper 0.1.0",
  "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "html-diff 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -11,7 +11,6 @@ path = "lib.rs"
 doctest = false
 
 [dependencies]
-log = "0.3"
 pulldown-cmark = { version = "0.1.0", default-features = false }
 html-diff = "0.0.5"
 


### PR DESCRIPTION
This change should have been included in PR #46386.

Since librustdoc doesn't explicitly depend on internal crates
(such as librustc_driver) through its Cargo.toml, it ends up using the
sysroot to resolve them. By removing the dependency on 'log',
we ensure that the syroot is used to resolve `log` as well. This ensures
that only one version of log is in use, so that `env_logger::init()`
enables all uses of `log!` macros.