### PR TITLE
Distribute intrinsic.natvis with the compiler for windows-msvc.

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -504,6 +504,7 @@ impl Step for DebuggerScripts {
             install(&build.src.join("src/etc/rust-windbg.cmd"), &sysroot.join("bin"),
                 0o755);
 
+            cp_debugger_script("natvis/intrinsic.natvis");
             cp_debugger_script("natvis/liballoc.natvis");
             cp_debugger_script("natvis/libcore.natvis");
         } else {

--- a/src/etc/rust-windbg.cmd
+++ b/src/etc/rust-windbg.cmd
@@ -15,4 +15,4 @@ for /f "delims=" %%i in ('rustc --print=sysroot') do set rustc_sysroot=%%i
 
 set rust_etc=%rustc_sysroot%\lib\rustlib\etc
 
-windbg -c ".nvload %rust_etc%\liballoc.natvis; .nvload %rust_etc%\libcore.natvis;" %*
+windbg -c ".nvload %rust_etc%\intrinsic.natvis; .nvload %rust_etc%\liballoc.natvis; .nvload %rust_etc%\libcore.natvis;" %*


### PR DESCRIPTION
This adds `intrinsic.natvis` to the `windows-msvc` distributions of Rust, enabling the visualization of `str` and slices in the VS debugger. Two other natvis files are already included, this was probably just an oversight.

I also updated `rust-windbg.cmd` to load this file as well.