### PR TITLE
Make eprint! use its own LOCAL_STDERR handle instead of reusing the panicking one

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -536,10 +536,12 @@ impl Collector {
             testfn: testing::DynTestFn(box move |()| {
                 let panic = io::set_panic(None);
                 let print = io::set_print(None);
+                let eprint = io::set_eprint(None);
                 match {
                     rustc_driver::in_rustc_thread(move || {
                         io::set_panic(panic);
                         io::set_print(print);
+                        io::set_eprint(eprint);
                         run_test(&test,
                                  &cratename,
                                  &filename,

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -297,7 +297,7 @@ pub use self::stdio::{StdoutLock, StderrLock, StdinLock};
 pub use self::stdio::{_print, _eprint};
 #[unstable(feature = "libstd_io_internals", issue = "42788")]
 #[doc(no_inline, hidden)]
-pub use self::stdio::{set_panic, set_print};
+pub use self::stdio::{set_panic, set_print, set_eprint};
 
 pub mod prelude;
 mod buffered;

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1399,6 +1399,7 @@ pub fn run_test(opts: &TestOpts,
             let oldio = if !nocapture {
                 Some((
                     io::set_print(Some(Box::new(Sink(data2.clone())))),
+                    io::set_eprint(Some(Box::new(Sink(data2.clone())))),
                     io::set_panic(Some(Box::new(Sink(data2))))
                 ))
             } else {
@@ -1409,8 +1410,9 @@ pub fn run_test(opts: &TestOpts,
                 testfn.call_box(())
             }));
 
-            if let Some((printio, panicio)) = oldio {
+            if let Some((printio, eprintio, panicio)) = oldio {
                 io::set_print(printio);
+                io::set_eprint(eprintio);
                 io::set_panic(panicio);
             };
 


### PR DESCRIPTION
rustc uses `io::set_panic` to eat panic messages, so eprint! currently does nothing in rustc. This fixes things so `io::set_panic` only affects panic messages.