### PR TITLE
LLVM5: Update DW_OP_plus to DW_OP_plus_uconst

### DIFF
--- a/src/librustc_llvm/ffi.rs
+++ b/src/librustc_llvm/ffi.rs
@@ -1546,7 +1546,7 @@ extern "C" {
                                                 InlinedAt: MetadataRef)
                                                 -> ValueRef;
     pub fn LLVMRustDIBuilderCreateOpDeref() -> i64;
-    pub fn LLVMRustDIBuilderCreateOpPlus() -> i64;
+    pub fn LLVMRustDIBuilderCreateOpPlusUconst() -> i64;
 
     pub fn LLVMRustWriteTypeToString(Type: TypeRef, s: RustStringRef);
     pub fn LLVMRustWriteValueToString(value_ref: ValueRef, s: RustStringRef);

--- a/src/librustc_trans/mir/mod.rs
+++ b/src/librustc_trans/mir/mod.rs
@@ -547,7 +547,7 @@ fn arg_local_refs<'a, 'tcx>(bx: &Builder<'a, 'tcx>,
 
                 let ops = unsafe {
                     [llvm::LLVMRustDIBuilderCreateOpDeref(),
-                     llvm::LLVMRustDIBuilderCreateOpPlus(),
+                     llvm::LLVMRustDIBuilderCreateOpPlusUconst(),
                      byte_offset_of_var_in_env as i64,
                      llvm::LLVMRustDIBuilderCreateOpDeref()]
                 };

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -866,7 +866,14 @@ extern "C" int64_t LLVMRustDIBuilderCreateOpDeref() {
   return dwarf::DW_OP_deref;
 }
 
-extern "C" int64_t LLVMRustDIBuilderCreateOpPlus() { return dwarf::DW_OP_plus; }
+extern "C" int64_t LLVMRustDIBuilderCreateOpPlusUconst() {
+#if LLVM_VERSION_GE(5, 0)
+  return dwarf::DW_OP_plus_uconst;
+#else
+  // older LLVM used `plus` to behave like `plus_uconst`.
+  return dwarf::DW_OP_plus;
+#endif
+}
 
 extern "C" void LLVMRustWriteTypeToString(LLVMTypeRef Ty, RustStringRef Str) {
   RawRustStringOstream OS(Str);


### PR DESCRIPTION
LLVM <= 4.0 used a non-standard interpretation of `DW_OP_plus`.  In the
DWARF standard, this adds two items on the expressions stack.  LLVM's
behavior was more like DWARF's `DW_OP_plus_uconst` -- adding a constant
that follows the op.  The patch series starting with [D33892] switched
to the standard DWARF interpretation, so we need to follow.

[D33892]: https://reviews.llvm.org/D33892

Fixes #47464 
r? @eddyb 