### PR TITLE
Remove syntax and syntax_pos thread locals

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2432,6 +2432,7 @@ dependencies = [
  "rustc_cratesio_shim 0.0.0",
  "rustc_data_structures 0.0.0",
  "rustc_errors 0.0.0",
+ "scoped-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serialize 0.0.0",
  "syntax_pos 0.0.0",
 ]
@@ -2453,6 +2454,7 @@ name = "syntax_pos"
 version = "0.0.0"
 dependencies = [
  "rustc_data_structures 0.0.0",
+ "scoped-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serialize 0.0.0",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -448,6 +448,17 @@ pub fn run_compiler<'a>(args: &[String],
                         emitter_dest: Option<Box<Write + Send>>)
                         -> (CompileResult, Option<Session>)
 {
+    syntax::with_globals(|| {
+        run_compiler_impl(args, callbacks, file_loader, emitter_dest)
+    })
+}
+
+fn run_compiler_impl<'a>(args: &[String],
+                         callbacks: &mut CompilerCalls<'a>,
+                         file_loader: Option<Box<FileLoader + 'static>>,
+                         emitter_dest: Option<Box<Write + Send>>)
+                         -> (CompileResult, Option<Session>)
+{
     macro_rules! do_or_return {($expr: expr, $sess: expr) => {
         match $expr {
             Compilation::Stop => return (Ok(()), $sess),

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -29,6 +29,7 @@ use rustc::hir::map as hir_map;
 use rustc::session::{self, config};
 use rustc::session::config::{OutputFilenames, OutputTypes};
 use rustc_data_structures::sync::Lrc;
+use syntax;
 use syntax::ast;
 use syntax::abi::Abi;
 use syntax::codemap::{CodeMap, FilePathMapping, FileName};
@@ -93,8 +94,18 @@ fn errors(msgs: &[&str]) -> (Box<Emitter + Send>, usize) {
 }
 
 fn test_env<F>(source_string: &str,
-               (emitter, expected_err_count): (Box<Emitter + Send>, usize),
+               args: (Box<Emitter + Send>, usize),
                body: F)
+    where F: FnOnce(Env)
+{
+    syntax::with_globals(|| {
+        test_env_impl(source_string, args, body)
+    });
+}
+
+fn test_env_impl<F>(source_string: &str,
+                    (emitter, expected_err_count): (Box<Emitter + Send>, usize),
+                    body: F)
     where F: FnOnce(Env)
 {
     let mut options = config::basic_options();

--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -398,6 +398,7 @@ mod test {
     use syntax::ast::*;
     use syntax::codemap::dummy_spanned;
     use syntax_pos::DUMMY_SP;
+    use syntax::with_globals;
 
     fn word_cfg(s: &str) -> Cfg {
         Cfg::Cfg(Symbol::intern(s), None)
@@ -409,479 +410,494 @@ mod test {
 
     #[test]
     fn test_cfg_not() {
-        assert_eq!(!Cfg::False, Cfg::True);
-        assert_eq!(!Cfg::True, Cfg::False);
-        assert_eq!(!word_cfg("test"), Cfg::Not(Box::new(word_cfg("test"))));
-        assert_eq!(
-            !Cfg::All(vec![word_cfg("a"), word_cfg("b")]),
-            Cfg::Not(Box::new(Cfg::All(vec![word_cfg("a"), word_cfg("b")])))
-        );
-        assert_eq!(
-            !Cfg::Any(vec![word_cfg("a"), word_cfg("b")]),
-            Cfg::Not(Box::new(Cfg::Any(vec![word_cfg("a"), word_cfg("b")])))
-        );
-        assert_eq!(!Cfg::Not(Box::new(word_cfg("test"))), word_cfg("test"));
+        with_globals(|| {
+            assert_eq!(!Cfg::False, Cfg::True);
+            assert_eq!(!Cfg::True, Cfg::False);
+            assert_eq!(!word_cfg("test"), Cfg::Not(Box::new(word_cfg("test"))));
+            assert_eq!(
+                !Cfg::All(vec![word_cfg("a"), word_cfg("b")]),
+                Cfg::Not(Box::new(Cfg::All(vec![word_cfg("a"), word_cfg("b")])))
+            );
+            assert_eq!(
+                !Cfg::Any(vec![word_cfg("a"), word_cfg("b")]),
+                Cfg::Not(Box::new(Cfg::Any(vec![word_cfg("a"), word_cfg("b")])))
+            );
+            assert_eq!(!Cfg::Not(Box::new(word_cfg("test"))), word_cfg("test"));
+        })
     }
 
     #[test]
     fn test_cfg_and() {
-        let mut x = Cfg::False;
-        x &= Cfg::True;
-        assert_eq!(x, Cfg::False);
+        with_globals(|| {
+            let mut x = Cfg::False;
+            x &= Cfg::True;
+            assert_eq!(x, Cfg::False);
 
-        x = word_cfg("test");
-        x &= Cfg::False;
-        assert_eq!(x, Cfg::False);
+            x = word_cfg("test");
+            x &= Cfg::False;
+            assert_eq!(x, Cfg::False);
 
-        x = word_cfg("test2");
-        x &= Cfg::True;
-        assert_eq!(x, word_cfg("test2"));
+            x = word_cfg("test2");
+            x &= Cfg::True;
+            assert_eq!(x, word_cfg("test2"));
 
-        x = Cfg::True;
-        x &= word_cfg("test3");
-        assert_eq!(x, word_cfg("test3"));
+            x = Cfg::True;
+            x &= word_cfg("test3");
+            assert_eq!(x, word_cfg("test3"));
 
-        x &= word_cfg("test4");
-        assert_eq!(x, Cfg::All(vec![word_cfg("test3"), word_cfg("test4")]));
+            x &= word_cfg("test4");
+            assert_eq!(x, Cfg::All(vec![word_cfg("test3"), word_cfg("test4")]));
 
-        x &= word_cfg("test5");
-        assert_eq!(x, Cfg::All(vec![word_cfg("test3"), word_cfg("test4"), word_cfg("test5")]));
+            x &= word_cfg("test5");
+            assert_eq!(x, Cfg::All(vec![word_cfg("test3"), word_cfg("test4"), word_cfg("test5")]));
 
-        x &= Cfg::All(vec![word_cfg("test6"), word_cfg("test7")]);
-        assert_eq!(x, Cfg::All(vec![
-            word_cfg("test3"),
-            word_cfg("test4"),
-            word_cfg("test5"),
-            word_cfg("test6"),
-            word_cfg("test7"),
-        ]));
+            x &= Cfg::All(vec![word_cfg("test6"), word_cfg("test7")]);
+            assert_eq!(x, Cfg::All(vec![
+                word_cfg("test3"),
+                word_cfg("test4"),
+                word_cfg("test5"),
+                word_cfg("test6"),
+                word_cfg("test7"),
+            ]));
 
-        let mut y = Cfg::Any(vec![word_cfg("a"), word_cfg("b")]);
-        y &= x;
-        assert_eq!(y, Cfg::All(vec![
-            word_cfg("test3"),
-            word_cfg("test4"),
-            word_cfg("test5"),
-            word_cfg("test6"),
-            word_cfg("test7"),
-            Cfg::Any(vec![word_cfg("a"), word_cfg("b")]),
-        ]));
+            let mut y = Cfg::Any(vec![word_cfg("a"), word_cfg("b")]);
+            y &= x;
+            assert_eq!(y, Cfg::All(vec![
+                word_cfg("test3"),
+                word_cfg("test4"),
+                word_cfg("test5"),
+                word_cfg("test6"),
+                word_cfg("test7"),
+                Cfg::Any(vec![word_cfg("a"), word_cfg("b")]),
+            ]));
 
-        assert_eq!(
-            word_cfg("a") & word_cfg("b") & word_cfg("c"),
-            Cfg::All(vec![word_cfg("a"), word_cfg("b"), word_cfg("c")])
-        );
+            assert_eq!(
+                word_cfg("a") & word_cfg("b") & word_cfg("c"),
+                Cfg::All(vec![word_cfg("a"), word_cfg("b"), word_cfg("c")])
+            );
+        })
     }
 
     #[test]
     fn test_cfg_or() {
-        let mut x = Cfg::True;
-        x |= Cfg::False;
-        assert_eq!(x, Cfg::True);
+        with_globals(|| {
+            let mut x = Cfg::True;
+            x |= Cfg::False;
+            assert_eq!(x, Cfg::True);
 
-        x = word_cfg("test");
-        x |= Cfg::True;
-        assert_eq!(x, Cfg::True);
+            x = word_cfg("test");
+            x |= Cfg::True;
+            assert_eq!(x, Cfg::True);
 
-        x = word_cfg("test2");
-        x |= Cfg::False;
-        assert_eq!(x, word_cfg("test2"));
+            x = word_cfg("test2");
+            x |= Cfg::False;
+            assert_eq!(x, word_cfg("test2"));
 
-        x = Cfg::False;
-        x |= word_cfg("test3");
-        assert_eq!(x, word_cfg("test3"));
+            x = Cfg::False;
+            x |= word_cfg("test3");
+            assert_eq!(x, word_cfg("test3"));
 
-        x |= word_cfg("test4");
-        assert_eq!(x, Cfg::Any(vec![word_cfg("test3"), word_cfg("test4")]));
+            x |= word_cfg("test4");
+            assert_eq!(x, Cfg::Any(vec![word_cfg("test3"), word_cfg("test4")]));
 
-        x |= word_cfg("test5");
-        assert_eq!(x, Cfg::Any(vec![word_cfg("test3"), word_cfg("test4"), word_cfg("test5")]));
+            x |= word_cfg("test5");
+            assert_eq!(x, Cfg::Any(vec![word_cfg("test3"), word_cfg("test4"), word_cfg("test5")]));
 
-        x |= Cfg::Any(vec![word_cfg("test6"), word_cfg("test7")]);
-        assert_eq!(x, Cfg::Any(vec![
-            word_cfg("test3"),
-            word_cfg("test4"),
-            word_cfg("test5"),
-            word_cfg("test6"),
-            word_cfg("test7"),
-        ]));
+            x |= Cfg::Any(vec![word_cfg("test6"), word_cfg("test7")]);
+            assert_eq!(x, Cfg::Any(vec![
+                word_cfg("test3"),
+                word_cfg("test4"),
+                word_cfg("test5"),
+                word_cfg("test6"),
+                word_cfg("test7"),
+            ]));
 
-        let mut y = Cfg::All(vec![word_cfg("a"), word_cfg("b")]);
-        y |= x;
-        assert_eq!(y, Cfg::Any(vec![
-            word_cfg("test3"),
-            word_cfg("test4"),
-            word_cfg("test5"),
-            word_cfg("test6"),
-            word_cfg("test7"),
-            Cfg::All(vec![word_cfg("a"), word_cfg("b")]),
-        ]));
+            let mut y = Cfg::All(vec![word_cfg("a"), word_cfg("b")]);
+            y |= x;
+            assert_eq!(y, Cfg::Any(vec![
+                word_cfg("test3"),
+                word_cfg("test4"),
+                word_cfg("test5"),
+                word_cfg("test6"),
+                word_cfg("test7"),
+                Cfg::All(vec![word_cfg("a"), word_cfg("b")]),
+            ]));
 
-        assert_eq!(
-            word_cfg("a") | word_cfg("b") | word_cfg("c"),
-            Cfg::Any(vec![word_cfg("a"), word_cfg("b"), word_cfg("c")])
-        );
+            assert_eq!(
+                word_cfg("a") | word_cfg("b") | word_cfg("c"),
+                Cfg::Any(vec![word_cfg("a"), word_cfg("b"), word_cfg("c")])
+            );
+        })
     }
 
     #[test]
     fn test_parse_ok() {
-        let mi = MetaItem {
-            name: Symbol::intern("all"),
-            node: MetaItemKind::Word,
-            span: DUMMY_SP,
-        };
-        assert_eq!(Cfg::parse(&mi), Ok(word_cfg("all")));
+        with_globals(|| {
+            let mi = MetaItem {
+                name: Symbol::intern("all"),
+                node: MetaItemKind::Word,
+                span: DUMMY_SP,
+            };
+            assert_eq!(Cfg::parse(&mi), Ok(word_cfg("all")));
 
-        let mi = MetaItem {
-            name: Symbol::intern("all"),
-            node: MetaItemKind::NameValue(dummy_spanned(LitKind::Str(
-                Symbol::intern("done"),
-                StrStyle::Cooked,
-            ))),
-            span: DUMMY_SP,
-        };
-        assert_eq!(Cfg::parse(&mi), Ok(name_value_cfg("all", "done")));
+            let mi = MetaItem {
+                name: Symbol::intern("all"),
+                node: MetaItemKind::NameValue(dummy_spanned(LitKind::Str(
+                    Symbol::intern("done"),
+                    StrStyle::Cooked,
+                ))),
+                span: DUMMY_SP,
+            };
+            assert_eq!(Cfg::parse(&mi), Ok(name_value_cfg("all", "done")));
 
-        let mi = MetaItem {
-            name: Symbol::intern("all"),
-            node: MetaItemKind::List(vec![
-                dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                    name: Symbol::intern("a"),
-                    node: MetaItemKind::Word,
-                    span: DUMMY_SP,
-                })),
-                dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                    name: Symbol::intern("b"),
-                    node: MetaItemKind::Word,
-                    span: DUMMY_SP,
-                })),
-            ]),
-            span: DUMMY_SP,
-        };
-        assert_eq!(Cfg::parse(&mi), Ok(word_cfg("a") & word_cfg("b")));
+            let mi = MetaItem {
+                name: Symbol::intern("all"),
+                node: MetaItemKind::List(vec![
+                    dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                        name: Symbol::intern("a"),
+                        node: MetaItemKind::Word,
+                        span: DUMMY_SP,
+                    })),
+                    dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                        name: Symbol::intern("b"),
+                        node: MetaItemKind::Word,
+                        span: DUMMY_SP,
+                    })),
+                ]),
+                span: DUMMY_SP,
+            };
+            assert_eq!(Cfg::parse(&mi), Ok(word_cfg("a") & word_cfg("b")));
 
-        let mi = MetaItem {
-            name: Symbol::intern("any"),
-            node: MetaItemKind::List(vec![
-                dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                    name: Symbol::intern("a"),
-                    node: MetaItemKind::Word,
-                    span: DUMMY_SP,
-                })),
-                dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                    name: Symbol::intern("b"),
-                    node: MetaItemKind::Word,
-                    span: DUMMY_SP,
-                })),
-            ]),
-            span: DUMMY_SP,
-        };
-        assert_eq!(Cfg::parse(&mi), Ok(word_cfg("a") | word_cfg("b")));
+            let mi = MetaItem {
+                name: Symbol::intern("any"),
+                node: MetaItemKind::List(vec![
+                    dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                        name: Symbol::intern("a"),
+                        node: MetaItemKind::Word,
+                        span: DUMMY_SP,
+                    })),
+                    dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                        name: Symbol::intern("b"),
+                        node: MetaItemKind::Word,
+                        span: DUMMY_SP,
+                    })),
+                ]),
+                span: DUMMY_SP,
+            };
+            assert_eq!(Cfg::parse(&mi), Ok(word_cfg("a") | word_cfg("b")));
 
-        let mi = MetaItem {
-            name: Symbol::intern("not"),
-            node: MetaItemKind::List(vec![
-                dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                    name: Symbol::intern("a"),
-                    node: MetaItemKind::Word,
-                    span: DUMMY_SP,
-                })),
-            ]),
-            span: DUMMY_SP,
-        };
-        assert_eq!(Cfg::parse(&mi), Ok(!word_cfg("a")));
+            let mi = MetaItem {
+                name: Symbol::intern("not"),
+                node: MetaItemKind::List(vec![
+                    dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                        name: Symbol::intern("a"),
+                        node: MetaItemKind::Word,
+                        span: DUMMY_SP,
+                    })),
+                ]),
+                span: DUMMY_SP,
+            };
+            assert_eq!(Cfg::parse(&mi), Ok(!word_cfg("a")));
 
-        let mi = MetaItem {
-            name: Symbol::intern("not"),
-            node: MetaItemKind::List(vec![
-                dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                    name: Symbol::intern("any"),
-                    node: MetaItemKind::List(vec![
-                        dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                            name: Symbol::intern("a"),
-                            node: MetaItemKind::Word,
-                            span: DUMMY_SP,
-                        })),
-                        dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                            name: Symbol::intern("all"),
-                            node: MetaItemKind::List(vec![
-                                dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                                    name: Symbol::intern("b"),
-                                    node: MetaItemKind::Word,
-                                    span: DUMMY_SP,
-                                })),
-                                dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                                    name: Symbol::intern("c"),
-                                    node: MetaItemKind::Word,
-                                    span: DUMMY_SP,
-                                })),
-                            ]),
-                            span: DUMMY_SP,
-                        })),
-                    ]),
-                    span: DUMMY_SP,
-                })),
-            ]),
-            span: DUMMY_SP,
-        };
-        assert_eq!(Cfg::parse(&mi), Ok(!(word_cfg("a") | (word_cfg("b") & word_cfg("c")))));
+            let mi = MetaItem {
+                name: Symbol::intern("not"),
+                node: MetaItemKind::List(vec![
+                    dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                        name: Symbol::intern("any"),
+                        node: MetaItemKind::List(vec![
+                            dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                                name: Symbol::intern("a"),
+                                node: MetaItemKind::Word,
+                                span: DUMMY_SP,
+                            })),
+                            dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                                name: Symbol::intern("all"),
+                                node: MetaItemKind::List(vec![
+                                    dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                                        name: Symbol::intern("b"),
+                                        node: MetaItemKind::Word,
+                                        span: DUMMY_SP,
+                                    })),
+                                    dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                                        name: Symbol::intern("c"),
+                                        node: MetaItemKind::Word,
+                                        span: DUMMY_SP,
+                                    })),
+                                ]),
+                                span: DUMMY_SP,
+                            })),
+                        ]),
+                        span: DUMMY_SP,
+                    })),
+                ]),
+                span: DUMMY_SP,
+            };
+            assert_eq!(Cfg::parse(&mi), Ok(!(word_cfg("a") | (word_cfg("b") & word_cfg("c")))));
 
-        let mi = MetaItem {
-            name: Symbol::intern("all"),
-            node: MetaItemKind::List(vec![
-                dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                    name: Symbol::intern("a"),
-                    node: MetaItemKind::Word,
-                    span: DUMMY_SP,
-                })),
-                dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                    name: Symbol::intern("b"),
-                    node: MetaItemKind::Word,
-                    span: DUMMY_SP,
-                })),
-                dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                    name: Symbol::intern("c"),
-                    node: MetaItemKind::Word,
-                    span: DUMMY_SP,
-                })),
-            ]),
-            span: DUMMY_SP,
-        };
-        assert_eq!(Cfg::parse(&mi), Ok(word_cfg("a") & word_cfg("b") & word_cfg("c")));
+            let mi = MetaItem {
+                name: Symbol::intern("all"),
+                node: MetaItemKind::List(vec![
+                    dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                        name: Symbol::intern("a"),
+                        node: MetaItemKind::Word,
+                        span: DUMMY_SP,
+                    })),
+                    dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                        name: Symbol::intern("b"),
+                        node: MetaItemKind::Word,
+                        span: DUMMY_SP,
+                    })),
+                    dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                        name: Symbol::intern("c"),
+                        node: MetaItemKind::Word,
+                        span: DUMMY_SP,
+                    })),
+                ]),
+                span: DUMMY_SP,
+            };
+            assert_eq!(Cfg::parse(&mi), Ok(word_cfg("a") & word_cfg("b") & word_cfg("c")));
+        })
     }
 
     #[test]
     fn test_parse_err() {
-        let mi = MetaItem {
-            name: Symbol::intern("foo"),
-            node: MetaItemKind::NameValue(dummy_spanned(LitKind::Bool(false))),
-            span: DUMMY_SP,
-        };
-        assert!(Cfg::parse(&mi).is_err());
+        with_globals(|| {
+            let mi = MetaItem {
+                name: Symbol::intern("foo"),
+                node: MetaItemKind::NameValue(dummy_spanned(LitKind::Bool(false))),
+                span: DUMMY_SP,
+            };
+            assert!(Cfg::parse(&mi).is_err());
 
-        let mi = MetaItem {
-            name: Symbol::intern("not"),
-            node: MetaItemKind::List(vec![
-                dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                    name: Symbol::intern("a"),
-                    node: MetaItemKind::Word,
-                    span: DUMMY_SP,
-                })),
-                dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                    name: Symbol::intern("b"),
-                    node: MetaItemKind::Word,
-                    span: DUMMY_SP,
-                })),
-            ]),
-            span: DUMMY_SP,
-        };
-        assert!(Cfg::parse(&mi).is_err());
+            let mi = MetaItem {
+                name: Symbol::intern("not"),
+                node: MetaItemKind::List(vec![
+                    dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                        name: Symbol::intern("a"),
+                        node: MetaItemKind::Word,
+                        span: DUMMY_SP,
+                    })),
+                    dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                        name: Symbol::intern("b"),
+                        node: MetaItemKind::Word,
+                        span: DUMMY_SP,
+                    })),
+                ]),
+                span: DUMMY_SP,
+            };
+            assert!(Cfg::parse(&mi).is_err());
 
-        let mi = MetaItem {
-            name: Symbol::intern("not"),
-            node: MetaItemKind::List(vec![]),
-            span: DUMMY_SP,
-        };
-        assert!(Cfg::parse(&mi).is_err());
+            let mi = MetaItem {
+                name: Symbol::intern("not"),
+                node: MetaItemKind::List(vec![]),
+                span: DUMMY_SP,
+            };
+            assert!(Cfg::parse(&mi).is_err());
 
-        let mi = MetaItem {
-            name: Symbol::intern("foo"),
-            node: MetaItemKind::List(vec![
-                dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                    name: Symbol::intern("a"),
-                    node: MetaItemKind::Word,
-                    span: DUMMY_SP,
-                })),
-            ]),
-            span: DUMMY_SP,
-        };
-        assert!(Cfg::parse(&mi).is_err());
+            let mi = MetaItem {
+                name: Symbol::intern("foo"),
+                node: MetaItemKind::List(vec![
+                    dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                        name: Symbol::intern("a"),
+                        node: MetaItemKind::Word,
+                        span: DUMMY_SP,
+                    })),
+                ]),
+                span: DUMMY_SP,
+            };
+            assert!(Cfg::parse(&mi).is_err());
 
-        let mi = MetaItem {
-            name: Symbol::intern("all"),
-            node: MetaItemKind::List(vec![
-                dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                    name: Symbol::intern("foo"),
-                    node: MetaItemKind::List(vec![]),
-                    span: DUMMY_SP,
-                })),
-                dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                    name: Symbol::intern("b"),
-                    node: MetaItemKind::Word,
-                    span: DUMMY_SP,
-                })),
-            ]),
-            span: DUMMY_SP,
-        };
-        assert!(Cfg::parse(&mi).is_err());
+            let mi = MetaItem {
+                name: Symbol::intern("all"),
+                node: MetaItemKind::List(vec![
+                    dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                        name: Symbol::intern("foo"),
+                        node: MetaItemKind::List(vec![]),
+                        span: DUMMY_SP,
+                    })),
+                    dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                        name: Symbol::intern("b"),
+                        node: MetaItemKind::Word,
+                        span: DUMMY_SP,
+                    })),
+                ]),
+                span: DUMMY_SP,
+            };
+            assert!(Cfg::parse(&mi).is_err());
 
-        let mi = MetaItem {
-            name: Symbol::intern("any"),
-            node: MetaItemKind::List(vec![
-                dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                    name: Symbol::intern("a"),
-                    node: MetaItemKind::Word,
-                    span: DUMMY_SP,
-                })),
-                dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                    name: Symbol::intern("foo"),
-                    node: MetaItemKind::List(vec![]),
-                    span: DUMMY_SP,
-                })),
-            ]),
-            span: DUMMY_SP,
-        };
-        assert!(Cfg::parse(&mi).is_err());
+            let mi = MetaItem {
+                name: Symbol::intern("any"),
+                node: MetaItemKind::List(vec![
+                    dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                        name: Symbol::intern("a"),
+                        node: MetaItemKind::Word,
+                        span: DUMMY_SP,
+                    })),
+                    dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                        name: Symbol::intern("foo"),
+                        node: MetaItemKind::List(vec![]),
+                        span: DUMMY_SP,
+                    })),
+                ]),
+                span: DUMMY_SP,
+            };
+            assert!(Cfg::parse(&mi).is_err());
 
-        let mi = MetaItem {
-            name: Symbol::intern("not"),
-            node: MetaItemKind::List(vec![
-                dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
-                    name: Symbol::intern("foo"),
-                    node: MetaItemKind::List(vec![]),
-                    span: DUMMY_SP,
-                })),
-            ]),
-            span: DUMMY_SP,
-        };
-        assert!(Cfg::parse(&mi).is_err());
+            let mi = MetaItem {
+                name: Symbol::intern("not"),
+                node: MetaItemKind::List(vec![
+                    dummy_spanned(NestedMetaItemKind::MetaItem(MetaItem {
+                        name: Symbol::intern("foo"),
+                        node: MetaItemKind::List(vec![]),
+                        span: DUMMY_SP,
+                    })),
+                ]),
+                span: DUMMY_SP,
+            };
+            assert!(Cfg::parse(&mi).is_err());
+        })
     }
 
     #[test]
     fn test_render_short_html() {
-        assert_eq!(
-            word_cfg("unix").render_short_html(),
-            "Unix"
-        );
-        assert_eq!(
-            name_value_cfg("target_os", "macos").render_short_html(),
-            "macOS"
-        );
-        assert_eq!(
-            name_value_cfg("target_pointer_width", "16").render_short_html(),
-            "16-bit"
-        );
-        assert_eq!(
-            name_value_cfg("target_endian", "little").render_short_html(),
-            "Little-endian"
-        );
-        assert_eq!(
-            (!word_cfg("windows")).render_short_html(),
-            "Non-Windows"
-        );
-        assert_eq!(
-            (word_cfg("unix") & word_cfg("windows")).render_short_html(),
-            "Unix and Windows"
-        );
-        assert_eq!(
-            (word_cfg("unix") | word_cfg("windows")).render_short_html(),
-            "Unix or Windows"
-        );
-        assert_eq!(
-            (
-                word_cfg("unix") & word_cfg("windows") & word_cfg("debug_assertions")
-            ).render_short_html(),
-            "Unix and Windows and debug-assertions enabled"
-        );
-        assert_eq!(
-            (
-                word_cfg("unix") | word_cfg("windows") | word_cfg("debug_assertions")
-            ).render_short_html(),
-            "Unix or Windows or debug-assertions enabled"
-        );
-        assert_eq!(
-            (
-                !(word_cfg("unix") | word_cfg("windows") | word_cfg("debug_assertions"))
-            ).render_short_html(),
-            "Neither Unix nor Windows nor debug-assertions enabled"
-        );
-        assert_eq!(
-            (
-                (word_cfg("unix") & name_value_cfg("target_arch", "x86_64")) |
-                (word_cfg("windows") & name_value_cfg("target_pointer_width", "64"))
-            ).render_short_html(),
-            "Unix and x86-64, or Windows and 64-bit"
-        );
-        assert_eq!(
-            (!(word_cfg("unix") & word_cfg("windows"))).render_short_html(),
-            "Not (Unix and Windows)"
-        );
-        assert_eq!(
-            (
-                (word_cfg("debug_assertions") | word_cfg("windows")) & word_cfg("unix")
-            ).render_short_html(),
-            "(Debug-assertions enabled or Windows) and Unix"
-        );
+        with_globals(|| {
+            assert_eq!(
+                word_cfg("unix").render_short_html(),
+                "Unix"
+            );
+            assert_eq!(
+                name_value_cfg("target_os", "macos").render_short_html(),
+                "macOS"
+            );
+            assert_eq!(
+                name_value_cfg("target_pointer_width", "16").render_short_html(),
+                "16-bit"
+            );
+            assert_eq!(
+                name_value_cfg("target_endian", "little").render_short_html(),
+                "Little-endian"
+            );
+            assert_eq!(
+                (!word_cfg("windows")).render_short_html(),
+                "Non-Windows"
+            );
+            assert_eq!(
+                (word_cfg("unix") & word_cfg("windows")).render_short_html(),
+                "Unix and Windows"
+            );
+            assert_eq!(
+                (word_cfg("unix") | word_cfg("windows")).render_short_html(),
+                "Unix or Windows"
+            );
+            assert_eq!(
+                (
+                    word_cfg("unix") & word_cfg("windows") & word_cfg("debug_assertions")
+                ).render_short_html(),
+                "Unix and Windows and debug-assertions enabled"
+            );
+            assert_eq!(
+                (
+                    word_cfg("unix") | word_cfg("windows") | word_cfg("debug_assertions")
+                ).render_short_html(),
+                "Unix or Windows or debug-assertions enabled"
+            );
+            assert_eq!(
+                (
+                    !(word_cfg("unix") | word_cfg("windows") | word_cfg("debug_assertions"))
+                ).render_short_html(),
+                "Neither Unix nor Windows nor debug-assertions enabled"
+            );
+            assert_eq!(
+                (
+                    (word_cfg("unix") & name_value_cfg("target_arch", "x86_64")) |
+                    (word_cfg("windows") & name_value_cfg("target_pointer_width", "64"))
+                ).render_short_html(),
+                "Unix and x86-64, or Windows and 64-bit"
+            );
+            assert_eq!(
+                (!(word_cfg("unix") & word_cfg("windows"))).render_short_html(),
+                "Not (Unix and Windows)"
+            );
+            assert_eq!(
+                (
+                    (word_cfg("debug_assertions") | word_cfg("windows")) & word_cfg("unix")
+                ).render_short_html(),
+                "(Debug-assertions enabled or Windows) and Unix"
+            );
+        })
     }
 
     #[test]
     fn test_render_long_html() {
-        assert_eq!(
-            word_cfg("unix").render_long_html(),
-            "This is supported on <strong>Unix</strong> only."
-        );
-        assert_eq!(
-            name_value_cfg("target_os", "macos").render_long_html(),
-            "This is supported on <strong>macOS</strong> only."
-        );
-        assert_eq!(
-            name_value_cfg("target_pointer_width", "16").render_long_html(),
-            "This is supported on <strong>16-bit</strong> only."
-        );
-        assert_eq!(
-            name_value_cfg("target_endian", "little").render_long_html(),
-            "This is supported on <strong>little-endian</strong> only."
-        );
-        assert_eq!(
-            (!word_cfg("windows")).render_long_html(),
-            "This is supported on <strong>non-Windows</strong> only."
-        );
-        assert_eq!(
-            (word_cfg("unix") & word_cfg("windows")).render_long_html(),
-            "This is supported on <strong>Unix and Windows</strong> only."
-        );
-        assert_eq!(
-            (word_cfg("unix") | word_cfg("windows")).render_long_html(),
-            "This is supported on <strong>Unix or Windows</strong> only."
-        );
-        assert_eq!(
-            (
-                word_cfg("unix") & word_cfg("windows") & word_cfg("debug_assertions")
-            ).render_long_html(),
-            "This is supported on <strong>Unix and Windows and debug-assertions enabled</strong> \
-                only."
-        );
-        assert_eq!(
-            (
-                word_cfg("unix") | word_cfg("windows") | word_cfg("debug_assertions")
-            ).render_long_html(),
-            "This is supported on <strong>Unix or Windows or debug-assertions enabled</strong> \
-                only."
-        );
-        assert_eq!(
-            (
-                !(word_cfg("unix") | word_cfg("windows") | word_cfg("debug_assertions"))
-            ).render_long_html(),
-            "This is supported on <strong>neither Unix nor Windows nor debug-assertions \
-                enabled</strong>."
-        );
-        assert_eq!(
-            (
-                (word_cfg("unix") & name_value_cfg("target_arch", "x86_64")) |
-                (word_cfg("windows") & name_value_cfg("target_pointer_width", "64"))
-            ).render_long_html(),
-            "This is supported on <strong>Unix and x86-64, or Windows and 64-bit</strong> only."
-        );
-        assert_eq!(
-            (!(word_cfg("unix") & word_cfg("windows"))).render_long_html(),
-            "This is supported on <strong>not (Unix and Windows)</strong>."
-        );
-        assert_eq!(
-            (
-                (word_cfg("debug_assertions") | word_cfg("windows")) & word_cfg("unix")
-            ).render_long_html(),
-            "This is supported on <strong>(debug-assertions enabled or Windows) and Unix</strong> \
-                only."
-        );
+        with_globals(|| {
+            assert_eq!(
+                word_cfg("unix").render_long_html(),
+                "This is supported on <strong>Unix</strong> only."
+            );
+            assert_eq!(
+                name_value_cfg("target_os", "macos").render_long_html(),
+                "This is supported on <strong>macOS</strong> only."
+            );
+            assert_eq!(
+                name_value_cfg("target_pointer_width", "16").render_long_html(),
+                "This is supported on <strong>16-bit</strong> only."
+            );
+            assert_eq!(
+                name_value_cfg("target_endian", "little").render_long_html(),
+                "This is supported on <strong>little-endian</strong> only."
+            );
+            assert_eq!(
+                (!word_cfg("windows")).render_long_html(),
+                "This is supported on <strong>non-Windows</strong> only."
+            );
+            assert_eq!(
+                (word_cfg("unix") & word_cfg("windows")).render_long_html(),
+                "This is supported on <strong>Unix and Windows</strong> only."
+            );
+            assert_eq!(
+                (word_cfg("unix") | word_cfg("windows")).render_long_html(),
+                "This is supported on <strong>Unix or Windows</strong> only."
+            );
+            assert_eq!(
+                (
+                    word_cfg("unix") & word_cfg("windows") & word_cfg("debug_assertions")
+                ).render_long_html(),
+                "This is supported on <strong>Unix and Windows and debug-assertions enabled\
+                 </strong> only."
+            );
+            assert_eq!(
+                (
+                    word_cfg("unix") | word_cfg("windows") | word_cfg("debug_assertions")
+                ).render_long_html(),
+                "This is supported on <strong>Unix or Windows or debug-assertions enabled\
+                 </strong> only."
+            );
+            assert_eq!(
+                (
+                    !(word_cfg("unix") | word_cfg("windows") | word_cfg("debug_assertions"))
+                ).render_long_html(),
+                "This is supported on <strong>neither Unix nor Windows nor debug-assertions \
+                    enabled</strong>."
+            );
+            assert_eq!(
+                (
+                    (word_cfg("unix") & name_value_cfg("target_arch", "x86_64")) |
+                    (word_cfg("windows") & name_value_cfg("target_pointer_width", "64"))
+                ).render_long_html(),
+                "This is supported on <strong>Unix and x86-64, or Windows and 64-bit</strong> \
+                 only."
+            );
+            assert_eq!(
+                (!(word_cfg("unix") & word_cfg("windows"))).render_long_html(),
+                "This is supported on <strong>not (Unix and Windows)</strong>."
+            );
+            assert_eq!(
+                (
+                    (word_cfg("debug_assertions") | word_cfg("windows")) & word_cfg("unix")
+                ).render_long_html(),
+                "This is supported on <strong>(debug-assertions enabled or Windows) and Unix\
+                </strong> only."
+            );
+        })
     }
 }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -102,7 +102,9 @@ pub fn main() {
     const STACK_SIZE: usize = 32_000_000; // 32MB
     env_logger::init();
     let res = std::thread::Builder::new().stack_size(STACK_SIZE).spawn(move || {
-        get_args().map(|args| main_args(&args)).unwrap_or(1)
+        syntax::with_globals(move || {
+            get_args().map(|args| main_args(&args)).unwrap_or(1)
+        })
     }).unwrap().join().unwrap_or(101);
     process::exit(res as i32);
 }
@@ -554,7 +556,8 @@ where R: 'static + Send, F: 'static + Send + FnOnce(Output) -> R {
     });
 
     let (tx, rx) = channel();
-    rustc_driver::monitor(move || {
+
+    rustc_driver::monitor(move || syntax::with_globals(move || {
         use rustc::session::config::Input;
 
         let (mut krate, renderinfo) =
@@ -623,7 +626,7 @@ where R: 'static + Send, F: 'static + Send + FnOnce(Output) -> R {
         let krate = pm.run_plugins(krate);
 
         tx.send(f(Output { krate: krate, renderinfo: renderinfo, passes: passes })).unwrap();
-    });
+    }));
     rx.recv().unwrap()
 }
 

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -35,6 +35,7 @@ use rustc_resolve::MakeGlobMap;
 use syntax::ast;
 use syntax::codemap::CodeMap;
 use syntax::feature_gate::UnstableFeatures;
+use syntax::with_globals;
 use syntax_pos::{BytePos, DUMMY_SP, Pos, Span, FileName};
 use errors;
 use errors::emitter::ColorConfig;
@@ -518,7 +519,7 @@ impl Collector {
                 let panic = io::set_panic(None);
                 let print = io::set_print(None);
                 match {
-                    rustc_driver::in_rustc_thread(move || {
+                    rustc_driver::in_rustc_thread(move || with_globals(move || {
                         io::set_panic(panic);
                         io::set_print(print);
                         run_test(&test,
@@ -536,7 +537,7 @@ impl Collector {
                                  &opts,
                                  maybe_sysroot,
                                  linker)
-                    })
+                    }))
                 } {
                     Ok(()) => (),
                     Err(err) => panic::resume_unwind(err),

--- a/src/libsyntax/Cargo.toml
+++ b/src/libsyntax/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["dylib"]
 bitflags = "1.0"
 serialize = { path = "../libserialize" }
 log = "0.4"
+scoped-tls = "0.1"
 syntax_pos = { path = "../libsyntax_pos" }
 rustc_cratesio_shim = { path = "../librustc_cratesio_shim" }
 rustc_errors = { path = "../librustc_errors" }

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -39,8 +39,11 @@ extern crate std_unicode;
 pub extern crate rustc_errors as errors;
 extern crate syntax_pos;
 extern crate rustc_data_structures;
+#[macro_use] extern crate scoped_tls;
 
 extern crate serialize as rustc_serialize; // used by deriving
+
+use rustc_data_structures::sync::Lock;
 
 // A variant of 'try!' that panics on an Err. This is used as a crutch on the
 // way towards a non-panic!-prone parser. It should be used for fatal parsing
@@ -71,6 +74,33 @@ macro_rules! unwrap_or {
         }
     }
 }
+
+struct Globals {
+    used_attrs: Lock<Vec<u64>>,
+    known_attrs: Lock<Vec<u64>>,
+    syntax_pos_globals: syntax_pos::Globals,
+}
+
+impl Globals {
+    fn new() -> Globals {
+        Globals {
+            used_attrs: Lock::new(Vec::new()),
+            known_attrs: Lock::new(Vec::new()),
+            syntax_pos_globals: syntax_pos::Globals::new(),
+        }
+    }
+}
+
+pub fn with_globals<F, R>(f: F) -> R
+    where F: FnOnce() -> R
+{
+    let globals = Globals::new();
+    GLOBALS.set(&globals, || {
+        syntax_pos::GLOBALS.set(&globals.syntax_pos_globals, f)
+    })
+}
+
+scoped_thread_local!(static GLOBALS: Globals);
 
 #[macro_use]
 pub mod diagnostics {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -3178,36 +3178,41 @@ mod tests {
     use ast;
     use codemap;
     use syntax_pos;
+    use with_globals;
 
     #[test]
     fn test_fun_to_string() {
-        let abba_ident = ast::Ident::from_str("abba");
+        with_globals(|| {
+            let abba_ident = ast::Ident::from_str("abba");
 
-        let decl = ast::FnDecl {
-            inputs: Vec::new(),
-            output: ast::FunctionRetTy::Default(syntax_pos::DUMMY_SP),
-            variadic: false
-        };
-        let generics = ast::Generics::default();
-        assert_eq!(fun_to_string(&decl, ast::Unsafety::Normal,
-                                 ast::Constness::NotConst,
-                                 abba_ident, &generics),
-                   "fn abba()");
+            let decl = ast::FnDecl {
+                inputs: Vec::new(),
+                output: ast::FunctionRetTy::Default(syntax_pos::DUMMY_SP),
+                variadic: false
+            };
+            let generics = ast::Generics::default();
+            assert_eq!(fun_to_string(&decl, ast::Unsafety::Normal,
+                                    ast::Constness::NotConst,
+                                    abba_ident, &generics),
+                    "fn abba()");
+        })
     }
 
     #[test]
     fn test_variant_to_string() {
-        let ident = ast::Ident::from_str("principal_skinner");
+        with_globals(|| {
+            let ident = ast::Ident::from_str("principal_skinner");
 
-        let var = codemap::respan(syntax_pos::DUMMY_SP, ast::Variant_ {
-            name: ident,
-            attrs: Vec::new(),
-            // making this up as I go.... ?
-            data: ast::VariantData::Unit(ast::DUMMY_NODE_ID),
-            disr_expr: None,
-        });
+            let var = codemap::respan(syntax_pos::DUMMY_SP, ast::Variant_ {
+                name: ident,
+                attrs: Vec::new(),
+                // making this up as I go.... ?
+                data: ast::VariantData::Unit(ast::DUMMY_NODE_ID),
+                disr_expr: None,
+            });
 
-        let varstr = variant_to_string(&var);
-        assert_eq!(varstr, "principal_skinner");
+            let varstr = variant_to_string(&var);
+            assert_eq!(varstr, "principal_skinner");
+        })
     }
 }

--- a/src/libsyntax/test_snippet.rs
+++ b/src/libsyntax/test_snippet.rs
@@ -18,6 +18,7 @@ use std::str;
 use std::sync::{Arc, Mutex};
 use std::path::Path;
 use syntax_pos::{BytePos, NO_EXPANSION, Span, MultiSpan};
+use with_globals;
 
 /// Identify a position in the text by the Nth occurrence of a string.
 struct Position {
@@ -46,37 +47,39 @@ impl<T: Write> Write for Shared<T> {
 }
 
 fn test_harness(file_text: &str, span_labels: Vec<SpanLabel>, expected_output: &str) {
-    let output = Arc::new(Mutex::new(Vec::new()));
+    with_globals(|| {
+        let output = Arc::new(Mutex::new(Vec::new()));
 
-    let code_map = Lrc::new(CodeMap::new(FilePathMapping::empty()));
-    code_map.new_filemap_and_lines(Path::new("test.rs"), &file_text);
+        let code_map = Lrc::new(CodeMap::new(FilePathMapping::empty()));
+        code_map.new_filemap_and_lines(Path::new("test.rs"), &file_text);
 
-    let primary_span = make_span(&file_text, &span_labels[0].start, &span_labels[0].end);
-    let mut msp = MultiSpan::from_span(primary_span);
-    for span_label in span_labels {
-        let span = make_span(&file_text, &span_label.start, &span_label.end);
-        msp.push_span_label(span, span_label.label.to_string());
-        println!("span: {:?} label: {:?}", span, span_label.label);
-        println!("text: {:?}", code_map.span_to_snippet(span));
-    }
+        let primary_span = make_span(&file_text, &span_labels[0].start, &span_labels[0].end);
+        let mut msp = MultiSpan::from_span(primary_span);
+        for span_label in span_labels {
+            let span = make_span(&file_text, &span_label.start, &span_label.end);
+            msp.push_span_label(span, span_label.label.to_string());
+            println!("span: {:?} label: {:?}", span, span_label.label);
+            println!("text: {:?}", code_map.span_to_snippet(span));
+        }
 
-    let emitter = EmitterWriter::new(Box::new(Shared { data: output.clone() }),
-                                     Some(code_map.clone()),
-                                     false,
-                                     false);
-    let handler = Handler::with_emitter(true, false, Box::new(emitter));
-    handler.span_err(msp, "foo");
+        let emitter = EmitterWriter::new(Box::new(Shared { data: output.clone() }),
+                                        Some(code_map.clone()),
+                                        false,
+                                        false);
+        let handler = Handler::with_emitter(true, false, Box::new(emitter));
+        handler.span_err(msp, "foo");
 
-    assert!(expected_output.chars().next() == Some('\n'),
-            "expected output should begin with newline");
-    let expected_output = &expected_output[1..];
+        assert!(expected_output.chars().next() == Some('\n'),
+                "expected output should begin with newline");
+        let expected_output = &expected_output[1..];
 
-    let bytes = output.lock().unwrap();
-    let actual_output = str::from_utf8(&bytes).unwrap();
-    println!("expected output:\n------\n{}------", expected_output);
-    println!("actual output:\n------\n{}------", actual_output);
+        let bytes = output.lock().unwrap();
+        let actual_output = str::from_utf8(&bytes).unwrap();
+        println!("expected output:\n------\n{}------", expected_output);
+        println!("actual output:\n------\n{}------", actual_output);
 
-    assert!(expected_output == actual_output)
+        assert!(expected_output == actual_output)
+    })
 }
 
 fn make_span(file_text: &str, start: &Position, end: &Position) -> Span {

--- a/src/libsyntax/tokenstream.rs
+++ b/src/libsyntax/tokenstream.rs
@@ -599,6 +599,7 @@ impl Hash for ThinTokenStream {
 mod tests {
     use super::*;
     use syntax::ast::Ident;
+    use with_globals;
     use syntax_pos::{Span, BytePos, NO_EXPANSION};
     use parse::token::Token;
     use util::parser_testing::string_to_stream;
@@ -613,67 +614,83 @@ mod tests {
 
     #[test]
     fn test_concat() {
-        let test_res = string_to_ts("foo::bar::baz");
-        let test_fst = string_to_ts("foo::bar");
-        let test_snd = string_to_ts("::baz");
-        let eq_res = TokenStream::concat(vec![test_fst, test_snd]);
-        assert_eq!(test_res.trees().count(), 5);
-        assert_eq!(eq_res.trees().count(), 5);
-        assert_eq!(test_res.eq_unspanned(&eq_res), true);
+        with_globals(|| {
+            let test_res = string_to_ts("foo::bar::baz");
+            let test_fst = string_to_ts("foo::bar");
+            let test_snd = string_to_ts("::baz");
+            let eq_res = TokenStream::concat(vec![test_fst, test_snd]);
+            assert_eq!(test_res.trees().count(), 5);
+            assert_eq!(eq_res.trees().count(), 5);
+            assert_eq!(test_res.eq_unspanned(&eq_res), true);
+        })
     }
 
     #[test]
     fn test_to_from_bijection() {
-        let test_start = string_to_ts("foo::bar(baz)");
-        let test_end = test_start.trees().collect();
-        assert_eq!(test_start, test_end)
+        with_globals(|| {
+            let test_start = string_to_ts("foo::bar(baz)");
+            let test_end = test_start.trees().collect();
+            assert_eq!(test_start, test_end)
+        })
     }
 
     #[test]
     fn test_eq_0() {
-        let test_res = string_to_ts("foo");
-        let test_eqs = string_to_ts("foo");
-        assert_eq!(test_res, test_eqs)
+        with_globals(|| {
+            let test_res = string_to_ts("foo");
+            let test_eqs = string_to_ts("foo");
+            assert_eq!(test_res, test_eqs)
+        })
     }
 
     #[test]
     fn test_eq_1() {
-        let test_res = string_to_ts("::bar::baz");
-        let test_eqs = string_to_ts("::bar::baz");
-        assert_eq!(test_res, test_eqs)
+        with_globals(|| {
+            let test_res = string_to_ts("::bar::baz");
+            let test_eqs = string_to_ts("::bar::baz");
+            assert_eq!(test_res, test_eqs)
+        })
     }
 
     #[test]
     fn test_eq_3() {
-        let test_res = string_to_ts("");
-        let test_eqs = string_to_ts("");
-        assert_eq!(test_res, test_eqs)
+        with_globals(|| {
+            let test_res = string_to_ts("");
+            let test_eqs = string_to_ts("");
+            assert_eq!(test_res, test_eqs)
+        })
     }
 
     #[test]
     fn test_diseq_0() {
-        let test_res = string_to_ts("::bar::baz");
-        let test_eqs = string_to_ts("bar::baz");
-        assert_eq!(test_res == test_eqs, false)
+        with_globals(|| {
+            let test_res = string_to_ts("::bar::baz");
+            let test_eqs = string_to_ts("bar::baz");
+            assert_eq!(test_res == test_eqs, false)
+        })
     }
 
     #[test]
     fn test_diseq_1() {
-        let test_res = string_to_ts("(bar,baz)");
-        let test_eqs = string_to_ts("bar,baz");
-        assert_eq!(test_res == test_eqs, false)
+        with_globals(|| {
+            let test_res = string_to_ts("(bar,baz)");
+            let test_eqs = string_to_ts("bar,baz");
+            assert_eq!(test_res == test_eqs, false)
+        })
     }
 
     #[test]
     fn test_is_empty() {
-        let test0: TokenStream = Vec::<TokenTree>::new().into_iter().collect();
-        let test1: TokenStream =
-            TokenTree::Token(sp(0, 1), Token::Ident(Ident::from_str("a"))).into();
-        let test2 = string_to_ts("foo(bar::baz)");
+        with_globals(|| {
+            let test0: TokenStream = Vec::<TokenTree>::new().into_iter().collect();
+            let test1: TokenStream =
+                TokenTree::Token(sp(0, 1), Token::Ident(Ident::from_str("a"))).into();
+            let test2 = string_to_ts("foo(bar::baz)");
 
-        assert_eq!(test0.is_empty(), true);
-        assert_eq!(test1.is_empty(), false);
-        assert_eq!(test2.is_empty(), false);
+            assert_eq!(test0.is_empty(), true);
+            assert_eq!(test1.is_empty(), false);
+            assert_eq!(test2.is_empty(), false);
+        })
     }
 
     #[test]

--- a/src/libsyntax_pos/Cargo.toml
+++ b/src/libsyntax_pos/Cargo.toml
@@ -11,4 +11,5 @@ crate-type = ["dylib"]
 [dependencies]
 serialize = { path = "../libserialize" }
 rustc_data_structures = { path = "../librustc_data_structures" }
+scoped-tls = { version = "0.1.1", features = ["nightly"] }
 unicode-width = "0.1.4"

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -15,11 +15,11 @@
 //! and definition contexts*. J. Funct. Program. 22, 2 (March 2012), 181-216.
 //! DOI=10.1017/S0956796812000093 <http://dx.doi.org/10.1017/S0956796812000093>
 
+use GLOBALS;
 use Span;
 use symbol::{Ident, Symbol};
 
 use serialize::{Encodable, Decodable, Encoder, Decoder};
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt;
 
@@ -119,7 +119,7 @@ impl Mark {
     }
 }
 
-struct HygieneData {
+pub struct HygieneData {
     marks: Vec<MarkData>,
     syntax_contexts: Vec<SyntaxContextData>,
     markings: HashMap<(SyntaxContext, Mark), SyntaxContext>,
@@ -127,7 +127,7 @@ struct HygieneData {
 }
 
 impl HygieneData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         HygieneData {
             marks: vec![MarkData {
                 parent: Mark::root(),
@@ -145,10 +145,7 @@ impl HygieneData {
     }
 
     fn with<T, F: FnOnce(&mut HygieneData) -> T>(f: F) -> T {
-        thread_local! {
-            static HYGIENE_DATA: RefCell<HygieneData> = RefCell::new(HygieneData::new());
-        }
-        HYGIENE_DATA.with(|data| f(&mut *data.borrow_mut()))
+        GLOBALS.with(|globals| f(&mut *globals.hygiene_data.borrow_mut()))
     }
 }
 

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -35,9 +35,12 @@ use std::ops::{Add, Sub};
 use std::path::PathBuf;
 
 use rustc_data_structures::stable_hasher::StableHasher;
-use rustc_data_structures::sync::Lrc;
+use rustc_data_structures::sync::{Lrc, Lock};
 
 extern crate rustc_data_structures;
+
+#[macro_use]
+extern crate scoped_tls;
 
 use serialize::{Encodable, Decodable, Encoder, Decoder};
 
@@ -53,6 +56,24 @@ mod span_encoding;
 pub use span_encoding::{Span, DUMMY_SP};
 
 pub mod symbol;
+
+pub struct Globals {
+    symbol_interner: Lock<symbol::Interner>,
+    span_interner: Lock<span_encoding::SpanInterner>,
+    hygiene_data: Lock<hygiene::HygieneData>,
+}
+
+impl Globals {
+    pub fn new() -> Globals {
+        Globals {
+            symbol_interner: Lock::new(symbol::Interner::fresh()),
+            span_interner: Lock::new(span_encoding::SpanInterner::default()),
+            hygiene_data: Lock::new(hygiene::HygieneData::new()),
+        }
+    }
+}
+
+scoped_thread_local!(pub static GLOBALS: Globals);
 
 /// Differentiates between real files and common virtual files
 #[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash, RustcDecodable, RustcEncodable)]

--- a/src/libsyntax_pos/span_encoding.rs
+++ b/src/libsyntax_pos/span_encoding.rs
@@ -14,11 +14,11 @@
 // The encoding format for inline spans were obtained by optimizing over crates in rustc/libstd.
 // See https://internals.rust-lang.org/t/rfc-compiler-refactoring-spans/1357/28
 
+use GLOBALS;
 use {BytePos, SpanData};
 use hygiene::SyntaxContext;
 
 use rustc_data_structures::fx::FxHashMap;
-use std::cell::RefCell;
 use std::hash::{Hash, Hasher};
 
 /// A compressed span.
@@ -133,7 +133,7 @@ fn decode(span: Span) -> SpanData {
 }
 
 #[derive(Default)]
-struct SpanInterner {
+pub struct SpanInterner {
     spans: FxHashMap<SpanData, u32>,
     span_data: Vec<SpanData>,
 }
@@ -156,11 +156,8 @@ impl SpanInterner {
     }
 }
 
-// If an interner exists in TLS, return it. Otherwise, prepare a fresh one.
+// If an interner exists, return it. Otherwise, prepare a fresh one.
 #[inline]
 fn with_span_interner<T, F: FnOnce(&mut SpanInterner) -> T>(f: F) -> T {
-    thread_local!(static INTERNER: RefCell<SpanInterner> = {
-        RefCell::new(SpanInterner::default())
-    });
-    INTERNER.with(|interner| f(&mut *interner.borrow_mut()))
+    GLOBALS.with(|globals| f(&mut *globals.span_interner.lock()))
 }

--- a/src/test/run-fail-fulldeps/qquote.rs
+++ b/src/test/run-fail-fulldeps/qquote.rs
@@ -24,6 +24,10 @@ use syntax::symbol::Symbol;
 use syntax_pos::DUMMY_SP;
 
 fn main() {
+    syntax::with_globals(|| run());
+}
+
+fn run() {
     let ps = syntax::parse::ParseSess::new(codemap::FilePathMapping::empty());
     let mut resolver = syntax::ext::base::DummyResolver;
     let mut cx = syntax::ext::base::ExtCtxt::new(

--- a/src/test/run-make/issue-19371/foo.rs
+++ b/src/test/run-make/issue-19371/foo.rs
@@ -69,18 +69,20 @@ fn basic_sess(sysroot: PathBuf) -> (Session, Rc<CStore>, Box<TransCrate>) {
 }
 
 fn compile(code: String, output: PathBuf, sysroot: PathBuf) {
-    let (sess, cstore, trans) = basic_sess(sysroot);
-    let control = CompileController::basic();
-    let input = Input::Str { name: FileName::Anon, input: code };
-    let _ = compile_input(
-        trans,
-        &sess,
-        &cstore,
-        &None,
-        &input,
-        &None,
-        &Some(output),
-        None,
-        &control
-    );
+    syntax::with_globals(|| {
+        let (sess, cstore, trans) = basic_sess(sysroot);
+        let control = CompileController::basic();
+        let input = Input::Str { name: FileName::Anon, input: code };
+        let _ = compile_input(
+            trans,
+            &sess,
+            &cstore,
+            &None,
+            &input,
+            &None,
+            &Some(output),
+            None,
+            &control
+        );
+    });
 }

--- a/src/test/run-pass-fulldeps/ast_stmt_expr_attr.rs
+++ b/src/test/run-pass-fulldeps/ast_stmt_expr_attr.rs
@@ -115,6 +115,10 @@ fn reject_stmt_parse(es: &str) {
 }
 
 fn main() {
+    syntax::with_globals(|| run());
+}
+
+fn run() {
     let both = &["#[attr]", "#![attr]"];
     let outer = &["#[attr]"];
     let none = &[];

--- a/src/test/run-pass-fulldeps/issue-35829.rs
+++ b/src/test/run-pass-fulldeps/issue-35829.rs
@@ -27,6 +27,10 @@ use syntax::ptr::P;
 use rustc_data_structures::sync::Lrc;
 
 fn main() {
+    syntax::with_globals(|| run());
+}
+
+fn run() {
     let parse_sess = ParseSess::new(FilePathMapping::empty());
     let exp_cfg = ExpansionConfig::default("issue_35829".to_owned());
     let mut resolver = DummyResolver;

--- a/src/test/run-pass-fulldeps/pprust-expr-roundtrip.rs
+++ b/src/test/run-pass-fulldeps/pprust-expr-roundtrip.rs
@@ -221,8 +221,11 @@ impl Folder for AddParens {
     }
 }
 
-
 fn main() {
+    syntax::with_globals(|| run());
+}
+
+fn run() {
     let ps = ParseSess::new(FilePathMapping::empty());
 
     iter_exprs(2, &mut |e| {

--- a/src/test/run-pass-fulldeps/qquote.rs
+++ b/src/test/run-pass-fulldeps/qquote.rs
@@ -21,6 +21,10 @@ use syntax::symbol::Symbol;
 use syntax_pos::DUMMY_SP;
 
 fn main() {
+    syntax::with_globals(|| run());
+}
+
+fn run() {
     let ps = syntax::parse::ParseSess::new(FilePathMapping::empty());
     let mut resolver = syntax::ext::base::DummyResolver;
     let mut cx = syntax::ext::base::ExtCtxt::new(

--- a/src/tools/error_index_generator/main.rs
+++ b/src/tools/error_index_generator/main.rs
@@ -263,7 +263,10 @@ fn main() {
         *slot.borrow_mut() = Some((None, String::from("https://play.rust-lang.org/")));
     });
     let (format, dst) = parse_args();
-    if let Err(e) = main_with_result(format, &dst) {
+    let result = syntax::with_globals(move || {
+        main_with_result(format, &dst)
+    });
+    if let Err(e) = result {
         panic!("{}", e.description());
     }
 }

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -93,6 +93,7 @@ static WHITELIST: &'static [Crate] = &[
     Crate("regex-syntax"),
     Crate("remove_dir_all"),
     Crate("rustc-demangle"),
+    Crate("scoped-tls"),
     Crate("smallvec"),
     Crate("stable_deref_trait"),
     Crate("tempdir"),


### PR DESCRIPTION
This moves `syntax` and `syntax_pos` globals into a struct which are pointed to by thread locals. Most of the changes here are indentation changes in test. It would probably be a good idea to ignore whitespace changes while reviewing. Some indentation is unchanged to avoid merge conflicts.

r? @michaelwoerister