### PR TITLE
Remove workarounds for cc 1.0.3.

### DIFF
--- a/src/ci/docker/dist-various-2/Dockerfile
+++ b/src/ci/docker/dist-various-2/Dockerfile
@@ -47,13 +47,6 @@ ENV \
     CC_x86_64_sun_solaris=x86_64-sun-solaris2.10-gcc \
     CXX_x86_64_sun_solaris=x86_64-sun-solaris2.10-g++
 
-# FIXME(EdSchouten): Remove this once cc ≥1.0.4 has been merged. It can
-# automatically pick the right compiler path.
-ENV \
-    AR_x86_64_unknown_cloudabi=x86_64-unknown-cloudabi-ar \
-    CC_x86_64_unknown_cloudabi=x86_64-unknown-cloudabi-clang \
-    CXX_x86_64_unknown_cloudabi=x86_64-unknown-cloudabi-clang++
-
 ENV TARGETS=x86_64-unknown-fuchsia
 ENV TARGETS=$TARGETS,aarch64-unknown-fuchsia
 ENV TARGETS=$TARGETS,sparcv9-sun-solaris

--- a/src/ci/docker/dist-various-2/build-cloudabi-toolchain.sh
+++ b/src/ci/docker/dist-various-2/build-cloudabi-toolchain.sh
@@ -40,12 +40,6 @@ ln -s ../lib/llvm-5.0/bin/clang /usr/bin/${target}-c++
 ln -s ../lib/llvm-5.0/bin/lld /usr/bin/${target}-ld
 ln -s ../../${target} /usr/lib/llvm-5.0/${target}
 
-# FIXME(EdSchouten): Remove this once cc ≥1.0.4 has been merged. It
-# can make use of ${target}-cc and ${target}-c++, without incorrectly
-# assuming it's MSVC.
-ln -s ../lib/llvm-5.0/bin/clang /usr/bin/${target}-clang
-ln -s ../lib/llvm-5.0/bin/clang /usr/bin/${target}-clang++
-
 # Install the C++ runtime libraries from CloudABI Ports.
 echo deb https://nuxi.nl/distfiles/cloudabi-ports/debian/ cloudabi cloudabi > \
     /etc/apt/sources.list.d/cloudabi.list


### PR DESCRIPTION
Now that the Rust codebase depends on cc 1.0.4, there is no longer any
need to specify a compiler for CloudABI manually. Cargo will
automatically call into the right compiler executable.