### PR TITLE
Warn when rustc output conflicts with existing directories

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -549,23 +549,43 @@ impl OutputFilenames {
         format!("{}{}", self.out_filestem, self.extra)
     }
 
+    fn check_output<F, T>(&self, f: F) -> Option<T> where F: Fn(PathBuf) -> Option<T> {
+        match self.single_output_file {
+            Some(ref output_path) => {
+                f(output_path.clone())
+            },
+            None => {
+                for k in self.outputs.keys() {
+                    let output_path = self.path(k.to_owned());
+                    if let Some(result) = f(output_path) {
+                        return Some(result);
+                    }
+                }
+                None
+            }
+        }
+    }
+
     pub fn contains_path(&self, input_path: &PathBuf) -> bool {
         let input_path = input_path.canonicalize().ok();
         if input_path.is_none() {
             return false
         }
-        match self.single_output_file {
-            Some(ref output_path) => output_path.canonicalize().ok() == input_path,
-            None => {
-                for k in self.outputs.keys() {
-                    let output_path = self.path(k.to_owned());
-                    if output_path.canonicalize().ok() == input_path {
-                        return true;
-                    }
-                }
-                false
-            }
-        }
+        let check = |output_path: PathBuf| {
+            if output_path.canonicalize().ok() == input_path {
+                Some(())
+            } else { None }
+        };
+        self.check_output(check).is_some()
+    }
+
+    pub fn conflicts_with_dir(&self) -> Option<PathBuf> {
+        let check = |output_path: PathBuf| {
+            if output_path.is_dir() {
+                Some(output_path)
+            } else { None }
+        };
+        self.check_output(check)
     }
 }
 

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -548,45 +548,6 @@ impl OutputFilenames {
     pub fn filestem(&self) -> String {
         format!("{}{}", self.out_filestem, self.extra)
     }
-
-    fn check_output<F, T>(&self, f: F) -> Option<T> where F: Fn(PathBuf) -> Option<T> {
-        match self.single_output_file {
-            Some(ref output_path) => {
-                f(output_path.clone())
-            },
-            None => {
-                for k in self.outputs.keys() {
-                    let output_path = self.path(k.to_owned());
-                    if let Some(result) = f(output_path) {
-                        return Some(result);
-                    }
-                }
-                None
-            }
-        }
-    }
-
-    pub fn contains_path(&self, input_path: &PathBuf) -> bool {
-        let input_path = input_path.canonicalize().ok();
-        if input_path.is_none() {
-            return false
-        }
-        let check = |output_path: PathBuf| {
-            if output_path.canonicalize().ok() == input_path {
-                Some(())
-            } else { None }
-        };
-        self.check_output(check).is_some()
-    }
-
-    pub fn conflicts_with_dir(&self) -> Option<PathBuf> {
-        let check = |output_path: PathBuf| {
-            if output_path.is_dir() {
-                Some(output_path)
-            } else { None }
-        };
-        self.check_output(check)
-    }
 }
 
 pub fn host_triple() -> &'static str {

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -145,26 +145,23 @@ pub fn compile_input(trans: Box<TransCrate>,
         let output_paths = generated_output_paths(sess, &outputs, &crate_name);
 
         // Ensure the source file isn't accidentally overwritten during compilation.
-        match *input_path {
-            Some(ref input_path) => {
-                if sess.opts.will_create_output_file() {
-                    if output_contains_path(&output_paths, input_path) {
-                        sess.err(&format!(
-                            "the input file \"{}\" would be overwritten by the generated \
-                            executable",
-                            input_path.display()));
-                        return Err(CompileIncomplete::Stopped);
-                    }
-                    if let Some(dir_path) = output_conflicts_with_dir(&output_paths) {
-                        sess.err(&format!(
-                            "the generated executable for the input file \"{}\" conflicts with the \
-                            existing directory \"{}\"",
-                            input_path.display(), dir_path.display()));
-                        return Err(CompileIncomplete::Stopped);
-                    }
+        if let Some(ref input_path) = *input_path {
+            if sess.opts.will_create_output_file() {
+                if output_contains_path(&output_paths, input_path) {
+                    sess.err(&format!(
+                        "the input file \"{}\" would be overwritten by the generated \
+                        executable",
+                        input_path.display()));
+                    return Err(CompileIncomplete::Stopped);
                 }
-            },
-            None => {}
+                if let Some(dir_path) = output_conflicts_with_dir(&output_paths) {
+                    sess.err(&format!(
+                        "the generated executable for the input file \"{}\" conflicts with the \
+                        existing directory \"{}\"",
+                        input_path.display(), dir_path.display()));
+                    return Err(CompileIncomplete::Stopped);
+                }
+            }
         }
 
         write_out_deps(sess, &outputs, &output_paths);

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -125,11 +125,20 @@ pub fn compile_input(trans: Box<TransCrate>,
         // Ensure the source file isn't accidentally overwritten during compilation.
         match *input_path {
             Some(ref input_path) => {
-                if outputs.contains_path(input_path) && sess.opts.will_create_output_file() {
-                    sess.err(&format!(
-                        "the input file \"{}\" would be overwritten by the generated executable",
-                        input_path.display()));
-                    return Err(CompileIncomplete::Stopped);
+                if sess.opts.will_create_output_file() {
+                    if outputs.contains_path(input_path) {
+                        sess.err(&format!(
+                            "the input file \"{}\" would be overwritten by the generated executable",
+                            input_path.display()));
+                        return Err(CompileIncomplete::Stopped);
+                    }
+                    if let Some(dir_path) = outputs.conflicts_with_dir() {
+                        sess.err(&format!(
+                            "the generated executable for the input file \"{}\" conflicts with the \
+                            existing directory \"{}\'",
+                            input_path.display(), dir_path.display()));
+                        return Err(CompileIncomplete::Stopped);
+                    }
                 }
             },
             None => {}

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -128,7 +128,8 @@ pub fn compile_input(trans: Box<TransCrate>,
                 if sess.opts.will_create_output_file() {
                     if outputs.contains_path(input_path) {
                         sess.err(&format!(
-                            "the input file \"{}\" would be overwritten by the generated executable",
+                            "the input file \"{}\" would be overwritten by the generated \
+                            executable",
                             input_path.display()));
                         return Err(CompileIncomplete::Stopped);
                     }

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -136,7 +136,7 @@ pub fn compile_input(trans: Box<TransCrate>,
                     if let Some(dir_path) = outputs.conflicts_with_dir() {
                         sess.err(&format!(
                             "the generated executable for the input file \"{}\" conflicts with the \
-                            existing directory \"{}\'",
+                            existing directory \"{}\"",
                             input_path.display(), dir_path.display()));
                         return Err(CompileIncomplete::Stopped);
                     }

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -121,33 +121,8 @@ pub fn compile_input(trans: Box<TransCrate>,
         };
 
         let outputs = build_output_filenames(input, outdir, output, &krate.attrs, sess);
-
-        // Ensure the source file isn't accidentally overwritten during compilation.
-        match *input_path {
-            Some(ref input_path) => {
-                if sess.opts.will_create_output_file() {
-                    if outputs.contains_path(input_path) {
-                        sess.err(&format!(
-                            "the input file \"{}\" would be overwritten by the generated \
-                            executable",
-                            input_path.display()));
-                        return Err(CompileIncomplete::Stopped);
-                    }
-                    if let Some(dir_path) = outputs.conflicts_with_dir() {
-                        sess.err(&format!(
-                            "the generated executable for the input file \"{}\" conflicts with the \
-                            existing directory \"{}\"",
-                            input_path.display(), dir_path.display()));
-                        return Err(CompileIncomplete::Stopped);
-                    }
-                }
-            },
-            None => {}
-        }
-
         let crate_name =
             ::rustc_trans_utils::link::find_crate_name(Some(sess), &krate.attrs, input);
-
         let ExpansionResult { expanded_crate, defs, analysis, resolutions, mut hir_forest } = {
             phase_2_configure_and_expand(
                 sess,
@@ -166,8 +141,33 @@ pub fn compile_input(trans: Box<TransCrate>,
                 }
             )?
         };
+        
+        let output_paths = generated_output_paths(sess, &outputs, &crate_name);
 
-        write_out_deps(sess, &outputs, &crate_name);
+        // Ensure the source file isn't accidentally overwritten during compilation.
+        match *input_path {
+            Some(ref input_path) => {
+                if sess.opts.will_create_output_file() {
+                    if output_contains_path(&output_paths, input_path) {
+                        sess.err(&format!(
+                            "the input file \"{}\" would be overwritten by the generated \
+                            executable",
+                            input_path.display()));
+                        return Err(CompileIncomplete::Stopped);
+                    }
+                    if let Some(dir_path) = output_conflicts_with_dir(&output_paths) {
+                        sess.err(&format!(
+                            "the generated executable for the input file \"{}\" conflicts with the \
+                            existing directory \"{}\"",
+                            input_path.display(), dir_path.display()));
+                        return Err(CompileIncomplete::Stopped);
+                    }
+                }
+            },
+            None => {}
+        }
+
+        write_out_deps(sess, &outputs, &output_paths);
         if sess.opts.output_types.contains_key(&OutputType::DepInfo) &&
             sess.opts.output_types.keys().count() == 1 {
             return Ok(())
@@ -1111,7 +1111,10 @@ fn escape_dep_filename(filename: &FileName) -> String {
     filename.to_string().replace(" ", "\\ ")
 }
 
-fn write_out_deps(sess: &Session, outputs: &OutputFilenames, crate_name: &str) {
+// Returns all the paths that correspond to generated files.
+fn generated_output_paths(sess: &Session,
+                          outputs: &OutputFilenames,
+                          crate_name: &str) -> Vec<PathBuf> {
     let mut out_filenames = Vec::new();
     for output_type in sess.opts.output_types.keys() {
         let file = outputs.path(*output_type);
@@ -1135,7 +1138,46 @@ fn write_out_deps(sess: &Session, outputs: &OutputFilenames, crate_name: &str) {
             }
         }
     }
+    out_filenames
+}
 
+// Runs `f` on every output file path and returns the first non-None result, or None if `f`
+// returns None for every file path.
+fn check_output<F, T>(output_paths: &Vec<PathBuf>, f: F) -> Option<T>
+        where F: Fn(&PathBuf) -> Option<T> {
+            for output_path in output_paths {
+                if let Some(result) = f(output_path) {
+                    return Some(result);
+                }
+            }
+            None
+}
+
+pub fn output_contains_path(output_paths: &Vec<PathBuf>, input_path: &PathBuf) -> bool {
+    let input_path = input_path.canonicalize().ok();
+    if input_path.is_none() {
+        return false
+    }
+    let check = |output_path: &PathBuf| {
+        if output_path.canonicalize().ok() == input_path {
+            Some(())
+        } else { None }
+    };
+    check_output(output_paths, check).is_some()
+}
+
+pub fn output_conflicts_with_dir(output_paths: &Vec<PathBuf>) -> Option<PathBuf> {
+    let check = |output_path: &PathBuf| {
+        if output_path.is_dir() {
+            Some(output_path.clone())
+        } else { None }
+    };
+    check_output(output_paths, check)
+}
+
+fn write_out_deps(sess: &Session,
+                  outputs: &OutputFilenames,
+                  out_filenames: &Vec<PathBuf>) {
     // Write out dependency rules to the dep-info file if requested
     if !sess.opts.output_types.contains_key(&OutputType::DepInfo) {
         return;
@@ -1154,7 +1196,7 @@ fn write_out_deps(sess: &Session, outputs: &OutputFilenames, crate_name: &str) {
                                          .map(|fmap| escape_dep_filename(&fmap.name))
                                          .collect();
             let mut file = fs::File::create(&deps_filename)?;
-            for path in &out_filenames {
+            for path in out_filenames {
                 write!(file, "{}: {}\n\n", path.display(), files.join(" "))?;
             }
 

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -141,7 +141,7 @@ pub fn compile_input(trans: Box<TransCrate>,
                 }
             )?
         };
-        
+
         let output_paths = generated_output_paths(sess, &outputs, &crate_name);
 
         // Ensure the source file isn't accidentally overwritten during compilation.

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1378,6 +1378,9 @@ pub fn build_output_filenames(input: &Input,
             if *odir != None {
                 sess.warn("ignoring --out-dir flag due to -o flag.");
             }
+            if !sess.opts.cg.extra_filename.is_empty() {
+                sess.warn("ignoring -C extra-filename flag due to -o flag.");
+            }
 
             let cur_dir = Path::new("");
 

--- a/src/test/run-make/output-filename-conflicts-with-directory/Makefile
+++ b/src/test/run-make/output-filename-conflicts-with-directory/Makefile
@@ -3,5 +3,5 @@
 all:
 	cp foo.rs $(TMPDIR)/foo.rs
 	mkdir $(TMPDIR)/foo
-	$(RUSTC) $(TMPDIR)/foo.rs 2>&1 \
+	$(RUSTC) $(TMPDIR)/foo.rs -o $(TMPDIR)/foo 2>&1 \
 		| $(CGREP) -e "the generated executable for the input file \".*foo\.rs\" conflicts with the existing directory \".*foo\""

--- a/src/test/run-make/output-filename-conflicts-with-directory/Makefile
+++ b/src/test/run-make/output-filename-conflicts-with-directory/Makefile
@@ -1,0 +1,7 @@
+-include ../tools.mk
+
+all:
+	cp foo.rs $(TMPDIR)/foo.rs
+	mkdir $(TMPDIR)/foo
+	$(RUSTC) $(TMPDIR)/foo.rs 2>&1 \
+		| $(CGREP) -e "the generated executable for the input file \".*foo\.rs\" conflicts with the existing directory \".*foo\'"

--- a/src/test/run-make/output-filename-conflicts-with-directory/Makefile
+++ b/src/test/run-make/output-filename-conflicts-with-directory/Makefile
@@ -4,4 +4,4 @@ all:
 	cp foo.rs $(TMPDIR)/foo.rs
 	mkdir $(TMPDIR)/foo
 	$(RUSTC) $(TMPDIR)/foo.rs 2>&1 \
-		| $(CGREP) -e "the generated executable for the input file \".*foo\.rs\" conflicts with the existing directory \".*foo\'"
+		| $(CGREP) -e "the generated executable for the input file \".*foo\.rs\" conflicts with the existing directory \".*foo\""

--- a/src/test/run-make/output-filename-conflicts-with-directory/foo.rs
+++ b/src/test/run-make/output-filename-conflicts-with-directory/foo.rs
@@ -1,0 +1,11 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {}

--- a/src/test/run-make/output-filename-overwrites-input/Makefile
+++ b/src/test/run-make/output-filename-overwrites-input/Makefile
@@ -2,8 +2,11 @@
 
 all:
 	cp foo.rs $(TMPDIR)/foo
-	$(RUSTC) $(TMPDIR)/foo 2>&1 \
+	$(RUSTC) $(TMPDIR)/foo -o $(TMPDIR)/foo 2>&1 \
 		| $(CGREP) -e "the input file \".*foo\" would be overwritten by the generated executable"
+	cp bar.rs $(TMPDIR)/bar.rlib
+	$(RUSTC) $(TMPDIR)/bar.rlib -o $(TMPDIR)/bar.rlib 2>&1 \
+		| $(CGREP) -e "the input file \".*bar.rlib\" would be overwritten by the generated executable"
 	$(RUSTC) foo.rs 2>&1 && $(RUSTC) -Z ls $(TMPDIR)/foo 2>&1
 	cp foo.rs $(TMPDIR)/foo.rs
 	$(RUSTC) $(TMPDIR)/foo.rs -o $(TMPDIR)/foo.rs 2>&1 \

--- a/src/test/run-make/output-filename-overwrites-input/bar.rs
+++ b/src/test/run-make/output-filename-overwrites-input/bar.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn main() {}
+#![crate_type = "lib"]

--- a/src/test/run-make/output-filename-overwrites-input/foo.rs
+++ b/src/test/run-make/output-filename-overwrites-input/foo.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //


### PR DESCRIPTION
When the compiled executable would conflict with a directory, display a
rustc error instead of a verbose and potentially-confusing linker
error. This is a usability improvement, and doesn’t actually change
behaviour with regards to compilation success. This addresses the
concern in #35887. Fixes #13098.