### PR TITLE
config.toml.example: fix typos.

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -295,7 +295,7 @@
 
 # Flag indicating whether git info will be retrieved from .git automatically.
 # Having the git information can cause a lot of rebuilds during development.
-# Note: If this attribute is not explicity set (e.g. if left commented out) it
+# Note: If this attribute is not explicitly set (e.g. if left commented out) it
 # will default to true if channel = "dev", but will default to false otherwise.
 #ignore-git = true
 
@@ -317,8 +317,8 @@
 # bootstrap)
 #codegen-backends = ["llvm"]
 
-# Flag indicating whether `libstd` calls an imported function to hande basic IO
-# when targetting WebAssembly. Enable this to debug tests for the `wasm32-unknown-unknown`
+# Flag indicating whether `libstd` calls an imported function to handle basic IO
+# when targeting WebAssembly. Enable this to debug tests for the `wasm32-unknown-unknown`
 # target, as without this option the test output will not be captured.
 #wasm-syscall = false
 
@@ -349,7 +349,7 @@
 #linker = "cc"
 
 # Path to the `llvm-config` binary of the installation of a custom LLVM to link
-# against. Note that if this is specifed we don't compile LLVM at all for this
+# against. Note that if this is specified we don't compile LLVM at all for this
 # target.
 #llvm-config = "../path/to/llvm/root/bin/llvm-config"
 


### PR DESCRIPTION
Most of them were found by codespell: https://github.com/lucasdemarchi/codespell