### PR TITLE
Continue parsing function after finding `...` arg

### DIFF
--- a/src/test/ui/invalid-variadic-function.rs
+++ b/src/test/ui/invalid-variadic-function.rs
@@ -1,0 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern "C" fn foo(x: u8, ...);
+//~^ ERROR only foreign functions are allowed to be variadic
+//~| ERROR expected one of `->`, `where`, or `{`, found `;`

--- a/src/test/ui/invalid-variadic-function.stderr
+++ b/src/test/ui/invalid-variadic-function.stderr
@@ -1,0 +1,14 @@
+error: only foreign functions are allowed to be variadic
+  --> $DIR/invalid-variadic-function.rs:11:26
+   |
+11 | extern "C" fn foo(x: u8, ...);
+   |                          ^^^
+
+error: expected one of `->`, `where`, or `{`, found `;`
+  --> $DIR/invalid-variadic-function.rs:11:30
+   |
+11 | extern "C" fn foo(x: u8, ...);
+   |                              ^ expected one of `->`, `where`, or `{` here
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
When encountering a variadic argument in a function definition that
doesn't accept it, if immediately after there's a closing paren,
continue parsing as normal. Otherwise keep current behavior of emitting
error and stopping.

Fix #31481.