### PR TITLE
Remove a token after closing delimiter from the span of macro in type position

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1553,7 +1553,7 @@ impl<'a> Parser<'a> {
             if self.eat(&token::Not) {
                 // Macro invocation in type position
                 let (_, tts) = self.expect_delimited_token_tree()?;
-                TyKind::Mac(respan(lo.to(self.span), Mac_ { path: path, tts: tts }))
+                TyKind::Mac(respan(lo.to(self.prev_span), Mac_ { path: path, tts: tts }))
             } else {
                 // Just a type path or bound list (trait object type) starting with a trait.
                 //   `Type`

--- a/src/test/ui/issue-32950.stderr
+++ b/src/test/ui/issue-32950.stderr
@@ -1,9 +1,8 @@
 error: `derive` cannot be used on items with type macros
   --> $DIR/issue-32950.rs:15:5
    |
-15 | /     concat_idents!(Foo, Bar) //~ ERROR `derive` cannot be used on items with type macros
-16 | | );
-   | |_^
+15 |     concat_idents!(Foo, Bar) //~ ERROR `derive` cannot be used on items with type macros
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
e.g.
```rust
let x = y: foo!();
```
The span for `foo!()` includes `;`.

cc https://github.com/rust-lang-nursery/rustfmt/issues/2290.