### PR TITLE
Use Alloc and Layout from core::heap.

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -21,6 +21,7 @@ use core::sync::atomic::Ordering::{Acquire, Relaxed, Release, SeqCst};
 use core::borrow;
 use core::fmt;
 use core::cmp::Ordering;
+use core::heap::{Alloc, Layout};
 use core::intrinsics::abort;
 use core::mem::{self, align_of_val, size_of_val, uninitialized};
 use core::ops::Deref;
@@ -31,7 +32,7 @@ use core::hash::{Hash, Hasher};
 use core::{isize, usize};
 use core::convert::From;
 
-use heap::{Heap, Alloc, Layout, box_free};
+use heap::{Heap, box_free};
 use boxed::Box;
 use string::String;
 use vec::Vec;

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -55,7 +55,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use heap::{Heap, Layout, Alloc};
+use heap::Heap;
 use raw_vec::RawVec;
 
 use core::any::Any;
@@ -63,6 +63,7 @@ use core::borrow;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{Hash, Hasher};
+use core::heap::{Alloc, Layout};
 use core::iter::FusedIterator;
 use core::marker::{self, Unpin, Unsize};
 use core::mem::{self, Pin};

--- a/src/liballoc/btree/node.rs
+++ b/src/liballoc/btree/node.rs
@@ -41,13 +41,14 @@
 // - A node of length `n` has `n` keys, `n` values, and (in an internal node) `n + 1` edges.
 //   This implies that even an empty internal node has at least one edge.
 
+use core::heap::{Alloc, Layout};
 use core::marker::PhantomData;
 use core::mem;
 use core::ptr::{self, Unique, NonNull};
 use core::slice;
 
 use boxed::Box;
-use heap::{Heap, Alloc, Layout};
+use heap::Heap;
 
 const B: usize = 6;
 pub const MIN_LEN: usize = B - 1;

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -9,11 +9,12 @@
 // except according to those terms.
 
 use core::cmp;
+use core::heap::{Alloc, Layout};
 use core::mem;
 use core::ops::Drop;
 use core::ptr::{self, Unique};
 use core::slice;
-use heap::{Alloc, Layout, Heap};
+use heap::Heap;
 use super::boxed::Box;
 use super::allocator::CollectionAllocErr;
 use super::allocator::CollectionAllocErr::*;

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -250,6 +250,7 @@ use core::cell::Cell;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{Hash, Hasher};
+use core::heap::{Alloc, Layout};
 use core::intrinsics::abort;
 use core::marker;
 use core::marker::{Unsize, PhantomData};
@@ -259,7 +260,7 @@ use core::ops::CoerceUnsized;
 use core::ptr::{self, NonNull};
 use core::convert::From;
 
-use heap::{Heap, Alloc, Layout, box_free};
+use heap::{Heap, box_free};
 use string::String;
 use vec::Vec;
 

--- a/src/liballoc_jemalloc/lib.rs
+++ b/src/liballoc_jemalloc/lib.rs
@@ -15,7 +15,6 @@
                       form or name",
             issue = "27783")]
 #![deny(warnings)]
-#![feature(alloc)]
 #![feature(alloc_system)]
 #![feature(libc)]
 #![feature(linkage)]
@@ -25,7 +24,6 @@
 #![cfg_attr(not(dummy_jemalloc), feature(allocator_api))]
 #![rustc_alloc_kind = "exe"]
 
-extern crate alloc;
 extern crate alloc_system;
 extern crate libc;
 
@@ -35,7 +33,7 @@ pub use contents::*;
 mod contents {
     use core::ptr;
 
-    use alloc::heap::{Alloc, AllocErr, Layout};
+    use core::heap::{Alloc, AllocErr, Layout};
     use alloc_system::System;
     use libc::{c_int, c_void, size_t};
 

--- a/src/liballoc_system/lib.rs
+++ b/src/liballoc_system/lib.rs
@@ -17,7 +17,6 @@
             issue = "32838")]
 #![feature(global_allocator)]
 #![feature(allocator_api)]
-#![feature(alloc)]
 #![feature(core_intrinsics)]
 #![feature(staged_api)]
 #![feature(rustc_attrs)]
@@ -43,9 +42,7 @@ const MIN_ALIGN: usize = 8;
 #[allow(dead_code)]
 const MIN_ALIGN: usize = 16;
 
-extern crate alloc;
-
-use self::alloc::heap::{Alloc, AllocErr, Layout, Excess, CannotReallocInPlace};
+use core::heap::{Alloc, AllocErr, Layout, Excess, CannotReallocInPlace};
 
 #[unstable(feature = "allocator_api", issue = "32838")]
 pub struct System;
@@ -125,7 +122,7 @@ mod platform {
 
     use MIN_ALIGN;
     use System;
-    use alloc::heap::{Alloc, AllocErr, Layout};
+    use core::heap::{Alloc, AllocErr, Layout};
 
     #[unstable(feature = "allocator_api", issue = "32838")]
     unsafe impl<'a> Alloc for &'a System {
@@ -279,7 +276,7 @@ mod platform {
 
     use MIN_ALIGN;
     use System;
-    use alloc::heap::{Alloc, AllocErr, Layout, CannotReallocInPlace};
+    use core::heap::{Alloc, AllocErr, Layout, CannotReallocInPlace};
 
     type LPVOID = *mut u8;
     type HANDLE = LPVOID;
@@ -491,7 +488,7 @@ mod platform {
 mod platform {
     extern crate dlmalloc;
 
-    use alloc::heap::{Alloc, AllocErr, Layout, Excess, CannotReallocInPlace};
+    use core::heap::{Alloc, AllocErr, Layout, Excess, CannotReallocInPlace};
     use System;
     use self::dlmalloc::GlobalDlmalloc;
 

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -11,9 +11,10 @@
 use self::Entry::*;
 use self::VacantEntryState::*;
 
-use alloc::heap::{Heap, Alloc};
+use alloc::heap::Heap;
 use alloc::allocator::CollectionAllocErr;
 use cell::Cell;
+use core::heap::Alloc;
 use borrow::Borrow;
 use cmp::max;
 use fmt::{self, Debug};

--- a/src/libstd/collections/hash/table.rs
+++ b/src/libstd/collections/hash/table.rs
@@ -8,7 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use alloc::heap::{Heap, Alloc, Layout};
+use alloc::heap::Heap;
+use core::heap::{Alloc, Layout};
 
 use cmp;
 use hash::{BuildHasher, Hash, Hasher};


### PR DESCRIPTION
94d1970bba87f2d2893f6e934e4c3f02ed50604d moved the alloc::allocator
module to core::heap, moving e.g. Alloc and Layout out of the alloc
crate. While alloc::heap reexports them, it's better to use them from
where they really come from.