### PR TITLE
Port libpanic_abort and libpanic_unwind to CloudABI

### DIFF
--- a/src/libpanic_abort/lib.rs
+++ b/src/libpanic_abort/lib.rs
@@ -53,7 +53,7 @@ pub unsafe extern fn __rust_maybe_catch_panic(f: fn(*mut u8),
 pub unsafe extern fn __rust_start_panic(_data: usize, _vtable: usize) -> u32 {
     abort();
 
-    #[cfg(unix)]
+    #[cfg(any(unix, target_os = "cloudabi"))]
     unsafe fn abort() -> ! {
         extern crate libc;
         libc::abort();

--- a/src/libpanic_unwind/lib.rs
+++ b/src/libpanic_unwind/lib.rs
@@ -68,6 +68,7 @@ mod imp;
 
 // i686-pc-windows-gnu and all others
 #[cfg(any(all(unix, not(target_os = "emscripten")),
+          target_os = "cloudabi",
           target_os = "redox",
           all(windows, target_arch = "x86", target_env = "gnu")))]
 #[path = "gcc.rs"]


### PR DESCRIPTION
This change ports both the libpanic* libraries to CloudABI.

The most interesting part of this pull request, however, is that it imports the CloudABI system call API into the Rust tree through a Git submodule. These will also be used by my port of libstd to CloudABI extensively, as that library obviously needs to invoke system calls to implement its primitives.

I have taken the same approach as libc: `src/libcloudabi` + `src/rustc/cloudabi_shim`. If some other naming scheme is preferred, feel free to let me know! As `libcloudabi` is pretty small, maybe it makes sense to copy, instead of using a submodule?