### PR TITLE
also point to value in "value assigned is never read" lint 

### DIFF
--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
@@ -29,7 +29,7 @@ warning: value assigned to `hours_are_suns` is never read
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:32:9
    |
 LL |         hours_are_suns = false;
-   |         ^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^   ^^^^^
    |
 note: lint level defined here
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:13:9

--- a/src/test/ui/lint/liveness-dead.rs
+++ b/src/test/ui/lint/liveness-dead.rs
@@ -18,7 +18,7 @@ fn f1(x: &mut isize) {
 }
 
 fn f2() {
-    let mut x: isize = 3; //~ WARN: value assigned to `x` is never read
+    let (mut x, y) = (3, 4); //~ WARN: value assigned to `x` is never read
     x = 4;
     x.clone();
 }

--- a/src/test/ui/lint/liveness-dead.rs
+++ b/src/test/ui/lint/liveness-dead.rs
@@ -8,15 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// must-compile-successfully
+
 #![allow(dead_code)]
-#![deny(unused_assignments)]
+#![warn(unused_assignments)]
 
 fn f1(x: &mut isize) {
     *x = 1; // no error
 }
 
 fn f2() {
-    let mut x: isize = 3; //~ ERROR: value assigned to `x` is never read
+    let mut x: isize = 3; //~ WARN: value assigned to `x` is never read
     x = 4;
     x.clone();
 }
@@ -24,17 +26,17 @@ fn f2() {
 fn f3() {
     let mut x: isize = 3;
     x.clone();
-    x = 4; //~ ERROR: value assigned to `x` is never read
+    x = 4; //~ WARN: value assigned to `x` is never read
 }
 
-fn f4(mut x: i32) { //~ ERROR: value passed to `x` is never read
+fn f4(mut x: i32) { //~ WARN: value passed to `x` is never read
     x = 4;
     x.clone();
 }
 
 fn f5(mut x: i32) {
     x.clone();
-    x = 4; //~ ERROR: value assigned to `x` is never read
+    x = 4; //~ WARN: value assigned to `x` is never read
 }
 
 fn main() {}

--- a/src/test/ui/lint/liveness-dead.stderr
+++ b/src/test/ui/lint/liveness-dead.stderr
@@ -1,8 +1,8 @@
 warning: value assigned to `x` is never read
-  --> $DIR/liveness-dead.rs:21:9
+  --> $DIR/liveness-dead.rs:21:10
    |
-LL |     let mut x: isize = 3; //~ WARN: value assigned to `x` is never read
-   |         ^^^^^
+LL |     let (mut x, y) = (3, 4); //~ WARN: value assigned to `x` is never read
+   |          ^^^^^       ^^^^^^
    |
 note: lint level defined here
   --> $DIR/liveness-dead.rs:14:9
@@ -14,7 +14,7 @@ warning: value assigned to `x` is never read
   --> $DIR/liveness-dead.rs:29:5
    |
 LL |     x = 4; //~ WARN: value assigned to `x` is never read
-   |     ^
+   |     ^   ^
 
 warning: value passed to `x` is never read
   --> $DIR/liveness-dead.rs:32:7
@@ -26,5 +26,5 @@ warning: value assigned to `x` is never read
   --> $DIR/liveness-dead.rs:39:5
    |
 LL |     x = 4; //~ WARN: value assigned to `x` is never read
-   |     ^
+   |     ^   ^
 

--- a/src/test/ui/lint/liveness-dead.stderr
+++ b/src/test/ui/lint/liveness-dead.stderr
@@ -1,0 +1,30 @@
+warning: value assigned to `x` is never read
+  --> $DIR/liveness-dead.rs:21:9
+   |
+LL |     let mut x: isize = 3; //~ WARN: value assigned to `x` is never read
+   |         ^^^^^
+   |
+note: lint level defined here
+  --> $DIR/liveness-dead.rs:14:9
+   |
+LL | #![warn(unused_assignments)]
+   |         ^^^^^^^^^^^^^^^^^^
+
+warning: value assigned to `x` is never read
+  --> $DIR/liveness-dead.rs:29:5
+   |
+LL |     x = 4; //~ WARN: value assigned to `x` is never read
+   |     ^
+
+warning: value passed to `x` is never read
+  --> $DIR/liveness-dead.rs:32:7
+   |
+LL | fn f4(mut x: i32) { //~ WARN: value passed to `x` is never read
+   |       ^^^^^
+
+warning: value assigned to `x` is never read
+  --> $DIR/liveness-dead.rs:39:5
+   |
+LL |     x = 4; //~ WARN: value assigned to `x` is never read
+   |     ^
+

--- a/src/test/ui/lint/liveness-unused.rs
+++ b/src/test/ui/lint/liveness-unused.rs
@@ -8,19 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![warn(unused)]
-#![deny(unused_variables)]
-#![deny(unused_assignments)]
+// must-compile-successfully
+
+#![warn(unused_variables, unused_assignments, unreachable_code)]
 #![allow(dead_code, non_camel_case_types, trivial_numeric_casts)]
 
 use std::ops::AddAssign;
 
 fn f1(x: isize) {
-    //~^ ERROR unused variable: `x`
+    //~^ WARN unused variable: `x`
 }
 
 fn f1b(x: &mut isize) {
-    //~^ ERROR unused variable: `x`
+    //~^ WARN unused variable: `x`
 }
 
 #[allow(unused_variables)]
@@ -28,24 +28,24 @@ fn f1c(x: isize) {}
 
 fn f1d() {
     let x: isize;
-    //~^ ERROR unused variable: `x`
+    //~^ WARN unused variable: `x`
 }
 
 fn f2() {
     let x = 3;
-    //~^ ERROR unused variable: `x`
+    //~^ WARN unused variable: `x`
 }
 
 fn f3() {
     let mut x = 3;
-    //~^ ERROR variable `x` is assigned to, but never used
+    //~^ WARN variable `x` is assigned to, but never used
     x += 4;
-    //~^ ERROR value assigned to `x` is never read
+    //~^ WARN value assigned to `x` is never read
 }
 
 fn f3b() {
     let mut z = 3;
-    //~^ ERROR variable `z` is assigned to, but never used
+    //~^ WARN variable `z` is assigned to, but never used
     loop {
         z += 4;
     }
@@ -67,7 +67,7 @@ fn f3d() {
 fn f4() {
     match Some(3) {
       Some(i) => {
-        //~^ ERROR unused variable: `i`
+        //~^ WARN unused variable: `i`
       }
       None => {}
     }
@@ -87,19 +87,19 @@ fn f4b() -> isize {
 
 fn f5a() {
     for x in 1..10 { }
-    //~^ ERROR unused variable: `x`
+    //~^ WARN unused variable: `x`
 }
 
 fn f5b() {
     for (x, _) in [1, 2, 3].iter().enumerate() { }
-    //~^ ERROR unused variable: `x`
+    //~^ WARN unused variable: `x`
 }
 
 fn f5c() {
     for (_, x) in [1, 2, 3].iter().enumerate() {
-    //~^ ERROR unused variable: `x`
+    //~^ WARN unused variable: `x`
         continue;
-        drop(*x as i32); //~ WARNING unreachable statement
+        drop(*x as i32); //~ WARN unreachable statement
     }
 }
 
@@ -120,10 +120,10 @@ fn f6() {
     // ensure an error shows up for x even if lhs of an overloaded add assign
 
     let x;
-    //~^ ERROR variable `x` is assigned to, but never used
+    //~^ WARN variable `x` is assigned to, but never used
 
     *({
-        x = 0;  //~ ERROR value assigned to `x` is never read
+        x = 0;  //~ WARN value assigned to `x` is never read
         &mut v
     }) += 1;
 }

--- a/src/test/ui/lint/liveness-unused.stderr
+++ b/src/test/ui/lint/liveness-unused.stderr
@@ -1,0 +1,108 @@
+warning: unreachable statement
+  --> $DIR/liveness-unused.rs:102:9
+   |
+LL |         drop(*x as i32); //~ WARN unreachable statement
+   |         ^^^^^^^^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/liveness-unused.rs:13:47
+   |
+LL | #![warn(unused_variables, unused_assignments, unreachable_code)]
+   |                                               ^^^^^^^^^^^^^^^^
+
+warning: unused variable: `x`
+  --> $DIR/liveness-unused.rs:18:7
+   |
+LL | fn f1(x: isize) {
+   |       ^ help: consider using `_x` instead
+   |
+note: lint level defined here
+  --> $DIR/liveness-unused.rs:13:9
+   |
+LL | #![warn(unused_variables, unused_assignments, unreachable_code)]
+   |         ^^^^^^^^^^^^^^^^
+
+warning: unused variable: `x`
+  --> $DIR/liveness-unused.rs:22:8
+   |
+LL | fn f1b(x: &mut isize) {
+   |        ^ help: consider using `_x` instead
+
+warning: unused variable: `x`
+  --> $DIR/liveness-unused.rs:30:9
+   |
+LL |     let x: isize;
+   |         ^ help: consider using `_x` instead
+
+warning: unused variable: `x`
+  --> $DIR/liveness-unused.rs:35:9
+   |
+LL |     let x = 3;
+   |         ^ help: consider using `_x` instead
+
+warning: variable `x` is assigned to, but never used
+  --> $DIR/liveness-unused.rs:40:9
+   |
+LL |     let mut x = 3;
+   |         ^^^^^
+   |
+   = note: consider using `_x` instead
+
+warning: value assigned to `x` is never read
+  --> $DIR/liveness-unused.rs:42:5
+   |
+LL |     x += 4;
+   |     ^
+   |
+note: lint level defined here
+  --> $DIR/liveness-unused.rs:13:27
+   |
+LL | #![warn(unused_variables, unused_assignments, unreachable_code)]
+   |                           ^^^^^^^^^^^^^^^^^^
+
+warning: variable `z` is assigned to, but never used
+  --> $DIR/liveness-unused.rs:47:9
+   |
+LL |     let mut z = 3;
+   |         ^^^^^
+   |
+   = note: consider using `_z` instead
+
+warning: unused variable: `i`
+  --> $DIR/liveness-unused.rs:69:12
+   |
+LL |       Some(i) => {
+   |            ^ help: consider using `_i` instead
+
+warning: unused variable: `x`
+  --> $DIR/liveness-unused.rs:89:9
+   |
+LL |     for x in 1..10 { }
+   |         ^ help: consider using `_x` instead
+
+warning: unused variable: `x`
+  --> $DIR/liveness-unused.rs:94:10
+   |
+LL |     for (x, _) in [1, 2, 3].iter().enumerate() { }
+   |          ^ help: consider using `_x` instead
+
+warning: unused variable: `x`
+  --> $DIR/liveness-unused.rs:99:13
+   |
+LL |     for (_, x) in [1, 2, 3].iter().enumerate() {
+   |             ^ help: consider using `_x` instead
+
+warning: variable `x` is assigned to, but never used
+  --> $DIR/liveness-unused.rs:122:9
+   |
+LL |     let x;
+   |         ^
+   |
+   = note: consider using `_x` instead
+
+warning: value assigned to `x` is never read
+  --> $DIR/liveness-unused.rs:126:9
+   |
+LL |         x = 0;  //~ WARN value assigned to `x` is never read
+   |         ^
+

--- a/src/test/ui/lint/liveness-unused.stderr
+++ b/src/test/ui/lint/liveness-unused.stderr
@@ -52,7 +52,7 @@ warning: value assigned to `x` is never read
   --> $DIR/liveness-unused.rs:42:5
    |
 LL |     x += 4;
-   |     ^
+   |     ^    ^
    |
 note: lint level defined here
   --> $DIR/liveness-unused.rs:13:27
@@ -104,5 +104,5 @@ warning: value assigned to `x` is never read
   --> $DIR/liveness-unused.rs:126:9
    |
 LL |         x = 0;  //~ WARN value assigned to `x` is never read
-   |         ^
+   |         ^   ^
 


### PR DESCRIPTION
The first commit ports some compile-fail tests to UI so that the output diff is easy to read in the second commit 60e2af0.

Thanks to @pr-yemibedu for [suggesting that](https://github.com/rust-lang/rust/issues/49171#issuecomment-374378989) we put a span on both sides of
the assignment. (Some might argue that we should just put the single
span on the right-hand side, but as the change to liveness-dead.rs
highlights, it's also nice to have a span on the left when the left-hand
side has multiple patterns being assigned.)


Resolves #49171.