### PR TITLE
Check all repr hints together when checking for mis-applied attributes

### DIFF
--- a/src/test/ui/attr-usage-repr.rs
+++ b/src/test/ui/attr-usage-repr.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(dead_code)]
 #![feature(attr_literals)]
 #![feature(repr_simd)]
 

--- a/src/test/ui/attr-usage-repr.stderr
+++ b/src/test/ui/attr-usage-repr.stderr
@@ -1,0 +1,42 @@
+error[E0517]: attribute should be applied to struct, enum or union
+  --> $DIR/attr-usage-repr.rs:14:8
+   |
+14 | #[repr(C)] //~ ERROR: attribute should be applied to struct, enum or union
+   |        ^
+15 | fn f() {}
+   | --------- not a struct, enum or union
+
+error[E0517]: attribute should be applied to enum
+  --> $DIR/attr-usage-repr.rs:26:8
+   |
+26 | #[repr(i8)] //~ ERROR: attribute should be applied to enum
+   |        ^^
+27 | struct SInt(f64, f64);
+   | ---------------------- not an enum
+
+error[E0517]: attribute should be applied to struct or union
+  --> $DIR/attr-usage-repr.rs:32:8
+   |
+32 | #[repr(align(8))] //~ ERROR: attribute should be applied to struct
+   |        ^^^^^^^^
+33 | enum EAlign { A, B }
+   | -------------------- not a struct or union
+
+error[E0517]: attribute should be applied to struct or union
+  --> $DIR/attr-usage-repr.rs:35:8
+   |
+35 | #[repr(packed)] //~ ERROR: attribute should be applied to struct
+   |        ^^^^^^
+36 | enum EPacked { A, B }
+   | --------------------- not a struct or union
+
+error[E0517]: attribute should be applied to struct
+  --> $DIR/attr-usage-repr.rs:38:8
+   |
+38 | #[repr(simd)] //~ ERROR: attribute should be applied to struct
+   |        ^^^^
+39 | enum ESimd { A, B }
+   | ------------------- not a struct
+
+error: aborting due to 5 previous errors
+

--- a/src/test/ui/feature-gate-simd-ffi.stderr
+++ b/src/test/ui/feature-gate-simd-ffi.stderr
@@ -1,15 +1,15 @@
 error: use of SIMD type `LocalSimd` in FFI is highly experimental and may result in invalid code
-  --> $DIR/feature-gate-simd-ffi.rs:20:17
+  --> $DIR/feature-gate-simd-ffi.rs:19:17
    |
-20 |     fn baz() -> LocalSimd; //~ ERROR use of SIMD type
+19 |     fn baz() -> LocalSimd; //~ ERROR use of SIMD type
    |                 ^^^^^^^^^
    |
    = help: add #![feature(simd_ffi)] to the crate attributes to enable
 
 error: use of SIMD type `LocalSimd` in FFI is highly experimental and may result in invalid code
-  --> $DIR/feature-gate-simd-ffi.rs:21:15
+  --> $DIR/feature-gate-simd-ffi.rs:20:15
    |
-21 |     fn qux(x: LocalSimd); //~ ERROR use of SIMD type
+20 |     fn qux(x: LocalSimd); //~ ERROR use of SIMD type
    |               ^^^^^^^^^
    |
    = help: add #![feature(simd_ffi)] to the crate attributes to enable

--- a/src/test/ui/issue-47094.rs
+++ b/src/test/ui/issue-47094.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,16 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(repr_simd)]
-#![allow(dead_code)]
+// must-compile-successfully
 
-#[repr(simd)]
-#[derive(Copy, Clone)]
-struct LocalSimd(u8, u8);
+#[repr(C,u8)]
+enum Foo {
+    A,
+    B,
+}
 
-extern {
-    fn baz() -> LocalSimd; //~ ERROR use of SIMD type
-    fn qux(x: LocalSimd); //~ ERROR use of SIMD type
+#[repr(C)]
+#[repr(u8)]
+enum Bar {
+    A,
+    B,
 }
 
 fn main() {}

--- a/src/test/ui/issue-47094.stderr
+++ b/src/test/ui/issue-47094.stderr
@@ -1,0 +1,14 @@
+warning[E0566]: conflicting representation hints
+  --> $DIR/issue-47094.rs:13:8
+   |
+13 | #[repr(C,u8)]
+   |        ^ ^^
+
+warning[E0566]: conflicting representation hints
+  --> $DIR/issue-47094.rs:19:8
+   |
+19 | #[repr(C)]
+   |        ^
+20 | #[repr(u8)]
+   |        ^^
+


### PR DESCRIPTION
Fixes #47094

Besides fixing that bug, this change has a user-visible effect on the spans in the "incompatible repr hints" warning and another error: they now point at `foo` and/or `bar` in `repr(foo, bar)` instead of the whole attribute. This is sometimes more precise (e.g., `#[repr(C, packed)]` on an enum points at the `packed`) but sometimes not. I moved a compile-fail test to a ui test to illustrate how it now looks in the common case of only one attribute.