### PR TITLE
Do not uppercase-lint #[no_mangle] statics

### DIFF
--- a/src/librustc_lint/bad_style.rs
+++ b/src/librustc_lint/bad_style.rs
@@ -368,6 +368,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonUpperCaseGlobals {
     fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
         match it.node {
             hir::ItemStatic(..) => {
+                if attr::find_by_name(&it.attrs, "no_mangle").is_some() {
+                    return;
+                }
                 NonUpperCaseGlobals::check_upper_case(cx, "static variable", it.name, it.span);
             }
             hir::ItemConst(..) => {

--- a/src/test/compile-fail/lint-non-uppercase-statics.rs
+++ b/src/test/compile-fail/lint-non-uppercase-statics.rs
@@ -16,4 +16,7 @@ static foo: isize = 1; //~ ERROR static variable `foo` should have an upper case
 static mut bar: isize = 1;
         //~^ ERROR static variable `bar` should have an upper case name such as `BAR`
 
+#[no_mangle]
+pub static extern_foo: isize = 1; // OK, because #[no_mangle] supersedes the warning
+
 fn main() { }


### PR DESCRIPTION
The reasoning being that `#[no_mangle]` expresses enough intention that there's likely a good reason for the name.

Fixes #36258.