### PR TITLE
Tweak wording for borrows within macro invocations

### DIFF
--- a/src/test/ui/borrowck/moves-inside-of-macro.rs
+++ b/src/test/ui/borrowck/moves-inside-of-macro.rs
@@ -1,0 +1,25 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z borrowck=compare
+
+macro_rules! test {
+    ($v:expr) => {{
+        drop(&$v);
+        $v
+    }}
+}
+
+fn main() {
+    let b = Box::new(true);
+    test!({b});
+    //~^ ERROR use of moved value: `b` (Ast)
+    //~^^ ERROR use of moved value: `b` (Mir)
+}

--- a/src/test/ui/borrowck/moves-inside-of-macro.stderr
+++ b/src/test/ui/borrowck/moves-inside-of-macro.stderr
@@ -1,0 +1,10 @@
+error[E0382]: use of moved value: `b`
+  --> $DIR/moves-inside-of-macro.rs:20:12
+   |
+20 |     test!({b});
+   |            ^ value moved inside this macro invocation
+   |
+   = note: move occurs because `b` has type `std::boxed::Box<bool>`, which does not implement the `Copy` trait
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fix #46099.