### PR TITLE
proc_macro: Reorganize public API

### DIFF
--- a/src/test/run-pass-fulldeps/auxiliary/cond_plugin.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/cond_plugin.rs
@@ -15,15 +15,15 @@
 
 extern crate proc_macro;
 
-use proc_macro::{TokenStream, TokenNode, quote};
+use proc_macro::*;
 
 #[proc_macro]
 pub fn cond(input: TokenStream) -> TokenStream {
     let mut conds = Vec::new();
     let mut input = input.into_iter().peekable();
     while let Some(tree) = input.next() {
-        let cond = match tree.kind {
-            TokenNode::Group(_, cond) => cond,
+        let cond = match tree {
+            TokenTree::Group(tt) => tt.stream(),
             _ => panic!("Invalid input"),
         };
         let mut cond_trees = cond.clone().into_iter();
@@ -32,8 +32,8 @@ pub fn cond(input: TokenStream) -> TokenStream {
         if rhs.is_empty() {
             panic!("Invalid macro usage in cond: {}", cond);
         }
-        let is_else = match test.kind {
-            TokenNode::Term(word) => word.as_str() == "else",
+        let is_else = match test {
+            TokenTree::Term(word) => word.as_str() == "else",
             _ => false,
         };
         conds.push(if is_else || input.peek().is_none() {
@@ -43,5 +43,5 @@ pub fn cond(input: TokenStream) -> TokenStream {
         });
     }
 
-    conds.into_iter().collect()
+    conds.into_iter().flat_map(|x| x.into_iter()).collect()
 }

--- a/src/test/run-pass-fulldeps/auxiliary/proc_macro_def.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/proc_macro_def.rs
@@ -15,7 +15,7 @@
 
 extern crate proc_macro;
 
-use proc_macro::{TokenStream, quote};
+use proc_macro::*;
 
 #[proc_macro_attribute]
 pub fn attr_tru(_attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/negative-token.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/negative-token.rs
@@ -19,16 +19,10 @@ use proc_macro::*;
 
 #[proc_macro]
 pub fn neg_one(_input: TokenStream) -> TokenStream {
-    TokenTree {
-        span: Span::call_site(),
-        kind: TokenNode::Literal(Literal::i32(-1)),
-    }.into()
+    TokenTree::Literal(Literal::i32_suffixed(-1)).into()
 }
 
 #[proc_macro]
 pub fn neg_one_float(_input: TokenStream) -> TokenStream {
-    TokenTree {
-        span: Span::call_site(),
-        kind: TokenNode::Literal(Literal::f32(-1.0)),
-    }.into()
+    TokenTree::Literal(Literal::f32_suffixed(-1.0)).into()
 }

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/span-api-tests.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/span-api-tests.rs
@@ -27,7 +27,7 @@ pub fn reemit(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn assert_fake_source_file(input: TokenStream) -> TokenStream {
     for tk in input {
-        let source_file = tk.span.source_file();
+        let source_file = tk.span().source_file();
         assert!(!source_file.is_real(), "Source file is real: {:?}", source_file);
     }
 
@@ -37,7 +37,7 @@ pub fn assert_fake_source_file(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn assert_source_file(input: TokenStream) -> TokenStream {
     for tk in input {
-        let source_file = tk.span.source_file();
+        let source_file = tk.span().source_file();
         assert!(source_file.is_real(), "Source file is not real: {:?}", source_file);
     }
 

--- a/src/test/ui-fulldeps/proc-macro/auxiliary/parent-source-spans.rs
+++ b/src/test/ui-fulldeps/proc-macro/auxiliary/parent-source-spans.rs
@@ -14,12 +14,12 @@
 
 extern crate proc_macro;
 
-use proc_macro::{TokenStream, TokenTree, TokenNode, Span};
+use proc_macro::{TokenStream, TokenTree, Span};
 
 fn lit_span(tt: TokenTree) -> (Span, String) {
-    use TokenNode::*;
-    match tt.kind {
-        Literal(..) | Group(..) => (tt.span, tt.to_string().trim().into()),
+    match tt {
+        TokenTree::Literal(..) |
+        TokenTree::Group(..) => (tt.span(), tt.to_string().trim().into()),
         _ => panic!("expected a literal in token tree, got: {:?}", tt)
     }
 }


### PR DESCRIPTION
This commit is a reorganization of the `proc_macro` crate's public user-facing
API. This is the result of a number of discussions at the recent Rust All-Hands
where we're hoping to get the `proc_macro` crate into ship shape for
stabilization of a subset of its functionality in the Rust 2018 release.

The reorganization here is motivated by experiences from the `proc-macro2`,
`quote`, and `syn` crates on crates.io (and other crates which depend on them).
The main focus is future flexibility along with making a few more operations
consistent and/or fixing bugs. A summary of the changes made from today's
`proc_macro` API is:

* The `TokenNode` enum has been removed and the public fields of `TokenTree`
  have also been removed. Instead the `TokenTree` type is now a public enum
  (what `TokenNode` was) and each variant is an opaque struct which internally
  contains `Span` information. This makes the various tokens a bit more
  consistent, require fewer wrappers, and otherwise provides good
  future-compatibility as opaque structs are easy to modify later on.

* `Literal` integer constructors have been expanded to be unambiguous as to what
  they're doing and also allow for more future flexibility. Previously
  constructors like `Literal::float` and `Literal::integer` were used to create
  unsuffixed literals and the concrete methods like `Literal::i32` would create
  a suffixed token. This wasn't immediately clear to all users (the
  suffixed/unsuffixed aspect) and having *one* constructor for unsuffixed
  literals required us to pick a largest type which may not always be true. To
  fix these issues all constructors are now of the form
  `Literal::i32_unsuffixed` or `Literal::i32_suffixed` (for all integral types).
  This should allow future compatibility as well as being immediately clear
  what's suffixed and what isn't.

* Each variant of `TokenTree` internally contains a `Span` which can also be
  configured via `set_span`. For example `Literal` and `Term` now both
  internally contain a `Span` rather than having it stored in an auxiliary
  location.

* Constructors of all tokens are called `new` now (aka `Term::intern` is gone)
  and most do not take spans. Manufactured tokens typically don't have a fresh
  span to go with them and the span is purely used for error-reporting
  **except** the span for `Term`, which currently affects hygiene. The default
  spans for all these constructed tokens is `Span::call_site()` for now.

  The `Term` type's constructor explicitly requires passing in a `Span` to
  provide future-proofing against possible hygiene changes. It's intended that a
  first pass of stabilization will likely only stabilize `Span::call_site()`
  which is an explicit opt-in for "I would like no hygiene here please". The
  intention here is to make this explicit in procedural macros to be
  forwards-compatible with a hygiene-specifying solution.

* Some of the conversions for `TokenStream` have been simplified a little.

* The `TokenTreeIter` iterator was renamed to `token_stream::IntoIter`.

Overall the hope is that this is the "final pass" at the API of `TokenStream`
and most of `TokenTree` before stabilization. Explicitly left out here is any
changes to `Span`'s API which will likely need to be re-evaluated before
stabilization.

All changes in this PR have already been reflected to the [`proc-macro2`],
`quote`, and `syn` crates. New versions of all these crates have also been
published to crates.io.

Once this lands in nightly I plan on making an internals post again summarizing
the changes made here and also calling on all macro authors to give the APIs a
spin and see how they work. Hopefully pending no major issues we can then have
an FCP to stabilize later this cycle!

[`proc-macro2`]: https://docs.rs/proc-macro2/0.3.1/proc_macro2/

Closes #49596