### PR TITLE
Work around LLVM TLS bug on SPARC

### DIFF
--- a/src/librustc_back/target/sparc64_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/sparc64_unknown_linux_gnu.rs
@@ -16,6 +16,10 @@ pub fn target() -> TargetResult {
     base.cpu = "v9".to_string();
     base.max_atomic_width = Some(64);
     base.exe_allocation_crate = None;
+    // Global-Dynamic and Local-Dynamic are currently broken when using LLVM's
+    // integrated assembler, as it doesn't emit a symbol table entry for
+    // __tls_get_addr (https://sourceware.org/bugzilla/show_bug.cgi?id=22832).
+    base.no_integrated_as = true;
 
     Ok(Target {
         llvm_target: "sparc64-unknown-linux-gnu".to_string(),

--- a/src/librustc_back/target/sparc64_unknown_netbsd.rs
+++ b/src/librustc_back/target/sparc64_unknown_netbsd.rs
@@ -16,6 +16,10 @@ pub fn target() -> TargetResult {
     base.cpu = "v9".to_string();
     base.pre_link_args.get_mut(&LinkerFlavor::Gcc).unwrap().push("-m64".to_string());
     base.max_atomic_width = Some(64);
+    // Global-Dynamic and Local-Dynamic are currently broken when using LLVM's
+    // integrated assembler, as it doesn't emit a symbol table entry for
+    // __tls_get_addr (https://sourceware.org/bugzilla/show_bug.cgi?id=22832).
+    base.no_integrated_as = true;
 
     Ok(Target {
         llvm_target: "sparc64-unknown-netbsd".to_string(),

--- a/src/librustc_back/target/sparcv9_sun_solaris.rs
+++ b/src/librustc_back/target/sparcv9_sun_solaris.rs
@@ -18,6 +18,10 @@ pub fn target() -> TargetResult {
     base.cpu = "v9".to_string();
     base.max_atomic_width = Some(64);
     base.exe_allocation_crate = None;
+    // Global-Dynamic and Local-Dynamic are currently broken when using LLVM's
+    // integrated assembler, as it doesn't emit a symbol table entry for
+    // __tls_get_addr (https://sourceware.org/bugzilla/show_bug.cgi?id=22832).
+    base.no_integrated_as = true;
 
     Ok(Target {
         llvm_target: "sparcv9-sun-solaris".to_string(),


### PR DESCRIPTION
SPARC's Global-Dynamic and Local-Dynamic relocations for calls to __tls_get_addr only reference the symbol implicitly. It must be added explicitly to the object file's symbol table, but LLVM does not do this, leading to a failure to link with either bfd ld or gold. Work around this for now by using the system assembler rather than LLVM's integrated one.