### PR TITLE
rustc_trans: don't write discriminants for uninhabited variants

### DIFF
--- a/src/librustc_trans/mir/place.rs
+++ b/src/librustc_trans/mir/place.rs
@@ -359,14 +359,12 @@ impl<'a, 'tcx> PlaceRef<'tcx> {
     /// Set the discriminant for a new value of the given case of the given
     /// representation.
     pub fn trans_set_discr(&self, bcx: &Builder<'a, 'tcx>, variant_index: usize) {
-        match self.layout.variants {
+            if self.layout.for_variant(bcx.ccx, variant_index).abi == layout::Abi::Uninhabited {
+                return;
+            }
+            match self.layout.variants {
             layout::Variants::Single { index } => {
-                if index != variant_index {
-                    // If the layout of an enum is `Single`, all
-                    // other variants are necessarily uninhabited.
-                    assert_eq!(self.layout.for_variant(bcx.ccx, variant_index).abi,
-                               layout::Abi::Uninhabited);
-                }
+                assert_eq!(index, variant_index);
             }
             layout::Variants::Tagged { .. } => {
                 let ptr = self.project_field(bcx, 0);

--- a/src/test/run-pass/issue-46519.rs
+++ b/src/test/run-pass/issue-46519.rs
@@ -1,0 +1,37 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:--test -O
+
+#[test]
+#[should_panic(expected = "creating inhabited type")]
+fn test() {
+    FontLanguageOverride::system_font(SystemFont::new());
+}
+
+pub enum FontLanguageOverride {
+    Normal,
+    Override(&'static str),
+    System(SystemFont)
+}
+
+pub enum SystemFont {}
+
+impl FontLanguageOverride {
+    fn system_font(f: SystemFont) -> Self {
+        FontLanguageOverride::System(f)
+    }
+}
+
+impl SystemFont {
+    fn new() -> Self {
+        panic!("creating inhabited type")
+    }
+}


### PR DESCRIPTION
Fixes #46519.

Patch as suggested by eddyb: https://github.com/rust-lang/rust/issues/46519#issuecomment-349443519