### PR TITLE
Prevent rustc overwriting input files

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -237,20 +237,6 @@ pub fn run_compiler<'a>(args: &[String],
     rustc_trans::init(&sess);
     rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
 
-    // Ensure the source file isn't accidentally overwritten during compilation.
-    match input_file_path {
-        Some(input_file_path) => {
-            if driver::build_output_filenames(&input, &odir, &ofile, &[], &sess)
-                .contains_path(&input_file_path) && sess.opts.will_create_output_file() {
-                sess.err(&format!(
-                    "the input file \"{}\" would be overwritten by the generated executable",
-                    input_file_path.display()));
-                return (Err(CompileIncomplete::Stopped), Some(sess));
-            }
-        },
-        None => {}
-    }
-
     let mut cfg = config::build_configuration(&sess, cfg);
     target_features::add_configuration(&mut cfg, &sess);
     sess.parse_sess.config = cfg;
@@ -266,6 +252,7 @@ pub fn run_compiler<'a>(args: &[String],
     let control = callbacks.build_controller(&sess, &matches);
     (driver::compile_input(&sess,
                            &cstore,
+                           &input_file_path,
                            &input,
                            &odir,
                            &ofile,

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -263,7 +263,7 @@ fn run_test(test: &str, cratename: &str, filename: &FileName, cfgs: Vec<String>,
     }
 
     let res = panic::catch_unwind(AssertUnwindSafe(|| {
-        driver::compile_input(&sess, &cstore, &input, &out, &None, None, &control)
+        driver::compile_input(&sess, &cstore, &None, &input, &out, &None, None, &control)
     }));
 
     let compile_result = match res {

--- a/src/test/run-make/issue-19371/foo.rs
+++ b/src/test/run-make/issue-19371/foo.rs
@@ -71,5 +71,5 @@ fn compile(code: String, output: PathBuf, sysroot: PathBuf) {
     let (sess, cstore) = basic_sess(sysroot);
     let control = CompileController::basic();
     let input = Input::Str { name: FileName::Anon, input: code };
-    let _ = compile_input(&sess, &cstore, &input, &None, &Some(output), None, &control);
+    let _ = compile_input(&sess, &cstore, &None, &input, &None, &Some(output), None, &control);
 }

--- a/src/test/run-make/output-filename-overwrites-input/Makefile
+++ b/src/test/run-make/output-filename-overwrites-input/Makefile
@@ -1,0 +1,10 @@
+-include ../tools.mk
+
+all:
+	cp foo.rs $(TMPDIR)/foo
+	$(RUSTC) $(TMPDIR)/foo 2>&1 \
+		| $(CGREP) -e "the input file \".*foo\" would be overwritten by the generated executable"
+	$(RUSTC) foo.rs 2>&1 && $(RUSTC) -Z ls $(TMPDIR)/foo 2>&1
+	cp foo.rs $(TMPDIR)/foo.rs
+	$(RUSTC) $(TMPDIR)/foo.rs -o $(TMPDIR)/foo.rs 2>&1 \
+		| $(CGREP) -e "the input file \".*foo.rs\" would be overwritten by the generated executable"

--- a/src/test/run-make/output-filename-overwrites-input/foo.rs
+++ b/src/test/run-make/output-filename-overwrites-input/foo.rs
@@ -1,0 +1,11 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {}

--- a/src/test/run-make/weird-output-filenames/Makefile
+++ b/src/test/run-make/weird-output-filenames/Makefile
@@ -7,8 +7,8 @@ all:
 	cp foo.rs $(TMPDIR)/.foo.bar
 	$(RUSTC) $(TMPDIR)/.foo.bar 2>&1 \
 		| $(CGREP) -e "invalid character.*in crate name:"
-	cp foo.rs $(TMPDIR)/+foo+bar
-	$(RUSTC) $(TMPDIR)/+foo+bar 2>&1 \
+	cp foo.rs $(TMPDIR)/+foo+bar.rs
+	$(RUSTC) $(TMPDIR)/+foo+bar.rs 2>&1 \
 		| $(CGREP) -e "invalid character.*in crate name:"
 	cp foo.rs $(TMPDIR)/-foo.rs
 	$(RUSTC) $(TMPDIR)/-foo.rs 2>&1 \


### PR DESCRIPTION
If rustc is invoked on a file that would be overwritten by the
compilation, the compilation now fails, to avoid accidental loss. This
resolves #13019. Kudos to @estebank, whose patch I finished off.