### PR TITLE
Add Iterator specialisation for Repeat::nth

### DIFF
--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -31,8 +31,12 @@ impl<A: Clone> Iterator for Repeat<A> {
 
     #[inline]
     fn next(&mut self) -> Option<A> { Some(self.element.clone()) }
+
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) { (usize::MAX, None) }
+
+    #[inline]
+    fn nth(&mut self, _: usize) -> Option<A> { self.next() }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1403,6 +1403,7 @@ fn test_repeat() {
     assert_eq!(it.next(), Some(42));
     assert_eq!(it.next(), Some(42));
     assert_eq!(it.next(), Some(42));
+    assert_eq!(it.nth(usize::MAX), Some(42));
 }
 
 #[test]

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1403,7 +1403,8 @@ fn test_repeat() {
     assert_eq!(it.next(), Some(42));
     assert_eq!(it.next(), Some(42));
     assert_eq!(it.next(), Some(42));
-    assert_eq!(it.nth(usize::MAX), Some(42));
+    let mut it = repeat(vec![42]);
+    assert_eq!(it.nth(usize::MAX), Some(vec![42]));
 }
 
 #[test]


### PR DESCRIPTION
A final (implementational) follow-up for https://github.com/rust-lang/rust/pull/47370, this (solely) adds an `Iterator::nth` optimisation specialisation for `Repeat`.

This changes the number of times `clone()` is called on the repeated value, which is an observable change. It's not entirely clear whether this is acceptable, and might benefit from a FCP.

cc @sfackler, @rkruppe, @bluss