### PR TITLE
rename epoch to edition

### DIFF
--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -201,7 +201,7 @@ impl LintStore {
                                         sess: Option<&Session>,
                                         lints: Vec<FutureIncompatibleInfo>) {
 
-        for edition in edition::ALL_EPOCHS {
+        for edition in edition::ALL_EDITIONS {
             let lints = lints.iter().filter(|f| f.edition == Some(*edition)).map(|f| f.id)
                              .collect::<Vec<_>>();
             if !lints.is_empty() {

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -41,7 +41,7 @@ use util::nodemap::FxHashMap;
 use std::default::Default as StdDefault;
 use std::cell::{Ref, RefCell};
 use syntax::ast;
-use syntax::epoch;
+use syntax::edition;
 use syntax_pos::{MultiSpan, Span};
 use errors::DiagnosticBuilder;
 use hir;
@@ -103,9 +103,9 @@ pub struct FutureIncompatibleInfo {
     pub id: LintId,
     /// e.g., a URL for an issue/PR/RFC or error code
     pub reference: &'static str,
-    /// If this is an epoch fixing lint, the epoch in which
+    /// If this is an edition fixing lint, the edition in which
     /// this lint becomes obsolete
-    pub epoch: Option<epoch::Epoch>,
+    pub edition: Option<edition::Edition>,
 }
 
 /// The target of the `by_name` map, which accounts for renaming/deprecation.
@@ -201,11 +201,11 @@ impl LintStore {
                                         sess: Option<&Session>,
                                         lints: Vec<FutureIncompatibleInfo>) {
 
-        for epoch in epoch::ALL_EPOCHS {
-            let lints = lints.iter().filter(|f| f.epoch == Some(*epoch)).map(|f| f.id)
+        for edition in edition::ALL_EPOCHS {
+            let lints = lints.iter().filter(|f| f.edition == Some(*edition)).map(|f| f.id)
                              .collect::<Vec<_>>();
             if !lints.is_empty() {
-                self.register_group(sess, false, epoch.lint_name(), lints)
+                self.register_group(sess, false, edition.lint_name(), lints)
             }
         }
 

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -42,7 +42,7 @@ use session::{Session, DiagnosticMessageId};
 use std::hash;
 use syntax::ast;
 use syntax::codemap::MultiSpan;
-use syntax::epoch::Epoch;
+use syntax::edition::Edition;
 use syntax::symbol::Symbol;
 use syntax::visit as ast_visit;
 use syntax_pos::Span;
@@ -77,8 +77,8 @@ pub struct Lint {
     /// e.g. "imports that are never used"
     pub desc: &'static str,
 
-    /// Deny lint after this epoch
-    pub epoch_deny: Option<Epoch>,
+    /// Deny lint after this edition
+    pub edition_deny: Option<Edition>,
 }
 
 impl Lint {
@@ -88,8 +88,8 @@ impl Lint {
     }
 
     pub fn default_level(&self, session: &Session) -> Level {
-        if let Some(epoch_deny) = self.epoch_deny {
-            if session.epoch() >= epoch_deny {
+        if let Some(edition_deny) = self.edition_deny {
+            if session.edition() >= edition_deny {
                 return Level::Deny
             }
         }
@@ -100,12 +100,12 @@ impl Lint {
 /// Declare a static item of type `&'static Lint`.
 #[macro_export]
 macro_rules! declare_lint {
-    ($vis: vis $NAME: ident, $Level: ident, $desc: expr, $epoch: expr) => (
+    ($vis: vis $NAME: ident, $Level: ident, $desc: expr, $edition: expr) => (
         $vis static $NAME: &$crate::lint::Lint = &$crate::lint::Lint {
             name: stringify!($NAME),
             default_level: $crate::lint::$Level,
             desc: $desc,
-            epoch_deny: Some($epoch)
+            edition_deny: Some($edition)
         };
     );
     ($vis: vis $NAME: ident, $Level: ident, $desc: expr) => (
@@ -113,7 +113,7 @@ macro_rules! declare_lint {
             name: stringify!($NAME),
             default_level: $crate::lint::$Level,
             desc: $desc,
-            epoch_deny: None,
+            edition_deny: None,
         };
     );
 }
@@ -499,8 +499,8 @@ pub fn struct_lint_level<'a>(sess: &'a Session,
     // Check for future incompatibility lints and issue a stronger warning.
     let lints = sess.lint_store.borrow();
     if let Some(future_incompatible) = lints.future_incompatible(LintId::of(lint)) {
-        let future = if let Some(epoch) = future_incompatible.epoch {
-            format!("the {} epoch", epoch)
+        let future = if let Some(edition) = future_incompatible.edition {
+            format!("the {} edition", edition)
         } else {
             "a future release".to_owned()
         };

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -28,7 +28,7 @@ use middle::cstore;
 
 use syntax::ast::{self, IntTy, UintTy};
 use syntax::codemap::{FileName, FilePathMapping};
-use syntax::epoch::Epoch;
+use syntax::edition::Edition;
 use syntax::parse::token;
 use syntax::parse;
 use syntax::symbol::Symbol;
@@ -771,7 +771,7 @@ macro_rules! options {
             Some("`string` or `string=string`");
         pub const parse_lto: Option<&'static str> =
             Some("one of `thin`, `fat`, or omitted");
-        pub const parse_epoch: Option<&'static str> =
+        pub const parse_edition: Option<&'static str> =
             Some("one of: `2015`, `2018`");
     }
 
@@ -780,7 +780,7 @@ macro_rules! options {
         use super::{$struct_name, Passes, SomePasses, AllPasses, Sanitizer, Lto};
         use rustc_back::{LinkerFlavor, PanicStrategy, RelroLevel};
         use std::path::PathBuf;
-        use syntax::epoch::Epoch;
+        use syntax::edition::Edition;
 
         $(
             pub fn $opt(cg: &mut $struct_name, v: Option<&str>) -> bool {
@@ -983,11 +983,11 @@ macro_rules! options {
             true
         }
 
-        fn parse_epoch(slot: &mut Epoch, v: Option<&str>) -> bool {
+        fn parse_edition(slot: &mut Edition, v: Option<&str>) -> bool {
             match v {
                 Some(s) => {
-                    let epoch = s.parse();
-                    if let Ok(parsed) = epoch {
+                    let edition = s.parse();
+                    if let Ok(parsed) = edition {
                         *slot = parsed;
                         true
                     } else {
@@ -1280,10 +1280,10 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
         `everybody_loops` (all function bodies replaced with `loop {}`),
         `hir` (the HIR), `hir,identified`, or
         `hir,typed` (HIR with types for each node)."),
-    epoch: Epoch = (Epoch::Epoch2015, parse_epoch, [TRACKED],
-        "The epoch to build Rust with. Newer epochs may include features
-         that require breaking changes. The default epoch is 2015 (the first
-         epoch). Crates compiled with different epochs can be linked together."),
+    edition: Edition = (Edition::Edition2015, parse_edition, [TRACKED],
+        "The edition to build Rust with. Newer editions may include features
+         that require breaking changes. The default edition is 2015 (the first
+         edition). Crates compiled with different editions can be linked together."),
     run_dsymutil: Option<bool> = (None, parse_opt_bool, [TRACKED],
           "run `dsymutil` and delete intermediate object files"),
     ui_testing: bool = (false, parse_bool, [UNTRACKED],
@@ -2258,7 +2258,7 @@ mod dep_tracking {
     use std::hash::Hash;
     use std::path::PathBuf;
     use std::collections::hash_map::DefaultHasher;
-    use super::{CrateType, DebugInfoLevel, Epoch, ErrorOutputType, Lto, OptLevel, OutputTypes,
+    use super::{CrateType, DebugInfoLevel, Edition, ErrorOutputType, Lto, OptLevel, OutputTypes,
                 Passes, Sanitizer};
     use syntax::feature_gate::UnstableFeatures;
     use rustc_back::{PanicStrategy, RelroLevel};
@@ -2320,7 +2320,7 @@ mod dep_tracking {
     impl_dep_tracking_hash_via_hash!(cstore::NativeLibraryKind);
     impl_dep_tracking_hash_via_hash!(Sanitizer);
     impl_dep_tracking_hash_via_hash!(Option<Sanitizer>);
-    impl_dep_tracking_hash_via_hash!(Epoch);
+    impl_dep_tracking_hash_via_hash!(Edition);
 
     impl_dep_tracking_hash_for_sortable_vec_of!(String);
     impl_dep_tracking_hash_for_sortable_vec_of!(PathBuf);

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -31,7 +31,7 @@ use rustc_data_structures::sync::{Lrc, Lock};
 use syntax::ast::NodeId;
 use errors::{self, DiagnosticBuilder, DiagnosticId};
 use errors::emitter::{Emitter, EmitterWriter};
-use syntax::epoch::Epoch;
+use syntax::edition::Edition;
 use syntax::json::JsonEmitter;
 use syntax::feature_gate;
 use syntax::symbol::Symbol;
@@ -976,13 +976,13 @@ impl Session {
         self.opts.debugging_opts.teach && !self.parse_sess.span_diagnostic.code_emitted(code)
     }
 
-    /// Are we allowed to use features from the Rust 2018 epoch?
+    /// Are we allowed to use features from the Rust 2018 edition?
     pub fn rust_2018(&self) -> bool {
-        self.opts.debugging_opts.epoch >= Epoch::Epoch2018
+        self.opts.debugging_opts.edition >= Edition::Edition2018
     }
 
-    pub fn epoch(&self) -> Epoch {
-        self.opts.debugging_opts.epoch
+    pub fn edition(&self) -> Edition {
+        self.opts.debugging_opts.edition
     }
 }
 

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -648,7 +648,7 @@ pub fn phase_2_configure_and_expand_inner<'a, F>(sess: &'a Session,
 {
     let (mut krate, features) = syntax::config::features(krate, &sess.parse_sess,
                                                          sess.opts.test,
-                                                         sess.opts.debugging_opts.epoch);
+                                                         sess.opts.debugging_opts.edition);
     // these need to be set "early" so that expansion sees `quote` if enabled.
     sess.init_features(features);
 

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -48,7 +48,7 @@ use rustc::session;
 use rustc::util;
 
 use session::Session;
-use syntax::epoch::Epoch;
+use syntax::edition::Edition;
 use lint::LintId;
 use lint::FutureIncompatibleInfo;
 
@@ -197,82 +197,82 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
         FutureIncompatibleInfo {
             id: LintId::of(PRIVATE_IN_PUBLIC),
             reference: "issue #34537 <https://github.com/rust-lang/rust/issues/34537>",
-            epoch: None,
+            edition: None,
         },
         FutureIncompatibleInfo {
             id: LintId::of(PUB_USE_OF_PRIVATE_EXTERN_CRATE),
             reference: "issue #34537 <https://github.com/rust-lang/rust/issues/34537>",
-            epoch: None,
+            edition: None,
         },
         FutureIncompatibleInfo {
             id: LintId::of(PATTERNS_IN_FNS_WITHOUT_BODY),
             reference: "issue #35203 <https://github.com/rust-lang/rust/issues/35203>",
-            epoch: None,
+            edition: None,
         },
         FutureIncompatibleInfo {
             id: LintId::of(SAFE_EXTERN_STATICS),
             reference: "issue #36247 <https://github.com/rust-lang/rust/issues/36247>",
-            epoch: None,
+            edition: None,
         },
         FutureIncompatibleInfo {
             id: LintId::of(INVALID_TYPE_PARAM_DEFAULT),
             reference: "issue #36887 <https://github.com/rust-lang/rust/issues/36887>",
-            epoch: None,
+            edition: None,
         },
         FutureIncompatibleInfo {
             id: LintId::of(LEGACY_DIRECTORY_OWNERSHIP),
             reference: "issue #37872 <https://github.com/rust-lang/rust/issues/37872>",
-            epoch: None,
+            edition: None,
         },
         FutureIncompatibleInfo {
             id: LintId::of(LEGACY_IMPORTS),
             reference: "issue #38260 <https://github.com/rust-lang/rust/issues/38260>",
-            epoch: None,
+            edition: None,
         },
         FutureIncompatibleInfo {
             id: LintId::of(LEGACY_CONSTRUCTOR_VISIBILITY),
             reference: "issue #39207 <https://github.com/rust-lang/rust/issues/39207>",
-            epoch: None,
+            edition: None,
         },
         FutureIncompatibleInfo {
             id: LintId::of(MISSING_FRAGMENT_SPECIFIER),
             reference: "issue #40107 <https://github.com/rust-lang/rust/issues/40107>",
-            epoch: None,
+            edition: None,
         },
         FutureIncompatibleInfo {
             id: LintId::of(ILLEGAL_FLOATING_POINT_LITERAL_PATTERN),
             reference: "issue #41620 <https://github.com/rust-lang/rust/issues/41620>",
-            epoch: None,
+            edition: None,
         },
         FutureIncompatibleInfo {
             id: LintId::of(ANONYMOUS_PARAMETERS),
             reference: "issue #41686 <https://github.com/rust-lang/rust/issues/41686>",
-            epoch: None,
+            edition: None,
         },
         FutureIncompatibleInfo {
             id: LintId::of(PARENTHESIZED_PARAMS_IN_TYPES_AND_MODULES),
             reference: "issue #42238 <https://github.com/rust-lang/rust/issues/42238>",
-            epoch: None,
+            edition: None,
         },
         FutureIncompatibleInfo {
             id: LintId::of(LATE_BOUND_LIFETIME_ARGUMENTS),
             reference: "issue #42868 <https://github.com/rust-lang/rust/issues/42868>",
-            epoch: None,
+            edition: None,
         },
         FutureIncompatibleInfo {
             id: LintId::of(SAFE_PACKED_BORROWS),
             reference: "issue #46043 <https://github.com/rust-lang/rust/issues/46043>",
-            epoch: None,
+            edition: None,
         },
         FutureIncompatibleInfo {
             id: LintId::of(INCOHERENT_FUNDAMENTAL_IMPLS),
             reference: "issue #46205 <https://github.com/rust-lang/rust/issues/46205>",
-            epoch: None,
+            edition: None,
         },
         FutureIncompatibleInfo {
             id: LintId::of(TYVAR_BEHIND_RAW_POINTER),
             reference: "issue #46906 <https://github.com/rust-lang/rust/issues/46906>",
-            epoch: Some(Epoch::Epoch2018),
+            edition: Some(Edition::Edition2018),
         }
         ]);
 

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -326,7 +326,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     if reached_raw_pointer
                     && !self.tcx.features().arbitrary_self_types {
                         // this case used to be allowed by the compiler,
-                        // so we do a future-compat lint here for the 2015 epoch
+                        // so we do a future-compat lint here for the 2015 edition
                         // (see https://github.com/rust-lang/rust/issues/46906)
                         if self.tcx.sess.rust_2018() {
                           span_err!(self.tcx.sess, span, E0908,

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -13,7 +13,7 @@ use feature_gate::{feature_err, EXPLAIN_STMT_ATTR_SYNTAX, Features, get_features
 use {fold, attr};
 use ast;
 use codemap::Spanned;
-use epoch::Epoch;
+use edition::Edition;
 use parse::{token, ParseSess};
 
 use ptr::P;
@@ -27,7 +27,7 @@ pub struct StripUnconfigured<'a> {
 }
 
 // `cfg_attr`-process the crate's attributes and compute the crate's features.
-pub fn features(mut krate: ast::Crate, sess: &ParseSess, should_test: bool, epoch: Epoch)
+pub fn features(mut krate: ast::Crate, sess: &ParseSess, should_test: bool, edition: Edition)
                 -> (ast::Crate, Features) {
     let features;
     {
@@ -47,7 +47,7 @@ pub fn features(mut krate: ast::Crate, sess: &ParseSess, should_test: bool, epoc
             return (krate, Features::new());
         }
 
-        features = get_features(&sess.span_diagnostic, &krate.attrs, epoch);
+        features = get_features(&sess.span_diagnostic, &krate.attrs, edition);
 
         // Avoid reconfiguring malformed `cfg_attr`s
         if err_count == sess.span_diagnostic.err_count() {

--- a/src/libsyntax/edition.rs
+++ b/src/libsyntax/edition.rs
@@ -36,7 +36,7 @@ pub enum Edition {
 }
 
 // must be in order from oldest to newest
-pub const ALL_EPOCHS: &[Edition] = &[Edition::Edition2015, Edition::Edition2018];
+pub const ALL_EDITIONS: &[Edition] = &[Edition::Edition2015, Edition::Edition2018];
 
 impl fmt::Display for Edition {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/libsyntax/edition.rs
+++ b/src/libsyntax/edition.rs
@@ -11,58 +11,58 @@
 use std::fmt;
 use std::str::FromStr;
 
-/// The epoch of the compiler (RFC 2052)
+/// The edition of the compiler (RFC 2052)
 #[derive(Clone, Copy, Hash, PartialOrd, Ord, Eq, PartialEq, Debug)]
 #[non_exhaustive]
-pub enum Epoch {
-    // epochs must be kept in order, newest to oldest
+pub enum Edition {
+    // editions must be kept in order, newest to oldest
 
-    /// The 2015 epoch
-    Epoch2015,
-    /// The 2018 epoch
-    Epoch2018,
+    /// The 2015 edition
+    Edition2015,
+    /// The 2018 edition
+    Edition2018,
 
-    // when adding new epochs, be sure to update:
+    // when adding new editions, be sure to update:
     //
-    // - the list in the `parse_epoch` static in librustc::session::config
+    // - the list in the `parse_edition` static in librustc::session::config
     // - add a `rust_####()` function to the session
     // - update the enum in Cargo's sources as well
     //
-    // When -Zepoch becomes --epoch, there will
-    // also be a check for the epoch being nightly-only
+    // When -Zedition becomes --edition, there will
+    // also be a check for the edition being nightly-only
     // somewhere. That will need to be updated
-    // whenever we're stabilizing/introducing a new epoch
+    // whenever we're stabilizing/introducing a new edition
     // as well as changing the default Cargo template.
 }
 
 // must be in order from oldest to newest
-pub const ALL_EPOCHS: &[Epoch] = &[Epoch::Epoch2015, Epoch::Epoch2018];
+pub const ALL_EPOCHS: &[Edition] = &[Edition::Edition2015, Edition::Edition2018];
 
-impl fmt::Display for Epoch {
+impl fmt::Display for Edition {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match *self {
-            Epoch::Epoch2015 => "2015",
-            Epoch::Epoch2018 => "2018",
+            Edition::Edition2015 => "2015",
+            Edition::Edition2018 => "2018",
         };
         write!(f, "{}", s)
     }
 }
 
-impl Epoch {
+impl Edition {
     pub fn lint_name(&self) -> &'static str {
         match *self {
-            Epoch::Epoch2015 => "epoch_2015",
-            Epoch::Epoch2018 => "epoch_2018",
+            Edition::Edition2015 => "edition_2015",
+            Edition::Edition2018 => "edition_2018",
         }
     }
 }
 
-impl FromStr for Epoch {
+impl FromStr for Edition {
     type Err = ();
     fn from_str(s: &str) -> Result<Self, ()> {
         match s {
-            "2015" => Ok(Epoch::Epoch2015),
-            "2018" => Ok(Epoch::Epoch2018),
+            "2015" => Ok(Edition::Edition2015),
+            "2018" => Ok(Edition::Edition2018),
             _ => Err(())
         }
     }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -28,7 +28,7 @@ use self::AttributeGate::*;
 use abi::Abi;
 use ast::{self, NodeId, PatKind, RangeEnd};
 use attr;
-use epoch::Epoch;
+use edition::Edition;
 use codemap::Spanned;
 use syntax_pos::{Span, DUMMY_SP};
 use errors::{DiagnosticBuilder, Handler, FatalError};
@@ -55,13 +55,13 @@ macro_rules! set {
 }
 
 macro_rules! declare_features {
-    ($((active, $feature: ident, $ver: expr, $issue: expr, $epoch: expr),)+) => {
+    ($((active, $feature: ident, $ver: expr, $issue: expr, $edition: expr),)+) => {
         /// Represents active features that are currently being implemented or
         /// currently being considered for addition/removal.
         const ACTIVE_FEATURES:
                 &'static [(&'static str, &'static str, Option<u32>,
-                           Option<Epoch>, fn(&mut Features, Span))] =
-            &[$((stringify!($feature), $ver, $issue, $epoch, set!($feature))),+];
+                           Option<Edition>, fn(&mut Features, Span))] =
+            &[$((stringify!($feature), $ver, $issue, $edition, set!($feature))),+];
 
         /// A set of features to be used by later passes.
         #[derive(Clone)]
@@ -402,7 +402,7 @@ declare_features! (
     (active, match_default_bindings, "1.22.0", Some(42640), None),
 
     // Trait object syntax with `dyn` prefix
-    (active, dyn_trait, "1.22.0", Some(44662), Some(Epoch::Epoch2018)),
+    (active, dyn_trait, "1.22.0", Some(44662), Some(Edition::Edition2018)),
 
     // `crate` as visibility modifier, synonymous to `pub(crate)`
     (active, crate_visibility_modifier, "1.23.0", Some(45388), None),
@@ -1800,16 +1800,16 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
 }
 
 pub fn get_features(span_handler: &Handler, krate_attrs: &[ast::Attribute],
-                    epoch: Epoch) -> Features {
+                    edition: Edition) -> Features {
     let mut features = Features::new();
 
     let mut feature_checker = FeatureChecker::default();
 
-    for &(.., f_epoch, set) in ACTIVE_FEATURES.iter() {
-        if let Some(f_epoch) = f_epoch {
-            if epoch >= f_epoch {
+    for &(.., f_edition, set) in ACTIVE_FEATURES.iter() {
+        if let Some(f_edition) = f_edition {
+            if edition >= f_edition {
                 // FIXME(Manishearth) there is currently no way to set
-                // lang features by epoch
+                // lang features by edition
                 set(&mut features, DUMMY_SP);
             }
         }

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -145,7 +145,7 @@ pub mod codemap;
 #[macro_use]
 pub mod config;
 pub mod entry;
-pub mod epoch;
+pub mod edition;
 pub mod feature_gate;
 pub mod fold;
 pub mod parse;

--- a/src/test/compile-fail/edition-raw-pointer-method-2015.rs
+++ b/src/test/compile-fail/edition-raw-pointer-method-2015.rs
@@ -9,14 +9,15 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags: -Zepoch=2018 -Zunstable-options
+// compile-flags: -Zedition=2015 -Zunstable-options
 
-// tests that epochs work with the tyvar warning-turned-error
+// tests that editions work with the tyvar warning-turned-error
 
 #[deny(warnings)]
 fn main() {
     let x = 0;
     let y = &x as *const _;
     let _ = y.is_null();
-    //~^ error: the type of this value must be known to call a method on a raw pointer on it [E0908]
+    //~^ error: type annotations needed [tyvar_behind_raw_pointer]
+    //~^^ warning: this was previously accepted
 }

--- a/src/test/compile-fail/edition-raw-pointer-method-2018.rs
+++ b/src/test/compile-fail/edition-raw-pointer-method-2018.rs
@@ -9,15 +9,14 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags: -Zepoch=2015 -Zunstable-options
+// compile-flags: -Zedition=2018 -Zunstable-options
 
-// tests that epochs work with the tyvar warning-turned-error
+// tests that editions work with the tyvar warning-turned-error
 
 #[deny(warnings)]
 fn main() {
     let x = 0;
     let y = &x as *const _;
     let _ = y.is_null();
-    //~^ error: type annotations needed [tyvar_behind_raw_pointer]
-    //~^^ warning: this was previously accepted
+    //~^ error: the type of this value must be known to call a method on a raw pointer on it [E0908]
 }

--- a/src/test/run-pass/dyn-trait.rs
+++ b/src/test/run-pass/dyn-trait.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty `dyn ::foo` parses differently in the current epoch
+// ignore-pretty `dyn ::foo` parses differently in the current edition
 
 #![feature(dyn_trait)]
 

--- a/src/test/run-pass/epoch-gate-feature.rs
+++ b/src/test/run-pass/epoch-gate-feature.rs
@@ -11,7 +11,7 @@
 // Checks if the correct registers are being used to pass arguments
 // when the sysv64 ABI is specified.
 
-// compile-flags: -Zepoch=2018
+// compile-flags: -Zedition=2018
 
 pub trait Foo {}
 

--- a/src/test/ui/inference-variable-behind-raw-pointer.stderr
+++ b/src/test/ui/inference-variable-behind-raw-pointer.stderr
@@ -5,6 +5,6 @@ LL |     if data.is_null() {}
    |             ^^^^^^^
    |
    = note: #[warn(tyvar_behind_raw_pointer)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 epoch!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue #46906 <https://github.com/rust-lang/rust/issues/46906>
 


### PR DESCRIPTION
As outlined in #49001 we'd like to rename all instances of `epoch` to `edition`. I developed the following bash script to assist in the rename. It renames all instances of `epoch` to `edition` and `Epoch` to `Edition` in all of the files I was able to determine were relevant. It then renames a few relevant files that had `epoch` in there name and finally prints out all of the remaining instance of the strings `epoch` and `Epoch` (which, as far as I can tell should not be changed). Here is the script:

```
replace() {
	sed -i '' "s/epoch/edition/g" "$1"
    sed -i '' "s/Epoch/Edition/g" "$1"
}

replace "src/librustc/lint/context.rs"
replace "src/librustc/lint/mod.rs"
replace "src/librustc/session/config.rs"
replace "src/librustc/session/mod.rs"
replace "src/librustc_driver/driver.rs"
replace "src/librustc_lint/lib.rs"
replace "src/librustc_typeck/check/method/probe.rs"
replace "src/libsyntax/config.rs"
replace "src/libsyntax/epoch.rs"
replace "src/libsyntax/feature_gate.rs"
replace "src/libsyntax/lib.rs"
replace "src/test/compile-fail/epoch-raw-pointer-method-2015.rs"
replace "src/test/compile-fail/epoch-raw-pointer-method-2018.rs"
replace "src/test/run-pass/dyn-trait.rs"
replace "src/test/run-pass/epoch-gate-feature.rs"
replace "src/test/ui/inference-variable-behind-raw-pointer.stderr"

git mv src/libsyntax/epoch.rs src/libsyntax/edition.rs
git mv src/test/compile-fail/epoch-raw-pointer-method-2015.rs src/test/compile-fail/edition-raw-pointer-method-2015.rs
git mv src/test/compile-fail/epoch-raw-pointer-method-2018.rs src/test/compile-fail/edition-raw-pointer-method-2018.rs

git grep "epoch" ./*
git grep "Epoch" ./*
```
And here is the output of the script:
```
kurtis-rust$ ./epoch_to_edition.sh
src/Cargo.lock: "crossbeam-epoch 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
src/Cargo.lock:name = "crossbeam-epoch"
src/Cargo.lock:"checksum crossbeam-epoch 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "59796cc6cbbdc6bb319161349db0c3250ec73ec7fcb763a51065ec4e2e158552"
src/ci/docker/scripts/android-start-emulator.sh:# Using the default qemu2 engine makes time::tests::since_epoch fails because
src/ci/docker/scripts/android-start-emulator.sh:# the emulator date is set to unix epoch (in armeabi-v7a-18 image). Using
src/librustc_incremental/persist/fs.rs:    let micros_since_unix_epoch = u64::from_str_radix(s, INT_ENCODE_BASE as u32);
src/librustc_incremental/persist/fs.rs:    if micros_since_unix_epoch.is_err() {
src/librustc_incremental/persist/fs.rs:    let micros_since_unix_epoch = micros_since_unix_epoch.unwrap();
src/librustc_incremental/persist/fs.rs:    let duration = Duration::new(micros_since_unix_epoch / 1_000_000,
src/librustc_incremental/persist/fs.rs:                                 1000 * (micros_since_unix_epoch % 1_000_000) as u32);
src/libstd/sys/cloudabi/abi/cloudabi.rs:  /// The epoch of this clock is undefined. The absolute
src/libstd/time.rs:        let one_second_from_epoch = UNIX_EPOCH + Duration::new(1, 0);
src/libstd/time.rs:        let one_second_from_epoch2 = UNIX_EPOCH + Duration::new(0, 500_000_000)
src/libstd/time.rs:        assert_eq!(one_second_from_epoch, one_second_from_epoch2);
src/libstd/time.rs:    fn since_epoch() {
src/test/run-pass/issue-29540.rs:    pub mon_min_osdmap_epochs: String,
src/test/run-pass/issue-29540.rs:    pub mon_max_pgmap_epochs: String,
src/test/run-pass/issue-29540.rs:    pub mon_max_log_epochs: String,
src/test/run-pass/issue-29540.rs:    pub mon_max_mdsmap_epochs: String,
src/test/run-pass/issue-29540.rs:    pub osd_map_share_max_epochs: String,
src/test/run-pass/issue-29540.rs:    pub osd_pg_epoch_persisted_max_stale: String,
```

If it looks like I've missed any things that should be converted, please let me know. There were also some notes in `src/libsyntax/epoch.rs` that indicated there might be some necessary/parallel changes that need to made in cargo. But we should probably make a separate issue for that.