### PR TITLE
Add an option to allow rustdoc to list modules by appearance

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -254,7 +254,8 @@ pub fn opts() -> Vec<RustcOptGroup> {
             o.optopt("", "linker", "linker used for building executable test code", "PATH")
         }),
         unstable("sort-modules-by-appearance", |o| {
-            o.optflag("", "sort-modules-by-appearance", "sort modules by where they appear in the program, rather than alphabetically")
+            o.optflag("", "sort-modules-by-appearance", "sort modules by where they appear in the \
+                                                         program, rather than alphabetically")
         }),
     ]
 }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -253,6 +253,9 @@ pub fn opts() -> Vec<RustcOptGroup> {
         unstable("linker", |o| {
             o.optopt("", "linker", "linker used for building executable test code", "PATH")
         }),
+        unstable("sort-modules-by-appearance", |o| {
+            o.optflag("", "sort-modules-by-appearance", "sort modules by where they appear in the program, rather than alphabetically")
+        }),
     ]
 }
 
@@ -369,6 +372,7 @@ pub fn main_args(args: &[String]) -> isize {
     let maybe_sysroot = matches.opt_str("sysroot").map(PathBuf::from);
     let display_warnings = matches.opt_present("display-warnings");
     let linker = matches.opt_str("linker").map(PathBuf::from);
+    let sort_modules_alphabetically = !matches.opt_present("sort-modules-by-appearance");
 
     match (should_test, markdown_input) {
         (true, true) => {
@@ -398,7 +402,8 @@ pub fn main_args(args: &[String]) -> isize {
                                   passes.into_iter().collect(),
                                   css_file_extension,
                                   renderinfo,
-                                  render_type)
+                                  render_type,
+                                  sort_modules_alphabetically)
                     .expect("failed to generate documentation");
                 0
             }

--- a/src/test/rustdoc/sort-modules-by-appearance.rs
+++ b/src/test/rustdoc/sort-modules-by-appearance.rs
@@ -1,0 +1,23 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests the rustdoc --sort-modules-by-appearance option, that allows module declarations to appear
+// in the order they are declared in the source code, rather than only alphabetically.
+
+// compile-flags: -Z unstable-options --sort-modules-by-appearance
+
+pub mod module_b {}
+
+pub mod module_c {}
+
+pub mod module_a {}
+
+// @matches 'sort_modules_by_appearance/index.html' '(?s)module_b.*module_c.*module_a'
+// @matches 'sort_modules_by_appearance/sidebar-items.js' '"module_b".*"module_c".*"module_a"'


### PR DESCRIPTION
The `--sort-modules-by-appearance` option will list modules in the
order that they appear in the source, rather than sorting them
alphabetically (as is the default). This resolves #8552.