### PR TITLE
fs_read_write_bytes stabilized in 1.26.0

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -259,7 +259,7 @@ fn initial_buffer_size(file: &File) -> usize {
 ///     Ok(())
 /// }
 /// ```
-#[stable(feature = "fs_read_write_bytes", since = "1.27.0")]
+#[stable(feature = "fs_read_write_bytes", since = "1.26.0")]
 pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
     let mut file = File::open(path)?;
     let mut bytes = Vec::with_capacity(initial_buffer_size(&file));
@@ -330,7 +330,7 @@ pub fn read_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
 ///     Ok(())
 /// }
 /// ```
-#[stable(feature = "fs_read_write_bytes", since = "1.27.0")]
+#[stable(feature = "fs_read_write_bytes", since = "1.26.0")]
 pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result<()> {
     File::create(path)?.write_all(contents.as_ref())
 }


### PR DESCRIPTION
Fix the stabilization attributes from #49422 because it merged before 1.26 branched to beta.

r? @TimNN