### PR TITLE
Don't allow #[should_panic] with non-() tests

### DIFF
--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-in-test-should-panic.rs
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-in-test-should-panic.rs
@@ -1,0 +1,26 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --test
+
+#![feature(termination_trait_test)]
+#![feature(test)]
+
+extern crate test;
+use std::num::ParseIntError;
+use test::Bencher;
+
+#[test]
+#[should_panic]
+fn not_a_num() -> Result<(), ParseIntError> {
+    //~^ ERROR functions using `#[should_panic]` must return `()`
+    let _: u32 = "abc".parse()?;
+    Ok(())
+}

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-in-test-should-panic.stderr
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-in-test-should-panic.stderr
@@ -1,0 +1,12 @@
+error: functions using `#[should_panic]` must return `()`
+  --> $DIR/termination-trait-in-test-should-panic.rs:22:1
+   |
+LL | / fn not_a_num() -> Result<(), ParseIntError> {
+LL | |     //~^ ERROR functions using `#[should_panic]` must return `()`
+LL | |     let _: u32 = "abc".parse()?;
+LL | |     Ok(())
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-in-test.rs
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-in-test.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // compile-flags: --test
+// run-pass
 
 #![feature(termination_trait_test)]
 #![feature(test)]
@@ -20,13 +21,6 @@ use test::Bencher;
 #[test]
 fn is_a_num() -> Result<(), ParseIntError> {
     let _: u32 = "22".parse()?;
-    Ok(())
-}
-
-#[test]
-#[should_panic]
-fn not_a_num() -> Result<(), ParseIntError> {
-    let _: u32 = "abc".parse()?;
     Ok(())
 }
 


### PR DESCRIPTION
Adds (removes) support for `#[should_panic]` when the test is non-`()`