### PR TITLE
test: travis: cache stage0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -301,6 +301,12 @@ notifications:
 cache:
   directories:
     - $HOME/docker
+    - build/x86_64-unknown-linux-gnu/stage0
+    - build/x86_64-unknown-linux-gnu/stage0-rustc
+    - build/x86_64-unknown-linux-gnu/stage0-std
+    - build/x86_64-unknown-linux-gnu/stage0-sysroot
+    - build/x86_64-unknown-linux-gnu/stage0-test
+    - build/x86_64-unknown-linux-gnu/stage0-tools
 
 before_deploy:
   - mkdir -p deploy/$TRAVIS_COMMIT


### PR DESCRIPTION
This is a test to see if we can cache stage0.
cc #48412

edit:
log 1: https://travis-ci.org/rust-lang/rust/builds/349703962
I force pushed to see if I could see any effect of this in the second log, but I am not sure if this will work / if the cache is retained per PR or if other PR builds that happened in between overwrote the cache.
log 2: https://travis-ci.org/rust-lang/rust/builds/349737662