### PR TITLE
Use f{32,64}::to_bits for is_zero test in vec::SpecFromElem

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1574,8 +1574,8 @@ impl_spec_from_elem!(u64, |x| x == 0);
 impl_spec_from_elem!(u128, |x| x == 0);
 impl_spec_from_elem!(usize, |x| x == 0);
 
-impl_spec_from_elem!(f32, |x: f32| x == 0. && x.is_sign_positive());
-impl_spec_from_elem!(f64, |x: f64| x == 0. && x.is_sign_positive());
+impl_spec_from_elem!(f32, |x: f32| x.to_bits() == 0);
+impl_spec_from_elem!(f64, |x: f64| x.to_bits() == 0);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Common trait implementations for Vec


### PR DESCRIPTION
vec::SpecFromElem provides an optimization to use calloc to fill a Vec
when the element given to fill the Vec is represented by 0.

For floats, the test for that currently used is `x == 0. &&
x.is_sign_positive()`. When compiled in a standalone function, rustc
generates the following assembly:

```
  xorps xmm1, xmm1
  ucomisd xmm0, xmm1
  setnp al
  sete cl
  and cl, al
  movq rax, xmm0
  test rax, rax
  setns al
  and al, cl
  ret
```

A simpler test telling us whether the value is represented by 0, is
`x.to_bits() == 0`, which rustc compiles to:

```
  movq rax, xmm0
  test rax, rax
  sete al
  ret
```

Not that the test is hot in any way, but it also makes it clearer what
the intent in the rust code is.