### PR TITLE
[proof of concept] give String support for CoW wrapping of literals

### DIFF
--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -269,7 +269,7 @@ impl<T, A: Alloc> RawVec<T, A> {
     ///
     /// impl<T> MyVec<T> {
     ///     pub fn push(&mut self, elem: T) {
-    ///         if self.len == self.buf.cap() { self.buf.double(); }
+    ///         if self.len >= self.buf.cap() { self.buf.double(self.len); }
     ///         // double would have aborted or panicked if the len exceeded
     ///         // `isize::MAX` so this is safe to do unchecked now.
     ///         unsafe {

--- a/src/liballoc/tests/lib.rs
+++ b/src/liballoc/tests/lib.rs
@@ -12,6 +12,7 @@
 
 #![feature(allocator_api)]
 #![feature(alloc_system)]
+#![feature(ascii_ctype)]
 #![feature(attr_literals)]
 #![feature(box_syntax)]
 #![feature(inclusive_range_syntax)]
@@ -20,6 +21,7 @@
 #![feature(drain_filter)]
 #![feature(exact_size_is_empty)]
 #![feature(iterator_step_by)]
+#![feature(lit_strings)]
 #![feature(pattern)]
 #![feature(placement_in_syntax)]
 #![feature(rand)]

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -732,8 +732,8 @@ impl<T> Vec<T> {
         assert!(index <= len);
 
         // space for the new element
-        if len == self.buf.cap() {
-            self.buf.double();
+        if len >= self.buf.cap() {
+            self.buf.double(len);
         }
 
         unsafe {
@@ -967,8 +967,8 @@ impl<T> Vec<T> {
     pub fn push(&mut self, value: T) {
         // This will panic or abort if we would allocate > isize::MAX bytes
         // or if the length increment would overflow for zero-sized types.
-        if self.len == self.buf.cap() {
-            self.buf.double();
+        if self.len >= self.buf.cap() {
+            self.buf.double(self.len);
         }
         unsafe {
             let end = self.as_mut_ptr().offset(self.len as isize);
@@ -1920,7 +1920,7 @@ impl<T> Vec<T> {
         //      }
         while let Some(element) = iterator.next() {
             let len = self.len();
-            if len == self.capacity() {
+            if len >= self.capacity() {
                 let (lower, _) = iterator.size_hint();
                 self.reserve(lower.saturating_add(1));
             }
@@ -2534,8 +2534,8 @@ impl<'a, T> Placer<T> for PlaceBack<'a, T> {
     fn make_place(self) -> Self {
         // This will panic or abort if we would allocate > isize::MAX bytes
         // or if the length increment would overflow for zero-sized types.
-        if self.vec.len == self.vec.buf.cap() {
-            self.vec.buf.double();
+        if self.vec.len >= self.vec.buf.cap() {
+            self.vec.buf.double(self.vec.len);
         }
         self
     }

--- a/src/liballoc/vec_deque.rs
+++ b/src/liballoc/vec_deque.rs
@@ -1754,7 +1754,7 @@ impl<T> VecDeque<T> {
     fn grow_if_necessary(&mut self) {
         if self.is_full() {
             let old_cap = self.cap();
-            self.buf.double();
+            self.buf.double(old_cap);
             unsafe {
                 self.handle_cap_increase(old_cap);
             }


### PR DESCRIPTION
This is a proof of concept implementation for people who want to test this out. It isn't fully tested, and the RawVec changes probably need more work. In addition the implementation isn't as optimized as it could be (see FIXME's).

This adds a `String::literally` constructor that wraps up a literal without allocating. It in turn makes Vec partially support this (with more robust capacity checking) and RawVec partially support this (by copying the source if len > cap). String also gains some make_unique guards for methods which don't naturally do this themselves (ones which make mutable views or mutate the middle of the buffer).

