### PR TITLE
rustc: Further tweak linkage in ThinLTO

### DIFF
--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -970,7 +970,7 @@ LLVMRustCreateThinLTOData(LLVMRustThinLTOModule *modules,
   std::set<GlobalValue::GUID> ExportedGUIDs;
   for (auto &List : Ret->Index) {
     for (auto &GVS: List.second) {
-      if (!GlobalValue::isExternalLinkage(GVS->linkage()))
+      if (GlobalValue::isLocalLinkage(GVS->linkage()))
         continue;
       auto GUID = GVS->getOriginalName();
       if (!DeadSymbols.count(GUID))

--- a/src/test/run-pass/thinlto/weak-works.rs
+++ b/src/test/run-pass/thinlto/weak-works.rs
@@ -1,0 +1,37 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -C codegen-units=8 -Z thinlto
+// ignore-windows
+// min-llvm-version 4.0
+
+#![feature(linkage)]
+
+pub mod foo {
+    #[linkage = "weak"]
+    #[no_mangle]
+    pub extern "C" fn FOO() -> i32 {
+        0
+    }
+}
+
+mod bar {
+    extern "C" {
+        fn FOO() -> i32;
+    }
+
+    pub fn bar() -> i32 {
+        unsafe { FOO() }
+    }
+}
+
+fn main() {
+    bar::bar();
+}


### PR DESCRIPTION
In #46382 the logic around linkage preservation with ThinLTO ws tweaked but the
loop that registered all otherwise exported GUID values as "don't internalize
me please" was erroneously too conservative and only asking "external" linkage
items to not be internalized. Instead we actually want the inversion of that
condition, everything *without* "local" linkage to be internalized.

This commit updates the condition there, adds a test, and...

Closes #46543