### PR TITLE
rustbuild: Restore Config.libdir_relative

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -444,10 +444,11 @@ impl<'a> Builder<'a> {
 
             fn run(self, builder: &Builder) -> Interned<PathBuf> {
                 let compiler = self.compiler;
-                let lib = if compiler.stage >= 1 && builder.build.config.libdir_relative.is_some() {
-                    builder.build.config.libdir_relative.clone().unwrap()
+                let config = &builder.build.config;
+                let lib = if compiler.stage >= 1 && config.libdir_relative().is_some() {
+                    builder.build.config.libdir_relative().unwrap()
                 } else {
-                    PathBuf::from("lib")
+                    Path::new("lib")
                 };
                 let sysroot = builder.sysroot(self.compiler).join(lib)
                     .join("rustlib").join(self.target).join("lib");

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -444,8 +444,8 @@ impl<'a> Builder<'a> {
 
             fn run(self, builder: &Builder) -> Interned<PathBuf> {
                 let compiler = self.compiler;
-                let lib = if compiler.stage >= 1 && builder.build.config.libdir.is_some() {
-                    builder.build.config.libdir.clone().unwrap()
+                let lib = if compiler.stage >= 1 && builder.build.config.libdir_relative.is_some() {
+                    builder.build.config.libdir_relative.clone().unwrap()
                 } else {
                     PathBuf::from("lib")
                 };

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -517,7 +517,7 @@ fn rustc_cargo_env(build: &Build, cargo: &mut Command) {
          .env("CFG_PREFIX", build.config.prefix.clone().unwrap_or_default());
 
     let libdir_relative =
-        build.config.libdir.clone().unwrap_or(PathBuf::from("lib"));
+        build.config.libdir_relative.clone().unwrap_or(PathBuf::from("lib"));
     cargo.env("CFG_LIBDIR_RELATIVE", libdir_relative);
 
     // If we're not building a compiler with debugging information then remove

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -516,8 +516,7 @@ fn rustc_cargo_env(build: &Build, cargo: &mut Command) {
          .env("CFG_VERSION", build.rust_version())
          .env("CFG_PREFIX", build.config.prefix.clone().unwrap_or_default());
 
-    let libdir_relative =
-        build.config.libdir_relative.clone().unwrap_or(PathBuf::from("lib"));
+    let libdir_relative = build.config.libdir_relative().unwrap_or(Path::new("lib"));
     cargo.env("CFG_LIBDIR_RELATIVE", libdir_relative);
 
     // If we're not building a compiler with debugging information then remove

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -126,6 +126,7 @@ pub struct Config {
     pub docdir: Option<PathBuf>,
     pub bindir: Option<PathBuf>,
     pub libdir: Option<PathBuf>,
+    pub libdir_relative: Option<PathBuf>,
     pub mandir: Option<PathBuf>,
     pub codegen_tests: bool,
     pub nodejs: Option<PathBuf>,
@@ -415,6 +416,22 @@ impl Config {
             config.bindir = install.bindir.clone().map(PathBuf::from);
             config.libdir = install.libdir.clone().map(PathBuf::from);
             config.mandir = install.mandir.clone().map(PathBuf::from);
+        }
+
+        // Try to infer `libdir_relative` from `libdir`.
+        if let Some(ref libdir) = config.libdir {
+            let mut libdir = libdir.as_path();
+            if !libdir.is_relative() {
+                // Try to make it relative to the prefix.
+                if let Some(ref prefix) = config.prefix {
+                    if let Ok(suffix) = libdir.strip_prefix(prefix) {
+                        libdir = suffix;
+                    }
+                }
+            }
+            if libdir.is_relative() {
+                config.libdir_relative = Some(libdir.to_path_buf());
+            }
         }
 
         // Store off these values as options because if they're not provided


### PR DESCRIPTION
This re-introduces a `Config.libdir_relative` field, now derived from
`libdir` and made relative to `prefix` if necessary.

This fixes a regression from #46592 when `--libdir` is given an absolute
path.  `Builder::sysroot_libdir` should always use a relative path so
its callers don't clobber system locations, and `librustc` also asserts
that `CFG_LIBDIR_RELATIVE` is really relative.