### PR TITLE
Add `#[repr(C)]` to `Path`

### DIFF
--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1654,6 +1654,7 @@ impl AsRef<OsStr> for PathBuf {
 /// assert_eq!(extension, Some(OsStr::new("txt")));
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[repr(C)]
 pub struct Path {
     inner: OsStr,
 }


### PR DESCRIPTION
`Path::new` casts a `*const OsStr` to a `*const Path`. I don't think this is strictly allowed when using Rust's struct layout.