### PR TITLE
Don't cross-compile Emscripten's LLVM

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -186,7 +186,7 @@ impl Step for Llvm {
         }
 
         // http://llvm.org/docs/HowToCrossCompileLLVM.html
-        if target != build.build {
+        if target != build.build && !self.emscripten {
             builder.ensure(Llvm {
                 target: build.build,
                 emscripten: false,


### PR DESCRIPTION
Eventually the LLVM version of Emscripten and the main LLVM will diverge, and we
can't cross-compile an older version of LLVM using a newer version of LLVM's
`llvm-config`.

This is extracted from #47828