### PR TITLE
Convert warning about `*const _` to a future-compat lint

### DIFF
--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -1833,7 +1833,7 @@ impl<T: ?Sized> *mut T {
     ///
     /// # #[allow(dead_code)]
     /// unsafe fn from_buf_raw<T: Copy>(ptr: *const T, elts: usize) -> Vec<T> {
-    ///     let mut dst = Vec::with_capacity(elts);
+    ///     let mut dst: Vec<T> = Vec::with_capacity(elts);
     ///     dst.set_len(elts);
     ///     dst.as_mut_ptr().copy_from(ptr, elts);
     ///     dst
@@ -1872,7 +1872,7 @@ impl<T: ?Sized> *mut T {
     ///
     /// # #[allow(dead_code)]
     /// unsafe fn from_buf_raw<T: Copy>(ptr: *const T, elts: usize) -> Vec<T> {
-    ///     let mut dst = Vec::with_capacity(elts);
+    ///     let mut dst: Vec<T> = Vec::with_capacity(elts);
     ///     dst.set_len(elts);
     ///     dst.as_mut_ptr().copy_from_nonoverlapping(ptr, elts);
     ///     dst

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -240,6 +240,12 @@ declare_lint! {
    "detects single use lifetimes"
 }
 
+declare_lint! {
+    pub TYVAR_BEHIND_RAW_POINTER,
+    Warn,
+    "raw pointer to an inference variable"
+}
+
 /// Does nothing as a lint pass, but registers some `Lint`s
 /// which are used by other parts of the compiler.
 #[derive(Copy, Clone)]
@@ -284,7 +290,8 @@ impl LintPass for HardwiredLints {
             UNUSED_UNSAFE,
             UNUSED_MUT,
             COERCE_NEVER,
-            SINGLE_USE_LIFETIME
+            SINGLE_USE_LIFETIME,
+            TYVAR_BEHIND_RAW_POINTER
         )
     }
 }

--- a/src/librustc_data_structures/array_vec.rs
+++ b/src/librustc_data_structures/array_vec.rs
@@ -255,7 +255,7 @@ impl<'a, A: Array> Drop for Drain<'a, A> {
 
         if self.tail_len > 0 {
             unsafe {
-                let source_array_vec = self.array_vec.as_mut();
+                let source_array_vec: &mut ArrayVec<A> = self.array_vec.as_mut();
                 // memmove back untouched tail, update to new length
                 let start = source_array_vec.len();
                 let tail = self.tail_start;

--- a/src/librustc_data_structures/array_vec.rs
+++ b/src/librustc_data_structures/array_vec.rs
@@ -138,7 +138,7 @@ impl<A: Array> ArrayVec<A> {
             // Use the borrow in the IterMut to indicate borrowing behavior of the
             // whole Drain iterator (like &mut T).
             let range_slice = {
-                let arr = &mut self.values as &mut [ManuallyDrop<_>];
+                let arr = &mut self.values as &mut [ManuallyDrop<<A as Array>::Element>];
                 slice::from_raw_parts_mut(arr.as_mut_ptr().offset(start as isize),
                                           end - start)
             };
@@ -260,7 +260,8 @@ impl<'a, A: Array> Drop for Drain<'a, A> {
                 let start = source_array_vec.len();
                 let tail = self.tail_start;
                 {
-                    let arr = &mut source_array_vec.values as &mut [ManuallyDrop<_>];
+                    let arr =
+                        &mut source_array_vec.values as &mut [ManuallyDrop<<A as Array>::Element>];
                     let src = arr.as_ptr().offset(tail as isize);
                     let dst = arr.as_mut_ptr().offset(start as isize);
                     ptr::copy(src, dst, self.tail_len);

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -255,6 +255,10 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
             id: LintId::of(COERCE_NEVER),
             reference: "issue #46325 <https://github.com/rust-lang/rust/issues/46325>",
         },
+        FutureIncompatibleInfo {
+            id: LintId::of(TYVAR_BEHIND_RAW_POINTER),
+            reference: "issue #46906 <https://github.com/rust-lang/rust/issues/46906>",
+        },
         ]);
 
     // Register renamed and removed lints

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -453,7 +453,7 @@ pub fn getenv(k: &OsStr) -> io::Result<Option<OsString>> {
     let k = CString::new(k.as_bytes())?;
     unsafe {
         ENV_LOCK.lock();
-        let s = libc::getenv(k.as_ptr()) as *const _;
+        let s = libc::getenv(k.as_ptr()) as *const libc::c_char;
         let ret = if s.is_null() {
             None
         } else {

--- a/src/libstd/sys/windows/fs.rs
+++ b/src/libstd/sys/windows/fs.rs
@@ -770,7 +770,7 @@ fn symlink_junction_inner(target: &Path, junction: &Path) -> io::Result<()> {
         let mut data = [0u8; c::MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
         let db = data.as_mut_ptr()
                     as *mut c::REPARSE_MOUNTPOINT_DATA_BUFFER;
-        let buf = &mut (*db).ReparseTarget as *mut _;
+        let buf = &mut (*db).ReparseTarget as *mut c::WCHAR;
         let mut i = 0;
         // FIXME: this conversion is very hacky
         let v = br"\??\";

--- a/src/libstd/sys_common/gnu/libbacktrace.rs
+++ b/src/libstd/sys_common/gnu/libbacktrace.rs
@@ -73,7 +73,7 @@ pub fn resolve_symname<F>(frame: Frame,
                 "failed to allocate libbacktrace state")
             )
         }
-        let mut data = ptr::null();
+        let mut data: *const libc::c_char = ptr::null();
         let data_addr = &mut data as *mut *const libc::c_char;
         let ret = unsafe {
             backtrace_syminfo(state,

--- a/src/test/ui/inference-variable-behind-raw-pointer.stderr
+++ b/src/test/ui/inference-variable-behind-raw-pointer.stderr
@@ -1,8 +1,10 @@
-warning[E0619]: the type of this value must be known in this context
+warning: the type of this value must be known in this context
   --> $DIR/inference-variable-behind-raw-pointer.rs:18:13
    |
 18 |     if data.is_null() {}
    |             ^^^^^^^
    |
-   = note: this will be made into a hard error in a future version of the compiler
+   = note: #[warn(tyvar_behind_raw_pointer)] on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #46906 <https://github.com/rust-lang/rust/issues/46906>
 


### PR DESCRIPTION
#46664 was merged before I could convert the soft warning about method lookup on `*const _` into a future-compatibility lint. This PR makes that change.

fixes #46837
tracking issue for the future-compatibility lint: #46906 

r? @arielb1