### PR TITLE
Blindly checkpoint status of NLL mode ui tests

### DIFF
--- a/src/test/ui/augmented-assignments.nll.stderr
+++ b/src/test/ui/augmented-assignments.nll.stderr
@@ -1,0 +1,26 @@
+error[E0505]: cannot move out of `x` because it is borrowed
+  --> $DIR/augmented-assignments.rs:26:5
+   |
+LL |       x   //~ error: use of moved value: `x`
+   |       -
+   |       |
+   |  _____borrow of `x` occurs here
+   | |
+LL | |     //~^ value used here after move
+LL | |     +=
+LL | |     x;  //~ value moved here
+   | |     -
+   | |     |
+   | |_____move out of `x` occurs here
+   |       borrow later used here
+
+error[E0596]: cannot borrow immutable item `y` as mutable
+  --> $DIR/augmented-assignments.rs:30:5
+   |
+LL |     y   //~ error: cannot borrow immutable local variable `y` as mutable
+   |     ^ cannot borrow as mutable
+
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0505, E0596.
+For more information about an error, try `rustc --explain E0505`.

--- a/src/test/ui/borrowck/borrowck-box-insensitivity.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-box-insensitivity.nll.stderr
@@ -1,0 +1,25 @@
+error[E0382]: use of moved value: `a.y`
+  --> $DIR/borrowck-box-insensitivity.rs:46:14
+   |
+LL |     let _x = a.x;
+   |              --- value moved here
+LL |     //~^ value moved here
+LL |     let _y = a.y; //~ ERROR use of moved
+   |              ^^^ value used here after move
+   |
+   = note: move occurs because `a.y` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a.y`
+  --> $DIR/borrowck-box-insensitivity.rs:108:14
+   |
+LL |     let _x = a.x.x;
+   |              ----- value moved here
+LL |     //~^ value moved here
+LL |     let _y = a.y; //~ ERROR use of collaterally moved
+   |              ^^^ value used here after move
+   |
+   = note: move occurs because `a.y` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/borrowck/borrowck-closures-two-mut.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-two-mut.nll.stderr
@@ -1,0 +1,78 @@
+error[E0499]: cannot borrow `x` as mutable more than once at a time (Ast)
+  --> $DIR/borrowck-closures-two-mut.rs:24:24
+   |
+LL |     let c1 = to_fn_mut(|| x = 4);
+   |                        -- - previous borrow occurs due to use of `x` in closure
+   |                        |
+   |                        first mutable borrow occurs here
+LL |     let c2 = to_fn_mut(|| x = 5); //~ ERROR cannot borrow `x` as mutable more than once
+   |                        ^^ - borrow occurs due to use of `x` in closure
+   |                        |
+   |                        second mutable borrow occurs here
+LL |     //~| ERROR cannot borrow `x` as mutable more than once
+LL | }
+   | - first borrow ends here
+
+error[E0499]: cannot borrow `x` as mutable more than once at a time (Ast)
+  --> $DIR/borrowck-closures-two-mut.rs:35:24
+   |
+LL |     let c1 = to_fn_mut(|| set(&mut x));
+   |                        --          - previous borrow occurs due to use of `x` in closure
+   |                        |
+   |                        first mutable borrow occurs here
+LL |     let c2 = to_fn_mut(|| set(&mut x)); //~ ERROR cannot borrow `x` as mutable more than once
+   |                        ^^          - borrow occurs due to use of `x` in closure
+   |                        |
+   |                        second mutable borrow occurs here
+LL |     //~| ERROR cannot borrow `x` as mutable more than once
+LL | }
+   | - first borrow ends here
+
+error[E0499]: cannot borrow `x` as mutable more than once at a time (Ast)
+  --> $DIR/borrowck-closures-two-mut.rs:42:24
+   |
+LL |     let c1 = to_fn_mut(|| x = 5);
+   |                        -- - previous borrow occurs due to use of `x` in closure
+   |                        |
+   |                        first mutable borrow occurs here
+LL |     let c2 = to_fn_mut(|| set(&mut x)); //~ ERROR cannot borrow `x` as mutable more than once
+   |                        ^^          - borrow occurs due to use of `x` in closure
+   |                        |
+   |                        second mutable borrow occurs here
+LL |     //~| ERROR cannot borrow `x` as mutable more than once
+LL | }
+   | - first borrow ends here
+
+error[E0499]: cannot borrow `x` as mutable more than once at a time (Ast)
+  --> $DIR/borrowck-closures-two-mut.rs:49:24
+   |
+LL |     let c1 = to_fn_mut(|| x = 5);
+   |                        -- - previous borrow occurs due to use of `x` in closure
+   |                        |
+   |                        first mutable borrow occurs here
+LL |     let c2 = to_fn_mut(|| { let _y = to_fn_mut(|| set(&mut x)); }); // (nested closure)
+   |                        ^^                                  - borrow occurs due to use of `x` in closure
+   |                        |
+   |                        second mutable borrow occurs here
+...
+LL | }
+   | - first borrow ends here
+
+error[E0499]: cannot borrow `x` as mutable more than once at a time (Ast)
+  --> $DIR/borrowck-closures-two-mut.rs:61:24
+   |
+LL |     let c1 = to_fn_mut(|| set(&mut *x.f));
+   |                        --           - previous borrow occurs due to use of `x` in closure
+   |                        |
+   |                        first mutable borrow occurs here
+LL |     let c2 = to_fn_mut(|| set(&mut *x.f));
+   |                        ^^           - borrow occurs due to use of `x` in closure
+   |                        |
+   |                        second mutable borrow occurs here
+...
+LL | }
+   | - first borrow ends here
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0499`.

--- a/src/test/ui/borrowck/borrowck-escaping-closure-error-1.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-escaping-closure-error-1.nll.stderr
@@ -1,0 +1,14 @@
+error[E0597]: `books` does not live long enough
+  --> $DIR/borrowck-escaping-closure-error-1.rs:23:11
+   |
+LL |     spawn(|| books.push(4));
+   |           ^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+LL |     //~^ ERROR E0373
+LL | }
+   | - borrowed value only lives until here
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/borrowck/borrowck-escaping-closure-error-2.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-escaping-closure-error-2.nll.stderr
@@ -1,0 +1,18 @@
+error[E0597]: `books` does not live long enough
+  --> $DIR/borrowck-escaping-closure-error-2.rs:21:14
+   |
+LL |     Box::new(|| books.push(4))
+   |              ^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+LL |     //~^ ERROR E0373
+LL | }
+   | - borrowed value only lives until here
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 19:1...
+  --> $DIR/borrowck-escaping-closure-error-2.rs:19:1
+   |
+LL | fn foo<'a>(x: &'a i32) -> Box<FnMut()+'a> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/borrowck/borrowck-in-static.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-in-static.nll.stderr
@@ -1,0 +1,9 @@
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/borrowck-in-static.rs:15:17
+   |
+LL |     Box::new(|| x) //~ ERROR cannot move out of captured outer variable
+   |                 ^ cannot move out of borrowed content
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0507`.

--- a/src/test/ui/borrowck/borrowck-move-error-with-note.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-move-error-with-note.nll.stderr
@@ -1,0 +1,40 @@
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/borrowck-move-error-with-note.rs:23:19
+   |
+LL |         Foo::Foo1(num1,
+   |                   ^^^^ cannot move out of borrowed content
+
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/borrowck-move-error-with-note.rs:24:19
+   |
+LL |                   num2) => (),
+   |                   ^^^^ cannot move out of borrowed content
+
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/borrowck-move-error-with-note.rs:25:19
+   |
+LL |         Foo::Foo2(num) => (),
+   |                   ^^^ cannot move out of borrowed content
+
+error[E0509]: cannot move out of type `S`, which implements the `Drop` trait
+  --> $DIR/borrowck-move-error-with-note.rs:42:16
+   |
+LL |             f: _s,
+   |                ^^ cannot move out of here
+
+error[E0509]: cannot move out of type `S`, which implements the `Drop` trait
+  --> $DIR/borrowck-move-error-with-note.rs:43:16
+   |
+LL |             g: _t
+   |                ^^ cannot move out of here
+
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/borrowck-move-error-with-note.rs:59:9
+   |
+LL |         n => {
+   |         ^ cannot move out of borrowed content
+
+error: aborting due to 6 previous errors
+
+Some errors occurred: E0507, E0509.
+For more information about an error, try `rustc --explain E0507`.

--- a/src/test/ui/borrowck/borrowck-move-out-of-vec-tail.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-of-vec-tail.nll.stderr
@@ -1,0 +1,15 @@
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/borrowck-move-out-of-vec-tail.rs:30:33
+   |
+LL |                 &[Foo { string: a },
+   |                                 ^ cannot move out of borrowed content
+
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/borrowck-move-out-of-vec-tail.rs:34:33
+   |
+LL |                   Foo { string: b }] => {
+   |                                 ^ cannot move out of borrowed content
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0507`.

--- a/src/test/ui/borrowck/borrowck-report-with-custom-diagnostic.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-report-with-custom-diagnostic.nll.stderr
@@ -1,0 +1,14 @@
+error: compilation successful
+  --> $DIR/borrowck-report-with-custom-diagnostic.rs:12:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     // Original borrow ends at end of function
+LL | |     let mut x = 1;
+LL | |     let y = &mut x;
+...  |
+LL | |     //~^ immutable borrow occurs here
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/borrowck/borrowck-report-with-custom-diagnostic.rs
+++ b/src/test/ui/borrowck/borrowck-report-with-custom-diagnostic.rs
@@ -7,9 +7,9 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
+#![feature(rustc_attrs)]
 #![allow(dead_code)]
-fn main() {
+fn main() { #![rustc_error] // rust-lang/rust#49855
     // Original borrow ends at end of function
     let mut x = 1;
     let y = &mut x;

--- a/src/test/ui/borrowck/borrowck-vec-pattern-nesting.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-vec-pattern-nesting.nll.stderr
@@ -1,0 +1,51 @@
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/borrowck-vec-pattern-nesting.rs:42:15
+   |
+LL |         &mut [_a, //~ ERROR cannot move out
+   |               ^^ cannot move out of borrowed content
+
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/borrowck-vec-pattern-nesting.rs:55:13
+   |
+LL |     let a = vec[0]; //~ ERROR cannot move out
+   |             ^^^^^^ cannot move out of borrowed content
+
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/borrowck-vec-pattern-nesting.rs:65:10
+   |
+LL |          _b] => {}
+   |          ^^ cannot move out of borrowed content
+
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/borrowck-vec-pattern-nesting.rs:68:13
+   |
+LL |     let a = vec[0]; //~ ERROR cannot move out
+   |             ^^^^^^ cannot move out of borrowed content
+
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/borrowck-vec-pattern-nesting.rs:76:15
+   |
+LL |         &mut [_a, _b, _c] => {}  //~ ERROR cannot move out
+   |               ^^ cannot move out of borrowed content
+
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/borrowck-vec-pattern-nesting.rs:76:19
+   |
+LL |         &mut [_a, _b, _c] => {}  //~ ERROR cannot move out
+   |                   ^^ cannot move out of borrowed content
+
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/borrowck-vec-pattern-nesting.rs:76:23
+   |
+LL |         &mut [_a, _b, _c] => {}  //~ ERROR cannot move out
+   |                       ^^ cannot move out of borrowed content
+
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/borrowck-vec-pattern-nesting.rs:80:13
+   |
+LL |     let a = vec[0]; //~ ERROR cannot move out
+   |             ^^^^^^ cannot move out of borrowed content
+
+error: aborting due to 8 previous errors
+
+For more information about this error, try `rustc --explain E0507`.

--- a/src/test/ui/borrowck/issue-45983.nll.stderr
+++ b/src/test/ui/borrowck/issue-45983.nll.stderr
@@ -1,0 +1,30 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/issue-45983.rs:17:27
+   |
+LL |     give_any(|y| x = Some(y));
+   |                           ^
+
+error: free region `` does not outlive free region `'_#2r`
+  --> $DIR/issue-45983.rs:17:27
+   |
+LL |     give_any(|y| x = Some(y));
+   |                           ^
+
+error[E0594]: cannot assign to immutable item `x`
+  --> $DIR/issue-45983.rs:17:18
+   |
+LL |     give_any(|y| x = Some(y));
+   |                  ^^^^^^^^^^^ cannot mutate
+   |
+   = note: Value not mutable causing this error: `x`
+
+error[E0596]: cannot borrow immutable item `x` as mutable
+  --> $DIR/issue-45983.rs:17:14
+   |
+LL |     give_any(|y| x = Some(y));
+   |              ^^^^^^^^^^^^^^^ cannot borrow as mutable
+
+error: aborting due to 3 previous errors
+
+Some errors occurred: E0594, E0596.
+For more information about an error, try `rustc --explain E0594`.

--- a/src/test/ui/borrowck/issue-7573.nll.stderr
+++ b/src/test/ui/borrowck/issue-7573.nll.stderr
@@ -1,0 +1,14 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/issue-7573.rs:27:31
+   |
+LL |     let mut lines_to_use: Vec<&CrateId> = Vec::new();
+   |                               ^
+
+error: free region `` does not outlive free region `'_#2r`
+  --> $DIR/issue-7573.rs:32:9
+   |
+LL |         lines_to_use.push(installed_id);
+   |         ^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/borrowck/mut-borrow-in-loop.nll.stderr
+++ b/src/test/ui/borrowck/mut-borrow-in-loop.nll.stderr
@@ -1,0 +1,21 @@
+error[E0499]: cannot borrow `*arg` as mutable more than once at a time
+  --> $DIR/mut-borrow-in-loop.rs:20:25
+   |
+LL |             (self.func)(arg) //~ ERROR cannot borrow
+   |                         ^^^ mutable borrow starts here in previous iteration of loop
+
+error[E0499]: cannot borrow `*arg` as mutable more than once at a time
+  --> $DIR/mut-borrow-in-loop.rs:26:25
+   |
+LL |             (self.func)(arg) //~ ERROR cannot borrow
+   |                         ^^^ mutable borrow starts here in previous iteration of loop
+
+error[E0499]: cannot borrow `*arg` as mutable more than once at a time
+  --> $DIR/mut-borrow-in-loop.rs:33:25
+   |
+LL |             (self.func)(arg) //~ ERROR cannot borrow
+   |                         ^^^ mutable borrow starts here in previous iteration of loop
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0499`.

--- a/src/test/ui/borrowck/mut-borrow-outside-loop.nll.stderr
+++ b/src/test/ui/borrowck/mut-borrow-outside-loop.nll.stderr
@@ -1,0 +1,14 @@
+error: compilation successful
+  --> $DIR/mut-borrow-outside-loop.rs:13:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     let mut void = ();
+LL | |
+LL | |     let first = &mut void;
+...  |
+LL | |     }
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/borrowck/mut-borrow-outside-loop.rs
+++ b/src/test/ui/borrowck/mut-borrow-outside-loop.rs
@@ -9,8 +9,8 @@
 // except according to those terms.
 
 // ensure borrowck messages are correct outside special case
-
-fn main() {
+#![feature(rustc_attrs)]
+fn main() { #![rustc_error] // rust-lang/rust#49855
     let mut void = ();
 
     let first = &mut void;

--- a/src/test/ui/borrowck/regions-escape-bound-fn-2.nll.stderr
+++ b/src/test/ui/borrowck/regions-escape-bound-fn-2.nll.stderr
@@ -1,0 +1,14 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/regions-escape-bound-fn-2.rs:18:27
+   |
+LL |     with_int(|y| x = Some(y));
+   |                           ^
+
+error: free region `` does not outlive free region `'_#2r`
+  --> $DIR/regions-escape-bound-fn-2.rs:18:27
+   |
+LL |     with_int(|y| x = Some(y));
+   |                           ^
+
+error: aborting due to previous error
+

--- a/src/test/ui/borrowck/regions-escape-bound-fn.nll.stderr
+++ b/src/test/ui/borrowck/regions-escape-bound-fn.nll.stderr
@@ -1,0 +1,14 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/regions-escape-bound-fn.rs:18:22
+   |
+LL |     with_int(|y| x = Some(y));
+   |                      ^^^^^^^
+
+error: free region `` does not outlive free region `'_#2r`
+  --> $DIR/regions-escape-bound-fn.rs:18:27
+   |
+LL |     with_int(|y| x = Some(y));
+   |                           ^
+
+error: aborting due to previous error
+

--- a/src/test/ui/borrowck/regions-escape-unboxed-closure.nll.stderr
+++ b/src/test/ui/borrowck/regions-escape-unboxed-closure.nll.stderr
@@ -1,0 +1,14 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/regions-escape-unboxed-closure.rs:16:27
+   |
+LL |     with_int(&mut |y| x = Some(y));
+   |                           ^^^^^^^
+
+error: free region `` does not outlive free region `'_#2r`
+  --> $DIR/regions-escape-unboxed-closure.rs:16:32
+   |
+LL |     with_int(&mut |y| x = Some(y));
+   |                                ^
+
+error: aborting due to previous error
+

--- a/src/test/ui/borrowck/unboxed-closures-move-upvar-from-non-once-ref-closure.nll.stderr
+++ b/src/test/ui/borrowck/unboxed-closures-move-upvar-from-non-once-ref-closure.nll.stderr
@@ -1,0 +1,9 @@
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/unboxed-closures-move-upvar-from-non-once-ref-closure.rs:21:9
+   |
+LL |         y.into_iter();
+   |         ^ cannot move out of borrowed content
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0507`.

--- a/src/test/ui/closure-expected-type/expect-region-supply-region.nll.stderr
+++ b/src/test/ui/closure-expected-type/expect-region-supply-region.nll.stderr
@@ -1,0 +1,44 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/expect-region-supply-region.rs:28:13
+   |
+LL |         f = Some(x); //~ ERROR borrowed data cannot be stored outside of its closure
+   |             ^^^^^^^
+
+warning: not reporting region error due to -Znll
+  --> $DIR/expect-region-supply-region.rs:38:13
+   |
+LL |         f = Some(x); //~ ERROR borrowed data cannot be stored outside of its closure
+   |             ^^^^^^^
+
+warning: not reporting region error due to -Znll
+  --> $DIR/expect-region-supply-region.rs:47:33
+   |
+LL |     closure_expecting_bound(|x: &'x u32| {
+   |                                 ^^^^^^^
+
+warning: not reporting region error due to -Znll
+  --> $DIR/expect-region-supply-region.rs:52:13
+   |
+LL |         f = Some(x);
+   |             ^^^^^^^
+
+error: free region `` does not outlive free region `'_#2r`
+  --> $DIR/expect-region-supply-region.rs:28:18
+   |
+LL |         f = Some(x); //~ ERROR borrowed data cannot be stored outside of its closure
+   |                  ^
+
+error: free region `` does not outlive free region `'_#2r`
+  --> $DIR/expect-region-supply-region.rs:38:18
+   |
+LL |         f = Some(x); //~ ERROR borrowed data cannot be stored outside of its closure
+   |                  ^
+
+error: free region `` does not outlive free region `'_#2r`
+  --> $DIR/expect-region-supply-region.rs:52:18
+   |
+LL |         f = Some(x);
+   |                  ^
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/closure_context/issue-42065.nll.stderr
+++ b/src/test/ui/closure_context/issue-42065.nll.stderr
@@ -1,0 +1,11 @@
+error[E0382]: use of moved value: `debug_dump_dict`
+  --> $DIR/issue-42065.rs:21:5
+   |
+LL |     debug_dump_dict();
+   |     --------------- value moved here
+LL |     debug_dump_dict();
+   |     ^^^^^^^^^^^^^^^ value used here after move
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/codemap_tests/huge_multispan_highlight.nll.stderr
+++ b/src/test/ui/codemap_tests/huge_multispan_highlight.nll.stderr
@@ -1,0 +1,9 @@
+error[E0596]: cannot borrow immutable item `x` as mutable
+  --> $DIR/huge_multispan_highlight.rs:100:13
+   |
+LL |     let y = &mut x; //~ ERROR cannot borrow
+   |             ^^^^^^ cannot borrow as mutable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/codemap_tests/issue-11715.nll.stderr
+++ b/src/test/ui/codemap_tests/issue-11715.nll.stderr
@@ -1,0 +1,12 @@
+error: compilation successful
+  --> $DIR/issue-11715.rs:97:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     let mut x = "foo";
+LL | |     let y = &mut x;
+LL | |     let z = &mut x; //~ ERROR cannot borrow
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/codemap_tests/issue-11715.rs
+++ b/src/test/ui/codemap_tests/issue-11715.rs
@@ -93,8 +93,8 @@
 
 
 
-
-fn main() {
+#![feature(rustc_attrs)]
+fn main() { #![rustc_error] // rust-lang/rust#49855
     let mut x = "foo";
     let y = &mut x;
     let z = &mut x; //~ ERROR cannot borrow

--- a/src/test/ui/codemap_tests/one_line.nll.stderr
+++ b/src/test/ui/codemap_tests/one_line.nll.stderr
@@ -1,0 +1,13 @@
+error[E0499]: cannot borrow `v` as mutable more than once at a time
+  --> $DIR/one_line.rs:13:12
+   |
+LL |     v.push(v.pop().unwrap()); //~ ERROR cannot borrow
+   |     -------^----------------
+   |     |      |
+   |     |      second mutable borrow occurs here
+   |     first mutable borrow occurs here
+   |     borrow later used here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0499`.

--- a/src/test/ui/codemap_tests/overlapping_spans.nll.stderr
+++ b/src/test/ui/codemap_tests/overlapping_spans.nll.stderr
@@ -1,0 +1,9 @@
+error[E0509]: cannot move out of type `S`, which implements the `Drop` trait
+  --> $DIR/overlapping_spans.rs:21:14
+   |
+LL |         S {f:_s} => {} //~ ERROR cannot move out
+   |              ^^ cannot move out of here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0509`.

--- a/src/test/ui/codemap_tests/tab_3.nll.stderr
+++ b/src/test/ui/codemap_tests/tab_3.nll.stderr
@@ -1,0 +1,14 @@
+error[E0382]: borrow of moved value: `some_vec`
+  --> $DIR/tab_3.rs:17:20
+   |
+LL |     some_vec.into_iter();
+   |     -------- value moved here
+LL |     {
+LL |         println!("{:?}", some_vec); //~ ERROR use of moved
+   |                          ^^^^^^^^ value borrowed here after move
+   |
+   = note: move occurs because `some_vec` has type `std::vec::Vec<&str>`, which does not implement the `Copy` trait
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/command-line-diagnostics.nll.stderr
+++ b/src/test/ui/command-line-diagnostics.nll.stderr
@@ -1,0 +1,11 @@
+error[E0384]: cannot assign twice to immutable variable `x`
+  --> $DIR/command-line-diagnostics.rs:16:5
+   |
+LL |     let x = 42;
+   |             -- first assignment to `x`
+LL |     x = 43;
+   |     ^^^^^^ cannot assign twice to immutable variable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0384`.

--- a/src/test/ui/did_you_mean/issue-31424.nll.stderr
+++ b/src/test/ui/did_you_mean/issue-31424.nll.stderr
@@ -1,0 +1,15 @@
+error[E0596]: cannot borrow immutable item `self` as mutable
+  --> $DIR/issue-31424.rs:17:9
+   |
+LL |         (&mut self).bar(); //~ ERROR cannot borrow
+   |         ^^^^^^^^^^^ cannot borrow as mutable
+
+error[E0596]: cannot borrow immutable item `self` as mutable
+  --> $DIR/issue-31424.rs:23:9
+   |
+LL |         (&mut self).bar(); //~ ERROR cannot borrow
+   |         ^^^^^^^^^^^ cannot borrow as mutable
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/did_you_mean/issue-34126.nll.stderr
+++ b/src/test/ui/did_you_mean/issue-34126.nll.stderr
@@ -1,0 +1,13 @@
+error[E0502]: cannot borrow `self` as mutable because it is also borrowed as immutable
+  --> $DIR/issue-34126.rs:16:18
+   |
+LL |         self.run(&mut self); //~ ERROR cannot borrow
+   |         ---------^^^^^^^^^-
+   |         |        |
+   |         |        mutable borrow occurs here
+   |         immutable borrow occurs here
+   |         borrow later used here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0502`.

--- a/src/test/ui/did_you_mean/issue-34337.nll.stderr
+++ b/src/test/ui/did_you_mean/issue-34337.nll.stderr
@@ -1,0 +1,9 @@
+error[E0596]: cannot borrow immutable item `key` as mutable
+  --> $DIR/issue-34337.rs:16:9
+   |
+LL |     get(&mut key); //~ ERROR cannot borrow
+   |         ^^^^^^^^ cannot borrow as mutable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/did_you_mean/issue-35937.nll.stderr
+++ b/src/test/ui/did_you_mean/issue-35937.nll.stderr
@@ -1,0 +1,28 @@
+error[E0596]: cannot borrow immutable item `f.v` as mutable
+  --> $DIR/issue-35937.rs:17:5
+   |
+LL |     f.v.push("cat".to_string()); //~ ERROR cannot borrow
+   |     ^^^ cannot borrow as mutable
+   |
+   = note: Value not mutable causing this error: `f`
+
+error[E0384]: cannot assign twice to immutable variable `s.x`
+  --> $DIR/issue-35937.rs:26:5
+   |
+LL |     let s = S { x: 42 };
+   |             ----------- first assignment to `s.x`
+LL |     s.x += 1; //~ ERROR cannot assign
+   |     ^^^^^^^^ cannot assign twice to immutable variable
+
+error[E0384]: cannot assign twice to immutable variable `s.x`
+  --> $DIR/issue-35937.rs:30:5
+   |
+LL | fn bar(s: S) {
+   |        - first assignment to `s.x`
+LL |     s.x += 1; //~ ERROR cannot assign
+   |     ^^^^^^^^ cannot assign twice to immutable variable
+
+error: aborting due to 3 previous errors
+
+Some errors occurred: E0384, E0596.
+For more information about an error, try `rustc --explain E0384`.

--- a/src/test/ui/did_you_mean/issue-37139.nll.stderr
+++ b/src/test/ui/did_you_mean/issue-37139.nll.stderr
@@ -1,0 +1,9 @@
+error[E0596]: cannot borrow immutable item `x` as mutable
+  --> $DIR/issue-37139.rs:22:18
+   |
+LL |             test(&mut x); //~ ERROR cannot borrow immutable
+   |                  ^^^^^^ cannot borrow as mutable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/did_you_mean/issue-38147-1.nll.stderr
+++ b/src/test/ui/did_you_mean/issue-38147-1.nll.stderr
@@ -1,0 +1,11 @@
+error[E0596]: cannot borrow immutable item `*self.s` as mutable
+  --> $DIR/issue-38147-1.rs:27:9
+   |
+LL |         self.s.push('x'); //~ ERROR cannot borrow data mutably
+   |         ^^^^^^ cannot borrow as mutable
+   |
+   = note: Value not mutable causing this error: `*self`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/did_you_mean/issue-38147-2.nll.stderr
+++ b/src/test/ui/did_you_mean/issue-38147-2.nll.stderr
@@ -1,0 +1,9 @@
+error[E0596]: cannot borrow immutable item `*self.s` as mutable
+  --> $DIR/issue-38147-2.rs:17:9
+   |
+LL |         self.s.push('x');
+   |         ^^^^^^ cannot borrow as mutable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/did_you_mean/issue-38147-3.nll.stderr
+++ b/src/test/ui/did_you_mean/issue-38147-3.nll.stderr
@@ -1,0 +1,9 @@
+error[E0596]: cannot borrow immutable item `*self.s` as mutable
+  --> $DIR/issue-38147-3.rs:17:9
+   |
+LL |         self.s.push('x');
+   |         ^^^^^^ cannot borrow as mutable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/did_you_mean/issue-38147-4.nll.stderr
+++ b/src/test/ui/did_you_mean/issue-38147-4.nll.stderr
@@ -1,0 +1,11 @@
+error[E0596]: cannot borrow immutable item `*f.s` as mutable
+  --> $DIR/issue-38147-4.rs:16:5
+   |
+LL |     f.s.push('x'); //~ ERROR cannot borrow data mutably
+   |     ^^^ cannot borrow as mutable
+   |
+   = note: Value not mutable causing this error: `*f`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/did_you_mean/issue-39544.nll.stderr
+++ b/src/test/ui/did_you_mean/issue-39544.nll.stderr
@@ -1,0 +1,98 @@
+error[E0596]: cannot borrow immutable item `z.x` as mutable
+  --> $DIR/issue-39544.rs:21:13
+   |
+LL |     let _ = &mut z.x; //~ ERROR cannot borrow
+   |             ^^^^^^^^ cannot borrow as mutable
+   |
+   = note: Value not mutable causing this error: `z`
+
+error[E0596]: cannot borrow immutable item `self.x` as mutable
+  --> $DIR/issue-39544.rs:26:17
+   |
+LL |         let _ = &mut self.x; //~ ERROR cannot borrow
+   |                 ^^^^^^^^^^^ cannot borrow as mutable
+   |
+   = note: Value not mutable causing this error: `*self`
+
+error[E0596]: cannot borrow immutable item `self.x` as mutable
+  --> $DIR/issue-39544.rs:30:17
+   |
+LL |         let _ = &mut self.x; //~ ERROR cannot borrow
+   |                 ^^^^^^^^^^^ cannot borrow as mutable
+   |
+   = note: Value not mutable causing this error: `*self`
+
+error[E0596]: cannot borrow immutable item `other.x` as mutable
+  --> $DIR/issue-39544.rs:31:17
+   |
+LL |         let _ = &mut other.x; //~ ERROR cannot borrow
+   |                 ^^^^^^^^^^^^ cannot borrow as mutable
+   |
+   = note: Value not mutable causing this error: `*other`
+
+error[E0596]: cannot borrow immutable item `self.x` as mutable
+  --> $DIR/issue-39544.rs:35:17
+   |
+LL |         let _ = &mut self.x; //~ ERROR cannot borrow
+   |                 ^^^^^^^^^^^ cannot borrow as mutable
+   |
+   = note: Value not mutable causing this error: `*self`
+
+error[E0596]: cannot borrow immutable item `other.x` as mutable
+  --> $DIR/issue-39544.rs:36:17
+   |
+LL |         let _ = &mut other.x; //~ ERROR cannot borrow
+   |                 ^^^^^^^^^^^^ cannot borrow as mutable
+   |
+   = note: Value not mutable causing this error: `*other`
+
+error[E0596]: cannot borrow immutable item `self.x` as mutable
+  --> $DIR/issue-39544.rs:40:17
+   |
+LL |         let _ = &mut self.x; //~ ERROR cannot borrow
+   |                 ^^^^^^^^^^^ cannot borrow as mutable
+   |
+   = note: Value not mutable causing this error: `*self`
+
+error[E0596]: cannot borrow immutable item `other.x` as mutable
+  --> $DIR/issue-39544.rs:41:17
+   |
+LL |         let _ = &mut other.x; //~ ERROR cannot borrow
+   |                 ^^^^^^^^^^^^ cannot borrow as mutable
+   |
+   = note: Value not mutable causing this error: `*other`
+
+error[E0596]: cannot borrow immutable item `other.x` as mutable
+  --> $DIR/issue-39544.rs:45:17
+   |
+LL |         let _ = &mut other.x; //~ ERROR cannot borrow
+   |                 ^^^^^^^^^^^^ cannot borrow as mutable
+   |
+   = note: Value not mutable causing this error: `*other`
+
+error[E0596]: cannot borrow immutable item `z.x` as mutable
+  --> $DIR/issue-39544.rs:51:13
+   |
+LL |     let _ = &mut z.x; //~ ERROR cannot borrow
+   |             ^^^^^^^^ cannot borrow as mutable
+   |
+   = note: Value not mutable causing this error: `z`
+
+error[E0596]: cannot borrow immutable item `w.x` as mutable
+  --> $DIR/issue-39544.rs:52:13
+   |
+LL |     let _ = &mut w.x; //~ ERROR cannot borrow
+   |             ^^^^^^^^ cannot borrow as mutable
+   |
+   = note: Value not mutable causing this error: `*w`
+
+error[E0594]: cannot assign to immutable item `*x.0`
+  --> $DIR/issue-39544.rs:58:5
+   |
+LL |     *x.0 = 1;
+   |     ^^^^^^^^ cannot mutate
+
+error: aborting due to 12 previous errors
+
+Some errors occurred: E0594, E0596.
+For more information about an error, try `rustc --explain E0594`.

--- a/src/test/ui/did_you_mean/issue-40823.nll.stderr
+++ b/src/test/ui/did_you_mean/issue-40823.nll.stderr
@@ -1,0 +1,9 @@
+error[E0596]: cannot borrow immutable item `*buf` as mutable
+  --> $DIR/issue-40823.rs:13:5
+   |
+LL |     buf.iter_mut(); //~ ERROR cannot borrow immutable borrowed content
+   |     ^^^ cannot borrow as mutable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/dropck/dropck-eyepatch-extern-crate.nll.stderr
+++ b/src/test/ui/dropck/dropck-eyepatch-extern-crate.nll.stderr
@@ -1,0 +1,14 @@
+error: compilation successful
+  --> $DIR/dropck-eyepatch-extern-crate.rs:27:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     use std::cell::Cell;
+LL | |     let c_long;
+LL | |     let (c, mut dt, mut dr, mut pt, mut pr, st, sr)
+...  |
+LL | |     println!("{:?}", (dt.0, dr.0, pt.0, pr.0, st.0, sr.0));
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/dropck/dropck-eyepatch-extern-crate.rs
+++ b/src/test/ui/dropck/dropck-eyepatch-extern-crate.rs
@@ -19,12 +19,12 @@
 //
 // See also dropck-eyepatch.rs for more information about the general
 // structure of the test.
-
+#![feature(rustc_attrs)]
 extern crate dropck_eyepatch_extern_crate as other;
 
 use other::{Dt,Dr,Pt,Pr,St,Sr};
 
-fn main() {
+fn main() { #![rustc_error] // rust-lang/rust#49855
     use std::cell::Cell;
     let c_long;
     let (c, mut dt, mut dr, mut pt, mut pr, st, sr)

--- a/src/test/ui/dropck/dropck-eyepatch-reorder.nll.stderr
+++ b/src/test/ui/dropck/dropck-eyepatch-reorder.nll.stderr
@@ -1,0 +1,14 @@
+error: compilation successful
+  --> $DIR/dropck-eyepatch-reorder.rs:44:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     use std::cell::Cell;
+LL | |     let c_long;
+LL | |     let (c, mut dt, mut dr, mut pt, mut pr, st, sr)
+...  |
+LL | |     println!("{:?}", (dt.0, dr.0, pt.0, pr.0, st.0, sr.0));
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/dropck/dropck-eyepatch-reorder.rs
+++ b/src/test/ui/dropck/dropck-eyepatch-reorder.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(dropck_eyepatch)]
+#![feature(dropck_eyepatch, rustc_attrs)]
 
 // The point of this test is to test uses of `#[may_dangle]` attribute
 // where the formal declaration order (in the impl generics) does not
@@ -41,7 +41,7 @@ unsafe impl<'b, #[may_dangle] 'a, B: fmt::Debug> Drop for Pr<'a, 'b, B> {
     fn drop(&mut self) { println!("drop {} {:?}", self.0, self.2); }
 }
 
-fn main() {
+fn main() { #![rustc_error] // rust-lang/rust#49855
     use std::cell::Cell;
     let c_long;
     let (c, mut dt, mut dr, mut pt, mut pr, st, sr)

--- a/src/test/ui/dropck/dropck-eyepatch.nll.stderr
+++ b/src/test/ui/dropck/dropck-eyepatch.nll.stderr
@@ -1,0 +1,14 @@
+error: compilation successful
+  --> $DIR/dropck-eyepatch.rs:67:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     use std::cell::Cell;
+LL | |     let c_long;
+LL | |     let (c, mut dt, mut dr, mut pt, mut pr, st, sr)
+...  |
+LL | |     println!("{:?}", (dt.0, dr.0, pt.0, pr.0, st.0, sr.0));
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/dropck/dropck-eyepatch.rs
+++ b/src/test/ui/dropck/dropck-eyepatch.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(dropck_eyepatch)]
+#![feature(dropck_eyepatch, rustc_attrs)]
 
 // The point of this test is to illustrate that the `#[may_dangle]`
 // attribute specifically allows, in the context of a type
@@ -64,7 +64,7 @@ unsafe impl<#[may_dangle] 'a, 'b, B: fmt::Debug> Drop for Pr<'a, 'b, B> {
     fn drop(&mut self) { println!("drop {} {:?}", self.0, self.2); }
 }
 
-fn main() {
+fn main() { #![rustc_error] // rust-lang/rust#49855
     use std::cell::Cell;
     let c_long;
     let (c, mut dt, mut dr, mut pt, mut pr, st, sr)

--- a/src/test/ui/error-codes/E0017.nll.stderr
+++ b/src/test/ui/error-codes/E0017.nll.stderr
@@ -1,0 +1,28 @@
+error[E0017]: references in constants may only refer to immutable values
+  --> $DIR/E0017.rs:14:30
+   |
+LL | const CR: &'static mut i32 = &mut C; //~ ERROR E0017
+   |                              ^^^^^^ constants require immutable values
+
+error[E0017]: references in statics may only refer to immutable values
+  --> $DIR/E0017.rs:15:39
+   |
+LL | static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
+   |                                       ^^^^^^ statics require immutable values
+
+error[E0017]: references in statics may only refer to immutable values
+  --> $DIR/E0017.rs:17:38
+   |
+LL | static CONST_REF: &'static mut i32 = &mut C; //~ ERROR E0017
+   |                                      ^^^^^^ statics require immutable values
+
+error[E0596]: cannot borrow immutable item `X` as mutable
+  --> $DIR/E0017.rs:15:39
+   |
+LL | static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
+   |                                       ^^^^^^ cannot borrow as mutable
+
+error: aborting due to 4 previous errors
+
+Some errors occurred: E0017, E0596.
+For more information about an error, try `rustc --explain E0017`.

--- a/src/test/ui/error-codes/E0161.nll.stderr
+++ b/src/test/ui/error-codes/E0161.nll.stderr
@@ -1,0 +1,16 @@
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/E0161.rs:14:28
+   |
+LL |     let _x: Box<str> = box *"hello"; //~ ERROR E0161
+   |                            ^^^^^^^^ cannot move out of borrowed content
+
+error[E0161]: cannot move a value of type str: the size of str cannot be statically determined
+  --> $DIR/E0161.rs:14:28
+   |
+LL |     let _x: Box<str> = box *"hello"; //~ ERROR E0161
+   |                            ^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0161, E0507.
+For more information about an error, try `rustc --explain E0161`.

--- a/src/test/ui/error-codes/E0388.nll.stderr
+++ b/src/test/ui/error-codes/E0388.nll.stderr
@@ -1,0 +1,28 @@
+error[E0017]: references in constants may only refer to immutable values
+  --> $DIR/E0388.rs:14:30
+   |
+LL | const CR: &'static mut i32 = &mut C; //~ ERROR E0017
+   |                              ^^^^^^ constants require immutable values
+
+error[E0017]: references in statics may only refer to immutable values
+  --> $DIR/E0388.rs:15:39
+   |
+LL | static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
+   |                                       ^^^^^^ statics require immutable values
+
+error[E0017]: references in statics may only refer to immutable values
+  --> $DIR/E0388.rs:17:38
+   |
+LL | static CONST_REF: &'static mut i32 = &mut C; //~ ERROR E0017
+   |                                      ^^^^^^ statics require immutable values
+
+error[E0596]: cannot borrow immutable item `X` as mutable
+  --> $DIR/E0388.rs:15:39
+   |
+LL | static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
+   |                                       ^^^^^^ cannot borrow as mutable
+
+error: aborting due to 4 previous errors
+
+Some errors occurred: E0017, E0596.
+For more information about an error, try `rustc --explain E0017`.

--- a/src/test/ui/error-codes/E0389.nll.stderr
+++ b/src/test/ui/error-codes/E0389.nll.stderr
@@ -1,0 +1,11 @@
+error[E0594]: cannot assign to immutable item `fancy_ref.num`
+  --> $DIR/E0389.rs:18:5
+   |
+LL |     fancy_ref.num = 6; //~ ERROR E0389
+   |     ^^^^^^^^^^^^^^^^^ cannot mutate
+   |
+   = note: Value not mutable causing this error: `*fancy_ref`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0594`.

--- a/src/test/ui/error-codes/E0499.nll.stderr
+++ b/src/test/ui/error-codes/E0499.nll.stderr
@@ -1,0 +1,12 @@
+error: compilation successful
+  --> $DIR/E0499.rs:11:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     let mut i = 0;
+LL | |     let mut x = &mut i;
+LL | |     let mut a = &mut i; //~ ERROR E0499
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/error-codes/E0499.rs
+++ b/src/test/ui/error-codes/E0499.rs
@@ -7,8 +7,8 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
-fn main() {
+#![feature(rustc_attrs)]
+fn main() { #![rustc_error] // rust-lang/rust#49855
     let mut i = 0;
     let mut x = &mut i;
     let mut a = &mut i; //~ ERROR E0499

--- a/src/test/ui/error-codes/E0502.nll.stderr
+++ b/src/test/ui/error-codes/E0502.nll.stderr
@@ -1,0 +1,9 @@
+error: compilation successful
+  --> $DIR/E0502.rs:17:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/error-codes/E0502.rs
+++ b/src/test/ui/error-codes/E0502.rs
@@ -7,12 +7,12 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
+#![feature(rustc_attrs)]
 fn bar(x: &mut i32) {}
 fn foo(a: &mut i32) {
     let ref y = a;
     bar(a); //~ ERROR E0502
 }
 
-fn main() {
+fn main() { #![rustc_error] // rust-lang/rust#49855
 }

--- a/src/test/ui/error-codes/E0503.nll.stderr
+++ b/src/test/ui/error-codes/E0503.nll.stderr
@@ -1,0 +1,12 @@
+error: compilation successful
+  --> $DIR/E0503.rs:11:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     let mut value = 3;
+LL | |     let _borrow = &mut value;
+LL | |     let _sum = value + 1; //~ ERROR E0503
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/error-codes/E0503.rs
+++ b/src/test/ui/error-codes/E0503.rs
@@ -7,8 +7,8 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
-fn main() {
+#![feature(rustc_attrs)]
+fn main() { #![rustc_error] // rust-lang/rust#49855
     let mut value = 3;
     let _borrow = &mut value;
     let _sum = value + 1; //~ ERROR E0503

--- a/src/test/ui/error-codes/E0504.nll.stderr
+++ b/src/test/ui/error-codes/E0504.nll.stderr
@@ -1,0 +1,18 @@
+error[E0505]: cannot move out of `fancy_num` because it is borrowed
+  --> $DIR/E0504.rs:19:13
+   |
+LL |       let fancy_ref = &fancy_num;
+   |                       ---------- borrow of `fancy_num` occurs here
+LL | 
+LL |       let x = move || {
+   |  _____________^
+LL | |         println!("child function: {}", fancy_num.num); //~ ERROR E0504
+LL | |     };
+   | |_____^ move out of `fancy_num` occurs here
+...
+LL |       println!("main function: {}", fancy_ref.num);
+   |                                     ------------- borrow later used here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0505`.

--- a/src/test/ui/error-codes/E0505.nll.stderr
+++ b/src/test/ui/error-codes/E0505.nll.stderr
@@ -1,0 +1,14 @@
+error: compilation successful
+  --> $DIR/E0505.rs:15:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     let x = Value{};
+LL | |     {
+LL | |         let _ref_to_val: &Value = &x;
+LL | |         eat(x); //~ ERROR E0505
+LL | |     }
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/error-codes/E0505.rs
+++ b/src/test/ui/error-codes/E0505.rs
@@ -7,12 +7,12 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
+#![feature(rustc_attrs)]
 struct Value {}
 
 fn eat(val: Value) {}
 
-fn main() {
+fn main() { #![rustc_error] // rust-lang/rust#49855
     let x = Value{};
     {
         let _ref_to_val: &Value = &x;

--- a/src/test/ui/error-codes/E0509.nll.stderr
+++ b/src/test/ui/error-codes/E0509.nll.stderr
@@ -1,0 +1,9 @@
+error[E0509]: cannot move out of type `DropStruct`, which implements the `Drop` trait
+  --> $DIR/E0509.rs:26:23
+   |
+LL |     let fancy_field = drop_struct.fancy; //~ ERROR E0509
+   |                       ^^^^^^^^^^^^^^^^^ cannot move out of here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0509`.

--- a/src/test/ui/error-codes/E0597.nll.stderr
+++ b/src/test/ui/error-codes/E0597.nll.stderr
@@ -1,0 +1,13 @@
+error: compilation successful
+  --> $DIR/E0597.rs:15:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     let mut x = Foo { x: None };
+LL | |     let y = 0;
+LL | |     x.x = Some(&y);
+LL | |     //~^ `y` does not live long enough [E0597]
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/error-codes/E0597.rs
+++ b/src/test/ui/error-codes/E0597.rs
@@ -7,12 +7,12 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
+#![feature(rustc_attrs)]
 struct Foo<'a> {
     x: Option<&'a u32>,
 }
 
-fn main() {
+fn main() { #![rustc_error] // rust-lang/rust#49855
     let mut x = Foo { x: None };
     let y = 0;
     x.x = Some(&y);

--- a/src/test/ui/error-codes/E0621-does-not-trigger-for-closures.nll.stderr
+++ b/src/test/ui/error-codes/E0621-does-not-trigger-for-closures.nll.stderr
@@ -1,0 +1,14 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/E0621-does-not-trigger-for-closures.rs:25:5
+   |
+LL |     invoke(&x, |a, b| if a > b { a } else { b }); //~ ERROR E0495
+   |     ^^^^^^
+
+error: free region `` does not outlive free region `'_#2r`
+  --> $DIR/E0621-does-not-trigger-for-closures.rs:25:26
+   |
+LL |     invoke(&x, |a, b| if a > b { a } else { b }); //~ ERROR E0495
+   |                          ^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/feature-gate-nll.nll.stderr
+++ b/src/test/ui/feature-gate-nll.nll.stderr
@@ -1,0 +1,13 @@
+error: compilation successful
+  --> $DIR/feature-gate-nll.rs:13:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     let mut x = 33;
+LL | |
+LL | |     let p = &x;
+LL | |     x = 22; //~ ERROR cannot assign to `x` because it is borrowed [E0506]
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/feature-gate-nll.rs
+++ b/src/test/ui/feature-gate-nll.rs
@@ -7,10 +7,10 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
+#![feature(rustc_attrs)]
 #![allow(dead_code)]
 
-fn main() {
+fn main() { #![rustc_error] // rust-lang/rust#49855
     let mut x = 33;
 
     let p = &x;

--- a/src/test/ui/generator/borrowing.nll.stderr
+++ b/src/test/ui/generator/borrowing.nll.stderr
@@ -1,0 +1,14 @@
+error: compilation successful
+  --> $DIR/borrowing.rs:15:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     let _b = {
+LL | |         let a = 3;
+LL | |         unsafe { (|| yield &a).resume() }
+...  |
+LL | |     };
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/generator/borrowing.rs
+++ b/src/test/ui/generator/borrowing.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(generators, generator_trait)]
+#![feature(generators, generator_trait, rustc_attrs)]
 
 use std::ops::Generator;
 
-fn main() {
+fn main() { #![rustc_error] // rust-lang/rust#49855
     let _b = {
         let a = 3;
         unsafe { (|| yield &a).resume() }

--- a/src/test/ui/generator/dropck.nll.stderr
+++ b/src/test/ui/generator/dropck.nll.stderr
@@ -1,0 +1,14 @@
+error: compilation successful
+  --> $DIR/dropck.rs:16:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     let (cell, mut gen);
+LL | |     cell = Box::new(RefCell::new(0));
+LL | |     let ref_ = Box::leak(Box::new(Some(cell.borrow_mut())));
+...  |
+LL | |     // drops the RefCell and then the Ref, leading to use-after-free
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/generator/dropck.rs
+++ b/src/test/ui/generator/dropck.rs
@@ -8,12 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(generators, generator_trait, box_leak)]
+#![feature(generators, generator_trait, box_leak, rustc_attrs)]
 
 use std::cell::RefCell;
 use std::ops::Generator;
 
-fn main() {
+fn main() { #![rustc_error] // rust-lang/rust#49855
     let (cell, mut gen);
     cell = Box::new(RefCell::new(0));
     let ref_ = Box::leak(Box::new(Some(cell.borrow_mut())));

--- a/src/test/ui/generator/pattern-borrow.nll.stderr
+++ b/src/test/ui/generator/pattern-borrow.nll.stderr
@@ -1,0 +1,8 @@
+error: compilation successful
+  --> $DIR/pattern-borrow.rs:15:1
+   |
+LL | fn main() { #![rustc_error] } // rust-lang/rust#49855
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/generator/pattern-borrow.rs
+++ b/src/test/ui/generator/pattern-borrow.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(generators)]
+#![feature(generators, rustc_attrs)]
 
 enum Test { A(i32), B, }
 
-fn main() { }
+fn main() { #![rustc_error] } // rust-lang/rust#49855
 
 fn fun(test: Test) {
     move || {

--- a/src/test/ui/generator/ref-escapes-but-not-over-yield.nll.stderr
+++ b/src/test/ui/generator/ref-escapes-but-not-over-yield.nll.stderr
@@ -1,0 +1,12 @@
+error[E0597]: `b` does not live long enough
+  --> $DIR/ref-escapes-but-not-over-yield.rs:24:13
+   |
+LL |         a = &b;
+   |             ^^ borrowed value does not live long enough
+LL |         //~^ ERROR `b` does not live long enough
+LL |     };
+   |     - borrowed value only lives until here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/generator/yield-in-args.nll.stderr
+++ b/src/test/ui/generator/yield-in-args.nll.stderr
@@ -1,0 +1,9 @@
+error[E0626]: borrow may still be in use when generator yields
+  --> $DIR/yield-in-args.rs:18:13
+   |
+LL |         foo(&b, yield); //~ ERROR
+   |             ^^  ----- possible yield occurs here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0626`.

--- a/src/test/ui/generator/yield-while-iterating.nll.stderr
+++ b/src/test/ui/generator/yield-while-iterating.nll.stderr
@@ -1,0 +1,55 @@
+error[E0626]: borrow may still be in use when generator yields
+  --> $DIR/yield-while-iterating.rs:22:18
+   |
+LL |         for p in &x { //~ ERROR
+   |                  ^^
+LL |             yield();
+   |             ------- possible yield occurs here
+
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/yield-while-iterating.rs:50:17
+   |
+LL |       let mut b = || {
+   |  _________________^
+LL | |         for p in &mut x {
+LL | |             yield p;
+LL | |         }
+LL | |     };
+   | |     ^
+   | |     |
+   | |_____temporary value only lives until here
+   |       temporary value does not live long enough
+
+error[E0502]: cannot borrow `x` as immutable because it is also borrowed as mutable
+  --> $DIR/yield-while-iterating.rs:67:20
+   |
+LL |       let mut b = || {
+   |  _________________-
+LL | |         for p in &mut x {
+LL | |             yield p;
+LL | |         }
+LL | |     };
+   | |_____- mutable borrow occurs here
+LL |       println!("{}", x[0]); //~ ERROR
+   |                      ^ immutable borrow occurs here
+LL |       b.resume();
+   |       - borrow later used here
+
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/yield-while-iterating.rs:62:17
+   |
+LL |       let mut b = || {
+   |  _________________^
+LL | |         for p in &mut x {
+LL | |             yield p;
+LL | |         }
+LL | |     };
+   | |     ^
+   | |     |
+   | |_____temporary value only lives until here
+   |       temporary value does not live long enough
+
+error: aborting due to 4 previous errors
+
+Some errors occurred: E0502, E0597, E0626.
+For more information about an error, try `rustc --explain E0502`.

--- a/src/test/ui/generator/yield-while-ref-reborrowed.nll.stderr
+++ b/src/test/ui/generator/yield-while-ref-reborrowed.nll.stderr
@@ -1,0 +1,18 @@
+error[E0501]: cannot borrow `x` as immutable because previous closure requires unique access
+  --> $DIR/yield-while-ref-reborrowed.rs:45:20
+   |
+LL |       let mut b = || {
+   |  _________________-
+LL | |         let a = &mut *x;
+LL | |         yield();
+LL | |         println!("{}", a);
+LL | |     };
+   | |_____- closure construction occurs here
+LL |       println!("{}", x); //~ ERROR
+   |                      ^ borrow occurs here
+LL |       b.resume();
+   |       - borrow later used here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0501`.

--- a/src/test/ui/in-band-lifetimes/impl/dyn-trait.nll.stderr
+++ b/src/test/ui/in-band-lifetimes/impl/dyn-trait.nll.stderr
@@ -1,0 +1,14 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/dyn-trait.rs:33:16
+   |
+LL |     static_val(x); //~ ERROR cannot infer
+   |                ^
+
+error: free region `'a` does not outlive free region `'static`
+  --> $DIR/dyn-trait.rs:33:5
+   |
+LL |     static_val(x); //~ ERROR cannot infer
+   |     ^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/in-band-lifetimes/mismatched.nll.stderr
+++ b/src/test/ui/in-band-lifetimes/mismatched.nll.stderr
@@ -1,0 +1,32 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/mismatched.rs:14:42
+   |
+LL | fn foo(x: &'a u32, y: &u32) -> &'a u32 { y } //~ ERROR explicit lifetime required
+   |                                          ^
+
+warning: not reporting region error due to -Znll
+  --> $DIR/mismatched.rs:16:46
+   |
+LL | fn foo2(x: &'a u32, y: &'b u32) -> &'a u32 { y } //~ ERROR lifetime mismatch
+   |                                              ^
+
+error[E0621]: explicit lifetime required in the type of `y`
+  --> $DIR/mismatched.rs:14:42
+   |
+LL | fn foo(x: &'a u32, y: &u32) -> &'a u32 { y } //~ ERROR explicit lifetime required
+   |                    -                     ^ lifetime `'a` required
+   |                    |
+   |                    consider changing the type of `y` to `&'a u32`
+
+error[E0623]: lifetime mismatch
+  --> $DIR/mismatched.rs:16:46
+   |
+LL | fn foo2(x: &'a u32, y: &'b u32) -> &'a u32 { y } //~ ERROR lifetime mismatch
+   |                        -------     -------   ^ ...but data from `y` is returned here
+   |                        |
+   |                        this parameter and the return type are declared with different lifetimes...
+
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0621, E0623.
+For more information about an error, try `rustc --explain E0621`.

--- a/src/test/ui/in-band-lifetimes/mismatched_trait.nll.stderr
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/mismatched_trait.rs:16:9
+   |
+LL |         y //~ ERROR explicit lifetime required
+   |         ^
+
+error[E0621]: explicit lifetime required in the type of `y`
+  --> $DIR/mismatched_trait.rs:16:9
+   |
+LL |     fn baz(&self, x: &'a u32, y: &u32) -> &'a u32 {
+   |                               - consider changing the type of `y` to `&'a u32`
+LL |         y //~ ERROR explicit lifetime required
+   |         ^ lifetime `'a` required
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0621`.

--- a/src/test/ui/in-band-lifetimes/mut_while_borrow.nll.stderr
+++ b/src/test/ui/in-band-lifetimes/mut_while_borrow.nll.stderr
@@ -1,0 +1,13 @@
+error[E0506]: cannot assign to `p` because it is borrowed
+  --> $DIR/mut_while_borrow.rs:19:5
+   |
+LL |     let r = foo(&p);
+   |                 -- borrow of `p` occurs here
+LL |     p += 1; //~ ERROR cannot assign to `p` because it is borrowed
+   |     ^^^^^^ assignment to borrowed `p` occurs here
+LL |     println!("{}", r);
+   |                    - borrow later used here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0506`.

--- a/src/test/ui/issue-13058.nll.stderr
+++ b/src/test/ui/issue-13058.nll.stderr
@@ -1,0 +1,27 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/issue-13058.rs:24:21
+   |
+LL |     let cont_iter = cont.iter();
+   |                     ^^^^
+
+warning: not reporting region error due to -Znll
+  --> $DIR/issue-13058.rs:24:26
+   |
+LL |     let cont_iter = cont.iter();
+   |                          ^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/issue-13058.rs:36:11
+   |
+LL |     check((3, 5));
+   |           ^^^^^^
+   |           |
+   |           expected reference, found tuple
+   |           help: consider borrowing here: `&(3, 5)`
+   |
+   = note: expected type `&_`
+              found type `({integer}, {integer})`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/issue-17263.nll.stderr
+++ b/src/test/ui/issue-17263.nll.stderr
@@ -1,0 +1,14 @@
+error: compilation successful
+  --> $DIR/issue-17263.rs:15:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     let mut x: Box<_> = box Foo { a: 1, b: 2 };
+LL | |     let (a, b) = (&mut x.a, &mut x.b);
+LL | |     //~^ ERROR cannot borrow `x` (via `x.b`) as mutable more than once at a time
+...  |
+LL | |     //~^ ERROR cannot borrow `foo` (via `foo.b`) as immutable
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/issue-17263.rs
+++ b/src/test/ui/issue-17263.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(box_syntax)]
+#![feature(box_syntax, rustc_attrs)]
 
 struct Foo { a: isize, b: isize }
 
-fn main() {
+fn main() { #![rustc_error] // rust-lang/rust#49855
     let mut x: Box<_> = box Foo { a: 1, b: 2 };
     let (a, b) = (&mut x.a, &mut x.b);
     //~^ ERROR cannot borrow `x` (via `x.b`) as mutable more than once at a time

--- a/src/test/ui/issue-21600.nll.stderr
+++ b/src/test/ui/issue-21600.nll.stderr
@@ -1,0 +1,15 @@
+error[E0596]: cannot borrow immutable item `x` as mutable
+  --> $DIR/issue-21600.rs:24:20
+   |
+LL |         call_it(|| x.gen_mut()); //~ ERROR cannot borrow data mutably in a captured outer
+   |                    ^ cannot borrow as mutable
+
+error[E0596]: cannot borrow immutable item `x` as mutable
+  --> $DIR/issue-21600.rs:24:17
+   |
+LL |         call_it(|| x.gen_mut()); //~ ERROR cannot borrow data mutably in a captured outer
+   |                 ^^^^^^^^^^^^^^ cannot borrow as mutable
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/issue-25793.nll.stderr
+++ b/src/test/ui/issue-25793.nll.stderr
@@ -1,0 +1,8 @@
+error: compilation successful
+  --> $DIR/issue-25793.rs:32:1
+   |
+LL | fn main() { #![rustc_error] } // rust-lang/rust#49855
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/issue-25793.rs
+++ b/src/test/ui/issue-25793.rs
@@ -7,7 +7,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
+#![feature(rustc_attrs)]
 macro_rules! width(
     ($this:expr) => {
         $this.width.unwrap()
@@ -29,4 +29,4 @@ impl HasInfo {
     }
 }
 
-fn main() {}
+fn main() { #![rustc_error] } // rust-lang/rust#49855

--- a/src/test/ui/issue-36400.nll.stderr
+++ b/src/test/ui/issue-36400.nll.stderr
@@ -1,0 +1,11 @@
+error[E0596]: cannot borrow immutable item `*x` as mutable
+  --> $DIR/issue-36400.rs:15:7
+   |
+LL |     f(&mut *x); //~ ERROR cannot borrow immutable
+   |       ^^^^^^^ cannot borrow as mutable
+   |
+   = note: Value not mutable causing this error: `x`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/issue-40402-ref-hints/issue-40402-1.nll.stderr
+++ b/src/test/ui/issue-40402-ref-hints/issue-40402-1.nll.stderr
@@ -1,0 +1,9 @@
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/issue-40402-1.rs:19:13
+   |
+LL |     let e = f.v[0]; //~ ERROR cannot move out of indexed content
+   |             ^^^^^^ cannot move out of borrowed content
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0507`.

--- a/src/test/ui/issue-40402-ref-hints/issue-40402-2.nll.stderr
+++ b/src/test/ui/issue-40402-ref-hints/issue-40402-2.nll.stderr
@@ -1,0 +1,15 @@
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/issue-40402-2.rs:15:10
+   |
+LL |     let (a, b) = x[0]; //~ ERROR cannot move out of indexed content
+   |          ^ cannot move out of borrowed content
+
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/issue-40402-2.rs:15:13
+   |
+LL |     let (a, b) = x[0]; //~ ERROR cannot move out of indexed content
+   |             ^ cannot move out of borrowed content
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0507`.

--- a/src/test/ui/issue-42106.nll.stderr
+++ b/src/test/ui/issue-42106.nll.stderr
@@ -1,0 +1,8 @@
+error: compilation successful
+  --> $DIR/issue-42106.rs:16:1
+   |
+LL | fn main() { #![rustc_error] } // rust-lang/rust#49855
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/issue-42106.rs
+++ b/src/test/ui/issue-42106.rs
@@ -7,10 +7,10 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
+#![feature(rustc_attrs)]
 fn do_something<T>(collection: &mut Vec<T>) {
     let _a = &collection;
     collection.swap(1, 2); //~ ERROR also borrowed as immutable
 }
 
-fn main() {}
+fn main() { #![rustc_error] } // rust-lang/rust#49855

--- a/src/test/ui/issue-4335.nll.stderr
+++ b/src/test/ui/issue-4335.nll.stderr
@@ -1,0 +1,25 @@
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/issue-4335.rs:16:20
+   |
+LL |     id(Box::new(|| *v))
+   |                    ^^ cannot move out of borrowed content
+
+error[E0597]: `v` does not live long enough
+  --> $DIR/issue-4335.rs:16:17
+   |
+LL |     id(Box::new(|| *v))
+   |                 ^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | - borrowed value only lives until here
+   |
+note: borrowed value must be valid for the lifetime 'r as defined on the function body at 15:1...
+  --> $DIR/issue-4335.rs:15:1
+   |
+LL | fn f<'r, T>(v: &'r T) -> Box<FnMut() -> T + 'r> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0507, E0597.
+For more information about an error, try `rustc --explain E0507`.

--- a/src/test/ui/issue-45697-1.nll.stderr
+++ b/src/test/ui/issue-45697-1.nll.stderr
@@ -1,0 +1,34 @@
+error[E0506]: cannot assign to `*y.pointer` because it is borrowed (Ast)
+  --> $DIR/issue-45697-1.rs:30:9
+   |
+LL |         let z = copy_borrowed_ptr(&mut y);
+   |                                        - borrow of `*y.pointer` occurs here
+LL |         *y.pointer += 1;
+   |         ^^^^^^^^^^^^^^^ assignment to borrowed `*y.pointer` occurs here
+
+error[E0503]: cannot use `*y.pointer` because it was mutably borrowed (Mir)
+  --> $DIR/issue-45697-1.rs:30:9
+   |
+LL |         let z = copy_borrowed_ptr(&mut y);
+   |                                   ------ borrow of `y` occurs here
+LL |         *y.pointer += 1;
+   |         ^^^^^^^^^^^^^^^ use of borrowed `y`
+...
+LL |         *z.pointer += 1;
+   |         --------------- borrow later used here
+
+error[E0506]: cannot assign to `*y.pointer` because it is borrowed (Mir)
+  --> $DIR/issue-45697-1.rs:30:9
+   |
+LL |         let z = copy_borrowed_ptr(&mut y);
+   |                                   ------ borrow of `*y.pointer` occurs here
+LL |         *y.pointer += 1;
+   |         ^^^^^^^^^^^^^^^ assignment to borrowed `*y.pointer` occurs here
+...
+LL |         *z.pointer += 1;
+   |         --------------- borrow later used here
+
+error: aborting due to 3 previous errors
+
+Some errors occurred: E0503, E0506.
+For more information about an error, try `rustc --explain E0503`.

--- a/src/test/ui/issue-45697.nll.stderr
+++ b/src/test/ui/issue-45697.nll.stderr
@@ -1,0 +1,34 @@
+error[E0506]: cannot assign to `*y.pointer` because it is borrowed (Ast)
+  --> $DIR/issue-45697.rs:30:9
+   |
+LL |         let z = copy_borrowed_ptr(&mut y);
+   |                                        - borrow of `*y.pointer` occurs here
+LL |         *y.pointer += 1;
+   |         ^^^^^^^^^^^^^^^ assignment to borrowed `*y.pointer` occurs here
+
+error[E0503]: cannot use `*y.pointer` because it was mutably borrowed (Mir)
+  --> $DIR/issue-45697.rs:30:9
+   |
+LL |         let z = copy_borrowed_ptr(&mut y);
+   |                                   ------ borrow of `y` occurs here
+LL |         *y.pointer += 1;
+   |         ^^^^^^^^^^^^^^^ use of borrowed `y`
+...
+LL |         *z.pointer += 1;
+   |         --------------- borrow later used here
+
+error[E0506]: cannot assign to `*y.pointer` because it is borrowed (Mir)
+  --> $DIR/issue-45697.rs:30:9
+   |
+LL |         let z = copy_borrowed_ptr(&mut y);
+   |                                   ------ borrow of `*y.pointer` occurs here
+LL |         *y.pointer += 1;
+   |         ^^^^^^^^^^^^^^^ assignment to borrowed `*y.pointer` occurs here
+...
+LL |         *z.pointer += 1;
+   |         --------------- borrow later used here
+
+error: aborting due to 3 previous errors
+
+Some errors occurred: E0503, E0506.
+For more information about an error, try `rustc --explain E0503`.

--- a/src/test/ui/issue-46471-1.nll.stderr
+++ b/src/test/ui/issue-46471-1.nll.stderr
@@ -1,0 +1,28 @@
+error[E0597]: `z` does not live long enough (Ast)
+  --> $DIR/issue-46471-1.rs:16:14
+   |
+LL |         &mut z
+   |              ^ borrowed value does not live long enough
+LL |     };
+   |     - `z` dropped here while still borrowed
+...
+LL | }
+   | - borrowed value needs to live until here
+
+error[E0597]: `z` does not live long enough (Mir)
+  --> $DIR/issue-46471-1.rs:16:9
+   |
+LL |       let y = {
+   |  _____________-
+LL | |         let mut z = 0;
+LL | |         &mut z
+   | |         ^^^^^^ borrowed value does not live long enough
+LL | |     };
+   | |     -
+   | |     |
+   | |_____borrowed value only lives until here
+   |       borrow later used here
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/lifetime-errors/42701_one_named_and_one_anonymous.nll.stderr
+++ b/src/test/ui/lifetime-errors/42701_one_named_and_one_anonymous.nll.stderr
@@ -1,0 +1,22 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/42701_one_named_and_one_anonymous.rs:20:9
+   |
+LL |         &*x //~ ERROR explicit lifetime
+   |         ^^^
+
+error[E0621]: explicit lifetime required in the type of `x`
+  --> $DIR/42701_one_named_and_one_anonymous.rs:16:5
+   |
+LL |   fn foo2<'a>(a: &'a Foo, x: &i32) -> &'a i32 {
+   |                           - consider changing the type of `x` to `&'a i32`
+LL | /     if true {
+LL | |         let p: &i32 = &a.field;
+LL | |         &*p
+LL | |     } else {
+LL | |         &*x //~ ERROR explicit lifetime
+LL | |     }
+   | |_____^ lifetime `'a` required
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0621`.

--- a/src/test/ui/lifetime-errors/ex1-return-one-existing-name-early-bound-in-struct.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex1-return-one-existing-name-early-bound-in-struct.nll.stderr
@@ -1,0 +1,23 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex1-return-one-existing-name-early-bound-in-struct.rs:21:21
+   |
+LL |                     other //~ ERROR explicit lifetime
+   |                     ^^^^^
+
+error[E0621]: explicit lifetime required in the type of `other`
+  --> $DIR/ex1-return-one-existing-name-early-bound-in-struct.rs:18:9
+   |
+LL |       fn bar(&self, other: Foo) -> Foo<'a> {
+   |                     ----- consider changing the type of `other` to `Foo<'a>`
+LL | /         match *self {
+LL | |             Foo::Bar(s) => {
+LL | |                 if s == "test" {
+LL | |                     other //~ ERROR explicit lifetime
+...  |
+LL | |             }
+LL | |         }
+   | |_________^ lifetime `'a` required
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0621`.

--- a/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else-2.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else-2.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex1-return-one-existing-name-if-else-2.rs:12:16
+   |
+LL |     if x > y { x } else { y } //~ ERROR explicit lifetime
+   |                ^
+
+error[E0621]: explicit lifetime required in the type of `x`
+  --> $DIR/ex1-return-one-existing-name-if-else-2.rs:12:8
+   |
+LL | fn foo<'a>(x: &i32, y: &'a i32) -> &'a i32 {
+   |            - consider changing the type of `x` to `&'a i32`
+LL |     if x > y { x } else { y } //~ ERROR explicit lifetime
+   |        ^^^^^ lifetime `'a` required
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0621`.

--- a/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else-3.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else-3.nll.stderr
@@ -1,0 +1,18 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex1-return-one-existing-name-if-else-3.rs:12:27
+   |
+LL |     if x > y { x } else { y } //~ ERROR explicit lifetime
+   |                           ^
+
+error[E0621]: explicit lifetime required in parameter type
+  --> $DIR/ex1-return-one-existing-name-if-else-3.rs:11:13
+   |
+LL | fn foo<'a>((x, y): (&'a i32, &i32)) -> &'a i32 {
+   |            -^----
+   |            ||
+   |            |lifetime `'a` required
+   |            consider changing type to `(&'a i32, &'a i32)`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0621`.

--- a/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl-2.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl-2.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex1-return-one-existing-name-if-else-using-impl-2.rs:14:15
+   |
+LL |    if x > y { x } else { y } //~ ERROR explicit lifetime
+   |               ^
+
+error[E0621]: explicit lifetime required in the type of `x`
+  --> $DIR/ex1-return-one-existing-name-if-else-using-impl-2.rs:14:7
+   |
+LL | fn foo<'a>(x: &i32, y: &'a i32) -> &'a i32 {
+   |            - consider changing the type of `x` to `&'a i32`
+LL |    if x > y { x } else { y } //~ ERROR explicit lifetime
+   |       ^^^^^ lifetime `'a` required
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0621`.

--- a/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl-3.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl-3.nll.stderr
@@ -1,0 +1,18 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex1-return-one-existing-name-if-else-using-impl-3.rs:18:36
+   |
+LL |     if true { &self.field } else { x } //~ ERROR explicit lifetime
+   |                                    ^
+
+error[E0621]: explicit lifetime required in the type of `x`
+  --> $DIR/ex1-return-one-existing-name-if-else-using-impl-3.rs:18:5
+   |
+LL |   fn foo<'a>(&'a self, x: &i32) -> &i32 {
+   |                        - consider changing the type of `x` to `&'a i32`
+LL | 
+LL |     if true { &self.field } else { x } //~ ERROR explicit lifetime
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime `'a` required
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0621`.

--- a/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl.nll.stderr
@@ -1,0 +1,20 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex1-return-one-existing-name-if-else-using-impl.rs:21:20
+   |
+LL |         if x > y { x } else { y } //~ ERROR lifetime mismatch
+   |                    ^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex1-return-one-existing-name-if-else-using-impl.rs:21:12
+   |
+LL |     fn foo<'a>(x: &i32, y: &'a i32) -> &'a i32 {
+   |                   ----                 -------
+   |                   |
+   |                   this parameter and the return type are declared with different lifetimes...
+LL | 
+LL |         if x > y { x } else { y } //~ ERROR lifetime mismatch
+   |            ^^^^^ ...but data from `x` is returned here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex1-return-one-existing-name-if-else.rs:12:27
+   |
+LL |     if x > y { x } else { y } //~ ERROR explicit lifetime
+   |                           ^
+
+error[E0621]: explicit lifetime required in the type of `y`
+  --> $DIR/ex1-return-one-existing-name-if-else.rs:12:8
+   |
+LL | fn foo<'a>(x: &'a i32, y: &i32) -> &'a i32 {
+   |                        - consider changing the type of `y` to `&'a i32`
+LL |     if x > y { x } else { y } //~ ERROR explicit lifetime
+   |        ^^^^^ lifetime `'a` required
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0621`.

--- a/src/test/ui/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.nll.stderr
@@ -1,0 +1,20 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex1-return-one-existing-name-return-type-is-anon.rs:18:5
+   |
+LL |     x //~ ERROR lifetime mismatch
+   |     ^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex1-return-one-existing-name-return-type-is-anon.rs:18:5
+   |
+LL |   fn foo<'a>(&self, x: &'a i32) -> &i32 {
+   |                        -------     ----
+   |                        |
+   |                        this parameter and the return type are declared with different lifetimes...
+LL | 
+LL |     x //~ ERROR lifetime mismatch
+   |     ^ ...but data from `x` is returned here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex1-return-one-existing-name-self-is-anon.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex1-return-one-existing-name-self-is-anon.nll.stderr
@@ -1,0 +1,20 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex1-return-one-existing-name-self-is-anon.rs:18:30
+   |
+LL |         if true { x } else { self } //~ ERROR lifetime mismatch
+   |                              ^^^^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex1-return-one-existing-name-self-is-anon.rs:18:9
+   |
+LL |     fn foo<'a>(&self, x: &'a Foo) -> &'a Foo {
+   |                -----                 -------
+   |                |
+   |                this parameter and the return type are declared with different lifetimes...
+LL | 
+LL |         if true { x } else { self } //~ ERROR lifetime mismatch
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...but data from `self` is returned here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex2a-push-one-existing-name-2.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex2a-push-one-existing-name-2.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex2a-push-one-existing-name-2.rs:16:12
+   |
+LL |     y.push(x); //~ ERROR explicit lifetime
+   |            ^
+
+error[E0621]: explicit lifetime required in the type of `x`
+  --> $DIR/ex2a-push-one-existing-name-2.rs:16:5
+   |
+LL | fn foo<'a>(x: Ref<i32>, y: &mut Vec<Ref<'a, i32>>) {
+   |            - consider changing the type of `x` to `Ref<'a, i32>`
+LL |     y.push(x); //~ ERROR explicit lifetime
+   |     ^ lifetime `'a` required
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0621`.

--- a/src/test/ui/lifetime-errors/ex2a-push-one-existing-name-early-bound.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex2a-push-one-existing-name-early-bound.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex2a-push-one-existing-name-early-bound.rs:17:12
+   |
+LL |     x.push(y); //~ ERROR explicit lifetime required
+   |            ^
+
+error[E0282]: type annotations needed
+  --> $DIR/ex2a-push-one-existing-name-early-bound.rs:20:9
+   |
+LL | let x = baz;
+   |     -   ^^^ cannot infer type for `T`
+   |     |
+   |     consider giving `x` a type
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/lifetime-errors/ex2a-push-one-existing-name.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex2a-push-one-existing-name.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex2a-push-one-existing-name.rs:16:12
+   |
+LL |     x.push(y); //~ ERROR explicit lifetime
+   |            ^
+
+error[E0621]: explicit lifetime required in the type of `y`
+  --> $DIR/ex2a-push-one-existing-name.rs:16:5
+   |
+LL | fn foo<'a>(x: &mut Vec<Ref<'a, i32>>, y: Ref<i32>) {
+   |                                       - consider changing the type of `y` to `Ref<'a, i32>`
+LL |     x.push(y); //~ ERROR explicit lifetime
+   |     ^ lifetime `'a` required
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0621`.

--- a/src/test/ui/lifetime-errors/ex2b-push-no-existing-names.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex2b-push-no-existing-names.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex2b-push-no-existing-names.rs:16:12
+   |
+LL |     x.push(y); //~ ERROR lifetime mismatch
+   |            ^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex2b-push-no-existing-names.rs:16:5
+   |
+LL | fn foo(x: &mut Vec<Ref<i32>>, y: Ref<i32>) {
+   |                    --------      -------- these two types are declared with different lifetimes...
+LL |     x.push(y); //~ ERROR lifetime mismatch
+   |     ^ ...but data from `y` flows into `x` here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex2c-push-inference-variable.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex2c-push-inference-variable.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex2c-push-inference-variable.rs:16:13
+   |
+LL |     let z = Ref { data: y.data };
+   |             ^^^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex2c-push-inference-variable.rs:16:9
+   |
+LL | fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
+   |                                   ------------      ------------ these two types are declared with different lifetimes...
+LL |     let z = Ref { data: y.data };
+   |         ^ ...but data from `y` flows into `x` here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex2d-push-inference-variable-2.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex2d-push-inference-variable-2.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex2d-push-inference-variable-2.rs:17:13
+   |
+LL |     let b = Ref { data: y.data };
+   |             ^^^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex2d-push-inference-variable-2.rs:16:9
+   |
+LL | fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
+   |                                   ------------      ------------ these two types are declared with different lifetimes...
+LL |     let a: &mut Vec<Ref<i32>> = x; //~ ERROR lifetime mismatch
+   |         ^ ...but data from `y` flows into `x` here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex2e-push-inference-variable-3.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex2e-push-inference-variable-3.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex2e-push-inference-variable-3.rs:17:13
+   |
+LL |     let b = Ref { data: y.data };
+   |             ^^^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex2e-push-inference-variable-3.rs:16:9
+   |
+LL | fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
+   |                                   ------------      ------------ these two types are declared with different lifetimes...
+LL |     let a: &mut Vec<Ref<i32>> = x; //~ ERROR lifetime mismatch
+   |         ^ ...but data from `y` flows into `x` here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-2.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-2.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex3-both-anon-regions-2.rs:12:9
+   |
+LL |     v = x; //~ ERROR lifetime mismatch
+   |         ^
+
+error[E0384]: cannot assign twice to immutable variable `v`
+  --> $DIR/ex3-both-anon-regions-2.rs:12:5
+   |
+LL | fn foo((v, w): (&u8, &u8), x: &u8) {
+   |         - first assignment to `v`
+LL |     v = x; //~ ERROR lifetime mismatch
+   |     ^^^^^ cannot assign twice to immutable variable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0384`.

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-3.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-3.nll.stderr
@@ -1,0 +1,31 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex3-both-anon-regions-3.rs:12:13
+   |
+LL |     z.push((x,y)); //~ ERROR lifetime mismatch
+   |             ^
+
+warning: not reporting region error due to -Znll
+  --> $DIR/ex3-both-anon-regions-3.rs:12:15
+   |
+LL |     z.push((x,y)); //~ ERROR lifetime mismatch
+   |               ^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-3.rs:11:33
+   |
+LL | fn foo(z: &mut Vec<(&u8,&u8)>, (x, y): (&u8, &u8)) {
+   |                     ---         ^       --- these two types are declared with different lifetimes...
+   |                                 |
+   |                                 ...but data flows into `z` here
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-3.rs:11:33
+   |
+LL | fn foo(z: &mut Vec<(&u8,&u8)>, (x, y): (&u8, &u8)) {
+   |                         ---     ^            --- these two types are declared with different lifetimes...
+   |                                 |
+   |                                 ...but data flows into `z` here
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-both-are-structs-2.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-both-are-structs-2.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex3-both-anon-regions-both-are-structs-2.rs:16:11
+   |
+LL |     x.b = y.b; //~ ERROR lifetime mismatch
+   |           ^^^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-both-are-structs-2.rs:16:5
+   |
+LL | fn foo(mut x: Ref, y: Ref) {
+   |               ---     --- these two types are declared with different lifetimes...
+LL |     x.b = y.b; //~ ERROR lifetime mismatch
+   |     ^^^^^^^^^ ...but data from `y` flows into `x` here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-both-are-structs-3.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-both-are-structs-3.nll.stderr
@@ -1,0 +1,19 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex3-both-anon-regions-both-are-structs-3.rs:16:11
+   |
+LL |     x.a = x.b; //~ ERROR lifetime mismatch
+   |           ^^^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-both-are-structs-3.rs:16:5
+   |
+LL | fn foo(mut x: Ref) {
+   |               ---
+   |               |
+   |               this type is declared with multiple lifetimes...
+LL |     x.a = x.b; //~ ERROR lifetime mismatch
+   |     ^^^^^^^^^ ...but data with one lifetime flows into the other here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-both-are-structs-4.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-both-are-structs-4.nll.stderr
@@ -1,0 +1,19 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex3-both-anon-regions-both-are-structs-4.rs:16:11
+   |
+LL |     x.a = x.b; //~ ERROR lifetime mismatch
+   |           ^^^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-both-are-structs-4.rs:16:5
+   |
+LL | fn foo(mut x: Ref) {
+   |               ---
+   |               |
+   |               this type is declared with multiple lifetimes...
+LL |     x.a = x.b; //~ ERROR lifetime mismatch
+   |     ^^^^^^^^^ ...but data with one lifetime flows into the other here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-both-are-structs-earlybound-regions.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-both-are-structs-earlybound-regions.nll.stderr
@@ -1,0 +1,18 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex3-both-anon-regions-both-are-structs-earlybound-regions.rs:18:12
+   |
+LL |     x.push(y); //~ ERROR lifetime mismatch
+   |            ^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-both-are-structs-earlybound-regions.rs:18:5
+   |
+LL | fn foo<'a, 'b>(mut x: Vec<Ref<'a>>, y: Ref<'b>)
+   |                           -------      ------- these two types are declared with different lifetimes...
+...
+LL |     x.push(y); //~ ERROR lifetime mismatch
+   |     ^ ...but data from `y` flows into `x` here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-both-are-structs-latebound-regions.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-both-are-structs-latebound-regions.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex3-both-anon-regions-both-are-structs-latebound-regions.rs:15:12
+   |
+LL |     x.push(y); //~ ERROR lifetime mismatch
+   |            ^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-both-are-structs-latebound-regions.rs:15:5
+   |
+LL | fn foo<'a, 'b>(mut x: Vec<Ref<'a>>, y: Ref<'b>) {
+   |                           -------      ------- these two types are declared with different lifetimes...
+LL |     x.push(y); //~ ERROR lifetime mismatch
+   |     ^ ...but data from `y` flows into `x` here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-both-are-structs.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-both-are-structs.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex3-both-anon-regions-both-are-structs.rs:15:12
+   |
+LL |     x.push(y); //~ ERROR lifetime mismatch
+   |            ^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-both-are-structs.rs:15:5
+   |
+LL | fn foo(mut x: Vec<Ref>, y: Ref) {
+   |                   ---      --- these two types are declared with different lifetimes...
+LL |     x.push(y); //~ ERROR lifetime mismatch
+   |     ^ ...but data from `y` flows into `x` here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-latebound-regions.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-latebound-regions.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex3-both-anon-regions-latebound-regions.rs:12:12
+   |
+LL |     x.push(y); //~ ERROR lifetime mismatch
+   |            ^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-latebound-regions.rs:12:5
+   |
+LL | fn foo<'a,'b>(x: &mut Vec<&'a u8>, y: &'b u8) {
+   |                           ------      ------ these two types are declared with different lifetimes...
+LL |     x.push(y); //~ ERROR lifetime mismatch
+   |     ^ ...but data from `y` flows into `x` here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-one-is-struct-2.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-one-is-struct-2.nll.stderr
@@ -1,0 +1,28 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex3-both-anon-regions-one-is-struct-2.rs:14:9
+   |
+LL |     y = x.b; //~ ERROR lifetime mismatch
+   |         ^^^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-one-is-struct-2.rs:14:5
+   |
+LL | fn foo(mut x: Ref, y: &u32) {
+   |               ---     ----
+   |               |
+   |               these two types are declared with different lifetimes...
+LL |     y = x.b; //~ ERROR lifetime mismatch
+   |     ^^^^^^^ ...but data from `x` flows into `y` here
+
+error[E0384]: cannot assign to immutable argument `y`
+  --> $DIR/ex3-both-anon-regions-one-is-struct-2.rs:14:5
+   |
+LL | fn foo(mut x: Ref, y: &u32) {
+   |                    - argument not declared as `mut`
+LL |     y = x.b; //~ ERROR lifetime mismatch
+   |     ^^^^^^^ cannot assign to immutable argument
+
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0384, E0623.
+For more information about an error, try `rustc --explain E0384`.

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-one-is-struct-3.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-one-is-struct-3.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex3-both-anon-regions-one-is-struct-3.rs:14:11
+   |
+LL |     y.b = x; //~ ERROR lifetime mismatch
+   |           ^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-one-is-struct-3.rs:14:5
+   |
+LL | fn foo(mut y: Ref, x: &u32) {
+   |               ---     ---- these two types are declared with different lifetimes...
+LL |     y.b = x; //~ ERROR lifetime mismatch
+   |     ^^^^^^^ ...but data from `x` flows into `y` here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-one-is-struct-4.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-one-is-struct-4.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex3-both-anon-regions-one-is-struct-4.rs:14:11
+   |
+LL |     y.b = x; //~ ERROR lifetime mismatch
+   |           ^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-one-is-struct-4.rs:14:5
+   |
+LL | fn foo(mut y: Ref, x: &u32) {
+   |               ---     ---- these two types are declared with different lifetimes...
+LL |     y.b = x; //~ ERROR lifetime mismatch
+   |     ^^^^^^^ ...but data from `x` flows into `y` here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-one-is-struct.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-one-is-struct.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex3-both-anon-regions-one-is-struct.rs:17:11
+   |
+LL |     x.b = y; //~ ERROR lifetime mismatch
+   |           ^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-one-is-struct.rs:17:5
+   |
+LL | fn foo(mut x: Ref, y: &u32) {
+   |               ---     ---- these two types are declared with different lifetimes...
+LL |     x.b = y; //~ ERROR lifetime mismatch
+   |     ^^^^^^^ ...but data from `y` flows into `x` here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.nll.stderr
@@ -1,0 +1,19 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex3-both-anon-regions-return-type-is-anon.rs:17:5
+   |
+LL |     x //~ ERROR lifetime mismatch
+   |     ^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-return-type-is-anon.rs:17:5
+   |
+LL |   fn foo<'a>(&self, x: &i32) -> &i32 {
+   |                        ----     ----
+   |                        |
+   |                        this parameter and the return type are declared with different lifetimes...
+LL |     x //~ ERROR lifetime mismatch
+   |     ^ ...but data from `x` is returned here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-self-is-anon.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-self-is-anon.nll.stderr
@@ -1,0 +1,19 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex3-both-anon-regions-self-is-anon.rs:17:19
+   |
+LL |         if true { x } else { self } //~ ERROR lifetime mismatch
+   |                   ^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-self-is-anon.rs:17:9
+   |
+LL |     fn foo<'a>(&self, x: &Foo) -> &Foo {
+   |                          ----     ----
+   |                          |
+   |                          this parameter and the return type are declared with different lifetimes...
+LL |         if true { x } else { self } //~ ERROR lifetime mismatch
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...but data from `x` is returned here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-using-fn-items.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-using-fn-items.nll.stderr
@@ -1,0 +1,24 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex3-both-anon-regions-using-fn-items.rs:11:10
+   |
+LL |   y.push(z); //~ ERROR lifetime mismatch
+   |          ^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-using-fn-items.rs:11:3
+   |
+LL | fn foo(x:fn(&u8, &u8), y: Vec<&u8>, z: &u8) {
+   |                               ---      --- these two types are declared with different lifetimes...
+LL |   y.push(z); //~ ERROR lifetime mismatch
+   |   ^ ...but data from `z` flows into `y` here
+
+error[E0596]: cannot borrow immutable item `y` as mutable
+  --> $DIR/ex3-both-anon-regions-using-fn-items.rs:11:3
+   |
+LL |   y.push(z); //~ ERROR lifetime mismatch
+   |   ^ cannot borrow as mutable
+
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0596, E0623.
+For more information about an error, try `rustc --explain E0596`.

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-using-impl-items.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-using-impl-items.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex3-both-anon-regions-using-impl-items.rs:15:16
+   |
+LL |         x.push(y); //~ ERROR lifetime mismatch
+   |                ^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-using-impl-items.rs:15:9
+   |
+LL |     fn foo(x: &mut Vec<&u8>, y: &u8) {
+   |                        ---      --- these two types are declared with different lifetimes...
+LL |         x.push(y); //~ ERROR lifetime mismatch
+   |         ^ ...but data from `y` flows into `x` here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-using-trait-objects.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-using-trait-objects.nll.stderr
@@ -1,0 +1,24 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex3-both-anon-regions-using-trait-objects.rs:11:10
+   |
+LL |   y.push(z); //~ ERROR lifetime mismatch
+   |          ^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-using-trait-objects.rs:11:3
+   |
+LL | fn foo(x:Box<Fn(&u8, &u8)> , y: Vec<&u8>, z: &u8) {
+   |                 ---  --- these two types are declared with different lifetimes...
+LL |   y.push(z); //~ ERROR lifetime mismatch
+   |   ^ ...but data from `z` flows into `y` here
+
+error[E0596]: cannot borrow immutable item `y` as mutable
+  --> $DIR/ex3-both-anon-regions-using-trait-objects.rs:11:3
+   |
+LL |   y.push(z); //~ ERROR lifetime mismatch
+   |   ^ cannot borrow as mutable
+
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0596, E0623.
+For more information about an error, try `rustc --explain E0596`.

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions.nll.stderr
@@ -1,0 +1,17 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/ex3-both-anon-regions.rs:12:12
+   |
+LL |     x.push(y); //~ ERROR lifetime mismatch
+   |            ^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions.rs:12:5
+   |
+LL | fn foo(x: &mut Vec<&u8>, y: &u8) {
+   |                    ---      --- these two types are declared with different lifetimes...
+LL |     x.push(y); //~ ERROR lifetime mismatch
+   |     ^ ...but data from `y` flows into `x` here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/borrowck-let-suggestion.nll.stderr
+++ b/src/test/ui/lifetimes/borrowck-let-suggestion.nll.stderr
@@ -1,0 +1,10 @@
+error: compilation successful
+  --> $DIR/borrowck-let-suggestion.rs:15:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     f();
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/lifetimes/borrowck-let-suggestion.rs
+++ b/src/test/ui/lifetimes/borrowck-let-suggestion.rs
@@ -7,11 +7,11 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
+#![feature(rustc_attrs)]
 fn f() {
     let x = vec![1].iter();
 }
 
-fn main() {
+fn main() { #![rustc_error] // rust-lang/rust#49855
     f();
 }

--- a/src/test/ui/macros/span-covering-argument-1.nll.stderr
+++ b/src/test/ui/macros/span-covering-argument-1.nll.stderr
@@ -1,0 +1,12 @@
+error[E0596]: cannot borrow immutable item `foo` as mutable
+  --> $DIR/span-covering-argument-1.rs:15:14
+   |
+LL |             *&mut $s = 0;
+   |              ^^^^^^^ cannot borrow as mutable
+...
+LL |     bad!(foo whatever);
+   |     ------------------- in this macro invocation
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/moves-based-on-type-block-bad.nll.stderr
+++ b/src/test/ui/moves-based-on-type-block-bad.nll.stderr
@@ -1,0 +1,9 @@
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/moves-based-on-type-block-bad.rs:37:28
+   |
+LL |                 box E::Bar(x) => println!("{}", x.to_string()),
+   |                            ^ cannot move out of borrowed content
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0507`.

--- a/src/test/ui/moves-based-on-type-match-bindings.nll.stderr
+++ b/src/test/ui/moves-based-on-type-match-bindings.nll.stderr
@@ -1,0 +1,14 @@
+error[E0382]: borrow of moved value: `x`
+  --> $DIR/moves-based-on-type-match-bindings.rs:26:11
+   |
+LL |         Foo {f} => {}
+   |              - value moved here
+...
+LL |     touch(&x); //~ ERROR use of partially moved value: `x`
+   |           ^^ value borrowed here after move
+   |
+   = note: move occurs because `x` has type `Foo<std::string::String>`, which does not implement the `Copy` trait
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/nll/get_default.nll.stderr
+++ b/src/test/ui/nll/get_default.nll.stderr
@@ -1,0 +1,51 @@
+error[E0502]: cannot borrow `*map` as mutable because it is also borrowed as immutable (Ast)
+  --> $DIR/get_default.rs:33:17
+   |
+LL |         match map.get() {
+   |               --- immutable borrow occurs here
+...
+LL |                 map.set(String::new()); // Just AST errors here
+   |                 ^^^ mutable borrow occurs here
+...
+LL | }
+   | - immutable borrow ends here
+
+error[E0502]: cannot borrow `*map` as mutable because it is also borrowed as immutable (Ast)
+  --> $DIR/get_default.rs:44:17
+   |
+LL |         match map.get() {
+   |               --- immutable borrow occurs here
+LL |             Some(v) => {
+LL |                 map.set(String::new()); // Both AST and MIR error here
+   |                 ^^^ mutable borrow occurs here
+...
+LL | }
+   | - immutable borrow ends here
+
+error[E0502]: cannot borrow `*map` as mutable because it is also borrowed as immutable (Ast)
+  --> $DIR/get_default.rs:50:17
+   |
+LL |         match map.get() {
+   |               --- immutable borrow occurs here
+...
+LL |                 map.set(String::new()); // Just AST errors here
+   |                 ^^^ mutable borrow occurs here
+...
+LL | }
+   | - immutable borrow ends here
+
+error[E0502]: cannot borrow `*map` as mutable because it is also borrowed as immutable (Mir)
+  --> $DIR/get_default.rs:44:17
+   |
+LL |         match map.get() {
+   |               --- immutable borrow occurs here
+LL |             Some(v) => {
+LL |                 map.set(String::new()); // Both AST and MIR error here
+   |                 ^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
+...
+LL |                 return v;
+   |                        - borrow later used here
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0502`.

--- a/src/test/ui/region-borrow-params-issue-29793-small.nll.stderr
+++ b/src/test/ui/region-borrow-params-issue-29793-small.nll.stderr
@@ -1,0 +1,279 @@
+error[E0597]: `x` does not live long enough
+  --> $DIR/region-borrow-params-issue-29793-small.rs:19:17
+   |
+LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |     };
+   |      - borrowed value only lives until here
+
+error[E0597]: `y` does not live long enough
+  --> $DIR/region-borrow-params-issue-29793-small.rs:19:17
+   |
+LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |     };
+   |      - borrowed value only lives until here
+
+error[E0597]: `x` does not live long enough
+  --> $DIR/region-borrow-params-issue-29793-small.rs:34:17
+   |
+LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |     };
+   |      - borrowed value only lives until here
+
+error[E0597]: `y` does not live long enough
+  --> $DIR/region-borrow-params-issue-29793-small.rs:34:17
+   |
+LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |     };
+   |      - borrowed value only lives until here
+
+error[E0597]: `x` does not live long enough
+  --> $DIR/region-borrow-params-issue-29793-small.rs:65:17
+   |
+LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |     };
+   |     - borrowed value only lives until here
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 64:5...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:64:5
+   |
+LL |     fn g<'a>(x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0597]: `y` does not live long enough
+  --> $DIR/region-borrow-params-issue-29793-small.rs:65:17
+   |
+LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |     };
+   |     - borrowed value only lives until here
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 64:5...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:64:5
+   |
+LL |     fn g<'a>(x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0597]: `x` does not live long enough
+  --> $DIR/region-borrow-params-issue-29793-small.rs:76:17
+   |
+LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |     };
+   |     - borrowed value only lives until here
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 75:5...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:75:5
+   |
+LL |     fn g<'a>(x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0597]: `y` does not live long enough
+  --> $DIR/region-borrow-params-issue-29793-small.rs:76:17
+   |
+LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |     };
+   |     - borrowed value only lives until here
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 75:5...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:75:5
+   |
+LL |     fn g<'a>(x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0597]: `x` does not live long enough
+  --> $DIR/region-borrow-params-issue-29793-small.rs:100:21
+   |
+LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |         }
+   |         - borrowed value only lives until here
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 99:9...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:99:9
+   |
+LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0597]: `y` does not live long enough
+  --> $DIR/region-borrow-params-issue-29793-small.rs:100:21
+   |
+LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |         }
+   |         - borrowed value only lives until here
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 99:9...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:99:9
+   |
+LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0597]: `x` does not live long enough
+  --> $DIR/region-borrow-params-issue-29793-small.rs:114:21
+   |
+LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |         }
+   |         - borrowed value only lives until here
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 113:9...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:113:9
+   |
+LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0597]: `y` does not live long enough
+  --> $DIR/region-borrow-params-issue-29793-small.rs:114:21
+   |
+LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |         }
+   |         - borrowed value only lives until here
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 113:9...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:113:9
+   |
+LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0597]: `x` does not live long enough
+  --> $DIR/region-borrow-params-issue-29793-small.rs:142:21
+   |
+LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |         }
+   |         - borrowed value only lives until here
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 141:9...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:141:9
+   |
+LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0597]: `y` does not live long enough
+  --> $DIR/region-borrow-params-issue-29793-small.rs:142:21
+   |
+LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |         }
+   |         - borrowed value only lives until here
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 141:9...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:141:9
+   |
+LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0597]: `x` does not live long enough
+  --> $DIR/region-borrow-params-issue-29793-small.rs:157:21
+   |
+LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |         }
+   |         - borrowed value only lives until here
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 156:9...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:156:9
+   |
+LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0597]: `y` does not live long enough
+  --> $DIR/region-borrow-params-issue-29793-small.rs:157:21
+   |
+LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |         }
+   |         - borrowed value only lives until here
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 156:9...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:156:9
+   |
+LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0597]: `x` does not live long enough
+  --> $DIR/region-borrow-params-issue-29793-small.rs:185:21
+   |
+LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |         }
+   |         - borrowed value only lives until here
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 184:9...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:184:9
+   |
+LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0597]: `y` does not live long enough
+  --> $DIR/region-borrow-params-issue-29793-small.rs:185:21
+   |
+LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |         }
+   |         - borrowed value only lives until here
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 184:9...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:184:9
+   |
+LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0597]: `x` does not live long enough
+  --> $DIR/region-borrow-params-issue-29793-small.rs:199:21
+   |
+LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |         }
+   |         - borrowed value only lives until here
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 198:9...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:198:9
+   |
+LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0597]: `y` does not live long enough
+  --> $DIR/region-borrow-params-issue-29793-small.rs:199:21
+   |
+LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |         }
+   |         - borrowed value only lives until here
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 198:9...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:198:9
+   |
+LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 20 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/regions-nested-fns-2.nll.stderr
+++ b/src/test/ui/regions-nested-fns-2.nll.stderr
@@ -1,0 +1,16 @@
+error[E0597]: `y` does not live long enough
+  --> $DIR/regions-nested-fns-2.rs:16:9
+   |
+LL | /         |z| {
+LL | |             //~^ ERROR E0373
+LL | |             if false { &y } else { z }
+LL | |         });
+   | |_________^ borrowed value does not live long enough
+LL |   }
+   |   - borrowed value only lives until here
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/rfc-2005-default-binding-mode/borrowck-issue-49631.nll.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/borrowck-issue-49631.nll.stderr
@@ -1,0 +1,14 @@
+error[E0502]: cannot borrow `foo` as mutable because it is also borrowed as immutable
+  --> $DIR/borrowck-issue-49631.rs:30:9
+   |
+LL |     while let Some(Ok(string)) = foo.get() {
+   |                                  --- immutable borrow occurs here
+LL |         foo.mutate();
+   |         ^^^^^^^^^^^^ mutable borrow occurs here
+LL |         //~^ ERROR cannot borrow `foo` as mutable
+LL |         println!("foo={:?}", *string);
+   |                              ------- borrow later used here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0502`.

--- a/src/test/ui/rfc-2005-default-binding-mode/enum.nll.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/enum.nll.stderr
@@ -1,0 +1,21 @@
+error[E0594]: cannot assign to immutable item `*x`
+  --> $DIR/enum.rs:19:5
+   |
+LL |     *x += 1; //~ ERROR cannot assign to immutable
+   |     ^^^^^^^ cannot mutate
+
+error[E0594]: cannot assign to immutable item `*x`
+  --> $DIR/enum.rs:23:9
+   |
+LL |         *x += 1; //~ ERROR cannot assign to immutable
+   |         ^^^^^^^ cannot mutate
+
+error[E0594]: cannot assign to immutable item `*x`
+  --> $DIR/enum.rs:29:9
+   |
+LL |         *x += 1; //~ ERROR cannot assign to immutable
+   |         ^^^^^^^ cannot mutate
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0594`.

--- a/src/test/ui/rfc-2005-default-binding-mode/explicit-mut.nll.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/explicit-mut.nll.stderr
@@ -1,0 +1,21 @@
+error[E0594]: cannot assign to immutable item `*n`
+  --> $DIR/explicit-mut.rs:17:13
+   |
+LL |             *n += 1; //~ ERROR cannot assign to immutable
+   |             ^^^^^^^ cannot mutate
+
+error[E0594]: cannot assign to immutable item `*n`
+  --> $DIR/explicit-mut.rs:25:13
+   |
+LL |             *n += 1; //~ ERROR cannot assign to immutable
+   |             ^^^^^^^ cannot mutate
+
+error[E0594]: cannot assign to immutable item `*n`
+  --> $DIR/explicit-mut.rs:33:13
+   |
+LL |             *n += 1; //~ ERROR cannot assign to immutable
+   |             ^^^^^^^ cannot mutate
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0594`.

--- a/src/test/ui/span/borrowck-borrow-overloaded-auto-deref-mut.nll.stderr
+++ b/src/test/ui/span/borrowck-borrow-overloaded-auto-deref-mut.nll.stderr
@@ -1,0 +1,51 @@
+error[E0596]: cannot borrow immutable item `x` as mutable
+  --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:63:24
+   |
+LL |     let __isize = &mut x.y; //~ ERROR cannot borrow
+   |                        ^ cannot borrow as mutable
+
+error[E0596]: cannot borrow immutable item `*x` as mutable
+  --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:75:10
+   |
+LL |     &mut x.y //~ ERROR cannot borrow
+   |          ^ cannot borrow as mutable
+
+error[E0596]: cannot borrow immutable item `x` as mutable
+  --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:98:5
+   |
+LL |     x.y = 3; //~ ERROR cannot borrow
+   |     ^ cannot borrow as mutable
+
+error[E0596]: cannot borrow immutable item `*x` as mutable
+  --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:102:5
+   |
+LL |     x.y = 3; //~ ERROR cannot borrow
+   |     ^ cannot borrow as mutable
+
+error[E0596]: cannot borrow immutable item `x` as mutable
+  --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:119:5
+   |
+LL |     x.set(0, 0); //~ ERROR cannot borrow
+   |     ^ cannot borrow as mutable
+
+error[E0596]: cannot borrow immutable item `*x` as mutable
+  --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:131:5
+   |
+LL |     x.y_mut() //~ ERROR cannot borrow
+   |     ^ cannot borrow as mutable
+
+error[E0596]: cannot borrow immutable item `x` as mutable
+  --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:139:6
+   |
+LL |     *x.y_mut() = 3; //~ ERROR cannot borrow
+   |      ^ cannot borrow as mutable
+
+error[E0596]: cannot borrow immutable item `*x` as mutable
+  --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:143:6
+   |
+LL |     *x.y_mut() = 3; //~ ERROR cannot borrow
+   |      ^ cannot borrow as mutable
+
+error: aborting due to 8 previous errors
+
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/span/borrowck-borrow-overloaded-deref-mut.nll.stderr
+++ b/src/test/ui/span/borrowck-borrow-overloaded-deref-mut.nll.stderr
@@ -1,0 +1,27 @@
+error[E0596]: cannot borrow immutable item `x` as mutable
+  --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:39:25
+   |
+LL |     let __isize = &mut *x; //~ ERROR cannot borrow
+   |                         ^ cannot borrow as mutable
+
+error[E0596]: cannot borrow immutable item `*x` as mutable
+  --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:51:11
+   |
+LL |     &mut **x //~ ERROR cannot borrow
+   |           ^^ cannot borrow as mutable
+
+error[E0596]: cannot borrow immutable item `x` as mutable
+  --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:59:6
+   |
+LL |     *x = 3; //~ ERROR cannot borrow
+   |      ^ cannot borrow as mutable
+
+error[E0596]: cannot borrow immutable item `*x` as mutable
+  --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:63:6
+   |
+LL |     **x = 3; //~ ERROR cannot borrow
+   |      ^^ cannot borrow as mutable
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/span/borrowck-call-is-borrow-issue-12224.nll.stderr
+++ b/src/test/ui/span/borrowck-call-is-borrow-issue-12224.nll.stderr
@@ -1,0 +1,54 @@
+error[E0499]: cannot borrow `f` as mutable more than once at a time
+  --> $DIR/borrowck-call-is-borrow-issue-12224.rs:22:16
+   |
+LL |       f(Box::new(|| {
+   |       -          ^^ second mutable borrow occurs here
+   |       |
+   |  _____first mutable borrow occurs here
+   | |
+LL | |     //~^ ERROR: cannot borrow `f` as mutable more than once
+LL | |         f((Box::new(|| {})))
+   | |         - borrow occurs due to use of `f` in closure
+LL | |     }));
+   | |_______- borrow later used here
+
+error[E0596]: cannot borrow immutable item `*f` as mutable
+  --> $DIR/borrowck-call-is-borrow-issue-12224.rs:35:5
+   |
+LL |     (*f)();
+   |     ^^^^ cannot borrow as mutable
+
+error[E0596]: cannot borrow immutable item `*f.f` as mutable
+  --> $DIR/borrowck-call-is-borrow-issue-12224.rs:44:5
+   |
+LL |     f.f.call_mut(())
+   |     ^^^ cannot borrow as mutable
+   |
+   = note: Value not mutable causing this error: `*f`
+
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/borrowck-call-is-borrow-issue-12224.rs:66:13
+   |
+LL |         foo(f);
+   |             ^ cannot move out of borrowed content
+
+error[E0505]: cannot move out of `f` because it is borrowed
+  --> $DIR/borrowck-call-is-borrow-issue-12224.rs:65:16
+   |
+LL |        f(Box::new(|a| {
+   |   _____-__________^
+   |  |     |
+   |  |_____borrow of `f` occurs here
+   | ||
+LL | ||         foo(f);
+LL | ||         //~^ ERROR cannot move `f` into closure because it is borrowed
+LL | ||         //~| ERROR cannot move out of captured outer variable in an `FnMut` closure
+LL | ||     }), 3);
+   | ||_____^____- borrow later used here
+   |  |_____|
+   |        move out of `f` occurs here
+
+error: aborting due to 5 previous errors
+
+Some errors occurred: E0499, E0505, E0507, E0596.
+For more information about an error, try `rustc --explain E0499`.

--- a/src/test/ui/span/borrowck-call-method-from-mut-aliasable.nll.stderr
+++ b/src/test/ui/span/borrowck-call-method-from-mut-aliasable.nll.stderr
@@ -1,0 +1,9 @@
+error[E0596]: cannot borrow immutable item `*x` as mutable
+  --> $DIR/borrowck-call-method-from-mut-aliasable.rs:27:5
+   |
+LL |     x.h(); //~ ERROR cannot borrow
+   |     ^ cannot borrow as mutable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/span/borrowck-fn-in-const-b.nll.stderr
+++ b/src/test/ui/span/borrowck-fn-in-const-b.nll.stderr
@@ -1,0 +1,9 @@
+error[E0596]: cannot borrow immutable item `*x` as mutable
+  --> $DIR/borrowck-fn-in-const-b.rs:17:9
+   |
+LL |         x.push(format!("this is broken"));
+   |         ^ cannot borrow as mutable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/span/borrowck-let-suggestion-suffixes.nll.stderr
+++ b/src/test/ui/span/borrowck-let-suggestion-suffixes.nll.stderr
@@ -1,0 +1,10 @@
+error: compilation successful
+  --> $DIR/borrowck-let-suggestion-suffixes.rs:61:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     f();
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/span/borrowck-let-suggestion-suffixes.rs
+++ b/src/test/ui/span/borrowck-let-suggestion-suffixes.rs
@@ -7,7 +7,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
+#![feature(rustc_attrs)]
 fn id<T>(x: T) -> T { x }
 
 fn f() {
@@ -58,6 +58,6 @@ fn f() {
 //~| NOTE temporary value needs to live until here
 //~| NOTE temporary value needs to live until here
 
-fn main() {
+fn main() { #![rustc_error] // rust-lang/rust#49855
     f();
 }

--- a/src/test/ui/span/borrowck-object-mutability.nll.stderr
+++ b/src/test/ui/span/borrowck-object-mutability.nll.stderr
@@ -1,0 +1,17 @@
+error[E0596]: cannot borrow immutable item `*x` as mutable
+  --> $DIR/borrowck-object-mutability.rs:19:5
+   |
+LL |     x.borrowed_mut(); //~ ERROR cannot borrow
+   |     ^ cannot borrow as mutable
+
+error[E0596]: cannot borrow immutable item `*x` as mutable
+  --> $DIR/borrowck-object-mutability.rs:29:5
+   |
+LL |     x.borrowed_mut(); //~ ERROR cannot borrow
+   |     ^ cannot borrow as mutable
+   |
+   = note: Value not mutable causing this error: `x`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/span/borrowck-ref-into-rvalue.nll.stderr
+++ b/src/test/ui/span/borrowck-ref-into-rvalue.nll.stderr
@@ -1,0 +1,14 @@
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/borrowck-ref-into-rvalue.rs:13:11
+   |
+LL |     match Some("Hello".to_string()) {
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^ temporary value does not live long enough
+...
+LL |     }
+   |     - temporary value only lives until here
+LL |     println!("{}", *msg);
+   |                    ---- borrow later used here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/dropck-object-cycle.nll.stderr
+++ b/src/test/ui/span/dropck-object-cycle.nll.stderr
@@ -1,0 +1,15 @@
+error[E0597]: `*m` does not live long enough
+  --> $DIR/dropck-object-cycle.rs:37:31
+   |
+LL |     assert_eq!(object_invoke1(&*m), (4,5));
+   |                               ^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `m` is dropped
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/dropck_arr_cycle_checked.nll.stderr
+++ b/src/test/ui/span/dropck_arr_cycle_checked.nll.stderr
@@ -1,0 +1,39 @@
+error[E0597]: `b1` does not live long enough
+  --> $DIR/dropck_arr_cycle_checked.rs:111:24
+   |
+LL |     b3.a[0].v.set(Some(&b1));
+   |                        ^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `b1` is dropped
+
+error[E0597]: `b2` does not live long enough
+  --> $DIR/dropck_arr_cycle_checked.rs:103:24
+   |
+LL |     b1.a[0].v.set(Some(&b2));
+   |                        ^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `b1` is dropped
+
+error[E0597]: `b3` does not live long enough
+  --> $DIR/dropck_arr_cycle_checked.rs:105:24
+   |
+LL |     b1.a[1].v.set(Some(&b3));
+   |                        ^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `b1` is dropped
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/dropck_direct_cycle_with_drop.nll.stderr
+++ b/src/test/ui/span/dropck_direct_cycle_with_drop.nll.stderr
@@ -1,0 +1,27 @@
+error[E0597]: `d1` does not live long enough
+  --> $DIR/dropck_direct_cycle_with_drop.rs:48:19
+   |
+LL |     d2.p.set(Some(&d1));
+   |                   ^^^ borrowed value does not live long enough
+LL |     //~^ ERROR `d1` does not live long enough
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `d1` is dropped
+
+error[E0597]: `d2` does not live long enough
+  --> $DIR/dropck_direct_cycle_with_drop.rs:46:19
+   |
+LL |     d1.p.set(Some(&d2));
+   |                   ^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `d1` is dropped
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/dropck_misc_variants.nll.stderr
+++ b/src/test/ui/span/dropck_misc_variants.nll.stderr
@@ -1,0 +1,26 @@
+error[E0597]: `bomb` does not live long enough
+  --> $DIR/dropck_misc_variants.rs:33:36
+   |
+LL |     _w = Wrap::<&[&str]>(NoisyDrop(&bomb));
+   |                                    ^^^^^ borrowed value does not live long enough
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `_w` is dropped
+
+error[E0597]: `v` does not live long enough
+  --> $DIR/dropck_misc_variants.rs:41:27
+   |
+LL |         let u = NoisyDrop(&v);
+   |                           ^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `_w` is dropped
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/dropck_vec_cycle_checked.nll.stderr
+++ b/src/test/ui/span/dropck_vec_cycle_checked.nll.stderr
@@ -1,0 +1,39 @@
+error[E0597]: `c1` does not live long enough
+  --> $DIR/dropck_vec_cycle_checked.rs:118:24
+   |
+LL |     c3.v[0].v.set(Some(&c1));
+   |                        ^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `c1` is dropped
+
+error[E0597]: `c2` does not live long enough
+  --> $DIR/dropck_vec_cycle_checked.rs:110:24
+   |
+LL |     c1.v[0].v.set(Some(&c2));
+   |                        ^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `c1` is dropped
+
+error[E0597]: `c3` does not live long enough
+  --> $DIR/dropck_vec_cycle_checked.rs:112:24
+   |
+LL |     c1.v[1].v.set(Some(&c3));
+   |                        ^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `c1` is dropped
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/issue-11925.nll.stderr
+++ b/src/test/ui/span/issue-11925.nll.stderr
@@ -1,0 +1,12 @@
+error[E0597]: `x` does not live long enough
+  --> $DIR/issue-11925.rs:18:35
+   |
+LL |         let f = to_fn_once(move|| &x); //~ ERROR does not live long enough
+   |                                   ^-
+   |                                   ||
+   |                                   |borrowed value only lives until here
+   |                                   borrowed value does not live long enough
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/issue-15480.nll.stderr
+++ b/src/test/ui/span/issue-15480.nll.stderr
@@ -1,0 +1,14 @@
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/issue-15480.rs:15:10
+   |
+LL |         &id(3)
+   |          ^^^^^ temporary value does not live long enough
+LL |     ];
+   |      - temporary value only lives until here
+...
+LL |     for &&x in &v {
+   |                -- borrow later used here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/issue-24805-dropck-child-has-items-via-parent.nll.stderr
+++ b/src/test/ui/span/issue-24805-dropck-child-has-items-via-parent.nll.stderr
@@ -1,0 +1,15 @@
+error[E0597]: `d1` does not live long enough
+  --> $DIR/issue-24805-dropck-child-has-items-via-parent.rs:38:18
+   |
+LL |     _d = D_Child(&d1);
+   |                  ^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `_d` is dropped
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/issue-24805-dropck-trait-has-items.nll.stderr
+++ b/src/test/ui/span/issue-24805-dropck-trait-has-items.nll.stderr
@@ -1,0 +1,36 @@
+error[E0597]: `d1` does not live long enough
+  --> $DIR/issue-24805-dropck-trait-has-items.rs:47:26
+   |
+LL |     _d = D_HasSelfMethod(&d1);
+   |                          ^^^ borrowed value does not live long enough
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `_d` is dropped
+
+error[E0597]: `d1` does not live long enough
+  --> $DIR/issue-24805-dropck-trait-has-items.rs:53:33
+   |
+LL |     _d = D_HasMethodWithSelfArg(&d1);
+   |                                 ^^^ borrowed value does not live long enough
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `_d` is dropped
+
+error[E0597]: `d1` does not live long enough
+  --> $DIR/issue-24805-dropck-trait-has-items.rs:59:20
+   |
+LL |     _d = D_HasType(&d1);
+   |                    ^^^ borrowed value does not live long enough
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `_d` is dropped
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/issue-24895-copy-clone-dropck.nll.stderr
+++ b/src/test/ui/span/issue-24895-copy-clone-dropck.nll.stderr
@@ -1,0 +1,14 @@
+error[E0597]: `d1` does not live long enough
+  --> $DIR/issue-24895-copy-clone-dropck.rs:37:14
+   |
+LL |     d2 = D(S(&d1, "inner"), "d2");
+   |              ^^^ borrowed value does not live long enough
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `d2` is dropped
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/issue-25199.nll.stderr
+++ b/src/test/ui/span/issue-25199.nll.stderr
@@ -1,0 +1,15 @@
+error[E0597]: `container` does not live long enough
+  --> $DIR/issue-25199.rs:80:27
+   |
+LL |     let test = Test{test: &container};
+   |                           ^^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `container` is dropped
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/issue-26656.nll.stderr
+++ b/src/test/ui/span/issue-26656.nll.stderr
@@ -1,0 +1,14 @@
+error[E0597]: `ticking` does not live long enough
+  --> $DIR/issue-26656.rs:50:35
+   |
+LL |     zook.button = B::BigRedButton(&ticking);
+   |                                   ^^^^^^^^ borrowed value does not live long enough
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `zook` is dropped
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/issue-29106.nll.stderr
+++ b/src/test/ui/span/issue-29106.nll.stderr
@@ -1,0 +1,25 @@
+error[E0597]: `x` does not live long enough
+  --> $DIR/issue-29106.rs:26:26
+   |
+LL |         y = Arc::new(Foo(&x));
+   |                          ^^ borrowed value does not live long enough
+LL |     }
+   |     -
+   |     |
+   |     borrowed value only lives until here
+   |     borrow later used here, when `y` is dropped
+
+error[E0597]: `x` does not live long enough
+  --> $DIR/issue-29106.rs:33:25
+   |
+LL |         y = Rc::new(Foo(&x));
+   |                         ^^ borrowed value does not live long enough
+LL |     }
+   |     -
+   |     |
+   |     borrowed value only lives until here
+   |     borrow later used here, when `y` is dropped
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/issue-36537.nll.stderr
+++ b/src/test/ui/span/issue-36537.nll.stderr
@@ -1,0 +1,13 @@
+error: compilation successful
+  --> $DIR/issue-36537.rs:11:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     let p;
+LL | |     let a = 42;
+LL | |     p = &a;
+LL | |     //~^ ERROR `a` does not live long enough
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/span/issue-36537.rs
+++ b/src/test/ui/span/issue-36537.rs
@@ -7,8 +7,8 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
-fn main() {
+#![feature(rustc_attrs)]
+fn main() { #![rustc_error] // rust-lang/rust#49855
     let p;
     let a = 42;
     p = &a;

--- a/src/test/ui/span/issue-40157.nll.stderr
+++ b/src/test/ui/span/issue-40157.nll.stderr
@@ -1,0 +1,13 @@
+error[E0597]: `foo` does not live long enough
+  --> $DIR/issue-40157.rs:12:53
+   |
+LL |     {println!("{:?}", match { let foo = vec![1, 2]; foo.get(1) } { x => x });}
+   |                       ------------------------------^^^--------------------
+   |                       |                             |          |
+   |                       |                             |          borrowed value only lives until here
+   |                       |                             borrowed value does not live long enough
+   |                       borrow later used here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/issue28498-reject-ex1.nll.stderr
+++ b/src/test/ui/span/issue28498-reject-ex1.nll.stderr
@@ -1,0 +1,15 @@
+error[E0597]: `foo.data` does not live long enough
+  --> $DIR/issue28498-reject-ex1.rs:44:29
+   |
+LL |     foo.data[0].1.set(Some(&foo.data[1]));
+   |                             ^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `foo` is dropped
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/issue28498-reject-lifetime-param.nll.stderr
+++ b/src/test/ui/span/issue28498-reject-lifetime-param.nll.stderr
@@ -1,0 +1,15 @@
+error[E0597]: `first_dropped` does not live long enough
+  --> $DIR/issue28498-reject-lifetime-param.rs:44:19
+   |
+LL |     foo1 = Foo(1, &first_dropped);
+   |                   ^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `foo1` is dropped
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/issue28498-reject-passed-to-fn.nll.stderr
+++ b/src/test/ui/span/issue28498-reject-passed-to-fn.nll.stderr
@@ -1,0 +1,15 @@
+error[E0597]: `first_dropped` does not live long enough
+  --> $DIR/issue28498-reject-passed-to-fn.rs:46:19
+   |
+LL |     foo1 = Foo(1, &first_dropped, Box::new(callback));
+   |                   ^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `foo1` is dropped
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/issue28498-reject-trait-bound.nll.stderr
+++ b/src/test/ui/span/issue28498-reject-trait-bound.nll.stderr
@@ -1,0 +1,15 @@
+error[E0597]: `first_dropped` does not live long enough
+  --> $DIR/issue28498-reject-trait-bound.rs:46:19
+   |
+LL |     foo1 = Foo(1, &first_dropped);
+   |                   ^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `foo1` is dropped
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/mut-arg-hint.nll.stderr
+++ b/src/test/ui/span/mut-arg-hint.nll.stderr
@@ -1,0 +1,21 @@
+error[E0596]: cannot borrow immutable item `*a` as mutable
+  --> $DIR/mut-arg-hint.rs:13:9
+   |
+LL |         a.push_str("bar"); //~ ERROR cannot borrow immutable borrowed content
+   |         ^ cannot borrow as mutable
+
+error[E0596]: cannot borrow immutable item `*a` as mutable
+  --> $DIR/mut-arg-hint.rs:18:5
+   |
+LL |     a.push_str("foo"); //~ ERROR cannot borrow immutable borrowed content
+   |     ^ cannot borrow as mutable
+
+error[E0596]: cannot borrow immutable item `*a` as mutable
+  --> $DIR/mut-arg-hint.rs:25:9
+   |
+LL |         a.push_str("foo"); //~ ERROR cannot borrow immutable borrowed content
+   |         ^ cannot borrow as mutable
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/span/mut-ptr-cant-outlive-ref.nll.stderr
+++ b/src/test/ui/span/mut-ptr-cant-outlive-ref.nll.stderr
@@ -1,0 +1,14 @@
+error: compilation successful
+  --> $DIR/mut-ptr-cant-outlive-ref.rs:13:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     let m = RefCell::new(0);
+LL | |     let p;
+LL | |     {
+...  |
+LL | |     //~^^ ERROR `b` does not live long enough
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/span/mut-ptr-cant-outlive-ref.rs
+++ b/src/test/ui/span/mut-ptr-cant-outlive-ref.rs
@@ -7,10 +7,10 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
+#![feature(rustc_attrs)]
 use std::cell::RefCell;
 
-fn main() {
+fn main() { #![rustc_error] // rust-lang/rust#49855
     let m = RefCell::new(0);
     let p;
     {

--- a/src/test/ui/span/range-2.nll.stderr
+++ b/src/test/ui/span/range-2.nll.stderr
@@ -1,0 +1,14 @@
+error: compilation successful
+  --> $DIR/range-2.rs:13:1
+   |
+LL | / pub fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     let r = {
+LL | |         let a = 42;
+LL | |         let b = 42;
+...  |
+LL | |     //~| ERROR `b` does not live long enough
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/span/range-2.rs
+++ b/src/test/ui/span/range-2.rs
@@ -9,8 +9,8 @@
 // except according to those terms.
 
 // Test range syntax - borrow errors.
-
-pub fn main() {
+#![feature(rustc_attrs)]
+pub fn main() { #![rustc_error] // rust-lang/rust#49855
     let r = {
         let a = 42;
         let b = 42;

--- a/src/test/ui/span/regionck-unboxed-closure-lifetimes.nll.stderr
+++ b/src/test/ui/span/regionck-unboxed-closure-lifetimes.nll.stderr
@@ -1,0 +1,14 @@
+error: compilation successful
+  --> $DIR/regionck-unboxed-closure-lifetimes.rs:13:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     let mut f;
+LL | |     {
+LL | |         let c = 1;
+...  |
+LL | |     }
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/span/regionck-unboxed-closure-lifetimes.rs
+++ b/src/test/ui/span/regionck-unboxed-closure-lifetimes.rs
@@ -7,10 +7,10 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
+#![feature(rustc_attrs)]
 use std::ops::FnMut;
 
-fn main() {
+fn main() { #![rustc_error] // rust-lang/rust#49855
     let mut f;
     {
         let c = 1;

--- a/src/test/ui/span/regions-close-over-borrowed-ref-in-obj.nll.stderr
+++ b/src/test/ui/span/regions-close-over-borrowed-ref-in-obj.nll.stderr
@@ -1,0 +1,14 @@
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/regions-close-over-borrowed-ref-in-obj.rs:22:27
+   |
+LL |         let ss: &isize = &id(1);
+   |                           ^^^^^ temporary value does not live long enough
+...
+LL |     }
+   |     - temporary value only lives until here
+LL | }
+   | - borrow later used here, when `blah` is dropped
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/regions-close-over-type-parameter-2.nll.stderr
+++ b/src/test/ui/span/regions-close-over-type-parameter-2.nll.stderr
@@ -1,0 +1,18 @@
+error[E0597]: `tmp0` does not live long enough
+  --> $DIR/regions-close-over-type-parameter-2.rs:33:20
+   |
+LL |       let _ = {
+   |  _____________-
+LL | |         let tmp0 = 3;
+LL | |         let tmp1 = &tmp0;
+   | |                    ^^^^^ borrowed value does not live long enough
+LL | |         repeater3(tmp1)
+LL | |     };
+   | |     -
+   | |     |
+   | |_____borrowed value only lives until here
+   |       borrow later used here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/regions-escape-loop-via-variable.nll.stderr
+++ b/src/test/ui/span/regions-escape-loop-via-variable.nll.stderr
@@ -1,0 +1,13 @@
+error[E0597]: `x` does not live long enough
+  --> $DIR/regions-escape-loop-via-variable.rs:21:13
+   |
+LL |         let x = 1 + *p;
+   |                     -- borrow later used here
+LL |         p = &x;
+   |             ^^ borrowed value does not live long enough
+LL |     }
+   |     - borrowed value only lives until here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/regions-escape-loop-via-vec.nll.stderr
+++ b/src/test/ui/span/regions-escape-loop-via-vec.nll.stderr
@@ -1,0 +1,49 @@
+error[E0503]: cannot use `x` because it was mutably borrowed
+  --> $DIR/regions-escape-loop-via-vec.rs:15:11
+   |
+LL |     let mut _y = vec![&mut x];
+   |                       ------ borrow of `x` occurs here
+LL |     while x < 10 { //~ ERROR cannot use `x` because it was mutably borrowed
+   |           ^ use of borrowed `x`
+LL |         let mut z = x; //~ ERROR cannot use `x` because it was mutably borrowed
+LL |         _y.push(&mut z);
+   |         -- borrow later used here
+
+error[E0503]: cannot use `x` because it was mutably borrowed
+  --> $DIR/regions-escape-loop-via-vec.rs:16:21
+   |
+LL |     let mut _y = vec![&mut x];
+   |                       ------ borrow of `x` occurs here
+LL |     while x < 10 { //~ ERROR cannot use `x` because it was mutably borrowed
+LL |         let mut z = x; //~ ERROR cannot use `x` because it was mutably borrowed
+   |                     ^ use of borrowed `x`
+LL |         _y.push(&mut z);
+   |         -- borrow later used here
+
+error[E0503]: cannot use `x` because it was mutably borrowed
+  --> $DIR/regions-escape-loop-via-vec.rs:19:9
+   |
+LL |     let mut _y = vec![&mut x];
+   |                       ------ borrow of `x` occurs here
+...
+LL |         _y.push(&mut z);
+   |         -- borrow later used here
+LL |         //~^ ERROR `z` does not live long enough
+LL |         x += 1; //~ ERROR cannot assign
+   |         ^^^^^^ use of borrowed `x`
+
+error[E0597]: `z` does not live long enough
+  --> $DIR/regions-escape-loop-via-vec.rs:17:17
+   |
+LL |         _y.push(&mut z);
+   |         --      ^^^^^^ borrowed value does not live long enough
+   |         |
+   |         borrow later used here
+...
+LL |     }
+   |     - borrowed value only lives until here
+
+error: aborting due to 4 previous errors
+
+Some errors occurred: E0503, E0597.
+For more information about an error, try `rustc --explain E0503`.

--- a/src/test/ui/span/regions-infer-borrow-scope-within-loop.nll.stderr
+++ b/src/test/ui/span/regions-infer-borrow-scope-within-loop.nll.stderr
@@ -1,0 +1,14 @@
+error[E0597]: `*x` does not live long enough
+  --> $DIR/regions-infer-borrow-scope-within-loop.rs:24:20
+   |
+LL |         y = borrow(&*x);
+   |                    ^^^ borrowed value does not live long enough
+...
+LL |     }
+   |     - borrowed value only lives until here
+LL |     assert!(*y != 0);
+   |             -- borrow later used here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/send-is-not-static-ensures-scoping.nll.stderr
+++ b/src/test/ui/span/send-is-not-static-ensures-scoping.nll.stderr
@@ -1,0 +1,30 @@
+error[E0597]: `y` does not live long enough
+  --> $DIR/send-is-not-static-ensures-scoping.rs:29:16
+   |
+LL |           scoped(|| {
+   |  ________________^
+LL | |             let _z = y;
+LL | |             //~^ ERROR `y` does not live long enough
+LL | |         })
+   | |_________^ borrowed value does not live long enough
+LL |       };
+   |       - borrowed value only lives until here
+LL | 
+LL |       bad.join();
+   |       --- borrow later used here
+
+error[E0597]: `x` does not live long enough
+  --> $DIR/send-is-not-static-ensures-scoping.rs:26:17
+   |
+LL |         let y = &x;
+   |                 ^^ borrowed value does not live long enough
+...
+LL |     };
+   |     - borrowed value only lives until here
+LL | 
+LL |     bad.join();
+   |     --- borrow later used here
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/send-is-not-static-std-sync-2.nll.stderr
+++ b/src/test/ui/span/send-is-not-static-std-sync-2.nll.stderr
@@ -1,0 +1,37 @@
+error[E0597]: `x` does not live long enough
+  --> $DIR/send-is-not-static-std-sync-2.rs:21:20
+   |
+LL |         Mutex::new(&x)
+   |                    ^^ borrowed value does not live long enough
+LL |     };
+   |     - borrowed value only lives until here
+...
+LL |     let _dangling = *lock.lock().unwrap();
+   |                      ---- borrow later used here
+
+error[E0597]: `x` does not live long enough
+  --> $DIR/send-is-not-static-std-sync-2.rs:31:21
+   |
+LL |         RwLock::new(&x)
+   |                     ^^ borrowed value does not live long enough
+LL |     };
+   |     - borrowed value only lives until here
+LL |     //~^^ ERROR `x` does not live long enough
+LL |     let _dangling = *lock.read().unwrap();
+   |                      ---- borrow later used here
+
+error[E0597]: `x` does not live long enough
+  --> $DIR/send-is-not-static-std-sync-2.rs:41:25
+   |
+LL |     let (_tx, rx) = {
+   |          --- borrow later used here
+...
+LL |         let _ = tx.send(&x);
+   |                         ^^ borrowed value does not live long enough
+LL |         (tx, rx)
+LL |     };
+   |     - borrowed value only lives until here
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/send-is-not-static-std-sync.nll.stderr
+++ b/src/test/ui/span/send-is-not-static-std-sync.nll.stderr
@@ -1,0 +1,48 @@
+error[E0505]: cannot move out of `y` because it is borrowed
+  --> $DIR/send-is-not-static-std-sync.rs:23:10
+   |
+LL |     *lock.lock().unwrap() = &*y;
+   |                             --- borrow of `*y` occurs here
+LL |     drop(y); //~ ERROR cannot move out
+   |          ^ move out of `y` occurs here
+...
+LL |         *lock.lock().unwrap() = &z;
+   |          ---- borrow later used here
+
+error[E0505]: cannot move out of `y` because it is borrowed
+  --> $DIR/send-is-not-static-std-sync.rs:36:10
+   |
+LL |     *lock.write().unwrap() = &*y;
+   |                              --- borrow of `*y` occurs here
+LL |     drop(y); //~ ERROR cannot move out
+   |          ^ move out of `y` occurs here
+...
+LL |         *lock.write().unwrap() = &z;
+   |          ---- borrow later used here
+
+error[E0505]: cannot move out of `y` because it is borrowed
+  --> $DIR/send-is-not-static-std-sync.rs:51:10
+   |
+LL |     tx.send(&*y);
+   |             --- borrow of `*y` occurs here
+LL |     drop(y); //~ ERROR cannot move out
+   |          ^ move out of `y` occurs here
+...
+LL |         tx.send(&z).unwrap();
+   |         -- borrow later used here
+
+error[E0597]: `z` does not live long enough
+  --> $DIR/send-is-not-static-std-sync.rs:54:17
+   |
+LL |         tx.send(&z).unwrap();
+   |                 ^^ borrowed value does not live long enough
+LL |     }
+   |     - borrowed value only lives until here
+LL |     //~^^ ERROR `z` does not live long enough
+LL | }
+   | - borrow later used here, when `tx` is dropped
+
+error: aborting due to 4 previous errors
+
+Some errors occurred: E0505, E0597.
+For more information about an error, try `rustc --explain E0505`.

--- a/src/test/ui/span/slice-borrow.nll.stderr
+++ b/src/test/ui/span/slice-borrow.nll.stderr
@@ -1,0 +1,14 @@
+error: compilation successful
+  --> $DIR/slice-borrow.rs:13:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     let y;
+LL | |     {
+LL | |         let x: &[isize] = &vec![1, 2, 3, 4, 5];
+LL | |         y = &x[1..];
+LL | |     }
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/span/slice-borrow.rs
+++ b/src/test/ui/span/slice-borrow.rs
@@ -7,10 +7,10 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
+#![feature(rustc_attrs)]
 // Test slicing expressions doesn't defeat the borrow checker.
 
-fn main() {
+fn main() { #![rustc_error] // rust-lang/rust#49855
     let y;
     {
         let x: &[isize] = &vec![1, 2, 3, 4, 5];

--- a/src/test/ui/span/vec-must-not-hide-type-from-dropck.nll.stderr
+++ b/src/test/ui/span/vec-must-not-hide-type-from-dropck.nll.stderr
@@ -1,0 +1,27 @@
+error[E0597]: `c1` does not live long enough
+  --> $DIR/vec-must-not-hide-type-from-dropck.rs:129:24
+   |
+LL |     c2.v[0].v.set(Some(&c1));
+   |                        ^^^ borrowed value does not live long enough
+LL |     //~^ ERROR `c1` does not live long enough
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `c1` is dropped
+
+error[E0597]: `c2` does not live long enough
+  --> $DIR/vec-must-not-hide-type-from-dropck.rs:127:24
+   |
+LL |     c1.v[0].v.set(Some(&c2));
+   |                        ^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `c1` is dropped
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/vec_refs_data_with_early_death.nll.stderr
+++ b/src/test/ui/span/vec_refs_data_with_early_death.nll.stderr
@@ -1,0 +1,14 @@
+error: compilation successful
+  --> $DIR/vec_refs_data_with_early_death.rs:21:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     let mut v = Vec::new();
+LL | |
+LL | |     let x: i8 = 3;
+...  |
+LL | |     assert_eq!(v, [&3, &4]);
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/span/vec_refs_data_with_early_death.rs
+++ b/src/test/ui/span/vec_refs_data_with_early_death.rs
@@ -17,8 +17,8 @@
 //  element it owns; thus, for data like this, it seems like we could
 //  loosen the restrictions here if we wanted. But it also is not
 //  clear whether such loosening is terribly important.)
-
-fn main() {
+#![feature(rustc_attrs)]
+fn main() { #![rustc_error] // rust-lang/rust#49855
     let mut v = Vec::new();
 
     let x: i8 = 3;

--- a/src/test/ui/span/wf-method-late-bound-regions.nll.stderr
+++ b/src/test/ui/span/wf-method-late-bound-regions.nll.stderr
@@ -1,0 +1,14 @@
+error: compilation successful
+  --> $DIR/wf-method-late-bound-regions.rs:25:1
+   |
+LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
+LL | |     let f = Foo(None);
+LL | |     let f2 = f;
+LL | |     let dangling = {
+...  |
+LL | |     println!("{}", dangling);
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/span/wf-method-late-bound-regions.rs
+++ b/src/test/ui/span/wf-method-late-bound-regions.rs
@@ -11,7 +11,7 @@
 // A method's receiver must be well-formed, even if it has late-bound regions.
 // Because of this, a method's substs being well-formed does not imply that
 // the method's implied bounds are met.
-
+#![feature(rustc_attrs)]
 struct Foo<'b>(Option<&'b ()>);
 
 trait Bar<'b> {
@@ -22,7 +22,7 @@ impl<'b> Bar<'b> for Foo<'b> {
     fn xmute<'a>(&'a self, u: &'b u32) -> &'a u32 { u }
 }
 
-fn main() {
+fn main() { #![rustc_error] // rust-lang/rust#49855
     let f = Foo(None);
     let f2 = f;
     let dangling = {

--- a/src/test/ui/suggestions/closure-immutable-outer-variable.nll.stderr
+++ b/src/test/ui/suggestions/closure-immutable-outer-variable.nll.stderr
@@ -1,0 +1,9 @@
+error[E0594]: cannot assign to immutable item `y`
+  --> $DIR/closure-immutable-outer-variable.rs:19:26
+   |
+LL |     foo(Box::new(move || y = false) as Box<_>); //~ ERROR cannot assign to captured outer variable
+   |                          ^^^^^^^^^ cannot mutate
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0594`.

--- a/src/test/ui/suggestions/fn-closure-mutable-capture.nll.stderr
+++ b/src/test/ui/suggestions/fn-closure-mutable-capture.nll.stderr
@@ -1,0 +1,9 @@
+error[E0594]: cannot assign to immutable item `x`
+  --> $DIR/fn-closure-mutable-capture.rs:15:17
+   |
+LL |     bar(move || x = 1);
+   |                 ^^^^^ cannot mutate
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0594`.

--- a/src/test/ui/underscore-lifetime/dyn-trait-underscore.nll.stderr
+++ b/src/test/ui/underscore-lifetime/dyn-trait-underscore.nll.stderr
@@ -1,0 +1,36 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/dyn-trait-underscore.rs:20:14
+   |
+LL |     Box::new(items.iter()) //~ ERROR cannot infer an appropriate lifetime
+   |              ^^^^^
+
+warning: not reporting region error due to -Znll
+  --> $DIR/dyn-trait-underscore.rs:20:20
+   |
+LL |     Box::new(items.iter()) //~ ERROR cannot infer an appropriate lifetime
+   |                    ^^^^
+
+warning: not reporting region error due to -Znll
+  --> $DIR/dyn-trait-underscore.rs:20:5
+   |
+LL |     Box::new(items.iter()) //~ ERROR cannot infer an appropriate lifetime
+   |     ^^^^^^^^
+
+warning: not reporting region error due to -Znll
+  --> $DIR/dyn-trait-underscore.rs:20:5
+   |
+LL |     Box::new(items.iter()) //~ ERROR cannot infer an appropriate lifetime
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+
+error: free region `` does not outlive free region `'static`
+  --> $DIR/dyn-trait-underscore.rs:18:52
+   |
+LL |   fn a<T>(items: &[T]) -> Box<dyn Iterator<Item=&T>> {
+   |  ____________________________________________________^
+LL | |     //                      ^^^^^^^^^^^^^^^^^^^^^ bound *here* defaults to `'static`
+LL | |     Box::new(items.iter()) //~ ERROR cannot infer an appropriate lifetime
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -12,14 +12,41 @@
 
 use std::path::Path;
 
+// See rust-lang/rust#48879: In addition to the mapping from `foo.rs`
+// to `foo.stderr`/`foo.stdout`, we also can optionally have
+// `foo.$mode.stderr`, where $mode is one of the strings on this list,
+// as an alternative to use when running under that mode.
+static COMPARE_MODE_NAMES: [&'static str; 1] = ["nll"];
+
 pub fn check(path: &Path, bad: &mut bool) {
     super::walk_many(&[&path.join("test/ui"), &path.join("test/ui-fulldeps")],
                      &mut |_| false,
                      &mut |file_path| {
         if let Some(ext) = file_path.extension() {
             if (ext == "stderr" || ext == "stdout") && !file_path.with_extension("rs").exists() {
-                println!("Stray file with UI testing output: {:?}", file_path);
-                *bad = true;
+
+                // rust-lang/rust#48879: this fn used to be beautful
+                // because Path API special-cases replacing
+                // extensions. That works great for ".stderr" but not
+                // so well for ".nll.stderr". To support the latter,
+                // we explicitly search backwards for mode's starting
+                // point and build corresponding source name.
+                let filename = file_path.file_name().expect("need filename")
+                    .to_str().expect("need UTF-8 filename");
+                let found_matching_prefix = COMPARE_MODE_NAMES.iter().any(|mode| {
+                    if let Some(r_idx) = filename.rfind(&format!(".{}", mode)) {
+                        let source_name = format!("{}.rs", &filename[0..r_idx]);
+                        let source_path = file_path.with_file_name(source_name);
+                        source_path.exists()
+                    } else {
+                        false
+                    }
+                });
+
+                if !found_matching_prefix {
+                    println!("Stray file with UI testing output: {:?}", file_path);
+                    *bad = true;
+                }
             }
         }
     });


### PR DESCRIPTION
This takes the next (and potentially final?) step with #48879.

Namely, this PR got things to the point where I can successfully run `compiletest` on `src/test/ui` with `--compile-mode=nll`.

Here are the main pieces of it:

 1. To figure out how to even run `compiletest` normally on the ui directory, I ran `x.py test -vv`, and then looked for the `compiletest` invocation that mentioned `src/test/ui`.
 2. I took the aforementioned `compiletest` invocation and used it, adding `--compile-mode=nll` to the end. It had 170 failing cases.
 3. Due to #49855, I had to edit some of the tests so that they fail even under NLL, via `#[rustc_error]`. That's the first commit. (Then goto 2 to double-check no such tests remain.)
 4. I took the generated `build/target/test/foo.stderr` file for every case that failed, and blindly copied it to `src/test/foo.nll.stderr`. That's the second commit.
 5. Goto 2 until there were no failing cases.
 6. Remove any stamp files, and re-run `x.py test` to make sure that the edits and new `.nll.stderr` files haven't broken the pre-existing test suite.

