### PR TITLE
Add TargetOption::force_pic_relocation_model and use it for mips64

### DIFF
--- a/src/librustc_back/target/mips64_unknown_linux_gnuabi64.rs
+++ b/src/librustc_back/target/mips64_unknown_linux_gnuabi64.rs
@@ -32,6 +32,9 @@ pub fn target() -> TargetResult {
             // see #36994
             exe_allocation_crate: None,
 
+            // see #49421
+            force_pic_relocation_model: true,
+
             ..super::linux_base::opts()
         },
     })

--- a/src/librustc_back/target/mips64el_unknown_linux_gnuabi64.rs
+++ b/src/librustc_back/target/mips64el_unknown_linux_gnuabi64.rs
@@ -32,6 +32,9 @@ pub fn target() -> TargetResult {
             // see #36994
             exe_allocation_crate: None,
 
+            // see #49421
+            force_pic_relocation_model: true,
+
             ..super::linux_base::opts()
         },
     })

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -478,6 +478,9 @@ pub struct TargetOptions {
 
     /// Whether or not bitcode is embedded in object files
     pub embed_bitcode: bool,
+
+    /// This target requires everything to be compiled with pic reloc model.
+    pub force_pic_relocation_model: bool,
 }
 
 impl Default for TargetOptions {
@@ -550,6 +553,7 @@ impl Default for TargetOptions {
             codegen_backend: "llvm".to_string(),
             default_hidden_visibility: false,
             embed_bitcode: false,
+            force_pic_relocation_model: false,
         }
     }
 }
@@ -799,6 +803,7 @@ impl Target {
         key!(codegen_backend);
         key!(default_hidden_visibility, bool);
         key!(embed_bitcode, bool);
+        key!(force_pic_relocation_model, bool);
 
         if let Some(array) = obj.find("abi-blacklist").and_then(Json::as_array) {
             for name in array.iter().filter_map(|abi| abi.as_string()) {
@@ -1002,6 +1007,7 @@ impl ToJson for Target {
         target_option_val!(codegen_backend);
         target_option_val!(default_hidden_visibility);
         target_option_val!(embed_bitcode);
+        target_option_val!(force_pic_relocation_model);
 
         if default.abi_blacklist != self.options.abi_blacklist {
             d.insert("abi-blacklist".to_string(), self.options.abi_blacklist.iter()

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -154,6 +154,14 @@ fn get_llvm_opt_size(optimize: config::OptLevel) -> llvm::CodeGenOptSize {
     }
 }
 
+fn get_llvm_reloc_model(sess: &Session) -> llvm::RelocMode {
+    if sess.target.target.options.force_pic_relocation_model {
+        llvm::RelocMode::PIC
+    } else {
+        get_reloc_model(sess)
+    }
+}
+
 pub fn create_target_machine(sess: &Session) -> TargetMachineRef {
     target_machine_factory(sess)().unwrap_or_else(|err| {
         llvm_err(sess.diagnostic(), err).raise()
@@ -163,7 +171,7 @@ pub fn create_target_machine(sess: &Session) -> TargetMachineRef {
 pub fn target_machine_factory(sess: &Session)
     -> Arc<Fn() -> Result<TargetMachineRef, String> + Send + Sync>
 {
-    let reloc_model = get_reloc_model(sess);
+    let reloc_model = get_llvm_reloc_model(sess);
 
     let opt_level = get_llvm_opt_level(sess.opts.optimize);
     let use_softfp = sess.opts.cg.soft_float;

--- a/src/librustc_trans/context.rs
+++ b/src/librustc_trans/context.rs
@@ -115,7 +115,7 @@ pub fn get_reloc_model(sess: &Session) -> llvm::RelocMode {
         None => &sess.target.target.options.relocation_model[..],
     };
 
-    match ::back::write::RELOC_MODEL_ARGS.iter().find(
+    let reloc_model = match ::back::write::RELOC_MODEL_ARGS.iter().find(
         |&&arg| arg.0 == reloc_model_arg) {
         Some(x) => x.1,
         _ => {
@@ -124,6 +124,12 @@ pub fn get_reloc_model(sess: &Session) -> llvm::RelocMode {
             sess.abort_if_errors();
             bug!();
         }
+    };
+
+    if sess.target.target.options.force_pic_relocation_model {
+        llvm::RelocMode::PIC
+    } else {
+        reloc_model
     }
 }
 

--- a/src/librustc_trans/context.rs
+++ b/src/librustc_trans/context.rs
@@ -115,7 +115,7 @@ pub fn get_reloc_model(sess: &Session) -> llvm::RelocMode {
         None => &sess.target.target.options.relocation_model[..],
     };
 
-    let reloc_model = match ::back::write::RELOC_MODEL_ARGS.iter().find(
+    match ::back::write::RELOC_MODEL_ARGS.iter().find(
         |&&arg| arg.0 == reloc_model_arg) {
         Some(x) => x.1,
         _ => {
@@ -124,12 +124,6 @@ pub fn get_reloc_model(sess: &Session) -> llvm::RelocMode {
             sess.abort_if_errors();
             bug!();
         }
-    };
-
-    if sess.target.target.options.force_pic_relocation_model {
-        llvm::RelocMode::PIC
-    } else {
-        reloc_model
     }
 }
 


### PR DESCRIPTION
Makes mips64 gnu targets use PIC relocation model regardless of what user specifies. See #49421. 