### PR TITLE
Don't promote to 'static the result of dereferences.

### DIFF
--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -491,9 +491,10 @@ impl<'a, 'tcx> Visitor<'tcx> for Qualifier<'a, 'tcx, 'tcx> {
                                 this.add(Qualif::STATIC);
                             }
 
+                            this.add(Qualif::NOT_CONST);
+
                             let base_ty = proj.base.ty(this.mir, this.tcx).to_ty(this.tcx);
                             if let ty::TyRawPtr(_) = base_ty.sty {
-                                this.add(Qualif::NOT_CONST);
                                 if this.mode != Mode::Fn {
                                     struct_span_err!(this.tcx.sess,
                                         this.span, E0396,
@@ -570,7 +571,38 @@ impl<'a, 'tcx> Visitor<'tcx> for Qualifier<'a, 'tcx, 'tcx> {
 
     fn visit_rvalue(&mut self, rvalue: &Rvalue<'tcx>, location: Location) {
         // Recurse through operands and places.
-        self.super_rvalue(rvalue, location);
+        if let Rvalue::Ref(region, kind, ref place) = *rvalue {
+            let mut is_reborrow = false;
+            if let Place::Projection(ref proj) = *place {
+                if let ProjectionElem::Deref = proj.elem {
+                    let base_ty = proj.base.ty(self.mir, self.tcx).to_ty(self.tcx);
+                    if let ty::TyRef(..) = base_ty.sty {
+                        is_reborrow = true;
+                    }
+                }
+            }
+
+            if is_reborrow {
+                self.nest(|this| {
+                    this.super_place(place, PlaceContext::Borrow {
+                        region,
+                        kind
+                    }, location);
+                    if !this.try_consume() {
+                        return;
+                    }
+
+                    if this.qualif.intersects(Qualif::STATIC_REF) {
+                        this.qualif = this.qualif - Qualif::STATIC_REF;
+                        this.add(Qualif::STATIC);
+                    }
+                });
+            } else {
+                self.super_rvalue(rvalue, location);
+            }
+        } else {
+            self.super_rvalue(rvalue, location);
+        }
 
         match *rvalue {
             Rvalue::Use(_) |

--- a/src/librustc_passes/consts.rs
+++ b/src/librustc_passes/consts.rs
@@ -352,14 +352,9 @@ fn check_expr<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>, e: &hir::Expr, node
         hir::ExprBox(_) => {
             v.promotable = false;
         }
-        hir::ExprUnary(op, ref inner) => {
-            match v.tables.node_id_to_type(inner.hir_id).sty {
-                ty::TyRawPtr(_) => {
-                    assert!(op == hir::UnDeref);
-
-                    v.promotable = false;
-                }
-                _ => {}
+        hir::ExprUnary(op, _) => {
+            if op == hir::UnDeref {
+                v.promotable = false;
             }
         }
         hir::ExprBinary(op, ref lhs, _) => {
@@ -548,7 +543,8 @@ fn check_expr<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>, e: &hir::Expr, node
 fn check_adjustments<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>, e: &hir::Expr) {
     use rustc::ty::adjustment::*;
 
-    for adjustment in v.tables.expr_adjustments(e) {
+    let mut adjustments = v.tables.expr_adjustments(e).iter().peekable();
+    while let Some(adjustment) = adjustments.next() {
         match adjustment.kind {
             Adjust::NeverToAny |
             Adjust::ReifyFnPointer |
@@ -558,11 +554,14 @@ fn check_adjustments<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>, e: &hir::Exp
             Adjust::Borrow(_) |
             Adjust::Unsize => {}
 
-            Adjust::Deref(ref overloaded) => {
-                if overloaded.is_some() {
-                    v.promotable = false;
-                    break;
+            Adjust::Deref(_) => {
+                if let Some(next_adjustment) = adjustments.peek() {
+                    if let Adjust::Borrow(_) = next_adjustment.kind {
+                        continue;
+                    }
                 }
+                v.promotable = false;
+                break;
             }
         }
     }


### PR DESCRIPTION
This is a **breaking change**, removing copies out of dereferences from rvalue-to-`'static` promotion.

With miri we won't easily know whether the dereference itself would see the same value at runtime as miri (e.g. after mutating a `static`) or even if it can be interpreted (e.g. integer pointers).
One alternative to this ban is defining at least *some* of those situations as UB, i.e. you shouldn't have a reference in the first place, and you should work through raw pointers instead, to avoid promotion.

**EDIT**: The other *may seem* to be to add some analysis which whitelists references-to-constant-values and assume any values produced by arbitrary computation to not be safe to promote dereferences thereof - but that means producing a reference from an associated constant or `const fn` would necessarily obscure it, and in the former case, this could still impact code that runs on stable today. What we do today to track "references to statics" only works because we restrict taking a reference to a `static` at all to other `static`s (which, again, are currently limited in that they can't be read at compile-time) and to runtime-only `fn`s (*not* `const fn`s).

I'm primarily opening this PR with a conservative first approximation (e.g. `&(*r).a` is not allowed, only reborrows are, and in the old borrow only implicit ones from adjustments, at that) for cratering.

r? @nikomatsakis 