### PR TITLE
Backport LLVM fixes for a JumpThreading / assume intrinsic bug

### DIFF
--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1246,18 +1246,15 @@ macro_rules! iterator {
             {
                 // The addition might panic on overflow
                 // Use the len of the slice to hint optimizer to remove result index bounds check.
-                let _n = make_slice!(self.ptr, self.end).len();
+                let n = make_slice!(self.ptr, self.end).len();
                 self.try_fold(0, move |i, x| {
                     if predicate(x) { Err(i) }
                     else { Ok(i + 1) }
                 }).err()
-                    // // FIXME(#48116/#45964):
-                    // // This assume() causes misoptimization on LLVM 6.
-                    // // Commented out until it is fixed again.
-                    // .map(|i| {
-                    //     unsafe { assume(i < n) };
-                    //     i
-                    // })
+                    .map(|i| {
+                        unsafe { assume(i < n) };
+                        i
+                    })
             }
 
             #[inline]
@@ -1274,13 +1271,10 @@ macro_rules! iterator {
                     if predicate(x) { Err(i) }
                     else { Ok(i) }
                 }).err()
-                    // // FIXME(#48116/#45964):
-                    // // This assume() causes misoptimization on LLVM 6.
-                    // // Commented out until it is fixed again.
-                    // .map(|i| {
-                    //     unsafe { assume(i < n) };
-                    //     i
-                    // })
+                    .map(|i| {
+                        unsafe { assume(i < n) };
+                        i
+                    })
             }
         }
 


### PR DESCRIPTION
This fixes the original cause of #48116 and restores the assume intrinsic that was removed as a workaround.

r? @alexcrichton 