### PR TITLE
Show the used type variable when issuing a "can't use type parameters from outer function" error message

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -571,7 +571,8 @@ impl<'a> LoweringContext<'a> {
                         def_node_id,
                         DefPathData::LifetimeDef(name.as_str()),
                         DefIndexAddressSpace::High,
-                        Mark::root()
+                        Mark::root(),
+                        span
                     );
 
                     hir::GenericParam::Lifetime(hir::LifetimeDef {
@@ -1003,7 +1004,8 @@ impl<'a> LoweringContext<'a> {
                             def_node_id,
                             DefPathData::ImplTrait,
                             DefIndexAddressSpace::High,
-                            Mark::root()
+                            Mark::root(),
+                            span
                         );
 
                         let hir_bounds = self.lower_bounds(bounds, itctx);
@@ -1150,7 +1152,8 @@ impl<'a> LoweringContext<'a> {
                         def_node_id,
                         DefPathData::LifetimeDef(name.name().as_str()),
                         DefIndexAddressSpace::High,
-                        Mark::root()
+                        Mark::root(),
+                        lifetime.span
                     );
                     let def_lifetime = hir::Lifetime {
                         id: def_node_id,

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -28,6 +28,7 @@ use std::hash::Hash;
 use syntax::ast;
 use syntax::ext::hygiene::Mark;
 use syntax::symbol::{Symbol, InternedString};
+use syntax_pos::{Span, DUMMY_SP};
 use util::nodemap::NodeMap;
 
 /// The DefPathTable maps DefIndexes to DefKeys and vice versa.
@@ -159,6 +160,7 @@ pub struct Definitions {
     macro_def_scopes: FxHashMap<Mark, DefId>,
     expansions: FxHashMap<DefIndex, Mark>,
     next_disambiguator: FxHashMap<(DefIndex, DefPathData), u32>,
+    def_index_to_span: FxHashMap<DefIndex, Span>,
 }
 
 // Unfortunately we have to provide a manual impl of Clone because of the
@@ -176,6 +178,7 @@ impl Clone for Definitions {
             macro_def_scopes: self.macro_def_scopes.clone(),
             expansions: self.expansions.clone(),
             next_disambiguator: self.next_disambiguator.clone(),
+            def_index_to_span: self.def_index_to_span.clone(),
         }
     }
 }
@@ -410,6 +413,7 @@ impl Definitions {
             macro_def_scopes: FxHashMap(),
             expansions: FxHashMap(),
             next_disambiguator: FxHashMap(),
+            def_index_to_span: FxHashMap(),
         }
     }
 
@@ -493,6 +497,22 @@ impl Definitions {
         self.node_to_hir_id[node_id]
     }
 
+    /// Retrieve the span of the given `DefId` if `DefId` is in the local crate, the span exists and
+    /// it's not DUMMY_SP
+    #[inline]
+    pub fn opt_span(&self, def_id: DefId) -> Option<Span> {
+        if def_id.krate == LOCAL_CRATE {
+            let span = self.def_index_to_span.get(&def_id.index).cloned().unwrap_or(DUMMY_SP);
+            if span != DUMMY_SP {
+                Some(span)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+
     /// Add a definition with a parent definition.
     pub fn create_root_def(&mut self,
                            crate_name: &str,
@@ -530,7 +550,8 @@ impl Definitions {
                                   node_id: ast::NodeId,
                                   data: DefPathData,
                                   address_space: DefIndexAddressSpace,
-                                  expansion: Mark)
+                                  expansion: Mark,
+                                  span: Span)
                                   -> DefIndex {
         debug!("create_def_with_parent(parent={:?}, node_id={:?}, data={:?})",
                parent, node_id, data);
@@ -581,6 +602,11 @@ impl Definitions {
         let expansion = expansion.modern();
         if expansion != Mark::root() {
             self.expansions.insert(index, expansion);
+        }
+
+        // The span is added if it isn't DUMMY_SP
+        if span != DUMMY_SP {
+            self.def_index_to_span.insert(index, span);
         }
 
         index
@@ -692,7 +718,8 @@ macro_rules! define_global_metadata_kind {
                         ast::DUMMY_NODE_ID,
                         DefPathData::GlobalMetaData(instance.name().as_str()),
                         GLOBAL_MD_ADDRESS_SPACE,
-                        Mark::root()
+                        Mark::root(),
+                        DUMMY_SP
                     );
 
                     // Make sure calling def_index does not crash.

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -41,7 +41,7 @@ use rustc::ty;
 use rustc::hir::{Freevar, FreevarMap, TraitCandidate, TraitMap, GlobMap};
 use rustc::util::nodemap::{NodeMap, NodeSet, FxHashMap, FxHashSet, DefIdMap};
 
-use syntax::codemap::{dummy_spanned, respan};
+use syntax::codemap::{dummy_spanned, respan, CodeMap};
 use syntax::ext::hygiene::{Mark, MarkKind, SyntaxContext};
 use syntax::ast::{self, Name, NodeId, Ident, SpannedIdent, FloatTy, IntTy, UintTy};
 use syntax::ext::base::SyntaxExtension;
@@ -123,7 +123,7 @@ impl Ord for BindingError {
 
 enum ResolutionError<'a> {
     /// error E0401: can't use type parameters from outer function
-    TypeParametersFromOuterFunction,
+    TypeParametersFromOuterFunction(Def),
     /// error E0403: the name is already used for a type parameter in this type parameter list
     NameAlreadyUsedInTypeParameterList(Name, &'a Span),
     /// error E0407: method is not a member of trait
@@ -173,13 +173,49 @@ fn resolve_struct_error<'sess, 'a>(resolver: &'sess Resolver,
                                    resolution_error: ResolutionError<'a>)
                                    -> DiagnosticBuilder<'sess> {
     match resolution_error {
-        ResolutionError::TypeParametersFromOuterFunction => {
+        ResolutionError::TypeParametersFromOuterFunction(outer_def) => {
             let mut err = struct_span_err!(resolver.session,
                                            span,
                                            E0401,
-                                           "can't use type parameters from outer function; \
-                                           try using a local type parameter instead");
+                                           "can't use type parameters from outer function");
             err.span_label(span, "use of type variable from outer function");
+            match outer_def {
+                Def::SelfTy(_, maybe_impl_defid) => {
+                    if let Some(impl_span) = maybe_impl_defid.map_or(None,
+                            |def_id| resolver.definitions.opt_span(def_id)) {
+                        let cm = resolver.session.codemap();
+                        err.span_label(reduce_impl_span_to_impl_keyword(cm, impl_span),
+                                    "`Self` type implicitely declared here, on the `impl`");
+                    }
+                },
+                Def::TyParam(typaram_defid) => {
+                    if let Some(typaram_span) = resolver.definitions.opt_span(typaram_defid) {
+                        err.span_label(typaram_span, "type variable from outer function");
+                    }
+                },
+                Def::Mod(..) | Def::Struct(..) | Def::Union(..) | Def::Enum(..) | Def::Variant(..) |
+                Def::Trait(..) | Def::TyAlias(..) | Def::TyForeign(..) | Def::TraitAlias(..) |
+                Def::AssociatedTy(..) | Def::PrimTy(..) | Def::Fn(..) | Def::Const(..) |
+                Def::Static(..) | Def::StructCtor(..) | Def::VariantCtor(..) | Def::Method(..) |
+                Def::AssociatedConst(..) | Def::Local(..) | Def::Upvar(..) | Def::Label(..) |
+                Def::Macro(..) | Def::GlobalAsm(..) | Def::Err =>
+                    bug!("TypeParametersFromOuterFunction should only be used with Def::SelfTy or \
+                         Def::TyParam")
+            }
+
+            // Try to retrieve the span of the function signature and generate a new message with
+            // a local type parameter
+            let sugg_msg = "try using a local type parameter instead";
+            if let Some((sugg_span, new_snippet)) = generate_local_type_param_snippet(
+                                                        resolver.session.codemap(), span) {
+                // Suggest the modification to the user
+                err.span_suggestion(sugg_span,
+                                    sugg_msg,
+                                    new_snippet);
+            } else {
+                err.help("try using a local type parameter instead");
+            }
+
             err
         }
         ResolutionError::NameAlreadyUsedInTypeParameterList(name, first_use_span) => {
@@ -356,6 +392,86 @@ fn resolve_struct_error<'sess, 'a>(resolver: &'sess Resolver,
             err
         }
     }
+}
+
+/// Adjust the impl span so that just the `impl` keyword is taken by removing
+/// everything after `<` (`"impl<T> Iterator for A<T> {}" -> "impl"`) and
+/// everything after the first whitespace (`"impl Iterator for A" -> "impl"`)
+///
+/// Attention: The method used is very fragile since it essentially duplicates the work of the
+/// parser. If you need to use this function or something similar, please consider updating the
+/// codemap functions and this function to something more robust.
+fn reduce_impl_span_to_impl_keyword(cm: &CodeMap, impl_span: Span) -> Span {
+    let impl_span = cm.span_until_char(impl_span, '<');
+    let impl_span = cm.span_until_whitespace(impl_span);
+    impl_span
+}
+
+/// Take the span of a type parameter in a function signature and try to generate a span for the
+/// function name (with generics) and a new snippet for this span with the pointed type parameter as
+/// a new local type parameter.
+///
+/// For instance:
+/// ```
+/// // Given span
+/// fn my_function(param: T)
+///                       ^ Original span
+///
+/// // Result
+/// fn my_function(param: T)
+///    ^^^^^^^^^^^ Generated span with snippet `my_function<T>`
+/// ```
+///
+/// Attention: The method used is very fragile since it essentially duplicates the work of the
+/// parser. If you need to use this function or something similar, please consider updating the
+/// codemap functions and this function to something more robust.
+fn generate_local_type_param_snippet(cm: &CodeMap, span: Span) -> Option<(Span, String)> {
+    // Try to extend the span to the previous "fn" keyword to retrieve the function
+    // signature
+    let sugg_span = cm.span_extend_to_prev_str(span, "fn");
+    if sugg_span != span {
+        if let Ok(snippet) = cm.span_to_snippet(sugg_span) {
+            use syntax::codemap::BytePos;
+
+            // Consume the function name
+            let mut offset = 0;
+            for c in snippet.chars().take_while(|c| c.is_ascii_alphanumeric() ||
+                                                    *c == '_') {
+                offset += c.len_utf8();
+            }
+
+            // Consume the generics part of the function signature
+            let mut bracket_counter = 0;
+            let mut last_char = None;
+            for c in snippet[offset..].chars() {
+                match c {
+                    '<' => bracket_counter += 1,
+                    '>' => bracket_counter -= 1,
+                    '(' => if bracket_counter == 0 { break; }
+                    _ => {}
+                }
+                offset += c.len_utf8();
+                last_char = Some(c);
+            }
+
+            // Adjust the suggestion span to encompass the function name with its generics
+            let sugg_span = sugg_span.with_hi(BytePos(sugg_span.lo().0 + offset as u32));
+
+            // Prepare the new suggested snippet to append the type parameter that triggered
+            // the error in the generics of the function signature
+            let mut new_snippet = if last_char == Some('>') {
+                format!("{}, ", &snippet[..(offset - '>'.len_utf8())])
+            } else {
+                format!("{}<", &snippet[..offset])
+            };
+            new_snippet.push_str(&cm.span_to_snippet(span).unwrap_or("T".to_string()));
+            new_snippet.push('>');
+
+            return Some((sugg_span, new_snippet));
+        }
+    }
+
+    None
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -3280,7 +3396,7 @@ impl<'a> Resolver<'a> {
                             // its scope.
                             if record_used {
                                 resolve_error(self, span,
-                                              ResolutionError::TypeParametersFromOuterFunction);
+                                    ResolutionError::TypeParametersFromOuterFunction(def));
                             }
                             return Def::Err;
                         }

--- a/src/test/compile-fail/inner-static-type-parameter.rs
+++ b/src/test/compile-fail/inner-static-type-parameter.rs
@@ -14,7 +14,7 @@ enum Bar<T> { What } //~ ERROR parameter `T` is never used
 
 fn foo<T>() {
     static a: Bar<T> = Bar::What;
-//~^ ERROR can't use type parameters from outer function; try using a local type parameter instead
+//~^ ERROR can't use type parameters from outer function
 }
 
 fn main() {

--- a/src/test/compile-fail/issue-3021-c.rs
+++ b/src/test/compile-fail/issue-3021-c.rs
@@ -11,8 +11,8 @@
 fn siphash<T>() {
 
     trait t {
-        fn g(&self, x: T) -> T;  //~ ERROR can't use type parameters from outer function; try using
-        //~^ ERROR can't use type parameters from outer function; try using
+        fn g(&self, x: T) -> T;  //~ ERROR can't use type parameters from outer function
+        //~^ ERROR can't use type parameters from outer function
     }
 }
 

--- a/src/test/compile-fail/issue-3214.rs
+++ b/src/test/compile-fail/issue-3214.rs
@@ -10,7 +10,7 @@
 
 fn foo<T>() {
     struct foo {
-        x: T, //~ ERROR can't use type parameters from outer function;
+        x: T, //~ ERROR can't use type parameters from outer function
     }
 
     impl<T> Drop for foo<T> {

--- a/src/test/compile-fail/issue-5997-struct.rs
+++ b/src/test/compile-fail/issue-5997-struct.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 fn f<T>() -> bool {
-    struct S(T); //~ ERROR can't use type parameters from outer function; try using
+    struct S(T); //~ ERROR can't use type parameters from outer function
 
     true
 }

--- a/src/test/compile-fail/nested-ty-params.rs
+++ b/src/test/compile-fail/nested-ty-params.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:can't use type parameters from outer function; try using
+// error-pattern:can't use type parameters from outer function
 fn hd<U>(v: Vec<U> ) -> U {
     fn hd1(w: [U]) -> U { return w[0]; }
 

--- a/src/test/compile-fail/type-arg-out-of-scope.rs
+++ b/src/test/compile-fail/type-arg-out-of-scope.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:can't use type parameters from outer function; try using
+// error-pattern:can't use type parameters from outer function
 fn foo<T>(x: T) {
     fn bar(f: Box<FnMut(T) -> T>) { }
 }

--- a/src/test/ui/error-codes/E0401.rs
+++ b/src/test/ui/error-codes/E0401.rs
@@ -8,10 +8,32 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+trait Baz<T> {}
+
 fn foo<T>(x: T) {
-    fn bar(y: T) { //~ ERROR E0401
+    fn bar<U, V: Baz<U>, W: Fn()>(y: T) { //~ ERROR E0401
+    }
+    fn baz<U,
+           V: Baz<U>,
+           W: Fn()>
+           (y: T) { //~ ERROR E0401
     }
     bar(x);
+}
+
+
+struct A<T> {
+    inner: T,
+}
+
+impl<T> Iterator for A<T> {
+    type Item = u8;
+    fn next(&mut self) -> Option<u8> {
+        fn helper(sel: &Self) -> u8 { //~ ERROR E0401
+            unimplemented!();
+        }
+        Some(helper(self))
+    }
 }
 
 fn main() {

--- a/src/test/ui/error-codes/E0401.stderr
+++ b/src/test/ui/error-codes/E0401.stderr
@@ -1,9 +1,35 @@
-error[E0401]: can't use type parameters from outer function; try using a local type parameter instead
-  --> $DIR/E0401.rs:12:15
+error[E0401]: can't use type parameters from outer function
+  --> $DIR/E0401.rs:14:38
    |
-LL |     fn bar(y: T) { //~ ERROR E0401
-   |               ^ use of type variable from outer function
+LL | fn foo<T>(x: T) {
+   |        - type variable from outer function
+LL |     fn bar<U, V: Baz<U>, W: Fn()>(y: T) { //~ ERROR E0401
+   |        --------------------------    ^ use of type variable from outer function
+   |        |
+   |        help: try using a local type parameter instead: `bar<U, V: Baz<U>, W: Fn(), T>`
 
-error: aborting due to previous error
+error[E0401]: can't use type parameters from outer function
+  --> $DIR/E0401.rs:19:16
+   |
+LL | fn foo<T>(x: T) {
+   |        - type variable from outer function
+...
+LL |            (y: T) { //~ ERROR E0401
+   |                ^ use of type variable from outer function
+   |
+   = help: try using a local type parameter instead
+
+error[E0401]: can't use type parameters from outer function
+  --> $DIR/E0401.rs:32:25
+   |
+LL | impl<T> Iterator for A<T> {
+   | ---- `Self` type implicitely declared here, on the `impl`
+...
+LL |         fn helper(sel: &Self) -> u8 { //~ ERROR E0401
+   |            ------       ^^^^ use of type variable from outer function
+   |            |
+   |            help: try using a local type parameter instead: `helper<Self>`
+
+error: aborting due to 3 previous errors
 
 If you want more information on this error, try using "rustc --explain E0401"


### PR DESCRIPTION
Fix #14844 

r? @estebank 