### PR TITLE
Fix ICE with impl Trait

### DIFF
--- a/src/librustc/infer/anon_types/mod.rs
+++ b/src/librustc/infer/anon_types/mod.rs
@@ -533,10 +533,14 @@ impl<'cx, 'gcx, 'tcx> TypeFolder<'gcx, 'tcx> for ReverseMapper<'cx, 'gcx, 'tcx> 
         match r {
             // ignore bound regions that appear in the type (e.g., this
             // would ignore `'r` in a type like `for<'r> fn(&'r u32)`.
-            ty::ReLateBound(..) => return r,
+            ty::ReLateBound(..) |
 
             // ignore `'static`, as that can appear anywhere
-            ty::ReStatic => return r,
+            ty::ReStatic |
+
+            // ignore `ReScope`, as that can appear anywhere
+            // See `src/test/run-pass/issue-49556.rs` for example.
+            ty::ReScope(..) => return r,
 
             _ => { }
         }

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -181,7 +181,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                 self.msg_span_from_early_bound_and_free_regions(region)
             },
             ty::ReStatic => ("the static lifetime".to_owned(), None),
-            _ => bug!(),
+            _ => bug!("{:?}", region),
         }
     }
 

--- a/src/test/run-pass/issue-49556.rs
+++ b/src/test/run-pass/issue-49556.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn iter<'a>(data: &'a [usize]) -> impl Iterator<Item = usize> + 'a {
+    data.iter()
+        .map(
+            |x| x // fn(&'a usize) -> &'(ReScope) usize
+        )
+        .map(
+            |x| *x // fn(&'(ReScope) usize) -> usize
+        )
+}
+
+fn main() {
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/49556#issuecomment-379154713. May or may not fix 49556 itself. Closures like `|x: &'a _| x` has `ClosureSubsts` of `fn(&'a _) -> &'(ReScope) _`, so `tcx.note_and_explain_free_region` (called [here](https://github.com/rust-lang/rust/blob/a143462783cec88b7b733e8aa09990bfeb59f754/src/librustc/infer/anon_types/mod.rs#L572)) panics.