### PR TITLE
[Underspecified semantics] Type check defaults at declaration.

### DIFF
--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1040,13 +1040,6 @@ impl<'a, 'gcx, 'tcx> Predicate<'tcx> {
                 Predicate::ConstEvaluatable(def_id, const_substs.subst(tcx, substs)),
         }
     }
-
-    pub fn as_poly_trait_predicate(&self) -> Option<&PolyTraitPredicate<'tcx>> {
-        match self {
-            Predicate::Trait(trait_pred) => Some(trait_pred),
-            _ => None
-        }
-    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, RustcEncodable, RustcDecodable)]

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1040,6 +1040,13 @@ impl<'a, 'gcx, 'tcx> Predicate<'tcx> {
                 Predicate::ConstEvaluatable(def_id, const_substs.subst(tcx, substs)),
         }
     }
+
+    pub fn as_poly_trait_predicate(&self) -> Option<&PolyTraitPredicate<'tcx>> {
+        match self {
+            Predicate::Trait(trait_pred) => Some(trait_pred),
+            _ => None
+        }
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, RustcEncodable, RustcDecodable)]

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -370,6 +370,9 @@ impl<'a, 'gcx> CheckTypeWellFormedVisitor<'a, 'gcx> {
         // Here the default `Vec<[u32]>` is not WF because `[u32]: Sized` does not hold.
         for d in generics.types.iter().cloned().filter(is_our_default).map(|p| p.def_id) {
             let ty = fcx.tcx.type_of(d);
+            // ignore dependent defaults -- that is, where the default of one type
+            // parameter includes another (e.g., <T, U = T>). In those cases, we can't
+            // be sure if it will error or not as user might always specify the other.
             if !ty.needs_subst() {
                 fcx.register_wf_obligation(ty, fcx.tcx.def_span(d), self.code.clone());
             }

--- a/src/test/run-pass/defaults-well-formedness.rs
+++ b/src/test/run-pass/defaults-well-formedness.rs
@@ -19,5 +19,7 @@ struct IndividuallyBogus<T = i32, U = i32>(TwoParams<T, U>) where TwoParams<T, U
 // Clauses with non-defaulted params are not checked.
 struct NonDefaultedInClause<T, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Marker;
 struct DefaultedLhs<U, V=i32>(U, V) where V: Trait<U>;
+// Dependent defaults.
+struct Dependent<T: Copy, U = T>(T, U) where U: Copy;
 
 fn main() {}

--- a/src/test/run-pass/defaults-well-formedness.rs
+++ b/src/test/run-pass/defaults-well-formedness.rs
@@ -11,11 +11,13 @@
 trait Trait<T> {}
 struct Foo<U, V=i32>(U, V) where U: Trait<V>;
 
-trait Trait2 {}
+trait Marker {}
 struct TwoParams<T, U>(T, U);
-impl Trait2 for TwoParams<i32, i32> {}
+impl Marker for TwoParams<i32, i32> {}
 // Check that defaults are substituted simultaneously.
-struct IndividuallyBogus<T = i32, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Trait2;
+struct IndividuallyBogus<T = i32, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Marker;
 // Clauses with non-defaulted params are not checked.
-struct NonDefaultedInClause<T, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Trait2;
+struct NonDefaultedInClause<T, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Marker;
+struct DefaultedLhs<U, V=i32>(U, V) where V: Trait<U>;
+
 fn main() {}

--- a/src/test/run-pass/defaults-well-formedness.rs
+++ b/src/test/run-pass/defaults-well-formedness.rs
@@ -14,12 +14,15 @@ struct Foo<U, V=i32>(U, V) where U: Trait<V>;
 trait Marker {}
 struct TwoParams<T, U>(T, U);
 impl Marker for TwoParams<i32, i32> {}
-// Check that defaults are substituted simultaneously.
+
+// Clauses with more than 1 param are not checked.
 struct IndividuallyBogus<T = i32, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Marker;
+struct BogusTogether<T = u32, U = i32>(T, U) where TwoParams<T, U>: Marker;
 // Clauses with non-defaulted params are not checked.
 struct NonDefaultedInClause<T, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Marker;
 struct DefaultedLhs<U, V=i32>(U, V) where V: Trait<U>;
-// Dependent defaults.
-struct Dependent<T: Copy, U = T>(T, U) where U: Copy;
+// Dependent defaults are not checked.
+struct Dependent<T, U = T>(T, U) where U: Copy;
+trait SelfBound<T: Copy=Self> {}
 
 fn main() {}

--- a/src/test/run-pass/defaults-well-formedness.rs
+++ b/src/test/run-pass/defaults-well-formedness.rs
@@ -1,0 +1,14 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Trait<T> {}
+struct Foo<U, V=i32>(U, V) where U: Trait<V>;
+
+fn main() {}

--- a/src/test/run-pass/defaults-well-formedness.rs
+++ b/src/test/run-pass/defaults-well-formedness.rs
@@ -24,5 +24,7 @@ struct DefaultedLhs<U, V=i32>(U, V) where V: Trait<U>;
 // Dependent defaults are not checked.
 struct Dependent<T, U = T>(T, U) where U: Copy;
 trait SelfBound<T: Copy=Self> {}
+// Not even for well-formedness.
+struct WellFormedProjection<A, T=<A as Iterator>::Item>(A, T);
 
 fn main() {}

--- a/src/test/run-pass/defaults-well-formedness.rs
+++ b/src/test/run-pass/defaults-well-formedness.rs
@@ -11,4 +11,11 @@
 trait Trait<T> {}
 struct Foo<U, V=i32>(U, V) where U: Trait<V>;
 
+trait Trait2 {}
+struct TwoParams<T, U>(T, U);
+impl Trait2 for TwoParams<i32, i32> {}
+// Check that defaults are substituted simultaneously.
+struct IndividuallyBogus<T = i32, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Trait2;
+// Clauses with non-defaulted params are not checked.
+struct NonDefaultedInClause<T, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Trait2;
 fn main() {}

--- a/src/test/run-pass/type-macros-simple.rs
+++ b/src/test/run-pass/type-macros-simple.rs
@@ -34,3 +34,4 @@ fn issue_36540() {
 }
 
 trait Trait<T> {}
+impl Trait<i32> for i32 {}

--- a/src/test/ui/type-check-defaults.rs
+++ b/src/test/ui/type-check-defaults.rs
@@ -1,0 +1,31 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+// compile-flags: --error-format=human
+
+use std::iter::FromIterator;
+use std::vec::IntoIter;
+use std::ops::Add;
+
+struct Foo<T, U: FromIterator<T>>(T, U);
+struct WellFormed<Z = Foo<i32, i32>>(Z);
+
+struct WellFormedProjection<A, T=<A as Iterator>::Item>(A, T);
+
+struct Bounds<T:Copy=String>(T);
+
+struct WhereClause<T=String>(T) where T: Copy;
+
+trait TraitBound<T:Copy=String> {}
+
+trait SelfBound<T:Copy=Self> {}
+
+trait FooTrait<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
+
+fn main() { }

--- a/src/test/ui/type-check-defaults.rs
+++ b/src/test/ui/type-check-defaults.rs
@@ -7,7 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-// compile-flags: --error-format=human
 
 use std::iter::FromIterator;
 use std::vec::IntoIter;
@@ -15,24 +14,34 @@ use std::ops::Add;
 
 struct Foo<T, U: FromIterator<T>>(T, U);
 struct WellFormed<Z = Foo<i32, i32>>(Z);
+//~^ error: the trait bound `i32: std::iter::FromIterator<i32>` is not satisfied [E0277]
 struct WellFormedNoBounds<Z:?Sized = Foo<i32, i32>>(Z);
+//~^ error: the trait bound `i32: std::iter::FromIterator<i32>` is not satisfied [E0277]
 
 struct WellFormedProjection<A, T=<A as Iterator>::Item>(A, T);
+//~^ error: the trait bound `A: std::iter::Iterator` is not satisfied [E0277]
 
 struct Bounds<T:Copy=String>(T);
+//~^ error: the trait bound `std::string::String: std::marker::Copy` is not satisfied [E0277]
 
 struct WhereClause<T=String>(T) where T: Copy;
+//~^ error: the trait bound `std::string::String: std::marker::Copy` is not satisfied [E0277]
 
 trait TraitBound<T:Copy=String> {}
+//~^ error: the trait bound `std::string::String: std::marker::Copy` is not satisfied [E0277]
 
 trait SelfBound<T:Copy=Self> {}
+//~^ error: the trait bound `Self: std::marker::Copy` is not satisfied [E0277]
 
 trait FooTrait<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
+//~^ error: the trait bound `i32: std::ops::Add<u8>` is not satisfied [E0277]
 
 trait Trait {}
 struct TwoParams<T, U>(T, U);
 impl Trait for TwoParams<i32, i32> {}
 // Check that each default is substituted individually in the clauses.
 struct Bogus<T = i32, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Trait;
+//~^ error: the trait bound `TwoParams<i32, U>: Trait` is not satisfied [E0277]
+//~^^ error: the trait bound `TwoParams<T, i32>: Trait` is not satisfied [E0277]
 
 fn main() { }

--- a/src/test/ui/type-check-defaults.rs
+++ b/src/test/ui/type-check-defaults.rs
@@ -30,25 +30,11 @@ struct WhereClause<T=String>(T) where T: Copy;
 trait TraitBound<T:Copy=String> {}
 //~^ error: the trait bound `std::string::String: std::marker::Copy` is not satisfied [E0277]
 
-trait SelfBound<T:Copy=Self> {}
-//~^ error: the trait bound `Self: std::marker::Copy` is not satisfied [E0277]
-
 trait Super<T: Copy> { }
 trait Base<T = String>: Super<T> { }
 //~^ error: the trait bound `T: std::marker::Copy` is not satisfied [E0277]
 
 trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
-//~^ error: the trait bound `i32: std::ops::Add<u8>` is not satisfied [E0277]
-
-// Defaults must work together.
-struct TwoParams<T = u32, U = i32>(T, U) where T: Bar<U>;
-//~^ the trait bound `u32: Bar<i32>` is not satisfied [E0277]
-trait Bar<V> {}
-impl Bar<String> for u32 { }
-impl Bar<i32> for String { }
-
-// Dependent defaults.
-struct Dependent<T, U = T>(T, U) where U: Copy;
-//~^ the trait bound `T: std::marker::Copy` is not satisfied [E0277]
+//~^ error:  cannot add `u8` to `i32` [E0277]
 
 fn main() { }

--- a/src/test/ui/type-check-defaults.rs
+++ b/src/test/ui/type-check-defaults.rs
@@ -33,19 +33,15 @@ trait TraitBound<T:Copy=String> {}
 trait SelfBound<T:Copy=Self> {}
 //~^ error: the trait bound `Self: std::marker::Copy` is not satisfied [E0277]
 
-trait FooTrait<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
-//~^ error: the trait bound `i32: std::ops::Add<u8>` is not satisfied [E0277]
-
-trait Trait {}
-struct TwoParams<T, U>(T, U);
-impl Trait for TwoParams<i32, i32> {}
-// Check that each default is substituted individually in the clauses.
-struct Bogus<T = i32, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Trait;
-//~^ error: the trait bound `TwoParams<i32, U>: Trait` is not satisfied [E0277]
-//~^^ error: the trait bound `TwoParams<T, i32>: Trait` is not satisfied [E0277]
-
 trait Super<T: Copy> { }
 trait Base<T = String>: Super<T> { }
 //~^ error: the trait bound `T: std::marker::Copy` is not satisfied [E0277]
 
+trait Trait<T> {}
+struct DefaultedLhs<U, V=i32>(U, V) where V: Trait<U>;
+//~^ error: the trait bound `i32: Trait<U>` is not satisfied [E0277]
+
+// FIXME: Deal with projection predicates
+// trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
+// ~^ error: the trait bound `i32: std::ops::Add<u8>` is not satisfied [E0277]
 fn main() { }

--- a/src/test/ui/type-check-defaults.rs
+++ b/src/test/ui/type-check-defaults.rs
@@ -15,6 +15,7 @@ use std::ops::Add;
 
 struct Foo<T, U: FromIterator<T>>(T, U);
 struct WellFormed<Z = Foo<i32, i32>>(Z);
+struct WellFormedNoBounds<Z:?Sized = Foo<i32, i32>>(Z);
 
 struct WellFormedProjection<A, T=<A as Iterator>::Item>(A, T);
 

--- a/src/test/ui/type-check-defaults.rs
+++ b/src/test/ui/type-check-defaults.rs
@@ -37,11 +37,14 @@ trait Super<T: Copy> { }
 trait Base<T = String>: Super<T> { }
 //~^ error: the trait bound `T: std::marker::Copy` is not satisfied [E0277]
 
-trait Trait<T> {}
-struct DefaultedLhs<U, V=i32>(U, V) where V: Trait<U>;
-//~^ error: the trait bound `i32: Trait<U>` is not satisfied [E0277]
+trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
+//~^ error: the trait bound `i32: std::ops::Add<u8>` is not satisfied [E0277]
 
-// FIXME: Deal with projection predicates
-// trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
-// ~^ error: the trait bound `i32: std::ops::Add<u8>` is not satisfied [E0277]
+// Defaults must work together.
+struct TwoParams<T = u32, U = i32>(T, U) where T: Bar<U>;
+//~^ the trait bound `u32: Bar<i32>` is not satisfied [E0277]
+trait Bar<V> {}
+impl Bar<String> for u32 { }
+impl Bar<i32> for String { }
+
 fn main() { }

--- a/src/test/ui/type-check-defaults.rs
+++ b/src/test/ui/type-check-defaults.rs
@@ -44,4 +44,8 @@ struct Bogus<T = i32, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Trait;
 //~^ error: the trait bound `TwoParams<i32, U>: Trait` is not satisfied [E0277]
 //~^^ error: the trait bound `TwoParams<T, i32>: Trait` is not satisfied [E0277]
 
+trait Super<T: Copy> { }
+trait Base<T = String>: Super<T> { }
+//~^ error: the trait bound `T: std::marker::Copy` is not satisfied [E0277]
+
 fn main() { }

--- a/src/test/ui/type-check-defaults.rs
+++ b/src/test/ui/type-check-defaults.rs
@@ -29,4 +29,10 @@ trait SelfBound<T:Copy=Self> {}
 
 trait FooTrait<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
 
+trait Trait {}
+struct TwoParams<T, U>(T, U);
+impl Trait for TwoParams<i32, i32> {}
+// Check that each default is substituted individually in the clauses.
+struct Bogus<T = i32, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Trait;
+
 fn main() { }

--- a/src/test/ui/type-check-defaults.rs
+++ b/src/test/ui/type-check-defaults.rs
@@ -47,4 +47,8 @@ trait Bar<V> {}
 impl Bar<String> for u32 { }
 impl Bar<i32> for String { }
 
+// Dependent defaults.
+struct Dependent<T, U = T>(T, U) where U: Copy;
+//~^ the trait bound `T: std::marker::Copy` is not satisfied [E0277]
+
 fn main() { }

--- a/src/test/ui/type-check-defaults.rs
+++ b/src/test/ui/type-check-defaults.rs
@@ -18,9 +18,6 @@ struct WellFormed<Z = Foo<i32, i32>>(Z);
 struct WellFormedNoBounds<Z:?Sized = Foo<i32, i32>>(Z);
 //~^ error: the trait bound `i32: std::iter::FromIterator<i32>` is not satisfied [E0277]
 
-struct WellFormedProjection<A, T=<A as Iterator>::Item>(A, T);
-//~^ error: the trait bound `A: std::iter::Iterator` is not satisfied [E0277]
-
 struct Bounds<T:Copy=String>(T);
 //~^ error: the trait bound `std::string::String: std::marker::Copy` is not satisfied [E0277]
 

--- a/src/test/ui/type-check-defaults.stderr
+++ b/src/test/ui/type-check-defaults.stderr
@@ -102,5 +102,14 @@ note: required by `Bar`
 46 | trait Bar<V> {}
    | ^^^^^^^^^^^^
 
-error: aborting due to 10 previous errors
+error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
+  --> $DIR/type-check-defaults.rs:51:1
+   |
+51 | struct Dependent<T, U = T>(T, U) where U: Copy;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |
+   = help: consider adding a `where T: std::marker::Copy` bound
+   = note: required by `std::marker::Copy`
+
+error: aborting due to 11 previous errors
 

--- a/src/test/ui/type-check-defaults.stderr
+++ b/src/test/ui/type-check-defaults.stderr
@@ -67,5 +67,23 @@ error[E0277]: the trait bound `i32: std::ops::Add<u8>` is not satisfied
    = help: the trait `std::ops::Add<u8>` is not implemented for `i32`
    = note: required by `std::ops::Add`
 
-error: aborting due to 8 previous errors
+error[E0277]: the trait bound `TwoParams<i32, U>: Trait` is not satisfied
+  --> $DIR/type-check-defaults.rs:36:1
+   |
+36 | struct Bogus<T = i32, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Trait;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `TwoParams<i32, U>`
+   |
+   = help: consider adding a `where TwoParams<i32, U>: Trait` bound
+   = note: required by `Trait`
+
+error[E0277]: the trait bound `TwoParams<T, i32>: Trait` is not satisfied
+  --> $DIR/type-check-defaults.rs:36:1
+   |
+36 | struct Bogus<T = i32, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Trait;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `TwoParams<T, i32>`
+   |
+   = help: consider adding a `where TwoParams<T, i32>: Trait` bound
+   = note: required by `Trait`
+
+error: aborting due to 10 previous errors
 

--- a/src/test/ui/type-check-defaults.stderr
+++ b/src/test/ui/type-check-defaults.stderr
@@ -79,17 +79,28 @@ note: required by `Super`
 36 | trait Super<T: Copy> { }
    | ^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `i32: Trait<U>` is not satisfied
-  --> $DIR/type-check-defaults.rs:41:1
-   |
-41 | struct DefaultedLhs<U, V=i32>(U, V) where V: Trait<U>;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<U>` is not implemented for `i32`
-   |
-note: required by `Trait`
+error[E0277]: the trait bound `i32: std::ops::Add<u8>` is not satisfied
   --> $DIR/type-check-defaults.rs:40:1
    |
-40 | trait Trait<T> {}
-   | ^^^^^^^^^^^^^^
+40 | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `i32 + u8`
+   |
+   = help: the trait `std::ops::Add<u8>` is not implemented for `i32`
+   = note: required by `std::ops::Add`
 
-error: aborting due to 9 previous errors
+error[E0277]: the trait bound `u32: Bar<i32>` is not satisfied
+  --> $DIR/type-check-defaults.rs:44:1
+   |
+44 | struct TwoParams<T = u32, U = i32>(T, U) where T: Bar<U>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar<i32>` is not implemented for `u32`
+   |
+   = help: the following implementations were found:
+             <u32 as Bar<std::string::String>>
+note: required by `Bar`
+  --> $DIR/type-check-defaults.rs:46:1
+   |
+46 | trait Bar<V> {}
+   | ^^^^^^^^^^^^
+
+error: aborting due to 10 previous errors
 

--- a/src/test/ui/type-check-defaults.stderr
+++ b/src/test/ui/type-check-defaults.stderr
@@ -24,61 +24,51 @@ note: required by `Foo`
 15 | struct Foo<T, U: FromIterator<T>>(T, U);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `A: std::iter::Iterator` is not satisfied
-  --> $DIR/type-check-defaults.rs:21:32
+error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
+  --> $DIR/type-check-defaults.rs:21:1
    |
-21 | struct WellFormedProjection<A, T=<A as Iterator>::Item>(A, T);
-   |                                ^ `A` is not an iterator; maybe try calling `.iter()` or a similar method
+21 | struct Bounds<T:Copy=String>(T);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
    |
-   = help: the trait `std::iter::Iterator` is not implemented for `A`
-   = help: consider adding a `where A: std::iter::Iterator` bound
-   = note: required by `std::iter::Iterator`
+   = note: required by `std::marker::Copy`
 
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:24:1
    |
-24 | struct Bounds<T:Copy=String>(T);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
+24 | struct WhereClause<T=String>(T) where T: Copy;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
    |
    = note: required by `std::marker::Copy`
 
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:27:1
    |
-27 | struct WhereClause<T=String>(T) where T: Copy;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
-   |
-   = note: required by `std::marker::Copy`
-
-error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
-  --> $DIR/type-check-defaults.rs:30:1
-   |
-30 | trait TraitBound<T:Copy=String> {}
+27 | trait TraitBound<T:Copy=String> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
    |
    = note: required by `std::marker::Copy`
 
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
-  --> $DIR/type-check-defaults.rs:34:1
+  --> $DIR/type-check-defaults.rs:31:1
    |
-34 | trait Base<T = String>: Super<T> { }
+31 | trait Base<T = String>: Super<T> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
    = help: consider adding a `where T: std::marker::Copy` bound
 note: required by `Super`
-  --> $DIR/type-check-defaults.rs:33:1
+  --> $DIR/type-check-defaults.rs:30:1
    |
-33 | trait Super<T: Copy> { }
+30 | trait Super<T: Copy> { }
    | ^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: cannot add `u8` to `i32`
-  --> $DIR/type-check-defaults.rs:37:1
+  --> $DIR/type-check-defaults.rs:34:1
    |
-37 | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
+34 | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `i32 + u8`
    |
    = help: the trait `std::ops::Add<u8>` is not implemented for `i32`
    = note: required by `std::ops::Add`
 
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 

--- a/src/test/ui/type-check-defaults.stderr
+++ b/src/test/ui/type-check-defaults.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `i32: std::iter::FromIterator<i32>` is not satisfied
-  --> $DIR/type-check-defaults.rs:17:19
+  --> $DIR/type-check-defaults.rs:16:19
    |
-17 | struct WellFormed<Z = Foo<i32, i32>>(Z);
+16 | struct WellFormed<Z = Foo<i32, i32>>(Z);
    |                   ^ a collection of type `i32` cannot be built from an iterator over elements of type `i32`
    |
    = help: the trait `std::iter::FromIterator<i32>` is not implemented for `i32`
@@ -17,69 +17,69 @@ error[E0277]: the trait bound `i32: std::iter::FromIterator<i32>` is not satisfi
    = note: required by `Foo`
 
 error[E0277]: the trait bound `A: std::iter::Iterator` is not satisfied
-  --> $DIR/type-check-defaults.rs:20:1
+  --> $DIR/type-check-defaults.rs:21:1
    |
-20 | struct WellFormedProjection<A, T=<A as Iterator>::Item>(A, T);
+21 | struct WellFormedProjection<A, T=<A as Iterator>::Item>(A, T);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `A` is not an iterator; maybe try calling `.iter()` or a similar method
    |
    = help: the trait `std::iter::Iterator` is not implemented for `A`
    = help: consider adding a `where A: std::iter::Iterator` bound
 
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
-  --> $DIR/type-check-defaults.rs:22:1
+  --> $DIR/type-check-defaults.rs:24:1
    |
-22 | struct Bounds<T:Copy=String>(T);
+24 | struct Bounds<T:Copy=String>(T);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
    |
    = note: required by `std::marker::Copy`
 
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
-  --> $DIR/type-check-defaults.rs:24:1
+  --> $DIR/type-check-defaults.rs:27:1
    |
-24 | struct WhereClause<T=String>(T) where T: Copy;
+27 | struct WhereClause<T=String>(T) where T: Copy;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
    |
    = note: required by `std::marker::Copy`
 
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
-  --> $DIR/type-check-defaults.rs:26:1
+  --> $DIR/type-check-defaults.rs:30:1
    |
-26 | trait TraitBound<T:Copy=String> {}
+30 | trait TraitBound<T:Copy=String> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
    |
    = note: required by `std::marker::Copy`
 
 error[E0277]: the trait bound `Self: std::marker::Copy` is not satisfied
-  --> $DIR/type-check-defaults.rs:28:1
+  --> $DIR/type-check-defaults.rs:33:1
    |
-28 | trait SelfBound<T:Copy=Self> {}
+33 | trait SelfBound<T:Copy=Self> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `Self`
    |
    = help: consider adding a `where Self: std::marker::Copy` bound
    = note: required by `std::marker::Copy`
 
 error[E0277]: the trait bound `i32: std::ops::Add<u8>` is not satisfied
-  --> $DIR/type-check-defaults.rs:30:1
+  --> $DIR/type-check-defaults.rs:36:1
    |
-30 | trait FooTrait<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
+36 | trait FooTrait<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `i32 + u8`
    |
    = help: the trait `std::ops::Add<u8>` is not implemented for `i32`
    = note: required by `std::ops::Add`
 
 error[E0277]: the trait bound `TwoParams<i32, U>: Trait` is not satisfied
-  --> $DIR/type-check-defaults.rs:36:1
+  --> $DIR/type-check-defaults.rs:43:1
    |
-36 | struct Bogus<T = i32, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Trait;
+43 | struct Bogus<T = i32, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Trait;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `TwoParams<i32, U>`
    |
    = help: consider adding a `where TwoParams<i32, U>: Trait` bound
    = note: required by `Trait`
 
 error[E0277]: the trait bound `TwoParams<T, i32>: Trait` is not satisfied
-  --> $DIR/type-check-defaults.rs:36:1
+  --> $DIR/type-check-defaults.rs:43:1
    |
-36 | struct Bogus<T = i32, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Trait;
+43 | struct Bogus<T = i32, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Trait;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `TwoParams<T, i32>`
    |
    = help: consider adding a `where TwoParams<T, i32>: Trait` bound

--- a/src/test/ui/type-check-defaults.stderr
+++ b/src/test/ui/type-check-defaults.stderr
@@ -1,62 +1,71 @@
 error[E0277]: the trait bound `i32: std::iter::FromIterator<i32>` is not satisfied
-  --> $DIR/type-check-defaults.rs:17:1
+  --> $DIR/type-check-defaults.rs:17:19
    |
 17 | struct WellFormed<Z = Foo<i32, i32>>(Z);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ a collection of type `i32` cannot be built from an iterator over elements of type `i32`
+   |                   ^ a collection of type `i32` cannot be built from an iterator over elements of type `i32`
+   |
+   = help: the trait `std::iter::FromIterator<i32>` is not implemented for `i32`
+   = note: required by `Foo`
+
+error[E0277]: the trait bound `i32: std::iter::FromIterator<i32>` is not satisfied
+  --> $DIR/type-check-defaults.rs:18:27
+   |
+18 | struct WellFormedNoBounds<Z:?Sized = Foo<i32, i32>>(Z);
+   |                           ^ a collection of type `i32` cannot be built from an iterator over elements of type `i32`
    |
    = help: the trait `std::iter::FromIterator<i32>` is not implemented for `i32`
    = note: required by `Foo`
 
 error[E0277]: the trait bound `A: std::iter::Iterator` is not satisfied
-  --> $DIR/type-check-defaults.rs:19:1
+  --> $DIR/type-check-defaults.rs:20:1
    |
-19 | struct WellFormedProjection<A, T=<A as Iterator>::Item>(A, T);
+20 | struct WellFormedProjection<A, T=<A as Iterator>::Item>(A, T);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `A` is not an iterator; maybe try calling `.iter()` or a similar method
    |
    = help: the trait `std::iter::Iterator` is not implemented for `A`
    = help: consider adding a `where A: std::iter::Iterator` bound
 
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
-  --> $DIR/type-check-defaults.rs:21:1
+  --> $DIR/type-check-defaults.rs:22:1
    |
-21 | struct Bounds<T:Copy=String>(T);
+22 | struct Bounds<T:Copy=String>(T);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
    |
    = note: required by `std::marker::Copy`
 
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
-  --> $DIR/type-check-defaults.rs:23:1
+  --> $DIR/type-check-defaults.rs:24:1
    |
-23 | struct WhereClause<T=String>(T) where T: Copy;
+24 | struct WhereClause<T=String>(T) where T: Copy;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
    |
    = note: required by `std::marker::Copy`
 
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
-  --> $DIR/type-check-defaults.rs:25:1
+  --> $DIR/type-check-defaults.rs:26:1
    |
-25 | trait TraitBound<T:Copy=String> {}
+26 | trait TraitBound<T:Copy=String> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
    |
    = note: required by `std::marker::Copy`
 
 error[E0277]: the trait bound `Self: std::marker::Copy` is not satisfied
-  --> $DIR/type-check-defaults.rs:27:1
+  --> $DIR/type-check-defaults.rs:28:1
    |
-27 | trait SelfBound<T:Copy=Self> {}
+28 | trait SelfBound<T:Copy=Self> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `Self`
    |
    = help: consider adding a `where Self: std::marker::Copy` bound
    = note: required by `std::marker::Copy`
 
 error[E0277]: the trait bound `i32: std::ops::Add<u8>` is not satisfied
-  --> $DIR/type-check-defaults.rs:29:1
+  --> $DIR/type-check-defaults.rs:30:1
    |
-29 | trait FooTrait<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
+30 | trait FooTrait<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `i32 + u8`
    |
    = help: the trait `std::ops::Add<u8>` is not implemented for `i32`
    = note: required by `std::ops::Add`
 
-error: aborting due to 7 previous errors
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/type-check-defaults.stderr
+++ b/src/test/ui/type-check-defaults.stderr
@@ -1,0 +1,62 @@
+error[E0277]: the trait bound `i32: std::iter::FromIterator<i32>` is not satisfied
+  --> $DIR/type-check-defaults.rs:17:1
+   |
+17 | struct WellFormed<Z = Foo<i32, i32>>(Z);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ a collection of type `i32` cannot be built from an iterator over elements of type `i32`
+   |
+   = help: the trait `std::iter::FromIterator<i32>` is not implemented for `i32`
+   = note: required by `Foo`
+
+error[E0277]: the trait bound `A: std::iter::Iterator` is not satisfied
+  --> $DIR/type-check-defaults.rs:19:1
+   |
+19 | struct WellFormedProjection<A, T=<A as Iterator>::Item>(A, T);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `A` is not an iterator; maybe try calling `.iter()` or a similar method
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `A`
+   = help: consider adding a `where A: std::iter::Iterator` bound
+
+error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
+  --> $DIR/type-check-defaults.rs:21:1
+   |
+21 | struct Bounds<T:Copy=String>(T);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
+   |
+   = note: required by `std::marker::Copy`
+
+error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
+  --> $DIR/type-check-defaults.rs:23:1
+   |
+23 | struct WhereClause<T=String>(T) where T: Copy;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
+   |
+   = note: required by `std::marker::Copy`
+
+error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
+  --> $DIR/type-check-defaults.rs:25:1
+   |
+25 | trait TraitBound<T:Copy=String> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
+   |
+   = note: required by `std::marker::Copy`
+
+error[E0277]: the trait bound `Self: std::marker::Copy` is not satisfied
+  --> $DIR/type-check-defaults.rs:27:1
+   |
+27 | trait SelfBound<T:Copy=Self> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `Self`
+   |
+   = help: consider adding a `where Self: std::marker::Copy` bound
+   = note: required by `std::marker::Copy`
+
+error[E0277]: the trait bound `i32: std::ops::Add<u8>` is not satisfied
+  --> $DIR/type-check-defaults.rs:29:1
+   |
+29 | trait FooTrait<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `i32 + u8`
+   |
+   = help: the trait `std::ops::Add<u8>` is not implemented for `i32`
+   = note: required by `std::ops::Add`
+
+error: aborting due to 7 previous errors
+

--- a/src/test/ui/type-check-defaults.stderr
+++ b/src/test/ui/type-check-defaults.stderr
@@ -25,13 +25,14 @@ note: required by `Foo`
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `A: std::iter::Iterator` is not satisfied
-  --> $DIR/type-check-defaults.rs:21:1
+  --> $DIR/type-check-defaults.rs:21:32
    |
 21 | struct WellFormedProjection<A, T=<A as Iterator>::Item>(A, T);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `A` is not an iterator; maybe try calling `.iter()` or a similar method
+   |                                ^ `A` is not an iterator; maybe try calling `.iter()` or a similar method
    |
    = help: the trait `std::iter::Iterator` is not implemented for `A`
    = help: consider adding a `where A: std::iter::Iterator` bound
+   = note: required by `std::iter::Iterator`
 
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:24:1
@@ -57,59 +58,27 @@ error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not sa
    |
    = note: required by `std::marker::Copy`
 
-error[E0277]: the trait bound `Self: std::marker::Copy` is not satisfied
-  --> $DIR/type-check-defaults.rs:33:1
-   |
-33 | trait SelfBound<T:Copy=Self> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `Self`
-   |
-   = help: consider adding a `where Self: std::marker::Copy` bound
-   = note: required by `std::marker::Copy`
-
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
-  --> $DIR/type-check-defaults.rs:37:1
+  --> $DIR/type-check-defaults.rs:34:1
    |
-37 | trait Base<T = String>: Super<T> { }
+34 | trait Base<T = String>: Super<T> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
    = help: consider adding a `where T: std::marker::Copy` bound
 note: required by `Super`
-  --> $DIR/type-check-defaults.rs:36:1
+  --> $DIR/type-check-defaults.rs:33:1
    |
-36 | trait Super<T: Copy> { }
+33 | trait Super<T: Copy> { }
    | ^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `i32: std::ops::Add<u8>` is not satisfied
-  --> $DIR/type-check-defaults.rs:40:1
+error[E0277]: cannot add `u8` to `i32`
+  --> $DIR/type-check-defaults.rs:37:1
    |
-40 | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
+37 | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `i32 + u8`
    |
    = help: the trait `std::ops::Add<u8>` is not implemented for `i32`
    = note: required by `std::ops::Add`
 
-error[E0277]: the trait bound `u32: Bar<i32>` is not satisfied
-  --> $DIR/type-check-defaults.rs:44:1
-   |
-44 | struct TwoParams<T = u32, U = i32>(T, U) where T: Bar<U>;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar<i32>` is not implemented for `u32`
-   |
-   = help: the following implementations were found:
-             <u32 as Bar<std::string::String>>
-note: required by `Bar`
-  --> $DIR/type-check-defaults.rs:46:1
-   |
-46 | trait Bar<V> {}
-   | ^^^^^^^^^^^^
-
-error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
-  --> $DIR/type-check-defaults.rs:51:1
-   |
-51 | struct Dependent<T, U = T>(T, U) where U: Copy;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
-   |
-   = help: consider adding a `where T: std::marker::Copy` bound
-   = note: required by `std::marker::Copy`
-
-error: aborting due to 11 previous errors
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/type-check-defaults.stderr
+++ b/src/test/ui/type-check-defaults.stderr
@@ -66,53 +66,30 @@ error[E0277]: the trait bound `Self: std::marker::Copy` is not satisfied
    = help: consider adding a `where Self: std::marker::Copy` bound
    = note: required by `std::marker::Copy`
 
-error[E0277]: the trait bound `i32: std::ops::Add<u8>` is not satisfied
-  --> $DIR/type-check-defaults.rs:36:1
-   |
-36 | trait FooTrait<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `i32 + u8`
-   |
-   = help: the trait `std::ops::Add<u8>` is not implemented for `i32`
-   = note: required by `std::ops::Add`
-
-error[E0277]: the trait bound `TwoParams<i32, U>: Trait` is not satisfied
-  --> $DIR/type-check-defaults.rs:43:1
-   |
-43 | struct Bogus<T = i32, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Trait;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `TwoParams<i32, U>`
-   |
-   = help: consider adding a `where TwoParams<i32, U>: Trait` bound
-note: required by `Trait`
-  --> $DIR/type-check-defaults.rs:39:1
-   |
-39 | trait Trait {}
-   | ^^^^^^^^^^^
-
-error[E0277]: the trait bound `TwoParams<T, i32>: Trait` is not satisfied
-  --> $DIR/type-check-defaults.rs:43:1
-   |
-43 | struct Bogus<T = i32, U = i32>(TwoParams<T, U>) where TwoParams<T, U>: Trait;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `TwoParams<T, i32>`
-   |
-   = help: consider adding a `where TwoParams<T, i32>: Trait` bound
-note: required by `Trait`
-  --> $DIR/type-check-defaults.rs:39:1
-   |
-39 | trait Trait {}
-   | ^^^^^^^^^^^
-
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
-  --> $DIR/type-check-defaults.rs:48:1
+  --> $DIR/type-check-defaults.rs:37:1
    |
-48 | trait Base<T = String>: Super<T> { }
+37 | trait Base<T = String>: Super<T> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
    = help: consider adding a `where T: std::marker::Copy` bound
 note: required by `Super`
-  --> $DIR/type-check-defaults.rs:47:1
+  --> $DIR/type-check-defaults.rs:36:1
    |
-47 | trait Super<T: Copy> { }
+36 | trait Super<T: Copy> { }
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 11 previous errors
+error[E0277]: the trait bound `i32: Trait<U>` is not satisfied
+  --> $DIR/type-check-defaults.rs:41:1
+   |
+41 | struct DefaultedLhs<U, V=i32>(U, V) where V: Trait<U>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<U>` is not implemented for `i32`
+   |
+note: required by `Trait`
+  --> $DIR/type-check-defaults.rs:40:1
+   |
+40 | trait Trait<T> {}
+   | ^^^^^^^^^^^^^^
+
+error: aborting due to 9 previous errors
 

--- a/src/test/ui/type-check-defaults.stderr
+++ b/src/test/ui/type-check-defaults.stderr
@@ -5,7 +5,11 @@ error[E0277]: the trait bound `i32: std::iter::FromIterator<i32>` is not satisfi
    |                   ^ a collection of type `i32` cannot be built from an iterator over elements of type `i32`
    |
    = help: the trait `std::iter::FromIterator<i32>` is not implemented for `i32`
-   = note: required by `Foo`
+note: required by `Foo`
+  --> $DIR/type-check-defaults.rs:15:1
+   |
+15 | struct Foo<T, U: FromIterator<T>>(T, U);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `i32: std::iter::FromIterator<i32>` is not satisfied
   --> $DIR/type-check-defaults.rs:18:27
@@ -14,7 +18,11 @@ error[E0277]: the trait bound `i32: std::iter::FromIterator<i32>` is not satisfi
    |                           ^ a collection of type `i32` cannot be built from an iterator over elements of type `i32`
    |
    = help: the trait `std::iter::FromIterator<i32>` is not implemented for `i32`
-   = note: required by `Foo`
+note: required by `Foo`
+  --> $DIR/type-check-defaults.rs:15:1
+   |
+15 | struct Foo<T, U: FromIterator<T>>(T, U);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `A: std::iter::Iterator` is not satisfied
   --> $DIR/type-check-defaults.rs:21:1
@@ -74,7 +82,11 @@ error[E0277]: the trait bound `TwoParams<i32, U>: Trait` is not satisfied
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `TwoParams<i32, U>`
    |
    = help: consider adding a `where TwoParams<i32, U>: Trait` bound
-   = note: required by `Trait`
+note: required by `Trait`
+  --> $DIR/type-check-defaults.rs:39:1
+   |
+39 | trait Trait {}
+   | ^^^^^^^^^^^
 
 error[E0277]: the trait bound `TwoParams<T, i32>: Trait` is not satisfied
   --> $DIR/type-check-defaults.rs:43:1
@@ -83,7 +95,24 @@ error[E0277]: the trait bound `TwoParams<T, i32>: Trait` is not satisfied
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `TwoParams<T, i32>`
    |
    = help: consider adding a `where TwoParams<T, i32>: Trait` bound
-   = note: required by `Trait`
+note: required by `Trait`
+  --> $DIR/type-check-defaults.rs:39:1
+   |
+39 | trait Trait {}
+   | ^^^^^^^^^^^
 
-error: aborting due to 10 previous errors
+error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
+  --> $DIR/type-check-defaults.rs:48:1
+   |
+48 | trait Base<T = String>: Super<T> { }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |
+   = help: consider adding a `where T: std::marker::Copy` bound
+note: required by `Super`
+  --> $DIR/type-check-defaults.rs:47:1
+   |
+47 | trait Super<T: Copy> { }
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 11 previous errors
 

--- a/src/test/ui/type-check-defaults.stderr
+++ b/src/test/ui/type-check-defaults.stderr
@@ -1,33 +1,33 @@
 error[E0277]: the trait bound `i32: std::iter::FromIterator<i32>` is not satisfied
   --> $DIR/type-check-defaults.rs:16:19
    |
-16 | struct WellFormed<Z = Foo<i32, i32>>(Z);
+LL | struct WellFormed<Z = Foo<i32, i32>>(Z);
    |                   ^ a collection of type `i32` cannot be built from an iterator over elements of type `i32`
    |
    = help: the trait `std::iter::FromIterator<i32>` is not implemented for `i32`
 note: required by `Foo`
   --> $DIR/type-check-defaults.rs:15:1
    |
-15 | struct Foo<T, U: FromIterator<T>>(T, U);
+LL | struct Foo<T, U: FromIterator<T>>(T, U);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `i32: std::iter::FromIterator<i32>` is not satisfied
   --> $DIR/type-check-defaults.rs:18:27
    |
-18 | struct WellFormedNoBounds<Z:?Sized = Foo<i32, i32>>(Z);
+LL | struct WellFormedNoBounds<Z:?Sized = Foo<i32, i32>>(Z);
    |                           ^ a collection of type `i32` cannot be built from an iterator over elements of type `i32`
    |
    = help: the trait `std::iter::FromIterator<i32>` is not implemented for `i32`
 note: required by `Foo`
   --> $DIR/type-check-defaults.rs:15:1
    |
-15 | struct Foo<T, U: FromIterator<T>>(T, U);
+LL | struct Foo<T, U: FromIterator<T>>(T, U);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:21:1
    |
-21 | struct Bounds<T:Copy=String>(T);
+LL | struct Bounds<T:Copy=String>(T);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
    |
    = note: required by `std::marker::Copy`
@@ -35,7 +35,7 @@ error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not sa
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:24:1
    |
-24 | struct WhereClause<T=String>(T) where T: Copy;
+LL | struct WhereClause<T=String>(T) where T: Copy;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
    |
    = note: required by `std::marker::Copy`
@@ -43,7 +43,7 @@ error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not sa
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:27:1
    |
-27 | trait TraitBound<T:Copy=String> {}
+LL | trait TraitBound<T:Copy=String> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
    |
    = note: required by `std::marker::Copy`
@@ -51,20 +51,20 @@ error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not sa
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:31:1
    |
-31 | trait Base<T = String>: Super<T> { }
+LL | trait Base<T = String>: Super<T> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
    = help: consider adding a `where T: std::marker::Copy` bound
 note: required by `Super`
   --> $DIR/type-check-defaults.rs:30:1
    |
-30 | trait Super<T: Copy> { }
+LL | trait Super<T: Copy> { }
    | ^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: cannot add `u8` to `i32`
   --> $DIR/type-check-defaults.rs:34:1
    |
-34 | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
+LL | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `i32 + u8`
    |
    = help: the trait `std::ops::Add<u8>` is not implemented for `i32`
@@ -72,3 +72,4 @@ error[E0277]: cannot add `u8` to `i32`
 
 error: aborting due to 7 previous errors
 
+If you want more information on this error, try using "rustc --explain E0277"


### PR DESCRIPTION
Fixes  #46669. See the test for code that compiles on stable but will no longer compile. This falls under a "Underspecified language semantics" fix. **Needs crater**.

On type and trait declarations, we currently allow anything that name checks as a type parameter default. That allows the user to write a default that can never be applied, or even a default that may conditionally be applied depending on the type of another parameter. Mostly this just defers the error to use sites, but also allows clever hacks such as `Foo<T, U = <T as Iterator>::Item>` where `U` will be able to apply it's default only when `T: Iterator`. Maybe that means this bug is a feature, but it's a fiddly behaviour that seems undesirable.

This PR validates defaults at declaration sites by ensuring all predicates on the parameter are valid for the default. With the exception of `Self: Sized` which we don't want to check to allow things like `trait Add<RHS = Self>`.