### PR TITLE
rustc: Load the `rustc_trans` crate at runtime

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1933,7 +1933,6 @@ dependencies = [
  "rustc_privacy 0.0.0",
  "rustc_resolve 0.0.0",
  "rustc_save_analysis 0.0.0",
- "rustc_trans 0.0.0",
  "rustc_trans_utils 0.0.0",
  "rustc_typeck 0.0.0",
  "serialize 0.0.0",
@@ -1984,6 +1983,7 @@ dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "build_helper 0.1.0",
  "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_cratesio_shim 0.0.0",
 ]
 
@@ -2121,6 +2121,7 @@ dependencies = [
  "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jobserver 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc 0.0.0",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "rustc",
   "libstd",
   "libtest",
+  "librustc_trans",
   "tools/cargotest",
   "tools/clippy",
   "tools/compiletest",

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -94,7 +94,7 @@ impl Step for Rustc {
         build.clear_if_dirty(&stage_out, &libtest_stamp(build, compiler, target));
 
         let mut cargo = builder.cargo(compiler, Mode::Librustc, target, "check");
-        rustc_cargo(build, target, &mut cargo);
+        rustc_cargo(build, &mut cargo);
         run_cargo(build,
                   &mut cargo,
                   &librustc_stamp(build, compiler, target),

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -617,7 +617,7 @@ impl Step for Rustc {
         t!(symlink_dir_force(&my_out, &out_dir));
 
         let mut cargo = builder.cargo(compiler, Mode::Librustc, target, "doc");
-        compile::rustc_cargo(build, target, &mut cargo);
+        compile::rustc_cargo(build, &mut cargo);
 
         if build.config.compiler_docs {
             // src/rustc/Cargo.toml contains a bin crate called rustc which

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -432,9 +432,6 @@ impl Build {
         if self.config.use_jemalloc {
             features.push_str(" jemalloc");
         }
-        if self.config.llvm_enabled {
-            features.push_str(" llvm");
-        }
         features
     }
 

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -57,11 +57,6 @@ impl Step for Llvm {
         let build = builder.build;
         let target = self.target;
 
-        // If we're not compiling for LLVM bail out here.
-        if !build.config.llvm_enabled {
-            return;
-        }
-
         // If we're using a custom LLVM bail out here, but we can only use a
         // custom LLVM for the build triple.
         if let Some(config) = build.config.target_config.get(&target) {

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -900,6 +900,8 @@ impl Step for Compiletest {
             cmd.env("PROFILER_SUPPORT", "1");
         }
 
+        cmd.env("RUST_TEST_TMPDIR", build.out.join("tmp"));
+
         cmd.arg("--adb-path").arg("adb");
         cmd.arg("--adb-test-dir").arg(ADB_TEST_DIR);
         if target.contains("android") {
@@ -1209,7 +1211,7 @@ impl Step for Crate {
             }
             Mode::Librustc => {
                 builder.ensure(compile::Rustc { compiler, target });
-                compile::rustc_cargo(build, target, &mut cargo);
+                compile::rustc_cargo(build, &mut cargo);
                 ("librustc", "rustc-main")
             }
             _ => panic!("can only test libraries"),

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -14,7 +14,7 @@ bitflags = "1.0"
 fmt_macros = { path = "../libfmt_macros" }
 graphviz = { path = "../libgraphviz" }
 jobserver = "0.1"
-log = "0.4"
+log = { version = "0.4", features = ["release_max_level_info", "std"] }
 rustc_apfloat = { path = "../librustc_apfloat" }
 rustc_back = { path = "../librustc_back" }
 rustc_const_math = { path = "../librustc_const_math" }
@@ -25,7 +25,6 @@ syntax = { path = "../libsyntax" }
 syntax_pos = { path = "../libsyntax_pos" }
 backtrace = "0.3.3"
 byteorder = { version = "1.1", features = ["i128"]}
-
 
 # Note that these dependencies are a lie, they're just here to get linkage to
 # work.

--- a/src/librustc_driver/Cargo.toml
+++ b/src/librustc_driver/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["dylib"]
 [dependencies]
 arena = { path = "../libarena" }
 graphviz = { path = "../libgraphviz" }
-log = { version = "0.4", features = ["release_max_level_info"] }
+log = "0.4"
 env_logger = { version = "0.4", default-features = false }
 rustc = { path = "../librustc" }
 rustc_allocator = { path = "../librustc_allocator" }
@@ -29,7 +29,6 @@ rustc_plugin = { path = "../librustc_plugin" }
 rustc_privacy = { path = "../librustc_privacy" }
 rustc_resolve = { path = "../librustc_resolve" }
 rustc_save_analysis = { path = "../librustc_save_analysis" }
-rustc_trans = { path = "../librustc_trans", optional = true }
 rustc_trans_utils = { path = "../librustc_trans_utils" }
 rustc_typeck = { path = "../librustc_typeck" }
 serialize = { path = "../libserialize" }
@@ -38,6 +37,3 @@ syntax_ext = { path = "../libsyntax_ext" }
 syntax_pos = { path = "../libsyntax_pos" }
 
 ar = "0.3.0"
-
-[features]
-llvm = ["rustc_trans"]

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -228,7 +228,8 @@ impl PpSourceMode {
             }
             PpmTyped => {
                 let control = &driver::CompileController::basic();
-                abort_on_err(driver::phase_3_run_analysis_passes(&*::DefaultTransCrate::new(&sess),
+                let trans = ::get_trans(sess);
+                abort_on_err(driver::phase_3_run_analysis_passes(&*trans,
                                                                  control,
                                                                  sess,
                                                                  cstore,
@@ -1081,7 +1082,8 @@ fn print_with_analysis<'tcx, 'a: 'tcx>(sess: &'a Session,
     let mut out = Vec::new();
 
     let control = &driver::CompileController::basic();
-    abort_on_err(driver::phase_3_run_analysis_passes(&*::DefaultTransCrate::new(&sess),
+    let trans = ::get_trans(sess);
+    abort_on_err(driver::phase_3_run_analysis_passes(&*trans,
                                                      control,
                                                      sess,
                                                      cstore,

--- a/src/librustc_llvm/Cargo.toml
+++ b/src/librustc_llvm/Cargo.toml
@@ -7,13 +7,13 @@ build = "build.rs"
 [lib]
 name = "rustc_llvm"
 path = "lib.rs"
-crate-type = ["dylib"]
 
 [features]
 static-libstdcpp = []
 
 [dependencies]
 bitflags = "1.0"
+libc = "0.2"
 rustc_cratesio_shim = { path = "../librustc_cratesio_shim" }
 
 [build-dependencies]

--- a/src/librustc_llvm/build.rs
+++ b/src/librustc_llvm/build.rs
@@ -146,6 +146,7 @@ fn main() {
         cfg.define(&flag, None);
     }
 
+    println!("cargo:rerun-if-changed-env=LLVM_RUSTLLVM");
     if env::var_os("LLVM_RUSTLLVM").is_some() {
         cfg.define("LLVM_RUSTLLVM", None);
     }

--- a/src/librustc_trans/Cargo.toml
+++ b/src/librustc_trans/Cargo.toml
@@ -13,6 +13,7 @@ test = false
 bitflags = "1.0"
 flate2 = "1.0"
 jobserver = "0.1.5"
+libc = "0.2"
 log = "0.4"
 num_cpus = "1.0"
 rustc = { path = "../librustc" }
@@ -36,3 +37,6 @@ tempdir = "0.3"
 
 [target."cfg(windows)".dependencies]
 cc = "1.0.1"
+
+[features]
+jemalloc = ["rustc_back/jemalloc"]

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use rustc_lint;
-use rustc_driver::{driver, target_features, abort_on_err};
+use rustc_driver::{self, driver, target_features, abort_on_err};
 use rustc::session::{self, config};
 use rustc::hir::def_id::DefId;
 use rustc::hir::def::Def;
@@ -18,7 +18,6 @@ use rustc::ty::{self, TyCtxt, AllArenas};
 use rustc::hir::map as hir_map;
 use rustc::lint;
 use rustc::util::nodemap::FxHashMap;
-use rustc_trans;
 use rustc_resolve as resolve;
 use rustc_metadata::creader::CrateLoader;
 use rustc_metadata::cstore::CStore;
@@ -151,7 +150,7 @@ pub fn run_core(search_paths: SearchPaths,
     let mut sess = session::build_session_(
         sessopts, cpath, diagnostic_handler, codemap,
     );
-    let trans = rustc_trans::LlvmTransCrate::new(&sess);
+    let trans = rustc_driver::get_trans(&sess);
     let cstore = Rc::new(CStore::new(trans.metadata_loader()));
     rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -63,8 +63,6 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::mpsc::channel;
 
-use rustc_driver::rustc_trans;
-
 use externalfiles::ExternalHtml;
 use rustc::session::search_paths::SearchPaths;
 use rustc::session::config::{ErrorOutputType, RustcOptGroup, nightly_options,

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -33,7 +33,6 @@ use rustc_driver::{self, driver, Compilation};
 use rustc_driver::driver::phase_2_configure_and_expand;
 use rustc_metadata::cstore::CStore;
 use rustc_resolve::MakeGlobMap;
-use rustc_trans;
 use syntax::ast;
 use syntax::codemap::CodeMap;
 use syntax::feature_gate::UnstableFeatures;
@@ -84,7 +83,7 @@ pub fn run(input_path: &Path,
     let mut sess = session::build_session_(
         sessopts, Some(input_path.to_owned()), handler, codemap.clone(),
     );
-    let trans = rustc_trans::LlvmTransCrate::new(&sess);
+    let trans = rustc_driver::get_trans(&sess);
     let cstore = Rc::new(CStore::new(trans.metadata_loader()));
     rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
     sess.parse_sess.config =
@@ -249,7 +248,7 @@ fn run_test(test: &str, cratename: &str, filename: &FileName, line: usize,
     let mut sess = session::build_session_(
         sessopts, None, diagnostic_handler, codemap,
     );
-    let trans = rustc_trans::LlvmTransCrate::new(&sess);
+    let trans = rustc_driver::get_trans(&sess);
     let cstore = Rc::new(CStore::new(trans.metadata_loader()));
     rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
 

--- a/src/rustc/Cargo.toml
+++ b/src/rustc/Cargo.toml
@@ -7,12 +7,9 @@ version = "0.0.0"
 name = "rustc"
 path = "rustc.rs"
 
-# All optional dependencies so the features passed to this Cargo.toml select
-# what should actually be built.
 [dependencies]
 rustc_back = { path = "../librustc_back" }
 rustc_driver = { path = "../librustc_driver" }
 
 [features]
 jemalloc = ["rustc_back/jemalloc"]
-llvm = ["rustc_driver/llvm"]

--- a/src/test/run-make/hotplug_codegen_backend/the_backend.rs
+++ b/src/test/run-make/hotplug_codegen_backend/the_backend.rs
@@ -77,6 +77,6 @@ impl TransCrate for TheBackend {
 
 /// This is the entrypoint for a hot plugged rustc_trans
 #[no_mangle]
-pub fn __rustc_codegen_backend(sess: &Session) -> Box<TransCrate> {
-    Box::new(TheBackend(MetadataOnlyTransCrate::new(sess)))
+pub fn __rustc_codegen_backend() -> Box<TransCrate> {
+    Box::new(TheBackend(MetadataOnlyTransCrate::new()))
 }

--- a/src/test/run-make/issue-19371/foo.rs
+++ b/src/test/run-make/issue-19371/foo.rs
@@ -15,7 +15,6 @@ extern crate rustc_driver;
 extern crate rustc_lint;
 extern crate rustc_metadata;
 extern crate rustc_errors;
-extern crate rustc_trans;
 extern crate rustc_trans_utils;
 extern crate syntax;
 
@@ -63,7 +62,7 @@ fn basic_sess(sysroot: PathBuf) -> (Session, Rc<CStore>, Box<TransCrate>) {
 
     let descriptions = Registry::new(&rustc::DIAGNOSTICS);
     let sess = build_session(opts, None, descriptions);
-    let trans = rustc_trans::LlvmTransCrate::new(&sess);
+    let trans = rustc_driver::get_trans(&sess);
     let cstore = Rc::new(CStore::new(trans.metadata_loader()));
     rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
     (sess, cstore, trans)

--- a/src/test/run-make/llvm-pass/Makefile
+++ b/src/test/run-make/llvm-pass/Makefile
@@ -1,5 +1,9 @@
 -include ../tools.mk
 
+ifeq ($(UNAME),Darwin)
+PLUGIN_FLAGS := -C link-args=-Wl,-undefined,dynamic_lookup
+endif
+
 ifeq ($(findstring stage1,$(RUST_BUILD_STAGE)),stage1)
 # ignore stage1
 all:
@@ -11,7 +15,7 @@ ifdef IS_WINDOWS
 all:
 else
 all: $(call NATIVE_STATICLIB,llvm-function-pass) $(call NATIVE_STATICLIB,llvm-module-pass)
-	$(RUSTC) plugin.rs -C prefer-dynamic
+	$(RUSTC) plugin.rs -C prefer-dynamic $(PLUGIN_FLAGS)
 	$(RUSTC) main.rs
 
 $(TMPDIR)/libllvm-function-pass.o:

--- a/src/test/run-make/llvm-pass/plugin.rs
+++ b/src/test/run-make/llvm-pass/plugin.rs
@@ -14,7 +14,6 @@
 
 extern crate rustc;
 extern crate rustc_plugin;
-extern crate rustc_trans;
 
 #[link(name = "llvm-function-pass", kind = "static")]
 #[link(name = "llvm-module-pass", kind = "static")]

--- a/src/test/run-pass-fulldeps/create-dir-all-bare.rs
+++ b/src/test/run-pass-fulldeps/create-dir-all-bare.rs
@@ -8,18 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-cross-compile
-
-#![feature(rustc_private)]
-
-extern crate tempdir;
-
 use std::env;
 use std::fs;
-use tempdir::TempDir;
+use std::path::PathBuf;
 
 fn main() {
-    let td = TempDir::new("create-dir-all-bare").unwrap();
-    env::set_current_dir(td.path()).unwrap();
+    let path = PathBuf::from(env::var_os("RUST_TEST_TMPDIR").unwrap());
+    env::set_current_dir(&path).unwrap();
     fs::create_dir_all("create-dir-all-bare").unwrap();
 }

--- a/src/test/run-pass-fulldeps/issue-15149.rs
+++ b/src/test/run-pass-fulldeps/issue-15149.rs
@@ -11,15 +11,11 @@
 // no-prefer-dynamic
 // ignore-cross-compile
 
-#![feature(rustc_private)]
-
-extern crate tempdir;
-
 use std::env;
 use std::fs;
 use std::process;
 use std::str;
-use tempdir::TempDir;
+use std::path::PathBuf;
 
 fn main() {
     // If we're the child, make sure we were invoked correctly
@@ -41,8 +37,9 @@ fn test() {
     let my_path = env::current_exe().unwrap();
     let my_dir  = my_path.parent().unwrap();
 
-    let child_dir = TempDir::new_in(&my_dir, "issue-15140-child").unwrap();
-    let child_dir = child_dir.path();
+    let child_dir = PathBuf::from(env::var_os("RUST_TEST_TMPDIR").unwrap());
+    let child_dir = child_dir.join("issue-15140-child");
+    fs::create_dir_all(&child_dir).unwrap();
 
     let child_path = child_dir.join(&format!("mytest{}",
                                              env::consts::EXE_SUFFIX));
@@ -63,11 +60,4 @@ fn test() {
             format!("child assertion failed\n child stdout:\n {}\n child stderr:\n {}",
                     str::from_utf8(&child_output.stdout).unwrap(),
                     str::from_utf8(&child_output.stderr).unwrap()));
-
-    let res = fs::remove_dir_all(&child_dir);
-    if res.is_err() {
-        // On Windows deleting just executed mytest.exe can fail because it's still locked
-        std::thread::sleep_ms(1000);
-        fs::remove_dir_all(&child_dir).unwrap();
-    }
 }

--- a/src/test/run-pass-fulldeps/rename-directory.rs
+++ b/src/test/run-pass-fulldeps/rename-directory.rs
@@ -13,17 +13,13 @@
 
 // ignore-cross-compile
 
-#![feature(rustc_private)]
-
-extern crate tempdir;
-
+use std::env;
 use std::ffi::CString;
 use std::fs::{self, File};
-use tempdir::TempDir;
+use std::path::PathBuf;
 
 fn rename_directory() {
-    let tmpdir = TempDir::new("rename_directory").ok().expect("rename_directory failed");
-    let tmpdir = tmpdir.path();
+    let tmpdir = PathBuf::from(env::var_os("RUST_TEST_TMPDIR").unwrap());
     let old_path = tmpdir.join("foo/bar/baz");
     fs::create_dir_all(&old_path).unwrap();
     let test_file = &old_path.join("temp.txt");

--- a/src/test/run-pass-fulldeps/stdio-from.rs
+++ b/src/test/run-pass-fulldeps/stdio-from.rs
@@ -10,17 +10,12 @@
 
 // ignore-cross-compile
 
-#![feature(rustc_private)]
-
-extern crate tempdir;
-
 use std::env;
 use std::fs::File;
 use std::io;
 use std::io::{Read, Write};
 use std::process::{Command, Stdio};
-
-use tempdir::TempDir;
+use std::path::PathBuf;
 
 fn main() {
     if env::args().len() > 1 {
@@ -31,9 +26,9 @@ fn main() {
 }
 
 fn parent() -> io::Result<()> {
-    let td = TempDir::new("foo").unwrap();
-    let input = td.path().join("input");
-    let output = td.path().join("output");
+    let td = PathBuf::from(env::var_os("RUST_TEST_TMPDIR").unwrap());
+    let input = td.join("stdio-from-input");
+    let output = td.join("stdio-from-output");
 
     File::create(&input)?.write_all(b"foo\n")?;
 

--- a/src/test/run-pass-fulldeps/switch-stdout.rs
+++ b/src/test/run-pass-fulldeps/switch-stdout.rs
@@ -8,14 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(rustc_private)]
-
-extern crate tempdir;
-
+use std::env;
 use std::fs::File;
 use std::io::{Read, Write};
-
-use tempdir::TempDir;
+use std::path::PathBuf;
 
 #[cfg(unix)]
 fn switch_stdout_to(file: File) {
@@ -48,8 +44,8 @@ fn switch_stdout_to(file: File) {
 }
 
 fn main() {
-    let td = TempDir::new("foo").unwrap();
-    let path = td.path().join("bar");
+    let path = PathBuf::from(env::var_os("RUST_TEST_TMPDIR").unwrap());
+    let path = path.join("switch-stdout-output");
     let f = File::create(&path).unwrap();
 
     println!("foo");


### PR DESCRIPTION
Building on the work of #45684 this commit updates the compiler to
unconditionally load the `rustc_trans` crate at runtime instead of linking to it
at compile time. The end goal of this work is to implement #46819 where rustc
will have multiple backends available to it to load.

This commit starts off by removing the `extern crate rustc_trans` from the
driver. This involved moving some miscellaneous functionality into the
`TransCrate` trait and also required an implementation of how to locate and load
the trans backend. This ended up being a little tricky because the sysroot isn't
always the right location (for example `--sysroot` arguments) so some extra code
was added as well to probe a directory relative to the current dll (the
rustc_driver dll).

Rustbuild has been updated accordingly as well to have a separate compilation
invocation for the `rustc_trans` crate and assembly it accordingly into the
sysroot. Finally, the distribution logic for the `rustc` package was also
updated to slurp up the trans backends folder.

A number of assorted fallout changes were included here as well to ensure tests
pass and such, and they should all be commented inline.