### PR TITLE
tweak code fences in the rustdoc book

### DIFF
--- a/src/doc/rustdoc/src/documentation-tests.md
+++ b/src/doc/rustdoc/src/documentation-tests.md
@@ -19,15 +19,19 @@ running `rustdoc --test foo.rs` will extract this example, and then run it as a 
 Please note that by default, if no language is set for the block code, `rustdoc`
 assumes it is `Rust` code. So the following:
 
+``````markdown
 ```rust
 let x = 5;
 ```
+``````
 
 is strictly equivalent to:
 
+``````markdown
 ```
 let x = 5;
 ```
+``````
 
 There's some subtlety though! Read on for more details.
 


### PR DESCRIPTION
You can stack backticks to create "big code fences" if you're documenting some markdown and need to have code fences inside your code fences. This is especially important in this spot in the Rustdoc Book, because we're showing that using no language specifier on your code blocks is interpreted as using `rust`, but the code blocks here lose their code fences!

`````````markdown
``````markdown
Just showing some recursion, nbd.

```rust
println!("sup");
```
``````

(If you have edit powers in the rust-lang/rust repo, hit the edit button to view the source and see even more recursion :P)
`````````