### PR TITLE
Ignore `unsopported constant expr` error

### DIFF
--- a/src/librustc_passes/consts.rs
+++ b/src/librustc_passes/consts.rs
@@ -135,6 +135,7 @@ impl<'a, 'gcx> CheckCrateVisitor<'a, 'gcx> {
                 IndexOpFeatureGated => {}
                 ErroneousReferencedConstant(_) => {}
                 TypeckError => {}
+                MiscCatchAll => {}
                 _ => {
                     self.tcx.lint_node(CONST_ERR,
                                        expr.id,

--- a/src/test/compile-fail/issue-7364.rs
+++ b/src/test/compile-fail/issue-7364.rs
@@ -16,6 +16,5 @@ use std::cell::RefCell;
 static boxed: Box<RefCell<isize>> = box RefCell::new(0);
 //~^ ERROR allocations are not allowed in statics
 //~| ERROR `std::cell::RefCell<isize>: std::marker::Sync` is not satisfied
-//~| WARN unsupported constant expr
 
 fn main() { }

--- a/src/test/compile-fail/static-mut-not-constant.rs
+++ b/src/test/compile-fail/static-mut-not-constant.rs
@@ -12,6 +12,5 @@
 
 static mut a: Box<isize> = box 3;
 //~^ ERROR allocations are not allowed in statics
-//~| WARN: constant evaluation error
 
 fn main() {}

--- a/src/test/run-pass/issue-46553.rs
+++ b/src/test/run-pass/issue-46553.rs
@@ -1,0 +1,32 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(const_fn)]
+#![warn(const_err)]
+
+pub struct Data<T> {
+    function: fn() -> T,
+}
+
+impl<T> Data<T> {
+    pub const fn new(function: fn() -> T) -> Data<T> {
+        Data {
+            function: function,
+        }
+    }
+}
+
+pub static DATA: Data<i32> = Data::new(|| {
+    413i32
+});
+
+fn main() {
+    print!("{:?}", (DATA.function)());
+}

--- a/src/test/run-pass/issue-46553.rs
+++ b/src/test/run-pass/issue-46553.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #![feature(const_fn)]
-#![warn(const_err)]
+#![deny(const_err)]
 
 pub struct Data<T> {
     function: fn() -> T,


### PR DESCRIPTION
Fixes #46553 