### PR TITLE
[beta] Backport fix for regression in defaults

### DIFF
--- a/src/test/run-pass/defaults-well-formedness.rs
+++ b/src/test/run-pass/defaults-well-formedness.rs
@@ -27,4 +27,8 @@ trait SelfBound<T: Copy=Self> {}
 // Not even for well-formedness.
 struct WellFormedProjection<A, T=<A as Iterator>::Item>(A, T);
 
+// Issue #49344, predicates with lifetimes should not be checked.
+trait Scope<'a> {}
+struct Request<'a, S: Scope<'a> = i32>(S, &'a ());
+
 fn main() {}


### PR DESCRIPTION
This proposes a backport of #49704, which fixes a regression that affects beta.

r? @nikomatsakis 