### PR TITLE
Avoid underflow in render_source_line

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -284,6 +284,10 @@ impl EmitterWriter {
                           line: &Line,
                           width_offset: usize,
                           code_offset: usize) -> Vec<(usize, Style)> {
+        if line.line_index == 0 {
+            return Vec::new();
+        }
+
         let source_string = match file.get_line(line.line_index - 1) {
             Some(s) => s,
             None => return Vec::new(),


### PR DESCRIPTION
While testing rust-lang/rust#47655 I was able to make the compiler panic when it's compiled with debug assertions:

```shell
> rustc /dev/null --crate-type proc-macro

error: internal compiler error: unexpected panic

note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports

note: rustc 1.25.0-dev running on x86_64-apple-darwin

note: run with `RUST_BACKTRACE=1` for a backtrace

thread 'rustc' panicked at 'attempt to subtract with overflow', librustc_errors/emitter.rs:287:49
```

Without debug assertions the following warning is emitted:

```shell
> rustc /dev/null --crate-type proc-macro

warning: unused variable: `registrar`
 --> /dev/null:0:1
  |
  |
  = note: #[warn(unused_variables)] on by default
  = note: to avoid this warning, consider using `_registrar` instead
```

The panic is due to the unused variable warning being spanned to `/dev/null:0:1`. When `render_source_line` subtracts 1 from the line number to look up the source line it panics due to underflow. Without debug assertions this would wrap and cause us to return a blank string instead.

Fix by explicitly testing for 0 and exiting early. I'm unsure how to automatically test this now that rust-lang/rust#46655 has been approved.