### PR TITLE
Base the SVH on source file hashes instead of more expensive HIR hashes.

### DIFF
--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -1061,6 +1061,8 @@ pub fn map_crate<'hir>(sess: &::session::Session,
         let cmdline_args = sess.opts.dep_tracking_hash();
         collector.finalize_and_compute_crate_hash(crate_disambiguator,
                                                   cstore,
+                                                  sess.codemap(),
+                                                  &sess.parse_sess.config,
                                                   cmdline_args)
     };
 

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -35,7 +35,7 @@ use syntax_pos::{Span, DUMMY_SP};
 use syntax::codemap::{self, Spanned};
 use syntax::abi::Abi;
 use syntax::ast::{Ident, Name, NodeId, DUMMY_NODE_ID, AsmDialect};
-use syntax::ast::{Attribute, Lit, StrStyle, FloatTy, IntTy, UintTy, MetaItem};
+use syntax::ast::{Attribute, Lit, StrStyle, FloatTy, IntTy, UintTy};
 use syntax::ext::hygiene::SyntaxContext;
 use syntax::ptr::P;
 use syntax::symbol::{Symbol, keywords};
@@ -512,8 +512,6 @@ pub struct WhereEqPredicate {
     pub lhs_ty: P<Ty>,
     pub rhs_ty: P<Ty>,
 }
-
-pub type CrateConfig = HirVec<P<MetaItem>>;
 
 /// The top-level data structure that stores the entire contents of
 /// the crate currently being compiled.


### PR DESCRIPTION
As per discussion in #46810, this PR bases the SVH on direct hashes of the source code instead of hashing the HIR. The `--cfg` flags also have to be hashed because they affect which part of the source is active. This should make non-incremental builds cheaper immediately and paves the way for some optimizations in the incr. comp. tracking system.

r? @eddyb 