### PR TITLE
Remove broken redundant backtrace hint

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1276,14 +1276,6 @@ pub fn monitor<F: FnOnce() + Send + 'static>(f: F) {
                              &note,
                              errors::Level::Note);
             }
-            if match env::var_os("RUST_BACKTRACE") {
-                Some(val) => &val != "0",
-                None => false,
-            } {
-                handler.emit(&MultiSpan::new(),
-                             "run with `RUST_BACKTRACE=1` for a backtrace",
-                             errors::Level::Note);
-            }
 
             eprintln!("{}", str::from_utf8(&data.lock().unwrap()).unwrap());
         }


### PR DESCRIPTION
When the compiler driver panics it attempts to show a hint about using `RUST_BACKTRACE`. However, the logic is currently reversed to the hint is only shown if `RUST_BACKTRACE` is **already**   set:

```shell
> RUST_BACKTRACE=1 rustc /dev/null --crate-type proc-macro
error: internal compiler error: unexpected panic
...
note: run with `RUST_BACKTRACE=1` for a backtrace

thread 'rustc' panicked at 'attempt to subtract with overflow', librustc_errors/emitter.rs:287:49
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

> RUST_BACKTRACE=0 rustc /dev/null --crate-type proc-macro
error: internal compiler error: unexpected panic
...
thread 'rustc' panicked at 'attempt to subtract with overflow', librustc_errors/emitter.rs:287:49
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

As the `panic` itself already has a working `RUST_BACKTRACE` hint just remove the broken duplicate hint entirely.