### PR TITLE
Cleanup liballoc use statements

### DIFF
--- a/src/doc/unstable-book/src/language-features/global-allocator.md
+++ b/src/doc/unstable-book/src/language-features/global-allocator.md
@@ -55,7 +55,7 @@ fn main() {
 ```
 
 And that's it! The `#[global_allocator]` attribute is applied to a `static`
-which implements the `Alloc` trait in the `std::heap` module. Note, though,
+which implements the `Alloc` trait in the `std::alloc` module. Note, though,
 that the implementation is defined for `&MyAllocator`, not just `MyAllocator`.
 You may wish, however, to also provide `Alloc for MyAllocator` for other use
 cases.

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -55,8 +55,6 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use raw_vec::RawVec;
-
 use core::any::Any;
 use core::borrow;
 use core::cmp::Ordering;
@@ -68,6 +66,8 @@ use core::mem::{self, Pin};
 use core::ops::{CoerceUnsized, Deref, DerefMut, Generator, GeneratorState};
 use core::ptr::{self, NonNull, Unique};
 use core::convert::From;
+
+use raw_vec::RawVec;
 use str::from_boxed_utf8_unchecked;
 
 /// A pointer type for heap allocation.

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -8,15 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use alloc::{Alloc, Layout, Global};
 use core::cmp;
 use core::mem;
 use core::ops::Drop;
 use core::ptr::{self, NonNull, Unique};
 use core::slice;
-use super::boxed::Box;
-use super::allocator::CollectionAllocErr;
-use super::allocator::CollectionAllocErr::*;
+
+use alloc::{Alloc, Layout, Global};
+use alloc::CollectionAllocErr;
+use alloc::CollectionAllocErr::*;
+use boxed::Box;
 
 /// A low-level utility for more ergonomically allocating, reallocating, and deallocating
 /// a buffer of memory on the heap without having to worry about all the corner cases

--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -46,12 +46,12 @@ use core::mem;
 use core::ptr;
 use core::iter::FusedIterator;
 
-use vec_deque::VecDeque;
 use borrow::{Borrow, ToOwned};
+use boxed::Box;
+use slice::{SliceConcatExt, SliceIndex};
 use string::String;
 use vec::Vec;
-use slice::{SliceConcatExt, SliceIndex};
-use boxed::Box;
+use vec_deque::VecDeque;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{FromStr, Utf8Error};

--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -66,11 +66,11 @@ use core::ptr;
 use core::str::pattern::Pattern;
 use core::str::lossy;
 
+use alloc::CollectionAllocErr;
 use borrow::{Cow, ToOwned};
+use boxed::Box;
 use str::{self, from_boxed_utf8_unchecked, FromStr, Utf8Error, Chars};
 use vec::Vec;
-use boxed::Box;
-use super::allocator::CollectionAllocErr;
 
 /// A UTF-8 encoded, growable string.
 ///

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -82,11 +82,11 @@ use core::ptr;
 use core::ptr::NonNull;
 use core::slice;
 
+use alloc::CollectionAllocErr;
 use borrow::ToOwned;
 use borrow::Cow;
 use boxed::Box;
 use raw_vec::RawVec;
-use super::allocator::CollectionAllocErr;
 
 /// A contiguous growable array type, written `Vec<T>` but pronounced 'vector'.
 ///

--- a/src/liballoc/vec_deque.rs
+++ b/src/liballoc/vec_deque.rs
@@ -30,10 +30,9 @@ use core::slice;
 use core::hash::{Hash, Hasher};
 use core::cmp;
 
+use alloc::CollectionAllocErr;
 use raw_vec::RawVec;
-
-use super::allocator::CollectionAllocErr;
-use super::vec::Vec;
+use vec::Vec;
 
 const INITIAL_CAPACITY: usize = 7; // 2^3 - 1
 const MINIMUM_CAPACITY: usize = 1; // 2 - 1

--- a/src/test/compile-fail/allocator/auxiliary/system-allocator.rs
+++ b/src/test/compile-fail/allocator/auxiliary/system-allocator.rs
@@ -13,7 +13,7 @@
 #![feature(global_allocator, allocator_api)]
 #![crate_type = "rlib"]
 
-use std::heap::System;
+use std::alloc::System;
 
 #[global_allocator]
 static A: System = System;

--- a/src/test/compile-fail/allocator/auxiliary/system-allocator2.rs
+++ b/src/test/compile-fail/allocator/auxiliary/system-allocator2.rs
@@ -13,7 +13,7 @@
 #![feature(global_allocator, allocator_api)]
 #![crate_type = "rlib"]
 
-use std::heap::System;
+use std::alloc::System;
 
 #[global_allocator]
 static A: System = System;

--- a/src/test/compile-fail/allocator/two-allocators.rs
+++ b/src/test/compile-fail/allocator/two-allocators.rs
@@ -10,7 +10,7 @@
 
 #![feature(global_allocator, allocator_api)]
 
-use std::heap::System;
+use std::alloc::System;
 
 #[global_allocator]
 static A: System = System;

--- a/src/test/compile-fail/allocator/two-allocators2.rs
+++ b/src/test/compile-fail/allocator/two-allocators2.rs
@@ -16,7 +16,7 @@
 
 extern crate system_allocator;
 
-use std::heap::System;
+use std::alloc::System;
 
 #[global_allocator]
 static A: System = System;

--- a/src/test/run-pass/allocator-alloc-one.rs
+++ b/src/test/run-pass/allocator-alloc-one.rs
@@ -10,15 +10,15 @@
 
 #![feature(allocator_api, nonnull)]
 
-use std::alloc::{Heap, Alloc};
+use std::alloc::{Alloc, Global};
 
 fn main() {
     unsafe {
-        let ptr = Heap.alloc_one::<i32>().unwrap_or_else(|_| {
-            Heap.oom()
+        let ptr = Global.alloc_one::<i32>().unwrap_or_else(|_| {
+            Global.oom()
         });
         *ptr.as_ptr() = 4;
         assert_eq!(*ptr.as_ptr(), 4);
-        Heap.dealloc_one(ptr);
+        Global.dealloc_one(ptr);
     }
 }

--- a/src/test/run-pass/allocator-alloc-one.rs
+++ b/src/test/run-pass/allocator-alloc-one.rs
@@ -10,7 +10,7 @@
 
 #![feature(allocator_api, nonnull)]
 
-use std::heap::{Heap, Alloc};
+use std::alloc::{Heap, Alloc};
 
 fn main() {
     unsafe {

--- a/src/test/run-pass/allocator/auxiliary/custom.rs
+++ b/src/test/run-pass/allocator/auxiliary/custom.rs
@@ -13,7 +13,7 @@
 #![feature(heap_api, allocator_api)]
 #![crate_type = "rlib"]
 
-use std::heap::{GlobalAlloc, System, Layout, Opaque};
+use std::alloc::{GlobalAlloc, System, Layout, Opaque};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub struct A(pub AtomicUsize);

--- a/src/test/run-pass/regions-mock-trans.rs
+++ b/src/test/run-pass/regions-mock-trans.rs
@@ -12,7 +12,7 @@
 
 #![feature(allocator_api)]
 
-use std::heap::{Alloc, Heap, Layout};
+use std::alloc::{Alloc, Heap, Layout};
 use std::ptr::NonNull;
 
 struct arena(());

--- a/src/test/run-pass/regions-mock-trans.rs
+++ b/src/test/run-pass/regions-mock-trans.rs
@@ -12,7 +12,7 @@
 
 #![feature(allocator_api)]
 
-use std::alloc::{Alloc, Heap, Layout};
+use std::alloc::{Alloc, Global, Layout};
 use std::ptr::NonNull;
 
 struct arena(());
@@ -32,8 +32,8 @@ struct Ccx {
 
 fn alloc<'a>(_bcx : &'a arena) -> &'a Bcx<'a> {
     unsafe {
-        let ptr = Heap.alloc(Layout::new::<Bcx>())
-            .unwrap_or_else(|_| Heap.oom());
+        let ptr = Global.alloc(Layout::new::<Bcx>())
+            .unwrap_or_else(|_| Global.oom());
         &*(ptr.as_ptr() as *const _)
     }
 }
@@ -46,7 +46,7 @@ fn g(fcx : &Fcx) {
     let bcx = Bcx { fcx: fcx };
     let bcx2 = h(&bcx);
     unsafe {
-        Heap.dealloc(NonNull::new_unchecked(bcx2 as *const _ as *mut _), Layout::new::<Bcx>());
+        Global.dealloc(NonNull::new_unchecked(bcx2 as *const _ as *mut _), Layout::new::<Bcx>());
     }
 }
 

--- a/src/test/run-pass/thin-lto-global-allocator.rs
+++ b/src/test/run-pass/thin-lto-global-allocator.rs
@@ -14,6 +14,6 @@
 #![feature(allocator_api, global_allocator)]
 
 #[global_allocator]
-static A: std::heap::System = std::heap::System;
+static A: std::alloc::System = std::alloc::System;
 
 fn main() {}


### PR DESCRIPTION
Some modules were still using the deprecated `allocator` module, use the
`alloc` module instead.

Some modules were using `super` while it's not needed.

Some modules were more or less ordering them, and other not, so the
latter have been modified to match the others.