### PR TITLE
Fix "since" version for getpid feature.

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1426,7 +1426,7 @@ pub fn abort() -> ! {
 /// ```
 ///
 ///
-#[stable(feature = "getpid", since = "1.27.0")]
+#[stable(feature = "getpid", since = "1.26.0")]
 pub fn id() -> u32 {
     ::sys::os::getpid()
 }


### PR DESCRIPTION
It was stabilized right before the beta branch was cut for 1.26.0.

See https://github.com/rust-lang/rust/pull/49523#issuecomment-377996315

This will need to be backported to beta (1.26.0)