### PR TITLE
[beta] Prepare the 1.26.0 beta release

### DIFF
--- a/src/ci/docker/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/x86_64-gnu-tools/checktools.sh
@@ -31,7 +31,6 @@ python2.7 "$X_PY" test --no-fail-fast \
     src/doc/rust-by-example \
     src/tools/rls \
     src/tools/rustfmt \
-    src/tools/miri \
     src/tools/clippy
 set -e
 

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -44,7 +44,7 @@ fi
 #
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
-export RUST_RELEASE_CHANNEL=nightly
+export RUST_RELEASE_CHANNEL=beta
 if [ "$DEPLOY$DEPLOY_ALT" != "" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=$RUST_RELEASE_CHANNEL"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,9 +12,9 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2018-03-18
-rustc: beta
-cargo: beta
+date: 2018-03-29
+rustc: 1.25.0
+cargo: 0.26.0
 
 # When making a stable release the process currently looks like:
 #


### PR DESCRIPTION
* Bump the bootstrap compiler to the stable release
* Update the channel to beta