### PR TITLE
Issue 48697 -- ICE in old borrowck mode

### DIFF
--- a/src/librustc_borrowck/borrowck/check_loans.rs
+++ b/src/librustc_borrowck/borrowck/check_loans.rs
@@ -417,11 +417,17 @@ impl<'a, 'tcx> CheckLoanCtxt<'a, 'tcx> {
             RegionKind::ReLateBound(..) |
             RegionKind::ReFree(..) |
             RegionKind::ReStatic => {
-                self.bccx
-                    .tcx
-                    .sess.delay_span_bug(borrow_span,
-                                         &format!("unexpected region for local data {:?}",
-                                                  loan_region));
+                if !self.bccx.tcx.nll() {
+                    self.bccx
+                        .tcx
+                        .sess.delay_span_bug(borrow_span,
+                                             &format!("unexpected region for local data {:?}",
+                                                      loan_region));
+                } else {
+                    // When in NLL mode, invalid region errors get
+                    // suppressed; it ought to be reported later, by
+                    // the NLL region analysis.
+                }
                 return
             }
 

--- a/src/librustc_mir/transform/elaborate_drops.rs
+++ b/src/librustc_mir/transform/elaborate_drops.rs
@@ -51,7 +51,13 @@ impl MirPass for ElaborateDrops {
             _ => return
         }
         let param_env = tcx.param_env(src.def_id);
-        let move_data = MoveData::gather_moves(mir, tcx).unwrap();
+        let move_data = match MoveData::gather_moves(mir, tcx) {
+            Ok(d) => d,
+            Err(_) => {
+                tcx.sess.delay_span_bug(mir.span, "ElaborateDrops: failed to gather move data");
+                return;
+            }
+        };
         let elaborate_patch = {
             let mir = &*mir;
             let env = MoveDataParamEnv {

--- a/src/test/ui/nll/issue-48697.rs
+++ b/src/test/ui/nll/issue-48697.rs
@@ -12,6 +12,8 @@
 // error that would otherwise cause AST borrowck to die.
 //
 // Regression test for #48697.
+//
+// run-pass
 
 #![feature(nll)]
 #![allow(warnings)]

--- a/src/test/ui/nll/issue-48697.rs
+++ b/src/test/ui/nll/issue-48697.rs
@@ -1,0 +1,26 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that we do not ICE when we have suppressed a lexical region
+// error that would otherwise cause AST borrowck to die.
+//
+// Regression test for #48697.
+
+#![feature(nll)]
+#![allow(warnings)]
+
+fn foo(x: &i32) -> &i32 {
+    let z = 4;
+    let f = &|y| { y };
+    let k = f(&z);
+    f(x)
+}
+
+fn main() {}

--- a/src/test/ui/nll/issue-48697.stderr
+++ b/src/test/ui/nll/issue-48697.stderr
@@ -1,0 +1,8 @@
+error: internal compiler error: unexpected region for local data ReFree(DefId(0/0:3 ~ issue_48697[317d]::foo[0]), BrAnon(0))
+  --> $DIR/issue-48697.rs:22:16
+   |
+LL |     let k = f(&z);
+   |                ^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
NLL can mask regionck failures, leading borrowck to get itself into surprising situations. Rather than ICE, just ignore that.

Fixes #48697 

r? @pnkfelix 