### PR TITLE
appveyor: Move run-pass-fulldeps to extra builders

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,10 +20,10 @@ environment:
     SCRIPT: python x.py test
   - MSYS_BITS: 32
     RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
-    SCRIPT: python x.py test --exclude src/test/run-pass --exclude src/test/compile-fail
+    SCRIPT: make appveyor-subset-1
   - MSYS_BITS: 32
     RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
-    SCRIPT: python x.py test src/test/run-pass src/test/compile-fail
+    SCRIPT: make appveyor-subset-2
 
   # MSVC aux tests
   - MSYS_BITS: 64
@@ -53,13 +53,13 @@ environment:
   # SourceForge is notoriously flaky, so we mirror it on our own infrastructure.
   - MSYS_BITS: 32
     RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
-    SCRIPT: python x.py test --exclude src/test/run-pass --exclude src/test/compile-fail
+    SCRIPT: make appveyor-subset-1
     MINGW_URL: https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror
     MINGW_ARCHIVE: i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
     MINGW_DIR: mingw32
   - MSYS_BITS: 32
     RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
-    SCRIPT: python x.py test src/test/run-pass src/test/compile-fail
+    SCRIPT: make appveyor-subset-2
     MINGW_URL: https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror
     MINGW_ARCHIVE: i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
     MINGW_DIR: mingw32

--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -85,5 +85,12 @@ check-stage2-T-arm-linux-androideabi-H-x86_64-unknown-linux-gnu:
 check-stage2-T-x86_64-unknown-linux-musl-H-x86_64-unknown-linux-gnu:
 	$(Q)$(BOOTSTRAP) test --target x86_64-unknown-linux-musl
 
+TESTS_IN_2 := src/test/run-pass src/test/compile-fail src/test/run-pass-fulldeps
+
+appveyor-subset-1:
+	$(Q)$(BOOTSTRAP) test $(TESTS_IN_2:%=--exclude %)
+appveyor-subset-2:
+	$(Q)$(BOOTSTRAP) test $(TESTS_IN_2)
+
 
 .PHONY: dist


### PR DESCRIPTION
We've made headway towards splitting the test suite across two appveyor builders
and this moves one more tests suite between builders. The last [failed
build][fail] had its longest running test suite and I've moved that to the
secondary builder.

cc #48844

[fail]: https://ci.appveyor.com/project/rust-lang/rust/build/1.0.6782