### PR TITLE
Optimize str::repeat

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -124,6 +124,7 @@
 #![feature(allocator_internals)]
 #![feature(on_unimplemented)]
 #![feature(exact_chunks)]
+#![feature(pointer_methods)]
 
 #![cfg_attr(not(test), feature(fused, fn_traits, placement_new_protocol, swap_with_slice, i128))]
 #![cfg_attr(test, feature(test, box_heap))]

--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -2113,9 +2113,9 @@ impl str {
                     (buf.as_mut_ptr() as *mut u8).add(buf.len()),
                     rem_len,
                 );
-                // `buf.len() + rem_len` equals to `buf.capacity()` (`self.len() * n`).
-                let buf_len = buf.len();
-                buf.set_len(buf_len + rem_len);
+                // `buf.len() + rem_len` equals to `buf.capacity()` (`= self.len() * n`).
+                let buf_cap = buf.capacity();
+                buf.set_len(buf_cap);
             }
         }
 


### PR DESCRIPTION
Improves the performance of `str::repeat` by bulk copying. Here is the benchmarks of `"abcde".repeat(n)`:

|`n`|old [ns/iter]|new [ns/iter]|diff [%]|
---|---|---|---
|1|27.205|27.421|+0.794|
|2|27.500|27.516|+0.0581|
|3|27.923|27.648|-0.985|
|4|31.206|30.145|-3.40|
|5|35.144|31.861|-9.34|
|7|43.131|34.621|-19.7|
|10|54.945|36.203|-34.1|
|100|428.31|52.895|-87.7|