### PR TITLE
Document the behaviour of infinite iterators on potentially-computable methods

### DIFF
--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -24,6 +24,10 @@ fn _assert_is_object_safe(_: &Iterator<Item=()>) {}
 /// This is the main iterator trait. For more about the concept of iterators
 /// generally, please see the [module-level documentation]. In particular, you
 /// may want to know how to [implement `Iterator`][impl].
+/// 
+/// Note: Methods on infinite iterators that generally require traversing every
+/// element to produce a result may not terminate, even on traits for which a
+/// result is determinable in finite time.
 ///
 /// [module-level documentation]: index.html
 /// [impl]: index.html#implementing-iterator

--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -25,10 +25,6 @@ fn _assert_is_object_safe(_: &Iterator<Item=()>) {}
 /// generally, please see the [module-level documentation]. In particular, you
 /// may want to know how to [implement `Iterator`][impl].
 ///
-/// Note: Methods on infinite iterators that generally require traversing every
-/// element to produce a result may not terminate, even on traits for which a
-/// result is determinable in finite time.
-///
 /// [module-level documentation]: index.html
 /// [impl]: index.html#implementing-iterator
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1429,6 +1425,10 @@ pub trait Iterator {
     ///
     /// Folding is useful whenever you have a collection of something, and want
     /// to produce a single value from it.
+    ///
+    /// Note: `fold()`, and similar methods that traverse the entire iterator,
+    /// may not terminate for infinite iterators, even on traits for which a
+    /// result is determinable in finite time.
     ///
     /// # Examples
     ///

--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -24,7 +24,7 @@ fn _assert_is_object_safe(_: &Iterator<Item=()>) {}
 /// This is the main iterator trait. For more about the concept of iterators
 /// generally, please see the [module-level documentation]. In particular, you
 /// may want to know how to [implement `Iterator`][impl].
-/// 
+///
 /// Note: Methods on infinite iterators that generally require traversing every
 /// element to produce a result may not terminate, even on traits for which a
 /// result is determinable in finite time.

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -299,15 +299,17 @@
 //! This will print the numbers `0` through `4`, each on their own line.
 //!
 //! Bear in mind that methods on infinite iterators, even those for which a
-//! result can be computed in finite time, may not terminate. Specifically,
-//! methods such as [`min`], which in the general case require traversing
-//! every element in the iterator, are likely never to terminate for any
-//! infinite iterators.
+//! result can be determined mathematically in finite time, may not terminate.
+//! Specifically, methods such as [`min`], which in the general case require
+//! traversing every element in the iterator, are likely not to return
+//! successfully for any infinite iterators.
 //!
 //! ```no_run
 //! let positives = 1..;
 //! let least = positives.min().unwrap(); // Oh no! An infinite loop!
-//! // `positives.min` causes an infinite loop, so we won't reach this point!
+//! // `positives.min` will either overflow and panic (in debug mode),
+//! // or cause an infinite loop (in release mode), so we won't reach
+//! // this point!
 //! println!("The least positive number is {}.", least);
 //! ```
 //!

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -305,12 +305,10 @@
 //! successfully for any infinite iterators.
 //!
 //! ```no_run
-//! let positives = 1..;
-//! let least = positives.min().unwrap(); // Oh no! An infinite loop!
-//! // `positives.min` will either overflow and panic (in debug mode),
-//! // or cause an infinite loop (in release mode), so we won't reach
-//! // this point!
-//! println!("The least positive number is {}.", least);
+//! let ones = std::iter::repeat(1);
+//! let least = ones.min().unwrap(); // Oh no! An infinite loop!
+//! // `ones.min()` causes an infinite loop, so we won't reach this point!
+//! println!("The smallest number one is {}.", least);
 //! ```
 //!
 //! [`take`]: trait.Iterator.html#method.take

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -297,14 +297,14 @@
 //! ```
 //!
 //! This will print the numbers `0` through `4`, each on their own line.
-//! 
+//!
 //! Bear in mind that methods on infinite iterators, even those for which a
 //! result can be computed in finite time, may not terminate. Specifically,
 //! methods such as [`min`], which in the general case require traversing
 //! every element in the iterator, are likely never to terminate for any
 //! infinite iterators.
-//! 
-//! ```
+//!
+//! ```no_run
 //! let positives = 1..;
 //! let least = positives.min().unwrap(); // Oh no! An infinite loop!
 //! // `positives.min` causes an infinite loop, so we won't reach this point!

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -297,8 +297,22 @@
 //! ```
 //!
 //! This will print the numbers `0` through `4`, each on their own line.
+//! 
+//! Bear in mind that methods on infinite iterators, even those for which a
+//! result can be computed in finite time, may not terminate. Specifically,
+//! methods such as [`min`], which in the general case require traversing
+//! every element in the iterator, are likely never to terminate for any
+//! infinite iterators.
+//! 
+//! ```
+//! let positives = 1..;
+//! let least = positives.min().unwrap(); // Oh no! An infinite loop!
+//! // `positives.min` causes an infinite loop, so we won't reach this point!
+//! println!("The least positive number is {}.", least);
+//! ```
 //!
 //! [`take`]: trait.Iterator.html#method.take
+//! [`min`]: trait.Iterator.html#method.min
 
 #![stable(feature = "rust1", since = "1.0.0")]
 


### PR DESCRIPTION
It’s not entirely clear from the current documentation what behaviour
calling a method such as `min` on an infinite iterator like `RangeFrom`
is. One might expect this to terminate, but in fact, for infinite
iterators, `min` is always nonterminating (at least in the standard
library). This adds a quick note about this behaviour for clarification.

cc @rkruppe