### PR TITLE
Modify part of `column!` documentation.

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -497,7 +497,7 @@ pub mod builtin {
     /// The expanded expression has type `u32` and is 1-based, so the first column
     /// in each line evaluates to 1, the second to 2, etc. This is consistent
     /// with error messages by common compilers or popular editors.
-    /// The returned column is not the invocation of the `column!` macro itself,
+    /// The returned column is *not necessarily* the line of the `column!` invocation itself,
     /// but rather the first macro invocation leading up to the invocation
     /// of the `column!` macro.
     ///


### PR DESCRIPTION
Just like `line!` documentation, I've replaced:

> The returned column is not the invocation of the `column!` macro itself

By

> The returned column is *not necessarily* the line of the `column!` invocation itself

See #46997.