### PR TITLE
dpl 1.9.5 has been released, revert #49217.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -318,8 +318,6 @@ before_deploy:
 
 deploy:
   - provider: s3
-    edge:
-      branch: s3-eager-autoload
     bucket: rust-lang-ci2
     skip_cleanup: true
     local_dir: deploy
@@ -336,8 +334,6 @@ deploy:
   # this is the same as the above deployment provider except that it uploads to
   # a slightly different directory and has a different trigger
   - provider: s3
-    edge:
-      branch: s3-eager-autoload
     bucket: rust-lang-ci2
     skip_cleanup: true
     local_dir: deploy
@@ -355,8 +351,6 @@ deploy:
   # try branch. Travis does not appear to provide a way to use "or" in these
   # conditions.
   - provider: s3
-    edge:
-      branch: s3-eager-autoload
     bucket: rust-lang-ci2
     skip_cleanup: true
     local_dir: deploy
@@ -371,8 +365,6 @@ deploy:
       condition: $DEPLOY = 1
 
   - provider: s3
-    edge:
-      branch: s3-eager-autoload
     bucket: rust-lang-ci2
     skip_cleanup: true
     local_dir: deploy


### PR DESCRIPTION
dpl 1.9.5 has been released which includes travis-ci/dpl#789, so we could move back to the standard Travis settings before that `s3-eager-autoload` branch is removed.