### PR TITLE
Add relro-level tests

### DIFF
--- a/src/librustc_back/lib.rs
+++ b/src/librustc_back/lib.rs
@@ -131,6 +131,7 @@ pub enum RelroLevel {
     Full,
     Partial,
     Off,
+    None,
 }
 
 impl RelroLevel {
@@ -139,6 +140,7 @@ impl RelroLevel {
             RelroLevel::Full => "full",
             RelroLevel::Partial => "partial",
             RelroLevel::Off => "off",
+            RelroLevel::None => "none",
         }
     }
 }
@@ -151,6 +153,7 @@ impl FromStr for RelroLevel {
             "full" => Ok(RelroLevel::Full),
             "partial" => Ok(RelroLevel::Partial),
             "off" => Ok(RelroLevel::Off),
+            "none" => Ok(RelroLevel::None),
             _ => Err(()),
         }
     }
@@ -162,6 +165,7 @@ impl ToJson for RelroLevel {
             RelroLevel::Full => "full".to_json(),
             RelroLevel::Partial => "partial".to_json(),
             RelroLevel::Off => "off".to_json(),
+            RelroLevel::None => "None".to_json(),
         }
     }
 }

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -514,7 +514,7 @@ impl Default for TargetOptions {
             has_rpath: false,
             no_default_libraries: true,
             position_independent_executables: false,
-            relro_level: RelroLevel::Off,
+            relro_level: RelroLevel::None,
             pre_link_objects_exe: Vec::new(),
             pre_link_objects_dll: Vec::new(),
             post_link_objects: Vec::new(),

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -1017,6 +1017,8 @@ fn link_args(cmd: &mut Linker,
         RelroLevel::Off => {
             cmd.no_relro();
         },
+        RelroLevel::None => {
+        },
     }
 
     // Pass optimization flags down to the linker.

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -1014,7 +1014,9 @@ fn link_args(cmd: &mut Linker,
         RelroLevel::Partial => {
             cmd.partial_relro();
         },
-        RelroLevel::Off => {},
+        RelroLevel::Off => {
+            cmd.no_relro();
+        },
     }
 
     // Pass optimization flags down to the linker.

--- a/src/librustc_trans/back/linker.rs
+++ b/src/librustc_trans/back/linker.rs
@@ -113,8 +113,9 @@ pub trait Linker {
     fn gc_sections(&mut self, keep_metadata: bool);
     fn position_independent_executable(&mut self);
     fn no_position_independent_executable(&mut self);
-    fn partial_relro(&mut self);
     fn full_relro(&mut self);
+    fn partial_relro(&mut self);
+    fn no_relro(&mut self);
     fn optimize(&mut self);
     fn debuginfo(&mut self);
     fn no_default_libraries(&mut self);
@@ -188,8 +189,9 @@ impl<'a> Linker for GccLinker<'a> {
     fn add_object(&mut self, path: &Path) { self.cmd.arg(path); }
     fn position_independent_executable(&mut self) { self.cmd.arg("-pie"); }
     fn no_position_independent_executable(&mut self) { self.cmd.arg("-no-pie"); }
-    fn partial_relro(&mut self) { self.linker_arg("-z,relro"); }
     fn full_relro(&mut self) { self.linker_arg("-z,relro,-z,now"); }
+    fn partial_relro(&mut self) { self.linker_arg("-z,relro"); }
+    fn no_relro(&mut self) { self.linker_arg("-z,norelro"); }
     fn build_static_executable(&mut self) { self.cmd.arg("-static"); }
     fn args(&mut self, args: &[String]) { self.cmd.args(args); }
 
@@ -452,11 +454,15 @@ impl<'a> Linker for MsvcLinker<'a> {
         // noop
     }
 
+    fn full_relro(&mut self) {
+        // noop
+    }
+
     fn partial_relro(&mut self) {
         // noop
     }
 
-    fn full_relro(&mut self) {
+    fn no_relro(&mut self) {
         // noop
     }
 
@@ -664,11 +670,15 @@ impl<'a> Linker for EmLinker<'a> {
         // noop
     }
 
+    fn full_relro(&mut self) {
+        // noop
+    }
+
     fn partial_relro(&mut self) {
         // noop
     }
 
-    fn full_relro(&mut self) {
+    fn no_relro(&mut self) {
         // noop
     }
 
@@ -829,10 +839,13 @@ impl Linker for WasmLd {
     fn position_independent_executable(&mut self) {
     }
 
+    fn full_relro(&mut self) {
+    }
+
     fn partial_relro(&mut self) {
     }
 
-    fn full_relro(&mut self) {
+    fn no_relro(&mut self) {
     }
 
     fn build_static_executable(&mut self) {

--- a/src/test/run-make/relro-levels/Makefile
+++ b/src/test/run-make/relro-levels/Makefile
@@ -1,0 +1,21 @@
+-include ../tools.mk
+
+# This tests the different -Zrelro-level values, and makes sure that they they work properly.
+
+all:
+ifeq ($(UNAME),Linux)
+	# Ensure that binaries built with the full relro level links them with both
+	# RELRO and BIND_NOW for doing eager symbol resolving.
+	$(RUSTC) -Zrelro-level=full hello.rs
+	readelf -l $(TMPDIR)/hello | grep -q GNU_RELRO
+	readelf -d $(TMPDIR)/hello | grep -q BIND_NOW
+
+	$(RUSTC) -Zrelro-level=partial hello.rs
+	readelf -l $(TMPDIR)/hello | grep -q GNU_RELRO
+
+	# Ensure that we're *not* built with RELRO when setting it to off.  We do
+	# not want to check for BIND_NOW however, as the linker might have that
+	# enabled by default.
+	$(RUSTC) -Zrelro-level=off hello.rs
+	! readelf -l $(TMPDIR)/hello | grep -q GNU_RELRO
+endif

--- a/src/test/run-make/relro-levels/hello.rs
+++ b/src/test/run-make/relro-levels/hello.rs
@@ -1,0 +1,13 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
The `relro-level` debugging flag was added in #43170 which was merged in July 2017.  This PR moves this flag to be a proper codegen flag.