### PR TITLE
Added inherent method Barrier::num_threads(&self) -> usize

### DIFF
--- a/src/libstd/sync/barrier.rs
+++ b/src/libstd/sync/barrier.rs
@@ -157,6 +157,33 @@ impl Barrier {
             BarrierWaitResult(true)
         }
     }
+
+    /// Returns 1 + the number of threads that the barrier will block.
+    /// This is the same value `n` that the barrier was constructed with in
+    /// [`Barrier::new(n)`](#method.new).
+    ///
+    /// Let `n = barrier.num_threads()`. Then the barrier will at most block
+    /// `n - 1` threads which call [`wait`]. Once the `n`th thread calls
+    /// [`wait`], all threads will be awaken.
+    ///
+    /// [`wait`]: #method.wait
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(barrier_num_threads)]
+    ///
+    /// use std::sync::Barrier;
+    /// 
+    /// fn main() {
+    ///     let barrier = Barrier::new(10);
+    ///     assert_eq!(barrier.num_threads(), 10);
+    /// }
+    /// ```
+    #[unstable(feature = "barrier_num_threads", issue = "0")]
+    pub fn num_threads(&self) -> usize {
+        self.num_threads
+    }
 }
 
 #[stable(feature = "std_debug", since = "1.16.0")]


### PR DESCRIPTION
Adds an inherent method to `Barrier`:
```rust
impl Barrier {
    pub fn num_threads(&self) -> usize { self.num_threads }
}
```

The method name was picked to be as straightforward as possible and matches with the field name used internally in `Barrier` as well as [the argument name used in C++](http://en.cppreference.com/w/cpp/experimental/barrier/barrier). One could perhaps also call the method `.size()` but I'd prefer we not go into an endless bike-shed because however which way you compare the names there will be trade-offs and nothing will be perfect.

The use case is primarily when `Barrier` has been randomly generated from a `usize` (or some smaller `u16`). Currently, the consumer of the generated `Barrier` has no way to know how many threads the `Barrier` "supports", but does so with `.num_threads()`. Consider for example:
```rust
impl_arbitrary!(Barrier, Mapped<'a, u16, Self>,
    any::<u16>().prop_map(|n| Barrier::new(n as usize))
);
```
Here, this generates `impl<'a> Arbitrary<'a> for Barrier {..}` where `Arbitrary` determines a canonical strategy to generate a value of type `Self` (think QuickCheck).