### PR TITLE
incr.comp.: Run cache directory garbage collection before loading dep-graph.

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -660,6 +660,15 @@ pub fn phase_2_configure_and_expand_inner<'a, F>(sess: &'a Session,
         disambiguator,
     );
 
+    if sess.opts.incremental.is_some() {
+        time(time_passes, "garbage collect incremental cache directory", || {
+            if let Err(e) = rustc_incremental::garbage_collect_session_directories(sess) {
+                warn!("Error while trying to garbage collect incremental \
+                       compilation cache directory: {}", e);
+            }
+        });
+    }
+
     // If necessary, compute the dependency graph (in the background).
     let future_dep_graph = if sess.opts.build_dep_graph() {
         Some(rustc_incremental::load_dep_graph(sess, time_passes))

--- a/src/librustc_incremental/lib.rs
+++ b/src/librustc_incremental/lib.rs
@@ -46,3 +46,4 @@ pub use persist::in_incr_comp_dir;
 pub use persist::prepare_session_directory;
 pub use persist::finalize_session_directory;
 pub use persist::delete_workproduct_files;
+pub use persist::garbage_collect_session_directories;

--- a/src/librustc_incremental/persist/mod.rs
+++ b/src/librustc_incremental/persist/mod.rs
@@ -20,9 +20,10 @@ mod save;
 mod work_product;
 mod file_format;
 
-pub use self::fs::prepare_session_directory;
 pub use self::fs::finalize_session_directory;
+pub use self::fs::garbage_collect_session_directories;
 pub use self::fs::in_incr_comp_dir;
+pub use self::fs::prepare_session_directory;
 pub use self::load::dep_graph_tcx_init;
 pub use self::load::load_dep_graph;
 pub use self::load::load_query_result_cache;


### PR DESCRIPTION
Prior to this PR, the incr. comp. cache directory would only be garbage collected after the final output artifacts were generated. However, compilation often aborts earlier and in the case of the RLS, which starts lots of compilation sessions, we might fill up the cache directory with chunk sessions.

This PR makes the compiler do a garbage collection run before loading the dep-graph.

cc @nrc https://github.com/rust-lang/rust/issues/48172

r? @nikomatsakis 