### PR TITLE
Add empty dropped variant to ManuallyDrop

### DIFF
--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -947,7 +947,7 @@ pub fn discriminant<T>(v: &T) -> Discriminant<T> {
 #[stable(feature = "manually_drop", since = "1.20.0")]
 #[allow(unions_with_drop_fields)]
 #[derive(Copy)]
-pub union ManuallyDrop<T>{ value: T }
+pub union ManuallyDrop<T>{ value: T, dropped: () }
 
 impl<T> ManuallyDrop<T> {
     /// Wrap a value to be manually dropped.


### PR DESCRIPTION
Change `ManuallyDrop`'s internal (unstable) representation to match the design of `MaybeUninit` in https://github.com/rust-lang/rfcs/pull/1892. This indicates that the union has more than one possible representation variant. After the inner type has been dropped, it is no longer a valid `T`, and so the union should be considered to contain only `()`.

cc @canndrew @RalfJung 