### PR TITLE
unused_unsafe: don't label irrelevant fns

### DIFF
--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -386,10 +386,13 @@ fn is_enclosed(tcx: TyCtxt,
         if used_unsafe.contains(&parent_id) {
             Some(("block".to_string(), parent_id))
         } else if let Some(hir::map::NodeItem(&hir::Item {
-            node: hir::ItemFn(_, hir::Unsafety::Unsafe, _, _, _, _),
+            node: hir::ItemFn(_, fn_unsafety, _, _, _, _),
             ..
         })) = tcx.hir.find(parent_id) {
-            Some(("fn".to_string(), parent_id))
+            match fn_unsafety {
+                hir::Unsafety::Unsafe => Some(("fn".to_string(), parent_id)),
+                hir::Unsafety::Normal => None,
+            }
         } else {
             is_enclosed(tcx, used_unsafe, parent_id)
         }

--- a/src/test/compile-fail/issue-48131.rs
+++ b/src/test/compile-fail/issue-48131.rs
@@ -1,0 +1,39 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This note is annotated because the purpose of the test
+// is to ensure that certain other notes are not generated.
+#![deny(unused_unsafe)] //~ NOTE
+
+// (test that no note is generated on this unsafe fn)
+pub unsafe fn a() {
+    fn inner() {
+        unsafe { /* unnecessary */ } //~ ERROR unnecessary `unsafe`
+                                     //~^ NOTE
+    }
+
+    inner()
+}
+
+pub fn b() {
+    // (test that no note is generated on this unsafe block)
+    unsafe {
+        fn inner() {
+            unsafe { /* unnecessary */ } //~ ERROR unnecessary `unsafe`
+                                         //~^ NOTE
+        }
+
+        let () = ::std::mem::uninitialized();
+
+        inner()
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #48131

Diagnostic bugfix to remove an errant note.  Stops the search for an enclosing unsafe scope at the first safe fn encountered.

```rust
pub unsafe fn outer() {
    fn inner() {
        unsafe { /* unnecessary */ }
    }
    
    inner()
}
```

**Before:**

```
warning: unnecessary `unsafe` block
 --> src/main.rs:3:9
  |
1 | pub unsafe fn outer() {
  | --------------------- because it's nested under this `unsafe` fn
2 |     fn inner() {
3 |         unsafe { /* unnecessary */ }
  |         ^^^^^^ unnecessary `unsafe` block
  |
  = note: #[warn(unused_unsafe)] on by default
```

**After:**

```
warning: unnecessary `unsafe` block
 --> src/main.rs:3:9
  |
3 |         unsafe { /* unnecessary */ }
  |         ^^^^^^ unnecessary `unsafe` block
  |
  = note: #[warn(unused_unsafe)] on by default
```