### PR TITLE
[beta] Prepare the 1.24.0 beta release

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -419,7 +419,8 @@ impl<'a> Builder<'a> {
            .env("RUSTC_LIBDIR", self.sysroot_libdir(compiler, self.build.build))
            .env("CFG_RELEASE_CHANNEL", &self.build.config.channel)
            .env("RUSTDOC_REAL", self.rustdoc(host))
-           .env("RUSTDOC_CRATE_VERSION", self.build.rust_version());
+           .env("RUSTDOC_CRATE_VERSION", self.build.rust_version())
+           .env("RUSTC_BOOTSTRAP", "1");
         if let Some(linker) = self.build.linker(host) {
             cmd.env("RUSTC_TARGET_LINKER", linker);
         }

--- a/src/ci/docker/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/x86_64-gnu-tools/checktools.sh
@@ -23,16 +23,14 @@ touch "$TOOLSTATE_FILE"
 set +e
 python2.7 "$X_PY" test --no-fail-fast \
     src/tools/rls \
-    src/tools/rustfmt \
-    src/tools/miri \
-    src/tools/clippy
+    src/tools/rustfmt
 set -e
 
 cat "$TOOLSTATE_FILE"
 
 # If this PR is intended to update one of these tools, do not let the build pass
 # when they do not test-pass.
-for TOOL in rls rustfmt miri clippy; do
+for TOOL in rls rustfmt; do
     echo "Verifying status of $TOOL..."
     if echo "$CHANGED_FILES" | grep -q "^M[[:blank:]]src/tools/$TOOL$"; then
         echo "This PR updated 'src/tools/$TOOL', verifying if status is 'test-pass'..."

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -42,7 +42,7 @@ fi
 #
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
-export RUST_RELEASE_CHANNEL=nightly
+export RUST_RELEASE_CHANNEL=beta
 if [ "$DEPLOY$DEPLOY_ALT" != "" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=$RUST_RELEASE_CHANNEL"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -300,7 +300,7 @@ impl<T: ?Sized> Box<T> {
                issue = "27730")]
     #[inline]
     pub unsafe fn from_unique(u: Unique<T>) -> Self {
-        Box(u)
+        mem::transmute(u)
     }
 
     /// Consumes the `Box`, returning the wrapped raw pointer.
@@ -362,9 +362,7 @@ impl<T: ?Sized> Box<T> {
                issue = "27730")]
     #[inline]
     pub fn into_unique(b: Box<T>) -> Unique<T> {
-        let unique = b.0;
-        mem::forget(b);
-        unique
+        unsafe { mem::transmute(b) }
     }
 
     /// Consumes and leaks the `Box`, returning a mutable reference,

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,9 +12,9 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2017-11-21
-rustc: beta
-cargo: beta
+date: 2018-01-02
+rustc: 1.23.0
+cargo: 0.24.0
 
 # When making a stable release the process currently looks like:
 #
@@ -34,4 +34,4 @@ cargo: beta
 # looking at a beta source tarball and it's uncommented we'll shortly comment it
 # out.
 
-#dev: 1
+dev: 1


### PR DESCRIPTION
* Update the channel of this release
* Update the bootstrap compiler to the dev artifacts
* Fix compile for last-minute backports