### PR TITLE
pass correct pie args to gcc linker

### DIFF
--- a/src/librustc_trans/back/command.rs
+++ b/src/librustc_trans/back/command.rs
@@ -109,6 +109,10 @@ impl Command {
 
     // extensions
 
+    pub fn get_args(&self) -> &[OsString] {
+        &self.args
+    }
+
     pub fn take_args(&mut self) -> Vec<OsString> {
         mem::replace(&mut self.args, Vec::new())
     }

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -669,7 +669,8 @@ fn link_natively(sess: &Session,
         // if the linker doesn't support -no-pie then it should not default to
         // linking executables as pie. Different versions of gcc seem to use
         // different quotes in the error message so don't check for them.
-        if (out.contains("unrecognized command line option") ||
+        if sess.target.target.options.linker_is_gnu &&
+           (out.contains("unrecognized command line option") ||
             out.contains("unknown argument")) &&
            out.contains("-no-pie") &&
            cmd.get_args().iter().any(|e| e.to_string_lossy() == "-no-pie") {
@@ -936,7 +937,12 @@ fn link_args(cmd: &mut Linker,
         if position_independent_executable {
             cmd.position_independent_executable();
         } else {
-            cmd.no_position_independent_executable();
+            // recent versions of gcc can be configured to generate position
+            // independent executables by default. We have to pass -no-pie to
+            // explicitly turn that off.
+            if sess.target.target.options.linker_is_gnu {
+                cmd.no_position_independent_executable();
+            }
         }
     }
 

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -668,7 +668,9 @@ fn link_natively(sess: &Session,
         // is safe because if the linker doesn't support -no-pie then it should not
         // default to linking executables as pie. Different versions of gcc seem to
         // use different quotes in the error message so don't check for them.
-        if out.contains("unrecognized command line option") && out.contains("-no-pie") {
+        if out.contains("unrecognized command line option") &&
+           out.contains("-no-pie") &&
+           cmd.get_args().iter().any(|e| e.to_string_lossy() == "-no-pie") {
             info!("linker output: {:?}", out);
             warn!("Linker does not support -no-pie command line option. Retrying without.");
             for arg in cmd.take_args() {

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -664,11 +664,13 @@ fn link_natively(sess: &Session,
         let out = String::from_utf8_lossy(&out);
 
         // Check to see if the link failed with "unrecognized command line option:
-        // '-no-pie'". If so, reperform the link step without the -no-pie option. This
-        // is safe because if the linker doesn't support -no-pie then it should not
-        // default to linking executables as pie. Different versions of gcc seem to
-        // use different quotes in the error message so don't check for them.
-        if out.contains("unrecognized command line option") &&
+        // '-no-pie'" for gcc or "unknown argument: '-no-pie'" for clang. If so,
+        // reperform the link step without the -no-pie option. This is safe because
+        // if the linker doesn't support -no-pie then it should not default to
+        // linking executables as pie. Different versions of gcc seem to use
+        // different quotes in the error message so don't check for them.
+        if (out.contains("unrecognized command line option") ||
+            out.contains("unknown argument")) &&
            out.contains("-no-pie") &&
            cmd.get_args().iter().any(|e| e.to_string_lossy() == "-no-pie") {
             info!("linker output: {:?}", out);

--- a/src/librustc_trans/back/linker.rs
+++ b/src/librustc_trans/back/linker.rs
@@ -105,6 +105,7 @@ pub trait Linker {
     fn add_object(&mut self, path: &Path);
     fn gc_sections(&mut self, keep_metadata: bool);
     fn position_independent_executable(&mut self);
+    fn no_position_independent_executable(&mut self);
     fn partial_relro(&mut self);
     fn full_relro(&mut self);
     fn optimize(&mut self);
@@ -179,6 +180,7 @@ impl<'a> Linker for GccLinker<'a> {
     fn output_filename(&mut self, path: &Path) { self.cmd.arg("-o").arg(path); }
     fn add_object(&mut self, path: &Path) { self.cmd.arg(path); }
     fn position_independent_executable(&mut self) { self.cmd.arg("-pie"); }
+    fn no_position_independent_executable(&mut self) { self.cmd.arg("-no-pie"); }
     fn partial_relro(&mut self) { self.linker_arg("-z,relro"); }
     fn full_relro(&mut self) { self.linker_arg("-z,relro,-z,now"); }
     fn build_static_executable(&mut self) { self.cmd.arg("-static"); }
@@ -439,6 +441,10 @@ impl<'a> Linker for MsvcLinker<'a> {
         // noop
     }
 
+    fn no_position_independent_executable(&mut self) {
+        // noop
+    }
+
     fn partial_relro(&mut self) {
         // noop
     }
@@ -644,6 +650,10 @@ impl<'a> Linker for EmLinker<'a> {
     }
 
     fn position_independent_executable(&mut self) {
+        // noop
+    }
+
+    fn no_position_independent_executable(&mut self) {
         // noop
     }
 


### PR DESCRIPTION
When linking with gcc, run gcc -v to see if --enable-default-pie is
compiled in. If it is, pass -no-pie when necessary to disable pie.
Otherwise, pass -pie when necessary to enable it.

Fixes #48032 and fixes #35061