### PR TITLE
add target features when extracting and running doctests

### DIFF
--- a/src/test/rustdoc/doc-cfg-target-feature.rs
+++ b/src/test/rustdoc/doc-cfg-target-feature.rs
@@ -1,0 +1,31 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// only-x86_64
+// compile-flags:--test
+// should-fail
+// no-system-llvm
+
+// #49723: rustdoc didn't add target features when extracting or running doctests
+
+#![feature(doc_cfg)]
+
+/// Foo
+///
+/// # Examples
+///
+/// ```
+/// #![feature(cfg_target_feature)]
+///
+/// #[cfg(target_feature = "sse")]
+/// assert!(false);
+/// ```
+#[doc(cfg(target_feature = "sse"))]
+pub unsafe fn foo() {}


### PR DESCRIPTION
When rendering documentation, rustdoc will happily load target features into the cfg environment from the current target, but fails to do this when doing anything with doctests. This would lead to situations where, thanks to https://github.com/rust-lang/rust/pull/48759, functions tagged with `#[target_feature]` couldn't run doctests, thanks to the automatic `#[doc(cfg(target_feature = "..."))]`.

Currently, there's no way to pass codegen options to rustdoc that will affect its rustc sessions, but for now this will let you use target features that come default on the platform you're targeting.

Fixes https://github.com/rust-lang/rust/issues/49723