### PR TITLE
Move PhantomData<T> from Shared<T> to users of both Shared and #[may_dangle]

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -26,7 +26,7 @@ use core::mem::{self, align_of_val, size_of_val, uninitialized};
 use core::ops::Deref;
 use core::ops::CoerceUnsized;
 use core::ptr::{self, Shared};
-use core::marker::Unsize;
+use core::marker::{Unsize, PhantomData};
 use core::hash::{Hash, Hasher};
 use core::{isize, usize};
 use core::convert::From;
@@ -198,6 +198,7 @@ const MAX_REFCOUNT: usize = (isize::MAX) as usize;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Arc<T: ?Sized> {
     ptr: Shared<ArcInner<T>>,
+    phantom: PhantomData<T>,
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -285,7 +286,7 @@ impl<T> Arc<T> {
             weak: atomic::AtomicUsize::new(1),
             data,
         };
-        Arc { ptr: Shared::from(Box::into_unique(x)) }
+        Arc { ptr: Shared::from(Box::into_unique(x)), phantom: PhantomData }
     }
 
     /// Returns the contained value, if the `Arc` has exactly one strong reference.
@@ -397,6 +398,7 @@ impl<T: ?Sized> Arc<T> {
 
         Arc {
             ptr: Shared::new_unchecked(arc_ptr),
+            phantom: PhantomData,
         }
     }
 
@@ -580,7 +582,7 @@ impl<T: ?Sized> Arc<T> {
             // Free the allocation without dropping its contents
             box_free(bptr);
 
-            Arc { ptr: Shared::new_unchecked(ptr) }
+            Arc { ptr: Shared::new_unchecked(ptr), phantom: PhantomData }
         }
     }
 }
@@ -607,7 +609,7 @@ impl<T> Arc<[T]> {
             &mut (*ptr).data as *mut [T] as *mut T,
             v.len());
 
-        Arc { ptr: Shared::new_unchecked(ptr) }
+        Arc { ptr: Shared::new_unchecked(ptr), phantom: PhantomData }
     }
 }
 
@@ -667,7 +669,7 @@ impl<T: Clone> ArcFromSlice<T> for Arc<[T]> {
             // All clear. Forget the guard so it doesn't free the new ArcInner.
             mem::forget(guard);
 
-            Arc { ptr: Shared::new_unchecked(ptr) }
+            Arc { ptr: Shared::new_unchecked(ptr), phantom: PhantomData }
         }
     }
 }
@@ -725,7 +727,7 @@ impl<T: ?Sized> Clone for Arc<T> {
             }
         }
 
-        Arc { ptr: self.ptr }
+        Arc { ptr: self.ptr, phantom: PhantomData }
     }
 }
 
@@ -1052,7 +1054,7 @@ impl<T: ?Sized> Weak<T> {
 
             // Relaxed is valid for the same reason it is on Arc's Clone impl
             match inner.strong.compare_exchange_weak(n, n + 1, Relaxed, Relaxed) {
-                Ok(_) => return Some(Arc { ptr: self.ptr }),
+                Ok(_) => return Some(Arc { ptr: self.ptr, phantom: PhantomData }),
                 Err(old) => n = old,
             }
         }

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -252,7 +252,7 @@ use core::fmt;
 use core::hash::{Hash, Hasher};
 use core::intrinsics::abort;
 use core::marker;
-use core::marker::Unsize;
+use core::marker::{Unsize, PhantomData};
 use core::mem::{self, align_of_val, forget, size_of_val, uninitialized};
 use core::ops::Deref;
 use core::ops::CoerceUnsized;
@@ -283,6 +283,7 @@ struct RcBox<T: ?Sized> {
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Rc<T: ?Sized> {
     ptr: Shared<RcBox<T>>,
+    phantom: PhantomData<T>,
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -315,6 +316,7 @@ impl<T> Rc<T> {
                 weak: Cell::new(1),
                 value,
             })),
+            phantom: PhantomData,
         }
     }
 
@@ -427,6 +429,7 @@ impl<T: ?Sized> Rc<T> {
 
         Rc {
             ptr: Shared::new_unchecked(rc_ptr),
+            phantom: PhantomData,
         }
     }
 
@@ -647,6 +650,7 @@ impl Rc<Any> {
                 forget(self);
                 Ok(Rc {
                     ptr: Shared::new_unchecked(raw as *const RcBox<T> as *mut _),
+                    phantom: PhantomData,
                 })
             }
         } else {
@@ -691,7 +695,7 @@ impl<T: ?Sized> Rc<T> {
             // Free the allocation without dropping its contents
             box_free(bptr);
 
-            Rc { ptr: Shared::new_unchecked(ptr) }
+            Rc { ptr: Shared::new_unchecked(ptr), phantom: PhantomData }
         }
     }
 }
@@ -718,7 +722,7 @@ impl<T> Rc<[T]> {
             &mut (*ptr).value as *mut [T] as *mut T,
             v.len());
 
-        Rc { ptr: Shared::new_unchecked(ptr) }
+        Rc { ptr: Shared::new_unchecked(ptr), phantom: PhantomData }
     }
 }
 
@@ -777,7 +781,7 @@ impl<T: Clone> RcFromSlice<T> for Rc<[T]> {
             // All clear. Forget the guard so it doesn't free the new RcBox.
             forget(guard);
 
-            Rc { ptr: Shared::new_unchecked(ptr) }
+            Rc { ptr: Shared::new_unchecked(ptr), phantom: PhantomData }
         }
     }
 }
@@ -868,7 +872,7 @@ impl<T: ?Sized> Clone for Rc<T> {
     #[inline]
     fn clone(&self) -> Rc<T> {
         self.inc_strong();
-        Rc { ptr: self.ptr }
+        Rc { ptr: self.ptr, phantom: PhantomData }
     }
 }
 
@@ -1228,7 +1232,7 @@ impl<T: ?Sized> Weak<T> {
             None
         } else {
             self.inc_strong();
-            Some(Rc { ptr: self.ptr })
+            Some(Rc { ptr: self.ptr, phantom: PhantomData })
         }
     }
 }

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -71,6 +71,7 @@ use core::fmt;
 use core::hash::{self, Hash};
 use core::intrinsics::{arith_offset, assume};
 use core::iter::{FromIterator, FusedIterator, TrustedLen};
+use core::marker::PhantomData;
 use core::mem;
 #[cfg(not(test))]
 use core::num::Float;
@@ -1743,6 +1744,7 @@ impl<T> IntoIterator for Vec<T> {
             mem::forget(self);
             IntoIter {
                 buf: Shared::new_unchecked(begin),
+                phantom: PhantomData,
                 cap,
                 ptr: begin,
                 end,
@@ -2264,6 +2266,7 @@ impl<'a, T> FromIterator<T> for Cow<'a, [T]> where T: Clone {
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct IntoIter<T> {
     buf: Shared<T>,
+    phantom: PhantomData<T>,
     cap: usize,
     ptr: *const T,
     end: *const T,


### PR DESCRIPTION
After discussing https://github.com/rust-lang/rust/issues/27730#issuecomment-316432083 today with @pnkfelix and @Gankro, we concluded that it’s ok for drop checking not to be much smarter than the current `#[may_dangle]` design which requires an explicit unsafe opt-in.

See reasoning below: https://github.com/rust-lang/rust/pull/46749#issuecomment-352146569