### PR TITLE
Move the alloc::allocator module to core::heap

### DIFF
--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -19,7 +19,7 @@ use core::intrinsics::{min_align_of_val, size_of_val};
 use core::mem::{self, ManuallyDrop};
 use core::usize;
 
-pub use allocator::*;
+pub use core::heap::*;
 #[doc(hidden)]
 pub mod __core {
     pub use core::*;

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -81,6 +81,7 @@
 #![cfg_attr(not(test), feature(exact_size_is_empty))]
 #![cfg_attr(not(test), feature(generator_trait))]
 #![cfg_attr(test, feature(rand, test))]
+#![feature(allocator_api)]
 #![feature(allow_internal_unstable)]
 #![feature(ascii_ctype)]
 #![feature(box_into_raw_non_null)]
@@ -145,9 +146,9 @@ extern crate std_unicode;
 #[macro_use]
 mod macros;
 
-// Allocator trait and helper struct definitions
-
-pub mod allocator;
+#[rustc_deprecated(since = "1.27.0", reason = "use the heap module in core, alloc, or std instead")]
+#[unstable(feature = "allocator_api", issue = "32838")]
+pub use core::heap as allocator;
 
 // Heaps provided for low-level allocation strategies
 

--- a/src/libcore/heap.rs
+++ b/src/libcore/heap.rs
@@ -15,11 +15,11 @@
                       tracing garbage collector",
             issue = "32838")]
 
-use core::cmp;
-use core::fmt;
-use core::mem;
-use core::usize;
-use core::ptr::{self, NonNull};
+use cmp;
+use fmt;
+use mem;
+use usize;
+use ptr::{self, NonNull};
 
 /// Represents the combination of a starting address and
 /// a total capacity of the returned block.
@@ -568,7 +568,7 @@ pub unsafe trait Alloc {
     /// invoked method, and let the client decide whether to invoke
     /// this `oom` method in response.
     fn oom(&mut self, _: AllocErr) -> ! {
-        unsafe { ::core::intrinsics::abort() }
+        unsafe { ::intrinsics::abort() }
     }
 
     // == ALLOCATOR-SPECIFIC QUANTITIES AND LIMITS ==

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -185,6 +185,10 @@ pub mod hash;
 pub mod fmt;
 pub mod time;
 
+/* Heap memory allocator trait */
+#[allow(missing_docs)]
+pub mod heap;
+
 // note: does not need to be public
 mod char_private;
 mod iter_private;

--- a/src/libstd/heap.rs
+++ b/src/libstd/heap.rs
@@ -12,8 +12,9 @@
 
 #![unstable(issue = "32838", feature = "allocator_api")]
 
-pub use alloc::heap::{Heap, Alloc, Layout, Excess, CannotReallocInPlace, AllocErr};
+pub use alloc::heap::Heap;
 pub use alloc_system::System;
+pub use core::heap::*;
 
 #[cfg(not(test))]
 #[doc(hidden)]


### PR DESCRIPTION
This is the `Alloc` trait and its dependencies.