### PR TITLE
incr.comp.: Cache type_of and some other queries.

### DIFF
--- a/src/librustc/ty/maps/config.rs
+++ b/src/librustc/ty/maps/config.rs
@@ -662,3 +662,6 @@ impl_disk_cacheable_query!(mir_const_qualif, |def_id| def_id.is_local());
 impl_disk_cacheable_query!(check_match, |def_id| def_id.is_local());
 impl_disk_cacheable_query!(contains_extern_indicator, |_| true);
 impl_disk_cacheable_query!(def_symbol_name, |_| true);
+impl_disk_cacheable_query!(type_of, |def_id| def_id.is_local());
+impl_disk_cacheable_query!(predicates_of, |def_id| def_id.is_local());
+impl_disk_cacheable_query!(used_trait_imports, |def_id| def_id.is_local());

--- a/src/librustc/ty/maps/config.rs
+++ b/src/librustc/ty/maps/config.rs
@@ -617,8 +617,8 @@ impl<'tcx> QueryDescription<'tcx> for queries::optimized_mir<'tcx> {
     }
 
     fn try_load_from_disk<'a>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                          id: SerializedDepNodeIndex)
-                          -> Option<Self::Value> {
+                              id: SerializedDepNodeIndex)
+                              -> Option<Self::Value> {
         let mir: Option<::mir::Mir<'tcx>> = tcx.on_disk_query_result_cache
                                                .try_load_query_result(tcx, id);
         mir.map(|x| tcx.alloc_mir(x))
@@ -634,6 +634,21 @@ impl<'tcx> QueryDescription<'tcx> for queries::substitute_normalize_and_test_pre
 impl<'tcx> QueryDescription<'tcx> for queries::target_features_whitelist<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
         format!("looking up the whitelist of target features")
+    }
+}
+
+impl<'tcx> QueryDescription<'tcx> for queries::generics_of<'tcx> {
+    #[inline]
+    fn cache_on_disk(def_id: Self::Key) -> bool {
+        def_id.is_local()
+    }
+
+    fn try_load_from_disk<'a>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
+                              id: SerializedDepNodeIndex)
+                              -> Option<Self::Value> {
+        let generics: Option<ty::Generics> = tcx.on_disk_query_result_cache
+                                                .try_load_query_result(tcx, id);
+        generics.map(|x| tcx.alloc_generics(x))
     }
 }
 

--- a/src/librustc/ty/maps/on_disk_cache.rs
+++ b/src/librustc/ty/maps/on_disk_cache.rs
@@ -205,6 +205,7 @@ impl<'sess> OnDiskCache<'sess> {
                 let qri = &mut query_result_index;
 
                 encode_query_results::<type_of, _>(tcx, enc, qri)?;
+                encode_query_results::<generics_of, _>(tcx, enc, qri)?;
                 encode_query_results::<predicates_of, _>(tcx, enc, qri)?;
                 encode_query_results::<used_trait_imports, _>(tcx, enc, qri)?;
                 encode_query_results::<typeck_tables_of, _>(tcx, enc, qri)?;

--- a/src/librustc/ty/maps/on_disk_cache.rs
+++ b/src/librustc/ty/maps/on_disk_cache.rs
@@ -204,8 +204,11 @@ impl<'sess> OnDiskCache<'sess> {
                 let enc = &mut encoder;
                 let qri = &mut query_result_index;
 
-                // Encode TypeckTables
+                encode_query_results::<type_of, _>(tcx, enc, qri)?;
+                encode_query_results::<predicates_of, _>(tcx, enc, qri)?;
+                encode_query_results::<used_trait_imports, _>(tcx, enc, qri)?;
                 encode_query_results::<typeck_tables_of, _>(tcx, enc, qri)?;
+                encode_query_results::<trans_fulfill_obligation, _>(tcx, enc, qri)?;
                 encode_query_results::<optimized_mir, _>(tcx, enc, qri)?;
                 encode_query_results::<unsafety_check_result, _>(tcx, enc, qri)?;
                 encode_query_results::<borrowck, _>(tcx, enc, qri)?;
@@ -215,7 +218,6 @@ impl<'sess> OnDiskCache<'sess> {
                 encode_query_results::<const_is_rvalue_promotable_to_static, _>(tcx, enc, qri)?;
                 encode_query_results::<contains_extern_indicator, _>(tcx, enc, qri)?;
                 encode_query_results::<symbol_name, _>(tcx, enc, qri)?;
-                encode_query_results::<trans_fulfill_obligation, _>(tcx, enc, qri)?;
                 encode_query_results::<check_match, _>(tcx, enc, qri)?;
             }
 

--- a/src/librustc/ty/maps/plumbing.rs
+++ b/src/librustc/ty/maps/plumbing.rs
@@ -982,4 +982,7 @@ impl_load_from_cache!(
     ConstIsRvaluePromotableToStatic => const_is_rvalue_promotable_to_static,
     ContainsExternIndicator => contains_extern_indicator,
     CheckMatch => check_match,
+    TypeOfItem => type_of,
+    PredicatesOfItem => predicates_of,
+    UsedTraitImports => used_trait_imports,
 );

--- a/src/librustc/ty/maps/plumbing.rs
+++ b/src/librustc/ty/maps/plumbing.rs
@@ -983,6 +983,7 @@ impl_load_from_cache!(
     ContainsExternIndicator => contains_extern_indicator,
     CheckMatch => check_match,
     TypeOfItem => type_of,
+    GenericsOfItem => generics_of,
     PredicatesOfItem => predicates_of,
     UsedTraitImports => used_trait_imports,
 );

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -17,7 +17,7 @@ pub use self::fold::TypeFoldable;
 
 use hir::{map as hir_map, FreevarMap, TraitMap};
 use hir::def::{Def, CtorKind, ExportMap};
-use hir::def_id::{CrateNum, DefId, DefIndex, LocalDefId, CRATE_DEF_INDEX, LOCAL_CRATE};
+use hir::def_id::{CrateNum, DefId, LocalDefId, CRATE_DEF_INDEX, LOCAL_CRATE};
 use hir::map::DefPathData;
 use hir::svh::Svh;
 use ich::Fingerprint;
@@ -39,7 +39,6 @@ use util::nodemap::{NodeSet, DefIdMap, FxHashMap, FxHashSet};
 
 use serialize::{self, Encodable, Encoder};
 use std::cell::RefCell;
-use std::collections::BTreeMap;
 use std::cmp;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -758,9 +757,8 @@ pub struct Generics {
     pub regions: Vec<RegionParameterDef>,
     pub types: Vec<TypeParameterDef>,
 
-    /// Reverse map to each `TypeParameterDef`'s `index` field, from
-    /// `def_id.index` (`def_id.krate` is the same as the item's).
-    pub type_param_to_index: BTreeMap<DefIndex, u32>,
+    /// Reverse map to each `TypeParameterDef`'s `index` field
+    pub type_param_to_index: FxHashMap<DefId, u32>,
 
     pub has_self: bool,
     pub has_late_bound_regions: Option<Span>,

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -979,7 +979,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
                 let item_id = tcx.hir.get_parent_node(node_id);
                 let item_def_id = tcx.hir.local_def_id(item_id);
                 let generics = tcx.generics_of(item_def_id);
-                let index = generics.type_param_to_index[&tcx.hir.local_def_id(node_id).index];
+                let index = generics.type_param_to_index[&tcx.hir.local_def_id(node_id)];
                 tcx.mk_param(index, tcx.hir.name(node_id))
             }
             Def::SelfTy(_, Some(def_id)) => {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1629,7 +1629,7 @@ impl<'a, 'gcx, 'tcx> AstConv<'gcx, 'tcx> for FnCtxt<'a, 'gcx, 'tcx> {
         let item_id = tcx.hir.ty_param_owner(node_id);
         let item_def_id = tcx.hir.local_def_id(item_id);
         let generics = tcx.generics_of(item_def_id);
-        let index = generics.type_param_to_index[&def_id.index];
+        let index = generics.type_param_to_index[&def_id];
         ty::GenericPredicates {
             parent: None,
             predicates: self.param_env.caller_bounds.iter().filter(|predicate| {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -40,8 +40,6 @@ use util::nodemap::FxHashMap;
 
 use rustc_const_math::ConstInt;
 
-use std::collections::BTreeMap;
-
 use syntax::{abi, ast};
 use syntax::codemap::Spanned;
 use syntax::symbol::{Symbol, keywords};
@@ -240,7 +238,7 @@ fn type_param_predicates<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let param_owner = tcx.hir.ty_param_owner(param_id);
     let param_owner_def_id = tcx.hir.local_def_id(param_owner);
     let generics = tcx.generics_of(param_owner_def_id);
-    let index = generics.type_param_to_index[&def_id.index];
+    let index = generics.type_param_to_index[&def_id];
     let ty = tcx.mk_param(index, tcx.hir.ty_param_name(param_id));
 
     // Don't look for bounds where the type parameter isn't in scope.
@@ -1024,10 +1022,9 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         });
     }
 
-    let mut type_param_to_index = BTreeMap::new();
-    for param in &types {
-        type_param_to_index.insert(param.def_id.index, param.index);
-    }
+    let type_param_to_index = types.iter()
+                                   .map(|param| (param.def_id, param.index))
+                                   .collect();
 
     tcx.alloc_generics(ty::Generics {
         parent: parent_def_id,


### PR DESCRIPTION
Cache some more queries that show up high during profiling. Does not include `generics_of` yet (which profiling shows to also take up quite some time) because the `type_param_to_index` field in there uses raw `DefIndex` values from other crates.

r? @nikomatsakis 