### PR TITLE
Follow up to #46924, fix massive spurious failure when starting docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -194,7 +194,7 @@ before_install:
   # they shouldn't exist, please revert once more official solutions appeared.
   # see https://github.com/travis-ci/travis-ci/issues/8891#issuecomment-353403729
   - if [ "$TRAVIS_OS_NAME" = linux ]; then
-      echo '{"ipv6":true,"fixed-cidr-v6":"fe80::/64"}' | sudo tee /etc/docker/daemon.json;
+      echo '{"ipv6":true,"fixed-cidr-v6":"fd9a:8454:6789:13f7::/64"}' | sudo tee /etc/docker/daemon.json;
       sudo service docker restart;
     fi
 


### PR DESCRIPTION
It seems using `fe80::/64` causes `docker start` to fail with "Address already in use". Try to change to a unique local address range instead.

`fe80::/64` is a link-local address (similar to `169.254.0.0/16` in IPv4). Let's try to use a random "private network" address to see whether that fixes things.

cc #47002

r? @aidanhs 