### PR TITLE
Add crate name to "main function not found" error message.

### DIFF
--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -165,7 +165,7 @@ fn configure_main(this: &mut EntryContext, crate_name: &str) {
     } else {
         // No main function
         let mut err = struct_err!(this.session, E0601,
-            "main function not found in crate {}", crate_name);
+            "`main` function not found in crate `{}`", crate_name);
         if !this.non_main_fns.is_empty() {
             // There were some functions named 'main' though. Try to give the user a hint.
             err.note("the main function must be defined at the crate level \
@@ -179,7 +179,7 @@ fn configure_main(this: &mut EntryContext, crate_name: &str) {
             this.session.abort_if_errors();
         } else {
             if let Some(ref filename) = this.session.local_crate_source_file {
-                err.note(&format!("consider adding a main function to {}", filename.display()));
+                err.note(&format!("consider adding a `main` function to `{}`", filename.display()));
             }
             if this.session.teach(&err.get_code().unwrap()) {
                 err.note("If you don't know the basics of Rust, you can go look to the Rust Book \

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -178,6 +178,9 @@ fn configure_main(this: &mut EntryContext, crate_name: &str) {
             err.emit();
             this.session.abort_if_errors();
         } else {
+            if let Some(ref filename) = this.session.local_crate_source_file {
+                err.note(&format!("consider adding a main function to {}", filename.display()));
+            }
             if this.session.teach(&err.get_code().unwrap()) {
                 err.note("If you don't know the basics of Rust, you can go look to the Rust Book \
                           to get started: https://doc.rust-lang.org/book/");

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -55,7 +55,9 @@ impl<'a, 'tcx> ItemLikeVisitor<'tcx> for EntryContext<'a, 'tcx> {
     }
 }
 
-pub fn find_entry_point(session: &Session, hir_map: &hir_map::Map) {
+pub fn find_entry_point(session: &Session,
+                        hir_map: &hir_map::Map,
+                        crate_name: &str) {
     let any_exe = session.crate_types.borrow().iter().any(|ty| {
         *ty == config::CrateTypeExecutable
     });
@@ -81,7 +83,7 @@ pub fn find_entry_point(session: &Session, hir_map: &hir_map::Map) {
 
     hir_map.krate().visit_all_item_likes(&mut ctxt);
 
-    configure_main(&mut ctxt);
+    configure_main(&mut ctxt, crate_name);
 }
 
 // Beware, this is duplicated in libsyntax/entry.rs, make sure to keep
@@ -150,7 +152,7 @@ fn find_item(item: &Item, ctxt: &mut EntryContext, at_root: bool) {
     }
 }
 
-fn configure_main(this: &mut EntryContext) {
+fn configure_main(this: &mut EntryContext, crate_name: &str) {
     if this.start_fn.is_some() {
         *this.session.entry_fn.borrow_mut() = this.start_fn;
         this.session.entry_type.set(Some(config::EntryStart));
@@ -162,7 +164,8 @@ fn configure_main(this: &mut EntryContext) {
         this.session.entry_type.set(Some(config::EntryMain));
     } else {
         // No main function
-        let mut err = struct_err!(this.session, E0601, "main function not found");
+        let mut err = struct_err!(this.session, E0601,
+            "main function not found in crate {}", crate_name);
         if !this.non_main_fns.is_empty() {
             // There were some functions named 'main' though. Try to give the user a hint.
             err.note("the main function must be defined at the crate level \

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -979,7 +979,7 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(trans: &TransCrate,
 
     time(sess,
          "looking for entry point",
-         || middle::entry::find_entry_point(sess, &hir_map));
+         || middle::entry::find_entry_point(sess, &hir_map, name));
 
     sess.plugin_registrar_fn.set(time(sess, "looking for plugin registrar", || {
         plugin::build::find_plugin_registrar(sess.diagnostic(), &hir_map)

--- a/src/test/compile-fail/cfg-attr-cfg-2.rs
+++ b/src/test/compile-fail/cfg-attr-cfg-2.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 //
-// error-pattern: main function not found
+// error-pattern: `main` function not found
 // compile-flags: --cfg foo
 
 // main is conditionally compiled, but the conditional compilation

--- a/src/test/compile-fail/cfg-in-crate-1.rs
+++ b/src/test/compile-fail/cfg-in-crate-1.rs
@@ -8,6 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:main function not found
+// error-pattern: `main` function not found
 
 #![cfg(bar)]

--- a/src/test/compile-fail/elided-test.rs
+++ b/src/test/compile-fail/elided-test.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: main function not found
+// error-pattern: `main` function not found
 
 // Since we're not compiling a test runner this function should be elided
 // and the build will fail because main doesn't exist

--- a/src/test/compile-fail/missing-main.rs
+++ b/src/test/compile-fail/missing-main.rs
@@ -8,5 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:main function not found
+// error-pattern: `main` function not found
 fn mian() { }

--- a/src/test/ui/error-codes/E0522.rs
+++ b/src/test/ui/error-codes/E0522.rs
@@ -15,3 +15,5 @@ fn cookie() -> ! {
 //~^^ ERROR definition of an unknown language item: `cookie` [E0522]
     loop {}
 }
+
+fn main() {}

--- a/src/test/ui/error-codes/E0522.stderr
+++ b/src/test/ui/error-codes/E0522.stderr
@@ -1,12 +1,9 @@
-error[E0601]: main function not found in crate E0522
-
 error[E0522]: definition of an unknown language item: `cookie`
   --> $DIR/E0522.rs:13:1
    |
 LL | #[lang = "cookie"]
    | ^^^^^^^^^^^^^^^^^^ definition of unknown language item `cookie`
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-Some errors occurred: E0522, E0601.
-For more information about an error, try `rustc --explain E0522`.
+For more information about this error, try `rustc --explain E0522`.

--- a/src/test/ui/error-codes/E0522.stderr
+++ b/src/test/ui/error-codes/E0522.stderr
@@ -1,4 +1,4 @@
-error[E0601]: main function not found
+error[E0601]: main function not found in crate E0522
 
 error[E0522]: definition of an unknown language item: `cookie`
   --> $DIR/E0522.rs:13:1

--- a/src/test/ui/error-codes/E0601.rs
+++ b/src/test/ui/error-codes/E0601.rs
@@ -1,0 +1,11 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test for main function not found.

--- a/src/test/ui/error-codes/E0601.stderr
+++ b/src/test/ui/error-codes/E0601.stderr
@@ -1,0 +1,7 @@
+error[E0601]: main function not found in crate E0601
+   |
+   = note: consider adding a main function to $DIR/E0601.rs
+
+error: aborting due to previous error
+
+If you want more information on this error, try using "rustc --explain E0601"

--- a/src/test/ui/error-codes/E0601.stderr
+++ b/src/test/ui/error-codes/E0601.stderr
@@ -1,6 +1,6 @@
-error[E0601]: main function not found in crate E0601
+error[E0601]: `main` function not found in crate `E0601`
    |
-   = note: consider adding a main function to $DIR/E0601.rs
+   = note: consider adding a `main` function to `$DIR/E0601.rs`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0601.stderr
+++ b/src/test/ui/error-codes/E0601.stderr
@@ -4,4 +4,4 @@ error[E0601]: `main` function not found in crate `E0601`
 
 error: aborting due to previous error
 
-If you want more information on this error, try using "rustc --explain E0601"
+For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/feature-gate-i128_type2.rs
+++ b/src/test/ui/feature-gate-i128_type2.rs
@@ -30,3 +30,5 @@ fn test3_2() {
 enum A { //~ ERROR 128-bit type is unstable
     A(u64)
 }
+
+fn main() {}

--- a/src/test/ui/feature-gate-i128_type2.stderr
+++ b/src/test/ui/feature-gate-i128_type2.stderr
@@ -30,8 +30,6 @@ LL |     let x: u128 = 0; //~ ERROR 128-bit type is unstable
    |
    = help: add #![feature(i128_type)] to the crate attributes to enable
 
-error[E0601]: main function not found in crate feature_gate_i128_type2
-
 error[E0658]: repr with 128-bit type is unstable (see issue #35118)
   --> $DIR/feature-gate-i128_type2.rs:30:1
    |
@@ -42,7 +40,6 @@ LL | | }
    |
    = help: add #![feature(repr128)] to the crate attributes to enable
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
-Some errors occurred: E0601, E0658.
-For more information about an error, try `rustc --explain E0601`.
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gate-i128_type2.stderr
+++ b/src/test/ui/feature-gate-i128_type2.stderr
@@ -30,7 +30,7 @@ LL |     let x: u128 = 0; //~ ERROR 128-bit type is unstable
    |
    = help: add #![feature(i128_type)] to the crate attributes to enable
 
-error[E0601]: main function not found
+error[E0601]: main function not found in crate feature_gate_i128_type2
 
 error[E0658]: repr with 128-bit type is unstable (see issue #35118)
   --> $DIR/feature-gate-i128_type2.rs:30:1

--- a/src/test/ui/feature-gate/issue-43106-gating-of-bench.rs
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-bench.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: main function not found
+// error-pattern: `main` function not found
 
 // At time of authorship, a crate-level #![bench] with no `--test`
 // will cause compilation to error unconditionally with "main function

--- a/src/test/ui/feature-gate/issue-43106-gating-of-bench.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-bench.stderr
@@ -1,6 +1,6 @@
-error[E0601]: main function not found in crate issue_43106_gating_of_bench
+error[E0601]: `main` function not found in crate `issue_43106_gating_of_bench`
    |
-   = note: consider adding a main function to $DIR/issue-43106-gating-of-bench.rs
+   = note: consider adding a `main` function to `$DIR/issue-43106-gating-of-bench.rs`
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gate/issue-43106-gating-of-bench.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-bench.stderr
@@ -1,4 +1,6 @@
 error[E0601]: main function not found in crate issue_43106_gating_of_bench
+   |
+   = note: consider adding a main function to $DIR/issue-43106-gating-of-bench.rs
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gate/issue-43106-gating-of-bench.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-bench.stderr
@@ -1,4 +1,4 @@
-error[E0601]: main function not found
+error[E0601]: main function not found in crate issue_43106_gating_of_bench
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gate/issue-43106-gating-of-inline.rs
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-inline.rs
@@ -35,3 +35,5 @@ mod inline {
     #[inline = "2100"] impl S { }
     //~^ ERROR attribute should be applied to function
 }
+
+fn main() {}

--- a/src/test/ui/feature-gate/issue-43106-gating-of-inline.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-inline.stderr
@@ -1,5 +1,3 @@
-error[E0601]: main function not found in crate issue_43106_gating_of_inline
-
 error[E0518]: attribute should be applied to function
   --> $DIR/issue-43106-gating-of-inline.rs:21:1
    |
@@ -39,7 +37,6 @@ error[E0518]: attribute should be applied to function
 LL |     #[inline = "2100"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^ ---------- not a function
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
-Some errors occurred: E0518, E0601.
-For more information about an error, try `rustc --explain E0518`.
+For more information about this error, try `rustc --explain E0518`.

--- a/src/test/ui/feature-gate/issue-43106-gating-of-inline.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-inline.stderr
@@ -1,4 +1,4 @@
-error[E0601]: main function not found
+error[E0601]: main function not found in crate issue_43106_gating_of_inline
 
 error[E0518]: attribute should be applied to function
   --> $DIR/issue-43106-gating-of-inline.rs:21:1

--- a/src/test/ui/feature-gate/issue-43106-gating-of-macro_escape.rs
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-macro_escape.rs
@@ -13,5 +13,9 @@
 // `#![macro_escape]` is incompatible with crate-level `#![macro_use]`
 // already present in issue-43106-gating-of-builtin-attrs.
 
+// must-compile-successfully
+
 #![macro_escape]
 //~^ WARN macro_escape is a deprecated synonym for macro_use
+
+fn main() {}

--- a/src/test/ui/feature-gate/issue-43106-gating-of-macro_escape.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-macro_escape.stderr
@@ -6,7 +6,7 @@ LL | #![macro_escape]
    |
    = help: consider an outer attribute, #[macro_use] mod ...
 
-error[E0601]: main function not found
+error[E0601]: main function not found in crate issue_43106_gating_of_macro_escape
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gate/issue-43106-gating-of-macro_escape.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-macro_escape.stderr
@@ -1,13 +1,8 @@
 warning: macro_escape is a deprecated synonym for macro_use
-  --> $DIR/issue-43106-gating-of-macro_escape.rs:16:1
+  --> $DIR/issue-43106-gating-of-macro_escape.rs:18:1
    |
 LL | #![macro_escape]
    | ^^^^^^^^^^^^^^^^
    |
    = help: consider an outer attribute, #[macro_use] mod ...
 
-error[E0601]: main function not found in crate issue_43106_gating_of_macro_escape
-
-error: aborting due to previous error
-
-For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/feature-gate/issue-43106-gating-of-proc_macro_derive.rs
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-proc_macro_derive.rs
@@ -40,3 +40,5 @@ mod proc_macro_derive2 {
     #[proc_macro_derive = "2500"] impl S { }
     //~^ ERROR the `#[proc_macro_derive]` attribute may only be used on bare functions
 }
+
+fn main() {}

--- a/src/test/ui/feature-gate/issue-43106-gating-of-proc_macro_derive.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-proc_macro_derive.stderr
@@ -34,8 +34,5 @@ error: the `#[proc_macro_derive]` attribute may only be used on bare functions
 LL |     #[proc_macro_derive = "2500"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0601]: main function not found in crate issue_43106_gating_of_proc_macro_derive
+error: aborting due to 6 previous errors
 
-error: aborting due to 7 previous errors
-
-For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/feature-gate/issue-43106-gating-of-proc_macro_derive.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-proc_macro_derive.stderr
@@ -34,7 +34,7 @@ error: the `#[proc_macro_derive]` attribute may only be used on bare functions
 LL |     #[proc_macro_derive = "2500"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0601]: main function not found
+error[E0601]: main function not found in crate issue_43106_gating_of_proc_macro_derive
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/feature-gate/issue-43106-gating-of-rustc_deprecated.rs
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-rustc_deprecated.rs
@@ -36,3 +36,4 @@ mod rustc_deprecated {
     //~^ ERROR stability attributes may not be used outside of the standard library
 }
 
+fn main() {}

--- a/src/test/ui/feature-gate/issue-43106-gating-of-rustc_deprecated.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-rustc_deprecated.stderr
@@ -1,5 +1,3 @@
-error[E0601]: main function not found in crate issue_43106_gating_of_rustc_deprecated
-
 error: stability attributes may not be used outside of the standard library
   --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:17:1
    |
@@ -42,6 +40,5 @@ error: stability attributes may not be used outside of the standard library
 LL |     #[rustc_deprecated = "1500"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 
-For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/feature-gate/issue-43106-gating-of-rustc_deprecated.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-rustc_deprecated.stderr
@@ -1,4 +1,4 @@
-error[E0601]: main function not found
+error[E0601]: main function not found in crate issue_43106_gating_of_rustc_deprecated
 
 error: stability attributes may not be used outside of the standard library
   --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:17:1

--- a/src/test/ui/feature-gate/issue-43106-gating-of-stable.rs
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-stable.rs
@@ -35,3 +35,5 @@ mod stable {
     #[stable = "1300"] impl S { }
     //~^ ERROR stability attributes may not be used outside of the standard library
 }
+
+fn main() {}

--- a/src/test/ui/feature-gate/issue-43106-gating-of-stable.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-stable.stderr
@@ -1,5 +1,3 @@
-error[E0601]: main function not found in crate issue_43106_gating_of_stable
-
 error: stability attributes may not be used outside of the standard library
   --> $DIR/issue-43106-gating-of-stable.rs:17:1
    |
@@ -42,6 +40,5 @@ error: stability attributes may not be used outside of the standard library
 LL |     #[stable = "1300"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 
-For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/feature-gate/issue-43106-gating-of-stable.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-stable.stderr
@@ -1,4 +1,4 @@
-error[E0601]: main function not found
+error[E0601]: main function not found in crate issue_43106_gating_of_stable
 
 error: stability attributes may not be used outside of the standard library
   --> $DIR/issue-43106-gating-of-stable.rs:17:1

--- a/src/test/ui/feature-gate/issue-43106-gating-of-test.rs
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-test.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: main function not found
+// error-pattern: `main` function not found
 
 // At time of authorship, crate-level #[test] attribute with no
 // `--test` signals unconditional error complaining of missing main

--- a/src/test/ui/feature-gate/issue-43106-gating-of-test.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-test.stderr
@@ -1,6 +1,6 @@
-error[E0601]: main function not found in crate issue_43106_gating_of_test
+error[E0601]: `main` function not found in crate `issue_43106_gating_of_test`
    |
-   = note: consider adding a main function to $DIR/issue-43106-gating-of-test.rs
+   = note: consider adding a `main` function to `$DIR/issue-43106-gating-of-test.rs`
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gate/issue-43106-gating-of-test.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-test.stderr
@@ -1,4 +1,4 @@
-error[E0601]: main function not found
+error[E0601]: main function not found in crate issue_43106_gating_of_test
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gate/issue-43106-gating-of-test.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-test.stderr
@@ -1,4 +1,6 @@
 error[E0601]: main function not found in crate issue_43106_gating_of_test
+   |
+   = note: consider adding a main function to $DIR/issue-43106-gating-of-test.rs
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gate/issue-43106-gating-of-unstable.rs
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-unstable.rs
@@ -35,3 +35,5 @@ mod unstable {
     #[unstable = "1200"] impl S { }
     //~^ ERROR stability attributes may not be used outside of the standard library
 }
+
+fn main() {}

--- a/src/test/ui/feature-gate/issue-43106-gating-of-unstable.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-unstable.stderr
@@ -1,4 +1,4 @@
-error[E0601]: main function not found
+error[E0601]: main function not found in crate issue_43106_gating_of_unstable
 
 error: stability attributes may not be used outside of the standard library
   --> $DIR/issue-43106-gating-of-unstable.rs:17:1

--- a/src/test/ui/feature-gate/issue-43106-gating-of-unstable.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-unstable.stderr
@@ -1,5 +1,3 @@
-error[E0601]: main function not found in crate issue_43106_gating_of_unstable
-
 error: stability attributes may not be used outside of the standard library
   --> $DIR/issue-43106-gating-of-unstable.rs:17:1
    |
@@ -42,6 +40,5 @@ error: stability attributes may not be used outside of the standard library
 LL |     #[unstable = "1200"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 
-For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/generator/yield-in-const.rs
+++ b/src/test/ui/generator/yield-in-const.rs
@@ -12,3 +12,5 @@
 
 const A: u8 = { yield 3u8; 3u8};
 //~^ ERROR yield statement outside
+
+fn main() {}

--- a/src/test/ui/generator/yield-in-const.stderr
+++ b/src/test/ui/generator/yield-in-const.stderr
@@ -1,12 +1,9 @@
-error[E0601]: main function not found in crate yield_in_const
-
 error[E0627]: yield statement outside of generator literal
   --> $DIR/yield-in-const.rs:13:17
    |
 LL | const A: u8 = { yield 3u8; 3u8};
    |                 ^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-Some errors occurred: E0601, E0627.
-For more information about an error, try `rustc --explain E0601`.
+For more information about this error, try `rustc --explain E0627`.

--- a/src/test/ui/generator/yield-in-const.stderr
+++ b/src/test/ui/generator/yield-in-const.stderr
@@ -1,4 +1,4 @@
-error[E0601]: main function not found
+error[E0601]: main function not found in crate yield_in_const
 
 error[E0627]: yield statement outside of generator literal
   --> $DIR/yield-in-const.rs:13:17

--- a/src/test/ui/generator/yield-in-static.rs
+++ b/src/test/ui/generator/yield-in-static.rs
@@ -12,3 +12,5 @@
 
 static B: u8 = { yield 3u8; 3u8};
 //~^ ERROR yield statement outside
+
+fn main() {}

--- a/src/test/ui/generator/yield-in-static.stderr
+++ b/src/test/ui/generator/yield-in-static.stderr
@@ -1,12 +1,9 @@
-error[E0601]: main function not found in crate yield_in_static
-
 error[E0627]: yield statement outside of generator literal
   --> $DIR/yield-in-static.rs:13:18
    |
 LL | static B: u8 = { yield 3u8; 3u8};
    |                  ^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-Some errors occurred: E0601, E0627.
-For more information about an error, try `rustc --explain E0601`.
+For more information about this error, try `rustc --explain E0627`.

--- a/src/test/ui/generator/yield-in-static.stderr
+++ b/src/test/ui/generator/yield-in-static.stderr
@@ -1,4 +1,4 @@
-error[E0601]: main function not found
+error[E0601]: main function not found in crate yield_in_static
 
 error[E0627]: yield statement outside of generator literal
   --> $DIR/yield-in-static.rs:13:18

--- a/src/test/ui/imports/macro-paths.rs
+++ b/src/test/ui/imports/macro-paths.rs
@@ -36,3 +36,5 @@ fn g() {
         mod baz { pub use two_macros::m; }
     }
 }
+
+fn main() {}

--- a/src/test/ui/imports/macro-paths.stderr
+++ b/src/test/ui/imports/macro-paths.stderr
@@ -36,7 +36,7 @@ LL | | }
    | |_^
    = note: macro-expanded items do not shadow when used in a macro invocation path
 
-error[E0601]: main function not found
+error[E0601]: main function not found in crate macro_paths
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/imports/macro-paths.stderr
+++ b/src/test/ui/imports/macro-paths.stderr
@@ -36,9 +36,6 @@ LL | | }
    | |_^
    = note: macro-expanded items do not shadow when used in a macro invocation path
 
-error[E0601]: main function not found in crate macro_paths
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors occurred: E0601, E0659.
-For more information about an error, try `rustc --explain E0601`.
+For more information about this error, try `rustc --explain E0659`.

--- a/src/test/ui/imports/macros.rs
+++ b/src/test/ui/imports/macros.rs
@@ -49,3 +49,5 @@ mod m4 {
     use two_macros::m;
     m!(); //~ ERROR ambiguous
 }
+
+fn main() {}

--- a/src/test/ui/imports/macros.stderr
+++ b/src/test/ui/imports/macros.stderr
@@ -51,9 +51,6 @@ LL |     use two_macros::m;
    |         ^^^^^^^^^^^^^
    = note: macro-expanded macro imports do not shadow
 
-error[E0601]: main function not found in crate macros
+error: aborting due to 3 previous errors
 
-error: aborting due to 4 previous errors
-
-Some errors occurred: E0601, E0659.
-For more information about an error, try `rustc --explain E0601`.
+For more information about this error, try `rustc --explain E0659`.

--- a/src/test/ui/imports/macros.stderr
+++ b/src/test/ui/imports/macros.stderr
@@ -51,7 +51,7 @@ LL |     use two_macros::m;
    |         ^^^^^^^^^^^^^
    = note: macro-expanded macro imports do not shadow
 
-error[E0601]: main function not found
+error[E0601]: main function not found in crate macros
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/in-band-lifetimes/mismatched_trait_impl-2.rs
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait_impl-2.rs
@@ -20,3 +20,5 @@ impl Deref for Struct {
     }
 }
 //~^^^^ ERROR cannot infer an appropriate lifetime for lifetime parameter
+
+fn main() {}

--- a/src/test/ui/in-band-lifetimes/mismatched_trait_impl-2.stderr
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait_impl-2.stderr
@@ -1,5 +1,3 @@
-error[E0601]: main function not found in crate mismatched_trait_impl_2
-
 error[E0495]: cannot infer an appropriate lifetime for lifetime parameter in generic type due to conflicting requirements
   --> $DIR/mismatched_trait_impl-2.rs:18:5
    |
@@ -18,7 +16,6 @@ LL | |     }
            expected fn(&Struct) -> &Trait + 'static
               found fn(&Struct) -> &Trait
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-Some errors occurred: E0495, E0601.
-For more information about an error, try `rustc --explain E0495`.
+For more information about this error, try `rustc --explain E0495`.

--- a/src/test/ui/in-band-lifetimes/mismatched_trait_impl-2.stderr
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait_impl-2.stderr
@@ -1,4 +1,4 @@
-error[E0601]: main function not found
+error[E0601]: main function not found in crate mismatched_trait_impl_2
 
 error[E0495]: cannot infer an appropriate lifetime for lifetime parameter in generic type due to conflicting requirements
   --> $DIR/mismatched_trait_impl-2.rs:18:5

--- a/src/test/ui/issue-47706-trait.rs
+++ b/src/test/ui/issue-47706-trait.rs
@@ -14,3 +14,5 @@ trait T {
     }
     //~^^ ERROR function is expected to take a single 0-tuple as argument
 }
+
+fn main() {}

--- a/src/test/ui/issue-47706-trait.stderr
+++ b/src/test/ui/issue-47706-trait.stderr
@@ -1,4 +1,4 @@
-error[E0601]: main function not found
+error[E0601]: main function not found in crate issue_47706_trait
 
 error[E0593]: function is expected to take a single 0-tuple as argument, but it takes 2 distinct arguments
   --> $DIR/issue-47706-trait.rs:13:20

--- a/src/test/ui/issue-47706-trait.stderr
+++ b/src/test/ui/issue-47706-trait.stderr
@@ -1,5 +1,3 @@
-error[E0601]: main function not found in crate issue_47706_trait
-
 error[E0593]: function is expected to take a single 0-tuple as argument, but it takes 2 distinct arguments
   --> $DIR/issue-47706-trait.rs:13:20
    |
@@ -8,7 +6,6 @@ LL |     fn f(&self, _: ()) {
 LL |         None::<()>.map(Self::f);
    |                    ^^^ expected function that takes a single 0-tuple as argument
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-Some errors occurred: E0593, E0601.
-For more information about an error, try `rustc --explain E0593`.
+For more information about this error, try `rustc --explain E0593`.

--- a/src/test/ui/main-wrong-location.stderr
+++ b/src/test/ui/main-wrong-location.stderr
@@ -1,4 +1,4 @@
-error[E0601]: main function not found
+error[E0601]: main function not found in crate main_wrong_location
    |
    = note: the main function must be defined at the crate level but you have one or more functions named 'main' that are not defined at the crate level. Either move the definition or attach the `#[main]` attribute to override this behavior.
 note: here is a function named 'main'

--- a/src/test/ui/main-wrong-location.stderr
+++ b/src/test/ui/main-wrong-location.stderr
@@ -1,4 +1,4 @@
-error[E0601]: main function not found in crate main_wrong_location
+error[E0601]: `main` function not found in crate `main_wrong_location`
    |
    = note: the main function must be defined at the crate level but you have one or more functions named 'main' that are not defined at the crate level. Either move the definition or attach the `#[main]` attribute to override this behavior.
 note: here is a function named 'main'

--- a/src/test/ui/missing-items/m2.rs
+++ b/src/test/ui/missing-items/m2.rs
@@ -18,3 +18,5 @@ struct X {
 
 impl m1::X for X { //~ ERROR not all trait items implemented
 }
+
+fn main() {}

--- a/src/test/ui/missing-items/m2.stderr
+++ b/src/test/ui/missing-items/m2.stderr
@@ -1,4 +1,4 @@
-error[E0601]: main function not found
+error[E0601]: main function not found in crate m2
 
 error[E0046]: not all trait items implemented, missing: `CONSTANT`, `Type`, `method`
   --> $DIR/m2.rs:19:1

--- a/src/test/ui/missing-items/m2.stderr
+++ b/src/test/ui/missing-items/m2.stderr
@@ -1,5 +1,3 @@
-error[E0601]: main function not found in crate m2
-
 error[E0046]: not all trait items implemented, missing: `CONSTANT`, `Type`, `method`
   --> $DIR/m2.rs:19:1
    |
@@ -10,7 +8,6 @@ LL | impl m1::X for X { //~ ERROR not all trait items implemented
    = note: `Type` from trait: `type Type;`
    = note: `method` from trait: `fn(&Self, std::string::String) -> <Self as m1::X>::Type`
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-Some errors occurred: E0046, E0601.
-For more information about an error, try `rustc --explain E0046`.
+For more information about this error, try `rustc --explain E0046`.

--- a/src/test/ui/resolve/issue-14254.rs
+++ b/src/test/ui/resolve/issue-14254.rs
@@ -111,3 +111,5 @@ impl Foo for Box<isize> {
         //~^ ERROR cannot find value `bah`
     }
 }
+
+fn main() {}

--- a/src/test/ui/resolve/issue-14254.stderr
+++ b/src/test/ui/resolve/issue-14254.stderr
@@ -142,7 +142,7 @@ error[E0425]: cannot find value `bah` in this scope
 LL |         bah;
    |         ^^^ help: try: `Self::bah`
 
-error[E0601]: main function not found
+error[E0601]: main function not found in crate issue_14254
 
 error: aborting due to 25 previous errors
 

--- a/src/test/ui/resolve/issue-14254.stderr
+++ b/src/test/ui/resolve/issue-14254.stderr
@@ -142,9 +142,6 @@ error[E0425]: cannot find value `bah` in this scope
 LL |         bah;
    |         ^^^ help: try: `Self::bah`
 
-error[E0601]: main function not found in crate issue_14254
+error: aborting due to 24 previous errors
 
-error: aborting due to 25 previous errors
-
-Some errors occurred: E0425, E0601.
-For more information about an error, try `rustc --explain E0425`.
+For more information about this error, try `rustc --explain E0425`.

--- a/src/test/ui/resolve/issue-21221-2.rs
+++ b/src/test/ui/resolve/issue-21221-2.rs
@@ -27,3 +27,5 @@ pub mod baz {
 struct Foo;
 impl T for Foo { }
 //~^ ERROR cannot find trait `T`
+
+fn main() {}

--- a/src/test/ui/resolve/issue-21221-2.stderr
+++ b/src/test/ui/resolve/issue-21221-2.stderr
@@ -8,7 +8,5 @@ help: possible candidate is found in another module, you can import it into scop
 LL | use foo::bar::T;
    |
 
-error[E0601]: main function not found in crate issue_21221_2
-
 error: cannot continue compilation due to previous error
 

--- a/src/test/ui/resolve/issue-21221-2.stderr
+++ b/src/test/ui/resolve/issue-21221-2.stderr
@@ -8,7 +8,7 @@ help: possible candidate is found in another module, you can import it into scop
 LL | use foo::bar::T;
    |
 
-error[E0601]: main function not found
+error[E0601]: main function not found in crate issue_21221_2
 
 error: cannot continue compilation due to previous error
 

--- a/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.rs
+++ b/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.rs
@@ -65,3 +65,5 @@ fn h8() -> i32 {
     a::b()
     //~^ ERROR expected function, found module `a::b`
 }
+
+fn main() {}

--- a/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
+++ b/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
@@ -72,9 +72,6 @@ LL |     a::b()
    |        |
    |        did you mean `I`?
 
-error[E0601]: main function not found in crate suggest_path_instead_of_mod_dot_item
+error: aborting due to 9 previous errors
 
-error: aborting due to 10 previous errors
-
-Some errors occurred: E0423, E0601.
-For more information about an error, try `rustc --explain E0423`.
+For more information about this error, try `rustc --explain E0423`.

--- a/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
+++ b/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
@@ -72,7 +72,7 @@ LL |     a::b()
    |        |
    |        did you mean `I`?
 
-error[E0601]: main function not found
+error[E0601]: main function not found in crate suggest_path_instead_of_mod_dot_item
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/span/issue-35987.rs
+++ b/src/test/ui/span/issue-35987.rs
@@ -20,3 +20,5 @@ impl<T: Clone, Add> Add for Foo<T> {
         unimplemented!();
     }
 }
+
+fn main() {}

--- a/src/test/ui/span/issue-35987.stderr
+++ b/src/test/ui/span/issue-35987.stderr
@@ -8,7 +8,7 @@ help: possible better candidate is found in another module, you can import it in
 LL | use std::ops::Add;
    |
 
-error[E0601]: main function not found
+error[E0601]: main function not found in crate issue_35987
 
 error: cannot continue compilation due to previous error
 

--- a/src/test/ui/span/issue-35987.stderr
+++ b/src/test/ui/span/issue-35987.stderr
@@ -8,7 +8,5 @@ help: possible better candidate is found in another module, you can import it in
 LL | use std::ops::Add;
    |
 
-error[E0601]: main function not found in crate issue_35987
-
 error: cannot continue compilation due to previous error
 

--- a/src/test/ui/token/issue-10636-2.rs
+++ b/src/test/ui/token/issue-10636-2.rs
@@ -17,3 +17,5 @@ pub fn trace_option(option: Option<isize>) {
 
 } //~ ERROR: incorrect close delimiter
 //~^ ERROR: expected expression, found `)`
+
+fn main() {}

--- a/src/test/ui/token/issue-10636-2.stderr
+++ b/src/test/ui/token/issue-10636-2.stderr
@@ -22,7 +22,7 @@ error: expected expression, found `)`
 LL | } //~ ERROR: incorrect close delimiter
    | ^ expected expression
 
-error[E0601]: main function not found
+error[E0601]: main function not found in crate issue_10636_2
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/token/issue-10636-2.stderr
+++ b/src/test/ui/token/issue-10636-2.stderr
@@ -22,8 +22,5 @@ error: expected expression, found `)`
 LL | } //~ ERROR: incorrect close delimiter
    | ^ expected expression
 
-error[E0601]: main function not found in crate issue_10636_2
+error: aborting due to 3 previous errors
 
-error: aborting due to 4 previous errors
-
-For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/token/issue-41155.rs
+++ b/src/test/ui/token/issue-41155.rs
@@ -11,3 +11,5 @@
 impl S { //~ ERROR cannot find type
     pub
 } //~ ERROR expected one of
+
+fn main() {}

--- a/src/test/ui/token/issue-41155.stderr
+++ b/src/test/ui/token/issue-41155.stderr
@@ -12,9 +12,6 @@ error[E0412]: cannot find type `S` in this scope
 LL | impl S { //~ ERROR cannot find type
    |      ^ not found in this scope
 
-error[E0601]: main function not found in crate issue_41155
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors occurred: E0412, E0601.
-For more information about an error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/token/issue-41155.stderr
+++ b/src/test/ui/token/issue-41155.stderr
@@ -12,7 +12,7 @@ error[E0412]: cannot find type `S` in this scope
 LL | impl S { //~ ERROR cannot find type
    |      ^ not found in this scope
 
-error[E0601]: main function not found
+error[E0601]: main function not found in crate issue_41155
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Fixes #44798 and rust-lang/cargo#4948.

I was wondering if it might be cleaner to update the ui tests to add a simple `fn main() {}` for the unrelated tests.  Let me know if you would prefer that.