### PR TITLE
rustc: unpack newtyped of #[repr(simd)] vector types.

### DIFF
--- a/src/librustc_trans/abi.rs
+++ b/src/librustc_trans/abi.rs
@@ -315,7 +315,7 @@ impl<'tcx> LayoutExt<'tcx> for TyLayout<'tcx> {
         match self.abi {
             layout::Abi::Uninhabited |
             layout::Abi::Scalar(_) |
-            layout::Abi::Vector => false,
+            layout::Abi::Vector { .. } => false,
             layout::Abi::ScalarPair(..) |
             layout::Abi::Aggregate { .. } => true
         }
@@ -339,7 +339,7 @@ impl<'tcx> LayoutExt<'tcx> for TyLayout<'tcx> {
                 })
             }
 
-            layout::Abi::Vector => {
+            layout::Abi::Vector { .. } => {
                 Some(Reg {
                     kind: RegKind::Vector,
                     size: self.size

--- a/src/librustc_trans/cabi_x86_64.rs
+++ b/src/librustc_trans/cabi_x86_64.rs
@@ -77,13 +77,14 @@ fn classify_arg<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, arg: &ArgType<'tcx>)
                 unify(cls, off, reg);
             }
 
-            layout::Abi::Vector => {
+            layout::Abi::Vector { ref element, count } => {
                 unify(cls, off, Class::Sse);
 
                 // everything after the first one is the upper
                 // half of a register.
-                for i in 1..layout.fields.count() {
-                    let field_off = off + layout.fields.offset(i);
+                let stride = element.value.size(ccx);
+                for i in 1..count {
+                    let field_off = off + stride * i;
                     unify(cls, field_off, Class::SseUp);
                 }
             }

--- a/src/librustc_trans/cabi_x86_win64.rs
+++ b/src/librustc_trans/cabi_x86_win64.rs
@@ -28,7 +28,7 @@ pub fn compute_abi_info(fty: &mut FnType) {
                     _ => a.make_indirect()
                 }
             }
-            layout::Abi::Vector => {
+            layout::Abi::Vector { .. } => {
                 // FIXME(eddyb) there should be a size cap here
                 // (probably what clang calls "illegal vectors").
             }

--- a/src/librustc_trans/mir/operand.rs
+++ b/src/librustc_trans/mir/operand.rs
@@ -163,7 +163,7 @@ impl<'a, 'tcx> OperandRef<'tcx> {
                 };
             }
 
-            // Newtype of a scalar or scalar pair.
+            // Newtype of a scalar, scalar pair or vector.
             (OperandValue::Immediate(_), _) |
             (OperandValue::Pair(..), _) if field.size == self.layout.size => {
                 assert_eq!(offset.bytes(), 0);
@@ -184,7 +184,7 @@ impl<'a, 'tcx> OperandRef<'tcx> {
             }
 
             // `#[repr(simd)]` types are also immediate.
-            (OperandValue::Immediate(llval), &layout::Abi::Vector) => {
+            (OperandValue::Immediate(llval), &layout::Abi::Vector { .. }) => {
                 OperandValue::Immediate(
                     bcx.extract_element(llval, C_usize(bcx.ccx, i as u64)))
             }


### PR DESCRIPTION
Prerequisite for a `#[repr(transparent)]` implementation that works with SIMD vectors.

cc @rkruppe 