### PR TITLE
rustbuild: canonicalize prefix `install_sh`

### DIFF
--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -72,7 +72,9 @@ fn install_sh(
     let bindir_default = PathBuf::from("bin");
     let libdir_default = PathBuf::from("lib");
     let mandir_default = datadir_default.join("man");
-    let prefix = build.config.prefix.as_ref().unwrap_or(&prefix_default);
+    let prefix = build.config.prefix.as_ref().map_or(prefix_default, |p| {
+        fs::canonicalize(p).expect(&format!("could not canonicalize {}", p.display()))
+    });
     let sysconfdir = build.config.sysconfdir.as_ref().unwrap_or(&sysconfdir_default);
     let datadir = build.config.datadir.as_ref().unwrap_or(&datadir_default);
     let docdir = build.config.docdir.as_ref().unwrap_or(&docdir_default);


### PR DESCRIPTION
Testing:
```
  $ git diff
  diff --git a/config.toml.example b/config.toml.example
  index 9dd3002506..b47bc490cd 100644
  --- a/config.toml.example
  +++ b/config.toml.example
  @@ -196,7 +196,7 @@
   [install]

   # Instead of installing to /usr/local, install to this path instead.
  -#prefix = "/usr/local"
  +prefix = "install-prefix"

   # Where to install system configuration files
   # If this is a relative path, it will get installed in `prefix` above
  $ mkdir install-prefix
  $ ./x.py install -i --stage 0 --config config.toml.example
  ...
  $ ls install-prefix/
  bin	lib	share
```

Closes #36989.

r? @Mark-Simulacrum 