### PR TITLE
Suggest setting associated type when type argument is given instead

### DIFF
--- a/src/test/ui/type-argument-instead-of-item.rs
+++ b/src/test/ui/type-argument-instead-of-item.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub trait T<X> {
+    type Item;
+    type OtherItem;
+}
+
+pub struct Foo { i: Box<T<usize, usize, OtherItem=usize>> }
+//~^ ERROR wrong number of type arguments: expected 1, found 2
+//~| ERROR the value of the associated type `Item` (from the trait `T`) must be specified
+
+fn main() {}

--- a/src/test/ui/type-argument-instead-of-item.stderr
+++ b/src/test/ui/type-argument-instead-of-item.stderr
@@ -1,0 +1,19 @@
+error[E0244]: wrong number of type arguments: expected 1, found 2
+  --> $DIR/type-argument-instead-of-item.rs:16:25
+   |
+16 | pub struct Foo { i: Box<T<usize, usize, OtherItem=usize>> }
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 type argument
+   |
+help: if you meant to set an associated type, include the name
+   |
+16 | pub struct Foo { i: Box<T<usize, AssociatedType="usize", OtherItem=usize>> }
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0191]: the value of the associated type `Item` (from the trait `T`) must be specified
+  --> $DIR/type-argument-instead-of-item.rs:16:25
+   |
+16 | pub struct Foo { i: Box<T<usize, usize, OtherItem=usize>> }
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing associated type `Item` value
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
When finding too many type arguments and too few associated types,
suggest using associated types in the appropriate place instead.

Fix #20977.