### PR TITLE
Implement fmt::Binary for f32 and f64

### DIFF
--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -8,9 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use fmt::{Formatter, Result, LowerExp, UpperExp, Display, Debug};
+use fmt::{Formatter, Result, LowerExp, UpperExp, Display, Debug, Binary};
 use mem;
-use num::flt2dec;
+use num::{flt2dec, Float};
 
 // Don't inline this so callers don't use the stack space this function
 // requires unless they have to.
@@ -148,6 +148,13 @@ macro_rules! floating {
         impl UpperExp for $ty {
             fn fmt(&self, fmt: &mut Formatter) -> Result {
                 float_to_exponential_common(fmt, self, true)
+            }
+        }
+
+        #[stable(feature = "floating_point_binary_fmt", since = "1.26.0")]
+        impl Binary for $ty {
+            fn fmt(&self, fmt: &mut Formatter) -> Result {
+                write!(fmt, "{:01$b}", self.to_bits(), 8 * mem::size_of::<$ty>())
             }
         }
     )


### PR DESCRIPTION
I often find it useful to print `f32` and `f64` in their binary formats when doing floating point analysis or bit manipulations (e.g. in #48622) and I'm [definitely not the only one](https://stackoverflow.com/questions/45265842/why-does-f32-not-implement-stdfmtbinary). Printing their binary representation seems like sensible behaviour for `fmt::Binary`.

I've opted to print fixed-width (i.e. 32 bits for `f32` and 64 bits for `f64`) because this seems to make the most sense for the primary use cases of printing the floating-point representation, where the bit ranges are very much relevant to the values, unlike for integers.