### PR TITLE
optimize Range[Inclusive].count()

### DIFF
--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -444,31 +444,13 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
         }
         Try::from_ok(accum)
     }
+
+    #[inline]
+    fn count(self) -> usize {
+        <A as Step>::steps_between(&self.start, &self.end)
+            .expect("Overflow on `RangeInclusive::count()`") + 1
+    }
 }
-
-macro_rules! impl_inclusive_range_count {
-    ($t:ty) => {
-        #[unstable(feature = "inclusive_range", reason = "recently added, follows RFC", issue = "28237")]
-        impl Iterator for ops::RangeInclusive<$t> {
-            #[inline]
-            fn count(self) -> usize {
-                (self.end.wrapping_sub(self.start) as usize).wrapping_add(1)
-            }
-        }
-    };
-}
-
-impl_inclusive_range_count!(u8);
-impl_inclusive_range_count!(u16);
-impl_inclusive_range_count!(u32);
-impl_inclusive_range_count!(u64);
-impl_inclusive_range_count!(usize);
-
-impl_inclusive_range_count!(i8);
-impl_inclusive_range_count!(i16);
-impl_inclusive_range_count!(i32);
-impl_inclusive_range_count!(i64);
-impl_inclusive_range_count!(isize);
 
 #[unstable(feature = "inclusive_range", reason = "recently added, follows RFC", issue = "28237")]
 impl<A: Step> DoubleEndedIterator for ops::RangeInclusive<A> {

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -268,6 +268,31 @@ impl<A: Step> Iterator for ops::Range<A> {
     }
 }
 
+macro_rules! impl_range_count {
+    ($t:ty) => {
+        #[unstable(feature = "inclusive_range", reason = "recently added, follows RFC", issue = "28237")]
+        impl Iterator for ops::Range<$t> {
+            #[inline]
+            fn count(self) -> usize {
+                self.end.wrapping_sub(self.start) as usize
+            }
+        }
+    };
+}
+
+impl_range_count!(u8);
+impl_range_count!(u16);
+impl_range_count!(u32);
+impl_range_count!(u64);
+impl_range_count!(usize);
+
+impl_range_count!(i8);
+impl_range_count!(i16);
+impl_range_count!(i32);
+impl_range_count!(i64);
+impl_range_count!(isize);
+
+
 // These macros generate `ExactSizeIterator` impls for various range types.
 // Range<{u,i}64> and RangeInclusive<{u,i}{32,64,size}> are excluded
 // because they cannot guarantee having a length <= usize::MAX, which is
@@ -420,6 +445,30 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
         Try::from_ok(accum)
     }
 }
+
+macro_rules! impl_inclusive_range_count {
+    ($t:ty) => {
+        #[unstable(feature = "inclusive_range", reason = "recently added, follows RFC", issue = "28237")]
+        impl Iterator for ops::RangeInclusive<$t> {
+            #[inline]
+            fn count(self) -> usize {
+                (self.end.wrapping_sub(self.start) as usize).wrapping_add(1)
+            }
+        }
+    };
+}
+
+impl_inclusive_range_count!(u8);
+impl_inclusive_range_count!(u16);
+impl_inclusive_range_count!(u32);
+impl_inclusive_range_count!(u64);
+impl_inclusive_range_count!(usize);
+
+impl_inclusive_range_count!(i8);
+impl_inclusive_range_count!(i16);
+impl_inclusive_range_count!(i32);
+impl_inclusive_range_count!(i64);
+impl_inclusive_range_count!(isize);
 
 #[unstable(feature = "inclusive_range", reason = "recently added, follows RFC", issue = "28237")]
 impl<A: Step> DoubleEndedIterator for ops::RangeInclusive<A> {

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1392,6 +1392,13 @@ fn test_range_inclusive_nth() {
 }
 
 #[test]
+fn test_range_inclusive_count() {
+    assert_eq!((1..=1).count(), 1);
+    assert_eq!((0..=10).count(), 11);
+    assert_eq!((5..=7).count(), 3);
+}
+
+#[test]
 fn test_range_step() {
     #![allow(deprecated)]
 


### PR DESCRIPTION
This special-cases count() for ranges to reduce them to simple arithmetic.

Open questions:

* How to deal with 128bit types?
* What further tests are needed?
