### PR TITLE
change opt-level 2 to 3 in bootstrap rustflags

### DIFF
--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -40,13 +40,10 @@ members = [
   "tools/rls/test_data/workspace_symbol",
 ]
 
-# Curiously, compiletest will segfault if compiled with opt-level=3 on 64-bit
-# MSVC when running the compile-fail test suite when a should-fail test panics.
-# But hey if this is removed and it gets past the bots, sounds good to me.
 [profile.release]
-opt-level = 2
+opt-level = 3
 [profile.bench]
-opt-level = 2
+opt-level = 3
 
 # These options are controlled from our rustc wrapper script, so turn them off
 # here and have them controlled elsewhere.


### PR DESCRIPTION
Since llvm got updated, maybe this also resolved unexpected crashes.
See discussion here: https://github.com/rust-lang/rust/commit/409d40f8af3fc458352237d1527fcf2791806ab2

Is it possible to give this a test-run?
//cc @Mark-Simulacrum 