### PR TITLE
update char_indices example to highlight big chars

### DIFF
--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -719,12 +719,16 @@ impl str {
     /// Remember, [`char`]s may not match your human intuition about characters:
     ///
     /// ```
-    /// let y = "y̆";
+    /// let yes = "y̆es";
     ///
-    /// let mut char_indices = y.char_indices();
+    /// let mut char_indices = yes.char_indices();
     ///
     /// assert_eq!(Some((0, 'y')), char_indices.next()); // not (0, 'y̆')
     /// assert_eq!(Some((1, '\u{0306}')), char_indices.next());
+    ///
+    /// // note the 3 here - the last character took up two bytes
+    /// assert_eq!(Some((3, 'e')), char_indices.next());
+    /// assert_eq!(Some((4, 's')), char_indices.next());
     ///
     /// assert_eq!(None, char_indices.next());
     /// ```


### PR DESCRIPTION
There was a comment today in IRC where someone thought `char_indices()` and `chars().enumerate()` were equivalent, so i wanted to put an example in the docs where that wasn't true.

r? @rust-lang/docs 