### PR TITLE
make codegen-backends directory name configurable

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -321,6 +321,9 @@
 # bootstrap)
 #codegen-backends = ["llvm"]
 
+# This is the name of the directory in which codegen backends will get installed
+#codegen-backends-dir = "codegen-backends"
+
 # Flag indicating whether `libstd` calls an imported function to handle basic IO
 # when targeting WebAssembly. Enable this to debug tests for the `wasm32-unknown-unknown`
 # target, as without this option the test output will not be captured.

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -462,7 +462,7 @@ impl<'a> Builder<'a> {
 
     pub fn sysroot_codegen_backends(&self, compiler: Compiler) -> PathBuf {
         self.sysroot_libdir(compiler, compiler.host)
-            .with_file_name("codegen-backends")
+            .with_file_name(self.build.config.rust_codegen_backends_dir.clone())
     }
 
     /// Returns the compiler's libdir where it stores the dynamic libraries that

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -514,7 +514,8 @@ fn rustc_cargo_env(build: &Build, cargo: &mut Command) {
     cargo.env("CFG_RELEASE", build.rust_release())
          .env("CFG_RELEASE_CHANNEL", &build.config.channel)
          .env("CFG_VERSION", build.rust_version())
-         .env("CFG_PREFIX", build.config.prefix.clone().unwrap_or_default());
+         .env("CFG_PREFIX", build.config.prefix.clone().unwrap_or_default())
+         .env("CFG_CODEGEN_BACKENDS_DIR", &build.config.rust_codegen_backends_dir);
 
     let libdir_relative = build.config.libdir_relative().unwrap_or(Path::new("lib"));
     cargo.env("CFG_LIBDIR_RELATIVE", libdir_relative);

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -96,6 +96,7 @@ pub struct Config {
     pub rust_debuginfo_tests: bool,
     pub rust_dist_src: bool,
     pub rust_codegen_backends: Vec<Interned<String>>,
+    pub rust_codegen_backends_dir: String,
 
     pub build: Interned<String>,
     pub hosts: Vec<Interned<String>>,
@@ -289,6 +290,7 @@ struct Rust {
     test_miri: Option<bool>,
     save_toolstates: Option<String>,
     codegen_backends: Option<Vec<String>>,
+    codegen_backends_dir: Option<String>,
     wasm_syscall: Option<bool>,
 }
 
@@ -330,6 +332,7 @@ impl Config {
         config.rust_dist_src = true;
         config.test_miri = false;
         config.rust_codegen_backends = vec![INTERNER.intern_str("llvm")];
+        config.rust_codegen_backends_dir = "codegen-backends".to_owned();
 
         config.rustc_error_format = flags.rustc_error_format;
         config.on_fail = flags.on_fail;
@@ -487,6 +490,8 @@ impl Config {
                     .map(|s| INTERNER.intern_str(s))
                     .collect();
             }
+
+            set(&mut config.rust_codegen_backends_dir, rust.codegen_backends_dir.clone());
 
             match rust.codegen_units {
                 Some(0) => config.rust_codegen_units = Some(num_cpus::get() as u32),

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -590,7 +590,8 @@ impl Step for Std {
         let mut src = builder.sysroot_libdir(compiler, target).to_path_buf();
         src.pop(); // Remove the trailing /lib folder from the sysroot_libdir
         cp_filtered(&src, &dst, &|path| {
-            path.file_name().and_then(|s| s.to_str()) != Some("codegen-backends")
+            path.file_name().and_then(|s| s.to_str()) !=
+                Some(build.config.rust_codegen_backends_dir.as_str())
         });
 
         let mut cmd = rust_installer(builder);

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -303,7 +303,9 @@ fn get_trans_sysroot(backend_name: &str) -> fn() -> Box<TransCrate> {
     let sysroot = sysroot_candidates.iter()
         .map(|sysroot| {
             let libdir = filesearch::relative_target_lib_path(&sysroot, &target);
-            sysroot.join(libdir).with_file_name("codegen-backends")
+            sysroot.join(libdir)
+                .with_file_name(option_env!("CFG_CODEGEN_BACKENDS_DIR")
+                                .unwrap_or("codegen-backends"))
         })
         .filter(|f| {
             info!("codegen backend candidate: {}", f.display());


### PR DESCRIPTION
This allows to parallel-install several versions of rust system-wide
Fixes #48263 