### PR TITLE
Fix the conversion between bit representations and i128 representations

### DIFF
--- a/src/test/run-pass/ctfe/signed_enum_discr.rs
+++ b/src/test/run-pass/ctfe/signed_enum_discr.rs
@@ -1,0 +1,27 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// https://github.com/rust-lang/rust/issues/49181
+
+#[derive(Eq, PartialEq)]
+#[repr(i8)]
+pub enum A {
+    B = -1,
+    C = 1,
+}
+
+pub const D: A = A::B;
+
+fn main() {
+    match A::C {
+        D => {},
+        _ => {}
+    }
+}


### PR DESCRIPTION
fixes #49181

the `Discr` type now encodes the bit representation instead of `i128` or `u128` casted to `u128`.

r? @eddyb 