### PR TITLE
WIP: Whitelist based suggestions

### DIFF
--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -70,6 +70,7 @@ pub struct NoMatchData<'tcx> {
     pub static_candidates: Vec<CandidateSource>,
     pub unsatisfied_predicates: Vec<TraitRef<'tcx>>,
     pub out_of_scope_traits: Vec<DefId>,
+    pub whitelist_candidate: Option<ty::AssociatedItem>,
     pub lev_candidate: Option<ty::AssociatedItem>,
     pub mode: probe::Mode,
 }
@@ -78,6 +79,7 @@ impl<'tcx> NoMatchData<'tcx> {
     pub fn new(static_candidates: Vec<CandidateSource>,
                unsatisfied_predicates: Vec<TraitRef<'tcx>>,
                out_of_scope_traits: Vec<DefId>,
+               whitelist_candidate: Option<ty::AssociatedItem>,
                lev_candidate: Option<ty::AssociatedItem>,
                mode: probe::Mode)
                -> Self {
@@ -85,6 +87,7 @@ impl<'tcx> NoMatchData<'tcx> {
             static_candidates,
             unsatisfied_predicates,
             out_of_scope_traits,
+            whitelist_candidate,
             lev_candidate,
             mode,
         }

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -164,6 +164,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             MethodError::NoMatch(NoMatchData { static_candidates: static_sources,
                                                unsatisfied_predicates,
                                                out_of_scope_traits,
+                                               whitelist_candidate,
                                                lev_candidate,
                                                mode,
                                                .. }) => {
@@ -284,7 +285,9 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                               rcvr_expr,
                                               out_of_scope_traits);
 
-                if let Some(lev_candidate) = lev_candidate {
+                if let Some(whitelist_candidate) = whitelist_candidate {
+                    err.help(&format!("did you mean `{}`?", whitelist_candidate.name));
+                } else if let Some(lev_candidate) = lev_candidate {
                     err.help(&format!("did you mean `{}`?", lev_candidate.name));
                 }
                 err.emit();

--- a/src/test/ui/suggestions/suggest-methods-whitelist.rs
+++ b/src/test/ui/suggestions/suggest-methods-whitelist.rs
@@ -1,0 +1,15 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let v = vec![1u8, 2u8];
+    let length = v.length();
+    let size = v.size();
+}

--- a/src/test/ui/suggestions/suggest-methods-whitelist.stderr
+++ b/src/test/ui/suggestions/suggest-methods-whitelist.stderr
@@ -1,0 +1,18 @@
+error[E0599]: no method named `length` found for type `std::vec::Vec<u8>` in the current scope
+  --> $DIR/suggest-methods-whitelist.rs:13:20
+   |
+13 |     let length = v.length();
+   |                    ^^^^^^
+   |
+   = help: did you mean `len`?
+
+error[E0599]: no method named `size` found for type `std::vec::Vec<u8>` in the current scope
+  --> $DIR/suggest-methods-whitelist.rs:14:18
+   |
+14 |     let size = v.size();
+   |                  ^^^^
+   |
+   = help: did you mean `len`?
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
This is my first rustc contribution, so if I overlooked some process let me know :)

It's an attempt at implementing a suggestion system that can do things like suggesting `.len()` if someone used `.length()` or `.size()` on a type, given that the former does exist and the latter does not.

If this feature itself is not desired for some reason, feel free to let me know. I feel that compiler hints are useful in this case though, and some common cases are not caught by the levenshtein suggestions.

This pull request is work in progress, because I'm not sure I'm doing it the right way.

- Is this feature something that might be considered for merging or not?
- Is this the right place to implement the feature?
- Can you come up with a better name than "whitelist suggestions"? I feel it's a bad name.
- Are there any internals docs on how to find a list of existing methods on a type?

I'd be happy about some pointers. Thanks a lot :)