### PR TITLE
save-analysis: avoid implicit unwrap

### DIFF
--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -791,7 +791,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
         field_ref: &ast::Field,
         variant: &ty::VariantDef,
     ) -> Option<Ref> {
-        let f = variant.field_named(field_ref.ident.node.name);
+        let f = variant.find_field_named(field_ref.ident.node.name)?;
         // We don't really need a sub-span here, but no harm done
         let sub_span = self.span_utils.span_for_last_ident(field_ref.ident.span);
         filter!(self.span_utils, sub_span, field_ref.ident.span, None);

--- a/src/test/run-make/save-analysis-fail/foo.rs
+++ b/src/test/run-make/save-analysis-fail/foo.rs
@@ -451,3 +451,11 @@ extern {
     static EXTERN_FOO: u8;
     fn extern_foo(a: u8, b: i32) -> String;
 }
+
+struct Rls699 {
+  f: u32,
+}
+
+fn new(f: u32) -> Rls699 {
+    Rls699 { fs }
+}


### PR DESCRIPTION
When looking up a field defintion, since the name might be incorrect in the field init shorthand case.

cc https://github.com/rust-lang-nursery/rls/issues/699

r? @eddyb