### PR TITLE
core: Inline `From<AllocErr> for CollectionAllocErr`

### DIFF
--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -380,6 +380,7 @@ pub enum CollectionAllocErr {
 
 #[unstable(feature = "try_reserve", reason = "new API", issue="48043")]
 impl From<AllocErr> for CollectionAllocErr {
+    #[inline]
     fn from(AllocErr: AllocErr) -> Self {
         CollectionAllocErr::AllocErr
     }


### PR DESCRIPTION
This shows up in allocations of vectors and such, so no need for it to not be
inlined!