### PR TITLE
Makes the constructors of Duration const fns.

### DIFF
--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -73,7 +73,7 @@ impl Duration {
     /// ```
     #[stable(feature = "duration", since = "1.3.0")]
     #[inline]
-    pub const fn new(secs: u64, nanos: u32) -> Duration {
+    pub fn new(secs: u64, nanos: u32) -> Duration {
         let secs = secs.checked_add((nanos / NANOS_PER_SEC) as u64)
             .expect("overflow in Duration::new");
         let nanos = nanos % NANOS_PER_SEC;
@@ -113,9 +113,10 @@ impl Duration {
     #[stable(feature = "duration", since = "1.3.0")]
     #[inline]
     pub const fn from_millis(millis: u64) -> Duration {
-        let secs = millis / MILLIS_PER_SEC;
-        let nanos = ((millis % MILLIS_PER_SEC) as u32) * NANOS_PER_MILLI;
-        Duration { secs: secs, nanos: nanos }
+        Duration {
+		secs: millis / MILLIS_PER_SEC,
+		nanos: ((millis % MILLIS_PER_SEC) as u32) * NANOS_PER_MILLI,
+	}
     }
 
     /// Creates a new `Duration` from the specified number of microseconds.
@@ -134,9 +135,10 @@ impl Duration {
     #[unstable(feature = "duration_from_micros", issue = "44400")]
     #[inline]
     pub const fn from_micros(micros: u64) -> Duration {
-        let secs = micros / MICROS_PER_SEC;
-        let nanos = ((micros % MICROS_PER_SEC) as u32) * NANOS_PER_MICRO;
-        Duration { secs: secs, nanos: nanos }
+        Duration {
+		secs: micros / MICROS_PER_SEC,
+		nanos: ((micros % MICROS_PER_SEC) as u32) * NANOS_PER_MICRO,
+	}
     }
 
     /// Creates a new `Duration` from the specified number of nanoseconds.
@@ -155,9 +157,10 @@ impl Duration {
     #[unstable(feature = "duration_extras", issue = "46507")]
     #[inline]
     pub const fn from_nanos(nanos: u64) -> Duration {
-        let secs = nanos / (NANOS_PER_SEC as u64);
-        let nanos = (nanos % (NANOS_PER_SEC as u64)) as u32;
-        Duration { secs: secs, nanos: nanos }
+        Duration {
+		secs: nanos / (NANOS_PER_SEC as u64),
+		nanos: (nanos % (NANOS_PER_SEC as u64)) as u32,
+	}
     }
 
     /// Returns the number of _whole_ seconds contained by this `Duration`.

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -114,9 +114,9 @@ impl Duration {
     #[inline]
     pub const fn from_millis(millis: u64) -> Duration {
         Duration {
-		secs: millis / MILLIS_PER_SEC,
-		nanos: ((millis % MILLIS_PER_SEC) as u32) * NANOS_PER_MILLI,
-	}
+            secs: millis / MILLIS_PER_SEC,
+            nanos: ((millis % MILLIS_PER_SEC) as u32) * NANOS_PER_MILLI,
+        }
     }
 
     /// Creates a new `Duration` from the specified number of microseconds.
@@ -136,9 +136,9 @@ impl Duration {
     #[inline]
     pub const fn from_micros(micros: u64) -> Duration {
         Duration {
-		secs: micros / MICROS_PER_SEC,
-		nanos: ((micros % MICROS_PER_SEC) as u32) * NANOS_PER_MICRO,
-	}
+            secs: micros / MICROS_PER_SEC,
+            nanos: ((micros % MICROS_PER_SEC) as u32) * NANOS_PER_MICRO,
+        }
     }
 
     /// Creates a new `Duration` from the specified number of nanoseconds.
@@ -158,9 +158,9 @@ impl Duration {
     #[inline]
     pub const fn from_nanos(nanos: u64) -> Duration {
         Duration {
-		secs: nanos / (NANOS_PER_SEC as u64),
-		nanos: (nanos % (NANOS_PER_SEC as u64)) as u32,
-	}
+            secs: nanos / (NANOS_PER_SEC as u64),
+            nanos: (nanos % (NANOS_PER_SEC as u64)) as u32,
+        }
     }
 
     /// Returns the number of _whole_ seconds contained by this `Duration`.

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -73,7 +73,7 @@ impl Duration {
     /// ```
     #[stable(feature = "duration", since = "1.3.0")]
     #[inline]
-    pub fn new(secs: u64, nanos: u32) -> Duration {
+    pub const fn new(secs: u64, nanos: u32) -> Duration {
         let secs = secs.checked_add((nanos / NANOS_PER_SEC) as u64)
             .expect("overflow in Duration::new");
         let nanos = nanos % NANOS_PER_SEC;
@@ -94,7 +94,7 @@ impl Duration {
     /// ```
     #[stable(feature = "duration", since = "1.3.0")]
     #[inline]
-    pub fn from_secs(secs: u64) -> Duration {
+    pub const fn from_secs(secs: u64) -> Duration {
         Duration { secs: secs, nanos: 0 }
     }
 
@@ -112,7 +112,7 @@ impl Duration {
     /// ```
     #[stable(feature = "duration", since = "1.3.0")]
     #[inline]
-    pub fn from_millis(millis: u64) -> Duration {
+    pub const fn from_millis(millis: u64) -> Duration {
         let secs = millis / MILLIS_PER_SEC;
         let nanos = ((millis % MILLIS_PER_SEC) as u32) * NANOS_PER_MILLI;
         Duration { secs: secs, nanos: nanos }
@@ -133,7 +133,7 @@ impl Duration {
     /// ```
     #[unstable(feature = "duration_from_micros", issue = "44400")]
     #[inline]
-    pub fn from_micros(micros: u64) -> Duration {
+    pub const fn from_micros(micros: u64) -> Duration {
         let secs = micros / MICROS_PER_SEC;
         let nanos = ((micros % MICROS_PER_SEC) as u32) * NANOS_PER_MICRO;
         Duration { secs: secs, nanos: nanos }
@@ -154,7 +154,7 @@ impl Duration {
     /// ```
     #[unstable(feature = "duration_extras", issue = "46507")]
     #[inline]
-    pub fn from_nanos(nanos: u64) -> Duration {
+    pub const fn from_nanos(nanos: u64) -> Duration {
         let secs = nanos / (NANOS_PER_SEC as u64);
         let nanos = (nanos % (NANOS_PER_SEC as u64)) as u32;
         Duration { secs: secs, nanos: nanos }


### PR DESCRIPTION
This affects `Duration::new`, `Duration::from_secs`, `Duration::from_millis`, `Duration::from_micros`, and `Duration::from_nanos`.