### PR TITLE
Unstabilize FusedIterator for Flatten since Flatten is unstable

### DIFF
--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -2605,7 +2605,7 @@ impl<I, U> DoubleEndedIterator for Flatten<I>
     }
 }
 
-#[stable(feature = "fused", since = "1.26.0")]
+#[unstable(feature = "iterator_flatten", issue = "48213")]
 impl<I, U> FusedIterator for Flatten<I>
     where I: FusedIterator, U: Iterator,
           I::Item: IntoIterator<IntoIter = U, Item = U::Item> {}


### PR DESCRIPTION
PR #47463 made `impl<I, U> FusedIterator for Flatten<I>` stable but shouldn't have since `Flatten` is still unstable. This PR makes the impl unstable again.

r? @bluss
cc @alexcrichton 