### PR TITLE
Tweak error message when reborrowing `&mut self` as `mut`

### DIFF
--- a/src/test/ui/borrowck/mut-reborrow-self.rs
+++ b/src/test/ui/borrowck/mut-reborrow-self.rs
@@ -1,0 +1,24 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo {
+    u :u32,
+}
+impl Foo {
+    fn foo(&mut self) {
+        || {
+            let r = &mut self;
+            r.u += 1;
+        };
+    }
+    //~^^^^^ ERROR closure cannot assign to immutable argument `self` [E0595]
+}
+
+fn main() {}

--- a/src/test/ui/borrowck/mut-reborrow-self.stderr
+++ b/src/test/ui/borrowck/mut-reborrow-self.stderr
@@ -1,0 +1,10 @@
+error[E0595]: closure cannot assign to immutable argument `self`
+  --> $DIR/mut-reborrow-self.rs:16:9
+   |
+15 |     fn foo(&mut self) {
+   |            --------- given this existing mutable borrow...
+16 |         || {
+   |         ^^ cannot reborrow immutable argument `self` mutably in this closure
+
+error: aborting due to previous error
+

--- a/src/test/ui/did_you_mean/issue-31424.stderr
+++ b/src/test/ui/did_you_mean/issue-31424.stderr
@@ -1,6 +1,8 @@
 error[E0596]: cannot borrow immutable argument `self` as mutable
   --> $DIR/issue-31424.rs:17:15
    |
+16 |     fn foo(&mut self) {
+   |            --------- given this existing mutable borrow...
 17 |         (&mut self).bar(); //~ ERROR cannot borrow
    |               ^^^^
    |               |

--- a/src/test/ui/did_you_mean/issue-34126.stderr
+++ b/src/test/ui/did_you_mean/issue-34126.stderr
@@ -1,6 +1,8 @@
 error[E0596]: cannot borrow immutable argument `self` as mutable
   --> $DIR/issue-34126.rs:16:23
    |
+15 |     fn start(&mut self) {
+   |              --------- given this existing mutable borrow...
 16 |         self.run(&mut self); //~ ERROR cannot borrow
    |                       ^^^^
    |                       |

--- a/src/test/ui/did_you_mean/issue-34337.stderr
+++ b/src/test/ui/did_you_mean/issue-34337.stderr
@@ -1,6 +1,8 @@
 error[E0596]: cannot borrow immutable local variable `key` as mutable
   --> $DIR/issue-34337.rs:16:14
    |
+15 |     let ref mut key = v[0];
+   |         ----------- given this existing mutable borrow...
 16 |     get(&mut key); //~ ERROR cannot borrow
    |              ^^^
    |              |

--- a/src/test/ui/did_you_mean/issue-37139.stderr
+++ b/src/test/ui/did_you_mean/issue-37139.stderr
@@ -1,6 +1,8 @@
 error[E0596]: cannot borrow immutable local variable `x` as mutable
   --> $DIR/issue-37139.rs:22:23
    |
+21 |         TestEnum::Item(ref mut x) => {
+   |                        --------- given this existing mutable borrow...
 22 |             test(&mut x); //~ ERROR cannot borrow immutable
    |                       ^
    |                       |


### PR DESCRIPTION
 - Point out the binding being reborrowed when trying to reborrow within a closure.
 - When reborrowing `&mut self` inside a closure, the error message doesn't point at the reborrow statement but at the closure signature (#47774). While we should fix the span itself, in the meantime mention the binding being reborrowed in the span label.