### PR TITLE
[beta] Update cargo and backport #49612

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1426,7 +1426,7 @@ pub fn abort() -> ! {
 /// ```
 ///
 ///
-#[stable(feature = "getpid", since = "1.27.0")]
+#[stable(feature = "getpid", since = "1.26.0")]
 pub fn id() -> u32 {
     ::sys::os::getpid()
 }


### PR DESCRIPTION
https://github.com/rust-lang/cargo/pull/5288 fixes a regression
where cargo would update registry on every operation.