### PR TITLE
std: Inline some Termination-related methods

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1452,6 +1452,7 @@ pub trait Termination {
 
 #[unstable(feature = "termination_trait_lib", issue = "43301")]
 impl Termination for () {
+    #[inline]
     fn report(self) -> i32 { ExitCode::SUCCESS.report() }
 }
 
@@ -1481,6 +1482,7 @@ impl<E: fmt::Debug> Termination for Result<!, E> {
 
 #[unstable(feature = "termination_trait_lib", issue = "43301")]
 impl Termination for ExitCode {
+    #[inline]
     fn report(self) -> i32 {
         self.0.as_i32()
     }

--- a/src/libstd/sys/unix/process/process_common.rs
+++ b/src/libstd/sys/unix/process/process_common.rs
@@ -404,6 +404,7 @@ impl ExitCode {
     pub const SUCCESS: ExitCode = ExitCode(EXIT_SUCCESS as _);
     pub const FAILURE: ExitCode = ExitCode(EXIT_FAILURE as _);
 
+    #[inline]
     pub fn as_i32(&self) -> i32 {
         self.0 as i32
     }

--- a/src/libstd/sys/windows/process.rs
+++ b/src/libstd/sys/windows/process.rs
@@ -414,6 +414,7 @@ impl ExitCode {
     pub const SUCCESS: ExitCode = ExitCode(EXIT_SUCCESS as _);
     pub const FAILURE: ExitCode = ExitCode(EXIT_FAILURE as _);
 
+    #[inline]
     pub fn as_i32(&self) -> i32 {
         self.0 as i32
     }


### PR DESCRIPTION
These were showing up in tests and in binaries but are trivially optimize-able
away, so add `#[inline]` attributes so LLVM has an opportunity to optimize them
out.