### PR TITLE
Correct a few stability attributes

### DIFF
--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1024,7 +1024,7 @@ impl<T: ::fmt::Debug> ::fmt::Debug for ManuallyDrop<T> {
     }
 }
 
-#[stable(feature = "manually_drop", since = "1.20.0")]
+#[stable(feature = "manually_drop_impls", since = "1.22.0")]
 impl<T: Clone> Clone for ManuallyDrop<T> {
     fn clone(&self) -> Self {
         ManuallyDrop::new(self.deref().clone())
@@ -1035,14 +1035,14 @@ impl<T: Clone> Clone for ManuallyDrop<T> {
     }
 }
 
-#[stable(feature = "manually_drop", since = "1.20.0")]
+#[stable(feature = "manually_drop_impls", since = "1.22.0")]
 impl<T: Default> Default for ManuallyDrop<T> {
     fn default() -> Self {
         ManuallyDrop::new(Default::default())
     }
 }
 
-#[stable(feature = "manually_drop", since = "1.20.0")]
+#[stable(feature = "manually_drop_impls", since = "1.22.0")]
 impl<T: PartialEq> PartialEq for ManuallyDrop<T> {
     fn eq(&self, other: &Self) -> bool {
         self.deref().eq(other)
@@ -1053,10 +1053,10 @@ impl<T: PartialEq> PartialEq for ManuallyDrop<T> {
     }
 }
 
-#[stable(feature = "manually_drop", since = "1.20.0")]
+#[stable(feature = "manually_drop_impls", since = "1.22.0")]
 impl<T: Eq> Eq for ManuallyDrop<T> {}
 
-#[stable(feature = "manually_drop", since = "1.20.0")]
+#[stable(feature = "manually_drop_impls", since = "1.22.0")]
 impl<T: PartialOrd> PartialOrd for ManuallyDrop<T> {
     fn partial_cmp(&self, other: &Self) -> Option<::cmp::Ordering> {
         self.deref().partial_cmp(other)
@@ -1079,14 +1079,14 @@ impl<T: PartialOrd> PartialOrd for ManuallyDrop<T> {
     }
 }
 
-#[stable(feature = "manually_drop", since = "1.20.0")]
+#[stable(feature = "manually_drop_impls", since = "1.22.0")]
 impl<T: Ord> Ord for ManuallyDrop<T> {
     fn cmp(&self, other: &Self) -> ::cmp::Ordering {
         self.deref().cmp(other)
     }
 }
 
-#[stable(feature = "manually_drop", since = "1.20.0")]
+#[stable(feature = "manually_drop_impls", since = "1.22.0")]
 impl<T: ::hash::Hash> ::hash::Hash for ManuallyDrop<T> {
     fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
         self.deref().hash(state);

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -1997,7 +1997,9 @@ mod traits {
         }
     }
 
-    #[stable(feature = "str_checked_slicing", since = "1.20.0")]
+    #[unstable(feature = "inclusive_range",
+               reason = "recently added, follows RFC",
+               issue = "28237")]
     impl SliceIndex<str> for ops::RangeInclusive<usize> {
         type Output = str;
         #[inline]
@@ -2040,7 +2042,9 @@ mod traits {
 
 
 
-    #[stable(feature = "str_checked_slicing", since = "1.20.0")]
+    #[unstable(feature = "inclusive_range",
+               reason = "recently added, follows RFC",
+               issue = "28237")]
     impl SliceIndex<str> for ops::RangeToInclusive<usize> {
         type Output = str;
         #[inline]

--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -944,6 +944,7 @@ macro_rules! atomic_int {
      $stable_cxchg:meta,
      $stable_debug:meta,
      $stable_access:meta,
+     $stable_from:meta,
      $s_int_type:expr, $int_ref:expr,
      $int_type:ident $atomic_type:ident $atomic_init:ident) => {
         /// An integer type which can be safely shared between threads.
@@ -978,7 +979,7 @@ macro_rules! atomic_int {
             }
         }
 
-        #[stable(feature = "atomic_from", since = "1.23.0")]
+        #[$stable_from]
         impl From<$int_type> for $atomic_type {
             #[inline]
             fn from(v: $int_type) -> Self { Self::new(v) }
@@ -1375,11 +1376,13 @@ atomic_int! {
     unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
+    unstable(feature = "integer_atomics", issue = "32976"),
     "i8", "../../../std/primitive.i8.html",
     i8 AtomicI8 ATOMIC_I8_INIT
 }
 #[cfg(target_has_atomic = "8")]
 atomic_int! {
+    unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
@@ -1393,11 +1396,13 @@ atomic_int! {
     unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
+    unstable(feature = "integer_atomics", issue = "32976"),
     "i16", "../../../std/primitive.i16.html",
     i16 AtomicI16 ATOMIC_I16_INIT
 }
 #[cfg(target_has_atomic = "16")]
 atomic_int! {
+    unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
@@ -1411,11 +1416,13 @@ atomic_int! {
     unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
+    unstable(feature = "integer_atomics", issue = "32976"),
     "i32", "../../../std/primitive.i32.html",
     i32 AtomicI32 ATOMIC_I32_INIT
 }
 #[cfg(target_has_atomic = "32")]
 atomic_int! {
+    unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
@@ -1429,11 +1436,13 @@ atomic_int! {
     unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
+    unstable(feature = "integer_atomics", issue = "32976"),
     "i64", "../../../std/primitive.i64.html",
     i64 AtomicI64 ATOMIC_I64_INIT
 }
 #[cfg(target_has_atomic = "64")]
 atomic_int! {
+    unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
@@ -1447,6 +1456,7 @@ atomic_int!{
     stable(feature = "extended_compare_and_swap", since = "1.10.0"),
     stable(feature = "atomic_debug", since = "1.3.0"),
     stable(feature = "atomic_access", since = "1.15.0"),
+    stable(feature = "atomic_from", since = "1.23.0"),
     "isize", "../../../std/primitive.isize.html",
     isize AtomicIsize ATOMIC_ISIZE_INIT
 }
@@ -1456,6 +1466,7 @@ atomic_int!{
     stable(feature = "extended_compare_and_swap", since = "1.10.0"),
     stable(feature = "atomic_debug", since = "1.3.0"),
     stable(feature = "atomic_access", since = "1.15.0"),
+    stable(feature = "atomic_from", since = "1.23.0"),
     "usize", "../../../std/primitive.usize.html",
     usize AtomicUsize ATOMIC_USIZE_INIT
 }

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -706,7 +706,7 @@ impl From<CString> for Box<CStr> {
     }
 }
 
-#[stable(feature = "shared_from_slice2", since = "1.23.0")]
+#[stable(feature = "shared_from_slice2", since = "1.24.0")]
 impl From<CString> for Arc<CStr> {
     #[inline]
     fn from(s: CString) -> Arc<CStr> {
@@ -715,7 +715,7 @@ impl From<CString> for Arc<CStr> {
     }
 }
 
-#[stable(feature = "shared_from_slice2", since = "1.23.0")]
+#[stable(feature = "shared_from_slice2", since = "1.24.0")]
 impl<'a> From<&'a CStr> for Arc<CStr> {
     #[inline]
     fn from(s: &CStr) -> Arc<CStr> {
@@ -724,7 +724,7 @@ impl<'a> From<&'a CStr> for Arc<CStr> {
     }
 }
 
-#[stable(feature = "shared_from_slice2", since = "1.23.0")]
+#[stable(feature = "shared_from_slice2", since = "1.24.0")]
 impl From<CString> for Rc<CStr> {
     #[inline]
     fn from(s: CString) -> Rc<CStr> {
@@ -733,7 +733,7 @@ impl From<CString> for Rc<CStr> {
     }
 }
 
-#[stable(feature = "shared_from_slice2", since = "1.23.0")]
+#[stable(feature = "shared_from_slice2", since = "1.24.0")]
 impl<'a> From<&'a CStr> for Rc<CStr> {
     #[inline]
     fn from(s: &CStr) -> Rc<CStr> {

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -594,7 +594,7 @@ impl From<OsString> for Box<OsStr> {
     }
 }
 
-#[stable(feature = "shared_from_slice2", since = "1.23.0")]
+#[stable(feature = "shared_from_slice2", since = "1.24.0")]
 impl From<OsString> for Arc<OsStr> {
     #[inline]
     fn from(s: OsString) -> Arc<OsStr> {
@@ -603,7 +603,7 @@ impl From<OsString> for Arc<OsStr> {
     }
 }
 
-#[stable(feature = "shared_from_slice2", since = "1.23.0")]
+#[stable(feature = "shared_from_slice2", since = "1.24.0")]
 impl<'a> From<&'a OsStr> for Arc<OsStr> {
     #[inline]
     fn from(s: &OsStr) -> Arc<OsStr> {
@@ -612,7 +612,7 @@ impl<'a> From<&'a OsStr> for Arc<OsStr> {
     }
 }
 
-#[stable(feature = "shared_from_slice2", since = "1.23.0")]
+#[stable(feature = "shared_from_slice2", since = "1.24.0")]
 impl From<OsString> for Rc<OsStr> {
     #[inline]
     fn from(s: OsString) -> Rc<OsStr> {
@@ -621,7 +621,7 @@ impl From<OsString> for Rc<OsStr> {
     }
 }
 
-#[stable(feature = "shared_from_slice2", since = "1.23.0")]
+#[stable(feature = "shared_from_slice2", since = "1.24.0")]
 impl<'a> From<&'a OsStr> for Rc<OsStr> {
     #[inline]
     fn from(s: &OsStr) -> Rc<OsStr> {

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1454,7 +1454,7 @@ impl<'a> From<PathBuf> for Cow<'a, Path> {
     }
 }
 
-#[stable(feature = "shared_from_slice2", since = "1.23.0")]
+#[stable(feature = "shared_from_slice2", since = "1.24.0")]
 impl From<PathBuf> for Arc<Path> {
     #[inline]
     fn from(s: PathBuf) -> Arc<Path> {
@@ -1463,7 +1463,7 @@ impl From<PathBuf> for Arc<Path> {
     }
 }
 
-#[stable(feature = "shared_from_slice2", since = "1.23.0")]
+#[stable(feature = "shared_from_slice2", since = "1.24.0")]
 impl<'a> From<&'a Path> for Arc<Path> {
     #[inline]
     fn from(s: &Path) -> Arc<Path> {
@@ -1472,7 +1472,7 @@ impl<'a> From<&'a Path> for Arc<Path> {
     }
 }
 
-#[stable(feature = "shared_from_slice2", since = "1.23.0")]
+#[stable(feature = "shared_from_slice2", since = "1.24.0")]
 impl From<PathBuf> for Rc<Path> {
     #[inline]
     fn from(s: PathBuf) -> Rc<Path> {
@@ -1481,7 +1481,7 @@ impl From<PathBuf> for Rc<Path> {
     }
 }
 
-#[stable(feature = "shared_from_slice2", since = "1.23.0")]
+#[stable(feature = "shared_from_slice2", since = "1.24.0")]
 impl<'a> From<&'a Path> for Rc<Path> {
     #[inline]
     fn from(s: &Path) -> Rc<Path> {

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -382,7 +382,7 @@ unsafe impl<#[may_dangle] T: ?Sized> Drop for Mutex<T> {
     }
 }
 
-#[stable(feature = "mutex_from", since = "1.22.0")]
+#[stable(feature = "mutex_from", since = "1.24.0")]
 impl<T> From<T> for Mutex<T> {
     /// Creates a new mutex in an unlocked state ready for use.
     /// This is equivalent to [`Mutex::new`].

--- a/src/libstd/sync/rwlock.rs
+++ b/src/libstd/sync/rwlock.rs
@@ -457,7 +457,7 @@ impl<T: Default> Default for RwLock<T> {
     }
 }
 
-#[stable(feature = "rw_lock_from", since = "1.22.0")]
+#[stable(feature = "rw_lock_from", since = "1.24.0")]
 impl<T> From<T> for RwLock<T> {
     /// Creates a new instance of an `RwLock<T>` which is unlocked.
     /// This is equivalent to [`RwLock::new`].


### PR DESCRIPTION
* The extra impls for `ManuallyDrop` were added in #44310 which was only stabilised in 1.22.0.
* The impls for `SliceIndex` were stabilised in #43373 but as `RangeInclusive` and `RangeToInclusive` are still unstable the impls should remain unstable.
* The `From` impls for atomic integers were added in #45610 but most atomic integers are still unstable.
* The `shared_from_slice2` impls were added in #45990 but they won't be stable until 1.24.0.
* The `Mutex` and `RwLock` impls were added in #46082 but won't be stable until 1.24.0.
