### PR TITLE
Fix not running some steps in CI

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -385,8 +385,10 @@ impl<'a> Builder<'a> {
             Subcommand::Clean { .. } => panic!(),
         };
 
-        if paths[0] == Path::new("nonexistent/path/to/trigger/cargo/metadata") {
-            return;
+        if let Some(path) = paths.get(0) {
+            if path == Path::new("nonexistent/path/to/trigger/cargo/metadata") {
+                return;
+            }
         }
 
         let builder = Builder {

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -217,7 +217,7 @@ impl StepDescription {
                 }
 
                 if !attempted_run {
-                    eprintln!("Warning: no rules matched {}.", path.display());
+                    panic!("Error: no rules matched {}.", path.display());
                 }
             }
         }

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -385,6 +385,10 @@ impl<'a> Builder<'a> {
             Subcommand::Clean { .. } => panic!(),
         };
 
+        if paths[0] == Path::new("nonexistent/path/to/trigger/cargo/metadata") {
+            return;
+        }
+
         let builder = Builder {
             build,
             top_stage: build.config.stage.unwrap_or(2),

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -278,9 +278,7 @@ Arguments:
         let src = matches.opt_str("src").map(PathBuf::from)
             .or_else(|| env::var_os("SRC").map(PathBuf::from))
             .unwrap_or(cwd.clone());
-        let paths = matches.free[1..].iter().map(|p| {
-            cwd.join(p).strip_prefix(&src).expect("paths passed to be inside checkout").into()
-        }).collect::<Vec<PathBuf>>();
+        let paths = matches.free[1..].iter().map(|p| p.into()).collect::<Vec<PathBuf>>();
 
         let cfg_file = matches.opt_str("config").map(PathBuf::from).or_else(|| {
             if fs::metadata("config.toml").is_ok() {
@@ -380,9 +378,7 @@ Arguments:
             cmd,
             incremental: matches.opt_present("incremental"),
             exclude: split(matches.opt_strs("exclude"))
-                .into_iter().map(|p| {
-                    cwd.join(p).strip_prefix(&src).expect("paths to be inside checkout").into()
-                }).collect::<Vec<_>>(),
+                .into_iter().map(|p| p.into()).collect::<Vec<_>>(),
             src,
         }
     }


### PR DESCRIPTION
We'd previously assumed that these paths would be relative to the src
dir, and that for example our various CI scripts would, when calling
x.py, use `../x.py build ../src/tools/...` but this isn't the case --
they use `../x.py` without using the relevant source-relative path.

We eventually may want to make this (actually somewhat logical) change,
but this is not that time.

r? @kennytm 