### PR TITLE
remove bogus assertion and comments

### DIFF
--- a/src/librustc_mir/borrow_check/nll/universal_regions.rs
+++ b/src/librustc_mir/borrow_check/nll/universal_regions.rs
@@ -584,13 +584,9 @@ impl<'cx, 'gcx, 'tcx> UniversalRegionsBuilder<'cx, 'gcx, 'tcx> {
 
             DefiningTy::FnDef(_, substs) => substs,
 
-            // When we encounter other sorts of constant
-            // expressions, such as the `22` in `[foo; 22]`, we can
-            // get the type `usize` here. For now, just return an
-            // empty vector of substs in this case, since there are no
-            // generics in scope in such expressions right now.
+            // When we encounter a constant body, just return whatever
+            // substitutions are in scope for that constant.
             DefiningTy::Const(_) => {
-                assert!(identity_substs.is_empty());
                 identity_substs
             }
         };
@@ -654,9 +650,8 @@ impl<'cx, 'gcx, 'tcx> UniversalRegionsBuilder<'cx, 'gcx, 'tcx> {
                 sig.inputs_and_output()
             }
 
-            // This happens on things like `[foo; 22]`. Hence, no
-            // inputs, one output, but it seems like we need a more
-            // general way to handle this category of MIR.
+            // For a constant body, there are no inputs, and one
+            // "output" (the type of the constant).
             DefiningTy::Const(ty) => ty::Binder::dummy(tcx.mk_type_list(iter::once(ty))),
         }
     }

--- a/src/test/run-pass/nll/issue-47153-generic-const.rs
+++ b/src/test/run-pass/nll/issue-47153-generic-const.rs
@@ -1,0 +1,27 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for #47153: constants in a generic context (such as
+// a trait) used to ICE.
+
+#![feature(nll)]
+#![allow(warnings)]
+
+trait Foo {
+    const B: bool = true;
+}
+
+struct Bar<T> { x: T }
+
+impl<T> Bar<T> {
+    const B: bool = true;
+}
+
+fn main() { }


### PR DESCRIPTION
The code (incorrectly) assumed that constants could not have generics
in scope, but it's not really a problem if they do.

Fixes #47153 

r? @pnkfelix 
