### PR TITLE
Revert rust-lang/rust#46833 on stable

### DIFF
--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -372,7 +372,9 @@ fn should_abort_on_panic<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
     // unwind anyway. Don't stop them.
     if tcx.has_attr(tcx.hir.local_def_id(fn_id), "unwind") { return false; }
 
-    return true;
+    // FIXME(rust-lang/rust#48251) -- Had to disable abort-on-panic
+    // for backwards compatibility reasons.
+    false
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/test/run-pass/abort-on-c-abi.rs
+++ b/src/test/run-pass/abort-on-c-abi.rs
@@ -12,6 +12,7 @@
 // we never unwind through them.
 
 // ignore-emscripten no processes
+// ignore-test FIXME rust-lang/rust#48251 -- temporarily disabled
 
 use std::{env, panic};
 use std::io::prelude::*;


### PR DESCRIPTION
This is a minimal diff to disable rust-lang/rust#46833 on stable (due to rust-lang/rust#48251). I have a more expansive diff for master that allows us to opt back in.

r? @Mark-Simulacrum 