### PR TITLE
Don't produce TOCs for doc markdown files

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -312,6 +312,7 @@ fn invoke_rustdoc(builder: &Builder, compiler: Compiler, target: Interned<String
     cmd.arg("--html-after-content").arg(&footer)
         .arg("--html-before-content").arg(&version_info)
         .arg("--html-in-header").arg(&favicon)
+        .arg("--markdown-no-toc")
         .arg("--markdown-playground-url")
         .arg("https://play.rust-lang.org/")
         .arg("-o").arg(&out)


### PR DESCRIPTION
Currently, we are producing headers for markdown files,
which is generally not what we want. As such, passing this
flag causes them to render normally.

https://doc.rust-lang.org/nightly/book/ is an example page currently where this is done incorrectly.