### PR TITLE
appveyor: Fix a switched condition for cargotest

### DIFF
--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -17,9 +17,9 @@ BOOTSTRAP_ARGS :=
 endif
 
 ifdef EXCLUDE_CARGO
-AUX_ARGS := src/tools/cargo src/tools/cargotest
-else
 AUX_ARGS :=
+else
+AUX_ARGS := src/tools/cargo src/tools/cargotest
 endif
 
 BOOTSTRAP := $(CFG_PYTHON) $(CFG_SRC_DIR)src/bootstrap/bootstrap.py


### PR DESCRIPTION
It was intended that EXCLUDE_CARGO *doesn't* run cargotest!