### PR TITLE
bump mipsel isa leval and enable fpxx

### DIFF
--- a/src/librustc_back/target/mips_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/mips_unknown_linux_gnu.rs
@@ -25,7 +25,7 @@ pub fn target() -> TargetResult {
         linker_flavor: LinkerFlavor::Gcc,
         options: TargetOptions {
             cpu: "mips32r2".to_string(),
-            features: "+mips32r2".to_string(),
+            features: "+mips32r2,+fpxx,+nooddspreg".to_string(),
             max_atomic_width: Some(32),
 
             // see #36994

--- a/src/librustc_back/target/mipsel_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/mipsel_unknown_linux_gnu.rs
@@ -26,7 +26,7 @@ pub fn target() -> TargetResult {
 
         options: TargetOptions {
             cpu: "mips32r2".to_string(),
-            features: "+mips32r2".to_string(),
+            features: "+mips32r2,+fpxx,+nooddspreg".to_string(),
             max_atomic_width: Some(32),
 
             // see #36994

--- a/src/librustc_back/target/mipsel_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/mipsel_unknown_linux_gnu.rs
@@ -25,8 +25,8 @@ pub fn target() -> TargetResult {
         linker_flavor: LinkerFlavor::Gcc,
 
         options: TargetOptions {
-            cpu: "mips32".to_string(),
-            features: "+mips32".to_string(),
+            cpu: "mips32r2".to_string(),
+            features: "+mips32r2".to_string(),
             max_atomic_width: Some(32),
 
             // see #36994

--- a/src/librustc_back/target/mipsel_unknown_linux_musl.rs
+++ b/src/librustc_back/target/mipsel_unknown_linux_musl.rs
@@ -13,8 +13,8 @@ use target::{Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_musl_base::opts();
-    base.cpu = "mips32".to_string();
-    base.features = "+mips32,+soft-float".to_string();
+    base.cpu = "mips32r2".to_string();
+    base.features = "+mips32r2,+soft-float".to_string();
     base.max_atomic_width = Some(32);
     // see #36994
     base.exe_allocation_crate = None;

--- a/src/librustc_back/target/mipsel_unknown_linux_uclibc.rs
+++ b/src/librustc_back/target/mipsel_unknown_linux_uclibc.rs
@@ -25,8 +25,8 @@ pub fn target() -> TargetResult {
         linker_flavor: LinkerFlavor::Gcc,
 
         options: TargetOptions {
-            cpu: "mips32".to_string(),
-            features: "+mips32,+soft-float".to_string(),
+            cpu: "mips32r2".to_string(),
+            features: "+mips32r2,+soft-float".to_string(),
             max_atomic_width: Some(32),
 
             // see #36994

--- a/src/librustc_trans/llvm_util.rs
+++ b/src/librustc_trans/llvm_util.rs
@@ -104,7 +104,7 @@ const POWERPC_WHITELIST: &'static [&'static str] = &["altivec",
                                                      "power8-vector", "power9-vector",
                                                      "vsx"];
 
-const MIPS_WHITELIST: &'static [&'static str] = &["msa"];
+const MIPS_WHITELIST: &'static [&'static str] = &["fp64", "msa"];
 
 pub fn to_llvm_feature<'a>(sess: &Session, s: &'a str) -> &'a str {
     let arch = if sess.target.target.arch == "x86_64" {


### PR DESCRIPTION
This PR:
* Bumps the default ISA level of the mipsel targets to `mips32r2`. The big endian mips targets are already built with `mips32r2`. This is the usual baseline for the MIPS ISA these days used by other projects, although it does drop support for the 4K processor (which was the only processor released with mips32 r1). Debian no longer supports pre-R2 processors. Using R2 also improves code generation in FPXX in certain circumstances.
* Enables the FPXX floating point ABI[1] on 32-bit hard-float targets by default. This ABI adds some extra restrictions to the existing ABI which allows code to run on the two main floating point modes found on MIPS (FR0 and FR1) and remains compatible with the FR32 ABI currently in use. All code within an executable (including all shared libraries) must be compiled with FPXX/FP64 to be able to use MSA on 32-bit MIPS.
* Enables the "nooddspreg" feature with FPXX. This feature is usually enabled whenever FPXX is. It also helps workaround some issues on Loongson processors. I'm hoping this will fix some test failures mentioned in #39013.
* Adds the `fp64` feature to the MIPS whitelist. This feature must be enabled to use MSA on 32-bit MIPS, otherwise LLVM will complain.

[1] See https://dmz-portal.mips.com/wiki/MIPS_O32_ABI_-_FR0_and_FR1_Interlinking