### PR TITLE
setting ABORTING_MALLOC=0 for asmjs backend

### DIFF
--- a/src/liballoc/tests/string.rs
+++ b/src/liballoc/tests/string.rs
@@ -9,11 +9,8 @@
 // except according to those terms.
 
 use std::borrow::Cow;
-#[cfg(not(target_arch = "asmjs"))]
 use std::collections::CollectionAllocErr::*;
-#[cfg(not(target_arch = "asmjs"))]
 use std::mem::size_of;
-#[cfg(not(target_arch = "asmjs"))]
 use std::{usize, isize};
 
 pub trait IntoCow<'a, B: ?Sized> where B: ToOwned {
@@ -535,7 +532,6 @@ fn test_reserve_exact() {
     assert!(s.capacity() >= 33)
 }
 
-#[cfg(not(target_arch = "asmjs"))]
 #[test]
 fn test_try_reserve() {
 
@@ -613,7 +609,6 @@ fn test_try_reserve() {
 
 }
 
-#[cfg(not(target_arch = "asmjs"))]
 #[test]
 fn test_try_reserve_exact() {
 

--- a/src/liballoc/tests/vec.rs
+++ b/src/liballoc/tests/vec.rs
@@ -10,11 +10,8 @@
 
 use std::borrow::Cow;
 use std::mem::size_of;
-use std::{usize, panic};
-#[cfg(not(target_arch = "asmjs"))]
-use std::isize;
+use std::{usize, isize, panic};
 use std::vec::{Drain, IntoIter};
-#[cfg(not(target_arch = "asmjs"))]
 use std::collections::CollectionAllocErr::*;
 
 struct DropCounter<'a> {
@@ -994,7 +991,6 @@ fn test_reserve_exact() {
     assert!(v.capacity() >= 33)
 }
 
-#[cfg(not(target_arch = "asmjs"))]
 #[test]
 fn test_try_reserve() {
 
@@ -1097,7 +1093,6 @@ fn test_try_reserve() {
 
 }
 
-#[cfg(not(target_arch = "asmjs"))]
 #[test]
 fn test_try_reserve_exact() {
 

--- a/src/liballoc/tests/vec_deque.rs
+++ b/src/liballoc/tests/vec_deque.rs
@@ -11,13 +11,9 @@
 use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::collections::vec_deque::{Drain};
-#[cfg(not(target_arch = "asmjs"))]
 use std::collections::CollectionAllocErr::*;
-#[cfg(not(target_arch = "asmjs"))]
 use std::mem::size_of;
-use std::isize;
-#[cfg(not(target_arch = "asmjs"))]
-use std::usize;
+use std::{usize, isize};
 
 use self::Taggy::*;
 use self::Taggypar::*;
@@ -1053,7 +1049,6 @@ fn test_reserve_exact_2() {
     assert!(v.capacity() >= 48)
 }
 
-#[cfg(not(target_arch = "asmjs"))]
 #[test]
 fn test_try_reserve() {
 
@@ -1155,7 +1150,6 @@ fn test_try_reserve() {
 
 }
 
-#[cfg(not(target_arch = "asmjs"))]
 #[test]
 fn test_try_reserve_exact() {
 

--- a/src/librustc_back/target/asmjs_unknown_emscripten.rs
+++ b/src/librustc_back/target/asmjs_unknown_emscripten.rs
@@ -15,7 +15,9 @@ pub fn target() -> Result<Target, String> {
     let mut args = LinkArgs::new();
     args.insert(LinkerFlavor::Em,
                 vec!["-s".to_string(),
-                     "ERROR_ON_UNDEFINED_SYMBOLS=1".to_string()]);
+                     "ERROR_ON_UNDEFINED_SYMBOLS=1".to_string(),
+                     "-s".to_string(),
+                     "ABORTING_MALLOC=0".to_string()]);
 
     let opts = TargetOptions {
         dynamic_linking: false,

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -2755,11 +2755,8 @@ mod test_map {
     use cell::RefCell;
     use rand::{thread_rng, Rng};
     use panic;
-    #[cfg(not(target_arch = "asmjs"))]
     use realstd::collections::CollectionAllocErr::*;
-    #[cfg(not(target_arch = "asmjs"))]
     use realstd::mem::size_of;
-    #[cfg(not(target_arch = "asmjs"))]
     use realstd::usize;
 
     #[test]
@@ -3696,7 +3693,6 @@ mod test_map {
         assert_eq!(hm.len(), 0);
     }
 
-    #[cfg(not(target_arch = "asmjs"))]
     #[test]
     fn test_try_reserve() {
 


### PR DESCRIPTION
This changes the behaviour of the allocator for asmjs backend.
It will return NULL on OOM instead of aborting and let Rust choose the behaviour.
Fixes #48968 and enables try_reserve (fallible allocation) in asmjs.