### PR TITLE
Swap the 2 variants of Option<T>

### DIFF
--- a/src/test/compile-fail/issue-2111.rs
+++ b/src/test/compile-fail/issue-2111.rs
@@ -10,7 +10,7 @@
 
 fn foo(a: Option<usize>, b: Option<usize>) {
   match (a,b) {
-  //~^ ERROR: non-exhaustive patterns: `(None, None)` not covered
+  //~^ ERROR: non-exhaustive patterns: `(Some(_), Some(_))` not covered
     (Some(a), Some(b)) if a == b => { }
     (Some(_), None) |
     (None, Some(_)) => { }

--- a/src/test/mir-opt/match_false_edges.rs
+++ b/src/test/mir-opt/match_false_edges.rs
@@ -55,7 +55,7 @@ fn main() {
 //      _2 = std::option::Option<i32>::Some(const 42i32,);
 //      _3 = discriminant(_2);
 //      _6 = discriminant(_2);
-//      switchInt(move _6) -> [0isize: bb6, 1isize: bb4, otherwise: bb8];
+//      switchInt(move _6) -> [0isize: bb4, 1isize: bb6, otherwise: bb8];
 //  }
 //  bb1: {
 //      resume;
@@ -119,7 +119,7 @@ fn main() {
 //      _2 = std::option::Option<i32>::Some(const 42i32,);
 //      _3 = discriminant(_2);
 //      _6 = discriminant(_2);
-//      switchInt(move _6) -> [0isize: bb5, 1isize: bb4, otherwise: bb8];
+//      switchInt(move _6) -> [0isize: bb4, 1isize: bb5, otherwise: bb8];
 //  }
 //  bb1: {
 //      resume;
@@ -183,7 +183,7 @@ fn main() {
 //     _2 = std::option::Option<i32>::Some(const 1i32,);
 //     _3 = discriminant(_2);
 //     _8 = discriminant(_2);
-//     switchInt(move _8) -> [1isize: bb4, otherwise: bb5];
+//     switchInt(move _8) -> [0isize: bb4, otherwise: bb5];
 // }
 // bb1: {
 //     resume;


### PR DESCRIPTION
That allows us to have a better path from `Result<T, E>` to `Option<T>` in the general case, without niche-filling optimisations.

@rust-lang/wg-codegen 

It should be noted that if you also have #49479 and #49420 (not sure this one matters but it was in my branch so full disclosure I guess), the methods for `Result<T, UnitStuff>` and `Option<T>` end up being shared for `T` values that don't trigger the niche-filling optimisation.

```rust
#![crate_type = "lib"]
#![feature(try_trait)]

pub fn foo(x: Option<i32>) -> Result<i32, std::option::NoneError> {
    match x {
        Some(v) => Ok(v),
        None => Err(std::option::NoneError),
    }
}

pub fn bar(x: Option<i32>) -> Option<i32> {
    match foo(x) {
        Ok(v) => Some(v),
        Err(_) => None,
    }
}
```

```llvm
; ModuleID = 'foo0-8787f43e282added376259c1adb08b80.rs'
source_filename = "foo0-8787f43e282added376259c1adb08b80.rs"
target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-apple-darwin"

; foo::bar
; Function Attrs: norecurse nounwind readnone uwtable
define { i32, i32 } @_ZN3foo3bar17h61d61d9e41681936E(i32 %x.0, i32 %x.1) unnamed_addr #0 {
start:
  %switch.i = icmp ne i32 %x.0, 0
  %. = zext i1 %switch.i to i32
  %0 = insertvalue { i32, i32 } undef, i32 %., 0
  %1 = insertvalue { i32, i32 } %0, i32 %x.1, 1
  ret { i32, i32 } %1
}

; foo::foo
; Function Attrs: norecurse nounwind readnone uwtable
define { i32, i32 } @_ZN3foo3foo17h9a3b40b224e16c75E(i32, i32) unnamed_addr #0 {
; call foo::bar
  %3 = tail call { i32, i32 } @_ZN3foo3bar17h61d61d9e41681936E(i32 %0, i32 %1) #0
  ret { i32, i32 } %3
}

attributes #0 = { norecurse nounwind readnone uwtable "no-frame-pointer-elim"="true" "probe-stack"="__rust_probestack" }
```