### PR TITLE
Allow two-phase borrows of &mut self in ops

### DIFF
--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -201,10 +201,9 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         let mutbl = match mt.mutbl {
                             hir::MutImmutable => AutoBorrowMutability::Immutable,
                             hir::MutMutable => AutoBorrowMutability::Mutable {
-                                // For initial two-phase borrow
-                                // deployment, conservatively omit
-                                // overloaded binary ops.
-                                allow_two_phase_borrow: false,
+                                // Allow two-phase borrows for binops in initial deployment
+                                // since they desugar to methods
+                                allow_two_phase_borrow: true,
                             }
                         };
                         let autoref = Adjustment {
@@ -219,10 +218,9 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         let mutbl = match mt.mutbl {
                             hir::MutImmutable => AutoBorrowMutability::Immutable,
                             hir::MutMutable => AutoBorrowMutability::Mutable {
-                                // For initial two-phase borrow
-                                // deployment, conservatively omit
-                                // overloaded binary ops.
-                                allow_two_phase_borrow: false,
+                                // Allow two-phase borrows for binops in initial deployment
+                                // since they desugar to methods
+                                allow_two_phase_borrow: true,
                             }
                         };
                         let autoref = Adjustment {

--- a/src/test/compile-fail/borrowck/two-phase-nonrecv-autoref.rs
+++ b/src/test/compile-fail/borrowck/two-phase-nonrecv-autoref.rs
@@ -30,8 +30,6 @@
 // #![feature(rustc_attrs)]
 
 use std::ops::{Index, IndexMut};
-use std::ops::{AddAssign, SubAssign, MulAssign, DivAssign, RemAssign};
-use std::ops::{BitAndAssign, BitOrAssign, BitXorAssign, ShlAssign, ShrAssign};
 
 // This is case outlined by Niko that we want to ensure we reject
 // (at least initially).
@@ -186,56 +184,6 @@ fn coerce_index_op() {
     //[nll]~^^ ERROR cannot borrow `i` as immutable because it is also borrowed as mutable [E0502]
 }
 
-struct A(i32);
-
-macro_rules! trivial_binop {
-    ($Trait:ident, $m:ident) => {
-        impl $Trait<i32> for A { fn $m(&mut self, rhs: i32) { self.0 = rhs; } }
-    }
-}
-
-trivial_binop!(AddAssign, add_assign);
-trivial_binop!(SubAssign, sub_assign);
-trivial_binop!(MulAssign, mul_assign);
-trivial_binop!(DivAssign, div_assign);
-trivial_binop!(RemAssign, rem_assign);
-trivial_binop!(BitAndAssign, bitand_assign);
-trivial_binop!(BitOrAssign, bitor_assign);
-trivial_binop!(BitXorAssign, bitxor_assign);
-trivial_binop!(ShlAssign, shl_assign);
-trivial_binop!(ShrAssign, shr_assign);
-
-fn overloaded_binops() {
-    let mut a = A(10);
-    a += a.0;
-    //[lxl]~^   ERROR cannot use `a.0` because it was mutably borrowed
-    //[nll]~^^  ERROR cannot use `a.0` because it was mutably borrowed
-    a -= a.0;
-    //[lxl]~^   ERROR cannot use `a.0` because it was mutably borrowed
-    //[nll]~^^  ERROR cannot use `a.0` because it was mutably borrowed
-    a *= a.0;
-    //[lxl]~^   ERROR cannot use `a.0` because it was mutably borrowed
-    //[nll]~^^  ERROR cannot use `a.0` because it was mutably borrowed
-    a /= a.0;
-    //[lxl]~^   ERROR cannot use `a.0` because it was mutably borrowed
-    //[nll]~^^  ERROR cannot use `a.0` because it was mutably borrowed
-    a &= a.0;
-    //[lxl]~^   ERROR cannot use `a.0` because it was mutably borrowed
-    //[nll]~^^  ERROR cannot use `a.0` because it was mutably borrowed
-    a |= a.0;
-    //[lxl]~^   ERROR cannot use `a.0` because it was mutably borrowed
-    //[nll]~^^  ERROR cannot use `a.0` because it was mutably borrowed
-    a ^= a.0;
-    //[lxl]~^   ERROR cannot use `a.0` because it was mutably borrowed
-    //[nll]~^^  ERROR cannot use `a.0` because it was mutably borrowed
-    a <<= a.0;
-    //[lxl]~^   ERROR cannot use `a.0` because it was mutably borrowed
-    //[nll]~^^  ERROR cannot use `a.0` because it was mutably borrowed
-    a >>= a.0;
-    //[lxl]~^   ERROR cannot use `a.0` because it was mutably borrowed
-    //[nll]~^^  ERROR cannot use `a.0` because it was mutably borrowed
-}
-
 fn main() {
 
     // As a reminder, this is the basic case we want to ensure we handle.
@@ -256,5 +204,4 @@ fn main() {
 
     coerce_unsized();
     coerce_index_op();
-    overloaded_binops();
 }

--- a/src/test/run-pass/borrowck/two-phase-bin-ops.rs
+++ b/src/test/run-pass/borrowck/two-phase-bin-ops.rs
@@ -1,0 +1,49 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// revisions: lxl nll
+//[lxl]compile-flags: -Z borrowck=mir -Z two-phase-borrows
+
+#![cfg_attr(nll, feature(nll))]
+
+use std::ops::{AddAssign, SubAssign, MulAssign, DivAssign, RemAssign};
+use std::ops::{BitAndAssign, BitOrAssign, BitXorAssign, ShlAssign, ShrAssign};
+
+struct A(i32);
+
+macro_rules! trivial_binop {
+    ($Trait:ident, $m:ident) => {
+        impl $Trait<i32> for A { fn $m(&mut self, rhs: i32) { self.0 = rhs; } }
+    }
+}
+
+trivial_binop!(AddAssign, add_assign);
+trivial_binop!(SubAssign, sub_assign);
+trivial_binop!(MulAssign, mul_assign);
+trivial_binop!(DivAssign, div_assign);
+trivial_binop!(RemAssign, rem_assign);
+trivial_binop!(BitAndAssign, bitand_assign);
+trivial_binop!(BitOrAssign, bitor_assign);
+trivial_binop!(BitXorAssign, bitxor_assign);
+trivial_binop!(ShlAssign, shl_assign);
+trivial_binop!(ShrAssign, shr_assign);
+
+fn main() {
+    let mut a = A(10);
+    a += a.0;
+    a -= a.0;
+    a *= a.0;
+    a /= a.0;
+    a &= a.0;
+    a |= a.0;
+    a ^= a.0;
+    a <<= a.0;
+    a >>= a.0;
+}

--- a/src/test/run-pass/borrowck/two-phase-bin-ops.rs
+++ b/src/test/run-pass/borrowck/two-phase-bin-ops.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 // revisions: lxl nll
-//[lxl]compile-flags: -Z borrowck=mir -Z two-phase-borrows
 
 #![cfg_attr(nll, feature(nll))]
 


### PR DESCRIPTION
We need two-phase borrows of ops to be in the initial NLL release since without them lots of existing code will break. Fixes #48129.
CC @pnkfelix  and @nikomatsakis 

r? @pnkfelix 