### PR TITLE
rustc_mir: promote references of statics from other statics.

### DIFF
--- a/src/test/run-pass/issue-44373.rs
+++ b/src/test/run-pass/issue-44373.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z borrowck=compare
+
 struct Foo(bool);
 
 struct Container(&'static [&'static Foo]);


### PR DESCRIPTION
Fixes #46522 by also allowing `STATIC_REF` in MIR const-qualification, not just AST rvalue promotion.