### PR TITLE
Remove ONLY_BUILD and ONLY_BUILD_TARGETS

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -95,7 +95,7 @@ fn main() {
     let rustc = env::var_os(rustc).unwrap_or_else(|| panic!("{:?} was not set", rustc));
     let libdir = env::var_os(libdir).unwrap_or_else(|| panic!("{:?} was not set", libdir));
     let mut dylib_path = bootstrap::util::dylib_path();
-    dylib_path.insert(0, PathBuf::from(libdir));
+    dylib_path.insert(0, PathBuf::from(&libdir));
 
     let mut cmd = Command::new(rustc);
     cmd.args(&args)
@@ -107,7 +107,7 @@ fn main() {
     if let Some(target) = target {
         // The stage0 compiler has a special sysroot distinct from what we
         // actually downloaded, so we just always pass the `--sysroot` option.
-        cmd.arg("--sysroot").arg(sysroot);
+        cmd.arg("--sysroot").arg(&sysroot);
 
         // When we build Rust dylibs they're all intended for intermediate
         // usage, so make sure we pass the -Cprefer-dynamic flag instead of
@@ -280,6 +280,8 @@ fn main() {
 
     if verbose > 1 {
         eprintln!("rustc command: {:?}", cmd);
+        eprintln!("sysroot: {:?}", sysroot);
+        eprintln!("libdir: {:?}", libdir);
     }
 
     // Actually run the compiler!

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -60,9 +60,6 @@ pub trait Step: 'static + Clone + Debug + PartialEq + Eq + Hash {
     /// Run this rule for all hosts without cross compiling.
     const ONLY_HOSTS: bool = false;
 
-    /// Only run this step with the build triple as host and target.
-    const ONLY_BUILD: bool = false;
-
     /// Primary function to execute this rule. Can call `builder.ensure(...)`
     /// with other steps to run those.
     fn run(self, builder: &Builder) -> Self::Output;
@@ -98,7 +95,6 @@ pub struct RunConfig<'a> {
 struct StepDescription {
     default: bool,
     only_hosts: bool,
-    only_build: bool,
     should_run: fn(ShouldRun) -> ShouldRun,
     make_run: fn(RunConfig),
     name: &'static str,
@@ -134,7 +130,6 @@ impl StepDescription {
         StepDescription {
             default: S::DEFAULT,
             only_hosts: S::ONLY_HOSTS,
-            only_build: S::ONLY_BUILD,
             should_run: S::should_run,
             make_run: S::make_run,
             name: unsafe { ::std::intrinsics::type_name::<S>() },
@@ -150,18 +145,12 @@ impl StepDescription {
                 self.name, builder.config.exclude);
         }
         let build = builder.build;
-        let hosts = if self.only_build {
-            build.build_triple()
-        } else {
-            &build.hosts
-        };
+        let hosts = &build.hosts;
 
         // Determine the targets participating in this rule.
         let targets = if self.only_hosts {
             if build.config.run_host_only {
                 &[]
-            } else if self.only_build {
-                build.build_triple()
             } else {
                 &build.hosts
             }

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -149,8 +149,8 @@ impl StepDescription {
 
         // Determine the targets participating in this rule.
         let targets = if self.only_hosts {
-            if build.config.run_host_only {
-                &[]
+            if !build.config.run_host_only {
+                return; // don't run anything
             } else {
                 &build.hosts
             }

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -60,9 +60,6 @@ pub trait Step: 'static + Clone + Debug + PartialEq + Eq + Hash {
     /// Run this rule for all hosts without cross compiling.
     const ONLY_HOSTS: bool = false;
 
-    /// Run this rule for all targets, but only with the native host.
-    const ONLY_BUILD_TARGETS: bool = false;
-
     /// Only run this step with the build triple as host and target.
     const ONLY_BUILD: bool = false;
 
@@ -101,7 +98,6 @@ pub struct RunConfig<'a> {
 struct StepDescription {
     default: bool,
     only_hosts: bool,
-    only_build_targets: bool,
     only_build: bool,
     should_run: fn(ShouldRun) -> ShouldRun,
     make_run: fn(RunConfig),
@@ -138,7 +134,6 @@ impl StepDescription {
         StepDescription {
             default: S::DEFAULT,
             only_hosts: S::ONLY_HOSTS,
-            only_build_targets: S::ONLY_BUILD_TARGETS,
             only_build: S::ONLY_BUILD,
             should_run: S::should_run,
             make_run: S::make_run,
@@ -155,7 +150,7 @@ impl StepDescription {
                 self.name, builder.config.exclude);
         }
         let build = builder.build;
-        let hosts = if self.only_build_targets || self.only_build {
+        let hosts = if self.only_build {
             build.build_triple()
         } else {
             &build.hosts

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -347,7 +347,7 @@ impl Config {
         config.keep_stage = flags.keep_stage;
 
         // If --target was specified but --host wasn't specified, don't run any host-only tests.
-        config.run_host_only = flags.host.is_empty() && !flags.target.is_empty();
+        config.run_host_only = !(flags.host.is_empty() && !flags.target.is_empty());
 
         let toml = file.map(|file| {
             let mut f = t!(File::open(&file));

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -70,7 +70,6 @@ pub struct Docs {
 impl Step for Docs {
     type Output = PathBuf;
     const DEFAULT: bool = true;
-    const ONLY_BUILD_TARGETS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         run.path("src/doc")
@@ -271,7 +270,6 @@ pub struct Mingw {
 impl Step for Mingw {
     type Output = Option<PathBuf>;
     const DEFAULT: bool = true;
-    const ONLY_BUILD_TARGETS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         run.never()
@@ -331,7 +329,6 @@ impl Step for Rustc {
     type Output = PathBuf;
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
-    const ONLY_BUILD_TARGETS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         run.path("src/librustc")
@@ -561,7 +558,6 @@ pub struct Std {
 impl Step for Std {
     type Output = PathBuf;
     const DEFAULT: bool = true;
-    const ONLY_BUILD_TARGETS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         run.path("src/libstd")
@@ -569,7 +565,7 @@ impl Step for Std {
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(Std {
-            compiler: run.builder.compiler(run.builder.top_stage, run.host),
+            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.build),
             target: run.target,
         });
     }
@@ -638,7 +634,6 @@ pub struct Analysis {
 impl Step for Analysis {
     type Output = PathBuf;
     const DEFAULT: bool = true;
-    const ONLY_BUILD_TARGETS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
@@ -647,7 +642,7 @@ impl Step for Analysis {
 
     fn make_run(run: RunConfig) {
         run.builder.ensure(Analysis {
-            compiler: run.builder.compiler(run.builder.top_stage, run.host),
+            compiler: run.builder.compiler(run.builder.top_stage, run.builder.build.build),
             target: run.target,
         });
     }
@@ -755,8 +750,6 @@ impl Step for Src {
     type Output = PathBuf;
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
-    const ONLY_BUILD_TARGETS: bool = true;
-    const ONLY_BUILD: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         run.path("src")
@@ -851,8 +844,6 @@ impl Step for PlainSourceTarball {
     type Output = PathBuf;
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
-    const ONLY_BUILD_TARGETS: bool = true;
-    const ONLY_BUILD: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
@@ -1007,7 +998,6 @@ pub struct Cargo {
 
 impl Step for Cargo {
     type Output = PathBuf;
-    const ONLY_BUILD_TARGETS: bool = true;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
@@ -1095,7 +1085,6 @@ pub struct Rls {
 
 impl Step for Rls {
     type Output = Option<PathBuf>;
-    const ONLY_BUILD_TARGETS: bool = true;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
@@ -1177,7 +1166,6 @@ pub struct Rustfmt {
 
 impl Step for Rustfmt {
     type Output = Option<PathBuf>;
-    const ONLY_BUILD_TARGETS: bool = true;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
@@ -1263,7 +1251,6 @@ pub struct Extended {
 impl Step for Extended {
     type Output = ();
     const DEFAULT: bool = true;
-    const ONLY_BUILD_TARGETS: bool = true;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
@@ -1274,7 +1261,7 @@ impl Step for Extended {
     fn make_run(run: RunConfig) {
         run.builder.ensure(Extended {
             stage: run.builder.top_stage,
-            host: run.host,
+            host: run.builder.build.build,
             target: run.target,
         });
     }
@@ -1692,9 +1679,7 @@ pub struct HashSign;
 
 impl Step for HashSign {
     type Output = ();
-    const ONLY_BUILD_TARGETS: bool = true;
     const ONLY_HOSTS: bool = true;
-    const ONLY_BUILD: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         run.path("hash-and-sign")

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -225,10 +225,6 @@ install!((self, builder, _config),
         });
         install_analysis(builder, self.stage, self.target);
     };
-    Src, "src", Self::should_build(_config) , only_hosts: true, {
-        builder.ensure(dist::Src);
-        install_src(builder, self.stage);
-    }, ONLY_BUILD;
     Rustc, "src/librustc", true, only_hosts: true, {
         builder.ensure(dist::Rustc {
             compiler: builder.compiler(self.stage, self.target),
@@ -236,3 +232,32 @@ install!((self, builder, _config),
         install_rustc(builder, self.stage, self.target);
     };
 );
+
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct Src {
+    pub stage: u32,
+}
+
+impl Step for Src {
+    type Output = ();
+    const DEFAULT: bool = true;
+    const ONLY_HOSTS: bool = true;
+
+    fn should_run(run: ShouldRun) -> ShouldRun {
+        let config = &run.builder.config;
+        let cond = config.extended &&
+            config.tools.as_ref().map_or(true, |t| t.contains("src"));
+        run.path("src").default_condition(cond)
+    }
+
+    fn make_run(run: RunConfig) {
+        run.builder.ensure(Src {
+            stage: run.builder.top_stage,
+        });
+    }
+
+    fn run(self, builder: &Builder) {
+        builder.ensure(dist::Src);
+        install_src(builder, self.stage);
+    }
+}

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -161,7 +161,6 @@ macro_rules! install {
         impl Step for $name {
             type Output = ();
             const DEFAULT: bool = true;
-            const ONLY_BUILD_TARGETS: bool = true;
             const ONLY_HOSTS: bool = $only_hosts;
             $(const $c: bool = true;)*
 
@@ -174,7 +173,7 @@ macro_rules! install {
                 run.builder.ensure($name {
                     stage: run.builder.top_stage,
                     target: run.target,
-                    host: run.host,
+                    host: run.builder.build.build,
                 });
             }
 

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -113,7 +113,7 @@
 //! More documentation can be found in each respective module below, and you can
 //! also check out the `src/bootstrap/README.md` file for more information.
 
-//#![deny(warnings)]
+#![deny(warnings)]
 #![feature(core_intrinsics)]
 
 #[macro_use]

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -505,27 +505,23 @@ impl Step for RustdocJS {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct Tidy {
-    host: Interned<String>,
-}
+pub struct Tidy;
 
 impl Step for Tidy {
     type Output = ();
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
-    const ONLY_BUILD: bool = true;
 
-    /// Runs the `tidy` tool as compiled in `stage` by the `host` compiler.
+    /// Runs the `tidy` tool.
     ///
     /// This tool in `src/tools` checks up on various bits and pieces of style and
     /// otherwise just implements a few lint-like checks that are specific to the
     /// compiler itself.
     fn run(self, builder: &Builder) {
         let build = builder.build;
-        let host = self.host;
 
         let _folder = build.fold_output(|| "tidy");
-        println!("tidy check ({})", host);
+        println!("tidy check");
         let mut cmd = builder.tool_cmd(Tool::Tidy);
         cmd.arg(build.src.join("src"));
         cmd.arg(&build.initial_cargo);
@@ -543,9 +539,7 @@ impl Step for Tidy {
     }
 
     fn make_run(run: RunConfig) {
-        run.builder.ensure(Tidy {
-            host: run.builder.build.build,
-        });
+        run.builder.ensure(Tidy);
     }
 }
 
@@ -1607,7 +1601,6 @@ pub struct Distcheck;
 
 impl Step for Distcheck {
     type Output = ();
-    const ONLY_BUILD: bool = true;
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         run.path("distcheck")
@@ -1673,7 +1666,6 @@ impl Step for Bootstrap {
     type Output = ();
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
-    const ONLY_BUILD: bool = true;
 
     /// Test the build system itself
     fn run(self, builder: &Builder) {


### PR DESCRIPTION
Primarily removes `ONLY_BUILD` and `ONLY_BUILD_TARGETS`. These aren't actually needed in the new system since we can simply not take the relevant `host` and `target` fields if we don't want to run with them in `Step::make_run`.

This PR also includes a few other commits which generally clean up the state of rustbuild, but are not related to the `Step` changes.