### PR TITLE
two-phase borrows: support multiple activations in one statement

### DIFF
--- a/src/test/ui/borrowck/two-phase-multi-mut.rs
+++ b/src/test/ui/borrowck/two-phase-multi-mut.rs
@@ -1,0 +1,26 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(nll)]
+
+struct Foo {
+}
+
+impl Foo {
+    fn method(&mut self, foo: &mut Foo) {
+    }
+}
+
+fn main() {
+    let mut foo = Foo { };
+    foo.method(&mut foo);
+    //~^     cannot borrow `foo` as mutable more than once at a time
+    //~^^    cannot borrow `foo` as mutable more than once at a time
+}

--- a/src/test/ui/borrowck/two-phase-multi-mut.stderr
+++ b/src/test/ui/borrowck/two-phase-multi-mut.stderr
@@ -1,0 +1,23 @@
+error[E0499]: cannot borrow `foo` as mutable more than once at a time
+  --> $DIR/two-phase-multi-mut.rs:23:16
+   |
+LL |     foo.method(&mut foo);
+   |     -----------^^^^^^^^-
+   |     |          |
+   |     |          second mutable borrow occurs here
+   |     first mutable borrow occurs here
+   |     borrow later used here
+
+error[E0499]: cannot borrow `foo` as mutable more than once at a time
+  --> $DIR/two-phase-multi-mut.rs:23:5
+   |
+LL |     foo.method(&mut foo);
+   |     ^^^^^^^^^^^--------^
+   |     |          |
+   |     |          first mutable borrow occurs here
+   |     second mutable borrow occurs here
+   |     borrow later used here
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0499`.

--- a/src/test/ui/borrowck/two-phase-multiple-activations.rs
+++ b/src/test/ui/borrowck/two-phase-multiple-activations.rs
@@ -1,0 +1,35 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// revisions: lxl nll
+//[lxl]compile-flags: -Z borrowck=mir -Z two-phase-borrows
+//[nll]compile-flags: -Z borrowck=mir -Z two-phase-borrows -Z nll
+
+// run-pass
+
+use std::io::Result;
+
+struct Foo {}
+
+pub trait FakeRead {
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize>;
+}
+
+impl FakeRead for Foo {
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+        Ok(4)
+    }
+}
+
+fn main() {
+    let mut a = Foo {};
+    let mut v = Vec::new();
+    a.read_to_end(&mut v);
+}


### PR DESCRIPTION
The need for this has arisen since the introduction of two-phase borrows on
method autorefs in #49348. r'ing @pnkfelix to keep things off Niko's plate so he can make this redundant, and @pnkfelix is familiar with the code.

Fixes #49635 
Fixes #49662

r? @pnkfelix