### PR TITLE
More precise suggestion for non_upper_case_globals

### DIFF
--- a/src/librustc_lint/bad_style.rs
+++ b/src/librustc_lint/bad_style.rs
@@ -16,7 +16,7 @@ use lint::{LintPass, LateLintPass};
 use syntax::abi::Abi;
 use syntax::ast;
 use syntax::attr;
-use syntax_pos::Span;
+use syntax_pos::{BytePos, Span};
 
 use rustc::hir::{self, PatKind};
 use rustc::hir::intravisit::FnKind;
@@ -342,6 +342,17 @@ impl NonUpperCaseGlobals {
     fn check_upper_case(cx: &LateContext, sort: &str, name: ast::Name, span: Span) {
         if name.as_str().chars().any(|c| c.is_lowercase()) {
             let uc = NonSnakeCase::to_snake_case(&name.as_str()).to_uppercase();
+
+            let start = cx.tcx.sess.codemap().span_to_snippet(span)
+                .map(|snippet| snippet.find(name.as_str().chars().as_str()).unwrap_or(0))
+                .unwrap_or(0);
+            let end = start + name.as_str().len();
+            let span = Span::new(
+                span.lo() + BytePos(start as u32),
+                span.lo() + BytePos(end as u32),
+                span.ctxt()
+            );
+
             if name != &*uc {
                 cx.span_lint(NON_UPPER_CASE_GLOBALS,
                              span,

--- a/src/test/ui/lint/lint-group-style.stderr
+++ b/src/test/ui/lint/lint-group-style.stderr
@@ -25,10 +25,10 @@ note: lint level defined here
    = note: #[forbid(non_snake_case)] implied by #[forbid(bad_style)]
 
 error: static variable `bad` should have an upper case name such as `BAD`
-  --> $DIR/lint-group-style.rs:24:9
+  --> $DIR/lint-group-style.rs:24:16
    |
 24 |         static bad: isize = 1; //~ ERROR should have an upper
-   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^
    |
 note: lint level defined here
   --> $DIR/lint-group-style.rs:20:14

--- a/src/test/ui/lint/non-upper-case-globals.rs
+++ b/src/test/ui/lint/non-upper-case-globals.rs
@@ -1,0 +1,33 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(dead_code)]
+#![deny(non_upper_case_globals)]
+
+static foo: isize = 1;
+//~^ ERROR static variable `foo` should have an upper case name such as `FOO`
+
+static mut bar: isize = 1;
+//~^ ERROR static variable `bar` should have an upper case name such as `BAR`
+
+fn main() {
+    const b: usize = 1;
+    //~^ ERROR constant `b` should have an upper case name such as `B`
+}
+
+trait Foo {
+    const camelCase: usize;
+    //~^ ERROR associated constant `camelCase` should have an upper case name such as `CAMEL_CASE`
+}
+
+impl Foo for i32 {
+    const camelCase: usize = 2;
+    //~^ ERROR associated constant `camelCase` should have an upper case name such as `CAMEL_CASE`
+}

--- a/src/test/ui/lint/non-upper-case-globals.stderr
+++ b/src/test/ui/lint/non-upper-case-globals.stderr
@@ -1,0 +1,38 @@
+error: static variable `foo` should have an upper case name such as `FOO`
+  --> $DIR/non-upper-case-globals.rs:14:8
+   |
+14 | static foo: isize = 1;
+   |        ^^^
+   |
+note: lint level defined here
+  --> $DIR/non-upper-case-globals.rs:12:9
+   |
+12 | #![deny(non_upper_case_globals)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: static variable `bar` should have an upper case name such as `BAR`
+  --> $DIR/non-upper-case-globals.rs:17:12
+   |
+17 | static mut bar: isize = 1;
+   |            ^^^
+
+error: constant `b` should have an upper case name such as `B`
+  --> $DIR/non-upper-case-globals.rs:21:11
+   |
+21 |     const b: usize = 1;
+   |           ^
+
+error: associated constant `camelCase` should have an upper case name such as `CAMEL_CASE`
+  --> $DIR/non-upper-case-globals.rs:26:11
+   |
+26 |     const camelCase: usize;
+   |           ^^^^^^^^^
+
+error: associated constant `camelCase` should have an upper case name such as `CAMEL_CASE`
+  --> $DIR/non-upper-case-globals.rs:31:11
+   |
+31 |     const camelCase: usize = 2;
+   |           ^^^^^^^^^
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
This makes the suggestion span for the `non_upper_case_globals` lint a bit
more precise. Before it was highlighting the whole line. With this change
it will highlight only the variable name itself.

Currently the way the span is calculated doesn't look very nice.
Especially the `name.as_str().chars().as_str()` which I used to turn an
`InternedString` into a `&str`. Unfortunately I couldn't find a better way.

r? @Manishearth 

Fixes #48103 