### PR TITLE
Don't include DefIndex in proc-macro registrar function symbol.

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -568,6 +568,11 @@ static HOST_COMPILETESTS: &[Test] = &[
         mode: "compile-fail",
         suite: "compile-fail-fulldeps",
     },
+    Test {
+        path: "src/test/incremental-fulldeps",
+        mode: "incremental",
+        suite: "incremental-fulldeps",
+    },
     Test { path: "src/test/run-make", mode: "run-make", suite: "run-make" },
     Test { path: "src/test/rustdoc", mode: "rustdoc", suite: "rustdoc" },
 

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -11,7 +11,7 @@
 pub use self::code_stats::{CodeStats, DataTypeKind, FieldInfo};
 pub use self::code_stats::{SizeKind, TypeSizeInfo, VariantInfo};
 
-use hir::def_id::{CrateNum, DefIndex};
+use hir::def_id::CrateNum;
 use ich::Fingerprint;
 
 use lint;
@@ -558,18 +558,16 @@ impl Session {
 
     /// Returns the symbol name for the registrar function,
     /// given the crate Svh and the function DefIndex.
-    pub fn generate_plugin_registrar_symbol(&self, disambiguator: CrateDisambiguator,
-                                            index: DefIndex)
+    pub fn generate_plugin_registrar_symbol(&self,
+                                            disambiguator: CrateDisambiguator)
                                             -> String {
-        format!("__rustc_plugin_registrar__{}_{}", disambiguator.to_fingerprint().to_hex(),
-                                                   index.to_proc_macro_index())
+        format!("__rustc_plugin_registrar_{}__", disambiguator.to_fingerprint().to_hex())
     }
 
-    pub fn generate_derive_registrar_symbol(&self, disambiguator: CrateDisambiguator,
-                                            index: DefIndex)
+    pub fn generate_derive_registrar_symbol(&self,
+                                            disambiguator: CrateDisambiguator)
                                             -> String {
-        format!("__rustc_derive_registrar__{}_{}", disambiguator.to_fingerprint().to_hex(),
-                                                   index.to_proc_macro_index())
+        format!("__rustc_derive_registrar_{}__", disambiguator.to_fingerprint().to_hex())
     }
 
     pub fn sysroot<'a>(&'a self) -> &'a Path {

--- a/src/librustc_plugin/load.rs
+++ b/src/librustc_plugin/load.rs
@@ -100,8 +100,8 @@ impl<'a> PluginLoader<'a> {
     fn load_plugin(&mut self, span: Span, name: &str, args: Vec<ast::NestedMetaItem>) {
         let registrar = self.reader.find_plugin_registrar(span, name);
 
-        if let Some((lib, disambiguator, index)) = registrar {
-            let symbol = self.sess.generate_plugin_registrar_symbol(disambiguator, index);
+        if let Some((lib, disambiguator)) = registrar {
+            let symbol = self.sess.generate_plugin_registrar_symbol(disambiguator);
             let fun = self.dylink_registrar(span, lib, symbol);
             self.plugins.push(PluginRegistrar {
                 fun,

--- a/src/librustc_trans/back/symbol_export.rs
+++ b/src/librustc_trans/back/symbol_export.rs
@@ -115,9 +115,8 @@ pub fn provide(providers: &mut Providers) {
 
         if let Some(id) = tcx.sess.derive_registrar_fn.get() {
             let def_id = tcx.hir.local_def_id(id);
-            let idx = def_id.index;
             let disambiguator = tcx.sess.local_crate_disambiguator();
-            let registrar = tcx.sess.generate_derive_registrar_symbol(disambiguator, idx);
+            let registrar = tcx.sess.generate_derive_registrar_symbol(disambiguator);
             local_crate.push((registrar, Some(def_id), SymbolExportLevel::C));
         }
 

--- a/src/librustc_trans/back/symbol_names.rs
+++ b/src/librustc_trans/back/symbol_names.rs
@@ -257,14 +257,12 @@ fn compute_symbol_name<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, instance: Instance
 
     if let Some(id) = node_id {
         if tcx.sess.plugin_registrar_fn.get() == Some(id) {
-            let idx = def_id.index;
             let disambiguator = tcx.sess.local_crate_disambiguator();
-            return tcx.sess.generate_plugin_registrar_symbol(disambiguator, idx);
+            return tcx.sess.generate_plugin_registrar_symbol(disambiguator);
         }
         if tcx.sess.derive_registrar_fn.get() == Some(id) {
-            let idx = def_id.index;
             let disambiguator = tcx.sess.local_crate_disambiguator();
-            return tcx.sess.generate_derive_registrar_symbol(disambiguator, idx);
+            return tcx.sess.generate_derive_registrar_symbol(disambiguator);
         }
     }
 

--- a/src/test/incremental-fulldeps/auxiliary/incremental_proc_macro_aux.rs
+++ b/src/test/incremental-fulldeps/auxiliary/incremental_proc_macro_aux.rs
@@ -1,0 +1,31 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+// Add a function to shift DefIndex of registrar function
+#[cfg(cfail2)]
+fn foo() {}
+
+#[proc_macro_derive(IncrementalMacro)]
+pub fn derive(input: TokenStream) -> TokenStream {
+    #[cfg(cfail2)]
+    {
+        foo();
+    }
+
+    "".parse().unwrap()
+}

--- a/src/test/incremental-fulldeps/incremental_proc_macro.rs
+++ b/src/test/incremental-fulldeps/incremental_proc_macro.rs
@@ -1,0 +1,27 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:incremental_proc_macro_aux.rs
+// ignore-stage1
+// revisions: cfail1 cfail2
+// must-compile-successfully
+
+// This test makes sure that we still find the proc-macro registrar function
+// when we compile proc-macros incrementally (see #47292).
+
+#![crate_type = "rlib"]
+
+#[macro_use]
+extern crate incremental_proc_macro_aux;
+
+#[derive(IncrementalMacro)]
+pub struct Foo {
+    x: u32
+}


### PR DESCRIPTION
There can only ever be one registrar function per plugin or proc-macro crate, so adding the `DefIndex` to the function's symbol name does not serve a real purpose. Remove the `DefIndex` from the symbol name makes it stable across incremental compilation sessions.

This should fix issue #47292.