### PR TITLE
Fix visible_parent_map to choose globally minimal paths

### DIFF
--- a/src/test/ui/auxiliary/xcrate_issue_46112_rexport_core.rs
+++ b/src/test/ui/auxiliary/xcrate_issue_46112_rexport_core.rs
@@ -1,0 +1,13 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type="lib"]
+
+pub extern crate core;

--- a/src/test/ui/issue-46112.rs
+++ b/src/test/ui/issue-46112.rs
@@ -1,0 +1,20 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue 46112: An extern crate pub reexporting libcore was causing
+// paths rooted from `std` to be misrendered in the diagnostic output.
+
+// ignore-windows
+// aux-build:xcrate_issue_46112_rexport_core.rs
+
+extern crate xcrate_issue_46112_rexport_core;
+fn test(r: Result<Option<()>, &'static str>) { }
+fn main() { test(Ok(())); }
+//~^ mismatched types

--- a/src/test/ui/issue-46112.stderr
+++ b/src/test/ui/issue-46112.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-46112.rs:19:21
+   |
+19 | fn main() { test(Ok(())); }
+   |                     ^^
+   |                     |
+   |                     expected enum `std::option::Option`, found ()
+   |                     help: try using a variant of the expected type: `Some(())`
+   |
+   = note: expected type `std::option::Option<()>`
+              found type `()`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fix #46112: visible_parent_map construction needs a BFS over whole crate forest to get globally minimal paths.

(There are other latent bugs that were e.g. causing this test case to have weirdness like `<unnamed>` in the diagnostic output. Those bugs are not fixed here, since they are issues long-standing in the stable channel.)