### PR TITLE
Restrict the Termination impls to simplify stabilization

### DIFF
--- a/src/test/run-pass/rfc-1937-termination-trait/termination-trait-for-exitcode.rs
+++ b/src/test/run-pass/rfc-1937-termination-trait/termination-trait-for-exitcode.rs
@@ -9,7 +9,10 @@
 // except according to those terms.
 
 #![feature(termination_trait)]
+#![feature(process_exitcode_placeholder)]
 
-fn main() -> i32 {
-    0
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    ExitCode(0)
 }


### PR DESCRIPTION
Make a minimal commitment in preparation for stabilization.  More impls, or broader ones, are likely in future, but are not necessary at this time and are more controversial.

cc https://github.com/rust-lang/rust/issues/48453#issuecomment-368155082
r? @nikomatsakis 