### PR TITLE
Correctly format `extern crate` conflict resolution help

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3980,14 +3980,14 @@ impl<'a> Resolver<'a> {
                           container));
 
         err.span_label(span, format!("`{}` re{} here", name, new_participle));
-        if old_binding.span != syntax_pos::DUMMY_SP {
+        if old_binding.span != DUMMY_SP {
             err.span_label(self.session.codemap().def_span(old_binding.span),
                            format!("previous {} of the {} `{}` here", old_noun, old_kind, name));
         }
 
         // See https://github.com/rust-lang/rust/issues/32354
         if old_binding.is_import() || new_binding.is_import() {
-            let binding = if new_binding.is_import() {
+            let binding = if new_binding.is_import() && new_binding.span != DUMMY_SP {
                 new_binding
             } else {
                 old_binding

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4000,7 +4000,13 @@ impl<'a> Resolver<'a> {
                                            binding.is_renamed_extern_crate()) {
                 err.span_suggestion(binding.span,
                                     rename_msg,
-                                    format!("{} as Other{}", snippet, name));
+                                    if snippet.ends_with(';') {
+                                        format!("{} as Other{};",
+                                                &snippet[..snippet.len()-1],
+                                                name)
+                                    } else {
+                                        format!("{} as Other{}", snippet, name)
+                                    });
             } else {
                 err.span_label(binding.span, rename_msg);
             }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -6128,10 +6128,9 @@ impl<'a> Parser<'a> {
         } else {
             (None, crate_name)
         };
-
-        // We grab this before expecting the `;` so it's not a part of the span
-        let prev_span = self.prev_span;
         self.expect(&token::Semi)?;
+
+        let prev_span = self.prev_span;
 
         Ok(self.mk_item(lo.to(prev_span),
                         ident,

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -6128,9 +6128,11 @@ impl<'a> Parser<'a> {
         } else {
             (None, crate_name)
         };
+
+        // We grab this before expecting the `;` so it's not a part of the span
+        let prev_span = self.prev_span;
         self.expect(&token::Semi)?;
 
-        let prev_span = self.prev_span;
         Ok(self.mk_item(lo.to(prev_span),
                         ident,
                         ItemKind::ExternCrate(maybe_path),

--- a/src/test/ui/suggestions/issue-45799-bad-extern-crate-rename-suggestion-formatting.rs
+++ b/src/test/ui/suggestions/issue-45799-bad-extern-crate-rename-suggestion-formatting.rs
@@ -1,0 +1,12 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate std;
+fn main() {}

--- a/src/test/ui/suggestions/issue-45799-bad-extern-crate-rename-suggestion-formatting.rs
+++ b/src/test/ui/suggestions/issue-45799-bad-extern-crate-rename-suggestion-formatting.rs
@@ -10,3 +10,4 @@
 
 extern crate std;
 fn main() {}
+//~^^ ERROR the name `std` is defined multiple times [E0259]

--- a/src/test/ui/suggestions/issue-45799-bad-extern-crate-rename-suggestion-formatting.stderr
+++ b/src/test/ui/suggestions/issue-45799-bad-extern-crate-rename-suggestion-formatting.stderr
@@ -2,13 +2,13 @@ error[E0259]: the name `std` is defined multiple times
   --> $DIR/issue-45799-bad-extern-crate-rename-suggestion-formatting.rs:11:1
    |
 11 | extern crate std;
-   | ^^^^^^^^^^^^^^^^ `std` reimported here
+   | ^^^^^^^^^^^^^^^^^ `std` reimported here
    |
    = note: `std` must be defined only once in the type namespace of this module
 help: You can use `as` to change the binding name of the import
    |
 11 | extern crate std as Otherstd;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/issue-45799-bad-extern-crate-rename-suggestion-formatting.stderr
+++ b/src/test/ui/suggestions/issue-45799-bad-extern-crate-rename-suggestion-formatting.stderr
@@ -1,0 +1,14 @@
+error[E0259]: the name `std` is defined multiple times
+  --> $DIR/issue-45799-bad-extern-crate-rename-suggestion-formatting.rs:11:1
+   |
+11 | extern crate std;
+   | ^^^^^^^^^^^^^^^^ `std` reimported here
+   |
+   = note: `std` must be defined only once in the type namespace of this module
+help: You can use `as` to change the binding name of the import
+   |
+11 | extern crate std as Otherstd;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Closes #45799. Follow up to @Cldfire's #45820.

If the `extern` statement that will have a suggestion ends on a `;`, synthesize a new span that doesn't include it.