### PR TITLE
rustc: Don't invoke `lld` with an `@`-file

### DIFF
--- a/src/librustc_trans/back/command.rs
+++ b/src/librustc_trans/back/command.rs
@@ -132,6 +132,13 @@ impl Command {
             return false
         }
 
+        // Right now LLD doesn't support the `@` syntax of passing an argument
+        // through files, so regardless of the platform we try to go to the OS
+        // on this one.
+        if let Program::Lld(..) = self.program {
+            return false
+        }
+
         // Ok so on Windows to spawn a process is 32,768 characters in its
         // command line [1]. Unfortunately we don't actually have access to that
         // as it's calculated just before spawning. Instead we perform a


### PR DESCRIPTION
Looks like LLD doesn't support this yet, so always try to use the OS before we
fall back to using `@`

cc https://github.com/rust-lang/rust/issues/48948