### PR TITLE
Hygiene opt-out for idents in expansion of declarative macros

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -677,7 +677,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             IdentTT(ref expander, tt_span, allow_internal_unstable) => {
                 if ident.name == keywords::Invalid.name() {
                     self.cx.span_err(path.span,
-                                    &format!("macro {}! expects an ident argument", path));
+                                     &format!("macro {}! expects an ident argument", path));
                     self.cx.trace_macros_diag();
                     kind.dummy(span)
                 } else {

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -230,7 +230,6 @@ pub fn count_names(ms: &[TokenTree]) -> usize {
             TokenTree::MetaVar(..) => 0,
             TokenTree::MetaVarDecl(..) => 1,
             TokenTree::Token(..) => 0,
-            TokenTree::IdentToken(..) => 0,
         }
     })
 }
@@ -334,8 +333,7 @@ fn nameize<I: Iterator<Item = NamedMatch>>(
                 }
             }
             TokenTree::MetaVar(..) |
-            TokenTree::Token(..) |
-            TokenTree::IdentToken(..) => (),
+            TokenTree::Token(..) => (),
         }
 
         Ok(())
@@ -543,7 +541,7 @@ fn inner_parse_loop(
                 //
                 // At the beginning of the loop, if we reach the end of the delimited submatcher,
                 // we pop the stack to backtrack out of the descent.
-                seq @ TokenTree::Delimited(..) | seq @ TokenTree::Token(_, DocComment(..)) => {
+                seq @ TokenTree::Delimited(..) | seq @ TokenTree::Token(_, DocComment(..), _) => {
                     let lower_elts = mem::replace(&mut item.top_elts, Tt(seq));
                     let idx = item.idx;
                     item.stack.push(MatcherTtFrame {
@@ -555,13 +553,7 @@ fn inner_parse_loop(
                 }
 
                 // We just matched a normal token. We can just advance the parser.
-                TokenTree::Token(_, ref t) if token_name_eq(t, token) => {
-                    item.idx += 1;
-                    next_items.push(item);
-                }
-
-                // We just matched an ident token. We can just advance the parser.
-                TokenTree::IdentToken(_, i, _) if token_name_eq(&token::Ident(i, false), token) => {
+                TokenTree::Token(_, ref t, _) if token_name_eq(t, token) => {
                     item.idx += 1;
                     next_items.push(item);
                 }
@@ -571,7 +563,6 @@ fn inner_parse_loop(
                 // `cur_items` end up doing this. There may still be some other matchers that do
                 // end up working out.
                 TokenTree::Token(..) |
-                TokenTree::IdentToken(..) |
                 TokenTree::MetaVar(..) => {}
             }
         }

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -230,6 +230,7 @@ pub fn count_names(ms: &[TokenTree]) -> usize {
             TokenTree::MetaVar(..) => 0,
             TokenTree::MetaVarDecl(..) => 1,
             TokenTree::Token(..) => 0,
+            TokenTree::IdentToken(..) => 0,
         }
     })
 }
@@ -332,7 +333,9 @@ fn nameize<I: Iterator<Item = NamedMatch>>(
                     }
                 }
             }
-            TokenTree::MetaVar(..) | TokenTree::Token(..) => (),
+            TokenTree::MetaVar(..) |
+            TokenTree::Token(..) |
+            TokenTree::IdentToken(..) => (),
         }
 
         Ok(())
@@ -557,11 +560,19 @@ fn inner_parse_loop(
                     next_items.push(item);
                 }
 
+                // We just matched an ident token. We can just advance the parser.
+                TokenTree::IdentToken(_, i, _) if token_name_eq(&token::Ident(i, false), token) => {
+                    item.idx += 1;
+                    next_items.push(item);
+                }
+
                 // There was another token that was not `token`... This means we can't add any
                 // rules. NOTE that this is not necessarily an error unless _all_ items in
                 // `cur_items` end up doing this. There may still be some other matchers that do
                 // end up working out.
-                TokenTree::Token(..) | TokenTree::MetaVar(..) => {}
+                TokenTree::Token(..) |
+                TokenTree::IdentToken(..) |
+                TokenTree::MetaVar(..) => {}
             }
         }
     }

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -202,7 +202,7 @@ pub fn compile(sess: &ParseSess, features: &Features, def: &ast::Item) -> Syntax
         quoted::TokenTree::Sequence(DUMMY_SP, Lrc::new(quoted::SequenceRepetition {
             tts: vec![
                 quoted::TokenTree::MetaVarDecl(DUMMY_SP, lhs_nm, ast::Ident::from_str("tt")),
-                quoted::TokenTree::Token(DUMMY_SP, token::FatArrow),
+                quoted::TokenTree::Token(DUMMY_SP, token::FatArrow, false),
                 quoted::TokenTree::MetaVarDecl(DUMMY_SP, rhs_nm, ast::Ident::from_str("tt")),
             ],
             separator: Some(if body.legacy { token::Semi } else { token::Comma }),
@@ -211,7 +211,7 @@ pub fn compile(sess: &ParseSess, features: &Features, def: &ast::Item) -> Syntax
         })),
         // to phase into semicolon-termination instead of semicolon-separation
         quoted::TokenTree::Sequence(DUMMY_SP, Lrc::new(quoted::SequenceRepetition {
-            tts: vec![quoted::TokenTree::Token(DUMMY_SP, token::Semi)],
+            tts: vec![quoted::TokenTree::Token(DUMMY_SP, token::Semi, false)],
             separator: None,
             op: quoted::KleeneOp::ZeroOrMore,
             num_captures: 0
@@ -329,7 +329,6 @@ fn check_lhs_no_empty_seq(sess: &ParseSess, tts: &[quoted::TokenTree]) -> bool {
     for tt in tts {
         match *tt {
             TokenTree::Token(..) |
-            TokenTree::IdentToken(..) |
             TokenTree::MetaVar(..) |
             TokenTree::MetaVarDecl(..) => (),
             TokenTree::Delimited(_, ref del) => if !check_lhs_no_empty_seq(sess, &del.tts) {
@@ -414,7 +413,6 @@ impl FirstSets {
             for tt in tts.iter().rev() {
                 match *tt {
                     TokenTree::Token(..) |
-                    TokenTree::IdentToken(..) |
                     TokenTree::MetaVar(..) |
                     TokenTree::MetaVarDecl(..) => {
                         first.replace_with(tt.clone());
@@ -446,7 +444,7 @@ impl FirstSets {
 
                         if let (Some(ref sep), true) = (seq_rep.separator.clone(),
                                                         subfirst.maybe_empty) {
-                            first.add_one_maybe(TokenTree::Token(sp, sep.clone()));
+                            first.add_one_maybe(TokenTree::Token(sp, sep.clone(), false));
                         }
 
                         // Reverse scan: Sequence comes before `first`.
@@ -477,7 +475,6 @@ impl FirstSets {
             assert!(first.maybe_empty);
             match *tt {
                 TokenTree::Token(..) |
-                TokenTree::IdentToken(..) |
                 TokenTree::MetaVar(..) |
                 TokenTree::MetaVarDecl(..) => {
                     first.add_one(tt.clone());
@@ -496,7 +493,7 @@ impl FirstSets {
 
                             if let (Some(ref sep), true) = (seq_rep.separator.clone(),
                                                             subfirst.maybe_empty) {
-                                first.add_one_maybe(TokenTree::Token(sp, sep.clone()));
+                                first.add_one_maybe(TokenTree::Token(sp, sep.clone(), false));
                             }
 
                             assert!(first.maybe_empty);
@@ -651,7 +648,6 @@ fn check_matcher_core(sess: &ParseSess,
         // of NT tokens that might end the sequence `... token`.
         match *token {
             TokenTree::Token(..) |
-            TokenTree::IdentToken(..) |
             TokenTree::MetaVar(..) |
             TokenTree::MetaVarDecl(..) => {
                 let can_be_followed_by_any;
@@ -704,7 +700,7 @@ fn check_matcher_core(sess: &ParseSess,
                 let mut new;
                 let my_suffix = if let Some(ref u) = seq_rep.separator {
                     new = suffix_first.clone();
-                    new.add_one_maybe(TokenTree::Token(sp, u.clone()));
+                    new.add_one_maybe(TokenTree::Token(sp, u.clone(), false));
                     &new
                 } else {
                     &suffix_first
@@ -817,7 +813,7 @@ fn frag_can_be_followed_by_any(frag: &str) -> bool {
 fn is_in_follow(tok: &quoted::TokenTree, frag: &str) -> Result<bool, (String, &'static str)> {
     use self::quoted::TokenTree;
 
-    if let TokenTree::Token(_, token::CloseDelim(_)) = *tok {
+    if let TokenTree::Token(_, token::CloseDelim(_), _) = *tok {
         // closing a token tree can never be matched by any fragment;
         // iow, we always require that `(` and `)` match, etc.
         Ok(true)
@@ -834,14 +830,14 @@ fn is_in_follow(tok: &quoted::TokenTree, frag: &str) -> Result<bool, (String, &'
                 Ok(true)
             },
             "stmt" | "expr"  => match *tok {
-                TokenTree::Token(_, ref tok) => match *tok {
+                TokenTree::Token(_, ref tok, _) => match *tok {
                     FatArrow | Comma | Semi => Ok(true),
                     _ => Ok(false)
                 },
                 _ => Ok(false),
             },
             "pat" => match *tok {
-                TokenTree::Token(_, ref tok) => match *tok {
+                TokenTree::Token(_, ref tok, _) => match *tok {
                     FatArrow | Comma | Eq | BinOp(token::Or) => Ok(true),
                     Ident(i, false) if i.name == "if" || i.name == "in" => Ok(true),
                     _ => Ok(false)
@@ -849,7 +845,7 @@ fn is_in_follow(tok: &quoted::TokenTree, frag: &str) -> Result<bool, (String, &'
                 _ => Ok(false),
             },
             "path" | "ty" => match *tok {
-                TokenTree::Token(_, ref tok) => match *tok {
+                TokenTree::Token(_, ref tok, _) => match *tok {
                     OpenDelim(token::DelimToken::Brace) | OpenDelim(token::DelimToken::Bracket) |
                     Comma | FatArrow | Colon | Eq | Gt | Semi | BinOp(token::Or) => Ok(true),
                     Ident(i, false) if i.name == "as" || i.name == "where" => Ok(true),
@@ -870,7 +866,7 @@ fn is_in_follow(tok: &quoted::TokenTree, frag: &str) -> Result<bool, (String, &'
             "vis" => {
                 // Explicitly disallow `priv`, on the off chance it comes back.
                 match *tok {
-                    TokenTree::Token(_, ref tok) => match *tok {
+                    TokenTree::Token(_, ref tok, _) => match *tok {
                         Comma => Ok(true),
                         Ident(i, is_raw) if is_raw || i.name != "priv" => Ok(true),
                         ref tok => Ok(tok.can_begin_type())
@@ -943,8 +939,7 @@ fn is_legal_fragment_specifier(sess: &ParseSess,
 
 fn quoted_tt_to_string(tt: &quoted::TokenTree) -> String {
     match *tt {
-        quoted::TokenTree::Token(_, ref tok) => ::print::pprust::token_to_string(tok),
-        quoted::TokenTree::IdentToken(_, ident, _) => ::print::pprust::token_to_string(&token::Ident(ident, false)),
+        quoted::TokenTree::Token(_, ref tok, _) => ::print::pprust::token_to_string(tok),
         quoted::TokenTree::MetaVar(_, name, _) => format!("${}", name),
         quoted::TokenTree::MetaVarDecl(_, name, kind) => format!("${}:{}", name, kind),
         _ => panic!("unexpected quoted::TokenTree::{{Sequence or Delimited}} \

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -202,7 +202,7 @@ pub fn compile(sess: &ParseSess, features: &Features, def: &ast::Item) -> Syntax
         quoted::TokenTree::Sequence(DUMMY_SP, Lrc::new(quoted::SequenceRepetition {
             tts: vec![
                 quoted::TokenTree::MetaVarDecl(DUMMY_SP, lhs_nm, ast::Ident::from_str("tt")),
-                quoted::TokenTree::Token(DUMMY_SP, token::FatArrow, false),
+                quoted::TokenTree::Token(DUMMY_SP, token::FatArrow, quoted::TokenHygiene::DefSite),
                 quoted::TokenTree::MetaVarDecl(DUMMY_SP, rhs_nm, ast::Ident::from_str("tt")),
             ],
             separator: Some(if body.legacy { token::Semi } else { token::Comma }),
@@ -211,7 +211,8 @@ pub fn compile(sess: &ParseSess, features: &Features, def: &ast::Item) -> Syntax
         })),
         // to phase into semicolon-termination instead of semicolon-separation
         quoted::TokenTree::Sequence(DUMMY_SP, Lrc::new(quoted::SequenceRepetition {
-            tts: vec![quoted::TokenTree::Token(DUMMY_SP, token::Semi, false)],
+            tts: vec![quoted::TokenTree::Token(DUMMY_SP, token::Semi,
+                quoted::TokenHygiene::DefSite)],
             separator: None,
             op: quoted::KleeneOp::ZeroOrMore,
             num_captures: 0
@@ -454,7 +455,8 @@ impl FirstSets {
 
                         if let (Some(ref sep), true) = (seq_rep.separator.clone(),
                                                         subfirst.maybe_empty) {
-                            first.add_one_maybe(TokenTree::Token(sp, sep.clone(), false));
+                            first.add_one_maybe(TokenTree::Token(sp, sep.clone(),
+                                quoted::TokenHygiene::DefSite));
                         }
 
                         // Reverse scan: Sequence comes before `first`.
@@ -503,7 +505,8 @@ impl FirstSets {
 
                             if let (Some(ref sep), true) = (seq_rep.separator.clone(),
                                                             subfirst.maybe_empty) {
-                                first.add_one_maybe(TokenTree::Token(sp, sep.clone(), false));
+                                first.add_one_maybe(TokenTree::Token(sp, sep.clone(),
+                                    quoted::TokenHygiene::DefSite));
                             }
 
                             assert!(first.maybe_empty);
@@ -710,7 +713,8 @@ fn check_matcher_core(sess: &ParseSess,
                 let mut new;
                 let my_suffix = if let Some(ref u) = seq_rep.separator {
                     new = suffix_first.clone();
-                    new.add_one_maybe(TokenTree::Token(sp, u.clone(), false));
+                    new.add_one_maybe(TokenTree::Token(sp, u.clone(),
+                        quoted::TokenHygiene::DefSite));
                     &new
                 } else {
                     &suffix_first

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -261,7 +261,7 @@ pub fn compile(sess: &ParseSess, features: &Features, def: &ast::Item) -> Syntax
                 if let MatchedNonterminal(ref nt) = *m {
                     if let NtTT(ref tt) = **nt {
                         return quoted::parse(tt.clone().into(),
-                                             !body.legacy,
+                                             !body.legacy && features.macro_hygiene_optout,
                                              false,
                                              sess,
                                              features,

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -237,7 +237,7 @@ pub fn compile(sess: &ParseSess, features: &Features, def: &ast::Item) -> Syntax
             s.iter().map(|m| {
                 if let MatchedNonterminal(ref nt) = *m {
                     if let NtTT(ref tt) = **nt {
-                        let tt = quoted::parse(tt.clone().into(), true, sess, features, &def.attrs)
+                        let tt = quoted::parse(tt.clone().into(), false, true, sess, features, &def.attrs)
                             .pop().unwrap();
                         valid &= check_lhs_nt_follows(sess, features, &def.attrs, &tt);
                         return tt;
@@ -254,7 +254,7 @@ pub fn compile(sess: &ParseSess, features: &Features, def: &ast::Item) -> Syntax
             s.iter().map(|m| {
                 if let MatchedNonterminal(ref nt) = *m {
                     if let NtTT(ref tt) = **nt {
-                        return quoted::parse(tt.clone().into(), false, sess, features, &def.attrs)
+                        return quoted::parse(tt.clone().into(), !body.legacy, false, sess, features, &def.attrs)
                             .pop().unwrap();
                     }
                 }

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -328,7 +328,10 @@ fn check_lhs_no_empty_seq(sess: &ParseSess, tts: &[quoted::TokenTree]) -> bool {
     use self::quoted::TokenTree;
     for tt in tts {
         match *tt {
-            TokenTree::Token(..) | TokenTree::MetaVar(..) | TokenTree::MetaVarDecl(..) => (),
+            TokenTree::Token(..) |
+            TokenTree::IdentToken(..) |
+            TokenTree::MetaVar(..) |
+            TokenTree::MetaVarDecl(..) => (),
             TokenTree::Delimited(_, ref del) => if !check_lhs_no_empty_seq(sess, &del.tts) {
                 return false;
             },
@@ -410,7 +413,10 @@ impl FirstSets {
             let mut first = TokenSet::empty();
             for tt in tts.iter().rev() {
                 match *tt {
-                    TokenTree::Token(..) | TokenTree::MetaVar(..) | TokenTree::MetaVarDecl(..) => {
+                    TokenTree::Token(..) |
+                    TokenTree::IdentToken(..) |
+                    TokenTree::MetaVar(..) |
+                    TokenTree::MetaVarDecl(..) => {
                         first.replace_with(tt.clone());
                     }
                     TokenTree::Delimited(span, ref delimited) => {
@@ -470,7 +476,10 @@ impl FirstSets {
         for tt in tts.iter() {
             assert!(first.maybe_empty);
             match *tt {
-                TokenTree::Token(..) | TokenTree::MetaVar(..) | TokenTree::MetaVarDecl(..) => {
+                TokenTree::Token(..) |
+                TokenTree::IdentToken(..) |
+                TokenTree::MetaVar(..) |
+                TokenTree::MetaVarDecl(..) => {
                     first.add_one(tt.clone());
                     return first;
                 }
@@ -641,7 +650,10 @@ fn check_matcher_core(sess: &ParseSess,
         // First, update `last` so that it corresponds to the set
         // of NT tokens that might end the sequence `... token`.
         match *token {
-            TokenTree::Token(..) | TokenTree::MetaVar(..) | TokenTree::MetaVarDecl(..) => {
+            TokenTree::Token(..) |
+            TokenTree::IdentToken(..) |
+            TokenTree::MetaVar(..) |
+            TokenTree::MetaVarDecl(..) => {
                 let can_be_followed_by_any;
                 if let Err(bad_frag) = has_legal_fragment_specifier(sess, features, attrs, token) {
                     let msg = format!("invalid fragment specifier `{}`", bad_frag);
@@ -932,7 +944,8 @@ fn is_legal_fragment_specifier(sess: &ParseSess,
 fn quoted_tt_to_string(tt: &quoted::TokenTree) -> String {
     match *tt {
         quoted::TokenTree::Token(_, ref tok) => ::print::pprust::token_to_string(tok),
-        quoted::TokenTree::MetaVar(_, name) => format!("${}", name),
+        quoted::TokenTree::IdentToken(_, ident, _) => ::print::pprust::token_to_string(&token::Ident(ident, false)),
+        quoted::TokenTree::MetaVar(_, name, _) => format!("${}", name),
         quoted::TokenTree::MetaVarDecl(_, name, kind) => format!("${}:{}", name, kind),
         _ => panic!("unexpected quoted::TokenTree::{{Sequence or Delimited}} \
                      in follow set checker"),

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -121,7 +121,7 @@ fn generic_extension<'cx>(cx: &'cx mut ExtCtxt,
                 };
 
                 let rhs_spans = rhs.iter().map(|t| t.span()).collect::<Vec<_>>();
-                // rhs has holes ( `$id` and `$(...)` that need filled)
+                // rhs has holes ( `$id` and `$(...)` which need to be filled)
                 let mut tts = transcribe(cx, Some(named_matches), rhs);
 
                 // Replace all the tokens for the corresponding positions in the macro, to maintain

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -237,7 +237,12 @@ pub fn compile(sess: &ParseSess, features: &Features, def: &ast::Item) -> Syntax
             s.iter().map(|m| {
                 if let MatchedNonterminal(ref nt) = *m {
                     if let NtTT(ref tt) = **nt {
-                        let tt = quoted::parse(tt.clone().into(), false, true, sess, features, &def.attrs)
+                        let tt = quoted::parse(tt.clone().into(),
+                                               false,
+                                               true,
+                                               sess,
+                                               features,
+                                               &def.attrs)
                             .pop().unwrap();
                         valid &= check_lhs_nt_follows(sess, features, &def.attrs, &tt);
                         return tt;
@@ -254,7 +259,12 @@ pub fn compile(sess: &ParseSess, features: &Features, def: &ast::Item) -> Syntax
             s.iter().map(|m| {
                 if let MatchedNonterminal(ref nt) = *m {
                     if let NtTT(ref tt) = **nt {
-                        return quoted::parse(tt.clone().into(), !body.legacy, false, sess, features, &def.attrs)
+                        return quoted::parse(tt.clone().into(),
+                                             !body.legacy,
+                                             false,
+                                             sess,
+                                             features,
+                                             &def.attrs)
                             .pop().unwrap();
                     }
                 }

--- a/src/libsyntax/ext/tt/quoted.rs
+++ b/src/libsyntax/ext/tt/quoted.rs
@@ -204,7 +204,13 @@ pub fn parse(
     while let Some(tree) = trees.next() {
         // Given the parsed tree, if there is a metavar and we are expecting matchers, actually
         // parse out the matcher (i.e. in `$id:ident` this would parse the `:` and `ident`).
-        let tree = parse_tree(tree, &mut trees, hygiene_optout, expect_matchers, sess, features, attrs);
+        let tree = parse_tree(tree,
+                              &mut trees,
+                              hygiene_optout,
+                              expect_matchers,
+                              sess,
+                              features,
+                              attrs);
         match tree {
             TokenTree::MetaVar(start_sp, ident, _) if expect_matchers => {
                 let span = match trees.next() {
@@ -273,7 +279,14 @@ where
         tokenstream::TokenTree::Token(span, token::Pound) if hygiene_optout => match trees.peek() {
             Some(tokenstream::TokenTree::Token(_, token::Dollar)) => {
                 if let tokenstream::TokenTree::Token(span, token::Dollar) = trees.next().unwrap() {
-                    parse_meta_var(true, span, trees, hygiene_optout, expect_matchers, sess, features, attrs)
+                    parse_meta_var(true,
+                                   span,
+                                   trees,
+                                   hygiene_optout,
+                                   expect_matchers,
+                                   sess,
+                                   features,
+                                   attrs)
                 } else {
                     unreachable!();
                 }
@@ -302,7 +315,14 @@ where
 
         // `tree` is a `$` token. Look at the next token in `trees`.
         tokenstream::TokenTree::Token(span, token::Dollar) =>
-            parse_meta_var(false, span, trees, hygiene_optout, expect_matchers, sess, features, attrs),
+            parse_meta_var(false,
+                           span,
+                           trees,
+                           hygiene_optout,
+                           expect_matchers,
+                           sess,
+                           features,
+                           attrs),
 
         // `tree` is an arbitrary token. Keep it.
         tokenstream::TokenTree::Token(span, tok) => TokenTree::Token(span, tok, false),
@@ -313,7 +333,12 @@ where
             span,
             Lrc::new(Delimited {
                 delim: delimited.delim,
-                tts: parse(delimited.tts.into(), hygiene_optout, expect_matchers, sess, features, attrs),
+                tts: parse(delimited.tts.into(),
+                           hygiene_optout,
+                           expect_matchers,
+                           sess,
+                           features,
+                           attrs),
             }),
         ),
     }
@@ -344,7 +369,14 @@ where
                 sess.span_diagnostic.span_err(span, &msg);
             }
             // Parse the contents of the sequence itself
-            let sequence = parse(delimited.tts.into(), hygiene_optout, expect_matchers, sess, features, attrs);
+            let sequence = parse(
+                delimited.tts.into(),
+                hygiene_optout,
+                expect_matchers,
+                sess,
+                features,
+                attrs
+            );
             // Get the Kleene operator and optional separator
             let (separator, op) = parse_sep_and_kleene_op(trees, span, sess, features, attrs);
             // Count the number of captured "names" (i.e. named metavars)

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -182,19 +182,19 @@ pub fn transcribe(cx: &ExtCtxt,
                 let sp = sp.with_ctxt(sp_ctxt.apply_mark(cx.current_expansion.mark));
 
                 let update_ident_ctxt = |ident: Ident| {
-                    let ident_ctxt = if escape_hygiene {
-                        cx.call_site().ctxt()
+                    let new_span = if escape_hygiene {
+                        cx.call_site()
                     } else {
-                        ident.ctxt.apply_mark(cx.current_expansion.mark)
+                        ident.span.apply_mark(cx.current_expansion.mark)
                     };
-                    Ident { ctxt: ident_ctxt, ..ident }
+                    Ident::new(ident.name, new_span)
                 };
 
                 let result_tok = match tok {
                     token::Ident(ident, is_raw) =>
                         TokenTree::Token(sp, token::Ident(update_ident_ctxt(ident), is_raw)),
                     token::Lifetime(ident) =>
-                        TokenTree::Token(sp, token::Lifetime(ident)),
+                        TokenTree::Token(sp, token::Lifetime()),
                     _ => {
                         let mut marker = Marker(cx.current_expansion.mark);
                         noop_fold_tt(TokenTree::Token(sp, tok), &mut marker)

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -305,6 +305,9 @@ declare_features! (
     // Declarative macros 2.0 (`macro`).
     (active, decl_macro, "1.17.0", Some(39412), None),
 
+    // Hygiene opt-out (escaping) for macros 2.0 using `#ident` syntax.
+    (active, macro_hygiene_optout, "1.27.0", None, None),
+
     // Allows #[link(kind="static-nobundle"...]
     (active, static_nobundle, "1.16.0", Some(37403), None),
 

--- a/src/test/compile-fail/feature-gate-macro-hygiene-optout.rs
+++ b/src/test/compile-fail/feature-gate-macro-hygiene-optout.rs
@@ -9,17 +9,14 @@
 // except according to those terms.
 
 #![feature(decl_macro)]
-#![feature(macro_hygiene_optout)]
 
-macro m($mod_name:ident) {
-    pub mod $#mod_name {
+macro m() {
+    pub mod #foo {
     //~^ ERROR expected identifier, found `#`
-    //~| ERROR unknown macro variable ``
-    //~| ERROR expected identifier, found reserved identifier ``
-    //~| ERROR expected one of `;` or `{`, found `mod_name`
+        pub const #BAR: u32 = 123;
     }
 }
 
 fn main() {
-    m!(foo);
+    m!();
 }

--- a/src/test/compile-fail/hygiene-optout-1.rs
+++ b/src/test/compile-fail/hygiene-optout-1.rs
@@ -1,0 +1,23 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(decl_macro)]
+
+macro m($mod_name:ident) {
+    pub mod $mod_name {
+        pub const BAR: u32 = 123;
+    }
+}
+
+fn main() {
+    m!(foo);
+    let _ = foo::BAR;
+    //~^ ERROR cannot find value `BAR` in module `foo`
+}

--- a/src/test/compile-fail/hygiene-optout-1.rs
+++ b/src/test/compile-fail/hygiene-optout-1.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(decl_macro)]
+#![feature(macro_hygiene_optout)]
 
 macro m($mod_name:ident) {
     pub mod $mod_name {

--- a/src/test/compile-fail/hygiene-optout-2.rs
+++ b/src/test/compile-fail/hygiene-optout-2.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(decl_macro)]
+#![feature(macro_hygiene_optout)]
 
 macro m() {
     pub mod #foo {

--- a/src/test/compile-fail/hygiene-optout-2.rs
+++ b/src/test/compile-fail/hygiene-optout-2.rs
@@ -1,0 +1,23 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(decl_macro)]
+
+macro m() {
+    pub mod #foo {
+        pub const BAR: u32 = 123;
+    }
+}
+
+fn main() {
+    m!();
+    let _ = foo::BAR;
+    //~^ ERROR cannot find value `BAR` in module `foo`
+}

--- a/src/test/compile-fail/hygiene-optout-3.rs
+++ b/src/test/compile-fail/hygiene-optout-3.rs
@@ -1,0 +1,26 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(decl_macro)]
+
+macro m_helper() {
+    struct #S;
+}
+
+macro m() {
+    m_helper!();
+    let s = S;
+}
+
+fn main() {
+    m!();
+    let s = S;
+    //~^ ERROR cannot find value `S` in this scope
+}

--- a/src/test/compile-fail/hygiene-optout-3.rs
+++ b/src/test/compile-fail/hygiene-optout-3.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(decl_macro)]
+#![feature(macro_hygiene_optout)]
 
 macro m_helper() {
     struct #S;

--- a/src/test/compile-fail/hygiene-optout-4.rs
+++ b/src/test/compile-fail/hygiene-optout-4.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(decl_macro)]
+#![feature(macro_hygiene_optout)]
 
 macro m() {
     struct #S;

--- a/src/test/compile-fail/hygiene-optout-4.rs
+++ b/src/test/compile-fail/hygiene-optout-4.rs
@@ -1,0 +1,24 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(decl_macro)]
+
+macro m() {
+    struct #S;
+
+    impl S {
+    //~^ ERROR cannot find type `S` in this scope
+        fn f() {}
+    }
+}
+
+fn main() {
+    m!();
+}

--- a/src/test/compile-fail/hygiene-optout-5.rs
+++ b/src/test/compile-fail/hygiene-optout-5.rs
@@ -1,0 +1,24 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(decl_macro)]
+
+macro m($mod_name:ident) {
+    pub mod $#mod_name {
+    //~^ ERROR expected identifier, found `#`
+    //~| ERROR unknown macro variable ``
+    //~| ERROR expected identifier, found reserved identifier ``
+    //~| ERROR expected one of `;` or `{`, found `mod_name`
+    }
+}
+
+fn main() {
+    m!(foo);
+}

--- a/src/test/run-pass-fulldeps/auxiliary/procedural_mbe_matching.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/procedural_mbe_matching.rs
@@ -39,6 +39,7 @@ fn expand_mbe_matches(cx: &mut ExtCtxt, _: Span, args: &[TokenTree])
 
     let mbe_matcher = quote_tokens!(cx, $$matched:expr, $$($$pat:pat)|+);
     let mbe_matcher = quoted::parse(mbe_matcher.into_iter().collect(),
+                                    false,
                                     true,
                                     cx.parse_sess,
                                     &Features::new(),

--- a/src/test/run-pass/hygiene-optout-1.rs
+++ b/src/test/run-pass/hygiene-optout-1.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(decl_macro)]
+
+macro m($mod_name:ident) {
+    pub mod #$mod_name {
+        pub const #BAR: u32 = 123;
+    }
+}
+
+fn main() {
+    m!(foo);
+    assert_eq!(123, foo::BAR);
+}

--- a/src/test/run-pass/hygiene-optout-1.rs
+++ b/src/test/run-pass/hygiene-optout-1.rs
@@ -9,14 +9,15 @@
 // except according to those terms.
 
 #![feature(decl_macro)]
+#![feature(macro_hygiene_optout)]
 
-macro m($mod_name:ident) {
-    pub mod #$mod_name {
+macro m() {
+    pub mod #foo {
         pub const #BAR: u32 = 123;
     }
 }
 
 fn main() {
-    m!(foo);
+    m!();
     assert_eq!(123, foo::BAR);
 }

--- a/src/test/run-pass/hygiene-optout-2.rs
+++ b/src/test/run-pass/hygiene-optout-2.rs
@@ -9,14 +9,15 @@
 // except according to those terms.
 
 #![feature(decl_macro)]
+#![feature(macro_hygiene_optout)]
 
-macro m() {
-    pub mod #foo {
+macro m($mod_name:ident) {
+    pub mod #$mod_name {
         pub const #BAR: u32 = 123;
     }
 }
 
 fn main() {
-    m!();
+    m!(foo);
     assert_eq!(123, foo::BAR);
 }

--- a/src/test/run-pass/hygiene-optout-2.rs
+++ b/src/test/run-pass/hygiene-optout-2.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(decl_macro)]
+
+macro m() {
+    pub mod #foo {
+        pub const #BAR: u32 = 123;
+    }
+}
+
+fn main() {
+    m!();
+    assert_eq!(123, foo::BAR);
+}

--- a/src/test/run-pass/hygiene-optout-lifetimes.rs
+++ b/src/test/run-pass/hygiene-optout-lifetimes.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(decl_macro)]
+#![feature(macro_hygiene_optout)]
 
 use std::marker::PhantomData;
 

--- a/src/test/run-pass/hygiene-optout-lifetimes.rs
+++ b/src/test/run-pass/hygiene-optout-lifetimes.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(decl_macro)]
+
+use std::marker::PhantomData;
+
+macro m($lifetime:tt) {
+    pub struct #Foo<$lifetime>(PhantomData<&#'a ()>);
+}
+
+fn main() {
+    m!('a);
+    let _ = Foo(Default::default());
+}


### PR DESCRIPTION
This PR adds basic support for hygiene opt-out for idents during macro expansion. This has been previously discussed in https://github.com/rust-lang/rust/pull/40847 and https://github.com/rust-lang/rust/issues/39412.

The syntax involves prefixing idents with the `#` (i.e. pound/hash) character to indicate that the syntax context of the ident should be that of the call site rather than the definition site.

The following now compiles and runs as expected:

```rust
#![feature(decl_macro)]

macro foo($mod_name:ident) {
    pub mod $mod_name {
        pub const #BAR: u32 = 123;
    }
}

foo!(foo_mod);

fn main() {
    println!("{}", foo_mod::BAR);
}
```

as does:

```rust
#![feature(decl_macro)]

macro foo() {
    pub mod #foo_mod {
        pub const #BAR: u32 = 123;
    }
}

foo!();

fn main() {
    println!("{}", foo_mod::BAR);
}
```

but the following does not:

```rust
#![feature(decl_macro)]

macro foo($mod_name:ident) {
    pub mod $mode_name {
        pub const BAR: u32 = 123;
    }
}

foo!(foo_mod);

fn main() {
    println!("{}", foo_mod::BAR);
}
```

nor does:

```rust
#![feature(decl_macro)]

macro foo() {
    pub mod #foo_mod {
        pub const BAR: u32 = 123;
    }
}

foo!();

fn main() {
    println!("{}", foo_mod::BAR);
}
```

**Questions:**
* Is the above the behaviour we want?
* Should we implement syntax context "lifting" using functionality suggested by RFC? https://github.com/rust-lang/rfcs/pull/2320 – this related to the 2nd question of @petrochenkov [here](https://github.com/rust-lang/rust/issues/39412#issuecomment-361732915)
* Hygiene opt-out doesn't make any sense for `macro_rules` macros, of course, but should we explicitly disallow the `#` syntax in such places? (Currently that is not done.)

CC @jseyfried