### PR TITLE
Remove warning about f64->f32 cast being potential UB

### DIFF
--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -502,10 +502,6 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                             &format!("{}, producing the closest possible value",
                                                      msg),
                                             cast_suggestion);
-                        err.warn("casting here will cause undefined behavior if the value is \
-                                  finite but larger or smaller than the largest or smallest \
-                                  finite value representable by `f32` (this is a bug and will be \
-                                  fixed)");
                     }
                     true
                 }


### PR DESCRIPTION
As discussed in #15536, the LLVM documentation incorrect described overflowing f64->f32 casts as being undefined behavior. LLVM never treated them as such, and the documentation has been adjusted in https://reviews.llvm.org/rL329065. As such, this warning can now be removed.

Closes #49622.

---

I could not find any existing test checking for this warning. Should I be adding a test for the absence of the warning instead?