### PR TITLE
Add `min` specialisation for `RangeFrom`

### DIFF
--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -320,6 +320,11 @@ impl<A: Step> Iterator for ops::RangeFrom<A> {
         self.start = plus_n.add_one();
         Some(plus_n)
     }
+
+    #[inline]
+    fn min(mut self) -> Option<A> {
+        self.next()
+    }
 }
 
 #[unstable(feature = "fused", issue = "35602")]

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1398,6 +1398,12 @@ fn test_range_inclusive_min() {
 }
 
 #[test]
+fn test_range_from_min() {
+    assert_eq!((0..).min(), Some(0));
+    assert_eq!((-20..).min(), Some(-20));
+}
+
+#[test]
 fn test_repeat() {
     let mut it = repeat(42);
     assert_eq!(it.next(), Some(42));


### PR DESCRIPTION
Calling `min` on `RangeFrom` currently causes an infinite loop. Although other methods such as `max` also result in an infinite loop, it is strictly incorrect in the case of `min`. Adding a specialisation fixes this.

Separated from https://github.com/rust-lang/rust/pull/47180 because this technically changes behaviour; it’s not just an optimisation, so it’s a little different.

r? @alexcrichton