### PR TITLE
turn errors from loading external docs into a proper lint

### DIFF
--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -139,6 +139,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
                  MutableTransmutes,
                  UnionsWithDropFields,
                  UnreachablePub,
+                 ExternalDocError,
                  );
 
     add_builtin_with_new!(sess,

--- a/src/test/compile-fail/lint-external-doc-error.rs
+++ b/src/test/compile-fail/lint-external-doc-error.rs
@@ -11,5 +11,7 @@
 #![feature(external_doc)]
 #![deny(external_doc_error)]
 
-#[doc(include = "not-a-file.md")] //~ ERROR
+#[doc(include = "not-a-file.md")] //~ ERROR: couldn't read
 pub struct SomeStruct;
+
+fn main() {}

--- a/src/test/compile-fail/lint-external-doc-error.rs
+++ b/src/test/compile-fail/lint-external-doc-error.rs
@@ -1,0 +1,15 @@
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(external_doc)]
+#![deny(external_doc_error)]
+
+#[doc(include = "not-a-file.md")] //~ ERROR
+pub struct SomeStruct;


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/44732

Based on discussion surrounding the original implementation, i wanted (1) the ability to test for errors that can occur during loading the file, and (2) the ability to let people silence them if they don't care about the docs, while also making rustdoc give an error for them.

The current design goes like this:

* libsyntax transforms a `#[doc(include="filename")]` into a `#[doc(include(file="filename, error="error message"))]` if it can't load the file (or if it's not UTF-8).
* The new `external_doc_error` lint picks up this format and emits a warning if it finds any.
  * It's not an error because the documentation isn't relevant to the compilation process, but i also wanted to warn about it. I could make it allow-by-default if that makes more sense.
  * The initial implementation currently emits a warning in libsyntax that isn't covered by `#[allow(warnings)]`.
* Rustdoc picks up this format and emits an error if it finds any.
  * The initial implementation currently ignores these errors, since the attribute is swallowed if libsyntax hits a problem.

I added a test for it, but for some reason it doesn't seem to generate the error i expected. When running compiletest on my own system it didn't seem to generate an error or warning at all. Hence the current WIP status.