### PR TITLE
Rename must-compile-successfully into compile-pass

### DIFF
--- a/src/test/COMPILER_TESTS.md
+++ b/src/test/COMPILER_TESTS.md
@@ -68,7 +68,7 @@ Some examples of `X` in `ignore-X`:
 
 * `min-{gdb,lldb}-version`
 * `min-llvm-version`
-* `must-compile-successfully` for UI tests, indicates that the test is supposed
+* `compile-pass` for UI tests, indicates that the test is supposed
   to compile, as opposed to the default where the test is supposed to error out.
 * `compile-flags` passes extra command-line args to the compiler,
   e.g. `compile-flags -g` which forces debuginfo to be enabled.
@@ -134,7 +134,7 @@ so forth.
 Normally, the test-runner checks that UI tests fail compilation. If you want
 to do a UI test for code that *compiles* (e.g. to test warnings, or if you
 have a collection of tests, only some of which error out), you can use the
-`// must-compile-successfully` header command to have the test runner instead
+`// compile-pass` header command to have the test runner instead
 check that the test compiles successfully.
 
 ### Editing and updating the reference files

--- a/src/test/compile-fail/closure-expected-type/expect-fn-supply-fn-multiple.rs
+++ b/src/test/compile-fail/closure-expected-type/expect-fn-supply-fn-multiple.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![allow(warnings)]
 

--- a/src/test/compile-fail/closure-expected-type/expect-infer-var-supply-ty-with-bound-region.rs
+++ b/src/test/compile-fail/closure-expected-type/expect-infer-var-supply-ty-with-bound-region.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 fn with_closure<F, A>(_: F)
     where F: FnOnce(A, &u32)

--- a/src/test/compile-fail/closure-expected-type/expect-infer-var-supply-ty-with-free-region.rs
+++ b/src/test/compile-fail/closure-expected-type/expect-infer-var-supply-ty-with-free-region.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 fn with_closure<F, A>(_: F)
     where F: FnOnce(A, &u32)

--- a/src/test/compile-fail/issue-47309.rs
+++ b/src/test/compile-fail/issue-47309.rs
@@ -13,7 +13,7 @@
 // See https://github.com/rust-lang/rust/issues/47309
 
 // compile-flags:-Clink-dead-code
-// must-compile-successfully
+// compile-pass
 
 #![crate_type="rlib"]
 

--- a/src/test/compile-fail/rmeta-lib-pass.rs
+++ b/src/test/compile-fail/rmeta-lib-pass.rs
@@ -11,7 +11,7 @@
 // compile-flags: --emit=metadata
 // aux-build:rmeta_rlib.rs
 // no-prefer-dynamic
-// must-compile-successfully
+// compile-pass
 
 // Check that building a metadata crate works with a dependent, rlib crate.
 // This is a cfail test since there is no executable to run.

--- a/src/test/compile-fail/rmeta-pass.rs
+++ b/src/test/compile-fail/rmeta-pass.rs
@@ -11,7 +11,7 @@
 // compile-flags: --emit=metadata
 // aux-build:rmeta_meta.rs
 // no-prefer-dynamic
-// must-compile-successfully
+// compile-pass
 
 // Check that building a metadata crate works with a dependent, metadata-only
 // crate.

--- a/src/test/compile-fail/rmeta-priv-warn.rs
+++ b/src/test/compile-fail/rmeta-priv-warn.rs
@@ -10,7 +10,7 @@
 
 // compile-flags: --emit=metadata
 // no-prefer-dynamic
-// must-compile-successfully
+// compile-pass
 
 #[deny(warnings)]
 

--- a/src/test/incremental-fulldeps/incremental_proc_macro.rs
+++ b/src/test/incremental-fulldeps/incremental_proc_macro.rs
@@ -11,7 +11,7 @@
 // aux-build:incremental_proc_macro_aux.rs
 // ignore-stage1
 // revisions: cfail1 cfail2
-// must-compile-successfully
+// compile-pass
 
 // This test makes sure that we still find the proc-macro registrar function
 // when we compile proc-macros incrementally (see #47292).

--- a/src/test/incremental/add_private_fn_at_krate_root_cc/struct_point.rs
+++ b/src/test/incremental/add_private_fn_at_krate_root_cc/struct_point.rs
@@ -15,7 +15,7 @@
 // revisions:cfail1 cfail2
 // compile-flags: -Z query-dep-graph
 // aux-build:point.rs
-// must-compile-successfully
+// compile-pass
 
 #![feature(rustc_attrs)]
 #![feature(stmt_expr_attributes)]

--- a/src/test/incremental/change_add_field/struct_point.rs
+++ b/src/test/incremental/change_add_field/struct_point.rs
@@ -15,7 +15,7 @@
 
 // revisions:cfail1 cfail2
 // compile-flags: -Z query-dep-graph
-// must-compile-successfully
+// compile-pass
 
 #![feature(rustc_attrs)]
 #![feature(stmt_expr_attributes)]

--- a/src/test/incremental/change_crate_dep_kind.rs
+++ b/src/test/incremental/change_crate_dep_kind.rs
@@ -13,7 +13,7 @@
 
 // revisions:cfail1 cfail2
 // compile-flags: -Z query-dep-graph -Cpanic=unwind
-// must-compile-successfully
+// compile-pass
 
 #![feature(panic_unwind)]
 

--- a/src/test/incremental/change_private_fn/struct_point.rs
+++ b/src/test/incremental/change_private_fn/struct_point.rs
@@ -13,7 +13,7 @@
 
 // revisions:cfail1 cfail2
 // compile-flags: -Z query-dep-graph
-// must-compile-successfully
+// compile-pass
 
 #![feature(rustc_attrs)]
 #![feature(stmt_expr_attributes)]

--- a/src/test/incremental/change_private_fn_cc/struct_point.rs
+++ b/src/test/incremental/change_private_fn_cc/struct_point.rs
@@ -14,7 +14,7 @@
 // revisions:cfail1 cfail2
 // compile-flags: -Z query-dep-graph
 // aux-build:point.rs
-// must-compile-successfully
+// compile-pass
 
 #![crate_type = "rlib"]
 #![feature(rustc_attrs)]

--- a/src/test/incremental/change_private_impl_method/struct_point.rs
+++ b/src/test/incremental/change_private_impl_method/struct_point.rs
@@ -13,7 +13,7 @@
 
 // revisions:cfail1 cfail2
 // compile-flags: -Z query-dep-graph
-// must-compile-successfully
+// compile-pass
 
 #![feature(rustc_attrs)]
 #![feature(stmt_expr_attributes)]

--- a/src/test/incremental/change_private_impl_method_cc/struct_point.rs
+++ b/src/test/incremental/change_private_impl_method_cc/struct_point.rs
@@ -14,7 +14,7 @@
 // revisions:cfail1 cfail2
 // compile-flags: -Z query-dep-graph
 // aux-build:point.rs
-// must-compile-successfully
+// compile-pass
 
 #![crate_type = "rlib"]
 #![feature(rustc_attrs)]

--- a/src/test/incremental/change_pub_inherent_method_body/struct_point.rs
+++ b/src/test/incremental/change_pub_inherent_method_body/struct_point.rs
@@ -12,7 +12,7 @@
 
 // revisions:cfail1 cfail2
 // compile-flags: -Z query-dep-graph
-// must-compile-successfully
+// compile-pass
 
 #![crate_type = "rlib"]
 #![feature(rustc_attrs)]

--- a/src/test/incremental/change_pub_inherent_method_sig/struct_point.rs
+++ b/src/test/incremental/change_pub_inherent_method_sig/struct_point.rs
@@ -12,7 +12,7 @@
 
 // revisions:cfail1 cfail2
 // compile-flags: -Z query-dep-graph
-// must-compile-successfully
+// compile-pass
 
 #![crate_type = "rlib"]
 #![feature(rustc_attrs)]

--- a/src/test/incremental/hashes/call_expressions.rs
+++ b/src/test/incremental/hashes/call_expressions.rs
@@ -16,7 +16,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/closure_expressions.rs
+++ b/src/test/incremental/hashes/closure_expressions.rs
@@ -16,7 +16,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/consts.rs
+++ b/src/test/incremental/hashes/consts.rs
@@ -16,7 +16,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/enum_constructors.rs
+++ b/src/test/incremental/hashes/enum_constructors.rs
@@ -16,7 +16,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/enum_defs.rs
+++ b/src/test/incremental/hashes/enum_defs.rs
@@ -21,7 +21,7 @@
 // results in a change of the ICH for the enum's metadata, and that it stays
 // the same between rev2 and rev3.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/exported_vs_not.rs
+++ b/src/test/incremental/hashes/exported_vs_not.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/extern_mods.rs
+++ b/src/test/incremental/hashes/extern_mods.rs
@@ -16,7 +16,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/for_loops.rs
+++ b/src/test/incremental/hashes/for_loops.rs
@@ -16,7 +16,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/function_interfaces.rs
+++ b/src/test/incremental/hashes/function_interfaces.rs
@@ -16,7 +16,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/if_expressions.rs
+++ b/src/test/incremental/hashes/if_expressions.rs
@@ -16,7 +16,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/indexing_expressions.rs
+++ b/src/test/incremental/hashes/indexing_expressions.rs
@@ -16,7 +16,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/inherent_impls.rs
+++ b/src/test/incremental/hashes/inherent_impls.rs
@@ -16,7 +16,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/inline_asm.rs
+++ b/src/test/incremental/hashes/inline_asm.rs
@@ -16,7 +16,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/let_expressions.rs
+++ b/src/test/incremental/hashes/let_expressions.rs
@@ -16,7 +16,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/loop_expressions.rs
+++ b/src/test/incremental/hashes/loop_expressions.rs
@@ -16,7 +16,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/match_expressions.rs
+++ b/src/test/incremental/hashes/match_expressions.rs
@@ -16,7 +16,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/panic_exprs.rs
+++ b/src/test/incremental/hashes/panic_exprs.rs
@@ -18,7 +18,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -C debug-assertions
 

--- a/src/test/incremental/hashes/statics.rs
+++ b/src/test/incremental/hashes/statics.rs
@@ -16,7 +16,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/struct_constructors.rs
+++ b/src/test/incremental/hashes/struct_constructors.rs
@@ -16,7 +16,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/struct_defs.rs
+++ b/src/test/incremental/hashes/struct_defs.rs
@@ -21,7 +21,7 @@
 // results in a change of the ICH for the struct's metadata, and that it stays
 // the same between rev2 and rev3.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/trait_defs.rs
+++ b/src/test/incremental/hashes/trait_defs.rs
@@ -21,7 +21,7 @@
 // results in a change of the ICH for the trait's metadata, and that it stays
 // the same between rev2 and rev3.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/trait_impls.rs
+++ b/src/test/incremental/hashes/trait_impls.rs
@@ -16,7 +16,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/type_defs.rs
+++ b/src/test/incremental/hashes/type_defs.rs
@@ -21,7 +21,7 @@
 // results in a change of the ICH for the enum's metadata, and that it stays
 // the same between rev2 and rev3.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/unary_and_binary_exprs.rs
+++ b/src/test/incremental/hashes/unary_and_binary_exprs.rs
@@ -16,7 +16,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/while_let_loops.rs
+++ b/src/test/incremental/hashes/while_let_loops.rs
@@ -16,7 +16,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/hashes/while_loops.rs
+++ b/src/test/incremental/hashes/while_loops.rs
@@ -16,7 +16,7 @@
 // and make sure that the hash has changed, then change nothing between rev2 and
 // rev3 and make sure that the hash has not changed.
 
-// must-compile-successfully
+// compile-pass
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
 

--- a/src/test/incremental/ich_nested_items.rs
+++ b/src/test/incremental/ich_nested_items.rs
@@ -12,7 +12,7 @@
 // the nested items (or even added new ones).
 
 // revisions: cfail1 cfail2
-// must-compile-successfully
+// compile-pass
 
 #![crate_type = "rlib"]
 #![feature(rustc_attrs)]

--- a/src/test/incremental/issue-42602.rs
+++ b/src/test/incremental/issue-42602.rs
@@ -18,7 +18,7 @@
 
 // revisions:cfail1 cfail2 cfail3
 // compile-flags:-Zquery-dep-graph
-// must-compile-successfully
+// compile-pass
 
 #![feature(rustc_attrs)]
 

--- a/src/test/incremental/issue-49595/issue_49595.rs
+++ b/src/test/incremental/issue-49595/issue_49595.rs
@@ -10,7 +10,7 @@
 
 // revisions:cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph --test
-// must-compile-successfully
+// compile-pass
 
 #![feature(rustc_attrs)]
 #![crate_type = "rlib"]

--- a/src/test/incremental/krate-inherent.rs
+++ b/src/test/incremental/krate-inherent.rs
@@ -10,7 +10,7 @@
 
 // revisions: cfail1 cfail2
 // compile-flags: -Z query-dep-graph
-// must-compile-successfully
+// compile-pass
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]

--- a/src/test/incremental/macro_export.rs
+++ b/src/test/incremental/macro_export.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // revisions: cfail1 cfail2 cfail3
-// must-compile-successfully
+// compile-pass
 
 // This test case makes sure that we can compile with incremental compilation
 // enabled when there are macros exported from this crate. (See #37756)

--- a/src/test/incremental/remove_source_file/main.rs
+++ b/src/test/incremental/remove_source_file/main.rs
@@ -16,7 +16,7 @@
 // Note that we specify -g so that the FileMaps actually get referenced by the
 // incr. comp. cache:
 // compile-flags: -Z query-dep-graph -g
-// must-compile-successfully
+// compile-pass
 
 #![crate_type= "rlib"]
 

--- a/src/test/incremental/string_constant.rs
+++ b/src/test/incremental/string_constant.rs
@@ -10,7 +10,7 @@
 
 // revisions: cfail1 cfail2
 // compile-flags: -Z query-dep-graph
-// must-compile-successfully
+// compile-pass
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]

--- a/src/test/incremental/warnings-reemitted.rs
+++ b/src/test/incremental/warnings-reemitted.rs
@@ -10,7 +10,7 @@
 
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Coverflow-checks=on
-// must-compile-successfully
+// compile-pass
 
 #![allow(warnings)]
 

--- a/src/test/run-fail/rfc-1937-termination-trait/termination-trait-for-box-dyn-error.rs
+++ b/src/test/run-fail/rfc-1937-termination-trait/termination-trait-for-box-dyn-error.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 // failure-status: 1
 
 #![feature(dyn_trait)]

--- a/src/test/run-fail/rfc-1937-termination-trait/termination-trait-for-result-box-error_err.rs
+++ b/src/test/run-fail/rfc-1937-termination-trait/termination-trait-for-result-box-error_err.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 // failure-status: 1
 
 use std::io::{Error, ErrorKind};

--- a/src/test/ui/check_match/issue-43253.rs
+++ b/src/test/ui/check_match/issue-43253.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![feature(exclusive_range_pattern)]
 #![warn(unreachable_patterns)]

--- a/src/test/ui/codemap_tests/unicode_3.rs
+++ b/src/test/ui/codemap_tests/unicode_3.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 fn main() {
     let s = "ZͨA͑ͦ͒͋ͤ͑̚L̄͑͋Ĝͨͥ̿͒̽̈́Oͥ͛ͭ!̏"; while true { break; }

--- a/src/test/ui/const-eval/const_transmute.rs
+++ b/src/test/ui/const-eval/const_transmute.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 // run-pass
 
 union Transmute<T: Copy, U: Copy> {

--- a/src/test/ui/const-eval/issue-47971.rs
+++ b/src/test/ui/const-eval/issue-47971.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![feature(const_fn)]
 

--- a/src/test/ui/const-eval/no_lint_for_statically_known_error.rs
+++ b/src/test/ui/const-eval/no_lint_for_statically_known_error.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 // if `X` were used instead of `x`, `X - 10` would result in a lint.
 // This file should never produce a lint, no matter how the const

--- a/src/test/ui/const-expr-addr-operator.rs
+++ b/src/test/ui/const-expr-addr-operator.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // Encountered while testing #44614.
-// must-compile-successfully
+// compile-pass
 
 pub fn main() {
     // Constant of generic type (int)

--- a/src/test/ui/const-pattern-not-const-evaluable.rs
+++ b/src/test/ui/const-pattern-not-const-evaluable.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![feature(const_fn)]
 

--- a/src/test/ui/explain.rs
+++ b/src/test/ui/explain.rs
@@ -9,4 +9,4 @@
 // except according to those terms.
 
 // compile-flags: --explain E0591
-// must-compile-successfully
+// compile-pass

--- a/src/test/ui/feature-gate-const-indexing.rs
+++ b/src/test/ui/feature-gate-const-indexing.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 fn main() {
     const ARR: [i32; 6] = [42, 43, 44, 45, 46, 47];

--- a/src/test/ui/feature-gate/issue-43106-gating-of-macro_escape.rs
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-macro_escape.rs
@@ -13,7 +13,7 @@
 // `#![macro_escape]` is incompatible with crate-level `#![macro_use]`
 // already present in issue-43106-gating-of-builtin-attrs.
 
-// must-compile-successfully
+// compile-pass
 
 #![macro_escape]
 //~^ WARN macro_escape is a deprecated synonym for macro_use

--- a/src/test/ui/generic-param-attrs.rs
+++ b/src/test/ui/generic-param-attrs.rs
@@ -16,7 +16,7 @@
 // using `rustc_attrs` feature. There is a separate compile-fail/ test
 // ensuring that the attribute feature-gating works in this context.)
 
-// must-compile-successfully
+// compile-pass
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/hello_world/main.rs
+++ b/src/test/ui/hello_world/main.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 // Test that compiling hello world succeeds with no output of any kind.
 

--- a/src/test/ui/inference-variable-behind-raw-pointer.rs
+++ b/src/test/ui/inference-variable-behind-raw-pointer.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 // tests that the following code compiles, but produces a future-compatibility warning
 

--- a/src/test/ui/issue-38875/issue_38875.rs
+++ b/src/test/ui/issue-38875/issue_38875.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:issue_38875_b.rs
-// must-compile-successfully
+// compile-pass
 
 extern crate issue_38875_b;
 

--- a/src/test/ui/issue-47094.rs
+++ b/src/test/ui/issue-47094.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #[repr(C,u8)]
 enum Foo {

--- a/src/test/ui/lint/command-line-lint-group-allow.rs
+++ b/src/test/ui/lint/command-line-lint-group-allow.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -A bad-style
-// must-compile-successfully
+// compile-pass
 
 fn main() {
     let _InappropriateCamelCasing = true;

--- a/src/test/ui/lint/command-line-lint-group-warn.rs
+++ b/src/test/ui/lint/command-line-lint-group-warn.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -W bad-style
-// must-compile-successfully
+// compile-pass
 
 fn main() {
     let _InappropriateCamelCasing = true;

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![warn(unused)] // UI tests pass `-A unused` (#43896)
 

--- a/src/test/ui/lint/issue-47775-nested-macro-unnecessary-parens-arg.rs
+++ b/src/test/ui/lint/issue-47775-nested-macro-unnecessary-parens-arg.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![warn(unused_parens)]
 

--- a/src/test/ui/lint/not_found.rs
+++ b/src/test/ui/lint/not_found.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 // this tests the `unknown_lint` lint, especially the suggestions
 

--- a/src/test/ui/lint/type-overflow.rs
+++ b/src/test/ui/lint/type-overflow.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 fn main() {
     let error = 255i8; //~WARNING literal out of range for i8

--- a/src/test/ui/lint/unreachable_pub-pub_crate.rs
+++ b/src/test/ui/lint/unreachable_pub-pub_crate.rs
@@ -14,7 +14,7 @@
 // suggestions to use `crate` given when it is on). When that feature becomes
 // stable, this test can be deleted.
 
-// must-compile-successfully
+// compile-pass
 
 #![feature(macro_vis_matcher)]
 

--- a/src/test/ui/lint/unreachable_pub.rs
+++ b/src/test/ui/lint/unreachable_pub.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![feature(crate_visibility_modifier)]
 #![feature(macro_vis_matcher)]

--- a/src/test/ui/lint/unused_parens_json_suggestion.rs
+++ b/src/test/ui/lint/unused_parens_json_suggestion.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags: --error-format pretty-json -Zunstable-options
-// must-compile-successfully
+// compile-pass
 
 // The output for humans should just highlight the whole span without showing
 // the suggested replacement, but we also want to test that suggested

--- a/src/test/ui/lint/unused_parens_json_suggestion.stderr
+++ b/src/test/ui/lint/unused_parens_json_suggestion.stderr
@@ -8,8 +8,8 @@
   "spans": [
     {
       "file_name": "$DIR/unused_parens_json_suggestion.rs",
-      "byte_start": 1056,
-      "byte_end": 1069,
+      "byte_start": 1043,
+      "byte_end": 1056,
       "line_start": 25,
       "line_end": 25,
       "column_start": 14,
@@ -35,8 +35,8 @@
       "spans": [
         {
           "file_name": "$DIR/unused_parens_json_suggestion.rs",
-          "byte_start": 902,
-          "byte_end": 915,
+          "byte_start": 889,
+          "byte_end": 902,
           "line_start": 20,
           "line_end": 20,
           "column_start": 9,
@@ -64,8 +64,8 @@
       "spans": [
         {
           "file_name": "$DIR/unused_parens_json_suggestion.rs",
-          "byte_start": 1056,
-          "byte_end": 1069,
+          "byte_start": 1043,
+          "byte_end": 1056,
           "line_start": 25,
           "line_end": 25,
           "column_start": 14,

--- a/src/test/ui/macros/trace-macro.rs
+++ b/src/test/ui/macros/trace-macro.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -Z trace-macros
-// must-compile-successfully
+// compile-pass
 
 fn main() {
     println!("Hello, World!");

--- a/src/test/ui/nll/closure-requirements/propagate-despite-same-free-region.rs
+++ b/src/test/ui/nll/closure-requirements/propagate-despite-same-free-region.rs
@@ -14,7 +14,7 @@
 // regions is erased.
 
 // compile-flags:-Znll -Zborrowck=mir -Zverbose
-// must-compile-successfully
+// compile-pass
 
 #![feature(rustc_attrs)]
 

--- a/src/test/ui/nll/closure-requirements/region-lbr1-does-outlive-lbr2-because-implied-bound.rs
+++ b/src/test/ui/nll/closure-requirements/region-lbr1-does-outlive-lbr2-because-implied-bound.rs
@@ -12,7 +12,7 @@
 // report an error because of the (implied) bound that `'b: 'a`.
 
 // compile-flags:-Znll -Zborrowck=mir -Zverbose
-// must-compile-successfully
+// compile-pass
 
 #![allow(warnings)]
 

--- a/src/test/ui/nll/constant.rs
+++ b/src/test/ui/nll/constant.rs
@@ -12,7 +12,7 @@
 // arbitrary types without ICEs.
 
 // compile-flags:-Znll -Zborrowck=mir -Zverbose
-// must-compile-successfully
+// compile-pass
 
 const HI: &str = "hi";
 

--- a/src/test/ui/nll/drop-may-dangle.rs
+++ b/src/test/ui/nll/drop-may-dangle.rs
@@ -13,7 +13,7 @@
 // including) the call to `use_x`. The `else` branch is not included.
 
 // compile-flags:-Znll -Zborrowck=mir
-// must-compile-successfully
+// compile-pass
 
 #![allow(warnings)]
 #![feature(dropck_eyepatch)]

--- a/src/test/ui/nll/generator-distinct-lifetime.rs
+++ b/src/test/ui/nll/generator-distinct-lifetime.rs
@@ -16,7 +16,7 @@
 // over a yield -- because the data that is borrowed (`*x`) is not
 // stored on the stack.
 
-// must-compile-successfully
+// compile-pass
 
 fn foo(x: &mut u32) {
     move || {

--- a/src/test/ui/nll/issue-16223.rs
+++ b/src/test/ui/nll/issue-16223.rs
@@ -23,7 +23,7 @@
 //    |
 //    = note: move occurs because the value has type `A`, which does not implement the `Copy` trait
 
-// must-compile-successfully
+// compile-pass
 
 #![feature(nll)]
 #![feature(box_patterns)]

--- a/src/test/ui/nll/issue-43058.rs
+++ b/src/test/ui/nll/issue-43058.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![feature(nll)]
 

--- a/src/test/ui/nll/issue-47022.rs
+++ b/src/test/ui/nll/issue-47022.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![allow(warnings)]
 #![feature(nll)]

--- a/src/test/ui/nll/maybe-initialized-drop-uninitialized.rs
+++ b/src/test/ui/nll/maybe-initialized-drop-uninitialized.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 //compile-flags: -Z emit-end-regions -Zborrowck=mir -Z nll
-// must-compile-successfully
+// compile-pass
 
 #![allow(warnings)]
 

--- a/src/test/ui/nll/projection-return.rs
+++ b/src/test/ui/nll/projection-return.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Znll -Zborrowck=mir
-// must-compile-successfully
+// compile-pass
 
 #![feature(rustc_attrs)]
 

--- a/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.rs
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.rs
@@ -13,7 +13,7 @@
 // we don't even propagate constraints from the closures to the callers.
 
 // compile-flags:-Znll -Zborrowck=mir -Zverbose
-// must-compile-successfully
+// compile-pass
 
 #![allow(warnings)]
 #![feature(dyn_trait)]

--- a/src/test/ui/nll/ty-outlives/ty-param-implied-bounds.rs
+++ b/src/test/ui/nll/ty-outlives/ty-param-implied-bounds.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Znll -Zborrowck=mir -Zverbose
-// must-compile-successfully
+// compile-pass
 
 // Test that we assume that universal types like `T` outlive the
 // function body.

--- a/src/test/ui/print-fuel/print-fuel.rs
+++ b/src/test/ui/print-fuel/print-fuel.rs
@@ -12,7 +12,7 @@
 #![allow(dead_code)]
 
 // compile-flags: -Z print-fuel=foo
-// must-compile-successfully
+// compile-pass
 
 struct S1(u8, u16, u8);
 struct S2(u8, u16, u8);

--- a/src/test/ui/print_type_sizes/anonymous.rs
+++ b/src/test/ui/print_type_sizes/anonymous.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -Z print-type-sizes
-// must-compile-successfully
+// compile-pass
 
 // All of the types that occur in this function are uninteresting, in
 // that one cannot control the sizes of these types with the same sort

--- a/src/test/ui/print_type_sizes/generics.rs
+++ b/src/test/ui/print_type_sizes/generics.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -Z print-type-sizes
-// must-compile-successfully
+// compile-pass
 
 // This file illustrates how generics are handled: types have to be
 // monomorphized, in the MIR of the original function in which they

--- a/src/test/ui/print_type_sizes/multiple_types.rs
+++ b/src/test/ui/print_type_sizes/multiple_types.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -Z print-type-sizes
-// must-compile-successfully
+// compile-pass
 
 // This file illustrates that when multiple structural types occur in
 // a function, every one of them is included in the output.

--- a/src/test/ui/print_type_sizes/niche-filling.rs
+++ b/src/test/ui/print_type_sizes/niche-filling.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -Z print-type-sizes
-// must-compile-successfully
+// compile-pass
 
 // This file illustrates how niche-filling enums are handled,
 // modelled after cases like `Option<&u32>`, `Option<bool>` and such.

--- a/src/test/ui/print_type_sizes/no_duplicates.rs
+++ b/src/test/ui/print_type_sizes/no_duplicates.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -Z print-type-sizes
-// must-compile-successfully
+// compile-pass
 
 // This file illustrates that when the same type occurs repeatedly
 // (even if multiple functions), it is only printed once in the

--- a/src/test/ui/print_type_sizes/packed.rs
+++ b/src/test/ui/print_type_sizes/packed.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -Z print-type-sizes
-// must-compile-successfully
+// compile-pass
 
 // This file illustrates how packing is handled; it should cause
 // the elimination of padding that would normally be introduced

--- a/src/test/ui/print_type_sizes/padding.rs
+++ b/src/test/ui/print_type_sizes/padding.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -Z print-type-sizes
-// must-compile-successfully
+// compile-pass
 
 // This file illustrates how padding is handled: alignment
 // requirements can lead to the introduction of padding, either before

--- a/src/test/ui/print_type_sizes/repr-align.rs
+++ b/src/test/ui/print_type_sizes/repr-align.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -Z print-type-sizes
-// must-compile-successfully
+// compile-pass
 
 // This file illustrates how padding is handled: alignment
 // requirements can lead to the introduction of padding, either before

--- a/src/test/ui/print_type_sizes/uninhabited.rs
+++ b/src/test/ui/print_type_sizes/uninhabited.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -Z print-type-sizes
-// must-compile-successfully
+// compile-pass
 
 #![feature(start)]
 

--- a/src/test/ui/print_type_sizes/variants.rs
+++ b/src/test/ui/print_type_sizes/variants.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -Z print-type-sizes
-// must-compile-successfully
+// compile-pass
 
 // This file illustrates two things:
 //

--- a/src/test/ui/reachable/expr_andand.rs
+++ b/src/test/ui/reachable/expr_andand.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![allow(unused_variables)]
 #![allow(dead_code)]

--- a/src/test/ui/reachable/expr_oror.rs
+++ b/src/test/ui/reachable/expr_oror.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![allow(unused_variables)]
 #![allow(dead_code)]

--- a/src/test/ui/rfc-2093-infer-outlives/enum-pass.rs
+++ b/src/test/ui/rfc-2093-infer-outlives/enum-pass.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![feature(infer_outlives_requirements)]
 

--- a/src/test/ui/rfc-2093-infer-outlives/explicit-impl-lifetime-pass.rs
+++ b/src/test/ui/rfc-2093-infer-outlives/explicit-impl-lifetime-pass.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-test
-// must-compile-successfully
+// compile-pass
 
 #![feature(infer_outlives_requirements)]
 // Outlives requirementes are inferred (RFC 2093)

--- a/src/test/ui/rfc-2093-infer-outlives/explicit-impl-pass.rs
+++ b/src/test/ui/rfc-2093-infer-outlives/explicit-impl-pass.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-test
-// must-compile-successfully
+// compile-pass
 
 #![feature(infer_outlives_requirements)]
 // Outlives requirementes are inferred (RFC 2093)

--- a/src/test/ui/rfc-2093-infer-outlives/explicit-where-pass.rs
+++ b/src/test/ui/rfc-2093-infer-outlives/explicit-where-pass.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![feature(infer_outlives_requirements)]
 // Outlives requirementes are inferred (RFC 2093)

--- a/src/test/ui/rfc-2093-infer-outlives/multiple-regions-pass.rs
+++ b/src/test/ui/rfc-2093-infer-outlives/multiple-regions-pass.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![feature(infer_outlives_requirements)]
 // Outlives requirementes are inferred (RFC 2093)

--- a/src/test/ui/rfc-2093-infer-outlives/nested-structs-pass.rs
+++ b/src/test/ui/rfc-2093-infer-outlives/nested-structs-pass.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![feature(infer_outlives_requirements)]
 // Outlives requirementes are inferred (RFC 2093)

--- a/src/test/ui/rfc-2093-infer-outlives/projections-pass.rs
+++ b/src/test/ui/rfc-2093-infer-outlives/projections-pass.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![feature(infer_outlives_requirements)]
 // Outlives requirementes are inferred (RFC 2093)

--- a/src/test/ui/rfc-2093-infer-outlives/reference-pass.rs
+++ b/src/test/ui/rfc-2093-infer-outlives/reference-pass.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![feature(infer_outlives_requirements)]
 // Outlives requirementes are inferred (RFC 2093)

--- a/src/test/ui/rfc-2093-infer-outlives/union-pass.rs
+++ b/src/test/ui/rfc-2093-infer-outlives/union-pass.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![feature(infer_outlives_requirements)]
 #![feature(untagged_unions)]

--- a/src/test/ui/rfc-2166-underscore-imports/basic.rs
+++ b/src/test/ui/rfc-2166-underscore-imports/basic.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![feature(underscore_imports)]
 #![warn(unused_imports, unused_extern_crates)]

--- a/src/test/ui/rfc1598-generic-associated-types/parse/in-trait-impl.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/parse/in-trait-impl.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -Z parse-only
-// must-compile-successfully
+// compile-pass
 
 #![feature(generic_associated_types)]
 

--- a/src/test/ui/rfc1598-generic-associated-types/parse/in-trait.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/parse/in-trait.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -Z parse-only
-// must-compile-successfully
+// compile-pass
 
 #![feature(generic_associated_types)]
 

--- a/src/test/ui/rfc_1940-must_use_on_functions/fn_must_use.rs
+++ b/src/test/ui/rfc_1940-must_use_on_functions/fn_must_use.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![feature(fn_must_use)]
 #![warn(unused_must_use)]

--- a/src/test/ui/span/macro-span-replacement.rs
+++ b/src/test/ui/span/macro-span-replacement.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![warn(unused)]
 

--- a/src/test/ui/span/multispan-import-lint.rs
+++ b/src/test/ui/span/multispan-import-lint.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 #![warn(unused)]
 

--- a/src/test/ui/type-alias-bounds.rs
+++ b/src/test/ui/type-alias-bounds.rs
@@ -10,7 +10,7 @@
 
 // Test ignored_generic_bounds lint warning about bounds in type aliases
 
-// must-compile-successfully
+// compile-pass
 #![allow(dead_code)]
 
 use std::rc::Rc;

--- a/src/test/ui/union/union-const-eval.rs
+++ b/src/test/ui/union/union-const-eval.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// must-compile-successfully
+// compile-pass
 
 union U {
     a: usize,

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -223,7 +223,7 @@ pub struct TestProps {
     // arguments. (In particular, it propagates to the aux-builds.)
     pub incremental_dir: Option<PathBuf>,
     // Specifies that a test must actually compile without errors.
-    pub must_compile_successfully: bool,
+    pub compile_pass: bool,
     // rustdoc will test the output of the `--test` option
     pub check_test_line_numbers_match: bool,
     // The test must be compiled and run successfully. Only used in UI tests for now.
@@ -257,7 +257,7 @@ impl TestProps {
             pretty_compare_only: false,
             forbid_output: vec![],
             incremental_dir: None,
-            must_compile_successfully: false,
+            compile_pass: false,
             check_test_line_numbers_match: false,
             run_pass: false,
             disable_ui_testing_normalization: false,
@@ -375,10 +375,10 @@ impl TestProps {
                 self.run_pass = config.parse_run_pass(ln);
             }
 
-            if !self.must_compile_successfully {
+            if !self.compile_pass {
                 // run-pass implies must_compile_sucessfully
-                self.must_compile_successfully =
-                    config.parse_must_compile_successfully(ln) || self.run_pass;
+                self.compile_pass =
+                    config.parse_compile_pass(ln) || self.run_pass;
             }
 
             if !self.disable_ui_testing_normalization {
@@ -508,8 +508,8 @@ impl Config {
         }
     }
 
-    fn parse_must_compile_successfully(&self, line: &str) -> bool {
-        self.parse_name_directive(line, "must-compile-successfully")
+    fn parse_compile_pass(&self, line: &str) -> bool {
+        self.parse_name_directive(line, "compile-pass")
     }
 
     fn parse_disable_ui_testing_normalization(&self, line: &str) -> bool {

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -232,7 +232,7 @@ impl<'test> TestCx<'test> {
     }
 
     fn check_if_test_should_compile(&self, proc_res: &ProcRes) {
-        if self.props.must_compile_successfully {
+        if self.props.compile_pass {
             if !proc_res.status.success() {
                 self.fatal_proc_rec("test compilation failed although it shouldn't!", proc_res);
             }
@@ -1100,7 +1100,7 @@ impl<'test> TestCx<'test> {
 
     fn check_error_patterns(&self, output_to_check: &str, proc_res: &ProcRes) {
         if self.props.error_patterns.is_empty() {
-            if self.props.must_compile_successfully {
+            if self.props.compile_pass {
                 return;
             } else {
                 self.fatal(&format!(


### PR DESCRIPTION
Fixes #49568.

r? @Mark-Simulacrum 