### PR TITLE
Use spans for -Z external-macro-backtrace

### DIFF
--- a/src/test/ui/macro_backtrace/auxiliary/ping.rs
+++ b/src/test/ui/macro_backtrace/auxiliary/ping.rs
@@ -18,3 +18,24 @@ macro_rules! ping {
     }
 }
 
+#[macro_export]
+macro_rules! deep {
+    () => {
+        foo!();
+    }
+}
+
+#[macro_export]
+macro_rules! foo {
+    () => {
+        bar!();
+    }
+}
+
+#[macro_export]
+macro_rules! bar {
+    () => {
+        ping!();
+    }
+}
+

--- a/src/test/ui/macro_backtrace/main.rs
+++ b/src/test/ui/macro_backtrace/main.rs
@@ -16,11 +16,14 @@
 
 // a local macro
 macro_rules! pong {
-    () => { syntax error }; //~ ERROR expected one of
+    () => { syntax error };
     //~^ ERROR expected one of
+    //~| ERROR expected one of
+    //~| ERROR expected one of
 }
 
 fn main() {
     pong!();
     ping!();
+    deep!();
 }

--- a/src/test/ui/macro_backtrace/main.rs
+++ b/src/test/ui/macro_backtrace/main.rs
@@ -17,10 +17,10 @@
 // a local macro
 macro_rules! pong {
     () => { syntax error };
-    //~^ ERROR expected one of
-    //~| ERROR expected one of
-    //~| ERROR expected one of
 }
+//~^^ ERROR expected one of
+//~| ERROR expected one of
+//~| ERROR expected one of
 
 fn main() {
     pong!();

--- a/src/test/ui/macro_backtrace/main.stderr
+++ b/src/test/ui/macro_backtrace/main.stderr
@@ -4,10 +4,7 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found
 18 | / macro_rules! pong {
 19 | |     () => { syntax error };
    | |                    ^^^^^ expected one of 8 possible tokens here
-20 | |     //~^ ERROR expected one of
-21 | |     //~| ERROR expected one of
-22 | |     //~| ERROR expected one of
-23 | | }
+20 | | }
    | |_- in this expansion of `pong!`
 ...
 26 |       pong!();
@@ -19,10 +16,7 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found
 18 | / macro_rules! pong {
 19 | |     () => { syntax error };
    | |                    ^^^^^ expected one of 8 possible tokens here
-20 | |     //~^ ERROR expected one of
-21 | |     //~| ERROR expected one of
-22 | |     //~| ERROR expected one of
-23 | | }
+20 | | }
    | |_- in this expansion of `pong!`
 ...
 27 |       ping!();
@@ -42,10 +36,7 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found
 18 | / macro_rules! pong {
 19 | |     () => { syntax error };
    | |                    ^^^^^ expected one of 8 possible tokens here
-20 | |     //~^ ERROR expected one of
-21 | |     //~| ERROR expected one of
-22 | |     //~| ERROR expected one of
-23 | | }
+20 | | }
    | |_- in this expansion of `pong!` (#5)
 ...
 28 |       deep!();

--- a/src/test/ui/macro_backtrace/main.stderr
+++ b/src/test/ui/macro_backtrace/main.stderr
@@ -1,17 +1,87 @@
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `error`
   --> $DIR/main.rs:19:20
    |
-19 |     () => { syntax error }; //~ ERROR expected one of
-   |                    ^^^^^ expected one of 8 possible tokens here
-$DIR/main.rs:24:5: 24:13 note: in this expansion of pong! (defined in $DIR/main.rs)
+18 | / macro_rules! pong {
+19 | |     () => { syntax error };
+   | |                    ^^^^^ expected one of 8 possible tokens here
+20 | |     //~^ ERROR expected one of
+21 | |     //~| ERROR expected one of
+22 | |     //~| ERROR expected one of
+23 | | }
+   | |_- in this expansion of `pong!`
+...
+26 |       pong!();
+   |       -------- in this macro invocation
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `error`
   --> $DIR/main.rs:19:20
    |
-19 |     () => { syntax error }; //~ ERROR expected one of
-   |                    ^^^^^ expected one of 8 possible tokens here
-$DIR/main.rs:25:5: 25:13 note: in this expansion of ping! (defined in <ping macros>)
-<ping macros>:1:11: 1:24 note: in this expansion of pong! (defined in $DIR/main.rs)
+18 | / macro_rules! pong {
+19 | |     () => { syntax error };
+   | |                    ^^^^^ expected one of 8 possible tokens here
+20 | |     //~^ ERROR expected one of
+21 | |     //~| ERROR expected one of
+22 | |     //~| ERROR expected one of
+23 | | }
+   | |_- in this expansion of `pong!`
+...
+27 |       ping!();
+   |       -------- in this macro invocation
+   | 
+  ::: <ping macros>
+   |
+1  |   (  ) => { pong ! (  ) ; }
+   |   -------------------------
+   |   |         |
+   |   |         in this macro invocation
+   |   in this expansion of `ping!`
 
-error: aborting due to 2 previous errors
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `error`
+  --> $DIR/main.rs:19:20
+   |
+18 | / macro_rules! pong {
+19 | |     () => { syntax error };
+   | |                    ^^^^^ expected one of 8 possible tokens here
+20 | |     //~^ ERROR expected one of
+21 | |     //~| ERROR expected one of
+22 | |     //~| ERROR expected one of
+23 | | }
+   | |_- in this expansion of `pong!` (#5)
+...
+28 |       deep!();
+   |       -------- in this macro invocation (#1)
+   | 
+  ::: <deep macros>
+   |
+1  |   (  ) => { foo ! (  ) ; }
+   |   ------------------------
+   |   |         |
+   |   |         in this macro invocation (#2)
+   |   in this expansion of `deep!` (#1)
+   | 
+  ::: <foo macros>
+   |
+1  |   (  ) => { bar ! (  ) ; }
+   |   ------------------------
+   |   |         |
+   |   |         in this macro invocation (#3)
+   |   in this expansion of `foo!` (#2)
+   | 
+  ::: <bar macros>
+   |
+1  |   (  ) => { ping ! (  ) ; }
+   |   -------------------------
+   |   |         |
+   |   |         in this macro invocation (#4)
+   |   in this expansion of `bar!` (#3)
+   | 
+  ::: <ping macros>
+   |
+1  |   (  ) => { pong ! (  ) ; }
+   |   -------------------------
+   |   |         |
+   |   |         in this macro invocation (#5)
+   |   in this expansion of `ping!` (#4)
+
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
```
% rustc ui/type-check/cannot_infer_local_or_vec.rs -Z external-macro-backtrace
error[E0282]: type annotations needed
  --> <vec macros>:3:1
   |
1  | / ( $ elem : expr ; $ n : expr ) => (
2  | | $ crate :: vec :: from_elem ( $ elem , $ n ) ) ; ( $ ( $ x : expr ) , * ) => (
3  | | < [ _ ] > :: into_vec ( box [ $ ( $ x ) , * ] ) ) ; ( $ ( $ x : expr , ) * )
   | | ^^^^^^^^^^^^^^^^^^^^^
   | | |
   | | cannot infer type for `T`
4  | | => ( vec ! [ $ ( $ x ) , * ] )
   | |______________________________- in this expansion of `vec!`
   |
  ::: ui/type-check/cannot_infer_local_or_vec.rs
   |
12 |       let x = vec![];
   |           -   ------ in this macro invocation
   |           |
   |           consider giving `x` a type

error: aborting due to previous error
```