### PR TITLE
incr.comp.: Make sanity check in try_mark_green() aware of error conditions.

### DIFF
--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -648,8 +648,15 @@ impl DepGraph {
                                 return None
                             }
                             None => {
-                                bug!("try_mark_green() - Forcing the DepNode \
-                                      should have set its color")
+                                if !tcx.sess.has_errors() {
+                                    bug!("try_mark_green() - Forcing the DepNode \
+                                          should have set its color")
+                                } else {
+                                    // If the query we just forced has resulted
+                                    // in some kind of compilation error, we
+                                    // don't expect that the corresponding
+                                    // dep-node color has been updated.
+                                }
                             }
                         }
                     } else {


### PR DESCRIPTION
Before this PR, `DepGraph::try_mark_green()` assumed that forcing a query would always set the color of the corresponding dep-node. However, it did not take into account that queries could also fail (e.g. with a cycle error). This PR makes the method handle that condition gracefully.

Fixes #49070.

r? @nikomatsakis 