### PR TITLE
libtest: Replace panics with error messages

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -72,6 +72,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Instant, Duration};
 use std::borrow::Cow;
+use std::process;
 
 const TEST_WARN_TIMEOUT_S: u64 = 60;
 const QUIET_MODE_MAX_COLUMN: usize = 100; // insert a '\n' after 100 tests in quiet mode
@@ -266,19 +267,27 @@ impl Options {
 pub fn test_main(args: &[String], tests: Vec<TestDescAndFn>, options: Options) {
     let mut opts = match parse_opts(args) {
         Some(Ok(o)) => o,
-        Some(Err(msg)) => panic!("{:?}", msg),
+        Some(Err(msg)) => {
+            eprintln!("error: {}", msg);
+            process::exit(101);
+        },
         None => return,
     };
+
     opts.options = options;
     if opts.list {
         if let Err(e) = list_tests_console(&opts, tests) {
-            panic!("io error when listing tests: {:?}", e);
+            eprintln!("error: io error when listing tests: {:?}", e);
+            process::exit(101);
         }
     } else {
         match run_tests_console(&opts, tests) {
             Ok(true) => {}
-            Ok(false) => std::process::exit(101),
-            Err(e) => panic!("io error when running tests: {:?}", e),
+            Ok(false) => process::exit(101),
+            Err(e) => {
+                eprintln!("error: io error when listing tests: {:?}", e);
+                process::exit(101);
+            },
         }
     }
 }


### PR DESCRIPTION
This replaces explicit panics on failures in libtest with prints to stderr.
Where "failures" == CLI argument parsing and such

Before:
```
$ ./foo-stable --not-an-option
thread 'main' panicked at '"Unrecognized option: \'not-an-option\'"', libtest/lib.rs:251:27
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

After:
```
$ ./foo-nightly --not-an-option
error: Unrecognized option: 'not-an-option'
```