### PR TITLE
incr.comp.: Cache check_match and use ensure() for coherence-related queries.

### DIFF
--- a/src/librustc/ty/maps/config.rs
+++ b/src/librustc/ty/maps/config.rs
@@ -647,5 +647,6 @@ impl_disk_cacheable_query!(unsafety_check_result, |def_id| def_id.is_local());
 impl_disk_cacheable_query!(borrowck, |def_id| def_id.is_local());
 impl_disk_cacheable_query!(mir_borrowck, |def_id| def_id.is_local());
 impl_disk_cacheable_query!(mir_const_qualif, |def_id| def_id.is_local());
+impl_disk_cacheable_query!(check_match, |def_id| def_id.is_local());
 impl_disk_cacheable_query!(contains_extern_indicator, |_| true);
 impl_disk_cacheable_query!(def_symbol_name, |_| true);

--- a/src/librustc/ty/maps/config.rs
+++ b/src/librustc/ty/maps/config.rs
@@ -102,7 +102,7 @@ impl<'tcx> QueryDescription<'tcx> for queries::type_param_predicates<'tcx> {
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::coherent_trait<'tcx> {
-    fn describe(tcx: TyCtxt, (_, def_id): (CrateNum, DefId)) -> String {
+    fn describe(tcx: TyCtxt, def_id: DefId) -> String {
         format!("coherence checking all impls of trait `{}`",
                 tcx.item_path_str(def_id))
     }

--- a/src/librustc/ty/maps/mod.rs
+++ b/src/librustc/ty/maps/mod.rs
@@ -187,7 +187,7 @@ define_maps! { <'tcx>
 
     [] fn has_typeck_tables: HasTypeckTables(DefId) -> bool,
 
-    [] fn coherent_trait: coherent_trait_dep_node((CrateNum, DefId)) -> (),
+    [] fn coherent_trait: CoherenceCheckTrait(DefId) -> (),
 
     [] fn borrowck: BorrowCheck(DefId) -> Rc<BorrowCheckResult>,
 
@@ -383,10 +383,6 @@ fn fulfill_obligation_dep_node<'tcx>((param_env, trait_ref):
         param_env,
         trait_ref
     }
-}
-
-fn coherent_trait_dep_node<'tcx>((_, def_id): (CrateNum, DefId)) -> DepConstructor<'tcx> {
-    DepConstructor::CoherenceCheckTrait(def_id)
 }
 
 fn crate_inherent_impls_dep_node<'tcx>(_: CrateNum) -> DepConstructor<'tcx> {

--- a/src/librustc/ty/maps/on_disk_cache.rs
+++ b/src/librustc/ty/maps/on_disk_cache.rs
@@ -217,6 +217,7 @@ impl<'sess> OnDiskCache<'sess> {
             encode_query_results::<contains_extern_indicator, _>(tcx, enc, qri)?;
             encode_query_results::<symbol_name, _>(tcx, enc, qri)?;
             encode_query_results::<trans_fulfill_obligation, _>(tcx, enc, qri)?;
+            encode_query_results::<check_match, _>(tcx, enc, qri)?;
         }
 
         // Encode diagnostics

--- a/src/librustc/ty/maps/plumbing.rs
+++ b/src/librustc/ty/maps/plumbing.rs
@@ -978,4 +978,5 @@ impl_load_from_cache!(
     SymbolName => def_symbol_name,
     ConstIsRvaluePromotableToStatic => const_is_rvalue_promotable_to_static,
     ContainsExternIndicator => contains_extern_indicator,
+    CheckMatch => check_match,
 );

--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -11,7 +11,7 @@
 //! misc. type-system utilities too small to deserve their own file
 
 use hir::def::Def;
-use hir::def_id::{DefId, LOCAL_CRATE};
+use hir::def_id::DefId;
 use hir::map::{DefPathData, Node};
 use hir;
 use ich::NodeIdHashingMode;
@@ -427,7 +427,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             return None;
         };
 
-        self.coherent_trait((LOCAL_CRATE, drop_trait));
+        ty::maps::queries::coherent_trait::ensure(self, drop_trait);
 
         let mut dtor_did = None;
         let ty = self.type_of(adt_did);

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -29,7 +29,7 @@ pub const FN_OUTPUT_NAME: &'static str = "Output";
 
 // Useful type to use with `Result<>` indicate that an error has already
 // been reported to the user, so no need to continue checking.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, RustcEncodable, RustcDecodable)]
 pub struct ErrorReported;
 
 thread_local!(static TIME_DEPTH: Cell<usize> = Cell::new(0));


### PR DESCRIPTION
Some minor optimizations.

r? @nikomatsakis 