### PR TITLE
Cleanup the shim code

### DIFF
--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1515,8 +1515,8 @@ pub enum AggregateKind<'tcx> {
     Array(Ty<'tcx>),
     Tuple,
 
-    /// The second field is variant number (discriminant), it's equal
-    /// to 0 for struct and union expressions. The fourth field is
+    /// The second field is the variant index. It's equal to 0 for struct
+    /// and union expressions. The fourth field is
     /// active field number and is present only for union expressions
     /// -- e.g. for a union expression `SomeUnion { c: .. }`, the
     /// active field index would identity the field `c`

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -305,11 +305,10 @@ fn build_clone_shim<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         }
         ty::TyClosure(def_id, substs) => {
             builder.tuple_like_shim(
-                &substs.upvar_tys(def_id, tcx).collect::<Vec<_>>(),
-                AggregateKind::Closure(def_id, substs)
+                &substs.upvar_tys(def_id, tcx).collect::<Vec<_>>()
             )
         }
-        ty::TyTuple(tys, _) => builder.tuple_like_shim(&**tys, AggregateKind::Tuple),
+        ty::TyTuple(tys, _) => builder.tuple_like_shim(&**tys),
         _ => {
             bug!("clone shim for `{:?}` which is not `Copy` and is not an aggregate", self_ty)
         }
@@ -625,12 +624,7 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
         self.block(vec![], TerminatorKind::Resume, true);
     }
 
-    fn tuple_like_shim(&mut self, tys: &[ty::Ty<'tcx>], kind: AggregateKind<'tcx>) {
-        match kind {
-            AggregateKind::Tuple | AggregateKind::Closure(..) => (),
-            _ => bug!("only tuples and closures are accepted"),
-        };
-
+    fn tuple_like_shim(&mut self, tys: &[ty::Ty<'tcx>]) {
         let rcvr = Place::Local(Local::new(1+0)).deref();
 
         let mut previous_place = None;


### PR DESCRIPTION


 - We now write directly to `RETURN_PLACE` instead of creating intermediates
 - `tuple_like_shim` takes an iterator (used by #47867)
 - `tuple_like_shim` no longer relies on it being the first thing to create blocks, and uses relative block indexing in a cleaner way (necessary for #47867)
 - All the shim builders take `dest, src` arguments instead of hardcoding RETURN_PLACE


r? @eddyb