### PR TITLE
Better error message when trying to write default impls

### DIFF
--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -272,7 +272,9 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     self.err_handler().span_err(item.span, "inherent impls cannot be negative");
                 }
                 if defaultness == Defaultness::Default {
-                    self.err_handler().span_err(item.span, "inherent impls cannot be default");
+                    self.err_handler()
+                        .struct_span_err(item.span, "inherent impls cannot be default")
+                        .help("maybe a missing `for` keyword?");
                 }
             }
             ItemKind::ForeignMod(..) => {

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -274,7 +274,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 if defaultness == Defaultness::Default {
                     self.err_handler()
                         .struct_span_err(item.span, "inherent impls cannot be default")
-                        .help("maybe a missing `for` keyword?").emit();
+                        .note("only trait implementations may be annotated with default").emit();
                 }
             }
             ItemKind::ForeignMod(..) => {

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -274,7 +274,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 if defaultness == Defaultness::Default {
                     self.err_handler()
                         .struct_span_err(item.span, "inherent impls cannot be default")
-                        .help("maybe a missing `for` keyword?");
+                        .help("maybe a missing `for` keyword?").emit();
                 }
             }
             ItemKind::ForeignMod(..) => {


### PR DESCRIPTION
Previously, if you tried to write this (using the specialization
feature flag):

default impl PartialEq<MyType> {
...
}

The compiler would give you the mysterious warning "inherent impls
cannot be default". What it really means is that you're trying to
write an impl for a Structure or *Trait Object*, and that cannot
be "default". However, one of the ways to encounter this error
(as shown by the above example) is when you forget to write "for
MyType".

This PR adds a help message that reads "maybe missing a `for`
keyword?" This is useful, actionable advice that will help any user
identify their mistake, and doesn't get in the way or mislead any
user that really meant to use the "default" keyword for this weird
purpose. In particular, this help message will be useful for any
users who don't know the "inherent impl" terminology, and/or users
who forget that inherent impls CAN be written for traits (they apply
to the trait objects). Both of these are somewhat confusing, seldom-
used concepts; a one-line error message without any error number for
longer explanation is NOT the place to introduce these ideas.

I wasn't quite sure what grammar / wording to use. I'm open to suggestions. CC @rust-lang/docs (I hope I'm doing that notation right)

(Apparently not. :( )