### PR TITLE
Properly handle ranges of signed enums using both extremums (fixes #49973)

### DIFF
--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -1700,18 +1700,19 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                     }
                 }
 
-                let discr = Scalar {
+                let tag_mask = !0u128 >> (128 - ity.size().bits());
+                let tag = Scalar {
                     value: Int(ity, signed),
-                    valid_range: (min as u128)..=(max as u128)
+                    valid_range: (min as u128 & tag_mask)..=(max as u128 & tag_mask),
                 };
-                let abi = if discr.value.size(dl) == size {
-                    Abi::Scalar(discr.clone())
+                let abi = if tag.value.size(dl) == size {
+                    Abi::Scalar(tag.clone())
                 } else {
                     Abi::Aggregate { sized: true }
                 };
                 tcx.intern_layout(LayoutDetails {
                     variants: Variants::Tagged {
-                        discr,
+                        discr: tag,
                         variants
                     },
                     fields: FieldPlacement::Arbitrary {

--- a/src/test/run-pass/issue-49973.rs
+++ b/src/test/run-pass/issue-49973.rs
@@ -1,0 +1,20 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[derive(Debug)]
+#[repr(i32)]
+enum E {
+    Min = -2147483648i32,
+    _Max = 2147483647i32,
+}
+
+fn main() {
+    assert_eq!(Some(E::Min).unwrap() as i32, -2147483648i32);
+}


### PR DESCRIPTION
Fixes #49973.