### PR TITLE
[WIP] Upgrade the Travis CI macOS images for testing from Xcode 8.3 to 9.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ matrix:
   include:
     # Images used in testing PR and try-build should be run first.
     - env: IMAGE=x86_64-gnu-llvm-3.9 RUST_BACKTRACE=1
-      if: type = pull_request OR branch = auto
+      #if: type = pull_request OR branch = auto
+      if: branch = auto
 
     - env: IMAGE=dist-x86_64-linux DEPLOY=1
       if: branch = try OR branch = auto
@@ -57,7 +58,7 @@ matrix:
         NO_DEBUG_ASSERTIONS=1
       os: osx
       osx_image: xcode9.2
-      if: branch = auto
+      #if: branch = auto
 
     - env: >
         RUST_CHECK_TARGET=check
@@ -71,7 +72,7 @@ matrix:
         NO_DEBUG_ASSERTIONS=1
       os: osx
       osx_image: xcode9.2
-      if: branch = auto
+      #if: branch = auto
 
     # OSX builders producing releases. These do not run the full test suite and
     # just produce a bunch of artifacts.

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,12 +51,12 @@ matrix:
         SRC=.
         RUSTC_RETRY_LINKER_ON_SEGFAULT=1
         SCCACHE_ERROR_LOG=/tmp/sccache.log
-        MACOSX_DEPLOYMENT_TARGET=10.8
+        MACOSX_DEPLOYMENT_TARGET=10.12
         MACOSX_STD_DEPLOYMENT_TARGET=10.7
         NO_LLVM_ASSERTIONS=1
         NO_DEBUG_ASSERTIONS=1
       os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9.2
       if: branch = auto
 
     - env: >
@@ -65,12 +65,12 @@ matrix:
         SRC=.
         RUSTC_RETRY_LINKER_ON_SEGFAULT=1
         SCCACHE_ERROR_LOG=/tmp/sccache.log
-        MACOSX_DEPLOYMENT_TARGET=10.8
+        MACOSX_DEPLOYMENT_TARGET=10.12
         MACOSX_STD_DEPLOYMENT_TARGET=10.7
         NO_LLVM_ASSERTIONS=1
         NO_DEBUG_ASSERTIONS=1
       os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9.2
       if: branch = auto
 
     # OSX builders producing releases. These do not run the full test suite and


### PR DESCRIPTION
(WIP: Last time we tried it cannot be built cleanly. Let me ensure Travis is ✅ first.)