### PR TITLE
Call non-git beta builds simply x.y.z-beta

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -776,7 +776,11 @@ impl Build {
     fn release(&self, num: &str) -> String {
         match &self.config.channel[..] {
             "stable" => num.to_string(),
-            "beta" => format!("{}-beta.{}", num, self.beta_prerelease_version()),
+            "beta" => if self.rust_info.is_git() {
+                format!("{}-beta.{}", num, self.beta_prerelease_version())
+            } else {
+                format!("{}-beta", num)
+            },
             "nightly" => format!("{}-nightly", num),
             _ => format!("{}-dev", num),
         }


### PR DESCRIPTION
We can't use git commands to compute a prerelease version when we're
building from a source tarball, or if git is otherwise unavailable.
We'll just call such builds `x.y.z-beta`, without a prerelease.

Fixes #47754
r? @alexcrichton