### PR TITLE
in which the non-shorthand patterns lint keeps its own counsel in macros

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -173,6 +173,12 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonShorthandFieldPatterns {
                 }
                 if let PatKind::Binding(_, _, name, None) = fieldpat.node.pat.node {
                     if name.node == fieldpat.node.name {
+                        if let Some(_) = fieldpat.span.ctxt().outer().expn_info() {
+                            // Don't lint if this is a macro expansion: macro authors
+                            // shouldn't have to worry about this kind of style issue
+                            // (Issue #49588)
+                            return;
+                        }
                         let mut err = cx.struct_span_lint(NON_SHORTHAND_FIELD_PATTERNS,
                                      fieldpat.span,
                                      &format!("the `{}:` in this pattern is redundant",

--- a/src/test/run-pass/issue-49588-non-shorthand-field-patterns-in-pattern-macro.rs
+++ b/src/test/run-pass/issue-49588-non-shorthand-field-patterns-in-pattern-macro.rs
@@ -1,0 +1,24 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(non_shorthand_field_patterns)]
+
+pub struct Value<A> { pub value: A }
+
+#[macro_export]
+macro_rules! pat {
+    ($a:pat) => {
+        Value { value: $a }
+    };
+}
+
+fn main() {
+    let pat!(value) = Value { value: () };
+}


### PR DESCRIPTION
In issue #49588, Michael Lamparski pointed out a scenario in which the
non-shorthand-field-patterns lint could be triggered by a macro-expanded
pattern, in a way which was direly unwieldy for the macro author to guard
against and unreasonable to expect the macro user to take into account. We can
avoid this by not linting patterns that come from macro-expansions. Although
this entails accepting "false negatives" where the lint could genuinely improve
macro-templated code, avoiding the reported "true-but-super-annoying positive"
may be worth the trade? (Some precedent for these relative priorities exists as
no. 47775 (5985b0b0).)

Resolves #49588.