### PR TITLE
implement "only-<platforms>" for test headers

### DIFF
--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -44,6 +44,8 @@ impl EarlyProps {
             props.ignore =
                 props.ignore ||
                 config.parse_cfg_name_directive(ln, "ignore") ||
+                (config.parse_cfg_prefix(ln, "only") &&
+                !config.parse_cfg_name_directive(ln, "only")) ||
                 ignore_gdb(config, ln) ||
                 ignore_lldb(config, ln) ||
                 ignore_llvm(config, ln);
@@ -559,6 +561,17 @@ impl Config {
                     _ => false,
                 } ||
                 (self.target != self.host && name == "cross-compile")
+        } else {
+            false
+        }
+    }
+
+    fn parse_cfg_prefix(&self, line: &str, prefix: &str) -> bool {
+        // returns whether this line contains this prefix or not. For prefix
+        // "ignore", returns true if line says "ignore-x86_64", "ignore-arch",
+        // "ignore-andorid" etc.
+        if line.starts_with(prefix) && line.as_bytes().get(prefix.len()) == Some(&b'-') {
+            true
         } else {
             false
         }

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -570,11 +570,7 @@ impl Config {
         // returns whether this line contains this prefix or not. For prefix
         // "ignore", returns true if line says "ignore-x86_64", "ignore-arch",
         // "ignore-andorid" etc.
-        if line.starts_with(prefix) && line.as_bytes().get(prefix.len()) == Some(&b'-') {
-            true
-        } else {
-            false
-        }
+        line.starts_with(prefix) && line.as_bytes().get(prefix.len()) == Some(&b'-')
     }
 
     fn parse_name_directive(&self, line: &str, directive: &str) -> bool {

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -41,6 +41,8 @@ impl EarlyProps {
         iter_header(testfile,
                     None,
                     &mut |ln| {
+            // we should check if any only-<platform> exists and if it exists
+            // and does not matches the current platform, skip the test
             props.ignore =
                 props.ignore ||
                 config.parse_cfg_name_directive(ln, "ignore") ||

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -44,7 +44,7 @@ impl EarlyProps {
             props.ignore =
                 props.ignore ||
                 config.parse_cfg_name_directive(ln, "ignore") ||
-                (config.parse_cfg_prefix(ln, "only") &&
+                (config.has_cfg_prefix(ln, "only") &&
                 !config.parse_cfg_name_directive(ln, "only")) ||
                 ignore_gdb(config, ln) ||
                 ignore_lldb(config, ln) ||
@@ -566,7 +566,7 @@ impl Config {
         }
     }
 
-    fn parse_cfg_prefix(&self, line: &str, prefix: &str) -> bool {
+    fn has_cfg_prefix(&self, line: &str, prefix: &str) -> bool {
         // returns whether this line contains this prefix or not. For prefix
         // "ignore", returns true if line says "ignore-x86_64", "ignore-arch",
         // "ignore-andorid" etc.


### PR DESCRIPTION
This patch implements "only-<platforms>" for tests headers using which one can
specify just the platforms on which the test should run rather than listing all
the platforms to ignore using "ignore-<platforms>".

This fixes #33581 and fixes #47459.