### PR TITLE
Add a generic `From<&Borrow>` impl for `Cow`

### DIFF
--- a/src/liballoc/borrow.rs
+++ b/src/liballoc/borrow.rs
@@ -361,7 +361,7 @@ impl<'a, T: ?Sized + ToOwned> AsRef<T> for Cow<'a, T> {
     }
 }
 
-#[unstable(feature = "generic_cow_from", reason = "recently added", issue = "0000")]
+#[stable(feature = "generic_cow_from", since = "1.24.0")]
 impl<'a, B, T> From<&'a B> for Cow<'a, T>
 where
     B: ?Sized + Borrow<T>,

--- a/src/liballoc/borrow.rs
+++ b/src/liballoc/borrow.rs
@@ -361,6 +361,17 @@ impl<'a, T: ?Sized + ToOwned> AsRef<T> for Cow<'a, T> {
     }
 }
 
+#[unstable(feature = "generic_cow_from", reason = "recently added", issue = "0000")]
+impl<'a, B, T> From<&'a B> for Cow<'a, T>
+where
+    B: ?Sized + Borrow<T>,
+    T: ?Sized + ToOwned,
+{
+    fn from(b: &'a B) -> Self {
+        Cow::Borrowed(b.borrow())
+    }
+}
+
 #[stable(feature = "cow_add", since = "1.14.0")]
 impl<'a> Add<&'a str> for Cow<'a, str> {
     type Output = Cow<'a, str>;

--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -2129,14 +2129,6 @@ impl<'a> From<Cow<'a, str>> for String {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> From<&'a str> for Cow<'a, str> {
-    #[inline]
-    fn from(s: &'a str) -> Cow<'a, str> {
-        Cow::Borrowed(s)
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> From<String> for Cow<'a, str> {
     #[inline]
     fn from(s: String) -> Cow<'a, str> {

--- a/src/liballoc/tests/borrow.rs
+++ b/src/liballoc/tests/borrow.rs
@@ -65,7 +65,7 @@ fn test_generic_cow_from() {
             VecWrapper {
                 _inner: val.into().into_owned(),
             }
-        } 
+        }
     }
 
     let ints = vec![0i32, 1, 2, 3, 4, 5];

--- a/src/liballoc/tests/borrow.rs
+++ b/src/liballoc/tests/borrow.rs
@@ -13,7 +13,6 @@ use std::path::{Path, PathBuf};
 use std::ffi::{CStr, CString, OsStr, OsString};
 
 #[test]
-#[ignore]
 fn test_cow_from() {
     const MSG: &'static str = "Hello, World";
     let s = MSG.to_string();

--- a/src/liballoc/tests/borrow.rs
+++ b/src/liballoc/tests/borrow.rs
@@ -10,35 +10,66 @@
 
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
-use std::ffi::{CStr, CString, OSStr, OSString};
+use std::ffi::{CStr, CString, OsStr, OsString};
 
 #[test]
+#[ignore]
 fn test_cow_from() {
     const MSG: &'static str = "Hello, World";
     let s = MSG.to_string();
-    assert_eq!(Cow::from(&s), Cow::Borrowed(MSG));
+    assert_eq!(Cow::<str>::from(&s), Cow::Borrowed(MSG));
     assert_eq!(Cow::from(s.as_str()), Cow::Borrowed(MSG));
-    assert_eq!(Cow::from(s), Cow::Owned(MSG.to_string()));
+    assert_eq!(
+        Cow::from(s),
+        || -> Cow<str> { Cow::Owned(MSG.to_string()) }()
+    );
 
-    const VALUES: &'static [u8] = [1u8, 2, 3, 4, 5, 6, 7, 8];
-    let v = VALUES.iter().collect::<Vec<_>>();
-    assert_eq!(Cow::from(&v), Cow::Borrowed(VALUES));
+    const VALUES: &[u8] = &[1u8, 2, 3, 4, 5, 6, 7, 8];
+    let v = VALUES.iter().map(|b| *b).collect::<Vec<u8>>();
+    assert_eq!(Cow::<[u8]>::from(&v), Cow::Borrowed(VALUES));
     assert_eq!(Cow::from(v.as_slice()), Cow::Borrowed(VALUES));
-    assert_eq!(Cow::from(v), Cow::Owned(VALUES.iter().collect::<Vec<_>>()));
+    assert_eq!(
+        Cow::from(v),
+        || -> Cow<[u8]> { Cow::Owned(VALUES.iter().map(|b| *b).collect::<Vec<u8>>() )}()
+    );
 
     let p = PathBuf::new();
-    assert_eq!(Cow::from(&p), Cow::Borrowed(Path::new("")));
+    assert_eq!(Cow::<Path>::from(&p), Cow::Borrowed(Path::new("")));
     assert_eq!(Cow::from(p.as_path()), Cow::Borrowed(Path::new("")));
+    assert_eq!(
+        Cow::from(p),
+        || -> Cow<Path> { Cow::Owned(PathBuf::new()) }()
+    );
 
-    let cstring = CString::new(MSG);
+    let cstring = CString::new(MSG).unwrap();
     let cstr = {
         const MSG_NULL_TERMINATED: &'static str = "Hello, World\0";
-        CStr::from_bytes_with_nul(MSG_NULL_TERMINATED).unwrap()
+        CStr::from_bytes_with_nul(MSG_NULL_TERMINATED.as_bytes()).unwrap()
     };
-    assert_eq(Cow::from(&cstring), Cow::Borrowed(cstr));
-    assert_eq(Cow::from(cstring.as_c_str()), Cow::Borrowed(cstr));
+    assert_eq!(Cow::<CStr>::from(&cstring), Cow::Borrowed(cstr));
+    assert_eq!(Cow::from(cstring.as_c_str()), Cow::Borrowed(cstr));
 
-    let s = OSString::from(MSG.into());
-    assert_eq!(Cow::from(&s), Cow::Borrowed(OSStr::new(msg)));
-    assert_eq!(Cow::from(s.as_os_str()), Cow::Borrowed(OSStr::new(msg)));
+    let s = OsString::from(MSG.to_string());
+    assert_eq!(Cow::<OsString>::from(&s), Cow::Borrowed(OsStr::new(MSG)));
+    assert_eq!(Cow::from(s.as_os_str()), Cow::Borrowed(OsStr::new(MSG)));
+}
+
+#[test]
+fn test_generic_cow_from() {
+    struct VecWrapper {
+        _inner: Vec<i32>,
+    }
+
+    impl VecWrapper {
+        fn new<'a, T: Into<Cow<'a, [i32]>>>(val: T) -> Self {
+            VecWrapper {
+                _inner: val.into().into_owned(),
+            }
+        } 
+    }
+
+    let ints = vec![0i32, 1, 2, 3, 4, 5];
+    let _vw0 = VecWrapper::new(ints.as_slice());
+    let _vw1 = VecWrapper::new(&ints);
+    let _vw2 = VecWrapper::new(ints);
 }

--- a/src/liballoc/tests/borrow.rs
+++ b/src/liballoc/tests/borrow.rs
@@ -1,0 +1,44 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::borrow::Cow;
+use std::path::PathBuf;
+use std::ffi::{CStr, CString, OSStr, OSString};
+
+#[test]
+fn test_cow_from() {
+    const MSG: &'static str = "Hello, World";
+    let s = MSG.to_string();
+    assert_eq!(Cow::from(&s), Cow::Borrowed(MSG));
+    assert_eq!(Cow::from(s.as_str()), Cow::Borrowed(MSG));
+    assert_eq!(Cow::from(s), Cow::Owned(MSG.to_string()));
+
+    const VALUES: &'static [u8] = [1u8, 2, 3, 4, 5, 6, 7, 8];
+    let v = VALUES.iter().collect::<Vec<_>>();
+    assert_eq!(Cow::from(&v), Cow::Borrowed(VALUES));
+    assert_eq!(Cow::from(v.as_slice()), Cow::Borrowed(VALUES));
+    assert_eq!(Cow::from(v), Cow::Owned(VALUES.iter().collect::<Vec<_>>()));
+
+    let p = PathBuf::new();
+    assert_eq!(Cow::from(&p), Cow::Borrowed(p.as_path()));
+    assert_eq!(Cow::from(v.as_path()), Cow::Borrowed(p.as_path()));
+
+    let cstring = CString::new(MSG);
+    let cstr = {
+        const MSG_NULL_TERMINATED: &'static str = "Hello, World\0";
+        CStr::from_bytes_with_nul(MSG_NULL_TERMINATED).unwrap()
+    };
+    assert_eq(Cow::from(&cstring), Cow::Borrowed(cstr));
+    assert_eq(Cow::from(cstring.as_c_str()), Cow::Borrowed(cstr));
+
+    let s = OSString::from(MSG.into());
+    assert_eq!(Cow::from(&s), Cow::Borrowed(OSStr::new(msg)));
+    assert_eq!(Cow::from(s.as_os_str()), Cow::Borrowed(OSStr::new(msg)));
+}

--- a/src/liballoc/tests/borrow.rs
+++ b/src/liballoc/tests/borrow.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use std::borrow::Cow;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::ffi::{CStr, CString, OSStr, OSString};
 
 #[test]
@@ -27,8 +27,8 @@ fn test_cow_from() {
     assert_eq!(Cow::from(v), Cow::Owned(VALUES.iter().collect::<Vec<_>>()));
 
     let p = PathBuf::new();
-    assert_eq!(Cow::from(&p), Cow::Borrowed(p.as_path()));
-    assert_eq!(Cow::from(v.as_path()), Cow::Borrowed(p.as_path()));
+    assert_eq!(Cow::from(&p), Cow::Borrowed(Path::new("")));
+    assert_eq!(Cow::from(p.as_path()), Cow::Borrowed(Path::new("")));
 
     let cstring = CString::new(MSG);
     let cstr = {

--- a/src/liballoc/tests/lib.rs
+++ b/src/liballoc/tests/lib.rs
@@ -40,6 +40,7 @@ use std::collections::hash_map::DefaultHasher;
 
 mod binary_heap;
 mod btree;
+mod borrow;
 mod cow_str;
 mod fmt;
 mod heap;

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2234,13 +2234,6 @@ impl<'a> From<&'a str> for Vec<u8> {
 ////////////////////////////////////////////////////////////////////////////////
 
 #[stable(feature = "cow_from_vec", since = "1.8.0")]
-impl<'a, T: Clone> From<&'a [T]> for Cow<'a, [T]> {
-    fn from(s: &'a [T]) -> Cow<'a, [T]> {
-        Cow::Borrowed(s)
-    }
-}
-
-#[stable(feature = "cow_from_vec", since = "1.8.0")]
 impl<'a, T: Clone> From<Vec<T>> for Cow<'a, [T]> {
     fn from(v: Vec<T>) -> Cow<'a, [T]> {
         Cow::Owned(v)

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1446,14 +1446,6 @@ impl Default for PathBuf {
 }
 
 #[stable(feature = "cow_from_path", since = "1.6.0")]
-impl<'a> From<&'a Path> for Cow<'a, Path> {
-    #[inline]
-    fn from(s: &'a Path) -> Cow<'a, Path> {
-        Cow::Borrowed(s)
-    }
-}
-
-#[stable(feature = "cow_from_path", since = "1.6.0")]
 impl<'a> From<PathBuf> for Cow<'a, Path> {
     #[inline]
     fn from(s: PathBuf) -> Cow<'a, Path> {


### PR DESCRIPTION
This commit removes the ad-hoc impls of `From<&Borrow> for Cow`, and replaces them with a generic `From` impl across all `&Borrow<T>`. I am unsure of how the stability attributes should work, so I will need some guidance to get this in good shape to submit.

The practical effects of this commit are:
- There are now `From<&Borrow>` impls derived for `Cow<CStr>` and `Cow<OsStr>`, as well as any other ecosystem types that can be borrowed (e.g. [ascii types](https://crates.io/crates/ascii))
- `From<&Owned>` is now auto implemented. This fixes some issues with using `Into<Cow<T>>` in generic situations, as shown in [this playground](https://play.rust-lang.org/?gist=c208363beb1408c4b019f33429420665&version=stable).

Some other issues:
- I attempted to add an `impl<T: ToOwned> From<T::Owned> for Cow<T>`, however it conflicted with the reflexive `From` impl in core. Thus, those impls will still have to be implemented in an ad-hoc way until maybe specialization could solve it.