### PR TITLE
use correct casing for rename suggestions

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3998,14 +3998,20 @@ impl<'a> Resolver<'a> {
 
             if let (Ok(snippet), false) = (cm.span_to_snippet(binding.span),
                                            binding.is_renamed_extern_crate()) {
+                let suggested_name = if name.as_str().chars().next().unwrap().is_uppercase() {
+                    format!("Other{}", name)
+                } else {
+                    format!("other_{}", name)
+                };
+
                 err.span_suggestion(binding.span,
                                     rename_msg,
                                     if snippet.ends_with(';') {
-                                        format!("{} as Other{};",
+                                        format!("{} as {};",
                                                 &snippet[..snippet.len()-1],
-                                                name)
+                                                suggested_name)
                                     } else {
-                                        format!("{} as Other{}", snippet, name)
+                                        format!("{} as {}", snippet, suggested_name)
                                     });
             } else {
                 err.span_label(binding.span, rename_msg);

--- a/src/test/ui/blind-item-item-shadow.stderr
+++ b/src/test/ui/blind-item-item-shadow.stderr
@@ -10,8 +10,8 @@ error[E0255]: the name `foo` is defined multiple times
    = note: `foo` must be defined only once in the type namespace of this module
 help: You can use `as` to change the binding name of the import
    |
-13 | use foo::foo as Otherfoo;
-   |     ^^^^^^^^^^^^^^^^^^^^
+13 | use foo::foo as other_foo;
+   |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/double-import.stderr
+++ b/src/test/ui/double-import.stderr
@@ -9,8 +9,8 @@ error[E0252]: the name `foo` is defined multiple times
    = note: `foo` must be defined only once in the value namespace of this module
 help: You can use `as` to change the binding name of the import
    |
-23 | use sub2::foo as Otherfoo; //~ ERROR the name `foo` is defined multiple times
-   |     ^^^^^^^^^^^^^^^^^^^^^
+23 | use sub2::foo as other_foo; //~ ERROR the name `foo` is defined multiple times
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/imports/duplicate.stderr
+++ b/src/test/ui/imports/duplicate.stderr
@@ -9,8 +9,8 @@ error[E0252]: the name `foo` is defined multiple times
    = note: `foo` must be defined only once in the value namespace of this module
 help: You can use `as` to change the binding name of the import
    |
-25 |     use a::foo as Otherfoo; //~ ERROR the name `foo` is defined multiple times
-   |         ^^^^^^^^^^^^^^^^^^
+25 |     use a::foo as other_foo; //~ ERROR the name `foo` is defined multiple times
+   |         ^^^^^^^^^^^^^^^^^^^
 
 error[E0659]: `foo` is ambiguous
   --> $DIR/duplicate.rs:56:9

--- a/src/test/ui/issue-26886.stderr
+++ b/src/test/ui/issue-26886.stderr
@@ -24,8 +24,8 @@ error[E0252]: the name `sync` is defined multiple times
    = note: `sync` must be defined only once in the type namespace of this module
 help: You can use `as` to change the binding name of the import
    |
-14 | use std::sync as Othersync; //~ ERROR the name `sync` is defined multiple times
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+14 | use std::sync as other_sync; //~ ERROR the name `sync` is defined multiple times
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve-conflict-item-vs-import.stderr
+++ b/src/test/ui/resolve-conflict-item-vs-import.stderr
@@ -10,8 +10,8 @@ error[E0255]: the name `transmute` is defined multiple times
    = note: `transmute` must be defined only once in the value namespace of this module
 help: You can use `as` to change the binding name of the import
    |
-11 | use std::mem::transmute as Othertransmute;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+11 | use std::mem::transmute as other_transmute;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/issue-45799-bad-extern-crate-rename-suggestion-formatting.stderr
+++ b/src/test/ui/suggestions/issue-45799-bad-extern-crate-rename-suggestion-formatting.stderr
@@ -7,7 +7,7 @@ error[E0259]: the name `std` is defined multiple times
    = note: `std` must be defined only once in the type namespace of this module
 help: You can use `as` to change the binding name of the import
    |
-11 | extern crate std as Otherstd;
+11 | extern crate std as other_std;
    |
 
 error: aborting due to previous error

--- a/src/test/ui/use-mod.stderr
+++ b/src/test/ui/use-mod.stderr
@@ -25,7 +25,7 @@ error[E0252]: the name `bar` is defined multiple times
    = note: `bar` must be defined only once in the type namespace of this module
 help: You can use `as` to change the binding name of the import
    |
-15 |     self as Otherbar
+15 |     self as other_bar
    |
 
 error: aborting due to 3 previous errors


### PR DESCRIPTION
If the original name is uppercase, use camel case. Otherwise, use snake
case.