### PR TITLE
Rewrite docs for `std::ptr`

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -992,11 +992,11 @@ extern "rust-intrinsic" {
     ///
     /// * The two regions of memory must *not* overlap.
     ///
-    /// Additionally, if `T` is not [`Copy`](../marker/trait.Copy), only the
-    /// region at `src` *or* the region at `dst` can be used or dropped after
-    /// calling `copy_nonoverlapping`.  `copy_nonoverlapping` creates bitwise
-    /// copies of `T`, regardless of whether `T: Copy`, which can result in
-    /// undefined behavior if both copies are used.
+    /// Additionally, if `T` is not [`Copy`](../marker/trait.Copy.html), only
+    /// the region at `src` *or* the region at `dst` can be used or dropped
+    /// after calling `copy_nonoverlapping`.  `copy_nonoverlapping` creates
+    /// bitwise copies of `T`, regardless of whether `T: Copy`, which can result
+    /// in undefined behavior if both copies are used.
     ///
     /// # Examples
     ///
@@ -1043,7 +1043,7 @@ extern "rust-intrinsic" {
     /// assert!(b.is_empty());
     /// ```
     ///
-    /// [`Vec::append()`]: ../vec/struct.Vec.html#method.append
+    /// [`Vec::append`]: ../../std/vec/struct.Vec.html#method.append
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
 

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -975,7 +975,7 @@ extern "rust-intrinsic" {
     /// The caller must ensure that `src` points to a valid sequence of type
     /// `T`.
     ///
-    /// # [Undefined Behavior]
+    /// # Undefined Behavior
     ///
     /// Behavior is undefined if any of the following conditions are violated:
     ///
@@ -997,8 +997,6 @@ extern "rust-intrinsic" {
     /// calling `copy_nonoverlapping`.  `copy_nonoverlapping` creates bitwise
     /// copies of `T`, regardless of whether `T: Copy`, which can result in
     /// undefined behavior if both copies are used.
-    ///
-    /// [Undefined Behavior]: ../../reference/behavior-considered-undefined.html
     ///
     /// # Examples
     ///
@@ -1065,7 +1063,7 @@ extern "rust-intrinsic" {
     /// `copy` is unsafe because it dereferences a raw pointer. The caller must
     /// ensure that `src` points to a valid sequence of type `T`.
     ///
-    /// # [Undefined Behavior]
+    /// # Undefined Behavior
     ///
     /// Behavior is undefined if any of the following conditions are violated:
     ///
@@ -1086,7 +1084,6 @@ extern "rust-intrinsic" {
     /// can result in undefined behavior if both copies are used.
     ///
     /// [`Copy`]: ../marker/trait.Copy.html
-    /// [Undefined Behavior]: ../../reference/behavior-considered-undefined.html
     ///
     /// # Examples
     ///
@@ -1118,7 +1115,7 @@ extern "rust-intrinsic" {
     /// `write_bytes` is unsafe because it dereferences a raw pointer. The
     /// caller must ensure that the poiinter points to a valid value of type `T`.
     ///
-    /// # [Undefined Behavior]
+    /// # Undefined Behavior
     ///
     /// Behavior is undefined if any of the following conditions are violated:
     ///

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -959,59 +959,134 @@ extern "rust-intrinsic" {
     /// value is not necessarily valid to be used to actually access memory.
     pub fn arith_offset<T>(dst: *const T, offset: isize) -> *const T;
 
-    /// Copies `count * size_of<T>` bytes from `src` to `dst`. The source
-    /// and destination may *not* overlap.
+    /// Copies `count * size_of::<T>()` bytes from `src` to `dst`. The source
+    /// and destination must *not* overlap.
     ///
-    /// `copy_nonoverlapping` is semantically equivalent to C's `memcpy`.
+    /// For regions of memory which might overlap, use [`copy`] instead.
+    ///
+    /// `copy_nonoverlapping` is semantically equivalent to C's [`memcpy`].
+    ///
+    /// [`copy`]: ./fn.copy.html
+    /// [`memcpy`]: https://www.gnu.org/software/libc/manual/html_node/Copying-Strings-and-Arrays.html#index-memcpy
     ///
     /// # Safety
     ///
-    /// Beyond requiring that the program must be allowed to access both regions
-    /// of memory, it is Undefined Behavior for source and destination to
-    /// overlap. Care must also be taken with the ownership of `src` and
-    /// `dst`. This method semantically moves the values of `src` into `dst`.
-    /// However it does not drop the contents of `dst`, or prevent the contents
-    /// of `src` from being dropped or used.
+    /// `copy_nonoverlapping` is unsafe because it dereferences a raw pointer.
+    /// The caller must ensure that `src` points to a valid sequence of type
+    /// `T`.
+    ///
+    /// # [Undefined Behavior]
+    ///
+    /// Behavior is undefined if any of the following conditions are violated:
+    ///
+    /// * The region of memory which begins at `src` and has a length of
+    ///   `count * size_of::<T>()` bytes must be *both* valid and initialized.
+    ///
+    /// * The region of memory which begins at `dst` and has a length of
+    ///   `count * size_of::<T>()` bytes must be valid (but may or may not be
+    ///   initialized).
+    ///
+    /// * `src` must be properly aligned.
+    ///
+    /// * `dst` must be properly aligned.
+    ///
+    /// * The two regions of memory must *not* overlap.
+    ///
+    /// Additionally, if `T` is not [`Copy`](../marker/trait.Copy), only the region at `src` *or* the
+    /// region at `dst` can be used or dropped after calling
+    /// `copy_nonoverlapping`. `copy_nonoverlapping` creates bitwise copies of
+    /// `T`, regardless of whether `T: Copy`, which can result in undefined
+    /// behavior if both copies are used.
+    ///
+    /// [Undefined Behavior]: ../../reference/behavior-considered-undefined.html
     ///
     /// # Examples
     ///
-    /// A safe swap function:
+    /// Manually implement [`Vec::append`]:
     ///
     /// ```
-    /// use std::mem;
     /// use std::ptr;
     ///
-    /// # #[allow(dead_code)]
-    /// fn swap<T>(x: &mut T, y: &mut T) {
+    /// /// Moves all the elements of `src` into `dst`, leaving `src` empty.
+    /// fn append<T>(dst: &mut Vec<T>, src: &mut Vec<T>) {
+    ///     let src_len = src.len();
+    ///     let dst_len = dst.len();
+    ///
+    ///     // Ensure that `dst` has enough capacity to hold all of `src`.
+    ///     dst.reserve(src_len);
+    ///
     ///     unsafe {
-    ///         // Give ourselves some scratch space to work with
-    ///         let mut t: T = mem::uninitialized();
+    ///         // The call to offset is always safe because `Vec` will never
+    ///         // allocate more than `isize::MAX` bytes.
+    ///         let dst = dst.as_mut_ptr().offset(dst_len as isize);
+    ///         let src = src.as_ptr();
     ///
-    ///         // Perform the swap, `&mut` pointers never alias
-    ///         ptr::copy_nonoverlapping(x, &mut t, 1);
-    ///         ptr::copy_nonoverlapping(y, x, 1);
-    ///         ptr::copy_nonoverlapping(&t, y, 1);
+    ///         // The two regions cannot overlap becuase mutable references do
+    ///         // not alias, and two different vectors cannot own the same
+    ///         // memory.
+    ///         ptr::copy_nonoverlapping(src, dst, src_len);
+    ///     }
     ///
-    ///         // y and t now point to the same thing, but we need to completely forget `t`
-    ///         // because it's no longer relevant.
-    ///         mem::forget(t);
+    ///     unsafe {
+    ///         // Truncate `src` without dropping its contents.
+    ///         src.set_len(0);
+    ///
+    ///         // Notify `dst` that it now holds the contents of `src`.
+    ///         dst.set_len(dst_len + src_len);
     ///     }
     /// }
+    ///
+    /// let mut a = vec!['r'];
+    /// let mut b = vec!['u', 's', 't'];
+    ///
+    /// append(&mut a, &mut b);
+    ///
+    /// assert_eq!(a, &['r', 'u', 's', 't']);
+    /// assert!(b.is_empty());
     /// ```
+    ///
+    /// [`Vec::append()`]: ../vec/struct.Vec.html#method.append
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
 
-    /// Copies `count * size_of<T>` bytes from `src` to `dst`. The source
+    /// Copies `count * size_of::<T>()` bytes from `src` to `dst`. The source
     /// and destination may overlap.
     ///
-    /// `copy` is semantically equivalent to C's `memmove`.
+    /// If the source and destination will *never* overlap,
+    /// [`copy_nonoverlapping`] can be used instead.
+    ///
+    /// `copy` is semantically equivalent to C's [`memmove`].
+    ///
+    /// [`copy_nonoverlapping`]: ./fn.copy_nonoverlapping.html
+    /// [`memmove`]: https://www.gnu.org/software/libc/manual/html_node/Copying-Strings-and-Arrays.html#index-memmove
     ///
     /// # Safety
     ///
-    /// Care must be taken with the ownership of `src` and `dst`.
-    /// This method semantically moves the values of `src` into `dst`.
-    /// However it does not drop the contents of `dst`, or prevent the contents of `src`
-    /// from being dropped or used.
+    /// `copy` is unsafe because it dereferences a raw pointer. The caller must
+    /// ensure that `src` points to a valid sequence of type `T`.
+    ///
+    /// # [Undefined Behavior]
+    ///
+    /// Behavior is undefined if any of the following conditions are violated:
+    ///
+    /// * The region of memory which begins at `src` and has a length of
+    ///   `count * size_of::<T>()` bytes must be *both* valid and initialized.
+    ///
+    /// * The region of memory which begins at `dst` and has a length of
+    ///   `count * size_of::<T>()` bytes must be valid (but may or may not be
+    ///   initialized).
+    ///
+    /// * `src` must be properly aligned.
+    ///
+    /// * `dst` must be properly aligned.
+    ///
+    /// Additionally, if `T` is not [`Copy`], only the region at `src` *or* the
+    /// region at `dst` can be used or dropped after calling `copy`. `copy`
+    /// creates bitwise copies of `T`, regardless of whether `T: Copy`, which
+    /// can result in undefined behavior if both copies are used.
+    ///
+    /// [`Copy`]: ../marker/trait.Copy.html
+    /// [Undefined Behavior]: ../../reference/behavior-considered-undefined.html
     ///
     /// # Examples
     ///
@@ -1028,14 +1103,38 @@ extern "rust-intrinsic" {
     ///     dst
     /// }
     /// ```
-    ///
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn copy<T>(src: *const T, dst: *mut T, count: usize);
 
-    /// Invokes memset on the specified pointer, setting `count * size_of::<T>()`
-    /// bytes of memory starting at `dst` to `val`.
+    /// Sets `count * size_of::<T>()` bytes of memory starting at `dst` to
+    /// `val`.
+    ///
+    /// `write_bytes` is semantically equivalent to C's [`memset`].
+    ///
+    /// [`memset`]: https://www.gnu.org/software/libc/manual/html_node/Copying-Strings-and-Arrays.html#index-memset
+    ///
+    /// # Safety
+    ///
+    /// `write_bytes` is unsafe because it dereferences a raw pointer. The
+    /// caller must ensure that the poiinter points to a valid value of type `T`.
+    ///
+    /// # [Undefined Behavior]
+    ///
+    /// Behavior is undefined if any of the following conditions are violated:
+    ///
+    /// * The region of memory which begins at `dst` and has a length of
+    ///   `count` bytes must be valid.
+    ///
+    /// * `dst` must be properly aligned.
+    ///
+    /// Additionally, the caller must ensure that writing `count` bytes to the
+    /// given region of memory results in a valid value of `T`. Creating an
+    /// invalid value of `T` can result in undefined behavior. An example is
+    /// provided below.
     ///
     /// # Examples
+    ///
+    /// Basic usage:
     ///
     /// ```
     /// use std::ptr;
@@ -1046,6 +1145,22 @@ extern "rust-intrinsic" {
     ///     ptr::write_bytes(vec_ptr, b'a', 2);
     /// }
     /// assert_eq!(vec, [b'a', b'a', 0, 0]);
+    /// ```
+    ///
+    /// Creating an invalid value:
+    ///
+    /// ```ignore
+    /// use std::{mem, ptr};
+    ///
+    /// let mut v = Box::new(0i32);
+    ///
+    /// unsafe {
+    ///     // Leaks the previously held value by overwriting the `Box<T>` with
+    ///     // a null pointer.
+    ///     ptr::write_bytes(&mut v, 0, mem::size_of::<Box<i32>>());
+    /// }
+    ///
+    /// // At this point, using or dropping `v` results in undefined behavior.
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn write_bytes<T>(dst: *mut T, val: u8, count: usize);

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -992,11 +992,11 @@ extern "rust-intrinsic" {
     ///
     /// * The two regions of memory must *not* overlap.
     ///
-    /// Additionally, if `T` is not [`Copy`](../marker/trait.Copy), only the region at `src` *or* the
-    /// region at `dst` can be used or dropped after calling
-    /// `copy_nonoverlapping`. `copy_nonoverlapping` creates bitwise copies of
-    /// `T`, regardless of whether `T: Copy`, which can result in undefined
-    /// behavior if both copies are used.
+    /// Additionally, if `T` is not [`Copy`](../marker/trait.Copy), only the
+    /// region at `src` *or* the region at `dst` can be used or dropped after
+    /// calling `copy_nonoverlapping`.  `copy_nonoverlapping` creates bitwise
+    /// copies of `T`, regardless of whether `T: Copy`, which can result in
+    /// undefined behavior if both copies are used.
     ///
     /// [Undefined Behavior]: ../../reference/behavior-considered-undefined.html
     ///
@@ -1149,7 +1149,7 @@ extern "rust-intrinsic" {
     ///
     /// Creating an invalid value:
     ///
-    /// ```ignore
+    /// ```no_run
     /// use std::{mem, ptr};
     ///
     /// let mut v = Box::new(0i32);
@@ -1161,6 +1161,7 @@ extern "rust-intrinsic" {
     /// }
     ///
     /// // At this point, using or dropping `v` results in undefined behavior.
+    /// // v = Box::new(0i32); // ERROR
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn write_bytes<T>(dst: *mut T, val: u8, count: usize);

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -971,12 +971,6 @@ extern "rust-intrinsic" {
     ///
     /// # Safety
     ///
-    /// `copy_nonoverlapping` is unsafe because it dereferences a raw pointer.
-    /// The caller must ensure that `src` points to a valid sequence of type
-    /// `T`.
-    ///
-    /// # Undefined Behavior
-    ///
     /// Behavior is undefined if any of the following conditions are violated:
     ///
     /// * The region of memory which begins at `src` and has a length of
@@ -986,17 +980,19 @@ extern "rust-intrinsic" {
     ///   `count * size_of::<T>()` bytes must be valid (but may or may not be
     ///   initialized).
     ///
+    /// * The two regions of memory must *not* overlap.
+    ///
     /// * `src` must be properly aligned.
     ///
     /// * `dst` must be properly aligned.
     ///
-    /// * The two regions of memory must *not* overlap.
+    /// Additionally, if `T` is not [`Copy`], only the region at `src` *or* the
+    /// region at `dst` can be used or dropped after calling
+    /// `copy_nonoverlapping`.  `copy_nonoverlapping` creates bitwise copies of
+    /// `T`, regardless of whether `T: Copy`, which can result in undefined
+    /// behavior if both copies are used.
     ///
-    /// Additionally, if `T` is not [`Copy`](../marker/trait.Copy.html), only
-    /// the region at `src` *or* the region at `dst` can be used or dropped
-    /// after calling `copy_nonoverlapping`.  `copy_nonoverlapping` creates
-    /// bitwise copies of `T`, regardless of whether `T: Copy`, which can result
-    /// in undefined behavior if both copies are used.
+    /// [`Copy`]: ../marker/trait.Copy.html
     ///
     /// # Examples
     ///
@@ -1060,11 +1056,6 @@ extern "rust-intrinsic" {
     ///
     /// # Safety
     ///
-    /// `copy` is unsafe because it dereferences a raw pointer. The caller must
-    /// ensure that `src` points to a valid sequence of type `T`.
-    ///
-    /// # Undefined Behavior
-    ///
     /// Behavior is undefined if any of the following conditions are violated:
     ///
     /// * The region of memory which begins at `src` and has a length of
@@ -1111,11 +1102,6 @@ extern "rust-intrinsic" {
     /// [`memset`]: https://www.gnu.org/software/libc/manual/html_node/Copying-Strings-and-Arrays.html#index-memset
     ///
     /// # Safety
-    ///
-    /// `write_bytes` is unsafe because it dereferences a raw pointer. The
-    /// caller must ensure that the poiinter points to a valid value of type `T`.
-    ///
-    /// # Undefined Behavior
     ///
     /// Behavior is undefined if any of the following conditions are violated:
     ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -337,7 +337,7 @@ unsafe fn swap_nonoverlapping_bytes(x: *mut u8, y: *mut u8, len: usize) {
 /// // `mem::replace` would have the same effect without requiring the unsafe
 /// // block.
 /// let b = unsafe {
-///     ptr::replace(&mut a[0], 'r')
+///     ptr::replace(&mut rust[0], 'r')
 /// };
 ///
 /// assert_eq!(b, 'b');

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -592,7 +592,7 @@ pub unsafe fn write<T>(dst: *mut T, src: T) {
 /// location pointed to by `dst`.
 ///
 /// This is appropriate for initializing uninitialized memory, or overwriting
-/// memory that has previously been [`read`] from.
+/// memory that has previously been read with [`read_unaligned`].
 ///
 /// [`write`]: ./fn.write.html
 /// [`read_unaligned`]: ./fn.read_unaligned.html

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -50,7 +50,7 @@ pub use intrinsics::write_bytes;
 ///   as the compiler doesn't need to prove that it's sound to elide the
 ///   copy.
 ///
-/// [`ptr::read`]: ./fn.read.html
+/// [`ptr::read`]: ../ptr/fn.read.html
 ///
 /// # Safety
 ///
@@ -72,7 +72,7 @@ pub use intrinsics::write_bytes;
 /// dropped.
 ///
 /// [`Copy`]: ../marker/trait.Copy.html
-/// [`write`]: ./fn.write.html
+/// [`write`]: ../ptr/fn.write.html
 ///
 /// # Examples
 ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -57,7 +57,7 @@ pub use intrinsics::write_bytes;
 /// `drop_in_place` is unsafe because it dereferences a raw pointer. The caller
 /// must ensure that the pointer points to a valid value of type `T`.
 ///
-/// # [Undefined Behavior]
+/// # Undefined Behavior
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
@@ -73,7 +73,6 @@ pub use intrinsics::write_bytes;
 ///
 /// [`Copy`]: ../marker/trait.Copy.html
 /// [`write`]: ./fn.write.html
-/// [Undefined Behavior]: ../../reference/behavior-considered-undefined.html
 ///
 /// # Examples
 ///
@@ -157,15 +156,13 @@ pub const fn null_mut<T>() -> *mut T { 0 as *mut T }
 /// `swap` is unsafe because it dereferences a raw pointer. The caller must
 /// ensure that both pointers point to valid values of type `T`.
 ///
-/// # [Undefined Behavior]
+/// # Undefined Behavior
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
 /// * `x` and `y` must point to valid, initialized memory.
 ///
 /// * `x` and `y` must be properly aligned.
-///
-/// [Undefined Behavior]: ../../reference/behavior-considered-undefined.html
 ///
 /// # Examples
 ///
@@ -317,15 +314,13 @@ unsafe fn swap_nonoverlapping_bytes(x: *mut u8, y: *mut u8, len: usize) {
 ///
 /// [`mem::replace`]: ../mem/fn.replace.html
 ///
-/// # [Undefined Behavior]
+/// # Undefined Behavior
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
 /// * `dest` must point to valid, initialized memory.
 ///
 /// * `dest` must be properly aligned.
-///
-/// [Undefined Behavior]: ../../reference/behavior-considered-undefined.html
 ///
 /// # Examples
 ///
@@ -358,7 +353,7 @@ pub unsafe fn replace<T>(dest: *mut T, mut src: T) -> T {
 /// `read` is unsafe because it dereferences a raw pointer. The caller
 /// must ensure that the pointer points to a valid value of type `T`.
 ///
-/// # [Undefined Behavior]
+/// # Undefined Behavior
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
@@ -377,7 +372,6 @@ pub unsafe fn replace<T>(dest: *mut T, mut src: T) -> T {
 /// [`Copy`]: ../marker/trait.Copy.html
 /// [`read_unaligned`]: ./fn.read_unaligned.html
 /// [`write`]: ./fn.write.html
-/// [Undefined Behavior]: ../../reference/behavior-considered-undefined.html
 ///
 /// # Examples
 ///
@@ -447,7 +441,7 @@ pub unsafe fn read<T>(src: *const T) -> T {
 /// `read_unaligned` is unsafe because it dereferences a raw pointer. The caller
 /// must ensure that the pointer points to a valid value of type `T`.
 ///
-/// # [Undefined Behavior]
+/// # Undefined Behavior
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
@@ -463,7 +457,6 @@ pub unsafe fn read<T>(src: *const T) -> T {
 ///
 /// [`Copy`]: ../marker/trait.Copy.html
 /// [`write_unaligned`]: ./fn.write_unaligned.html
-/// [Undefined Behavior]: ../../reference/behavior-considered-undefined.html
 ///
 /// # Examples
 ///
@@ -530,7 +523,7 @@ pub unsafe fn read_unaligned<T>(src: *const T) -> T {
 ///
 /// `write` is unsafe because it dereferences a raw pointer.
 ///
-/// # [Undefined Behavior]
+/// # Undefined Behavior
 ///
 /// `write` can trigger undefined behavior if any of the following conditions
 /// are violated:
@@ -540,7 +533,6 @@ pub unsafe fn read_unaligned<T>(src: *const T) -> T {
 /// * `dst` must be properly aligned. Use [`write_unaligned`] if this is not the
 ///   case.
 ///
-/// [Undefined Behavior]: ../../reference/behavior-considered-undefined.html
 /// [`write_unaligned`]: ./fn.write_unaligned.html
 ///
 /// # Examples
@@ -609,14 +601,12 @@ pub unsafe fn write<T>(dst: *mut T, src: T) {
 ///
 /// `write_unaligned` is unsafe because it dereferences a raw pointer.
 ///
-/// # [Undefined Behavior]
+/// # Undefined Behavior
 ///
 /// `write_unaligned` can trigger undefined behavior if any of the following
 /// conditions are violated:
 ///
 /// * `dst` must point to valid memory.
-///
-/// [Undefined Behavior]: ../../reference/behavior-considered-undefined.html
 ///
 /// # Examples
 ///
@@ -684,7 +674,7 @@ pub unsafe fn write_unaligned<T>(dst: *mut T, src: T) {
 /// `read_volatile` is unsafe because it dereferences a raw pointer. The caller
 /// must ensure that the pointer points to a valid value of type `T`.
 ///
-/// # [Undefined Behavior]
+/// # Undefined Behavior
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
@@ -702,7 +692,6 @@ pub unsafe fn write_unaligned<T>(dst: *mut T, src: T) {
 ///
 /// [`Copy`]: ../marker/trait.Copy.html
 /// [`write_volatile`]: ./fn.write_volatile.html
-/// [Undefined Behavior]: ../../reference/behavior-considered-undefined.html
 ///
 /// # Examples
 ///
@@ -754,7 +743,7 @@ pub unsafe fn read_volatile<T>(src: *const T) -> T {
 ///
 /// `write_volatile` is unsafe because it dereferences a raw pointer.
 ///
-/// # [Undefined Behavior]
+/// # Undefined Behavior
 ///
 /// `write_volatile` can trigger undefined behavior if any of the following
 /// conditions are violated:
@@ -762,8 +751,6 @@ pub unsafe fn read_volatile<T>(src: *const T) -> T {
 /// * `dst` must point to valid memory.
 ///
 /// * `dst` must be properly aligned.
-///
-/// [Undefined Behavior]: ../../reference/behavior-considered-undefined.html
 ///
 /// # Examples
 ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -10,7 +10,7 @@
 
 // FIXME: talk about offset, copy_memory, copy_nonoverlapping_memory
 
-//! Manually manage memory through raw, unsafe pointers.
+//! Manually manage memory through raw pointers.
 //!
 //! *[See also the pointer primitive types](../../std/primitive.pointer.html).*
 
@@ -438,6 +438,8 @@ pub unsafe fn read<T>(src: *const T) -> T {
 ///
 /// [`read`]: ./fn.read.html
 ///
+/// # Safety
+///
 /// `read_unaligned` is unsafe because it dereferences a raw pointer. The caller
 /// must ensure that the pointer points to a valid value of type `T`.
 ///
@@ -525,8 +527,7 @@ pub unsafe fn read_unaligned<T>(src: *const T) -> T {
 ///
 /// # Undefined Behavior
 ///
-/// `write` can trigger undefined behavior if any of the following conditions
-/// are violated:
+/// Behavior is undefined if any of the following conditions are violated:
 ///
 /// * `dst` must point to valid memory.
 ///
@@ -603,8 +604,7 @@ pub unsafe fn write<T>(dst: *mut T, src: T) {
 ///
 /// # Undefined Behavior
 ///
-/// `write_unaligned` can trigger undefined behavior if any of the following
-/// conditions are violated:
+/// Behavior is undefined if any of the following conditions are violated:
 ///
 /// * `dst` must point to valid memory.
 ///
@@ -745,8 +745,7 @@ pub unsafe fn read_volatile<T>(src: *const T) -> T {
 ///
 /// # Undefined Behavior
 ///
-/// `write_volatile` can trigger undefined behavior if any of the following
-/// conditions are violated:
+/// Behavior is undefined if any of the following conditions are violated:
 ///
 /// * `dst` must point to valid memory.
 ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -622,6 +622,11 @@ pub unsafe fn write_unaligned<T>(dst: *mut T, src: T) {
 /// to not be elided or reordered by the compiler across other volatile
 /// operations.
 ///
+/// Memory read with `read_volatile` should almost always be written to using
+/// [`write_volatile`].
+///
+/// [`write_volatile`]: ./fn.write_volatile.html
+///
 /// # Notes
 ///
 /// Rust does not currently have a rigorously and formally defined memory model,
@@ -644,16 +649,13 @@ pub unsafe fn write_unaligned<T>(dst: *mut T, src: T) {
 ///
 /// * `src` must be properly aligned.
 ///
-/// Additionally, if `T` is not [`Copy`], only the returned value *or* the
-/// pointed-to value can be used or dropped after calling `read_volatile`.
-/// `read_volatile` creates a bitwise copy of `T`, regardless of whether `T:
-/// Copy`, which can result in undefined behavior if both copies are used.
-/// Note that `*src = foo` counts as a use because it will attempt to drop the
-/// value previously at `*src`. [`write_volatile`] can be used to overwrite
-/// data without causing it to be dropped.
+/// Like [`read`], `read_volatile` creates a bitwise copy of the pointed-to
+/// object, regardless of whether `T` is [`Copy`]. Using both values can cause
+/// undefined behavior. However, storing non-[`Copy`] data in I/O memory is
+/// almost certainly incorrect.
 ///
 /// [`Copy`]: ../marker/trait.Copy.html
-/// [`write_volatile`]: ./fn.write_volatile.html
+/// [`read`]: ./fn.read.html
 ///
 /// # Examples
 ///
@@ -680,12 +682,17 @@ pub unsafe fn read_volatile<T>(src: *const T) -> T {
 /// to not be elided or reordered by the compiler across other volatile
 /// operations.
 ///
+/// Memory written with `write_volatile` should almost always be read from using
+/// [`read_volatile`].
+///
 /// `write_volatile` does not drop the contents of `dst`. This is safe, but it
 /// could leak allocations or resources, so care must be taken not to overwrite
 /// an object that should be dropped.
 ///
 /// Additionally, it does not drop `src`. Semantically, `src` is moved into the
 /// location pointed to by `dst`.
+///
+/// [`read_volatile`]: ./fn.read_volatile.html
 ///
 /// # Notes
 ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -54,11 +54,6 @@ pub use intrinsics::write_bytes;
 ///
 /// # Safety
 ///
-/// `drop_in_place` is unsafe because it dereferences a raw pointer. The caller
-/// must ensure that the pointer points to a valid value of type `T`.
-///
-/// # Undefined Behavior
-///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
 /// * `to_drop` must point to valid memory.
@@ -152,11 +147,6 @@ pub const fn null_mut<T>() -> *mut T { 0 as *mut T }
 /// [`mem::swap`]: ../mem/fn.swap.html
 ///
 /// # Safety
-///
-/// `swap` is unsafe because it dereferences a raw pointer. The caller must
-/// ensure that both pointers point to valid values of type `T`.
-///
-/// # Undefined Behavior
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
@@ -307,14 +297,9 @@ unsafe fn swap_nonoverlapping_bytes(x: *mut u8, y: *mut u8, len: usize) {
 /// operates on raw pointers instead of references. When references are
 /// available, [`mem::replace`] should be preferred.
 ///
-/// # Safety
-///
-/// `replace` is unsafe because it dereferences a raw pointer. The caller
-/// must ensure that the pointer points to a valid value of type `T`.
-///
 /// [`mem::replace`]: ../mem/fn.replace.html
 ///
-/// # Undefined Behavior
+/// # Safety
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
@@ -349,11 +334,6 @@ pub unsafe fn replace<T>(dest: *mut T, mut src: T) -> T {
 /// memory in `src` unchanged.
 ///
 /// # Safety
-///
-/// `read` is unsafe because it dereferences a raw pointer. The caller
-/// must ensure that the pointer points to a valid value of type `T`.
-///
-/// # Undefined Behavior
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
@@ -440,11 +420,6 @@ pub unsafe fn read<T>(src: *const T) -> T {
 ///
 /// # Safety
 ///
-/// `read_unaligned` is unsafe because it dereferences a raw pointer. The caller
-/// must ensure that the pointer points to a valid value of type `T`.
-///
-/// # Undefined Behavior
-///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
 /// * `src` must point to valid, initialized memory.
@@ -523,10 +498,6 @@ pub unsafe fn read_unaligned<T>(src: *const T) -> T {
 ///
 /// # Safety
 ///
-/// `write` is unsafe because it dereferences a raw pointer.
-///
-/// # Undefined Behavior
-///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
 /// * `dst` must point to valid memory.
@@ -600,10 +571,6 @@ pub unsafe fn write<T>(dst: *mut T, src: T) {
 ///
 /// # Safety
 ///
-/// `write_unaligned` is unsafe because it dereferences a raw pointer.
-///
-/// # Undefined Behavior
-///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
 /// * `dst` must point to valid memory.
@@ -671,11 +638,6 @@ pub unsafe fn write_unaligned<T>(dst: *mut T, src: T) {
 ///
 /// # Safety
 ///
-/// `read_volatile` is unsafe because it dereferences a raw pointer. The caller
-/// must ensure that the pointer points to a valid value of type `T`.
-///
-/// # Undefined Behavior
-///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
 /// * `src` must point to valid, initialized memory.
@@ -740,10 +702,6 @@ pub unsafe fn read_volatile<T>(src: *const T) -> T {
 /// [c11]: http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf
 ///
 /// # Safety
-///
-/// `write_volatile` is unsafe because it dereferences a raw pointer.
-///
-/// # Undefined Behavior
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///


### PR DESCRIPTION
This PR attempts to resolve #29371.

[Rendered](https://ecstatic-morse.github.io/rust/std/ptr/index.html)

This is a fairly major rewrite of the `std::ptr` docs, and deserves a fair bit of scrutiny. It adds links to the GNU libc docs for various instrinsics, adds internal links to types and functions referenced in the docs, adds new, more complex examples for many functions, and introduces a common template for discussing unsafety of functions in `std::ptr`.

All functions in `std::ptr` (with the exception of `ptr::eq`) are unsafe because they either read from or write to a raw pointer. The "Safety" section now informs that the function is unsafe because it dereferences a raw pointer and requires that any pointer to be read by the function points to "a valid vaue of type `T`".

Additionally, each function imposes some subset of the following conditions on its arguments.

* The pointer points to valid memory.
* The pointer points to initialized memory.
* The pointer is properly aligned.

These requirements are discussed in the "Undefined Behavior" section along with the  consequences of using functions that perform bitwise copies without requiring `T: Copy`. I don't love my new descriptions of the consequences of making such copies. Perhaps the old ones were good enough?

Some issues which still need to be addressed before this is merged:
- [ ] The new docs assert that `drop_in_place` is equivalent to calling `read` and discarding the value. Is this correct?
- [ ] Do `write_bytes` and `swap_nonoverlapping` require properly aligned pointers?
- [ ] The new example for `drop_in_place` is a lackluster.
- [x] Should these docs rigorously define what `valid` memory is? Or should is that the job of the reference? Should we link to the reference?
- [x] Is it correct to require that pointers that will be read from refer to "valid values of type `T`"?
- [x] I can't imagine ever using `{read,write}_volatile` with non-`Copy` types.  Should I just link to {read,write} and say that the same issues with non-`Copy` types apply?
- [x] `write_volatile` doesn't link back to `read_volatile`.
- [ ] Update docs for the unstable [`swap_nonoverlapping`](https://github.com/rust-lang/rust/issues/42818)
- [ ] Update docs for the unstable [unsafe pointer methods RFC](https://github.com/rust-lang/rfcs/pull/1966)

Looking forward to your feedback.

r? @steveklabnik
