### PR TITLE
Fix ICE when use trees have multiple empty nested groups

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2045,7 +2045,7 @@ impl<'a> Resolver<'a> {
                     segments: vec![],
                     span: use_tree.span,
                 };
-                self.resolve_use_tree(item, use_tree, &path);
+                self.resolve_use_tree(item.id, use_tree, &path);
             }
 
             ItemKind::ExternCrate(_) | ItemKind::MacroDef(..) | ItemKind::GlobalAsm(_) => {
@@ -2056,7 +2056,7 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    fn resolve_use_tree(&mut self, item: &Item, use_tree: &ast::UseTree, prefix: &Path) {
+    fn resolve_use_tree(&mut self, id: NodeId, use_tree: &ast::UseTree, prefix: &Path) {
         match use_tree.kind {
             ast::UseTreeKind::Nested(ref items) => {
                 let path = Path {
@@ -2070,10 +2070,10 @@ impl<'a> Resolver<'a> {
 
                 if items.len() == 0 {
                     // Resolve prefix of an import with empty braces (issue #28388).
-                    self.smart_resolve_path(item.id, None, &path, PathSource::ImportPrefix);
+                    self.smart_resolve_path(id, None, &path, PathSource::ImportPrefix);
                 } else {
-                    for &(ref tree, _) in items {
-                        self.resolve_use_tree(item, tree, &path);
+                    for &(ref tree, nested_id) in items {
+                        self.resolve_use_tree(nested_id, tree, &path);
                     }
                 }
             }

--- a/src/test/run-pass/issue-47673.rs
+++ b/src/test/run-pass/issue-47673.rs
@@ -1,0 +1,16 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(use_nested_groups)]
+#![allow(unused_import)]
+
+use {{}, {}};
+
+fn main() {}


### PR DESCRIPTION
The issue was caused by an oversight of mine in the original use_nested_groups PR, where different paths were resolved with the same `NodeId` in some cases (such as in `use {{}, {}};`).

Fixes #47673
r? @petrochenkov 