### PR TITLE
Add UnboundedIterator Trait

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -63,7 +63,7 @@ use core::borrow;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{self, Hash, Hasher};
-use core::iter::FusedIterator;
+use core::iter::{FusedIterator, UnboundedIterator};
 use core::marker::{self, Unsize};
 use core::mem;
 use core::ops::{CoerceUnsized, Deref, DerefMut, Generator, GeneratorState};
@@ -758,6 +758,9 @@ impl<I: ExactSizeIterator + ?Sized> ExactSizeIterator for Box<I> {
 
 #[unstable(feature = "fused", issue = "35602")]
 impl<I: FusedIterator + ?Sized> FusedIterator for Box<I> {}
+
+#[unstable(feature = "unbounded_iter", issue = "0")]
+unsafe impl<I: UnboundedIterator + ?Sized> UnboundedIterator for Box<I> {}
 
 
 /// `FnBox` is a version of the `FnOnce` intended for use with boxed

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -118,6 +118,7 @@
 #![feature(staged_api)]
 #![feature(str_internals)]
 #![feature(trusted_len)]
+#![feature(unbounded_iter)]
 #![feature(unboxed_closures)]
 #![feature(unicode)]
 #![feature(unique)]

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -332,7 +332,10 @@ pub use self::traits::FusedIterator;
 #[unstable(feature = "trusted_len", issue = "37572")]
 pub use self::traits::TrustedLen;
 #[unstable(feature = "unbounded_iter", issue = "0")]
-pub use self::traits::{UnboundedIterator, UnboundedIteratorAuto};
+pub use self::traits::UnboundedIterator;
+// FIXME: #46813
+//#[unstable(feature = "unbounded_iter", issue = "0")]
+//pub use self::traits::UnboundedIteratorAuto;
 
 mod iterator;
 mod range;
@@ -705,6 +708,7 @@ impl<I> Iterator for StepBy<I> where I: Iterator {
 }
 
 // StepBy specialization trait
+// FIXME: #36262
 #[doc(hidden)]
 trait StepByImpl {
     fn size_hint(&self) -> (usize, Option<usize>);
@@ -976,6 +980,7 @@ impl<A, B> DoubleEndedIterator for Chain<A, B> where
 }
 
 // Chain specialization trait
+// FIXME: #36262
 #[doc(hidden)]
 trait ChainImpl {
     fn size_hint(&self) -> (usize, Option<usize>);
@@ -1577,6 +1582,7 @@ impl<I: DoubleEndedIterator, P> DoubleEndedIterator for Filter<I, P>
 }
 
 // Filter specialization trait
+// FIXME: #36262
 #[doc(hidden)]
 trait FilterImpl {
     fn size_hint(&self) -> (usize, Option<usize>);
@@ -1721,6 +1727,7 @@ impl<B, I: DoubleEndedIterator, F> DoubleEndedIterator for FilterMap<I, F>
 }
 
 // FilterMap specialization trait
+// FIXME: #36262
 #[doc(hidden)]
 trait FilterMapImpl {
     fn size_hint(&self) -> (usize, Option<usize>);
@@ -2170,6 +2177,7 @@ impl<I: Iterator, P> Iterator for SkipWhile<I, P>
 }
 
 // SkipWhile specialization trait
+// FIXME: #36262
 #[doc(hidden)]
 trait SkipWhileImpl {
     fn size_hint(&self) -> (usize, Option<usize>);
@@ -2418,6 +2426,7 @@ impl<I> DoubleEndedIterator for Skip<I> where I: DoubleEndedIterator + ExactSize
 }
 
 // Skip specialization trait
+// FIXME: #36262
 #[doc(hidden)]
 trait SkipImpl {
     fn size_hint(&self) -> (usize, Option<usize>);
@@ -2755,6 +2764,7 @@ impl<I: DoubleEndedIterator, U, F> DoubleEndedIterator for FlatMap<I, U, F> wher
 }
 
 // FlatMap specialization trait
+// FIXME: #36262
 #[doc(hidden)]
 trait FlatMapImpl {
     fn size_hint(&self) -> (usize, Option<usize>);

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -682,7 +682,7 @@ impl<I> CycleImpl for Cycle<I> where I: Clone + Iterator {
     }
 }
 
-// Specialized StepBy impl for an underlying UnboundedIterator
+// Specialized Cycle impl for an underlying UnboundedIterator
 impl<I> CycleImpl for Cycle<I> where I: Clone + UnboundedIterator {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -781,6 +781,11 @@ impl<I: UnboundedIterator> StepByImpl for StepBy<I> {
            reason = "unstable replacement of Range::step_by",
            issue = "27741")]
 impl<I> ExactSizeIterator for StepBy<I> where I: ExactSizeIterator {}
+
+#[unstable(feature = "iterator_step_by",
+           reason = "unstable replacement of Range::step_by",
+           issue = "27741")]
+impl<I> FusedIterator for StepBy<I> where I: FusedIterator {}
 
 #[unstable(feature = "iterator_step_by",
            reason = "unstable replacement of Range::step_by",
@@ -1091,7 +1096,7 @@ unsafe impl<A, B> TrustedLen for Chain<A, B>
 #[unstable(feature = "unbounded_iter", issue = "0")]
 unsafe impl<A, B> UnboundedIterator for Chain<A, B>
     where A: UnboundedIterator,
-          B: Iterator<Item=A::Item>,
+          B: FusedIterator<Item=A::Item>,
 //          (A, B): UnboundedIteratorAuto
 {}
 //#[unstable(feature = "unbounded_iter", issue = "0")]
@@ -2807,7 +2812,7 @@ trait FlatMapImpl {
     fn size_hint(&self) -> (usize, Option<usize>);
 }
 
-// General StepBy impl
+// General FlatMap impl
 impl<I: Iterator, U: IntoIterator, F> FlatMapImpl for FlatMap<I, U, F>
     where F: FnMut(I::Item) -> U,
 {

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -1650,7 +1650,7 @@ impl<I: UnboundedIterator, P> FilterImpl for Filter<I, P>
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         // If the underlying iterator is unbounded, we will either filter out all items
-        // and thus diverge, or filter some of the infinitely many items out.
+        // and thus diverge, or filter out some of the infinitely many items.
         (usize::MAX, None)
     }
 }

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -13,7 +13,7 @@ use mem;
 use ops::{self, Add, Sub};
 use usize;
 
-use super::{FusedIterator, TrustedLen};
+use super::{FusedIterator, TrustedLen, UnboundedIterator};
 
 /// Objects that can be stepped over in both directions.
 ///
@@ -266,6 +266,12 @@ range_incl_exact_iter_impl!(u8 u16 i8 i16);
 // the upper bound is None when it does not fit the type limits.
 range_trusted_len_impl!(usize isize u8 i8 u16 i16 u32 i32 i64 u64);
 range_incl_trusted_len_impl!(usize isize u8 i8 u16 i16 u32 i32 i64 u64);
+
+// We can safely implement `UnboundedIterator` for all RangeFrom because
+// `Step::add_one` will always return `Self` or diverge, which is exactly
+// the contract `UnboundedIterator` describes.
+#[unstable(feature = "unbounded_iter", issue = "0")]
+unsafe impl<A: Step> UnboundedIterator for ops::RangeFrom<A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A: Step> DoubleEndedIterator for ops::Range<A> {

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -269,7 +269,7 @@ range_incl_trusted_len_impl!(usize isize u8 i8 u16 i16 u32 i32 i64 u64);
 
 // We can safely implement `UnboundedIterator` for all RangeFrom because
 // `Step::add_one` will always return `Self` or diverge, which is exactly
-// the contract `UnboundedIterator` describes.
+// what the contract `UnboundedIterator` describes.
 #[unstable(feature = "unbounded_iter", issue = "0")]
 unsafe impl<A: Step> UnboundedIterator for ops::RangeFrom<A> {}
 

--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -12,7 +12,7 @@ use fmt;
 use marker;
 use usize;
 
-use super::{FusedIterator, TrustedLen};
+use super::{FusedIterator, TrustedLen, UnboundedIterator};
 
 /// An iterator that repeats an element endlessly.
 ///
@@ -43,6 +43,9 @@ impl<A: Clone> DoubleEndedIterator for Repeat<A> {
 
 #[unstable(feature = "fused", issue = "35602")]
 impl<A: Clone> FusedIterator for Repeat<A> {}
+
+#[unstable(feature = "unbounded_iter", issue = "0")]
+unsafe impl<A: Clone> UnboundedIterator for Repeat<A> {}
 
 /// Creates a new iterator that endlessly repeats a single element.
 ///

--- a/src/libcore/iter/traits.rs
+++ b/src/libcore/iter/traits.rs
@@ -1008,10 +1008,11 @@ unsafe impl<'a, I: UnboundedIterator + ?Sized> UnboundedIterator for &'a mut I {
 
 // Hacky auto trait to allow specialization of iter::Chain,
 // because it requares either A: UI or B: UI or both.
-#[unstable(feature = "unbounded_iter", issue = "0")]
-#[doc(hidden)]
-pub auto trait UnboundedIteratorAuto {}
-
-#[unstable(feature = "unbounded_iter", issue = "0")]
-impl<A, B> !UnboundedIteratorAuto for (A, B)
-    where A: UnboundedIteratorAuto, B: UnboundedIteratorAuto {}
+// FIXME: #46813
+//#[unstable(feature = "unbounded_iter", issue = "0")]
+//#[doc(hidden)]
+//pub auto trait UnboundedIteratorAuto {}
+//
+//#[unstable(feature = "unbounded_iter", issue = "0")]
+//impl<A, B> !UnboundedIteratorAuto for (A, B)
+//    where A: UnboundedIteratorAuto, B: UnboundedIteratorAuto {}

--- a/src/libcore/iter/traits.rs
+++ b/src/libcore/iter/traits.rs
@@ -1000,8 +1000,10 @@ unsafe impl<'a, I: TrustedLen + ?Sized> TrustedLen for &'a mut I {}
 ///
 /// [`None`]: ../../std/option/enum.Option.html#variant.None
 /// [`.size_hint`]: ../../std/iter/trait.Iterator.html#method.size_hint
+// We can't implement FusedIterator for T where T: UnboundedIterator due to
+// a clash for &'a mut I. Thus, we need to make it a supertrait.
 #[unstable(feature = "unbounded_iter", issue = "0")]
-pub unsafe trait UnboundedIterator : Iterator {}
+pub unsafe trait UnboundedIterator : FusedIterator {}
 
 #[unstable(feature = "unbounded_iter", issue = "0")]
 unsafe impl<'a, I: UnboundedIterator + ?Sized> UnboundedIterator for &'a mut I {}

--- a/src/libcore/iter/traits.rs
+++ b/src/libcore/iter/traits.rs
@@ -1000,9 +1000,18 @@ unsafe impl<'a, I: TrustedLen + ?Sized> TrustedLen for &'a mut I {}
 ///
 /// [`None`]: ../../std/option/enum.Option.html#variant.None
 /// [`.size_hint`]: ../../std/iter/trait.Iterator.html#method.size_hint
-#[unstable(feature="unbounded_iter", issue = "0")]
+#[unstable(feature = "unbounded_iter", issue = "0")]
 pub unsafe trait UnboundedIterator : Iterator {}
 
-#[unstable(feature="unbounded_iter", issue = "0")]
+#[unstable(feature = "unbounded_iter", issue = "0")]
 unsafe impl<'a, I: UnboundedIterator + ?Sized> UnboundedIterator for &'a mut I {}
 
+// Hacky auto trait to allow specialization of iter::Chain,
+// because it requares either A: UI or B: UI or both.
+#[unstable(feature = "unbounded_iter", issue = "0")]
+#[doc(hidden)]
+pub auto trait UnboundedIteratorAuto {}
+
+#[unstable(feature = "unbounded_iter", issue = "0")]
+impl<A, B> !UnboundedIteratorAuto for (A, B)
+    where A: UnboundedIteratorAuto, B: UnboundedIteratorAuto {}

--- a/src/libcore/iter/traits.rs
+++ b/src/libcore/iter/traits.rs
@@ -987,3 +987,22 @@ pub unsafe trait TrustedLen : Iterator {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<'a, I: TrustedLen + ?Sized> TrustedLen for &'a mut I {}
+
+/// An iterator that will never return [`None`].
+///
+/// Any iterator implementing this trait will either continue to return
+/// values infinitely, or diverge.
+/// Additionally, its [`.size_hint`] must return `(usize::MAX, None)`.
+///
+/// # Safety
+///
+/// This trait must only be implemented when the contract is upheld.
+///
+/// [`None`]: ../../std/option/enum.Option.html#variant.None
+/// [`.size_hint`]: ../../std/iter/trait.Iterator.html#method.size_hint
+#[unstable(feature="unbounded_iter", issue = "0")]
+pub unsafe trait UnboundedIterator : Iterator {}
+
+#[unstable(feature="unbounded_iter", issue = "0")]
+unsafe impl<'a, I: UnboundedIterator + ?Sized> UnboundedIterator for &'a mut I {}
+

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -952,14 +952,14 @@ fn test_iterator_size_hint() {
     assert_eq!(c.clone().take(5).size_hint(), (5, Some(5)));
     assert_eq!(c.clone().skip(5).size_hint().1, None);
     assert_eq!(c.clone().take_while(|_| false).size_hint(), (0, None));
-    assert_eq!(c.clone().skip_while(|_| false).size_hint(), (0, None));
+    assert_eq!(c.clone().skip_while(|_| false).size_hint(), (usize::MAX, None));
     assert_eq!(c.clone().enumerate().size_hint(), (usize::MAX, None));
     assert_eq!(c.clone().chain(vi.clone().cloned()).size_hint(), (usize::MAX, None));
     assert_eq!(c.clone().zip(vi.clone()).size_hint(), (10, Some(10)));
     assert_eq!(c.clone().scan(0, |_,_| Some(0)).size_hint(), (0, None));
-    assert_eq!(c.clone().filter(|_| false).size_hint(), (0, None));
+    assert_eq!(c.clone().filter(|_| false).size_hint(), (usize::MAX, None));
     assert_eq!(c.clone().map(|_| 0).size_hint(), (usize::MAX, None));
-    assert_eq!(c.filter_map(|_| Some(0)).size_hint(), (0, None));
+    assert_eq!(c.filter_map(|_| Some(0)).size_hint(), (usize::MAX, None));
 
     assert_eq!(vi.clone().take(5).size_hint(), (5, Some(5)));
     assert_eq!(vi.clone().take(12).size_hint(), (10, Some(10)));
@@ -1700,4 +1700,118 @@ fn test_flat_map_try_folds() {
     assert_eq!(iter.next(), Some(17));
     assert_eq!(iter.try_rfold(0, i8::checked_add), None);
     assert_eq!(iter.next_back(), Some(35));
+}
+
+fn test_unbounded_iterator<I: UnboundedIterator>(iter: I) {
+    assert_eq!(iter.size_hint(), (usize::MAX, None))
+}
+
+fn test_trusted_len<I: TrustedLen>(_: I) {}
+
+#[test]
+fn test_unbounded_iterator_repeat() {
+    test_unbounded_iterator(repeat(0))
+}
+
+#[test]
+fn test_unbounded_iterator_rangefrom() {
+    test_unbounded_iterator(0..)
+}
+
+#[test]
+fn test_unbounded_iterator_rev() {
+    test_unbounded_iterator(repeat(0).rev())
+}
+
+#[test]
+fn test_unbounded_iterator_filter() {
+    test_unbounded_iterator(repeat(0).filter(|_| true))
+}
+
+#[test]
+fn test_unbounded_iterator_cycle() {
+    test_unbounded_iterator(repeat(0).cycle())
+}
+
+#[test]
+fn test_unbounded_iterator_fuse() {
+    test_unbounded_iterator(repeat(0).fuse())
+}
+
+#[test]
+fn test_unbounded_iterator_map() {
+    test_unbounded_iterator(repeat(0).map(|_| 1))
+}
+
+#[test]
+fn test_unbounded_iterator_inspect() {
+    test_unbounded_iterator(repeat(0).inspect(|_| {}))
+}
+
+#[test]
+fn test_unbounded_iterator_skip_while() {
+    test_unbounded_iterator(repeat(0).skip_while(|_| false))
+}
+
+#[test]
+fn test_unbounded_iterator_filter_map() {
+    test_unbounded_iterator(repeat(0).filter_map(|_| Some(1)))
+}
+
+#[test]
+fn test_unbounded_iterator_zip() {
+    test_unbounded_iterator(repeat(0).zip(0..))
+}
+
+#[test]
+fn test_unbounded_iterator_step_by() {
+    test_unbounded_iterator(repeat(0).step_by(5))
+}
+
+#[test]
+fn test_unbounded_iterator_chain() {
+    test_unbounded_iterator(repeat(0).chain(0..));
+    test_unbounded_iterator(repeat(0).chain(Some(1)));
+    // FIXME: #46813
+//    test_unbounded_iterator(Some(1).into_iter().chain(repeat(0)));
+}
+
+#[test]
+fn test_unbounded_iterator_enumerate() {
+    test_unbounded_iterator(repeat(0).enumerate())
+}
+
+#[test]
+fn test_unbounded_iterator_flat_map() {
+    test_unbounded_iterator(repeat(0).flat_map(|_| Some(1)));
+}
+
+#[test]
+fn test_unbounded_iterator_skip() {
+    test_unbounded_iterator(repeat(0).skip(5))
+}
+
+#[test]
+fn test_unbounded_iterator_peekable() {
+    test_unbounded_iterator(repeat(0).peekable())
+}
+
+#[test]
+fn test_unbounded_iterator_cloned() {
+    test_unbounded_iterator(repeat(&0).cloned())
+}
+
+#[test]
+fn test_unbounded_iterator_box() {
+    test_unbounded_iterator(Box::new(repeat(0)))
+}
+
+#[test]
+fn test_trusted_len_repeat_take() {
+    test_trusted_len(repeat(0).take(100))
+}
+
+#[test]
+fn test_trusted_len_rangefrom_take() {
+    test_trusted_len((0..).take(100))
 }

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -38,6 +38,7 @@
 #![feature(step_trait)]
 #![feature(test)]
 #![feature(trusted_len)]
+#![feature(unbounded_iter)]
 #![feature(try_from)]
 #![feature(try_trait)]
 #![feature(unique)]


### PR DESCRIPTION
[The `TrustedLen` PR](https://github.com/rust-lang/rust/pull/37306) ([tracking issue](https://github.com/rust-lang/rust/issues/37572)) is an effort to improve the performance of `FromIterator` / `Extend` code using specialization when working with iterators reporting a correct `size_hint` (i.e. are marked with the `TrustedLen` trait).  Unfortunately, it does not work for infinite iterators, which a fixed number of elements are `take`n from. Instead, currently calling e.g. `.take(n).collect::<Vec<_>>()` on an unbounded iterator produces [a loop adding one element at a time to the vector with capacity checks on each iteraton](https://godbolt.org/g/pPrnrH). The optimized implementation of `vec!`, which should be used here as well, just uses `calloc` as we'd expect when creating a zeroed vector.
Using any number different from zero results in the same loop with the iterator approach. The macro produces partially unrolled asm with SIMD instructions instead.

This PR introduces the unsafe `UnboundedIterator` trait, which marks infinite iterators. This marker is used for optimizations.

Its contract is described as the following:

```
An iterator that will never return None.

Any iterator implementing this trait will either continue to return
values infinitely, or diverge.
Additionally, its .size_hint must return (usize::MAX, None).

# Safety

This trait must only be implemented when the contract is upheld.
```

## Improvements

* `TrustedLen` is implemented whenever `.take(n)` is called on an `UnboundedIterator`. This optimizes cases similar to `repeat(x).take(n).collect()`.
* Calling `.fuse()` on an `UnboundedIterator` becomes a noop.
* Calling `.cycle()` on an `UnboundedIterator` becomes a noop.

## Possible Future Improvements (TBD)

* Calling a consumer function on an unbounded iterator can produce a compile warning, as it most likely indicates a bug in the code. More on this in Unresolved Questions.
* With this PR, `repeat(0).take(n).collect::<Vec<_>>` allocates the size on the heap and uses memset to set the values to 0. This could be optimized to use `__rustc_alloc_zeroed` just as `vec![0; n]` is optimized to do.
* Another marker trait can be introduced, which marks iterators that return at least one value (first `.next()` call will return `Some`). (One problem here is code like `let iter = _; iter.next(); iter.cycle()`, as any call to `.next()` invalidates the property). This can be used for further improvements to `Cycle` as it can be an `UnboundedIterator` if the underlying iterator returns at least one value (currently it's only unbounded if the inner iterator is unbounded). Additionally, FlatMap with an outer iterator producing at least one element and an unbounded inner iterator can be unbounded as well.
* In an intermediate representation inside the rust compiler it should be possible to elide all `None`-branches from code handling return values of `.next()` calls on unbounded iterators. For now, I wasn't able to find a case where llvm wasn't able to do this already with static linking. With dynamic libraries, though, this is a possible optimization (if we trust the library file).

## Unbounded Iterator Implementers

* "Generators": `Repeat`, `RangeFrom`
* Simple: `Rev`, `Fuse`, `Map`, `Inspect`, `Zip`, `Enumerate`, `Peekable`, `Cloned`, `Box`
* With specialization for `size_hint`: `Filter`, `SkipWhile`, `FilterMap`, `StepBy`, `FlatMap`, `Skip`
* `Cycle`: If the inner iterator is unbounded, `T` is in theory not required to be `Clone`. Unfortunately, removing it from the `UnboundedIterator` implementation results in `conflicting implementation` in the specialization trait implementation.
* `Chain`: In theory, a `Chain` with the first, second or both iterators being unbounded can be an `UnboundedIterator`. Unfortunately, afaik it's not possible to express this right now. [I tried some auto trait hackery](https://play.rust-lang.org/?gist=2930b00ec6172710d3beb4f3ceb63f2b&version=nightly), but ran into #46813 . Thus, currently it's only implemented if the first one is unbounded.

## Alternatives

* Introduce `size_hint2` on `Iterator` returning more information than `size_hint`, which can also indicate unbounded iterators. This will be a large public change, which will probably require an RFC first. Additionally, static analyses e.g. to warn on calling consumers on unbounded iterators might become harder. Optimizations would happen inside each function, which will match on the return value of `size_hint2` instead of specialization, increasing the cyclomatic complexity of these functions.
* Instead of using an unsafe marker trait, a safe trait could be used with `fn next(&mut self) -> Self::Item`, which expresses the contract of `UnboundedIterator` in the type system.

## Implementation Notes / Questions

As this is my first contribution to Rust, I'd like to evaluate on some of my design decisions and ask some questions. Also I'd highly appreciate any feedback on my code.

* Which feature gate should I use when implementing `UnboundedIterator` for `StepBy`, `iterator_step_by` or `unbounded_iter`? I decided to go with the former, as that was also done by `FusedIterator`.
* Is it currently possible to express the three possible combinations of trait bounds for `Chain` as described in Unbounded Iterator Implementers?
* Can the implementation of `UnboundedIterator` on `Cycle` remove the `Clone` trait bound as mentioned in Unbounded Iterator Implementers?
* Currently, to make `.fuse()` into a noop, I use `FusedIterator` as supertrait: `trait UnboundedIterator: FusedIterator`. While this results in the desired optimization, I'd rather like to express it using `impl<I: UnboundedIterator> FusedIterator for I`. Unfortunately, that conflicts with `impl<'a, I: FusedIterator + ?Sized> FusedIterator for &'a mut I {}`.
Additionally, making `FusedIterator` a supertrait of `UnboundedIterator` requires `Chain<A, B>` to have both A fused and B fused due to the implementation of `FusedIterator` for `Chain`. Is there a better way to express that any `UnboundedIterator` is also a `FusedIterator`, which passes the compiler?
* I used a new specialization trait for structs requiring specialization of their `size_hint` method instead of directly specializing `Iterator` and `UnboundedIterator` because it currently breaks type inference: https://github.com/rust-lang/rust/issues/36262#issuecomment-353197822

## Unresolved Questions

1. Introducing `UnboundedIterator` allows us to detect some possibly infinite loops, namely calling consumer functions on them. For example `repeat(0).count()` will result in an infinite loop. I'd suggest that a compile warning should be produced in these cases. In most cases, this is a bug. And in the few cases where this is intended behaviour, `#[allow(...)]` can be used. Consuming methods are `count`, `last`, `fold`, `all`, `max`, `min`, `max_by_key`, `max_by`, `min_by_key`, `min_by`, `sum` and `product`. The functions `collect` and `partition` might fit here as well, but their contract does not actually state that they consume all elements. So there can be an implementation of `FromIterator` which only consumes a finite number of elements. Nonetheless, usually this points to a bug, so I think calling these two methods should still produce a warning.
When discussing this in the Rust discord guild I got mixed feedback, which is why I'm adding this as part of the Unresolved Questions. What do you think about this?
Also, in which layer would this change be done? As far as I understand, adding a new warning requires a new lint. Would it be possible to add this similar to `#[deprecated]` as an annotation which is added to the default implementations of these functions on `UnboundedIterator`?
1. Should `TrustedLen` be implemented for `UnboundedIterator`s? Any `UnboundedIterator` does follow the contract, but does that implementation actually add anything useful?
1. Should every implementation of `UnboundedIterator` specialize the underlying struct's `size_hint` method to ensure returning `(usize::MAX, None)`? Currently types that don't need specialization do return this with their current implementation. But maybe with a later PR this might change. Specializing all of them better ensures the contract in case of changes not keeping in mind the `UnboundedIterator` contract.
1. Currently there is the constraint of `size_hint` needing to return `(usize::MAX, None)` for `UnboundedIterator` implementers. This is both because `Take` has a `size_hint` implementation, which works correctly if the underlying iterator returns these values, and because it makes sense. Should this constrait be removed and `Take` specialized instead?