### PR TITLE
rustc: don't use union layouts for tagged union enums.

### DIFF
--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -1655,10 +1655,10 @@ impl<'a, 'tcx> LayoutDetails {
                         discr,
                         variants
                     },
-                    // FIXME(eddyb): using `FieldPlacement::Arbitrary` here results
-                    // in lost optimizations, specifically around allocations, see
-                    // `test/codegen/{alloc-optimisation,vec-optimizes-away}.rs`.
-                    fields: FieldPlacement::Union(1),
+                    fields: FieldPlacement::Arbitrary {
+                        offsets: vec![Size::from_bytes(0)],
+                        memory_index: vec![0]
+                    },
                     abi,
                     align,
                     size

--- a/src/test/codegen/align-struct.rs
+++ b/src/test/codegen/align-struct.rs
@@ -32,13 +32,14 @@ pub enum Enum4 {
     A(i32),
     B(i32),
 }
-// CHECK: %Enum4 = type { [2 x i32] }
+// CHECK: %Enum4 = type { [0 x i32], i32, [1 x i32] }
+// CHECK: %"Enum4::A" = type { [1 x i32], i32, [0 x i32] }
 
 pub enum Enum64 {
     A(Align64),
     B(i32),
 }
-// CHECK: %Enum64 = type { [16 x i64] }
+// CHECK: %Enum64 = type { [0 x i32], i32, [31 x i32] }
 // CHECK: %"Enum64::A" = type { [8 x i64], %Align64, [0 x i64] }
 
 // CHECK-LABEL: @align64


### PR DESCRIPTION
Fixes #46897, fixes #43517 (AFAICT from the testcases).
This PR doesn't add any testcases, we should try to at least get perf ones (cc @Mark-Simulacrum).
I couldn't find an example in those issues where the choice of LLVM array vs struct (with N identical fields) for padding filler types is still needed, *on top of* this change, to prevent excessive LLVM sinking.

r? @arielb1 