### PR TITLE
mir: Gather move at SwitchInt, Assert terminators

### DIFF
--- a/src/librustc_mir/dataflow/move_paths/builder.rs
+++ b/src/librustc_mir/dataflow/move_paths/builder.rs
@@ -353,9 +353,12 @@ impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
                 self.gather_move(&Place::Local(RETURN_PLACE));
             }
 
-            TerminatorKind::Assert { .. } |
-            TerminatorKind::SwitchInt { .. } => {
-                // branching terminators - these don't move anything
+            TerminatorKind::Assert { ref cond, .. } => {
+                self.gather_operand(cond);
+            }
+
+            TerminatorKind::SwitchInt { ref discr, .. } => {
+                self.gather_operand(discr);
             }
 
             TerminatorKind::Yield { ref value, .. } => {


### PR DESCRIPTION
Previously, `_1` was not marked as "definitely uninitialized" after a `switchInt(move _1)` terminator.

I think the same goes for the `assert` terminator.

Related discussion: https://internals.rust-lang.org/t/why-is-2-definitely-initialized-after-switchint-move-2/6760
