### PR TITLE
Remove armv5te target from dist-various-1

### DIFF
--- a/src/ci/docker/dist-various-1/Dockerfile
+++ b/src/ci/docker/dist-various-1/Dockerfile
@@ -46,20 +46,15 @@ ENV TARGETS=$TARGETS,mips-unknown-linux-musl
 ENV TARGETS=$TARGETS,mipsel-unknown-linux-musl
 ENV TARGETS=$TARGETS,arm-unknown-linux-musleabi
 ENV TARGETS=$TARGETS,arm-unknown-linux-musleabihf
-ENV TARGETS=$TARGETS,armv5te-unknown-linux-gnueabi
 ENV TARGETS=$TARGETS,armv7-unknown-linux-musleabihf
 ENV TARGETS=$TARGETS,aarch64-unknown-linux-musl
 ENV TARGETS=$TARGETS,sparc64-unknown-linux-gnu
 ENV TARGETS=$TARGETS,x86_64-unknown-redox
 
-# FIXME: remove armv5te vars after https://github.com/alexcrichton/cc-rs/issues/271
-#        get fixed and cc update
 ENV CC_mipsel_unknown_linux_musl=mipsel-openwrt-linux-gcc \
     CC_mips_unknown_linux_musl=mips-openwrt-linux-gcc \
     CC_sparc64_unknown_linux_gnu=sparc64-linux-gnu-gcc \
-    CC_x86_64_unknown_redox=x86_64-unknown-redox-gcc \
-    CC_armv5te_unknown_linux_gnueabi=arm-linux-gnueabi-gcc \
-    CFLAGS_armv5te_unknown_linux_gnueabi="-march=armv5te -mfloat-abi=soft"
+    CC_x86_64_unknown_redox=x86_64-unknown-redox-gcc
 
 # Suppress some warnings in the openwrt toolchains we downloaded
 ENV STAGING_DIR=/tmp


### PR DESCRIPTION
Reverts https://github.com/rust-lang/rust/pull/46498

I must have made some mistake when I tested that commit and thought armv5te target worked. but testing it now the produced binaries segfaults (https://github.com/rust-lang/rust/pull/46498#issuecomment-350599233).

I tried using crosstool-ng and buildroot toolchain (for armv5te) but the produced binaries also segfaults. Maybe there is a issue with the target, but I cannot investigate it any further.

I think the best for now is not to distribute the armv5te target.

I'm sorry for what happened.