### PR TITLE
Skip linker-output-non-utf8 test on Apple

### DIFF
--- a/src/test/run-make/linker-output-non-utf8/Makefile
+++ b/src/test/run-make/linker-output-non-utf8/Makefile
@@ -10,7 +10,7 @@
 ifndef IS_WINDOWS
 
 # This also does not work on Apple APFS due to the filesystem requiring
-# valid UTF-u paths.
+# valid UTF-8 paths.
 ifneq ($(shell uname),Darwin)
 
 # The zzz it to allow humans to tab complete or glob this thing.

--- a/src/test/run-make/linker-output-non-utf8/Makefile
+++ b/src/test/run-make/linker-output-non-utf8/Makefile
@@ -2,15 +2,12 @@
 
 # Make sure we don't ICE if the linker prints a non-UTF-8 error message.
 
-ifdef IS_WINDOWS
-# ignore windows
+# Ignore Windows and Apple
 
-# This does not work in its current form on windows, possibly due to
-# gcc bugs or something about valid Windows paths.  See issue #29151
-# for more information.
-all:
-
-else
+# This does not work in its current form on Windows or Apple APFS due
+# to their filesystems requiring paths to be valid Unicode.
+ifndef IS_WINDOWS
+ifneq ($(shell uname),Darwin)
 
 # The zzz it to allow humans to tab complete or glob this thing.
 bad_dir := $(TMPDIR)/zzz$$'\xff'
@@ -20,5 +17,12 @@ all:
 	mkdir $(bad_dir)
 	mv $(TMPDIR)/liblibrary.a $(bad_dir)
 	LIBRARY_PATH=$(bad_dir) $(RUSTC) exec.rs 2>&1 | $(CGREP) this_symbol_not_defined
+else
+all:
+
+endif
+
+else
+all:
 
 endif

--- a/src/test/run-make/linker-output-non-utf8/Makefile
+++ b/src/test/run-make/linker-output-non-utf8/Makefile
@@ -4,9 +4,13 @@
 
 # Ignore Windows and Apple
 
-# This does not work in its current form on Windows or Apple APFS due
-# to their filesystems requiring paths to be valid Unicode.
+# This does not work in its current form on windows, possibly due to
+# gcc bugs or something about valid Windows paths.  See issue #29151
+# for more information.
 ifndef IS_WINDOWS
+
+# This also does not work on Apple APFS due to the filesystem requiring
+# valid UTF-u paths.
 ifneq ($(shell uname),Darwin)
 
 # The zzz it to allow humans to tab complete or glob this thing.


### PR DESCRIPTION
This test fails on APFS filesystems with the following error:

```shell
mkdir: /Users/ryan/Code/rust/build/x86_64-apple-darwin/test/run-make/linker-output-non-utf8.stage2-x86_64-apple-darwin/zzz�: Illegal byte sequence
```

The mkdir does succeed on an HFS+ volume mounted on the same system:
```shell
$ mkdir zzz$$'\xff'
$ ls
zzz47432\xff
```


This is due to APFS now requiring that all paths are valid UTF-8. As APFS will be the default filesystem for all new Darwin-based systems the most straightforward fix is to skip this test on Darwin as well as Windows.