### PR TITLE
Make anon params lint warn-by-default

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -69,6 +69,7 @@
 #![feature(catch_expr)]
 #![feature(test)]
 #![feature(in_band_lifetimes)]
+#![feature(macro_at_most_once_rep)]
 
 #![recursion_limit="512"]
 

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -29,6 +29,7 @@
 #![feature(macro_vis_matcher)]
 #![feature(quote)]
 #![feature(rustc_diagnostic_macros)]
+#![feature(macro_at_most_once_rep)]
 
 extern crate syntax;
 #[macro_use]

--- a/src/test/compile-fail-fulldeps/auxiliary/lint_for_crate.rs
+++ b/src/test/compile-fail-fulldeps/auxiliary/lint_for_crate.rs
@@ -13,6 +13,7 @@
 #![feature(plugin_registrar, rustc_private)]
 #![feature(box_syntax)]
 #![feature(macro_vis_matcher)]
+#![feature(macro_at_most_once_rep)]
 
 #[macro_use] extern crate rustc;
 extern crate rustc_plugin;

--- a/src/test/compile-fail-fulldeps/auxiliary/lint_group_plugin_test.rs
+++ b/src/test/compile-fail-fulldeps/auxiliary/lint_group_plugin_test.rs
@@ -13,6 +13,7 @@
 #![feature(plugin_registrar)]
 #![feature(box_syntax, rustc_private)]
 #![feature(macro_vis_matcher)]
+#![feature(macro_at_most_once_rep)]
 
 // Load rustc as a plugin to get macros
 #[macro_use]

--- a/src/test/compile-fail-fulldeps/auxiliary/lint_plugin_test.rs
+++ b/src/test/compile-fail-fulldeps/auxiliary/lint_plugin_test.rs
@@ -13,6 +13,7 @@
 #![feature(plugin_registrar)]
 #![feature(box_syntax, rustc_private)]
 #![feature(macro_vis_matcher)]
+#![feature(macro_at_most_once_rep)]
 
 extern crate syntax;
 

--- a/src/test/compile-fail/anon-params-deprecated.rs
+++ b/src/test/compile-fail/anon-params-deprecated.rs
@@ -12,13 +12,13 @@
 // Test for the anonymous_parameters deprecation lint (RFC 1685)
 
 trait T {
-    fn foo(i32); //~ ERROR use of deprecated anonymous parameter
+    fn foo(i32); //~ ERROR anonymous parameters are deprecated
                  //~| WARNING hard error
 
     fn bar_with_default_impl(String, String) {}
-    //~^ ERROR use of deprecated anonymous parameter
+    //~^ ERROR anonymous parameters are deprecated
     //~| WARNING hard error
-    //~| ERROR use of deprecated anonymous parameter
+    //~| ERROR anonymous parameters are deprecated
     //~| WARNING hard error
 }
 

--- a/src/test/run-pass-fulldeps/auxiliary/lint_for_crate.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/lint_for_crate.rs
@@ -13,6 +13,7 @@
 #![feature(plugin_registrar, rustc_private)]
 #![feature(box_syntax)]
 #![feature(macro_vis_matcher)]
+#![feature(macro_at_most_once_rep)]
 
 #[macro_use] extern crate rustc;
 extern crate rustc_plugin;

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/issue-40001-plugin.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/issue-40001-plugin.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 #![feature(box_syntax, plugin, plugin_registrar, rustc_private)]
 #![feature(macro_vis_matcher)]
+#![feature(macro_at_most_once_rep)]
 #![crate_type = "dylib"]
 
 #[macro_use]

--- a/src/test/ui-fulldeps/auxiliary/lint_group_plugin_test.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint_group_plugin_test.rs
@@ -13,6 +13,7 @@
 #![feature(plugin_registrar)]
 #![feature(box_syntax, rustc_private)]
 #![feature(macro_vis_matcher)]
+#![feature(macro_at_most_once_rep)]
 
 // Load rustc as a plugin to get macros
 #[macro_use]

--- a/src/test/ui-fulldeps/auxiliary/lint_plugin_test.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint_plugin_test.rs
@@ -13,6 +13,7 @@
 #![feature(plugin_registrar)]
 #![feature(box_syntax, rustc_private)]
 #![feature(macro_vis_matcher)]
+#![feature(macro_at_most_once_rep)]
 
 extern crate syntax;
 

--- a/src/test/ui/lint-anon-param-edition.fixed
+++ b/src/test/ui/lint-anon-param-edition.fixed
@@ -1,4 +1,4 @@
-// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,11 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![deny(future_incompatible)]
+// tests that the anonymous_parameters lint is warn-by-default on the 2018 edition
 
-trait Tr {
-    fn f(u8) {} //~ ERROR anonymous parameters are deprecated
-                //~^ WARN this was previously accepted
+// compile-pass
+// compile-flags: --edition=2018
+// run-rustfix
+
+trait Foo {
+    fn foo(_: u8);
+    //^ WARN anonymous parameters are deprecated
+    //| WARN this was previously accepted
 }
 
 fn main() {}

--- a/src/test/ui/lint-anon-param-edition.rs
+++ b/src/test/ui/lint-anon-param-edition.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,11 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![deny(future_incompatible)]
+// tests that the anonymous_parameters lint is warn-by-default on the 2018 edition
 
-trait Tr {
-    fn f(u8) {} //~ ERROR anonymous parameters are deprecated
-                //~^ WARN this was previously accepted
+// compile-pass
+// compile-flags: --edition=2018
+// run-rustfix
+
+trait Foo {
+    fn foo(u8);
+    //^ WARN anonymous parameters are deprecated
+    //| WARN this was previously accepted
 }
 
 fn main() {}

--- a/src/test/ui/lint-anon-param-edition.stderr
+++ b/src/test/ui/lint-anon-param-edition.stderr
@@ -1,0 +1,10 @@
+warning: anonymous parameters are deprecated and will be removed in the next edition.
+  --> $DIR/lint-anon-param-edition.rs:18:12
+   |
+LL |     fn foo(u8);
+   |            ^^ help: Try naming the parameter or explicitly ignoring it: `_: u8`
+   |
+   = note: #[warn(anonymous_parameters)] on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>
+


### PR DESCRIPTION
This is intended as a followup on anonymous parameters deprecation.

Cross-posting from #41686:

> After having read a bit more of the discussion that I can find, I propose a more aggressive deprecation strategy:
> - We make the lint warn-by-default as soon as possible
> - We make anon parameters a hard error at the epoch boundary

cc @matklad @est31 @aturon 