### PR TITLE
The Great Generics Generalisation: Ty Edition

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1459,10 +1459,9 @@ impl<'a> LoweringContext<'a> {
                             return n;
                         }
                         assert!(!def_id.is_local());
-                        let n = self.cstore
-                            .item_generics_cloned_untracked(def_id, self.sess)
-                            .lifetimes()
-                            .len();
+                        let item_generics =
+                            self.cstore.item_generics_cloned_untracked(def_id, self.sess);
+                        let n = item_generics.lifetimes().count();
                         self.type_def_lifetime_params.insert(def_id, n);
                         n
                     });

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1895,11 +1895,13 @@ impl<'a> LoweringContext<'a> {
                 GenericParam::Lifetime(ref lifetime_def) => {
                     hir::GenericParam::Lifetime(self.lower_lifetime_def(lifetime_def))
                 }
-                GenericParam::Type(ref ty_param) => hir::GenericParam::Type(self.lower_ty_param(
-                    ty_param,
-                    add_bounds.get(&ty_param.id).map_or(&[][..], |x| &x),
-                    itctx,
-                )),
+                GenericParam::Type(ref ty_param) => {
+                    hir::GenericParam::Type(self.lower_ty_param(
+                        ty_param,
+                        add_bounds.get(&ty_param.id).map_or(&[][..], |x| &x),
+                        itctx,
+                    ))
+                }
             })
             .collect()
     }

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -374,8 +374,8 @@ impl<'a> LoweringContext<'a> {
 
                 if item_lowered {
                     let item_lifetimes = match self.lctx.items.get(&item.id).unwrap().node {
-                        hir::Item_::ItemImpl(_, _, _, ref generics, .. ) |
-                        hir::Item_::ItemTrait(_, _, ref generics, .. ) => {
+                        hir::Item_::ItemImpl(_, _, _, ref generics, ..)
+                        | hir::Item_::ItemTrait(_, _, ref generics, ..) => {
                             generics.lifetimes().cloned().collect::<Vec<_>>()
                         }
                         _ => Vec::new(),
@@ -1895,13 +1895,11 @@ impl<'a> LoweringContext<'a> {
                 GenericParam::Lifetime(ref lifetime_def) => {
                     hir::GenericParam::Lifetime(self.lower_lifetime_def(lifetime_def))
                 }
-                GenericParam::Type(ref ty_param) => {
-                    hir::GenericParam::Type(self.lower_ty_param(
-                        ty_param,
-                        add_bounds.get(&ty_param.id).map_or(&[][..], |x| &x),
-                        itctx,
-                    ))
-                }
+                GenericParam::Type(ref ty_param) => hir::GenericParam::Type(self.lower_ty_param(
+                    ty_param,
+                    add_bounds.get(&ty_param.id).map_or(&[][..], |x| &x),
+                    itctx,
+                )),
             })
             .collect()
     }

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1461,7 +1461,7 @@ impl<'a> LoweringContext<'a> {
                         assert!(!def_id.is_local());
                         let n = self.cstore
                             .item_generics_cloned_untracked(def_id, self.sess)
-                            .regions
+                            .lifetimes()
                             .len();
                         self.type_def_lifetime_params.insert(def_id, n);
                         n

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -46,6 +46,7 @@ use hir::HirVec;
 use hir::map::{DefKey, DefPathData, Definitions};
 use hir::def_id::{DefId, DefIndex, DefIndexAddressSpace, CRATE_DEF_INDEX};
 use hir::def::{Def, PathResolution};
+use ty::Kind;
 use lint::builtin::{self, PARENTHESIZED_PARAMS_IN_TYPES_AND_MODULES};
 use middle::cstore::CrateStore;
 use rustc_data_structures::indexed_vec::IndexVec;
@@ -1461,7 +1462,7 @@ impl<'a> LoweringContext<'a> {
                         assert!(!def_id.is_local());
                         let item_generics =
                             self.cstore.item_generics_cloned_untracked(def_id, self.sess);
-                        let n = item_generics.lifetimes().count();
+                        let n = item_generics.param_counts()[&Kind::Lifetime];
                         self.type_def_lifetime_params.insert(def_id, n);
                         n
                     });

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -46,7 +46,6 @@ use hir::HirVec;
 use hir::map::{DefKey, DefPathData, Definitions};
 use hir::def_id::{DefId, DefIndex, DefIndexAddressSpace, CRATE_DEF_INDEX};
 use hir::def::{Def, PathResolution};
-use ty::Kind;
 use lint::builtin::{self, PARENTHESIZED_PARAMS_IN_TYPES_AND_MODULES};
 use middle::cstore::CrateStore;
 use rustc_data_structures::indexed_vec::IndexVec;
@@ -1462,7 +1461,7 @@ impl<'a> LoweringContext<'a> {
                         assert!(!def_id.is_local());
                         let item_generics =
                             self.cstore.item_generics_cloned_untracked(def_id, self.sess);
-                        let n = item_generics.param_counts()[&Kind::Lifetime];
+                        let n = item_generics.param_counts().lifetimes;
                         self.type_def_lifetime_params.insert(def_id, n);
                         n
                     });

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -374,8 +374,8 @@ impl<'a> LoweringContext<'a> {
 
                 if item_lowered {
                     let item_lifetimes = match self.lctx.items.get(&item.id).unwrap().node {
-                        hir::Item_::ItemImpl(_, _, _, ref generics, ..)
-                        | hir::Item_::ItemTrait(_, _, ref generics, ..) => {
+                        hir::Item_::ItemImpl(_, _, _, ref generics, .. ) |
+                        hir::Item_::ItemTrait(_, _, ref generics, .. ) => {
                             generics.lifetimes().cloned().collect::<Vec<_>>()
                         }
                         _ => Vec::new(),

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1461,7 +1461,7 @@ impl<'a> LoweringContext<'a> {
                         assert!(!def_id.is_local());
                         let item_generics =
                             self.cstore.item_generics_cloned_untracked(def_id, self.sess);
-                        let n = item_generics.param_counts().lifetimes;
+                        let n = item_generics.own_counts().lifetimes;
                         self.type_def_lifetime_params.insert(def_id, n);
                         n
                     });

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -2043,7 +2043,10 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    pub fn print_generic_params(&mut self, generic_params: &[hir::GenericParam]) -> io::Result<()> {
+    pub fn print_generic_params(&mut self,
+                                generic_params: &[hir::GenericParam])
+                                -> io::Result<()>
+    {
         if !generic_params.is_empty() {
             self.s.word("<")?;
 

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -2043,10 +2043,7 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    pub fn print_generic_params(&mut self,
-                                generic_params: &[hir::GenericParam])
-                                -> io::Result<()>
-    {
+    pub fn print_generic_params(&mut self, generic_params: &[hir::GenericParam]) -> io::Result<()> {
         if !generic_params.is_empty() {
             self.s.word("<")?;
 

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -753,7 +753,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for ty::Generics {
     }
 }
 
-impl_stable_hash_for!(enum ty::GenericParameterDef {
+impl_stable_hash_for!(enum ty::GenericParam {
     Lifetime(lt),
     Type(ty)
 });

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -738,7 +738,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for ty::Generics {
             ref parent_count,
             ref params,
 
-            // Reverse map to each `TypeParameterDef`'s `index` field, from
+            // Reverse map to each `TypeParamDef`'s `index` field, from
             // `def_id.index` (`def_id.krate` is the same as the item's).
             type_param_to_index: _, // Don't hash this
             has_self,
@@ -759,11 +759,11 @@ impl_stable_hash_for!(enum ty::GenericParamDef {
 });
 
 impl<'a> HashStable<StableHashingContext<'a>>
-for ty::RegionParameterDef {
+for ty::RegionParamDef {
     fn hash_stable<W: StableHasherResult>(&self,
                                           hcx: &mut StableHashingContext<'a>,
                                           hasher: &mut StableHasher<W>) {
-        let ty::RegionParameterDef {
+        let ty::RegionParamDef {
             name,
             def_id,
             index,
@@ -777,7 +777,7 @@ for ty::RegionParameterDef {
     }
 }
 
-impl_stable_hash_for!(struct ty::TypeParameterDef {
+impl_stable_hash_for!(struct ty::TypeParamDef {
     name,
     def_id,
     index,

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -736,7 +736,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for ty::Generics {
         let ty::Generics {
             parent,
             ref parent_count,
-            ref parameters,
+            ref params,
 
             // Reverse map to each `TypeParameterDef`'s `index` field, from
             // `def_id.index` (`def_id.krate` is the same as the item's).
@@ -747,7 +747,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for ty::Generics {
 
         parent.hash_stable(hcx, hasher);
         parent_count.hash_stable(hcx, hasher);
-        parameters.hash_stable(hcx, hasher);
+        params.hash_stable(hcx, hasher);
         has_self.hash_stable(hcx, hasher);
         has_late_bound_regions.hash_stable(hcx, hasher);
     }

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -753,34 +753,23 @@ impl<'a> HashStable<StableHashingContext<'a>> for ty::Generics {
     }
 }
 
-impl_stable_hash_for!(enum ty::GenericParamDef {
+impl_stable_hash_for!(enum ty::GenericParamDefKind {
     Lifetime(lt),
     Type(ty)
 });
 
-impl<'a> HashStable<StableHashingContext<'a>>
-for ty::RegionParamDef {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
-        let ty::RegionParamDef {
-            name,
-            def_id,
-            index,
-            pure_wrt_drop
-        } = *self;
-
-        name.hash_stable(hcx, hasher);
-        def_id.hash_stable(hcx, hasher);
-        index.hash_stable(hcx, hasher);
-        pure_wrt_drop.hash_stable(hcx, hasher);
-    }
-}
-
-impl_stable_hash_for!(struct ty::TypeParamDef {
+impl_stable_hash_for!(struct ty::GenericParamDef {
     name,
     def_id,
     index,
+    kind
+});
+
+impl_stable_hash_for!(struct ty::RegionParamDef {
+    pure_wrt_drop
+});
+
+impl_stable_hash_for!(struct ty::TypeParamDef {
     has_default,
     object_lifetime_default,
     pure_wrt_drop,

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -735,7 +735,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for ty::Generics {
                                           hasher: &mut StableHasher<W>) {
         let ty::Generics {
             parent,
-            ref parent_parameters,
+            ref parent_count,
             ref parameters,
 
             // Reverse map to each `TypeParameterDef`'s `index` field, from
@@ -746,7 +746,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for ty::Generics {
         } = *self;
 
         parent.hash_stable(hcx, hasher);
-        parent_parameters.hash_stable(hcx, hasher);
+        parent_count.hash_stable(hcx, hasher);
         parameters.hash_stable(hcx, hasher);
         has_self.hash_stable(hcx, hasher);
         has_late_bound_regions.hash_stable(hcx, hasher);

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -765,7 +765,7 @@ impl_stable_hash_for!(struct ty::GenericParamDef {
     kind
 });
 
-impl_stable_hash_for!(struct ty::RegionParamDef {
+impl_stable_hash_for!(struct ty::LifetimeParamDef {
     pure_wrt_drop
 });
 

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -753,7 +753,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for ty::Generics {
     }
 }
 
-impl_stable_hash_for!(enum ty::GenericParam {
+impl_stable_hash_for!(enum ty::GenericParamDef {
     Lifetime(lt),
     Type(ty)
 });

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -754,7 +754,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for ty::Generics {
 }
 
 impl_stable_hash_for!(enum ty::GenericParamDefKind {
-    Lifetime(lt),
+    Lifetime,
     Type(ty)
 });
 
@@ -762,17 +762,13 @@ impl_stable_hash_for!(struct ty::GenericParamDef {
     name,
     def_id,
     index,
+    pure_wrt_drop,
     kind
-});
-
-impl_stable_hash_for!(struct ty::LifetimeParamDef {
-    pure_wrt_drop
 });
 
 impl_stable_hash_for!(struct ty::TypeParamDef {
     has_default,
     object_lifetime_default,
-    pure_wrt_drop,
     synthetic
 });
 

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -735,10 +735,8 @@ impl<'a> HashStable<StableHashingContext<'a>> for ty::Generics {
                                           hasher: &mut StableHasher<W>) {
         let ty::Generics {
             parent,
-            parent_regions,
-            parent_types,
-            ref regions,
-            ref types,
+            ref parent_parameters,
+            ref parameters,
 
             // Reverse map to each `TypeParameterDef`'s `index` field, from
             // `def_id.index` (`def_id.krate` is the same as the item's).
@@ -748,14 +746,17 @@ impl<'a> HashStable<StableHashingContext<'a>> for ty::Generics {
         } = *self;
 
         parent.hash_stable(hcx, hasher);
-        parent_regions.hash_stable(hcx, hasher);
-        parent_types.hash_stable(hcx, hasher);
-        regions.hash_stable(hcx, hasher);
-        types.hash_stable(hcx, hasher);
+        parent_parameters.hash_stable(hcx, hasher);
+        parameters.hash_stable(hcx, hasher);
         has_self.hash_stable(hcx, hasher);
         has_late_bound_regions.hash_stable(hcx, hasher);
     }
 }
+
+impl_stable_hash_for!(enum ty::GenericParameterDef {
+    Lifetime(lt),
+    Type(ty)
+});
 
 impl<'a> HashStable<StableHashingContext<'a>>
 for ty::RegionParameterDef {

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -740,7 +740,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for ty::Generics {
 
             // Reverse map to each `TypeParamDef`'s `index` field, from
             // `def_id.index` (`def_id.krate` is the same as the item's).
-            type_param_to_index: _, // Don't hash this
+            param_def_id_to_index: _, // Don't hash this
             has_self,
             has_late_bound_regions,
         } = *self;

--- a/src/librustc/infer/anon_types/mod.rs
+++ b/src/librustc/infer/anon_types/mod.rs
@@ -315,7 +315,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         let mut least_region = None;
         for param in &abstract_type_generics.params {
             match param.kind {
-                GenericParamDefKind::Lifetime(_) => {}
+                GenericParamDefKind::Lifetime => {}
                 _ => continue
             }
             // Get the value supplied for this region from the substs.

--- a/src/librustc/infer/anon_types/mod.rs
+++ b/src/librustc/infer/anon_types/mod.rs
@@ -313,7 +313,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         // `['a]` for the first impl trait and `'b` for the
         // second.
         let mut least_region = None;
-        for region_def in abstract_type_generics.lifetimes() {
+        for region_def in abstract_type_generics.lifetimes_depr() {
             // Find the index of this region in the list of substitutions.
             let index = region_def.index as usize;
 

--- a/src/librustc/infer/anon_types/mod.rs
+++ b/src/librustc/infer/anon_types/mod.rs
@@ -313,16 +313,13 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         // `['a]` for the first impl trait and `'b` for the
         // second.
         let mut least_region = None;
-        for index in abstract_type_generics.params.iter().filter_map(|param| {
-            if let GenericParamDefKind::Lifetime(_) = param.kind {
-                // Find the index of this region in the list of substitutions.
-                Some(param.index as usize)
-            } else {
-                None
+        for param in &abstract_type_generics.params {
+            match param.kind {
+                GenericParamDefKind::Lifetime(_) => {}
+                _ => continue
             }
-        }) {
             // Get the value supplied for this region from the substs.
-            let subst_arg = anon_defn.substs.region_at(index);
+            let subst_arg = anon_defn.substs.region_at(param.index as usize);
 
             // Compute the least upper bound of it with the other regions.
             debug!("constrain_anon_types: least_region={:?}", least_region);

--- a/src/librustc/infer/anon_types/mod.rs
+++ b/src/librustc/infer/anon_types/mod.rs
@@ -616,10 +616,9 @@ impl<'cx, 'gcx, 'tcx> TypeFolder<'gcx, 'tcx> for ReverseMapper<'cx, 'gcx, 'tcx> 
                 // during trans.
 
                 let generics = self.tcx.generics_of(def_id);
-                let parent_len = generics.parent_count();
                 let substs = self.tcx.mk_substs(substs.substs.iter().enumerate().map(
                     |(index, &kind)| {
-                        if index < parent_len {
+                        if index < generics.parent_count {
                             // Accommodate missing regions in the parent kinds...
                             self.fold_kind_mapping_missing_regions_to_empty(kind)
                         } else {

--- a/src/librustc/infer/anon_types/mod.rs
+++ b/src/librustc/infer/anon_types/mod.rs
@@ -14,7 +14,7 @@ use infer::outlives::free_region_map::FreeRegionRelations;
 use rustc_data_structures::fx::FxHashMap;
 use syntax::ast;
 use traits::{self, PredicateObligation};
-use ty::{self, Ty, TyCtxt, GenericParamDef};
+use ty::{self, Ty, TyCtxt, GenericParamDefKind};
 use ty::fold::{BottomUpFolder, TypeFoldable, TypeFolder};
 use ty::outlives::Component;
 use ty::subst::{Kind, Substs, UnpackedKind};
@@ -313,16 +313,14 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         // `['a]` for the first impl trait and `'b` for the
         // second.
         let mut least_region = None;
-        for region_def in abstract_type_generics.params.iter().filter_map(|param| {
-            if let GenericParamDef::Lifetime(lt) = param {
-                Some(lt)
+        for index in abstract_type_generics.params.iter().filter_map(|param| {
+            if let GenericParamDefKind::Lifetime(_) = param.kind {
+                // Find the index of this region in the list of substitutions.
+                Some(param.index as usize)
             } else {
                 None
             }
         }) {
-            // Find the index of this region in the list of substitutions.
-            let index = region_def.index as usize;
-
             // Get the value supplied for this region from the substs.
             let subst_arg = anon_defn.substs.region_at(index);
 

--- a/src/librustc/infer/anon_types/mod.rs
+++ b/src/librustc/infer/anon_types/mod.rs
@@ -14,7 +14,7 @@ use infer::outlives::free_region_map::FreeRegionRelations;
 use rustc_data_structures::fx::FxHashMap;
 use syntax::ast;
 use traits::{self, PredicateObligation};
-use ty::{self, Ty, TyCtxt};
+use ty::{self, Ty, TyCtxt, GenericParamDef};
 use ty::fold::{BottomUpFolder, TypeFoldable, TypeFolder};
 use ty::outlives::Component;
 use ty::subst::{Kind, Substs, UnpackedKind};
@@ -313,7 +313,13 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         // `['a]` for the first impl trait and `'b` for the
         // second.
         let mut least_region = None;
-        for region_def in abstract_type_generics.lifetimes_depr() {
+        for region_def in abstract_type_generics.params.iter().filter_map(|param| {
+            if let GenericParamDef::Lifetime(lt) = param {
+                Some(lt)
+            } else {
+                None
+            }
+        }) {
             // Find the index of this region in the list of substitutions.
             let index = region_def.index as usize;
 

--- a/src/librustc/infer/anon_types/mod.rs
+++ b/src/librustc/infer/anon_types/mod.rs
@@ -313,7 +313,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         // `['a]` for the first impl trait and `'b` for the
         // second.
         let mut least_region = None;
-        for region_def in &abstract_type_generics.regions {
+        for region_def in abstract_type_generics.lifetimes() {
             // Find the index of this region in the list of substitutions.
             let index = region_def.index as usize;
 

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -905,34 +905,34 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         self.next_region_var(RegionVariableOrigin::NLL(origin))
     }
 
-    /// Create a region inference variable for the given
-    /// region parameter definition.
-    pub fn region_var_for_def(&self,
-                              span: Span,
-                              def: &ty::GenericParamDef)
-                              -> ty::Region<'tcx> {
-        self.next_region_var(EarlyBoundRegion(span, def.name))
-    }
+    pub fn var_for_def(&self,
+                       span: Span,
+                       param: &ty::GenericParamDef)
+                       -> UnpackedKind<'tcx> {
+        match param.kind {
+            GenericParamDefKind::Lifetime => {
+                // Create a region inference variable for the given
+                // region parameter definition.
+                UnpackedKind::Lifetime(self.next_region_var(EarlyBoundRegion(span, param.name)))
+            }
+            GenericParamDefKind::Type(_) => {
+                // Create a type inference variable for the given
+                // type parameter definition. The substitutions are
+                // for actual parameters that may be referred to by
+                // the default of this type parameter, if it exists.
+                // E.g. `struct Foo<A, B, C = (A, B)>(...);` when
+                // used in a path such as `Foo::<T, U>::new()` will
+                // use an inference variable for `C` with `[T, U]`
+                // as the substitutions for the default, `(T, U)`.
+                let ty_var_id = self.type_variables
+                                    .borrow_mut()
+                                    .new_var(self.universe(),
+                                             false,
+                                             TypeVariableOrigin::TypeParameterDefinition(span, param.name));
 
-    /// Create a type inference variable for the given
-    /// type parameter definition. The substitutions are
-    /// for actual parameters that may be referred to by
-    /// the default of this type parameter, if it exists.
-    /// E.g. `struct Foo<A, B, C = (A, B)>(...);` when
-    /// used in a path such as `Foo::<T, U>::new()` will
-    /// use an inference variable for `C` with `[T, U]`
-    /// as the substitutions for the default, `(T, U)`.
-    pub fn type_var_for_def(&self,
-                            span: Span,
-                            def: &ty::GenericParamDef)
-                            -> Ty<'tcx> {
-        let ty_var_id = self.type_variables
-                            .borrow_mut()
-                            .new_var(self.universe(),
-                                     false,
-                                     TypeVariableOrigin::TypeParameterDefinition(span, def.name));
-
-        self.tcx.mk_var(ty_var_id)
+                UnpackedKind::Type(self.tcx.mk_var(ty_var_id))
+            }
+        }
     }
 
     /// Given a set of generics defined on a type or impl, returns a substitution mapping each
@@ -942,14 +942,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                                  def_id: DefId)
                                  -> &'tcx Substs<'tcx> {
         Substs::for_item(self.tcx, def_id, |param, _| {
-            match param.kind {
-                GenericParamDefKind::Lifetime => {
-                    UnpackedKind::Lifetime(self.region_var_for_def(span, param))
-                }
-                GenericParamDefKind::Type(_) => {
-                    UnpackedKind::Type(self.type_var_for_def(span, param))
-                }
-            }
+            self.var_for_def(span, param)
         })
     }
 

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -909,7 +909,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     /// region parameter definition.
     pub fn region_var_for_def(&self,
                               span: Span,
-                              def: &ty::RegionParamDef)
+                              def: &ty::GenericParamDef)
                               -> ty::Region<'tcx> {
         self.next_region_var(EarlyBoundRegion(span, def.name))
     }
@@ -924,7 +924,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     /// as the substitutions for the default, `(T, U)`.
     pub fn type_var_for_def(&self,
                             span: Span,
-                            def: &ty::TypeParamDef)
+                            def: &ty::GenericParamDef)
                             -> Ty<'tcx> {
         let ty_var_id = self.type_variables
                             .borrow_mut()

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -909,7 +909,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     /// region parameter definition.
     pub fn region_var_for_def(&self,
                               span: Span,
-                              def: &ty::RegionParameterDef)
+                              def: &ty::RegionParamDef)
                               -> ty::Region<'tcx> {
         self.next_region_var(EarlyBoundRegion(span, def.name))
     }
@@ -924,7 +924,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     /// as the substitutions for the default, `(T, U)`.
     pub fn type_var_for_def(&self,
                             span: Span,
-                            def: &ty::TypeParameterDef)
+                            def: &ty::TypeParamDef)
                             -> Ty<'tcx> {
         let ty_var_id = self.type_variables
                             .borrow_mut()

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -21,7 +21,7 @@ use hir::def_id::DefId;
 use middle::free_region::RegionRelations;
 use middle::region;
 use middle::lang_items;
-use ty::subst::{UnpackedKind, Substs};
+use ty::subst::{Kind, Substs};
 use ty::{TyVid, IntVid, FloatVid};
 use ty::{self, Ty, TyCtxt, GenericParamDefKind};
 use ty::error::{ExpectedFound, TypeError, UnconstrainedNumeric};
@@ -908,12 +908,12 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     pub fn var_for_def(&self,
                        span: Span,
                        param: &ty::GenericParamDef)
-                       -> UnpackedKind<'tcx> {
+                       -> Kind<'tcx> {
         match param.kind {
             GenericParamDefKind::Lifetime => {
                 // Create a region inference variable for the given
                 // region parameter definition.
-                UnpackedKind::Lifetime(self.next_region_var(EarlyBoundRegion(span, param.name)))
+                self.next_region_var(EarlyBoundRegion(span, param.name)).into()
             }
             GenericParamDefKind::Type(_) => {
                 // Create a type inference variable for the given
@@ -930,7 +930,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                                              false,
                                              TypeVariableOrigin::TypeParameterDefinition(span, param.name));
 
-                UnpackedKind::Type(self.tcx.mk_var(ty_var_id))
+                self.tcx.mk_var(ty_var_id).into()
             }
         }
     }

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -924,11 +924,12 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                 // used in a path such as `Foo::<T, U>::new()` will
                 // use an inference variable for `C` with `[T, U]`
                 // as the substitutions for the default, `(T, U)`.
-                let ty_var_id = self.type_variables
-                                    .borrow_mut()
-                                    .new_var(self.universe(),
-                                             false,
-                                             TypeVariableOrigin::TypeParameterDefinition(span, param.name));
+                let ty_var_id =
+                    self.type_variables
+                        .borrow_mut()
+                        .new_var(self.universe(),
+                                    false,
+                                    TypeVariableOrigin::TypeParameterDefinition(span, param.name));
 
                 self.tcx.mk_var(ty_var_id).into()
             }

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -49,6 +49,7 @@
 #![cfg_attr(stage0, feature(dyn_trait))]
 #![feature(from_ref)]
 #![feature(fs_read_write)]
+#![feature(iterator_find_map)]
 #![cfg_attr(windows, feature(libc))]
 #![cfg_attr(stage0, feature(macro_lifetime_matcher))]
 #![feature(macro_vis_matcher)]

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -1659,7 +1659,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                     .entry(def_id)
                     .or_insert_with(|| {
                         tcx.generics_of(def_id)
-                            .types
+                            .types()
                             .iter()
                             .map(|def| def.object_lifetime_default)
                             .collect()

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -1659,8 +1659,11 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                     .entry(def_id)
                     .or_insert_with(|| {
                         tcx.generics_of(def_id)
-                            .types_depr()
-                            .map(|def| def.object_lifetime_default)
+                            .params
+                            .iter()
+                            .filter_map(|param| {
+                                param.get_type().and_then(|ty| Some(ty.object_lifetime_default))
+                            })
                             .collect()
                     })
             };

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -667,8 +667,8 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
                 for lt_def in generics.lifetimes() {
                     let (lt_name, region) = Region::early(&self.tcx.hir, &mut index, &lt_def);
                     if let hir::LifetimeName::Underscore = lt_name {
-                        // Pick the elided lifetime "definition" if one exists and use it to make an
-                        // elision scope.
+                        // Pick the elided lifetime "definition" if one exists and use it to make
+                        // an elision scope.
                         elision = Some(region);
                     } else {
                         lifetimes.insert(lt_name, region);

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -1666,7 +1666,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                                     GenericParamDefKind::Type(ty) => {
                                         Some(ty.object_lifetime_default)
                                     }
-                                    GenericParamDefKind::Lifetime(_) => None,
+                                    GenericParamDefKind::Lifetime => None,
                                 }
                             })
                             .collect()

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -1660,7 +1660,6 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                     .or_insert_with(|| {
                         tcx.generics_of(def_id)
                             .types()
-                            .iter()
                             .map(|def| def.object_lifetime_default)
                             .collect()
                     })

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -1659,7 +1659,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                     .entry(def_id)
                     .or_insert_with(|| {
                         tcx.generics_of(def_id)
-                            .types()
+                            .types_depr()
                             .map(|def| def.object_lifetime_default)
                             .collect()
                     })

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -20,7 +20,7 @@ use hir::def_id::{CrateNum, DefId, LocalDefId, LOCAL_CRATE};
 use hir::map::Map;
 use hir::ItemLocalId;
 use hir::LifetimeName;
-use ty::{self, TyCtxt};
+use ty::{self, TyCtxt, GenericParamDef};
 
 use errors::DiagnosticBuilder;
 use rustc::lint;
@@ -1662,7 +1662,10 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                             .params
                             .iter()
                             .filter_map(|param| {
-                                param.get_type().and_then(|ty| Some(ty.object_lifetime_default))
+                                match *param {
+                                    GenericParamDef::Type(ty) => Some(ty.object_lifetime_default),
+                                    GenericParamDef::Lifetime(_) => None,
+                                }
                             })
                             .collect()
                     })

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -20,7 +20,7 @@ use hir::def_id::{CrateNum, DefId, LocalDefId, LOCAL_CRATE};
 use hir::map::Map;
 use hir::ItemLocalId;
 use hir::LifetimeName;
-use ty::{self, TyCtxt, GenericParamDef};
+use ty::{self, TyCtxt, GenericParamDefKind};
 
 use errors::DiagnosticBuilder;
 use rustc::lint;
@@ -1662,9 +1662,11 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                             .params
                             .iter()
                             .filter_map(|param| {
-                                match *param {
-                                    GenericParamDef::Type(ty) => Some(ty.object_lifetime_default),
-                                    GenericParamDef::Lifetime(_) => None,
+                                match param.kind {
+                                    GenericParamDefKind::Type(ty) => {
+                                        Some(ty.object_lifetime_default)
+                                    }
+                                    GenericParamDefKind::Lifetime(_) => None,
                                 }
                             })
                             .collect()

--- a/src/librustc/traits/auto_trait.rs
+++ b/src/librustc/traits/auto_trait.rs
@@ -226,7 +226,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                 .iter()
                 .filter_map(|param| {
                     match param.kind {
-                        ty::GenericParamDefKind::Lifetime(_) => Some(param.name.to_string()),
+                        ty::GenericParamDefKind::Lifetime => Some(param.name.to_string()),
                         _ => None
                     }
                 })

--- a/src/librustc/traits/auto_trait.rs
+++ b/src/librustc/traits/auto_trait.rs
@@ -222,9 +222,14 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
             });
 
             let names_map: FxHashSet<String> = generics
-                .regions
+                .params
                 .iter()
-                .map(|l| l.name.to_string())
+                .filter_map(|param| {
+                    match param.kind {
+                        ty::GenericParamDefKind::Lifetime(_) => Some(param.name.to_string()),
+                        _ => None
+                    }
+                })
                 .collect();
 
             let body_ids: FxHashSet<_> = infcx

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -35,7 +35,7 @@ use infer::type_variable::TypeVariableOrigin;
 use std::fmt;
 use syntax::ast;
 use session::DiagnosticMessageId;
-use ty::{self, AdtKind, ToPredicate, ToPolyTraitRef, Ty, TyCtxt, TypeFoldable};
+use ty::{self, AdtKind, ToPredicate, ToPolyTraitRef, Ty, TyCtxt, TypeFoldable, GenericParamDef};
 use ty::error::ExpectedFound;
 use ty::fast_reject;
 use ty::fold::TypeFolder;
@@ -378,7 +378,12 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             flags.push(("_Self".to_string(), Some(self.tcx.type_of(def.did).to_string())));
         }
 
-        for param in generics.params.iter().filter_map(|param| param.get_type()) {
+        for param in generics.params.iter().filter_map(|param| {
+            match *param {
+                GenericParamDef::Type(ty) => Some(ty),
+                GenericParamDef::Lifetime(_) => None,
+            }
+        }) {
             let name = param.name.to_string();
             let ty = trait_ref.substs.type_for_def(&param);
             let ty_str = ty.to_string();

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -382,13 +382,12 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         for param in generics.params.iter() {
             let value = match param.kind {
                 GenericParamDefKind::Type(_) => {
-                    let ty = trait_ref.substs.type_for_def(&param);
-                    ty.to_string()
+                    trait_ref.substs[param.index as usize].to_string()
                 },
                 GenericParamDefKind::Lifetime => continue,
             };
             let name = param.name.to_string();
-            flags.push((name.clone(), Some(value.clone())));
+            flags.push((name, Some(value)));
         }
 
         if let Some(true) = self_ty.ty_to_def_id().map(|def_id| def_id.is_local()) {

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -35,7 +35,8 @@ use infer::type_variable::TypeVariableOrigin;
 use std::fmt;
 use syntax::ast;
 use session::DiagnosticMessageId;
-use ty::{self, AdtKind, ToPredicate, ToPolyTraitRef, Ty, TyCtxt, TypeFoldable, GenericParamDef};
+use ty::{self, AdtKind, ToPredicate, ToPolyTraitRef, Ty, TyCtxt, TypeFoldable};
+use ty::GenericParamDefKind;
 use ty::error::ExpectedFound;
 use ty::fast_reject;
 use ty::fold::TypeFolder;
@@ -378,10 +379,10 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             flags.push(("_Self".to_string(), Some(self.tcx.type_of(def.did).to_string())));
         }
 
-        for param in generics.params.iter().filter_map(|param| {
-            match *param {
-                GenericParamDef::Type(ty) => Some(ty),
-                GenericParamDef::Lifetime(_) => None,
+        for param in generics.params.iter().filter(|param| {
+            match param.kind {
+                GenericParamDefKind::Type(_) => true,
+                GenericParamDefKind::Lifetime(_) => false,
             }
         }) {
             let name = param.name.to_string();

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -378,9 +378,9 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             flags.push(("_Self".to_string(), Some(self.tcx.type_of(def.did).to_string())));
         }
 
-        for param in generics.types_depr() {
+        for param in generics.params.iter().filter_map(|param| param.get_type()) {
             let name = param.name.to_string();
-            let ty = trait_ref.substs.type_for_def(param);
+            let ty = trait_ref.substs.type_for_def(&param);
             let ty_str = ty.to_string();
             flags.push((name.clone(), Some(ty_str.clone())));
         }

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -386,7 +386,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                     let ty = trait_ref.substs.type_for_def(&param);
                     ty.to_string()
                 },
-                GenericParamDefKind::Lifetime(_) => continue,
+                GenericParamDefKind::Lifetime => continue,
             };
             flags.push((name.clone(), Some(value.clone())));
         }

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -378,7 +378,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             flags.push(("_Self".to_string(), Some(self.tcx.type_of(def.did).to_string())));
         }
 
-        for param in generics.types() {
+        for param in generics.types_depr() {
             let name = param.name.to_string();
             let ty = trait_ref.substs.type_for_def(param);
             let ty_str = ty.to_string();

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -382,8 +382,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             let name = param.name.to_string();
             let ty = trait_ref.substs.type_for_def(param);
             let ty_str = ty.to_string();
-            flags.push((name.clone(),
-                        Some(ty_str.clone())));
+            flags.push((name.clone(), Some(ty_str.clone())));
         }
 
         if let Some(true) = self_ty.ty_to_def_id().map(|def_id| def_id.is_local()) {

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -378,7 +378,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             flags.push(("_Self".to_string(), Some(self.tcx.type_of(def.did).to_string())));
         }
 
-        for param in generics.types().iter() {
+        for param in generics.types() {
             let name = param.name.to_string();
             let ty = trait_ref.substs.type_for_def(param);
             let ty_str = ty.to_string();

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -379,16 +379,16 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             flags.push(("_Self".to_string(), Some(self.tcx.type_of(def.did).to_string())));
         }
 
-        for param in generics.params.iter().filter(|param| {
-            match param.kind {
-                GenericParamDefKind::Type(_) => true,
-                GenericParamDefKind::Lifetime(_) => false,
-            }
-        }) {
+        for param in generics.params.iter() {
             let name = param.name.to_string();
-            let ty = trait_ref.substs.type_for_def(&param);
-            let ty_str = ty.to_string();
-            flags.push((name.clone(), Some(ty_str.clone())));
+            let value = match param.kind {
+                GenericParamDefKind::Type(_) => {
+                    let ty = trait_ref.substs.type_for_def(&param);
+                    ty.to_string()
+                },
+                GenericParamDefKind::Lifetime(_) => continue,
+            };
+            flags.push((name.clone(), Some(value.clone())));
         }
 
         if let Some(true) = self_ty.ty_to_def_id().map(|def_id| def_id.is_local()) {

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -378,7 +378,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             flags.push(("_Self".to_string(), Some(self.tcx.type_of(def.did).to_string())));
         }
 
-        for param in generics.types.iter() {
+        for param in generics.types().iter() {
             let name = param.name.to_string();
             let ty = trait_ref.substs.type_for_def(param);
             let ty_str = ty.to_string();

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -380,7 +380,6 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         }
 
         for param in generics.params.iter() {
-            let name = param.name.to_string();
             let value = match param.kind {
                 GenericParamDefKind::Type(_) => {
                     let ty = trait_ref.substs.type_for_def(&param);
@@ -388,6 +387,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                 },
                 GenericParamDefKind::Lifetime => continue,
             };
+            let name = param.name.to_string();
             flags.push((name.clone(), Some(value.clone())));
         }
 

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -22,7 +22,7 @@ use hir::def_id::DefId;
 use infer::outlives::env::OutlivesEnvironment;
 use middle::region;
 use middle::const_val::ConstEvalErr;
-use ty::subst::{UnpackedKind, Substs};
+use ty::subst::Substs;
 use ty::{self, AdtKind, Slice, Ty, TyCtxt, GenericParamDefKind, TypeFoldable, ToPredicate};
 use ty::error::{ExpectedFound, TypeError};
 use infer::{InferCtxt};
@@ -843,11 +843,9 @@ fn vtable_methods<'a, 'tcx>(
                 let substs = trait_ref.map_bound(|trait_ref| {
                     Substs::for_item(tcx, def_id, |param, _| {
                         match param.kind {
-                            GenericParamDefKind::Lifetime => {
-                                UnpackedKind::Lifetime(tcx.types.re_erased)
-                            }
+                            GenericParamDefKind::Lifetime => tcx.types.re_erased.into(),
                             GenericParamDefKind::Type(_) => {
-                                UnpackedKind::Type(trait_ref.substs.type_for_def(param))
+                                trait_ref.substs.type_for_def(param).into()
                             }
                         }
                     })

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -845,7 +845,7 @@ fn vtable_methods<'a, 'tcx>(
                         match param.kind {
                             GenericParamDefKind::Lifetime => tcx.types.re_erased.into(),
                             GenericParamDefKind::Type(_) => {
-                                trait_ref.substs.type_for_def(param).into()
+                                trait_ref.substs[param.index as usize]
                             }
                         }
                     })

--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -21,7 +21,7 @@ use super::elaborate_predicates;
 
 use hir::def_id::DefId;
 use traits;
-use ty::{self, Ty, TyCtxt, TypeFoldable};
+use ty::{self, Ty, TyCtxt, Kind, TypeFoldable};
 use ty::subst::Substs;
 use ty::util::ExplicitSelf;
 use std::borrow::Cow;
@@ -284,7 +284,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         }
 
         // We can't monomorphize things like `fn foo<A>(...)`.
-        if self.generics_of(method.def_id).types().count() != 0 {
+        if self.generics_of(method.def_id).param_counts()[&Kind::Type] != 0 {
             return Some(MethodViolationCode::Generic);
         }
 

--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -284,7 +284,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         }
 
         // We can't monomorphize things like `fn foo<A>(...)`.
-        if !self.generics_of(method.def_id).types.is_empty() {
+        if !self.generics_of(method.def_id).types().is_empty() {
             return Some(MethodViolationCode::Generic);
         }
 

--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -284,7 +284,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         }
 
         // We can't monomorphize things like `fn foo<A>(...)`.
-        if !self.generics_of(method.def_id).types().is_empty() {
+        if self.generics_of(method.def_id).types().count() != 0 {
             return Some(MethodViolationCode::Generic);
         }
 

--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -387,7 +387,6 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 }
 
 pub(super) fn is_object_safe_provider<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                                         trait_def_id: DefId)
-                                         -> bool {
+                                                trait_def_id: DefId) -> bool {
     tcx.object_safety_violations(trait_def_id).is_empty()
 }

--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -21,7 +21,7 @@ use super::elaborate_predicates;
 
 use hir::def_id::DefId;
 use traits;
-use ty::{self, Ty, TyCtxt, Kind, TypeFoldable};
+use ty::{self, Ty, TyCtxt, TypeFoldable};
 use ty::subst::Substs;
 use ty::util::ExplicitSelf;
 use std::borrow::Cow;
@@ -284,7 +284,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         }
 
         // We can't monomorphize things like `fn foo<A>(...)`.
-        if self.generics_of(method.def_id).param_counts()[&Kind::Type] != 0 {
+        if self.generics_of(method.def_id).param_counts().types != 0 {
             return Some(MethodViolationCode::Generic);
         }
 

--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -284,7 +284,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         }
 
         // We can't monomorphize things like `fn foo<A>(...)`.
-        if self.generics_of(method.def_id).param_counts().types != 0 {
+        if self.generics_of(method.def_id).own_counts().types != 0 {
             return Some(MethodViolationCode::Generic);
         }
 

--- a/src/librustc/traits/on_unimplemented.rs
+++ b/src/librustc/traits/on_unimplemented.rs
@@ -288,13 +288,14 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedFormatString {
         let trait_str = tcx.item_path_str(trait_ref.def_id);
         let generics = tcx.generics_of(trait_ref.def_id);
         let generic_map = generics.params.iter().filter_map(|param| {
-            match param.kind {
+            let value = match param.kind {
                 GenericParamDefKind::Type(_) => {
-                    Some((param.name.to_string(),
-                         trait_ref.substs.type_for_def(&param).to_string()))
+                    trait_ref.substs.type_for_def(&param).to_string()
                 },
-                GenericParamDefKind::Lifetime => None
-            }
+                GenericParamDefKind::Lifetime => return None
+            };
+            let name = param.name.to_string();
+            Some((name, value))
         }).collect::<FxHashMap<String, String>>();
 
         let parser = Parser::new(&self.0);

--- a/src/librustc/traits/on_unimplemented.rs
+++ b/src/librustc/traits/on_unimplemented.rs
@@ -243,7 +243,7 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedFormatString {
         let name = tcx.item_name(trait_def_id);
         let generics = tcx.generics_of(trait_def_id);
         let parser = Parser::new(&self.0);
-        let types = &generics.types;
+        let types = generics.types();
         let mut result = Ok(());
         for token in parser {
             match token {
@@ -288,7 +288,7 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedFormatString {
         let name = tcx.item_name(trait_ref.def_id);
         let trait_str = tcx.item_path_str(trait_ref.def_id);
         let generics = tcx.generics_of(trait_ref.def_id);
-        let generic_map = generics.types.iter().map(|param| {
+        let generic_map = generics.types().iter().map(|param| {
             (param.name.to_string(),
              trait_ref.substs.type_for_def(param).to_string())
         }).collect::<FxHashMap<String, String>>();

--- a/src/librustc/traits/on_unimplemented.rs
+++ b/src/librustc/traits/on_unimplemented.rs
@@ -11,7 +11,7 @@
 use fmt_macros::{Parser, Piece, Position};
 
 use hir::def_id::DefId;
-use ty::{self, TyCtxt, GenericParamDef};
+use ty::{self, TyCtxt, GenericParamDefKind};
 use util::common::ErrorReported;
 use util::nodemap::FxHashMap;
 
@@ -254,9 +254,9 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedFormatString {
                     Position::ArgumentNamed(s) if s == name => (),
                     // So is `{A}` if A is a type parameter
                     Position::ArgumentNamed(s) => match generics.params.iter().find(|param| {
-                        match *param {
-                            GenericParamDef::Type(ty) => ty.name == s,
-                            GenericParamDef::Lifetime(_) => false,
+                        match param.kind {
+                            GenericParamDefKind::Type(_) => param.name == s,
+                            GenericParamDefKind::Lifetime(_) => false,
                         }
                     }) {
                         Some(_) => (),
@@ -291,11 +291,12 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedFormatString {
         let trait_str = tcx.item_path_str(trait_ref.def_id);
         let generics = tcx.generics_of(trait_ref.def_id);
         let generic_map = generics.params.iter().filter_map(|param| {
-            match *param {
-                GenericParamDef::Type(ty) => {
-                    Some((ty.name.to_string(), trait_ref.substs.type_for_def(&ty).to_string()))
+            match param.kind {
+                GenericParamDefKind::Type(_) => {
+                    Some((param.name.to_string(),
+                         trait_ref.substs.type_for_def(&param).to_string()))
                 },
-                GenericParamDef::Lifetime(_) => None
+                GenericParamDefKind::Lifetime(_) => None
             }
         }).collect::<FxHashMap<String, String>>();
 

--- a/src/librustc/traits/on_unimplemented.rs
+++ b/src/librustc/traits/on_unimplemented.rs
@@ -291,7 +291,7 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedFormatString {
         let name = tcx.item_name(trait_ref.def_id);
         let trait_str = tcx.item_path_str(trait_ref.def_id);
         let generics = tcx.generics_of(trait_ref.def_id);
-        let generic_map = generics.types().map(|param| {
+        let generic_map = generics.types_depr().map(|param| {
             (param.name.to_string(), trait_ref.substs.type_for_def(param).to_string())
         }).collect::<FxHashMap<String, String>>();
 

--- a/src/librustc/traits/on_unimplemented.rs
+++ b/src/librustc/traits/on_unimplemented.rs
@@ -293,7 +293,7 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedFormatString {
                     Some((param.name.to_string(),
                          trait_ref.substs.type_for_def(&param).to_string()))
                 },
-                GenericParamDefKind::Lifetime(_) => None
+                GenericParamDefKind::Lifetime => None
             }
         }).collect::<FxHashMap<String, String>>();
 

--- a/src/librustc/traits/on_unimplemented.rs
+++ b/src/librustc/traits/on_unimplemented.rs
@@ -254,15 +254,12 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedFormatString {
                     Position::ArgumentNamed(s) if s == name => (),
                     // So is `{A}` if A is a type parameter
                     Position::ArgumentNamed(s) => match generics.params.iter().find(|param| {
-                        match param.kind {
-                            GenericParamDefKind::Type(_) => param.name == s,
-                            GenericParamDefKind::Lifetime(_) => false,
-                        }
+                        param.name == s
                     }) {
                         Some(_) => (),
                         None => {
                             span_err!(tcx.sess, span, E0230,
-                                      "there is no type parameter \
+                                      "there is no parameter \
                                        {} on trait {}",
                                       s, name);
                             result = Err(ErrorReported);

--- a/src/librustc/traits/on_unimplemented.rs
+++ b/src/librustc/traits/on_unimplemented.rs
@@ -243,7 +243,7 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedFormatString {
         let name = tcx.item_name(trait_def_id);
         let generics = tcx.generics_of(trait_def_id);
         let parser = Parser::new(&self.0);
-        let types = generics.types();
+        let mut types = generics.types();
         let mut result = Ok(());
         for token in parser {
             match token {
@@ -254,7 +254,7 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedFormatString {
                     // `{ThisTraitsName}` is allowed
                     Position::ArgumentNamed(s) if s == name => (),
                     // So is `{A}` if A is a type parameter
-                    Position::ArgumentNamed(s) => match types.iter().find(|t| {
+                    Position::ArgumentNamed(s) => match types.find(|t| {
                         t.name == s
                     }) {
                         Some(_) => (),
@@ -288,7 +288,7 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedFormatString {
         let name = tcx.item_name(trait_ref.def_id);
         let trait_str = tcx.item_path_str(trait_ref.def_id);
         let generics = tcx.generics_of(trait_ref.def_id);
-        let generic_map = generics.types().iter().map(|param| {
+        let generic_map = generics.types().map(|param| {
             (param.name.to_string(),
              trait_ref.substs.type_for_def(param).to_string())
         }).collect::<FxHashMap<String, String>>();

--- a/src/librustc/traits/on_unimplemented.rs
+++ b/src/librustc/traits/on_unimplemented.rs
@@ -290,7 +290,7 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedFormatString {
         let generic_map = generics.params.iter().filter_map(|param| {
             let value = match param.kind {
                 GenericParamDefKind::Type(_) => {
-                    trait_ref.substs.type_for_def(&param).to_string()
+                    trait_ref.substs[param.index as usize].to_string()
                 },
                 GenericParamDefKind::Lifetime => return None
             };

--- a/src/librustc/traits/on_unimplemented.rs
+++ b/src/librustc/traits/on_unimplemented.rs
@@ -291,8 +291,12 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedFormatString {
         let name = tcx.item_name(trait_ref.def_id);
         let trait_str = tcx.item_path_str(trait_ref.def_id);
         let generics = tcx.generics_of(trait_ref.def_id);
-        let generic_map = generics.types_depr().map(|param| {
-            (param.name.to_string(), trait_ref.substs.type_for_def(param).to_string())
+        let generic_map = generics.params.iter().filter_map(|param| {
+            if let Some(ty) = param.get_type() {
+                Some((ty.name.to_string(), trait_ref.substs.type_for_def(&ty).to_string()))
+            } else {
+                None
+            }
         }).collect::<FxHashMap<String, String>>();
 
         let parser = Parser::new(&self.0);

--- a/src/librustc/traits/on_unimplemented.rs
+++ b/src/librustc/traits/on_unimplemented.rs
@@ -254,10 +254,9 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedFormatString {
                     Position::ArgumentNamed(s) if s == name => (),
                     // So is `{A}` if A is a type parameter
                     Position::ArgumentNamed(s) => match generics.params.iter().find(|param| {
-                        if let GenericParamDef::Type(ty) = param {
-                            ty.name == s
-                        } else {
-                            false
+                        match *param {
+                            GenericParamDef::Type(ty) => ty.name == s,
+                            GenericParamDef::Lifetime(_) => false,
                         }
                     }) {
                         Some(_) => (),
@@ -292,10 +291,11 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedFormatString {
         let trait_str = tcx.item_path_str(trait_ref.def_id);
         let generics = tcx.generics_of(trait_ref.def_id);
         let generic_map = generics.params.iter().filter_map(|param| {
-            if let Some(ty) = param.get_type() {
-                Some((ty.name.to_string(), trait_ref.substs.type_for_def(&ty).to_string()))
-            } else {
-                None
+            match *param {
+                GenericParamDef::Type(ty) => {
+                    Some((ty.name.to_string(), trait_ref.substs.type_for_def(&ty).to_string()))
+                },
+                GenericParamDef::Lifetime(_) => None
             }
         }).collect::<FxHashMap<String, String>>();
 

--- a/src/librustc/traits/util.rs
+++ b/src/librustc/traits/util.rs
@@ -213,7 +213,7 @@ impl<'cx, 'gcx, 'tcx> Elaborator<'cx, 'gcx, 'tcx> {
                            },
 
                            Component::Param(p) => {
-                               let ty = tcx.mk_param(p.idx, p.name);
+                               let ty = tcx.mk_ty_param(p.idx, p.name);
                                Some(ty::Predicate::TypeOutlives(
                                    ty::Binder::dummy(ty::OutlivesPredicate(ty, r_min))))
                            },

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -2467,7 +2467,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         self.mk_param(0, keywords::SelfType.name().as_interned_str())
     }
 
-    pub fn mk_param_from_def(self, def: &ty::TypeParameterDef) -> Ty<'tcx> {
+    pub fn mk_param_from_def(self, def: &ty::TypeParamDef) -> Ty<'tcx> {
         self.mk_param(def.index, def.name)
     }
 

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -2329,18 +2329,12 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         let substs = Substs::for_item(self, def_id, |param, substs| {
             match param.kind {
                 GenericParamDefKind::Lifetime => bug!(),
-                GenericParamDefKind::Type(_) => {
+                GenericParamDefKind::Type(ty_param) => {
                     if param.index == 0 {
                         UnpackedKind::Type(ty)
                     } else {
-                        match param.kind {
-                            ty::GenericParamDefKind::Type(ty_param) => {
-                                assert!(ty_param.has_default);
-                                UnpackedKind::Type(
-                                    self.type_of(param.def_id).subst(self, substs))
-                            }
-                            _ => unreachable!()
-                        }
+                        assert!(ty_param.has_default);
+                        UnpackedKind::Type(self.type_of(param.def_id).subst(self, substs))
                     }
                 }
             }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -32,7 +32,7 @@ use middle::lang_items;
 use middle::resolve_lifetime::{self, ObjectLifetimeDefault};
 use middle::stability;
 use mir::{self, Mir, interpret};
-use ty::subst::{Kind, UnpackedKind, Substs, Subst};
+use ty::subst::{Kind, Substs, Subst};
 use ty::ReprOptions;
 use ty::Instance;
 use traits;
@@ -2331,10 +2331,10 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                 GenericParamDefKind::Lifetime => bug!(),
                 GenericParamDefKind::Type(ty_param) => {
                     if param.index == 0 {
-                        UnpackedKind::Type(ty)
+                        ty.into()
                     } else {
                         assert!(ty_param.has_default);
-                        UnpackedKind::Type(self.type_of(param.def_id).subst(self, substs))
+                        self.type_of(param.def_id).subst(self, substs).into()
                     }
                 }
             }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -2457,18 +2457,18 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         self.mk_ty(TyInfer(it))
     }
 
-    pub fn mk_param(self,
+    pub fn mk_ty_param(self,
                     index: u32,
                     name: InternedString) -> Ty<'tcx> {
         self.mk_ty(TyParam(ParamTy { idx: index, name: name }))
     }
 
     pub fn mk_self_type(self) -> Ty<'tcx> {
-        self.mk_param(0, keywords::SelfType.name().as_interned_str())
+        self.mk_ty_param(0, keywords::SelfType.name().as_interned_str())
     }
 
-    pub fn mk_param_from_def(self, def: &ty::TypeParamDef) -> Ty<'tcx> {
-        self.mk_param(def.index, def.name)
+    pub fn mk_ty_param_from_def(self, def: &ty::GenericParamDef) -> Ty<'tcx> {
+        self.mk_ty_param(def.index, def.name)
     }
 
     pub fn mk_anon(self, def_id: DefId, substs: &'tcx Substs<'tcx>) -> Ty<'tcx> {

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -2472,8 +2472,13 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         self.mk_ty_param(0, keywords::SelfType.name().as_interned_str())
     }
 
-    pub fn mk_ty_param_from_def(self, def: &ty::GenericParamDef) -> Ty<'tcx> {
-        self.mk_ty_param(def.index, def.name)
+    pub fn mk_param_from_def(self, param: &ty::GenericParamDef) -> Kind<'tcx> {
+        match param.kind {
+            GenericParamDefKind::Lifetime => {
+                self.mk_region(ty::ReEarlyBound(param.to_early_bound_region_data())).into()
+            }
+            GenericParamDefKind::Type(_) => self.mk_ty_param(param.index, param.name).into(),
+        }
     }
 
     pub fn mk_anon(self, def_id: DefId, substs: &'tcx Substs<'tcx>) -> Ty<'tcx> {

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -35,6 +35,7 @@ use mir::{self, Mir, interpret};
 use ty::subst::{Kind, Substs, Subst};
 use ty::ReprOptions;
 use ty::Instance;
+use ty::GenericParamDefKind;
 use traits;
 use traits::{Clause, Clauses, Goal, Goals};
 use ty::{self, Ty, TypeAndMut};
@@ -2328,9 +2329,14 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         let generics = self.generics_of(def_id);
         let mut substs = vec![Kind::from(ty)];
         // Add defaults for other generic params if there are some.
-        for def in generics.types.iter().skip(1) {
-            assert!(def.has_default);
-            let ty = self.type_of(def.def_id).subst(self, &substs);
+        for (def_id, has_default) in generics.params.iter().filter_map(|param| {
+            match param.kind {
+                GenericParamDefKind::Type(ty) => Some((param.def_id, ty.has_default)),
+                GenericParamDefKind::Lifetime(_) => None
+            }
+        }).skip(1) {
+            assert!(has_default);
+            let ty = self.type_of(def_id).subst(self, &substs);
             substs.push(ty.into());
         }
         let substs = self.mk_substs(substs.into_iter());

--- a/src/librustc/ty/maps/config.rs
+++ b/src/librustc/ty/maps/config.rs
@@ -543,7 +543,7 @@ impl<'tcx> QueryDescription<'tcx> for queries::named_region_map<'tcx> {
 
 impl<'tcx> QueryDescription<'tcx> for queries::is_late_bound_map<'tcx> {
     fn describe(_tcx: TyCtxt, _: DefIndex) -> String {
-        format!("testing if a region is late boudn")
+        format!("testing if a region is late bound")
     }
 }
 

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -710,7 +710,7 @@ pub enum IntVarValue {
 pub struct FloatVarValue(pub ast::FloatTy);
 
 #[derive(Copy, Clone, RustcEncodable, RustcDecodable)]
-pub struct TypeParameterDef {
+pub struct TypeParamDef {
     pub name: InternedString,
     pub def_id: DefId,
     pub index: u32,
@@ -726,7 +726,7 @@ pub struct TypeParameterDef {
 }
 
 #[derive(Copy, Clone, RustcEncodable, RustcDecodable)]
-pub struct RegionParameterDef {
+pub struct RegionParamDef {
     pub name: InternedString,
     pub def_id: DefId,
     pub index: u32,
@@ -737,7 +737,7 @@ pub struct RegionParameterDef {
     pub pure_wrt_drop: bool,
 }
 
-impl RegionParameterDef {
+impl RegionParamDef {
     pub fn to_early_bound_region_data(&self) -> ty::EarlyBoundRegion {
         ty::EarlyBoundRegion {
             def_id: self.def_id,
@@ -759,8 +759,8 @@ impl ty::EarlyBoundRegion {
 
 #[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
 pub enum GenericParamDef {
-    Lifetime(RegionParameterDef),
-    Type(TypeParameterDef),
+    Lifetime(RegionParamDef),
+    Type(TypeParamDef),
 }
 
 impl GenericParamDef {
@@ -787,7 +787,7 @@ pub struct Generics {
     pub parent_count: usize,
     pub params: Vec<GenericParamDef>,
 
-    /// Reverse map to each `TypeParameterDef`'s `index` field
+    /// Reverse map to each `TypeParamDef`'s `index` field
     pub type_param_to_index: FxHashMap<DefId, u32>,
 
     pub has_self: bool,
@@ -799,7 +799,7 @@ impl<'a, 'gcx, 'tcx> Generics {
         self.parent_count + self.params.len()
     }
 
-    pub fn lifetimes(&self) -> impl DoubleEndedIterator<Item = &RegionParameterDef> {
+    pub fn lifetimes(&self) -> impl DoubleEndedIterator<Item = &RegionParamDef> {
         self.params.iter().filter_map(|p| {
             if let GenericParamDef::Lifetime(lt) = p {
                 Some(lt)
@@ -809,7 +809,7 @@ impl<'a, 'gcx, 'tcx> Generics {
         })
     }
 
-    pub fn types(&self) -> impl DoubleEndedIterator<Item = &TypeParameterDef> {
+    pub fn types(&self) -> impl DoubleEndedIterator<Item = &TypeParamDef> {
         self.params.iter().filter_map(|p| {
             if let GenericParamDef::Type(ty) = p {
                 Some(ty)
@@ -836,7 +836,7 @@ impl<'a, 'gcx, 'tcx> Generics {
     pub fn region_param(&'tcx self,
                         param: &EarlyBoundRegion,
                         tcx: TyCtxt<'a, 'gcx, 'tcx>)
-                        -> &'tcx RegionParameterDef
+                        -> &'tcx RegionParamDef
     {
         if let Some(index) = param.index.checked_sub(self.parent_count as u32) {
             // We're currently assuming that lifetimes precede other generic parameters.
@@ -850,11 +850,11 @@ impl<'a, 'gcx, 'tcx> Generics {
         }
     }
 
-    /// Returns the `TypeParameterDef` associated with this `ParamTy`.
+    /// Returns the `TypeParamDef` associated with this `ParamTy`.
     pub fn type_param(&'tcx self,
                       param: &ParamTy,
                       tcx: TyCtxt<'a, 'gcx, 'tcx>)
-                      -> &TypeParameterDef {
+                      -> &TypeParamDef {
         if let Some(idx) = param.idx.checked_sub(self.parent_count as u32) {
             // non-Self type parameters are always offset by exactly
             // `self.regions.len()`. In the absence of a Self, this is obvious,

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -723,7 +723,7 @@ pub struct TypeParamDef {
 }
 
 #[derive(Copy, Clone, Debug, RustcEncodable, RustcDecodable)]
-pub struct RegionParamDef {
+pub struct LifetimeParamDef {
     /// `pure_wrt_drop`, set by the (unsafe) `#[may_dangle]` attribute
     /// on generic parameter `'a`, asserts data of lifetime `'a`
     /// won't be accessed during the parent type's `Drop` impl.
@@ -738,7 +738,7 @@ impl ty::EarlyBoundRegion {
 
 #[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
 pub enum GenericParamDefKind {
-    Lifetime(RegionParamDef),
+    Lifetime(LifetimeParamDef),
     Type(TypeParamDef),
 }
 
@@ -751,7 +751,7 @@ pub struct GenericParamDef {
 }
 
 impl GenericParamDef {
-    pub fn to_lifetime(&self) -> RegionParamDef {
+    pub fn to_lifetime(&self) -> LifetimeParamDef {
         match self.kind {
             GenericParamDefKind::Lifetime(lt) => lt,
             _ => bug!("cannot convert a non-lifetime to a lifetime")

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -837,7 +837,7 @@ impl<'a, 'gcx, 'tcx> Generics {
             let param = &self.params[index as usize];
             match param.kind {
                 ty::GenericParamDefKind::Lifetime => param,
-                _ => bug!("expected region parameter, but found another generic parameter")
+                _ => bug!("expected lifetime parameter, but found another generic parameter")
             }
         } else {
             tcx.generics_of(self.parent.expect("parent_count>0 but no parent?"))
@@ -851,7 +851,11 @@ impl<'a, 'gcx, 'tcx> Generics {
                       tcx: TyCtxt<'a, 'gcx, 'tcx>)
                       -> &'tcx GenericParamDef {
         if let Some(index) = param.idx.checked_sub(self.parent_count as u32) {
-            &self.params[index as usize]
+            let param = &self.params[index as usize];
+            match param.kind {
+                ty::GenericParamDefKind::Type(_) => param,
+                _ => bug!("expected type parameter, but found another generic parameter")
+            }
         } else {
             tcx.generics_of(self.parent.expect("parent_count>0 but no parent?"))
                 .type_param(param, tcx)

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -767,7 +767,14 @@ impl GenericParamDef {
     pub fn index(&self) -> u32 {
         match self {
             GenericParamDef::Lifetime(lt) => lt.index,
-            GenericParamDef::Type(ty)     => ty.index,
+            GenericParamDef::Type(ty) => ty.index,
+        }
+    }
+
+    pub fn def_id(&self) -> DefId {
+        match self {
+            GenericParamDef::Lifetime(lt) => lt.def_id,
+            GenericParamDef::Type(ty) => ty.def_id,
         }
     }
 
@@ -795,7 +802,7 @@ pub struct Generics {
     pub parent_count: usize,
     pub params: Vec<GenericParamDef>,
 
-    /// Reverse map to each `TypeParamDef`'s `index` field
+    /// Reverse map to the `index` field of each `GenericParamDef`'s inner type
     pub param_def_id_to_index: FxHashMap<DefId, u32>,
 
     pub has_self: bool,
@@ -824,18 +831,6 @@ impl<'a, 'gcx, 'tcx> Generics {
         }
 
         param_counts
-    }
-
-    pub fn type_params_without_defaults(&self) -> usize {
-        let mut count = 0;
-        for param in self.params.iter() {
-            if let GenericParamDef::Type(ty) = param {
-                if !ty.has_default {
-                    count += 1
-                }
-            }
-        }
-        count
     }
 
     pub fn requires_monomorphization(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> bool {

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -743,13 +743,6 @@ pub struct GenericParamDef {
 }
 
 impl GenericParamDef {
-    pub fn to_type(&self) -> TypeParamDef {
-        match self.kind {
-            GenericParamDefKind::Type(ty) => ty,
-            _ => bug!("cannot convert a non-type to a type")
-        }
-    }
-
     pub fn to_early_bound_region_data(&self) -> ty::EarlyBoundRegion {
         match self.kind {
             GenericParamDefKind::Lifetime => {

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -796,7 +796,7 @@ pub struct Generics {
     pub params: Vec<GenericParamDef>,
 
     /// Reverse map to each `TypeParamDef`'s `index` field
-    pub type_param_to_index: FxHashMap<DefId, u32>,
+    pub param_def_id_to_index: FxHashMap<DefId, u32>,
 
     pub has_self: bool,
     pub has_late_bound_regions: Option<Span>,

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -794,23 +794,23 @@ impl<'a, 'gcx, 'tcx> Generics {
         self.parent_count + self.params.len()
     }
 
-    pub fn param_counts(&self) -> GenericParamCount {
+    pub fn own_counts(&self) -> GenericParamCount {
         // We could cache this as a property of `GenericParamCount`, but
         // the aim is to refactor this away entirely eventually and the
         // presence of this method will be a constant reminder.
-        let mut param_counts = GenericParamCount {
+        let mut own_counts = GenericParamCount {
             lifetimes: 0,
             types: 0,
         };
 
         for param in self.params.iter() {
             match param.kind {
-                GenericParamDefKind::Lifetime => param_counts.lifetimes += 1,
-                GenericParamDefKind::Type(_) => param_counts.types += 1,
+                GenericParamDefKind::Lifetime => own_counts.lifetimes += 1,
+                GenericParamDefKind::Type(_) => own_counts.types += 1,
             };
         }
 
-        param_counts
+        own_counts
     }
 
     pub fn requires_monomorphization(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> bool {

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -758,16 +758,16 @@ impl ty::EarlyBoundRegion {
 }
 
 #[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
-pub enum GenericParameterDef {
+pub enum GenericParam {
     Lifetime(RegionParameterDef),
     Type(TypeParameterDef),
 }
 
-impl GenericParameterDef {
+impl GenericParam {
     pub fn index(&self) -> u32 {
         match self {
-            GenericParameterDef::Lifetime(lt) => lt.index,
-            GenericParameterDef::Type(ty)     => ty.index,
+            GenericParam::Lifetime(lt) => lt.index,
+            GenericParam::Type(ty)     => ty.index,
         }
     }
 }
@@ -785,7 +785,7 @@ impl GenericParameterDef {
 pub struct Generics {
     pub parent: Option<DefId>,
     pub parent_count: usize,
-    pub params: Vec<GenericParameterDef>,
+    pub params: Vec<GenericParam>,
 
     /// Reverse map to each `TypeParameterDef`'s `index` field
     pub type_param_to_index: FxHashMap<DefId, u32>,
@@ -805,7 +805,7 @@ impl<'a, 'gcx, 'tcx> Generics {
 
     pub fn lifetimes(&self) -> Vec<&RegionParameterDef> {
         self.params.iter().filter_map(|p| {
-            if let GenericParameterDef::Lifetime(lt) = p {
+            if let GenericParam::Lifetime(lt) = p {
                 Some(lt)
             } else {
                 None
@@ -815,7 +815,7 @@ impl<'a, 'gcx, 'tcx> Generics {
 
     pub fn types(&self) -> Vec<&TypeParameterDef> {
         self.params.iter().filter_map(|p| {
-            if let GenericParameterDef::Type(ty) = p {
+            if let GenericParam::Type(ty) = p {
                 Some(ty)
             } else {
                 None
@@ -843,7 +843,7 @@ impl<'a, 'gcx, 'tcx> Generics {
         if let Some(index) = param.index.checked_sub(self.parent_count as u32) {
             // We're currently assuming that lifetimes precede other generic parameters.
             match self.params[index as usize - self.has_self as usize] {
-                ty::GenericParameterDef::Lifetime(ref lt) => lt,
+                ty::GenericParam::Lifetime(ref lt) => lt,
                 _ => bug!("expected region parameter, but found another generic parameter")
             }
         } else {
@@ -893,13 +893,13 @@ impl<'a, 'gcx, 'tcx> Generics {
             if let Some(_) = (idx as usize).checked_sub(type_param_offset) {
                 assert!(!is_separated_self, "found a Self after type_param_offset");
                 match self.params[idx as usize] {
-                    ty::GenericParameterDef::Type(ref ty) => ty,
+                    ty::GenericParam::Type(ref ty) => ty,
                     _ => bug!("expected type parameter, but found another generic parameter")
                 }
             } else {
                 assert!(is_separated_self, "non-Self param before type_param_offset");
                 match self.params[type_param_offset] {
-                    ty::GenericParameterDef::Type(ref ty) => ty,
+                    ty::GenericParam::Type(ref ty) => ty,
                     _ => bug!("expected type parameter, but found another generic parameter")
                 }
             }

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -803,28 +803,28 @@ impl<'a, 'gcx, 'tcx> Generics {
         self.parent_count + self.own_count()
     }
 
-    pub fn lifetimes(&self) -> Vec<&RegionParameterDef> {
+    pub fn lifetimes(&self) -> impl DoubleEndedIterator<Item = &RegionParameterDef> {
         self.params.iter().filter_map(|p| {
             if let GenericParam::Lifetime(lt) = p {
                 Some(lt)
             } else {
                 None
             }
-        }).collect()
+        })
     }
 
-    pub fn types(&self) -> Vec<&TypeParameterDef> {
+    pub fn types(&self) -> impl DoubleEndedIterator<Item = &TypeParameterDef> {
         self.params.iter().filter_map(|p| {
             if let GenericParam::Type(ty) = p {
                 Some(ty)
             } else {
                 None
             }
-        }).collect()
+        })
     }
 
     pub fn has_type_parameters(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> bool {
-        if self.types().len() != 0 {
+        if self.types().count() != 0 {
             return true;
         }
         if let Some(parent_def_id) = self.parent {
@@ -885,7 +885,7 @@ impl<'a, 'gcx, 'tcx> Generics {
             // And it can be seen that in both cases, to move from a substs
             // offset to a generics offset you just have to offset by the
             // number of regions.
-            let type_param_offset = self.lifetimes().len();
+            let type_param_offset = self.lifetimes().count();
 
             let has_self = self.has_self && self.parent.is_none();
             let is_separated_self = type_param_offset != 0 && idx == 0 && has_self;

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -785,7 +785,7 @@ impl GenericParameterDef {
 pub struct Generics {
     pub parent: Option<DefId>,
     pub parent_count: usize,
-    pub parameters: Vec<GenericParameterDef>,
+    pub params: Vec<GenericParameterDef>,
 
     /// Reverse map to each `TypeParameterDef`'s `index` field
     pub type_param_to_index: FxHashMap<DefId, u32>,
@@ -796,7 +796,7 @@ pub struct Generics {
 
 impl<'a, 'gcx, 'tcx> Generics {
     pub fn own_count(&self) -> usize {
-        self.parameters.len()
+        self.params.len()
     }
 
     pub fn count(&self) -> usize {
@@ -804,7 +804,7 @@ impl<'a, 'gcx, 'tcx> Generics {
     }
 
     pub fn lifetimes(&self) -> Vec<&RegionParameterDef> {
-        self.parameters.iter().filter_map(|p| {
+        self.params.iter().filter_map(|p| {
             if let GenericParameterDef::Lifetime(lt) = p {
                 Some(lt)
             } else {
@@ -814,7 +814,7 @@ impl<'a, 'gcx, 'tcx> Generics {
     }
 
     pub fn types(&self) -> Vec<&TypeParameterDef> {
-        self.parameters.iter().filter_map(|p| {
+        self.params.iter().filter_map(|p| {
             if let GenericParameterDef::Type(ty) = p {
                 Some(ty)
             } else {
@@ -842,7 +842,7 @@ impl<'a, 'gcx, 'tcx> Generics {
     {
         if let Some(index) = param.index.checked_sub(self.parent_count as u32) {
             // We're currently assuming that lifetimes precede other generic parameters.
-            match self.parameters[index as usize - self.has_self as usize] {
+            match self.params[index as usize - self.has_self as usize] {
                 ty::GenericParameterDef::Lifetime(ref lt) => lt,
                 _ => bug!("expected region parameter, but found another generic parameter")
             }
@@ -892,13 +892,13 @@ impl<'a, 'gcx, 'tcx> Generics {
 
             if let Some(_) = (idx as usize).checked_sub(type_param_offset) {
                 assert!(!is_separated_self, "found a Self after type_param_offset");
-                match self.parameters[idx as usize] {
+                match self.params[idx as usize] {
                     ty::GenericParameterDef::Type(ref ty) => ty,
                     _ => bug!("expected type parameter, but found another generic parameter")
                 }
             } else {
                 assert!(is_separated_self, "non-Self param before type_param_offset");
-                match self.parameters[type_param_offset] {
+                match self.params[type_param_offset] {
                     ty::GenericParameterDef::Type(ref ty) => ty,
                     _ => bug!("expected type parameter, but found another generic parameter")
                 }

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -795,12 +795,8 @@ pub struct Generics {
 }
 
 impl<'a, 'gcx, 'tcx> Generics {
-    pub fn own_count(&self) -> usize {
-        self.params.len()
-    }
-
     pub fn count(&self) -> usize {
-        self.parent_count + self.own_count()
+        self.parent_count + self.params.len()
     }
 
     pub fn lifetimes(&self) -> impl DoubleEndedIterator<Item = &RegionParameterDef> {

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -819,13 +819,15 @@ impl<'a, 'gcx, 'tcx> Generics {
         })
     }
 
-    pub fn has_type_parameters(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> bool {
-        if self.types().count() != 0 {
+    pub fn requires_monomorphization(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> bool {
+        if self.params.iter().any(|p| {
+            if let GenericParam::Type(_) = p { true } else { false }
+        }) {
             return true;
         }
         if let Some(parent_def_id) = self.parent {
             let parent = tcx.generics_of(parent_def_id);
-            parent.has_type_parameters(tcx)
+            parent.requires_monomorphization(tcx)
         } else {
             false
         }

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -847,16 +847,6 @@ impl<'a, 'gcx, 'tcx> Generics {
         count
     }
 
-    pub fn types_depr(&self) -> impl DoubleEndedIterator<Item = &TypeParamDef> {
-        self.params.iter().filter_map(|p| {
-            if let GenericParamDef::Type(ty) = p {
-                Some(ty)
-            } else {
-                None
-            }
-        })
-    }
-
     pub fn requires_monomorphization(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> bool {
         if self.params.iter().any(|p| p.get_type().is_some()) {
             return true;

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -777,13 +777,6 @@ impl GenericParamDef {
             GenericParamDef::Type(ty) => ty.def_id,
         }
     }
-
-    pub fn get_type(&self) -> Option<TypeParamDef> {
-        match *self {
-            GenericParamDef::Type(ty) => Some(ty),
-            _ => None,
-        }
-    }
 }
 
 pub struct GenericParamCount {
@@ -834,7 +827,12 @@ impl<'a, 'gcx, 'tcx> Generics {
     }
 
     pub fn requires_monomorphization(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> bool {
-        if self.params.iter().any(|p| p.get_type().is_some()) {
+        if self.params.iter().any(|param| {
+            match *param {
+                GenericParamDef::Type(_) => true,
+                GenericParamDef::Lifetime(_) => false
+            }
+        }) {
             return true;
         }
         if let Some(parent_def_id) = self.parent {

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -847,16 +847,6 @@ impl<'a, 'gcx, 'tcx> Generics {
         count
     }
 
-    pub fn lifetimes_depr(&self) -> impl DoubleEndedIterator<Item = &RegionParamDef> {
-        self.params.iter().filter_map(|p| {
-            if let GenericParamDef::Lifetime(lt) = p {
-                Some(lt)
-            } else {
-                None
-            }
-        })
-    }
-
     pub fn types_depr(&self) -> impl DoubleEndedIterator<Item = &TypeParamDef> {
         self.params.iter().filter_map(|p| {
             if let GenericParamDef::Type(ty) = p {

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -803,7 +803,7 @@ impl<'a, 'gcx, 'tcx> Generics {
             types: 0,
         };
 
-        for param in self.params.iter() {
+        for param in &self.params {
             match param.kind {
                 GenericParamDefKind::Lifetime => own_counts.lifetimes += 1,
                 GenericParamDefKind::Type(_) => own_counts.types += 1,
@@ -814,7 +814,7 @@ impl<'a, 'gcx, 'tcx> Generics {
     }
 
     pub fn requires_monomorphization(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> bool {
-        for param in self.params.iter() {
+        for param in &self.params {
             match param.kind {
                 GenericParamDefKind::Type(_) => return true,
                 GenericParamDefKind::Lifetime => {}

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -928,7 +928,7 @@ impl<'a, 'gcx, 'tcx> ParamTy {
         ParamTy::new(0, keywords::SelfType.name().as_interned_str())
     }
 
-    pub fn for_def(def: &ty::TypeParameterDef) -> ParamTy {
+    pub fn for_def(def: &ty::TypeParamDef) -> ParamTy {
         ParamTy::new(def.index, def.name)
     }
 

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -366,7 +366,7 @@ struct SplitGeneratorSubsts<'tcx> {
 impl<'tcx> GeneratorSubsts<'tcx> {
     fn split(self, def_id: DefId, tcx: TyCtxt<'_, '_, '_>) -> SplitGeneratorSubsts<'tcx> {
         let generics = tcx.generics_of(def_id);
-        let parent_len = generics.parent_count();
+        let parent_len = generics.parent_count;
         SplitGeneratorSubsts {
             yield_ty: self.substs.type_at(parent_len),
             return_ty: self.substs.type_at(parent_len + 1),

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -292,7 +292,7 @@ impl<'tcx> ClosureSubsts<'tcx> {
     /// ordering.
     fn split(self, def_id: DefId, tcx: TyCtxt<'_, '_, '_>) -> SplitClosureSubsts<'tcx> {
         let generics = tcx.generics_of(def_id);
-        let parent_len = generics.parent_count();
+        let parent_len = generics.parent_count;
         SplitClosureSubsts {
             closure_kind_ty: self.substs.type_at(parent_len),
             closure_sig_ty: self.substs.type_at(parent_len + 1),

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -928,12 +928,12 @@ impl<'a, 'gcx, 'tcx> ParamTy {
         ParamTy::new(0, keywords::SelfType.name().as_interned_str())
     }
 
-    pub fn for_def(def: &ty::TypeParamDef) -> ParamTy {
+    pub fn for_def(def: &ty::GenericParamDef) -> ParamTy {
         ParamTy::new(def.index, def.name)
     }
 
     pub fn to_ty(self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Ty<'tcx> {
-        tcx.mk_param(self.idx, self.name)
+        tcx.mk_ty_param(self.idx, self.name)
     }
 
     pub fn is_self(&self) -> bool {

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -254,10 +254,10 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
 
         for def in &defs.params {
             let param = match def {
-                ty::GenericParameterDef::Lifetime(ref lt) => {
+                ty::GenericParam::Lifetime(ref lt) => {
                     UnpackedKind::Lifetime(mk_region(lt, substs))
                 }
-                ty::GenericParameterDef::Type(ref ty) => {
+                ty::GenericParam::Type(ref ty) => {
                     if skip_self {
                         skip_self = false;
                         continue

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -184,12 +184,9 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
         Substs::for_item(tcx, def_id, |param, _| {
             match param.kind {
                 GenericParamDefKind::Lifetime => {
-                    UnpackedKind::Lifetime(
-                        tcx.mk_region(ty::ReEarlyBound(param.to_early_bound_region_data())))
+                    tcx.mk_region(ty::ReEarlyBound(param.to_early_bound_region_data())).into()
                 }
-                GenericParamDefKind::Type(_) => {
-                    UnpackedKind::Type(tcx.mk_ty_param_from_def(param))
-                }
+                GenericParamDefKind::Type(_) => tcx.mk_ty_param_from_def(param).into(),
             }
         })
     }
@@ -203,7 +200,7 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
                        def_id: DefId,
                        mut mk_kind: F)
                        -> &'tcx Substs<'tcx>
-    where F: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> UnpackedKind<'tcx>
+    where F: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> Kind<'tcx>
     {
         let defs = tcx.generics_of(def_id);
         let mut substs = Vec::with_capacity(defs.count());
@@ -216,7 +213,7 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
                         def_id: DefId,
                         mut mk_kind: F)
                         -> &'tcx Substs<'tcx>
-    where F: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> UnpackedKind<'tcx>
+    where F: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> Kind<'tcx>
     {
         let defs = tcx.generics_of(def_id);
         let mut result = Vec::with_capacity(defs.count());
@@ -229,7 +226,7 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
                              tcx: TyCtxt<'a, 'gcx, 'tcx>,
                              defs: &ty::Generics,
                              mk_kind: &mut F)
-    where F: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> UnpackedKind<'tcx>
+    where F: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> Kind<'tcx>
     {
 
         if let Some(def_id) = defs.parent {
@@ -242,12 +239,12 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
     fn fill_single<F>(substs: &mut Vec<Kind<'tcx>>,
                            defs: &ty::Generics,
                            mk_kind: &mut F)
-    where F: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> UnpackedKind<'tcx>
+    where F: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> Kind<'tcx>
     {
         for param in &defs.params {
             let kind = mk_kind(param, substs);
             assert_eq!(param.index as usize, substs.len());
-            substs.push(kind.pack());
+            substs.push(kind);
         }
     }
 

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -243,7 +243,7 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
           FT: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> Ty<'tcx> {
         for param in &defs.params {
             let kind = match param.kind {
-                ty::GenericParamDefKind::Lifetime(_) => mk_region(param, substs).into(),
+                ty::GenericParamDefKind::Lifetime => mk_region(param, substs).into(),
                 ty::GenericParamDefKind::Type(_) => mk_type(param, substs).into(),
             };
             assert_eq!(param.index as usize, substs.len());

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -242,8 +242,7 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
     where FR: FnMut(&ty::RegionParameterDef, &[Kind<'tcx>]) -> ty::Region<'tcx>,
           FT: FnMut(&ty::TypeParameterDef, &[Kind<'tcx>]) -> Ty<'tcx> {
         // Handle Self first, before all regions.
-        let types = defs.types();
-        let mut types = types.iter();
+        let mut types = defs.types();
         let mut skip_self = defs.parent.is_none() && defs.has_self;
         if skip_self {
             let def = types.next().unwrap();

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -242,11 +242,10 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
     where FR: FnMut(&ty::RegionParamDef, &[Kind<'tcx>]) -> ty::Region<'tcx>,
           FT: FnMut(&ty::TypeParamDef, &[Kind<'tcx>]) -> Ty<'tcx> {
         // Handle Self first, before all regions.
-        let mut types = defs.types();
         let mut skip_self = defs.parent.is_none() && defs.has_self;
         if skip_self {
-            let def = types.next().unwrap();
-            let ty = mk_type(def, substs);
+            let def = defs.params.iter().find_map(|p| p.get_type()).unwrap();
+            let ty = mk_type(&def, substs);
             assert_eq!(def.index as usize, substs.len());
             substs.push(ty.into());
         }

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -196,8 +196,8 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
                             mut mk_region: FR,
                             mut mk_type: FT)
                             -> &'tcx Substs<'tcx>
-    where FR: FnMut(&ty::RegionParameterDef, &[Kind<'tcx>]) -> ty::Region<'tcx>,
-          FT: FnMut(&ty::TypeParameterDef, &[Kind<'tcx>]) -> Ty<'tcx> {
+    where FR: FnMut(&ty::RegionParamDef, &[Kind<'tcx>]) -> ty::Region<'tcx>,
+          FT: FnMut(&ty::TypeParamDef, &[Kind<'tcx>]) -> Ty<'tcx> {
         let defs = tcx.generics_of(def_id);
         let mut substs = Vec::with_capacity(defs.count());
         Substs::fill_item(&mut substs, tcx, defs, &mut mk_region, &mut mk_type);
@@ -210,8 +210,8 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
                              mut mk_region: FR,
                              mut mk_type: FT)
                              -> &'tcx Substs<'tcx>
-    where FR: FnMut(&ty::RegionParameterDef, &[Kind<'tcx>]) -> ty::Region<'tcx>,
-          FT: FnMut(&ty::TypeParameterDef, &[Kind<'tcx>]) -> Ty<'tcx>
+    where FR: FnMut(&ty::RegionParamDef, &[Kind<'tcx>]) -> ty::Region<'tcx>,
+          FT: FnMut(&ty::TypeParamDef, &[Kind<'tcx>]) -> Ty<'tcx>
     {
         let defs = tcx.generics_of(def_id);
         let mut result = Vec::with_capacity(defs.count());
@@ -225,8 +225,8 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
                              defs: &ty::Generics,
                              mk_region: &mut FR,
                              mk_type: &mut FT)
-    where FR: FnMut(&ty::RegionParameterDef, &[Kind<'tcx>]) -> ty::Region<'tcx>,
-          FT: FnMut(&ty::TypeParameterDef, &[Kind<'tcx>]) -> Ty<'tcx> {
+    where FR: FnMut(&ty::RegionParamDef, &[Kind<'tcx>]) -> ty::Region<'tcx>,
+          FT: FnMut(&ty::TypeParamDef, &[Kind<'tcx>]) -> Ty<'tcx> {
 
         if let Some(def_id) = defs.parent {
             let parent_defs = tcx.generics_of(def_id);
@@ -239,8 +239,8 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
                            defs: &ty::Generics,
                            mk_region: &mut FR,
                            mk_type: &mut FT)
-    where FR: FnMut(&ty::RegionParameterDef, &[Kind<'tcx>]) -> ty::Region<'tcx>,
-          FT: FnMut(&ty::TypeParameterDef, &[Kind<'tcx>]) -> Ty<'tcx> {
+    where FR: FnMut(&ty::RegionParamDef, &[Kind<'tcx>]) -> ty::Region<'tcx>,
+          FT: FnMut(&ty::TypeParamDef, &[Kind<'tcx>]) -> Ty<'tcx> {
         // Handle Self first, before all regions.
         let mut types = defs.types();
         let mut skip_self = defs.parent.is_none() && defs.has_self;
@@ -314,12 +314,12 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
     }
 
     #[inline]
-    pub fn type_for_def(&self, ty_param_def: &ty::TypeParameterDef) -> Ty<'tcx> {
+    pub fn type_for_def(&self, ty_param_def: &ty::TypeParamDef) -> Ty<'tcx> {
         self.type_at(ty_param_def.index as usize)
     }
 
     #[inline]
-    pub fn region_for_def(&self, def: &ty::RegionParameterDef) -> ty::Region<'tcx> {
+    pub fn region_for_def(&self, def: &ty::RegionParamDef) -> ty::Region<'tcx> {
         self.region_at(def.index as usize)
     }
 

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -11,7 +11,7 @@
 // Type substitutions.
 
 use hir::def_id::DefId;
-use ty::{self, Lift, Slice, Region, Ty, TyCtxt};
+use ty::{self, Lift, Slice, Region, Ty, TyCtxt, GenericParamDefKind};
 use ty::fold::{TypeFoldable, TypeFolder, TypeVisitor};
 
 use serialize::{self, Encodable, Encoder, Decodable, Decoder};
@@ -174,80 +174,80 @@ impl<'tcx> Decodable for Kind<'tcx> {
     }
 }
 
-/// A substitution mapping type/region parameters to new values.
+/// A substitution mapping generic parameters to new values.
 pub type Substs<'tcx> = Slice<Kind<'tcx>>;
 
 impl<'a, 'gcx, 'tcx> Substs<'tcx> {
     /// Creates a Substs that maps each generic parameter to itself.
     pub fn identity_for_item(tcx: TyCtxt<'a, 'gcx, 'tcx>, def_id: DefId)
                              -> &'tcx Substs<'tcx> {
-        Substs::for_item(tcx, def_id, |def, _| {
-            tcx.mk_region(ty::ReEarlyBound(def.to_early_bound_region_data()))
-        }, |def, _| tcx.mk_ty_param_from_def(def))
+        Substs::for_item(tcx, def_id, |param, _| {
+            match param.kind {
+                GenericParamDefKind::Lifetime => {
+                    UnpackedKind::Lifetime(
+                        tcx.mk_region(ty::ReEarlyBound(param.to_early_bound_region_data())))
+                }
+                GenericParamDefKind::Type(_) => {
+                    UnpackedKind::Type(tcx.mk_ty_param_from_def(param))
+                }
+            }
+        })
     }
 
     /// Creates a Substs for generic parameter definitions,
-    /// by calling closures to obtain each region and type.
+    /// by calling closures to obtain each kind.
     /// The closures get to observe the Substs as they're
     /// being built, which can be used to correctly
-    /// substitute defaults of type parameters.
-    pub fn for_item<FR, FT>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
-                            def_id: DefId,
-                            mut mk_region: FR,
-                            mut mk_type: FT)
-                            -> &'tcx Substs<'tcx>
-    where FR: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> ty::Region<'tcx>,
-          FT: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> Ty<'tcx> {
+    /// substitute defaults of generic parameters.
+    pub fn for_item<F>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
+                       def_id: DefId,
+                       mut mk_kind: F)
+                       -> &'tcx Substs<'tcx>
+    where F: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> UnpackedKind<'tcx>
+    {
         let defs = tcx.generics_of(def_id);
         let mut substs = Vec::with_capacity(defs.count());
-        Substs::fill_item(&mut substs, tcx, defs, &mut mk_region, &mut mk_type);
+        Substs::fill_item(&mut substs, tcx, defs, &mut mk_kind);
         tcx.intern_substs(&substs)
     }
 
-    pub fn extend_to<FR, FT>(&self,
-                             tcx: TyCtxt<'a, 'gcx, 'tcx>,
-                             def_id: DefId,
-                             mut mk_region: FR,
-                             mut mk_type: FT)
-                             -> &'tcx Substs<'tcx>
-    where FR: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> ty::Region<'tcx>,
-          FT: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> Ty<'tcx>
+    pub fn extend_to<F>(&self,
+                        tcx: TyCtxt<'a, 'gcx, 'tcx>,
+                        def_id: DefId,
+                        mut mk_kind: F)
+                        -> &'tcx Substs<'tcx>
+    where F: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> UnpackedKind<'tcx>
     {
         let defs = tcx.generics_of(def_id);
         let mut result = Vec::with_capacity(defs.count());
         result.extend(self[..].iter().cloned());
-        Substs::fill_single(&mut result, defs, &mut mk_region, &mut mk_type);
+        Substs::fill_single(&mut result, defs, &mut mk_kind);
         tcx.intern_substs(&result)
     }
 
-    pub fn fill_item<FR, FT>(substs: &mut Vec<Kind<'tcx>>,
+    pub fn fill_item<F>(substs: &mut Vec<Kind<'tcx>>,
                              tcx: TyCtxt<'a, 'gcx, 'tcx>,
                              defs: &ty::Generics,
-                             mk_region: &mut FR,
-                             mk_type: &mut FT)
-    where FR: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> ty::Region<'tcx>,
-          FT: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> Ty<'tcx> {
+                             mk_kind: &mut F)
+    where F: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> UnpackedKind<'tcx>
+    {
 
         if let Some(def_id) = defs.parent {
             let parent_defs = tcx.generics_of(def_id);
-            Substs::fill_item(substs, tcx, parent_defs, mk_region, mk_type);
+            Substs::fill_item(substs, tcx, parent_defs, mk_kind);
         }
-        Substs::fill_single(substs, defs, mk_region, mk_type)
+        Substs::fill_single(substs, defs, mk_kind)
     }
 
-    fn fill_single<FR, FT>(substs: &mut Vec<Kind<'tcx>>,
+    fn fill_single<F>(substs: &mut Vec<Kind<'tcx>>,
                            defs: &ty::Generics,
-                           mk_region: &mut FR,
-                           mk_type: &mut FT)
-    where FR: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> ty::Region<'tcx>,
-          FT: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> Ty<'tcx> {
+                           mk_kind: &mut F)
+    where F: FnMut(&ty::GenericParamDef, &[Kind<'tcx>]) -> UnpackedKind<'tcx>
+    {
         for param in &defs.params {
-            let kind = match param.kind {
-                ty::GenericParamDefKind::Lifetime => mk_region(param, substs).into(),
-                ty::GenericParamDefKind::Type(_) => mk_type(param, substs).into(),
-            };
+            let kind = mk_kind(param, substs);
             assert_eq!(param.index as usize, substs.len());
-            substs.push(kind);
+            substs.push(kind.pack());
         }
     }
 

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -241,25 +241,12 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
                            mk_type: &mut FT)
     where FR: FnMut(&ty::RegionParamDef, &[Kind<'tcx>]) -> ty::Region<'tcx>,
           FT: FnMut(&ty::TypeParamDef, &[Kind<'tcx>]) -> Ty<'tcx> {
-        // Handle Self first, before all regions.
-        let mut skip_self = defs.parent.is_none() && defs.has_self;
-        if skip_self {
-            let def = defs.params.iter().find_map(|p| p.get_type()).unwrap();
-            let ty = mk_type(&def, substs);
-            assert_eq!(def.index as usize, substs.len());
-            substs.push(ty.into());
-        }
-
         for def in &defs.params {
             let param = match def {
                 ty::GenericParamDef::Lifetime(ref lt) => {
                     mk_region(lt, substs).into()
                 }
                 ty::GenericParamDef::Type(ref ty) => {
-                    if skip_self {
-                        skip_self = false;
-                        continue
-                    }
                     mk_type(ty, substs).into()
                 }
             };

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -252,7 +252,7 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
             substs.push(ty.into());
         }
 
-        for def in &defs.parameters {
+        for def in &defs.params {
             let param = match def {
                 ty::GenericParameterDef::Lifetime(ref lt) => {
                     UnpackedKind::Lifetime(mk_region(lt, substs))

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -11,7 +11,7 @@
 // Type substitutions.
 
 use hir::def_id::DefId;
-use ty::{self, Lift, Slice, Region, Ty, TyCtxt, GenericParamDefKind};
+use ty::{self, Lift, Slice, Region, Ty, TyCtxt};
 use ty::fold::{TypeFoldable, TypeFolder, TypeVisitor};
 
 use serialize::{self, Encodable, Encoder, Decodable, Decoder};
@@ -182,12 +182,7 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
     pub fn identity_for_item(tcx: TyCtxt<'a, 'gcx, 'tcx>, def_id: DefId)
                              -> &'tcx Substs<'tcx> {
         Substs::for_item(tcx, def_id, |param, _| {
-            match param.kind {
-                GenericParamDefKind::Lifetime => {
-                    tcx.mk_region(ty::ReEarlyBound(param.to_early_bound_region_data())).into()
-                }
-                GenericParamDefKind::Type(_) => tcx.mk_ty_param_from_def(param).into(),
-            }
+            tcx.mk_param_from_def(param)
         })
     }
 
@@ -293,13 +288,8 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
     }
 
     #[inline]
-    pub fn type_for_def(&self, ty_param_def: &ty::GenericParamDef) -> Ty<'tcx> {
-        self.type_at(ty_param_def.index as usize)
-    }
-
-    #[inline]
-    pub fn region_for_def(&self, def: &ty::GenericParamDef) -> ty::Region<'tcx> {
-        self.region_at(def.index as usize)
+    pub fn type_for_def(&self, def: &ty::GenericParamDef) -> Kind<'tcx> {
+        self.type_at(def.index as usize).into()
     }
 
     /// Transform from substitutions for a child of `source_ancestor`

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -253,10 +253,10 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
 
         for def in &defs.params {
             let param = match def {
-                ty::GenericParam::Lifetime(ref lt) => {
+                ty::GenericParamDef::Lifetime(ref lt) => {
                     mk_region(lt, substs).into()
                 }
-                ty::GenericParam::Type(ref ty) => {
+                ty::GenericParamDef::Type(ref ty) => {
                     if skip_self {
                         skip_self = false;
                         continue

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -252,7 +252,6 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
         }
 
         for def in &defs.params {
-            assert_eq!(def.index() as usize, substs.len());
             let param = match def {
                 ty::GenericParam::Lifetime(ref lt) => {
                     mk_region(lt, substs).into()
@@ -265,6 +264,7 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
                     mk_type(ty, substs).into()
                 }
             };
+            assert_eq!(def.index() as usize, substs.len());
             substs.push(param);
         }
     }

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -252,20 +252,20 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
         }
 
         for def in &defs.params {
+            assert_eq!(def.index() as usize, substs.len());
             let param = match def {
                 ty::GenericParam::Lifetime(ref lt) => {
-                    UnpackedKind::Lifetime(mk_region(lt, substs))
+                    mk_region(lt, substs).into()
                 }
                 ty::GenericParam::Type(ref ty) => {
                     if skip_self {
                         skip_self = false;
                         continue
                     }
-                    UnpackedKind::Type(mk_type(ty, substs))
+                    mk_type(ty, substs).into()
                 }
             };
-            assert_eq!(def.index() as usize, substs.len());
-            substs.push(param.pack());
+            substs.push(param);
         }
     }
 
@@ -333,7 +333,7 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
                        target_substs: &Substs<'tcx>)
                        -> &'tcx Substs<'tcx> {
         let defs = tcx.generics_of(source_ancestor);
-        tcx.mk_substs(target_substs.iter().chain(&self[defs.own_count()..]).cloned())
+        tcx.mk_substs(target_substs.iter().chain(&self[defs.params.len()..]).cloned())
     }
 
     pub fn truncate_to(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>, generics: &ty::Generics)
@@ -586,7 +586,7 @@ impl<'a, 'gcx, 'tcx> ty::TraitRef<'tcx> {
 
         ty::TraitRef {
             def_id: trait_id,
-            substs: tcx.intern_substs(&substs[..defs.own_count()])
+            substs: tcx.intern_substs(&substs[..defs.params.len()])
         }
     }
 }

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -243,12 +243,8 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
           FT: FnMut(&ty::TypeParamDef, &[Kind<'tcx>]) -> Ty<'tcx> {
         for def in &defs.params {
             let param = match def {
-                ty::GenericParamDef::Lifetime(ref lt) => {
-                    mk_region(lt, substs).into()
-                }
-                ty::GenericParamDef::Type(ref ty) => {
-                    mk_type(ty, substs).into()
-                }
+                ty::GenericParamDef::Lifetime(ref lt) => mk_region(lt, substs).into(),
+                ty::GenericParamDef::Type(ref ty) => mk_type(ty, substs).into(),
             };
             assert_eq!(def.index() as usize, substs.len());
             substs.push(param);

--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -505,12 +505,12 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             .filter(|&(_, &k)| {
                 match k.unpack() {
                     UnpackedKind::Lifetime(&ty::RegionKind::ReEarlyBound(ref ebr)) => {
-                        !impl_generics.region_param(ebr, self).pure_wrt_drop
+                        !impl_generics.region_param(ebr, self).to_lifetime().pure_wrt_drop
                     }
                     UnpackedKind::Type(&ty::TyS {
                         sty: ty::TypeVariants::TyParam(ref pt), ..
                     }) => {
-                        !impl_generics.type_param(pt, self).pure_wrt_drop
+                        !impl_generics.type_param(pt, self).to_type().pure_wrt_drop
                     }
                     UnpackedKind::Lifetime(_) | UnpackedKind::Type(_) => {
                         // not a type or region param - this should be reported

--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -576,7 +576,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     pub fn empty_substs_for_def_id(self, item_def_id: DefId) -> &'tcx Substs<'tcx> {
         Substs::for_item(self, item_def_id, |param, _| {
             match param.kind {
-                GenericParamDefKind::Lifetime => UnpackedKind::Lifetime(self.types.re_erased),
+                GenericParamDefKind::Lifetime => self.types.re_erased.into(),
                 GenericParamDefKind::Type(_) => {
                     bug!("empty_substs_for_def_id: {:?} has type parameters", item_def_id)
                 }

--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -505,12 +505,12 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             .filter(|&(_, &k)| {
                 match k.unpack() {
                     UnpackedKind::Lifetime(&ty::RegionKind::ReEarlyBound(ref ebr)) => {
-                        !impl_generics.region_param(ebr, self).to_lifetime().pure_wrt_drop
+                        !impl_generics.region_param(ebr, self).pure_wrt_drop
                     }
                     UnpackedKind::Type(&ty::TyS {
                         sty: ty::TypeVariants::TyParam(ref pt), ..
                     }) => {
-                        !impl_generics.type_param(pt, self).to_type().pure_wrt_drop
+                        !impl_generics.type_param(pt, self).pure_wrt_drop
                     }
                     UnpackedKind::Lifetime(_) | UnpackedKind::Type(_) => {
                         // not a type or region param - this should be reported

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -588,18 +588,18 @@ define_print! {
     }
 }
 
-impl fmt::Debug for ty::TypeParameterDef {
+impl fmt::Debug for ty::TypeParamDef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "TypeParameterDef({}, {:?}, {})",
+        write!(f, "TypeParamDef({}, {:?}, {})",
                self.name,
                self.def_id,
                self.index)
     }
 }
 
-impl fmt::Debug for ty::RegionParameterDef {
+impl fmt::Debug for ty::RegionParamDef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "RegionParameterDef({}, {:?}, {})",
+        write!(f, "RegionParamDef({}, {:?}, {})",
                self.name,
                self.def_id,
                self.index)

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -310,10 +310,10 @@ impl PrintContext {
             if let Some(def_id) = generics.parent {
                 // Methods.
                 assert!(is_value_path);
-                child_types = generics.types.len();
+                child_types = generics.types().len();
                 generics = tcx.generics_of(def_id);
-                num_regions = generics.regions.len();
-                num_types = generics.types.len();
+                num_regions = generics.lifetimes().len();
+                num_types = generics.types().len();
 
                 if has_self {
                     print!(f, self, write("<"), print_display(substs.type_at(0)), write(" as "))?;
@@ -328,16 +328,16 @@ impl PrintContext {
                     assert_eq!(has_self, false);
                 } else {
                     // Types and traits.
-                    num_regions = generics.regions.len();
-                    num_types = generics.types.len();
+                    num_regions = generics.lifetimes().len();
+                    num_types = generics.types().len();
                 }
             }
 
             if !verbose {
-                if generics.types.last().map_or(false, |def| def.has_default) {
+                if generics.types().last().map_or(false, |def| def.has_default) {
                     if let Some(substs) = tcx.lift(&substs) {
                         let tps = substs.types().rev().skip(child_types);
-                        for (def, actual) in generics.types.iter().rev().zip(tps) {
+                        for (def, actual) in generics.types().iter().rev().zip(tps) {
                             if !def.has_default {
                                 break;
                             }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -335,10 +335,10 @@ impl PrintContext {
             }
 
             if !verbose {
-                if generics.types().last().map_or(false, |def| def.has_default) {
+                if generics.types_depr().last().map_or(false, |def| def.has_default) {
                     if let Some(substs) = tcx.lift(&substs) {
                         let tps = substs.types().rev().skip(child_types);
-                        for (def, actual) in generics.types().rev().zip(tps) {
+                        for (def, actual) in generics.types_depr().rev().zip(tps) {
                             if !def.has_default {
                                 break;
                             }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -340,7 +340,7 @@ impl PrintContext {
                     generics.params.iter().rev().filter_map(|param| {
                         match param.kind {
                             GenericParamDefKind::Type(ty) => Some((param.def_id, ty.has_default)),
-                            GenericParamDefKind::Lifetime(_) => None,
+                            GenericParamDefKind::Lifetime => None,
                         }
                     });
                 if let Some(last_ty) = type_params.next() {
@@ -606,7 +606,7 @@ define_print! {
 impl fmt::Debug for ty::GenericParamDef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let type_name = match self.kind {
-            ty::GenericParamDefKind::Lifetime(_) => "Lifetime",
+            ty::GenericParamDefKind::Lifetime => "Lifetime",
             ty::GenericParamDefKind::Type(_) => "Type",
         };
         write!(f, "{}({}, {:?}, {})",

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -351,8 +351,10 @@ impl PrintContext {
                             let zipped = iter::once((last_ty, types.next().unwrap()))
                                               .chain(type_params.zip(types));
                             for ((def_id, has_default), actual) in zipped {
-                                if !has_default ||
-                                        tcx.type_of(def_id).subst(tcx, substs) != actual {
+                                if !has_default {
+                                    break;
+                                }
+                                if tcx.type_of(def_id).subst(tcx, substs) != actual {
                                     break;
                                 }
                                 num_supplied_defaults += 1;
@@ -604,7 +606,7 @@ define_print! {
 impl fmt::Debug for ty::GenericParamDef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let type_name = match self.kind {
-            ty::GenericParamDefKind::Lifetime(_) => "Region",
+            ty::GenericParamDefKind::Lifetime(_) => "Lifetime",
             ty::GenericParamDefKind::Type(_) => "Type",
         };
         write!(f, "{}({}, {:?}, {})",

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -19,7 +19,7 @@ use ty::{TyError, TyStr, TyArray, TySlice, TyFloat, TyFnDef, TyFnPtr};
 use ty::{TyParam, TyRawPtr, TyRef, TyNever, TyTuple};
 use ty::{TyClosure, TyGenerator, TyGeneratorWitness, TyForeign, TyProjection, TyAnon};
 use ty::{TyDynamic, TyInt, TyUint, TyInfer};
-use ty::{self, Ty, TyCtxt, TypeFoldable, GenericParamCount};
+use ty::{self, Ty, TyCtxt, TypeFoldable, GenericParamCount, GenericParamDef};
 use util::nodemap::FxHashSet;
 
 use std::cell::Cell;
@@ -337,7 +337,12 @@ impl PrintContext {
 
             if !verbose {
                 let mut type_params =
-                    generics.params.iter().rev().filter_map(|param| param.get_type());
+                    generics.params.iter().rev().filter_map(|param| {
+                        match *param {
+                            GenericParamDef::Type(ty) => Some(ty),
+                            GenericParamDef::Lifetime(_) => None,
+                        }
+                    });
                 if let Some(last_ty) = type_params.next() {
                     if last_ty.has_default {
                         if let Some(substs) = tcx.lift(&substs) {

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -310,10 +310,10 @@ impl PrintContext {
             if let Some(def_id) = generics.parent {
                 // Methods.
                 assert!(is_value_path);
-                child_types = generics.types().len();
+                child_types = generics.types().count();
                 generics = tcx.generics_of(def_id);
-                num_regions = generics.lifetimes().len();
-                num_types = generics.types().len();
+                num_regions = generics.lifetimes().count();
+                num_types = generics.types().count();
 
                 if has_self {
                     print!(f, self, write("<"), print_display(substs.type_at(0)), write(" as "))?;
@@ -328,8 +328,8 @@ impl PrintContext {
                     assert_eq!(has_self, false);
                 } else {
                     // Types and traits.
-                    num_regions = generics.lifetimes().len();
-                    num_types = generics.types().len();
+                    num_regions = generics.lifetimes().count();
+                    num_types = generics.types().count();
                 }
             }
 
@@ -337,7 +337,7 @@ impl PrintContext {
                 if generics.types().last().map_or(false, |def| def.has_default) {
                     if let Some(substs) = tcx.lift(&substs) {
                         let tps = substs.types().rev().skip(child_types);
-                        for (def, actual) in generics.types().iter().rev().zip(tps) {
+                        for (def, actual) in generics.types().rev().zip(tps) {
                             if !def.has_default {
                                 break;
                             }

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -308,7 +308,7 @@ impl<'a, 'gcx, 'tcx> Env<'a, 'gcx, 'tcx> {
 
     pub fn t_param(&self, index: u32) -> Ty<'tcx> {
         let name = format!("T{}", index);
-        self.infcx.tcx.mk_param(index, Symbol::intern(&name).as_interned_str())
+        self.infcx.tcx.mk_ty_param(index, Symbol::intern(&name).as_interned_str())
     }
 
     pub fn re_early_bound(&self, index: u32, name: &'static str) -> ty::Region<'tcx> {

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -929,7 +929,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
                 hir::ImplItemKind::Const(..) => true,
                 hir::ImplItemKind::Method(ref sig, _) => {
                     let generics = self.tcx.generics_of(def_id);
-                    let types = generics.parent_types as usize + generics.types.len();
+                    let types = generics.parent_types() as usize + generics.types().len();
                     let needs_inline =
                         (types > 0 || tcx.trans_fn_attrs(def_id).requests_inline())
                             && !self.metadata_output_only();

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -929,10 +929,9 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
                 hir::ImplItemKind::Const(..) => true,
                 hir::ImplItemKind::Method(ref sig, _) => {
                     let generics = self.tcx.generics_of(def_id);
-                    let types = generics.parent_types() as usize + generics.types().len();
-                    let needs_inline =
-                        (types > 0 || tcx.trans_fn_attrs(def_id).requests_inline())
-                            && !self.metadata_output_only();
+                    let needs_inline = (generics.has_type_parameters(self.tcx) ||
+                                        tcx.trans_fn_attrs(def_id).requests_inline()) &&
+                                        !self.metadata_output_only();
                     let is_const_fn = sig.constness == hir::Constness::Const;
                     let always_encode_mir = self.tcx.sess.opts.debugging_opts.always_encode_mir;
                     needs_inline || is_const_fn || always_encode_mir

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -929,7 +929,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
                 hir::ImplItemKind::Const(..) => true,
                 hir::ImplItemKind::Method(ref sig, _) => {
                     let generics = self.tcx.generics_of(def_id);
-                    let needs_inline = (generics.has_type_parameters(self.tcx) ||
+                    let needs_inline = (generics.requires_monomorphization(self.tcx) ||
                                         tcx.trans_fn_attrs(def_id).requests_inline()) &&
                                         !self.metadata_output_only();
                     let is_const_fn = sig.constness == hir::Constness::Const;

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -1076,7 +1076,7 @@ impl<'b, 'a, 'v> RootCollector<'b, 'a, 'v> {
 
 fn item_has_type_parameters<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> bool {
     let generics = tcx.generics_of(def_id);
-    generics.parent_types as usize + generics.types.len() > 0
+    generics.parent_types() as usize + generics.types().len() > 0
 }
 
 fn create_mono_items_for_default_impls<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
@@ -1108,7 +1108,7 @@ fn create_mono_items_for_default_impls<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                         continue;
                     }
 
-                    if !tcx.generics_of(method.def_id).types.is_empty() {
+                    if !tcx.generics_of(method.def_id).types().is_empty() {
                         continue;
                     }
 

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -1108,7 +1108,7 @@ fn create_mono_items_for_default_impls<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                         continue;
                     }
 
-                    if tcx.generics_of(method.def_id).param_counts().types != 0 {
+                    if tcx.generics_of(method.def_id).own_counts().types != 0 {
                         continue;
                     }
 

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -1108,7 +1108,7 @@ fn create_mono_items_for_default_impls<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                         continue;
                     }
 
-                    if !tcx.generics_of(method.def_id).types().is_empty() {
+                    if tcx.generics_of(method.def_id).types().count() != 0 {
                         continue;
                     }
 

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -1076,7 +1076,7 @@ impl<'b, 'a, 'v> RootCollector<'b, 'a, 'v> {
 
 fn item_has_type_parameters<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> bool {
     let generics = tcx.generics_of(def_id);
-    generics.parent_types() as usize + generics.types().len() > 0
+    generics.has_type_parameters(tcx)
 }
 
 fn create_mono_items_for_default_impls<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -1076,7 +1076,7 @@ impl<'b, 'a, 'v> RootCollector<'b, 'a, 'v> {
 
 fn item_has_type_parameters<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> bool {
     let generics = tcx.generics_of(def_id);
-    generics.has_type_parameters(tcx)
+    generics.requires_monomorphization(tcx)
 }
 
 fn create_mono_items_for_default_impls<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -1116,7 +1116,7 @@ fn create_mono_items_for_default_impls<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                         match param.kind {
                             GenericParamDefKind::Lifetime => tcx.types.re_erased.into(),
                             GenericParamDefKind::Type(_) => {
-                                trait_ref.substs.type_for_def(param).into()
+                                trait_ref.substs[param.index as usize]
                             }
                         }
                     });

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -1108,7 +1108,7 @@ fn create_mono_items_for_default_impls<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                         continue;
                     }
 
-                    if tcx.generics_of(method.def_id).param_counts()[&ty::Kind::Type] != 0 {
+                    if tcx.generics_of(method.def_id).param_counts().types != 0 {
                         continue;
                     }
 

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -1108,7 +1108,7 @@ fn create_mono_items_for_default_impls<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                         continue;
                     }
 
-                    if tcx.generics_of(method.def_id).types().count() != 0 {
+                    if tcx.generics_of(method.def_id).param_counts()[&ty::Kind::Type] != 0 {
                         continue;
                     }
 

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -196,7 +196,7 @@ use rustc::hir::def_id::DefId;
 use rustc::middle::const_val::ConstVal;
 use rustc::mir::interpret::{AllocId, ConstValue};
 use rustc::middle::lang_items::{ExchangeMallocFnLangItem, StartFnLangItem};
-use rustc::ty::subst::{Substs, Kind, UnpackedKind};
+use rustc::ty::subst::{Substs, Kind};
 use rustc::ty::{self, TypeFoldable, Ty, TyCtxt, GenericParamDefKind};
 use rustc::ty::adjustment::CustomCoerceUnsized;
 use rustc::session::config;
@@ -1114,11 +1114,9 @@ fn create_mono_items_for_default_impls<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
                     let substs = Substs::for_item(tcx, method.def_id, |param, _| {
                         match param.kind {
-                            GenericParamDefKind::Lifetime => {
-                                UnpackedKind::Lifetime(tcx.types.re_erased)
-                            }
+                            GenericParamDefKind::Lifetime => tcx.types.re_erased.into(),
                             GenericParamDefKind::Type(_) => {
-                                UnpackedKind::Type(trait_ref.substs.type_for_def(param))
+                                trait_ref.substs.type_for_def(param).into()
                             }
                         }
                     });

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -13,7 +13,7 @@ use rustc::hir::def_id::DefId;
 use rustc::infer;
 use rustc::mir::*;
 use rustc::ty::{self, Ty, TyCtxt, GenericParamDefKind};
-use rustc::ty::subst::{Kind, UnpackedKind, Subst, Substs};
+use rustc::ty::subst::{Kind, Subst, Substs};
 use rustc::ty::maps::Providers;
 
 use rustc_data_structures::indexed_vec::{IndexVec, Idx};
@@ -429,8 +429,8 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
 
         let substs = Substs::for_item(tcx, self.def_id, |param, _| {
             match param.kind {
-                GenericParamDefKind::Lifetime => UnpackedKind::Lifetime(tcx.types.re_erased),
-                GenericParamDefKind::Type(_) => UnpackedKind::Type(ty),
+                GenericParamDefKind::Lifetime => tcx.types.re_erased.into(),
+                GenericParamDefKind::Type(_) => ty.into(),
             }
         });
 

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -12,8 +12,8 @@ use rustc::hir;
 use rustc::hir::def_id::DefId;
 use rustc::infer;
 use rustc::mir::*;
-use rustc::ty::{self, Ty, TyCtxt};
-use rustc::ty::subst::{Kind, Subst, Substs};
+use rustc::ty::{self, Ty, TyCtxt, GenericParamDefKind};
+use rustc::ty::subst::{Kind, UnpackedKind, Subst, Substs};
 use rustc::ty::maps::Providers;
 
 use rustc_data_structures::indexed_vec::{IndexVec, Idx};
@@ -427,12 +427,12 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
     ) {
         let tcx = self.tcx;
 
-        let substs = Substs::for_item(
-            tcx,
-            self.def_id,
-            |_, _| tcx.types.re_erased,
-            |_, _| ty
-        );
+        let substs = Substs::for_item(tcx, self.def_id, |param, _| {
+            match param.kind {
+                GenericParamDefKind::Lifetime => UnpackedKind::Lifetime(tcx.types.re_erased),
+                GenericParamDefKind::Type(_) => UnpackedKind::Type(ty),
+            }
+        });
 
         // `func == Clone::clone(&ty) -> ty`
         let func_ty = tcx.mk_fn_def(self.def_id, substs);

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -357,7 +357,7 @@ fn unsafe_derive_on_repr_packed<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: D
 
     // FIXME: when we make this a hard error, this should have its
     // own error code.
-    let message = if tcx.generics_of(def_id).param_counts().types != 0 {
+    let message = if tcx.generics_of(def_id).own_counts().types != 0 {
         format!("#[derive] can't be used on a #[repr(packed)] struct with \
                  type parameters (error E0133)")
     } else {

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -13,7 +13,7 @@ use rustc_data_structures::indexed_vec::IndexVec;
 use rustc_data_structures::sync::Lrc;
 
 use rustc::ty::maps::Providers;
-use rustc::ty::{self, TyCtxt};
+use rustc::ty::{self, TyCtxt, Kind};
 use rustc::hir;
 use rustc::hir::def_id::DefId;
 use rustc::lint::builtin::{SAFE_EXTERN_STATICS, SAFE_PACKED_BORROWS, UNUSED_UNSAFE};
@@ -357,7 +357,7 @@ fn unsafe_derive_on_repr_packed<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: D
 
     // FIXME: when we make this a hard error, this should have its
     // own error code.
-    let message = if tcx.generics_of(def_id).types().count() != 0 {
+    let message = if tcx.generics_of(def_id).param_counts()[&Kind::Type] != 0 {
         format!("#[derive] can't be used on a #[repr(packed)] struct with \
                  type parameters (error E0133)")
     } else {

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -357,7 +357,7 @@ fn unsafe_derive_on_repr_packed<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: D
 
     // FIXME: when we make this a hard error, this should have its
     // own error code.
-    let message = if !tcx.generics_of(def_id).types.is_empty() {
+    let message = if !tcx.generics_of(def_id).types().is_empty() {
         format!("#[derive] can't be used on a #[repr(packed)] struct with \
                  type parameters (error E0133)")
     } else {

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -357,7 +357,7 @@ fn unsafe_derive_on_repr_packed<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: D
 
     // FIXME: when we make this a hard error, this should have its
     // own error code.
-    let message = if !tcx.generics_of(def_id).types().is_empty() {
+    let message = if tcx.generics_of(def_id).types().count() != 0 {
         format!("#[derive] can't be used on a #[repr(packed)] struct with \
                  type parameters (error E0133)")
     } else {

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -13,7 +13,7 @@ use rustc_data_structures::indexed_vec::IndexVec;
 use rustc_data_structures::sync::Lrc;
 
 use rustc::ty::maps::Providers;
-use rustc::ty::{self, TyCtxt, Kind};
+use rustc::ty::{self, TyCtxt};
 use rustc::hir;
 use rustc::hir::def_id::DefId;
 use rustc::lint::builtin::{SAFE_EXTERN_STATICS, SAFE_PACKED_BORROWS, UNUSED_UNSAFE};
@@ -357,7 +357,7 @@ fn unsafe_derive_on_repr_packed<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: D
 
     // FIXME: when we make this a hard error, this should have its
     // own error code.
-    let message = if tcx.generics_of(def_id).param_counts()[&Kind::Type] != 0 {
+    let message = if tcx.generics_of(def_id).param_counts().types != 0 {
         format!("#[derive] can't be used on a #[repr(packed)] struct with \
                  type parameters (error E0133)")
     } else {

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -184,7 +184,7 @@ impl<'b, 'a, 'tcx:'b> ConstPropagator<'b, 'a, 'tcx> {
             // evaluate the promoted and replace the constant with the evaluated result
             Literal::Promoted { index } => {
                 let generics = self.tcx.generics_of(self.source.def_id);
-                if generics.has_type_parameters(self.tcx) {
+                if generics.requires_monomorphization(self.tcx) {
                     // FIXME: can't handle code with generics
                     return None;
                 }
@@ -295,7 +295,7 @@ impl<'b, 'a, 'tcx:'b> ConstPropagator<'b, 'a, 'tcx> {
                     self.source.def_id
                 };
                 let generics = self.tcx.generics_of(def_id);
-                if generics.has_type_parameters(self.tcx) {
+                if generics.requires_monomorphization(self.tcx) {
                     // FIXME: can't handle code with generics
                     return None;
                 }
@@ -317,7 +317,7 @@ impl<'b, 'a, 'tcx:'b> ConstPropagator<'b, 'a, 'tcx> {
                     self.source.def_id
                 };
                 let generics = self.tcx.generics_of(def_id);
-                if generics.has_type_parameters(self.tcx) {
+                if generics.requires_monomorphization(self.tcx) {
                     // FIXME: can't handle code with generics
                     return None;
                 }

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -184,7 +184,7 @@ impl<'b, 'a, 'tcx:'b> ConstPropagator<'b, 'a, 'tcx> {
             // evaluate the promoted and replace the constant with the evaluated result
             Literal::Promoted { index } => {
                 let generics = self.tcx.generics_of(self.source.def_id);
-                if generics.parent_types as usize + generics.types.len() > 0 {
+                if generics.has_type_parameters(self.tcx) {
                     // FIXME: can't handle code with generics
                     return None;
                 }
@@ -295,7 +295,7 @@ impl<'b, 'a, 'tcx:'b> ConstPropagator<'b, 'a, 'tcx> {
                     self.source.def_id
                 };
                 let generics = self.tcx.generics_of(def_id);
-                if generics.parent_types as usize + generics.types.len() > 0 {
+                if generics.has_type_parameters(self.tcx) {
                     // FIXME: can't handle code with generics
                     return None;
                 }
@@ -317,8 +317,7 @@ impl<'b, 'a, 'tcx:'b> ConstPropagator<'b, 'a, 'tcx> {
                     self.source.def_id
                 };
                 let generics = self.tcx.generics_of(def_id);
-                let has_generics = generics.parent_types as usize + generics.types.len() > 0;
-                if has_generics {
+                if generics.has_type_parameters(self.tcx) {
                     // FIXME: can't handle code with generics
                     return None;
                 }

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -399,7 +399,7 @@ impl<'a, 'tcx> Visitor<'tcx> for EmbargoVisitor<'a, 'tcx> {
 
 impl<'b, 'a, 'tcx> ReachEverythingInTheInterfaceVisitor<'b, 'a, 'tcx> {
     fn generics(&mut self) -> &mut Self {
-        for def in &self.ev.tcx.generics_of(self.item_def_id).types() {
+        for def in self.ev.tcx.generics_of(self.item_def_id).types() {
             if def.has_default {
                 self.ev.tcx.type_of(def.def_id).visit_with(self);
             }
@@ -1335,7 +1335,7 @@ struct SearchInterfaceForPrivateItemsVisitor<'a, 'tcx: 'a> {
 
 impl<'a, 'tcx: 'a> SearchInterfaceForPrivateItemsVisitor<'a, 'tcx> {
     fn generics(&mut self) -> &mut Self {
-        for def in &self.tcx.generics_of(self.item_def_id).types() {
+        for def in self.tcx.generics_of(self.item_def_id).types() {
             if def.has_default {
                 self.tcx.type_of(def.def_id).visit_with(self);
             }

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -399,7 +399,7 @@ impl<'a, 'tcx> Visitor<'tcx> for EmbargoVisitor<'a, 'tcx> {
 
 impl<'b, 'a, 'tcx> ReachEverythingInTheInterfaceVisitor<'b, 'a, 'tcx> {
     fn generics(&mut self) -> &mut Self {
-        for param in self.ev.tcx.generics_of(self.item_def_id).params.iter() {
+        for param in &self.ev.tcx.generics_of(self.item_def_id).params {
             match param.kind {
                 GenericParamDefKind::Type(ty) => {
                     if ty.has_default {
@@ -1340,7 +1340,7 @@ struct SearchInterfaceForPrivateItemsVisitor<'a, 'tcx: 'a> {
 
 impl<'a, 'tcx: 'a> SearchInterfaceForPrivateItemsVisitor<'a, 'tcx> {
     fn generics(&mut self) -> &mut Self {
-        for param in self.tcx.generics_of(self.item_def_id).params.iter() {
+        for param in &self.tcx.generics_of(self.item_def_id).params {
             match param.kind {
                 GenericParamDefKind::Type(ty) => {
                     if ty.has_default {

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -27,7 +27,7 @@ use rustc::hir::intravisit::{self, Visitor, NestedVisitorMap};
 use rustc::hir::itemlikevisit::DeepVisitor;
 use rustc::lint;
 use rustc::middle::privacy::{AccessLevel, AccessLevels};
-use rustc::ty::{self, TyCtxt, Ty, TypeFoldable};
+use rustc::ty::{self, TyCtxt, Ty, TypeFoldable, GenericParamDef};
 use rustc::ty::fold::TypeVisitor;
 use rustc::ty::maps::Providers;
 use rustc::ty::subst::UnpackedKind;
@@ -399,9 +399,14 @@ impl<'a, 'tcx> Visitor<'tcx> for EmbargoVisitor<'a, 'tcx> {
 
 impl<'b, 'a, 'tcx> ReachEverythingInTheInterfaceVisitor<'b, 'a, 'tcx> {
     fn generics(&mut self) -> &mut Self {
-        for def in self.ev.tcx.generics_of(self.item_def_id).types() {
-            if def.has_default {
-                self.ev.tcx.type_of(def.def_id).visit_with(self);
+        for def in self.ev.tcx.generics_of(self.item_def_id).params.iter() {
+            match def {
+                GenericParamDef::Type(ty) => {
+                    if ty.has_default {
+                        self.ev.tcx.type_of(ty.def_id).visit_with(self);
+                    }
+                }
+                GenericParamDef::Lifetime(_) => {}
             }
         }
         self
@@ -1335,9 +1340,14 @@ struct SearchInterfaceForPrivateItemsVisitor<'a, 'tcx: 'a> {
 
 impl<'a, 'tcx: 'a> SearchInterfaceForPrivateItemsVisitor<'a, 'tcx> {
     fn generics(&mut self) -> &mut Self {
-        for def in self.tcx.generics_of(self.item_def_id).types() {
-            if def.has_default {
-                self.tcx.type_of(def.def_id).visit_with(self);
+        for def in self.tcx.generics_of(self.item_def_id).params.iter() {
+            match def {
+                GenericParamDef::Type(ty) => {
+                    if ty.has_default {
+                        self.tcx.type_of(ty.def_id).visit_with(self);
+                    }
+                }
+                GenericParamDef::Lifetime(_) => {}
             }
         }
         self

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -399,7 +399,7 @@ impl<'a, 'tcx> Visitor<'tcx> for EmbargoVisitor<'a, 'tcx> {
 
 impl<'b, 'a, 'tcx> ReachEverythingInTheInterfaceVisitor<'b, 'a, 'tcx> {
     fn generics(&mut self) -> &mut Self {
-        for def in &self.ev.tcx.generics_of(self.item_def_id).types {
+        for def in &self.ev.tcx.generics_of(self.item_def_id).types() {
             if def.has_default {
                 self.ev.tcx.type_of(def.def_id).visit_with(self);
             }
@@ -1335,7 +1335,7 @@ struct SearchInterfaceForPrivateItemsVisitor<'a, 'tcx: 'a> {
 
 impl<'a, 'tcx: 'a> SearchInterfaceForPrivateItemsVisitor<'a, 'tcx> {
     fn generics(&mut self) -> &mut Self {
-        for def in &self.tcx.generics_of(self.item_def_id).types {
+        for def in &self.tcx.generics_of(self.item_def_id).types() {
             if def.has_default {
                 self.tcx.type_of(def.def_id).visit_with(self);
             }

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -27,7 +27,7 @@ use rustc::hir::intravisit::{self, Visitor, NestedVisitorMap};
 use rustc::hir::itemlikevisit::DeepVisitor;
 use rustc::lint;
 use rustc::middle::privacy::{AccessLevel, AccessLevels};
-use rustc::ty::{self, TyCtxt, Ty, TypeFoldable, GenericParamDef};
+use rustc::ty::{self, TyCtxt, Ty, TypeFoldable, GenericParamDefKind};
 use rustc::ty::fold::TypeVisitor;
 use rustc::ty::maps::Providers;
 use rustc::ty::subst::UnpackedKind;
@@ -399,14 +399,14 @@ impl<'a, 'tcx> Visitor<'tcx> for EmbargoVisitor<'a, 'tcx> {
 
 impl<'b, 'a, 'tcx> ReachEverythingInTheInterfaceVisitor<'b, 'a, 'tcx> {
     fn generics(&mut self) -> &mut Self {
-        for def in self.ev.tcx.generics_of(self.item_def_id).params.iter() {
-            match def {
-                GenericParamDef::Type(ty) => {
+        for param in self.ev.tcx.generics_of(self.item_def_id).params.iter() {
+            match param.kind {
+                GenericParamDefKind::Type(ty) => {
                     if ty.has_default {
-                        self.ev.tcx.type_of(ty.def_id).visit_with(self);
+                        self.ev.tcx.type_of(param.def_id).visit_with(self);
                     }
                 }
-                GenericParamDef::Lifetime(_) => {}
+                GenericParamDefKind::Lifetime(_) => {}
             }
         }
         self
@@ -1340,14 +1340,14 @@ struct SearchInterfaceForPrivateItemsVisitor<'a, 'tcx: 'a> {
 
 impl<'a, 'tcx: 'a> SearchInterfaceForPrivateItemsVisitor<'a, 'tcx> {
     fn generics(&mut self) -> &mut Self {
-        for def in self.tcx.generics_of(self.item_def_id).params.iter() {
-            match def {
-                GenericParamDef::Type(ty) => {
+        for param in self.tcx.generics_of(self.item_def_id).params.iter() {
+            match param.kind {
+                GenericParamDefKind::Type(ty) => {
                     if ty.has_default {
-                        self.tcx.type_of(ty.def_id).visit_with(self);
+                        self.tcx.type_of(param.def_id).visit_with(self);
                     }
                 }
-                GenericParamDef::Lifetime(_) => {}
+                GenericParamDefKind::Lifetime(_) => {}
             }
         }
         self

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -406,7 +406,7 @@ impl<'b, 'a, 'tcx> ReachEverythingInTheInterfaceVisitor<'b, 'a, 'tcx> {
                         self.ev.tcx.type_of(param.def_id).visit_with(self);
                     }
                 }
-                GenericParamDefKind::Lifetime(_) => {}
+                GenericParamDefKind::Lifetime => {}
             }
         }
         self
@@ -1347,7 +1347,7 @@ impl<'a, 'tcx: 'a> SearchInterfaceForPrivateItemsVisitor<'a, 'tcx> {
                         self.tcx.type_of(param.def_id).visit_with(self);
                     }
                 }
-                GenericParamDefKind::Lifetime(_) => {}
+                GenericParamDefKind::Lifetime => {}
             }
         }
         self

--- a/src/librustc_traits/dropck_outlives.rs
+++ b/src/librustc_traits/dropck_outlives.rs
@@ -13,7 +13,7 @@ use rustc::hir::def_id::DefId;
 use rustc::traits::{FulfillmentContext, Normalized, ObligationCause};
 use rustc::traits::query::{CanonicalTyGoal, NoSolution};
 use rustc::traits::query::dropck_outlives::{DtorckConstraint, DropckOutlivesResult};
-use rustc::ty::{self, ParamEnvAnd, Ty, TyCtxt, GenericParamDef};
+use rustc::ty::{self, ParamEnvAnd, Ty, TyCtxt};
 use rustc::ty::subst::Subst;
 use rustc::util::nodemap::FxHashSet;
 use rustc_data_structures::sync::Lrc;
@@ -278,13 +278,11 @@ crate fn adt_dtorck_constraint<'a, 'tcx>(
     debug!("dtorck_constraint: {:?}", def);
 
     if def.is_phantom_data() {
-        let type_param = match tcx.generics_of(def_id).params[0] {
-            GenericParamDef::Type(ty) => ty,
-            GenericParamDef::Lifetime(_) => unreachable!(),
-        };
+        // The first generic parameter here is guaranteed to be a type because it's `PhantomData`.
+        let param = &tcx.generics_of(def_id).params[0];
         let result = DtorckConstraint {
             outlives: vec![],
-            dtorck_types: vec![tcx.mk_param_from_def(&type_param)],
+            dtorck_types: vec![tcx.mk_ty_param_from_def(param)],
             overflows: vec![],
         };
         debug!("dtorck_constraint: {:?} => {:?}", def, result);

--- a/src/librustc_traits/dropck_outlives.rs
+++ b/src/librustc_traits/dropck_outlives.rs
@@ -280,7 +280,8 @@ crate fn adt_dtorck_constraint<'a, 'tcx>(
     if def.is_phantom_data() {
         let result = DtorckConstraint {
             outlives: vec![],
-            dtorck_types: vec![tcx.mk_param_from_def(&tcx.generics_of(def_id).types[0])],
+            dtorck_types: vec![tcx.mk_param_from_def(&tcx.generics_of(def_id).types().next()
+                .expect("should be at least one type parameter"))],
             overflows: vec![],
         };
         debug!("dtorck_constraint: {:?} => {:?}", def, result);

--- a/src/librustc_traits/dropck_outlives.rs
+++ b/src/librustc_traits/dropck_outlives.rs
@@ -280,12 +280,7 @@ crate fn adt_dtorck_constraint<'a, 'tcx>(
     if def.is_phantom_data() {
         let result = DtorckConstraint {
             outlives: vec![],
-            dtorck_types: vec![tcx.mk_param_from_def(
-                &tcx.generics_of(def_id)
-                    .params
-                    .iter()
-                    .find_map(|p| p.get_type())
-                    .expect("should be at least one type parameter"))],
+            dtorck_types: vec![tcx.mk_param_from_def(&tcx.generics_of(def_id).params[0].get_type().unwrap())],
             overflows: vec![],
         };
         debug!("dtorck_constraint: {:?} => {:?}", def, result);

--- a/src/librustc_traits/dropck_outlives.rs
+++ b/src/librustc_traits/dropck_outlives.rs
@@ -280,8 +280,12 @@ crate fn adt_dtorck_constraint<'a, 'tcx>(
     if def.is_phantom_data() {
         let result = DtorckConstraint {
             outlives: vec![],
-            dtorck_types: vec![tcx.mk_param_from_def(&tcx.generics_of(def_id).types().next()
-                .expect("should be at least one type parameter"))],
+            dtorck_types: vec![tcx.mk_param_from_def(
+                &tcx.generics_of(def_id)
+                    .params
+                    .iter()
+                    .find_map(|p| p.get_type())
+                    .expect("should be at least one type parameter"))],
             overflows: vec![],
         };
         debug!("dtorck_constraint: {:?} => {:?}", def, result);

--- a/src/librustc_traits/dropck_outlives.rs
+++ b/src/librustc_traits/dropck_outlives.rs
@@ -13,7 +13,7 @@ use rustc::hir::def_id::DefId;
 use rustc::traits::{FulfillmentContext, Normalized, ObligationCause};
 use rustc::traits::query::{CanonicalTyGoal, NoSolution};
 use rustc::traits::query::dropck_outlives::{DtorckConstraint, DropckOutlivesResult};
-use rustc::ty::{self, ParamEnvAnd, Ty, TyCtxt};
+use rustc::ty::{self, ParamEnvAnd, Ty, TyCtxt, GenericParamDef};
 use rustc::ty::subst::Subst;
 use rustc::util::nodemap::FxHashSet;
 use rustc_data_structures::sync::Lrc;
@@ -278,9 +278,13 @@ crate fn adt_dtorck_constraint<'a, 'tcx>(
     debug!("dtorck_constraint: {:?}", def);
 
     if def.is_phantom_data() {
+        let type_param = match tcx.generics_of(def_id).params[0] {
+            GenericParamDef::Type(ty) => ty,
+            GenericParamDef::Lifetime(_) => unreachable!(),
+        };
         let result = DtorckConstraint {
             outlives: vec![],
-            dtorck_types: vec![tcx.mk_param_from_def(&tcx.generics_of(def_id).params[0].get_type().unwrap())],
+            dtorck_types: vec![tcx.mk_param_from_def(&type_param)],
             overflows: vec![],
         };
         debug!("dtorck_constraint: {:?} => {:?}", def, result);

--- a/src/librustc_traits/lib.rs
+++ b/src/librustc_traits/lib.rs
@@ -12,6 +12,7 @@
 //! the guts are broken up into modules; see the comments in those modules.
 
 #![feature(crate_visibility_modifier)]
+#![feature(iterator_find_map)]
 
 #[macro_use]
 extern crate log;

--- a/src/librustc_trans/back/symbol_export.rs
+++ b/src/librustc_trans/back/symbol_export.rs
@@ -117,7 +117,7 @@ fn reachable_non_generics_provider<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 }) => {
                     let def_id = tcx.hir.local_def_id(node_id);
                     let generics = tcx.generics_of(def_id);
-                    if (generics.parent_types == 0 && generics.types.is_empty()) &&
+                    if !generics.has_type_parameters(tcx) &&
                         // Functions marked with #[inline] are only ever translated
                         // with "internal" linkage and are never exported.
                         !Instance::mono(tcx, def_id).def.requires_local(tcx) {

--- a/src/librustc_trans/back/symbol_export.rs
+++ b/src/librustc_trans/back/symbol_export.rs
@@ -117,7 +117,7 @@ fn reachable_non_generics_provider<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 }) => {
                     let def_id = tcx.hir.local_def_id(node_id);
                     let generics = tcx.generics_of(def_id);
-                    if !generics.has_type_parameters(tcx) &&
+                    if !generics.requires_monomorphization(tcx) &&
                         // Functions marked with #[inline] are only ever translated
                         // with "internal" linkage and are never exported.
                         !Instance::mono(tcx, def_id).def.requires_local(tcx) {

--- a/src/librustc_trans/debuginfo/mod.rs
+++ b/src/librustc_trans/debuginfo/mod.rs
@@ -417,7 +417,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CodegenCx<'a, 'tcx>,
         let mut names = generics.parent.map_or(vec![], |def_id| {
             get_type_parameter_names(cx, cx.tcx.generics_of(def_id))
         });
-        names.extend(generics.types().iter().map(|param| param.name));
+        names.extend(generics.types().map(|param| param.name));
         names
     }
 

--- a/src/librustc_trans/debuginfo/mod.rs
+++ b/src/librustc_trans/debuginfo/mod.rs
@@ -417,7 +417,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CodegenCx<'a, 'tcx>,
         let mut names = generics.parent.map_or(vec![], |def_id| {
             get_type_parameter_names(cx, cx.tcx.generics_of(def_id))
         });
-        names.extend(generics.types.iter().map(|param| param.name));
+        names.extend(generics.types().iter().map(|param| param.name));
         names
     }
 

--- a/src/librustc_trans/debuginfo/mod.rs
+++ b/src/librustc_trans/debuginfo/mod.rs
@@ -26,7 +26,7 @@ use llvm::debuginfo::{DIFile, DIType, DIScope, DIBuilderRef, DISubprogram, DIArr
 use rustc::hir::TransFnAttrFlags;
 use rustc::hir::def_id::{DefId, CrateNum};
 use rustc::ty::subst::Substs;
-use rustc::ty::{Kind, GenericParamDef};
+use rustc::ty::GenericParamDef;
 
 use abi::Abi;
 use common::CodegenCx;
@@ -195,6 +195,12 @@ pub fn finalize(cx: &CodegenCx) {
         llvm::LLVMRustAddModuleFlag(cx.llmod, ptr as *const _,
                                     llvm::LLVMRustDebugMetadataVersion());
     };
+}
+
+#[derive(PartialEq, Eq, Hash)]
+pub enum Kind {
+    Lifetime,
+    Type,
 }
 
 /// Creates the function-specific debug context.

--- a/src/librustc_trans/debuginfo/mod.rs
+++ b/src/librustc_trans/debuginfo/mod.rs
@@ -429,7 +429,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CodegenCx<'a, 'tcx>,
         });
         names.extend(generics.params.iter().map(|param| {
             match param {
-                GenericParamDef::Lifetime(lt) => (Kind::Lifetime, lt.name.as_str()),
+                GenericParamDef::Lifetime(lt) => (Kind::Lifetime, lt.name),
                 GenericParamDef::Type(ty) => (Kind::Type, ty.name),
             }
         }));

--- a/src/librustc_trans/debuginfo/mod.rs
+++ b/src/librustc_trans/debuginfo/mod.rs
@@ -26,7 +26,6 @@ use llvm::debuginfo::{DIFile, DIType, DIScope, DIBuilderRef, DISubprogram, DIArr
 use rustc::hir::TransFnAttrFlags;
 use rustc::hir::def_id::{DefId, CrateNum};
 use rustc::ty::subst::{Substs, UnpackedKind};
-use rustc::ty::GenericParamDef;
 
 use abi::Abi;
 use common::CodegenCx;
@@ -425,12 +424,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CodegenCx<'a, 'tcx>,
         let mut names = generics.parent.map_or(vec![], |def_id| {
             get_parameter_names(cx, cx.tcx.generics_of(def_id))
         });
-        names.extend(generics.params.iter().map(|param| {
-            match param {
-                GenericParamDef::Lifetime(lt) => lt.name,
-                GenericParamDef::Type(ty) => ty.name,
-            }
-        }));
+        names.extend(generics.params.iter().map(|param| param.name));
         names
     }
 

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -225,11 +225,23 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
         let type_params_offset = self_ty.is_some() as usize;
         let ty_param_defs = param_counts.types - type_params_offset;
         if !infer_types || num_types_provided > ty_param_defs {
+            let type_params_without_defaults = {
+                let mut count = 0;
+                for param in decl_generics.params.iter() {
+                    if let ty::GenericParamDef::Type(ty) = param {
+                        if !ty.has_default {
+                            count += 1
+                        }
+                    }
+                }
+                count
+            };
+
             check_type_argument_count(tcx,
                 span,
                 num_types_provided,
                 ty_param_defs,
-                decl_generics.type_params_without_defaults() - type_params_offset);
+                type_params_without_defaults - type_params_offset);
         }
 
         let is_object = self_ty.map_or(false, |ty| ty.sty == TRAIT_OBJECT_DUMMY_SELF);

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -210,7 +210,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
         let decl_generics = tcx.generics_of(def_id);
         let param_counts = decl_generics.param_counts();
         let num_types_provided = parameters.types.len();
-        let expected_num_region_params = param_counts[&ty::Kind::Lifetime];
+        let expected_num_region_params = param_counts.lifetimes;
         let supplied_num_region_params = parameters.lifetimes.len();
         if expected_num_region_params != supplied_num_region_params {
             report_lifetime_number_error(tcx, span,
@@ -223,7 +223,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
 
         // Check the number of type parameters supplied by the user.
         let type_params_offset = self_ty.is_some() as usize;
-        let ty_param_defs = param_counts[&ty::Kind::Type] - type_params_offset;
+        let ty_param_defs = param_counts.types - type_params_offset;
         if !infer_types || num_types_provided > ty_param_defs {
             check_type_argument_count(tcx,
                 span,
@@ -260,7 +260,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
                 return ty;
             }
 
-            let i = i - (param_counts[&ty::Kind::Lifetime] + type_params_offset);
+            let i = i - (param_counts.lifetimes + type_params_offset);
             if i < num_types_provided {
                 // A provided type parameter.
                 self.ast_ty_to_ty(&parameters.types[i])

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -985,7 +985,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
                 let item_id = tcx.hir.get_parent_node(node_id);
                 let item_def_id = tcx.hir.local_def_id(item_id);
                 let generics = tcx.generics_of(item_def_id);
-                let index = generics.type_param_to_index[&tcx.hir.local_def_id(node_id)];
+                let index = generics.param_def_id_to_index[&tcx.hir.local_def_id(node_id)];
                 tcx.mk_param(index, tcx.hir.name(node_id).as_interned_str())
             }
             Def::SelfTy(_, Some(def_id)) => {

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1158,13 +1158,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
         if let Some(parent_id) = generics.parent {
             let parent_generics = tcx.generics_of(parent_id);
             Substs::fill_item(&mut substs, tcx, parent_generics, &mut |param, _| {
-                match param.kind {
-                    GenericParamDefKind::Lifetime => {
-                        tcx.mk_region(
-                            ty::ReEarlyBound(param.to_early_bound_region_data())).into()
-                    }
-                    GenericParamDefKind::Type(_) => tcx.mk_ty_param_from_def(param).into(),
-                }
+                tcx.mk_param_from_def(param)
             });
 
             // Replace all lifetimes with 'static

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1143,7 +1143,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
         assert_eq!(substs.len(), generics.parent_count);
 
         // Fill in our own generics with the resolved lifetimes
-        assert_eq!(lifetimes.len(), generics.own_count());
+        assert_eq!(lifetimes.len(), generics.params.len());
         substs.extend(lifetimes.iter().map(|lt| Kind::from(self.ast_region_to_region(lt, None))));
 
         debug!("impl_trait_ty_to_ty: final substs = {:?}", substs);

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -43,7 +43,7 @@ pub trait AstConv<'gcx, 'tcx> {
                                  -> ty::GenericPredicates<'tcx>;
 
     /// What lifetime should we use when a lifetime is omitted (and not elided)?
-    fn re_infer(&self, span: Span, _def: Option<&ty::RegionParameterDef>)
+    fn re_infer(&self, span: Span, _def: Option<&ty::RegionParamDef>)
                 -> Option<ty::Region<'tcx>>;
 
     /// What type should we use when a type is omitted?
@@ -51,7 +51,7 @@ pub trait AstConv<'gcx, 'tcx> {
 
     /// Same as ty_infer, but with a known type parameter definition.
     fn ty_infer_for_def(&self,
-                        _def: &ty::TypeParameterDef,
+                        _def: &ty::TypeParamDef,
                         span: Span) -> Ty<'tcx> {
         self.ty_infer(span)
     }
@@ -95,7 +95,7 @@ const TRAIT_OBJECT_DUMMY_SELF: ty::TypeVariants<'static> = ty::TyInfer(ty::Fresh
 impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
     pub fn ast_region_to_region(&self,
         lifetime: &hir::Lifetime,
-        def: Option<&ty::RegionParameterDef>)
+        def: Option<&ty::RegionParamDef>)
         -> ty::Region<'tcx>
     {
         let tcx = self.tcx();
@@ -228,7 +228,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
         }
 
         let is_object = self_ty.map_or(false, |ty| ty.sty == TRAIT_OBJECT_DUMMY_SELF);
-        let default_needs_object_self = |p: &ty::TypeParameterDef| {
+        let default_needs_object_self = |p: &ty::TypeParamDef| {
             if is_object && p.has_default {
                 if tcx.at(span).type_of(p.def_id).has_self_ty() {
                     // There is no suitable inference default for a type parameter
@@ -1301,7 +1301,7 @@ fn split_auto_traits<'a, 'b, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
 }
 
 fn check_type_argument_count(tcx: TyCtxt, span: Span, supplied: usize,
-                             ty_param_defs: &[&ty::TypeParameterDef]) {
+                             ty_param_defs: &[&ty::TypeParamDef]) {
     let accepted = ty_param_defs.len();
     let required = ty_param_defs.iter().take_while(|x| !x.has_default).count();
     if supplied < required {

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -208,9 +208,9 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
         // region with the current anon region binding (in other words,
         // whatever & would get replaced with).
         let decl_generics = tcx.generics_of(def_id);
-        let param_counts = decl_generics.param_counts();
+        let own_counts = decl_generics.own_counts();
         let num_types_provided = parameters.types.len();
-        let expected_num_region_params = param_counts.lifetimes;
+        let expected_num_region_params = own_counts.lifetimes;
         let supplied_num_region_params = parameters.lifetimes.len();
         if expected_num_region_params != supplied_num_region_params {
             report_lifetime_number_error(tcx, span,
@@ -223,7 +223,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
 
         // Check the number of type parameters supplied by the user.
         let own_self = self_ty.is_some() as usize;
-        let ty_param_defs = param_counts.types - own_self;
+        let ty_param_defs = own_counts.types - own_self;
         if !infer_types || num_types_provided > ty_param_defs {
             let type_params_without_defaults = {
                 let mut count = 0;
@@ -279,7 +279,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
                 _ => unreachable!()
             };
 
-            let i = i - (param_counts.lifetimes + own_self);
+            let i = i - (own_counts.lifetimes + own_self);
             if i < num_types_provided {
                 // A provided type parameter.
                 self.ast_ty_to_ty(&parameters.types[i])

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1139,7 +1139,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
             }
             debug!("impl_trait_ty_to_ty: substs from parent = {:?}", substs);
         }
-        assert_eq!(substs.len(), generics.parent_count());
+        assert_eq!(substs.len(), generics.parent_count);
 
         // Fill in our own generics with the resolved lifetimes
         assert_eq!(lifetimes.len(), generics.own_count());

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -209,7 +209,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
         // whatever & would get replaced with).
         let decl_generics = tcx.generics_of(def_id);
         let num_types_provided = parameters.types.len();
-        let expected_num_region_params = decl_generics.regions.len();
+        let expected_num_region_params = decl_generics.lifetimes().len();
         let supplied_num_region_params = parameters.lifetimes.len();
         if expected_num_region_params != supplied_num_region_params {
             report_lifetime_number_error(tcx, span,
@@ -221,7 +221,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
         assert_eq!(decl_generics.has_self, self_ty.is_some());
 
         // Check the number of type parameters supplied by the user.
-        let ty_param_defs = &decl_generics.types[self_ty.is_some() as usize..];
+        let ty_param_defs = &decl_generics.types()[self_ty.is_some() as usize..];
         if !infer_types || num_types_provided > ty_param_defs.len() {
             check_type_argument_count(tcx, span, num_types_provided, ty_param_defs);
         }
@@ -254,7 +254,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
                 return ty;
             }
 
-            let i = i - self_ty.is_some() as usize - decl_generics.regions.len();
+            let i = i - self_ty.is_some() as usize - decl_generics.lifetimes().len();
             if i < num_types_provided {
                 // A provided type parameter.
                 self.ast_ty_to_ty(&parameters.types[i])
@@ -1300,7 +1300,7 @@ fn split_auto_traits<'a, 'b, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
 }
 
 fn check_type_argument_count(tcx: TyCtxt, span: Span, supplied: usize,
-                             ty_param_defs: &[ty::TypeParameterDef]) {
+                             ty_param_defs: &[&ty::TypeParameterDef]) {
     let accepted = ty_param_defs.len();
     let required = ty_param_defs.iter().take_while(|x| !x.has_default).count();
     if supplied < required {

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -276,7 +276,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
                     };
                     UnpackedKind::Lifetime(lt)
                 }
-                GenericParamDefKind::Type(_) => {
+                GenericParamDefKind::Type(ty) => {
                     let i = param.index as usize;
 
                     // Handle Self first, so we can adjust the index to match the AST.
@@ -284,24 +284,18 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
                         return UnpackedKind::Type(ty);
                     }
 
-                    let has_default = match param.kind {
-                        GenericParamDefKind::Type(ty) => ty.has_default,
-                        _ => unreachable!()
-                    };
-
                     let i = i - (lt_accepted + own_self);
                     let ty = if i < ty_provided {
                         // A provided type parameter.
                         self.ast_ty_to_ty(&parameters.types[i])
                     } else if infer_types {
                         // No type parameters were provided, we can infer all.
-                        let ty_var = if !default_needs_object_self(param) {
+                        if !default_needs_object_self(param) {
                             self.ty_infer_for_def(param, span)
                         } else {
                             self.ty_infer(span)
-                        };
-                        ty_var
-                    } else if has_default {
+                        }
+                    } else if ty.has_default {
                         // No type parameter provided, but a default exists.
 
                         // If we are converting an object type, then the

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -19,7 +19,7 @@ use rustc::infer::LateBoundRegionConversionTime;
 use rustc::infer::type_variable::TypeVariableOrigin;
 use rustc::traits::error_reporting::ArgKind;
 use rustc::ty::{self, ToPolyTraitRef, Ty, GenericParamDefKind};
-use rustc::ty::subst::{UnpackedKind, Substs};
+use rustc::ty::subst::Substs;
 use rustc::ty::TypeFoldable;
 use std::cmp;
 use std::iter;
@@ -110,8 +110,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     span_bug!(expr.span, "closure has region param")
                 }
                 GenericParamDefKind::Type(_) => {
-                    UnpackedKind::Type(self.infcx
-                        .next_ty_var(TypeVariableOrigin::ClosureSynthetic(expr.span)))
+                    self.infcx
+                        .next_ty_var(TypeVariableOrigin::ClosureSynthetic(expr.span)).into()
                 }
             }
         });

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -728,7 +728,9 @@ fn compare_synthetic_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let mut error_found = false;
     let impl_m_generics = tcx.generics_of(impl_m.def_id);
     let trait_m_generics = tcx.generics_of(trait_m.def_id);
-    for (impl_ty, trait_ty) in impl_m_generics.types_depr().zip(trait_m_generics.types_depr()) {
+    let impl_m_type_params = impl_m_generics.params.iter().filter_map(|param| param.get_type());
+    let trait_m_type_params = trait_m_generics.params.iter().filter_map(|param| param.get_type());
+    for (impl_ty, trait_ty) in impl_m_type_params.zip(trait_m_type_params) {
         if impl_ty.synthetic != trait_ty.synthetic {
             let impl_node_id = tcx.hir.as_local_node_id(impl_ty.def_id).unwrap();
             let impl_span = tcx.hir.span(impl_node_id);

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -731,13 +731,13 @@ fn compare_synthetic_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let impl_m_type_params = impl_m_generics.params.iter().filter_map(|param| {
         match param.kind {
             GenericParamDefKind::Type(_) => Some(param),
-            GenericParamDefKind::Lifetime(_) => None,
+            GenericParamDefKind::Lifetime => None,
         }
     });
     let trait_m_type_params = trait_m_generics.params.iter().filter_map(|param| {
         match param.kind {
             GenericParamDefKind::Type(_) => Some(param),
-            GenericParamDefKind::Lifetime(_) => None,
+            GenericParamDefKind::Lifetime => None,
         }
     });
     for (impl_ty, trait_ty) in impl_m_type_params.zip(trait_m_type_params) {

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -10,7 +10,7 @@
 
 use rustc::hir::{self, ImplItemKind, TraitItemKind};
 use rustc::infer::{self, InferOk};
-use rustc::ty::{self, TyCtxt, GenericParamDef};
+use rustc::ty::{self, TyCtxt, GenericParamDefKind};
 use rustc::ty::util::ExplicitSelf;
 use rustc::traits::{self, ObligationCause, ObligationCauseCode, Reveal};
 use rustc::ty::error::{ExpectedFound, TypeError};
@@ -729,19 +729,19 @@ fn compare_synthetic_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let impl_m_generics = tcx.generics_of(impl_m.def_id);
     let trait_m_generics = tcx.generics_of(trait_m.def_id);
     let impl_m_type_params = impl_m_generics.params.iter().filter_map(|param| {
-        match *param {
-            GenericParamDef::Type(ty) => Some(ty),
-            GenericParamDef::Lifetime(_) => None,
+        match param.kind {
+            GenericParamDefKind::Type(_) => Some(param),
+            GenericParamDefKind::Lifetime(_) => None,
         }
     });
     let trait_m_type_params = trait_m_generics.params.iter().filter_map(|param| {
-        match *param {
-            GenericParamDef::Type(ty) => Some(ty),
-            GenericParamDef::Lifetime(_) => None,
+        match param.kind {
+            GenericParamDefKind::Type(_) => Some(param),
+            GenericParamDefKind::Lifetime(_) => None,
         }
     });
     for (impl_ty, trait_ty) in impl_m_type_params.zip(trait_m_type_params) {
-        if impl_ty.synthetic != trait_ty.synthetic {
+        if impl_ty.to_type().synthetic != trait_ty.to_type().synthetic {
             let impl_node_id = tcx.hir.as_local_node_id(impl_ty.def_id).unwrap();
             let impl_span = tcx.hir.span(impl_node_id);
             let trait_span = tcx.def_span(trait_ty.def_id);

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -357,8 +357,8 @@ fn check_region_bounds_on_impl_method<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                                 trait_to_skol_substs: &Substs<'tcx>)
                                                 -> Result<(), ErrorReported> {
     let span = tcx.sess.codemap().def_span(span);
-    let trait_params = &trait_generics.regions[..];
-    let impl_params = &impl_generics.regions[..];
+    let trait_params = trait_generics.lifetimes();
+    let impl_params = impl_generics.lifetimes();
 
     debug!("check_region_bounds_on_impl_method: \
             trait_generics={:?} \
@@ -574,8 +574,8 @@ fn compare_number_of_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                         -> Result<(), ErrorReported> {
     let impl_m_generics = tcx.generics_of(impl_m.def_id);
     let trait_m_generics = tcx.generics_of(trait_m.def_id);
-    let num_impl_m_type_params = impl_m_generics.types.len();
-    let num_trait_m_type_params = trait_m_generics.types.len();
+    let num_impl_m_type_params = impl_m_generics.types().len();
+    let num_trait_m_type_params = trait_m_generics.types().len();
     if num_impl_m_type_params != num_trait_m_type_params {
         let impl_m_node_id = tcx.hir.as_local_node_id(impl_m.def_id).unwrap();
         let impl_m_item = tcx.hir.expect_impl_item(impl_m_node_id);
@@ -728,7 +728,7 @@ fn compare_synthetic_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let mut error_found = false;
     let impl_m_generics = tcx.generics_of(impl_m.def_id);
     let trait_m_generics = tcx.generics_of(trait_m.def_id);
-    for (impl_ty, trait_ty) in impl_m_generics.types.iter().zip(trait_m_generics.types.iter()) {
+    for (impl_ty, trait_ty) in impl_m_generics.types().iter().zip(trait_m_generics.types().iter()) {
         if impl_ty.synthetic != trait_ty.synthetic {
             let impl_node_id = tcx.hir.as_local_node_id(impl_ty.def_id).unwrap();
             let impl_span = tcx.hir.span(impl_node_id);

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -10,7 +10,7 @@
 
 use rustc::hir::{self, ImplItemKind, TraitItemKind};
 use rustc::infer::{self, InferOk};
-use rustc::ty::{self, TyCtxt};
+use rustc::ty::{self, TyCtxt, GenericParamDef};
 use rustc::ty::util::ExplicitSelf;
 use rustc::traits::{self, ObligationCause, ObligationCauseCode, Reveal};
 use rustc::ty::error::{ExpectedFound, TypeError};
@@ -728,8 +728,18 @@ fn compare_synthetic_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let mut error_found = false;
     let impl_m_generics = tcx.generics_of(impl_m.def_id);
     let trait_m_generics = tcx.generics_of(trait_m.def_id);
-    let impl_m_type_params = impl_m_generics.params.iter().filter_map(|param| param.get_type());
-    let trait_m_type_params = trait_m_generics.params.iter().filter_map(|param| param.get_type());
+    let impl_m_type_params = impl_m_generics.params.iter().filter_map(|param| {
+        match *param {
+            GenericParamDef::Type(ty) => Some(ty),
+            GenericParamDef::Lifetime(_) => None,
+        }
+    });
+    let trait_m_type_params = trait_m_generics.params.iter().filter_map(|param| {
+        match *param {
+            GenericParamDef::Type(ty) => Some(ty),
+            GenericParamDef::Lifetime(_) => None,
+        }
+    });
     for (impl_ty, trait_ty) in impl_m_type_params.zip(trait_m_type_params) {
         if impl_ty.synthetic != trait_ty.synthetic {
             let impl_node_id = tcx.hir.as_local_node_id(impl_ty.def_id).unwrap();

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -377,7 +377,7 @@ fn check_region_bounds_on_impl_method<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     // but found 0" it's confusing, because it looks like there
     // are zero. Since I don't quite know how to phrase things at
     // the moment, give a kind of vague error message.
-    if trait_params.len() != impl_params.len() {
+    if trait_params.count() != impl_params.count() {
         let mut err = struct_span_err!(tcx.sess,
                                        span,
                                        E0195,
@@ -574,8 +574,8 @@ fn compare_number_of_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                         -> Result<(), ErrorReported> {
     let impl_m_generics = tcx.generics_of(impl_m.def_id);
     let trait_m_generics = tcx.generics_of(trait_m.def_id);
-    let num_impl_m_type_params = impl_m_generics.types().len();
-    let num_trait_m_type_params = trait_m_generics.types().len();
+    let num_impl_m_type_params = impl_m_generics.types().count();
+    let num_trait_m_type_params = trait_m_generics.types().count();
     if num_impl_m_type_params != num_trait_m_type_params {
         let impl_m_node_id = tcx.hir.as_local_node_id(impl_m.def_id).unwrap();
         let impl_m_item = tcx.hir.expect_impl_item(impl_m_node_id);
@@ -728,7 +728,7 @@ fn compare_synthetic_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let mut error_found = false;
     let impl_m_generics = tcx.generics_of(impl_m.def_id);
     let trait_m_generics = tcx.generics_of(trait_m.def_id);
-    for (impl_ty, trait_ty) in impl_m_generics.types().iter().zip(trait_m_generics.types().iter()) {
+    for (impl_ty, trait_ty) in impl_m_generics.types().zip(trait_m_generics.types()) {
         if impl_ty.synthetic != trait_ty.synthetic {
             let impl_node_id = tcx.hir.as_local_node_id(impl_ty.def_id).unwrap();
             let impl_span = tcx.hir.span(impl_node_id);

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -357,8 +357,8 @@ fn check_region_bounds_on_impl_method<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                                 trait_to_skol_substs: &Substs<'tcx>)
                                                 -> Result<(), ErrorReported> {
     let span = tcx.sess.codemap().def_span(span);
-    let trait_params = trait_generics.param_counts().lifetimes;
-    let impl_params = impl_generics.param_counts().lifetimes;
+    let trait_params = trait_generics.own_counts().lifetimes;
+    let impl_params = impl_generics.own_counts().lifetimes;
 
     debug!("check_region_bounds_on_impl_method: \
             trait_generics={:?} \
@@ -574,8 +574,8 @@ fn compare_number_of_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                         -> Result<(), ErrorReported> {
     let impl_m_generics = tcx.generics_of(impl_m.def_id);
     let trait_m_generics = tcx.generics_of(trait_m.def_id);
-    let num_impl_m_type_params = impl_m_generics.param_counts().types;
-    let num_trait_m_type_params = trait_m_generics.param_counts().types;
+    let num_impl_m_type_params = impl_m_generics.own_counts().types;
+    let num_trait_m_type_params = trait_m_generics.own_counts().types;
     if num_impl_m_type_params != num_trait_m_type_params {
         let impl_m_node_id = tcx.hir.as_local_node_id(impl_m.def_id).unwrap();
         let impl_m_item = tcx.hir.expect_impl_item(impl_m_node_id);

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -10,7 +10,7 @@
 
 use rustc::hir::{self, ImplItemKind, TraitItemKind};
 use rustc::infer::{self, InferOk};
-use rustc::ty::{self, TyCtxt, Kind};
+use rustc::ty::{self, TyCtxt};
 use rustc::ty::util::ExplicitSelf;
 use rustc::traits::{self, ObligationCause, ObligationCauseCode, Reveal};
 use rustc::ty::error::{ExpectedFound, TypeError};
@@ -357,8 +357,8 @@ fn check_region_bounds_on_impl_method<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                                 trait_to_skol_substs: &Substs<'tcx>)
                                                 -> Result<(), ErrorReported> {
     let span = tcx.sess.codemap().def_span(span);
-    let trait_params = trait_generics.param_counts()[&Kind::Lifetime];
-    let impl_params = impl_generics.param_counts()[&Kind::Lifetime];
+    let trait_params = trait_generics.param_counts().lifetimes;
+    let impl_params = impl_generics.param_counts().lifetimes;
 
     debug!("check_region_bounds_on_impl_method: \
             trait_generics={:?} \
@@ -574,8 +574,8 @@ fn compare_number_of_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                         -> Result<(), ErrorReported> {
     let impl_m_generics = tcx.generics_of(impl_m.def_id);
     let trait_m_generics = tcx.generics_of(trait_m.def_id);
-    let num_impl_m_type_params = impl_m_generics.param_counts()[&Kind::Type];
-    let num_trait_m_type_params = trait_m_generics.param_counts()[&Kind::Type];
+    let num_impl_m_type_params = impl_m_generics.param_counts().types;
+    let num_trait_m_type_params = trait_m_generics.param_counts().types;
     if num_impl_m_type_params != num_trait_m_type_params {
         let impl_m_node_id = tcx.hir.as_local_node_id(impl_m.def_id).unwrap();
         let impl_m_item = tcx.hir.expect_impl_item(impl_m_node_id);

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -10,7 +10,7 @@
 
 use rustc::hir::{self, ImplItemKind, TraitItemKind};
 use rustc::infer::{self, InferOk};
-use rustc::ty::{self, TyCtxt};
+use rustc::ty::{self, TyCtxt, Kind};
 use rustc::ty::util::ExplicitSelf;
 use rustc::traits::{self, ObligationCause, ObligationCauseCode, Reveal};
 use rustc::ty::error::{ExpectedFound, TypeError};
@@ -357,8 +357,8 @@ fn check_region_bounds_on_impl_method<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                                 trait_to_skol_substs: &Substs<'tcx>)
                                                 -> Result<(), ErrorReported> {
     let span = tcx.sess.codemap().def_span(span);
-    let trait_params = trait_generics.lifetimes();
-    let impl_params = impl_generics.lifetimes();
+    let trait_params = trait_generics.param_counts()[&Kind::Lifetime];
+    let impl_params = impl_generics.param_counts()[&Kind::Lifetime];
 
     debug!("check_region_bounds_on_impl_method: \
             trait_generics={:?} \
@@ -377,7 +377,7 @@ fn check_region_bounds_on_impl_method<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     // but found 0" it's confusing, because it looks like there
     // are zero. Since I don't quite know how to phrase things at
     // the moment, give a kind of vague error message.
-    if trait_params.count() != impl_params.count() {
+    if trait_params != impl_params {
         let mut err = struct_span_err!(tcx.sess,
                                        span,
                                        E0195,
@@ -574,8 +574,8 @@ fn compare_number_of_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                         -> Result<(), ErrorReported> {
     let impl_m_generics = tcx.generics_of(impl_m.def_id);
     let trait_m_generics = tcx.generics_of(trait_m.def_id);
-    let num_impl_m_type_params = impl_m_generics.types().count();
-    let num_trait_m_type_params = trait_m_generics.types().count();
+    let num_impl_m_type_params = impl_m_generics.param_counts()[&Kind::Type];
+    let num_trait_m_type_params = trait_m_generics.param_counts()[&Kind::Type];
     if num_impl_m_type_params != num_trait_m_type_params {
         let impl_m_node_id = tcx.hir.as_local_node_id(impl_m.def_id).unwrap();
         let impl_m_item = tcx.hir.expect_impl_item(impl_m_node_id);
@@ -728,7 +728,7 @@ fn compare_synthetic_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let mut error_found = false;
     let impl_m_generics = tcx.generics_of(impl_m.def_id);
     let trait_m_generics = tcx.generics_of(trait_m.def_id);
-    for (impl_ty, trait_ty) in impl_m_generics.types().zip(trait_m_generics.types()) {
+    for (impl_ty, trait_ty) in impl_m_generics.types_depr().zip(trait_m_generics.types_depr()) {
         if impl_ty.synthetic != trait_ty.synthetic {
             let impl_node_id = tcx.hir.as_local_node_id(impl_ty.def_id).unwrap();
             let impl_span = tcx.hir.span(impl_node_id);

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -730,21 +730,22 @@ fn compare_synthetic_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let trait_m_generics = tcx.generics_of(trait_m.def_id);
     let impl_m_type_params = impl_m_generics.params.iter().filter_map(|param| {
         match param.kind {
-            GenericParamDefKind::Type(_) => Some(param),
+            GenericParamDefKind::Type(ty) => Some((param.def_id, ty.synthetic)),
             GenericParamDefKind::Lifetime => None,
         }
     });
     let trait_m_type_params = trait_m_generics.params.iter().filter_map(|param| {
         match param.kind {
-            GenericParamDefKind::Type(_) => Some(param),
+            GenericParamDefKind::Type(ty) => Some((param.def_id, ty.synthetic)),
             GenericParamDefKind::Lifetime => None,
         }
     });
-    for (impl_ty, trait_ty) in impl_m_type_params.zip(trait_m_type_params) {
-        if impl_ty.to_type().synthetic != trait_ty.to_type().synthetic {
-            let impl_node_id = tcx.hir.as_local_node_id(impl_ty.def_id).unwrap();
+    for ((impl_def_id, impl_synthetic),
+         (trait_def_id, trait_synthetic)) in impl_m_type_params.zip(trait_m_type_params) {
+        if impl_synthetic != trait_synthetic {
+            let impl_node_id = tcx.hir.as_local_node_id(impl_def_id).unwrap();
             let impl_span = tcx.hir.span(impl_node_id);
-            let trait_span = tcx.def_span(trait_ty.def_id);
+            let trait_span = tcx.def_span(trait_def_id);
             let mut err = struct_span_err!(tcx.sess,
                                            impl_span,
                                            E0643,

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -45,7 +45,7 @@ fn equate_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         }
     }
 
-    let i_n_tps = tcx.generics_of(def_id).types().len();
+    let i_n_tps = tcx.generics_of(def_id).types().count();
     if i_n_tps != n_tps {
         let span = match it.node {
             hir::ForeignItemFn(_, _, ref generics) => generics.span,
@@ -346,7 +346,7 @@ pub fn check_platform_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     };
 
     let def_id = tcx.hir.local_def_id(it.id);
-    let i_n_tps = tcx.generics_of(def_id).types().len();
+    let i_n_tps = tcx.generics_of(def_id).types().count();
     let name = it.name.as_str();
 
     let (n_tps, inputs, output) = match &*name {

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -13,7 +13,7 @@
 
 use intrinsics;
 use rustc::traits::{ObligationCause, ObligationCauseCode};
-use rustc::ty::{self, TyCtxt, Ty, Kind};
+use rustc::ty::{self, TyCtxt, Ty};
 use rustc::util::nodemap::FxHashMap;
 use require_same_types;
 
@@ -45,7 +45,7 @@ fn equate_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         }
     }
 
-    let i_n_tps = tcx.generics_of(def_id).param_counts()[&Kind::Type];
+    let i_n_tps = tcx.generics_of(def_id).param_counts().types;
     if i_n_tps != n_tps {
         let span = match it.node {
             hir::ForeignItemFn(_, _, ref generics) => generics.span,
@@ -346,7 +346,7 @@ pub fn check_platform_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     };
 
     let def_id = tcx.hir.local_def_id(it.id);
-    let i_n_tps = tcx.generics_of(def_id).param_counts()[&Kind::Type];
+    let i_n_tps = tcx.generics_of(def_id).param_counts().types;
     let name = it.name.as_str();
 
     let (n_tps, inputs, output) = match &*name {

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -13,7 +13,7 @@
 
 use intrinsics;
 use rustc::traits::{ObligationCause, ObligationCauseCode};
-use rustc::ty::{self, TyCtxt, Ty};
+use rustc::ty::{self, TyCtxt, Ty, Kind};
 use rustc::util::nodemap::FxHashMap;
 use require_same_types;
 
@@ -45,7 +45,7 @@ fn equate_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         }
     }
 
-    let i_n_tps = tcx.generics_of(def_id).types().count();
+    let i_n_tps = tcx.generics_of(def_id).param_counts()[&Kind::Type];
     if i_n_tps != n_tps {
         let span = match it.node {
             hir::ForeignItemFn(_, _, ref generics) => generics.span,
@@ -346,7 +346,7 @@ pub fn check_platform_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     };
 
     let def_id = tcx.hir.local_def_id(it.id);
-    let i_n_tps = tcx.generics_of(def_id).types().count();
+    let i_n_tps = tcx.generics_of(def_id).param_counts()[&Kind::Type];
     let name = it.name.as_str();
 
     let (n_tps, inputs, output) = match &*name {

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -45,7 +45,7 @@ fn equate_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         }
     }
 
-    let i_n_tps = tcx.generics_of(def_id).param_counts().types;
+    let i_n_tps = tcx.generics_of(def_id).own_counts().types;
     if i_n_tps != n_tps {
         let span = match it.node {
             hir::ForeignItemFn(_, _, ref generics) => generics.span,
@@ -346,7 +346,7 @@ pub fn check_platform_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     };
 
     let def_id = tcx.hir.local_def_id(it.id);
-    let i_n_tps = tcx.generics_of(def_id).param_counts().types;
+    let i_n_tps = tcx.generics_of(def_id).own_counts().types;
     let name = it.name.as_str();
 
     let (n_tps, inputs, output) = match &*name {

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -45,7 +45,7 @@ fn equate_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         }
     }
 
-    let i_n_tps = tcx.generics_of(def_id).types.len();
+    let i_n_tps = tcx.generics_of(def_id).types().len();
     if i_n_tps != n_tps {
         let span = match it.node {
             hir::ForeignItemFn(_, _, ref generics) => generics.span,
@@ -346,7 +346,7 @@ pub fn check_platform_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     };
 
     let def_id = tcx.hir.local_def_id(it.id);
-    let i_n_tps = tcx.generics_of(def_id).types.len();
+    let i_n_tps = tcx.generics_of(def_id).types().len();
     let name = it.name.as_str();
 
     let (n_tps, inputs, output) = match &*name {

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -76,7 +76,7 @@ fn equate_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 /// and in libcore/intrinsics.rs
 pub fn check_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                       it: &hir::ForeignItem) {
-    let param = |n| tcx.mk_param(n, Symbol::intern(&format!("P{}", n)).as_interned_str());
+    let param = |n| tcx.mk_ty_param(n, Symbol::intern(&format!("P{}", n)).as_interned_str());
     let name = it.name.as_str();
     let (n_tps, inputs, output) = if name.starts_with("atomic_") {
         let split : Vec<&str> = name.split('_').collect();
@@ -342,7 +342,7 @@ pub fn check_platform_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                                it: &hir::ForeignItem) {
     let param = |n| {
         let name = Symbol::intern(&format!("P{}", n)).as_interned_str();
-        tcx.mk_param(n, name)
+        tcx.mk_ty_param(n, name)
     };
 
     let def_id = tcx.hir.local_def_id(it.id);

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -332,7 +332,7 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
                 parent_substs.type_at(i)
             } else if let Some(ast_ty)
                 = provided.as_ref().and_then(|p| {
-                    p.types.get(i - parent_substs.len() - method_generics.regions.len())
+                    p.types.get(i - parent_substs.len() - method_generics.lifetimes().len())
                 })
             {
                 self.to_ty(ast_ty)

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -332,7 +332,7 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
                 parent_substs.type_at(i)
             } else if let Some(ast_ty)
                 = provided.as_ref().and_then(|p| {
-                    p.types.get(i - parent_substs.len() - method_generics.lifetimes().len())
+                    p.types.get(i - parent_substs.len() - method_generics.lifetimes().count())
                 })
             {
                 self.to_ty(ast_ty)

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -15,7 +15,7 @@ use check::{FnCtxt, PlaceOp, callee, Needs};
 use hir::def_id::DefId;
 use rustc::ty::subst::Substs;
 use rustc::traits;
-use rustc::ty::{self, Ty};
+use rustc::ty::{self, Ty, Kind};
 use rustc::ty::subst::Subst;
 use rustc::ty::adjustment::{Adjustment, Adjust, OverloadedDeref};
 use rustc::ty::adjustment::{AllowTwoPhase, AutoBorrow, AutoBorrowMutability};
@@ -332,7 +332,9 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
                 parent_substs.type_at(i)
             } else if let Some(ast_ty)
                 = provided.as_ref().and_then(|p| {
-                    p.types.get(i - parent_substs.len() - method_generics.lifetimes().count())
+                    let idx =
+                        i - parent_substs.len() - method_generics.param_counts()[&Kind::Lifetime];
+                    p.types.get(idx)
                 })
             {
                 self.to_ty(ast_ty)

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -316,7 +316,7 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
         // parameters from the type and those from the method.
         assert_eq!(method_generics.parent_count, parent_substs.len());
         let provided = &segment.parameters;
-        let param_counts = method_generics.param_counts();
+        let own_counts = method_generics.own_counts();
         Substs::for_item(self.tcx, pick.item.def_id, |def, _| {
             let i = def.index as usize;
             if i < parent_substs.len() {
@@ -334,7 +334,7 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
             } else if let Some(ast_ty)
                 = provided.as_ref().and_then(|p| {
                     let idx =
-                        i - parent_substs.len() - param_counts.lifetimes;
+                        i - parent_substs.len() - own_counts.lifetimes;
                     p.types.get(idx)
                 })
             {

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -316,6 +316,7 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
         // parameters from the type and those from the method.
         assert_eq!(method_generics.parent_count, parent_substs.len());
         let provided = &segment.parameters;
+        let param_counts = method_generics.param_counts();
         Substs::for_item(self.tcx, pick.item.def_id, |def, _| {
             let i = def.index as usize;
             if i < parent_substs.len() {
@@ -333,7 +334,7 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
             } else if let Some(ast_ty)
                 = provided.as_ref().and_then(|p| {
                     let idx =
-                        i - parent_substs.len() - method_generics.param_counts().lifetimes;
+                        i - parent_substs.len() - param_counts.lifetimes;
                     p.types.get(idx)
                 })
             {

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -15,7 +15,7 @@ use check::{FnCtxt, PlaceOp, callee, Needs};
 use hir::def_id::DefId;
 use rustc::ty::subst::Substs;
 use rustc::traits;
-use rustc::ty::{self, Ty, Kind};
+use rustc::ty::{self, Ty};
 use rustc::ty::subst::Subst;
 use rustc::ty::adjustment::{Adjustment, Adjust, OverloadedDeref};
 use rustc::ty::adjustment::{AllowTwoPhase, AutoBorrow, AutoBorrowMutability};
@@ -333,7 +333,7 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
             } else if let Some(ast_ty)
                 = provided.as_ref().and_then(|p| {
                     let idx =
-                        i - parent_substs.len() - method_generics.param_counts()[&Kind::Lifetime];
+                        i - parent_substs.len() - method_generics.param_counts().lifetimes;
                     p.types.get(idx)
                 })
             {

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -314,7 +314,7 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
 
         // Create subst for early-bound lifetime parameters, combining
         // parameters from the type and those from the method.
-        assert_eq!(method_generics.parent_count(), parent_substs.len());
+        assert_eq!(method_generics.parent_count, parent_substs.len());
         let provided = &segment.parameters;
         Substs::for_item(self.tcx, pick.item.def_id, |def, _| {
             let i = def.index as usize;

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -16,7 +16,7 @@ use hir::def_id::DefId;
 use rustc::ty::subst::Substs;
 use rustc::traits;
 use rustc::ty::{self, Ty, GenericParamDefKind};
-use rustc::ty::subst::{UnpackedKind, Subst};
+use rustc::ty::subst::Subst;
 use rustc::ty::adjustment::{Adjustment, Adjust, OverloadedDeref};
 use rustc::ty::adjustment::{AllowTwoPhase, AutoBorrow, AutoBorrowMutability};
 use rustc::ty::fold::TypeFoldable;
@@ -320,22 +320,22 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
         Substs::for_item(self.tcx, pick.item.def_id, |param, _| {
             let i = param.index as usize;
             if i < parent_substs.len() {
-                parent_substs[i].unpack()
+                parent_substs[i]
             } else {
                 match param.kind {
                     GenericParamDefKind::Lifetime => {
                         if let Some(lifetime) = provided.as_ref().and_then(|p| {
                             p.lifetimes.get(i - parent_substs.len())
                         }) {
-                            return UnpackedKind::Lifetime(
-                                AstConv::ast_region_to_region(self.fcx, lifetime, Some(param)));
+                            return AstConv::ast_region_to_region(
+                                self.fcx, lifetime, Some(param)).into();
                         }
                     }
                     GenericParamDefKind::Type(_) => {
                         if let Some(ast_ty) = provided.as_ref().and_then(|p| {
                             p.types.get(i - parent_substs.len() - own_counts.lifetimes)
                         }) {
-                            return UnpackedKind::Type(self.to_ty(ast_ty));
+                            return self.to_ty(ast_ty).into();
                         }
                     }
                 }

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -20,7 +20,7 @@ use rustc::ty::subst::Substs;
 use rustc::traits;
 use rustc::ty::{self, Ty, ToPredicate, ToPolyTraitRef, TraitRef, TypeFoldable};
 use rustc::ty::GenericParamDefKind;
-use rustc::ty::subst::{UnpackedKind, Subst};
+use rustc::ty::subst::Subst;
 use rustc::infer::{self, InferOk};
 
 use syntax::ast;
@@ -259,9 +259,9 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 GenericParamDefKind::Lifetime => {}
                 GenericParamDefKind::Type(_) => {
                     if param.index == 0 {
-                        return UnpackedKind::Type(self_ty);
+                        return self_ty.into();
                     } else if let Some(ref input_types) = opt_input_types {
-                        return UnpackedKind::Type(input_types[param.index as usize - 1]);
+                        return input_types[param.index as usize - 1].into();
                     }
                 }
             }

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -288,7 +288,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         let method_item = self.associated_item(trait_def_id, m_name, Namespace::Value).unwrap();
         let def_id = method_item.def_id;
         let generics = tcx.generics_of(def_id);
-        assert_eq!(generics.parameters.len(), 0);
+        assert_eq!(generics.params.len(), 0);
 
         debug!("lookup_in_trait_adjusted: method_item={:?}", method_item);
         let mut obligations = vec![];

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -256,20 +256,16 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         // Construct a trait-reference `self_ty : Trait<input_tys>`
         let substs = Substs::for_item(self.tcx, trait_def_id, |param, _| {
             match param.kind {
-                GenericParamDefKind::Lifetime => {
-                    UnpackedKind::Lifetime(self.region_var_for_def(span, param))
-                }
+                GenericParamDefKind::Lifetime => {}
                 GenericParamDefKind::Type(_) => {
-                    let ty = if param.index == 0 {
-                        self_ty
+                    if param.index == 0 {
+                        return UnpackedKind::Type(self_ty);
                     } else if let Some(ref input_types) = opt_input_types {
-                        input_types[param.index as usize - 1]
-                    } else {
-                        self.type_var_for_def(span, param)
-                    };
-                    UnpackedKind::Type(ty)
+                        return UnpackedKind::Type(input_types[param.index as usize - 1]);
+                    }
                 }
             }
+            self.var_for_def(span, param)
         });
 
         let trait_ref = ty::TraitRef::new(trait_def_id, substs);

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -288,8 +288,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         let method_item = self.associated_item(trait_def_id, m_name, Namespace::Value).unwrap();
         let def_id = method_item.def_id;
         let generics = tcx.generics_of(def_id);
-        assert_eq!(generics.types.len(), 0);
-        assert_eq!(generics.regions.len(), 0);
+        assert_eq!(generics.parameters.len(), 0);
 
         debug!("lookup_in_trait_adjusted: method_item={:?}", method_item);
         let mut obligations = vec![];

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -1378,8 +1378,7 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
         // method yet. So create fresh variables here for those too,
         // if there are any.
         let generics = self.tcx.generics_of(method);
-        assert_eq!(substs.regions().count(), generics.parent_lifetimes() as usize);
-        assert_eq!(substs.types().count(), generics.parent_types() as usize);
+        assert_eq!(substs.len(), generics.parent_count as usize);
 
         // Erase any late-bound regions from the method and substitute
         // in the values from the substitution.

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -1378,14 +1378,14 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
         // method yet. So create fresh variables here for those too,
         // if there are any.
         let generics = self.tcx.generics_of(method);
-        assert_eq!(substs.types().count(), generics.parent_types as usize);
-        assert_eq!(substs.regions().count(), generics.parent_regions as usize);
+        assert_eq!(substs.regions().count(), generics.parent_lifetimes() as usize);
+        assert_eq!(substs.types().count(), generics.parent_types() as usize);
 
         // Erase any late-bound regions from the method and substitute
         // in the values from the substitution.
         let xform_fn_sig = self.erase_late_bound_regions(&fn_sig);
 
-        if generics.types.is_empty() && generics.regions.is_empty() {
+        if generics.parameters.is_empty() {
             xform_fn_sig.subst(self.tcx, substs)
         } else {
             let substs = Substs::for_item(self.tcx, method, |def, _| {

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -1384,7 +1384,7 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
         // in the values from the substitution.
         let xform_fn_sig = self.erase_late_bound_regions(&fn_sig);
 
-        if generics.parameters.is_empty() {
+        if generics.params.is_empty() {
             xform_fn_sig.subst(self.tcx, substs)
         } else {
             let substs = Substs::for_item(self.tcx, method, |def, _| {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -5094,8 +5094,8 @@ pub fn check_bounds_are_used<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
     for param in generics.params.iter() {
         let key = match param {
-            hir::GenericParamDef::Type(_) => ty::Kind::Type,
-            hir::GenericParamDef::Lifetime(_) => ty::Kind::Lifetime,
+            hir::GenericParam::Type(_) => ty::Kind::Type,
+            hir::GenericParam::Lifetime(_) => ty::Kind::Lifetime,
         };
         *param_counts.get_mut(&key).unwrap() += 1;
     }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4751,7 +4751,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
         let (fn_start, has_self) = match (type_segment, fn_segment) {
             (_, Some((_, generics))) => {
-                (generics.parent_count(), generics.has_self)
+                (generics.parent_count, generics.has_self)
             }
             (Some((_, generics)), None) => {
                 (generics.own_count(), generics.has_self)

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4925,8 +4925,19 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 let type_params_offset
                     = (generics.parent.is_none() && generics.has_self) as usize;
                 let type_params = param_counts.types - type_params_offset;
+                let type_params_without_defaults = {
+                    let mut count = 0;
+                    for param in generics.params.iter() {
+                        if let ty::GenericParamDef::Type(ty) = param {
+                            if !ty.has_default {
+                                count += 1
+                            }
+                        }
+                    }
+                    count
+                };
                 let type_params_barring_defaults =
-                    generics.type_params_without_defaults() - type_params_offset;
+                    type_params_without_defaults - type_params_offset;
 
                 (type_params_barring_defaults, type_params, param_counts.lifetimes)
             });

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4754,7 +4754,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 (generics.parent_count, generics.has_self)
             }
             (Some((_, generics)), None) => {
-                (generics.own_count(), generics.has_self)
+                (generics.params.len(), generics.has_self)
             }
             (None, None) => (0, false)
         };

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -96,7 +96,7 @@ use rustc::middle::region;
 use rustc::mir::interpret::{GlobalId};
 use rustc::ty::subst::{Kind, Subst, Substs};
 use rustc::traits::{self, ObligationCause, ObligationCauseCode, TraitEngine};
-use rustc::ty::{self, Ty, TyCtxt, Visibility, ToPredicate};
+use rustc::ty::{self, Ty, TyCtxt, GenericParamDefKind, Visibility, ToPredicate};
 use rustc::ty::adjustment::{Adjust, Adjustment, AllowTwoPhase, AutoBorrow, AutoBorrowMutability};
 use rustc::ty::fold::TypeFoldable;
 use rustc::ty::maps::Providers;
@@ -4802,10 +4802,15 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 i -= generics.param_counts().lifetimes;
             }
 
+            let has_default = match def.kind {
+                GenericParamDefKind::Type(ty) => ty.has_default,
+                _ => unreachable!()
+            };
+
             if let Some(ast_ty) = types.get(i) {
                 // A provided type parameter.
                 self.to_ty(ast_ty)
-            } else if !infer_types && def.to_type().has_default {
+            } else if !infer_types && has_default {
                 // No type parameter provided, but a default exists.
                 let default = self.tcx.type_of(def.def_id);
                 self.normalize_ty(

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1730,7 +1730,7 @@ impl<'a, 'gcx, 'tcx> AstConv<'gcx, 'tcx> for FnCtxt<'a, 'gcx, 'tcx> {
         }
     }
 
-    fn re_infer(&self, span: Span, def: Option<&ty::RegionParamDef>)
+    fn re_infer(&self, span: Span, def: Option<&ty::GenericParamDef>)
                 -> Option<ty::Region<'tcx>> {
         let v = match def {
             Some(def) => infer::EarlyBoundRegion(span, def.name),
@@ -1744,7 +1744,7 @@ impl<'a, 'gcx, 'tcx> AstConv<'gcx, 'tcx> for FnCtxt<'a, 'gcx, 'tcx> {
     }
 
     fn ty_infer_for_def(&self,
-                        ty_param_def: &ty::TypeParamDef,
+                        ty_param_def: &ty::GenericParamDef,
                         span: Span) -> Ty<'tcx> {
         self.type_var_for_def(span, ty_param_def)
     }
@@ -4805,7 +4805,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             if let Some(ast_ty) = types.get(i) {
                 // A provided type parameter.
                 self.to_ty(ast_ty)
-            } else if !infer_types && def.has_default {
+            } else if !infer_types && def.to_type().has_default {
                 // No type parameter provided, but a default exists.
                 let default = self.tcx.type_of(def.def_id);
                 self.normalize_ty(
@@ -4928,7 +4928,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 let type_params_without_defaults = {
                     let mut count = 0;
                     for param in generics.params.iter() {
-                        if let ty::GenericParamDef::Type(ty) = param {
+                        if let ty::GenericParamDefKind::Type(ty) = param.kind {
                             if !ty.has_default {
                                 count += 1
                             }
@@ -5025,7 +5025,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         let segment = segment.map(|(path_segment, generics)| {
             let explicit = !path_segment.infer_types;
             let impl_trait = generics.params.iter().any(|param| {
-                if let ty::GenericParamDef::Type(ty) = param {
+                if let ty::GenericParamDefKind::Type(ty) = param.kind {
                     if let Some(hir::SyntheticTyParamKind::ImplTrait) = ty.synthetic {
                         return true;
                     }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1746,7 +1746,11 @@ impl<'a, 'gcx, 'tcx> AstConv<'gcx, 'tcx> for FnCtxt<'a, 'gcx, 'tcx> {
     fn ty_infer_for_def(&self,
                         ty_param_def: &ty::GenericParamDef,
                         span: Span) -> Ty<'tcx> {
-        self.type_var_for_def(span, ty_param_def)
+        if let UnpackedKind::Type(ty) = self.var_for_def(span, ty_param_def) {
+            ty
+        } else {
+            unreachable!()
+        }
     }
 
     fn projected_ty_from_poly_trait_ref(&self,
@@ -4759,17 +4763,26 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             (None, None) => (0, false)
         };
         let substs = Substs::for_item(self.tcx, def.def_id(), |param, substs| {
+            let mut i = param.index as usize;
+
+            let segment = if i < fn_start {
+                if let GenericParamDefKind::Type(_) = param.kind {
+                    // Handle Self first, so we can adjust the index to match the AST.
+                    if has_self && i == 0 {
+                        return opt_self_ty.map(|ty| UnpackedKind::Type(ty)).unwrap_or_else(|| {
+                            self.var_for_def(span, param)
+                        });
+                    }
+                }
+                i -= has_self as usize;
+                type_segment
+            } else {
+                i -= fn_start;
+                fn_segment
+            };
+
             match param.kind {
                 GenericParamDefKind::Lifetime => {
-                    let mut i = param.index as usize;
-
-                    let segment = if i < fn_start {
-                        i -= has_self as usize;
-                        type_segment
-                    } else {
-                        i -= fn_start;
-                        fn_segment
-                    };
                     let lifetimes = segment.map_or(&[][..], |(s, _)| {
                         s.parameters.as_ref().map_or(&[][..], |p| &p.lifetimes[..])
                     });
@@ -4782,21 +4795,6 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     UnpackedKind::Lifetime(lt)
                 }
                 GenericParamDefKind::Type(_) => {
-                    let mut i = param.index as usize;
-
-                    let segment = if i < fn_start {
-                        // Handle Self first, so we can adjust the index to match the AST.
-                        if has_self && i == 0 {
-                            return UnpackedKind::Type(opt_self_ty.unwrap_or_else(|| {
-                                self.type_var_for_def(span, param)
-                            }));
-                        }
-                        i -= has_self as usize;
-                        type_segment
-                    } else {
-                        i -= fn_start;
-                        fn_segment
-                    };
                     let (types, infer_types) = segment.map_or((&[][..], true), |(s, _)| {
                         (s.parameters.as_ref().map_or(&[][..], |p| &p.types[..]), s.infer_types)
                     });
@@ -4811,24 +4809,23 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         _ => unreachable!()
                     };
 
-                    let ty = if let Some(ast_ty) = types.get(i) {
+                    if let Some(ast_ty) = types.get(i) {
                         // A provided type parameter.
-                        self.to_ty(ast_ty)
+                        UnpackedKind::Type(self.to_ty(ast_ty))
                     } else if !infer_types && has_default {
                         // No type parameter provided, but a default exists.
                         let default = self.tcx.type_of(param.def_id);
-                        self.normalize_ty(
+                        UnpackedKind::Type(self.normalize_ty(
                             span,
                             default.subst_spanned(self.tcx, substs, Some(span))
-                        )
+                        ))
                     } else {
                         // No type parameters were provided, we can infer all.
                         // This can also be reached in some error cases:
                         // We prefer to use inference variables instead of
                         // TyError to let type inference recover somewhat.
-                        self.type_var_for_def(span, param)
-                    };
-                    UnpackedKind::Type(ty)
+                        self.var_for_def(span, param)
+                    }
                 }
             }
         });

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4925,27 +4925,32 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         // Check provided parameters.
         let ((ty_required, ty_accepted), lt_accepted) =
             segment.map_or(((0, 0), 0), |(_, generics)| {
+                struct ParamRange {
+                    required: usize,
+                    accepted: usize
+                };
+
                 let mut lt_accepted = 0;
-                let mut ty_range = (0, 0);
+                let mut ty_params = ParamRange { required: 0, accepted: 0 };
                 for param in &generics.params {
                     match param.kind {
                         GenericParamDefKind::Lifetime => {
                             lt_accepted += 1;
                         }
                         GenericParamDefKind::Type(ty) => {
-                            ty_range.1 += 1;
+                            ty_params.accepted += 1;
                             if !ty.has_default {
-                                ty_range.0 += 1;
+                                ty_params.required += 1;
                             }
                         }
                     };
                 }
                 if generics.parent.is_none() && generics.has_self {
-                    ty_range.0 -= 1;
-                    ty_range.1 -= 1;
+                    ty_params.required -= 1;
+                    ty_params.accepted -= 1;
                 }
 
-                ((ty_range.0, ty_range.1), lt_accepted)
+                ((ty_params.required, ty_params.accepted), lt_accepted)
             });
 
         if types.len() > ty_accepted {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1730,7 +1730,7 @@ impl<'a, 'gcx, 'tcx> AstConv<'gcx, 'tcx> for FnCtxt<'a, 'gcx, 'tcx> {
         }
     }
 
-    fn re_infer(&self, span: Span, def: Option<&ty::RegionParameterDef>)
+    fn re_infer(&self, span: Span, def: Option<&ty::RegionParamDef>)
                 -> Option<ty::Region<'tcx>> {
         let v = match def {
             Some(def) => infer::EarlyBoundRegion(span, def.name),
@@ -1744,7 +1744,7 @@ impl<'a, 'gcx, 'tcx> AstConv<'gcx, 'tcx> for FnCtxt<'a, 'gcx, 'tcx> {
     }
 
     fn ty_infer_for_def(&self,
-                        ty_param_def: &ty::TypeParameterDef,
+                        ty_param_def: &ty::TypeParamDef,
                         span: Span) -> Ty<'tcx> {
         self.type_var_for_def(span, ty_param_def)
     }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1239,7 +1239,7 @@ pub fn check_item_type<'a,'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, it: &'tcx hir::Item
         } else {
             for item in &m.items {
                 let generics = tcx.generics_of(tcx.hir.local_def_id(item.id));
-                if generics.params.len() - generics.param_counts().lifetimes != 0 {
+                if generics.params.len() - generics.own_counts().lifetimes != 0 {
                     let mut err = struct_span_err!(tcx.sess, item.span, E0044,
                         "foreign items may not have type parameters");
                     err.span_label(item.span, "can't have type parameters");
@@ -4799,7 +4799,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
             // Skip over the lifetimes in the same segment.
             if let Some((_, generics)) = segment {
-                i -= generics.param_counts().lifetimes;
+                i -= generics.own_counts().lifetimes;
             }
 
             let has_default = match def.kind {
@@ -4925,10 +4925,10 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         // Check provided parameters.
         let (ty_req_len, accepted, lt_req_len) =
             segment.map_or((0, 0, 0), |(_, generics)| {
-                let param_counts = generics.param_counts();
+                let own_counts = generics.own_counts();
 
                 let own_self = (generics.parent.is_none() && generics.has_self) as usize;
-                let type_params = param_counts.types - own_self;
+                let type_params = own_counts.types - own_self;
                 let type_params_without_defaults = {
                     let mut count = 0;
                     for param in generics.params.iter() {
@@ -4943,7 +4943,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 let type_params_barring_defaults =
                     type_params_without_defaults - own_self;
 
-                (type_params_barring_defaults, type_params, param_counts.lifetimes)
+                (type_params_barring_defaults, type_params, own_counts.lifetimes)
             });
 
         if types.len() > accepted {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1716,7 +1716,7 @@ impl<'a, 'gcx, 'tcx> AstConv<'gcx, 'tcx> for FnCtxt<'a, 'gcx, 'tcx> {
         let item_id = tcx.hir.ty_param_owner(node_id);
         let item_def_id = tcx.hir.local_def_id(item_id);
         let generics = tcx.generics_of(item_def_id);
-        let index = generics.type_param_to_index[&def_id];
+        let index = generics.param_def_id_to_index[&def_id];
         ty::GenericPredicates {
             parent: None,
             predicates: self.param_env.caller_bounds.iter().filter(|predicate| {

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -662,7 +662,7 @@ fn reject_shadowing_parameters(tcx: TyCtxt, def_id: DefId) {
                      .collect();
 
     for method_param in generics.params.iter() {
-        // Shadowing is currently permitted with lifetimes.
+        // Shadowing is checked in resolve_lifetime.
         if let GenericParamDef::Lifetime(_) = method_param {
             continue;
         }

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -14,7 +14,7 @@ use constrained_type_params::{identify_constrained_type_params, Parameter};
 use hir::def_id::DefId;
 use rustc::traits::{self, ObligationCauseCode};
 use rustc::ty::{self, Lift, Ty, TyCtxt, GenericParamDefKind};
-use rustc::ty::subst::{UnpackedKind, Substs};
+use rustc::ty::subst::Substs;
 use rustc::ty::util::ExplicitSelf;
 use rustc::util::nodemap::{FxHashSet, FxHashMap};
 use rustc::middle::lang_items;
@@ -409,8 +409,7 @@ fn check_where_clauses<'a, 'gcx, 'fcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'gcx>,
         match param.kind {
             GenericParamDefKind::Lifetime => {
                 // All regions are identity.
-                UnpackedKind::Lifetime(
-                    fcx.tcx.mk_region(ty::ReEarlyBound(param.to_early_bound_region_data())))
+                fcx.tcx.mk_region(ty::ReEarlyBound(param.to_early_bound_region_data())).into()
             }
             GenericParamDefKind::Type(_) => {
                 // If the param has a default,
@@ -419,11 +418,11 @@ fn check_where_clauses<'a, 'gcx, 'fcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'gcx>,
                     // and it's not a dependent default
                     if !default_ty.needs_subst() {
                         // then substitute with the default.
-                        return UnpackedKind::Type(default_ty);
+                        return default_ty.into();
                     }
                 }
                 // Mark unwanted params as err.
-                UnpackedKind::Type(fcx.tcx.types.err)
+                fcx.tcx.types.err.into()
             }
         }
     });

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -377,7 +377,7 @@ fn check_where_clauses<'a, 'gcx, 'fcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'gcx>,
     // For example this forbids the declaration:
     // struct Foo<T = Vec<[u32]>> { .. }
     // Here the default `Vec<[u32]>` is not WF because `[u32]: Sized` does not hold.
-    for d in generics.types().cloned().filter(is_our_default).map(|p| p.def_id) {
+    for d in generics.types_depr().cloned().filter(is_our_default).map(|p| p.def_id) {
         let ty = fcx.tcx.type_of(d);
         // ignore dependent defaults -- that is, where the default of one type
         // parameter includes another (e.g., <T, U = T>). In those cases, we can't

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -371,7 +371,12 @@ fn check_where_clauses<'a, 'gcx, 'fcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'gcx>,
 
     let generics = tcx.generics_of(def_id);
     let is_our_default = |def: &ty::GenericParamDef| {
-        def.to_type().has_default && def.index >= generics.parent_count as u32
+        match def.kind {
+            GenericParamDefKind::Type(ty) => {
+                ty.has_default && def.index >= generics.parent_count as u32
+            }
+            _ => unreachable!()
+        }
     };
 
     // Check that concrete defaults are well-formed. See test `type-check-defaults.rs`.

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -652,7 +652,7 @@ fn reject_shadowing_parameters(tcx: TyCtxt, def_id: DefId) {
         parent.params.iter()
                      .flat_map(|param| {
                          match param.kind {
-                             GenericParamDefKind::Lifetime(_) => None,
+                             GenericParamDefKind::Lifetime => None,
                              GenericParamDefKind::Type(_) => Some((param.name, param.def_id)),
                          }
                      })
@@ -661,7 +661,7 @@ fn reject_shadowing_parameters(tcx: TyCtxt, def_id: DefId) {
     for method_param in generics.params.iter() {
         match method_param.kind {
             // Shadowing is checked in resolve_lifetime.
-            GenericParamDefKind::Lifetime(_) => continue,
+            GenericParamDefKind::Lifetime => continue,
             _ => {},
         };
         if impl_params.contains_key(&method_param.name) {

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -642,7 +642,6 @@ fn reject_shadowing_type_parameters(tcx: TyCtxt, def_id: DefId) {
     let generics = tcx.generics_of(def_id);
     let parent = tcx.generics_of(generics.parent.unwrap());
     let impl_params: FxHashMap<_, _> = parent.types()
-                                             .iter()
                                              .map(|tp| (tp.name, tp.def_id))
                                              .collect();
 

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -641,12 +641,12 @@ fn report_bivariance<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 fn reject_shadowing_type_parameters(tcx: TyCtxt, def_id: DefId) {
     let generics = tcx.generics_of(def_id);
     let parent = tcx.generics_of(generics.parent.unwrap());
-    let impl_params: FxHashMap<_, _> = parent.types
-                                       .iter()
-                                       .map(|tp| (tp.name, tp.def_id))
-                                       .collect();
+    let impl_params: FxHashMap<_, _> = parent.types()
+                                             .iter()
+                                             .map(|tp| (tp.name, tp.def_id))
+                                             .collect();
 
-    for method_param in &generics.types {
+    for method_param in generics.types() {
         if impl_params.contains_key(&method_param.name) {
             // Tighten up the span to focus on only the shadowing type
             let type_span = tcx.def_span(method_param.def_id);

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -369,13 +369,13 @@ fn check_where_clauses<'a, 'gcx, 'fcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'gcx>,
 
     let generics = tcx.generics_of(def_id);
     let is_our_default = |def: &ty::TypeParameterDef|
-                            def.has_default && def.index >= generics.parent_count() as u32;
+                            def.has_default && def.index >= generics.parent_count as u32;
 
     // Check that concrete defaults are well-formed. See test `type-check-defaults.rs`.
     // For example this forbids the declaration:
     // struct Foo<T = Vec<[u32]>> { .. }
     // Here the default `Vec<[u32]>` is not WF because `[u32]: Sized` does not hold.
-    for d in generics.types.iter().cloned().filter(is_our_default).map(|p| p.def_id) {
+    for d in generics.types().cloned().filter(is_our_default).map(|p| p.def_id) {
         let ty = fcx.tcx.type_of(d);
         // ignore dependent defaults -- that is, where the default of one type
         // parameter includes another (e.g., <T, U = T>). In those cases, we can't

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -675,7 +675,7 @@ fn reject_shadowing_parameters(tcx: TyCtxt, def_id: DefId) {
             // local so it should be okay to just unwrap everything.
             let trait_def_id = impl_params[&name];
             let trait_decl_span = tcx.def_span(trait_def_id);
-            error_194(tcx, type_span, trait_decl_span, &name[..]);
+            error_194(tcx, type_span, trait_decl_span, &name.as_str()[..]);
         }
     }
 }

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -409,7 +409,7 @@ fn check_where_clauses<'a, 'gcx, 'fcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'gcx>,
         match param.kind {
             GenericParamDefKind::Lifetime => {
                 // All regions are identity.
-                fcx.tcx.mk_region(ty::ReEarlyBound(param.to_early_bound_region_data())).into()
+                fcx.tcx.mk_param_from_def(param)
             }
             GenericParamDefKind::Type(_) => {
                 // If the param has a default,

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -368,7 +368,7 @@ fn check_where_clauses<'a, 'gcx, 'fcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'gcx>,
     let mut substituted_predicates = Vec::new();
 
     let generics = tcx.generics_of(def_id);
-    let is_our_default = |def: &ty::TypeParameterDef|
+    let is_our_default = |def: &ty::TypeParamDef|
                             def.has_default && def.index >= generics.parent_count as u32;
 
     // Check that concrete defaults are well-formed. See test `type-check-defaults.rs`.

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -903,7 +903,7 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let object_lifetime_defaults = tcx.object_lifetime_defaults(hir_id);
 
     // Now create the real type parameters.
-    let type_start = params.len() as u32;
+    let type_start = own_start - has_self as u32 + params.len() as u32;
     params.extend(ast_generics.ty_params().enumerate().map(|(i, p)| {
         if p.name == keywords::SelfType.name() {
             span_bug!(p.span, "`Self` should not be the name of a regular parameter");

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -973,15 +973,9 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                  .chain(types)
                                  .collect();
 
-    let param_def_id_to_index =
-        params.iter()
-              .map(|param| {
-                  match param {
-                      ty::GenericParamDef::Lifetime(lt) => (lt.def_id, lt.index),
-                      ty::GenericParamDef::Type(ty) => (ty.def_id, ty.index),
-                  }
-              })
-              .collect();
+    let param_def_id_to_index = params.iter()
+                                      .map(|param| (param.def_id(), param.index()))
+                                      .collect();
 
     tcx.alloc_generics(ty::Generics {
         parent: parent_def_id,

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -31,7 +31,6 @@ use middle::lang_items::SizedTraitLangItem;
 use middle::resolve_lifetime as rl;
 use rustc::mir::mono::Linkage;
 use rustc::ty::subst::Substs;
-use rustc::ty::GenericParamDefKind;
 use rustc::ty::{ToPredicate, ReprOptions};
 use rustc::ty::{self, AdtKind, ToPolyTraitRef, Ty, TyCtxt};
 use rustc::ty::maps::Providers;
@@ -1098,13 +1097,7 @@ fn type_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
             let substs = ty::ClosureSubsts {
                 substs: Substs::for_item(tcx, def_id, |param, _| {
-                    match param.kind {
-                        GenericParamDefKind::Lifetime => {
-                            let region = param.to_early_bound_region_data();
-                            tcx.mk_region(ty::ReEarlyBound(region)).into()
-                        }
-                        GenericParamDefKind::Type(_) => tcx.mk_ty_param_from_def(param).into(),
-                    }
+                    tcx.mk_param_from_def(param)
                 })
             };
 

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -30,7 +30,7 @@ use constrained_type_params as ctp;
 use middle::lang_items::SizedTraitLangItem;
 use middle::resolve_lifetime as rl;
 use rustc::mir::mono::Linkage;
-use rustc::ty::subst::{UnpackedKind, Substs};
+use rustc::ty::subst::Substs;
 use rustc::ty::GenericParamDefKind;
 use rustc::ty::{ToPredicate, ReprOptions};
 use rustc::ty::{self, AdtKind, ToPolyTraitRef, Ty, TyCtxt};
@@ -1101,11 +1101,9 @@ fn type_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                     match param.kind {
                         GenericParamDefKind::Lifetime => {
                             let region = param.to_early_bound_region_data();
-                            UnpackedKind::Lifetime(tcx.mk_region(ty::ReEarlyBound(region)))
+                            tcx.mk_region(ty::ReEarlyBound(region)).into()
                         }
-                        GenericParamDefKind::Type(_) => {
-                            UnpackedKind::Type(tcx.mk_ty_param_from_def(param))
-                        }
+                        GenericParamDefKind::Type(_) => tcx.mk_ty_param_from_def(param).into(),
                     }
                 })
             };

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -971,10 +971,10 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                    .collect();
 
     let lifetimes: Vec<ty::GenericParam> =
-        regions.into_iter().map(|lt| ty::GenericParam::Lifetime(lt)).collect();
+        regions.into_iter().map(|lt| ty::GenericParam::Lifetime(lt));
     let types: Vec<ty::GenericParam> =
-        types.into_iter().map(|ty| ty::GenericParam::Type(ty)).collect();
-    let params = lifetimes.into_iter().chain(types.into_iter()).collect();
+        types.into_iter().map(|ty| ty::GenericParam::Type(ty));
+    let params = lifetimes.chain(types).collect();
 
     tcx.alloc_generics(ty::Generics {
         parent: parent_def_id,

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -970,10 +970,10 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                    .map(|param| (param.def_id, param.index))
                                    .collect();
 
-    let lifetimes: Vec<ty::GenericParameterDef> =
-        regions.into_iter().map(|lt| ty::GenericParameterDef::Lifetime(lt)).collect();
-    let types: Vec<ty::GenericParameterDef> =
-        types.into_iter().map(|ty| ty::GenericParameterDef::Type(ty)).collect();
+    let lifetimes: Vec<ty::GenericParam> =
+        regions.into_iter().map(|lt| ty::GenericParam::Lifetime(lt)).collect();
+    let types: Vec<ty::GenericParam> =
+        types.into_iter().map(|ty| ty::GenericParam::Type(ty)).collect();
     let params = lifetimes.into_iter().chain(types.into_iter()).collect();
 
     tcx.alloc_generics(ty::Generics {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -970,10 +970,8 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                    .map(|param| (param.def_id, param.index))
                                    .collect();
 
-    let lifetimes: Vec<ty::GenericParam> =
-        regions.into_iter().map(|lt| ty::GenericParam::Lifetime(lt));
-    let types: Vec<ty::GenericParam> =
-        types.into_iter().map(|ty| ty::GenericParam::Type(ty));
+    let lifetimes = regions.into_iter().map(|lt| ty::GenericParam::Lifetime(lt));
+    let types = types.into_iter().map(|ty| ty::GenericParam::Type(ty));
     let params = lifetimes.chain(types).collect();
 
     tcx.alloc_generics(ty::Generics {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -844,10 +844,10 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                         index: 0,
                         name: keywords::SelfType.name().as_interned_str(),
                         def_id: tcx.hir.local_def_id(param_id),
+                        pure_wrt_drop: false,
                         kind: ty::GenericParamDefKind::Type(ty::TypeParamDef {
                             has_default: false,
                             object_lifetime_default: rl::Set1::Empty,
-                            pure_wrt_drop: false,
                             synthetic: None,
                         }),
                     });
@@ -892,9 +892,8 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             name: l.lifetime.name.name().as_interned_str(),
             index: own_start + i as u32,
             def_id: tcx.hir.local_def_id(l.lifetime.id),
-            kind: ty::GenericParamDefKind::Lifetime(ty::LifetimeParamDef {
-                pure_wrt_drop: l.pure_wrt_drop,
-            }),
+            pure_wrt_drop: l.pure_wrt_drop,
+            kind: ty::GenericParamDefKind::Lifetime,
         }
     }).collect::<Vec<_>>();
 
@@ -923,11 +922,11 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             index: type_start + i as u32,
             name: p.name.as_interned_str(),
             def_id: tcx.hir.local_def_id(p.id),
+            pure_wrt_drop: p.pure_wrt_drop,
             kind: ty::GenericParamDefKind::Type(ty::TypeParamDef {
                 has_default: p.default.is_some(),
                 object_lifetime_default:
                     object_lifetime_defaults.as_ref().map_or(rl::Set1::Empty, |o| o[i]),
-                pure_wrt_drop: p.pure_wrt_drop,
                 synthetic: p.synthetic,
             }),
         }
@@ -948,10 +947,10 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 index: type_start + i as u32,
                 name: Symbol::intern(arg).as_interned_str(),
                 def_id,
+                pure_wrt_drop: false,
                 kind: ty::GenericParamDefKind::Type(ty::TypeParamDef {
                     has_default: false,
                     object_lifetime_default: rl::Set1::Empty,
-                    pure_wrt_drop: false,
                     synthetic: None,
                 }),
             });
@@ -963,10 +962,10 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                     index: type_start + i,
                     name: Symbol::intern("<upvar>").as_interned_str(),
                     def_id,
+                    pure_wrt_drop: false,
                     kind: ty::GenericParamDefKind::Type(ty::TypeParamDef {
                         has_default: false,
                         object_lifetime_default: rl::Set1::Empty,
-                        pure_wrt_drop: false,
                         synthetic: None,
                     }),
                 }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -881,7 +881,7 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         assert_eq!(has_self, false);
         parent_has_self = generics.has_self;
         own_start = generics.count() as u32;
-        generics.parent_count + generics.parameters.len()
+        generics.parent_count + generics.params.len()
     });
 
     let early_lifetimes = early_bound_lifetimes_from_generics(tcx, ast_generics);
@@ -974,12 +974,12 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         regions.into_iter().map(|lt| ty::GenericParameterDef::Lifetime(lt)).collect();
     let types: Vec<ty::GenericParameterDef> =
         types.into_iter().map(|ty| ty::GenericParameterDef::Type(ty)).collect();
-    let parameters = lifetimes.into_iter().chain(types.into_iter()).collect();
+    let params = lifetimes.into_iter().chain(types.into_iter()).collect();
 
     tcx.alloc_generics(ty::Generics {
         parent: parent_def_id,
         parent_count,
-        parameters,
+        params,
         type_param_to_index,
         has_self: has_self || parent_has_self,
         has_late_bound_regions: has_late_bound_regions(tcx, node),

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -181,7 +181,7 @@ impl<'a, 'tcx> AstConv<'tcx, 'tcx> for ItemCtxt<'a, 'tcx> {
         self.tcx.at(span).type_param_predicates((self.item_def_id, def_id))
     }
 
-    fn re_infer(&self, _span: Span, _def: Option<&ty::RegionParameterDef>)
+    fn re_infer(&self, _span: Span, _def: Option<&ty::RegionParamDef>)
                 -> Option<ty::Region<'tcx>> {
         None
     }
@@ -840,7 +840,7 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                     // the node id for the Self type parameter.
                     let param_id = item.id;
 
-                    opt_self = Some(ty::TypeParameterDef {
+                    opt_self = Some(ty::TypeParamDef {
                         index: 0,
                         name: keywords::SelfType.name().as_interned_str(),
                         def_id: tcx.hir.local_def_id(param_id),
@@ -886,7 +886,7 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
     let early_lifetimes = early_bound_lifetimes_from_generics(tcx, ast_generics);
     let regions = early_lifetimes.enumerate().map(|(i, l)| {
-        ty::RegionParameterDef {
+        ty::RegionParamDef {
             name: l.lifetime.name.name().as_interned_str(),
             index: own_start + i as u32,
             def_id: tcx.hir.local_def_id(l.lifetime.id),
@@ -915,7 +915,7 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             }
         }
 
-        ty::TypeParameterDef {
+        ty::TypeParamDef {
             index: type_start + i as u32,
             name: p.name.as_interned_str(),
             def_id: tcx.hir.local_def_id(p.id),
@@ -940,7 +940,7 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         };
 
         for (i, &arg) in dummy_args.iter().enumerate() {
-            types.push(ty::TypeParameterDef {
+            types.push(ty::TypeParamDef {
                 index: type_start + i as u32,
                 name: Symbol::intern(arg).as_interned_str(),
                 def_id,

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -927,7 +927,7 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         }
     });
 
-    let mut types: Vec<_> = opt_self.into_iter().chain(types).collect();
+    let mut types: Vec<_> = types.into_iter().collect();
 
     // provide junk type parameter defs - the only place that
     // cares about anything but the length is instantiation,
@@ -966,13 +966,17 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         });
     }
 
-    let type_param_to_index = types.iter()
-                                   .map(|param| (param.def_id, param.index))
-                                   .collect();
+    let type_param_to_index = opt_self.iter()
+                                      .chain(types.iter())
+                                      .map(|ty| (ty.def_id, ty.index))
+                                      .collect();
 
+    let opt_self = opt_self.into_iter().map(|ty| ty::GenericParamDef::Type(ty));
     let lifetimes = regions.into_iter().map(|lt| ty::GenericParamDef::Lifetime(lt));
     let types = types.into_iter().map(|ty| ty::GenericParamDef::Type(ty));
-    let params = lifetimes.chain(types).collect();
+    let params = opt_self.chain(lifetimes)
+                         .chain(types)
+                         .collect();
 
     tcx.alloc_generics(ty::Generics {
         parent: parent_def_id,

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -903,7 +903,7 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
     // Now create the real type parameters.
     let type_start = own_start + lifetimes.len() as u32;
-    let types = ast_generics.ty_params().enumerate().map(|(i, p)| {
+    let mut types: Vec<_> = ast_generics.ty_params().enumerate().map(|(i, p)| {
         if p.name == keywords::SelfType.name() {
             span_bug!(p.span, "`Self` should not be the name of a regular parameter");
         }
@@ -931,9 +931,7 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 synthetic: p.synthetic,
             }),
         }
-    });
-
-    let mut types: Vec<_> = types.into_iter().collect();
+    }).collect();
 
     // provide junk type parameter defs - the only place that
     // cares about anything but the length is instantiation,

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -970,8 +970,8 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                    .map(|param| (param.def_id, param.index))
                                    .collect();
 
-    let lifetimes = regions.into_iter().map(|lt| ty::GenericParam::Lifetime(lt));
-    let types = types.into_iter().map(|ty| ty::GenericParam::Type(ty));
+    let lifetimes = regions.into_iter().map(|lt| ty::GenericParamDef::Lifetime(lt));
+    let types = types.into_iter().map(|ty| ty::GenericParamDef::Type(ty));
     let params = lifetimes.chain(types).collect();
 
     tcx.alloc_generics(ty::Generics {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -892,7 +892,7 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             name: l.lifetime.name.name().as_interned_str(),
             index: own_start + i as u32,
             def_id: tcx.hir.local_def_id(l.lifetime.id),
-            kind: ty::GenericParamDefKind::Lifetime(ty::RegionParamDef {
+            kind: ty::GenericParamDefKind::Lifetime(ty::LifetimeParamDef {
                 pure_wrt_drop: l.pure_wrt_drop,
             }),
         }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1096,9 +1096,7 @@ fn type_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             }
 
             let substs = ty::ClosureSubsts {
-                substs: Substs::for_item(tcx, def_id, |param, _| {
-                    tcx.mk_param_from_def(param)
-                })
+                substs: Substs::identity_for_item(tcx, def_id),
             };
 
             tcx.mk_closure(def_id, substs)

--- a/src/librustc_typeck/impl_wf_check.rs
+++ b/src/librustc_typeck/impl_wf_check.rs
@@ -105,7 +105,7 @@ fn enforce_impl_params_are_constrained<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         tcx, &impl_predicates.predicates.as_slice(), impl_trait_ref, &mut input_parameters);
 
     // Disallow ANY unconstrained type parameters.
-    for (ty_param, param) in impl_generics.types.iter().zip(impl_hir_generics.ty_params()) {
+    for (ty_param, param) in impl_generics.types().iter().zip(impl_hir_generics.ty_params()) {
         let param_ty = ty::ParamTy::for_def(ty_param);
         if !input_parameters.contains(&ctp::Parameter::from(param_ty)) {
             report_unused_parameter(tcx, param.span, "type", &param_ty.to_string());
@@ -122,7 +122,7 @@ fn enforce_impl_params_are_constrained<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         .flat_map(|def_id| {
             ctp::parameters_for(&tcx.type_of(def_id), true)
         }).collect();
-    for (ty_lifetime, lifetime) in impl_generics.regions.iter()
+    for (ty_lifetime, lifetime) in impl_generics.lifetimes().iter()
         .zip(impl_hir_generics.lifetimes())
     {
         let param = ctp::Parameter::from(ty_lifetime.to_early_bound_region_data());

--- a/src/librustc_typeck/impl_wf_check.rs
+++ b/src/librustc_typeck/impl_wf_check.rs
@@ -119,13 +119,13 @@ fn enforce_impl_params_are_constrained<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                               .zip(impl_hir_generics.params.iter()) {
         match (ty_param, hir_param) {
             // Disallow ANY unconstrained type parameters.
-            (ty::GenericParamDef::Type(ty_ty), hir::GenericParamDef::Type(hir_ty)) => {
+            (ty::GenericParamDef::Type(ty_ty), hir::GenericParam::Type(hir_ty)) => {
                 let param_ty = ty::ParamTy::for_def(ty_ty);
                 if !input_parameters.contains(&ctp::Parameter::from(param_ty)) {
                     report_unused_parameter(tcx, hir_ty.span, "type", &param_ty.to_string());
                 }
             }
-            (ty::GenericParamDef::Lifetime(ty_lt), hir::GenericParamDef::Lifetime(hir_lt)) => {
+            (ty::GenericParamDef::Lifetime(ty_lt), hir::GenericParam::Lifetime(hir_lt)) => {
                 let param = ctp::Parameter::from(ty_lt.to_early_bound_region_data());
                 if lifetimes_in_associated_types.contains(&param) && // (*)
                     !input_parameters.contains(&param) {

--- a/src/librustc_typeck/impl_wf_check.rs
+++ b/src/librustc_typeck/impl_wf_check.rs
@@ -105,7 +105,7 @@ fn enforce_impl_params_are_constrained<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         tcx, &impl_predicates.predicates.as_slice(), impl_trait_ref, &mut input_parameters);
 
     // Disallow ANY unconstrained type parameters.
-    for (ty_param, param) in impl_generics.types().zip(impl_hir_generics.ty_params()) {
+    for (ty_param, param) in impl_generics.types_depr().zip(impl_hir_generics.ty_params()) {
         let param_ty = ty::ParamTy::for_def(ty_param);
         if !input_parameters.contains(&ctp::Parameter::from(param_ty)) {
             report_unused_parameter(tcx, param.span, "type", &param_ty.to_string());
@@ -122,13 +122,13 @@ fn enforce_impl_params_are_constrained<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         .flat_map(|def_id| {
             ctp::parameters_for(&tcx.type_of(def_id), true)
         }).collect();
-    for (ty_lifetime, lifetime) in impl_generics.lifetimes().zip(impl_hir_generics.lifetimes()) {
-        let param = ctp::Parameter::from(ty_lifetime.to_early_bound_region_data());
+    for (ty_lt, lt) in impl_generics.lifetimes_depr().zip(impl_hir_generics.lifetimes()) {
+        let param = ctp::Parameter::from(ty_lt.to_early_bound_region_data());
 
         if lifetimes_in_associated_types.contains(&param) && // (*)
             !input_parameters.contains(&param) {
-            report_unused_parameter(tcx, lifetime.lifetime.span,
-                                    "lifetime", &lifetime.lifetime.name.name().to_string());
+            report_unused_parameter(tcx, lt.lifetime.span,
+                                    "lifetime", &lt.lifetime.name.name().to_string());
         }
     }
 

--- a/src/librustc_typeck/impl_wf_check.rs
+++ b/src/librustc_typeck/impl_wf_check.rs
@@ -125,7 +125,7 @@ fn enforce_impl_params_are_constrained<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                     report_unused_parameter(tcx, hir_ty.span, "type", &param_ty.to_string());
                 }
             }
-            (&ty::GenericParamDefKind::Lifetime(_), hir::GenericParam::Lifetime(hir_lt)) => {
+            (&ty::GenericParamDefKind::Lifetime, hir::GenericParam::Lifetime(hir_lt)) => {
                 let param = ctp::Parameter::from(ty_param.to_early_bound_region_data());
                 if lifetimes_in_associated_types.contains(&param) && // (*)
                     !input_parameters.contains(&param) {
@@ -134,7 +134,7 @@ fn enforce_impl_params_are_constrained<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 }
             }
             (&ty::GenericParamDefKind::Type(_), _) => continue,
-            (&ty::GenericParamDefKind::Lifetime(_), _) => continue,
+            (&ty::GenericParamDefKind::Lifetime, _) => continue,
         }
     }
 

--- a/src/librustc_typeck/impl_wf_check.rs
+++ b/src/librustc_typeck/impl_wf_check.rs
@@ -117,24 +117,24 @@ fn enforce_impl_params_are_constrained<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
     for (ty_param, hir_param) in impl_generics.params.iter()
                                               .zip(impl_hir_generics.params.iter()) {
-        match (ty_param, hir_param) {
+        match (&ty_param.kind, hir_param) {
             // Disallow ANY unconstrained type parameters.
-            (ty::GenericParamDef::Type(ty_ty), hir::GenericParam::Type(hir_ty)) => {
-                let param_ty = ty::ParamTy::for_def(ty_ty);
+            (&ty::GenericParamDefKind::Type(_), hir::GenericParam::Type(hir_ty)) => {
+                let param_ty = ty::ParamTy::for_def(ty_param);
                 if !input_parameters.contains(&ctp::Parameter::from(param_ty)) {
                     report_unused_parameter(tcx, hir_ty.span, "type", &param_ty.to_string());
                 }
             }
-            (ty::GenericParamDef::Lifetime(ty_lt), hir::GenericParam::Lifetime(hir_lt)) => {
-                let param = ctp::Parameter::from(ty_lt.to_early_bound_region_data());
+            (&ty::GenericParamDefKind::Lifetime(_), hir::GenericParam::Lifetime(hir_lt)) => {
+                let param = ctp::Parameter::from(ty_param.to_early_bound_region_data());
                 if lifetimes_in_associated_types.contains(&param) && // (*)
                     !input_parameters.contains(&param) {
                     report_unused_parameter(tcx, hir_lt.lifetime.span,
                                             "lifetime", &hir_lt.lifetime.name.name().to_string());
                 }
             }
-            (ty::GenericParamDef::Type(_), _) => continue,
-            (ty::GenericParamDef::Lifetime(_), _) => continue,
+            (&ty::GenericParamDefKind::Type(_), _) => continue,
+            (&ty::GenericParamDefKind::Lifetime(_), _) => continue,
         }
     }
 

--- a/src/librustc_typeck/impl_wf_check.rs
+++ b/src/librustc_typeck/impl_wf_check.rs
@@ -105,7 +105,7 @@ fn enforce_impl_params_are_constrained<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         tcx, &impl_predicates.predicates.as_slice(), impl_trait_ref, &mut input_parameters);
 
     // Disallow ANY unconstrained type parameters.
-    for (ty_param, param) in impl_generics.types().iter().zip(impl_hir_generics.ty_params()) {
+    for (ty_param, param) in impl_generics.types().zip(impl_hir_generics.ty_params()) {
         let param_ty = ty::ParamTy::for_def(ty_param);
         if !input_parameters.contains(&ctp::Parameter::from(param_ty)) {
             report_unused_parameter(tcx, param.span, "type", &param_ty.to_string());
@@ -114,7 +114,7 @@ fn enforce_impl_params_are_constrained<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
     // Disallow unconstrained lifetimes, but only if they appear in assoc types.
     let lifetimes_in_associated_types: FxHashSet<_> = impl_item_refs.iter()
-        .map(|item_ref|  tcx.hir.local_def_id(item_ref.id.node_id))
+        .map(|item_ref| tcx.hir.local_def_id(item_ref.id.node_id))
         .filter(|&def_id| {
             let item = tcx.associated_item(def_id);
             item.kind == ty::AssociatedKind::Type && item.defaultness.has_value()
@@ -122,15 +122,11 @@ fn enforce_impl_params_are_constrained<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         .flat_map(|def_id| {
             ctp::parameters_for(&tcx.type_of(def_id), true)
         }).collect();
-    for (ty_lifetime, lifetime) in impl_generics.lifetimes().iter()
-        .zip(impl_hir_generics.lifetimes())
-    {
+    for (ty_lifetime, lifetime) in impl_generics.lifetimes().zip(impl_hir_generics.lifetimes()) {
         let param = ctp::Parameter::from(ty_lifetime.to_early_bound_region_data());
 
-        if
-            lifetimes_in_associated_types.contains(&param) && // (*)
-            !input_parameters.contains(&param)
-        {
+        if lifetimes_in_associated_types.contains(&param) && // (*)
+            !input_parameters.contains(&param) {
             report_unused_parameter(tcx, lifetime.lifetime.span,
                                     "lifetime", &lifetime.lifetime.name.name().to_string());
         }

--- a/src/librustc_typeck/impl_wf_check.rs
+++ b/src/librustc_typeck/impl_wf_check.rs
@@ -72,7 +72,7 @@ struct ImplWfCheck<'a, 'tcx: 'a> {
 impl<'a, 'tcx> ItemLikeVisitor<'tcx> for ImplWfCheck<'a, 'tcx> {
     fn visit_item(&mut self, item: &'tcx hir::Item) {
         match item.node {
-            hir::ItemImpl(.., _, _, _, ref impl_item_refs) => {
+            hir::ItemImpl(.., ref impl_item_refs) => {
                 let impl_def_id = self.tcx.hir.local_def_id(item.id);
                 enforce_impl_params_are_constrained(self.tcx,
                                                     impl_def_id,

--- a/src/librustc_typeck/outlives/implicit_infer.rs
+++ b/src/librustc_typeck/outlives/implicit_infer.rs
@@ -353,7 +353,7 @@ fn insert_outlives_predicate<'tcx>(
                         // Vec<U>`.  Decomposing `Vec<U>` into
                         // components would yield `U`, and we add the
                         // where clause that `U: 'a`.
-                        let ty: Ty<'tcx> = tcx.mk_param(param_ty.idx, param_ty.name);
+                        let ty: Ty<'tcx> = tcx.mk_ty_param(param_ty.idx, param_ty.name);
                         required_predicates
                             .insert(ty::OutlivesPredicate(ty.into(), outlived_region));
                     }

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -229,7 +229,7 @@ impl<'a, 'tcx, 'rcx> AutoTraitFinder<'a, 'tcx, 'rcx> {
 
         for param in generics.params.iter() {
             match param.kind {
-                ty::GenericParamDefKind::Lifetime(_) => {
+                ty::GenericParamDefKind::Lifetime => {
                     let name = if param.name == "" {
                         hir::LifetimeName::Static
                     } else {

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -256,7 +256,7 @@ impl<'a, 'tcx, 'rcx> AutoTraitFinder<'a, 'tcx, 'rcx> {
         }
     }
 
-    fn ty_param_to_ty(&self, param: ty::TypeParameterDef) -> hir::Ty {
+    fn ty_param_to_ty(&self, param: ty::TypeParamDef) -> hir::Ty {
         debug!("ty_param_to_ty({:?}) {:?}", param, param.def_id);
         hir::Ty {
             id: ast::DUMMY_NODE_ID,

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -225,30 +225,28 @@ impl<'a, 'tcx, 'rcx> AutoTraitFinder<'a, 'tcx, 'rcx> {
 
     fn generics_to_path_params(&self, generics: ty::Generics) -> hir::PathParameters {
         let lifetimes = HirVec::from_vec(
-            generics
-                .regions
-                .iter()
-                .map(|p| {
-                    let name = if p.name == "" {
-                        hir::LifetimeName::Static
-                    } else {
-                        hir::LifetimeName::Name(p.name.as_symbol())
-                    };
+            generics.lifetimes()
+                    .iter()
+                    .map(|p| {
+                        let name = if p.name == "" {
+                            hir::LifetimeName::Static
+                        } else {
+                            hir::LifetimeName::Name(p.name.as_symbol())
+                        };
 
-                    hir::Lifetime {
-                        id: ast::DUMMY_NODE_ID,
-                        span: DUMMY_SP,
-                        name,
-                    }
-                })
-                .collect(),
+                        hir::Lifetime {
+                            id: ast::DUMMY_NODE_ID,
+                            span: DUMMY_SP,
+                            name,
+                        }
+                    })
+                    .collect(),
         );
         let types = HirVec::from_vec(
-            generics
-                .types
-                .iter()
-                .map(|p| P(self.ty_param_to_ty(p.clone())))
-                .collect(),
+            generics.types()
+                    .into_iter()
+                    .map(|p| P(self.ty_param_to_ty(p.clone())))
+                    .collect(),
         );
 
         hir::PathParameters {

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -224,33 +224,33 @@ impl<'a, 'tcx, 'rcx> AutoTraitFinder<'a, 'tcx, 'rcx> {
     }
 
     fn generics_to_path_params(&self, generics: ty::Generics) -> hir::PathParameters {
-        let lifetimes = HirVec::from_vec(
-            generics.lifetimes()
-                    .map(|p| {
-                        let name = if p.name == "" {
-                            hir::LifetimeName::Static
-                        } else {
-                            hir::LifetimeName::Name(p.name.as_symbol())
-                        };
+        let mut lifetimes = vec![];
+        let mut types = vec![];
 
-                        hir::Lifetime {
-                            id: ast::DUMMY_NODE_ID,
-                            span: DUMMY_SP,
-                            name,
-                        }
-                    })
-                    .collect(),
-        );
-        let types = HirVec::from_vec(
-            generics.types()
-                    .into_iter()
-                    .map(|p| P(self.ty_param_to_ty(p.clone())))
-                    .collect(),
-        );
+        for param in generics.params.iter() {
+            match param {
+                ty::GenericParamDef::Lifetime(lt) => {
+                    let name = if lt.name == "" {
+                        hir::LifetimeName::Static
+                    } else {
+                        hir::LifetimeName::Name(lt.name.as_symbol())
+                    };
+
+                    lifetimes.push(hir::Lifetime {
+                        id: ast::DUMMY_NODE_ID,
+                        span: DUMMY_SP,
+                        name,
+                    });
+                }
+                ty::GenericParamDef::Type(ty) => {
+                    types.push(P(self.ty_param_to_ty(ty.clone())));
+                }
+            }
+        }
 
         hir::PathParameters {
-            lifetimes: lifetimes,
-            types: types,
+            lifetimes: HirVec::from_vec(lifetimes),
+            types: HirVec::from_vec(types),
             bindings: HirVec::new(),
             parenthesized: false,
         }

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -228,12 +228,12 @@ impl<'a, 'tcx, 'rcx> AutoTraitFinder<'a, 'tcx, 'rcx> {
         let mut types = vec![];
 
         for param in generics.params.iter() {
-            match param {
-                ty::GenericParamDef::Lifetime(lt) => {
-                    let name = if lt.name == "" {
+            match param.kind {
+                ty::GenericParamDefKind::Lifetime(_) => {
+                    let name = if param.name == "" {
                         hir::LifetimeName::Static
                     } else {
-                        hir::LifetimeName::Name(lt.name.as_symbol())
+                        hir::LifetimeName::Name(param.name.as_symbol())
                     };
 
                     lifetimes.push(hir::Lifetime {
@@ -242,8 +242,8 @@ impl<'a, 'tcx, 'rcx> AutoTraitFinder<'a, 'tcx, 'rcx> {
                         name,
                     });
                 }
-                ty::GenericParamDef::Type(ty) => {
-                    types.push(P(self.ty_param_to_ty(ty.clone())));
+                ty::GenericParamDefKind::Type(_) => {
+                    types.push(P(self.ty_param_to_ty(param.clone())));
                 }
             }
         }
@@ -256,7 +256,7 @@ impl<'a, 'tcx, 'rcx> AutoTraitFinder<'a, 'tcx, 'rcx> {
         }
     }
 
-    fn ty_param_to_ty(&self, param: ty::TypeParamDef) -> hir::Ty {
+    fn ty_param_to_ty(&self, param: ty::GenericParamDef) -> hir::Ty {
         debug!("ty_param_to_ty({:?}) {:?}", param, param.def_id);
         hir::Ty {
             id: ast::DUMMY_NODE_ID,

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -491,7 +491,7 @@ impl<'a, 'tcx, 'rcx> AutoTraitFinder<'a, 'tcx, 'rcx> {
         &self,
         tcx: TyCtxt<'b, 'c, 'd>,
         pred: ty::Predicate<'d>,
-    ) -> FxHashSet<GenericParam> {
+    ) -> FxHashSet<GenericParamDef> {
         pred.walk_tys()
             .flat_map(|t| {
                 let mut regions = FxHashSet();
@@ -502,7 +502,7 @@ impl<'a, 'tcx, 'rcx> AutoTraitFinder<'a, 'tcx, 'rcx> {
                         // We only care about late bound regions, as we need to add them
                         // to the 'for<>' section
                         &ty::ReLateBound(_, ty::BoundRegion::BrNamed(_, name)) => {
-                            Some(GenericParam::Lifetime(Lifetime(name.to_string())))
+                            Some(GenericParamDef::Lifetime(Lifetime(name.to_string())))
                         }
                         &ty::ReVar(_) | &ty::ReEarlyBound(_) => None,
                         _ => panic!("Unexpected region type {:?}", r),
@@ -850,7 +850,7 @@ impl<'a, 'tcx, 'rcx> AutoTraitFinder<'a, 'tcx, 'rcx> {
 
         for p in generic_params.iter_mut() {
             match p {
-                &mut GenericParam::Type(ref mut ty) => {
+                &mut GenericParamDef::Type(ref mut ty) => {
                     // We never want something like 'impl<T=Foo>'
                     ty.default.take();
 

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -226,7 +226,6 @@ impl<'a, 'tcx, 'rcx> AutoTraitFinder<'a, 'tcx, 'rcx> {
     fn generics_to_path_params(&self, generics: ty::Generics) -> hir::PathParameters {
         let lifetimes = HirVec::from_vec(
             generics.lifetimes()
-                    .iter()
                     .map(|p| {
                         let name = if p.name == "" {
                             hir::LifetimeName::Static

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -860,7 +860,7 @@ impl<'a, 'tcx, 'rcx> AutoTraitFinder<'a, 'tcx, 'rcx> {
                         ty.bounds.insert(0, TyParamBound::maybe_sized(self.cx));
                     }
                 }
-                _ => {}
+                GenericParamDef::Lifetime(_) => {}
             }
         }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1800,7 +1800,7 @@ impl<'a, 'tcx> Clean<Generics> for (&'a ty::Generics,
         // Bounds in the type_params and lifetimes fields are repeated in the
         // predicates field (see rustc_typeck::collect::ty_generics), so remove
         // them.
-        let stripped_typarams = gens.types.iter().filter_map(|tp| {
+        let stripped_typarams = gens.types().iter().filter_map(|tp| {
             if tp.name == keywords::SelfType.name().as_str() {
                 assert_eq!(tp.index, 0);
                 None
@@ -1849,16 +1849,15 @@ impl<'a, 'tcx> Clean<Generics> for (&'a ty::Generics,
         // and instead see `where T: Foo + Bar + Sized + 'a`
 
         Generics {
-            params: gens.regions
-                .clean(cx)
-                .into_iter()
-                .map(|lp| GenericParam::Lifetime(lp))
-                .chain(
-                    simplify::ty_params(stripped_typarams)
+            params: gens.lifetimes()
                         .into_iter()
-                        .map(|tp| GenericParam::Type(tp))
-                )
-                .collect(),
+                        .map(|lp| GenericParam::Lifetime(lp.clean(cx)))
+                        .chain(
+                            simplify::ty_params(stripped_typarams)
+                                .into_iter()
+                                .map(|tp| GenericParam::Type(tp))
+                        )
+                        .collect(),
             where_predicates: simplify::where_clauses(cx, where_predicates),
         }
     }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1855,7 +1855,7 @@ impl<'a, 'tcx> Clean<Generics> for (&'a ty::Generics,
             params: gens.params
                         .iter()
                         .flat_map(|param| {
-                            if let ty::GenericParamDefKind::Lifetime(_) = param.kind {
+                            if let ty::GenericParamDefKind::Lifetime = param.kind {
                                 Some(GenericParamDef::Lifetime(param.clean(cx)))
                             } else {
                                 None

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1753,7 +1753,7 @@ impl Clean<Generics> for hir::Generics {
         let mut params = Vec::with_capacity(self.params.len());
         for p in &self.params {
             let p = p.clean(cx);
-            if let GenericParam::Type(ref tp) = p {
+            if let GenericParamDef::Type(ref tp) = p {
                 if tp.synthetic == Some(hir::SyntheticTyParamKind::ImplTrait) {
                     cx.impl_trait_bounds.borrow_mut().insert(tp.did, tp.bounds.clone());
                 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1339,11 +1339,15 @@ impl Clean<TyParam> for hir::TyParam {
 impl<'tcx> Clean<TyParam> for ty::GenericParamDef {
     fn clean(&self, cx: &DocContext) -> TyParam {
         cx.renderinfo.borrow_mut().external_typarams.insert(self.def_id, self.name.clean(cx));
+        let has_default = match self.kind {
+            ty::GenericParamDefKind::Type(ty) => ty.has_default,
+            _ => panic!("tried to convert a non-type GenericParamDef as a type")
+        };
         TyParam {
             name: self.name.clean(cx),
             did: self.def_id,
             bounds: vec![], // these are filled in from the where-clauses
-            default: if self.to_type().has_default {
+            default: if has_default {
                 Some(cx.tcx.type_of(self.def_id).clean(cx))
             } else {
                 None

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1800,12 +1800,16 @@ impl<'a, 'tcx> Clean<Generics> for (&'a ty::Generics,
         // Bounds in the type_params and lifetimes fields are repeated in the
         // predicates field (see rustc_typeck::collect::ty_generics), so remove
         // them.
-        let stripped_typarams = gens.types_depr().filter_map(|tp| {
-            if tp.name == keywords::SelfType.name().as_str() {
-                assert_eq!(tp.index, 0);
-                None
+        let stripped_typarams = gens.params.iter().filter_map(|param| {
+            if let ty::GenericParamDef::Type(ty) = param {
+                if ty.name == keywords::SelfType.name().as_str() {
+                    assert_eq!(ty.index, 0);
+                    None
+                } else {
+                    Some(ty.clean(cx))
+                }
             } else {
-                Some(tp.clean(cx))
+                None
             }
         }).collect::<Vec<_>>();
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1725,10 +1725,9 @@ pub enum GenericParamDef {
 
 impl GenericParamDef {
     pub fn is_synthetic_type_param(&self) -> bool {
-        if let GenericParamDef::Type(ref t) = *self {
-            t.synthetic.is_some()
-        } else {
-            false
+        match self {
+            GenericParamDef::Type(ty) => ty.synthetic.is_some(),
+            GenericParamDef::Lifetime(_) => false,
         }
     }
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1336,7 +1336,7 @@ impl Clean<TyParam> for hir::TyParam {
     }
 }
 
-impl<'tcx> Clean<TyParam> for ty::TypeParameterDef {
+impl<'tcx> Clean<TyParam> for ty::TypeParamDef {
     fn clean(&self, cx: &DocContext) -> TyParam {
         cx.renderinfo.borrow_mut().external_typarams.insert(self.def_id, self.name.clean(cx));
         TyParam {
@@ -1577,7 +1577,7 @@ impl Clean<Lifetime> for hir::LifetimeDef {
     }
 }
 
-impl Clean<Lifetime> for ty::RegionParameterDef {
+impl Clean<Lifetime> for ty::RegionParamDef {
     fn clean(&self, _: &DocContext) -> Lifetime {
         Lifetime(self.name.to_string())
     }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1800,7 +1800,7 @@ impl<'a, 'tcx> Clean<Generics> for (&'a ty::Generics,
         // Bounds in the type_params and lifetimes fields are repeated in the
         // predicates field (see rustc_typeck::collect::ty_generics), so remove
         // them.
-        let stripped_typarams = gens.types().iter().filter_map(|tp| {
+        let stripped_typarams = gens.types().filter_map(|tp| {
             if tp.name == keywords::SelfType.name().as_str() {
                 assert_eq!(tp.index, 0);
                 None

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1849,10 +1849,15 @@ impl<'a, 'tcx> Clean<Generics> for (&'a ty::Generics,
         // and instead see `where T: Foo + Bar + Sized + 'a`
 
         Generics {
-            params: gens.lifetimes_depr()
-                        .into_iter()
-                        .map(|lp| GenericParamDef::Lifetime(lp.clean(cx)))
-                        .chain(
+            params: gens.params
+                        .iter()
+                        .flat_map(|param| {
+                            if let ty::GenericParamDef::Lifetime(lt) = param {
+                                Some(GenericParamDef::Lifetime(lt.clean(cx)))
+                            } else {
+                                None
+                            }
+                        }).chain(
                             simplify::ty_params(stripped_typarams)
                                 .into_iter()
                                 .map(|tp| GenericParamDef::Type(tp))

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1800,7 +1800,7 @@ impl<'a, 'tcx> Clean<Generics> for (&'a ty::Generics,
         // Bounds in the type_params and lifetimes fields are repeated in the
         // predicates field (see rustc_typeck::collect::ty_generics), so remove
         // them.
-        let stripped_typarams = gens.types().filter_map(|tp| {
+        let stripped_typarams = gens.types_depr().filter_map(|tp| {
             if tp.name == keywords::SelfType.name().as_str() {
                 assert_eq!(tp.index, 0);
                 None
@@ -1849,7 +1849,7 @@ impl<'a, 'tcx> Clean<Generics> for (&'a ty::Generics,
         // and instead see `where T: Foo + Bar + Sized + 'a`
 
         Generics {
-            params: gens.lifetimes()
+            params: gens.lifetimes_depr()
                         .into_iter()
                         .map(|lp| GenericParamDef::Lifetime(lp.clean(cx)))
                         .chain(

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2687,7 +2687,7 @@ impl Clean<Type> for hir::Ty {
                         let mut indices = FxHashMap();
                         for param in generics.params.iter() {
                             match param {
-                                GenericParamDef::Type(ty_param) => {
+                                hir::GenericParam::Type(ty_param) => {
                                     let i = indices.entry(Kind::Type).or_insert(0);
                                     let ty_param_def =
                                         Def::TyParam(cx.tcx.hir.local_def_id(ty_param.id));
@@ -2699,7 +2699,7 @@ impl Clean<Type> for hir::Ty {
                                     }
                                     *i += 1;
                                 }
-                                GenericParamDef::Lifetime(lt_param) => {
+                                hir::GenericParam::Lifetime(lt_param) => {
                                     let i = indices.entry(Kind::Type).or_insert(0);
                                     if let Some(lt) = provided_params.lifetimes.get(*i).cloned() {
                                         if !lt.is_elided() {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1484,7 +1484,7 @@ impl<'a, 'tcx> Clean<TyParamBound> for (&'a ty::TraitRef<'tcx>, Vec<TypeBinding>
                         if let &ty::RegionKind::ReLateBound(..) = *reg {
                             debug!("  hit an ReLateBound {:?}", reg);
                             if let Some(lt) = reg.clean(cx) {
-                                late_bounds.push(GenericParam::Lifetime(lt));
+                                late_bounds.push(GenericParamDef::Lifetime(lt));
                             }
                         }
                     }
@@ -1718,14 +1718,14 @@ impl<'tcx> Clean<Type> for ty::ProjectionTy<'tcx> {
 }
 
 #[derive(Clone, RustcEncodable, RustcDecodable, PartialEq, Eq, Debug, Hash)]
-pub enum GenericParam {
+pub enum GenericParamDef {
     Lifetime(Lifetime),
     Type(TyParam),
 }
 
-impl GenericParam {
+impl GenericParamDef {
     pub fn is_synthetic_type_param(&self) -> bool {
-        if let GenericParam::Type(ref t) = *self {
+        if let GenericParamDef::Type(ref t) = *self {
             t.synthetic.is_some()
         } else {
             false
@@ -1733,11 +1733,11 @@ impl GenericParam {
     }
 }
 
-impl Clean<GenericParam> for hir::GenericParam {
-    fn clean(&self, cx: &DocContext) -> GenericParam {
+impl Clean<GenericParamDef> for hir::GenericParam {
+    fn clean(&self, cx: &DocContext) -> GenericParamDef {
         match *self {
-            hir::GenericParam::Lifetime(ref l) => GenericParam::Lifetime(l.clean(cx)),
-            hir::GenericParam::Type(ref t) => GenericParam::Type(t.clean(cx)),
+            hir::GenericParam::Lifetime(ref l) => GenericParamDef::Lifetime(l.clean(cx)),
+            hir::GenericParam::Type(ref t) => GenericParamDef::Type(t.clean(cx)),
         }
     }
 }
@@ -1745,7 +1745,7 @@ impl Clean<GenericParam> for hir::GenericParam {
 // maybe use a Generic enum and use Vec<Generic>?
 #[derive(Clone, RustcEncodable, RustcDecodable, PartialEq, Eq, Debug, Default, Hash)]
 pub struct Generics {
-    pub params: Vec<GenericParam>,
+    pub params: Vec<GenericParamDef>,
     pub where_predicates: Vec<WherePredicate>,
 }
 
@@ -1774,7 +1774,7 @@ impl Clean<Generics> for hir::Generics {
                 WherePredicate::BoundPredicate { ty: Generic(ref name), ref mut bounds } => {
                     if bounds.is_empty() {
                         for param in &mut g.params {
-                            if let GenericParam::Type(ref mut type_param) = *param {
+                            if let GenericParamDef::Type(ref mut type_param) = *param {
                                 if &type_param.name == name {
                                     mem::swap(bounds, &mut type_param.bounds);
                                     break
@@ -1851,11 +1851,11 @@ impl<'a, 'tcx> Clean<Generics> for (&'a ty::Generics,
         Generics {
             params: gens.lifetimes()
                         .into_iter()
-                        .map(|lp| GenericParam::Lifetime(lp.clean(cx)))
+                        .map(|lp| GenericParamDef::Lifetime(lp.clean(cx)))
                         .chain(
                             simplify::ty_params(stripped_typarams)
                                 .into_iter()
-                                .map(|tp| GenericParam::Type(tp))
+                                .map(|tp| GenericParamDef::Type(tp))
                         )
                         .collect(),
             where_predicates: simplify::where_clauses(cx, where_predicates),
@@ -2348,7 +2348,7 @@ impl<'tcx> Clean<Item> for ty::AssociatedItem {
 #[derive(Clone, RustcEncodable, RustcDecodable, PartialEq, Eq, Debug, Hash)]
 pub struct PolyTrait {
     pub trait_: Type,
-    pub generic_params: Vec<GenericParam>,
+    pub generic_params: Vec<GenericParamDef>,
 }
 
 /// A representation of a Type suitable for hyperlinking purposes. Ideally one can get the original
@@ -3413,7 +3413,7 @@ impl Clean<Item> for doctree::Typedef {
 #[derive(Clone, RustcEncodable, RustcDecodable, PartialEq, Eq, Debug, Hash)]
 pub struct BareFunctionDecl {
     pub unsafety: hir::Unsafety,
-    pub generic_params: Vec<GenericParam>,
+    pub generic_params: Vec<GenericParamDef>,
     pub decl: FnDecl,
     pub abi: Abi,
 }
@@ -4172,7 +4172,7 @@ struct RegionDeps<'tcx> {
 #[derive(Eq, PartialEq, Hash, Debug)]
 enum SimpleBound {
     RegionBound(Lifetime),
-    TraitBound(Vec<PathSegment>, Vec<SimpleBound>, Vec<GenericParam>, hir::TraitBoundModifier)
+    TraitBound(Vec<PathSegment>, Vec<SimpleBound>, Vec<GenericParamDef>, hir::TraitBoundModifier)
 }
 
 enum AutoTraitResult {

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -117,11 +117,11 @@ impl<'a> fmt::Display for TyParamBounds<'a> {
     }
 }
 
-impl fmt::Display for clean::GenericParam {
+impl fmt::Display for clean::GenericParamDef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            clean::GenericParam::Lifetime(ref lp) => write!(f, "{}", lp),
-            clean::GenericParam::Type(ref tp) => {
+            clean::GenericParamDef::Lifetime(ref lp) => write!(f, "{}", lp),
+            clean::GenericParamDef::Type(ref tp) => {
                 f.write_str(&tp.name)?;
 
                 if !tp.bounds.is_empty() {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1437,8 +1437,11 @@ impl DocFolder for Cache {
 impl<'a> Cache {
     fn generics(&mut self, generics: &clean::Generics) {
         for param in &generics.params {
-            if let clean::GenericParamDef::Type(ref typ) = *param {
-                self.typarams.insert(typ.did, typ.name.clone());
+            match *param {
+                clean::GenericParamDef::Type(ref typ) => {
+                    self.typarams.insert(typ.did, typ.name.clone());
+                }
+                clean::GenericParamDef::Lifetime(_) => {}
             }
         }
     }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1437,7 +1437,7 @@ impl DocFolder for Cache {
 impl<'a> Cache {
     fn generics(&mut self, generics: &clean::Generics) {
         for param in &generics.params {
-            if let clean::GenericParam::Type(ref typ) = *param {
+            if let clean::GenericParamDef::Type(ref typ) = *param {
                 self.typarams.insert(typ.did, typ.name.clone());
             }
         }

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -72,9 +72,7 @@ pub trait Visitor<'ast>: Sized {
     fn visit_expr(&mut self, ex: &'ast Expr) { walk_expr(self, ex) }
     fn visit_expr_post(&mut self, _ex: &'ast Expr) { }
     fn visit_ty(&mut self, t: &'ast Ty) { walk_ty(self, t) }
-    fn visit_generic_param(&mut self, param: &'ast GenericParam) {
-        walk_generic_param(self, param)
-    }
+    fn visit_generic_param(&mut self, param: &'ast GenericParam) { walk_generic_param(self, param) }
     fn visit_generics(&mut self, g: &'ast Generics) { walk_generics(self, g) }
     fn visit_where_predicate(&mut self, p: &'ast WherePredicate) {
         walk_where_predicate(self, p)

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -72,7 +72,9 @@ pub trait Visitor<'ast>: Sized {
     fn visit_expr(&mut self, ex: &'ast Expr) { walk_expr(self, ex) }
     fn visit_expr_post(&mut self, _ex: &'ast Expr) { }
     fn visit_ty(&mut self, t: &'ast Ty) { walk_ty(self, t) }
-    fn visit_generic_param(&mut self, param: &'ast GenericParam) { walk_generic_param(self, param) }
+    fn visit_generic_param(&mut self, param: &'ast GenericParam) {
+        walk_generic_param(self, param)
+    }
     fn visit_generics(&mut self, g: &'ast Generics) { walk_generics(self, g) }
     fn visit_where_predicate(&mut self, p: &'ast WherePredicate) {
         walk_where_predicate(self, p)

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -570,7 +570,11 @@ impl<'a> TraitDef<'a> {
                         bounds.push((*declared_bound).clone());
                     }
 
-                    GenericParam::Type(cx.typaram(self.span, ty_param.ident, vec![], bounds, None))
+                    GenericParam::Type(cx.typaram(self.span,
+                                                  ty_param.ident,
+                                                  vec![],
+                                                  bounds,
+                                                  None))
                 }
             }
         }));

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -570,11 +570,7 @@ impl<'a> TraitDef<'a> {
                         bounds.push((*declared_bound).clone());
                     }
 
-                    GenericParam::Type(cx.typaram(self.span,
-                                                  ty_param.ident,
-                                                  vec![],
-                                                  bounds,
-                                                  None))
+                    GenericParam::Type(cx.typaram(self.span, ty_param.ident, vec![], bounds, None))
                 }
             }
         }));

--- a/src/libsyntax_ext/deriving/generic/ty.rs
+++ b/src/libsyntax_ext/deriving/generic/ty.rs
@@ -187,9 +187,7 @@ impl<'a> Ty<'a> {
                 let self_params = self_generics.params
                     .iter()
                     .filter_map(|param| match *param {
-                        GenericParam::Type(ref ty_param) => {
-                            Some(cx.ty_ident(span, ty_param.ident))
-                        }
+                        GenericParam::Type(ref ty_param) => Some(cx.ty_ident(span, ty_param.ident)),
                         _ => None,
                     })
                     .collect();
@@ -272,10 +270,7 @@ impl<'a> LifetimeBounds<'a> {
                 let bounds = bounds.iter()
                     .map(|b| cx.lifetime(span, Ident::from_str(b)))
                     .collect();
-                GenericParam::Lifetime(cx.lifetime_def(span,
-                                       Ident::from_str(lt),
-                                       vec![],
-                                       bounds))
+                GenericParam::Lifetime(cx.lifetime_def(span, Ident::from_str(lt), vec![], bounds))
             })
             .chain(self.bounds
                 .iter()

--- a/src/libsyntax_ext/deriving/generic/ty.rs
+++ b/src/libsyntax_ext/deriving/generic/ty.rs
@@ -187,7 +187,9 @@ impl<'a> Ty<'a> {
                 let self_params = self_generics.params
                     .iter()
                     .filter_map(|param| match *param {
-                        GenericParam::Type(ref ty_param) => Some(cx.ty_ident(span, ty_param.ident)),
+                        GenericParam::Type(ref ty_param) => {
+                            Some(cx.ty_ident(span, ty_param.ident))
+                        }
                         _ => None,
                     })
                     .collect();
@@ -270,7 +272,10 @@ impl<'a> LifetimeBounds<'a> {
                 let bounds = bounds.iter()
                     .map(|b| cx.lifetime(span, Ident::from_str(b)))
                     .collect();
-                GenericParam::Lifetime(cx.lifetime_def(span, Ident::from_str(lt), vec![], bounds))
+                GenericParam::Lifetime(cx.lifetime_def(span,
+                                       Ident::from_str(lt),
+                                       vec![],
+                                       bounds))
             })
             .chain(self.bounds
                 .iter()

--- a/src/test/ui/on-unimplemented/bad-annotation.rs
+++ b/src/test/ui/on-unimplemented/bad-annotation.rs
@@ -28,7 +28,7 @@ trait BadAnnotation1
 {}
 
 #[rustc_on_unimplemented = "Unimplemented trait error on `{Self}` with params `<{A},{B},{C}>`"]
-//~^ ERROR there is no type parameter C on trait BadAnnotation2
+//~^ ERROR there is no parameter C on trait BadAnnotation2
 trait BadAnnotation2<A,B>
 {}
 

--- a/src/test/ui/on-unimplemented/bad-annotation.stderr
+++ b/src/test/ui/on-unimplemented/bad-annotation.stderr
@@ -6,7 +6,7 @@ LL | #[rustc_on_unimplemented] //~ ERROR `#[rustc_on_unimplemented]` requires a 
    |
    = note: eg `#[rustc_on_unimplemented = "foo"]`
 
-error[E0230]: there is no type parameter C on trait BadAnnotation2
+error[E0230]: there is no parameter C on trait BadAnnotation2
   --> $DIR/bad-annotation.rs:30:1
    |
 LL | #[rustc_on_unimplemented = "Unimplemented trait error on `{Self}` with params `<{A},{B},{C}>`"]


### PR DESCRIPTION
Part of the generic parameter refactoring effort, split off from https://github.com/rust-lang/rust/pull/48149. Contains the `ty`-relative refactoring.

r? @eddyb