### PR TITLE
Replace uninhabited error enums in std with never

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -101,6 +101,7 @@
 #![feature(iter_rfold)]
 #![feature(lang_items)]
 #![feature(needs_allocator)]
+#![cfg_attr(stage0, feature(never_type))]
 #![feature(nonzero)]
 #![feature(offset_to)]
 #![feature(optin_builtin_traits)]

--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -2031,6 +2031,10 @@ impl ops::DerefMut for String {
 
 /// An error when parsing a `String`.
 ///
+/// As of Rust 1.26, this is a type alias for [`!`].  Code that doesn't need to
+/// support compilation with older compiler versions should just use that type
+/// directly; this alias will be deprecated in the future.
+///
 /// This `enum` is slightly awkward: it will never actually exist. This error is
 /// part of the type signature of the implementation of [`FromStr`] on
 /// [`String`]. The return type of [`from_str`], requires that an error be
@@ -2038,12 +2042,12 @@ impl ops::DerefMut for String {
 /// [`String`] without error, this type will never actually be returned. As
 /// such, it is only here to satisfy said signature, and is useless otherwise.
 ///
+/// [`!`]: ../../std/primitive.never.html
 /// [`FromStr`]: ../../std/str/trait.FromStr.html
 /// [`String`]: struct.String.html
 /// [`from_str`]: ../../std/str/trait.FromStr.html#tymethod.from_str
 #[stable(feature = "str_parse_error", since = "1.5.0")]
-#[derive(Copy)]
-pub enum ParseError {}
+pub type ParseError = !;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl FromStr for String {
@@ -2053,37 +2057,6 @@ impl FromStr for String {
         Ok(String::from(s))
     }
 }
-
-#[stable(feature = "str_parse_error", since = "1.5.0")]
-impl Clone for ParseError {
-    fn clone(&self) -> ParseError {
-        match *self {}
-    }
-}
-
-#[stable(feature = "str_parse_error", since = "1.5.0")]
-impl fmt::Debug for ParseError {
-    fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
-        match *self {}
-    }
-}
-
-#[stable(feature = "str_parse_error2", since = "1.8.0")]
-impl fmt::Display for ParseError {
-    fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
-        match *self {}
-    }
-}
-
-#[stable(feature = "str_parse_error", since = "1.5.0")]
-impl PartialEq for ParseError {
-    fn eq(&self, _: &ParseError) -> bool {
-        match *self {}
-    }
-}
-
-#[stable(feature = "str_parse_error", since = "1.5.0")]
-impl Eq for ParseError {}
 
 /// A trait for converting a value to a `String`.
 ///

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -310,13 +310,6 @@ impl Error for string::FromUtf16Error {
     }
 }
 
-#[stable(feature = "str_parse_error2", since = "1.8.0")]
-impl Error for string::ParseError {
-    fn description(&self) -> &str {
-        match *self {}
-    }
-}
-
 #[stable(feature = "decode_utf16", since = "1.9.0")]
 impl Error for char::DecodeUtf16Error {
     fn description(&self) -> &str {

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1442,26 +1442,10 @@ impl From<String> for PathBuf {
     }
 }
 
-/// Error returned from [`PathBuf::from_str`][`from_str`].
-///
-/// Note that parsing a path will never fail. This error is just a placeholder
-/// for implementing `FromStr` for `PathBuf`.
-///
-/// [`from_str`]: struct.PathBuf.html#method.from_str
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[stable(feature = "path_from_str", since = "1.26.0")]
-pub enum ParsePathError {}
-
-#[stable(feature = "path_from_str", since = "1.26.0")]
-impl fmt::Display for ParsePathError {
-    fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
-        match *self {}
-    }
-}
-
+/// Note that parsing a path will never fail.
 #[stable(feature = "path_from_str", since = "1.26.0")]
 impl FromStr for PathBuf {
-    type Err = ParsePathError;
+    type Err = !;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(PathBuf::from(s))


### PR DESCRIPTION
Luckily I only found two, and one of them isn't in beta yet, so can disappear completely :sunglasses:

Are there any others I forgot?  (There are lots in things like liblibc and libstd/sys, but AFAIK those don't matter, nor do things like `btree::node::LeafOrInternal` or `str::pattern::RejectAndMatch`.)

The unstable `convert::Infallible` is being handled by https://github.com/rust-lang/rust/pull/49038

:warning: This change [may](https://github.com/rust-lang/rust/issues/48950#issuecomment-373179874) be a 1.26-or-never one.

cc https://github.com/rust-lang/rust/issues/48950#issuecomment-372468319
r? @alexcrichton 