### PR TITLE
config.toml.example: thinlto bootstrap was removed

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -239,11 +239,6 @@
 # compiler.
 #codegen-units = 1
 
-# Whether to enable ThinLTO (and increase the codegen units to either a default
-# or the configured value). On by default. If we want the fastest possible
-# compiler, we should disable this.
-#thinlto = true
-
 # Whether or not debug assertions are enabled for the compiler and standard
 # library. Also enables compilation of debug! and trace! logging macros.
 #debug-assertions = false


### PR DESCRIPTION
 It was removed in ff227c4a2d8a2fad5abf322f6f1391ae6779197f so remove the option that no longer works (we did not notice because it was commented out by default).