### PR TITLE
rustc: Add a `#[wasm_import_module]` attribute

### DIFF
--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -590,6 +590,7 @@ define_dep_nodes!( <'tcx>
     [] ImplementationsOfTrait { krate: CrateNum, trait_id: DefId },
     [] AllTraitImplementations(CrateNum),
 
+    [] DllimportForeignItems(CrateNum),
     [] IsDllimportForeignItem(DefId),
     [] IsStaticallyIncludedForeignItem(DefId),
     [] NativeLibraryKind(DefId),
@@ -648,6 +649,9 @@ define_dep_nodes!( <'tcx>
     [] GetSymbolExportLevel(DefId),
 
     [input] Features,
+
+    [] WasmImportModuleMap(CrateNum),
+    [] ForeignModules(CrateNum),
 );
 
 trait DepNodeParams<'a, 'gcx: 'tcx + 'a, 'tcx: 'a> : fmt::Debug {

--- a/src/librustc/hir/check_attr.rs
+++ b/src/librustc/hir/check_attr.rs
@@ -25,6 +25,7 @@ enum Target {
     Struct,
     Union,
     Enum,
+    ForeignMod,
     Other,
 }
 
@@ -35,6 +36,7 @@ impl Target {
             hir::ItemStruct(..) => Target::Struct,
             hir::ItemUnion(..) => Target::Union,
             hir::ItemEnum(..) => Target::Enum,
+            hir::ItemForeignMod(..) => Target::ForeignMod,
             _ => Target::Other,
         }
     }
@@ -55,12 +57,31 @@ impl<'a, 'tcx> CheckAttrVisitor<'a, 'tcx> {
                 .emit();
         }
 
+        let mut has_wasm_import_module = false;
         for attr in &item.attrs {
-            if let Some(name) = attr.name() {
-                if name == "inline" {
-                    self.check_inline(attr, item, target)
+            if attr.check_name("inline") {
+                self.check_inline(attr, item, target)
+            } else if attr.check_name("wasm_import_module") {
+                has_wasm_import_module = true;
+                if attr.value_str().is_none() {
+                    self.tcx.sess.span_err(attr.span, "\
+                        must be of the form #[wasm_import_module = \"...\"]");
+                }
+                if target != Target::ForeignMod {
+                    self.tcx.sess.span_err(attr.span, "\
+                        must only be attached to foreign modules");
                 }
             }
+        }
+
+        if target == Target::ForeignMod &&
+            !has_wasm_import_module &&
+            self.tcx.sess.target.target.arch == "wasm32" &&
+            false // FIXME: eventually enable this warning when stable
+        {
+            self.tcx.sess.span_warn(item.span, "\
+                must have a #[wasm_import_module = \"...\"] attribute, this \
+                will become a hard error before too long");
         }
 
         self.check_repr(item, target);

--- a/src/librustc/ich/impls_cstore.rs
+++ b/src/librustc/ich/impls_cstore.rs
@@ -33,7 +33,12 @@ impl_stable_hash_for!(struct middle::cstore::NativeLibrary {
     kind,
     name,
     cfg,
-    foreign_items
+    foreign_module
+});
+
+impl_stable_hash_for!(struct middle::cstore::ForeignModule {
+    foreign_items,
+    def_id
 });
 
 impl_stable_hash_for!(enum middle::cstore::LinkagePreference {

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -132,7 +132,13 @@ pub struct NativeLibrary {
     pub kind: NativeLibraryKind,
     pub name: Symbol,
     pub cfg: Option<ast::MetaItem>,
+    pub foreign_module: Option<DefId>,
+}
+
+#[derive(Clone, Hash, RustcEncodable, RustcDecodable)]
+pub struct ForeignModule {
     pub foreign_items: Vec<DefId>,
+    pub def_id: DefId,
 }
 
 pub enum LoadedMacro {

--- a/src/librustc/ty/maps/config.rs
+++ b/src/librustc/ty/maps/config.rs
@@ -418,6 +418,12 @@ impl<'tcx> QueryDescription<'tcx> for queries::native_libraries<'tcx> {
     }
 }
 
+impl<'tcx> QueryDescription<'tcx> for queries::foreign_modules<'tcx> {
+    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+        format!("looking up the foreign modules of a linked crate")
+    }
+}
+
 impl<'tcx> QueryDescription<'tcx> for queries::plugin_registrar_fn<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
         format!("looking up the plugin registrar for a crate")
@@ -678,6 +684,18 @@ impl<'tcx> QueryDescription<'tcx> for queries::generics_of<'tcx> {
         let generics: Option<ty::Generics> = tcx.on_disk_query_result_cache
                                                 .try_load_query_result(tcx, id);
         generics.map(|x| tcx.alloc_generics(x))
+    }
+}
+
+impl<'tcx> QueryDescription<'tcx> for queries::wasm_import_module_map<'tcx> {
+    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+        format!("wasm import module map")
+    }
+}
+
+impl<'tcx> QueryDescription<'tcx> for queries::dllimport_foreign_items<'tcx> {
+    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+        format!("wasm import module map")
     }
 }
 

--- a/src/librustc/ty/maps/mod.rs
+++ b/src/librustc/ty/maps/mod.rs
@@ -18,7 +18,7 @@ use infer::canonical::{Canonical, QueryResult};
 use lint;
 use middle::borrowck::BorrowCheckResult;
 use middle::cstore::{ExternCrate, LinkagePreference, NativeLibrary,
-                     ExternBodyNestedBodies};
+                     ExternBodyNestedBodies, ForeignModule};
 use middle::cstore::{NativeLibraryKind, DepKind, CrateSource, ExternConstBody};
 use middle::privacy::AccessLevels;
 use middle::reachable::ReachableSet;
@@ -315,6 +315,9 @@ define_maps! { <'tcx>
 
 
     [] fn native_libraries: NativeLibraries(CrateNum) -> Lrc<Vec<NativeLibrary>>,
+
+    [] fn foreign_modules: ForeignModules(CrateNum) -> Lrc<Vec<ForeignModule>>,
+
     [] fn plugin_registrar_fn: PluginRegistrarFn(CrateNum) -> Option<DefId>,
     [] fn derive_registrar_fn: DeriveRegistrarFn(CrateNum) -> Option<DefId>,
     [] fn crate_disambiguator: CrateDisambiguator(CrateNum) -> CrateDisambiguator,
@@ -326,6 +329,8 @@ define_maps! { <'tcx>
     [] fn all_trait_implementations: AllTraitImplementations(CrateNum)
         -> Lrc<Vec<DefId>>,
 
+    [] fn dllimport_foreign_items: DllimportForeignItems(CrateNum)
+        -> Lrc<FxHashSet<DefIndex>>,
     [] fn is_dllimport_foreign_item: IsDllimportForeignItem(DefId) -> bool,
     [] fn is_statically_included_foreign_item: IsStaticallyIncludedForeignItem(DefId) -> bool,
     [] fn native_library_kind: NativeLibraryKind(DefId)
@@ -417,6 +422,8 @@ define_maps! { <'tcx>
         -> usize,
 
     [] fn features_query: features_node(CrateNum) -> Lrc<feature_gate::Features>,
+    [] fn wasm_import_module_map: WasmImportModuleMap(CrateNum)
+        -> Lrc<FxHashMap<DefIndex, String>>,
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/src/librustc/ty/maps/plumbing.rs
+++ b/src/librustc/ty/maps/plumbing.rs
@@ -883,6 +883,9 @@ pub fn force_from_dep_node<'a, 'gcx, 'lcx>(tcx: TyCtxt<'a, 'gcx, 'lcx>,
             force!(all_trait_implementations, krate!());
         }
 
+        DepKind::DllimportForeignItems => {
+            force!(dllimport_foreign_items, krate!());
+        }
         DepKind::IsDllimportForeignItem => {
             force!(is_dllimport_foreign_item, def_id!());
         }
@@ -935,6 +938,8 @@ pub fn force_from_dep_node<'a, 'gcx, 'lcx>(tcx: TyCtxt<'a, 'gcx, 'lcx>,
 
         DepKind::GetSymbolExportLevel => { force!(symbol_export_level, def_id!()); }
         DepKind::Features => { force!(features_query, LOCAL_CRATE); }
+        DepKind::WasmImportModuleMap => { force!(wasm_import_module_map, krate!()); }
+        DepKind::ForeignModules => { force!(foreign_modules, krate!()); }
     }
 
     true

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -12,7 +12,6 @@
 
 use cstore::{self, CStore, CrateSource, MetadataBlob};
 use locator::{self, CratePaths};
-use native_libs::relevant_lib;
 use schema::CrateRoot;
 use rustc_data_structures::sync::Lrc;
 
@@ -231,7 +230,7 @@ impl<'a> CrateLoader<'a> {
             .map(|trait_impls| (trait_impls.trait_id, trait_impls.impls))
             .collect();
 
-        let mut cmeta = cstore::CrateMetadata {
+        let cmeta = cstore::CrateMetadata {
             name,
             extern_crate: Cell::new(None),
             def_path_table: Lrc::new(def_path_table),
@@ -251,24 +250,7 @@ impl<'a> CrateLoader<'a> {
                 rlib,
                 rmeta,
             },
-            // Initialize this with an empty set. The field is populated below
-            // after we were able to deserialize its contents.
-            dllimport_foreign_items: FxHashSet(),
         };
-
-        let dllimports: FxHashSet<_> = cmeta
-            .root
-            .native_libraries
-            .decode((&cmeta, self.sess))
-            .filter(|lib| relevant_lib(self.sess, lib) &&
-                          lib.kind == cstore::NativeLibraryKind::NativeUnknown)
-            .flat_map(|lib| {
-                assert!(lib.foreign_items.iter().all(|def_id| def_id.krate == cnum));
-                lib.foreign_items.into_iter().map(|def_id| def_id.index)
-            })
-            .collect();
-
-        cmeta.dllimport_foreign_items = dllimports;
 
         let cmeta = Lrc::new(cmeta);
         self.cstore.set_crate_data(cnum, cmeta.clone());

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -20,7 +20,7 @@ use rustc::middle::cstore::{DepKind, ExternCrate, MetadataLoader};
 use rustc::session::{Session, CrateDisambiguator};
 use rustc_back::PanicStrategy;
 use rustc_data_structures::indexed_vec::IndexVec;
-use rustc::util::nodemap::{FxHashMap, FxHashSet, NodeMap};
+use rustc::util::nodemap::{FxHashMap, NodeMap};
 
 use std::cell::{RefCell, Cell};
 use rustc_data_structures::sync::Lrc;
@@ -31,7 +31,7 @@ use syntax_pos;
 
 pub use rustc::middle::cstore::{NativeLibrary, NativeLibraryKind, LinkagePreference};
 pub use rustc::middle::cstore::NativeLibraryKind::*;
-pub use rustc::middle::cstore::{CrateSource, LibSource};
+pub use rustc::middle::cstore::{CrateSource, LibSource, ForeignModule};
 
 pub use cstore_impl::{provide, provide_extern};
 
@@ -85,8 +85,6 @@ pub struct CrateMetadata {
     pub source: CrateSource,
 
     pub proc_macros: Option<Vec<(ast::Name, Lrc<SyntaxExtension>)>>,
-    // Foreign items imported from a dylib (Windows only)
-    pub dllimport_foreign_items: FxHashSet<DefIndex>,
 }
 
 pub struct CStore {

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -12,6 +12,7 @@ use cstore;
 use encoder;
 use link_args;
 use native_libs;
+use foreign_modules;
 use schema;
 
 use rustc::ty::maps::QueryConfig;
@@ -194,6 +195,7 @@ provide! { <'tcx> tcx, def_id, other, cdata,
         Lrc::new(reachable_non_generics)
     }
     native_libraries => { Lrc::new(cdata.get_native_libraries(tcx.sess)) }
+    foreign_modules => { Lrc::new(cdata.get_foreign_modules(tcx.sess)) }
     plugin_registrar_fn => {
         cdata.root.plugin_registrar_fn.map(|index| {
             DefId { krate: def_id.krate, index }
@@ -221,9 +223,6 @@ provide! { <'tcx> tcx, def_id, other, cdata,
         Lrc::new(result)
     }
 
-    is_dllimport_foreign_item => {
-        cdata.is_dllimport_foreign_item(def_id.index)
-    }
     visibility => { cdata.get_visibility(def_id.index) }
     dep_kind => { cdata.dep_kind.get() }
     crate_name => { cdata.name }
@@ -297,12 +296,27 @@ pub fn provide<'tcx>(providers: &mut Providers<'tcx>) {
             tcx.native_libraries(id.krate)
                 .iter()
                 .filter(|lib| native_libs::relevant_lib(&tcx.sess, lib))
-                .find(|l| l.foreign_items.contains(&id))
+                .find(|lib| {
+                    let fm_id = match lib.foreign_module {
+                        Some(id) => id,
+                        None => return false,
+                    };
+                    tcx.foreign_modules(id.krate)
+                        .iter()
+                        .find(|m| m.def_id == fm_id)
+                        .expect("failed to find foreign module")
+                        .foreign_items
+                        .contains(&id)
+                })
                 .map(|l| l.kind)
         },
         native_libraries: |tcx, cnum| {
             assert_eq!(cnum, LOCAL_CRATE);
             Lrc::new(native_libs::collect(tcx))
+        },
+        foreign_modules: |tcx, cnum| {
+            assert_eq!(cnum, LOCAL_CRATE);
+            Lrc::new(foreign_modules::collect(tcx))
         },
         link_args: |tcx, cnum| {
             assert_eq!(cnum, LOCAL_CRATE);

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -10,7 +10,7 @@
 
 // Decoding metadata from a single crate's metadata
 
-use cstore::{self, CrateMetadata, MetadataBlob, NativeLibrary};
+use cstore::{self, CrateMetadata, MetadataBlob, NativeLibrary, ForeignModule};
 use schema::*;
 
 use rustc_data_structures::sync::Lrc;
@@ -1034,6 +1034,10 @@ impl<'a, 'tcx> CrateMetadata {
         self.root.native_libraries.decode((self, sess)).collect()
     }
 
+    pub fn get_foreign_modules(&self, sess: &Session) -> Vec<ForeignModule> {
+        self.root.foreign_modules.decode((self, sess)).collect()
+    }
+
     pub fn get_dylib_dependency_formats(&self) -> Vec<(CrateNum, LinkagePreference)> {
         self.root
             .dylib_dependency_formats
@@ -1094,10 +1098,6 @@ impl<'a, 'tcx> CrateMetadata {
             EntryKind::ForeignFn(_) => true,
             _ => false,
         }
-    }
-
-    pub fn is_dllimport_foreign_item(&self, id: DefIndex) -> bool {
-        self.dllimport_foreign_items.contains(&id)
     }
 
     pub fn fn_sig(&self,

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -14,7 +14,7 @@ use isolated_encoder::IsolatedEncoder;
 use schema::*;
 
 use rustc::middle::cstore::{LinkMeta, LinkagePreference, NativeLibrary,
-                            EncodedMetadata};
+                            EncodedMetadata, ForeignModule};
 use rustc::hir::def::CtorKind;
 use rustc::hir::def_id::{CrateNum, CRATE_DEF_INDEX, DefIndex, DefId, LocalDefId, LOCAL_CRATE};
 use rustc::hir::map::definitions::DefPathTable;
@@ -416,6 +416,10 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             ());
         let native_lib_bytes = self.position() - i;
 
+        let foreign_modules = self.tracked(
+            IsolatedEncoder::encode_foreign_modules,
+            ());
+
         // Encode codemap
         i = self.position();
         let codemap = self.encode_codemap();
@@ -478,6 +482,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             lang_items,
             lang_items_missing,
             native_libraries,
+            foreign_modules,
             codemap,
             def_path_table,
             impls,
@@ -1332,6 +1337,11 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
     fn encode_native_libraries(&mut self, _: ()) -> LazySeq<NativeLibrary> {
         let used_libraries = self.tcx.native_libraries(LOCAL_CRATE);
         self.lazy_seq(used_libraries.iter().cloned())
+    }
+
+    fn encode_foreign_modules(&mut self, _: ()) -> LazySeq<ForeignModule> {
+        let foreign_modules = self.tcx.foreign_modules(LOCAL_CRATE);
+        self.lazy_seq(foreign_modules.iter().cloned())
     }
 
     fn encode_crate_deps(&mut self, _: ()) -> LazySeq<CrateDep> {

--- a/src/librustc_metadata/foreign_modules.rs
+++ b/src/librustc_metadata/foreign_modules.rs
@@ -1,0 +1,48 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use rustc::hir::itemlikevisit::ItemLikeVisitor;
+use rustc::hir;
+use rustc::middle::cstore::ForeignModule;
+use rustc::ty::TyCtxt;
+
+pub fn collect<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) -> Vec<ForeignModule> {
+    let mut collector = Collector {
+        tcx,
+        modules: Vec::new(),
+    };
+    tcx.hir.krate().visit_all_item_likes(&mut collector);
+    return collector.modules
+}
+
+struct Collector<'a, 'tcx: 'a> {
+    tcx: TyCtxt<'a, 'tcx, 'tcx>,
+    modules: Vec<ForeignModule>,
+}
+
+impl<'a, 'tcx> ItemLikeVisitor<'tcx> for Collector<'a, 'tcx> {
+    fn visit_item(&mut self, it: &'tcx hir::Item) {
+        let fm = match it.node {
+            hir::ItemForeignMod(ref fm) => fm,
+            _ => return,
+        };
+
+        let foreign_items = fm.items.iter()
+            .map(|it| self.tcx.hir.local_def_id(it.id))
+            .collect();
+        self.modules.push(ForeignModule {
+            foreign_items,
+            def_id: self.tcx.hir.local_def_id(it.id),
+        });
+    }
+
+    fn visit_trait_item(&mut self, _it: &'tcx hir::TraitItem) {}
+    fn visit_impl_item(&mut self, _it: &'tcx hir::ImplItem) {}
+}

--- a/src/librustc_metadata/lib.rs
+++ b/src/librustc_metadata/lib.rs
@@ -56,6 +56,7 @@ mod isolated_encoder;
 mod schema;
 mod native_libs;
 mod link_args;
+mod foreign_modules;
 
 pub mod creader;
 pub mod cstore;

--- a/src/librustc_metadata/native_libs.rs
+++ b/src/librustc_metadata/native_libs.rs
@@ -105,14 +105,11 @@ impl<'a, 'tcx> ItemLikeVisitor<'tcx> for Collector<'a, 'tcx> {
             } else {
                 None
             };
-            let foreign_items = fm.items.iter()
-                .map(|it| self.tcx.hir.local_def_id(it.id))
-                .collect();
             let lib = NativeLibrary {
                 name: n,
                 kind,
                 cfg,
-                foreign_items,
+                foreign_module: Some(self.tcx.hir.local_def_id(it.id)),
             };
             self.register_native_lib(Some(m.span), lib);
         }
@@ -218,7 +215,7 @@ impl<'a, 'tcx> Collector<'a, 'tcx> {
                     name: Symbol::intern(new_name.unwrap_or(name)),
                     kind: if let Some(k) = kind { k } else { cstore::NativeUnknown },
                     cfg: None,
-                    foreign_items: Vec::new(),
+                    foreign_module: None,
                 };
                 self.register_native_lib(None, lib);
             }

--- a/src/librustc_metadata/schema.rs
+++ b/src/librustc_metadata/schema.rs
@@ -15,8 +15,8 @@ use rustc::hir;
 use rustc::hir::def::{self, CtorKind};
 use rustc::hir::def_id::{DefIndex, DefId, CrateNum};
 use rustc::ich::StableHashingContext;
-use rustc::middle::cstore::{DepKind, LinkagePreference, NativeLibrary};
 use rustc::middle::exported_symbols::{ExportedSymbol, SymbolExportLevel};
+use rustc::middle::cstore::{DepKind, LinkagePreference, NativeLibrary, ForeignModule};
 use rustc::middle::lang_items;
 use rustc::mir;
 use rustc::session::CrateDisambiguator;
@@ -200,6 +200,7 @@ pub struct CrateRoot {
     pub lang_items: LazySeq<(DefIndex, usize)>,
     pub lang_items_missing: LazySeq<lang_items::LangItem>,
     pub native_libraries: LazySeq<NativeLibrary>,
+    pub foreign_modules: LazySeq<ForeignModule>,
     pub codemap: LazySeq<syntax_pos::FileMap>,
     pub def_path_table: Lazy<hir::map::definitions::DefPathTable>,
     pub impls: LazySeq<TraitImpls>,

--- a/src/librustc_trans/attributes.rs
+++ b/src/librustc_trans/attributes.rs
@@ -14,8 +14,10 @@ use std::ffi::{CStr, CString};
 use rustc::hir::TransFnAttrFlags;
 use rustc::hir::def_id::{DefId, LOCAL_CRATE};
 use rustc::session::config::Sanitizer;
+use rustc::ty::TyCtxt;
 use rustc::ty::maps::Providers;
 use rustc_data_structures::sync::Lrc;
+use rustc_data_structures::fx::FxHashMap;
 
 use llvm::{self, Attribute, ValueRef};
 use llvm::AttributePlace::Function;
@@ -139,6 +141,20 @@ pub fn from_fn_attrs(cx: &CodegenCx, llfn: ValueRef, id: DefId) {
             llfn, llvm::AttributePlace::Function,
             cstr("target-features\0"), &val);
     }
+
+    // Note that currently the `wasm-import-module` doesn't do anything, but
+    // eventually LLVM 7 should read this and ferry the appropriate import
+    // module to the output file.
+    if cx.tcx.sess.target.target.arch == "wasm32" {
+        if let Some(module) = wasm_import_module(cx.tcx, id) {
+            llvm::AddFunctionAttrStringValue(
+                llfn,
+                llvm::AttributePlace::Function,
+                cstr("wasm-import-module\0"),
+                &module,
+            );
+        }
+    }
 }
 
 fn cstr(s: &'static str) -> &CStr {
@@ -153,4 +169,35 @@ pub fn provide(providers: &mut Providers) {
             .map(|c| c.to_string())
             .collect())
     };
+
+    provide_extern(providers);
+}
+
+pub fn provide_extern(providers: &mut Providers) {
+    providers.wasm_import_module_map = |tcx, cnum| {
+        let mut ret = FxHashMap();
+        for lib in tcx.foreign_modules(cnum).iter() {
+            let attrs = tcx.get_attrs(lib.def_id);
+            let mut module = None;
+            for attr in attrs.iter().filter(|a| a.check_name("wasm_import_module")) {
+                module = attr.value_str();
+            }
+            let module = match module {
+                Some(s) => s,
+                None => continue,
+            };
+            for id in lib.foreign_items.iter() {
+                assert_eq!(id.krate, cnum);
+                ret.insert(id.index, module.to_string());
+            }
+        }
+
+        Lrc::new(ret)
+    }
+}
+
+fn wasm_import_module(tcx: TyCtxt, id: DefId) -> Option<CString> {
+    tcx.wasm_import_module_map(id.krate)
+        .get(&id.index)
+        .map(|s| CString::new(&s[..]).unwrap())
 }

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use back::wasm;
 use cc::windows_registry;
 use super::archive::{ArchiveBuilder, ArchiveConfig};
 use super::bytecode::RLIB_BYTECODE_EXTENSION;
@@ -809,6 +810,10 @@ fn link_natively(sess: &Session,
             Ok(..) => {}
             Err(e) => sess.fatal(&format!("failed to run dsymutil: {}", e)),
         }
+    }
+
+    if sess.opts.target_triple == "wasm32-unknown-unknown" {
+        wasm::rewrite_imports(&out_filename, &trans.crate_info.wasm_imports);
     }
 }
 

--- a/src/librustc_trans/back/wasm.rs
+++ b/src/librustc_trans/back/wasm.rs
@@ -1,0 +1,213 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::fs;
+use std::path::Path;
+use std::str;
+
+use rustc_data_structures::fx::FxHashMap;
+use serialize::leb128;
+
+// https://webassembly.github.io/spec/core/binary/modules.html#binary-importsec
+const WASM_IMPORT_SECTION_ID: u8 = 2;
+
+const WASM_EXTERNAL_KIND_FUNCTION: u8 = 0;
+const WASM_EXTERNAL_KIND_TABLE: u8 = 1;
+const WASM_EXTERNAL_KIND_MEMORY: u8 = 2;
+const WASM_EXTERNAL_KIND_GLOBAL: u8 = 3;
+
+/// Rewrite the module imports are listed from in a wasm module given the field
+/// name to module name mapping in `import_map`.
+///
+/// LLVM 6 which we're using right now doesn't have the ability to configure the
+/// module a wasm symbol is import from. Rather all imported symbols come from
+/// the bland `"env"` module unconditionally. Furthermore we'd *also* need
+/// support in LLD for preserving these import modules, which it unfortunately
+/// currently does not.
+///
+/// This function is intended as a hack for now where we manually rewrite the
+/// wasm output by LLVM to have the correct import modules listed. The
+/// `#[wasm_import_module]` attribute in Rust translates to the module that each
+/// symbol is imported from, so here we manually go through the wasm file,
+/// decode it, rewrite imports, and then rewrite the wasm module.
+pub fn rewrite_imports(path: &Path, import_map: &FxHashMap<String, String>) {
+    let wasm = fs::read(path).expect("failed to read wasm output");
+    let mut ret = WasmEncoder::new();
+    ret.data.extend(&wasm[..8]);
+
+    // skip the 8 byte wasm/version header
+    for (id, raw) in WasmSections(WasmDecoder::new(&wasm[8..])) {
+        ret.u32(id as u32);
+        if id == WASM_IMPORT_SECTION_ID {
+            info!("rewriting import section");
+            let data = rewrite_import_section(
+                &mut WasmDecoder::new(raw),
+                import_map,
+            );
+            ret.bytes(&data);
+        } else {
+            info!("carry forward section {}, {} bytes long", id, raw.len());
+            ret.bytes(raw);
+        }
+    }
+
+    fs::write(path, &ret.data).expect("failed to write wasm output");
+
+    fn rewrite_import_section(
+        wasm: &mut WasmDecoder,
+        import_map: &FxHashMap<String, String>,
+    )
+        -> Vec<u8>
+    {
+        let mut dst = WasmEncoder::new();
+        let n = wasm.u32();
+        dst.u32(n);
+        info!("rewriting {} imports", n);
+        for _ in 0..n {
+            rewrite_import_entry(wasm, &mut dst, import_map);
+        }
+        return dst.data
+    }
+
+    fn rewrite_import_entry(wasm: &mut WasmDecoder,
+                            dst: &mut WasmEncoder,
+                            import_map: &FxHashMap<String, String>) {
+        // More info about the binary format here is available at:
+        // https://webassembly.github.io/spec/core/binary/modules.html#import-section
+        //
+        // Note that you can also find the whole point of existence of this
+        // function here, where we map the `module` name to a different one if
+        // we've got one listed.
+        let module = wasm.str();
+        let field = wasm.str();
+        let new_module = if module == "env" {
+            import_map.get(field).map(|s| &**s).unwrap_or(module)
+        } else {
+            module
+        };
+        info!("import rewrite ({} => {}) / {}", module, new_module, field);
+        dst.str(new_module);
+        dst.str(field);
+        let kind = wasm.byte();
+        dst.byte(kind);
+        match kind {
+            WASM_EXTERNAL_KIND_FUNCTION => dst.u32(wasm.u32()),
+            WASM_EXTERNAL_KIND_TABLE => {
+                dst.u32(wasm.u32()); // element_type
+                dst.limits(wasm.limits());
+            }
+            WASM_EXTERNAL_KIND_MEMORY => dst.limits(wasm.limits()),
+            WASM_EXTERNAL_KIND_GLOBAL => {
+                dst.u32(wasm.u32()); // content_type
+                dst.bool(wasm.bool()); // mutable
+            }
+            b => panic!("unknown kind: {}", b),
+        }
+    }
+}
+
+struct WasmSections<'a>(WasmDecoder<'a>);
+
+impl<'a> Iterator for WasmSections<'a> {
+    type Item = (u8, &'a [u8]);
+
+    fn next(&mut self) -> Option<(u8, &'a [u8])> {
+        if self.0.data.len() == 0 {
+            return None
+        }
+
+        // see https://webassembly.github.io/spec/core/binary/modules.html#sections
+        let id = self.0.byte();
+        let section_len = self.0.u32();
+        info!("new section {} / {} bytes", id, section_len);
+        let section = self.0.skip(section_len as usize);
+        Some((id, section))
+    }
+}
+
+struct WasmDecoder<'a> {
+    data: &'a [u8],
+}
+
+impl<'a> WasmDecoder<'a> {
+    fn new(data: &'a [u8]) -> WasmDecoder<'a> {
+        WasmDecoder { data }
+    }
+
+    fn byte(&mut self) -> u8 {
+        self.skip(1)[0]
+    }
+
+    fn u32(&mut self) -> u32 {
+        let (n, l1) = leb128::read_u32_leb128(self.data);
+        self.data = &self.data[l1..];
+        return n
+    }
+
+    fn skip(&mut self, amt: usize) -> &'a [u8] {
+        let (data, rest) = self.data.split_at(amt);
+        self.data = rest;
+        data
+    }
+
+    fn str(&mut self) -> &'a str {
+        let len = self.u32();
+        str::from_utf8(self.skip(len as usize)).unwrap()
+    }
+
+    fn bool(&mut self) -> bool {
+        self.byte() == 1
+    }
+
+    fn limits(&mut self) -> (u32, Option<u32>) {
+        let has_max = self.bool();
+        (self.u32(), if has_max { Some(self.u32()) } else { None })
+    }
+}
+
+struct WasmEncoder {
+    data: Vec<u8>,
+}
+
+impl WasmEncoder {
+    fn new() -> WasmEncoder {
+        WasmEncoder { data: Vec::new() }
+    }
+
+    fn u32(&mut self, val: u32) {
+        let at = self.data.len();
+        leb128::write_u32_leb128(&mut self.data, at, val);
+    }
+
+    fn byte(&mut self, val: u8) {
+        self.data.push(val);
+    }
+
+    fn bytes(&mut self, val: &[u8]) {
+        self.u32(val.len() as u32);
+        self.data.extend_from_slice(val);
+    }
+
+    fn str(&mut self, val: &str) {
+        self.bytes(val.as_bytes())
+    }
+
+    fn bool(&mut self, b: bool) {
+        self.byte(b as u8);
+    }
+
+    fn limits(&mut self, limits: (u32, Option<u32>)) {
+        self.bool(limits.1.is_some());
+        self.u32(limits.0);
+        if let Some(c) = limits.1 {
+            self.u32(c);
+        }
+    }
+}

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -98,6 +98,7 @@ mod back {
     pub mod symbol_export;
     pub mod write;
     mod rpath;
+    mod wasm;
 }
 
 mod abi;
@@ -213,6 +214,8 @@ impl TransCrate for LlvmTransCrate {
 
     fn provide_extern(&self, providers: &mut ty::maps::Providers) {
         back::symbol_export::provide_extern(providers);
+        base::provide_extern(providers);
+        attributes::provide_extern(providers);
     }
 
     fn trans_crate<'a, 'tcx>(
@@ -399,6 +402,7 @@ struct CrateInfo {
     used_crate_source: FxHashMap<CrateNum, Lrc<CrateSource>>,
     used_crates_static: Vec<(CrateNum, LibSource)>,
     used_crates_dynamic: Vec<(CrateNum, LibSource)>,
+    wasm_imports: FxHashMap<String, String>,
 }
 
 __build_diagnostic_array! { librustc_trans, DIAGNOSTICS }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -455,6 +455,9 @@ declare_features! (
 
     // Parentheses in patterns
     (active, pattern_parentheses, "1.26.0", None, None),
+
+    // The #![wasm_import_module] attribute
+    (active, wasm_import_module, "1.26.0", None, None),
 );
 
 declare_features! (
@@ -908,6 +911,10 @@ pub const BUILTIN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeG
         "the `#[no_debug]` attribute was an experimental feature that has been \
          deprecated due to lack of demand",
         cfg_fn!(no_debug))),
+    ("wasm_import_module", Normal, Gated(Stability::Unstable,
+                                 "wasm_import_module",
+                                 "experimental attribute",
+                                 cfg_fn!(wasm_import_module))),
     ("omit_gdb_pretty_printer_section", Whitelisted, Gated(Stability::Unstable,
                                                        "omit_gdb_pretty_printer_section",
                                                        "the `#[omit_gdb_pretty_printer_section]` \

--- a/src/test/ui/feature-gate-wasm_import_module.rs
+++ b/src/test/ui/feature-gate-wasm_import_module.rs
@@ -1,0 +1,15 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[wasm_import_module = "test"] //~ ERROR: experimental
+extern {
+}
+
+fn main() {}

--- a/src/test/ui/feature-gate-wasm_import_module.stderr
+++ b/src/test/ui/feature-gate-wasm_import_module.stderr
@@ -1,0 +1,11 @@
+error[E0658]: experimental attribute
+  --> $DIR/feature-gate-wasm_import_module.rs:11:1
+   |
+LL | #[wasm_import_module = "test"] //~ ERROR: experimental
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(wasm_import_module)] to the crate attributes to enable
+
+error: aborting due to previous error
+
+If you want more information on this error, try using "rustc --explain E0658"

--- a/src/test/ui/wasm-import-module.rs
+++ b/src/test/ui/wasm-import-module.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(wasm_import_module)]
+
+#[wasm_import_module] //~ ERROR: must be of the form
+extern {}
+
+#[wasm_import_module = "foo"] //~ ERROR: must only be attached to
+fn foo() {}
+
+fn main() {}
+

--- a/src/test/ui/wasm-import-module.stderr
+++ b/src/test/ui/wasm-import-module.stderr
@@ -1,0 +1,14 @@
+error: must be of the form #[wasm_import_module = "..."]
+  --> $DIR/wasm-import-module.rs:13:1
+   |
+LL | #[wasm_import_module] //~ ERROR: must be of the form
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error: must only be attached to foreign modules
+  --> $DIR/wasm-import-module.rs:16:1
+   |
+LL | #[wasm_import_module = "foo"] //~ ERROR: must only be attached to
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
This commit adds a new attribute to the Rust compiler specific to the wasm
target (and no other targets). The `#[wasm_import_module]` attribute is used to
specify the module that a name is imported from, and is used like so:

    #[wasm_import_module = "./foo.js"]
    extern {
        fn some_js_function();
    }

Here the import of the symbol `some_js_function` is tagged with the `./foo.js`
module in the wasm output file. Wasm-the-format includes two fields on all
imports, a module and a field. The field is the symbol name (`some_js_function`
above) and the module has historically unconditionally been `"env"`. I'm not
sure if this `"env"` convention has asm.js or LLVM roots, but regardless we'd
like the ability to configure it!

The proposed ES module integration with wasm (aka a wasm module is "just another
ES module") requires that the import module of wasm imports is interpreted as an
ES module import, meaning that you'll need to encode paths, NPM packages, etc.
As a result, we'll need this to be something other than `"env"`!

Unfortunately neither our version of LLVM nor LLD supports custom import modules
(aka anything not `"env"`). My hope is that by the time LLVM 7 is released both
will have support, but in the meantime this commit adds some primitive
encoding/decoding of wasm files to the compiler. This way rustc postprocesses
the wasm module that LLVM emits to ensure it's got all the imports we'd like to
have in it.

Eventually I'd ideally like to unconditionally require this attribute to be
placed on all `extern { ... }` blocks. For now though it seemed prudent to add
it as an unstable attribute, so for now it's not required (as that'd force usage
of a feature gate). Hopefully it doesn't take too long to "stabilize" this!

cc rust-lang-nursery/rust-wasm#29