### PR TITLE
Keep sysroot rpath entries as absolute.

### DIFF
--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -997,6 +997,7 @@ fn link_args(cmd: &mut Linker,
             has_rpath: sess.target.target.options.has_rpath,
             is_like_osx: sess.target.target.options.is_like_osx,
             linker_is_gnu: sess.target.target.options.linker_is_gnu,
+            sysroot_lib_path: sess.host_filesearch(PathKind::All).get_lib_path(),
             get_install_prefix_lib_path: &mut get_install_prefix_lib_path,
         };
         cmd.args(&rpath::get_rpath_flags(&mut rpath_config));


### PR DESCRIPTION
Fixes rust-lang/cargo#12746

When generating rpath entries for the final binary, rustc generally
turns the paths into relative paths. This allows for binaries to be
moved around (as long as their dependency libraries get moved as well)
and the binary still runs.

However, if the libraries are part of the rustc sysroot, then it doesn't
make sense to make these rpath entries relative, because the sysroot is
unlikely to be moved with the binary. Instead, we should keep those
rpath entries absolute.

This patch accomplishes this by checking to see if a given library
dependency lives inside the sysroot lib dir, and if it does, keeps the
corresponding rpath entry absolute instead of making it relative.