### PR TITLE
Checks for unknown attributes before aborting due to unresolved macros

### DIFF
--- a/src/test/ui/issue-49074.rs
+++ b/src/test/ui/issue-49074.rs
@@ -1,0 +1,24 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that unknown attribute error is shown even if there are unresolved macros.
+
+#[marco_use] // typo
+//~^ ERROR The attribute `marco_use` is currently unknown to the compiler
+mod foo {
+    macro_rules! bar {
+        () => ();
+    }
+}
+
+fn main() {
+   bar!();
+   //~^ ERROR cannot find macro `bar!`
+}

--- a/src/test/ui/issue-49074.stderr
+++ b/src/test/ui/issue-49074.stderr
@@ -1,0 +1,19 @@
+error: cannot find macro `bar!` in this scope
+  --> $DIR/issue-49074.rs:22:4
+   |
+LL |    bar!();
+   |    ^^^
+   |
+   = help: have you added the `#[macro_use]` on the module/import?
+
+error[E0658]: The attribute `marco_use` is currently unknown to the compiler and may have meaning added to it in the future (see issue #29642)
+  --> $DIR/issue-49074.rs:13:1
+   |
+LL | #[marco_use] // typo
+   | ^^^^^^^^^^^^
+   |
+   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Fixes #49074 

The ``attribute `...` is currently unknown to the compiler`` error was not shown if there are any unresolved macros, which might be caused by mistyped `macro_use`.