### PR TITLE
add emit_debug_gdb_scripts target option and ..

### DIFF
--- a/src/librustc_back/target/apple_base.rs
+++ b/src/librustc_back/target/apple_base.rs
@@ -47,6 +47,7 @@ pub fn opts() -> TargetOptions {
         exe_allocation_crate: super::maybe_jemalloc(),
         has_elf_tls: version >= (10, 7),
         abi_return_struct_as_int: true,
+        emit_debug_gdb_scripts: false,
         .. Default::default()
     }
 }

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -478,6 +478,9 @@ pub struct TargetOptions {
 
     /// Whether or not bitcode is embedded in object files
     pub embed_bitcode: bool,
+
+    /// Whether a .debug_gdb_scripts section will be added to the output object file
+    pub emit_debug_gdb_scripts: bool,
 }
 
 impl Default for TargetOptions {
@@ -550,6 +553,7 @@ impl Default for TargetOptions {
             codegen_backend: "llvm".to_string(),
             default_hidden_visibility: false,
             embed_bitcode: false,
+            emit_debug_gdb_scripts: true,
         }
     }
 }
@@ -799,6 +803,7 @@ impl Target {
         key!(codegen_backend);
         key!(default_hidden_visibility, bool);
         key!(embed_bitcode, bool);
+        key!(emit_debug_gdb_scripts, bool);
 
         if let Some(array) = obj.find("abi-blacklist").and_then(Json::as_array) {
             for name in array.iter().filter_map(|abi| abi.as_string()) {
@@ -1002,6 +1007,7 @@ impl ToJson for Target {
         target_option_val!(codegen_backend);
         target_option_val!(default_hidden_visibility);
         target_option_val!(embed_bitcode);
+        target_option_val!(emit_debug_gdb_scripts);
 
         if default.abi_blacklist != self.options.abi_blacklist {
             d.insert("abi-blacklist".to_string(), self.options.abi_blacklist.iter()

--- a/src/librustc_back/target/msp430_none_elf.rs
+++ b/src/librustc_back/target/msp430_none_elf.rs
@@ -59,6 +59,9 @@ pub fn target() -> TargetResult {
             // too much overhead for such small target.
             trap_unreachable: false,
 
+            // See the thumb_base.rs file for an explanation of this value
+            emit_debug_gdb_scripts: false,
+
             .. Default::default( )
         }
     })

--- a/src/librustc_back/target/thumb_base.rs
+++ b/src/librustc_back/target/thumb_base.rs
@@ -53,6 +53,13 @@ pub fn opts() -> TargetOptions {
         // costs it involves.
         relocation_model: "static".to_string(),
         abi_blacklist: super::arm_base::abi_blacklist(),
+        // When this section is added a volatile load to its start address is also generated. This
+        // volatile load is a footgun as it can end up loading an invalid memory address, depending
+        // on how the user set up their linker scripts. This section adds pretty printer for stuff
+        // like std::Vec, which is not that used in no-std context, so it's best to left it out
+        // until we figure a way to add the pretty printers without requiring a volatile load cf.
+        // rust-lang/rust#44993.
+        emit_debug_gdb_scripts: false,
         .. Default::default()
     }
 }

--- a/src/librustc_back/target/windows_base.rs
+++ b/src/librustc_back/target/windows_base.rs
@@ -102,6 +102,7 @@ pub fn opts() -> TargetOptions {
         ],
         custom_unwind_resume: true,
         abi_return_struct_as_int: true,
+        emit_debug_gdb_scripts: false,
 
         .. Default::default()
     }

--- a/src/librustc_back/target/windows_msvc_base.rs
+++ b/src/librustc_back/target/windows_msvc_base.rs
@@ -34,6 +34,7 @@ pub fn opts() -> TargetOptions {
         crt_static_allows_dylibs: true,
         crt_static_respected: true,
         abi_return_struct_as_int: true,
+        emit_debug_gdb_scripts: false,
 
         .. Default::default()
     }

--- a/src/librustc_trans/debuginfo/gdb.rs
+++ b/src/librustc_trans/debuginfo/gdb.rs
@@ -83,8 +83,6 @@ pub fn needs_gdb_debug_scripts_section(cx: &CodegenCx) -> bool {
                             "omit_gdb_pretty_printer_section");
 
     !omit_gdb_pretty_printer_section &&
-    !cx.sess().target.target.options.is_like_osx &&
-    !cx.sess().target.target.options.is_like_windows &&
     cx.sess().opts.debuginfo != NoDebugInfo &&
     cx.sess().target.target.options.emit_debug_gdb_scripts
 }

--- a/src/librustc_trans/debuginfo/gdb.rs
+++ b/src/librustc_trans/debuginfo/gdb.rs
@@ -85,5 +85,6 @@ pub fn needs_gdb_debug_scripts_section(cx: &CodegenCx) -> bool {
     !omit_gdb_pretty_printer_section &&
     !cx.sess().target.target.options.is_like_osx &&
     !cx.sess().target.target.options.is_like_windows &&
-    cx.sess().opts.debuginfo != NoDebugInfo
+    cx.sess().opts.debuginfo != NoDebugInfo &&
+    cx.sess().target.target.options.emit_debug_gdb_scripts
 }


### PR DESCRIPTION
set it to false for no-std targets like ARM Cortex-M and MSP430. For the rationale of this change see the comment in thumb_base.rs

this is a temporary workaround until #44993 is implemented

r? @alexcrichton or @michaelwoerister 