### PR TITLE
Use the slice length to hint the optimizer about iter.position result

### DIFF
--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1223,7 +1223,8 @@ macro_rules! iterator {
                 P: FnMut(Self::Item) -> bool,
             {
                 // The addition might panic on overflow
-                let n = self.len();
+                // Use the len of the slice to hint optimizer to remove result index bounds check.
+                let n = make_slice!(self.ptr, self.end).len();
                 self.try_fold(0, move |i, x| {
                     if predicate(x) { Err(i) }
                     else { Ok(i + 1) }
@@ -1241,7 +1242,8 @@ macro_rules! iterator {
             {
                 // No need for an overflow check here, because `ExactSizeIterator`
                 // implies that the number of elements fits into a `usize`.
-                let n = self.len();
+                // Use the len of the slice to hint optimizer to remove result index bounds check.
+                let n = make_slice!(self.ptr, self.end).len();
                 self.try_rfold(n, move |i, x| {
                     let i = i - 1;
                     if predicate(x) { Err(i) }


### PR DESCRIPTION
Using the len of the iterator doesn't give the same result.
That's also why we can't generalize it to all TrustedLen iterators.

Problem demo: https://godbolt.org/g/MXg2ae
Fix demo: https://godbolt.org/g/P8q5aZ

Second attempt of #47333
Third attempt of #45501
Fixes #45964
