### PR TITLE
in which parentheses are suggested for should-have-been-tuple-patterns

### DIFF
--- a/src/test/ui/did_you_mean/issue-48492-tuple-destructure-missing-parens.rs
+++ b/src/test/ui/did_you_mean/issue-48492-tuple-destructure-missing-parens.rs
@@ -1,0 +1,97 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(unused)]
+
+#[derive(Copy, Clone)]
+enum Nucleotide {
+    Adenine,
+    Thymine,
+    Cytosine,
+    Guanine
+}
+
+#[derive(Clone)]
+struct Autosome;
+
+#[derive(Clone)]
+enum Allosome {
+    X(Vec<Nucleotide>),
+    Y(Vec<Nucleotide>)
+}
+
+impl Allosome {
+    fn is_x(&self) -> bool {
+        match *self {
+            Allosome::X(_) => true,
+            Allosome::Y(_) => false,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct Genome {
+    autosomes: [Autosome; 22],
+    allosomes: (Allosome, Allosome)
+}
+
+fn find_start_codon(strand: &[Nucleotide]) -> Option<usize> {
+    let mut reading_frame = strand.windows(3);
+    // (missing parentheses in `while let` tuple pattern)
+    while let b1, b2, b3 = reading_frame.next().expect("there should be a start codon") {
+        //~^ ERROR unexpected `,` in pattern
+        // ...
+    }
+    None
+}
+
+fn find_thr(strand: &[Nucleotide]) -> Option<usize> {
+    let mut reading_frame = strand.windows(3);
+    let mut i = 0;
+    // (missing parentheses in `if let` tuple pattern)
+    if let b1, b2, b3 = reading_frame.next().unwrap() {
+        //~^ ERROR unexpected `,` in pattern
+        // ...
+    }
+    None
+}
+
+fn is_thr(codon: (Nucleotide, Nucleotide, Nucleotide)) -> bool {
+    match codon {
+        // (missing parentheses in match arm tuple pattern)
+        Nucleotide::Adenine, Nucleotide::Cytosine, _ => true
+        //~^ ERROR unexpected `,` in pattern
+        _ => false
+    }
+}
+
+fn analyze_female_sex_chromosomes(women: &[Genome]) {
+    // (missing parentheses in `for` tuple pattern)
+    for x, _barr_body in women.iter().map(|woman| woman.allosomes.clone()) {
+        //~^ ERROR unexpected `,` in pattern
+        // ...
+    }
+}
+
+fn analyze_male_sex_chromosomes(men: &[Genome]) {
+    // (missing parentheses in pattern with `@` binding)
+    for x, y @ Allosome::Y(_) in men.iter().map(|man| man.allosomes.clone()) {
+        //~^ ERROR unexpected `,` in pattern
+        // ...
+    }
+}
+
+fn main() {
+    let genomes = Vec::new();
+    // (missing parentheses in `let` pattern)
+    let women, men: (Vec<Genome>, Vec<Genome>) = genomes.iter().cloned()
+    //~^ ERROR unexpected `,` in pattern
+        .partition(|g: &Genome| g.allosomes.0.is_x() && g.allosomes.1.is_x());
+}

--- a/src/test/ui/did_you_mean/issue-48492-tuple-destructure-missing-parens.stderr
+++ b/src/test/ui/did_you_mean/issue-48492-tuple-destructure-missing-parens.stderr
@@ -1,0 +1,38 @@
+error: unexpected `,` in pattern
+  --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:48:17
+   |
+LL |     while let b1, b2, b3 = reading_frame.next().expect("there should be a start codon") {
+   |               --^------- help: try adding parentheses: `(b1, b2, b3)`
+
+error: unexpected `,` in pattern
+  --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:59:14
+   |
+LL |     if let b1, b2, b3 = reading_frame.next().unwrap() {
+   |            --^------- help: try adding parentheses: `(b1, b2, b3)`
+
+error: unexpected `,` in pattern
+  --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:69:28
+   |
+LL |         Nucleotide::Adenine, Nucleotide::Cytosine, _ => true
+   |         -------------------^------------------------ help: try adding parentheses: `(Nucleotide::Adenine, Nucleotide::Cytosine, _)`
+
+error: unexpected `,` in pattern
+  --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:77:10
+   |
+LL |     for x, _barr_body in women.iter().map(|woman| woman.allosomes.clone()) {
+   |         -^----------- help: try adding parentheses: `(x, _barr_body)`
+
+error: unexpected `,` in pattern
+  --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:85:10
+   |
+LL |     for x, y @ Allosome::Y(_) in men.iter().map(|man| man.allosomes.clone()) {
+   |         -^------------------- help: try adding parentheses: `(x, y @ Allosome::Y(_))`
+
+error: unexpected `,` in pattern
+  --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:94:14
+   |
+LL |     let women, men: (Vec<Genome>, Vec<Genome>) = genomes.iter().cloned()
+   |         -----^---- help: try adding parentheses: `(women, men)`
+
+error: aborting due to 6 previous errors
+


### PR DESCRIPTION
![destructure_suggest_parens](https://user-images.githubusercontent.com/1076988/36638335-48b082d4-19a7-11e8-9726-0d043544df2f.png)

Programmers used to working in some other languages (such as Python or
Go) might expect to be able to destructure values with comma-separated
identifiers but no parentheses on the left side of an assignment.

Previously, the first name in such code would get parsed as a
single-indentifier pattern—recognizing, for example, the
`let a` in `let a, b = (1, 2);`—whereupon we would have a fatal syntax
error on seeing an unexpected comma rather than the expected semicolon
(all the way nearer to the end of `parse_full_stmt`).

Instead, let's look for that comma when parsing the pattern, and if we
see it, make-believe that we're parsing the remaining elements in a
tuple pattern, so that we can suggest wrapping it all in parentheses. We
need to do this in a separate wrapper method called on a "top-level"
pattern, rather than within
`parse_pat` itself, because `parse_pat` gets called recursively to parse
the sub-patterns within a tuple pattern.

~~We could also do this for `match` arms, `if let`, and `while let`, but
we elect not to in this patch, as it seems less likely for users to make
the mistake in those contexts.~~

Resolves #48492.

r? @petrochenkov 