### PR TITLE
[WIP] Warn when `$name:matcher` syntax is used on expansion side

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1716,7 +1716,7 @@ macro_rules! tuple {
     () => ();
     ( $($name:ident,)+ ) => (
         #[stable(feature = "rust1", since = "1.0.0")]
-        impl<$($name:Debug),*> Debug for ($($name,)*) where last_type!($($name,)+): ?Sized {
+        impl<$($name: Debug),*> Debug for ($($name,)*) where last_type!($($name,)+): ?Sized {
             #[allow(non_snake_case, unused_assignments, deprecated)]
             fn fmt(&self, f: &mut Formatter) -> Result {
                 let mut builder = f.debug_tuple("");

--- a/src/libcore/tuple.rs
+++ b/src/libcore/tuple.rs
@@ -22,7 +22,7 @@ macro_rules! tuple_impls {
     )+) => {
         $(
             #[stable(feature = "rust1", since = "1.0.0")]
-            impl<$($T:PartialEq),+> PartialEq for ($($T,)+) where last_type!($($T,)+): ?Sized {
+            impl<$($T: PartialEq),+> PartialEq for ($($T,)+) where last_type!($($T,)+): ?Sized {
                 #[inline]
                 fn eq(&self, other: &($($T,)+)) -> bool {
                     $(self.$idx == other.$idx)&&+
@@ -34,10 +34,10 @@ macro_rules! tuple_impls {
             }
 
             #[stable(feature = "rust1", since = "1.0.0")]
-            impl<$($T:Eq),+> Eq for ($($T,)+) where last_type!($($T,)+): ?Sized {}
+            impl<$($T: Eq),+> Eq for ($($T,)+) where last_type!($($T,)+): ?Sized {}
 
             #[stable(feature = "rust1", since = "1.0.0")]
-            impl<$($T:PartialOrd + PartialEq),+> PartialOrd for ($($T,)+)
+            impl<$($T: PartialOrd + PartialEq),+> PartialOrd for ($($T,)+)
                     where last_type!($($T,)+): ?Sized {
                 #[inline]
                 fn partial_cmp(&self, other: &($($T,)+)) -> Option<Ordering> {
@@ -62,7 +62,7 @@ macro_rules! tuple_impls {
             }
 
             #[stable(feature = "rust1", since = "1.0.0")]
-            impl<$($T:Ord),+> Ord for ($($T,)+) where last_type!($($T,)+): ?Sized {
+            impl<$($T: Ord),+> Ord for ($($T,)+) where last_type!($($T,)+): ?Sized {
                 #[inline]
                 fn cmp(&self, other: &($($T,)+)) -> Ordering {
                     lexical_cmp!($(self.$idx, other.$idx),+)
@@ -70,7 +70,7 @@ macro_rules! tuple_impls {
             }
 
             #[stable(feature = "rust1", since = "1.0.0")]
-            impl<$($T:Default),+> Default for ($($T,)+) {
+            impl<$($T: Default),+> Default for ($($T,)+) {
                 #[inline]
                 fn default() -> ($($T,)+) {
                     ($({ let x: $T = Default::default(); x},)+)

--- a/src/libserialize/serialize.rs
+++ b/src/libserialize/serialize.rs
@@ -679,7 +679,7 @@ macro_rules! count_idents {
 macro_rules! tuple {
     () => ();
     ( $($name:ident,)+ ) => (
-        impl<$($name:Decodable),*> Decodable for ($($name,)*) {
+        impl<$($name: Decodable),*> Decodable for ($($name,)*) {
             #[allow(non_snake_case)]
             fn decode<D: Decoder>(d: &mut D) -> Result<($($name,)*), D::Error> {
                 let len: usize = count_idents!($($name,)*);
@@ -693,7 +693,7 @@ macro_rules! tuple {
                 })
             }
         }
-        impl<$($name:Encodable),*> Encodable for ($($name,)*) {
+        impl<$($name: Encodable),*> Encodable for ($($name,)*) {
             #[allow(non_snake_case)]
             fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
                 let ($(ref $name,)*) = *self;

--- a/src/libsyntax/ext/tt/quoted.rs
+++ b/src/libsyntax/ext/tt/quoted.rs
@@ -205,29 +205,29 @@ pub fn parse(
                     }
                 } else {
                     const VALID_SPECIFIERS: &[&str] = &[
-                        "ident", "block", "stmt", "expr", "pat", "ty",
-                        "path", "meta", "tt", "item", "vis"
+                        "ident", "block", "stmt", "expr", "pat", "ty", "path", "meta", "tt",
+                        "item", "vis",
                     ];
                     match parse_matcher(start_sp, ident, &mut trees.clone()) {
                         Ok((TokenTree::MetaVarDecl(full_sp, _, kind), colon_sp, end_sp))
-                        if start_sp.hi() == colon_sp.lo()
-                        && colon_sp.hi() == end_sp.lo()
-                        && VALID_SPECIFIERS.contains(&&*kind.name.as_str()) => {
+                            if start_sp.hi() == colon_sp.lo() && colon_sp.hi() == end_sp.lo()
+                                && VALID_SPECIFIERS.contains(&&*kind.name.as_str()) =>
+                        {
                             let specifier_sp = colon_sp.with_hi(end_sp.hi());
                             sess.span_diagnostic
                                 .struct_span_warn(
                                     specifier_sp,
-                                    "macro expansion includes fragment specifier"
+                                    "macro expansion includes fragment specifier",
                                 )
                                 .span_suggestion(
                                     full_sp,
                                     "to just use the macro argument, remove the fragment specifier",
-                                    format!("${}", ident)
+                                    format!("${}", ident),
                                 )
                                 .span_suggestion(
                                     specifier_sp,
                                     "to suppress this warning, add a space after the colon",
-                                    format!(": {}", kind)
+                                    format!(": {}", kind),
                                 )
                                 .emit();
                         }
@@ -259,10 +259,10 @@ pub fn parse(
 fn parse_matcher<I>(
     start_sp: Span,
     ident: ast::Ident,
-    trees: &mut I
+    trees: &mut I,
 ) -> Result<(TokenTree, Span, Span), Span>
 where
-    I: Iterator<Item = tokenstream::TokenTree>
+    I: Iterator<Item = tokenstream::TokenTree>,
 {
     match trees.next() {
         Some(tokenstream::TokenTree::Token(colon_sp, token::Colon)) => match trees.next() {
@@ -280,7 +280,9 @@ where
                 Err(span)
             }
         },
-        tree => Err(tree.as_ref().map(tokenstream::TokenTree::span).unwrap_or(start_sp))
+        tree => Err(tree.as_ref()
+            .map(tokenstream::TokenTree::span)
+            .unwrap_or(start_sp)),
     }
 }
 

--- a/src/libsyntax/ext/tt/quoted.rs
+++ b/src/libsyntax/ext/tt/quoted.rs
@@ -204,16 +204,19 @@ pub fn parse(
                         }
                     }
                 } else {
-                    if let Ok((_, colon_sp, end_sp)) = parse_matcher(start_sp, ident, &mut trees.clone()) {
-                        if start_sp.hi() == colon_sp.lo() && colon_sp.hi() == end_sp.lo() {
+                    match parse_matcher(start_sp, ident, &mut trees.clone()) {
+                        Ok((_, colon_sp, end_sp))
+                        if start_sp.hi() == colon_sp.lo() && colon_sp.hi() == end_sp.lo() => {
                             sess.span_diagnostic
                                 .struct_span_warn(
                                     colon_sp.with_hi(end_sp.hi()),
                                     "matchers are treated literally on the expansion side"
                                 )
-                                .help("if this is what you want, insert spaces to silence this warning")
+                                .help("if this is what you want, \
+                                       insert spaces to silence this warning")
                                 .emit();
                         }
+                        _ => {}
                     }
                     result.push(tree)
                 }
@@ -238,7 +241,11 @@ pub fn parse(
 ///
 /// On success, returns a parsed `MetaVarDecl`, span of `:` and span of matcher's type
 /// On error, returns a span for error.
-fn parse_matcher<I>(start_sp: Span, ident: ast::Ident, trees: &mut I) -> Result<(TokenTree, Span, Span), Span>
+fn parse_matcher<I>(
+    start_sp: Span,
+    ident: ast::Ident,
+    trees: &mut I
+) -> Result<(TokenTree, Span, Span), Span>
 where
     I: Iterator<Item = tokenstream::TokenTree>
 {

--- a/src/libsyntax/ext/tt/quoted.rs
+++ b/src/libsyntax/ext/tt/quoted.rs
@@ -204,9 +204,15 @@ pub fn parse(
                         }
                     }
                 } else {
+                    const VALID_SPECIFIERS: &[&str] = &[
+                        "ident", "block", "stmt", "expr", "pat", "ty",
+                        "path", "meta", "tt", "item", "vis"
+                    ];
                     match parse_matcher(start_sp, ident, &mut trees.clone()) {
-                        Ok((_, colon_sp, end_sp))
-                        if start_sp.hi() == colon_sp.lo() && colon_sp.hi() == end_sp.lo() => {
+                        Ok((TokenTree::MetaVarDecl(_, _, kind), colon_sp, end_sp))
+                        if start_sp.hi() == colon_sp.lo()
+                        && colon_sp.hi() == end_sp.lo()
+                        && VALID_SPECIFIERS.contains(&&*kind.name.as_str()) => {
                             sess.span_diagnostic
                                 .struct_span_warn(
                                     colon_sp.with_hi(end_sp.hi()),

--- a/src/test/compile-fail/hygiene/globs.rs
+++ b/src/test/compile-fail/hygiene/globs.rs
@@ -47,7 +47,7 @@ macro n($i:ident) {
             }
         }
 
-        macro n($j:ident) {
+        macro n($j: ident) {
             mod test {
                 use super::*;
                 fn g() {

--- a/src/test/compile-fail/hygiene/nested_macro_privacy.rs
+++ b/src/test/compile-fail/hygiene/nested_macro_privacy.rs
@@ -14,7 +14,7 @@ macro n($foo:ident, $S:ident, $i:ident, $m:ident) {
     mod $foo {
         #[derive(Default)]
         pub struct $S { $i: u32 }
-        pub macro $m($e:expr) { $e.$i }
+        pub macro $m($e: expr) { $e.$i }
     }
 }
 

--- a/src/test/ui/fragment_specifier_in_expansion.rs
+++ b/src/test/ui/fragment_specifier_in_expansion.rs
@@ -1,0 +1,30 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests the "fragment specifier in expansion" warning
+
+// must-compile-successfully
+
+#![allow(unused)]
+
+macro_rules! warn_me {
+    ( $thing:tt ) => { $thing:tt }
+    //~^ WARN fragment specifier
+}
+
+macro_rules! with_space {
+    ( $thing:tt ) => { $thing: tt }
+}
+
+macro_rules! unknown_specifier {
+    ( $thing:tt ) => { $thing:foobar }
+}
+
+fn main() {}

--- a/src/test/ui/fragment_specifier_in_expansion.stderr
+++ b/src/test/ui/fragment_specifier_in_expansion.stderr
@@ -1,0 +1,14 @@
+warning: macro expansion includes fragment specifier
+  --> $DIR/fragment_specifier_in_expansion.rs:18:30
+   |
+18 |     ( $thing:tt ) => { $thing:tt }
+   |                              ^^^
+help: to just use the macro argument, remove the fragment specifier
+   |
+18 |     ( $thing:tt ) => { $thing }
+   |                        ^^^^^^
+help: to suppress this warning, add a space after the colon
+   |
+18 |     ( $thing:tt ) => { $thing: tt }
+   |                              ^^^^
+


### PR DESCRIPTION
This pull request is in obviously unfinished state (missing tests, etc.), but I wanted to publish it anyway to ask whether you think this kind of warning is a good idea in the first place.

I do often make mistake by unnecessarily adding `:tt`-like annotations on the expansion side, which may result in weird errors in unrelated places. That's why I wanted to take a stab at creating warning for such a case. Here's an example how the warning looks like.

![tt-warning](https://user-images.githubusercontent.com/3074996/35740413-04ec0006-0835-11e8-9cb7-9950d11d477a.png)

### Unresolved questions

1. Does this warning is worth creating at all?
2. Should we warn on any `$foo:bar` or only when `bar` is an actual `tt`, `expr` etc.?
3. Is the `.clone()` in the implementation lightweight enough?
4. Should the warning be registered, so one can `allow` it?
5. The exact warning/note message.

cc @estebank 