### PR TITLE
add kbd style tag to main.css in rustdoc

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -94,20 +94,22 @@ r##"<!DOCTYPE html>
                 <h2>Keyboard Shortcuts</h2>
 
                 <dl>
-                    <dt>?</dt>
+                    <dt><kbd>?</kbd></dt>
                     <dd>Show this help dialog</dd>
-                    <dt>S</dt>
+                    <dt><kbd>S</kbd></dt>
                     <dd>Focus the search field</dd>
-                    <dt>↑</dt>
+                    <dt><kbd>↑</kbd></dt>
                     <dd>Move up in search results</dd>
-                    <dt>↓</dt>
+                    <dt><kbd>↓</kbd></dt>
                     <dd>Move down in search results</dd>
-                    <dt>↹</dt>
+                    <dt><kbd>↹</kbd></dt>
                     <dd>Switch tab</dd>
-                    <dt>&#9166;</dt>
+                    <dt><kbd>&#9166;</kbd></dt>
                     <dd>Go to active search result</dd>
-                    <dt style="width:31px;">+ / -</dt>
-                    <dd>Collapse/expand all sections</dd>
+                    <dt><kbd>+</kbd></dt>
+                    <dd>Expand all sections</dd>
+                    <dt><kbd>-</kbd></dt>
+                    <dd>Collapse all sections</dd>
                 </dl>
             </div>
 

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1107,3 +1107,17 @@ h3.important {
 	left: -42px;
 	margin-top: 2px;
 }
+
+kbd {
+	display: inline-block;
+	padding: 3px 5px;
+	font: 11px "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+	line-height: 10px;
+	color: #444d56;
+	vertical-align: middle;
+	background-color: #fafbfc;
+	border: solid 1px #d1d5da;
+	border-bottom-color: #c6cbd1;
+	border-radius: 3px;
+	box-shadow: inset 0 -1px 0 #c6cbd1;
+}

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1113,11 +1113,8 @@ kbd {
 	padding: 3px 5px;
 	font: 11px "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
 	line-height: 10px;
-	color: #444d56;
 	vertical-align: middle;
-	background-color: #fafbfc;
-	border: solid 1px #d1d5da;
-	border-bottom-color: #c6cbd1;
+	border: solid 1px;
 	border-radius: 3px;
-	box-shadow: inset 0 -1px 0 #c6cbd1;
+	box-shadow: inset 0 -1px 0;
 }

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -589,9 +589,9 @@ body.blur > :not(#help) {
 	border: 1px solid;
 }
 #help dt {
-    float: left;
-    clear: left;
-    display: block;
+	float: left;
+	clear: left;
+	display: block;
 }
 #help dd { margin: 5px 35px; }
 #help .infos { padding-left: 0; }

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -585,18 +585,13 @@ body.blur > :not(#help) {
 	flex: 0 0 auto;
 	box-shadow: 0 0 6px rgba(0,0,0,.2);
 	width: 550px;
-	height: 354px;
+	height: auto;
 	border: 1px solid;
 }
 #help dt {
-	float: left;
-	border-radius: 4px;
-	border: 1px solid;
-	width: 23px;
-	text-align: center;
-	clear: left;
-	display: block;
-	margin-top: -1px;
+    float: left;
+    clear: left;
+    display: block;
 }
 #help dd { margin: 5px 35px; }
 #help .infos { padding-left: 0; }
@@ -1111,7 +1106,7 @@ h3.important {
 kbd {
 	display: inline-block;
 	padding: 3px 5px;
-	font: 11px "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+	font: 15px "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
 	line-height: 10px;
 	vertical-align: middle;
 	border: solid 1px;

--- a/src/librustdoc/html/static/styles/main.css
+++ b/src/librustdoc/html/static/styles/main.css
@@ -343,3 +343,12 @@ pre.ignore:hover, .information:hover + pre.ignore {
 		border-right-color: #000;
 	}
 }
+
+kbd {
+    color: #444d56;
+    background-color: #fafbfc;
+    border-color: #d1d5da;
+    border-bottom-color: #c6cbd1;
+    box-shadow-color: #c6cbd1;
+}
+

--- a/src/librustdoc/html/static/styles/main.css
+++ b/src/librustdoc/html/static/styles/main.css
@@ -194,11 +194,6 @@ a.test-arrow {
 	border-color: #bfbfbf;;
 }
 
-#help dt {
-	border-color: #bfbfbf;
-	background: #fff;
-}
-
 .since {
 	color: grey;
 }

--- a/src/librustdoc/html/static/styles/main.css
+++ b/src/librustdoc/html/static/styles/main.css
@@ -340,10 +340,9 @@ pre.ignore:hover, .information:hover + pre.ignore {
 }
 
 kbd {
-    color: #444d56;
-    background-color: #fafbfc;
-    border-color: #d1d5da;
-    border-bottom-color: #c6cbd1;
-    box-shadow-color: #c6cbd1;
+	color: #444d56;
+	background-color: #fafbfc;
+	border-color: #d1d5da;
+	border-bottom-color: #c6cbd1;
+	box-shadow-color: #c6cbd1;
 }
-


### PR DESCRIPTION
Added css style for kbd tags so they actually look like keys. 
Result preview and discussion was going on in #46900 .


