### PR TITLE
Deprecate signed std::num::NonZeroI* with a call for use cases 

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -86,6 +86,7 @@
 #![feature(lang_items)]
 #![feature(link_llvm_intrinsics)]
 #![feature(exhaustive_patterns)]
+#![feature(macro_at_most_once_rep)]
 #![feature(no_core)]
 #![feature(on_unimplemented)]
 #![feature(optin_builtin_traits)]

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -23,6 +23,7 @@ macro_rules! impl_nonzero_fmt {
     ( #[$stability: meta] ( $( $Trait: ident ),+ ) for $Ty: ident ) => {
         $(
             #[$stability]
+            #[allow(deprecated)]
             impl fmt::$Trait for $Ty {
                 #[inline]
                 fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -34,7 +35,7 @@ macro_rules! impl_nonzero_fmt {
 }
 
 macro_rules! nonzero_integers {
-    ( #[$stability: meta] $( $Ty: ident($Int: ty); )+ ) => {
+    ( #[$stability: meta] #[$deprecation: meta] $( $Ty: ident($Int: ty); )+ ) => {
         $(
             /// An integer that is known not to equal zero.
             ///
@@ -46,6 +47,7 @@ macro_rules! nonzero_integers {
             /// assert_eq!(size_of::<Option<std::num::NonZeroU32>>(), size_of::<u32>());
             /// ```
             #[$stability]
+            #[$deprecation]
             #[allow(deprecated)]
             #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
             pub struct $Ty(NonZero<$Int>);
@@ -93,12 +95,26 @@ macro_rules! nonzero_integers {
 
 nonzero_integers! {
     #[unstable(feature = "nonzero", issue = "49137")]
-    NonZeroU8(u8); NonZeroI8(i8);
-    NonZeroU16(u16); NonZeroI16(i16);
-    NonZeroU32(u32); NonZeroI32(i32);
-    NonZeroU64(u64); NonZeroI64(i64);
-    NonZeroU128(u128); NonZeroI128(i128);
-    NonZeroUsize(usize); NonZeroIsize(isize);
+    #[allow(deprecated)]  // Redundant, works around "error: inconsistent lockstep iteration"
+    NonZeroU8(u8);
+    NonZeroU16(u16);
+    NonZeroU32(u32);
+    NonZeroU64(u64);
+    NonZeroU128(u128);
+    NonZeroUsize(usize);
+}
+
+nonzero_integers! {
+    #[unstable(feature = "nonzero", issue = "49137")]
+    #[rustc_deprecated(since = "1.26.0", reason = "\
+        signed non-zero integers are considered for removal due to lack of known use cases. \
+        If you’re using them, please comment on https://github.com/rust-lang/rust/issues/49137")]
+    NonZeroI8(i8);
+    NonZeroI16(i16);
+    NonZeroI32(i32);
+    NonZeroI64(i64);
+    NonZeroI128(i128);
+    NonZeroIsize(isize);
 }
 
 /// Provides intentionally-wrapped arithmetic on `T`.

--- a/src/libstd/num.rs
+++ b/src/libstd/num.rs
@@ -22,6 +22,7 @@ pub use core::num::{FpCategory, ParseIntError, ParseFloatError, TryFromIntError}
 pub use core::num::Wrapping;
 
 #[unstable(feature = "nonzero", issue = "49137")]
+#[allow(deprecated)]
 pub use core::num::{
     NonZeroU8, NonZeroI8, NonZeroU16, NonZeroI16, NonZeroU32, NonZeroI32,
     NonZeroU64, NonZeroI64, NonZeroU128, NonZeroI128, NonZeroUsize, NonZeroIsize,


### PR DESCRIPTION
CC https://github.com/rust-lang/rust/issues/49137#issuecomment-375823481