### PR TITLE
[incremental] Don't panic if decoding the cache fails

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -901,7 +901,9 @@ pub fn phase_2_configure_and_expand_inner<'a, F>(sess: &'a Session,
         Some(future) => {
             let prev_graph = time(sess, "blocked while dep-graph loading finishes", || {
                 future.open()
-                      .expect("Could not join with background dep_graph thread")
+                      .unwrap_or_else(|e| rustc_incremental::LoadResult::Error {
+                          message: format!("could not decode incremental cache: {:?}", e)
+                      })
                       .open(sess)
             });
             DepGraph::new(prev_graph)

--- a/src/librustc_incremental/lib.rs
+++ b/src/librustc_incremental/lib.rs
@@ -39,6 +39,7 @@ pub use assert_dep_graph::assert_dep_graph;
 pub use persist::dep_graph_tcx_init;
 pub use persist::load_dep_graph;
 pub use persist::load_query_result_cache;
+pub use persist::LoadResult;
 pub use persist::save_dep_graph;
 pub use persist::save_trans_partition;
 pub use persist::save_work_products;

--- a/src/librustc_incremental/persist/load.rs
+++ b/src/librustc_incremental/persist/load.rs
@@ -89,7 +89,8 @@ impl LoadResult<PreviousDepGraph> {
     pub fn open(self, sess: &Session) -> PreviousDepGraph {
         match self {
             LoadResult::Error { message } => {
-                sess.fatal(&message) /* never returns */
+                sess.warn(&message);
+                PreviousDepGraph::new(SerializedDepGraph::new())
             },
             LoadResult::DataOutOfDate => {
                 if let Err(err) = delete_all_session_dir_contents(sess) {

--- a/src/librustc_incremental/persist/mod.rs
+++ b/src/librustc_incremental/persist/mod.rs
@@ -27,6 +27,7 @@ pub use self::fs::prepare_session_directory;
 pub use self::load::dep_graph_tcx_init;
 pub use self::load::load_dep_graph;
 pub use self::load::load_query_result_cache;
+pub use self::load::LoadResult;
 pub use self::save::save_dep_graph;
 pub use self::save::save_work_products;
 pub use self::work_product::save_trans_partition;


### PR DESCRIPTION
If the cached data can't be loaded from disk, just issue a warning to
the user so they know why compilation is taking longer than usual but
don't fail the entire compilation since we can recover by ignorning the
on disk cache.

In the same way, if the disk cache can't be deserialized (because it has
been corrupted for some reason), report the issue as a warning and
continue without failing the compilation. `Decodable::decode()` tends to
panic with various errors like "entered unreachable code" or "index out
of range" if the input data is corrupted. Work around this by catching
panics from the `decode()` calls and continuing without the cached data.

Fixes #48847