### PR TITLE
rustbuild: Don't leak file handles when creating junctions on Windows

### DIFF
--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -288,6 +288,7 @@ pub fn symlink_dir(src: &Path, dest: &Path) -> io::Result<()> {
                                nOutBufferSize: DWORD,
                                lpBytesReturned: LPDWORD,
                                lpOverlapped: LPOVERLAPPED) -> BOOL;
+            fn CloseHandle(hObject: HANDLE) -> BOOL;
         }
 
         fn to_u16s<S: AsRef<OsStr>>(s: S) -> io::Result<Vec<u16>> {
@@ -341,11 +342,13 @@ pub fn symlink_dir(src: &Path, dest: &Path) -> io::Result<()> {
                                       &mut ret,
                                       ptr::null_mut());
 
-            if res == 0 {
+            let out = if res == 0 {
                 Err(io::Error::last_os_error())
             } else {
                 Ok(())
-            }
+            };
+            CloseHandle(h);
+            out
         }
     }
 }


### PR DESCRIPTION
This fixes building the compiler docs because stage1-rustc\x86_64-pc-windows-msvc\doc is used twice which doesn't work if we still have a handle from the first time.