### PR TITLE
Add -Ztime-passes line for dep-graph loading.

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -889,10 +889,11 @@ pub fn phase_2_configure_and_expand<F>(sess: &Session,
     let dep_graph = match future_dep_graph {
         None => DepGraph::new_disabled(),
         Some(future) => {
-            let prev_graph = future
-                .open()
-                .expect("Could not join with background dep_graph thread")
-                .open(sess);
+            let prev_graph = time(time_passes, "blocked while dep-graph loading finishes", || {
+                future.open()
+                      .expect("Could not join with background dep_graph thread")
+                      .open(sess)
+            });
             DepGraph::new(prev_graph)
         }
     };


### PR DESCRIPTION
We measure how much time the background thread spends on loading the dep-graph but not how long the main thread is blocked while the background thread is still working. Let's change that!