### PR TITLE
RFC 2070 part 1: PanicInfo and Location API changes

### DIFF
--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -232,7 +232,7 @@ unsafe impl Alloc for Heap {
 ///
 /// This preserves the non-null invariant for types like `Box<T>`. The address
 /// may overlap with non-zero-size memory allocations.
-#[rustc_deprecated(since = "1.19", reason = "Use Unique/NonNull::empty() instead")]
+#[rustc_deprecated(since = "1.19.0", reason = "Use Unique/NonNull::empty() instead")]
 #[unstable(feature = "heap_api", issue = "27700")]
 pub const EMPTY: *mut () = 1 as *mut ();
 

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -158,6 +158,7 @@ pub mod array;
 pub mod sync;
 pub mod cell;
 pub mod char;
+pub mod panic;
 pub mod panicking;
 pub mod iter;
 pub mod option;

--- a/src/libcore/panic.rs
+++ b/src/libcore/panic.rs
@@ -130,8 +130,8 @@ impl<'a> fmt::Display for PanicInfo<'a> {
         }
         // NOTE: we cannot use downcast_ref::<String>() here
         // since String is not available in libcore!
-        // A String payload and no message is what we’d get from `std::panic!`
-        // called with multiple arguments.
+        // The payload is a String when `std::panic!` is called with multiple arguments,
+        // but in that case the message is also available.
 
         self.location.fmt(formatter)
     }

--- a/src/libcore/panic.rs
+++ b/src/libcore/panic.rs
@@ -15,6 +15,7 @@
             issue = "44489")]
 
 use any::Any;
+use fmt;
 
 /// A struct providing information about a panic.
 ///
@@ -38,6 +39,7 @@ use any::Any;
 #[derive(Debug)]
 pub struct PanicInfo<'a> {
     payload: &'a (Any + Send),
+    message: Option<&'a fmt::Arguments<'a>>,
     location: Location<'a>,
 }
 
@@ -47,8 +49,11 @@ impl<'a> PanicInfo<'a> {
                           and related macros",
                 issue = "0")]
     #[doc(hidden)]
-    pub fn internal_constructor(payload: &'a (Any + Send), location: Location<'a>,) -> Self {
-        PanicInfo { payload, location }
+    pub fn internal_constructor(payload: &'a (Any + Send),
+                                message: Option<&'a fmt::Arguments<'a>>,
+                                location: Location<'a>)
+                                -> Self {
+        PanicInfo { payload, location, message }
     }
 
     /// Returns the payload associated with the panic.
@@ -71,6 +76,16 @@ impl<'a> PanicInfo<'a> {
     #[stable(feature = "panic_hooks", since = "1.10.0")]
     pub fn payload(&self) -> &(Any + Send) {
         self.payload
+    }
+
+    /// If the `panic!` macro from the `core` crate (not from `std`)
+    /// was used with a formatting string and some additional arguments,
+    /// returns that message ready to be used for example with [`fmt::write`]
+    ///
+    /// [`fmt::write`]: ../fmt/fn.write.html
+    #[unstable(feature = "panic_info_message", issue = "44489")]
+    pub fn message(&self) -> Option<&fmt::Arguments> {
+        self.message
     }
 
     /// Returns information about the location from which the panic originated,

--- a/src/libcore/panic.rs
+++ b/src/libcore/panic.rs
@@ -1,0 +1,213 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Panic support in the standard library.
+
+#![unstable(feature = "core_panic_info",
+            reason = "newly available in libcore",
+            issue = "44489")]
+
+use any::Any;
+
+/// A struct providing information about a panic.
+///
+/// `PanicInfo` structure is passed to a panic hook set by the [`set_hook`]
+/// function.
+///
+/// [`set_hook`]: ../../std/panic/fn.set_hook.html
+///
+/// # Examples
+///
+/// ```should_panic
+/// use std::panic;
+///
+/// panic::set_hook(Box::new(|panic_info| {
+///     println!("panic occurred: {:?}", panic_info.payload().downcast_ref::<&str>().unwrap());
+/// }));
+///
+/// panic!("Normal panic");
+/// ```
+#[stable(feature = "panic_hooks", since = "1.10.0")]
+#[derive(Debug)]
+pub struct PanicInfo<'a> {
+    payload: &'a (Any + Send),
+    location: Location<'a>,
+}
+
+impl<'a> PanicInfo<'a> {
+    #![unstable(feature = "panic_internals",
+                reason = "internal details of the implementation of the `panic!` \
+                          and related macros",
+                issue = "0")]
+    #[doc(hidden)]
+    pub fn internal_constructor(payload: &'a (Any + Send), location: Location<'a>,) -> Self {
+        PanicInfo { payload, location }
+    }
+
+    /// Returns the payload associated with the panic.
+    ///
+    /// This will commonly, but not always, be a `&'static str` or [`String`].
+    ///
+    /// [`String`]: ../../std/string/struct.String.html
+    ///
+    /// # Examples
+    ///
+    /// ```should_panic
+    /// use std::panic;
+    ///
+    /// panic::set_hook(Box::new(|panic_info| {
+    ///     println!("panic occurred: {:?}", panic_info.payload().downcast_ref::<&str>().unwrap());
+    /// }));
+    ///
+    /// panic!("Normal panic");
+    /// ```
+    #[stable(feature = "panic_hooks", since = "1.10.0")]
+    pub fn payload(&self) -> &(Any + Send) {
+        self.payload
+    }
+
+    /// Returns information about the location from which the panic originated,
+    /// if available.
+    ///
+    /// This method will currently always return [`Some`], but this may change
+    /// in future versions.
+    ///
+    /// [`Some`]: ../../std/option/enum.Option.html#variant.Some
+    ///
+    /// # Examples
+    ///
+    /// ```should_panic
+    /// use std::panic;
+    ///
+    /// panic::set_hook(Box::new(|panic_info| {
+    ///     if let Some(location) = panic_info.location() {
+    ///         println!("panic occurred in file '{}' at line {}", location.file(),
+    ///             location.line());
+    ///     } else {
+    ///         println!("panic occurred but can't get location information...");
+    ///     }
+    /// }));
+    ///
+    /// panic!("Normal panic");
+    /// ```
+    #[stable(feature = "panic_hooks", since = "1.10.0")]
+    pub fn location(&self) -> Option<&Location> {
+        // NOTE: If this is changed to sometimes return None,
+        // deal with that case in std::panicking::default_hook.
+        Some(&self.location)
+    }
+}
+
+/// A struct containing information about the location of a panic.
+///
+/// This structure is created by the [`location`] method of [`PanicInfo`].
+///
+/// [`location`]: ../../std/panic/struct.PanicInfo.html#method.location
+/// [`PanicInfo`]: ../../std/panic/struct.PanicInfo.html
+///
+/// # Examples
+///
+/// ```should_panic
+/// use std::panic;
+///
+/// panic::set_hook(Box::new(|panic_info| {
+///     if let Some(location) = panic_info.location() {
+///         println!("panic occurred in file '{}' at line {}", location.file(), location.line());
+///     } else {
+///         println!("panic occurred but can't get location information...");
+///     }
+/// }));
+///
+/// panic!("Normal panic");
+/// ```
+#[derive(Debug)]
+#[stable(feature = "panic_hooks", since = "1.10.0")]
+pub struct Location<'a> {
+    file: &'a str,
+    line: u32,
+    col: u32,
+}
+
+impl<'a> Location<'a> {
+    #![unstable(feature = "panic_internals",
+                reason = "internal details of the implementation of the `panic!` \
+                          and related macros",
+                issue = "0")]
+    #[doc(hidden)]
+    pub fn internal_constructor(file: &'a str, line: u32, col: u32) -> Self {
+        Location { file, line, col }
+    }
+
+    /// Returns the name of the source file from which the panic originated.
+    ///
+    /// # Examples
+    ///
+    /// ```should_panic
+    /// use std::panic;
+    ///
+    /// panic::set_hook(Box::new(|panic_info| {
+    ///     if let Some(location) = panic_info.location() {
+    ///         println!("panic occurred in file '{}'", location.file());
+    ///     } else {
+    ///         println!("panic occurred but can't get location information...");
+    ///     }
+    /// }));
+    ///
+    /// panic!("Normal panic");
+    /// ```
+    #[stable(feature = "panic_hooks", since = "1.10.0")]
+    pub fn file(&self) -> &str {
+        self.file
+    }
+
+    /// Returns the line number from which the panic originated.
+    ///
+    /// # Examples
+    ///
+    /// ```should_panic
+    /// use std::panic;
+    ///
+    /// panic::set_hook(Box::new(|panic_info| {
+    ///     if let Some(location) = panic_info.location() {
+    ///         println!("panic occurred at line {}", location.line());
+    ///     } else {
+    ///         println!("panic occurred but can't get location information...");
+    ///     }
+    /// }));
+    ///
+    /// panic!("Normal panic");
+    /// ```
+    #[stable(feature = "panic_hooks", since = "1.10.0")]
+    pub fn line(&self) -> u32 {
+        self.line
+    }
+
+    /// Returns the column from which the panic originated.
+    ///
+    /// # Examples
+    ///
+    /// ```should_panic
+    /// use std::panic;
+    ///
+    /// panic::set_hook(Box::new(|panic_info| {
+    ///     if let Some(location) = panic_info.location() {
+    ///         println!("panic occurred at column {}", location.column());
+    ///     } else {
+    ///         println!("panic occurred but can't get location information...");
+    ///     }
+    /// }));
+    ///
+    /// panic!("Normal panic");
+    /// ```
+    #[stable(feature = "panic_col", since = "1.25")]
+    pub fn column(&self) -> u32 {
+        self.col
+    }
+}

--- a/src/libcore/panic.rs
+++ b/src/libcore/panic.rs
@@ -120,6 +120,23 @@ impl<'a> PanicInfo<'a> {
     }
 }
 
+impl<'a> fmt::Display for PanicInfo<'a> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("panicked at ")?;
+        if let Some(message) = self.message {
+            write!(formatter, "'{}', ", message)?
+        } else if let Some(payload) = self.payload.downcast_ref::<&'static str>() {
+            write!(formatter, "'{}', ", payload)?
+        }
+        // NOTE: we cannot use downcast_ref::<String>() here
+        // since String is not available in libcore!
+        // A String payload and no message is what we’d get from `std::panic!`
+        // called with multiple arguments.
+
+        self.location.fmt(formatter)
+    }
+}
+
 /// A struct containing information about the location of a panic.
 ///
 /// This structure is created by the [`location`] method of [`PanicInfo`].
@@ -224,5 +241,11 @@ impl<'a> Location<'a> {
     #[stable(feature = "panic_col", since = "1.25")]
     pub fn column(&self) -> u32 {
         self.col
+    }
+}
+
+impl<'a> fmt::Display for Location<'a> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "{}:{}:{}", self.file, self.line, self.col)
     }
 }

--- a/src/libcore/panic.rs
+++ b/src/libcore/panic.rs
@@ -238,7 +238,7 @@ impl<'a> Location<'a> {
     ///
     /// panic!("Normal panic");
     /// ```
-    #[stable(feature = "panic_col", since = "1.25")]
+    #[stable(feature = "panic_col", since = "1.25.0")]
     pub fn column(&self) -> u32 {
         self.col
     }

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2461,7 +2461,7 @@ impl<'a, T: ?Sized> From<NonNull<T>> for Unique<T> {
 }
 
 /// Previous name of `NonNull`.
-#[rustc_deprecated(since = "1.24", reason = "renamed to `NonNull`")]
+#[rustc_deprecated(since = "1.25.0", reason = "renamed to `NonNull`")]
 #[unstable(feature = "shared", issue = "27730")]
 pub type Shared<T> = NonNull<T>;
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -288,6 +288,7 @@
 #![feature(on_unimplemented)]
 #![feature(oom)]
 #![feature(optin_builtin_traits)]
+#![feature(panic_internals)]
 #![feature(panic_unwind)]
 #![feature(peek)]
 #![feature(placement_in_syntax)]

--- a/src/libstd/net/mod.rs
+++ b/src/libstd/net/mod.rs
@@ -134,14 +134,14 @@ fn each_addr<A: ToSocketAddrs, F, T>(addr: A, mut f: F) -> io::Result<T>
                                               iterator and returning socket \
                                               addresses",
            issue = "27705")]
-#[rustc_deprecated(since = "1.25", reason = "Use the ToSocketAddrs trait instead")]
+#[rustc_deprecated(since = "1.25.0", reason = "Use the ToSocketAddrs trait instead")]
 pub struct LookupHost(net_imp::LookupHost);
 
 #[unstable(feature = "lookup_host", reason = "unsure about the returned \
                                               iterator and returning socket \
                                               addresses",
            issue = "27705")]
-#[rustc_deprecated(since = "1.25", reason = "Use the ToSocketAddrs trait instead")]
+#[rustc_deprecated(since = "1.25.0", reason = "Use the ToSocketAddrs trait instead")]
 #[allow(deprecated)]
 impl Iterator for LookupHost {
     type Item = SocketAddr;
@@ -152,7 +152,7 @@ impl Iterator for LookupHost {
                                               iterator and returning socket \
                                               addresses",
            issue = "27705")]
-#[rustc_deprecated(since = "1.25", reason = "Use the ToSocketAddrs trait instead")]
+#[rustc_deprecated(since = "1.25.0", reason = "Use the ToSocketAddrs trait instead")]
 #[allow(deprecated)]
 impl fmt::Debug for LookupHost {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -186,7 +186,7 @@ impl fmt::Debug for LookupHost {
                                               iterator and returning socket \
                                               addresses",
            issue = "27705")]
-#[rustc_deprecated(since = "1.25", reason = "Use the ToSocketAddrs trait instead")]
+#[rustc_deprecated(since = "1.25.0", reason = "Use the ToSocketAddrs trait instead")]
 #[allow(deprecated)]
 pub fn lookup_host(host: &str) -> io::Result<LookupHost> {
     net_imp::lookup_host(host).map(LookupHost)

--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -23,7 +23,10 @@ use sync::{Arc, Mutex, RwLock, atomic};
 use thread::Result;
 
 #[stable(feature = "panic_hooks", since = "1.10.0")]
-pub use panicking::{take_hook, set_hook, PanicInfo, Location};
+pub use panicking::{take_hook, set_hook};
+
+#[stable(feature = "panic_hooks", since = "1.10.0")]
+pub use core::panic::{PanicInfo, Location};
 
 /// A marker trait which represents "panic safe" types in Rust.
 ///

--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -391,6 +391,7 @@ fn rust_panic_with_hook(msg: Box<Any + Send>,
     unsafe {
         let info = PanicInfo::internal_constructor(
             &*msg,
+            None,
             Location::internal_constructor(file, line, col),
         );
         HOOK_LOCK.read();

--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -21,6 +21,7 @@ use io::prelude::*;
 
 use any::Any;
 use cell::RefCell;
+use core::panic::{PanicInfo, Location};
 use fmt;
 use intrinsics;
 use mem;
@@ -158,182 +159,6 @@ pub fn take_hook() -> Box<Fn(&PanicInfo) + 'static + Sync + Send> {
     }
 }
 
-/// A struct providing information about a panic.
-///
-/// `PanicInfo` structure is passed to a panic hook set by the [`set_hook`]
-/// function.
-///
-/// [`set_hook`]: ../../std/panic/fn.set_hook.html
-///
-/// # Examples
-///
-/// ```should_panic
-/// use std::panic;
-///
-/// panic::set_hook(Box::new(|panic_info| {
-///     println!("panic occurred: {:?}", panic_info.payload().downcast_ref::<&str>().unwrap());
-/// }));
-///
-/// panic!("Normal panic");
-/// ```
-#[stable(feature = "panic_hooks", since = "1.10.0")]
-#[derive(Debug)]
-pub struct PanicInfo<'a> {
-    payload: &'a (Any + Send),
-    location: Location<'a>,
-}
-
-impl<'a> PanicInfo<'a> {
-    /// Returns the payload associated with the panic.
-    ///
-    /// This will commonly, but not always, be a `&'static str` or [`String`].
-    ///
-    /// [`String`]: ../../std/string/struct.String.html
-    ///
-    /// # Examples
-    ///
-    /// ```should_panic
-    /// use std::panic;
-    ///
-    /// panic::set_hook(Box::new(|panic_info| {
-    ///     println!("panic occurred: {:?}", panic_info.payload().downcast_ref::<&str>().unwrap());
-    /// }));
-    ///
-    /// panic!("Normal panic");
-    /// ```
-    #[stable(feature = "panic_hooks", since = "1.10.0")]
-    pub fn payload(&self) -> &(Any + Send) {
-        self.payload
-    }
-
-    /// Returns information about the location from which the panic originated,
-    /// if available.
-    ///
-    /// This method will currently always return [`Some`], but this may change
-    /// in future versions.
-    ///
-    /// [`Some`]: ../../std/option/enum.Option.html#variant.Some
-    ///
-    /// # Examples
-    ///
-    /// ```should_panic
-    /// use std::panic;
-    ///
-    /// panic::set_hook(Box::new(|panic_info| {
-    ///     if let Some(location) = panic_info.location() {
-    ///         println!("panic occurred in file '{}' at line {}", location.file(),
-    ///             location.line());
-    ///     } else {
-    ///         println!("panic occurred but can't get location information...");
-    ///     }
-    /// }));
-    ///
-    /// panic!("Normal panic");
-    /// ```
-    #[stable(feature = "panic_hooks", since = "1.10.0")]
-    pub fn location(&self) -> Option<&Location> {
-        Some(&self.location)
-    }
-}
-
-/// A struct containing information about the location of a panic.
-///
-/// This structure is created by the [`location`] method of [`PanicInfo`].
-///
-/// [`location`]: ../../std/panic/struct.PanicInfo.html#method.location
-/// [`PanicInfo`]: ../../std/panic/struct.PanicInfo.html
-///
-/// # Examples
-///
-/// ```should_panic
-/// use std::panic;
-///
-/// panic::set_hook(Box::new(|panic_info| {
-///     if let Some(location) = panic_info.location() {
-///         println!("panic occurred in file '{}' at line {}", location.file(), location.line());
-///     } else {
-///         println!("panic occurred but can't get location information...");
-///     }
-/// }));
-///
-/// panic!("Normal panic");
-/// ```
-#[derive(Debug)]
-#[stable(feature = "panic_hooks", since = "1.10.0")]
-pub struct Location<'a> {
-    file: &'a str,
-    line: u32,
-    col: u32,
-}
-
-impl<'a> Location<'a> {
-    /// Returns the name of the source file from which the panic originated.
-    ///
-    /// # Examples
-    ///
-    /// ```should_panic
-    /// use std::panic;
-    ///
-    /// panic::set_hook(Box::new(|panic_info| {
-    ///     if let Some(location) = panic_info.location() {
-    ///         println!("panic occurred in file '{}'", location.file());
-    ///     } else {
-    ///         println!("panic occurred but can't get location information...");
-    ///     }
-    /// }));
-    ///
-    /// panic!("Normal panic");
-    /// ```
-    #[stable(feature = "panic_hooks", since = "1.10.0")]
-    pub fn file(&self) -> &str {
-        self.file
-    }
-
-    /// Returns the line number from which the panic originated.
-    ///
-    /// # Examples
-    ///
-    /// ```should_panic
-    /// use std::panic;
-    ///
-    /// panic::set_hook(Box::new(|panic_info| {
-    ///     if let Some(location) = panic_info.location() {
-    ///         println!("panic occurred at line {}", location.line());
-    ///     } else {
-    ///         println!("panic occurred but can't get location information...");
-    ///     }
-    /// }));
-    ///
-    /// panic!("Normal panic");
-    /// ```
-    #[stable(feature = "panic_hooks", since = "1.10.0")]
-    pub fn line(&self) -> u32 {
-        self.line
-    }
-
-    /// Returns the column from which the panic originated.
-    ///
-    /// # Examples
-    ///
-    /// ```should_panic
-    /// use std::panic;
-    ///
-    /// panic::set_hook(Box::new(|panic_info| {
-    ///     if let Some(location) = panic_info.location() {
-    ///         println!("panic occurred at column {}", location.column());
-    ///     } else {
-    ///         println!("panic occurred but can't get location information...");
-    ///     }
-    /// }));
-    ///
-    /// panic!("Normal panic");
-    /// ```
-    #[stable(feature = "panic_col", since = "1.25")]
-    pub fn column(&self) -> u32 {
-        self.col
-    }
-}
-
 fn default_hook(info: &PanicInfo) {
     #[cfg(feature = "backtrace")]
     use sys_common::backtrace;
@@ -351,13 +176,14 @@ fn default_hook(info: &PanicInfo) {
         }
     };
 
-    let file = info.location.file;
-    let line = info.location.line;
-    let col = info.location.col;
+    let location = info.location().unwrap();  // The current implementation always returns Some
+    let file = location.file();
+    let line = location.line();
+    let col = location.column();
 
-    let msg = match info.payload.downcast_ref::<&'static str>() {
+    let msg = match info.payload().downcast_ref::<&'static str>() {
         Some(s) => *s,
-        None => match info.payload.downcast_ref::<String>() {
+        None => match info.payload().downcast_ref::<String>() {
             Some(s) => &s[..],
             None => "Box<Any>",
         }
@@ -563,14 +389,10 @@ fn rust_panic_with_hook(msg: Box<Any + Send>,
     }
 
     unsafe {
-        let info = PanicInfo {
-            payload: &*msg,
-            location: Location {
-                file,
-                line,
-                col,
-            },
-        };
+        let info = PanicInfo::internal_constructor(
+            &*msg,
+            Location::internal_constructor(file, line, col),
+        );
         HOOK_LOCK.read();
         match HOOK {
             Hook::Default => default_hook(&info),


### PR DESCRIPTION
This implements part of https://rust-lang.github.io/rfcs/2070-panic-implementation.html
Tracking issue: https://github.com/rust-lang/rust/issues/44489

* Move `std::panic::PanicInfo` and `std::panic::Location` to a new `core::panic` module. The two types and the `std` module were already `#[stable]` and stay that way, the new `core` module is `#[unstable]`.
* Add a new `PanicInfo::message(&self) -> Option<&fmt::Arguments>` method, which is `#[unstable]`.
* Implement `Display` for `PanicInfo` and `Location`