### PR TITLE
Don't announce CloudABI as being UNIX.

### DIFF
--- a/src/librustc_back/target/cloudabi_base.rs
+++ b/src/librustc_back/target/cloudabi_base.rs
@@ -23,7 +23,7 @@ pub fn opts() -> TargetOptions {
 
     TargetOptions {
         executables: true,
-        target_family: Some("unix".to_string()),
+        target_family: None,
         linker_is_gnu: true,
         pre_link_args: args,
         position_independent_executables: true,


### PR DESCRIPTION
This was originally brought in, because the definitions are based on
those of FreeBSD, Linux, etc. Even though CloudABI is based on POSIX, it
uses a subset that is so small that it's not reasonable to call it POSIX.

Now that I'm porting libstd, I'm running into some spots where I have to
explicitly disable code paths that were enabled by cfg(unix).