### PR TITLE
[beta] Turn back on "fat" LTO by default

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -807,9 +807,15 @@ impl Session {
             return enabled
         }
 
-        // If there's only one codegen unit and LTO isn't enabled then there's
-        // no need for ThinLTO so just return false.
-        if self.codegen_units() == 1 && !self.lto() {
+        // If LTO is enabled we right now unconditionally disable ThinLTO.
+        // This'll come at a later date! (full crate graph ThinLTO)
+        if self.lto() {
+            return false
+        }
+
+        // If there's only one codegen unit or then there's no need for ThinLTO
+        // so just return false.
+        if self.codegen_units() == 1 {
             return false
         }
 


### PR DESCRIPTION
This commit reverts a small portion of the switch to ThinLTO by default which
changed the meaning of `-C lto` from "put the whole crate graph into one codegen
unit" to "perform ThinLTO over the whole crate graph". This backport has no
corresponding commit on master as #47521 is making the same change but in a
slightly different manner. This commit is intended to be a surgical change with
low impact on beta.

Closes #47409