### PR TITLE
Automaticaly calculate beta prerelease numbers

### DIFF
--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -26,11 +26,6 @@ use config::Config;
 // The version number
 pub const CFG_RELEASE_NUM: &str = "1.25.0";
 
-// An optional number to put after the label, e.g. '.2' -> '-beta.2'
-// Be sure to make this starts with a dot to conform to semver pre-release
-// versions (section 9)
-pub const CFG_PRERELEASE_VERSION: &str = ".1";
-
 pub struct GitInfo {
     inner: Option<Info>,
 }

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1652,7 +1652,6 @@ fn add_env(build: &Build, cmd: &mut Command, target: Interned<String>) {
     cmd.env("CFG_RELEASE_INFO", build.rust_version())
        .env("CFG_RELEASE_NUM", channel::CFG_RELEASE_NUM)
        .env("CFG_RELEASE", build.rust_release())
-       .env("CFG_PRERELEASE_VERSION", channel::CFG_PRERELEASE_VERSION)
        .env("CFG_VER_MAJOR", parts.next().unwrap())
        .env("CFG_VER_MINOR", parts.next().unwrap())
        .env("CFG_VER_PATCH", parts.next().unwrap())

--- a/src/ci/init_repo.sh
+++ b/src/ci/init_repo.sh
@@ -36,6 +36,12 @@ fi
 rm -rf "$CACHE_DIR"
 mkdir "$CACHE_DIR"
 
+# On the beta channel we'll be automatically calculating the prerelease version
+# via the git history, so unshallow our shallow clone from CI.
+if grep -q RUST_RELEASE_CHANNEL=beta src/ci/run.sh; then
+  git fetch origin --unshallow beta master
+fi
+
 travis_fold start update_cache
 travis_time_start
 


### PR DESCRIPTION
This is a forward-port of:

* 9426dda83d7a928d6ced377345e14b84b0f11c21
* cbfb9858951da7aee22d82178405306fca9decb1

from the beta branch which is used to automatically calculate the beta number
based on the number of merges to the beta branch so far.