### PR TITLE
rustc: Tweak Literal APIs of `proc_macro`

### DIFF
--- a/src/libproc_macro/quote.rs
+++ b/src/libproc_macro/quote.rs
@@ -156,7 +156,7 @@ impl<'a> Quote for &'a str {
 
 impl Quote for usize {
     fn quote(self) -> TokenStream {
-        TokenNode::Literal(Literal::integer(self as i128)).into()
+        TokenNode::Literal(Literal::integer(self as u128)).into()
     }
 }
 


### PR DESCRIPTION
This commit tweaks the public api of the `proc_macro::Literal` structure to
solve #48889, an issue about negative integers and their representation in
`proc_macro` tokens. Currently the compiler assumes that all integer tokens are
*positive* integers rather than embedding a negative sign. The negative sign is
a separate token from the integer itself.

Currently there's a function like:

    impl Literal {
        pub fn i32(i: i32) -> Literal;
    }

but unfortunately this doesn't work for negative integers. When called with
negative integers weird errors end up getting thrown later during the parsing
process.

This function tweaks the definitions to instead use:

    impl Literal {
        pub fn i32(i: u32) -> Literal;
    }

This construction makes it more clear that negative arguments are not supported.
This additionally allows literals like `-128i8` where `128`, the positive
integer part of this literal, isn't representable in `i8`. By taking an unsigned
number in each constructor we can allow constructing the minimum literal for
each signed type as well.

The final tweak of this commit is to panic in `Literal::{f32, f64}` if the input
number is negative. This is similar to how infinite/nan literals are handled
today (they panic) and constructing a literal should be possible by negating a
float and then separately passing in a literal.

Closes #48889