### PR TITLE
Fix rustllvm compile on LLVM 6

### DIFF
--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -552,9 +552,11 @@ static unsigned fromRust(LLVMRustDIFlags Flags) {
   if (isSet(Flags & LLVMRustDIFlags::FlagRValueReference)) {
     Result |= DINode::DIFlags::FlagRValueReference;
   }
+#if LLVM_VERSION_LE(4, 0)
   if (isSet(Flags & LLVMRustDIFlags::FlagExternalTypeRef)) {
     Result |= DINode::DIFlags::FlagExternalTypeRef;
   }
+#endif
   if (isSet(Flags & LLVMRustDIFlags::FlagIntroducedVirtual)) {
     Result |= DINode::DIFlags::FlagIntroducedVirtual;
   }


### PR DESCRIPTION
This snuck in at the last minute and is otherwise extracted from #47828