### PR TITLE
Add help message for incorrect pattern syntax

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3437,11 +3437,9 @@ impl<'a> Parser<'a> {
                                    "unexpected token `||` after pattern",
                                    "did you mean to use `|` to specify multiple patterns?");
                 self.bump();
-            }
-            else if self.check(&token::BinOp(token::Or)) {
+            } else if self.check(&token::BinOp(token::Or)) {
                 self.bump();
-            }
-            else {
+            } else {
                 return Ok(pats);
             }
         };

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3436,8 +3436,8 @@ impl<'a> Parser<'a> {
                 // Accidental use of || instead of | inbetween patterns
                 if self.token == token::OrOr {
                     return Err(self.span_fatal_help(
-                           self.span, "Unexpected token `||` after pattern",
-                           "Did you mean to use `|` to specify multiple patterns instead?"));
+                           self.span, "unexpected token `||` after pattern",
+                           "did you mean to use `|` to specify multiple patterns instead?"));
                 }
 
                 return Ok(pats);

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3431,15 +3431,17 @@ impl<'a> Parser<'a> {
         let mut pats = Vec::new();
         loop {
             pats.push(self.parse_pat()?);
-            if self.check(&token::BinOp(token::Or)) { self.bump();}
-            else {
-                // Accidental use of || instead of | inbetween patterns
-                if self.token == token::OrOr {
-                    return Err(self.span_fatal_help(
-                           self.span, "unexpected token `||` after pattern",
-                           "did you mean to use `|` to specify multiple patterns instead?"));
-                }
 
+            if self.token == token::OrOr {
+                self.span_err_help(self.span,
+                                   "unexpected token `||` after pattern",
+                                   "did you mean to use `|` to specify multiple patterns?");
+                self.bump();
+            }
+            else if self.check(&token::BinOp(token::Or)) {
+                self.bump();
+            }
+            else {
                 return Ok(pats);
             }
         };

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3433,8 +3433,11 @@ impl<'a> Parser<'a> {
             pats.push(self.parse_pat()?);
 
             if self.token == token::OrOr {
-                let mut err = self.struct_span_err(self.span, "unexpected token `||` after pattern");
-                err.span_suggestion(self.span, "use a single `|` to specify multiple patterns", "|".to_owned());
+                let mut err = self.struct_span_err(self.span,
+                                                   "unexpected token `||` after pattern");
+                err.span_suggestion(self.span,
+                                    "use a single `|` to specify multiple patterns",
+                                    "|".to_owned());
                 err.emit();
                 self.bump();
             } else if self.check(&token::BinOp(token::Or)) {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3433,9 +3433,9 @@ impl<'a> Parser<'a> {
             pats.push(self.parse_pat()?);
 
             if self.token == token::OrOr {
-                self.span_err_help(self.span,
-                                   "unexpected token `||` after pattern",
-                                   "did you mean to use `|` to specify multiple patterns?");
+                let mut err = self.struct_span_err(self.span, "unexpected token `||` after pattern");
+                err.span_suggestion(self.span, "use a single `|` to specify multiple patterns", "|".to_owned());
+                err.emit();
                 self.bump();
             } else if self.check(&token::BinOp(token::Or)) {
                 self.bump();

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3432,7 +3432,16 @@ impl<'a> Parser<'a> {
         loop {
             pats.push(self.parse_pat()?);
             if self.check(&token::BinOp(token::Or)) { self.bump();}
-            else { return Ok(pats); }
+            else {
+                // Accidental use of || instead of | inbetween patterns
+                if self.token == token::OrOr {
+                    return Err(self.span_fatal_help(
+                           self.span, "Unexpected token `||` after pattern",
+                           "Did you mean to use `|` to specify multiple patterns instead?"));
+                }
+
+                return Ok(pats);
+            }
         };
     }
 

--- a/src/test/ui/did_you_mean/multiple-pattern-typo.rs
+++ b/src/test/ui/did_you_mean/multiple-pattern-typo.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let x = 3;
+    match x {
+        1 | 2 || 3 => (), //~ ERROR unexpected token `||` after pattern
+        _ => (),
+    }
+}

--- a/src/test/ui/did_you_mean/multiple-pattern-typo.stderr
+++ b/src/test/ui/did_you_mean/multiple-pattern-typo.stderr
@@ -2,9 +2,7 @@ error: unexpected token `||` after pattern
   --> $DIR/multiple-pattern-typo.rs:14:15
    |
 14 |         1 | 2 || 3 => (), //~ ERROR unexpected token `||` after pattern
-   |               ^^
-   |
-   = help: did you mean to use `|` to specify multiple patterns?
+   |               ^^ help: use a single `|` to specify multiple patterns: `|`
 
 error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/multiple-pattern-typo.stderr
+++ b/src/test/ui/did_you_mean/multiple-pattern-typo.stderr
@@ -1,0 +1,10 @@
+error: unexpected token `||` after pattern
+  --> $DIR/multiple-pattern-typo.rs:14:15
+   |
+14 |         1 | 2 || 3 => (), //~ ERROR unexpected token `||` after pattern
+   |               ^^
+   |
+   = help: did you mean to use `|` to specify multiple patterns?
+
+error: aborting due to previous error
+


### PR DESCRIPTION
When I was getting started with rust I often made the mistake of using `||` instead of `|` to match multiple patterns and spent a long time staring at my code wondering what was wrong. 


for example: 

```
fn main() {
    let x = 1;

    match x {
        1 || 2 => println!("1 or 2"),
        _ => println!("Something else"),
    }
}

```


If you compile this with current rustc you will see

```
error: expected one of `...`, `..=`, `..`, `=>`, `if`, or `|`, found `||`
 --> test.rs:5:11
  |
5 |         1 || 2 => println!("1 or 2"),
  |          -^^ unexpected token
  |          |
  |          expected one of `...`, `..=`, `..`, `=>`, `if`, or `|` here

error: aborting due to previous error
```

With my proposed change it will show:
```
error: unexpected token `||` after pattern
 --> test.rs:5:11
  |
5 |         1 || 2 => println!("1 or 2"),
  |           ^^
  |
  = help: did you mean to use `|` to specify multiple patterns instead?

error: aborting due to previous error
```



  