### PR TITLE
incr.comp.: Precompute small hash for filenames to save some work.

### DIFF
--- a/src/librustc/ich/hcx.rs
+++ b/src/librustc/ich/hcx.rs
@@ -341,7 +341,7 @@ impl<'gcx> HashStable<StableHashingContext<'gcx>> for Span {
         std_hash::Hash::hash(&TAG_VALID_SPAN, hasher);
         // We truncate the stable_id hash and line and col numbers. The chances
         // of causing a collision this way should be minimal.
-        std_hash::Hash::hash(&file_lo.name, hasher);
+        std_hash::Hash::hash(&(file_lo.name_hash as u64), hasher);
 
         let col = (col_lo.0 as u64) & 0xFF;
         let line = ((line_lo as u64) & 0xFF_FF_FF) << 8;

--- a/src/librustc/ich/impls_syntax.rs
+++ b/src/librustc/ich/impls_syntax.rs
@@ -387,7 +387,8 @@ impl<'gcx> HashStable<StableHashingContext<'gcx>> for FileMap {
                                           hcx: &mut StableHashingContext<'gcx>,
                                           hasher: &mut StableHasher<W>) {
         let FileMap {
-            ref name,
+            name: _, // We hash the smaller name_hash instead of this
+            name_hash,
             name_was_remapped,
             unmapped_path: _,
             crate_of_origin,
@@ -402,7 +403,7 @@ impl<'gcx> HashStable<StableHashingContext<'gcx>> for FileMap {
             ref non_narrow_chars,
         } = *self;
 
-        name.hash_stable(hcx, hasher);
+        (name_hash as u64).hash_stable(hcx, hasher);
         name_was_remapped.hash_stable(hcx, hasher);
 
         DefId {

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -1129,6 +1129,7 @@ impl<'a, 'tcx> CrateMetadata {
                                       lines,
                                       multibyte_chars,
                                       non_narrow_chars,
+                                      name_hash,
                                       .. } = filemap_to_import;
 
             let source_length = (end_pos - start_pos).to_usize();
@@ -1155,6 +1156,7 @@ impl<'a, 'tcx> CrateMetadata {
                                                                    name_was_remapped,
                                                                    self.cnum.as_u32(),
                                                                    src_hash,
+                                                                   name_hash,
                                                                    source_length,
                                                                    lines,
                                                                    multibyte_chars,

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -28,8 +28,10 @@ use rustc::ty::codec::{self as ty_codec, TyEncoder};
 use rustc::session::config::{self, CrateTypeProcMacro};
 use rustc::util::nodemap::{FxHashMap, NodeSet};
 
+use rustc_data_structures::stable_hasher::StableHasher;
 use rustc_serialize::{Encodable, Encoder, SpecializedEncoder, opaque};
 
+use std::hash::Hash;
 use std::io::prelude::*;
 use std::io::Cursor;
 use std::path::Path;
@@ -290,6 +292,11 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                         } else {
                             let mut adapted = (**filemap).clone();
                             adapted.name = Path::new(&working_dir).join(name).into();
+                            adapted.name_hash = {
+                                let mut hasher: StableHasher<u128> = StableHasher::new();
+                                adapted.name.hash(&mut hasher);
+                                hasher.finish()
+                            };
                             Rc::new(adapted)
                         }
                     },

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -246,6 +246,7 @@ impl CodeMap {
                                 name_was_remapped: bool,
                                 crate_of_origin: u32,
                                 src_hash: u128,
+                                name_hash: u128,
                                 source_len: usize,
                                 mut file_local_lines: Vec<BytePos>,
                                 mut file_local_multibyte_chars: Vec<MultiByteChar>,
@@ -282,6 +283,7 @@ impl CodeMap {
             lines: RefCell::new(file_local_lines),
             multibyte_chars: RefCell::new(file_local_multibyte_chars),
             non_narrow_chars: RefCell::new(file_local_non_narrow_chars),
+            name_hash,
         });
 
         files.push(filemap.clone());


### PR DESCRIPTION
For each span we hash the filename of the file it points to. Since filenames can be quite long, especially with absolute paths, this PR pre-computes a hash of the filename and we then only hash the hash. 

r? @nikomatsakis 