### PR TITLE
Give TargetOptions::linker a sane default value for CloudABI.

### DIFF
--- a/src/librustc_back/target/aarch64_unknown_cloudabi.rs
+++ b/src/librustc_back/target/aarch64_unknown_cloudabi.rs
@@ -15,6 +15,7 @@ pub fn target() -> TargetResult {
     let mut base = super::cloudabi_base::opts();
     base.max_atomic_width = Some(128);
     base.abi_blacklist = super::arm_base::abi_blacklist();
+    base.linker = "aarch64-unknown-cloudabi-cc".to_string();
 
     Ok(Target {
         llvm_target: "aarch64-unknown-cloudabi".to_string(),

--- a/src/librustc_back/target/armv7_unknown_cloudabi_eabihf.rs
+++ b/src/librustc_back/target/armv7_unknown_cloudabi_eabihf.rs
@@ -17,6 +17,7 @@ pub fn target() -> TargetResult {
     base.max_atomic_width = Some(64);
     base.features = "+v7,+vfp3,+neon".to_string();
     base.abi_blacklist = super::arm_base::abi_blacklist();
+    base.linker = "armv7-unknown-cloudabi-eabihf-cc".to_string();
 
     Ok(Target {
         llvm_target: "armv7-unknown-cloudabi-eabihf".to_string(),

--- a/src/librustc_back/target/i686_unknown_cloudabi.rs
+++ b/src/librustc_back/target/i686_unknown_cloudabi.rs
@@ -15,6 +15,7 @@ pub fn target() -> TargetResult {
     let mut base = super::cloudabi_base::opts();
     base.cpu = "pentium4".to_string();
     base.max_atomic_width = Some(64);
+    base.linker = "i686-unknown-cloudabi-cc".to_string();
     base.pre_link_args.get_mut(&LinkerFlavor::Gcc).unwrap().push("-m32".to_string());
     base.stack_probes = true;
 

--- a/src/librustc_back/target/x86_64_unknown_cloudabi.rs
+++ b/src/librustc_back/target/x86_64_unknown_cloudabi.rs
@@ -15,6 +15,7 @@ pub fn target() -> TargetResult {
     let mut base = super::cloudabi_base::opts();
     base.cpu = "x86-64".to_string();
     base.max_atomic_width = Some(64);
+    base.linker = "x86_64-unknown-cloudabi-cc".to_string();
     base.pre_link_args.get_mut(&LinkerFlavor::Gcc).unwrap().push("-m64".to_string());
     base.stack_probes = true;
 


### PR DESCRIPTION
Though some parts of rust use cc-rs to invoke a compiler/linker, Cargo
seems to make use of the TargetOptions::linker property. Make the out of
the box experience for CloudABI a bit better by using the same compiler
name as cc-rs.