### PR TITLE
rustc: Fix ICE with `#[target_feature]` on module

### DIFF
--- a/src/librustc/hir/check_attr.rs
+++ b/src/librustc/hir/check_attr.rs
@@ -47,7 +47,13 @@ struct CheckAttrVisitor<'a, 'tcx: 'a> {
 impl<'a, 'tcx> CheckAttrVisitor<'a, 'tcx> {
     /// Check any attribute.
     fn check_attributes(&self, item: &hir::Item, target: Target) {
-        self.tcx.trans_fn_attrs(self.tcx.hir.local_def_id(item.id));
+        if target == Target::Fn {
+            self.tcx.trans_fn_attrs(self.tcx.hir.local_def_id(item.id));
+        } else if let Some(a) = item.attrs.iter().find(|a| a.check_name("target_feature")) {
+            self.tcx.sess.struct_span_err(a.span, "attribute should be applied to a function")
+                .span_label(item.span, "not a function")
+                .emit();
+        }
 
         for attr in &item.attrs {
             if let Some(name) = attr.name() {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1883,6 +1883,7 @@ fn trans_fn_attrs<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, id: DefId) -> TransFnAt
                     .emit();
             }
         } else if attr.check_name("target_feature") {
+            // handle deprecated #[target_feature = "..."]
             if let Some(val) = attr.value_str() {
                 for feat in val.as_str().split(",").map(|f| f.trim()) {
                     if !feat.is_empty() && !feat.contains('\0') {

--- a/src/test/ui/target-feature-wrong.rs
+++ b/src/test/ui/target-feature-wrong.rs
@@ -29,6 +29,10 @@ unsafe fn foo() {}
 //~^ ERROR: can only be applied to `unsafe` function
 fn bar() {}
 
+#[target_feature(enable = "sse2")]
+//~^ ERROR: should be applied to a function
+mod another {}
+
 fn main() {
     unsafe {
         foo();

--- a/src/test/ui/target-feature-wrong.stderr
+++ b/src/test/ui/target-feature-wrong.stderr
@@ -28,5 +28,14 @@ error: #[target_feature(..)] can only be applied to `unsafe` function
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: attribute should be applied to a function
+  --> $DIR/target-feature-wrong.rs:32:1
+   |
+LL | #[target_feature(enable = "sse2")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | //~^ ERROR: should be applied to a function
+LL | mod another {}
+   | -------------- not a function
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
This commit fixes an ICE in rustc when `#[target_feature]` was applied to items
other than functions due to the way the feature was validated.