### PR TITLE
Recommends lazily evaluated alternatives for `Option::or` and `Result::or`

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -338,9 +338,11 @@ impl<T> Option<T> {
 
     /// Returns the contained value or a default.
     ///
-    /// Arguments passed to `unwrap_or` are eagerly evaluated; if you are passing 
-    /// the result of a function call, it is recommended to use `unwrap_or_else`, 
-    /// which is lazily evaluated. 
+    /// Arguments passed to `unwrap_or` are eagerly evaluated; if you are passing
+    /// the result of a function call, it is recommended to use [`unwrap_or_else`],
+    /// which is lazily evaluated.
+    ///
+    /// [`unwrap_or_else`]: #method.unwrap_or_else
     ///
     /// # Examples
     ///
@@ -456,7 +458,7 @@ impl<T> Option<T> {
     /// [`Ok(v)`] and [`None`] to [`Err(err)`].
     ///
     /// Arguments passed to `ok_or` are eagerly evaluated; if you are passing the
-    /// result of a function call, it is recommended to use `ok_or_else`, which is
+    /// result of a function call, it is recommended to use [`ok_or_else`], which is
     /// lazily evaluated.
     ///
     /// [`Result<T, E>`]: ../../std/result/enum.Result.html
@@ -464,6 +466,7 @@ impl<T> Option<T> {
     /// [`Err(err)`]: ../../std/result/enum.Result.html#variant.Err
     /// [`None`]: #variant.None
     /// [`Some(v)`]: #variant.Some
+    /// [`ok_or_else`]: #method.ok_or_else
     ///
     /// # Examples
     ///
@@ -618,8 +621,10 @@ impl<T> Option<T> {
     /// Returns the option if it contains a value, otherwise returns `optb`.
     ///
     /// Arguments passed to `or` are eagerly evaluated; if you are passing the
-    /// result of a function call, it is recommended to use `or_else`, which is
+    /// result of a function call, it is recommended to use [`or_else`], which is
     /// lazily evaluated.
+    ///
+    /// [`or_else`]: #method.or_else
     ///
     /// # Examples
     ///

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -338,6 +338,10 @@ impl<T> Option<T> {
 
     /// Returns the contained value or a default.
     ///
+    /// Arguments passed to `unwrap_or` are eagerly evaluated; if you are passing 
+    /// the result of a function call, it is recommended to use `unwrap_or_else`, 
+    /// which is lazily evaluated. 
+    ///
     /// # Examples
     ///
     /// ```
@@ -450,6 +454,10 @@ impl<T> Option<T> {
 
     /// Transforms the `Option<T>` into a [`Result<T, E>`], mapping [`Some(v)`] to
     /// [`Ok(v)`] and [`None`] to [`Err(err)`].
+    ///
+    /// Arguments passed to `ok_or` are eagerly evaluated; if you are passing the
+    /// result of a function call, it is recommended to use `ok_or_else`, which is
+    /// lazily evaluated.
     ///
     /// [`Result<T, E>`]: ../../std/result/enum.Result.html
     /// [`Ok(v)`]: ../../std/result/enum.Result.html#variant.Ok
@@ -608,6 +616,10 @@ impl<T> Option<T> {
     }
 
     /// Returns the option if it contains a value, otherwise returns `optb`.
+    ///
+    /// Arguments passed to `or` are eagerly evaluated; if you are passing the
+    /// result of a function call, it is recommended to use `or_else`, which is
+    /// lazily evaluated.
     ///
     /// # Examples
     ///

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -626,11 +626,12 @@ impl<T, E> Result<T, E> {
     /// Returns `res` if the result is [`Err`], otherwise returns the [`Ok`] value of `self`.
     ///
     /// Arguments passed to `or` are eagerly evaluated; if you are passing the
-    /// result of a function call, it is recommended to use `or_else`, which is
+    /// result of a function call, it is recommended to use [`or_else`], which is
     /// lazily evaluated.
     ///
     /// [`Ok`]: enum.Result.html#variant.Ok
     /// [`Err`]: enum.Result.html#variant.Err
+    /// [`or_else`]: #method.or_else
     ///
     /// # Examples
     ///
@@ -694,12 +695,13 @@ impl<T, E> Result<T, E> {
     /// Unwraps a result, yielding the content of an [`Ok`].
     /// Else, it returns `optb`.
     ///
-    /// Arguments passed to `unwrap_or` are eagerly evaluated; if you are passing 
-    /// the result of a function call, it is recommended to use `unwrap_or_else`, 
-    /// which is lazily evaluated. 
+    /// Arguments passed to `unwrap_or` are eagerly evaluated; if you are passing
+    /// the result of a function call, it is recommended to use [`unwrap_or_else`],
+    /// which is lazily evaluated.
     ///
     /// [`Ok`]: enum.Result.html#variant.Ok
     /// [`Err`]: enum.Result.html#variant.Err
+    /// [`unwrap_or_else`]: #method.unwrap_or_else
     ///
     /// # Examples
     ///

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -625,6 +625,10 @@ impl<T, E> Result<T, E> {
 
     /// Returns `res` if the result is [`Err`], otherwise returns the [`Ok`] value of `self`.
     ///
+    /// Arguments passed to `or` are eagerly evaluated; if you are passing the
+    /// result of a function call, it is recommended to use `or_else`, which is
+    /// lazily evaluated.
+    ///
     /// [`Ok`]: enum.Result.html#variant.Ok
     /// [`Err`]: enum.Result.html#variant.Err
     ///
@@ -689,6 +693,10 @@ impl<T, E> Result<T, E> {
 
     /// Unwraps a result, yielding the content of an [`Ok`].
     /// Else, it returns `optb`.
+    ///
+    /// Arguments passed to `unwrap_or` are eagerly evaluated; if you are passing 
+    /// the result of a function call, it is recommended to use `unwrap_or_else`, 
+    /// which is lazily evaluated. 
     ///
     /// [`Ok`]: enum.Result.html#variant.Ok
     /// [`Err`]: enum.Result.html#variant.Err


### PR DESCRIPTION
Adds language to docs for `Option` and `Result` recommending the use of lazily evaluated alternatives when appropriate. These comments are intended to echo a [clippy lint] on the same topic. The [reddit discussion] may also be of interest. 

[clippy lint]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#or_fun_call
[reddit discussion]: https://www.reddit.com/r/rust/comments/7hutqn/perils_of_optionor_and_resultor/