### PR TITLE
adds simd_select intrinsic

### DIFF
--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -361,6 +361,7 @@ pub fn check_platform_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         "simd_insert" => (2, vec![param(0), tcx.types.u32, param(1)], param(0)),
         "simd_extract" => (2, vec![param(0), tcx.types.u32], param(1)),
         "simd_cast" => (2, vec![param(0)], param(1)),
+        "simd_select" => (2, vec![param(0), param(1), param(1)], param(1)),
         "simd_reduce_all" | "simd_reduce_any" => (1, vec![param(0)], tcx.types.bool),
         "simd_reduce_add_ordered" | "simd_reduce_mul_ordered"
             => (2, vec![param(0), param(1)], param(1)),

--- a/src/test/codegen/simd-intrinsic-generic-select.rs
+++ b/src/test/codegen/simd-intrinsic-generic-select.rs
@@ -1,0 +1,35 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -C no-prepopulate-passes
+
+#![crate_type = "lib"]
+
+#![feature(repr_simd, platform_intrinsics)]
+#[allow(non_camel_case_types)]
+
+#[repr(simd)]
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+
+#[repr(simd)]
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct b8x4(pub i8, pub i8, pub i8, pub i8);
+
+extern "platform-intrinsic" {
+    fn simd_select<T, U>(x: T, a: U, b: U) -> U;
+}
+
+// CHECK-LABEL: @select
+#[no_mangle]
+pub unsafe fn select(m: b8x4, a: f32x4, b: f32x4) -> f32x4 {
+    // CHECK: select <4 x i1>
+    simd_select(m, a, b)
+}

--- a/src/test/compile-fail/simd-intrinsic-generic-select.rs
+++ b/src/test/compile-fail/simd-intrinsic-generic-select.rs
@@ -1,0 +1,56 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that the simd_select intrinsic produces ok-ish error
+// messages when misused.
+
+#![feature(repr_simd, platform_intrinsics)]
+#![allow(non_camel_case_types)]
+
+#[repr(simd)]
+#[derive(Copy, Clone)]
+pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+
+#[repr(simd)]
+#[derive(Copy, Clone)]
+pub struct u32x4(pub u32, pub u32, pub u32, pub u32);
+
+#[repr(simd)]
+#[derive(Copy, Clone, PartialEq)]
+struct b8x4(pub i8, pub i8, pub i8, pub i8);
+
+#[repr(simd)]
+#[derive(Copy, Clone, PartialEq)]
+struct b8x8(pub i8, pub i8, pub i8, pub i8,
+            pub i8, pub i8, pub i8, pub i8);
+
+extern "platform-intrinsic" {
+    fn simd_select<T, U>(x: T, a: U, b: U) -> U;
+}
+
+fn main() {
+    let m4 = b8x4(0, 0, 0, 0);
+    let m8 = b8x8(0, 0, 0, 0, 0, 0, 0, 0);
+    let x = u32x4(0, 0, 0, 0);
+    let z = f32x4(0.0, 0.0, 0.0, 0.0);
+
+    unsafe {
+        simd_select(m4, x, x);
+
+        simd_select(m8, x, x);
+        //~^ ERROR mismatched lengths: mask length `8` != other vector length `4`
+
+        simd_select(x, x, x);
+        //~^ ERROR mask element type is `u32`, expected `i_`
+
+        simd_select(z, z, z);
+        //~^ ERROR mask element type is `f32`, expected `i_`
+    }
+}

--- a/src/test/run-pass/simd-intrinsic-generic-select.rs
+++ b/src/test/run-pass/simd-intrinsic-generic-select.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
+
 // Test that the simd_select intrinsics produces correct results.
 
 #![feature(repr_simd, platform_intrinsics)]

--- a/src/test/run-pass/simd-intrinsic-generic-select.rs
+++ b/src/test/run-pass/simd-intrinsic-generic-select.rs
@@ -1,0 +1,144 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that the simd_select intrinsics produces correct results.
+
+#![feature(repr_simd, platform_intrinsics)]
+#[allow(non_camel_case_types)]
+
+#[repr(simd)]
+#[derive(Copy, Clone, PartialEq, Debug)]
+struct i32x4(pub i32, pub i32, pub i32, pub i32);
+
+#[repr(simd)]
+#[derive(Copy, Clone, PartialEq, Debug)]
+struct u32x4(pub u32, pub u32, pub u32, pub u32);
+
+#[repr(simd)]
+#[derive(Copy, Clone, PartialEq, Debug)]
+struct f32x4(pub f32, pub f32, pub f32, pub f32);
+
+#[repr(simd)]
+#[derive(Copy, Clone, PartialEq, Debug)]
+struct b8x4(pub i8, pub i8, pub i8, pub i8);
+
+extern "platform-intrinsic" {
+    fn simd_select<T, U>(x: T, a: U, b: U) -> U;
+}
+
+fn main() {
+    let m0 = b8x4(!0, !0, !0, !0);
+    let m1 = b8x4(0, 0, 0, 0);
+    let m2 = b8x4(!0, !0, 0, 0);
+    let m3 = b8x4(0, 0, !0, !0);
+    let m4 = b8x4(!0, 0, !0, 0);
+
+    unsafe {
+        let a = i32x4(1, -2, 3, 4);
+        let b = i32x4(5, 6, -7, 8);
+
+        let r: i32x4 = simd_select(m0, a, b);
+        let e = a;
+        assert_eq!(r, e);
+
+        let r: i32x4 = simd_select(m1, a, b);
+        let e = b;
+        assert_eq!(r, e);
+
+        let r: i32x4 = simd_select(m2, a, b);
+        let e = i32x4(1, -2, -7, 8);
+        assert_eq!(r, e);
+
+        let r: i32x4 = simd_select(m3, a, b);
+        let e = i32x4(5, 6, 3, 4);
+        assert_eq!(r, e);
+
+        let r: i32x4 = simd_select(m4, a, b);
+        let e = i32x4(1, 6, 3, 8);
+        assert_eq!(r, e);
+    }
+
+    unsafe {
+        let a = u32x4(1, 2, 3, 4);
+        let b = u32x4(5, 6, 7, 8);
+
+        let r: u32x4 = simd_select(m0, a, b);
+        let e = a;
+        assert_eq!(r, e);
+
+        let r: u32x4 = simd_select(m1, a, b);
+        let e = b;
+        assert_eq!(r, e);
+
+        let r: u32x4 = simd_select(m2, a, b);
+        let e = u32x4(1, 2, 7, 8);
+        assert_eq!(r, e);
+
+        let r: u32x4 = simd_select(m3, a, b);
+        let e = u32x4(5, 6, 3, 4);
+        assert_eq!(r, e);
+
+        let r: u32x4 = simd_select(m4, a, b);
+        let e = u32x4(1, 6, 3, 8);
+        assert_eq!(r, e);
+    }
+
+    unsafe {
+        let a = f32x4(1., 2., 3., 4.);
+        let b = f32x4(5., 6., 7., 8.);
+
+        let r: f32x4 = simd_select(m0, a, b);
+        let e = a;
+        assert_eq!(r, e);
+
+        let r: f32x4 = simd_select(m1, a, b);
+        let e = b;
+        assert_eq!(r, e);
+
+        let r: f32x4 = simd_select(m2, a, b);
+        let e = f32x4(1., 2., 7., 8.);
+        assert_eq!(r, e);
+
+        let r: f32x4 = simd_select(m3, a, b);
+        let e = f32x4(5., 6., 3., 4.);
+        assert_eq!(r, e);
+
+        let r: f32x4 = simd_select(m4, a, b);
+        let e = f32x4(1., 6., 3., 8.);
+        assert_eq!(r, e);
+    }
+
+    unsafe {
+        let t = !0 as i8;
+        let f = 0 as i8;
+        let a = b8x4(t, f, t, f);
+        let b = b8x4(f, f, f, t);
+
+        let r: b8x4 = simd_select(m0, a, b);
+        let e = a;
+        assert_eq!(r, e);
+
+        let r: b8x4 = simd_select(m1, a, b);
+        let e = b;
+        assert_eq!(r, e);
+
+        let r: b8x4 = simd_select(m2, a, b);
+        let e = b8x4(t, f, f, t);
+        assert_eq!(r, e);
+
+        let r: b8x4 = simd_select(m3, a, b);
+        let e = b8x4(f, f, t, f);
+        assert_eq!(r, e);
+
+        let r: b8x4 = simd_select(m4, a, b);
+        let e = b8x4(t, f, t, t);
+        assert_eq!(r, e);
+    }
+}


### PR DESCRIPTION
The select SIMD intrinsic is used to select elements from two SIMD vectors using a mask:

```rust
let mask = b8x4::new(true, false, false, true);
let a = f32x4::new(1., 2., 3., 4.);
let b = f32x4::new(5., 6., 7., 8.);
assert_eq!(simd_select(mask, a, b), f32x4::new(1., 6., 7., 4.));
```

The number of lanes between the mask and the vectors must match, but the vector width of the mask does not need to match that of the vectors. The mask is required to be a vector of signed integers.

Note: this intrinsic will be exposed via `std::simd`'s vector masks - users are not expected to use it directly.