### PR TITLE
Followup for #46112.

### DIFF
--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -305,7 +305,18 @@ pub fn provide<'tcx>(providers: &mut Providers<'tcx>) {
             // whatever crate we happened to encounter first in this
             // traversal, but not globally minimal across all crates.
             let bfs_queue = &mut VecDeque::new();
-            for &cnum in tcx.crates().iter() {
+
+            // Preferring shortest paths alone does not guarantee a
+            // deterministic result; so sort by crate num to avoid
+            // hashtable iteration non-determinism. This only makes
+            // things as deterministic as crate-nums assignment is,
+            // which is to say, its not deterministic in general. But
+            // we believe that libstd is consistently assigned crate
+            // num 1, so it should be enough to resolve #46112.
+            let mut crates: Vec<CrateNum> = (*tcx.crates()).clone();
+            crates.sort();
+
+            for &cnum in crates.iter() {
                 // Ignore crates without a corresponding local `extern crate` item.
                 if tcx.missing_extern_crate_item(cnum) {
                     continue

--- a/src/test/compile-fail/auxiliary/issue_1920.rs
+++ b/src/test/compile-fail/auxiliary/issue_1920.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,15 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Test that when a crate is linked under another name that name is used in global paths
+// Just exporting some type to test for correct diagnostics when this
+// crate is pulled in at a non-root location in client crate.
 
-// aux-build:issue_1920.rs
-
-extern crate issue_1920 as bar;
-
-fn assert_clone<T>() where T : Clone { }
-
-fn main() {
-    assert_clone::<bar::S>();
-    //~^ ERROR `bar::S: std::clone::Clone` is not satisfied
-}
+pub struct S;

--- a/src/test/compile-fail/issue-17959.rs
+++ b/src/test/compile-fail/issue-17959.rs
@@ -19,7 +19,7 @@ struct G<T: ?Sized> {
 }
 
 impl<T> Drop for G<T> {
-//~^ ERROR: The requirement `T: core::marker::Sized` is added only by the Drop impl. [E0367]
+//~^ ERROR: The requirement `T: std::marker::Sized` is added only by the Drop impl. [E0367]
     fn drop(&mut self) {
         if !self._ptr.is_null() {
         }

--- a/src/test/compile-fail/issue-1920-1.rs
+++ b/src/test/compile-fail/issue-1920-1.rs
@@ -10,13 +10,15 @@
 
 //! Test that absolute path names are correct when a crate is not linked into the root namespace
 
+// aux-build:issue_1920.rs
+
 mod foo {
-    pub extern crate core;
+    pub extern crate issue_1920;
 }
 
 fn assert_clone<T>() where T : Clone { }
 
 fn main() {
-    assert_clone::<foo::core::sync::atomic::AtomicBool>();
-    //~^ ERROR `foo::core::sync::atomic::AtomicBool: foo::core::clone::Clone` is not satisfied
+    assert_clone::<foo::issue_1920::S>();
+    //~^ ERROR `foo::issue_1920::S: std::clone::Clone` is not satisfied
 }

--- a/src/test/compile-fail/issue-1920-3.rs
+++ b/src/test/compile-fail/issue-1920-3.rs
@@ -10,15 +10,17 @@
 
 //! Test that when a crate is linked multiple times that the shortest absolute path name is used
 
+// aux-build:issue_1920.rs
+
 mod foo {
-    pub extern crate core;
+    pub extern crate issue_1920;
 }
 
-extern crate core;
+extern crate issue_1920;
 
 fn assert_clone<T>() where T : Clone { }
 
 fn main() {
-    assert_clone::<foo::core::sync::atomic::AtomicBool>();
-    //~^ ERROR `core::sync::atomic::AtomicBool: core::clone::Clone` is not satisfied
+    assert_clone::<foo::issue_1920::S>();
+    //~^ ERROR `issue_1920::S: std::clone::Clone` is not satisfied
 }

--- a/src/test/compile-fail/kindck-send-unsafe.rs
+++ b/src/test/compile-fail/kindck-send-unsafe.rs
@@ -14,7 +14,7 @@ fn assert_send<T:Send>() { }
 
 fn test71<'a>() {
     assert_send::<*mut &'a isize>();
-    //~^ ERROR `*mut &'a isize: core::marker::Send` is not satisfied
+    //~^ ERROR `*mut &'a isize: std::marker::Send` is not satisfied
 }
 
 fn main() {

--- a/src/test/ui/print_type_sizes/niche-filling.stdout
+++ b/src/test/ui/print_type_sizes/niche-filling.stdout
@@ -69,11 +69,11 @@ print-type-size type: `MyOption<bool>`: 1 bytes, alignment: 1 bytes
 print-type-size     variant `None`: 0 bytes
 print-type-size     variant `Some`: 1 bytes
 print-type-size         field `.0`: 1 bytes
-print-type-size type: `MyOption<core::cmp::Ordering>`: 1 bytes, alignment: 1 bytes
+print-type-size type: `MyOption<std::cmp::Ordering>`: 1 bytes, alignment: 1 bytes
 print-type-size     variant `None`: 0 bytes
 print-type-size     variant `Some`: 1 bytes
 print-type-size         field `.0`: 1 bytes
-print-type-size type: `core::cmp::Ordering`: 1 bytes, alignment: 1 bytes
+print-type-size type: `std::cmp::Ordering`: 1 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Less`: 0 bytes
 print-type-size     variant `Equal`: 0 bytes


### PR DESCRIPTION
Sorting by crate-num should ensure that we favor `std::foo::bar` over
`any_other_crate::foo::bar`.

Interestingly, *this* change had a much larger impact on our internal
test suite than PR #46708 (which was my original fix to #46112).