### PR TITLE
Fix type inhabitedness check for arrays

### DIFF
--- a/src/librustc/ty/inhabitedness/mod.rs
+++ b/src/librustc/ty/inhabitedness/mod.rs
@@ -262,10 +262,11 @@ impl<'a, 'gcx, 'tcx> TyS<'tcx> {
                 }))
             },
             TyArray(ty, len) => {
-                if len.val.to_const_int().and_then(|i| i.to_u64()) == Some(0) {
-                    DefIdForest::empty()
-                } else {
-                    ty.uninhabited_from(visited, tcx)
+                match len.val.to_const_int().and_then(|i| i.to_u64()) {
+                    Some(n) if n != 0 => ty.uninhabited_from(visited, tcx),
+                    // If the array is definitely non-empty, it's uninhabited if
+                    // the type of its elements is uninhabited.
+                    _ => DefIdForest::empty()
                 }
             }
             TyRef(_, ref tm) => {

--- a/src/librustc/ty/inhabitedness/mod.rs
+++ b/src/librustc/ty/inhabitedness/mod.rs
@@ -263,9 +263,9 @@ impl<'a, 'gcx, 'tcx> TyS<'tcx> {
             },
             TyArray(ty, len) => {
                 match len.val.to_const_int().and_then(|i| i.to_u64()) {
-                    Some(n) if n != 0 => ty.uninhabited_from(visited, tcx),
                     // If the array is definitely non-empty, it's uninhabited if
                     // the type of its elements is uninhabited.
+                    Some(n) if n != 0 => ty.uninhabited_from(visited, tcx),
                     _ => DefIdForest::empty()
                 }
             }

--- a/src/test/compile-fail/empty-never-array.rs
+++ b/src/test/compile-fail/empty-never-array.rs
@@ -1,0 +1,26 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(never_type)]
+
+enum Helper<T, U> {
+    T(T, [!; 0]),
+    #[allow(dead_code)]
+    U(U),
+}
+
+fn transmute<T, U>(t: T) -> U {
+    let Helper::U(u) = Helper::T(t, []); //~ ERROR refutable pattern in local binding: `T(_, _)` not covered
+    u
+}
+
+fn main() {
+    println!("{:?}", transmute::<&str, (*const u8, u64)>("type safety"));
+}

--- a/src/test/compile-fail/empty-never-array.rs
+++ b/src/test/compile-fail/empty-never-array.rs
@@ -17,7 +17,8 @@ enum Helper<T, U> {
 }
 
 fn transmute<T, U>(t: T) -> U {
-    let Helper::U(u) = Helper::T(t, []); //~ ERROR refutable pattern in local binding: `T(_, _)` not covered
+    let Helper::U(u) = Helper::T(t, []);
+    //~^ ERROR refutable pattern in local binding: `T(_, _)` not covered
     u
 }
 


### PR DESCRIPTION
Arrays of uninhabited types were considered to also be uninhabited if
their length had not been evaluated, causing unsoundness.

Fixes #47563.

r? @eddyb