### PR TITLE
add Rust By Example to the bookshelf

### DIFF
--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -28,6 +28,7 @@ Rust provides a number of book-length sets of documentation, collectively
 nicknamed 'The Rust Bookshelf.'
 
 * [The Rust Programming Language][book] teaches you how to program in Rust.
+* [Rust By Example][rbe] teaches you how to program in Rust using editable examples.
 * [The Cargo Book][cargo-book] is a guide to Cargo, Rust's build tool and dependency manager.
 * [The Unstable Book][unstable-book] has documentation for unstable features.
 * [The Rustonomicon][nomicon] is your guidebook to the dark arts of unsafe Rust.
@@ -51,6 +52,7 @@ before this policy was put into place. That work is being tracked
 [refchecklist]: https://github.com/rust-lang-nursery/reference/issues/9
 [err]: error-index.html
 [book]: book/index.html
+[rbe]: rust-by-example/index.html
 [nomicon]: nomicon/index.html
 [unstable-book]: unstable-book/index.html
 [rustdoc-book]: rustdoc/index.html


### PR DESCRIPTION
cc #46194

With #46196 freshly merged, we should add a link to the main docs distribution so people can find it! We discussed this at the docs team meeting today and decided to go ahead with adding it to the bookshelf.