### PR TITLE
str: add cut and cutn methods

### DIFF
--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -1853,6 +1853,37 @@ impl str {
         result
     }
 
+    /// Removes all matches of a pattern.
+    ///
+    /// `cut` creates a new [`String`], and copies the data from this string slice into it.
+    /// While doing so, it attempts to find matches of a pattern. If it finds any, it
+    /// excludes them from the String.
+    ///
+    /// [`String`]: string/struct.String.html
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(str_cut)]
+    /// let s = "this is new";
+    ///
+    /// assert_eq!("this is ew", s.cut('n'));
+    /// ```
+    ///
+    /// When the pattern doesn't match:
+    ///
+    /// ```
+    /// #![feature(str_cut)]
+    /// let s = "this is old";
+    /// assert_eq!(s, s.cut("new"));
+    /// ```
+    #[unstable(feature = "str_cut", issue = "0")]
+    pub fn cut<'a, P: Pattern<'a>>(&'a self, pattern: P) -> String {
+        self.replace(pattern, "")
+    }
+
     /// Replaces first N matches of a pattern with another string.
     ///
     /// `replacen` creates a new [`String`], and copies the data from this string slice into it.
@@ -1890,6 +1921,38 @@ impl str {
         }
         result.push_str(unsafe { self.slice_unchecked(last_end, self.len()) });
         result
+    }
+
+    /// Removes first N matches of a pattern.
+    ///
+    /// `cutn` creates a new [`String`], and copies the data from this string slice into it.
+    /// While doing so, it attempts to find matches of a pattern. If it finds any, it
+    /// excludes them from the String at most `count` times.
+    ///
+    /// [`String`]: string/struct.String.html
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(str_cutn)]
+    /// let s = "foo foo 123 foo";
+    /// assert_eq!("  123 foo", s.cutn("foo", 2));
+    /// assert_eq!("f fo 123 foo", s.cutn('o', 3));
+    /// assert_eq!("foo foo 3 foo", s.cutn(char::is_numeric, 2));
+    /// ```
+    ///
+    /// When the pattern doesn't match:
+    ///
+    /// ```
+    /// #![feature(str_cutn)]
+    /// let s = "this is old";
+    /// assert_eq!(s, s.cutn("new", 1));
+    /// ```
+    #[unstable(feature = "str_cutn", issue = "0")]
+    pub fn cutn<'a, P: Pattern<'a>>(&'a self, pattern: P, count: usize) -> String {
+        self.replacen(pattern, "", count)
     }
 
     /// Returns the lowercase equivalent of this string slice, as a new [`String`].

--- a/src/liballoc/tests/lib.rs
+++ b/src/liballoc/tests/lib.rs
@@ -29,6 +29,8 @@
 #![feature(unboxed_closures)]
 #![feature(unicode)]
 #![feature(exact_chunks)]
+#![feature(str_cut)]
+#![feature(str_cutn)]
 
 extern crate alloc_system;
 extern crate std_unicode;

--- a/src/liballoc/tests/str.rs
+++ b/src/liballoc/tests/str.rs
@@ -292,6 +292,45 @@ fn test_replace_pattern() {
 }
 
 #[test]
+fn test_cutn() {
+    assert_eq!("".cutn('a', 5), "");
+    assert_eq!("acaaa".cutn('a', 3), "ca");
+    assert_eq!("aaaa".cutn('a', 0), "aaaa");
+
+    let test = "test";
+    assert_eq!(" test test ".cutn(test, 3), "   ");
+    assert_eq!(" test test ".cutn(test, 0), " test test ");
+    assert_eq!(" test test ".cutn("", 1), " test test ");
+
+    assert_eq!("qwer123zxc789".cutn(char::is_numeric, 3), "qwerzxc789");
+
+    let jyushimatsu = "松野 十四松";
+    assert_eq!(jyushimatsu.cutn('松', 1), "野 十四松");
+}
+
+#[test]
+fn test_cut() {
+    assert_eq!("".cut('a'), "");
+    assert_eq!("a".cut('a'), "");
+    assert_eq!("ab".cut('a'), "b");
+
+    assert_eq!(" test test ".cut("test"), "   ");
+}
+
+#[test]
+fn test_cut_2() {
+    let programming_lang = "язык программирования";
+    let karamatsu = "松野 カラ松";
+
+    assert_eq!("язык програмвания", programming_lang.cut("миро"));
+    assert_eq!(" ", karamatsu.cut(char::is_alphabetic));
+    assert_eq!("языкпрограммирования", programming_lang.cut(char::is_whitespace));
+    assert_eq!("野 カラ", karamatsu.cut('松'));
+    assert_eq!("язык прогрммировния", programming_lang.cut('а'));
+    assert_eq!("松野 松", karamatsu.cut("カラ"));
+}
+
+#[test]
 fn test_slice() {
     assert_eq!("ab", &"abc"[0..2]);
     assert_eq!("bc", &"abc"[1..3]);


### PR DESCRIPTION
These methods just wrap replace/replacen and provide a more concise way to remove patterns from strs