### PR TITLE
Bump beta to .2.

### DIFF
--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -29,7 +29,7 @@ pub const CFG_RELEASE_NUM: &str = "1.23.0";
 // An optional number to put after the label, e.g. '.2' -> '-beta.2'
 // Be sure to make this starts with a dot to conform to semver pre-release
 // versions (section 9)
-pub const CFG_PRERELEASE_VERSION: &str = ".1";
+pub const CFG_PRERELEASE_VERSION: &str = ".2";
 
 pub struct GitInfo {
     inner: Option<Info>,


### PR DESCRIPTION
Trigger a 1.23.0-beta.2 release to make #46516 availble, which blocks some issues for Firefox.