### PR TITLE
Generate code for unused const- and inline-fns if -Clink-dead-code is specified.

### DIFF
--- a/src/librustc_mir/monomorphize/item.rs
+++ b/src/librustc_mir/monomorphize/item.rs
@@ -115,7 +115,7 @@ pub trait MonoItemExt<'a, 'tcx>: fmt::Debug {
         let inline_in_all_cgus =
             tcx.sess.opts.debugging_opts.inline_in_all_cgus.unwrap_or_else(|| {
                 tcx.sess.opts.optimize != OptLevel::No
-            });
+            }) && !tcx.sess.opts.cg.link_dead_code;
 
         match *self.as_mono_item() {
             MonoItem::Fn(ref instance) => {

--- a/src/librustc_mir/monomorphize/partitioning.rs
+++ b/src/librustc_mir/monomorphize/partitioning.rs
@@ -236,7 +236,9 @@ pub fn partition<'a, 'tcx, I>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
     // Next we try to make as many symbols "internal" as possible, so LLVM has
     // more freedom to optimize.
-    internalize_symbols(tcx, &mut post_inlining, inlining_map);
+    if !tcx.sess.opts.cg.link_dead_code {
+        internalize_symbols(tcx, &mut post_inlining, inlining_map);
+    }
 
     // Finally, sort by codegen unit name, so that we get deterministic results
     let PostInliningPartitioning {

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -1014,7 +1014,13 @@ fn collect_and_partition_translation_items<'a, 'tcx>(
                 MonoItemCollectionMode::Lazy
             }
         }
-        None => MonoItemCollectionMode::Lazy
+        None => {
+            if tcx.sess.opts.cg.link_dead_code {
+                MonoItemCollectionMode::Eager
+            } else {
+                MonoItemCollectionMode::Lazy
+            }
+        }
     };
 
     let (items, inlining_map) =

--- a/src/test/codegen/link-dead-code.rs
+++ b/src/test/codegen/link-dead-code.rs
@@ -1,0 +1,27 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:-Clink-dead-code
+
+#![feature(const_fn)]
+#![crate_type = "rlib"]
+
+// This test makes sure that, when -Clink-dead-code is specified, we generate
+// code for functions that would otherwise be skipped.
+
+// CHECK-LABEL: define hidden i32 @_ZN14link_dead_code8const_fn
+const fn const_fn() -> i32 { 1 }
+
+// CHECK-LABEL: define hidden i32 @_ZN14link_dead_code9inline_fn
+#[inline]
+fn inline_fn() -> i32 { 2 }
+
+// CHECK-LABEL: define hidden i32 @_ZN14link_dead_code10private_fn
+fn private_fn() -> i32 { 3 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/46467.

r? @alexcrichton 