### PR TITLE
Fix oversized loads on x86_64 SysV FFI calls

### DIFF
--- a/src/librustc_trans/cabi_x86_64.rs
+++ b/src/librustc_trans/cabi_x86_64.rs
@@ -134,12 +134,13 @@ fn reg_component(cls: &[Option<Class>], i: &mut usize, size: Size) -> Option<Reg
         None => None,
         Some(Class::Int) => {
             *i += 1;
-            Some(match size.bytes() {
-                1 => Reg::i8(),
-                2 => Reg::i16(),
-                3 |
-                4 => Reg::i32(),
-                _ => Reg::i64()
+            Some(if size.bytes() < 8 {
+                Reg {
+                    kind: RegKind::Integer,
+                    size
+                }
+            } else {
+                Reg::i64()
             })
         }
         Some(Class::Sse) => {

--- a/src/test/codegen/abi-x86_64_sysv.rs
+++ b/src/test/codegen/abi-x86_64_sysv.rs
@@ -1,0 +1,39 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// only-x86_64
+
+// compile-flags: -C no-prepopulate-passes
+
+#![crate_type = "lib"]
+
+pub struct S24 {
+  a: i8,
+  b: i8,
+  c: i8,
+}
+
+pub struct S48 {
+  a: i16,
+  b: i16,
+  c: i8,
+}
+
+// CHECK: i24 @struct_24_bits(i24
+#[no_mangle]
+pub extern "sysv64" fn struct_24_bits(a: S24) -> S24 {
+  a
+}
+
+// CHECK: i48 @struct_48_bits(i48
+#[no_mangle]
+pub extern "sysv64" fn struct_48_bits(a: S48) -> S48 {
+  a
+}

--- a/src/test/codegen/repr-transparent-sysv64.rs
+++ b/src/test/codegen/repr-transparent-sysv64.rs
@@ -1,0 +1,39 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// only-x86_64
+
+// compile-flags: -C no-prepopulate-passes
+
+#![crate_type="lib"]
+#![feature(repr_transparent)]
+
+#[repr(C)]
+pub struct Rgb8 { r: u8, g: u8, b: u8 }
+
+#[repr(transparent)]
+pub struct Rgb8Wrap(Rgb8);
+
+// CHECK: i24 @test_Rgb8Wrap(i24)
+#[no_mangle]
+pub extern "sysv64" fn test_Rgb8Wrap(_: Rgb8Wrap) -> Rgb8Wrap { loop {} }
+
+#[repr(C)]
+pub union FloatBits {
+    float: f32,
+    bits: u32,
+}
+
+#[repr(transparent)]
+pub struct SmallUnion(FloatBits);
+
+// CHECK: i32 @test_SmallUnion(i32)
+#[no_mangle]
+pub extern "sysv64" fn test_SmallUnion(_: SmallUnion) -> SmallUnion { loop {} }


### PR DESCRIPTION
The x86_64 SysV ABI should use exact sizes for small structs passed in
registers, i.e. a struct that occupies 3 bytes should use an i24,
instead of the i32 it currently uses.

Refs #45543