### PR TITLE
Fix derive(PartialOrd) and optimise final field operation

### DIFF
--- a/src/etc/generate-deriving-span-tests.py
+++ b/src/etc/generate-deriving-span-tests.py
@@ -113,7 +113,7 @@ traits = {
 
 for (trait, supers, errs) in [('Clone', [], 1),
                               ('PartialEq', [], 2),
-                              ('PartialOrd', ['PartialEq'], 3),
+                              ('PartialOrd', ['PartialEq'], 5),
                               ('Eq', ['PartialEq'], 1),
                               ('Ord', ['Eq', 'PartialOrd', 'PartialEq'], 1),
                               ('Debug', [], 1),

--- a/src/libsyntax_ext/deriving/cmp/partial_eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/partial_eq.rs
@@ -26,71 +26,48 @@ pub fn expand_deriving_partial_eq(cx: &mut ExtCtxt,
                                   push: &mut FnMut(Annotatable)) {
     // structures are equal if all fields are equal, and non equal, if
     // any fields are not equal or if the enum variants are different
-    fn cs_eq(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<Expr> {
+    fn cs_op(cx: &mut ExtCtxt,
+             span: Span,
+             substr: &Substructure,
+             op: BinOpKind,
+             combiner: BinOpKind,
+             base: bool)
+             -> P<Expr>
+    {
+        let op = |cx: &mut ExtCtxt, span: Span, self_f: P<Expr>, other_fs: &[P<Expr>]| {
+            let other_f = match (other_fs.len(), other_fs.get(0)) {
+                (1, Some(o_f)) => o_f,
+                _ => cx.span_bug(span, "not exactly 2 arguments in `derive(PartialEq)`"),
+            };
+
+            cx.expr_binary(span, op, self_f, other_f.clone())
+        };
+
         cs_fold1(true, // use foldl
             |cx, span, subexpr, self_f, other_fs| {
-                let other_f = match (other_fs.len(), other_fs.get(0)) {
-                    (1, Some(o_f)) => o_f,
-                    _ => cx.span_bug(span, "not exactly 2 arguments in `derive(PartialEq)`"),
-                };
-
-                let eq = cx.expr_binary(span, BinOpKind::Eq, self_f, other_f.clone());
-
-                cx.expr_binary(span, BinOpKind::And, subexpr, eq)
+                let eq = op(cx, span, self_f, other_fs);
+                cx.expr_binary(span, combiner, subexpr, eq)
             },
             |cx, args| {
                 match args {
                     Some((span, self_f, other_fs)) => {
                         // Special-case the base case to generate cleaner code.
-                        let other_f = match (other_fs.len(), other_fs.get(0)) {
-                            (1, Some(o_f)) => o_f,
-                            _ => {
-                                cx.span_bug(span, "not exactly 2 arguments in `derive(PartialEq)`")
-                            }
-                        };
-
-                        cx.expr_binary(span, BinOpKind::Eq, self_f, other_f.clone())
+                        op(cx, span, self_f, other_fs)
                     }
-                    None => cx.expr_bool(span, true),
+                    None => cx.expr_bool(span, base),
                 }
             },
-            Box::new(|cx, span, _, _| cx.expr_bool(span, false)),
+            Box::new(|cx, span, _, _| cx.expr_bool(span, !base)),
             cx,
             span,
             substr)
     }
+
+    fn cs_eq(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<Expr> {
+        cs_op(cx, span, substr, BinOpKind::Eq, BinOpKind::And, true)
+    }
     fn cs_ne(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<Expr> {
-        cs_fold1(true, // use foldl
-            |cx, span, subexpr, self_f, other_fs| {
-                let other_f = match (other_fs.len(), other_fs.get(0)) {
-                    (1, Some(o_f)) => o_f,
-                    _ => cx.span_bug(span, "not exactly 2 arguments in `derive(PartialEq)`"),
-                };
-
-                let eq = cx.expr_binary(span, BinOpKind::Ne, self_f, other_f.clone());
-
-                cx.expr_binary(span, BinOpKind::Or, subexpr, eq)
-            },
-            |cx, args| {
-                match args {
-                    Some((span, self_f, other_fs)) => {
-                        // Special-case the base case to generate cleaner code.
-                        let other_f = match (other_fs.len(), other_fs.get(0)) {
-                            (1, Some(o_f)) => o_f,
-                            _ => {
-                                cx.span_bug(span, "not exactly 2 arguments in `derive(PartialEq)`")
-                            }
-                        };
-
-                        cx.expr_binary(span, BinOpKind::Ne, self_f, other_f.clone())
-                    }
-                    None => cx.expr_bool(span, false),
-                }
-            },
-            Box::new(|cx, span, _, _| cx.expr_bool(span, true)),
-            cx,
-            span,
-            substr)
+        cs_op(cx, span, substr, BinOpKind::Ne, BinOpKind::Or, false)
     }
 
     macro_rules! md {

--- a/src/libsyntax_ext/deriving/cmp/partial_eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/partial_eq.rs
@@ -27,40 +27,70 @@ pub fn expand_deriving_partial_eq(cx: &mut ExtCtxt,
     // structures are equal if all fields are equal, and non equal, if
     // any fields are not equal or if the enum variants are different
     fn cs_eq(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<Expr> {
-        cs_fold(true, // use foldl
-                |cx, span, subexpr, self_f, other_fs| {
-            let other_f = match (other_fs.len(), other_fs.get(0)) {
-                (1, Some(o_f)) => o_f,
-                _ => cx.span_bug(span, "not exactly 2 arguments in `derive(PartialEq)`"),
-            };
+        cs_fold1(true, // use foldl
+            |cx, span, subexpr, self_f, other_fs| {
+                let other_f = match (other_fs.len(), other_fs.get(0)) {
+                    (1, Some(o_f)) => o_f,
+                    _ => cx.span_bug(span, "not exactly 2 arguments in `derive(PartialEq)`"),
+                };
 
-            let eq = cx.expr_binary(span, BinOpKind::Eq, self_f, other_f.clone());
+                let eq = cx.expr_binary(span, BinOpKind::Eq, self_f, other_f.clone());
 
-            cx.expr_binary(span, BinOpKind::And, subexpr, eq)
-        },
-                cx.expr_bool(span, true),
-                Box::new(|cx, span, _, _| cx.expr_bool(span, false)),
-                cx,
-                span,
-                substr)
+                cx.expr_binary(span, BinOpKind::And, subexpr, eq)
+            },
+            |cx, args| {
+                match args {
+                    Some((span, self_f, other_fs)) => {
+                        // Special-case the base case to generate cleaner code.
+                        let other_f = match (other_fs.len(), other_fs.get(0)) {
+                            (1, Some(o_f)) => o_f,
+                            _ => {
+                                cx.span_bug(span, "not exactly 2 arguments in `derive(PartialEq)`")
+                            }
+                        };
+
+                        cx.expr_binary(span, BinOpKind::Eq, self_f, other_f.clone())
+                    }
+                    None => cx.expr_bool(span, true),
+                }
+            },
+            Box::new(|cx, span, _, _| cx.expr_bool(span, false)),
+            cx,
+            span,
+            substr)
     }
     fn cs_ne(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<Expr> {
-        cs_fold(true, // use foldl
-                |cx, span, subexpr, self_f, other_fs| {
-            let other_f = match (other_fs.len(), other_fs.get(0)) {
-                (1, Some(o_f)) => o_f,
-                _ => cx.span_bug(span, "not exactly 2 arguments in `derive(PartialEq)`"),
-            };
+        cs_fold1(true, // use foldl
+            |cx, span, subexpr, self_f, other_fs| {
+                let other_f = match (other_fs.len(), other_fs.get(0)) {
+                    (1, Some(o_f)) => o_f,
+                    _ => cx.span_bug(span, "not exactly 2 arguments in `derive(PartialEq)`"),
+                };
 
-            let eq = cx.expr_binary(span, BinOpKind::Ne, self_f, other_f.clone());
+                let eq = cx.expr_binary(span, BinOpKind::Ne, self_f, other_f.clone());
 
-            cx.expr_binary(span, BinOpKind::Or, subexpr, eq)
-        },
-                cx.expr_bool(span, false),
-                Box::new(|cx, span, _, _| cx.expr_bool(span, true)),
-                cx,
-                span,
-                substr)
+                cx.expr_binary(span, BinOpKind::Or, subexpr, eq)
+            },
+            |cx, args| {
+                match args {
+                    Some((span, self_f, other_fs)) => {
+                        // Special-case the base case to generate cleaner code.
+                        let other_f = match (other_fs.len(), other_fs.get(0)) {
+                            (1, Some(o_f)) => o_f,
+                            _ => {
+                                cx.span_bug(span, "not exactly 2 arguments in `derive(PartialEq)`")
+                            }
+                        };
+
+                        cx.expr_binary(span, BinOpKind::Ne, self_f, other_f.clone())
+                    }
+                    None => cx.expr_bool(span, false),
+                }
+            },
+            Box::new(|cx, span, _, _| cx.expr_bool(span, true)),
+            cx,
+            span,
+            substr)
     }
 
     macro_rules! md {

--- a/src/libsyntax_ext/deriving/cmp/partial_ord.rs
+++ b/src/libsyntax_ext/deriving/cmp/partial_ord.rs
@@ -199,9 +199,16 @@ fn cs_op(less: bool, equal: bool, cx: &mut ExtCtxt, span: Span, substr: &Substru
             //
             // ```
             // self.f1 < other.f1 || (!(other.f1 < self.f1) &&
-            // (self.f2 < other.f2 || (!(other.f2 < self.f2) &&
-            // (false)
-            // ))
+            // self.f2 < other.f2
+            // )
+            // ```
+            //
+            // and for op ==
+            // `ast::le`
+            //
+            // ```
+            // self.f1 < other.f1 || (self.f1 == other.f1 &&
+            // self.f2 <= other.f2
             // )
             // ```
             //

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -1745,8 +1745,15 @@ pub fn cs_fold<F>(use_foldl: bool,
     }
 }
 
-/// Special version of `cs_fold` that uses the result of a function call on the first field
-/// as the base case when is at least 1 field, and the usual base case when there are zero fields.
+/// Function to fold over fields, with three cases, to generate more efficient and concise code.
+/// When the `substructure` has grouped fields, there are two cases:
+/// Zero fields: call the base case function with None (like the usual base case of `cs_fold`).
+/// One or more fields: call the base case function on the first value (which depends on
+/// `use_fold`), and use that as the base case. Then perform `cs_fold` on the remainder of the
+/// fields.
+/// When the `substructure` is a `EnumNonMatchingCollapsed`, the result of `enum_nonmatch_f`
+/// is returned. Statics may not be folded over.
+/// See `cs_op` in `partial_ord.rs` for a model example.
 pub fn cs_fold1<F, B>(use_foldl: bool,
                       f: F,
                       mut b: B,

--- a/src/test/compile-fail/derives-span-PartialOrd-enum-struct-variant.rs
+++ b/src/test/compile-fail/derives-span-PartialOrd-enum-struct-variant.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -19,6 +19,8 @@ enum Enum {
      x: Error //~ ERROR
 //~^ ERROR
 //~^^ ERROR
+//~^^^ ERROR
+//~^^^^ ERROR
    }
 }
 

--- a/src/test/compile-fail/derives-span-PartialOrd-enum.rs
+++ b/src/test/compile-fail/derives-span-PartialOrd-enum.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -19,6 +19,8 @@ enum Enum {
      Error //~ ERROR
 //~^ ERROR
 //~^^ ERROR
+//~^^^ ERROR
+//~^^^^ ERROR
      )
 }
 

--- a/src/test/compile-fail/derives-span-PartialOrd-struct.rs
+++ b/src/test/compile-fail/derives-span-PartialOrd-struct.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -18,6 +18,8 @@ struct Struct {
     x: Error //~ ERROR
 //~^ ERROR
 //~^^ ERROR
+//~^^^ ERROR
+//~^^^^ ERROR
 }
 
 fn main() {}

--- a/src/test/compile-fail/derives-span-PartialOrd-tuple-struct.rs
+++ b/src/test/compile-fail/derives-span-PartialOrd-tuple-struct.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -18,6 +18,8 @@ struct Struct(
     Error //~ ERROR
 //~^ ERROR
 //~^^ ERROR
+//~^^^ ERROR
+//~^^^^ ERROR
 );
 
 fn main() {}

--- a/src/test/compile-fail/range_traits-1.rs
+++ b/src/test/compile-fail/range_traits-1.rs
@@ -42,6 +42,8 @@ struct AllTheRanges {
     //~^^ ERROR Ord
     //~^^^ ERROR binary operation `<` cannot be applied to type
     //~^^^^ ERROR binary operation `>` cannot be applied to type
+    //~^^^^^ ERROR binary operation `<=` cannot be applied to type
+    //~^^^^^^ ERROR binary operation `>=` cannot be applied to type
 }
 
 fn main() {}

--- a/src/test/run-pass/derive-partialord-correctness.rs
+++ b/src/test/run-pass/derive-partialord-correctness.rs
@@ -1,0 +1,18 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Original issue: #49650
+
+#[derive(PartialOrd, PartialEq)]
+struct FloatWrapper(f64);
+
+fn main() {
+    assert!((0.0 / 0.0 >= 0.0) == (FloatWrapper(0.0 / 0.0) >= FloatWrapper(0.0)))
+}


### PR DESCRIPTION
```rust
// Before (`lt` on 2-field struct)
self.f1 < other.f1 || (!(other.f1 < self.f1) &&
(self.f2 < other.f2 || (!(other.f2 < self.f2) &&
(false)
))
)

// After
self.f1 < other.f1 || (!(other.f1 < self.f1) &&
self.f2 < other.f2
)

// Before (`le` on 2-field struct)
self.f1 < other.f1 || (!(other.f1 < self.f1) &&
(self.f2 < other.f2 || (!(other.f2 < self.f2) &&
(true)
))
)

// After
self.f1 < other.f1 || (self.f1 == other.f1 &&
self.f2 <= other.f2
)
```

(The big diff is mainly because of a past faulty rustfmt application that I corrected 😒)

Fixes #49650 and fixes #49505.