### PR TITLE
[beta] [incremental] Hash `Allocation`s

### DIFF
--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -399,7 +399,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for mir::interpret::AllocId {
             let tcx = tcx.expect("can't hash AllocIds during hir lowering");
             if let Some(alloc) = tcx.interpret_interner.get_alloc(*self) {
                 AllocDiscriminant::Alloc.hash_stable(hcx, hasher);
-                if !hcx.alloc_id_recursion_tracker.insert(*self) {
+                if hcx.alloc_id_recursion_tracker.insert(*self) {
                     tcx
                         .interpret_interner
                         .get_corresponding_static_def_id(*self)

--- a/src/test/incremental/issue-49595/auxiliary/lit_a.rs
+++ b/src/test/incremental/issue-49595/auxiliary/lit_a.rs
@@ -1,0 +1,11 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub const A: &str = "hello";

--- a/src/test/incremental/issue-49595/auxiliary/lit_b.rs
+++ b/src/test/incremental/issue-49595/auxiliary/lit_b.rs
@@ -1,0 +1,11 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub const A: &str = "xxxxx";

--- a/src/test/incremental/issue-49595/issue_49595.rs
+++ b/src/test/incremental/issue-49595/issue_49595.rs
@@ -1,0 +1,42 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// revisions:cfail1 cfail2 cfail3
+// compile-flags: -Z query-dep-graph --test
+// must-compile-successfully
+
+#![feature(rustc_attrs)]
+#![crate_type = "rlib"]
+
+#![rustc_partition_translated(module="issue_49595-tests", cfg="cfail2")]
+#![rustc_partition_translated(module="issue_49595-lit_test", cfg="cfail3")]
+
+mod tests {
+    #[cfg_attr(not(cfail1), ignore)]
+    #[test]
+    fn test() {
+    }
+}
+
+
+// Checks that changing a string literal without changing its span
+// takes effect.
+
+// replacing a module to have a stable span
+#[cfg_attr(not(cfail3), path = "auxiliary/lit_a.rs")]
+#[cfg_attr(cfail3, path = "auxiliary/lit_b.rs")]
+mod lit;
+
+pub mod lit_test {
+    #[test]
+    fn lit_test() {
+        println!("{}", ::lit::A);
+    }
+}


### PR DESCRIPTION
backport of #49752 

cc @matklad @sinkuu 