### PR TITLE
Fix another circular deps link args issue

### DIFF
--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -36,6 +36,7 @@ use llvm;
 use metadata;
 use rustc::hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use rustc::middle::lang_items::StartFnLangItem;
+use rustc::middle::weak_lang_items;
 use rustc::mir::mono::{Linkage, Visibility, Stats};
 use rustc::middle::cstore::{EncodedMetadata};
 use rustc::ty::{self, Ty, TyCtxt};
@@ -1137,6 +1138,13 @@ impl CrateInfo {
                     info.lang_item_to_crate.insert(item, id.krate);
                 }
             }
+
+            // No need to look for lang items that are whitelisted and don't
+            // actually need to exist.
+            let missing = missing.iter()
+                .cloned()
+                .filter(|&l| !weak_lang_items::whitelisted(tcx, l))
+                .collect();
             info.missing_lang_items.insert(cnum, missing);
         }
 

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -407,7 +407,7 @@ struct CrateInfo {
     wasm_custom_sections: BTreeMap<String, Vec<u8>>,
     wasm_imports: FxHashMap<String, String>,
     lang_item_to_crate: FxHashMap<LangItem, CrateNum>,
-    missing_lang_items: FxHashMap<CrateNum, Lrc<Vec<LangItem>>>,
+    missing_lang_items: FxHashMap<CrateNum, Vec<LangItem>>,
 }
 
 __build_diagnostic_array! { librustc_trans, DIAGNOSTICS }

--- a/src/test/run-make-fulldeps/std-core-cycle/Makefile
+++ b/src/test/run-make-fulldeps/std-core-cycle/Makefile
@@ -13,3 +13,4 @@ endif
 all:
 	$(RUSTC) bar.rs
 	$(RUSTC) foo.rs $(FLAGS)
+	$(RUSTC) foo.rs $(FLAGS) -C panic=abort


### PR DESCRIPTION
It turns out that the support in #49316 wasn't enough to handle all cases
notably the example in #48661. The underlying bug was connected to panic=abort
where lang items were listed in the `missing_lang_items` sets but didn't
actually exist anywhere.

This caused the linker backend to deduce that start-group/end-group wasn't
needed because not all items were defined. Instead the missing lang items that
don't actually need to have a definition are filtered out and not considered for
the start-group/end-group arguments

Closes #48661