### PR TITLE
rustdoctest: suppress the default allow(unused) under --display-warnings

### DIFF
--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -149,6 +149,7 @@ pub fn test(input: &str, cfgs: Vec<String>, libs: SearchPaths, externs: Externs,
 
     let mut opts = TestOptions::default();
     opts.no_crate_inject = true;
+    opts.display_warnings = display_warnings;
     let mut collector = Collector::new(input.to_owned(), cfgs, libs, externs,
                                        true, opts, maybe_sysroot, None,
                                        Some(PathBuf::from(input)),


### PR DESCRIPTION
If you're passing rustdoc `--display-warnings`, you probably want to see the default ones too. This change modifies `test::make_test` to suppress the default `#![allow(unused)]` if the `--display-warnings` CLI flag was provided to rustdoc.

cc https://github.com/rust-lang/rust/issues/41574