### PR TITLE
Create a directory for --out-dir if it does not already exist

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -163,6 +163,13 @@ pub fn compile_input(trans: Box<TransCrate>,
             return Ok(())
         }
 
+        if let &Some(ref dir) = outdir {
+            if fs::create_dir_all(dir).is_err() {
+                sess.err("failed to find or create the directory specified by --out-dir");
+                return Err(CompileIncomplete::Stopped);
+            }
+        }
+
         let arenas = AllArenas::new();
 
         // Construct the HIR map


### PR DESCRIPTION
Currently if `--out-dir` is set to a non-existent directory, the compiler will throw unfriendly messages like `error: could not write output to subdir/example.crate.allocator.rcgu.o: No such file or
directory`, which, while not completely unreadable, isn’t very user-friendly either. This change creates the directory automatically if it does not yet exist.