### PR TITLE
rustbuild: Don't allow stable bootstrap from dev

### DIFF
--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -21,9 +21,10 @@
 use std::collections::HashMap;
 use std::env;
 use std::ffi::{OsString, OsStr};
-use std::fs;
-use std::process::Command;
+use std::fs::{self, File};
+use std::io::Read;
 use std::path::PathBuf;
+use std::process::Command;
 
 use build_helper::output;
 
@@ -233,5 +234,15 @@ $ pacman -R cmake && pacman -S mingw-w64-x86_64-cmake
 
     if let Some(ref s) = build.config.ccache {
         cmd_finder.must_have(s);
+    }
+
+    if build.config.channel == "stable" {
+        let mut stage0 = String::new();
+        t!(t!(File::open(build.src.join("src/stage0.txt")))
+            .read_to_string(&mut stage0));
+        if stage0.contains("\ndev:") {
+            panic!("bootstrapping from a dev compiler in a stable release, but \
+                    should only be bootstrapping from a released compiler!");
+        }
     }
 }


### PR DESCRIPTION
I forgot to update the bootstrap compiler for the 1.23.0 release so let's make
sure it doesn't happen again!