### PR TITLE
remove noop landing pads in cleanup shims

### DIFF
--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -28,7 +28,7 @@ use std::fmt;
 use std::iter;
 
 use transform::{add_moves_for_packed_drops, add_call_guards};
-use transform::{no_landing_pads, simplify};
+use transform::{remove_noop_landing_pads, no_landing_pads, simplify};
 use util::elaborate_drops::{self, DropElaborator, DropStyle, DropFlagMode};
 use util::patch::MirPatch;
 
@@ -118,6 +118,7 @@ fn make_shim<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     add_moves_for_packed_drops::add_moves_for_packed_drops(
         tcx, &mut result, instance.def_id());
     no_landing_pads::no_landing_pads(tcx, &mut result);
+    remove_noop_landing_pads::remove_noop_landing_pads(tcx, &mut result);
     simplify::simplify_cfg(&mut result);
     add_call_guards::CriticalCallEdges.add_call_guards(&mut result);
     debug!("make_shim({:?}) = {:?}", instance, result);

--- a/src/librustc_mir/transform/remove_noop_landing_pads.rs
+++ b/src/librustc_mir/transform/remove_noop_landing_pads.rs
@@ -20,17 +20,24 @@ use util::patch::MirPatch;
 /// code for these.
 pub struct RemoveNoopLandingPads;
 
+pub fn remove_noop_landing_pads<'a, 'tcx>(
+    tcx: TyCtxt<'a, 'tcx, 'tcx>,
+    mir: &mut Mir<'tcx>)
+{
+    if tcx.sess.no_landing_pads() {
+        return
+    }
+    debug!("remove_noop_landing_pads({:?})", mir);
+
+    RemoveNoopLandingPads.remove_nop_landing_pads(mir)
+}
+
 impl MirPass for RemoveNoopLandingPads {
     fn run_pass<'a, 'tcx>(&self,
                           tcx: TyCtxt<'a, 'tcx, 'tcx>,
                           _src: MirSource,
                           mir: &mut Mir<'tcx>) {
-        if tcx.sess.no_landing_pads() {
-            return
-        }
-
-        debug!("remove_noop_landing_pads({:?})", mir);
-        self.remove_nop_landing_pads(mir);
+        remove_noop_landing_pads(tcx, mir);
     }
 }
 

--- a/src/test/codegen/issue-47442.rs
+++ b/src/test/codegen/issue-47442.rs
@@ -1,0 +1,32 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// check that we don't emit unneeded `resume` cleanup blocks for every
+// destructor.
+
+// CHECK-NOT: Unwind
+
+#![feature(test)]
+#![crate_type="rlib"]
+
+extern crate test;
+
+struct Foo {}
+
+impl Drop for Foo {
+    fn drop(&mut self) {
+        test::black_box(());
+    }
+}
+
+#[no_mangle]
+pub fn foo() {
+    let _foo = Foo {};
+}


### PR DESCRIPTION
No-op landing pads are already removed in the normal optimization pipeline - so also removing them on the shim pipeline should slightly improve codegen performance, as these cleanup blocks are known to hurt LLVM.

This un-regresses and is therefore a fix for #47442. However, the reporter of that issue should try using `-C panic=abort` instead of carefully avoiding panics.

r? @eddyb 