### PR TITLE
MIPS testsuite fixes

### DIFF
--- a/src/test/codegen/abi-main-signature-16bit-c-int.rs
+++ b/src/test/codegen/abi-main-signature-16bit-c-int.rs
@@ -17,6 +17,7 @@
 // ignore-asmjs
 // ignore-hexagon
 // ignore-mips
+// ignore-mips64
 // ignore-powerpc
 // ignore-s390x
 // ignore-sparc

--- a/src/test/codegen/fastcall-inreg.rs
+++ b/src/test/codegen/fastcall-inreg.rs
@@ -21,9 +21,7 @@
 // ignore-bpfeb
 // ignore-hexagon
 // ignore-mips
-// ignore-mipsel
 // ignore-mips64
-// ignore-mips64el
 // ignore-msp430
 // ignore-powerpc
 // ignore-r600

--- a/src/test/codegen/global_asm.rs
+++ b/src/test/codegen/global_asm.rs
@@ -17,9 +17,7 @@
 // ignore-bpfeb
 // ignore-hexagon
 // ignore-mips
-// ignore-mipsel
 // ignore-mips64
-// ignore-mips64el
 // ignore-msp430
 // ignore-powerpc
 // ignore-r600

--- a/src/test/codegen/global_asm_include.rs
+++ b/src/test/codegen/global_asm_include.rs
@@ -17,9 +17,7 @@
 // ignore-bpfeb
 // ignore-hexagon
 // ignore-mips
-// ignore-mipsel
 // ignore-mips64
-// ignore-mips64el
 // ignore-msp430
 // ignore-powerpc
 // ignore-r600

--- a/src/test/codegen/global_asm_x2.rs
+++ b/src/test/codegen/global_asm_x2.rs
@@ -17,9 +17,7 @@
 // ignore-bpfeb
 // ignore-hexagon
 // ignore-mips
-// ignore-mipsel
 // ignore-mips64
-// ignore-mips64el
 // ignore-msp430
 // ignore-powerpc
 // ignore-r600

--- a/src/test/codegen/repr-transparent-aggregates-3.rs
+++ b/src/test/codegen/repr-transparent-aggregates-3.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,13 +10,7 @@
 
 // compile-flags: -C no-prepopulate-passes
 
-// ignore-aarch64
-// ignore-asmjs
-// ignore-mips64
-// ignore-s390x
-// ignore-wasm
-// ignore-x86
-// ignore-x86_64
+// only-mips64
 // See repr-transparent.rs
 
 #![crate_type="lib"]
@@ -29,11 +23,11 @@ pub struct Big([u32; 16]);
 #[repr(transparent)]
 pub struct BigW(Big);
 
-// CHECK: define void @test_Big(%Big* [[BIG_RET_ATTRS:.*]], [16 x i32]
+// CHECK: define void @test_Big(%Big* [[BIG_RET_ATTRS:.*]], [8 x i64]
 #[no_mangle]
 pub extern fn test_Big(_: Big) -> Big { loop {} }
 
-// CHECK: define void @test_BigW(%BigW* [[BIG_RET_ATTRS]], [16 x i32]
+// CHECK: define void @test_BigW(%BigW* [[BIG_RET_ATTRS]], [8 x i64]
 #[no_mangle]
 pub extern fn test_BigW(_: BigW) -> BigW { loop {} }
 
@@ -46,10 +40,10 @@ pub union BigU {
 #[repr(transparent)]
 pub struct BigUw(BigU);
 
-// CHECK: define void @test_BigU(%BigU* [[BIGU_RET_ATTRS:.*]], [16 x i32]
+// CHECK: define void @test_BigU(%BigU* [[BIGU_RET_ATTRS:.*]], [8 x i64]
 #[no_mangle]
 pub extern fn test_BigU(_: BigU) -> BigU { loop {} }
 
-// CHECK: define void @test_BigUw(%BigUw* [[BIGU_RET_ATTRS]], [16 x i32]
+// CHECK: define void @test_BigUw(%BigUw* [[BIGU_RET_ATTRS]], [8 x i64]
 #[no_mangle]
 pub extern fn test_BigUw(_: BigUw) -> BigUw { loop {} }

--- a/src/test/codegen/stack-probes.rs
+++ b/src/test/codegen/stack-probes.rs
@@ -10,6 +10,8 @@
 
 // ignore-arm
 // ignore-aarch64
+// ignore-mips
+// ignore-mips64
 // ignore-powerpc
 // ignore-wasm
 // ignore-emscripten

--- a/src/test/codegen/stack-probes.rs
+++ b/src/test/codegen/stack-probes.rs
@@ -11,7 +11,6 @@
 // ignore-arm
 // ignore-aarch64
 // ignore-powerpc
-// ignore-aarch64
 // ignore-wasm
 // ignore-emscripten
 // ignore-windows

--- a/src/test/codegen/x86_mmx.rs
+++ b/src/test/codegen/x86_mmx.rs
@@ -11,6 +11,8 @@
 // ignore-arm
 // ignore-aarch64
 // ignore-emscripten
+// ignore-mips
+// ignore-mips64
 // compile-flags: -O
 
 #![feature(repr_simd)]

--- a/src/test/compile-fail/asm-bad-clobber.rs
+++ b/src/test/compile-fail/asm-bad-clobber.rs
@@ -15,6 +15,8 @@
 // ignore-emscripten
 // ignore-powerpc
 // ignore-sparc
+// ignore-mips
+// ignore-mips64
 
 #![feature(asm, rustc_attrs)]
 

--- a/src/test/compile-fail/asm-in-bad-modifier.rs
+++ b/src/test/compile-fail/asm-in-bad-modifier.rs
@@ -12,6 +12,8 @@
 // ignore-emscripten
 // ignore-powerpc
 // ignore-sparc
+// ignore-mips
+// ignore-mips64
 
 #![feature(asm)]
 

--- a/src/test/compile-fail/asm-misplaced-option.rs
+++ b/src/test/compile-fail/asm-misplaced-option.rs
@@ -15,6 +15,8 @@
 // ignore-emscripten
 // ignore-powerpc
 // ignore-sparc
+// ignore-mips
+// ignore-mips64
 
 #![feature(asm, rustc_attrs)]
 

--- a/src/test/compile-fail/asm-out-no-modifier.rs
+++ b/src/test/compile-fail/asm-out-no-modifier.rs
@@ -12,6 +12,8 @@
 // ignore-emscripten
 // ignore-powerpc
 // ignore-sparc
+// ignore-mips
+// ignore-mips64
 
 #![feature(asm)]
 

--- a/src/test/compile-fail/asm-out-read-uninit.rs
+++ b/src/test/compile-fail/asm-out-read-uninit.rs
@@ -12,6 +12,8 @@
 // ignore-emscripten
 // ignore-powerpc
 // ignore-sparc
+// ignore-mips
+// ignore-mips64
 
 // revisions: ast mir
 //[mir]compile-flags: -Z borrowck=mir

--- a/src/test/compile-fail/borrowck/borrowck-asm.rs
+++ b/src/test/compile-fail/borrowck/borrowck-asm.rs
@@ -21,7 +21,9 @@
 #[cfg(any(target_arch = "x86",
             target_arch = "x86_64",
             target_arch = "arm",
-            target_arch = "aarch64"))]
+            target_arch = "aarch64",
+            target_arch = "mips",
+            target_arch = "mips64"))]
 mod test_cases {
     fn is_move() {
         let y: &mut isize;

--- a/src/test/run-pass/stack-probes-lto.rs
+++ b/src/test/run-pass/stack-probes-lto.rs
@@ -10,6 +10,8 @@
 
 // ignore-arm
 // ignore-aarch64
+// ignore-mips
+// ignore-mips64
 // ignore-wasm
 // ignore-cloudabi no processes
 // ignore-emscripten no processes

--- a/src/test/run-pass/stack-probes.rs
+++ b/src/test/run-pass/stack-probes.rs
@@ -10,6 +10,8 @@
 
 // ignore-arm
 // ignore-aarch64
+// ignore-mips
+// ignore-mips64
 // ignore-wasm
 // ignore-cloudabi no processes
 // ignore-emscripten no processes

--- a/src/tools/compiletest/src/util.rs
+++ b/src/tools/compiletest/src/util.rs
@@ -40,6 +40,7 @@ const ARCH_TABLE: &'static [(&'static str, &'static str)] = &[
     ("i386", "x86"),
     ("i586", "x86"),
     ("i686", "x86"),
+    ("mips64", "mips64"),
     ("mips", "mips"),
     ("msp430", "msp430"),
     ("powerpc", "powerpc"),


### PR DESCRIPTION
This PR adjusts various bits in the testsuite so that more stuff passes on mips*.