### PR TITLE
Update clippy

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -282,14 +282,14 @@ dependencies = [
 
 [[package]]
 name = "clippy"
-version = "0.0.174"
+version = "0.0.180"
 dependencies = [
  "cargo_metadata 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy-mini-macro-test 0.1.0",
- "clippy_lints 0.0.174",
+ "clippy-mini-macro-test 0.2.0",
+ "clippy_lints 0.0.180",
  "compiletest_rs 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "duct 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -297,15 +297,15 @@ dependencies = [
 
 [[package]]
 name = "clippy-mini-macro-test"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "clippy_lints"
-version = "0.0.174"
+version = "0.0.180"
 dependencies = [
  "if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
r? @Manishearth 

cc @kennytm 

supersedes #47172 by not running dogfood in the rustc test suite and placing the clippy ui output files into /tmp