### PR TITLE
Report an error when resolving non-ident macro path failed

### DIFF
--- a/src/test/compile-fail/extern-macro.rs
+++ b/src/test/compile-fail/extern-macro.rs
@@ -1,0 +1,18 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// #41719
+
+#![feature(use_extern_macros)]
+
+fn main() {
+    enum Foo {}
+    let _ = Foo::bar!(); //~ ERROR fail to resolve non-ident macro path
+}


### PR DESCRIPTION
Closes #41719.

Please feel free to bikeshed on the error message.