### PR TITLE
Correct a few stability attributes

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -2881,7 +2881,7 @@ pub enum FpCategory {
            issue = "32110")]
 pub trait Float: Sized {
     /// Type used by `to_bits` and `from_bits`.
-    #[stable(feature = "core_float_bits", since = "1.24.0")]
+    #[stable(feature = "core_float_bits", since = "1.25.0")]
     type Bits;
 
     /// Returns `true` if this value is NaN and false otherwise.
@@ -2947,10 +2947,10 @@ pub trait Float: Sized {
     fn min(self, other: Self) -> Self;
 
     /// Raw transmutation to integer.
-    #[stable(feature = "core_float_bits", since="1.24.0")]
+    #[stable(feature = "core_float_bits", since="1.25.0")]
     fn to_bits(self) -> Self::Bits;
     /// Raw transmutation from integer.
-    #[stable(feature = "core_float_bits", since="1.24.0")]
+    #[stable(feature = "core_float_bits", since="1.25.0")]
     fn from_bits(v: Self::Bits) -> Self;
 }
 

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2573,7 +2573,7 @@ impl<T: ?Sized> Clone for NonNull<T> {
 #[stable(feature = "nonnull", since = "1.25.0")]
 impl<T: ?Sized> Copy for NonNull<T> { }
 
-#[stable(feature = "nonnull", since = "1.25.0")]
+#[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: ?Sized, U: ?Sized> CoerceUnsized<NonNull<U>> for NonNull<T> where T: Unsize<U> { }
 
 #[stable(feature = "nonnull", since = "1.25.0")]
@@ -2621,7 +2621,7 @@ impl<T: ?Sized> hash::Hash for NonNull<T> {
     }
 }
 
-#[stable(feature = "nonnull", since = "1.25.0")]
+#[unstable(feature = "ptr_internals", issue = "0")]
 impl<T: ?Sized> From<Unique<T>> for NonNull<T> {
     fn from(unique: Unique<T>) -> Self {
         NonNull { pointer: unique.pointer }

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -7,7 +7,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![stable(feature = "duration_core", since = "1.24.0")]
+#![stable(feature = "duration_core", since = "1.25.0")]
 
 //! Temporal quantification.
 //!
@@ -58,7 +58,7 @@ const MICROS_PER_SEC: u64 = 1_000_000;
 ///
 /// let ten_millis = Duration::from_millis(10);
 /// ```
-#[stable(feature = "duration_core", since = "1.24.0")]
+#[stable(feature = "duration", since = "1.3.0")]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Default)]
 pub struct Duration {
     secs: u64,

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -296,7 +296,7 @@ impl<'a> Write for Cursor<&'a mut [u8]> {
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }
 
-#[unstable(feature = "cursor_mut_vec", issue = "30132")]
+#[stable(feature = "cursor_mut_vec", since = "1.25.0")]
 impl<'a> Write for Cursor<&'a mut Vec<u8>> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         vec_write(&mut self.pos, self.inner, buf)

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -576,7 +576,7 @@ impl<'a> AsRef<OsStr> for Component<'a> {
     }
 }
 
-#[stable(feature = "path_component_asref", since = "1.24.0")]
+#[stable(feature = "path_component_asref", since = "1.25.0")]
 impl<'a> AsRef<Path> for Component<'a> {
     fn as_ref(&self) -> &Path {
         self.as_os_str().as_ref()

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -538,7 +538,7 @@ declare_features! (
     // instead of just the platforms on which it is the C ABI
     (accepted, abi_sysv64, "1.24.0", Some(36167)),
     // Allows `repr(align(16))` struct attribute (RFC 1358)
-    (accepted, repr_align, "1.24.0", Some(33626)),
+    (accepted, repr_align, "1.25.0", Some(33626)),
     // allow '|' at beginning of match arms (RFC 1925)
     (accepted, match_beginning_vert, "1.25.0", Some(44101)),
     // Nested groups in `use` (RFC 2128)


### PR DESCRIPTION
* `core_float_bits`, `duration_core`, `path_component_asref`, and `repr_align` were stabalized in 1.25.0 not 1.24.0.
* Impls for `NonNull` involving unstable things should remain unstable.
* `Duration` should remain stable since 1.3.0 so it appears correctly in the `std` docs.
* `cursor_mut_vec` is an impl on only stable things so should be marked stable.