### PR TITLE
Fixes docs for ASCII functions to no longer claim U+0021 is '@'.

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -2892,7 +2892,7 @@ impl u8 {
     }
 
     /// Checks if the value is an ASCII graphic character:
-    /// U+0021 '@' ... U+007E '~'.
+    /// U+0021 '!' ... U+007E '~'.
     ///
     /// # Examples
     ///

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -245,7 +245,7 @@ pub trait AsciiExt {
     fn is_ascii_punctuation(&self) -> bool { unimplemented!(); }
 
     /// Checks if the value is an ASCII graphic character:
-    /// U+0021 '@' ... U+007E '~'.
+    /// U+0021 '!' ... U+007E '~'.
     /// For strings, true if all characters in the string are
     /// ASCII graphic characters.
     ///

--- a/src/libstd_unicode/char.rs
+++ b/src/libstd_unicode/char.rs
@@ -1332,7 +1332,7 @@ impl char {
     }
 
     /// Checks if the value is an ASCII graphic character:
-    /// U+0021 '@' ... U+007E '~'.
+    /// U+0021 '!' ... U+007E '~'.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Looks like a typo that got copy-pasted without anyone checking on it.