### PR TITLE
Use box syntax instead of Box::new in Mutex::remutex on Windows

### DIFF
--- a/src/libstd/sys/windows/mutex.rs
+++ b/src/libstd/sys/windows/mutex.rs
@@ -117,7 +117,7 @@ impl Mutex {
             0 => {}
             n => return n as *mut _,
         }
-        let mut re = Box::new(ReentrantMutex::uninitialized());
+        let mut re = box ReentrantMutex::uninitialized();
         re.init();
         let re = Box::into_raw(re);
         match self.lock.compare_and_swap(0, re as usize, Ordering::SeqCst) {


### PR DESCRIPTION
The Box::new(mem::uninitialized()) pattern actually actively copies
uninitialized bytes from the stack into the box, which is a waste of
time. Using the box syntax instead avoids the useless copy.