### PR TITLE
Fix typo

### DIFF
--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -180,7 +180,7 @@ impl<R: Read> BufReader<R> {
     ///
     /// # Examples
     ///
-    /// ```no_ru
+    /// ```no_run
     /// # #![feature(bufreader_buffer)]
     /// use std::io::{BufReader, BufRead};
     /// use std::fs::File;


### PR DESCRIPTION
In `libstd/io/buffered.rs` one example was marked as `no_ru` instead of `no_run`. I assume this is a typo.