### PR TITLE
Add hashmap! + hashset! macros

### DIFF
--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -2709,6 +2709,39 @@ fn assert_covariance() {
     }
 }
 
+/// Creates a `HashMap` containing the provided key-value pairs.
+///
+/// `hashmap!` allows `HashMap`s to be defined with the same syntax as an array of tuples.
+///
+/// ```
+/// use std::collections::HashMap;
+///
+/// let m = hashmap![("one", 1), ("two", 2), ("three", 3)];
+/// assert_eq!(m["one"], 1);
+/// assert_eq!(m["two"], 2);
+/// assert_eq!(m["three"], 3);
+///
+/// let mut m = hashmap![];
+/// m.insert("one", 1);
+/// m.insert("two", 2);
+/// m.insert("three", 3);
+///
+/// assert_eq!(m, hashmap![("one", 1), ("three", 3), ("two", 2),]);
+/// ```
+#[macro_export]
+macro_rules! hashmap {
+    ($(($key:expr, $value:expr)),*) => (
+        {
+            let mut map = HashMap::new();
+            $(
+                map.insert($key, $value);
+            )*
+            map
+        }
+    );
+    ($(($key:expr, $value:expr),)*) => (hashmap![$(($key, $value)),*])
+}
+
 #[cfg(test)]
 mod test_map {
     use super::HashMap;
@@ -3650,5 +3683,25 @@ mod test_map {
         hm.insert(0, TestV(&mut can_drop));
         let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| { hm.entry(0) <- makepanic(); }));
         assert_eq!(hm.len(), 0);
+    }
+
+    #[test]
+    fn test_macro() {
+        let mut expected = HashMap::new();
+        expected.insert("this is a test", 'a');
+        expected.insert("это испытание", 'b');
+        expected.insert("هذا اختبار", 'c');
+
+        assert_eq!(expected, hashmap![("this is a test", 'a'), ("هذا اختبار", 'c'), ("это испытание", 'b'),]);
+
+        let mut second_a = HashMap::new();
+        let mut second_b = hashmap![];
+
+        second_a.insert("three", 3.0);
+        second_a.insert("four", 4.0);
+        second_b.insert("three", 3.0);
+        second_b.insert("four", 4.0);
+
+        assert_eq!(second_a, second_b);
     }
 }

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -1371,6 +1371,39 @@ fn assert_covariance() {
     }
 }
 
+/// Creates a `HashSet` containing the provided key-value pairs.
+///
+/// `hashset!` allows `HashSet`s to be defined with the same syntax as array expressions.
+///
+/// ```
+/// use std::collections::HashSet;
+///
+/// let s = hashset!["one", "two", "three"];
+/// assert!(s.contains("one"));
+/// assert!(s.contains("two"));
+/// assert!(s.contains("three"));
+///
+/// let mut s = hashset![];
+/// s.insert("one");
+/// s.insert("two");
+/// s.insert("three");
+///
+/// assert_eq!(s, hashset!["one", "three", "two",]);
+/// ```
+#[macro_export]
+macro_rules! hashset {
+    ($($key:expr),*) => (
+        {
+            let mut set = HashSet::new();
+            $(
+                set.insert($key);
+            )*
+            set
+        }
+    );
+    ($($key:expr,)*) => (hashset![$($key),*])
+}
+
 #[cfg(test)]
 mod test_set {
     use super::HashSet;
@@ -1751,5 +1784,25 @@ mod test_set {
         assert!(set.contains(&2));
         assert!(set.contains(&4));
         assert!(set.contains(&6));
+    }
+
+    #[test]
+    fn test_macro() {
+        let mut expected = HashSet::new();
+        expected.insert("this is a test");
+        expected.insert("это испытание");
+        expected.insert("هذا اختبار");
+
+        assert_eq!(expected, hashset!["this is a test", "هذا اختبار", "это испытание",]);
+
+        let mut second_a = HashSet::new();
+        let mut second_b = hashset![];
+
+        second_a.insert("one");
+        second_a.insert("two");
+        second_b.insert("one");
+        second_b.insert("two");
+
+        assert_eq!(second_a, second_b);
     }
 }


### PR DESCRIPTION
These macros let you make HashMaps and HashSets filled w/ items in 1 pass much like vec!. They can also be used as a slightly shorter alternative to HashMap::new()/HashSet::new() for empty HashMaps/HashSets

HashMap!'s syntax's meant to be similar to using the insert method:
```Rust
let mut book_reviews = HashMap::new();
book_reviews.insert("Adventures of Huckleberry Finn", "My favorite book.");
book_reviews.insert("Grimms' Fairy Tales", "Masterpiece.");
let mut book_reviews = hashmap![("Adventures of Huckleberry Finn", "My favorite book."), ("Grimms' Fairy Tales", "Masterpiece.")];
```
No feature gates coz apparently feature gates don't work for macros
Issues: these macros're available even when HashMap/HashSet ain't in scope, tho I ain't sure how much of a problem that is in practice since I imagine people'll type `use std::collections::HashMap` 1st

```Rust
fn main() {
    let map = hashmap![("test", 1)];
}
```
```
error[E0433]: failed to resolve. Use of undeclared type or module `HashMap`
 --> src/main.rs:2:15
  |
2 |     let map = hashmap![("test", 1)];
  |               ^^^^^^^^^^^^^^^^^^^^^ Use of undeclared type or module `HashMap`
  |
```
Maybe add HashMap and HashSet to the prelude but I don't think that's likely