### PR TITLE
Pass correct span when lowering grouped imports

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -2051,7 +2051,7 @@ impl<'a> LoweringContext<'a> {
                         .chain(path.segments.iter())
                         .cloned()
                         .collect(),
-                    span: path.span.to(prefix.span),
+                    span: path.span
                 };
 
                 // Correctly resolve `self` imports

--- a/src/test/ui/issue-46576.rs
+++ b/src/test/ui/issue-46576.rs
@@ -1,0 +1,31 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(dead_code)]
+#![deny(unused_imports)]
+
+use std::fs::File;
+use std::io::{BufRead, BufReader, Read};
+//~^ ERROR unused import: `BufRead`
+
+pub fn read_from_file(path: &str) {
+    let file = File::open(&path).unwrap();
+    let mut reader = BufReader::new(file);
+    let mut s = String::new();
+    reader.read_to_string(&mut s).unwrap();
+}
+
+pub fn read_lines(s: &str) {
+    for _line in s.lines() {
+
+    }
+}
+
+fn main() {}

--- a/src/test/ui/issue-46576.stderr
+++ b/src/test/ui/issue-46576.stderr
@@ -1,0 +1,14 @@
+error: unused import: `BufRead`
+  --> $DIR/issue-46576.rs:15:15
+   |
+15 | use std::io::{BufRead, BufReader, Read};
+   |               ^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/issue-46576.rs:12:9
+   |
+12 | #![deny(unused_imports)]
+   |         ^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint-output-format-2.stderr
+++ b/src/test/ui/lint-output-format-2.stderr
@@ -1,8 +1,8 @@
 warning: use of deprecated item 'lint_output_format::foo': text
-  --> $DIR/lint-output-format-2.rs:20:5
+  --> $DIR/lint-output-format-2.rs:20:26
    |
 20 | use lint_output_format::{foo, bar};
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                          ^^^
    |
    = note: #[warn(deprecated)] on by default
 


### PR DESCRIPTION
Solves incorrect diagnostics for unused or deprecated imports. Closes #46576.

Deprecated imports had an existing test which asserted the incorrect span.
That test has been corrected as part of this commit.