### PR TITLE
Fix process test when using busybox mkdir

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1584,7 +1584,7 @@ mod tests {
              = if cfg!(target_os = "windows") {
                  Command::new("cmd").args(&["/C", "mkdir ."]).output().unwrap()
              } else {
-                 Command::new("mkdir").arg(".").output().unwrap()
+                 Command::new("mkdir").arg("./").output().unwrap()
              };
 
         assert!(status.code() == Some(1));


### PR DESCRIPTION
busybox mkdir . returns 0
busybox mkdir ./ returns 1