### PR TITLE
Expand Attributes on Statements and Expressions

### DIFF
--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -837,6 +837,13 @@ impl Stmt {
             _ => false,
         }
     }
+
+    pub fn is_expr(&self) -> bool {
+        match self.node {
+            StmtKind::Expr(_) => true,
+            _ => false,
+        }
+    }
 }
 
 impl fmt::Debug for Stmt {

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -149,17 +149,24 @@ impl<'a> StripUnconfigured<'a> {
     fn visit_expr_attrs(&mut self, attrs: &[ast::Attribute]) {
         // flag the offending attributes
         for attr in attrs.iter() {
-            if !self.features.map(|features| features.stmt_expr_attributes).unwrap_or(true) {
-                let mut err = feature_err(self.sess,
-                                          "stmt_expr_attributes",
-                                          attr.span,
-                                          GateIssue::Language,
-                                          EXPLAIN_STMT_ATTR_SYNTAX);
-                if attr.is_sugared_doc {
-                    err.help("`///` is for documentation comments. For a plain comment, use `//`.");
-                }
-                err.emit();
+            self.maybe_emit_expr_attr_err(attr);
+        }
+    }
+
+    /// If attributes are not allowed on expressions, emit an error for `attr`
+    pub fn maybe_emit_expr_attr_err(&self, attr: &ast::Attribute) {
+        if !self.features.map(|features| features.stmt_expr_attributes).unwrap_or(true) {
+            let mut err = feature_err(self.sess,
+                                      "stmt_expr_attributes",
+                                      attr.span,
+                                      GateIssue::Language,
+                                      EXPLAIN_STMT_ATTR_SYNTAX);
+
+            if attr.is_sugared_doc {
+                err.help("`///` is for documentation comments. For a plain comment, use `//`.");
             }
+
+            err.emit();
         }
     }
 

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -38,6 +38,8 @@ pub enum Annotatable {
     Item(P<ast::Item>),
     TraitItem(P<ast::TraitItem>),
     ImplItem(P<ast::ImplItem>),
+    Stmt(P<ast::Stmt>),
+    Expr(P<ast::Expr>),
 }
 
 impl HasAttrs for Annotatable {
@@ -46,6 +48,8 @@ impl HasAttrs for Annotatable {
             Annotatable::Item(ref item) => &item.attrs,
             Annotatable::TraitItem(ref trait_item) => &trait_item.attrs,
             Annotatable::ImplItem(ref impl_item) => &impl_item.attrs,
+            Annotatable::Stmt(ref stmt) => stmt.attrs(),
+            Annotatable::Expr(ref expr) => &expr.attrs,
         }
     }
 
@@ -54,6 +58,8 @@ impl HasAttrs for Annotatable {
             Annotatable::Item(item) => Annotatable::Item(item.map_attrs(f)),
             Annotatable::TraitItem(trait_item) => Annotatable::TraitItem(trait_item.map_attrs(f)),
             Annotatable::ImplItem(impl_item) => Annotatable::ImplItem(impl_item.map_attrs(f)),
+            Annotatable::Stmt(stmt) => Annotatable::Stmt(stmt.map_attrs(f)),
+            Annotatable::Expr(expr) => Annotatable::Expr(expr.map_attrs(f)),
         }
     }
 }
@@ -64,6 +70,8 @@ impl Annotatable {
             Annotatable::Item(ref item) => item.span,
             Annotatable::TraitItem(ref trait_item) => trait_item.span,
             Annotatable::ImplItem(ref impl_item) => impl_item.span,
+            Annotatable::Stmt(ref stmt) => stmt.span,
+            Annotatable::Expr(ref expr) => expr.span,
         }
     }
 

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -1250,7 +1250,7 @@ const EXPLAIN_BOX_SYNTAX: &'static str =
     "box expression syntax is experimental; you can call `Box::new` instead.";
 
 pub const EXPLAIN_STMT_ATTR_SYNTAX: &'static str =
-    "attributes on non-item statements and expressions are experimental.";
+    "attributes on expressions are experimental.";
 
 pub const EXPLAIN_ASM: &'static str =
     "inline assembly is not stable enough for use and is subject to change";

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4601,6 +4601,9 @@ impl<'a> Parser<'a> {
 
     /// Parse a statement, including the trailing semicolon.
     pub fn parse_full_stmt(&mut self, macro_legacy_warnings: bool) -> PResult<'a, Option<Stmt>> {
+        // skip looking for a trailing semicolon when we have an interpolated statement
+        maybe_whole!(self, NtStmt, |x| Some(x));
+
         let mut stmt = match self.parse_stmt_without_recovery(macro_legacy_warnings)? {
             Some(stmt) => stmt,
             None => return Ok(None),

--- a/src/libsyntax_ext/deriving/custom.rs
+++ b/src/libsyntax_ext/deriving/custom.rs
@@ -54,7 +54,9 @@ impl MultiItemModifier for ProcMacroDerive {
         let item = match item {
             Annotatable::Item(item) => item,
             Annotatable::ImplItem(_) |
-            Annotatable::TraitItem(_) => {
+            Annotatable::TraitItem(_) |
+            Annotatable::Stmt(_) |
+            Annotatable::Expr(_) => {
                 ecx.span_err(span, "proc-macro derives may only be \
                                     applied to struct/enum items");
                 return Vec::new()

--- a/src/test/compile-fail-fulldeps/auxiliary/macro_crate_test.rs
+++ b/src/test/compile-fail-fulldeps/auxiliary/macro_crate_test.rs
@@ -93,6 +93,8 @@ fn expand_into_foo_multi(cx: &mut ExtCtxt,
                 }
             })
         }
+        // these are covered in proc_macro/attr-stmt-expr.rs
+        Annotatable::Stmt(_) | Annotatable::Expr(_) => panic!("expected item")
     }
 }
 
@@ -145,6 +147,8 @@ fn expand_duplicate(cx: &mut ExtCtxt,
             new_it.ident = copy_name;
             push(Annotatable::TraitItem(P(new_it)));
         }
+        // covered in proc_macro/attr-stmt-expr.rs
+        Annotatable::Stmt(_) | Annotatable::Expr(_) => panic!("expected item")
     }
 }
 

--- a/src/test/compile-fail-fulldeps/proc-macro/attr-invalid-exprs.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/attr-invalid-exprs.rs
@@ -1,0 +1,38 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:attr-stmt-expr.rs
+// ignore-stage1
+
+//! Attributes producing expressions in invalid locations
+
+#![feature(proc_macro, stmt_expr_attributes)]
+
+extern crate attr_stmt_expr;
+use attr_stmt_expr::{duplicate, no_output};
+
+fn main() {
+    let _ = #[no_output] "Hello, world!";
+    //~^ ERROR expected expression, found `<eof>`
+
+    let _ = #[duplicate] "Hello, world!";
+    //~^ ERROR macro expansion ignores token `,` and any following
+
+    let _ = {
+        #[no_output]
+        "Hello, world!"
+    };
+
+    let _ = {
+        #[duplicate]
+        //~^ ERROR macro expansion ignores token `,` and any following
+        "Hello, world!"
+    };
+}

--- a/src/test/compile-fail-fulldeps/proc-macro/attr-stmt-expr.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/attr-stmt-expr.rs
@@ -1,0 +1,38 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:attr-stmt-expr.rs
+// ignore-stage1
+
+#![feature(proc_macro)]
+
+extern crate attr_stmt_expr;
+use attr_stmt_expr::{expect_let, expect_print_stmt, expect_expr, expect_print_expr};
+
+fn print_str(string: &'static str) {
+    // macros are handled a bit differently
+    #[expect_print_expr]
+    //~^ ERROR attributes on expressions are experimental
+    //~| HELP add #![feature(stmt_expr_attributes)] to the crate attributes to enable
+    println!("{}", string)
+}
+
+fn main() {
+    #[expect_let]
+    let string = "Hello, world!";
+
+    #[expect_print_stmt]
+    println!("{}", string);
+
+    #[expect_expr]
+    //~^ ERROR attributes on expressions are experimental
+    //~| HELP add #![feature(stmt_expr_attributes)] to the crate attributes to enable
+    print_str("string")
+}

--- a/src/test/compile-fail-fulldeps/proc-macro/auxiliary/attr-stmt-expr.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/auxiliary/attr-stmt-expr.rs
@@ -1,0 +1,59 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![feature(proc_macro)]
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn expect_let(attr: TokenStream, item: TokenStream) -> TokenStream {
+    assert!(attr.to_string().is_empty());
+    assert_eq!(item.to_string(), "let string = \"Hello, world!\";");
+    item
+}
+
+#[proc_macro_attribute]
+pub fn expect_print_stmt(attr: TokenStream, item: TokenStream) -> TokenStream {
+    assert!(attr.to_string().is_empty());
+    assert_eq!(item.to_string(), "println!(\"{}\" , string);");
+    item
+}
+
+#[proc_macro_attribute]
+pub fn expect_expr(attr: TokenStream, item: TokenStream) -> TokenStream {
+    assert!(attr.to_string().is_empty());
+    assert_eq!(item.to_string(), "print_str(\"string\")");
+    item
+}
+
+#[proc_macro_attribute]
+pub fn expect_print_expr(attr: TokenStream, item: TokenStream) -> TokenStream {
+    assert!(attr.to_string().is_empty());
+    assert_eq!(item.to_string(), "println!(\"{}\" , string)");
+    item
+}
+
+#[proc_macro_attribute]
+pub fn duplicate(attr: TokenStream, item: TokenStream) -> TokenStream {
+    assert!(attr.to_string().is_empty());
+    format!("{}, {}", item, item).parse().unwrap()
+}
+
+#[proc_macro_attribute]
+pub fn no_output(attr: TokenStream, item: TokenStream) -> TokenStream {
+    assert!(attr.to_string().is_empty());
+    assert!(!item.to_string().is_empty());
+    "".parse().unwrap()
+}

--- a/src/test/run-pass-fulldeps/auxiliary/macro_crate_test.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/macro_crate_test.rs
@@ -96,6 +96,8 @@ fn expand_into_foo_multi(cx: &mut ExtCtxt,
                 }
             })
         ],
+        // these are covered in proc_macro/attr-stmt-expr.rs
+        Annotatable::Stmt(_) | Annotatable::Expr(_) => panic!("expected item"),
     }
 }
 
@@ -140,6 +142,8 @@ fn expand_duplicate(cx: &mut ExtCtxt,
             new_it.ident = copy_name;
             push(Annotatable::TraitItem(P(new_it)));
         }
+        // these are covered in proc_macro/attr-stmt-expr.rs
+        Annotatable::Stmt(_) | Annotatable::Expr(_) => panic!("expected item")
     }
 }
 

--- a/src/test/run-pass-fulldeps/proc-macro/attr-stmt-expr.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/attr-stmt-expr.rs
@@ -1,0 +1,34 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:attr-stmt-expr.rs
+// ignore-stage1
+
+#![feature(proc_macro, stmt_expr_attributes)]
+
+extern crate attr_stmt_expr;
+use attr_stmt_expr::{expect_let, expect_print_stmt, expect_expr, expect_print_expr};
+
+fn print_str(string: &'static str) {
+    // macros are handled a bit differently
+    #[expect_print_expr]
+    println!("{}", string)
+}
+
+fn main() {
+    #[expect_let]
+    let string = "Hello, world!";
+
+    #[expect_print_stmt]
+    println!("{}", string);
+
+    #[expect_expr]
+    print_str("string")
+}

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/attr-stmt-expr.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/attr-stmt-expr.rs
@@ -1,0 +1,46 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![feature(proc_macro)]
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn expect_let(attr: TokenStream, item: TokenStream) -> TokenStream {
+    assert!(attr.to_string().is_empty());
+    assert_eq!(item.to_string(), "let string = \"Hello, world!\";");
+    item
+}
+
+#[proc_macro_attribute]
+pub fn expect_print_stmt(attr: TokenStream, item: TokenStream) -> TokenStream {
+    assert!(attr.to_string().is_empty());
+    assert_eq!(item.to_string(), "println!(\"{}\" , string);");
+    item
+}
+
+#[proc_macro_attribute]
+pub fn expect_expr(attr: TokenStream, item: TokenStream) -> TokenStream {
+    assert!(attr.to_string().is_empty());
+    assert_eq!(item.to_string(), "print_str(\"string\")");
+    item
+}
+
+#[proc_macro_attribute]
+pub fn expect_print_expr(attr: TokenStream, item: TokenStream) -> TokenStream {
+    assert!(attr.to_string().is_empty());
+    assert_eq!(item.to_string(), "println!(\"{}\" , string)");
+    item
+}

--- a/src/test/ui/feature-gate-stmt_expr_attributes.rs
+++ b/src/test/ui/feature-gate-stmt_expr_attributes.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 const X: i32 = #[allow(dead_code)] 8;
-//~^ ERROR attributes on non-item statements and expressions are experimental. (see issue #15701)
+//~^ ERROR attributes on expressions are experimental. (see issue #15701)
 
 fn main() {}

--- a/src/test/ui/feature-gate-stmt_expr_attributes.stderr
+++ b/src/test/ui/feature-gate-stmt_expr_attributes.stderr
@@ -1,4 +1,4 @@
-error[E0658]: attributes on non-item statements and expressions are experimental. (see issue #15701)
+error[E0658]: attributes on expressions are experimental. (see issue #15701)
   --> $DIR/feature-gate-stmt_expr_attributes.rs:11:16
    |
 LL | const X: i32 = #[allow(dead_code)] 8;


### PR DESCRIPTION
This enables attribute-macro expansion on statements and expressions while retaining the `stmt_expr_attributes` feature requirement for attributes on expressions.

closes #41475 
cc #38356  @petrochenkov @jseyfried 
r? @nrc