### PR TITLE
Correct the return type for `x86_mm256_sad_epu8`

### DIFF
--- a/src/etc/platform-intrinsics/x86/avx2.json
+++ b/src/etc/platform-intrinsics/x86/avx2.json
@@ -174,7 +174,7 @@
             "intrinsic": "256_sad_epu8",
             "width": [256],
             "llvm": "psad.bw",
-            "ret": "u8",
+            "ret": "u64",
             "args": ["0", "0"]
         },
         {

--- a/src/librustc_platform_intrinsics/x86.rs
+++ b/src/librustc_platform_intrinsics/x86.rs
@@ -354,7 +354,7 @@ pub fn find(name: &str) -> Option<Intrinsic> {
         },
         "_mm256_sad_epu8" => Intrinsic {
             inputs: { static INPUTS: [&'static Type; 2] = [&::U8x32, &::U8x32]; &INPUTS },
-            output: &::U8x32,
+            output: &::U64x4,
             definition: Named("llvm.x86.avx2.psad.bw")
         },
         "_mm256_shuffle_epi8" => Intrinsic {


### PR DESCRIPTION
Fixes #43439.