### PR TITLE
don't mention tasks in stability warnings of #[thread_local] #47755

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -694,9 +694,7 @@ pub const BUILTIN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeG
     ("thread_local", Whitelisted, Gated(Stability::Unstable,
                                         "thread_local",
                                         "`#[thread_local]` is an experimental feature, and does \
-                                         not currently handle destructors. There is no \
-                                         corresponding `#[task_local]` mapping to the task \
-                                         model",
+                                         not currently handle destructors.",
                                         cfg_fn!(thread_local))),
 
     ("rustc_on_unimplemented", Normal, Gated(Stability::Unstable,

--- a/src/test/ui/feature-gate-thread_local.stderr
+++ b/src/test/ui/feature-gate-thread_local.stderr
@@ -1,4 +1,4 @@
-error[E0658]: `#[thread_local]` is an experimental feature, and does not currently handle destructors. There is no corresponding `#[task_local]` mapping to the task model (see issue #29594)
+error[E0658]: `#[thread_local]` is an experimental feature, and does not currently handle destructors. (see issue #29594)
   --> $DIR/feature-gate-thread_local.rs:18:1
    |
 18 | #[thread_local] //~ ERROR `#[thread_local]` is an experimental feature


### PR DESCRIPTION
This is a fix for issue #47755.