### PR TITLE
Better diagnostics for '..' pattern fragment not in the last position

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3675,7 +3675,13 @@ impl<'a> Parser<'a> {
                 if self.token != token::CloseDelim(token::Brace) {
                     let token_str = self.this_token_to_string();
                     let mut err = self.fatal(&format!("expected `{}`, found `{}`", "}", token_str));
-                    err.span_label(self.span, "expected `}`");
+                    if self.token == token::Comma { // Issue #49257
+                        err.span_label(self.span,
+                                       "`..` must be in the last position, \
+                                        and cannot have a trailing comma");
+                    } else {
+                        err.span_label(self.span, "expected `}`");
+                    }
                     return Err(err);
                 }
                 etc = true;

--- a/src/test/ui/issue-49257.rs
+++ b/src/test/ui/issue-49257.rs
@@ -18,6 +18,6 @@ struct Point { x: u8, y: u8 }
 fn main() {
     let p = Point { x: 0, y: 0 };
     let Point { .., y } = p; //~ ERROR expected `}`, found `,`
-    //~^ pattern does not mention field `x`
-    //~^^ pattern does not mention field `y`
+    //~| ERROR pattern does not mention field `x`
+    //~| ERROR pattern does not mention field `y`
 }

--- a/src/test/ui/issue-49257.rs
+++ b/src/test/ui/issue-49257.rs
@@ -1,0 +1,23 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test for #49257:
+// emits good diagnostics for `..` pattern fragments not in the last position.
+
+#![allow(unused)]
+
+struct Point { x: u8, y: u8 }
+
+fn main() {
+    let p = Point { x: 0, y: 0 };
+    let Point { .., y } = p; //~ ERROR expected `}`, found `,`
+    //~^ pattern does not mention field `x`
+    //~^^ pattern does not mention field `y`
+}

--- a/src/test/ui/issue-49257.rs
+++ b/src/test/ui/issue-49257.rs
@@ -18,6 +18,5 @@ struct Point { x: u8, y: u8 }
 fn main() {
     let p = Point { x: 0, y: 0 };
     let Point { .., y } = p; //~ ERROR expected `}`, found `,`
-    //~| ERROR pattern does not mention field `x`
-    //~| ERROR pattern does not mention field `y`
+    //~| ERROR pattern does not mention fields `x`, `y`
 }

--- a/src/test/ui/issue-49257.stderr
+++ b/src/test/ui/issue-49257.stderr
@@ -4,18 +4,12 @@ error: expected `}`, found `,`
 LL |     let Point { .., y } = p; //~ ERROR expected `}`, found `,`
    |                   ^ `..` must be in the last position, and cannot have a trailing comma
 
-error[E0027]: pattern does not mention field `x`
+error[E0027]: pattern does not mention fields `x`, `y`
   --> $DIR/issue-49257.rs:20:9
    |
 LL |     let Point { .., y } = p; //~ ERROR expected `}`, found `,`
-   |         ^^^^^^^^^^^^^^^ missing field `x`
+   |         ^^^^^^^^^^^^^^^ missing fields `x`, `y`
 
-error[E0027]: pattern does not mention field `y`
-  --> $DIR/issue-49257.rs:20:9
-   |
-LL |     let Point { .., y } = p; //~ ERROR expected `}`, found `,`
-   |         ^^^^^^^^^^^^^^^ missing field `y`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0027`.

--- a/src/test/ui/issue-49257.stderr
+++ b/src/test/ui/issue-49257.stderr
@@ -1,0 +1,21 @@
+error: expected `}`, found `,`
+  --> $DIR/issue-49257.rs:20:19
+   |
+LL |     let Point { .., y } = p; //~ ERROR expected `}`, found `,`
+   |                   ^ `..` must be in the last position, and cannot have a trailing comma
+
+error[E0027]: pattern does not mention field `x`
+  --> $DIR/issue-49257.rs:20:9
+   |
+LL |     let Point { .., y } = p; //~ ERROR expected `}`, found `,`
+   |         ^^^^^^^^^^^^^^^ missing field `x`
+
+error[E0027]: pattern does not mention field `y`
+  --> $DIR/issue-49257.rs:20:9
+   |
+LL |     let Point { .., y } = p; //~ ERROR expected `}`, found `,`
+   |         ^^^^^^^^^^^^^^^ missing field `y`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0027`.


### PR DESCRIPTION
Fixes #49257.