### PR TITLE
std: Child::kill() returns error if process has already exited

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1146,7 +1146,7 @@ impl Child {
     ///
     /// [`ErrorKind`]: ../io/enum.ErrorKind.html
     /// [`InvalidInput`]: ../io/enum.ErrorKind.html#variant.InvalidInput
-    /// [`Other]: ../io/enum.ErrorKind.html#variant.Other
+    /// [`Other`]: ../io/enum.ErrorKind.html#variant.Other
     #[stable(feature = "process", since = "1.0.0")]
     pub fn kill(&mut self) -> io::Result<()> {
         self.handle.kill()

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1121,7 +1121,7 @@ impl ExitCode {
 }
 
 impl Child {
-    /// Forces the child process to exit.  If the child has already exited, an [`InvalidInput`]
+    /// Forces the child process to exit. If the child has already exited, an [`InvalidInput`]
     /// error is returned.
     ///
     /// The mapping to [`ErrorKind`]s is not part of the compatibility contract of the function,

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1121,8 +1121,9 @@ impl ExitCode {
 }
 
 impl Child {
-    /// Forces the child to exit. This is equivalent to sending a
-    /// SIGKILL on unix platforms.
+    /// Forces the child process to exit.  If the child has already exited, an error is returned.
+    ///
+    /// This is equivalent to sending a SIGKILL on Unix platforms.
     ///
     /// # Examples
     ///

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1122,7 +1122,10 @@ impl ExitCode {
 
 impl Child {
     /// Forces the child process to exit.  If the child has already exited, an [`InvalidInput`]
-    /// error might be returned.
+    /// error is returned.
+    ///
+    /// The mapping to [`ErrorKind`]s is not part of the compatibility contract of the function,
+    /// especially the [`Other`] kind might change to more specific kinds in the future.
     ///
     /// This is equivalent to sending a SIGKILL on Unix platforms.
     ///
@@ -1141,7 +1144,9 @@ impl Child {
     /// }
     /// ```
     ///
+    /// [`ErrorKind`]: ../io/enum.ErrorKind.html
     /// [`InvalidInput`]: ../io/enum.ErrorKind.html#variant.InvalidInput
+    /// [`Other]: ../io/enum.ErrorKind.html#variant.Other
     #[stable(feature = "process", since = "1.0.0")]
     pub fn kill(&mut self) -> io::Result<()> {
         self.handle.kill()

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1121,7 +1121,8 @@ impl ExitCode {
 }
 
 impl Child {
-    /// Forces the child process to exit.  If the child has already exited, an error is returned.
+    /// Forces the child process to exit.  If the child has already exited, an [`InvalidInput`]
+    /// error might be returned.
     ///
     /// This is equivalent to sending a SIGKILL on Unix platforms.
     ///
@@ -1139,6 +1140,8 @@ impl Child {
     ///     println!("yes command didn't start");
     /// }
     /// ```
+    ///
+    /// [`InvalidInput`]: ../io/enum.ErrorKind.html#variant.InvalidInput
     #[stable(feature = "process", since = "1.0.0")]
     pub fn kill(&mut self) -> io::Result<()> {
         self.handle.kill()


### PR DESCRIPTION
This patch makes it clear in std::process::Child::kill()'s API
documentation that an error is returned if the child process has
already cleanly exited.  This is implied by the example, but not
called out explicitly.