### PR TITLE
Only bump error count when we are sure that the diagnostic is not a repetition

### DIFF
--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -100,9 +100,6 @@ impl Diagnostic {
 
     /// Cancel the diagnostic (a structured diagnostic must either be emitted or
     /// canceled or it will panic when dropped).
-    /// BEWARE: if this DiagnosticBuilder is an error, then creating it will
-    /// bump the error count on the Handler and canceling it won't undo that.
-    /// If you want to decrement the error count you should use `Handler::cancel`.
     pub fn cancel(&mut self) {
         self.level = Level::Cancelled;
     }

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -83,7 +83,12 @@ impl<'a> DiagnosticBuilder<'a> {
             return;
         }
 
-        let is_error = match self.level {
+        self.handler.emit_db(&self);
+        self.cancel();
+    }
+
+    pub fn is_error(&self) -> bool {
+        match self.level {
             Level::Bug |
             Level::Fatal |
             Level::PhaseFatal |
@@ -97,18 +102,7 @@ impl<'a> DiagnosticBuilder<'a> {
             Level::Cancelled => {
                 false
             }
-        };
-
-        self.handler.emit_db(&self);
-        self.cancel();
-
-        if is_error {
-            self.handler.bump_err_count();
         }
-
-        // if self.is_fatal() {
-        //     panic!(FatalError);
-        // }
     }
 
     /// Convenience function for internal use, clients should use one of the

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -588,6 +588,9 @@ impl Handler {
         // one:
         if self.emitted_diagnostics.borrow_mut().insert(diagnostic_hash) {
             self.emitter.borrow_mut().emit(db);
+            if db.is_error() {
+                self.bump_err_count();
+            }
         }
     }
 }

--- a/src/test/ui/feature-gate/issue-43106-gating-of-rustc_deprecated.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-rustc_deprecated.stderr
@@ -42,5 +42,5 @@ error: stability attributes may not be used outside of the standard library
 35 |     #[rustc_deprecated = "1500"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 9 previous errors
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/feature-gate/issue-43106-gating-of-stable.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-stable.stderr
@@ -42,5 +42,5 @@ error: stability attributes may not be used outside of the standard library
 35 |     #[stable = "1300"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 9 previous errors
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/feature-gate/issue-43106-gating-of-unstable.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-unstable.stderr
@@ -42,5 +42,5 @@ error: stability attributes may not be used outside of the standard library
 35 |     #[unstable = "1200"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 9 previous errors
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/issue-42106.stderr
+++ b/src/test/ui/issue-42106.stderr
@@ -8,5 +8,5 @@ error[E0502]: cannot borrow `*collection` as mutable because `collection` is als
 14 | }
    | - immutable borrow ends here
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 

--- a/src/test/ui/span/macro-ty-params.stderr
+++ b/src/test/ui/span/macro-ty-params.stderr
@@ -22,5 +22,5 @@ error: generic arguments in macro path
 20 |     m!(MyTrait<>); //~ ERROR generic arguments in macro path
    |               ^^
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
This ensures that if we emit the same diagnostic twice, the error count will
match the real number of errors shown to the user.

Fixes #42106

This is a followup of https://github.com/rust-lang/rust/pull/45603 as stated in https://github.com/rust-lang/rust/issues/42106#issuecomment-345218473.

This program, for example:

```rust
fn do_something<T>(collection: &mut Vec<T>) {
    let _a = &collection;
    collection.swap(1, 2);
}

fn main() {}
```

without this patch, produces:

```
error[E0502]: cannot borrow `*collection` as mutable because `collection` is also borrowed as immutable
  --> $DIR/issue-42106.rs:13:5
   |
12 |     let _a = &collection;
   |               ---------- immutable borrow occurs here
13 |     collection.swap(1, 2); //~ ERROR also borrowed as immutable
   |     ^^^^^^^^^^ mutable borrow occurs here
14 | }
   | - immutable borrow ends here

error: aborting due to 2 previous errors
```

The number of errors do not match the diagnostics reported. This PR fixes this problem. The output is now in this case:

```
error[E0502]: cannot borrow `*collection` as mutable because `collection` is also borrowed as immutable
  --> $DIR/issue-42106.rs:13:5
   |
12 |     let _a = &collection;
   |               ---------- immutable borrow occurs here
13 |     collection.swap(1, 2); //~ ERROR also borrowed as immutable
   |     ^^^^^^^^^^ mutable borrow occurs here
14 | }
   | - immutable borrow ends here

error: aborting due to previous error
```

Also, some other tests outputs have been adapted because their count didn't really match the number of diagnostics reported.

As an aside, an outdated comment has been removed (`Handler::cancel` will only call to the `Diagnostic::cancel` method and will not decrease the count of errors).

All tests are passing with this PR (`x.py test` is successful).