### PR TITLE
Add env flags `RUSTC_COLOR` and `RUSTC_ERROR_FORMAT`

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -269,15 +269,6 @@ fn main() {
         cmd.arg("--cfg").arg("parallel_queries");
     }
 
-    let color = match env::var("RUSTC_COLOR") {
-        Ok(s) => usize::from_str(&s).expect("RUSTC_COLOR should be an integer"),
-        Err(_) => 0,
-    };
-
-    if color != 0 {
-        cmd.arg("--color=always");
-    }
-
     if verbose > 1 {
         eprintln!("rustc command: {:?}", cmd);
     }

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -799,7 +799,7 @@ fn run_cargo(build: &Build, cargo: &mut Command, stamp: &Path) {
         // since we pass message-format=json to cargo, we need to tell the rustc
         // wrapper to give us colored output if necessary. This is because we
         // only want Cargo's JSON output, not rustcs.
-        cargo.env("RUSTC_COLOR", "1");
+        cargo.env("RUSTC_COLOR", "always");
     }
 
     build.verbose(&format!("running: {:?}", cargo));

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -99,6 +99,7 @@ use syntax::codemap::{CodeMap, FileLoader, RealFileLoader};
 use syntax::feature_gate::{GatedCfg, UnstableFeatures};
 use syntax::parse::{self, PResult};
 use syntax_pos::{DUMMY_SP, MultiSpan, FileName};
+use errors::{EnvDefaults, FromEnv};
 
 #[cfg(test)]
 mod test;
@@ -203,7 +204,8 @@ pub fn run_compiler<'a>(args: &[String],
         None => return (Ok(()), None),
     };
 
-    let (sopts, cfg) = config::build_session_options_and_crate_config(&matches);
+    let defaults = EnvDefaults::from_env();
+    let (sopts, cfg) = config::build_session_options_and_crate_config(&matches, defaults);
 
     if sopts.debugging_opts.debug_llvm {
         rustc_trans::enable_llvm_debug();

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -28,7 +28,7 @@ extern crate serialize as rustc_serialize;
 extern crate syntax_pos;
 extern crate unicode_width;
 
-pub use emitter::ColorConfig;
+pub use emitter::{ColorConfig, ErrorFormat, EnvDefaults, FromEnv};
 
 use self::Level::*;
 


### PR DESCRIPTION
- Rework flag `RUSTC_COLOR`.
- Add flag `RUSTC_ERROR_FORMAT`.

r? @nikomatsakis 