### PR TITLE
Add Hash impl for SystemTime and Instant

### DIFF
--- a/src/libstd/sys/redox/time.rs
+++ b/src/libstd/sys/redox/time.rs
@@ -13,6 +13,7 @@ use fmt;
 use sys::{cvt, syscall};
 use time::Duration;
 use convert::TryInto;
+use core::hash::{Hash, Hasher};
 
 const NSEC_PER_SEC: u64 = 1_000_000_000;
 
@@ -110,12 +111,19 @@ impl Ord for Timespec {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+impl Hash for Timespec {
+    fn hash<H : Hasher>(&self, state: &mut H) {
+        self.t.tv_sec.hash(state);
+        self.t.tv_nsec.hash(state);
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Instant {
     t: Timespec,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SystemTime {
     t: Timespec,
 }

--- a/src/libstd/sys/unix/time.rs
+++ b/src/libstd/sys/unix/time.rs
@@ -11,6 +11,7 @@
 use cmp::Ordering;
 use libc;
 use time::Duration;
+use core::hash::{Hash, Hasher};
 
 pub use self::inner::{Instant, SystemTime, UNIX_EPOCH};
 use convert::TryInto;
@@ -111,6 +112,13 @@ impl Ord for Timespec {
     }
 }
 
+impl Hash for Timespec {
+    fn hash<H : Hasher>(&self, state: &mut H) {
+        self.t.tv_sec.hash(state);
+        self.t.tv_nsec.hash(state);
+    }
+}
+
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 mod inner {
     use fmt;
@@ -123,12 +131,12 @@ mod inner {
     use super::NSEC_PER_SEC;
     use super::Timespec;
 
-    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
     pub struct Instant {
         t: u64
     }
 
-    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct SystemTime {
         t: Timespec,
     }
@@ -255,12 +263,12 @@ mod inner {
 
     use super::Timespec;
 
-    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct Instant {
         t: Timespec,
     }
 
-    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct SystemTime {
         t: Timespec,
     }

--- a/src/libstd/sys/wasm/time.rs
+++ b/src/libstd/sys/wasm/time.rs
@@ -11,10 +11,10 @@
 use fmt;
 use time::Duration;
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub struct Instant;
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SystemTime;
 
 pub const UNIX_EPOCH: SystemTime = SystemTime;

--- a/src/libstd/sys/windows/time.rs
+++ b/src/libstd/sys/windows/time.rs
@@ -17,11 +17,12 @@ use sys::cvt;
 use sys_common::mul_div_u64;
 use time::Duration;
 use convert::TryInto;
+use core::hash::{Hash, Hasher};
 
 const NANOS_PER_SEC: u64 = 1_000_000_000;
 const INTERVALS_PER_SEC: u64 = NANOS_PER_SEC / 100;
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub struct Instant {
     t: c::LARGE_INTEGER,
 }
@@ -170,6 +171,12 @@ impl fmt::Debug for SystemTime {
 impl From<c::FILETIME> for SystemTime {
     fn from(t: c::FILETIME) -> SystemTime {
         SystemTime { t: t }
+    }
+}
+
+impl Hash for SystemTime {
+    fn hash<H : Hasher>(&self, state: &mut H) {
+        self.intervals().hash(state)
     }
 }
 

--- a/src/libstd/time/mod.rs
+++ b/src/libstd/time/mod.rs
@@ -66,7 +66,7 @@ mod duration;
 ///    println!("{}", now.elapsed().as_secs());
 /// }
 /// ```
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[stable(feature = "time2", since = "1.8.0")]
 pub struct Instant(time::Instant);
 
@@ -118,7 +118,7 @@ pub struct Instant(time::Instant);
 ///    }
 /// }
 /// ```
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[stable(feature = "time2", since = "1.8.0")]
 pub struct SystemTime(time::SystemTime);
 


### PR DESCRIPTION
Closes #46670.

Not sure how to actually test non-Linux platforms. 
`rustc --target=i686-pc-windows-gnu --crate-name std --crate-type rlib src/libstd/lib.rs -o q.rlib` works a bit, but for Redox I'm not sure what to do.

r? @dtolnay