### PR TITLE
Some minor CI changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -275,11 +275,12 @@ after_failure:
   - ls -lat $HOME/Library/Logs/DiagnosticReports/
   - find $HOME/Library/Logs/DiagnosticReports
       -type f
+      -name '*.crash'
       -not -name '*.stage2-*.crash'
       -not -name 'com.apple.CoreSimulator.CoreSimulatorService-*.crash'
       -exec printf travis_fold":start:crashlog\n\033[31;1m%s\033[0m\n" {} \;
       -exec head -750 {} \;
-      -exec echo travis_fold":"end:crashlog \;
+      -exec echo travis_fold":"end:crashlog \; || true
 
   # attempt to debug anything killed by the oom killer on linux, just to see if
   # it happened

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -91,11 +91,19 @@ make check-bootstrap
 travis_fold end check-bootstrap
 travis_time_finish
 
+# Display the CPU and memory information. This helps us know why the CI timing
+# is fluctuating.
+travis_fold start log-system-info
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+    system_profiler SPHardwareDataType || true
+    sysctl hw || true
     ncpus=$(sysctl -n hw.ncpu)
 else
+    cat /proc/cpuinfo || true
+    cat /proc/meminfo || true
     ncpus=$(grep processor /proc/cpuinfo | wc -l)
 fi
+travis_fold end log-system-info
 
 if [ ! -z "$SCRIPT" ]; then
   sh -x -c "$SCRIPT"


### PR DESCRIPTION
1. On macOS, ensure crash log printing won't error, and only real crash logs are printed. This may avoid the `find` process exiting abnormally and truncated the Travis log (I guess).

2. Print `/proc/cpuinfo` and `/proc/meminfo`. To determine if there's any variation in the reported clock rate between jobs.