### PR TITLE
Clarify where `is_import` is used

### DIFF
--- a/src/librustc/hir/def.rs
+++ b/src/librustc/hir/def.rs
@@ -132,6 +132,7 @@ pub struct Export {
     /// We include non-`pub` exports for hygienic macros that get used from extern crates.
     pub vis: ty::Visibility,
     /// True if from a `use` or and `extern crate`.
+    /// Used in rustdoc.
     pub is_import: bool,
 }
 


### PR DESCRIPTION
So it's not mistaken for dead code.