### PR TITLE
Standardize on "re-export" rather than "reexport"

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -577,7 +577,7 @@ Compatibility Notes
   a warning.
 - [From the pound escape, lines consisting of multiple `#`s are
   now visible][41785]
-- [It is an error to reexport private enum variants][42460]. This is
+- [It is an error to re-export private enum variants][42460]. This is
   known to break a number of crates that depend on an older version of
   mustache.
 - [On Windows, if `VCINSTALLDIR` is set incorrectly, `rustc` will try
@@ -2251,10 +2251,10 @@ Rustdoc
 -------
 
 * [Fix empty implementation section on some module pages](https://github.com/rust-lang/rust/pull/34536)
-* [Fix inlined renamed reexports in import lists](https://github.com/rust-lang/rust/pull/34479)
+* [Fix inlined renamed re-exports in import lists](https://github.com/rust-lang/rust/pull/34479)
 * [Fix search result layout for enum variants and struct fields](https://github.com/rust-lang/rust/pull/34477)
 * [Fix issues with source links to external crates](https://github.com/rust-lang/rust/pull/34387)
-* [Fix redirect pages for renamed reexports](https://github.com/rust-lang/rust/pull/34245)
+* [Fix redirect pages for renamed re-exports](https://github.com/rust-lang/rust/pull/34245)
 
 Tooling
 -------
@@ -4988,7 +4988,7 @@ Version 0.10 (2014-04-03)
     * std: The `vec` module has been renamed to `slice`.
     * std: A new vector type, `Vec<T>`, has been added in preparation for DST.
       This will become the only growable vector in the future.
-    * std: `std::io` now has more public-reexports. Types such as `BufferedReader`
+    * std: `std::io` now has more public re-exports. Types such as `BufferedReader`
       are now found at `std::io::BufferedReader` instead of
       `std::io::buffered::BufferedReader`.
     * std: `print` and `println` are no longer in the prelude, the `print!` and
@@ -5079,8 +5079,8 @@ Version 0.10 (2014-04-03)
       * render standalone markdown files.
       * the --test flag tests all code blocks by default.
       * exported macros are displayed.
-      * reexported types have their documentation inlined at the location of the
-        first reexport.
+      * re-exported types have their documentation inlined at the location of the
+        first re-export.
       * search works across crates that have been rendered to the same output
         directory.
 
@@ -5467,7 +5467,7 @@ Version 0.7 (2013-07-03)
         incl. `any`, `all`. removed.
       * std: The `finalize` method of `Drop` renamed to `drop`.
       * std: The `drop` method now takes `&mut self` instead of `&self`.
-      * std: The prelude no longer reexports any modules, only types and traits.
+      * std: The prelude no longer re-exports any modules, only types and traits.
       * std: Prelude additions: `print`, `println`, `FromStr`, `ApproxEq`, `Equiv`,
         `Iterator`, `IteratorUtil`, many numeric traits, many tuple traits.
       * std: New numeric traits: `Fractional`, `Real`, `RealExt`, `Integer`, `Ratio`,

--- a/src/doc/rustdoc/src/the-doc-attribute.md
+++ b/src/doc/rustdoc/src/the-doc-attribute.md
@@ -1,7 +1,7 @@
 # The `#[doc]` attribute
 
 The `#[doc]` attribute lets you control various aspects of how `rustdoc` does
-its job. 
+its job.
 
 The most basic function of `#[doc]` is to handle the actual documentation
 text. That is, `///` is syntax sugar for `#[doc]`. This means that these two
@@ -143,7 +143,7 @@ pub mod bar {
 }
 ```
 
-The documentation will generate a "Reexports" section, and say `pub use bar::Bar;`, where
+The documentation will generate a "Re-exports" section, and say `pub use bar::Bar;`, where
 `Bar` is a link to its page.
 
 If we change the `use` line like this:
@@ -184,7 +184,7 @@ mod bar {
 }
 ```
 
-Now we'll have a `Reexports` line, and `Bar` will not link to anywhere.
+Now we'll have a `Re-exports` line, and `Bar` will not link to anywhere.
 
 ## `#[doc(hidden)]`
 

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! This library, like libcore, is not intended for general usage, but rather as
 //! a building block of other libraries. The types and interfaces in this
-//! library are reexported through the [standard library](../std/index.html),
+//! library are re-exported through the [standard library](../std/index.html),
 //! and should not be used through this library.
 //!
 //! ## Boxed values
@@ -52,7 +52,7 @@
 //! ## Collections
 //!
 //! Implementations of the most common general purpose data structures are
-//! defined in this library. They are reexported through the
+//! defined in this library. They are re-exported through the
 //! [standard collections library](../std/collections/index.html).
 //!
 //! ## Heap interfaces

--- a/src/libcore/prelude/v1.rs
+++ b/src/libcore/prelude/v1.rs
@@ -16,7 +16,7 @@
 
 #![stable(feature = "core_prelude", since = "1.4.0")]
 
-// Reexported core operators
+// Re-exported core operators
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
 pub use marker::{Copy, Send, Sized, Sync};
@@ -24,12 +24,12 @@ pub use marker::{Copy, Send, Sized, Sync};
 #[doc(no_inline)]
 pub use ops::{Drop, Fn, FnMut, FnOnce};
 
-// Reexported functions
+// Re-exported functions
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
 pub use mem::drop;
 
-// Reexported types and traits
+// Re-exported types and traits
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
 pub use clone::Clone;
@@ -55,7 +55,7 @@ pub use option::Option::{self, Some, None};
 #[doc(no_inline)]
 pub use result::Result::{self, Ok, Err};
 
-// Reexported extension traits for primitive types
+// Re-exported extension traits for primitive types
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
 pub use slice::SliceExt;

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -22,7 +22,7 @@
 // a lot of stuff defined here. Let's keep it clean.
 //
 // Since slices don't support inherent methods; all operations
-// on them are defined on traits, which are then reexported from
+// on them are defined on traits, which are then re-exported from
 // the prelude for convenience. So there are a lot of traits here.
 //
 // The layout of this file is thus:

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -2119,7 +2119,7 @@ impl<'a> LoweringContext<'a> {
 
                 // Privatize the degenerate import base, used only to check
                 // the stability of `use a::{};`, to avoid it showing up as
-                // a reexport by accident when `pub`, e.g. in documentation.
+                // a re-export by accident when `pub`, e.g. in documentation.
                 let path = P(self.lower_path(id, &prefix, ParamMode::Explicit, true));
                 *vis = hir::Inherited;
                 hir::ItemUse(path, hir::UseKind::ListStem)

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -127,7 +127,7 @@ declare_lint! {
 declare_lint! {
     pub PUB_USE_OF_PRIVATE_EXTERN_CRATE,
     Deny,
-    "detect public reexports of private extern crates"
+    "detect public re-exports of private extern crates"
 }
 
 declare_lint! {

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -26,9 +26,9 @@ pub enum AccessLevel {
     // public, then type `T` is reachable. Its values can be obtained by other crates
     // even if the type itself is not nameable.
     Reachable,
-    // Public items + items accessible to other crates with help of `pub use` reexports
+    // Public items + items accessible to other crates with help of `pub use` re-exports
     Exported,
-    // Items accessible to other crates directly, without help of reexports
+    // Items accessible to other crates directly, without help of re-exports
     Public,
 }
 

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -702,8 +702,8 @@ impl<'a, 'tcx> CrateMetadata {
                     let vis = self.get_visibility(child_index);
                     let is_import = false;
                     callback(def::Export { def, ident, vis, span, is_import });
-                    // For non-reexport structs and variants add their constructors to children.
-                    // Reexport lists automatically contain constructors when necessary.
+                    // For non-re-export structs and variants add their constructors to children.
+                    // Re-export lists automatically contain constructors when necessary.
                     match def {
                         Def::Struct(..) => {
                             if let Some(ctor_def_id) = self.get_struct_ctor_def_id(child_index) {

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -219,7 +219,7 @@ impl<'a, 'tcx> Visitor<'tcx> for EmbargoVisitor<'a, 'tcx> {
             hir::ItemExternCrate(..) => {}
             // All nested items are checked by visit_item
             hir::ItemMod(..) => {}
-            // Reexports are handled in visit_mod
+            // Re-exports are handled in visit_mod
             hir::ItemUse(..) => {}
             // The interface is empty
             hir::ItemGlobalAsm(..) => {}
@@ -1049,7 +1049,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ObsoleteVisiblePrivateTypesVisitor<'a, 'tcx> {
 
     fn visit_item(&mut self, item: &'tcx hir::Item) {
         match item.node {
-            // contents of a private mod can be reexported, so we need
+            // contents of a private mod can be re-exported, so we need
             // to check internals.
             hir::ItemMod(_) => {}
 

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -683,7 +683,7 @@ impl<'a> Resolver<'a> {
                 let (def, vis) = (binding.def(), binding.vis);
                 self.macro_exports.push(Export { ident, def, vis, span, is_import: true });
             } else {
-                span_err!(self.session, span, E0470, "reexported macro not found");
+                span_err!(self.session, span, E0470, "re-exported macro not found");
             }
         }
         used
@@ -729,7 +729,7 @@ impl<'a> Resolver<'a> {
                 }
             } else if attr.check_name("macro_reexport") {
                 let bad_macro_reexport = |this: &mut Self, span| {
-                    span_err!(this.session, span, E0467, "bad macro reexport");
+                    span_err!(this.session, span, E0467, "bad macro re-export");
                 };
                 if let Some(names) = attr.meta_item_list() {
                     for attr in names {

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -1374,7 +1374,7 @@ arguments.
 "##,
 
 E0467: r##"
-Macro reexport declarations were empty or malformed.
+Macro re-export declarations were empty or malformed.
 
 Erroneous code examples:
 
@@ -1389,12 +1389,12 @@ extern crate core as other_macros_for_good;
 This is a syntax error at the level of attribute declarations.
 
 Currently, `macro_reexport` requires at least one macro name to be listed.
-Unlike `macro_use`, listing no names does not reexport all macros from the
+Unlike `macro_use`, listing no names does not re-export all macros from the
 given crate.
 
 Decide which macros you would like to export and list them properly.
 
-These are proper reexport declarations:
+These are proper re-export declarations:
 
 ```ignore (cannot-doctest-multicrate-project)
 #[macro_reexport(some_macro, another_macro)]
@@ -1475,7 +1475,7 @@ extern crate some_crate; //ok!
 "##,
 
 E0470: r##"
-A macro listed for reexport was not found.
+A macro listed for re-export was not found.
 
 Erroneous code example:
 
@@ -1493,7 +1493,7 @@ exported from the given crate.
 
 This could be caused by a typo. Did you misspell the macro's name?
 
-Double-check the names of the macros listed for reexport, and that the crate
+Double-check the names of the macros listed for re-export, and that the crate
 in question exports them.
 
 A working version:

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2751,7 +2751,7 @@ impl<'a> Resolver<'a> {
                                 let lint = lint::builtin::LEGACY_CONSTRUCTOR_VISIBILITY;
                                 self.session.buffer_lint(lint, id, span,
                                     "private struct constructors are not usable through \
-                                     reexports in outer modules",
+                                     re-exports in outer modules",
                                 );
                                 res = Some(PathResolution::new(ctor_def));
                             }

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -803,8 +803,9 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
         if !any_successful_reexport {
             let (ns, binding) = reexport_error.unwrap();
             if ns == TypeNS && binding.is_extern_crate() {
-                let msg = format!("extern crate `{}` is private, and cannot be reexported \
-                                   (error E0365), consider declaring with `pub`",
+                let msg = format!("extern crate `{}` is private, and cannot be \
+                                   re-exported (error E0365), consider declaring with \
+                                   `pub`",
                                    ident);
                 self.session.buffer_lint(PUB_USE_OF_PRIVATE_EXTERN_CRATE,
                                          directive.id,
@@ -812,12 +813,12 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
                                          &msg);
             } else if ns == TypeNS {
                 struct_span_err!(self.session, directive.span, E0365,
-                                 "`{}` is private, and cannot be reexported", ident)
-                    .span_label(directive.span, format!("reexport of private `{}`", ident))
+                                 "`{}` is private, and cannot be re-exported", ident)
+                    .span_label(directive.span, format!("re-export of private `{}`", ident))
                     .note(&format!("consider declaring type or module `{}` with `pub`", ident))
                     .emit();
             } else {
-                let msg = format!("`{}` is private, and cannot be reexported", ident);
+                let msg = format!("`{}` is private, and cannot be re-exported", ident);
                 let note_msg =
                     format!("consider marking `{}` as `pub` in the imported module", ident);
                 struct_span_err!(self.session, directive.span, E0364, "{}", &msg)
@@ -932,12 +933,12 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
                         !orig_binding.vis.is_at_least(binding.vis, &*self) {
                             let msg = match directive.subclass {
                                 ImportDirectiveSubclass::SingleImport { .. } => {
-                                    format!("variant `{}` is private and cannot be reexported",
+                                    format!("variant `{}` is private and cannot be re-exported",
                                             ident)
                                 },
                                 ImportDirectiveSubclass::GlobImport { .. } => {
                                     let msg = "enum is private and its variants \
-                                               cannot be reexported".to_owned();
+                                               cannot be re-exported".to_owned();
                                     let error_id = (DiagnosticMessageId::ErrorId(0), // no code?!
                                                     Some(binding.span),
                                                     msg.clone());

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -46,8 +46,8 @@ pub enum ImportDirectiveSubclass<'a> {
     },
     GlobImport {
         is_prelude: bool,
-        max_vis: Cell<ty::Visibility>, // The visibility of the greatest reexport.
-        // n.b. `max_vis` is only used in `finalize_import` to check for reexport errors.
+        max_vis: Cell<ty::Visibility>, // The visibility of the greatest re-export.
+        // n.b. `max_vis` is only used in `finalize_import` to check for re-export errors.
     },
     ExternCrate(Option<Name>),
     MacroUse,
@@ -877,7 +877,7 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
         self.record_def(directive.id, PathResolution::new(module.def().unwrap()));
     }
 
-    // Miscellaneous post-processing, including recording reexports,
+    // Miscellaneous post-processing, including recording re-exports,
     // reporting conflicts, and reporting unresolved imports.
     fn finalize_resolutions_in(&mut self, module: Module<'b>) {
         // Since import resolution is finished, globs will not define any more names.

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -82,9 +82,9 @@ pub fn try_inline(cx: &DocContext, def: Def, name: ast::Name)
             ret.extend(build_impls(cx, did));
             clean::ForeignTypeItem
         }
-        // Never inline enum variants but leave them shown as reexports.
+        // Never inline enum variants but leave them shown as re-exports.
         Def::Variant(..) => return None,
-        // Assume that enum variants and struct types are reexported next to
+        // Assume that enum variants and struct types are re-exported next to
         // their constructors.
         Def::VariantCtor(..) |
         Def::StructCtor(..) => return Some(Vec::new()),
@@ -365,7 +365,7 @@ fn build_module(cx: &DocContext, did: DefId) -> clean::Module {
     };
 
     fn fill_in(cx: &DocContext, did: DefId, items: &mut Vec<clean::Item>) {
-        // If we're reexporting a reexport it may actually reexport something in
+        // If we're re-exporting a re-export it may actually re-export something in
         // two namespaces, so the target may be listed twice. Make sure we only
         // visit each node at most once.
         let mut visited = FxHashSet();

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1286,9 +1286,9 @@ impl DocFolder for Cache {
             clean::ConstantItem(..) | clean::StaticItem(..) |
             clean::UnionItem(..) | clean::ForeignTypeItem
             if !self.stripped_mod => {
-                // Reexported items mean that the same id can show up twice
+                // Re-exported items mean that the same id can show up twice
                 // in the rustdoc ast that we're looking at. We know,
-                // however, that a reexported item doesn't show up in the
+                // however, that a re-exported item doesn't show up in the
                 // `public_items` map, so we can skip inserting into the
                 // paths map if there was already an entry present and we're
                 // not a public item.
@@ -1545,7 +1545,7 @@ impl Context {
     {
         // Stripped modules survive the rustdoc passes (i.e. `strip-private`)
         // if they contain impls for public types. These modules can also
-        // contain items such as publicly reexported structures.
+        // contain items such as publicly re-exported structures.
         //
         // External crates will provide links to these structures, so
         // these modules are recursed into, but not rendered normally
@@ -2008,7 +2008,7 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
     if cx.shared.sort_modules_alphabetically {
         indices.sort_by(|&i1, &i2| cmp(&items[i1], &items[i2], i1, i2));
     }
-    // This call is to remove reexport duplicates in cases such as:
+    // This call is to remove re-export duplicates in cases such as:
     //
     // ```
     // pub mod foo {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2059,7 +2059,7 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
             curty = myty;
             let (short, name) = match myty.unwrap() {
                 ItemType::ExternCrate |
-                ItemType::Import          => ("reexports", "Reexports"),
+                ItemType::Import          => ("reexports", "Re-exports"),
                 ItemType::Module          => ("modules", "Modules"),
                 ItemType::Struct          => ("structs", "Structs"),
                 ItemType::Union           => ("unions", "Unions"),
@@ -3959,7 +3959,7 @@ fn sidebar_module(fmt: &mut fmt::Formatter, _it: &clean::Item,
                              it.type_() == ItemType::Import) {
         sidebar.push_str(&format!("<li><a href=\"#{id}\">{name}</a></li>",
                                   id = "reexports",
-                                  name = "Reexports"));
+                                  name = "Re-exports"));
     }
 
     // ordering taken from item_module, reorder, where it prioritized elements in a certain order
@@ -3972,7 +3972,7 @@ fn sidebar_module(fmt: &mut fmt::Formatter, _it: &clean::Item,
         if items.iter().any(|it| !it.is_stripped() && it.type_() == myty) {
             let (short, name) = match myty {
                 ItemType::ExternCrate |
-                ItemType::Import          => ("reexports", "Reexports"),
+                ItemType::Import          => ("reexports", "Re-exports"),
                 ItemType::Module          => ("modules", "Modules"),
                 ItemType::Struct          => ("structs", "Structs"),
                 ItemType::Union           => ("unions", "Unions"),

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -55,7 +55,7 @@ pub struct RustdocVisitor<'a, 'tcx: 'a> {
 impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
     pub fn new(cstore: &'tcx CrateStore,
                cx: &'a core::DocContext<'a, 'tcx>) -> RustdocVisitor<'a, 'tcx> {
-        // If the root is reexported, terminate all recursion.
+        // If the root is re-exported, terminate all recursion.
         let mut stack = FxHashSet();
         stack.insert(ast::CRATE_NODE_ID);
         RustdocVisitor {
@@ -214,7 +214,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                     let imported_from = self.cx.tcx.original_crate_name(def_id.krate);
                     let def = match self.cstore.load_macro_untracked(def_id, self.cx.sess()) {
                         LoadedMacro::MacroDef(macro_def) => macro_def,
-                        // FIXME(jseyfried): document proc macro reexports
+                        // FIXME(jseyfried): document proc macro re-exports
                         LoadedMacro::ProcMacro(..) => continue,
                     };
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -351,9 +351,9 @@ use prelude::v1::*;
 #[cfg(test)] extern crate test;
 #[cfg(test)] extern crate rand;
 
-// We want to reexport a few macros from core but libcore has already been
+// We want to re-export a few macros from core but libcore has already been
 // imported by the compiler (via our #[no_std] attribute) In this case we just
-// add a new crate name so we can attach the reexports to it.
+// add a new crate name so we can attach the re-exports to it.
 #[macro_reexport(assert, assert_eq, assert_ne, debug_assert, debug_assert_eq,
                  debug_assert_ne, unreachable, unimplemented, write, writeln, try)]
 extern crate core as __core;
@@ -390,7 +390,7 @@ mod macros;
 // The Rust prelude
 pub mod prelude;
 
-// Public module declarations and reexports
+// Public module declarations and re-exports
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::any;
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/prelude/mod.rs
+++ b/src/libstd/prelude/mod.rs
@@ -52,7 +52,7 @@
 //! # Prelude contents
 //!
 //! The current version of the prelude (version 1) lives in
-//! [`std::prelude::v1`], and reexports the following.
+//! [`std::prelude::v1`], and re-exports the following.
 //!
 //! * [`std::marker`]::{[`Copy`], [`Send`], [`Sized`], [`Sync`]}. The marker
 //!   traits indicate fundamental properties of types.

--- a/src/libstd/prelude/v1.rs
+++ b/src/libstd/prelude/v1.rs
@@ -14,17 +14,17 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-// Reexported core operators
+// Re-exported core operators
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)] pub use marker::{Copy, Send, Sized, Sync};
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)] pub use ops::{Drop, Fn, FnMut, FnOnce};
 
-// Reexported functions
+// Re-exported functions
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)] pub use mem::drop;
 
-// Reexported types and traits
+// Re-exported types and traits
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)] pub use boxed::Box;
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/rt.rs
+++ b/src/libstd/rt.rs
@@ -23,7 +23,7 @@
 #![doc(hidden)]
 
 
-// Reexport some of our utilities which are expected by other crates.
+// Re-export some of our utilities which are expected by other crates.
 pub use panicking::{begin_panic, begin_panic_fmt, update_panic_count};
 
 // To reduce the generated code of the new `lang_start`, this function is doing

--- a/src/libstd_unicode/char.rs
+++ b/src/libstd_unicode/char.rs
@@ -33,7 +33,7 @@ use core::iter::FusedIterator;
 use core::fmt::{self, Write};
 use tables::{conversions, derived_property, general_category, property};
 
-// stable reexports
+// stable re-exports
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::char::{MAX, from_digit, from_u32, from_u32_unchecked};
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -41,7 +41,7 @@ pub use core::char::{EscapeDebug, EscapeDefault, EscapeUnicode};
 #[stable(feature = "char_from_str", since = "1.20.0")]
 pub use core::char::ParseCharError;
 
-// unstable reexports
+// unstable re-exports
 #[unstable(feature = "try_from", issue = "33417")]
 pub use core::char::CharTryFromError;
 #[unstable(feature = "decode_utf8", issue = "33906")]

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -17,7 +17,7 @@ use ext::base::ExtCtxt;
 use ptr::P;
 use symbol::{Symbol, keywords};
 
-// Transitional reexports so qquote can find the paths it is looking for
+// Transitional re-exports so qquote can find the paths it is looking for
 mod syntax {
     pub use ext;
     pub use parse;

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -1479,7 +1479,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
             ast::ItemKind::ExternCrate(_) => {
                 if let Some(attr) = attr::find_by_name(&i.attrs[..], "macro_reexport") {
                     gate_feature_post!(&self, macro_reexport, attr.span,
-                                       "macros reexports are experimental \
+                                       "macros re-exports are experimental \
                                         and possibly buggy");
                 }
             }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -155,7 +155,7 @@ declare_features! (
     // OIBIT specific features
     (active, optin_builtin_traits, "1.0.0", Some(13231)),
 
-    // macro reexport needs more discussion and stabilization
+    // macro re-export needs more discussion and stabilization
     (active, macro_reexport, "1.0.0", Some(29638)),
 
     // Allows use of #[staged_api]

--- a/src/test/compile-fail-fulldeps/gated-macro-reexports.rs
+++ b/src/test/compile-fail-fulldeps/gated-macro-reexports.rs
@@ -16,6 +16,6 @@
 #![crate_type = "dylib"]
 
 #[macro_reexport(reexported)]
-//~^ ERROR macros reexports are experimental and possibly buggy
+//~^ ERROR macros re-exports are experimental and possibly buggy
 #[macro_use] #[no_link]
 extern crate macro_reexport_1;

--- a/src/test/compile-fail-fulldeps/gated-macro-reexports.rs
+++ b/src/test/compile-fail-fulldeps/gated-macro-reexports.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test that macro reexports item are gated by `macro_reexport` feature gate.
+// Test that macro re-exports item are gated by `macro_reexport` feature gate.
 
 // aux-build:macro_reexport_1.rs
 // gate-test-macro_reexport

--- a/src/test/compile-fail/E0365.rs
+++ b/src/test/compile-fail/E0365.rs
@@ -13,6 +13,6 @@ mod foo {
 }
 
 pub use foo as foo2;
-//~^ ERROR `foo` is private, and cannot be reexported [E0365]
+//~^ ERROR `foo` is private, and cannot be re-exported [E0365]
 
 fn main() {}

--- a/src/test/compile-fail/auxiliary/static_priv_by_default.rs
+++ b/src/test/compile-fail/auxiliary/static_priv_by_default.rs
@@ -32,7 +32,7 @@ mod foo {
         fn foo() {}
     }
 
-    // these are public so the parent can reexport them.
+    // these are public so the parent can re-export them.
     pub static reexported_a: isize = 0;
     pub fn reexported_b() {}
     pub struct reexported_c;

--- a/src/test/compile-fail/imports/reexports.rs
+++ b/src/test/compile-fail/imports/reexports.rs
@@ -13,7 +13,7 @@ mod a {
     mod foo {}
 
     mod a {
-        pub use super::foo; //~ ERROR cannot be reexported
+        pub use super::foo; //~ ERROR cannot be re-exported
         pub use super::*; //~ ERROR must import something with the glob's visibility
     }
 }
@@ -24,17 +24,17 @@ mod b {
 
     pub mod a {
         pub use super::foo; // This is OK since the value `foo` is visible enough.
-        fn f(_: foo::S) {} // `foo` is imported in the type namespace (but not `pub` reexported).
+        fn f(_: foo::S) {} // `foo` is imported in the type namespace (but not `pub` re-exported).
     }
 
     pub mod b {
         pub use super::*; // This is also OK since the value `foo` is visible enough.
-        fn f(_: foo::S) {} // Again, the module `foo` is imported (but not `pub` reexported).
+        fn f(_: foo::S) {} // Again, the module `foo` is imported (but not `pub` re-exported).
     }
 }
 
 mod c {
-    // Test that `foo` is not reexported.
+    // Test that `foo` is not re-exported.
     use b::a::foo::S; //~ ERROR `foo`
     use b::b::foo::S as T; //~ ERROR `foo`
 }

--- a/src/test/compile-fail/issue-46209-private-enum-variant-reexport.rs
+++ b/src/test/compile-fail/issue-46209-private-enum-variant-reexport.rs
@@ -12,14 +12,14 @@
 
 mod rank {
     pub use self::Professor::*;
-    //~^ ERROR enum is private and its variants cannot be reexported
+    //~^ ERROR enum is private and its variants cannot be re-exported
     pub use self::Lieutenant::{JuniorGrade, Full};
-    //~^ ERROR variant `JuniorGrade` is private and cannot be reexported
-    //~| ERROR variant `Full` is private and cannot be reexported
+    //~^ ERROR variant `JuniorGrade` is private and cannot be re-exported
+    //~| ERROR variant `Full` is private and cannot be re-exported
     pub use self::PettyOfficer::*;
-    //~^ ERROR enum is private and its variants cannot be reexported
+    //~^ ERROR enum is private and its variants cannot be re-exported
     pub use self::Crewman::*;
-    //~^ ERROR enum is private and its variants cannot be reexported
+    //~^ ERROR enum is private and its variants cannot be re-exported
 
     enum Professor {
         Adjunct,

--- a/src/test/compile-fail/lint-unused-extern-crate.rs
+++ b/src/test/compile-fail/lint-unused-extern-crate.rs
@@ -20,7 +20,7 @@
 
 extern crate lint_unused_extern_crate5; //~ ERROR: unused extern crate
 
-pub extern crate lint_unused_extern_crate4; // no error, it is reexported
+pub extern crate lint_unused_extern_crate4; // no error, it is re-exported
 
 extern crate lint_unused_extern_crate3; // no error, it is used
 

--- a/src/test/compile-fail/macro-reexport-malformed-1.rs
+++ b/src/test/compile-fail/macro-reexport-malformed-1.rs
@@ -12,5 +12,5 @@
 #![feature(macro_reexport)]
 
 #[allow(unused_extern_crates)]
-#[macro_reexport]  //~ ERROR bad macro reexport
+#[macro_reexport]  //~ ERROR bad macro re-export
 extern crate std;

--- a/src/test/compile-fail/macro-reexport-malformed-2.rs
+++ b/src/test/compile-fail/macro-reexport-malformed-2.rs
@@ -12,5 +12,5 @@
 #![feature(macro_reexport)]
 
 #[allow(unused_extern_crates)]
-#[macro_reexport="foo"]  //~ ERROR bad macro reexport
+#[macro_reexport="foo"]  //~ ERROR bad macro re-export
 extern crate std;

--- a/src/test/compile-fail/macro-reexport-malformed-3.rs
+++ b/src/test/compile-fail/macro-reexport-malformed-3.rs
@@ -12,5 +12,5 @@
 #![feature(macro_reexport)]
 
 #[allow(unused_extern_crates)]
-#[macro_reexport(foo="bar")]  //~ ERROR bad macro reexport
+#[macro_reexport(foo="bar")]  //~ ERROR bad macro re-export
 extern crate std;

--- a/src/test/compile-fail/macro-reexport-undef.rs
+++ b/src/test/compile-fail/macro-reexport-undef.rs
@@ -13,7 +13,7 @@
 #![feature(macro_reexport)]
 
 #[macro_use(macro_two)]
-#[macro_reexport(no_way)] //~ ERROR reexported macro not found
+#[macro_reexport(no_way)] //~ ERROR re-exported macro not found
 extern crate two_macros;
 
 pub fn main() {

--- a/src/test/compile-fail/privacy/legacy-ctor-visibility.rs
+++ b/src/test/compile-fail/privacy/legacy-ctor-visibility.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-tidy-linelength
+
 #![allow(unused)]
 
 use m::S;
@@ -19,7 +21,7 @@ mod m {
         use S;
         fn f() {
             S(10);
-            //~^ ERROR private struct constructors are not usable through reexports in outer modules
+            //~^ ERROR private struct constructors are not usable through re-exports in outer modules
             //~| WARN this was previously accepted
         }
     }

--- a/src/test/compile-fail/privacy/restricted/test.rs
+++ b/src/test/compile-fail/privacy/restricted/test.rs
@@ -28,7 +28,7 @@ mod foo {
     fn f() {
         use foo::bar::S;
         pub(self) use foo::bar::f; // ok
-        pub(super) use foo::bar::f as g; //~ ERROR cannot be reexported
+        pub(super) use foo::bar::f as g; //~ ERROR cannot be re-exported
         S::default().x; // ok
         S::default().f(); // ok
         S::g(); // ok

--- a/src/test/compile-fail/private-variant-reexport.rs
+++ b/src/test/compile-fail/private-variant-reexport.rs
@@ -9,19 +9,19 @@
 // except according to those terms.
 
 mod m1 {
-    pub use ::E::V; //~ ERROR variant `V` is private and cannot be reexported
+    pub use ::E::V; //~ ERROR variant `V` is private and cannot be re-exported
 }
 
 mod m2 {
-    pub use ::E::{V}; //~ ERROR variant `V` is private and cannot be reexported
+    pub use ::E::{V}; //~ ERROR variant `V` is private and cannot be re-exported
 }
 
 mod m3 {
-    pub use ::E::V::{self}; //~ ERROR variant `V` is private and cannot be reexported
+    pub use ::E::V::{self}; //~ ERROR variant `V` is private and cannot be re-exported
 }
 
 mod m4 {
-    pub use ::E::*; //~ ERROR enum is private and its variants cannot be reexported
+    pub use ::E::*; //~ ERROR enum is private and its variants cannot be re-exported
 }
 
 enum E { V }

--- a/src/test/compile-fail/pub-reexport-priv-extern-crate.rs
+++ b/src/test/compile-fail/pub-reexport-priv-extern-crate.rs
@@ -11,7 +11,7 @@
 #![allow(unused)]
 
 extern crate core;
-pub use core as reexported_core; //~ ERROR `core` is private, and cannot be reexported
+pub use core as reexported_core; //~ ERROR `core` is private, and cannot be re-exported
                                  //~^ WARN this was previously accepted
 
 mod foo1 {
@@ -19,7 +19,7 @@ mod foo1 {
 }
 
 mod foo2 {
-    use foo1::core; //~ ERROR `core` is private, and cannot be reexported
+    use foo1::core; //~ ERROR `core` is private, and cannot be re-exported
                     //~^ WARN this was previously accepted
     pub mod bar {
         extern crate core;
@@ -27,7 +27,7 @@ mod foo2 {
 }
 
 mod baz {
-    pub use foo2::bar::core; //~ ERROR `core` is private, and cannot be reexported
+    pub use foo2::bar::core; //~ ERROR `core` is private, and cannot be re-exported
                              //~^ WARN this was previously accepted
 }
 

--- a/src/test/run-make/type-mismatch-same-crate-name/crateC.rs
+++ b/src/test/run-make/type-mismatch-same-crate-name/crateC.rs
@@ -18,7 +18,7 @@
 // compile-fail/type-mismatch-same-crate-name.rs
 // but deals with the case where one of the crates
 // is only introduced as an indirect dependency.
-// and the type is accessed via a reexport.
+// and the type is accessed via a re-export.
 // This is similar to how the error can be introduced
 // when using cargo's automatic dependency resolution.
 

--- a/src/test/run-pass/unboxed-closures-prelude.rs
+++ b/src/test/run-pass/unboxed-closures-prelude.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Tests that the reexports of `FnOnce` et al from the prelude work.
+// Tests that the re-exports of `FnOnce` et al from the prelude work.
 
 // pretty-expanded FIXME #23616
 

--- a/src/test/rustdoc/inline_cross/auxiliary/rustdoc-nonreachable-impls.rs
+++ b/src/test/rustdoc/inline_cross/auxiliary/rustdoc-nonreachable-impls.rs
@@ -36,7 +36,7 @@ pub mod hidden {
     pub struct Wobble;
 
 
-    // these should only be shown if they're reexported correctly
+    // these should only be shown if they're re-exported correctly
     impl Qux for ::Foo {}
     impl Qux for Wobble {}
     impl ::Bark for Wobble {}

--- a/src/test/ui/issue-46112.rs
+++ b/src/test/ui/issue-46112.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Issue 46112: An extern crate pub reexporting libcore was causing
+// Issue 46112: An extern crate pub re-exporting libcore was causing
 // paths rooted from `std` to be misrendered in the diagnostic output.
 
 // ignore-windows


### PR DESCRIPTION
While working on the book with our editors, it was brought to our attention that we're not consistent with when we use "re-export" versus "reexport". For the book, we've decided (with our editors) to go with "re-export"; in prose, I think that looks better. In code, I'm fine with "reexport".

However, the rustdoc generated section is currently "Reexports", so when we have a screenshot of generated documentation with the prose where we use "re-export", it's inconsistent.

It's too late to fix this for the book because we're using 1.21.0 for the output in the book, and it's really only one spot so it's not a huge deal, but I'd like to advocate for changing the documentation header so that a future edition of the book can be consistent.

The first commit here only changes the documentation section heading text and rustdoc documentation that references it. This is the commit that's most important to me.

The second commit changes error messages and associated tests to also be consistent with the use of re-export. This is the next most important commit to me, but I could be argued out of this one because then it won't match code like the `macro_reexports` feature name, which ostensibly should change to `macro_re_exports` to be most consistent but I didn't want to change code.

The last commit changes re-export anywhere else in prose: either in documentation comments or regular comments. This is least important as most of them aren't user-visible. Instances like these will likely sneak back in over time. I'm totally fine dropping this commit if anyone wants, but [the hobgoblins made me do it](http://www.bartleby.com/100/420.47.html) and it sets a good example.

r? @steveklabnik 