### PR TITLE
Remove usages of Term::as_str and mark it for removal

### DIFF
--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -715,6 +715,7 @@ impl Term {
         }
     }
 
+    // FIXME: Remove this, do not stabilize
     /// Get a reference to the interned string.
     #[unstable(feature = "proc_macro", issue = "38356")]
     pub fn as_str(&self) -> &str {
@@ -739,7 +740,7 @@ impl Term {
 #[unstable(feature = "proc_macro", issue = "38356")]
 impl fmt::Display for Term {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.as_str().fmt(f)
+        self.sym.as_str().fmt(f)
     }
 }
 
@@ -1131,7 +1132,7 @@ impl TokenTree {
             },
             self::TokenTree::Term(tt) => {
                 let ident = ast::Ident::new(tt.sym, tt.span.0);
-                let sym_str = tt.sym.as_str();
+                let sym_str = tt.sym.to_string();
                 let token = if sym_str.starts_with("'") {
                     Lifetime(ident)
                 } else if sym_str.starts_with("r#") {

--- a/src/libproc_macro/quote.rs
+++ b/src/libproc_macro/quote.rs
@@ -183,7 +183,7 @@ impl Quote for Op {
 
 impl Quote for Term {
     fn quote(self) -> TokenStream {
-        quote!(::Term::new((quote self.as_str()), (quote self.span())))
+        quote!(::Term::new((quote self.sym.as_str()), (quote self.span())))
     }
 }
 

--- a/src/test/compile-fail-fulldeps/proc-macro/auxiliary/attributes-included.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/auxiliary/attributes-included.rs
@@ -86,7 +86,7 @@ fn assert_doc(slice: &mut &[TokenTree]) {
     }
 
     match &tokens[0] {
-        TokenTree::Term(tt) => assert_eq!("doc", tt.as_str()),
+        TokenTree::Term(tt) => assert_eq!("doc", &*tt.to_string()),
         _ => panic!("expected `doc`"),
     }
     match &tokens[1] {
@@ -118,11 +118,11 @@ fn assert_invoc(slice: &mut &[TokenTree]) {
 
 fn assert_foo(slice: &mut &[TokenTree]) {
     match &slice[0] {
-        TokenTree::Term(tt) => assert_eq!(tt.as_str(), "fn"),
+        TokenTree::Term(tt) => assert_eq!(&*tt.to_string(), "fn"),
         _ => panic!("expected fn"),
     }
     match &slice[1] {
-        TokenTree::Term(tt) => assert_eq!(tt.as_str(), "foo"),
+        TokenTree::Term(tt) => assert_eq!(&*tt.to_string(), "foo"),
         _ => panic!("expected foo"),
     }
     match &slice[2] {

--- a/src/test/run-pass-fulldeps/auxiliary/cond_plugin.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/cond_plugin.rs
@@ -33,7 +33,7 @@ pub fn cond(input: TokenStream) -> TokenStream {
             panic!("Invalid macro usage in cond: {}", cond);
         }
         let is_else = match test {
-            TokenTree::Term(word) => word.as_str() == "else",
+            TokenTree::Term(word) => &*word.to_string() == "else",
             _ => false,
         };
         conds.push(if is_else || input.peek().is_none() {


### PR DESCRIPTION
Returning references to rustc internal data structures is a bad idea since their lifetimes are unrelated to the lifetimes of proc_macro values.

See https://github.com/rust-lang/rust/pull/46972 and the `Taming thread-local storage` section of https://internals.rust-lang.org/t/parallelizing-rustc-using-rayon/6606

r? @alexcrichton