### PR TITLE
Tiny fixes to make compiletest work for CloudABI cross builds

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -203,13 +203,6 @@ pub struct TestDesc {
     pub allow_fail: bool,
 }
 
-#[derive(Clone)]
-pub struct TestPaths {
-    pub file: PathBuf,         // e.g., compile-test/foo/bar/baz.rs
-    pub base: PathBuf,         // e.g., compile-test, auxiliary
-    pub relative_dir: PathBuf, // e.g., foo/bar
-}
-
 #[derive(Debug)]
 pub struct TestDescAndFn {
     pub desc: TestDesc,

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -13,7 +13,7 @@ use std::fmt;
 use std::str::FromStr;
 use std::path::PathBuf;
 
-use test::{ColorConfig, TestPaths};
+use test::ColorConfig;
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Mode {
@@ -220,6 +220,13 @@ pub struct Config {
     pub llvm_components: String,
     pub llvm_cxxflags: String,
     pub nodejs: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct TestPaths {
+    pub file: PathBuf,         // e.g., compile-test/foo/bar/baz.rs
+    pub base: PathBuf,         // e.g., compile-test, auxiliary
+    pub relative_dir: PathBuf, // e.g., foo/bar
 }
 
 /// Used by `ui` tests to generate things like `foo.stderr` from `foo.rs`.

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -33,10 +33,10 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use filetime::FileTime;
 use getopts::Options;
-use common::Config;
+use common::{Config, TestPaths};
 use common::{DebugInfoGdb, DebugInfoLldb, Mode, Pretty};
 use common::{expected_output_path, UI_EXTENSIONS};
-use test::{ColorConfig, TestPaths};
+use test::ColorConfig;
 use util::logv;
 
 use self::header::EarlyProps;

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use common::Config;
+use common::{Config, TestPaths};
 use common::{CompileFail, ParseFail, Pretty, RunFail, RunPass, RunPassValgrind};
 use common::{Codegen, CodegenUnits, DebugInfoGdb, DebugInfoLldb, Rustdoc};
 use common::{Incremental, MirOpt, RunMake, Ui};
@@ -18,7 +18,6 @@ use errors::{self, Error, ErrorKind};
 use filetime::FileTime;
 use json;
 use header::TestProps;
-use test::TestPaths;
 use util::logv;
 use regex::Regex;
 

--- a/src/tools/compiletest/src/util.rs
+++ b/src/tools/compiletest/src/util.rs
@@ -15,6 +15,7 @@ use common::Config;
 const OS_TABLE: &'static [(&'static str, &'static str)] = &[
     ("android", "android"),
     ("bitrig", "bitrig"),
+    ("cloudabi", "cloudabi"),
     ("darwin", "macos"),
     ("dragonfly", "dragonfly"),
     ("freebsd", "freebsd"),


### PR DESCRIPTION
I'm currently working toward getting a `src/ci/docker` container working to do isolated/automated builds and testing of `x86_64-unknown-cloudabi`. This is working pretty well, but still requires some fixes to `libtest` and `compiletest`. Here is the first set of fixes that I had to apply.