### PR TITLE
Disable printing of error message on file descriptor 2 on CloudABI.

### DIFF
--- a/src/liballoc_system/lib.rs
+++ b/src/liballoc_system/lib.rs
@@ -21,7 +21,7 @@
 #![feature(core_intrinsics)]
 #![feature(staged_api)]
 #![feature(rustc_attrs)]
-#![cfg_attr(any(unix, target_os = "redox"), feature(libc))]
+#![cfg_attr(any(unix, target_os = "cloudabi", target_os = "redox"), feature(libc))]
 #![rustc_alloc_kind = "lib"]
 
 // The minimum alignment guaranteed by the architecture. This value is used to
@@ -116,7 +116,7 @@ unsafe impl Alloc for System {
     }
 }
 
-#[cfg(any(unix, target_os = "redox"))]
+#[cfg(any(unix, target_os = "cloudabi", target_os = "redox"))]
 mod platform {
     extern crate libc;
 

--- a/src/liballoc_system/lib.rs
+++ b/src/liballoc_system/lib.rs
@@ -213,6 +213,16 @@ mod platform {
             struct Stderr;
 
             impl Write for Stderr {
+                #[cfg(target_os = "cloudabi")]
+                fn write_str(&mut self, _: &str) -> fmt::Result {
+                    // CloudABI does not have any reserved file descriptor
+                    // numbers. We should not attempt to write to file
+                    // descriptor #2, as it may be associated with any kind of
+                    // resource.
+                    Ok(())
+                }
+
+                #[cfg(not(target_os = "cloudabi"))]
                 fn write_str(&mut self, s: &str) -> fmt::Result {
                     unsafe {
                         libc::write(libc::STDERR_FILENO,


### PR DESCRIPTION
As CloudABI is a capability-based runtime environment, file descriptors
are the mechanism that grants rights to a process. These file
descriptors may be passed into processes on startup using a utility
called cloudabi-run. Unlike the POSIX shell, cloudabi-run does not
follow the UNIX model where file descriptors 0, 1 and 2 represent stdin,
stdout and stderr. There can be arbitrary many (or few) file descriptors
that can be provided. For this reason, CloudABI's C library also doesn't
define STD*_FILENO. liblibc should also not declare these.

Disable the code in liballoc_system that tries to print error messages
over file descriptor 2. For now, let's keep this function quiet. We'll
see if we can think of some other way to log this in the future.