### PR TITLE
Provide better borrow checker error message

### DIFF
--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -1191,15 +1191,14 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                 if let ty::BindByValue(bind_value_mut) = self.local_binding_mode(node_id) {
                     let (local_node_ty, is_implicit_self) = self.local_ty(node_id);
                     if let Some(local_node_ty) = local_node_ty {
-                        if let hir::Ty_::TyPtr(ref ty_ptr_mutability) = local_node_ty.node {
-                            if ty_ptr_mutability.mutbl == bind_value_mut {
-                                if let Ok(snippet) =self.tcx.sess.codemap().span_to_snippet(let_span)   {
+                        match (local_node_ty.node, self.tcx.sess.codemap().span_to_snippet(let_span)) {
+                            (hir::Ty_::TyPtr(ref ty_ptr_mutability), Ok(snippet)) if ty_ptr_mutability.mutbl == bind_value_mut => {
                                     db.span_suggestion(
                                         error_span,
                                         "consider removing the `&mut`, as it is an immutable binding to a mutable reference",
                                         snippet);
-                                }
-                            }
+                            },
+                            _ => {}
                         }
                     } else if let Ok(snippet) = self.tcx.sess.codemap().span_to_snippet(let_span) {
                         if is_implicit_self && snippet != "self" {

--- a/src/test/ui/unnecessary_mut_reference.rs
+++ b/src/test/ui/unnecessary_mut_reference.rs
@@ -1,0 +1,18 @@
+struct User {
+    name: String,
+}
+
+fn main() {
+    let mut user1 = User{
+        name: String::from("Kurtis"),
+    };
+    mutator_part1(&mut user1);
+}
+
+fn mutator_part1(user: &mut User) {
+    mutator_part2(&mut user);
+}
+
+fn mutator_part2(user: &mut User) {
+    user.name = String::from("Steve");
+}

--- a/src/test/ui/unnecessary_mut_reference.stderr
+++ b/src/test/ui/unnecessary_mut_reference.stderr
@@ -1,0 +1,9 @@
+error[E0596]: cannot borrow immutable argument `user` as mutable
+  --> unnecessary_mut_reference.rs:13:24
+   |
+12 | fn mutator_part1(user: &mut User) {
+13 |     mutator_part2(&mut user);
+   |                        ^^^^ cannot borrow mutably
+   |                   --------- consider removing the `&mut`, as it is an immutable binding to a mutable reference
+
+error: aborting due to previous error


### PR DESCRIPTION
Fix for issue #45392

Given incorrect code like:
```rust
fn foo(a: &mut Bar) {}

fn baz(b: &mut Bar) {
    foo(&mut b)
}
```

Rust suggests:
```
fn baz(b: &mut Bar) {
       - consider changing this to `mut b`
```

This isn't the best suggestion in this case. We should instead have a suggestion that informs the user they should change their code to look like:
```rust
fn baz(b: &mut Bar) {
    foo(b)
}
```