### PR TITLE
rustdoc: add option to abort the process on markdown differences

### DIFF
--- a/src/bootstrap/bin/rustdoc.rs
+++ b/src/bootstrap/bin/rustdoc.rs
@@ -57,6 +57,10 @@ fn main() {
         // This "unstable-options" can be removed when `--crate-version` is stabilized
         cmd.arg("-Z").arg("unstable-options")
            .arg("--crate-version").arg(version);
+
+        // While we can assume that `-Z unstable-options` is set, let's also force rustdoc to panic
+        // if pulldown rendering differences are found
+        cmd.arg("--deny-render-differences");
     }
 
     std::process::exit(match cmd.status() {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -495,7 +495,8 @@ pub fn run(mut krate: clean::Crate,
            css_file_extension: Option<PathBuf>,
            renderinfo: RenderInfo,
            render_type: RenderType,
-           sort_modules_alphabetically: bool) -> Result<(), Error> {
+           sort_modules_alphabetically: bool,
+           deny_render_differences: bool) -> Result<(), Error> {
     let src_root = match krate.src {
         FileName::Real(ref p) => match p.parent() {
             Some(p) => p.to_path_buf(),
@@ -658,6 +659,11 @@ pub fn run(mut krate: clean::Crate,
             for d in diffs {
                 render_difference(d, &mut intro_msg, span, text);
             }
+        }
+
+        if deny_render_differences {
+            println!("Aborting with {} rendering differences", markdown_warnings.len());
+            ::std::process::exit(1);
         }
     }
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -257,6 +257,10 @@ pub fn opts() -> Vec<RustcOptGroup> {
             o.optflag("", "sort-modules-by-appearance", "sort modules by where they appear in the \
                                                          program, rather than alphabetically")
         }),
+        unstable("deny-render-differences", |o| {
+            o.optflag("", "deny-render-differences", "abort doc runs when markdown rendering \
+                                                      differences are found")
+        }),
     ]
 }
 
@@ -393,6 +397,7 @@ pub fn main_args(args: &[String]) -> isize {
     }
 
     let output_format = matches.opt_str("w");
+    let deny_render_differences = matches.opt_present("deny-render-differences");
     let res = acquire_input(PathBuf::from(input), externs, &matches, move |out| {
         let Output { krate, passes, renderinfo } = out;
         info!("going to format");
@@ -404,7 +409,8 @@ pub fn main_args(args: &[String]) -> isize {
                                   css_file_extension,
                                   renderinfo,
                                   render_type,
-                                  sort_modules_alphabetically)
+                                  sort_modules_alphabetically,
+                                  deny_render_differences)
                     .expect("failed to generate documentation");
                 0
             }


### PR DESCRIPTION
In the efforts of keeping the std docs free of markdown warnings, this PR adds a stopgap measure to make sure the CI fails if it detects a markdown difference. It does this by adding a new unstable flag to rustdoc, `--deny-render-differences`, which bootstrap then passes to rustdoc when documenting std and friends.

The implementation is... probably not the cleanest option. It currently adds an extra branch after it prints the markdown warnings, which just prints a final line and calls `::std::process::abort(1)`. I did it like this because if it just panics regularly, it looks like an ICE, an even though `html::render::run` returns a Result, that Result is also just `expect`ed immediately, generating the same problem. This way bypasses the panic handler at the top of the thread and looks like a proper failure. Since i don't have a real error Handler there, this is the best i can do without pulling in a real error system for rustdoc.

This PR is blocked on https://github.com/rust-lang/rust/pull/46853, which will fix the rendering differences that were present on master when i started this branch.