### PR TITLE
add documentation from doc(include) to analysis data

### DIFF
--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -870,6 +870,17 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                         result.push_str(&val.as_str());
                     }
                     result.push('\n');
+                } else if let Some(meta_list) = attr.meta_item_list() {
+                    meta_list.into_iter()
+                             .filter(|it| it.check_name("include"))
+                             .filter_map(|it| it.meta_item_list().map(|l| l.to_owned()))
+                             .flat_map(|it| it)
+                             .filter(|meta| meta.check_name("contents"))
+                             .filter_map(|meta| meta.value_str())
+                             .for_each(|val| {
+                                 result.push_str(&val.as_str());
+                                 result.push('\n');
+                             });
                 }
             }
         }

--- a/src/test/run-make/save-analysis/extra-docs.md
+++ b/src/test/run-make/save-analysis/extra-docs.md
@@ -1,0 +1,1 @@
+Extra docs for this struct.

--- a/src/test/run-make/save-analysis/foo.rs
+++ b/src/test/run-make/save-analysis/foo.rs
@@ -12,6 +12,7 @@
 #![feature(box_syntax)]
 #![feature(rustc_private)]
 #![feature(associated_type_defaults)]
+#![feature(external_doc)]
 
 extern crate graphviz;
 // A simple rust project
@@ -461,3 +462,6 @@ impl Iterator for SilenceGenerator {
 trait Foo {
     type Bar = FrameBuffer;
 }
+
+#[doc(include="extra-docs.md")]
+struct StructWithDocs;


### PR DESCRIPTION
cc #44732 

Currently save-analysis only loads docs from plain doc comments and doc attributes. Since `#[doc(include="filename.md")]` doesn't create a plain doc attribute when it loads the file, we need to be sure to pick up this info for the analysis data.