### PR TITLE
rephrase UnsafeCell doc

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1167,7 +1167,7 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for RefMut<'a, T> {
 /// feature to work around this restriction. All other types that allow internal mutability, such as
 /// `Cell<T>` and `RefCell<T>` use `UnsafeCell` to wrap their internal data.
 ///
-/// The `UnsafeCell` API itself is technically very simple: it gives you a raw pointer `*mut T` to 
+/// The `UnsafeCell` API itself is technically very simple: it gives you a raw pointer `*mut T` to
 /// its contents. It is up to _you_ as the abstraction designer to use that raw pointer correctly.
 ///
 /// The precise Rust aliasing rules are somewhat in flux, but the main points are not contentious:
@@ -1182,7 +1182,7 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for RefMut<'a, T> {
 /// that reference expires. 
 ///
 /// - At all times, you must avoid data races, meaning that if multiple threads have access to
-/// the same `UnsafeCell`, then any writes must have a proper happens-before relation to all other 
+/// the same `UnsafeCell`, then any writes must have a proper happens-before relation to all other
 /// accesses (or use atomics).
 ///
 /// To assist with proper design, the following scenarios are explicitly declared legal

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1176,10 +1176,10 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for RefMut<'a, T> {
 /// is accessible by safe code (for example, because you returned it), then you must not access
 /// the data in any way that contradicts that reference for the remainder of `'a`. For example, that
 /// means that if you take the `*mut T` from an `UnsafeCell<T>` and case it to an `&T`, then until
-/// that reference's lifetime expires, the data in `T` must remain immutable (modulo any 
+/// that reference's lifetime expires, the data in `T` must remain immutable (modulo any
 /// `UnsafeCell` data found within `T`, of course). Similarly, if you create an `&mut T` reference
 /// that is released to safe code, then you must not access the data within the `UnsafeCell` until
-/// that reference expires. 
+/// that reference expires.
 ///
 /// - At all times, you must avoid data races, meaning that if multiple threads have access to
 /// the same `UnsafeCell`, then any writes must have a proper happens-before relation to all other
@@ -1189,7 +1189,7 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for RefMut<'a, T> {
 /// for single-threaded code:
 ///
 /// 1. A `&T` reference can be released to safe code and there it can co-exit with other `&T`
-/// references, but not with a `&mut T` 
+/// references, but not with a `&mut T`
 ///
 /// 2. A `&mut T` reference may be released to safe code, provided neither other `&mut T` nor `&T`
 /// co-exist with it. A `&mut T` must always be unique.

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1166,12 +1166,12 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for RefMut<'a, T> {
 /// `Mutex`, etc, you need to turn these optimizations off. `UnsafeCell` is the only legal way
 /// to do this. When `UnsafeCell<T>` itself is immutably aliased, it is still safe to obtain
 /// a mutable reference to its interior and/or to mutate the interior. However, the abstraction
-/// designer must ensure that any active mutable references to the interior obtained this way does 
-/// not co-exist with other active references to the interior, either mutable or not. This is often 
+/// designer must ensure that any active mutable references to the interior obtained this way does
+/// not co-exist with other active references to the interior, either mutable or not. This is often
 /// done via runtime checks. Naturally, several active immutable references to the interior can 
 /// co-exits with each other (but not with a mutable reference).
 ///
-/// To put it in other words, if a mutable reference to the contents is active, no other references 
+/// To put it in other words, if a mutable reference to the contents is active, no other references
 /// can be active at the same time, and if an immutable reference to the contents is active, then
 /// only other immutable reference may be active. 
 ///

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1168,12 +1168,12 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for RefMut<'a, T> {
 /// a mutable reference to its interior and/or to mutate the interior. However, the abstraction
 /// designer must ensure that any active mutable references to the interior obtained this way does
 /// not co-exist with other active references to the interior, either mutable or not. This is often
-/// done via runtime checks. Naturally, several active immutable references to the interior can 
+/// done via runtime checks. Naturally, several active immutable references to the interior can
 /// co-exits with each other (but not with a mutable reference).
 ///
 /// To put it in other words, if a mutable reference to the contents is active, no other references
 /// can be active at the same time, and if an immutable reference to the contents is active, then
-/// only other immutable reference may be active. 
+/// only other immutable reference may be active.
 ///
 /// Note that while mutating or mutably aliasing the contents of an `& UnsafeCell<T>` is
 /// okay (provided you enforce the invariants some other way), it is still undefined behavior

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1164,8 +1164,8 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for RefMut<'a, T> {
 /// The compiler makes optimizations based on the knowledge that `&T` is not mutably aliased or
 /// mutated, and that `&mut T` is unique. When building abstractions like `Cell`, `RefCell`,
 /// `Mutex`, etc, you need to turn these optimizations off. `UnsafeCell` is the only legal way
-/// to do this. When `UnsafeCell<T>` _itself_ is immutably aliased, it is still safe to obtain
-/// a mutable reference to its _interior_ and/or to mutate the interior. However, it is up to
+/// to do this. When `UnsafeCell<T>` itself is immutably aliased, it is still safe to obtain
+/// a mutable reference to its interior and/or to mutate the interior. However, it is up to
 /// the abstraction designer to ensure that no two mutable references obtained this way are active
 /// at the same time, there are no active immutable reference when a mutable reference is obtained
 /// from the cell, and that there are no active mutable references or mutations when an immutable

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1172,7 +1172,7 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for RefMut<'a, T> {
 /// reference is obtained. This is often done via runtime checks.
 ///
 /// Note that while mutating or mutably aliasing the contents of an `& UnsafeCell<T>` is
-/// okay (provided you enforce the invariants some other way); it is still undefined behavior
+/// okay (provided you enforce the invariants some other way), it is still undefined behavior
 /// to have multiple `&mut UnsafeCell<T>` aliases.
 ///
 ///

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1164,11 +1164,12 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for RefMut<'a, T> {
 /// The compiler makes optimizations based on the knowledge that `&T` is not mutably aliased or
 /// mutated, and that `&mut T` is unique. When building abstractions like `Cell`, `RefCell`,
 /// `Mutex`, etc, you need to turn these optimizations off. `UnsafeCell` is the only legal way
-/// to do this. When `UnsafeCell<T>` is immutably aliased, it is still safe to obtain a mutable
-/// reference to its interior and/or to mutate it. However, it is up to the abstraction designer
-/// to ensure that no two mutable references obtained this way are active at the same time, and
-/// that there are no active mutable references or mutations when an immutable reference is obtained
-/// from the cell. This is often done via runtime checks.
+/// to do this. When `UnsafeCell<T>` _itself_ is immutably aliased, it is still safe to obtain
+/// a mutable reference to its _interior_ and/or to mutate the interior. However, it is up to 
+/// the abstraction designer to ensure that no two mutable references obtained this way are active
+/// at the same time, there are no active immutable reference when a mutable reference is obtained
+/// from the cell, and that there are no active mutable references or mutations when an immutable
+/// reference is obtained. This is often done via runtime checks.
 ///
 /// Note that while mutating or mutably aliasing the contents of an `& UnsafeCell<T>` is
 /// okay (provided you enforce the invariants some other way); it is still undefined behavior
@@ -1240,9 +1241,9 @@ impl<T: ?Sized> UnsafeCell<T> {
     /// Gets a mutable pointer to the wrapped value.
     ///
     /// This can be cast to a pointer of any kind.
-    /// Ensure that the access is unique when casting to
-    /// `&mut T`, and ensure that there are no mutations or mutable
-    /// aliases going on when casting to `&T`
+    /// Ensure that the access is unique (no active references, mutable or not)
+    /// when casting to `&mut T`, and ensure that there are no mutations
+	/// or mutable aliases going on when casting to `&T`
     ///
     /// # Examples
     ///

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1165,11 +1165,15 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for RefMut<'a, T> {
 /// mutated, and that `&mut T` is unique. When building abstractions like `Cell`, `RefCell`,
 /// `Mutex`, etc, you need to turn these optimizations off. `UnsafeCell` is the only legal way
 /// to do this. When `UnsafeCell<T>` itself is immutably aliased, it is still safe to obtain
-/// a mutable reference to its interior and/or to mutate the interior. However, it is up to
-/// the abstraction designer to ensure that no two mutable references obtained this way are active
-/// at the same time, there are no active immutable reference when a mutable reference is obtained
-/// from the cell, and that there are no active mutable references or mutations when an immutable
-/// reference is obtained. This is often done via runtime checks.
+/// a mutable reference to its interior and/or to mutate the interior. However, the abstraction
+/// designer must ensure that any active mutable references to the interior obtained this way does 
+/// not co-exist with other active references to the interior, either mutable or not. This is often 
+/// done via runtime checks. Naturally, several active immutable references to the interior can 
+/// co-exits with each other (but not with a mutable reference).
+///
+/// To put it in other words, if a mutable reference to the contents is active, no other references 
+/// can be active at the same time, and if an immutable reference to the contents is active, then
+/// only other immutable reference may be active. 
 ///
 /// Note that while mutating or mutably aliasing the contents of an `& UnsafeCell<T>` is
 /// okay (provided you enforce the invariants some other way), it is still undefined behavior

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1165,7 +1165,7 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for RefMut<'a, T> {
 /// mutated, and that `&mut T` is unique. When building abstractions like `Cell`, `RefCell`,
 /// `Mutex`, etc, you need to turn these optimizations off. `UnsafeCell` is the only legal way
 /// to do this. When `UnsafeCell<T>` _itself_ is immutably aliased, it is still safe to obtain
-/// a mutable reference to its _interior_ and/or to mutate the interior. However, it is up to 
+/// a mutable reference to its _interior_ and/or to mutate the interior. However, it is up to
 /// the abstraction designer to ensure that no two mutable references obtained this way are active
 /// at the same time, there are no active immutable reference when a mutable reference is obtained
 /// from the cell, and that there are no active mutable references or mutations when an immutable
@@ -1243,7 +1243,7 @@ impl<T: ?Sized> UnsafeCell<T> {
     /// This can be cast to a pointer of any kind.
     /// Ensure that the access is unique (no active references, mutable or not)
     /// when casting to `&mut T`, and ensure that there are no mutations
-	/// or mutable aliases going on when casting to `&T`
+    /// or mutable aliases going on when casting to `&T`
     ///
     /// # Examples
     ///


### PR DESCRIPTION
As shown by discussions on users.rust-lang.org [[1]], [[2]], UnsafeCell doc is not totally clear. I tried to made the doc univocal regarding what is allowed and what is not. The edits are based on my understanding following [[1]].

[1]: https://users.rust-lang.org/t/unsafecell-behavior-details/1560
[2]: https://users.rust-lang.org/t/is-there-a-better-way-to-overload-index-indexmut-for-a-rc-refcell/15591/12