### PR TITLE
Use the right TLS model for CloudABI.

### DIFF
--- a/src/librustc_back/target/cloudabi_base.rs
+++ b/src/librustc_back/target/cloudabi_base.rs
@@ -27,6 +27,7 @@ pub fn opts() -> TargetOptions {
         linker_is_gnu: true,
         pre_link_args: args,
         position_independent_executables: true,
+        tls_model: "local-exec".to_string(),
         relro_level: RelroLevel::Full,
         exe_allocation_crate: super::maybe_jemalloc(),
         .. Default::default()

--- a/src/librustc_back/target/cloudabi_base.rs
+++ b/src/librustc_back/target/cloudabi_base.rs
@@ -27,6 +27,17 @@ pub fn opts() -> TargetOptions {
         linker_is_gnu: true,
         pre_link_args: args,
         position_independent_executables: true,
+        // As CloudABI only supports static linkage, there is no need
+        // for dynamic TLS. The C library therefore does not provide
+        // __tls_get_addr(), which is normally used to perform dynamic
+        // TLS lookups by programs that make use of dlopen(). Only the
+        // "local-exec" and "initial-exec" TLS models can be used.
+        //
+        // "local-exec" is more efficient than "initial-exec", as the
+        // latter has one more level of indirection: it accesses the GOT
+        // (Global Offset Table) to obtain the effective address of a
+        // thread-local variable. Using a GOT is useful only when doing
+        // dynamic linking.
         tls_model: "local-exec".to_string(),
         relro_level: RelroLevel::Full,
         exe_allocation_crate: super::maybe_jemalloc(),


### PR DESCRIPTION
CloudABI doesn't do dynamic linking. For this reason, there is no need
to handle any other TLS model than local-exec. CloudABI's C library
doesn't provide a __tls_get_addr() function to do Dynamic TLS.

By forcing local-exec to be used here, we ensure that we don't generate
function calls to __tls_get_addr().