### PR TITLE
Compare only the data part of fat pointers

### DIFF
--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2105,7 +2105,8 @@ impl<T: ?Sized> Eq for *mut T {}
 #[stable(feature = "ptr_eq", since = "1.17.0")]
 #[inline]
 pub fn eq<T: ?Sized>(a: *const T, b: *const T) -> bool {
-    a == b
+    // cast to thin pointers to ignore the vtable part
+    a as *const () == b as *const ()
 }
 
 // Impls for function pointers


### PR DESCRIPTION
Two fat pointers may point to the same data, but with different vtables (the compiler do not guarantee that vtables are unique).

Such pointers should be considered equal by `std::ptr::eq()`, so cast them to thin pointers to compare only their data part.

See <https://github.com/rust-lang/rust/issues/48795>.