### PR TITLE
Improve documentation for Borrow

### DIFF
--- a/src/libcore/borrow.rs
+++ b/src/libcore/borrow.rs
@@ -12,7 +12,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-/// A trait identifying how borrowed data behaves.
+/// A trait for borrowing data.
 ///
 /// In Rust, it is common to provide different representations of a type for
 /// different use cases. For instance, storage location and management for a
@@ -24,40 +24,37 @@
 /// [`str`]. This requires keeping additional information unnecessary for a
 /// simple, immutable string.
 ///
-/// These types signal that they are a specialized representation of a basic
-/// type `T` by implementing `Borrow<T>`. The method `borrow` provides a way
-/// to convert a reference to the type into a reference to this basic type
-/// `T`.
+/// These types provide access to the underlying data through references
+/// to the type of that data. They are said to be ‘borrowed as’ that type.
+/// For instance, a [`Box<T>`] can be borrowed as `T` while a [`String`]
+/// can be borrowed as `str`.
+///
+/// Types express that they can be borrowed as some type `T` by implementing
+/// `Borrow<T>`, providing a reference to a `T` in the trait’s
+/// [`borrow`] method. A type is free to borrow as several different types.
+/// If it wishes to mutably borrow as the type – allowing the underlying data
+/// to be modified, it can additionally implement [`BorrowMut<T>`].
 ///
 /// Further, when providing implementations for additional traits, it needs
 /// to be considered whether they should behave identical to those of the
 /// underlying type as a consequence of acting as a representation of that
-/// underlying type.
-///
-/// Generic code typically uses `Borrow<T>` when it not only needs access
-/// to a reference of the underlying type but relies on the identical
-/// behavior of these additional trait implementations. These traits are
-/// likely to appear as additional trait bounds.
+/// underlying type. Generic code typically uses `Borrow<T>` when it relies
+/// on the identical behavior of these additional trait implementations.
+/// These traits will likely appear as additional trait bounds.
 ///
 /// If generic code merely needs to work for all types that can
 /// provide a reference to related type `T`, it is often better to use
 /// [`AsRef<T>`] as more types can safely implement it.
 ///
-/// If a type implementing `Borrow<T>` also wishes to allow mutable access
-/// to the underlying type `T`, it can do so by implementing the companion
-/// trait [`BorrowMut`].
-///
-/// Note also that it is perfectly fine for a single type to have multiple
-/// implementations of `Borrow<T>` for different `T`s. In fact, a blanket
-/// implementation lets every type be at least a borrow of itself.
-///
 /// [`AsRef<T>`]: ../../std/convert/trait.AsRef.html
-/// [`BorrowMut`]: trait.BorrowMut.html
+/// [`BorrowMut<T>`]: trait.BorrowMut.html
 /// [`Box<T>`]: ../../std/boxed/struct.Box.html
 /// [`Mutex<T>`]: ../../std/sync/struct.Mutex.html
 /// [`Rc<T>`]: ../../std/rc/struct.Rc.html
 /// [`str`]: ../../std/primitive.str.html
 /// [`String`]: ../../std/string/struct.String.html
+/// [`borrow`]: #tymethod.borrow
+///
 ///
 /// # Examples
 ///
@@ -113,10 +110,10 @@
 /// `str` is available.
 ///
 /// Instead, the `get` method is generic over the type of the underlying key
-/// data, called `Q` in the method signature above. It states that `K` is a
-/// representation of `Q` by requiring that `K: Borrow<Q>`. By additionally
-/// requiring `Q: Hash + Eq`, it demands that `K` and `Q` have
-/// implementations of the `Hash` and `Eq` traits that produce identical
+/// data, called `Q` in the method signature above. It states that `K`
+/// borrows as a `Q` by requiring that `K: Borrow<Q>`. By additionally
+/// requiring `Q: Hash + Eq`, it signals the requirement that `K` and `Q`
+/// have implementations of the `Hash` and `Eq` traits that produce identical
 /// results.
 ///
 /// The implementation of `get` relies in particular on identical
@@ -141,7 +138,7 @@
 /// ```
 ///
 /// Because two equal values need to produce the same hash value, the
-/// implementation of `Hash` needs to reflect that, too:
+/// implementation of `Hash` needs to ignore ASCII case, too:
 ///
 /// ```
 /// # use std::hash::{Hash, Hasher};

--- a/src/libcore/borrow.rs
+++ b/src/libcore/borrow.rs
@@ -191,7 +191,11 @@ pub trait Borrow<Borrowed: ?Sized> {
 
 /// A trait for mutably borrowing data.
 ///
-/// Similar to `Borrow`, but for mutable borrows.
+/// As a companion to [`Borrow<T>`] this trait allows a type to borrow as
+/// an underlying type by providing a mutable reference. See [`Borrow<T>`]
+/// for more information on borrowing as another type.
+///
+/// [`Borrow<T>`]: trait.Borrow.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait BorrowMut<Borrowed: ?Sized> : Borrow<Borrowed> {
     /// Mutably borrows from an owned value.

--- a/src/libcore/borrow.rs
+++ b/src/libcore/borrow.rs
@@ -55,7 +55,6 @@
 /// [`String`]: ../../std/string/struct.String.html
 /// [`borrow`]: #tymethod.borrow
 ///
-///
 /// # Examples
 ///
 /// As a data collection, [`HashMap<K, V>`] owns both keys and values. If
@@ -163,7 +162,6 @@
 /// [`HashMap<K, V>`]: ../../std/collections/struct.HashMap.html
 /// [`String`]: ../../std/string/struct.String.html
 /// [`str`]: ../../std/primitive.str.html
-///
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Borrow<Borrowed: ?Sized> {
     /// Immutably borrows from an owned value.

--- a/src/libcore/borrow.rs
+++ b/src/libcore/borrow.rs
@@ -100,12 +100,12 @@
 ///
 /// Instead, `get` relies on `Q`’s implementation of `Hash` and uses `Borrow`
 /// to indicate that `K`’s implementation of `Hash` must produce the same
-/// result as `Q`’s by demanding that `K: Borrow<Q>`. 
+/// result as `Q`’s by demanding that `K: Borrow<Q>`.
 ///
 /// As a consequence, the hash map breaks if a `K` wrapping a `Q` value
 /// produces a different hash than `Q`. For instance, image you have a
 /// type that wraps a string but compares ASCII letters case-insensitive:
-/// 
+///
 /// ```
 /// use std::ascii::AsciiExt;
 ///
@@ -148,7 +148,7 @@
 /// [`HashMap`]: ../collections/struct.HashMap.html
 /// [`String`]: ../string/struct.String.html
 /// [`str`]: ../primitive.str.html
-/// 
+///
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Borrow<Borrowed: ?Sized> {
     /// Immutably borrows from an owned value.

--- a/src/libcore/borrow.rs
+++ b/src/libcore/borrow.rs
@@ -37,10 +37,10 @@
 /// The companion trait [`BorrowMut`] provides the same guarantees for
 /// mutable references.
 ///
-/// [`Box<T>`]: ../boxed/struct.Box.html
-/// [`Rc<T>`]: ../rc/struct.Rc.html
-/// [`Vec<T>`]: ../vec/struct.Vec.html
-/// [`AsRef`]: ../convert/trait.AsRef.html
+/// [`Box<T>`]: ../../std/boxed/struct.Box.html
+/// [`Rc<T>`]: ../../std/rc/struct.Rc.html
+/// [`Vec<T>`]: ../../std/vec/struct.Vec.html
+/// [`AsRef`]: ../../std/convert/trait.AsRef.html
 /// [`BorrowMut`]: trait.BorrowMut.html
 ///
 /// # Examples
@@ -144,10 +144,10 @@
 /// others access to the underlying `str`, it can do that via `AsRef<str>`
 /// which doesn’t carry any such restrictions.
 ///
-/// [`Hash`]: ../hash/trait.Hash.html
-/// [`HashMap<K, V>`]: ../collections/struct.HashMap.html
-/// [`String`]: ../string/struct.String.html
-/// [`str`]: ../primitive.str.html
+/// [`Hash`]: ../../std/hash/trait.Hash.html
+/// [`HashMap<K, V>`]: ../../std/collections/struct.HashMap.html
+/// [`String`]: ../../std/string/struct.String.html
+/// [`str`]: ../../std/primitive.str.html
 ///
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Borrow<Borrowed: ?Sized> {

--- a/src/libcore/borrow.rs
+++ b/src/libcore/borrow.rs
@@ -12,10 +12,6 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-// impl Borrow<str> for String
-// impl<T> Borrow<T> for Arc<T>
-// impl<K> HashSet<K> { fn get<Q>(&self, q: &Q) where K: Borrow<Q> }
-
 /// A trait identifying how borrowed data behaves.
 ///
 /// If a type implements this trait, it signals that a reference to it behaves
@@ -26,10 +22,10 @@
 ///
 /// As a consequence, this trait should only be implemented for types managing
 /// a value of another type without modifying its behavior. Examples are
-/// smart pointers such as [`Box`] or [`Rc`] as well the owned version of
-/// slices such as [`Vec`].
+/// smart pointers such as [`Box<T>`] or [`Rc<T>`] as well the owned version
+/// of slices such as [`Vec<T>`].
 ///
-/// A relaxed version that allows providing a reference to some other type
+/// A relaxed version that allows converting a reference to some other type
 /// without any further promises is available through [`AsRef`].
 ///
 /// When writing generic code, a use of `Borrow` should always be justified
@@ -41,23 +37,24 @@
 /// The companion trait [`BorrowMut`] provides the same guarantees for
 /// mutable references.
 ///
-/// [`Box`]: ../boxed/struct.Box.html
-/// [`Rc`]: ../rc/struct.Rc.html
-/// [`Vec`]: ../vec/struct.Vec.html
+/// [`Box<T>`]: ../boxed/struct.Box.html
+/// [`Rc<T>`]: ../rc/struct.Rc.html
+/// [`Vec<T>`]: ../vec/struct.Vec.html
 /// [`AsRef`]: ../convert/trait.AsRef.html
 /// [`BorrowMut`]: trait.BorrowMut.html
 ///
 /// # Examples
 ///
-/// As a data collection, [`HashMap`] owns both keys and values. If the key’s
-/// actual data is wrapped in a managing type of some kind, it should,
-/// however, still be possible to search for a value using a reference to the
-/// key’s data. For instance, if the key is a string, then it is likely
-/// stored with the hash map as a [`String`], while it should be possible
-/// to search using a [`&str`][`str`]. Thus, `insert` needs to operate on a
-/// string while `get` needs to be able to use a `&str`.
+/// As a data collection, [`HashMap<K, V>`] owns both keys and values. If
+/// the key’s actual data is wrapped in a managing type of some kind, it
+/// should, however, still be possible to search for a value using a
+/// reference to the key’s data. For instance, if the key is a string, then
+/// it is likely stored with the hash map as a [`String`], while it should
+/// be possible to search using a [`&str`][`str`]. Thus, `insert` needs to
+/// operate on a `String` while `get` needs to be able to use a `&str`.
 ///
-/// Slightly simplified, the relevant parts of `HashMap` look like this:
+/// Slightly simplified, the relevant parts of `HashMap<K, V>` look like
+/// this:
 ///
 /// ```
 /// use std::borrow::Borrow;
@@ -70,15 +67,16 @@
 ///
 /// impl<K, V> HashMap<K, V> {
 ///     pub fn insert(&self, key: K, value: V) -> Option<V>
-///         where K: Hash + Eq
+///     where K: Hash + Eq
 ///     {
 ///         # unimplemented!()
 ///         // ...
 ///     }
 ///
 ///     pub fn get<Q>(&self, k: &Q) -> Option<&V>
-///         where K: Borrow<Q>,
-///               Q: Hash + Eq + ?Sized
+///     where
+///         K: Borrow<Q>,
+///         Q: Hash + Eq + ?Sized
 ///     {
 ///         # unimplemented!()
 ///         // ...
@@ -86,10 +84,11 @@
 /// }
 /// ```
 ///
-/// The entire hash map is generic over the stored type for the key, `K`.
-/// When inserting a value, the map is given such a `K` and needs to find
-/// the correct hash bucket and check if the key is already present based
-/// on that `K` value. It therefore requires `K: Hash + Eq`.
+/// The entire hash map is generic over a key type `K`. Because these keys
+/// are stored by with the hash map, this type as to own the key’s data.
+/// When inserting a key-value pair, the map is given such a `K` and needs
+/// to find the correct hash bucket and check if the key is already present
+/// based on that `K`. It therefore requires `K: Hash + Eq`.
 ///
 /// In order to search for a value based on the key’s data, the `get` method
 /// is generic over some type `Q`. Technically, it needs to convert that `Q`
@@ -103,10 +102,11 @@
 /// result as `Q`’s by demanding that `K: Borrow<Q>`.
 ///
 /// As a consequence, the hash map breaks if a `K` wrapping a `Q` value
-/// produces a different hash than `Q`. For instance, image you have a
-/// type that wraps a string but compares ASCII letters case-insensitive:
+/// produces a different hash than `Q`. For instance, imagine you have a
+/// type that wraps a string but compares ASCII letters ignoring their case:
 ///
 /// ```
+/// # #[allow(unused_imports)]
 /// use std::ascii::AsciiExt;
 ///
 /// pub struct CIString(String);
@@ -121,10 +121,10 @@
 /// ```
 ///
 /// Because two equal values need to produce the same hash value, the
-/// implementation of `Hash` need to reflect that, too:
+/// implementation of `Hash` needs to reflect that, too:
 ///
 /// ```
-/// # use std::ascii::AsciiExt;
+/// # #[allow(unused_imports)] use std::ascii::AsciiExt;
 /// # use std::hash::{Hash, Hasher};
 /// # pub struct CIString(String);
 /// impl Hash for CIString {
@@ -145,7 +145,7 @@
 /// which doesn’t carry any such restrictions.
 ///
 /// [`Hash`]: ../hash/trait.Hash.html
-/// [`HashMap`]: ../collections/struct.HashMap.html
+/// [`HashMap<K, V>`]: ../collections/struct.HashMap.html
 /// [`String`]: ../string/struct.String.html
 /// [`str`]: ../primitive.str.html
 ///

--- a/src/libcore/borrow.rs
+++ b/src/libcore/borrow.rs
@@ -12,26 +12,143 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-/// A trait for borrowing data.
+// impl Borrow<str> for String
+// impl<T> Borrow<T> for Arc<T>
+// impl<K> HashSet<K> { fn get<Q>(&self, q: &Q) where K: Borrow<Q> }
+
+/// A trait identifying how borrowed data behaves.
 ///
-/// In general, there may be several ways to "borrow" a piece of data.  The
-/// typical ways of borrowing a type `T` are `&T` (a shared borrow) and `&mut T`
-/// (a mutable borrow). But types like `Vec<T>` provide additional kinds of
-/// borrows: the borrowed slices `&[T]` and `&mut [T]`.
+/// If a type implements this trait, it signals that a reference to it behaves
+/// exactly like a reference to `Borrowed`. As a consequence, if a trait is
+/// implemented both by `Self` and `Borrowed`, all trait methods that
+/// take a `&self` argument must produce the same result in both
+/// implementations.
 ///
-/// When writing generic code, it is often desirable to abstract over all ways
-/// of borrowing data from a given type. That is the role of the `Borrow`
-/// trait: if `T: Borrow<U>`, then `&U` can be borrowed from `&T`.  A given
-/// type can be borrowed as multiple different types. In particular, `Vec<T>:
-/// Borrow<Vec<T>>` and `Vec<T>: Borrow<[T]>`.
+/// As a consequence, this trait should only be implemented for types managing
+/// a value of another type without modifying its behavior. Examples are
+/// smart pointers such as [`Box`] or [`Rc`] as well the owned version of
+/// slices such as [`Vec`].
 ///
-/// If you are implementing `Borrow` and both `Self` and `Borrowed` implement
-/// `Hash`, `Eq`, and/or `Ord`, they must produce the same result.
+/// A relaxed version that allows providing a reference to some other type
+/// without any further promises is available through [`AsRef`].
 ///
-/// `Borrow` is very similar to, but different than, `AsRef`. See
-/// [the book][book] for more.
+/// When writing generic code, a use of `Borrow` should always be justified
+/// by additional trait bounds, making it clear that the two types need to
+/// behave identically in a certain context. If the code should merely be
+/// able to operate on any type that can produce a reference to a given type,
+/// you should use [`AsRef`] instead.
 ///
-/// [book]: ../../book/first-edition/borrow-and-asref.html
+/// The companion trait [`BorrowMut`] provides the same guarantees for
+/// mutable references.
+///
+/// [`Box`]: ../boxed/struct.Box.html
+/// [`Rc`]: ../rc/struct.Rc.html
+/// [`Vec`]: ../vec/struct.Vec.html
+/// [`AsRef`]: ../convert/trait.AsRef.html
+/// [`BorrowMut`]: trait.BorrowMut.html
+///
+/// # Examples
+///
+/// As a data collection, [`HashMap`] owns both keys and values. If the key’s
+/// actual data is wrapped in a managing type of some kind, it should,
+/// however, still be possible to search for a value using a reference to the
+/// key’s data. For instance, if the key is a string, then it is likely
+/// stored with the hash map as a [`String`], while it should be possible
+/// to search using a [`&str`][`str`]. Thus, `insert` needs to operate on a
+/// string while `get` needs to be able to use a `&str`.
+///
+/// Slightly simplified, the relevant parts of `HashMap` look like this:
+///
+/// ```
+/// use std::borrow::Borrow;
+/// use std::hash::Hash;
+///
+/// pub struct HashMap<K, V> {
+///     # marker: ::std::marker::PhantomData<(K, V)>,
+///     // fields omitted
+/// }
+///
+/// impl<K, V> HashMap<K, V> {
+///     pub fn insert(&self, key: K, value: V) -> Option<V>
+///         where K: Hash + Eq
+///     {
+///         # unimplemented!()
+///         // ...
+///     }
+///
+///     pub fn get<Q>(&self, k: &Q) -> Option<&V>
+///         where K: Borrow<Q>,
+///               Q: Hash + Eq + ?Sized
+///     {
+///         # unimplemented!()
+///         // ...
+///     }
+/// }
+/// ```
+///
+/// The entire hash map is generic over the stored type for the key, `K`.
+/// When inserting a value, the map is given such a `K` and needs to find
+/// the correct hash bucket and check if the key is already present based
+/// on that `K` value. It therefore requires `K: Hash + Eq`.
+///
+/// In order to search for a value based on the key’s data, the `get` method
+/// is generic over some type `Q`. Technically, it needs to convert that `Q`
+/// into a `K` in order to use `K`’s [`Hash`] implementation to be able to
+/// arrive at the same hash value as during insertion in order to look into
+/// the right hash bucket. Since `K` is some kind of owned value, this likely
+/// would involve cloning and isn’t really practical.
+///
+/// Instead, `get` relies on `Q`’s implementation of `Hash` and uses `Borrow`
+/// to indicate that `K`’s implementation of `Hash` must produce the same
+/// result as `Q`’s by demanding that `K: Borrow<Q>`. 
+///
+/// As a consequence, the hash map breaks if a `K` wrapping a `Q` value
+/// produces a different hash than `Q`. For instance, image you have a
+/// type that wraps a string but compares ASCII letters case-insensitive:
+/// 
+/// ```
+/// use std::ascii::AsciiExt;
+///
+/// pub struct CIString(String);
+///
+/// impl PartialEq for CIString {
+///     fn eq(&self, other: &Self) -> bool {
+///         self.0.eq_ignore_ascii_case(&other.0)
+///     }
+/// }
+///
+/// impl Eq for CIString { }
+/// ```
+///
+/// Because two equal values need to produce the same hash value, the
+/// implementation of `Hash` need to reflect that, too:
+///
+/// ```
+/// # use std::ascii::AsciiExt;
+/// # use std::hash::{Hash, Hasher};
+/// # pub struct CIString(String);
+/// impl Hash for CIString {
+///     fn hash<H: Hasher>(&self, state: &mut H) {
+///         for c in self.0.as_bytes() {
+///             c.to_ascii_lowercase().hash(state)
+///         }
+///     }
+/// }
+/// ```
+///
+/// Can `CIString` implement `Borrow<str>`? It certainly can provide a
+/// reference to a string slice via its contained owned string. But because
+/// its `Hash` implementation differs, it cannot fulfill the guarantee for
+/// `Borrow` that all common trait implementations must behave the same way
+/// and must not, in fact, implement `Borrow<str>`. If it wants to allow
+/// others access to the underlying `str`, it can do that via `AsRef<str>`
+/// which doesn’t carry any such restrictions.
+///
+/// [`Hash`]: ../hash/trait.Hash.html
+/// [`HashMap`]: ../collections/struct.HashMap.html
+/// [`String`]: ../string/struct.String.html
+/// [`str`]: ../primitive.str.html
+/// 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Borrow<Borrowed: ?Sized> {
     /// Immutably borrows from an owned value.


### PR DESCRIPTION
This is the first step in improving the documentation for all the reference conversion traits. It proposes new text for the trait documentation of `Borrow`. Since I feel it is a somewhat radical rewrite and includes a stricter contract for `Borrow` then the previous text—namely that *all* shared traits need to behave the same, not just a select few—, I wanted to get some feedback before continuing.

Apart from the ‘normative’ description, the new text also includes a fairly extensive explanation of how the trait is used in the examples section. I included it because every time I look at how `HashMap` uses the trait, I need to think for a while as the use is a bit twisted. So, I thought having this thinking written down as part of the trait itself might be useful. One could argue that this should go into The Book, and, while I really like having everything important in the docs, I can see the text moved there, too.

So, before I move on: is this new text any good? Do we feel it is correct, useful, comprehensive, and understandable?

(This PR is in response to #44868 and #24140.)