### PR TITLE
miri: use AllocId instead of u64.

### DIFF
--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -145,7 +145,7 @@ impl<'tcx> MemoryPointer {
 }
 
 
-#[derive(Copy, Clone, Eq, Hash, Ord, PartialEq, PartialOrd, Debug)]
+#[derive(Copy, Clone, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Debug)]
 pub struct AllocId(pub u64);
 
 impl fmt::Display for AllocId {

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -895,31 +895,29 @@ pub struct InterpretInterner<'tcx> {
     allocs: FxHashSet<&'tcx interpret::Allocation>,
 
     /// Allows obtaining function instance handles via a unique identifier
-    functions: FxHashMap<u64, Instance<'tcx>>,
+    functions: FxHashMap<interpret::AllocId, Instance<'tcx>>,
 
     /// Inverse map of `interpret_functions`.
     /// Used so we don't allocate a new pointer every time we need one
-    function_cache: FxHashMap<Instance<'tcx>, u64>,
+    function_cache: FxHashMap<Instance<'tcx>, interpret::AllocId>,
 
     /// Allows obtaining const allocs via a unique identifier
-    alloc_by_id: FxHashMap<u64, &'tcx interpret::Allocation>,
+    alloc_by_id: FxHashMap<interpret::AllocId, &'tcx interpret::Allocation>,
 
     /// The AllocId to assign to the next new regular allocation.
     /// Always incremented, never gets smaller.
-    next_id: u64,
+    next_id: interpret::AllocId,
 
     /// Allows checking whether a constant already has an allocation
-    ///
-    /// The pointers are to the beginning of an `alloc_by_id` allocation
-    alloc_cache: FxHashMap<interpret::GlobalId<'tcx>, interpret::Pointer>,
+    alloc_cache: FxHashMap<interpret::GlobalId<'tcx>, interpret::AllocId>,
 
     /// A cache for basic byte allocations keyed by their contents. This is used to deduplicate
     /// allocations for string and bytestring literals.
-    literal_alloc_cache: FxHashMap<Vec<u8>, u64>,
+    literal_alloc_cache: FxHashMap<Vec<u8>, interpret::AllocId>,
 }
 
 impl<'tcx> InterpretInterner<'tcx> {
-    pub fn create_fn_alloc(&mut self, instance: Instance<'tcx>) -> u64 {
+    pub fn create_fn_alloc(&mut self, instance: Instance<'tcx>) -> interpret::AllocId {
         if let Some(&alloc_id) = self.function_cache.get(&instance) {
             return alloc_id;
         }
@@ -932,14 +930,14 @@ impl<'tcx> InterpretInterner<'tcx> {
 
     pub fn get_fn(
         &self,
-        id: u64,
+        id: interpret::AllocId,
     ) -> Option<Instance<'tcx>> {
         self.functions.get(&id).cloned()
     }
 
     pub fn get_alloc(
         &self,
-        id: u64,
+        id: interpret::AllocId,
     ) -> Option<&'tcx interpret::Allocation> {
         self.alloc_by_id.get(&id).cloned()
     }
@@ -947,14 +945,14 @@ impl<'tcx> InterpretInterner<'tcx> {
     pub fn get_cached(
         &self,
         global_id: interpret::GlobalId<'tcx>,
-    ) -> Option<interpret::Pointer> {
+    ) -> Option<interpret::AllocId> {
         self.alloc_cache.get(&global_id).cloned()
     }
 
     pub fn cache(
         &mut self,
         global_id: interpret::GlobalId<'tcx>,
-        ptr: interpret::Pointer,
+        ptr: interpret::AllocId,
     ) {
         if let Some(old) = self.alloc_cache.insert(global_id, ptr) {
             bug!("tried to cache {:?}, but was already existing as {:#?}", global_id, old);
@@ -963,7 +961,7 @@ impl<'tcx> InterpretInterner<'tcx> {
 
     pub fn intern_at_reserved(
         &mut self,
-        id: u64,
+        id: interpret::AllocId,
         alloc: &'tcx interpret::Allocation,
     ) {
         if let Some(old) = self.alloc_by_id.insert(id, alloc) {
@@ -975,9 +973,9 @@ impl<'tcx> InterpretInterner<'tcx> {
     /// yet have an allocation backing it.
     pub fn reserve(
         &mut self,
-    ) -> u64 {
+    ) -> interpret::AllocId {
         let next = self.next_id;
-        self.next_id = self.next_id
+        self.next_id.0 = self.next_id.0
             .checked_add(1)
             .expect("You overflowed a u64 by incrementing by 1... \
                      You've just earned yourself a free drink if we ever meet. \
@@ -1069,7 +1067,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     }
 
     /// Allocates a byte or string literal for `mir::interpret`
-    pub fn allocate_cached(self, bytes: &[u8]) -> u64 {
+    pub fn allocate_cached(self, bytes: &[u8]) -> interpret::AllocId {
         // check whether we already allocated this literal or a constant with the same memory
         if let Some(&alloc_id) = self.interpret_interner.borrow().literal_alloc_cache.get(bytes) {
             return alloc_id;

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -950,8 +950,8 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
     }
 
     pub fn read_global_as_value(&self, gid: GlobalId, layout: TyLayout) -> Value {
-        Value::ByRef(self.tcx.interpret_interner.borrow().get_cached(gid).expect("global not cached"),
-                     layout.align)
+        let alloc = self.tcx.interpret_interner.borrow().get_cached(gid).expect("global not cached");
+        Value::ByRef(MemoryPointer::new(alloc, 0).into(), layout.align)
     }
 
     pub fn force_allocation(&mut self, place: Place) -> EvalResult<'tcx, Place> {

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -2,7 +2,7 @@
 //! This separation exists to ensure that no fancy miri features like
 //! interpreting common C functions leak into CTFE.
 
-use rustc::mir::interpret::{EvalResult, PrimVal, MemoryPointer, AccessKind};
+use rustc::mir::interpret::{AllocId, EvalResult, PrimVal, MemoryPointer, AccessKind};
 use super::{EvalContext, Place, ValTy, Memory};
 
 use rustc::mir;
@@ -89,12 +89,12 @@ pub trait Machine<'tcx>: Sized {
 
     fn add_lock<'a>(
         _mem: &mut Memory<'a, 'tcx, Self>,
-        _id: u64,
+        _id: AllocId,
     ) {}
 
     fn free_lock<'a>(
         _mem: &mut Memory<'a, 'tcx, Self>,
-        _id: u64,
+        _id: AllocId,
         _len: u64,
     ) -> EvalResult<'tcx> {
         Ok(())

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -194,8 +194,9 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                     promoted: None,
                 };
                 let layout = self.layout_of(self.place_ty(mir_place))?;
+                let alloc = self.tcx.interpret_interner.borrow().get_cached(gid).expect("uncached global");
                 Place::Ptr {
-                    ptr: self.tcx.interpret_interner.borrow().get_cached(gid).expect("uncached global"),
+                    ptr: MemoryPointer::new(alloc, 0).into(),
                     align: layout.align,
                     extra: PlaceExtra::None,
                 }

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -180,7 +180,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             layout.align,
             None,
         )?;
-        self.tcx.interpret_interner.borrow_mut().cache(cid, ptr.into());
+        self.tcx.interpret_interner.borrow_mut().cache(cid, ptr.alloc_id);
         let internally_mutable = !layout.ty.is_freeze(self.tcx, self.param_env, span);
         let mutability = if mutability == Mutability::Mutable || internally_mutable {
             Mutability::Mutable
@@ -265,7 +265,7 @@ impl<'a, 'b, 'tcx, M: Machine<'tcx>> Visitor<'tcx> for ConstantExtractor<'a, 'b,
                         layout.align,
                         None,
                     )?;
-                    this.ecx.tcx.interpret_interner.borrow_mut().cache(cid, ptr.into());
+                    this.ecx.tcx.interpret_interner.borrow_mut().cache(cid, ptr.alloc_id);
                     trace!("pushing stack frame for {:?}", index);
                     this.ecx.push_stack_frame(
                         this.instance,


### PR DESCRIPTION
This makes @alexreg's miri allocation -> LLVM global translation more straight-forward.

r? @oli-obk 
