### PR TITLE
Ignore stack-probes tests on powerpc/s390x too

### DIFF
--- a/src/test/codegen/stack-probes.rs
+++ b/src/test/codegen/stack-probes.rs
@@ -13,6 +13,7 @@
 // ignore-mips
 // ignore-mips64
 // ignore-powerpc
+// ignore-s390x
 // ignore-wasm
 // ignore-emscripten
 // ignore-windows

--- a/src/test/run-pass/stack-probes-lto.rs
+++ b/src/test/run-pass/stack-probes-lto.rs
@@ -12,6 +12,8 @@
 // ignore-aarch64
 // ignore-mips
 // ignore-mips64
+// ignore-powerpc
+// ignore-s390x
 // ignore-wasm
 // ignore-cloudabi no processes
 // ignore-emscripten no processes

--- a/src/test/run-pass/stack-probes.rs
+++ b/src/test/run-pass/stack-probes.rs
@@ -12,6 +12,8 @@
 // ignore-aarch64
 // ignore-mips
 // ignore-mips64
+// ignore-powerpc
+// ignore-s390x
 // ignore-wasm
 // ignore-cloudabi no processes
 // ignore-emscripten no processes


### PR DESCRIPTION
We only support stack probes on x86 and x86_64.
Other arches are already ignored.