### PR TITLE
Correct a few stability attributes

### DIFF
--- a/src/libcore/ascii.rs
+++ b/src/libcore/ascii.rs
@@ -31,7 +31,7 @@ use iter::FusedIterator;
 /// documentation for more.
 ///
 /// [`escape_default`]: fn.escape_default.html
-#[stable(feature = "core_ascii", since = "1.26.0")]
+#[stable(feature = "rust1", since = "1.0.0")]
 pub struct EscapeDefault {
     range: Range<usize>,
     data: [u8; 4],
@@ -99,7 +99,7 @@ pub struct EscapeDefault {
 /// assert_eq!(b'9', escaped.next().unwrap());
 /// assert_eq!(b'd', escaped.next().unwrap());
 /// ```
-#[stable(feature = "core_ascii", since = "1.26.0")]
+#[stable(feature = "rust1", since = "1.0.0")]
 pub fn escape_default(c: u8) -> EscapeDefault {
     let (data, len) = match c {
         b'\t' => ([b'\\', b't', 0, 0], 2),

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -200,7 +200,7 @@ macro_rules! range_trusted_len_impl {
 
 macro_rules! range_incl_trusted_len_impl {
     ($($t:ty)*) => ($(
-        #[stable(feature = "inclusive_range", since = "1.26.0")]
+        #[unstable(feature = "trusted_len", issue = "37572")]
         unsafe impl TrustedLen for ops::RangeInclusive<$t> { }
     )*)
 }

--- a/src/libcore/panic.rs
+++ b/src/libcore/panic.rs
@@ -120,6 +120,7 @@ impl<'a> PanicInfo<'a> {
     }
 }
 
+#[stable(feature = "panic_hook_display", since = "1.26.0")]
 impl<'a> fmt::Display for PanicInfo<'a> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("panicked at ")?;
@@ -244,6 +245,7 @@ impl<'a> Location<'a> {
     }
 }
 
+#[stable(feature = "panic_hook_display", since = "1.26.0")]
 impl<'a> fmt::Display for Location<'a> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "{}:{}:{}", self.file, self.line, self.col)

--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -723,10 +723,10 @@ pub fn args_os() -> ArgsOs {
     ArgsOs { inner: sys::args::args() }
 }
 
-#[stable(feature = "env_unimpl_send_sync", since = "1.25.0")]
+#[stable(feature = "env_unimpl_send_sync", since = "1.26.0")]
 impl !Send for Args {}
 
-#[stable(feature = "env_unimpl_send_sync", since = "1.25.0")]
+#[stable(feature = "env_unimpl_send_sync", since = "1.26.0")]
 impl !Sync for Args {}
 
 #[stable(feature = "env", since = "1.0.0")]
@@ -760,10 +760,10 @@ impl fmt::Debug for Args {
     }
 }
 
-#[stable(feature = "env_unimpl_send_sync", since = "1.25.0")]
+#[stable(feature = "env_unimpl_send_sync", since = "1.26.0")]
 impl !Send for ArgsOs {}
 
-#[stable(feature = "env_unimpl_send_sync", since = "1.25.0")]
+#[stable(feature = "env_unimpl_send_sync", since = "1.26.0")]
 impl !Sync for ArgsOs {}
 
 #[stable(feature = "env", since = "1.0.0")]

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -483,7 +483,7 @@ declare_features! (
     // allow empty structs and enum variants with braces
     (accepted, braced_empty_structs, "1.8.0", Some(29720), None),
     // Allows indexing into constant arrays.
-    (accepted, const_indexing, "1.24.0", Some(29947), None),
+    (accepted, const_indexing, "1.26.0", Some(29947), None),
     (accepted, default_type_params, "1.0.0", None, None),
     (accepted, globs, "1.0.0", None, None),
     (accepted, if_let, "1.0.0", None, None),


### PR DESCRIPTION
* `const_indexing` language feature was stabilized in 1.26.0 by #46882
* `Display` impls for `PanicInfo` and `Location` were stabilized in 1.26.0 by #47687
* `TrustedLen` is still unstable so its impls should be as well even though `RangeInclusive` was stabilized by #47813
* `!Send` and `!Sync` for `Args` and `ArgsOs` were stabilized in 1.26.0 by #48005
* `EscapeDefault` has been stable since 1.0.0 so should continue to show that even though it was moved to core in #48735

This could be backported to beta like #49612