### PR TITLE
Fix spurious warning on empty proc macro crates

### DIFF
--- a/src/libsyntax_ext/proc_macro_registrar.rs
+++ b/src/libsyntax_ext/proc_macro_registrar.rs
@@ -381,7 +381,7 @@ fn mk_registrar(cx: &mut ExtCtxt,
 
     let __internal = Ident::from_str("__internal");
     let registry = Ident::from_str("Registry");
-    let registrar = Ident::from_str("registrar");
+    let registrar = Ident::from_str("_registrar");
     let register_custom_derive = Ident::from_str("register_custom_derive");
     let register_attr_proc_macro = Ident::from_str("register_attr_proc_macro");
     let register_bang_proc_macro = Ident::from_str("register_bang_proc_macro");

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/empty-crate.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/empty-crate.rs
@@ -1,0 +1,14 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+#![deny(unused_variables)]

--- a/src/test/run-pass-fulldeps/proc-macro/empty-crate.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/empty-crate.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:empty-crate.rs
+// ignore-stage1
+
+#[macro_use]
+extern crate empty_crate;
+
+fn main() {}


### PR DESCRIPTION
While attempting to reproduce rust-lang/rust#47086 I noticed the following warning:

```shell
> rustc /dev/null --crate-type proc-macro
warning: unused variable: `registrar`
 --> /dev/null:0:1
```

As there are no macros to register the automatically generated registrar function for the crate has no body. As a result its `registrar` argument is unused triggering the above warning.

The warning is confusing and not easily actionable by the developer. It could also be triggered legitimately by e.g. having all of the macros in a crate #[cfg]'ed out.

Fix by naming the generated argument `_registrar` inside `mk_registrar()`. This suppresses the unused variable warning.