### PR TITLE
rustc: Move location of `codegen-backends` dir

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -377,6 +377,11 @@ impl<'a> Builder<'a> {
         self.ensure(Libdir { compiler, target })
     }
 
+    pub fn sysroot_codegen_backends(&self, compiler: Compiler) -> PathBuf {
+        self.sysroot_libdir(compiler, compiler.host)
+            .with_file_name("codegen-backends")
+    }
+
     /// Returns the compiler's libdir where it stores the dynamic libraries that
     /// it itself links against.
     ///

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -724,8 +724,7 @@ fn copy_codegen_backends_to_sysroot(builder: &Builder,
     //
     // Here we're looking for the output dylib of the `CodegenBackend` step and
     // we're copying that into the `codegen-backends` folder.
-    let libdir = builder.sysroot_libdir(target_compiler, target);
-    let dst = libdir.join("codegen-backends");
+    let dst = builder.sysroot_codegen_backends(target_compiler);
     t!(fs::create_dir_all(&dst));
 
     for backend in builder.config.rust_codegen_backends.iter() {

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -435,11 +435,9 @@ impl Step for Rustc {
             }
 
             // Copy over the codegen backends
-            let backends_src = builder.sysroot_libdir(compiler, host)
-                .join("codegen-backends");
-            let backends_dst = image.join("lib/rustlib")
-                .join(&*host)
-                .join("lib/codegen-backends");
+            let backends_src = builder.sysroot_codegen_backends(compiler);
+            let backends_rel = backends_src.strip_prefix(&src).unwrap();
+            let backends_dst = image.join(&backends_rel);
             t!(fs::create_dir_all(&backends_dst));
             cp_r(&backends_src, &backends_dst);
 

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -289,7 +289,7 @@ fn get_trans_sysroot(backend_name: &str) -> fn() -> Box<TransCrate> {
     let sysroot = sysroot_candidates.iter()
         .map(|sysroot| {
             let libdir = filesearch::relative_target_lib_path(&sysroot, &target);
-            sysroot.join(&libdir).join("codegen-backends")
+            sysroot.join(libdir).with_file_name("codegen-backends")
         })
         .filter(|f| {
             info!("codegen backend candidate: {}", f.display());


### PR DESCRIPTION
Right now this directory is located under:

```
$sysroot/lib/rustlib/$target/lib/codegen-backends
```

but after seeing what we do in a few other places it seems that a more
appropriate location would be:

```
$sysroot/lib/rustlib/$target/codegen-backends
```

so this commit moves it!