### PR TITLE
Make UNIX_EPOCH an associated constant of SystemTime

### DIFF
--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -271,6 +271,7 @@ impl SystemTime {
     /// # Examples
     ///
     /// ```no_run
+    /// #![feature(assoc_unix_epoch)]
     /// use std::time::SystemTime;
     ///
     /// match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -259,6 +259,28 @@ impl fmt::Debug for Instant {
 }
 
 impl SystemTime {
+    /// An anchor in time which can be used to create new `SystemTime` instances or
+    /// learn about where in time a `SystemTime` lies.
+    ///
+    /// This constant is defined to be "1970-01-01 00:00:00 UTC" on all systems with
+    /// respect to the system clock. Using `duration_since` on an existing
+    /// `SystemTime` instance can tell how far away from this point in time a
+    /// measurement lies, and using `UNIX_EPOCH + duration` can be used to create a
+    /// `SystemTime` instance to represent another fixed point in time.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::time::SystemTime;
+    ///
+    /// match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+    ///     Ok(n) => println!("1970-01-01 00:00:00 UTC was {} seconds ago!", n.as_secs()),
+    ///     Err(_) => panic!("SystemTime before UNIX EPOCH!"),
+    /// }
+    /// ```
+    #[unstable(feature = "assoc_unix_epoch", issue = "49502")]
+    pub const UNIX_EPOCH: SystemTime = UNIX_EPOCH;
+
     /// Returns the system time corresponding to "now".
     ///
     /// # Examples


### PR DESCRIPTION
It's not very discoverable as a separate const in the module.

r? @alexcrichton 