### PR TITLE
Add `std::fmt::Pointer` implementation for `AtomicPtr`

### DIFF
--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -1819,3 +1819,11 @@ impl<T> fmt::Debug for AtomicPtr<T> {
         f.debug_tuple("AtomicPtr").field(&self.load(Ordering::SeqCst)).finish()
     }
 }
+
+#[cfg(target_has_atomic = "ptr")]
+#[stable(feature = "atomic_pointer", since = "1.24.0")]
+impl<T> fmt::Pointer for AtomicPtr<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Pointer::fmt(&self.load(Ordering::SeqCst), f)
+    }
+}


### PR DESCRIPTION
Resolves #29212.