### PR TITLE
Don't use underscores in argument names for derive output

### DIFF
--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -156,14 +156,14 @@
 //!
 //! ```{.text}
 //! EnumNonMatchingCollapsed(
-//!     vec![<ident of self>, <ident of __arg_1>],
+//!     vec![<ident of self>, <ident of arg_1>],
 //!     &[<ast::Variant for C0>, <ast::Variant for C1>],
-//!     &[<ident for self index value>, <ident of __arg_1 index value>])
+//!     &[<ident for self index value>, <ident of arg_1 index value>])
 //! ```
 //!
 //! It is the same for when the arguments are flipped to `C1 {x}` and
 //! `C0(a)`; the only difference is what the values of the identifiers
-//! <ident for self index value> and <ident of __arg_1 index value> will
+//! <ident for self index value> and <ident of arg_1 index value> will
 //! be in the generated code.
 //!
 //! `EnumNonMatchingCollapsed` deliberately provides far less information
@@ -912,7 +912,7 @@ impl<'a> MethodDef<'a> {
 
         for (i, ty) in self.args.iter().enumerate() {
             let ast_ty = ty.to_ty(cx, trait_.span, type_ident, generics);
-            let ident = cx.ident_of(&format!("__arg_{}", i));
+            let ident = cx.ident_of(&format!("arg_{}", i));
             arg_tys.push((ident, ast_ty));
 
             let arg_expr = cx.expr_ident(trait_.span, ident);
@@ -999,10 +999,10 @@ impl<'a> MethodDef<'a> {
     ///
     /// // equivalent to:
     /// impl PartialEq for A {
-    ///     fn eq(&self, __arg_1: &A) -> bool {
+    ///     fn eq(&self, arg_1: &A) -> bool {
     ///         match *self {
     ///             A {x: ref __self_0_0, y: ref __self_0_1} => {
-    ///                 match *__arg_1 {
+    ///                 match *arg_1 {
     ///                     A {x: ref __self_1_0, y: ref __self_1_1} => {
     ///                         __self_0_0.eq(__self_1_0) && __self_0_1.eq(__self_1_1)
     ///                     }
@@ -1015,10 +1015,10 @@ impl<'a> MethodDef<'a> {
     /// // or if A is repr(packed) - note fields are matched by-value
     /// // instead of by-reference.
     /// impl PartialEq for A {
-    ///     fn eq(&self, __arg_1: &A) -> bool {
+    ///     fn eq(&self, arg_1: &A) -> bool {
     ///         match *self {
     ///             A {x: __self_0_0, y: __self_0_1} => {
-    ///                 match __arg_1 {
+    ///                 match arg_1 {
     ///                     A {x: __self_1_0, y: __self_1_1} => {
     ///                         __self_0_0.eq(&__self_1_0) && __self_0_1.eq(&__self_1_1)
     ///                     }
@@ -1129,14 +1129,14 @@ impl<'a> MethodDef<'a> {
     /// // is equivalent to
     ///
     /// impl PartialEq for A {
-    ///     fn eq(&self, __arg_1: &A) -> ::bool {
-    ///         match (&*self, &*__arg_1) {
+    ///     fn eq(&self, arg_1: &A) -> ::bool {
+    ///         match (&*self, &*arg_1) {
     ///             (&A1, &A1) => true,
     ///             (&A2(ref self_0),
-    ///              &A2(ref __arg_1_0)) => (*self_0).eq(&(*__arg_1_0)),
+    ///              &A2(ref arg_1_0)) => (*self_0).eq(&(*arg_1_0)),
     ///             _ => {
     ///                 let __self_vi = match *self { A1(..) => 0, A2(..) => 1 };
-    ///                 let __arg_1_vi = match *__arg_1 { A1(..) => 0, A2(..) => 1 };
+    ///                 let arg_1_vi = match *arg_1 { A1(..) => 0, A2(..) => 1 };
     ///                 false
     ///             }
     ///         }
@@ -1144,10 +1144,10 @@ impl<'a> MethodDef<'a> {
     /// }
     /// ```
     ///
-    /// (Of course `__self_vi` and `__arg_1_vi` are unused for
+    /// (Of course `__self_vi` and `arg_1_vi` are unused for
     /// `PartialEq`, and those subcomputations will hopefully be removed
     /// as their results are unused.  The point of `__self_vi` and
-    /// `__arg_1_vi` is for `PartialOrd`; see #15503.)
+    /// `arg_1_vi` is for `PartialOrd`; see #15503.)
     fn expand_enum_method_body<'b>(&self,
                                    cx: &mut ExtCtxt,
                                    trait_: &TraitDef<'b>,
@@ -1220,7 +1220,7 @@ impl<'a> MethodDef<'a> {
                 if arg_count == 0 {
                     "__self".to_string()
                 } else {
-                    format!("__arg_{}", arg_count)
+                    format!("arg_{}", arg_count)
                 }
             })
             .collect::<Vec<String>>();
@@ -1442,7 +1442,7 @@ impl<'a> MethodDef<'a> {
             // down to desired places, but we cannot actually deref
             // them when they are fed as r-values into a tuple
             // expression; here add a layer of borrowing, turning
-            // `(*self, *__arg_0, ...)` into `(&*self, &*__arg_0, ...)`.
+            // `(*self, *arg_0, ...)` into `(&*self, &*arg_0, ...)`.
             let borrowed_self_args = self_args.move_map(|self_arg| cx.expr_addr_of(sp, self_arg));
             let match_arg = cx.expr(sp, ast::ExprKind::Tup(borrowed_self_args));
 
@@ -1481,7 +1481,7 @@ impl<'a> MethodDef<'a> {
             // generate code like this:
             //
             //     _ => { let __self0 = match *self { };
-            //            let __self1 = match *__arg_0 { };
+            //            let __self1 = match *arg_0 { };
             //            <catch-all-expr> }
             //
             // Which is yields bindings for variables which type
@@ -1519,7 +1519,7 @@ impl<'a> MethodDef<'a> {
             // down to desired places, but we cannot actually deref
             // them when they are fed as r-values into a tuple
             // expression; here add a layer of borrowing, turning
-            // `(*self, *__arg_0, ...)` into `(&*self, &*__arg_0, ...)`.
+            // `(*self, *arg_0, ...)` into `(&*self, &*arg_0, ...)`.
             let borrowed_self_args = self_args.move_map(|self_arg| cx.expr_addr_of(sp, self_arg));
             let match_arg = cx.expr(sp, ast::ExprKind::Tup(borrowed_self_args));
             cx.expr_match(sp, match_arg, match_arms)
@@ -1720,8 +1720,8 @@ pub fn cs_fold<F>(use_foldl: bool,
 /// process the collected results. i.e.
 ///
 /// ```ignore (only-for-syntax-highlight)
-/// f(cx, span, vec![self_1.method(__arg_1_1, __arg_2_1),
-///                  self_2.method(__arg_1_2, __arg_2_2)])
+/// f(cx, span, vec![self_1.method(arg_1_1, arg_2_1),
+///                  self_2.method(arg_1_2, arg_2_2)])
 /// ```
 #[inline]
 pub fn cs_same_method<F>(f: F,

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -560,7 +560,7 @@ impl<'a, 'b> Context<'a, 'b> {
         // of each variable because we don't want to move out of the arguments
         // passed to this function.
         for (i, e) in self.args.into_iter().enumerate() {
-            let name = self.ecx.ident_of(&format!("__arg{}", i));
+            let name = self.ecx.ident_of(&format!("arg{}", i));
             let span =
                 DUMMY_SP.with_ctxt(e.span.ctxt().apply_mark(self.ecx.current_expansion.mark));
             pats.push(self.ecx.pat_ident(span, name));
@@ -571,7 +571,7 @@ impl<'a, 'b> Context<'a, 'b> {
         }
         for pos in self.count_args {
             let name = self.ecx.ident_of(&match pos {
-                Exact(i) => format!("__arg{}", i),
+                Exact(i) => format!("arg{}", i),
                 _ => panic!("should never happen"),
             });
             let span = match pos {


### PR DESCRIPTION
Currently in the docs `#[derive()]`d functions show up with arguments like `__arg0`, `__arg1`, etc.

Ideally they'd have descriptive names set by the derive, but for now I'd just like to remove the underscores.

The underscores exist so that the `unused_variable` lint isn't triggered, but there's a simpler solution there -- don't run that pass for these functions.


In a followup I'll make it possible for consumers of the builtin derive helpers to specify argument names; or teach rust/rustdoc to scrape them off the trait.


r? @jseyfried @eddyb

cc @QuietMisdreavus