### PR TITLE
[beta] properly run doctests in standalone markdown files with pulldown

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -434,7 +434,7 @@ fn partition_source(s: &str) -> (String, String) {
 pub struct Collector {
     pub tests: Vec<testing::TestDescAndFn>,
     // to be removed when hoedown will be definitely gone
-    pub old_tests: HashMap<String, Vec<String>>,
+    pub old_tests: HashMap<FileName, Vec<String>>,
 
     // The name of the test displayed to the user, separated by `::`.
     //
@@ -501,14 +501,8 @@ impl Collector {
         format!("{} - {} (line {})", filename, self.names.join("::"), line)
     }
 
-    // to be removed once hoedown is gone
-    fn generate_name_beginning(&self, filename: &FileName) -> String {
-        format!("{} - {} (line", filename, self.names.join("::"))
-    }
-
     pub fn add_old_test(&mut self, test: String, filename: FileName) {
-        let name_beg = self.generate_name_beginning(&filename);
-        let entry = self.old_tests.entry(name_beg)
+        let entry = self.old_tests.entry(filename.clone())
                                   .or_insert(Vec::new());
         entry.push(test.trim().to_owned());
     }
@@ -520,10 +514,9 @@ impl Collector {
         let name = self.generate_name(line, &filename);
         // to be removed when hoedown is removed
         if self.render_type == RenderType::Pulldown {
-            let name_beg = self.generate_name_beginning(&filename);
             let mut found = false;
             let test = test.trim().to_owned();
-            if let Some(entry) = self.old_tests.get_mut(&name_beg) {
+            if let Some(entry) = self.old_tests.get_mut(&filename) {
                 found = entry.remove_item(&test).is_some();
             }
             if !found {


### PR DESCRIPTION
This is a beta-specific fix for https://github.com/rust-lang/rust/issues/48327, since a different fix landed in nightly (https://github.com/rust-lang/rust/pull/48274) that is infeasible to backport.

The nature of the issue was that when running doctests on standalone Markdown files, rustdoc names the tests based on the headings in the files. Therefore, with the following `a.md`:

``````markdown
# My Cool Library

This is my cool library!

## Examples

Here's some cool code samples!

```rust
assert_eq!(2+2, 4);
```
``````

Running this file with `rustdoc --test a.md` would show a test named `a.md - my_cool_library::examples (line 9)`. So far, this works just fine between Hoedown and Pulldown. But it gets murkier when you introduce markup into your headings. Consider the following `b.md`:

``````markdown
# My Cool Library

This is my cool library!

## `libcool`

```rust
assert_eq!(2+2, 4);
```
``````

The code surrounding the different renderers handles this differently. Pulldown handles just the first `Text` event after seeing the header, so it names the test `b.md - my_cool_library::libcool (line 9)`. Hoedown, on the other hand, takes all the test within the heading, which Hoedown renders before handing to library code. Therefore, it will name the test `b.md - my_cool_library::_code_libcool__code_ (line 9)`. (Somewhere between rustdoc and libtest, the `</>` characters are replaced with underscores.)

This causes a problem with another piece of code: The one that checks for whether Pulldown detected a code block that Hoedown didn't. The test collector groups the "old tests" listing by the full test name, but it *inserts* with the Hoedown name, and *searches* for the Pulldown name! This creates a situation where when `b.md` from above is run, it can't find a matching test from the ones Hoedown extracted, so it discards it and emits a warning.

On nightly, this has been fixed by... ditching Hoedown entirely. This also removed the code that tracked the different test listings, and made it run the test anyway. Since backporting the Hoedown removal is infeasible (i'm personally relying on the change to ride the trains to give the stabilization enough time to complete), this instead chooses to group the test by the filename, instead of the full test name as before. This means that the test extractor finds the test properly, and properly runs the test.