### PR TITLE
 Clarified why `Sized` bound not implicit on trait's implicit `Self` type.

### DIFF
--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -65,11 +65,11 @@ impl<T: ?Sized> !Send for *mut T { }
 ///
 /// The one exception is the implicit `Self` type of a trait. A trait does not
 /// have an implicit `Sized` bound as this is incompatible with [trait object]s
-/// where, by definition, one cannot know the size of all possible
-/// implementations of the trait.
+/// where, by definition, the trait needs to work with all possible implementors,
+/// and thus could be any size.
 ///
 /// Although Rust will let you bind `Sized` to a trait, you won't
-/// be able to use it as a trait object later:
+/// be able to use it to form a trait object later:
 ///
 /// ```
 /// # #![allow(unused_variables)]

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -63,9 +63,13 @@ impl<T: ?Sized> !Send for *mut T { }
 /// struct BarUse(Bar<[i32]>); // OK
 /// ```
 ///
-/// The one exception is the implicit `Self` type of a trait, which does not
-/// get an implicit `Sized` bound. This is because a `Sized` bound prevents
-/// the trait from being used to form a [trait object]:
+/// The one exception is the implicit `Self` type of a trait. A trait does not
+/// have an implicit `Sized` bound as this is incompatible with [trait object]s
+/// where, by definition, one cannot know the size of all possible
+/// implementations of the trait.
+///
+/// Although Rust will let you bind `Sized` to a trait, you won't
+/// be able to use it as a trait object later:
 ///
 /// ```
 /// # #![allow(unused_variables)]


### PR DESCRIPTION
This part of the documentation was a little confusing to me on first read. I've added a couple lines for further explanation. Hopefully this makes things a bit clearer for new readers.

r? @steveklabnik