### PR TITLE
save-analysis: add parents to imports

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1596,6 +1596,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rls-data"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rls-rustc"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1964,7 +1973,7 @@ name = "rustc_save_analysis"
 version = "0.0.0"
 dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-data 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-data 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc 0.0.0",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2839,6 +2848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum rls-analysis 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "171fcab0206870b8bec0d2c60dea66f820ce648a85abffc66f7e2df95c283e06"
 "checksum rls-data 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff85bb3a0daf9f64207a5530d90ae1c10f5515cef064c88b6821090678382b44"
+"checksum rls-data 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8024f1feaca72d0aa4ae1e2a8d454a31b9a33ed02f8d0e9c8559bf53c267ec3c"
 "checksum rls-rustc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b21ea952e9bf1569929abf1bb920262cde04b7b1b26d8e0260286302807299d2"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
 "checksum rls-vfs 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd34691a510938bb67fe0444fb363103c73ffb31c121d1e16bc92d8945ea8ff"

--- a/src/librustc_save_analysis/Cargo.toml
+++ b/src/librustc_save_analysis/Cargo.toml
@@ -15,7 +15,7 @@ rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_typeck = { path = "../librustc_typeck" }
 syntax = { path = "../libsyntax" }
 syntax_pos = { path = "../libsyntax_pos" }
-rls-data = "0.13"
+rls-data = "0.14"
 rls-span = "0.4"
 # FIXME(#40527) should move rustc serialize out of tree
 rustc-serialize = "0.3"

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -1404,6 +1404,9 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> Visitor<'l> for DumpVisitor<'l, 'tc
                 if !self.span.filter_generated(alias_span, item.span) {
                     let span =
                         self.span_from_span(alias_span.expect("No span found for extern crate"));
+                    let parent = self.save_ctxt.tcx.hir.opt_local_def_id(item.id)
+                        .and_then(|id| self.save_ctxt.tcx.parent_def_id(id))
+                        .map(::id_from_def_id);
                     self.dumper.import(
                         &Access {
                             public: false,
@@ -1415,7 +1418,7 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> Visitor<'l> for DumpVisitor<'l, 'tc
                             span,
                             name: item.ident.to_string(),
                             value: String::new(),
-                            parent: None,
+                            parent,
                         },
                     );
                 }

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -1231,6 +1231,14 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> DumpVisitor<'l, 'tcx, 'll, O> {
         }
     }
 
+    /// Dumps imports in a use tree recursively.
+    ///
+    /// A use tree is an import that may contain nested braces (RFC 2128). The `use_tree` parameter
+    /// is the current use tree under scrutiny, while `id` and `prefix` are its corresponding node
+    /// id and path. `root_item` is the topmost use tree in the hierarchy.
+    ///
+    /// If `use_tree` is a simple or glob import, it is dumped into the analysis data. Otherwise,
+    /// each child use tree is dumped recursively.
     fn process_use_tree(&mut self,
                          use_tree: &'l ast::UseTree,
                          id: NodeId,
@@ -1238,6 +1246,8 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> DumpVisitor<'l, 'tcx, 'll, O> {
                          prefix: &ast::Path) {
         let path = &use_tree.prefix;
         let access = access_from!(self.save_ctxt, root_item);
+
+        // The parent def id of a given use tree is always the enclosing item.
         let parent = self.save_ctxt.tcx.hir.opt_local_def_id(id)
             .and_then(|id| self.save_ctxt.tcx.parent_def_id(id))
             .map(::id_from_def_id);


### PR DESCRIPTION
This PR populates the `parent` field added to `Import` in `rls-data` 0.14.

I'm not quite sure if I handled nested imports' parents correctly: this is a new feature to me.

r? @nrc

cc https://github.com/nrc/rls-analysis/issues/123