### PR TITLE
rustc_trans: ignore trailing padding larger than 8 bytes.

### DIFF
--- a/src/librustc_trans/cabi_x86_64.rs
+++ b/src/librustc_trans/cabi_x86_64.rs
@@ -179,12 +179,12 @@ fn cast_target(cls: &[Class], size: Size) -> CastTarget {
     let mut i = 0;
     let lo = reg_component(cls, &mut i, size).unwrap();
     let offset = Size::from_bytes(8) * (i as u64);
-    let target = if size <= offset {
-        CastTarget::from(lo)
-    } else {
-        let hi = reg_component(cls, &mut i, size - offset).unwrap();
-        CastTarget::Pair(lo, hi)
-    };
+    let mut target = CastTarget::from(lo);
+    if size > offset {
+        if let Some(hi) = reg_component(cls, &mut i, size - offset) {
+            target = CastTarget::Pair(lo, hi);
+        }
+    }
     assert_eq!(reg_component(cls, &mut i, Size::from_bytes(0)), None);
     target
 }

--- a/src/test/run-pass/align-with-extern-c-fn.rs
+++ b/src/test/run-pass/align-with-extern-c-fn.rs
@@ -14,10 +14,10 @@
 #![feature(attr_literals)]
 
 #[repr(align(16))]
-pub struct A {
-    y: i64,
-}
+pub struct A(i64);
 
 pub extern "C" fn foo(x: A) {}
 
-fn main() {}
+fn main() {
+    foo(A(0));
+}


### PR DESCRIPTION
Fixes #45662 by ignoring a missing second register component, as it could be entirely padding.