### PR TITLE
do not run MIR type checker twice

### DIFF
--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -1585,6 +1585,8 @@ impl MirPass for TypeckMir {
         let id = tcx.hir.as_local_node_id(def_id).unwrap();
         debug!("run_pass: {:?}", def_id);
 
+        // When NLL is enabled, the borrow checker runs the typeck
+        // itself, so we don't need this MIR pass anymore.
         if tcx.sess.nll() {
             return;
         }

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -1585,6 +1585,10 @@ impl MirPass for TypeckMir {
         let id = tcx.hir.as_local_node_id(def_id).unwrap();
         debug!("run_pass: {:?}", def_id);
 
+        if tcx.sess.nll() {
+            return;
+        }
+
         if tcx.sess.err_count() > 0 {
             // compiling a broken program can obviously result in a
             // broken MIR, so try not to report duplicate errors.

--- a/src/test/compile-fail/borrowck/two-phase-nonrecv-autoref.rs
+++ b/src/test/compile-fail/borrowck/two-phase-nonrecv-autoref.rs
@@ -105,14 +105,10 @@ fn overloaded_call_traits() {
         //[lxl]~^^^           ERROR use of moved value: `*f`
         //[nll]~^^^^          ERROR cannot move a value of type
         //[nll]~^^^^^         ERROR cannot move a value of type
-        //[nll]~^^^^^^        ERROR cannot move a value of type
-        //[nll]~^^^^^^^       ERROR cannot move a value of type
-        //[nll]~^^^^^^^^      ERROR use of moved value: `*f`
-        //[g2p]~^^^^^^^^^     ERROR cannot move a value of type
-        //[g2p]~^^^^^^^^^^    ERROR cannot move a value of type
-        //[g2p]~^^^^^^^^^^^   ERROR cannot move a value of type
-        //[g2p]~^^^^^^^^^^^^  ERROR cannot move a value of type
-        //[g2p]~^^^^^^^^^^^^^ ERROR use of moved value: `*f`
+        //[nll]~^^^^^^        ERROR use of moved value: `*f`
+        //[g2p]~^^^^^^^       ERROR cannot move a value of type
+        //[g2p]~^^^^^^^^      ERROR cannot move a value of type
+        //[g2p]~^^^^^^^^^     ERROR use of moved value: `*f`
     }
 
     twice_ten_sm(&mut |x| x + 1);

--- a/src/test/ui/nll/ty-outlives/projection-no-regions-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-no-regions-closure.stderr
@@ -25,53 +25,6 @@ note: External requirements
    = note: number of external vids: 3
    = note: where <T as std::iter::Iterator>::Item: '_#2r
 
-note: External requirements
-  --> $DIR/projection-no-regions-closure.rs:46:23
-   |
-46 |     with_signature(x, |mut y| Box::new(y.next()))
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: defining type: DefId(0/1:18 ~ projection_no_regions_closure[317d]::correct_region[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               T,
-               i32,
-               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<Anything + '_#2r>
-           ]
-   = note: number of external vids: 3
-   = note: where <T as std::iter::Iterator>::Item: '_#2r
-
-note: External requirements
-  --> $DIR/projection-no-regions-closure.rs:54:23
-   |
-54 |     with_signature(x, |mut y| Box::new(y.next()))
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: defining type: DefId(0/1:22 ~ projection_no_regions_closure[317d]::wrong_region[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
-               i32,
-               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<Anything + '_#3r>
-           ]
-   = note: number of external vids: 4
-   = note: where <T as std::iter::Iterator>::Item: '_#3r
-
-note: External requirements
-  --> $DIR/projection-no-regions-closure.rs:65:23
-   |
-65 |     with_signature(x, |mut y| Box::new(y.next()))
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: defining type: DefId(0/1:26 ~ projection_no_regions_closure[317d]::outlives_region[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
-               i32,
-               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<Anything + '_#3r>
-           ]
-   = note: number of external vids: 4
-   = note: where <T as std::iter::Iterator>::Item: '_#3r
-
 error[E0309]: the associated type `<T as std::iter::Iterator>::Item` may not live long enough
   --> $DIR/projection-no-regions-closure.rs:36:23
    |
@@ -97,6 +50,21 @@ note: No external requirements
                T
            ]
 
+note: External requirements
+  --> $DIR/projection-no-regions-closure.rs:46:23
+   |
+46 |     with_signature(x, |mut y| Box::new(y.next()))
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: defining type: DefId(0/1:18 ~ projection_no_regions_closure[317d]::correct_region[0]::{{closure}}[0]) with closure substs [
+               '_#1r,
+               T,
+               i32,
+               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<Anything + '_#2r>
+           ]
+   = note: number of external vids: 3
+   = note: where <T as std::iter::Iterator>::Item: '_#2r
+
 note: No external requirements
   --> $DIR/projection-no-regions-closure.rs:42:1
    |
@@ -112,6 +80,22 @@ note: No external requirements
                '_#1r,
                T
            ]
+
+note: External requirements
+  --> $DIR/projection-no-regions-closure.rs:54:23
+   |
+54 |     with_signature(x, |mut y| Box::new(y.next()))
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: defining type: DefId(0/1:22 ~ projection_no_regions_closure[317d]::wrong_region[0]::{{closure}}[0]) with closure substs [
+               '_#1r,
+               '_#2r,
+               T,
+               i32,
+               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<Anything + '_#3r>
+           ]
+   = note: number of external vids: 4
+   = note: where <T as std::iter::Iterator>::Item: '_#3r
 
 error[E0309]: the associated type `<T as std::iter::Iterator>::Item` may not live long enough
   --> $DIR/projection-no-regions-closure.rs:54:23
@@ -138,6 +122,22 @@ note: No external requirements
                '_#2r,
                T
            ]
+
+note: External requirements
+  --> $DIR/projection-no-regions-closure.rs:65:23
+   |
+65 |     with_signature(x, |mut y| Box::new(y.next()))
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: defining type: DefId(0/1:26 ~ projection_no_regions_closure[317d]::outlives_region[0]::{{closure}}[0]) with closure substs [
+               '_#1r,
+               '_#2r,
+               T,
+               i32,
+               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<Anything + '_#3r>
+           ]
+   = note: number of external vids: 4
+   = note: where <T as std::iter::Iterator>::Item: '_#3r
 
 note: No external requirements
   --> $DIR/projection-no-regions-closure.rs:60:1

--- a/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
@@ -32,57 +32,6 @@ note: External requirements
    = note: where T: '_#2r
    = note: where '_#1r: '_#2r
 
-note: External requirements
-  --> $DIR/projection-one-region-closure.rs:68:29
-   |
-68 |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: defining type: DefId(0/1:23 ~ projection_one_region_closure[317d]::no_relationships_early[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
-               i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
-           ]
-   = note: number of external vids: 4
-   = note: where T: '_#3r
-   = note: where '_#2r: '_#3r
-
-note: External requirements
-  --> $DIR/projection-one-region-closure.rs:90:29
-   |
-90 |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: defining type: DefId(0/1:27 ~ projection_one_region_closure[317d]::projection_outlives[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
-               i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
-           ]
-   = note: number of external vids: 4
-   = note: where T: '_#3r
-   = note: where '_#2r: '_#3r
-
-note: External requirements
-   --> $DIR/projection-one-region-closure.rs:103:29
-    |
-103 |     with_signature(cell, t, |cell, t| require(cell, t));
-    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-    |
-    = note: defining type: DefId(0/1:31 ~ projection_one_region_closure[317d]::elements_outlive[0]::{{closure}}[0]) with closure substs [
-                '_#1r,
-                '_#2r,
-                T,
-                i32,
-                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
-            ]
-    = note: number of external vids: 4
-    = note: where T: '_#3r
-    = note: where '_#2r: '_#3r
-
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/projection-one-region-closure.rs:56:29
    |
@@ -113,6 +62,23 @@ note: No external requirements
                '_#1r,
                T
            ]
+
+note: External requirements
+  --> $DIR/projection-one-region-closure.rs:68:29
+   |
+68 |     with_signature(cell, t, |cell, t| require(cell, t));
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: defining type: DefId(0/1:23 ~ projection_one_region_closure[317d]::no_relationships_early[0]::{{closure}}[0]) with closure substs [
+               '_#1r,
+               '_#2r,
+               T,
+               i32,
+               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
+           ]
+   = note: number of external vids: 4
+   = note: where T: '_#3r
+   = note: where '_#2r: '_#3r
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/projection-one-region-closure.rs:68:29
@@ -146,6 +112,23 @@ note: No external requirements
                T
            ]
 
+note: External requirements
+  --> $DIR/projection-one-region-closure.rs:90:29
+   |
+90 |     with_signature(cell, t, |cell, t| require(cell, t));
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: defining type: DefId(0/1:27 ~ projection_one_region_closure[317d]::projection_outlives[0]::{{closure}}[0]) with closure substs [
+               '_#1r,
+               '_#2r,
+               T,
+               i32,
+               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
+           ]
+   = note: number of external vids: 4
+   = note: where T: '_#3r
+   = note: where '_#2r: '_#3r
+
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/projection-one-region-closure.rs:90:29
    |
@@ -177,6 +160,23 @@ note: No external requirements
                '_#2r,
                T
            ]
+
+note: External requirements
+   --> $DIR/projection-one-region-closure.rs:103:29
+    |
+103 |     with_signature(cell, t, |cell, t| require(cell, t));
+    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: defining type: DefId(0/1:31 ~ projection_one_region_closure[317d]::elements_outlive[0]::{{closure}}[0]) with closure substs [
+                '_#1r,
+                '_#2r,
+                T,
+                i32,
+                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
+            ]
+    = note: number of external vids: 4
+    = note: where T: '_#3r
+    = note: where '_#2r: '_#3r
 
 note: No external requirements
    --> $DIR/projection-one-region-closure.rs:97:1

--- a/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
@@ -31,69 +31,6 @@ note: External requirements
    = note: number of external vids: 3
    = note: where '_#1r: '_#2r
 
-note: External requirements
-  --> $DIR/projection-one-region-trait-bound-closure.rs:59:29
-   |
-59 |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: defining type: DefId(0/1:23 ~ projection_one_region_trait_bound_closure[317d]::no_relationships_early[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
-               i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
-           ]
-   = note: number of external vids: 4
-   = note: where '_#2r: '_#3r
-
-note: External requirements
-  --> $DIR/projection-one-region-trait-bound-closure.rs:80:29
-   |
-80 |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: defining type: DefId(0/1:27 ~ projection_one_region_trait_bound_closure[317d]::projection_outlives[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
-               i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
-           ]
-   = note: number of external vids: 4
-   = note: where '_#2r: '_#3r
-
-note: External requirements
-  --> $DIR/projection-one-region-trait-bound-closure.rs:91:29
-   |
-91 |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: defining type: DefId(0/1:31 ~ projection_one_region_trait_bound_closure[317d]::elements_outlive[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
-               i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
-           ]
-   = note: number of external vids: 4
-   = note: where '_#2r: '_#3r
-
-note: External requirements
-   --> $DIR/projection-one-region-trait-bound-closure.rs:103:29
-    |
-103 |     with_signature(cell, t, |cell, t| require(cell, t));
-    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-    |
-    = note: defining type: DefId(0/1:34 ~ projection_one_region_trait_bound_closure[317d]::one_region[0]::{{closure}}[0]) with closure substs [
-                '_#1r,
-                T,
-                i32,
-                extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T))
-            ]
-    = note: number of external vids: 3
-    = note: where '_#1r: '_#2r
-
 error: free region `ReEarlyBound(0, 'b)` does not outlive free region `ReFree(DefId(0/0:8 ~ projection_one_region_trait_bound_closure[317d]::no_relationships_late[0]), BrNamed(crate0:DefIndex(1:16), 'a))`
   --> $DIR/projection-one-region-trait-bound-closure.rs:48:20
    |
@@ -116,6 +53,22 @@ note: No external requirements
                '_#1r,
                T
            ]
+
+note: External requirements
+  --> $DIR/projection-one-region-trait-bound-closure.rs:59:29
+   |
+59 |     with_signature(cell, t, |cell, t| require(cell, t));
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: defining type: DefId(0/1:23 ~ projection_one_region_trait_bound_closure[317d]::no_relationships_early[0]::{{closure}}[0]) with closure substs [
+               '_#1r,
+               '_#2r,
+               T,
+               i32,
+               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
+           ]
+   = note: number of external vids: 4
+   = note: where '_#2r: '_#3r
 
 error: free region `ReEarlyBound(1, 'b)` does not outlive free region `ReEarlyBound(0, 'a)`
   --> $DIR/projection-one-region-trait-bound-closure.rs:59:20
@@ -141,6 +94,22 @@ note: No external requirements
                T
            ]
 
+note: External requirements
+  --> $DIR/projection-one-region-trait-bound-closure.rs:80:29
+   |
+80 |     with_signature(cell, t, |cell, t| require(cell, t));
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: defining type: DefId(0/1:27 ~ projection_one_region_trait_bound_closure[317d]::projection_outlives[0]::{{closure}}[0]) with closure substs [
+               '_#1r,
+               '_#2r,
+               T,
+               i32,
+               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
+           ]
+   = note: number of external vids: 4
+   = note: where '_#2r: '_#3r
+
 error: free region `ReEarlyBound(1, 'b)` does not outlive free region `ReEarlyBound(0, 'a)`
   --> $DIR/projection-one-region-trait-bound-closure.rs:80:20
    |
@@ -165,6 +134,22 @@ note: No external requirements
                T
            ]
 
+note: External requirements
+  --> $DIR/projection-one-region-trait-bound-closure.rs:91:29
+   |
+91 |     with_signature(cell, t, |cell, t| require(cell, t));
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: defining type: DefId(0/1:31 ~ projection_one_region_trait_bound_closure[317d]::elements_outlive[0]::{{closure}}[0]) with closure substs [
+               '_#1r,
+               '_#2r,
+               T,
+               i32,
+               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
+           ]
+   = note: number of external vids: 4
+   = note: where '_#2r: '_#3r
+
 note: No external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:86:1
    |
@@ -182,6 +167,21 @@ note: No external requirements
                '_#2r,
                T
            ]
+
+note: External requirements
+   --> $DIR/projection-one-region-trait-bound-closure.rs:103:29
+    |
+103 |     with_signature(cell, t, |cell, t| require(cell, t));
+    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: defining type: DefId(0/1:34 ~ projection_one_region_trait_bound_closure[317d]::one_region[0]::{{closure}}[0]) with closure substs [
+                '_#1r,
+                T,
+                i32,
+                extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T))
+            ]
+    = note: number of external vids: 3
+    = note: where '_#1r: '_#2r
 
 note: No external requirements
    --> $DIR/projection-one-region-trait-bound-closure.rs:95:1

--- a/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.stderr
@@ -12,61 +12,6 @@ note: No external requirements
            ]
 
 note: No external requirements
-  --> $DIR/projection-one-region-trait-bound-static-closure.rs:56:29
-   |
-56 |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: defining type: DefId(0/1:23 ~ projection_one_region_trait_bound_static_closure[317d]::no_relationships_early[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
-               i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
-           ]
-
-note: No external requirements
-  --> $DIR/projection-one-region-trait-bound-static-closure.rs:75:29
-   |
-75 |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: defining type: DefId(0/1:27 ~ projection_one_region_trait_bound_static_closure[317d]::projection_outlives[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
-               i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
-           ]
-
-note: No external requirements
-  --> $DIR/projection-one-region-trait-bound-static-closure.rs:84:29
-   |
-84 |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: defining type: DefId(0/1:31 ~ projection_one_region_trait_bound_static_closure[317d]::elements_outlive[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
-               i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
-           ]
-
-note: No external requirements
-  --> $DIR/projection-one-region-trait-bound-static-closure.rs:96:29
-   |
-96 |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: defining type: DefId(0/1:34 ~ projection_one_region_trait_bound_static_closure[317d]::one_region[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               T,
-               i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T))
-           ]
-
-note: No external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:43:1
    |
 43 | / fn no_relationships_late<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
@@ -80,6 +25,20 @@ note: No external requirements
    = note: defining type: DefId(0/0:8 ~ projection_one_region_trait_bound_static_closure[317d]::no_relationships_late[0]) with substs [
                '_#1r,
                T
+           ]
+
+note: No external requirements
+  --> $DIR/projection-one-region-trait-bound-static-closure.rs:56:29
+   |
+56 |     with_signature(cell, t, |cell, t| require(cell, t));
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: defining type: DefId(0/1:23 ~ projection_one_region_trait_bound_static_closure[317d]::no_relationships_early[0]::{{closure}}[0]) with closure substs [
+               '_#1r,
+               '_#2r,
+               T,
+               i32,
+               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
            ]
 
 note: No external requirements
@@ -101,6 +60,20 @@ note: No external requirements
            ]
 
 note: No external requirements
+  --> $DIR/projection-one-region-trait-bound-static-closure.rs:75:29
+   |
+75 |     with_signature(cell, t, |cell, t| require(cell, t));
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: defining type: DefId(0/1:27 ~ projection_one_region_trait_bound_static_closure[317d]::projection_outlives[0]::{{closure}}[0]) with closure substs [
+               '_#1r,
+               '_#2r,
+               T,
+               i32,
+               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
+           ]
+
+note: No external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:60:1
    |
 60 | / fn projection_outlives<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
@@ -119,6 +92,20 @@ note: No external requirements
            ]
 
 note: No external requirements
+  --> $DIR/projection-one-region-trait-bound-static-closure.rs:84:29
+   |
+84 |     with_signature(cell, t, |cell, t| require(cell, t));
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: defining type: DefId(0/1:31 ~ projection_one_region_trait_bound_static_closure[317d]::elements_outlive[0]::{{closure}}[0]) with closure substs [
+               '_#1r,
+               '_#2r,
+               T,
+               i32,
+               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
+           ]
+
+note: No external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:79:1
    |
 79 | / fn elements_outlive<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
@@ -134,6 +121,19 @@ note: No external requirements
                '_#1r,
                '_#2r,
                T
+           ]
+
+note: No external requirements
+  --> $DIR/projection-one-region-trait-bound-static-closure.rs:96:29
+   |
+96 |     with_signature(cell, t, |cell, t| require(cell, t));
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: defining type: DefId(0/1:34 ~ projection_one_region_trait_bound_static_closure[317d]::one_region[0]::{{closure}}[0]) with closure substs [
+               '_#1r,
+               T,
+               i32,
+               extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T))
            ]
 
 note: No external requirements

--- a/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
@@ -38,120 +38,6 @@ note: External requirements
    = note: number of external vids: 4
    = note: where <T as Anything<ReClosureBound('_#1r), ReClosureBound('_#2r)>>::AssocType: '_#3r
 
-note: External requirements
-  --> $DIR/projection-two-region-trait-bound-closure.rs:60:29
-   |
-60 |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: defining type: DefId(0/1:27 ~ projection_two_region_trait_bound_closure[317d]::no_relationships_early[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               '_#3r,
-               T,
-               i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#4r ()>, T))
-           ]
-   = note: number of external vids: 5
-   = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#3r)>>::AssocType: '_#4r
-
-note: External requirements
-  --> $DIR/projection-two-region-trait-bound-closure.rs:81:29
-   |
-81 |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: defining type: DefId(0/1:32 ~ projection_two_region_trait_bound_closure[317d]::projection_outlives[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               '_#3r,
-               T,
-               i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#4r ()>, T))
-           ]
-   = note: number of external vids: 5
-   = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#3r)>>::AssocType: '_#4r
-
-note: External requirements
-  --> $DIR/projection-two-region-trait-bound-closure.rs:92:29
-   |
-92 |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: defining type: DefId(0/1:37 ~ projection_two_region_trait_bound_closure[317d]::elements_outlive1[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               '_#3r,
-               T,
-               i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#4r ()>, T))
-           ]
-   = note: number of external vids: 5
-   = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#3r)>>::AssocType: '_#4r
-
-note: External requirements
-   --> $DIR/projection-two-region-trait-bound-closure.rs:101:29
-    |
-101 |     with_signature(cell, t, |cell, t| require(cell, t));
-    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-    |
-    = note: defining type: DefId(0/1:42 ~ projection_two_region_trait_bound_closure[317d]::elements_outlive2[0]::{{closure}}[0]) with closure substs [
-                '_#1r,
-                '_#2r,
-                '_#3r,
-                T,
-                i32,
-                extern "rust-call" fn((std::cell::Cell<&'_#4r ()>, T))
-            ]
-    = note: number of external vids: 5
-    = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#3r)>>::AssocType: '_#4r
-
-note: External requirements
-   --> $DIR/projection-two-region-trait-bound-closure.rs:109:29
-    |
-109 |     with_signature(cell, t, |cell, t| require(cell, t));
-    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-    |
-    = note: defining type: DefId(0/1:46 ~ projection_two_region_trait_bound_closure[317d]::two_regions[0]::{{closure}}[0]) with closure substs [
-                '_#1r,
-                T,
-                i32,
-                extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T))
-            ]
-    = note: number of external vids: 3
-    = note: where <T as Anything<ReClosureBound('_#1r), ReClosureBound('_#1r)>>::AssocType: '_#2r
-
-note: External requirements
-   --> $DIR/projection-two-region-trait-bound-closure.rs:120:29
-    |
-120 |     with_signature(cell, t, |cell, t| require(cell, t));
-    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-    |
-    = note: defining type: DefId(0/1:50 ~ projection_two_region_trait_bound_closure[317d]::two_regions_outlive[0]::{{closure}}[0]) with closure substs [
-                '_#1r,
-                '_#2r,
-                T,
-                i32,
-                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
-            ]
-    = note: number of external vids: 4
-    = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#2r)>>::AssocType: '_#3r
-
-note: External requirements
-   --> $DIR/projection-two-region-trait-bound-closure.rs:132:29
-    |
-132 |     with_signature(cell, t, |cell, t| require(cell, t));
-    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-    |
-    = note: defining type: DefId(0/1:53 ~ projection_two_region_trait_bound_closure[317d]::one_region[0]::{{closure}}[0]) with closure substs [
-                '_#1r,
-                T,
-                i32,
-                extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T))
-            ]
-    = note: number of external vids: 3
-    = note: where <T as Anything<ReClosureBound('_#1r), ReClosureBound('_#1r)>>::AssocType: '_#2r
-
 error[E0309]: the associated type `<T as Anything<'_#5r, '_#6r>>::AssocType` may not live long enough
   --> $DIR/projection-two-region-trait-bound-closure.rs:49:29
    |
@@ -177,6 +63,23 @@ note: No external requirements
                '_#2r,
                T
            ]
+
+note: External requirements
+  --> $DIR/projection-two-region-trait-bound-closure.rs:60:29
+   |
+60 |     with_signature(cell, t, |cell, t| require(cell, t));
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: defining type: DefId(0/1:27 ~ projection_two_region_trait_bound_closure[317d]::no_relationships_early[0]::{{closure}}[0]) with closure substs [
+               '_#1r,
+               '_#2r,
+               '_#3r,
+               T,
+               i32,
+               extern "rust-call" fn((std::cell::Cell<&'_#4r ()>, T))
+           ]
+   = note: number of external vids: 5
+   = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#3r)>>::AssocType: '_#4r
 
 error[E0309]: the associated type `<T as Anything<'_#6r, '_#7r>>::AssocType` may not live long enough
   --> $DIR/projection-two-region-trait-bound-closure.rs:60:29
@@ -205,6 +108,23 @@ note: No external requirements
                T
            ]
 
+note: External requirements
+  --> $DIR/projection-two-region-trait-bound-closure.rs:81:29
+   |
+81 |     with_signature(cell, t, |cell, t| require(cell, t));
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: defining type: DefId(0/1:32 ~ projection_two_region_trait_bound_closure[317d]::projection_outlives[0]::{{closure}}[0]) with closure substs [
+               '_#1r,
+               '_#2r,
+               '_#3r,
+               T,
+               i32,
+               extern "rust-call" fn((std::cell::Cell<&'_#4r ()>, T))
+           ]
+   = note: number of external vids: 5
+   = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#3r)>>::AssocType: '_#4r
+
 error[E0309]: the associated type `<T as Anything<'_#6r, '_#7r>>::AssocType` may not live long enough
   --> $DIR/projection-two-region-trait-bound-closure.rs:81:29
    |
@@ -232,6 +152,23 @@ note: No external requirements
                T
            ]
 
+note: External requirements
+  --> $DIR/projection-two-region-trait-bound-closure.rs:92:29
+   |
+92 |     with_signature(cell, t, |cell, t| require(cell, t));
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: defining type: DefId(0/1:37 ~ projection_two_region_trait_bound_closure[317d]::elements_outlive1[0]::{{closure}}[0]) with closure substs [
+               '_#1r,
+               '_#2r,
+               '_#3r,
+               T,
+               i32,
+               extern "rust-call" fn((std::cell::Cell<&'_#4r ()>, T))
+           ]
+   = note: number of external vids: 5
+   = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#3r)>>::AssocType: '_#4r
+
 note: No external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:87:1
    |
@@ -251,6 +188,23 @@ note: No external requirements
                T
            ]
 
+note: External requirements
+   --> $DIR/projection-two-region-trait-bound-closure.rs:101:29
+    |
+101 |     with_signature(cell, t, |cell, t| require(cell, t));
+    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: defining type: DefId(0/1:42 ~ projection_two_region_trait_bound_closure[317d]::elements_outlive2[0]::{{closure}}[0]) with closure substs [
+                '_#1r,
+                '_#2r,
+                '_#3r,
+                T,
+                i32,
+                extern "rust-call" fn((std::cell::Cell<&'_#4r ()>, T))
+            ]
+    = note: number of external vids: 5
+    = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#3r)>>::AssocType: '_#4r
+
 note: No external requirements
    --> $DIR/projection-two-region-trait-bound-closure.rs:96:1
     |
@@ -269,6 +223,21 @@ note: No external requirements
                 '_#3r,
                 T
             ]
+
+note: External requirements
+   --> $DIR/projection-two-region-trait-bound-closure.rs:109:29
+    |
+109 |     with_signature(cell, t, |cell, t| require(cell, t));
+    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: defining type: DefId(0/1:46 ~ projection_two_region_trait_bound_closure[317d]::two_regions[0]::{{closure}}[0]) with closure substs [
+                '_#1r,
+                T,
+                i32,
+                extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T))
+            ]
+    = note: number of external vids: 3
+    = note: where <T as Anything<ReClosureBound('_#1r), ReClosureBound('_#1r)>>::AssocType: '_#2r
 
 error: free region `ReEarlyBound(0, 'b)` does not outlive free region `ReFree(DefId(0/0:13 ~ projection_two_region_trait_bound_closure[317d]::two_regions[0]), BrNamed(crate0:DefIndex(1:43), 'a))`
    --> $DIR/projection-two-region-trait-bound-closure.rs:109:20
@@ -293,6 +262,22 @@ note: No external requirements
                 T
             ]
 
+note: External requirements
+   --> $DIR/projection-two-region-trait-bound-closure.rs:120:29
+    |
+120 |     with_signature(cell, t, |cell, t| require(cell, t));
+    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: defining type: DefId(0/1:50 ~ projection_two_region_trait_bound_closure[317d]::two_regions_outlive[0]::{{closure}}[0]) with closure substs [
+                '_#1r,
+                '_#2r,
+                T,
+                i32,
+                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
+            ]
+    = note: number of external vids: 4
+    = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#2r)>>::AssocType: '_#3r
+
 note: No external requirements
    --> $DIR/projection-two-region-trait-bound-closure.rs:115:1
     |
@@ -310,6 +295,21 @@ note: No external requirements
                 '_#2r,
                 T
             ]
+
+note: External requirements
+   --> $DIR/projection-two-region-trait-bound-closure.rs:132:29
+    |
+132 |     with_signature(cell, t, |cell, t| require(cell, t));
+    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: defining type: DefId(0/1:53 ~ projection_two_region_trait_bound_closure[317d]::one_region[0]::{{closure}}[0]) with closure substs [
+                '_#1r,
+                T,
+                i32,
+                extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T))
+            ]
+    = note: number of external vids: 3
+    = note: where <T as Anything<ReClosureBound('_#1r), ReClosureBound('_#1r)>>::AssocType: '_#2r
 
 note: No external requirements
    --> $DIR/projection-two-region-trait-bound-closure.rs:124:1

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
@@ -30,20 +30,6 @@ note: External requirements
    = note: number of external vids: 2
    = note: where T: '_#1r
 
-note: External requirements
-  --> $DIR/ty-param-closure-approximate-lower-bound.rs:43:24
-   |
-43 |     twice(cell, value, |a, b| invoke(a, b));
-   |                        ^^^^^^^^^^^^^^^^^^^
-   |
-   = note: defining type: DefId(0/1:17 ~ ty_param_closure_approximate_lower_bound[317d]::generic_fail[0]::{{closure}}[0]) with closure substs [
-               T,
-               i16,
-               for<'r, 's> extern "rust-call" fn((std::option::Option<std::cell::Cell<&'_#1r &ReLateBound(DebruijnIndex { depth: 1 }, BrNamed(crate0:DefIndex(0:0), 'r)) ()>>, &ReLateBound(DebruijnIndex { depth: 1 }, BrNamed(crate0:DefIndex(0:0), 's)) T))
-           ]
-   = note: number of external vids: 2
-   = note: where T: '_#1r
-
 note: No external requirements
   --> $DIR/ty-param-closure-approximate-lower-bound.rs:33:1
    |
@@ -59,6 +45,20 @@ note: No external requirements
    = note: defining type: DefId(0/0:5 ~ ty_param_closure_approximate_lower_bound[317d]::generic[0]) with substs [
                T
            ]
+
+note: External requirements
+  --> $DIR/ty-param-closure-approximate-lower-bound.rs:43:24
+   |
+43 |     twice(cell, value, |a, b| invoke(a, b));
+   |                        ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: defining type: DefId(0/1:17 ~ ty_param_closure_approximate_lower_bound[317d]::generic_fail[0]::{{closure}}[0]) with closure substs [
+               T,
+               i16,
+               for<'r, 's> extern "rust-call" fn((std::option::Option<std::cell::Cell<&'_#1r &ReLateBound(DebruijnIndex { depth: 1 }, BrNamed(crate0:DefIndex(0:0), 'r)) ()>>, &ReLateBound(DebruijnIndex { depth: 1 }, BrNamed(crate0:DefIndex(0:0), 's)) T))
+           ]
+   = note: number of external vids: 2
+   = note: where T: '_#1r
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-closure-approximate-lower-bound.rs:43:24

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
@@ -31,69 +31,6 @@ note: External requirements
    = note: number of external vids: 2
    = note: where T: '_#1r
 
-note: External requirements
-  --> $DIR/ty-param-closure-outlives-from-where-clause.rs:55:26
-   |
-55 |       with_signature(a, b, |x, y| {
-   |  __________________________^
-56 | |         // Key point of this test:
-57 | |         //
-58 | |         // The *closure* is being type-checked with all of its free
-...  |
-67 | |         require(&x, &y)
-68 | |     })
-   | |_____^
-   |
-   = note: defining type: DefId(0/1:19 ~ ty_param_closure_outlives_from_where_clause[317d]::correct_region[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               T,
-               i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T))
-           ]
-   = note: number of external vids: 3
-   = note: where T: '_#2r
-
-note: External requirements
-  --> $DIR/ty-param-closure-outlives-from-where-clause.rs:76:26
-   |
-76 |       with_signature(a, b, |x, y| {
-   |  __________________________^
-77 | |         //~^ ERROR the parameter type `T` may not live long enough
-78 | |         // See `correct_region`
-79 | |         require(&x, &y)
-80 | |         //~^ WARNING not reporting region error due to -Znll
-81 | |     })
-   | |_____^
-   |
-   = note: defining type: DefId(0/1:23 ~ ty_param_closure_outlives_from_where_clause[317d]::wrong_region[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               T,
-               i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T))
-           ]
-   = note: number of external vids: 3
-   = note: where T: '_#2r
-
-note: External requirements
-  --> $DIR/ty-param-closure-outlives-from-where-clause.rs:90:26
-   |
-90 |       with_signature(a, b, |x, y| {
-   |  __________________________^
-91 | |         // See `correct_region`
-92 | |         require(&x, &y)
-93 | |     })
-   | |_____^
-   |
-   = note: defining type: DefId(0/1:27 ~ ty_param_closure_outlives_from_where_clause[317d]::outlives_region[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
-               i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
-           ]
-   = note: number of external vids: 4
-   = note: where T: '_#3r
-
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:38:26
    |
@@ -125,6 +62,28 @@ note: No external requirements
                T
            ]
 
+note: External requirements
+  --> $DIR/ty-param-closure-outlives-from-where-clause.rs:55:26
+   |
+55 |       with_signature(a, b, |x, y| {
+   |  __________________________^
+56 | |         // Key point of this test:
+57 | |         //
+58 | |         // The *closure* is being type-checked with all of its free
+...  |
+67 | |         require(&x, &y)
+68 | |     })
+   | |_____^
+   |
+   = note: defining type: DefId(0/1:19 ~ ty_param_closure_outlives_from_where_clause[317d]::correct_region[0]::{{closure}}[0]) with closure substs [
+               '_#1r,
+               T,
+               i32,
+               extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T))
+           ]
+   = note: number of external vids: 3
+   = note: where T: '_#2r
+
 note: No external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:51:1
    |
@@ -141,6 +100,27 @@ note: No external requirements
                '_#1r,
                T
            ]
+
+note: External requirements
+  --> $DIR/ty-param-closure-outlives-from-where-clause.rs:76:26
+   |
+76 |       with_signature(a, b, |x, y| {
+   |  __________________________^
+77 | |         //~^ ERROR the parameter type `T` may not live long enough
+78 | |         // See `correct_region`
+79 | |         require(&x, &y)
+80 | |         //~^ WARNING not reporting region error due to -Znll
+81 | |     })
+   | |_____^
+   |
+   = note: defining type: DefId(0/1:23 ~ ty_param_closure_outlives_from_where_clause[317d]::wrong_region[0]::{{closure}}[0]) with closure substs [
+               '_#1r,
+               T,
+               i32,
+               extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T))
+           ]
+   = note: number of external vids: 3
+   = note: where T: '_#2r
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:76:26
@@ -172,6 +152,26 @@ note: No external requirements
                '_#1r,
                T
            ]
+
+note: External requirements
+  --> $DIR/ty-param-closure-outlives-from-where-clause.rs:90:26
+   |
+90 |       with_signature(a, b, |x, y| {
+   |  __________________________^
+91 | |         // See `correct_region`
+92 | |         require(&x, &y)
+93 | |     })
+   | |_____^
+   |
+   = note: defining type: DefId(0/1:27 ~ ty_param_closure_outlives_from_where_clause[317d]::outlives_region[0]::{{closure}}[0]) with closure substs [
+               '_#1r,
+               '_#2r,
+               T,
+               i32,
+               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T))
+           ]
+   = note: number of external vids: 4
+   = note: where T: '_#3r
 
 note: No external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:85:1


### PR DESCRIPTION
The MIR type checker currently runs twice when NLL is enabled: once as a sanity check, and once "for real". No need for that.