### PR TITLE
mem-categorization, coherence fix

### DIFF
--- a/src/test/ui/issue-48728.rs
+++ b/src/test/ui/issue-48728.rs
@@ -1,0 +1,23 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for #48728, an ICE that occurred computing
+// coherence "help" information.
+
+#[derive(Clone)] //~ ERROR conflicting implementations of trait `std::clone::Clone`
+struct Node<T: ?Sized>(Box<T>);
+
+impl<T: Clone + ?Sized> Clone for Node<[T]> {
+    fn clone(&self) -> Self {
+        Node(Box::clone(&self.0))
+    }
+}
+
+fn main() {}

--- a/src/test/ui/issue-48728.stderr
+++ b/src/test/ui/issue-48728.stderr
@@ -1,0 +1,12 @@
+error[E0119]: conflicting implementations of trait `std::clone::Clone` for type `Node<[_]>`:
+  --> $DIR/issue-48728.rs:14:10
+   |
+LL | #[derive(Clone)] //~ ERROR conflicting implementations of trait `std::clone::Clone`
+   |          ^^^^^ conflicting implementation for `Node<[_]>`
+...
+LL | impl<T: Clone + ?Sized> Clone for Node<[T]> {
+   | ------------------------------------------- first implementation here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0119`.

--- a/src/test/ui/rfc-2005-default-binding-mode/borrowck-issue-49631.rs
+++ b/src/test/ui/rfc-2005-default-binding-mode/borrowck-issue-49631.rs
@@ -1,0 +1,34 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct Foo {
+}
+
+impl Foo {
+    fn get(&self) -> Option<&Result<String, String>> {
+        None
+    }
+
+    fn mutate(&mut self) { }
+}
+
+fn main() {
+    let mut foo = Foo { };
+
+    // foo.get() returns type Option<&Result<String, String>>, so
+    // using `string` keeps borrow of `foo` alive. Hence calling
+    // `foo.mutate()` should be an error.
+    while let Some(Ok(string)) = foo.get() {
+        foo.mutate();
+        //~^ ERROR cannot borrow `foo` as mutable
+        println!("foo={:?}", *string);
+    }
+}

--- a/src/test/ui/rfc-2005-default-binding-mode/borrowck-issue-49631.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/borrowck-issue-49631.stderr
@@ -1,0 +1,13 @@
+error[E0502]: cannot borrow `foo` as mutable because it is also borrowed as immutable
+  --> $DIR/borrowck-issue-49631.rs:30:9
+   |
+LL |     while let Some(Ok(string)) = foo.get() {
+   |                                  ---     - immutable borrow ends here
+   |                                  |
+   |                                  immutable borrow occurs here
+LL |         foo.mutate();
+   |         ^^^ mutable borrow occurs here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0502`.


### PR DESCRIPTION
make mem-categorization use adjusted type for patterns: Fixes #49631 

do not propagate `Err` when determing causal info: Fixes #48728 

r? @eddyb 