### PR TITLE
rustc_driver: Catch ICEs on the main thread too

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1526,7 +1526,8 @@ pub fn in_rustc_thread<F, R>(f: F) -> Result<R, Box<Any + Send>>
         let thread = cfg.spawn(f);
         thread.unwrap().join()
     } else {
-        Ok(f())
+        let f = panic::AssertUnwindSafe(f);
+        panic::catch_unwind(f)
     }
 }
 


### PR DESCRIPTION
#48575 introduced an optimization to run rustc directly on the main thread when possible.  However, the threaded code detects panics when they `join()` to report as an ICE.  When running directly, we need to use `panic::catch_unwind` to get the same effect.

cc @ishitatsuyuki 
r? @alexcrichton 