### PR TITLE
Enable ASan and TSan on FreeBSD (WIP)

### DIFF
--- a/src/build_helper/lib.rs
+++ b/src/build_helper/lib.rs
@@ -214,6 +214,10 @@ pub fn sanitizer_lib_boilerplate(sanitizer_name: &str) -> Result<NativeLibBoiler
             format!("clang_rt.{}-x86_64", sanitizer_name),
             "build/lib/linux",
         ),
+        "x86_64-unknown-freebsd" => (
+            format!("clang_rt.{}-x86_64", sanitizer_name),
+            "build/lib/freebsd",
+        ),
         "x86_64-apple-darwin" => (
             format!("dylib=clang_rt.{}_osx_dynamic", sanitizer_name),
             "build/lib/darwin",

--- a/src/ci/docker/dist-x86_64-freebsd/Dockerfile
+++ b/src/ci/docker/dist-x86_64-freebsd/Dockerfile
@@ -29,5 +29,5 @@ ENV \
 
 ENV HOSTS=x86_64-unknown-freebsd
 
-ENV RUST_CONFIGURE_ARGS --host=$HOSTS --enable-extended
+ENV RUST_CONFIGURE_ARGS --host=$HOSTS --enable-extended --enable-sanitizers
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -707,9 +707,11 @@ impl<'a> CrateLoader<'a> {
             // Sanitizers can only be used on some tested platforms with
             // executables linked to `std`
             const ASAN_SUPPORTED_TARGETS: &[&str] = &["x86_64-unknown-linux-gnu",
-                                                      "x86_64-apple-darwin"];
+                                                      "x86_64-apple-darwin",
+                                                      "x86_64-unknown-freebsd"];
             const TSAN_SUPPORTED_TARGETS: &[&str] = &["x86_64-unknown-linux-gnu",
-                                                      "x86_64-apple-darwin"];
+                                                      "x86_64-apple-darwin",
+                                                      "x86_64-unknown-freebsd"];
             const LSAN_SUPPORTED_TARGETS: &[&str] = &["x86_64-unknown-linux-gnu"];
             const MSAN_SUPPORTED_TARGETS: &[&str] = &["x86_64-unknown-linux-gnu"];
 

--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -38,6 +38,10 @@ rustc_lsan = { path = "../librustc_lsan" }
 rustc_msan = { path = "../librustc_msan" }
 rustc_tsan = { path = "../librustc_tsan" }
 
+[target.x86_64-unknown-freebsd.dependencies]
+rustc_asan = { path = "../librustc_asan" }
+rustc_tsan = { path = "../librustc_tsan" }
+
 [build-dependencies]
 build_helper = { path = "../build_helper" }
 


### PR DESCRIPTION
I managed to get ASan running on my Rust program on FreeBSD, however, this patch is incomplete: seems like Rust's LLVM build is not building these `clang_rt.{}-x86_64` libraries. (`find` doesn't even find them.) I haven't found where to turn them on, can anyone help?

For now, I had to use the OS packaged LLVM's ASan library:

```sh
RUSTFLAGS="-L /usr/local/llvm40/lib/clang/4.0.1/lib/freebsd/ -l static=clang_rt.asan-x86_64 -l pthread -Z sanitizer=address" \
  cargo build --example simple --target x86_64-unknown-freebsd

ASAN_OPTIONS=detect_odr_violation=0 ASAN_SYMBOLIZER_PATH=/usr/local/llvm40/bin/llvm-symbolizer \
  ../target/x86_64-unknown-freebsd/debug/examples/simple
```

And note the `pthread`, [we have to link it when ASan is used](https://reviews.llvm.org/D39254). Not exactly sure where to add that. (Wouldn't have noticed this if my program used threads, by the way…)

Also, looks like we have LSan too (at least the library is present in system LLVM packages)…