### PR TITLE
Do not expand a derive invocation when derive is not allowed 

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1571,7 +1571,7 @@ impl<'a> LoweringContext<'a> {
             bounds,
             default: tp.default.as_ref().map(|x| self.lower_ty(x, ImplTraitContext::Disallowed)),
             span: tp.span,
-            pure_wrt_drop: tp.attrs.iter().any(|attr| attr.check_name("may_dangle")),
+            pure_wrt_drop: attr::contains_name(&tp.attrs, "may_dangle"),
             synthetic: tp.attrs.iter()
                                .filter(|attr| attr.check_name("rustc_synthetic"))
                                .map(|_| hir::SyntheticTyParamKind::ImplTrait)
@@ -1611,7 +1611,7 @@ impl<'a> LoweringContext<'a> {
         let def = hir::LifetimeDef {
             lifetime: self.lower_lifetime(&l.lifetime),
             bounds: self.lower_lifetimes(&l.bounds),
-            pure_wrt_drop: l.attrs.iter().any(|attr| attr.check_name("may_dangle")),
+            pure_wrt_drop: attr::contains_name(&l.attrs, "may_dangle"),
             in_band: false,
         };
 
@@ -2331,7 +2331,7 @@ impl<'a> LoweringContext<'a> {
         let mut vis = self.lower_visibility(&i.vis, None);
         let attrs = self.lower_attrs(&i.attrs);
         if let ItemKind::MacroDef(ref def) = i.node {
-            if !def.legacy || i.attrs.iter().any(|attr| attr.path == "macro_export") {
+            if !def.legacy || attr::contains_name(&i.attrs, "macro_export") {
                 let body = self.lower_token_stream(def.stream());
                 self.exported_macros.push(hir::MacroDef {
                     name,

--- a/src/librustc/traits/on_unimplemented.rs
+++ b/src/librustc/traits/on_unimplemented.rs
@@ -140,9 +140,7 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedDirective {
     {
         let attrs = tcx.get_attrs(impl_def_id);
 
-        let attr = if let Some(item) =
-            attrs.into_iter().find(|a| a.check_name("rustc_on_unimplemented"))
-        {
+        let attr = if let Some(item) = attr::find_by_name(&attrs, "rustc_on_unimplemented") {
             item
         } else {
             return Ok(None);

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2402,7 +2402,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 
     /// Determine whether an item is annotated with an attribute
     pub fn has_attr(self, did: DefId, attr: &str) -> bool {
-        self.get_attrs(did).iter().any(|item| item.check_name(attr))
+        attr::contains_name(&self.get_attrs(did), attr)
     }
 
     /// Returns true if this is an `auto trait`.

--- a/src/librustc_driver/README.md
+++ b/src/librustc_driver/README.md
@@ -3,7 +3,7 @@ compiler as a whole, see
 [the README.md file found in `librustc`](../librustc/README.md).
 
 The `driver` crate is effectively the "main" function for the rust
-compiler.  It orchstrates the compilation process and "knits together"
+compiler.  It orchestrates the compilation process and "knits together"
 the code from the other crates within rustc. This crate itself does
 not contain any of the "main logic" of the compiler (though it does
 have some code related to pretty printing or other minor compiler

--- a/src/librustc_lint/bad_style.rs
+++ b/src/librustc_lint/bad_style.rs
@@ -221,9 +221,7 @@ impl LintPass for NonSnakeCase {
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
     fn check_crate(&mut self, cx: &LateContext, cr: &hir::Crate) {
-        let attr_crate_name = cr.attrs
-            .iter()
-            .find(|at| at.check_name("crate_name"))
+        let attr_crate_name = attr::find_by_name(&cr.attrs, "crate_name")
             .and_then(|at| at.value_str().map(|s| (at, s)));
         if let Some(ref name) = cx.tcx.sess.opts.crate_name {
             self.check_snake_case(cx, "crate", name, None);

--- a/src/librustc_mir/hair/cx/mod.rs
+++ b/src/librustc_mir/hair/cx/mod.rs
@@ -27,6 +27,7 @@ use rustc::ty::subst::Subst;
 use rustc::ty::{self, Ty, TyCtxt};
 use rustc::ty::subst::Substs;
 use syntax::ast;
+use syntax::attr;
 use syntax::symbol::Symbol;
 use rustc::hir;
 use rustc_const_math::{ConstInt, ConstUsize};
@@ -78,8 +79,7 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
         // Some functions always have overflow checks enabled,
         // however, they may not get codegen'd, depending on
         // the settings for the crate they are translated in.
-        let mut check_overflow = attrs.iter()
-            .any(|item| item.check_name("rustc_inherit_overflow_checks"));
+        let mut check_overflow = attr::contains_name(attrs, "rustc_inherit_overflow_checks");
 
         // Respect -C overflow-checks.
         check_overflow |= tcx.sess.overflow_checks();

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -51,8 +51,7 @@ impl<'a> AstValidator<'a> {
     }
 
     fn invalid_non_exhaustive_attribute(&self, variant: &Variant) {
-        let has_non_exhaustive = variant.node.attrs.iter()
-            .any(|attr| attr.check_name("non_exhaustive"));
+        let has_non_exhaustive = attr::contains_name(&variant.node.attrs, "non_exhaustive");
         if has_non_exhaustive {
             self.err_handler().span_err(variant.span,
                                         "#[non_exhaustive] is not yet supported on variants");
@@ -308,7 +307,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
             ItemKind::Mod(_) => {
                 // Ensure that `path` attributes on modules are recorded as used (c.f. #35584).
                 attr::first_attr_value_str_by_name(&item.attrs, "path");
-                if item.attrs.iter().any(|attr| attr.check_name("warn_directory_ownership")) {
+                if attr::contains_name(&item.attrs, "warn_directory_ownership") {
                     let lint = lint::builtin::LEGACY_DIRECTORY_OWNERSHIP;
                     let msg = "cannot declare a new module at this location";
                     self.session.buffer_lint(lint, item.id, item.span, msg);

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -358,8 +358,7 @@ impl<'a> Resolver<'a> {
 
                 let mut ctor_vis = vis;
 
-                let has_non_exhaustive = item.attrs.iter()
-                    .any(|item| item.check_name("non_exhaustive"));
+                let has_non_exhaustive = attr::contains_name(&item.attrs, "non_exhaustive");
 
                 // If the structure is marked as non_exhaustive then lower the visibility
                 // to within the crate.

--- a/src/librustc_trans_utils/link.rs
+++ b/src/librustc_trans_utils/link.rs
@@ -13,7 +13,7 @@ use rustc::session::Session;
 use rustc::middle::cstore::{self, LinkMeta};
 use rustc::hir::svh::Svh;
 use std::path::{Path, PathBuf};
-use syntax::ast;
+use syntax::{ast, attr};
 use syntax_pos::Span;
 
 pub fn out_filename(sess: &Session,
@@ -69,8 +69,8 @@ pub fn find_crate_name(sess: Option<&Session>,
     // as used. After doing this, however, we still prioritize a crate name from
     // the command line over one found in the #[crate_name] attribute. If we
     // find both we ensure that they're the same later on as well.
-    let attr_crate_name = attrs.iter().find(|at| at.check_name("crate_name"))
-                               .and_then(|at| at.value_str().map(|s| (at, s)));
+    let attr_crate_name = attr::find_by_name(attrs, "crate_name")
+        .and_then(|at| at.value_str().map(|s| (at, s)));
 
     if let Some(sess) = sess {
         if let Some(ref s) = sess.opts.crate_name {

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -96,6 +96,18 @@ impl Annotatable {
             _ => panic!("expected Item")
         }
     }
+
+    pub fn derive_allowed(&self) -> bool {
+        match *self {
+            Annotatable::Item(ref item) => match item.node {
+                ast::ItemKind::Struct(..) |
+                ast::ItemKind::Enum(..) |
+                ast::ItemKind::Union(..) => true,
+                _ => false,
+            },
+            _ => false,
+        }
+    }
 }
 
 // A more flexible ItemDecorator.

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -386,15 +386,15 @@ fn is_bench_fn(cx: &TestCtxt, i: &ast::Item) -> bool {
 }
 
 fn is_ignored(i: &ast::Item) -> bool {
-    i.attrs.iter().any(|attr| attr.check_name("ignore"))
+    attr::contains_name(&i.attrs, "ignore")
 }
 
 fn is_allowed_fail(i: &ast::Item) -> bool {
-    i.attrs.iter().any(|attr| attr.check_name("allow_fail"))
+    attr::contains_name(&i.attrs, "allow_fail")
 }
 
 fn should_panic(i: &ast::Item, cx: &TestCtxt) -> ShouldPanic {
-    match i.attrs.iter().find(|attr| attr.check_name("should_panic")) {
+    match attr::find_by_name(&i.attrs, "should_panic") {
         Some(attr) => {
             let sd = cx.span_diagnostic;
             if attr.is_value_str() {

--- a/src/libsyntax_ext/proc_macro_registrar.rs
+++ b/src/libsyntax_ext/proc_macro_registrar.rs
@@ -13,6 +13,7 @@ use std::mem;
 use errors;
 
 use syntax::ast::{self, Ident, NodeId};
+use syntax::attr;
 use syntax::codemap::{ExpnInfo, NameAndSpan, MacroAttribute};
 use syntax::ext::base::ExtCtxt;
 use syntax::ext::build::AstBuilder;
@@ -248,8 +249,7 @@ impl<'a> CollectProcMacros<'a> {
 impl<'a> Visitor<'a> for CollectProcMacros<'a> {
     fn visit_item(&mut self, item: &'a ast::Item) {
         if let ast::ItemKind::MacroDef(..) = item.node {
-            if self.is_proc_macro_crate &&
-               item.attrs.iter().any(|attr| attr.path == "macro_export") {
+            if self.is_proc_macro_crate && attr::contains_name(&item.attrs, "macro_export") {
                 let msg =
                     "cannot export macro_rules! macros from a `proc-macro` crate type currently";
                 self.handler.span_err(item.span, msg);

--- a/src/test/compile-fail/derive-on-trait-item-or-impl-item.rs
+++ b/src/test/compile-fail/derive-on-trait-item-or-impl-item.rs
@@ -1,0 +1,23 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Foo {
+    #[derive(Clone)]
+    //~^ ERROR `derive` may only be applied to structs, enums and unions
+    type Bar;
+}
+
+impl Bar {
+    #[derive(Clone)]
+    //~^ ERROR `derive` may only be applied to structs, enums and unions
+    fn bar(&self) {}
+}
+
+fn main() {}

--- a/src/test/run-pass-fulldeps/auxiliary/custom_derive_plugin_attr.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/custom_derive_plugin_attr.rs
@@ -21,6 +21,7 @@ extern crate rustc;
 extern crate rustc_plugin;
 
 use syntax::ast;
+use syntax::attr;
 use syntax::ext::base::{MultiDecorator, ExtCtxt, Annotatable};
 use syntax::ext::build::AstBuilder;
 use syntax::symbol::Symbol;
@@ -80,7 +81,7 @@ fn totalsum_substructure(cx: &mut ExtCtxt, trait_span: Span,
     };
 
     fields.iter().fold(cx.expr_isize(trait_span, 0), |acc, ref item| {
-        if item.attrs.iter().find(|a| a.check_name("ignore")).is_some() {
+        if attr::contains_name(&item.attrs, "ignore") {
             acc
         } else {
             cx.expr_binary(item.span, ast::BinOpKind::Add, acc,

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/issue-40001-plugin.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/issue-40001-plugin.rs
@@ -17,6 +17,7 @@ extern crate rustc_plugin;
 extern crate syntax;
 
 use rustc_plugin::Registry;
+use syntax::attr;
 use syntax::ext::base::*;
 use syntax::feature_gate::AttributeType::Whitelisted;
 use syntax::symbol::Symbol;
@@ -59,9 +60,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingWhitelistedAttrPass {
             _ => cx.tcx.hir.expect_item(cx.tcx.hir.get_parent(id)),
         };
 
-        if !item.attrs.iter().any(|a| a.check_name("whitelisted_attr")) {
+        if !attr::contains_name(&item.attrs, "whitelisted_attr") {
             cx.span_lint(MISSING_WHITELISTED_ATTR, span,
-                         "Missing 'whitelited_attr' attribute");
+                         "Missing 'whitelisted_attr' attribute");
         }
     }
 }


### PR DESCRIPTION
Closes #46655.

The first commit is what actually closes #46655. The second one is just a refactoring I have done while waiting on a test.