### PR TITLE
Download crosstool-ng from GitHub

### DIFF
--- a/src/ci/docker/scripts/crosstool-ng.sh
+++ b/src/ci/docker/scripts/crosstool-ng.sh
@@ -10,11 +10,12 @@
 
 set -ex
 
-url="http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.22.0.tar.bz2"
-curl -f $url | tar xjf -
-cd crosstool-ng
+url="https://github.com/crosstool-ng/crosstool-ng/archive/crosstool-ng-1.22.0.tar.gz"
+curl -Lf $url | tar xzf -
+cd crosstool-ng-crosstool-ng-1.22.0
+./bootstrap
 ./configure --prefix=/usr/local
 make -j$(nproc)
 make install
 cd ..
-rm -rf crosstool-ng
+rm -rf crosstool-ng-crosstool-ng-1.22.0


### PR DESCRIPTION
Workaround the current problem where http://crosstool-ng.org was done, causing all non-x86 jobs to fail spuriously (cc #40474).

If http://crosstool-ng.org becomes online before this PR is merged, this PR should be closed and the tree should be reopened.