### PR TITLE
Add error codes for libsyntax_ext

### DIFF
--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -14,7 +14,7 @@ use ast::{self, Attribute, Name, PatKind, MetaItem};
 use attr::HasAttrs;
 use codemap::{self, CodeMap, Spanned, respan};
 use syntax_pos::{Span, MultiSpan, DUMMY_SP};
-use errors::DiagnosticBuilder;
+use errors::{DiagnosticBuilder, DiagnosticId};
 use ext::expand::{self, Expansion, Invocation};
 use ext::hygiene::{Mark, SyntaxContext};
 use fold::{self, Folder};
@@ -840,6 +840,9 @@ impl<'a> ExtCtxt<'a> {
     /// the macro expansion phase).
     pub fn span_err<S: Into<MultiSpan>>(&self, sp: S, msg: &str) {
         self.parse_sess.span_diagnostic.span_err(sp, msg);
+    }
+    pub fn span_err_with_code<S: Into<MultiSpan>>(&self, sp: S, msg: &str, code: DiagnosticId) {
+        self.parse_sess.span_diagnostic.span_err_with_code(sp, msg, code);
     }
     pub fn mut_span_err<S: Into<MultiSpan>>(&self, sp: S, msg: &str)
                         -> DiagnosticBuilder<'a> {

--- a/src/libsyntax_ext/diagnostics.rs
+++ b/src/libsyntax_ext/diagnostics.rs
@@ -1,0 +1,22 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(non_snake_case)]
+
+// Error messages for EXXXX errors.
+// Each message should start and end with a new line, and be wrapped to 80 characters.
+// In vim you can `:set tw=80` and use `gq` to wrap paragraphs. Use `:set tw=0` to disable.
+register_long_diagnostics! {
+E0660: r##"
+"##,
+
+E0661: r##"
+"##,
+}

--- a/src/libsyntax_ext/diagnostics.rs
+++ b/src/libsyntax_ext/diagnostics.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -15,8 +15,31 @@
 // In vim you can `:set tw=80` and use `gq` to wrap paragraphs. Use `:set tw=0` to disable.
 register_long_diagnostics! {
 E0660: r##"
+The argument to the `asm` macro is not well-formed.
+
+Erroneous code example:
+
+```compile_fail,E0660
+asm!("nop" "nop");
+```
+
+Considering that this would be a long explanation, we instead recommend you to
+take a look at the unstable book:
+https://doc.rust-lang.org/unstable-book/language-features/asm.html
 "##,
 
 E0661: r##"
+An invalid syntax was passed to the second argument of an `asm` macro line.
+
+Erroneous code example:
+
+```compile_fail,E0661
+let a;
+asm!("nop" : "r"(a));
+```
+
+Considering that this would be a long explanation, we instead recommend you to
+take a look at the unstable book:
+https://doc.rust-lang.org/unstable-book/language-features/asm.html
 "##,
 }

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -18,6 +18,8 @@
 #![feature(decl_macro)]
 #![feature(str_escape)]
 
+#![cfg_attr(not(stage0), feature(rustc_diagnostic_macros))]
+
 extern crate fmt_macros;
 #[macro_use]
 extern crate syntax;
@@ -25,6 +27,9 @@ extern crate syntax_pos;
 extern crate proc_macro;
 extern crate rustc_data_structures;
 extern crate rustc_errors as errors;
+
+#[cfg(not(stage0))]
+mod diagnostics;
 
 mod assert;
 mod asm;

--- a/src/test/ui/E0660.rs
+++ b/src/test/ui/E0660.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(asm)]
+
+fn main() {
+    let a;
+    asm!("nop" "nop");
+    asm!("nop" "nop" : "=r"(a));
+}

--- a/src/test/ui/E0660.rs
+++ b/src/test/ui/E0660.rs
@@ -8,10 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-stage1
+
 #![feature(asm)]
 
 fn main() {
     let a;
     asm!("nop" "nop");
+    //~^ ERROR E0660
     asm!("nop" "nop" : "=r"(a));
+    //~^ ERROR E0660
 }

--- a/src/test/ui/E0660.stderr
+++ b/src/test/ui/E0660.stderr
@@ -1,0 +1,15 @@
+error[E0660]: malformed inline assembly
+  --> $DIR/E0660.rs:15:5
+   |
+LL |     asm!("nop" "nop");
+   |     ^^^^^^^^^^^^^^^^^^
+
+error[E0660]: malformed inline assembly
+  --> $DIR/E0660.rs:16:5
+   |
+LL |     asm!("nop" "nop" : "=r"(a));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0660`.

--- a/src/test/ui/E0660.stderr
+++ b/src/test/ui/E0660.stderr
@@ -1,11 +1,11 @@
 error[E0660]: malformed inline assembly
-  --> $DIR/E0660.rs:15:5
+  --> $DIR/E0660.rs:17:5
    |
 LL |     asm!("nop" "nop");
    |     ^^^^^^^^^^^^^^^^^^
 
 error[E0660]: malformed inline assembly
-  --> $DIR/E0660.rs:16:5
+  --> $DIR/E0660.rs:19:5
    |
 LL |     asm!("nop" "nop" : "=r"(a));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/E0661.rs
+++ b/src/test/ui/E0661.rs
@@ -8,9 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-stage1
+
 #![feature(asm)]
 
 fn main() {
     let a;
     asm!("nop" : "r"(a));
+    //~^ ERROR E0661
 }

--- a/src/test/ui/E0661.rs
+++ b/src/test/ui/E0661.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -7,10 +7,10 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
 #![feature(asm)]
 
 fn main() {
     let a;
-    asm!("nop" "nop"); //~ ERROR malformed inline assembly
-    asm!("nop" "nop" : "=r"(a)); //~ ERROR malformed inline assembly
+    asm!("nop" : "r"(a));
 }

--- a/src/test/ui/E0661.stderr
+++ b/src/test/ui/E0661.stderr
@@ -1,0 +1,9 @@
+error[E0661]: output operand constraint lacks '=' or '+'
+  --> $DIR/E0661.rs:15:18
+   |
+LL |     asm!("nop" : "r"(a));
+   |                  ^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0661`.

--- a/src/test/ui/E0661.stderr
+++ b/src/test/ui/E0661.stderr
@@ -1,5 +1,5 @@
 error[E0661]: output operand constraint lacks '=' or '+'
-  --> $DIR/E0661.rs:15:18
+  --> $DIR/E0661.rs:17:18
    |
 LL |     asm!("nop" : "r"(a));
    |                  ^^^


### PR DESCRIPTION
I intend to add error codes for `libsyntax_ext` as well. However, they cannot be used at stage 0 directly so I thought it might be possible to enable them at the stage 1 only so we can have access to the macros. However, the error code registration seems to not work this way. Currently I get the following error:

```
error: used diagnostic code E0660 not registered
  --> libsyntax_ext/asm.rs:93:25
   |
93 |                         span_err!(cx, sp, E0660, "malformed inline assembly");
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

error: used diagnostic code E0661 not registered
   --> libsyntax_ext/asm.rs:151:33
    |
151 | /                                 span_err!(cx, sp, E0661,
152 | |                                           "output operand constraint lacks '=' or '+'");
    | |________________________________________________________________________________________^
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

error: aborting due to 2 previous errors

error: Could not compile `syntax_ext`.
```

If anyone has an idea, I'd gladly take it. I'm trying to figure this out on my side as well. I also opened this PR to know if it was worth it to continue (maybe we don't want this?).

Anyway, any answer for both questions is very welcome!

cc @rust-lang/compiler 