### PR TITLE
test: Fix s390x-unknown-linux-gnu atomic-lock-free test not run for systemz

### DIFF
--- a/src/test/run-make/atomic-lock-free/Makefile
+++ b/src/test/run-make/atomic-lock-free/Makefile
@@ -36,6 +36,8 @@ ifeq ($(filter powerpc,$(LLVM_COMPONENTS)),powerpc)
 	nm "$(TMPDIR)/libatomic_lock_free.rlib" | $(CGREP) -v __atomic_fetch_add
 	$(RUSTC) --target=powerpc64le-unknown-linux-gnu atomic_lock_free.rs
 	nm "$(TMPDIR)/libatomic_lock_free.rlib" | $(CGREP) -v __atomic_fetch_add
+endif
+ifeq ($(filter systemz,$(LLVM_COMPONENTS)),systemz)
 	$(RUSTC) --target=s390x-unknown-linux-gnu atomic_lock_free.rs
 	nm "$(TMPDIR)/libatomic_lock_free.rlib" | $(CGREP) -v __atomic_fetch_add
 endif


### PR DESCRIPTION
The s390-unknown-linux-gnu atomic-lock-free test is currently run for ```LLVM_COMPONENTS == powerpc```. I assume it was meant to be run for ```LLVM_COMPONENTS == systemz```, so let's fix this.