### PR TITLE
Match libunwind's EABI selection with libpanic_unwind

### DIFF
--- a/src/libunwind/libunwind.rs
+++ b/src/libunwind/libunwind.rs
@@ -93,8 +93,7 @@ extern "C" {
 }
 
 cfg_if! {
-if #[cfg(not(any(all(target_os = "android", target_arch = "arm"),
-                 all(target_os = "linux", target_arch = "arm"))))] {
+if #[cfg(all(any(target_os = "ios", not(target_arch = "arm"))))] {
     // Not ARM EHABI
     #[repr(C)]
     #[derive(Copy, Clone, PartialEq)]


### PR DESCRIPTION
Currently, the `libunwind` crate will only select the ARM EABI if it is compiling for ARM/Linux or Android targets. `libpanic_unwind`, however, will choose the ARM EABI if the target arch is ARM and the OS is not iOS. This means that if one tries to enable unwinding for a non-standard ARM target (such as implementing a custom stdlib via Xargo, for example), then the two crates can potentially disagree about which EABI is being targeted.

This PR makes `libunwind` use the [same logic](https://github.com/rust-lang/rust/blob/master/src/libpanic_unwind/gcc.rs#L139-L146) as `libpanic_unwind` when choosing the EABI.

I noticed there are a few comments about certain functions only differing on Android or ARM/Linux, but I *think* that those differences apply to the ARM EABI in general. Let me know if I'm wrong about that.

