### PR TITLE
Make core::ops::Place an unsafe trait

### DIFF
--- a/src/liballoc/binary_heap.rs
+++ b/src/liballoc/binary_heap.rs
@@ -1211,7 +1211,7 @@ where T: Clone + Ord {
 #[unstable(feature = "collection_placement",
            reason = "placement protocol is subject to change",
            issue = "30172")]
-impl<'a, T> Place<T> for BinaryHeapPlace<'a, T>
+unsafe impl<'a, T> Place<T> for BinaryHeapPlace<'a, T>
 where T: Clone + Ord {
     fn pointer(&mut self) -> *mut T {
         self.place.pointer()

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -142,7 +142,7 @@ pub struct IntermediateBox<T: ?Sized> {
 #[unstable(feature = "placement_in",
            reason = "placement box design is still being worked out.",
            issue = "27779")]
-impl<T> Place<T> for IntermediateBox<T> {
+unsafe impl<T> Place<T> for IntermediateBox<T> {
     fn pointer(&mut self) -> *mut T {
         self.ptr as *mut T
     }

--- a/src/liballoc/linked_list.rs
+++ b/src/liballoc/linked_list.rs
@@ -1286,7 +1286,7 @@ impl<'a, T> Placer<T> for FrontPlace<'a, T> {
 #[unstable(feature = "collection_placement",
            reason = "placement protocol is subject to change",
            issue = "30172")]
-impl<'a, T> Place<T> for FrontPlace<'a, T> {
+unsafe impl<'a, T> Place<T> for FrontPlace<'a, T> {
     fn pointer(&mut self) -> *mut T {
         unsafe { &mut (*self.node.pointer()).element }
     }
@@ -1341,7 +1341,7 @@ impl<'a, T> Placer<T> for BackPlace<'a, T> {
 #[unstable(feature = "collection_placement",
            reason = "placement protocol is subject to change",
            issue = "30172")]
-impl<'a, T> Place<T> for BackPlace<'a, T> {
+unsafe impl<'a, T> Place<T> for BackPlace<'a, T> {
     fn pointer(&mut self) -> *mut T {
         unsafe { &mut (*self.node.pointer()).element }
     }

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2544,7 +2544,7 @@ impl<'a, T> Placer<T> for PlaceBack<'a, T> {
 #[unstable(feature = "collection_placement",
            reason = "placement protocol is subject to change",
            issue = "30172")]
-impl<'a, T> Place<T> for PlaceBack<'a, T> {
+unsafe impl<'a, T> Place<T> for PlaceBack<'a, T> {
     fn pointer(&mut self) -> *mut T {
         unsafe { self.vec.as_mut_ptr().offset(self.vec.len as isize) }
     }

--- a/src/liballoc/vec_deque.rs
+++ b/src/liballoc/vec_deque.rs
@@ -2564,7 +2564,7 @@ impl<'a, T> Placer<T> for PlaceBack<'a, T> {
 #[unstable(feature = "collection_placement",
            reason = "placement protocol is subject to change",
            issue = "30172")]
-impl<'a, T> Place<T> for PlaceBack<'a, T> {
+unsafe impl<'a, T> Place<T> for PlaceBack<'a, T> {
     fn pointer(&mut self) -> *mut T {
         unsafe { self.vec_deque.ptr().offset(self.vec_deque.head as isize) }
     }
@@ -2610,7 +2610,7 @@ impl<'a, T> Placer<T> for PlaceFront<'a, T> {
 #[unstable(feature = "collection_placement",
            reason = "placement protocol is subject to change",
            issue = "30172")]
-impl<'a, T> Place<T> for PlaceFront<'a, T> {
+unsafe impl<'a, T> Place<T> for PlaceFront<'a, T> {
     fn pointer(&mut self) -> *mut T {
         let tail = self.vec_deque.wrap_sub(self.vec_deque.tail, 1);
         unsafe { self.vec_deque.ptr().offset(tail as isize) }

--- a/src/libcore/ops/place.rs
+++ b/src/libcore/ops/place.rs
@@ -27,10 +27,13 @@
 /// implementation of Place to clean up any intermediate state
 /// (e.g. deallocate box storage, pop a stack, etc).
 #[unstable(feature = "placement_new_protocol", issue = "27779")]
-pub trait Place<Data: ?Sized> {
+pub unsafe trait Place<Data: ?Sized> {
     /// Returns the address where the input value will be written.
     /// Note that the data at this address is generally uninitialized,
     /// and thus one should use `ptr::write` for initializing it.
+    ///
+    /// This function must return a valid (non-zero) pointer to
+    /// a location at which a value of type `Data` can be written.
     fn pointer(&mut self) -> *mut Data;
 }
 

--- a/src/libcore/ops/place.rs
+++ b/src/libcore/ops/place.rs
@@ -32,8 +32,8 @@ pub unsafe trait Place<Data: ?Sized> {
     /// Note that the data at this address is generally uninitialized,
     /// and thus one should use `ptr::write` for initializing it.
     ///
-    /// This function must return a valid (non-zero) pointer to
-    /// a location at which a value of type `Data` can be written.
+    /// This function must return a pointer through which a value
+    /// of type `Data` can be written.
     fn pointer(&mut self) -> *mut Data;
 }
 

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1932,7 +1932,7 @@ impl<'a, K, V> Placer<V> for Entry<'a, K, V> {
 #[unstable(feature = "collection_placement",
            reason = "placement protocol is subject to change",
            issue = "30172")]
-impl<'a, K, V> Place<V> for EntryPlace<'a, K, V> {
+unsafe impl<'a, K, V> Place<V> for EntryPlace<'a, K, V> {
     fn pointer(&mut self) -> *mut V {
         self.bucket.read_mut().1
     }


### PR DESCRIPTION
Consumers of `Place` would reasonably expect that the `pointer` function returns a valid pointer to memory that can actually be written to.