### PR TITLE
Fixes for intra-doc-links

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -904,9 +904,7 @@ fn resolve(cx: &DocContext, path_str: &str, is_val: bool) -> Result<hir::Path, (
                                                         &path_str, is_val)
                     })
     } else {
-        // FIXME(Manishearth) this branch doesn't seem to ever be hit, really
-        cx.resolver.borrow_mut()
-                   .resolve_str_path_error(DUMMY_SP, &path_str, is_val)
+        Err(())
     }
 }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -880,10 +880,10 @@ fn ambiguity_error(cx: &DocContext, attrs: &Attributes,
     let sp = attrs.doc_strings.first()
                   .map_or(DUMMY_SP, |a| a.span());
     cx.sess()
-      .struct_span_err(sp,
-                       &format!("`{}` is both {} {} and {} {}",
-                                path_str, article1, kind1,
-                                article2, kind2))
+      .struct_span_warn(sp,
+                        &format!("`{}` is both {} {} and {} {}",
+                                 path_str, article1, kind1,
+                                 article2, kind2))
       .help(&format!("try `{}` if you want to select the {}, \
                       or `{}` if you want to \
                       select the {}",

--- a/src/test/rustdoc/intra-links.rs
+++ b/src/test/rustdoc/intra-links.rs
@@ -10,7 +10,13 @@
 
 // @has intra_links/index.html
 // @has - '//a/@href' '../intra_links/struct.ThisType.html'
+// @has - '//a/@href' '../intra_links/struct.ThisType.html#method.this_method'
 // @has - '//a/@href' '../intra_links/enum.ThisEnum.html'
+// @has - '//a/@href' '../intra_links/enum.ThisEnum.html#ThisVariant.v'
+// @has - '//a/@href' '../intra_links/trait.ThisTrait.html'
+// @has - '//a/@href' '../intra_links/trait.ThisTrait.html#tymethod.this_associated_method'
+// @has - '//a/@href' '../intra_links/trait.ThisTrait.html#associatedtype.ThisAssociatedType'
+// @has - '//a/@href' '../intra_links/trait.ThisTrait.html#associatedconstant.THIS_ASSOCIATED_CONST'
 // @has - '//a/@href' '../intra_links/trait.ThisTrait.html'
 // @has - '//a/@href' '../intra_links/type.ThisAlias.html'
 // @has - '//a/@href' '../intra_links/union.ThisUnion.html'
@@ -23,8 +29,13 @@
 //! In this crate we would like to link to:
 //!
 //! * [`ThisType`](ThisType)
+//! * [`ThisType::this_method`](ThisType::this_method)
 //! * [`ThisEnum`](ThisEnum)
+//! * [`ThisEnum::ThisVariant`](ThisEnum::ThisVariant)
 //! * [`ThisTrait`](ThisTrait)
+//! * [`ThisTrait::this_associated_method`](ThisTrait::this_associated_method)
+//! * [`ThisTrait::ThisAssociatedType`](ThisTrait::ThisAssociatedType)
+//! * [`ThisTrait::THIS_ASSOCIATED_CONST`](ThisTrait::THIS_ASSOCIATED_CONST)
 //! * [`ThisAlias`](ThisAlias)
 //! * [`ThisUnion`](ThisUnion)
 //! * [`this_function`](this_function())
@@ -45,8 +56,16 @@ macro_rules! this_macro {
 }
 
 pub struct ThisType;
+
+impl ThisType {
+    pub fn this_method() {}
+}
 pub enum ThisEnum { ThisVariant, }
-pub trait ThisTrait {}
+pub trait ThisTrait {
+    type ThisAssociatedType;
+    const THIS_ASSOCIATED_CONST: u8;
+    fn this_associated_method();
+}
 pub type ThisAlias = Result<(), ()>;
 pub union ThisUnion { this_field: usize, }
 


### PR DESCRIPTION
Turn errors into warnings, also handle methods, trait items, and variants.

r? @killercup @QuietMisdreavus