### PR TITLE
Fix info about generic impls in AsMut docs

### DIFF
--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -141,9 +141,9 @@ pub trait AsRef<T: ?Sized> {
 ///
 /// # Generic Implementations
 ///
-/// - `AsMut` auto-dereferences if the inner type is a reference or a mutable
-///   reference (e.g.: `foo.as_ref()` will work the same if `foo` has type
-///   `&mut Foo` or `&&mut Foo`)
+/// - `AsMut` auto-dereferences if the inner type is a mutable reference
+///   (e.g.: `foo.as_mut()` will work the same if `foo` has type `&mut Foo`
+///   or `&mut &mut Foo`)
 ///
 /// # Examples
 ///


### PR DESCRIPTION
This text was copy-pasted from the `AsRef` docs to `AsMut`, but needed some additional adjustments for correctness.