### PR TITLE
Don't normalize paths in backtraces to be relative to the cwd.

### DIFF
--- a/src/libstd/sys_common/backtrace.rs
+++ b/src/libstd/sys_common/backtrace.rs
@@ -16,7 +16,6 @@ use io::prelude::*;
 use io;
 use str;
 use sync::atomic::{self, Ordering};
-use path::{self, Path};
 use sys::mutex::Mutex;
 use ptr;
 
@@ -215,23 +214,7 @@ fn output_fileline(w: &mut Write,
     }
 
     let file = str::from_utf8(file).unwrap_or("<unknown>");
-    let file_path = Path::new(file);
-    let mut already_printed = false;
-    if format == PrintFormat::Short && file_path.is_absolute() {
-        if let Ok(cwd) = env::current_dir() {
-            if let Ok(stripped) = file_path.strip_prefix(&cwd) {
-                if let Some(s) = stripped.to_str() {
-                    write!(w, "  at .{}{}:{}", path::MAIN_SEPARATOR, s, line)?;
-                    already_printed = true;
-                }
-            }
-        }
-    }
-    if !already_printed {
-        write!(w, "  at {}:{}", file, line)?;
-    }
-
-    w.write_all(b"\n")
+    write!(w, "  at {}:{}\n", file, line)
 }
 
 


### PR DESCRIPTION
Though this code is well intended, it is the only place in the backtrace
code where we depend on local file system interaction. By adding this
normalization, it becomes harder to use this code in environments where
there is no current working directory (i.e., freestanding environments
or sandboxed environments, such as CloudABI).

I suspect that printing absolute paths here is also useful to prevent
confusion and to make it easier to copy-paste and use paths between
separate terminal sessions.