### PR TITLE
fix miri argument unpacking issue

### DIFF
--- a/src/librustc_mir/interpret/terminator/mod.rs
+++ b/src/librustc_mir/interpret/terminator/mod.rs
@@ -351,12 +351,16 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                                     other => {
                                         trace!("{:#?}, {:#?}", other, layout);
                                         let mut layout = layout;
+                                        let mut skip_arg_locals = true;
                                         'outer: loop {
                                             for i in 0..layout.fields.count() {
                                                 let field = layout.field(&self, i)?;
                                                 if layout.fields.offset(i).bytes() == 0 && layout.size == field.size {
                                                     layout = field;
+                                                    skip_arg_locals = false;
                                                     continue 'outer;
+                                                } else if skip_arg_locals {
+                                                    arg_locals.next().unwrap();
                                                 }
                                             }
                                             break;


### PR DESCRIPTION
This should fix https://github.com/solson/miri/pull/360. I haven't actually tested it.

I believe this fix is correct because a similar fix works for Seer: https://github.com/dwrensha/seer/commit/a071e1c61653792ebdc41e8804da4f1695b13ffa

cc @oli-obk 