### PR TITLE
Make CGU-local globals private so they don't show up in the local symbol table.

### DIFF
--- a/src/librustc_trans/consts.rs
+++ b/src/librustc_trans/consts.rs
@@ -74,7 +74,7 @@ pub fn addr_of_mut(ccx: &CrateContext,
         });
         llvm::LLVMSetInitializer(gv, cv);
         set_global_alignment(ccx, gv, align);
-        llvm::LLVMRustSetLinkage(gv, llvm::Linkage::InternalLinkage);
+        llvm::LLVMRustSetLinkage(gv, llvm::Linkage::PrivateLinkage);
         SetUnnamedAddr(gv, true);
         gv
     }


### PR DESCRIPTION
Should reduce binary sizes. Great find, @eddyb!

r? @alexcrichton 
(I have not tested this locally. Better wait for travis to turn green before approving)