### PR TITLE
fix typos in src/{bootstrap,ci,etc,lib{backtrace,core,fmt_macros}}

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -570,7 +570,7 @@ impl<'a> Builder<'a> {
         // build scripts in that situation.
         //
         // If LLVM support is disabled we need to use the snapshot compiler to compile
-        // build scripts, as the new compiler doesnt support executables.
+        // build scripts, as the new compiler doesn't support executables.
         if mode == Mode::Libstd || !self.build.config.llvm_enabled {
             cargo.env("RUSTC_SNAPSHOT", &self.initial_rustc)
                  .env("RUSTC_SNAPSHOT_LIBDIR", self.rustc_snapshot_libdir());

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -666,7 +666,7 @@ impl Build {
         }
     }
 
-    /// Returns the path to the linker for the given target if it needs to be overriden.
+    /// Returns the path to the linker for the given target if it needs to be overridden.
     fn linker(&self, target: Interned<String>) -> Option<&Path> {
         if let Some(linker) = self.config.target_config.get(&target)
                                                        .and_then(|c| c.linker.as_ref()) {

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -902,7 +902,7 @@ impl Step for Compiletest {
             }
         }
         if suite == "run-make" && !build.config.llvm_enabled {
-            println!("Ignoring run-make test suite as they generally dont work without LLVM");
+            println!("Ignoring run-make test suite as they generally don't work without LLVM");
             return;
         }
 

--- a/src/ci/docker/dist-x86_64-netbsd/build-netbsd-toolchain.sh
+++ b/src/ci/docker/dist-x86_64-netbsd/build-netbsd-toolchain.sh
@@ -54,7 +54,7 @@ cd usr/src
 # The options, in order, do the following
 # * this is an unprivileged build
 # * output to a predictable location
-# * disable various uneeded stuff
+# * disable various unneeded stuff
 MKUNPRIVED=yes TOOLDIR=/x-tools/x86_64-unknown-netbsd \
 MKSHARE=no MKDOC=no MKHTML=no MKINFO=no MKKMOD=no MKLINT=no MKMAN=no MKNLS=no MKPROFILE=no \
 hide_output ./build.sh -j10 -m amd64 tools

--- a/src/etc/installer/msi/rust.wxs
+++ b/src/etc/installer/msi/rust.wxs
@@ -18,7 +18,7 @@
     <!-- Upgrade code should be different for each platform -->
     <?if $(sys.BUILDARCH)="x64" ?>
         <?if $(env.CFG_ABI)="GNU" ?>
-            <!-- UpgradeCode shoud stay the same for all MSI versions in channel -->
+            <!-- UpgradeCode should stay the same for all MSI versions in channel -->
             <?if $(env.CFG_CHANNEL)="stable" ?>
                 <?define UpgradeCode="B440B077-F8D1-4730-8E1D-D6D37702B4CE" ?>
             <?elseif $(env.CFG_CHANNEL)="beta" ?>
@@ -129,7 +129,7 @@
 
         <!-- Path of cmd.exe for the shortcut -->
         <Property Id="SHORTCUTTARGET" Value="%windir%\System32\cmd.exe" />
-        <!-- Microsoft Installer will resolve any Enviroment Variables in the working directory at install time -->
+        <!-- Microsoft Installer will resolve any Environment Variables in the working directory at install time -->
         <Property Id="SHORTCUTWKDIR" Value="%SystemDrive%\" />
 
         <InstallUISequence>

--- a/src/etc/platform-intrinsics/generator.py
+++ b/src/etc/platform-intrinsics/generator.py
@@ -591,7 +591,7 @@ def parse_args():
         The X86 architecture is specified as multiple files (for the different
         instruction sets that x86 supports). To generate the compiler
         definitions one needs to pass the script a "platform information file"
-        (with the -i flag) next to the files of the different intruction sets.
+        (with the -i flag) next to the files of the different instruction sets.
         For example, to generate the X86 compiler-definitions for SSE4.2, just:
 
         python generator.py --format compiler-defs -i x86/info.json sse42.json

--- a/src/etc/test-float-parse/runtests.py
+++ b/src/etc/test-float-parse/runtests.py
@@ -41,7 +41,7 @@ Instead, we take the input and compute the true value with bignum arithmetic
 (as a fraction, using the ``fractions`` module).
 
 Given an input string and the corresponding float computed via Rust, simply
-decode the float into f * 2^k (for intergers f, k) and the ULP.
+decode the float into f * 2^k (for integers f, k) and the ULP.
 We can now easily compute the error and check if it is within 0.5 ULP as it
 should be. Zero and infinites are handled similarly:
 

--- a/src/libbacktrace/ltmain.sh
+++ b/src/libbacktrace/ltmain.sh
@@ -487,7 +487,7 @@ func_mkdir_p ()
       # While some portion of DIR does not yet exist...
       while test ! -d "$my_directory_path"; do
         # ...make a list in topmost first order.  Use a colon delimited
-	# list incase some portion of path contains whitespace.
+	# list in case some portion of path contains whitespace.
         my_dir_list="$my_directory_path:$my_dir_list"
 
         # If the last portion added has no slash in it, the list is done

--- a/src/libbacktrace/macho.c
+++ b/src/libbacktrace/macho.c
@@ -327,7 +327,7 @@ macho_get_commands (struct backtrace_state *state, int descriptor,
         goto end;
       file_header_view_valid = 1;
 
-      // The endianess of the slice may be different than the fat image
+      // The endianness of the slice may be different than the fat image
       switch (*(uint32_t *) file_header_view.data)
         {
           case MH_MAGIC:

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -327,7 +327,7 @@ macro_rules! debug_assert_ne {
 ///     }
 /// }
 ///
-/// // The prefered method of quick returning Errors
+/// // The preferred method of quick returning Errors
 /// fn write_to_file_question() -> Result<(), MyError> {
 ///     let mut file = File::create("my_best_friends.txt")?;
 ///     file.write_all(b"This is a list of my best friends.")?;

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -73,7 +73,7 @@ pub struct FormatSpec<'a> {
 /// Enum describing where an argument for a format can be located.
 #[derive(Copy, Clone, PartialEq)]
 pub enum Position<'a> {
-    /// The arugment is implied to be located at an index
+    /// The argument is implied to be located at an index
     ArgumentImplicitlyIs(usize),
     /// The argument is located at a specific index given in the format
     ArgumentIs(usize),


### PR DESCRIPTION
via codespell