### PR TITLE
Lint #[inline] attr without body

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -246,6 +246,12 @@ declare_lint! {
     "raw pointer to an inference variable"
 }
 
+declare_lint! {
+    pub INLINE_ATTRS_IN_FNS_WITHOUT_BODY,
+    Warn,
+    "detects use of inline attributes on methods without bodies"
+}
+
 /// Does nothing as a lint pass, but registers some `Lint`s
 /// which are used by other parts of the compiler.
 #[derive(Copy, Clone)]
@@ -291,7 +297,8 @@ impl LintPass for HardwiredLints {
             UNUSED_MUT,
             COERCE_NEVER,
             SINGLE_USE_LIFETIME,
-            TYVAR_BEHIND_RAW_POINTER
+            TYVAR_BEHIND_RAW_POINTER,
+            INLINE_ATTRS_IN_FNS_WITHOUT_BODY
         )
     }
 }

--- a/src/test/compile-fail/inline-attr-on-fn-without-body.rs
+++ b/src/test/compile-fail/inline-attr-on-fn-without-body.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(inline_attrs_in_fns_without_body)]
+
+trait Tr {
+    #[inline] //~ ERROR inline attributes have no effect on methods without bodies
+    fn f1();
+
+    #[inline(always)] //~ ERROR inline attributes have no effect on methods without bodies
+    fn f2();
+
+    #[inline]
+    fn f3() {} // OK
+}


### PR DESCRIPTION
Inline attributes have no effect on trait methods without bodies; they only apply to a method implementation. Add a lint to catch this case.

One quirk of how this was previously handled is that even invalid inline attributes were ignored (e.g.  [inline(notathing)]). We can't start rejecting these without breaking backwards compatibility. Instead, just have a single lint to cover both valid and invalid attributes.

Fixes #47475

r? @petrochenkov