### PR TITLE
Fix built-in indexing not being used where index type wasn't "obviously" usize

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2217,18 +2217,6 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                adjusted_ty,
                index_ty);
 
-        // First, try built-in indexing.
-        match (adjusted_ty.builtin_index(), &index_ty.sty) {
-            (Some(ty), &ty::TyUint(ast::UintTy::Usize)) |
-            (Some(ty), &ty::TyInfer(ty::IntVar(_))) => {
-                debug!("try_index_step: success, using built-in indexing");
-                let adjustments = autoderef.adjust_steps(lvalue_pref);
-                self.apply_adjustments(base_expr, adjustments);
-                return Some((self.tcx.types.usize, ty));
-            }
-            _ => {}
-        }
-
         for &unsize in &[false, true] {
             let mut self_ty = adjusted_ty;
             if unsize {

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -17,7 +17,7 @@ use rustc::hir;
 use rustc::hir::def_id::{DefId, DefIndex};
 use rustc::hir::intravisit::{self, NestedVisitorMap, Visitor};
 use rustc::infer::InferCtxt;
-use rustc::ty::{self, Ty, TyCtxt};
+use rustc::ty::{self, Ty, TyCtxt, TypeVariants};
 use rustc::ty::adjustment::{Adjust, Adjustment};
 use rustc::ty::fold::{TypeFoldable, TypeFolder};
 use rustc::util::nodemap::DefIdSet;
@@ -168,14 +168,23 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
     fn fix_index_builtin_expr(&mut self, e: &hir::Expr) {
         if let hir::ExprIndex(ref base, ref index) = e.node {
             let mut tables = self.fcx.tables.borrow_mut();
-            
-            let base_ty = tables.expr_ty_adjusted(&base);
-            let base_ty = self.fcx.resolve_type_vars_if_possible(&base_ty);
+
+            let base_ty = {
+                let base_ty = tables.expr_ty_adjusted(&base);
+                // When unsizing, the final type of the expression is taken
+                // from the first argument of the indexing operator, which
+                // is a &self, and has to be deconstructed
+                if let TypeVariants::TyRef(_, ref ref_to) = base_ty.sty {
+                    ref_to.ty
+                } else {
+                    base_ty
+                }
+            };
+
             let index_ty = tables.expr_ty_adjusted(&index);
             let index_ty = self.fcx.resolve_type_vars_if_possible(&index_ty);
 
             if base_ty.builtin_index().is_some() && index_ty.is_uint() {
-                
                 // Remove the method call record, which blocks use in
                 // constant or static cases
                 tables.type_dependent_defs_mut().remove(e.hir_id);

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -184,7 +184,7 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
             let index_ty = tables.expr_ty_adjusted(&index);
             let index_ty = self.fcx.resolve_type_vars_if_possible(&index_ty);
 
-            if base_ty.builtin_index().is_some() 
+            if base_ty.builtin_index().is_some()
                 && index_ty == self.fcx.tcx.types.usize {
                 // Remove the method call record
                 tables.type_dependent_defs_mut().remove(e.hir_id);

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -12,12 +12,13 @@
 // unresolved type variables and replaces "ty_var" types with their
 // substitutions.
 
-use check::FnCtxt;
+use check::{FnCtxt, LvalueOp};
 use rustc::hir;
 use rustc::hir::def_id::{DefId, DefIndex};
 use rustc::hir::intravisit::{self, NestedVisitorMap, Visitor};
 use rustc::infer::InferCtxt;
-use rustc::ty::{self, Ty, TyCtxt};
+use rustc::ty::{self, LvaluePreference, Ty, TyCtxt};
+use rustc::ty::adjustment::{Adjust, Adjustment};
 use rustc::ty::fold::{TypeFoldable, TypeFolder};
 use rustc::util::nodemap::DefIdSet;
 use syntax::ast;
@@ -159,7 +160,85 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
             _ => {}
         }
     }
+
+    // Similar to operators, indexing is always assumed to be overloaded
+    // Here, correct cases where an indexing expression can be simplified
+    // to use builtin indexing because the index type is known to be
+    // usize-ish
+    fn fix_index_builtin_expr(&mut self, e: &hir::Expr) {
+        if let hir::ExprIndex(ref base, ref index) = e.node {
+            let base_ty = self.fcx.node_ty(base.hir_id);
+            let base_ty = self.fcx.resolve_type_vars_if_possible(&base_ty);
+            let index_ty = self.fcx.node_ty(index.hir_id);
+            let index_ty = self.fcx.resolve_type_vars_if_possible(&index_ty);
+
+            if index_ty.is_uint() {
+                // HACK: the *actual* type being indexed is not stored anywhere
+                // so we try to find it again here by derefs
+                let mut autoderef = self.fcx.autoderef(e.span, base_ty);
+                let builtin_ty : Option<_> = {
+                    loop {
+                        // This is essentially a duplicate of the index discovery
+                        // logic in typechecking code
+                        // Find the first type dereffable to which has builtin 
+                        // indexing - this 
+                        if let Some(_) = autoderef.next() {
+                            let current_ty = autoderef.unambiguous_final_ty();
+
+                            if current_ty.builtin_index().is_some() {
+                                // If there is a builtin index, use it
+                                break Some(current_ty);
+                            } else {
+                                // If there's an overloaded index which happens
+                                // to take a uint, stop looking - otherwise we
+                                // might incorrectly deref further
+                                let overloaded_method = 
+                                    self.fcx.try_overloaded_lvalue_op(
+                                        e.span,
+                                        base_ty,
+                                        &[index_ty],
+                                        LvaluePreference::NoPreference,
+                                        LvalueOp::Index
+                                    );
+
+                                if overloaded_method.is_some() {
+                                    break None;
+                                }
+                            }
+                        } else {
+                            break None;
+                        }
+                    }
+                };
+
+                if builtin_ty.is_some() {
+                    let mut tables = self.fcx.tables.borrow_mut();
+                 
+                    // Remove the method call record, which blocks use in
+                    // constant or static cases
+                    tables.type_dependent_defs_mut().remove(e.hir_id);
+                    tables.node_substs_mut().remove(e.hir_id);
+
+                    tables.adjustments_mut().get_mut(base.hir_id).map(|a| {
+                        // Discard the need for a mutable borrow
+                        match a.pop() {
+                            // Extra adjustment made when indexing causes a drop
+                            // of size information - we need to get rid of it
+                            // Since this is "after" the other adjustment to be
+                            // discarded, we do an extra `pop()`
+                            Some(Adjustment { kind: Adjust::Unsize, .. }) => {
+                                // So the borrow discard actually happens here
+                                a.pop();
+                            },
+                            _ => {}
+                        }
+                    });
+                }
+            }
+        }
+    }
 }
+
 
 ///////////////////////////////////////////////////////////////////////////
 // Impl of Visitor for Resolver
@@ -176,6 +255,7 @@ impl<'cx, 'gcx, 'tcx> Visitor<'gcx> for WritebackCx<'cx, 'gcx, 'tcx> {
 
     fn visit_expr(&mut self, e: &'gcx hir::Expr) {
         self.fix_scalar_builtin_expr(e);
+        self.fix_index_builtin_expr(e);
 
         self.visit_node_id(e.span, e.hir_id);
 

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -17,7 +17,7 @@ use rustc::hir;
 use rustc::hir::def_id::{DefId, DefIndex};
 use rustc::hir::intravisit::{self, NestedVisitorMap, Visitor};
 use rustc::infer::InferCtxt;
-use rustc::ty::{self, Ty, TyCtxt, TypeVariants};
+use rustc::ty::{self, Ty, TyCtxt};
 use rustc::ty::adjustment::{Adjust, Adjustment};
 use rustc::ty::fold::{TypeFoldable, TypeFolder};
 use rustc::util::nodemap::DefIdSet;
@@ -174,7 +174,7 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
                 // When unsizing, the final type of the expression is taken
                 // from the first argument of the indexing operator, which
                 // is a &self, and has to be deconstructed
-                if let TypeVariants::TyRef(_, ref ref_to) = base_ty.sty {
+                if let ty::TyRef(_, ref ref_to) = base_ty.sty {
                     ref_to.ty
                 } else {
                     base_ty
@@ -184,9 +184,9 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
             let index_ty = tables.expr_ty_adjusted(&index);
             let index_ty = self.fcx.resolve_type_vars_if_possible(&index_ty);
 
-            if base_ty.builtin_index().is_some() && index_ty.is_uint() {
-                // Remove the method call record, which blocks use in
-                // constant or static cases
+            if base_ty.builtin_index().is_some() 
+                && index_ty == self.fcx.tcx.types.usize {
+                // Remove the method call record
                 tables.type_dependent_defs_mut().remove(e.hir_id);
                 tables.node_substs_mut().remove(e.hir_id);
 

--- a/src/test/run-pass/issue-33903.rs
+++ b/src/test/run-pass/issue-33903.rs
@@ -1,0 +1,19 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue 33903:
+// Built-in indexing should be used even when the index is not
+// trivially an integer
+// Only built-in indexing can be used in constant expresssions
+
+const FOO: i32 = [12, 34][0 + 1];
+
+fn main() {}
+

--- a/src/test/run-pass/issue-46095.rs
+++ b/src/test/run-pass/issue-46095.rs
@@ -1,0 +1,39 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct A;
+
+impl A {
+    fn take_mutably(&mut self) {}
+}
+
+fn identity<T>(t: T) -> T {
+    t
+}
+
+// Issue 46095
+// Built-in indexing should be used even when the index is not
+// trivially an integer
+// Overloaded indexing would cause wrapped to be borrowed mutably
+
+fn main() {
+    let mut a1 = A;
+    let mut a2 = A;
+
+    let wrapped = [&mut a1, &mut a2];
+
+    {
+        wrapped[0 + 1 - 1].take_mutably();
+    }
+
+    {
+        wrapped[identity(0)].take_mutably();
+    }
+}


### PR DESCRIPTION
Fixes #33903
Fixes #46095

This PR was made possible thanks to the generous help of @eddyb 

Following the example of binary operators, builtin checking for indexing has been moved from the typecheck stage to a writeback stage, after type constraints have been resolved.