### PR TITLE
Extend macro name suggestion span

### DIFF
--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -36,7 +36,7 @@ use syntax::ptr::P;
 use syntax::symbol::{Symbol, keywords};
 use syntax::tokenstream::{TokenStream, TokenTree, Delimited};
 use syntax::util::lev_distance::find_best_match_for_name;
-use syntax_pos::{Span, DUMMY_SP};
+use syntax_pos::{Span, DUMMY_SP, BytePos};
 
 use std::cell::Cell;
 use std::mem;
@@ -691,7 +691,10 @@ impl<'a> Resolver<'a> {
         if let Some(suggestion) = suggestion {
             if suggestion != name {
                 if let MacroKind::Bang = kind {
-                    err.span_suggestion(span, "you could try the macro",
+                    // Our suggested replacement includes the macro's bang. Extend the span by one
+                    // byte to ensure it does as well.
+                    let span_with_bang = span.with_hi(span.hi() + BytePos(1));
+                    err.span_suggestion(span_with_bang, "you could try the macro",
                                         format!("{}!", suggestion));
                 } else {
                     err.span_suggestion(span, "try", suggestion.to_string());

--- a/src/test/ui/macros/macro-name-typo.stderr
+++ b/src/test/ui/macros/macro-name-typo.stderr
@@ -2,7 +2,9 @@ error: cannot find macro `printlx!` in this scope
   --> $DIR/macro-name-typo.rs:12:5
    |
 12 |     printlx!("oh noes!"); //~ ERROR cannot find
-   |     ^^^^^^^ help: you could try the macro: `println!`
+   |     ^^^^^^^-
+   |     |
+   |     help: you could try the macro: `println!`
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/macro_undefined.stderr
+++ b/src/test/ui/macros/macro_undefined.stderr
@@ -10,7 +10,9 @@ error: cannot find macro `k!` in this scope
   --> $DIR/macro_undefined.rs:21:5
    |
 21 |     k!(); //~ ERROR cannot find
-   |     ^ help: you could try the macro: `kl!`
+   |     ^-
+   |     |
+   |     help: you could try the macro: `kl!`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
When we suggest the replacement for a macro we include the "!" in the suggested replacement but the span only contains the name of the macro itself. Using that replacement would cause a duplicate "!" in the resulting code.

Fix by extending the suggestion's span by one byte to include the "!". The error span itself still only includes the macro's name.

Fixes #47418