### PR TITLE
Add rustc_trans to x.py check

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -310,7 +310,7 @@ impl<'a> Builder<'a> {
                 tool::Compiletest, tool::RemoteTestServer, tool::RemoteTestClient,
                 tool::RustInstaller, tool::Cargo, tool::Rls, tool::Rustdoc, tool::Clippy,
                 native::Llvm, tool::Rustfmt, tool::Miri, native::Lld),
-            Kind::Check => describe!(check::Std, check::Test, check::Rustc),
+            Kind::Check => describe!(check::Std, check::Test, check::Rustc, check::CodegenBackend),
             Kind::Test => describe!(test::Tidy, test::Bootstrap, test::Ui, test::RunPass,
                 test::CompileFail, test::ParseFail, test::RunFail, test::RunPassValgrind,
                 test::MirOpt, test::Codegen, test::CodegenUnits, test::Incremental, test::Debuginfo,
@@ -834,7 +834,7 @@ impl<'a> Builder<'a> {
         cargo
     }
 
-    /// Ensure that a given step is built, returning it's output. This will
+    /// Ensure that a given step is built, returning its output. This will
     /// cache the step, so it is safe (and good!) to call this as often as
     /// needed to ensure that all dependencies are built.
     pub fn ensure<S: Step>(&'a self, step: S) -> S::Output {

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -552,6 +552,12 @@ impl<'a> Builder<'a> {
              .arg("--target")
              .arg(target);
 
+        // Set a flag for `check` so that certain build scripts can do less work
+        // (e.g. not building/requiring LLVM).
+        if cmd == "check" {
+            cargo.env("RUST_CHECK", "1");
+        }
+
         // If we were invoked from `make` then that's already got a jobserver
         // set up for us so no need to tell Cargo about jobs all over again.
         if env::var_os("MAKEFLAGS").is_none() && env::var_os("MFLAGS").is_none() {

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -11,10 +11,9 @@
 //! Implementation of compiling the compiler and standard library, in "check" mode.
 
 use compile::{run_cargo, std_cargo, test_cargo, rustc_cargo, rustc_cargo_env, add_to_sysroot};
-use compile::compiler_file;
+use compile::build_codegen_backend;
 use builder::{RunConfig, Builder, ShouldRun, Step};
 use {Compiler, Mode};
-use native;
 use cache::{INTERNER, Interned};
 use std::path::PathBuf;
 
@@ -136,60 +135,19 @@ impl Step for CodegenBackend {
         let build = builder.build;
         let compiler = builder.compiler(0, build.build);
         let target = self.target;
+        let backend = self.backend;
 
         let mut cargo = builder.cargo(compiler, Mode::Librustc, target, "check");
         let mut features = build.rustc_features().to_string();
         cargo.arg("--manifest-path").arg(build.src.join("src/librustc_trans/Cargo.toml"));
         rustc_cargo_env(build, &mut cargo);
 
-        match &*self.backend {
-            "llvm" | "emscripten" => {
-                // Build LLVM for our target. This will implicitly build the
-                // host LLVM if necessary.
-                let llvm_config = builder.ensure(native::Llvm {
-                    target,
-                    emscripten: self.backend == "emscripten",
-                });
-
-                if self.backend == "emscripten" {
-                    features.push_str(" emscripten");
-                }
-
-                // Pass down configuration from the LLVM build into the build of
-                // librustc_llvm and librustc_trans.
-                if build.is_rust_llvm(target) {
-                    cargo.env("LLVM_RUSTLLVM", "1");
-                }
-                cargo.env("LLVM_CONFIG", &llvm_config);
-                if self.backend != "emscripten" {
-                    let target_config = build.config.target_config.get(&target);
-                    if let Some(s) = target_config.and_then(|c| c.llvm_config.as_ref()) {
-                        cargo.env("CFG_LLVM_ROOT", s);
-                    }
-                }
-                // Building with a static libstdc++ is only supported on linux right now,
-                // not for MSVC or macOS
-                if build.config.llvm_static_stdcpp &&
-                   !target.contains("freebsd") &&
-                   !target.contains("windows") &&
-                   !target.contains("apple") {
-                    let file = compiler_file(build,
-                                             build.cxx(target).unwrap(),
-                                             target,
-                                             "libstdc++.a");
-                    cargo.env("LLVM_STATIC_STDCPP", file);
-                }
-                if build.config.llvm_link_shared {
-                    cargo.env("LLVM_LINK_SHARED", "1");
-                }
-            }
-            _ => panic!("unknown backend: {}", self.backend),
-        }
+        features += &build_codegen_backend(&builder, &mut cargo, &compiler, target, backend);
 
         let _folder = build.fold_output(|| format!("stage{}-rustc_trans", compiler.stage));
         run_cargo(build,
                   cargo.arg("--features").arg(features),
-                  &codegen_backend_stamp(build, compiler, target, self.backend),
+                  &codegen_backend_stamp(build, compiler, target, backend),
                   true);
     }
 }

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -11,7 +11,6 @@
 //! Implementation of compiling the compiler and standard library, in "check" mode.
 
 use compile::{run_cargo, std_cargo, test_cargo, rustc_cargo, rustc_cargo_env, add_to_sysroot};
-use compile::build_codegen_backend;
 use builder::{RunConfig, Builder, ShouldRun, Step};
 use {Compiler, Mode};
 use cache::{INTERNER, Interned};
@@ -138,11 +137,11 @@ impl Step for CodegenBackend {
         let backend = self.backend;
 
         let mut cargo = builder.cargo(compiler, Mode::Librustc, target, "check");
-        let mut features = build.rustc_features().to_string();
+        let features = build.rustc_features().to_string();
         cargo.arg("--manifest-path").arg(build.src.join("src/librustc_trans/Cargo.toml"));
         rustc_cargo_env(build, &mut cargo);
 
-        features += &build_codegen_backend(&builder, &mut cargo, &compiler, target, backend);
+        // We won't build LLVM if it's not available, as it shouldn't affect `check`.
 
         let _folder = build.fold_output(|| format!("stage{}-rustc_trans", compiler.stage));
         run_cargo(build,

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -186,13 +186,10 @@ impl Step for CodegenBackend {
             _ => panic!("unknown backend: {}", self.backend),
         }
 
-        let tmp_stamp = build.cargo_out(compiler, Mode::Librustc, target)
-            .join(".tmp.stamp");
-
         let _folder = build.fold_output(|| format!("stage{}-rustc_trans", compiler.stage));
         run_cargo(build,
                   cargo.arg("--features").arg(features),
-                  &tmp_stamp,
+                  &codegen_backend_stamp(build, compiler, target, self.backend),
                   true);
     }
 }
@@ -253,4 +250,14 @@ pub fn libtest_stamp(builder: &Builder, compiler: Compiler, target: Interned<Str
 /// compiler for the specified target.
 pub fn librustc_stamp(builder: &Builder, compiler: Compiler, target: Interned<String>) -> PathBuf {
     builder.cargo_out(compiler, Mode::Librustc, target).join(".librustc-check.stamp")
+}
+
+/// Cargo's output path for librustc_trans in a given stage, compiled by a particular
+/// compiler for the specified target and backend.
+fn codegen_backend_stamp(build: &Build,
+                         compiler: Compiler,
+                         target: Interned<String>,
+                         backend: Interned<String>) -> PathBuf {
+    build.cargo_out(compiler, Mode::Librustc, target)
+         .join(format!(".librustc_trans-{}-check.stamp", backend))
 }

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -795,6 +795,8 @@ pub fn librustc_stamp(builder: &Builder, compiler: Compiler, target: Interned<St
     builder.cargo_out(compiler, Mode::Librustc, target).join(".librustc.stamp")
 }
 
+/// Cargo's output path for librustc_trans in a given stage, compiled by a particular
+/// compiler for the specified target and backend.
 fn codegen_backend_stamp(builder: &Builder,
                          compiler: Compiler,
                          target: Interned<String>,

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -667,7 +667,7 @@ impl Step for CodegenBackend {
                    codegen_backend.display(),
                    f.display());
         }
-        let stamp = codegen_backend_stamp(build, compiler, target, backend);
+        let stamp = codegen_backend_stamp(builder, compiler, target, backend);
         let codegen_backend = codegen_backend.to_str().unwrap();
         t!(t!(File::create(&stamp)).write_all(codegen_backend.as_bytes()));
     }

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -519,7 +519,7 @@ pub fn rustc_cargo(builder: &Builder, cargo: &mut Command) {
     rustc_cargo_env(builder, cargo);
 }
 
-fn rustc_cargo_env(builder: &Builder, cargo: &mut Command) {
+pub fn rustc_cargo_env(builder: &Builder, cargo: &mut Command) {
     // Set some configuration variables picked up by build scripts and
     // the compiler alike
     cargo.env("CFG_RELEASE", builder.rust_release())
@@ -614,7 +614,7 @@ impl Step for CodegenBackend {
         run.builder.ensure(CodegenBackend {
             compiler: run.builder.compiler(run.builder.top_stage, run.host),
             target: run.target,
-            backend
+            backend,
         });
     }
 
@@ -803,7 +803,7 @@ fn codegen_backend_stamp(builder: &Builder,
         .join(format!(".librustc_trans-{}.stamp", backend))
 }
 
-fn compiler_file(builder: &Builder,
+pub fn compiler_file(builder: &Builder,
                  compiler: &Path,
                  target: Interned<String>,
                  file: &str) -> PathBuf {

--- a/src/librustc_llvm/build.rs
+++ b/src/librustc_llvm/build.rs
@@ -30,6 +30,7 @@ fn detect_llvm_link() -> (&'static str, &'static str) {
 fn main() {
     if env::var_os("RUST_CHECK").is_some() {
         // If we're just running `check`, there's no need for LLVM to be built.
+        println!("cargo:rerun-if-env-changed=RUST_CHECK");
         return;
     }
 

--- a/src/librustc_llvm/build.rs
+++ b/src/librustc_llvm/build.rs
@@ -28,6 +28,11 @@ fn detect_llvm_link() -> (&'static str, &'static str) {
 }
 
 fn main() {
+    if env::var_os("RUST_CHECK").is_some() {
+        // If we're just running `check`, there's no need for LLVM to be built.
+        return;
+    }
+
     let target = env::var("TARGET").expect("TARGET was not set");
     let llvm_config = env::var_os("LLVM_CONFIG")
         .map(PathBuf::from)


### PR DESCRIPTION
r? @Mark-Simulacrum 

I looked at `bootstrap/compile.rs` and `bootstrap/check.rs` to try to work out which steps were appropriate, but I'm sure I've overlooked some details here, so it's worth checking carefully I've got all the steps right (e.g. I wasn't sure whether we want to build LLVM if necessary with `x.py check`, though I thought it was probably better to than to not).

From a quick test, it seems to be working, though.