### PR TITLE
Implement TryFrom for float to integer types

### DIFF
--- a/src/libcore/tests/num/i16.rs
+++ b/src/libcore/tests/num/i16.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-int_module!(i16, i16);
+int_module!(i16, i16, 16);

--- a/src/libcore/tests/num/i32.rs
+++ b/src/libcore/tests/num/i32.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-int_module!(i32, i32);
+int_module!(i32, i32, 32);

--- a/src/libcore/tests/num/i64.rs
+++ b/src/libcore/tests/num/i64.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-int_module!(i64, i64);
+int_module!(i64, i64, 64);

--- a/src/libcore/tests/num/i8.rs
+++ b/src/libcore/tests/num/i8.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-int_module!(i8, i8);
+int_module!(i8, i8, 8);

--- a/src/libcore/tests/num/int_macros.rs
+++ b/src/libcore/tests/num/int_macros.rs
@@ -8,13 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-macro_rules! int_module { ($T:ident, $T_i:ident) => (
+macro_rules! int_module { ($T:ident, $T_i:ident, $w:expr) => (
 #[cfg(test)]
 mod tests {
     use core::$T_i::*;
     use core::isize;
     use core::ops::{Shl, Shr, Not, BitXor, BitAnd, BitOr};
     use core::mem;
+    use core::convert::TryInto;
 
     use num;
 
@@ -213,6 +214,38 @@ mod tests {
         r = -2 as $T;
         assert_eq!(r.pow(2), 4 as $T);
         assert_eq!(r.pow(3), -8 as $T);
+    }
+
+    #[test]
+    fn test_f32_try_from() {
+        for n in &[1f32, 2f32, 3f32] {
+            let v = 2f32.powi(i32::min(24, $w - 1)) - n;
+            assert!((v.try_into() as Result<$T, _>).is_ok());
+        }
+
+        for n in &[0f32, 1f32, 2f32] {
+            let v = -2f32.powi(i32::min(24, $w - 1)) + n;
+            assert!((v.try_into() as Result<$T, _>).is_ok());
+        }
+
+        assert!((2f32.powi($w - 1).try_into() as Result<$T, _>).is_err());
+        assert!(((-2f32.powi($w)).try_into() as Result<$T, _>).is_err());
+    }
+
+    #[test]
+    fn test_f64_try_from() {
+        for n in &[1f64, 2f64, 3f64] {
+            let v = 2f64.powi(i32::min(53, $w - 1)) - n;
+            assert!((v.try_into() as Result<$T, _>).is_ok());
+        }
+
+        for n in &[0f64, 1f64, 2f64] {
+            let v = -2f64.powi(i32::min(53, $w - 1)) + n;
+            assert!((v.try_into() as Result<$T, _>).is_ok());
+        }
+
+        assert!((2f64.powi($w - 1).try_into() as Result<$T, _>).is_err());
+        assert!(((-2f64.powi($w)).try_into() as Result<$T, _>).is_err());
     }
 }
 

--- a/src/libcore/tests/num/u16.rs
+++ b/src/libcore/tests/num/u16.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-uint_module!(u16, u16);
+uint_module!(u16, u16, 16);

--- a/src/libcore/tests/num/u32.rs
+++ b/src/libcore/tests/num/u32.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-uint_module!(u32, u32);
+uint_module!(u32, u32, 32);

--- a/src/libcore/tests/num/u64.rs
+++ b/src/libcore/tests/num/u64.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-uint_module!(u64, u64);
+uint_module!(u64, u64, 64);

--- a/src/libcore/tests/num/u8.rs
+++ b/src/libcore/tests/num/u8.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-uint_module!(u8, u8);
+uint_module!(u8, u8, 8);

--- a/src/libcore/tests/num/uint_macros.rs
+++ b/src/libcore/tests/num/uint_macros.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-macro_rules! uint_module { ($T:ident, $T_i:ident) => (
+macro_rules! uint_module { ($T:ident, $T_i:ident, $w:expr) => (
 #[cfg(test)]
 mod tests {
     use core::$T_i::*;
@@ -16,6 +16,7 @@ mod tests {
     use core::ops::{BitOr, BitAnd, BitXor, Shl, Shr, Not};
     use std::str::FromStr;
     use std::mem;
+    use core::convert::TryInto;
 
     #[test]
     fn test_overflows() {
@@ -153,6 +154,26 @@ mod tests {
 
         assert_eq!($T::from_str_radix("Z", 10).ok(), None::<$T>);
         assert_eq!($T::from_str_radix("_", 2).ok(), None::<$T>);
+    }
+
+    #[test]
+    fn test_f32_try_from() {
+        for n in &[1f32, 2f32, 3f32] {
+            let v = 2f32.powi(i32::min(24, $w)) - n;
+            assert!((v.try_into() as Result<$T, _>).is_ok());
+        }
+
+        assert!((2f32.powi($w).try_into() as Result<$T, _>).is_err());
+    }
+
+    #[test]
+    fn test_f64_try_from() {
+        for n in &[1f64, 2f64, 3f64] {
+            let v = 2f64.powi(i32::min(53, $w)) - n;
+            assert!((v.try_into() as Result<$T, _>).is_ok());
+        }
+
+        assert!((2f64.powi($w).try_into() as Result<$T, _>).is_err());
     }
 }
 )}


### PR DESCRIPTION
This implements `TryFrom` for `f32`, and `f64` to all integer types.

This is accomplished by casting the floating point number, into the target type and back, and then comparing if the resulting value is identical to the converted value.

I'm not sure this implementation is sound, in particular issues like #10184 seem to indicate that these kinds of casts are not always sound. A review by someone who knows more about floating point numbers, and what kind of guarantees the casts give us would be highly appreciated.

If there is a better way to determine if a given floating point number can be converted into an integer, I'd also love to know.