### PR TITLE
Point at var in short lived borrows instead of drop location

### DIFF
--- a/src/librustc_mir/borrow_check/error_reporting.rs
+++ b/src/librustc_mir/borrow_check/error_reporting.rs
@@ -394,10 +394,10 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         &mut self, name: &String, _scope_tree: &Rc<ScopeTree>, _borrow: &BorrowData<'tcx>,
         drop_span: Span, borrow_span: Span, _proper_span: Span, end_span: Option<Span>
     ) {
-        let mut err = self.tcx.path_does_not_live_long_enough(drop_span,
+        let mut err = self.tcx.path_does_not_live_long_enough(borrow_span,
                                                               &format!("`{}`", name),
                                                               Origin::Mir);
-        err.span_label(borrow_span, "borrow occurs here");
+        err.span_label(borrow_span, "borrowed value does not live long enough");
         err.span_label(drop_span, format!("`{}` dropped here while still borrowed", name));
         if let Some(end) = end_span {
             err.span_label(end, "borrowed value needs to live until here");
@@ -407,12 +407,12 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
 
     fn report_scoped_temporary_value_does_not_live_long_enough(
         &mut self, _scope_tree: &Rc<ScopeTree>, _borrow: &BorrowData<'tcx>,
-        drop_span: Span, borrow_span: Span, proper_span: Span, end_span: Option<Span>
+        drop_span: Span, _borrow_span: Span, proper_span: Span, end_span: Option<Span>
     ) {
-        let mut err = self.tcx.path_does_not_live_long_enough(borrow_span,
+        let mut err = self.tcx.path_does_not_live_long_enough(proper_span,
                                                               "borrowed value",
                                                               Origin::Mir);
-        err.span_label(proper_span, "temporary value created here");
+        err.span_label(proper_span, "temporary value does not live long enough");
         err.span_label(drop_span, "temporary value dropped here while still borrowed");
         err.note("consider using a `let` binding to increase its lifetime");
         if let Some(end) = end_span {
@@ -428,7 +428,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         let mut err = self.tcx.path_does_not_live_long_enough(borrow_span,
                                                               &format!("`{}`", name),
                                                               Origin::Mir);
-        err.span_label(borrow_span, "does not live long enough");
+        err.span_label(borrow_span, "borrowed value does not live long enough");
         err.span_label(drop_span, "borrowed value only lives until here");
         self.tcx.note_and_explain_region(scope_tree, &mut err,
                                          "borrowed value must be valid for ",
@@ -443,7 +443,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         let mut err = self.tcx.path_does_not_live_long_enough(proper_span,
                                                               "borrowed value",
                                                               Origin::Mir);
-        err.span_label(proper_span, "does not live long enough");
+        err.span_label(proper_span, "temporary value does not live long enough");
         err.span_label(drop_span, "temporary value only lives until here");
         self.tcx.note_and_explain_region(scope_tree, &mut err,
                                          "borrowed value must be valid for ",

--- a/src/test/compile-fail-fulldeps/dropck_tarena_cycle_checked.rs
+++ b/src/test/compile-fail-fulldeps/dropck_tarena_cycle_checked.rs
@@ -124,4 +124,4 @@ fn f<'a>(arena: &'a TypedArena<C<'a>>) {
 fn main() {
     let arena = TypedArena::new();
     f(&arena);
-} //~ ERROR `arena` does not live long enough
+} //~^ ERROR `arena` does not live long enough

--- a/src/test/compile-fail-fulldeps/dropck_tarena_unsound_drop.rs
+++ b/src/test/compile-fail-fulldeps/dropck_tarena_unsound_drop.rs
@@ -49,5 +49,5 @@ fn f<'a>(_arena: &'a TypedArena<C<'a>>) {}
 fn main() {
     let arena: TypedArena<C> = TypedArena::new();
     f(&arena);
-} //~ ERROR `arena` does not live long enough
+} //~^ ERROR `arena` does not live long enough
 

--- a/src/test/compile-fail/E0597.rs
+++ b/src/test/compile-fail/E0597.rs
@@ -16,4 +16,5 @@ fn main() {
     let mut x = Foo { x: None };
     let y = 0;
     x.x = Some(&y);
-} //~ `y` does not live long enough [E0597]
+    //~^ `y` does not live long enough [E0597]
+}

--- a/src/test/compile-fail/catch-bad-lifetime.rs
+++ b/src/test/compile-fail/catch-bad-lifetime.rs
@@ -18,10 +18,11 @@ pub fn main() {
         let _result: Result<(), &str> = do catch {
             let my_string = String::from("");
             let my_str: & str = & my_string;
+            //~^ ERROR `my_string` does not live long enough
             Err(my_str) ?;
             Err("") ?;
             Ok(())
-        }; //~ ERROR `my_string` does not live long enough
+        };
     }
 
     {

--- a/src/test/compile-fail/issue-36082.rs
+++ b/src/test/compile-fail/issue-36082.rs
@@ -21,11 +21,11 @@ fn main() {
     let val: &_ = x.borrow().0;
     //[ast]~^ ERROR borrowed value does not live long enough [E0597]
     //[ast]~| NOTE temporary value dropped here while still borrowed
-    //[ast]~| NOTE temporary value created here
+    //[ast]~| NOTE temporary value does not live long enough
     //[ast]~| NOTE consider using a `let` binding to increase its lifetime
     //[mir]~^^^^^ ERROR borrowed value does not live long enough [E0597]
     //[mir]~| NOTE temporary value dropped here while still borrowed
-    //[mir]~| NOTE temporary value created here
+    //[mir]~| NOTE temporary value does not live long enough
     //[mir]~| NOTE consider using a `let` binding to increase its lifetime
     println!("{}", val);
 }

--- a/src/test/compile-fail/region-borrow-params-issue-29793-big.rs
+++ b/src/test/compile-fail/region-borrow-params-issue-29793-big.rs
@@ -81,9 +81,9 @@ fn main() {
         WrapB::new().set(|t: bool| if t { x } else { y }) // (separate errors for `x` vs `y`)
             //[ast]~^ ERROR `x` does not live long enough
             //[ast]~| ERROR `y` does not live long enough
+            //[mir]~^^^ ERROR `x` does not live long enough
+            //[mir]~| ERROR `y` does not live long enough
     });
-    //[mir]~^ ERROR `x` does not live long enough
-    //[mir]~| ERROR `y` does not live long enough
 
     w.handle(); // This works
     // w.handle_ref(); // This doesn't

--- a/src/test/ui/dropck/dropck-eyepatch-extern-crate.rs
+++ b/src/test/ui/dropck/dropck-eyepatch-extern-crate.rs
@@ -37,7 +37,9 @@ fn main() {
     dr = Dr("dr", &c_long);
     // Error: destructor order imprecisely modelled
     dt = Dt("dt", &c);
+    //~^ ERROR `c` does not live long enough
     dr = Dr("dr", &c);
+    //~^ ERROR `c` does not live long enough
 
     // No error: Drop impl asserts .1 (A and &'a _) are not accessed
     pt = Pt("pt", &c, &c_long);
@@ -45,14 +47,13 @@ fn main() {
 
     // Error: Drop impl's assertion does not apply to `B` nor `&'b _`
     pt = Pt("pt", &c_long, &c);
+    //~^ ERROR `c` does not live long enough
     pr = Pr("pr", &c_long, &c);
+    //~^ ERROR `c` does not live long enough
 
     // No error: St and Sr have no destructor.
     st = St("st", &c);
     sr = Sr("sr", &c);
 
     println!("{:?}", (dt.0, dr.0, pt.0, pr.0, st.0, sr.0));
-}//~ ERROR `c` does not live long enough
-//~^ ERROR `c` does not live long enough
-//~| ERROR `c` does not live long enough
-//~| ERROR `c` does not live long enough
+}

--- a/src/test/ui/dropck/dropck-eyepatch-extern-crate.stderr
+++ b/src/test/ui/dropck/dropck-eyepatch-extern-crate.stderr
@@ -1,44 +1,44 @@
 error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch-extern-crate.rs:55:1
+  --> $DIR/dropck-eyepatch-extern-crate.rs:39:20
    |
 39 |     dt = Dt("dt", &c);
-   |                    - borrow occurs here
+   |                    ^ borrowed value does not live long enough
 ...
-55 | }//~ ERROR `c` does not live long enough
-   | ^ `c` dropped here while still borrowed
+59 | }
+   | - `c` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch-extern-crate.rs:55:1
+  --> $DIR/dropck-eyepatch-extern-crate.rs:41:20
    |
-40 |     dr = Dr("dr", &c);
-   |                    - borrow occurs here
+41 |     dr = Dr("dr", &c);
+   |                    ^ borrowed value does not live long enough
 ...
-55 | }//~ ERROR `c` does not live long enough
-   | ^ `c` dropped here while still borrowed
+59 | }
+   | - `c` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch-extern-crate.rs:55:1
+  --> $DIR/dropck-eyepatch-extern-crate.rs:49:29
    |
-47 |     pt = Pt("pt", &c_long, &c);
-   |                             - borrow occurs here
+49 |     pt = Pt("pt", &c_long, &c);
+   |                             ^ borrowed value does not live long enough
 ...
-55 | }//~ ERROR `c` does not live long enough
-   | ^ `c` dropped here while still borrowed
+59 | }
+   | - `c` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch-extern-crate.rs:55:1
+  --> $DIR/dropck-eyepatch-extern-crate.rs:51:29
    |
-48 |     pr = Pr("pr", &c_long, &c);
-   |                             - borrow occurs here
+51 |     pr = Pr("pr", &c_long, &c);
+   |                             ^ borrowed value does not live long enough
 ...
-55 | }//~ ERROR `c` does not live long enough
-   | ^ `c` dropped here while still borrowed
+59 | }
+   | - `c` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/test/ui/dropck/dropck-eyepatch-reorder.rs
+++ b/src/test/ui/dropck/dropck-eyepatch-reorder.rs
@@ -55,7 +55,9 @@ fn main() {
     dr = Dr("dr", &c_long);
     // Error: destructor order imprecisely modelled
     dt = Dt("dt", &c);
+    //~^ ERROR `c` does not live long enough
     dr = Dr("dr", &c);
+    //~^ ERROR `c` does not live long enough
 
     // No error: Drop impl asserts .1 (A and &'a _) are not accessed
     pt = Pt("pt", &c, &c_long);
@@ -63,7 +65,9 @@ fn main() {
 
     // Error: Drop impl's assertion does not apply to `B` nor `&'b _`
     pt = Pt("pt", &c_long, &c);
+    //~^ ERROR `c` does not live long enough
     pr = Pr("pr", &c_long, &c);
+    //~^ ERROR `c` does not live long enough
 
     // No error: St and Sr have no destructor.
     st = St("st", &c);
@@ -71,7 +75,3 @@ fn main() {
 
     println!("{:?}", (dt.0, dr.0, pt.0, pr.0, st.0, sr.0));
 }
-//~^ ERROR `c` does not live long enough
-//~| ERROR `c` does not live long enough
-//~| ERROR `c` does not live long enough
-//~| ERROR `c` does not live long enough

--- a/src/test/ui/dropck/dropck-eyepatch-reorder.stderr
+++ b/src/test/ui/dropck/dropck-eyepatch-reorder.stderr
@@ -1,44 +1,44 @@
 error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch-reorder.rs:73:1
+  --> $DIR/dropck-eyepatch-reorder.rs:57:20
    |
 57 |     dt = Dt("dt", &c);
-   |                    - borrow occurs here
+   |                    ^ borrowed value does not live long enough
 ...
-73 | }
-   | ^ `c` dropped here while still borrowed
+77 | }
+   | - `c` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch-reorder.rs:73:1
+  --> $DIR/dropck-eyepatch-reorder.rs:59:20
    |
-58 |     dr = Dr("dr", &c);
-   |                    - borrow occurs here
+59 |     dr = Dr("dr", &c);
+   |                    ^ borrowed value does not live long enough
 ...
-73 | }
-   | ^ `c` dropped here while still borrowed
+77 | }
+   | - `c` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch-reorder.rs:73:1
+  --> $DIR/dropck-eyepatch-reorder.rs:67:29
    |
-65 |     pt = Pt("pt", &c_long, &c);
-   |                             - borrow occurs here
+67 |     pt = Pt("pt", &c_long, &c);
+   |                             ^ borrowed value does not live long enough
 ...
-73 | }
-   | ^ `c` dropped here while still borrowed
+77 | }
+   | - `c` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch-reorder.rs:73:1
+  --> $DIR/dropck-eyepatch-reorder.rs:69:29
    |
-66 |     pr = Pr("pr", &c_long, &c);
-   |                             - borrow occurs here
+69 |     pr = Pr("pr", &c_long, &c);
+   |                             ^ borrowed value does not live long enough
 ...
-73 | }
-   | ^ `c` dropped here while still borrowed
+77 | }
+   | - `c` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/test/ui/dropck/dropck-eyepatch.rs
+++ b/src/test/ui/dropck/dropck-eyepatch.rs
@@ -78,7 +78,9 @@ fn main() {
     dr = Dr("dr", &c_long);
     // Error: destructor order imprecisely modelled
     dt = Dt("dt", &c);
+    //~^ ERROR `c` does not live long enough
     dr = Dr("dr", &c);
+    //~^ ERROR `c` does not live long enough
 
     // No error: Drop impl asserts .1 (A and &'a _) are not accessed
     pt = Pt("pt", &c, &c_long);
@@ -86,7 +88,9 @@ fn main() {
 
     // Error: Drop impl's assertion does not apply to `B` nor `&'b _`
     pt = Pt("pt", &c_long, &c);
+    //~^ ERROR `c` does not live long enough
     pr = Pr("pr", &c_long, &c);
+    //~^ ERROR `c` does not live long enough
 
     // No error: St and Sr have no destructor.
     st = St("st", &c);
@@ -94,7 +98,3 @@ fn main() {
 
     println!("{:?}", (dt.0, dr.0, pt.0, pr.0, st.0, sr.0));
 }
-//~^ ERROR `c` does not live long enough
-//~| ERROR `c` does not live long enough
-//~| ERROR `c` does not live long enough
-//~| ERROR `c` does not live long enough

--- a/src/test/ui/dropck/dropck-eyepatch.stderr
+++ b/src/test/ui/dropck/dropck-eyepatch.stderr
@@ -1,46 +1,46 @@
 error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch.rs:96:1
-   |
-80 |     dt = Dt("dt", &c);
-   |                    - borrow occurs here
+   --> $DIR/dropck-eyepatch.rs:80:20
+    |
+80  |     dt = Dt("dt", &c);
+    |                    ^ borrowed value does not live long enough
 ...
-96 | }
-   | ^ `c` dropped here while still borrowed
-   |
-   = note: values in a scope are dropped in the opposite order they are created
+100 | }
+    | - `c` dropped here while still borrowed
+    |
+    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch.rs:96:1
-   |
-81 |     dr = Dr("dr", &c);
-   |                    - borrow occurs here
+   --> $DIR/dropck-eyepatch.rs:82:20
+    |
+82  |     dr = Dr("dr", &c);
+    |                    ^ borrowed value does not live long enough
 ...
-96 | }
-   | ^ `c` dropped here while still borrowed
-   |
-   = note: values in a scope are dropped in the opposite order they are created
+100 | }
+    | - `c` dropped here while still borrowed
+    |
+    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch.rs:96:1
-   |
-88 |     pt = Pt("pt", &c_long, &c);
-   |                             - borrow occurs here
+   --> $DIR/dropck-eyepatch.rs:90:29
+    |
+90  |     pt = Pt("pt", &c_long, &c);
+    |                             ^ borrowed value does not live long enough
 ...
-96 | }
-   | ^ `c` dropped here while still borrowed
-   |
-   = note: values in a scope are dropped in the opposite order they are created
+100 | }
+    | - `c` dropped here while still borrowed
+    |
+    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch.rs:96:1
-   |
-89 |     pr = Pr("pr", &c_long, &c);
-   |                             - borrow occurs here
+   --> $DIR/dropck-eyepatch.rs:92:29
+    |
+92  |     pr = Pr("pr", &c_long, &c);
+    |                             ^ borrowed value does not live long enough
 ...
-96 | }
-   | ^ `c` dropped here while still borrowed
-   |
-   = note: values in a scope are dropped in the opposite order they are created
+100 | }
+    | - `c` dropped here while still borrowed
+    |
+    = note: values in a scope are dropped in the opposite order they are created
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/generator/borrowing.stderr
+++ b/src/test/ui/generator/borrowing.stderr
@@ -2,7 +2,7 @@ error[E0597]: `a` does not live long enough
   --> $DIR/borrowing.rs:18:20
    |
 18 |         (|| yield &a).resume()
-   |          --        ^ does not live long enough
+   |          --        ^ borrowed value does not live long enough
    |          |
    |          capture occurs here
 19 |         //~^ ERROR: `a` does not live long enough
@@ -18,7 +18,7 @@ error[E0597]: `a` does not live long enough
 24 |         || {
    |         -- capture occurs here
 25 |             yield &a
-   |                    ^ does not live long enough
+   |                    ^ borrowed value does not live long enough
 ...
 28 |     };
    |     - borrowed value only lives until here

--- a/src/test/ui/generator/ref-escapes-but-not-over-yield.rs
+++ b/src/test/ui/generator/ref-escapes-but-not-over-yield.rs
@@ -22,7 +22,8 @@ fn foo(x: &i32) {
         yield();
         let b = 5;
         a = &b;
-    }; //~ ERROR
+        //~^ ERROR `b` does not live long enough
+    };
 }
 
 fn main() { }

--- a/src/test/ui/generator/ref-escapes-but-not-over-yield.stderr
+++ b/src/test/ui/generator/ref-escapes-but-not-over-yield.stderr
@@ -1,11 +1,12 @@
 error[E0597]: `b` does not live long enough
-  --> $DIR/ref-escapes-but-not-over-yield.rs:25:5
+  --> $DIR/ref-escapes-but-not-over-yield.rs:24:14
    |
 24 |         a = &b;
-   |              - borrow occurs here
-25 |     }; //~ ERROR
-   |     ^ `b` dropped here while still borrowed
-26 | }
+   |              ^ borrowed value does not live long enough
+25 |         //~^ ERROR `b` does not live long enough
+26 |     };
+   |     - `b` dropped here while still borrowed
+27 | }
    | - borrowed value needs to live until here
 
 error: aborting due to previous error

--- a/src/test/ui/issue-46471-1.rs
+++ b/src/test/ui/issue-46471-1.rs
@@ -15,7 +15,7 @@ fn main() {
         let mut z = 0;
         &mut z
     };
-    //~^ ERROR `z` does not live long enough (Ast) [E0597]
+    //~^^ ERROR `z` does not live long enough (Ast) [E0597]
     //~| ERROR `z` does not live long enough (Mir) [E0597]
     println!("{}", y);
 }

--- a/src/test/ui/issue-46471-1.stderr
+++ b/src/test/ui/issue-46471-1.stderr
@@ -10,12 +10,12 @@ error[E0597]: `z` does not live long enough (Ast)
    | - borrowed value needs to live until here
 
 error[E0597]: `z` does not live long enough (Mir)
-  --> $DIR/issue-46471-1.rs:17:6
+  --> $DIR/issue-46471-1.rs:16:9
    |
 16 |         &mut z
-   |         ------ borrow occurs here
+   |         ^^^^^^ borrowed value does not live long enough
 17 |     };
-   |      ^ `z` dropped here while still borrowed
+   |      - `z` dropped here while still borrowed
 ...
 21 | }
    | - borrowed value needs to live until here

--- a/src/test/ui/issue-46471-1.stderr
+++ b/src/test/ui/issue-46471-1.stderr
@@ -1,10 +1,10 @@
 error[E0597]: `z` does not live long enough (Ast)
-  --> $DIR/issue-46471-1.rs:17:5
+  --> $DIR/issue-46471-1.rs:16:14
    |
 16 |         &mut z
-   |              - borrow occurs here
+   |              ^ borrowed value does not live long enough
 17 |     };
-   |     ^ `z` dropped here while still borrowed
+   |     - `z` dropped here while still borrowed
 ...
 21 | }
    | - borrowed value needs to live until here

--- a/src/test/ui/issue-46471.stderr
+++ b/src/test/ui/issue-46471.stderr
@@ -13,7 +13,7 @@ error[E0597]: `x` does not live long enough (Mir)
   --> $DIR/issue-46471.rs:15:5
    |
 15 |     &x
-   |     ^^ does not live long enough
+   |     ^^ borrowed value does not live long enough
 ...
 18 | }
    |  - borrowed value only lives until here

--- a/src/test/ui/issue-46471.stderr
+++ b/src/test/ui/issue-46471.stderr
@@ -2,7 +2,7 @@ error[E0597]: `x` does not live long enough (Ast)
   --> $DIR/issue-46471.rs:15:6
    |
 15 |     &x
-   |      ^ does not live long enough
+   |      ^ borrowed value does not live long enough
 ...
 18 | }
    | - borrowed value only lives until here

--- a/src/test/ui/issue-46472.stderr
+++ b/src/test/ui/issue-46472.stderr
@@ -2,7 +2,7 @@ error[E0597]: borrowed value does not live long enough (Ast)
   --> $DIR/issue-46472.rs:14:10
    |
 14 |     &mut 4
-   |          ^ does not live long enough
+   |          ^ temporary value does not live long enough
 ...
 17 | }
    | - temporary value only lives until here

--- a/src/test/ui/issue-46472.stderr
+++ b/src/test/ui/issue-46472.stderr
@@ -21,7 +21,7 @@ error[E0597]: borrowed value does not live long enough (Mir)
   --> $DIR/issue-46472.rs:14:10
    |
 14 |     &mut 4
-   |          ^ does not live long enough
+   |          ^ temporary value does not live long enough
 ...
 17 | }
    |  - temporary value only lives until here

--- a/src/test/ui/lifetimes/borrowck-let-suggestion.rs
+++ b/src/test/ui/lifetimes/borrowck-let-suggestion.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 fn f() {
-    let x = vec![1].iter(); //~ ERROR does not live long enough
+    let x = vec![1].iter();
 }
 
 fn main() {

--- a/src/test/ui/lifetimes/borrowck-let-suggestion.stderr
+++ b/src/test/ui/lifetimes/borrowck-let-suggestion.stderr
@@ -1,10 +1,10 @@
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/borrowck-let-suggestion.rs:12:27
+  --> $DIR/borrowck-let-suggestion.rs:12:13
    |
-12 |     let x = vec![1].iter(); //~ ERROR does not live long enough
-   |             -------       ^ temporary value dropped here while still borrowed
+12 |     let x = vec![1].iter();
+   |             ^^^^^^^       - temporary value dropped here while still borrowed
    |             |
-   |             temporary value created here
+   |             temporary value does not live long enough
 13 | }
    | - temporary value needs to live until here
    |

--- a/src/test/ui/nll/capture-ref-in-struct.stderr
+++ b/src/test/ui/nll/capture-ref-in-struct.stderr
@@ -2,7 +2,7 @@ error[E0597]: `y` does not live long enough
   --> $DIR/capture-ref-in-struct.rs:32:16
    |
 32 |             y: &y,
-   |                ^^ does not live long enough
+   |                ^^ borrowed value does not live long enough
 ...
 37 |     }
    |      - borrowed value only lives until here

--- a/src/test/ui/nll/closure-requirements/escape-argument.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-argument.stderr
@@ -28,7 +28,7 @@ error[E0597]: `y` does not live long enough
   --> $DIR/escape-argument.rs:37:25
    |
 37 |         closure(&mut p, &y);
-   |                         ^^ does not live long enough
+   |                         ^^ borrowed value does not live long enough
 38 |         //~^ ERROR `y` does not live long enough [E0597]
 39 |     }
    |      - borrowed value only lives until here

--- a/src/test/ui/nll/closure-requirements/escape-upvar-nested.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-nested.stderr
@@ -54,7 +54,7 @@ error[E0597]: `y` does not live long enough
 31 | |             let mut closure1 = || p = &y;
 32 | |             closure1();
 33 | |         };
-   | |_________^ does not live long enough
+   | |_________^ borrowed value does not live long enough
 ...
 36 |       }
    |        - borrowed value only lives until here

--- a/src/test/ui/nll/closure-requirements/escape-upvar-ref.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-ref.stderr
@@ -31,7 +31,7 @@ error[E0597]: `y` does not live long enough
   --> $DIR/escape-upvar-ref.rs:33:27
    |
 33 |         let mut closure = || p = &y;
-   |                           ^^^^^^^^^ does not live long enough
+   |                           ^^^^^^^^^ borrowed value does not live long enough
 ...
 36 |     }
    |      - borrowed value only lives until here

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -75,7 +75,7 @@ error[E0597]: `a` does not live long enough
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:41:26
    |
 41 |     let cell = Cell::new(&a);
-   |                          ^^ does not live long enough
+   |                          ^^ borrowed value does not live long enough
 ...
 49 | }
    | - borrowed value only lives until here

--- a/src/test/ui/region-borrow-params-issue-29793-small.stderr
+++ b/src/test/ui/region-borrow-params-issue-29793-small.stderr
@@ -2,7 +2,7 @@ error[E0597]: `x` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:19:34
    |
 19 |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                 ---------        ^ does not live long enough
+   |                 ---------        ^ borrowed value does not live long enough
    |                 |
    |                 capture occurs here
 ...
@@ -15,7 +15,7 @@ error[E0597]: `y` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:19:45
    |
 19 |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                 ---------                   ^ does not live long enough
+   |                 ---------                   ^ borrowed value does not live long enough
    |                 |
    |                 capture occurs here
 ...
@@ -28,7 +28,7 @@ error[E0597]: `x` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:34:34
    |
 34 |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                 ---------        ^ does not live long enough
+   |                 ---------        ^ borrowed value does not live long enough
    |                 |
    |                 capture occurs here
 ...
@@ -41,7 +41,7 @@ error[E0597]: `y` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:34:45
    |
 34 |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                 ---------                   ^ does not live long enough
+   |                 ---------                   ^ borrowed value does not live long enough
    |                 |
    |                 capture occurs here
 ...

--- a/src/test/ui/span/borrowck-let-suggestion-suffixes.rs
+++ b/src/test/ui/span/borrowck-let-suggestion-suffixes.rs
@@ -42,6 +42,7 @@ fn f() {
         //~| NOTE consider using a `let` binding to increase its lifetime
 
     }                       // (statement 7)
+    //~^ NOTE temporary value needs to live until here
 
     let mut v5 = Vec::new(); // statement 8
 

--- a/src/test/ui/span/borrowck-let-suggestion-suffixes.rs
+++ b/src/test/ui/span/borrowck-let-suggestion-suffixes.rs
@@ -19,11 +19,17 @@ fn f() {
     let young = ['y'];       // statement 3
 
     v2.push(&young[0]);      // statement 4
+    //~^ ERROR `young[..]` does not live long enough
+    //~| NOTE borrowed value does not live long enough
+    //~| NOTE values in a scope are dropped in the opposite order they are created
 
     let mut v3 = Vec::new(); // statement 5
 
     v3.push(&id('x'));           // statement 6
     //~^ ERROR borrowed value does not live long enough
+    //~| NOTE temporary value does not live long enough
+    //~| NOTE temporary value dropped here while still borrowed
+    //~| NOTE consider using a `let` binding to increase its lifetime
 
     {
 
@@ -31,6 +37,9 @@ fn f() {
 
         v4.push(&id('y'));
         //~^ ERROR borrowed value does not live long enough
+        //~| NOTE temporary value does not live long enough
+        //~| NOTE temporary value dropped here while still borrowed
+        //~| NOTE consider using a `let` binding to increase its lifetime
 
     }                       // (statement 7)
 
@@ -38,10 +47,15 @@ fn f() {
 
     v5.push(&id('z'));
     //~^ ERROR borrowed value does not live long enough
+    //~| NOTE temporary value does not live long enough
+    //~| NOTE temporary value dropped here while still borrowed
+    //~| NOTE consider using a `let` binding to increase its lifetime
 
     v1.push(&old[0]);
 }
-//~^ ERROR `young[..]` does not live long enough
+//~^ NOTE `young[..]` dropped here while still borrowed
+//~| NOTE temporary value needs to live until here
+//~| NOTE temporary value needs to live until here
 
 fn main() {
     f();

--- a/src/test/ui/span/borrowck-let-suggestion-suffixes.stderr
+++ b/src/test/ui/span/borrowck-let-suggestion-suffixes.stderr
@@ -1,49 +1,49 @@
 error[E0597]: `young[..]` does not live long enough
-  --> $DIR/borrowck-let-suggestion-suffixes.rs:43:1
+  --> $DIR/borrowck-let-suggestion-suffixes.rs:21:14
    |
 21 |     v2.push(&young[0]);      // statement 4
-   |              -------- borrow occurs here
+   |              ^^^^^^^^ borrowed value does not live long enough
 ...
-43 | }
-   | ^ `young[..]` dropped here while still borrowed
+56 | }
+   | - `young[..]` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/borrowck-let-suggestion-suffixes.rs:25:22
+  --> $DIR/borrowck-let-suggestion-suffixes.rs:28:14
    |
-25 |     v3.push(&id('x'));           // statement 6
-   |              ------- ^ temporary value dropped here while still borrowed
+28 |     v3.push(&id('x'));           // statement 6
+   |              ^^^^^^^ - temporary value dropped here while still borrowed
    |              |
-   |              temporary value created here
+   |              temporary value does not live long enough
 ...
-43 | }
+56 | }
    | - temporary value needs to live until here
    |
    = note: consider using a `let` binding to increase its lifetime
 
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/borrowck-let-suggestion-suffixes.rs:32:26
+  --> $DIR/borrowck-let-suggestion-suffixes.rs:38:18
    |
-32 |         v4.push(&id('y'));
-   |                  ------- ^ temporary value dropped here while still borrowed
+38 |         v4.push(&id('y'));
+   |                  ^^^^^^^ - temporary value dropped here while still borrowed
    |                  |
-   |                  temporary value created here
+   |                  temporary value does not live long enough
 ...
-35 |     }                       // (statement 7)
+44 |     }                       // (statement 7)
    |     - temporary value needs to live until here
    |
    = note: consider using a `let` binding to increase its lifetime
 
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/borrowck-let-suggestion-suffixes.rs:39:22
+  --> $DIR/borrowck-let-suggestion-suffixes.rs:49:14
    |
-39 |     v5.push(&id('z'));
-   |              ------- ^ temporary value dropped here while still borrowed
+49 |     v5.push(&id('z'));
+   |              ^^^^^^^ - temporary value dropped here while still borrowed
    |              |
-   |              temporary value created here
+   |              temporary value does not live long enough
 ...
-43 | }
+56 | }
    | - temporary value needs to live until here
    |
    = note: consider using a `let` binding to increase its lifetime

--- a/src/test/ui/span/borrowck-ref-into-rvalue.rs
+++ b/src/test/ui/span/borrowck-ref-into-rvalue.rs
@@ -12,9 +12,10 @@ fn main() {
     let msg;
     match Some("Hello".to_string()) {
         Some(ref m) => {
+        //~^ ERROR borrowed value does not live long enough
             msg = m;
         },
         None => { panic!() }
-    } //~ ERROR borrowed value does not live long enough
+    }
     println!("{}", *msg);
 }

--- a/src/test/ui/span/borrowck-ref-into-rvalue.stderr
+++ b/src/test/ui/span/borrowck-ref-into-rvalue.stderr
@@ -1,13 +1,13 @@
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/borrowck-ref-into-rvalue.rs:18:5
+  --> $DIR/borrowck-ref-into-rvalue.rs:14:14
    |
 14 |         Some(ref m) => {
-   |              ----- borrow occurs here
+   |              ^^^^^ borrowed value does not live long enough
 ...
-18 |     } //~ ERROR borrowed value does not live long enough
-   |     ^ borrowed value dropped here while still borrowed
-19 |     println!("{}", *msg);
-20 | }
+19 |     }
+   |     - borrowed value dropped here while still borrowed
+20 |     println!("{}", *msg);
+21 | }
    | - borrowed value needs to live until here
    |
    = note: consider using a `let` binding to increase its lifetime

--- a/src/test/ui/span/destructor-restrictions.rs
+++ b/src/test/ui/span/destructor-restrictions.rs
@@ -16,6 +16,6 @@ fn main() {
     let b = {
         let a = Box::new(RefCell::new(4));
         *a.borrow() + 1
-    }; //~ ERROR `*a` does not live long enough
+    }; //~^ ERROR `*a` does not live long enough
     println!("{}", b);
 }

--- a/src/test/ui/span/destructor-restrictions.stderr
+++ b/src/test/ui/span/destructor-restrictions.stderr
@@ -1,10 +1,10 @@
 error[E0597]: `*a` does not live long enough
-  --> $DIR/destructor-restrictions.rs:19:5
+  --> $DIR/destructor-restrictions.rs:18:10
    |
 18 |         *a.borrow() + 1
-   |          - borrow occurs here
-19 |     }; //~ ERROR `*a` does not live long enough
-   |     ^- borrowed value needs to live until here
+   |          ^ borrowed value does not live long enough
+19 |     }; //~^ ERROR `*a` does not live long enough
+   |     -- borrowed value needs to live until here
    |     |
    |     `*a` dropped here while still borrowed
 

--- a/src/test/ui/span/dropck-object-cycle.rs
+++ b/src/test/ui/span/dropck-object-cycle.rs
@@ -35,6 +35,7 @@ impl<'t> MakerTrait for Box<Trait<'t>+'static> {
 pub fn main() {
     let m : Box<Trait+'static> = make_val();
     assert_eq!(object_invoke1(&*m), (4,5));
+    //~^ ERROR `*m` does not live long enough
 
     // the problem here is that the full type of `m` is
     //
@@ -54,5 +55,4 @@ pub fn main() {
     // the type of `m` *strictly outlives* `'m`. Hence we get an
     // error.
 }
-//~^ ERROR `*m` does not live long enough
 

--- a/src/test/ui/span/dropck-object-cycle.stderr
+++ b/src/test/ui/span/dropck-object-cycle.stderr
@@ -1,11 +1,11 @@
 error[E0597]: `*m` does not live long enough
-  --> $DIR/dropck-object-cycle.rs:56:1
+  --> $DIR/dropck-object-cycle.rs:37:32
    |
 37 |     assert_eq!(object_invoke1(&*m), (4,5));
-   |                                -- borrow occurs here
+   |                                ^^ borrowed value does not live long enough
 ...
-56 | }
-   | ^ `*m` dropped here while still borrowed
+57 | }
+   | - `*m` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/test/ui/span/dropck_arr_cycle_checked.rs
+++ b/src/test/ui/span/dropck_arr_cycle_checked.rs
@@ -101,18 +101,18 @@ fn f() {
     b2 = B::new();
     b3 = B::new();
     b1.a[0].v.set(Some(&b2));
+    //~^ ERROR `b2` does not live long enough
     b1.a[1].v.set(Some(&b3));
+    //~^ ERROR `b3` does not live long enough
     b2.a[0].v.set(Some(&b2));
+    //~^ ERROR `b2` does not live long enough
     b2.a[1].v.set(Some(&b3));
+    //~^ ERROR `b3` does not live long enough
     b3.a[0].v.set(Some(&b1));
+    //~^ ERROR `b1` does not live long enough
     b3.a[1].v.set(Some(&b2));
+    //~^ ERROR `b2` does not live long enough
 }
-//~^ ERROR `b2` does not live long enough
-//~| ERROR `b3` does not live long enough
-//~| ERROR `b2` does not live long enough
-//~| ERROR `b3` does not live long enough
-//~| ERROR `b1` does not live long enough
-//~| ERROR `b2` does not live long enough
 
 fn main() {
     f();

--- a/src/test/ui/span/dropck_arr_cycle_checked.stderr
+++ b/src/test/ui/span/dropck_arr_cycle_checked.stderr
@@ -1,65 +1,66 @@
 error[E0597]: `b2` does not live long enough
-   --> $DIR/dropck_arr_cycle_checked.rs:109:1
+   --> $DIR/dropck_arr_cycle_checked.rs:103:25
     |
 103 |     b1.a[0].v.set(Some(&b2));
-    |                         -- borrow occurs here
+    |                         ^^ borrowed value does not live long enough
 ...
-109 | }
-    | ^ `b2` dropped here while still borrowed
+115 | }
+    | - `b2` dropped here while still borrowed
     |
     = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `b3` does not live long enough
-   --> $DIR/dropck_arr_cycle_checked.rs:109:1
+   --> $DIR/dropck_arr_cycle_checked.rs:105:25
     |
-104 |     b1.a[1].v.set(Some(&b3));
-    |                         -- borrow occurs here
+105 |     b1.a[1].v.set(Some(&b3));
+    |                         ^^ borrowed value does not live long enough
 ...
-109 | }
-    | ^ `b3` dropped here while still borrowed
+115 | }
+    | - `b3` dropped here while still borrowed
     |
     = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `b2` does not live long enough
-   --> $DIR/dropck_arr_cycle_checked.rs:109:1
+   --> $DIR/dropck_arr_cycle_checked.rs:107:25
     |
-105 |     b2.a[0].v.set(Some(&b2));
-    |                         -- borrow occurs here
+107 |     b2.a[0].v.set(Some(&b2));
+    |                         ^^ borrowed value does not live long enough
 ...
-109 | }
-    | ^ `b2` dropped here while still borrowed
+115 | }
+    | - `b2` dropped here while still borrowed
     |
     = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `b3` does not live long enough
-   --> $DIR/dropck_arr_cycle_checked.rs:109:1
+   --> $DIR/dropck_arr_cycle_checked.rs:109:25
     |
-106 |     b2.a[1].v.set(Some(&b3));
-    |                         -- borrow occurs here
+109 |     b2.a[1].v.set(Some(&b3));
+    |                         ^^ borrowed value does not live long enough
 ...
-109 | }
-    | ^ `b3` dropped here while still borrowed
+115 | }
+    | - `b3` dropped here while still borrowed
     |
     = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `b1` does not live long enough
-   --> $DIR/dropck_arr_cycle_checked.rs:109:1
+   --> $DIR/dropck_arr_cycle_checked.rs:111:25
     |
-107 |     b3.a[0].v.set(Some(&b1));
-    |                         -- borrow occurs here
-108 |     b3.a[1].v.set(Some(&b2));
-109 | }
-    | ^ `b1` dropped here while still borrowed
+111 |     b3.a[0].v.set(Some(&b1));
+    |                         ^^ borrowed value does not live long enough
+...
+115 | }
+    | - `b1` dropped here while still borrowed
     |
     = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `b2` does not live long enough
-   --> $DIR/dropck_arr_cycle_checked.rs:109:1
+   --> $DIR/dropck_arr_cycle_checked.rs:113:25
     |
-108 |     b3.a[1].v.set(Some(&b2));
-    |                         -- borrow occurs here
-109 | }
-    | ^ `b2` dropped here while still borrowed
+113 |     b3.a[1].v.set(Some(&b2));
+    |                         ^^ borrowed value does not live long enough
+114 |     //~^ ERROR `b2` does not live long enough
+115 | }
+    | - `b2` dropped here while still borrowed
     |
     = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/test/ui/span/dropck_direct_cycle_with_drop.rs
+++ b/src/test/ui/span/dropck_direct_cycle_with_drop.rs
@@ -44,10 +44,10 @@ impl<'a> Drop for D<'a> {
 fn g() {
     let (d1, d2) = (D::new(format!("d1")), D::new(format!("d2")));
     d1.p.set(Some(&d2));
+    //~^ ERROR `d2` does not live long enough
     d2.p.set(Some(&d1));
+    //~^ ERROR `d1` does not live long enough
 }
-//~^ ERROR `d2` does not live long enough
-//~| ERROR `d1` does not live long enough
 
 fn main() {
     g();

--- a/src/test/ui/span/dropck_direct_cycle_with_drop.stderr
+++ b/src/test/ui/span/dropck_direct_cycle_with_drop.stderr
@@ -1,21 +1,22 @@
 error[E0597]: `d2` does not live long enough
-  --> $DIR/dropck_direct_cycle_with_drop.rs:48:1
+  --> $DIR/dropck_direct_cycle_with_drop.rs:46:20
    |
 46 |     d1.p.set(Some(&d2));
-   |                    -- borrow occurs here
-47 |     d2.p.set(Some(&d1));
-48 | }
-   | ^ `d2` dropped here while still borrowed
+   |                    ^^ borrowed value does not live long enough
+...
+50 | }
+   | - `d2` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `d1` does not live long enough
-  --> $DIR/dropck_direct_cycle_with_drop.rs:48:1
+  --> $DIR/dropck_direct_cycle_with_drop.rs:48:20
    |
-47 |     d2.p.set(Some(&d1));
-   |                    -- borrow occurs here
-48 | }
-   | ^ `d1` dropped here while still borrowed
+48 |     d2.p.set(Some(&d1));
+   |                    ^^ borrowed value does not live long enough
+49 |     //~^ ERROR `d1` does not live long enough
+50 | }
+   | - `d1` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/test/ui/span/dropck_misc_variants.rs
+++ b/src/test/ui/span/dropck_misc_variants.rs
@@ -32,16 +32,16 @@ fn projection() {
     bomb = vec![""];
     _w = Wrap::<&[&str]>(NoisyDrop(&bomb));
 }
-//~^ ERROR `bomb` does not live long enough
+//~^^ ERROR `bomb` does not live long enough
 
 fn closure() {
     let (_w,v);
     v = vec![""];
     _w = {
         let u = NoisyDrop(&v);
+        //~^ ERROR `v` does not live long enough
         move || u.0.len()
     };
 }
-//~^ ERROR `v` does not live long enough
 
 fn main() { closure(); projection() }

--- a/src/test/ui/span/dropck_misc_variants.stderr
+++ b/src/test/ui/span/dropck_misc_variants.stderr
@@ -1,21 +1,21 @@
 error[E0597]: `bomb` does not live long enough
-  --> $DIR/dropck_misc_variants.rs:34:1
+  --> $DIR/dropck_misc_variants.rs:33:37
    |
 33 |     _w = Wrap::<&[&str]>(NoisyDrop(&bomb));
-   |                                     ---- borrow occurs here
+   |                                     ^^^^ borrowed value does not live long enough
 34 | }
-   | ^ `bomb` dropped here while still borrowed
+   | - `bomb` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `v` does not live long enough
-  --> $DIR/dropck_misc_variants.rs:44:1
+  --> $DIR/dropck_misc_variants.rs:41:28
    |
 41 |         let u = NoisyDrop(&v);
-   |                            - borrow occurs here
+   |                            ^ borrowed value does not live long enough
 ...
-44 | }
-   | ^ `v` dropped here while still borrowed
+45 | }
+   | - `v` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/test/ui/span/dropck_vec_cycle_checked.rs
+++ b/src/test/ui/span/dropck_vec_cycle_checked.rs
@@ -108,18 +108,18 @@ fn f() {
     c3.v.push(CheckId(Cell::new(None)));
 
     c1.v[0].v.set(Some(&c2));
+    //~^ ERROR `c2` does not live long enough
     c1.v[1].v.set(Some(&c3));
+    //~^ ERROR `c3` does not live long enough
     c2.v[0].v.set(Some(&c2));
+    //~^ ERROR `c2` does not live long enough
     c2.v[1].v.set(Some(&c3));
+    //~^ ERROR `c3` does not live long enough
     c3.v[0].v.set(Some(&c1));
+    //~^ ERROR `c1` does not live long enough
     c3.v[1].v.set(Some(&c2));
+    //~^ ERROR `c2` does not live long enough
 }
-//~^ ERROR `c2` does not live long enough
-//~| ERROR `c3` does not live long enough
-//~| ERROR `c2` does not live long enough
-//~| ERROR `c3` does not live long enough
-//~| ERROR `c1` does not live long enough
-//~| ERROR `c2` does not live long enough
 
 fn main() {
     f();

--- a/src/test/ui/span/dropck_vec_cycle_checked.stderr
+++ b/src/test/ui/span/dropck_vec_cycle_checked.stderr
@@ -1,65 +1,66 @@
 error[E0597]: `c2` does not live long enough
-   --> $DIR/dropck_vec_cycle_checked.rs:116:1
+   --> $DIR/dropck_vec_cycle_checked.rs:110:25
     |
 110 |     c1.v[0].v.set(Some(&c2));
-    |                         -- borrow occurs here
+    |                         ^^ borrowed value does not live long enough
 ...
-116 | }
-    | ^ `c2` dropped here while still borrowed
+122 | }
+    | - `c2` dropped here while still borrowed
     |
     = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `c3` does not live long enough
-   --> $DIR/dropck_vec_cycle_checked.rs:116:1
+   --> $DIR/dropck_vec_cycle_checked.rs:112:25
     |
-111 |     c1.v[1].v.set(Some(&c3));
-    |                         -- borrow occurs here
+112 |     c1.v[1].v.set(Some(&c3));
+    |                         ^^ borrowed value does not live long enough
 ...
-116 | }
-    | ^ `c3` dropped here while still borrowed
+122 | }
+    | - `c3` dropped here while still borrowed
     |
     = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `c2` does not live long enough
-   --> $DIR/dropck_vec_cycle_checked.rs:116:1
+   --> $DIR/dropck_vec_cycle_checked.rs:114:25
     |
-112 |     c2.v[0].v.set(Some(&c2));
-    |                         -- borrow occurs here
+114 |     c2.v[0].v.set(Some(&c2));
+    |                         ^^ borrowed value does not live long enough
 ...
-116 | }
-    | ^ `c2` dropped here while still borrowed
+122 | }
+    | - `c2` dropped here while still borrowed
     |
     = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `c3` does not live long enough
-   --> $DIR/dropck_vec_cycle_checked.rs:116:1
+   --> $DIR/dropck_vec_cycle_checked.rs:116:25
     |
-113 |     c2.v[1].v.set(Some(&c3));
-    |                         -- borrow occurs here
+116 |     c2.v[1].v.set(Some(&c3));
+    |                         ^^ borrowed value does not live long enough
 ...
-116 | }
-    | ^ `c3` dropped here while still borrowed
+122 | }
+    | - `c3` dropped here while still borrowed
     |
     = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `c1` does not live long enough
-   --> $DIR/dropck_vec_cycle_checked.rs:116:1
+   --> $DIR/dropck_vec_cycle_checked.rs:118:25
     |
-114 |     c3.v[0].v.set(Some(&c1));
-    |                         -- borrow occurs here
-115 |     c3.v[1].v.set(Some(&c2));
-116 | }
-    | ^ `c1` dropped here while still borrowed
+118 |     c3.v[0].v.set(Some(&c1));
+    |                         ^^ borrowed value does not live long enough
+...
+122 | }
+    | - `c1` dropped here while still borrowed
     |
     = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `c2` does not live long enough
-   --> $DIR/dropck_vec_cycle_checked.rs:116:1
+   --> $DIR/dropck_vec_cycle_checked.rs:120:25
     |
-115 |     c3.v[1].v.set(Some(&c2));
-    |                         -- borrow occurs here
-116 | }
-    | ^ `c2` dropped here while still borrowed
+120 |     c3.v[1].v.set(Some(&c2));
+    |                         ^^ borrowed value does not live long enough
+121 |     //~^ ERROR `c2` does not live long enough
+122 | }
+    | - `c2` dropped here while still borrowed
     |
     = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/test/ui/span/issue-11925.stderr
+++ b/src/test/ui/span/issue-11925.stderr
@@ -4,7 +4,7 @@ error[E0597]: `x` does not live long enough
 18 |         let f = to_fn_once(move|| &x); //~ ERROR does not live long enough
    |                                    ^
    |                                    |
-   |                                    borrow occurs here
+   |                                    borrowed value does not live long enough
    |                                    `x` dropped here while still borrowed
 ...
 23 | }

--- a/src/test/ui/span/issue-15480.rs
+++ b/src/test/ui/span/issue-15480.rs
@@ -13,7 +13,8 @@ fn id<T>(x: T) -> T { x }
 fn main() {
     let v = vec![
         &id(3)
-    ]; //~ ERROR borrowed value does not live long enough
+    ];
+    //~^^ ERROR borrowed value does not live long enough
 
     for &&x in &v {
         println!("{}", x + 3);

--- a/src/test/ui/span/issue-15480.stderr
+++ b/src/test/ui/span/issue-15480.stderr
@@ -1,12 +1,12 @@
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/issue-15480.rs:16:6
+  --> $DIR/issue-15480.rs:15:10
    |
 15 |         &id(3)
-   |          ----- temporary value created here
-16 |     ]; //~ ERROR borrowed value does not live long enough
-   |      ^ temporary value dropped here while still borrowed
+   |          ^^^^^ temporary value does not live long enough
+16 |     ];
+   |      - temporary value dropped here while still borrowed
 ...
-21 | }
+22 | }
    | - temporary value needs to live until here
    |
    = note: consider using a `let` binding to increase its lifetime

--- a/src/test/ui/span/issue-23338-locals-die-before-temps-of-body.rs
+++ b/src/test/ui/span/issue-23338-locals-die-before-temps-of-body.rs
@@ -19,13 +19,14 @@ fn foo(x: RefCell<String>) -> String {
     let y = x;
     y.borrow().clone()
 }
-//~^ ERROR `y` does not live long enough
+//~^^ ERROR `y` does not live long enough
 
 fn foo2(x: RefCell<String>) -> String {
     let ret = {
         let y = x;
         y.borrow().clone()
-    }; //~ ERROR `y` does not live long enough
+    };
+    //~^^ ERROR `y` does not live long enough
     ret
 }
 

--- a/src/test/ui/span/issue-23338-locals-die-before-temps-of-body.stderr
+++ b/src/test/ui/span/issue-23338-locals-die-before-temps-of-body.stderr
@@ -1,20 +1,20 @@
 error[E0597]: `y` does not live long enough
-  --> $DIR/issue-23338-locals-die-before-temps-of-body.rs:21:1
+  --> $DIR/issue-23338-locals-die-before-temps-of-body.rs:20:5
    |
 20 |     y.borrow().clone()
-   |     - borrow occurs here
+   |     ^ borrowed value does not live long enough
 21 | }
-   | ^ `y` dropped here while still borrowed
+   | - `y` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/issue-23338-locals-die-before-temps-of-body.rs:28:5
+  --> $DIR/issue-23338-locals-die-before-temps-of-body.rs:27:9
    |
 27 |         y.borrow().clone()
-   |         - borrow occurs here
-28 |     }; //~ ERROR `y` does not live long enough
-   |     ^- borrowed value needs to live until here
+   |         ^ borrowed value does not live long enough
+28 |     };
+   |     -- borrowed value needs to live until here
    |     |
    |     `y` dropped here while still borrowed
 

--- a/src/test/ui/span/issue-24805-dropck-child-has-items-via-parent.rs
+++ b/src/test/ui/span/issue-24805-dropck-child-has-items-via-parent.rs
@@ -36,11 +36,11 @@ fn f_child() {
     d1 = D_Child(1);
     // ... we store a reference to `d1` within `_d` ...
     _d = D_Child(&d1);
+    //~^ ERROR `d1` does not live long enough
 
     // ... dropck *should* complain, because Drop of _d could (and
     // does) access the already dropped `d1` via the `foo` method.
 }
-//~^ ERROR `d1` does not live long enough
 
 fn main() {
     f_child();

--- a/src/test/ui/span/issue-24805-dropck-child-has-items-via-parent.stderr
+++ b/src/test/ui/span/issue-24805-dropck-child-has-items-via-parent.stderr
@@ -1,11 +1,11 @@
 error[E0597]: `d1` does not live long enough
-  --> $DIR/issue-24805-dropck-child-has-items-via-parent.rs:42:1
+  --> $DIR/issue-24805-dropck-child-has-items-via-parent.rs:38:19
    |
 38 |     _d = D_Child(&d1);
-   |                   -- borrow occurs here
+   |                   ^^ borrowed value does not live long enough
 ...
-42 | }
-   | ^ `d1` dropped here while still borrowed
+43 | }
+   | - `d1` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/test/ui/span/issue-24805-dropck-trait-has-items.rs
+++ b/src/test/ui/span/issue-24805-dropck-trait-has-items.rs
@@ -46,19 +46,19 @@ fn f_sm() {
     d1 = D_HasSelfMethod(1);
     _d = D_HasSelfMethod(&d1);
 }
-//~^ ERROR `d1` does not live long enough
+//~^^ ERROR `d1` does not live long enough
 fn f_mwsa() {
     let (_d, d1);
     d1 = D_HasMethodWithSelfArg(1);
     _d = D_HasMethodWithSelfArg(&d1);
 }
-//~^ ERROR `d1` does not live long enough
+//~^^ ERROR `d1` does not live long enough
 fn f_t() {
     let (_d, d1);
     d1 = D_HasType(1);
     _d = D_HasType(&d1);
 }
-//~^ ERROR `d1` does not live long enough
+//~^^ ERROR `d1` does not live long enough
 
 fn main() {
     f_sm();

--- a/src/test/ui/span/issue-24805-dropck-trait-has-items.stderr
+++ b/src/test/ui/span/issue-24805-dropck-trait-has-items.stderr
@@ -1,30 +1,30 @@
 error[E0597]: `d1` does not live long enough
-  --> $DIR/issue-24805-dropck-trait-has-items.rs:48:1
+  --> $DIR/issue-24805-dropck-trait-has-items.rs:47:27
    |
 47 |     _d = D_HasSelfMethod(&d1);
-   |                           -- borrow occurs here
+   |                           ^^ borrowed value does not live long enough
 48 | }
-   | ^ `d1` dropped here while still borrowed
+   | - `d1` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `d1` does not live long enough
-  --> $DIR/issue-24805-dropck-trait-has-items.rs:54:1
+  --> $DIR/issue-24805-dropck-trait-has-items.rs:53:34
    |
 53 |     _d = D_HasMethodWithSelfArg(&d1);
-   |                                  -- borrow occurs here
+   |                                  ^^ borrowed value does not live long enough
 54 | }
-   | ^ `d1` dropped here while still borrowed
+   | - `d1` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `d1` does not live long enough
-  --> $DIR/issue-24805-dropck-trait-has-items.rs:60:1
+  --> $DIR/issue-24805-dropck-trait-has-items.rs:59:21
    |
 59 |     _d = D_HasType(&d1);
-   |                     -- borrow occurs here
+   |                     ^^ borrowed value does not live long enough
 60 | }
-   | ^ `d1` dropped here while still borrowed
+   | - `d1` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/test/ui/span/issue-24895-copy-clone-dropck.rs
+++ b/src/test/ui/span/issue-24895-copy-clone-dropck.rs
@@ -35,4 +35,5 @@ fn main() {
     let (d2, d1);
     d1 = D(34, "d1");
     d2 = D(S(&d1, "inner"), "d2");
-} //~ ERROR `d1` does not live long enough
+}
+//~^^ ERROR `d1` does not live long enough

--- a/src/test/ui/span/issue-24895-copy-clone-dropck.stderr
+++ b/src/test/ui/span/issue-24895-copy-clone-dropck.stderr
@@ -1,10 +1,10 @@
 error[E0597]: `d1` does not live long enough
-  --> $DIR/issue-24895-copy-clone-dropck.rs:38:1
+  --> $DIR/issue-24895-copy-clone-dropck.rs:37:15
    |
 37 |     d2 = D(S(&d1, "inner"), "d2");
-   |               -- borrow occurs here
-38 | } //~ ERROR `d1` does not live long enough
-   | ^ `d1` dropped here while still borrowed
+   |               ^^ borrowed value does not live long enough
+38 | }
+   | - `d1` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/test/ui/span/issue-25199.rs
+++ b/src/test/ui/span/issue-25199.rs
@@ -78,8 +78,8 @@ impl<'a> Drop for Test<'a> {
 fn main() {
     let container = Container::new();
     let test = Test{test: &container};
+    //~^ ERROR `container` does not live long enough
     println!("container.v[30]: {:?}", container.v.v[30]);
     container.store(test);
+    //~^ ERROR `container` does not live long enough
 }
-//~^ ERROR `container` does not live long enough
-//~| ERROR `container` does not live long enough

--- a/src/test/ui/span/issue-25199.stderr
+++ b/src/test/ui/span/issue-25199.stderr
@@ -1,21 +1,22 @@
 error[E0597]: `container` does not live long enough
-  --> $DIR/issue-25199.rs:83:1
+  --> $DIR/issue-25199.rs:80:28
    |
 80 |     let test = Test{test: &container};
-   |                            --------- borrow occurs here
+   |                            ^^^^^^^^^ borrowed value does not live long enough
 ...
-83 | }
-   | ^ `container` dropped here while still borrowed
+85 | }
+   | - `container` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `container` does not live long enough
-  --> $DIR/issue-25199.rs:83:1
+  --> $DIR/issue-25199.rs:83:5
    |
-82 |     container.store(test);
-   |     --------- borrow occurs here
-83 | }
-   | ^ `container` dropped here while still borrowed
+83 |     container.store(test);
+   |     ^^^^^^^^^ borrowed value does not live long enough
+84 |     //~^ ERROR `container` does not live long enough
+85 | }
+   | - `container` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/test/ui/span/issue-26656.rs
+++ b/src/test/ui/span/issue-26656.rs
@@ -49,4 +49,4 @@ fn main() {
     ticking = Bomb { usable: true };
     zook.button = B::BigRedButton(&ticking);
 }
-//~^ ERROR `ticking` does not live long enough
+//~^^ ERROR `ticking` does not live long enough

--- a/src/test/ui/span/issue-26656.stderr
+++ b/src/test/ui/span/issue-26656.stderr
@@ -1,10 +1,10 @@
 error[E0597]: `ticking` does not live long enough
-  --> $DIR/issue-26656.rs:51:1
+  --> $DIR/issue-26656.rs:50:36
    |
 50 |     zook.button = B::BigRedButton(&ticking);
-   |                                    ------- borrow occurs here
+   |                                    ^^^^^^^ borrowed value does not live long enough
 51 | }
-   | ^ `ticking` dropped here while still borrowed
+   | - `ticking` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/test/ui/span/issue-29106.rs
+++ b/src/test/ui/span/issue-29106.rs
@@ -24,11 +24,13 @@ fn main() {
         let (y, x);
         x = "alive".to_string();
         y = Arc::new(Foo(&x));
-    } //~ ERROR `x` does not live long enough
+    }
+    //~^^ ERROR `x` does not live long enough
 
     {
         let (y, x);
         x = "alive".to_string();
         y = Rc::new(Foo(&x));
-    } //~ ERROR `x` does not live long enough
+    }
+    //~^^ ERROR `x` does not live long enough
 }

--- a/src/test/ui/span/issue-29106.stderr
+++ b/src/test/ui/span/issue-29106.stderr
@@ -1,20 +1,20 @@
 error[E0597]: `x` does not live long enough
-  --> $DIR/issue-29106.rs:27:5
+  --> $DIR/issue-29106.rs:26:27
    |
 26 |         y = Arc::new(Foo(&x));
-   |                           - borrow occurs here
-27 |     } //~ ERROR `x` does not live long enough
-   |     ^ `x` dropped here while still borrowed
+   |                           ^ borrowed value does not live long enough
+27 |     }
+   |     - `x` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/issue-29106.rs:33:5
+  --> $DIR/issue-29106.rs:33:26
    |
-32 |         y = Rc::new(Foo(&x));
-   |                          - borrow occurs here
-33 |     } //~ ERROR `x` does not live long enough
-   |     ^ `x` dropped here while still borrowed
+33 |         y = Rc::new(Foo(&x));
+   |                          ^ borrowed value does not live long enough
+34 |     }
+   |     - `x` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/test/ui/span/issue-36537.rs
+++ b/src/test/ui/span/issue-36537.rs
@@ -12,5 +12,5 @@ fn main() {
     let p;
     let a = 42;
     p = &a;
+    //~^ ERROR `a` does not live long enough
 }
-//~^ ERROR `a` does not live long enough

--- a/src/test/ui/span/issue-36537.stderr
+++ b/src/test/ui/span/issue-36537.stderr
@@ -1,10 +1,11 @@
 error[E0597]: `a` does not live long enough
-  --> $DIR/issue-36537.rs:15:1
+  --> $DIR/issue-36537.rs:14:10
    |
 14 |     p = &a;
-   |          - borrow occurs here
-15 | }
-   | ^ `a` dropped here while still borrowed
+   |          ^ borrowed value does not live long enough
+15 |     //~^ ERROR `a` does not live long enough
+16 | }
+   | - `a` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/test/ui/span/issue-40157.stderr
+++ b/src/test/ui/span/issue-40157.stderr
@@ -1,11 +1,11 @@
 error[E0597]: `foo` does not live long enough
-  --> $DIR/issue-40157.rs:12:64
+  --> $DIR/issue-40157.rs:12:53
    |
 12 |     {println!("{:?}", match { let foo = vec![1, 2]; foo.get(1) } { x => x });}
-   |      ----------------------------------------------------------^-------------
+   |      -----------------------------------------------^^^----------------------
    |      |                                              |          |
    |      |                                              |          `foo` dropped here while still borrowed
-   |      |                                              borrow occurs here
+   |      |                                              borrowed value does not live long enough
    |      borrowed value needs to live until here
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

--- a/src/test/ui/span/issue28498-reject-ex1.rs
+++ b/src/test/ui/span/issue28498-reject-ex1.rs
@@ -42,7 +42,7 @@ fn main() {
     foo.data.push(Concrete(0, Cell::new(None)));
 
     foo.data[0].1.set(Some(&foo.data[1]));
+    //~^ ERROR `foo.data` does not live long enough
     foo.data[1].1.set(Some(&foo.data[0]));
+    //~^ ERROR `foo.data` does not live long enough
 }
-//~^ ERROR `foo.data` does not live long enough
-//~| ERROR `foo.data` does not live long enough

--- a/src/test/ui/span/issue28498-reject-ex1.stderr
+++ b/src/test/ui/span/issue28498-reject-ex1.stderr
@@ -1,21 +1,22 @@
 error[E0597]: `foo.data` does not live long enough
-  --> $DIR/issue28498-reject-ex1.rs:46:1
+  --> $DIR/issue28498-reject-ex1.rs:44:29
    |
 44 |     foo.data[0].1.set(Some(&foo.data[1]));
-   |                             -------- borrow occurs here
-45 |     foo.data[1].1.set(Some(&foo.data[0]));
-46 | }
-   | ^ `foo.data` dropped here while still borrowed
+   |                             ^^^^^^^^ borrowed value does not live long enough
+...
+48 | }
+   | - `foo.data` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `foo.data` does not live long enough
-  --> $DIR/issue28498-reject-ex1.rs:46:1
+  --> $DIR/issue28498-reject-ex1.rs:46:29
    |
-45 |     foo.data[1].1.set(Some(&foo.data[0]));
-   |                             -------- borrow occurs here
-46 | }
-   | ^ `foo.data` dropped here while still borrowed
+46 |     foo.data[1].1.set(Some(&foo.data[0]));
+   |                             ^^^^^^^^ borrowed value does not live long enough
+47 |     //~^ ERROR `foo.data` does not live long enough
+48 | }
+   | - `foo.data` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/test/ui/span/issue28498-reject-lifetime-param.rs
+++ b/src/test/ui/span/issue28498-reject-lifetime-param.rs
@@ -40,9 +40,9 @@ fn main() {
     last_dropped = ScribbleOnDrop(format!("last"));
     first_dropped = ScribbleOnDrop(format!("first"));
     foo0 = Foo(0, &last_dropped);
+    //~^ ERROR `last_dropped` does not live long enough
     foo1 = Foo(1, &first_dropped);
+    //~^ ERROR `first_dropped` does not live long enough
 
     println!("foo0.1: {:?} foo1.1: {:?}", foo0.1, foo1.1);
 }
-//~^ ERROR `last_dropped` does not live long enough
-//~| ERROR `first_dropped` does not live long enough

--- a/src/test/ui/span/issue28498-reject-lifetime-param.stderr
+++ b/src/test/ui/span/issue28498-reject-lifetime-param.stderr
@@ -1,22 +1,22 @@
 error[E0597]: `last_dropped` does not live long enough
-  --> $DIR/issue28498-reject-lifetime-param.rs:46:1
+  --> $DIR/issue28498-reject-lifetime-param.rs:42:20
    |
 42 |     foo0 = Foo(0, &last_dropped);
-   |                    ------------ borrow occurs here
+   |                    ^^^^^^^^^^^^ borrowed value does not live long enough
 ...
-46 | }
-   | ^ `last_dropped` dropped here while still borrowed
+48 | }
+   | - `last_dropped` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `first_dropped` does not live long enough
-  --> $DIR/issue28498-reject-lifetime-param.rs:46:1
+  --> $DIR/issue28498-reject-lifetime-param.rs:44:20
    |
-43 |     foo1 = Foo(1, &first_dropped);
-   |                    ------------- borrow occurs here
+44 |     foo1 = Foo(1, &first_dropped);
+   |                    ^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
-46 | }
-   | ^ `first_dropped` dropped here while still borrowed
+48 | }
+   | - `first_dropped` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/test/ui/span/issue28498-reject-passed-to-fn.rs
+++ b/src/test/ui/span/issue28498-reject-passed-to-fn.rs
@@ -42,9 +42,9 @@ fn main() {
     last_dropped = ScribbleOnDrop(format!("last"));
     first_dropped = ScribbleOnDrop(format!("first"));
     foo0 = Foo(0, &last_dropped, Box::new(callback));
+    //~^ ERROR `last_dropped` does not live long enough
     foo1 = Foo(1, &first_dropped, Box::new(callback));
+    //~^ ERROR `first_dropped` does not live long enough
 
     println!("foo0.1: {:?} foo1.1: {:?}", foo0.1, foo1.1);
 }
-//~^ ERROR `last_dropped` does not live long enough
-//~| ERROR `first_dropped` does not live long enough

--- a/src/test/ui/span/issue28498-reject-passed-to-fn.stderr
+++ b/src/test/ui/span/issue28498-reject-passed-to-fn.stderr
@@ -1,22 +1,22 @@
 error[E0597]: `last_dropped` does not live long enough
-  --> $DIR/issue28498-reject-passed-to-fn.rs:48:1
+  --> $DIR/issue28498-reject-passed-to-fn.rs:44:20
    |
 44 |     foo0 = Foo(0, &last_dropped, Box::new(callback));
-   |                    ------------ borrow occurs here
+   |                    ^^^^^^^^^^^^ borrowed value does not live long enough
 ...
-48 | }
-   | ^ `last_dropped` dropped here while still borrowed
+50 | }
+   | - `last_dropped` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `first_dropped` does not live long enough
-  --> $DIR/issue28498-reject-passed-to-fn.rs:48:1
+  --> $DIR/issue28498-reject-passed-to-fn.rs:46:20
    |
-45 |     foo1 = Foo(1, &first_dropped, Box::new(callback));
-   |                    ------------- borrow occurs here
+46 |     foo1 = Foo(1, &first_dropped, Box::new(callback));
+   |                    ^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
-48 | }
-   | ^ `first_dropped` dropped here while still borrowed
+50 | }
+   | - `first_dropped` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/test/ui/span/issue28498-reject-trait-bound.rs
+++ b/src/test/ui/span/issue28498-reject-trait-bound.rs
@@ -42,9 +42,9 @@ fn main() {
     last_dropped = ScribbleOnDrop(format!("last"));
     first_dropped = ScribbleOnDrop(format!("first"));
     foo0 = Foo(0, &last_dropped);
+    //~^ ERROR `last_dropped` does not live long enough
     foo1 = Foo(1, &first_dropped);
+    //~^ ERROR `first_dropped` does not live long enough
 
     println!("foo0.1: {:?} foo1.1: {:?}", foo0.1, foo1.1);
 }
-//~^ ERROR `last_dropped` does not live long enough
-//~| ERROR `first_dropped` does not live long enough

--- a/src/test/ui/span/issue28498-reject-trait-bound.stderr
+++ b/src/test/ui/span/issue28498-reject-trait-bound.stderr
@@ -1,22 +1,22 @@
 error[E0597]: `last_dropped` does not live long enough
-  --> $DIR/issue28498-reject-trait-bound.rs:48:1
+  --> $DIR/issue28498-reject-trait-bound.rs:44:20
    |
 44 |     foo0 = Foo(0, &last_dropped);
-   |                    ------------ borrow occurs here
+   |                    ^^^^^^^^^^^^ borrowed value does not live long enough
 ...
-48 | }
-   | ^ `last_dropped` dropped here while still borrowed
+50 | }
+   | - `last_dropped` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `first_dropped` does not live long enough
-  --> $DIR/issue28498-reject-trait-bound.rs:48:1
+  --> $DIR/issue28498-reject-trait-bound.rs:46:20
    |
-45 |     foo1 = Foo(1, &first_dropped);
-   |                    ------------- borrow occurs here
+46 |     foo1 = Foo(1, &first_dropped);
+   |                    ^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
-48 | }
-   | ^ `first_dropped` dropped here while still borrowed
+50 | }
+   | - `first_dropped` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/test/ui/span/mut-ptr-cant-outlive-ref.rs
+++ b/src/test/ui/span/mut-ptr-cant-outlive-ref.rs
@@ -16,5 +16,6 @@ fn main() {
     {
         let b = m.borrow();
         p = &*b;
-    } //~ ERROR `b` does not live long enough
+    }
+    //~^^ ERROR `b` does not live long enough
 }

--- a/src/test/ui/span/mut-ptr-cant-outlive-ref.stderr
+++ b/src/test/ui/span/mut-ptr-cant-outlive-ref.stderr
@@ -1,11 +1,12 @@
 error[E0597]: `b` does not live long enough
-  --> $DIR/mut-ptr-cant-outlive-ref.rs:19:5
+  --> $DIR/mut-ptr-cant-outlive-ref.rs:18:15
    |
 18 |         p = &*b;
-   |               - borrow occurs here
-19 |     } //~ ERROR `b` does not live long enough
-   |     ^ `b` dropped here while still borrowed
-20 | }
+   |               ^ borrowed value does not live long enough
+19 |     }
+   |     - `b` dropped here while still borrowed
+20 |     //~^^ ERROR `b` does not live long enough
+21 | }
    | - borrowed value needs to live until here
 
 error: aborting due to previous error

--- a/src/test/ui/span/range-2.rs
+++ b/src/test/ui/span/range-2.rs
@@ -16,6 +16,6 @@ pub fn main() {
         let b = 42;
         &a..&b
     };
-    //~^ ERROR `a` does not live long enough
-    //~^^ ERROR `b` does not live long enough
+    //~^^ ERROR `a` does not live long enough
+    //~| ERROR `b` does not live long enough
 }

--- a/src/test/ui/span/range-2.stderr
+++ b/src/test/ui/span/range-2.stderr
@@ -1,21 +1,21 @@
 error[E0597]: `a` does not live long enough
-  --> $DIR/range-2.rs:18:5
+  --> $DIR/range-2.rs:17:10
    |
 17 |         &a..&b
-   |          - borrow occurs here
+   |          ^ borrowed value does not live long enough
 18 |     };
-   |     ^ `a` dropped here while still borrowed
+   |     - `a` dropped here while still borrowed
 ...
 21 | }
    | - borrowed value needs to live until here
 
 error[E0597]: `b` does not live long enough
-  --> $DIR/range-2.rs:18:5
+  --> $DIR/range-2.rs:17:14
    |
 17 |         &a..&b
-   |              - borrow occurs here
+   |              ^ borrowed value does not live long enough
 18 |     };
-   |     ^ `b` dropped here while still borrowed
+   |     - `b` dropped here while still borrowed
 ...
 21 | }
    | - borrowed value needs to live until here

--- a/src/test/ui/span/regionck-unboxed-closure-lifetimes.rs
+++ b/src/test/ui/span/regionck-unboxed-closure-lifetimes.rs
@@ -15,6 +15,7 @@ fn main() {
     {
         let c = 1;
         let c_ref = &c;
+        //~^ ERROR `c` does not live long enough
         f = move |a: isize, b: isize| { a + b + *c_ref };
-    } //~ ERROR `c` does not live long enough
+    }
 }

--- a/src/test/ui/span/regionck-unboxed-closure-lifetimes.stderr
+++ b/src/test/ui/span/regionck-unboxed-closure-lifetimes.stderr
@@ -1,12 +1,12 @@
 error[E0597]: `c` does not live long enough
-  --> $DIR/regionck-unboxed-closure-lifetimes.rs:19:5
+  --> $DIR/regionck-unboxed-closure-lifetimes.rs:17:22
    |
 17 |         let c_ref = &c;
-   |                      - borrow occurs here
-18 |         f = move |a: isize, b: isize| { a + b + *c_ref };
-19 |     } //~ ERROR `c` does not live long enough
-   |     ^ `c` dropped here while still borrowed
-20 | }
+   |                      ^ borrowed value does not live long enough
+...
+20 |     }
+   |     - `c` dropped here while still borrowed
+21 | }
    | - borrowed value needs to live until here
 
 error: aborting due to previous error

--- a/src/test/ui/span/regions-close-over-borrowed-ref-in-obj.rs
+++ b/src/test/ui/span/regions-close-over-borrowed-ref-in-obj.rs
@@ -20,6 +20,7 @@ fn main() {
     let blah;
     {
         let ss: &isize = &id(1);
+        //~^ ERROR borrowed value does not live long enough
         blah = box ss as Box<Foo>;
-    } //~ ERROR does not live long enough
+    }
 }

--- a/src/test/ui/span/regions-close-over-borrowed-ref-in-obj.stderr
+++ b/src/test/ui/span/regions-close-over-borrowed-ref-in-obj.stderr
@@ -1,12 +1,12 @@
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/regions-close-over-borrowed-ref-in-obj.rs:24:5
+  --> $DIR/regions-close-over-borrowed-ref-in-obj.rs:22:27
    |
 22 |         let ss: &isize = &id(1);
-   |                           ----- temporary value created here
-23 |         blah = box ss as Box<Foo>;
-24 |     } //~ ERROR does not live long enough
-   |     ^ temporary value dropped here while still borrowed
-25 | }
+   |                           ^^^^^ temporary value does not live long enough
+...
+25 |     }
+   |     - temporary value dropped here while still borrowed
+26 | }
    | - temporary value needs to live until here
 
 error: aborting due to previous error

--- a/src/test/ui/span/regions-close-over-type-parameter-2.rs
+++ b/src/test/ui/span/regions-close-over-type-parameter-2.rs
@@ -32,5 +32,6 @@ fn main() {
         let tmp0 = 3;
         let tmp1 = &tmp0;
         repeater3(tmp1)
-    }; //~ ERROR `tmp0` does not live long enough
+    };
+    //~^^^ ERROR `tmp0` does not live long enough
 }

--- a/src/test/ui/span/regions-close-over-type-parameter-2.stderr
+++ b/src/test/ui/span/regions-close-over-type-parameter-2.stderr
@@ -1,11 +1,11 @@
 error[E0597]: `tmp0` does not live long enough
-  --> $DIR/regions-close-over-type-parameter-2.rs:35:5
+  --> $DIR/regions-close-over-type-parameter-2.rs:33:21
    |
 33 |         let tmp1 = &tmp0;
-   |                     ---- borrow occurs here
+   |                     ^^^^ borrowed value does not live long enough
 34 |         repeater3(tmp1)
-35 |     }; //~ ERROR `tmp0` does not live long enough
-   |     ^- borrowed value needs to live until here
+35 |     };
+   |     -- borrowed value needs to live until here
    |     |
    |     `tmp0` dropped here while still borrowed
 

--- a/src/test/ui/span/regions-escape-loop-via-variable.rs
+++ b/src/test/ui/span/regions-escape-loop-via-variable.rs
@@ -19,5 +19,6 @@ fn main() {
     loop {
         let x = 1 + *p;
         p = &x;
-    } //~ ERROR `x` does not live long enough
+    }
+    //~^^ ERROR `x` does not live long enough
 }

--- a/src/test/ui/span/regions-escape-loop-via-variable.stderr
+++ b/src/test/ui/span/regions-escape-loop-via-variable.stderr
@@ -1,11 +1,12 @@
 error[E0597]: `x` does not live long enough
-  --> $DIR/regions-escape-loop-via-variable.rs:22:5
+  --> $DIR/regions-escape-loop-via-variable.rs:21:14
    |
 21 |         p = &x;
-   |              - borrow occurs here
-22 |     } //~ ERROR `x` does not live long enough
-   |     ^ `x` dropped here while still borrowed
-23 | }
+   |              ^ borrowed value does not live long enough
+22 |     }
+   |     - `x` dropped here while still borrowed
+23 |     //~^^ ERROR `x` does not live long enough
+24 | }
    | - borrowed value needs to live until here
 
 error: aborting due to previous error

--- a/src/test/ui/span/regions-escape-loop-via-vec.rs
+++ b/src/test/ui/span/regions-escape-loop-via-vec.rs
@@ -15,9 +15,9 @@ fn broken() {
     while x < 10 { //~ ERROR cannot use `x` because it was mutably borrowed
         let mut z = x; //~ ERROR cannot use `x` because it was mutably borrowed
         _y.push(&mut z);
+        //~^ ERROR `z` does not live long enough
         x += 1; //~ ERROR cannot assign
     }
-    //~^ ERROR `z` does not live long enough
 }
 
 fn main() { }

--- a/src/test/ui/span/regions-escape-loop-via-vec.stderr
+++ b/src/test/ui/span/regions-escape-loop-via-vec.stderr
@@ -1,12 +1,11 @@
 error[E0597]: `z` does not live long enough
-  --> $DIR/regions-escape-loop-via-vec.rs:19:5
+  --> $DIR/regions-escape-loop-via-vec.rs:17:22
    |
 17 |         _y.push(&mut z);
-   |                      - borrow occurs here
-18 |         x += 1; //~ ERROR cannot assign
-19 |     }
-   |     ^ `z` dropped here while still borrowed
-20 |     //~^ ERROR `z` does not live long enough
+   |                      ^ borrowed value does not live long enough
+...
+20 |     }
+   |     - `z` dropped here while still borrowed
 21 | }
    | - borrowed value needs to live until here
 
@@ -28,12 +27,12 @@ error[E0503]: cannot use `x` because it was mutably borrowed
    |             ^^^^^ use of borrowed `x`
 
 error[E0506]: cannot assign to `x` because it is borrowed
-  --> $DIR/regions-escape-loop-via-vec.rs:18:9
+  --> $DIR/regions-escape-loop-via-vec.rs:19:9
    |
 14 |     let mut _y = vec![&mut x];
    |                            - borrow of `x` occurs here
 ...
-18 |         x += 1; //~ ERROR cannot assign
+19 |         x += 1; //~ ERROR cannot assign
    |         ^^^^^^ assignment to borrowed `x` occurs here
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/span/regions-infer-borrow-scope-within-loop.rs
+++ b/src/test/ui/span/regions-infer-borrow-scope-within-loop.rs
@@ -22,10 +22,11 @@ fn foo<C, M>(mut cond: C, mut make_box: M) where
         // Here we complain because the resulting region
         // of this borrow is the fn body as a whole.
         y = borrow(&*x);
+        //~^ ERROR `*x` does not live long enough
 
         assert_eq!(*x, *y);
         if cond() { break; }
-    } //~ ERROR `*x` does not live long enough
+    }
     assert!(*y != 0);
 }
 

--- a/src/test/ui/span/regions-infer-borrow-scope-within-loop.stderr
+++ b/src/test/ui/span/regions-infer-borrow-scope-within-loop.stderr
@@ -1,13 +1,13 @@
 error[E0597]: `*x` does not live long enough
-  --> $DIR/regions-infer-borrow-scope-within-loop.rs:28:5
+  --> $DIR/regions-infer-borrow-scope-within-loop.rs:24:21
    |
 24 |         y = borrow(&*x);
-   |                     -- borrow occurs here
+   |                     ^^ borrowed value does not live long enough
 ...
-28 |     } //~ ERROR `*x` does not live long enough
-   |     ^ `*x` dropped here while still borrowed
-29 |     assert!(*y != 0);
-30 | }
+29 |     }
+   |     - `*x` dropped here while still borrowed
+30 |     assert!(*y != 0);
+31 | }
    | - borrowed value needs to live until here
 
 error: aborting due to previous error

--- a/src/test/ui/span/send-is-not-static-ensures-scoping.rs
+++ b/src/test/ui/span/send-is-not-static-ensures-scoping.rs
@@ -24,12 +24,13 @@ fn main() {
     let bad = {
         let x = 1;
         let y = &x;
+        //~^ ERROR `x` does not live long enough
 
         scoped(|| {
             let _z = y;
             //~^ ERROR `y` does not live long enough
         })
-    }; //~ ERROR `x` does not live long enough
+    };
 
     bad.join();
 }

--- a/src/test/ui/span/send-is-not-static-ensures-scoping.stderr
+++ b/src/test/ui/span/send-is-not-static-ensures-scoping.stderr
@@ -1,27 +1,27 @@
 error[E0597]: `x` does not live long enough
-  --> $DIR/send-is-not-static-ensures-scoping.rs:32:5
+  --> $DIR/send-is-not-static-ensures-scoping.rs:26:18
    |
 26 |         let y = &x;
-   |                  - borrow occurs here
+   |                  ^ borrowed value does not live long enough
 ...
-32 |     }; //~ ERROR `x` does not live long enough
-   |     ^ `x` dropped here while still borrowed
+33 |     };
+   |     - `x` dropped here while still borrowed
 ...
-35 | }
+36 | }
    | - borrowed value needs to live until here
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/send-is-not-static-ensures-scoping.rs:29:22
+  --> $DIR/send-is-not-static-ensures-scoping.rs:30:22
    |
-28 |         scoped(|| {
+29 |         scoped(|| {
    |                -- capture occurs here
-29 |             let _z = y;
-   |                      ^ does not live long enough
+30 |             let _z = y;
+   |                      ^ borrowed value does not live long enough
 ...
-32 |     }; //~ ERROR `x` does not live long enough
+33 |     };
    |     - borrowed value only lives until here
 ...
-35 | }
+36 | }
    | - borrowed value needs to live until here
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/span/send-is-not-static-std-sync-2.rs
+++ b/src/test/ui/span/send-is-not-static-std-sync-2.rs
@@ -19,7 +19,8 @@ fn mutex() {
     let lock = {
         let x = 1;
         Mutex::new(&x)
-    }; //~ ERROR does not live long enough
+    };
+    //~^^ ERROR `x` does not live long enough
 
     let _dangling = *lock.lock().unwrap();
 }
@@ -28,7 +29,8 @@ fn rwlock() {
     let lock = {
         let x = 1;
         RwLock::new(&x)
-    }; //~ ERROR does not live long enough
+    };
+    //~^^ ERROR `x` does not live long enough
     let _dangling = *lock.read().unwrap();
 }
 
@@ -38,7 +40,8 @@ fn channel() {
         let (tx, rx) = mpsc::channel();
         let _ = tx.send(&x);
         (tx, rx)
-    }; //~ ERROR does not live long enough
+    };
+    //~^^^ ERROR `x` does not live long enough
 
     let _dangling = rx.recv();
 }

--- a/src/test/ui/span/send-is-not-static-std-sync-2.stderr
+++ b/src/test/ui/span/send-is-not-static-std-sync-2.stderr
@@ -1,35 +1,35 @@
 error[E0597]: `x` does not live long enough
-  --> $DIR/send-is-not-static-std-sync-2.rs:22:5
+  --> $DIR/send-is-not-static-std-sync-2.rs:21:21
    |
 21 |         Mutex::new(&x)
-   |                     - borrow occurs here
-22 |     }; //~ ERROR does not live long enough
-   |     ^ `x` dropped here while still borrowed
+   |                     ^ borrowed value does not live long enough
+22 |     };
+   |     - `x` dropped here while still borrowed
 ...
-25 | }
+26 | }
    | - borrowed value needs to live until here
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/send-is-not-static-std-sync-2.rs:31:5
+  --> $DIR/send-is-not-static-std-sync-2.rs:31:22
    |
-30 |         RwLock::new(&x)
-   |                      - borrow occurs here
-31 |     }; //~ ERROR does not live long enough
-   |     ^ `x` dropped here while still borrowed
-32 |     let _dangling = *lock.read().unwrap();
-33 | }
+31 |         RwLock::new(&x)
+   |                      ^ borrowed value does not live long enough
+32 |     };
+   |     - `x` dropped here while still borrowed
+...
+35 | }
    | - borrowed value needs to live until here
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/send-is-not-static-std-sync-2.rs:41:5
+  --> $DIR/send-is-not-static-std-sync-2.rs:41:26
    |
-39 |         let _ = tx.send(&x);
-   |                          - borrow occurs here
-40 |         (tx, rx)
-41 |     }; //~ ERROR does not live long enough
-   |     ^ `x` dropped here while still borrowed
+41 |         let _ = tx.send(&x);
+   |                          ^ borrowed value does not live long enough
+42 |         (tx, rx)
+43 |     };
+   |     - `x` dropped here while still borrowed
 ...
-44 | }
+47 | }
    | - borrowed value needs to live until here
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/span/send-is-not-static-std-sync.rs
+++ b/src/test/ui/span/send-is-not-static-std-sync.rs
@@ -24,7 +24,8 @@ fn mutex() {
     {
         let z = 2;
         *lock.lock().unwrap() = &z;
-    } //~ ERROR does not live long enough
+    }
+    //~^^ ERROR `z` does not live long enough
 }
 
 fn rwlock() {
@@ -36,7 +37,8 @@ fn rwlock() {
     {
         let z = 2;
         *lock.write().unwrap() = &z;
-    } //~ ERROR does not live long enough
+    }
+    //~^^ ERROR `z` does not live long enough
 }
 
 fn channel() {
@@ -50,7 +52,8 @@ fn channel() {
     {
         let z = 2;
         tx.send(&z).unwrap();
-    } //~ ERROR does not live long enough
+    }
+    //~^^ ERROR `z` does not live long enough
 }
 
 fn main() {}

--- a/src/test/ui/span/send-is-not-static-std-sync.stderr
+++ b/src/test/ui/span/send-is-not-static-std-sync.stderr
@@ -1,11 +1,12 @@
 error[E0597]: `z` does not live long enough
-  --> $DIR/send-is-not-static-std-sync.rs:27:5
+  --> $DIR/send-is-not-static-std-sync.rs:26:34
    |
 26 |         *lock.lock().unwrap() = &z;
-   |                                  - borrow occurs here
-27 |     } //~ ERROR does not live long enough
-   |     ^ `z` dropped here while still borrowed
-28 | }
+   |                                  ^ borrowed value does not live long enough
+27 |     }
+   |     - `z` dropped here while still borrowed
+28 |     //~^^ ERROR `z` does not live long enough
+29 | }
    | - borrowed value needs to live until here
 
 error[E0505]: cannot move out of `y` because it is borrowed
@@ -17,39 +18,41 @@ error[E0505]: cannot move out of `y` because it is borrowed
    |          ^ move out of `y` occurs here
 
 error[E0597]: `z` does not live long enough
-  --> $DIR/send-is-not-static-std-sync.rs:39:5
+  --> $DIR/send-is-not-static-std-sync.rs:39:35
    |
-38 |         *lock.write().unwrap() = &z;
-   |                                   - borrow occurs here
-39 |     } //~ ERROR does not live long enough
-   |     ^ `z` dropped here while still borrowed
-40 | }
+39 |         *lock.write().unwrap() = &z;
+   |                                   ^ borrowed value does not live long enough
+40 |     }
+   |     - `z` dropped here while still borrowed
+41 |     //~^^ ERROR `z` does not live long enough
+42 | }
    | - borrowed value needs to live until here
 
 error[E0505]: cannot move out of `y` because it is borrowed
-  --> $DIR/send-is-not-static-std-sync.rs:35:10
+  --> $DIR/send-is-not-static-std-sync.rs:36:10
    |
-34 |     *lock.write().unwrap() = &*y;
+35 |     *lock.write().unwrap() = &*y;
    |                               -- borrow of `*y` occurs here
-35 |     drop(y); //~ ERROR cannot move out
+36 |     drop(y); //~ ERROR cannot move out
    |          ^ move out of `y` occurs here
 
 error[E0597]: `z` does not live long enough
-  --> $DIR/send-is-not-static-std-sync.rs:53:5
+  --> $DIR/send-is-not-static-std-sync.rs:54:18
    |
-52 |         tx.send(&z).unwrap();
-   |                  - borrow occurs here
-53 |     } //~ ERROR does not live long enough
-   |     ^ `z` dropped here while still borrowed
-54 | }
+54 |         tx.send(&z).unwrap();
+   |                  ^ borrowed value does not live long enough
+55 |     }
+   |     - `z` dropped here while still borrowed
+56 |     //~^^ ERROR `z` does not live long enough
+57 | }
    | - borrowed value needs to live until here
 
 error[E0505]: cannot move out of `y` because it is borrowed
-  --> $DIR/send-is-not-static-std-sync.rs:49:10
+  --> $DIR/send-is-not-static-std-sync.rs:51:10
    |
-48 |     tx.send(&*y);
+50 |     tx.send(&*y);
    |              -- borrow of `*y` occurs here
-49 |     drop(y); //~ ERROR cannot move out
+51 |     drop(y); //~ ERROR cannot move out
    |          ^ move out of `y` occurs here
 
 error: aborting due to 6 previous errors

--- a/src/test/ui/span/slice-borrow.rs
+++ b/src/test/ui/span/slice-borrow.rs
@@ -15,5 +15,5 @@ fn main() {
     {
         let x: &[isize] = &vec![1, 2, 3, 4, 5];
         y = &x[1..];
-    } //~ ERROR does not live long enough
+    }
 }

--- a/src/test/ui/span/slice-borrow.stderr
+++ b/src/test/ui/span/slice-borrow.stderr
@@ -1,11 +1,11 @@
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/slice-borrow.rs:18:5
+  --> $DIR/slice-borrow.rs:16:28
    |
 16 |         let x: &[isize] = &vec![1, 2, 3, 4, 5];
-   |                            ------------------- temporary value created here
+   |                            ^^^^^^^^^^^^^^^^^^^ temporary value does not live long enough
 17 |         y = &x[1..];
-18 |     } //~ ERROR does not live long enough
-   |     ^ temporary value dropped here while still borrowed
+18 |     }
+   |     - temporary value dropped here while still borrowed
 19 | }
    | - temporary value needs to live until here
    |

--- a/src/test/ui/span/vec-must-not-hide-type-from-dropck.rs
+++ b/src/test/ui/span/vec-must-not-hide-type-from-dropck.rs
@@ -125,10 +125,10 @@ fn f() {
     c1.v.push(CheckId(Cell::new(None)));
     c2.v.push(CheckId(Cell::new(None)));
     c1.v[0].v.set(Some(&c2));
+    //~^ ERROR `c2` does not live long enough
     c2.v[0].v.set(Some(&c1));
+    //~^ ERROR `c1` does not live long enough
 }
-//~^ ERROR `c2` does not live long enough
-//~| ERROR `c1` does not live long enough
 
 fn main() {
     f();

--- a/src/test/ui/span/vec-must-not-hide-type-from-dropck.stderr
+++ b/src/test/ui/span/vec-must-not-hide-type-from-dropck.stderr
@@ -1,21 +1,22 @@
 error[E0597]: `c2` does not live long enough
-   --> $DIR/vec-must-not-hide-type-from-dropck.rs:129:1
+   --> $DIR/vec-must-not-hide-type-from-dropck.rs:127:25
     |
 127 |     c1.v[0].v.set(Some(&c2));
-    |                         -- borrow occurs here
-128 |     c2.v[0].v.set(Some(&c1));
-129 | }
-    | ^ `c2` dropped here while still borrowed
+    |                         ^^ borrowed value does not live long enough
+...
+131 | }
+    | - `c2` dropped here while still borrowed
     |
     = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `c1` does not live long enough
-   --> $DIR/vec-must-not-hide-type-from-dropck.rs:129:1
+   --> $DIR/vec-must-not-hide-type-from-dropck.rs:129:25
     |
-128 |     c2.v[0].v.set(Some(&c1));
-    |                         -- borrow occurs here
-129 | }
-    | ^ `c1` dropped here while still borrowed
+129 |     c2.v[0].v.set(Some(&c1));
+    |                         ^^ borrowed value does not live long enough
+130 |     //~^ ERROR `c1` does not live long enough
+131 | }
+    | - `c1` dropped here while still borrowed
     |
     = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/test/ui/span/vec_refs_data_with_early_death.rs
+++ b/src/test/ui/span/vec_refs_data_with_early_death.rs
@@ -25,9 +25,9 @@ fn main() {
     let y: i8 = 4;
 
     v.push(&x);
+    //~^ ERROR `x` does not live long enough
     v.push(&y);
+    //~^ ERROR `y` does not live long enough
 
     assert_eq!(v, [&3, &4]);
 }
-//~^ ERROR `x` does not live long enough
-//~| ERROR `y` does not live long enough

--- a/src/test/ui/span/vec_refs_data_with_early_death.stderr
+++ b/src/test/ui/span/vec_refs_data_with_early_death.stderr
@@ -1,22 +1,22 @@
 error[E0597]: `x` does not live long enough
-  --> $DIR/vec_refs_data_with_early_death.rs:31:1
+  --> $DIR/vec_refs_data_with_early_death.rs:27:13
    |
 27 |     v.push(&x);
-   |             - borrow occurs here
+   |             ^ borrowed value does not live long enough
 ...
-31 | }
-   | ^ `x` dropped here while still borrowed
+33 | }
+   | - `x` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/vec_refs_data_with_early_death.rs:31:1
+  --> $DIR/vec_refs_data_with_early_death.rs:29:13
    |
-28 |     v.push(&y);
-   |             - borrow occurs here
+29 |     v.push(&y);
+   |             ^ borrowed value does not live long enough
 ...
-31 | }
-   | ^ `y` dropped here while still borrowed
+33 | }
+   | - `y` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/test/ui/span/wf-method-late-bound-regions.rs
+++ b/src/test/ui/span/wf-method-late-bound-regions.rs
@@ -28,6 +28,7 @@ fn main() {
     let dangling = {
         let pointer = Box::new(42);
         f2.xmute(&pointer)
-    }; //~ ERROR `pointer` does not live long enough
+    };
+    //~^^ ERROR `pointer` does not live long enough
     println!("{}", dangling);
 }

--- a/src/test/ui/span/wf-method-late-bound-regions.stderr
+++ b/src/test/ui/span/wf-method-late-bound-regions.stderr
@@ -1,12 +1,12 @@
 error[E0597]: `pointer` does not live long enough
-  --> $DIR/wf-method-late-bound-regions.rs:31:5
+  --> $DIR/wf-method-late-bound-regions.rs:30:19
    |
 30 |         f2.xmute(&pointer)
-   |                   ------- borrow occurs here
-31 |     }; //~ ERROR `pointer` does not live long enough
-   |     ^ `pointer` dropped here while still borrowed
-32 |     println!("{}", dangling);
-33 | }
+   |                   ^^^^^^^ borrowed value does not live long enough
+31 |     };
+   |     - `pointer` dropped here while still borrowed
+...
+34 | }
    | - borrowed value needs to live until here
 
 error: aborting due to previous error


### PR DESCRIPTION
For RLS' sake, point at the borrow location as primary span for short lived borrows, instead of the borrow drop location.

Fix #39268.