### PR TITLE
Add '\e' escape sequence

### DIFF
--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -901,7 +901,7 @@ impl<'a> StringReader<'a> {
                     None => {}  // EOF here is an error that will be checked later.
                     Some(e) => {
                         return match e {
-                            'n' | 'r' | 't' | '\\' | '\'' | '"' | '0' => true,
+                            'n' | 'r' | 't' | '\\' | '\'' | '"' | '0' | 'e' => true,
                             'x' => self.scan_byte_escape(delim, !ascii_only),
                             'u' => {
                                 let valid = if self.ch_is('{') {

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -261,6 +261,7 @@ pub fn char_lit(lit: &str, diag: Option<(Span, &Handler)>) -> (char, isize) {
         '\\' => ('\\', 2),
         '\'' => ('\'', 2),
         '0' => ('\0', 2),
+        'e' => ('\x1b', 2),
         'x' => {
             let v = u32::from_str_radix(&lit[2..4], 16).unwrap();
             let c = char::from_u32(v).unwrap();
@@ -484,6 +485,7 @@ pub fn byte_lit(lit: &str) -> (u8, usize) {
             b'\\' => b'\\',
             b'\'' => b'\'',
             b'0' => b'\0',
+            b'e' => b'\x1b',
             _ => {
                 match u64::from_str_radix(&lit[2..4], 16).ok() {
                     Some(c) =>


### PR DESCRIPTION
Hello,
I am used to C-style escape sequence '\e' which corresponds to the ESC character also seen as '\033' or '\x1b'. This allows you to easily write [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code) to add colors to terminal output.
Example:
```rust
println!("\e[31mThis is red\e[0m");  
println!("\x1b[31mThis is too\x1b[0m");
```
The '\e' is two characters shorter and more obvious (e as 'escape').
I added this by using some greps to find what i had to modify and it seems to work, however i don't know if that is enough and it obviously needs documentation and maybe a test.
What do you think of it?
I don't see any disadvantages as it is a commonly used escape sequence and the traditional '\x1b' still works.
Thanks for feedback