### PR TITLE
Clarify "length" wording in `Vec::with_capacity`.

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -334,9 +334,10 @@ impl<T> Vec<T> {
     /// The vector will be able to hold exactly `capacity` elements without
     /// reallocating. If `capacity` is 0, the vector will not allocate.
     ///
-    /// It is important to note that this function does not specify the *length*
-    /// of the returned vector, but only the *capacity*. For an explanation of
-    /// the difference between length and capacity, see *[Capacity and reallocation]*.
+    /// It is important to note that although the returned vector has the
+    /// *capacity* specified, the vector will have a zero *length*. For an
+    /// explanation of the difference between length and capacity, see
+    /// *[Capacity and reallocation]*.
     ///
     /// [Capacity and reallocation]: #capacity-and-reallocation
     ///


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/49448.