### PR TITLE
HashMap, HashSet: impl Hash

### DIFF
--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1391,9 +1391,9 @@ impl<K, V, S> Hash for HashMap<K, V, S>
         // we might be able do so in the future.
         hasher.write_u64(
             self.iter()
-                .map(|(k, v)| {
+                .map(|kv| {
                     let mut h = DefaultHasher::new();
-                    (k, v).hash(&mut h);
+                    kv.hash(&mut h);
                     h.finish()
                 })
                 .fold(0, u64::wrapping_add)

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1378,13 +1378,14 @@ impl<K, V, S> Hash for HashMap<K, V, S>
 {
     fn hash<H: Hasher>(&self, hasher: &mut H) {
         // We must preserve:  x == y -> hash(x) == hash(y).
-        // HashMaps have no order, so we must use a commutative operation
-        // (.wrapping_add) so that the order does not matter.
+        // HashMaps have no order, so we must combine the elements with an
+        // associative and commutative operation • so that the order does not
+        // matter. In other words, (u64, •, 0) must form a commutative monoid.
+        // This is satisfied by • = u64::wrapping_add.
         //
-        // For this to hold, we must also ensure that the hashing of
-        // individual elements does not depend on the state of the given Hasher.
-        // So we ensure that hashing each individual element starts with the
-        // same state.
+        // We must further ensure that the hashing of individual elements does
+        // not depend on the state of the given Hasher. So we ensure that
+        // hashing each individual element starts with the same state.
         //
         // Unfortunately, we can't .clone() the hasher since we can't add more
         // constraints than H being a Hasher. With some sort of ConstraintKinds

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -757,6 +757,16 @@ impl<T, S> Eq for HashSet<T, S>
 {
 }
 
+#[unstable(feature = "hashmap_hash", issue = "0")]
+impl<T, S> Hash for HashSet<T, S>
+    where T: Eq + Hash,
+          S: BuildHasher
+{
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.map.hash(hasher);
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T, S> fmt::Debug for HashSet<T, S>
     where T: Eq + Hash + fmt::Debug,

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -10,7 +10,7 @@
 
 use borrow::Borrow;
 use fmt;
-use hash::{Hash, BuildHasher};
+use hash::{Hash, Hasher, BuildHasher};
 use iter::{Chain, FromIterator, FusedIterator};
 use ops::{BitOr, BitAnd, BitXor, Sub};
 


### PR DESCRIPTION
This PR makes `HashMap`s and `HashSet`s implement `Hash` themselves.
Since neither of those have any defined order among elements, a commutative operation is used (as well as an independent `Hasher` for each one) to ensure that the order in which they are hashed does not matter.

cc https://github.com/rust-lang/rfcs/issues/2190 for improving this in the future.

r? @alexcrichton 