### PR TITLE
Add size_hints for btree iterators

### DIFF
--- a/src/liballoc/btree/map.rs
+++ b/src/liballoc/btree/map.rs
@@ -1481,15 +1481,7 @@ impl<'a, K, V> Iterator for Range<'a, K, V> {
         }
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.front == self.back {
-            (0, Some(0))
-        } else {
-            // There doesn't seem to be any way to get the size of the whole tree
-            // from a NodeRef.
-            (1, None)
-        }
-    }
+    // FIXME(#49205): Add size_hint.
 }
 
 #[stable(feature = "map_values_mut", since = "1.10.0")]
@@ -1623,15 +1615,7 @@ impl<'a, K, V> Iterator for RangeMut<'a, K, V> {
         }
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.front == self.back {
-            (0, Some(0))
-        } else {
-            // We can get the root node by using into_root_mut; but there doesn't
-            // seem to be any way to get the size of the tree from the root node.
-            (1, None)
-        }
-    }
+    // FIXME(#49205): Add size_hint.
 }
 
 impl<'a, K, V> RangeMut<'a, K, V> {
@@ -2576,11 +2560,11 @@ impl<K: Ord, V, I: Iterator<Item = (K, V)>> Iterator for MergeIter<K, V, I> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (left_lower, left_upper) = self.left.size_hint();
         let (right_lower, right_upper) = self.right.size_hint();
-        let lower = left_lower + right_lower;
+        let lower = left_lower.saturating_add(right_lower);
         let upper = match (left_upper, right_upper) {
             (Some(left), Some(right)) => left.checked_add(right),
-            (left, None) => left,
-            (None, right) => right
+            (_, None) => None,
+            (None, _) => None
         };
         (lower, upper)
     }

--- a/src/liballoc/btree/set.rs
+++ b/src/liballoc/btree/set.rs
@@ -987,6 +987,10 @@ impl<'a, T> Iterator for Range<'a, T> {
     fn next(&mut self) -> Option<&'a T> {
         self.iter.next().map(|(k, _)| k)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 #[stable(feature = "btree_range", since = "1.17.0")]


### PR DESCRIPTION
Continues work on adding size_hint implementations for iterators:
issue #49205