### PR TITLE
Handle fast-submodules option correctly

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -647,7 +647,7 @@ class RustBuild(object):
         if (not os.path.exists(os.path.join(self.rust_root, ".git"))) or \
                 self.get_toml('submodules') == "false":
             return
-        slow_submodules = self.get_toml('fast-submodule') == "false"
+        slow_submodules = self.get_toml('fast-submodules') == "false"
         start_time = time()
         if slow_submodules:
             print('Unconditionally updating all submodules')

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -45,6 +45,7 @@ pub struct Config {
     pub ninja: bool,
     pub verbose: usize,
     pub submodules: bool,
+    pub fast_submodules: bool,
     pub compiler_docs: bool,
     pub docs: bool,
     pub locked_deps: bool,
@@ -191,6 +192,7 @@ struct Build {
     compiler_docs: Option<bool>,
     docs: Option<bool>,
     submodules: Option<bool>,
+    fast_submodules: Option<bool>,
     gdb: Option<String>,
     locked_deps: Option<bool>,
     vendor: Option<bool>,
@@ -328,6 +330,7 @@ impl Config {
         config.rust_optimize = true;
         config.rust_optimize_tests = true;
         config.submodules = true;
+        config.fast_submodules = true;
         config.docs = true;
         config.rust_rpath = true;
         config.channel = "dev".to_string();
@@ -404,6 +407,7 @@ impl Config {
         set(&mut config.compiler_docs, build.compiler_docs);
         set(&mut config.docs, build.docs);
         set(&mut config.submodules, build.submodules);
+        set(&mut config.fast_submodules, build.fast_submodules);
         set(&mut config.locked_deps, build.locked_deps);
         set(&mut config.vendor, build.vendor);
         set(&mut config.full_bootstrap, build.full_bootstrap);


### PR DESCRIPTION
This option was introduced in 72cb109bec8, but it uses two different
spellings (`fast-submodule` in `bootstrap.py` vs `fast-submodules` in
`config.toml.example`) and isn't handled by Rust bootstrap which means
that any attempt to set this flag fails.