### PR TITLE
Crater Run: Make tyvar_behind_raw_pointer an error

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -242,7 +242,7 @@ declare_lint! {
 
 declare_lint! {
     pub TYVAR_BEHIND_RAW_POINTER,
-    Deny,
+    Forbid,
     "raw pointer to an inference variable"
 }
 

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -242,7 +242,7 @@ declare_lint! {
 
 declare_lint! {
     pub TYVAR_BEHIND_RAW_POINTER,
-    Warn,
+    Deny,
     "raw pointer to an inference variable"
 }
 


### PR DESCRIPTION
In preparation for a crater run to determine its impact