### PR TITLE
Allow installing rustfmt without config.extended

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1186,7 +1186,6 @@ impl Step for Rustfmt {
         let build = builder.build;
         let stage = self.stage;
         let target = self.target;
-        assert!(build.config.extended);
 
         println!("Dist Rustfmt stage{} ({})", stage, target);
         let src = build.src.join("src/tools/rustfmt");


### PR DESCRIPTION
This assertion was preventing `./x.py install rustfmt` if attempted
without an "extended" build configuration, but it actually builds and
installs just fine.