### PR TITLE
Add missing link for read_line

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1506,6 +1506,8 @@ pub trait BufRead: Read {
     /// error is encountered then `buf` may contain some bytes already read in
     /// the event that all data read so far was valid UTF-8.
     ///
+    /// [`read_until`]: #method.read_until
+    ///
     /// # Examples
     ///
     /// [`std::io::Cursor`][`Cursor`] is a type that implements `BufRead`. In


### PR DESCRIPTION
Seems I found a missing link 🔗

https://doc.rust-lang.org/stable/std/io/trait.BufRead.html#errors-2