### PR TITLE
Change the hashcounts in raw `Lit` variants from usize to u16.

### DIFF
--- a/src/libproc_macro/quote.rs
+++ b/src/libproc_macro/quote.rs
@@ -163,9 +163,9 @@ impl<'a> Quote for &'a str {
     }
 }
 
-impl Quote for usize {
+impl Quote for u16 {
     fn quote(self) -> TokenStream {
-        TokenTree::from(Literal::usize_unsuffixed(self)).into()
+        TokenTree::from(Literal::u16_unsuffixed(self)).into()
     }
 }
 
@@ -197,7 +197,7 @@ macro_rules! literals {
     ($($i:ident),*; $($raw:ident),*) => {
         pub enum LiteralKind {
             $($i,)*
-            $($raw(usize),)*
+            $($raw(u16),)*
         }
 
         impl LiteralKind {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1260,8 +1260,8 @@ pub enum StrStyle {
     Cooked,
     /// A raw string, like `r##"foo"##`
     ///
-    /// The uint is the number of `#` symbols used
-    Raw(usize)
+    /// The value is the number of `#` symbols used.
+    Raw(u16)
 }
 
 /// A literal

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -139,6 +139,7 @@ pub trait AstBuilder {
     fn expr_usize(&self, span: Span, i: usize) -> P<ast::Expr>;
     fn expr_isize(&self, sp: Span, i: isize) -> P<ast::Expr>;
     fn expr_u8(&self, sp: Span, u: u8) -> P<ast::Expr>;
+    fn expr_u16(&self, sp: Span, u: u16) -> P<ast::Expr>;
     fn expr_u32(&self, sp: Span, u: u32) -> P<ast::Expr>;
     fn expr_bool(&self, sp: Span, value: bool) -> P<ast::Expr>;
 
@@ -707,6 +708,10 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     fn expr_u32(&self, sp: Span, u: u32) -> P<ast::Expr> {
         self.expr_lit(sp, ast::LitKind::Int(u as u128,
                                             ast::LitIntType::Unsigned(ast::UintTy::U32)))
+    }
+    fn expr_u16(&self, sp: Span, u: u16) -> P<ast::Expr> {
+        self.expr_lit(sp, ast::LitKind::Int(u as u128,
+                                            ast::LitIntType::Unsigned(ast::UintTy::U16)))
     }
     fn expr_u8(&self, sp: Span, u: u8) -> P<ast::Expr> {
         self.expr_lit(sp, ast::LitKind::Int(u as u128, ast::LitIntType::Unsigned(ast::UintTy::U8)))

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -623,7 +623,7 @@ fn expr_mk_token(cx: &ExtCtxt, sp: Span, tok: &token::Token) -> P<ast::Expr> {
         ($name: expr, $suffix: expr, $content: expr $(, $count: expr)*) => {{
             let name = mk_name(cx, sp, ast::Ident::with_empty_ctxt($content));
             let inner = cx.expr_call(sp, mk_token_path(cx, sp, $name), vec![
-                name $(, cx.expr_usize(sp, $count))*
+                name $(, cx.expr_u16(sp, $count))*
             ]);
             let suffix = match $suffix {
                 Some(name) => cx.expr_some(sp, mk_name(cx, sp, ast::Ident::with_empty_ctxt(name))),

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -133,12 +133,12 @@ impl<'a> StringReader<'a> {
         Ok(ret_val)
     }
 
-    fn fail_unterminated_raw_string(&self, pos: BytePos, hash_count: usize) {
+    fn fail_unterminated_raw_string(&self, pos: BytePos, hash_count: u16) {
         let mut err = self.struct_span_fatal(pos, pos, "unterminated raw string");
         err.span_label(self.mk_sp(pos, pos), "unterminated raw string");
         if hash_count > 0 {
             err.note(&format!("this raw string should be terminated with `\"{}`",
-                              "#".repeat(hash_count)));
+                              "#".repeat(hash_count as usize)));
         }
         err.emit();
         FatalError.raise();
@@ -1439,7 +1439,7 @@ impl<'a> StringReader<'a> {
             'r' => {
                 let start_bpos = self.pos;
                 self.bump();
-                let mut hash_count = 0;
+                let mut hash_count: u16 = 0;
                 while self.ch_is('#') {
                     self.bump();
                     hash_count += 1;

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -72,9 +72,9 @@ pub enum Lit {
     Integer(ast::Name),
     Float(ast::Name),
     Str_(ast::Name),
-    StrRaw(ast::Name, usize), /* raw str delimited by n hash symbols */
+    StrRaw(ast::Name, u16), /* raw str delimited by n hash symbols */
     ByteStr(ast::Name),
-    ByteStrRaw(ast::Name, usize), /* raw byte str delimited by n hash symbols */
+    ByteStrRaw(ast::Name, u16), /* raw byte str delimited by n hash symbols */
 }
 
 impl Lit {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -234,11 +234,11 @@ pub fn token_to_string(tok: &Token) -> String {
                 token::Integer(c)        => c.to_string(),
                 token::Str_(s)           => format!("\"{}\"", s),
                 token::StrRaw(s, n)      => format!("r{delim}\"{string}\"{delim}",
-                                                    delim=repeat("#", n),
+                                                    delim=repeat("#", n as usize),
                                                     string=s),
                 token::ByteStr(v)         => format!("b\"{}\"", v),
                 token::ByteStrRaw(s, n)   => format!("br{delim}\"{string}\"{delim}",
-                                                    delim=repeat("#", n),
+                                                    delim=repeat("#", n as usize),
                                                     string=s),
             };
 
@@ -660,7 +660,7 @@ pub trait PrintState<'a> {
             }
             ast::StrStyle::Raw(n) => {
                 (format!("r{delim}\"{string}\"{delim}",
-                         delim=repeat("#", n),
+                         delim=repeat("#", n as usize),
                          string=st))
             }
         };


### PR DESCRIPTION
This reduces the size of `Token` from 32 bytes to 24 bytes on 64-bit
platforms.