### PR TITLE
Update musl to 1.1.18

### DIFF
--- a/src/ci/docker/scripts/musl.sh
+++ b/src/ci/docker/scripts/musl.sh
@@ -30,7 +30,7 @@ exit 1
 TAG=$1
 shift
 
-MUSL=musl-1.1.17
+MUSL=musl-1.1.18
 
 # may have been downloaded in a previous run
 if [ ! -d $MUSL ]; then


### PR DESCRIPTION
According to http://www.musl-libc.org/download.html:

This release corrects regressions in glob() and armv4t build failure
introduced in the previous release, and includes an important bug fix
for posix_spawnp in the presence of a large PATH environment variable.