### PR TITLE
rustdoc: Remove methods from #[doc(masked)] crates from the search index

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1174,6 +1174,16 @@ impl DocFolder for Cache {
             _ => self.stripped_mod,
         };
 
+        // If the impl is from a masked crate or references something from a
+        // masked crate then remove it completely.
+        if let clean::ImplItem(ref i) = item.inner {
+            if self.masked_crates.contains(&item.def_id.krate) ||
+               i.trait_.def_id().map_or(false, |d| self.masked_crates.contains(&d.krate)) ||
+               i.for_.def_id().map_or(false, |d| self.masked_crates.contains(&d.krate)) {
+                return None;
+            }
+        }
+
         // Register any generics to their corresponding string. This is used
         // when pretty-printing types.
         if let Some(generics) = item.inner.generics() {
@@ -1188,14 +1198,10 @@ impl DocFolder for Cache {
 
         // Collect all the implementors of traits.
         if let clean::ImplItem(ref i) = item.inner {
-            if !self.masked_crates.contains(&item.def_id.krate) {
-                if let Some(did) = i.trait_.def_id() {
-                    if i.for_.def_id().map_or(true, |d| !self.masked_crates.contains(&d.krate)) {
-                        self.implementors.entry(did).or_insert(vec![]).push(Impl {
-                            impl_item: item.clone(),
-                        });
-                    }
-                }
+            if let Some(did) = i.trait_.def_id() {
+                self.implementors.entry(did).or_insert(vec![]).push(Impl {
+                    impl_item: item.clone(),
+                });
             }
         }
 
@@ -1358,24 +1364,20 @@ impl DocFolder for Cache {
                 // Note: matching twice to restrict the lifetime of the `i` borrow.
                 let mut dids = FxHashSet();
                 if let clean::Item { inner: clean::ImplItem(ref i), .. } = item {
-                    let masked_trait = i.trait_.def_id().map_or(false,
-                        |d| self.masked_crates.contains(&d.krate));
-                    if !masked_trait {
-                        match i.for_ {
-                            clean::ResolvedPath { did, .. } |
-                            clean::BorrowedRef {
-                                type_: box clean::ResolvedPath { did, .. }, ..
-                            } => {
-                                dids.insert(did);
-                            }
-                            ref t => {
-                                let did = t.primitive_type().and_then(|t| {
-                                    self.primitive_locations.get(&t).cloned()
-                                });
+                    match i.for_ {
+                        clean::ResolvedPath { did, .. } |
+                        clean::BorrowedRef {
+                            type_: box clean::ResolvedPath { did, .. }, ..
+                        } => {
+                            dids.insert(did);
+                        }
+                        ref t => {
+                            let did = t.primitive_type().and_then(|t| {
+                                self.primitive_locations.get(&t).cloned()
+                            });
 
-                                if let Some(did) = did {
-                                    dids.insert(did);
-                                }
+                            if let Some(did) = did {
+                                dids.insert(did);
                             }
                         }
                     }

--- a/src/test/rustdoc-js/from_u.js
+++ b/src/test/rustdoc-js/from_u.js
@@ -15,7 +15,5 @@ const EXPECTED = {
         { 'path': 'std::char', 'name': 'from_u32' },
         { 'path': 'std::str', 'name': 'from_utf8' },
         { 'path': 'std::string::String', 'name': 'from_utf8' },
-        { 'path': 'std::i32', 'name': 'from_unsigned' },
-        { 'path': 'std::i128', 'name': 'from_unsigned' },
     ],
 };

--- a/src/test/rustdoc/auxiliary/masked.rs
+++ b/src/test/rustdoc/auxiliary/masked.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[derive(Clone)]
+pub struct MaskedStruct;
+
+pub trait MaskedTrait {
+    fn masked_method();
+}
+
+impl MaskedTrait for String {
+    fn masked_method() {}
+}

--- a/src/test/rustdoc/masked.rs
+++ b/src/test/rustdoc/masked.rs
@@ -1,0 +1,40 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:masked.rs
+
+#![feature(doc_masked)]
+
+#![crate_name = "foo"]
+
+#[doc(masked)]
+extern crate masked;
+
+// @!has 'search-index.js' 'masked_method'
+
+// @!has 'foo/struct.String.html' 'MaskedTrait'
+// @!has 'foo/struct.String.html' 'masked_method'
+pub use std::string::String;
+
+// @!has 'foo/trait.Clone.html' 'MaskedStruct'
+pub use std::clone::Clone;
+
+// @!has 'foo/struct.MyStruct.html' 'MaskedTrait'
+// @!has 'foo/struct.MyStruct.html' 'masked_method'
+pub struct MyStruct;
+
+impl masked::MaskedTrait for MyStruct {
+    fn masked_method() {}
+}
+
+// @!has 'foo/trait.MyTrait.html' 'MaskedStruct'
+pub trait MyTrait {}
+
+impl MyTrait for masked::MaskedStruct {}


### PR DESCRIPTION
For example: https://doc.rust-lang.org/nightly/std/?search=from_parts

Fixes #44740

r? @QuietMisdreavus