### PR TITLE
Do not emit type errors on recovered blocks

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -359,18 +359,21 @@ lifetime elision rules (see below).
 Here are some simple examples of where you'll run into this error:
 
 ```compile_fail,E0106
-struct Foo { x: &bool }        // error
-struct Foo<'a> { x: &'a bool } // correct
+struct Foo1 { x: &bool }
+              // ^ expected lifetime parameter
+struct Foo2<'a> { x: &'a bool } // correct
 
-struct Bar { x: Foo }
-               ^^^ expected lifetime parameter
-struct Bar<'a> { x: Foo<'a> } // correct
+struct Bar1 { x: Foo2 }
+              // ^^^^ expected lifetime parameter
+struct Bar2<'a> { x: Foo2<'a> } // correct
 
-enum Bar { A(u8), B(&bool), }        // error
-enum Bar<'a> { A(u8), B(&'a bool), } // correct
+enum Baz1 { A(u8), B(&bool), }
+                  // ^ expected lifetime parameter
+enum Baz2<'a> { A(u8), B(&'a bool), } // correct
 
-type MyStr = &str;        // error
-type MyStr<'a> = &'a str; // correct
+type MyStr1 = &str;
+           // ^ expected lifetime parameter
+type MyStr2<'a> = &'a str; // correct
 ```
 
 Lifetime elision is a special, limited kind of inference for lifetimes in

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1835,6 +1835,7 @@ impl<'a> LoweringContext<'a> {
             rules: self.lower_block_check_mode(&b.rules),
             span: b.span,
             targeted_by_break,
+            recovered: b.recovered,
         })
     }
 
@@ -2691,6 +2692,7 @@ impl<'a> LoweringContext<'a> {
                                 rules: hir::DefaultBlock,
                                 span,
                                 targeted_by_break: false,
+                                recovered: blk.recovered,
                             });
                             P(self.expr_block(blk, ThinVec::new()))
                         }
@@ -3507,6 +3509,7 @@ impl<'a> LoweringContext<'a> {
             rules: hir::DefaultBlock,
             span,
             targeted_by_break: false,
+            recovered: false,
         }
     }
 
@@ -3610,6 +3613,7 @@ impl<'a> LoweringContext<'a> {
             stmts,
             expr: Some(expr),
             targeted_by_break: false,
+            recovered: false,
         });
         self.expr_block(block, attrs)
     }

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -625,6 +625,11 @@ pub struct Block {
     /// currently permitted in Rust itself, but it is generated as
     /// part of `catch` statements.
     pub targeted_by_break: bool,
+    /// If true, don't emit return value type errors as the parser had
+    /// to recover from a parse error so this block will not have an
+    /// appropriate type. A parse error will have been emitted so the
+    /// compilation will never succeed if this is true.
+    pub recovered: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash)]

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -378,12 +378,14 @@ impl<'gcx> HashStable<StableHashingContext<'gcx>> for hir::Block {
             rules,
             span,
             targeted_by_break,
+            recovered,
         } = *self;
 
         stmts.hash_stable(hcx, hasher);
         expr.hash_stable(hcx, hasher);
         rules.hash_stable(hcx, hasher);
         span.hash_stable(hcx, hasher);
+        recovered.hash_stable(hcx, hasher);
         targeted_by_break.hash_stable(hcx, hasher);
     }
 }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4279,7 +4279,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 //
                 // #41425 -- label the implicit `()` as being the
                 // "found type" here, rather than the "expected type".
-                if !self.diverges.get().always() {
+                //
+                // #44579 -- if the block was recovered during parsing,
+                // the type would be nonsensical and it is not worth it
+                // to perform the type check, so we avoid generating the
+                // diagnostic output.
+                if !self.diverges.get().always() && !blk.recovered {
                     coerce.coerce_forced_unit(self, &self.misc(blk.span), &mut |err| {
                         if let Some(expected_ty) = expected.only_has_type(self) {
                             self.consider_hint_about_removing_semicolon(blk,

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -468,6 +468,7 @@ pub struct Block {
     /// Distinguishes between `unsafe { ... }` and `{ ... }`
     pub rules: BlockCheckMode,
     pub span: Span,
+    pub recovered: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash)]

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -594,6 +594,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
            id: ast::DUMMY_NODE_ID,
            rules: BlockCheckMode::Default,
            span,
+           recovered: false,
         })
     }
 

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -851,11 +851,12 @@ fn noop_fold_bounds<T: Folder>(bounds: TyParamBounds, folder: &mut T)
 }
 
 pub fn noop_fold_block<T: Folder>(b: P<Block>, folder: &mut T) -> P<Block> {
-    b.map(|Block {id, stmts, rules, span}| Block {
+    b.map(|Block {id, stmts, rules, span, recovered}| Block {
         id: folder.new_id(id),
         stmts: stmts.move_flat_map(|s| folder.fold_stmt(s).into_iter()),
         rules,
         span: folder.new_span(span),
+        recovered,
     })
 }
 

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -931,6 +931,7 @@ mod tests {
                                         id: ast::DUMMY_NODE_ID,
                                         rules: ast::BlockCheckMode::Default, // no idea
                                         span: sp(15,21),
+                                        recovered: false,
                                     })),
                             vis: ast::Visibility::Inherited,
                             span: sp(0,21)})));

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4371,13 +4371,15 @@ impl<'a> Parser<'a> {
     /// Precondition: already parsed the '{'.
     fn parse_block_tail(&mut self, lo: Span, s: BlockCheckMode) -> PResult<'a, P<Block>> {
         let mut stmts = vec![];
+        let mut recovered = false;
 
         while !self.eat(&token::CloseDelim(token::Brace)) {
             let stmt = match self.parse_full_stmt(false) {
                 Err(mut err) => {
                     err.emit();
-                    self.recover_stmt_(SemiColonMode::Ignore, BlockMode::Break);
+                    self.recover_stmt_(SemiColonMode::Ignore, BlockMode::Ignore);
                     self.eat(&token::CloseDelim(token::Brace));
+                    recovered = true;
                     break;
                 }
                 Ok(stmt) => stmt,
@@ -4396,12 +4398,13 @@ impl<'a> Parser<'a> {
             id: ast::DUMMY_NODE_ID,
             rules: s,
             span: lo.to(self.prev_span),
+            recovered,
         }))
     }
 
     /// Parse a statement, including the trailing semicolon.
     pub fn parse_full_stmt(&mut self, macro_legacy_warnings: bool) -> PResult<'a, Option<Stmt>> {
-        let mut stmt = match self.parse_stmt_(macro_legacy_warnings) {
+        let mut stmt = match self.parse_stmt_without_recovery(macro_legacy_warnings)? {
             Some(stmt) => stmt,
             None => return Ok(None),
         };

--- a/src/libsyntax_ext/deriving/mod.rs
+++ b/src/libsyntax_ext/deriving/mod.rs
@@ -158,5 +158,6 @@ fn call_intrinsic(cx: &ExtCtxt,
         id: ast::DUMMY_NODE_ID,
         rules: ast::BlockCheckMode::Unsafe(ast::CompilerGenerated),
         span,
+        recovered: false,
     }))
 }

--- a/src/test/compile-fail/issue-34334.rs
+++ b/src/test/compile-fail/issue-34334.rs
@@ -11,5 +11,4 @@
 fn main () {
     let sr: Vec<(u32, _, _) = vec![]; //~ ERROR expected one of `,` or `>`, found `=`
     let sr2: Vec<(u32, _, _)> = sr.iter().map(|(faction, th_sender, th_receiver)| {}).collect();
-    //~^ ERROR cannot find value `sr` in this scope
 }

--- a/src/test/parse-fail/issue-22647.rs
+++ b/src/test/parse-fail/issue-22647.rs
@@ -16,7 +16,6 @@ fn main() {
         println!("Y {}",x);
         return x;
     };
-    //~^ ERROR expected item, found `;`
 
     caller(bar_handler);
 }

--- a/src/test/parse-fail/keywords-followed-by-double-colon.rs
+++ b/src/test/parse-fail/keywords-followed-by-double-colon.rs
@@ -11,6 +11,10 @@
 // compile-flags: -Z parse-only
 
 fn main() {
-    struct::foo();  //~ ERROR expected identifier
-    mut::baz(); //~ ERROR expected expression, found keyword `mut`
+    struct::foo();
+    //~^ ERROR expected identifier
+}
+fn bar() {
+    mut::baz();
+    //~^ ERROR expected expression, found keyword `mut`
 }

--- a/src/test/parse-fail/mut-patterns.rs
+++ b/src/test/parse-fail/mut-patterns.rs
@@ -15,5 +15,4 @@
 pub fn main() {
     struct Foo { x: isize }
     let mut Foo { x: x } = Foo { x: 3 }; //~ ERROR: expected one of `:`, `;`, `=`, or `@`, found `{`
-    //~^ ERROR expected item, found `=`
 }

--- a/src/test/run-pass-fulldeps/pprust-expr-roundtrip.rs
+++ b/src/test/run-pass-fulldeps/pprust-expr-roundtrip.rs
@@ -131,6 +131,7 @@ fn iter_exprs(depth: usize, f: &mut FnMut(P<Expr>)) {
                     id: DUMMY_NODE_ID,
                     rules: BlockCheckMode::Default,
                     span: DUMMY_SP,
+                    recovered: false,
                 });
                 iter_exprs(depth - 1, &mut |e| g(ExprKind::If(e, block.clone(), None)));
             },

--- a/src/test/ui/impossible_range.rs
+++ b/src/test/ui/impossible_range.rs
@@ -17,11 +17,13 @@ pub fn main() {
     0..;
     ..1;
     0..1;
-
     ..=; //~ERROR inclusive range with no end
-    0..=; //~ERROR inclusive range with no end
-    ..=1;
-    0..=1;
+         //~^HELP bounded at the end
 }
 
-
+fn _foo1() {
+    ..=1;
+    0..=1;
+    0..=; //~ERROR inclusive range with no end
+          //~^HELP bounded at the end
+}

--- a/src/test/ui/impossible_range.stderr
+++ b/src/test/ui/impossible_range.stderr
@@ -1,15 +1,15 @@
 error[E0586]: inclusive range with no end
-  --> $DIR/impossible_range.rs:21:8
+  --> $DIR/impossible_range.rs:20:8
    |
-21 |     ..=; //~ERROR inclusive range with no end
+20 |     ..=; //~ERROR inclusive range with no end
    |        ^
    |
    = help: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
 
 error[E0586]: inclusive range with no end
-  --> $DIR/impossible_range.rs:22:9
+  --> $DIR/impossible_range.rs:27:9
    |
-22 |     0..=; //~ERROR inclusive range with no end
+27 |     0..=; //~ERROR inclusive range with no end
    |         ^
    |
    = help: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)

--- a/src/test/ui/issue-44406.stderr
+++ b/src/test/ui/issue-44406.stderr
@@ -13,5 +13,3 @@ error: expected type, found keyword `true`
 18 |     foo!(true); //~ ERROR expected type, found keyword
    |          ^^^^ expecting a type here because of type ascription
 
-error: aborting due to 2 previous errors
-

--- a/src/test/ui/macro-context.stderr
+++ b/src/test/ui/macro-context.stderr
@@ -43,5 +43,3 @@ error: expected expression, found reserved keyword `typeof`
 26 |     m!();
    |     ----- in this macro invocation
 
-error: aborting due to 4 previous errors
-

--- a/src/test/ui/mismatched_types/recovered-block.rs
+++ b/src/test/ui/mismatched_types/recovered-block.rs
@@ -1,0 +1,31 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::env;
+
+pub struct Foo {
+    text: String
+}
+
+pub fn foo() -> Foo {
+    let args: Vec<String> = env::args().collect();
+    let text = args[1].clone();
+
+    pub Foo { text }
+}
+//~^^ ERROR missing `struct` for struct definition
+
+pub fn bar() -> Foo {
+    fn
+    Foo { text: "".to_string() }
+}
+//~^^ ERROR expected one of `(` or `<`, found `{`
+
+fn main() {}

--- a/src/test/ui/mismatched_types/recovered-block.stderr
+++ b/src/test/ui/mismatched_types/recovered-block.stderr
@@ -1,0 +1,18 @@
+error: missing `struct` for struct definition
+  --> $DIR/recovered-block.rs:21:8
+   |
+21 |     pub Foo { text }
+   |        ^
+help: add `struct` here to parse `Foo` as a public struct
+   |
+21 |     pub struct Foo { text }
+   |         ^^^^^^
+
+error: expected one of `(` or `<`, found `{`
+  --> $DIR/recovered-block.rs:27:9
+   |
+27 |     Foo { text: "".to_string() }
+   |         ^ expected one of `(` or `<` here
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/resolve/token-error-correct.rs
+++ b/src/test/ui/resolve/token-error-correct.rs
@@ -16,4 +16,3 @@ fn main() {
 }
 //~^ ERROR: incorrect close delimiter: `}`
 //~| ERROR: incorrect close delimiter: `}`
-//~| ERROR: expected expression, found `)`

--- a/src/test/ui/resolve/token-error-correct.stderr
+++ b/src/test/ui/resolve/token-error-correct.stderr
@@ -28,11 +28,5 @@ error: expected expression, found `;`
 14 |     foo(bar(;
    |             ^
 
-error: expected expression, found `)`
-  --> $DIR/token-error-correct.rs:16:1
-   |
-16 | }
-   | ^
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 

--- a/src/tools/toolstate.toml
+++ b/src/tools/toolstate.toml
@@ -26,7 +26,7 @@
 miri = "Broken"
 
 # ping @Manishearth @llogiq @mcarton @oli-obk
-clippy = "Testing"
+clippy = "Broken"
 
 # ping @nrc
 rls = "Broken"


### PR DESCRIPTION
When a parse error occurs on a block, the parser will recover and create
a block with the statements collected until that point. Now a flag
stating that a recovery has been performed in this block is propagated
so that the type checker knows that the type of the block (which will be
identified as `()`) shouldn't be checked against the expectation to
reduce the amount of irrelevant diagnostic errors shown to the user.

Fix #44579.