### PR TITLE
Fix ICE on const eval of union field

### DIFF
--- a/src/librustc_trans/mir/constant.rs
+++ b/src/librustc_trans/mir/constant.rs
@@ -140,7 +140,10 @@ impl<'a, 'tcx> Const<'tcx> {
                 }
             }
             _ => {
-                const_get_elt(self.llval, layout.llvm_field_index(i))
+                match layout.fields {
+                    layout::FieldPlacement::Union(_) => self.llval,
+                    _ => const_get_elt(self.llval, layout.llvm_field_index(i)),
+                }
             }
         }
     }

--- a/src/test/run-pass/union/union-const-eval-field.rs
+++ b/src/test/run-pass/union/union-const-eval-field.rs
@@ -1,0 +1,26 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(const_fn)]
+
+union DummyUnion {
+    field1: i32,
+    field2: i32,
+}
+
+const fn read_field() -> i32 {
+    const UNION: DummyUnion = DummyUnion { field1: 5 };
+    const FIELD: i32 = unsafe { UNION.field2 };
+    FIELD
+}
+
+fn main() {
+    assert_eq!(read_field(), 5);
+}

--- a/src/test/run-pass/union/union-const-eval-field.rs
+++ b/src/test/run-pass/union/union-const-eval-field.rs
@@ -10,17 +10,36 @@
 
 #![feature(const_fn)]
 
+type Field1 = i32;
+type Field2 = f32;
+type Field3 = i64;
+
 union DummyUnion {
-    field1: i32,
-    field2: i32,
+    field1: Field1,
+    field2: Field2,
+    field3: Field3,
 }
 
-const fn read_field() -> i32 {
-    const UNION: DummyUnion = DummyUnion { field1: 5 };
-    const FIELD: i32 = unsafe { UNION.field2 };
-    FIELD
+const FLOAT1_AS_I32: i32 = 1065353216;
+const UNION: DummyUnion = DummyUnion { field1: FLOAT1_AS_I32 };
+
+const fn read_field1() -> Field1 {
+    const FIELD1: Field1 = unsafe { UNION.field1 };
+    FIELD1
+}
+
+const fn read_field2() -> Field2 {
+    const FIELD2: Field2 = unsafe { UNION.field2 };
+    FIELD2
+}
+
+const fn read_field3() -> Field3 {
+    const FIELD3: Field3 = unsafe { UNION.field3 };
+    FIELD3
 }
 
 fn main() {
-    assert_eq!(read_field(), 5);
+    assert_eq!(read_field1(), FLOAT1_AS_I32);
+    assert_eq!(read_field2(), 1.0);
+    assert_eq!(read_field3(), unsafe { UNION.field3 });
 }


### PR DESCRIPTION
MIR's `Const::get_field()` attempts to retrieve the value for a given field in a constant. In the case of a union constant it was falling through to a generic `const_get_elt` based on the field index. As union fields don't have an index this caused an ICE in `llvm_field_index`.

Fix by simply returning the current value when accessing any field in a union. This works because all union fields start at byte offset 0.

The added test uses `const_fn` it ensure the field is extracted using MIR's const evaluation. The crash is reproducible without it, however.

Fixes #47788

r? @eddyb