### PR TITLE
rustbuild: Ship libsynchronization

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -221,6 +221,7 @@ fn make_win_dist(
         "libsecur32.a",
         "libsetupapi.a",
         "libshell32.a",
+        "libsynchronization.a",
         "libuser32.a",
         "libuserenv.a",
         "libuuid.a",


### PR DESCRIPTION
Hot on the heels of #49044 comes similar issue with libsynchronization. Discovered while building clippy:
```
<skipped>
Compiling serde_derive v1.0.33
error: linking with `gcc` failed: exit code: 1
<skipped>
  = note: ld: cannot find -lsynchronization
```

r? @nikomatsakis 