### PR TITLE
Improve error messages on LLVM bitcode parsing failure

### DIFF
--- a/src/librustc_trans/back/lto.rs
+++ b/src/librustc_trans/back/lto.rs
@@ -613,7 +613,10 @@ impl ThinModule {
             self.data().len(),
             self.shared.module_names[self.idx].as_ptr(),
         );
-        assert!(!llmod.is_null());
+        if llmod.is_null() {
+            let msg = format!("failed to parse bitcode for thin LTO module");
+            return Err(write::llvm_err(&diag_handler, msg));
+        }
         let mtrans = ModuleTranslation {
             source: ModuleSource::Translated(ModuleLlvm {
                 llmod,


### PR DESCRIPTION
The LLVM error causing the parse failure is now printed, in the style
of the other thin LTO error messages. This prevents a flood of
assertion failure messages if the bitcode can’t be parsed.