### PR TITLE
Ignore proc macro stage 1 tests

### DIFF
--- a/src/test/run-pass-fulldeps/compiler-calls.rs
+++ b/src/test/run-pass-fulldeps/compiler-calls.rs
@@ -12,6 +12,10 @@
 
 // ignore-cross-compile
 
+// FIXME: The proc-macro tests should work for stage1 when #49219 is merged.
+//        See also #49352.
+// ignore-stage1
+
 #![feature(rustc_private, path)]
 #![feature(core)]
 

--- a/src/test/run-pass-fulldeps/proc-macro/span-api-tests.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/span-api-tests.rs
@@ -13,6 +13,10 @@
 
 // ignore-pretty
 
+// FIXME: The proc-macro tests should work for stage1 when #49219 is merged.
+//        See also #49352.
+// ignore-stage1
+
 #![feature(proc_macro)]
 
 #[macro_use]

--- a/src/test/ui-fulldeps/proc-macro/load-panic.rs
+++ b/src/test/ui-fulldeps/proc-macro/load-panic.rs
@@ -11,6 +11,10 @@
 // aux-build:derive-panic.rs
 // compile-flags:--error-format human
 
+// FIXME: The proc-macro tests should work for stage1 when #49219 is merged.
+//        See also #49352.
+// ignore-stage1
+
 #[macro_use]
 extern crate derive_panic;
 


### PR DESCRIPTION
A few tests related to proc-macros fail when performing stage-1
testing. This PR adds // ignore-stage1 to them, along with a FIXME.

Original issue: #49352

This should (hopefully) be fixed when #49219 is merged.