### PR TITLE
tweaks and fixes for doc(include)

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -349,7 +349,27 @@ impl MissingDoc {
             }
         }
 
-        let has_doc = attrs.iter().any(|a| a.is_value_str() && a.check_name("doc"));
+        fn has_doc(attr: &ast::Attribute) -> bool {
+            if !attr.check_name("doc") {
+                return false;
+            }
+
+            if attr.is_value_str() {
+                return true;
+            }
+
+            if let Some(list) = attr.meta_item_list() {
+                for meta in list {
+                    if meta.check_name("include") {
+                        return true;
+                    }
+                }
+            }
+
+            false
+        }
+
+        let has_doc = attrs.iter().any(|a| has_doc(a));
         if !has_doc {
             cx.span_lint(MISSING_DOCS,
                          sp,

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1111,10 +1111,10 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
                     match File::open(&filename).and_then(|mut f| f.read_to_end(&mut buf)) {
                         Ok(..) => {}
                         Err(e) => {
-                            self.cx.span_warn(at.span,
-                                              &format!("couldn't read {}: {}",
-                                                       filename.display(),
-                                                       e));
+                            self.cx.span_err(at.span,
+                                             &format!("couldn't read {}: {}",
+                                                      filename.display(),
+                                                      e));
                         }
                     }
 
@@ -1133,9 +1133,9 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
                                         attr::mk_list_item("include".into(), include_info))));
                         }
                         Err(_) => {
-                            self.cx.span_warn(at.span,
-                                              &format!("{} wasn't a utf-8 file",
-                                                       filename.display()));
+                            self.cx.span_err(at.span,
+                                             &format!("{} wasn't a utf-8 file",
+                                                      filename.display()));
                         }
                     }
                 } else {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1120,6 +1120,10 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
 
                     match String::from_utf8(buf) {
                         Ok(src) => {
+                            // Add this input file to the code map to make it available as
+                            // dependency information
+                            self.cx.codemap().new_filemap_and_lines(&filename, &src);
+
                             let include_info = vec![
                                 dummy_spanned(ast::NestedMetaItemKind::MetaItem(
                                         attr::mk_name_value_item_str("file".into(),

--- a/src/test/compile-fail/external-doc-error.rs
+++ b/src/test/compile-fail/external-doc-error.rs
@@ -1,0 +1,16 @@
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(external_doc)]
+
+#[doc(include = "not-a-file.md")] //~ ERROR: couldn't read
+pub struct SomeStruct;
+
+fn main() {}

--- a/src/test/run-make/include_bytes_deps/Makefile
+++ b/src/test/run-make/include_bytes_deps/Makefile
@@ -8,7 +8,7 @@ ifneq ($(shell uname),FreeBSD)
 ifndef IS_WINDOWS
 all:
 	$(RUSTC) --emit dep-info main.rs
-	$(CGREP) "input.txt" "input.bin" < $(TMPDIR)/main.d
+	$(CGREP) "input.txt" "input.bin" "input.md" < $(TMPDIR)/main.d
 else
 all:
 

--- a/src/test/run-make/include_bytes_deps/input.md
+++ b/src/test/run-make/include_bytes_deps/input.md
@@ -1,0 +1,1 @@
+# Hello, world!

--- a/src/test/run-make/include_bytes_deps/main.rs
+++ b/src/test/run-make/include_bytes_deps/main.rs
@@ -8,6 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(external_doc)]
+
+#[doc(include="input.md")]
+pub struct SomeStruct;
+
 pub fn main() {
     const INPUT_TXT: &'static str = include_str!("input.txt");
     const INPUT_BIN: &'static [u8] = include_bytes!("input.bin");

--- a/src/test/rustdoc/auxiliary/external-cross.rs
+++ b/src/test/rustdoc/auxiliary/external-cross.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(external_doc)]
+#![deny(missing_doc)]
 
 #[doc(include="external-cross-doc.md")]
 pub struct NeedMoreDocs;


### PR DESCRIPTION
This PR makes a handful of changes around `#[doc(include="file.md")]` (https://github.com/rust-lang/rust/issues/44732):

* Turns errors when loading files into full errors. This matches the original RFC text.
* Makes the `missing_docs` lint check for `#[doc(include="file.md")]` as well as regular `#[doc="text"]` attributes.
* Loads files included by `#[doc(include="file.md")]` into dep-info, mirroring the behavior of `include_str!()` and friends.
* Adds or modifies tests to check for all of these.