### PR TITLE
Use an uninitialized buffer in GenericRadix::fmt_int, like in Display::fmt for numeric types

### DIFF
--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -65,7 +65,7 @@ trait GenericRadix {
         // characters for a base 2 number.
         let zero = T::zero();
         let is_nonnegative = x >= zero;
-        let mut buf = [0; 128];
+        let mut buf: [u8; 128] = unsafe { mem::uninitialized() };
         let mut curr = buf.len();
         let base = T::from_u8(self.base());
         if is_nonnegative {


### PR DESCRIPTION
The code using a slice of that buffer is only ever going to use
bytes that are subsequently initialized.