### PR TITLE
rustbuild: Fix MSBuild location of `llvm-config.exe`

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -46,7 +46,7 @@ impl Step for Std {
         let out_dir = build.stage_out(compiler, Mode::Libstd);
         build.clear_if_dirty(&out_dir, &builder.rustc(compiler));
         let mut cargo = builder.cargo(compiler, Mode::Libstd, target, "check");
-        std_cargo(build, &compiler, target, &mut cargo);
+        std_cargo(builder, &compiler, target, &mut cargo);
         run_cargo(build,
                   &mut cargo,
                   &libstd_stamp(build, compiler, target),

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -105,7 +105,7 @@ impl Step for Std {
         let out_dir = build.stage_out(compiler, Mode::Libstd);
         build.clear_if_dirty(&out_dir, &builder.rustc(compiler));
         let mut cargo = builder.cargo(compiler, Mode::Libstd, target, "build");
-        std_cargo(build, &compiler, target, &mut cargo);
+        std_cargo(builder, &compiler, target, &mut cargo);
         run_cargo(build,
                   &mut cargo,
                   &libstd_stamp(build, compiler, target),
@@ -135,7 +135,7 @@ fn copy_musl_third_party_objects(build: &Build,
 
 /// Configure cargo to compile the standard library, adding appropriate env vars
 /// and such.
-pub fn std_cargo(build: &Build,
+pub fn std_cargo(build: &Builder,
                  compiler: &Compiler,
                  target: Interned<String>,
                  cargo: &mut Command) {
@@ -162,7 +162,11 @@ pub fn std_cargo(build: &Build,
         // missing
         // We also only build the runtimes when --enable-sanitizers (or its
         // config.toml equivalent) is used
-        cargo.env("LLVM_CONFIG", build.llvm_config(target));
+        let llvm_config = build.ensure(native::Llvm {
+            target: build.config.build,
+            emscripten: false,
+        });
+        cargo.env("LLVM_CONFIG", llvm_config);
     }
 
     cargo.arg("--features").arg(features)

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -481,7 +481,7 @@ impl Step for Std {
         t!(symlink_dir_force(&my_out, &out_dir));
 
         let mut cargo = builder.cargo(compiler, Mode::Libstd, target, "doc");
-        compile::std_cargo(build, &compiler, target, &mut cargo);
+        compile::std_cargo(builder, &compiler, target, &mut cargo);
 
         // We don't want to build docs for internal std dependencies unless
         // in compiler-docs mode. When not in that mode, we whitelist the crates

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -532,20 +532,6 @@ impl Build {
         }
     }
 
-    /// Returns the path to `llvm-config` for the specified target.
-    ///
-    /// If a custom `llvm-config` was specified for target then that's returned
-    /// instead.
-    fn llvm_config(&self, target: Interned<String>) -> PathBuf {
-        let target_config = self.config.target_config.get(&target);
-        if let Some(s) = target_config.and_then(|c| c.llvm_config.as_ref()) {
-            s.clone()
-        } else {
-            self.llvm_out(self.config.build).join("bin")
-                .join(exe("llvm-config", &*target))
-        }
-    }
-
     /// Returns the path to `FileCheck` binary for the specified target
     fn llvm_filecheck(&self, target: Interned<String>) -> PathBuf {
         let target_config = self.config.target_config.get(&target);

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -81,11 +81,14 @@ impl Step for Llvm {
 
         let (out_dir, llvm_config_ret_dir) = if emscripten {
             let dir = build.emscripten_llvm_out(target);
-            let config_dir = dir.join("build/bin");
+            let config_dir = dir.join("bin");
             (dir, config_dir)
         } else {
-            (build.llvm_out(target),
-                build.llvm_out(build.config.build).join("build/bin"))
+            let mut dir = build.llvm_out(build.config.build);
+            if !build.config.build.contains("msvc") || build.config.ninja {
+                dir.push("build");
+            }
+            (build.llvm_out(target), dir.join("bin"))
         };
         let done_stamp = out_dir.join("llvm-finished-building");
         let build_llvm_config = llvm_config_ret_dir

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -915,7 +915,10 @@ impl Step for Compiletest {
         }
 
         if build.config.llvm_enabled {
-            let llvm_config = build.llvm_config(build.config.build);
+            let llvm_config = builder.ensure(native::Llvm {
+                target: build.config.build,
+                emscripten: false,
+            });
             let llvm_version = output(Command::new(&llvm_config).arg("--version"));
             cmd.arg("--llvm-version").arg(llvm_version);
             if !build.is_rust_llvm(target) {
@@ -1382,7 +1385,7 @@ impl Step for Crate {
         let mut cargo = builder.cargo(compiler, mode, target, test_kind.subcommand());
         match mode {
             Mode::Libstd => {
-                compile::std_cargo(build, &compiler, target, &mut cargo);
+                compile::std_cargo(builder, &compiler, target, &mut cargo);
             }
             Mode::Libtest => {
                 compile::test_cargo(build, &compiler, target, &mut cargo);


### PR DESCRIPTION
For LLD integration the path to `llvm-config` needed to change to inside the
build directory itself (for whatever reason) but the build directory is
different on MSBuild than it is on `ninja` for MSVC builds, so the path to
`llvm-config.exe` was actually wrong and not working!

This commit removes the `Build::llvm_config` function in favor of the source of
truth, the `Llvm` build step itself. The build step was then updated to find the
right build directory for MSBuild as well as `ninja` for where `llvm-config.exe`
is located.

Closes #48749