### PR TITLE
Implement excluding a build-step via --exclude

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -286,8 +286,7 @@ impl<'a> Builder<'a> {
                 doc::Reference, doc::Rustdoc, doc::RustByExample, doc::CargoBook),
             Kind::Dist => describe!(dist::Docs, dist::Mingw, dist::Rustc, dist::DebuggerScripts,
                 dist::Std, dist::Analysis, dist::Src, dist::PlainSourceTarball, dist::Cargo,
-                dist::Rls, dist::Rustfmt, dist::Extended, dist::HashSign,
-                dist::DontDistWithMiriEnabled),
+                dist::Rls, dist::Rustfmt, dist::Extended, dist::HashSign),
             Kind::Install => describe!(install::Docs, install::Std, install::Cargo, install::Rls,
                 install::Rustfmt, install::Analysis, install::Src, install::Rustc),
         }
@@ -343,6 +342,12 @@ impl<'a> Builder<'a> {
             cache: Cache::new(),
             stack: RefCell::new(Vec::new()),
         };
+
+        if kind == Kind::Dist {
+            assert!(!build.config.test_miri, "Do not distribute with miri enabled.\n\
+                The distributed libraries would include all MIR (increasing binary size).
+                The distributed MIR would include validation statements.");
+        }
 
         StepDescription::run(&Builder::get_step_descriptions(builder.kind), &builder, paths);
     }

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -26,7 +26,7 @@ impl Step for Std {
     const DEFAULT: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
-        run.path("src/libstd").krate("std")
+        run.all_krates("std")
     }
 
     fn make_run(run: RunConfig) {
@@ -67,7 +67,7 @@ impl Step for Rustc {
     const DEFAULT: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
-        run.path("src/librustc").krate("rustc-main")
+        run.all_krates("rustc-main")
     }
 
     fn make_run(run: RunConfig) {
@@ -114,7 +114,7 @@ impl Step for Test {
     const DEFAULT: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
-        run.path("src/libtest").krate("test")
+        run.all_krates("test")
     }
 
     fn make_run(run: RunConfig) {

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -48,7 +48,7 @@ impl Step for Std {
     const DEFAULT: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
-        run.path("src/libstd").krate("std")
+        run.all_krates("std")
     }
 
     fn make_run(run: RunConfig) {
@@ -320,7 +320,7 @@ impl Step for Test {
     const DEFAULT: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
-        run.path("src/libtest").krate("test")
+        run.all_krates("test")
     }
 
     fn make_run(run: RunConfig) {
@@ -436,7 +436,7 @@ impl Step for Rustc {
     const DEFAULT: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
-        run.path("src/librustc").krate("rustc-main")
+        run.all_krates("rustc-main")
     }
 
     fn make_run(run: RunConfig) {
@@ -593,7 +593,7 @@ impl Step for CodegenBackend {
     const DEFAULT: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
-        run.path("src/librustc_trans")
+        run.all_krates("rustc_trans")
     }
 
     fn make_run(run: RunConfig) {
@@ -828,7 +828,7 @@ impl Step for Assemble {
     type Output = Compiler;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
-        run.path("src/rustc")
+        run.all_krates("rustc-main")
     }
 
     /// Prepare a new compiler from the artifacts in `stage`

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -56,6 +56,7 @@ pub struct Config {
     pub sanitizers: bool,
     pub profiler: bool,
     pub ignore_git: bool,
+    pub exclude: Vec<PathBuf>,
 
     pub run_host_only: bool,
 
@@ -311,6 +312,7 @@ impl Config {
         let flags = Flags::parse(&args);
         let file = flags.config.clone();
         let mut config = Config::default();
+        config.exclude = flags.exclude;
         config.llvm_enabled = true;
         config.llvm_optimize = true;
         config.llvm_version_check = true;

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1233,31 +1233,6 @@ impl Step for Rustfmt {
     }
 }
 
-
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub struct DontDistWithMiriEnabled;
-
-impl Step for DontDistWithMiriEnabled {
-    type Output = PathBuf;
-    const DEFAULT: bool = true;
-
-    fn should_run(run: ShouldRun) -> ShouldRun {
-        let build_miri = run.builder.build.config.test_miri;
-        run.default_condition(build_miri)
-    }
-
-    fn make_run(run: RunConfig) {
-        run.builder.ensure(DontDistWithMiriEnabled);
-    }
-
-    fn run(self, _: &Builder) -> PathBuf {
-        panic!("Do not distribute with miri enabled.\n\
-                The distributed libraries would include all MIR (increasing binary size).
-                The distributed MIR would include validation statements.");
-    }
-}
-
-
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Extended {
     stage: u32,

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -429,7 +429,7 @@ impl Step for Std {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.krate("std").default_condition(builder.build.config.docs)
+        run.all_krates("std").default_condition(builder.build.config.docs)
     }
 
     fn make_run(run: RunConfig) {

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -275,7 +275,12 @@ Arguments:
         };
         // Get any optional paths which occur after the subcommand
         let cwd = t!(env::current_dir());
-        let paths = matches.free[1..].iter().map(|p| cwd.join(p)).collect::<Vec<_>>();
+        let src = matches.opt_str("src").map(PathBuf::from)
+            .or_else(|| env::var_os("SRC").map(PathBuf::from))
+            .unwrap_or(cwd.clone());
+        let paths = matches.free[1..].iter().map(|p| {
+            cwd.join(p).strip_prefix(&src).expect("paths passed to be inside checkout").into()
+        }).collect::<Vec<PathBuf>>();
 
         let cfg_file = matches.opt_str("config").map(PathBuf::from).or_else(|| {
             if fs::metadata("config.toml").is_ok() {
@@ -360,10 +365,6 @@ Arguments:
             stage = Some(1);
         }
 
-        let src = matches.opt_str("src").map(PathBuf::from)
-            .or_else(|| env::var_os("SRC").map(PathBuf::from))
-            .unwrap_or(cwd.clone());
-
         Flags {
             verbose: matches.opt_count("verbose"),
             stage,
@@ -375,12 +376,14 @@ Arguments:
             target: split(matches.opt_strs("target"))
                 .into_iter().map(|x| INTERNER.intern_string(x)).collect::<Vec<_>>(),
             config: cfg_file,
-            src,
             jobs: matches.opt_str("jobs").map(|j| j.parse().unwrap()),
             cmd,
             incremental: matches.opt_present("incremental"),
             exclude: split(matches.opt_strs("exclude"))
-                .into_iter().map(|p| cwd.join(p)).collect::<Vec<_>>(),
+                .into_iter().map(|p| {
+                    cwd.join(p).strip_prefix(&src).expect("paths to be inside checkout").into()
+                }).collect::<Vec<_>>(),
+            src,
         }
     }
 }

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -42,6 +42,7 @@ pub struct Flags {
     pub jobs: Option<u32>,
     pub cmd: Subcommand,
     pub incremental: bool,
+    pub exclude: Vec<PathBuf>,
 }
 
 pub enum Subcommand {
@@ -109,6 +110,7 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`");
         opts.optopt("", "build", "build target of the stage0 compiler", "BUILD");
         opts.optmulti("", "host", "host targets to build", "HOST");
         opts.optmulti("", "target", "target targets to build", "TARGET");
+        opts.optmulti("", "exclude", "build paths to exclude", "PATH");
         opts.optopt("", "on-fail", "command to run on failure", "CMD");
         opts.optopt("", "stage", "stage to build", "N");
         opts.optopt("", "keep-stage", "stage to keep without recompiling", "N");
@@ -358,10 +360,9 @@ Arguments:
             stage = Some(1);
         }
 
-        let cwd = t!(env::current_dir());
         let src = matches.opt_str("src").map(PathBuf::from)
             .or_else(|| env::var_os("SRC").map(PathBuf::from))
-            .unwrap_or(cwd);
+            .unwrap_or(cwd.clone());
 
         Flags {
             verbose: matches.opt_count("verbose"),
@@ -378,6 +379,8 @@ Arguments:
             jobs: matches.opt_str("jobs").map(|j| j.parse().unwrap()),
             cmd,
             incremental: matches.opt_present("incremental"),
+            exclude: split(matches.opt_strs("exclude"))
+                .into_iter().map(|p| cwd.join(p)).collect::<Vec<_>>(),
         }
     }
 }

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -51,9 +51,7 @@ impl Step for Llvm {
     }
 
     fn make_run(run: RunConfig) {
-        let emscripten = run.path.map(|p| {
-            p.ends_with("llvm-emscripten")
-        }).unwrap_or(false);
+        let emscripten = run.path.ends_with("llvm-emscripten");
         run.builder.ensure(Llvm {
             target: run.target,
             emscripten,


### PR DESCRIPTION
First step to fixing https://github.com/rust-lang/rust/issues/47911. This doesn't change any CI configuration, but implements what I believe necessary to make that feasible in rustbuild.

In theory this should be sufficient to allow someone to open a PR against .travis.yml and appveyor.yml which splits the Windows 32-bit tests and maybe the OS X tests into multiple builders (depending on what our cost-concerns are) to reduce runtimes.

r? @alexcrichton 
cc @kennytm 