### PR TITLE
Split PlaceContext::Store into Store & AsmOutput

### DIFF
--- a/src/librustc_mir/dataflow/impls/borrows.rs
+++ b/src/librustc_mir/dataflow/impls/borrows.rs
@@ -540,6 +540,10 @@ impl<'a, 'b, 'tcx> FindPlaceUses<'a, 'b, 'tcx> {
             // "deep" does validation go?
             PlaceContext::Validate => false,
 
+            // FIXME: This is here to not change behaviour from before
+            // AsmOutput existed, but it's not necessarily a pure overwrite.
+            // so it's possible this should activate the place.
+            PlaceContext::AsmOutput |
             // pure overwrites of an place do not activate it. (note
             // PlaceContext::Call is solely about dest place)
             PlaceContext::Store | PlaceContext::Call => false,

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -173,6 +173,7 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
                     ty::TyAdt(adt, _) => {
                         if adt.is_union() {
                             if context == PlaceContext::Store ||
+                                context == PlaceContext::AsmOutput ||
                                 context == PlaceContext::Drop
                             {
                                 let elem_ty = match elem {

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -103,6 +103,7 @@ impl<'tcx> Visitor<'tcx> for TempCollector<'tcx> {
         if *temp == TempState::Undefined {
             match context {
                 PlaceContext::Store |
+                PlaceContext::AsmOutput |
                 PlaceContext::Call => {
                     *temp = TempState::Defined {
                         location,

--- a/src/librustc_mir/util/liveness.rs
+++ b/src/librustc_mir/util/liveness.rs
@@ -240,6 +240,9 @@ impl<'tcx> Visitor<'tcx> for DefsUsesVisitor {
 
             PlaceContext::Store |
 
+            // This is potentially both a def and a use...
+            PlaceContext::AsmOutput |
+
             // We let Call define the result in both the success and
             // unwind cases. This is not really correct, however it
             // does not seem to be observable due to the way that we

--- a/src/librustc_trans/mir/analyze.rs
+++ b/src/librustc_trans/mir/analyze.rs
@@ -193,6 +193,7 @@ impl<'mir, 'a, 'tcx> Visitor<'tcx> for LocalAnalyzer<'mir, 'a, 'tcx> {
 
             PlaceContext::Inspect |
             PlaceContext::Store |
+            PlaceContext::AsmOutput |
             PlaceContext::Borrow { .. } |
             PlaceContext::Projection(..) => {
                 self.mark_as_memory(index);


### PR DESCRIPTION
Outputs in InlineAsm can be read-write, so splitting it out is useful for things like Store-Store folding, as that's unsound for a Store-AsmOutput.

This PR is intended to make no changes, just be the mechanical split of the enum.  Future changes can use the split, like a MIR pass I'm working on and perhaps two-phase borrows (see this FIXME: https://github.com/rust-lang/rust/pull/46852/files#diff-74dcd7740ab2104cd2b9a3b68dd4f208R543)