### PR TITLE
Prepare stable release for 1.24.0

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -42,7 +42,7 @@ fi
 #
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
-export RUST_RELEASE_CHANNEL=beta
+export RUST_RELEASE_CHANNEL=stable
 if [ "$DEPLOY$DEPLOY_ALT" != "" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=$RUST_RELEASE_CHANNEL"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"


### PR DESCRIPTION
Cargo submodule appears to already be at tip and RLS has no branch to sync to (or 1.23.0 branch).

