### PR TITLE
Use #[non_exhaustive] when possible.

### DIFF
--- a/src/doc/unstable-book/src/library-features/future-atomic-orderings.md
+++ b/src/doc/unstable-book/src/library-features/future-atomic-orderings.md
@@ -1,5 +1,0 @@
-# `future_atomic_orderings`
-
-This feature is internal to the Rust compiler and is not intended for general use.
-
-------------------------

--- a/src/doc/unstable-book/src/library-features/io-error-internals.md
+++ b/src/doc/unstable-book/src/library-features/io-error-internals.md
@@ -1,5 +1,0 @@
-# `io_error_internals`
-
-This feature is internal to the Rust compiler and is not intended for general use.
-
-------------------------

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -91,7 +91,7 @@ use str::from_boxed_utf8_unchecked;
 #[unstable(feature = "box_heap",
            reason = "may be renamed; uncertain about custom allocator design",
            issue = "27779")]
-pub const HEAP: ExchangeHeapSingleton = ExchangeHeapSingleton { _force_singleton: () };
+pub const HEAP: ExchangeHeapSingleton = ExchangeHeapSingleton { };
 
 /// This the singleton type used solely for `boxed::HEAP`.
 #[unstable(feature = "box_heap",
@@ -99,9 +99,8 @@ pub const HEAP: ExchangeHeapSingleton = ExchangeHeapSingleton { _force_singleton
            issue = "27779")]
 #[allow(missing_debug_implementations)]
 #[derive(Copy, Clone)]
-pub struct ExchangeHeapSingleton {
-    _force_singleton: (),
-}
+#[non_exhaustive]
+pub struct ExchangeHeapSingleton { }
 
 /// A pointer type for heap allocation.
 ///

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -91,7 +91,7 @@ use str::from_boxed_utf8_unchecked;
 #[unstable(feature = "box_heap",
            reason = "may be renamed; uncertain about custom allocator design",
            issue = "27779")]
-pub const HEAP: ExchangeHeapSingleton = ExchangeHeapSingleton { };
+pub const HEAP: ExchangeHeapSingleton = ExchangeHeapSingleton;
 
 /// This the singleton type used solely for `boxed::HEAP`.
 #[unstable(feature = "box_heap",
@@ -100,7 +100,7 @@ pub const HEAP: ExchangeHeapSingleton = ExchangeHeapSingleton { };
 #[allow(missing_debug_implementations)]
 #[derive(Copy, Clone)]
 #[non_exhaustive]
-pub struct ExchangeHeapSingleton { }
+pub struct ExchangeHeapSingleton;
 
 /// A pointer type for heap allocation.
 ///

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -104,6 +104,7 @@
 #![feature(lang_items)]
 #![feature(needs_allocator)]
 #![feature(nonzero)]
+#![feature(non_exhaustive)]
 #![feature(offset_to)]
 #![feature(optin_builtin_traits)]
 #![feature(pattern)]

--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -357,7 +357,8 @@ pub struct FromUtf8Error {
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug)]
-pub struct FromUtf16Error(());
+#[non_exhaustive]
+pub struct FromUtf16Error { }
 
 impl String {
     /// Creates a new empty `String`.
@@ -616,7 +617,7 @@ impl String {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn from_utf16(v: &[u16]) -> Result<String, FromUtf16Error> {
-        decode_utf16(v.iter().cloned()).collect::<Result<_, _>>().map_err(|_| FromUtf16Error(()))
+        decode_utf16(v.iter().cloned()).collect::<Result<_, _>>().map_err(|_| FromUtf16Error { })
     }
 
     /// Decode a UTF-16 encoded slice `v` into a `String`, replacing

--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -358,7 +358,7 @@ pub struct FromUtf8Error {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug)]
 #[non_exhaustive]
-pub struct FromUtf16Error { }
+pub struct FromUtf16Error;
 
 impl String {
     /// Creates a new empty `String`.
@@ -617,7 +617,7 @@ impl String {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn from_utf16(v: &[u16]) -> Result<String, FromUtf16Error> {
-        decode_utf16(v.iter().cloned()).collect::<Result<_, _>>().map_err(|_| FromUtf16Error { })
+        decode_utf16(v.iter().cloned()).collect::<Result<_, _>>().map_err(|_| FromUtf16Error)
     }
 
     /// Decode a UTF-16 encoded slice `v` into a `String`, replacing

--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -62,7 +62,7 @@ unsafe impl<T, A: Unsize<[T]>> FixedSizeArray<T> for A {
 #[unstable(feature = "try_from", issue = "33417")]
 #[derive(Debug, Copy, Clone)]
 #[non_exhaustive]
-pub struct TryFromSliceError { }
+pub struct TryFromSliceError;
 
 impl fmt::Display for TryFromSliceError {
     #[inline]
@@ -158,7 +158,7 @@ macro_rules! array_impls {
                         let ptr = slice.as_ptr() as *const [T; $N];
                         unsafe { Ok(&*ptr) }
                     } else {
-                        Err(TryFromSliceError { })
+                        Err(TryFromSliceError)
                     }
                 }
             }
@@ -172,7 +172,7 @@ macro_rules! array_impls {
                         let ptr = slice.as_mut_ptr() as *mut [T; $N];
                         unsafe { Ok(&mut *ptr) }
                     } else {
-                        Err(TryFromSliceError { })
+                        Err(TryFromSliceError)
                     }
                 }
             }

--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -61,7 +61,8 @@ unsafe impl<T, A: Unsize<[T]>> FixedSizeArray<T> for A {
 /// The error type returned when a conversion from a slice to an array fails.
 #[unstable(feature = "try_from", issue = "33417")]
 #[derive(Debug, Copy, Clone)]
-pub struct TryFromSliceError(());
+#[non_exhaustive]
+pub struct TryFromSliceError { }
 
 impl fmt::Display for TryFromSliceError {
     #[inline]
@@ -157,7 +158,7 @@ macro_rules! array_impls {
                         let ptr = slice.as_ptr() as *const [T; $N];
                         unsafe { Ok(&*ptr) }
                     } else {
-                        Err(TryFromSliceError(()))
+                        Err(TryFromSliceError { })
                     }
                 }
             }
@@ -171,7 +172,7 @@ macro_rules! array_impls {
                         let ptr = slice.as_mut_ptr() as *mut [T; $N];
                         unsafe { Ok(&mut *ptr) }
                     } else {
-                        Err(TryFromSliceError(()))
+                        Err(TryFromSliceError { })
                     }
                 }
             }

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -488,9 +488,8 @@ pub struct RefCell<T: ?Sized> {
 
 /// An error returned by [`RefCell::try_borrow`](struct.RefCell.html#method.try_borrow).
 #[stable(feature = "try_borrow", since = "1.13.0")]
-pub struct BorrowError {
-    _private: (),
-}
+#[non_exhaustive]
+pub struct BorrowError { }
 
 #[stable(feature = "try_borrow", since = "1.13.0")]
 impl Debug for BorrowError {
@@ -508,9 +507,8 @@ impl Display for BorrowError {
 
 /// An error returned by [`RefCell::try_borrow_mut`](struct.RefCell.html#method.try_borrow_mut).
 #[stable(feature = "try_borrow", since = "1.13.0")]
-pub struct BorrowMutError {
-    _private: (),
-}
+#[non_exhaustive]
+pub struct BorrowMutError { }
 
 #[stable(feature = "try_borrow", since = "1.13.0")]
 impl Debug for BorrowMutError {
@@ -725,7 +723,7 @@ impl<T: ?Sized> RefCell<T> {
                 value: unsafe { &*self.value.get() },
                 borrow: b,
             }),
-            None => Err(BorrowError { _private: () }),
+            None => Err(BorrowError { }),
         }
     }
 
@@ -801,7 +799,7 @@ impl<T: ?Sized> RefCell<T> {
                 value: unsafe { &mut *self.value.get() },
                 borrow: b,
             }),
-            None => Err(BorrowMutError { _private: () }),
+            None => Err(BorrowMutError { }),
         }
     }
 

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -489,7 +489,7 @@ pub struct RefCell<T: ?Sized> {
 /// An error returned by [`RefCell::try_borrow`](struct.RefCell.html#method.try_borrow).
 #[stable(feature = "try_borrow", since = "1.13.0")]
 #[non_exhaustive]
-pub struct BorrowError { }
+pub struct BorrowError;
 
 #[stable(feature = "try_borrow", since = "1.13.0")]
 impl Debug for BorrowError {
@@ -508,7 +508,7 @@ impl Display for BorrowError {
 /// An error returned by [`RefCell::try_borrow_mut`](struct.RefCell.html#method.try_borrow_mut).
 #[stable(feature = "try_borrow", since = "1.13.0")]
 #[non_exhaustive]
-pub struct BorrowMutError { }
+pub struct BorrowMutError;
 
 #[stable(feature = "try_borrow", since = "1.13.0")]
 impl Debug for BorrowMutError {
@@ -723,7 +723,7 @@ impl<T: ?Sized> RefCell<T> {
                 value: unsafe { &*self.value.get() },
                 borrow: b,
             }),
-            None => Err(BorrowError { }),
+            None => Err(BorrowError),
         }
     }
 
@@ -799,7 +799,7 @@ impl<T: ?Sized> RefCell<T> {
                 value: unsafe { &mut *self.value.get() },
                 borrow: b,
             }),
-            None => Err(BorrowMutError { }),
+            None => Err(BorrowMutError),
         }
     }
 

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -272,7 +272,7 @@ impl TryFrom<u32> for char {
     #[inline]
     fn try_from(i: u32) -> Result<Self, Self::Error> {
         if (i > MAX as u32) || (i >= 0xD800 && i <= 0xDFFF) {
-            Err(CharTryFromError(()))
+            Err(CharTryFromError { })
         } else {
             Ok(unsafe { from_u32_unchecked(i) })
         }
@@ -282,7 +282,8 @@ impl TryFrom<u32> for char {
 /// The error type returned when a conversion from u32 to char fails.
 #[unstable(feature = "try_from", issue = "33417")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct CharTryFromError(());
+#[non_exhaustive]
+pub struct CharTryFromError { }
 
 #[unstable(feature = "try_from", issue = "33417")]
 impl fmt::Display for CharTryFromError {
@@ -818,7 +819,8 @@ pub fn decode_utf8<I: IntoIterator<Item = u8>>(i: I) -> DecodeUtf8<I::IntoIter> 
 /// `<DecodeUtf8 as Iterator>::next` returns this for an invalid input sequence.
 #[unstable(feature = "decode_utf8", issue = "33906")]
 #[derive(PartialEq, Eq, Debug)]
-pub struct InvalidSequence(());
+#[non_exhaustive]
+pub struct InvalidSequence { }
 
 #[unstable(feature = "decode_utf8", issue = "33906")]
 impl<I: Iterator<Item = u8>> Iterator for DecodeUtf8<I> {
@@ -849,7 +851,7 @@ impl<I: Iterator<Item = u8>> Iterator for DecodeUtf8<I> {
                             code_point = (code_point << 6) | u32::from(byte & 0b0011_1111);
                             self.0.next();
                         }
-                        _ => return Err(InvalidSequence(()))
+                        _ => return Err(InvalidSequence { })
                     }
                 }
             }
@@ -895,7 +897,7 @@ impl<I: Iterator<Item = u8>> Iterator for DecodeUtf8<I> {
                     continuation_byte!();
                     continuation_byte!();
                 }
-                _ => return Err(InvalidSequence(()))  // Illegal first byte, overlong, or beyond MAX
+                _ => return Err(InvalidSequence { })  // Illegal first byte, overlong, or beyond MAX
             }
             unsafe {
                 Ok(from_u32_unchecked(code_point))

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -272,7 +272,7 @@ impl TryFrom<u32> for char {
     #[inline]
     fn try_from(i: u32) -> Result<Self, Self::Error> {
         if (i > MAX as u32) || (i >= 0xD800 && i <= 0xDFFF) {
-            Err(CharTryFromError { })
+            Err(CharTryFromError)
         } else {
             Ok(unsafe { from_u32_unchecked(i) })
         }
@@ -283,7 +283,7 @@ impl TryFrom<u32> for char {
 #[unstable(feature = "try_from", issue = "33417")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
-pub struct CharTryFromError { }
+pub struct CharTryFromError;
 
 #[unstable(feature = "try_from", issue = "33417")]
 impl fmt::Display for CharTryFromError {
@@ -820,7 +820,7 @@ pub fn decode_utf8<I: IntoIterator<Item = u8>>(i: I) -> DecodeUtf8<I::IntoIter> 
 #[unstable(feature = "decode_utf8", issue = "33906")]
 #[derive(PartialEq, Eq, Debug)]
 #[non_exhaustive]
-pub struct InvalidSequence { }
+pub struct InvalidSequence;
 
 #[unstable(feature = "decode_utf8", issue = "33906")]
 impl<I: Iterator<Item = u8>> Iterator for DecodeUtf8<I> {
@@ -851,7 +851,7 @@ impl<I: Iterator<Item = u8>> Iterator for DecodeUtf8<I> {
                             code_point = (code_point << 6) | u32::from(byte & 0b0011_1111);
                             self.0.next();
                         }
-                        _ => return Err(InvalidSequence { })
+                        _ => return Err(InvalidSequence)
                     }
                 }
             }
@@ -897,7 +897,7 @@ impl<I: Iterator<Item = u8>> Iterator for DecodeUtf8<I> {
                     continuation_byte!();
                     continuation_byte!();
                 }
-                _ => return Err(InvalidSequence { })  // Illegal first byte, overlong, or beyond MAX
+                _ => return Err(InvalidSequence)  // Illegal first byte, overlong, or beyond MAX
             }
             unsafe {
                 Ok(from_u32_unchecked(code_point))

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -260,7 +260,6 @@ pub struct Formatter<'a> {
 // equivalent to `exists T.(&T, fn(&T, &mut Formatter) -> Result`.
 
 struct Void {
-    _priv: (),
     /// Erases all oibits, because `Void` erases the type of the object that
     /// will be used to produce formatted output. Since we do not know what
     /// oibits the real types have (and they can have any or none), we need to

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -80,6 +80,7 @@
 #![feature(lang_items)]
 #![feature(never_type)]
 #![feature(no_core)]
+#![feature(non_exhaustive)]
 #![feature(on_unimplemented)]
 #![feature(optin_builtin_traits)]
 #![feature(prelude_import)]

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -2960,7 +2960,7 @@ from_str_radix_int_impl! { isize i8 i16 i32 i64 i128 usize u8 u16 u32 u64 u128 }
 #[unstable(feature = "try_from", issue = "33417")]
 #[derive(Debug, Copy, Clone)]
 #[non_exhaustive]
-pub struct TryFromIntError { }
+pub struct TryFromIntError;
 
 impl TryFromIntError {
     #[unstable(feature = "int_error_internals",
@@ -3015,7 +3015,7 @@ macro_rules! try_from_lower_bounded {
                 if u >= 0 {
                     Ok(u as $target)
                 } else {
-                    Err(TryFromIntError { })
+                    Err(TryFromIntError)
                 }
             }
         }
@@ -3032,7 +3032,7 @@ macro_rules! try_from_upper_bounded {
             #[inline]
             fn try_from(u: $source) -> Result<$target, TryFromIntError> {
                 if u > (<$target>::max_value() as $source) {
-                    Err(TryFromIntError { })
+                    Err(TryFromIntError)
                 } else {
                     Ok(u as $target)
                 }
@@ -3053,7 +3053,7 @@ macro_rules! try_from_both_bounded {
                 let min = <$target>::min_value() as $source;
                 let max = <$target>::max_value() as $source;
                 if u < min || u > max {
-                    Err(TryFromIntError { })
+                    Err(TryFromIntError)
                 } else {
                     Ok(u as $target)
                 }

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -2959,7 +2959,8 @@ from_str_radix_int_impl! { isize i8 i16 i32 i64 i128 usize u8 u16 u32 u64 u128 }
 /// The error type returned when a checked integral type conversion fails.
 #[unstable(feature = "try_from", issue = "33417")]
 #[derive(Debug, Copy, Clone)]
-pub struct TryFromIntError(());
+#[non_exhaustive]
+pub struct TryFromIntError { }
 
 impl TryFromIntError {
     #[unstable(feature = "int_error_internals",
@@ -3014,7 +3015,7 @@ macro_rules! try_from_lower_bounded {
                 if u >= 0 {
                     Ok(u as $target)
                 } else {
-                    Err(TryFromIntError(()))
+                    Err(TryFromIntError { })
                 }
             }
         }
@@ -3031,7 +3032,7 @@ macro_rules! try_from_upper_bounded {
             #[inline]
             fn try_from(u: $source) -> Result<$target, TryFromIntError> {
                 if u > (<$target>::max_value() as $source) {
-                    Err(TryFromIntError(()))
+                    Err(TryFromIntError { })
                 } else {
                     Ok(u as $target)
                 }
@@ -3052,7 +3053,7 @@ macro_rules! try_from_both_bounded {
                 let min = <$target>::min_value() as $source;
                 let max = <$target>::max_value() as $source;
                 if u < min || u > max {
-                    Err(TryFromIntError(()))
+                    Err(TryFromIntError { })
                 } else {
                     Ok(u as $target)
                 }

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -132,7 +132,7 @@ impl FromStr for bool {
         match s {
             "true"  => Ok(true),
             "false" => Ok(false),
-            _       => Err(ParseBoolError { }),
+            _       => Err(ParseBoolError),
         }
     }
 }
@@ -143,7 +143,7 @@ impl FromStr for bool {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[non_exhaustive]
-pub struct ParseBoolError { }
+pub struct ParseBoolError;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Display for ParseBoolError {

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -132,7 +132,7 @@ impl FromStr for bool {
         match s {
             "true"  => Ok(true),
             "false" => Ok(false),
-            _       => Err(ParseBoolError { _priv: () }),
+            _       => Err(ParseBoolError { }),
         }
     }
 }
@@ -142,7 +142,8 @@ impl FromStr for bool {
 /// [`from_str`]: ../../std/primitive.bool.html#method.from_str
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct ParseBoolError { _priv: () }
+#[non_exhaustive]
+pub struct ParseBoolError { }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Display for ParseBoolError {

--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -182,6 +182,7 @@ unsafe impl<T> Sync for AtomicPtr<T> {}
 /// [nomicon]: ../../../nomicon/atomics.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Copy, Clone, Debug)]
+#[non_exhaustive]
 pub enum Ordering {
     /// No ordering constraints, only atomic operations.
     ///
@@ -215,10 +216,6 @@ pub enum Ordering {
     /// sequentially consistent operations in the same order.
     #[stable(feature = "rust1", since = "1.0.0")]
     SeqCst,
-    // Prevent exhaustive matching to allow for future extension
-    #[doc(hidden)]
-    #[unstable(feature = "future_atomic_orderings", issue = "0")]
-    __Nonexhaustive,
 }
 
 /// An [`AtomicBool`] initialized to `false`.
@@ -1468,7 +1465,6 @@ fn strongest_failure_ordering(order: Ordering) -> Ordering {
         SeqCst => SeqCst,
         Acquire => Acquire,
         AcqRel => Acquire,
-        __Nonexhaustive => __Nonexhaustive,
     }
 }
 
@@ -1480,7 +1476,6 @@ unsafe fn atomic_store<T>(dst: *mut T, val: T, order: Ordering) {
         SeqCst => intrinsics::atomic_store(dst, val),
         Acquire => panic!("there is no such thing as an acquire store"),
         AcqRel => panic!("there is no such thing as an acquire/release store"),
-        __Nonexhaustive => panic!("invalid memory ordering"),
     }
 }
 
@@ -1492,7 +1487,6 @@ unsafe fn atomic_load<T>(dst: *const T, order: Ordering) -> T {
         SeqCst => intrinsics::atomic_load(dst),
         Release => panic!("there is no such thing as a release load"),
         AcqRel => panic!("there is no such thing as an acquire/release load"),
-        __Nonexhaustive => panic!("invalid memory ordering"),
     }
 }
 
@@ -1504,7 +1498,6 @@ unsafe fn atomic_swap<T>(dst: *mut T, val: T, order: Ordering) -> T {
         AcqRel => intrinsics::atomic_xchg_acqrel(dst, val),
         Relaxed => intrinsics::atomic_xchg_relaxed(dst, val),
         SeqCst => intrinsics::atomic_xchg(dst, val),
-        __Nonexhaustive => panic!("invalid memory ordering"),
     }
 }
 
@@ -1517,7 +1510,6 @@ unsafe fn atomic_add<T>(dst: *mut T, val: T, order: Ordering) -> T {
         AcqRel => intrinsics::atomic_xadd_acqrel(dst, val),
         Relaxed => intrinsics::atomic_xadd_relaxed(dst, val),
         SeqCst => intrinsics::atomic_xadd(dst, val),
-        __Nonexhaustive => panic!("invalid memory ordering"),
     }
 }
 
@@ -1530,7 +1522,6 @@ unsafe fn atomic_sub<T>(dst: *mut T, val: T, order: Ordering) -> T {
         AcqRel => intrinsics::atomic_xsub_acqrel(dst, val),
         Relaxed => intrinsics::atomic_xsub_relaxed(dst, val),
         SeqCst => intrinsics::atomic_xsub(dst, val),
-        __Nonexhaustive => panic!("invalid memory ordering"),
     }
 }
 
@@ -1551,8 +1542,6 @@ unsafe fn atomic_compare_exchange<T>(dst: *mut T,
         (AcqRel, Relaxed) => intrinsics::atomic_cxchg_acqrel_failrelaxed(dst, old, new),
         (SeqCst, Relaxed) => intrinsics::atomic_cxchg_failrelaxed(dst, old, new),
         (SeqCst, Acquire) => intrinsics::atomic_cxchg_failacq(dst, old, new),
-        (__Nonexhaustive, _) => panic!("invalid memory ordering"),
-        (_, __Nonexhaustive) => panic!("invalid memory ordering"),
         (_, AcqRel) => panic!("there is no such thing as an acquire/release failure ordering"),
         (_, Release) => panic!("there is no such thing as a release failure ordering"),
         _ => panic!("a failure ordering can't be stronger than a success ordering"),
@@ -1577,8 +1566,6 @@ unsafe fn atomic_compare_exchange_weak<T>(dst: *mut T,
         (AcqRel, Relaxed) => intrinsics::atomic_cxchgweak_acqrel_failrelaxed(dst, old, new),
         (SeqCst, Relaxed) => intrinsics::atomic_cxchgweak_failrelaxed(dst, old, new),
         (SeqCst, Acquire) => intrinsics::atomic_cxchgweak_failacq(dst, old, new),
-        (__Nonexhaustive, _) => panic!("invalid memory ordering"),
-        (_, __Nonexhaustive) => panic!("invalid memory ordering"),
         (_, AcqRel) => panic!("there is no such thing as an acquire/release failure ordering"),
         (_, Release) => panic!("there is no such thing as a release failure ordering"),
         _ => panic!("a failure ordering can't be stronger than a success ordering"),
@@ -1594,7 +1581,6 @@ unsafe fn atomic_and<T>(dst: *mut T, val: T, order: Ordering) -> T {
         AcqRel => intrinsics::atomic_and_acqrel(dst, val),
         Relaxed => intrinsics::atomic_and_relaxed(dst, val),
         SeqCst => intrinsics::atomic_and(dst, val),
-        __Nonexhaustive => panic!("invalid memory ordering"),
     }
 }
 
@@ -1606,7 +1592,6 @@ unsafe fn atomic_or<T>(dst: *mut T, val: T, order: Ordering) -> T {
         AcqRel => intrinsics::atomic_or_acqrel(dst, val),
         Relaxed => intrinsics::atomic_or_relaxed(dst, val),
         SeqCst => intrinsics::atomic_or(dst, val),
-        __Nonexhaustive => panic!("invalid memory ordering"),
     }
 }
 
@@ -1618,7 +1603,6 @@ unsafe fn atomic_xor<T>(dst: *mut T, val: T, order: Ordering) -> T {
         AcqRel => intrinsics::atomic_xor_acqrel(dst, val),
         Relaxed => intrinsics::atomic_xor_relaxed(dst, val),
         SeqCst => intrinsics::atomic_xor(dst, val),
-        __Nonexhaustive => panic!("invalid memory ordering"),
     }
 }
 
@@ -1708,7 +1692,6 @@ pub fn fence(order: Ordering) {
             AcqRel => intrinsics::atomic_fence_acqrel(),
             SeqCst => intrinsics::atomic_fence(),
             Relaxed => panic!("there is no such thing as a relaxed fence"),
-            __Nonexhaustive => panic!("invalid memory ordering"),
         }
     }
 }
@@ -1798,7 +1781,6 @@ pub fn compiler_fence(order: Ordering) {
             AcqRel => intrinsics::atomic_singlethreadfence_acqrel(),
             SeqCst => intrinsics::atomic_singlethreadfence(),
             Relaxed => panic!("there is no such thing as a relaxed compiler fence"),
-            __Nonexhaustive => panic!("invalid memory ordering"),
         }
     }
 }

--- a/src/libproc_macro/diagnostic.rs
+++ b/src/libproc_macro/diagnostic.rs
@@ -15,6 +15,7 @@ use rustc_errors as rustc;
 /// An enum representing a diagnostic level.
 #[unstable(feature = "proc_macro", issue = "38356")]
 #[derive(Copy, Clone, Debug)]
+#[non_exhaustive]
 pub enum Level {
     /// An error.
     Error,
@@ -24,8 +25,6 @@ pub enum Level {
     Note,
     /// A help message.
     Help,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 /// A structure representing a diagnostic message and associated children
@@ -128,7 +127,6 @@ pub mod __internal {
             Level::Warning => rustc::Level::Warning,
             Level::Note => rustc::Level::Note,
             Level::Help => rustc::Level::Help,
-            Level::__Nonexhaustive => unreachable!("Level::__Nonexhaustive")
         }
     }
 }

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -35,6 +35,7 @@
        test(attr(allow(dead_code, deprecated, unused_variables, unused_mut))))]
 
 #![feature(i128_type)]
+#![feature(non_exhaustive)]
 #![feature(rustc_private)]
 #![feature(staged_api)]
 #![feature(lang_items)]
@@ -79,7 +80,7 @@ pub struct TokenStream(tokenstream::TokenStream);
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 #[derive(Debug)]
 #[non_exhaustive]
-pub struct LexError { }
+pub struct LexError;
 
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl FromStr for TokenStream {
@@ -826,5 +827,5 @@ pub mod __internal {
 
 fn parse_to_lex_err(mut err: DiagnosticBuilder) -> LexError {
     err.cancel();
-    LexError { }
+    LexError
 }

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -78,9 +78,8 @@ pub struct TokenStream(tokenstream::TokenStream);
 /// Error returned from `TokenStream::from_str`.
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 #[derive(Debug)]
-pub struct LexError {
-    _inner: (),
-}
+#[non_exhaustive]
+pub struct LexError { }
 
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl FromStr for TokenStream {
@@ -827,5 +826,5 @@ pub mod __internal {
 
 fn parse_to_lex_err(mut err: DiagnosticBuilder) -> LexError {
     err.cancel();
-    LexError { _inner: () }
+    LexError { }
 }

--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -90,7 +90,7 @@ struct Custom {
 /// [`io::Error`]: struct.Error.html
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[allow(deprecated)]
+#[non_exhaustive]
 pub enum ErrorKind {
     /// An entity was not found, often a file.
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -174,15 +174,6 @@ pub enum ErrorKind {
     /// read.
     #[stable(feature = "read_exact", since = "1.6.0")]
     UnexpectedEof,
-
-    /// A marker variant that tells the compiler that users of this enum cannot
-    /// match it exhaustively.
-    #[unstable(feature = "io_error_internals",
-               reason = "better expressed through extensible enums that this \
-                         enum cannot be exhaustively matched against",
-               issue = "0")]
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl ErrorKind {
@@ -206,7 +197,6 @@ impl ErrorKind {
             ErrorKind::Interrupted => "operation interrupted",
             ErrorKind::Other => "other os error",
             ErrorKind::UnexpectedEof => "unexpected end of file",
-            ErrorKind::__Nonexhaustive => unreachable!()
         }
     }
 }

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -75,7 +75,8 @@ pub fn copy<R: ?Sized, W: ?Sized>(reader: &mut R, writer: &mut W) -> io::Result<
 ///
 /// [`empty`]: fn.empty.html
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct Empty { _priv: () }
+#[non_exhaustive]
+pub struct Empty { }
 
 /// Constructs a new handle to an empty reader.
 ///
@@ -95,7 +96,7 @@ pub struct Empty { _priv: () }
 /// assert!(buffer.is_empty());
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn empty() -> Empty { Empty { _priv: () } }
+pub fn empty() -> Empty { Empty { } }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Read for Empty {
@@ -178,7 +179,8 @@ impl fmt::Debug for Repeat {
 ///
 /// [sink]: fn.sink.html
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct Sink { _priv: () }
+#[non_exhaustive]
+pub struct Sink { }
 
 /// Creates an instance of a writer which will successfully consume all data.
 ///
@@ -195,7 +197,7 @@ pub struct Sink { _priv: () }
 /// assert_eq!(num_bytes, 5);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn sink() -> Sink { Sink { _priv: () } }
+pub fn sink() -> Sink { Sink { } }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Write for Sink {

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -76,7 +76,7 @@ pub fn copy<R: ?Sized, W: ?Sized>(reader: &mut R, writer: &mut W) -> io::Result<
 /// [`empty`]: fn.empty.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[non_exhaustive]
-pub struct Empty { }
+pub struct Empty;
 
 /// Constructs a new handle to an empty reader.
 ///
@@ -96,7 +96,7 @@ pub struct Empty { }
 /// assert!(buffer.is_empty());
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn empty() -> Empty { Empty { } }
+pub fn empty() -> Empty { Empty }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Read for Empty {
@@ -180,7 +180,7 @@ impl fmt::Debug for Repeat {
 /// [sink]: fn.sink.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[non_exhaustive]
-pub struct Sink { }
+pub struct Sink;
 
 /// Creates an instance of a writer which will successfully consume all data.
 ///
@@ -197,7 +197,7 @@ pub struct Sink { }
 /// assert_eq!(num_bytes, 5);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn sink() -> Sink { Sink { } }
+pub fn sink() -> Sink { Sink }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Write for Sink {

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -283,6 +283,7 @@
 #![feature(macro_vis_matcher)]
 #![feature(needs_panic_runtime)]
 #![feature(never_type)]
+#![feature(non_exhaustive)]
 #![feature(num_bits_bytes)]
 #![feature(old_wrapping)]
 #![feature(on_unimplemented)]

--- a/src/libstd/net/parser.rs
+++ b/src/libstd/net/parser.rs
@@ -306,7 +306,7 @@ impl FromStr for IpAddr {
     fn from_str(s: &str) -> Result<IpAddr, AddrParseError> {
         match Parser::new(s).read_till_eof(|p| p.read_ip_addr()) {
             Some(s) => Ok(s),
-            None => Err(AddrParseError(()))
+            None => Err(AddrParseError { })
         }
     }
 }
@@ -317,7 +317,7 @@ impl FromStr for Ipv4Addr {
     fn from_str(s: &str) -> Result<Ipv4Addr, AddrParseError> {
         match Parser::new(s).read_till_eof(|p| p.read_ipv4_addr()) {
             Some(s) => Ok(s),
-            None => Err(AddrParseError(()))
+            None => Err(AddrParseError { })
         }
     }
 }
@@ -328,7 +328,7 @@ impl FromStr for Ipv6Addr {
     fn from_str(s: &str) -> Result<Ipv6Addr, AddrParseError> {
         match Parser::new(s).read_till_eof(|p| p.read_ipv6_addr()) {
             Some(s) => Ok(s),
-            None => Err(AddrParseError(()))
+            None => Err(AddrParseError { })
         }
     }
 }
@@ -339,7 +339,7 @@ impl FromStr for SocketAddrV4 {
     fn from_str(s: &str) -> Result<SocketAddrV4, AddrParseError> {
         match Parser::new(s).read_till_eof(|p| p.read_socket_addr_v4()) {
             Some(s) => Ok(s),
-            None => Err(AddrParseError(())),
+            None => Err(AddrParseError { }),
         }
     }
 }
@@ -350,7 +350,7 @@ impl FromStr for SocketAddrV6 {
     fn from_str(s: &str) -> Result<SocketAddrV6, AddrParseError> {
         match Parser::new(s).read_till_eof(|p| p.read_socket_addr_v6()) {
             Some(s) => Ok(s),
-            None => Err(AddrParseError(())),
+            None => Err(AddrParseError { }),
         }
     }
 }
@@ -361,7 +361,7 @@ impl FromStr for SocketAddr {
     fn from_str(s: &str) -> Result<SocketAddr, AddrParseError> {
         match Parser::new(s).read_till_eof(|p| p.read_socket_addr()) {
             Some(s) => Ok(s),
-            None => Err(AddrParseError(())),
+            None => Err(AddrParseError { }),
         }
     }
 }
@@ -381,7 +381,8 @@ impl FromStr for SocketAddr {
 /// [`SocketAddrV6`]: ../../std/net/struct.SocketAddrV6.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AddrParseError(());
+#[non_exhaustive]
+pub struct AddrParseError { }
 
 #[stable(feature = "addr_parse_error_error", since = "1.4.0")]
 impl fmt::Display for AddrParseError {

--- a/src/libstd/net/parser.rs
+++ b/src/libstd/net/parser.rs
@@ -306,7 +306,7 @@ impl FromStr for IpAddr {
     fn from_str(s: &str) -> Result<IpAddr, AddrParseError> {
         match Parser::new(s).read_till_eof(|p| p.read_ip_addr()) {
             Some(s) => Ok(s),
-            None => Err(AddrParseError { })
+            None => Err(AddrParseError)
         }
     }
 }
@@ -317,7 +317,7 @@ impl FromStr for Ipv4Addr {
     fn from_str(s: &str) -> Result<Ipv4Addr, AddrParseError> {
         match Parser::new(s).read_till_eof(|p| p.read_ipv4_addr()) {
             Some(s) => Ok(s),
-            None => Err(AddrParseError { })
+            None => Err(AddrParseError)
         }
     }
 }
@@ -328,7 +328,7 @@ impl FromStr for Ipv6Addr {
     fn from_str(s: &str) -> Result<Ipv6Addr, AddrParseError> {
         match Parser::new(s).read_till_eof(|p| p.read_ipv6_addr()) {
             Some(s) => Ok(s),
-            None => Err(AddrParseError { })
+            None => Err(AddrParseError)
         }
     }
 }
@@ -339,7 +339,7 @@ impl FromStr for SocketAddrV4 {
     fn from_str(s: &str) -> Result<SocketAddrV4, AddrParseError> {
         match Parser::new(s).read_till_eof(|p| p.read_socket_addr_v4()) {
             Some(s) => Ok(s),
-            None => Err(AddrParseError { }),
+            None => Err(AddrParseError),
         }
     }
 }
@@ -350,7 +350,7 @@ impl FromStr for SocketAddrV6 {
     fn from_str(s: &str) -> Result<SocketAddrV6, AddrParseError> {
         match Parser::new(s).read_till_eof(|p| p.read_socket_addr_v6()) {
             Some(s) => Ok(s),
-            None => Err(AddrParseError { }),
+            None => Err(AddrParseError),
         }
     }
 }
@@ -361,7 +361,7 @@ impl FromStr for SocketAddr {
     fn from_str(s: &str) -> Result<SocketAddr, AddrParseError> {
         match Parser::new(s).read_till_eof(|p| p.read_socket_addr()) {
             Some(s) => Ok(s),
-            None => Err(AddrParseError { }),
+            None => Err(AddrParseError),
         }
     }
 }
@@ -382,7 +382,7 @@ impl FromStr for SocketAddr {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
-pub struct AddrParseError { }
+pub struct AddrParseError;
 
 #[stable(feature = "addr_parse_error_error", since = "1.4.0")]
 impl fmt::Display for AddrParseError {

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1591,7 +1591,7 @@ pub struct Path {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[stable(since = "1.7.0", feature = "strip_prefix")]
 #[non_exhaustive]
-pub struct StripPrefixError { }
+pub struct StripPrefixError;
 
 impl Path {
     // The following (private!) function allows construction of a path from a u8
@@ -1878,7 +1878,7 @@ impl Path {
                          -> Result<&'a Path, StripPrefixError> {
         iter_after(self.components(), base.components())
             .map(|c| c.as_path())
-            .ok_or(StripPrefixError { })
+            .ok_or(StripPrefixError)
     }
 
     /// Determines whether `base` is a prefix of `self`.

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1590,7 +1590,8 @@ pub struct Path {
 /// [`Path`]: struct.Path.html
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[stable(since = "1.7.0", feature = "strip_prefix")]
-pub struct StripPrefixError(());
+#[non_exhaustive]
+pub struct StripPrefixError { }
 
 impl Path {
     // The following (private!) function allows construction of a path from a u8
@@ -1877,7 +1878,7 @@ impl Path {
                          -> Result<&'a Path, StripPrefixError> {
         iter_after(self.components(), base.components())
             .map(|c| c.as_path())
-            .ok_or(StripPrefixError(()))
+            .ok_or(StripPrefixError { })
     }
 
     /// Determines whether `base` is a prefix of `self`.

--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -237,9 +237,8 @@ pub enum LocalKeyState {
 #[unstable(feature = "thread_local_state",
            reason = "state querying was recently added",
            issue = "27716")]
-pub struct AccessError {
-    _private: (),
-}
+#[non_exhaustive]
+pub struct AccessError { }
 
 #[unstable(feature = "thread_local_state",
            reason = "state querying was recently added",
@@ -371,9 +370,7 @@ impl<T: 'static> LocalKey<T> {
     pub fn try_with<F, R>(&'static self, f: F) -> Result<R, AccessError>
                       where F: FnOnce(&T) -> R {
         unsafe {
-            let slot = (self.inner)().ok_or(AccessError {
-                _private: (),
-            })?;
+            let slot = (self.inner)().ok_or(AccessError { })?;
             Ok(f(match *slot.get() {
                 Some(ref inner) => inner,
                 None => self.init(slot),

--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -238,7 +238,7 @@ pub enum LocalKeyState {
            reason = "state querying was recently added",
            issue = "27716")]
 #[non_exhaustive]
-pub struct AccessError { }
+pub struct AccessError;
 
 #[unstable(feature = "thread_local_state",
            reason = "state querying was recently added",
@@ -370,7 +370,7 @@ impl<T: 'static> LocalKey<T> {
     pub fn try_with<F, R>(&'static self, f: F) -> Result<R, AccessError>
                       where F: FnOnce(&T) -> R {
         unsafe {
-            let slot = (self.inner)().ok_or(AccessError { })?;
+            let slot = (self.inner)().ok_or(AccessError)?;
             Ok(f(match *slot.get() {
                 Some(ref inner) => inner,
                 None => self.init(slot),

--- a/src/libstd_unicode/lib.rs
+++ b/src/libstd_unicode/lib.rs
@@ -38,6 +38,7 @@
 #![feature(fused)]
 #![feature(fn_traits)]
 #![feature(lang_items)]
+#![feature(non_exhaustive)]
 #![feature(staged_api)]
 #![feature(try_from)]
 #![feature(unboxed_closures)]

--- a/src/libstd_unicode/tables.rs
+++ b/src/libstd_unicode/tables.rs
@@ -16,6 +16,7 @@
 ///
 /// See also: <http://www.unicode.org/versions/>
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[non_exhaustive]
 pub struct UnicodeVersion {
     /// Major version.
     pub major: u32,
@@ -25,9 +26,6 @@ pub struct UnicodeVersion {
 
     /// Micro (or Update) version.
     pub micro: u32,
-
-    // Private field to keep struct expandable.
-    _priv: (),
 }
 
 /// The version of [Unicode](http://www.unicode.org/) that the Unicode parts of
@@ -36,7 +34,6 @@ pub const UNICODE_VERSION: UnicodeVersion = UnicodeVersion {
     major: 10,
     minor: 0,
     micro: 0,
-    _priv: (),
 };
 
 

--- a/src/libstd_unicode/unicode.py
+++ b/src/libstd_unicode/unicode.py
@@ -561,6 +561,7 @@ if __name__ == "__main__":
 ///
 /// See also: <http://www.unicode.org/versions/>
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[non_exhaustive]
 pub struct UnicodeVersion {
     /// Major version.
     pub major: u32,
@@ -570,9 +571,6 @@ pub struct UnicodeVersion {
 
     /// Micro (or Update) version.
     pub micro: u32,
-
-    // Private field to keep struct expandable.
-    _priv: (),
 }
 
 /// The version of [Unicode](http://www.unicode.org/) that the Unicode parts of
@@ -581,7 +579,6 @@ pub const UNICODE_VERSION: UnicodeVersion = UnicodeVersion {
     major: %s,
     minor: %s,
     micro: %s,
-    _priv: (),
 };
 """ % unicode_version)
         (canon_decomp, compat_decomp, gencats, combines,


### PR DESCRIPTION
This gets rid of the `future_atomic_orderings` and `io_error_internals`
feature gates, as they are no longer needed.