### PR TITLE
Fix "fp" target feature for AArch64

### DIFF
--- a/src/librustc_trans/llvm_util.rs
+++ b/src/librustc_trans/llvm_util.rs
@@ -134,6 +134,7 @@ pub fn to_llvm_feature<'a>(sess: &Session, s: &'a str) -> &'a str {
         ("x86", "pclmulqdq") => "pclmul",
         ("x86", "rdrand") => "rdrnd",
         ("x86", "bmi1") => "bmi",
+        ("aarch64", "fp") => "fp-armv8",
         ("aarch64", "fp16") => "fullfp16",
         (_, s) => s,
     }


### PR DESCRIPTION
This fixes the following warning on AArch64:
```
'+fp' is not a recognized feature for this target (ignoring feature)
```

Fixes #49782