### PR TITLE
Use sparse bitsets instead of dense ones for NLL results

### DIFF
--- a/src/librustc_data_structures/bitvec.rs
+++ b/src/librustc_data_structures/bitvec.rs
@@ -184,7 +184,7 @@ impl BitMatrix {
     /// Sets the cell at `(row, column)` to true. Put another way, add
     /// `column` to the bitset for `row`.
     ///
-    /// Returns true if this changed the matrix, and false otherwies.
+    /// Returns true if this changed the matrix, and false otherwise.
     pub fn add(&mut self, row: usize, column: usize) -> bool {
         let (start, _) = self.range(row);
         let (word, mask) = word_mask(column);

--- a/src/librustc_data_structures/bitvec.rs
+++ b/src/librustc_data_structures/bitvec.rs
@@ -27,7 +27,9 @@ impl BitVector {
     #[inline]
     pub fn new(num_bits: usize) -> BitVector {
         let num_words = words(num_bits);
-        BitVector { data: vec![0; num_words] }
+        BitVector {
+            data: vec![0; num_words],
+        }
     }
 
     #[inline]
@@ -133,7 +135,10 @@ impl<'a> Iterator for BitVectorIter<'a> {
 }
 
 impl FromIterator<bool> for BitVector {
-    fn from_iter<I>(iter: I) -> BitVector where I: IntoIterator<Item=bool> {
+    fn from_iter<I>(iter: I) -> BitVector
+    where
+        I: IntoIterator<Item = bool>,
+    {
         let iter = iter.into_iter();
         let (len, _) = iter.size_hint();
         // Make the minimum length for the bitvector WORD_BITS bits since that's
@@ -262,7 +267,11 @@ impl BitMatrix {
 }
 
 #[derive(Clone, Debug)]
-pub struct SparseBitMatrix<R, C> where R: Idx, C: Idx {
+pub struct SparseBitMatrix<R, C>
+where
+    R: Idx,
+    C: Idx,
+{
     vector: IndexVec<R, SparseBitSet<C>>,
 }
 
@@ -340,7 +349,7 @@ impl<I: Idx> SparseChunk<I> {
         SparseChunk {
             key,
             bits: 1 << (index % 128),
-            _marker: PhantomData
+            _marker: PhantomData,
         }
     }
 
@@ -351,18 +360,20 @@ impl<I: Idx> SparseChunk<I> {
     pub fn iter(&self) -> impl Iterator<Item = I> {
         let base = self.key as usize * 128;
         let mut bits = self.bits;
-        (0..128).map(move |i| {
-            let current_bits = bits;
-            bits >>= 1;
-            (i, current_bits)
-        }).take_while(|&(_, bits)| bits != 0)
-          .filter_map(move |(i, bits)| {
-            if (bits & 1) != 0 {
-                Some(I::new(base + i))
-            } else {
-                None
-            }
-        })
+        (0..128)
+            .map(move |i| {
+                let current_bits = bits;
+                bits >>= 1;
+                (i, current_bits)
+            })
+            .take_while(|&(_, bits)| bits != 0)
+            .filter_map(move |(i, bits)| {
+                if (bits & 1) != 0 {
+                    Some(I::new(base + i))
+                } else {
+                    None
+                }
+            })
     }
 }
 
@@ -370,7 +381,7 @@ impl<I: Idx> SparseBitSet<I> {
     pub fn new() -> Self {
         SparseBitSet {
             chunk_bits: BTreeMap::new(),
-            _marker: PhantomData
+            _marker: PhantomData,
         }
     }
 
@@ -380,7 +391,9 @@ impl<I: Idx> SparseBitSet<I> {
 
     pub fn contains_chunk(&self, chunk: SparseChunk<I>) -> SparseChunk<I> {
         SparseChunk {
-            bits: self.chunk_bits.get(&chunk.key).map_or(0, |bits| bits & chunk.bits),
+            bits: self.chunk_bits
+                .get(&chunk.key)
+                .map_or(0, |bits| bits & chunk.bits),
             ..chunk
         }
     }
@@ -415,7 +428,7 @@ impl<I: Idx> SparseBitSet<I> {
                 }
                 new_bits ^ old_bits
             }
-            Entry::Vacant(_) => 0
+            Entry::Vacant(_) => 0,
         };
         SparseChunk {
             bits: changed,
@@ -428,12 +441,10 @@ impl<I: Idx> SparseBitSet<I> {
     }
 
     pub fn chunks<'a>(&'a self) -> impl Iterator<Item = SparseChunk<I>> + 'a {
-        self.chunk_bits.iter().map(|(&key, &bits)| {
-            SparseChunk {
-                key,
-                bits,
-                _marker: PhantomData
-            }
+        self.chunk_bits.iter().map(|(&key, &bits)| SparseChunk {
+            key,
+            bits,
+            _marker: PhantomData,
         })
     }
 
@@ -478,10 +489,11 @@ fn bitvec_iter_works() {
     bitvec.insert(65);
     bitvec.insert(66);
     bitvec.insert(99);
-    assert_eq!(bitvec.iter().collect::<Vec<_>>(),
-               [1, 10, 19, 62, 63, 64, 65, 66, 99]);
+    assert_eq!(
+        bitvec.iter().collect::<Vec<_>>(),
+        [1, 10, 19, 62, 63, 64, 65, 66, 99]
+    );
 }
-
 
 #[test]
 fn bitvec_iter_works_2() {
@@ -514,24 +526,24 @@ fn union_two_vecs() {
 #[test]
 fn grow() {
     let mut vec1 = BitVector::new(65);
-    for index in 0 .. 65 {
+    for index in 0..65 {
         assert!(vec1.insert(index));
         assert!(!vec1.insert(index));
     }
     vec1.grow(128);
 
     // Check if the bits set before growing are still set
-    for index in 0 .. 65 {
+    for index in 0..65 {
         assert!(vec1.contains(index));
     }
 
     // Check if the new bits are all un-set
-    for index in 65 .. 128 {
+    for index in 65..128 {
         assert!(!vec1.contains(index));
     }
 
     // Check that we can set all new bits without running out of bounds
-    for index in 65 .. 128 {
+    for index in 65..128 {
         assert!(vec1.insert(index));
         assert!(!vec1.insert(index));
     }

--- a/src/librustc_data_structures/indexed_vec.rs
+++ b/src/librustc_data_structures/indexed_vec.rs
@@ -482,6 +482,21 @@ impl<I: Idx, T> IndexVec<I, T> {
     pub fn get_mut(&mut self, index: I) -> Option<&mut T> {
         self.raw.get_mut(index.index())
     }
+
+    /// Return mutable references to two distinct elements, a and b. Panics if a == b.
+    #[inline]
+    pub fn pick2_mut(&mut self, a: I, b: I) -> (&mut T, &mut T) {
+        let (ai, bi) = (a.index(), b.index());
+        assert!(ai != bi);
+
+        if ai < bi {
+            let (c1, c2) = self.raw.split_at_mut(bi);
+            (&mut c1[ai], &mut c2[0])
+        } else {
+            let (c2, c1) = self.pick2_mut(b, a);
+            (c1, c2)
+        }
+    }
 }
 
 impl<I: Idx, T: Clone> IndexVec<I, T> {

--- a/src/librustc_mir/borrow_check/nll/region_infer/values.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/values.rs
@@ -69,9 +69,7 @@ impl RegionValueElements {
 
     /// Iterates over the `RegionElementIndex` for all points in the CFG.
     pub(super) fn all_point_indices<'a>(&'a self) -> impl Iterator<Item = RegionElementIndex> + 'a {
-        (0..self.num_points).map(move |i| {
-            RegionElementIndex::new(i + self.num_universal_regions)
-        })
+        (0..self.num_points).map(move |i| RegionElementIndex::new(i + self.num_universal_regions))
     }
 
     /// Iterates over the `RegionElementIndex` for all points in the CFG.
@@ -154,7 +152,6 @@ pub(super) enum RegionElement {
     UniversalRegion(RegionVid),
 }
 
-
 pub(super) trait ToElementIndex {
     fn to_element_index(self, elements: &RegionValueElements) -> RegionElementIndex;
 }
@@ -214,8 +211,10 @@ impl RegionValues {
 
         Self {
             elements: elements.clone(),
-            matrix: SparseBitMatrix::new(RegionVid::new(num_region_variables),
-                                         RegionElementIndex::new(elements.num_elements())),
+            matrix: SparseBitMatrix::new(
+                RegionVid::new(num_region_variables),
+                RegionElementIndex::new(elements.num_elements()),
+            ),
             causes: if track_causes.0 {
                 Some(CauseMap::default())
             } else {
@@ -295,8 +294,7 @@ impl RegionValues {
         // complicate causal tracking though.
         debug!(
             "add_universal_regions_outlived_by(from_region={:?}, to_region={:?})",
-            from_region,
-            to_region
+            from_region, to_region
         );
         let mut changed = false;
         for elem in self.elements.all_universal_region_indices() {
@@ -326,9 +324,7 @@ impl RegionValues {
         &'a self,
         r: RegionVid,
     ) -> impl Iterator<Item = RegionElementIndex> + 'a {
-        self.matrix
-            .iter(r)
-            .map(move |i| i)
+        self.matrix.iter(r).map(move |i| i)
     }
 
     /// Returns just the universal regions that are contained in a given region's value.
@@ -416,9 +412,7 @@ impl RegionValues {
             assert_eq!(location1.block, location2.block);
             str.push_str(&format!(
                 "{:?}[{}..={}]",
-                location1.block,
-                location1.statement_index,
-                location2.statement_index
+                location1.block, location1.statement_index, location2.statement_index
             ));
         }
     }


### PR DESCRIPTION
This is for https://github.com/rust-lang/rust/issues/48170.

r? @nikomatsakis 