### PR TITLE
Add missing inline annotations to Cell

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -331,6 +331,7 @@ impl<T:Ord + Copy> Ord for Cell<T> {
 
 #[stable(feature = "cell_from", since = "1.12.0")]
 impl<T> From<T> for Cell<T> {
+    #[inline]
     fn from(t: T) -> Cell<T> {
         Cell::new(t)
     }
@@ -449,6 +450,7 @@ impl<T> Cell<T> {
     /// assert_eq!(cell.replace(10), 5);
     /// assert_eq!(cell.get(), 10);
     /// ```
+    #[inline]
     #[stable(feature = "move_cell", since = "1.17.0")]
     pub fn replace(&self, val: T) -> T {
         mem::replace(unsafe { &mut *self.value.get() }, val)
@@ -466,6 +468,7 @@ impl<T> Cell<T> {
     ///
     /// assert_eq!(five, 5);
     /// ```
+    #[inline]
     #[stable(feature = "move_cell", since = "1.17.0")]
     pub fn into_inner(self) -> T {
         self.value.into_inner()
@@ -486,6 +489,7 @@ impl<T: Default> Cell<T> {
     /// assert_eq!(five, 5);
     /// assert_eq!(c.into_inner(), 0);
     /// ```
+    #[inline]
     #[stable(feature = "move_cell", since = "1.17.0")]
     pub fn take(&self) -> T {
         self.replace(Default::default())


### PR DESCRIPTION
Were seeing some odd performance problems when using incremental compilation where `Rc` pointers were actually slower than `Arc` pointers (the problem goes away when using non-incremental compilation). I haven't been able to build rustc locally to verify that this fixes it but these missing inline annotations seem to be the only thing that could affect performance (to this extent).

```
test vector_push_back        ... bench:  11,668,015 ns/iter (+/- 772,861)
test vector_push_back_mut    ... bench:   1,423,771 ns/iter (+/- 22,011)
test vector_push_back_mut_rc ... bench:   1,181,765 ns/iter (+/- 123,724)
test vector_push_back_rc     ... bench:  17,141,746 ns/iter (+/- 203,048)
```
(Source and non incremental benchmarks https://github.com/orium/rpds/issues/7#issuecomment-371974567)