### PR TITLE
rustc: Group linked libraries where needed

### DIFF
--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -1082,7 +1082,10 @@ impl CrateInfo {
             used_crate_source: FxHashMap(),
             wasm_custom_sections: BTreeMap::new(),
             wasm_imports: FxHashMap(),
+            lang_item_to_crate: FxHashMap(),
+            missing_lang_items: FxHashMap(),
         };
+        let lang_items = tcx.lang_items();
 
         let load_wasm_items = tcx.sess.crate_types.borrow()
             .iter()
@@ -1128,6 +1131,13 @@ impl CrateInfo {
                 }
                 info.load_wasm_imports(tcx, cnum);
             }
+            let missing = tcx.missing_lang_items(cnum);
+            for &item in missing.iter() {
+                if let Ok(id) = lang_items.require(item) {
+                    info.lang_item_to_crate.insert(item, id.krate);
+                }
+            }
+            info.missing_lang_items.insert(cnum, missing);
         }
 
         return info

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -78,6 +78,7 @@ use rustc::dep_graph::DepGraph;
 use rustc::hir::def_id::CrateNum;
 use rustc::middle::cstore::MetadataLoader;
 use rustc::middle::cstore::{NativeLibrary, CrateSource, LibSource};
+use rustc::middle::lang_items::LangItem;
 use rustc::session::{Session, CompileIncomplete};
 use rustc::session::config::{OutputFilenames, OutputType, PrintRequest};
 use rustc::ty::{self, TyCtxt};
@@ -405,6 +406,8 @@ struct CrateInfo {
     used_crates_dynamic: Vec<(CrateNum, LibSource)>,
     wasm_custom_sections: BTreeMap<String, Vec<u8>>,
     wasm_imports: FxHashMap<String, String>,
+    lang_item_to_crate: FxHashMap<LangItem, CrateNum>,
+    missing_lang_items: FxHashMap<CrateNum, Lrc<Vec<LangItem>>>,
 }
 
 __build_diagnostic_array! { librustc_trans, DIAGNOSTICS }

--- a/src/test/run-make-fulldeps/std-core-cycle/Makefile
+++ b/src/test/run-make-fulldeps/std-core-cycle/Makefile
@@ -1,0 +1,15 @@
+-include ../tools.mk
+
+ifeq ($(UNAME),Darwin)
+FLAGS :=
+else
+ifdef IS_WINDOWS
+FLAGS :=
+else
+FLAGS := -C link-args=-Wl,--no-undefined
+endif
+endif
+
+all:
+	$(RUSTC) bar.rs
+	$(RUSTC) foo.rs $(FLAGS)

--- a/src/test/run-make-fulldeps/std-core-cycle/bar.rs
+++ b/src/test/run-make-fulldeps/std-core-cycle/bar.rs
@@ -1,0 +1,26 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(allocator_api)]
+#![crate_type = "rlib"]
+
+use std::heap::*;
+
+pub struct A;
+
+unsafe impl<'a> Alloc for &'a A {
+    unsafe fn alloc(&mut self, _: Layout) -> Result<*mut u8, AllocErr> {
+        loop {}
+    }
+
+    unsafe fn dealloc(&mut self, _ptr: *mut u8, _: Layout) {
+        loop {}
+    }
+}

--- a/src/test/run-make-fulldeps/std-core-cycle/foo.rs
+++ b/src/test/run-make-fulldeps/std-core-cycle/foo.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(global_allocator)]
+#![crate_type = "cdylib"]
+
+extern crate bar;
+
+#[global_allocator]
+static A: bar::A = bar::A;
+
+#[no_mangle]
+pub extern fn a(a: u32, b: u32) -> u32 {
+    a / b
+}


### PR DESCRIPTION
This commit fixes a longstanding issue with the compiler with circular
dependencies between libcore and libstd. The `core` crate requires at least one
symbol, the ability to unwind. The `std` crate is the crate which actually
defines this symbol, but the `std` crate also depends on the `core` crate.

This circular dependency is in general disallowed in Rust as crates cannot have
cycles amongst them. A special exception is made just for core/std, but this is
also unfortunately incompatible with how GNU linkers work. GNU linkers will
process undefined symbols in a left-to-right fashion, only actually linking an
rlib like libstd if there are any symbols used from it. This strategy is
incompatible with circular dependencies because if we otherwise don't use
symbols from libstd we don't discover that we needed it until we're later
processing libcore's symbols!

To fix this GNU linkers support the `--start-group` and `--end-group` options
which indicate "libraries between these markers may have circular dependencies
amongst them. The linker invocation has been updated to automatically pass these
arguments when we're invoking a GNU linker and automatically calculate where the
arguments need to go (around libstd and libcore)

Closes #18807
Closes #47074