### PR TITLE
Remember state of top-level collapse toggle widget

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1623,7 +1623,7 @@
     function toggleAllDocs() {
         var toggle = document.getElementById("toggle-all-docs");
         if (hasClass(toggle, "will-expand")) {
-            updateLocalStorage("collapse", "false");
+            updateLocalStorage("rustdoc-collapse", "false");
             removeClass(toggle, "will-expand");
             onEveryMatchingChild(toggle, "inner", function(e) {
                 e.innerHTML = labelForToggleButton(false);
@@ -1633,7 +1633,7 @@
                 collapseDocs(e, "show");
             });
         } else {
-            updateLocalStorage("collapse", "true");
+            updateLocalStorage("rustdoc-collapse", "true");
             addClass(toggle, "will-expand");
             onEveryMatchingChild(toggle, "inner", function(e) {
                 e.innerHTML = labelForToggleButton(true);
@@ -1975,7 +1975,7 @@
         hideSidebar();
     };
 
-    if (getCurrentValue("collapse") === "true") {
+    if (getCurrentValue("rustdoc-collapse") === "true") {
         toggleAllDocs();
     }
 }());

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1623,6 +1623,7 @@
     function toggleAllDocs() {
         var toggle = document.getElementById("toggle-all-docs");
         if (hasClass(toggle, "will-expand")) {
+            updateLocalStorage("collapse", "false");
             removeClass(toggle, "will-expand");
             onEveryMatchingChild(toggle, "inner", function(e) {
                 e.innerHTML = labelForToggleButton(false);
@@ -1632,6 +1633,7 @@
                 collapseDocs(e, "show");
             });
         } else {
+            updateLocalStorage("collapse", "true");
             addClass(toggle, "will-expand");
             onEveryMatchingChild(toggle, "inner", function(e) {
                 e.innerHTML = labelForToggleButton(true);
@@ -1972,6 +1974,10 @@
     window.onresize = function() {
         hideSidebar();
     };
+
+    if (getCurrentValue("collapse") === "true") {
+        toggleAllDocs();
+    }
 }());
 
 // Sets the focus on the search bar at the top of the page


### PR DESCRIPTION
This change allows the big top-right expand/collapse toggle to remember its setting across navigation or page reloads. Prior to this change, there was this annoyance:

- browse to some docs
- Click the minus button to collapse them
- browse to other docs (or reload the page)
- Everything is expanded again

The solution is based on storing a simple boolean flag in localStorage. I think it's a good improvement, but it does introduce the following potentially surprising behavior:

- browse to some docs
- click the minus button to collapse them
- click to expand a particular item (not the main top-right big one)
- reload the page, everything is collapsed

Paired with @debugsteven on this.