### PR TITLE
Slight modification to the as_ref example of std::option::Option

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -237,7 +237,6 @@ impl<T> Option<T> {
     /// // First, cast `Option<String>` to `Option<&String>` with `as_ref`,
     /// // then consume *that* with `map`, leaving `text` on the stack.
     /// let text_length: Option<usize> = text.as_ref().map(|s| s.len());
-    /// println!("text length: {}", text_length);
     /// println!("still can print text: {:?}", text);
     /// ```
     #[inline]

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -233,11 +233,12 @@ impl<T> Option<T> {
     /// [`usize`]: ../../std/primitive.usize.html
     ///
     /// ```
-    /// let num_as_str: Option<String> = Some("12".to_string());
+    /// let text: Option<String> = Some("Hello, world!".to_string());
     /// // First, cast `Option<String>` to `Option<&String>` with `as_ref`,
-    /// // then consume *that* with `map`, leaving `num_as_str` on the stack.
-    /// let num_length: Option<usize> = num_as_str.as_ref().map(|n| n.len());
-    /// println!("still can print num_as_str: {:?}", num_as_str);
+    /// // then consume *that* with `map`, leaving `text` on the stack.
+    /// let text_length: Option<usize> = text.as_ref().map(|s| s.len());
+    /// println!("text length: {}", text_length);
+    /// println!("still can print text: {:?}", text);
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -233,10 +233,10 @@ impl<T> Option<T> {
     /// [`usize`]: ../../std/primitive.usize.html
     ///
     /// ```
-    /// let num_as_str: Option<String> = Some("10".to_string());
+    /// let num_as_str: Option<String> = Some("12".to_string());
     /// // First, cast `Option<String>` to `Option<&String>` with `as_ref`,
     /// // then consume *that* with `map`, leaving `num_as_str` on the stack.
-    /// let num_as_int: Option<usize> = num_as_str.as_ref().map(|n| n.len());
+    /// let num_length: Option<usize> = num_as_str.as_ref().map(|n| n.len());
     /// println!("still can print num_as_str: {:?}", num_as_str);
     /// ```
     #[inline]


### PR DESCRIPTION
A user in a reddit thread was confused by the name of the variable
"num_as_int"; they thought the example was trying to convert the
string "10" as if it were binary 2 by calling str::len(). In reality,
the example is simply demonstrating how to take an immutable reference
to the value of an Option. The confusion comes from the coincidence
that the length of the string "10" is also its binary representation,
and the implication from the variable names that a conversion was
occuring ("num_as_str" to "num_as_int").

This PR changes the example number to 12 instead of 10, and changes
the variable name from "num_as_int" to "num_length" to better
communicate what the example is doing.

The reddit thread:
https://www.reddit.com/r/rust/comments/7zpvev/notyetawesome_rust_what_use_cases_would_you_like/dur39xw/