### PR TITLE
Fix panic strings.

### DIFF
--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -1046,7 +1046,7 @@ pub fn check_ast_crate(sess: &Session, krate: &ast::Crate) {
     // calculated the lint levels for all AST nodes.
     for (_id, lints) in cx.buffered.map {
         for early_lint in lints {
-            span_bug!(early_lint.span, "failed to process bufferd lint here");
+            span_bug!(early_lint.span, "failed to process buffered lint here");
         }
     }
 }


### PR DESCRIPTION
 - Fix panic string in `check_ast_crate`.
 - Update panic string for Duration subtraction on overflow/underflow.

Not sure if the changes to `Duration` are helpful/needed. Mostly just a nit.
Otherwise this is just a one character change :)

On another note: I hit the panic in `check_ast_crate` when compiling
[m-labs/smoltcp] with the following:

```
cargo test --doc --no-default-features --features "std socket-raw"`
```

[m-labs/smoltcp]: https://github.com/m-labs/smoltcp