### PR TITLE
Add info message for -Wall command

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1138,10 +1138,9 @@ fn usage(verbose: bool, include_unstable_options: bool) {
 
 fn print_wall_help() {
     println!("
-The flag -Wall does not exist in rustc. Most useful lints are enabled by default.
-Use `rustc -W help` to see all available lints. The most used lints that are not
-enabled by default covered by -Wunused; however, the best practice is to put
-warning settings in the crate root using `#![warn(unused)]` instead of using
+The flag `-Wall` does not exist in `rustc`. Most useful lints are enabled by
+default. Use `rustc -W help` to see all available lints. It's more common to put
+warning settings in the crate root using `#![warn(LINT_NAME)]` instead of using
 the command line flag directly.
 ");
 }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1136,6 +1136,16 @@ fn usage(verbose: bool, include_unstable_options: bool) {
              verbose_help);
 }
 
+fn print_wall_help() {
+    println!("
+The flag -Wall does not exist in rustc. Most useful lints are enabled by default.
+Use `rustc -W help` to see all available lints. The most used lints that are not
+enabled by default covered by -Wunused; however, the best practice is to put
+warning settings in the crate root using `#![warn(unused)]` instead of using
+the command line flag directly.
+");
+}
+
 fn describe_lints(sess: &Session, lint_store: &lint::LintStore, loaded_plugins: bool) {
     println!("
 Available lint options:
@@ -1377,6 +1387,13 @@ pub fn handle_options(args: &[String]) -> Option<getopts::Matches> {
         // historically.
         usage(matches.opt_present("verbose"),
               nightly_options::is_unstable_enabled(&matches));
+        return None;
+    }
+    
+    // Handle the special case of -Wall.
+    let wall = matches.opt_strs("W");
+    if wall.iter().any(|x| *x == "all") {
+        print_wall_help();
         return None;
     }
 

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1389,7 +1389,7 @@ pub fn handle_options(args: &[String]) -> Option<getopts::Matches> {
               nightly_options::is_unstable_enabled(&matches));
         return None;
     }
-    
+
     // Handle the special case of -Wall.
     let wall = matches.opt_strs("W");
     if wall.iter().any(|x| *x == "all") {


### PR DESCRIPTION
Users coming from other languages (namely C and C++) often expect
to use a -Wall flag. Rustc doesn't support that, and previously it
simply printed that it didn't recognize the "all" lint.

This change makes rustc print out a help message, explaining:
- Why there is no -Wall flag
- How to view all the available warnings
- Point out that the most commonly used warning is -Wunused
- Instead of using a command-line flag, the user should consider
  a !#[warn(unused)] directive in the root of their crate.

I tried to keep the language consistent with the other usage help. Comment if I should change anything.

closes #10234, if accepted.