### PR TITLE
Generalise slice::contains over PartialEq

### DIFF
--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -981,7 +981,7 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn contains<U>(&self, x: &U) -> bool
-        where T: PartialEq<U>
+        where U: ?Sized, T: PartialEq<U>
     {
         core_slice::SliceExt::contains(self, x)
     }

--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -980,8 +980,8 @@ impl<T> [T] {
     /// assert!(!v.contains(&50));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn contains(&self, x: &T) -> bool
-        where T: PartialEq
+    pub fn contains<U>(&self, x: &U) -> bool
+        where T: PartialEq<U>
     {
         core_slice::SliceExt::contains(self, x)
     }

--- a/src/liballoc/tests/slice.rs
+++ b/src/liballoc/tests/slice.rs
@@ -1052,6 +1052,19 @@ fn test_shrink_to_fit() {
 }
 
 #[test]
+fn test_contains() {
+    let numbers = [1, 2, 3];
+    assert!(numbers.contains(&2));
+    assert!(!numbers.contains(&4));
+
+    let strings = vec![String::from("AB"), String::from("CD")];
+    assert!(strings.contains(&String::from("AB")));
+    assert!(!strings.contains(&String::from("A")));
+    assert!(strings.contains(&"AB"));
+    assert!(!strings.contains(&"BC"));
+}
+
+#[test]
 fn test_starts_with() {
     assert!(b"foobar".starts_with(b"foo"));
     assert!(!b"foobar".starts_with(b"oob"));

--- a/src/liballoc/tests/slice.rs
+++ b/src/liballoc/tests/slice.rs
@@ -1062,6 +1062,7 @@ fn test_contains() {
     assert!(!strings.contains(&String::from("A")));
     assert!(strings.contains(&"AB"));
     assert!(!strings.contains(&"BC"));
+    assert!(strings.contains("AB"));
 }
 
 #[test]

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -192,7 +192,7 @@ pub trait SliceExt {
     fn as_mut_ptr(&mut self) -> *mut Self::Item;
 
     #[stable(feature = "core", since = "1.6.0")]
-    fn contains<U>(&self, x: &U) -> bool where Self::Item: PartialEq<U>;
+    fn contains<U>(&self, x: &U) -> bool where U: ?Sized, Self::Item: PartialEq<U>;
 
     #[stable(feature = "core", since = "1.6.0")]
     fn starts_with(&self, needle: &[Self::Item]) -> bool where Self::Item: PartialEq;
@@ -618,7 +618,7 @@ impl<T> SliceExt for [T] {
     }
 
     #[inline]
-    fn contains<U>(&self, x: &U) -> bool where T: PartialEq<U> {
+    fn contains<U>(&self, x: &U) -> bool where U: ?Sized, T: PartialEq<U> {
         self.iter().any(|e| e == x)
     }
 

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -192,7 +192,7 @@ pub trait SliceExt {
     fn as_mut_ptr(&mut self) -> *mut Self::Item;
 
     #[stable(feature = "core", since = "1.6.0")]
-    fn contains(&self, x: &Self::Item) -> bool where Self::Item: PartialEq;
+    fn contains<U>(&self, x: &U) -> bool where Self::Item: PartialEq<U>;
 
     #[stable(feature = "core", since = "1.6.0")]
     fn starts_with(&self, needle: &[Self::Item]) -> bool where Self::Item: PartialEq;
@@ -618,8 +618,8 @@ impl<T> SliceExt for [T] {
     }
 
     #[inline]
-    fn contains(&self, x: &T) -> bool where T: PartialEq {
-        self.iter().any(|elt| *x == *elt)
+    fn contains<U>(&self, x: &U) -> bool where T: PartialEq<U> {
+        self.iter().any(|e| e == x)
     }
 
     #[inline]

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -1608,7 +1608,7 @@ mod traits {
         fn ne(&self, other: &str) -> bool { !(*self).eq(other) }
     }
 
-    #[stable(feature = "rust1", since = "1.24.0")]
+    #[unstable(feature = "str_str_ref_partialeq", issue = "46934")]
     impl<'a> PartialEq<&'a str> for str {
         #[inline]
         fn eq(&self, other: &&'a str) -> bool { self == *other }
@@ -1616,7 +1616,7 @@ mod traits {
         fn ne(&self, other: &&'a str) -> bool { self != *other }
     }
 
-    #[stable(feature = "rust1", since = "1.24.0")]
+    #[unstable(feature = "str_str_ref_partialeq", issue = "46934")]
     impl<'a> PartialEq<str> for &'a str {
         #[inline]
         fn eq(&self, other: &str) -> bool { *self == other }

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -1608,6 +1608,22 @@ mod traits {
         fn ne(&self, other: &str) -> bool { !(*self).eq(other) }
     }
 
+    #[stable(feature = "rust1", since = "1.24.0")]
+    impl<'a> PartialEq<&'a str> for str {
+        #[inline]
+        fn eq(&self, other: &&'a str) -> bool { self == *other }
+        #[inline]
+        fn ne(&self, other: &&'a str) -> bool { self != *other }
+    }
+
+    #[stable(feature = "rust1", since = "1.24.0")]
+    impl<'a> PartialEq<str> for &'a str {
+        #[inline]
+        fn eq(&self, other: &str) -> bool { *self == other }
+        #[inline]
+        fn ne(&self, other: &str) -> bool { *self != other }
+    }
+
     #[stable(feature = "rust1", since = "1.0.0")]
     impl Eq for str {}
 


### PR DESCRIPTION
This allows `contains` to be used on slices to search for elements that
satisfy a partial equality with the slice item type, rather than an
identity. This closes #42671. Note that string literals need to be
referenced in this implementation due to `str` not implementing
`Sized`. It’s likely this will have to go through a Crater run to test
for breakage (see https://github.com/rust-lang/rust/pull/43020).