### PR TITLE
"incompatible arm" diagnostic span tweak

### DIFF
--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -437,10 +437,20 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         match cause.code {
             ObligationCauseCode::MatchExpressionArm { arm_span, source } => match source {
                 hir::MatchSource::IfLetDesugar {..} => {
-                    err.span_note(arm_span, "`if let` arm with an incompatible type");
+                    let msg = "`if let` arm with an incompatible type";
+                    if self.tcx.sess.codemap().is_multiline(arm_span) {
+                        err.span_note(arm_span, msg);
+                    } else {
+                        err.span_label(arm_span, msg);
+                    }
                 }
                 _ => {
-                    err.span_note(arm_span, "match arm with an incompatible type");
+                    let msg = "match arm with an incompatible type";
+                    if self.tcx.sess.codemap().is_multiline(arm_span) {
+                        err.span_note(arm_span, msg);
+                    } else {
+                        err.span_label(arm_span, msg);
+                    }
                 }
             },
             _ => ()

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -446,6 +446,12 @@ impl CodeMap {
             .expect("CodeMap::span_to_unmapped_path called for imported FileMap?")
     }
 
+    pub fn is_multiline(&self, sp: Span) -> bool {
+        let lo = self.lookup_char_pos(sp.lo());
+        let hi = self.lookup_char_pos(sp.hi());
+        lo.line != hi.line
+    }
+
     pub fn span_to_lines(&self, sp: Span) -> FileLinesResult {
         debug!("span_to_lines(sp={:?})", sp);
 

--- a/src/test/ui/issue-11319.stderr
+++ b/src/test/ui/issue-11319.stderr
@@ -6,17 +6,14 @@ error[E0308]: match arms have incompatible types
 14 | |     //~| expected type `bool`
 15 | |     //~| found type `()`
 ...  |
+19 | |         None    => (),
+   | |                    -- match arm with an incompatible type
 20 | |         _       => true
 21 | |     }
    | |_____^ expected bool, found ()
    |
    = note: expected type `bool`
               found type `()`
-note: match arm with an incompatible type
-  --> $DIR/issue-11319.rs:19:20
-   |
-19 |         None    => (),
-   |                    ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issue-24036.stderr
+++ b/src/test/ui/issue-24036.stderr
@@ -17,6 +17,7 @@ error[E0308]: match arms have incompatible types
 19 | |     //~^ ERROR match arms have incompatible types
 20 | |         1 => |c| c + 1,
 21 | |         2 => |c| c - 1,
+   | |              --------- match arm with an incompatible type
 22 | |         _ => |c| c - 1
 23 | |     };
    | |_____^ expected closure, found a different closure
@@ -25,11 +26,6 @@ error[E0308]: match arms have incompatible types
               found type `[closure@$DIR/issue-24036.rs:21:14: 21:23]`
    = note: no two closures, even if identical, have the same type
    = help: consider boxing your closure and/or using it as a trait object
-note: match arm with an incompatible type
-  --> $DIR/issue-24036.rs:21:14
-   |
-21 |         2 => |c| c - 1,
-   |              ^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/lub-glb/old-lub-glb-hr.stderr
+++ b/src/test/ui/lub-glb/old-lub-glb-hr.stderr
@@ -5,6 +5,7 @@ error[E0308]: match arms have incompatible types
    |  _____________^
 19 | |         0 => x,
 20 | |         _ => y,
+   | |              - match arm with an incompatible type
 21 | |     };
    | |_____^ expected bound lifetime parameter, found concrete lifetime
    |
@@ -12,11 +13,6 @@ error[E0308]: match arms have incompatible types
               found type `for<'a> fn(&'a u8, &'a u8)`
    = note: this was previously accepted by the compiler but has been phased out
    = note: for more information, see https://github.com/rust-lang/rust/issues/45852
-note: match arm with an incompatible type
-  --> $DIR/old-lub-glb-hr.rs:20:14
-   |
-20 |         _ => y,
-   |              ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/lub-glb/old-lub-glb-object.stderr
+++ b/src/test/ui/lub-glb/old-lub-glb-object.stderr
@@ -5,6 +5,7 @@ error[E0308]: match arms have incompatible types
    |  _____________^
 21 | |         0 => x,
 22 | |         _ => y,
+   | |              - match arm with an incompatible type
 23 | |     };
    | |_____^ expected bound lifetime parameter 'a, found concrete lifetime
    |
@@ -12,11 +13,6 @@ error[E0308]: match arms have incompatible types
               found type `&for<'a> Foo<&'a u8, &'a u8>`
    = note: this was previously accepted by the compiler but has been phased out
    = note: for more information, see https://github.com/rust-lang/rust/issues/45852
-note: match arm with an incompatible type
-  --> $DIR/old-lub-glb-object.rs:22:14
-   |
-22 |         _ => y,
-   |              ^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Use span label instead of span note for single line spans in
"incompatible arm" diagnostic.