### PR TITLE
Ensure main() always has external linkage

### DIFF
--- a/src/librustc_mir/monomorphize/item.rs
+++ b/src/librustc_mir/monomorphize/item.rs
@@ -118,10 +118,13 @@ pub trait MonoItemExt<'a, 'tcx>: fmt::Debug {
 
         match *self.as_mono_item() {
             MonoItem::Fn(ref instance) => {
+                let entry_def_id =
+                    tcx.sess.entry_fn.borrow().map(|(id, _)| tcx.hir.local_def_id(id));
                 // If this function isn't inlined or otherwise has explicit
                 // linkage, then we'll be creating a globally shared version.
                 if self.explicit_linkage(tcx).is_some() ||
-                    !instance.def.requires_local(tcx)
+                    !instance.def.requires_local(tcx) ||
+                    Some(instance.def_id()) == entry_def_id
                 {
                     return InstantiationMode::GloballyShared  { may_conflict: false }
                 }

--- a/src/test/run-pass/inlined-main.rs
+++ b/src/test/run-pass/inlined-main.rs
@@ -1,0 +1,12 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[inline(always)]
+fn main() {}


### PR DESCRIPTION
This ensures that the entry function is never elided due to inlining, even with `inline(always)`. Fixes #47783.

There were a couple of possible ways of addressing this issue; I simply picked the one that seemed most direct. A warning could be appropriate, but considering using inlining hints in other places it doesn't apply also throws no warnings, and it seems like an edge case anyway, I haven't added one for now.