### PR TITLE
macros: hygienize use of `core`/`std` in builtin macros

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -175,7 +175,7 @@ pub fn lower_crate(sess: &Session,
     let _ignore = dep_graph.in_ignore();
 
     LoweringContext {
-        crate_root: std_inject::injected_crate_name(krate),
+        crate_root: std_inject::injected_crate_name(),
         sess,
         cstore,
         parent_def: None,

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -262,6 +262,10 @@ impl<'a> Resolver<'a> {
                 let module =
                     self.get_module(DefId { krate: crate_id, index: CRATE_DEF_INDEX });
                 self.populate_module_if_necessary(module);
+                if self.injected_crate_name.map_or(false, |name| item.ident.name == name) {
+                    self.injected_crate = Some(module);
+                }
+
                 let used = self.process_legacy_macro_imports(item, module, expansion);
                 let binding =
                     (module, ty::Visibility::Public, sp, expansion).to_name_binding(self.arenas);
@@ -561,8 +565,7 @@ impl<'a> Resolver<'a> {
         if let Some(id) = self.definitions.as_local_node_id(def_id) {
             self.local_macro_def_scopes[&id]
         } else if def_id.krate == BUILTIN_MACROS_CRATE {
-            // FIXME(jseyfried): This happens when `include!()`ing a `$crate::` path, c.f, #40469.
-            self.graph_root
+            self.injected_crate.unwrap_or(self.graph_root)
         } else {
             let module_def_id = ty::DefIdTree::parent(&*self, def_id).unwrap();
             self.get_module(module_def_id)

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -40,6 +40,7 @@ use syntax::ext::base::Determinacy::Undetermined;
 use syntax::ext::hygiene::Mark;
 use syntax::ext::tt::macro_rules;
 use syntax::parse::token::{self, Token};
+use syntax::std_inject::injected_crate_name;
 use syntax::symbol::keywords;
 use syntax::symbol::Symbol;
 use syntax::visit::{self, Visitor};
@@ -262,7 +263,7 @@ impl<'a> Resolver<'a> {
                 let module =
                     self.get_module(DefId { krate: crate_id, index: CRATE_DEF_INDEX });
                 self.populate_module_if_necessary(module);
-                if self.injected_crate_name.map_or(false, |name| item.ident.name == name) {
+                if injected_crate_name().map_or(false, |name| item.ident.name == name) {
                     self.injected_crate = Some(module);
                 }
 

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -58,6 +58,7 @@ use syntax::ast::{Item, ItemKind, ImplItem, ImplItemKind};
 use syntax::ast::{Local, Mutability, Pat, PatKind, Path};
 use syntax::ast::{QSelf, TraitItemKind, TraitRef, Ty, TyKind};
 use syntax::feature_gate::{feature_err, emit_feature_err, GateIssue};
+use syntax::std_inject::injected_crate_name;
 
 use syntax_pos::{Span, DUMMY_SP, MultiSpan};
 use errors::{DiagnosticBuilder, DiagnosticId};
@@ -1333,6 +1334,9 @@ pub struct Resolver<'a> {
 
     // Only used for better errors on `fn(): fn()`
     current_type_ascription: Vec<Span>,
+
+    injected_crate_name: Option<&'static str>,
+    injected_crate: Option<Module<'a>>,
 }
 
 pub struct ResolverArenas<'a> {
@@ -1532,6 +1536,8 @@ impl<'a> Resolver<'a> {
             found_unresolved_macro: false,
             unused_macros: FxHashSet(),
             current_type_ascription: Vec::new(),
+            injected_crate_name: injected_crate_name(krate),
+            injected_crate: None,
         }
     }
 

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -58,7 +58,6 @@ use syntax::ast::{Item, ItemKind, ImplItem, ImplItemKind};
 use syntax::ast::{Local, Mutability, Pat, PatKind, Path};
 use syntax::ast::{QSelf, TraitItemKind, TraitRef, Ty, TyKind};
 use syntax::feature_gate::{feature_err, emit_feature_err, GateIssue};
-use syntax::std_inject::injected_crate_name;
 
 use syntax_pos::{Span, DUMMY_SP, MultiSpan};
 use errors::{DiagnosticBuilder, DiagnosticId};
@@ -1335,7 +1334,6 @@ pub struct Resolver<'a> {
     // Only used for better errors on `fn(): fn()`
     current_type_ascription: Vec<Span>,
 
-    injected_crate_name: Option<&'static str>,
     injected_crate: Option<Module<'a>>,
 }
 
@@ -1536,7 +1534,6 @@ impl<'a> Resolver<'a> {
             found_unresolved_macro: false,
             unused_macros: FxHashSet(),
             current_type_ascription: Vec::new(),
-            injected_crate_name: injected_crate_name(krate),
             injected_crate: None,
         }
     }

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -319,9 +319,12 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                 types: Vec<P<ast::Ty>>,
                 bindings: Vec<ast::TypeBinding> )
                 -> ast::Path {
+        use syntax::parse::token;
+
         let last_identifier = idents.pop().unwrap();
         let mut segments: Vec<ast::PathSegment> = Vec::new();
-        if global {
+        if global &&
+           !idents.first().map_or(false, |&ident| token::Ident(ident).is_path_segment_keyword()) {
             segments.push(ast::PathSegment::crate_root(span));
         }
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -25,7 +25,6 @@ use parse::{DirectoryOwnership, PResult};
 use parse::token::{self, Token};
 use parse::parser::Parser;
 use ptr::P;
-use std_inject;
 use symbol::Symbol;
 use symbol::keywords;
 use syntax_pos::{Span, DUMMY_SP};
@@ -219,7 +218,6 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
     }
 
     pub fn expand_crate(&mut self, mut krate: ast::Crate) -> ast::Crate {
-        self.cx.crate_root = std_inject::injected_crate_name(&krate);
         let mut module = ModuleData {
             mod_path: vec![Ident::from_str(&self.cx.ecfg.crate_name)],
             directory: self.cx.codemap().span_to_unmapped_path(krate.span),

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -272,7 +272,7 @@ fn generate_test_harness(sess: &ParseSess,
 
     let mark = Mark::fresh(Mark::root());
 
-    let mut cx: TestCtxt = TestCtxt {
+    let cx = TestCtxt {
         span_diagnostic: sd,
         ext_cx: ExtCtxt::new(sess, ExpansionConfig::default("test".to_string()), resolver),
         path: Vec::new(),
@@ -283,7 +283,6 @@ fn generate_test_harness(sess: &ParseSess,
         toplevel_reexport: None,
         ctxt: SyntaxContext::empty().apply_mark(mark),
     };
-    cx.ext_cx.crate_root = Some("std");
 
     mark.set_expn_info(ExpnInfo {
         call_site: DUMMY_SP,

--- a/src/libsyntax_ext/deriving/bounds.rs
+++ b/src/libsyntax_ext/deriving/bounds.rs
@@ -8,9 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use deriving::path_std;
 use deriving::generic::*;
 use deriving::generic::ty::*;
-
 use syntax::ast::MetaItem;
 use syntax::ext::base::{Annotatable, ExtCtxt};
 use syntax_pos::Span;
@@ -28,15 +28,10 @@ pub fn expand_deriving_copy(cx: &mut ExtCtxt,
                             mitem: &MetaItem,
                             item: &Annotatable,
                             push: &mut FnMut(Annotatable)) {
-    let mut v = cx.crate_root.map(|s| vec![s]).unwrap_or(Vec::new());
-    v.push("marker");
-    v.push("Copy");
-    let path = Path::new(v);
-
     let trait_def = TraitDef {
         span,
         attributes: Vec::new(),
-        path,
+        path: path_std!(cx, marker::Copy),
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         is_unsafe: false,

--- a/src/libsyntax_ext/deriving/clone.rs
+++ b/src/libsyntax_ext/deriving/clone.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use deriving::path_std;
 use deriving::generic::*;
 use deriving::generic::ty::*;
 
@@ -55,7 +56,7 @@ pub fn expand_deriving_clone(cx: &mut ExtCtxt,
                     }));
                 }
                 ItemKind::Union(..) => {
-                    bounds = vec![Literal(path_std!(cx, core::marker::Copy))];
+                    bounds = vec![Literal(path_std!(cx, marker::Copy))];
                     is_shallow = true;
                     substructure = combine_substructure(Box::new(|c, s, sub| {
                         cs_clone_shallow("Clone", c, s, sub, true)
@@ -79,7 +80,7 @@ pub fn expand_deriving_clone(cx: &mut ExtCtxt,
     let trait_def = TraitDef {
         span,
         attributes: Vec::new(),
-        path: path_std!(cx, core::clone::Clone),
+        path: path_std!(cx, clone::Clone),
         additional_bounds: bounds,
         generics: LifetimeBounds::empty(),
         is_unsafe: false,

--- a/src/libsyntax_ext/deriving/cmp/eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/eq.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use deriving::path_std;
 use deriving::generic::*;
 use deriving::generic::ty::*;
 
@@ -30,7 +31,7 @@ pub fn expand_deriving_eq(cx: &mut ExtCtxt,
     let trait_def = TraitDef {
         span,
         attributes: Vec::new(),
-        path: path_std!(cx, core::cmp::Eq),
+        path: path_std!(cx, cmp::Eq),
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         is_unsafe: false,

--- a/src/libsyntax_ext/deriving/cmp/ord.rs
+++ b/src/libsyntax_ext/deriving/cmp/ord.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use deriving::path_std;
 use deriving::generic::*;
 use deriving::generic::ty::*;
 
@@ -28,7 +29,7 @@ pub fn expand_deriving_ord(cx: &mut ExtCtxt,
     let trait_def = TraitDef {
         span,
         attributes: Vec::new(),
-        path: path_std!(cx, core::cmp::Ord),
+        path: path_std!(cx, cmp::Ord),
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         is_unsafe: false,
@@ -38,7 +39,7 @@ pub fn expand_deriving_ord(cx: &mut ExtCtxt,
                           generics: LifetimeBounds::empty(),
                           explicit_self: borrowed_explicit_self(),
                           args: vec![borrowed_self()],
-                          ret_ty: Literal(path_std!(cx, core::cmp::Ordering)),
+                          ret_ty: Literal(path_std!(cx, cmp::Ordering)),
                           attributes: attrs,
                           is_unsafe: false,
                           unify_fieldless_variants: true,

--- a/src/libsyntax_ext/deriving/cmp/partial_eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/partial_eq.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use deriving::{path_local, path_std};
 use deriving::generic::*;
 use deriving::generic::ty::*;
 
@@ -93,7 +94,7 @@ pub fn expand_deriving_partial_eq(cx: &mut ExtCtxt,
     let trait_def = TraitDef {
         span,
         attributes: Vec::new(),
-        path: path_std!(cx, core::cmp::PartialEq),
+        path: path_std!(cx, cmp::PartialEq),
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         is_unsafe: false,

--- a/src/libsyntax_ext/deriving/cmp/partial_ord.rs
+++ b/src/libsyntax_ext/deriving/cmp/partial_ord.rs
@@ -10,6 +10,7 @@
 
 pub use self::OrderingOp::*;
 
+use deriving::{path_local, pathvec_std, path_std};
 use deriving::generic::*;
 use deriving::generic::ty::*;
 
@@ -45,11 +46,11 @@ pub fn expand_deriving_partial_ord(cx: &mut ExtCtxt,
         } }
     }
 
-    let ordering_ty = Literal(path_std!(cx, core::cmp::Ordering));
-    let ret_ty = Literal(Path::new_(pathvec_std!(cx, core::option::Option),
+    let ordering_ty = Literal(path_std!(cx, cmp::Ordering));
+    let ret_ty = Literal(Path::new_(pathvec_std!(cx, option::Option),
                                     None,
                                     vec![Box::new(ordering_ty)],
-                                    true));
+                                    PathKind::Std));
 
     let inline = cx.meta_word(span, Symbol::intern("inline"));
     let attrs = vec![cx.attribute(span, inline)];
@@ -84,7 +85,7 @@ pub fn expand_deriving_partial_ord(cx: &mut ExtCtxt,
     let trait_def = TraitDef {
         span,
         attributes: vec![],
-        path: path_std!(cx, core::cmp::PartialOrd),
+        path: path_std!(cx, cmp::PartialOrd),
         additional_bounds: vec![],
         generics: LifetimeBounds::empty(),
         is_unsafe: false,

--- a/src/libsyntax_ext/deriving/debug.rs
+++ b/src/libsyntax_ext/deriving/debug.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use deriving::path_std;
 use deriving::generic::*;
 use deriving::generic::ty::*;
 
@@ -24,13 +25,13 @@ pub fn expand_deriving_debug(cx: &mut ExtCtxt,
                              item: &Annotatable,
                              push: &mut FnMut(Annotatable)) {
     // &mut ::std::fmt::Formatter
-    let fmtr = Ptr(Box::new(Literal(path_std!(cx, core::fmt::Formatter))),
+    let fmtr = Ptr(Box::new(Literal(path_std!(cx, fmt::Formatter))),
                    Borrowed(None, ast::Mutability::Mutable));
 
     let trait_def = TraitDef {
         span,
         attributes: Vec::new(),
-        path: path_std!(cx, core::fmt::Debug),
+        path: path_std!(cx, fmt::Debug),
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         is_unsafe: false,
@@ -40,7 +41,7 @@ pub fn expand_deriving_debug(cx: &mut ExtCtxt,
                           generics: LifetimeBounds::empty(),
                           explicit_self: borrowed_explicit_self(),
                           args: vec![fmtr],
-                          ret_ty: Literal(path_std!(cx, core::fmt::Result)),
+                          ret_ty: Literal(path_std!(cx, fmt::Result)),
                           attributes: Vec::new(),
                           is_unsafe: false,
                           unify_fieldless_variants: false,

--- a/src/libsyntax_ext/deriving/decodable.rs
+++ b/src/libsyntax_ext/deriving/decodable.rs
@@ -10,7 +10,7 @@
 
 //! The compiler code necessary for `#[derive(Decodable)]`. See encodable.rs for more.
 
-use deriving;
+use deriving::{self, pathvec_std};
 use deriving::generic::*;
 use deriving::generic::ty::*;
 use deriving::warn_if_deprecated;
@@ -46,20 +46,12 @@ fn expand_deriving_decodable_imp(cx: &mut ExtCtxt,
                                  item: &Annotatable,
                                  push: &mut FnMut(Annotatable),
                                  krate: &'static str) {
-    if cx.crate_root != Some("std") {
-        // FIXME(#21880): lift this requirement.
-        cx.span_err(span,
-                    "this trait cannot be derived with #![no_std] \
-                           or #![no_core]");
-        return;
-    }
-
     let typaram = &*deriving::hygienic_type_parameter(item, "__D");
 
     let trait_def = TraitDef {
         span,
         attributes: Vec::new(),
-        path: Path::new_(vec![krate, "Decodable"], None, vec![], true),
+        path: Path::new_(vec![krate, "Decodable"], None, vec![], PathKind::Global),
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         is_unsafe: false,
@@ -72,18 +64,18 @@ fn expand_deriving_decodable_imp(cx: &mut ExtCtxt,
                                             vec![Path::new_(vec![krate, "Decoder"],
                                                             None,
                                                             vec![],
-                                                            true)])],
+                                                            PathKind::Global)])],
                           },
                           explicit_self: None,
                           args: vec![Ptr(Box::new(Literal(Path::new_local(typaram))),
                                          Borrowed(None, Mutability::Mutable))],
                           ret_ty:
-                              Literal(Path::new_(pathvec_std!(cx, core::result::Result),
+                              Literal(Path::new_(pathvec_std!(cx, result::Result),
                                                  None,
                                                  vec![Box::new(Self_), Box::new(Literal(Path::new_(
-                        vec![typaram, "Error"], None, vec![], false
+                        vec![typaram, "Error"], None, vec![], PathKind::Local
                     )))],
-                                                 true)),
+                                                 PathKind::Std)),
                           attributes: Vec::new(),
                           is_unsafe: false,
                           unify_fieldless_variants: false,

--- a/src/libsyntax_ext/deriving/default.rs
+++ b/src/libsyntax_ext/deriving/default.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use deriving::path_std;
 use deriving::generic::*;
 use deriving::generic::ty::*;
 
@@ -28,7 +29,7 @@ pub fn expand_deriving_default(cx: &mut ExtCtxt,
     let trait_def = TraitDef {
         span,
         attributes: Vec::new(),
-        path: path_std!(cx, core::default::Default),
+        path: path_std!(cx, default::Default),
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         is_unsafe: false,

--- a/src/libsyntax_ext/deriving/hash.rs
+++ b/src/libsyntax_ext/deriving/hash.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use deriving;
+use deriving::{self, pathvec_std, path_std};
 use deriving::generic::*;
 use deriving::generic::ty::*;
 
@@ -24,7 +24,7 @@ pub fn expand_deriving_hash(cx: &mut ExtCtxt,
                             item: &Annotatable,
                             push: &mut FnMut(Annotatable)) {
 
-    let path = Path::new_(pathvec_std!(cx, core::hash::Hash), None, vec![], true);
+    let path = Path::new_(pathvec_std!(cx, hash::Hash), None, vec![], PathKind::Std);
 
     let typaram = &*deriving::hygienic_type_parameter(item, "__H");
 
@@ -41,7 +41,7 @@ pub fn expand_deriving_hash(cx: &mut ExtCtxt,
                           name: "hash",
                           generics: LifetimeBounds {
                               lifetimes: Vec::new(),
-                              bounds: vec![(typaram, vec![path_std!(cx, core::hash::Hasher)])],
+                              bounds: vec![(typaram, vec![path_std!(cx, hash::Hasher)])],
                           },
                           explicit_self: borrowed_explicit_self(),
                           args: vec![Ptr(Box::new(Literal(arg)),

--- a/src/libsyntax_ext/deriving/mod.rs
+++ b/src/libsyntax_ext/deriving/mod.rs
@@ -19,32 +19,16 @@ use syntax::ptr::P;
 use syntax::symbol::Symbol;
 use syntax_pos::Span;
 
-macro_rules! pathvec {
-    ($($x:ident)::+) => (
-        vec![ $( stringify!($x) ),+ ]
-    )
+macro path_local($x:ident) {
+    generic::ty::Path::new_local(stringify!($x))
 }
 
-macro_rules! path_local {
-    ($x:ident) => (
-        ::deriving::generic::ty::Path::new_local(stringify!($x))
-    )
-}
+macro pathvec_std($cx:expr, $($rest:ident)::+) {{
+    vec![ $( stringify!($rest) ),+ ]
+}}
 
-macro_rules! pathvec_std {
-    ($cx:expr, $first:ident :: $($rest:ident)::+) => ({
-        let mut v = pathvec![$($rest)::+];
-        if let Some(s) = $cx.crate_root {
-            v.insert(0, s);
-        }
-        v
-    })
-}
-
-macro_rules! path_std {
-    ($($x:tt)*) => (
-        ::deriving::generic::ty::Path::new( pathvec_std!( $($x)* ) )
-    )
+macro path_std($($x:tt)*) {
+    generic::ty::Path::new( pathvec_std!( $($x)* ) )
 }
 
 pub mod bounds;

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -16,6 +16,7 @@
 #![deny(warnings)]
 
 #![feature(proc_macro_internals)]
+#![feature(decl_macro)]
 
 extern crate fmt_macros;
 #[macro_use]

--- a/src/test/pretty/issue-4264.pp
+++ b/src/test/pretty/issue-4264.pp
@@ -40,7 +40,7 @@ pub fn bar() ({
 
 
                   ((::fmt::format as
-                       for<'r> fn(std::fmt::Arguments<'r>) -> std::string::String {std::fmt::format})(((<::std::fmt::Arguments>::new_v1
+                       for<'r> fn(std::fmt::Arguments<'r>) -> std::string::String {std::fmt::format})(((<::fmt::Arguments>::new_v1
                                                                                                            as
                                                                                                            fn(&[&str], &[std::fmt::ArgumentV1<'_>]) -> std::fmt::Arguments<'_> {std::fmt::Arguments<'_>::new_v1})((&([("test"
                                                                                                                                                                                                                           as

--- a/src/test/run-pass-fulldeps/auxiliary/custom_derive_partial_eq.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/custom_derive_partial_eq.rs
@@ -69,7 +69,7 @@ fn expand_deriving_partial_eq(cx: &mut ExtCtxt, span: Span, mitem: &MetaItem, it
     let trait_def = TraitDef {
         span: span,
         attributes: Vec::new(),
-        path: deriving::generic::ty::Path::new(vec!["std", "cmp", "PartialEq"]),
+        path: deriving::generic::ty::Path::new(vec!["cmp", "PartialEq"]),
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         is_unsafe: false,

--- a/src/test/run-pass-fulldeps/auxiliary/custom_derive_plugin.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/custom_derive_plugin.rs
@@ -50,7 +50,7 @@ fn expand(cx: &mut ExtCtxt,
     let trait_def = TraitDef {
         span: span,
         attributes: vec![],
-        path: Path::new(vec!["TotalSum"]),
+        path: Path::new_local("TotalSum"),
         additional_bounds: vec![],
         generics: LifetimeBounds::empty(),
         associated_types: vec![],

--- a/src/test/run-pass-fulldeps/auxiliary/custom_derive_plugin_attr.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/custom_derive_plugin_attr.rs
@@ -46,7 +46,7 @@ fn expand(cx: &mut ExtCtxt,
     let trait_def = TraitDef {
         span: span,
         attributes: vec![],
-        path: Path::new(vec!["TotalSum"]),
+        path: Path::new_local("TotalSum"),
         additional_bounds: vec![],
         generics: LifetimeBounds::empty(),
         associated_types: vec![],

--- a/src/test/run-pass-fulldeps/derive-no-std-not-supported.rs
+++ b/src/test/run-pass-fulldeps/derive-no-std-not-supported.rs
@@ -8,22 +8,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(rustc_private)]
 #![no_std]
 
 extern crate serialize as rustc_serialize;
 
-#[derive(RustcEncodable)]  //~ ERROR this trait cannot be derived
+#[derive(RustcEncodable)]
 struct Bar {
     x: u32,
 }
 
-#[derive(RustcDecodable)]  //~ ERROR this trait cannot be derived
+#[derive(RustcDecodable)]
 struct Baz {
     x: u32,
 }
 
 fn main() {
-    Foo { x: 0 };
     Bar { x: 0 };
     Baz { x: 0 };
 }


### PR DESCRIPTION
Today, if a builtin macro wants to access an item from `core` or `std` (depending `#![no_std]`), it generates `::core::path::to::item` or `::std::path::to::item` respectively (c.f. `fn std_path()` in `libsyntax/ext/base.rs`).

This PR refactors the builtin macros to instead always emit `$crate::path::to::item` here. That is, the def site of builtin macros is taken to be in `extern crate core;` or `extern crate std;`. Since builtin macros are macros 1.0 (i.e. mostly unhygienic), changing the def site can only effect the resolution of `$crate`.

r? @nrc 