### PR TITLE
Test rustdoc js

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -445,7 +445,8 @@ impl<'a> Builder<'a> {
         let out_dir = self.stage_out(compiler, mode);
         cargo.env("CARGO_TARGET_DIR", out_dir)
              .arg(cmd)
-             .arg("--target").arg(target);
+             .arg("--target")
+             .arg(target);
 
         // If we were invoked from `make` then that's already got a jobserver
         // set up for us so no need to tell Cargo about jobs all over again.

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -254,7 +254,9 @@ impl<'a> Builder<'a> {
             Kind::Test => describe!(check::Tidy, check::Bootstrap, check::DefaultCompiletest,
                 check::HostCompiletest, check::Crate, check::CrateLibrustc, check::Rustdoc,
                 check::Linkcheck, check::Cargotest, check::Cargo, check::Rls, check::Docs,
-                check::ErrorIndex, check::Distcheck, check::Rustfmt, check::Miri, check::Clippy),
+                check::ErrorIndex, check::Distcheck, check::Rustfmt, check::Miri, check::Clippy,
+                check::RustdocJS),
+
             Kind::Bench => describe!(check::Crate, check::CrateLibrustc),
             Kind::Doc => describe!(doc::UnstableBook, doc::UnstableBookGen, doc::TheBook,
                 doc::Standalone, doc::Std, doc::Test, doc::Rustc, doc::ErrorIndex, doc::Nomicon,

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -447,14 +447,17 @@ impl Step for RustdocJS {
     }
 
     fn run(self, builder: &Builder) {
-        let nodejs = builder.config.nodejs.clone();
-        let mut command = Command::new(&nodejs.expect("no nodejs found"));
-        command.args(&["src/tools/rustdoc-js/tester.js", &*self.host]);
-        builder.ensure(::doc::Std {
-            target: self.target,
-            stage: builder.top_stage,
-        });
-        builder.run(&mut command);
+        if let Some(ref nodejs) = builder.config.nodejs {
+            let mut command = Command::new(nodejs);
+            command.args(&["src/tools/rustdoc-js/tester.js", &*self.host]);
+            builder.ensure(::doc::Std {
+                target: self.target,
+                stage: builder.top_stage,
+            });
+            builder.run(&mut command);
+        } else {
+            println!("No nodejs found, skipping \"src/test/rustdoc-js\" tests");
+        }
     }
 }
 

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -430,12 +430,12 @@ pub struct RustdocJS {
 }
 
 impl Step for RustdocJS {
-    type Output = PathBuf;
+    type Output = ();
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
-        run.path("node")
+        run.path("src/tests/rustdoc-js")
     }
 
     fn make_run(run: RunConfig) {
@@ -444,17 +444,11 @@ impl Step for RustdocJS {
         });
     }
 
-    fn run(self, _: &Builder) {
-        let cmd = if cfg!(target_os = "windows") {
-            let command = Command::new("cmd");
-            command.args(&["/C", "node src/tools/rustdoc-js/tester.js"]);
-            command
-        } else {
-            let command = Command::new("sh");
-            command.args(&["-c", "node src/tools/rustdoc-js/tester.js"]);
-            command
-        };
-        builder.run(cmd);
+    fn run(self, builder: &Builder) {
+        let nodejs = builder.config.nodejs.clone();
+        let mut command = Command::new(&nodejs.expect("no nodejs found"));
+        command.args(&["src/tools/rustdoc-js/tester.js", &*self.host]);
+        builder.run(&mut command);
     }
 }
 
@@ -604,7 +598,6 @@ static HOST_COMPILETESTS: &[Test] = &[
     },
     Test { path: "src/test/run-make", mode: "run-make", suite: "run-make" },
     Test { path: "src/test/rustdoc", mode: "rustdoc", suite: "rustdoc" },
-    Test { path: "src/test/rustdoc-js", mode: "rustdoc-js", suite: "rustdoc-js" },
 
     Test { path: "src/test/pretty", mode: "pretty", suite: "pretty" },
     Test { path: "src/test/run-pass/pretty", mode: "pretty", suite: "run-pass" },

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -427,6 +427,7 @@ fn path_for_cargo(builder: &Builder, compiler: Compiler) -> OsString {
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct RustdocJS {
     pub host: Interned<String>,
+    pub target: Interned<String>,
 }
 
 impl Step for RustdocJS {
@@ -435,12 +436,13 @@ impl Step for RustdocJS {
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
-        run.path("src/tests/rustdoc-js")
+        run.path("src/test/rustdoc-js")
     }
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(RustdocJS {
             host: run.host,
+            target: run.target,
         });
     }
 
@@ -448,6 +450,10 @@ impl Step for RustdocJS {
         let nodejs = builder.config.nodejs.clone();
         let mut command = Command::new(&nodejs.expect("no nodejs found"));
         command.args(&["src/tools/rustdoc-js/tester.js", &*self.host]);
+        builder.ensure(::doc::Std {
+            target: self.target,
+            stage: builder.top_stage,
+        });
         builder.run(&mut command);
     }
 }

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -424,6 +424,40 @@ fn path_for_cargo(builder: &Builder, compiler: Compiler) -> OsString {
     env::join_paths(iter::once(path).chain(env::split_paths(&old_path))).expect("")
 }
 
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct RustdocJS {
+    pub host: Interned<String>,
+}
+
+impl Step for RustdocJS {
+    type Output = PathBuf;
+    const DEFAULT: bool = true;
+    const ONLY_HOSTS: bool = true;
+
+    fn should_run(run: ShouldRun) -> ShouldRun {
+        run.path("node")
+    }
+
+    fn make_run(run: RunConfig) {
+        run.builder.ensure(RustdocJS {
+            host: run.host,
+        });
+    }
+
+    fn run(self, _: &Builder) {
+        let cmd = if cfg!(target_os = "windows") {
+            let command = Command::new("cmd");
+            command.args(&["/C", "node src/tools/rustdoc-js/tester.js"]);
+            command
+        } else {
+            let command = Command::new("sh");
+            command.args(&["-c", "node src/tools/rustdoc-js/tester.js"]);
+            command
+        };
+        builder.run(cmd);
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Tidy {
     host: Interned<String>,
@@ -570,6 +604,7 @@ static HOST_COMPILETESTS: &[Test] = &[
     },
     Test { path: "src/test/run-make", mode: "run-make", suite: "run-make" },
     Test { path: "src/test/rustdoc", mode: "rustdoc", suite: "rustdoc" },
+    Test { path: "src/test/rustdoc-js", mode: "rustdoc-js", suite: "rustdoc-js" },
 
     Test { path: "src/test/pretty", mode: "pretty", suite: "pretty" },
     Test { path: "src/test/run-pass/pretty", mode: "pretty", suite: "run-pass" },

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -418,8 +418,8 @@ impl Step for Standalone {
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Std {
-    stage: u32,
-    target: Interned<String>,
+    pub stage: u32,
+    pub target: Interned<String>,
 }
 
 impl Step for Std {

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -260,7 +260,6 @@ tool!(
     BuildManifest, "src/tools/build-manifest", "build-manifest", Mode::Libstd;
     RemoteTestClient, "src/tools/remote-test-client", "remote-test-client", Mode::Libstd;
     RustInstaller, "src/tools/rust-installer", "fabricate", Mode::Libstd;
-    RustdocJS, "rustdoc-js", "js-tests", Mode::Tool;
 );
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -260,7 +260,7 @@ tool!(
     BuildManifest, "src/tools/build-manifest", "build-manifest", Mode::Libstd;
     RemoteTestClient, "src/tools/remote-test-client", "remote-test-client", Mode::Libstd;
     RustInstaller, "src/tools/rust-installer", "fabricate", Mode::Libstd;
-    RustdocJS, "node", "node", Mode::Tool;
+    RustdocJS, "rustdoc-js", "js-tests", Mode::Tool;
 );
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -260,6 +260,7 @@ tool!(
     BuildManifest, "src/tools/build-manifest", "build-manifest", Mode::Libstd;
     RemoteTestClient, "src/tools/remote-test-client", "remote-test-client", Mode::Libstd;
     RustInstaller, "src/tools/rust-installer", "fabricate", Mode::Libstd;
+    RustdocJS, "node", "node", Mode::Tool;
 );
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -353,35 +353,33 @@
      * This code is an unmodified version of the code written by Marco de Wit
      * and was found at http://stackoverflow.com/a/18514751/745719
      */
-    var levenshtein = (function() {
-        var row2 = [];
-        return function(s1, s2) {
-            if (s1 === s2) {
-                return 0;
+    var levenshtein_row2 = [];
+    function levenshtein(s1, s2) {
+        if (s1 === s2) {
+            return 0;
+        }
+        var s1_len = s1.length, s2_len = s2.length;
+        if (s1_len && s2_len) {
+            var i1 = 0, i2 = 0, a, b, c, c2, row = levenshtein_row2;
+            while (i1 < s1_len) {
+                row[i1] = ++i1;
             }
-            var s1_len = s1.length, s2_len = s2.length;
-            if (s1_len && s2_len) {
-                var i1 = 0, i2 = 0, a, b, c, c2, row = row2;
-                while (i1 < s1_len) {
-                    row[i1] = ++i1;
+            while (i2 < s2_len) {
+                c2 = s2.charCodeAt(i2);
+                a = i2;
+                ++i2;
+                b = i2;
+                for (i1 = 0; i1 < s1_len; ++i1) {
+                    c = a + (s1.charCodeAt(i1) !== c2 ? 1 : 0);
+                    a = row[i1];
+                    b = b < a ? (b < c ? b + 1 : c) : (a < c ? a + 1 : c);
+                    row[i1] = b;
                 }
-                while (i2 < s2_len) {
-                    c2 = s2.charCodeAt(i2);
-                    a = i2;
-                    ++i2;
-                    b = i2;
-                    for (i1 = 0; i1 < s1_len; ++i1) {
-                        c = a + (s1.charCodeAt(i1) !== c2 ? 1 : 0);
-                        a = row[i1];
-                        b = b < a ? (b < c ? b + 1 : c) : (a < c ? a + 1 : c);
-                        row[i1] = b;
-                    }
-                }
-                return b;
             }
-            return s1_len + s2_len;
-        };
-    })();
+            return b;
+        }
+        return s1_len + s2_len;
+    }
 
     function initSearch(rawSearchIndex) {
         var currentResults, index, searchIndex;
@@ -400,12 +398,20 @@
         /**
          * Executes the query and builds an index of results
          * @param  {[Object]} query     [The user query]
-         * @param  {[type]} max         [The maximum results returned]
          * @param  {[type]} searchWords [The list of search words to query
          *                               against]
          * @return {[type]}             [A search index of results]
          */
-        function execQuery(query, max, searchWords) {
+        function execQuery(query, searchWords) {
+            function itemTypeFromName(typename) {
+                for (var i = 0; i < itemTypes.length; ++i) {
+                    if (itemTypes[i] === typename) {
+                        return i;
+                    }
+                }
+                return -1;
+            }
+
             var valLower = query.query.toLowerCase(),
                 val = valLower,
                 typeFilter = itemTypeFromName(query.type),
@@ -1021,9 +1027,8 @@
             return true;
         }
 
-        function getQuery() {
-            var matches, type, query, raw =
-                document.getElementsByClassName('search-input')[0].value;
+        function getQuery(raw) {
+            var matches, type, query;
             query = raw;
 
             matches = query.match(/^(fn|mod|struct|enum|trait|type|const|macro)\s*:\s*/i);
@@ -1227,7 +1232,7 @@
         }
 
         function showResults(results) {
-            var output, query = getQuery();
+            var output, query = getQuery(document.getElementsByClassName('search-input')[0].value);
 
             currentResults = query.id;
             output = '<h1>Results for ' + escape(query.query) +
@@ -1271,7 +1276,7 @@
                 resultIndex;
             var params = getQueryStringParams();
 
-            query = getQuery();
+            query = getQuery(document.getElementsByClassName('search-input')[0].value);
             if (e) {
                 e.preventDefault();
             }
@@ -1293,17 +1298,8 @@
                 }
             }
 
-            results = execQuery(query, 20000, index);
+            results = execQuery(query, index);
             showResults(results);
-        }
-
-        function itemTypeFromName(typename) {
-            for (var i = 0; i < itemTypes.length; ++i) {
-                if (itemTypes[i] === typename) {
-                    return i;
-                }
-            }
-            return -1;
         }
 
         function buildIndex(rawSearchIndex) {

--- a/src/test/rustdoc-js/basic.js
+++ b/src/test/rustdoc-js/basic.js
@@ -1,0 +1,15 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const QUERY = 'String';
+
+const EXPECTED = [
+    {'all': ['std::string::String']},
+];

--- a/src/test/rustdoc-js/enum-option.js
+++ b/src/test/rustdoc-js/enum-option.js
@@ -8,18 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-const QUERY = 'String';
+const QUERY = 'enum:Option';
 
 const EXPECTED = {
     'others': [
-        { 'path': 'std::string', 'name': 'String' },
-        { 'path': 'std::ffi', 'name': 'OsString' },
-        { 'path': 'std::ffi', 'name': 'CString' },
-    ],
-    'in_args': [
-        { 'path': 'std::str', 'name': 'eq' },
-    ],
-    'returned': [
-        { 'path': 'std::string::String', 'name': 'add' },
+        { 'path': 'std::option', 'name': 'Option' },
     ],
 };

--- a/src/test/rustdoc-js/fn-forget.js
+++ b/src/test/rustdoc-js/fn-forget.js
@@ -8,18 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-const QUERY = 'String';
+const QUERY = 'fn:forget';
 
 const EXPECTED = {
     'others': [
-        { 'path': 'std::string', 'name': 'String' },
-        { 'path': 'std::ffi', 'name': 'OsString' },
-        { 'path': 'std::ffi', 'name': 'CString' },
-    ],
-    'in_args': [
-        { 'path': 'std::str', 'name': 'eq' },
-    ],
-    'returned': [
-        { 'path': 'std::string::String', 'name': 'add' },
+        { 'path': 'std::mem', 'name': 'forget' },
+        { 'path': 'std::fmt', 'name': 'format' },
     ],
 };

--- a/src/test/rustdoc-js/from_u.js
+++ b/src/test/rustdoc-js/from_u.js
@@ -8,18 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-const QUERY = 'String';
+const QUERY = 'from_u';
 
 const EXPECTED = {
     'others': [
-        { 'path': 'std::string', 'name': 'String' },
-        { 'path': 'std::ffi', 'name': 'OsString' },
-        { 'path': 'std::ffi', 'name': 'CString' },
-    ],
-    'in_args': [
-        { 'path': 'std::str', 'name': 'eq' },
-    ],
-    'returned': [
-        { 'path': 'std::string::String', 'name': 'add' },
+        { 'path': 'std::char', 'name': 'from_u32' },
+        { 'path': 'std::str', 'name': 'from_utf8' },
+        { 'path': 'std::string::String', 'name': 'from_utf8' },
+        { 'path': 'std::boxed::Box', 'name': 'from_unique' },
+        { 'path': 'std::i32', 'name': 'from_unsigned' },
+        { 'path': 'std::i128', 'name': 'from_unsigned' },
     ],
 };

--- a/src/test/rustdoc-js/macro-print.js
+++ b/src/test/rustdoc-js/macro-print.js
@@ -8,18 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-const QUERY = 'String';
+const QUERY = 'macro:print';
 
 const EXPECTED = {
     'others': [
-        { 'path': 'std::string', 'name': 'String' },
-        { 'path': 'std::ffi', 'name': 'OsString' },
-        { 'path': 'std::ffi', 'name': 'CString' },
-    ],
-    'in_args': [
-        { 'path': 'std::str', 'name': 'eq' },
-    ],
-    'returned': [
-        { 'path': 'std::string::String', 'name': 'add' },
+        { 'path': 'std', 'name': 'print' },
+        { 'path': 'std', 'name': 'eprint' },
+        { 'path': 'std', 'name': 'println' },
+        { 'path': 'std', 'name': 'eprintln' },
     ],
 };

--- a/src/test/rustdoc-js/string-from_ut.js
+++ b/src/test/rustdoc-js/string-from_ut.js
@@ -8,18 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-const QUERY = 'String';
+const QUERY = 'String::from_ut';
 
 const EXPECTED = {
     'others': [
-        { 'path': 'std::string', 'name': 'String' },
-        { 'path': 'std::ffi', 'name': 'OsString' },
-        { 'path': 'std::ffi', 'name': 'CString' },
-    ],
-    'in_args': [
-        { 'path': 'std::str', 'name': 'eq' },
-    ],
-    'returned': [
-        { 'path': 'std::string::String', 'name': 'add' },
+        { 'path': 'std::string::String', 'name': 'from_utf8' },
+        { 'path': 'std::string::String', 'name': 'from_utf8' },
+        { 'path': 'std::string::String', 'name': 'from_utf8_lossy' },
+        { 'path': 'std::string::String', 'name': 'from_utf16_lossy' },
+        { 'path': 'std::string::String', 'name': 'from_utf8_unchecked' },
     ],
 };

--- a/src/test/rustdoc-js/struct-vec.js
+++ b/src/test/rustdoc-js/struct-vec.js
@@ -8,18 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-const QUERY = 'String';
+const QUERY = 'struct:Vec';
 
 const EXPECTED = {
     'others': [
-        { 'path': 'std::string', 'name': 'String' },
-        { 'path': 'std::ffi', 'name': 'OsString' },
-        { 'path': 'std::ffi', 'name': 'CString' },
-    ],
-    'in_args': [
-        { 'path': 'std::str', 'name': 'eq' },
-    ],
-    'returned': [
-        { 'path': 'std::string::String', 'name': 'add' },
+        { 'path': 'std::vec', 'name': 'Vec' },
+        { 'path': 'std::collections', 'name': 'VecDeque' },
+        { 'path': 'alloc::raw_vec', 'name': 'RawVec' },
     ],
 };

--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -1,4 +1,4 @@
-// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -12,15 +12,199 @@ const fs = require('fs');
 
 const TEST_FOLDER = 'src/test/rustdoc-js/';
 
-function loadFile(filePath) {
-    var src = fs.readFileSync(filePath, 'utf8').split('\n').slice(15, -10).join('\n');
-    var Module = module.constructor;
-    var m = new Module();
-    m._compile(src, filePath);
-    return m;
+// Stupid function extractor based on indent.
+function extractFunction(content, functionName) {
+    var x = content.split('\n');
+    var in_func = false;
+    var indent = 0;
+    var lines = [];
+
+    for (var i = 0; i < x.length; ++i) {
+        if (in_func === false) {
+            var splitter = "function " + functionName + "(";
+            if (x[i].trim().startsWith(splitter)) {
+                in_func = true;
+                indent = x[i].split(splitter)[0].length;
+                lines.push(x[i]);
+            }
+        } else {
+            lines.push(x[i]);
+            if (x[i].trim() === "}" && x[i].split("}")[0].length === indent) {
+                return lines.join("\n");
+            }
+        }
+    }
+    return null;
 }
 
-fs.readdirSync(TEST_FOLDER).forEach(function(file) {
-    var file = require(TEST_FOLDER + file);
-    const expected = file.EXPECTED;
-});
+// Stupid function extractor for array.
+function extractArrayVariable(content, arrayName) {
+    var x = content.split('\n');
+    var found_var = false;
+    var lines = [];
+
+    for (var i = 0; i < x.length; ++i) {
+        if (found_var === false) {
+            var splitter = "var " + arrayName + " = [";
+            if (x[i].trim().startsWith(splitter)) {
+                found_var = true;
+                i -= 1;
+            }
+        } else {
+            lines.push(x[i]);
+            if (x[i].endsWith('];')) {
+                return lines.join("\n");
+            }
+        }
+    }
+    return null;
+}
+
+// Stupid function extractor for variable.
+function extractVariable(content, varName) {
+    var x = content.split('\n');
+    var found_var = false;
+    var lines = [];
+
+    for (var i = 0; i < x.length; ++i) {
+        if (found_var === false) {
+            var splitter = "var " + varName + " = ";
+            if (x[i].trim().startsWith(splitter)) {
+                found_var = true;
+                i -= 1;
+            }
+        } else {
+            lines.push(x[i]);
+            if (x[i].endsWith(';')) {
+                return lines.join("\n");
+            }
+        }
+    }
+    return null;
+}
+
+function loadContent(content) {
+    var Module = module.constructor;
+    var m = new Module();
+    m._compile(content, "tmp.js");
+    return m.exports;
+}
+
+function readFile(filePath) {
+    return fs.readFileSync(filePath, 'utf8');
+}
+
+function loadThings(thingsToLoad, kindOfLoad, funcToCall, fileContent) {
+    var content = '';
+    for (var i = 0; i < thingsToLoad.length; ++i) {
+        var tmp = funcToCall(fileContent, thingsToLoad[i]);
+        if (tmp === null) {
+            console.error('enable to find ' + kindOfLoad + ' "' + thingsToLoad[i] + '"');
+            process.exit(1);
+        }
+        content += tmp;
+        content += 'exports.' + thingsToLoad[i] + ' = ' + thingsToLoad[i] + ';';
+    }
+    return content;
+}
+
+function lookForEntry(entry, data) {
+    for (var i = 0; i < data.length; ++i) {
+        var allGood = true;
+        for (var key in entry) {
+            if (!entry.hasOwnProperty(key)) {
+                continue;
+            }
+            let value = data[i][key];
+            // To make our life easier, if there is a "parent" type, we add it to the path.
+            if (key === 'path' && data[i]['parent'] !== undefined) {
+                if (value.length > 0) {
+                    value += '::' + data[i]['parent']['name'];
+                } else {
+                    value = data[i]['parent']['name'];
+                }
+            }
+            if (value !== entry[key]) {
+                allGood = false;
+                break;
+            }
+        }
+        if (allGood === true) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function main(argv) {
+    if (argv.length !== 3) {
+        console.error("Expected toolchain to check as argument (for example 'x86_64-apple-darwin'");
+        return 1;
+    }
+    var toolchain = argv[2];
+
+    var mainJs = readFile("build/" + toolchain + "/doc/main.js");
+    var searchIndex = readFile("build/" + toolchain + "/doc/search-index.js").split("\n");
+    if (searchIndex[searchIndex.length - 1].length === 0) {
+        searchIndex.pop();
+    }
+    searchIndex.pop();
+    searchIndex = loadContent(searchIndex.join("\n") + '\nexports.searchIndex = searchIndex;');
+    finalJS = "";
+
+    var arraysToLoad = ["itemTypes"];
+    var variablesToLoad = ["MAX_LEV_DISTANCE", "MAX_RESULTS", "TY_PRIMITIVE", "levenshtein_row2"];
+    // execQuery first parameter is built in getQuery (which takes in the search input).
+    // execQuery last parameter is built in buildIndex.
+    // buildIndex requires the hashmap from search-index.
+    var functionsToLoad = ["levenshtein", "validateResult", "getQuery", "buildIndex", "execQuery"];
+
+    finalJS += 'window = { "currentCrate": "std" };\n';
+    finalJS += loadThings(arraysToLoad, 'array', extractArrayVariable, mainJs);
+    finalJS += loadThings(variablesToLoad, 'variable', extractVariable, mainJs);
+    finalJS += loadThings(functionsToLoad, 'function', extractFunction, mainJs);
+
+    var loaded = loadContent(finalJS);
+    var index = loaded.buildIndex(searchIndex.searchIndex);
+
+    var errors = 0;
+
+    fs.readdirSync(TEST_FOLDER).forEach(function(file) {
+        var loadedFile = loadContent(readFile(TEST_FOLDER + file) +
+                               'exports.QUERY = QUERY;exports.EXPECTED = EXPECTED;');
+        const expected = loadedFile.EXPECTED;
+        const query = loadedFile.QUERY;
+        var results = loaded.execQuery(loaded.getQuery(query), index);
+        process.stdout.write('Checking "' + file + '" ... ');
+        var error_text = [];
+        for (var key in expected) {
+            if (!expected.hasOwnProperty(key)) {
+                continue;
+            }
+            if (!results.hasOwnProperty(key)) {
+                error_text.push('==> Unknown key "' + key + '"');
+                break;
+            }
+            var entry = expected[key];
+            var found = false;
+            for (var i = 0; i < entry.length; ++i) {
+                if (lookForEntry(entry[i], results[key]) === true) {
+                    found = true;
+                } else {
+                    error_text.push("==> Result not found in '" + key + "': '" +
+                                    JSON.stringify(entry[i]) + "'");
+                }
+            }
+        }
+        if (error_text.length !== 0) {
+            errors += 1;
+            console.error("FAILED");
+            console.error(error_text.join("\n"));
+        } else {
+            console.log("OK");
+        }
+    });
+    return errors;
+}
+
+process.exit(main(process.argv));

--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -115,7 +115,7 @@ function lookForEntry(entry, data) {
             if (!entry.hasOwnProperty(key)) {
                 continue;
             }
-            let value = data[i][key];
+            var value = data[i][key];
             // To make our life easier, if there is a "parent" type, we add it to the path.
             if (key === 'path' && data[i]['parent'] !== undefined) {
                 if (value.length > 0) {

--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -1,0 +1,26 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const fs = require('fs');
+
+const TEST_FOLDER = 'src/test/rustdoc-js/';
+
+function loadFile(filePath) {
+    var src = fs.readFileSync(filePath, 'utf8').split('\n').slice(15, -10).join('\n');
+    var Module = module.constructor;
+    var m = new Module();
+    m._compile(src, filePath);
+    return m;
+}
+
+fs.readdirSync(TEST_FOLDER).forEach(function(file) {
+    var file = require(TEST_FOLDER + file);
+    const expected = file.EXPECTED;
+});


### PR DESCRIPTION
Add tests for the rustdoc search. It was heavily required because of all the recent breaking changes that happened while I went through improvements in doc search (add search in/for generic search for example).