### PR TITLE
Ignore copyright year when generating deriving span tests

### DIFF
--- a/src/etc/generate-deriving-span-tests.py
+++ b/src/etc/generate-deriving-span-tests.py
@@ -18,7 +18,7 @@ derives have spans that point to the fields, rather than the
 sample usage: src/etc/generate-deriving-span-tests.py
 """
 
-import sys, os, datetime, stat
+import sys, os, datetime, stat, re
 
 TEST_DIR = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '../test/compile-fail'))
@@ -87,16 +87,25 @@ def create_test_case(type, trait, super_traits, error_count):
 def write_file(name, string):
     test_file = os.path.join(TEST_DIR, 'derives-span-%s.rs' % name)
 
+    with open(test_file) as f:
+        old_str = f.read()
+        old_str_ignoring_date = re.sub(r'^// Copyright \d+',
+                                        '// Copyright {year}'.format(year = YEAR), old_str)
+        if old_str_ignoring_date == string:
+            # if all we're doing is updating the copyright year, ignore it
+            return 0
+
     # set write permission if file exists, so it can be changed
     if os.path.exists(test_file):
         os.chmod(test_file, stat.S_IWUSR)
 
-    with open(test_file, 'wt') as f:
+    with open(test_file, 'w') as f:
         f.write(string)
 
     # mark file read-only
     os.chmod(test_file, stat.S_IRUSR|stat.S_IRGRP|stat.S_IROTH)
 
+    return 1
 
 
 ENUM = 1
@@ -120,11 +129,15 @@ for (trait, supers, errs) in [('Clone', [], 1),
                               ('Hash', [], 1)]:
     traits[trait] = (ALL, supers, errs)
 
+files = 0
+
 for (trait, (types, super_traits, error_count)) in traits.items():
     mk = lambda ty: create_test_case(ty, trait, super_traits, error_count)
     if types & ENUM:
-        write_file(trait + '-enum', mk(ENUM_TUPLE))
-        write_file(trait + '-enum-struct-variant', mk(ENUM_STRUCT))
+        files += write_file(trait + '-enum', mk(ENUM_TUPLE))
+        files += write_file(trait + '-enum-struct-variant', mk(ENUM_STRUCT))
     if types & STRUCT:
-        write_file(trait + '-struct', mk(STRUCT_FIELDS))
-        write_file(trait + '-tuple-struct', mk(STRUCT_TUPLE))
+        files += write_file(trait + '-struct', mk(STRUCT_FIELDS))
+        files += write_file(trait + '-tuple-struct', mk(STRUCT_TUPLE))
+
+print('Generated {files} deriving span test{}.'.format('s' if files != 1 else '', files = files))


### PR DESCRIPTION
Previously, generate-deriving-span-tests.py would regenerate all the tests anew, even if they hadn't changed. This creates unnecessary diffs that only change the copyright year. Now we check to see if any of the content of the test has changed before generating the new one.