### PR TITLE
Make wasm obey backtrace feature, like other targets

### DIFF
--- a/src/libstd/sys/wasm/mod.rs
+++ b/src/libstd/sys/wasm/mod.rs
@@ -39,6 +39,7 @@ use os::raw::c_char;
 const DEBUG: bool = false;
 
 pub mod args;
+#[cfg(feature = "backtrace")]
 pub mod backtrace;
 pub mod cmath;
 pub mod condvar;


### PR DESCRIPTION
E.g. https://github.com/rust-lang/rust/blob/6828cf90146c7fefc4ba4f16dffe75f763f2d910/src/libstd/sys/unix/mod.rs#L40-L41