### PR TITLE
Implement fixed-size-buffer constructors for CString

### DIFF
--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -419,7 +419,7 @@ impl CString {
     ///
     /// No bytes past the end of the buffer will be accessed even if no null terminator
     /// is found.
-    /// 
+    ///
     /// Since the data is copied, the buffer may be freed once this function returns.
     ///
     /// # Examples
@@ -428,7 +428,7 @@ impl CString {
     ///
     /// ```no_run
     /// #![feature(cstr_of_fixed_size)]
-    /// 
+    ///
     /// use std::ffi::CString;
     /// use std::os::raw::c_char;
     /// use std::mem;
@@ -461,7 +461,7 @@ impl CString {
     ///
     /// ```no_run
     /// #![feature(cstr_of_fixed_size)]
-    /// 
+    ///
     /// use std::ffi::CString;
     /// use std::os::raw::c_char;
     /// use std::mem;
@@ -484,7 +484,7 @@ impl CString {
     }
 
     /// Creates a new C-compatible string from a container of bytes.
-    /// 
+    ///
     /// The string is terminated at the first null byte present within the
     /// container.
     ///
@@ -494,7 +494,7 @@ impl CString {
     ///
     /// ```no_run
     /// #![feature(cstr_of_fixed_size)]
-    /// 
+    ///
     /// use std::ffi::CString;
     /// use std::os::raw::c_char;
     ///

--- a/src/libstd/sys/redox/mod.rs
+++ b/src/libstd/sys/redox/mod.rs
@@ -12,7 +12,7 @@
 
 use io::{self, ErrorKind};
 
-pub use libc::strlen;
+pub use libc::{strlen, strnlen};
 pub use self::rand::hashmap_random_keys;
 
 pub mod args;

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -30,7 +30,7 @@ use libc;
 #[cfg(all(not(dox), target_os = "l4re"))]      pub use os::linux as platform;
 
 pub use self::rand::hashmap_random_keys;
-pub use libc::strlen;
+pub use libc::{strlen, strnlen};
 
 #[macro_use]
 pub mod weak;

--- a/src/libstd/sys/wasm/mod.rs
+++ b/src/libstd/sys/wasm/mod.rs
@@ -90,6 +90,15 @@ pub unsafe fn strlen(mut s: *const c_char) -> usize {
     return n
 }
 
+pub unsafe fn strnlen(mut s: *const c_char, maxlen: usize) -> usize {
+    let mut n = 0;
+    while n < maxlen && *s != 0 {
+        n += 1;
+        s = s.offset(1);
+    }
+    return n
+}
+
 pub unsafe fn abort_internal() -> ! {
     ::intrinsics::abort();
 }

--- a/src/libstd/sys/windows/mod.rs
+++ b/src/libstd/sys/windows/mod.rs
@@ -17,7 +17,7 @@ use os::windows::ffi::{OsStrExt, OsStringExt};
 use path::PathBuf;
 use time::Duration;
 
-pub use libc::strlen;
+pub use libc::{strlen, strnlen};
 pub use self::rand::hashmap_random_keys;
 
 #[macro_use] pub mod compat;


### PR DESCRIPTION
Fixes #20475

I added three variants. Not sure about naming/whether we necessarily need all three.

```rust
impl CString {
    // Copy from raw C-style buffer into new CString
    unsafe fn of_fixed_size_raw(ptr: *const c_char, maxlen: usize) -> CString;

    // Copy from byte slice into new CString
    fn of_fixed_size(slice: &[u8]) -> CString;

    // Convert owned byte buffer into CString
    fn from_fixed_size<T: Into<Vec<u8>>>(vec: T) -> CString;
}
```

For comparison, the existing constructors are:

```rust
impl CString {
    // Input must not contain \0
    fn new<T: Into<Vec<u8>>>(t: T) -> Result<CString, NulError>;
    unsafe fn from_vec_unchecked(v: Vec<u8>) -> CString;

    // Must have come from CString::into_raw
    unsafe fn from_raw(ptr: *mut c_char) -> CString;
}
```

r? @dtolnay 