### PR TITLE
Add std::time::Duration::{from_days, from_hours, from_mins}

### DIFF
--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -80,6 +80,63 @@ impl Duration {
         Duration { secs: secs, nanos: nanos }
     }
 
+    /// Creates a new `Duration` from the specified number of whole days.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(duration_from_hours)]
+    /// use std::time::Duration;
+    ///
+    /// let duration = Duration::from_days(1);
+    ///
+    /// assert_eq!(86_400, duration.as_secs());
+    /// assert_eq!(0, duration.subsec_nanos());
+    /// ```
+    #[unstable(feature = "duration_from_hours", issue = "47097")]
+    #[inline]
+    pub fn from_days(days: u64) -> Duration {
+        Duration { secs: 86_400*days, nanos: 0 }
+    }
+
+    /// Creates a new `Duration` from the specified number of whole hours.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(duration_from_hours)]
+    /// use std::time::Duration;
+    ///
+    /// let duration = Duration::from_hours(2);
+    ///
+    /// assert_eq!(7200, duration.as_secs());
+    /// assert_eq!(0, duration.subsec_nanos());
+    /// ```
+    #[unstable(feature = "duration_from_hours", issue = "47097")]
+    #[inline]
+    pub fn from_hours(hours: u64) -> Duration {
+        Duration { secs: 3600*hours, nanos: 0 }
+    }
+
+    /// Creates a new `Duration` from the specified number of whole minutes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(duration_from_mins)]
+    /// use std::time::Duration;
+    ///
+    /// let duration = Duration::from_mins(5);
+    ///
+    /// assert_eq!(300, duration.as_secs());
+    /// assert_eq!(0, duration.subsec_nanos());
+    /// ```
+    #[unstable(feature = "duration_from_mins", issue = "47097")]
+    #[inline]
+    pub fn from_mins(mins: u64) -> Duration {
+        Duration { secs: 60*mins, nanos: 0 }
+    }
+
     /// Creates a new `Duration` from the specified number of whole seconds.
     ///
     /// # Examples

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -80,12 +80,14 @@ impl Duration {
         Duration { secs: secs, nanos: nanos }
     }
 
-    /// Creates a new `Duration` from the specified number of whole days.
+    /// Creates a new `Duration` from the specified number of whole days. Note that days are
+    /// strictly interpreted as duration math, i.e. one day is strictly twenty-four hours. This
+    /// function does not perform any calendar math or timezone math.
     ///
     /// # Examples
     ///
     /// ```
-    /// #![feature(duration_from_hours)]
+    /// #![feature(duration_from)]
     /// use std::time::Duration;
     ///
     /// let duration = Duration::from_days(1);
@@ -93,7 +95,7 @@ impl Duration {
     /// assert_eq!(86_400, duration.as_secs());
     /// assert_eq!(0, duration.subsec_nanos());
     /// ```
-    #[unstable(feature = "duration_from_hours", issue = "47097")]
+    #[unstable(feature = "duration_from", issue = "47097")]
     #[inline]
     pub fn from_days(days: u64) -> Duration {
         Duration { secs: 86_400*days, nanos: 0 }
@@ -104,7 +106,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// #![feature(duration_from_hours)]
+    /// #![feature(duration_from)]
     /// use std::time::Duration;
     ///
     /// let duration = Duration::from_hours(2);
@@ -112,7 +114,7 @@ impl Duration {
     /// assert_eq!(7200, duration.as_secs());
     /// assert_eq!(0, duration.subsec_nanos());
     /// ```
-    #[unstable(feature = "duration_from_hours", issue = "47097")]
+    #[unstable(feature = "duration_from", issue = "47097")]
     #[inline]
     pub fn from_hours(hours: u64) -> Duration {
         Duration { secs: 3600*hours, nanos: 0 }
@@ -123,7 +125,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// #![feature(duration_from_mins)]
+    /// #![feature(duration_from)]
     /// use std::time::Duration;
     ///
     /// let duration = Duration::from_mins(5);
@@ -131,10 +133,10 @@ impl Duration {
     /// assert_eq!(300, duration.as_secs());
     /// assert_eq!(0, duration.subsec_nanos());
     /// ```
-    #[unstable(feature = "duration_from_mins", issue = "47097")]
+    #[unstable(feature = "duration_from", issue = "47097")]
     #[inline]
-    pub fn from_mins(mins: u64) -> Duration {
-        Duration { secs: 60*mins, nanos: 0 }
+    pub fn from_minutes(minutes: u64) -> Duration {
+        Duration { secs: 60*minutes, nanos: 0 }
     }
 
     /// Creates a new `Duration` from the specified number of whole seconds.

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -80,27 +80,6 @@ impl Duration {
         Duration { secs: secs, nanos: nanos }
     }
 
-    /// Creates a new `Duration` from the specified number of whole days. Note that days are
-    /// strictly interpreted as duration math, i.e. one day is strictly twenty-four hours. This
-    /// function does not perform any calendar math or timezone math.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(duration_from)]
-    /// use std::time::Duration;
-    ///
-    /// let duration = Duration::from_days(1);
-    ///
-    /// assert_eq!(86_400, duration.as_secs());
-    /// assert_eq!(0, duration.subsec_nanos());
-    /// ```
-    #[unstable(feature = "duration_from", issue = "47097")]
-    #[inline]
-    pub fn from_days(days: u64) -> Duration {
-        Duration { secs: 86_400*days, nanos: 0 }
-    }
-
     /// Creates a new `Duration` from the specified number of whole hours.
     ///
     /// # Examples
@@ -128,7 +107,7 @@ impl Duration {
     /// #![feature(duration_from)]
     /// use std::time::Duration;
     ///
-    /// let duration = Duration::from_mins(5);
+    /// let duration = Duration::from_minutes(5);
     ///
     /// assert_eq!(300, duration.as_secs());
     /// assert_eq!(0, duration.subsec_nanos());


### PR DESCRIPTION
Minutes, hours and days* have a fixed number of seconds. Allowing to construct a `Duration` from a number of these common time spans alleviates a minor implementation by each dev needing this.

_Note of warning_: This is my first contribution attempt to the rust code base. I think I've followed all the rules, but let me know if I haven't.

I am already planning to using this in [hifitime](https://crates.io/crates/hifitime), and I thought it may be useful to the broader Rust community. BTW, `hifitime` is a crate for date time handling in rust built on top of the current std::time::Duration and it supports leap seconds (which I need for other projects).

(*) Days _may_ have an extra second called the leap second. It's announced and determined by the IETF one year around the end of December. In recent years, there's been one leap second every two years. So we can safely assume that when a dev would called `Duration::from_days` they expect the usual number of seconds in a day.

Tests passed locally:
```
test time/duration.rs - time::duration::Duration (line 37) ... ok
test time/duration.rs - time::duration::Duration::as_secs (line 238) ... ok
test time/duration.rs - time::duration::Duration::as_secs (line 227) ... ok
test time/duration.rs - time::duration::Duration::checked_add (line 320) ... ok
test time/duration.rs - time::duration::Duration::checked_div (line 429) ... ok
test time/duration.rs - time::duration::Duration::checked_mul (line 394) ... ok
test time/duration.rs - time::duration::Duration::checked_sub (line 358) ... ok
test thread/mod.rs - thread::spawn (line 488) ... ok
test time/duration.rs - time::duration::Duration::from_hours (line 106) ... ok
test time/duration.rs - time::duration::Duration::from_days (line 87) ... ok
test time/duration.rs - time::duration::Duration::from_millis (line 162) ... ok
test time/duration.rs - time::duration::Duration::from_micros (line 182) ... ok
test time/mod.rs - time::Instant (line 56) ... ok
test time/mod.rs - time::Instant::duration_since (line 170) ... ok
test time/duration.rs - time::duration::Duration::from_secs (line 144) ... ok
test time/duration.rs - time::duration::Duration::new (line 69) ... ok
test time/mod.rs - time::Instant::elapsed (line 194) ... ok
test time/duration.rs - time::duration::Duration::from_mins (line 125) ... ok
test time/duration.rs - time::duration::Duration::from_nanos (line 203) ... ok
```