### PR TITLE
Add "-lmsvcrt" twice to get rustc to build with the latest mingw64

### DIFF
--- a/src/librustc_back/target/windows_base.rs
+++ b/src/librustc_back/target/windows_base.rs
@@ -59,7 +59,15 @@ pub fn opts() -> TargetOptions {
         "-lmingw32".to_string(),
         "-lgcc".to_string(), // alas, mingw* libraries above depend on libgcc
         "-lmsvcrt".to_string(),
-        "-lmsvcrt".to_string(), // mingw is insane...?
+        // mingw's msvcrt is a weird hybrid import library and static library.
+        // And it seems that the linker fails to use import symbols from msvcrt
+        // that are required from functions in msvcrt in certain cases. For example
+        // `_fmode` that is used by an implementation of `__p__fmode` in x86_64.
+        // Listing the library twice seems to fix that, and seems to also be done
+        // by mingw's gcc (Though not sure if it's done on purpose, or by mistake).
+        //
+        // See https://github.com/rust-lang/rust/pull/47483
+        "-lmsvcrt".to_string(),
         "-luser32".to_string(),
         "-lkernel32".to_string(),
     ]);

--- a/src/librustc_back/target/windows_base.rs
+++ b/src/librustc_back/target/windows_base.rs
@@ -59,6 +59,7 @@ pub fn opts() -> TargetOptions {
         "-lmingw32".to_string(),
         "-lgcc".to_string(), // alas, mingw* libraries above depend on libgcc
         "-lmsvcrt".to_string(),
+        "-lmsvcrt".to_string(), // mingw is insane...?
         "-luser32".to_string(),
         "-lkernel32".to_string(),
     ]);


### PR DESCRIPTION
After updating mingw-w64 in Msys2, I started getting this when doing `./x.py build --stage 1 src/libtest`:
```
error: linking with `gcc` failed: exit code: 1
  |
  = note: "gcc" "-Wl,--enable-long-section-names" "-fno-use-linker-plugin" "-Wl,--nxcompat" "-nostdlib" "-m64" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-sysroot\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\crt2.o" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-sysroot\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\rsbegin.o" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-sysroot\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps\\rustc-b67a4fe646fd8794.rustc0-833528dbd46ff06c3b1f5154abdef2ed.rs.rcgu.o" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps\\rustc-b67a4fe646fd8794.rustc1-833528dbd46ff06c3b1f5154abdef2ed.rs.rcgu.o" "-o" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps\\rustc-b67a4fe646fd8794.exe" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps\\rustc-b67a4fe646fd8794.crate.allocator.rcgu.o" "-Wl,--gc-sections" "-nodefaultlibs" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\release\\deps" "-L" "...\\.cargo\\registry\\src\\github.com-1ecc6299db9ec823\\dbghelp-sys-0.2.0/x86_64" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\build\\miniz-sys-98d83a845f69b3ab\\out" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\build\\rustc_binaryen-f106436b515711ff\\out/build/lib" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\build\\rustc_binaryen-f106436b515711ff\\out" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\build\\rustc_llvm-9a040fa1f1937a67\\out" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\llvm/lib" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-sysroot\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_driver-224d9efe142c632e" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_trans-767a58ff60ff6a03" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_resolve-bcc2d91b756552d1" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_incremental-e93e816231352cc9" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_plugin-8273bd6d564e8657" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_metadata-5537b9a8ab6e6015" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_lint-796681662b9ad8e1" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_passes-9ef6de765e132a7c" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_privacy-2289da126d06c49e" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_llvm-893cdac51017c26f" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_borrowck-ac2009fc1ce58d88" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_mir-d4ce85a1cded4423" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_const_eval-a4e766ec47afde96" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_save_analysis-66d4c41e75392976" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_typeck-4e21db5573af1446" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_platform_intrinsics-f40c4b99b60d15e9" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_allocator-86ef12c8efbcf068" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_trans_utils-8199c3d0e673bb7b" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc-8f435ca07f1a04ff" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-sysroot\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib" "-l" "test-8abb197945b79a6a" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_const_math-fa724350247d1ae6" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_back-838b735c189dd798" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "graphviz-42c69c0ff2aacc5b" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "arena-454325a3f2773bc8" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "syntax_ext-7880c41067f1be05" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "proc_macro-f609718c6b927026" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "syntax-3d2aaf6e201abcfe" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_errors-2c007ffe6a847ed7" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "syntax_pos-067e758dda669d03" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_data_structures-50e5e6db2f34c196" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-sysroot\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib" "-l" "term-9d9f4c10ffba6dd6" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "serialize-e55b4fb27a4d08bf" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "rustc_cratesio_shim-baed94e463835a87" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-rustc\\x86_64-pc-windows-gnu\\release\\deps" "-l" "fmt_macros-3c2cdca7d2f8dd09" "-L" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-sysroot\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib" "-l" "std-b1b09a5d7798628b" "-Wl,-Bstatic" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-sysroot\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\libcompiler_builtins-69f85297d9318c97.rlib" "-Wl,-Bdynamic" "-l" "advapi32" "-l" "ole32" "-l" "oleaut32" "-l" "psapi" "-l" "shell32" "-l" "ole32" "-l" "uuid" "-l" "stdc++" "-l" "gcc_eh" "-l" "pthread" "-l" "psapi" "-l" "dbghelp" "-l" "kernel32" "-l" "advapi32" "-l" "kernel32" "-l" "advapi32" "-l" "ws2_32" "-l" "userenv" "-l" "shell32" "-lmingwex" "-lmingw32" "-lgcc" "-lmsvcrt" "-luser32" "-lkernel32" "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0-sysroot\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\rsend.o"
  = note: rust/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/7.2.0/../../../../x86_64-w64-mingw32/lib/../lib/libmsvcrt.a(lib64_libmsvcrt_os_a-__p__fmode.o):__p__fmode.c:(.rdata$.refptr.__imp__fmode[.refptr.__imp__fmode]+0x0): undefined reference to `__imp__fmode'
          collect2.exe: error: ld returned 1 exit status


error: aborting due to previous error

error: Could not compile `rustc-main`.

Caused by:
  process didn't exit successfully: `rust\msys64\home\...\rust\build\bootstrap/debug/rustc --crate-name rustc rustc\rustc.rs --error-format json --crate-type bin --emit=dep-info,link -C opt-level=2 --cfg feature="jemalloc" --cfg feature="llvm" --cfg feature="rustc_back" --cfg feature="rustc_driver" -C metadata=b67a4fe646fd8794 -C extra-filename=-b67a4fe646fd8794 --out-dir rust\msys64\home\...\rust\build\x86_64-pc-windows-gnu\stage0-rustc\x86_64-pc-windows-gnu\release\deps --target x86_64-pc-windows-gnu -L dependency=rust\msys64\home\...\rust\build\x86_64-pc-windows-gnu\stage0-rustc\x86_64-pc-windows-gnu\release\deps -L dependency=rust\msys64\home\...\rust\build\x86_64-pc-windows-gnu\stage0-rustc\release\deps --extern rustc_back=rust\msys64\home\...\rust\build\x86_64-pc-windows-gnu\stage0-rustc\x86_64-pc-windows-gnu\release\deps\rustc_back-838b735c189dd798.dll --extern rustc_driver=rust\msys64\home\...\rust\build\x86_64-pc-windows-gnu\stage0-rustc\x86_64-pc-windows-gnu\release\deps\rustc_driver-224d9efe142c632e.dll -L native=...\.cargo\registry\src\github.com-1ecc6299db9ec823\dbghelp-sys-0.2.0/x86_64 -L native=rust\msys64\home\...\rust\build\x86_64-pc-windows-gnu\stage0-rustc\x86_64-pc-windows-gnu\release\build\miniz-sys-98d83a845f69b3ab\out -L native=rust\msys64\home\...\rust\build\x86_64-pc-windows-gnu\stage0-rustc\x86_64-pc-windows-gnu\release\build\rustc_binaryen-f106436b515711ff\out/build/lib -L native=rust\msys64\home\...\rust\build\x86_64-pc-windows-gnu\stage0-rustc\x86_64-pc-windows-gnu\release\build\rustc_binaryen-f106436b515711ff\out -L native=rust\msys64\home\...\rust\build\x86_64-pc-windows-gnu\stage0-rustc\x86_64-pc-windows-gnu\release\build\rustc_llvm-9a040fa1f1937a67\out -L native=rust\msys64\home\...\rust\build\x86_64-pc-windows-gnu\llvm/lib` (exit code: 101)
thread 'main' panicked at 'command did not execute successfully: "rust\\msys64\\home\\...\\rust\\build\\x86_64-pc-windows-gnu\\stage0/bin\\cargo.exe" "build" "--target" "x86_64-pc-windows-gnu" "-j" "4" "--release" "--features" " jemalloc llvm" "--manifest-path" "rust/msys64/home/.../rust\\src/rustc/Cargo.toml" "--message-format" "json"
expected success, got: exit code: 101', bootstrap\compile.rs:886:9
note: Run with `RUST_BACKTRACE=1` for a backtrace.
failed to run: rust/msys64/home/.../rust/build/bootstrap/debug/bootstrap build --stage 1 src/libtest
Build completed unsuccessfully in 0:00:25
```

The code that uses `__p__fmode` was added in https://github.com/mirror/mingw-w64/commit/2e64b9e4537d564478f17b873b2f655f518325ed, apparently in x86_64, it uses its own implementation of it. libmsvcrt.a is kind of a weird beast, it's both an import library for the system msvcrt.dll, but it also is a library that includes compiled code.

For some reason it fails to find the reference for the import symbol that is found in the very same archive as the function that uses it. I don't know what in the Rust code base triggers this. i.e. Create an MWE that can show why this PR is required.

This probably *shouldn't be merged* without understanding why this is necessary or not.

To successfully bootstrap rustc and show that this does make the build work (On latest mingw-w64 x86_64 on Msys2):
```sh
$ RUSTFLAGS="-C link-arg=-lmsvcrt" ./x.py build --stage 1 src/libtest
$ ./x.py build --keep-stage 1 --stage 2 src/libtest # Should work with the patch, and fail without it
```

Fixes #47265