### PR TITLE
 Download the GCC artifacts from the HTTP server instead of FTP server.

### DIFF
--- a/src/ci/docker/dist-i686-linux/build-gcc.sh
+++ b/src/ci/docker/dist-i686-linux/build-gcc.sh
@@ -17,6 +17,23 @@ GCC=4.8.5
 
 curl https://ftp.gnu.org/gnu/gcc/gcc-$GCC/gcc-$GCC.tar.bz2 | tar xjf -
 cd gcc-$GCC
+
+# FIXME(#49246): Remove the `sed` below.
+#
+# On 2018 March 21st, two Travis builders' cache for Docker are suddenly invalidated. Normally this
+# is fine, because we just need to rebuild the Docker image. However, it reveals a network issue:
+# downloading from `ftp://gcc.gnu.org/` from Travis (using passive mode) often leads to "Connection
+# timed out" error, and even when the download completed, the file is usually corrupted. This causes
+# nothing to be landed that day.
+#
+# We observed that the `gcc-4.8.5.tar.bz2` above can be downloaded successfully, so as a stability
+# improvement we try to download from the HTTPS mirror instead. Turns out this uncovered the third
+# bug: the host `gcc.gnu.org` and `cygwin.com` share the same IP, and the TLS certificate of the
+# latter host is presented to `wget`! Therefore, we choose to download from the insecure HTTP server
+# instead here.
+#
+sed -i'' 's|ftp://gcc\.gnu\.org/|http://gcc.gnu.org/|g' ./contrib/download_prerequisites
+
 ./contrib/download_prerequisites
 mkdir ../gcc-build
 cd ../gcc-build

--- a/src/ci/docker/dist-i686-linux/build-git.sh
+++ b/src/ci/docker/dist-i686-linux/build-git.sh
@@ -12,7 +12,7 @@
 set -ex
 source shared.sh
 
-curl https://www.kernel.org/pub/software/scm/git/git-2.10.0.tar.gz | tar xzf -
+curl -L https://www.kernel.org/pub/software/scm/git/git-2.10.0.tar.gz | tar xzf -
 
 cd git-2.10.0
 make configure

--- a/src/ci/docker/dist-x86_64-linux/build-gcc.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-gcc.sh
@@ -17,6 +17,23 @@ GCC=4.8.5
 
 curl https://ftp.gnu.org/gnu/gcc/gcc-$GCC/gcc-$GCC.tar.bz2 | tar xjf -
 cd gcc-$GCC
+
+# FIXME(#49246): Remove the `sed` below.
+#
+# On 2018 March 21st, two Travis builders' cache for Docker are suddenly invalidated. Normally this
+# is fine, because we just need to rebuild the Docker image. However, it reveals a network issue:
+# downloading from `ftp://gcc.gnu.org/` from Travis (using passive mode) often leads to "Connection
+# timed out" error, and even when the download completed, the file is usually corrupted. This causes
+# nothing to be landed that day.
+#
+# We observed that the `gcc-4.8.5.tar.bz2` above can be downloaded successfully, so as a stability
+# improvement we try to download from the HTTPS mirror instead. Turns out this uncovered the third
+# bug: the host `gcc.gnu.org` and `cygwin.com` share the same IP, and the TLS certificate of the
+# latter host is presented to `wget`! Therefore, we choose to download from the insecure HTTP server
+# instead here.
+#
+sed -i'' 's|ftp://gcc\.gnu\.org/|http://gcc.gnu.org/|g' ./contrib/download_prerequisites
+
 ./contrib/download_prerequisites
 mkdir ../gcc-build
 cd ../gcc-build

--- a/src/ci/docker/dist-x86_64-linux/build-git.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-git.sh
@@ -12,7 +12,7 @@
 set -ex
 source shared.sh
 
-curl https://www.kernel.org/pub/software/scm/git/git-2.10.0.tar.gz | tar xzf -
+curl -L https://www.kernel.org/pub/software/scm/git/git-2.10.0.tar.gz | tar xzf -
 
 cd git-2.10.0
 make configure

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -105,7 +105,15 @@ fi
 travis_fold end log-system-info
 
 if [ ! -z "$SCRIPT" ]; then
-  sh -x -c "$SCRIPT"
+  # FIXME(#49246): Re-enable these tools after #49246 has been merged and thus fixing the cache.
+  if [ "$DEPLOY_ALT" = 1 ]; then
+    sh -x -c "$SCRIPT \
+       --exclude src/tools/rls \
+       --exclude src/tools/rustfmt \
+       --exclude src/tools/clippy"
+  else
+    sh -x -c "$SCRIPT"
+  fi
 else
   do_make() {
     travis_fold start "make-$1"


### PR DESCRIPTION
Try to bring back the `dist-i686-linux` and `dist-x86_64-linux alt` builders which has mysteriously lost their cache 14 hours ago and stuck forever unable to download `mpfr-2.4.2.tar.bz2` since it keeps getting

```
==> PASV ... couldn't connect to 209.132.180.131 port 10058: Connection timed out
```