### PR TITLE
Add some groundwork for cross-language LTO.

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -832,7 +832,7 @@ test!(RunFailFullDepsPretty {
     host: true
 });
 
-default_test!(RunMake {
+host_test!(RunMake {
     path: "src/test/run-make",
     mode: "run-make",
     suite: "run-make"

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1030,17 +1030,6 @@ impl Step for Compiletest {
                 if let Some(ar) = builder.ar(target) {
                     cmd.arg("--ar").arg(ar);
                 }
-
-                // Add the llvm/bin directory to PATH since it contains lots of
-                // useful, platform-independent tools
-                let llvm_bin_path = llvm_config.parent()
-                    .expect("Expected llvm-config to be contained in directory");
-                assert!(llvm_bin_path.is_dir());
-                let old_path = env::var_os("PATH").unwrap_or_default();
-                let new_path = env::join_paths(iter::once(llvm_bin_path.to_path_buf())
-                                               .chain(env::split_paths(&old_path)))
-                               .expect("");
-                cmd.env("PATH", new_path);
             }
         }
         if mode == "run-make" && !builder.config.llvm_enabled {

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1293,6 +1293,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
           "make the current crate share its generic instantiations"),
     chalk: bool = (false, parse_bool, [TRACKED],
           "enable the experimental Chalk-based trait solving engine"),
+    cross_lang_lto: bool = (false, parse_bool, [TRACKED],
+          "generate build artifacts that are compatible with linker-based LTO."),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -842,7 +842,11 @@ unsafe fn embed_bitcode(cgcx: &CodegenContext,
         "rustc.embedded.module\0".as_ptr() as *const _,
     );
     llvm::LLVMSetInitializer(llglobal, llconst);
-    let section = if cgcx.opts.target_triple.triple().contains("-ios") {
+
+    let is_apple = cgcx.opts.target_triple.triple().contains("-ios") ||
+                   cgcx.opts.target_triple.triple().contains("-darwin");
+
+    let section = if is_apple {
         "__LLVM,__bitcode\0"
     } else {
         ".llvmbc\0"
@@ -858,7 +862,7 @@ unsafe fn embed_bitcode(cgcx: &CodegenContext,
         "rustc.embedded.cmdline\0".as_ptr() as *const _,
     );
     llvm::LLVMSetInitializer(llglobal, llconst);
-    let section = if cgcx.opts.target_triple.triple().contains("-ios") {
+    let section = if  is_apple {
         "__LLVM,__cmdline\0"
     } else {
         ".llvmcmd\0"

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -1356,6 +1356,10 @@ fn execute_work_item(cgcx: &CodegenContext,
             // settings.
             let needs_lto = needs_lto && mtrans.kind != ModuleKind::Metadata;
 
+            // Don't run LTO passes when cross-lang LTO is enabled. The linker
+            // will do that for us in this case.
+            let needs_lto = needs_lto && !cgcx.opts.debugging_opts.cross_lang_lto;
+
             if needs_lto {
                 Ok(WorkItemResult::NeedsLTO(mtrans))
             } else {

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -848,6 +848,7 @@ unsafe fn embed_bitcode(cgcx: &CodegenContext,
     };
     llvm::LLVMSetSection(llglobal, section.as_ptr() as *const _);
     llvm::LLVMRustSetLinkage(llglobal, llvm::Linkage::PrivateLinkage);
+    llvm::LLVMSetGlobalConstant(llglobal, llvm::True);
 
     let llconst = C_bytes_in_context(llcx, &[]);
     let llglobal = llvm::LLVMAddGlobal(

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -293,7 +293,8 @@ impl ModuleConfig {
         self.inline_threshold = sess.opts.cg.inline_threshold;
         self.obj_is_bitcode = sess.target.target.options.obj_is_bitcode;
         let embed_bitcode = sess.target.target.options.embed_bitcode ||
-            sess.opts.debugging_opts.embed_bitcode;
+                            sess.opts.debugging_opts.embed_bitcode ||
+                            sess.opts.debugging_opts.cross_lang_lto;
         if embed_bitcode {
             match sess.opts.optimize {
                 config::OptLevel::No |

--- a/src/test/run-make/cross-lang-lto/Makefile
+++ b/src/test/run-make/cross-lang-lto/Makefile
@@ -1,8 +1,11 @@
+
+# min-llvm-version 4.0
+
+-include ../../run-make-fulldeps/tools.mk
+
 # This test makes sure that the expected .llvmbc sections for use by
 # linker-based LTO are available in object files when compiling with
 # -Z cross-lang-lto
-
--include ../../run-make-fulldeps/tools.mk
 
 LLVMBC_SECTION_NAME=\\.llvmbc
 

--- a/src/test/run-make/cross-lang-lto/Makefile
+++ b/src/test/run-make/cross-lang-lto/Makefile
@@ -11,7 +11,7 @@ ifeq ($(UNAME),Darwin)
 endif
 
 
-OBJDUMP=$(HOST_RPATH_DIR)/../../llvm/bin/llvm-objdump
+OBJDUMP=llvm-objdump
 SECTION_HEADERS=$(OBJDUMP) -section-headers
 
 BUILD_LIB=$(RUSTC) lib.rs -Copt-level=2 -Z cross-lang-lto -Ccodegen-units=1

--- a/src/test/run-make/cross-lang-lto/Makefile
+++ b/src/test/run-make/cross-lang-lto/Makefile
@@ -1,0 +1,49 @@
+# This test makes sure that the expected .llvmbc sections for use by
+# linker-based LTO are available in object files when compiling with
+# -Z cross-lang-lto
+
+-include ../../run-make-fulldeps/tools.mk
+
+LLVMBC_SECTION_NAME=\\.llvmbc
+
+ifeq ($(UNAME),Darwin)
+	LLVMBC_SECTION_NAME=__LLVM,__bitcode
+endif
+
+
+OBJDUMP=$(HOST_RPATH_DIR)/../../llvm/bin/llvm-objdump
+SECTION_HEADERS=$(OBJDUMP) -section-headers
+
+BUILD_LIB=$(RUSTC) lib.rs -Copt-level=2 -Z cross-lang-lto -Ccodegen-units=1
+
+BUILD_EXE=$(RUSTC) main.rs -Copt-level=2 -Z cross-lang-lto -Ccodegen-units=1 --emit=obj
+
+all: staticlib staticlib-fat-lto staticlib-thin-lto rlib exe cdylib rdylib
+
+staticlib: lib.rs
+	$(BUILD_LIB) --crate-type=staticlib
+	[ "$$($(SECTION_HEADERS) $(TMPDIR)/liblib.a | grep -c $(LLVMBC_SECTION_NAME))" -ne "0" ]
+
+staticlib-fat-lto: lib.rs
+	$(BUILD_LIB) --crate-type=staticlib -o $(TMPDIR)/liblib-fat-lto.a -Clto=fat
+	[ "$$($(SECTION_HEADERS) $(TMPDIR)/liblib-fat-lto.a | grep -c $(LLVMBC_SECTION_NAME))" -ne "0" ]
+
+staticlib-thin-lto: lib.rs
+	$(BUILD_LIB) --crate-type=staticlib -o $(TMPDIR)/liblib-thin-lto.a -Clto=thin
+	[ "$$($(SECTION_HEADERS) $(TMPDIR)/liblib-thin-lto.a | grep -c $(LLVMBC_SECTION_NAME))" -ne "0" ]
+
+rlib: lib.rs
+	$(BUILD_LIB) --crate-type=rlib
+	[ "$$($(SECTION_HEADERS) $(TMPDIR)/liblib.rlib | grep -c $(LLVMBC_SECTION_NAME))" -ne "0" ]
+
+cdylib: lib.rs
+	$(BUILD_LIB) --crate-type=cdylib --emit=obj -o $(TMPDIR)/cdylib.o
+	[ "$$($(SECTION_HEADERS) $(TMPDIR)/cdylib.o | grep -c $(LLVMBC_SECTION_NAME))" -ne "0" ]
+
+rdylib: lib.rs
+	$(BUILD_LIB) --crate-type=dylib --emit=obj -o $(TMPDIR)/rdylib.o
+	[ "$$($(SECTION_HEADERS) $(TMPDIR)/rdylib.o | grep -c $(LLVMBC_SECTION_NAME))" -ne "0" ]
+
+exe: lib.rs
+	$(BUILD_EXE) -o $(TMPDIR)/exe.o
+	[ "$$($(SECTION_HEADERS) $(TMPDIR)/exe.o | grep -c $(LLVMBC_SECTION_NAME))" -ne "0" ]

--- a/src/test/run-make/cross-lang-lto/Makefile
+++ b/src/test/run-make/cross-lang-lto/Makefile
@@ -1,5 +1,6 @@
 
 # min-llvm-version 4.0
+# ignore-mingw
 
 -include ../../run-make-fulldeps/tools.mk
 
@@ -24,7 +25,7 @@ BUILD_EXE=$(RUSTC) main.rs -Copt-level=2 -Z cross-lang-lto -Ccodegen-units=1 --e
 all: staticlib staticlib-fat-lto staticlib-thin-lto rlib exe cdylib rdylib
 
 staticlib: lib.rs
-	$(BUILD_LIB) --crate-type=staticlib
+	$(BUILD_LIB) --crate-type=staticlib -o $(TMPDIR)/liblib.a
 	[ "$$($(SECTION_HEADERS) $(TMPDIR)/liblib.a | grep -c $(LLVMBC_SECTION_NAME))" -ne "0" ]
 
 staticlib-fat-lto: lib.rs
@@ -36,7 +37,7 @@ staticlib-thin-lto: lib.rs
 	[ "$$($(SECTION_HEADERS) $(TMPDIR)/liblib-thin-lto.a | grep -c $(LLVMBC_SECTION_NAME))" -ne "0" ]
 
 rlib: lib.rs
-	$(BUILD_LIB) --crate-type=rlib
+	$(BUILD_LIB) --crate-type=rlib -o $(TMPDIR)/liblib.rlib
 	[ "$$($(SECTION_HEADERS) $(TMPDIR)/liblib.rlib | grep -c $(LLVMBC_SECTION_NAME))" -ne "0" ]
 
 cdylib: lib.rs

--- a/src/test/run-make/cross-lang-lto/Makefile
+++ b/src/test/run-make/cross-lang-lto/Makefile
@@ -11,7 +11,7 @@
 LLVMBC_SECTION_NAME=\\.llvmbc
 
 ifeq ($(UNAME),Darwin)
-	LLVMBC_SECTION_NAME=__LLVM,__bitcode
+	LLVMBC_SECTION_NAME=__bitcode
 endif
 
 

--- a/src/test/run-make/cross-lang-lto/lib.rs
+++ b/src/test/run-make/cross-lang-lto/lib.rs
@@ -1,0 +1,14 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[no_mangle]
+pub extern "C" fn foo() {
+    println!("abc");
+}

--- a/src/test/run-make/cross-lang-lto/main.rs
+++ b/src/test/run-make/cross-lang-lto/main.rs
@@ -1,0 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    println!("Hello World");
+}

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -610,7 +610,12 @@ pub fn is_test(file_name: &OsString) -> bool {
 }
 
 pub fn make_test(config: &Config, testpaths: &TestPaths) -> test::TestDescAndFn {
-    let early_props = EarlyProps::from_file(config, &testpaths.file);
+
+    let early_props = if config.mode == Mode::RunMake {
+        EarlyProps::from_file(config, &testpaths.file.join("Makefile"))
+    } else {
+        EarlyProps::from_file(config, &testpaths.file)
+    };
 
     // The `should-fail` annotation doesn't apply to pretty tests,
     // since we run the pretty printer across all tests by default.


### PR DESCRIPTION
Implements part of #49879:
- Adds a `-Z cross-lang-lto` flag to rustc
- Makes sure that bitcode is embedded in object files if the flag is set.

This should already allow for using cross language LTO for staticlibs (where one has to invoke the linker manually anyway). However, `rustc` will not try to enable LTO for its own linker invocations yet.

r? @alexcrichton 