### PR TITLE
Enable target_feature on any LLVM 6+

### DIFF
--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -205,17 +205,13 @@ GEN_SUBTARGETS
 
 extern "C" bool LLVMRustHasFeature(LLVMTargetMachineRef TM,
                                    const char *Feature) {
-#if LLVM_RUSTLLVM
+#if LLVM_VERSION_GE(6, 0)
   TargetMachine *Target = unwrap(TM);
   const MCSubtargetInfo *MCInfo = Target->getMCSubtargetInfo();
-  const FeatureBitset &Bits = MCInfo->getFeatureBits();
-  const ArrayRef<SubtargetFeatureKV> FeatTable = MCInfo->getFeatureTable();
-
-  for (auto &FeatureEntry : FeatTable)
-    if (!strcmp(FeatureEntry.Key, Feature))
-      return (Bits & FeatureEntry.Value) == FeatureEntry.Value;
-#endif
+  return MCInfo->checkFeatures(std::string("+") + Feature);
+#else
   return false;
+#endif
 }
 
 enum class LLVMRustCodeModel {

--- a/src/test/run-pass/sse2.rs
+++ b/src/test/run-pass/sse2.rs
@@ -8,7 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// no-system-llvm -- needs MCSubtargetInfo::getFeatureTable()
+// min-llvm-version 6.0
+// ^ needs MCSubtargetInfo::checkFeatures()
 // ignore-cloudabi no std::env
 
 #![feature(cfg_target_feature)]
@@ -29,4 +30,7 @@ fn main() {
         assert!(cfg!(target_feature = "sse2"),
                 "SSE2 was not detected as available on an x86 platform");
     }
+    // check a negative case too -- whitelisted on x86, but not enabled by default
+    assert!(cfg!(not(target_feature = "avx2")),
+            "AVX2 shouldn't be detected as available by default on any platform");
 }


### PR DESCRIPTION
In `LLVMRustHasFeature()`, rather than using `MCInfo->getFeatureTable()`
that is specific to Rust's LLVM fork, we can use this in LLVM 6:

    /// Check whether the subtarget features are enabled/disabled as per
    /// the provided string, ignoring all other features.
    bool checkFeatures(StringRef FS) const;

Now rustc using external LLVM can also have `target_feature`.

r? @alexcrichton