### PR TITLE
MIR: terminate unreachable blocks in construct_const

### DIFF
--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -472,6 +472,13 @@ fn construct_const<'a, 'gcx, 'tcx>(hir: Cx<'a, 'gcx, 'tcx>,
     // Constants can't `return` so a return block should not be created.
     assert_eq!(builder.cached_return_block, None);
 
+    // Constants may be match expressions in which case an unreachable block may
+    // be created, so terminate it properly.
+    if let Some(unreachable_block) = builder.cached_unreachable_block {
+        builder.cfg.terminate(unreachable_block, source_info,
+                              TerminatorKind::Unreachable);
+    }
+
     builder.finish(vec![], None)
 }
 

--- a/src/test/compile-fail/issue-46843.rs
+++ b/src/test/compile-fail/issue-46843.rs
@@ -1,0 +1,22 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum Thing { This, That }
+
+fn non_const() -> Thing {
+    Thing::This
+}
+
+pub const Q: i32 = match non_const() { //~ ERROR E0015
+    Thing::This => 1, //~ ERROR unimplemented expression type
+    Thing::That => 0
+};
+
+fn main() {}


### PR DESCRIPTION
Fixes #46843.

#45821 added unreachable blocks in matches, which were terminated in
construct_fn but not in construct_const, causing a panic due to "no
terminator on block" when constants involved matching on enums.

The "unimplemented expression type" error may go away in the future, the
key is that we see the E0015 about using a non-const function and then
don't ICE.