### PR TITLE
Fix ref-to-ptr coercions not working with NLL in certain cases

### DIFF
--- a/src/test/mir-opt/validate_5.rs
+++ b/src/test/mir-opt/validate_5.rs
@@ -52,12 +52,15 @@ fn main() {
 //         Validate(Acquire, [_1: &ReFree(DefId(0/1:9 ~ validate_5[317d]::main[0]::{{closure}}[0]), BrEnv) [closure@NodeId(46)], _2: &ReFree(DefId(0/1:9 ~ validate_5[317d]::main[0]::{{closure}}[0]), BrAnon(0)) mut i32]);
 //         StorageLive(_3);
 //         StorageLive(_4);
+//         StorageLive(_5);
 //         Validate(Suspend(ReScope(Node(ItemLocalId(9)))), [(*_2): i32]);
-//         _4 = &ReErased mut (*_2);
-//         Validate(Acquire, [(*_4): i32/ReScope(Node(ItemLocalId(9)))]);
-//         _3 = move _4 as *mut i32 (Misc);
+//         _5 = &ReErased mut (*_2);
+//         Validate(Acquire, [(*_5): i32/ReScope(Node(ItemLocalId(9)))]);
+//         _4 = move _5 as *mut i32 (Misc);
+//         _3 = move _4;
 //         EndRegion(ReScope(Node(ItemLocalId(9))));
 //         StorageDead(_4);
+//         StorageDead(_5);
 //         Validate(Release, [_0: bool, _3: *mut i32]);
 //         _0 = const write_42(move _3) -> bb1;
 //     }

--- a/src/test/run-pass/issue-47722.rs
+++ b/src/test/run-pass/issue-47722.rs
@@ -1,0 +1,26 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+// Tests that automatic coercions from &mut T to *mut T
+// allow borrows of T to expire immediately - essentially, that
+// they work identically to 'foo as *mut T'
+#![feature(nll)]
+
+struct SelfReference {
+    self_reference: *mut SelfReference,
+}
+
+impl SelfReference {
+    fn set_self_ref(&mut self) {
+        self.self_reference = self;
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Implicit coercions from references to pointers were lowered to slightly
different Mir than explicit casts (e.g. 'foo as *mut T'). This resulted
in certain uses of self-referential structs compiling correctly when an
explicit cast was used, but not when the implicit coercion was used.

To fix this, this commit adds an outer 'Use' expr when applying a
raw-ptr-borrow adjustment. This makes the lowered Mir for coercions
identical to that of explicit coercions, allowing the original code to
compile regardless of how the raw ptr cast occurs.

Fixes #47722