### PR TITLE
Host compiler documentation: Include private items

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -696,6 +696,7 @@ impl Step for Rustc {
         t!(symlink_dir_force(&out, &out_dir));
 
         let mut cargo = builder.cargo(compiler, Mode::Librustc, target, "doc");
+        cargo.env("RUSTDOCFLAGS", "--document-private-items");
         compile::rustc_cargo(build, &mut cargo);
 
         // Only include compiler crates, no dependencies of those, such as `libc`.

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -353,8 +353,8 @@ pub struct ScopeTree {
     /// the result of `g()` occurs after the yield (and therefore
     /// doesn't). If we want to infer that, we can look at the
     /// postorder traversal:
-    /// ```
-    /// `foo` `f` Call#1 `y` Yield `bar` `g` Call#3 Call#2 Call#0
+    /// ```plain,ignore
+    ///     `foo` `f` Call#1 `y` Yield `bar` `g` Call#3 Call#2 Call#0
     /// ```
     ///
     /// In which we can easily see that `Call#1` occurs before the yield,

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -362,7 +362,9 @@ enum EvaluationResult {
     /// When checking `foo`, we have to prove `T: Trait`. This basically
     /// translates into this:
     ///
+    /// ```plain,ignore
     ///     (T: Trait + Sized →_\impl T: Trait), T: Trait ⊢ T: Trait
+    /// ```
     ///
     /// When we try to prove it, we first go the first option, which
     /// recurses. This shows us that the impl is "useless" - it won't

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -427,14 +427,14 @@ fn generate_fn_name_span(cm: &CodeMap, span: Span) -> Option<Span> {
 /// a new local type parameter.
 ///
 /// For instance:
-/// ```
+/// ```rust,ignore (pseudo-Rust)
 /// // Given span
 /// fn my_function(param: T)
-///                       ^ Original span
+/// //                    ^ Original span
 ///
 /// // Result
 /// fn my_function(param: T)
-///    ^^^^^^^^^^^ Generated span with snippet `my_function<T>`
+/// // ^^^^^^^^^^^ Generated span with snippet `my_function<T>`
 /// ```
 ///
 /// Attention: The method used is very fragile since it essentially duplicates the work of the

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -1164,10 +1164,12 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
     /// constraint that `'z <= 'a`. Given this setup, let's clarify the
     /// parameters in (roughly) terms of the example:
     ///
+    /// ```plain,ignore (pseudo-Rust)
     ///     A borrow of: `& 'z bk * r` where `r` has type `& 'a bk T`
     ///     borrow_region   ^~                 ref_region    ^~
     ///     borrow_kind        ^~               ref_kind        ^~
     ///     ref_cmt                 ^
+    /// ```
     ///
     /// Here `bk` stands for some borrow-kind (e.g., `mut`, `uniq`, etc).
     ///

--- a/src/librustc_typeck/impl_wf_check.rs
+++ b/src/librustc_typeck/impl_wf_check.rs
@@ -42,21 +42,21 @@ use syntax_pos::Span;
 ///
 /// Example:
 ///
-/// ```
+/// ```rust,ignore (pseudo-Rust)
 /// impl<T> Trait<Foo> for Bar { ... }
-///      ^ T does not appear in `Foo` or `Bar`, error!
+/// //   ^ T does not appear in `Foo` or `Bar`, error!
 ///
 /// impl<T> Trait<Foo<T>> for Bar { ... }
-///      ^ T appears in `Foo<T>`, ok.
+/// //   ^ T appears in `Foo<T>`, ok.
 ///
 /// impl<T> Trait<Foo> for Bar where Bar: Iterator<Item=T> { ... }
-///      ^ T is bound to `<Bar as Iterator>::Item`, ok.
+/// //   ^ T is bound to `<Bar as Iterator>::Item`, ok.
 ///
 /// impl<'a> Trait<Foo> for Bar { }
-///      ^ 'a is unused, but for back-compat we allow it
+/// //   ^ 'a is unused, but for back-compat we allow it
 ///
 /// impl<'a> Trait<Foo> for Bar { type X = &'a i32; }
-///      ^ 'a is unused and appears in assoc type, error
+/// //   ^ 'a is unused and appears in assoc type, error
 /// ```
 pub fn impl_wf_check<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     // We will tag this as part of the WF check -- logically, it is,


### PR DESCRIPTION
Fixes #29893. Now that compiler documentation is being hosted, including private items seems sensible as these types are going to be being used by contributors working on the compiler. 

However, including this means that doc comments that contain codeblocks with invalid Rust and can fail the documenting of a given crate (as evidenced by the changes in the second commit included in this PR). We'd need some way of ensuring that this cannot happen so that these failures don't cause documenting to fail. I'm unsure whether this change to documentation steps will cause this to happen already or if something new will be required.

r? @alexcrichton 