### PR TITLE
Add a potential cause raising `ParseIntError`.

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -3845,7 +3845,13 @@ fn from_str_radix<T: FromStrRadixHelper>(src: &str, radix: u32) -> Result<T, Par
 ///
 /// This error is used as the error type for the `from_str_radix()` functions
 /// on the primitive integer types, such as [`i8::from_str_radix`].
+/// 
+/// # Potential causes
 ///
+/// Among other causes, `ParseIntError` can be thrown because of leading or trailing whitespaces in the string e.g. when it is getted from the standard input. 
+/// Using the [`str.trim()`] method ensures that no whitespace remains before parsing.
+///
+/// [`str.trim()`]: ../../std/primitive.str.html#method.trim
 /// [`i8::from_str_radix`]: ../../std/primitive.i8.html#method.from_str_radix
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -3848,7 +3848,8 @@ fn from_str_radix<T: FromStrRadixHelper>(src: &str, radix: u32) -> Result<T, Par
 /// 
 /// # Potential causes
 ///
-/// Among other causes, `ParseIntError` can be thrown because of leading or trailing whitespaces in the string e.g. when it is getted from the standard input. 
+/// Among other causes, `ParseIntError` can be thrown because of leading or trailing whitespaces 
+/// in the string e.g. when it is getted from the standard input. 
 /// Using the [`str.trim()`] method ensures that no whitespace remains before parsing.
 ///
 /// [`str.trim()`]: ../../std/primitive.str.html#method.trim

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -3848,7 +3848,7 @@ fn from_str_radix<T: FromStrRadixHelper>(src: &str, radix: u32) -> Result<T, Par
 ///
 /// # Potential causes
 ///
-/// Among other causes, `ParseIntError` can be thrown because of leading or trailing whitespaces
+/// Among other causes, `ParseIntError` can be thrown because of leading or trailing whitespace
 /// in the string e.g. when it is obtained from the standard input.
 /// Using the [`str.trim()`] method ensures that no whitespace remains before parsing.
 ///

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -3845,11 +3845,11 @@ fn from_str_radix<T: FromStrRadixHelper>(src: &str, radix: u32) -> Result<T, Par
 ///
 /// This error is used as the error type for the `from_str_radix()` functions
 /// on the primitive integer types, such as [`i8::from_str_radix`].
-/// 
+///
 /// # Potential causes
 ///
-/// Among other causes, `ParseIntError` can be thrown because of leading or trailing whitespaces 
-/// in the string e.g. when it is getted from the standard input. 
+/// Among other causes, `ParseIntError` can be thrown because of leading or trailing whitespaces
+/// in the string e.g. when it is obtained from the standard input.
 /// Using the [`str.trim()`] method ensures that no whitespace remains before parsing.
 ///
 /// [`str.trim()`]: ../../std/primitive.str.html#method.trim


### PR DESCRIPTION
Initially, I wanted to add it directly to the documentation of `str. parse()` method, I finally found that it was more relevant (I hope so?) to directly document the structure in question. I've added a scenario, in which we could all get caught at least once, to make it easier to diagnose the problem when parsing integers.