### PR TITLE
Inject the `compiler_builtins` crate whenever the `core` crate is injected

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
 name = "alloc"
 version = "0.0.0"
 dependencies = [
+ "compiler_builtins 0.0.0",
  "core 0.0.0",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "std_unicode 0.0.0",
@@ -23,6 +24,7 @@ dependencies = [
  "alloc_system 0.0.0",
  "build_helper 0.1.0",
  "cc 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compiler_builtins 0.0.0",
  "core 0.0.0",
  "libc 0.0.0",
 ]
@@ -32,6 +34,7 @@ name = "alloc_system"
 version = "0.0.0"
 dependencies = [
  "alloc 0.0.0",
+ "compiler_builtins 0.0.0",
  "core 0.0.0",
  "dlmalloc 0.0.0",
  "libc 0.0.0",
@@ -541,6 +544,7 @@ name = "dlmalloc"
 version = "0.0.0"
 dependencies = [
  "alloc 0.0.0",
+ "compiler_builtins 0.0.0",
  "core 0.0.0",
 ]
 
@@ -976,6 +980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libc"
 version = "0.0.0"
 dependencies = [
+ "compiler_builtins 0.0.0",
  "core 0.0.0",
 ]
 
@@ -1254,6 +1259,7 @@ dependencies = [
 name = "panic_abort"
 version = "0.0.0"
 dependencies = [
+ "compiler_builtins 0.0.0",
  "core 0.0.0",
  "libc 0.0.0",
 ]
@@ -1263,6 +1269,7 @@ name = "panic_unwind"
 version = "0.0.0"
 dependencies = [
  "alloc 0.0.0",
+ "compiler_builtins 0.0.0",
  "core 0.0.0",
  "libc 0.0.0",
  "unwind 0.0.0",
@@ -1401,6 +1408,7 @@ name = "profiler_builtins"
 version = "0.0.0"
 dependencies = [
  "cc 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compiler_builtins 0.0.0",
  "core 0.0.0",
 ]
 
@@ -1797,6 +1805,7 @@ dependencies = [
  "alloc_system 0.0.0",
  "build_helper 0.1.0",
  "cmake 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compiler_builtins 0.0.0",
  "core 0.0.0",
 ]
 
@@ -1942,6 +1951,7 @@ dependencies = [
  "alloc_system 0.0.0",
  "build_helper 0.1.0",
  "cmake 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compiler_builtins 0.0.0",
  "core 0.0.0",
 ]
 
@@ -1991,6 +2001,7 @@ dependencies = [
  "alloc_system 0.0.0",
  "build_helper 0.1.0",
  "cmake 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compiler_builtins 0.0.0",
  "core 0.0.0",
 ]
 
@@ -2130,6 +2141,7 @@ dependencies = [
  "alloc_system 0.0.0",
  "build_helper 0.1.0",
  "cmake 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compiler_builtins 0.0.0",
  "core 0.0.0",
 ]
 
@@ -2343,6 +2355,7 @@ dependencies = [
 name = "std_unicode"
 version = "0.0.0"
 dependencies = [
+ "compiler_builtins 0.0.0",
  "core 0.0.0",
 ]
 
@@ -2725,6 +2738,7 @@ dependencies = [
 name = "unwind"
 version = "0.0.0"
 dependencies = [
+ "compiler_builtins 0.0.0",
  "core 0.0.0",
  "libc 0.0.0",
 ]

--- a/src/liballoc/Cargo.toml
+++ b/src/liballoc/Cargo.toml
@@ -10,6 +10,7 @@ path = "lib.rs"
 [dependencies]
 core = { path = "../libcore" }
 std_unicode = { path = "../libstd_unicode" }
+compiler_builtins = { path = "../rustc/compiler_builtins_shim" }
 
 [dev-dependencies]
 rand = "0.4"

--- a/src/liballoc_jemalloc/Cargo.toml
+++ b/src/liballoc_jemalloc/Cargo.toml
@@ -16,6 +16,7 @@ alloc = { path = "../liballoc" }
 alloc_system = { path = "../liballoc_system" }
 core = { path = "../libcore" }
 libc = { path = "../rustc/libc_shim" }
+compiler_builtins = { path = "../rustc/compiler_builtins_shim" }
 
 [build-dependencies]
 build_helper = { path = "../build_helper" }

--- a/src/liballoc_system/Cargo.toml
+++ b/src/liballoc_system/Cargo.toml
@@ -13,6 +13,7 @@ doc = false
 alloc = { path = "../liballoc" }
 core = { path = "../libcore" }
 libc = { path = "../rustc/libc_shim" }
+compiler_builtins = { path = "../rustc/compiler_builtins_shim" }
 
 # See comments in the source for what this dependency is
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]

--- a/src/libpanic_abort/Cargo.toml
+++ b/src/libpanic_abort/Cargo.toml
@@ -12,3 +12,4 @@ doc = false
 [dependencies]
 core = { path = "../libcore" }
 libc = { path = "../rustc/libc_shim" }
+compiler_builtins = { path = "../rustc/compiler_builtins_shim" }

--- a/src/libpanic_unwind/Cargo.toml
+++ b/src/libpanic_unwind/Cargo.toml
@@ -14,3 +14,4 @@ alloc = { path = "../liballoc" }
 core = { path = "../libcore" }
 libc = { path = "../rustc/libc_shim" }
 unwind = { path = "../libunwind" }
+compiler_builtins = { path = "../rustc/compiler_builtins_shim" }

--- a/src/libprofiler_builtins/Cargo.toml
+++ b/src/libprofiler_builtins/Cargo.toml
@@ -13,6 +13,7 @@ doc = false
 
 [dependencies]
 core = { path = "../libcore" }
+compiler_builtins = { path = "../rustc/compiler_builtins_shim" }
 
 [build-dependencies]
 cc = "1.0.1"

--- a/src/librustc_asan/Cargo.toml
+++ b/src/librustc_asan/Cargo.toml
@@ -17,3 +17,4 @@ cmake = "0.1.18"
 alloc = { path = "../liballoc" }
 alloc_system = { path = "../liballoc_system" }
 core = { path = "../libcore" }
+compiler_builtins = { path = "../rustc/compiler_builtins_shim" }

--- a/src/librustc_lsan/Cargo.toml
+++ b/src/librustc_lsan/Cargo.toml
@@ -17,3 +17,4 @@ cmake = "0.1.18"
 alloc = { path = "../liballoc" }
 alloc_system = { path = "../liballoc_system" }
 core = { path = "../libcore" }
+compiler_builtins = { path = "../rustc/compiler_builtins_shim" }

--- a/src/librustc_msan/Cargo.toml
+++ b/src/librustc_msan/Cargo.toml
@@ -17,3 +17,4 @@ cmake = "0.1.18"
 alloc = { path = "../liballoc" }
 alloc_system = { path = "../liballoc_system" }
 core = { path = "../libcore" }
+compiler_builtins = { path = "../rustc/compiler_builtins_shim" }

--- a/src/librustc_tsan/Cargo.toml
+++ b/src/librustc_tsan/Cargo.toml
@@ -17,3 +17,4 @@ cmake = "0.1.18"
 alloc = { path = "../liballoc" }
 alloc_system = { path = "../liballoc_system" }
 core = { path = "../libcore" }
+compiler_builtins = { path = "../rustc/compiler_builtins_shim" }

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -373,6 +373,7 @@ extern crate unwind;
 
 // compiler-rt intrinsics
 #[doc(masked)]
+#[cfg(stage0)]
 extern crate compiler_builtins;
 
 // During testing, this crate is not actually the "real" std library, but rather

--- a/src/libstd_unicode/Cargo.toml
+++ b/src/libstd_unicode/Cargo.toml
@@ -15,3 +15,4 @@ path = "tests/lib.rs"
 
 [dependencies]
 core = { path = "../libcore" }
+compiler_builtins = { path = "../rustc/compiler_builtins_shim" }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -94,7 +94,7 @@ pub fn print_crate<'a>(cm: &'a CodeMap,
                        is_expanded: bool) -> io::Result<()> {
     let mut s = State::new_from_input(cm, sess, filename, input, out, ann, is_expanded);
 
-    if is_expanded && !std_inject::injected_crate_name().is_none() {
+    if is_expanded && std_inject::injected_crate_name().is_some() {
         // We need to print `#![no_std]` (and its feature gate) so that
         // compiling pretty-printed source won't inject libstd again.
         // However we don't want these attributes in the AST because

--- a/src/libunwind/Cargo.toml
+++ b/src/libunwind/Cargo.toml
@@ -14,3 +14,4 @@ doc = false
 [dependencies]
 core = { path = "../libcore" }
 libc = { path = "../rustc/libc_shim" }
+compiler_builtins = { path = "../rustc/compiler_builtins_shim" }

--- a/src/rustc/dlmalloc_shim/Cargo.toml
+++ b/src/rustc/dlmalloc_shim/Cargo.toml
@@ -11,4 +11,5 @@ doc = false
 
 [dependencies]
 core = { path = "../../libcore" }
+compiler_builtins = { path = "../../rustc/compiler_builtins_shim" }
 alloc = { path = "../../liballoc" }

--- a/src/rustc/libc_shim/Cargo.toml
+++ b/src/rustc/libc_shim/Cargo.toml
@@ -29,6 +29,8 @@ doc = false
 #
 # See https://github.com/rust-lang/rfcs/pull/1133.
 core = { path = "../../libcore" }
+compiler_builtins = { path = "../compiler_builtins_shim" }
+
 
 [features]
 # Certain parts of libc are conditionally compiled differently than when used


### PR DESCRIPTION
It depends on libcore for providing all lang items that are necessary for doing anything useful, so core can't depend on it.

r? @japaric 

cc @aturon 