### PR TITLE
Equivalent example for ? operator

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -330,6 +330,7 @@ macro_rules! debug_assert_ne {
 /// // The prefered method of quick returning Errors
 /// fn write_to_file_question() -> Result<(), MyError> {
 ///     let mut file = File::create("my_best_friends.txt")?;
+///     file.write_all(b"This is a list of my best friends.")?;
 ///     Ok(())
 /// }
 ///


### PR DESCRIPTION
The example with the ? operator in the documentation for try! macro was missing file.write_all.
Now all three examples are consistent.