### PR TITLE
Bring back beginning_vert field to ast::Arm

### DIFF
--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -883,6 +883,9 @@ pub struct Arm {
     pub pats: Vec<P<Pat>>,
     pub guard: Option<P<Expr>>,
     pub body: P<Expr>,
+    /// Holds a span of `| ` at the beginning of an arm, if available.
+    /// This field is used in rustfmt.
+    pub beginning_vert: Option<Span>,
 }
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -883,6 +883,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             pats,
             guard: None,
             body: expr,
+            beginning_vert: None,
         }
     }
 

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -340,13 +340,14 @@ pub fn fold_thin_attrs<T: Folder>(attrs: ThinVec<Attribute>, fld: &mut T) -> Thi
     fold_attrs(attrs.into(), fld).into()
 }
 
-pub fn noop_fold_arm<T: Folder>(Arm {attrs, pats, guard, body}: Arm,
+pub fn noop_fold_arm<T: Folder>(Arm {attrs, pats, guard, body, beginning_vert}: Arm,
     fld: &mut T) -> Arm {
     Arm {
         attrs: fold_attrs(attrs, fld),
         pats: pats.move_map(|x| fld.fold_pat(x)),
         guard: guard.map(|x| fld.fold_expr(x)),
         body: fld.fold_expr(body),
+        beginning_vert,
     }
 }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3395,7 +3395,11 @@ impl<'a> Parser<'a> {
 
         let attrs = self.parse_outer_attributes()?;
         // Allow a '|' before the pats (RFC 1925)
-        self.eat(&token::BinOp(token::Or));
+        let beginning_vert = if self.eat(&token::BinOp(token::Or)) {
+            Some(self.prev_span)
+        } else {
+            None
+        };
         let pats = self.parse_pats()?;
         let guard = if self.eat_keyword(keywords::If) {
             Some(self.parse_expr()?)
@@ -3419,6 +3423,7 @@ impl<'a> Parser<'a> {
             pats,
             guard,
             body: expr,
+            beginning_vert,
         })
     }
 


### PR DESCRIPTION
`beginning_vert` field was removed from `ast::Arm` in [the stabilization PR](https://github.com/rust-lang/rust/pull/47947), but rustfmt needs this to properly format a match arm with `|` at the beginning, so please bring this back!