### PR TITLE
Remove some unnecessary IdxSet methods

### DIFF
--- a/src/librustc_data_structures/indexed_set.rs
+++ b/src/librustc_data_structures/indexed_set.rs
@@ -224,32 +224,6 @@ impl<T: Idx> IdxSet<T> {
             _pd: PhantomData,
         }
     }
-
-    pub fn elems(&self, universe_size: usize) -> Elems<T> {
-        Elems { i: 0, set: self, universe_size: universe_size }
-    }
-}
-
-pub struct Elems<'a, T: Idx> { i: usize, set: &'a IdxSet<T>, universe_size: usize }
-
-impl<'a, T: Idx> Iterator for Elems<'a, T> {
-    type Item = T;
-    fn next(&mut self) -> Option<T> {
-        if self.i >= self.universe_size { return None; }
-        let mut i = self.i;
-        loop {
-            if i >= self.universe_size {
-                self.i = i; // (mark iteration as complete.)
-                return None;
-            }
-            if self.set.contains(&T::new(i)) {
-                self.i = i + 1; // (next element to start at.)
-                return Some(T::new(i));
-            }
-            i = i + 1;
-        }
-    }
-}
 }
 
 pub struct Iter<'a, T: Idx> {

--- a/src/librustc_data_structures/indexed_set.rs
+++ b/src/librustc_data_structures/indexed_set.rs
@@ -231,11 +231,6 @@ impl<T: Idx> IdxSet<T> {
         each_bit(self, max_bits, f)
     }
 
-    /// Removes all elements from this set.
-    pub fn reset_to_empty(&mut self) {
-        for word in self.words_mut() { *word = 0; }
-    }
-
     pub fn elems(&self, universe_size: usize) -> Elems<T> {
         Elems { i: 0, set: self, universe_size: universe_size }
     }

--- a/src/librustc_data_structures/indexed_set.rs
+++ b/src/librustc_data_structures/indexed_set.rs
@@ -225,12 +225,6 @@ impl<T: Idx> IdxSet<T> {
         }
     }
 
-    /// Calls `f` on each index value held in this set, up to the
-    /// bound `max_bits` on the size of universe of indexes.
-    pub fn each_bit<F>(&self, max_bits: usize, f: F) where F: FnMut(T) {
-        each_bit(self, max_bits, f)
-    }
-
     pub fn elems(&self, universe_size: usize) -> Elems<T> {
         Elems { i: 0, set: self, universe_size: universe_size }
     }
@@ -256,33 +250,6 @@ impl<'a, T: Idx> Iterator for Elems<'a, T> {
         }
     }
 }
-
-fn each_bit<T: Idx, F>(words: &IdxSet<T>, max_bits: usize, mut f: F) where F: FnMut(T) {
-    let usize_bits: usize = mem::size_of::<usize>() * 8;
-
-    for (word_index, &word) in words.words().iter().enumerate() {
-        if word != 0 {
-            let base_index = word_index * usize_bits;
-            for offset in 0..usize_bits {
-                let bit = 1 << offset;
-                if (word & bit) != 0 {
-                    // NB: we round up the total number of bits
-                    // that we store in any given bit set so that
-                    // it is an even multiple of usize::BITS. This
-                    // means that there may be some stray bits at
-                    // the end that do not correspond to any
-                    // actual value; that's why we first check
-                    // that we are in range of bits_per_block.
-                    let bit_index = base_index + offset as usize;
-                    if bit_index >= max_bits {
-                        return;
-                    } else {
-                        f(Idx::new(bit_index));
-                    }
-                }
-            }
-        }
-    }
 }
 
 pub struct Iter<'a, T: Idx> {

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -555,7 +555,7 @@ impl<'cx, 'gcx, 'tcx> DataflowResultsConsumer<'cx, 'tcx> for MirBorrowckCtxt<'cx
                     // Look for any active borrows to locals
                     let domain = flow_state.borrows.operator();
                     let data = domain.borrows();
-                    flow_state.borrows.with_elems_outgoing(|borrows| {
+                    flow_state.borrows.with_iter_outgoing(|borrows| {
                         for i in borrows {
                             let borrow = &data[i.borrow_index()];
                             self.check_for_local_borrow(borrow, span);
@@ -571,7 +571,7 @@ impl<'cx, 'gcx, 'tcx> DataflowResultsConsumer<'cx, 'tcx> for MirBorrowckCtxt<'cx
                 // so this "extra check" serves as a kind of backup.
                 let domain = flow_state.borrows.operator();
                 let data = domain.borrows();
-                flow_state.borrows.with_elems_outgoing(|borrows| {
+                flow_state.borrows.with_iter_outgoing(|borrows| {
                     for i in borrows {
                         let borrow = &data[i.borrow_index()];
                         let context = ContextKind::StorageDead.new(loc);
@@ -1310,7 +1310,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
             place
         );
 
-        for i in flow_state.ever_inits.elems_incoming() {
+        for i in flow_state.ever_inits.iter_incoming() {
             let init = self.move_data.inits[i];
             let init_place = &self.move_data.move_paths[init.path].place;
             if self.places_conflict(&init_place, place, Deep) {
@@ -2155,8 +2155,8 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
 
         // check for loan restricting path P being used. Accounts for
         // borrows of P, P.a.b, etc.
-        let mut elems_incoming = flow_state.borrows.elems_incoming();
-        while let Some(i) = elems_incoming.next() {
+        let mut iter_incoming = flow_state.borrows.iter_incoming();
+        while let Some(i) = iter_incoming.next() {
             let borrowed = &data[i.borrow_index()];
 
             if self.places_conflict(&borrowed.borrowed_place, place, access) {

--- a/src/librustc_mir/dataflow/at_location.rs
+++ b/src/librustc_mir/dataflow/at_location.rs
@@ -147,8 +147,8 @@ impl<BD> FlowsAtLocation for FlowAtLocation<BD>
     }
 
     fn reconstruct_statement_effect(&mut self, loc: Location) {
-        self.stmt_gen.reset_to_empty();
-        self.stmt_kill.reset_to_empty();
+        self.stmt_gen.clear();
+        self.stmt_kill.clear();
         {
             let mut sets = BlockSets {
                 on_entry: &mut self.curr_state,
@@ -172,8 +172,8 @@ impl<BD> FlowsAtLocation for FlowAtLocation<BD>
     }
 
     fn reconstruct_terminator_effect(&mut self, loc: Location) {
-        self.stmt_gen.reset_to_empty();
-        self.stmt_kill.reset_to_empty();
+        self.stmt_gen.clear();
+        self.stmt_kill.clear();
         {
             let mut sets = BlockSets {
                 on_entry: &mut self.curr_state,

--- a/src/librustc_mir/dataflow/at_location.rs
+++ b/src/librustc_mir/dataflow/at_location.rs
@@ -12,7 +12,7 @@
 //! locations.
 
 use rustc::mir::{BasicBlock, Location};
-use rustc_data_structures::indexed_set::{self, IdxSetBuf};
+use rustc_data_structures::indexed_set::{IdxSetBuf, Iter};
 use rustc_data_structures::indexed_vec::Idx;
 
 use dataflow::{BitDenotation, BlockSets, DataflowResults};
@@ -117,23 +117,21 @@ where
     }
 
     /// Returns an iterator over the elements present in the current state.
-    pub fn elems_incoming(&self) -> iter::Peekable<indexed_set::Elems<BD::Idx>> {
-        let univ = self.base_results.sets().bits_per_block();
-        self.curr_state.elems(univ).peekable()
+    pub fn iter_incoming(&self) -> iter::Peekable<Iter<BD::Idx>> {
+        self.curr_state.iter().peekable()
     }
 
     /// Creates a clone of the current state and applies the local
     /// effects to the clone (leaving the state of self intact).
     /// Invokes `f` with an iterator over the resulting state.
-    pub fn with_elems_outgoing<F>(&self, f: F)
+    pub fn with_iter_outgoing<F>(&self, f: F)
     where
-        F: FnOnce(indexed_set::Elems<BD::Idx>),
+        F: FnOnce(Iter<BD::Idx>),
     {
         let mut curr_state = self.curr_state.clone();
         curr_state.union(&self.stmt_gen);
         curr_state.subtract(&self.stmt_kill);
-        let univ = self.base_results.sets().bits_per_block();
-        f(curr_state.elems(univ));
+        f(curr_state.iter());
     }
 }
 

--- a/src/librustc_mir/dataflow/at_location.rs
+++ b/src/librustc_mir/dataflow/at_location.rs
@@ -81,8 +81,7 @@ where
     where
         F: FnMut(BD::Idx),
     {
-        self.curr_state
-            .each_bit(self.base_results.operator().bits_per_block(), f)
+        self.curr_state.iter().for_each(f)
     }
 
     /// Iterate over each `gen` bit in the current effect (invoke
@@ -92,8 +91,7 @@ where
     where
         F: FnMut(BD::Idx),
     {
-        self.stmt_gen
-            .each_bit(self.base_results.operator().bits_per_block(), f)
+        self.stmt_gen.iter().for_each(f)
     }
 
     pub fn new(results: DataflowResults<BD>) -> Self {

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -444,8 +444,7 @@ pub struct DataflowState<O: BitDenotation>
 impl<O: BitDenotation> DataflowState<O> {
     pub fn each_bit<F>(&self, words: &IdxSet<O::Idx>, f: F) where F: FnMut(O::Idx)
     {
-        let bits_per_block = self.operator.bits_per_block();
-        words.each_bit(bits_per_block, f)
+        words.iter().for_each(f)
     }
 
     pub(crate) fn interpret_set<'c, P>(&self,


### PR DESCRIPTION
This replaces `IdxSet:: reset_to_empty` with `IdxSet:: clear`, and `IdxSet::elems`/`IdxSet::each_bit` with `IdxSet::iter`. Based on some [comments on #rustc](https://botbot.me/mozilla/rustc/2018-01-23/?msg=96063396).

r? @pnkfelix 