### PR TITLE
Re-enable num tests on wasm

### DIFF
--- a/src/libcore/tests/num/mod.rs
+++ b/src/libcore/tests/num/mod.rs
@@ -197,7 +197,6 @@ test_impl_from! { test_u16f64, u16, f64 }
 test_impl_from! { test_u32f64, u32, f64 }
 
 // Float -> Float
-#[cfg_attr(all(target_arch = "wasm32", target_os = "emscripten"), ignore)] // issue 42630
 #[test]
 fn test_f32f64() {
     use core::f32;


### PR DESCRIPTION
Issue #42630 was closed but the tests are still ignored, supposedly they should pass now.