### PR TITLE
Clarify the difference between get_mut and into_mut for OccupiedEntry

### DIFF
--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -2319,7 +2319,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// assert_eq!(map["poneyland"], 12);
     /// if let Entry::Occupied(mut o) = map.entry("poneyland") {
     ///     *o.get_mut() += 10;
-    ///     assert_eq!(o.get(), 22);
+    ///     assert_eq!(*o.get(), 22);
     ///
     ///     // We can use the same Entry multiple times.
     ///     *o.get_mut() += 2;

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -2318,10 +2318,14 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     ///
     /// assert_eq!(map["poneyland"], 12);
     /// if let Entry::Occupied(mut o) = map.entry("poneyland") {
-    ///      *o.get_mut() += 10;
+    ///     *o.get_mut() += 10;
+    ///     assert_eq!(o.get(), 22);
+    ///
+    ///     // We can use the same Entry multiple times.
+    ///     *o.get_mut() += 2;
     /// }
     ///
-    /// assert_eq!(map["poneyland"], 22);
+    /// assert_eq!(map["poneyland"], 24);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn get_mut(&mut self) -> &mut V {


### PR DESCRIPTION
The examples for both `hash_map::OccupiedEntry::get_mut` and
`hash_map::OccupiedEntry::into_mut` were almost identical. This led
to some confusion over the difference, namely why you would ever
use `get_mut` when `into_mut` gives a longer lifetime. Reddit thread:
https://www.reddit.com/r/rust/comments/8a5swr/why_does_hashmaps

This commit adds two lines and a comment to the example, to show
that the entry object can be re-used after calling `get_mut`.

I'm open to alternate ways to modify these examples.