### PR TITLE
Handle future deprecation annotations 

### DIFF
--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -587,7 +587,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                 // version, then we should display no warning message.
                 let deprecated_in_future_version = if let Some(sym) = depr_entry.attr.since {
                     let since = sym.as_str();
-                    !deprecation_in_effect(since.as_ref())
+                    !deprecation_in_effect(&since)
                 } else {
                     false
                 };

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2113,7 +2113,7 @@ fn short_stability(item: &clean::Item, cx: &Context, show_reason: bool) -> Vec<S
                         since,
                         MarkdownHtml(&deprecated_reason))
             } else {
-                format!("This will be deprecated in {}{}",
+                format!("Deprecating in {}{}",
                         Escape(&stab.deprecated_since),
                         MarkdownHtml(&deprecated_reason))
             };
@@ -2171,7 +2171,7 @@ fn short_stability(item: &clean::Item, cx: &Context, show_reason: bool) -> Vec<S
                     since,
                     MarkdownHtml(&note))
         } else {
-            format!("This will be deprecated in {}{}",
+            format!("Deprecating in {}{}",
                     Escape(&depr.since),
                     MarkdownHtml(&note))
         };

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2108,9 +2108,15 @@ fn short_stability(item: &clean::Item, cx: &Context, show_reason: bool) -> Vec<S
             } else {
                 String::new()
             };
-            let text = format!("Deprecated{}{}",
-                               since,
-                               MarkdownHtml(&deprecated_reason));
+            let text = if stability::deprecation_in_effect(&stab.deprecated_since) {
+                format!("Deprecated{}{}",
+                        since,
+                        MarkdownHtml(&deprecated_reason))
+            } else {
+                format!("This will be deprecated in {}{}",
+                        Escape(&stab.deprecated_since),
+                        MarkdownHtml(&deprecated_reason))
+            };
             stability.push(format!("<div class='stab deprecated'>{}</div>", text))
         };
 
@@ -2160,7 +2166,15 @@ fn short_stability(item: &clean::Item, cx: &Context, show_reason: bool) -> Vec<S
             String::new()
         };
 
-        let text = format!("Deprecated{}{}", since, MarkdownHtml(&note));
+        let text = if stability::deprecation_in_effect(&depr.since) {
+            format!("Deprecated{}{}",
+                    since,
+                    MarkdownHtml(&note))
+        } else {
+            format!("This will be deprecated in {}{}",
+                    Escape(&depr.since),
+                    MarkdownHtml(&note))
+        };
         stability.push(format!("<div class='stab deprecated'>{}</div>", text))
     }
 

--- a/src/test/compile-fail/deprecation-lint.rs
+++ b/src/test/compile-fail/deprecation-lint.rs
@@ -180,6 +180,11 @@ mod this_crate {
     #[deprecated(since = "1.0.0", note = "text")]
     pub fn deprecated_text() {}
 
+    #[deprecated(since = "99.99.99", note = "text")]
+    pub fn deprecated_future() {}
+    #[deprecated(since = "99.99.99", note = "text")]
+    pub fn deprecated_future_text() {}
+
     pub struct MethodTester;
 
     impl MethodTester {
@@ -265,6 +270,9 @@ mod this_crate {
         Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
         <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
         <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+
+        deprecated_future(); // Fine; no error.
+        deprecated_future_text(); // Fine; no error.
 
         let _ = DeprecatedStruct {
             //~^ ERROR use of deprecated item 'this_crate::DeprecatedStruct': text

--- a/src/test/rustdoc/deprecated-future.rs
+++ b/src/test/rustdoc/deprecated-future.rs
@@ -11,6 +11,6 @@
 #![feature(deprecated)]
 
 // @has deprecated_future/struct.S.html '//*[@class="stab deprecated"]' \
-//      'This will be deprecated in 99.99.99: effectively never'
+//      'Deprecating in 99.99.99: effectively never'
 #[deprecated(since = "99.99.99", note = "effectively never")]
 pub struct S;

--- a/src/test/rustdoc/deprecated-future.rs
+++ b/src/test/rustdoc/deprecated-future.rs
@@ -1,0 +1,16 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(deprecated)]
+
+// @has deprecated_future/struct.S.html '//*[@class="stab deprecated"]' \
+//      'This will be deprecated in 99.99.99: effectively never'
+#[deprecated(since = "99.99.99", note = "effectively never")]
+pub struct S;


### PR DESCRIPTION
This adds special handling to the `since` parameter of the `deprecated` attribute: in particular, if the `since` version exceeds the version of the compiler, the deprecation notice will not be printed; but a note is added to the documentation stating that the item will be deprecated in a later version.

(I've used `since` for this, rather than adding a new attribute, because it's more seamless and, I feel, intuitive. Plus it involves less code churn.)

![image](https://user-images.githubusercontent.com/3943692/37611317-ef5cdf16-2b99-11e8-8251-e35e8f7b0137.png)
![image](https://user-images.githubusercontent.com/3943692/37611323-f748c2d0-2b99-11e8-966b-11408c73d416.png)

This is a prerequisite for doing things renaming methods in the standard library (e.g. #30459). Resolves #30785.