### PR TITLE
Compiletest: delete the compiled program once its test is done. 

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1343,7 +1343,7 @@ impl<'test> TestCx<'test> {
     fn exec_compiled_test(&self) -> ProcRes {
         let env = &self.props.exec_env;
 
-        match &*self.config.target {
+        let proc_res = match &*self.config.target {
             // This is pretty similar to below, we're transforming:
             //
             //      program arg1 arg2
@@ -1398,7 +1398,13 @@ impl<'test> TestCx<'test> {
                     None,
                 )
             }
-        }
+        };
+
+        // delete the executable after running it to save space.
+        // it is ok if the deletion failed.
+        let _ = fs::remove_file(self.make_exe_name());
+
+        proc_res
     }
 
     /// For each `aux-build: foo/bar` annotation, we check to find the

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1400,9 +1400,11 @@ impl<'test> TestCx<'test> {
             }
         };
 
-        // delete the executable after running it to save space.
-        // it is ok if the deletion failed.
-        let _ = fs::remove_file(self.make_exe_name());
+        if proc_res.status.success() {
+            // delete the executable after running it to save space.
+            // it is ok if the deletion failed.
+            let _ = fs::remove_file(self.make_exe_name());
+        }
 
         proc_res
     }


### PR DESCRIPTION
Reduces CI disk usage which prevents #48118 from succeeding. 