### PR TITLE
rustc_trans: Fix indentation in trans_set_discr.

### DIFF
--- a/src/librustc_trans/mir/place.rs
+++ b/src/librustc_trans/mir/place.rs
@@ -359,10 +359,10 @@ impl<'a, 'tcx> PlaceRef<'tcx> {
     /// Set the discriminant for a new value of the given case of the given
     /// representation.
     pub fn trans_set_discr(&self, bcx: &Builder<'a, 'tcx>, variant_index: usize) {
-            if self.layout.for_variant(bcx.ccx, variant_index).abi == layout::Abi::Uninhabited {
-                return;
-            }
-            match self.layout.variants {
+        if self.layout.for_variant(bcx.ccx, variant_index).abi == layout::Abi::Uninhabited {
+            return;
+        }
+        match self.layout.variants {
             layout::Variants::Single { index } => {
                 assert_eq!(index, variant_index);
             }


### PR DESCRIPTION
Just noticed this while reading through #46521, which introduced this weird
alignment.