### PR TITLE
Immutably and implicitly borrow all pattern ids for their guards (NLL only)

### DIFF
--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1467,6 +1467,14 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         self.borrowck_mode().use_mir()
     }
 
+    /// If true, pattern variables for use in guards on match arms
+    /// will be bound as references to the data, and occurrences of
+    /// those variables in the guard expression will implicitly
+    /// dereference those bindings. (See rust-lang/rust#27282.)
+    pub fn all_pat_vars_are_implicit_refs_within_guards(self) -> bool {
+        self.borrowck_mode().use_mir()
+    }
+
     /// If true, we should enable two-phase borrows checks. This is
     /// done with either `-Ztwo-phase-borrows` or with
     /// `#![feature(nll)]`.

--- a/src/librustc_mir/borrow_check/error_reporting.rs
+++ b/src/librustc_mir/borrow_check/error_reporting.rs
@@ -471,7 +471,8 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
             | (RegionKind::ReClosureBound(_), _)
             | (RegionKind::ReCanonical(_), _)
             | (RegionKind::ReErased, _) => {
-                span_bug!(drop_span, "region does not make sense in this context");
+                span_bug!(drop_span, "region {:?} does not make sense in this context",
+                          borrow.region);
             }
         }
     }

--- a/src/librustc_mir/build/block.rs
+++ b/src/librustc_mir/build/block.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 use build::{BlockAnd, BlockAndExtension, Builder};
+use build::ForGuard::OutsideGuard;
+use build::matches::ArmHasGuard;
 use hair::*;
 use rustc::mir::*;
 use rustc::hir;
@@ -113,7 +115,8 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                     // Declare the bindings, which may create a visibility scope.
                     let remainder_span = remainder_scope.span(this.hir.tcx(),
                                                               &this.hir.region_scope_tree);
-                    let scope = this.declare_bindings(None, remainder_span, lint_level, &pattern);
+                    let scope = this.declare_bindings(None, remainder_span, lint_level, &pattern,
+                                                      ArmHasGuard(false));
 
                     // Evaluate the initializer, if present.
                     if let Some(init) = initializer {
@@ -135,8 +138,8 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                         }
 
                         this.visit_bindings(&pattern, &mut |this, _, _, node, span, _| {
-                            this.storage_live_binding(block, node, span);
-                            this.schedule_drop_for_binding(node, span);
+                            this.storage_live_binding(block, node, span, OutsideGuard);
+                            this.schedule_drop_for_binding(node, span, OutsideGuard);
                         })
                     }
 

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -291,8 +291,14 @@ struct Builder<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
     visibility_scope_info: IndexVec<VisibilityScope, VisibilityScopeInfo>,
     visibility_scope: VisibilityScope,
 
+    /// the guard-context: each time we build the guard expression for
+    /// a match arm, we push onto this stack, and then pop when we
+    /// finish building it.
+    guard_context: Vec<GuardFrame>,
+
     /// Maps node ids of variable bindings to the `Local`s created for them.
-    var_indices: NodeMap<Local>,
+    /// (A match binding can have two locals; the 2nd is for the arm's guard.)
+    var_indices: NodeMap<LocalsForNode>,
     local_decls: IndexVec<Local, LocalDecl<'tcx>>,
     unit_temp: Option<Place<'tcx>>,
 
@@ -303,6 +309,74 @@ struct Builder<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
     cached_return_block: Option<BasicBlock>,
     /// cached block with the UNREACHABLE terminator
     cached_unreachable_block: Option<BasicBlock>,
+}
+
+impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
+    fn is_bound_var_in_guard(&self, id: ast::NodeId) -> bool {
+        self.guard_context.iter().any(|frame| frame.locals.iter().any(|local| local.id == id))
+    }
+
+    fn var_local_id(&self, id: ast::NodeId, for_guard: ForGuard) -> Local {
+        self.var_indices[&id].local_id(for_guard)
+    }
+}
+
+#[derive(Debug)]
+enum LocalsForNode {
+    One(Local),
+    Two { for_guard: Local, for_arm_body: Local },
+}
+
+#[derive(Debug)]
+struct GuardFrameLocal {
+    id: ast::NodeId,
+}
+
+impl GuardFrameLocal {
+    fn new(id: ast::NodeId, _binding_mode: BindingMode) -> Self {
+        GuardFrameLocal {
+            id: id,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct GuardFrame {
+    /// These are the id's of names that are bound by patterns of the
+    /// arm of *this* guard.
+    ///
+    /// (Frames higher up the stack will have the id's bound in arms
+    /// further out, such as in a case like:
+    ///
+    /// match E1 {
+    ///      P1(id1) if (... (match E2 { P2(id2) if ... => B2 })) => B1,
+    /// }
+    ///
+    /// here, when building for FIXME
+    locals: Vec<GuardFrameLocal>,
+}
+
+/// ForGuard is isomorphic to a boolean flag. It indicates whether we are
+/// talking about the temp for a local binding for a use within a guard expression,
+/// or a temp for use outside of a guard expressions.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum ForGuard {
+    WithinGuard,
+    OutsideGuard,
+}
+
+impl LocalsForNode {
+    fn local_id(&self, for_guard: ForGuard) -> Local {
+        match (self, for_guard) {
+            (&LocalsForNode::One(local_id), ForGuard::OutsideGuard) |
+            (&LocalsForNode::Two { for_guard: local_id, .. }, ForGuard::WithinGuard) |
+            (&LocalsForNode::Two { for_arm_body: local_id, .. }, ForGuard::OutsideGuard) =>
+                local_id,
+
+            (&LocalsForNode::One(_), ForGuard::WithinGuard) =>
+                bug!("anything with one local should never be within a guard."),
+        }
+    }
 }
 
 struct CFG<'tcx> {
@@ -548,6 +622,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             visibility_scopes: IndexVec::new(),
             visibility_scope: ARGUMENT_VISIBILITY_SCOPE,
             visibility_scope_info: IndexVec::new(),
+            guard_context: vec![],
             push_unsafe_count: 0,
             unpushed_unsafe: safety,
             breakable_scopes: vec![],
@@ -636,11 +711,12 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                     // Don't introduce extra copies for simple bindings
                     PatternKind::Binding { mutability, var, mode: BindingMode::ByValue, .. } => {
                         self.local_decls[local].mutability = mutability;
-                        self.var_indices.insert(var, local);
+                        self.var_indices.insert(var, LocalsForNode::One(local));
                     }
                     _ => {
                         scope = self.declare_bindings(scope, ast_body.span,
-                                                      LintLevel::Inherited, &pattern);
+                                                      LintLevel::Inherited, &pattern,
+                                                      matches::ArmHasGuard(false));
                         unpack!(block = self.place_into_pattern(block, pattern, &place));
                     }
                 }

--- a/src/librustc_mir/dataflow/impls/borrows.rs
+++ b/src/librustc_mir/dataflow/impls/borrows.rs
@@ -179,8 +179,14 @@ impl<'a, 'gcx, 'tcx> BitDenotation for Borrows<'a, 'gcx, 'tcx> {
                     if let RegionKind::ReEmpty = region {
                         // If the borrowed value dies before the borrow is used, the region for
                         // the borrow can be empty. Don't track the borrow in that case.
+                        debug!("Borrows::statement_effect_on_borrows \
+                                location: {:?} stmt: {:?} has empty region, killing {:?}",
+                               location, stmt.kind, index);
                         sets.kill(&index);
                         return
+                    } else {
+                        debug!("Borrows::statement_effect_on_borrows location: {:?} stmt: {:?}",
+                               location, stmt.kind);
                     }
 
                     assert!(self.borrow_set.region_map.get(region).unwrap_or_else(|| {

--- a/src/test/compile-fail/nll/match-guards-always-borrow.rs
+++ b/src/test/compile-fail/nll/match-guards-always-borrow.rs
@@ -1,0 +1,61 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//revisions: ast mir
+//[mir] compile-flags: -Z borrowck=mir
+
+#![feature(rustc_attrs)]
+
+// Here is arielb1's basic example from rust-lang/rust#27282
+// that AST borrowck is flummoxed by:
+
+fn should_reject_destructive_mutate_in_guard() {
+    match Some(&4) {
+        None => {},
+        ref mut foo if {
+            (|| { let bar = foo; bar.take() })();
+            //[mir]~^ ERROR cannot move out of borrowed content [E0507]
+            false } => { },
+        Some(s) => std::process::exit(*s),
+    }
+}
+
+// Here below is a case that needs to keep working: we only use the
+// binding via immutable-borrow in the guard, and we mutate in the arm
+// body.
+fn allow_mutate_in_arm_body() {
+    match Some(&4) {
+        None => {},
+        ref mut foo if foo.is_some() && false => { foo.take(); () }
+        Some(s) => std::process::exit(*s),
+    }
+}
+
+// Here below is a case that needs to keep working: we only use the
+// binding via immutable-borrow in the guard, and we move into the arm
+// body.
+fn allow_move_into_arm_body() {
+    match Some(&4) {
+        None => {},
+        mut foo if foo.is_some() && false => { foo.take(); () }
+        Some(s) => std::process::exit(*s),
+    }
+}
+
+// Since this is a compile-fail test that is explicitly encoding the
+// different behavior of AST- vs MIR-borrowck where AST-borrowck does
+// not error, we need to use rustc_error to placate the test harness
+// that wants *some* error to occur.
+#[rustc_error]
+fn main() { //[ast]~ ERROR compilation successful
+    should_reject_destructive_mutate_in_guard();
+    allow_mutate_in_arm_body();
+    allow_move_into_arm_body();
+}

--- a/src/test/mir-opt/match_false_edges.rs
+++ b/src/test/mir-opt/match_false_edges.rs
@@ -54,17 +54,17 @@ fn main() {
 //      ...
 //      _2 = std::option::Option<i32>::Some(const 42i32,);
 //      _3 = discriminant(_2);
-//      _6 = discriminant(_2);
-//      switchInt(move _6) -> [0isize: bb6, 1isize: bb4, otherwise: bb8];
+//      _7 = discriminant(_2);
+//      switchInt(move _7) -> [0isize: bb6, 1isize: bb4, otherwise: bb8];
 //  }
 //  bb1: {
 //      resume;
 //  }
 //  bb2: {  // arm1
-//      StorageLive(_8);
-//      _8 = _4;
-//      _1 = (const 1i32, move _8);
-//      StorageDead(_8);
+//      StorageLive(_9);
+//      _9 = _4;
+//      _1 = (const 1i32, move _9);
+//      StorageDead(_9);
 //      goto -> bb13;
 //  }
 //  bb3: { // binding3(empty) and arm3
@@ -87,24 +87,26 @@ fn main() {
 //      unreachable;
 //  }
 //  bb9: { // binding1 and guard
-//      StorageLive(_4);
-//      _4 = ((_2 as Some).0: i32);
-//      StorageLive(_7);
-//      _7 = const guard() -> [return: bb10, unwind: bb1];
+//      StorageLive(_5);
+//      _5 = &((_2 as Some).0: i32);
+//      StorageLive(_8);
+//      _8 = const guard() -> [return: bb10, unwind: bb1];
 //  }
 //  bb10: { // end of guard
-//      switchInt(move _7) -> [false: bb11, otherwise: bb2];
+//      StorageLive(_4);
+//      _4 = ((_2 as Some).0: i32);
+//      switchInt(move _8) -> [false: bb11, otherwise: bb2];
 //  }
 //  bb11: { // to pre_binding2
 //      falseEdges -> [real: bb5, imaginary: bb5];
 //  }
 //  bb12: { // bindingNoLandingPads.before.mir2 and arm2
-//      StorageLive(_5);
-//      _5 = ((_2 as Some).0: i32);
-//      StorageLive(_9);
-//      _9 = _5;
-//      _1 = (const 2i32, move _9);
-//      StorageDead(_9);
+//      StorageLive(_6);
+//      _6 = ((_2 as Some).0: i32);
+//      StorageLive(_10);
+//      _10 = _6;
+//      _1 = (const 2i32, move _10);
+//      StorageDead(_10);
 //      goto -> bb13;
 //  }
 //  bb13: {
@@ -118,17 +120,17 @@ fn main() {
 //      ...
 //      _2 = std::option::Option<i32>::Some(const 42i32,);
 //      _3 = discriminant(_2);
-//      _6 = discriminant(_2);
-//      switchInt(move _6) -> [0isize: bb5, 1isize: bb4, otherwise: bb8];
+//      _7 = discriminant(_2);
+//      switchInt(move _7) -> [0isize: bb5, 1isize: bb4, otherwise: bb8];
 //  }
 //  bb1: {
 //      resume;
 //  }
 //  bb2: { // arm1
-//      StorageLive(_8);
-//      _8 = _4;
-//      _1 = (const 1i32, move _8);
-//      StorageDead(_8);
+//      StorageLive(_9);
+//      _9 = _4;
+//      _1 = (const 1i32, move _9);
+//      StorageDead(_9);
 //      goto -> bb13;
 //  }
 //  bb3: { // binding3(empty) and arm3
@@ -151,24 +153,26 @@ fn main() {
 //      unreachable;
 //  }
 //  bb9: { // binding1 and guard
-//      StorageLive(_4);
-//      _4 = ((_2 as Some).0: i32);
-//      StorageLive(_7);
-//      _7 = const guard() -> [return: bb10, unwind: bb1];
+//      StorageLive(_5);
+//      _5 = &((_2 as Some).0: i32);
+//      StorageLive(_8);
+//      _8 = const guard() -> [return: bb10, unwind: bb1];
 //  }
 //  bb10: { // end of guard
-//      switchInt(move _7) -> [false: bb11, otherwise: bb2];
+//      StorageLive(_4);
+//      _4 = ((_2 as Some).0: i32);
+//      switchInt(move _8) -> [false: bb11, otherwise: bb2];
 //  }
 //  bb11: { // to pre_binding2
 //      falseEdges -> [real: bb6, imaginary: bb5];
 //  }
 //  bb12: { // binding2 and arm2
-//      StorageLive(_5);
-//      _5 = ((_2 as Some).0: i32);
-//      StorageLive(_9);
-//      _9 = _5;
-//      _1 = (const 2i32, move _9);
-//      StorageDead(_9);
+//      StorageLive(_6);
+//      _6 = ((_2 as Some).0: i32);
+//      StorageLive(_10);
+//      _10 = _6;
+//      _1 = (const 2i32, move _10);
+//      StorageDead(_10);
 //      goto -> bb13;
 //  }
 //  bb13: {
@@ -182,8 +186,8 @@ fn main() {
 //     ...
 //     _2 = std::option::Option<i32>::Some(const 1i32,);
 //     _3 = discriminant(_2);
-//     _8 = discriminant(_2);
-//     switchInt(move _8) -> [1isize: bb4, otherwise: bb5];
+//     _10 = discriminant(_2);
+//     switchInt(move _10) -> [1isize: bb4, otherwise: bb5];
 // }
 // bb1: {
 //     resume;
@@ -213,41 +217,45 @@ fn main() {
 //     unreachable;
 // }
 // bb9: { // binding1: Some(w) if guard()
-//     StorageLive(_4);
-//     _4 = ((_2 as Some).0: i32);
-//     StorageLive(_9);
-//     _9 = const guard() -> [return: bb10, unwind: bb1];
+//     StorageLive(_5);
+//     _5 = &((_2 as Some).0: i32);
+//     StorageLive(_11);
+//     _11 = const guard() -> [return: bb10, unwind: bb1];
 // }
 // bb10: { //end of guard
-//    switchInt(move _9) -> [false: bb11, otherwise: bb2];
+//    StorageLive(_4);
+//    _4 = ((_2 as Some).0: i32);
+//    switchInt(move _11) -> [false: bb11, otherwise: bb2];
 // }
 // bb11: { // to pre_binding2
 //     falseEdges -> [real: bb5, imaginary: bb5];
 // }
 // bb12: { // binding2 & arm2
-//     StorageLive(_5);
-//     _5 = _2;
+//     StorageLive(_6);
+//     _6 = _2;
 //     _1 = const 2i32;
 //     goto -> bb17;
 // }
 // bb13: { // binding3: Some(y) if guard2(y)
-//     StorageLive(_6);
-//     _6 = ((_2 as Some).0: i32);
-//     StorageLive(_11);
-//     StorageLive(_12);
-//     _12 = _6;
-//     _11 = const guard2(move _12) -> [return: bb14, unwind: bb1];
+//     StorageLive(_8);
+//     _8 = &((_2 as Some).0: i32);
+//     StorageLive(_13);
+//     StorageLive(_14);
+//     _14 = (*_8);
+//     _13 = const guard2(move _14) -> [return: bb14, unwind: bb1];
 // }
 // bb14: { // end of guard2
-//     StorageDead(_12);
-//     switchInt(move _11) -> [false: bb15, otherwise: bb3];
+//     StorageDead(_14);
+//     StorageLive(_7);
+//     _7 = ((_2 as Some).0: i32);
+//     switchInt(move _13) -> [false: bb15, otherwise: bb3];
 // }
 // bb15: { // to pre_binding4
 //     falseEdges -> [real: bb7, imaginary: bb7];
 // }
 // bb16: { // binding4 & arm4
-//     StorageLive(_7);
-//     _7 = _2;
+//     StorageLive(_9);
+//     _9 = _2;
 //     _1 = const 4i32;
 //     goto -> bb17;
 // }

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2735,10 +2735,12 @@ impl<'test> TestCx<'test> {
             panic!(
                 "Did not find expected line, error: {}\n\
                  Expected Line: {:?}\n\
+                 Test Name: {}\n\
                  Expected:\n{}\n\
                  Actual:\n{}",
                 extra_msg,
                 expected_line,
+                test_name,
                 expected_content,
                 normalize_all
             );


### PR DESCRIPTION
This is an important piece of rust-lang/rust#27282.

It applies only to NLL mode. It is a change to MIR codegen that is currently toggled on only when NLL is turned on. It thus affect MIR-borrowck but not the earlier static analyses (such as the type checker).

This change makes it so that any pattern bindings of type T for a match arm will map to a `&T` within the context of the guard expression for that arm, but will continue to map to a `T` in the context of the arm body.

To avoid surfacing this type distinction in the user source code (which would be a severe change to the language and would also require far more revision to the compiler internals), any occurrence of such an identifier in the guard expression will automatically get a deref op applied to it.

So an input like:
```rust
let place = (1, Foo::new());
match place {
  (1, foo) if inspect(foo) => feed(foo), 
  ...  
}
```
will be treated as if it were really something like:
 ```rust
let place = (1, Foo::new());
match place {
    (1, Foo { .. }) if { let tmp1 = &place.1; inspect(*tmp1) }
                    => { let tmp2 = place.1; feed(tmp2) },
    ...
}
```

And an input like:
```rust
let place = (2, Foo::new());
match place {
    (2, ref mut foo) if inspect(foo) => feed(foo),
    ... 
}
```
will be treated as if it were really something like:

```rust
let place = (2, Foo::new());
match place {
    (2, Foo { .. }) if { let tmp1 = & &mut place.1; inspect(*tmp1) }
                    => { let tmp2 = &mut place.1; feed(tmp2) },
    ... 
}
```

In short, any pattern binding will always look like *some* kind of `&T` within the guard at least in terms of how the MIR-borrowck views it, and this will ensure that guard expressions cannot mutate their the match inputs via such bindings. (It also ensures that guard expressions can at most *copy* values from such bindings; non-Copy things cannot be moved via these pattern bindings in guard expressions, since one cannot move out of a `&T`.)
