### PR TITLE
Make internal docs build properly.

### DIFF
--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1818,7 +1818,7 @@ pub struct GeneratorLayout<'tcx> {
 ///
 /// Example: If type check produces a closure with the closure substs:
 ///
-/// ```
+/// ```text
 /// ClosureSubsts = [
 ///     i8,                                  // the "closure kind"
 ///     for<'x> fn(&'a &'x u32) -> &'x u32,  // the "closure signature"
@@ -1829,7 +1829,7 @@ pub struct GeneratorLayout<'tcx> {
 /// here, there is one unique free region (`'a`) but it appears
 /// twice. We would "renumber" each occurence to a unique vid, as follows:
 ///
-/// ```
+/// ```text
 /// ClosureSubsts = [
 ///     i8,                                  // the "closure kind"
 ///     for<'x> fn(&'1 &'x u32) -> &'x u32,  // the "closure signature"


### PR DESCRIPTION
`'1` isn't a valid lifetime and resulted in a syntax error.