### PR TITLE
Fix the wrong subtraction in align_offset intrinsic.

### DIFF
--- a/src/librustc_trans/intrinsic.rs
+++ b/src/librustc_trans/intrinsic.rs
@@ -406,8 +406,8 @@ pub fn trans_intrinsic_call<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
             let zero = C_null(bcx.ccx.isize_ty());
             // `offset == 0`
             let is_zero = bcx.icmp(llvm::IntPredicate::IntEQ, offset, zero);
-            // `if offset == 0 { 0 } else { offset - align }`
-            bcx.select(is_zero, zero, bcx.sub(offset, align))
+            // `if offset == 0 { 0 } else { align - offset }`
+            bcx.select(is_zero, zero, bcx.sub(align, offset))
         }
         name if name.starts_with("simd_") => {
             match generic_simd_intrinsic(bcx, name,

--- a/src/test/run-pass/align-offset-sign.rs
+++ b/src/test/run-pass/align-offset-sign.rs
@@ -1,0 +1,16 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(align_offset)]
+
+fn main() {
+    let x = 1 as *const u8;
+    assert_eq!(x.align_offset(8), 7);
+}


### PR DESCRIPTION
Given how the stage0 implementation in #43903 is written, as well as that in the RFC, I suppose the current implementation has a typo.

cc #44488, cc @oli-obk.