### PR TITLE
in which leading zeroes on tuple-struct accesses are abjured

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2592,7 +2592,7 @@ impl<'a> Parser<'a> {
                   token::Ident(..) => {
                     e = self.parse_dot_suffix(e, lo)?;
                   }
-                  token::Literal(token::Integer(n), suf) => {
+                  token::Literal(token::Integer(index_ident), suf) => {
                     let sp = self.span;
 
                     // A tuple index may not have a suffix
@@ -2602,16 +2602,25 @@ impl<'a> Parser<'a> {
                     hi = self.span;
                     self.bump();
 
-                    let index = n.as_str().parse::<usize>().ok();
+                    let invalid_msg = "invalid tuple or struct index";
+
+                    let index = index_ident.as_str().parse::<usize>().ok();
                     match index {
                         Some(n) => {
+                            if n.to_string() != index_ident.as_str() {
+                                let mut err = self.struct_span_err(self.prev_span, invalid_msg);
+                                err.span_suggestion(self.prev_span,
+                                                    "try simplifying the index",
+                                                    n.to_string());
+                                err.emit();
+                            }
                             let id = respan(dot_span.to(hi), n);
                             let field = self.mk_tup_field(e, id);
                             e = self.mk_expr(lo.to(hi), field, ThinVec::new());
                         }
                         None => {
                             let prev_span = self.prev_span;
-                            self.span_err(prev_span, "invalid tuple or tuple struct index");
+                            self.span_err(prev_span, invalid_msg);
                         }
                     }
                   }

--- a/src/test/ui/issue-47073-zero-padded-tuple-struct-indices.rs
+++ b/src/test/ui/issue-47073-zero-padded-tuple-struct-indices.rs
@@ -1,0 +1,22 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+type Guilty = bool;
+type FineDollars = u32;
+
+struct Verdict(Guilty, Option<FineDollars>);
+
+fn main() {
+    let justice = Verdict(true, Some(2718));
+    let _condemned = justice.00;
+    //~^ ERROR invalid tuple or struct index
+    let _punishment = justice.001;
+    //~^ ERROR invalid tuple or struct index
+}

--- a/src/test/ui/issue-47073-zero-padded-tuple-struct-indices.stderr
+++ b/src/test/ui/issue-47073-zero-padded-tuple-struct-indices.stderr
@@ -1,0 +1,14 @@
+error: invalid tuple or struct index
+  --> $DIR/issue-47073-zero-padded-tuple-struct-indices.rs:18:30
+   |
+18 |     let _condemned = justice.00;
+   |                              ^^ help: try simplifying the index: `0`
+
+error: invalid tuple or struct index
+  --> $DIR/issue-47073-zero-padded-tuple-struct-indices.rs:20:31
+   |
+20 |     let _punishment = justice.001;
+   |                               ^^^ help: try simplifying the index: `1`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Resolves #47073. If accepted, a point in the compatibility section of the release notes is warranted.