### PR TITLE
Limit style lint to non-synthetic generic params

### DIFF
--- a/src/librustc_lint/bad_style.rs
+++ b/src/librustc_lint/bad_style.rs
@@ -128,7 +128,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonCamelCaseTypes {
 
     fn check_generic_param(&mut self, cx: &LateContext, param: &hir::GenericParam) {
         if let hir::GenericParam::Type(ref gen) = *param {
-            self.check_case(cx, "type parameter", gen.name, gen.span);
+            if gen.synthetic.is_none() {
+                self.check_case(cx, "type parameter", gen.name, gen.span);
+            }
         }
     }
 }

--- a/src/test/run-pass/issue-46959.rs
+++ b/src/test/run-pass/issue-46959.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(universal_impl_trait)]
+#![feature(conservative_impl_trait)]
+#![deny(non_camel_case_types)]
+
+#[allow(dead_code)]
+fn qqq(lol: impl Iterator<Item=u32>) -> impl Iterator<Item=u64> {
+        lol.map(|x|x as u64)
+}
+
+fn main() {}


### PR DESCRIPTION
Fix https://github.com/rust-lang/rust/issues/46959

r? @nikomatsakis 