### PR TITLE
Bump to 1.25.0

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -484,8 +484,8 @@ impl<'a> Builder<'a> {
              } else {
                  PathBuf::from("/path/to/nowhere/rustdoc/not/required")
              })
-             .env("TEST_MIRI", self.config.test_miri.to_string());
-
+             .env("TEST_MIRI", self.config.test_miri.to_string())
+             .env("RUSTC_ERROR_METADATA_DST", self.extended_error_dir());
         if let Some(n) = self.config.rust_codegen_units {
             cargo.env("RUSTC_CODEGEN_UNITS", n.to_string());
         }

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -419,7 +419,8 @@ impl<'a> Builder<'a> {
            .env("RUSTC_LIBDIR", self.sysroot_libdir(compiler, self.build.build))
            .env("CFG_RELEASE_CHANNEL", &self.build.config.channel)
            .env("RUSTDOC_REAL", self.rustdoc(host))
-           .env("RUSTDOC_CRATE_VERSION", self.build.rust_version());
+           .env("RUSTDOC_CRATE_VERSION", self.build.rust_version())
+           .env("RUSTC_BOOTSTRAP", "1");
         if let Some(linker) = self.build.linker(host) {
             cmd.env("RUSTC_TARGET_LINKER", linker);
         }

--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -24,7 +24,7 @@ use Build;
 use config::Config;
 
 // The version number
-pub const CFG_RELEASE_NUM: &str = "1.24.0";
+pub const CFG_RELEASE_NUM: &str = "1.25.0";
 
 // An optional number to put after the label, e.g. '.2' -> '-beta.2'
 // Be sure to make this starts with a dot to conform to semver pre-release

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -975,7 +975,8 @@ impl Step for ErrorIndex {
         build.run(builder.tool_cmd(Tool::ErrorIndex)
                     .arg("markdown")
                     .arg(&output)
-                    .env("CFG_BUILD", &build.build));
+                    .env("CFG_BUILD", &build.build)
+                    .env("RUSTC_ERROR_METADATA_DST", build.extended_error_dir()));
 
         markdown_test(builder, compiler, &output);
     }

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -671,7 +671,8 @@ impl Step for ErrorIndex {
         index.arg(out.join("error-index.html"));
 
         // FIXME: shouldn't have to pass this env var
-        index.env("CFG_BUILD", &build.build);
+        index.env("CFG_BUILD", &build.build)
+             .env("RUSTC_ERROR_METADATA_DST", build.extended_error_dir());
 
         build.run(&mut index);
     }

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -718,6 +718,11 @@ impl Build {
         self.config.python.as_ref().unwrap()
     }
 
+    /// Temporary directory that extended error information is emitted to.
+    fn extended_error_dir(&self) -> PathBuf {
+        self.out.join("tmp/extended-error-metadata")
+    }
+
     /// Tests whether the `compiler` compiling for `target` should be forced to
     /// use a stage1 compiler instead.
     ///

--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -315,7 +315,7 @@ pub fn symlink_dir(src: &Path, dest: &Path) -> io::Result<()> {
             let mut data = [0u8; MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
             let db = data.as_mut_ptr()
                             as *mut REPARSE_MOUNTPOINT_DATA_BUFFER;
-            let buf = &mut (*db).ReparseTarget as *mut _;
+            let buf = &mut (*db).ReparseTarget as *mut u16;
             let mut i = 0;
             // FIXME: this conversion is very hacky
             let v = br"\??\";

--- a/src/ci/docker/x86_64-gnu-incremental/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-incremental/Dockerfile
@@ -19,3 +19,4 @@ RUN sh /scripts/sccache.sh
 ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu
 ENV RUSTFLAGS -Zincremental=/tmp/rust-incr-cache
 ENV RUST_CHECK_TARGET check
+ENV CARGO_INCREMENTAL 0

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1390,6 +1390,5 @@ extern "rust-intrinsic" {
 
     /// Emits a `!nontemporal` store according to LLVM (see their docs).
     /// Probably will never become stable.
-    #[cfg(not(stage0))]
     pub fn nontemporal_store<T>(ptr: *mut T, val: T);
 }

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -175,4 +175,5 @@ fn noop() {
 
 
 // Build the diagnostics array at the end so that the metadata includes error use sites.
+#[cfg(not(stage0))] // remove after the next snapshot
 __build_diagnostic_array! { librustc, DIAGNOSTICS }

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -642,6 +642,7 @@ impl Session {
             IncrCompSession::Active { ref session_directory, .. } => {
                 session_directory.clone()
             }
+            IncrCompSession::InvalidBecauseOfErrors { .. } => return,
             _ => bug!("Trying to invalidate IncrCompSession `{:?}`",
                       *incr_comp_session),
         };

--- a/src/librustc_const_eval/lib.rs
+++ b/src/librustc_const_eval/lib.rs
@@ -56,4 +56,5 @@ pub fn provide(providers: &mut Providers) {
 }
 
 // Build the diagnostics array at the end so that the metadata includes error use sites.
+#[cfg(not(stage0))] // remove after the next snapshot
 __build_diagnostic_array! { librustc_const_eval, DIAGNOSTICS }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1268,6 +1268,14 @@ fn exit_on_err() -> ! {
     panic!();
 }
 
+#[cfg(stage0)]
+pub fn diagnostics_registry() -> errors::registry::Registry {
+    use errors::registry::Registry;
+
+    Registry::new(&[])
+}
+
+#[cfg(not(stage0))]
 pub fn diagnostics_registry() -> errors::registry::Registry {
     use errors::registry::Registry;
 

--- a/src/librustc_metadata/lib.rs
+++ b/src/librustc_metadata/lib.rs
@@ -58,4 +58,5 @@ pub mod cstore;
 pub mod dynamic_lib;
 pub mod locator;
 
+#[cfg(not(stage0))] // remove after the next snapshot
 __build_diagnostic_array! { librustc_metadata, DIAGNOSTICS }

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -79,4 +79,5 @@ pub fn provide(providers: &mut Providers) {
     providers.const_eval = interpret::const_eval_provider;
 }
 
+#[cfg(not(stage0))] // remove after the next snapshot
 __build_diagnostic_array! { librustc_mir, DIAGNOSTICS }

--- a/src/librustc_passes/lib.rs
+++ b/src/librustc_passes/lib.rs
@@ -45,6 +45,7 @@ mod mir_stats;
 pub mod no_asm;
 pub mod static_recursion;
 
+#[cfg(not(stage0))] // remove after the next snapshot
 __build_diagnostic_array! { librustc_passes, DIAGNOSTICS }
 
 pub fn provide(providers: &mut Providers) {

--- a/src/librustc_plugin/lib.rs
+++ b/src/librustc_plugin/lib.rs
@@ -82,4 +82,5 @@ pub mod registry;
 pub mod load;
 pub mod build;
 
+#[cfg(not(stage0))] // remove after the next snapshot
 __build_diagnostic_array! { librustc_plugin, DIAGNOSTICS }

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -1725,4 +1725,5 @@ fn privacy_access_levels<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     Rc::new(visitor.access_levels)
 }
 
+#[cfg(not(stage0))] // remove after the next snapshot
 __build_diagnostic_array! { librustc_privacy, DIAGNOSTICS }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4089,4 +4089,5 @@ pub enum MakeGlobMap {
     No,
 }
 
+#[cfg(not(stage0))] // remove after the next snapshot
 __build_diagnostic_array! { librustc_resolve, DIAGNOSTICS }

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -328,4 +328,5 @@ pub struct CrateInfo {
     used_crates_dynamic: Vec<(CrateNum, LibSource)>,
 }
 
+#[cfg(not(stage0))] // remove after the next snapshot
 __build_diagnostic_array! { librustc_trans, DIAGNOSTICS }

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -380,4 +380,5 @@ pub fn hir_trait_to_predicates<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, hir_trait:
     (principal, projections)
 }
 
+#[cfg(not(stage0))] // remove after the next snapshot
 __build_diagnostic_array! { librustc_typeck, DIAGNOSTICS }

--- a/src/libstd/rt.rs
+++ b/src/libstd/rt.rs
@@ -28,7 +28,7 @@ pub use panicking::{begin_panic, begin_panic_fmt, update_panic_count};
 
 // To reduce the generated code of the new `lang_start`, this function is doing
 // the real work.
-#[cfg(not(any(test, stage0)))]
+#[cfg(not(test))]
 fn lang_start_internal(main: &(Fn() -> i32 + Sync + ::panic::RefUnwindSafe),
                        argc: isize, argv: *const *const u8) -> isize {
     use panic;
@@ -66,55 +66,10 @@ fn lang_start_internal(main: &(Fn() -> i32 + Sync + ::panic::RefUnwindSafe),
     }
 }
 
-#[cfg(not(any(test, stage0)))]
+#[cfg(not(test))]
 #[lang = "start"]
 fn lang_start<T: ::termination::Termination + 'static>
     (main: fn() -> T, argc: isize, argv: *const *const u8) -> isize
 {
     lang_start_internal(&move || main().report(), argc, argv)
-}
-
-#[cfg(all(not(test), stage0))]
-#[lang = "start"]
-fn lang_start(main: fn(), argc: isize, argv: *const *const u8) -> isize {
-    use panic;
-    use sys;
-    use sys_common;
-    use sys_common::thread_info;
-    use thread::Thread;
-    #[cfg(not(feature = "backtrace"))]
-    use mem;
-
-    sys::init();
-
-    let failed = unsafe {
-        let main_guard = sys::thread::guard::init();
-        sys::stack_overflow::init();
-
-        // Next, set up the current Thread with the guard information we just
-        // created. Note that this isn't necessary in general for new threads,
-        // but we just do this to name the main thread and to give it correct
-        // info about the stack bounds.
-        let thread = Thread::new(Some("main".to_owned()));
-        thread_info::set(main_guard, thread);
-
-        // Store our args if necessary in a squirreled away location
-        sys::args::init(argc, argv);
-
-        // Let's run some code!
-        #[cfg(feature = "backtrace")]
-        let res = panic::catch_unwind(|| {
-            ::sys_common::backtrace::__rust_begin_short_backtrace(main)
-        });
-        #[cfg(not(feature = "backtrace"))]
-        let res = panic::catch_unwind(mem::transmute::<_, fn()>(main));
-        sys_common::cleanup();
-        res.is_err()
-    };
-
-    if failed {
-        101
-    } else {
-        0
-    }
 }

--- a/src/libstd/termination.rs
+++ b/src/libstd/termination.rs
@@ -29,7 +29,7 @@ mod exit {
 ///
 /// The default implementations are returning `libc::EXIT_SUCCESS` to indicate
 /// a successful execution. In case of a failure, `libc::EXIT_FAILURE` is returned.
-#[cfg_attr(not(any(stage0, test)), lang = "termination")]
+#[cfg_attr(not(test), lang = "termination")]
 #[unstable(feature = "termination_trait", issue = "43301")]
 #[rustc_on_unimplemented =
   "`main` can only return types that implement {Termination}, not `{Self}`"]

--- a/src/libsyntax/diagnostics/metadata.rs
+++ b/src/libsyntax/diagnostics/metadata.rs
@@ -14,18 +14,16 @@
 //! currently always a crate name.
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::env;
 use std::fs::{remove_file, create_dir_all, File};
 use std::io::Write;
+use std::path::PathBuf;
 use std::error::Error;
 use rustc_serialize::json::as_json;
 
 use syntax_pos::{Span, FileName};
 use ext::base::ExtCtxt;
 use diagnostics::plugin::{ErrorMap, ErrorInfo};
-
-// Default metadata directory to use for extended error JSON.
-const ERROR_METADATA_PREFIX: &'static str = "tmp/extended-errors";
 
 /// JSON encodable/decodable version of `ErrorInfo`.
 #[derive(PartialEq, RustcDecodable, RustcEncodable)]
@@ -59,7 +57,10 @@ impl ErrorLocation {
 ///
 /// See `output_metadata`.
 pub fn get_metadata_dir(prefix: &str) -> PathBuf {
-    PathBuf::from(ERROR_METADATA_PREFIX).join(prefix)
+    env::var_os("RUSTC_ERROR_METADATA_DST")
+        .map(PathBuf::from)
+        .expect("env var `RUSTC_ERROR_METADATA_DST` isn't set")
+        .join(prefix)
 }
 
 /// Map `name` to a path in the given directory: <directory>/<name>.json

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -151,4 +151,5 @@ pub mod ext {
 #[cfg(test)]
 mod test_snippet;
 
+#[cfg(not(stage0))] // remove after the next snapshot
 __build_diagnostic_array! { libsyntax, DIAGNOSTICS }

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,7 +12,7 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2017-11-21
+date: 2018-01-02
 rustc: beta
 cargo: beta
 


### PR DESCRIPTION
* Bump the release version to 1.25
* Bump the bootstrap compiler to the recent beta
* Allow using unstable rustdoc features on beta - this fix has been applied to
  the beta branch but needed to go to the master branch as well.