### PR TITLE
Issue 46976

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -995,9 +995,10 @@ impl<'a> LoweringContext<'a> {
                         );
 
                         let hir_bounds = self.lower_bounds(bounds, itctx);
+                        // Set the name to `impl Bound1 + Bound2`
+                        let name = Symbol::intern(&pprust::ty_to_string(t));
                         self.in_band_ty_params.push(hir::TyParam {
-                            // Set the name to `impl Bound1 + Bound2`
-                            name: Symbol::intern(&pprust::ty_to_string(t)),
+                            name,
                             id: def_node_id,
                             bounds: hir_bounds,
                             default: None,
@@ -1009,7 +1010,7 @@ impl<'a> LoweringContext<'a> {
                         hir::TyPath(hir::QPath::Resolved(None, P(hir::Path {
                             span,
                             def: Def::TyParam(DefId::local(def_index)),
-                            segments: vec![].into(),
+                            segments: hir_vec![hir::PathSegment::from_name(name)],
                         })))
                     },
                     ImplTraitContext::Disallowed => {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -4130,7 +4130,11 @@ fn get_index_type_name(clean_type: &clean::Type, accept_generic: bool) -> Option
     match *clean_type {
         clean::ResolvedPath { ref path, .. } => {
             let segments = &path.segments;
-            Some(segments[segments.len() - 1].name.clone())
+            let path_segment = segments.into_iter().last().unwrap_or_else(|| panic!(
+                "get_index_type_name(clean_type: {:?}, accept_generic: {:?}) had length zero path",
+                clean_type, accept_generic
+            ));
+            Some(path_segment.name.clone())
         }
         clean::Generic(ref s) if accept_generic => Some(s.clone()),
         clean::Primitive(ref p) => Some(format!("{:?}", p)),

--- a/src/test/rustdoc/issue-46976.rs
+++ b/src/test/rustdoc/issue-46976.rs
@@ -1,0 +1,12 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(universal_impl_trait)]
+pub fn ice(f: impl Fn()) {}


### PR DESCRIPTION
ICE is due to an empty path segments, so I set the path to be the same as the in band ty params symbol. (I think this is how regular generics end up being handled?)

Pinging @cramertj, this is your code I'm editing here.