### PR TITLE
Replace new-in-1.26 ParsePathError with !

### DIFF
--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1442,26 +1442,10 @@ impl From<String> for PathBuf {
     }
 }
 
-/// Error returned from [`PathBuf::from_str`][`from_str`].
-///
-/// Note that parsing a path will never fail. This error is just a placeholder
-/// for implementing `FromStr` for `PathBuf`.
-///
-/// [`from_str`]: struct.PathBuf.html#method.from_str
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[stable(feature = "path_from_str", since = "1.26.0")]
-pub enum ParsePathError {}
-
-#[stable(feature = "path_from_str", since = "1.26.0")]
-impl fmt::Display for ParsePathError {
-    fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
-        match *self {}
-    }
-}
-
+/// Note that parsing a path will never fail.
 #[stable(feature = "path_from_str", since = "1.26.0")]
 impl FromStr for PathBuf {
-    type Err = ParsePathError;
+    type Err = !;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(PathBuf::from(s))


### PR DESCRIPTION
This is the "definitely ok because it only changes things that have never been released in stable" version of https://github.com/rust-lang/rust/pull/49039.  Posting this in case it's decided there that changing `string::ParseError` is undesirable.

r? @alexcrichton 