### PR TITLE
travis: Upgrade OSX builders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
         NO_LLVM_ASSERTIONS=1
         NO_DEBUG_ASSERTIONS=1
       os: osx
-      osx_image: xcode9.2
+      osx_image: xcode9.3-moar
       if: branch = auto
 
     - env: >
@@ -70,7 +70,7 @@ matrix:
         NO_LLVM_ASSERTIONS=1
         NO_DEBUG_ASSERTIONS=1
       os: osx
-      osx_image: xcode9.2
+      osx_image: xcode9.3-moar
       if: branch = auto
 
     # OSX builders producing releases. These do not run the full test suite and

--- a/src/test/debuginfo/lexical-scope-with-macro.rs
+++ b/src/test/debuginfo/lexical-scope-with-macro.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // min-lldb-version: 310
+// ignore-macos FIXME #48807
 
 // compile-flags:-g -Zdebug-macros
 

--- a/src/test/run-make/long-linker-command-lines/Makefile
+++ b/src/test/run-make/long-linker-command-lines/Makefile
@@ -1,5 +1,5 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) foo.rs -g
+	$(RUSTC) foo.rs -g -O
 	RUSTC="$(RUSTC_ORIGINAL)" $(call RUN,foo)

--- a/src/test/run-make/reproducible-build/Makefile
+++ b/src/test/run-make/reproducible-build/Makefile
@@ -10,31 +10,27 @@ all:  \
 
 smoke:
 	rm -rf $(TMPDIR) && mkdir $(TMPDIR)
+	$(RUSTC) linker.rs -O
 	$(RUSTC) reproducible-build-aux.rs
-	$(RUSTC) reproducible-build.rs -o"$(TMPDIR)/reproducible-build1"
-	$(RUSTC) reproducible-build.rs -o"$(TMPDIR)/reproducible-build2"
-	$(B2)
-	nm "$(TMPDIR)/reproducible-build1" | sort > "$(TMPDIR)/reproducible-build1.nm"
-	nm "$(TMPDIR)/reproducible-build2" | sort > "$(TMPDIR)/reproducible-build2.nm"
-	cmp "$(TMPDIR)/reproducible-build1.nm" "$(TMPDIR)/reproducible-build2.nm" || exit 1
+	$(RUSTC) reproducible-build.rs -C linker=$(call RUN_BINFILE,linker)
+	$(RUSTC) reproducible-build.rs -C linker=$(call RUN_BINFILE,linker)
+	diff -u "$(TMPDIR)/linker-arguments1" "$(TMPDIR)/linker-arguments2"
 
 debug:
 	rm -rf $(TMPDIR) && mkdir $(TMPDIR)
+	$(RUSTC) linker.rs -O
 	$(RUSTC) reproducible-build-aux.rs -g
-	$(RUSTC) reproducible-build.rs -o"$(TMPDIR)/reproducible-build1" -g
-	$(RUSTC) reproducible-build.rs -o"$(TMPDIR)/reproducible-build2" -g
-	nm "$(TMPDIR)/reproducible-build1" | sort > "$(TMPDIR)/reproducible-build1-debug.nm"
-	nm "$(TMPDIR)/reproducible-build2" | sort > "$(TMPDIR)/reproducible-build2-debug.nm"
-	cmp "$(TMPDIR)/reproducible-build1-debug.nm" "$(TMPDIR)/reproducible-build2-debug.nm" || exit 1
+	$(RUSTC) reproducible-build.rs -C linker=$(call RUN_BINFILE,linker) -g
+	$(RUSTC) reproducible-build.rs -C linker=$(call RUN_BINFILE,linker) -g
+	diff -u "$(TMPDIR)/linker-arguments1" "$(TMPDIR)/linker-arguments2"
 
 opt:
 	rm -rf $(TMPDIR) && mkdir $(TMPDIR)
+	$(RUSTC) linker.rs -O
 	$(RUSTC) reproducible-build-aux.rs -O
-	$(RUSTC) reproducible-build.rs -o"$(TMPDIR)/reproducible-build1" -O
-	$(RUSTC) reproducible-build.rs -o"$(TMPDIR)/reproducible-build2" -O
-	nm "$(TMPDIR)/reproducible-build1" | sort > "$(TMPDIR)/reproducible-build1-opt.nm"
-	nm "$(TMPDIR)/reproducible-build2" | sort > "$(TMPDIR)/reproducible-build2-opt.nm"
-	cmp "$(TMPDIR)/reproducible-build1-opt.nm" "$(TMPDIR)/reproducible-build2-opt.nm" || exit 1
+	$(RUSTC) reproducible-build.rs -C linker=$(call RUN_BINFILE,linker) -O
+	$(RUSTC) reproducible-build.rs -C linker=$(call RUN_BINFILE,linker) -O
+	diff -u "$(TMPDIR)/linker-arguments1" "$(TMPDIR)/linker-arguments2"
 
 link_paths:
 	rm -rf $(TMPDIR) && mkdir $(TMPDIR)

--- a/src/test/run-make/reproducible-build/linker.rs
+++ b/src/test/run-make/reproducible-build/linker.rs
@@ -1,0 +1,54 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::env;
+use std::path::Path;
+use std::fs::File;
+use std::io::{Read, Write};
+
+fn main() {
+    let mut dst = env::current_exe().unwrap();
+    dst.pop();
+    dst.push("linker-arguments1");
+    if dst.exists() {
+        dst.pop();
+        dst.push("linker-arguments2");
+        assert!(!dst.exists());
+    }
+
+    let mut out = String::new();
+    for arg in env::args().skip(1) {
+        let path = Path::new(&arg);
+        if !path.is_file() {
+            out.push_str(&arg);
+            out.push_str("\n");
+            continue
+        }
+
+        let mut contents = Vec::new();
+        File::open(path).unwrap().read_to_end(&mut contents).unwrap();
+
+        out.push_str(&format!("{}: {}\n", arg, hash(&contents)));
+    }
+
+    File::create(dst).unwrap().write_all(out.as_bytes()).unwrap();
+}
+
+// fnv hash for now
+fn hash(contents: &[u8]) -> u64 {
+    let mut hash = 0xcbf29ce484222325;
+
+    for byte in contents {
+        hash = hash ^ (*byte as u64);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+
+    hash
+}


### PR DESCRIPTION
This upgrades the OSX builders to the `xcode9.3-moar` image which has 3 cores as
opposed to the 2 that our builders currently have. Should help make those OSX
builds a bit speedier!