### PR TITLE
Remove unwrap() from cabi_x86_64.rs 

### DIFF
--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -12,7 +12,7 @@
 //! the parent links in the region hierarchy.
 //!
 //! Most of the documentation on regions can be found in
-//! `middle/infer/region_constraints/README.md`
+//! `librustc/infer/region_constraints/README.md`
 
 use ich::{StableHashingContext, NodeIdHashingMode};
 use util::nodemap::{FxHashMap, FxHashSet};

--- a/src/librustc_trans/cabi_x86_64.rs
+++ b/src/librustc_trans/cabi_x86_64.rs
@@ -14,7 +14,7 @@
 use abi::{ArgType, CastTarget, FnType, LayoutExt, Reg, RegKind};
 use context::CrateContext;
 
-use rustc::ty::layout::{self, TyLayout, Size};
+use rustc::ty::layout::{self, Integer, Primitive, TyLayout, Size};
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 enum Class {
@@ -87,7 +87,12 @@ fn classify_arg<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, arg: &ArgType<'tcx>)
             layout::Abi::Uninhabited => return Ok(()),
 
             layout::Abi::Scalar(ref scalar) => {
+                if let Primitive::Int(Integer::I128, _) = scalar.value {
+                    unify(cls, off, Class::Int);
+                    unify(cls, off + Size::from_bytes(8), Class::Int);
+                } else {
                 unify(cls, off, Class::from_layout(ccx, layout));
+                }
                 off + scalar.value.size(ccx)
             }
 

--- a/src/test/run-pass/issue-38763.rs
+++ b/src/test/run-pass/issue-38763.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,17 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// #45662
+#![feature(i128_type)]
 
-#![feature(repr_align)]
-#![feature(attr_literals)]
-
-#[repr(align(16))]
-pub struct A {
-    y: i64,
-}
+#[repr(C)]
+pub struct Foo(i128);
 
 #[no_mangle]
-pub extern "C" fn foo(x: A) {}
+pub extern "C" fn foo(x: Foo) -> Foo { x }
 
-fn main() {}
+fn main() {
+    foo(Foo(1));
+}


### PR DESCRIPTION
This PR is a follow-up of #47014. I am not certain whether simply removing `unwrap()` suffices, but at least no test failed.

Closes #38763. Closes #45662.