### PR TITLE
Rename rdrnd target feature to rdrand

### DIFF
--- a/src/librustc_trans/llvm_util.rs
+++ b/src/librustc_trans/llvm_util.rs
@@ -83,18 +83,17 @@ const ARM_WHITELIST: &'static [&'static str] = &["neon", "v7", "vfp2", "vfp3", "
 
 const AARCH64_WHITELIST: &'static [&'static str] = &["neon", "v7"];
 
-const X86_WHITELIST: &'static [&'static str] = &["avx", "avx2", "bmi", "bmi2", "sse",
-                                                 "sse2", "sse3", "sse4.1", "sse4.2",
-                                                 "ssse3", "tbm", "lzcnt", "popcnt",
-                                                 "sse4a","fma", "rdrand", "rdseed",
-                                                 "xsave", "xsaveopt", "xsavec",
-                                                 "xsaves", "aes", "pclmulqdq",
-                                                 "avx512bw", "avx512cd",
-                                                 "avx512dq", "avx512er",
-                                                 "avx512f", "avx512ifma",
-                                                 "avx512pf", "avx512vbmi",
-                                                 "avx512vl", "avx512vpopcntdq",
-                                                 "mmx", "fxsr"];
+const X86_WHITELIST: &'static [&'static str] = &["aes", "avx", "avx2", "avx512bw",
+                                                 "avx512cd", "avx512dq", "avx512er",
+                                                 "avx512f", "avx512ifma", "avx512pf",
+                                                 "avx512vbmi", "avx512vl", "avx512vpopcntdq",
+                                                 "bmi", "bmi2", "fma", "fxsr",
+                                                 "lzcnt", "mmx", "pclmulqdq",
+                                                 "popcnt", "rdrand", "rdseed",
+                                                 "sse", "sse2", "sse3", "sse4.1",
+                                                 "sse4.2", "sse4a", "ssse3",
+                                                 "tbm", "xsave", "xsavec",
+                                                 "xsaveopt", "xsaves"];
 
 const HEXAGON_WHITELIST: &'static [&'static str] = &["hvx", "hvx-double"];
 

--- a/src/librustc_trans/llvm_util.rs
+++ b/src/librustc_trans/llvm_util.rs
@@ -75,9 +75,9 @@ unsafe fn configure_llvm(sess: &Session) {
                                  llvm_args.as_ptr());
 }
 
-// WARNING: the features must be known to LLVM or the feature
-// detection code will walk past the end of the feature array,
-// leading to crashes.
+// WARNING: the features after aplpying `to_llvm_feature` must be known
+// to LLVM or the feature detection code will walk past the end of the feature
+// array, leading to crashes.
 
 const ARM_WHITELIST: &'static [&'static str] = &["neon", "v7", "vfp2", "vfp3", "vfp4"];
 
@@ -86,7 +86,7 @@ const AARCH64_WHITELIST: &'static [&'static str] = &["neon", "v7"];
 const X86_WHITELIST: &'static [&'static str] = &["avx", "avx2", "bmi", "bmi2", "sse",
                                                  "sse2", "sse3", "sse4.1", "sse4.2",
                                                  "ssse3", "tbm", "lzcnt", "popcnt",
-                                                 "sse4a", "rdrnd", "rdseed", "fma",
+                                                 "sse4a","fma", "rdrand", "rdseed",
                                                  "xsave", "xsaveopt", "xsavec",
                                                  "xsaves", "aes", "pclmulqdq",
                                                  "avx512bw", "avx512cd",
@@ -108,6 +108,7 @@ const MIPS_WHITELIST: &'static [&'static str] = &["msa"];
 pub fn to_llvm_feature(s: &str) -> &str {
     match s {
         "pclmulqdq" => "pclmul",
+        "rdrand" => "rdrnd",
         s => s,
     }
 }

--- a/src/librustc_trans/llvm_util.rs
+++ b/src/librustc_trans/llvm_util.rs
@@ -75,7 +75,7 @@ unsafe fn configure_llvm(sess: &Session) {
                                  llvm_args.as_ptr());
 }
 
-// WARNING: the features after aplpying `to_llvm_feature` must be known
+// WARNING: the features after applying `to_llvm_feature` must be known
 // to LLVM or the feature detection code will walk past the end of the feature
 // array, leading to crashes.
 


### PR DESCRIPTION
Plus minor cleanup.

Related stdsimd [issue](https://github.com/rust-lang-nursery/stdsimd/issues/325).