### PR TITLE
[unstable book] remove duplicate entries

### DIFF
--- a/src/doc/unstable-book/src/library-features/proc-macro.md
+++ b/src/doc/unstable-book/src/library-features/proc-macro.md
@@ -1,7 +1,0 @@
-# `proc_macro`
-
-The tracking issue for this feature is: [#38356]
-
-[#38356]: https://github.com/rust-lang/rust/issues/38356
-
-------------------------

--- a/src/tools/tidy/src/unstable_book.rs
+++ b/src/tools/tidy/src/unstable_book.rs
@@ -87,7 +87,9 @@ pub fn check(path: &path::Path, bad: &mut bool) {
     // Library features
 
     let lang_features = collect_lang_features(path);
-    let lib_features = collect_lib_features(path);
+    let lib_features = collect_lib_features(path).iter().filter(|(name, _) {
+        !lang_features.contains_key(name)
+    }).collect();
 
     let unstable_lib_feature_names = collect_unstable_feature_names(&lib_features);
     let unstable_book_lib_features_section_file_names =

--- a/src/tools/tidy/src/unstable_book.rs
+++ b/src/tools/tidy/src/unstable_book.rs
@@ -87,7 +87,7 @@ pub fn check(path: &path::Path, bad: &mut bool) {
     // Library features
 
     let lang_features = collect_lang_features(path);
-    let lib_features = collect_lib_features(path).iter().filter(|(name, _) {
+    let lib_features = collect_lib_features(path).into_iter().filter(|&(ref name, _)| {
         !lang_features.contains_key(name)
     }).collect();
 

--- a/src/tools/unstable-book-gen/src/main.rs
+++ b/src/tools/unstable-book-gen/src/main.rs
@@ -129,7 +129,11 @@ fn main() {
     let dest_path = Path::new(&dest_path_str).join("src");
 
     let lang_features = collect_lang_features(src_path);
-    let lib_features = collect_lib_features(src_path);
+    let lib_features = collect_lib_features(src_path)
+                                            .iter()
+                                            .filter(|(name, _) {
+                                                !lang_features.contains_key(name)
+                                            }).collect();
 
     let doc_src_path = src_path.join(PATH_STR);
 

--- a/src/tools/unstable-book-gen/src/main.rs
+++ b/src/tools/unstable-book-gen/src/main.rs
@@ -129,11 +129,9 @@ fn main() {
     let dest_path = Path::new(&dest_path_str).join("src");
 
     let lang_features = collect_lang_features(src_path);
-    let lib_features = collect_lib_features(src_path)
-                                            .iter()
-                                            .filter(|(name, _) {
-                                                !lang_features.contains_key(name)
-                                            }).collect();
+    let lib_features = collect_lib_features(src_path).into_iter().filter(|&(ref name, _)| {
+        !lang_features.contains_key(name)
+    }).collect();
 
     let doc_src_path = src_path.join(PATH_STR);
 


### PR DESCRIPTION
if a unstable feature is a language feature, it shouldn't also have a library feature stub generated