### PR TITLE
Expose the line and column fields from the proc_macro::LineColumn struct

### DIFF
--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -265,10 +265,12 @@ impl Span {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct LineColumn {
     /// The 1-indexed line in the source file on which the span starts or ends (inclusive).
-    line: usize,
+    #[unstable(feature = "proc_macro", issue = "38356")]
+    pub line: usize,
     /// The 0-indexed column (in UTF-8 characters) in the source file on which
     /// the span starts or ends (inclusive).
-    column: usize
+    #[unstable(feature = "proc_macro", issue = "38356")]
+    pub column: usize
 }
 
 /// The source file of a given `Span`.


### PR DESCRIPTION
Right now the `LineColumn` struct is pretty useless because the fields are private.

This patch just marks the fields as public, which seems like the easiest solution.