### PR TITLE
Do not assume dynamic linking for musl/mips[el] targets

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -80,7 +80,7 @@ impl Step for Std {
 
             // Even if we're not building std this stage, the new sysroot must
             // still contain the musl startup objects.
-            if target.contains("musl") && !target.contains("mips") {
+            if target.contains("musl") {
                 let libdir = builder.sysroot_libdir(compiler, target);
                 copy_musl_third_party_objects(build, target, &libdir);
             }
@@ -97,7 +97,7 @@ impl Step for Std {
         println!("Building stage{} std artifacts ({} -> {})", compiler.stage,
                 &compiler.host, target);
 
-        if target.contains("musl") && !target.contains("mips") {
+        if target.contains("musl") {
             let libdir = builder.sysroot_libdir(compiler, target);
             copy_musl_third_party_objects(build, target, &libdir);
         }

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -120,6 +120,10 @@ v("musl-root-armv7", "target.armv7-unknown-linux-musleabihf.musl-root",
   "armv7-unknown-linux-musleabihf install directory")
 v("musl-root-aarch64", "target.aarch64-unknown-linux-musl.musl-root",
   "aarch64-unknown-linux-musl install directory")
+v("musl-root-mips", "target.mips-unknown-linux-musl.musl-root",
+  "mips-unknown-linux-musl install directory")
+v("musl-root-mipsel", "target.mipsel-unknown-linux-musl.musl-root",
+  "mipsel-unknown-linux-musl install directory")
 v("qemu-armhf-rootfs", "target.arm-unknown-linux-gnueabihf.qemu-rootfs",
   "rootfs in qemu testing, you probably don't want to use this")
 v("qemu-aarch64-rootfs", "target.aarch64-unknown-linux-gnu.qemu-rootfs",

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -170,7 +170,7 @@ pub fn check(build: &mut Build) {
         }
 
         // Make sure musl-root is valid
-        if target.contains("musl") && !target.contains("mips") {
+        if target.contains("musl") {
             // If this is a native target (host is also musl) and no musl-root is given,
             // fall back to the system toolchain in /usr before giving up
             if build.musl_root(*target).is_none() && build.config.build == *target {

--- a/src/ci/docker/dist-i586-gnu-i586-i686-musl/Dockerfile
+++ b/src/ci/docker/dist-i586-gnu-i586-i686-musl/Dockerfile
@@ -18,10 +18,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /build/
 COPY scripts/musl.sh /build/
-RUN CC=gcc CFLAGS="-m32 -fPIC -Wa,-mrelax-relocations=no" \
+RUN CC=gcc CFLAGS="-m32 -Wa,-mrelax-relocations=no" \
     CXX=g++ CXXFLAGS="-m32 -Wa,-mrelax-relocations=no" \
     bash musl.sh i686 --target=i686 && \
-    CC=gcc CFLAGS="-march=pentium -m32 -fPIC -Wa,-mrelax-relocations=no" \
+    CC=gcc CFLAGS="-march=pentium -m32 -Wa,-mrelax-relocations=no" \
     CXX=g++ CXXFLAGS="-march=pentium -m32 -Wa,-mrelax-relocations=no" \
     bash musl.sh i586 --target=i586 && \
     rm -rf /build

--- a/src/ci/docker/dist-various-1/Dockerfile
+++ b/src/ci/docker/dist-various-1/Dockerfile
@@ -89,7 +89,6 @@ ENV CC_mipsel_unknown_linux_musl=mipsel-openwrt-linux-gcc \
     CFLAGS_armv5te_unknown_linux_gnueabi="-march=armv5te -marm -mfloat-abi=soft"
 
 ENV RUST_CONFIGURE_ARGS \
-      --enable-extended \
       --target=$TARGETS \
       --musl-root-arm=/musl-arm \
       --musl-root-armhf=/musl-armhf \

--- a/src/ci/docker/dist-various-1/Dockerfile
+++ b/src/ci/docker/dist-various-1/Dockerfile
@@ -30,6 +30,15 @@ RUN ./build-rumprun.sh
 COPY dist-various-1/install-x86_64-redox.sh /build
 RUN ./install-x86_64-redox.sh
 
+COPY dist-various-1/install-mips-musl.sh /build
+RUN ./install-mips-musl.sh
+
+COPY dist-various-1/install-mipsel-musl.sh /build
+RUN ./install-mipsel-musl.sh
+
+# Suppress some warnings in the openwrt toolchains we downloaded
+ENV STAGING_DIR=/tmp
+
 COPY scripts/musl.sh /build
 RUN env \
     CC=arm-linux-gnueabi-gcc CFLAGS="-march=armv6 -marm" \
@@ -47,13 +56,15 @@ RUN env \
     CC=aarch64-linux-gnu-gcc \
     CXX=aarch64-linux-gnu-g++ \
     bash musl.sh aarch64 && \
+    env \
+    CC=mips-openwrt-linux-gcc \
+    CXX=mips-openwrt-linux-g++ \
+    bash musl.sh mips && \
+    env \
+    CC=mipsel-openwrt-linux-gcc \
+    CXX=mipsel-openwrt-linux-g++ \
+    bash musl.sh mipsel && \
     rm -rf /build/*
-
-COPY dist-various-1/install-mips-musl.sh /build
-RUN ./install-mips-musl.sh
-
-COPY dist-various-1/install-mipsel-musl.sh /build
-RUN ./install-mipsel-musl.sh
 
 ENV TARGETS=asmjs-unknown-emscripten
 ENV TARGETS=$TARGETS,wasm32-unknown-emscripten
@@ -77,16 +88,16 @@ ENV CC_mipsel_unknown_linux_musl=mipsel-openwrt-linux-gcc \
     CC_armv5te_unknown_linux_gnueabi=arm-linux-gnueabi-gcc \
     CFLAGS_armv5te_unknown_linux_gnueabi="-march=armv5te -marm -mfloat-abi=soft"
 
-# Suppress some warnings in the openwrt toolchains we downloaded
-ENV STAGING_DIR=/tmp
-
 ENV RUST_CONFIGURE_ARGS \
       --enable-extended \
       --target=$TARGETS \
       --musl-root-arm=/musl-arm \
       --musl-root-armhf=/musl-armhf \
       --musl-root-armv7=/musl-armv7 \
-      --musl-root-aarch64=/musl-aarch64
+      --musl-root-aarch64=/musl-aarch64 \
+      --musl-root-mips=/musl-mips \
+      --musl-root-mipsel=/musl-mipsel
+
 ENV SCRIPT python2.7 ../x.py dist --target $TARGETS
 
 # sccache

--- a/src/ci/docker/dist-x86_64-musl/Dockerfile
+++ b/src/ci/docker/dist-x86_64-musl/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /build/
 COPY scripts/musl.sh /build/
 # We need to mitigate rust-lang/rust#34978 when compiling musl itself as well
 RUN CC=gcc \
-    CFLAGS="-fPIC -Wa,-mrelax-relocations=no" \
+    CFLAGS="-Wa,-mrelax-relocations=no" \
     CXX=g++ \
     CXXFLAGS="-Wa,-mrelax-relocations=no" \
     bash musl.sh x86_64 && rm -rf /build

--- a/src/ci/docker/scripts/musl.sh
+++ b/src/ci/docker/scripts/musl.sh
@@ -49,7 +49,16 @@ hide_output make clean
 
 cd ..
 
-LLVM=39
+# use version 60 for all targets after llvm 6.0 release
+case $TAG in
+  mips|mipsel)
+    LLVM=60
+    ;;
+  *)
+    LLVM=39
+    ;;
+esac
+
 # may have been downloaded in a previous run
 if [ ! -d libunwind-release_$LLVM ]; then
   curl -L https://github.com/llvm-mirror/llvm/archive/release_$LLVM.tar.gz | tar xzf -

--- a/src/ci/docker/scripts/musl.sh
+++ b/src/ci/docker/scripts/musl.sh
@@ -57,37 +57,6 @@ LLVM=60
 if [ ! -d libunwind-release_$LLVM ]; then
   curl -L https://github.com/llvm-mirror/llvm/archive/release_$LLVM.tar.gz | tar xzf -
   curl -L https://github.com/llvm-mirror/libunwind/archive/release_$LLVM.tar.gz | tar xzf -
-  # Whoa what's this mysterious patch we're applying to libunwind! Why are we
-  # swapping the values of ESP/EBP in libunwind?!
-  #
-  # Discovered in #35599 it turns out that the vanilla build of libunwind is not
-  # suitable for unwinding i686 musl. After some investigation it ended up
-  # looking like the register values for ESP/EBP were indeed incorrect (swapped)
-  # in the source. Similar commits in libunwind (r280099 and r282589) have noticed
-  # this for other platforms, and we just need to realize it for musl linux as
-  # well.
-  #
-  # More technical info can be found at #35599
-  cd libunwind-release_$LLVM
-  patch -Np1 << EOF
-diff --git a/include/libunwind.h b/include/libunwind.h
-index c5b9633..1360eb2 100644
---- a/include/libunwind.h
-+++ b/include/libunwind.h
-@@ -151,8 +151,8 @@ enum {
-   UNW_X86_ECX = 1,
-   UNW_X86_EDX = 2,
-   UNW_X86_EBX = 3,
--  UNW_X86_EBP = 4,
--  UNW_X86_ESP = 5,
-+  UNW_X86_ESP = 4,
-+  UNW_X86_EBP = 5,
-   UNW_X86_ESI = 6,
-   UNW_X86_EDI = 7
- };
-fi
-EOF
-  cd ..
 fi
 
 mkdir libunwind-build

--- a/src/ci/docker/scripts/musl.sh
+++ b/src/ci/docker/scripts/musl.sh
@@ -30,6 +30,8 @@ exit 1
 TAG=$1
 shift
 
+export CFLAGS="-fPIC $CFLAGS"
+
 MUSL=musl-1.1.18
 
 # may have been downloaded in a previous run

--- a/src/ci/docker/scripts/musl.sh
+++ b/src/ci/docker/scripts/musl.sh
@@ -49,15 +49,7 @@ hide_output make clean
 
 cd ..
 
-# use version 60 for all targets after llvm 6.0 release
-case $TAG in
-  mips|mipsel)
-    LLVM=60
-    ;;
-  *)
-    LLVM=39
-    ;;
-esac
+LLVM=60
 
 # may have been downloaded in a previous run
 if [ ! -d libunwind-release_$LLVM ]; then

--- a/src/librustc_back/target/mips_unknown_linux_musl.rs
+++ b/src/librustc_back/target/mips_unknown_linux_musl.rs
@@ -18,6 +18,7 @@ pub fn target() -> TargetResult {
     base.max_atomic_width = Some(32);
     // see #36994
     base.exe_allocation_crate = None;
+    base.crt_static_default = false;
     Ok(Target {
         llvm_target: "mips-unknown-linux-musl".to_string(),
         target_endian: "big".to_string(),

--- a/src/librustc_back/target/mips_unknown_linux_musl.rs
+++ b/src/librustc_back/target/mips_unknown_linux_musl.rs
@@ -9,9 +9,15 @@
 // except according to those terms.
 
 use LinkerFlavor;
-use target::{Target, TargetOptions, TargetResult};
+use target::{Target, TargetResult};
 
 pub fn target() -> TargetResult {
+    let mut base = super::linux_musl_base::opts();
+    base.cpu = "mips32r2".to_string();
+    base.features = "+mips32r2,+soft-float".to_string();
+    base.max_atomic_width = Some(32);
+    // see #36994
+    base.exe_allocation_crate = None;
     Ok(Target {
         llvm_target: "mips-unknown-linux-musl".to_string(),
         target_endian: "big".to_string(),
@@ -23,15 +29,6 @@ pub fn target() -> TargetResult {
         target_env: "musl".to_string(),
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
-        options: TargetOptions {
-            cpu: "mips32r2".to_string(),
-            features: "+mips32r2,+soft-float".to_string(),
-            max_atomic_width: Some(32),
-
-            // see #36994
-            exe_allocation_crate: None,
-
-            ..super::linux_base::opts()
-        }
+        options: base,
     })
 }

--- a/src/librustc_back/target/mipsel_unknown_linux_musl.rs
+++ b/src/librustc_back/target/mipsel_unknown_linux_musl.rs
@@ -18,6 +18,7 @@ pub fn target() -> TargetResult {
     base.max_atomic_width = Some(32);
     // see #36994
     base.exe_allocation_crate = None;
+    base.crt_static_default = false;
     Ok(Target {
         llvm_target: "mipsel-unknown-linux-musl".to_string(),
         target_endian: "little".to_string(),

--- a/src/librustc_back/target/mipsel_unknown_linux_musl.rs
+++ b/src/librustc_back/target/mipsel_unknown_linux_musl.rs
@@ -9,9 +9,15 @@
 // except according to those terms.
 
 use LinkerFlavor;
-use target::{Target, TargetOptions, TargetResult};
+use target::{Target, TargetResult};
 
 pub fn target() -> TargetResult {
+    let mut base = super::linux_musl_base::opts();
+    base.cpu = "mips32".to_string();
+    base.features = "+mips32,+soft-float".to_string();
+    base.max_atomic_width = Some(32);
+    // see #36994
+    base.exe_allocation_crate = None;
     Ok(Target {
         llvm_target: "mipsel-unknown-linux-musl".to_string(),
         target_endian: "little".to_string(),
@@ -23,15 +29,6 @@ pub fn target() -> TargetResult {
         target_env: "musl".to_string(),
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
-        options: TargetOptions {
-            cpu: "mips32".to_string(),
-            features: "+mips32,+soft-float".to_string(),
-            max_atomic_width: Some(32),
-
-            // see #36994
-            exe_allocation_crate: None,
-
-            ..super::linux_base::opts()
-        }
+        options: base,
     })
 }

--- a/src/libunwind/build.rs
+++ b/src/libunwind/build.rs
@@ -15,7 +15,7 @@ fn main() {
     let target = env::var("TARGET").expect("TARGET was not set");
 
     if target.contains("linux") {
-        if target.contains("musl") && !target.contains("mips") {
+        if target.contains("musl") {
             // musl is handled in lib.rs
         } else if !target.contains("android") {
             println!("cargo:rustc-link-lib=gcc_s");

--- a/src/libunwind/lib.rs
+++ b/src/libunwind/lib.rs
@@ -35,7 +35,7 @@ cfg_if! {
     }
 }
 
-#[cfg(all(target_env = "musl", not(target_arch = "mips")))]
+#[cfg(target_env = "musl")]
 #[link(name = "unwind", kind = "static", cfg(target_feature = "crt-static"))]
 #[link(name = "gcc_s", cfg(not(target_feature = "crt-static")))]
 extern {}


### PR DESCRIPTION
All musl targets except mips[el] assume static linking by default. This can be [confusing](https://users.rust-lang.org/t/static-cross-compiled-binaries-arent-really-static/6084).

When the musl/mips[el] targets was [added](https://github.com/rust-lang/rust/pull/31298), dynamic linking was chosen because of binary size concerns, and probably also because libunwind [didn't](https://users.rust-lang.org/t/static-cross-compiled-binaries-arent-really-static/6084/8) supported mips.

Now that we have `crt-static` target-feature (the user can choose dynamic link for musl targets), and libunwind [6.0](https://github.com/llvm-mirror/libunwind/commits/release_60) add support to mips, we do not need to assume dynamic linking.