### PR TITLE
Warn about more ignored bounds in type aliases

### DIFF
--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -383,7 +383,7 @@ fn ensure_no_param_bounds(tcx: TyCtxt,
         // part of this PR. Still, convert to warning to
         // make bootstrapping easier.
         span_warn!(tcx.sess, span, E0122,
-                   "bounds are ignored in {}",
+                   "generic bounds are ignored in {}",
                    thing);
     }
 }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -355,31 +355,26 @@ fn is_param<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     }
 }
 
-fn ensure_no_ty_param_bounds(tcx: TyCtxt,
-                             span: Span,
-                             generics: &hir::Generics,
-                             thing: &'static str) {
+fn ensure_no_param_bounds(tcx: TyCtxt,
+                          span: Span,
+                          generics: &hir::Generics,
+                          thing: &'static str) {
     let mut warn = false;
 
     for ty_param in generics.ty_params() {
-        for bound in ty_param.bounds.iter() {
-            match *bound {
-                hir::TraitTyParamBound(..) => {
-                    warn = true;
-                }
-                hir::RegionTyParamBound(..) => { }
-            }
+        if !ty_param.bounds.is_empty() {
+            warn = true;
         }
     }
 
-    for predicate in generics.where_clause.predicates.iter() {
-        match *predicate {
-            hir::WherePredicate::BoundPredicate(..) => {
-                warn = true;
-            }
-            hir::WherePredicate::RegionPredicate(..) => { }
-            hir::WherePredicate::EqPredicate(..) => { }
+    for lft_param in generics.lifetimes() {
+        if !lft_param.bounds.is_empty() {
+            warn = true;
         }
+    }
+
+    if !generics.where_clause.predicates.is_empty() {
+        warn = true;
     }
 
     if warn {
@@ -388,7 +383,7 @@ fn ensure_no_ty_param_bounds(tcx: TyCtxt,
         // part of this PR. Still, convert to warning to
         // make bootstrapping easier.
         span_warn!(tcx.sess, span, E0122,
-                   "trait bounds are ignored in {} definitions",
+                   "bounds are ignored in {}",
                    thing);
     }
 }
@@ -454,7 +449,7 @@ fn convert_item<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, item_id: ast::NodeId) {
             }
         },
         hir::ItemTy(_, ref generics) => {
-            ensure_no_ty_param_bounds(tcx, it.span, generics, "type");
+            ensure_no_param_bounds(tcx, it.span, generics, "type aliases");
             tcx.generics_of(def_id);
             tcx.type_of(def_id);
             tcx.predicates_of(def_id);

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -388,8 +388,7 @@ fn ensure_no_ty_param_bounds(tcx: TyCtxt,
         // part of this PR. Still, convert to warning to
         // make bootstrapping easier.
         span_warn!(tcx.sess, span, E0122,
-                   "trait bounds are not (yet) enforced \
-                   in {} definitions",
+                   "trait bounds are ignored in {} definitions",
                    thing);
     }
 }

--- a/src/test/compile-fail/dst-bad-assign-3.rs
+++ b/src/test/compile-fail/dst-bad-assign-3.rs
@@ -13,7 +13,7 @@
 #![feature(unsized_tuple_coercion)]
 
 type Fat<T: ?Sized> = (isize, &'static str, T);
-//~^ WARNING trait bounds are not (yet) enforced
+//~^ WARNING bounds are ignored
 
 #[derive(PartialEq,Eq)]
 struct Bar;

--- a/src/test/compile-fail/private-in-public-warn.rs
+++ b/src/test/compile-fail/private-in-public-warn.rs
@@ -58,7 +58,7 @@ mod traits {
     pub trait PubTr {}
 
     pub type Alias<T: PrivTr> = T; //~ ERROR private trait `traits::PrivTr` in public interface
-    //~^ WARN trait bounds are not (yet) enforced in type definitions
+    //~^ WARN bounds are ignored in type aliases
     //~| WARNING hard error
     pub trait Tr1: PrivTr {} //~ ERROR private trait `traits::PrivTr` in public interface
     //~^ WARNING hard error

--- a/src/test/ui/param-bounds-ignored.rs
+++ b/src/test/ui/param-bounds-ignored.rs
@@ -1,0 +1,33 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// must-compile-successfully
+
+use std::rc::Rc;
+
+type SVec<T: Send> = Vec<T>;
+type VVec<'b, 'a: 'b> = Vec<&'a i32>;
+type WVec<'b, T: 'b> = Vec<T>;
+
+fn foo<'a>(y: &'a i32) {
+    // If the bounds above would matter, the code below would be rejected.
+    let mut x : SVec<_> = Vec::new();
+    x.push(Rc::new(42));
+
+    let mut x : VVec<'static, 'a> = Vec::new();
+    x.push(y);
+
+    let mut x : WVec<'static, & 'a i32> = Vec::new();
+    x.push(y);
+}
+
+fn main() {
+    foo(&42);
+}

--- a/src/test/ui/param-bounds-ignored.stderr
+++ b/src/test/ui/param-bounds-ignored.stderr
@@ -1,0 +1,18 @@
+warning[E0122]: bounds are ignored in type aliases
+  --> $DIR/param-bounds-ignored.rs:15:1
+   |
+15 | type SVec<T: Send> = Vec<T>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning[E0122]: bounds are ignored in type aliases
+  --> $DIR/param-bounds-ignored.rs:16:1
+   |
+16 | type VVec<'b, 'a: 'b> = Vec<&'a i32>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning[E0122]: bounds are ignored in type aliases
+  --> $DIR/param-bounds-ignored.rs:17:1
+   |
+17 | type WVec<'b, T: 'b> = Vec<T>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/src/test/ui/param-bounds-ignored.stderr
+++ b/src/test/ui/param-bounds-ignored.stderr
@@ -1,16 +1,16 @@
-warning[E0122]: bounds are ignored in type aliases
+warning[E0122]: generic bounds are ignored in type aliases
   --> $DIR/param-bounds-ignored.rs:15:1
    |
 15 | type SVec<T: Send> = Vec<T>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning[E0122]: bounds are ignored in type aliases
+warning[E0122]: generic bounds are ignored in type aliases
   --> $DIR/param-bounds-ignored.rs:16:1
    |
 16 | type VVec<'b, 'a: 'b> = Vec<&'a i32>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning[E0122]: bounds are ignored in type aliases
+warning[E0122]: generic bounds are ignored in type aliases
   --> $DIR/param-bounds-ignored.rs:17:1
    |
 17 | type WVec<'b, T: 'b> = Vec<T>;


### PR DESCRIPTION
It seems that all bounds in type aliases are entirely ignored, not just type bounds. This extends the warning appropriately.

I assume this should be made a hard error with the next epoch? I can't see any reason to accept these programs. (And suddenly enforcing these type bounds would be a breaking change.)