### PR TITLE
Make core::f32/f64 docs match std.

### DIFF
--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -8,7 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Operations and constants for 32-bits floats (`f32` type)
+//! This module provides constants which are specific to the implementation
+//! of the `f32` floating point data type.
+//!
+//! Mathematically significant numbers are provided in the `consts` sub-module.
+//!
+//! *[See also the `f32` primitive type](../../std/primitive.f32.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -8,7 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Operations and constants for 64-bits floats (`f64` type)
+//! This module provides constants which are specific to the implementation
+//! of the `f64` floating point data type.
+//!
+//! Mathematically significant numbers are provided in the `consts` sub-module.
+//!
+//! *[See also the `f64` primitive type](../../std/primitive.f64.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -13,7 +13,7 @@
 //!
 //! Mathematically significant numbers are provided in the `consts` sub-module.
 //!
-//! *[See also the `f32` primitive type](../primitive.f32.html).*
+//! *[See also the `f32` primitive type](../../std/primitive.f32.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![allow(missing_docs)]

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -13,7 +13,7 @@
 //!
 //! Mathematically significant numbers are provided in the `consts` sub-module.
 //!
-//! *[See also the `f64` primitive type](../primitive.f64.html).*
+//! *[See also the `f64` primitive type](../../std/primitive.f64.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![allow(missing_docs)]


### PR DESCRIPTION
For some reason these weren't in sync.