### PR TITLE
doc: improve None condition doc for `checked_div` and `checked_rem`

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -435,7 +435,7 @@ macro_rules! int_impl {
         }
 
         /// Checked integer division. Computes `self / rhs`, returning `None`
-        /// if `rhs == 0` or the operation results in overflow.
+        /// if `rhs == 0` or the division results in overflow.
         ///
         /// # Examples
         ///
@@ -457,7 +457,7 @@ macro_rules! int_impl {
         }
 
         /// Checked integer remainder. Computes `self % rhs`, returning `None`
-        /// if `rhs == 0` or the operation results in overflow.
+        /// if `rhs == 0` or the division results in overflow.
         ///
         /// # Examples
         ///
@@ -1599,7 +1599,7 @@ macro_rules! uint_impl {
         }
 
         /// Checked integer division. Computes `self / rhs`, returning `None`
-        /// if `rhs == 0` or the operation results in overflow.
+        /// if `rhs == 0`.
         ///
         /// # Examples
         ///
@@ -1619,7 +1619,7 @@ macro_rules! uint_impl {
         }
 
         /// Checked integer remainder. Computes `self % rhs`, returning `None`
-        /// if `rhs == 0` or the operation results in overflow.
+        /// if `rhs == 0`.
         ///
         /// # Examples
         ///


### PR DESCRIPTION
This commit improves the condition mentioned in the docs for which `checked_div` and `checked_rem` return `None`.

For signed division, the commit changes "the operation results in overflow" to "the division results in overflow", otherwise there is room for misinterpretation for `checked_rem`: Without considering overflow, `MIN % -1` would be simply zero, allowing the misinterpretation that "the operation" does not result in overflow in this case. This ambiguity is removed using "when the division results in overflow".

For unsigned division, the condition for `None` should be simply when `rhs == 0`, as no other overflow is possible.