### PR TITLE
Help Cargo tolerate RUSTFLAGS="--print=native-static-libs"

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -810,9 +810,8 @@ impl RustcDefaultCalls {
                 PrintRequest::TargetCPUs | PrintRequest::TargetFeatures => {
                     rustc_trans::print(*req, sess);
                 }
-                PrintRequest::NativeStaticLibs => {
-                    println!("Native static libs can be printed only during linking");
-                }
+                // Any output here interferes with Cargo's parsing of other printed output
+                PrintRequest::NativeStaticLibs => {}
             }
         }
         return Compilation::Stop;


### PR DESCRIPTION
Alternative to https://github.com/rust-lang/cargo/pull/4807

Having this "error" message was a mistake, as it's firing at exactly wrong time when Cargo is trying to read the output of other print commands.