### PR TITLE
[MIR Borrowck] Moveck inline asm statements

### DIFF
--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -392,7 +392,7 @@ impl<'cx, 'gcx, 'tcx> DataflowResultsConsumer<'cx, 'tcx> for MirBorrowckCtxt<'cx
                         self.mutate_place(
                             context,
                             (output, span),
-                            Deep,
+                            if o.is_rw { Deep } else { Shallow(None) },
                             if o.is_rw { WriteAndRead } else { JustWrite },
                             flow_state,
                         );

--- a/src/test/compile-fail/asm-out-read-uninit.rs
+++ b/src/test/compile-fail/asm-out-read-uninit.rs
@@ -13,6 +13,9 @@
 // ignore-powerpc
 // ignore-sparc
 
+// revisions: ast mir
+//[mir]compile-flags: -Z borrowck=mir
+
 #![feature(asm)]
 
 fn foo(x: isize) { println!("{}", x); }
@@ -24,7 +27,9 @@ fn foo(x: isize) { println!("{}", x); }
 pub fn main() {
     let x: isize;
     unsafe {
-        asm!("mov $1, $0" : "=r"(x) : "r"(x)); //~ ERROR use of possibly uninitialized variable: `x`
+        asm!("mov $1, $0" : "=r"(x) : "r"(x));
+        //[ast]~^ ERROR use of possibly uninitialized variable: `x`
+        //[mir]~^^ ERROR use of possibly uninitialized variable: `x`
     }
     foo(x);
 }

--- a/src/test/compile-fail/borrowck/borrowck-asm.rs
+++ b/src/test/compile-fail/borrowck/borrowck-asm.rs
@@ -1,0 +1,97 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-sparc
+
+// revisions: ast mir
+//[mir]compile-flags: -Z borrowck=mir -Z nll
+
+#![feature(asm)]
+
+#[cfg(any(target_arch = "x86",
+            target_arch = "x86_64",
+            target_arch = "arm",
+            target_arch = "aarch64"))]
+mod test_cases {
+    fn is_move() {
+        let y: &mut isize;
+        let x = &mut 0isize;
+        unsafe {
+            asm!("nop" : : "r"(x));
+        }
+        let z = x;  //[ast]~ ERROR use of moved value: `x`
+                    //[mir]~^ ERROR use of moved value: `x`
+    }
+
+    fn in_is_read() {
+        let mut x = 3;
+        let y = &mut x;
+        unsafe {
+            asm!("nop" : : "r"(x)); //[ast]~ ERROR cannot use
+                                    //[mir]~^ ERROR cannot use
+        }
+        let z = y;
+    }
+
+    fn out_is_assign() {
+        let x = 3;
+        unsafe {
+            asm!("nop" : "=r"(x));  //[ast]~ ERROR cannot assign twice
+                                    //[mir]~^ ERROR cannot assign twice
+        }
+        let mut a = &mut 3;
+        let b = &*a;
+        unsafe {
+            asm!("nop" : "=r"(a));  //[ast]~ ERROR cannot assign to `a` because it is borrowed
+                                    // No MIR error, this is a shallow write.
+        }
+        let c = b;
+        let d = *a;
+    }
+
+    fn rw_is_assign() {
+        let x = 3;
+        unsafe {
+            asm!("nop" : "+r"(x));  //[ast]~ ERROR cannot assign twice
+                                    //[mir]~^ ERROR cannot assign twice
+        }
+    }
+
+    fn indirect_is_not_init() {
+        let x: i32;
+        unsafe {
+            asm!("nop" : "=*r"(x)); //[ast]~ ERROR use of possibly uninitialized variable
+                                    //[mir]~^ ERROR use of possibly uninitialized variable
+        }
+    }
+
+    fn rw_is_read() {
+        let mut x = &mut 3;
+        let y = &*x;
+        unsafe {
+            asm!("nop" : "+r"(x));  //[ast]~ ERROR cannot assign to `x` because it is borrowed
+                                    //[mir]~^ ERROR cannot assign to `x` because it is borrowed
+        }
+        let z = y;
+    }
+
+    fn two_moves() {
+        let x = &mut 2;
+        unsafe {
+            asm!("nop" : : "r"(x), "r"(x) );    //[ast]~ ERROR use of moved value
+                                                //[mir]~^ ERROR use of moved value
+        }
+    }
+}
+
+fn main() {}

--- a/src/test/run-pass/asm-in-moved.rs
+++ b/src/test/run-pass/asm-in-moved.rs
@@ -1,0 +1,41 @@
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// revisions: ast mir
+//[mir]compile-flags: -Z borrowck=mir
+
+#![feature(asm)]
+
+use std::cell::Cell;
+
+#[repr(C)]
+struct NoisyDrop<'a>(&'a Cell<&'static str>);
+impl<'a> Drop for NoisyDrop<'a> {
+    fn drop(&mut self) {
+        self.0.set("destroyed");
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn main() {
+    let status = Cell::new("alive");
+    {
+        let _y: Box<NoisyDrop>;
+        let x = Box::new(NoisyDrop(&status));
+        unsafe {
+            asm!("mov $1, $0" : "=r"(_y) : "r"(x));
+        }
+        assert_eq!(status.get(), "alive");
+    }
+    assert_eq!(status.get(), "destroyed");
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn main() {}

--- a/src/test/run-pass/asm-out-assign.rs
+++ b/src/test/run-pass/asm-out-assign.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// revisions ast mir
+//[mir]compile-flags: -Z borrowck=mir
 
 #![feature(asm)]
 


### PR DESCRIPTION
Closes #45695

New behavior:
* Input operands to `asm!` are moved, direct output operands are initialized.
* Direct, non-read-write outputs match the assignment changes in #46752 (Shallow writes, end borrows).
