### PR TITLE
rustdoc: Include `impl [u8]` in the docs

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -269,6 +269,7 @@ pub fn build_impls(cx: &DocContext, did: DefId) -> Vec<clean::Item> {
         lang_items.char_impl(),
         lang_items.str_impl(),
         lang_items.slice_impl(),
+        lang_items.slice_u8_impl(),
         lang_items.const_ptr_impl(),
         lang_items.mut_ptr_impl(),
     ];


### PR DESCRIPTION
The impl was added in #44042 but wasn't visible in the docs.