### PR TITLE
Add CloudABI to the list of systems on which we stub out alloc_jemalloc.

### DIFF
--- a/src/liballoc_jemalloc/build.rs
+++ b/src/liballoc_jemalloc/build.rs
@@ -29,9 +29,9 @@ fn main() {
     // for targets like emscripten, even if we don't use it.
     let target = env::var("TARGET").expect("TARGET was not set");
     let host = env::var("HOST").expect("HOST was not set");
-    if target.contains("rumprun") || target.contains("bitrig") || target.contains("openbsd") ||
-       target.contains("msvc") || target.contains("emscripten") || target.contains("fuchsia") ||
-       target.contains("redox") || target.contains("wasm32") {
+    if target.contains("bitrig") || target.contains("cloudabi") || target.contains("emscripten") ||
+       target.contains("fuchsia") || target.contains("msvc") || target.contains("openbsd") ||
+       target.contains("redox") || target.contains("rumprun") || target.contains("wasm32") {
         println!("cargo:rustc-cfg=dummy_jemalloc");
         return;
     }


### PR DESCRIPTION
The official jemalloc sources don't build cleanly on CloudABI yet, for
the reason that some of its tracing frameworks try to access the global
filesystem namespace, which CloudABI doesn't provide.

Always make use of the malloc implementation used by the C library,
which already happens to be jemalloc with some tiny build fixes.