### PR TITLE
Reword E0044 and message for `!Send` types

### DIFF
--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -344,6 +344,14 @@ pub trait Copy : Clone {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[lang = "sync"]
 #[rustc_on_unimplemented(
+    on(
+        _Self="std::sync::mpsc::Receiver<T>",
+        label="`{Self}` cannot be shared safely, if using a closure consider marking it `move`"
+    ),
+    on(
+        _Self="std::sync::mpsc::Sender<T>",
+        label="`{Self}` cannot be shared safely, if using a closure consider marking it `move`"
+    ),
     message="`{Self}` cannot be shared between threads safely",
     label="`{Self}` cannot be shared between threads safely"
 )]

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -344,18 +344,20 @@ pub trait Copy : Clone {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[lang = "sync"]
 #[rustc_on_unimplemented(
-    on(
-        _Self="std::sync::mpsc::Receiver<T>",
-        label="`{Self}` cannot be shared safely, consider marking the closure `move`"
-    ),
-    on(
-        _Self="std::sync::mpsc::Sender<T>",
-        label="`{Self}` cannot be shared safely, consider marking the closure `move`"
-    ),
     message="`{Self}` cannot be shared between threads safely",
     label="`{Self}` cannot be shared between threads safely"
 )]
 pub unsafe auto trait Sync {
+    // FIXME(estebank): once support to add notes in `rustc_on_unimplemented`
+    // lands in beta, and it has been extended to check whether a closure is
+    // anywhere in the requirement chain, extend it as such (#48534):
+    // ```
+    // on(
+    //     closure,
+    //     note="`{Self}` cannot be shared safely, consider marking the closure `move`"
+    // ),
+    // ```
+
     // Empty
 }
 

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -346,11 +346,11 @@ pub trait Copy : Clone {
 #[rustc_on_unimplemented(
     on(
         _Self="std::sync::mpsc::Receiver<T>",
-        label="`{Self}` cannot be shared safely, if using a closure consider marking it `move`"
+        label="`{Self}` cannot be shared safely, consider marking the closure `move`"
     ),
     on(
         _Self="std::sync::mpsc::Sender<T>",
-        label="`{Self}` cannot be shared safely, if using a closure consider marking it `move`"
+        label="`{Self}` cannot be shared safely, consider marking the closure `move`"
     ),
     message="`{Self}` cannot be shared between threads safely",
     label="`{Self}` cannot be shared between threads safely"

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -343,7 +343,10 @@ pub trait Copy : Clone {
 /// [transmute]: ../../std/mem/fn.transmute.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[lang = "sync"]
-#[rustc_on_unimplemented = "`{Self}` cannot be shared between threads safely"]
+#[rustc_on_unimplemented(
+    message="`{Self}` cannot be shared between threads safely",
+    label="`{Self}` cannot be shared between threads safely"
+)]
 pub unsafe auto trait Sync {
     // Empty
 }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1222,9 +1222,10 @@ pub fn check_item_type<'a,'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, it: &'tcx hir::Item
                 if !generics.types.is_empty() {
                     let mut err = struct_span_err!(tcx.sess, item.span, E0044,
                         "foreign items may not have type parameters");
-                    span_help!(&mut err, item.span,
-                        "consider using specialization instead of \
-                        type parameters");
+                    // FIXME: once we start storing spans for type arguments, turn this into a
+                    // suggestion.
+                    err.help("use specialization instead of type parameters by replacing them \
+                              with concrete types like `u32`");
                     err.emit();
                 }
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1222,6 +1222,7 @@ pub fn check_item_type<'a,'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, it: &'tcx hir::Item
                 if !generics.types.is_empty() {
                     let mut err = struct_span_err!(tcx.sess, item.span, E0044,
                         "foreign items may not have type parameters");
+                    err.span_label(item.span, "can't have type parameters");
                     // FIXME: once we start storing spans for type arguments, turn this into a
                     // suggestion.
                     err.help("use specialization instead of type parameters by replacing them \

--- a/src/test/compile-fail/builtin-superkinds-double-superkind.rs
+++ b/src/test/compile-fail/builtin-superkinds-double-superkind.rs
@@ -13,9 +13,11 @@
 
 trait Foo : Send+Sync { }
 
-impl <T: Sync+'static> Foo for (T,) { } //~ ERROR `T: std::marker::Send` is not satisfied
+impl <T: Sync+'static> Foo for (T,) { }
+//~^ ERROR the trait bound `T: std::marker::Send` is not satisfied in `(T,)` [E0277]
 
-impl <T: Send> Foo for (T,T) { } //~ ERROR `T: std::marker::Sync` is not satisfied
+impl <T: Send> Foo for (T,T) { }
+//~^ ERROR `T` cannot be shared between threads safely [E0277]
 
 impl <T: Send+Sync> Foo for (T,T,T) { } // (ok)
 

--- a/src/test/compile-fail/closure-bounds-subtype.rs
+++ b/src/test/compile-fail/closure-bounds-subtype.rs
@@ -21,7 +21,7 @@ fn give_any<F>(f: F) where F: FnOnce() {
 
 fn give_owned<F>(f: F) where F: FnOnce() + Send {
     take_any(f);
-    take_const_owned(f); //~ ERROR `F: std::marker::Sync` is not satisfied
+    take_const_owned(f); //~ ERROR `F` cannot be shared between threads safely [E0277]
 }
 
 fn main() {}

--- a/src/test/compile-fail/extern-types-not-sync-send.rs
+++ b/src/test/compile-fail/extern-types-not-sync-send.rs
@@ -21,7 +21,7 @@ fn assert_send<T: ?Sized + Send>() { }
 
 fn main() {
     assert_sync::<A>();
-    //~^ ERROR the trait bound `A: std::marker::Sync` is not satisfied
+    //~^ ERROR `A` cannot be shared between threads safely [E0277]
 
     assert_send::<A>();
     //~^ ERROR the trait bound `A: std::marker::Send` is not satisfied

--- a/src/test/compile-fail/issue-16538.rs
+++ b/src/test/compile-fail/issue-16538.rs
@@ -21,7 +21,7 @@ mod Y {
 }
 
 static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
-//~^ ERROR `*const usize: std::marker::Sync` is not satisfied
+//~^ ERROR `*const usize` cannot be shared between threads safely [E0277]
 //~| ERROR cannot refer to other statics by value, use the address-of operator or a constant instead
 //~| ERROR E0015
 

--- a/src/test/compile-fail/issue-17718-static-sync.rs
+++ b/src/test/compile-fail/issue-17718-static-sync.rs
@@ -17,6 +17,6 @@ impl !Sync for Foo {}
 
 static FOO: usize = 3;
 static BAR: Foo = Foo;
-//~^ ERROR: `Foo: std::marker::Sync` is not satisfied
+//~^ ERROR: `Foo` cannot be shared between threads safely [E0277]
 
 fn main() {}

--- a/src/test/compile-fail/issue-43733-2.rs
+++ b/src/test/compile-fail/issue-43733-2.rs
@@ -33,7 +33,7 @@ impl<T> Key<T> {
 use std::thread::__FastLocalKeyInner as Key;
 
 static __KEY: Key<()> = Key::new();
-//~^ ERROR `std::cell::UnsafeCell<std::option::Option<()>>: std::marker::Sync` is not satisfied
-//~| ERROR `std::cell::Cell<bool>: std::marker::Sync` is not satisfied
+//~^ ERROR `std::cell::UnsafeCell<std::option::Option<()>>` cannot be shared between threads
+//~| ERROR `std::cell::Cell<bool>` cannot be shared between threads safely [E0277]
 
 fn main() {}

--- a/src/test/compile-fail/issue-7364.rs
+++ b/src/test/compile-fail/issue-7364.rs
@@ -15,6 +15,6 @@ use std::cell::RefCell;
 // Regression test for issue 7364
 static boxed: Box<RefCell<isize>> = box RefCell::new(0);
 //~^ ERROR allocations are not allowed in statics
-//~| ERROR `std::cell::RefCell<isize>: std::marker::Sync` is not satisfied
+//~| ERROR `std::cell::RefCell<isize>` cannot be shared between threads safely [E0277]
 
 fn main() { }

--- a/src/test/compile-fail/kindck-send-object.rs
+++ b/src/test/compile-fail/kindck-send-object.rs
@@ -20,7 +20,7 @@ trait Message : Send { }
 
 fn object_ref_with_static_bound_not_ok() {
     assert_send::<&'static (Dummy+'static)>();
-    //~^ ERROR : std::marker::Sync` is not satisfied
+    //~^ ERROR `Dummy + 'static` cannot be shared between threads safely [E0277]
 }
 
 fn box_object_with_no_bound_not_ok<'a>() {

--- a/src/test/compile-fail/kindck-send-object1.rs
+++ b/src/test/compile-fail/kindck-send-object1.rs
@@ -18,7 +18,7 @@ trait Dummy { }
 // careful with object types, who knows what they close over...
 fn test51<'a>() {
     assert_send::<&'a Dummy>();
-    //~^ ERROR : std::marker::Sync` is not satisfied
+    //~^ ERROR `Dummy + 'a` cannot be shared between threads safely [E0277]
 }
 fn test52<'a>() {
     assert_send::<&'a (Dummy+Sync)>();

--- a/src/test/compile-fail/kindck-send-object2.rs
+++ b/src/test/compile-fail/kindck-send-object2.rs
@@ -14,7 +14,8 @@ fn assert_send<T:Send>() { }
 trait Dummy { }
 
 fn test50() {
-    assert_send::<&'static Dummy>(); //~ ERROR : std::marker::Sync` is not satisfied
+    assert_send::<&'static Dummy>();
+    //~^ ERROR `Dummy + 'static` cannot be shared between threads safely [E0277]
 }
 
 fn test53() {

--- a/src/test/compile-fail/mutable-enum-indirect.rs
+++ b/src/test/compile-fail/mutable-enum-indirect.rs
@@ -24,5 +24,6 @@ fn bar<T: Sync>(_: T) {}
 
 fn main() {
     let x = Foo::A(NoSync);
-    bar(&x); //~ ERROR `NoSync: std::marker::Sync` is not satisfied
+    bar(&x);
+    //~^ ERROR `NoSync` cannot be shared between threads safely [E0277]
 }

--- a/src/test/compile-fail/mutexguard-sync.rs
+++ b/src/test/compile-fail/mutexguard-sync.rs
@@ -18,5 +18,6 @@ fn main()
 {
     let m = Mutex::new(Cell::new(0i32));
     let guard = m.lock().unwrap();
-    test_sync(guard); //~ ERROR the trait bound
+    test_sync(guard);
+    //~^ ERROR `std::cell::Cell<i32>` cannot be shared between threads safely [E0277]
 }

--- a/src/test/compile-fail/no_share-enum.rs
+++ b/src/test/compile-fail/no_share-enum.rs
@@ -22,5 +22,5 @@ fn bar<T: Sync>(_: T) {}
 fn main() {
     let x = Foo::A(NoSync);
     bar(x);
-    //~^ ERROR `NoSync: std::marker::Sync` is not satisfied
+    //~^ ERROR `NoSync` cannot be shared between threads safely [E0277]
 }

--- a/src/test/compile-fail/no_share-struct.rs
+++ b/src/test/compile-fail/no_share-struct.rs
@@ -20,5 +20,5 @@ fn bar<T: Sync>(_: T) {}
 fn main() {
     let x = Foo { a: 5 };
     bar(x);
-    //~^ ERROR `Foo: std::marker::Sync` is not satisfied
+    //~^ ERROR `Foo` cannot be shared between threads safely [E0277]
 }

--- a/src/test/compile-fail/not-sync.rs
+++ b/src/test/compile-fail/not-sync.rs
@@ -16,17 +16,17 @@ fn test<T: Sync>() {}
 
 fn main() {
     test::<Cell<i32>>();
-    //~^ ERROR `std::cell::Cell<i32>: std::marker::Sync` is not satisfied
+    //~^ ERROR `std::cell::Cell<i32>` cannot be shared between threads safely [E0277]
     test::<RefCell<i32>>();
-    //~^ ERROR `std::cell::RefCell<i32>: std::marker::Sync` is not satisfied
+    //~^ ERROR `std::cell::RefCell<i32>` cannot be shared between threads safely [E0277]
 
     test::<Rc<i32>>();
-    //~^ ERROR `std::rc::Rc<i32>: std::marker::Sync` is not satisfied
+    //~^ ERROR `std::rc::Rc<i32>` cannot be shared between threads safely [E0277]
     test::<Weak<i32>>();
-    //~^ ERROR `std::rc::Weak<i32>: std::marker::Sync` is not satisfied
+    //~^ ERROR `std::rc::Weak<i32>` cannot be shared between threads safely [E0277]
 
     test::<Receiver<i32>>();
-    //~^ ERROR `std::sync::mpsc::Receiver<i32>: std::marker::Sync` is not satisfied
+    //~^ ERROR `std::sync::mpsc::Receiver<i32>` cannot be shared between threads safely [E0277]
     test::<Sender<i32>>();
-    //~^ ERROR `std::sync::mpsc::Sender<i32>: std::marker::Sync` is not satisfied
+    //~^ ERROR `std::sync::mpsc::Sender<i32>` cannot be shared between threads safely [E0277]
 }

--- a/src/test/compile-fail/phantom-oibit.rs
+++ b/src/test/compile-fail/phantom-oibit.rs
@@ -28,11 +28,13 @@ struct Nested<T>(T);
 fn is_zen<T: Zen>(_: T) {}
 
 fn not_sync<T>(x: Guard<T>) {
-    is_zen(x)  //~ error: `T: std::marker::Sync` is not satisfied
+    is_zen(x)
+    //~^ ERROR `T` cannot be shared between threads safely [E0277]
 }
 
 fn nested_not_sync<T>(x: Nested<Guard<T>>) {
-    is_zen(x)  //~ error: `T: std::marker::Sync` is not satisfied
+    is_zen(x)
+    //~^ ERROR `T` cannot be shared between threads safely [E0277]
 }
 
 fn main() {}

--- a/src/test/compile-fail/typeck-default-trait-impl-negation-sync.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-negation-sync.rs
@@ -43,11 +43,11 @@ fn is_sync<T: Sync>() {}
 fn main() {
     is_sync::<MySync>();
     is_sync::<MyNotSync>();
-    //~^ ERROR `MyNotSync: std::marker::Sync` is not satisfied
+    //~^ ERROR `MyNotSync` cannot be shared between threads safely [E0277]
 
     is_sync::<MyTypeWUnsafe>();
-    //~^ ERROR `std::cell::UnsafeCell<u8>: std::marker::Sync` is not satisfied
+    //~^ ERROR `std::cell::UnsafeCell<u8>` cannot be shared between threads safely [E0277]
 
     is_sync::<MyTypeManaged>();
-    //~^ ERROR `Managed: std::marker::Sync` is not satisfied
+    //~^ ERROR `Managed` cannot be shared between threads safely [E0277]
 }

--- a/src/test/compile-fail/typeck-unsafe-always-share.rs
+++ b/src/test/compile-fail/typeck-unsafe-always-share.rs
@@ -27,16 +27,16 @@ fn test<T: Sync>(s: T) {}
 fn main() {
     let us = UnsafeCell::new(MySync{u: UnsafeCell::new(0)});
     test(us);
-    //~^ ERROR `std::cell::UnsafeCell<MySync<{integer}>>: std::marker::Sync` is not satisfied
+    //~^ ERROR `std::cell::UnsafeCell<MySync<{integer}>>` cannot be shared between threads safely
 
     let uns = UnsafeCell::new(NoSync);
     test(uns);
-    //~^ ERROR `std::cell::UnsafeCell<NoSync>: std::marker::Sync` is not satisfied
+    //~^ ERROR `std::cell::UnsafeCell<NoSync>` cannot be shared between threads safely [E0277]
 
     let ms = MySync{u: uns};
     test(ms);
-    //~^ ERROR `std::cell::UnsafeCell<NoSync>: std::marker::Sync` is not satisfied
+    //~^ ERROR `std::cell::UnsafeCell<NoSync>` cannot be shared between threads safely [E0277]
 
     test(NoSync);
-    //~^ ERROR `NoSync: std::marker::Sync` is not satisfied
+    //~^ ERROR `NoSync` cannot be shared between threads safely [E0277]
 }

--- a/src/test/ui/closure-move-sync.rs
+++ b/src/test/ui/closure-move-sync.rs
@@ -1,0 +1,32 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::thread;
+use std::sync::mpsc::channel;
+
+fn bar() {
+    let (send, recv) = channel();
+    let t = thread::spawn(|| {
+        recv.recv().unwrap();
+        //~^^ ERROR `std::sync::mpsc::Receiver<()>` cannot be shared between threads safely
+    });
+
+    send.send(());
+
+    t.join().unwrap();
+}
+
+fn foo() {
+    let (tx, _rx) = channel();
+    thread::spawn(|| tx.send(()).unwrap());
+    //~^ ERROR `std::sync::mpsc::Sender<()>` cannot be shared between threads safely
+}
+
+fn main() {}

--- a/src/test/ui/closure-move-sync.stderr
+++ b/src/test/ui/closure-move-sync.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::sync::mpsc::Receiver<()>` cannot be shared between threads s
   --> $DIR/closure-move-sync.rs:16:13
    |
 16 |     let t = thread::spawn(|| {
-   |             ^^^^^^^^^^^^^ `std::sync::mpsc::Receiver<()>` cannot be shared safely, if using a closure consider marking it `move`
+   |             ^^^^^^^^^^^^^ `std::sync::mpsc::Receiver<()>` cannot be shared safely, consider marking the closure `move`
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::sync::mpsc::Receiver<()>`
    = note: required because of the requirements on the impl of `std::marker::Send` for `&std::sync::mpsc::Receiver<()>`
@@ -13,7 +13,7 @@ error[E0277]: `std::sync::mpsc::Sender<()>` cannot be shared between threads saf
   --> $DIR/closure-move-sync.rs:28:5
    |
 28 |     thread::spawn(|| tx.send(()).unwrap());
-   |     ^^^^^^^^^^^^^ `std::sync::mpsc::Sender<()>` cannot be shared safely, if using a closure consider marking it `move`
+   |     ^^^^^^^^^^^^^ `std::sync::mpsc::Sender<()>` cannot be shared safely, consider marking the closure `move`
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::sync::mpsc::Sender<()>`
    = note: required because of the requirements on the impl of `std::marker::Send` for `&std::sync::mpsc::Sender<()>`

--- a/src/test/ui/closure-move-sync.stderr
+++ b/src/test/ui/closure-move-sync.stderr
@@ -22,4 +22,4 @@ LL |     thread::spawn(|| tx.send(()).unwrap());
 
 error: aborting due to 2 previous errors
 
-If you want more information on this error, try using "rustc --explain E0277"
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/closure-move-sync.stderr
+++ b/src/test/ui/closure-move-sync.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `std::sync::mpsc::Receiver<()>` cannot be shared between threads safely
   --> $DIR/closure-move-sync.rs:16:13
    |
-16 |     let t = thread::spawn(|| {
-   |             ^^^^^^^^^^^^^ `std::sync::mpsc::Receiver<()>` cannot be shared safely, consider marking the closure `move`
+LL |     let t = thread::spawn(|| {
+   |             ^^^^^^^^^^^^^ `std::sync::mpsc::Receiver<()>` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::sync::mpsc::Receiver<()>`
    = note: required because of the requirements on the impl of `std::marker::Send` for `&std::sync::mpsc::Receiver<()>`
@@ -12,8 +12,8 @@ error[E0277]: `std::sync::mpsc::Receiver<()>` cannot be shared between threads s
 error[E0277]: `std::sync::mpsc::Sender<()>` cannot be shared between threads safely
   --> $DIR/closure-move-sync.rs:28:5
    |
-28 |     thread::spawn(|| tx.send(()).unwrap());
-   |     ^^^^^^^^^^^^^ `std::sync::mpsc::Sender<()>` cannot be shared safely, consider marking the closure `move`
+LL |     thread::spawn(|| tx.send(()).unwrap());
+   |     ^^^^^^^^^^^^^ `std::sync::mpsc::Sender<()>` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::sync::mpsc::Sender<()>`
    = note: required because of the requirements on the impl of `std::marker::Send` for `&std::sync::mpsc::Sender<()>`
@@ -22,3 +22,4 @@ error[E0277]: `std::sync::mpsc::Sender<()>` cannot be shared between threads saf
 
 error: aborting due to 2 previous errors
 
+If you want more information on this error, try using "rustc --explain E0277"

--- a/src/test/ui/closure-move-sync.stderr
+++ b/src/test/ui/closure-move-sync.stderr
@@ -1,0 +1,24 @@
+error[E0277]: `std::sync::mpsc::Receiver<()>` cannot be shared between threads safely
+  --> $DIR/closure-move-sync.rs:16:13
+   |
+16 |     let t = thread::spawn(|| {
+   |             ^^^^^^^^^^^^^ `std::sync::mpsc::Receiver<()>` cannot be shared safely, if using a closure consider marking it `move`
+   |
+   = help: the trait `std::marker::Sync` is not implemented for `std::sync::mpsc::Receiver<()>`
+   = note: required because of the requirements on the impl of `std::marker::Send` for `&std::sync::mpsc::Receiver<()>`
+   = note: required because it appears within the type `[closure@$DIR/closure-move-sync.rs:16:27: 19:6 recv:&std::sync::mpsc::Receiver<()>]`
+   = note: required by `std::thread::spawn`
+
+error[E0277]: `std::sync::mpsc::Sender<()>` cannot be shared between threads safely
+  --> $DIR/closure-move-sync.rs:28:5
+   |
+28 |     thread::spawn(|| tx.send(()).unwrap());
+   |     ^^^^^^^^^^^^^ `std::sync::mpsc::Sender<()>` cannot be shared safely, if using a closure consider marking it `move`
+   |
+   = help: the trait `std::marker::Sync` is not implemented for `std::sync::mpsc::Sender<()>`
+   = note: required because of the requirements on the impl of `std::marker::Send` for `&std::sync::mpsc::Sender<()>`
+   = note: required because it appears within the type `[closure@$DIR/closure-move-sync.rs:28:19: 28:42 tx:&std::sync::mpsc::Sender<()>]`
+   = note: required by `std::thread::spawn`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/error-codes/E0044.rs
+++ b/src/test/ui/error-codes/E0044.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,7 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern { fn some_func<T>(x: T); } //~ ERROR E0044
+extern {
+    fn sqrt<T>(f: T) -> T;
+    //~^ ERROR foreign items may not have type parameters [E0044]
+    //~| HELP use specialization instead of type parameters by replacing them with concrete types
+}
 
 fn main() {
 }

--- a/src/test/ui/error-codes/E0044.rs
+++ b/src/test/ui/error-codes/E0044.rs
@@ -12,6 +12,7 @@ extern {
     fn sqrt<T>(f: T) -> T;
     //~^ ERROR foreign items may not have type parameters [E0044]
     //~| HELP use specialization instead of type parameters by replacing them with concrete types
+    //~| NOTE can't have type parameters
 }
 
 fn main() {

--- a/src/test/ui/error-codes/E0044.stderr
+++ b/src/test/ui/error-codes/E0044.stderr
@@ -1,14 +1,10 @@
 error[E0044]: foreign items may not have type parameters
-  --> $DIR/E0044.rs:11:10
+  --> $DIR/E0044.rs:12:5
    |
-LL | extern { fn some_func<T>(x: T); } //~ ERROR E0044
-   |          ^^^^^^^^^^^^^^^^^^^^^^
+LL |     fn sqrt<T>(f: T) -> T;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-help: consider using specialization instead of type parameters
-  --> $DIR/E0044.rs:11:10
-   |
-LL | extern { fn some_func<T>(x: T); } //~ ERROR E0044
-   |          ^^^^^^^^^^^^^^^^^^^^^^
+   = help: use specialization instead of type parameters by replacing them with concrete types like `u32`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0044.stderr
+++ b/src/test/ui/error-codes/E0044.stderr
@@ -2,7 +2,7 @@ error[E0044]: foreign items may not have type parameters
   --> $DIR/E0044.rs:12:5
    |
 LL |     fn sqrt<T>(f: T) -> T;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^ can't have type parameters
    |
    = help: use specialization instead of type parameters by replacing them with concrete types like `u32`
 

--- a/src/test/ui/fmt/send-sync.rs
+++ b/src/test/ui/fmt/send-sync.rs
@@ -15,6 +15,6 @@ fn main() {
     // `Cell` is not `Sync`, so `&Cell` is neither `Sync` nor `Send`,
     // `std::fmt::Arguments` used to forget this...
     let c = std::cell::Cell::new(42);
-    send(format_args!("{:?}", c)); //~ ERROR Sync` is not satisfied
-    sync(format_args!("{:?}", c)); //~ ERROR Sync` is not satisfied
+    send(format_args!("{:?}", c)); //~ ERROR E0277
+    sync(format_args!("{:?}", c)); //~ ERROR E0277
 }

--- a/src/test/ui/fmt/send-sync.stderr
+++ b/src/test/ui/fmt/send-sync.stderr
@@ -1,7 +1,7 @@
-error[E0277]: the trait bound `*mut std::ops::Fn() + 'static: std::marker::Sync` is not satisfied in `[std::fmt::ArgumentV1<'_>]`
+error[E0277]: `*mut std::ops::Fn() + 'static` cannot be shared between threads safely
   --> $DIR/send-sync.rs:18:5
    |
-LL |     send(format_args!("{:?}", c)); //~ ERROR Sync` is not satisfied
+LL |     send(format_args!("{:?}", c)); //~ ERROR E0277
    |     ^^^^ `*mut std::ops::Fn() + 'static` cannot be shared between threads safely
    |
    = help: within `[std::fmt::ArgumentV1<'_>]`, the trait `std::marker::Sync` is not implemented for `*mut std::ops::Fn() + 'static`
@@ -18,10 +18,10 @@ note: required by `send`
 LL | fn send<T: Send>(_: T) {}
    | ^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `*mut std::ops::Fn() + 'static: std::marker::Sync` is not satisfied in `std::fmt::Arguments<'_>`
+error[E0277]: `*mut std::ops::Fn() + 'static` cannot be shared between threads safely
   --> $DIR/send-sync.rs:19:5
    |
-LL |     sync(format_args!("{:?}", c)); //~ ERROR Sync` is not satisfied
+LL |     sync(format_args!("{:?}", c)); //~ ERROR E0277
    |     ^^^^ `*mut std::ops::Fn() + 'static` cannot be shared between threads safely
    |
    = help: within `std::fmt::Arguments<'_>`, the trait `std::marker::Sync` is not implemented for `*mut std::ops::Fn() + 'static`

--- a/src/test/ui/generator/not-send-sync.rs
+++ b/src/test/ui/generator/not-send-sync.rs
@@ -17,14 +17,14 @@ fn main() {
     fn assert_send<T: Send>(_: T) {}
 
     assert_sync(|| {
-        //~^ ERROR: Sync` is not satisfied
+        //~^ ERROR: E0277
         let a = Cell::new(2);
         yield;
     });
 
     let a = Cell::new(2);
     assert_send(|| {
-        //~^ ERROR: Sync` is not satisfied
+        //~^ ERROR: E0277
         drop(&a);
         yield;
     });

--- a/src/test/ui/generator/not-send-sync.stderr
+++ b/src/test/ui/generator/not-send-sync.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `std::cell::Cell<i32>: std::marker::Sync` is not satisfied
+error[E0277]: `std::cell::Cell<i32>` cannot be shared between threads safely
   --> $DIR/not-send-sync.rs:26:5
    |
 LL |     assert_send(|| {
@@ -13,7 +13,7 @@ note: required by `main::assert_send`
 LL |     fn assert_send<T: Send>(_: T) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `std::cell::Cell<i32>: std::marker::Sync` is not satisfied in `[generator@$DIR/not-send-sync.rs:19:17: 23:6 {std::cell::Cell<i32>, ()}]`
+error[E0277]: `std::cell::Cell<i32>` cannot be shared between threads safely
   --> $DIR/not-send-sync.rs:19:5
    |
 LL |     assert_sync(|| {


### PR DESCRIPTION
 - Reword E0044 help.
 - Change error message for types that don't implement `Send`

CC #45092, #46678, #24909, #33307.