### PR TITLE
Provide context for missing comma in match arm and if statement without block

### DIFF
--- a/src/test/ui/cross-file-errors/main.stderr
+++ b/src/test/ui/cross-file-errors/main.stderr
@@ -2,7 +2,7 @@ error: expected expression, found `_`
   --> $DIR/underscore.rs:18:9
    |
 LL |         _
-   |         ^
+   |         ^ expected expression
    | 
   ::: $DIR/main.rs:15:5
    |

--- a/src/test/ui/did_you_mean/issue-40006.stderr
+++ b/src/test/ui/did_you_mean/issue-40006.stderr
@@ -19,7 +19,7 @@ error: expected `[`, found `#`
   --> $DIR/issue-40006.rs:20:17
    |
 LL |     fn xxx() { ### } //~ ERROR missing
-   |                 ^
+   |                 ^ expected `[`
 
 error: missing `fn`, `type`, or `const` for trait-item declaration
   --> $DIR/issue-40006.rs:20:21

--- a/src/test/ui/if-without-block.rs
+++ b/src/test/ui/if-without-block.rs
@@ -1,0 +1,18 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let n = 1;
+    if 5 == {
+    //~^ NOTE this `if` statement has a condition, but no block
+        println!("five");
+    }
+}
+//~^ ERROR expected `{`, found `}`

--- a/src/test/ui/if-without-block.stderr
+++ b/src/test/ui/if-without-block.stderr
@@ -1,10 +1,10 @@
 error: expected `{`, found `}`
   --> $DIR/if-without-block.rs:17:1
    |
-13 |     if 5 == {
+LL |     if 5 == {
    |     -- this `if` statement has a condition, but no block
 ...
-17 | }
+LL | }
    | ^
 
 error: aborting due to previous error

--- a/src/test/ui/if-without-block.stderr
+++ b/src/test/ui/if-without-block.stderr
@@ -1,0 +1,11 @@
+error: expected `{`, found `}`
+  --> $DIR/if-without-block.rs:17:1
+   |
+13 |     if 5 == {
+   |     -- this `if` statement has a condition, but no block
+...
+17 | }
+   | ^
+
+error: aborting due to previous error
+

--- a/src/test/ui/macro-context.stderr
+++ b/src/test/ui/macro-context.stderr
@@ -38,7 +38,7 @@ error: expected expression, found reserved keyword `typeof`
   --> $DIR/macro-context.rs:13:17
    |
 LL |     () => ( i ; typeof );   //~ ERROR expected expression, found reserved keyword `typeof`
-   |                 ^^^^^^
+   |                 ^^^^^^ expected expression
 ...
 LL |     m!();
    |     ----- in this macro invocation

--- a/src/test/ui/missing-block-hint.stderr
+++ b/src/test/ui/missing-block-hint.stderr
@@ -2,7 +2,9 @@ error: expected `{`, found `=>`
   --> $DIR/missing-block-hint.rs:13:18
    |
 LL |         if (foo) => {} //~ ERROR expected `{`, found `=>`
-   |                  ^^ help: only necessary in match arms, not before if blocks
+   |         --       ^^
+   |         |
+   |         this `if` statement has a condition, but no block
 
 error: expected `{`, found `bar`
   --> $DIR/missing-block-hint.rs:17:13

--- a/src/test/ui/missing-block-hint.stderr
+++ b/src/test/ui/missing-block-hint.stderr
@@ -2,11 +2,13 @@ error: expected `{`, found `=>`
   --> $DIR/missing-block-hint.rs:13:18
    |
 LL |         if (foo) => {} //~ ERROR expected `{`, found `=>`
-   |                  ^^
+   |                  ^^ help: only necessary in match arms, not before if blocks
 
 error: expected `{`, found `bar`
   --> $DIR/missing-block-hint.rs:17:13
    |
+LL |         if (foo)
+   |         -- this `if` statement has a condition, but no block
 LL |             bar; //~ ERROR expected `{`, found `bar`
    |             ^^^-
    |             |

--- a/src/test/ui/resolve/token-error-correct.stderr
+++ b/src/test/ui/resolve/token-error-correct.stderr
@@ -26,7 +26,7 @@ error: expected expression, found `;`
   --> $DIR/token-error-correct.rs:14:13
    |
 LL |     foo(bar(;
-   |             ^
+   |             ^ expected expression
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/suggestions/missing-comma-in-match.rs
+++ b/src/test/ui/suggestions/missing-comma-in-match.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    match &Some(3) {
+        &None => 1
+        &Some(2) => { 3 }
+        //~^ ERROR expected one of `,`, `.`, `?`, `}`, or an operator, found `=>`
+        //~| NOTE expected one of `,`, `.`, `?`, `}`, or an operator here
+        //~^^^^ NOTE while parsing the match arm starting here
+        _ => 2
+    };
+}

--- a/src/test/ui/suggestions/missing-comma-in-match.rs
+++ b/src/test/ui/suggestions/missing-comma-in-match.rs
@@ -14,7 +14,6 @@ fn main() {
         &Some(2) => { 3 }
         //~^ ERROR expected one of `,`, `.`, `?`, `}`, or an operator, found `=>`
         //~| NOTE expected one of `,`, `.`, `?`, `}`, or an operator here
-        //~^^^^ NOTE while parsing the match arm starting here
         _ => 2
     };
 }

--- a/src/test/ui/suggestions/missing-comma-in-match.stderr
+++ b/src/test/ui/suggestions/missing-comma-in-match.stderr
@@ -2,9 +2,7 @@ error: expected one of `,`, `.`, `?`, `}`, or an operator, found `=>`
   --> $DIR/missing-comma-in-match.rs:14:18
    |
 13 |         &None => 1
-   |               --  - help: missing a comma here to end this match arm
-   |               |
-   |               while parsing the match arm starting here
+   |                   - help: missing a comma here to end this `match` arm
 14 |         &Some(2) => { 3 }
    |                  ^^ expected one of `,`, `.`, `?`, `}`, or an operator here
 

--- a/src/test/ui/suggestions/missing-comma-in-match.stderr
+++ b/src/test/ui/suggestions/missing-comma-in-match.stderr
@@ -1,0 +1,12 @@
+error: expected one of `,`, `.`, `?`, `}`, or an operator, found `=>`
+  --> $DIR/missing-comma-in-match.rs:14:18
+   |
+13 |         &None => 1
+   |               --  - help: missing a comma here to end this match arm
+   |               |
+   |               while parsing the match arm starting here
+14 |         &Some(2) => { 3 }
+   |                  ^^ expected one of `,`, `.`, `?`, `}`, or an operator here
+
+error: aborting due to previous error
+

--- a/src/test/ui/suggestions/missing-comma-in-match.stderr
+++ b/src/test/ui/suggestions/missing-comma-in-match.stderr
@@ -1,9 +1,9 @@
 error: expected one of `,`, `.`, `?`, `}`, or an operator, found `=>`
   --> $DIR/missing-comma-in-match.rs:14:18
    |
-13 |         &None => 1
+LL |         &None => 1
    |                   - help: missing a comma here to end this `match` arm
-14 |         &Some(2) => { 3 }
+LL |         &Some(2) => { 3 }
    |                  ^^ expected one of `,`, `.`, `?`, `}`, or an operator here
 
 error: aborting due to previous error

--- a/src/test/ui/token/issue-10636-2.stderr
+++ b/src/test/ui/token/issue-10636-2.stderr
@@ -20,7 +20,7 @@ error: expected expression, found `)`
   --> $DIR/issue-10636-2.rs:18:1
    |
 LL | } //~ ERROR: incorrect close delimiter
-   | ^
+   | ^ expected expression
 
 error[E0601]: main function not found
 


### PR DESCRIPTION
When finding:

```rust
match &Some(3) {
    &None => 1
    &Some(2) => { 3 }
    _ => 2
}
```

provide the following diagnostic:

```
error: expected one of `,`, `.`, `?`, `}`, or an operator, found `=>`
 --> $DIR/missing-comma-in-match.rs:15:18
  |
X |         &None => 1
  |               --  - help: missing comma
  |               |
  |               while parsing the match arm starting here
X |         &Some(2) => { 3 }
  |                  ^^ expected one of `,`, `.`, `?`, `}`, or an operator here
```

When unnecessarily using a fat arrow after an if condition, suggest the
removal of it.

```
error: expected `{`, found `=>`
  --> $DIR/missing-block-hint.rs:13:18
   |
13 |         if (foo) => {} //~ ERROR expected `{`, found `=>`
   |                  ^^ help: only necessary in match arms, not before if blocks
```

When finding an if statement with no block, point at the `if` keyword to
provide more context:

```

error: expected `{`, found `}`
  --> file.rs:6:1
   |
13 |     if 5 == {
   |     -- this `if` statement has a condition, but no block
...
17 | }
   | ^
```

Fix #29586, fix #30035.