### PR TITLE
Introduce compile-pass

### DIFF
--- a/src/test/run-pass/compiletest-skip-trans.rs
+++ b/src/test/run-pass/compiletest-skip-trans.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that with the `skip-trans` option the test isn't executed.
+
+// skip-trans
+
+fn main() {
+    unreachable!();
+}

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -228,6 +228,8 @@ pub struct TestProps {
     pub check_test_line_numbers_match: bool,
     // The test must be compiled and run successfully. Only used in UI tests for now.
     pub run_pass: bool,
+    // Skip any codegen step and running the executable. Only for run-pass.
+    pub skip_trans: bool,
     // Do not pass `-Z ui-testing` to UI tests
     pub disable_ui_testing_normalization: bool,
     // customized normalization rules
@@ -260,6 +262,7 @@ impl TestProps {
             compile_pass: false,
             check_test_line_numbers_match: false,
             run_pass: false,
+            skip_trans: false,
             disable_ui_testing_normalization: false,
             normalize_stdout: vec![],
             normalize_stderr: vec![],
@@ -380,6 +383,10 @@ impl TestProps {
                 self.compile_pass =
                     config.parse_compile_pass(ln) || self.run_pass;
             }
+
+                        if !self.skip_trans {
+                            self.skip_trans = config.parse_skip_trans(ln);
+                        }
 
             if !self.disable_ui_testing_normalization {
                 self.disable_ui_testing_normalization =
@@ -522,6 +529,10 @@ impl Config {
 
     fn parse_run_pass(&self, line: &str) -> bool {
         self.parse_name_directive(line, "run-pass")
+    }
+
+    fn parse_skip_trans(&self, line: &str) -> bool {
+        self.parse_name_directive(line, "skip-trans")
     }
 
     fn parse_env(&self, line: &str, name: &str) -> Option<(String, String)> {

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -343,9 +343,11 @@ impl<'test> TestCx<'test> {
             "run-pass tests with expected warnings should be moved to ui/"
         );
 
-        let proc_res = self.exec_compiled_test();
-        if !proc_res.status.success() {
-            self.fatal_proc_rec("test run failed!", &proc_res);
+        if !self.props.skip_trans {
+            let proc_res = self.exec_compiled_test();
+            if !proc_res.status.success() {
+                self.fatal_proc_rec("test run failed!", &proc_res);
+            }
         }
     }
 
@@ -1695,6 +1697,11 @@ impl<'test> TestCx<'test> {
             CodegenUnits => {
                 // do not use JSON output
             }
+        }
+
+        if self.props.skip_trans {
+            assert!(!self.props.compile_flags.iter().any(|s| s.starts_with("--emit")));
+            rustc.args(&["--emit", "metadata"]);
         }
 
         if !is_rustdoc {


### PR DESCRIPTION
r? @alexcrichton 

The plan is to move things that cannot fail (no assert, unwrap, etc) out so we don't have to run them, and in the long term we can also stop running LLVM for them.

Out of 3215 tests...

```
Language            Files        Lines         Code     Comments       Blanks
Rust                 3215       119254        64688        35135        19431
```

16% of them has an empty main (which is already moved in this PR).

```
grep -rnPzl 'fn main\(\)\s*{\s*}' | xargs rg --files-without-match cfg | wc -l
547
```

And only 50% of the tests contains assertions:

```
rg -e assert -e unwrap -e expect -e panic -l | wc -l
1600
```

The remainder is likely able to get moved, but they need check by a human so I didn't touch them in PR.

cc @rust-lang/compiler

* [ ] Update documentation