### PR TITLE
Make run-pass/env-home-dir.rs test more robust

### DIFF
--- a/src/test/run-pass/env-home-dir.rs
+++ b/src/test/run-pass/env-home-dir.rs
@@ -16,9 +16,6 @@
 use std::env::*;
 use std::path::PathBuf;
 
-/// When HOME is not set, some platforms return `None`, but others return `Some` with a default.
-/// Just check that it is not "/home/MountainView".
-
 #[cfg(unix)]
 fn main() {
     let oldhome = var("HOME");
@@ -30,6 +27,9 @@ fn main() {
     if cfg!(target_os = "android") {
         assert!(home_dir().is_none());
     } else {
+        // When HOME is not set, some platforms return `None`,
+        // but others return `Some` with a default.
+        // Just check that it is not "/home/MountainView".
         assert_ne!(home_dir(), Some(PathBuf::from("/home/MountainView")));
     }
 }

--- a/src/test/run-pass/env-home-dir.rs
+++ b/src/test/run-pass/env-home-dir.rs
@@ -16,6 +16,9 @@
 use std::env::*;
 use std::path::PathBuf;
 
+/// When HOME is not set, some platforms return `None`, but others return `Some` with a default.
+/// Just check that it is not "/home/MountainView".
+
 #[cfg(unix)]
 fn main() {
     let oldhome = var("HOME");
@@ -27,7 +30,7 @@ fn main() {
     if cfg!(target_os = "android") {
         assert!(home_dir().is_none());
     } else {
-        assert!(home_dir().is_some());
+        assert_ne!(home_dir(), Some(PathBuf::from("/home/MountainView")));
     }
 }
 


### PR DESCRIPTION
Remove the assumption that home_dir always returns Some.

This allows the test to be executed with [cross](https://github.com/japaric/cross).