### PR TITLE
[stable] 1.24.1 stable release

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,16 @@
+Version 1.24.1 (2018-03-01)
+==========================
+
+ - [Do not abort when unwinding through FFI][48251]
+ - [Emit UTF-16 files for linker arguments on Windows][48318]
+ - [Make the error index generator work again][48308]
+ - [Cargo will warn on Windows 7 if an update is needed][cargo/5069].
+
+[48251]: https://github.com/rust-lang/rust/issues/48251
+[48308]: https://github.com/rust-lang/rust/issues/48308
+[48318]: https://github.com/rust-lang/rust/issues/48318
+[cargo/5069]: https://github.com/rust-lang/cargo/pull/5069
+
 Version 1.24.0 (2018-02-15)
 ==========================
 

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -484,8 +484,8 @@ impl<'a> Builder<'a> {
              } else {
                  PathBuf::from("/path/to/nowhere/rustdoc/not/required")
              })
-             .env("TEST_MIRI", self.config.test_miri.to_string());
-
+             .env("TEST_MIRI", self.config.test_miri.to_string())
+             .env("RUSTC_ERROR_METADATA_DST", self.extended_error_dir());
         if let Some(n) = self.config.rust_codegen_units {
             cargo.env("RUSTC_CODEGEN_UNITS", n.to_string());
         }

--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -24,7 +24,7 @@ use Build;
 use config::Config;
 
 // The version number
-pub const CFG_RELEASE_NUM: &str = "1.24.0";
+pub const CFG_RELEASE_NUM: &str = "1.24.1";
 
 pub struct GitInfo {
     inner: Option<Info>,

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -980,7 +980,8 @@ impl Step for ErrorIndex {
         build.run(builder.tool_cmd(Tool::ErrorIndex)
                     .arg("markdown")
                     .arg(&output)
-                    .env("CFG_BUILD", &build.build));
+                    .env("CFG_BUILD", &build.build)
+                    .env("RUSTC_ERROR_METADATA_DST", build.extended_error_dir()));
 
         markdown_test(builder, compiler, &output);
     }

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -671,7 +671,8 @@ impl Step for ErrorIndex {
         index.arg(out.join("error-index.html"));
 
         // FIXME: shouldn't have to pass this env var
-        index.env("CFG_BUILD", &build.build);
+        index.env("CFG_BUILD", &build.build)
+             .env("RUSTC_ERROR_METADATA_DST", build.extended_error_dir());
 
         build.run(&mut index);
     }

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -721,6 +721,11 @@ impl Build {
         self.config.python.as_ref().unwrap()
     }
 
+    /// Temporary directory that extended error information is emitted to.
+    fn extended_error_dir(&self) -> PathBuf {
+        self.out.join("tmp/extended-error-metadata")
+    }
+
     /// Tests whether the `compiler` compiling for `target` should be forced to
     /// use a stage1 compiler instead.
     ///

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -372,7 +372,9 @@ fn should_abort_on_panic<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
     // unwind anyway. Don't stop them.
     if tcx.has_attr(tcx.hir.local_def_id(fn_id), "unwind") { return false; }
 
-    return true;
+    // FIXME(rust-lang/rust#48251) -- Had to disable abort-on-panic
+    // for backwards compatibility reasons.
+    false
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -776,7 +776,19 @@ fn exec_linker(sess: &Session, cmd: &mut Command, tmpdir: &Path)
         args.push_str("\n");
     }
     let file = tmpdir.join("linker-arguments");
-    fs::write(&file, args.as_bytes())?;
+    let bytes = if sess.target.target.options.is_like_msvc {
+        let mut out = vec![];
+        // start the stream with a UTF-16 BOM
+        for c in vec![0xFEFF].into_iter().chain(args.encode_utf16()) {
+            // encode in little endian
+            out.push(c as u8);
+            out.push((c >> 8) as u8);
+        }
+        out
+    } else {
+        args.into_bytes()
+    };
+    fs::write(&file, &bytes)?;
     cmd2.arg(format!("@{}", file.display()));
     return cmd2.output();
 

--- a/src/libsyntax/diagnostics/metadata.rs
+++ b/src/libsyntax/diagnostics/metadata.rs
@@ -14,18 +14,16 @@
 //! currently always a crate name.
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::env;
 use std::fs::{remove_file, create_dir_all, File};
 use std::io::Write;
+use std::path::PathBuf;
 use std::error::Error;
 use rustc_serialize::json::as_json;
 
 use syntax_pos::{Span, FileName};
 use ext::base::ExtCtxt;
 use diagnostics::plugin::{ErrorMap, ErrorInfo};
-
-// Default metadata directory to use for extended error JSON.
-const ERROR_METADATA_PREFIX: &'static str = "tmp/extended-errors";
 
 /// JSON encodable/decodable version of `ErrorInfo`.
 #[derive(PartialEq, RustcDecodable, RustcEncodable)]
@@ -59,7 +57,10 @@ impl ErrorLocation {
 ///
 /// See `output_metadata`.
 pub fn get_metadata_dir(prefix: &str) -> PathBuf {
-    PathBuf::from(ERROR_METADATA_PREFIX).join(prefix)
+    env::var_os("RUSTC_ERROR_METADATA_DST")
+        .map(PathBuf::from)
+        .expect("env var `RUSTC_ERROR_METADATA_DST` isn't set")
+        .join(prefix)
 }
 
 /// Map `name` to a path in the given directory: <directory>/<name>.json

--- a/src/test/run-pass/abort-on-c-abi.rs
+++ b/src/test/run-pass/abort-on-c-abi.rs
@@ -12,6 +12,7 @@
 // we never unwind through them.
 
 // ignore-emscripten no processes
+// ignore-test FIXME rust-lang/rust#48251 -- temporarily disabled
 
 use std::{env, panic};
 use std::io::prelude::*;


### PR DESCRIPTION
The includes the following commits:
 - 6a600f827b632fb798b9ca52345130748fe86a30: Fixes #48251, unwinding through FFI no longer aborts
 - https://github.com/cuviper/rust/commit/b445a52ea322758fb7b60fab5f890ef8c0f8df9c: Fixes https://github.com/rust-lang/rust/issues/48308, fixing the error index generator
 - f8e00d0dc221564701ecdbb6dde57e0e9dd12900: Fixes https://github.com/rust-lang/rust/issues/48318 by emitting UTF-16 output on MSVC targets.
 - 2a0af8c448: Bumps the version number to 1.24.1.
 - 93220f0f45: Release notes
 - 6031718d8836f95bbfeddfaa63f1ee1d66e53f26: Cargo TLS warnings on Windows.