### PR TITLE
rustc: Set release mode cgus to 16 by default

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -785,10 +785,7 @@ impl Session {
         // As a result 16 was chosen here! Mostly because it was a power of 2
         // and most benchmarks agreed it was roughly a local optimum. Not very
         // scientific.
-        match self.opts.optimize {
-            config::OptLevel::No => 16,
-            _ => 1, // FIXME(#46346) this should be 16
-        }
+        16
     }
 
     /// Returns whether ThinLTO is enabled for this compilation

--- a/src/librustc_llvm/ffi.rs
+++ b/src/librustc_llvm/ffi.rs
@@ -1732,4 +1732,5 @@ extern "C" {
                                            CU1: *mut *mut c_void,
                                            CU2: *mut *mut c_void);
     pub fn LLVMRustThinLTOPatchDICompileUnit(M: ModuleRef, CU: *mut c_void);
+    pub fn LLVMRustThinLTORemoveAvailableExternally(M: ModuleRef);
 }

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -1182,6 +1182,15 @@ LLVMRustThinLTOPatchDICompileUnit(LLVMModuleRef Mod, DICompileUnit *Unit) {
   MD->addOperand(Unit);
 }
 
+extern "C" void
+LLVMRustThinLTORemoveAvailableExternally(LLVMModuleRef Mod) {
+  Module *M = unwrap(Mod);
+  for (Function &F : M->functions()) {
+    if (F.hasAvailableExternallyLinkage())
+      F.deleteBody();
+  }
+}
+
 #else
 
 extern "C" bool
@@ -1272,4 +1281,10 @@ extern "C" void
 LLVMRustThinLTOPatchDICompileUnit(LLVMModuleRef Mod) {
   report_fatal_error("ThinLTO not available");
 }
+
+extern "C" void
+LLVMRustThinLTORemoveAvailableExternally(LLVMModuleRef Mod) {
+  report_fatal_error("ThinLTO not available");
+}
+
 #endif // LLVM_VERSION_GE(4, 0)


### PR DESCRIPTION
This commit is the next attempt to enable multiple codegen units by default in
release mode, getting some of those sweet, sweet parallelism wins by running
codegen in parallel. Performance should not be lost due to ThinLTO being on by
default as well.

Closes #45320