### PR TITLE
Future-proof the compiler for Box<T, A>.

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -568,7 +568,8 @@ impl<T: ?Sized> Arc<T> {
 
     fn from_box(v: Box<T>) -> Arc<T> {
         unsafe {
-            let bptr = Box::into_raw(v);
+            let box_unique = Box::into_unique(v);
+            let bptr = box_unique.as_ptr();
 
             let value_size = size_of_val(&*bptr);
             let ptr = Self::allocate_for_ptr(bptr);
@@ -580,7 +581,7 @@ impl<T: ?Sized> Arc<T> {
                 value_size);
 
             // Free the allocation without dropping its contents
-            box_free(bptr);
+            box_free(box_unique);
 
             Arc { ptr: Shared::new_unchecked(ptr), phantom: PhantomData }
         }

--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -17,6 +17,7 @@
 
 use core::intrinsics::{min_align_of_val, size_of_val};
 use core::mem::{self, ManuallyDrop};
+use core::ptr::Unique;
 use core::usize;
 
 pub use allocator::*;
@@ -252,9 +253,21 @@ unsafe fn exchange_malloc(size: usize, align: usize) -> *mut u8 {
     }
 }
 
-#[cfg_attr(not(test), lang = "box_free")]
+#[cfg(stage0)]
+#[lang = "box_free"]
 #[inline]
-pub(crate) unsafe fn box_free<T: ?Sized>(ptr: *mut T) {
+pub(crate) unsafe fn old_box_free<T: ?Sized>(ptr: *mut T) {
+    box_free(Unique::new_unchecked(ptr))
+}
+
+#[cfg_attr(not(any(test, stage0)), lang = "box_free")]
+#[inline]
+// Invoked by the compiler to deallocate the storage of `Box<T>`,
+// after the owned `T` value on the heap has already been dropped.
+// NB: the generics should be the same as for `Box`, and the
+// argument types should match the fields in `struct Box`.
+pub(crate) unsafe fn box_free<T: ?Sized>(ptr: Unique<T>) {
+    let ptr = ptr.as_ptr();
     let size = size_of_val(&*ptr);
     let align = min_align_of_val(&*ptr);
     // We do not allocate for Box<T> when T is ZST, so deallocation is also not necessary.

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -681,7 +681,8 @@ impl<T: ?Sized> Rc<T> {
 
     fn from_box(v: Box<T>) -> Rc<T> {
         unsafe {
-            let bptr = Box::into_raw(v);
+            let box_unique = Box::into_unique(v);
+            let bptr = box_unique.as_ptr();
 
             let value_size = size_of_val(&*bptr);
             let ptr = Self::allocate_for_ptr(bptr);
@@ -693,7 +694,7 @@ impl<T: ?Sized> Rc<T> {
                 value_size);
 
             // Free the allocation without dropping its contents
-            box_free(bptr);
+            box_free(box_unique);
 
             Rc { ptr: Shared::new_unchecked(ptr), phantom: PhantomData }
         }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -31,7 +31,7 @@ use middle::lang_items;
 use middle::resolve_lifetime::{self, ObjectLifetimeDefault};
 use middle::stability;
 use mir::{Mir, interpret};
-use ty::subst::{Kind, Substs};
+use ty::subst::{Kind, Substs, Subst};
 use ty::ReprOptions;
 use ty::Instance;
 use traits;
@@ -1959,7 +1959,14 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     pub fn mk_box(self, ty: Ty<'tcx>) -> Ty<'tcx> {
         let def_id = self.require_lang_item(lang_items::OwnedBoxLangItem);
         let adt_def = self.adt_def(def_id);
-        let substs = self.mk_substs(iter::once(Kind::from(ty)));
+        let substs = Substs::for_item(self, def_id, |_, _| bug!(), |def, substs| {
+            if def.index == 0 {
+                ty
+            } else {
+                assert!(def.has_default);
+                self.type_of(def.def_id).subst(self, substs)
+            }
+        });
         self.mk_ty(TyAdt(adt_def, substs))
     }
 

--- a/src/librustc_const_eval/_match.rs
+++ b/src/librustc_const_eval/_match.rs
@@ -853,7 +853,7 @@ fn constructor_sub_pattern_tys<'a, 'tcx: 'a>(cx: &MatchCheckCtxt<'a, 'tcx>,
         ty::TyAdt(adt, substs) => {
             if adt.is_box() {
                 // Use T as the sub pattern type of Box<T>.
-                vec![substs[0].as_type().unwrap()]
+                vec![ty.boxed_ty()]
             } else {
                 adt.variants[ctor.variant_index_for_adt(adt)].fields.iter().map(|field| {
                     let is_visible = adt.is_enum()

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -823,9 +823,6 @@ fn find_vtable_types_for_unsizing<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
          &ty::TyRawPtr(ty::TypeAndMut { ty: b, .. })) => {
             ptr_vtable(a, b)
         }
-        (&ty::TyAdt(def_a, _), &ty::TyAdt(def_b, _)) if def_a.is_box() && def_b.is_box() => {
-            ptr_vtable(source_ty.boxed_ty(), target_ty.boxed_ty())
-        }
 
         (&ty::TyAdt(source_adt_def, source_substs),
          &ty::TyAdt(target_adt_def, target_substs)) => {

--- a/src/librustc_trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/debuginfo/metadata.rs
@@ -558,6 +558,7 @@ pub fn type_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                 Err(metadata) => return metadata,
             }
         }
+        // FIXME(eddyb) remove this Box special-case.
         ty::TyAdt(def, _) if def.is_box() => {
             match ptr_metadata(t.boxed_ty()) {
                 Ok(res) => res,

--- a/src/librustc_trans/debuginfo/mod.rs
+++ b/src/librustc_trans/debuginfo/mod.rs
@@ -431,6 +431,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                 // Only "class" methods are generally understood by LLVM,
                 // so avoid methods on other types (e.g. `<*mut T>::null`).
                 match impl_self_ty.sty {
+                    // FIXME(eddyb) remove this Box special-case.
                     ty::TyAdt(def, ..) if !def.is_box() => {
                         Some(type_metadata(cx, impl_self_ty, syntax_pos::DUMMY_SP))
                     }

--- a/src/librustc_trans/intrinsic.rs
+++ b/src/librustc_trans/intrinsic.rs
@@ -248,7 +248,7 @@ pub fn trans_intrinsic_call<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
         },
         "volatile_store" => {
             let tp_ty = substs.type_at(0);
-            let dst = args[0].deref(bcx.ccx);
+            let dst = args[0].deref(bcx);
             if let OperandValue::Pair(a, b) = args[1].val {
                 bcx.volatile_store(a, dst.project_field(bcx, 0).llval);
                 bcx.volatile_store(b, dst.project_field(bcx, 1).llval);
@@ -394,7 +394,7 @@ pub fn trans_intrinsic_call<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
         },
 
         "discriminant_value" => {
-            args[0].deref(bcx.ccx).trans_get_discr(bcx, ret_ty)
+            args[0].deref(bcx).trans_get_discr(bcx, ret_ty)
         }
 
         "align_offset" => {
@@ -542,7 +542,7 @@ pub fn trans_intrinsic_call<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
 
         "nontemporal_store" => {
             let tp_ty = substs.type_at(0);
-            let dst = args[0].deref(bcx.ccx);
+            let dst = args[0].deref(bcx);
             let val = if let OperandValue::Ref(ptr, align) = args[1].val {
                 bcx.load(ptr, align)
             } else {

--- a/src/librustc_trans/mir/place.rs
+++ b/src/librustc_trans/mir/place.rs
@@ -431,7 +431,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 elem: mir::ProjectionElem::Deref
             }) => {
                 // Load the pointer from its location.
-                self.trans_consume(bcx, base).deref(bcx.ccx)
+                self.trans_consume(bcx, base).deref(bcx)
             }
             mir::Place::Projection(ref projection) => {
                 let tr_base = self.trans_place(bcx, &projection.base);

--- a/src/librustc_trans/type_of.rs
+++ b/src/librustc_trans/type_of.rs
@@ -252,6 +252,7 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyLayout<'tcx> {
                 ty::TyRawPtr(ty::TypeAndMut { ty, .. }) => {
                     ccx.layout_of(ty).llvm_type(ccx).ptr_to()
                 }
+                // FIXME(eddyb) remove this Box special-case.
                 ty::TyAdt(def, _) if def.is_box() => {
                     ccx.layout_of(self.ty.boxed_ty()).llvm_type(ccx).ptr_to()
                 }
@@ -340,10 +341,6 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyLayout<'tcx> {
             ty::TyRef(..) |
             ty::TyRawPtr(_) => {
                 return self.field(ccx, index).llvm_type(ccx);
-            }
-            ty::TyAdt(def, _) if def.is_box() => {
-                let ptr_ty = ccx.tcx().mk_mut_ptr(self.ty.boxed_ty());
-                return ccx.layout_of(ptr_ty).scalar_pair_element_llvm_type(ccx, index);
             }
             _ => {}
         }

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -713,11 +713,6 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
                 self.type_must_outlive(infer::RelateObjectBound(cast_expr.span), from_ty, r);
             }
 
-            /*From:*/ (&ty::TyAdt(from_def, _),
-            /*To:  */  &ty::TyAdt(to_def, _)) if from_def.is_box() && to_def.is_box() => {
-                self.walk_cast(cast_expr, from_ty.boxed_ty(), to_ty.boxed_ty());
-            }
-
             _ => { }
         }
     }

--- a/src/test/codegen/function-arguments.rs
+++ b/src/test/codegen/function-arguments.rs
@@ -128,7 +128,7 @@ pub fn str(_: &[u8]) {
 pub fn trait_borrow(_: &Drop) {
 }
 
-// CHECK: @trait_box(%"core::ops::drop::Drop"* noalias nonnull, {}* noalias nonnull readonly)
+// CHECK: @trait_box(i8* noalias nonnull, i8* noalias nonnull readonly)
 #[no_mangle]
 pub fn trait_box(_: Box<Drop>) {
 }

--- a/src/test/compile-fail/regions-close-object-into-object-5.rs
+++ b/src/test/compile-fail/regions-close-object-into-object-5.rs
@@ -30,7 +30,6 @@ fn f<'a, T, U>(v: Box<A<T>+'static>) -> Box<X+'static> {
         //~| ERROR the parameter type `T` may not live long enough
         //~| ERROR the parameter type `T` may not live long enough
         //~| ERROR the parameter type `T` may not live long enough
-        //~| ERROR the parameter type `T` may not live long enough
 }
 
 fn main() {}

--- a/src/test/compile-fail/regions-close-over-type-parameter-1.rs
+++ b/src/test/compile-fail/regions-close-over-type-parameter-1.rs
@@ -19,7 +19,6 @@ trait SomeTrait { fn get(&self) -> isize; }
 fn make_object1<A:SomeTrait>(v: A) -> Box<SomeTrait+'static> {
     box v as Box<SomeTrait+'static>
         //~^ ERROR the parameter type `A` may not live long enough
-        //~| ERROR the parameter type `A` may not live long enough
 }
 
 fn make_object2<'a,A:SomeTrait+'a>(v: A) -> Box<SomeTrait+'a> {
@@ -29,7 +28,6 @@ fn make_object2<'a,A:SomeTrait+'a>(v: A) -> Box<SomeTrait+'a> {
 fn make_object3<'a,'b,A:SomeTrait+'a>(v: A) -> Box<SomeTrait+'b> {
     box v as Box<SomeTrait+'b>
         //~^ ERROR the parameter type `A` may not live long enough
-        //~| ERROR the parameter type `A` may not live long enough
 }
 
 fn main() { }


### PR DESCRIPTION
@Ericson2314 is playing around with `Box<T, A = Heap>` and there is still some special-casing in the compiler around `Box`, some of which is removed by this PR.
Ideally we can merge this before the beta cutoff to avoid needing a `cfg(stage0)` copy of `Box`.

r? @alexcrichton 