### PR TITLE
Early exit for empty HashMap (issue #38880)

### DIFF
--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -564,7 +564,7 @@ impl<K, V, S> HashMap<K, V, S>
         where K: Borrow<Q>,
               Q: Eq + Hash
     {
-        if !self.is_empty() {
+        if self.is_empty() {
             return None;
         }
 

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1290,10 +1290,6 @@ impl<K, V, S> HashMap<K, V, S>
         where K: Borrow<Q>,
               Q: Hash + Eq
     {
-        if self.table.size() == 0 {
-            return None;
-        }
-
         self.search_mut(k)
             .map(|bucket| {
                 let (k, v, _) = pop_internal(bucket);

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1031,7 +1031,9 @@ impl<K, V, S> HashMap<K, V, S>
     pub fn entry(&mut self, key: K) -> Entry<K, V> {
         // Gotta resize now.
         self.reserve(1);
-        self.search_mut(&key).into_entry(key).expect("unreachable")
+        let hash = self.make_hash(&key);
+        search_hashed(&mut self.table, hash, |q| q.eq(&key))
+            .into_entry(key).expect("unreachable")
     }
 
     /// Returns the number of elements in the map.

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1039,9 +1039,7 @@ impl<K, V, S> HashMap<K, V, S>
     pub fn entry(&mut self, key: K) -> Entry<K, V> {
         // Gotta resize now.
         self.reserve(1);
-        let hash = self.make_hash(&key);
-        search_hashed(&mut self.table, hash, |q| q.eq(&key))
-            .into_entry(key).expect("unreachable")
+        self.search_mut(&key).into_entry(key).expect("unreachable")
     }
 
     /// Returns the number of elements in the map.

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -417,7 +417,7 @@ fn search_hashed<K, V, M, F>(table: M, hash: SafeHash, is_match: F) -> InternalE
 
 /// Search for a pre-hashed key when the hash map is known to be non-empty.
 #[inline]
-fn search_hashed_nonempty<K, V, M, F>(table: M, hash: SafeHash, is_match: F)
+fn search_hashed_nonempty<K, V, M, F>(table: M, hash: SafeHash, mut is_match: F)
     -> InternalEntry<K, V, M>
     where M: Deref<Target = RawTable<K, V>>,
           F: FnMut(&K) -> bool


### PR DESCRIPTION
Addresses issue #38880 by checking if the HashMap is empty before computing the value of the hash.

Before (integer keys)
```
running 4 tests
test empty_once ... bench:          13 ns/iter (+/- 0)
test empty_100  ... bench:       1,367 ns/iter (+/- 35)
test exist_once ... bench:          14 ns/iter (+/- 0)
test exist_100  ... bench:       1,518 ns/iter (+/- 40)
```

After
```
running 4 tests
test empty_once ... bench:           2 ns/iter (+/- 0)
test empty_100  ... bench:         221 ns/iter (+/- 0)
test exist_once ... bench:          15 ns/iter (+/- 0)
test exist_100  ... bench:       1,515 ns/iter (+/- 92)
```

When the HashMap is not empty, the performance remains the same, and when it is empty the performance is significantly improved.