### PR TITLE
Make `assert` a built-in procedural macro

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -76,6 +76,7 @@ macro_rules! panic {
 /// ```
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(stage0)]
 macro_rules! assert {
     ($cond:expr) => (
         if !$cond {
@@ -783,5 +784,19 @@ mod builtin {
     macro_rules! include {
         ($file:expr) => ({ /* compiler built-in */ });
         ($file:expr,) => ({ /* compiler built-in */ });
+    }
+
+    /// Ensure that a boolean expression is `true` at runtime.
+    ///
+    /// For more information, see the documentation for [`std::assert!`].
+    ///
+    /// [`std::assert!`]: ../std/macro.assert.html
+    #[macro_export]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(dox)]
+    macro_rules! assert {
+        ($cond:expr) => ({ /* compiler built-in */ });
+        ($cond:expr,) => ({ /* compiler built-in */ });
+        ($cond:expr, $($arg:tt)+) => ({ /* compiler built-in */ });
     }
 }

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -355,8 +355,9 @@ use prelude::v1::*;
 // We want to re-export a few macros from core but libcore has already been
 // imported by the compiler (via our #[no_std] attribute) In this case we just
 // add a new crate name so we can attach the re-exports to it.
-#[macro_reexport(assert, assert_eq, assert_ne, debug_assert, debug_assert_eq,
+#[macro_reexport(assert_eq, assert_ne, debug_assert, debug_assert_eq,
                  debug_assert_ne, unreachable, unimplemented, write, writeln, try)]
+#[cfg_attr(stage0, macro_reexport(assert))]
 extern crate core as __core;
 
 #[macro_use]

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -719,6 +719,60 @@ pub mod builtin {
         ($file:expr) => ({ /* compiler built-in */ });
         ($file:expr,) => ({ /* compiler built-in */ });
     }
+
+    /// Ensure that a boolean expression is `true` at runtime.
+    ///
+    /// This will invoke the [`panic!`] macro if the provided expression cannot be
+    /// evaluated to `true` at runtime.
+    ///
+    /// # Uses
+    ///
+    /// Assertions are always checked in both debug and release builds, and cannot
+    /// be disabled. See [`debug_assert!`] for assertions that are not enabled in
+    /// release builds by default.
+    ///
+    /// Unsafe code relies on `assert!` to enforce run-time invariants that, if
+    /// violated could lead to unsafety.
+    ///
+    /// Other use-cases of `assert!` include [testing] and enforcing run-time
+    /// invariants in safe code (whose violation cannot result in unsafety).
+    ///
+    /// # Custom Messages
+    ///
+    /// This macro has a second form, where a custom panic message can
+    /// be provided with or without arguments for formatting.  See [`std::fmt`]
+    /// for syntax for this form.
+    ///
+    /// [`panic!`]: macro.panic.html
+    /// [`debug_assert!`]: macro.debug_assert.html
+    /// [testing]: ../book/second-edition/ch11-01-writing-tests.html#checking-results-with-the-assert-macro
+    /// [`std::fmt`]: ../std/fmt/index.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// // the panic message for these assertions is the stringified value of the
+    /// // expression given.
+    /// assert!(true);
+    ///
+    /// fn some_computation() -> bool { true } // a very simple function
+    ///
+    /// assert!(some_computation());
+    ///
+    /// // assert with a custom message
+    /// let x = true;
+    /// assert!(x, "x wasn't true!");
+    ///
+    /// let a = 3; let b = 27;
+    /// assert!(a + b == 30, "a = {}, b = {}", a, b);
+    /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[macro_export]
+    macro_rules! assert {
+        ($cond:expr) => ({ /* compiler built-in */ });
+        ($cond:expr,) => ({ /* compiler built-in */ });
+        ($cond:expr, $($arg:tt)+) => ({ /* compiler built-in */ });
+    }
 }
 
 /// A macro for defining #[cfg] if-else statements.

--- a/src/libsyntax_ext/assert.rs
+++ b/src/libsyntax_ext/assert.rs
@@ -15,7 +15,7 @@ use syntax::ext::build::AstBuilder;
 use syntax::parse::token;
 use syntax::print::pprust;
 use syntax::tokenstream::{TokenStream, TokenTree};
-use syntax_pos::Span;
+use syntax_pos::{Span, DUMMY_SP};
 
 pub fn expand_assert<'cx>(
     cx: &'cx mut ExtCtxt,
@@ -41,10 +41,18 @@ pub fn expand_assert<'cx>(
         tts: if let Some(ts) = custom_msg_args {
             ts.into()
         } else {
-            let panic_str = format!("assertion failed: {}", pprust::expr_to_string(&cond_expr));
-            TokenStream::from(token::Literal(
-                token::Lit::Str_(Name::intern(&panic_str)),
-                None,
+            // `expr_to_string` escapes the string literals with `.escape_default()`
+            // which escapes all non-ASCII characters with `\u`.
+            let escaped_expr = escape_format_string(&unescape_printable_unicode(
+                &pprust::expr_to_string(&cond_expr),
+            ));
+
+            TokenStream::from(TokenTree::Token(
+                DUMMY_SP,
+                token::Literal(
+                    token::Lit::Str_(Name::intern(&format!("assertion failed: {}", escaped_expr))),
+                    None,
+                ),
             )).into()
         },
     };
@@ -61,4 +69,54 @@ pub fn expand_assert<'cx>(
         None,
     );
     MacEager::expr(if_expr)
+}
+
+/// Escapes a string for use as a formatting string.
+fn escape_format_string(s: &str) -> String {
+    let mut res = String::with_capacity(s.len());
+    for c in s.chars() {
+        res.extend(c.escape_debug());
+        match c {
+            '{' | '}' => res.push(c),
+            _ => {}
+        }
+    }
+    res
+}
+
+#[test]
+fn test_escape_format_string() {
+    assert!(escape_format_string(r"foo{}\") == r"foo{{}}\\");
+}
+
+/// Unescapes the escaped unicodes (`\u{...}`) that are printable.
+fn unescape_printable_unicode(mut s: &str) -> String {
+    use std::{char, u32};
+
+    let mut res = String::with_capacity(s.len());
+
+    loop {
+        if let Some(start) = s.find(r"\u{") {
+            res.push_str(&s[0..start]);
+            s = &s[start..];
+            s.find('}')
+                .and_then(|end| {
+                    let v = u32::from_str_radix(&s[3..end], 16).ok()?;
+                    let c = char::from_u32(v)?;
+                    // Escape unprintable characters.
+                    res.extend(c.escape_debug());
+                    s = &s[end + 1..];
+                    Some(())
+                })
+                .expect("lexer should have rejected invalid escape sequences");
+        } else {
+            res.push_str(s);
+            return res;
+        }
+    }
+}
+
+#[test]
+fn test_unescape_printable_unicode() {
+    assert!(unescape_printable_unicode(r"\u{2603}\n\u{0}") == r"☃\n\u{0}");
 }

--- a/src/libsyntax_ext/assert.rs
+++ b/src/libsyntax_ext/assert.rs
@@ -1,0 +1,64 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use syntax::ast::*;
+use syntax::codemap::Spanned;
+use syntax::ext::base::*;
+use syntax::ext::build::AstBuilder;
+use syntax::parse::token;
+use syntax::print::pprust;
+use syntax::tokenstream::{TokenStream, TokenTree};
+use syntax_pos::Span;
+
+pub fn expand_assert<'cx>(
+    cx: &'cx mut ExtCtxt,
+    sp: Span,
+    tts: &[TokenTree],
+) -> Box<MacResult + 'cx> {
+    let mut parser = cx.new_parser_from_tts(tts);
+    let cond_expr = panictry!(parser.parse_expr());
+    let custom_msg_args = if parser.eat(&token::Comma) {
+        let ts = parser.parse_tokens();
+        if !ts.is_empty() {
+            Some(ts)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    let sp = sp.with_ctxt(sp.ctxt().apply_mark(cx.current_expansion.mark));
+    let panic_call = Mac_ {
+        path: Path::from_ident(sp, Ident::from_str("panic")),
+        tts: if let Some(ts) = custom_msg_args {
+            ts.into()
+        } else {
+            let panic_str = format!("assertion failed: {}", pprust::expr_to_string(&cond_expr));
+            TokenStream::from(token::Literal(
+                token::Lit::Str_(Name::intern(&panic_str)),
+                None,
+            )).into()
+        },
+    };
+    let if_expr = cx.expr_if(
+        sp,
+        cx.expr(sp, ExprKind::Unary(UnOp::Not, cond_expr)),
+        cx.expr(
+            sp,
+            ExprKind::Mac(Spanned {
+                span: sp,
+                node: panic_call,
+            }),
+        ),
+        None,
+    );
+    MacEager::expr(if_expr)
+}

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -17,6 +17,7 @@
 
 #![feature(proc_macro_internals)]
 #![feature(decl_macro)]
+#![feature(str_escape)]
 
 extern crate fmt_macros;
 #[macro_use]

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -26,6 +26,7 @@ extern crate proc_macro;
 extern crate rustc_data_structures;
 extern crate rustc_errors as errors;
 
+mod assert;
 mod asm;
 mod cfg;
 mod compile_error;
@@ -111,6 +112,7 @@ pub fn register_builtins(resolver: &mut syntax::ext::base::Resolver,
         log_syntax: log_syntax::expand_syntax_ext,
         trace_macros: trace_macros::expand_trace_macros,
         compile_error: compile_error::expand_compile_error,
+        assert: assert::expand_assert,
     }
 
     // format_args uses `unstable` things internally.

--- a/src/test/run-pass/assert-escape.rs
+++ b/src/test/run-pass/assert-escape.rs
@@ -1,0 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    assert!(r#"☃\backslash"#.contains("\\"));
+}

--- a/src/test/ui/codemap_tests/issue-28308.rs
+++ b/src/test/ui/codemap_tests/issue-28308.rs
@@ -10,4 +10,5 @@
 
 fn main() {
     assert!("foo");
+    //~^ ERROR cannot apply unary operator `!`
 }

--- a/src/test/ui/codemap_tests/issue-28308.stderr
+++ b/src/test/ui/codemap_tests/issue-28308.stderr
@@ -3,8 +3,6 @@ error[E0600]: cannot apply unary operator `!` to type `&'static str`
    |
 LL |     assert!("foo");
    |     ^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Makes `assert` macro a built-in one without touching its functionality. This is a prerequisite for RFC 2011 (#44838).