### PR TITLE
syntax: recovery for incorrect associated item paths like `[T; N]::clone`

### DIFF
--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -22,6 +22,7 @@
 
 #![feature(unicode)]
 #![feature(rustc_diagnostic_macros)]
+#![feature(match_default_bindings)]
 #![feature(i128_type)]
 
 // See librustc_cratesio_shim/Cargo.toml for a comment explaining this.

--- a/src/test/ui/did_you_mean/bad-assoc-expr.rs
+++ b/src/test/ui/did_you_mean/bad-assoc-expr.rs
@@ -1,0 +1,24 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let a = [1, 2, 3, 4];
+    [i32; 4]::clone(&a);
+    //~^ ERROR missing angle brackets in associated item path
+
+    [i32]::as_ref(&a);
+    //~^ ERROR missing angle brackets in associated item path
+
+    (u8)::clone(&0);
+    //~^ ERROR missing angle brackets in associated item path
+
+    (u8, u8)::clone(&(0, 0));
+    //~^ ERROR missing angle brackets in associated item path
+}

--- a/src/test/ui/did_you_mean/bad-assoc-expr.stderr
+++ b/src/test/ui/did_you_mean/bad-assoc-expr.stderr
@@ -1,0 +1,26 @@
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-expr.rs:13:5
+   |
+13 |     [i32; 4]::clone(&a);
+   |     ^^^^^^^^^^^^^^^ help: try: `<[i32; 4]>::clone`
+
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-expr.rs:16:5
+   |
+16 |     [i32]::as_ref(&a);
+   |     ^^^^^^^^^^^^^ help: try: `<[i32]>::as_ref`
+
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-expr.rs:19:5
+   |
+19 |     (u8)::clone(&0);
+   |     ^^^^^^^^^^^ help: try: `<(u8)>::clone`
+
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-expr.rs:22:5
+   |
+22 |     (u8, u8)::clone(&(0, 0));
+   |     ^^^^^^^^^^^^^^^ help: try: `<(u8, u8)>::clone`
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/did_you_mean/bad-assoc-pat.rs
+++ b/src/test/ui/did_you_mean/bad-assoc-pat.rs
@@ -1,0 +1,23 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    match 0u8 {
+        [u8]::AssocItem => {}
+        //~^ ERROR missing angle brackets in associated item path
+        //~| ERROR no associated item named `AssocItem` found for type `[u8]` in the current scope
+        (u8, u8)::AssocItem => {}
+        //~^ ERROR missing angle brackets in associated item path
+        //~| ERROR no associated item named `AssocItem` found for type `(u8, u8)` in the current sco
+        _::AssocItem => {}
+        //~^ ERROR missing angle brackets in associated item path
+        //~| ERROR no associated item named `AssocItem` found for type `_` in the current scope
+    }
+}

--- a/src/test/ui/did_you_mean/bad-assoc-pat.stderr
+++ b/src/test/ui/did_you_mean/bad-assoc-pat.stderr
@@ -1,0 +1,38 @@
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-pat.rs:13:9
+   |
+13 |         [u8]::AssocItem => {}
+   |         ^^^^^^^^^^^^^^^ help: try: `<[u8]>::AssocItem`
+
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-pat.rs:16:9
+   |
+16 |         (u8, u8)::AssocItem => {}
+   |         ^^^^^^^^^^^^^^^^^^^ help: try: `<(u8, u8)>::AssocItem`
+
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-pat.rs:19:9
+   |
+19 |         _::AssocItem => {}
+   |         ^^^^^^^^^^^^ help: try: `<_>::AssocItem`
+
+error[E0599]: no associated item named `AssocItem` found for type `[u8]` in the current scope
+  --> $DIR/bad-assoc-pat.rs:13:9
+   |
+13 |         [u8]::AssocItem => {}
+   |         ^^^^^^^^^^^^^^^ associated item not found in `[u8]`
+
+error[E0599]: no associated item named `AssocItem` found for type `(u8, u8)` in the current scope
+  --> $DIR/bad-assoc-pat.rs:16:9
+   |
+16 |         (u8, u8)::AssocItem => {}
+   |         ^^^^^^^^^^^^^^^^^^^ associated item not found in `(u8, u8)`
+
+error[E0599]: no associated item named `AssocItem` found for type `_` in the current scope
+  --> $DIR/bad-assoc-pat.rs:19:9
+   |
+19 |         _::AssocItem => {}
+   |         ^^^^^^^^^^^^ associated item not found in `_`
+
+error: aborting due to 6 previous errors
+

--- a/src/test/ui/did_you_mean/bad-assoc-ty.rs
+++ b/src/test/ui/did_you_mean/bad-assoc-ty.rs
@@ -1,0 +1,31 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+type A = [u8; 4]::AssocTy;
+//~^ ERROR missing angle brackets in associated item path
+//~| ERROR ambiguous associated type
+
+type B = [u8]::AssocTy;
+//~^ ERROR missing angle brackets in associated item path
+//~| ERROR ambiguous associated type
+
+type C = (u8)::AssocTy;
+//~^ ERROR missing angle brackets in associated item path
+//~| ERROR ambiguous associated type
+
+type D = (u8, u8)::AssocTy;
+//~^ ERROR missing angle brackets in associated item path
+//~| ERROR ambiguous associated type
+
+type E = _::AssocTy;
+//~^ ERROR missing angle brackets in associated item path
+//~| ERROR the type placeholder `_` is not allowed within types on item signatures
+
+fn main() {}

--- a/src/test/ui/did_you_mean/bad-assoc-ty.stderr
+++ b/src/test/ui/did_you_mean/bad-assoc-ty.stderr
@@ -1,0 +1,70 @@
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-ty.rs:11:10
+   |
+11 | type A = [u8; 4]::AssocTy;
+   |          ^^^^^^^^^^^^^^^^ help: try: `<[u8; 4]>::AssocTy`
+
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-ty.rs:15:10
+   |
+15 | type B = [u8]::AssocTy;
+   |          ^^^^^^^^^^^^^ help: try: `<[u8]>::AssocTy`
+
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-ty.rs:19:10
+   |
+19 | type C = (u8)::AssocTy;
+   |          ^^^^^^^^^^^^^ help: try: `<(u8)>::AssocTy`
+
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-ty.rs:23:10
+   |
+23 | type D = (u8, u8)::AssocTy;
+   |          ^^^^^^^^^^^^^^^^^ help: try: `<(u8, u8)>::AssocTy`
+
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-ty.rs:27:10
+   |
+27 | type E = _::AssocTy;
+   |          ^^^^^^^^^^ help: try: `<_>::AssocTy`
+
+error[E0223]: ambiguous associated type
+  --> $DIR/bad-assoc-ty.rs:11:10
+   |
+11 | type A = [u8; 4]::AssocTy;
+   |          ^^^^^^^^^^^^^^^^ ambiguous associated type
+   |
+   = note: specify the type using the syntax `<[u8; <unevaluated[]>] as Trait>::AssocTy`
+
+error[E0223]: ambiguous associated type
+  --> $DIR/bad-assoc-ty.rs:15:10
+   |
+15 | type B = [u8]::AssocTy;
+   |          ^^^^^^^^^^^^^ ambiguous associated type
+   |
+   = note: specify the type using the syntax `<[u8] as Trait>::AssocTy`
+
+error[E0223]: ambiguous associated type
+  --> $DIR/bad-assoc-ty.rs:19:10
+   |
+19 | type C = (u8)::AssocTy;
+   |          ^^^^^^^^^^^^^ ambiguous associated type
+   |
+   = note: specify the type using the syntax `<u8 as Trait>::AssocTy`
+
+error[E0223]: ambiguous associated type
+  --> $DIR/bad-assoc-ty.rs:23:10
+   |
+23 | type D = (u8, u8)::AssocTy;
+   |          ^^^^^^^^^^^^^^^^^ ambiguous associated type
+   |
+   = note: specify the type using the syntax `<(u8, u8) as Trait>::AssocTy`
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/bad-assoc-ty.rs:27:10
+   |
+27 | type E = _::AssocTy;
+   |          ^ not allowed in type signatures
+
+error: aborting due to 10 previous errors
+


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/pull/44970
Fixes https://github.com/rust-lang/rust/issues/42187
r? @estebank 