### PR TITLE
correct E0619 span re method call receivers whose type must be known

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2925,7 +2925,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         let rcvr = &args[0];
         let rcvr_t = self.check_expr_with_needs(&rcvr, needs);
         // no need to check for bot/err -- callee does that
-        let rcvr_t = self.structurally_resolved_type(expr.span, rcvr_t);
+        let rcvr_t = self.structurally_resolved_type(args[0].span, rcvr_t);
 
         let method = match self.lookup_method(rcvr_t,
                                               segment,

--- a/src/test/ui/span/issue-42234-unknown-receiver-type.rs
+++ b/src/test/ui/span/issue-42234-unknown-receiver-type.rs
@@ -1,0 +1,27 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// When the type of a method call's receiver is unknown, the span should point
+// to the receiver (and not the entire call, as was previously the case before
+// the fix of which this tests).
+
+fn shines_a_beacon_through_the_darkness() {
+    let x: Option<_> = None;
+    x.unwrap().method_that_could_exist_on_some_type();
+    //~^ ERROR 17:5: 17:15: the type of this value must be known in this context
+}
+
+fn courier_to_des_moines_and_points_west(data: &[u32]) -> String {
+    data.iter() //~ ERROR 22:5: 23:20: the type of this value must be known in this context
+        .sum::<_>()
+        .to_string()
+}
+
+fn main() {}

--- a/src/test/ui/span/issue-42234-unknown-receiver-type.stderr
+++ b/src/test/ui/span/issue-42234-unknown-receiver-type.stderr
@@ -1,0 +1,15 @@
+error[E0619]: the type of this value must be known in this context
+  --> $DIR/issue-42234-unknown-receiver-type.rs:17:5
+   |
+17 |     x.unwrap().method_that_could_exist_on_some_type();
+   |     ^^^^^^^^^^
+
+error[E0619]: the type of this value must be known in this context
+  --> $DIR/issue-42234-unknown-receiver-type.rs:22:5
+   |
+22 | /     data.iter() //~ ERROR 22:5: 23:20: the type of this value must be known in this context
+23 | |         .sum::<_>()
+   | |___________________^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Previously, when the type of a method receiver could not be determined,
the error message would, potentially confusingly, highlight the span of
the entire method call.

![unknown_receiver_type](https://user-images.githubusercontent.com/1076988/35838930-a595b17c-0aa2-11e8-9364-6b8e2329f051.png)

Resolves #36598, resolves #42234.