### PR TITLE
Filter out missing components from manifests

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -356,6 +356,28 @@ impl Builder {
                 target: "*".to_string(),
             });
 
+            // If the components/extensions don't actually exist for this
+            // particular host/target combination then nix it entirely from our
+            // lists.
+            {
+                let has_component = |c: &Component| {
+                    if c.target == "*" {
+                        return true
+                    }
+                    let pkg = match manifest.pkg.get(&c.pkg) {
+                        Some(p) => p,
+                        None => return false,
+                    };
+                    let target = match pkg.target.get(&c.target) {
+                        Some(t) => t,
+                        None => return false,
+                    };
+                    target.available
+                };
+                extensions.retain(&has_component);
+                components.retain(&has_component);
+            }
+
             pkg.target.insert(host.to_string(), Target {
                 available: true,
                 url: Some(self.url(&filename)),


### PR DESCRIPTION
This commit updates our manifest generation for rustup to filter out any
components/extensions which are actually missing. This is intended to help
mitigate #49462 by making the manifests reflect reality, that many targets now
are missing a `rust-docs` component rather than requiring it exists.