### PR TITLE
Allow lifetimes in macros

### DIFF
--- a/src/doc/unstable-book/src/language-features/macro-lifetime-matcher.md
+++ b/src/doc/unstable-book/src/language-features/macro-lifetime-matcher.md
@@ -1,0 +1,14 @@
+# `macro_lifetime_matcher`
+
+The tracking issue for this feature is: [#46895]
+
+With this feature gate enabled, the [list of fragment specifiers][frags] gains one more entry:
+
+* `lifetime`: a lifetime. Examples: 'static, 'a.
+
+A `lifetime` variable may be followed by anything.
+
+[#46895]: https://github.com/rust-lang/rust/issues/46895
+[frags]: ../book/first-edition/macros.html#syntactic-requirements
+
+------------------------

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -192,8 +192,7 @@ pub mod rt {
 
     impl ToTokens for ast::Lifetime {
         fn to_tokens(&self, _cx: &ExtCtxt) -> Vec<TokenTree> {
-            let lifetime_ident = ast::Ident::with_empty_ctxt(self.name);
-            vec![TokenTree::Token(DUMMY_SP, token::Lifetime(lifetime_ident))]
+            vec![TokenTree::Token(DUMMY_SP, token::Lifetime(self.ident))]
         }
     }
 

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -190,6 +190,13 @@ pub mod rt {
         }
     }
 
+    impl ToTokens for ast::Lifetime {
+        fn to_tokens(&self, _cx: &ExtCtxt) -> Vec<TokenTree> {
+            let lifetime_ident = ast::Ident::with_empty_ctxt(self.name);
+            vec![TokenTree::Token(DUMMY_SP, token::Lifetime(lifetime_ident))]
+        }
+    }
+
     macro_rules! impl_to_tokens_slice {
         ($t: ty, $sep: expr) => {
             impl ToTokens for [$t] {

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -603,6 +603,7 @@ fn parse_nt<'a>(p: &mut Parser<'a>, sp: Span, name: &str) -> Nonterminal {
         "path" => token::NtPath(panictry!(p.parse_path_common(PathStyle::Type, false))),
         "meta" => token::NtMeta(panictry!(p.parse_meta_item())),
         "vis" => token::NtVis(panictry!(p.parse_visibility(true))),
+        "lifetime" => token::NtLifetime(panictry!(p.parse_lifetime())),
         // this is not supposed to happen, since it has been checked
         // when compiling the macro.
         _ => p.span_bug(sp, "invalid fragment specifier")

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -603,7 +603,7 @@ fn parse_nt<'a>(p: &mut Parser<'a>, sp: Span, name: &str) -> Nonterminal {
         "path" => token::NtPath(panictry!(p.parse_path_common(PathStyle::Type, false))),
         "meta" => token::NtMeta(panictry!(p.parse_meta_item())),
         "vis" => token::NtVis(panictry!(p.parse_visibility(true))),
-        "lifetime" => token::NtLifetime(panictry!(p.parse_lifetime())),
+        "lifetime" => token::NtLifetime(p.expect_lifetime()),
         // this is not supposed to happen, since it has been checked
         // when compiling the macro.
         _ => p.span_bug(sp, "invalid fragment specifier")

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -889,8 +889,8 @@ fn is_legal_fragment_specifier(sess: &ParseSess,
         "item" | "block" | "stmt" | "expr" | "pat" |
         "path" | "ty" | "ident" | "meta" | "tt" | "" => true,
         "lifetime" => {
-            if     !features.borrow().macro_lifetime_matcher
-                && !attr::contains_name(attrs, "allow_internal_unstable") {
+            if !features.borrow().macro_lifetime_matcher &&
+               !attr::contains_name(attrs, "allow_internal_unstable") {
                 let explain = feature_gate::EXPLAIN_LIFETIME_MATCHER;
                 emit_feature_err(sess,
                                  "macro_lifetime_matcher",
@@ -901,8 +901,8 @@ fn is_legal_fragment_specifier(sess: &ParseSess,
             true
         },
         "vis" => {
-            if     !features.borrow().macro_vis_matcher
-                && !attr::contains_name(attrs, "allow_internal_unstable") {
+            if !features.borrow().macro_vis_matcher &&
+               !attr::contains_name(attrs, "allow_internal_unstable") {
                 let explain = feature_gate::EXPLAIN_VIS_MATCHER;
                 emit_feature_err(sess,
                                  "macro_vis_matcher",

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -768,10 +768,11 @@ fn token_can_be_followed_by_any(tok: &quoted::TokenTree) -> bool {
 /// ANYTHING without fear of future compatibility hazards).
 fn frag_can_be_followed_by_any(frag: &str) -> bool {
     match frag {
-        "item"  | // always terminated by `}` or `;`
-        "block" | // exactly one token tree
-        "ident" | // exactly one token tree
-        "meta"  | // exactly one token tree
+        "item"     | // always terminated by `}` or `;`
+        "block"    | // exactly one token tree
+        "ident"    | // exactly one token tree
+        "meta"     | // exactly one token tree
+        "lifetime" | // exactly one token tree
         "tt" =>   // exactly one token tree
             true,
 
@@ -832,8 +833,8 @@ fn is_in_follow(tok: &quoted::TokenTree, frag: &str) -> Result<bool, (String, &'
                 TokenTree::MetaVarDecl(_, _, frag) if frag.name == "block" => Ok(true),
                 _ => Ok(false),
             },
-            "ident" => {
-                // being a single token, idents are harmless
+            "ident" | "lifetime" => {
+                // being a single token, idents and lifetimes are harmless
                 Ok(true)
             },
             "meta" | "tt" => {
@@ -885,7 +886,7 @@ fn is_legal_fragment_specifier(sess: &ParseSess,
                                frag_name: &str,
                                frag_span: Span) -> bool {
     match frag_name {
-        "item" | "block" | "stmt" | "expr" | "pat" |
+        "item" | "block" | "stmt" | "expr" | "pat" | "lifetime" |
         "path" | "ty" | "ident" | "meta" | "tt" | "" => true,
         "vis" => {
             if     !features.borrow().macro_vis_matcher

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -886,8 +886,20 @@ fn is_legal_fragment_specifier(sess: &ParseSess,
                                frag_name: &str,
                                frag_span: Span) -> bool {
     match frag_name {
-        "item" | "block" | "stmt" | "expr" | "pat" | "lifetime" |
+        "item" | "block" | "stmt" | "expr" | "pat" |
         "path" | "ty" | "ident" | "meta" | "tt" | "" => true,
+        "lifetime" => {
+            if     !features.borrow().macro_lifetime_matcher
+                && !attr::contains_name(attrs, "allow_internal_unstable") {
+                let explain = feature_gate::EXPLAIN_LIFETIME_MATCHER;
+                emit_feature_err(sess,
+                                 "macro_lifetime_matcher",
+                                 frag_span,
+                                 GateIssue::Language,
+                                 explain);
+            }
+            true
+        },
         "vis" => {
             if     !features.borrow().macro_vis_matcher
                 && !attr::contains_name(attrs, "allow_internal_unstable") {

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -447,6 +447,9 @@ declare_features! (
 
     // Termination trait in main (RFC 1937)
     (active, termination_trait, "1.24.0", Some(43301)),
+
+    // Allows use of the :lifetime macro fragment specifier
+    (active, macro_lifetime_matcher, "1.24.0", Some(46895)),
 );
 
 declare_features! (
@@ -520,7 +523,7 @@ declare_features! (
     (accepted, loop_break_value, "1.19.0", Some(37339)),
     // Permits numeric fields in struct expressions and patterns.
     (accepted, relaxed_adts, "1.19.0", Some(35626)),
-    // Coerces non capturing closures to function pointers
+   // Coerces non capturing closures to function pointers
     (accepted, closure_to_fn_coercion, "1.19.0", Some(39817)),
     // Allows attributes on struct literal fields.
     (accepted, struct_field_attributes, "1.20.0", Some(38814)),
@@ -1225,6 +1228,9 @@ pub const EXPLAIN_DERIVE_UNDERSCORE: &'static str =
 
 pub const EXPLAIN_VIS_MATCHER: &'static str =
     ":vis fragment specifier is experimental and subject to change";
+
+pub const EXPLAIN_LIFETIME_MATCHER: &'static str =
+    ":lifetime fragment specifier is experimental and subject to change";
 
 pub const EXPLAIN_PLACEMENT_IN: &'static str =
     "placement-in expression syntax is experimental and subject to change.";

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -523,7 +523,7 @@ declare_features! (
     (accepted, loop_break_value, "1.19.0", Some(37339)),
     // Permits numeric fields in struct expressions and patterns.
     (accepted, relaxed_adts, "1.19.0", Some(35626)),
-   // Coerces non capturing closures to function pointers
+    // Coerces non capturing closures to function pointers
     (accepted, closure_to_fn_coercion, "1.19.0", Some(39817)),
     // Allows attributes on struct literal fields.
     (accepted, struct_field_attributes, "1.20.0", Some(38814)),

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -642,6 +642,7 @@ pub fn noop_fold_interpolated<T: Folder>(nt: token::Nonterminal, fld: &mut T)
             token::NtWhereClause(fld.fold_where_clause(where_clause)),
         token::NtArg(arg) => token::NtArg(fld.fold_arg(arg)),
         token::NtVis(vis) => token::NtVis(fld.fold_vis(vis)),
+        token::NtLifetime(lifetime) => token::NtLifetime(fld.fold_lifetime(lifetime)),
     }
 }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2040,12 +2040,11 @@ impl<'a> Parser<'a> {
             token::Lifetime(ident) =>
                 Lifetime { ident: ident, span: self.span, id: ast::DUMMY_NODE_ID },
             token::Interpolated(ref nt) => match nt.0 {
-                token::NtLifetime(lifetime) => 
+                token::NtLifetime(lifetime) =>
                     lifetime,
-                    //Lifetime { ident: lifetime.ident, span: lifetime.span, id: ast::DUMMY_NODE_ID },
-                _ => self.span_bug(self.span, &format!("not a lifetime: {:?}", self.token))
+                _ => self.span_bug(self.span, "not a lifetime")
             }
-            _ => self.span_bug(self.span, &format!("not a lifetime: {:?}", self.token))
+            _ => self.span_bug(self.span, "not a lifetime")
         };
 
         self.bump();

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2036,19 +2036,12 @@ impl<'a> Parser<'a> {
 
     /// Parse single lifetime 'a or panic.
     pub fn expect_lifetime(&mut self) -> Lifetime {
-        let lifetime = match self.token {
-            token::Lifetime(ident) =>
-                Lifetime { ident: ident, span: self.span, id: ast::DUMMY_NODE_ID },
-            token::Interpolated(ref nt) => match nt.0 {
-                token::NtLifetime(lifetime) =>
-                    lifetime,
-                _ => self.span_bug(self.span, "not a lifetime")
-            }
-            _ => self.span_bug(self.span, "not a lifetime")
-        };
-
-        self.bump();
-        lifetime
+        if let Some(lifetime) = self.token.lifetime(self.span) {
+            self.bump();
+            lifetime
+        } else {
+            self.span_bug(self.span, "not a lifetime")
+        }
     }
 
     /// Parse mutability (`mut` or nothing).

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2031,7 +2031,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse single lifetime 'a or panic.
-    fn expect_lifetime(&mut self) -> Lifetime {
+    pub fn expect_lifetime(&mut self) -> Lifetime {
         match self.token {
             token::Lifetime(ident) => {
                 let ident_span = self.span;

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -314,16 +314,24 @@ impl Token {
         false
     }
 
+    /// Returns a lifetime with the span and a dummy id if it is a lifetime,
+    /// or the original lifetime if it is an interpolated lifetime, ignoring
+    /// the span.
+    pub fn lifetime(&self, span: Span) -> Option<ast::Lifetime> {
+        match *self {
+            Lifetime(ident) =>
+                Some(ast::Lifetime { ident: ident, span: span, id: ast::DUMMY_NODE_ID }),
+            Interpolated(ref nt) => match nt.0 {
+                NtLifetime(lifetime) => Some(lifetime),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
     /// Returns `true` if the token is a lifetime.
     pub fn is_lifetime(&self) -> bool {
-        match *self {
-            Lifetime(..) => true,
-            Interpolated(ref nt) => match nt.0 {
-                NtLifetime(..) => true,
-                _ => false,
-            },
-            _ => false,
-        }
+        self.lifetime(syntax_pos::DUMMY_SP).is_some()
     }
 
     /// Returns `true` if the token is either the `mut` or `const` keyword.

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -251,7 +251,7 @@ impl Token {
             Lt | BinOp(Shl)             | // associated path
             ModSep                      => true, // global path
             Interpolated(ref nt) => match nt.0 {
-                NtIdent(..) | NtTy(..) | NtPath(..) => true,
+                NtIdent(..) | NtTy(..) | NtPath(..) | NtLifetime(..) => true,
                 _ => false,
             },
             _ => false,
@@ -318,7 +318,11 @@ impl Token {
     pub fn is_lifetime(&self) -> bool {
         match *self {
             Lifetime(..) => true,
-            _            => false,
+            Interpolated(ref nt) => match nt.0 {
+                NtLifetime(..) => true,
+                _ => false,
+            },
+            _ => false,
         }
     }
 
@@ -485,6 +489,10 @@ impl Token {
             Nonterminal::NtIdent(ident) => {
                 let token = Token::Ident(ident.node);
                 tokens = Some(TokenTree::Token(ident.span, token).into());
+            }
+            Nonterminal::NtLifetime(lifetime) => {
+                let token = Token::Lifetime(lifetime.ident);
+                tokens = Some(TokenTree::Token(lifetime.span, token).into());
             }
             Nonterminal::NtTT(ref tt) => {
                 tokens = Some(tt.clone().into());

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -524,6 +524,7 @@ pub enum Nonterminal {
     NtGenerics(ast::Generics),
     NtWhereClause(ast::WhereClause),
     NtArg(ast::Arg),
+    NtLifetime(ast::Lifetime),
 }
 
 impl fmt::Debug for Nonterminal {
@@ -546,6 +547,7 @@ impl fmt::Debug for Nonterminal {
             NtWhereClause(..) => f.pad("NtWhereClause(..)"),
             NtArg(..) => f.pad("NtArg(..)"),
             NtVis(..) => f.pad("NtVis(..)"),
+            NtLifetime(..) => f.pad("NtLifetime(..)"),
         }
     }
 }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -279,6 +279,7 @@ pub fn token_to_string(tok: &Token) -> String {
             token::NtWhereClause(ref e) => where_clause_to_string(e),
             token::NtArg(ref e)         => arg_to_string(e),
             token::NtVis(ref e)         => vis_to_string(e),
+            token::NtLifetime(ref e)    => lifetime_to_string(e),
         }
     }
 }

--- a/src/test/run-pass/macro-lifetime-used-with-bound.rs
+++ b/src/test/run-pass/macro-lifetime-used-with-bound.rs
@@ -1,0 +1,23 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! foo {
+    ($l:lifetime, $l2:lifetime) => {
+        fn f<$l: $l2, $l2>(arg: &$l str, arg2: &$l2 str) -> &$l str {
+            arg
+        }
+    }
+}
+
+pub fn main() {
+    foo!('a, 'b);
+    let x: &'static str = f("hi", "there");
+    assert_eq!("hi", x);
+}

--- a/src/test/run-pass/macro-lifetime-used-with-bound.rs
+++ b/src/test/run-pass/macro-lifetime-used-with-bound.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(macro_lifetime_matcher)]
+
 macro_rules! foo {
     ($l:lifetime, $l2:lifetime) => {
         fn f<$l: $l2, $l2>(arg: &$l str, arg2: &$l2 str) -> &$l str {

--- a/src/test/run-pass/macro-lifetime-used-with-labels.rs
+++ b/src/test/run-pass/macro-lifetime-used-with-labels.rs
@@ -1,0 +1,43 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(unreachable_code)]
+
+macro_rules! x {
+    ($a:lifetime) => {
+        $a: loop {
+            break $a;
+            panic!("failed");
+        }
+    }
+}
+macro_rules! br {
+    ($a:lifetime) => {
+        break $a;
+    }
+}
+macro_rules! br2 {
+    ($b:lifetime) => {
+        'b: loop {
+            break $b; // this $b should refer to the outer loop.
+        }
+    }
+}
+fn main() {
+    x!('a);
+    'c: loop {
+        br!('c);
+        panic!("failed");
+    }
+    'b: loop {
+        br2!('b);
+        panic!("failed");
+    }
+}

--- a/src/test/run-pass/macro-lifetime-used-with-labels.rs
+++ b/src/test/run-pass/macro-lifetime-used-with-labels.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![allow(unreachable_code)]
+#![feature(macro_lifetime_matcher)]
 
 macro_rules! x {
     ($a:lifetime) => {

--- a/src/test/run-pass/macro-lifetime-used-with-static.rs
+++ b/src/test/run-pass/macro-lifetime-used-with-static.rs
@@ -1,0 +1,23 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! foo {
+    ($l:lifetime) => {
+        fn f(arg: &$l str) -> &$l str {
+            arg
+        }
+    }
+}
+
+pub fn main() {
+    foo!('static);
+    let x: &'static str = f("hi");
+    assert_eq!("hi", x);
+}

--- a/src/test/run-pass/macro-lifetime.rs
+++ b/src/test/run-pass/macro-lifetime.rs
@@ -1,0 +1,23 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! foo {
+    ($l:lifetime) => {
+        fn f<$l>(arg: &$l str) -> &$l str {
+            arg
+        }
+    }
+}
+
+pub fn main() {
+    foo!('a);
+    let x: &'static str = f("hi");
+    assert_eq!("hi", x);
+}

--- a/src/test/run-pass/macro-lifetime.rs
+++ b/src/test/run-pass/macro-lifetime.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(macro_lifetime_matcher)]
+
 macro_rules! foo {
     ($l:lifetime) => {
         fn f<$l>(arg: &$l str) -> &$l str {

--- a/src/test/ui/feature-gate-macro-lifetime-matcher.rs
+++ b/src/test/ui/feature-gate-macro-lifetime-matcher.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,18 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(macro_lifetime_matcher)]
+// Test that the :lifetime macro fragment cannot be used when macro_lifetime_matcher
+// feature gate is not used.
 
-macro_rules! foo {
-    ($l:lifetime) => {
-        fn f(arg: &$l str) -> &$l str {
-            arg
-        }
-    }
-}
+macro_rules! m { ($lt:lifetime) => {} }
+//~^ ERROR :lifetime fragment specifier is experimental and subject to change
 
-pub fn main() {
-    foo!('static);
-    let x: &'static str = f("hi");
-    assert_eq!("hi", x);
+fn main() {
+    m!('a);
 }

--- a/src/test/ui/feature-gate-macro-lifetime-matcher.stderr
+++ b/src/test/ui/feature-gate-macro-lifetime-matcher.stderr
@@ -1,0 +1,10 @@
+error: :lifetime fragment specifier is experimental and subject to change (see issue #46895)
+  --> $DIR/feature-gate-macro-lifetime-matcher.rs:14:19
+   |
+14 | macro_rules! m { ($lt:lifetime) => {} }
+   |                   ^^^^^^^^^^^^
+   |
+   = help: add #![feature(macro_lifetime_matcher)] to the crate attributes to enable
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This is a resurrection of PR #41927 which was a resurrection of #33135, which is intended to fix #34303.

In short, this allows macros_rules! to use :lifetime as a matcher to match 'lifetimes.

Still to do:
- [x]  Feature gate
