### PR TITLE
NLL: bad error message when converting anonymous lifetime to `'static`

### DIFF
--- a/src/librustc/infer/error_reporting/nice_region_error/named_anon_conflict.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/named_anon_conflict.rs
@@ -118,4 +118,17 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
             .emit();
         return Some(ErrorReported);
     }
+
+    // This method returns whether the given Region is Named
+    pub(super) fn is_named_region(&self, region: ty::Region<'tcx>) -> bool {
+        match *region {
+            ty::ReStatic => true,
+            ty::ReFree(ref free_region) => match free_region.bound_region {
+                ty::BrNamed(..) => true,
+                _ => false,
+            },
+            ty::ReEarlyBound(_) => true,
+            _ => false,
+        }
+    }
 }

--- a/src/librustc/infer/error_reporting/nice_region_error/util.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/util.rs
@@ -198,16 +198,4 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
         }
         false
     }
-
-    // This method returns whether the given Region is Named
-    pub(super) fn is_named_region(&self, region: Region<'tcx>) -> bool {
-        match *region {
-            ty::ReFree(ref free_region) => match free_region.bound_region {
-                ty::BrNamed(..) => true,
-                _ => false,
-            },
-            ty::ReEarlyBound(_) => true,
-            _ => false,
-        }
-    }
 }

--- a/src/test/compile-fail/closure-bounds-static-cant-capture-borrowed.rs
+++ b/src/test/compile-fail/closure-bounds-static-cant-capture-borrowed.rs
@@ -13,7 +13,7 @@ fn bar<F>(blk: F) where F: FnOnce() + 'static {
 
 fn foo(x: &()) {
     bar(|| {
-        //~^ ERROR does not fulfill
+        //~^ ERROR explicit lifetime required in the type of `x` [E0621]
         let _ = x;
     })
 }

--- a/src/test/compile-fail/impl-trait/must_outlive_least_region_or_bound.rs
+++ b/src/test/compile-fail/impl-trait/must_outlive_least_region_or_bound.rs
@@ -13,7 +13,7 @@
 use std::fmt::Debug;
 
 fn elided(x: &i32) -> impl Copy { x }
-//~^ ERROR cannot infer an appropriate lifetime
+//~^ ERROR explicit lifetime required in the type of `x` [E0621]
 
 fn explicit<'a>(x: &'a i32) -> impl Copy { x }
 //~^ ERROR cannot infer an appropriate lifetime

--- a/src/test/compile-fail/issue-16922.rs
+++ b/src/test/compile-fail/issue-16922.rs
@@ -12,7 +12,7 @@ use std::any::Any;
 
 fn foo<T: Any>(value: &T) -> Box<Any> {
     Box::new(value) as Box<Any>
-    //~^ ERROR: cannot infer an appropriate lifetime
+    //~^ ERROR explicit lifetime required in the type of `value` [E0621]
 }
 
 fn main() {

--- a/src/test/compile-fail/object-lifetime-default-from-box-error.rs
+++ b/src/test/compile-fail/object-lifetime-default-from-box-error.rs
@@ -25,7 +25,7 @@ fn load(ss: &mut SomeStruct) -> Box<SomeTrait> {
     // `Box<SomeTrait>` defaults to a `'static` bound, so this return
     // is illegal.
 
-    ss.r //~ ERROR cannot infer an appropriate lifetime
+    ss.r //~ ERROR explicit lifetime required in the type of `ss` [E0621]
 }
 
 fn store(ss: &mut SomeStruct, b: Box<SomeTrait>) {

--- a/src/test/compile-fail/region-object-lifetime-in-coercion.rs
+++ b/src/test/compile-fail/region-object-lifetime-in-coercion.rs
@@ -16,20 +16,20 @@ impl<'a> Foo for &'a [u8] {}
 
 fn a(v: &[u8]) -> Box<Foo + 'static> {
     let x: Box<Foo + 'static> = Box::new(v);
-    //~^ ERROR cannot infer an appropriate lifetime due to conflicting
+    //~^ ERROR explicit lifetime required in the type of `v` [E0621]
     x
 }
 
 fn b(v: &[u8]) -> Box<Foo + 'static> {
     Box::new(v)
-        //~^ ERROR cannot infer an appropriate lifetime due to conflicting
+        //~^ ERROR explicit lifetime required in the type of `v` [E0621]
 }
 
 fn c(v: &[u8]) -> Box<Foo> {
     // same as previous case due to RFC 599
 
     Box::new(v)
-        //~^ ERROR cannot infer an appropriate lifetime due to conflicting
+        //~^ ERROR explicit lifetime required in the type of `v` [E0621]
 }
 
 fn d<'a,'b>(v: &'a [u8]) -> Box<Foo+'b> {

--- a/src/test/compile-fail/regions-proc-bound-capture.rs
+++ b/src/test/compile-fail/regions-proc-bound-capture.rs
@@ -16,7 +16,7 @@ fn borrowed_proc<'a>(x: &'a isize) -> Box<FnMut()->(isize) + 'a> {
 
 fn static_proc(x: &isize) -> Box<FnMut()->(isize) + 'static> {
     // This is illegal, because the region bound on `proc` is 'static.
-    Box::new(move|| { *x }) //~ ERROR cannot infer an appropriate lifetime
+    Box::new(move|| { *x }) //~ ERROR explicit lifetime required in the type of `x` [E0621]
 }
 
 fn main() { }

--- a/src/test/compile-fail/regions-static-bound.rs
+++ b/src/test/compile-fail/regions-static-bound.rs
@@ -22,12 +22,12 @@ fn static_id_wrong_way<'a>(t: &'a ()) -> &'static () where 'static: 'a {
 }
 
 fn error(u: &(), v: &()) {
-    static_id(&u); //[ll]~ ERROR cannot infer an appropriate lifetime
+    static_id(&u); //[ll]~ ERROR explicit lifetime required in the type of `u` [E0621]
     //[nll]~^ WARNING not reporting region error due to -Znll
-    //[nll]~| ERROR free region `` does not outlive free region `'static`
-    static_id_indirect(&v); //[ll]~ ERROR cannot infer an appropriate lifetime
+    //[nll]~| ERROR explicit lifetime required in the type of `u` [E0621]
+    static_id_indirect(&v); //[ll]~ ERROR explicit lifetime required in the type of `v` [E0621]
     //[nll]~^ WARNING not reporting region error due to -Znll
-    //[nll]~| ERROR free region `` does not outlive free region `'static`
+    //[nll]~| ERROR explicit lifetime required in the type of `v` [E0621]
 }
 
 fn main() {}

--- a/src/test/ui/issue-46983.rs
+++ b/src/test/ui/issue-46983.rs
@@ -1,0 +1,18 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(nll)]
+
+fn foo(x: &u32) -> &'static u32 {
+    &*x
+    //~^ ERROR explicit lifetime required in the type of `x` [E0621]
+}
+
+fn main() {}

--- a/src/test/ui/issue-46983.stderr
+++ b/src/test/ui/issue-46983.stderr
@@ -1,0 +1,10 @@
+error[E0621]: explicit lifetime required in the type of `x`
+  --> $DIR/issue-46983.rs:14:5
+   |
+13 | fn foo(x: &u32) -> &'static u32 {
+   |        - consider changing the type of `x` to `&'static u32`
+14 |     &*x
+   |     ^^^ lifetime `'static` required
+
+error: aborting due to previous error
+

--- a/src/test/ui/nll/closure-requirements/region-lbr-anon-does-not-outlive-static.rs
+++ b/src/test/ui/nll/closure-requirements/region-lbr-anon-does-not-outlive-static.rs
@@ -18,7 +18,7 @@
 fn foo(x: &u32) -> &'static u32 {
     &*x
         //~^ WARN not reporting region error due to -Znll
-        //~| ERROR does not outlive free region
+        //~| ERROR explicit lifetime required in the type of `x`
 }
 
 fn main() { }

--- a/src/test/ui/nll/closure-requirements/region-lbr-anon-does-not-outlive-static.stderr
+++ b/src/test/ui/nll/closure-requirements/region-lbr-anon-does-not-outlive-static.stderr
@@ -4,11 +4,13 @@ warning: not reporting region error due to -Znll
 19 |     &*x
    |     ^^^
 
-error: free region `ReFree(DefId(0/0:3 ~ region_lbr_anon_does_not_outlive_static[317d]::foo[0]), BrAnon(0))` does not outlive free region `ReStatic`
+error[E0621]: explicit lifetime required in the type of `x`
   --> $DIR/region-lbr-anon-does-not-outlive-static.rs:19:5
    |
+18 | fn foo(x: &u32) -> &'static u32 {
+   |        - consider changing the type of `x` to `&ReStatic u32`
 19 |     &*x
-   |     ^^^
+   |     ^^^ lifetime `ReStatic` required
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/guarantor-issue-46974.rs
+++ b/src/test/ui/nll/guarantor-issue-46974.rs
@@ -22,7 +22,7 @@ fn foo(s: &mut (i32,)) -> i32 {
 
 fn bar(s: &Box<(i32,)>) -> &'static i32 {
     // FIXME(#46983): error message should be better
-    &s.0 //~ ERROR free region `` does not outlive free region `'static`
+    &s.0 //~ ERROR explicit lifetime required in the type of `s` [E0621]
 }
 
 fn main() {

--- a/src/test/ui/nll/guarantor-issue-46974.stderr
+++ b/src/test/ui/nll/guarantor-issue-46974.stderr
@@ -7,11 +7,14 @@ error[E0506]: cannot assign to `*s` because it is borrowed
 19 |     *s = (2,); //~ ERROR cannot assign to `*s`
    |     ^^^^^^^^^ assignment to borrowed `*s` occurs here
 
-error: free region `` does not outlive free region `'static`
+error[E0621]: explicit lifetime required in the type of `s`
   --> $DIR/guarantor-issue-46974.rs:25:5
    |
-25 |     &s.0 //~ ERROR free region `` does not outlive free region `'static`
-   |     ^^^^
+23 | fn bar(s: &Box<(i32,)>) -> &'static i32 {
+   |        - consider changing the type of `s` to `&'static std::boxed::Box<(i32,)>`
+24 |     // FIXME(#46983): error message should be better
+25 |     &s.0 //~ ERROR explicit lifetime required in the type of `s` [E0621]
+   |     ^^^^ lifetime `'static` required
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Fixes #46983.

r? @nikomatsakis 