### PR TITLE
rustc: Rename `bmi` feature to `bmi1`

### DIFF
--- a/src/librustc_trans/llvm_util.rs
+++ b/src/librustc_trans/llvm_util.rs
@@ -87,7 +87,7 @@ const X86_WHITELIST: &'static [&'static str] = &["aes", "avx", "avx2", "avx512bw
                                                  "avx512cd", "avx512dq", "avx512er",
                                                  "avx512f", "avx512ifma", "avx512pf",
                                                  "avx512vbmi", "avx512vl", "avx512vpopcntdq",
-                                                 "bmi", "bmi2", "fma", "fxsr",
+                                                 "bmi1", "bmi2", "fma", "fxsr",
                                                  "lzcnt", "mmx", "pclmulqdq",
                                                  "popcnt", "rdrand", "rdseed",
                                                  "sse", "sse2", "sse3", "sse4.1",
@@ -108,6 +108,7 @@ pub fn to_llvm_feature(s: &str) -> &str {
     match s {
         "pclmulqdq" => "pclmul",
         "rdrand" => "rdrnd",
+        "bmi1" => "bmi",
         s => s,
     }
 }


### PR DESCRIPTION
This is what [Intel calls it][bmi1] and will [remove a special case][stdsimd]
when verifying intrinsics in stdsimd.

[bmi1]: https://software.intel.com/sites/landingpage/IntrinsicsGuide/#othertechs=BMI1
[stdsimd]: https://github.com/rust-lang-nursery/stdsimd/blob/bed25b2a9f3b28e6ea80de6d87842f739a2e2d58/crates/stdsimd-verify/tests/x86-intel.rs#L252-L258