### PR TITLE
Clarify docs for split_at_mut

### DIFF
--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -699,7 +699,7 @@ impl<T> [T] {
         core_slice::SliceExt::split_at(self, mid)
     }
 
-    /// Divides one `&mut` into two at an index.
+    /// Divides one mutable slice into two at an index.
     ///
     /// The first will contain all indices from `[0, mid)` (excluding
     /// the index `mid` itself) and the second will contain all


### PR DESCRIPTION
The `&mut` here didn't make immediate sense to me. Keep the docs for this function consistent with the non-mut version.