### PR TITLE
Avoid ICE in arg mistmatch error for tuple variants

### DIFF
--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -756,7 +756,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                         }).collect(),
                     ref sty => vec![ArgKind::Arg("_".to_owned(), format!("{}", sty))],
                 };
-                if found.len()== expected.len() {
+                if found.len() == expected.len() {
                     self.report_closure_arg_mismatch(span,
                                                      found_span,
                                                      found_trait_ref,
@@ -869,6 +869,19 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                     ),
                     _ => ArgKind::Arg("_".to_owned(), "_".to_owned())
                 }).collect::<Vec<ArgKind>>())
+            }
+            hir::map::NodeVariant(&hir::Variant {
+                span,
+                node: hir::Variant_ {
+                    data: hir::VariantData::Tuple(ref fields, _),
+                    ..
+                },
+                ..
+            }) => {
+                (self.tcx.sess.codemap().def_span(span),
+                 fields.iter().map(|field| {
+                     ArgKind::Arg(format!("{}", field.name), "_".to_string())
+                 }).collect::<Vec<_>>())
             }
             _ => panic!("non-FnLike node found: {:?}", node),
         }

--- a/src/test/ui/issue-47706.rs
+++ b/src/test/ui/issue-47706.rs
@@ -22,3 +22,18 @@ impl Foo {
     }
     //~^^ ERROR function is expected to take 1 argument, but it takes 2 arguments [E0593]
 }
+
+enum Qux {
+    Bar(i32),
+}
+
+fn foo<F>(f: F)
+where
+    F: Fn(),
+{
+}
+
+fn main() {
+    foo(Qux::Bar);
+}
+//~^^ ERROR function is expected to take 0 arguments, but it takes 1 argument [E0593]

--- a/src/test/ui/issue-47706.stderr
+++ b/src/test/ui/issue-47706.stderr
@@ -1,5 +1,3 @@
-error[E0601]: main function not found
-
 error[E0593]: function is expected to take 1 argument, but it takes 2 arguments
   --> $DIR/issue-47706.rs:21:18
    |
@@ -8,6 +6,25 @@ error[E0593]: function is expected to take 1 argument, but it takes 2 arguments
 ...
 21 |         self.foo.map(Foo::new)
    |                  ^^^ expected function that takes 1 argument
+
+error[E0593]: function is expected to take 0 arguments, but it takes 1 argument
+  --> $DIR/issue-47706.rs:37:5
+   |
+27 |     Bar(i32),
+   |     -------- takes 1 argument
+...
+37 |     foo(Qux::Bar);
+   |     ^^^ expected function that takes 0 arguments
+   |
+note: required by `foo`
+  --> $DIR/issue-47706.rs:30:1
+   |
+30 | / fn foo<F>(f: F)
+31 | | where
+32 | |     F: Fn(),
+33 | | {
+34 | | }
+   | |_^
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Fix #47706.