### PR TITLE
Closure type error ui tweak

### DIFF
--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -170,7 +170,7 @@ fn configure_main(this: &mut EntryContext) {
                       defined at the crate level. Either move the definition or \
                       attach the `#[main]` attribute to override this behavior.");
             for &(_, span) in &this.non_main_fns {
-                err.span_note(span, "here is a function named 'main'");
+                err.span_label(span, "here is a function named 'main'");
             }
             err.emit();
             this.session.abort_if_errors();

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -170,7 +170,7 @@ fn configure_main(this: &mut EntryContext) {
                       defined at the crate level. Either move the definition or \
                       attach the `#[main]` attribute to override this behavior.");
             for &(_, span) in &this.non_main_fns {
-                err.span_label(span, "here is a function named 'main'");
+                err.span_note(span, "here is a function named 'main'");
             }
             err.emit();
             this.session.abort_if_errors();

--- a/src/librustc/ty/error.rs
+++ b/src/librustc/ty/error.rs
@@ -260,10 +260,8 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                 let expected_str = values.expected.sort_string(self);
                 let found_str = values.found.sort_string(self);
                 if expected_str == found_str && expected_str == "closure" {
-                    db.span_note(sp,
-                        "no two closures, even if identical, have the same type");
-                    db.span_help(sp,
-                        "consider boxing your closure and/or using it as a trait object");
+                    db.note("no two closures, even if identical, have the same type");
+                    db.help("consider boxing your closure and/or using it as a trait object");
                 }
             },
             TyParamDefaultMismatch(values) => {

--- a/src/librustc_const_eval/check_match.rs
+++ b/src/librustc_const_eval/check_match.rs
@@ -402,8 +402,8 @@ fn check_arms<'a, 'tcx>(cx: &mut MatchCheckCtxt<'a, 'tcx>,
                             );
                             // if we had a catchall pattern, hint at that
                             if let Some(catchall) = catchall {
-                                err.span_label(pat.span, "this is an unreachable pattern");
-                                err.span_label(catchall, "this pattern matches any value");
+                                err.span_label(pat.span, "unreachable pattern");
+                                err.span_label(catchall, "matches any value");
                             }
                             err.emit();
                         },

--- a/src/librustc_const_eval/check_match.rs
+++ b/src/librustc_const_eval/check_match.rs
@@ -403,7 +403,7 @@ fn check_arms<'a, 'tcx>(cx: &mut MatchCheckCtxt<'a, 'tcx>,
                             // if we had a catchall pattern, hint at that
                             if let Some(catchall) = catchall {
                                 err.span_label(pat.span, "this is an unreachable pattern");
-                                err.span_note(catchall, "this pattern matches any value");
+                                err.span_label(catchall, "this pattern matches any value");
                             }
                             err.emit();
                         },

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -220,7 +220,7 @@ impl<'a> Resolver<'a> {
                         ResolutionError::SelfImportCanOnlyAppearOnceInTheList);
 
                     for other_span in self_spans.iter().skip(1) {
-                        e.span_note(*other_span, "another `self` import appears here");
+                        e.span_label(*other_span, "another `self` import appears here");
                     }
 
                     e.emit();

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -290,17 +290,17 @@ fn resolve_struct_error<'sess, 'a>(resolver: &'sess Resolver,
                              "`self` imports are only allowed within a { } list")
         }
         ResolutionError::SelfImportCanOnlyAppearOnceInTheList => {
-            struct_span_err!(resolver.session,
-                             span,
-                             E0430,
-                             "`self` import can only appear once in the list")
+            let mut err = struct_span_err!(resolver.session, span, E0430,
+                                           "`self` import can only appear once in an import list");
+            err.span_label(span, "can only appear once in an import list");
+            err
         }
         ResolutionError::SelfImportOnlyInImportListWithNonEmptyPrefix => {
-            struct_span_err!(resolver.session,
-                             span,
-                             E0431,
-                             "`self` import can only appear in an import list with a \
-                              non-empty prefix")
+            let mut err = struct_span_err!(resolver.session, span, E0431,
+                                           "`self` import can only appear in an import list with \
+                                            a non-empty prefix");
+            err.span_label(span, "can only appear in an import list with a non-empty prefix");
+            err
         }
         ResolutionError::UnresolvedImport(name) => {
             let (span, msg) = match name {
@@ -320,18 +320,17 @@ fn resolve_struct_error<'sess, 'a>(resolver: &'sess Resolver,
             err
         }
         ResolutionError::CannotCaptureDynamicEnvironmentInFnItem => {
-            struct_span_err!(resolver.session,
-                             span,
-                             E0434,
-                             "{}",
-                             "can't capture dynamic environment in a fn item; use the || { ... } \
-                              closure form instead")
+            let mut err = struct_span_err!(resolver.session,
+                                           span,
+                                           E0434,
+                                           "{}",
+                                           "can't capture dynamic environment in a fn item");
+            err.help("use the `|| { ... }` closure form instead");
+            err
         }
         ResolutionError::AttemptToUseNonConstantValueInConstant => {
-            let mut err = struct_span_err!(resolver.session,
-                             span,
-                             E0435,
-                             "attempt to use a non-constant value in a constant");
+            let mut err = struct_span_err!(resolver.session, span, E0435,
+                                           "attempt to use a non-constant value in a constant");
             err.span_label(span, "non-constant value");
             err
         }
@@ -351,8 +350,7 @@ fn resolve_struct_error<'sess, 'a>(resolver: &'sess Resolver,
             let mut err = struct_span_err!(resolver.session, span, E0128,
                                            "type parameters with a default cannot use \
                                             forward declared identifiers");
-            err.span_label(span, format!("defaulted type parameters \
-                                           cannot be forward declared"));
+            err.span_label(span, format!("defaulted type parameters cannot be forward declared"));
             err
         }
     }
@@ -3941,7 +3939,7 @@ impl<'a> Resolver<'a> {
 
                     feature_err(&self.session.parse_sess, feature,
                                 attr.span, GateIssue::Language, msg)
-                        .span_note(binding.span(), "procedural macro imported here")
+                        .span_label(binding.span(), "procedural macro imported here")
                         .emit();
                 }
             }

--- a/src/test/compile-fail/bad-env-capture.rs
+++ b/src/test/compile-fail/bad-env-capture.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: can't capture dynamic environment in a fn item;
+// error-pattern: can't capture dynamic environment in a fn item
 fn foo() {
     let x: isize;
     fn bar() { log(debug, x); }

--- a/src/test/compile-fail/bad-env-capture2.rs
+++ b/src/test/compile-fail/bad-env-capture2.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: can't capture dynamic environment in a fn item;
+// error-pattern: can't capture dynamic environment in a fn item
 fn foo(x: isize) {
     fn bar() { log(debug, x); }
 }

--- a/src/test/compile-fail/bad-env-capture3.rs
+++ b/src/test/compile-fail/bad-env-capture3.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: can't capture dynamic environment in a fn item;
+// error-pattern: can't capture dynamic environment in a fn item
 fn foo(x: isize) {
     fn mth() {
         fn bar() { log(debug, x); }

--- a/src/test/compile-fail/capture1.rs
+++ b/src/test/compile-fail/capture1.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 
-// error-pattern: can't capture dynamic environment in a fn item;
+// error-pattern: can't capture dynamic environment in a fn item
 
 fn main() {
     let bar: isize = 5;

--- a/src/test/ui/issue-24036.stderr
+++ b/src/test/ui/issue-24036.stderr
@@ -6,16 +6,8 @@ error[E0308]: mismatched types
    |
    = note: expected type `[closure@$DIR/issue-24036.rs:12:17: 12:26]`
               found type `[closure@$DIR/issue-24036.rs:13:9: 13:18]`
-note: no two closures, even if identical, have the same type
-  --> $DIR/issue-24036.rs:13:9
-   |
-13 |     x = |c| c + 1;
-   |         ^^^^^^^^^
-help: consider boxing your closure and/or using it as a trait object
-  --> $DIR/issue-24036.rs:13:9
-   |
-13 |     x = |c| c + 1;
-   |         ^^^^^^^^^
+   = note: no two closures, even if identical, have the same type
+   = help: consider boxing your closure and/or using it as a trait object
 
 error[E0308]: match arms have incompatible types
   --> $DIR/issue-24036.rs:18:13
@@ -31,28 +23,8 @@ error[E0308]: match arms have incompatible types
    |
    = note: expected type `[closure@$DIR/issue-24036.rs:20:14: 20:23]`
               found type `[closure@$DIR/issue-24036.rs:21:14: 21:23]`
-note: no two closures, even if identical, have the same type
-  --> $DIR/issue-24036.rs:18:13
-   |
-18 |       let x = match 1usize {
-   |  _____________^
-19 | |     //~^ ERROR match arms have incompatible types
-20 | |         1 => |c| c + 1,
-21 | |         2 => |c| c - 1,
-22 | |         _ => |c| c - 1
-23 | |     };
-   | |_____^
-help: consider boxing your closure and/or using it as a trait object
-  --> $DIR/issue-24036.rs:18:13
-   |
-18 |       let x = match 1usize {
-   |  _____________^
-19 | |     //~^ ERROR match arms have incompatible types
-20 | |         1 => |c| c + 1,
-21 | |         2 => |c| c - 1,
-22 | |         _ => |c| c - 1
-23 | |     };
-   | |_____^
+   = note: no two closures, even if identical, have the same type
+   = help: consider boxing your closure and/or using it as a trait object
 note: match arm with an incompatible type
   --> $DIR/issue-24036.rs:21:14
    |

--- a/src/test/ui/issue-30302.stderr
+++ b/src/test/ui/issue-30302.stderr
@@ -9,6 +9,9 @@ warning[E0170]: pattern binding `Nil` is named the same as one of the variants o
 error: unreachable pattern
   --> $DIR/issue-30302.rs:25:9
    |
+23 |         Nil => true,
+   |         --- this pattern matches any value
+24 | //~^ WARN pattern binding `Nil` is named the same as one of the variants of the type `Stack`
 25 |         _ => false
    |         ^ this is an unreachable pattern
    |
@@ -17,11 +20,6 @@ note: lint level defined here
    |
 14 | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
-note: this pattern matches any value
-  --> $DIR/issue-30302.rs:23:9
-   |
-23 |         Nil => true,
-   |         ^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issue-30302.stderr
+++ b/src/test/ui/issue-30302.stderr
@@ -10,10 +10,10 @@ error: unreachable pattern
   --> $DIR/issue-30302.rs:25:9
    |
 23 |         Nil => true,
-   |         --- this pattern matches any value
+   |         --- matches any value
 24 | //~^ WARN pattern binding `Nil` is named the same as one of the variants of the type `Stack`
 25 |         _ => false
-   |         ^ this is an unreachable pattern
+   |         ^ unreachable pattern
    |
 note: lint level defined here
   --> $DIR/issue-30302.rs:14:9

--- a/src/test/ui/issue-31221.stderr
+++ b/src/test/ui/issue-31221.stderr
@@ -2,9 +2,9 @@ error: unreachable pattern
   --> $DIR/issue-31221.rs:28:9
    |
 27 |         Var3 => (),
-   |         ---- this pattern matches any value
+   |         ---- matches any value
 28 |         Var2 => (),
-   |         ^^^^ this is an unreachable pattern
+   |         ^^^^ unreachable pattern
    |
 note: lint level defined here
   --> $DIR/issue-31221.rs:14:9
@@ -16,19 +16,17 @@ error: unreachable pattern
   --> $DIR/issue-31221.rs:34:9
    |
 33 |         &Var3 => (),
-   |         ----- this pattern matches any value
+   |         ----- matches any value
 34 |         &Var2 => (),
-   |         ^^^^^ this is an unreachable pattern
-   |
+   |         ^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/issue-31221.rs:41:9
    |
 40 |         (c, d) => (),
-   |         ------ this pattern matches any value
+   |         ------ matches any value
 41 |         anything => ()
-   |         ^^^^^^^^ this is an unreachable pattern
-   |
+   |         ^^^^^^^^ unreachable pattern
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issue-31221.stderr
+++ b/src/test/ui/issue-31221.stderr
@@ -1,6 +1,8 @@
 error: unreachable pattern
   --> $DIR/issue-31221.rs:28:9
    |
+27 |         Var3 => (),
+   |         ---- this pattern matches any value
 28 |         Var2 => (),
    |         ^^^^ this is an unreachable pattern
    |
@@ -9,35 +11,24 @@ note: lint level defined here
    |
 14 | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
-note: this pattern matches any value
-  --> $DIR/issue-31221.rs:27:9
-   |
-27 |         Var3 => (),
-   |         ^^^^
 
 error: unreachable pattern
   --> $DIR/issue-31221.rs:34:9
    |
+33 |         &Var3 => (),
+   |         ----- this pattern matches any value
 34 |         &Var2 => (),
    |         ^^^^^ this is an unreachable pattern
    |
-note: this pattern matches any value
-  --> $DIR/issue-31221.rs:33:9
-   |
-33 |         &Var3 => (),
-   |         ^^^^^
 
 error: unreachable pattern
   --> $DIR/issue-31221.rs:41:9
    |
+40 |         (c, d) => (),
+   |         ------ this pattern matches any value
 41 |         anything => ()
    |         ^^^^^^^^ this is an unreachable pattern
    |
-note: this pattern matches any value
-  --> $DIR/issue-31221.rs:40:9
-   |
-40 |         (c, d) => (),
-   |         ^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/use-mod.rs
+++ b/src/test/ui/use-mod.rs
@@ -10,7 +10,7 @@
 
 use foo::bar::{
     self,
-//~^ ERROR `self` import can only appear once in the list
+//~^ ERROR `self` import can only appear once in an import list
     Bar,
     self
 //~^ ERROR the name `bar` is defined multiple times

--- a/src/test/ui/use-mod.stderr
+++ b/src/test/ui/use-mod.stderr
@@ -1,20 +1,17 @@
-error[E0430]: `self` import can only appear once in the list
+error[E0430]: `self` import can only appear once in an import list
   --> $DIR/use-mod.rs:12:5
    |
 12 |     self,
-   |     ^^^^
-   |
-note: another `self` import appears here
-  --> $DIR/use-mod.rs:15:5
-   |
+   |     ^^^^ can only appear once in an import list
+...
 15 |     self
-   |     ^^^^
+   |     ---- another `self` import appears here
 
 error[E0431]: `self` import can only appear in an import list with a non-empty prefix
   --> $DIR/use-mod.rs:19:6
    |
 19 | use {self};
-   |      ^^^^
+   |      ^^^^ can only appear in an import list with a non-empty prefix
 
 error[E0252]: the name `bar` is defined multiple times
   --> $DIR/use-mod.rs:15:5


### PR DESCRIPTION
Do not point at the same span on all notes/help messages, and instead
show them without a span.