### PR TITLE
Ignore run-pass/sse2 when using system LLVM

### DIFF
--- a/src/test/run-pass/sse2.rs
+++ b/src/test/run-pass/sse2.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// min-llvm-version 4.0
+// no-system-llvm -- needs MCSubtargetInfo::getFeatureTable()
 // ignore-cloudabi no std::env
 
 #![feature(cfg_target_feature)]


### PR DESCRIPTION
This is a test of `target_feature`, which needs a rust-specific patch to
LLVM to add `MCSubtargetInfo::getFeatureTable()`.