### PR TITLE
Fix nested imports not included in the save_analysis output

### DIFF
--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -1252,7 +1252,13 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> DumpVisitor<'l, 'tcx, 'll, O> {
                          root_item: &'l ast::Item,
                          prefix: &ast::Path) {
         let path = &use_tree.prefix;
-        let access = access_from!(self.save_ctxt, root_item);
+
+        // The access is calculated using the current tree ID, but with the root tree's visibility
+        // (since nested trees don't have their own visibility).
+        let access = Access {
+            public: root_item.vis == ast::Visibility::Public,
+            reachable: self.save_ctxt.analysis.access_levels.is_reachable(id),
+        };
 
         // The parent def id of a given use tree is always the enclosing item.
         let parent = self.save_ctxt.tcx.hir.opt_local_def_id(id)


### PR DESCRIPTION
This PR fixes #46823.

The bug was caused by the old access level checking code, which checked against the root UseTree even for nested trees. The problem with that is, for nested trees the root is lowered as an empty `ListStem`, which is not reachable by definition. The new code computes the access level with each tree's own ID, and with the root tree's visibility.

I tested this manually and it works, but I'm not really satisfied with that. I looked at the existing tests though, and no one checked for the save_analysis output as far as I can see. How should I proceed with that? I think having a test about this would be really nice.