### PR TITLE
Fix ICE with `main`'s return type containing lifetimes

### DIFF
--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -212,8 +212,6 @@ use monomorphize::item::{MonoItemExt, DefPathBasedNames, InstantiationMode};
 
 use rustc_data_structures::bitvec::BitVector;
 
-use std::iter;
-
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
 pub enum MonoItemCollectionMode {
     Eager,
@@ -1030,13 +1028,15 @@ impl<'b, 'a, 'v> RootCollector<'b, 'a, 'v> {
         // late-bound regions, since late-bound
         // regions must appear in the argument
         // listing.
-        let main_ret_ty = main_ret_ty.no_late_bound_regions().unwrap();
+        let main_ret_ty = self.tcx.erase_regions(
+            &main_ret_ty.no_late_bound_regions().unwrap(),
+        );
 
         let start_instance = Instance::resolve(
             self.tcx,
             ty::ParamEnv::reveal_all(),
             start_def_id,
-            self.tcx.mk_substs(iter::once(Kind::from(main_ret_ty)))
+            self.tcx.intern_substs(&[Kind::from(main_ret_ty)])
         ).unwrap();
 
         self.output.push(create_fn_mono_item(start_instance));

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -82,7 +82,6 @@ use std::str;
 use std::sync::Arc;
 use std::time::{Instant, Duration};
 use std::{i32, usize};
-use std::iter;
 use std::sync::mpsc;
 use syntax_pos::Span;
 use syntax_pos::symbol::InternedString;
@@ -553,7 +552,9 @@ fn maybe_create_entry_wrapper(cx: &CodegenCx) {
         // late-bound regions, since late-bound
         // regions must appear in the argument
         // listing.
-        let main_ret_ty = main_ret_ty.no_late_bound_regions().unwrap();
+        let main_ret_ty = cx.tcx.erase_regions(
+            &main_ret_ty.no_late_bound_regions().unwrap(),
+        );
 
         if declare::get_defined_value(cx, "main").is_some() {
             // FIXME: We should be smart and show a better diagnostic here.
@@ -580,8 +581,11 @@ fn maybe_create_entry_wrapper(cx: &CodegenCx) {
 
         let (start_fn, args) = if use_start_lang_item {
             let start_def_id = cx.tcx.require_lang_item(StartFnLangItem);
-            let start_fn = callee::resolve_and_get_fn(cx, start_def_id, cx.tcx.mk_substs(
-                iter::once(Kind::from(main_ret_ty))));
+            let start_fn = callee::resolve_and_get_fn(
+                cx,
+                start_def_id,
+                cx.tcx.intern_substs(&[Kind::from(main_ret_ty)]),
+            );
             (start_fn, vec![bx.pointercast(rust_main, Type::i8p(cx).ptr_to()),
                             arg_argc, arg_argv])
         } else {

--- a/src/test/run-fail/rfc-1937-termination-trait/termination-trait-for-box-dyn-error.rs
+++ b/src/test/run-fail/rfc-1937-termination-trait/termination-trait-for-box-dyn-error.rs
@@ -1,0 +1,21 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// must-compile-successfully
+// failure-status: 1
+
+#![feature(dyn_trait)]
+
+use std::error::Error;
+use std::io;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    Err(Box::new(io::Error::new(io::ErrorKind::Other, "returned Box<dyn Error> from main()")))
+}

--- a/src/test/run-fail/rfc-1937-termination-trait/termination-trait-for-str.rs
+++ b/src/test/run-fail/rfc-1937-termination-trait/termination-trait-for-str.rs
@@ -1,0 +1,15 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: An error message for you
+
+fn main() -> Result<(), &'static str> {
+    Err("An error message for you")
+}

--- a/src/test/run-fail/rfc-1937-termination-trait/termination-trait-for-str.rs
+++ b/src/test/run-fail/rfc-1937-termination-trait/termination-trait-for-str.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // error-pattern: An error message for you
+// failure-status: 1
 
 fn main() -> Result<(), &'static str> {
     Err("An error message for you")

--- a/src/test/run-pass/rfc-1937-termination-trait/termination-trait-for-box-dyn-error.rs
+++ b/src/test/run-pass/rfc-1937-termination-trait/termination-trait-for-box-dyn-error.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(dyn_trait)]
+
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    Ok(())
+}

--- a/src/test/run-pass/rfc-1937-termination-trait/termination-trait-for-str.rs
+++ b/src/test/run-pass/rfc-1937-termination-trait/termination-trait-for-str.rs
@@ -1,0 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() -> Result<(), &'static str> {
+    Ok(())
+}


### PR DESCRIPTION
Fixes #48890