### PR TITLE
nll: Improved error messages in the case of partial and collateral moves

### DIFF
--- a/src/test/compile-fail/borrowck/borrowck-uninit-field-access.rs
+++ b/src/test/compile-fail/borrowck/borrowck-uninit-field-access.rs
@@ -31,16 +31,17 @@ impl Line { fn consume(self) { } }
 
 fn main() {
     let mut a: Point;
-    let _ = a.x + 1; //[ast]~ ERROR use of possibly uninitialized variable: `a.x`
-                     //[mir]~^ ERROR [E0381]
+    let _ = a.x + 1; //[ast]~ ERROR use of possibly uninitialized variable: `a.x` [E0381]
+                     //[mir]~^ ERROR use of possibly uninitialized variable: `a.x` [E0381]
 
     let mut line1 = Line::default();
     let _moved = line1.origin;
-    let _ = line1.origin.x + 1; //[ast]~ ERROR use of collaterally moved value: `line1.origin.x`
-                                //[mir]~^ [E0382]
+    let _ = line1.origin.x + 1;
+        //[ast]~^ ERROR use of collaterally moved value: `line1.origin.x` [E0382]
+        //[mir]~^^ ERROR use of collaterally moved value: `line1.origin.x` [E0382]
 
     let mut line2 = Line::default();
     let _moved = (line2.origin, line2.middle);
     line2.consume(); //[ast]~ ERROR use of partially moved value: `line2` [E0382]
-                     //[mir]~^ [E0382]
+                     //[mir]~^ ERROR use of partially moved value: `line2` [E0382]
 }


### PR DESCRIPTION
Fixes #45700