### PR TITLE
Make ".e0" not parse as 0.0

### DIFF
--- a/src/libcore/num/dec2flt/parse.rs
+++ b/src/libcore/num/dec2flt/parse.rs
@@ -73,7 +73,8 @@ pub fn parse_decimal(s: &str) -> ParseResult {
         }
         Some(&b'.') => {
             let (fractional, s) = eat_digits(&s[1..]);
-            if integral.is_empty() && fractional.is_empty() && s.is_empty() {
+            if integral.is_empty() && fractional.is_empty() {
+                // We require at least a single digit before or after the point.
                 return Invalid;
             }
 

--- a/src/libcore/tests/num/dec2flt/mod.rs
+++ b/src/libcore/tests/num/dec2flt/mod.rs
@@ -102,6 +102,12 @@ fn lonely_dot() {
 }
 
 #[test]
+fn exponentiated_dot() {
+    assert!(".e0".parse::<f32>().is_err());
+    assert!(".e0".parse::<f64>().is_err());
+}
+
+#[test]
 fn lonely_sign() {
     assert!("+".parse::<f32>().is_err());
     assert!("-".parse::<f64>().is_err());


### PR DESCRIPTION
This forces floats to have either a digit before the separating point, or after. Thus `".e0"` is invalid like `"."`, when using `parse()`. Fixes #40654. As mentioned in the issue, this is technically a breaking change... but clearly incorrect behaviour at present.