### PR TITLE
Remove an unused import for cfg(not(feature = "backtrace")).

### DIFF
--- a/src/libstd/rt.rs
+++ b/src/libstd/rt.rs
@@ -36,8 +36,6 @@ fn lang_start_internal(main: &(Fn() -> i32 + Sync + ::panic::RefUnwindSafe),
     use sys_common;
     use sys_common::thread_info;
     use thread::Thread;
-    #[cfg(not(feature = "backtrace"))]
-    use mem;
 
     sys::init();
 


### PR DESCRIPTION
The 'mem' module is not used for this specific code. This was
copy-pasted in by accident when adding RFC 1937 (? in main) support.