### PR TITLE
Upgrade the Travis CI macOS images for testing from Xcode 8.3 to 9.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
         NO_LLVM_ASSERTIONS=1
         NO_DEBUG_ASSERTIONS=1
       os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9.2
       if: branch = auto
 
     - env: >
@@ -70,7 +70,7 @@ matrix:
         NO_LLVM_ASSERTIONS=1
         NO_DEBUG_ASSERTIONS=1
       os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9.2
       if: branch = auto
 
     # OSX builders producing releases. These do not run the full test suite and


### PR DESCRIPTION
Retry of #47749, since LLVM 6 has been merged.