### PR TITLE
Explicitly mention `Option` in `?` error message.

### DIFF
--- a/src/libcore/ops/try.rs
+++ b/src/libcore/ops/try.rs
@@ -20,7 +20,7 @@
        any(from_method="from_error", from_method="from_ok"),
        from_desugaring="?"),
       message="the `?` operator can only be used in a \
-               function that returns `Result` \
+               function that returns `Result` or `Option` \
                (or another type that implements `{Try}`)",
       label="cannot use the `?` operator in a function that returns `{Self}`"),
    on(all(from_method="into_result", from_desugaring="?"),

--- a/src/test/ui/suggestions/try-on-option.stderr
+++ b/src/test/ui/suggestions/try-on-option.stderr
@@ -6,7 +6,7 @@ LL |     x?; //~ the trait bound
    |
    = note: required by `std::convert::From::from`
 
-error[E0277]: the `?` operator can only be used in a function that returns `Result` (or another type that implements `std::ops::Try`)
+error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `std::ops::Try`)
   --> $DIR/try-on-option.rs:23:5
    |
 LL |     x?; //~ the `?` operator

--- a/src/test/ui/suggestions/try-operator-on-main.stderr
+++ b/src/test/ui/suggestions/try-operator-on-main.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the `?` operator can only be used in a function that returns `Result` (or another type that implements `std::ops::Try`)
+error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `std::ops::Try`)
   --> $DIR/try-operator-on-main.rs:19:5
    |
 LL |     std::fs::File::open("foo")?; //~ ERROR the `?` operator can only


### PR DESCRIPTION
Save users the time/effort of having to lookup what types implement
the `Try` trait.