### PR TITLE
add target/ to ignored tidy dirs

### DIFF
--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -69,6 +69,7 @@ fn filter_dirs(path: &Path) -> bool {
         "src/tools/miri",
         "src/librustc/mir/interpret",
         "src/librustc_mir/interpret",
+        "src/target",
     ];
     skip.iter().any(|p| path.ends_with(p))
 }


### PR DESCRIPTION
Sometimes you get a target directory from running cargo in the rust repo (the root is `src/`), and it contains generated files. Just whitelist it since it causes tidy to spew warnings uncontrollably.