### PR TITLE
syntax: Follow-up to the incorrect qpath recovery PR

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1467,7 +1467,7 @@ impl<'a> Parser<'a> {
 
     // Parse a type
     pub fn parse_ty(&mut self) -> PResult<'a, P<Ty>> {
-        self.parse_ty_common(true)
+        self.parse_ty_common(true, true)
     }
 
     /// Parse a type in restricted contexts where `+` is not permitted.
@@ -1476,10 +1476,11 @@ impl<'a> Parser<'a> {
     /// Example 2: `value1 as TYPE + value2`
     ///     `+` is prohibited to avoid interactions with expression grammar.
     fn parse_ty_no_plus(&mut self) -> PResult<'a, P<Ty>> {
-        self.parse_ty_common(false)
+        self.parse_ty_common(false, true)
     }
 
-    fn parse_ty_common(&mut self, allow_plus: bool) -> PResult<'a, P<Ty>> {
+    fn parse_ty_common(&mut self, allow_plus: bool, allow_qpath_recovery: bool)
+                       -> PResult<'a, P<Ty>> {
         maybe_whole!(self, NtTy, |x| x);
 
         let lo = self.span;
@@ -1612,7 +1613,7 @@ impl<'a> Parser<'a> {
 
         // Try to recover from use of `+` with incorrect priority.
         self.maybe_recover_from_bad_type_plus(allow_plus, &ty)?;
-        let ty = self.maybe_recover_from_bad_qpath(ty)?;
+        let ty = self.maybe_recover_from_bad_qpath(ty, allow_qpath_recovery)?;
 
         Ok(P(ty))
     }
@@ -1668,9 +1669,10 @@ impl<'a> Parser<'a> {
     }
 
     // Try to recover from associated item paths like `[T]::AssocItem`/`(T, U)::AssocItem`.
-    fn maybe_recover_from_bad_qpath<T: RecoverQPath>(&mut self, base: T) -> PResult<'a, T> {
+    fn maybe_recover_from_bad_qpath<T: RecoverQPath>(&mut self, base: T, allow_recovery: bool)
+                                                     -> PResult<'a, T> {
         // Do not add `::` to expected tokens.
-        if self.token != token::ModSep {
+        if !allow_recovery || self.token != token::ModSep {
             return Ok(base);
         }
         let ty = match base.to_ty() {
@@ -2004,7 +2006,7 @@ impl<'a> Parser<'a> {
                     |p| p.parse_ty())?;
                 self.bump(); // `)`
                 let output = if self.eat(&token::RArrow) {
-                    Some(self.parse_ty_no_plus()?)
+                    Some(self.parse_ty_common(false, false)?)
                 } else {
                     None
                 };
@@ -2411,7 +2413,7 @@ impl<'a> Parser<'a> {
         }
 
         let expr = Expr { node: ex, span: lo.to(hi), id: ast::DUMMY_NODE_ID, attrs };
-        let expr = self.maybe_recover_from_bad_qpath(expr)?;
+        let expr = self.maybe_recover_from_bad_qpath(expr, true)?;
 
         return Ok(P(expr));
     }
@@ -3778,7 +3780,7 @@ impl<'a> Parser<'a> {
         }
 
         let pat = Pat { node: pat, span: lo.to(self.prev_span), id: ast::DUMMY_NODE_ID };
-        let pat = self.maybe_recover_from_bad_qpath(pat)?;
+        let pat = self.maybe_recover_from_bad_qpath(pat, true)?;
 
         Ok(P(pat))
     }

--- a/src/test/ui/did_you_mean/bad-assoc-expr.rs
+++ b/src/test/ui/did_you_mean/bad-assoc-expr.rs
@@ -21,4 +21,10 @@ fn main() {
 
     (u8, u8)::clone(&(0, 0));
     //~^ ERROR missing angle brackets in associated item path
+
+    &(u8)::clone(&0);
+    //~^ ERROR missing angle brackets in associated item path
+
+    10 + (u8)::clone(&0);
+    //~^ ERROR missing angle brackets in associated item path
 }

--- a/src/test/ui/did_you_mean/bad-assoc-expr.stderr
+++ b/src/test/ui/did_you_mean/bad-assoc-expr.stderr
@@ -22,5 +22,17 @@ error: missing angle brackets in associated item path
 22 |     (u8, u8)::clone(&(0, 0));
    |     ^^^^^^^^^^^^^^^ help: try: `<(u8, u8)>::clone`
 
-error: aborting due to 4 previous errors
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-expr.rs:25:6
+   |
+25 |     &(u8)::clone(&0);
+   |      ^^^^^^^^^^^ help: try: `<(u8)>::clone`
+
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-expr.rs:28:10
+   |
+28 |     10 + (u8)::clone(&0);
+   |          ^^^^^^^^^^^ help: try: `<(u8)>::clone`
+
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/did_you_mean/bad-assoc-pat.rs
+++ b/src/test/ui/did_you_mean/bad-assoc-pat.rs
@@ -20,4 +20,9 @@ fn main() {
         //~^ ERROR missing angle brackets in associated item path
         //~| ERROR no associated item named `AssocItem` found for type `_` in the current scope
     }
+    match &0u8 {
+        &(u8,)::AssocItem => {}
+        //~^ ERROR missing angle brackets in associated item path
+        //~| ERROR no associated item named `AssocItem` found for type `(u8,)` in the current scope
+    }
 }

--- a/src/test/ui/did_you_mean/bad-assoc-pat.stderr
+++ b/src/test/ui/did_you_mean/bad-assoc-pat.stderr
@@ -16,6 +16,12 @@ error: missing angle brackets in associated item path
 19 |         _::AssocItem => {}
    |         ^^^^^^^^^^^^ help: try: `<_>::AssocItem`
 
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-pat.rs:24:10
+   |
+24 |         &(u8,)::AssocItem => {}
+   |          ^^^^^^^^^^^^^^^^ help: try: `<(u8,)>::AssocItem`
+
 error[E0599]: no associated item named `AssocItem` found for type `[u8]` in the current scope
   --> $DIR/bad-assoc-pat.rs:13:9
    |
@@ -34,5 +40,11 @@ error[E0599]: no associated item named `AssocItem` found for type `_` in the cur
 19 |         _::AssocItem => {}
    |         ^^^^^^^^^^^^ associated item not found in `_`
 
-error: aborting due to 6 previous errors
+error[E0599]: no associated item named `AssocItem` found for type `(u8,)` in the current scope
+  --> $DIR/bad-assoc-pat.rs:24:10
+   |
+24 |         &(u8,)::AssocItem => {}
+   |          ^^^^^^^^^^^^^^^^ associated item not found in `(u8,)`
+
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/did_you_mean/bad-assoc-ty.rs
+++ b/src/test/ui/did_you_mean/bad-assoc-ty.rs
@@ -28,4 +28,21 @@ type E = _::AssocTy;
 //~^ ERROR missing angle brackets in associated item path
 //~| ERROR the type placeholder `_` is not allowed within types on item signatures
 
+type F = &'static (u8)::AssocTy;
+//~^ ERROR missing angle brackets in associated item path
+//~| ERROR ambiguous associated type
+
+// Qualified paths cannot appear in bounds, so the recovery
+// should apply to the whole sum and not `(Send)`.
+type G = 'static + (Send)::AssocTy;
+//~^ ERROR missing angle brackets in associated item path
+//~| ERROR ambiguous associated type
+
+// FIXME
+// This is actually a legal path with fn-like generic arguments in the middle!
+// Recovery should not apply in this context.
+type H = Fn(u8) -> (u8)::Output;
+//~^ ERROR missing angle brackets in associated item path
+//~| ERROR ambiguous associated type
+
 fn main() {}

--- a/src/test/ui/did_you_mean/bad-assoc-ty.rs
+++ b/src/test/ui/did_you_mean/bad-assoc-ty.rs
@@ -38,11 +38,9 @@ type G = 'static + (Send)::AssocTy;
 //~^ ERROR missing angle brackets in associated item path
 //~| ERROR ambiguous associated type
 
-// FIXME
 // This is actually a legal path with fn-like generic arguments in the middle!
 // Recovery should not apply in this context.
 type H = Fn(u8) -> (u8)::Output;
-//~^ ERROR missing angle brackets in associated item path
-//~| ERROR ambiguous associated type
+//~^ ERROR ambiguous associated type
 
 fn main() {}

--- a/src/test/ui/did_you_mean/bad-assoc-ty.stderr
+++ b/src/test/ui/did_you_mean/bad-assoc-ty.stderr
@@ -38,13 +38,7 @@ error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-ty.rs:37:10
    |
 37 | type G = 'static + (Send)::AssocTy;
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `< 'static + Send>::AssocTy`
-
-error: missing angle brackets in associated item path
-  --> $DIR/bad-assoc-ty.rs:44:20
-   |
-44 | type H = Fn(u8) -> (u8)::Output;
-   |                    ^^^^^^^^^^^^ help: try: `<(u8)>::Output`
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `<'static + Send>::AssocTy`
 
 error[E0223]: ambiguous associated type
   --> $DIR/bad-assoc-ty.rs:11:10
@@ -101,12 +95,12 @@ error[E0223]: ambiguous associated type
    = note: specify the type using the syntax `<std::marker::Send + 'static as Trait>::AssocTy`
 
 error[E0223]: ambiguous associated type
-  --> $DIR/bad-assoc-ty.rs:44:20
+  --> $DIR/bad-assoc-ty.rs:43:10
    |
-44 | type H = Fn(u8) -> (u8)::Output;
-   |                    ^^^^^^^^^^^^ ambiguous associated type
+43 | type H = Fn(u8) -> (u8)::Output;
+   |          ^^^^^^^^^^^^^^^^^^^^^^ ambiguous associated type
    |
-   = note: specify the type using the syntax `<u8 as Trait>::Output`
+   = note: specify the type using the syntax `<std::ops::Fn(u8) -> u8 + 'static as Trait>::Output`
 
-error: aborting due to 16 previous errors
+error: aborting due to 15 previous errors
 

--- a/src/test/ui/did_you_mean/bad-assoc-ty.stderr
+++ b/src/test/ui/did_you_mean/bad-assoc-ty.stderr
@@ -28,6 +28,24 @@ error: missing angle brackets in associated item path
 27 | type E = _::AssocTy;
    |          ^^^^^^^^^^ help: try: `<_>::AssocTy`
 
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-ty.rs:31:19
+   |
+31 | type F = &'static (u8)::AssocTy;
+   |                   ^^^^^^^^^^^^^ help: try: `<(u8)>::AssocTy`
+
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-ty.rs:37:10
+   |
+37 | type G = 'static + (Send)::AssocTy;
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `< 'static + Send>::AssocTy`
+
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-ty.rs:44:20
+   |
+44 | type H = Fn(u8) -> (u8)::Output;
+   |                    ^^^^^^^^^^^^ help: try: `<(u8)>::Output`
+
 error[E0223]: ambiguous associated type
   --> $DIR/bad-assoc-ty.rs:11:10
    |
@@ -66,5 +84,29 @@ error[E0121]: the type placeholder `_` is not allowed within types on item signa
 27 | type E = _::AssocTy;
    |          ^ not allowed in type signatures
 
-error: aborting due to 10 previous errors
+error[E0223]: ambiguous associated type
+  --> $DIR/bad-assoc-ty.rs:31:19
+   |
+31 | type F = &'static (u8)::AssocTy;
+   |                   ^^^^^^^^^^^^^ ambiguous associated type
+   |
+   = note: specify the type using the syntax `<u8 as Trait>::AssocTy`
+
+error[E0223]: ambiguous associated type
+  --> $DIR/bad-assoc-ty.rs:37:10
+   |
+37 | type G = 'static + (Send)::AssocTy;
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^ ambiguous associated type
+   |
+   = note: specify the type using the syntax `<std::marker::Send + 'static as Trait>::AssocTy`
+
+error[E0223]: ambiguous associated type
+  --> $DIR/bad-assoc-ty.rs:44:20
+   |
+44 | type H = Fn(u8) -> (u8)::Output;
+   |                    ^^^^^^^^^^^^ ambiguous associated type
+   |
+   = note: specify the type using the syntax `<u8 as Trait>::Output`
+
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/pull/46788

Add tests checking that "priority" of qpath recovery is higher than priority of unary and binary operators
Fix regressed parsing of paths with fn-like generic arguments
r? @estebank 