### PR TITLE
Fix save-analysis generation crash with invalid tuple access

### DIFF
--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -1665,13 +1665,16 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> Visitor<'l> for DumpVisitor<'l, 'tc
                         if !self.span.filter_generated(sub_span, ex.span) {
                             let span =
                                 self.span_from_span(sub_span.expect("No span found for var ref"));
-                            let ref_id =
-                                ::id_from_def_id(def.non_enum_variant().fields[idx.node].did);
-                            self.dumper.dump_ref(Ref {
-                                kind: RefKind::Variable,
-                                span,
-                                ref_id,
-                            });
+                            if let Some(field) = def.non_enum_variant().fields.get(idx.node) {
+                                let ref_id = ::id_from_def_id(field.did);
+                                self.dumper.dump_ref(Ref {
+                                    kind: RefKind::Variable,
+                                    span,
+                                    ref_id,
+                                });
+                            } else {
+                                return;
+                            }
                         }
                     }
                     ty::TyTuple(..) => {}

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -1675,7 +1675,10 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> Visitor<'l> for DumpVisitor<'l, 'tc
                         }
                     }
                     ty::TyTuple(..) => {}
-                    _ => span_bug!(ex.span, "Expected struct or tuple type, found {:?}", ty),
+                    _ => {
+                        debug!("Expected struct or tuple type, found {:?}", ty);
+                        return;
+                    }
                 }
             }
             ast::ExprKind::Closure(_, _, ref decl, ref body, _fn_decl_span) => {

--- a/src/test/run-make/save-analysis-fail/foo.rs
+++ b/src/test/run-make/save-analysis-fail/foo.rs
@@ -462,4 +462,7 @@ fn new(f: u32) -> Rls699 {
 
 fn invalid_tuple_struct_access() {
     bar.0;
+
+    struct S;
+    S.0;
 }

--- a/src/test/run-make/save-analysis-fail/foo.rs
+++ b/src/test/run-make/save-analysis-fail/foo.rs
@@ -459,3 +459,7 @@ struct Rls699 {
 fn new(f: u32) -> Rls699 {
     Rls699 { fs }
 }
+
+fn invalid_tuple_struct_access() {
+    bar.0;
+}


### PR DESCRIPTION
Reproduction:

```rust
fn invalid_tuple_struct_accessing() {
    bar.0;
}
```
```
error[E0425]: cannot find value `bar` in this scope
 --> test.rs:2:5
  |
2 |     bar.0;
  |     ^^^ not found in this scope

error[E0601]: main function not found

error: internal compiler error: librustc_save_analysis/dump_visitor.rs:1678: Expected struct or tuple type, found TyError
 --> test.rs:2:5
  |
2 |     bar.0;
  |     ^^^^^

thread 'rustc' panicked at 'Box<Any>', librustc_errors/lib.rs:482:9
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

This should fix a crash in RLS when editing such code. cc @nrc