### PR TITLE
rustc: Add the ability to not run dsymutil

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1320,6 +1320,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
         "The epoch to build Rust with. Newer epochs may include features
          that require breaking changes. The default epoch is 2015 (the first
          epoch). Crates compiled with different epochs can be linked together."),
+    run_dsymutil: Option<bool> = (None, parse_opt_bool, [TRACKED],
+          "run `dsymutil` and delete intermediate object files"),
 }
 
 pub fn default_lib_output() -> CrateType {


### PR DESCRIPTION
This commit adds the ability for rustc to not run `dsymutil` by default
on OSX. A new codegen option, `-Z run-dsymutil=no`, was added to specify
that `dsymutil` should *not* run and instead the compiler should
unconditionally keep the object files around in a compilation if
necessary for debug information.

cc #47240