### PR TITLE
Fix anchor position on fields

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -533,6 +533,9 @@ a {
 	left: -5px;
 }
 .small-section-header > .anchor {
+	left: -20px;
+}
+.small-section-header > .anchor:not(.field) {
 	left: -28px;
 }
 .anchor:before {


### PR DESCRIPTION
Take a look at `Option` variants for example and try to click on `§` to get the issue.

r? @QuietMisdreavus 