### PR TITLE
Fix 45345

### DIFF
--- a/src/bootstrap/bin/rustdoc.rs
+++ b/src/bootstrap/bin/rustdoc.rs
@@ -23,7 +23,7 @@ use std::path::PathBuf;
 fn main() {
     let args = env::args_os().skip(1).collect::<Vec<_>>();
     let rustdoc = env::var_os("RUSTDOC_REAL").expect("RUSTDOC_REAL was not set");
-    let libdir = env::var_os("RUSTC_LIBDIR").expect("RUSTC_LIBDIR was not set");
+    let libdir = env::var_os("RUSTDOC_LIBDIR").expect("RUSTDOC_LIBDIR was not set");
     let stage = env::var("RUSTC_STAGE").expect("RUSTC_STAGE was not set");
     let sysroot = env::var_os("RUSTC_SYSROOT").expect("RUSTC_SYSROOT was not set");
 

--- a/src/bootstrap/bin/rustdoc.rs
+++ b/src/bootstrap/bin/rustdoc.rs
@@ -27,6 +27,13 @@ fn main() {
     let stage = env::var("RUSTC_STAGE").expect("RUSTC_STAGE was not set");
     let sysroot = env::var_os("RUSTC_SYSROOT").expect("RUSTC_SYSROOT was not set");
 
+    use std::str::FromStr;
+
+    let verbose = match env::var("RUSTC_VERBOSE") {
+        Ok(s) => usize::from_str(&s).expect("RUSTC_VERBOSE should be an integer"),
+        Err(_) => 0,
+    };
+
     let mut dylib_path = bootstrap::util::dylib_path();
     dylib_path.insert(0, PathBuf::from(libdir));
 
@@ -61,6 +68,10 @@ fn main() {
         // While we can assume that `-Z unstable-options` is set, let's also force rustdoc to panic
         // if pulldown rendering differences are found
         cmd.arg("--deny-render-differences");
+    }
+
+    if verbose > 1 {
+        eprintln!("rustdoc command: {:?}", cmd);
     }
 
     std::process::exit(match cmd.status() {

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -357,7 +357,7 @@ impl<'a> Builder<'a> {
 
             fn run(self, builder: &Builder) -> Interned<PathBuf> {
                 let compiler = self.compiler;
-                let lib = if compiler.stage >= 2 && builder.build.config.libdir_relative.is_some() {
+                let lib = if compiler.stage >= 1 && builder.build.config.libdir_relative.is_some() {
                     builder.build.config.libdir_relative.clone().unwrap()
                 } else {
                     PathBuf::from("lib")

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -416,7 +416,7 @@ impl<'a> Builder<'a> {
         let compiler = self.compiler(self.top_stage, host);
         cmd.env("RUSTC_STAGE", compiler.stage.to_string())
            .env("RUSTC_SYSROOT", self.sysroot(compiler))
-           .env("RUSTC_LIBDIR", self.sysroot_libdir(compiler, self.build.build))
+           .env("RUSTDOC_LIBDIR", self.sysroot_libdir(compiler, self.build.build))
            .env("CFG_RELEASE_CHANNEL", &self.build.config.channel)
            .env("RUSTDOC_REAL", self.rustdoc(host))
            .env("RUSTDOC_CRATE_VERSION", self.build.rust_version())
@@ -495,6 +495,9 @@ impl<'a> Builder<'a> {
         }
         if let Some(target_linker) = self.build.linker(target) {
             cargo.env("RUSTC_TARGET_LINKER", target_linker);
+        }
+        if cmd != "build" {
+            cargo.env("RUSTDOC_LIBDIR", self.rustc_libdir(self.compiler(2, self.build.build)));
         }
 
         if mode != Mode::Tool {

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -357,8 +357,8 @@ impl<'a> Builder<'a> {
 
             fn run(self, builder: &Builder) -> Interned<PathBuf> {
                 let compiler = self.compiler;
-                let lib = if compiler.stage >= 1 && builder.build.config.libdir_relative.is_some() {
-                    builder.build.config.libdir_relative.clone().unwrap()
+                let lib = if compiler.stage >= 1 && builder.build.config.libdir.is_some() {
+                    builder.build.config.libdir.clone().unwrap()
                 } else {
                     PathBuf::from("lib")
                 };

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -1166,7 +1166,7 @@ impl Step for Crate {
             }
             Mode::Librustc => {
                 builder.ensure(compile::Rustc { compiler, target });
-                compile::rustc_cargo(build, &compiler, target, &mut cargo);
+                compile::rustc_cargo(build, target, &mut cargo);
                 ("librustc", "rustc-main")
             }
             _ => panic!("can only test libraries"),

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -500,7 +500,7 @@ impl Step for Rustc {
 
 /// Same as `std_cargo`, but for libtest
 pub fn rustc_cargo(build: &Build,
-                   compiler: &Compiler,
+                   _compiler: &Compiler,
                    target: Interned<String>,
                    cargo: &mut Command) {
     cargo.arg("--features").arg(build.rustc_features())
@@ -514,13 +514,9 @@ pub fn rustc_cargo(build: &Build,
          .env("CFG_VERSION", build.rust_version())
          .env("CFG_PREFIX", build.config.prefix.clone().unwrap_or_default());
 
-    if compiler.stage == 0 {
-        cargo.env("CFG_LIBDIR_RELATIVE", "lib");
-    } else {
-        let libdir_relative =
-            build.config.libdir_relative.clone().unwrap_or(PathBuf::from("lib"));
-        cargo.env("CFG_LIBDIR_RELATIVE", libdir_relative);
-    }
+    let libdir_relative =
+        build.config.libdir_relative.clone().unwrap_or(PathBuf::from("lib"));
+    cargo.env("CFG_LIBDIR_RELATIVE", libdir_relative);
 
     // If we're not building a compiler with debugging information then remove
     // these two env vars which would be set otherwise.

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -485,7 +485,7 @@ impl Step for Rustc {
         build.clear_if_dirty(&stage_out, &libtest_stamp(build, compiler, target));
 
         let mut cargo = builder.cargo(compiler, Mode::Librustc, target, "build");
-        rustc_cargo(build, &compiler, target, &mut cargo);
+        rustc_cargo(build, target, &mut cargo);
         run_cargo(build,
                   &mut cargo,
                   &librustc_stamp(build, compiler, target));
@@ -500,7 +500,6 @@ impl Step for Rustc {
 
 /// Same as `std_cargo`, but for libtest
 pub fn rustc_cargo(build: &Build,
-                   _compiler: &Compiler,
                    target: Interned<String>,
                    cargo: &mut Command) {
     cargo.arg("--features").arg(build.rustc_features())

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -514,7 +514,7 @@ pub fn rustc_cargo(build: &Build,
          .env("CFG_PREFIX", build.config.prefix.clone().unwrap_or_default());
 
     let libdir_relative =
-        build.config.libdir_relative.clone().unwrap_or(PathBuf::from("lib"));
+        build.config.libdir.clone().unwrap_or(PathBuf::from("lib"));
     cargo.env("CFG_LIBDIR_RELATIVE", libdir_relative);
 
     // If we're not building a compiler with debugging information then remove

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -403,6 +403,7 @@ impl Config {
             config.docdir = install.docdir.clone().map(PathBuf::from);
             config.bindir = install.bindir.clone().map(PathBuf::from);
             config.libdir = install.libdir.clone().map(PathBuf::from);
+            config.libdir_relative = install.libdir.clone().map(PathBuf::from);
             config.mandir = install.mandir.clone().map(PathBuf::from);
         }
 

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -121,7 +121,6 @@ pub struct Config {
     pub docdir: Option<PathBuf>,
     pub bindir: Option<PathBuf>,
     pub libdir: Option<PathBuf>,
-    pub libdir_relative: Option<PathBuf>,
     pub mandir: Option<PathBuf>,
     pub codegen_tests: bool,
     pub nodejs: Option<PathBuf>,
@@ -403,7 +402,6 @@ impl Config {
             config.docdir = install.docdir.clone().map(PathBuf::from);
             config.bindir = install.bindir.clone().map(PathBuf::from);
             config.libdir = install.libdir.clone().map(PathBuf::from);
-            config.libdir_relative = install.libdir.clone().map(PathBuf::from);
             config.mandir = install.mandir.clone().map(PathBuf::from);
         }
 

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -616,7 +616,7 @@ impl Step for Rustc {
         t!(symlink_dir_force(&my_out, &out_dir));
 
         let mut cargo = builder.cargo(compiler, Mode::Librustc, target, "doc");
-        compile::rustc_cargo(build, &compiler, target, &mut cargo);
+        compile::rustc_cargo(build, target, &mut cargo);
 
         if build.config.compiler_docs {
             // src/rustc/Cargo.toml contains a bin crate called rustc which


### PR DESCRIPTION
There is a fix for https://github.com/rust-lang/rust/issues/45345

It re-introduces `CFG_LIBDIR_RELATIVE` which was broken when migration from `configure` script to `x.py`.

Other commits fix errors which happen after rustbuild cleanups.