### PR TITLE
rustc: Update LLVM

### DIFF
--- a/src/rustllvm/llvm-rebuild-trigger
+++ b/src/rustllvm/llvm-rebuild-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be (optionally) cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2018-02-09
+2018-03-06


### PR DESCRIPTION
This pulls in the rest of LLVM's `release_60` branch (the actual 6.0.0 release)
and also pulls in a cherry-pick to...

Closes #48226