### PR TITLE
Reorder injection of std to get better compilation error

### DIFF
--- a/src/libsyntax/std_inject.rs
+++ b/src/libsyntax/std_inject.rs
@@ -57,7 +57,8 @@ pub fn maybe_inject_crates_ref(mut krate: ast::Crate, alt_std_name: Option<&str>
         &["std"]
     };
 
-    for name in names {
+    // .rev() to preserve ordering above in combination with insert(0, ...)
+    for name in names.iter().rev() {
         krate.module.items.insert(0, P(ast::Item {
             attrs: vec![attr::mk_attr_outer(DUMMY_SP,
                                             attr::mk_attr_id(),

--- a/src/test/ui/issue-49851/compiler-builtins-error.rs
+++ b/src/test/ui/issue-49851/compiler-builtins-error.rs
@@ -1,0 +1,18 @@
+//~ ERROR 1:1: 1:1: can't find crate for `core` [E0463]
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --target thumbv7em-none-eabihf
+#![deny(unsafe_code)]
+#![deny(warnings)]
+#![no_std]
+
+extern crate cortex_m;
+

--- a/src/test/ui/issue-49851/compiler-builtins-error.stderr
+++ b/src/test/ui/issue-49851/compiler-builtins-error.stderr
@@ -1,0 +1,7 @@
+error[E0463]: can't find crate for `core`
+   |
+   = note: the `thumbv7em-none-eabihf` target may not be installed
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0463`.


### PR DESCRIPTION
Per #49851, reorder injection imports to get a better error message.

r? @oli-obk  