### PR TITLE
Remove adjacent all-const match arm hack.

### DIFF
--- a/src/test/compile-fail/move-guard-same-consts.rs
+++ b/src/test/compile-fail/move-guard-same-consts.rs
@@ -8,7 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// #47295: We used to have a hack of special-casing adjacent amtch
+// arms whose patterns were composed solely of constants to not have
+// them linked in the cfg.
+//
+// THis was broken for various reasons. In particular, that hack was
+// originally authored under the assunption that other checks
+// elsewhere would ensure that the two patterns did not overlap.  But
+// that assumption did not hold, at least not in the long run (namely,
+// overlapping patterns were turned into warnings rather than errors).
 
 #![feature(box_syntax)]
 
@@ -18,8 +26,8 @@ fn main() {
     let v = (1, 2);
 
     match v {
-        (2, 1) if take(x) => (),
         (1, 2) if take(x) => (),
+        (1, 2) if take(x) => (), //~ ERROR use of moved value: `x`
         _ => (),
     }
 }


### PR DESCRIPTION
An old fix for moves-in-guards had a hack for adjacent all-const match arms.

The hack was explained in a comment, which you can see here:
https://github.com/rust-lang/rust/pull/22580/files#diff-402a0fa4b3c6755c5650027c6d4cf1efR497

But hack was incomplete (and thus unsound), as pointed out here:
https://github.com/rust-lang/rust/issues/47295#issuecomment-357108458

Plus, it is likely to be at least tricky to reimplement this hack in
the new NLL borrowck.

So rather than try to preserve the hack, we want to try to just remove
it outright. (At least to see the results of a crater run.)

[breaking-change]

This is a breaking-change, but our hope is that no one is actually
relying on such an extreme special case. (We hypothesize the hack was
originally added to accommodate a file in our own test suite, not code
in the wild.)