### PR TITLE
Access individual fields of tuples, closures and generators on drop.

### DIFF
--- a/src/test/run-pass/issue-47703-tuple.rs
+++ b/src/test/run-pass/issue-47703-tuple.rs
@@ -1,0 +1,21 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(nll)]
+
+struct WithDrop;
+
+impl Drop for WithDrop {
+    fn drop(&mut self) {}
+}
+
+fn consume(x: (&mut (), WithDrop)) -> &mut () { x.0 }
+
+fn main() {}

--- a/src/test/run-pass/nll/issue-48623-closure.rs
+++ b/src/test/run-pass/nll/issue-48623-closure.rs
@@ -1,0 +1,24 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(nll)]
+
+struct WithDrop;
+
+impl Drop for WithDrop {
+    fn drop(&mut self) {}
+}
+
+fn reborrow_from_closure(r: &mut ()) -> &mut () {
+    let d = WithDrop;
+    (move || { d; &mut *r })()
+}
+
+fn main() {}

--- a/src/test/run-pass/nll/issue-48623-generator.rs
+++ b/src/test/run-pass/nll/issue-48623-generator.rs
@@ -1,0 +1,25 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(nll)]
+#![feature(generators, generator_trait)]
+
+struct WithDrop;
+
+impl Drop for WithDrop {
+    fn drop(&mut self) {}
+}
+
+fn reborrow_from_generator(r: &mut ()) {
+    let d = WithDrop;
+    move || { d; yield; &mut *r };
+}
+
+fn main() {}

--- a/src/test/ui/generator/yield-while-iterating.nll.stderr
+++ b/src/test/ui/generator/yield-while-iterating.nll.stderr
@@ -6,20 +6,6 @@ LL |         for p in &x { //~ ERROR
 LL |             yield();
    |             ------- possible yield occurs here
 
-error[E0597]: borrowed value does not live long enough
-  --> $DIR/yield-while-iterating.rs:50:17
-   |
-LL |       let mut b = || {
-   |  _________________^
-LL | |         for p in &mut x {
-LL | |             yield p;
-LL | |         }
-LL | |     };
-   | |     ^
-   | |     |
-   | |_____temporary value only lives until here
-   |       temporary value does not live long enough
-
 error[E0502]: cannot borrow `x` as immutable because it is also borrowed as mutable
   --> $DIR/yield-while-iterating.rs:67:20
    |
@@ -35,21 +21,7 @@ LL |       println!("{}", x[0]); //~ ERROR
 LL |       b.resume();
    |       - borrow later used here
 
-error[E0597]: borrowed value does not live long enough
-  --> $DIR/yield-while-iterating.rs:62:17
-   |
-LL |       let mut b = || {
-   |  _________________^
-LL | |         for p in &mut x {
-LL | |             yield p;
-LL | |         }
-LL | |     };
-   | |     ^
-   | |     |
-   | |_____temporary value only lives until here
-   |       temporary value does not live long enough
+error: aborting due to 2 previous errors
 
-error: aborting due to 4 previous errors
-
-Some errors occurred: E0502, E0597, E0626.
+Some errors occurred: E0502, E0626.
 For more information about an error, try `rustc --explain E0502`.


### PR DESCRIPTION
Fixes #48623, by extending the change in #47917 to closures. Also does this for tuples and generators for consistency.

Enums are unchanged because there is no way to borrow `*enum.field` without borrowing `enum.field` at the moment, so any error would be reported when the enum goes out of scope. Unions aren't changed because unions they don't automatically drop their fields.

r? @nikomatsakis 