### PR TITLE
rustbuild: pass datadir to rust-installer

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -127,6 +127,7 @@ pub struct Config {
     pub musl_root: Option<PathBuf>,
     pub prefix: Option<PathBuf>,
     pub sysconfdir: Option<PathBuf>,
+    pub datadir: Option<PathBuf>,
     pub docdir: Option<PathBuf>,
     pub bindir: Option<PathBuf>,
     pub libdir: Option<PathBuf>,
@@ -212,13 +213,13 @@ struct Build {
 struct Install {
     prefix: Option<String>,
     sysconfdir: Option<String>,
+    datadir: Option<String>,
     docdir: Option<String>,
     bindir: Option<String>,
     libdir: Option<String>,
     mandir: Option<String>,
 
     // standard paths, currently unused
-    datadir: Option<String>,
     infodir: Option<String>,
     localstatedir: Option<String>,
 }
@@ -419,6 +420,7 @@ impl Config {
         if let Some(ref install) = toml.install {
             config.prefix = install.prefix.clone().map(PathBuf::from);
             config.sysconfdir = install.sysconfdir.clone().map(PathBuf::from);
+            config.datadir = install.datadir.clone().map(PathBuf::from);
             config.docdir = install.docdir.clone().map(PathBuf::from);
             config.bindir = install.bindir.clone().map(PathBuf::from);
             config.libdir = install.libdir.clone().map(PathBuf::from);

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -67,18 +67,21 @@ fn install_sh(
 
     let prefix_default = PathBuf::from("/usr/local");
     let sysconfdir_default = PathBuf::from("/etc");
-    let docdir_default = PathBuf::from("share/doc/rust");
+    let datadir_default = PathBuf::from("share");
+    let docdir_default = datadir_default.join("doc/rust");
     let bindir_default = PathBuf::from("bin");
     let libdir_default = PathBuf::from("lib");
-    let mandir_default = PathBuf::from("share/man");
+    let mandir_default = datadir_default.join("man");
     let prefix = build.config.prefix.as_ref().unwrap_or(&prefix_default);
     let sysconfdir = build.config.sysconfdir.as_ref().unwrap_or(&sysconfdir_default);
+    let datadir = build.config.datadir.as_ref().unwrap_or(&datadir_default);
     let docdir = build.config.docdir.as_ref().unwrap_or(&docdir_default);
     let bindir = build.config.bindir.as_ref().unwrap_or(&bindir_default);
     let libdir = build.config.libdir.as_ref().unwrap_or(&libdir_default);
     let mandir = build.config.mandir.as_ref().unwrap_or(&mandir_default);
 
     let sysconfdir = prefix.join(sysconfdir);
+    let datadir = prefix.join(datadir);
     let docdir = prefix.join(docdir);
     let bindir = prefix.join(bindir);
     let libdir = prefix.join(libdir);
@@ -88,6 +91,7 @@ fn install_sh(
 
     let prefix = add_destdir(&prefix, &destdir);
     let sysconfdir = add_destdir(&sysconfdir, &destdir);
+    let datadir = add_destdir(&datadir, &destdir);
     let docdir = add_destdir(&docdir, &destdir);
     let bindir = add_destdir(&bindir, &destdir);
     let libdir = add_destdir(&libdir, &destdir);
@@ -107,6 +111,7 @@ fn install_sh(
         .arg(sanitize_sh(&tmpdir(build).join(&package_name).join("install.sh")))
         .arg(format!("--prefix={}", sanitize_sh(&prefix)))
         .arg(format!("--sysconfdir={}", sanitize_sh(&sysconfdir)))
+        .arg(format!("--datadir={}", sanitize_sh(&datadir)))
         .arg(format!("--docdir={}", sanitize_sh(&docdir)))
         .arg(format!("--bindir={}", sanitize_sh(&bindir)))
         .arg(format!("--libdir={}", sanitize_sh(&libdir)))


### PR DESCRIPTION
This fixes zsh completion install when $datadir != $prefix/share