### PR TITLE
Report errors instead of panic!() when linkcheck encounters absolute paths

### DIFF
--- a/src/tools/linkchecker/main.rs
+++ b/src/tools/linkchecker/main.rs
@@ -192,7 +192,17 @@ fn check(cache: &mut Cache,
             for part in Path::new(base).join(url).components() {
                 match part {
                     Component::Prefix(_) |
-                    Component::RootDir => panic!(),
+                    Component::RootDir => {
+                        // Avoid absolute paths as they make the docs not
+                        // relocatable by making assumptions on where the docs
+                        // are hosted relative to the site root.
+                        *errors = true;
+                        println!("{}:{}: absolute path - {}",
+                                 pretty_file.display(),
+                                 i + 1,
+                                 Path::new(base).join(url).display());
+                        return;
+                    }
                     Component::CurDir => {}
                     Component::ParentDir => { path.pop(); }
                     Component::Normal(s) => { path.push(s); }


### PR DESCRIPTION
The RBE contained some absolute links that failed the link check in #46196. Diagnosing these issues was needlessly complicated, thanks to the linkchecker just panicing instead of reporting proper errors.

This PR replaces the panic with a proper `*errors = true` + error message handling.

The linkchecker itself doesn't have any tests so I intentionally didn't touch anything else than the code that previously did the `panic!()`. A small code quality improvement might be made by binding the `Path::new(base).join(url)` into a variable before the for-loop and using this resolved url in both the for loop and the error message.

r? @steveklabnik 

(If not for any other reason than having r on the #46196.)