### PR TITLE
Remove "empty buffer" doc in read_until

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1437,8 +1437,6 @@ pub trait BufRead: Read {
     ///
     /// If successful, this function will return the total number of bytes read.
     ///
-    /// An empty buffer returned indicates that the stream has reached EOF.
-    ///
     /// # Errors
     ///
     /// This function will ignore all instances of [`ErrorKind::Interrupted`] and


### PR DESCRIPTION
This appears copied from fill_buf, but the above paragraph already indicates that a lack of delimiter at the end is EOF.