### PR TITLE
Do not automatically merge `Cargo.lock`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@
 src/etc/installer/gfx/* binary
 *.woff binary
 src/vendor/** -text
+Cargo.lock -merge


### PR DESCRIPTION
It essentially never does what it's supposed to and often leaves the `Cargo.lock` in a state where it needs manual adjustments or resetting to master/yourbranch. With this setting git will always choose your `Cargo.lock` over the one from master and report a merge error (if both master and your branch touched `Cargo.lock`). Now you can run `./x.py help` and it should normally update the `Cargo.lock` to be one that has everything needed by master and your branch.