### PR TITLE
Use File::metadata instead of fs::metadata to choose buffer size

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -211,12 +211,12 @@ pub struct DirBuilder {
     recursive: bool,
 }
 
-/// How large a buffer to pre-allocate before reading the entire file at `path`.
-fn initial_buffer_size<P: AsRef<Path>>(path: P) -> usize {
+/// How large a buffer to pre-allocate before reading the entire file.
+fn initial_buffer_size(file: &File) -> usize {
     // Allocate one extra byte so the buffer doesn't need to grow before the
     // final `read` call at the end of the file.  Don't worry about `usize`
     // overflow because reading will fail regardless in that case.
-    metadata(path).map(|m| m.len() as usize + 1).unwrap_or(0)
+    file.metadata().map(|m| m.len() as usize + 1).unwrap_or(0)
 }
 
 /// Read the entire contents of a file into a bytes vector.
@@ -254,8 +254,9 @@ fn initial_buffer_size<P: AsRef<Path>>(path: P) -> usize {
 /// ```
 #[unstable(feature = "fs_read_write", issue = "46588")]
 pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
-    let mut bytes = Vec::with_capacity(initial_buffer_size(&path));
-    File::open(path)?.read_to_end(&mut bytes)?;
+    let mut file = File::open(path)?;
+    let mut bytes = Vec::with_capacity(initial_buffer_size(&file));
+    file.read_to_end(&mut bytes)?;
     Ok(bytes)
 }
 
@@ -295,8 +296,9 @@ pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
 /// ```
 #[unstable(feature = "fs_read_write", issue = "46588")]
 pub fn read_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
-    let mut string = String::with_capacity(initial_buffer_size(&path));
-    File::open(path)?.read_to_string(&mut string)?;
+    let mut file = File::open(path)?;
+    let mut string = String::with_capacity(initial_buffer_size(&file));
+    file.read_to_string(&mut string)?;
     Ok(string)
 }
 


### PR DESCRIPTION
This replaces a `stat` syscall with `fstat` or similar, which can be faster.  Fixes #47519.