### PR TITLE
Fix GDB pretty-printers for compressed enums

### DIFF
--- a/src/etc/debugger_pretty_printers_common.py
+++ b/src/etc/debugger_pretty_printers_common.py
@@ -289,7 +289,7 @@ class EncodedEnumInfo(object):
 
         # If the discriminant field is a fat pointer we have to consider the
         # first word as the true discriminant
-        if discriminant_val.type.get_dwarf_type_kind() == DWARF_TYPE_CODE_STRUCT:
+        while discriminant_val.type.get_dwarf_type_kind() == DWARF_TYPE_CODE_STRUCT:
             discriminant_val = discriminant_val.get_child_at_index(0)
 
         return discriminant_val.as_integer() == 0


### PR DESCRIPTION
Pretty-printing of `Option` failed with exception:
```
Traceback (most recent call last):
  File "/opt/rust-bin-9999/lib/rustlib/etc/gdb_rust_pretty_printing.py", line 166, in rust_pretty_printer_lookup_function
    if encoded_enum_info.is_null_variant():
  File "/opt/rust-bin-9999/lib/rustlib/etc/debugger_pretty_printers_common.py", line 295, in is_null_variant
    return discriminant_val.as_integer() == 0
  File "/opt/rust-bin-9999/lib/rustlib/etc/gdb_rust_pretty_printing.py", line 83, in as_integer
    return int(self.gdb_val)
gdb.error: Cannot convert value to long.
```
|Before|After|
|---|---|
|![gdb_before](https://user-images.githubusercontent.com/1297574/35187244-6b6c4f90-fe29-11e7-85d3-6cfd37ab5821.png)|![gdb_after](https://user-images.githubusercontent.com/1297574/35187245-716d1816-fe29-11e7-809c-46c46b8e0e3d.png)|

`main.rs`
```rust
fn main() {
    let vec_u8: Option<Vec<u8>> = Some(vec![1,2,3]);
    let empty_vec_u8: Option<Vec<u8>> = None;
    let string: Option<String> = Some("I'm an optional string!".to_owned());
    let empty_string: Option<String> = None;

     println!("breakpoint here");
}
```