### PR TITLE
implement "only-<platforms>" for test headers

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1236,6 +1236,9 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
          overriding the default for the current target"),
     human_readable_cgu_names: bool = (false, parse_bool, [TRACKED],
         "generate human-readable, predictable names for codegen units"),
+    dep_info_omit_d_target: bool = (false, parse_bool, [TRACKED],
+        "in dep-info output, omit targets for tracking dependencies of the dep-info files \
+         themselves"),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1162,6 +1162,8 @@ fn write_out_deps(sess: &Session, outputs: &OutputFilenames, crate_name: &str) {
                     out_filenames.push(p);
                 }
             }
+            // Do not include the dep-info file in itself as a target
+            OutputType::DepInfo => { }
             _ => {
                 out_filenames.push(file);
             }

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1162,8 +1162,9 @@ fn write_out_deps(sess: &Session, outputs: &OutputFilenames, crate_name: &str) {
                     out_filenames.push(p);
                 }
             }
-            // Do not include the dep-info file in itself as a target
-            OutputType::DepInfo => { }
+            OutputType::DepInfo if sess.opts.debugging_opts.dep_info_omit_d_target => {
+                // Don't add the dep-info output when omitting it from dep-info targets
+            }
             _ => {
                 out_filenames.push(file);
             }

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -44,6 +44,8 @@ impl EarlyProps {
             props.ignore =
                 props.ignore ||
                 config.parse_cfg_name_directive(ln, "ignore") ||
+                (config.parse_cfg_prefix(ln, "only") &&
+                !config.parse_cfg_name_directive(ln, "only")) ||
                 ignore_gdb(config, ln) ||
                 ignore_lldb(config, ln) ||
                 ignore_llvm(config, ln);
@@ -559,6 +561,17 @@ impl Config {
                     _ => false,
                 } ||
                 (self.target != self.host && name == "cross-compile")
+        } else {
+            false
+        }
+    }
+
+    fn parse_cfg_prefix(&self, line: &str, prefix: &str) -> bool {
+        // returns whether this line contains this prefix or not. For prefix
+        // "ignore", returns true if line says "ignore-x86_64", "ignore-arch",
+        // "ignore-andorid" etc.
+        if line.starts_with(prefix) && line.as_bytes().get(prefix.len()) == Some(&b'-') {
+            true
         } else {
             false
         }


### PR DESCRIPTION
This patch implements "only-<platforms>" for tests headers using which one can
specify just the platforms on which the test should run rather than listing all
the platforms to ignore using "ignore-<platform>".

This is a fix for issues #33581 and #47459.