### PR TITLE
Use GNU version of fgrep/egrep tool if available

### DIFF
--- a/src/etc/cat-and-grep.sh
+++ b/src/etc/cat-and-grep.sh
@@ -63,6 +63,11 @@ done
 
 shift $((OPTIND - 1))
 
+# use gnu version of tool if available (for bsd)
+if command -v "g${GREPPER}"; then
+    GREPPER="g${GREPPER}"
+fi
+
 LOG=$(mktemp -t cgrep.XXXXXX)
 trap "rm -f $LOG" EXIT
 


### PR DESCRIPTION
It is mostly for BSD system. Some tests (run-make/issue-35164 and
run-make/cat-and-grep-sanity-check) are failing with BSD
fgrep, whereas they pass with gnu version (gfgrep).