### PR TITLE
Modify part of `line!` documentation.

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -472,7 +472,7 @@ pub mod builtin {
     /// The expanded expression has type `u32` and is 1-based, so the first line
     /// in each file evaluates to 1, the second to 2, etc. This is consistent
     /// with error messages by common compilers or popular editors.
-    /// The returned line is not the invocation of the `line!` macro itself,
+    /// The returned line is *not necessarily* the line of the `line!` invocation itself,
     /// but rather the first macro invocation leading up to the invocation
     /// of the `line!` macro.
     ///


### PR DESCRIPTION
In accordance with #46997, I've replaced:

> The returned line is not the invocation of the line! macro itself [...]

By

> The returned line is *not necessarily* the line of the `line!` invocation itself [...]