### PR TITLE
Reject superfluous `::` in IPv6 addresses

### DIFF
--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -1451,6 +1451,9 @@ mod tests {
         // two double colons
         let none: Option<Ipv6Addr> = "1:2::6::8".parse().ok();
         assert_eq!(None, none);
+        // `::` indicating zero groups of zeros
+        let none: Option<Ipv6Addr> = "1:2:3:4::5:6:7:8".parse().ok();
+        assert_eq!(None, none);
     }
 
     #[test]

--- a/src/libstd/net/parser.rs
+++ b/src/libstd/net/parser.rs
@@ -246,7 +246,9 @@ impl<'a> Parser<'a> {
         }
 
         let mut tail = [0; 8];
-        let (tail_size, _) = read_groups(self, &mut tail, 8 - head_size);
+        // `::` indicates one or more groups of 16 bits of zeros
+        let limit = 8 - (head_size + 1);
+        let (tail_size, _) = read_groups(self, &mut tail, limit);
         Some(ipv6_addr_from_head_tail(&head[..head_size], &tail[..tail_size]))
     }
 


### PR DESCRIPTION
Fixes #46263.