### PR TITLE
Apply optimization from #44355 to retain

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -814,7 +814,7 @@ impl<T> Vec<T> {
                 if !f(&v[i]) {
                     del += 1;
                     unsafe {
-                        ptr::read(&v[i]);
+                        ptr::drop_in_place(&mut v[i]);
                     }
                 } else if del > 0 {
                     let src: *const T = &v[i];

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -805,27 +805,7 @@ impl<T> Vec<T> {
     pub fn retain<F>(&mut self, mut f: F)
         where F: FnMut(&T) -> bool
     {
-        let len = self.len();
-        let mut del = 0;
-        {
-            let v = &mut **self;
-
-            for i in 0..len {
-                if !f(&v[i]) {
-                    del += 1;
-                    unsafe {
-                        ptr::drop_in_place(&mut v[i]);
-                    }
-                } else if del > 0 {
-                    let src: *const T = &v[i];
-                    let dst: *mut T = &mut v[i - del];
-                    unsafe {
-                        ptr::copy_nonoverlapping(src, dst, 1);
-                    }
-                }
-            }
-        }
-        self.len = len - del;
+        self.drain_filter(|x| !f(x));
     }
 
     /// Removes all but the first of consecutive elements in the vector that resolve to the same

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -813,14 +813,19 @@ impl<T> Vec<T> {
             for i in 0..len {
                 if !f(&v[i]) {
                     del += 1;
+                    unsafe {
+                        ptr::read(&v[i]);
+                    }
                 } else if del > 0 {
-                    v.swap(i - del, i);
+                    let src: *const T = &v[i];
+                    let dst: *mut T = &mut v[i - del];
+                    unsafe {
+                        ptr::copy_nonoverlapping(src, dst, 1);
+                    }
                 }
             }
         }
-        if del > 0 {
-            self.truncate(len - del);
-        }
+        self.len = len - del;
     }
 
     /// Removes all but the first of consecutive elements in the vector that resolve to the same


### PR DESCRIPTION
As discussed in #44355 this PR applies a similar optimization to `Vec::retain`.  For `drain_filter`, a very similar function, this improved performance by up to 20%.