### PR TITLE
specialize Iterator::nth for Cycles over ExactSizeIterators to

### DIFF
--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -647,14 +647,13 @@ impl<I> Iterator for Cycle<I> where I: Clone + Iterator {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<I> Iterator for Cycle<I>
-where I: Clone + Iterator + ExactSizeIterator,
-      <I as Iterator>::Item : Clone + Copy {
+where I: Copy + ExactSizeIterator, <I as Iterator>::Item : Copy {
     fn nth(&mut self, n: usize) -> Option<<I as Iterator>::Item> {
         let cur_len = self.iter.len();
         if n < cur_len {
             self.iter.nth(n)
         } else {
-            self.iter = self.orig.clone();
+            self.iter = self.orig;
             self.iter.nth((n - cur_len) % self.orig.len())
         }
     }

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -647,7 +647,7 @@ impl<I> Iterator for Cycle<I> where I: Clone + Iterator {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<I> Iterator for Cycle<I>
-where I: Clone + ExactSizeIterator, <I as Iterator>::Item : Copy {
+where I: Clone + ExactSizeIterator, I::Item : Copy {
     fn nth(&mut self, n: usize) -> Option<<I as Iterator>::Item> {
         let cur_len = self.iter.len();
         if n < cur_len {

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -647,7 +647,8 @@ impl<I> Iterator for Cycle<I> where I: Clone + Iterator {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<I> Iterator for Cycle<I>
-where I: Clone + Iterator + ExactSizeIterator {
+where I: Clone + Iterator + ExactSizeIterator,
+      <I as Iterator>::Item : Clone + Copy {
     fn nth(&mut self, n: usize) -> Option<<I as Iterator>::Item> {
         let cur_len = self.iter.len();
         if n < cur_len {

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -647,13 +647,13 @@ impl<I> Iterator for Cycle<I> where I: Clone + Iterator {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<I> Iterator for Cycle<I>
-where I: Copy + ExactSizeIterator, <I as Iterator>::Item : Copy {
+where I: Clone + ExactSizeIterator, <I as Iterator>::Item : Copy {
     fn nth(&mut self, n: usize) -> Option<<I as Iterator>::Item> {
         let cur_len = self.iter.len();
         if n < cur_len {
             self.iter.nth(n)
         } else {
-            self.iter = self.orig;
+            self.iter = self.orig.clone();
             self.iter.nth((n - cur_len) % self.orig.len())
         }
     }

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -645,6 +645,20 @@ impl<I> Iterator for Cycle<I> where I: Clone + Iterator {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<I> Iterator for Cycle<I>
+where I: Clone + Iterator + ExactSizeIterator {
+    fn nth(&mut self, n: usize) -> Option<<I as Iterator>::Item> {
+        let cur_len = self.iter.len();
+        if n < cur_len {
+            self.iter.nth(n)
+        } else {
+            self.iter = self.orig.clone();
+            self.iter.nth((n - cur_len) % self.orig.len())
+        }
+    }
+}
+
 #[unstable(feature = "fused", issue = "35602")]
 impl<I> FusedIterator for Cycle<I> where I: Clone + Iterator {}
 


### PR DESCRIPTION
reduce clones at the cost of one remainder. This should be faster in most cases and may in some situations reduce memory churn via clones.