### PR TITLE
Work around LLVM OCAML binding installation failure

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -155,6 +155,7 @@ impl Step for Llvm {
            .define("WITH_POLLY", "OFF")
            .define("LLVM_ENABLE_TERMINFO", "OFF")
            .define("LLVM_ENABLE_LIBEDIT", "OFF")
+           .define("LLVM_OCAML_INSTALL_PATH", "usr/lib/ocaml")
            .define("LLVM_PARALLEL_COMPILE_JOBS", build.jobs().to_string())
            .define("LLVM_TARGET_ARCH", target.split('-').next().unwrap())
            .define("LLVM_DEFAULT_TARGET_TRIPLE", target);

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -155,11 +155,18 @@ impl Step for Llvm {
            .define("WITH_POLLY", "OFF")
            .define("LLVM_ENABLE_TERMINFO", "OFF")
            .define("LLVM_ENABLE_LIBEDIT", "OFF")
-           .define("LLVM_OCAML_INSTALL_PATH", "usr/lib/ocaml")
            .define("LLVM_PARALLEL_COMPILE_JOBS", build.jobs().to_string())
            .define("LLVM_TARGET_ARCH", target.split('-').next().unwrap())
            .define("LLVM_DEFAULT_TARGET_TRIPLE", target);
 
+        // By default, LLVM will automatically find OCaml and, if it finds it,
+        // install the LLVM bindings in LLVM_OCAML_INSTALL_PATH, which defaults
+        // to /usr/bin/ocaml.
+        // This causes problem for non-root builds of Rust. Side-step the issue
+        // by setting LLVM_OCAML_INSTALL_PATH to a relative path, so it installs
+        // in the prefix.
+        cfg.define("LLVM_OCAML_INSTALL_PATH",
+            env::var_os("LLVM_OCAML_INSTALL_PATH").unwrap_or_else(|| "usr/lib/ocaml".into()));
 
         // This setting makes the LLVM tools link to the dynamic LLVM library,
         // which saves both memory during parallel links and overall disk space


### PR DESCRIPTION
Hello,

I have OCaml installed on my machine, and compiling rust systematically fails when LLVM attempts installing the OCaml bindings in `/usr/lib/ocaml`, which is write-protected. Here are the logs: https://gist.github.com/roblabla/3f147914c5df627c9d97ab311ba133ad

Some digging around the issue reveals:

- The code that finds if OCaml is installed, and sets the bindings to be compiled/installed: https://github.com/llvm-mirror/llvm/blob/b24a45d2e9f4fc10c3f9e16172104910b38637f2/cmake/config-ix.cmake#L612
- https://github.com/llvm-mirror/llvm/blob/b24a45d2e9f4fc10c3f9e16172104910b38637f2/bindings/ocaml/llvm/CMakeLists.txt Some code that does the installation.

The problem seems to be that `LLVM_OCAML_INSTALL_PATH` is set to `OCAML_STDLIB_PATH` by default, which is in `/usr/lib/ocaml`, instead of the prefix.

This PR "fixes" the issue by setting `LLVM_OCAML_INSTALL_PATH` to `usr/lib/ocaml`. I haven't found a way to make LLVM not build OCaml, which would probably be a superior fix.