### PR TITLE
[NLL] Improve DefiningTy::Const

### DIFF
--- a/src/librustc_mir/borrow_check/nll/region_infer/annotation.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/annotation.rs
@@ -45,10 +45,11 @@ impl<'gcx, 'tcx> RegionInferenceContext<'tcx> {
                     &substs[..]
                 ));
             }
-            DefiningTy::Const(ty) => {
+            DefiningTy::Const(def_id, substs) => {
                 err.note(&format!(
-                    "defining type: {:?}",
-                    ty
+                    "defining constant type: {:?} with substs {:#?}",
+                    def_id,
+                    &substs[..]
                 ));
             }
         }

--- a/src/test/ui/nll/trait-associated-constant.rs
+++ b/src/test/ui/nll/trait-associated-constant.rs
@@ -1,0 +1,42 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test cases where we put various lifetime constraints on trait
+// associated constants.
+
+#![feature(rustc_attrs)]
+
+use std::option::Option;
+
+trait Anything<'a: 'b, 'b> {
+    const AC: Option<&'b str>;
+}
+
+struct OKStruct { }
+
+impl<'a: 'b, 'b> Anything<'a, 'b> for OKStruct {
+    const AC: Option<&'b str> = None;
+}
+
+struct FailStruct1 { }
+
+impl<'a: 'b, 'b, 'c> Anything<'a, 'b> for FailStruct1 {
+    const AC: Option<&'c str> = None;
+    //~^ ERROR: mismatched types
+}
+
+struct FailStruct2 { }
+
+impl<'a: 'b, 'b> Anything<'a, 'b> for FailStruct2 {
+    const AC: Option<&'a str> = None;
+    //~^ ERROR: mismatched types
+}
+
+fn main() {}

--- a/src/test/ui/nll/trait-associated-constant.stderr
+++ b/src/test/ui/nll/trait-associated-constant.stderr
@@ -9,19 +9,13 @@ error[E0308]: mismatched types
 note: the lifetime 'c as defined on the impl at 30:1...
   --> $DIR/trait-associated-constant.rs:30:1
    |
-30 | / impl<'a: 'b, 'b, 'c> Anything<'a, 'b> for FailStruct1 {
-31 | |     const AC: Option<&'c str> = None;
-32 | |     //~^ ERROR: mismatched types
-33 | | }
-   | |_^
+30 | impl<'a: 'b, 'b, 'c> Anything<'a, 'b> for FailStruct1 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...does not necessarily outlive the lifetime 'b as defined on the impl at 30:1
   --> $DIR/trait-associated-constant.rs:30:1
    |
-30 | / impl<'a: 'b, 'b, 'c> Anything<'a, 'b> for FailStruct1 {
-31 | |     const AC: Option<&'c str> = None;
-32 | |     //~^ ERROR: mismatched types
-33 | | }
-   | |_^
+30 | impl<'a: 'b, 'b, 'c> Anything<'a, 'b> for FailStruct1 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/trait-associated-constant.rs:38:5
@@ -34,19 +28,13 @@ error[E0308]: mismatched types
 note: the lifetime 'a as defined on the impl at 37:1...
   --> $DIR/trait-associated-constant.rs:37:1
    |
-37 | / impl<'a: 'b, 'b> Anything<'a, 'b> for FailStruct2 {
-38 | |     const AC: Option<&'a str> = None;
-39 | |     //~^ ERROR: mismatched types
-40 | | }
-   | |_^
+37 | impl<'a: 'b, 'b> Anything<'a, 'b> for FailStruct2 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...does not necessarily outlive the lifetime 'b as defined on the impl at 37:1
   --> $DIR/trait-associated-constant.rs:37:1
    |
-37 | / impl<'a: 'b, 'b> Anything<'a, 'b> for FailStruct2 {
-38 | |     const AC: Option<&'a str> = None;
-39 | |     //~^ ERROR: mismatched types
-40 | | }
-   | |_^
+37 | impl<'a: 'b, 'b> Anything<'a, 'b> for FailStruct2 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/trait-associated-constant.stderr
+++ b/src/test/ui/nll/trait-associated-constant.stderr
@@ -1,0 +1,52 @@
+error[E0308]: mismatched types
+  --> $DIR/trait-associated-constant.rs:31:5
+   |
+31 |     const AC: Option<&'c str> = None;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
+   |
+   = note: expected type `std::option::Option<&'b str>`
+              found type `std::option::Option<&'c str>`
+note: the lifetime 'c as defined on the impl at 30:1...
+  --> $DIR/trait-associated-constant.rs:30:1
+   |
+30 | / impl<'a: 'b, 'b, 'c> Anything<'a, 'b> for FailStruct1 {
+31 | |     const AC: Option<&'c str> = None;
+32 | |     //~^ ERROR: mismatched types
+33 | | }
+   | |_^
+note: ...does not necessarily outlive the lifetime 'b as defined on the impl at 30:1
+  --> $DIR/trait-associated-constant.rs:30:1
+   |
+30 | / impl<'a: 'b, 'b, 'c> Anything<'a, 'b> for FailStruct1 {
+31 | |     const AC: Option<&'c str> = None;
+32 | |     //~^ ERROR: mismatched types
+33 | | }
+   | |_^
+
+error[E0308]: mismatched types
+  --> $DIR/trait-associated-constant.rs:38:5
+   |
+38 |     const AC: Option<&'a str> = None;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
+   |
+   = note: expected type `std::option::Option<&'b str>`
+              found type `std::option::Option<&'a str>`
+note: the lifetime 'a as defined on the impl at 37:1...
+  --> $DIR/trait-associated-constant.rs:37:1
+   |
+37 | / impl<'a: 'b, 'b> Anything<'a, 'b> for FailStruct2 {
+38 | |     const AC: Option<&'a str> = None;
+39 | |     //~^ ERROR: mismatched types
+40 | | }
+   | |_^
+note: ...does not necessarily outlive the lifetime 'b as defined on the impl at 37:1
+  --> $DIR/trait-associated-constant.rs:37:1
+   |
+37 | / impl<'a: 'b, 'b> Anything<'a, 'b> for FailStruct2 {
+38 | |     const AC: Option<&'a str> = None;
+39 | |     //~^ ERROR: mismatched types
+40 | | }
+   | |_^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #47590 by fixing the way DefiningTy represents constants. Previously, constants were represented using just the type of the variable. However, this will fail to capture early-bound regions as NLL inference vars, resulting in an ICE when we try to compute region VIDs a little bit later in the universal
region resolution process. (ref #47590)