### PR TITLE
rustc: Tweak `#[target_feature]` syntax

### DIFF
--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -635,6 +635,10 @@ define_dep_nodes!( <'tcx>
     [] Null,
 
     [] SubstituteNormalizeAndTestPredicates { key: (DefId, &'tcx Substs<'tcx>) },
+
+    [input] TargetFeaturesWhitelist,
+    [] TargetFeaturesEnabled(DefId),
+
 );
 
 trait DepNodeParams<'a, 'gcx: 'tcx + 'a, 'tcx: 'a> : fmt::Debug {

--- a/src/librustc/hir/check_attr.rs
+++ b/src/librustc/hir/check_attr.rs
@@ -14,11 +14,10 @@
 //! conflicts between multiple such attributes attached to the same
 //! item.
 
-use session::Session;
+use ty::TyCtxt;
 
-use syntax::ast;
-use syntax::visit;
-use syntax::visit::Visitor;
+use hir;
+use hir::intravisit::{self, Visitor, NestedVisitorMap};
 
 #[derive(Copy, Clone, PartialEq)]
 enum Target {
@@ -30,24 +29,26 @@ enum Target {
 }
 
 impl Target {
-    fn from_item(item: &ast::Item) -> Target {
+    fn from_item(item: &hir::Item) -> Target {
         match item.node {
-            ast::ItemKind::Fn(..) => Target::Fn,
-            ast::ItemKind::Struct(..) => Target::Struct,
-            ast::ItemKind::Union(..) => Target::Union,
-            ast::ItemKind::Enum(..) => Target::Enum,
+            hir::ItemFn(..) => Target::Fn,
+            hir::ItemStruct(..) => Target::Struct,
+            hir::ItemUnion(..) => Target::Union,
+            hir::ItemEnum(..) => Target::Enum,
             _ => Target::Other,
         }
     }
 }
 
-struct CheckAttrVisitor<'a> {
-    sess: &'a Session,
+struct CheckAttrVisitor<'a, 'tcx: 'a> {
+    tcx: TyCtxt<'a, 'tcx, 'tcx>,
 }
 
-impl<'a> CheckAttrVisitor<'a> {
+impl<'a, 'tcx> CheckAttrVisitor<'a, 'tcx> {
     /// Check any attribute.
-    fn check_attributes(&self, item: &ast::Item, target: Target) {
+    fn check_attributes(&self, item: &hir::Item, target: Target) {
+        self.tcx.target_features_enabled(self.tcx.hir.local_def_id(item.id));
+
         for attr in &item.attrs {
             if let Some(name) = attr.name() {
                 if name == "inline" {
@@ -55,20 +56,24 @@ impl<'a> CheckAttrVisitor<'a> {
                 }
             }
         }
+
         self.check_repr(item, target);
     }
 
     /// Check if an `#[inline]` is applied to a function.
-    fn check_inline(&self, attr: &ast::Attribute, item: &ast::Item, target: Target) {
+    fn check_inline(&self, attr: &hir::Attribute, item: &hir::Item, target: Target) {
         if target != Target::Fn {
-            struct_span_err!(self.sess, attr.span, E0518, "attribute should be applied to function")
+            struct_span_err!(self.tcx.sess,
+                             attr.span,
+                             E0518,
+                             "attribute should be applied to function")
                 .span_label(item.span, "not a function")
                 .emit();
         }
     }
 
     /// Check if the `#[repr]` attributes on `item` are valid.
-    fn check_repr(&self, item: &ast::Item, target: Target) {
+    fn check_repr(&self, item: &hir::Item, target: Target) {
         // Extract the names of all repr hints, e.g., [foo, bar, align] for:
         // ```
         // #[repr(foo)]
@@ -144,7 +149,7 @@ impl<'a> CheckAttrVisitor<'a> {
                 }
                 _ => continue,
             };
-            struct_span_err!(self.sess, hint.span, E0517,
+            struct_span_err!(self.tcx.sess, hint.span, E0517,
                              "attribute should be applied to {}", allowed_targets)
                 .span_label(item.span, format!("not {} {}", article, allowed_targets))
                 .emit();
@@ -154,32 +159,37 @@ impl<'a> CheckAttrVisitor<'a> {
         if (int_reprs > 1)
            || (is_simd && is_c)
            || (int_reprs == 1 && is_c && is_c_like_enum(item)) {
-            // Just point at all repr hints. This is not ideal, but tracking precisely which ones
-            // are at fault is a huge hassle.
+            // Just point at all repr hints. This is not ideal, but tracking
+            // precisely which ones are at fault is a huge hassle.
             let spans: Vec<_> = hints.iter().map(|hint| hint.span).collect();
-            span_warn!(self.sess, spans, E0566,
+            span_warn!(self.tcx.sess, spans, E0566,
                        "conflicting representation hints");
         }
     }
 }
 
-impl<'a> Visitor<'a> for CheckAttrVisitor<'a> {
-    fn visit_item(&mut self, item: &'a ast::Item) {
+impl<'a, 'tcx> Visitor<'tcx> for CheckAttrVisitor<'a, 'tcx> {
+    fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
+        NestedVisitorMap::None
+    }
+
+    fn visit_item(&mut self, item: &'tcx hir::Item) {
         let target = Target::from_item(item);
         self.check_attributes(item, target);
-        visit::walk_item(self, item);
+        intravisit::walk_item(self, item);
     }
 }
 
-pub fn check_crate(sess: &Session, krate: &ast::Crate) {
-    visit::walk_crate(&mut CheckAttrVisitor { sess: sess }, krate);
+pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
+    let mut checker = CheckAttrVisitor { tcx };
+    tcx.hir.krate().visit_all_item_likes(&mut checker.as_deep_visitor());
 }
 
-fn is_c_like_enum(item: &ast::Item) -> bool {
-    if let ast::ItemKind::Enum(ref def, _) = item.node {
+fn is_c_like_enum(item: &hir::Item) -> bool {
+    if let hir::ItemEnum(ref def, _) = item.node {
         for variant in &def.variants {
             match variant.node.data {
-                ast::VariantData::Unit(_) => { /* continue */ }
+                hir::VariantData::Unit(_) => { /* continue */ }
                 _ => { return false; }
             }
         }

--- a/src/librustc/ty/maps/config.rs
+++ b/src/librustc/ty/maps/config.rs
@@ -631,6 +631,12 @@ impl<'tcx> QueryDescription<'tcx> for queries::substitute_normalize_and_test_pre
     }
 }
 
+impl<'tcx> QueryDescription<'tcx> for queries::target_features_whitelist<'tcx> {
+    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+        format!("looking up the whitelist of target features")
+    }
+}
+
 macro_rules! impl_disk_cacheable_query(
     ($query_name:ident, |$key:tt| $cond:expr) => {
         impl<'tcx> QueryDescription<'tcx> for queries::$query_name<'tcx> {

--- a/src/librustc/ty/maps/mod.rs
+++ b/src/librustc/ty/maps/mod.rs
@@ -363,6 +363,11 @@ define_maps! { <'tcx>
 
     [] fn substitute_normalize_and_test_predicates:
         substitute_normalize_and_test_predicates_node((DefId, &'tcx Substs<'tcx>)) -> bool,
+
+    [] fn target_features_whitelist:
+        target_features_whitelist_node(CrateNum) -> Rc<FxHashSet<String>>,
+    [] fn target_features_enabled: TargetFeaturesEnabled(DefId) -> Rc<Vec<String>>,
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -507,4 +512,8 @@ fn normalize_ty_node<'tcx>(_: Ty<'tcx>) -> DepConstructor<'tcx> {
 fn substitute_normalize_and_test_predicates_node<'tcx>(key: (DefId, &'tcx Substs<'tcx>))
                                             -> DepConstructor<'tcx> {
     DepConstructor::SubstituteNormalizeAndTestPredicates { key }
+}
+
+fn target_features_whitelist_node<'tcx>(_: CrateNum) -> DepConstructor<'tcx> {
+    DepConstructor::TargetFeaturesWhitelist
 }

--- a/src/librustc/ty/maps/plumbing.rs
+++ b/src/librustc/ty/maps/plumbing.rs
@@ -918,6 +918,9 @@ pub fn force_from_dep_node<'a, 'gcx, 'lcx>(tcx: TyCtxt<'a, 'gcx, 'lcx>,
         }
         DepKind::IsTranslatedFunction => { force!(is_translated_function, def_id!()); }
         DepKind::OutputFilenames => { force!(output_filenames, LOCAL_CRATE); }
+
+        DepKind::TargetFeaturesWhitelist => { force!(target_features_whitelist, LOCAL_CRATE); }
+        DepKind::TargetFeaturesEnabled => { force!(target_features_enabled, def_id!()); }
     }
 
     true

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -210,10 +210,6 @@ pub fn compile_input(sess: &Session,
                                     Ok(()));
         }
 
-        time(sess.time_passes(), "attribute checking", || {
-            hir::check_attr::check_crate(sess, &expanded_crate);
-        });
-
         let opt_crate = if control.keep_ast {
             Some(&expanded_crate)
         } else {
@@ -1037,6 +1033,10 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(control: &CompileController,
         // Do some initialization of the DepGraph that can only be done with the
         // tcx available.
         rustc_incremental::dep_graph_tcx_init(tcx);
+
+        time(sess.time_passes(), "attribute checking", || {
+            hir::check_attr::check_crate(tcx)
+        });
 
         time(time_passes,
              "stability checking",

--- a/src/librustc_trans/callee.rs
+++ b/src/librustc_trans/callee.rs
@@ -99,8 +99,7 @@ pub fn get_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         if instance.def.is_inline(tcx) {
             attributes::inline(llfn, attributes::InlineAttr::Hint);
         }
-        let attrs = instance.def.attrs(ccx.tcx());
-        attributes::from_fn_attrs(ccx, &attrs, llfn);
+        attributes::from_fn_attrs(ccx, llfn, instance.def.def_id());
 
         let instance_def_id = instance.def_id();
 

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -167,6 +167,7 @@ impl rustc_trans_utils::trans_crate::TransCrate for LlvmTransCrate {
         back::symbol_names::provide(providers);
         back::symbol_export::provide(providers);
         base::provide(providers);
+        attributes::provide(providers);
     }
 
     fn provide_extern(providers: &mut ty::maps::Providers) {

--- a/src/librustc_trans/trans_item.rs
+++ b/src/librustc_trans/trans_item.rs
@@ -199,7 +199,7 @@ fn predefine_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     if instance.def.is_inline(ccx.tcx()) {
         attributes::inline(lldecl, attributes::InlineAttr::Hint);
     }
-    attributes::from_fn_attrs(ccx, &attrs, lldecl);
+    attributes::from_fn_attrs(ccx, lldecl, instance.def.def_id());
 
     ccx.instances().borrow_mut().insert(instance, lldecl);
 }

--- a/src/test/ui/feature-gate/issue-43106-gating-of-inline.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-inline.stderr
@@ -1,3 +1,5 @@
+error[E0601]: main function not found
+
 error[E0518]: attribute should be applied to function
   --> $DIR/issue-43106-gating-of-inline.rs:21:1
    |
@@ -36,8 +38,6 @@ error[E0518]: attribute should be applied to function
    |
 35 |     #[inline = "2100"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^ ---------- not a function
-
-error[E0601]: main function not found
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/target-feature-wrong.rs
+++ b/src/test/ui/target-feature-wrong.rs
@@ -10,6 +10,8 @@
 
 // ignore-arm
 // ignore-aarch64
+// ignore-wasm
+// ignore-emscripten
 
 #![feature(target_feature)]
 

--- a/src/test/ui/target-feature-wrong.rs
+++ b/src/test/ui/target-feature-wrong.rs
@@ -1,0 +1,35 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-arm
+// ignore-aarch64
+
+#![feature(target_feature)]
+
+#[target_feature = "+sse2"]
+//~^ WARN: deprecated
+#[target_feature(enable = "foo")]
+//~^ ERROR: not valid for this target
+#[target_feature(bar)]
+//~^ ERROR: only accepts sub-keys
+#[target_feature(disable = "baz")]
+//~^ ERROR: only accepts sub-keys
+unsafe fn foo() {}
+
+#[target_feature(enable = "sse2")]
+//~^ ERROR: can only be applied to `unsafe` function
+fn bar() {}
+
+fn main() {
+    unsafe {
+        foo();
+        bar();
+    }
+}

--- a/src/test/ui/target-feature-wrong.stderr
+++ b/src/test/ui/target-feature-wrong.stderr
@@ -1,0 +1,32 @@
+warning: #[target_feature = ".."] is deprecated and will eventually be removed, use #[target_feature(enable = "..")] instead
+  --> $DIR/target-feature-wrong.rs:16:1
+   |
+16 | #[target_feature = "+sse2"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: the feature named `foo` is not valid for this target
+  --> $DIR/target-feature-wrong.rs:18:18
+   |
+18 | #[target_feature(enable = "foo")]
+   |                  ^^^^^^^^^^^^^^
+
+error: #[target_feature(..)] only accepts sub-keys of `enable` currently
+  --> $DIR/target-feature-wrong.rs:20:18
+   |
+20 | #[target_feature(bar)]
+   |                  ^^^
+
+error: #[target_feature(..)] only accepts sub-keys of `enable` currently
+  --> $DIR/target-feature-wrong.rs:22:18
+   |
+22 | #[target_feature(disable = "baz")]
+   |                  ^^^^^^^^^^^^^^^
+
+error: #[target_feature(..)] can only be applied to `unsafe` function
+  --> $DIR/target-feature-wrong.rs:26:1
+   |
+26 | #[target_feature(enable = "sse2")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/target-feature-wrong.stderr
+++ b/src/test/ui/target-feature-wrong.stderr
@@ -1,31 +1,31 @@
 warning: #[target_feature = ".."] is deprecated and will eventually be removed, use #[target_feature(enable = "..")] instead
-  --> $DIR/target-feature-wrong.rs:16:1
+  --> $DIR/target-feature-wrong.rs:18:1
    |
-16 | #[target_feature = "+sse2"]
+18 | #[target_feature = "+sse2"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: the feature named `foo` is not valid for this target
-  --> $DIR/target-feature-wrong.rs:18:18
-   |
-18 | #[target_feature(enable = "foo")]
-   |                  ^^^^^^^^^^^^^^
-
-error: #[target_feature(..)] only accepts sub-keys of `enable` currently
   --> $DIR/target-feature-wrong.rs:20:18
    |
-20 | #[target_feature(bar)]
-   |                  ^^^
+20 | #[target_feature(enable = "foo")]
+   |                  ^^^^^^^^^^^^^^
 
 error: #[target_feature(..)] only accepts sub-keys of `enable` currently
   --> $DIR/target-feature-wrong.rs:22:18
    |
-22 | #[target_feature(disable = "baz")]
+22 | #[target_feature(bar)]
+   |                  ^^^
+
+error: #[target_feature(..)] only accepts sub-keys of `enable` currently
+  --> $DIR/target-feature-wrong.rs:24:18
+   |
+24 | #[target_feature(disable = "baz")]
    |                  ^^^^^^^^^^^^^^^
 
 error: #[target_feature(..)] can only be applied to `unsafe` function
-  --> $DIR/target-feature-wrong.rs:26:1
+  --> $DIR/target-feature-wrong.rs:28:1
    |
-26 | #[target_feature(enable = "sse2")]
+28 | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors


### PR DESCRIPTION
This is an implementation of the `#[target_feature]` syntax-related changes of
[RFC 2045][rfc]. Notably two changes have been implemented:

* The new syntax is `#[target_feature(enable = "..")]` instead of
  `#[target_feature = "+.."]`. The `enable` key is necessary instead of the `+`
  to indicate that a feature is being enabled, and a sub-list is used for
  possible expansion in the future. Additionally within this syntax the feature
  names being enabled are now whitelisted against a known set of target feature
  names that we know about.

* The `#[target_feature]` attribute can only be applied to unsafe functions. It
  was decided in the RFC that invoking an instruction possibly not defined for
  the current processor is undefined behavior, so to enable this feature for now
  it requires an `unsafe` intervention.

[rfc]: https://github.com/rust-lang/rfcs/blob/master/text/2045-target-feature.md