### PR TITLE
rustc: Start a custom cabi module for wasm32

### DIFF
--- a/src/librustc_trans/abi.rs
+++ b/src/librustc_trans/abi.rs
@@ -30,6 +30,7 @@ use cabi_sparc64;
 use cabi_nvptx;
 use cabi_nvptx64;
 use cabi_hexagon;
+use cabi_wasm32;
 use mir::place::PlaceRef;
 use mir::operand::OperandValue;
 use type_::Type;
@@ -948,7 +949,13 @@ impl<'a, 'tcx> FnType<'tcx> {
             "powerpc64" => cabi_powerpc64::compute_abi_info(cx, self),
             "s390x" => cabi_s390x::compute_abi_info(cx, self),
             "asmjs" => cabi_asmjs::compute_abi_info(cx, self),
-            "wasm32" => cabi_asmjs::compute_abi_info(cx, self),
+            "wasm32" => {
+                if cx.sess().opts.target_triple.contains("emscripten") {
+                    cabi_asmjs::compute_abi_info(cx, self)
+                } else {
+                    cabi_wasm32::compute_abi_info(cx, self)
+                }
+            }
             "msp430" => cabi_msp430::compute_abi_info(self),
             "sparc" => cabi_sparc::compute_abi_info(cx, self),
             "sparc64" => cabi_sparc64::compute_abi_info(cx, self),

--- a/src/librustc_trans/cabi_wasm32.rs
+++ b/src/librustc_trans/cabi_wasm32.rs
@@ -1,0 +1,31 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use abi::{FnType, ArgType};
+use context::CodegenCx;
+
+fn classify_ret_ty<'a, 'tcx>(_cx: &CodegenCx<'a, 'tcx>, ret: &mut ArgType<'tcx>) {
+    ret.extend_integer_width_to(32);
+}
+
+fn classify_arg_ty(arg: &mut ArgType) {
+    arg.extend_integer_width_to(32);
+}
+
+pub fn compute_abi_info<'a, 'tcx>(cx: &CodegenCx<'a, 'tcx>, fty: &mut FnType<'tcx>) {
+    if !fty.ret.is_ignore() {
+        classify_ret_ty(cx, &mut fty.ret);
+    }
+
+    for arg in &mut fty.args {
+        if arg.is_ignore() { continue; }
+        classify_arg_ty(arg);
+    }
+}

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -123,6 +123,7 @@ mod cabi_sparc64;
 mod cabi_x86;
 mod cabi_x86_64;
 mod cabi_x86_win64;
+mod cabi_wasm32;
 mod callee;
 mod common;
 mod consts;


### PR DESCRIPTION
It actually was already using the `cabi_asmjs` module but that was by accident,
so route the new `wasm32-unknown-unknown` target to a new `cabi_wasm32` module.
The first entries in this module are to use `signext` and `zeroext` for types
that are under 32 bytes in size

Closes rust-lang-nursery/rust-wasm#88