### PR TITLE
rustbuild: Pass `-j1` to OpenSSL `make install`

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -596,7 +596,7 @@ impl Step for Openssl {
         println!("Building openssl for {}", target);
         build.run_quiet(Command::new("make").arg("-j1").current_dir(&obj));
         println!("Installing openssl for {}", target);
-        build.run_quiet(Command::new("make").arg("install").current_dir(&obj));
+        build.run_quiet(Command::new("make").arg("install").arg("-j1").current_dir(&obj));
 
         let mut f = t!(File::create(&stamp));
         t!(f.write_all(OPENSSL_VERS.as_bytes()));


### PR DESCRIPTION
We explicitly do this when compiling OpenSSL itself due to weird racy issues in
its build system, and now we've started seeing issues in the `make install` step
so let's try and see what ratcheting down the parallelism does here...