### PR TITLE
When encountering invalid token after `unsafe`, mention `{`

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -6469,6 +6469,8 @@ impl<'a> Parser<'a> {
             && self.look_ahead(1, |t| *t != token::OpenDelim(token::Brace)) {
             // UNSAFE FUNCTION ITEM
             self.bump(); // `unsafe`
+            // `{` is also expected after `unsafe`, in case of error, include it in the diagnostic
+            self.check(&token::OpenDelim(token::Brace));
             let abi = if self.eat_keyword(keywords::Extern) {
                 self.parse_opt_abi()?.unwrap_or(Abi::C)
             } else {

--- a/src/test/ui/unsafe-block-without-braces.rs
+++ b/src/test/ui/unsafe-block-without-braces.rs
@@ -1,0 +1,16 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    unsafe //{
+        std::mem::transmute::<f32, u32>(1.0);
+    //}
+}
+//~^^^ ERROR expected one of `extern`, `fn`, or `{`, found `std`

--- a/src/test/ui/unsafe-block-without-braces.stderr
+++ b/src/test/ui/unsafe-block-without-braces.stderr
@@ -1,0 +1,10 @@
+error: expected one of `extern`, `fn`, or `{`, found `std`
+  --> $DIR/unsafe-block-without-braces.rs:13:9
+   |
+12 |     unsafe //{
+   |           - expected one of `extern`, `fn`, or `{` here
+13 |         std::mem::transmute::<f32, u32>(1.0);
+   |         ^^^ unexpected token
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fix #37158.