### PR TITLE
Use Rc<str> and Rc<[T]> instead of Rc<String> and Rc<Vec<T>>

### DIFF
--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -399,10 +399,9 @@ pub fn used_crates(tcx: TyCtxt, prefer: LinkagePreference)
             Some((cnum, path))
         })
         .collect::<Vec<_>>();
-    let mut ordering = tcx.postorder_cnums(LOCAL_CRATE);
-    Lrc::make_mut(&mut ordering).reverse();
+    let ordering = tcx.postorder_cnums(LOCAL_CRATE);
     libs.sort_by_key(|&(a, _)| {
-        ordering.iter().position(|x| *x == a)
+        ordering.iter().rev().position(|x| *x == a)
     });
     libs
 }

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -217,7 +217,7 @@ pub struct ResolveLifetimes {
     defs: FxHashMap<LocalDefId, Lrc<FxHashMap<ItemLocalId, Region>>>,
     late_bound: FxHashMap<LocalDefId, Lrc<FxHashSet<ItemLocalId>>>,
     object_lifetime_defaults:
-        FxHashMap<LocalDefId, Lrc<FxHashMap<ItemLocalId, Lrc<Vec<ObjectLifetimeDefault>>>>>,
+        FxHashMap<LocalDefId, Lrc<FxHashMap<ItemLocalId, Lrc<[ObjectLifetimeDefault]>>>>,
 }
 
 impl_stable_hash_for!(struct ::middle::resolve_lifetime::ResolveLifetimes {
@@ -406,7 +406,7 @@ fn resolve_lifetimes<'tcx>(
             .or_insert_with(|| Lrc::new(FxHashMap()));
         Lrc::get_mut(map)
             .unwrap()
-            .insert(hir_id.local_id, Lrc::new(v));
+            .insert(hir_id.local_id, Lrc::from(v));
     }
 
     Lrc::new(ResolveLifetimes {

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -824,11 +824,11 @@ fn substitute_normalize_and_test_predicates<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx
 fn vtable_methods<'a, 'tcx>(
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
     trait_ref: ty::PolyTraitRef<'tcx>)
-    -> Lrc<Vec<Option<(DefId, &'tcx Substs<'tcx>)>>>
+    -> Lrc<[Option<(DefId, &'tcx Substs<'tcx>)>]>
 {
     debug!("vtable_methods({:?})", trait_ref);
 
-    Lrc::new(
+    Lrc::from(
         supertraits(tcx, trait_ref).flat_map(move |trait_ref| {
             let trait_methods = tcx.associated_items(trait_ref.def_id())
                 .filter(|item| item.kind == ty::AssociatedKind::Method);
@@ -871,7 +871,7 @@ fn vtable_methods<'a, 'tcx>(
 
                 Some((def_id, substs))
             })
-        }).collect()
+        }).collect::<Vec<_>>()
     )
 }
 

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -847,7 +847,7 @@ pub struct GlobalCtxt<'tcx> {
                                        Lrc<StableVec<TraitCandidate>>>>>,
 
     /// Export map produced by name resolution.
-    export_map: FxHashMap<DefId, Lrc<Vec<Export>>>,
+    export_map: FxHashMap<DefId, Lrc<[Export]>>,
 
     pub hir: hir_map::Map<'tcx>,
 
@@ -860,7 +860,7 @@ pub struct GlobalCtxt<'tcx> {
     // Records the free variables refrenced by every closure
     // expression. Do not track deps for this, just recompute it from
     // scratch every time.
-    freevars: FxHashMap<DefId, Lrc<Vec<hir::Freevar>>>,
+    freevars: FxHashMap<DefId, Lrc<[hir::Freevar]>>,
 
     maybe_unused_trait_imports: FxHashSet<DefId>,
 
@@ -1255,10 +1255,10 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             types: common_types,
             trait_map,
             export_map: resolutions.export_map.into_iter().map(|(k, v)| {
-                (k, Lrc::new(v))
+                (k, Lrc::from(v))
             }).collect(),
             freevars: resolutions.freevars.into_iter().map(|(k, v)| {
-                (hir.local_def_id(k), Lrc::new(v))
+                (hir.local_def_id(k), Lrc::from(v))
             }).collect(),
             maybe_unused_trait_imports:
                 resolutions.maybe_unused_trait_imports
@@ -1338,7 +1338,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         self.stability_index(LOCAL_CRATE)
     }
 
-    pub fn crates(self) -> Lrc<Vec<CrateNum>> {
+    pub fn crates(self) -> Lrc<[CrateNum]> {
         self.all_crate_nums(LOCAL_CRATE)
     }
 
@@ -2617,7 +2617,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     }
 
     pub fn object_lifetime_defaults(self, id: HirId)
-        -> Option<Lrc<Vec<ObjectLifetimeDefault>>>
+        -> Option<Lrc<[ObjectLifetimeDefault]>>
     {
         self.object_lifetime_defaults_map(id.owner)
             .and_then(|map| map.get(&id.local_id).cloned())
@@ -2696,7 +2696,7 @@ pub fn provide(providers: &mut ty::maps::Providers) {
     };
     providers.maybe_unused_extern_crates = |tcx, cnum| {
         assert_eq!(cnum, LOCAL_CRATE);
-        Lrc::new(tcx.maybe_unused_extern_crates.clone())
+        Lrc::from(tcx.maybe_unused_extern_crates.clone())
     };
 
     providers.stability_index = |tcx, cnum| {
@@ -2719,11 +2719,11 @@ pub fn provide(providers: &mut ty::maps::Providers) {
     };
     providers.all_crate_nums = |tcx, cnum| {
         assert_eq!(cnum, LOCAL_CRATE);
-        Lrc::new(tcx.cstore.crates_untracked())
+        Lrc::from(tcx.cstore.crates_untracked())
     };
     providers.postorder_cnums = |tcx, cnum| {
         assert_eq!(cnum, LOCAL_CRATE);
-        Lrc::new(tcx.cstore.postorder_cnums_untracked())
+        Lrc::from(tcx.cstore.postorder_cnums_untracked())
     };
     providers.output_filenames = |tcx, cnum| {
         assert_eq!(cnum, LOCAL_CRATE);

--- a/src/librustc/ty/maps/mod.rs
+++ b/src/librustc/ty/maps/mod.rs
@@ -136,13 +136,13 @@ define_maps! { <'tcx>
 
     /// Maps from def-id of a type or region parameter to its
     /// (inferred) variance.
-    [] fn variances_of: ItemVariances(DefId) -> Lrc<Vec<ty::Variance>>,
+    [] fn variances_of: ItemVariances(DefId) -> Lrc<[ty::Variance]>,
 
     /// Maps from def-id of a type to its (inferred) outlives.
     [] fn inferred_outlives_of: InferredOutlivesOf(DefId) -> Vec<ty::Predicate<'tcx>>,
 
     /// Maps from an impl/trait def-id to a list of the def-ids of its items
-    [] fn associated_item_def_ids: AssociatedItemDefIds(DefId) -> Lrc<Vec<DefId>>,
+    [] fn associated_item_def_ids: AssociatedItemDefIds(DefId) -> Lrc<[DefId]>,
 
     /// Maps from a trait item to the trait item "descriptor"
     [] fn associated_item: AssociatedItems(DefId) -> ty::AssociatedItem,
@@ -256,7 +256,7 @@ define_maps! { <'tcx>
     [] fn rvalue_promotable_map: RvaluePromotableMap(DefId) -> Lrc<ItemLocalSet>,
     [] fn is_mir_available: IsMirAvailable(DefId) -> bool,
     [] fn vtable_methods: vtable_methods_node(ty::PolyTraitRef<'tcx>)
-                          -> Lrc<Vec<Option<(DefId, &'tcx Substs<'tcx>)>>>,
+                          -> Lrc<[Option<(DefId, &'tcx Substs<'tcx>)>]>,
 
     [] fn trans_fulfill_obligation: fulfill_obligation_dep_node(
         (ty::ParamEnv<'tcx>, ty::PolyTraitRef<'tcx>)) -> Vtable<'tcx, ()>,
@@ -283,7 +283,7 @@ define_maps! { <'tcx>
                                             ty::layout::LayoutError<'tcx>>,
 
     [] fn dylib_dependency_formats: DylibDepFormats(CrateNum)
-                                    -> Lrc<Vec<(CrateNum, LinkagePreference)>>,
+                                    -> Lrc<[(CrateNum, LinkagePreference)]>,
 
     [fatal_cycle] fn is_panic_runtime: IsPanicRuntime(CrateNum) -> bool,
     [fatal_cycle] fn is_compiler_builtins: IsCompilerBuiltins(CrateNum) -> bool,
@@ -298,7 +298,7 @@ define_maps! { <'tcx>
     [] fn specializes: specializes_node((DefId, DefId)) -> bool,
     [] fn in_scope_traits_map: InScopeTraits(DefIndex)
         -> Option<Lrc<FxHashMap<ItemLocalId, Lrc<StableVec<TraitCandidate>>>>>,
-    [] fn module_exports: ModuleExports(DefId) -> Option<Lrc<Vec<Export>>>,
+    [] fn module_exports: ModuleExports(DefId) -> Option<Lrc<[Export]>>,
     [] fn lint_levels: lint_levels_node(CrateNum) -> Lrc<lint::LintLevelMap>,
 
     [] fn impl_defaultness: ImplDefaultness(DefId) -> hir::Defaultness,
@@ -329,9 +329,9 @@ define_maps! { <'tcx>
     [] fn upstream_monomorphizations_for: UpstreamMonomorphizationsFor(DefId)
         -> Option<Lrc<FxHashMap<&'tcx Substs<'tcx>, CrateNum>>>,
 
-    [] fn native_libraries: NativeLibraries(CrateNum) -> Lrc<Vec<NativeLibrary>>,
+    [] fn native_libraries: NativeLibraries(CrateNum) -> Lrc<[NativeLibrary]>,
 
-    [] fn foreign_modules: ForeignModules(CrateNum) -> Lrc<Vec<ForeignModule>>,
+    [] fn foreign_modules: ForeignModules(CrateNum) -> Lrc<[ForeignModule]>,
 
     [] fn plugin_registrar_fn: PluginRegistrarFn(CrateNum) -> Option<DefId>,
     [] fn derive_registrar_fn: DeriveRegistrarFn(CrateNum) -> Option<DefId>,
@@ -341,9 +341,9 @@ define_maps! { <'tcx>
     [] fn extra_filename: ExtraFileName(CrateNum) -> String,
 
     [] fn implementations_of_trait: implementations_of_trait_node((CrateNum, DefId))
-        -> Lrc<Vec<DefId>>,
+        -> Lrc<[DefId]>,
     [] fn all_trait_implementations: AllTraitImplementations(CrateNum)
-        -> Lrc<Vec<DefId>>,
+        -> Lrc<[DefId]>,
 
     [] fn dllimport_foreign_items: DllimportForeignItems(CrateNum)
         -> Lrc<FxHashSet<DefId>>,
@@ -351,7 +351,7 @@ define_maps! { <'tcx>
     [] fn is_statically_included_foreign_item: IsStaticallyIncludedForeignItem(DefId) -> bool,
     [] fn native_library_kind: NativeLibraryKind(DefId)
         -> Option<NativeLibraryKind>,
-    [] fn link_args: link_args_node(CrateNum) -> Lrc<Vec<String>>,
+    [] fn link_args: link_args_node(CrateNum) -> Lrc<[String]>,
 
     // Lifetime resolution. See `middle::resolve_lifetimes`.
     [] fn resolve_lifetimes: ResolveLifetimes(CrateNum) -> Lrc<ResolveLifetimes>,
@@ -360,31 +360,31 @@ define_maps! { <'tcx>
     [] fn is_late_bound_map: IsLateBound(DefIndex) ->
         Option<Lrc<FxHashSet<ItemLocalId>>>,
     [] fn object_lifetime_defaults_map: ObjectLifetimeDefaults(DefIndex)
-        -> Option<Lrc<FxHashMap<ItemLocalId, Lrc<Vec<ObjectLifetimeDefault>>>>>,
+        -> Option<Lrc<FxHashMap<ItemLocalId, Lrc<[ObjectLifetimeDefault]>>>>,
 
     [] fn visibility: Visibility(DefId) -> ty::Visibility,
     [] fn dep_kind: DepKind(CrateNum) -> DepKind,
     [] fn crate_name: CrateName(CrateNum) -> Symbol,
-    [] fn item_children: ItemChildren(DefId) -> Lrc<Vec<Export>>,
+    [] fn item_children: ItemChildren(DefId) -> Lrc<[Export]>,
     [] fn extern_mod_stmt_cnum: ExternModStmtCnum(DefId) -> Option<CrateNum>,
 
     [] fn get_lang_items: get_lang_items_node(CrateNum) -> Lrc<LanguageItems>,
-    [] fn defined_lang_items: DefinedLangItems(CrateNum) -> Lrc<Vec<(DefId, usize)>>,
-    [] fn missing_lang_items: MissingLangItems(CrateNum) -> Lrc<Vec<LangItem>>,
+    [] fn defined_lang_items: DefinedLangItems(CrateNum) -> Lrc<[(DefId, usize)]>,
+    [] fn missing_lang_items: MissingLangItems(CrateNum) -> Lrc<[LangItem]>,
     [] fn extern_const_body: ExternConstBody(DefId) -> ExternConstBody<'tcx>,
     [] fn visible_parent_map: visible_parent_map_node(CrateNum)
         -> Lrc<DefIdMap<DefId>>,
     [] fn missing_extern_crate_item: MissingExternCrateItem(CrateNum) -> bool,
     [] fn used_crate_source: UsedCrateSource(CrateNum) -> Lrc<CrateSource>,
-    [] fn postorder_cnums: postorder_cnums_node(CrateNum) -> Lrc<Vec<CrateNum>>,
+    [] fn postorder_cnums: postorder_cnums_node(CrateNum) -> Lrc<[CrateNum]>,
 
-    [] fn freevars: Freevars(DefId) -> Option<Lrc<Vec<hir::Freevar>>>,
+    [] fn freevars: Freevars(DefId) -> Option<Lrc<[hir::Freevar]>>,
     [] fn maybe_unused_trait_import: MaybeUnusedTraitImport(DefId) -> bool,
     [] fn maybe_unused_extern_crates: maybe_unused_extern_crates_node(CrateNum)
-        -> Lrc<Vec<(DefId, Span)>>,
+        -> Lrc<[(DefId, Span)]>,
 
     [] fn stability_index: stability_index_node(CrateNum) -> Lrc<stability::Index<'tcx>>,
-    [] fn all_crate_nums: all_crate_nums_node(CrateNum) -> Lrc<Vec<CrateNum>>,
+    [] fn all_crate_nums: all_crate_nums_node(CrateNum) -> Lrc<[CrateNum]>,
 
     [] fn exported_symbols: ExportedSymbols(CrateNum)
         -> Arc<Vec<(ExportedSymbol<'tcx>, SymbolExportLevel)>>,
@@ -435,9 +435,9 @@ define_maps! { <'tcx>
 
     [] fn features_query: features_node(CrateNum) -> Lrc<feature_gate::Features>,
 
-    [] fn program_clauses_for: ProgramClausesFor(DefId) -> Lrc<Vec<Clause<'tcx>>>,
+    [] fn program_clauses_for: ProgramClausesFor(DefId) -> Lrc<[Clause<'tcx>]>,
 
-    [] fn wasm_custom_sections: WasmCustomSections(CrateNum) -> Lrc<Vec<DefId>>,
+    [] fn wasm_custom_sections: WasmCustomSections(CrateNum) -> Lrc<[DefId]>,
     [] fn wasm_import_module_map: WasmImportModuleMap(CrateNum)
         -> Lrc<FxHashMap<DefId, String>>,
 }

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -337,10 +337,10 @@ pub struct CrateVariancesMap {
     /// For each item with generics, maps to a vector of the variance
     /// of its generics.  If an item has no generics, it will have no
     /// entry.
-    pub variances: FxHashMap<DefId, Lrc<Vec<ty::Variance>>>,
+    pub variances: FxHashMap<DefId, Lrc<[ty::Variance]>>,
 
     /// An empty vector, useful for cloning.
-    pub empty_variance: Lrc<Vec<ty::Variance>>,
+    pub empty_variance: Lrc<[ty::Variance]>,
 }
 
 impl Variance {
@@ -2641,7 +2641,7 @@ fn adt_sized_constraint<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
 fn associated_item_def_ids<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                      def_id: DefId)
-                                     -> Lrc<Vec<DefId>> {
+                                     -> Lrc<[DefId]> {
     let id = tcx.hir.as_local_node_id(def_id).unwrap();
     let item = tcx.hir.expect_item(id);
     let vec: Vec<_> = match item.node {
@@ -2660,7 +2660,7 @@ fn associated_item_def_ids<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         hir::ItemTraitAlias(..) => vec![],
         _ => span_bug!(item.span, "associated_item_def_ids: not impl or trait")
     };
-    Lrc::new(vec)
+    Lrc::from(vec)
 }
 
 fn def_span<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> Span {
@@ -2772,6 +2772,7 @@ pub fn provide(providers: &mut ty::maps::Providers) {
 /// (constructing this map requires touching the entire crate).
 #[derive(Clone, Debug)]
 pub struct CrateInherentImpls {
+    // Note: needs to be a Lrc<Vec<DefId>> since get_mut().push() is used
     pub inherent_impls: DefIdMap<Lrc<Vec<DefId>>>,
 }
 

--- a/src/librustc/ty/relate.rs
+++ b/src/librustc/ty/relate.rs
@@ -131,7 +131,7 @@ impl<'tcx> Relate<'tcx> for ty::TypeAndMut<'tcx> {
 }
 
 pub fn relate_substs<'a, 'gcx, 'tcx, R>(relation: &mut R,
-                                        variances: Option<&Vec<ty::Variance>>,
+                                        variances: Option<&[ty::Variance]>,
                                         a_subst: &'tcx Substs<'tcx>,
                                         b_subst: &'tcx Substs<'tcx>)
                                         -> RelateResult<'tcx, &'tcx Substs<'tcx>>

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -115,12 +115,12 @@ provide! { <'tcx> tcx, def_id, other, cdata,
         let _ = cdata;
         tcx.calculate_dtor(def_id, &mut |_,_| Ok(()))
     }
-    variances_of => { Lrc::new(cdata.get_item_variances(def_id.index)) }
+    variances_of => { Lrc::from(cdata.get_item_variances(def_id.index)) }
     associated_item_def_ids => {
         let mut result = vec![];
         cdata.each_child_of_item(def_id.index,
           |child| result.push(child.def.def_id()), tcx.sess);
-        Lrc::new(result)
+        Lrc::from(result)
     }
     associated_item => { cdata.get_associated_item(def_id.index) }
     impl_trait_ref => { cdata.get_impl_trait(def_id.index, tcx) }
@@ -144,7 +144,7 @@ provide! { <'tcx> tcx, def_id, other, cdata,
     }
     typeck_tables_of => { cdata.item_body_tables(def_id.index, tcx) }
     fn_sig => { cdata.fn_sig(def_id.index, tcx) }
-    inherent_impls => { Lrc::new(cdata.get_inherent_implementations_for_type(def_id.index)) }
+    inherent_impls => { Lrc::from(cdata.get_inherent_implementations_for_type(def_id.index)) }
     is_const_fn => { cdata.is_const_fn(def_id.index) }
     is_foreign_item => { cdata.is_foreign_item(def_id.index) }
     describe_def => { cdata.get_def(def_id.index) }
@@ -169,7 +169,7 @@ provide! { <'tcx> tcx, def_id, other, cdata,
     }
     is_mir_available => { cdata.is_item_mir_available(def_id.index) }
 
-    dylib_dependency_formats => { Lrc::new(cdata.get_dylib_dependency_formats()) }
+    dylib_dependency_formats => { Lrc::from(cdata.get_dylib_dependency_formats()) }
     is_panic_runtime => { cdata.is_panic_runtime(tcx.sess) }
     is_compiler_builtins => { cdata.is_compiler_builtins(tcx.sess) }
     has_global_allocator => { cdata.has_global_allocator() }
@@ -197,8 +197,8 @@ provide! { <'tcx> tcx, def_id, other, cdata,
 
         Lrc::new(reachable_non_generics)
     }
-    native_libraries => { Lrc::new(cdata.get_native_libraries(tcx.sess)) }
-    foreign_modules => { Lrc::new(cdata.get_foreign_modules(tcx.sess)) }
+    native_libraries => { Lrc::from(cdata.get_native_libraries(tcx.sess)) }
+    foreign_modules => { Lrc::from(cdata.get_foreign_modules(tcx.sess)) }
     plugin_registrar_fn => {
         cdata.root.plugin_registrar_fn.map(|index| {
             DefId { krate: def_id.krate, index }
@@ -220,13 +220,13 @@ provide! { <'tcx> tcx, def_id, other, cdata,
         let mut result = vec![];
         let filter = Some(other);
         cdata.get_implementations_for_trait(filter, &mut result);
-        Lrc::new(result)
+        Lrc::from(result)
     }
 
     all_trait_implementations => {
         let mut result = vec![];
         cdata.get_implementations_for_trait(None, &mut result);
-        Lrc::new(result)
+        Lrc::from(result)
     }
 
     visibility => { cdata.get_visibility(def_id.index) }
@@ -238,10 +238,10 @@ provide! { <'tcx> tcx, def_id, other, cdata,
     item_children => {
         let mut result = vec![];
         cdata.each_child_of_item(def_id.index, |child| result.push(child), tcx.sess);
-        Lrc::new(result)
+        Lrc::from(result)
     }
-    defined_lang_items => { Lrc::new(cdata.get_lang_items()) }
-    missing_lang_items => { Lrc::new(cdata.get_missing_lang_items()) }
+    defined_lang_items => { Lrc::from(cdata.get_lang_items()) }
+    missing_lang_items => { Lrc::from(cdata.get_missing_lang_items()) }
 
     extern_const_body => {
         debug!("item_body({:?}): inlining item", def_id);
@@ -271,7 +271,7 @@ provide! { <'tcx> tcx, def_id, other, cdata,
         Arc::new(cdata.exported_symbols(tcx))
     }
 
-    wasm_custom_sections => { Lrc::new(cdata.wasm_custom_sections()) }
+    wasm_custom_sections => { Lrc::from(cdata.wasm_custom_sections()) }
 }
 
 pub fn provide<'tcx>(providers: &mut Providers<'tcx>) {
@@ -321,15 +321,15 @@ pub fn provide<'tcx>(providers: &mut Providers<'tcx>) {
         },
         native_libraries: |tcx, cnum| {
             assert_eq!(cnum, LOCAL_CRATE);
-            Lrc::new(native_libs::collect(tcx))
+            Lrc::from(native_libs::collect(tcx))
         },
         foreign_modules: |tcx, cnum| {
             assert_eq!(cnum, LOCAL_CRATE);
-            Lrc::new(foreign_modules::collect(tcx))
+            Lrc::from(foreign_modules::collect(tcx))
         },
         link_args: |tcx, cnum| {
             assert_eq!(cnum, LOCAL_CRATE);
-            Lrc::new(link_args::collect(tcx))
+            Lrc::from(link_args::collect(tcx))
         },
 
         // Returns a map from a sufficiently visible external item (i.e. an
@@ -362,7 +362,7 @@ pub fn provide<'tcx>(providers: &mut Providers<'tcx>) {
             // which is to say, its not deterministic in general. But
             // we believe that libstd is consistently assigned crate
             // num 1, so it should be enough to resolve #46112.
-            let mut crates: Vec<CrateNum> = (*tcx.crates()).clone();
+            let mut crates: Vec<CrateNum> = tcx.crates().to_vec();
             crates.sort();
 
             for &cnum in crates.iter() {

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -608,7 +608,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
 
         let data = ModData {
             reexports: match tcx.module_exports(def_id) {
-                Some(ref exports) => self.lazy_seq_from_slice(exports.as_slice()),
+                Some(ref exports) => self.lazy_seq_from_slice(&exports),
                 _ => LazySeq::empty(),
             },
         };

--- a/src/librustc_traits/lowering.rs
+++ b/src/librustc_traits/lowering.rs
@@ -91,7 +91,7 @@ impl<'tcx> Lower<PolyDomainGoal<'tcx>> for ty::Predicate<'tcx> {
 }
 
 crate fn program_clauses_for<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId)
-    -> Lrc<Vec<Clause<'tcx>>>
+    -> Lrc<[Clause<'tcx>]>
 {
     let node_id = tcx.hir.as_local_node_id(def_id).unwrap();
     let item = tcx.hir.expect_item(node_id);
@@ -100,12 +100,12 @@ crate fn program_clauses_for<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefI
         hir::ItemImpl(..) => program_clauses_for_impl(tcx, def_id),
 
         // FIXME: other constructions e.g. traits, associated types...
-        _ => Lrc::new(vec![]),
+        _ => Lrc::new([]),
     }
 }
 
 fn program_clauses_for_trait<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId)
-    -> Lrc<Vec<Clause<'tcx>>>
+    -> Lrc<[Clause<'tcx>]>
 {
     // Rule Implemented-From-Env (see rustc guide)
     //
@@ -134,14 +134,14 @@ fn program_clauses_for_trait<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefI
         goal: impl_trait,
         hypotheses: vec![from_env],
     };
-    Lrc::new(vec![Clause::ForAll(ty::Binder::dummy(clause))])
+    Lrc::new([Clause::ForAll(ty::Binder::dummy(clause))])
 }
 
 fn program_clauses_for_impl<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId)
-    -> Lrc<Vec<Clause<'tcx>>>
+    -> Lrc<[Clause<'tcx>]>
 {
     if let ImplPolarity::Negative = tcx.impl_polarity(def_id) {
-        return Lrc::new(vec![]);
+        return Lrc::new([]);
     }
 
     // Rule Implemented-From-Impl (see rustc guide)
@@ -165,7 +165,7 @@ fn program_clauses_for_impl<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId
         goal: trait_pred,
         hypotheses: where_clauses.into_iter().map(|wc| wc.into()).collect()
     };
-    Lrc::new(vec![Clause::ForAll(ty::Binder::dummy(clause))])
+    Lrc::new([Clause::ForAll(ty::Binder::dummy(clause))])
 }
 
 pub fn dump_program_clauses<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {

--- a/src/librustc_trans/attributes.rs
+++ b/src/librustc_trans/attributes.rs
@@ -188,7 +188,7 @@ pub fn provide(providers: &mut Providers) {
         assert_eq!(cnum, LOCAL_CRATE);
         let mut finder = WasmSectionFinder { tcx, list: Vec::new() };
         tcx.hir.krate().visit_all_item_likes(&mut finder);
-        Lrc::new(finder.list)
+        Lrc::from(finder.list)
     };
 
     provide_extern(providers);

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -398,17 +398,17 @@ struct CrateInfo {
     profiler_runtime: Option<CrateNum>,
     sanitizer_runtime: Option<CrateNum>,
     is_no_builtins: FxHashSet<CrateNum>,
-    native_libraries: FxHashMap<CrateNum, Lrc<Vec<NativeLibrary>>>,
+    native_libraries: FxHashMap<CrateNum, Lrc<[NativeLibrary]>>,
     crate_name: FxHashMap<CrateNum, String>,
-    used_libraries: Lrc<Vec<NativeLibrary>>,
-    link_args: Lrc<Vec<String>>,
+    used_libraries: Lrc<[NativeLibrary]>,
+    link_args: Lrc<[String]>,
     used_crate_source: FxHashMap<CrateNum, Lrc<CrateSource>>,
     used_crates_static: Vec<(CrateNum, LibSource)>,
     used_crates_dynamic: Vec<(CrateNum, LibSource)>,
     wasm_custom_sections: BTreeMap<String, Vec<u8>>,
     wasm_imports: FxHashMap<String, String>,
     lang_item_to_crate: FxHashMap<LangItem, CrateNum>,
-    missing_lang_items: FxHashMap<CrateNum, Lrc<Vec<LangItem>>>,
+    missing_lang_items: FxHashMap<CrateNum, Lrc<[LangItem]>>,
 }
 
 __build_diagnostic_array! { librustc_trans, DIAGNOSTICS }

--- a/src/librustc_typeck/variance/mod.rs
+++ b/src/librustc_typeck/variance/mod.rs
@@ -54,7 +54,7 @@ fn crate_variances<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, crate_num: CrateNum)
 }
 
 fn variances_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, item_def_id: DefId)
-                            -> Lrc<Vec<ty::Variance>> {
+                            -> Lrc<[ty::Variance]> {
     let id = tcx.hir.as_local_node_id(item_def_id).expect("expected local def-id");
     let unsupported = || {
         // Variance not relevant.

--- a/src/librustc_typeck/variance/solve.rs
+++ b/src/librustc_typeck/variance/solve.rs
@@ -51,7 +51,7 @@ pub fn solve_constraints(constraints_cx: ConstraintContext) -> ty::CrateVariance
     };
     solutions_cx.solve();
     let variances = solutions_cx.create_map();
-    let empty_variance = Lrc::new(Vec::new());
+    let empty_variance = Lrc::new([]);
 
     ty::CrateVariancesMap { variances, empty_variance }
 }
@@ -88,7 +88,7 @@ impl<'a, 'tcx> SolveContext<'a, 'tcx> {
         }
     }
 
-    fn create_map(&self) -> FxHashMap<DefId, Lrc<Vec<ty::Variance>>> {
+    fn create_map(&self) -> FxHashMap<DefId, Lrc<[ty::Variance]>> {
         let tcx = self.terms_cx.tcx;
 
         let solutions = &self.solutions;
@@ -109,7 +109,7 @@ impl<'a, 'tcx> SolveContext<'a, 'tcx> {
                 }
             }
 
-            (def_id, Lrc::new(variances))
+            (def_id, Lrc::from(variances))
         }).collect()
     }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -4097,7 +4097,7 @@ pub fn path_to_def(tcx: &TyCtxt, path: &[&str]) -> Option<DefId> {
                 None => return None,
             };
 
-            for item in mem::replace(&mut items, Lrc::new(vec![])).iter() {
+            for item in mem::replace(&mut items, Lrc::new([])).iter() {
                 if item.ident.name == *segment {
                     if path_it.peek().is_none() {
                         return match item.def {

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -2341,14 +2341,14 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// use std::collections::hash_map::{Entry, HashMap};
     /// use std::rc::Rc;
     ///
-    /// let mut map: HashMap<Rc<String>, u32> = HashMap::new();
-    /// map.insert(Rc::new("Stringthing".to_string()), 15);
+    /// let mut map: HashMap<Rc<str>, u32> = HashMap::new();
+    /// map.insert("Stringthing".into(), 15);
     ///
-    /// let my_key = Rc::new("Stringthing".to_string());
+    /// let my_key: Rc<str> = "Stringthing".into();
     ///
     /// if let Entry::Occupied(entry) = map.entry(my_key) {
     ///     // Also replace the key with a handle to our other key.
-    ///     let (old_key, old_value): (Rc<String>, u32) = entry.replace_entry(16);
+    ///     let (old_key, old_value): (Rc<str>, u32) = entry.replace_entry(16);
     /// }
     ///
     /// ```
@@ -2371,14 +2371,14 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// use std::collections::hash_map::{Entry, HashMap};
     /// use std::rc::Rc;
     ///
-    /// let mut map: HashMap<Rc<String>, u32> = HashMap::new();
-    /// let mut known_strings: Vec<Rc<String>> = Vec::new();
+    /// let mut map: HashMap<Rc<str>, u32> = HashMap::new();
+    /// let mut known_strings: Vec<Rc<str>> = Vec::new();
     ///
     /// // Initialise known strings, run program, etc.
     ///
     /// reclaim_memory(&mut map, &known_strings);
     ///
-    /// fn reclaim_memory(map: &mut HashMap<Rc<String>, u32>, known_strings: &[Rc<String>] ) {
+    /// fn reclaim_memory(map: &mut HashMap<Rc<str>, u32>, known_strings: &[Rc<str>] ) {
     ///     for s in known_strings {
     ///         if let Entry::Occupied(entry) = map.entry(s.clone()) {
     ///             // Replaces the entry's key with our version of it in `known_strings`.

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1282,7 +1282,7 @@ pub enum LitKind {
     /// A string literal (`"foo"`)
     Str(Symbol, StrStyle),
     /// A byte string (`b"foo"`)
-    ByteStr(Lrc<Vec<u8>>),
+    ByteStr(Lrc<[u8]>),
     /// A byte char (`b'f'`)
     Byte(u8),
     /// A character literal (`'a'`)

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -184,7 +184,7 @@ pub fn expand_include_bytes(cx: &mut ExtCtxt, sp: Span, tts: &[tokenstream::Toke
             // dependency information, but don't enter it's contents
             cx.codemap().new_filemap_and_lines(&file, "");
 
-            base::MacEager::expr(cx.expr_lit(sp, ast::LitKind::ByteStr(Lrc::new(bytes))))
+            base::MacEager::expr(cx.expr_lit(sp, ast::LitKind::ByteStr(Lrc::from(bytes))))
         }
     }
 }

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -61,7 +61,7 @@ pub struct StringReader<'a> {
     pub fatal_errs: Vec<DiagnosticBuilder<'a>>,
     // cache a direct reference to the source text, so that we don't have to
     // retrieve it via `self.filemap.src.as_ref().unwrap()` all the time.
-    source_text: Lrc<String>,
+    source_text: Lrc<str>,
     /// Stack of open delimiters and their spans. Used for error message.
     token: token::Token,
     span: Span,

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -428,7 +428,7 @@ pub fn lit_token(lit: token::Lit, suf: Option<Symbol>, diag: Option<(Span, &Hand
             (true, Some(LitKind::ByteStr(byte_str_lit(&i.as_str()))))
         }
         token::ByteStrRaw(i, _) => {
-            (true, Some(LitKind::ByteStr(Lrc::new(i.to_string().into_bytes()))))
+            (true, Some(LitKind::ByteStr(Lrc::from(i.as_str().as_bytes()))))
         }
     }
 }
@@ -502,7 +502,7 @@ pub fn byte_lit(lit: &str) -> (u8, usize) {
     }
 }
 
-pub fn byte_str_lit(lit: &str) -> Lrc<Vec<u8>> {
+pub fn byte_str_lit(lit: &str) -> Lrc<[u8]> {
     let mut res = Vec::with_capacity(lit.len());
 
     let error = |i| format!("lexer should have rejected {} at {}", lit, i);
@@ -558,7 +558,7 @@ pub fn byte_str_lit(lit: &str) -> Lrc<Vec<u8>> {
         }
     }
 
-    Lrc::new(res)
+    Lrc::from(res)
 }
 
 pub fn integer_lit(s: &str, suffix: Option<Symbol>, diag: Option<(Span, &Handler)>)

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -751,7 +751,7 @@ pub struct FileMap {
     /// Indicates which crate this FileMap was imported from.
     pub crate_of_origin: u32,
     /// The complete source code
-    pub src: Option<Lrc<String>>,
+    pub src: Option<Lrc<str>>,
     /// The source code's hash
     pub src_hash: u128,
     /// The external source code (used for external crates, which will have a `None`
@@ -937,7 +937,7 @@ impl FileMap {
             name_was_remapped,
             unmapped_path: Some(unmapped_path),
             crate_of_origin: 0,
-            src: Some(Lrc::new(src)),
+            src: Some(Lrc::from(src)),
             src_hash,
             external_src: Lock::new(ExternalSource::Unneeded),
             start_pos,

--- a/src/test/run-pass-fulldeps/issue-35829.rs
+++ b/src/test/run-pass-fulldeps/issue-35829.rs
@@ -37,12 +37,12 @@ fn run() {
 
     // check byte string
     let byte_string = quote_expr!(&cx, b"one");
-    let byte_string_lit_kind = LitKind::ByteStr(Lrc::new(b"one".to_vec()));
+    let byte_string_lit_kind = LitKind::ByteStr(Lrc::from(&b"one"[..]));
     assert_eq!(byte_string.node, ExprKind::Lit(P(dummy_spanned(byte_string_lit_kind))));
 
     // check raw byte string
     let raw_byte_string = quote_expr!(&cx, br###"#"two"#"###);
-    let raw_byte_string_lit_kind = LitKind::ByteStr(Lrc::new(b"#\"two\"#".to_vec()));
+    let raw_byte_string_lit_kind = LitKind::ByteStr(Lrc::from(&b"#\"two\"#"[..]));
     assert_eq!(raw_byte_string.node, ExprKind::Lit(P(dummy_spanned(raw_byte_string_lit_kind))));
 
     // check dotdoteq


### PR DESCRIPTION
to save a bit of memory and pointer chasing.

For the `Vec<T>` case, there is one instance each of `get_mut` and `make_mut` that preclude the use of the slice type:

* the `get_mut` one does `push`, so I left it as is
* the `make_mut` one does a `reverse`, which would be fine but `Lrc<[T]>` does not impl `Clone` (should it?) - however, the reverse seems to be unnecessary - please check if the solution makes sense

Had some unrelated-looking local test failures, let's see if if CI gets them too.