### PR TITLE
Changed color of struct link from #ff794d to #2dbfb8 for Rust docs

### DIFF
--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -127,7 +127,7 @@ pre {
 .content .highlighted.primitive { background-color: #00708a; }
 
 .content span.enum, .content a.enum, .block a.current.enum { color: #82b089; }
-.content span.struct, .content a.struct, .block a.current.struct { color: #ff794d; }
+.content span.struct, .content a.struct, .block a.current.struct { color: #2dbfb8; }
 .content span.type, .content a.type, .block a.current.type { color: #ff7f00; }
 .content span.foreigntype, .content a.foreigntype, .block a.current.foreigntype { color: #dd7de8; }
 .content span.macro, .content a.macro, .block a.current.macro { color: #09bd00; }

--- a/src/librustdoc/html/static/themes/main.css
+++ b/src/librustdoc/html/static/themes/main.css
@@ -130,7 +130,7 @@ pre {
 .content .highlighted.primitive { background-color: #9aecff; }
 
 .content span.enum, .content a.enum, .block a.current.enum { color: #508157; }
-.content span.struct, .content a.struct, .block a.current.struct { color: #df3600; }
+.content span.struct, .content a.struct, .block a.current.struct { color: #2dbfb8; }
 .content span.type, .content a.type, .block a.current.type { color: #ba5d00; }
 .content span.foreigntype, .content a.foreigntype, .block a.current.foreigntype { color: #cd00e2; }
 .content span.macro, .content a.macro, .block a.current.macro { color: #068000; }

--- a/src/librustdoc/html/static/themes/main.css
+++ b/src/librustdoc/html/static/themes/main.css
@@ -130,7 +130,7 @@ pre {
 .content .highlighted.primitive { background-color: #9aecff; }
 
 .content span.enum, .content a.enum, .block a.current.enum { color: #508157; }
-.content span.struct, .content a.struct, .block a.current.struct { color: #2dbfb8; }
+.content span.struct, .content a.struct, .block a.current.struct { color: #ad448e; }
 .content span.type, .content a.type, .block a.current.type { color: #ba5d00; }
 .content span.foreigntype, .content a.foreigntype, .block a.current.foreigntype { color: #cd00e2; }
 .content span.macro, .content a.macro, .block a.current.macro { color: #068000; }


### PR DESCRIPTION
This is in reference to https://github.com/rust-lang/rust/issues/47801

here I have changed the default color of struct link for `#ff794d` to `#2dbfb8`

cc: @nagisa  @timClicks