### PR TITLE
Workaround abort(2) on compilation error on FreeBSD.

### DIFF
--- a/src/librustc_back/target/freebsd_base.rs
+++ b/src/librustc_back/target/freebsd_base.rs
@@ -33,6 +33,7 @@ pub fn opts() -> TargetOptions {
         has_rpath: true,
         pre_link_args: args,
         position_independent_executables: true,
+        eliminate_frame_pointer: false, // FIXME 43575
         relro_level: RelroLevel::Full,
         exe_allocation_crate: super::maybe_jemalloc(),
         .. Default::default()


### PR DESCRIPTION
Same problem as OpenBSD, tracking bug #43575.
