### PR TITLE
Add iterator method specialisations to Range*

### DIFF
--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -253,6 +253,16 @@ impl<A: Step> Iterator for ops::Range<A> {
     }
 
     #[inline]
+    fn last(mut self) -> Option<A> {
+        self.next_back()
+    }
+
+    #[inline]
+    fn min(mut self) -> Option<A> {
+        self.next()
+    }
+
+    #[inline]
     fn max(mut self) -> Option<A> {
         self.next_back()
     }

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -367,6 +367,16 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
         self.end.replace_zero();
         None
     }
+
+    #[inline]
+    fn min(self) -> Option<A> {
+        Some(self.start)
+    }
+
+    #[inline]
+    fn max(self) -> Option<A> {
+        Some(self.end)
+    }
 }
 
 #[unstable(feature = "inclusive_range", reason = "recently added, follows RFC", issue = "28237")]

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -305,6 +305,11 @@ impl<A: Step> Iterator for ops::RangeFrom<A> {
         self.start = plus_n.add_one();
         Some(plus_n)
     }
+
+    #[inline]
+    fn min(self) -> Option<A> {
+        Some(self.start)
+    }
 }
 
 #[unstable(feature = "fused", issue = "35602")]
@@ -366,6 +371,11 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
         self.start.replace_one();
         self.end.replace_zero();
         None
+    }
+
+    #[inline]
+    fn last(self) -> Option<A> {
+        Some(self.end)
     }
 
     #[inline]

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -13,7 +13,7 @@ use mem;
 use ops::{self, Add, Sub};
 use usize;
 
-use super::{FusedIterator, TrustedLen, Sum};
+use super::{FusedIterator, TrustedLen};
 
 /// Objects that can be stepped over in both directions.
 ///
@@ -177,20 +177,6 @@ step_impl_signed!([i64: u64]);
 step_impl_no_between!(u64 i64);
 step_impl_no_between!(u128 i128);
 
-macro_rules! range_inc_iter_impl {
-    ($($t:ty)*) => ($(
-        #[stable(feature = "rust1", since = "1.0.0")]
-        impl Iterator for ops::RangeInclusive<$t> {
-            #[inline]
-            fn sum<S>(self) -> S where S: Sum<$t> {
-                let a = self.start;
-                let b = self.end;
-                S::sum(super::once((a + b) * (1 + b - a) / 2))
-            }
-        }
-    )*)
-}
-
 macro_rules! range_exact_iter_impl {
     ($($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -273,9 +259,6 @@ impl<A: Step> Iterator for ops::Range<A> {
         } else { None }
     }
 }
-
-// These macros generate specialisations for `Iterator` methods for efficiency purposes.
-range_inc_iter_impl!(usize u8 u16 u32 u64 isize i8 i16 i32 i64);
 
 // These macros generate `ExactSizeIterator` impls for various range types.
 // Range<{u,i}64> and RangeInclusive<{u,i}{32,64,size}> are excluded

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -13,7 +13,7 @@ use mem;
 use ops::{self, Add, Sub};
 use usize;
 
-use super::{FusedIterator, TrustedLen};
+use super::{FusedIterator, TrustedLen, Sum};
 
 /// Objects that can be stepped over in both directions.
 ///
@@ -177,6 +177,20 @@ step_impl_signed!([i64: u64]);
 step_impl_no_between!(u64 i64);
 step_impl_no_between!(u128 i128);
 
+macro_rules! range_inc_iter_impl {
+    ($($t:ty)*) => ($(
+        #[stable(feature = "rust1", since = "1.0.0")]
+        impl Iterator for ops::RangeInclusive<$t> {
+            #[inline]
+            fn sum<S>(self) -> S where S: Sum<$t> {
+                let a = self.start;
+                let b = self.end;
+                S::sum(super::once((a + b) * (1 + b - a) / 2))
+            }
+        }
+    )*)
+}
+
 macro_rules! range_exact_iter_impl {
     ($($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -251,7 +265,17 @@ impl<A: Step> Iterator for ops::Range<A> {
         self.start = self.end.clone();
         None
     }
+
+    #[inline]
+    fn max(self) -> Option<A> {
+        if self.start != self.end {
+            Some(self.end.sub_one())
+        } else { None }
+    }
 }
+
+// These macros generate specialisations for `Iterator` methods for efficiency purposes.
+range_inc_iter_impl!(usize u8 u16 u32 u64 isize i8 i16 i32 i64);
 
 // These macros generate `ExactSizeIterator` impls for various range types.
 // Range<{u,i}64> and RangeInclusive<{u,i}{32,64,size}> are excluded

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -312,11 +312,6 @@ impl<A: Step> Iterator for ops::RangeFrom<A> {
         self.start = plus_n.add_one();
         Some(plus_n)
     }
-
-    #[inline]
-    fn min(self) -> Option<A> {
-        Some(self.start)
-    }
 }
 
 #[unstable(feature = "fused", issue = "35602")]

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -377,17 +377,23 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
 
     #[inline]
     fn last(self) -> Option<A> {
-        Some(self.end)
+        if self.start <= self.end {
+            Some(self.end)
+        } else { None }
     }
 
     #[inline]
     fn min(self) -> Option<A> {
-        Some(self.start)
+        if self.start <= self.end {
+            Some(self.start)
+        } else { None }
     }
 
     #[inline]
     fn max(self) -> Option<A> {
-        Some(self.end)
+        if self.start <= self.end {
+            Some(self.end)
+        } else { None }
     }
 }
 

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -253,10 +253,8 @@ impl<A: Step> Iterator for ops::Range<A> {
     }
 
     #[inline]
-    fn max(self) -> Option<A> {
-        if self.start != self.end {
-            Some(self.end.sub_one())
-        } else { None }
+    fn max(mut self) -> Option<A> {
+        self.next_back()
     }
 }
 
@@ -376,24 +374,18 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
     }
 
     #[inline]
-    fn last(self) -> Option<A> {
-        if self.start <= self.end {
-            Some(self.end)
-        } else { None }
+    fn last(mut self) -> Option<A> {
+        self.next_back()
     }
 
     #[inline]
-    fn min(self) -> Option<A> {
-        if self.start <= self.end {
-            Some(self.start)
-        } else { None }
+    fn min(mut self) -> Option<A> {
+        self.next()
     }
 
     #[inline]
-    fn max(self) -> Option<A> {
-        if self.start <= self.end {
-            Some(self.end)
-        } else { None }
+    fn max(mut self) -> Option<A> {
+        self.next_back()
     }
 }
 

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1353,10 +1353,14 @@ fn test_range_step() {
 }
 
 #[test]
-fn test_range_max() {
-    assert_eq!((0..100).max(), Some(99));
-    assert_eq!((-20..-10).max(), Some(-11));
-    assert_eq!((1..1).max(), None);
+fn test_range_last_max() {
+    assert_eq!((0..20).last(), Some(19));
+    assert_eq!((-20..0).last(), Some(-1));
+    assert_eq!((5..5).last(), None);
+
+    assert_eq!((0..20).max(), Some(19));
+    assert_eq!((-20..0).max(), Some(-1));
+    assert_eq!((5..5).max(), None);
 }
 
 #[test]
@@ -1374,6 +1378,13 @@ fn test_range_inclusive_last_max() {
     let mut r = 10..=10;
     r.next();
     assert_eq!(r.max(), None);
+}
+
+#[test]
+fn test_range_min() {
+    assert_eq!((0..20).min(), Some(0));
+    assert_eq!((-20..0).min(), Some(-20));
+    assert_eq!((5..5).min(), None);
 }
 
 #[test]

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1360,13 +1360,6 @@ fn test_range_max() {
 }
 
 #[test]
-fn test_range_from_min() {
-    assert_eq!((0..).min(), Some(0));
-    assert_eq!((-20..).min(), Some(-20));
-    assert_eq!((20..).min(), Some(20));
-}
-
-#[test]
 fn test_range_inc_last_max() {
     assert_eq!((0..=20).last(), Some(20));
     assert_eq!((-20..=0).last(), Some(0));

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1353,6 +1353,38 @@ fn test_range_step() {
 }
 
 #[test]
+fn test_range_max() {
+    assert_eq!((0..100).max(), Some(99));
+    assert_eq!((-20..-10).max(), Some(-11));
+    assert_eq!((1..1).max(), None);
+}
+
+#[test]
+fn test_range_from_min() {
+    assert_eq!((0..).min(), Some(0));
+    assert_eq!((-20..).min(), Some(-20));
+    assert_eq!((20..).min(), Some(20));
+}
+
+#[test]
+fn test_range_inc_last_max() {
+    assert_eq!((0..=20).last(), Some(20));
+    assert_eq!((-20..=0).last(), Some(0));
+    assert_eq!((5..=5).last(), Some(5));
+
+    assert_eq!((0..=20).max(), Some(20));
+    assert_eq!((-20..=0).max(), Some(0));
+    assert_eq!((5..=5).max(), Some(5));
+}
+
+#[test]
+fn test_range_inc_min() {
+    assert_eq!((0..=20).min(), Some(0));
+    assert_eq!((-20..=0).min(), Some(-20));
+    assert_eq!((5..=5).min(), Some(5));
+}
+
+#[test]
 fn test_repeat() {
     let mut it = repeat(42);
     assert_eq!(it.next(), Some(42));

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1360,21 +1360,30 @@ fn test_range_max() {
 }
 
 #[test]
-fn test_range_inc_last_max() {
+fn test_range_inclusive_last_max() {
     assert_eq!((0..=20).last(), Some(20));
     assert_eq!((-20..=0).last(), Some(0));
     assert_eq!((5..=5).last(), Some(5));
+    let mut r = 10..=10;
+    r.next();
+    assert_eq!(r.last(), None);
 
     assert_eq!((0..=20).max(), Some(20));
     assert_eq!((-20..=0).max(), Some(0));
     assert_eq!((5..=5).max(), Some(5));
+    let mut r = 10..=10;
+    r.next();
+    assert_eq!(r.max(), None);
 }
 
 #[test]
-fn test_range_inc_min() {
+fn test_range_inclusive_min() {
     assert_eq!((0..=20).min(), Some(0));
     assert_eq!((-20..=0).min(), Some(-20));
     assert_eq!((5..=5).min(), Some(5));
+    let mut r = 10..=10;
+    r.next();
+    assert_eq!(r.min(), None);
 }
 
 #[test]


### PR DESCRIPTION
Add specialised implementations of `max` for `Range`, and `last`, `min` and `max` for `RangeInclusive`, all of which lead to significant advantages in the generated assembly on x86.

Note that adding specialisations of `min` and `last` for `Range` led to no benefit, and adding `sum` for `Range` and `RangeInclusive` led to type inference issues (though this is possibly still worthwhile considering the performance gain).

This addresses some of the concerns in #39975.
  
  