### PR TITLE
Make --emit=metadata output metadata regardless of link

### DIFF
--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -146,9 +146,7 @@ pub(crate) fn link_binary(sess: &Session,
     let mut out_filenames = Vec::new();
     for &crate_type in sess.crate_types.borrow().iter() {
         // Ignore executable crates if we have -Z no-trans, as they will error.
-        if (sess.opts.debugging_opts.no_trans ||
-            !sess.opts.output_types.should_trans()) &&
-           crate_type == config::CrateTypeExecutable {
+        if sess.opts.debugging_opts.no_trans && crate_type == config::CrateTypeExecutable {
             continue;
         }
 

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -146,7 +146,10 @@ pub(crate) fn link_binary(sess: &Session,
     let mut out_filenames = Vec::new();
     for &crate_type in sess.crate_types.borrow().iter() {
         // Ignore executable crates if we have -Z no-trans, as they will error.
-        if sess.opts.debugging_opts.no_trans && crate_type == config::CrateTypeExecutable {
+        let output_metadata = sess.opts.output_types.contains_key(&OutputType::Metadata);
+        let ignore_executable = sess.opts.debugging_opts.no_trans ||
+            !(sess.opts.output_types.should_trans() || output_metadata);
+        if crate_type == config::CrateTypeExecutable && ignore_executable {
             continue;
         }
 

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -147,9 +147,9 @@ pub(crate) fn link_binary(sess: &Session,
     for &crate_type in sess.crate_types.borrow().iter() {
         // Ignore executable crates if we have -Z no-trans, as they will error.
         let output_metadata = sess.opts.output_types.contains_key(&OutputType::Metadata);
-        let ignore_executable = sess.opts.debugging_opts.no_trans ||
-            !(sess.opts.output_types.should_trans() || output_metadata);
-        if crate_type == config::CrateTypeExecutable && ignore_executable {
+        if (sess.opts.debugging_opts.no_trans || !sess.opts.output_types.should_trans()) &&
+           !output_metadata &&
+           crate_type == config::CrateTypeExecutable {
             continue;
         }
 


### PR DESCRIPTION
Fixes #40109. I'm not sure whether this condition was important here or not, but I can't see why it is required (removing it doesn't cause the error the comment warns about, so I'm assuming it's safe). If this is too heavy-handed, I can special-case on `OutputType::Metadata`.

r? @nrc