### PR TITLE
Don't include bang in macro replacement suggestion

### DIFF
--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -691,8 +691,7 @@ impl<'a> Resolver<'a> {
         if let Some(suggestion) = suggestion {
             if suggestion != name {
                 if let MacroKind::Bang = kind {
-                    err.span_suggestion(span, "you could try the macro",
-                                        format!("{}!", suggestion));
+                    err.span_suggestion(span, "you could try the macro", suggestion.to_string());
                 } else {
                     err.span_suggestion(span, "try", suggestion.to_string());
                 }

--- a/src/test/ui-fulldeps/resolve-error.stderr
+++ b/src/test/ui-fulldeps/resolve-error.stderr
@@ -38,13 +38,13 @@ error: cannot find macro `FooWithLongNama!` in this scope
   --> $DIR/resolve-error.rs:62:5
    |
 62 |     FooWithLongNama!();
-   |     ^^^^^^^^^^^^^^^ help: you could try the macro: `FooWithLongNam!`
+   |     ^^^^^^^^^^^^^^^ help: you could try the macro: `FooWithLongNam`
 
 error: cannot find macro `attr_proc_macra!` in this scope
   --> $DIR/resolve-error.rs:65:5
    |
 65 |     attr_proc_macra!();
-   |     ^^^^^^^^^^^^^^^ help: you could try the macro: `attr_proc_mac!`
+   |     ^^^^^^^^^^^^^^^ help: you could try the macro: `attr_proc_mac`
 
 error: cannot find macro `Dlona!` in this scope
   --> $DIR/resolve-error.rs:68:5
@@ -56,7 +56,7 @@ error: cannot find macro `bang_proc_macrp!` in this scope
   --> $DIR/resolve-error.rs:71:5
    |
 71 |     bang_proc_macrp!();
-   |     ^^^^^^^^^^^^^^^ help: you could try the macro: `bang_proc_macro!`
+   |     ^^^^^^^^^^^^^^^ help: you could try the macro: `bang_proc_macro`
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/macros/macro-name-typo.stderr
+++ b/src/test/ui/macros/macro-name-typo.stderr
@@ -2,7 +2,7 @@ error: cannot find macro `printlx!` in this scope
   --> $DIR/macro-name-typo.rs:12:5
    |
 12 |     printlx!("oh noes!"); //~ ERROR cannot find
-   |     ^^^^^^^ help: you could try the macro: `println!`
+   |     ^^^^^^^ help: you could try the macro: `println`
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/macro_undefined.stderr
+++ b/src/test/ui/macros/macro_undefined.stderr
@@ -10,7 +10,7 @@ error: cannot find macro `k!` in this scope
   --> $DIR/macro_undefined.rs:21:5
    |
 21 |     k!(); //~ ERROR cannot find
-   |     ^ help: you could try the macro: `kl!`
+   |     ^ help: you could try the macro: `kl`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
When we suggest the replacement for a macro we include the "!" in the suggested replacement but the span only contains the name of the macro itself. Using that replacement would cause a duplicate "!" in the resulting code.

I originally tried to extend the span to be replaced by 1 byte in rust-lang/rust#47424. However, @zackmdavis pointed out that there can be whitespace between the macro name and the bang.

Instead, just remove the bang from the suggested replacement.

Fixes #47418

r? @estebank