### PR TITLE
rustc_driver: get rid of the extra thread

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1480,9 +1480,9 @@ pub fn in_rustc_thread<F, R>(f: F) -> Result<R, Box<Any + Send>>
             rlim.rlim_cur = STACK_SIZE as libc::rlim_t;
             if libc::setrlimit(libc::RLIMIT_STACK, &mut rlim) != 0 {
                 let err = io::Error::last_os_error();
-                // We have already deinited the stack. Further corruption is
-                // not allowed.
-                panic!("in_rustc_thread: error calling setrlimit: {}", err);
+                error!("in_rustc_thread: error calling setrlimit: {}", err);
+                std::rt::update_stack_guard();
+                true
             } else {
                 std::rt::update_stack_guard();
                 false

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1488,7 +1488,11 @@ pub fn in_rustc_thread<F, R>(f: F) -> Result<R, Box<Any + Send>>
         }
     };
 
-    #[cfg(not(unix))]
+    // We set the stack size at link time. See src/rustc/rustc.rs.
+    #[cfg(windows)]
+    let spawn_thread = false;
+
+    #[cfg(not(any(windows,unix)))]
     let spawn_thread = true;
 
     // The or condition is added from backward compatibility.

--- a/src/libstd/rt.rs
+++ b/src/libstd/rt.rs
@@ -73,3 +73,18 @@ fn lang_start<T: ::process::Termination + 'static>
 {
     lang_start_internal(&move || main().report(), argc, argv)
 }
+
+/// Function used for reverting changes to the main stack before setrlimit().
+/// This is POSIX (non-Linux) specific and unlikely to be directly stabilized.
+#[unstable(feature = "rustc_stack_internals", issue = "0")]
+pub unsafe fn deinit_stack_guard() {
+    ::sys::thread::guard::deinit();
+}
+
+/// Function used for resetting the main stack guard address after setrlimit().
+/// This is POSIX specific and unlikely to be directly stabilized.
+#[unstable(feature = "rustc_stack_internals", issue = "0")]
+pub unsafe fn update_stack_guard() {
+    let main_guard = ::sys::thread::guard::init();
+    ::sys_common::thread_info::reset_guard(main_guard);
+}

--- a/src/libstd/sys/cloudabi/thread.rs
+++ b/src/libstd/sys/cloudabi/thread.rs
@@ -118,6 +118,7 @@ pub mod guard {
     pub unsafe fn init() -> Option<Guard> {
         None
     }
+    pub unsafe fn deinit() {}
 }
 
 fn min_stack_size(_: *const libc::pthread_attr_t) -> usize {

--- a/src/libstd/sys/redox/thread.rs
+++ b/src/libstd/sys/redox/thread.rs
@@ -91,4 +91,5 @@ pub mod guard {
     pub type Guard = !;
     pub unsafe fn current() -> Option<Guard> { None }
     pub unsafe fn init() -> Option<Guard> { None }
+    pub unsafe fn deinit() {}
 }

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -223,7 +223,7 @@ pub mod guard {
 #[cfg_attr(test, allow(dead_code))]
 pub mod guard {
     use libc;
-    use libc::mmap;
+    use libc::{mmap, mprotect};
     use libc::{PROT_NONE, PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANON, MAP_FAILED, MAP_FIXED};
     use ops::Range;
     use sys::os;

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -355,10 +355,9 @@ pub mod guard {
                 // macOS. Instead, just restore the page to a writable state.
                 // This ain't Linux, so we probably don't need to care about
                 // execstack.
-                let result = mmap(stackaddr, PAGE_SIZE, PROT_READ | PROT_WRITE,
-                                  MAP_PRIVATE | MAP_ANON | MAP_FIXED, -1, 0);
+                let result = mprotect(stackaddr, PAGE_SIZE, PROT_READ | PROT_WRITE);
 
-                if result != stackaddr || result == MAP_FAILED {
+                if result != 0 {
                     panic!("unable to reset the guard page");
                 }
             }

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -209,6 +209,7 @@ pub mod guard {
     pub type Guard = Range<usize>;
     pub unsafe fn current() -> Option<Guard> { None }
     pub unsafe fn init() -> Option<Guard> { None }
+    pub unsafe fn deinit() {}
 }
 
 

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -284,10 +284,10 @@ pub mod guard {
         ret
     }
 
-    pub unsafe fn init() -> Option<Guard> {
-        PAGE_SIZE = os::page_size();
-
-        let mut stackaddr = get_stack_start()?;
+    // Precondition: PAGE_SIZE is initialized.
+    unsafe fn get_stack_start_aligned() -> Option<*mut libc::c_void> {
+        assert!(PAGE_SIZE != 0);
+        let stackaddr = get_stack_start()?;
 
         // Ensure stackaddr is page aligned! A parent process might
         // have reset RLIMIT_STACK to be non-page aligned. The
@@ -296,10 +296,17 @@ pub mod guard {
         // page-aligned, calculate the fix such that stackaddr <
         // new_page_aligned_stackaddr < stackaddr + stacksize
         let remainder = (stackaddr as usize) % PAGE_SIZE;
-        if remainder != 0 {
-            stackaddr = ((stackaddr as usize) + PAGE_SIZE - remainder)
-                as *mut libc::c_void;
-        }
+        Some(if remainder == 0 {
+            stackaddr
+        } else {
+            ((stackaddr as usize) + PAGE_SIZE - remainder) as *mut libc::c_void
+        })
+    }
+
+    pub unsafe fn init() -> Option<Guard> {
+        PAGE_SIZE = os::page_size();
+
+        let stackaddr = get_stack_start_aligned()?;
 
         if cfg!(target_os = "linux") {
             // Linux doesn't allocate the whole stack right away, and
@@ -338,14 +345,7 @@ pub mod guard {
 
     pub unsafe fn deinit() {
         if !cfg!(target_os = "linux") {
-            if let Some(mut stackaddr) = get_stack_start() {
-                // Ensure address is aligned. Same as above.
-                let remainder = (stackaddr as usize) % PAGE_SIZE;
-                if remainder != 0 {
-                    stackaddr = ((stackaddr as usize) + PAGE_SIZE - remainder)
-                        as *mut libc::c_void;
-                }
-
+            if let Some(stackaddr) = get_stack_start_aligned() {
                 // Undo the guard page mapping.
                 if munmap(stackaddr, PAGE_SIZE) != 0 {
                     panic!("unable to deallocate the guard page");

--- a/src/libstd/sys/wasm/thread.rs
+++ b/src/libstd/sys/wasm/thread.rs
@@ -46,4 +46,5 @@ pub mod guard {
     pub type Guard = !;
     pub unsafe fn current() -> Option<Guard> { None }
     pub unsafe fn init() -> Option<Guard> { None }
+    pub unsafe fn deinit() {}
 }

--- a/src/libstd/sys/windows/thread.rs
+++ b/src/libstd/sys/windows/thread.rs
@@ -96,4 +96,5 @@ pub mod guard {
     pub type Guard = !;
     pub unsafe fn current() -> Option<Guard> { None }
     pub unsafe fn init() -> Option<Guard> { None }
+    pub unsafe fn deinit() {}
 }

--- a/src/libstd/sys_common/thread_info.rs
+++ b/src/libstd/sys_common/thread_info.rs
@@ -50,3 +50,7 @@ pub fn set(stack_guard: Option<Guard>, thread: Thread) {
         thread,
     }));
 }
+
+pub fn reset_guard(stack_guard: Option<Guard>) {
+    THREAD_INFO.with(move |c| c.borrow_mut().as_mut().unwrap().stack_guard = stack_guard);
+}

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -208,6 +208,14 @@ pub use self::local::{LocalKey, AccessError};
 #[unstable(feature = "libstd_thread_internals", issue = "0")]
 #[doc(hidden)] pub use self::local::os::Key as __OsLocalKeyInner;
 
+/// Function used for resetting the main stack guard address after setrlimit().
+/// This is POSIX specific and unlikely to be directly stabilized.
+#[unstable(feature = "rustc_stack_internals", issue = "0")]
+pub unsafe fn update_stack_guard() {
+    let main_guard = imp::guard::init();
+    thread_info::reset_guard(main_guard);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Builder
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -208,14 +208,6 @@ pub use self::local::{LocalKey, AccessError};
 #[unstable(feature = "libstd_thread_internals", issue = "0")]
 #[doc(hidden)] pub use self::local::os::Key as __OsLocalKeyInner;
 
-/// Function used for resetting the main stack guard address after setrlimit().
-/// This is POSIX specific and unlikely to be directly stabilized.
-#[unstable(feature = "rustc_stack_internals", issue = "0")]
-pub unsafe fn update_stack_guard() {
-    let main_guard = imp::guard::init();
-    thread_info::reset_guard(main_guard);
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // Builder
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/rustc/rustc.rs
+++ b/src/rustc/rustc.rs
@@ -17,6 +17,7 @@
 // We only build for msvc and gnu now, but we use a exhaustive condition here
 // so we can expect either the stack size to be set or the build fails.
 #[cfg_attr(all(windows, not(target_env = "msvc")), link_args = "-Wl,--stack,16777216")]
+// Also, don't forget to set this for rustdoc.
 extern {}
 
 extern crate rustc_driver;

--- a/src/rustc/rustc.rs
+++ b/src/rustc/rustc.rs
@@ -9,6 +9,15 @@
 // except according to those terms.
 
 #![feature(rustc_private)]
+#![feature(link_args)]
+
+// Set the stack size at link time on Windows. See rustc_driver::in_rustc_thread
+// for the rationale.
+#[cfg_attr(all(windows, target_env = "msvc"), link_args = "/STACK:16777216")]
+// We only build for msvc and gnu now, but we use a exhaustive condition here
+// so we can expect either the stack size to be set or the build fails.
+#[cfg_attr(all(windows, not(target_env = "msvc")), link_args = "-Wl,--stack,16777216")]
+extern {}
 
 extern crate rustc_driver;
 

--- a/src/tools/rustdoc/main.rs
+++ b/src/tools/rustdoc/main.rs
@@ -8,6 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(link_args)]
+// Set the stack size at link time on Windows. See rustc_driver::in_rustc_thread
+// for the rationale.
+#[cfg_attr(all(windows, target_env = "msvc"), link_args = "/STACK:16777216")]
+// We only build for msvc and gnu now, but we use a exhaustive condition here
+// so we can expect either the stack size to be set or the build fails.
+#[cfg_attr(all(windows, not(target_env = "msvc")), link_args = "-Wl,--stack,16777216")]
+// See src/rustc/rustc.rs for the corresponding rustc settings.
+extern {}
+
 extern crate rustdoc;
 
 fn main() { rustdoc::main() }


### PR DESCRIPTION
**Do not rollup**

We can alter the stack size afterwards on Unix.

Having a separate thread causes poor debugging experience when interrupting with signals. I have to get the backtrace of the all thread, as the main thread is waiting to join doing nothing else. This patch allows me to just run `bt` to get the desired backtrace.