### PR TITLE
Give compile_error macro examples

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -596,9 +596,9 @@ mod builtin {
 
     /// Unconditionally causes compilation to fail with the given error message when encountered.
     ///
-    /// For more information, see the [RFC].
+    /// For more information, see the documentation for [`std::compile_error!`].
     ///
-    /// [RFC]: https://github.com/rust-lang/rfcs/blob/master/text/1695-add-error-macro.md
+    /// [`std::compile_error!`]: ../std/macro.compile_error.html
     #[stable(feature = "compile_error_macro", since = "1.20.0")]
     #[macro_export]
     #[cfg(dox)]

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -282,9 +282,26 @@ pub mod builtin {
 
     /// Unconditionally causes compilation to fail with the given error message when encountered.
     ///
-    /// For more information, see the [RFC].
+    /// This macro should be used when a crate uses a conditional compilation strategy to provide
+    /// better error messages for errornous conditions.
     ///
-    /// [RFC]: https://github.com/rust-lang/rfcs/blob/master/text/1695-add-error-macro.md
+    /// # Examples
+    /// Two such examples are macros and `#[cfg]` environments.
+    ///
+    /// ```
+    /// macro_rules! give_me_foo_or_bar {
+    ///     (foo) => {};
+    ///     (bar) => {};
+    ///     ($x:ident) => {
+    ///         compile_error!("This macro only accepts `foo` or `bar`");
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ```compile_fail
+    /// #[cfg(not(any(feature = "foo", feature = "bar")))]
+    /// compile_error!("Either feature \"foo\" or \"bar\" must be enabled for this crate.")
+    /// ```
     #[stable(feature = "compile_error_macro", since = "1.20.0")]
     #[macro_export]
     macro_rules! compile_error { ($msg:expr) => ({ /* compiler built-in */ }) }

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -286,7 +286,10 @@ pub mod builtin {
     /// better error messages for errornous conditions.
     ///
     /// # Examples
+    ///
     /// Two such examples are macros and `#[cfg]` environments.
+    ///
+    /// Emit better compiler error if a macro is passed invalid values.
     ///
     /// ```compile_fail
     /// macro_rules! give_me_foo_or_bar {
@@ -300,6 +303,8 @@ pub mod builtin {
     /// give_me_foo_or_bar!(neither);
     /// // ^ will fail at compile time with message "This macro only accepts `foo` or `bar`"
     /// ```
+    ///
+    /// Emit compiler error if one of a number of features isn't available.
     ///
     /// ```compile_fail
     /// #[cfg(not(any(feature = "foo", feature = "bar")))]

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -288,7 +288,7 @@ pub mod builtin {
     /// # Examples
     /// Two such examples are macros and `#[cfg]` environments.
     ///
-    /// ```
+    /// ```compile_fail
     /// macro_rules! give_me_foo_or_bar {
     ///     (foo) => {};
     ///     (bar) => {};
@@ -296,6 +296,9 @@ pub mod builtin {
     ///         compile_error!("This macro only accepts `foo` or `bar`");
     ///     }
     /// }
+    ///
+    /// give_me_foo_or_bar!(neither);
+    /// // ^ will fail at compile time with message "This macro only accepts `foo` or `bar`"
     /// ```
     ///
     /// ```compile_fail


### PR DESCRIPTION
I cannot get Rust to build at all with it complaining about GCC not being a valid C compiler or something, so letting TravisCI be my tester...

Fixes #46171