### PR TITLE
Fix error-format to properly send JSON to stdout

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -1007,6 +1007,10 @@ pub fn run_cargo(build: &Build, cargo: &mut Command, stamp: &Path, is_check: boo
             continue
         };
         if json["reason"].as_str() != Some("compiler-artifact") {
+            if build.config.rustc_error_format.as_ref().map_or(false, |e| e == "json") {
+                // most likely not a cargo message, so let's send it out as well
+                println!("{}", line);
+            }
             continue
         }
         for filename in json["filenames"].as_array().unwrap() {

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -119,7 +119,7 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`");
         opts.optopt("", "src", "path to the root of the rust checkout", "DIR");
         opts.optopt("j", "jobs", "number of jobs to run in parallel", "JOBS");
         opts.optflag("h", "help", "print this help message");
-        opts.optflag("", "error-format", "rustc error format");
+        opts.optopt("", "error-format", "rustc error format", "FORMAT");
 
         // fn usage()
         let usage = |exit_code: i32, opts: &Options, subcommand_help: &str, extra_help: &str| -> ! {


### PR DESCRIPTION
Since we take Cargo's JSON messages as well we need to specifically send
rustc's messages out so we don't hide them.

r? @Manishearth