### PR TITLE
Fix FreeBSD struct returning ABI.

### DIFF
--- a/src/librustc_back/target/apple_base.rs
+++ b/src/librustc_back/target/apple_base.rs
@@ -46,6 +46,7 @@ pub fn opts() -> TargetOptions {
         pre_link_args: LinkArgs::new(),
         exe_allocation_crate: super::maybe_jemalloc(),
         has_elf_tls: version >= (10, 7),
+        abi_return_struct_as_int: true,
         .. Default::default()
     }
 }

--- a/src/librustc_back/target/freebsd_base.rs
+++ b/src/librustc_back/target/freebsd_base.rs
@@ -36,6 +36,7 @@ pub fn opts() -> TargetOptions {
         eliminate_frame_pointer: false, // FIXME 43575
         relro_level: RelroLevel::Full,
         exe_allocation_crate: super::maybe_jemalloc(),
+        abi_return_struct_as_int: true,
         .. Default::default()
     }
 }

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -343,9 +343,8 @@ pub struct TargetOptions {
     pub staticlib_suffix: String,
     /// OS family to use for conditional compilation. Valid options: "unix", "windows".
     pub target_family: Option<String>,
-    /// Whether the target toolchain is like OpenBSD's.
-    /// Only useful for compiling against OpenBSD, for configuring abi when returning a struct.
-    pub is_like_openbsd: bool,
+    /// Whether the target toolchain's ABI supports returning small structs as an integer.
+    pub abi_return_struct_as_int: bool,
     /// Whether the target toolchain is like macOS's. Only useful for compiling against iOS/macOS,
     /// in particular running dsymutil and some other stuff like `-dead_strip`. Defaults to false.
     pub is_like_osx: bool,
@@ -501,7 +500,7 @@ impl Default for TargetOptions {
             staticlib_prefix: "lib".to_string(),
             staticlib_suffix: ".a".to_string(),
             target_family: None,
-            is_like_openbsd: false,
+            abi_return_struct_as_int: false,
             is_like_osx: false,
             is_like_solaris: false,
             is_like_windows: false,
@@ -756,7 +755,7 @@ impl Target {
         key!(staticlib_prefix);
         key!(staticlib_suffix);
         key!(target_family, optional);
-        key!(is_like_openbsd, bool);
+        key!(abi_return_struct_as_int, bool);
         key!(is_like_osx, bool);
         key!(is_like_solaris, bool);
         key!(is_like_windows, bool);
@@ -954,7 +953,7 @@ impl ToJson for Target {
         target_option_val!(staticlib_prefix);
         target_option_val!(staticlib_suffix);
         target_option_val!(target_family);
-        target_option_val!(is_like_openbsd);
+        target_option_val!(abi_return_struct_as_int);
         target_option_val!(is_like_osx);
         target_option_val!(is_like_solaris);
         target_option_val!(is_like_windows);

--- a/src/librustc_back/target/openbsd_base.rs
+++ b/src/librustc_back/target/openbsd_base.rs
@@ -31,7 +31,7 @@ pub fn opts() -> TargetOptions {
         target_family: Some("unix".to_string()),
         linker_is_gnu: true,
         has_rpath: true,
-        is_like_openbsd: true,
+        abi_return_struct_as_int: true,
         pre_link_args: args,
         position_independent_executables: true,
         eliminate_frame_pointer: false, // FIXME 43575

--- a/src/librustc_back/target/windows_base.rs
+++ b/src/librustc_back/target/windows_base.rs
@@ -101,6 +101,7 @@ pub fn opts() -> TargetOptions {
             "rsend.o".to_string()
         ],
         custom_unwind_resume: true,
+        abi_return_struct_as_int: true,
 
         .. Default::default()
     }

--- a/src/librustc_back/target/windows_msvc_base.rs
+++ b/src/librustc_back/target/windows_msvc_base.rs
@@ -34,6 +34,7 @@ pub fn opts() -> TargetOptions {
         pre_link_args: args,
         crt_static_allows_dylibs: true,
         crt_static_respected: true,
+        abi_return_struct_as_int: true,
 
         .. Default::default()
     }

--- a/src/librustc_trans/cabi_x86.rs
+++ b/src/librustc_trans/cabi_x86.rs
@@ -52,8 +52,7 @@ pub fn compute_abi_info<'a, 'tcx>(cx: &CodegenCx<'a, 'tcx>,
             // http://www.angelcode.com/dev/callconv/callconv.html
             // Clang's ABI handling is in lib/CodeGen/TargetInfo.cpp
             let t = &cx.sess().target.target;
-            if t.options.is_like_osx || t.options.is_like_windows
-                || t.options.is_like_openbsd {
+            if t.options.abi_return_struct_as_int {
                 // According to Clang, everyone but MSVC returns single-element
                 // float aggregates directly in a floating-point register.
                 if !t.options.is_like_msvc && is_single_fp_element(cx, fty.ret.layout) {


### PR DESCRIPTION
FreeBSD has had a patch similar to this for a while. See https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=223047.

This reworks 6774e7a to be more specific about what `compute_abi_info` is checking for per target.