### PR TITLE
add 64-element arrays to default array implementations

### DIFF
--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -260,7 +260,7 @@ array_impls! {
      0  1  2  3  4  5  6  7  8  9
     10 11 12 13 14 15 16 17 18 19
     20 21 22 23 24 25 26 27 28 29
-    30 31 32
+    30 31 32 64
 }
 
 // The Default impls cannot be generated using the array_impls! macro because


### PR DESCRIPTION
I'm interested in using 64-byte arrays, specifically to pass the results of
SHA256 to base64 encode them:

```
error[E0277]: the trait bound `[u8; 64]: std::convert::AsRef<[u8]>` is not satisfied
  --> src/main.rs:53:12
   |
53 |     return base64::encode(&bytes)
   |            ^^^^^^^^^^^^^^ the trait `std::convert::AsRef<[u8]>` is not implemented for `[u8; 64]`
   |
   = help: the following implementations were found:
             <[T; 6] as std::convert::AsRef<[T]>>
             <[T; 4] as std::convert::AsRef<[T]>>
             <[T; 22] as std::convert::AsRef<[T]>>
             <[T; 32] as std::convert::AsRef<[T]>>
           and 30 others
   = note: required by `base64::encode`

error: aborting due to previous error
```

Given that there are many other sizes that are automatically converted, IMO we
should convert 64 as well.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>