### PR TITLE
Edition-gated keywords

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -1096,7 +1096,8 @@ pub fn build_session_(
     };
     let target_cfg = config::build_target_config(&sopts, &span_diagnostic);
 
-    let p_s = parse::ParseSess::with_span_handler(span_diagnostic, codemap);
+    let p_s = parse::ParseSess::with_span_handler(span_diagnostic, codemap,
+                                                  sopts.debugging_opts.edition);
     let default_sysroot = match sopts.maybe_sysroot {
         Some(_) => None,
         None => Some(filesearch::get_or_default_sysroot()),

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -21,7 +21,6 @@ use rustc::session::Session;
 use syntax::ast::*;
 use syntax::attr;
 use syntax::codemap::Spanned;
-use syntax::parse::token;
 use syntax::symbol::keywords;
 use syntax::visit::{self, Visitor};
 use syntax_pos::Span;
@@ -40,14 +39,15 @@ impl<'a> AstValidator<'a> {
         let valid_names = [keywords::UnderscoreLifetime.name(),
                            keywords::StaticLifetime.name(),
                            keywords::Invalid.name()];
-        if !valid_names.contains(&ident.name) &&
-            token::is_reserved_ident(ident.without_first_quote()) {
+        if !valid_names.contains(&ident.name)
+           && ident.without_first_quote().is_reserved()
+            {
             self.err_handler().span_err(ident.span, "lifetimes cannot use keyword names");
         }
     }
 
     fn check_label(&self, ident: Ident) {
-        if token::is_reserved_ident(ident.without_first_quote()) {
+        if ident.without_first_quote().is_reserved() {
             self.err_handler()
                 .span_err(ident.span, &format!("invalid label name `{}`", ident.name));
         }

--- a/src/libsyntax/edition.rs
+++ b/src/libsyntax/edition.rs
@@ -10,6 +10,7 @@
 
 use std::fmt;
 use std::str::FromStr;
+use symbol::{self, Symbol};
 
 /// The edition of the compiler (RFC 2052)
 #[derive(Clone, Copy, Hash, PartialOrd, Ord, Eq, PartialEq, Debug)]
@@ -53,6 +54,13 @@ impl Edition {
         match *self {
             Edition::Edition2015 => "edition_2015",
             Edition::Edition2018 => "edition_2018",
+        }
+    }
+
+    pub fn is_future_edition_keyword(&self, sym: Symbol) -> bool {
+        match *self {
+            Edition::Edition2015 => symbol::is_future_edition_keyword_2015(sym),
+            Edition::Edition2018 => symbol::is_future_edition_keyword_2018(sym),
         }
     }
 

--- a/src/libsyntax/edition.rs
+++ b/src/libsyntax/edition.rs
@@ -10,7 +10,7 @@
 
 use std::fmt;
 use std::str::FromStr;
-use symbol::{self, Symbol};
+use symbol::Symbol;
 
 /// The edition of the compiler (RFC 2052)
 #[derive(Clone, Copy, Hash, PartialOrd, Ord, Eq, PartialEq, Debug)]
@@ -59,8 +59,8 @@ impl Edition {
 
     pub fn is_future_edition_keyword(&self, sym: Symbol) -> bool {
         match *self {
-            Edition::Edition2015 => symbol::is_future_edition_keyword_2015(sym),
-            Edition::Edition2018 => symbol::is_future_edition_keyword_2018(sym),
+            Edition::Edition2015 => sym.is_future_edition_keyword_2015(),
+            Edition::Edition2018 => sym.is_future_edition_keyword_2018(),
         }
     }
 

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1778,6 +1778,7 @@ mod tests {
     use symbol::Symbol;
     use syntax_pos::{BytePos, Span, NO_EXPANSION};
     use codemap::CodeMap;
+    use edition::Edition;
     use errors;
     use feature_gate::UnstableFeatures;
     use parse::token;
@@ -1802,6 +1803,7 @@ mod tests {
             raw_identifier_spans: Lock::new(Vec::new()),
             registered_diagnostics: Lock::new(ErrorMap::new()),
             non_modrs_mods: Lock::new(vec![]),
+            edition: Edition::Edition2015,
         }
     }
 

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -14,6 +14,7 @@ use rustc_data_structures::sync::{Lrc, Lock};
 use ast::{self, CrateConfig};
 use codemap::{CodeMap, FilePathMapping};
 use syntax_pos::{self, Span, FileMap, NO_EXPANSION, FileName};
+use edition::Edition;
 use errors::{Handler, ColorConfig, DiagnosticBuilder};
 use feature_gate::UnstableFeatures;
 use parse::parser::Parser;
@@ -54,6 +55,7 @@ pub struct ParseSess {
     // Spans where a `mod foo;` statement was included in a non-mod.rs file.
     // These are used to issue errors if the non_modrs_mods feature is not enabled.
     pub non_modrs_mods: Lock<Vec<(ast::Ident, Span)>>,
+    pub edition: Edition,
     /// Used to determine and report recursive mod inclusions
     included_mod_stack: Lock<Vec<PathBuf>>,
     code_map: Lrc<CodeMap>,
@@ -66,10 +68,11 @@ impl ParseSess {
                                                 true,
                                                 false,
                                                 Some(cm.clone()));
-        ParseSess::with_span_handler(handler, cm)
+        ParseSess::with_span_handler(handler, cm, Edition::Edition2015)
     }
 
-    pub fn with_span_handler(handler: Handler, code_map: Lrc<CodeMap>) -> ParseSess {
+    pub fn with_span_handler(handler: Handler, code_map: Lrc<CodeMap>,
+                             edition: Edition) -> ParseSess {
         ParseSess {
             span_diagnostic: handler,
             unstable_features: UnstableFeatures::from_environment(),
@@ -80,6 +83,7 @@ impl ParseSess {
             included_mod_stack: Lock::new(vec![]),
             code_map,
             non_modrs_mods: Lock::new(vec![]),
+            edition,
         }
     }
 

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -145,14 +145,7 @@ pub fn is_path_segment_keyword(id: ast::Ident) -> bool {
 // How was it written originally? Did it use the raw form? Let's try to guess.
 pub fn is_raw_guess(ident: ast::Ident) -> bool {
     ident.name != keywords::Invalid.name() &&
-    is_reserved_ident(ident) && !is_path_segment_keyword(ident)
-}
-
-pub use syntax_pos::symbol::{is_special_ident, is_used_keyword, is_unused_keyword};
-
-/// Returns `true` if the token is either a special identifier or a keyword.
-pub fn is_reserved_ident(id: ast::Ident) -> bool {
-    is_special_ident(id) || is_used_keyword(id) || is_unused_keyword(id)
+    ident.is_reserved() && !is_path_segment_keyword(ident)
 }
 
 #[derive(Clone, RustcEncodable, RustcDecodable, PartialEq, Eq, Hash, Debug)]
@@ -399,7 +392,7 @@ impl Token {
     // unnamed method parameters, crate root module, error recovery etc.
     pub fn is_special_ident(&self) -> bool {
         match self.ident() {
-            Some((id, false)) => is_special_ident(id),
+            Some((id, false)) => id.is_special(),
             _ => false,
         }
     }
@@ -407,7 +400,7 @@ impl Token {
     /// Returns `true` if the token is a keyword used in the language.
     pub fn is_used_keyword(&self) -> bool {
         match self.ident() {
-            Some((id, false)) => is_used_keyword(id),
+            Some((id, false)) => id.is_used_keyword(),
             _ => false,
         }
     }
@@ -415,7 +408,7 @@ impl Token {
     /// Returns `true` if the token is a keyword reserved for possible future use.
     pub fn is_unused_keyword(&self) -> bool {
         match self.ident() {
-            Some((id, false)) => is_unused_keyword(id),
+            Some((id, false)) => id.is_unused_keyword(),
             _ => false,
         }
     }
@@ -423,7 +416,7 @@ impl Token {
     /// Returns `true` if the token is either a special identifier or a keyword.
     pub fn is_reserved_ident(&self) -> bool {
         match self.ident() {
-            Some((id, false)) => is_reserved_ident(id),
+            Some((id, false)) => id.is_reserved(),
             _ => false,
         }
     }

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -148,21 +148,7 @@ pub fn is_raw_guess(ident: ast::Ident) -> bool {
     is_reserved_ident(ident) && !is_path_segment_keyword(ident)
 }
 
-// Returns true for reserved identifiers used internally for elided lifetimes,
-// unnamed method parameters, crate root module, error recovery etc.
-pub fn is_special_ident(id: ast::Ident) -> bool {
-    id.name <= keywords::Underscore.name()
-}
-
-/// Returns `true` if the token is a keyword used in the language.
-pub fn is_used_keyword(id: ast::Ident) -> bool {
-    id.name >= keywords::As.name() && id.name <= keywords::While.name()
-}
-
-/// Returns `true` if the token is a keyword reserved for possible future use.
-pub fn is_unused_keyword(id: ast::Ident) -> bool {
-    id.name >= keywords::Abstract.name() && id.name <= keywords::Yield.name()
-}
+pub use syntax_pos::symbol::{is_special_ident, is_used_keyword, is_unused_keyword};
 
 /// Returns `true` if the token is either a special identifier or a keyword.
 pub fn is_reserved_ident(id: ast::Ident) -> bool {

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -325,6 +325,9 @@ declare_keywords! {
     (37, Use,                "use")
     (38, Where,              "where")
     (39, While,              "while")
+    // edition-gated used keywords go here
+    // be sure to update is_used_keyword and
+    // is_future_edition_keyword_* below
 
     // Keywords reserved for future use.
     (40, Abstract,           "abstract")
@@ -343,17 +346,45 @@ declare_keywords! {
     (53, Unsized,            "unsized")
     (54, Virtual,            "virtual")
     (55, Yield,              "yield")
+    // edition-gated reserved keywords
+    // be sure to update is_unused_keyword and
+    // is_future_edition_keyword_* below
+    (56, Async,              "async") // Rust 2018+ only
 
     // Special lifetime names
-    (56, UnderscoreLifetime, "'_")
-    (57, StaticLifetime,     "'static")
+    (57, UnderscoreLifetime, "'_")
+    (58, StaticLifetime,     "'static")
 
     // Weak keywords, have special meaning only in specific contexts.
-    (58, Auto,               "auto")
-    (59, Catch,              "catch")
-    (60, Default,            "default")
-    (61, Dyn,                "dyn")
-    (62, Union,              "union")
+    (59, Auto,               "auto")
+    (60, Catch,              "catch")
+    (61, Default,            "default")
+    (62, Dyn,                "dyn")
+    (63, Union,              "union")
+}
+
+// Returns true for reserved identifiers used internally for elided lifetimes,
+// unnamed method parameters, crate root module, error recovery etc.
+pub fn is_special_ident(id: Ident) -> bool {
+    id.name <= self::keywords::Underscore.name()
+}
+
+/// Returns `true` if the token is a keyword used in the language.
+pub fn is_used_keyword(id: Ident) -> bool {
+    id.name >= self::keywords::As.name() && id.name <= self::keywords::While.name()
+}
+
+/// Returns `true` if the token is a keyword reserved for possible future use.
+pub fn is_unused_keyword(id: Ident) -> bool {
+    id.name >= self::keywords::Abstract.name() && id.name <= self::keywords::Async.name()
+}
+
+pub fn is_future_edition_keyword_2015(sym: Symbol) -> bool {
+    sym == self::keywords::Async.name()
+}
+
+pub fn is_future_edition_keyword_2018(_: Symbol) -> bool {
+    false
 }
 
 // If an interner exists, return it. Otherwise, prepare a fresh one.

--- a/src/test/compile-fail/auxiliary/edition-kw-macro-2015.rs
+++ b/src/test/compile-fail/auxiliary/edition-kw-macro-2015.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Zedition=2015 -Zunstable-options
+
+#[macro_export]
+macro_rules! consumes_async {
+    (async) => (1)
+}
+

--- a/src/test/compile-fail/edition-keywords-2018.rs
+++ b/src/test/compile-fail/edition-keywords-2018.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Zedition=2018 -Zunstable-options
+// aux-build:edition-kw-macro-2015.rs
+
+#![feature(raw_identifiers)]
+
+#[macro_use]
+extern crate edition_kw_macro_2015;
+
+pub fn main() {
+    let _ = consumes_async!(async);
+    //~^ ERROR no rules expected the token `async`
+}

--- a/src/test/compile-fail/edition-kw.rs
+++ b/src/test/compile-fail/edition-kw.rs
@@ -1,0 +1,18 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Zedition=2018 -Zunstable-options
+
+#![allow(unused)]
+
+pub fn main() {
+    let async = 1;
+    //~^ ERROR expected pattern, found reserved keyword `async`
+}

--- a/src/test/run-pass/auxiliary/edition-kw-macro-2015.rs
+++ b/src/test/run-pass/auxiliary/edition-kw-macro-2015.rs
@@ -1,0 +1,37 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Zedition=2015 -Zunstable-options
+#![feature(raw_identifiers)]
+
+#[macro_export]
+macro_rules! produces_async {
+    () => (pub fn async() {})
+}
+
+#[macro_export]
+macro_rules! produces_async_raw {
+    () => (pub fn r#async() {})
+}
+
+#[macro_export]
+macro_rules! consumes_async {
+    (async) => (1)
+}
+
+#[macro_export]
+macro_rules! consumes_async_raw {
+    (r#async) => (1)
+}
+
+#[macro_export]
+macro_rules! consumes_ident {
+    ($i:ident) => ($i)
+}

--- a/src/test/run-pass/auxiliary/edition-kw-macro-2018.rs
+++ b/src/test/run-pass/auxiliary/edition-kw-macro-2018.rs
@@ -1,0 +1,32 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Zedition=2018 -Zunstable-options
+#![feature(raw_identifiers)]
+
+#[macro_export]
+macro_rules! produces_async {
+    () => (pub fn async() {})
+}
+
+#[macro_export]
+macro_rules! produces_async_raw {
+    () => (pub fn r#async() {})
+}
+
+#[macro_export]
+macro_rules! consumes_async_raw {
+    (r#async) => (1)
+}
+
+#[macro_export]
+macro_rules! consumes_ident {
+    ($i:ident) => ($i)
+}

--- a/src/test/run-pass/edition-keywords-2015.rs
+++ b/src/test/run-pass/edition-keywords-2015.rs
@@ -1,0 +1,45 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Zedition=2015 -Zunstable-options
+// aux-build:edition-kw-macro-2018.rs
+
+#![feature(raw_identifiers)]
+
+#[macro_use]
+extern crate edition_kw_macro_2018;
+
+
+pub fn main() {
+    let mut async = 1;
+    async = consumes_async_raw!(r#async);
+    async = consumes_async_raw!(async);
+    if r#async == 1 {
+
+    }
+    if consumes_ident!(r#async) == 1 {
+        // ...
+    }
+    if consumes_ident!(async) == 1 {
+        // ...
+    }
+    one::r#async();
+    two::r#async();
+    one::async();
+    two::async();
+}
+
+
+mod one {
+    produces_async! {}
+}
+mod two {
+    produces_async_raw! {}
+}

--- a/src/test/run-pass/edition-keywords-2018.rs
+++ b/src/test/run-pass/edition-keywords-2018.rs
@@ -1,0 +1,38 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Zedition=2018 -Zunstable-options
+// aux-build:edition-kw-macro-2015.rs
+
+#![feature(raw_identifiers)]
+
+#[macro_use]
+extern crate edition_kw_macro_2015;
+
+pub fn main() {
+    let mut r#async = 1;
+
+    r#async = consumes_async!(r#async);
+    r#async = consumes_async_raw!(r#async);
+
+    if consumes_ident!(r#async) == 1 {
+        // ...
+    }
+    one::r#async();
+    two::r#async();
+}
+
+
+mod one {
+    produces_async! {}
+}
+mod two {
+    produces_async_raw! {}
+}


### PR DESCRIPTION
This implements edition-gated keywords as discussed in #49610 . 


Currently only does async.
