### PR TITLE
Soft-deprecate the description() method of the Error trait

### DIFF
--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -36,9 +36,9 @@ use str;
 use string;
 
 /// `Error` is a trait representing the basic expectations for error values,
-/// i.e. values of type `E` in [`Result<T, E>`]. At a minimum, errors must provide
-/// a description, but they may optionally provide additional detail (via
-/// [`Display`]) and cause chain information:
+/// i.e. values of type `E` in [`Result<T, E>`]. Errors must describe
+/// themselves through the [`Display`] and [`Debug`] traits, and may provide
+/// cause chain information:
 ///
 /// The [`cause`] method is generally used when errors cross "abstraction
 /// boundaries", i.e.  when a one module must report an error that is "caused"

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -52,30 +52,29 @@ use string;
 /// [`cause`]: trait.Error.html#method.cause
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Error: Debug + Display {
-    /// A short description of the error.
+    /// **This method is soft-deprecated.**
     ///
-    /// The description should only be used for a simple message.
-    /// It should not contain newlines or sentence-ending punctuation,
-    /// to facilitate embedding in larger user-facing strings.
-    /// For showing formatted error messages with more information see
-    /// [`Display`].
+    /// Although using it won’t cause compilation warning,
+    /// new code should use [`Display`] instead
+    /// and new `impl`s can omit it.
     ///
     /// [`Display`]: ../fmt/trait.Display.html
     ///
     /// # Examples
     ///
     /// ```
-    /// use std::error::Error;
-    ///
     /// match "xc".parse::<u32>() {
     ///     Err(e) => {
-    ///         println!("Error: {}", e.description());
+    ///         // Print `e` itself, not `e.description()`.
+    ///         println!("Error: {}", e);
     ///     }
     ///     _ => println!("No error"),
     /// }
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn description(&self) -> &str;
+    fn description(&self) -> &str {
+        ""
+    }
 
     /// The lower-level cause of this error, if any.
     ///

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -9,34 +9,6 @@
 // except according to those terms.
 
 //! Traits for working with Errors.
-//!
-//! # The `Error` trait
-//!
-//! `Error` is a trait representing the basic expectations for error values,
-//! i.e. values of type `E` in [`Result<T, E>`]. At a minimum, errors must provide
-//! a description, but they may optionally provide additional detail (via
-//! [`Display`]) and cause chain information:
-//!
-//! ```
-//! use std::fmt::Display;
-//!
-//! trait Error: Display {
-//!     fn description(&self) -> &str;
-//!
-//!     fn cause(&self) -> Option<&Error> { None }
-//! }
-//! ```
-//!
-//! The [`cause`] method is generally used when errors cross "abstraction
-//! boundaries", i.e.  when a one module must report an error that is "caused"
-//! by an error from a lower-level module. This setup makes it possible for the
-//! high-level module to provide its own errors that do not commit to any
-//! particular implementation, but also reveal some of its implementation for
-//! debugging via [`cause`] chains.
-//!
-//! [`Result<T, E>`]: ../result/enum.Result.html
-//! [`Display`]: ../fmt/trait.Display.html
-//! [`cause`]: trait.Error.html#method.cause
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -63,7 +35,31 @@ use num;
 use str;
 use string;
 
-/// Base functionality for all errors in Rust.
+/// `Error` is a trait representing the basic expectations for error values,
+/// i.e. values of type `E` in [`Result<T, E>`]. At a minimum, errors must provide
+/// a description, but they may optionally provide additional detail (via
+/// [`Display`]) and cause chain information:
+///
+/// ```
+/// use std::fmt::Display;
+///
+/// trait Error: Display {
+///     fn description(&self) -> &str;
+///
+///     fn cause(&self) -> Option<&Error> { None }
+/// }
+/// ```
+///
+/// The [`cause`] method is generally used when errors cross "abstraction
+/// boundaries", i.e.  when a one module must report an error that is "caused"
+/// by an error from a lower-level module. This setup makes it possible for the
+/// high-level module to provide its own errors that do not commit to any
+/// particular implementation, but also reveal some of its implementation for
+/// debugging via [`cause`] chains.
+///
+/// [`Result<T, E>`]: ../result/enum.Result.html
+/// [`Display`]: ../fmt/trait.Display.html
+/// [`cause`]: trait.Error.html#method.cause
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Error: Debug + Display {
     /// A short description of the error.

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -40,16 +40,6 @@ use string;
 /// a description, but they may optionally provide additional detail (via
 /// [`Display`]) and cause chain information:
 ///
-/// ```
-/// use std::fmt::Display;
-///
-/// trait Error: Display {
-///     fn description(&self) -> &str;
-///
-///     fn cause(&self) -> Option<&Error> { None }
-/// }
-/// ```
-///
 /// The [`cause`] method is generally used when errors cross "abstraction
 /// boundaries", i.e.  when a one module must report an error that is "caused"
 /// by an error from a lower-level module. This setup makes it possible for the


### PR DESCRIPTION
By providing a default impl and documenting that `Display` should be used instead.

Closes https://github.com/rust-lang/rfcs/pull/2230.