### PR TITLE
Fix collapse toggle insertions on impl with docs

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1816,6 +1816,9 @@
 
     var func = function(e) {
         var next = e.nextElementSibling;
+        if (hasClass(e, 'impl') && next && hasClass(next, 'docblock')) {
+            next = next.nextElementSibling;
+        }
         if (!next) {
             return;
         }


### PR DESCRIPTION
Just went through this one randomly... When an impl has docs, the collapse toggle isn't generated. This fixes it.

r? @QuietMisdreavus 