### PR TITLE
Point at whole method call instead of args

### DIFF
--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -714,7 +714,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                 let found_did = found_trait_ty.ty_to_def_id();
                 let found_span = found_did.and_then(|did| {
                     self.tcx.hir.span_if_local(did)
-                });
+                }).map(|sp| self.tcx.sess.codemap().def_span(sp)); // the sp could be an fn def
 
                 let found_ty_count =
                     match found_trait_ref.skip_binder().substs.type_at(1).sty {
@@ -751,7 +751,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                     //
                     // ```
                     // [1i32, 2, 3].sort_by(|(a, b)| ..)
-                    // //                   ^^^^^^^^
+                    // //           ^^^^^^^ --------
                     // // expected_trait_ref:  std::ops::FnMut<(&i32, &i32)>
                     // //    found_trait_ref:  std::ops::FnMut<(&i32,)>
                     // ```

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1559,6 +1559,7 @@ impl<'a, 'gcx, 'tcx> TyS<'tcx> {
             TyAdt(def, _) => Some(def.did),
             TyForeign(did) => Some(did),
             TyClosure(id, _) => Some(id),
+            TyFnDef(id, _) => Some(id),
             _ => None,
         }
     }

--- a/src/test/ui/anonymous-higher-ranked-lifetime.stderr
+++ b/src/test/ui/anonymous-higher-ranked-lifetime.stderr
@@ -2,7 +2,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:12:5
    |
 12 |     f1(|_: (), _: ()| {}); //~ ERROR type mismatch
-   |     ^^ ----------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'r, 's> fn(&'r (), &'s ()) -> _`
    |
@@ -12,7 +12,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:13:5
    |
 13 |     f2(|_: (), _: ()| {}); //~ ERROR type mismatch
-   |     ^^ ----------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'a, 'r> fn(&'a (), &'r ()) -> _`
    |
@@ -22,7 +22,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:14:5
    |
 14 |     f3(|_: (), _: ()| {}); //~ ERROR type mismatch
-   |     ^^ ----------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'r> fn(&(), &'r ()) -> _`
    |
@@ -32,7 +32,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:15:5
    |
 15 |     f4(|_: (), _: ()| {}); //~ ERROR type mismatch
-   |     ^^ ----------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'s, 'r> fn(&'s (), &'r ()) -> _`
    |
@@ -42,7 +42,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:16:5
    |
 16 |     f5(|_: (), _: ()| {}); //~ ERROR type mismatch
-   |     ^^ ----------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'r> fn(&'r (), &'r ()) -> _`
    |
@@ -52,7 +52,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:17:5
    |
 17 |     g1(|_: (), _: ()| {}); //~ ERROR type mismatch
-   |     ^^ ----------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'r> fn(&'r (), std::boxed::Box<for<'s> std::ops::Fn(&'s ()) + 'static>) -> _`
    |
@@ -62,7 +62,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:18:5
    |
 18 |     g2(|_: (), _: ()| {}); //~ ERROR type mismatch
-   |     ^^ ----------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'r> fn(&'r (), for<'s> fn(&'s ())) -> _`
    |
@@ -72,7 +72,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:19:5
    |
 19 |     g3(|_: (), _: ()| {}); //~ ERROR type mismatch
-   |     ^^ ----------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'s> fn(&'s (), std::boxed::Box<for<'r> std::ops::Fn(&'r ()) + 'static>) -> _`
    |
@@ -82,7 +82,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:20:5
    |
 20 |     g4(|_: (), _: ()| {}); //~ ERROR type mismatch
-   |     ^^ ----------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'s> fn(&'s (), for<'r> fn(&'r ())) -> _`
    |
@@ -92,7 +92,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:21:5
    |
 21 |     h1(|_: (), _: (), _: (), _: ()| {}); //~ ERROR type mismatch
-   |     ^^ ------------------------------- found signature of `fn((), (), (), ()) -> _`
+   |     ^^ ---------------------------- found signature of `fn((), (), (), ()) -> _`
    |     |
    |     expected signature of `for<'r, 's> fn(&'r (), std::boxed::Box<for<'t0> std::ops::Fn(&'t0 ()) + 'static>, &'s (), for<'t0, 't1> fn(&'t0 (), &'t1 ())) -> _`
    |
@@ -102,7 +102,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:22:5
    |
 22 |     h2(|_: (), _: (), _: (), _: ()| {}); //~ ERROR type mismatch
-   |     ^^ ------------------------------- found signature of `fn((), (), (), ()) -> _`
+   |     ^^ ---------------------------- found signature of `fn((), (), (), ()) -> _`
    |     |
    |     expected signature of `for<'r, 't0> fn(&'r (), std::boxed::Box<for<'s> std::ops::Fn(&'s ()) + 'static>, &'t0 (), for<'s, 't1> fn(&'s (), &'t1 ())) -> _`
    |

--- a/src/test/ui/method-call-err-msg.stderr
+++ b/src/test/ui/method-call-err-msg.stderr
@@ -1,29 +1,29 @@
 error[E0061]: this function takes 0 parameters but 1 parameter was supplied
-  --> $DIR/method-call-err-msg.rs:25:12
+  --> $DIR/method-call-err-msg.rs:25:7
    |
 15 |     fn zero(self) -> Foo { self }
-   |     ----------------------------- defined here
+   |     -------------------- defined here
 ...
 25 |     x.zero(0)   //~ ERROR this function takes 0 parameters but 1 parameter was supplied
-   |            ^ expected 0 parameters
+   |       ^^^^ expected 0 parameters
 
 error[E0061]: this function takes 1 parameter but 0 parameters were supplied
   --> $DIR/method-call-err-msg.rs:27:7
    |
 17 |     fn one(self, _: isize) -> Foo { self }
-   |     -------------------------------------- defined here
+   |     ----------------------------- defined here
 ...
 27 |      .one()     //~ ERROR this function takes 1 parameter but 0 parameters were supplied
    |       ^^^ expected 1 parameter
 
 error[E0061]: this function takes 2 parameters but 1 parameter was supplied
-  --> $DIR/method-call-err-msg.rs:29:11
+  --> $DIR/method-call-err-msg.rs:29:7
    |
 19 |     fn two(self, _: isize, _: isize) -> Foo { self }
-   |     ------------------------------------------------ defined here
+   |     --------------------------------------- defined here
 ...
 29 |      .two(0);   //~ ERROR this function takes 2 parameters but 1 parameter was supplied
-   |           ^ expected 2 parameters
+   |       ^^^ expected 2 parameters
 
 error[E0599]: no method named `take` found for type `Foo` in the current scope
   --> $DIR/method-call-err-msg.rs:34:7

--- a/src/test/ui/mismatched_types/E0631.stderr
+++ b/src/test/ui/mismatched_types/E0631.stderr
@@ -2,7 +2,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/E0631.rs:17:5
    |
 17 |     foo(|_: isize| {}); //~ ERROR type mismatch
-   |     ^^^ ------------- found signature of `fn(isize) -> _`
+   |     ^^^ ---------- found signature of `fn(isize) -> _`
    |     |
    |     expected signature of `fn(usize) -> _`
    |
@@ -12,7 +12,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/E0631.rs:18:5
    |
 18 |     bar(|_: isize| {}); //~ ERROR type mismatch
-   |     ^^^ ------------- found signature of `fn(isize) -> _`
+   |     ^^^ ---------- found signature of `fn(isize) -> _`
    |     |
    |     expected signature of `fn(usize) -> _`
    |
@@ -21,22 +21,22 @@ error[E0631]: type mismatch in closure arguments
 error[E0631]: type mismatch in function arguments
   --> $DIR/E0631.rs:19:5
    |
+16 |     fn f(_: u64) {}
+   |     ------------ found signature of `fn(u64) -> _`
+...
 19 |     foo(f); //~ ERROR type mismatch
-   |     ^^^
-   |     |
-   |     expected signature of `fn(usize) -> _`
-   |     found signature of `fn(u64) -> _`
+   |     ^^^ expected signature of `fn(usize) -> _`
    |
    = note: required by `foo`
 
 error[E0631]: type mismatch in function arguments
   --> $DIR/E0631.rs:20:5
    |
+16 |     fn f(_: u64) {}
+   |     ------------ found signature of `fn(u64) -> _`
+...
 20 |     bar(f); //~ ERROR type mismatch
-   |     ^^^
-   |     |
-   |     expected signature of `fn(usize) -> _`
-   |     found signature of `fn(u64) -> _`
+   |     ^^^ expected signature of `fn(usize) -> _`
    |
    = note: required by `bar`
 

--- a/src/test/ui/mismatched_types/closure-arg-count.rs
+++ b/src/test/ui/mismatched_types/closure-arg-count.rs
@@ -29,6 +29,9 @@ fn main() {
     //~^ ERROR closure is expected to take
     let _it = vec![1, 2, 3].into_iter().enumerate().map(foo);
     //~^ ERROR function is expected to take
+    let bar = |i, x, y| i;
+    let _it = vec![1, 2, 3].into_iter().enumerate().map(bar);
+    //~^ ERROR closure is expected to take
 }
 
 fn foo() {}

--- a/src/test/ui/mismatched_types/closure-arg-count.rs
+++ b/src/test/ui/mismatched_types/closure-arg-count.rs
@@ -27,4 +27,8 @@ fn main() {
     //~^ ERROR closure is expected to take
     let _it = vec![1, 2, 3].into_iter().enumerate().map(|i, x, y| i);
     //~^ ERROR closure is expected to take
+    let _it = vec![1, 2, 3].into_iter().enumerate().map(foo);
+    //~^ ERROR function is expected to take
 }
+
+fn foo() {}

--- a/src/test/ui/mismatched_types/closure-arg-count.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-count.stderr
@@ -62,8 +62,16 @@ error[E0593]: function is expected to take a single 2-tuple as argument, but it 
 30 |     let _it = vec![1, 2, 3].into_iter().enumerate().map(foo);
    |                                                     ^^^ expected function that takes a single 2-tuple as argument
 ...
-34 | fn foo() {}
+37 | fn foo() {}
    | -------- takes 0 arguments
 
-error: aborting due to 8 previous errors
+error[E0593]: closure is expected to take a single 2-tuple as argument, but it takes 3 distinct arguments
+  --> $DIR/closure-arg-count.rs:33:53
+   |
+32 |     let bar = |i, x, y| i;
+   |               --------- takes 3 distinct arguments
+33 |     let _it = vec![1, 2, 3].into_iter().enumerate().map(bar);
+   |                                                     ^^^ expected closure that takes a single 2-tuple as argument
+
+error: aborting due to 9 previous errors
 

--- a/src/test/ui/mismatched_types/closure-arg-count.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-count.stderr
@@ -56,5 +56,14 @@ error[E0593]: closure is expected to take a single 2-tuple as argument, but it t
    |                                                     |
    |                                                     expected closure that takes a single 2-tuple as argument
 
-error: aborting due to 7 previous errors
+error[E0593]: function is expected to take a single 2-tuple as argument, but it takes 0 arguments
+  --> $DIR/closure-arg-count.rs:30:53
+   |
+30 |     let _it = vec![1, 2, 3].into_iter().enumerate().map(foo);
+   |                                                     ^^^ expected function that takes a single 2-tuple as argument
+...
+34 | fn foo() {}
+   | -------- takes 0 arguments
+
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/mismatched_types/fn-variance-1.rs
+++ b/src/test/ui/mismatched_types/fn-variance-1.rs
@@ -9,8 +9,10 @@
 // except according to those terms.
 
 fn takes_imm(x: &isize) { }
+//~^ NOTE found signature
 
 fn takes_mut(x: &mut isize) { }
+//~^ NOTE found signature
 
 fn apply<T, F>(t: T, f: F) where F: FnOnce(T) {
     f(t)
@@ -22,12 +24,10 @@ fn main() {
     //~^ ERROR type mismatch
     //~| NOTE required by `apply`
     //~| NOTE expected signature
-    //~| NOTE found signature
 
     apply(&mut 3, takes_mut);
     apply(&mut 3, takes_imm);
     //~^ ERROR type mismatch
     //~| NOTE required by `apply`
     //~| NOTE expected signature
-    //~| NOTE found signature
 }

--- a/src/test/ui/mismatched_types/fn-variance-1.stderr
+++ b/src/test/ui/mismatched_types/fn-variance-1.stderr
@@ -1,21 +1,21 @@
 error[E0631]: type mismatch in function arguments
-  --> $DIR/fn-variance-1.rs:21:5
+  --> $DIR/fn-variance-1.rs:23:5
    |
-13 | fn takes_mut(x: &mut isize) { }
+14 | fn takes_mut(x: &mut isize) { }
    | --------------------------- found signature of `for<'r> fn(&'r mut isize) -> _`
 ...
-21 |     apply(&3, takes_mut);
+23 |     apply(&3, takes_mut);
    |     ^^^^^ expected signature of `fn(&{integer}) -> _`
    |
    = note: required by `apply`
 
 error[E0631]: type mismatch in function arguments
-  --> $DIR/fn-variance-1.rs:28:5
+  --> $DIR/fn-variance-1.rs:29:5
    |
 11 | fn takes_imm(x: &isize) { }
    | ----------------------- found signature of `for<'r> fn(&'r isize) -> _`
 ...
-28 |     apply(&mut 3, takes_imm);
+29 |     apply(&mut 3, takes_imm);
    |     ^^^^^ expected signature of `fn(&mut {integer}) -> _`
    |
    = note: required by `apply`

--- a/src/test/ui/mismatched_types/fn-variance-1.stderr
+++ b/src/test/ui/mismatched_types/fn-variance-1.stderr
@@ -1,22 +1,22 @@
 error[E0631]: type mismatch in function arguments
   --> $DIR/fn-variance-1.rs:21:5
    |
+13 | fn takes_mut(x: &mut isize) { }
+   | --------------------------- found signature of `for<'r> fn(&'r mut isize) -> _`
+...
 21 |     apply(&3, takes_mut);
-   |     ^^^^^
-   |     |
-   |     expected signature of `fn(&{integer}) -> _`
-   |     found signature of `for<'r> fn(&'r mut isize) -> _`
+   |     ^^^^^ expected signature of `fn(&{integer}) -> _`
    |
    = note: required by `apply`
 
 error[E0631]: type mismatch in function arguments
   --> $DIR/fn-variance-1.rs:28:5
    |
+11 | fn takes_imm(x: &isize) { }
+   | ----------------------- found signature of `for<'r> fn(&'r isize) -> _`
+...
 28 |     apply(&mut 3, takes_imm);
-   |     ^^^^^
-   |     |
-   |     expected signature of `fn(&mut {integer}) -> _`
-   |     found signature of `for<'r> fn(&'r isize) -> _`
+   |     ^^^^^ expected signature of `fn(&mut {integer}) -> _`
    |
    = note: required by `apply`
 

--- a/src/test/ui/mismatched_types/overloaded-calls-bad.stderr
+++ b/src/test/ui/mismatched_types/overloaded-calls-bad.stderr
@@ -14,10 +14,10 @@ error[E0057]: this function takes 1 parameter but 0 parameters were supplied
    |               ^^^ expected 1 parameter
 
 error[E0057]: this function takes 1 parameter but 2 parameters were supplied
-  --> $DIR/overloaded-calls-bad.rs:44:17
+  --> $DIR/overloaded-calls-bad.rs:44:15
    |
 44 |     let ans = s("burma", "shave");
-   |                 ^^^^^^^^^^^^^^^^ expected 1 parameter
+   |               ^^^^^^^^^^^^^^^^^^^ expected 1 parameter
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
+++ b/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
@@ -2,7 +2,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/unboxed-closures-vtable-mismatch.rs:24:13
    |
 22 |     let f = to_fn_mut(|x: usize, y: isize| -> isize { (x as isize) + y });
-   |                       -------------------------------------------------- found signature of `fn(usize, isize) -> _`
+   |                       ----------------------------- found signature of `fn(usize, isize) -> _`
 23 |     //~^ NOTE found signature of `fn(usize, isize)
 24 |     let z = call_it(3, f);
    |             ^^^^^^^ expected signature of `fn(isize, isize) -> _`

--- a/src/test/ui/span/E0057.stderr
+++ b/src/test/ui/span/E0057.stderr
@@ -5,10 +5,10 @@ error[E0057]: this function takes 1 parameter but 0 parameters were supplied
    |             ^^^ expected 1 parameter
 
 error[E0057]: this function takes 1 parameter but 2 parameters were supplied
-  --> $DIR/E0057.rs:15:15
+  --> $DIR/E0057.rs:15:13
    |
 15 |     let c = f(2, 3); //~ ERROR E0057
-   |               ^^^^ expected 1 parameter
+   |             ^^^^^^^ expected 1 parameter
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/issue-34264.stderr
+++ b/src/test/ui/span/issue-34264.stderr
@@ -17,13 +17,13 @@ error: expected one of `:` or `@`, found `,`
    |         ^ expected one of `:` or `@` here
 
 error[E0061]: this function takes 2 parameters but 3 parameters were supplied
-  --> $DIR/issue-34264.rs:17:9
+  --> $DIR/issue-34264.rs:17:5
    |
 11 | fn foo(Option<i32>, String) {} //~ ERROR expected one of
-   | ------------------------------ defined here
+   | --------------------------- defined here
 ...
 17 |     foo(Some(42), 2, ""); //~ ERROR this function takes
-   |         ^^^^^^^^^^^^^^^ expected 2 parameters
+   |     ^^^^^^^^^^^^^^^^^^^^ expected 2 parameters
 
 error[E0308]: mismatched types
   --> $DIR/issue-34264.rs:18:13
@@ -37,13 +37,13 @@ error[E0308]: mismatched types
            - .len()
 
 error[E0061]: this function takes 2 parameters but 3 parameters were supplied
-  --> $DIR/issue-34264.rs:20:9
+  --> $DIR/issue-34264.rs:20:5
    |
 13 | fn bar(x, y: usize) {} //~ ERROR expected one of
-   | ---------------------- defined here
+   | ------------------- defined here
 ...
 20 |     bar(1, 2, 3); //~ ERROR this function takes
-   |         ^^^^^^^ expected 2 parameters
+   |     ^^^^^^^^^^^^ expected 2 parameters
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/span/missing-unit-argument.stderr
+++ b/src/test/ui/span/missing-unit-argument.stderr
@@ -12,25 +12,25 @@ error[E0061]: this function takes 2 parameters but 0 parameters were supplied
   --> $DIR/missing-unit-argument.rs:22:5
    |
 11 | fn foo(():(), ():()) {}
-   | ----------------------- defined here
+   | -------------------- defined here
 ...
 22 |     foo(); //~ ERROR this function takes
    |     ^^^^^ expected 2 parameters
 
 error[E0061]: this function takes 2 parameters but 1 parameter was supplied
-  --> $DIR/missing-unit-argument.rs:23:9
+  --> $DIR/missing-unit-argument.rs:23:5
    |
 11 | fn foo(():(), ():()) {}
-   | ----------------------- defined here
+   | -------------------- defined here
 ...
 23 |     foo(()); //~ ERROR this function takes
-   |         ^^ expected 2 parameters
+   |     ^^^^^^^ expected 2 parameters
 
 error[E0061]: this function takes 1 parameter but 0 parameters were supplied
   --> $DIR/missing-unit-argument.rs:24:5
    |
 12 | fn bar(():()) {}
-   | ---------------- defined here
+   | ------------- defined here
 ...
 24 |     bar(); //~ ERROR this function takes
    |     ^^^^^
@@ -43,7 +43,7 @@ error[E0061]: this function takes 1 parameter but 0 parameters were supplied
   --> $DIR/missing-unit-argument.rs:25:7
    |
 16 |     fn baz(self, (): ()) { }
-   |     ------------------------ defined here
+   |     -------------------- defined here
 ...
 25 |     S.baz(); //~ ERROR this function takes
    |       ^^^
@@ -56,7 +56,7 @@ error[E0061]: this function takes 1 parameter but 0 parameters were supplied
   --> $DIR/missing-unit-argument.rs:26:7
    |
 17 |     fn generic<T>(self, _: T) { }
-   |     ----------------------------- defined here
+   |     ------------------------- defined here
 ...
 26 |     S.generic::<()>(); //~ ERROR this function takes
    |       ^^^^^^^

--- a/src/test/ui/suggestions/type-ascription-instead-of-initializer.stderr
+++ b/src/test/ui/suggestions/type-ascription-instead-of-initializer.stderr
@@ -8,10 +8,10 @@ error: expected type, found `10`
    |         while parsing the type for `x`
 
 error[E0061]: this function takes 1 parameter but 2 parameters were supplied
-  --> $DIR/type-ascription-instead-of-initializer.rs:12:31
+  --> $DIR/type-ascription-instead-of-initializer.rs:12:12
    |
 12 |     let x: Vec::with_capacity(10, 20);  //~ ERROR expected type, found `10`
-   |                               ^^^^^^ expected 1 parameter
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 parameter
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
To avoid confusion in cases where the code is

```rust
fn foo() {}
/ foo(
|     bar()
|     ^^^ current diagnostics point here for arg count mismatch
| );
|_^ new diagnostic span points here
```

as this leads to confusion making people think that the diagnostic is
talking about `bar`'s arg count, not `foo`'s.

Point at `fn`s definition on arg mismatch, just like we do for closures.

Re #42855, Fix #45633.