### PR TITLE
[feedback] per-edge dataflow

### DIFF
--- a/src/librustc_data_structures/access_tracker.rs
+++ b/src/librustc_data_structures/access_tracker.rs
@@ -1,0 +1,50 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::ops::{Deref, DerefMut};
+
+/// Takes ownership of `T` and tracks whether it was accessed mutably
+/// (via `DerefMut`). You can access this via the `maybe_mutated` fn.
+#[derive(Clone, Debug)]
+pub struct AccessTracker<T> {
+    value: T,
+    mutated: bool,
+}
+
+impl<T> AccessTracker<T> {
+    pub fn new(value: T) -> Self {
+        AccessTracker { value, mutated: false }
+    }
+
+    /// True if the owned value was accessed mutably (so far).
+    pub fn maybe_mutated(this: &Self) -> bool {
+        this.mutated
+    }
+
+    pub fn into_inner(this: Self) -> (T, bool) {
+        (this.value, this.mutated)
+    }
+}
+
+impl<T> Deref for AccessTracker<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.value
+    }
+}
+
+impl<T> DerefMut for AccessTracker<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        self.mutated = true;
+        &mut self.value
+    }
+}
+

--- a/src/librustc_data_structures/indexed_set.rs
+++ b/src/librustc_data_structures/indexed_set.rs
@@ -161,6 +161,11 @@ impl<T: Idx> IdxSet<T> {
         }
     }
 
+    /// True if there are no elements
+    pub fn is_empty(&self) -> bool {
+        self.bits.iter().all(|&b| b == 0)
+    }
+
     /// Removes all elements
     pub fn clear(&mut self) {
         for b in &mut self.bits {

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -52,6 +52,7 @@ extern crate stable_deref_trait;
 pub use rustc_serialize::hex::ToHex;
 
 pub mod array_vec;
+pub mod access_tracker;
 pub mod accumulate_vec;
 pub mod small_vec;
 pub mod base_n;

--- a/src/librustc_mir/dataflow/impls/borrows.rs
+++ b/src/librustc_mir/dataflow/impls/borrows.rs
@@ -19,6 +19,7 @@ use rustc::ty::RegionKind;
 use rustc::ty::RegionKind::ReScope;
 use rustc::util::nodemap::{FxHashMap, FxHashSet};
 
+use rustc_data_structures::access_tracker::AccessTracker;
 use rustc_data_structures::bitslice::{BitwiseOperator};
 use rustc_data_structures::indexed_set::{IdxSet};
 use rustc_data_structures::indexed_vec::{Idx, IndexVec};
@@ -679,7 +680,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for Reservations<'a, 'gcx, 'tcx> {
 
     fn edge_effect(
         &self,
-        _sets: &mut BlockSets<Self::Idx>,
+        _sets: &mut AccessTracker<&mut BlockSets<Self::Idx>>,
         _source_block: mir::BasicBlock,
         _edge_kind: EdgeKind<'_>,
         _target_terminator: mir::BasicBlock,
@@ -742,7 +743,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for ActiveBorrows<'a, 'gcx, 'tcx> {
 
     fn edge_effect(
         &self,
-        _sets: &mut BlockSets<Self::Idx>,
+        _sets: &mut AccessTracker<&mut BlockSets<Self::Idx>>,
         _source_block: mir::BasicBlock,
         _edge_kind: EdgeKind<'_>,
         _target_terminator: mir::BasicBlock,

--- a/src/librustc_mir/dataflow/impls/borrows.rs
+++ b/src/librustc_mir/dataflow/impls/borrows.rs
@@ -678,7 +678,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for Reservations<'a, 'gcx, 'tcx> {
     }
 
     fn propagate_call_return(&self,
-                             _in_out: &mut IdxSet<ReserveOrActivateIndex>,
+                             _sets: &mut BlockSets<'_, ReserveOrActivateIndex>,
                              _call_bb: mir::BasicBlock,
                              _dest_bb: mir::BasicBlock,
                              _dest_place: &mir::Place) {
@@ -739,7 +739,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for ActiveBorrows<'a, 'gcx, 'tcx> {
     }
 
     fn propagate_call_return(&self,
-                             _in_out: &mut IdxSet<ReserveOrActivateIndex>,
+                             _sets: &mut BlockSets<'_, ReserveOrActivateIndex>,
                              _call_bb: mir::BasicBlock,
                              _dest_bb: mir::BasicBlock,
                              _dest_place: &mir::Place) {

--- a/src/librustc_mir/dataflow/impls/borrows.rs
+++ b/src/librustc_mir/dataflow/impls/borrows.rs
@@ -23,7 +23,7 @@ use rustc_data_structures::bitslice::{BitwiseOperator};
 use rustc_data_structures::indexed_set::{IdxSet};
 use rustc_data_structures::indexed_vec::{Idx, IndexVec};
 
-use dataflow::{BitDenotation, BlockSets, InitialFlow};
+use dataflow::{BitDenotation, BlockSets, EdgeKind, InitialFlow};
 pub use dataflow::indexes::{BorrowIndex, ReserveOrActivateIndex};
 use borrow_check::nll::region_infer::RegionInferenceContext;
 use borrow_check::nll::ToRegionVid;
@@ -677,12 +677,14 @@ impl<'a, 'gcx, 'tcx> BitDenotation for Reservations<'a, 'gcx, 'tcx> {
         self.0.terminator_effect_on_borrows(sets, location, false);
     }
 
-    fn propagate_call_return(&self,
-                             _sets: &mut BlockSets<'_, ReserveOrActivateIndex>,
-                             _call_bb: mir::BasicBlock,
-                             _dest_bb: mir::BasicBlock,
-                             _dest_place: &mir::Place) {
-        // there are no effects on borrows from method call return...
+    fn edge_effect(
+        &self,
+        _sets: &mut BlockSets<Self::Idx>,
+        _source_block: mir::BasicBlock,
+        _edge_kind: EdgeKind<'_>,
+        _target_terminator: mir::BasicBlock,
+    ) {
+        // there are no effects on borrows from edges...
         //
         // ... but if overwriting a place can affect flow state, then
         // latter is not true; see NOTE on Assign case in
@@ -738,12 +740,14 @@ impl<'a, 'gcx, 'tcx> BitDenotation for ActiveBorrows<'a, 'gcx, 'tcx> {
         self.0.terminator_effect_on_borrows(sets, location, true);
     }
 
-    fn propagate_call_return(&self,
-                             _sets: &mut BlockSets<'_, ReserveOrActivateIndex>,
-                             _call_bb: mir::BasicBlock,
-                             _dest_bb: mir::BasicBlock,
-                             _dest_place: &mir::Place) {
-        // there are no effects on borrows from method call return...
+    fn edge_effect(
+        &self,
+        _sets: &mut BlockSets<Self::Idx>,
+        _source_block: mir::BasicBlock,
+        _edge_kind: EdgeKind<'_>,
+        _target_terminator: mir::BasicBlock,
+    ) {
+        // there are no effects on borrows from edges...
         //
         // ... but If overwriting a place can affect flow state, then
         // latter is not true; see NOTE on Assign case in

--- a/src/librustc_mir/dataflow/impls/mod.rs
+++ b/src/librustc_mir/dataflow/impls/mod.rs
@@ -14,6 +14,7 @@
 
 use rustc::ty::TyCtxt;
 use rustc::mir::{self, Mir, Location};
+use rustc_data_structures::access_tracker::AccessTracker;
 use rustc_data_structures::bitslice::{BitwiseOperator};
 use rustc_data_structures::indexed_set::{IdxSet};
 use rustc_data_structures::indexed_vec::Idx;
@@ -364,7 +365,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for MaybeInitializedLvals<'a, 'gcx, 'tcx> {
 
     fn edge_effect(
         &self,
-        sets: &mut BlockSets<Self::Idx>,
+        sets: &mut AccessTracker<&mut BlockSets<Self::Idx>>,
         _source_block: mir::BasicBlock,
         edge_kind: EdgeKind<'_>,
         _target_block: mir::BasicBlock,
@@ -432,7 +433,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for MaybeUninitializedLvals<'a, 'gcx, 'tcx> {
 
     fn edge_effect(
         &self,
-        sets: &mut BlockSets<Self::Idx>,
+        sets: &mut AccessTracker<&mut BlockSets<Self::Idx>>,
         _source_block: mir::BasicBlock,
         edge_kind: EdgeKind<'_>,
         _target_block: mir::BasicBlock,
@@ -499,7 +500,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for DefinitelyInitializedLvals<'a, 'gcx, 'tcx
 
     fn edge_effect(
         &self,
-        sets: &mut BlockSets<Self::Idx>,
+        sets: &mut AccessTracker<&mut BlockSets<Self::Idx>>,
         _source_block: mir::BasicBlock,
         edge_kind: EdgeKind<'_>,
         _target_block: mir::BasicBlock,
@@ -582,7 +583,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for MovingOutStatements<'a, 'gcx, 'tcx> {
 
     fn edge_effect(
         &self,
-        sets: &mut BlockSets<Self::Idx>,
+        sets: &mut AccessTracker<&mut BlockSets<Self::Idx>>,
         _source_block: mir::BasicBlock,
         edge_kind: EdgeKind<'_>,
         _target_terminator: mir::BasicBlock,
@@ -689,7 +690,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for EverInitializedLvals<'a, 'gcx, 'tcx> {
 
     fn edge_effect(
         &self,
-        sets: &mut BlockSets<Self::Idx>,
+        sets: &mut AccessTracker<&mut BlockSets<Self::Idx>>,
         source_block: mir::BasicBlock,
         edge_kind: EdgeKind<'_>,
         _target_block: mir::BasicBlock,

--- a/src/librustc_mir/dataflow/impls/mod.rs
+++ b/src/librustc_mir/dataflow/impls/mod.rs
@@ -292,7 +292,7 @@ impl<'a, 'gcx, 'tcx> HasMoveData<'tcx> for EverInitializedLvals<'a, 'gcx, 'tcx> 
 
 
 impl<'a, 'gcx, 'tcx> MaybeInitializedLvals<'a, 'gcx, 'tcx> {
-    fn update_bits(sets: &mut BlockSets<MovePathIndex>, path: MovePathIndex,
+    fn update_bits(sets: &mut BlockSets<'_, MovePathIndex>, path: MovePathIndex,
                    state: DropFlagState)
     {
         match state {
@@ -303,7 +303,7 @@ impl<'a, 'gcx, 'tcx> MaybeInitializedLvals<'a, 'gcx, 'tcx> {
 }
 
 impl<'a, 'gcx, 'tcx> MaybeUninitializedLvals<'a, 'gcx, 'tcx> {
-    fn update_bits(sets: &mut BlockSets<MovePathIndex>, path: MovePathIndex,
+    fn update_bits(sets: &mut BlockSets<'_, MovePathIndex>, path: MovePathIndex,
                    state: DropFlagState)
     {
         match state {
@@ -314,7 +314,7 @@ impl<'a, 'gcx, 'tcx> MaybeUninitializedLvals<'a, 'gcx, 'tcx> {
 }
 
 impl<'a, 'gcx, 'tcx> DefinitelyInitializedLvals<'a, 'gcx, 'tcx> {
-    fn update_bits(sets: &mut BlockSets<MovePathIndex>, path: MovePathIndex,
+    fn update_bits(sets: &mut BlockSets<'_, MovePathIndex>, path: MovePathIndex,
                    state: DropFlagState)
     {
         match state {
@@ -341,7 +341,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for MaybeInitializedLvals<'a, 'gcx, 'tcx> {
     }
 
     fn statement_effect(&self,
-                        sets: &mut BlockSets<MovePathIndex>,
+                        sets: &mut BlockSets<'_, MovePathIndex>,
                         location: Location)
     {
         drop_flag_effects_for_location(
@@ -352,7 +352,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for MaybeInitializedLvals<'a, 'gcx, 'tcx> {
     }
 
     fn terminator_effect(&self,
-                         sets: &mut BlockSets<MovePathIndex>,
+                         sets: &mut BlockSets<'_, MovePathIndex>,
                          location: Location)
     {
         drop_flag_effects_for_location(
@@ -396,7 +396,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for MaybeUninitializedLvals<'a, 'gcx, 'tcx> {
     }
 
     fn statement_effect(&self,
-                        sets: &mut BlockSets<MovePathIndex>,
+                        sets: &mut BlockSets<'_, MovePathIndex>,
                         location: Location)
     {
         drop_flag_effects_for_location(
@@ -407,7 +407,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for MaybeUninitializedLvals<'a, 'gcx, 'tcx> {
     }
 
     fn terminator_effect(&self,
-                         sets: &mut BlockSets<MovePathIndex>,
+                         sets: &mut BlockSets<'_, MovePathIndex>,
                          location: Location)
     {
         drop_flag_effects_for_location(
@@ -450,7 +450,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for DefinitelyInitializedLvals<'a, 'gcx, 'tcx
     }
 
     fn statement_effect(&self,
-                        sets: &mut BlockSets<MovePathIndex>,
+                        sets: &mut BlockSets<'_, MovePathIndex>,
                         location: Location)
     {
         drop_flag_effects_for_location(
@@ -461,7 +461,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for DefinitelyInitializedLvals<'a, 'gcx, 'tcx
     }
 
     fn terminator_effect(&self,
-                         sets: &mut BlockSets<MovePathIndex>,
+                         sets: &mut BlockSets<'_, MovePathIndex>,
                          location: Location)
     {
         drop_flag_effects_for_location(
@@ -497,7 +497,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for MovingOutStatements<'a, 'gcx, 'tcx> {
     }
 
     fn statement_effect(&self,
-                        sets: &mut BlockSets<MoveOutIndex>,
+                        sets: &mut BlockSets<'_, MoveOutIndex>,
                         location: Location) {
         let (tcx, mir, move_data) = (self.tcx, self.mir, self.move_data());
         let stmt = &mir[location.block].statements[location.statement_index];
@@ -525,7 +525,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for MovingOutStatements<'a, 'gcx, 'tcx> {
     }
 
     fn terminator_effect(&self,
-                         sets: &mut BlockSets<MoveOutIndex>,
+                         sets: &mut BlockSets<'_, MoveOutIndex>,
                          location: Location)
     {
         let (tcx, mir, move_data) = (self.tcx, self.mir, self.move_data());
@@ -542,7 +542,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for MovingOutStatements<'a, 'gcx, 'tcx> {
     }
 
     fn propagate_call_return(&self,
-                             in_out: &mut IdxSet<MoveOutIndex>,
+                             sets: &mut BlockSets<'_, MoveOutIndex>,
                              _call_bb: mir::BasicBlock,
                              _dest_bb: mir::BasicBlock,
                              dest_place: &mir::Place) {
@@ -575,7 +575,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for EverInitializedLvals<'a, 'gcx, 'tcx> {
     }
 
     fn statement_effect(&self,
-                        sets: &mut BlockSets<InitIndex>,
+                        sets: &mut BlockSets<'_, InitIndex>,
                         location: Location) {
         let (_, mir, move_data) = (self.tcx, self.mir, self.move_data());
         let stmt = &mir[location.block].statements[location.statement_index];
@@ -622,7 +622,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for EverInitializedLvals<'a, 'gcx, 'tcx> {
     }
 
     fn terminator_effect(&self,
-                         sets: &mut BlockSets<InitIndex>,
+                         sets: &mut BlockSets<'_, InitIndex>,
                          location: Location)
     {
         let (mir, move_data) = (self.mir, self.move_data());

--- a/src/librustc_mir/dataflow/impls/storage_liveness.rs
+++ b/src/librustc_mir/dataflow/impls/storage_liveness.rs
@@ -59,7 +59,7 @@ impl<'a, 'tcx> BitDenotation for MaybeStorageLive<'a, 'tcx> {
     }
 
     fn propagate_call_return(&self,
-                             _in_out: &mut IdxSet<Local>,
+                             _sets: &mut BlockSets<'_, Local>,
                              _call_bb: mir::BasicBlock,
                              _dest_bb: mir::BasicBlock,
                              _dest_place: &mir::Place) {

--- a/src/librustc_mir/dataflow/impls/storage_liveness.rs
+++ b/src/librustc_mir/dataflow/impls/storage_liveness.rs
@@ -58,12 +58,14 @@ impl<'a, 'tcx> BitDenotation for MaybeStorageLive<'a, 'tcx> {
         // Terminators have no effect
     }
 
-    fn propagate_call_return(&self,
-                             _sets: &mut BlockSets<'_, Local>,
-                             _call_bb: mir::BasicBlock,
-                             _dest_bb: mir::BasicBlock,
-                             _dest_place: &mir::Place) {
-        // Nothing to do when a call returns successfully
+    fn edge_effect(
+        &self,
+        _sets: &mut BlockSets<Self::Idx>,
+        _source_block: mir::BasicBlock,
+        _edge_kind: EdgeKind<'_>,
+        _target_terminator: mir::BasicBlock,
+    ) {
+        // No special effects on edges
     }
 }
 

--- a/src/librustc_mir/dataflow/impls/storage_liveness.rs
+++ b/src/librustc_mir/dataflow/impls/storage_liveness.rs
@@ -10,8 +10,9 @@
 
 pub use super::*;
 
-use rustc::mir::*;
 use dataflow::BitDenotation;
+use rustc::mir::*;
+use rustc_data_structures::access_tracker::AccessTracker;
 
 #[derive(Copy, Clone)]
 pub struct MaybeStorageLive<'a, 'tcx: 'a> {
@@ -60,7 +61,7 @@ impl<'a, 'tcx> BitDenotation for MaybeStorageLive<'a, 'tcx> {
 
     fn edge_effect(
         &self,
-        _sets: &mut BlockSets<Self::Idx>,
+        _sets: &mut AccessTracker<&mut BlockSets<Self::Idx>>,
         _source_block: mir::BasicBlock,
         _edge_kind: EdgeKind<'_>,
         _target_terminator: mir::BasicBlock,

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -612,11 +612,10 @@ pub trait BitDenotation: BitwiseOperator {
     /// `sets.on_entry` to that local clone into `statement_effect` and
     /// `terminator_effect`).
     ///
-    /// When its false, no local clone is constucted; instead a
-    /// reference directly into `on_entry` is passed along via
-    /// `sets.on_entry` instead, which represents the flow state at
-    /// the block's start, not necessarily the state immediately prior
-    /// to the statement/terminator under analysis.
+    /// When its false, no local clone is constucted; instead it is
+    /// undefined what `on_entry` points to (in practice, it will
+    /// frequently be a reference the flow state at the block's start,
+    /// but you should not rely on that).
     ///
     /// In either case, the passed reference is mutable; but this is a
     /// wart from using the `BlockSets` type in the API; the intention

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -835,31 +835,31 @@ impl<'a, 'tcx: 'a, D> DataflowAnalysis<'a, 'tcx, D> where D: BitDenotation
             mir::TerminatorKind::DropAndReplace {
                 ref target, value: _, location: _, unwind: None
             } => {
-                self.propagate_bits_into_entry_set_for(&mut sets.on_entry, changed, target);
+                self.propagate_bits_into_entry_set_for(&sets.on_entry, changed, target);
             }
             mir::TerminatorKind::Yield { resume: ref target, drop: Some(ref drop), .. } => {
-                self.propagate_bits_into_entry_set_for(&mut sets.on_entry, changed, target);
-                self.propagate_bits_into_entry_set_for(&mut sets.on_entry, changed, drop);
+                self.propagate_bits_into_entry_set_for(&sets.on_entry, changed, target);
+                self.propagate_bits_into_entry_set_for(&sets.on_entry, changed, drop);
             }
             mir::TerminatorKind::Assert { ref target, cleanup: Some(ref unwind), .. } |
             mir::TerminatorKind::Drop { ref target, location: _, unwind: Some(ref unwind) } |
             mir::TerminatorKind::DropAndReplace {
                 ref target, value: _, location: _, unwind: Some(ref unwind)
             } => {
-                self.propagate_bits_into_entry_set_for(&mut sets.on_entry, changed, target);
+                self.propagate_bits_into_entry_set_for(&sets.on_entry, changed, target);
                 if !self.dead_unwinds.contains(&bb) {
-                    self.propagate_bits_into_entry_set_for(&mut sets.on_entry, changed, unwind);
+                    self.propagate_bits_into_entry_set_for(&sets.on_entry, changed, unwind);
                 }
             }
             mir::TerminatorKind::SwitchInt { ref targets, .. } => {
                 for target in targets {
-                    self.propagate_bits_into_entry_set_for(&mut sets.on_entry, changed, target);
+                    self.propagate_bits_into_entry_set_for(&sets.on_entry, changed, target);
                 }
             }
             mir::TerminatorKind::Call { ref cleanup, ref destination, func: _, args: _ } => {
                 if let Some(ref unwind) = *cleanup {
                     if !self.dead_unwinds.contains(&bb) {
-                        self.propagate_bits_into_entry_set_for(&mut sets.on_entry, changed, unwind);
+                        self.propagate_bits_into_entry_set_for(&sets.on_entry, changed, unwind);
                     }
                 }
                 if let Some((ref dest_place, ref dest_bb)) = *destination {
@@ -869,13 +869,13 @@ impl<'a, 'tcx: 'a, D> DataflowAnalysis<'a, 'tcx, D> where D: BitDenotation
                     self.flow_state.operator.propagate_call_return(
                         sets, bb, *dest_bb, dest_place);
                     sets.apply_local_effect();
-                    self.propagate_bits_into_entry_set_for(&mut sets.on_entry, changed, dest_bb);
+                    self.propagate_bits_into_entry_set_for(&sets.on_entry, changed, dest_bb);
                 }
             }
             mir::TerminatorKind::FalseEdges { ref real_target, ref imaginary_targets } => {
-                self.propagate_bits_into_entry_set_for(&mut sets.on_entry, changed, real_target);
+                self.propagate_bits_into_entry_set_for(&sets.on_entry, changed, real_target);
                 for target in imaginary_targets {
-                    self.propagate_bits_into_entry_set_for(&mut sets.on_entry, changed, target);
+                    self.propagate_bits_into_entry_set_for(&sets.on_entry, changed, target);
                 }
             }
         }

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -15,7 +15,7 @@ use rustc_data_structures::indexed_vec::Idx;
 use rustc_data_structures::bitslice::{bitwise, BitwiseOperator};
 
 use rustc::ty::{self, TyCtxt};
-use rustc::mir::{self, Mir, BasicBlock, BasicBlockData, Location, Statement, Terminator};
+use rustc::mir::{self, BasicBlock, BasicBlockData, Location, Mir, Place, Statement, Terminator};
 use rustc::session::Session;
 
 use std::borrow::{Borrow, Cow};
@@ -576,6 +576,10 @@ impl<'a, E:Idx> BlockSets<'a, E> {
         self.gen_set.clear();
         self.kill_set.clear();
     }
+
+    fn has_empty_local_effect(&mut self) -> bool {
+        self.gen_set.is_empty() && self.kill_set.is_empty()
+    }
 }
 
 impl<E:Idx> AllSets<E> {
@@ -721,35 +725,59 @@ pub trait BitDenotation: BitwiseOperator {
     /// block, represented via GEN and KILL sets.
     ///
     /// The effects applied here cannot depend on which branch the
-    /// terminator took.
+    /// terminator took. Hence they are best understood as the effects
+    /// up to -- but not including -- the branches.
     fn terminator_effect(&self,
                          sets: &mut BlockSets<'_, Self::Idx>,
                          location: Location);
 
     /// Mutates the block-sets according to the (flow-dependent)
-    /// effect of a successful return from a Call terminator.
+    /// effect of a particular outgoing edge from a terminator. For
+    /// many terminators/operators, this is a no-op, since the effect
+    /// of the terminator is not dependent on which branch is taken
+    /// and hence can be accumulated via `terminator_effect`.
     ///
-    /// If basic-block BB_x ends with a call-instruction that, upon
-    /// successful return, flows to BB_y, then this method will be
-    /// called on the exit flow-state of BB_x in order to set up the
-    /// entry flow-state of BB_y.
+    /// One example where this callback is needed involves Call
+    /// terminators. In the case of a call terminator:
     ///
-    /// This is used, in particular, as a special case during the
-    /// "propagate" loop where all of the basic blocks are repeatedly
-    /// visited. Since the effects of a Call terminator are
-    /// flow-dependent, the current MIR cannot encode them via just
-    /// GEN and KILL sets attached to the block, and so instead we add
-    /// this extra machinery to represent the flow-dependent effect.
+    ///     tmp0 = call foo(...)
     ///
-    /// FIXME: Right now this is a bit of a wart in the API. It might
-    /// be better to represent this as an additional gen- and
-    /// kill-sets associated with each edge coming out of the basic
-    /// block.
-    fn propagate_call_return(&self,
-                             sets: &mut BlockSets<'_, Self::Idx>,
-                             call_bb: mir::BasicBlock,
-                             dest_bb: mir::BasicBlock,
-                             dest_place: &mir::Place);
+    /// the assignment to `tmp0` only occurs if the call returns
+    /// normally (without unwinding). Therefore, we wish to apply the
+    /// effect of considering `tmp0` to be initialized only on the one
+    /// edge.
+    ///
+    /// The `edge_kind` parameter can be used to determine what sort
+    /// of terminator this is (you may need to add variants, though,
+    /// as the current set is somewhat minimal).
+    ///
+    /// Note that, during propagation, edge-specific effects are not
+    /// accumulated into the overall gen-kill sets for a block, and
+    /// hence this function will be called repeatedly as we iterate to
+    /// a fixed point. But so long as you define this callback (and
+    /// the rest) as a "pure function", this need not concern you.
+    fn edge_effect(
+        &self,
+        sets: &mut BlockSets<Self::Idx>,
+        source_block: mir::BasicBlock,
+        edge_kind: EdgeKind<'_>,
+        target_terminator: mir::BasicBlock,
+    );
+}
+
+#[derive(Copy, Clone)]
+pub enum EdgeKind<'mir> {
+    /// A standard edge -- one where the terminator does not
+    /// perform any action along the edge. The edge may be a normal
+    /// or an unwinding edge.
+    Noop,
+
+    /// An edge that doesn't really execute at runtime.
+    FalseEdge,
+
+    /// A "call return" edge, where the return value of a call (a call
+    /// that did not unwind) is stored into its destination.
+    CallReturn(&'mir Place<'mir>),
 }
 
 impl<'a, 'tcx, D> DataflowAnalysis<'a, 'tcx, D> where D: BitDenotation
@@ -830,8 +858,7 @@ impl<'a, 'tcx: 'a, D> DataflowAnalysis<'a, 'tcx, D> where D: BitDenotation
         changed: &mut bool,
         (bb, bb_data): (mir::BasicBlock, &mir::BasicBlockData<'tcx>))
     {
-        let terminator = bb_data.terminator();
-        match terminator.kind {
+        match bb_data.terminator().kind {
             mir::TerminatorKind::Return |
             mir::TerminatorKind::Resume |
             mir::TerminatorKind::Abort |
@@ -849,8 +876,7 @@ impl<'a, 'tcx: 'a, D> DataflowAnalysis<'a, 'tcx, D> where D: BitDenotation
                     scratch_buf,
                     changed,
                     bb,
-                    terminator,
-                    &[target],
+                    iter::once((target, EdgeKind::Noop)),
                 )
             }
             mir::TerminatorKind::Yield { resume: target, drop: Some(drop), .. } => {
@@ -859,8 +885,8 @@ impl<'a, 'tcx: 'a, D> DataflowAnalysis<'a, 'tcx, D> where D: BitDenotation
                     scratch_buf,
                     changed,
                     bb,
-                    terminator,
-                    &[target, drop],
+                    iter::once((target, EdgeKind::Noop))
+                        .chain(iter::once((drop, EdgeKind::Noop))),
                 )
             }
             mir::TerminatorKind::Assert { target, cleanup: Some(unwind), .. } |
@@ -868,15 +894,15 @@ impl<'a, 'tcx: 'a, D> DataflowAnalysis<'a, 'tcx, D> where D: BitDenotation
             mir::TerminatorKind::DropAndReplace {
                 target, value: _, location: _, unwind: Some(unwind)
             } => {
-                let all_targets = [target, unwind];
+                let all_targets = [(target, EdgeKind::Noop), (unwind, EdgeKind::Noop)];
                 let unwind_is_dead = self.dead_unwinds.contains(&bb);
+                let targets = if unwind_is_dead { &all_targets[..1] } else { &all_targets[..] };
                 self.propagate_bits_across_edges(
                     sets,
                     scratch_buf,
                     changed,
                     bb,
-                    terminator,
-                    if unwind_is_dead { &all_targets[..1] } else { &all_targets[..] },
+                    targets.iter().cloned(),
                 )
             }
             mir::TerminatorKind::SwitchInt { ref targets, .. } => {
@@ -885,25 +911,30 @@ impl<'a, 'tcx: 'a, D> DataflowAnalysis<'a, 'tcx, D> where D: BitDenotation
                     scratch_buf,
                     changed,
                     bb,
-                    terminator,
-                    targets,
+                    targets.into_iter().map(|&target| (target, EdgeKind::Noop)),
                 )
             }
             mir::TerminatorKind::Call { cleanup, ref destination, func: _, args: _ } => {
-                if let Some(ref unwind) = cleanup {
+                let mut unwind_edge = None;
+                let mut normal_edge = None;
+
+                if let Some(unwind) = cleanup {
                     if !self.dead_unwinds.contains(&bb) {
-                        self.propagate_bits_into_entry_set_for(&sets.on_entry, changed, unwind);
+                        unwind_edge = Some((unwind, EdgeKind::Noop));
                     }
                 }
+
                 if let Some((dest_place, dest_bb)) = destination {
-                    // N.B.: This must be done *last*, after all other
-                    // propagation, as documented in comment above.
-                    sets.clear_local_effect();
-                    self.flow_state.operator.propagate_call_return(
-                        sets, bb, *dest_bb, dest_place);
-                    sets.apply_local_effect();
-                    self.propagate_bits_into_entry_set_for(&sets.on_entry, changed, dest_bb);
+                    normal_edge = Some((*dest_bb, EdgeKind::CallReturn(dest_place)));
                 }
+
+                self.propagate_bits_across_edges(
+                    sets,
+                    scratch_buf,
+                    changed,
+                    bb,
+                    unwind_edge.into_iter().chain(normal_edge),
+                )
             }
             mir::TerminatorKind::FalseEdges { real_target, ref imaginary_targets } => {
                 self.propagate_bits_across_edges(
@@ -911,23 +942,63 @@ impl<'a, 'tcx: 'a, D> DataflowAnalysis<'a, 'tcx, D> where D: BitDenotation
                     scratch_buf,
                     changed,
                     bb,
-                    terminator,
-                    iter::once(&real_target).chain(imaginary_targets),
+                    iter::once((real_target, EdgeKind::Noop))
+                        .chain(
+                            imaginary_targets.into_iter()
+                                             .map(|&target| (target, EdgeKind::FalseEdge)),
+                        ),
                 )
             }
         }
     }
 
-    fn propagate_bits_across_edges<'bb>(
+    fn propagate_bits_across_edges<'ek>(
         &mut self,
         sets: &mut BlockSets<'_, D::Idx>,
-        _scratch_buf: &mut IdxSet<D::Idx>,
+        scratch_buf: &mut IdxSet<D::Idx>,
         changed: &mut bool,
-        _source: mir::BasicBlock,
-        _terminator: &mir::Terminator<'tcx>,
-        targets: impl IntoIterator<Item = &'bb BasicBlock>,
+        source: mir::BasicBlock,
+        targets: impl IntoIterator<Item = (BasicBlock, EdgeKind<'ek>)>,
     ) {
-        for target in targets {
+        // When true, the initial value of `sets.on_entry` has been copied
+        // into `scratch_buf`.
+        let mut is_saved = false;
+
+        // When true, the value of `sets.on_entry` has been changed
+        // from its initial value (and not yet restored).
+        let mut is_dirty = false;
+
+        // Just in case some previous caller left them dirty, clear
+        // the gen/kill sets to start.
+        sets.clear_local_effect();
+
+        for (target, edge_kind) in targets {
+            if is_dirty {
+                // Some previous edge generated (and applied) gen/kill
+                // effects. Undo them.
+                assert!(is_saved);
+                sets.clear_local_effect();
+                sets.on_entry.clone_from(scratch_buf);
+                is_dirty = false;
+            }
+
+            // Compute the gen/kill sets for this edge.
+            self.flow_state.operator.edge_effect(sets, source, edge_kind, target);
+
+            // If those gen/kill sets are non-empty, apply them.
+            if !sets.has_empty_local_effect() {
+                if !is_saved {
+                    // But first, save the "pristine" on-entry set so
+                    // that we can restore it for other edges.
+                    scratch_buf.clone_from(&sets.on_entry);
+                    is_saved = true;
+                }
+
+                sets.apply_local_effect();
+                is_dirty = true;
+            }
+
+            // Update the on-entry set for `target`.
             self.propagate_bits_into_entry_set_for(&sets.on_entry, changed, target);
         }
     }
@@ -935,7 +1006,7 @@ impl<'a, 'tcx: 'a, D> DataflowAnalysis<'a, 'tcx, D> where D: BitDenotation
     fn propagate_bits_into_entry_set_for(&mut self,
                                          in_out: &IdxSet<D::Idx>,
                                          changed: &mut bool,
-                                         bb: &mir::BasicBlock) {
+                                         bb: mir::BasicBlock) {
         let entry_set = self.flow_state.sets.for_block(bb.index()).on_entry;
         let set_changed = bitwise(entry_set.words_mut(),
                                   in_out.words(),

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -674,7 +674,7 @@ pub trait BitDenotation: BitwiseOperator {
     /// `bb_data` is the sequence of statements identified by `bb` in
     /// the MIR.
     fn statement_effect(&self,
-                        sets: &mut BlockSets<Self::Idx>,
+                        sets: &mut BlockSets<'_, Self::Idx>,
                         location: Location);
 
     /// Similar to `terminator_effect`, except it applies
@@ -703,7 +703,7 @@ pub trait BitDenotation: BitwiseOperator {
     /// The effects applied here cannot depend on which branch the
     /// terminator took.
     fn terminator_effect(&self,
-                         sets: &mut BlockSets<Self::Idx>,
+                         sets: &mut BlockSets<'_, Self::Idx>,
                          location: Location);
 
     /// Mutates the block-sets according to the (flow-dependent)

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -37,6 +37,7 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![feature(collection_placement)]
 #![feature(nonzero)]
 #![feature(underscore_lifetimes)]
+#![feature(universal_impl_trait)]
 
 #[macro_use]
 extern crate bitflags;


### PR DESCRIPTION
This is a branch I had lying around. It is an attempt to modify the dataflow APIs to support "bits per edge" -- this was intended to fix a shortcoming in NLL, but then @arielb1 had a better fix anyhow. I'm not sure if this code (or some variant of it) is worth landing or not.

The basic idea is that the data flow operator may define the bits on **any** given edge, instead of just the "call return edge". The propagation code is rewritten so apply and unroll these effects as it goes; it is optimized for the case that individual edges do not have distinct effects. To micro-optimize, I added what is either a brilliant hack or a terrible idea: it's a wrapper whose `DerefMut` impl sets a flag, so that code which never winds up trying to mutate will be seamlessly detected.

Anyway, I have a feeling that these changes are starting to get into "over-designed" territory, so I thought I'd throw them out for some feedback.

r? @pnkfelix 