### PR TITLE
[incremental] Specialize encoding and decoding of Fingerprints 

### DIFF
--- a/src/librustc/ich/fingerprint.rs
+++ b/src/librustc/ich/fingerprint.rs
@@ -8,9 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::mem;
 use rustc_data_structures::stable_hasher;
+use serialize;
+use serialize::opaque::{EncodeResult, Encoder, Decoder};
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Clone, Copy, RustcEncodable, RustcDecodable)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Clone, Copy)]
 pub struct Fingerprint(u64, u64);
 
 impl Fingerprint {
@@ -46,6 +49,21 @@ impl Fingerprint {
         format!("{:x}{:x}", self.0, self.1)
     }
 
+    pub fn encode_opaque(&self, encoder: &mut Encoder) -> EncodeResult {
+        let bytes: [u8; 16] = unsafe { mem::transmute([self.0.to_le(), self.1.to_le()]) };
+
+        encoder.emit_raw_bytes(&bytes)
+    }
+
+    pub fn decode_opaque<'a>(decoder: &mut Decoder<'a>) -> Result<Fingerprint, String> {
+        let mut bytes = [0; 16];
+
+        decoder.read_raw_bytes(&mut bytes)?;
+
+        let [l, r]: [u64; 2] = unsafe { mem::transmute(bytes) };
+
+        Ok(Fingerprint(u64::from_le(l), u64::from_le(r)))
+    }
 }
 
 impl ::std::fmt::Display for Fingerprint {
@@ -67,5 +85,21 @@ impl<CTX> stable_hasher::HashStable<CTX> for Fingerprint {
                                           _: &mut CTX,
                                           hasher: &mut stable_hasher::StableHasher<W>) {
         ::std::hash::Hash::hash(self, hasher);
+    }
+}
+
+impl serialize::UseSpecializedEncodable for Fingerprint { }
+
+impl serialize::UseSpecializedDecodable for Fingerprint { }
+
+impl<'a> serialize::SpecializedEncoder<Fingerprint> for serialize::opaque::Encoder<'a> {
+    fn specialized_encode(&mut self, f: &Fingerprint) -> Result<(), Self::Error> {
+        f.encode_opaque(self)
+    }
+}
+
+impl<'a> serialize::SpecializedDecoder<Fingerprint> for serialize::opaque::Decoder<'a> {
+    fn specialized_decode(&mut self) -> Result<Fingerprint, Self::Error> {
+        Fingerprint::decode_opaque(self)
     }
 }

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -336,6 +336,12 @@ impl<'a, 'tcx> SpecializedDecoder<Span> for DecodeContext<'a, 'tcx> {
     }
 }
 
+impl<'a, 'tcx> SpecializedDecoder<Fingerprint> for DecodeContext<'a, 'tcx> {
+    fn specialized_decode(&mut self) -> Result<Fingerprint, Self::Error> {
+        Fingerprint::decode_opaque(&mut self.opaque)
+    }
+}
+
 impl<'a, 'tcx, T: Decodable> SpecializedDecoder<mir::ClearCrossCrate<T>>
 for DecodeContext<'a, 'tcx> {
     #[inline]

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -18,6 +18,7 @@ use rustc::middle::cstore::{LinkMeta, LinkagePreference, NativeLibrary,
 use rustc::hir::def::CtorKind;
 use rustc::hir::def_id::{CrateNum, CRATE_DEF_INDEX, DefIndex, DefId, LOCAL_CRATE};
 use rustc::hir::map::definitions::DefPathTable;
+use rustc::ich::Fingerprint;
 use rustc::middle::dependency_format::Linkage;
 use rustc::middle::lang_items;
 use rustc::mir;
@@ -151,6 +152,12 @@ impl<'a, 'tcx> SpecializedEncoder<ty::GenericPredicates<'tcx>> for EncodeContext
                           predicates: &ty::GenericPredicates<'tcx>)
                           -> Result<(), Self::Error> {
         ty_codec::encode_predicates(self, predicates, |ecx| &mut ecx.predicate_shorthands)
+    }
+}
+
+impl<'a, 'tcx> SpecializedEncoder<Fingerprint> for EncodeContext<'a, 'tcx> {
+    fn specialized_encode(&mut self, f: &Fingerprint) -> Result<(), Self::Error> {
+        f.encode_opaque(&mut self.opaque)
     }
 }
 

--- a/src/libserialize/opaque.rs
+++ b/src/libserialize/opaque.rs
@@ -27,6 +27,10 @@ impl<'a> Encoder<'a> {
     pub fn new(cursor: &'a mut io::Cursor<Vec<u8>>) -> Encoder<'a> {
         Encoder { cursor: cursor }
     }
+
+    pub fn emit_raw_bytes(&mut self, s: &[u8]) -> EncodeResult {
+        self.cursor.write_all(s)
+    }
 }
 
 
@@ -168,6 +172,16 @@ impl<'a> Decoder<'a> {
 
     pub fn advance(&mut self, bytes: usize) {
         self.position += bytes;
+    }
+
+    pub fn read_raw_bytes(&mut self, s: &mut [u8]) -> Result<(), String> {
+        let len = s.len();
+
+        self.position += len;
+
+        s.copy_from_slice(&self.data[0..len]);
+
+        Ok(())
     }
 }
 

--- a/src/libserialize/opaque.rs
+++ b/src/libserialize/opaque.rs
@@ -175,11 +175,12 @@ impl<'a> Decoder<'a> {
     }
 
     pub fn read_raw_bytes(&mut self, s: &mut [u8]) -> Result<(), String> {
-        let len = s.len();
+        let start = self.position;
+        let end = start + s.len();
 
-        self.position += len;
+        s.copy_from_slice(&self.data[start..end]);
 
-        s.copy_from_slice(&self.data[0..len]);
+        self.position = end;
 
         Ok(())
     }


### PR DESCRIPTION
This saves the storage space used by about 32 bits per `Fingerprint`.
On average, this reduces the size of the `/target/{mode}/incremental`
folder by roughly 5% [Full details here](https://gist.github.com/wesleywiser/264076314794fbd6a4c110d7c1adc43e).

Fixes #45875

r? @michaelwoerister 
  