### PR TITLE
Properly pass down immutability info for thread-locals.

### DIFF
--- a/src/test/compile-fail/nll/constant-thread-locals-issue-47053.rs
+++ b/src/test/compile-fail/nll/constant-thread-locals-issue-47053.rs
@@ -1,0 +1,21 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for issue #47053
+
+#![feature(nll)]
+#![feature(thread_local)]
+
+#[thread_local]
+static FOO: isize = 5;
+
+fn main() {
+    FOO = 6; //~ ERROR cannot assign to immutable item `FOO` [E0594]
+}


### PR DESCRIPTION
For thread-locals we call into cat_rvalue_node() to create a CMT
(Category, Mutability, Type) that always has McDeclared. This is
incorrect for thread-locals that don't have the 'mut' keyword; we should
use McImmutable there.

Extend cat_rvalue_node() to have an additional mutability parameter. Fix
up all the callers to make use of that function. Also extend one of the
existing unit tests to cover this.

Fixes: #47053