### PR TITLE
[rustbuild] Implement testing and refactor configuration

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -130,6 +130,7 @@ dependencies = [
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pretty_assertions 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -525,6 +526,11 @@ dependencies = [
 [[package]]
 name = "diff"
 version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "difference"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1354,6 +1360,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "pkg-config"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pretty_assertions"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "proc_macro"
@@ -2804,6 +2819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum curl-sys 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f46e49c7125131f5afaded06944d6888b55cbdf8eba05dae73c954019b907961"
 "checksum derive-new 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "415f627ab054041c3eb748c2e1da0ef751989f5f0c386b63a098e545854a98ba"
 "checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
+"checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d8acd393692c503b168471874953a2531df0e9ab77d0b6bbc582395743300a4a"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum duct 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e45aa15fe0a8a8f511e6d834626afd55e49b62e5c8802e18328a87e8a8f6065c"
@@ -2887,6 +2903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pest 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0a6dda33d67c26f0aac90d324ab2eb7239c819fc7b2552fe9faa4fe88441edc8"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
+"checksum pretty_assertions 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "693786a0719bce004cf22e8d1923f678ba47b1e01589a973146cb10fe1be677e"
 "checksum pulldown-cmark 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "378e941dbd392c101f2cb88097fa4d7167bc421d4b88de3ff7dbee503bc3233b"
 "checksum pulldown-cmark 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d6fdf85cda6cadfae5428a54661d431330b312bc767ddbc57adbedc24da66e32"
 "checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -42,3 +42,6 @@ serde_json = "1.0.2"
 toml = "0.4"
 lazy_static = "0.2"
 time = "0.1"
+
+[dev-dependencies]
+pretty_assertions = "0.5"

--- a/src/bootstrap/bin/main.rs
+++ b/src/bootstrap/bin/main.rs
@@ -21,7 +21,7 @@ extern crate bootstrap;
 
 use std::env;
 
-use bootstrap::{Config, Build};
+use bootstrap::{Build, Config};
 
 fn main() {
     let args = env::args().skip(1).collect::<Vec<_>>();

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -95,7 +95,7 @@ fn main() {
     let rustc = env::var_os(rustc).unwrap_or_else(|| panic!("{:?} was not set", rustc));
     let libdir = env::var_os(libdir).unwrap_or_else(|| panic!("{:?} was not set", libdir));
     let mut dylib_path = bootstrap::util::dylib_path();
-    dylib_path.insert(0, PathBuf::from(libdir));
+    dylib_path.insert(0, PathBuf::from(&libdir));
 
     let mut cmd = Command::new(rustc);
     cmd.args(&args)
@@ -107,7 +107,7 @@ fn main() {
     if let Some(target) = target {
         // The stage0 compiler has a special sysroot distinct from what we
         // actually downloaded, so we just always pass the `--sysroot` option.
-        cmd.arg("--sysroot").arg(sysroot);
+        cmd.arg("--sysroot").arg(&sysroot);
 
         // When we build Rust dylibs they're all intended for intermediate
         // usage, so make sure we pass the -Cprefer-dynamic flag instead of
@@ -280,6 +280,8 @@ fn main() {
 
     if verbose > 1 {
         eprintln!("rustc command: {:?}", cmd);
+        eprintln!("sysroot: {:?}", sysroot);
+        eprintln!("libdir: {:?}", libdir);
     }
 
     // Actually run the compiler!

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -45,12 +45,15 @@ fn main() {
             // Dirty code for borrowing issues
             let mut new = None;
             if let Some(current_as_str) = args[i].to_str() {
-                if (&*args[i - 1] == "-C" && current_as_str.starts_with("metadata")) ||
-                   current_as_str.starts_with("-Cmetadata") {
+                if (&*args[i - 1] == "-C" && current_as_str.starts_with("metadata"))
+                    || current_as_str.starts_with("-Cmetadata")
+                {
                     new = Some(format!("{}-{}", current_as_str, s));
                 }
             }
-            if let Some(new) = new { args[i] = new.into(); }
+            if let Some(new) = new {
+                args[i] = new.into();
+            }
         }
     }
 
@@ -101,8 +104,10 @@ fn main() {
     cmd.args(&args)
         .arg("--cfg")
         .arg(format!("stage{}", stage))
-        .env(bootstrap::util::dylib_path_var(),
-             env::join_paths(&dylib_path).unwrap());
+        .env(
+            bootstrap::util::dylib_path_var(),
+            env::join_paths(&dylib_path).unwrap(),
+        );
 
     if let Some(target) = target {
         // The stage0 compiler has a special sysroot distinct from what we
@@ -130,9 +135,7 @@ fn main() {
             cmd.arg(format!("-Clinker={}", target_linker));
         }
 
-        let crate_name = args.windows(2)
-            .find(|a| &*a[0] == "--crate-name")
-            .unwrap();
+        let crate_name = args.windows(2).find(|a| &*a[0] == "--crate-name").unwrap();
         let crate_name = &*crate_name[1];
 
         // If we're compiling specifically the `panic_abort` crate then we pass
@@ -147,8 +150,7 @@ fn main() {
         // `compiler_builtins` are unconditionally compiled with panic=abort to
         // workaround undefined references to `rust_eh_unwind_resume` generated
         // otherwise, see issue https://github.com/rust-lang/rust/issues/43095.
-        if crate_name == "panic_abort" ||
-           crate_name == "compiler_builtins" && stage != "0" {
+        if crate_name == "panic_abort" || crate_name == "compiler_builtins" && stage != "0" {
             cmd.arg("-C").arg("panic=abort");
         }
 
@@ -160,7 +162,11 @@ fn main() {
             cmd.arg("-Cdebuginfo=1");
         }
         let debug_assertions = match env::var("RUSTC_DEBUG_ASSERTIONS") {
-            Ok(s) => if s == "true" { "y" } else { "n" },
+            Ok(s) => if s == "true" {
+                "y"
+            } else {
+                "n"
+            },
             Err(..) => "n",
         };
 
@@ -169,7 +175,8 @@ fn main() {
         if crate_name == "compiler_builtins" {
             cmd.arg("-C").arg("debug-assertions=no");
         } else {
-            cmd.arg("-C").arg(format!("debug-assertions={}", debug_assertions));
+            cmd.arg("-C")
+                .arg(format!("debug-assertions={}", debug_assertions));
         }
 
         if let Ok(s) = env::var("RUSTC_CODEGEN_UNITS") {
@@ -182,10 +189,12 @@ fn main() {
         // Emit save-analysis info.
         if env::var("RUSTC_SAVE_ANALYSIS") == Ok("api".to_string()) {
             cmd.arg("-Zsave-analysis");
-            cmd.env("RUST_SAVE_ANALYSIS_CONFIG",
-                    "{\"output_file\": null,\"full_docs\": false,\
-                     \"pub_only\": true,\"reachable_only\": false,\
-                     \"distro_crate\": true,\"signatures\": false,\"borrow_data\": false}");
+            cmd.env(
+                "RUST_SAVE_ANALYSIS_CONFIG",
+                "{\"output_file\": null,\"full_docs\": false,\
+                 \"pub_only\": true,\"reachable_only\": false,\
+                 \"distro_crate\": true,\"signatures\": false,\"borrow_data\": false}",
+            );
         }
 
         // Dealing with rpath here is a little special, so let's go into some
@@ -216,7 +225,6 @@ fn main() {
         // to change a flag in a binary?
         if env::var("RUSTC_RPATH") == Ok("true".to_string()) {
             let rpath = if target.contains("apple") {
-
                 // Note that we need to take one extra step on macOS to also pass
                 // `-Wl,-instal_name,@rpath/...` to get things to work right. To
                 // do that we pass a weird flag to the compiler to get it to do
@@ -244,7 +252,10 @@ fn main() {
         }
 
         // When running miri tests, we need to generate MIR for all libraries
-        if env::var("TEST_MIRI").ok().map_or(false, |val| val == "true") {
+        if env::var("TEST_MIRI")
+            .ok()
+            .map_or(false, |val| val == "true")
+        {
             cmd.arg("-Zalways-encode-mir");
             if stage != "0" {
                 cmd.arg("-Zmiri");

--- a/src/bootstrap/bin/rustdoc.rs
+++ b/src/bootstrap/bin/rustdoc.rs
@@ -45,8 +45,10 @@ fn main() {
         .arg("dox")
         .arg("--sysroot")
         .arg(sysroot)
-        .env(bootstrap::util::dylib_path_var(),
-             env::join_paths(&dylib_path).unwrap());
+        .env(
+            bootstrap::util::dylib_path_var(),
+            env::join_paths(&dylib_path).unwrap(),
+        );
 
     // Force all crates compiled by this compiler to (a) be unstable and (b)
     // allow the `rustc_private` feature to link to other unstable crates
@@ -55,7 +57,10 @@ fn main() {
         cmd.arg("-Z").arg("force-unstable-if-unmarked");
     }
     if let Some(linker) = env::var_os("RUSTC_TARGET_LINKER") {
-        cmd.arg("--linker").arg(linker).arg("-Z").arg("unstable-options");
+        cmd.arg("--linker")
+            .arg(linker)
+            .arg("-Z")
+            .arg("unstable-options");
     }
 
     // Bootstrap's Cargo-command builder sets this variable to the current Rust version; let's pick
@@ -63,8 +68,9 @@ fn main() {
     if let Some(version) = env::var_os("RUSTDOC_CRATE_VERSION") {
         // This "unstable-options" can be removed when `--crate-version` is stabilized
         cmd.arg("-Z")
-           .arg("unstable-options")
-           .arg("--crate-version").arg(version);
+            .arg("unstable-options")
+            .arg("--crate-version")
+            .arg(version);
     }
 
     if verbose > 1 {

--- a/src/bootstrap/bin/sccache-plus-cl.rs
+++ b/src/bootstrap/bin/sccache-plus-cl.rs
@@ -20,12 +20,12 @@ fn main() {
     env::remove_var("CXX");
     let mut cfg = cc::Build::new();
     cfg.cargo_metadata(false)
-       .out_dir("/")
-       .target(&target)
-       .host(&target)
-       .opt_level(0)
-       .warnings(false)
-       .debug(false);
+        .out_dir("/")
+        .target(&target)
+        .host(&target)
+        .opt_level(0)
+        .warnings(false)
+        .debug(false);
     let compiler = cfg.get_compiler();
 
     // Invoke sccache with said compiler

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -751,6 +751,7 @@ def bootstrap():
     env["SRC"] = build.rust_root
     env["BOOTSTRAP_PARENT_ID"] = str(os.getpid())
     env["BOOTSTRAP_PYTHON"] = sys.executable
+    env["BUILD_DIR"] = build.build_dir
     run(args, env=env, verbose=build.verbose)
 
 

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -60,9 +60,6 @@ pub trait Step: 'static + Clone + Debug + PartialEq + Eq + Hash {
     /// Run this rule for all hosts without cross compiling.
     const ONLY_HOSTS: bool = false;
 
-    /// Only run this step with the build triple as host and target.
-    const ONLY_BUILD: bool = false;
-
     /// Primary function to execute this rule. Can call `builder.ensure(...)`
     /// with other steps to run those.
     fn run(self, builder: &Builder) -> Self::Output;
@@ -98,7 +95,6 @@ pub struct RunConfig<'a> {
 struct StepDescription {
     default: bool,
     only_hosts: bool,
-    only_build: bool,
     should_run: fn(ShouldRun) -> ShouldRun,
     make_run: fn(RunConfig),
     name: &'static str,
@@ -134,7 +130,6 @@ impl StepDescription {
         StepDescription {
             default: S::DEFAULT,
             only_hosts: S::ONLY_HOSTS,
-            only_build: S::ONLY_BUILD,
             should_run: S::should_run,
             make_run: S::make_run,
             name: unsafe { ::std::intrinsics::type_name::<S>() },
@@ -150,18 +145,12 @@ impl StepDescription {
                 self.name, builder.config.exclude);
         }
         let build = builder.build;
-        let hosts = if self.only_build {
-            build.build_triple()
-        } else {
-            &build.hosts
-        };
+        let hosts = &build.hosts;
 
         // Determine the targets participating in this rule.
         let targets = if self.only_hosts {
             if build.config.run_host_only {
                 &[]
-            } else if self.only_build {
-                build.build_triple()
             } else {
                 &build.hosts
             }

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -149,8 +149,8 @@ impl StepDescription {
 
         // Determine the targets participating in this rule.
         let targets = if self.only_hosts {
-            if build.config.run_host_only {
-                &[]
+            if !build.config.run_host_only {
+                return; // don't run anything
             } else {
                 &build.hosts
             }

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -60,9 +60,6 @@ pub trait Step: 'static + Clone + Debug + PartialEq + Eq + Hash {
     /// Run this rule for all hosts without cross compiling.
     const ONLY_HOSTS: bool = false;
 
-    /// Run this rule for all targets, but only with the native host.
-    const ONLY_BUILD_TARGETS: bool = false;
-
     /// Only run this step with the build triple as host and target.
     const ONLY_BUILD: bool = false;
 
@@ -101,7 +98,6 @@ pub struct RunConfig<'a> {
 struct StepDescription {
     default: bool,
     only_hosts: bool,
-    only_build_targets: bool,
     only_build: bool,
     should_run: fn(ShouldRun) -> ShouldRun,
     make_run: fn(RunConfig),
@@ -138,7 +134,6 @@ impl StepDescription {
         StepDescription {
             default: S::DEFAULT,
             only_hosts: S::ONLY_HOSTS,
-            only_build_targets: S::ONLY_BUILD_TARGETS,
             only_build: S::ONLY_BUILD,
             should_run: S::should_run,
             make_run: S::make_run,
@@ -155,7 +150,7 @@ impl StepDescription {
                 self.name, builder.config.exclude);
         }
         let build = builder.build;
-        let hosts = if self.only_build_targets || self.only_build {
+        let hosts = if self.only_build {
             build.build_triple()
         } else {
             &build.hosts

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -432,7 +432,7 @@ impl<'a> Builder<'a> {
                 let compiler = self.compiler;
                 let config = &builder.build.config;
                 let lib = if compiler.stage >= 1 && config.libdir_relative().is_some() {
-                    builder.build.config.libdir_relative().unwrap()
+                    config.libdir_relative().unwrap()
                 } else {
                     Path::new("lib")
                 };

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -480,7 +480,7 @@ impl<'a> Builder<'a> {
     /// Get a path to the compiler specified.
     pub fn rustc(&self, compiler: Compiler) -> PathBuf {
         if compiler.is_snapshot(self) {
-            self.initial_rustc.clone()
+            self.config.initial_rustc.clone()
         } else {
             self.sysroot(compiler).join("bin").join(exe("rustc", &compiler.host))
         }
@@ -518,7 +518,7 @@ impl<'a> Builder<'a> {
              mode: Mode,
              target: Interned<String>,
              cmd: &str) -> Command {
-        let mut cargo = Command::new(&self.initial_cargo);
+        let mut cargo = Command::new(&self.config.initial_cargo);
         let out_dir = self.stage_out(compiler, mode);
         cargo.env("CARGO_TARGET_DIR", out_dir)
              .arg(cmd)
@@ -644,7 +644,7 @@ impl<'a> Builder<'a> {
         // If LLVM support is disabled we need to use the snapshot compiler to compile
         // build scripts, as the new compiler doesn't support executables.
         if mode == Mode::Libstd || !self.build.config.llvm_enabled {
-            cargo.env("RUSTC_SNAPSHOT", &self.initial_rustc)
+            cargo.env("RUSTC_SNAPSHOT", &self.config.initial_rustc)
                  .env("RUSTC_SNAPSHOT_LIBDIR", self.rustc_snapshot_libdir());
         } else {
             self.ensure(compile::Std { compiler, target: compiler.host });

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -791,6 +791,7 @@ impl<'a> Builder<'a> {
         cmd: &'static str,
     ) -> CargoCommand {
         let mut cargo = Command::new(&self.config.general.initial_cargo);
+        cargo.arg(cmd);
         let out_dir = self.stage_out(compiler, mode);
         self.clear_if_dirty(&out_dir, &self.rustc(compiler));
 
@@ -840,7 +841,6 @@ impl<'a> Builder<'a> {
 
         cargo
             .env("CARGO_TARGET_DIR", out_dir)
-            .arg(cmd)
             .arg("--target")
             .arg(target);
 

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -491,7 +491,7 @@ impl<'a> Builder<'a> {
     }
 
     pub fn rustdoc_cmd(&self, host: Interned<String>) -> Command {
-        let mut cmd = Command::new(&self.config.out.join("bootstrap/debug/rustdoc"));
+        let mut cmd = Command::new(&self.config.general.out.join("bootstrap/debug/rustdoc"));
         let compiler = self.compiler(self.top_stage, host);
         cmd.env("RUSTC_STAGE", compiler.stage.to_string())
            .env("RUSTC_SYSROOT", self.sysroot(compiler))
@@ -562,7 +562,7 @@ impl<'a> Builder<'a> {
         // These variables are primarily all read by
         // src/bootstrap/bin/{rustc.rs,rustdoc.rs}
         cargo.env("RUSTBUILD_NATIVE_DIR", self.native_dir(target))
-             .env("RUSTC", self.config.out.join("bootstrap/debug/rustc"))
+             .env("RUSTC", self.config.general.out.join("bootstrap/debug/rustc"))
              .env("RUSTC_REAL", self.rustc(compiler))
              .env("RUSTC_STAGE", stage.to_string())
              .env("RUSTC_DEBUG_ASSERTIONS",
@@ -570,7 +570,7 @@ impl<'a> Builder<'a> {
              .env("RUSTC_SYSROOT", self.sysroot(compiler))
              .env("RUSTC_LIBDIR", self.rustc_libdir(compiler))
              .env("RUSTC_RPATH", self.config.rust.rpath.to_string())
-             .env("RUSTDOC", self.config.out.join("bootstrap/debug/rustdoc"))
+             .env("RUSTDOC", self.config.general.out.join("bootstrap/debug/rustdoc"))
              .env("RUSTDOC_REAL", if cmd == "doc" || cmd == "test" {
                  self.rustdoc(compiler.host)
              } else {

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -643,7 +643,7 @@ impl<'a> Builder<'a> {
         //
         // If LLVM support is disabled we need to use the snapshot compiler to compile
         // build scripts, as the new compiler doesn't support executables.
-        if mode == Mode::Libstd || !self.build.config.llvm_enabled {
+        if mode == Mode::Libstd || !self.build.config.llvm.enabled {
             cargo.env("RUSTC_SNAPSHOT", &self.config.initial_rustc)
                  .env("RUSTC_SNAPSHOT_LIBDIR", self.rustc_snapshot_libdir());
         } else {

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1284,8 +1284,8 @@ impl<'a> CargoCommand<'a> {
             for filename in json["filenames"].as_array().unwrap() {
                 let filename = filename.as_str().unwrap();
                 // Skip files like executables
-                if !filename.ends_with(".rlib") && !filename.ends_with(".lib") && !is_dylib(&filename)
-                    && !(is_check && filename.ends_with(".rmeta"))
+                if !filename.ends_with(".rlib") && !filename.ends_with(".lib")
+                    && !is_dylib(&filename) && !(is_check && filename.ends_with(".rmeta"))
                 {
                     continue;
                 }
@@ -1354,7 +1354,9 @@ impl<'a> CargoCommand<'a> {
                     && filename.ends_with(&extension[..]) && meta.len() == expected_len
             });
             let max = candidates
-                .max_by_key(|&&(_, _, ref metadata)| FileTime::from_last_modification_time(metadata));
+                .max_by_key(|&&(_, _, ref metadata)| {
+                    FileTime::from_last_modification_time(metadata)
+                });
             let path_to_add = match max {
                 Some(triple) => triple.0.to_str().unwrap(),
                 None => panic!("no output generated for {:?} {:?}", prefix, extension),

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -480,7 +480,7 @@ impl<'a> Builder<'a> {
     /// Get a path to the compiler specified.
     pub fn rustc(&self, compiler: Compiler) -> PathBuf {
         if compiler.is_snapshot(self) {
-            self.config.initial_rustc.clone()
+            self.config.general.initial_rustc.clone()
         } else {
             self.sysroot(compiler).join("bin").join(exe("rustc", &compiler.host))
         }
@@ -518,7 +518,7 @@ impl<'a> Builder<'a> {
              mode: Mode,
              target: Interned<String>,
              cmd: &str) -> Command {
-        let mut cargo = Command::new(&self.config.initial_cargo);
+        let mut cargo = Command::new(&self.config.general.initial_cargo);
         let out_dir = self.stage_out(compiler, mode);
         cargo.env("CARGO_TARGET_DIR", out_dir)
              .arg(cmd)
@@ -644,7 +644,7 @@ impl<'a> Builder<'a> {
         // If LLVM support is disabled we need to use the snapshot compiler to compile
         // build scripts, as the new compiler doesn't support executables.
         if mode == Mode::Libstd || !self.build.config.llvm.enabled {
-            cargo.env("RUSTC_SNAPSHOT", &self.config.initial_rustc)
+            cargo.env("RUSTC_SNAPSHOT", &self.config.general.initial_rustc)
                  .env("RUSTC_SNAPSHOT_LIBDIR", self.rustc_snapshot_libdir());
         } else {
             self.ensure(compile::Std { compiler, target: compiler.host });

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -495,7 +495,7 @@ impl<'a> Builder<'a> {
         let compiler = self.compiler(self.top_stage, host);
         cmd.env("RUSTC_STAGE", compiler.stage.to_string())
            .env("RUSTC_SYSROOT", self.sysroot(compiler))
-           .env("RUSTDOC_LIBDIR", self.sysroot_libdir(compiler, self.build.build))
+           .env("RUSTDOC_LIBDIR", self.sysroot_libdir(compiler, self.build.config.build))
            .env("CFG_RELEASE_CHANNEL", &self.build.config.channel)
            .env("RUSTDOC_REAL", self.rustdoc(host))
            .env("RUSTDOC_CRATE_VERSION", self.build.rust_version())
@@ -589,7 +589,7 @@ impl<'a> Builder<'a> {
             cargo.env("RUSTC_ERROR_FORMAT", error_format);
         }
         if cmd != "build" && cmd != "check" {
-            cargo.env("RUSTDOC_LIBDIR", self.rustc_libdir(self.compiler(2, self.build.build)));
+            cargo.env("RUSTDOC_LIBDIR", self.rustc_libdir(self.compiler(2, self.build.config.build)));
         }
 
         if mode != Mode::Tool {

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1476,6 +1476,9 @@ mod __test {
         assert_eq!(first(builder.cache.all::<dist::Rustc>()), &[
             dist::Rustc { compiler: Compiler { host: a, stage: 2 } },
         ]);
+        let ds = first(builder.cache.all::<dist::DebuggerScripts>());
+        assert_eq!(ds.len(), 1);
+        assert_eq!(ds[0].host, a);
         assert_eq!(first(builder.cache.all::<dist::Std>()), &[
             dist::Std {
                 compiler: Compiler { host: a, stage: 2 },
@@ -1483,6 +1486,56 @@ mod __test {
             },
         ]);
         assert_eq!(first(builder.cache.all::<dist::Src>()), &[dist::Src]);
+        assert_eq!(first(builder.cache.all::<dist::PlainSourceTarball>()),
+            &[dist::PlainSourceTarball]);
+    }
+
+    #[test]
+    fn dist_baseline_extended() {
+        let mut config = configure(&[], &[]);
+        config.general.extended = true;
+        let build = Build::new(config);
+        let mut builder = Builder::new(&build);
+        builder.run_step_descriptions(&Builder::get_step_descriptions(Kind::Dist), &[]);
+
+        let a = "A".intern();
+
+        assert_eq!(first(builder.cache.all::<dist::Docs>()), &[
+            dist::Docs { stage: 2, host: a },
+        ]);
+        assert_eq!(first(builder.cache.all::<dist::Mingw>()), &[
+            dist::Mingw { host: a },
+        ]);
+        assert_eq!(first(builder.cache.all::<dist::Rustc>()), &[
+            dist::Rustc { compiler: Compiler { host: a, stage: 2 } },
+        ]);
+        let ds = first(builder.cache.all::<dist::DebuggerScripts>());
+        assert_eq!(ds.len(), 1);
+        assert_eq!(ds[0].host, a);
+        assert_eq!(first(builder.cache.all::<dist::Std>()), &[
+            dist::Std {
+                compiler: Compiler { host: a, stage: 2 },
+                target: a,
+            },
+        ]);
+        assert_eq!(first(builder.cache.all::<dist::Analysis>()), &[
+            dist::Analysis {
+                compiler: Compiler { host: a, stage: 2 },
+                target: a,
+            },
+        ]);
+        assert_eq!(first(builder.cache.all::<dist::Cargo>()), &[
+            dist::Cargo { stage: 2, target: a },
+        ]);
+        assert_eq!(first(builder.cache.all::<dist::Rls>()), &[
+            dist::Rls { stage: 2, target: a },
+        ]);
+        assert_eq!(first(builder.cache.all::<dist::Rustfmt>()), &[
+            dist::Rustfmt { stage: 2, target: a },
+        ]);
+        assert_eq!(first(builder.cache.all::<dist::Src>()), &[dist::Src]);
+        assert_eq!(first(builder.cache.all::<dist::PlainSourceTarball>()),
+            &[dist::PlainSourceTarball]);
     }
 
     #[test]

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -536,7 +536,7 @@ impl<'a> Builder<'a> {
         cargo.env("__CARGO_DEFAULT_LIB_METADATA", &self.config.channel);
 
         let stage;
-        if compiler.stage == 0 && self.local_rebuild {
+        if compiler.stage == 0 && self.config.local_rebuild {
             // Assume the local-rebuild rustc already has stage1 features.
             stage = 1;
         } else {

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -491,7 +491,7 @@ impl<'a> Builder<'a> {
     }
 
     pub fn rustdoc_cmd(&self, host: Interned<String>) -> Command {
-        let mut cmd = Command::new(&self.out.join("bootstrap/debug/rustdoc"));
+        let mut cmd = Command::new(&self.config.out.join("bootstrap/debug/rustdoc"));
         let compiler = self.compiler(self.top_stage, host);
         cmd.env("RUSTC_STAGE", compiler.stage.to_string())
            .env("RUSTC_SYSROOT", self.sysroot(compiler))
@@ -562,7 +562,7 @@ impl<'a> Builder<'a> {
         // These variables are primarily all read by
         // src/bootstrap/bin/{rustc.rs,rustdoc.rs}
         cargo.env("RUSTBUILD_NATIVE_DIR", self.native_dir(target))
-             .env("RUSTC", self.out.join("bootstrap/debug/rustc"))
+             .env("RUSTC", self.config.out.join("bootstrap/debug/rustc"))
              .env("RUSTC_REAL", self.rustc(compiler))
              .env("RUSTC_STAGE", stage.to_string())
              .env("RUSTC_DEBUG_ASSERTIONS",
@@ -570,7 +570,7 @@ impl<'a> Builder<'a> {
              .env("RUSTC_SYSROOT", self.sysroot(compiler))
              .env("RUSTC_LIBDIR", self.rustc_libdir(compiler))
              .env("RUSTC_RPATH", self.config.rust_rpath.to_string())
-             .env("RUSTDOC", self.out.join("bootstrap/debug/rustdoc"))
+             .env("RUSTDOC", self.config.out.join("bootstrap/debug/rustdoc"))
              .env("RUSTDOC_REAL", if cmd == "doc" || cmd == "test" {
                  self.rustdoc(compiler.host)
              } else {

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -272,7 +272,7 @@ impl<'a> Builder<'a> {
 
         let builder = Builder {
             build,
-            top_stage: build.config.stage.unwrap_or(2),
+            top_stage: build.config.stage,
             kind,
             cache: Cache::new(),
             stack: RefCell::new(Vec::new()),
@@ -374,7 +374,7 @@ impl<'a> Builder<'a> {
 
         let builder = Builder {
             build,
-            top_stage: build.config.stage.unwrap_or(2),
+            top_stage: build.config.stage,
             kind,
             cache: Cache::new(),
             stack: RefCell::new(Vec::new()),

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -663,7 +663,7 @@ impl<'a> Builder<'a> {
             cargo.env("RUSTC_ON_FAIL", on_fail);
         }
 
-        cargo.env("RUSTC_VERBOSE", format!("{}", self.verbosity));
+        cargo.env("RUSTC_VERBOSE", format!("{}", self.config.verbose));
 
         // Throughout the build Cargo can execute a number of build scripts
         // compiling C/C++ code and we need to pass compilers, archivers, flags, etc

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1565,6 +1565,41 @@ mod __test {
             },
         ]);
         assert_eq!(first(builder.cache.all::<dist::Src>()), &[dist::Src]);
+
+
+        assert_eq!(first(builder.cache.all::<compile::Rustc>()), &[
+            compile::Rustc {
+                compiler: Compiler { host: a, stage: 0 },
+                target: a,
+            },
+            compile::Rustc { // FIXME: this is not needed
+                compiler: Compiler { host: a, stage: 1 },
+                target: a,
+            },
+            compile::Rustc { // FIXME: this is not needed
+                compiler: Compiler { host: a, stage: 2 },
+                target: a,
+            },
+        ]);
+
+        assert_eq!(first(builder.cache.all::<compile::Test>()), &[
+            compile::Test {
+                compiler: Compiler { host: a, stage: 0 },
+                target: a,
+            },
+            compile::Test {
+                compiler: Compiler { host: a, stage: 1 },
+                target: a,
+            },
+            compile::Test {
+                compiler: Compiler { host: a, stage: 2 },
+                target: a,
+            },
+            compile::Test {
+                compiler: Compiler { host: a, stage: 2 },
+                target: b,
+            },
+        ]);
     }
 
     #[test]
@@ -1680,6 +1715,56 @@ mod __test {
             },
         ]);
         assert_eq!(first(builder.cache.all::<dist::Src>()), &[]);
+
+        assert_eq!(first(builder.cache.all::<compile::Rustc>()), &[
+            compile::Rustc {
+                compiler: Compiler { host: a, stage: 0 },
+                target: a,
+            },
+            compile::Rustc {
+                compiler: Compiler { host: a, stage: 1 },
+                target: a,
+            },
+            compile::Rustc {
+                compiler: Compiler { host: a, stage: 1 },
+                target: b,
+            },
+            compile::Rustc {
+                compiler: Compiler { host: a, stage: 2 },
+                target: a,
+            },
+            compile::Rustc {
+                compiler: Compiler { host: a, stage: 2 },
+                target: b,
+            },
+        ]);
+
+        assert_eq!(first(builder.cache.all::<compile::Test>()), &[
+            compile::Test {
+                compiler: Compiler { host: a, stage: 0 },
+                target: a,
+            },
+            compile::Test {
+                compiler: Compiler { host: a, stage: 1 },
+                target: a,
+            },
+            compile::Test {
+                compiler: Compiler { host: a, stage: 2 },
+                target: a,
+            },
+            compile::Test {
+                compiler: Compiler { host: a, stage: 1 },
+                target: b,
+            },
+            compile::Test {
+                compiler: Compiler { host: a, stage: 2 },
+                target: b,
+            },
+            compile::Test {
+                compiler: Compiler { host: a, stage: 2 },
+                target: c,
+            },
+        ]);
     }
 
     #[test]
@@ -1859,6 +1944,8 @@ mod __test {
 
     #[test]
     fn build_with_target_flag() {
+        // --build=A --host=B --target=C:
+        // ./x.py build --target=C
         let mut config = configure(&["B"], &["C"]);
         config.run_host_only = false;
         let build = Build::new(config);

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -145,7 +145,7 @@ impl StepDescription {
                 self.name, builder.config.exclude);
         }
         let build = builder.build;
-        let hosts = &build.hosts;
+        let hosts = &build.config.hosts;
 
         if self.only_hosts && !build.config.run_host_only {
             return;
@@ -153,9 +153,9 @@ impl StepDescription {
 
         // Determine the targets participating in this rule.
         let targets = if self.only_hosts {
-            &build.hosts
+            &build.config.hosts
         } else {
-            &build.targets
+            &build.config.targets
         };
 
         for host in hosts {

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -495,7 +495,7 @@ impl<'a> Builder<'a> {
         let compiler = self.compiler(self.top_stage, host);
         cmd.env("RUSTC_STAGE", compiler.stage.to_string())
            .env("RUSTC_SYSROOT", self.sysroot(compiler))
-           .env("RUSTDOC_LIBDIR", self.sysroot_libdir(compiler, self.build.config.build))
+           .env("RUSTDOC_LIBDIR", self.sysroot_libdir(compiler, self.build.config.general.build))
            .env("CFG_RELEASE_CHANNEL", &self.build.config.rust.channel)
            .env("RUSTDOC_REAL", self.rustdoc(host))
            .env("RUSTDOC_CRATE_VERSION", self.build.rust_version())
@@ -589,7 +589,7 @@ impl<'a> Builder<'a> {
             cargo.env("RUSTC_ERROR_FORMAT", error_format);
         }
         if cmd != "build" && cmd != "check" {
-            cargo.env("RUSTDOC_LIBDIR", self.rustc_libdir(self.compiler(2, self.build.config.build)));
+            cargo.env("RUSTDOC_LIBDIR", self.rustc_libdir(self.compiler(2, self.build.config.general.build)));
         }
 
         if mode != Mode::Tool {

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -645,6 +645,7 @@ impl<'a> Builder<'a> {
             cargo.env("RUSTC_SNAPSHOT", &self.initial_rustc)
                  .env("RUSTC_SNAPSHOT_LIBDIR", self.rustc_snapshot_libdir());
         } else {
+            self.ensure(compile::Std { compiler, target: compiler.host });
             cargo.env("RUSTC_SNAPSHOT", self.rustc(compiler))
                  .env("RUSTC_SNAPSHOT_LIBDIR", self.rustc_libdir(compiler));
         }

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -536,7 +536,7 @@ impl<'a> Builder<'a> {
         cargo.env("__CARGO_DEFAULT_LIB_METADATA", &self.config.rust.channel);
 
         let stage;
-        if compiler.stage == 0 && self.config.local_rebuild {
+        if compiler.stage == 0 && self.config.general.local_rebuild {
             // Assume the local-rebuild rustc already has stage1 features.
             stage = 1;
         } else {
@@ -663,7 +663,7 @@ impl<'a> Builder<'a> {
             cargo.env("RUSTC_ON_FAIL", on_fail);
         }
 
-        cargo.env("RUSTC_VERBOSE", format!("{}", self.config.verbose));
+        cargo.env("RUSTC_VERBOSE", format!("{}", self.config.general.verbose));
 
         // Throughout the build Cargo can execute a number of build scripts
         // compiling C/C++ code and we need to pass compilers, archivers, flags, etc
@@ -697,7 +697,7 @@ impl<'a> Builder<'a> {
             }
         }
 
-        if mode == Mode::Libstd && self.config.extended && compiler.is_final_stage(self) {
+        if mode == Mode::Libstd && self.config.general.extended && compiler.is_final_stage(self) {
             cargo.env("RUSTC_SAVE_ANALYSIS", "api".to_string());
         }
 
@@ -773,10 +773,10 @@ impl<'a> Builder<'a> {
             }
         }
 
-        if self.config.locked_deps {
+        if self.config.general.locked_deps {
             cargo.arg("--locked");
         }
-        if self.config.vendor || self.config.is_sudo {
+        if self.config.general.vendor || self.config.is_sudo {
             cargo.arg("--frozen");
         }
 

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -358,14 +358,14 @@ impl<'a> Builder<'a> {
     }
 
     pub fn run(build: &Build) {
-        let (kind, paths) = match build.config.cmd {
-            Subcommand::Build { ref paths } => (Kind::Build, &paths[..]),
-            Subcommand::Check { ref paths } => (Kind::Check, &paths[..]),
-            Subcommand::Doc { ref paths } => (Kind::Doc, &paths[..]),
-            Subcommand::Test { ref paths, .. } => (Kind::Test, &paths[..]),
-            Subcommand::Bench { ref paths, .. } => (Kind::Bench, &paths[..]),
-            Subcommand::Dist { ref paths } => (Kind::Dist, &paths[..]),
-            Subcommand::Install { ref paths } => (Kind::Install, &paths[..]),
+        let kind = match build.config.cmd {
+            Subcommand::Build => Kind::Build,
+            Subcommand::Check => Kind::Check,
+            Subcommand::Doc { .. } => Kind::Doc,
+            Subcommand::Test { .. } => Kind::Test,
+            Subcommand::Bench { .. } => Kind::Bench,
+            Subcommand::Dist => Kind::Dist,
+            Subcommand::Install { .. } => Kind::Install,
             Subcommand::Clean { .. } => panic!(),
         };
 
@@ -389,7 +389,11 @@ impl<'a> Builder<'a> {
                 The distributed MIR would include validation statements.");
         }
 
-        StepDescription::run(&Builder::get_step_descriptions(builder.kind), &builder, paths);
+        StepDescription::run(
+            &Builder::get_step_descriptions(builder.kind),
+            &builder,
+            &builder.config.paths
+        );
     }
 
     pub fn default_doc(&self, paths: Option<&[PathBuf]>) {

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -541,8 +541,8 @@ impl<'a> Builder<'a> {
             fn run(self, builder: &Builder) -> Interned<PathBuf> {
                 let compiler = self.compiler;
                 let config = &builder.build.config;
-                let lib = if compiler.stage >= 1 && config.libdir_relative().is_some() {
-                    config.libdir_relative().unwrap()
+                let lib = if compiler.stage >= 1 {
+                    config.libdir_relative()
                 } else {
                     Path::new("lib")
                 };
@@ -736,7 +736,7 @@ impl<'a> Builder<'a> {
             .env("CFG_VERSION", self.rust_version())
             .env("CFG_PREFIX", &self.config.install.prefix);
 
-        let libdir_relative = self.config.libdir_relative().unwrap_or(Path::new("lib"));
+        let libdir_relative = self.config.libdir_relative();
         cargo.env("CFG_LIBDIR_RELATIVE", libdir_relative);
 
         // If we're not building a compiler with debugging information then remove

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -121,7 +121,7 @@ impl PathSet {
     }
 
     fn path(&self, builder: &Builder) -> PathBuf {
-        self.set.iter().next().unwrap_or(&builder.build.src).to_path_buf()
+        self.set.iter().next().unwrap_or(&builder.config.src).to_path_buf()
     }
 }
 

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -24,7 +24,7 @@ use install;
 use dist;
 use util::{exe, libdir, add_lib_path};
 use {Build, Mode};
-use cache::{INTERNER, Interned, Cache};
+use cache::{Intern, Interned, Cache};
 use check;
 use test;
 use flags::Subcommand;
@@ -440,7 +440,7 @@ impl<'a> Builder<'a> {
                     .join("rustlib").join(self.target).join("lib");
                 let _ = fs::remove_dir_all(&sysroot);
                 t!(fs::create_dir_all(&sysroot));
-                INTERNER.intern_path(sysroot)
+                sysroot.intern()
             }
         }
         self.ensure(Libdir { compiler, target })

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -145,7 +145,7 @@ impl StepDescription {
                 self.name, builder.config.exclude);
         }
         let build = builder.build;
-        let hosts = &build.config.hosts;
+        let hosts = &build.config.general.host;
 
         if self.only_hosts && !build.config.run_host_only {
             return;
@@ -153,9 +153,9 @@ impl StepDescription {
 
         // Determine the targets participating in this rule.
         let targets = if self.only_hosts {
-            &build.config.hosts
+            &build.config.general.host
         } else {
-            &build.config.targets
+            &build.config.general.target
         };
 
         for host in hosts {

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -147,13 +147,13 @@ impl StepDescription {
         let build = builder.build;
         let hosts = &build.hosts;
 
+        if self.only_hosts && !build.config.run_host_only {
+            return;
+        }
+
         // Determine the targets participating in this rule.
         let targets = if self.only_hosts {
-            if !build.config.run_host_only {
-                return; // don't run anything
-            } else {
-                &build.hosts
-            }
+            &build.hosts
         } else {
             &build.targets
         };

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -776,7 +776,7 @@ impl<'a> Builder<'a> {
         if self.config.locked_deps {
             cargo.arg("--locked");
         }
-        if self.config.vendor || self.is_sudo {
+        if self.config.vendor || self.config.is_sudo {
             cargo.arg("--frozen");
         }
 

--- a/src/bootstrap/cache.rs
+++ b/src/bootstrap/cache.rs
@@ -19,6 +19,7 @@ use std::mem;
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::sync::Mutex;
+use std::cmp::{PartialOrd, Ord, Ordering};
 
 use builder::Step;
 
@@ -80,6 +81,22 @@ impl<B> Eq for Interned<B>
 where
     Interned<B>: PartialEq<Interned<B>>,
 {}
+
+impl<A, B> PartialOrd<Interned<A>> for Interned<B>
+where
+    Interned<B>: PartialEq<Interned<A>>,
+    B: PartialOrd<A>,
+{
+    fn partial_cmp(&self, other: &Interned<A>) -> Option<Ordering> {
+        PartialOrd::partial_cmp(self.as_static(), other.as_static())
+    }
+}
+
+impl<T: Ord + PartialOrd<T>> Ord for Interned<T> {
+    fn cmp(&self, other: &Interned<T>) -> Ordering {
+        Ord::cmp(self.as_static(), other.as_static())
+    }
+}
 
 impl<'a, T> PartialEq<Interned<T>> for &'a Interned<T> {
     fn eq(&self, other: &Interned<T>) -> bool {

--- a/src/bootstrap/cache.rs
+++ b/src/bootstrap/cache.rs
@@ -164,7 +164,7 @@ impl<T: Hash + Clone + Eq> TyIntern<T> {
     }
 }
 
-pub struct Interner {
+struct Interner {
     generic: Mutex<Vec<Box<Any + Send + 'static>>>,
 }
 
@@ -204,21 +204,10 @@ impl Interner {
         l.push(Box::new(ty_interner));
         interned
     }
-
-    pub fn intern_str(&self, s: &str) -> Interned<String> {
-        s.intern()
-    }
-    pub fn intern_string(&self, s: String) -> Interned<String> {
-        s.intern()
-    }
-
-    pub fn intern_path(&self, s: PathBuf) -> Interned<PathBuf> {
-        s.intern()
-    }
 }
 
 lazy_static! {
-    pub static ref INTERNER: Interner = Interner::new();
+    static ref INTERNER: Interner = Interner::new();
 }
 
 /// This is essentially a HashMap which allows storing any type in its input and

--- a/src/bootstrap/cc_detect.rs
+++ b/src/bootstrap/cc_detect.rs
@@ -73,8 +73,8 @@ fn cc2ar(cc: &Path, target: &str) -> Option<PathBuf> {
 pub fn find(build: &mut Build) {
     // For all targets we're going to need a C compiler for building some shims
     // and such as well as for being a linker for Rust code.
-    let targets = build.config.targets.iter()
-        .chain(&build.config.hosts).cloned()
+    let targets = build.config.general.target.iter()
+        .chain(&build.config.general.host).cloned()
         .chain(iter::once(build.config.build))
         .collect::<HashSet<_>>();
     for target in targets.into_iter() {
@@ -105,7 +105,7 @@ pub fn find(build: &mut Build) {
     }
 
     // For all host triples we need to find a C++ compiler as well
-    let hosts = build.config.hosts.iter().cloned().chain(iter::once(build.config.build)).collect::<HashSet<_>>();
+    let hosts = build.config.general.host.iter().cloned().chain(iter::once(build.config.build)).collect::<HashSet<_>>();
     for host in hosts.into_iter() {
         let mut cfg = cc::Build::new();
         cfg.cargo_metadata(false).opt_level(0).warnings(false).debug(false).cpp(true)

--- a/src/bootstrap/cc_detect.rs
+++ b/src/bootstrap/cc_detect.rs
@@ -73,14 +73,23 @@ fn cc2ar(cc: &Path, target: &str) -> Option<PathBuf> {
 pub fn find(build: &mut Build) {
     // For all targets we're going to need a C compiler for building some shims
     // and such as well as for being a linker for Rust code.
-    let targets = build.config.general.target.iter()
-        .chain(&build.config.general.host).cloned()
+    let targets = build
+        .config
+        .general
+        .target
+        .iter()
+        .chain(&build.config.general.host)
+        .cloned()
         .chain(iter::once(build.config.general.build))
         .collect::<HashSet<_>>();
     for target in targets.into_iter() {
         let mut cfg = cc::Build::new();
-        cfg.cargo_metadata(false).opt_level(0).warnings(false).debug(false)
-           .target(&target).host(&build.config.general.build);
+        cfg.cargo_metadata(false)
+            .opt_level(0)
+            .warnings(false)
+            .debug(false)
+            .target(&target)
+            .host(&build.config.general.build);
 
         let config = build.config.target_config.get(&target);
         if let Some(cc) = config.and_then(|c| c.cc.as_ref()) {
@@ -105,11 +114,23 @@ pub fn find(build: &mut Build) {
     }
 
     // For all host triples we need to find a C++ compiler as well
-    let hosts = build.config.general.host.iter().cloned().chain(iter::once(build.config.general.build)).collect::<HashSet<_>>();
+    let hosts = build
+        .config
+        .general
+        .host
+        .iter()
+        .cloned()
+        .chain(iter::once(build.config.general.build))
+        .collect::<HashSet<_>>();
     for host in hosts.into_iter() {
         let mut cfg = cc::Build::new();
-        cfg.cargo_metadata(false).opt_level(0).warnings(false).debug(false).cpp(true)
-           .target(&host).host(&build.config.general.build);
+        cfg.cargo_metadata(false)
+            .opt_level(0)
+            .warnings(false)
+            .debug(false)
+            .cpp(true)
+            .target(&host)
+            .host(&build.config.general.build);
         let config = build.config.target_config.get(&host);
         if let Some(cxx) = config.and_then(|c| c.cxx.as_ref()) {
             cfg.compiler(cxx);
@@ -122,11 +143,13 @@ pub fn find(build: &mut Build) {
     }
 }
 
-fn set_compiler(cfg: &mut cc::Build,
-                compiler: Language,
-                target: Interned<String>,
-                config: Option<&Target>,
-                build: &Build) {
+fn set_compiler(
+    cfg: &mut cc::Build,
+    compiler: Language,
+    target: Interned<String>,
+    config: Option<&Target>,
+    build: &Build,
+) {
     match &*target {
         // When compiling for android we may have the NDK configured in the
         // config.toml in which case we look there. Otherwise the default
@@ -145,7 +168,7 @@ fn set_compiler(cfg: &mut cc::Build,
             let c = cfg.get_compiler();
             let gnu_compiler = compiler.gcc();
             if !c.path().ends_with(gnu_compiler) {
-                return
+                return;
             }
 
             let output = output(c.to_command().arg("--version"));
@@ -154,7 +177,7 @@ fn set_compiler(cfg: &mut cc::Build,
                 None => return,
             };
             match output[i + 3..].chars().next().unwrap() {
-                '0' ... '6' => {}
+                '0'...'6' => {}
                 _ => return,
             }
             let alternative = format!("e{}", gnu_compiler);

--- a/src/bootstrap/cc_detect.rs
+++ b/src/bootstrap/cc_detect.rs
@@ -75,12 +75,12 @@ pub fn find(build: &mut Build) {
     // and such as well as for being a linker for Rust code.
     let targets = build.config.general.target.iter()
         .chain(&build.config.general.host).cloned()
-        .chain(iter::once(build.config.build))
+        .chain(iter::once(build.config.general.build))
         .collect::<HashSet<_>>();
     for target in targets.into_iter() {
         let mut cfg = cc::Build::new();
         cfg.cargo_metadata(false).opt_level(0).warnings(false).debug(false)
-           .target(&target).host(&build.config.build);
+           .target(&target).host(&build.config.general.build);
 
         let config = build.config.target_config.get(&target);
         if let Some(cc) = config.and_then(|c| c.cc.as_ref()) {
@@ -105,11 +105,11 @@ pub fn find(build: &mut Build) {
     }
 
     // For all host triples we need to find a C++ compiler as well
-    let hosts = build.config.general.host.iter().cloned().chain(iter::once(build.config.build)).collect::<HashSet<_>>();
+    let hosts = build.config.general.host.iter().cloned().chain(iter::once(build.config.general.build)).collect::<HashSet<_>>();
     for host in hosts.into_iter() {
         let mut cfg = cc::Build::new();
         cfg.cargo_metadata(false).opt_level(0).warnings(false).debug(false).cpp(true)
-           .target(&host).host(&build.config.build);
+           .target(&host).host(&build.config.general.build);
         let config = build.config.target_config.get(&host);
         if let Some(cxx) = config.and_then(|c| c.cxx.as_ref()) {
             cfg.compiler(cxx);

--- a/src/bootstrap/cc_detect.rs
+++ b/src/bootstrap/cc_detect.rs
@@ -73,12 +73,14 @@ fn cc2ar(cc: &Path, target: &str) -> Option<PathBuf> {
 pub fn find(build: &mut Build) {
     // For all targets we're going to need a C compiler for building some shims
     // and such as well as for being a linker for Rust code.
-    let targets = build.targets.iter().chain(&build.hosts).cloned().chain(iter::once(build.build))
-                               .collect::<HashSet<_>>();
+    let targets = build.config.targets.iter()
+        .chain(&build.config.hosts).cloned()
+        .chain(iter::once(build.config.build))
+        .collect::<HashSet<_>>();
     for target in targets.into_iter() {
         let mut cfg = cc::Build::new();
         cfg.cargo_metadata(false).opt_level(0).warnings(false).debug(false)
-           .target(&target).host(&build.build);
+           .target(&target).host(&build.config.build);
 
         let config = build.config.target_config.get(&target);
         if let Some(cc) = config.and_then(|c| c.cc.as_ref()) {
@@ -103,11 +105,11 @@ pub fn find(build: &mut Build) {
     }
 
     // For all host triples we need to find a C++ compiler as well
-    let hosts = build.hosts.iter().cloned().chain(iter::once(build.build)).collect::<HashSet<_>>();
+    let hosts = build.config.hosts.iter().cloned().chain(iter::once(build.config.build)).collect::<HashSet<_>>();
     for host in hosts.into_iter() {
         let mut cfg = cc::Build::new();
         cfg.cargo_metadata(false).opt_level(0).warnings(false).debug(false).cpp(true)
-           .target(&host).host(&build.build);
+           .target(&host).host(&build.config.build);
         let config = build.config.target_config.get(&host);
         if let Some(cxx) = config.and_then(|c| c.cxx.as_ref()) {
             cfg.compiler(cxx);

--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -40,7 +40,7 @@ struct Info {
 impl GitInfo {
     pub fn new(config: &Config, dir: &Path) -> GitInfo {
         // See if this even begins to look like a git dir
-        if config.ignore_git || !dir.join(".git").exists() {
+        if config.rust.ignore_git() || !dir.join(".git").exists() {
             return GitInfo { inner: None }
         }
 

--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -26,6 +26,7 @@ use config::Config;
 // The version number
 pub const CFG_RELEASE_NUM: &str = "1.26.0";
 
+#[derive(Default)]
 pub struct GitInfo {
     inner: Option<Info>,
 }

--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -41,31 +41,41 @@ impl GitInfo {
     pub fn new(config: &Config, dir: &Path) -> GitInfo {
         // See if this even begins to look like a git dir
         if config.rust.ignore_git() || !dir.join(".git").exists() {
-            return GitInfo { inner: None }
+            return GitInfo { inner: None };
         }
 
         // Make sure git commands work
         let out = Command::new("git")
-                          .arg("rev-parse")
-                          .current_dir(dir)
-                          .output()
-                          .expect("failed to spawn git");
+            .arg("rev-parse")
+            .current_dir(dir)
+            .output()
+            .expect("failed to spawn git");
         if !out.status.success() {
-            return GitInfo { inner: None }
+            return GitInfo { inner: None };
         }
 
         // Ok, let's scrape some info
-        let ver_date = output(Command::new("git").current_dir(dir)
-                                      .arg("log").arg("-1")
-                                      .arg("--date=short")
-                                      .arg("--pretty=format:%cd"));
-        let ver_hash = output(Command::new("git").current_dir(dir)
-                                      .arg("rev-parse").arg("HEAD"));
-        let short_ver_hash = output(Command::new("git")
-                                            .current_dir(dir)
-                                            .arg("rev-parse")
-                                            .arg("--short=9")
-                                            .arg("HEAD"));
+        let ver_date = output(
+            Command::new("git")
+                .current_dir(dir)
+                .arg("log")
+                .arg("-1")
+                .arg("--date=short")
+                .arg("--pretty=format:%cd"),
+        );
+        let ver_hash = output(
+            Command::new("git")
+                .current_dir(dir)
+                .arg("rev-parse")
+                .arg("HEAD"),
+        );
+        let short_ver_hash = output(
+            Command::new("git")
+                .current_dir(dir)
+                .arg("rev-parse")
+                .arg("--short=9")
+                .arg("HEAD"),
+        );
         GitInfo {
             inner: Some(Info {
                 commit_date: ver_date.trim().to_string(),

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -10,7 +10,7 @@
 
 //! Implementation of compiling the compiler and standard library, in "check" mode.
 
-use compile::{add_to_sysroot, run_cargo};
+use compile::{add_to_sysroot};
 use builder::{Builder, RunConfig, ShouldRun, Step};
 use Mode;
 use cache::Interned;
@@ -40,8 +40,7 @@ impl Step for Std {
         println!("Checking std artifacts ({} -> {})", &compiler.host, target);
 
         let mut cargo = builder.cargo(compiler, Mode::Libstd, target, "check");
-        run_cargo(
-            builder,
+        builder.run_cargo(
             &mut cargo,
             &builder.libstd_stamp(compiler, target),
             true,
@@ -85,8 +84,7 @@ impl Step for Rustc {
         );
 
         let mut cargo = builder.cargo(compiler, Mode::Librustc, target, "check");
-        run_cargo(
-            builder,
+        builder.run_cargo(
             &mut cargo,
             &builder.librustc_stamp(compiler, target),
             true,
@@ -120,8 +118,7 @@ impl Step for Test {
         let _folder = builder.fold_output(|| format!("stage{}-test", compiler.stage));
         println!("Checking test artifacts ({} -> {})", &compiler.host, target);
         let mut cargo = builder.cargo(compiler, Mode::Libtest, target, "check");
-        run_cargo(
-            builder,
+        builder.run_cargo(
             &mut cargo,
             &builder.libtest_stamp(compiler, target),
             true,

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -38,7 +38,7 @@ impl Step for Std {
     fn run(self, builder: &Builder) {
         let build = builder.build;
         let target = self.target;
-        let compiler = builder.compiler(0, build.build);
+        let compiler = builder.compiler(0, build.config.build);
 
         let _folder = build.fold_output(|| format!("stage{}-std", compiler.stage));
         println!("Checking std artifacts ({} -> {})", &compiler.host, target);
@@ -83,7 +83,7 @@ impl Step for Rustc {
     /// created will also be linked into the sysroot directory.
     fn run(self, builder: &Builder) {
         let build = builder.build;
-        let compiler = builder.compiler(0, build.build);
+        let compiler = builder.compiler(0, build.config.build);
         let target = self.target;
 
         let _folder = build.fold_output(|| format!("stage{}-rustc", compiler.stage));
@@ -126,7 +126,7 @@ impl Step for Test {
     fn run(self, builder: &Builder) {
         let build = builder.build;
         let target = self.target;
-        let compiler = builder.compiler(0, build.build);
+        let compiler = builder.compiler(0, build.config.build);
 
         let _folder = build.fold_output(|| format!("stage{}-test", compiler.stage));
         println!("Checking test artifacts ({} -> {})", &compiler.host, target);

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -39,12 +39,7 @@ impl Step for Std {
         let _folder = builder.fold_output(|| format!("stage{}-std", compiler.stage));
         println!("Checking std artifacts ({} -> {})", &compiler.host, target);
 
-        let mut cargo = builder.cargo(compiler, Mode::Libstd, target, "check");
-        builder.run_cargo(
-            &mut cargo,
-            &builder.libstd_stamp(compiler, target),
-            true,
-        );
+        builder.cargo(compiler, Mode::Libstd, target, "check").run();
         let libdir = builder.sysroot_libdir(compiler, target);
         add_to_sysroot(&libdir, &builder.libstd_stamp(compiler, target));
     }
@@ -83,12 +78,7 @@ impl Step for Rustc {
             &compiler.host, target
         );
 
-        let mut cargo = builder.cargo(compiler, Mode::Librustc, target, "check");
-        builder.run_cargo(
-            &mut cargo,
-            &builder.librustc_stamp(compiler, target),
-            true,
-        );
+        builder.cargo(compiler, Mode::Librustc, target, "check").run();
         let libdir = builder.sysroot_libdir(compiler, target);
         add_to_sysroot(&libdir, &builder.librustc_stamp(compiler, target));
     }
@@ -117,12 +107,7 @@ impl Step for Test {
 
         let _folder = builder.fold_output(|| format!("stage{}-test", compiler.stage));
         println!("Checking test artifacts ({} -> {})", &compiler.host, target);
-        let mut cargo = builder.cargo(compiler, Mode::Libtest, target, "check");
-        builder.run_cargo(
-            &mut cargo,
-            &builder.libtest_stamp(compiler, target),
-            true,
-        );
+        builder.cargo(compiler, Mode::Libtest, target, "check").run();
         let libdir = builder.sysroot_libdir(compiler, target);
         add_to_sysroot(&libdir, &builder.libtest_stamp(compiler, target));
     }

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -34,25 +34,24 @@ impl Step for Std {
     }
 
     fn run(self, builder: &Builder) {
-        let build = builder.build;
         let target = self.target;
-        let compiler = builder.compiler(0, build.config.general.build);
+        let compiler = builder.compiler(0, builder.config.general.build);
 
-        let _folder = build.fold_output(|| format!("stage{}-std", compiler.stage));
+        let _folder = builder.fold_output(|| format!("stage{}-std", compiler.stage));
         println!("Checking std artifacts ({} -> {})", &compiler.host, target);
 
-        let out_dir = build.stage_out(compiler, Mode::Libstd);
-        build.clear_if_dirty(&out_dir, &builder.rustc(compiler));
+        let out_dir = builder.stage_out(compiler, Mode::Libstd);
+        builder.clear_if_dirty(&out_dir, &builder.rustc(compiler));
         let mut cargo = builder.cargo(compiler, Mode::Libstd, target, "check");
-        std_cargo(build, &compiler, target, &mut cargo);
+        std_cargo(builder, &compiler, target, &mut cargo);
         run_cargo(
-            build,
+            builder,
             &mut cargo,
-            &libstd_stamp(build, compiler, target),
+            &libstd_stamp(builder, compiler, target),
             true,
         );
         let libdir = builder.sysroot_libdir(compiler, target);
-        add_to_sysroot(&libdir, &libstd_stamp(build, compiler, target));
+        add_to_sysroot(&libdir, &libstd_stamp(builder, compiler, target));
     }
 }
 
@@ -80,30 +79,29 @@ impl Step for Rustc {
     /// the `compiler` targeting the `target` architecture. The artifacts
     /// created will also be linked into the sysroot directory.
     fn run(self, builder: &Builder) {
-        let build = builder.build;
-        let compiler = builder.compiler(0, build.config.general.build);
+        let compiler = builder.compiler(0, builder.config.general.build);
         let target = self.target;
 
-        let _folder = build.fold_output(|| format!("stage{}-rustc", compiler.stage));
+        let _folder = builder.fold_output(|| format!("stage{}-rustc", compiler.stage));
         println!(
             "Checking compiler artifacts ({} -> {})",
             &compiler.host, target
         );
 
         let stage_out = builder.stage_out(compiler, Mode::Librustc);
-        build.clear_if_dirty(&stage_out, &libstd_stamp(build, compiler, target));
-        build.clear_if_dirty(&stage_out, &libtest_stamp(build, compiler, target));
+        builder.clear_if_dirty(&stage_out, &libstd_stamp(builder, compiler, target));
+        builder.clear_if_dirty(&stage_out, &libtest_stamp(builder, compiler, target));
 
         let mut cargo = builder.cargo(compiler, Mode::Librustc, target, "check");
-        rustc_cargo(build, &mut cargo);
+        rustc_cargo(builder, &mut cargo);
         run_cargo(
-            build,
+            builder,
             &mut cargo,
-            &librustc_stamp(build, compiler, target),
+            &librustc_stamp(builder, compiler, target),
             true,
         );
         let libdir = builder.sysroot_libdir(compiler, target);
-        add_to_sysroot(&libdir, &librustc_stamp(build, compiler, target));
+        add_to_sysroot(&libdir, &librustc_stamp(builder, compiler, target));
     }
 }
 
@@ -125,24 +123,23 @@ impl Step for Test {
     }
 
     fn run(self, builder: &Builder) {
-        let build = builder.build;
         let target = self.target;
-        let compiler = builder.compiler(0, build.config.general.build);
+        let compiler = builder.compiler(0, builder.config.general.build);
 
-        let _folder = build.fold_output(|| format!("stage{}-test", compiler.stage));
+        let _folder = builder.fold_output(|| format!("stage{}-test", compiler.stage));
         println!("Checking test artifacts ({} -> {})", &compiler.host, target);
-        let out_dir = build.stage_out(compiler, Mode::Libtest);
-        build.clear_if_dirty(&out_dir, &libstd_stamp(build, compiler, target));
+        let out_dir = builder.stage_out(compiler, Mode::Libtest);
+        builder.clear_if_dirty(&out_dir, &libstd_stamp(builder, compiler, target));
         let mut cargo = builder.cargo(compiler, Mode::Libtest, target, "check");
-        test_cargo(build, &compiler, target, &mut cargo);
+        test_cargo(builder, &compiler, target, &mut cargo);
         run_cargo(
-            build,
+            builder,
             &mut cargo,
-            &libtest_stamp(build, compiler, target),
+            &libtest_stamp(builder, compiler, target),
             true,
         );
         let libdir = builder.sysroot_libdir(compiler, target);
-        add_to_sysroot(&libdir, &libtest_stamp(build, compiler, target));
+        add_to_sysroot(&libdir, &libtest_stamp(builder, compiler, target));
     }
 }
 

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -38,7 +38,7 @@ impl Step for Std {
     fn run(self, builder: &Builder) {
         let build = builder.build;
         let target = self.target;
-        let compiler = builder.compiler(0, build.config.build);
+        let compiler = builder.compiler(0, build.config.general.build);
 
         let _folder = build.fold_output(|| format!("stage{}-std", compiler.stage));
         println!("Checking std artifacts ({} -> {})", &compiler.host, target);
@@ -83,7 +83,7 @@ impl Step for Rustc {
     /// created will also be linked into the sysroot directory.
     fn run(self, builder: &Builder) {
         let build = builder.build;
-        let compiler = builder.compiler(0, build.config.build);
+        let compiler = builder.compiler(0, build.config.general.build);
         let target = self.target;
 
         let _folder = build.fold_output(|| format!("stage{}-rustc", compiler.stage));
@@ -126,7 +126,7 @@ impl Step for Test {
     fn run(self, builder: &Builder) {
         let build = builder.build;
         let target = self.target;
-        let compiler = builder.compiler(0, build.config.build);
+        let compiler = builder.compiler(0, build.config.general.build);
 
         let _folder = build.fold_output(|| format!("stage{}-test", compiler.stage));
         println!("Checking test artifacts ({} -> {})", &compiler.host, target);

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -10,7 +10,7 @@
 
 //! Implementation of compiling the compiler and standard library, in "check" mode.
 
-use compile::{add_to_sysroot, run_cargo, rustc_cargo, std_cargo, test_cargo};
+use compile::{add_to_sysroot, run_cargo};
 use builder::{Builder, RunConfig, ShouldRun, Step};
 use Mode;
 use cache::Interned;
@@ -40,7 +40,6 @@ impl Step for Std {
         println!("Checking std artifacts ({} -> {})", &compiler.host, target);
 
         let mut cargo = builder.cargo(compiler, Mode::Libstd, target, "check");
-        std_cargo(builder, &compiler, target, &mut cargo);
         run_cargo(
             builder,
             &mut cargo,
@@ -86,7 +85,6 @@ impl Step for Rustc {
         );
 
         let mut cargo = builder.cargo(compiler, Mode::Librustc, target, "check");
-        rustc_cargo(builder, &mut cargo);
         run_cargo(
             builder,
             &mut cargo,
@@ -122,7 +120,6 @@ impl Step for Test {
         let _folder = builder.fold_output(|| format!("stage{}-test", compiler.stage));
         println!("Checking test artifacts ({} -> {})", &compiler.host, target);
         let mut cargo = builder.cargo(compiler, Mode::Libtest, target, "check");
-        test_cargo(builder, &compiler, target, &mut cargo);
         run_cargo(
             builder,
             &mut cargo,

--- a/src/bootstrap/clean.rs
+++ b/src/bootstrap/clean.rs
@@ -39,7 +39,7 @@ pub fn clean(build: &Build, all: bool) {
             for entry in entries {
                 let entry = t!(entry);
                 if entry.file_name().to_str() == Some("llvm") {
-                    continue
+                    continue;
                 }
                 let path = t!(entry.path().canonicalize());
                 rm_rf(&path);
@@ -55,7 +55,7 @@ fn rm_rf(path: &Path) {
                 return;
             }
             panic!("failed to get metadata for file {}: {}", path.display(), e);
-        },
+        }
         Ok(metadata) => {
             if metadata.file_type().is_file() || metadata.file_type().is_symlink() {
                 do_op(path, "remove file", |p| fs::remove_file(p));
@@ -66,20 +66,20 @@ fn rm_rf(path: &Path) {
                 rm_rf(&t!(file).path());
             }
             do_op(path, "remove dir", |p| fs::remove_dir(p));
-        },
+        }
     };
 }
 
 fn do_op<F>(path: &Path, desc: &str, mut f: F)
-    where F: FnMut(&Path) -> io::Result<()>
+where
+    F: FnMut(&Path) -> io::Result<()>,
 {
     match f(path) {
         Ok(()) => {}
         // On windows we can't remove a readonly file, and git will often clone files as readonly.
         // As a result, we have some special logic to remove readonly files on windows.
         // This is also the reason that we can't use things like fs::remove_dir_all().
-        Err(ref e) if cfg!(windows) &&
-                      e.kind() == ErrorKind::PermissionDenied => {
+        Err(ref e) if cfg!(windows) && e.kind() == ErrorKind::PermissionDenied => {
             let mut p = t!(path.symlink_metadata()).permissions();
             p.set_readonly(false);
             t!(fs::set_permissions(path, p));

--- a/src/bootstrap/clean.rs
+++ b/src/bootstrap/clean.rs
@@ -25,13 +25,13 @@ pub fn clean(build: &Build, all: bool) {
     rm_rf("tmp".as_ref());
 
     if all {
-        rm_rf(&build.out);
+        rm_rf(&build.config.out);
     } else {
-        rm_rf(&build.out.join("tmp"));
-        rm_rf(&build.out.join("dist"));
+        rm_rf(&build.config.out.join("tmp"));
+        rm_rf(&build.config.out.join("dist"));
 
         for host in &build.hosts {
-            let entries = match build.out.join(host).read_dir() {
+            let entries = match build.config.out.join(host).read_dir() {
                 Ok(iter) => iter,
                 Err(_) => continue,
             };

--- a/src/bootstrap/clean.rs
+++ b/src/bootstrap/clean.rs
@@ -25,13 +25,13 @@ pub fn clean(build: &Build, all: bool) {
     rm_rf("tmp".as_ref());
 
     if all {
-        rm_rf(&build.config.out);
+        rm_rf(&build.config.general.out);
     } else {
-        rm_rf(&build.config.out.join("tmp"));
-        rm_rf(&build.config.out.join("dist"));
+        rm_rf(&build.config.general.out.join("tmp"));
+        rm_rf(&build.config.general.out.join("dist"));
 
         for host in &build.config.hosts {
-            let entries = match build.config.out.join(host).read_dir() {
+            let entries = match build.config.general.out.join(host).read_dir() {
                 Ok(iter) => iter,
                 Err(_) => continue,
             };

--- a/src/bootstrap/clean.rs
+++ b/src/bootstrap/clean.rs
@@ -30,7 +30,7 @@ pub fn clean(build: &Build, all: bool) {
         rm_rf(&build.config.out.join("tmp"));
         rm_rf(&build.config.out.join("dist"));
 
-        for host in &build.hosts {
+        for host in &build.config.hosts {
             let entries = match build.config.out.join(host).read_dir() {
                 Ok(iter) => iter,
                 Err(_) => continue,

--- a/src/bootstrap/clean.rs
+++ b/src/bootstrap/clean.rs
@@ -15,10 +15,10 @@
 //! `build/cache` directory (download cache) or the `build/$target/llvm`
 //! directory unless the --all flag is present.
 
-use std::fs;
 use std::io::{self, ErrorKind};
 use std::path::Path;
 
+use fs;
 use Build;
 
 pub fn clean(build: &Build, all: bool) {

--- a/src/bootstrap/clean.rs
+++ b/src/bootstrap/clean.rs
@@ -30,7 +30,7 @@ pub fn clean(build: &Build, all: bool) {
         rm_rf(&build.config.general.out.join("tmp"));
         rm_rf(&build.config.general.out.join("dist"));
 
-        for host in &build.config.hosts {
+        for host in &build.config.general.host {
             let entries = match build.config.general.out.join(host).read_dir() {
                 Ok(iter) => iter,
                 Err(_) => continue,

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -150,11 +150,11 @@ pub fn std_cargo(build: &Build,
     // same view of what the default allocator is, but fails otherwise. Since
     // we don't have a way to express an allocator preference yet, work
     // around the issue in the case of a local rebuild with jemalloc disabled.
-    if compiler.stage == 0 && build.config.local_rebuild && !build.config.rust.use_jemalloc {
+    if compiler.stage == 0 && build.config.general.local_rebuild && !build.config.rust.use_jemalloc {
         features.push_str(" force_alloc_system");
     }
 
-    if compiler.stage != 0 && build.config.sanitizers {
+    if compiler.stage != 0 && build.config.general.sanitizers {
         // This variable is used by the sanitizer runtime crates, e.g.
         // rustc_lsan, to build the sanitizer runtime from C code
         // When this variable is missing, those crates won't compile the C code,
@@ -217,7 +217,7 @@ impl Step for StdLink {
         let libdir = builder.sysroot_libdir(target_compiler, target);
         add_to_sysroot(&libdir, &libstd_stamp(build, compiler, target));
 
-        if build.config.sanitizers && compiler.stage != 0 && target == "x86_64-apple-darwin" {
+        if build.config.general.sanitizers && compiler.stage != 0 && target == "x86_64-apple-darwin" {
             // The sanitizers are only built in stage1 or above, so the dylibs will
             // be missing in stage0 and causes panic. See the `std()` function above
             // for reason why the sanitizers are not built in stage0.

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -71,7 +71,7 @@ impl Step for Std {
         builder.ensure(StartupObjects { compiler, target });
 
         if build.force_use_stage1(compiler, target) {
-            let from = builder.compiler(1, build.build);
+            let from = builder.compiler(1, build.config.build);
             builder.ensure(Std {
                 compiler: from,
                 target,
@@ -112,7 +112,7 @@ impl Step for Std {
                   false);
 
         builder.ensure(StdLink {
-            compiler: builder.compiler(compiler.stage, build.build),
+            compiler: builder.compiler(compiler.stage, build.config.build),
             target_compiler: compiler,
             target,
         });
@@ -344,12 +344,12 @@ impl Step for Test {
 
         if build.force_use_stage1(compiler, target) {
             builder.ensure(Test {
-                compiler: builder.compiler(1, build.build),
+                compiler: builder.compiler(1, build.config.build),
                 target,
             });
-            println!("Uplifting stage1 test ({} -> {})", &build.build, target);
+            println!("Uplifting stage1 test ({} -> {})", &build.config.build, target);
             builder.ensure(TestLink {
-                compiler: builder.compiler(1, build.build),
+                compiler: builder.compiler(1, build.config.build),
                 target_compiler: compiler,
                 target,
             });
@@ -369,7 +369,7 @@ impl Step for Test {
                   false);
 
         builder.ensure(TestLink {
-            compiler: builder.compiler(compiler.stage, build.build),
+            compiler: builder.compiler(compiler.stage, build.config.build),
             target_compiler: compiler,
             target,
         });
@@ -460,12 +460,12 @@ impl Step for Rustc {
 
         if build.force_use_stage1(compiler, target) {
             builder.ensure(Rustc {
-                compiler: builder.compiler(1, build.build),
+                compiler: builder.compiler(1, build.config.build),
                 target,
             });
-            println!("Uplifting stage1 rustc ({} -> {})", &build.build, target);
+            println!("Uplifting stage1 rustc ({} -> {})", &build.config.build, target);
             builder.ensure(RustcLink {
-                compiler: builder.compiler(1, build.build),
+                compiler: builder.compiler(1, build.config.build),
                 target_compiler: compiler,
                 target,
             });
@@ -474,8 +474,8 @@ impl Step for Rustc {
 
         // Ensure that build scripts have a std to link against.
         builder.ensure(Std {
-            compiler: builder.compiler(self.compiler.stage, build.build),
-            target: build.build,
+            compiler: builder.compiler(self.compiler.stage, build.config.build),
+            target: build.config.build,
         });
 
         let _folder = build.fold_output(|| format!("stage{}-rustc", compiler.stage));
@@ -494,7 +494,7 @@ impl Step for Rustc {
                   false);
 
         builder.ensure(RustcLink {
-            compiler: builder.compiler(compiler.stage, build.build),
+            compiler: builder.compiler(compiler.stage, build.config.build),
             target_compiler: compiler,
             target,
         });
@@ -616,7 +616,7 @@ impl Step for CodegenBackend {
 
         if build.force_use_stage1(compiler, target) {
             builder.ensure(CodegenBackend {
-                compiler: builder.compiler(1, build.build),
+                compiler: builder.compiler(1, build.config.build),
                 target,
                 backend: self.backend,
             });
@@ -840,7 +840,7 @@ impl Step for Assemble {
         let target_compiler = self.target_compiler;
 
         if target_compiler.stage == 0 {
-            assert_eq!(build.build, target_compiler.host,
+            assert_eq!(build.config.build, target_compiler.host,
                 "Cannot obtain compiler for non-native build triple at stage 0");
             // The stage 0 compiler for the build triple is always pre-built.
             return target_compiler;
@@ -863,7 +863,7 @@ impl Step for Assemble {
         // FIXME: It may be faster if we build just a stage 1 compiler and then
         //        use that to bootstrap this compiler forward.
         let build_compiler =
-            builder.compiler(target_compiler.stage - 1, build.build);
+            builder.compiler(target_compiler.stage - 1, build.config.build);
 
         // Build the libraries for this compiler to link to (i.e., the libraries
         // it uses at runtime). NOTE: Crates the target compiler compiles don't

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -660,7 +660,7 @@ impl Step for CodegenBackend {
                 }
                 // Building with a static libstdc++ is only supported on linux right now,
                 // not for MSVC or macOS
-                if build.config.llvm_static_stdcpp &&
+                if build.config.llvm.static_libstdcpp &&
                    !target.contains("freebsd") &&
                    !target.contains("windows") &&
                    !target.contains("apple") {
@@ -670,7 +670,7 @@ impl Step for CodegenBackend {
                                              "libstdc++.a");
                     cargo.env("LLVM_STATIC_STDCPP", file);
                 }
-                if build.config.llvm_link_shared {
+                if build.config.llvm.link_shared {
                     cargo.env("LLVM_LINK_SHARED", "1");
                 }
             }

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -514,7 +514,7 @@ fn rustc_cargo_env(build: &Build, cargo: &mut Command) {
     cargo.env("CFG_RELEASE", build.rust_release())
          .env("CFG_RELEASE_CHANNEL", &build.config.channel)
          .env("CFG_VERSION", build.rust_version())
-         .env("CFG_PREFIX", build.config.prefix.clone().unwrap_or_default());
+         .env("CFG_PREFIX", &build.config.install.prefix);
 
     let libdir_relative = build.config.libdir_relative().unwrap_or(Path::new("lib"));
     cargo.env("CFG_LIBDIR_RELATIVE", libdir_relative);

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -16,7 +16,6 @@
 //! compiler. This module is also responsible for assembling the sysroot as it
 //! goes along from the output of the previous stage.
 
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str;
@@ -24,6 +23,7 @@ use std::cmp::min;
 
 use build_helper::{output, up_to_date};
 
+use fs;
 use util::{copy, exe, is_dylib, libdir, read_stamp_file};
 use {Compiler, Mode};
 use native;
@@ -31,7 +31,7 @@ use native;
 use cache::{Intern, Interned};
 use builder::{Builder, RunConfig, ShouldRun, Step};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Std {
     pub target: Interned<String>,
     pub compiler: Compiler,
@@ -123,6 +123,8 @@ impl Step for StdLink {
     fn should_run(run: ShouldRun) -> ShouldRun {
         run.never()
     }
+
+    fn for_test(self, _builder: &Builder) {}
 
     /// Link all libstd rlibs/dylibs into the sysroot location.
     ///
@@ -237,10 +239,10 @@ impl Step for StartupObjects {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Test {
-    pub compiler: Compiler,
     pub target: Interned<String>,
+    pub compiler: Compiler,
 }
 
 impl Step for Test {
@@ -315,6 +317,8 @@ impl Step for TestLink {
         run.never()
     }
 
+    fn for_test(self, _builder: &Builder) {}
+
     /// Same as `std_link`, only for libtest
     fn run(self, builder: &Builder) {
         let compiler = self.compiler;
@@ -331,7 +335,7 @@ impl Step for TestLink {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Rustc {
     pub compiler: Compiler,
     pub target: Interned<String>,
@@ -416,6 +420,8 @@ impl Step for RustcLink {
     fn should_run(run: ShouldRun) -> ShouldRun {
         run.never()
     }
+
+    fn for_test(self, _builder: &Builder) {}
 
     /// Same as `std_link`, only for librustc
     fn run(self, builder: &Builder) {
@@ -628,7 +634,7 @@ impl Step for Sysroot {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Assemble {
     /// The compiler which we will produce in this step. Assemble itself will
     /// take care of ensuring that the necessary prerequisites to do so exist,

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -86,12 +86,7 @@ impl Step for Std {
             compiler.stage, &compiler.host, target
         );
 
-        let mut cargo = builder.cargo(compiler, Mode::Libstd, target, "build");
-        builder.run_cargo(
-            &mut cargo,
-            &builder.libstd_stamp(compiler, target),
-            false,
-        );
+        builder.cargo(compiler, Mode::Libstd, target, "build").run();
 
         builder.ensure(StdLink {
             compiler: builder.compiler(compiler.stage, builder.config.general.build),
@@ -303,12 +298,7 @@ impl Step for Test {
             "Building stage{} test artifacts ({} -> {})",
             compiler.stage, &compiler.host, target
         );
-        let mut cargo = builder.cargo(compiler, Mode::Libtest, target, "build");
-        builder.run_cargo(
-            &mut cargo,
-            &builder.libtest_stamp(compiler, target),
-            false,
-        );
+        builder.cargo(compiler, Mode::Libtest, target, "build").run();
 
         builder.ensure(TestLink {
             compiler: builder.compiler(compiler.stage, builder.config.general.build),
@@ -415,12 +405,7 @@ impl Step for Rustc {
             compiler.stage, &compiler.host, target
         );
 
-        let mut cargo = builder.cargo(compiler, Mode::Librustc, target, "build");
-        builder.run_cargo(
-            &mut cargo,
-            &builder.librustc_stamp(compiler, target),
-            false,
-        );
+        builder.cargo(compiler, Mode::Librustc, target, "build").run();
 
         builder.ensure(RustcLink {
             compiler: builder.compiler(compiler.stage, builder.config.general.build),
@@ -554,11 +539,7 @@ impl Step for CodegenBackend {
             _ => panic!("unknown backend: {}", self.backend),
         }
 
-        builder.run_cargo(
-            &mut cargo,
-            &builder.codegen_backend_stamp(compiler, target, &*self.backend),
-            false,
-        );
+        cargo.run();
     }
 }
 

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -16,19 +16,15 @@
 //! compiler. This module is also responsible for assembling the sysroot as it
 //! goes along from the output of the previous stage.
 
-use std::fs::{self, File};
-use std::io::BufReader;
-use std::io::prelude::*;
+use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Command;
 use std::str;
 use std::cmp::min;
 
-use build_helper::{mtime, output, up_to_date};
-use filetime::FileTime;
-use serde_json;
+use build_helper::{output, up_to_date};
 
-use util::{copy, exe, is_dylib, libdir, read_stamp_file, CiEnv};
+use util::{copy, exe, is_dylib, libdir, read_stamp_file};
 use {Compiler, Mode};
 use native;
 use tool;
@@ -91,8 +87,7 @@ impl Step for Std {
         );
 
         let mut cargo = builder.cargo(compiler, Mode::Libstd, target, "build");
-        run_cargo(
-            builder,
+        builder.run_cargo(
             &mut cargo,
             &builder.libstd_stamp(compiler, target),
             false,
@@ -309,8 +304,7 @@ impl Step for Test {
             compiler.stage, &compiler.host, target
         );
         let mut cargo = builder.cargo(compiler, Mode::Libtest, target, "build");
-        run_cargo(
-            builder,
+        builder.run_cargo(
             &mut cargo,
             &builder.libtest_stamp(compiler, target),
             false,
@@ -422,8 +416,7 @@ impl Step for Rustc {
         );
 
         let mut cargo = builder.cargo(compiler, Mode::Librustc, target, "build");
-        run_cargo(
-            builder,
+        builder.run_cargo(
             &mut cargo,
             &builder.librustc_stamp(compiler, target),
             false,
@@ -561,8 +554,7 @@ impl Step for CodegenBackend {
             _ => panic!("unknown backend: {}", self.backend),
         }
 
-        run_cargo(
-            builder,
+        builder.run_cargo(
             &mut cargo,
             &builder.codegen_backend_stamp(compiler, target, &*self.backend),
             false,
@@ -810,208 +802,4 @@ pub fn add_to_sysroot(sysroot_dst: &Path, stamp: &Path) {
     for path in read_stamp_file(stamp) {
         copy(&path, &sysroot_dst.join(path.file_name().unwrap()));
     }
-}
-
-// Avoiding a dependency on winapi to keep compile times down
-#[cfg(unix)]
-fn stderr_isatty() -> bool {
-    use libc;
-    unsafe { libc::isatty(libc::STDERR_FILENO) != 0 }
-}
-#[cfg(windows)]
-fn stderr_isatty() -> bool {
-    type DWORD = u32;
-    type BOOL = i32;
-    type HANDLE = *mut u8;
-    const STD_ERROR_HANDLE: DWORD = -12i32 as DWORD;
-    extern "system" {
-        fn GetStdHandle(which: DWORD) -> HANDLE;
-        fn GetConsoleMode(hConsoleHandle: HANDLE, lpMode: *mut DWORD) -> BOOL;
-    }
-    unsafe {
-        let handle = GetStdHandle(STD_ERROR_HANDLE);
-        let mut out = 0;
-        GetConsoleMode(handle, &mut out) != 0
-    }
-}
-
-pub fn run_cargo(
-    builder: &Builder,
-    cargo: &mut Command,
-    stamp: &Path,
-    is_check: bool,
-) -> Vec<PathBuf> {
-    // Instruct Cargo to give us json messages on stdout, critically leaving
-    // stderr as piped so we can get those pretty colors.
-    cargo
-        .arg("--message-format")
-        .arg("json")
-        .stdout(Stdio::piped());
-
-    if stderr_isatty() && builder.ci_env == CiEnv::None {
-        // since we pass message-format=json to cargo, we need to tell the rustc
-        // wrapper to give us colored output if necessary. This is because we
-        // only want Cargo's JSON output, not rustcs.
-        cargo.env("RUSTC_COLOR", "1");
-    }
-
-    builder.verbose(&format!("running: {:?}", cargo));
-    let mut child = match cargo.spawn() {
-        Ok(child) => child,
-        Err(e) => panic!("failed to execute command: {:?}\nerror: {}", cargo, e),
-    };
-
-    // `target_root_dir` looks like $dir/$target/release
-    let target_root_dir = stamp.parent().unwrap();
-    // `target_deps_dir` looks like $dir/$target/release/deps
-    let target_deps_dir = target_root_dir.join("deps");
-    // `host_root_dir` looks like $dir/release
-    let host_root_dir = target_root_dir.parent().unwrap() // chop off `release`
-                                       .parent().unwrap() // chop off `$target`
-                                       .join(target_root_dir.file_name().unwrap());
-
-    // Spawn Cargo slurping up its JSON output. We'll start building up the
-    // `deps` array of all files it generated along with a `toplevel` array of
-    // files we need to probe for later.
-    let mut deps = Vec::new();
-    let mut toplevel = Vec::new();
-    let stdout = BufReader::new(child.stdout.take().unwrap());
-    for line in stdout.lines() {
-        let line = t!(line);
-        let json: serde_json::Value = if line.starts_with("{") {
-            t!(serde_json::from_str(&line))
-        } else {
-            // If this was informational, just print it out and continue
-            println!("{}", line);
-            continue;
-        };
-        if json["reason"].as_str() != Some("compiler-artifact") {
-            continue;
-        }
-        for filename in json["filenames"].as_array().unwrap() {
-            let filename = filename.as_str().unwrap();
-            // Skip files like executables
-            if !filename.ends_with(".rlib") && !filename.ends_with(".lib") && !is_dylib(&filename)
-                && !(is_check && filename.ends_with(".rmeta"))
-            {
-                continue;
-            }
-
-            let filename = Path::new(filename);
-
-            // If this was an output file in the "host dir" we don't actually
-            // worry about it, it's not relevant for us.
-            if filename.starts_with(&host_root_dir) {
-                continue;
-            }
-
-            // If this was output in the `deps` dir then this is a precise file
-            // name (hash included) so we start tracking it.
-            if filename.starts_with(&target_deps_dir) {
-                deps.push(filename.to_path_buf());
-                continue;
-            }
-
-            // Otherwise this was a "top level artifact" which right now doesn't
-            // have a hash in the name, but there's a version of this file in
-            // the `deps` folder which *does* have a hash in the name. That's
-            // the one we'll want to we'll probe for it later.
-            //
-            // We do not use `Path::file_stem` or `Path::extension` here,
-            // because some generated files may have multiple extensions e.g.
-            // `std-<hash>.dll.lib` on Windows. The aforementioned methods only
-            // split the file name by the last extension (`.lib`) while we need
-            // to split by all extensions (`.dll.lib`).
-            let expected_len = t!(filename.metadata()).len();
-            let filename = filename.file_name().unwrap().to_str().unwrap();
-            let mut parts = filename.splitn(2, '.');
-            let file_stem = parts.next().unwrap().to_owned();
-            let extension = parts.next().unwrap().to_owned();
-
-            toplevel.push((file_stem, extension, expected_len));
-        }
-    }
-
-    // Make sure Cargo actually succeeded after we read all of its stdout.
-    let status = t!(child.wait());
-    if !status.success() {
-        panic!(
-            "command did not execute successfully: {:?}\n\
-             expected success, got: {}",
-            cargo, status
-        );
-    }
-
-    // Ok now we need to actually find all the files listed in `toplevel`. We've
-    // got a list of prefix/extensions and we basically just need to find the
-    // most recent file in the `deps` folder corresponding to each one.
-    let contents = t!(target_deps_dir.read_dir())
-        .map(|e| t!(e))
-        .map(|e| {
-            (
-                e.path(),
-                e.file_name().into_string().unwrap(),
-                t!(e.metadata()),
-            )
-        })
-        .collect::<Vec<_>>();
-    for (prefix, extension, expected_len) in toplevel {
-        let candidates = contents.iter().filter(|&&(_, ref filename, ref meta)| {
-            filename.starts_with(&prefix[..]) && filename[prefix.len()..].starts_with("-")
-                && filename.ends_with(&extension[..]) && meta.len() == expected_len
-        });
-        let max = candidates
-            .max_by_key(|&&(_, _, ref metadata)| FileTime::from_last_modification_time(metadata));
-        let path_to_add = match max {
-            Some(triple) => triple.0.to_str().unwrap(),
-            None => panic!("no output generated for {:?} {:?}", prefix, extension),
-        };
-        if is_dylib(path_to_add) {
-            let candidate = format!("{}.lib", path_to_add);
-            let candidate = PathBuf::from(candidate);
-            if candidate.exists() {
-                deps.push(candidate);
-            }
-        }
-        deps.push(path_to_add.into());
-    }
-
-    // Now we want to update the contents of the stamp file, if necessary. First
-    // we read off the previous contents along with its mtime. If our new
-    // contents (the list of files to copy) is different or if any dep's mtime
-    // is newer then we rewrite the stamp file.
-    deps.sort();
-    let mut stamp_contents = Vec::new();
-    if let Ok(mut f) = File::open(stamp) {
-        t!(f.read_to_end(&mut stamp_contents));
-    }
-    let stamp_mtime = mtime(&stamp);
-    let mut new_contents = Vec::new();
-    let mut max = None;
-    let mut max_path = None;
-    for dep in deps.iter() {
-        let mtime = mtime(dep);
-        if Some(mtime) > max {
-            max = Some(mtime);
-            max_path = Some(dep.clone());
-        }
-        new_contents.extend(dep.to_str().unwrap().as_bytes());
-        new_contents.extend(b"\0");
-    }
-    let max = max.unwrap();
-    let max_path = max_path.unwrap();
-    if stamp_contents == new_contents && max <= stamp_mtime {
-        builder.verbose(&format!(
-            "not updating {:?}; contents equal and {} <= {}",
-            stamp, max, stamp_mtime
-        ));
-        return deps;
-    }
-    if max > stamp_mtime {
-        builder.verbose(&format!("updating {:?} as {:?} changed", stamp, max_path));
-    } else {
-        builder.verbose(&format!("updating {:?} as deps changed", stamp));
-    }
-    t!(t!(File::create(stamp)).write_all(&new_contents));
-    deps
 }

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -805,9 +805,9 @@ impl Step for Sysroot {
         let build = builder.build;
         let compiler = self.compiler;
         let sysroot = if compiler.stage == 0 {
-            build.config.out.join(&compiler.host).join("stage0-sysroot")
+            build.config.general.out.join(&compiler.host).join("stage0-sysroot")
         } else {
-            build.config.out.join(&compiler.host).join(format!("stage{}", compiler.stage))
+            build.config.general.out.join(&compiler.host).join(format!("stage{}", compiler.stage))
         };
         let _ = fs::remove_dir_all(&sysroot);
         t!(fs::create_dir_all(&sysroot));

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -150,7 +150,7 @@ pub fn std_cargo(build: &Build,
     // same view of what the default allocator is, but fails otherwise. Since
     // we don't have a way to express an allocator preference yet, work
     // around the issue in the case of a local rebuild with jemalloc disabled.
-    if compiler.stage == 0 && build.local_rebuild && !build.config.use_jemalloc {
+    if compiler.stage == 0 && build.config.local_rebuild && !build.config.use_jemalloc {
         features.push_str(" force_alloc_system");
     }
 

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -287,7 +287,7 @@ impl Step for StartupObjects {
             let src_file = &src_dir.join(file.to_string() + ".rs");
             let dst_file = &dst_dir.join(file.to_string() + ".o");
             if !up_to_date(src_file, dst_file) {
-                let mut cmd = Command::new(&build.config.initial_rustc);
+                let mut cmd = Command::new(&build.config.general.initial_rustc);
                 build.run(cmd.env("RUSTC_BOOTSTRAP", "1")
                             .arg("--cfg").arg("stage0")
                             .arg("--target").arg(target)

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -27,7 +27,6 @@ use build_helper::{output, up_to_date};
 use util::{copy, exe, is_dylib, libdir, read_stamp_file};
 use {Compiler, Mode};
 use native;
-use tool;
 
 use cache::{Intern, Interned};
 use builder::{Builder, RunConfig, ShouldRun, Step};
@@ -157,12 +156,6 @@ impl Step for StdLink {
             let libdir = builder.sysroot_libdir(target_compiler, target);
             copy_musl_third_party_objects(builder, target, &libdir);
         }
-
-        builder.ensure(tool::CleanTools {
-            compiler: target_compiler,
-            target,
-            mode: Mode::Libstd,
-        });
     }
 }
 
@@ -335,11 +328,6 @@ impl Step for TestLink {
             &builder.sysroot_libdir(target_compiler, target),
             &builder.libtest_stamp(compiler, target),
         );
-        builder.ensure(tool::CleanTools {
-            compiler: target_compiler,
-            target,
-            mode: Mode::Libtest,
-        });
     }
 }
 
@@ -442,11 +430,6 @@ impl Step for RustcLink {
             &builder.sysroot_libdir(target_compiler, target),
             &builder.librustc_stamp(compiler, target),
         );
-        builder.ensure(tool::CleanTools {
-            compiler: target_compiler,
-            target,
-            mode: Mode::Librustc,
-        });
     }
 }
 

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -167,7 +167,7 @@ pub fn std_cargo(build: &Build,
 
     cargo.arg("--features").arg(features)
         .arg("--manifest-path")
-        .arg(build.src.join("src/libstd/Cargo.toml"));
+        .arg(build.config.src.join("src/libstd/Cargo.toml"));
 
     if let Some(target) = build.config.target_config.get(&target) {
         if let Some(ref jemalloc) = target.jemalloc {
@@ -278,7 +278,7 @@ impl Step for StartupObjects {
             return
         }
 
-        let src_dir = &build.src.join("src/rtstartup");
+        let src_dir = &build.config.src.join("src/rtstartup");
         let dst_dir = &build.native_dir(target).join("rtstartup");
         let sysroot_dir = &builder.sysroot_libdir(for_compiler, target);
         t!(fs::create_dir_all(dst_dir));
@@ -385,7 +385,7 @@ pub fn test_cargo(build: &Build,
         cargo.env("MACOSX_DEPLOYMENT_TARGET", target);
     }
     cargo.arg("--manifest-path")
-        .arg(build.src.join("src/libtest/Cargo.toml"));
+        .arg(build.config.src.join("src/libtest/Cargo.toml"));
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -504,7 +504,7 @@ impl Step for Rustc {
 pub fn rustc_cargo(build: &Build, cargo: &mut Command) {
     cargo.arg("--features").arg(build.rustc_features())
          .arg("--manifest-path")
-         .arg(build.src.join("src/rustc/Cargo.toml"));
+         .arg(build.config.src.join("src/rustc/Cargo.toml"));
     rustc_cargo_env(build, cargo);
 }
 
@@ -626,7 +626,7 @@ impl Step for CodegenBackend {
         let mut cargo = builder.cargo(compiler, Mode::Librustc, target, "build");
         let mut features = build.rustc_features().to_string();
         cargo.arg("--manifest-path")
-            .arg(build.src.join("src/librustc_trans/Cargo.toml"));
+            .arg(build.config.src.join("src/librustc_trans/Cargo.toml"));
         rustc_cargo_env(build, &mut cargo);
 
         match &*self.backend {

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -71,7 +71,7 @@ impl Step for Std {
         builder.ensure(StartupObjects { compiler, target });
 
         if build.force_use_stage1(compiler, target) {
-            let from = builder.compiler(1, build.config.build);
+            let from = builder.compiler(1, build.config.general.build);
             builder.ensure(Std {
                 compiler: from,
                 target,
@@ -112,7 +112,7 @@ impl Step for Std {
                   false);
 
         builder.ensure(StdLink {
-            compiler: builder.compiler(compiler.stage, build.config.build),
+            compiler: builder.compiler(compiler.stage, build.config.general.build),
             target_compiler: compiler,
             target,
         });
@@ -344,12 +344,12 @@ impl Step for Test {
 
         if build.force_use_stage1(compiler, target) {
             builder.ensure(Test {
-                compiler: builder.compiler(1, build.config.build),
+                compiler: builder.compiler(1, build.config.general.build),
                 target,
             });
-            println!("Uplifting stage1 test ({} -> {})", &build.config.build, target);
+            println!("Uplifting stage1 test ({} -> {})", &build.config.general.build, target);
             builder.ensure(TestLink {
-                compiler: builder.compiler(1, build.config.build),
+                compiler: builder.compiler(1, build.config.general.build),
                 target_compiler: compiler,
                 target,
             });
@@ -369,7 +369,7 @@ impl Step for Test {
                   false);
 
         builder.ensure(TestLink {
-            compiler: builder.compiler(compiler.stage, build.config.build),
+            compiler: builder.compiler(compiler.stage, build.config.general.build),
             target_compiler: compiler,
             target,
         });
@@ -460,12 +460,12 @@ impl Step for Rustc {
 
         if build.force_use_stage1(compiler, target) {
             builder.ensure(Rustc {
-                compiler: builder.compiler(1, build.config.build),
+                compiler: builder.compiler(1, build.config.general.build),
                 target,
             });
-            println!("Uplifting stage1 rustc ({} -> {})", &build.config.build, target);
+            println!("Uplifting stage1 rustc ({} -> {})", &build.config.general.build, target);
             builder.ensure(RustcLink {
-                compiler: builder.compiler(1, build.config.build),
+                compiler: builder.compiler(1, build.config.general.build),
                 target_compiler: compiler,
                 target,
             });
@@ -474,8 +474,8 @@ impl Step for Rustc {
 
         // Ensure that build scripts have a std to link against.
         builder.ensure(Std {
-            compiler: builder.compiler(self.compiler.stage, build.config.build),
-            target: build.config.build,
+            compiler: builder.compiler(self.compiler.stage, build.config.general.build),
+            target: build.config.general.build,
         });
 
         let _folder = build.fold_output(|| format!("stage{}-rustc", compiler.stage));
@@ -494,7 +494,7 @@ impl Step for Rustc {
                   false);
 
         builder.ensure(RustcLink {
-            compiler: builder.compiler(compiler.stage, build.config.build),
+            compiler: builder.compiler(compiler.stage, build.config.general.build),
             target_compiler: compiler,
             target,
         });
@@ -617,7 +617,7 @@ impl Step for CodegenBackend {
 
         if build.force_use_stage1(compiler, target) {
             builder.ensure(CodegenBackend {
-                compiler: builder.compiler(1, build.config.build),
+                compiler: builder.compiler(1, build.config.general.build),
                 target,
                 backend: self.backend,
             });
@@ -841,7 +841,7 @@ impl Step for Assemble {
         let target_compiler = self.target_compiler;
 
         if target_compiler.stage == 0 {
-            assert_eq!(build.config.build, target_compiler.host,
+            assert_eq!(build.config.general.build, target_compiler.host,
                 "Cannot obtain compiler for non-native build triple at stage 0");
             // The stage 0 compiler for the build triple is always pre-built.
             return target_compiler;
@@ -864,7 +864,7 @@ impl Step for Assemble {
         // FIXME: It may be faster if we build just a stage 1 compiler and then
         //        use that to bootstrap this compiler forward.
         let build_compiler =
-            builder.compiler(target_compiler.stage - 1, build.config.build);
+            builder.compiler(target_compiler.stage - 1, build.config.general.build);
 
         // Build the libraries for this compiler to link to (i.e., the libraries
         // it uses at runtime). NOTE: Crates the target compiler compiles don't

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -287,7 +287,7 @@ impl Step for StartupObjects {
             let src_file = &src_dir.join(file.to_string() + ".rs");
             let dst_file = &dst_dir.join(file.to_string() + ".o");
             if !up_to_date(src_file, dst_file) {
-                let mut cmd = Command::new(&build.initial_rustc);
+                let mut cmd = Command::new(&build.config.initial_rustc);
                 build.run(cmd.env("RUSTC_BOOTSTRAP", "1")
                             .arg("--cfg").arg("stage0")
                             .arg("--target").arg(target)

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -30,7 +30,7 @@ use filetime::FileTime;
 use serde_json;
 
 use util::{copy, exe, is_dylib, libdir, read_stamp_file, CiEnv};
-use {Build, Compiler, Mode};
+use {Compiler, Mode};
 use native;
 use tool;
 
@@ -64,14 +64,13 @@ impl Step for Std {
     /// using the `compiler` targeting the `target` architecture. The artifacts
     /// created will also be linked into the sysroot directory.
     fn run(self, builder: &Builder) {
-        let build = builder.build;
         let target = self.target;
         let compiler = self.compiler;
 
         builder.ensure(StartupObjects { compiler, target });
 
-        if build.force_use_stage1(compiler, target) {
-            let from = builder.compiler(1, build.config.general.build);
+        if builder.force_use_stage1(compiler, target) {
+            let from = builder.compiler(1, builder.config.general.build);
             builder.ensure(Std {
                 compiler: from,
                 target,
@@ -82,7 +81,7 @@ impl Step for Std {
             // still contain the musl startup objects.
             if target.contains("musl") {
                 let libdir = builder.sysroot_libdir(compiler, target);
-                copy_musl_third_party_objects(build, target, &libdir);
+                copy_musl_third_party_objects(builder, target, &libdir);
             }
 
             builder.ensure(StdLink {
@@ -93,7 +92,7 @@ impl Step for Std {
             return;
         }
 
-        let _folder = build.fold_output(|| format!("stage{}-std", compiler.stage));
+        let _folder = builder.fold_output(|| format!("stage{}-std", compiler.stage));
         println!(
             "Building stage{} std artifacts ({} -> {})",
             compiler.stage, &compiler.host, target
@@ -101,22 +100,22 @@ impl Step for Std {
 
         if target.contains("musl") {
             let libdir = builder.sysroot_libdir(compiler, target);
-            copy_musl_third_party_objects(build, target, &libdir);
+            copy_musl_third_party_objects(builder, target, &libdir);
         }
 
-        let out_dir = build.stage_out(compiler, Mode::Libstd);
-        build.clear_if_dirty(&out_dir, &builder.rustc(compiler));
+        let out_dir = builder.stage_out(compiler, Mode::Libstd);
+        builder.clear_if_dirty(&out_dir, &builder.rustc(compiler));
         let mut cargo = builder.cargo(compiler, Mode::Libstd, target, "build");
-        std_cargo(build, &compiler, target, &mut cargo);
+        std_cargo(builder, &compiler, target, &mut cargo);
         run_cargo(
-            build,
+            builder,
             &mut cargo,
-            &libstd_stamp(build, compiler, target),
+            &libstd_stamp(builder, compiler, target),
             false,
         );
 
         builder.ensure(StdLink {
-            compiler: builder.compiler(compiler.stage, build.config.general.build),
+            compiler: builder.compiler(compiler.stage, builder.config.general.build),
             target_compiler: compiler,
             target,
         });
@@ -129,10 +128,10 @@ impl Step for Std {
 /// with a glibc-targeting toolchain, given we have the appropriate startup
 /// files. As those shipped with glibc won't work, copy the ones provided by
 /// musl so we have them on linux-gnu hosts.
-fn copy_musl_third_party_objects(build: &Build, target: Interned<String>, into: &Path) {
+fn copy_musl_third_party_objects(builder: &Builder, target: Interned<String>, into: &Path) {
     for &obj in &["crt1.o", "crti.o", "crtn.o"] {
         copy(
-            &build.musl_root(target).unwrap().join("lib").join(obj),
+            &builder.musl_root(target).unwrap().join("lib").join(obj),
             &into.join(obj),
         );
     }
@@ -141,12 +140,12 @@ fn copy_musl_third_party_objects(build: &Build, target: Interned<String>, into: 
 /// Configure cargo to compile the standard library, adding appropriate env vars
 /// and such.
 pub fn std_cargo(
-    build: &Build,
+    builder: &Builder,
     compiler: &Compiler,
     target: Interned<String>,
     cargo: &mut Command,
 ) {
-    let mut features = build.std_features();
+    let mut features = builder.std_features();
 
     if let Some(target) = env::var_os("MACOSX_STD_DEPLOYMENT_TARGET") {
         cargo.env("MACOSX_DEPLOYMENT_TARGET", target);
@@ -157,12 +156,13 @@ pub fn std_cargo(
     // same view of what the default allocator is, but fails otherwise. Since
     // we don't have a way to express an allocator preference yet, work
     // around the issue in the case of a local rebuild with jemalloc disabled.
-    if compiler.stage == 0 && build.config.general.local_rebuild && !build.config.rust.use_jemalloc
+    if compiler.stage == 0 && builder.config.general.local_rebuild
+        && !builder.config.rust.use_jemalloc
     {
         features.push_str(" force_alloc_system");
     }
 
-    if compiler.stage != 0 && build.config.general.sanitizers {
+    if compiler.stage != 0 && builder.config.general.sanitizers {
         // This variable is used by the sanitizer runtime crates, e.g.
         // rustc_lsan, to build the sanitizer runtime from C code
         // When this variable is missing, those crates won't compile the C code,
@@ -170,22 +170,22 @@ pub fn std_cargo(
         // missing
         // We also only build the runtimes when --enable-sanitizers (or its
         // config.toml equivalent) is used
-        cargo.env("LLVM_CONFIG", build.llvm_config(target));
+        cargo.env("LLVM_CONFIG", builder.llvm_config(target));
     }
 
     cargo
         .arg("--features")
         .arg(features)
         .arg("--manifest-path")
-        .arg(build.config.src.join("src/libstd/Cargo.toml"));
+        .arg(builder.config.src.join("src/libstd/Cargo.toml"));
 
-    if let Some(target) = build.config.target_config.get(&target) {
+    if let Some(target) = builder.config.target_config.get(&target) {
         if let Some(ref jemalloc) = target.jemalloc {
             cargo.env("JEMALLOC_OVERRIDE", jemalloc);
         }
     }
     if target.contains("musl") {
-        if let Some(p) = build.musl_root(target) {
+        if let Some(p) = builder.musl_root(target) {
             cargo.env("MUSL_ROOT", p);
         }
     }
@@ -214,7 +214,6 @@ impl Step for StdLink {
     /// libraries for `target`, and this method will find them in the relevant
     /// output directory.
     fn run(self, builder: &Builder) {
-        let build = builder.build;
         let compiler = self.compiler;
         let target_compiler = self.target_compiler;
         let target = self.target;
@@ -223,14 +222,15 @@ impl Step for StdLink {
             target_compiler.stage, compiler.stage, &compiler.host, target_compiler.host, target
         );
         let libdir = builder.sysroot_libdir(target_compiler, target);
-        add_to_sysroot(&libdir, &libstd_stamp(build, compiler, target));
+        add_to_sysroot(&libdir, &libstd_stamp(builder, compiler, target));
 
-        if build.config.general.sanitizers && compiler.stage != 0 && target == "x86_64-apple-darwin"
+        if builder.config.general.sanitizers && compiler.stage != 0
+            && target == "x86_64-apple-darwin"
         {
             // The sanitizers are only built in stage1 or above, so the dylibs will
             // be missing in stage0 and causes panic. See the `std()` function above
             // for reason why the sanitizers are not built in stage0.
-            copy_apple_sanitizer_dylibs(&build.native_dir(target), "osx", &libdir);
+            copy_apple_sanitizer_dylibs(&builder.native_dir(target), "osx", &libdir);
         }
 
         builder.ensure(tool::CleanTools {
@@ -280,15 +280,14 @@ impl Step for StartupObjects {
     /// files, so we just use the nightly snapshot compiler to always build them (as
     /// no other compilers are guaranteed to be available).
     fn run(self, builder: &Builder) {
-        let build = builder.build;
         let for_compiler = self.compiler;
         let target = self.target;
         if !target.contains("pc-windows-gnu") {
             return;
         }
 
-        let src_dir = &build.config.src.join("src/rtstartup");
-        let dst_dir = &build.native_dir(target).join("rtstartup");
+        let src_dir = &builder.config.src.join("src/rtstartup");
+        let dst_dir = &builder.native_dir(target).join("rtstartup");
         let sysroot_dir = &builder.sysroot_libdir(for_compiler, target);
         t!(fs::create_dir_all(dst_dir));
 
@@ -296,8 +295,8 @@ impl Step for StartupObjects {
             let src_file = &src_dir.join(file.to_string() + ".rs");
             let dst_file = &dst_dir.join(file.to_string() + ".o");
             if !up_to_date(src_file, dst_file) {
-                let mut cmd = Command::new(&build.config.general.initial_rustc);
-                build.run(
+                let mut cmd = Command::new(&builder.config.general.initial_rustc);
+                builder.run(
                     cmd.env("RUSTC_BOOTSTRAP", "1")
                         .arg("--cfg")
                         .arg("stage0")
@@ -314,7 +313,7 @@ impl Step for StartupObjects {
         }
 
         for obj in ["crt2.o", "dllcrt2.o"].iter() {
-            let src = compiler_file(build, build.cc(target), target, obj);
+            let src = compiler_file(builder, builder.cc(target), target, obj);
             copy(&src, &sysroot_dir.join(obj));
         }
     }
@@ -347,47 +346,46 @@ impl Step for Test {
     /// the build using the `compiler` targeting the `target` architecture. The
     /// artifacts created will also be linked into the sysroot directory.
     fn run(self, builder: &Builder) {
-        let build = builder.build;
         let target = self.target;
         let compiler = self.compiler;
 
         builder.ensure(Std { compiler, target });
 
-        if build.force_use_stage1(compiler, target) {
+        if builder.force_use_stage1(compiler, target) {
             builder.ensure(Test {
-                compiler: builder.compiler(1, build.config.general.build),
+                compiler: builder.compiler(1, builder.config.general.build),
                 target,
             });
             println!(
                 "Uplifting stage1 test ({} -> {})",
-                &build.config.general.build, target
+                &builder.config.general.build, target
             );
             builder.ensure(TestLink {
-                compiler: builder.compiler(1, build.config.general.build),
+                compiler: builder.compiler(1, builder.config.general.build),
                 target_compiler: compiler,
                 target,
             });
             return;
         }
 
-        let _folder = build.fold_output(|| format!("stage{}-test", compiler.stage));
+        let _folder = builder.fold_output(|| format!("stage{}-test", compiler.stage));
         println!(
             "Building stage{} test artifacts ({} -> {})",
             compiler.stage, &compiler.host, target
         );
-        let out_dir = build.stage_out(compiler, Mode::Libtest);
-        build.clear_if_dirty(&out_dir, &libstd_stamp(build, compiler, target));
+        let out_dir = builder.stage_out(compiler, Mode::Libtest);
+        builder.clear_if_dirty(&out_dir, &libstd_stamp(builder, compiler, target));
         let mut cargo = builder.cargo(compiler, Mode::Libtest, target, "build");
-        test_cargo(build, &compiler, target, &mut cargo);
+        test_cargo(builder, &compiler, target, &mut cargo);
         run_cargo(
-            build,
+            builder,
             &mut cargo,
-            &libtest_stamp(build, compiler, target),
+            &libtest_stamp(builder, compiler, target),
             false,
         );
 
         builder.ensure(TestLink {
-            compiler: builder.compiler(compiler.stage, build.config.general.build),
+            compiler: builder.compiler(compiler.stage, builder.config.general.build),
             target_compiler: compiler,
             target,
         });
@@ -396,7 +394,7 @@ impl Step for Test {
 
 /// Same as `std_cargo`, but for libtest
 pub fn test_cargo(
-    build: &Build,
+    builder: &Builder,
     _compiler: &Compiler,
     _target: Interned<String>,
     cargo: &mut Command,
@@ -406,7 +404,7 @@ pub fn test_cargo(
     }
     cargo
         .arg("--manifest-path")
-        .arg(build.config.src.join("src/libtest/Cargo.toml"));
+        .arg(builder.config.src.join("src/libtest/Cargo.toml"));
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -425,7 +423,6 @@ impl Step for TestLink {
 
     /// Same as `std_link`, only for libtest
     fn run(self, builder: &Builder) {
-        let build = builder.build;
         let compiler = self.compiler;
         let target_compiler = self.target_compiler;
         let target = self.target;
@@ -435,7 +432,7 @@ impl Step for TestLink {
         );
         add_to_sysroot(
             &builder.sysroot_libdir(target_compiler, target),
-            &libtest_stamp(build, compiler, target),
+            &libtest_stamp(builder, compiler, target),
         );
         builder.ensure(tool::CleanTools {
             compiler: target_compiler,
@@ -473,23 +470,22 @@ impl Step for Rustc {
     /// the `compiler` targeting the `target` architecture. The artifacts
     /// created will also be linked into the sysroot directory.
     fn run(self, builder: &Builder) {
-        let build = builder.build;
         let compiler = self.compiler;
         let target = self.target;
 
         builder.ensure(Test { compiler, target });
 
-        if build.force_use_stage1(compiler, target) {
+        if builder.force_use_stage1(compiler, target) {
             builder.ensure(Rustc {
-                compiler: builder.compiler(1, build.config.general.build),
+                compiler: builder.compiler(1, builder.config.general.build),
                 target,
             });
             println!(
                 "Uplifting stage1 rustc ({} -> {})",
-                &build.config.general.build, target
+                &builder.config.general.build, target
             );
             builder.ensure(RustcLink {
-                compiler: builder.compiler(1, build.config.general.build),
+                compiler: builder.compiler(1, builder.config.general.build),
                 target_compiler: compiler,
                 target,
             });
@@ -498,78 +494,78 @@ impl Step for Rustc {
 
         // Ensure that build scripts have a std to link against.
         builder.ensure(Std {
-            compiler: builder.compiler(self.compiler.stage, build.config.general.build),
-            target: build.config.general.build,
+            compiler: builder.compiler(self.compiler.stage, builder.config.general.build),
+            target: builder.config.general.build,
         });
 
-        let _folder = build.fold_output(|| format!("stage{}-rustc", compiler.stage));
+        let _folder = builder.fold_output(|| format!("stage{}-rustc", compiler.stage));
         println!(
             "Building stage{} compiler artifacts ({} -> {})",
             compiler.stage, &compiler.host, target
         );
 
         let stage_out = builder.stage_out(compiler, Mode::Librustc);
-        build.clear_if_dirty(&stage_out, &libstd_stamp(build, compiler, target));
-        build.clear_if_dirty(&stage_out, &libtest_stamp(build, compiler, target));
+        builder.clear_if_dirty(&stage_out, &libstd_stamp(builder, compiler, target));
+        builder.clear_if_dirty(&stage_out, &libtest_stamp(builder, compiler, target));
 
         let mut cargo = builder.cargo(compiler, Mode::Librustc, target, "build");
-        rustc_cargo(build, &mut cargo);
+        rustc_cargo(builder, &mut cargo);
         run_cargo(
-            build,
+            builder,
             &mut cargo,
-            &librustc_stamp(build, compiler, target),
+            &librustc_stamp(builder, compiler, target),
             false,
         );
 
         builder.ensure(RustcLink {
-            compiler: builder.compiler(compiler.stage, build.config.general.build),
+            compiler: builder.compiler(compiler.stage, builder.config.general.build),
             target_compiler: compiler,
             target,
         });
     }
 }
 
-pub fn rustc_cargo(build: &Build, cargo: &mut Command) {
+pub fn rustc_cargo(builder: &Builder, cargo: &mut Command) {
     cargo
         .arg("--features")
-        .arg(build.rustc_features())
+        .arg(builder.rustc_features())
         .arg("--manifest-path")
-        .arg(build.config.src.join("src/rustc/Cargo.toml"));
-    rustc_cargo_env(build, cargo);
+        .arg(builder.config.src.join("src/rustc/Cargo.toml"));
+    rustc_cargo_env(builder, cargo);
 }
 
-fn rustc_cargo_env(build: &Build, cargo: &mut Command) {
+fn rustc_cargo_env(builder: &Builder, cargo: &mut Command) {
     // Set some configuration variables picked up by build scripts and
     // the compiler alike
     cargo
-        .env("CFG_RELEASE", build.rust_release())
-        .env("CFG_RELEASE_CHANNEL", &build.config.rust.channel)
-        .env("CFG_VERSION", build.rust_version())
-        .env("CFG_PREFIX", &build.config.install.prefix);
+        .env("CFG_RELEASE", builder.rust_release())
+        .env("CFG_RELEASE_CHANNEL", &builder.config.rust.channel)
+        .env("CFG_VERSION", builder.rust_version())
+        .env("CFG_PREFIX", &builder.config.install.prefix);
 
-    let libdir_relative = build.config.libdir_relative().unwrap_or(Path::new("lib"));
+    let libdir_relative = builder.config.libdir_relative().unwrap_or(Path::new("lib"));
     cargo.env("CFG_LIBDIR_RELATIVE", libdir_relative);
 
     // If we're not building a compiler with debugging information then remove
     // these two env vars which would be set otherwise.
-    if build.config.rust.debuginfo_only_std() {
+    if builder.config.rust.debuginfo_only_std() {
         cargo.env_remove("RUSTC_DEBUGINFO");
         cargo.env_remove("RUSTC_DEBUGINFO_LINES");
     }
 
-    if let Some(ref ver_date) = build.rust_info.commit_date() {
+    if let Some(ref ver_date) = builder.rust_info.commit_date() {
         cargo.env("CFG_VER_DATE", ver_date);
     }
-    if let Some(ref ver_hash) = build.rust_info.sha() {
+    if let Some(ref ver_hash) = builder.rust_info.sha() {
         cargo.env("CFG_VER_HASH", ver_hash);
     }
-    if !build.unstable_features() {
+    if !builder.unstable_features() {
         cargo.env("CFG_DISABLE_UNSTABLE_FEATURES", "1");
     }
-    if let Some(ref s) = build.config.rust.default_linker {
+    if let Some(ref s) = builder.config.rust.default_linker {
         cargo.env("CFG_DEFAULT_LINKER", s);
     }
-    if build.config.rust.experimental_parallel_queries {
+    if builder.config.rust.experimental_parallel_queries {
         cargo.env("RUSTC_PARALLEL_QUERIES", "1");
     }
 }
@@ -590,7 +586,6 @@ impl Step for RustcLink {
 
     /// Same as `std_link`, only for librustc
     fn run(self, builder: &Builder) {
-        let build = builder.build;
         let compiler = self.compiler;
         let target_compiler = self.target_compiler;
         let target = self.target;
@@ -600,7 +595,7 @@ impl Step for RustcLink {
         );
         add_to_sysroot(
             &builder.sysroot_libdir(target_compiler, target),
-            &librustc_stamp(build, compiler, target),
+            &librustc_stamp(builder, compiler, target),
         );
         builder.ensure(tool::CleanTools {
             compiler: target_compiler,
@@ -638,15 +633,14 @@ impl Step for CodegenBackend {
     }
 
     fn run(self, builder: &Builder) {
-        let build = builder.build;
         let compiler = self.compiler;
         let target = self.target;
 
         builder.ensure(Rustc { compiler, target });
 
-        if build.force_use_stage1(compiler, target) {
+        if builder.force_use_stage1(compiler, target) {
             builder.ensure(CodegenBackend {
-                compiler: builder.compiler(1, build.config.general.build),
+                compiler: builder.compiler(1, builder.config.general.build),
                 target,
                 backend: self.backend,
             });
@@ -654,11 +648,11 @@ impl Step for CodegenBackend {
         }
 
         let mut cargo = builder.cargo(compiler, Mode::Librustc, target, "build");
-        let mut features = build.rustc_features().to_string();
+        let mut features = builder.rustc_features().to_string();
         cargo
             .arg("--manifest-path")
-            .arg(build.config.src.join("src/librustc_trans/Cargo.toml"));
-        rustc_cargo_env(build, &mut cargo);
+            .arg(builder.config.src.join("src/librustc_trans/Cargo.toml"));
+        rustc_cargo_env(builder, &mut cargo);
 
         match &*self.backend {
             "llvm" | "emscripten" => {
@@ -673,7 +667,8 @@ impl Step for CodegenBackend {
                     features.push_str(" emscripten");
                 }
 
-                let _folder = build.fold_output(|| format!("stage{}-rustc_trans", compiler.stage));
+                let _folder =
+                    builder.fold_output(|| format!("stage{}-rustc_trans", compiler.stage));
                 println!(
                     "Building stage{} codegen artifacts ({} -> {}, {})",
                     compiler.stage, &compiler.host, target, self.backend
@@ -681,37 +676,37 @@ impl Step for CodegenBackend {
 
                 // Pass down configuration from the LLVM build into the build of
                 // librustc_llvm and librustc_trans.
-                if build.is_rust_llvm(target) {
+                if builder.is_rust_llvm(target) {
                     cargo.env("LLVM_RUSTLLVM", "1");
                 }
                 cargo.env("LLVM_CONFIG", &llvm_config);
                 if self.backend != "emscripten" {
-                    let target_config = build.config.target_config.get(&target);
+                    let target_config = builder.config.target_config.get(&target);
                     if let Some(s) = target_config.and_then(|c| c.llvm_config.as_ref()) {
                         cargo.env("CFG_LLVM_ROOT", s);
                     }
                 }
                 // Building with a static libstdc++ is only supported on linux right now,
                 // not for MSVC or macOS
-                if build.config.llvm.static_libstdcpp && !target.contains("freebsd")
+                if builder.config.llvm.static_libstdcpp && !target.contains("freebsd")
                     && !target.contains("windows") && !target.contains("apple")
                 {
                     let file =
-                        compiler_file(build, build.cxx(target).unwrap(), target, "libstdc++.a");
+                        compiler_file(builder, builder.cxx(target).unwrap(), target, "libstdc++.a");
                     cargo.env("LLVM_STATIC_STDCPP", file);
                 }
-                if build.config.llvm.link_shared {
+                if builder.config.llvm.link_shared {
                     cargo.env("LLVM_LINK_SHARED", "1");
                 }
             }
             _ => panic!("unknown backend: {}", self.backend),
         }
 
-        let tmp_stamp = build
+        let tmp_stamp = builder
             .cargo_out(compiler, Mode::Librustc, target)
             .join(".tmp.stamp");
         let files = run_cargo(
-            build,
+            builder,
             cargo.arg("--features").arg(features),
             &tmp_stamp,
             false,
@@ -731,7 +726,7 @@ impl Step for CodegenBackend {
                 f.display()
             );
         }
-        let stamp = codegen_backend_stamp(build, compiler, target, &*self.backend);
+        let stamp = codegen_backend_stamp(builder, compiler, target, &*self.backend);
         let codegen_backend = codegen_backend.to_str().unwrap();
         t!(t!(File::create(&stamp)).write_all(codegen_backend.as_bytes()));
     }
@@ -748,7 +743,6 @@ fn copy_codegen_backends_to_sysroot(
     compiler: Compiler,
     target_compiler: Compiler,
 ) {
-    let build = builder.build;
     let target = target_compiler.host;
 
     // Note that this step is different than all the other `*Link` steps in
@@ -763,7 +757,7 @@ fn copy_codegen_backends_to_sysroot(
     t!(fs::create_dir_all(&dst));
 
     for backend in builder.config.rust.codegen_backends.iter() {
-        let stamp = codegen_backend_stamp(build, compiler, target, &backend);
+        let stamp = codegen_backend_stamp(builder, compiler, target, &backend);
         let mut dylib = String::new();
         t!(t!(File::open(&stamp)).read_to_string(&mut dylib));
         let file = Path::new(&dylib);
@@ -780,42 +774,47 @@ fn copy_codegen_backends_to_sysroot(
 
 /// Cargo's output path for the standard library in a given stage, compiled
 /// by a particular compiler for the specified target.
-pub fn libstd_stamp(build: &Build, compiler: Compiler, target: Interned<String>) -> PathBuf {
-    build
+pub fn libstd_stamp(builder: &Builder, compiler: Compiler, target: Interned<String>) -> PathBuf {
+    builder
         .cargo_out(compiler, Mode::Libstd, target)
         .join(".libstd.stamp")
 }
 
 /// Cargo's output path for libtest in a given stage, compiled by a particular
 /// compiler for the specified target.
-pub fn libtest_stamp(build: &Build, compiler: Compiler, target: Interned<String>) -> PathBuf {
-    build
+pub fn libtest_stamp(builder: &Builder, compiler: Compiler, target: Interned<String>) -> PathBuf {
+    builder
         .cargo_out(compiler, Mode::Libtest, target)
         .join(".libtest.stamp")
 }
 
 /// Cargo's output path for librustc in a given stage, compiled by a particular
 /// compiler for the specified target.
-pub fn librustc_stamp(build: &Build, compiler: Compiler, target: Interned<String>) -> PathBuf {
-    build
+pub fn librustc_stamp(builder: &Builder, compiler: Compiler, target: Interned<String>) -> PathBuf {
+    builder
         .cargo_out(compiler, Mode::Librustc, target)
         .join(".librustc.stamp")
 }
 
 fn codegen_backend_stamp(
-    build: &Build,
+    builder: &Builder,
     compiler: Compiler,
     target: Interned<String>,
     backend: &str,
 ) -> PathBuf {
-    build
+    builder
         .cargo_out(compiler, Mode::Librustc, target)
         .join(format!(".librustc_trans-{}.stamp", backend))
 }
 
-fn compiler_file(build: &Build, compiler: &Path, target: Interned<String>, file: &str) -> PathBuf {
+fn compiler_file(
+    builder: &Builder,
+    compiler: &Path,
+    target: Interned<String>,
+    file: &str,
+) -> PathBuf {
     let mut cmd = Command::new(compiler);
-    cmd.args(build.cflags(target));
+    cmd.args(builder.cflags(target));
     cmd.arg(format!("-print-file-name={}", file));
     let out = output(&mut cmd);
     PathBuf::from(out.trim())
@@ -840,17 +839,16 @@ impl Step for Sysroot {
     /// thinks it is by default, but it's the same as the default for stages
     /// 1-3.
     fn run(self, builder: &Builder) -> Interned<PathBuf> {
-        let build = builder.build;
         let compiler = self.compiler;
         let sysroot = if compiler.stage == 0 {
-            build
+            builder
                 .config
                 .general
                 .out
                 .join(&compiler.host)
                 .join("stage0-sysroot")
         } else {
-            build
+            builder
                 .config
                 .general
                 .out
@@ -882,15 +880,14 @@ impl Step for Assemble {
     /// Prepare a new compiler from the artifacts in `stage`
     ///
     /// This will assemble a compiler in `build/$host/stage$stage`. The compiler
-    /// must have been previously produced by the `stage - 1` build.build
+    /// must have been previously produced by the `stage - 1` builder.build
     /// compiler.
     fn run(self, builder: &Builder) -> Compiler {
-        let build = builder.build;
         let target_compiler = self.target_compiler;
 
         if target_compiler.stage == 0 {
             assert_eq!(
-                build.config.general.build, target_compiler.host,
+                builder.config.general.build, target_compiler.host,
                 "Cannot obtain compiler for non-native build triple at stage 0"
             );
             // The stage 0 compiler for the build triple is always pre-built.
@@ -914,7 +911,7 @@ impl Step for Assemble {
         // FIXME: It may be faster if we build just a stage 1 compiler and then
         //        use that to bootstrap this compiler forward.
         let build_compiler =
-            builder.compiler(target_compiler.stage - 1, build.config.general.build);
+            builder.compiler(target_compiler.stage - 1, builder.config.general.build);
 
         // Build the libraries for this compiler to link to (i.e., the libraries
         // it uses at runtime). NOTE: Crates the target compiler compiles don't
@@ -953,7 +950,7 @@ impl Step for Assemble {
                 compiler: build_compiler,
                 target: target_compiler.host,
             });
-            for backend in build.config.rust.codegen_backends.iter() {
+            for backend in builder.config.rust.codegen_backends.iter() {
                 builder.ensure(CodegenBackend {
                     compiler: build_compiler,
                     target: target_compiler.host,
@@ -981,7 +978,7 @@ impl Step for Assemble {
         copy_codegen_backends_to_sysroot(builder, build_compiler, target_compiler);
 
         // Link the compiler binary itself into place
-        let out_dir = build.cargo_out(build_compiler, Mode::Librustc, host);
+        let out_dir = builder.cargo_out(build_compiler, Mode::Librustc, host);
         let rustc = out_dir.join(exe("rustc", &*host));
         let bindir = sysroot.join("bin");
         t!(fs::create_dir_all(&bindir));
@@ -1027,7 +1024,12 @@ fn stderr_isatty() -> bool {
     }
 }
 
-pub fn run_cargo(build: &Build, cargo: &mut Command, stamp: &Path, is_check: bool) -> Vec<PathBuf> {
+pub fn run_cargo(
+    builder: &Builder,
+    cargo: &mut Command,
+    stamp: &Path,
+    is_check: bool,
+) -> Vec<PathBuf> {
     // Instruct Cargo to give us json messages on stdout, critically leaving
     // stderr as piped so we can get those pretty colors.
     cargo
@@ -1035,14 +1037,14 @@ pub fn run_cargo(build: &Build, cargo: &mut Command, stamp: &Path, is_check: boo
         .arg("json")
         .stdout(Stdio::piped());
 
-    if stderr_isatty() && build.ci_env == CiEnv::None {
+    if stderr_isatty() && builder.ci_env == CiEnv::None {
         // since we pass message-format=json to cargo, we need to tell the rustc
         // wrapper to give us colored output if necessary. This is because we
         // only want Cargo's JSON output, not rustcs.
         cargo.env("RUSTC_COLOR", "1");
     }
 
-    build.verbose(&format!("running: {:?}", cargo));
+    builder.verbose(&format!("running: {:?}", cargo));
     let mut child = match cargo.spawn() {
         Ok(child) => child,
         Err(e) => panic!("failed to execute command: {:?}\nerror: {}", cargo, e),
@@ -1188,16 +1190,16 @@ pub fn run_cargo(build: &Build, cargo: &mut Command, stamp: &Path, is_check: boo
     let max = max.unwrap();
     let max_path = max_path.unwrap();
     if stamp_contents == new_contents && max <= stamp_mtime {
-        build.verbose(&format!(
+        builder.verbose(&format!(
             "not updating {:?}; contents equal and {} <= {}",
             stamp, max, stamp_mtime
         ));
         return deps;
     }
     if max > stamp_mtime {
-        build.verbose(&format!("updating {:?} as {:?} changed", stamp, max_path));
+        builder.verbose(&format!("updating {:?} as {:?} changed", stamp, max_path));
     } else {
-        build.verbose(&format!("updating {:?} as deps changed", stamp));
+        builder.verbose(&format!("updating {:?} as deps changed", stamp));
     }
     t!(t!(File::create(stamp)).write_all(&new_contents));
     deps

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -804,9 +804,9 @@ impl Step for Sysroot {
         let build = builder.build;
         let compiler = self.compiler;
         let sysroot = if compiler.stage == 0 {
-            build.out.join(&compiler.host).join("stage0-sysroot")
+            build.config.out.join(&compiler.host).join("stage0-sysroot")
         } else {
-            build.out.join(&compiler.host).join(format!("stage{}", compiler.stage))
+            build.config.out.join(&compiler.host).join(format!("stage{}", compiler.stage))
         };
         let _ = fs::remove_dir_all(&sysroot);
         t!(fs::create_dir_all(&sysroot));

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -34,7 +34,7 @@ use {Build, Compiler, Mode};
 use native;
 use tool;
 
-use cache::{INTERNER, Interned};
+use cache::{Intern, Interned};
 use builder::{Step, RunConfig, ShouldRun, Builder};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -600,7 +600,7 @@ impl Step for CodegenBackend {
         let backend = backend.cloned().unwrap_or_else(|| {
             String::from("llvm")
         });
-        let backend = INTERNER.intern_string(backend);
+        let backend = backend.intern();
         run.builder.ensure(CodegenBackend {
             compiler: run.builder.compiler(run.builder.top_stage, run.host),
             target: run.target,
@@ -811,7 +811,7 @@ impl Step for Sysroot {
         };
         let _ = fs::remove_dir_all(&sysroot);
         t!(fs::create_dir_all(&sysroot));
-        INTERNER.intern_path(sysroot)
+        sysroot.intern()
     }
 }
 
@@ -890,7 +890,7 @@ impl Step for Assemble {
                 builder.ensure(CodegenBackend {
                     compiler: build_compiler,
                     target: target_compiler.host,
-                    backend: INTERNER.intern_str(backend),
+                    backend: backend.intern(),
                 });
             }
         }

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -67,6 +67,7 @@ pub struct Config {
     pub src: PathBuf,
     pub jobs: Option<u32>,
     pub cmd: Subcommand,
+    pub paths: Vec<PathBuf>,
     pub incremental: bool,
 
     // llvm codegen options
@@ -314,6 +315,7 @@ impl Config {
         let file = flags.config.clone();
         let mut config = Config::default();
         config.exclude = flags.exclude;
+        config.paths = flags.paths;
         config.llvm_enabled = true;
         config.llvm_optimize = true;
         config.llvm_version_check = true;

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -39,7 +39,6 @@ pub use flags::Subcommand;
 /// filled out from the decoded forms of the structs below. For documentation
 /// each field, see the corresponding fields in
 /// `config.toml.example`.
-#[derive(Default)]
 pub struct Config {
     pub rustc_error_format: Option<String>,
     pub build: Interned<String>,

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -85,7 +85,6 @@ pub struct Config {
     pub rustc_default_linker: Option<String>,
     pub rust_optimize_tests: bool,
     pub rust_debuginfo_tests: bool,
-    pub rust_dist_src: bool,
     pub rust_codegen_backends: Vec<Interned<String>>,
 
     pub build: Interned<String>,
@@ -94,9 +93,7 @@ pub struct Config {
     pub local_rebuild: bool,
 
     // dist misc
-    pub dist_sign_folder: Option<PathBuf>,
-    pub dist_upload_addr: Option<String>,
-    pub dist_gpg_password_file: Option<PathBuf>,
+    pub dist: Dist,
 
     // libstd features
     pub debug_jemalloc: bool,
@@ -306,11 +303,11 @@ impl Default for Llvm {
 
 #[derive(Deserialize, Clone)]
 #[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
-struct Dist {
-    sign_folder: Option<PathBuf>,
-    gpg_password_file: Option<PathBuf>,
-    upload_addr: Option<String>,
-    src_tarball: bool,
+pub struct Dist {
+    pub sign_folder: Option<PathBuf>,
+    pub gpg_password_file: Option<PathBuf>,
+    pub upload_addr: Option<String>,
+    pub src_tarball: bool,
 }
 
 impl Default for Dist {
@@ -348,6 +345,7 @@ struct Rust {
     debuginfo: Option<bool>,
     debuginfo_lines: Option<bool>,
     debuginfo_only_std: Option<bool>,
+    rpath: bool,
     experimental_parallel_queries: bool,
     debug_jemalloc: Option<bool>,
     use_jemalloc: bool,
@@ -355,7 +353,6 @@ struct Rust {
     default_linker: Option<String>,
     channel: String,
     musl_root: Option<PathBuf>,
-    rpath: bool,
     optimize_tests: bool,
     debuginfo_tests: bool,
     codegen_tests: bool,
@@ -566,10 +563,7 @@ impl Config {
             });
         }
 
-        config.dist_sign_folder = toml.dist.sign_folder.clone();
-        config.dist_gpg_password_file = toml.dist.gpg_password_file.clone();
-        config.dist_upload_addr = toml.dist.upload_addr.clone();
-        config.rust_dist_src = toml.dist.src_tarball;
+        config.dist = toml.dist;
 
         let cwd = t!(env::current_dir());
         let out = cwd.join("build");

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -15,7 +15,6 @@
 
 use std::collections::{HashMap, HashSet};
 use std::env;
-use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::process::{self, Command};
 use std::cmp;
@@ -29,7 +28,7 @@ use cache::{Intern, Interned};
 use flags::Flags;
 use build_helper::output;
 pub use flags::Subcommand;
-use fs::File;
+use fs;
 
 /// Global configuration for the entire build and/or bootstrap.
 ///
@@ -439,9 +438,7 @@ impl Config {
             .config
             .as_ref()
             .map(|file| {
-                let mut f = t!(File::open(&file));
-                let mut contents = String::new();
-                t!(f.read_to_string(&mut contents));
+                let contents = t!(fs::read_string(&file));
                 match toml::from_str(&contents) {
                     Ok(table) => table,
                     Err(err) => {

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -422,9 +422,7 @@ struct TomlTarget {
 impl Config {
     pub fn parse(args: &[String]) -> Config {
         let flags = Flags::parse(&args);
-        let file = flags.config.clone();
-
-        let mut toml = file.map(|file| {
+        let mut toml: TomlConfig = flags.config.as_ref().map(|file| {
             let mut f = t!(File::open(&file));
             let mut contents = String::new();
             t!(f.read_to_string(&mut contents));
@@ -436,7 +434,7 @@ impl Config {
                     process::exit(2);
                 }
             }
-        }).unwrap_or_else(|| TomlConfig::default());
+        }).unwrap_or_default();
 
         let mut hosts = if !flags.host.is_empty() {
             flags.host.clone()

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -28,6 +28,7 @@ use cache::{Intern, Interned};
 use flags::Flags;
 use build_helper::output;
 pub use flags::Subcommand;
+use serde;
 use fs;
 
 /// Global configuration for the entire build and/or bootstrap.
@@ -94,12 +95,20 @@ struct TomlConfig {
     dist: Dist,
 }
 
+fn build_build_deserialize<'de, D>(_d: D) -> Result<Interned<String>, D::Error>
+where
+    D: serde::Deserializer<'de>
+{
+    let build = env::var("BUILD").expect("'BUILD' defined").intern();
+    Ok(build)
+}
+
 /// TOML representation of various global build decisions.
 #[derive(Deserialize, Clone)]
 #[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Build {
-    #[serde(skip)]
     // We get build from the BUILD env-var, provided by bootstrap.py
+    #[serde(deserialize_with = "build_build_deserialize")]
     pub build: Interned<String>,
     pub host: Vec<Interned<String>>,
     pub target: Vec<Interned<String>>,

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -65,6 +65,7 @@ pub struct Config {
     pub stage: Option<u32>,
     pub keep_stage: Option<u32>,
     pub src: PathBuf,
+    pub out: PathBuf,
     pub jobs: Option<u32>,
     pub cmd: Subcommand,
     pub paths: Vec<PathBuf>,
@@ -531,6 +532,7 @@ impl Config {
 
         let cwd = t!(env::current_dir());
         let out = cwd.join("build");
+        config.out = out.clone();
 
         let stage0_root = out.join(&config.build).join("stage0/bin");
         config.initial_rustc = match build.rustc {

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -45,10 +45,6 @@ pub struct Config {
     pub hosts: Vec<Interned<String>>,
     pub targets: Vec<Interned<String>>,
 
-    // These are either the stage0 downloaded binaries or the locally installed ones.
-    pub initial_cargo: PathBuf,
-    pub initial_rustc: PathBuf,
-
     pub run_host_only: bool,
     pub is_sudo: bool,
 
@@ -522,8 +518,6 @@ impl Config {
             build: toml.build.build.clone(),
             hosts: toml.build.host.clone(),
             targets: toml.build.target.clone(),
-            initial_rustc: toml.build.initial_rustc.clone(),
-            initial_cargo: toml.build.initial_cargo.clone(),
 
             general: toml.build,
             install: toml.install,

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -55,7 +55,7 @@ pub struct Config {
 
     pub exclude: Vec<PathBuf>,
     pub on_fail: Option<String>,
-    pub stage: Option<u32>,
+    pub stage: u32,
     pub keep_stage: Option<u32>,
     pub src: PathBuf,
     pub jobs: Option<u32>,
@@ -500,7 +500,7 @@ impl Config {
             paths: flags.paths,
             on_fail: flags.on_fail,
             rustc_error_format: flags.rustc_error_format,
-            stage: flags.stage,
+            stage: flags.stage.unwrap_or(2),
             src: flags.src,
             jobs: flags.jobs,
             cmd: flags.cmd,

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -51,7 +51,6 @@ pub struct Config {
 
     pub run_host_only: bool,
     pub is_sudo: bool,
-    pub out: PathBuf,
 
     pub exclude: Vec<PathBuf>,
     pub on_fail: Option<String>,
@@ -519,7 +518,6 @@ impl Config {
                 }
                 None => false,
             },
-            out: toml.build.out.clone(),
             // bootstrap.py already handles this fully -- checks flags, toml, and default-generates
             build: toml.build.build.clone(),
             hosts: toml.build.host.clone(),

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -40,12 +40,10 @@ pub use flags::Subcommand;
 /// each field, see the corresponding fields in
 /// `config.toml.example`.
 pub struct Config {
-    pub rustc_error_format: Option<String>,
-    pub build: Interned<String>,
-
     pub run_host_only: bool,
     pub is_sudo: bool,
 
+    pub rustc_error_format: Option<String>,
     pub exclude: Vec<PathBuf>,
     pub on_fail: Option<String>,
     pub stage: u32,
@@ -103,7 +101,7 @@ struct TomlConfig {
 pub struct Build {
     #[serde(skip)]
     // We get build from the BUILD env-var, provided by bootstrap.py
-    build: Interned<String>,
+    pub build: Interned<String>,
     pub host: Vec<Interned<String>>,
     pub target: Vec<Interned<String>>,
 
@@ -512,8 +510,6 @@ impl Config {
                 }
                 None => false,
             },
-            // bootstrap.py already handles this fully -- checks flags, toml, and default-generates
-            build: toml.build.build.clone(),
 
             general: toml.build,
             install: toml.install,

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -428,6 +428,7 @@ impl Config {
             cmd: Subcommand::default(),
             incremental: false,
             keep_stage: None,
+            rustc_error_format: None,
 
             run_host_only: true,
             is_sudo: false,

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -42,8 +42,6 @@ pub use flags::Subcommand;
 pub struct Config {
     pub rustc_error_format: Option<String>,
     pub build: Interned<String>,
-    pub hosts: Vec<Interned<String>>,
-    pub targets: Vec<Interned<String>>,
 
     pub run_host_only: bool,
     pub is_sudo: bool,
@@ -106,8 +104,8 @@ pub struct Build {
     #[serde(skip)]
     // We get build from the BUILD env-var, provided by bootstrap.py
     build: Interned<String>,
-    host: Vec<Interned<String>>,
-    target: Vec<Interned<String>>,
+    pub host: Vec<Interned<String>>,
+    pub target: Vec<Interned<String>>,
 
     #[serde(rename = "cargo")]
     pub initial_cargo: PathBuf,
@@ -516,8 +514,6 @@ impl Config {
             },
             // bootstrap.py already handles this fully -- checks flags, toml, and default-generates
             build: toml.build.build.clone(),
-            hosts: toml.build.host.clone(),
-            targets: toml.build.target.clone(),
 
             general: toml.build,
             install: toml.install,

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -545,26 +545,19 @@ impl Config {
         }
 
         for (triple, cfg) in toml.target {
-            let mut target = Target::default();
-
-            if let Some(ref s) = cfg.llvm_config {
-                target.llvm_config = Some(env::current_dir().unwrap().join(s));
-            }
-            if let Some(ref s) = cfg.jemalloc {
-                target.jemalloc = Some(env::current_dir().unwrap().join(s));
-            }
-            if let Some(ref s) = cfg.android_ndk {
-                target.ndk = Some(env::current_dir().unwrap().join(s));
-            }
-            target.cc = cfg.cc.clone();
-            target.cxx = cfg.cxx.clone();
-            target.ar = cfg.ar.clone();
-            target.linker = cfg.linker.clone();
-            target.crt_static = cfg.crt_static.clone();
-            target.musl_root = cfg.musl_root.clone();
-            target.qemu_rootfs = cfg.qemu_rootfs.clone();
-
-            config.target_config.insert(INTERNER.intern_string(triple.clone()), target);
+            let cwd = t!(env::current_dir());
+            config.target_config.insert(INTERNER.intern_string(triple.clone()), Target {
+                llvm_config: cfg.llvm_config.map(|p| cwd.join(p)),
+                jemalloc: cfg.jemalloc.map(|p| cwd.join(p)),
+                ndk: cfg.android_ndk.map(|p| cwd.join(p)),
+                cc: cfg.cc,
+                cxx: cfg.cxx,
+                ar: cfg.ar,
+                linker: cfg.linker,
+                crt_static: cfg.crt_static,
+                musl_root: cfg.musl_root,
+                qemu_rootfs: cfg.qemu_rootfs,
+            });
         }
 
         config.dist_sign_folder = toml.dist.sign_folder.clone();

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -341,7 +341,7 @@ impl Config {
         config.keep_stage = flags.keep_stage;
 
         // If --target was specified but --host wasn't specified, don't run any host-only tests.
-        config.run_host_only = flags.host.is_empty() && !flags.target.is_empty();
+        config.run_host_only = !(flags.host.is_empty() && !flags.target.is_empty());
 
         let toml = file.map(|file| {
             let mut f = t!(File::open(&file));

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -62,6 +62,7 @@ pub struct Config {
     pub rustc_error_format: Option<String>,
 
     pub run_host_only: bool,
+    pub is_sudo: bool,
 
     pub on_fail: Option<String>,
     pub stage: Option<u32>,
@@ -347,6 +348,16 @@ impl Config {
 
         // If --target was specified but --host wasn't specified, don't run any host-only tests.
         config.run_host_only = !(flags.host.is_empty() && !flags.target.is_empty());
+
+        config.is_sudo = match env::var_os("SUDO_USER") {
+            Some(sudo_user) => {
+                match env::var_os("USER") {
+                    Some(user) => user != sudo_user,
+                    None => false,
+                }
+            }
+            None => false,
+        };
 
         let toml = file.map(|file| {
             let mut f = t!(File::open(&file));

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -572,13 +572,13 @@ impl Config {
     }
 
     /// Try to find the relative path of `libdir`.
-    pub fn libdir_relative(&self) -> Option<&Path> {
-        let libdir = self.install.libdir.as_ref()?;
+    pub fn libdir_relative(&self) -> &Path {
+        let libdir = &self.install.libdir;
         if libdir.is_relative() {
-            Some(libdir)
+            libdir
         } else {
             // Try to make it relative to the prefix.
-            libdir.strip_prefix(self.prefix.as_ref()?).ok()
+            libdir.strip_prefix(&self.install.prefix).unwrap_or(Path::new("lib"))
         }
     }
 

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -62,7 +62,7 @@ o("ninja", "llvm.ninja", "build LLVM using the Ninja generator (for MSVC, requir
 o("locked-deps", "build.locked-deps", "force Cargo.lock to be up to date")
 o("vendor", "build.vendor", "enable usage of vendored Rust crates")
 o("sanitizers", "build.sanitizers", "build the sanitizer runtimes (asan, lsan, msan, tsan)")
-o("dist-src", "rust.dist-src", "when building tarballs enables building a source tarball")
+o("dist-src", "dist.src-tarball", "when building tarballs enables building a source tarball")
 o("cargo-openssl-static", "build.openssl-static", "static openssl in cargo")
 o("profiler", "build.profiler", "build the profiler runtime")
 o("emscripten", None, "compile the emscripten backend as well as LLVM")

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -827,7 +827,7 @@ impl Step for PlainSourceTarball {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.path("src").default_condition(builder.config.rust_dist_src)
+        run.path("src").default_condition(builder.config.dist.src_tarball)
     }
 
     fn make_run(run: RunConfig) {
@@ -1672,13 +1672,13 @@ impl Step for HashSign {
     fn run(self, builder: &Builder) {
         let build = builder.build;
         let mut cmd = builder.tool_cmd(Tool::BuildManifest);
-        let sign = build.config.dist_sign_folder.as_ref().unwrap_or_else(|| {
+        let sign = build.config.dist.sign_folder.as_ref().unwrap_or_else(|| {
             panic!("\n\nfailed to specify `dist.sign-folder` in `config.toml`\n\n")
         });
-        let addr = build.config.dist_upload_addr.as_ref().unwrap_or_else(|| {
+        let addr = build.config.dist.upload_addr.as_ref().unwrap_or_else(|| {
             panic!("\n\nfailed to specify `dist.upload-addr` in `config.toml`\n\n")
         });
-        let file = build.config.dist_gpg_password_file.as_ref().unwrap_or_else(|| {
+        let file = build.config.dist.gpg_password_file.as_ref().unwrap_or_else(|| {
             panic!("\n\nfailed to specify `dist.gpg-password-file` in `config.toml`\n\n")
         });
         let mut pass = String::new();

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -572,7 +572,7 @@ impl Step for Std {
         // We want to package up as many target libraries as possible
         // for the `rust-std` package, so if this is a host target we
         // depend on librustc and otherwise we just depend on libtest.
-        if build.config.hosts.iter().any(|t| t == target) {
+        if build.config.general.host.iter().any(|t| t == target) {
             builder.ensure(compile::Rustc { compiler, target });
         } else {
             builder.ensure(compile::Test { compiler, target });

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -90,7 +90,7 @@ impl Step for Docs {
         let name = pkgname(build, "rust-docs");
 
         println!("Dist docs ({})", host);
-        if !build.config.docs {
+        if !build.config.general.docs {
             println!("\tskipping - docs disabled");
             return distdir(build).join(format!("{}-{}.tar.gz", name, host));
         }
@@ -618,7 +618,7 @@ impl Step for Analysis {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.path("analysis").default_condition(builder.build.config.extended)
+        run.path("analysis").default_condition(builder.build.config.general.extended)
     }
 
     fn make_run(run: RunConfig) {
@@ -633,7 +633,7 @@ impl Step for Analysis {
         let build = builder.build;
         let compiler = self.compiler;
         let target = self.target;
-        assert!(build.config.extended);
+        assert!(build.config.general.extended);
         println!("Dist analysis");
         let name = pkgname(build, "rust-analysis");
 
@@ -1082,7 +1082,7 @@ impl Step for Rls {
         let build = builder.build;
         let stage = self.stage;
         let target = self.target;
-        assert!(build.config.extended);
+        assert!(build.config.general.extended);
 
         println!("Dist RLS stage{} ({})", stage, target);
         let src = build.config.src.join("src/tools/rls");
@@ -1163,7 +1163,7 @@ impl Step for Rustfmt {
         let build = builder.build;
         let stage = self.stage;
         let target = self.target;
-        assert!(build.config.extended);
+        assert!(build.config.general.extended);
 
         println!("Dist Rustfmt stage{} ({})", stage, target);
         let src = build.config.src.join("src/tools/rustfmt");
@@ -1235,7 +1235,7 @@ impl Step for Extended {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.path("extended").default_condition(builder.config.extended)
+        run.path("extended").default_condition(builder.config.general.extended)
     }
 
     fn make_run(run: RunConfig) {
@@ -1299,7 +1299,7 @@ impl Step for Extended {
         tarballs.extend(rustfmt_installer.clone());
         tarballs.push(analysis_installer);
         tarballs.push(std_installer);
-        if build.config.docs {
+        if build.config.general.docs {
             tarballs.push(docs_installer);
         }
         if target.contains("pc-windows-gnu") {

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -122,7 +122,7 @@ impl Step for Docs {
 
         // As part of this step, *also* copy the docs directory to a directory which
         // buildbot typically uploads.
-        if host == build.build {
+        if host == build.config.build {
             let dst = distdir(build).join("doc").join(build.rust_package_vers());
             t!(fs::create_dir_all(&dst));
             cp_r(&src, &dst);
@@ -549,7 +549,7 @@ impl Step for Std {
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(Std {
-            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.build),
+            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.build),
             target: run.target,
         });
     }
@@ -564,7 +564,7 @@ impl Step for Std {
 
         // The only true set of target libraries came from the build triple, so
         // let's reduce redundant work by only producing archives from that host.
-        if compiler.host != build.build {
+        if compiler.host != build.config.build {
             println!("\tskipping, not a build host");
             return distdir(build).join(format!("{}-{}.tar.gz", name, target));
         }
@@ -623,7 +623,7 @@ impl Step for Analysis {
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(Analysis {
-            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.build),
+            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.build),
             target: run.target,
         });
     }
@@ -637,7 +637,7 @@ impl Step for Analysis {
         println!("Dist analysis");
         let name = pkgname(build, "rust-analysis");
 
-        if &compiler.host != build.build {
+        if &compiler.host != build.config.build {
             println!("\tskipping, not a build host");
             return distdir(build).join(format!("{}-{}.tar.gz", name, target));
         }
@@ -1012,7 +1012,7 @@ impl Step for Cargo {
         t!(fs::create_dir_all(image.join("share/zsh/site-functions")));
         t!(fs::create_dir_all(image.join("etc/bash_completion.d")));
         let cargo = builder.ensure(tool::Cargo {
-            compiler: builder.compiler(stage, build.build),
+            compiler: builder.compiler(stage, build.config.build),
             target
         });
         install(&cargo, &image.join("bin"), 0o755);
@@ -1099,7 +1099,7 @@ impl Step for Rls {
         // We expect RLS to build, because we've exited this step above if tool
         // state for RLS isn't testing.
         let rls = builder.ensure(tool::Rls {
-            compiler: builder.compiler(stage, build.build),
+            compiler: builder.compiler(stage, build.config.build),
             target
         }).or_else(|| { println!("Unable to build RLS, skipping dist"); None })?;
 
@@ -1178,11 +1178,11 @@ impl Step for Rustfmt {
 
         // Prepare the image directory
         let rustfmt = builder.ensure(tool::Rustfmt {
-            compiler: builder.compiler(stage, build.build),
+            compiler: builder.compiler(stage, build.config.build),
             target
         }).or_else(|| { println!("Unable to build Rustfmt, skipping dist"); None })?;
         let cargofmt = builder.ensure(tool::Cargofmt {
-            compiler: builder.compiler(stage, build.build),
+            compiler: builder.compiler(stage, build.config.build),
             target
         }).or_else(|| { println!("Unable to build Cargofmt, skipping dist"); None })?;
 
@@ -1241,7 +1241,7 @@ impl Step for Extended {
     fn make_run(run: RunConfig) {
         run.builder.ensure(Extended {
             stage: run.builder.top_stage,
-            host: run.builder.build.build,
+            host: run.builder.build.config.build,
             target: run.host,
         });
     }

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -572,7 +572,7 @@ impl Step for Std {
         // We want to package up as many target libraries as possible
         // for the `rust-std` package, so if this is a host target we
         // depend on librustc and otherwise we just depend on libtest.
-        if build.hosts.iter().any(|t| t == target) {
+        if build.config.hosts.iter().any(|t| t == target) {
             builder.ensure(compile::Rustc { compiler, target });
         } else {
             builder.ensure(compile::Test { compiler, target });

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -505,7 +505,7 @@ impl Step for Rustc {
     }
 }
 
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DebuggerScripts {
     pub sysroot: Interned<PathBuf>,
     pub host: Interned<String>,
@@ -650,7 +650,7 @@ impl Step for Std {
     }
 }
 
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Analysis {
     pub compiler: Compiler,
     pub target: Interned<String>,
@@ -890,7 +890,7 @@ impl Step for Src {
 
 const CARGO_VENDOR_VERSION: &str = "0.1.4";
 
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PlainSourceTarball;
 
 impl Step for PlainSourceTarball {
@@ -1043,7 +1043,7 @@ fn write_file(path: &Path, data: &[u8]) {
     t!(vf.write_all(data));
 }
 
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Cargo {
     pub stage: u32,
     pub target: Interned<String>,
@@ -1115,7 +1115,7 @@ impl Step for Cargo {
         install(&src.join("LICENSE-MIT"), &overlay, 0o644);
         install(&src.join("LICENSE-APACHE"), &overlay, 0o644);
         install(&src.join("LICENSE-THIRD-PARTY"), &overlay, 0o644);
-        t!(t!(File::create(overlay.join("version"))).write_all(version.as_bytes()));
+        create(&overlay.join("version"), &version);
 
         // Generate the installer tarball
         let mut cmd = rust_installer(builder);
@@ -1139,7 +1139,7 @@ impl Step for Cargo {
     }
 }
 
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Rls {
     pub stage: u32,
     pub target: Interned<String>,
@@ -1202,7 +1202,7 @@ impl Step for Rls {
         install(&src.join("README.md"), &overlay, 0o644);
         install(&src.join("LICENSE-MIT"), &overlay, 0o644);
         install(&src.join("LICENSE-APACHE"), &overlay, 0o644);
-        t!(t!(File::create(overlay.join("version"))).write_all(version.as_bytes()));
+        create(&overlay.join("version"), &version);
 
         // Generate the installer tarball
         let mut cmd = rust_installer(builder);
@@ -1227,7 +1227,7 @@ impl Step for Rls {
     }
 }
 
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Rustfmt {
     pub stage: u32,
     pub target: Interned<String>,
@@ -1298,7 +1298,7 @@ impl Step for Rustfmt {
         install(&src.join("README.md"), &overlay, 0o644);
         install(&src.join("LICENSE-MIT"), &overlay, 0o644);
         install(&src.join("LICENSE-APACHE"), &overlay, 0o644);
-        t!(t!(File::create(overlay.join("version"))).write_all(version.as_bytes()));
+        create(&overlay.join("version"), &version);
 
         // Generate the installer tarball
         let mut cmd = rust_installer(builder);
@@ -1323,7 +1323,7 @@ impl Step for Rustfmt {
     }
 }
 
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Extended {
     stage: u32,
     host: Interned<String>,
@@ -1387,9 +1387,9 @@ impl Step for Extended {
         install(&builder.config.src.join("LICENSE-APACHE"), &overlay, 0o644);
         install(&builder.config.src.join("LICENSE-MIT"), &overlay, 0o644);
         let version = builder.rust_version();
-        t!(t!(File::create(overlay.join("version"))).write_all(version.as_bytes()));
+        create(&overlay.join("version"), &version);
         if let Some(sha) = builder.rust_sha() {
-            t!(t!(File::create(overlay.join("git-commit-hash"))).write_all(sha.as_bytes()));
+            create(&overlay.join("git-commit-hash"), &sha);
         }
         install(&etc.join("README.md"), &overlay, 0o644);
 
@@ -1481,7 +1481,7 @@ impl Step for Extended {
                 contents = filter(&contents, "rustfmt");
             }
             let ret = tmp.join(p.file_name().unwrap());
-            t!(t!(File::create(&ret)).write_all(contents.as_bytes()));
+            create(&ret, &contents);
             return ret;
         };
 
@@ -1831,7 +1831,7 @@ fn add_env(builder: &Builder, cmd: &mut Command, target: Interned<String>) {
     }
 }
 
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct HashSign;
 
 impl Step for HashSign {

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -33,7 +33,7 @@ use builder::{Builder, RunConfig, ShouldRun, Step};
 use compile;
 use native;
 use tool::{self, Tool};
-use cache::{INTERNER, Interned};
+use cache::{Intern, Interned};
 use time;
 
 pub fn pkgname(build: &Build, component: &str) -> String {
@@ -460,7 +460,7 @@ impl Step for Rustc {
 
             // Debugger scripts
             builder.ensure(DebuggerScripts {
-                sysroot: INTERNER.intern_path(image.to_owned()),
+                sysroot: image.intern(),
                 host,
             });
 

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -122,7 +122,7 @@ impl Step for Docs {
 
         // As part of this step, *also* copy the docs directory to a directory which
         // buildbot typically uploads.
-        if host == build.config.build {
+        if host == build.config.general.build {
             let dst = distdir(build).join("doc").join(build.rust_package_vers());
             t!(fs::create_dir_all(&dst));
             cp_r(&src, &dst);
@@ -549,7 +549,7 @@ impl Step for Std {
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(Std {
-            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.build),
+            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.general.build),
             target: run.target,
         });
     }
@@ -564,7 +564,7 @@ impl Step for Std {
 
         // The only true set of target libraries came from the build triple, so
         // let's reduce redundant work by only producing archives from that host.
-        if compiler.host != build.config.build {
+        if compiler.host != build.config.general.build {
             println!("\tskipping, not a build host");
             return distdir(build).join(format!("{}-{}.tar.gz", name, target));
         }
@@ -623,7 +623,7 @@ impl Step for Analysis {
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(Analysis {
-            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.build),
+            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.general.build),
             target: run.target,
         });
     }
@@ -637,7 +637,7 @@ impl Step for Analysis {
         println!("Dist analysis");
         let name = pkgname(build, "rust-analysis");
 
-        if &compiler.host != build.config.build {
+        if &compiler.host != build.config.general.build {
             println!("\tskipping, not a build host");
             return distdir(build).join(format!("{}-{}.tar.gz", name, target));
         }
@@ -890,9 +890,9 @@ impl Step for PlainSourceTarball {
                    .arg("--vers").arg(CARGO_VENDOR_VERSION)
                    .arg("cargo-vendor")
                    .env("RUSTC", &build.config.general.initial_rustc);
-                if let Some(dir) = build.openssl_install_dir(build.config.build) {
+                if let Some(dir) = build.openssl_install_dir(build.config.general.build) {
                     builder.ensure(native::Openssl {
-                        target: build.config.build,
+                        target: build.config.general.build,
                     });
                     cmd.env("OPENSSL_DIR", dir);
                 }
@@ -1012,7 +1012,7 @@ impl Step for Cargo {
         t!(fs::create_dir_all(image.join("share/zsh/site-functions")));
         t!(fs::create_dir_all(image.join("etc/bash_completion.d")));
         let cargo = builder.ensure(tool::Cargo {
-            compiler: builder.compiler(stage, build.config.build),
+            compiler: builder.compiler(stage, build.config.general.build),
             target
         });
         install(&cargo, &image.join("bin"), 0o755);
@@ -1099,7 +1099,7 @@ impl Step for Rls {
         // We expect RLS to build, because we've exited this step above if tool
         // state for RLS isn't testing.
         let rls = builder.ensure(tool::Rls {
-            compiler: builder.compiler(stage, build.config.build),
+            compiler: builder.compiler(stage, build.config.general.build),
             target
         }).or_else(|| { println!("Unable to build RLS, skipping dist"); None })?;
 
@@ -1178,11 +1178,11 @@ impl Step for Rustfmt {
 
         // Prepare the image directory
         let rustfmt = builder.ensure(tool::Rustfmt {
-            compiler: builder.compiler(stage, build.config.build),
+            compiler: builder.compiler(stage, build.config.general.build),
             target
         }).or_else(|| { println!("Unable to build Rustfmt, skipping dist"); None })?;
         let cargofmt = builder.ensure(tool::Cargofmt {
-            compiler: builder.compiler(stage, build.config.build),
+            compiler: builder.compiler(stage, build.config.general.build),
             target
         }).or_else(|| { println!("Unable to build Cargofmt, skipping dist"); None })?;
 
@@ -1241,7 +1241,7 @@ impl Step for Extended {
     fn make_run(run: RunConfig) {
         run.builder.ensure(Extended {
             stage: run.builder.top_stage,
-            host: run.builder.build.config.build,
+            host: run.builder.build.config.general.build,
             target: run.host,
         });
     }

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -50,11 +50,11 @@ pub fn pkgname(build: &Build, component: &str) -> String {
 }
 
 fn distdir(build: &Build) -> PathBuf {
-    build.config.out.join("dist")
+    build.config.general.out.join("dist")
 }
 
 pub fn tmpdir(build: &Build) -> PathBuf {
-    build.config.out.join("tmp/dist")
+    build.config.general.out.join("tmp/dist")
 }
 
 fn rust_installer(builder: &Builder) -> Command {
@@ -102,7 +102,7 @@ impl Step for Docs {
 
         let dst = image.join("share/doc/rust/html");
         t!(fs::create_dir_all(&dst));
-        let src = build.config.out.join(host).join("doc");
+        let src = build.config.general.out.join(host).join("doc");
         cp_r(&src, &dst);
 
         let mut cmd = rust_installer(builder);

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -50,11 +50,11 @@ pub fn pkgname(build: &Build, component: &str) -> String {
 }
 
 fn distdir(build: &Build) -> PathBuf {
-    build.out.join("dist")
+    build.config.out.join("dist")
 }
 
 pub fn tmpdir(build: &Build) -> PathBuf {
-    build.out.join("tmp/dist")
+    build.config.out.join("tmp/dist")
 }
 
 fn rust_installer(builder: &Builder) -> Command {
@@ -102,7 +102,7 @@ impl Step for Docs {
 
         let dst = image.join("share/doc/rust/html");
         t!(fs::create_dir_all(&dst));
-        let src = build.out.join(host).join("doc");
+        let src = build.config.out.join(host).join("doc");
         cp_r(&src, &dst);
 
         let mut cmd = rust_installer(builder);

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -336,7 +336,7 @@ impl Step for Rustc {
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(Rustc {
-            compiler: run.builder.compiler(run.builder.top_stage, run.target),
+            compiler: run.builder.compiler(run.builder.top_stage, run.host),
         });
     }
 
@@ -987,7 +987,7 @@ impl Step for Cargo {
     fn make_run(run: RunConfig) {
         run.builder.ensure(Cargo {
             stage: run.builder.top_stage,
-            target: run.target,
+            target: run.host,
         });
     }
 
@@ -1074,7 +1074,7 @@ impl Step for Rls {
     fn make_run(run: RunConfig) {
         run.builder.ensure(Rls {
             stage: run.builder.top_stage,
-            target: run.target,
+            target: run.host,
         });
     }
 
@@ -1155,7 +1155,7 @@ impl Step for Rustfmt {
     fn make_run(run: RunConfig) {
         run.builder.ensure(Rustfmt {
             stage: run.builder.top_stage,
-            target: run.target,
+            target: run.host,
         });
     }
 
@@ -1242,7 +1242,7 @@ impl Step for Extended {
         run.builder.ensure(Extended {
             stage: run.builder.top_stage,
             host: run.builder.build.build,
-            target: run.target,
+            target: run.host,
         });
     }
 

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -878,18 +878,18 @@ impl Step for PlainSourceTarball {
         if build.rust_info.is_git() {
             // Get cargo-vendor installed, if it isn't already.
             let mut has_cargo_vendor = false;
-            let mut cmd = Command::new(&build.initial_cargo);
+            let mut cmd = Command::new(&build.config.initial_cargo);
             for line in output(cmd.arg("install").arg("--list")).lines() {
                 has_cargo_vendor |= line.starts_with("cargo-vendor ");
             }
             if !has_cargo_vendor {
-                let mut cmd = Command::new(&build.initial_cargo);
+                let mut cmd = Command::new(&build.config.initial_cargo);
                 cmd.arg("install")
                    .arg("--force")
                    .arg("--debug")
                    .arg("--vers").arg(CARGO_VENDOR_VERSION)
                    .arg("cargo-vendor")
-                   .env("RUSTC", &build.initial_rustc);
+                   .env("RUSTC", &build.config.initial_rustc);
                 if let Some(dir) = build.openssl_install_dir(build.config.build) {
                     builder.ensure(native::Openssl {
                         target: build.config.build,
@@ -900,7 +900,7 @@ impl Step for PlainSourceTarball {
             }
 
             // Vendor all Cargo dependencies
-            let mut cmd = Command::new(&build.initial_cargo);
+            let mut cmd = Command::new(&build.config.initial_cargo);
             cmd.arg("vendor")
                .current_dir(&plain_dst_src.join("src"));
             build.run(&mut cmd);

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -878,18 +878,18 @@ impl Step for PlainSourceTarball {
         if build.rust_info.is_git() {
             // Get cargo-vendor installed, if it isn't already.
             let mut has_cargo_vendor = false;
-            let mut cmd = Command::new(&build.config.initial_cargo);
+            let mut cmd = Command::new(&build.config.general.initial_cargo);
             for line in output(cmd.arg("install").arg("--list")).lines() {
                 has_cargo_vendor |= line.starts_with("cargo-vendor ");
             }
             if !has_cargo_vendor {
-                let mut cmd = Command::new(&build.config.initial_cargo);
+                let mut cmd = Command::new(&build.config.general.initial_cargo);
                 cmd.arg("install")
                    .arg("--force")
                    .arg("--debug")
                    .arg("--vers").arg(CARGO_VENDOR_VERSION)
                    .arg("cargo-vendor")
-                   .env("RUSTC", &build.config.initial_rustc);
+                   .env("RUSTC", &build.config.general.initial_rustc);
                 if let Some(dir) = build.openssl_install_dir(build.config.build) {
                     builder.ensure(native::Openssl {
                         target: build.config.build,
@@ -900,7 +900,7 @@ impl Step for PlainSourceTarball {
             }
 
             // Vendor all Cargo dependencies
-            let mut cmd = Command::new(&build.config.initial_cargo);
+            let mut cmd = Command::new(&build.config.general.initial_cargo);
             cmd.arg("vendor")
                .current_dir(&plain_dst_src.join("src"));
             build.run(&mut cmd);

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1637,7 +1637,7 @@ fn add_env(build: &Build, cmd: &mut Command, target: Interned<String>) {
        .env("CFG_PACKAGE_VERS", build.rust_package_vers())
        .env("CFG_PACKAGE_NAME", pkgname(build, "rust"))
        .env("CFG_BUILD", target)
-       .env("CFG_CHANNEL", &build.config.channel);
+       .env("CFG_CHANNEL", &build.config.rust.channel);
 
     if target.contains("windows-gnu") {
        cmd.env("CFG_MINGW", "1")

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -70,7 +70,6 @@ pub struct Docs {
 impl Step for Docs {
     type Output = PathBuf;
     const DEFAULT: bool = true;
-    const ONLY_BUILD_TARGETS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         run.path("src/doc")
@@ -271,7 +270,6 @@ pub struct Mingw {
 impl Step for Mingw {
     type Output = Option<PathBuf>;
     const DEFAULT: bool = true;
-    const ONLY_BUILD_TARGETS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         run.never()
@@ -331,7 +329,6 @@ impl Step for Rustc {
     type Output = PathBuf;
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
-    const ONLY_BUILD_TARGETS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         run.path("src/librustc")
@@ -545,7 +542,6 @@ pub struct Std {
 impl Step for Std {
     type Output = PathBuf;
     const DEFAULT: bool = true;
-    const ONLY_BUILD_TARGETS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         run.path("src/libstd")
@@ -553,7 +549,7 @@ impl Step for Std {
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(Std {
-            compiler: run.builder.compiler(run.builder.top_stage, run.host),
+            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.build),
             target: run.target,
         });
     }
@@ -619,7 +615,6 @@ pub struct Analysis {
 impl Step for Analysis {
     type Output = PathBuf;
     const DEFAULT: bool = true;
-    const ONLY_BUILD_TARGETS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
@@ -628,7 +623,7 @@ impl Step for Analysis {
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(Analysis {
-            compiler: run.builder.compiler(run.builder.top_stage, run.host),
+            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.build),
             target: run.target,
         });
     }
@@ -736,8 +731,6 @@ impl Step for Src {
     type Output = PathBuf;
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
-    const ONLY_BUILD_TARGETS: bool = true;
-    const ONLY_BUILD: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         run.path("src")
@@ -831,8 +824,6 @@ impl Step for PlainSourceTarball {
     type Output = PathBuf;
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
-    const ONLY_BUILD_TARGETS: bool = true;
-    const ONLY_BUILD: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
@@ -987,7 +978,6 @@ pub struct Cargo {
 
 impl Step for Cargo {
     type Output = PathBuf;
-    const ONLY_BUILD_TARGETS: bool = true;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
@@ -1075,7 +1065,6 @@ pub struct Rls {
 
 impl Step for Rls {
     type Output = Option<PathBuf>;
-    const ONLY_BUILD_TARGETS: bool = true;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
@@ -1157,7 +1146,6 @@ pub struct Rustfmt {
 
 impl Step for Rustfmt {
     type Output = Option<PathBuf>;
-    const ONLY_BUILD_TARGETS: bool = true;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
@@ -1243,7 +1231,6 @@ pub struct Extended {
 impl Step for Extended {
     type Output = ();
     const DEFAULT: bool = true;
-    const ONLY_BUILD_TARGETS: bool = true;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
@@ -1254,7 +1241,7 @@ impl Step for Extended {
     fn make_run(run: RunConfig) {
         run.builder.ensure(Extended {
             stage: run.builder.top_stage,
-            host: run.host,
+            host: run.builder.build.build,
             target: run.target,
         });
     }
@@ -1672,9 +1659,7 @@ pub struct HashSign;
 
 impl Step for HashSign {
     type Output = ();
-    const ONLY_BUILD_TARGETS: bool = true;
     const ONLY_HOSTS: bool = true;
-    const ONLY_BUILD: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         run.path("hash-and-sign")

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Documentation generation for rustbuild.
+//! Documentation generation for rustbuilder.
 //!
 //! This module implements generation for all bits and pieces of documentation
 //! for the Rust project. This notably includes suites like the rust book, the
@@ -45,7 +45,7 @@ macro_rules! book {
 
             fn should_run(run: ShouldRun) -> ShouldRun {
                 let builder = run.builder;
-                run.path($path).default_condition(builder.build.config.general.docs)
+                run.path($path).default_condition(builder.config.general.docs)
             }
 
             fn make_run(run: RunConfig) {
@@ -92,7 +92,7 @@ impl Step for Rustbook {
     /// This will not actually generate any documentation if the documentation has
     /// already been generated.
     fn run(self, builder: &Builder) {
-        let src = builder.build.config.src.join("src/doc");
+        let src = builder.config.src.join("src/doc");
         builder.ensure(RustbookSrc {
             target: self.target,
             name: self.name,
@@ -113,7 +113,7 @@ impl Step for UnstableBook {
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
         run.path("src/doc/unstable-book")
-            .default_condition(builder.build.config.general.docs)
+            .default_condition(builder.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
@@ -127,7 +127,7 @@ impl Step for UnstableBook {
         builder.ensure(RustbookSrc {
             target: self.target,
             name: "unstable-book".intern(),
-            src: builder.build.md_doc_out(self.target),
+            src: builder.md_doc_out(self.target),
         })
     }
 }
@@ -145,7 +145,7 @@ impl Step for CargoBook {
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
         run.path("src/tools/cargo/src/doc/book")
-            .default_condition(builder.build.config.general.docs)
+            .default_condition(builder.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
@@ -156,13 +156,11 @@ impl Step for CargoBook {
     }
 
     fn run(self, builder: &Builder) {
-        let build = builder.build;
-
         let target = self.target;
         let name = self.name;
-        let src = build.config.src.join("src/tools/cargo/src/doc");
+        let src = builder.config.src.join("src/tools/cargo/src/doc");
 
-        let out = build.doc_out(target);
+        let out = builder.doc_out(target);
         t!(fs::create_dir_all(&out));
 
         let out = out.join(name);
@@ -171,7 +169,7 @@ impl Step for CargoBook {
 
         let _ = fs::remove_dir_all(&out);
 
-        build.run(
+        builder.run(
             builder
                 .tool_cmd(Tool::Rustbook)
                 .arg("build")
@@ -201,11 +199,10 @@ impl Step for RustbookSrc {
     /// This will not actually generate any documentation if the documentation has
     /// already been generated.
     fn run(self, builder: &Builder) {
-        let build = builder.build;
         let target = self.target;
         let name = self.name;
         let src = self.src;
-        let out = build.doc_out(target);
+        let out = builder.doc_out(target);
         t!(fs::create_dir_all(&out));
 
         let out = out.join(name);
@@ -217,7 +214,7 @@ impl Step for RustbookSrc {
         }
         println!("Rustbook ({}) - {}", target, name);
         let _ = fs::remove_dir_all(&out);
-        build.run(
+        builder.run(
             builder
                 .tool_cmd(Tool::Rustbook)
                 .arg("build")
@@ -242,15 +239,13 @@ impl Step for TheBook {
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
         run.path("src/doc/book")
-            .default_condition(builder.build.config.general.docs)
+            .default_condition(builder.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(TheBook {
-            compiler: run.builder.compiler(
-                run.builder.top_stage,
-                run.builder.build.config.general.build,
-            ),
+            compiler: run.builder
+                .compiler(run.builder.top_stage, run.builder.config.general.build),
             target: run.target,
             name: "book",
         });
@@ -266,7 +261,6 @@ impl Step for TheBook {
     /// * Index page
     /// * Redirect pages
     fn run(self, builder: &Builder) {
-        let build = builder.build;
         let compiler = self.compiler;
         let target = self.target;
         let name = self.name;
@@ -293,7 +287,7 @@ impl Step for TheBook {
         // build the redirect pages
         println!("Documenting book redirect pages ({})", target);
         for file in t!(fs::read_dir(
-            build.config.src.join("src/doc/book/redirects")
+            builder.config.src.join("src/doc/book/redirects")
         )) {
             let file = t!(file);
             let path = file.path();
@@ -305,13 +299,12 @@ impl Step for TheBook {
 }
 
 fn invoke_rustdoc(builder: &Builder, compiler: Compiler, target: Interned<String>, markdown: &str) {
-    let build = builder.build;
-    let out = build.doc_out(target);
+    let out = builder.doc_out(target);
 
-    let path = build.config.src.join("src/doc").join(markdown);
+    let path = builder.config.src.join("src/doc").join(markdown);
 
-    let favicon = build.config.src.join("src/doc/favicon.inc");
-    let footer = build.config.src.join("src/doc/footer.inc");
+    let favicon = builder.config.src.join("src/doc/favicon.inc");
+    let footer = builder.config.src.join("src/doc/footer.inc");
     let version_info = out.join("version_info.html");
 
     let mut cmd = builder.rustdoc_cmd(compiler.host);
@@ -332,7 +325,7 @@ fn invoke_rustdoc(builder: &Builder, compiler: Compiler, target: Interned<String
         .arg("--markdown-css")
         .arg("../rust.css");
 
-    build.run(&mut cmd);
+    builder.run(&mut cmd);
 }
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -348,15 +341,13 @@ impl Step for Standalone {
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
         run.path("src/doc")
-            .default_condition(builder.build.config.general.docs)
+            .default_condition(builder.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(Standalone {
-            compiler: run.builder.compiler(
-                run.builder.top_stage,
-                run.builder.build.config.general.build,
-            ),
+            compiler: run.builder
+                .compiler(run.builder.top_stage, run.builder.config.general.build),
             target: run.target,
         });
     }
@@ -370,34 +361,36 @@ impl Step for Standalone {
     ///
     /// In the end, this is just a glorified wrapper around rustdoc!
     fn run(self, builder: &Builder) {
-        let build = builder.build;
         let target = self.target;
         let compiler = self.compiler;
         println!("Documenting standalone ({})", target);
-        let out = build.doc_out(target);
+        let out = builder.doc_out(target);
         t!(fs::create_dir_all(&out));
 
-        let favicon = build.config.src.join("src/doc/favicon.inc");
-        let footer = build.config.src.join("src/doc/footer.inc");
-        let full_toc = build.config.src.join("src/doc/full-toc.inc");
+        let favicon = builder.config.src.join("src/doc/favicon.inc");
+        let footer = builder.config.src.join("src/doc/footer.inc");
+        let full_toc = builder.config.src.join("src/doc/full-toc.inc");
         t!(fs::copy(
-            build.config.src.join("src/doc/rust.css"),
+            builder.config.src.join("src/doc/rust.css"),
             out.join("rust.css")
         ));
 
-        let version_input = build.config.src.join("src/doc/version_info.html.template");
+        let version_input = builder
+            .config
+            .src
+            .join("src/doc/version_info.html.template");
         let version_info = out.join("version_info.html");
 
         if !up_to_date(&version_input, &version_info) {
             let mut info = String::new();
             t!(t!(File::open(&version_input)).read_to_string(&mut info));
-            let info = info.replace("VERSION", &build.rust_release())
-                .replace("SHORT_HASH", build.rust_info.sha_short().unwrap_or(""))
-                .replace("STAMP", build.rust_info.sha().unwrap_or(""));
+            let info = info.replace("VERSION", &builder.rust_release())
+                .replace("SHORT_HASH", builder.rust_info.sha_short().unwrap_or(""))
+                .replace("STAMP", builder.rust_info.sha().unwrap_or(""));
             t!(t!(File::create(&version_info)).write_all(info.as_bytes()));
         }
 
-        for file in t!(fs::read_dir(build.config.src.join("src/doc"))) {
+        for file in t!(fs::read_dir(builder.config.src.join("src/doc"))) {
             let file = t!(file);
             let path = file.path();
             let filename = path.file_name().unwrap().to_str().unwrap();
@@ -434,7 +427,7 @@ impl Step for Standalone {
             } else {
                 cmd.arg("--markdown-css").arg("rust.css");
             }
-            build.run(&mut cmd);
+            builder.run(&mut cmd);
         }
     }
 }
@@ -452,7 +445,7 @@ impl Step for Std {
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
         run.all_krates("std")
-            .default_condition(builder.build.config.general.docs)
+            .default_condition(builder.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
@@ -467,22 +460,21 @@ impl Step for Std {
     /// This will generate all documentation for the standard library and its
     /// dependencies. This is largely just a wrapper around `cargo doc`.
     fn run(self, builder: &Builder) {
-        let build = builder.build;
         let stage = self.stage;
         let target = self.target;
         println!("Documenting stage{} std ({})", stage, target);
-        let out = build.doc_out(target);
+        let out = builder.doc_out(target);
         t!(fs::create_dir_all(&out));
-        let compiler = builder.compiler(stage, build.config.general.build);
+        let compiler = builder.compiler(stage, builder.config.general.build);
         let rustdoc = builder.rustdoc(compiler.host);
-        let compiler = if build.force_use_stage1(compiler, target) {
+        let compiler = if builder.force_use_stage1(compiler, target) {
             builder.compiler(1, compiler.host)
         } else {
             compiler
         };
 
         builder.ensure(compile::Std { compiler, target });
-        let out_dir = build
+        let out_dir = builder
             .stage_out(compiler, Mode::Libstd)
             .join(target)
             .join("doc");
@@ -500,17 +492,17 @@ impl Step for Std {
         //
         // This way rustdoc generates output directly into the output, and rustdoc
         // will also directly handle merging.
-        let my_out = build.crate_doc_out(target);
-        build.clear_if_dirty(&my_out, &rustdoc);
+        let my_out = builder.crate_doc_out(target);
+        builder.clear_if_dirty(&my_out, &rustdoc);
         t!(symlink_dir_force(&my_out, &out_dir));
 
         let mut cargo = builder.cargo(compiler, Mode::Libstd, target, "doc");
-        compile::std_cargo(build, &compiler, target, &mut cargo);
+        compile::std_cargo(builder, &compiler, target, &mut cargo);
 
         // We don't want to build docs for internal std dependencies unless
         // in compiler-docs mode. When not in that mode, we whitelist the crates
         // for which docs must be built.
-        if !build.config.general.compiler_docs {
+        if !builder.config.general.compiler_docs {
             cargo.arg("--no-deps");
             for krate in &["alloc", "core", "std", "std_unicode"] {
                 cargo.arg("-p").arg(krate);
@@ -521,7 +513,7 @@ impl Step for Std {
             }
         }
 
-        build.run(&mut cargo);
+        builder.run(&mut cargo);
         cp_r(&my_out, &out);
     }
 }
@@ -554,15 +546,14 @@ impl Step for Test {
     /// This will generate all documentation for libtest and its dependencies. This
     /// is largely just a wrapper around `cargo doc`.
     fn run(self, builder: &Builder) {
-        let build = builder.build;
         let stage = self.stage;
         let target = self.target;
         println!("Documenting stage{} test ({})", stage, target);
-        let out = build.doc_out(target);
+        let out = builder.doc_out(target);
         t!(fs::create_dir_all(&out));
-        let compiler = builder.compiler(stage, build.config.general.build);
+        let compiler = builder.compiler(stage, builder.config.general.build);
         let rustdoc = builder.rustdoc(compiler.host);
-        let compiler = if build.force_use_stage1(compiler, target) {
+        let compiler = if builder.force_use_stage1(compiler, target) {
             builder.compiler(1, compiler.host)
         } else {
             compiler
@@ -572,19 +563,19 @@ impl Step for Test {
         builder.ensure(Std { stage, target });
 
         builder.ensure(compile::Test { compiler, target });
-        let out_dir = build
+        let out_dir = builder
             .stage_out(compiler, Mode::Libtest)
             .join(target)
             .join("doc");
 
         // See docs in std above for why we symlink
-        let my_out = build.crate_doc_out(target);
-        build.clear_if_dirty(&my_out, &rustdoc);
+        let my_out = builder.crate_doc_out(target);
+        builder.clear_if_dirty(&my_out, &rustdoc);
         t!(symlink_dir_force(&my_out, &out_dir));
 
         let mut cargo = builder.cargo(compiler, Mode::Libtest, target, "doc");
-        compile::test_cargo(build, &compiler, target, &mut cargo);
-        build.run(&mut cargo);
+        compile::test_cargo(builder, &compiler, target, &mut cargo);
+        builder.run(&mut cargo);
         cp_r(&my_out, &out);
     }
 }
@@ -603,7 +594,7 @@ impl Step for Rustc {
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
         run.krate("rustc-main")
-            .default_condition(builder.build.config.general.docs)
+            .default_condition(builder.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
@@ -618,15 +609,14 @@ impl Step for Rustc {
     /// This will generate all documentation for the compiler libraries and their
     /// dependencies. This is largely just a wrapper around `cargo doc`.
     fn run(self, builder: &Builder) {
-        let build = builder.build;
         let stage = self.stage;
         let target = self.target;
         println!("Documenting stage{} compiler ({})", stage, target);
-        let out = build.doc_out(target);
+        let out = builder.doc_out(target);
         t!(fs::create_dir_all(&out));
-        let compiler = builder.compiler(stage, build.config.general.build);
+        let compiler = builder.compiler(stage, builder.config.general.build);
         let rustdoc = builder.rustdoc(compiler.host);
-        let compiler = if build.force_use_stage1(compiler, target) {
+        let compiler = if builder.force_use_stage1(compiler, target) {
             builder.compiler(1, compiler.host)
         } else {
             compiler
@@ -636,20 +626,20 @@ impl Step for Rustc {
         builder.ensure(Std { stage, target });
 
         builder.ensure(compile::Rustc { compiler, target });
-        let out_dir = build
+        let out_dir = builder
             .stage_out(compiler, Mode::Librustc)
             .join(target)
             .join("doc");
 
         // See docs in std above for why we symlink
-        let my_out = build.crate_doc_out(target);
-        build.clear_if_dirty(&my_out, &rustdoc);
+        let my_out = builder.crate_doc_out(target);
+        builder.clear_if_dirty(&my_out, &rustdoc);
         t!(symlink_dir_force(&my_out, &out_dir));
 
         let mut cargo = builder.cargo(compiler, Mode::Librustc, target, "doc");
-        compile::rustc_cargo(build, &mut cargo);
+        compile::rustc_cargo(builder, &mut cargo);
 
-        if build.config.general.compiler_docs {
+        if builder.config.general.compiler_docs {
             // src/rustc/Cargo.toml contains a bin crate called rustc which
             // would otherwise overwrite the docs for the real rustc lib crate.
             cargo.arg("-p").arg("rustc_driver");
@@ -662,7 +652,7 @@ impl Step for Rustc {
             }
         }
 
-        build.run(&mut cargo);
+        builder.run(&mut cargo);
         cp_r(&my_out, &out);
     }
 }
@@ -680,7 +670,7 @@ impl Step for ErrorIndex {
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
         run.path("src/tools/error_index_generator")
-            .default_condition(builder.build.config.general.docs)
+            .default_condition(builder.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
@@ -690,11 +680,10 @@ impl Step for ErrorIndex {
     /// Generates the HTML rendered error-index by running the
     /// `error_index_generator` tool.
     fn run(self, builder: &Builder) {
-        let build = builder.build;
         let target = self.target;
 
         println!("Documenting error index ({})", target);
-        let out = build.doc_out(target);
+        let out = builder.doc_out(target);
         t!(fs::create_dir_all(&out));
         let mut index = builder.tool_cmd(Tool::ErrorIndex);
         index.arg("html");
@@ -702,10 +691,10 @@ impl Step for ErrorIndex {
 
         // FIXME: shouldn't have to pass this env var
         index
-            .env("CFG_BUILD", &build.config.general.build)
-            .env("RUSTC_ERROR_METADATA_DST", build.extended_error_dir());
+            .env("CFG_BUILD", &builder.config.general.build)
+            .env("RUSTC_ERROR_METADATA_DST", builder.extended_error_dir());
 
-        build.run(&mut index);
+        builder.run(&mut index);
     }
 }
 
@@ -722,7 +711,7 @@ impl Step for UnstableBookGen {
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
         run.path("src/tools/unstable-book-gen")
-            .default_condition(builder.build.config.general.docs)
+            .default_condition(builder.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
@@ -730,23 +719,22 @@ impl Step for UnstableBookGen {
     }
 
     fn run(self, builder: &Builder) {
-        let build = builder.build;
         let target = self.target;
 
         builder.ensure(compile::Std {
-            compiler: builder.compiler(builder.top_stage, build.config.general.build),
+            compiler: builder.compiler(builder.top_stage, builder.config.general.build),
             target,
         });
 
         println!("Generating unstable book md files ({})", target);
-        let out = build.md_doc_out(target).join("unstable-book");
+        let out = builder.md_doc_out(target).join("unstable-book");
         t!(fs::create_dir_all(&out));
         t!(fs::remove_dir_all(&out));
         let mut cmd = builder.tool_cmd(Tool::UnstableBookGen);
-        cmd.arg(build.config.src.join("src"));
+        cmd.arg(builder.config.src.join("src"));
         cmd.arg(out);
 
-        build.run(&mut cmd);
+        builder.run(&mut cmd);
     }
 }
 

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -497,7 +497,6 @@ impl Step for Std {
         t!(symlink_dir_force(&my_out, &out_dir));
 
         let mut cargo = builder.cargo(compiler, Mode::Libstd, target, "doc");
-        compile::std_cargo(builder, &compiler, target, &mut cargo);
 
         // We don't want to build docs for internal std dependencies unless
         // in compiler-docs mode. When not in that mode, we whitelist the crates
@@ -574,7 +573,6 @@ impl Step for Test {
         t!(symlink_dir_force(&my_out, &out_dir));
 
         let mut cargo = builder.cargo(compiler, Mode::Libtest, target, "doc");
-        compile::test_cargo(builder, &compiler, target, &mut cargo);
         builder.run(&mut cargo);
         cp_r(&my_out, &out);
     }
@@ -637,7 +635,6 @@ impl Step for Rustc {
         t!(symlink_dir_force(&my_out, &out_dir));
 
         let mut cargo = builder.cargo(compiler, Mode::Librustc, target, "doc");
-        compile::rustc_cargo(builder, &mut cargo);
 
         if builder.config.general.compiler_docs {
             // src/rustc/Cargo.toml contains a bin crate called rustc which

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -92,7 +92,7 @@ impl Step for Rustbook {
     /// This will not actually generate any documentation if the documentation has
     /// already been generated.
     fn run(self, builder: &Builder) {
-        let src = builder.build.src.join("src/doc");
+        let src = builder.build.config.src.join("src/doc");
         builder.ensure(RustbookSrc {
             target: self.target,
             name: self.name,
@@ -160,7 +160,7 @@ impl Step for CargoBook {
 
         let target = self.target;
         let name = self.name;
-        let src = build.src.join("src/tools/cargo/src/doc");
+        let src = build.config.src.join("src/tools/cargo/src/doc");
 
         let out = build.doc_out(target);
         t!(fs::create_dir_all(&out));
@@ -285,7 +285,7 @@ impl Step for TheBook {
 
         // build the redirect pages
         println!("Documenting book redirect pages ({})", target);
-        for file in t!(fs::read_dir(build.src.join("src/doc/book/redirects"))) {
+        for file in t!(fs::read_dir(build.config.src.join("src/doc/book/redirects"))) {
             let file = t!(file);
             let path = file.path();
             let path = path.to_str().unwrap();
@@ -299,10 +299,10 @@ fn invoke_rustdoc(builder: &Builder, compiler: Compiler, target: Interned<String
     let build = builder.build;
     let out = build.doc_out(target);
 
-    let path = build.src.join("src/doc").join(markdown);
+    let path = build.config.src.join("src/doc").join(markdown);
 
-    let favicon = build.src.join("src/doc/favicon.inc");
-    let footer = build.src.join("src/doc/footer.inc");
+    let favicon = build.config.src.join("src/doc/favicon.inc");
+    let footer = build.config.src.join("src/doc/footer.inc");
     let version_info = out.join("version_info.html");
 
     let mut cmd = builder.rustdoc_cmd(compiler.host);
@@ -360,12 +360,12 @@ impl Step for Standalone {
         let out = build.doc_out(target);
         t!(fs::create_dir_all(&out));
 
-        let favicon = build.src.join("src/doc/favicon.inc");
-        let footer = build.src.join("src/doc/footer.inc");
-        let full_toc = build.src.join("src/doc/full-toc.inc");
-        t!(fs::copy(build.src.join("src/doc/rust.css"), out.join("rust.css")));
+        let favicon = build.config.src.join("src/doc/favicon.inc");
+        let footer = build.config.src.join("src/doc/footer.inc");
+        let full_toc = build.config.src.join("src/doc/full-toc.inc");
+        t!(fs::copy(build.config.src.join("src/doc/rust.css"), out.join("rust.css")));
 
-        let version_input = build.src.join("src/doc/version_info.html.template");
+        let version_input = build.config.src.join("src/doc/version_info.html.template");
         let version_info = out.join("version_info.html");
 
         if !up_to_date(&version_input, &version_info) {
@@ -377,7 +377,7 @@ impl Step for Standalone {
             t!(t!(File::create(&version_info)).write_all(info.as_bytes()));
         }
 
-        for file in t!(fs::read_dir(build.src.join("src/doc"))) {
+        for file in t!(fs::read_dir(build.config.src.join("src/doc"))) {
             let file = t!(file);
             let path = file.path();
             let filename = path.file_name().unwrap().to_str().unwrap();
@@ -714,7 +714,7 @@ impl Step for UnstableBookGen {
         t!(fs::create_dir_all(&out));
         t!(fs::remove_dir_all(&out));
         let mut cmd = builder.tool_cmd(Tool::UnstableBookGen);
-        cmd.arg(build.src.join("src"));
+        cmd.arg(build.config.src.join("src"));
         cmd.arg(out);
 
         build.run(&mut cmd);

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -17,7 +17,6 @@
 //! Everything here is basically just a shim around calling either `rustbook` or
 //! `rustdoc`.
 
-use std::fs::{self, File};
 use std::io::prelude::*;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -25,6 +24,7 @@ use std::path::{Path, PathBuf};
 use Mode;
 use build_helper::up_to_date;
 
+use fs::{self, File};
 use util::{cp_r, symlink_dir};
 use builder::{Builder, Compiler, RunConfig, ShouldRun, Step};
 use tool::Tool;
@@ -736,6 +736,7 @@ impl Step for UnstableBookGen {
 }
 
 fn symlink_dir_force(src: &Path, dst: &Path) -> io::Result<()> {
+    if cfg!(test) { return Ok(()); }
     if let Ok(m) = fs::symlink_metadata(dst) {
         if m.file_type().is_dir() {
             try!(fs::remove_dir_all(dst));

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -20,7 +20,7 @@
 use std::fs::{self, File};
 use std::io::prelude::*;
 use std::io;
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 
 use Mode;
 use build_helper::up_to_date;
@@ -112,13 +112,12 @@ impl Step for UnstableBook {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.path("src/doc/unstable-book").default_condition(builder.build.config.general.docs)
+        run.path("src/doc/unstable-book")
+            .default_condition(builder.build.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
-        run.builder.ensure(UnstableBook {
-            target: run.target,
-        });
+        run.builder.ensure(UnstableBook { target: run.target });
     }
 
     fn run(self, builder: &Builder) {
@@ -145,7 +144,8 @@ impl Step for CargoBook {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.path("src/tools/cargo/src/doc/book").default_condition(builder.build.config.general.docs)
+        run.path("src/tools/cargo/src/doc/book")
+            .default_condition(builder.build.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
@@ -171,11 +171,14 @@ impl Step for CargoBook {
 
         let _ = fs::remove_dir_all(&out);
 
-        build.run(builder.tool_cmd(Tool::Rustbook)
-                       .arg("build")
-                       .arg(&src)
-                       .arg("-d")
-                       .arg(out));
+        build.run(
+            builder
+                .tool_cmd(Tool::Rustbook)
+                .arg("build")
+                .arg(&src)
+                .arg("-d")
+                .arg(out),
+        );
     }
 }
 
@@ -210,15 +213,18 @@ impl Step for RustbookSrc {
         let index = out.join("index.html");
         let rustbook = builder.tool_exe(Tool::Rustbook);
         if up_to_date(&src, &index) && up_to_date(&rustbook, &index) {
-            return
+            return;
         }
         println!("Rustbook ({}) - {}", target, name);
         let _ = fs::remove_dir_all(&out);
-        build.run(builder.tool_cmd(Tool::Rustbook)
-                       .arg("build")
-                       .arg(&src)
-                       .arg("-d")
-                       .arg(out));
+        build.run(
+            builder
+                .tool_cmd(Tool::Rustbook)
+                .arg("build")
+                .arg(&src)
+                .arg("-d")
+                .arg(out),
+        );
     }
 }
 
@@ -235,12 +241,16 @@ impl Step for TheBook {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.path("src/doc/book").default_condition(builder.build.config.general.docs)
+        run.path("src/doc/book")
+            .default_condition(builder.build.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(TheBook {
-            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.general.build),
+            compiler: run.builder.compiler(
+                run.builder.top_stage,
+                run.builder.build.config.general.build,
+            ),
             target: run.target,
             name: "book",
         });
@@ -273,10 +283,7 @@ impl Step for TheBook {
         });
 
         // build the version info page and CSS
-        builder.ensure(Standalone {
-            compiler,
-            target,
-        });
+        builder.ensure(Standalone { compiler, target });
 
         // build the index page
         let index = format!("{}/index.md", name);
@@ -285,7 +292,9 @@ impl Step for TheBook {
 
         // build the redirect pages
         println!("Documenting book redirect pages ({})", target);
-        for file in t!(fs::read_dir(build.config.src.join("src/doc/book/redirects"))) {
+        for file in t!(fs::read_dir(
+            build.config.src.join("src/doc/book/redirects")
+        )) {
             let file = t!(file);
             let path = file.path();
             let path = path.to_str().unwrap();
@@ -309,12 +318,16 @@ fn invoke_rustdoc(builder: &Builder, compiler: Compiler, target: Interned<String
 
     let out = out.join("book");
 
-    cmd.arg("--html-after-content").arg(&footer)
-        .arg("--html-before-content").arg(&version_info)
-        .arg("--html-in-header").arg(&favicon)
+    cmd.arg("--html-after-content")
+        .arg(&footer)
+        .arg("--html-before-content")
+        .arg(&version_info)
+        .arg("--html-in-header")
+        .arg(&favicon)
         .arg("--markdown-playground-url")
         .arg("https://play.rust-lang.org/")
-        .arg("-o").arg(&out)
+        .arg("-o")
+        .arg(&out)
         .arg(&path)
         .arg("--markdown-css")
         .arg("../rust.css");
@@ -334,12 +347,16 @@ impl Step for Standalone {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.path("src/doc").default_condition(builder.build.config.general.docs)
+        run.path("src/doc")
+            .default_condition(builder.build.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(Standalone {
-            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.general.build),
+            compiler: run.builder.compiler(
+                run.builder.top_stage,
+                run.builder.build.config.general.build,
+            ),
             target: run.target,
         });
     }
@@ -363,7 +380,10 @@ impl Step for Standalone {
         let favicon = build.config.src.join("src/doc/favicon.inc");
         let footer = build.config.src.join("src/doc/footer.inc");
         let full_toc = build.config.src.join("src/doc/full-toc.inc");
-        t!(fs::copy(build.config.src.join("src/doc/rust.css"), out.join("rust.css")));
+        t!(fs::copy(
+            build.config.src.join("src/doc/rust.css"),
+            out.join("rust.css")
+        ));
 
         let version_input = build.config.src.join("src/doc/version_info.html.template");
         let version_info = out.join("version_info.html");
@@ -372,8 +392,8 @@ impl Step for Standalone {
             let mut info = String::new();
             t!(t!(File::open(&version_input)).read_to_string(&mut info));
             let info = info.replace("VERSION", &build.rust_release())
-                           .replace("SHORT_HASH", build.rust_info.sha_short().unwrap_or(""))
-                           .replace("STAMP", build.rust_info.sha().unwrap_or(""));
+                .replace("SHORT_HASH", build.rust_info.sha_short().unwrap_or(""))
+                .replace("STAMP", build.rust_info.sha().unwrap_or(""));
             t!(t!(File::create(&version_info)).write_all(info.as_bytes()));
         }
 
@@ -382,33 +402,35 @@ impl Step for Standalone {
             let path = file.path();
             let filename = path.file_name().unwrap().to_str().unwrap();
             if !filename.ends_with(".md") || filename == "README.md" {
-                continue
+                continue;
             }
 
             let html = out.join(filename).with_extension("html");
             let rustdoc = builder.rustdoc(compiler.host);
-            if up_to_date(&path, &html) &&
-               up_to_date(&footer, &html) &&
-               up_to_date(&favicon, &html) &&
-               up_to_date(&full_toc, &html) &&
-               up_to_date(&version_info, &html) &&
-               up_to_date(&rustdoc, &html) {
-                continue
+            if up_to_date(&path, &html) && up_to_date(&footer, &html) && up_to_date(&favicon, &html)
+                && up_to_date(&full_toc, &html) && up_to_date(&version_info, &html)
+                && up_to_date(&rustdoc, &html)
+            {
+                continue;
             }
 
             let mut cmd = builder.rustdoc_cmd(compiler.host);
-            cmd.arg("--html-after-content").arg(&footer)
-               .arg("--html-before-content").arg(&version_info)
-               .arg("--html-in-header").arg(&favicon)
-               .arg("--markdown-playground-url")
-               .arg("https://play.rust-lang.org/")
-               .arg("-o").arg(&out)
-               .arg(&path);
+            cmd.arg("--html-after-content")
+                .arg(&footer)
+                .arg("--html-before-content")
+                .arg(&version_info)
+                .arg("--html-in-header")
+                .arg(&favicon)
+                .arg("--markdown-playground-url")
+                .arg("https://play.rust-lang.org/")
+                .arg("-o")
+                .arg(&out)
+                .arg(&path);
 
             if filename == "not_found.md" {
                 cmd.arg("--markdown-no-toc")
-                   .arg("--markdown-css")
-                   .arg("https://doc.rust-lang.org/rust.css");
+                    .arg("--markdown-css")
+                    .arg("https://doc.rust-lang.org/rust.css");
             } else {
                 cmd.arg("--markdown-css").arg("rust.css");
             }
@@ -429,13 +451,14 @@ impl Step for Std {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.all_krates("std").default_condition(builder.build.config.general.docs)
+        run.all_krates("std")
+            .default_condition(builder.build.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(Std {
             stage: run.builder.top_stage,
-            target: run.target
+            target: run.target,
         });
     }
 
@@ -459,8 +482,10 @@ impl Step for Std {
         };
 
         builder.ensure(compile::Std { compiler, target });
-        let out_dir = build.stage_out(compiler, Mode::Libstd)
-                           .join(target).join("doc");
+        let out_dir = build
+            .stage_out(compiler, Mode::Libstd)
+            .join(target)
+            .join("doc");
 
         // Here what we're doing is creating a *symlink* (directory junction on
         // Windows) to the final output location. This is not done as an
@@ -496,7 +521,6 @@ impl Step for Std {
             }
         }
 
-
         build.run(&mut cargo);
         cp_r(&my_out, &out);
     }
@@ -514,7 +538,8 @@ impl Step for Test {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.krate("test").default_condition(builder.config.general.compiler_docs)
+        run.krate("test")
+            .default_condition(builder.config.general.compiler_docs)
     }
 
     fn make_run(run: RunConfig) {
@@ -547,8 +572,10 @@ impl Step for Test {
         builder.ensure(Std { stage, target });
 
         builder.ensure(compile::Test { compiler, target });
-        let out_dir = build.stage_out(compiler, Mode::Libtest)
-                           .join(target).join("doc");
+        let out_dir = build
+            .stage_out(compiler, Mode::Libtest)
+            .join(target)
+            .join("doc");
 
         // See docs in std above for why we symlink
         let my_out = build.crate_doc_out(target);
@@ -575,7 +602,8 @@ impl Step for Rustc {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.krate("rustc-main").default_condition(builder.build.config.general.docs)
+        run.krate("rustc-main")
+            .default_condition(builder.build.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
@@ -608,8 +636,10 @@ impl Step for Rustc {
         builder.ensure(Std { stage, target });
 
         builder.ensure(compile::Rustc { compiler, target });
-        let out_dir = build.stage_out(compiler, Mode::Librustc)
-                           .join(target).join("doc");
+        let out_dir = build
+            .stage_out(compiler, Mode::Librustc)
+            .join(target)
+            .join("doc");
 
         // See docs in std above for why we symlink
         let my_out = build.crate_doc_out(target);
@@ -649,13 +679,12 @@ impl Step for ErrorIndex {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.path("src/tools/error_index_generator").default_condition(builder.build.config.general.docs)
+        run.path("src/tools/error_index_generator")
+            .default_condition(builder.build.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
-        run.builder.ensure(ErrorIndex {
-            target: run.target,
-        });
+        run.builder.ensure(ErrorIndex { target: run.target });
     }
 
     /// Generates the HTML rendered error-index by running the
@@ -672,8 +701,9 @@ impl Step for ErrorIndex {
         index.arg(out.join("error-index.html"));
 
         // FIXME: shouldn't have to pass this env var
-        index.env("CFG_BUILD", &build.config.general.build)
-             .env("RUSTC_ERROR_METADATA_DST", build.extended_error_dir());
+        index
+            .env("CFG_BUILD", &build.config.general.build)
+            .env("RUSTC_ERROR_METADATA_DST", build.extended_error_dir());
 
         build.run(&mut index);
     }
@@ -691,13 +721,12 @@ impl Step for UnstableBookGen {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.path("src/tools/unstable-book-gen").default_condition(builder.build.config.general.docs)
+        run.path("src/tools/unstable-book-gen")
+            .default_condition(builder.build.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
-        run.builder.ensure(UnstableBookGen {
-            target: run.target,
-        });
+        run.builder.ensure(UnstableBookGen { target: run.target });
     }
 
     fn run(self, builder: &Builder) {
@@ -728,9 +757,7 @@ fn symlink_dir_force(src: &Path, dst: &Path) -> io::Result<()> {
         } else {
             // handle directory junctions on windows by falling back to
             // `remove_dir`.
-            try!(fs::remove_file(dst).or_else(|_| {
-                fs::remove_dir(dst)
-            }));
+            try!(fs::remove_file(dst).or_else(|_| fs::remove_dir(dst)));
         }
     }
 

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -29,7 +29,7 @@ use util::{cp_r, symlink_dir};
 use builder::{Builder, Compiler, RunConfig, ShouldRun, Step};
 use tool::Tool;
 use compile;
-use cache::{INTERNER, Interned};
+use cache::{Intern, Interned};
 
 macro_rules! book {
     ($($name:ident, $path:expr, $book_name:expr;)+) => {
@@ -57,7 +57,7 @@ macro_rules! book {
             fn run(self, builder: &Builder) {
                 builder.ensure(Rustbook {
                     target: self.target,
-                    name: INTERNER.intern_str($book_name),
+                    name: $book_name.intern(),
                 })
             }
         }
@@ -96,7 +96,7 @@ impl Step for Rustbook {
         builder.ensure(RustbookSrc {
             target: self.target,
             name: self.name,
-            src: INTERNER.intern_path(src),
+            src: src.intern(),
         });
     }
 }
@@ -127,7 +127,7 @@ impl Step for UnstableBook {
         });
         builder.ensure(RustbookSrc {
             target: self.target,
-            name: INTERNER.intern_str("unstable-book"),
+            name: "unstable-book".intern(),
             src: builder.build.md_doc_out(self.target),
         })
     }
@@ -151,7 +151,7 @@ impl Step for CargoBook {
     fn make_run(run: RunConfig) {
         run.builder.ensure(CargoBook {
             target: run.target,
-            name: INTERNER.intern_str("cargo"),
+            name: "cargo".intern(),
         });
     }
 
@@ -263,13 +263,13 @@ impl Step for TheBook {
         // build book first edition
         builder.ensure(Rustbook {
             target,
-            name: INTERNER.intern_string(format!("{}/first-edition", name)),
+            name: format!("{}/first-edition", name).intern(),
         });
 
         // build book second edition
         builder.ensure(Rustbook {
             target,
-            name: INTERNER.intern_string(format!("{}/second-edition", name)),
+            name: format!("{}/second-edition", name).intern(),
         });
 
         // build the version info page and CSS

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -45,7 +45,7 @@ macro_rules! book {
 
             fn should_run(run: ShouldRun) -> ShouldRun {
                 let builder = run.builder;
-                run.path($path).default_condition(builder.build.config.docs)
+                run.path($path).default_condition(builder.build.config.general.docs)
             }
 
             fn make_run(run: RunConfig) {
@@ -112,7 +112,7 @@ impl Step for UnstableBook {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.path("src/doc/unstable-book").default_condition(builder.build.config.docs)
+        run.path("src/doc/unstable-book").default_condition(builder.build.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
@@ -145,7 +145,7 @@ impl Step for CargoBook {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.path("src/tools/cargo/src/doc/book").default_condition(builder.build.config.docs)
+        run.path("src/tools/cargo/src/doc/book").default_condition(builder.build.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
@@ -235,7 +235,7 @@ impl Step for TheBook {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.path("src/doc/book").default_condition(builder.build.config.docs)
+        run.path("src/doc/book").default_condition(builder.build.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
@@ -334,7 +334,7 @@ impl Step for Standalone {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.path("src/doc").default_condition(builder.build.config.docs)
+        run.path("src/doc").default_condition(builder.build.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
@@ -429,7 +429,7 @@ impl Step for Std {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.all_krates("std").default_condition(builder.build.config.docs)
+        run.all_krates("std").default_condition(builder.build.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
@@ -485,7 +485,7 @@ impl Step for Std {
         // We don't want to build docs for internal std dependencies unless
         // in compiler-docs mode. When not in that mode, we whitelist the crates
         // for which docs must be built.
-        if !build.config.compiler_docs {
+        if !build.config.general.compiler_docs {
             cargo.arg("--no-deps");
             for krate in &["alloc", "core", "std", "std_unicode"] {
                 cargo.arg("-p").arg(krate);
@@ -514,7 +514,7 @@ impl Step for Test {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.krate("test").default_condition(builder.config.compiler_docs)
+        run.krate("test").default_condition(builder.config.general.compiler_docs)
     }
 
     fn make_run(run: RunConfig) {
@@ -575,7 +575,7 @@ impl Step for Rustc {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.krate("rustc-main").default_condition(builder.build.config.docs)
+        run.krate("rustc-main").default_condition(builder.build.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
@@ -619,7 +619,7 @@ impl Step for Rustc {
         let mut cargo = builder.cargo(compiler, Mode::Librustc, target, "doc");
         compile::rustc_cargo(build, &mut cargo);
 
-        if build.config.compiler_docs {
+        if build.config.general.compiler_docs {
             // src/rustc/Cargo.toml contains a bin crate called rustc which
             // would otherwise overwrite the docs for the real rustc lib crate.
             cargo.arg("-p").arg("rustc_driver");
@@ -649,7 +649,7 @@ impl Step for ErrorIndex {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.path("src/tools/error_index_generator").default_condition(builder.build.config.docs)
+        run.path("src/tools/error_index_generator").default_condition(builder.build.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
@@ -691,7 +691,7 @@ impl Step for UnstableBookGen {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.path("src/tools/unstable-book-gen").default_condition(builder.build.config.docs)
+        run.path("src/tools/unstable-book-gen").default_condition(builder.build.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -17,14 +17,13 @@
 //! Everything here is basically just a shim around calling either `rustbook` or
 //! `rustdoc`.
 
-use std::io::prelude::*;
 use std::io;
 use std::path::{Path, PathBuf};
 
 use Mode;
 use build_helper::up_to_date;
 
-use fs::{self, File};
+use fs;
 use util::{cp_r, symlink_dir};
 use builder::{Builder, Compiler, RunConfig, ShouldRun, Step};
 use tool::Tool;
@@ -382,12 +381,11 @@ impl Step for Standalone {
         let version_info = out.join("version_info.html");
 
         if !up_to_date(&version_input, &version_info) {
-            let mut info = String::new();
-            t!(t!(File::open(&version_input)).read_to_string(&mut info));
+            let info = t!(fs::read_string(&version_input));
             let info = info.replace("VERSION", &builder.rust_release())
                 .replace("SHORT_HASH", builder.rust_info.sha_short().unwrap_or(""))
                 .replace("STAMP", builder.rust_info.sha().unwrap_or(""));
-            t!(t!(File::create(&version_info)).write_all(info.as_bytes()));
+            t!(fs::write(&version_info, info))
         }
 
         for file in t!(fs::read_dir(builder.config.src.join("src/doc"))) {

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -240,7 +240,7 @@ impl Step for TheBook {
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(TheBook {
-            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.build),
+            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.general.build),
             target: run.target,
             name: "book",
         });
@@ -339,7 +339,7 @@ impl Step for Standalone {
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(Standalone {
-            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.build),
+            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.general.build),
             target: run.target,
         });
     }
@@ -450,7 +450,7 @@ impl Step for Std {
         println!("Documenting stage{} std ({})", stage, target);
         let out = build.doc_out(target);
         t!(fs::create_dir_all(&out));
-        let compiler = builder.compiler(stage, build.config.build);
+        let compiler = builder.compiler(stage, build.config.general.build);
         let rustdoc = builder.rustdoc(compiler.host);
         let compiler = if build.force_use_stage1(compiler, target) {
             builder.compiler(1, compiler.host)
@@ -535,7 +535,7 @@ impl Step for Test {
         println!("Documenting stage{} test ({})", stage, target);
         let out = build.doc_out(target);
         t!(fs::create_dir_all(&out));
-        let compiler = builder.compiler(stage, build.config.build);
+        let compiler = builder.compiler(stage, build.config.general.build);
         let rustdoc = builder.rustdoc(compiler.host);
         let compiler = if build.force_use_stage1(compiler, target) {
             builder.compiler(1, compiler.host)
@@ -596,7 +596,7 @@ impl Step for Rustc {
         println!("Documenting stage{} compiler ({})", stage, target);
         let out = build.doc_out(target);
         t!(fs::create_dir_all(&out));
-        let compiler = builder.compiler(stage, build.config.build);
+        let compiler = builder.compiler(stage, build.config.general.build);
         let rustdoc = builder.rustdoc(compiler.host);
         let compiler = if build.force_use_stage1(compiler, target) {
             builder.compiler(1, compiler.host)
@@ -672,7 +672,7 @@ impl Step for ErrorIndex {
         index.arg(out.join("error-index.html"));
 
         // FIXME: shouldn't have to pass this env var
-        index.env("CFG_BUILD", &build.config.build)
+        index.env("CFG_BUILD", &build.config.general.build)
              .env("RUSTC_ERROR_METADATA_DST", build.extended_error_dir());
 
         build.run(&mut index);
@@ -705,7 +705,7 @@ impl Step for UnstableBookGen {
         let target = self.target;
 
         builder.ensure(compile::Std {
-            compiler: builder.compiler(builder.top_stage, build.config.build),
+            compiler: builder.compiler(builder.top_stage, build.config.general.build),
             target,
         });
 

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -240,7 +240,7 @@ impl Step for TheBook {
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(TheBook {
-            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.build),
+            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.build),
             target: run.target,
             name: "book",
         });
@@ -339,7 +339,7 @@ impl Step for Standalone {
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(Standalone {
-            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.build),
+            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.build),
             target: run.target,
         });
     }
@@ -450,7 +450,7 @@ impl Step for Std {
         println!("Documenting stage{} std ({})", stage, target);
         let out = build.doc_out(target);
         t!(fs::create_dir_all(&out));
-        let compiler = builder.compiler(stage, build.build);
+        let compiler = builder.compiler(stage, build.config.build);
         let rustdoc = builder.rustdoc(compiler.host);
         let compiler = if build.force_use_stage1(compiler, target) {
             builder.compiler(1, compiler.host)
@@ -535,7 +535,7 @@ impl Step for Test {
         println!("Documenting stage{} test ({})", stage, target);
         let out = build.doc_out(target);
         t!(fs::create_dir_all(&out));
-        let compiler = builder.compiler(stage, build.build);
+        let compiler = builder.compiler(stage, build.config.build);
         let rustdoc = builder.rustdoc(compiler.host);
         let compiler = if build.force_use_stage1(compiler, target) {
             builder.compiler(1, compiler.host)
@@ -596,7 +596,7 @@ impl Step for Rustc {
         println!("Documenting stage{} compiler ({})", stage, target);
         let out = build.doc_out(target);
         t!(fs::create_dir_all(&out));
-        let compiler = builder.compiler(stage, build.build);
+        let compiler = builder.compiler(stage, build.config.build);
         let rustdoc = builder.rustdoc(compiler.host);
         let compiler = if build.force_use_stage1(compiler, target) {
             builder.compiler(1, compiler.host)
@@ -672,7 +672,7 @@ impl Step for ErrorIndex {
         index.arg(out.join("error-index.html"));
 
         // FIXME: shouldn't have to pass this env var
-        index.env("CFG_BUILD", &build.build)
+        index.env("CFG_BUILD", &build.config.build)
              .env("RUSTC_ERROR_METADATA_DST", build.extended_error_dir());
 
         build.run(&mut index);
@@ -705,7 +705,7 @@ impl Step for UnstableBookGen {
         let target = self.target;
 
         builder.ensure(compile::Std {
-            compiler: builder.compiler(builder.top_stage, build.build),
+            compiler: builder.compiler(builder.top_stage, build.config.build),
             target,
         });
 

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -44,45 +44,32 @@ pub struct Flags {
     pub incremental: bool,
     pub exclude: Vec<PathBuf>,
     pub rustc_error_format: Option<String>,
+    pub paths: Vec<PathBuf>,
 }
 
 pub enum Subcommand {
-    Build {
-        paths: Vec<PathBuf>,
-    },
-    Check {
-        paths: Vec<PathBuf>,
-    },
-    Doc {
-        paths: Vec<PathBuf>,
-    },
+    Build,
+    Check,
+    Doc,
     Test {
-        paths: Vec<PathBuf>,
         test_args: Vec<String>,
         rustc_args: Vec<String>,
         fail_fast: bool,
         doc_tests: bool,
     },
     Bench {
-        paths: Vec<PathBuf>,
         test_args: Vec<String>,
     },
     Clean {
         all: bool,
     },
-    Dist {
-        paths: Vec<PathBuf>,
-    },
-    Install {
-        paths: Vec<PathBuf>,
-    },
+    Dist,
+    Install,
 }
 
 impl Default for Subcommand {
     fn default() -> Subcommand {
-        Subcommand::Build {
-            paths: vec![PathBuf::from("nowhere")],
-        }
+        Subcommand::Build
     }
 }
 
@@ -313,14 +300,13 @@ Arguments:
 
         let cmd = match subcommand.as_str() {
             "build" => {
-                Subcommand::Build { paths: paths }
+                Subcommand::Build
             }
             "check" => {
-                Subcommand::Check { paths: paths }
+                Subcommand::Check
             }
             "test" => {
                 Subcommand::Test {
-                    paths,
                     test_args: matches.opt_strs("test-args"),
                     rustc_args: matches.opt_strs("rustc-args"),
                     fail_fast: !matches.opt_present("no-fail-fast"),
@@ -329,12 +315,11 @@ Arguments:
             }
             "bench" => {
                 Subcommand::Bench {
-                    paths,
                     test_args: matches.opt_strs("test-args"),
                 }
             }
             "doc" => {
-                Subcommand::Doc { paths: paths }
+                Subcommand::Doc
             }
             "clean" => {
                 if paths.len() > 0 {
@@ -347,14 +332,10 @@ Arguments:
                 }
             }
             "dist" => {
-                Subcommand::Dist {
-                    paths,
-                }
+                Subcommand::Dist
             }
             "install" => {
-                Subcommand::Install {
-                    paths,
-                }
+                Subcommand::Install
             }
             _ => {
                 usage(1, &opts, &subcommand_help, &extra_help);
@@ -386,6 +367,7 @@ Arguments:
             exclude: split(matches.opt_strs("exclude"))
                 .into_iter().map(|p| p.into()).collect::<Vec<_>>(),
             src,
+            paths,
         }
     }
 }

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -25,7 +25,7 @@ use config::Config;
 use metadata;
 use builder::Builder;
 
-use cache::{Interned, INTERNER};
+use cache::{Interned, Intern};
 
 /// Deserialized version of all flags for this compile.
 pub struct Flags {
@@ -355,11 +355,11 @@ Arguments:
             on_fail: matches.opt_str("on-fail"),
             rustc_error_format: matches.opt_str("error-format"),
             keep_stage: matches.opt_str("keep-stage").map(|j| j.parse().unwrap()),
-            build: matches.opt_str("build").map(|s| INTERNER.intern_string(s)),
+            build: matches.opt_str("build").map(|s| s.intern()),
             host: split(matches.opt_strs("host"))
-                .into_iter().map(|x| INTERNER.intern_string(x)).collect::<Vec<_>>(),
+                .into_iter().map(|x| x.intern()).collect::<Vec<_>>(),
             target: split(matches.opt_strs("target"))
-                .into_iter().map(|x| INTERNER.intern_string(x)).collect::<Vec<_>>(),
+                .into_iter().map(|x| x.intern()).collect::<Vec<_>>(),
             config: cfg_file,
             jobs: matches.opt_str("jobs").map(|j| j.parse().unwrap()),
             cmd,

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -25,7 +25,7 @@ use config::Config;
 use metadata;
 use builder::Builder;
 
-use cache::{Interned, Intern};
+use cache::{Intern, Interned};
 
 /// Deserialized version of all flags for this compile.
 pub struct Flags {
@@ -76,7 +76,8 @@ impl Default for Subcommand {
 impl Flags {
     pub fn parse(args: &[String]) -> Flags {
         let mut extra_help = String::new();
-        let mut subcommand_help = format!("\
+        let mut subcommand_help = format!(
+            "\
 Usage: x.py <subcommand> [options] [<paths>...]
 
 Subcommands:
@@ -89,7 +90,8 @@ Subcommands:
     dist        Build distribution artifacts
     install     Install distribution artifacts
 
-To learn more about a subcommand, run `./x.py <subcommand> -h`");
+To learn more about a subcommand, run `./x.py <subcommand> -h`"
+        );
 
         let mut opts = Options::new();
         // Options common to all subcommands
@@ -109,28 +111,24 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`");
         opts.optflag("", "error-format", "rustc error format");
 
         // fn usage()
-        let usage = |exit_code: i32, opts: &Options, subcommand_help: &str, extra_help: &str| -> ! {
-            println!("{}", opts.usage(subcommand_help));
-            if !extra_help.is_empty() {
-                println!("{}", extra_help);
-            }
-            process::exit(exit_code);
-        };
+        let usage =
+            |exit_code: i32, opts: &Options, subcommand_help: &str, extra_help: &str| -> ! {
+                println!("{}", opts.usage(subcommand_help));
+                if !extra_help.is_empty() {
+                    println!("{}", extra_help);
+                }
+                process::exit(exit_code);
+            };
 
         // We can't use getopt to parse the options until we have completed specifying which
         // options are valid, but under the current implementation, some options are conditional on
         // the subcommand. Therefore we must manually identify the subcommand first, so that we can
         // complete the definition of the options.  Then we can use the getopt::Matches object from
         // there on out.
-        let subcommand = args.iter().find(|&s|
-            (s == "build")
-            || (s == "check")
-            || (s == "test")
-            || (s == "bench")
-            || (s == "doc")
-            || (s == "clean")
-            || (s == "dist")
-            || (s == "install"));
+        let subcommand = args.iter().find(|&s| {
+            (s == "build") || (s == "check") || (s == "test") || (s == "bench") || (s == "doc")
+                || (s == "clean") || (s == "dist") || (s == "install")
+        });
         let subcommand = match subcommand {
             Some(s) => s,
             None => {
@@ -145,7 +143,7 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`");
 
         // Some subcommands get extra options
         match subcommand.as_str() {
-            "test"  => {
+            "test" => {
                 opts.optflag("", "no-fail-fast", "Run all tests regardless of failure");
                 opts.optmulti("", "test-args", "extra arguments", "ARGS");
                 opts.optmulti(
@@ -155,10 +153,14 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`");
                     "ARGS",
                 );
                 opts.optflag("", "doc", "run doc tests");
-            },
-            "bench" => { opts.optmulti("", "test-args", "extra arguments", "ARGS"); },
-            "clean" => { opts.optflag("", "all", "clean all build artifacts"); },
-            _ => { },
+            }
+            "bench" => {
+                opts.optmulti("", "test-args", "extra arguments", "ARGS");
+            }
+            "clean" => {
+                opts.optflag("", "all", "clean all build artifacts");
+            }
+            _ => {}
         };
 
         // Done specifying what options are possible, so do the getopts parsing
@@ -178,21 +180,24 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`");
                 if check_subcommand != subcommand {
                     pass_sanity_check = false;
                 }
-            },
+            }
             None => {
                 pass_sanity_check = false;
             }
         }
         if !pass_sanity_check {
             println!("{}\n", subcommand_help);
-            println!("Sorry, I couldn't figure out which subcommand you were trying to specify.\n\
-                      You may need to move some options to after the subcommand.\n");
+            println!(
+                "Sorry, I couldn't figure out which subcommand you were trying to specify.\n\
+                 You may need to move some options to after the subcommand.\n"
+            );
             process::exit(1);
         }
         // Extra help text for some commands
         match subcommand.as_str() {
             "build" => {
-                subcommand_help.push_str("\n
+                subcommand_help.push_str(
+                    "\n
 Arguments:
     This subcommand accepts a number of paths to directories to the crates
     and/or artifacts to compile. For example:
@@ -214,10 +219,12 @@ Arguments:
     This will first build everything once (like --stage 0 without further
     arguments would), and then use the compiler built in stage 0 to build
     src/libtest and its dependencies.
-    Once this is done, build/$ARCH/stage1 contains a usable compiler.");
+    Once this is done, build/$ARCH/stage1 contains a usable compiler.",
+                );
             }
             "check" => {
-                subcommand_help.push_str("\n
+                subcommand_help.push_str(
+                    "\n
 Arguments:
     This subcommand accepts a number of paths to directories to the crates
     and/or artifacts to compile. For example:
@@ -229,10 +236,12 @@ Arguments:
     also that since we use `cargo check`, by default this will automatically enable incremental
     compilation, so there's no need to pass it separately, though it won't hurt. We also completely
     ignore the stage passed, as there's no way to compile in non-stage 0 without actually building
-    the compiler.");
+    the compiler.",
+                );
             }
             "test" => {
-                subcommand_help.push_str("\n
+                subcommand_help.push_str(
+                    "\n
 Arguments:
     This subcommand accepts a number of paths to directories to tests that
     should be compiled and run. For example:
@@ -245,10 +254,12 @@ Arguments:
     compiled and tested.
 
         ./x.py test
-        ./x.py test --stage 1");
+        ./x.py test --stage 1",
+                );
             }
             "doc" => {
-                subcommand_help.push_str("\n
+                subcommand_help.push_str(
+                    "\n
 Arguments:
     This subcommand accepts a number of paths to directories of documentation
     to build. For example:
@@ -260,16 +271,22 @@ Arguments:
     If no arguments are passed then everything is documented:
 
         ./x.py doc
-        ./x.py doc --stage 1");
+        ./x.py doc --stage 1",
+                );
             }
-            _ => { }
+            _ => {}
         };
         // Get any optional paths which occur after the subcommand
         let cwd = t!(env::current_dir());
-        let src = matches.opt_str("src").map(PathBuf::from)
+        let src = matches
+            .opt_str("src")
+            .map(PathBuf::from)
             .or_else(|| env::var_os("SRC").map(PathBuf::from))
             .unwrap_or(cwd.clone());
-        let paths = matches.free[1..].iter().map(|p| p.into()).collect::<Vec<PathBuf>>();
+        let paths = matches.free[1..]
+            .iter()
+            .map(|p| p.into())
+            .collect::<Vec<PathBuf>>();
 
         let cfg_file = matches.opt_str("config").map(PathBuf::from).or_else(|| {
             if fs::metadata("config.toml").is_ok() {
@@ -288,9 +305,12 @@ Arguments:
             let maybe_rules_help = Builder::get_help(&build, subcommand.as_str());
             extra_help.push_str(maybe_rules_help.unwrap_or_default().as_str());
         } else if subcommand.as_str() != "clean" {
-            extra_help.push_str(format!(
-                "Run `./x.py {} -h -v` to see a list of available paths.",
-                subcommand).as_str());
+            extra_help.push_str(
+                format!(
+                    "Run `./x.py {} -h -v` to see a list of available paths.",
+                    subcommand
+                ).as_str(),
+            );
         }
 
         // User passed in -h/--help?
@@ -299,28 +319,18 @@ Arguments:
         }
 
         let cmd = match subcommand.as_str() {
-            "build" => {
-                Subcommand::Build
-            }
-            "check" => {
-                Subcommand::Check
-            }
-            "test" => {
-                Subcommand::Test {
-                    test_args: matches.opt_strs("test-args"),
-                    rustc_args: matches.opt_strs("rustc-args"),
-                    fail_fast: !matches.opt_present("no-fail-fast"),
-                    doc_tests: matches.opt_present("doc"),
-                }
-            }
-            "bench" => {
-                Subcommand::Bench {
-                    test_args: matches.opt_strs("test-args"),
-                }
-            }
-            "doc" => {
-                Subcommand::Doc
-            }
+            "build" => Subcommand::Build,
+            "check" => Subcommand::Check,
+            "test" => Subcommand::Test {
+                test_args: matches.opt_strs("test-args"),
+                rustc_args: matches.opt_strs("rustc-args"),
+                fail_fast: !matches.opt_present("no-fail-fast"),
+                doc_tests: matches.opt_present("doc"),
+            },
+            "bench" => Subcommand::Bench {
+                test_args: matches.opt_strs("test-args"),
+            },
+            "doc" => Subcommand::Doc,
             "clean" => {
                 if paths.len() > 0 {
                     println!("\nclean does not take a path argument\n");
@@ -331,17 +341,12 @@ Arguments:
                     all: matches.opt_present("all"),
                 }
             }
-            "dist" => {
-                Subcommand::Dist
-            }
-            "install" => {
-                Subcommand::Install
-            }
+            "dist" => Subcommand::Dist,
+            "install" => Subcommand::Install,
             _ => {
                 usage(1, &opts, &subcommand_help, &extra_help);
             }
         };
-
 
         let mut stage = matches.opt_str("stage").map(|j| j.parse().unwrap());
 
@@ -357,15 +362,21 @@ Arguments:
             keep_stage: matches.opt_str("keep-stage").map(|j| j.parse().unwrap()),
             build: matches.opt_str("build").map(|s| s.intern()),
             host: split(matches.opt_strs("host"))
-                .into_iter().map(|x| x.intern()).collect::<Vec<_>>(),
+                .into_iter()
+                .map(|x| x.intern())
+                .collect::<Vec<_>>(),
             target: split(matches.opt_strs("target"))
-                .into_iter().map(|x| x.intern()).collect::<Vec<_>>(),
+                .into_iter()
+                .map(|x| x.intern())
+                .collect::<Vec<_>>(),
             config: cfg_file,
             jobs: matches.opt_str("jobs").map(|j| j.parse().unwrap()),
             cmd,
             incremental: matches.opt_present("incremental"),
             exclude: split(matches.opt_strs("exclude"))
-                .into_iter().map(|p| p.into()).collect::<Vec<_>>(),
+                .into_iter()
+                .map(|p| p.into())
+                .collect::<Vec<_>>(),
             src,
             paths,
         }
@@ -375,9 +386,11 @@ Arguments:
 impl Subcommand {
     pub fn test_args(&self) -> Vec<&str> {
         match *self {
-            Subcommand::Test { ref test_args, .. } |
-            Subcommand::Bench { ref test_args, .. } => {
-                test_args.iter().flat_map(|s| s.split_whitespace()).collect()
+            Subcommand::Test { ref test_args, .. } | Subcommand::Bench { ref test_args, .. } => {
+                test_args
+                    .iter()
+                    .flat_map(|s| s.split_whitespace())
+                    .collect()
             }
             _ => Vec::new(),
         }
@@ -385,9 +398,10 @@ impl Subcommand {
 
     pub fn rustc_args(&self) -> Vec<&str> {
         match *self {
-            Subcommand::Test { ref rustc_args, .. } => {
-                rustc_args.iter().flat_map(|s| s.split_whitespace()).collect()
-            }
+            Subcommand::Test { ref rustc_args, .. } => rustc_args
+                .iter()
+                .flat_map(|s| s.split_whitespace())
+                .collect(),
             _ => Vec::new(),
         }
     }
@@ -408,5 +422,8 @@ impl Subcommand {
 }
 
 fn split(s: Vec<String>) -> Vec<String> {
-    s.iter().flat_map(|s| s.split(',')).map(|s| s.to_string()).collect()
+    s.iter()
+        .flat_map(|s| s.split(','))
+        .map(|s| s.to_string())
+        .collect()
 }

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -14,12 +14,12 @@
 //! has various flags to configure how it's run.
 
 use std::env;
-use std::fs;
 use std::path::PathBuf;
 use std::process;
 
 use getopts::Options;
 
+use fs;
 use Build;
 use config::Config;
 use metadata;

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -161,7 +161,6 @@ macro_rules! install {
         impl Step for $name {
             type Output = ();
             const DEFAULT: bool = true;
-            const ONLY_BUILD_TARGETS: bool = true;
             const ONLY_HOSTS: bool = $only_hosts;
             $(const $c: bool = true;)*
 
@@ -174,7 +173,7 @@ macro_rules! install {
                 run.builder.ensure($name {
                     stage: run.builder.top_stage,
                     target: run.target,
-                    host: run.host,
+                    host: run.builder.build.build,
                 });
             }
 

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -184,7 +184,7 @@ install!((self, builder, _config),
         install_docs(builder, self.stage, self.target);
     };
     Std, "src/libstd", true, only_hosts: true, {
-        for target in &builder.config.targets {
+        for target in &builder.config.general.target {
             builder.ensure(dist::Std {
                 compiler: builder.compiler(self.stage, self.host),
                 target: *target

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -167,7 +167,7 @@ macro_rules! install {
                 run.builder.ensure($name {
                     stage: run.builder.top_stage,
                     target: run.target,
-                    host: run.builder.build.config.build,
+                    host: run.builder.build.config.general.build,
                 });
             }
 
@@ -220,7 +220,7 @@ install!((self, builder, _config),
         install_analysis(builder, self.stage, self.target);
     };
     Src, "src", Self::should_build(_config) , only_hosts: true, {
-        if self.target == builder.build.config.build {
+        if self.target == builder.build.config.general.build {
             builder.ensure(dist::Src);
             install_src(builder, self.stage);
         }

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -14,12 +14,12 @@
 //! compiler, and documentation.
 
 use std::env;
-use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
 use dist::{self, pkgname, sanitize_sh, tmpdir};
 
+use fs;
 use builder::{Builder, RunConfig, ShouldRun, Step};
 use cache::Interned;
 use config::Config;

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -142,13 +142,13 @@ macro_rules! install {
         impl $name {
             #[allow(dead_code)]
             fn should_build(config: &Config) -> bool {
-                config.extended && config.tools.as_ref()
+                config.general.extended && config.general.tools.as_ref()
                     .map_or(true, |t| t.contains($path))
             }
 
             #[allow(dead_code)]
             fn should_install(builder: &Builder) -> bool {
-                builder.config.tools.as_ref().map_or(false, |t| t.contains($path))
+                builder.config.general.tools.as_ref().map_or(false, |t| t.contains($path))
             }
         }
 
@@ -179,7 +179,7 @@ macro_rules! install {
 }
 
 install!((self, builder, _config),
-    Docs, "src/doc", _config.docs, only_hosts: false, {
+    Docs, "src/doc", _config.general.docs, only_hosts: false, {
         builder.ensure(dist::Docs { stage: self.stage, host: self.target });
         install_docs(builder, self.stage, self.target);
     };

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -226,9 +226,11 @@ install!((self, builder, _config),
         install_analysis(builder, self.stage, self.target);
     };
     Src, "src", Self::should_build(_config) , only_hosts: true, {
-        builder.ensure(dist::Src);
-        install_src(builder, self.stage);
-    }, ONLY_BUILD;
+        if self.target == builder.build.build {
+            builder.ensure(dist::Src);
+            install_src(builder, self.stage);
+        }
+    };
     Rustc, "src/librustc", true, only_hosts: true, {
         builder.ensure(dist::Rustc {
             compiler: builder.compiler(self.stage, self.target),

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -93,7 +93,7 @@ fn install_sh(
     let libdir = add_destdir(&libdir, &destdir);
     let mandir = add_destdir(&mandir, &destdir);
 
-    let empty_dir = build.out.join("tmp/empty_dir");
+    let empty_dir = build.config.out.join("tmp/empty_dir");
 
     t!(fs::create_dir_all(&empty_dir));
     let package_name = if let Some(host) = host {

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -15,7 +15,7 @@
 
 use std::env;
 use std::fs;
-use std::path::{Path, PathBuf, Component};
+use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
 use dist::{self, pkgname, sanitize_sh, tmpdir};
@@ -60,7 +60,7 @@ fn install_sh(
     package: &str,
     name: &str,
     stage: u32,
-    host: Option<Interned<String>>
+    host: Option<Interned<String>>,
 ) {
     let build = builder.build;
     println!("Install {} stage{} ({:?})", package, stage, host);
@@ -98,7 +98,9 @@ fn install_sh(
 
     let mut cmd = Command::new("sh");
     cmd.current_dir(&empty_dir)
-        .arg(sanitize_sh(&tmpdir(build).join(&package_name).join("install.sh")))
+        .arg(sanitize_sh(&tmpdir(build)
+            .join(&package_name)
+            .join("install.sh")))
         .arg(format!("--prefix={}", sanitize_sh(&prefix)))
         .arg(format!("--sysconfdir={}", sanitize_sh(&sysconfdir)))
         .arg(format!("--docdir={}", sanitize_sh(&docdir)))

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -173,7 +173,7 @@ macro_rules! install {
                 run.builder.ensure($name {
                     stage: run.builder.top_stage,
                     target: run.target,
-                    host: run.builder.build.build,
+                    host: run.builder.build.config.build,
                 });
             }
 
@@ -226,7 +226,7 @@ install!((self, builder, _config),
         install_analysis(builder, self.stage, self.target);
     };
     Src, "src", Self::should_build(_config) , only_hosts: true, {
-        if self.target == builder.build.build {
+        if self.target == builder.build.config.build {
             builder.ensure(dist::Src);
             install_src(builder, self.stage);
         }

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -190,7 +190,7 @@ install!((self, builder, _config),
         install_docs(builder, self.stage, self.target);
     };
     Std, "src/libstd", true, only_hosts: true, {
-        for target in &builder.build.targets {
+        for target in &builder.config.targets {
             builder.ensure(dist::Std {
                 compiler: builder.compiler(self.stage, self.host),
                 target: *target

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -87,7 +87,7 @@ fn install_sh(
     let libdir = add_destdir(&libdir, &destdir);
     let mandir = add_destdir(&mandir, &destdir);
 
-    let empty_dir = build.config.out.join("tmp/empty_dir");
+    let empty_dir = build.config.general.out.join("tmp/empty_dir");
 
     t!(fs::create_dir_all(&empty_dir));
     let package_name = if let Some(host) = host {

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -65,18 +65,12 @@ fn install_sh(
     let build = builder.build;
     println!("Install {} stage{} ({:?})", package, stage, host);
 
-    let prefix_default = PathBuf::from("/usr/local");
-    let sysconfdir_default = PathBuf::from("/etc");
-    let docdir_default = PathBuf::from("share/doc/rust");
-    let bindir_default = PathBuf::from("bin");
-    let libdir_default = PathBuf::from("lib");
-    let mandir_default = PathBuf::from("share/man");
-    let prefix = build.config.prefix.as_ref().unwrap_or(&prefix_default);
-    let sysconfdir = build.config.sysconfdir.as_ref().unwrap_or(&sysconfdir_default);
-    let docdir = build.config.docdir.as_ref().unwrap_or(&docdir_default);
-    let bindir = build.config.bindir.as_ref().unwrap_or(&bindir_default);
-    let libdir = build.config.libdir.as_ref().unwrap_or(&libdir_default);
-    let mandir = build.config.mandir.as_ref().unwrap_or(&mandir_default);
+    let prefix = &build.config.install.prefix;
+    let sysconfdir = &build.config.install.sysconfdir;
+    let docdir = &build.config.install.docdir;
+    let bindir = &build.config.install.bindir;
+    let libdir = &build.config.install.libdir;
+    let mandir = &build.config.install.mandir;
 
     let sysconfdir = prefix.join(sysconfdir);
     let docdir = prefix.join(docdir);

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -113,7 +113,7 @@
 //! More documentation can be found in each respective module below, and you can
 //! also check out the `src/bootstrap/README.md` file for more information.
 
-//#![deny(warnings)]
+#![deny(warnings)]
 #![feature(core_intrinsics)]
 
 #[macro_use]

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -123,6 +123,7 @@ extern crate serde_derive;
 #[macro_use]
 extern crate lazy_static;
 extern crate serde_json;
+extern crate serde;
 extern crate cmake;
 extern crate filetime;
 extern crate cc;

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -277,8 +277,12 @@ pub enum Mode {
     /// Output also goes into stageN-rustc.
     CodegenBackend(Interned<String>),
 
-    /// Build some tool, placing output in the "stageN-tools" directory.
-    Tool,
+    /// Build some tool, placing output in the "stageN-{std/test/rustc}-tools" directory.
+    /// N.B. There is no StdTool because all tools may want to run tests. It is Cargo's job to
+    /// determine whether we'd need to recompile, and it's not all that bad to require test. It's
+    /// fast to build and is (almost) always built in a pair with std anyway, at least on CI.
+    TestTool,
+    RustcTool,
 }
 
 impl Build {
@@ -426,7 +430,8 @@ impl Build {
         let suffix = match mode {
             Mode::Libstd => "-std",
             Mode::Libtest => "-test",
-            Mode::Tool => "-tools",
+            Mode::TestTool => "-test-tools",
+            Mode::RustcTool => "-rustc-tools",
             Mode::Librustc | Mode::CodegenBackend(_) => "-rustc",
         };
         self.config

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -226,9 +226,6 @@ pub struct Build {
     doc_tests: bool,
     verbosity: usize,
 
-    // Targets for which to build.
-    build: Interned<String>,
-
     // Probed tools at runtime
     lldb_version: Option<String>,
     lldb_python_dir: Option<String>,
@@ -300,8 +297,6 @@ impl Build {
             doc_tests: config.cmd.doc_tests(),
             verbosity: config.verbose,
 
-            build: config.build,
-
             config,
 
             rust_info,
@@ -322,7 +317,7 @@ impl Build {
 
     pub fn build_triple(&self) -> &[Interned<String>] {
         unsafe {
-            slice::from_raw_parts(&self.build, 1)
+            slice::from_raw_parts(&self.config.build, 1)
         }
     }
 
@@ -714,7 +709,7 @@ impl Build {
     fn force_use_stage1(&self, compiler: Compiler, target: Interned<String>) -> bool {
         !self.config.full_bootstrap &&
             compiler.stage >= 2 &&
-            (self.config.hosts.iter().any(|h| *h == target) || target == self.build)
+            (self.config.hosts.iter().any(|h| *h == target) || target == self.config.build)
     }
 
     /// Returns the directory that OpenSSL artifacts are compiled into if
@@ -944,7 +939,7 @@ impl<'a> Compiler {
 
     /// Returns whether this is a snapshot compiler for `build`'s configuration
     pub fn is_snapshot(&self, build: &Build) -> bool {
-        self.stage == 0 && self.host == build.build
+        self.stage == 0 && self.host == build.config.build
     }
 
     /// Returns if this compiler should be treated as a final stage one in the

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -261,10 +261,6 @@ struct Crate {
     version: String,
     deps: Vec<Interned<String>>,
     path: PathBuf,
-    doc_step: String,
-    build_step: String,
-    test_step: String,
-    bench_step: String,
 }
 
 impl Crate {

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -223,7 +223,6 @@ pub struct Build {
     cargo_info: channel::GitInfo,
     rls_info: channel::GitInfo,
     rustfmt_info: channel::GitInfo,
-    doc_tests: bool,
 
     // Probed tools at runtime
     lldb_version: Option<String>,
@@ -292,8 +291,6 @@ impl Build {
         let rustfmt_info = channel::GitInfo::new(&config, &config.src.join("src/tools/rustfmt"));
 
         Build {
-            doc_tests: config.cmd.doc_tests(),
-
             config,
 
             rust_info,

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -213,6 +213,7 @@ pub struct Compiler {
 /// although most functions are implemented as free functions rather than
 /// methods specifically on this structure itself (to make it easier to
 /// organize).
+#[derive(Default)]
 pub struct Build {
     // User-specified configuration via config.toml
     config: Config,

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -368,19 +368,19 @@ impl Build {
     fn std_features(&self) -> String {
         let mut features = "panic-unwind".to_string();
 
-        if self.config.debug_jemalloc {
+        if self.config.rust.debug_jemalloc() {
             features.push_str(" debug-jemalloc");
         }
-        if self.config.use_jemalloc {
+        if self.config.rust.use_jemalloc {
             features.push_str(" jemalloc");
         }
-        if self.config.backtrace {
+        if self.config.rust.backtrace {
             features.push_str(" backtrace");
         }
         if self.config.profiler {
             features.push_str(" profiler");
         }
-        if self.config.wasm_syscall {
+        if self.config.rust.wasm_syscall {
             features.push_str(" wasm_syscall");
         }
         features
@@ -389,7 +389,7 @@ impl Build {
     /// Get the space-separated set of activated features for the compiler.
     fn rustc_features(&self) -> String {
         let mut features = String::new();
-        if self.config.use_jemalloc {
+        if self.config.rust.use_jemalloc {
             features.push_str(" jemalloc");
         }
         features
@@ -398,7 +398,7 @@ impl Build {
     /// Component directory that Cargo will produce output into (e.g.
     /// release/debug)
     fn cargo_dir(&self) -> &'static str {
-        if self.config.rust_optimize {"release"} else {"debug"}
+        if self.config.rust.optimize() {"release"} else {"debug"}
     }
 
     fn tools_dir(&self, compiler: Compiler) -> PathBuf {
@@ -650,7 +650,7 @@ impl Build {
     fn musl_root(&self, target: Interned<String>) -> Option<&Path> {
         self.config.target_config.get(&target)
             .and_then(|t| t.musl_root.as_ref())
-            .or(self.config.musl_root.as_ref())
+            .or(self.config.rust.musl_root.as_ref())
             .map(|p| &**p)
     }
 
@@ -731,7 +731,7 @@ impl Build {
     /// For example on nightly this returns "a.b.c-nightly", on beta it returns
     /// "a.b.c-beta.1" and on stable it just returns "a.b.c".
     fn release(&self, num: &str) -> String {
-        match &self.config.channel[..] {
+        match &self.config.rust.channel[..] {
             "stable" => num.to_string(),
             "beta" => if self.rust_info.is_git() {
                 format!("{}-beta.{}", num, self.beta_prerelease_version())
@@ -802,7 +802,7 @@ impl Build {
     /// For channels like beta/nightly it's just the channel name, otherwise
     /// it's the `num` provided.
     fn package_vers(&self, num: &str) -> String {
-        match &self.config.channel[..] {
+        match &self.config.rust.channel[..] {
             "stable" => num.to_string(),
             "beta" => "beta".to_string(),
             "nightly" => "nightly".to_string(),
@@ -863,7 +863,7 @@ impl Build {
     /// Returns whether unstable features should be enabled for the compiler
     /// we're building.
     fn unstable_features(&self) -> bool {
-        match &self.config.channel[..] {
+        match &self.config.rust.channel[..] {
             "stable" | "beta" => false,
             "nightly" | _ => true,
         }
@@ -890,7 +890,7 @@ impl Build {
     pub fn save_toolstate(&self, tool: &str, state: ToolState) {
         use std::io::{Seek, SeekFrom};
 
-        if let Some(ref path) = self.config.save_toolstates {
+        if let Some(ref path) = self.config.rust.save_toolstates {
             let mut file = t!(fs::OpenOptions::new()
                 .create(true)
                 .read(true)

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -703,7 +703,7 @@ impl Build {
     fn force_use_stage1(&self, compiler: Compiler, target: Interned<String>) -> bool {
         !self.config.general.full_bootstrap &&
             compiler.stage >= 2 &&
-            (self.config.hosts.iter().any(|h| *h == target) || target == self.config.build)
+            (self.config.general.host.iter().any(|h| *h == target) || target == self.config.build)
     }
 
     /// Returns the directory that OpenSSL artifacts are compiled into if

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -311,7 +311,7 @@ impl Build {
 
     pub fn build_triple(&self) -> &[Interned<String>] {
         unsafe {
-            slice::from_raw_parts(&self.config.build, 1)
+            slice::from_raw_parts(&self.config.general.build, 1)
         }
     }
 
@@ -481,7 +481,7 @@ impl Build {
         if let Some(s) = target_config.and_then(|c| c.llvm_config.as_ref()) {
             s.clone()
         } else {
-            self.llvm_out(self.config.build).join("bin")
+            self.llvm_out(self.config.general.build).join("bin")
                 .join(exe("llvm-config", &*target))
         }
     }
@@ -493,9 +493,9 @@ impl Build {
             let llvm_bindir = output(Command::new(s).arg("--bindir"));
             Path::new(llvm_bindir.trim()).join(exe("FileCheck", &*target))
         } else {
-            let base = self.llvm_out(self.config.build).join("build");
+            let base = self.llvm_out(self.config.general.build).join("build");
             let exe = exe("FileCheck", &*target);
-            if !self.config.llvm.ninja && self.config.build.contains("msvc") {
+            if !self.config.llvm.ninja && self.config.general.build.contains("msvc") {
                 base.join("Release/bin").join(exe)
             } else {
                 base.join("bin").join(exe)
@@ -524,7 +524,7 @@ impl Build {
     /// Returns the libdir of the snapshot compiler.
     fn rustc_snapshot_libdir(&self) -> PathBuf {
         self.config.general.initial_rustc.parent().unwrap().parent().unwrap()
-            .join(libdir(&self.config.build))
+            .join(libdir(&self.config.general.build))
     }
 
     /// Runs a command, printing out nice contextual information if it fails.
@@ -628,7 +628,7 @@ impl Build {
         if let Some(linker) = self.config.target_config.get(&target)
                                                        .and_then(|c| c.linker.as_ref()) {
             Some(linker)
-        } else if target != self.config.build &&
+        } else if target != self.config.general.build &&
                   !target.contains("msvc") && !target.contains("emscripten") {
             Some(self.cc(target))
         } else {
@@ -703,7 +703,7 @@ impl Build {
     fn force_use_stage1(&self, compiler: Compiler, target: Interned<String>) -> bool {
         !self.config.general.full_bootstrap &&
             compiler.stage >= 2 &&
-            (self.config.general.host.iter().any(|h| *h == target) || target == self.config.build)
+            (self.config.general.host.iter().any(|h| *h == target) || target == self.config.general.build)
     }
 
     /// Returns the directory that OpenSSL artifacts are compiled into if
@@ -933,7 +933,7 @@ impl<'a> Compiler {
 
     /// Returns whether this is a snapshot compiler for `build`'s configuration
     pub fn is_snapshot(&self, build: &Build) -> bool {
-        self.stage == 0 && self.host == build.config.build
+        self.stage == 0 && self.host == build.config.general.build
     }
 
     /// Returns if this compiler should be treated as a final stage one in the

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -273,6 +273,10 @@ pub enum Mode {
     /// Build librustc and compiler libraries, placing output in the "stageN-rustc" directory.
     Librustc,
 
+    /// Build the codegen backend, with the string being its name.
+    /// Output also goes into stageN-rustc.
+    CodegenBackend(Interned<String>),
+
     /// Build some tool, placing output in the "stageN-tools" directory.
     Tool,
 }
@@ -423,7 +427,7 @@ impl Build {
             Mode::Libstd => "-std",
             Mode::Libtest => "-test",
             Mode::Tool => "-tools",
-            Mode::Librustc => "-rustc",
+            Mode::Librustc | Mode::CodegenBackend(_) => "-rustc",
         };
         self.config
             .general

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -402,7 +402,7 @@ impl Build {
     }
 
     fn tools_dir(&self, compiler: Compiler) -> PathBuf {
-        let out = self.config.out.join(&*compiler.host)
+        let out = self.config.general.out.join(&*compiler.host)
             .join(format!("stage{}-tools-bin", compiler.stage));
         t!(fs::create_dir_all(&out));
         out
@@ -419,7 +419,7 @@ impl Build {
             Mode::Tool => "-tools",
             Mode::Librustc => "-rustc",
         };
-        self.config.out.join(&*compiler.host)
+        self.config.general.out.join(&*compiler.host)
                 .join(format!("stage{}{}", compiler.stage, suffix))
     }
 
@@ -438,28 +438,28 @@ impl Build {
     /// Note that if LLVM is configured externally then the directory returned
     /// will likely be empty.
     fn llvm_out(&self, target: Interned<String>) -> PathBuf {
-        self.config.out.join(&*target).join("llvm")
+        self.config.general.out.join(&*target).join("llvm")
     }
 
     fn emscripten_llvm_out(&self, target: Interned<String>) -> PathBuf {
-        self.config.out.join(&*target).join("llvm-emscripten")
+        self.config.general.out.join(&*target).join("llvm-emscripten")
     }
 
     /// Output directory for all documentation for a target
     fn doc_out(&self, target: Interned<String>) -> PathBuf {
-        self.config.out.join(&*target).join("doc")
+        self.config.general.out.join(&*target).join("doc")
     }
 
     /// Output directory for some generated md crate documentation for a target (temporary)
     fn md_doc_out(&self, target: Interned<String>) -> Interned<PathBuf> {
-        self.config.out.join(&*target).join("md-doc").intern()
+        self.config.general.out.join(&*target).join("md-doc").intern()
     }
 
     /// Output directory for all crate documentation for a target (temporary)
     ///
     /// The artifacts here are then copied into `doc_out` above.
     fn crate_doc_out(&self, target: Interned<String>) -> PathBuf {
-        self.config.out.join(&*target).join("crate-docs")
+        self.config.general.out.join(&*target).join("crate-docs")
     }
 
     /// Returns true if no custom `llvm-config` is set for the specified target.
@@ -505,7 +505,7 @@ impl Build {
 
     /// Directory for libraries built from C/C++ code and shared between stages.
     fn native_dir(&self, target: Interned<String>) -> PathBuf {
-        self.config.out.join(&*target).join("native")
+        self.config.general.out.join(&*target).join("native")
     }
 
     /// Root output directory for rust_test_helpers library compiled for
@@ -679,7 +679,7 @@ impl Build {
 
     /// Temporary directory that extended error information is emitted to.
     fn extended_error_dir(&self) -> PathBuf {
-        self.config.out.join("tmp/extended-error-metadata")
+        self.config.general.out.join("tmp/extended-error-metadata")
     }
 
     /// Tests whether the `compiler` compiling for `target` should be forced to
@@ -713,7 +713,7 @@ impl Build {
         if target.contains("windows") {
             None
         } else if self.config.general.openssl_static {
-            Some(self.config.out.join(&*target).join("openssl"))
+            Some(self.config.general.out.join(&*target).join("openssl"))
         } else {
             None
         }

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -222,7 +222,6 @@ pub struct Build {
     cargo_info: channel::GitInfo,
     rls_info: channel::GitInfo,
     rustfmt_info: channel::GitInfo,
-    local_rebuild: bool,
     fail_fast: bool,
     doc_tests: bool,
     verbosity: usize,
@@ -309,7 +308,6 @@ impl Build {
         let rustfmt_info = channel::GitInfo::new(&config, &config.src.join("src/tools/rustfmt"));
 
         Build {
-            local_rebuild: config.local_rebuild,
             fail_fast: config.cmd.fail_fast(),
             doc_tests: config.cmd.doc_tests(),
             verbosity: config.verbose,
@@ -357,17 +355,6 @@ impl Build {
         cc_detect::find(self);
         self.verbose("running sanity check");
         sanity::check(self);
-        // If local-rust is the same major.minor as the current version, then force a local-rebuild
-        let local_version_verbose = output(
-            Command::new(&self.config.initial_rustc).arg("--version").arg("--verbose"));
-        let local_release = local_version_verbose
-            .lines().filter(|x| x.starts_with("release:"))
-            .next().unwrap().trim_left_matches("release:").trim();
-        let my_version = channel::CFG_RELEASE_NUM;
-        if local_release.split('.').take(2).eq(my_version.split('.').take(2)) {
-            self.verbose(&format!("auto-detected local-rebuild {}", local_release));
-            self.local_rebuild = true;
-        }
         self.verbose("learning about cargo");
         metadata::build(self);
 

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -224,7 +224,6 @@ pub struct Build {
     rustfmt_info: channel::GitInfo,
     fail_fast: bool,
     doc_tests: bool,
-    verbosity: usize,
 
     // Probed tools at runtime
     lldb_version: Option<String>,
@@ -295,7 +294,6 @@ impl Build {
         Build {
             fail_fast: config.cmd.fail_fast(),
             doc_tests: config.cmd.doc_tests(),
-            verbosity: config.verbose,
 
             config,
 
@@ -562,11 +560,11 @@ impl Build {
     }
 
     pub fn is_verbose(&self) -> bool {
-        self.verbosity > 0
+        self.config.verbose > 0
     }
 
     pub fn is_very_verbose(&self) -> bool {
-        self.verbosity > 1
+        self.config.verbose > 1
     }
 
     /// Prints a message if this build is configured in verbose mode.

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -523,7 +523,7 @@ impl Build {
 
     /// Returns the libdir of the snapshot compiler.
     fn rustc_snapshot_libdir(&self) -> PathBuf {
-        self.config.initial_rustc.parent().unwrap().parent().unwrap()
+        self.config.general.initial_rustc.parent().unwrap().parent().unwrap()
             .join(libdir(&self.config.build))
     }
 

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -228,7 +228,6 @@ pub struct Build {
 
     // Targets for which to build.
     build: Interned<String>,
-    targets: Vec<Interned<String>>,
 
     // Probed tools at runtime
     lldb_version: Option<String>,
@@ -302,7 +301,6 @@ impl Build {
             verbosity: config.verbose,
 
             build: config.build,
-            targets: config.targets.clone(),
 
             config,
 

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -228,7 +228,6 @@ pub struct Build {
 
     // Targets for which to build.
     build: Interned<String>,
-    hosts: Vec<Interned<String>>,
     targets: Vec<Interned<String>>,
 
     // Probed tools at runtime
@@ -303,7 +302,6 @@ impl Build {
             verbosity: config.verbose,
 
             build: config.build,
-            hosts: config.hosts.clone(),
             targets: config.targets.clone(),
 
             config,
@@ -718,7 +716,7 @@ impl Build {
     fn force_use_stage1(&self, compiler: Compiler, target: Interned<String>) -> bool {
         !self.config.full_bootstrap &&
             compiler.stage >= 2 &&
-            (self.hosts.iter().any(|h| *h == target) || target == self.build)
+            (self.config.hosts.iter().any(|h| *h == target) || target == self.build)
     }
 
     /// Returns the directory that OpenSSL artifacts are compiled into if

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -175,7 +175,7 @@ mod job {
     use libc;
 
     pub unsafe fn setup(build: &mut ::Build) {
-        if build.config.low_priority {
+        if build.config.general.low_priority {
             libc::setpriority(libc::PRIO_PGRP as _, 0, 10);
         }
     }
@@ -377,7 +377,7 @@ impl Build {
         if self.config.rust.backtrace {
             features.push_str(" backtrace");
         }
-        if self.config.profiler {
+        if self.config.general.profiler {
             features.push_str(" profiler");
         }
         if self.config.rust.wasm_syscall {
@@ -556,11 +556,11 @@ impl Build {
     }
 
     pub fn is_verbose(&self) -> bool {
-        self.config.verbose > 0
+        self.config.verbose()
     }
 
     pub fn is_very_verbose(&self) -> bool {
-        self.config.verbose > 1
+        self.config.very_verbose()
     }
 
     /// Prints a message if this build is configured in verbose mode.
@@ -674,7 +674,7 @@ impl Build {
 
     /// Path to the python interpreter to use
     fn python(&self) -> &Path {
-        self.config.python.as_ref().unwrap()
+        self.config.general.python.as_ref().unwrap()
     }
 
     /// Temporary directory that extended error information is emitted to.
@@ -701,7 +701,7 @@ impl Build {
     /// When all of these conditions are met the build will lift artifacts from
     /// the previous stage forward.
     fn force_use_stage1(&self, compiler: Compiler, target: Interned<String>) -> bool {
-        !self.config.full_bootstrap &&
+        !self.config.general.full_bootstrap &&
             compiler.stage >= 2 &&
             (self.config.hosts.iter().any(|h| *h == target) || target == self.config.build)
     }
@@ -712,7 +712,7 @@ impl Build {
         // OpenSSL not used on Windows
         if target.contains("windows") {
             None
-        } else if self.config.openssl_static {
+        } else if self.config.general.openssl_static {
             Some(self.config.out.join(&*target).join("openssl"))
         } else {
             None
@@ -941,7 +941,7 @@ impl<'a> Compiler {
     /// This takes into account whether we're performing a full bootstrap or
     /// not; don't directly compare the stage with `2`!
     pub fn is_final_stage(&self, build: &Build) -> bool {
-        let final_stage = if build.config.full_bootstrap { 2 } else { 1 };
+        let final_stage = if build.config.general.full_bootstrap { 2 } else { 1 };
         self.stage >= final_stage
     }
 }

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -118,35 +118,35 @@
 
 #[macro_use]
 extern crate build_helper;
-#[macro_use]
-extern crate serde_derive;
-#[macro_use]
-extern crate lazy_static;
-extern crate serde_json;
-extern crate serde;
+extern crate cc;
 extern crate cmake;
 extern crate filetime;
-extern crate cc;
 extern crate getopts;
+#[macro_use]
+extern crate lazy_static;
 extern crate num_cpus;
-extern crate toml;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
 extern crate time;
+extern crate toml;
 
 #[cfg(unix)]
 extern crate libc;
 
-use std::cell::{RefCell, Cell};
-use std::collections::{HashSet, HashMap};
+use std::cell::{Cell, RefCell};
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::{self, File};
 use std::io::Read;
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 use std::process::{self, Command};
 use std::slice;
 
-use build_helper::{run_silent, run_suppressed, try_run_silent, try_run_suppressed, output, mtime};
+use build_helper::{mtime, output, run_silent, run_suppressed, try_run_silent, try_run_suppressed};
 
-use util::{exe, libdir, OutputFolder, CiEnv};
+use util::{exe, libdir, CiEnv, OutputFolder};
 
 mod cc_detect;
 mod channel;
@@ -184,13 +184,12 @@ mod job {
 
 #[cfg(not(any(unix, windows)))]
 mod job {
-    pub unsafe fn setup(_build: &mut ::Build) {
-    }
+    pub unsafe fn setup(_build: &mut ::Build) {}
 }
 
 pub use config::Config;
 use flags::Subcommand;
-use cache::{Interned, Intern};
+use cache::{Intern, Interned};
 use toolstate::ToolState;
 
 /// A structure representing a Rust compiler.
@@ -250,8 +249,7 @@ struct Crate {
 
 impl Crate {
     fn is_local(&self, build: &Build) -> bool {
-        self.path.starts_with(&build.config.src) &&
-        !self.path.to_string_lossy().ends_with("_shim")
+        self.path.starts_with(&build.config.src) && !self.path.to_string_lossy().ends_with("_shim")
     }
 
     fn local_path(&self, build: &Build) -> PathBuf {
@@ -310,9 +308,7 @@ impl Build {
     }
 
     pub fn build_triple(&self) -> &[Interned<String>] {
-        unsafe {
-            slice::from_raw_parts(&self.config.general.build, 1)
-        }
+        unsafe { slice::from_raw_parts(&self.config.general.build, 1) }
     }
 
     /// Executes the entire build, as configured by the flags and configuration.
@@ -337,7 +333,10 @@ impl Build {
         // Check for postponed failures from `test --no-fail-fast`.
         let failures = self.delayed_failures.borrow();
         if failures.len() > 0 {
-            println!("\n{} command(s) did not execute successfully:\n", failures.len());
+            println!(
+                "\n{} command(s) did not execute successfully:\n",
+                failures.len()
+            );
             for failure in failures.iter() {
                 println!("  - {}\n", failure);
             }
@@ -398,11 +397,18 @@ impl Build {
     /// Component directory that Cargo will produce output into (e.g.
     /// release/debug)
     fn cargo_dir(&self) -> &'static str {
-        if self.config.rust.optimize() {"release"} else {"debug"}
+        if self.config.rust.optimize() {
+            "release"
+        } else {
+            "debug"
+        }
     }
 
     fn tools_dir(&self, compiler: Compiler) -> PathBuf {
-        let out = self.config.general.out.join(&*compiler.host)
+        let out = self.config
+            .general
+            .out
+            .join(&*compiler.host)
             .join(format!("stage{}-tools-bin", compiler.stage));
         t!(fs::create_dir_all(&out));
         out
@@ -419,18 +425,20 @@ impl Build {
             Mode::Tool => "-tools",
             Mode::Librustc => "-rustc",
         };
-        self.config.general.out.join(&*compiler.host)
-                .join(format!("stage{}{}", compiler.stage, suffix))
+        self.config
+            .general
+            .out
+            .join(&*compiler.host)
+            .join(format!("stage{}{}", compiler.stage, suffix))
     }
 
     /// Returns the root output directory for all Cargo output in a given stage,
     /// running a particular compiler, whether or not we're building the
     /// standard library, and targeting the specified architecture.
-    fn cargo_out(&self,
-                 compiler: Compiler,
-                 mode: Mode,
-                 target: Interned<String>) -> PathBuf {
-        self.stage_out(compiler, mode).join(&*target).join(self.cargo_dir())
+    fn cargo_out(&self, compiler: Compiler, mode: Mode, target: Interned<String>) -> PathBuf {
+        self.stage_out(compiler, mode)
+            .join(&*target)
+            .join(self.cargo_dir())
     }
 
     /// Root output directory for LLVM compiled for `target`
@@ -442,7 +450,11 @@ impl Build {
     }
 
     fn emscripten_llvm_out(&self, target: Interned<String>) -> PathBuf {
-        self.config.general.out.join(&*target).join("llvm-emscripten")
+        self.config
+            .general
+            .out
+            .join(&*target)
+            .join("llvm-emscripten")
     }
 
     /// Output directory for all documentation for a target
@@ -452,7 +464,12 @@ impl Build {
 
     /// Output directory for some generated md crate documentation for a target (temporary)
     fn md_doc_out(&self, target: Interned<String>) -> Interned<PathBuf> {
-        self.config.general.out.join(&*target).join("md-doc").intern()
+        self.config
+            .general
+            .out
+            .join(&*target)
+            .join("md-doc")
+            .intern()
     }
 
     /// Output directory for all crate documentation for a target (temporary)
@@ -468,7 +485,7 @@ impl Build {
     fn is_rust_llvm(&self, target: Interned<String>) -> bool {
         match self.config.target_config.get(&target) {
             Some(ref c) => c.llvm_config.is_none(),
-            None => true
+            None => true,
         }
     }
 
@@ -481,7 +498,8 @@ impl Build {
         if let Some(s) = target_config.and_then(|c| c.llvm_config.as_ref()) {
             s.clone()
         } else {
-            self.llvm_out(self.config.general.build).join("bin")
+            self.llvm_out(self.config.general.build)
+                .join("bin")
                 .join(exe("llvm-config", &*target))
         }
     }
@@ -523,7 +541,13 @@ impl Build {
 
     /// Returns the libdir of the snapshot compiler.
     fn rustc_snapshot_libdir(&self) -> PathBuf {
-        self.config.general.initial_rustc.parent().unwrap().parent().unwrap()
+        self.config
+            .general
+            .initial_rustc
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
             .join(libdir(&self.config.general.build))
     }
 
@@ -586,10 +610,12 @@ impl Build {
     fn cflags(&self, target: Interned<String>) -> Vec<String> {
         // Filter out -O and /O (the optimization flags) that we picked up from
         // cc-rs because the build scripts will determine that for themselves.
-        let mut base = self.cc[&target].args().iter()
-                           .map(|s| s.to_string_lossy().into_owned())
-                           .filter(|s| !s.starts_with("-O") && !s.starts_with("/O"))
-                           .collect::<Vec<_>>();
+        let mut base = self.cc[&target]
+            .args()
+            .iter()
+            .map(|s| s.to_string_lossy().into_owned())
+            .filter(|s| !s.starts_with("-O") && !s.starts_with("/O"))
+            .collect::<Vec<_>>();
 
         // If we're compiling on macOS then we add a few unconditional flags
         // indicating that we want libc++ (more filled out than libstdc++) and
@@ -618,18 +644,23 @@ impl Build {
         match self.cxx.get(&target) {
             Some(p) => Ok(p.path()),
             None => Err(format!(
-                    "target `{}` is not configured as a host, only as a target",
-                    target))
+                "target `{}` is not configured as a host, only as a target",
+                target
+            )),
         }
     }
 
     /// Returns the path to the linker for the given target if it needs to be overridden.
     fn linker(&self, target: Interned<String>) -> Option<&Path> {
-        if let Some(linker) = self.config.target_config.get(&target)
-                                                       .and_then(|c| c.linker.as_ref()) {
+        if let Some(linker) = self.config
+            .target_config
+            .get(&target)
+            .and_then(|c| c.linker.as_ref())
+        {
             Some(linker)
-        } else if target != self.config.general.build &&
-                  !target.contains("msvc") && !target.contains("emscripten") {
+        } else if target != self.config.general.build && !target.contains("msvc")
+            && !target.contains("emscripten")
+        {
             Some(self.cc(target))
         } else {
             None
@@ -641,14 +672,18 @@ impl Build {
         if target.contains("pc-windows-msvc") {
             Some(true)
         } else {
-            self.config.target_config.get(&target)
+            self.config
+                .target_config
+                .get(&target)
                 .and_then(|t| t.crt_static)
         }
     }
 
     /// Returns the "musl root" for this `target`, if defined
     fn musl_root(&self, target: Interned<String>) -> Option<&Path> {
-        self.config.target_config.get(&target)
+        self.config
+            .target_config
+            .get(&target)
             .and_then(|t| t.musl_root.as_ref())
             .or(self.config.rust.musl_root.as_ref())
             .map(|p| &**p)
@@ -657,8 +692,8 @@ impl Build {
     /// Returns whether the target will be tested using the `remote-test-client`
     /// and `remote-test-server` binaries.
     fn remote_tested(&self, target: Interned<String>) -> bool {
-        self.qemu_rootfs(target).is_some() || target.contains("android") ||
-        env::var_os("TEST_DEVICE_ADDR").is_some()
+        self.qemu_rootfs(target).is_some() || target.contains("android")
+            || env::var_os("TEST_DEVICE_ADDR").is_some()
     }
 
     /// Returns the root of the "rootfs" image that this target will be using,
@@ -667,7 +702,9 @@ impl Build {
     /// If `Some` is returned then that means that tests for this target are
     /// emulated with QEMU and binaries will need to be shipped to the emulator.
     fn qemu_rootfs(&self, target: Interned<String>) -> Option<&Path> {
-        self.config.target_config.get(&target)
+        self.config
+            .target_config
+            .get(&target)
             .and_then(|t| t.qemu_rootfs.as_ref())
             .map(|p| &**p)
     }
@@ -701,9 +738,9 @@ impl Build {
     /// When all of these conditions are met the build will lift artifacts from
     /// the previous stage forward.
     fn force_use_stage1(&self, compiler: Compiler, target: Interned<String>) -> bool {
-        !self.config.general.full_bootstrap &&
-            compiler.stage >= 2 &&
-            (self.config.general.host.iter().any(|h| *h == target) || target == self.config.general.build)
+        !self.config.general.full_bootstrap && compiler.stage >= 2
+            && (self.config.general.host.iter().any(|h| *h == target)
+                || target == self.config.general.build)
     }
 
     /// Returns the directory that OpenSSL artifacts are compiled into if
@@ -745,7 +782,7 @@ impl Build {
 
     fn beta_prerelease_version(&self) -> u32 {
         if let Some(s) = self.prerelease_version.get() {
-            return s
+            return s;
         }
 
         let beta = output(
@@ -753,7 +790,7 @@ impl Build {
                 .arg("ls-remote")
                 .arg("origin")
                 .arg("beta")
-                .current_dir(&self.config.src)
+                .current_dir(&self.config.src),
         );
         let beta = beta.trim().split_whitespace().next().unwrap();
         let master = output(
@@ -761,7 +798,7 @@ impl Build {
                 .arg("ls-remote")
                 .arg("origin")
                 .arg("master")
-                .current_dir(&self.config.src)
+                .current_dir(&self.config.src),
         );
         let master = master.trim().split_whitespace().next().unwrap();
 
@@ -847,13 +884,15 @@ impl Build {
     /// Returns the `a.b.c` version that the given package is at.
     fn release_num(&self, package: &str) -> String {
         let mut toml = String::new();
-        let toml_file_name = self.config.src.join(&format!("src/tools/{}/Cargo.toml", package));
+        let toml_file_name = self.config
+            .src
+            .join(&format!("src/tools/{}/Cargo.toml", package));
         t!(t!(File::open(toml_file_name)).read_to_string(&mut toml));
         for line in toml.lines() {
             let prefix = "version = \"";
             let suffix = "\"";
             if line.starts_with(prefix) && line.ends_with(suffix) {
-                return line[prefix.len()..line.len() - suffix.len()].to_string()
+                return line[prefix.len()..line.len() - suffix.len()].to_string();
             }
         }
 
@@ -873,7 +912,9 @@ impl Build {
     /// ends when the returned object is dropped. Folding can only be used in
     /// the Travis CI environment.
     pub fn fold_output<D, F>(&self, name: F) -> Option<OutputFolder>
-        where D: Into<String>, F: FnOnce() -> D
+    where
+        D: Into<String>,
+        F: FnOnce() -> D,
     {
         if self.ci_env == CiEnv::Travis {
             Some(OutputFolder::new(name().into()))
@@ -941,7 +982,11 @@ impl<'a> Compiler {
     /// This takes into account whether we're performing a full bootstrap or
     /// not; don't directly compare the stage with `2`!
     pub fn is_final_stage(&self, build: &Build) -> bool {
-        let final_stage = if build.config.general.full_bootstrap { 2 } else { 1 };
+        let final_stage = if build.config.general.full_bootstrap {
+            2
+        } else {
+            1
+        };
         self.stage >= final_stage
     }
 }

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -242,7 +242,6 @@ pub struct Build {
     ar: HashMap<Interned<String>, PathBuf>,
     // Misc
     crates: HashMap<Interned<String>, Crate>,
-    is_sudo: bool,
     ci_env: CiEnv,
     delayed_failures: RefCell<Vec<String>>,
     prerelease_version: Cell<Option<u32>>,
@@ -293,15 +292,6 @@ impl Build {
     ///
     /// By default all build output will be placed in the current directory.
     pub fn new(config: Config) -> Build {
-        let is_sudo = match env::var_os("SUDO_USER") {
-            Some(sudo_user) => {
-                match env::var_os("USER") {
-                    Some(user) => user != sudo_user,
-                    None => false,
-                }
-            }
-            None => false,
-        };
         let rust_info = channel::GitInfo::new(&config, &config.src);
         let cargo_info = channel::GitInfo::new(&config, &config.src.join("src/tools/cargo"));
         let rls_info = channel::GitInfo::new(&config, &config.src.join("src/tools/rls"));
@@ -328,7 +318,6 @@ impl Build {
             crates: HashMap::new(),
             lldb_version: None,
             lldb_python_dir: None,
-            is_sudo,
             ci_env: CiEnv::current(),
             delayed_failures: RefCell::new(Vec::new()),
             prerelease_version: Cell::new(None),

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -222,7 +222,6 @@ pub struct Build {
     cargo_info: channel::GitInfo,
     rls_info: channel::GitInfo,
     rustfmt_info: channel::GitInfo,
-    fail_fast: bool,
     doc_tests: bool,
 
     // Probed tools at runtime
@@ -292,7 +291,6 @@ impl Build {
         let rustfmt_info = channel::GitInfo::new(&config, &config.src.join("src/tools/rustfmt"));
 
         Build {
-            fail_fast: config.cmd.fail_fast(),
             doc_tests: config.cmd.doc_tests(),
 
             config,

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -232,10 +232,6 @@ pub struct Build {
     hosts: Vec<Interned<String>>,
     targets: Vec<Interned<String>>,
 
-    // Stage 0 (downloaded) compiler and cargo or their local rust equivalents.
-    initial_rustc: PathBuf,
-    initial_cargo: PathBuf,
-
     // Probed tools at runtime
     lldb_version: Option<String>,
     lldb_python_dir: Option<String>,
@@ -313,8 +309,6 @@ impl Build {
         let rustfmt_info = channel::GitInfo::new(&config, &config.src.join("src/tools/rustfmt"));
 
         Build {
-            initial_rustc: config.initial_rustc.clone(),
-            initial_cargo: config.initial_cargo.clone(),
             local_rebuild: config.local_rebuild,
             fail_fast: config.cmd.fail_fast(),
             doc_tests: config.cmd.doc_tests(),
@@ -365,7 +359,7 @@ impl Build {
         sanity::check(self);
         // If local-rust is the same major.minor as the current version, then force a local-rebuild
         let local_version_verbose = output(
-            Command::new(&self.initial_rustc).arg("--version").arg("--verbose"));
+            Command::new(&self.config.initial_rustc).arg("--version").arg("--verbose"));
         let local_release = local_version_verbose
             .lines().filter(|x| x.starts_with("release:"))
             .next().unwrap().trim_left_matches("release:").trim();
@@ -568,7 +562,7 @@ impl Build {
 
     /// Returns the libdir of the snapshot compiler.
     fn rustc_snapshot_libdir(&self) -> PathBuf {
-        self.initial_rustc.parent().unwrap().parent().unwrap()
+        self.config.initial_rustc.parent().unwrap().parent().unwrap()
             .join(libdir(&self.config.build))
     }
 

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -189,7 +189,7 @@ mod job {
 
 pub use config::Config;
 use flags::Subcommand;
-use cache::{Interned, INTERNER};
+use cache::{Interned, Intern};
 use toolstate::ToolState;
 
 /// A structure representing a Rust compiler.
@@ -452,7 +452,7 @@ impl Build {
 
     /// Output directory for some generated md crate documentation for a target (temporary)
     fn md_doc_out(&self, target: Interned<String>) -> Interned<PathBuf> {
-        INTERNER.intern_path(self.config.out.join(&*target).join("md-doc"))
+        self.config.out.join(&*target).join("md-doc").intern()
     }
 
     /// Output directory for all crate documentation for a target (temporary)
@@ -908,7 +908,7 @@ impl Build {
 
     fn in_tree_crates(&self, root: &str) -> Vec<&Crate> {
         let mut ret = Vec::new();
-        let mut list = vec![INTERNER.intern_str(root)];
+        let mut list = vec![root.intern()];
         let mut visited = HashSet::new();
         while let Some(krate) = list.pop() {
             let krate = &self.crates[&krate];

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -214,7 +214,6 @@ pub struct Compiler {
 /// although most functions are implemented as free functions rather than
 /// methods specifically on this structure itself (to make it easier to
 /// organize).
-#[derive(Default)]
 pub struct Build {
     // User-specified configuration via config.toml
     config: Config,

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -498,7 +498,7 @@ impl Build {
         } else {
             let base = self.llvm_out(self.config.build).join("build");
             let exe = exe("FileCheck", &*target);
-            if !self.config.ninja && self.config.build.contains("msvc") {
+            if !self.config.llvm.ninja && self.config.build.contains("msvc") {
                 base.join("Release/bin").join(exe)
             } else {
                 base.join("bin").join(exe)

--- a/src/bootstrap/metadata.rs
+++ b/src/bootstrap/metadata.rs
@@ -16,7 +16,7 @@ use build_helper::output;
 use serde_json;
 
 use {Build, Crate};
-use cache::INTERNER;
+use cache::Intern;
 
 #[derive(Deserialize)]
 struct Output {
@@ -60,7 +60,7 @@ fn build_krate(build: &mut Build, krate: &str) {
     let mut id2name = HashMap::new();
     for package in output.packages {
         if package.source.is_none() {
-            let name = INTERNER.intern_string(package.name);
+            let name = package.name.intern();
             id2name.insert(package.id, name);
             let mut path = PathBuf::from(package.manifest_path);
             path.pop();

--- a/src/bootstrap/metadata.rs
+++ b/src/bootstrap/metadata.rs
@@ -51,12 +51,6 @@ pub fn build(build: &mut Build) {
 }
 
 fn build_krate(build: &mut Build, krate: &str) {
-    // Run `cargo metadata` to figure out what crates we're testing.
-    //
-    // Down below we're going to call `cargo test`, but to test the right set
-    // of packages we're going to have to know what `-p` arguments to pass it
-    // to know what crates to test. Here we run `cargo metadata` to learn about
-    // the dependency graph and what `-p` arguments there are.
     let mut cargo = Command::new(&build.initial_cargo);
     cargo.arg("metadata")
          .arg("--format-version").arg("1")
@@ -71,10 +65,6 @@ fn build_krate(build: &mut Build, krate: &str) {
             let mut path = PathBuf::from(package.manifest_path);
             path.pop();
             build.crates.insert(name, Crate {
-                build_step: format!("build-crate-{}", name),
-                doc_step: format!("doc-crate-{}", name),
-                test_step: format!("test-crate-{}", name),
-                bench_step: format!("bench-crate-{}", name),
                 name,
                 version: package.version,
                 deps: Vec::new(),

--- a/src/bootstrap/metadata.rs
+++ b/src/bootstrap/metadata.rs
@@ -52,9 +52,12 @@ pub fn build(build: &mut Build) {
 
 fn build_krate(build: &mut Build, krate: &str) {
     let mut cargo = Command::new(&build.config.general.initial_cargo);
-    cargo.arg("metadata")
-         .arg("--format-version").arg("1")
-         .arg("--manifest-path").arg(build.config.src.join(krate).join("Cargo.toml"));
+    cargo
+        .arg("metadata")
+        .arg("--format-version")
+        .arg("1")
+        .arg("--manifest-path")
+        .arg(build.config.src.join(krate).join("Cargo.toml"));
     let output = output(&mut cargo);
     let output: Output = serde_json::from_str(&output).unwrap();
     let mut id2name = HashMap::new();
@@ -64,12 +67,15 @@ fn build_krate(build: &mut Build, krate: &str) {
             id2name.insert(package.id, name);
             let mut path = PathBuf::from(package.manifest_path);
             path.pop();
-            build.crates.insert(name, Crate {
+            build.crates.insert(
                 name,
-                version: package.version,
-                deps: Vec::new(),
-                path,
-            });
+                Crate {
+                    name,
+                    version: package.version,
+                    deps: Vec::new(),
+                    path,
+                },
+            );
         }
     }
 

--- a/src/bootstrap/metadata.rs
+++ b/src/bootstrap/metadata.rs
@@ -51,7 +51,7 @@ pub fn build(build: &mut Build) {
 }
 
 fn build_krate(build: &mut Build, krate: &str) {
-    let mut cargo = Command::new(&build.initial_cargo);
+    let mut cargo = Command::new(&build.config.initial_cargo);
     cargo.arg("metadata")
          .arg("--format-version").arg("1")
          .arg("--manifest-path").arg(build.config.src.join(krate).join("Cargo.toml"));

--- a/src/bootstrap/metadata.rs
+++ b/src/bootstrap/metadata.rs
@@ -51,7 +51,7 @@ pub fn build(build: &mut Build) {
 }
 
 fn build_krate(build: &mut Build, krate: &str) {
-    let mut cargo = Command::new(&build.config.initial_cargo);
+    let mut cargo = Command::new(&build.config.general.initial_cargo);
     cargo.arg("metadata")
          .arg("--format-version").arg("1")
          .arg("--manifest-path").arg(build.config.src.join(krate).join("Cargo.toml"));

--- a/src/bootstrap/metadata.rs
+++ b/src/bootstrap/metadata.rs
@@ -54,7 +54,7 @@ fn build_krate(build: &mut Build, krate: &str) {
     let mut cargo = Command::new(&build.initial_cargo);
     cargo.arg("metadata")
          .arg("--format-version").arg("1")
-         .arg("--manifest-path").arg(build.src.join(krate).join("Cargo.toml"));
+         .arg("--manifest-path").arg(build.config.src.join(krate).join("Cargo.toml"));
     let output = output(&mut cargo);
     let output: Output = serde_json::from_str(&output).unwrap();
     let mut id2name = HashMap::new();

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -75,7 +75,7 @@ impl Step for Llvm {
             }
         }
 
-        let rebuild_trigger = build.src.join("src/rustllvm/llvm-rebuild-trigger");
+        let rebuild_trigger = build.config.src.join("src/rustllvm/llvm-rebuild-trigger");
         let mut rebuild_trigger_contents = String::new();
         t!(t!(File::open(&rebuild_trigger)).read_to_string(&mut rebuild_trigger_contents));
 
@@ -109,7 +109,7 @@ impl Step for Llvm {
 
         // http://llvm.org/docs/CMake.html
         let root = if self.emscripten { "src/llvm-emscripten" } else { "src/llvm" };
-        let mut cfg = cmake::Config::new(build.src.join(root));
+        let mut cfg = cmake::Config::new(build.config.src.join(root));
         if build.config.ninja {
             cfg.generator("Ninja");
         }
@@ -326,7 +326,7 @@ impl Step for TestHelpers {
         let build = builder.build;
         let target = self.target;
         let dst = build.test_helpers_out(target);
-        let src = build.src.join("src/test/auxiliary/rust_test_helpers.c");
+        let src = build.config.src.join("src/test/auxiliary/rust_test_helpers.c");
         if up_to_date(&src, &dst.join("librust_test_helpers.a")) {
             return
         }
@@ -353,7 +353,7 @@ impl Step for TestHelpers {
            .opt_level(0)
            .warnings(false)
            .debug(false)
-           .file(build.src.join("src/test/auxiliary/rust_test_helpers.c"))
+           .file(build.config.src.join("src/test/auxiliary/rust_test_helpers.c"))
            .compile("rust_test_helpers");
     }
 }

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -53,7 +53,7 @@ impl Step for Llvm {
     fn make_run(run: RunConfig) {
         let emscripten = run.path.ends_with("llvm-emscripten");
         run.builder.ensure(Llvm {
-            target: run.target,
+            target: run.host,
             emscripten,
         });
     }

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -20,7 +20,6 @@
 
 use std::env;
 use std::ffi::OsString;
-use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -29,6 +28,7 @@ use build_helper::output;
 use cmake;
 use cc;
 
+use fs::{self, File};
 use util::{self, exe};
 use build_helper::up_to_date;
 use builder::{Builder, RunConfig, ShouldRun, Step};
@@ -55,6 +55,10 @@ impl Step for Llvm {
             target: run.host,
             emscripten,
         });
+    }
+
+    fn for_test(self, _builder: &Builder) -> PathBuf {
+        PathBuf::from("llvm-config-for-test")
     }
 
     /// Compile LLVM for `target`.
@@ -335,6 +339,8 @@ impl Step for TestHelpers {
         run.path("src/test/auxiliary/rust_test_helpers.c")
     }
 
+    fn for_test(self, _builder: &Builder) {}
+
     fn make_run(run: RunConfig) {
         run.builder.ensure(TestHelpers { target: run.target })
     }
@@ -391,6 +397,8 @@ impl Step for Openssl {
     fn should_run(run: ShouldRun) -> ShouldRun {
         run.never()
     }
+
+    fn for_test(self, _builder: &Builder) {}
 
     fn run(self, builder: &Builder) {
         let target = self.target;

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -70,7 +70,7 @@ impl Step for Llvm {
             if let Some(config) = build.config.target_config.get(&target) {
                 if let Some(ref s) = config.llvm_config {
                     check_llvm_version(build, s);
-                    return s.to_path_buf()
+                    return s.to_path_buf();
                 }
             }
         }
@@ -84,12 +84,14 @@ impl Step for Llvm {
             let config_dir = dir.join("bin");
             (dir, config_dir)
         } else {
-            (build.llvm_out(target),
-                build.llvm_out(build.config.general.build).join("bin"))
+            (
+                build.llvm_out(target),
+                build.llvm_out(build.config.general.build).join("bin"),
+            )
         };
         let done_stamp = out_dir.join("llvm-finished-building");
-        let build_llvm_config = llvm_config_ret_dir
-            .join(exe("llvm-config", &*build.config.general.build));
+        let build_llvm_config =
+            llvm_config_ret_dir.join(exe("llvm-config", &*build.config.general.build));
         if done_stamp.exists() {
             let mut done_contents = String::new();
             t!(t!(File::open(&done_stamp)).read_to_string(&mut done_contents));
@@ -97,7 +99,7 @@ impl Step for Llvm {
             // If LLVM was already built previously and contents of the rebuild-trigger file
             // didn't change from the previous build, then no action is required.
             if done_contents == rebuild_trigger_contents {
-                return build_llvm_config
+                return build_llvm_config;
             }
         }
 
@@ -108,13 +110,20 @@ impl Step for Llvm {
         t!(fs::create_dir_all(&out_dir));
 
         // http://llvm.org/docs/CMake.html
-        let root = if self.emscripten { "src/llvm-emscripten" } else { "src/llvm" };
+        let root = if self.emscripten {
+            "src/llvm-emscripten"
+        } else {
+            "src/llvm"
+        };
         let mut cfg = cmake::Config::new(build.config.src.join(root));
         if build.config.llvm.ninja {
             cfg.generator("Ninja");
         }
 
-        let profile = match (build.config.llvm.optimize, build.config.llvm.release_debuginfo) {
+        let profile = match (
+            build.config.llvm.optimize,
+            build.config.llvm.release_debuginfo,
+        ) {
             (false, _) => "Debug",
             (true, false) => "Release",
             (true, true) => "RelWithDebInfo",
@@ -134,25 +143,29 @@ impl Step for Llvm {
             &build.config.llvm.experimental_targets[..]
         };
 
-        let assertions = if build.config.llvm.assertions {"ON"} else {"OFF"};
+        let assertions = if build.config.llvm.assertions {
+            "ON"
+        } else {
+            "OFF"
+        };
 
         cfg.target(&target)
-           .host(&build.config.general.build)
-           .out_dir(&out_dir)
-           .profile(profile)
-           .define("LLVM_ENABLE_ASSERTIONS", assertions)
-           .define("LLVM_TARGETS_TO_BUILD", llvm_targets)
-           .define("LLVM_EXPERIMENTAL_TARGETS_TO_BUILD", llvm_exp_targets)
-           .define("LLVM_INCLUDE_EXAMPLES", "OFF")
-           .define("LLVM_INCLUDE_TESTS", "OFF")
-           .define("LLVM_INCLUDE_DOCS", "OFF")
-           .define("LLVM_ENABLE_ZLIB", "OFF")
-           .define("WITH_POLLY", "OFF")
-           .define("LLVM_ENABLE_TERMINFO", "OFF")
-           .define("LLVM_ENABLE_LIBEDIT", "OFF")
-           .define("LLVM_PARALLEL_COMPILE_JOBS", build.jobs().to_string())
-           .define("LLVM_TARGET_ARCH", target.split('-').next().unwrap())
-           .define("LLVM_DEFAULT_TARGET_TRIPLE", target);
+            .host(&build.config.general.build)
+            .out_dir(&out_dir)
+            .profile(profile)
+            .define("LLVM_ENABLE_ASSERTIONS", assertions)
+            .define("LLVM_TARGETS_TO_BUILD", llvm_targets)
+            .define("LLVM_EXPERIMENTAL_TARGETS_TO_BUILD", llvm_exp_targets)
+            .define("LLVM_INCLUDE_EXAMPLES", "OFF")
+            .define("LLVM_INCLUDE_TESTS", "OFF")
+            .define("LLVM_INCLUDE_DOCS", "OFF")
+            .define("LLVM_ENABLE_ZLIB", "OFF")
+            .define("WITH_POLLY", "OFF")
+            .define("LLVM_ENABLE_TERMINFO", "OFF")
+            .define("LLVM_ENABLE_LIBEDIT", "OFF")
+            .define("LLVM_PARALLEL_COMPILE_JOBS", build.jobs().to_string())
+            .define("LLVM_TARGET_ARCH", target.split('-').next().unwrap())
+            .define("LLVM_DEFAULT_TARGET_TRIPLE", target);
 
         // By default, LLVM will automatically find OCaml and, if it finds it,
         // install the LLVM bindings in LLVM_OCAML_INSTALL_PATH, which defaults
@@ -160,15 +173,17 @@ impl Step for Llvm {
         // This causes problem for non-root builds of Rust. Side-step the issue
         // by setting LLVM_OCAML_INSTALL_PATH to a relative path, so it installs
         // in the prefix.
-        cfg.define("LLVM_OCAML_INSTALL_PATH",
-            env::var_os("LLVM_OCAML_INSTALL_PATH").unwrap_or_else(|| "usr/lib/ocaml".into()));
+        cfg.define(
+            "LLVM_OCAML_INSTALL_PATH",
+            env::var_os("LLVM_OCAML_INSTALL_PATH").unwrap_or_else(|| "usr/lib/ocaml".into()),
+        );
 
         // This setting makes the LLVM tools link to the dynamic LLVM library,
         // which saves both memory during parallel links and overall disk space
         // for the tools.  We don't distribute any of those tools, so this is
         // just a local concern.  However, it doesn't work well everywhere.
         if target.contains("linux-gnu") || target.contains("apple-darwin") {
-           cfg.define("LLVM_LINK_LLVM_DYLIB", "ON");
+            cfg.define("LLVM_LINK_LLVM_DYLIB", "ON");
         }
 
         if target.contains("msvc") {
@@ -183,7 +198,10 @@ impl Step for Llvm {
         }
 
         if build.config.llvm.link_jobs > 0 {
-            cfg.define("LLVM_PARALLEL_LINK_JOBS", build.config.llvm.link_jobs.to_string());
+            cfg.define(
+                "LLVM_PARALLEL_LINK_JOBS",
+                build.config.llvm.link_jobs.to_string(),
+            );
         }
 
         // http://llvm.org/docs/HowToCrossCompileLLVM.html
@@ -195,17 +213,22 @@ impl Step for Llvm {
             // FIXME: if the llvm root for the build triple is overridden then we
             //        should use llvm-tblgen from there, also should verify that it
             //        actually exists most of the time in normal installs of LLVM.
-            let host = build.llvm_out(build.config.general.build).join("bin/llvm-tblgen");
+            let host = build
+                .llvm_out(build.config.general.build)
+                .join("bin/llvm-tblgen");
             cfg.define("CMAKE_CROSSCOMPILING", "True")
-               .define("LLVM_TABLEGEN", &host);
+                .define("LLVM_TABLEGEN", &host);
 
             if target.contains("netbsd") {
-               cfg.define("CMAKE_SYSTEM_NAME", "NetBSD");
+                cfg.define("CMAKE_SYSTEM_NAME", "NetBSD");
             } else if target.contains("freebsd") {
-               cfg.define("CMAKE_SYSTEM_NAME", "FreeBSD");
+                cfg.define("CMAKE_SYSTEM_NAME", "FreeBSD");
             }
 
-            cfg.define("LLVM_NATIVE_BUILD", build.llvm_out(build.config.general.build).join("build"));
+            cfg.define(
+                "LLVM_NATIVE_BUILD",
+                build.llvm_out(build.config.general.build).join("build"),
+            );
         }
 
         let sanitize_cc = |cc: &Path| {
@@ -221,35 +244,34 @@ impl Step for Llvm {
             // vars that we'd otherwise configure. In that case we just skip this
             // entirely.
             if target.contains("msvc") && !build.config.llvm.ninja {
-                return
+                return;
             }
 
             let cc = build.cc(target);
             let cxx = build.cxx(target).unwrap();
 
             // Handle msvc + ninja + ccache specially (this is what the bots use)
-            if target.contains("msvc") &&
-               build.config.llvm.ninja &&
-               build.config.llvm.ccache().is_some() {
+            if target.contains("msvc") && build.config.llvm.ninja
+                && build.config.llvm.ccache().is_some()
+            {
                 let mut cc = env::current_exe().expect("failed to get cwd");
                 cc.set_file_name("sccache-plus-cl.exe");
 
-               cfg.define("CMAKE_C_COMPILER", sanitize_cc(&cc))
-                  .define("CMAKE_CXX_COMPILER", sanitize_cc(&cc));
-               cfg.env("SCCACHE_PATH",
-                       build.config.llvm.ccache().as_ref().unwrap())
-                  .env("SCCACHE_TARGET", target);
+                cfg.define("CMAKE_C_COMPILER", sanitize_cc(&cc))
+                    .define("CMAKE_CXX_COMPILER", sanitize_cc(&cc));
+                cfg.env("SCCACHE_PATH", build.config.llvm.ccache().as_ref().unwrap())
+                    .env("SCCACHE_TARGET", target);
 
             // If ccache is configured we inform the build a little differently hwo
             // to invoke ccache while also invoking our compilers.
             } else if let Some(ref ccache) = build.config.llvm.ccache() {
-               cfg.define("CMAKE_C_COMPILER", ccache)
-                  .define("CMAKE_C_COMPILER_ARG1", sanitize_cc(cc))
-                  .define("CMAKE_CXX_COMPILER", ccache)
-                  .define("CMAKE_CXX_COMPILER_ARG1", sanitize_cc(cxx));
+                cfg.define("CMAKE_C_COMPILER", ccache)
+                    .define("CMAKE_C_COMPILER_ARG1", sanitize_cc(cc))
+                    .define("CMAKE_CXX_COMPILER", ccache)
+                    .define("CMAKE_CXX_COMPILER_ARG1", sanitize_cc(cxx));
             } else {
-               cfg.define("CMAKE_C_COMPILER", sanitize_cc(cc))
-                  .define("CMAKE_CXX_COMPILER", sanitize_cc(cxx));
+                cfg.define("CMAKE_C_COMPILER", sanitize_cc(cc))
+                    .define("CMAKE_CXX_COMPILER", sanitize_cc(cxx));
             }
 
             cfg.build_arg("-j").build_arg(build.jobs().to_string());
@@ -284,16 +306,18 @@ impl Step for Llvm {
 
 fn check_llvm_version(build: &Build, llvm_config: &Path) {
     if !build.config.llvm.version_check {
-        return
+        return;
     }
 
     let mut cmd = Command::new(llvm_config);
     let version = output(cmd.arg("--version"));
-    let mut parts = version.split('.').take(2)
+    let mut parts = version
+        .split('.')
+        .take(2)
         .filter_map(|s| s.parse::<u32>().ok());
     if let (Some(major), Some(minor)) = (parts.next(), parts.next()) {
         if major > 3 || (major == 3 && minor >= 9) {
-            return
+            return;
         }
     }
     panic!("\n\nbad LLVM version: {}, need >=3.9\n\n", version)
@@ -323,7 +347,7 @@ impl Step for TestHelpers {
         let dst = build.test_helpers_out(target);
         let src = build.config.src.join("src/test/auxiliary/rust_test_helpers.c");
         if up_to_date(&src, &dst.join("librust_test_helpers.a")) {
-            return
+            return;
         }
 
         let _folder = build.fold_output(|| "build_test_helpers");
@@ -342,14 +366,14 @@ impl Step for TestHelpers {
         }
 
         cfg.cargo_metadata(false)
-           .out_dir(&dst)
-           .target(&target)
-           .host(&build.config.general.build)
-           .opt_level(0)
-           .warnings(false)
-           .debug(false)
-           .file(build.config.src.join("src/test/auxiliary/rust_test_helpers.c"))
-           .compile("rust_test_helpers");
+            .out_dir(&dst)
+            .target(&target)
+            .host(&build.config.general.build)
+            .opt_level(0)
+            .warnings(false)
+            .debug(false)
+            .file(build.config.src.join("src/test/auxiliary/rust_test_helpers.c"))
+            .compile("rust_test_helpers");
     }
 }
 
@@ -381,7 +405,7 @@ impl Step for Openssl {
         let mut contents = String::new();
         drop(File::open(&stamp).and_then(|mut f| f.read_to_string(&mut contents)));
         if contents == OPENSSL_VERS {
-            return
+            return;
         }
         t!(fs::create_dir_all(&out));
 
@@ -390,8 +414,10 @@ impl Step for Openssl {
         if !tarball.exists() {
             let tmp = tarball.with_extension("tmp");
             // originally from https://www.openssl.org/source/...
-            let url = format!("https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror/{}",
-                              name);
+            let url = format!(
+                "https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror/{}",
+                name
+            );
             let mut last_error = None;
             for _ in 0..3 {
                 let status = Command::new("curl")
@@ -408,13 +434,14 @@ impl Step for Openssl {
                 }
 
                 // Ensure the hash is correct.
-                let mut shasum = if target.contains("apple") || build.config.general.build.contains("netbsd") {
-                    let mut cmd = Command::new("shasum");
-                    cmd.arg("-a").arg("256");
-                    cmd
-                } else {
-                    Command::new("sha256sum")
-                };
+                let mut shasum =
+                    if target.contains("apple") || build.config.general.build.contains("netbsd") {
+                        let mut cmd = Command::new("shasum");
+                        cmd.arg("-a").arg("256");
+                        cmd
+                    } else {
+                        Command::new("sha256sum")
+                    };
                 let output = output(&mut shasum.arg(&tmp));
                 let found = output.split_whitespace().next().unwrap();
 
@@ -425,8 +452,7 @@ impl Step for Openssl {
                         "downloaded openssl sha256 different\n\
                          expected: {}\n\
                          found:    {}\n",
-                        OPENSSL_SHA256,
-                        found
+                        OPENSSL_SHA256, found
                     ));
                     continue;
                 }
@@ -444,7 +470,12 @@ impl Step for Openssl {
         let dst = build.openssl_install_dir(target).unwrap();
         drop(fs::remove_dir_all(&obj));
         drop(fs::remove_dir_all(&dst));
-        build.run(Command::new("tar").arg("zxf").arg(&tarball).current_dir(&out));
+        build.run(
+            Command::new("tar")
+                .arg("zxf")
+                .arg(&tarball)
+                .current_dir(&out),
+        );
 
         let mut configure = Command::new("perl");
         configure.arg(obj.join("Configure"));

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -95,7 +95,7 @@ pub fn check(build: &mut Build) {
 
     // Ninja is currently only used for LLVM itself.
     if building_llvm {
-        if build.config.ninja {
+        if build.config.llvm.ninja {
             // Some Linux distros rename `ninja` to `ninja-build`.
             // CMake can work with either binary name.
             if cmd_finder.maybe_have("ninja-build").is_none() {
@@ -110,9 +110,9 @@ pub fn check(build: &mut Build) {
         //
         // In these cases we automatically enable Ninja if we find it in the
         // environment.
-        if !build.config.ninja && build.config.build.contains("msvc") {
+        if !build.config.llvm.ninja && build.config.build.contains("msvc") {
             if cmd_finder.maybe_have("ninja").is_some() {
-                build.config.ninja = true;
+                build.config.llvm.ninja = true;
             }
         }
     }
@@ -233,7 +233,7 @@ $ pacman -R cmake && pacman -S mingw-w64-x86_64-cmake
         build.lldb_python_dir = run(Command::new("lldb").arg("-P")).ok();
     }
 
-    if let Some(ref s) = build.config.ccache {
+    if let Some(ref s) = build.config.llvm.ccache() {
         cmd_finder.must_have(s);
     }
 

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -21,13 +21,12 @@
 use std::collections::HashMap;
 use std::env;
 use std::ffi::{OsStr, OsString};
-use std::fs::{self, File};
 use std::io::Read;
 use std::path::PathBuf;
 use std::process::Command;
 
 use build_helper::output;
-
+use fs::{self, File};
 use Build;
 
 struct Finder {

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -157,7 +157,7 @@ pub fn check(build: &mut Build) {
     }
 
     // Externally configured LLVM requires FileCheck to exist
-    let filecheck = build.llvm_filecheck(build.build);
+    let filecheck = build.llvm_filecheck(build.config.build);
     if !filecheck.starts_with(&build.config.out) && !filecheck.exists() &&
         build.config.codegen_tests {
         panic!("FileCheck executable {:?} does not exist", filecheck);
@@ -166,7 +166,7 @@ pub fn check(build: &mut Build) {
     for target in &build.config.targets {
         // Can't compile for iOS unless we're on macOS
         if target.contains("apple-ios") &&
-           !build.build.contains("apple-darwin") {
+           !build.config.build.contains("apple-darwin") {
             panic!("the iOS target is only supported on macOS");
         }
 

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -152,7 +152,7 @@ pub fn check(build: &mut Build) {
 
     // Externally configured LLVM requires FileCheck to exist
     let filecheck = build.llvm_filecheck(build.config.build);
-    if !filecheck.starts_with(&build.config.out) && !filecheck.exists() &&
+    if !filecheck.starts_with(&build.config.general.out) && !filecheck.exists() &&
         build.config.rust.codegen_tests {
         panic!("FileCheck executable {:?} does not exist", filecheck);
     }

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -21,12 +21,11 @@
 use std::collections::HashMap;
 use std::env;
 use std::ffi::{OsStr, OsString};
-use std::io::Read;
 use std::path::PathBuf;
 use std::process::Command;
 
 use build_helper::output;
-use fs::{self, File};
+use fs;
 use Build;
 
 struct Finder {
@@ -261,8 +260,7 @@ $ pacman -R cmake && pacman -S mingw-w64-x86_64-cmake
     }
 
     if build.config.rust.channel == "stable" {
-        let mut stage0 = String::new();
-        t!(t!(File::open(build.config.src.join("src/stage0.txt"))).read_to_string(&mut stage0));
+        let stage0 = t!(fs::read_string(build.config.src.join("src/stage0.txt")));
         if stage0.contains("\ndev:") {
             panic!(
                 "bootstrapping from a dev compiler in a stable release, but \

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -89,7 +89,7 @@ pub fn check(build: &mut Build) {
     let building_llvm = build.config.hosts.iter()
         .filter_map(|host| build.config.target_config.get(host))
         .any(|config| config.llvm_config.is_none());
-    if building_llvm || build.config.sanitizers {
+    if building_llvm || build.config.general.sanitizers {
         cmd_finder.must_have("cmake");
     }
 
@@ -117,17 +117,17 @@ pub fn check(build: &mut Build) {
         }
     }
 
-    build.config.python = build.config.python.take().map(|p| cmd_finder.must_have(p))
+    build.config.general.python = build.config.general.python.take().map(|p| cmd_finder.must_have(p))
         .or_else(|| env::var_os("BOOTSTRAP_PYTHON").map(PathBuf::from)) // set by bootstrap.py
         .or_else(|| cmd_finder.maybe_have("python2.7"))
         .or_else(|| cmd_finder.maybe_have("python2"))
         .or_else(|| Some(cmd_finder.must_have("python")));
 
-    build.config.nodejs = build.config.nodejs.take().map(|p| cmd_finder.must_have(p))
+    build.config.general.nodejs = build.config.general.nodejs.take().map(|p| cmd_finder.must_have(p))
         .or_else(|| cmd_finder.maybe_have("node"))
         .or_else(|| cmd_finder.maybe_have("nodejs"));
 
-    build.config.gdb = build.config.gdb.take().map(|p| cmd_finder.must_have(p))
+    build.config.general.gdb = build.config.general.gdb.take().map(|p| cmd_finder.must_have(p))
         .or_else(|| cmd_finder.maybe_have("gdb"));
 
     // We're gonna build some custom C code here and there, host triples

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -132,7 +132,7 @@ pub fn check(build: &mut Build) {
 
     // We're gonna build some custom C code here and there, host triples
     // also build some C++ shims for LLVM so we need a C++ compiler.
-    for target in &build.targets {
+    for target in &build.config.targets {
         // On emscripten we don't actually need the C compiler to just
         // build the target artifacts, only for testing. For the sake
         // of easier bot configuration, just skip detection.
@@ -163,7 +163,7 @@ pub fn check(build: &mut Build) {
         panic!("FileCheck executable {:?} does not exist", filecheck);
     }
 
-    for target in &build.targets {
+    for target in &build.config.targets {
         // Can't compile for iOS unless we're on macOS
         if target.contains("apple-ios") &&
            !build.build.contains("apple-darwin") {

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -86,7 +86,7 @@ pub fn check(build: &mut Build) {
     }
 
     // We need cmake, but only if we're actually building LLVM or sanitizers.
-    let building_llvm = build.hosts.iter()
+    let building_llvm = build.config.hosts.iter()
         .filter_map(|host| build.config.target_config.get(host))
         .any(|config| config.llvm_config.is_none());
     if building_llvm || build.config.sanitizers {
@@ -146,7 +146,7 @@ pub fn check(build: &mut Build) {
         }
     }
 
-    for host in &build.hosts {
+    for host in &build.config.hosts {
         cmd_finder.must_have(build.cxx(*host).unwrap());
 
         // The msvc hosts don't use jemalloc, turn it off globally to

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -86,7 +86,7 @@ pub fn check(build: &mut Build) {
     }
 
     // We need cmake, but only if we're actually building LLVM or sanitizers.
-    let building_llvm = build.config.hosts.iter()
+    let building_llvm = build.config.general.host.iter()
         .filter_map(|host| build.config.target_config.get(host))
         .any(|config| config.llvm_config.is_none());
     if building_llvm || build.config.general.sanitizers {
@@ -132,7 +132,7 @@ pub fn check(build: &mut Build) {
 
     // We're gonna build some custom C code here and there, host triples
     // also build some C++ shims for LLVM so we need a C++ compiler.
-    for target in &build.config.targets {
+    for target in &build.config.general.target {
         // On emscripten we don't actually need the C compiler to just
         // build the target artifacts, only for testing. For the sake
         // of easier bot configuration, just skip detection.
@@ -146,7 +146,7 @@ pub fn check(build: &mut Build) {
         }
     }
 
-    for host in &build.config.hosts {
+    for host in &build.config.general.host {
         cmd_finder.must_have(build.cxx(*host).unwrap());
     }
 
@@ -157,7 +157,7 @@ pub fn check(build: &mut Build) {
         panic!("FileCheck executable {:?} does not exist", filecheck);
     }
 
-    for target in &build.config.targets {
+    for target in &build.config.general.target {
         // Can't compile for iOS unless we're on macOS
         if target.contains("apple-ios") &&
            !build.config.build.contains("apple-darwin") {

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -110,7 +110,7 @@ pub fn check(build: &mut Build) {
         //
         // In these cases we automatically enable Ninja if we find it in the
         // environment.
-        if !build.config.llvm.ninja && build.config.build.contains("msvc") {
+        if !build.config.llvm.ninja && build.config.general.build.contains("msvc") {
             if cmd_finder.maybe_have("ninja").is_some() {
                 build.config.llvm.ninja = true;
             }
@@ -151,7 +151,7 @@ pub fn check(build: &mut Build) {
     }
 
     // Externally configured LLVM requires FileCheck to exist
-    let filecheck = build.llvm_filecheck(build.config.build);
+    let filecheck = build.llvm_filecheck(build.config.general.build);
     if !filecheck.starts_with(&build.config.general.out) && !filecheck.exists() &&
         build.config.rust.codegen_tests {
         panic!("FileCheck executable {:?} does not exist", filecheck);
@@ -160,7 +160,7 @@ pub fn check(build: &mut Build) {
     for target in &build.config.general.target {
         // Can't compile for iOS unless we're on macOS
         if target.contains("apple-ios") &&
-           !build.config.build.contains("apple-darwin") {
+           !build.config.general.build.contains("apple-darwin") {
             panic!("the iOS target is only supported on macOS");
         }
 
@@ -168,7 +168,7 @@ pub fn check(build: &mut Build) {
         if target.contains("musl") {
             // If this is a native target (host is also musl) and no musl-root is given,
             // fall back to the system toolchain in /usr before giving up
-            if build.musl_root(*target).is_none() && build.config.build == *target {
+            if build.musl_root(*target).is_none() && build.config.general.build == *target {
                 let target = build.config.target_config.entry(target.clone())
                                  .or_insert(Default::default());
                 target.musl_root = Some("/usr".into());

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -158,7 +158,8 @@ pub fn check(build: &mut Build) {
 
     // Externally configured LLVM requires FileCheck to exist
     let filecheck = build.llvm_filecheck(build.build);
-    if !filecheck.starts_with(&build.out) && !filecheck.exists() && build.config.codegen_tests {
+    if !filecheck.starts_with(&build.config.out) && !filecheck.exists() &&
+        build.config.codegen_tests {
         panic!("FileCheck executable {:?} does not exist", filecheck);
     }
 

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -148,18 +148,12 @@ pub fn check(build: &mut Build) {
 
     for host in &build.config.hosts {
         cmd_finder.must_have(build.cxx(*host).unwrap());
-
-        // The msvc hosts don't use jemalloc, turn it off globally to
-        // avoid packaging the dummy liballoc_jemalloc on that platform.
-        if host.contains("msvc") {
-            build.config.use_jemalloc = false;
-        }
     }
 
     // Externally configured LLVM requires FileCheck to exist
     let filecheck = build.llvm_filecheck(build.config.build);
     if !filecheck.starts_with(&build.config.out) && !filecheck.exists() &&
-        build.config.codegen_tests {
+        build.config.rust.codegen_tests {
         panic!("FileCheck executable {:?} does not exist", filecheck);
     }
 
@@ -237,7 +231,7 @@ $ pacman -R cmake && pacman -S mingw-w64-x86_64-cmake
         cmd_finder.must_have(s);
     }
 
-    if build.config.channel == "stable" {
+    if build.config.rust.channel == "stable" {
         let mut stage0 = String::new();
         t!(t!(File::open(build.config.src.join("src/stage0.txt")))
             .read_to_string(&mut stage0));

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -238,7 +238,7 @@ $ pacman -R cmake && pacman -S mingw-w64-x86_64-cmake
 
     if build.config.channel == "stable" {
         let mut stage0 = String::new();
-        t!(t!(File::open(build.src.join("src/stage0.txt")))
+        t!(t!(File::open(build.config.src.join("src/stage0.txt")))
             .read_to_string(&mut stage0));
         if stage0.contains("\ndev:") {
             panic!("bootstrapping from a dev compiler in a stable release, but \

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -20,7 +20,7 @@
 
 use std::collections::HashMap;
 use std::env;
-use std::ffi::{OsString, OsStr};
+use std::ffi::{OsStr, OsString};
 use std::fs::{self, File};
 use std::io::Read;
 use std::path::PathBuf;
@@ -39,26 +39,31 @@ impl Finder {
     fn new() -> Self {
         Self {
             cache: HashMap::new(),
-            path: env::var_os("PATH").unwrap_or_default()
+            path: env::var_os("PATH").unwrap_or_default(),
         }
     }
 
     fn maybe_have<S: AsRef<OsStr>>(&mut self, cmd: S) -> Option<PathBuf> {
         let cmd: OsString = cmd.as_ref().into();
         let path = self.path.clone();
-        self.cache.entry(cmd.clone()).or_insert_with(|| {
-            for path in env::split_paths(&path) {
-                let target = path.join(&cmd);
-                let mut cmd_alt = cmd.clone();
-                cmd_alt.push(".exe");
-                if target.is_file() || // some/path/git
+        self.cache
+            .entry(cmd.clone())
+            .or_insert_with(|| {
+                for path in env::split_paths(&path) {
+                    let target = path.join(&cmd);
+                    let mut cmd_alt = cmd.clone();
+                    cmd_alt.push(".exe");
+                    if target.is_file() || // some/path/git
                 target.with_extension("exe").exists() || // some/path/git.exe
-                target.join(&cmd_alt).exists() { // some/path/git/git.exe
-                    return Some(target);
+                target.join(&cmd_alt).exists()
+                    {
+                        // some/path/git/git.exe
+                        return Some(target);
+                    }
                 }
-            }
-            None
-        }).clone()
+                None
+            })
+            .clone()
     }
 
     fn must_have<S: AsRef<OsStr>>(&mut self, cmd: S) -> PathBuf {
@@ -86,7 +91,11 @@ pub fn check(build: &mut Build) {
     }
 
     // We need cmake, but only if we're actually building LLVM or sanitizers.
-    let building_llvm = build.config.general.host.iter()
+    let building_llvm = build
+        .config
+        .general
+        .host
+        .iter()
         .filter_map(|host| build.config.target_config.get(host))
         .any(|config| config.llvm_config.is_none());
     if building_llvm || build.config.general.sanitizers {
@@ -117,17 +126,28 @@ pub fn check(build: &mut Build) {
         }
     }
 
-    build.config.general.python = build.config.general.python.take().map(|p| cmd_finder.must_have(p))
+    build.config.general.python = build.config.general.python.take()
+        .map(|p| cmd_finder.must_have(p))
         .or_else(|| env::var_os("BOOTSTRAP_PYTHON").map(PathBuf::from)) // set by bootstrap.py
         .or_else(|| cmd_finder.maybe_have("python2.7"))
         .or_else(|| cmd_finder.maybe_have("python2"))
         .or_else(|| Some(cmd_finder.must_have("python")));
 
-    build.config.general.nodejs = build.config.general.nodejs.take().map(|p| cmd_finder.must_have(p))
+    build.config.general.nodejs = build
+        .config
+        .general
+        .nodejs
+        .take()
+        .map(|p| cmd_finder.must_have(p))
         .or_else(|| cmd_finder.maybe_have("node"))
         .or_else(|| cmd_finder.maybe_have("nodejs"));
 
-    build.config.general.gdb = build.config.general.gdb.take().map(|p| cmd_finder.must_have(p))
+    build.config.general.gdb = build
+        .config
+        .general
+        .gdb
+        .take()
+        .map(|p| cmd_finder.must_have(p))
         .or_else(|| cmd_finder.maybe_have("gdb"));
 
     // We're gonna build some custom C code here and there, host triples
@@ -152,15 +172,15 @@ pub fn check(build: &mut Build) {
 
     // Externally configured LLVM requires FileCheck to exist
     let filecheck = build.llvm_filecheck(build.config.general.build);
-    if !filecheck.starts_with(&build.config.general.out) && !filecheck.exists() &&
-        build.config.rust.codegen_tests {
+    if !filecheck.starts_with(&build.config.general.out) && !filecheck.exists()
+        && build.config.rust.codegen_tests
+    {
         panic!("FileCheck executable {:?} does not exist", filecheck);
     }
 
     for target in &build.config.general.target {
         // Can't compile for iOS unless we're on macOS
-        if target.contains("apple-ios") &&
-           !build.config.general.build.contains("apple-darwin") {
+        if target.contains("apple-ios") && !build.config.general.build.contains("apple-darwin") {
             panic!("the iOS target is only supported on macOS");
         }
 
@@ -169,26 +189,33 @@ pub fn check(build: &mut Build) {
             // If this is a native target (host is also musl) and no musl-root is given,
             // fall back to the system toolchain in /usr before giving up
             if build.musl_root(*target).is_none() && build.config.general.build == *target {
-                let target = build.config.target_config.entry(target.clone())
-                                 .or_insert(Default::default());
+                let target = build
+                    .config
+                    .target_config
+                    .entry(target.clone())
+                    .or_insert(Default::default());
                 target.musl_root = Some("/usr".into());
             }
             match build.musl_root(*target) {
                 Some(root) => {
                     if fs::metadata(root.join("lib/libc.a")).is_err() {
-                        panic!("couldn't find libc.a in musl dir: {}",
-                               root.join("lib").display());
+                        panic!(
+                            "couldn't find libc.a in musl dir: {}",
+                            root.join("lib").display()
+                        );
                     }
                     if fs::metadata(root.join("lib/libunwind.a")).is_err() {
-                        panic!("couldn't find libunwind.a in musl dir: {}",
-                               root.join("lib").display());
+                        panic!(
+                            "couldn't find libunwind.a in musl dir: {}",
+                            root.join("lib").display()
+                        );
                     }
                 }
-                None => {
-                    panic!("when targeting MUSL either the rust.musl-root \
-                            option or the target.$TARGET.musl-root option must \
-                            be specified in config.toml")
-                }
+                None => panic!(
+                    "when targeting MUSL either the rust.musl-root \
+                     option or the target.$TARGET.musl-root option must \
+                     be specified in config.toml"
+                ),
             }
         }
 
@@ -198,7 +225,8 @@ pub fn check(build: &mut Build) {
             // Studio, so detect that here and error.
             let out = output(Command::new("cmake").arg("--help"));
             if !out.contains("Visual Studio") {
-                panic!("
+                panic!(
+                    "
 cmake does not support Visual Studio generators.
 
 This is likely due to it being an msys/cygwin build of cmake,
@@ -209,7 +237,8 @@ If you are building under msys2 try installing the mingw-w64-x86_64-cmake
 package instead of cmake:
 
 $ pacman -R cmake && pacman -S mingw-w64-x86_64-cmake
-");
+"
+                );
             }
         }
     }
@@ -217,9 +246,10 @@ $ pacman -R cmake && pacman -S mingw-w64-x86_64-cmake
     let run = |cmd: &mut Command| {
         cmd.output().map(|output| {
             String::from_utf8_lossy(&output.stdout)
-                   .lines().next().unwrap_or_else(|| {
-                       panic!("{:?} failed {:?}", cmd, output)
-                   }).to_string()
+                .lines()
+                .next()
+                .unwrap_or_else(|| panic!("{:?} failed {:?}", cmd, output))
+                .to_string()
         })
     };
     build.lldb_version = run(Command::new("lldb").arg("--version")).ok();
@@ -233,11 +263,12 @@ $ pacman -R cmake && pacman -S mingw-w64-x86_64-cmake
 
     if build.config.rust.channel == "stable" {
         let mut stage0 = String::new();
-        t!(t!(File::open(build.config.src.join("src/stage0.txt")))
-            .read_to_string(&mut stage0));
+        t!(t!(File::open(build.config.src.join("src/stage0.txt"))).read_to_string(&mut stage0));
         if stage0.contains("\ndev:") {
-            panic!("bootstrapping from a dev compiler in a stable release, but \
-                    should only be bootstrapping from a released compiler!");
+            panic!(
+                "bootstrapping from a dev compiler in a stable release, but \
+                 should only be bootstrapping from a released compiler!"
+            );
         }
     }
 }

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1629,7 +1629,7 @@ impl Step for Bootstrap {
         let mut cmd = Command::new(&build.initial_cargo);
         cmd.arg("test")
            .current_dir(build.src.join("src/bootstrap"))
-           .env("CARGO_TARGET_DIR", build.out.join("bootstrap"))
+           .env("CARGO_TARGET_DIR", build.out.join("bootstrap-test"))
            .env("RUSTC_BOOTSTRAP", "1")
            .env("RUSTC", &build.initial_rustc);
         if !build.fail_fast {

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -910,7 +910,7 @@ impl Step for Compiletest {
             cmd.arg("--quiet");
         }
 
-        if build.config.llvm_enabled {
+        if build.config.llvm.enabled {
             let llvm_config = build.llvm_config(target);
             let llvm_version = output(Command::new(&llvm_config).arg("--version"));
             cmd.arg("--llvm-version").arg(llvm_version);
@@ -933,7 +933,7 @@ impl Step for Compiletest {
                 }
             }
         }
-        if suite == "run-make" && !build.config.llvm_enabled {
+        if suite == "run-make" && !build.config.llvm.enabled {
             println!("Ignoring run-make test suite as they generally don't work without LLVM");
             return;
         }

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1382,15 +1382,10 @@ impl Step for Crate {
 
         let mut cargo = builder.cargo(compiler, mode, target, test_kind.subcommand());
         match mode {
-            Mode::Libstd => {
-                compile::std_cargo(builder, &compiler, target, &mut cargo);
-            }
-            Mode::Libtest => {
-                compile::test_cargo(builder, &compiler, target, &mut cargo);
-            }
+            Mode::Libstd => {}
+            Mode::Libtest => {}
             Mode::Librustc => {
                 builder.ensure(compile::Rustc { compiler, target });
-                compile::rustc_cargo(builder, &mut cargo);
             }
             _ => panic!("can only test libraries"),
         };

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -19,11 +19,10 @@ use std::iter;
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::io::Read;
 
 use build_helper::{self, output};
 
-use fs::{self, File};
+use fs;
 use builder::{Builder, Compiler, Kind, RunConfig, ShouldRun, Step};
 use Crate as CargoCrate;
 use cache::{Intern, Interned};
@@ -1159,9 +1158,7 @@ impl Step for ErrorIndex {
 }
 
 fn markdown_test(builder: &Builder, compiler: Compiler, markdown: &Path) {
-    let mut file = t!(File::open(markdown));
-    let mut contents = String::new();
-    t!(file.read_to_string(&mut contents));
+    let contents = t!(fs::read_string(markdown));
     if !contents.contains("```") {
         return;
     }

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -113,7 +113,7 @@ impl Step for Linkcheck {
 
         let _time = util::timeit();
         try_run(build, builder.tool_cmd(Tool::Linkchecker)
-                              .arg(build.config.out.join(host).join("doc")));
+                              .arg(build.config.general.out.join(host).join("doc")));
     }
 
     fn should_run(run: ShouldRun) -> ShouldRun {
@@ -159,7 +159,7 @@ impl Step for Cargotest {
         // Note that this is a short, cryptic, and not scoped directory name. This
         // is currently to minimize the length of path on Windows where we otherwise
         // quickly run into path name limit constraints.
-        let out_dir = build.config.out.join("ct");
+        let out_dir = build.config.general.out.join("ct");
         t!(fs::create_dir_all(&out_dir));
 
         let _time = util::timeit();
@@ -546,7 +546,7 @@ impl Step for Tidy {
 }
 
 fn testdir(build: &Build, host: Interned<String>) -> PathBuf {
-    build.config.out.join(host).join("test")
+    build.config.general.out.join(host).join("test")
 }
 
 macro_rules! default_test {
@@ -973,7 +973,7 @@ impl Step for Compiletest {
             cmd.env("PROFILER_SUPPORT", "1");
         }
 
-        cmd.env("RUST_TEST_TMPDIR", build.config.out.join("tmp"));
+        cmd.env("RUST_TEST_TMPDIR", build.config.general.out.join("tmp"));
 
         cmd.arg("--adb-path").arg("adb");
         cmd.arg("--adb-test-dir").arg(ADB_TEST_DIR);
@@ -1520,7 +1520,7 @@ impl Step for RemoteCopyLibs {
         builder.ensure(compile::Test { compiler, target });
 
         println!("REMOTE copy libs to emulator ({})", target);
-        t!(fs::create_dir_all(build.config.out.join("tmp")));
+        t!(fs::create_dir_all(build.config.general.out.join("tmp")));
 
         let server = builder.ensure(tool::RemoteTestServer { compiler, target });
 
@@ -1530,7 +1530,7 @@ impl Step for RemoteCopyLibs {
         cmd.arg("spawn-emulator")
            .arg(target)
            .arg(&server)
-           .arg(build.config.out.join("tmp"));
+           .arg(build.config.general.out.join("tmp"));
         if let Some(rootfs) = build.qemu_rootfs(target) {
             cmd.arg(rootfs);
         }
@@ -1568,7 +1568,7 @@ impl Step for Distcheck {
         let build = builder.build;
 
         println!("Distcheck");
-        let dir = build.config.out.join("tmp").join("distcheck");
+        let dir = build.config.general.out.join("tmp").join("distcheck");
         let _ = fs::remove_dir_all(&dir);
         t!(fs::create_dir_all(&dir));
 
@@ -1592,7 +1592,7 @@ impl Step for Distcheck {
 
         // Now make sure that rust-src has all of libstd's dependencies
         println!("Distcheck rust-src");
-        let dir = build.config.out.join("tmp").join("distcheck-src");
+        let dir = build.config.general.out.join("tmp").join("distcheck-src");
         let _ = fs::remove_dir_all(&dir);
         t!(fs::create_dir_all(&dir));
 
@@ -1626,7 +1626,7 @@ impl Step for Bootstrap {
         let mut cmd = Command::new(&build.config.initial_cargo);
         cmd.arg("test")
            .current_dir(build.config.src.join("src/bootstrap"))
-           .env("CARGO_TARGET_DIR", build.config.out.join("bootstrap-test"))
+           .env("CARGO_TARGET_DIR", build.config.general.out.join("bootstrap-test"))
            .env("RUSTC_BOOTSTRAP", "1")
            .env("RUSTC", &build.config.initial_rustc);
         if !build.config.cmd.fail_fast() {

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -17,13 +17,13 @@ use std::env;
 use std::ffi::OsString;
 use std::iter;
 use std::fmt;
-use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::io::Read;
 
 use build_helper::{self, output};
 
+use fs::{self, File};
 use builder::{Builder, Compiler, Kind, RunConfig, ShouldRun, Step};
 use Crate as CargoCrate;
 use cache::{Intern, Interned};
@@ -1702,7 +1702,8 @@ impl Step for Bootstrap {
     fn run(self, builder: &Builder) {
         let mut cmd = Command::new(&builder.config.general.initial_cargo);
         cmd.arg("test")
-            .current_dir(builder.config.src.join("src/bootstrap"))
+            .arg("--manifest-path")
+            .arg(builder.config.src.join("src/bootstrap/Cargo.toml"))
             .env(
                 "CARGO_TARGET_DIR",
                 builder.config.general.out.join("bootstrap-test"),
@@ -1712,6 +1713,7 @@ impl Step for Bootstrap {
         if !builder.config.cmd.fail_fast() {
             cmd.arg("--no-fail-fast");
         }
+        cmd.arg("--lib");
         cmd.arg("--").args(&builder.config.cmd.test_args());
         try_run(builder, &mut cmd);
     }

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -118,7 +118,7 @@ impl Step for Linkcheck {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.path("src/tools/linkchecker").default_condition(builder.build.config.docs)
+        run.path("src/tools/linkchecker").default_condition(builder.build.config.general.docs)
     }
 
     fn make_run(run: RunConfig) {
@@ -488,7 +488,7 @@ impl Step for RustdocJS {
     }
 
     fn run(self, builder: &Builder) {
-        if let Some(ref nodejs) = builder.config.nodejs {
+        if let Some(ref nodejs) = builder.config.general.nodejs {
             let mut command = Command::new(nodejs);
             command.args(&["src/tools/rustdoc-js/tester.js", &*self.host]);
             builder.ensure(::doc::Std {
@@ -525,7 +525,7 @@ impl Step for Tidy {
         println!("tidy check ({})", host);
         let mut cmd = builder.tool_cmd(Tool::Tidy);
         cmd.arg(build.config.src.join("src"));
-        if !build.config.vendor {
+        if !build.config.general.vendor {
             cmd.arg("--no-vendor");
         }
         if build.config.rust.quiet_tests {
@@ -853,7 +853,7 @@ impl Step for Compiletest {
         cmd.arg("--host").arg(&*compiler.host);
         cmd.arg("--llvm-filecheck").arg(build.llvm_filecheck(build.config.build));
 
-        if let Some(ref nodejs) = build.config.nodejs {
+        if let Some(ref nodejs) = build.config.general.nodejs {
             cmd.arg("--nodejs").arg(nodejs);
         }
 
@@ -890,7 +890,7 @@ impl Step for Compiletest {
             cmd.arg("--lldb-python").arg(build.python());
         }
 
-        if let Some(ref gdb) = build.config.gdb {
+        if let Some(ref gdb) = build.config.general.gdb {
             cmd.arg("--gdb").arg(gdb);
         }
         if let Some(ref vers) = build.lldb_version {
@@ -965,11 +965,11 @@ impl Step for Compiletest {
         cmd.env("RUSTC_BOOTSTRAP", "1");
         build.add_rust_test_threads(&mut cmd);
 
-        if build.config.sanitizers {
+        if build.config.general.sanitizers {
             cmd.env("SANITIZER_SUPPORT", "1");
         }
 
-        if build.config.profiler {
+        if build.config.general.profiler {
             cmd.env("PROFILER_SUPPORT", "1");
         }
 
@@ -1380,7 +1380,7 @@ impl Step for Crate {
 
         if target.contains("emscripten") {
             cargo.env(format!("CARGO_TARGET_{}_RUNNER", envify(&target)),
-                      build.config.nodejs.as_ref().expect("nodejs not configured"));
+                      build.config.general.nodejs.as_ref().expect("nodejs not configured"));
         } else if target.starts_with("wasm32") {
             // Warn about running tests without the `wasm_syscall` feature enabled.
             // The javascript shim implements the syscall interface so that test
@@ -1394,7 +1394,7 @@ impl Step for Crate {
             // incompatible with `-C prefer-dynamic`, so disable that here
             cargo.env("RUSTC_NO_PREFER_DYNAMIC", "1");
 
-            let node = build.config.nodejs.as_ref()
+            let node = build.config.general.nodejs.as_ref()
                 .expect("nodejs not configured");
             let runner = format!("{} {}/src/etc/wasm32-shim.js",
                                  node.display(),
@@ -1583,7 +1583,7 @@ impl Step for Distcheck {
            .current_dir(&dir);
         build.run(&mut cmd);
         build.run(Command::new("./configure")
-                         .args(&build.config.configure_args)
+                         .args(&build.config.general.configure_args)
                          .arg("--enable-vendor")
                          .current_dir(&dir));
         build.run(Command::new(build_helper::make(&build.config.build))

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -209,7 +209,7 @@ impl Step for Cargo {
             compiler,
             target: self.host,
         });
-        let mut cargo = builder.cargo(compiler, Mode::Tool, self.host, "test");
+        let mut cargo = builder.cargo(compiler, Mode::RustcTool, self.host, "test");
         cargo
             .arg("--manifest-path")
             .arg(builder.config.src.join("src/tools/cargo/Cargo.toml"));
@@ -262,7 +262,8 @@ impl Step for Rls {
             compiler,
             target: self.host,
         });
-        let mut cargo = tool::prepare_tool_cargo(builder, compiler, host, "test", "src/tools/rls");
+        let mut cargo = tool::prepare_tool_cargo(
+            builder, compiler, Mode::RustcTool, host, "test", "src/tools/rls");
 
         // Don't build tests dynamically, just a pain to work with
         cargo.env("RUSTC_NO_PREFER_DYNAMIC", "1");
@@ -307,7 +308,7 @@ impl Step for Rustfmt {
             target: self.host,
         });
         let mut cargo =
-            tool::prepare_tool_cargo(builder, compiler, host, "test", "src/tools/rustfmt");
+            tool::prepare_tool_cargo(builder, compiler, Mode::RustcTool, host, "test", "src/tools/rustfmt");
 
         // Don't build tests dynamically, just a pain to work with
         cargo.env("RUSTC_NO_PREFER_DYNAMIC", "1");
@@ -353,7 +354,7 @@ impl Step for Miri {
             compiler,
             target: self.host,
         }) {
-            let mut cargo = builder.cargo(compiler, Mode::Tool, host, "test");
+            let mut cargo = builder.cargo(compiler, Mode::RustcTool, host, "test");
             cargo
                 .arg("--manifest-path")
                 .arg(builder.config.src.join("src/tools/miri/Cargo.toml"));
@@ -409,7 +410,7 @@ impl Step for Clippy {
             compiler,
             target: self.host,
         }) {
-            let mut cargo = builder.cargo(compiler, Mode::Tool, host, "test");
+            let mut cargo = builder.cargo(compiler, Mode::RustcTool, host, "test");
             cargo
                 .arg("--manifest-path")
                 .arg(builder.config.src.join("src/tools/clippy/Cargo.toml"));
@@ -421,7 +422,7 @@ impl Step for Clippy {
             cargo.env("RUSTC_TEST_SUITE", builder.rustc(compiler));
             cargo.env("RUSTC_LIB_PATH", builder.rustc_libdir(compiler));
             let host_libs = builder
-                .stage_out(compiler, Mode::Tool)
+                .stage_out(compiler, Mode::RustcTool)
                 .join(builder.cargo_dir());
             cargo.env("HOST_LIBS", host_libs);
             // clippy tests need to find the driver
@@ -1522,6 +1523,7 @@ impl Step for CrateRustdoc {
         let mut cargo = tool::prepare_tool_cargo(
             builder,
             compiler,
+            Mode::TestTool,
             target,
             test_kind.subcommand(),
             "src/tools/rustdoc",

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -540,7 +540,7 @@ impl Step for Tidy {
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(Tidy {
-            host: run.builder.build.build,
+            host: run.builder.build.config.build,
         });
     }
 }
@@ -791,12 +791,12 @@ impl Step for Compiletest {
 
         if suite == "debuginfo" {
             // Skip debuginfo tests on MSVC
-            if build.build.contains("msvc") {
+            if build.config.build.contains("msvc") {
                 return;
             }
 
             if mode == "debuginfo-XXX" {
-                return if build.build.contains("apple") {
+                return if build.config.build.contains("apple") {
                     builder.ensure(Compiletest {
                         mode: "debuginfo-lldb",
                         ..self
@@ -851,7 +851,7 @@ impl Step for Compiletest {
         cmd.arg("--mode").arg(mode);
         cmd.arg("--target").arg(target);
         cmd.arg("--host").arg(&*compiler.host);
-        cmd.arg("--llvm-filecheck").arg(build.llvm_filecheck(build.build));
+        cmd.arg("--llvm-filecheck").arg(build.llvm_filecheck(build.config.build));
 
         if let Some(ref nodejs) = build.config.nodejs {
             cmd.arg("--nodejs").arg(nodejs);
@@ -881,7 +881,7 @@ impl Step for Compiletest {
 
         cmd.arg("--docck-python").arg(build.python());
 
-        if build.build.ends_with("apple-darwin") {
+        if build.config.build.ends_with("apple-darwin") {
             // Force /usr/bin/python on macOS for LLDB tests because we're loading the
             // LLDB plugin's compiled module which only works with the system python
             // (namely not Homebrew-installed python)
@@ -1093,7 +1093,7 @@ impl Step for ErrorIndex {
         build.run(builder.tool_cmd(Tool::ErrorIndex)
                     .arg("markdown")
                     .arg(&output)
-                    .env("CFG_BUILD", &build.build)
+                    .env("CFG_BUILD", &build.config.build)
                     .env("RUSTC_ERROR_METADATA_DST", build.extended_error_dir()));
 
         markdown_test(builder, compiler, &output);
@@ -1586,7 +1586,7 @@ impl Step for Distcheck {
                          .args(&build.config.configure_args)
                          .arg("--enable-vendor")
                          .current_dir(&dir));
-        build.run(Command::new(build_helper::make(&build.build))
+        build.run(Command::new(build_helper::make(&build.config.build))
                          .arg("check")
                          .current_dir(&dir));
 

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -540,7 +540,7 @@ impl Step for Tidy {
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(Tidy {
-            host: run.builder.build.config.build,
+            host: run.builder.build.config.general.build,
         });
     }
 }
@@ -791,12 +791,12 @@ impl Step for Compiletest {
 
         if suite == "debuginfo" {
             // Skip debuginfo tests on MSVC
-            if build.config.build.contains("msvc") {
+            if build.config.general.build.contains("msvc") {
                 return;
             }
 
             if mode == "debuginfo-XXX" {
-                return if build.config.build.contains("apple") {
+                return if build.config.general.build.contains("apple") {
                     builder.ensure(Compiletest {
                         mode: "debuginfo-lldb",
                         ..self
@@ -851,7 +851,7 @@ impl Step for Compiletest {
         cmd.arg("--mode").arg(mode);
         cmd.arg("--target").arg(target);
         cmd.arg("--host").arg(&*compiler.host);
-        cmd.arg("--llvm-filecheck").arg(build.llvm_filecheck(build.config.build));
+        cmd.arg("--llvm-filecheck").arg(build.llvm_filecheck(build.config.general.build));
 
         if let Some(ref nodejs) = build.config.general.nodejs {
             cmd.arg("--nodejs").arg(nodejs);
@@ -881,7 +881,7 @@ impl Step for Compiletest {
 
         cmd.arg("--docck-python").arg(build.python());
 
-        if build.config.build.ends_with("apple-darwin") {
+        if build.config.general.build.ends_with("apple-darwin") {
             // Force /usr/bin/python on macOS for LLDB tests because we're loading the
             // LLDB plugin's compiled module which only works with the system python
             // (namely not Homebrew-installed python)
@@ -1093,7 +1093,7 @@ impl Step for ErrorIndex {
         build.run(builder.tool_cmd(Tool::ErrorIndex)
                     .arg("markdown")
                     .arg(&output)
-                    .env("CFG_BUILD", &build.config.build)
+                    .env("CFG_BUILD", &build.config.general.build)
                     .env("RUSTC_ERROR_METADATA_DST", build.extended_error_dir()));
 
         markdown_test(builder, compiler, &output);
@@ -1586,7 +1586,7 @@ impl Step for Distcheck {
                          .args(&build.config.general.configure_args)
                          .arg("--enable-vendor")
                          .current_dir(&dir));
-        build.run(Command::new(build_helper::make(&build.config.build))
+        build.run(Command::new(build_helper::make(&build.config.general.build))
                          .arg("check")
                          .current_dir(&dir));
 

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -66,7 +66,7 @@ impl fmt::Display for TestKind {
 }
 
 fn try_run(build: &Build, cmd: &mut Command) -> bool {
-    if !build.fail_fast {
+    if !build.config.cmd.fail_fast() {
         if !build.try_run(cmd) {
             let mut failures = build.delayed_failures.borrow_mut();
             failures.push(format!("{:?}", cmd));
@@ -79,7 +79,7 @@ fn try_run(build: &Build, cmd: &mut Command) -> bool {
 }
 
 fn try_run_quiet(build: &Build, cmd: &mut Command) {
-    if !build.fail_fast {
+    if !build.config.cmd.fail_fast() {
         if !build.try_run_quiet(cmd) {
             let mut failures = build.delayed_failures.borrow_mut();
             failures.push(format!("{:?}", cmd));
@@ -200,7 +200,7 @@ impl Step for Cargo {
         builder.ensure(tool::Cargo { compiler, target: self.host });
         let mut cargo = builder.cargo(compiler, Mode::Tool, self.host, "test");
         cargo.arg("--manifest-path").arg(build.config.src.join("src/tools/cargo/Cargo.toml"));
-        if !build.fail_fast {
+        if !build.config.cmd.fail_fast() {
             cargo.arg("--no-fail-fast");
         }
 
@@ -1351,7 +1351,7 @@ impl Step for Crate {
         // Pass in some standard flags then iterate over the graph we've discovered
         // in `cargo metadata` with the maps above and figure out what `-p`
         // arguments need to get passed.
-        if test_kind.subcommand() == "test" && !build.fail_fast {
+        if test_kind.subcommand() == "test" && !build.config.cmd.fail_fast() {
             cargo.arg("--no-fail-fast");
         }
         if build.doc_tests {
@@ -1459,7 +1459,7 @@ impl Step for CrateRustdoc {
         println!("{} rustdoc stage{} ({} -> {})", test_kind, compiler.stage,
                 &compiler.host, target);
 
-        if test_kind.subcommand() == "test" && !build.fail_fast {
+        if test_kind.subcommand() == "test" && !build.config.cmd.fail_fast() {
             cargo.arg("--no-fail-fast");
         }
 
@@ -1629,7 +1629,7 @@ impl Step for Bootstrap {
            .env("CARGO_TARGET_DIR", build.config.out.join("bootstrap-test"))
            .env("RUSTC_BOOTSTRAP", "1")
            .env("RUSTC", &build.config.initial_rustc);
-        if !build.fail_fast {
+        if !build.config.cmd.fail_fast() {
             cmd.arg("--no-fail-fast");
         }
         cmd.arg("--").args(&build.config.cmd.test_args());

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -319,7 +319,7 @@ impl Step for Miri {
     const DEFAULT: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
-        let test_miri = run.builder.build.config.test_miri;
+        let test_miri = run.builder.build.config.rust.test_miri;
         run.path("src/tools/miri").default_condition(test_miri)
     }
 
@@ -454,7 +454,7 @@ impl Step for RustdocTheme {
            .env("RUSTC_STAGE", self.compiler.stage.to_string())
            .env("RUSTC_SYSROOT", builder.sysroot(self.compiler))
            .env("RUSTDOC_LIBDIR", builder.sysroot_libdir(self.compiler, self.compiler.host))
-           .env("CFG_RELEASE_CHANNEL", &builder.build.config.channel)
+           .env("CFG_RELEASE_CHANNEL", &builder.build.config.rust.channel)
            .env("RUSTDOC_REAL", builder.rustdoc(self.compiler.host))
            .env("RUSTDOC_CRATE_VERSION", builder.build.rust_version())
            .env("RUSTC_BOOTSTRAP", "1");
@@ -528,7 +528,7 @@ impl Step for Tidy {
         if !build.config.vendor {
             cmd.arg("--no-vendor");
         }
-        if build.config.quiet_tests {
+        if build.config.rust.quiet_tests {
             cmd.arg("--quiet");
         }
         try_run(build, &mut cmd);
@@ -785,7 +785,7 @@ impl Step for Compiletest {
         let suite = self.suite;
 
         // Skip codegen tests if they aren't enabled in configuration.
-        if !build.config.codegen_tests && suite == "codegen" {
+        if !build.config.rust.codegen_tests && suite == "codegen" {
             return;
         }
 
@@ -858,10 +858,10 @@ impl Step for Compiletest {
         }
 
         let mut flags = vec!["-Crpath".to_string()];
-        if build.config.rust_optimize_tests {
+        if build.config.rust.optimize_tests {
             flags.push("-O".to_string());
         }
-        if build.config.rust_debuginfo_tests {
+        if build.config.rust.debuginfo_tests {
             flags.push("-g".to_string());
         }
         flags.push("-Zmiri -Zunstable-options".to_string());
@@ -906,7 +906,7 @@ impl Step for Compiletest {
             cmd.arg("--verbose");
         }
 
-        if build.config.quiet_tests {
+        if build.config.rust.quiet_tests {
             cmd.arg("--quiet");
         }
 
@@ -1119,7 +1119,7 @@ fn markdown_test(builder: &Builder, compiler: Compiler, markdown: &Path) {
     let test_args = build.config.cmd.test_args().join(" ");
     cmd.arg("--test-args").arg(test_args);
 
-    if build.config.quiet_tests {
+    if build.config.rust.quiet_tests {
         try_run_quiet(build, &mut cmd);
     } else {
         try_run(build, &mut cmd);
@@ -1372,7 +1372,7 @@ impl Step for Crate {
         cargo.arg("--");
         cargo.args(&build.config.cmd.test_args());
 
-        if build.config.quiet_tests {
+        if build.config.rust.quiet_tests {
             cargo.arg("--quiet");
         }
 
@@ -1385,7 +1385,7 @@ impl Step for Crate {
             // Warn about running tests without the `wasm_syscall` feature enabled.
             // The javascript shim implements the syscall interface so that test
             // output can be correctly reported.
-            if !build.config.wasm_syscall {
+            if !build.config.rust.wasm_syscall {
                 println!("Libstd was built without `wasm_syscall` feature enabled: \
                           test output may not be visible.");
             }
@@ -1468,7 +1468,7 @@ impl Step for CrateRustdoc {
         cargo.arg("--");
         cargo.args(&build.config.cmd.test_args());
 
-        if build.config.quiet_tests {
+        if build.config.rust.quiet_tests {
             cargo.arg("--quiet");
         }
 

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -306,8 +306,8 @@ impl Step for Rustfmt {
             compiler,
             target: self.host,
         });
-        let mut cargo =
-            tool::prepare_tool_cargo(builder, compiler, Mode::RustcTool, host, "test", "src/tools/rustfmt");
+        let mut cargo = tool::prepare_tool_cargo(
+                builder, compiler, Mode::RustcTool, host, "test", "src/tools/rustfmt");
 
         // Don't build tests dynamically, just a pain to work with
         cargo.env("RUSTC_NO_PREFER_DYNAMIC", "1");

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -199,7 +199,7 @@ impl Step for Cargo {
 
         builder.ensure(tool::Cargo { compiler, target: self.host });
         let mut cargo = builder.cargo(compiler, Mode::Tool, self.host, "test");
-        cargo.arg("--manifest-path").arg(build.src.join("src/tools/cargo/Cargo.toml"));
+        cargo.arg("--manifest-path").arg(build.config.src.join("src/tools/cargo/Cargo.toml"));
         if !build.fail_fast {
             cargo.arg("--no-fail-fast");
         }
@@ -339,7 +339,7 @@ impl Step for Miri {
 
         if let Some(miri) = builder.ensure(tool::Miri { compiler, target: self.host }) {
             let mut cargo = builder.cargo(compiler, Mode::Tool, host, "test");
-            cargo.arg("--manifest-path").arg(build.src.join("src/tools/miri/Cargo.toml"));
+            cargo.arg("--manifest-path").arg(build.config.src.join("src/tools/miri/Cargo.toml"));
 
             // Don't build tests dynamically, just a pain to work with
             cargo.env("RUSTC_NO_PREFER_DYNAMIC", "1");
@@ -391,7 +391,7 @@ impl Step for Clippy {
 
         if let Some(clippy) = builder.ensure(tool::Clippy { compiler, target: self.host }) {
             let mut cargo = builder.cargo(compiler, Mode::Tool, host, "test");
-            cargo.arg("--manifest-path").arg(build.src.join("src/tools/clippy/Cargo.toml"));
+            cargo.arg("--manifest-path").arg(build.config.src.join("src/tools/clippy/Cargo.toml"));
 
             // Don't build tests dynamically, just a pain to work with
             cargo.env("RUSTC_NO_PREFER_DYNAMIC", "1");
@@ -450,7 +450,7 @@ impl Step for RustdocTheme {
         let rustdoc = builder.rustdoc(self.compiler.host);
         let mut cmd = builder.tool_cmd(Tool::RustdocTheme);
         cmd.arg(rustdoc.to_str().unwrap())
-           .arg(builder.src.join("src/librustdoc/html/static/themes").to_str().unwrap())
+           .arg(builder.config.src.join("src/librustdoc/html/static/themes").to_str().unwrap())
            .env("RUSTC_STAGE", self.compiler.stage.to_string())
            .env("RUSTC_SYSROOT", builder.sysroot(self.compiler))
            .env("RUSTDOC_LIBDIR", builder.sysroot_libdir(self.compiler, self.compiler.host))
@@ -524,7 +524,7 @@ impl Step for Tidy {
         let _folder = build.fold_output(|| "tidy");
         println!("tidy check ({})", host);
         let mut cmd = builder.tool_cmd(Tool::Tidy);
-        cmd.arg(build.src.join("src"));
+        cmd.arg(build.config.src.join("src"));
         if !build.config.vendor {
             cmd.arg("--no-vendor");
         }
@@ -845,7 +845,7 @@ impl Step for Compiletest {
             cmd.arg("--rustdoc-path").arg(builder.rustdoc(compiler.host));
         }
 
-        cmd.arg("--src-base").arg(build.src.join("src/test").join(suite));
+        cmd.arg("--src-base").arg(build.config.src.join("src/test").join(suite));
         cmd.arg("--build-base").arg(testdir(build, compiler.host).join(suite));
         cmd.arg("--stage-id").arg(format!("stage{}-{}", compiler.stage, target));
         cmd.arg("--mode").arg(mode);
@@ -1025,7 +1025,7 @@ impl Step for Docs {
 
         // Do a breadth-first traversal of the `src/doc` directory and just run
         // tests for all files that end in `*.md`
-        let mut stack = vec![build.src.join("src/doc")];
+        let mut stack = vec![build.config.src.join("src/doc")];
         let _time = util::timeit();
         let _folder = build.fold_output(|| "test_docs");
 
@@ -1398,7 +1398,7 @@ impl Step for Crate {
                 .expect("nodejs not configured");
             let runner = format!("{} {}/src/etc/wasm32-shim.js",
                                  node.display(),
-                                 build.src.display());
+                                 build.config.src.display());
             cargo.env(format!("CARGO_TARGET_{}_RUNNER", envify(&target)), &runner);
         } else if build.remote_tested(target) {
             cargo.env(format!("CARGO_TARGET_{}_RUNNER", envify(&target)),
@@ -1625,7 +1625,7 @@ impl Step for Bootstrap {
         let build = builder.build;
         let mut cmd = Command::new(&build.initial_cargo);
         cmd.arg("test")
-           .current_dir(build.src.join("src/bootstrap"))
+           .current_dir(build.config.src.join("src/bootstrap"))
            .env("CARGO_TARGET_DIR", build.out.join("bootstrap-test"))
            .env("RUSTC_BOOTSTRAP", "1")
            .env("RUSTC", &build.initial_rustc);

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -122,7 +122,7 @@ impl Step for Linkcheck {
     }
 
     fn make_run(run: RunConfig) {
-        run.builder.ensure(Linkcheck { host: run.target });
+        run.builder.ensure(Linkcheck { host: run.host });
     }
 }
 
@@ -143,7 +143,7 @@ impl Step for Cargotest {
     fn make_run(run: RunConfig) {
         run.builder.ensure(Cargotest {
             stage: run.builder.top_stage,
-            host: run.target,
+            host: run.host,
         });
     }
 
@@ -188,7 +188,7 @@ impl Step for Cargo {
     fn make_run(run: RunConfig) {
         run.builder.ensure(Cargo {
             stage: run.builder.top_stage,
-            host: run.target,
+            host: run.host,
         });
     }
 
@@ -232,7 +232,7 @@ impl Step for Rls {
     fn make_run(run: RunConfig) {
         run.builder.ensure(Rls {
             stage: run.builder.top_stage,
-            host: run.target,
+            host: run.host,
         });
     }
 
@@ -278,7 +278,7 @@ impl Step for Rustfmt {
     fn make_run(run: RunConfig) {
         run.builder.ensure(Rustfmt {
             stage: run.builder.top_stage,
-            host: run.target,
+            host: run.host,
         });
     }
 
@@ -326,7 +326,7 @@ impl Step for Miri {
     fn make_run(run: RunConfig) {
         run.builder.ensure(Miri {
             stage: run.builder.top_stage,
-            host: run.target,
+            host: run.host,
         });
     }
 
@@ -378,7 +378,7 @@ impl Step for Clippy {
     fn make_run(run: RunConfig) {
         run.builder.ensure(Clippy {
             stage: run.builder.top_stage,
-            host: run.target,
+            host: run.host,
         });
     }
 

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -113,7 +113,7 @@ impl Step for Linkcheck {
 
         let _time = util::timeit();
         try_run(build, builder.tool_cmd(Tool::Linkchecker)
-                              .arg(build.out.join(host).join("doc")));
+                              .arg(build.config.out.join(host).join("doc")));
     }
 
     fn should_run(run: ShouldRun) -> ShouldRun {
@@ -159,7 +159,7 @@ impl Step for Cargotest {
         // Note that this is a short, cryptic, and not scoped directory name. This
         // is currently to minimize the length of path on Windows where we otherwise
         // quickly run into path name limit constraints.
-        let out_dir = build.out.join("ct");
+        let out_dir = build.config.out.join("ct");
         t!(fs::create_dir_all(&out_dir));
 
         let _time = util::timeit();
@@ -546,7 +546,7 @@ impl Step for Tidy {
 }
 
 fn testdir(build: &Build, host: Interned<String>) -> PathBuf {
-    build.out.join(host).join("test")
+    build.config.out.join(host).join("test")
 }
 
 macro_rules! default_test {
@@ -973,7 +973,7 @@ impl Step for Compiletest {
             cmd.env("PROFILER_SUPPORT", "1");
         }
 
-        cmd.env("RUST_TEST_TMPDIR", build.out.join("tmp"));
+        cmd.env("RUST_TEST_TMPDIR", build.config.out.join("tmp"));
 
         cmd.arg("--adb-path").arg("adb");
         cmd.arg("--adb-test-dir").arg(ADB_TEST_DIR);
@@ -1520,7 +1520,7 @@ impl Step for RemoteCopyLibs {
         builder.ensure(compile::Test { compiler, target });
 
         println!("REMOTE copy libs to emulator ({})", target);
-        t!(fs::create_dir_all(build.out.join("tmp")));
+        t!(fs::create_dir_all(build.config.out.join("tmp")));
 
         let server = builder.ensure(tool::RemoteTestServer { compiler, target });
 
@@ -1530,7 +1530,7 @@ impl Step for RemoteCopyLibs {
         cmd.arg("spawn-emulator")
            .arg(target)
            .arg(&server)
-           .arg(build.out.join("tmp"));
+           .arg(build.config.out.join("tmp"));
         if let Some(rootfs) = build.qemu_rootfs(target) {
             cmd.arg(rootfs);
         }
@@ -1568,7 +1568,7 @@ impl Step for Distcheck {
         let build = builder.build;
 
         println!("Distcheck");
-        let dir = build.out.join("tmp").join("distcheck");
+        let dir = build.config.out.join("tmp").join("distcheck");
         let _ = fs::remove_dir_all(&dir);
         t!(fs::create_dir_all(&dir));
 
@@ -1592,7 +1592,7 @@ impl Step for Distcheck {
 
         // Now make sure that rust-src has all of libstd's dependencies
         println!("Distcheck rust-src");
-        let dir = build.out.join("tmp").join("distcheck-src");
+        let dir = build.config.out.join("tmp").join("distcheck-src");
         let _ = fs::remove_dir_all(&dir);
         t!(fs::create_dir_all(&dir));
 
@@ -1626,7 +1626,7 @@ impl Step for Bootstrap {
         let mut cmd = Command::new(&build.initial_cargo);
         cmd.arg("test")
            .current_dir(build.config.src.join("src/bootstrap"))
-           .env("CARGO_TARGET_DIR", build.out.join("bootstrap-test"))
+           .env("CARGO_TARGET_DIR", build.config.out.join("bootstrap-test"))
            .env("RUSTC_BOOTSTRAP", "1")
            .env("RUSTC", &build.initial_rustc);
         if !build.fail_fast {

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -511,7 +511,6 @@ impl Step for Tidy {
     type Output = ();
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
-    const ONLY_BUILD: bool = true;
 
     /// Runs the `tidy` tool as compiled in `stage` by the `host` compiler.
     ///
@@ -1555,7 +1554,6 @@ pub struct Distcheck;
 
 impl Step for Distcheck {
     type Output = ();
-    const ONLY_BUILD: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         run.path("distcheck")
@@ -1621,7 +1619,6 @@ impl Step for Bootstrap {
     type Output = ();
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
-    const ONLY_BUILD: bool = true;
 
     /// Test the build system itself
     fn run(self, builder: &Builder) {

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -26,7 +26,7 @@ use build_helper::{self, output};
 
 use builder::{Kind, RunConfig, ShouldRun, Builder, Compiler, Step};
 use Crate as CargoCrate;
-use cache::{INTERNER, Interned};
+use cache::{Intern, Interned};
 use compile;
 use dist;
 use native;
@@ -1230,7 +1230,7 @@ impl Step for CrateNotDefault {
             target: self.target,
             mode: Mode::Libstd,
             test_kind: self.test_kind,
-            krate: INTERNER.intern_str(self.krate),
+            krate: self.krate.intern(),
         });
     }
 }

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1354,7 +1354,7 @@ impl Step for Crate {
         if test_kind.subcommand() == "test" && !build.config.cmd.fail_fast() {
             cargo.arg("--no-fail-fast");
         }
-        if build.doc_tests {
+        if builder.config.cmd.doc_tests() {
             cargo.arg("--doc");
         }
 

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -164,7 +164,7 @@ impl Step for Cargotest {
 
         let _time = util::timeit();
         let mut cmd = builder.tool_cmd(Tool::CargoTest);
-        try_run(build, cmd.arg(&build.config.initial_cargo)
+        try_run(build, cmd.arg(&build.config.general.initial_cargo)
                           .arg(&out_dir)
                           .env("RUSTC", builder.rustc(compiler))
                           .env("RUSTDOC", builder.rustdoc(compiler.host)));
@@ -1604,7 +1604,7 @@ impl Step for Distcheck {
         build.run(&mut cmd);
 
         let toml = dir.join("rust-src/lib/rustlib/src/rust/src/libstd/Cargo.toml");
-        build.run(Command::new(&build.config.initial_cargo)
+        build.run(Command::new(&build.config.general.initial_cargo)
                          .arg("generate-lockfile")
                          .arg("--manifest-path")
                          .arg(&toml)
@@ -1623,12 +1623,12 @@ impl Step for Bootstrap {
     /// Test the build system itself
     fn run(self, builder: &Builder) {
         let build = builder.build;
-        let mut cmd = Command::new(&build.config.initial_cargo);
+        let mut cmd = Command::new(&build.config.general.initial_cargo);
         cmd.arg("test")
            .current_dir(build.config.src.join("src/bootstrap"))
            .env("CARGO_TARGET_DIR", build.config.general.out.join("bootstrap-test"))
            .env("RUSTC_BOOTSTRAP", "1")
-           .env("RUSTC", &build.config.initial_rustc);
+           .env("RUSTC", &build.config.general.initial_rustc);
         if !build.config.cmd.fail_fast() {
             cmd.arg("--no-fail-fast");
         }

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -164,7 +164,7 @@ impl Step for Cargotest {
 
         let _time = util::timeit();
         let mut cmd = builder.tool_cmd(Tool::CargoTest);
-        try_run(build, cmd.arg(&build.initial_cargo)
+        try_run(build, cmd.arg(&build.config.initial_cargo)
                           .arg(&out_dir)
                           .env("RUSTC", builder.rustc(compiler))
                           .env("RUSTDOC", builder.rustdoc(compiler.host)));
@@ -1604,7 +1604,7 @@ impl Step for Distcheck {
         build.run(&mut cmd);
 
         let toml = dir.join("rust-src/lib/rustlib/src/rust/src/libstd/Cargo.toml");
-        build.run(Command::new(&build.initial_cargo)
+        build.run(Command::new(&build.config.initial_cargo)
                          .arg("generate-lockfile")
                          .arg("--manifest-path")
                          .arg(&toml)
@@ -1623,12 +1623,12 @@ impl Step for Bootstrap {
     /// Test the build system itself
     fn run(self, builder: &Builder) {
         let build = builder.build;
-        let mut cmd = Command::new(&build.initial_cargo);
+        let mut cmd = Command::new(&build.config.initial_cargo);
         cmd.arg("test")
            .current_dir(build.config.src.join("src/bootstrap"))
            .env("CARGO_TARGET_DIR", build.config.out.join("bootstrap-test"))
            .env("RUSTC_BOOTSTRAP", "1")
-           .env("RUSTC", &build.initial_rustc);
+           .env("RUSTC", &build.config.initial_rustc);
         if !build.fail_fast {
             cmd.arg("--no-fail-fast");
         }

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -17,7 +17,7 @@ use Mode;
 use Compiler;
 use builder::{Builder, RunConfig, ShouldRun, Step};
 use util::{add_lib_path, copy, exe};
-use compile::{self, librustc_stamp, libstd_stamp, libtest_stamp};
+use compile;
 use native;
 use channel::GitInfo;
 use cache::Interned;
@@ -54,9 +54,9 @@ impl Step for CleanTools {
 
         for &cur_mode in &[Mode::Libstd, Mode::Libtest, Mode::Librustc] {
             let stamp = match cur_mode {
-                Mode::Libstd => libstd_stamp(builder, compiler, target),
-                Mode::Libtest => libtest_stamp(builder, compiler, target),
-                Mode::Librustc => librustc_stamp(builder, compiler, target),
+                Mode::Libstd => builder.libstd_stamp(compiler, target),
+                Mode::Libtest => builder.libtest_stamp(compiler, target),
+                Mode::Librustc => builder.librustc_stamp(compiler, target),
                 _ => panic!(),
             };
 

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -332,6 +332,10 @@ impl Step for Rustdoc {
             builder.compiler(target_compiler.stage - 1, builder.build.build)
         };
 
+        // we need the full rustc compiler for both the build compiler and the target. proc macro
+        // libraries are required for the build compiler, whereas we need the target compiler to be
+        // built because rustdoc links to it
+        builder.ensure(compile::Rustc { compiler: build_compiler, target: build_compiler.host });
         builder.ensure(compile::Rustc { compiler: build_compiler, target });
 
         let _folder = build.fold_output(|| format!("stage{}-rustdoc", target_compiler.stage));

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -386,7 +386,7 @@ impl Step for Cargo {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.path("src/tools/cargo").default_condition(builder.build.config.extended)
+        run.path("src/tools/cargo").default_condition(builder.build.config.general.extended)
     }
 
     fn make_run(run: RunConfig) {
@@ -438,7 +438,7 @@ macro_rules! tool_extended {
 
             fn should_run(run: ShouldRun) -> ShouldRun {
                 let builder = run.builder;
-                run.path($path).default_condition(builder.build.config.extended)
+                run.path($path).default_condition(builder.build.config.general.extended)
             }
 
             fn make_run(run: RunConfig) {

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -163,7 +163,7 @@ pub fn prepare_tool_cargo(
     // own copy
     cargo.env("LZMA_API_STATIC", "1");
 
-    cargo.env("CFG_RELEASE_CHANNEL", &build.config.channel);
+    cargo.env("CFG_RELEASE_CHANNEL", &build.config.rust.channel);
     cargo.env("CFG_VERSION", build.rust_version());
 
     let info = GitInfo::new(&build.config, &dir);
@@ -348,8 +348,8 @@ impl Step for Rustdoc {
                                            "src/tools/rustdoc");
 
         // Most tools don't get debuginfo, but rustdoc should.
-        cargo.env("RUSTC_DEBUGINFO", builder.config.rust_debuginfo.to_string())
-             .env("RUSTC_DEBUGINFO_LINES", builder.config.rust_debuginfo_lines.to_string());
+        cargo.env("RUSTC_DEBUGINFO", builder.config.rust.debuginfo().to_string())
+             .env("RUSTC_DEBUGINFO_LINES", builder.config.rust.debuginfo_lines().to_string());
 
         build.run(&mut cargo);
         // Cargo adds a number of paths to the dylib search path on windows, which results in

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -146,7 +146,7 @@ pub fn prepare_tool_cargo(
 ) -> Command {
     let build = builder.build;
     let mut cargo = builder.cargo(compiler, Mode::Tool, target, command);
-    let dir = build.src.join(path);
+    let dir = build.config.src.join(path);
     cargo.arg("--manifest-path").arg(dir.join("Cargo.toml"));
 
     // We don't want to build tools dynamically as they'll be running across

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -38,7 +38,6 @@ impl Step for CleanTools {
     }
 
     fn run(self, builder: &Builder) {
-        let build = builder.build;
         let compiler = self.compiler;
         let target = self.target;
         let mode = self.mode;
@@ -46,7 +45,7 @@ impl Step for CleanTools {
         // This is for the original compiler, but if we're forced to use stage 1, then
         // std/test/rustc stamps won't exist in stage 2, so we need to get those from stage 1, since
         // we copy the libs forward.
-        let tools_dir = build.stage_out(compiler, Mode::Tool);
+        let tools_dir = builder.stage_out(compiler, Mode::Tool);
         let compiler = if builder.force_use_stage1(compiler, target) {
             builder.compiler(1, compiler.host)
         } else {
@@ -55,13 +54,13 @@ impl Step for CleanTools {
 
         for &cur_mode in &[Mode::Libstd, Mode::Libtest, Mode::Librustc] {
             let stamp = match cur_mode {
-                Mode::Libstd => libstd_stamp(build, compiler, target),
-                Mode::Libtest => libtest_stamp(build, compiler, target),
-                Mode::Librustc => librustc_stamp(build, compiler, target),
+                Mode::Libstd => libstd_stamp(builder, compiler, target),
+                Mode::Libtest => libtest_stamp(builder, compiler, target),
+                Mode::Librustc => librustc_stamp(builder, compiler, target),
                 _ => panic!(),
             };
 
-            if build.clear_if_dirty(&tools_dir, &stamp) {
+            if builder.clear_if_dirty(&tools_dir, &stamp) {
                 break;
             }
 
@@ -96,7 +95,6 @@ impl Step for ToolBuild {
     /// This will build the specified tool with the specified `host` compiler in
     /// `stage` into the normal cargo output directory.
     fn run(self, builder: &Builder) -> Option<PathBuf> {
-        let build = builder.build;
         let compiler = self.compiler;
         let target = self.target;
         let tool = self.tool;
@@ -110,15 +108,15 @@ impl Step for ToolBuild {
             Mode::Tool => panic!("unexpected Mode::Tool for tool build"),
         }
 
-        let _folder = build.fold_output(|| format!("stage{}-{}", compiler.stage, tool));
+        let _folder = builder.fold_output(|| format!("stage{}-{}", compiler.stage, tool));
         println!(
             "Building stage{} tool {} ({})",
             compiler.stage, tool, target
         );
 
         let mut cargo = prepare_tool_cargo(builder, compiler, target, "build", path);
-        let is_expected = build.try_run(&mut cargo);
-        build.save_toolstate(
+        let is_expected = builder.try_run(&mut cargo);
+        builder.save_toolstate(
             tool,
             if is_expected {
                 ToolState::TestFail
@@ -134,10 +132,10 @@ impl Step for ToolBuild {
                 return None;
             }
         } else {
-            let cargo_out = build
+            let cargo_out = builder
                 .cargo_out(compiler, Mode::Tool, target)
                 .join(exe(tool, &compiler.host));
-            let bin = build.tools_dir(compiler).join(exe(tool, &compiler.host));
+            let bin = builder.tools_dir(compiler).join(exe(tool, &compiler.host));
             copy(&cargo_out, &bin);
             Some(bin)
         }
@@ -151,16 +149,15 @@ pub fn prepare_tool_cargo(
     command: &'static str,
     path: &'static str,
 ) -> Command {
-    let build = builder.build;
     let mut cargo = builder.cargo(compiler, Mode::Tool, target, command);
-    let dir = build.config.src.join(path);
+    let dir = builder.config.src.join(path);
     cargo.arg("--manifest-path").arg(dir.join("Cargo.toml"));
 
     // We don't want to build tools dynamically as they'll be running across
     // stages and such and it's just easier if they're not dynamically linked.
     cargo.env("RUSTC_NO_PREFER_DYNAMIC", "1");
 
-    if let Some(dir) = build.openssl_install_dir(target) {
+    if let Some(dir) = builder.openssl_install_dir(target) {
         cargo.env("OPENSSL_STATIC", "1");
         cargo.env("OPENSSL_DIR", dir);
         cargo.env("LIBZ_SYS_STATIC", "1");
@@ -170,10 +167,10 @@ pub fn prepare_tool_cargo(
     // own copy
     cargo.env("LZMA_API_STATIC", "1");
 
-    cargo.env("CFG_RELEASE_CHANNEL", &build.config.rust.channel);
-    cargo.env("CFG_VERSION", build.rust_version());
+    cargo.env("CFG_RELEASE_CHANNEL", &builder.config.rust.channel);
+    cargo.env("CFG_VERSION", builder.rust_version());
 
-    let info = GitInfo::new(&build.config, &dir);
+    let info = GitInfo::new(&builder.config, &dir);
     if let Some(sha) = info.sha() {
         cargo.env("CFG_COMMIT_HASH", sha);
     }
@@ -201,8 +198,8 @@ macro_rules! tool {
                 match tool {
                     $(Tool::$name =>
                         self.ensure($name {
-                            compiler: self.compiler(stage, self.build.config.general.build),
-                            target: self.build.config.general.build,
+                            compiler: self.compiler(stage, self.config.general.build),
+                            target: self.config.general.build,
                         }),
                     )+
                 }
@@ -237,7 +234,7 @@ macro_rules! tool {
             fn make_run(run: RunConfig) {
                 run.builder.ensure($name {
                     compiler: run.builder.compiler(run.builder.top_stage,
-                                  run.builder.build.config.general.build),
+                                  run.builder.config.general.build),
                     target: run.target,
                 });
             }
@@ -286,10 +283,8 @@ impl Step for RemoteTestServer {
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(RemoteTestServer {
-            compiler: run.builder.compiler(
-                run.builder.top_stage,
-                run.builder.build.config.general.build,
-            ),
+            compiler: run.builder
+                .compiler(run.builder.top_stage, run.builder.config.general.build),
             target: run.target,
         });
     }
@@ -327,23 +322,19 @@ impl Step for Rustdoc {
     }
 
     fn run(self, builder: &Builder) -> PathBuf {
-        let build = builder.build;
         let target_compiler = builder.compiler(builder.top_stage, self.host);
         let target = target_compiler.host;
         let build_compiler = if target_compiler.stage == 0 {
-            builder.compiler(0, builder.build.config.general.build)
+            builder.compiler(0, builder.config.general.build)
         } else if target_compiler.stage >= 2 {
             // Past stage 2, we consider the compiler to be ABI-compatible and hence capable of
             // building rustdoc itself.
-            builder.compiler(target_compiler.stage, builder.build.config.general.build)
+            builder.compiler(target_compiler.stage, builder.config.general.build)
         } else {
             // Similar to `compile::Assemble`, build with the previous stage's compiler. Otherwise
             // we'd have stageN/bin/rustc and stageN/bin/rustdoc be effectively different stage
             // compilers, which isn't what we want.
-            builder.compiler(
-                target_compiler.stage - 1,
-                builder.build.config.general.build,
-            )
+            builder.compiler(target_compiler.stage - 1, builder.config.general.build)
         };
 
         // we need the full rustc compiler for both the build compiler and the target. proc macro
@@ -358,7 +349,7 @@ impl Step for Rustdoc {
             target,
         });
 
-        let _folder = build.fold_output(|| format!("stage{}-rustdoc", target_compiler.stage));
+        let _folder = builder.fold_output(|| format!("stage{}-rustdoc", target_compiler.stage));
         println!(
             "Building rustdoc for stage{} ({})",
             target_compiler.stage, target_compiler.host
@@ -383,11 +374,11 @@ impl Step for Rustdoc {
                 builder.config.rust.debuginfo_lines().to_string(),
             );
 
-        build.run(&mut cargo);
+        builder.run(&mut cargo);
         // Cargo adds a number of paths to the dylib search path on windows, which results in
         // the wrong rustdoc being executed. To avoid the conflicting rustdocs, we name the "tool"
         // rustdoc a different name.
-        let tool_rustdoc = build
+        let tool_rustdoc = builder
             .cargo_out(build_compiler, Mode::Tool, target)
             .join(exe("rustdoc-tool-binary", &target_compiler.host));
 
@@ -420,15 +411,13 @@ impl Step for Cargo {
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
         run.path("src/tools/cargo")
-            .default_condition(builder.build.config.general.extended)
+            .default_condition(builder.config.general.extended)
     }
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(Cargo {
-            compiler: run.builder.compiler(
-                run.builder.top_stage,
-                run.builder.build.config.general.build,
-            ),
+            compiler: run.builder
+                .compiler(run.builder.top_stage, run.builder.config.general.build),
             target: run.target,
         });
     }
@@ -441,7 +430,7 @@ impl Step for Cargo {
         // compiler to be available, so we need to depend on that.
         builder.ensure(compile::Rustc {
             compiler: self.compiler,
-            target: builder.build.config.general.build,
+            target: builder.config.general.build,
         });
         builder
             .ensure(ToolBuild {
@@ -477,13 +466,13 @@ macro_rules! tool_extended {
 
             fn should_run(run: ShouldRun) -> ShouldRun {
                 let builder = run.builder;
-                run.path($path).default_condition(builder.build.config.general.extended)
+                run.path($path).default_condition(builder.config.general.extended)
             }
 
             fn make_run(run: RunConfig) {
                 run.builder.ensure($name {
                     compiler: run.builder.compiler(
-                                  run.builder.top_stage, run.builder.build.config.general.build),
+                                  run.builder.top_stage, run.builder.config.general.build),
                     target: run.target,
                 });
             }
@@ -511,7 +500,7 @@ tool_extended!((self, builder),
         // compiler to be available, so we need to depend on that.
         builder.ensure(compile::Rustc {
             compiler: self.compiler,
-            target: builder.build.config.general.build,
+            target: builder.config.general.build,
         });
     };
     Miri, miri, "src/tools/miri", "miri", {};
@@ -523,7 +512,7 @@ tool_extended!((self, builder),
         // compiler to be available, so we need to depend on that.
         builder.ensure(compile::Rustc {
             compiler: self.compiler,
-            target: builder.build.config.general.build,
+            target: builder.config.general.build,
         });
     };
     Rustfmt, rustfmt, "src/tools/rustfmt", "rustfmt", {};
@@ -534,10 +523,7 @@ impl<'a> Builder<'a> {
     /// `host`.
     pub fn tool_cmd(&self, tool: Tool) -> Command {
         let mut cmd = Command::new(self.tool_exe(tool));
-        let compiler = self.compiler(
-            self.tool_default_stage(tool),
-            self.build.config.general.build,
-        );
+        let compiler = self.compiler(self.tool_default_stage(tool), self.config.general.build);
         self.prepare_tool_cmd(compiler, &mut cmd);
         cmd
     }

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -105,6 +105,9 @@ impl Step for ToolBuild {
             Mode::Libstd => builder.ensure(compile::Std { compiler, target }),
             Mode::Libtest => builder.ensure(compile::Test { compiler, target }),
             Mode::Librustc => builder.ensure(compile::Rustc { compiler, target }),
+            Mode::CodegenBackend(name) => builder.ensure(compile::CodegenBackend {
+                compiler, target, backend: name,
+            }),
             Mode::Tool => panic!("unexpected Mode::Tool for tool build"),
         }
 

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -194,8 +194,8 @@ macro_rules! tool {
                 match tool {
                     $(Tool::$name =>
                         self.ensure($name {
-                            compiler: self.compiler(stage, self.build.config.build),
-                            target: self.build.config.build,
+                            compiler: self.compiler(stage, self.build.config.general.build),
+                            target: self.build.config.general.build,
                         }),
                     )+
                 }
@@ -229,7 +229,7 @@ macro_rules! tool {
 
             fn make_run(run: RunConfig) {
                 run.builder.ensure($name {
-                    compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.build),
+                    compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.general.build),
                     target: run.target,
                 });
             }
@@ -278,7 +278,7 @@ impl Step for RemoteTestServer {
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(RemoteTestServer {
-            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.build),
+            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.general.build),
             target: run.target,
         });
     }
@@ -320,16 +320,16 @@ impl Step for Rustdoc {
         let target_compiler = builder.compiler(builder.top_stage, self.host);
         let target = target_compiler.host;
         let build_compiler = if target_compiler.stage == 0 {
-            builder.compiler(0, builder.build.config.build)
+            builder.compiler(0, builder.build.config.general.build)
         } else if target_compiler.stage >= 2 {
             // Past stage 2, we consider the compiler to be ABI-compatible and hence capable of
             // building rustdoc itself.
-            builder.compiler(target_compiler.stage, builder.build.config.build)
+            builder.compiler(target_compiler.stage, builder.build.config.general.build)
         } else {
             // Similar to `compile::Assemble`, build with the previous stage's compiler. Otherwise
             // we'd have stageN/bin/rustc and stageN/bin/rustdoc be effectively different stage
             // compilers, which isn't what we want.
-            builder.compiler(target_compiler.stage - 1, builder.build.config.build)
+            builder.compiler(target_compiler.stage - 1, builder.build.config.general.build)
         };
 
         // we need the full rustc compiler for both the build compiler and the target. proc macro
@@ -391,7 +391,7 @@ impl Step for Cargo {
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(Cargo {
-            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.build),
+            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.general.build),
             target: run.target,
         });
     }
@@ -404,7 +404,7 @@ impl Step for Cargo {
         // compiler to be available, so we need to depend on that.
         builder.ensure(compile::Rustc {
             compiler: self.compiler,
-            target: builder.build.config.build,
+            target: builder.build.config.general.build,
         });
         builder.ensure(ToolBuild {
             compiler: self.compiler,
@@ -443,7 +443,7 @@ macro_rules! tool_extended {
 
             fn make_run(run: RunConfig) {
                 run.builder.ensure($name {
-                    compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.build),
+                    compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.config.general.build),
                     target: run.target,
                 });
             }
@@ -471,7 +471,7 @@ tool_extended!((self, builder),
         // compiler to be available, so we need to depend on that.
         builder.ensure(compile::Rustc {
             compiler: self.compiler,
-            target: builder.build.config.build,
+            target: builder.build.config.general.build,
         });
     };
     Miri, miri, "src/tools/miri", "miri", {};
@@ -483,7 +483,7 @@ tool_extended!((self, builder),
         // compiler to be available, so we need to depend on that.
         builder.ensure(compile::Rustc {
             compiler: self.compiler,
-            target: builder.build.config.build,
+            target: builder.build.config.general.build,
         });
     };
     Rustfmt, rustfmt, "src/tools/rustfmt", "rustfmt", {};
@@ -494,7 +494,7 @@ impl<'a> Builder<'a> {
     /// `host`.
     pub fn tool_cmd(&self, tool: Tool) -> Command {
         let mut cmd = Command::new(self.tool_exe(tool));
-        let compiler = self.compiler(self.tool_default_stage(tool), self.build.config.build);
+        let compiler = self.compiler(self.tool_default_stage(tool), self.build.config.general.build);
         self.prepare_tool_cmd(compiler, &mut cmd);
         cmd
     }

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -15,7 +15,7 @@ use std::process::{exit, Command};
 
 use Mode;
 use Compiler;
-use builder::{Builder, RunConfig, ShouldRun, Step};
+use builder::{CargoCommand, Builder, RunConfig, ShouldRun, Step};
 use util::{add_lib_path, copy, exe};
 use compile;
 use native;
@@ -145,13 +145,13 @@ impl Step for ToolBuild {
     }
 }
 
-pub fn prepare_tool_cargo(
-    builder: &Builder,
+pub fn prepare_tool_cargo<'a>(
+    builder: &'a Builder<'a>,
     compiler: Compiler,
     target: Interned<String>,
     command: &'static str,
     path: &'static str,
-) -> Command {
+) -> CargoCommand<'a> {
     let mut cargo = builder.cargo(compiler, Mode::Tool, target, command);
     let dir = builder.config.src.join(path);
     cargo.arg("--manifest-path").arg(dir.join("Cargo.toml"));

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -156,23 +156,6 @@ pub fn prepare_tool_cargo<'a>(
     let dir = builder.config.src.join(path);
     cargo.arg("--manifest-path").arg(dir.join("Cargo.toml"));
 
-    // We don't want to build tools dynamically as they'll be running across
-    // stages and such and it's just easier if they're not dynamically linked.
-    cargo.env("RUSTC_NO_PREFER_DYNAMIC", "1");
-
-    if let Some(dir) = builder.openssl_install_dir(target) {
-        cargo.env("OPENSSL_STATIC", "1");
-        cargo.env("OPENSSL_DIR", dir);
-        cargo.env("LIBZ_SYS_STATIC", "1");
-    }
-
-    // if tools are using lzma we want to force the build script to build its
-    // own copy
-    cargo.env("LZMA_API_STATIC", "1");
-
-    cargo.env("CFG_RELEASE_CHANNEL", &builder.config.rust.channel);
-    cargo.env("CFG_VERSION", builder.rust_version());
-
     let info = GitInfo::new(&builder.config, &dir);
     if let Some(sha) = info.sha() {
         cargo.env("CFG_COMMIT_HASH", sha);

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fs;
 use std::env;
 use std::path::PathBuf;
 use std::process::{exit, Command};
@@ -22,6 +21,7 @@ use native;
 use channel::GitInfo;
 use cache::Interned;
 use toolstate::ToolState;
+use fs;
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 struct ToolBuild {
@@ -81,7 +81,11 @@ impl Step for ToolBuild {
 
         if !is_expected {
             if !is_ext_tool {
-                exit(1);
+                if cfg!(test) {
+                    panic!("unexpected failure; would have aborted");
+                } else {
+                    exit(1);
+                }
             } else {
                 return None;
             }

--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -16,10 +16,10 @@
 use std::env;
 use std::str;
 use std::fs::{self, File, OpenOptions};
-use std::io::{self, Read, Write, Seek, SeekFrom};
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::{SystemTime, Instant};
+use std::time::{Instant, SystemTime};
 
 use filetime::{self, FileTime};
 
@@ -38,11 +38,15 @@ pub fn copy(src: &Path, dst: &Path) {
     // Attempt to "easy copy" by creating a hard link (symlinks don't work on
     // windows), but if that fails just fall back to a slow `copy` operation.
     if let Ok(()) = fs::hard_link(src, dst) {
-        return
+        return;
     }
     if let Err(e) = fs::copy(src, dst) {
-        panic!("failed to copy `{}` to `{}`: {}", src.display(),
-               dst.display(), e)
+        panic!(
+            "failed to copy `{}` to `{}`: {}",
+            src.display(),
+            dst.display(),
+            e
+        )
     }
     let metadata = t!(src.metadata());
     t!(fs::set_permissions(dst, metadata.permissions()));
@@ -73,7 +77,7 @@ pub fn read_stamp_file(stamp: &Path) -> Vec<PathBuf> {
     // run_cargo for more information (in compile.rs).
     for part in contents.split(|b| *b == 0) {
         if part.is_empty() {
-            continue
+            continue;
         }
         let path = PathBuf::from(t!(str::from_utf8(part)));
         paths.push(path);
@@ -146,7 +150,11 @@ pub fn is_dylib(name: &str) -> bool {
 /// Returns the corresponding relative library directory that the compiler's
 /// dylibs will be found in.
 pub fn libdir(target: &str) -> &'static str {
-    if target.contains("windows") {"bin"} else {"lib"}
+    if target.contains("windows") {
+        "bin"
+    } else {
+        "lib"
+    }
 }
 
 /// Adds a list of lookup paths to `cmd`'s dynamic library lookup path.
@@ -180,7 +188,9 @@ pub fn dylib_path() -> Vec<PathBuf> {
 
 /// `push` all components to `buf`. On windows, append `.exe` to the last component.
 pub fn push_exe_path(mut buf: PathBuf, components: &[&str]) -> PathBuf {
-    let (&file, components) = components.split_last().expect("at least one component required");
+    let (&file, components) = components
+        .split_last()
+        .expect("at least one component required");
     let mut file = file.to_owned();
 
     if cfg!(windows) {
@@ -206,9 +216,11 @@ pub fn timeit() -> TimeIt {
 impl Drop for TimeIt {
     fn drop(&mut self) {
         let time = self.0.elapsed();
-        println!("\tfinished in {}.{:03}",
-                 time.as_secs(),
-                 time.subsec_nanos() / 1_000_000);
+        println!(
+            "\tfinished in {}.{:03}",
+            time.as_secs(),
+            time.subsec_nanos() / 1_000_000
+        );
     }
 }
 
@@ -272,22 +284,25 @@ pub fn symlink_dir(src: &Path, dest: &Path) -> io::Result<()> {
         }
 
         extern "system" {
-            fn CreateFileW(lpFileName: LPCWSTR,
-                           dwDesiredAccess: DWORD,
-                           dwShareMode: DWORD,
-                           lpSecurityAttributes: LPSECURITY_ATTRIBUTES,
-                           dwCreationDisposition: DWORD,
-                           dwFlagsAndAttributes: DWORD,
-                           hTemplateFile: HANDLE)
-                           -> HANDLE;
-            fn DeviceIoControl(hDevice: HANDLE,
-                               dwIoControlCode: DWORD,
-                               lpInBuffer: LPVOID,
-                               nInBufferSize: DWORD,
-                               lpOutBuffer: LPVOID,
-                               nOutBufferSize: DWORD,
-                               lpBytesReturned: LPDWORD,
-                               lpOverlapped: LPOVERLAPPED) -> BOOL;
+            fn CreateFileW(
+                lpFileName: LPCWSTR,
+                dwDesiredAccess: DWORD,
+                dwShareMode: DWORD,
+                lpSecurityAttributes: LPSECURITY_ATTRIBUTES,
+                dwCreationDisposition: DWORD,
+                dwFlagsAndAttributes: DWORD,
+                hTemplateFile: HANDLE,
+            ) -> HANDLE;
+            fn DeviceIoControl(
+                hDevice: HANDLE,
+                dwIoControlCode: DWORD,
+                lpInBuffer: LPVOID,
+                nInBufferSize: DWORD,
+                lpOutBuffer: LPVOID,
+                nOutBufferSize: DWORD,
+                lpBytesReturned: LPDWORD,
+                lpOverlapped: LPOVERLAPPED,
+            ) -> BOOL;
         }
 
         fn to_u16s<S: AsRef<OsStr>>(s: S) -> io::Result<Vec<u16>> {
@@ -304,17 +319,18 @@ pub fn symlink_dir(src: &Path, dest: &Path) -> io::Result<()> {
         let path = try!(to_u16s(junction));
 
         unsafe {
-            let h = CreateFileW(path.as_ptr(),
-                                GENERIC_WRITE,
-                                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                                0 as *mut _,
-                                OPEN_EXISTING,
-                                FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS,
-                                ptr::null_mut());
+            let h = CreateFileW(
+                path.as_ptr(),
+                GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                0 as *mut _,
+                OPEN_EXISTING,
+                FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS,
+                ptr::null_mut(),
+            );
 
             let mut data = [0u8; MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
-            let db = data.as_mut_ptr()
-                            as *mut REPARSE_MOUNTPOINT_DATA_BUFFER;
+            let db = data.as_mut_ptr() as *mut REPARSE_MOUNTPOINT_DATA_BUFFER;
             let buf = &mut (*db).ReparseTarget as *mut u16;
             let mut i = 0;
             // FIXME: this conversion is very hacky
@@ -329,17 +345,19 @@ pub fn symlink_dir(src: &Path, dest: &Path) -> io::Result<()> {
             (*db).ReparseTag = IO_REPARSE_TAG_MOUNT_POINT;
             (*db).ReparseTargetMaximumLength = (i * 2) as WORD;
             (*db).ReparseTargetLength = ((i - 1) * 2) as WORD;
-            (*db).ReparseDataLength =
-                    (*db).ReparseTargetLength as DWORD + 12;
+            (*db).ReparseDataLength = (*db).ReparseTargetLength as DWORD + 12;
 
             let mut ret = 0;
-            let res = DeviceIoControl(h as *mut _,
-                                      FSCTL_SET_REPARSE_POINT,
-                                      data.as_ptr() as *mut _,
-                                      (*db).ReparseDataLength + 8,
-                                      ptr::null_mut(), 0,
-                                      &mut ret,
-                                      ptr::null_mut());
+            let res = DeviceIoControl(
+                h as *mut _,
+                FSCTL_SET_REPARSE_POINT,
+                data.as_ptr() as *mut _,
+                (*db).ReparseDataLength + 8,
+                ptr::null_mut(),
+                0,
+                &mut ret,
+                ptr::null_mut(),
+            );
 
             if res == 0 {
                 Err(io::Error::last_os_error())
@@ -376,7 +394,10 @@ impl OutputFolder {
         // the ANSI escape code to clear from the cursor to end of line.
         // Travis seems to have trouble when _not_ using "\r\x1b[0K", that will
         // randomly put lines to the top of the webpage.
-        print!("travis_fold:start:{0}\r\x1b[0Ktravis_time:start:{0}\r\x1b[0K", name);
+        print!(
+            "travis_fold:start:{0}\r\x1b[0Ktravis_time:start:{0}\r\x1b[0K",
+            name
+        );
         OutputFolder {
             name,
             start_time: SystemTime::now(),
@@ -402,7 +423,7 @@ impl Drop for OutputFolder {
         let finish = end_time.duration_since(UNIX_EPOCH);
         println!(
             "travis_fold:end:{0}\r\x1b[0K\n\
-                travis_time:end:{0}:start={1},finish={2},duration={3}\r\x1b[0K",
+             travis_time:end:{0}:start={1},finish={2},duration={3}\r\x1b[0K",
             self.name,
             to_nanos(start),
             to_nanos(finish),

--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -424,6 +424,12 @@ pub enum CiEnv {
     AppVeyor,
 }
 
+impl Default for CiEnv {
+    fn default() -> CiEnv {
+        CiEnv::None
+    }
+}
+
 impl CiEnv {
     /// Obtains the current CI environment.
     pub fn current() -> CiEnv {

--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -15,12 +15,12 @@
 
 use std::env;
 use std::str;
-use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Instant, SystemTime};
 
+use fs::{self, File, OpenOptions};
 use filetime::{self, FileTime};
 
 /// Returns the `name` as the filename of a static library for `target`.
@@ -34,6 +34,7 @@ pub fn staticlib(name: &str, target: &str) -> String {
 
 /// Copies a file from `src` to `dst`
 pub fn copy(src: &Path, dst: &Path) {
+    if cfg!(test) { return; }
     let _ = fs::remove_file(&dst);
     // Attempt to "easy copy" by creating a hard link (symlinks don't work on
     // windows), but if that fails just fall back to a slow `copy` operation.
@@ -70,6 +71,7 @@ pub fn replace_in_file(path: &Path, replacements: &[(&str, &str)]) {
 }
 
 pub fn read_stamp_file(stamp: &Path) -> Vec<PathBuf> {
+    if cfg!(test) { return Vec::new(); }
     let mut paths = Vec::new();
     let mut contents = Vec::new();
     t!(t!(File::open(stamp)).read_to_end(&mut contents));

--- a/src/ci/docker/arm-android/Dockerfile
+++ b/src/ci/docker/arm-android/Dockerfile
@@ -31,9 +31,7 @@ ENV PATH=$PATH:/android/sdk/platform-tools
 
 ENV TARGETS=arm-linux-androideabi
 
-ENV RUST_CONFIGURE_ARGS \
-      --target=$TARGETS \
-      --arm-linux-androideabi-ndk=/android/ndk/arm-14
+ENV RUST_CONFIGURE_ARGS --arm-linux-androideabi-ndk=/android/ndk/arm-14
 
 ENV SCRIPT python2.7 ../x.py test --target $TARGETS
 

--- a/src/ci/docker/armhf-gnu/Dockerfile
+++ b/src/ci/docker/armhf-gnu/Dockerfile
@@ -76,9 +76,7 @@ RUN curl -O http://ftp.nl.debian.org/debian/dists/jessie/main/installer-armhf/cu
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV RUST_CONFIGURE_ARGS \
-      --target=arm-unknown-linux-gnueabihf \
-      --qemu-armhf-rootfs=/tmp/rootfs
+ENV RUST_CONFIGURE_ARGS --qemu-armhf-rootfs=/tmp/rootfs
 ENV SCRIPT python2.7 ../x.py test --target arm-unknown-linux-gnueabihf
 
 ENV NO_CHANGE_USER=1

--- a/src/ci/docker/asmjs/Dockerfile
+++ b/src/ci/docker/asmjs/Dockerfile
@@ -29,6 +29,6 @@ ENV EM_CONFIG=/emsdk-portable/.emscripten
 
 ENV TARGETS=asmjs-unknown-emscripten
 
-ENV RUST_CONFIGURE_ARGS --target=$TARGETS --enable-emscripten
+ENV RUST_CONFIGURE_ARGS --enable-emscripten
 
 ENV SCRIPT python2.7 ../x.py test --target $TARGETS

--- a/src/ci/docker/disabled/aarch64-gnu/Dockerfile
+++ b/src/ci/docker/disabled/aarch64-gnu/Dockerfile
@@ -74,7 +74,6 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV RUST_CONFIGURE_ARGS \
-      --target=aarch64-unknown-linux-gnu \
       --qemu-aarch64-rootfs=/tmp/rootfs
 ENV SCRIPT python2.7 ../x.py test --target aarch64-unknown-linux-gnu
 ENV NO_CHANGE_USER=1

--- a/src/ci/docker/disabled/dist-aarch64-android/Dockerfile
+++ b/src/ci/docker/disabled/dist-aarch64-android/Dockerfile
@@ -14,8 +14,6 @@ ENV DEP_Z_ROOT=/android/ndk/arm64-21/sysroot/usr/
 ENV HOSTS=aarch64-linux-android
 
 ENV RUST_CONFIGURE_ARGS \
-      --host=$HOSTS \
-      --target=$HOSTS \
       --aarch64-linux-android-ndk=/android/ndk/arm64-21 \
       --disable-rpath \
       --enable-extended \

--- a/src/ci/docker/disabled/dist-armv7-android/Dockerfile
+++ b/src/ci/docker/disabled/dist-armv7-android/Dockerfile
@@ -20,8 +20,6 @@ ENV DEP_Z_ROOT=/android/ndk/arm-14/sysroot/usr/
 ENV HOSTS=armv7-linux-androideabi
 
 ENV RUST_CONFIGURE_ARGS \
-      --host=$HOSTS \
-      --target=$HOSTS \
       --armv7-linux-androideabi-ndk=/android/ndk/arm \
       --disable-rpath \
       --enable-extended \

--- a/src/ci/docker/disabled/dist-i686-android/Dockerfile
+++ b/src/ci/docker/disabled/dist-i686-android/Dockerfile
@@ -20,8 +20,6 @@ ENV DEP_Z_ROOT=/android/ndk/x86-14/sysroot/usr/
 ENV HOSTS=i686-linux-android
 
 ENV RUST_CONFIGURE_ARGS \
-      --host=$HOSTS \
-      --target=$HOSTS \
       --i686-linux-android-ndk=/android/ndk/x86 \
       --disable-rpath \
       --enable-extended \

--- a/src/ci/docker/disabled/dist-x86_64-android/Dockerfile
+++ b/src/ci/docker/disabled/dist-x86_64-android/Dockerfile
@@ -14,8 +14,6 @@ ENV DEP_Z_ROOT=/android/ndk/x86_64-21/sysroot/usr/
 ENV HOSTS=x86_64-linux-android
 
 ENV RUST_CONFIGURE_ARGS \
-      --host=$HOSTS \
-      --target=$HOSTS \
       --x86_64-linux-android-ndk=/android/ndk/x86_64-21 \
       --disable-rpath \
       --enable-extended \

--- a/src/ci/docker/disabled/dist-x86_64-dragonfly/Dockerfile
+++ b/src/ci/docker/disabled/dist-x86_64-dragonfly/Dockerfile
@@ -32,5 +32,5 @@ ENV \
 
 ENV HOSTS=x86_64-unknown-dragonfly
 
-ENV RUST_CONFIGURE_ARGS --host=$HOSTS --enable-extended
+ENV RUST_CONFIGURE_ARGS --enable-extended
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/disabled/dist-x86_64-haiku/Dockerfile
+++ b/src/ci/docker/disabled/dist-x86_64-haiku/Dockerfile
@@ -42,8 +42,8 @@ RUN sh /scripts/sccache.sh
 ENV HOST=x86_64-unknown-haiku
 ENV TARGET=target.$HOST
 
-ENV RUST_CONFIGURE_ARGS --host=$HOST --target=$HOST --disable-jemalloc \
+ENV RUST_CONFIGURE_ARGS --disable-jemalloc \
   --set=$TARGET.cc=x86_64-unknown-haiku-gcc \
   --set=$TARGET.cxx=x86_64-unknown-haiku-g++ \
   --set=$TARGET.llvm-config=/bin/llvm-config-haiku
-ENV SCRIPT python2.7 ../x.py dist
+ENV SCRIPT python2.7 ../x.py dist --host=$HOST --target=$HOST

--- a/src/ci/docker/disabled/dist-x86_64-redox/Dockerfile
+++ b/src/ci/docker/disabled/dist-x86_64-redox/Dockerfile
@@ -18,5 +18,5 @@ ENV \
     CC_x86_64_unknown_redox=x86_64-unknown-redox-gcc \
     CXX_x86_64_unknown_redox=x86_64-unknown-redox-g++
 
-ENV RUST_CONFIGURE_ARGS --target=x86_64-unknown-redox --enable-extended
+ENV RUST_CONFIGURE_ARGS --enable-extended
 ENV SCRIPT python2.7 ../x.py dist --target x86_64-unknown-redox

--- a/src/ci/docker/disabled/wasm32-exp/Dockerfile
+++ b/src/ci/docker/disabled/wasm32-exp/Dockerfile
@@ -30,6 +30,6 @@ ENV EM_CONFIG=/root/.emscripten
 
 ENV TARGETS=wasm32-experimental-emscripten
 
-ENV RUST_CONFIGURE_ARGS --target=$TARGETS --experimental-targets=WebAssembly
+ENV RUST_CONFIGURE_ARGS --experimental-targets=WebAssembly
 
 ENV SCRIPT python2.7 ../x.py test --target $TARGETS

--- a/src/ci/docker/disabled/wasm32/Dockerfile
+++ b/src/ci/docker/disabled/wasm32/Dockerfile
@@ -29,7 +29,4 @@ ENV BINARYEN_ROOT=/emsdk-portable/clang/e1.37.13_64bit/binaryen/
 ENV EM_CONFIG=/emsdk-portable/.emscripten
 
 ENV TARGETS=wasm32-unknown-emscripten
-
-ENV RUST_CONFIGURE_ARGS --target=$TARGETS
-
 ENV SCRIPT python2.7 ../x.py test --target $TARGETS

--- a/src/ci/docker/dist-aarch64-linux/Dockerfile
+++ b/src/ci/docker/dist-aarch64-linux/Dockerfile
@@ -32,5 +32,5 @@ ENV CC_aarch64_unknown_linux_gnu=aarch64-unknown-linux-gnueabi-gcc \
 
 ENV HOSTS=aarch64-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --host=$HOSTS --enable-extended
+ENV RUST_CONFIGURE_ARGS --enable-extended
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-android/Dockerfile
+++ b/src/ci/docker/dist-android/Dockerfile
@@ -21,7 +21,6 @@ ENV TARGETS=$TARGETS,aarch64-linux-android
 ENV TARGETS=$TARGETS,x86_64-linux-android
 
 ENV RUST_CONFIGURE_ARGS \
-      --target=$TARGETS \
       --enable-extended \
       --arm-linux-androideabi-ndk=/android/ndk/arm-14 \
       --armv7-linux-androideabi-ndk=/android/ndk/arm-14 \

--- a/src/ci/docker/dist-arm-linux/Dockerfile
+++ b/src/ci/docker/dist-arm-linux/Dockerfile
@@ -32,5 +32,5 @@ ENV CC_arm_unknown_linux_gnueabi=arm-unknown-linux-gnueabi-gcc \
 
 ENV HOSTS=arm-unknown-linux-gnueabi
 
-ENV RUST_CONFIGURE_ARGS --host=$HOSTS --enable-extended
+ENV RUST_CONFIGURE_ARGS --enable-extended
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-armhf-linux/Dockerfile
+++ b/src/ci/docker/dist-armhf-linux/Dockerfile
@@ -32,5 +32,5 @@ ENV CC_arm_unknown_linux_gnueabihf=arm-unknown-linux-gnueabihf-gcc \
 
 ENV HOSTS=arm-unknown-linux-gnueabihf
 
-ENV RUST_CONFIGURE_ARGS --host=$HOSTS --enable-extended
+ENV RUST_CONFIGURE_ARGS --enable-extended
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-armv7-linux/Dockerfile
+++ b/src/ci/docker/dist-armv7-linux/Dockerfile
@@ -32,5 +32,5 @@ ENV CC_armv7_unknown_linux_gnueabihf=armv7-unknown-linux-gnueabihf-gcc \
 
 ENV HOSTS=armv7-unknown-linux-gnueabihf
 
-ENV RUST_CONFIGURE_ARGS --host=$HOSTS --enable-extended
+ENV RUST_CONFIGURE_ARGS --enable-extended
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-i586-gnu-i586-i686-musl/Dockerfile
+++ b/src/ci/docker/dist-i586-gnu-i586-i686-musl/Dockerfile
@@ -30,7 +30,6 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV RUST_CONFIGURE_ARGS \
-      --target=i686-unknown-linux-musl,i586-unknown-linux-gnu \
       --musl-root-i586=/musl-i586 \
       --musl-root-i686=/musl-i686 \
       --enable-extended
@@ -46,8 +45,7 @@ ENV CFLAGS_i586_unknown_linux_gnu=-Wa,-mrelax-relocations=no
 #       https://github.com/alexcrichton/cc-rs/pull/281
 ENV CFLAGS_i586_unknown_linux_musl="-Wa,-mrelax-relocations=no -Wl,-melf_i386"
 
-ENV TARGETS=i586-unknown-linux-gnu
-ENV TARGETS=$TARGETS,i686-unknown-linux-musl
+ENV TARGETS=i586-unknown-linux-gnu,i686-unknown-linux-musl
 
 ENV SCRIPT \
       python2.7 ../x.py test --target $TARGETS && \

--- a/src/ci/docker/dist-i686-freebsd/Dockerfile
+++ b/src/ci/docker/dist-i686-freebsd/Dockerfile
@@ -29,5 +29,5 @@ ENV \
 
 ENV HOSTS=i686-unknown-freebsd
 
-ENV RUST_CONFIGURE_ARGS --host=$HOSTS --enable-extended
+ENV RUST_CONFIGURE_ARGS --enable-extended
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-i686-linux/Dockerfile
+++ b/src/ci/docker/dist-i686-linux/Dockerfile
@@ -82,13 +82,11 @@ RUN sh /scripts/sccache.sh
 ENV HOSTS=i686-unknown-linux-gnu
 
 ENV RUST_CONFIGURE_ARGS \
-      --host=$HOSTS \
       --enable-extended \
       --enable-sanitizers \
       --enable-profiler \
       --enable-emscripten \
-      --build=i686-unknown-linux-gnu
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python2.7 ../x.py dist --build $HOSTS --host $HOSTS --target $HOSTS
 
 # This is the only builder which will create source tarballs
 ENV DIST_SRC 1

--- a/src/ci/docker/dist-mips-linux/Dockerfile
+++ b/src/ci/docker/dist-mips-linux/Dockerfile
@@ -22,5 +22,5 @@ RUN sh /scripts/sccache.sh
 
 ENV HOSTS=mips-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --host=$HOSTS --enable-extended
+ENV RUST_CONFIGURE_ARGS --enable-extended
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-mips64-linux/Dockerfile
+++ b/src/ci/docker/dist-mips64-linux/Dockerfile
@@ -21,5 +21,5 @@ RUN sh /scripts/sccache.sh
 
 ENV HOSTS=mips64-unknown-linux-gnuabi64
 
-ENV RUST_CONFIGURE_ARGS --host=$HOSTS --enable-extended
+ENV RUST_CONFIGURE_ARGS --enable-extended
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-mips64el-linux/Dockerfile
+++ b/src/ci/docker/dist-mips64el-linux/Dockerfile
@@ -22,5 +22,5 @@ RUN sh /scripts/sccache.sh
 
 ENV HOSTS=mips64el-unknown-linux-gnuabi64
 
-ENV RUST_CONFIGURE_ARGS --host=$HOSTS --enable-extended
+ENV RUST_CONFIGURE_ARGS --enable-extended
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-mipsel-linux/Dockerfile
+++ b/src/ci/docker/dist-mipsel-linux/Dockerfile
@@ -21,5 +21,5 @@ RUN sh /scripts/sccache.sh
 
 ENV HOSTS=mipsel-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --host=$HOSTS --enable-extended
+ENV RUST_CONFIGURE_ARGS --enable-extended
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-powerpc-linux/Dockerfile
+++ b/src/ci/docker/dist-powerpc-linux/Dockerfile
@@ -34,7 +34,7 @@ ENV \
 
 ENV HOSTS=powerpc-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --host=$HOSTS --enable-extended
+ENV RUST_CONFIGURE_ARGS --enable-extended
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
 
 # FIXME(#36150) this will fail the bootstrap. Probably means something bad is

--- a/src/ci/docker/dist-powerpc64-linux/Dockerfile
+++ b/src/ci/docker/dist-powerpc64-linux/Dockerfile
@@ -35,5 +35,5 @@ ENV \
 
 ENV HOSTS=powerpc64-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --host=$HOSTS --enable-extended
+ENV RUST_CONFIGURE_ARGS --enable-extended
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-powerpc64le-linux/Dockerfile
+++ b/src/ci/docker/dist-powerpc64le-linux/Dockerfile
@@ -32,5 +32,5 @@ ENV \
 
 ENV HOSTS=powerpc64le-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --host=$HOSTS --enable-extended
+ENV RUST_CONFIGURE_ARGS --enable-extended
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-s390x-linux/Dockerfile
+++ b/src/ci/docker/dist-s390x-linux/Dockerfile
@@ -34,5 +34,5 @@ ENV \
 
 ENV HOSTS=s390x-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --host=$HOSTS --enable-extended
+ENV RUST_CONFIGURE_ARGS --enable-extended
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-various-1/Dockerfile
+++ b/src/ci/docker/dist-various-1/Dockerfile
@@ -89,7 +89,6 @@ ENV CC_mipsel_unknown_linux_musl=mipsel-openwrt-linux-gcc \
     CFLAGS_armv5te_unknown_linux_gnueabi="-march=armv5te -marm -mfloat-abi=soft"
 
 ENV RUST_CONFIGURE_ARGS \
-      --target=$TARGETS \
       --musl-root-arm=/musl-arm \
       --musl-root-armhf=/musl-armhf \
       --musl-root-armv7=/musl-armv7 \

--- a/src/ci/docker/dist-various-2/Dockerfile
+++ b/src/ci/docker/dist-various-2/Dockerfile
@@ -55,5 +55,5 @@ ENV TARGETS=$TARGETS,x86_64-sun-solaris
 ENV TARGETS=$TARGETS,x86_64-unknown-linux-gnux32
 ENV TARGETS=$TARGETS,x86_64-unknown-cloudabi
 
-ENV RUST_CONFIGURE_ARGS --target=$TARGETS --enable-extended
+ENV RUST_CONFIGURE_ARGS --enable-extended
 ENV SCRIPT python2.7 ../x.py dist --target $TARGETS

--- a/src/ci/docker/dist-x86_64-freebsd/Dockerfile
+++ b/src/ci/docker/dist-x86_64-freebsd/Dockerfile
@@ -29,5 +29,5 @@ ENV \
 
 ENV HOSTS=x86_64-unknown-freebsd
 
-ENV RUST_CONFIGURE_ARGS --host=$HOSTS --enable-extended
+ENV RUST_CONFIGURE_ARGS --enable-extended
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/dist-x86_64-linux/Dockerfile
@@ -82,7 +82,6 @@ RUN sh /scripts/sccache.sh
 ENV HOSTS=x86_64-unknown-linux-gnu
 
 ENV RUST_CONFIGURE_ARGS \
-      --host=$HOSTS \
       --enable-extended \
       --enable-sanitizers \
       --enable-profiler \

--- a/src/ci/docker/dist-x86_64-musl/Dockerfile
+++ b/src/ci/docker/dist-x86_64-musl/Dockerfile
@@ -30,7 +30,6 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV RUST_CONFIGURE_ARGS \
-      --target=x86_64-unknown-linux-musl \
       --musl-root-x86_64=/musl-x86_64 \
       --enable-extended
 

--- a/src/ci/docker/dist-x86_64-netbsd/Dockerfile
+++ b/src/ci/docker/dist-x86_64-netbsd/Dockerfile
@@ -33,5 +33,5 @@ ENV \
 
 ENV HOSTS=x86_64-unknown-netbsd
 
-ENV RUST_CONFIGURE_ARGS --host=$HOSTS --enable-extended
+ENV RUST_CONFIGURE_ARGS --enable-extended
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/wasm32-unknown/Dockerfile
+++ b/src/ci/docker/wasm32-unknown/Dockerfile
@@ -22,7 +22,6 @@ RUN sh /scripts/sccache.sh
 ENV TARGETS=wasm32-unknown-unknown
 
 ENV RUST_CONFIGURE_ARGS \
-  --target=$TARGETS \
   --set build.nodejs=/node-v9.2.0-linux-x64/bin/node
 
 ENV SCRIPT python2.7 /checkout/x.py test --target $TARGETS \


### PR DESCRIPTION
The important commits for review are marked with `[VIC]`. Each commit is intended to be relatively small, even though the overall patch is quite large. I would recommend reviewing by-commit for review purposes. I'm happy to split this PR up into smaller ones if that makes things easier -- the last commit (which implements the actual tests) is fairly small, though it builds on the refactoring done in the rest of the commits quite heavily.

### Configuration refactor

This PR refactors the configuration to utilize `Default` impls for the structs and to directly include toml-deserialized structs in the final `Config` struct. This avoids quite a bit of boilerplate code, and, in my opinion, makes it considerably easier to understand what the default value for a given option is. It's intended that nothing has actually changed, but it's possible that I've accidentally forgotten some option -- I've tried to check manually and found nothing relevant.

### Testing design (also included in relevant commit)

In order to run tests, various parts of rustbuild are cfg'd out,
generally speaking, these are filesystem-related operations and running
commands. Then, rustbuild is run "as normal" and the various steps that
where run are retrieved from the cache and checked against the expected
results.

Note that this means that the current implementation primarily tests
"what" we build, but doesn't actually test that what we build *will*
build. In other words, it doesn't do any form of dependency verification
for any crate. This is possible to implement, but is considered future
work.

This implementation strives to cfg out as little code as possible; it
also does not currently test anywhere near all of rustbuild. The current
tests are also not checked for "correctness," rather, they simply
represent what we do as of this commit, which may be wrong.

A fake fs module is also added to src/bootstrap/lib.rs and used
throughout rustbuild to make it so that most of the code doesn't have to
cfg out create_dir_all and remove_dir_all, etc.

Test cases are drawn from the old implementation of rustbuild, though
the expected results may vary.

r? @alexcrichton 