### PR TITLE
Make liballoc_jemalloc work on CloudABI.

### DIFF
--- a/src/liballoc_jemalloc/build.rs
+++ b/src/liballoc_jemalloc/build.rs
@@ -29,10 +29,17 @@ fn main() {
     // for targets like emscripten, even if we don't use it.
     let target = env::var("TARGET").expect("TARGET was not set");
     let host = env::var("HOST").expect("HOST was not set");
-    if target.contains("bitrig") || target.contains("cloudabi") || target.contains("emscripten") ||
-       target.contains("fuchsia") || target.contains("msvc") || target.contains("openbsd") ||
-       target.contains("redox") || target.contains("rumprun") || target.contains("wasm32") {
+    if target.contains("bitrig") || target.contains("emscripten") || target.contains("fuchsia") ||
+       target.contains("msvc") || target.contains("openbsd") || target.contains("redox") ||
+       target.contains("rumprun") || target.contains("wasm32") {
         println!("cargo:rustc-cfg=dummy_jemalloc");
+        return;
+    }
+
+    // CloudABI ships with a copy of jemalloc that has been patched to
+    // work well with sandboxing. Don't attempt to build our own copy,
+    // as it won't build.
+    if target.contains("cloudabi") {
         return;
     }
 


### PR DESCRIPTION
The automated builds for CloudABI in dist-various-2 don't use
--disable-jemalloc, even though my original container image did. Instead
of setting that flag, let's go the extra mile of making jemalloc work.
CloudABI's C library already uses jemalloc and now exposes the API
extensions used by us.

This makes the CloudABI dist work out of the box.