### PR TITLE
Add iterator specialisations for Repeat and Cycle

### DIFF
--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -302,7 +302,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use cmp;
+use cmp::{self, Ordering};
 use fmt;
 use iter_private::TrustedRandomAccess;
 use ops::Try;
@@ -642,6 +642,41 @@ impl<I> Iterator for Cycle<I> where I: Clone + Iterator {
             (0, _) => (0, None),
             _ => (usize::MAX, None)
         }
+    }
+
+    #[inline]
+    fn all<F>(&mut self, f: F) -> bool where F: FnMut(Self::Item) -> bool { self.orig.clone().all(f) }
+
+    #[inline]
+    fn max(self) -> Option<Self::Item> where Self::Item: cmp::Ord { self.orig.clone().max() }
+
+    #[inline]
+    fn min(self) -> Option<Self::Item> where Self::Item: cmp::Ord {
+        cmp::min(self.iter.min(), self.orig.clone().min())
+    }
+
+    #[inline]
+    fn max_by_key<B: Ord, F>(self, f: F) -> Option<Self::Item>
+            where F: FnMut(&Self::Item) -> B {
+        self.orig.clone().max_by_key(f)
+    }
+
+    #[inline]
+    fn max_by<F>(self, f: F) -> Option<Self::Item>
+            where F: FnMut(&Self::Item, &Self::Item) -> Ordering {
+        self.orig.clone().max_by(f)
+    }
+
+    #[inline]
+    fn min_by_key<B: Ord, F>(self, f: F) -> Option<Self::Item>
+            where F: FnMut(&Self::Item) -> B {
+        self.iter.chain(self.orig.clone()).min_by_key(f)
+    }
+
+    #[inline]
+    fn min_by<F>(self, f: F) -> Option<Self::Item>
+            where F: FnMut(&Self::Item, &Self::Item) -> Ordering {
+        self.iter.chain(self.orig.clone()).min_by(f)
     }
 }
 

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -645,7 +645,9 @@ impl<I> Iterator for Cycle<I> where I: Clone + Iterator {
     }
 
     #[inline]
-    fn all<F>(&mut self, f: F) -> bool where F: FnMut(Self::Item) -> bool { self.orig.clone().all(f) }
+    fn all<F>(&mut self, f: F) -> bool where F: FnMut(Self::Item) -> bool {
+        self.iter.clone().chain(self.orig.clone()).all(f)
+    }
 
     #[inline]
     fn max(self) -> Option<Self::Item> where Self::Item: cmp::Ord { self.orig.clone().max() }

--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -11,6 +11,7 @@
 use fmt;
 use marker;
 use usize;
+use cmp::Ordering;
 
 use super::{FusedIterator, TrustedLen};
 
@@ -31,8 +32,41 @@ impl<A: Clone> Iterator for Repeat<A> {
 
     #[inline]
     fn next(&mut self) -> Option<A> { Some(self.element.clone()) }
+
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) { (usize::MAX, None) }
+
+    #[inline]
+    fn nth(&mut self, _: usize) -> Option<A> { self.next() }
+
+    #[inline]
+    fn all<F>(&mut self, f: F) -> bool where F: FnMut(A) -> bool { self.any(f) }
+
+    #[inline]
+    fn max(mut self) -> Option<A> { self.next() }
+
+    #[inline]
+    fn min(mut self) -> Option<A> { self.next() }
+
+    #[inline]
+    fn max_by_key<B: Ord, F>(mut self, _: F) -> Option<A> where F: FnMut(&A) -> B {
+        self.next()
+    }
+
+    #[inline]
+    fn max_by<F>(mut self, _: F) -> Option<A> where F: FnMut(&A, &A) -> Ordering {
+        self.next()
+    }
+
+    #[inline]
+    fn min_by_key<B: Ord, F>(mut self, _: F) -> Option<A> where F: FnMut(&A) -> B {
+        self.next()
+    }
+
+    #[inline]
+    fn min_by<F>(mut self, _: F) -> Option<A> where F: FnMut(&A, &A) -> Ordering {
+        self.next()
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -40,7 +40,7 @@ impl<A: Clone> Iterator for Repeat<A> {
     fn nth(&mut self, _: usize) -> Option<A> { self.next() }
 
     #[inline]
-    fn all<F>(&mut self, f: F) -> bool where F: FnMut(A) -> bool { self.any(f) }
+    fn all<F>(&mut self, mut f: F) -> bool where F: FnMut(A) -> bool { f(self.element.clone()) }
 
     #[inline]
     fn max(mut self) -> Option<A> { self.next() }

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -11,6 +11,7 @@
 use core::iter::*;
 use core::{i8, i16, isize};
 use core::usize;
+use std::cmp::Ordering;
 
 #[test]
 fn test_lt() {
@@ -1403,6 +1404,19 @@ fn test_repeat() {
     assert_eq!(it.next(), Some(42));
     assert_eq!(it.next(), Some(42));
     assert_eq!(it.next(), Some(42));
+}
+
+#[test]
+fn test_repeat_iterator() {
+    let mut it = repeat(42);
+    assert_eq!(it.nth(usize::MAX), Some(42));
+    assert_eq!(it.all(|x| x == 42), true);
+    assert_eq!(repeat(42).max(), Some(42));
+    assert_eq!(repeat(42).min(), Some(42));
+    assert_eq!(repeat(42).max_by_key(|_| 0), Some(42));
+    assert_eq!(repeat(42).max_by_key(|_| Ordering::Greater), Some(42));
+    assert_eq!(repeat(42).min_by_key(|_| 0), Some(42));
+    assert_eq!(repeat(42).min_by_key(|_| Ordering::Greater), Some(42));
 }
 
 #[test]

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -868,6 +868,20 @@ fn test_cycle() {
 }
 
 #[test]
+fn test_cycle_iterator() {
+    let a = 1;
+    let b = 5;
+    let mut it = (a..b).cycle();
+    assert_eq!(it.all(|x| x <= b), true);
+    assert_eq!((a..b).cycle().max(), Some(b - 1));
+    assert_eq!((a..b).cycle().min(), Some(a));
+    assert_eq!((a..b).cycle().max_by_key(|x| -x), Some(a));
+    assert_eq!((a..b).cycle().max_by(|x, y| y.cmp(x)), Some(a));
+    assert_eq!((a..b).cycle().min_by_key(|x| -x), Some(b - 1));
+    assert_eq!((a..b).cycle().min_by(|x, y| y.cmp(x)), Some(b - 1));
+}
+
+#[test]
 fn test_iterator_nth() {
     let v: &[_] = &[0, 1, 2, 3, 4];
     for i in 0..v.len() {
@@ -1414,9 +1428,9 @@ fn test_repeat_iterator() {
     assert_eq!(repeat(42).max(), Some(42));
     assert_eq!(repeat(42).min(), Some(42));
     assert_eq!(repeat(42).max_by_key(|_| 0), Some(42));
-    assert_eq!(repeat(42).max_by_key(|_| Ordering::Greater), Some(42));
+    assert_eq!(repeat(42).max_by(|_, _| Ordering::Equal), Some(42));
     assert_eq!(repeat(42).min_by_key(|_| 0), Some(42));
-    assert_eq!(repeat(42).min_by_key(|_| Ordering::Greater), Some(42));
+    assert_eq!(repeat(42).min_by(|_, _| Ordering::Equal), Some(42));
 }
 
 #[test]


### PR DESCRIPTION
`Repeat` and `Cycle` are infinite iterators that make use of the default iterator implementations, which means that for some methods for which there is a determinable return value, they infinitely loop instead.

This adds specialisations so that the iterators return values as expected. Also optimises `nth` for `Repeat`.

r? @alexcrichton