### PR TITLE
rustdoc: Don't try to generate links for modules in import paths

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -435,32 +435,10 @@ pub fn href(did: DefId) -> Option<(String, ItemType, Vec<String>)> {
 fn resolved_path(w: &mut fmt::Formatter, did: DefId, path: &clean::Path,
                  print_all: bool, use_absolute: bool) -> fmt::Result {
     let last = path.segments.last().unwrap();
-    let rel_root = match &*path.segments[0].name {
-        "self" => Some("./".to_string()),
-        _ => None,
-    };
 
     if print_all {
-        let amt = path.segments.len() - 1;
-        match rel_root {
-            Some(mut root) => {
-                for seg in &path.segments[..amt] {
-                    if "super" == seg.name || "self" == seg.name || w.alternate() {
-                        write!(w, "{}::", seg.name)?;
-                    } else {
-                        root.push_str(&seg.name);
-                        root.push_str("/");
-                        write!(w, "<a class=\"mod\" href=\"{}index.html\">{}</a>::",
-                               root,
-                               seg.name)?;
-                    }
-                }
-            }
-            None => {
-                for seg in &path.segments[..amt] {
-                    write!(w, "{}::", seg.name)?;
-                }
-            }
+        for seg in &path.segments[..path.segments.len() - 1] {
+            write!(w, "{}::", seg.name)?;
         }
     }
     if w.alternate() {

--- a/src/test/rustdoc/issue-46766.rs
+++ b/src/test/rustdoc/issue-46766.rs
@@ -1,0 +1,16 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "foo"]
+
+pub enum Enum{Variant}
+pub use self::Enum::Variant;
+
+// @!has foo/index.html '//a/@href' './Enum/index.html'

--- a/src/test/rustdoc/issue-46767.rs
+++ b/src/test/rustdoc/issue-46767.rs
@@ -1,0 +1,18 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "foo"]
+
+mod private {
+    pub enum Enum{Variant}
+}
+pub use self::private::Enum::*;
+
+// @!has foo/index.html '//a/@href' './private/index.html'


### PR DESCRIPTION
The modules may be private or may even be enums so it would generate dead links.

Fixes #29814
Fixes #46766
Fixes #46767