### PR TITLE
Treat generators as if they have an arbitrary destructor

### DIFF
--- a/src/test/ui/generator/borrowing.nll.stderr
+++ b/src/test/ui/generator/borrowing.nll.stderr
@@ -1,14 +1,30 @@
-error: compilation successful
-  --> $DIR/borrowing.rs:15:1
+error[E0597]: `a` does not live long enough
+  --> $DIR/borrowing.rs:18:18
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     let _b = {
-LL | |         let a = 3;
-LL | |         unsafe { (|| yield &a).resume() }
-...  |
-LL | |     };
-LL | | }
-   | |_^
+LL |         unsafe { (|| yield &a).resume() }
+   |                  ^^^^^^^^^^^^^
+   |                  |
+   |                  borrowed value does not live long enough
+   |                  borrow may end up in a temporary, created here
+LL |         //~^ ERROR: `a` does not live long enough
+LL |     };
+   |     -- temporary later dropped here, potentially using the reference
+   |     |
+   |     borrowed value only lives until here
 
-error: aborting due to previous error
+error[E0597]: `a` does not live long enough
+  --> $DIR/borrowing.rs:24:9
+   |
+LL | /         || {
+LL | |             yield &a
+LL | |             //~^ ERROR: `a` does not live long enough
+LL | |         }
+   | |_________^ borrowed value does not live long enough
+LL |       };
+   |       - borrowed value only lives until here
+LL |   }
+   |   - borrow later used here, when `_b` is dropped
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/generator/borrowing.rs
+++ b/src/test/ui/generator/borrowing.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(generators, generator_trait, rustc_attrs)]
+#![feature(generators, generator_trait)]
 
 use std::ops::Generator;
 
-fn main() { #![rustc_error] // rust-lang/rust#49855
+fn main() {
     let _b = {
         let a = 3;
         unsafe { (|| yield &a).resume() }

--- a/src/test/ui/generator/dropck.nll.stderr
+++ b/src/test/ui/generator/dropck.nll.stderr
@@ -1,14 +1,20 @@
-error: compilation successful
-  --> $DIR/dropck.rs:16:1
+error[E0597]: `ref_` does not live long enough
+  --> $DIR/dropck.rs:22:11
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     let (cell, mut gen);
-LL | |     cell = Box::new(RefCell::new(0));
-LL | |     let ref_ = Box::leak(Box::new(Some(cell.borrow_mut())));
-...  |
-LL | |     // drops the RefCell and then the Ref, leading to use-after-free
-LL | | }
-   | |_^
+LL |       gen = || {
+   |  ___________^
+LL | |         // but the generator can use it to drop a `Ref<'a, i32>`.
+LL | |         let _d = ref_.take(); //~ ERROR `ref_` does not live long enough
+LL | |         yield;
+LL | |     };
+   | |_____^ borrowed value does not live long enough
+...
+LL |   }
+   |   -
+   |   |
+   |   borrowed value only lives until here
+   |   borrow later used here, when `gen` is dropped
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/generator/dropck.rs
+++ b/src/test/ui/generator/dropck.rs
@@ -8,15 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(generators, generator_trait, box_leak, rustc_attrs)]
+#![feature(generators, generator_trait, box_leak)]
 
 use std::cell::RefCell;
 use std::ops::Generator;
 
-fn main() { #![rustc_error] // rust-lang/rust#49855
+fn main() {
     let (cell, mut gen);
     cell = Box::new(RefCell::new(0));
     let ref_ = Box::leak(Box::new(Some(cell.borrow_mut())));
+    //~^ ERROR `*cell` does not live long enough [E0597]
     // the upvar is the non-dropck `&mut Option<Ref<'a, i32>>`.
     gen = || {
         // but the generator can use it to drop a `Ref<'a, i32>`.

--- a/src/test/ui/generator/dropck.stderr
+++ b/src/test/ui/generator/dropck.stderr
@@ -1,5 +1,16 @@
+error[E0597]: `*cell` does not live long enough
+  --> $DIR/dropck.rs:19:40
+   |
+LL |     let ref_ = Box::leak(Box::new(Some(cell.borrow_mut())));
+   |                                        ^^^^ borrowed value does not live long enough
+...
+LL | }
+   | - `*cell` dropped here while still borrowed
+   |
+   = note: values in a scope are dropped in the opposite order they are created
+
 error[E0597]: `ref_` does not live long enough
-  --> $DIR/dropck.rs:23:18
+  --> $DIR/dropck.rs:24:18
    |
 LL |     gen = || {
    |           -- capture occurs here
@@ -12,6 +23,6 @@ LL | }
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/generator/ref-escapes-but-not-over-yield.nll.stderr
+++ b/src/test/ui/generator/ref-escapes-but-not-over-yield.nll.stderr
@@ -1,11 +1,19 @@
 error[E0597]: `b` does not live long enough
   --> $DIR/ref-escapes-but-not-over-yield.rs:24:13
    |
-LL |         a = &b;
-   |             ^^ borrowed value does not live long enough
-LL |         //~^ ERROR `b` does not live long enough
-LL |     };
-   |     - borrowed value only lives until here
+LL |       let mut b = move || {
+   |  _________________-
+LL | |         yield();
+LL | |         let b = 5;
+LL | |         a = &b;
+   | |             ^^ borrowed value does not live long enough
+LL | |         //~^ ERROR `b` does not live long enough
+LL | |     };
+   | |     -
+   | |     |
+   | |     borrowed value only lives until here
+   | |_____temporary later dropped here, potentially using the reference
+   |       borrow may end up in a temporary, created here
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Conservatively assume dropping a generator touches its upvars, via locals' destructors.

Fix #49918