### PR TITLE
`struct` pattern parsing and diagnostic tweaks

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -609,14 +609,21 @@ impl<'a> Parser<'a> {
         Parser::token_to_string(&self.token)
     }
 
+    pub fn token_descr(&self) -> Option<&'static str> {
+        Some(match &self.token {
+            t if t.is_special_ident() => "reserved identifier",
+            t if t.is_used_keyword() => "keyword",
+            t if t.is_unused_keyword() => "reserved keyword",
+            _ => return None,
+        })
+    }
+
     pub fn this_token_descr(&self) -> String {
-        let prefix = match &self.token {
-            t if t.is_special_ident() => "reserved identifier ",
-            t if t.is_used_keyword() => "keyword ",
-            t if t.is_unused_keyword() => "reserved keyword ",
-            _ => "",
-        };
-        format!("{}`{}`", prefix, self.this_token_to_string())
+        if let Some(prefix) = self.token_descr() {
+            format!("{} `{}`", prefix, self.this_token_to_string())
+        } else {
+            format!("`{}`", self.this_token_to_string())
+        }
     }
 
     pub fn unexpected_last<T>(&self, t: &token::Token) -> PResult<'a, T> {
@@ -752,11 +759,27 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_ident(&mut self) -> PResult<'a, ast::Ident> {
+        self.parse_ident_common(true)
+    }
+
+    fn parse_ident_common(&mut self, recover: bool) -> PResult<'a, ast::Ident> {
         match self.token {
             token::Ident(i) => {
                 if self.token.is_reserved_ident() {
-                    self.span_err(self.span, &format!("expected identifier, found {}",
-                                                      self.this_token_descr()));
+                    let mut err = self.struct_span_err(self.span,
+                                                       &format!("expected identifier, found {}",
+                                                                self.this_token_descr()));
+                    if let Some(token_descr) = self.token_descr() {
+                        err.span_label(self.span, format!("expected identifier, found {}",
+                                                          token_descr));
+                    } else {
+                        err.span_label(self.span, "expected identifier");
+                    }
+                    if recover {
+                        err.emit();
+                    } else {
+                        return Err(err);
+                    }
                 }
                 self.bump();
                 Ok(i)
@@ -767,6 +790,12 @@ impl<'a> Parser<'a> {
                     } else {
                         let mut err = self.fatal(&format!("expected identifier, found `{}`",
                                                           self.this_token_to_string()));
+                        if let Some(token_descr) = self.token_descr() {
+                            err.span_label(self.span, format!("expected identifier, found {}",
+                                                              token_descr));
+                        } else {
+                            err.span_label(self.span, "expected identifier");
+                        }
                         if self.token == token::Underscore {
                             err.note("`_` is a wildcard pattern, not an identifier");
                         }
@@ -2056,7 +2085,7 @@ impl<'a> Parser<'a> {
             self.bump();
             Ok(Ident::with_empty_ctxt(name))
         } else {
-            self.parse_ident()
+            self.parse_ident_common(false)
         }
     }
 
@@ -2073,7 +2102,7 @@ impl<'a> Parser<'a> {
             hi = self.prev_span;
             (fieldname, self.parse_expr()?, false)
         } else {
-            let fieldname = self.parse_ident()?;
+            let fieldname = self.parse_ident_common(false)?;
             hi = self.prev_span;
 
             // Mimic `x: x` for the `x` field shorthand.
@@ -2424,6 +2453,7 @@ impl<'a> Parser<'a> {
 
     fn parse_struct_expr(&mut self, lo: Span, pth: ast::Path, mut attrs: ThinVec<Attribute>)
                          -> PResult<'a, P<Expr>> {
+        let struct_sp = lo.to(self.prev_span);
         self.bump();
         let mut fields = Vec::new();
         let mut base = None;
@@ -2458,6 +2488,7 @@ impl<'a> Parser<'a> {
             match self.parse_field() {
                 Ok(f) => fields.push(f),
                 Err(mut e) => {
+                    e.span_label(struct_sp, "while parsing this struct");
                     e.emit();
                     self.recover_stmt();
                     break;

--- a/src/test/compile-fail/issue-28433.rs
+++ b/src/test/compile-fail/issue-28433.rs
@@ -13,7 +13,7 @@
 enum bird {
     pub duck,
     //~^ ERROR: expected identifier, found keyword `pub`
-    //~^^ ERROR: expected
+    //~| ERROR: expected
     goose
 }
 

--- a/src/test/parse-fail/issue-32501.rs
+++ b/src/test/parse-fail/issue-32501.rs
@@ -18,4 +18,5 @@ fn main() {
     let mut _b = 0;
     let mut _ = 0; //~ ERROR expected identifier, found `_`
     //~^ NOTE `_` is a wildcard pattern, not an identifier
+    //~| NOTE expected identifier
 }

--- a/src/test/ui/issue-44406.stderr
+++ b/src/test/ui/issue-44406.stderr
@@ -2,7 +2,7 @@ error: expected identifier, found keyword `true`
   --> $DIR/issue-44406.rs:18:10
    |
 18 |     foo!(true); //~ ERROR expected type, found keyword
-   |          ^^^^
+   |          ^^^^ expected identifier, found keyword
 
 error: expected type, found keyword `true`
   --> $DIR/issue-44406.rs:18:10

--- a/src/test/ui/pub/pub-restricted-error.stderr
+++ b/src/test/ui/pub/pub-restricted-error.stderr
@@ -2,7 +2,7 @@ error: expected identifier, found `(`
   --> $DIR/pub-restricted-error.rs:16:16
    |
 16 |     pub(crate) () foo: usize, //~ ERROR expected identifier
-   |                ^
+   |                ^ expected identifier
 
 error: aborting due to previous error
 

--- a/src/test/ui/pub/pub-restricted-non-path.stderr
+++ b/src/test/ui/pub/pub-restricted-non-path.stderr
@@ -2,7 +2,7 @@ error: expected identifier, found `.`
   --> $DIR/pub-restricted-non-path.rs:13:6
    |
 13 | pub (.) fn afn() {} //~ ERROR expected identifier
-   |      ^
+   |      ^ expected identifier
 
 error: aborting due to previous error
 

--- a/src/test/ui/token/issue-15980.rs
+++ b/src/test/ui/token/issue-15980.rs
@@ -1,0 +1,29 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::io;
+
+fn main(){
+    let x: io::IoResult<()> = Ok(());
+    //~^ ERROR cannot find type `IoResult` in module `io`
+    //~| NOTE did you mean `Result`?
+    match x {
+        Err(ref e) if e.kind == io::EndOfFile {
+            //~^ NOTE while parsing this struct
+            return
+            //~^ ERROR expected identifier, found keyword `return`
+            //~| NOTE expected identifier, found keyword
+        }
+        //~^ NOTE expected one of `.`, `=>`, `?`, or an operator here
+        _ => {}
+        //~^ ERROR expected one of `.`, `=>`, `?`, or an operator, found `_`
+        //~| NOTE unexpected token
+    }
+}

--- a/src/test/ui/token/issue-15980.stderr
+++ b/src/test/ui/token/issue-15980.stderr
@@ -1,0 +1,26 @@
+error: expected identifier, found keyword `return`
+  --> $DIR/issue-15980.rs:20:13
+   |
+18 |         Err(ref e) if e.kind == io::EndOfFile {
+   |                                 ------------- while parsing this struct
+19 |             //~^ NOTE while parsing this struct
+20 |             return
+   |             ^^^^^^ expected identifier, found keyword
+
+error: expected one of `.`, `=>`, `?`, or an operator, found `_`
+  --> $DIR/issue-15980.rs:25:9
+   |
+23 |         }
+   |          - expected one of `.`, `=>`, `?`, or an operator here
+24 |         //~^ NOTE expected one of `.`, `=>`, `?`, or an operator here
+25 |         _ => {}
+   |         ^ unexpected token
+
+error[E0412]: cannot find type `IoResult` in module `io`
+  --> $DIR/issue-15980.rs:14:16
+   |
+14 |     let x: io::IoResult<()> = Ok(());
+   |                ^^^^^^^^ did you mean `Result`?
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
 - Recover from struct parse error on match and point out missing match
   body.
 - Point at struct when finding non-identifier while parsing its fields.
 - Add label to "expected identifier, found {}" error.

Fix #15980.