### PR TITLE
Add Iterator::exhaust

### DIFF
--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -2223,7 +2223,7 @@ pub trait Iterator {
         Sum::sum(self)
     }
 
-    /// Iterates over the entire iterator, multiplying all the elements
+    /// Iterates over the entire iterator, multiplying all the elements.
     ///
     /// An empty iterator returns the one value of the type.
     ///

--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -2251,6 +2251,32 @@ pub trait Iterator {
         Product::product(self)
     }
 
+    /// Eagerly consume the iterator, evaluating all the elements.
+    ///
+    /// This is primarily useful for evaluating the effects of an iterator that
+    /// has previously been created. To evaluate the effects of an iterator
+    /// immediately, it is likely better to use [`for_each`].
+    ///
+    /// [`for_each`]: #method.for_each
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// // Prepare an iterator with side effects...
+    /// let count_aloud = 1..=10.map(|x| println!("{}", x));
+    ///
+    /// // ...
+    ///
+    /// // Trigger the effects!
+    /// count_aloud.exhaust();
+    ///
+    /// ```
+    #[inline]
+    #[unstable(feature = "iter_exhaust", issue = "44546")]
+    fn exhaust(self) where Self: Sized {
+        for _ in self {}
+    }
+
     /// Lexicographically compares the elements of this `Iterator` with those
     /// of another.
     #[stable(feature = "iter_order", since = "1.5.0")]


### PR DESCRIPTION
This adds an `Iterator::exhaust` method for evaluating the side effects of an iterator conveniently. There are already ways to do this simply, but a little uglily (e.g. `iter.for_each(|_| ())` or `iter.collect::<()>()`) and it was proposed in #44546 that it'd be nicer to have a dedicated (and discoverable) method to do this.

Closes #44546.

r? @dtolnay 