### PR TITLE
Remove dep-info files as targets in themselves

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1236,6 +1236,9 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
          overriding the default for the current target"),
     human_readable_cgu_names: bool = (false, parse_bool, [TRACKED],
         "generate human-readable, predictable names for codegen units"),
+    dep_info_omit_d_target: bool = (false, parse_bool, [TRACKED],
+        "in dep-info output, omit targets for tracking dependencies of the dep-info files \
+         themselves"),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1162,6 +1162,8 @@ fn write_out_deps(sess: &Session, outputs: &OutputFilenames, crate_name: &str) {
                     out_filenames.push(p);
                 }
             }
+            // Do not include the dep-info file in itself as a target
+            OutputType::DepInfo => { }
             _ => {
                 out_filenames.push(file);
             }

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1162,8 +1162,9 @@ fn write_out_deps(sess: &Session, outputs: &OutputFilenames, crate_name: &str) {
                     out_filenames.push(p);
                 }
             }
-            // Do not include the dep-info file in itself as a target
-            OutputType::DepInfo => { }
+            OutputType::DepInfo if sess.opts.debugging_opts.dep_info_omit_d_target => {
+                // Don't add the dep-info output when omitting it from dep-info targets
+            }
             _ => {
                 out_filenames.push(file);
             }


### PR DESCRIPTION
If you ask `rustc` to `--emit dep-info`, the resulting dependency file contains a rule for producing the dependency file itself. This differs from the output of `gcc -MD` or `clang -MD`, which only includes dependency rules for the object files produced.

Tools like Ninja often consume and delete dependency files as soon as they’re produced for performance reasons, particularly on Windows. In the case of `rustc` output, though, the recently-deleted dependency file is cached by Ninja as a target, and therefore triggers a rebuild every time.

This very small patch removes the dep-info file from the list of output filenames, so it matches the behavior of gcc and clang.