### PR TITLE
ci: Actually bootstrap on i686 dist

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -31,6 +31,7 @@ use channel;
 use util::{cp_r, libdir, is_dylib, cp_filtered, copy, replace_in_file};
 use builder::{Builder, RunConfig, ShouldRun, Step};
 use compile;
+use native;
 use tool::{self, Tool};
 use cache::{INTERNER, Interned};
 use time;
@@ -898,6 +899,12 @@ impl Step for PlainSourceTarball {
                    .arg("--vers").arg(CARGO_VENDOR_VERSION)
                    .arg("cargo-vendor")
                    .env("RUSTC", &build.initial_rustc);
+                if let Some(dir) = build.openssl_install_dir(build.config.build) {
+                    builder.ensure(native::Openssl {
+                        target: build.config.build,
+                    });
+                    cmd.env("OPENSSL_DIR", dir);
+                }
                 build.run(&mut cmd);
             }
 

--- a/src/ci/docker/dist-i686-linux/Dockerfile
+++ b/src/ci/docker/dist-i686-linux/Dockerfile
@@ -86,7 +86,8 @@ ENV RUST_CONFIGURE_ARGS \
       --enable-extended \
       --enable-sanitizers \
       --enable-profiler \
-      --enable-emscripten
+      --enable-emscripten \
+      --build=i686-unknown-linux-gnu
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
 
 # This is the only builder which will create source tarballs


### PR DESCRIPTION
Right now the `--build` option was accidentally omitted, so we're bootstraping
from `x86_64` to `i686`. In addition to being slower (more compiles) that's not
actually bootstrapping!