### PR TITLE
fix read_exact for Cursor

### DIFF
--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -677,7 +677,7 @@ mod tests {
         c.set_position(<usize>::max_value() as u64 + 1);
         assert!(c.write_all(&[1, 2, 3]).is_err());
     }
-    
+
     #[test]
     fn vec_read_exact_past_end() {
         let mut in_buf = vec![0, 1, 2, 3, 4, 5, 6, 7];

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -232,16 +232,9 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
 
     fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
         let n = buf.len();
-        match Read::read_exact(&mut self.fill_buf()?, buf) {
-            Err(e) => {
-                self.pos = self.inner.as_ref().len() as u64;
-                Err(e)
-            }
-            Ok(_) => {
-                self.pos += n as u64;
-                Ok(())
-            }
-        }
+        Read::read_exact(&mut self.fill_buf()?, buf)?;
+        self.pos += n as u64;
+        Ok(())
     }
 
     #[inline]
@@ -683,6 +676,7 @@ mod tests {
         let mut in_buf = vec![0, 1, 2, 3, 4, 5, 6, 7];
         let mut r = Cursor::new(vec![1]);
         assert!(r.read_exact(&mut in_buf).is_err());
+        assert_eq!(in_buf, [1, 1, 2, 3, 4, 5, 6, 7]);
         assert_eq!(r.position(), 1);
     }
 

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -232,9 +232,16 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
 
     fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
         let n = buf.len();
-        Read::read_exact(&mut self.fill_buf()?, buf)?;
-        self.pos += n as u64;
-        Ok(())
+        match Read::read_exact(&mut self.fill_buf()?, buf) {
+            Err(e) => {
+                self.pos = self.inner.as_ref().len() as u64;
+                Err(e)
+            }
+            Ok(_) => {
+                self.pos += n as u64;
+                Ok(())
+            }
+        }
     }
 
     #[inline]
@@ -670,4 +677,13 @@ mod tests {
         c.set_position(<usize>::max_value() as u64 + 1);
         assert!(c.write_all(&[1, 2, 3]).is_err());
     }
+    
+    #[test]
+    fn vec_read_exact_past_end() {
+        let mut in_buf = vec![0, 1, 2, 3, 4, 5, 6, 7];
+        let mut r = Cursor::new(vec![1]);
+        assert!(r.read_exact(&mut in_buf).is_err());
+        assert_eq!(r.position(), 1);
+    }
+
 }


### PR DESCRIPTION
```rust
fn main() {
    use std::io::Cursor;
    use std::io::prelude::*;
    let mut in_buf = vec![0, 1, 2, 3, 4, 5, 6, 7];
    let mut r = Cursor::new(vec![1]);
    assert!(r.read_exact(&mut in_buf).is_err());
    assert_eq!(r.position(), 1);
}
```
pos unchanged.