### PR TITLE
Use NonNull in the allocator API

### DIFF
--- a/src/doc/unstable-book/src/language-features/global-allocator.md
+++ b/src/doc/unstable-book/src/language-features/global-allocator.md
@@ -30,15 +30,16 @@ looks like:
 #![feature(global_allocator, allocator_api, heap_api)]
 
 use std::heap::{Alloc, System, Layout, AllocErr};
+use std::ptr::NonNull;
 
 struct MyAllocator;
 
 unsafe impl<'a> Alloc for &'a MyAllocator {
-    unsafe fn alloc(&mut self, layout: Layout) -> Result<*mut u8, AllocErr> {
+    unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
         System.alloc(layout)
     }
 
-    unsafe fn dealloc(&mut self, ptr: *mut u8, layout: Layout) {
+    unsafe fn dealloc(&mut self, ptr: NonNull<u8>, layout: Layout) {
         System.dealloc(ptr, layout)
     }
 }

--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -513,15 +513,13 @@ impl<T: ?Sized> Arc<T> {
     // Non-inlined part of `drop`.
     #[inline(never)]
     unsafe fn drop_slow(&mut self) {
-        let ptr = self.ptr.as_ptr();
-
         // Destroy the data at this time, even though we may not free the box
         // allocation itself (there may still be weak pointers lying around).
         ptr::drop_in_place(&mut self.ptr.as_mut().data);
 
         if self.inner().weak.fetch_sub(1, Release) == 1 {
             atomic::fence(Acquire);
-            Heap.dealloc(ptr as *mut u8, Layout::for_value(&*ptr))
+            Heap.dealloc(self.ptr.cast(), Layout::for_value(self.ptr.as_ref()))
         }
     }
 
@@ -559,7 +557,7 @@ impl<T: ?Sized> Arc<T> {
             .unwrap_or_else(|e| Heap.oom(e));
 
         // Initialize the real ArcInner
-        let inner = set_data_ptr(ptr as *mut T, mem) as *mut ArcInner<T>;
+        let inner = set_data_ptr(ptr as *mut T, mem.as_ptr()) as *mut ArcInner<T>;
 
         ptr::write(&mut (*inner).strong, atomic::AtomicUsize::new(1));
         ptr::write(&mut (*inner).weak, atomic::AtomicUsize::new(1));
@@ -626,7 +624,7 @@ impl<T: Clone> ArcFromSlice<T> for Arc<[T]> {
         // In the event of a panic, elements that have been written
         // into the new ArcInner will be dropped, then the memory freed.
         struct Guard<T> {
-            mem: *mut u8,
+            mem: NonNull<u8>,
             elems: *mut T,
             layout: Layout,
             n_elems: usize,
@@ -656,7 +654,7 @@ impl<T: Clone> ArcFromSlice<T> for Arc<[T]> {
             let elems = &mut (*ptr).data as *mut [T] as *mut T;
 
             let mut guard = Guard{
-                mem: mem,
+                mem: NonNull::new_unchecked(mem),
                 elems: elems,
                 layout: layout,
                 n_elems: 0,
@@ -1148,8 +1146,6 @@ impl<T: ?Sized> Drop for Weak<T> {
     /// assert!(other_weak_foo.upgrade().is_none());
     /// ```
     fn drop(&mut self) {
-        let ptr = self.ptr.as_ptr();
-
         // If we find out that we were the last weak pointer, then its time to
         // deallocate the data entirely. See the discussion in Arc::drop() about
         // the memory orderings
@@ -1161,7 +1157,7 @@ impl<T: ?Sized> Drop for Weak<T> {
         if self.inner().weak.fetch_sub(1, Release) == 1 {
             atomic::fence(Acquire);
             unsafe {
-                Heap.dealloc(ptr as *mut u8, Layout::for_value(&*ptr))
+                Heap.dealloc(self.ptr.cast(), Layout::for_value(self.ptr.as_ref()))
             }
         }
     }

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -102,6 +102,7 @@
 #![feature(iter_rfold)]
 #![feature(lang_items)]
 #![feature(needs_allocator)]
+#![feature(nonnull_cast)]
 #![feature(nonzero)]
 #![feature(offset_to)]
 #![feature(optin_builtin_traits)]

--- a/src/liballoc/tests/heap.rs
+++ b/src/liballoc/tests/heap.rs
@@ -34,7 +34,8 @@ fn check_overalign_requests<T: Alloc>(mut allocator: T) {
             allocator.alloc(Layout::from_size_align(size, align).unwrap()).unwrap()
         }).collect();
         for &ptr in &pointers {
-            assert_eq!((ptr as usize) % align, 0, "Got a pointer less aligned than requested")
+            assert_eq!((ptr.as_ptr() as usize) % align, 0,
+                       "Got a pointer less aligned than requested")
         }
 
         // Clean up

--- a/src/libcore/heap.rs
+++ b/src/libcore/heap.rs
@@ -24,7 +24,7 @@ use ptr::{self, NonNull};
 /// Represents the combination of a starting address and
 /// a total capacity of the returned block.
 #[derive(Debug)]
-pub struct Excess(pub *mut u8, pub usize);
+pub struct Excess(pub NonNull<u8>, pub usize);
 
 fn size_align<T>() -> (usize, usize) {
     (mem::size_of::<T>(), mem::align_of::<T>())
@@ -522,7 +522,7 @@ pub unsafe trait Alloc {
     /// Clients wishing to abort computation in response to an
     /// allocation error are encouraged to call the allocator's `oom`
     /// method, rather than directly invoking `panic!` or similar.
-    unsafe fn alloc(&mut self, layout: Layout) -> Result<*mut u8, AllocErr>;
+    unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr>;
 
     /// Deallocate the memory referenced by `ptr`.
     ///
@@ -539,7 +539,7 @@ pub unsafe trait Alloc {
     /// * In addition to fitting the block of memory `layout`, the
     ///   alignment of the `layout` must match the alignment used
     ///   to allocate that block of memory.
-    unsafe fn dealloc(&mut self, ptr: *mut u8, layout: Layout);
+    unsafe fn dealloc(&mut self, ptr: NonNull<u8>, layout: Layout);
 
     /// Allocator-specific method for signaling an out-of-memory
     /// condition.
@@ -672,9 +672,9 @@ pub unsafe trait Alloc {
     /// reallocation error are encouraged to call the allocator's `oom`
     /// method, rather than directly invoking `panic!` or similar.
     unsafe fn realloc(&mut self,
-                      ptr: *mut u8,
+                      ptr: NonNull<u8>,
                       layout: Layout,
-                      new_layout: Layout) -> Result<*mut u8, AllocErr> {
+                      new_layout: Layout) -> Result<NonNull<u8>, AllocErr> {
         let new_size = new_layout.size();
         let old_size = layout.size();
         let aligns_match = layout.align == new_layout.align;
@@ -692,7 +692,9 @@ pub unsafe trait Alloc {
         // otherwise, fall back on alloc + copy + dealloc.
         let result = self.alloc(new_layout);
         if let Ok(new_ptr) = result {
-            ptr::copy_nonoverlapping(ptr as *const u8, new_ptr, cmp::min(old_size, new_size));
+            ptr::copy_nonoverlapping(ptr.as_ptr() as *const u8,
+                                     new_ptr.as_ptr(),
+                                     cmp::min(old_size, new_size));
             self.dealloc(ptr, layout);
         }
         result
@@ -714,11 +716,11 @@ pub unsafe trait Alloc {
     /// Clients wishing to abort computation in response to an
     /// allocation error are encouraged to call the allocator's `oom`
     /// method, rather than directly invoking `panic!` or similar.
-    unsafe fn alloc_zeroed(&mut self, layout: Layout) -> Result<*mut u8, AllocErr> {
+    unsafe fn alloc_zeroed(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
         let size = layout.size();
         let p = self.alloc(layout);
         if let Ok(p) = p {
-            ptr::write_bytes(p, 0, size);
+            ptr::write_bytes(p.as_ptr(), 0, size);
         }
         p
     }
@@ -763,7 +765,7 @@ pub unsafe trait Alloc {
     /// reallocation error are encouraged to call the allocator's `oom`
     /// method, rather than directly invoking `panic!` or similar.
     unsafe fn realloc_excess(&mut self,
-                             ptr: *mut u8,
+                             ptr: NonNull<u8>,
                              layout: Layout,
                              new_layout: Layout) -> Result<Excess, AllocErr> {
         let usable_size = self.usable_size(&new_layout);
@@ -808,7 +810,7 @@ pub unsafe trait Alloc {
     /// `grow_in_place` failures without aborting, or to fall back on
     /// another reallocation method before resorting to an abort.
     unsafe fn grow_in_place(&mut self,
-                            ptr: *mut u8,
+                            ptr: NonNull<u8>,
                             layout: Layout,
                             new_layout: Layout) -> Result<(), CannotReallocInPlace> {
         let _ = ptr; // this default implementation doesn't care about the actual address.
@@ -866,7 +868,7 @@ pub unsafe trait Alloc {
     /// `shrink_in_place` failures without aborting, or to fall back
     /// on another reallocation method before resorting to an abort.
     unsafe fn shrink_in_place(&mut self,
-                              ptr: *mut u8,
+                              ptr: NonNull<u8>,
                               layout: Layout,
                               new_layout: Layout) -> Result<(), CannotReallocInPlace> {
         let _ = ptr; // this default implementation doesn't care about the actual address.
@@ -918,7 +920,7 @@ pub unsafe trait Alloc {
     {
         let k = Layout::new::<T>();
         if k.size() > 0 {
-            unsafe { self.alloc(k).map(|p| NonNull::new_unchecked(p as *mut T)) }
+            unsafe { self.alloc(k).map(|p| p.cast()) }
         } else {
             Err(AllocErr::invalid_input("zero-sized type invalid for alloc_one"))
         }
@@ -944,10 +946,9 @@ pub unsafe trait Alloc {
     unsafe fn dealloc_one<T>(&mut self, ptr: NonNull<T>)
         where Self: Sized
     {
-        let raw_ptr = ptr.as_ptr() as *mut u8;
         let k = Layout::new::<T>();
         if k.size() > 0 {
-            self.dealloc(raw_ptr, k);
+            self.dealloc(ptr.cast(), k);
         }
     }
 
@@ -987,10 +988,7 @@ pub unsafe trait Alloc {
         match Layout::array::<T>(n) {
             Some(ref layout) if layout.size() > 0 => {
                 unsafe {
-                    self.alloc(layout.clone())
-                        .map(|p| {
-                            NonNull::new_unchecked(p as *mut T)
-                        })
+                    self.alloc(layout.clone()).map(|p| p.cast())
                 }
             }
             _ => Err(AllocErr::invalid_input("invalid layout for alloc_array")),
@@ -1035,10 +1033,9 @@ pub unsafe trait Alloc {
                                n_new: usize) -> Result<NonNull<T>, AllocErr>
         where Self: Sized
     {
-        match (Layout::array::<T>(n_old), Layout::array::<T>(n_new), ptr.as_ptr()) {
-            (Some(ref k_old), Some(ref k_new), ptr) if k_old.size() > 0 && k_new.size() > 0 => {
-                self.realloc(ptr as *mut u8, k_old.clone(), k_new.clone())
-                    .map(|p| NonNull::new_unchecked(p as *mut T))
+        match (Layout::array::<T>(n_old), Layout::array::<T>(n_new)) {
+            (Some(ref k_old), Some(ref k_new)) if k_old.size() > 0 && k_new.size() > 0 => {
+                self.realloc(ptr.cast(), k_old.clone(), k_new.clone()).map(|p| p.cast())
             }
             _ => {
                 Err(AllocErr::invalid_input("invalid layout for realloc_array"))
@@ -1069,10 +1066,9 @@ pub unsafe trait Alloc {
     unsafe fn dealloc_array<T>(&mut self, ptr: NonNull<T>, n: usize) -> Result<(), AllocErr>
         where Self: Sized
     {
-        let raw_ptr = ptr.as_ptr() as *mut u8;
         match Layout::array::<T>(n) {
             Some(ref k) if k.size() > 0 => {
-                Ok(self.dealloc(raw_ptr, k.clone()))
+                Ok(self.dealloc(ptr.cast(), k.clone()))
             }
             _ => {
                 Err(AllocErr::invalid_input("invalid layout for dealloc_array"))

--- a/src/libstd/collections/hash/table.rs
+++ b/src/libstd/collections/hash/table.rs
@@ -760,12 +760,10 @@ impl<K, V> RawTable<K, V> {
         let buffer = Heap.alloc(Layout::from_size_align(size, alignment)
             .ok_or(CollectionAllocErr::CapacityOverflow)?)?;
 
-        let hashes = buffer as *mut HashUint;
-
         Ok(RawTable {
             capacity_mask: capacity.wrapping_sub(1),
             size: 0,
-            hashes: TaggedHashUintPtr::new(hashes),
+            hashes: TaggedHashUintPtr::new(buffer.cast().as_ptr()),
             marker: marker::PhantomData,
         })
     }
@@ -1188,7 +1186,7 @@ unsafe impl<#[may_dangle] K, #[may_dangle] V> Drop for RawTable<K, V> {
         debug_assert!(!oflo, "should be impossible");
 
         unsafe {
-            Heap.dealloc(self.hashes.ptr() as *mut u8,
+            Heap.dealloc(NonNull::new_unchecked(self.hashes.ptr()).cast(),
                          Layout::from_size_align(size, align).unwrap());
             // Remember how everything was allocated out of one buffer
             // during initialization? We only need one call to free here.

--- a/src/libstd/heap.rs
+++ b/src/libstd/heap.rs
@@ -21,7 +21,7 @@ pub use core::heap::*;
 #[allow(unused_attributes)]
 pub mod __default_lib_allocator {
     use super::{System, Layout, Alloc, AllocErr};
-    use ptr;
+    use ptr::{self, NonNull};
 
     // for symbol names src/librustc/middle/allocator.rs
     // for signatures src/librustc_allocator/lib.rs
@@ -36,7 +36,7 @@ pub mod __default_lib_allocator {
                                      err: *mut u8) -> *mut u8 {
         let layout = Layout::from_size_align_unchecked(size, align);
         match System.alloc(layout) {
-            Ok(p) => p,
+            Ok(p) => p.as_ptr(),
             Err(e) => {
                 ptr::write(err as *mut AllocErr, e);
                 0 as *mut u8
@@ -55,7 +55,8 @@ pub mod __default_lib_allocator {
     pub unsafe extern fn __rdl_dealloc(ptr: *mut u8,
                                        size: usize,
                                        align: usize) {
-        System.dealloc(ptr, Layout::from_size_align_unchecked(size, align))
+        System.dealloc(NonNull::new_unchecked(ptr),
+                       Layout::from_size_align_unchecked(size, align))
     }
 
     #[no_mangle]
@@ -78,8 +79,8 @@ pub mod __default_lib_allocator {
                                        err: *mut u8) -> *mut u8 {
         let old_layout = Layout::from_size_align_unchecked(old_size, old_align);
         let new_layout = Layout::from_size_align_unchecked(new_size, new_align);
-        match System.realloc(ptr, old_layout, new_layout) {
-            Ok(p) => p,
+        match System.realloc(NonNull::new_unchecked(ptr), old_layout, new_layout) {
+            Ok(p) => p.as_ptr(),
             Err(e) => {
                 ptr::write(err as *mut AllocErr, e);
                 0 as *mut u8
@@ -94,7 +95,7 @@ pub mod __default_lib_allocator {
                                             err: *mut u8) -> *mut u8 {
         let layout = Layout::from_size_align_unchecked(size, align);
         match System.alloc_zeroed(layout) {
-            Ok(p) => p,
+            Ok(p) => p.as_ptr(),
             Err(e) => {
                 ptr::write(err as *mut AllocErr, e);
                 0 as *mut u8
@@ -112,7 +113,7 @@ pub mod __default_lib_allocator {
         match System.alloc_excess(layout) {
             Ok(p) => {
                 *excess = p.1;
-                p.0
+                p.0.as_ptr()
             }
             Err(e) => {
                 ptr::write(err as *mut AllocErr, e);
@@ -132,10 +133,10 @@ pub mod __default_lib_allocator {
                                               err: *mut u8) -> *mut u8 {
         let old_layout = Layout::from_size_align_unchecked(old_size, old_align);
         let new_layout = Layout::from_size_align_unchecked(new_size, new_align);
-        match System.realloc_excess(ptr, old_layout, new_layout) {
+        match System.realloc_excess(NonNull::new_unchecked(ptr), old_layout, new_layout) {
             Ok(p) => {
                 *excess = p.1;
-                p.0
+                p.0.as_ptr()
             }
             Err(e) => {
                 ptr::write(err as *mut AllocErr, e);
@@ -153,7 +154,7 @@ pub mod __default_lib_allocator {
                                              new_align: usize) -> u8 {
         let old_layout = Layout::from_size_align_unchecked(old_size, old_align);
         let new_layout = Layout::from_size_align_unchecked(new_size, new_align);
-        match System.grow_in_place(ptr, old_layout, new_layout) {
+        match System.grow_in_place(NonNull::new_unchecked(ptr), old_layout, new_layout) {
             Ok(()) => 1,
             Err(_) => 0,
         }
@@ -168,7 +169,7 @@ pub mod __default_lib_allocator {
                                                new_align: usize) -> u8 {
         let old_layout = Layout::from_size_align_unchecked(old_size, old_align);
         let new_layout = Layout::from_size_align_unchecked(new_size, new_align);
-        match System.shrink_in_place(ptr, old_layout, new_layout) {
+        match System.shrink_in_place(NonNull::new_unchecked(ptr), old_layout, new_layout) {
             Ok(()) => 1,
             Err(_) => 0,
         }

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -280,6 +280,7 @@
 #![feature(macro_reexport)]
 #![feature(macro_vis_matcher)]
 #![feature(needs_panic_runtime)]
+#![feature(nonnull_cast)]
 #![feature(exhaustive_patterns)]
 #![feature(nonzero)]
 #![feature(num_bits_bytes)]

--- a/src/test/run-make-fulldeps/std-core-cycle/bar.rs
+++ b/src/test/run-make-fulldeps/std-core-cycle/bar.rs
@@ -12,15 +12,16 @@
 #![crate_type = "rlib"]
 
 use std::heap::*;
+use std::ptr::NonNull;
 
 pub struct A;
 
 unsafe impl<'a> Alloc for &'a A {
-    unsafe fn alloc(&mut self, _: Layout) -> Result<*mut u8, AllocErr> {
+    unsafe fn alloc(&mut self, _: Layout) -> Result<NonNull<u8>, AllocErr> {
         loop {}
     }
 
-    unsafe fn dealloc(&mut self, _ptr: *mut u8, _: Layout) {
+    unsafe fn dealloc(&mut self, _ptr: NonNull<u8>, _: Layout) {
         loop {}
     }
 }

--- a/src/test/run-pass/allocator/auxiliary/custom.rs
+++ b/src/test/run-pass/allocator/auxiliary/custom.rs
@@ -14,17 +14,18 @@
 #![crate_type = "rlib"]
 
 use std::heap::{Alloc, System, AllocErr, Layout};
+use std::ptr::NonNull;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub struct A(pub AtomicUsize);
 
 unsafe impl<'a> Alloc for &'a A {
-    unsafe fn alloc(&mut self, layout: Layout) -> Result<*mut u8, AllocErr> {
+    unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
         self.0.fetch_add(1, Ordering::SeqCst);
         System.alloc(layout)
     }
 
-    unsafe fn dealloc(&mut self, ptr: *mut u8, layout: Layout) {
+    unsafe fn dealloc(&mut self, ptr: NonNull<u8>, layout: Layout) {
         self.0.fetch_add(1, Ordering::SeqCst);
         System.dealloc(ptr, layout)
     }

--- a/src/test/run-pass/allocator/custom.rs
+++ b/src/test/run-pass/allocator/custom.rs
@@ -16,6 +16,7 @@
 extern crate helper;
 
 use std::heap::{Heap, Alloc, System, Layout, AllocErr};
+use std::ptr::NonNull;
 use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 
 static HITS: AtomicUsize = ATOMIC_USIZE_INIT;
@@ -23,12 +24,12 @@ static HITS: AtomicUsize = ATOMIC_USIZE_INIT;
 struct A;
 
 unsafe impl<'a> Alloc for &'a A {
-    unsafe fn alloc(&mut self, layout: Layout) -> Result<*mut u8, AllocErr> {
+    unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
         HITS.fetch_add(1, Ordering::SeqCst);
         System.alloc(layout)
     }
 
-    unsafe fn dealloc(&mut self, ptr: *mut u8, layout: Layout) {
+    unsafe fn dealloc(&mut self, ptr: NonNull<u8>, layout: Layout) {
         HITS.fetch_add(1, Ordering::SeqCst);
         System.dealloc(ptr, layout)
     }

--- a/src/test/run-pass/realloc-16687.rs
+++ b/src/test/run-pass/realloc-16687.rs
@@ -16,7 +16,7 @@
 #![feature(heap_api, allocator_api)]
 
 use std::heap::{Heap, Alloc, Layout};
-use std::ptr;
+use std::ptr::{self, NonNull};
 
 fn main() {
     unsafe {
@@ -56,7 +56,7 @@ unsafe fn test_triangle() -> bool {
             println!("allocate({:?}) = {:?}", layout, ret);
         }
 
-        ret
+        ret.as_ptr()
     }
 
     unsafe fn deallocate(ptr: *mut u8, layout: Layout) {
@@ -64,7 +64,7 @@ unsafe fn test_triangle() -> bool {
             println!("deallocate({:?}, {:?}", ptr, layout);
         }
 
-        Heap.dealloc(ptr, layout);
+        Heap.dealloc(NonNull::new_unchecked(ptr), layout);
     }
 
     unsafe fn reallocate(ptr: *mut u8, old: Layout, new: Layout) -> *mut u8 {
@@ -72,14 +72,14 @@ unsafe fn test_triangle() -> bool {
             println!("reallocate({:?}, old={:?}, new={:?})", ptr, old, new);
         }
 
-        let ret = Heap.realloc(ptr, old.clone(), new.clone())
+        let ret = Heap.realloc(NonNull::new_unchecked(ptr), old.clone(), new.clone())
             .unwrap_or_else(|e| Heap.oom(e));
 
         if PRINT {
             println!("reallocate({:?}, old={:?}, new={:?}) = {:?}",
                      ptr, old, new, ret);
         }
-        ret
+        ret.as_ptr()
     }
 
     fn idx_to_size(i: usize) -> usize { (i+1) * 10 }

--- a/src/test/run-pass/regions-mock-trans.rs
+++ b/src/test/run-pass/regions-mock-trans.rs
@@ -13,6 +13,7 @@
 #![feature(allocator_api)]
 
 use std::heap::{Alloc, Heap, Layout};
+use std::ptr::NonNull;
 
 struct arena(());
 
@@ -33,7 +34,7 @@ fn alloc<'a>(_bcx : &'a arena) -> &'a Bcx<'a> {
     unsafe {
         let ptr = Heap.alloc(Layout::new::<Bcx>())
             .unwrap_or_else(|e| Heap.oom(e));
-        &*(ptr as *const _)
+        &*(ptr.as_ptr() as *const _)
     }
 }
 
@@ -45,7 +46,7 @@ fn g(fcx : &Fcx) {
     let bcx = Bcx { fcx: fcx };
     let bcx2 = h(&bcx);
     unsafe {
-        Heap.dealloc(bcx2 as *const _ as *mut _, Layout::new::<Bcx>());
+        Heap.dealloc(NonNull::new_unchecked(bcx2 as *const _ as *mut _), Layout::new::<Bcx>());
     }
 }
 


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/rust/issues/32838#issuecomment-370223269
and following, instead of *mut pointers, use NonNull for the allocator
API.

One issue is that older rustc versions, used to bootstrap the compiler,
expands #[global_allocator], used in various places including libstd or
librustc_[almt]san, to code that uses the Alloc trait, so changes to
that trait make bootstrapping fail. Thankfully, it does so through the
location of the Alloc trait before 94d1970bba87f2d2893f6e934e4c3f02ed50604d
so we can use at our advantage by making stage0 expose the old API as
alloc::heap::Alloc.

At the same time, we change the expansion for #[global_allocator] to use
the new trait location under core, which will allow newer versions of
rustc to bootstrap stage0 as well, despite the workaround described above.

The downside is that this is a breaking change, albeit, for an unstable feature,
that will pile up with the upcoming GlobalAlloc change. It /might/ make sense to
wait for GlobalAlloc to go in first, so that `#[global_allocator]` only breaks once.
But I still wanted to put this out there, get feedback on the change itself. It will be
trivial to rebase on top of GlobalAlloc if we decide to wait for that.

Cc @SimonSapin @alexcrichton 