### PR TITLE
MIR borrowck: no "move occurs because `X` is not Copy` error

### DIFF
--- a/src/librustc_mir/borrow_check/error_reporting.rs
+++ b/src/librustc_mir/borrow_check/error_reporting.rs
@@ -81,7 +81,34 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                     err.span_label(move_span, format!("value moved{} here", move_msg));
                 };
             }
-            //FIXME: add note for closure
+
+            if let Some(ty) = self.retrieve_type_for_place(place) {
+                let needs_note = match ty.sty {
+                    ty::TypeVariants::TyClosure(id, _) => {
+                        let tables = self.tcx.typeck_tables_of(id);
+                        let node_id = self.tcx.hir.as_local_node_id(id).unwrap();
+                        let hir_id = self.tcx.hir.node_to_hir_id(node_id);
+                        if let Some(_) = tables.closure_kind_origins().get(hir_id) {
+                            false
+                        } else {
+                            true
+                        }
+                    },
+                    _ => true,
+                };
+
+                if needs_note {
+                    let note_msg = match self.describe_place(place) {
+                        Some(name) => format!("`{}`", name),
+                        None => "value".to_owned(),
+                    };
+
+                    err.note(&format!("move occurs because {} has type `{}`, \
+                                       which does not implement the `Copy` trait",
+                                       note_msg, ty));
+                }
+            }
+
             err.emit();
         }
     }
@@ -654,5 +681,22 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
     // Retrieve span of given borrow from the current MIR representation
     fn retrieve_borrow_span(&self, borrow: &BorrowData) -> Span {
         self.mir.source_info(borrow.location).span
+    }
+
+    // Retrieve type of a place for the current MIR representation
+    fn retrieve_type_for_place(&self, place: &Place<'tcx>) -> Option<ty::Ty> {
+        match place {
+            Place::Local(local) => {
+                let local = &self.mir.local_decls[*local];
+                Some(local.ty)
+            },
+            Place::Static(ref st) => Some(st.ty),
+            Place::Projection(ref proj) => {
+                match proj.elem {
+                    ProjectionElem::Field(_, ty) => Some(ty),
+                    _ => None,
+                }
+            },
+        }
     }
 }

--- a/src/test/ui/borrowck/borrowck-reinit.stderr
+++ b/src/test/ui/borrowck/borrowck-reinit.stderr
@@ -15,6 +15,8 @@ error[E0382]: use of moved value: `x` (Mir)
    |          - value moved here
 18 |     let _ = (1,x); //~ ERROR use of moved value: `x` (Ast)
    |                ^ value used here after move
+   |
+   = note: move occurs because `x` has type `std::boxed::Box<i32>`, which does not implement the `Copy` trait
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/moves-based-on-type-tuple.rs
+++ b/src/test/ui/moves-based-on-type-tuple.rs
@@ -10,9 +10,14 @@
 
 #![feature(box_syntax)]
 
+// compile-flags: -Z emit-end-regions -Z borrowck=compare
+
 fn dup(x: Box<isize>) -> Box<(Box<isize>,Box<isize>)> {
-    box (x, x) //~ ERROR use of moved value
+    box (x, x)
+    //~^ use of moved value: `x` (Ast) [E0382]
+    //~| use of moved value: `x` (Mir) [E0382]
 }
+
 fn main() {
     dup(box 3);
 }

--- a/src/test/ui/moves-based-on-type-tuple.stderr
+++ b/src/test/ui/moves-based-on-type-tuple.stderr
@@ -1,0 +1,22 @@
+error[E0382]: use of moved value: `x` (Ast)
+  --> $DIR/moves-based-on-type-tuple.rs:16:13
+   |
+16 |     box (x, x)
+   |          -  ^ value used here after move
+   |          |
+   |          value moved here
+   |
+   = note: move occurs because `x` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `x` (Mir)
+  --> $DIR/moves-based-on-type-tuple.rs:16:13
+   |
+16 |     box (x, x)
+   |          -  ^ value used here after move
+   |          |
+   |          value moved here
+   |
+   = note: move occurs because `x` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #46631.

r? @arielb1 