### PR TITLE
Minor message/label formatting consistency fix.

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1444,7 +1444,7 @@ pub fn id() -> u32 {
 #[unstable(feature = "termination_trait_lib", issue = "43301")]
 #[rustc_on_unimplemented(
   message="`main` has invalid return type `{Self}`",
-  label="`main` can only return types that implement {Termination}")]
+  label="`main` can only return types that implement `{Termination}`")]
 pub trait Termination {
     /// Is called to get the representation of the value as status code.
     /// This status code is returned to the operating system.

--- a/src/test/compile-fail/rfc-1937-termination-trait/termination-trait-main-i32.rs
+++ b/src/test/compile-fail/rfc-1937-termination-trait/termination-trait-main-i32.rs
@@ -10,7 +10,7 @@
 
 fn main() -> i32 {
 //~^ ERROR `main` has invalid return type `i32`
-//~| NOTE `main` can only return types that implement std::process::Termination
+//~| NOTE `main` can only return types that implement `std::process::Termination`
 //~| HELP consider using `()`, or a `Result`
     0
 }

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-main-wrong-type.stderr
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-main-wrong-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: `main` has invalid return type `char`
   --> $DIR/termination-trait-main-wrong-type.rs:11:14
    |
 LL | fn main() -> char { //~ ERROR
-   |              ^^^^ `main` can only return types that implement std::process::Termination
+   |              ^^^^ `main` can only return types that implement `std::process::Termination`
    |
    = help: consider using `()`, or a `Result`
 


### PR DESCRIPTION
The unimplemented label for `Termination` was missing some backticks for consistency with the message.