### PR TITLE
Implement some trivial size_hints for various iterators

### DIFF
--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -902,6 +902,11 @@ impl<I: Iterator<Item = u8>> Iterator for DecodeUtf8<I> {
             }
         })
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
 }
 
 #[unstable(feature = "decode_utf8", issue = "33906")]

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -905,12 +905,12 @@ impl<I: Iterator<Item = u8>> Iterator for DecodeUtf8<I> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.0.len();
+        let (lower, upper) = self.0.size_hint();
 
         // A code point is at most 4 bytes long.
-        let min_code_points = len / 4;
+        let min_code_points = lower / 4;
 
-        (min_code_points, Some(len))
+        (min_code_points, upper)
     }
 }
 

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -905,7 +905,7 @@ impl<I: Iterator<Item = u8>> Iterator for DecodeUtf8<I> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.iter.len();
+        let len = self.0.len();
 
         // A code point is at most 4 bytes long.
         let min_code_points = len / 4;

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -905,7 +905,12 @@ impl<I: Iterator<Item = u8>> Iterator for DecodeUtf8<I> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.0.size_hint()
+        let len = self.iter.len();
+
+        // A code point is at most 4 bytes long.
+        let min_code_points = len / 4;
+
+        (min_code_points, Some(len))
     }
 }
 

--- a/src/libcore/iter/traits.rs
+++ b/src/libcore/iter/traits.rs
@@ -903,7 +903,12 @@ impl<I, T, E> Iterator for ResultShunt<I, E>
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.iter.size_hint()
+        if self.error.is_some() {
+            (0, Some(0))
+        } else {
+            let (_, upper) = self.iter.size_hint();
+            (0, upper)
+        }
     }
 }
 

--- a/src/libcore/iter/traits.rs
+++ b/src/libcore/iter/traits.rs
@@ -901,6 +901,10 @@ impl<I, T, E> Iterator for ResultShunt<I, E>
             None => None,
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 #[stable(feature = "iter_arith_traits_result", since="1.16.0")]

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1191,7 +1191,12 @@ impl<A, V: FromIterator<A>> FromIterator<Option<A>> for Option<V> {
 
             #[inline]
             fn size_hint(&self) -> (usize, Option<usize>) {
-                self.iter.size_hint()
+                if self.found_none {
+                    (0, Some(0))
+                } else {
+                    let (_, upper) = self.iter.size_hint();
+                    (0, upper)
+                }
             }
         }
 

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1188,6 +1188,11 @@ impl<A, V: FromIterator<A>> FromIterator<Option<A>> for Option<V> {
                     None => None,
                 }
             }
+
+            #[inline]
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                self.iter.size_hint()
+            }
         }
 
         let mut adapter = Adapter { iter: iter.into_iter(), found_none: false };

--- a/src/librustc/hir/pat_util.rs
+++ b/src/librustc/hir/pat_util.rs
@@ -31,6 +31,10 @@ impl<I> Iterator for EnumerateAndAdjust<I> where I: Iterator {
             (if i < self.gap_pos { i } else { i + self.gap_len }, elem)
         })
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.enumerate.size_hint()
+    }
 }
 
 pub trait EnumerateAndAdjustIterator {

--- a/src/librustc/mir/traversal.rs
+++ b/src/librustc/mir/traversal.rs
@@ -77,7 +77,17 @@ impl<'a, 'tcx> Iterator for Preorder<'a, 'tcx> {
 
         None
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // All the blocks, minus the number of blocks we've visited.
+        let remaining = self.mir.basic_blocks().len() - self.visited.count();
+
+        // We will visit all remaining blocks exactly once.
+        (remaining, Some(remaining))
+    }
 }
+
+impl<'a, 'tcx> ExactSizeIterator for Preorder<'a, 'tcx> {}
 
 /// Postorder traversal of a graph.
 ///
@@ -210,7 +220,17 @@ impl<'a, 'tcx> Iterator for Postorder<'a, 'tcx> {
 
         next.map(|(bb, _)| (bb, &self.mir[bb]))
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // All the blocks, minus the number of blocks we've visited.
+        let remaining = self.mir.basic_blocks().len() - self.visited.count();
+
+        // We will visit all remaining blocks exactly once.
+        (remaining, Some(remaining))
+    }
 }
+
+impl<'a, 'tcx> ExactSizeIterator for Postorder<'a, 'tcx> {}
 
 /// Reverse postorder traversal of a graph
 ///
@@ -276,4 +296,10 @@ impl<'a, 'tcx> Iterator for ReversePostorder<'a, 'tcx> {
 
         self.blocks.get(self.idx).map(|&bb| (bb, &self.mir[bb]))
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.idx, Some(self.idx))
+    }
 }
+
+impl<'a, 'tcx> ExactSizeIterator for ReversePostorder<'a, 'tcx> {}

--- a/src/librustc/session/search_paths.rs
+++ b/src/librustc/session/search_paths.rs
@@ -78,4 +78,11 @@ impl<'a> Iterator for Iter<'a> {
             }
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // This iterator will never return more elements than the base iterator;
+        // but it can ignore all the remaining elements.
+        let (_, upper) = self.iter.size_hint();
+        (0, upper)
+    }
 }

--- a/src/librustc/traits/util.rs
+++ b/src/librustc/traits/util.rs
@@ -347,6 +347,11 @@ impl<'tcx,I:Iterator<Item=ty::Predicate<'tcx>>> Iterator for FilterToTraits<I> {
             }
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.base_iterator.size_hint();
+        (0, upper)
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/librustc_data_structures/bitvec.rs
+++ b/src/librustc_data_structures/bitvec.rs
@@ -132,6 +132,11 @@ impl<'a> Iterator for BitVectorIter<'a> {
         self.idx += offset + 1;
         return Some(self.idx - 1);
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.iter.size_hint();
+        (0, upper)
+    }
 }
 
 impl FromIterator<bool> for BitVector {

--- a/src/librustc_data_structures/graph/mod.rs
+++ b/src/librustc_data_structures/graph/mod.rs
@@ -334,6 +334,11 @@ impl<'g, N: Debug, E: Debug> Iterator for AdjacentEdges<'g, N, E> {
         self.next = edge.next_edge[self.direction.repr];
         Some((edge_index, edge))
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // At most, all the edges in the graph.
+        (0, Some(self.graph.len_edges()))
+    }
 }
 
 pub struct DepthFirstTraversal<'g, N, E>
@@ -383,7 +388,15 @@ impl<'g, N: Debug, E: Debug> Iterator for DepthFirstTraversal<'g, N, E> {
         }
         next
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // We will visit every node in the graph exactly once.
+        let remaining = self.graph.len_nodes() - self.visited.count();
+        (remaining, Some(remaining))
+    }
 }
+
+impl<'g, N: Debug, E: Debug> ExactSizeIterator for DepthFirstTraversal<'g, N, E> {}
 
 impl<E> Edge<E> {
     pub fn source(&self) -> NodeIndex {

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -584,6 +584,13 @@ impl<'a, 'hir> Iterator for NodesMatchingUII<'a, 'hir> {
             &mut NodesMatchingSuffix(ref mut iter) => iter.next(),
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            &NodesMatchingDirect(ref iter) => iter.size_hint(),
+            &NodesMatchingSuffix(ref iter) => iter.size_hint(),
+        }
+    }
 }
 
 impl UserIdentifiedItem {

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -718,7 +718,14 @@ impl<'a> Iterator for AllTraits<'a> {
             TraitInfo::new(*info)
         })
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.borrow.as_ref().unwrap().len() - self.idx;
+        (len, Some(len))
+    }
 }
+
+impl<'a> ExactSizeIterator for AllTraits<'a> {}
 
 
 struct UsePlacementFinder<'a, 'tcx: 'a, 'gcx: 'tcx> {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -602,6 +602,11 @@ impl<'a> Iterator for ListAttributesIter<'a> {
 
         None
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let lower = self.current_list.len();
+        (lower, None)
+    }
 }
 
 pub trait AttributesExt {

--- a/src/libsyntax_ext/format_foreign.rs
+++ b/src/libsyntax_ext/format_foreign.rs
@@ -272,6 +272,11 @@ pub mod printf {
             self.s = tail;
             Some(sub)
         }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            // Substitutions are at least 2 characters long.
+            (0, Some(self.s.len() / 2))
+        }
     }
 
     enum State {
@@ -781,6 +786,10 @@ pub mod shell {
                 },
                 None => None,
             }
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (0, Some(self.s.len()))
         }
     }
 


### PR DESCRIPTION
This also implements ExactSizeIterator where applicable.

Addresses most of the Iterator traits mentioned in #23708.

I intend to do more, but I don't want to make the PR too large.