### PR TITLE
Ensure derive(PartialOrd) is no longer accidentally exponential

### DIFF
--- a/src/etc/generate-deriving-span-tests.py
+++ b/src/etc/generate-deriving-span-tests.py
@@ -122,7 +122,7 @@ traits = {
 
 for (trait, supers, errs) in [('Clone', [], 1),
                               ('PartialEq', [], 2),
-                              ('PartialOrd', ['PartialEq'], 2),
+                              ('PartialOrd', ['PartialEq'], 1),
                               ('Eq', ['PartialEq'], 1),
                               ('Ord', ['Eq', 'PartialOrd', 'PartialEq'], 1),
                               ('Debug', [], 1),

--- a/src/etc/generate-deriving-span-tests.py
+++ b/src/etc/generate-deriving-span-tests.py
@@ -122,7 +122,7 @@ traits = {
 
 for (trait, supers, errs) in [('Clone', [], 1),
                               ('PartialEq', [], 2),
-                              ('PartialOrd', ['PartialEq'], 5),
+                              ('PartialOrd', ['PartialEq'], 2),
                               ('Eq', ['PartialEq'], 1),
                               ('Ord', ['Eq', 'PartialOrd', 'PartialEq'], 1),
                               ('Debug', [], 1),

--- a/src/test/compile-fail/derives-span-PartialOrd-enum-struct-variant.rs
+++ b/src/test/compile-fail/derives-span-PartialOrd-enum-struct-variant.rs
@@ -17,7 +17,6 @@ struct Error;
 enum Enum {
    A {
      x: Error //~ ERROR
-//~^ ERROR
    }
 }
 

--- a/src/test/compile-fail/derives-span-PartialOrd-enum-struct-variant.rs
+++ b/src/test/compile-fail/derives-span-PartialOrd-enum-struct-variant.rs
@@ -18,9 +18,6 @@ enum Enum {
    A {
      x: Error //~ ERROR
 //~^ ERROR
-//~^^ ERROR
-//~^^^ ERROR
-//~^^^^ ERROR
    }
 }
 

--- a/src/test/compile-fail/derives-span-PartialOrd-enum.rs
+++ b/src/test/compile-fail/derives-span-PartialOrd-enum.rs
@@ -17,7 +17,6 @@ struct Error;
 enum Enum {
    A(
      Error //~ ERROR
-//~^ ERROR
      )
 }
 

--- a/src/test/compile-fail/derives-span-PartialOrd-enum.rs
+++ b/src/test/compile-fail/derives-span-PartialOrd-enum.rs
@@ -18,9 +18,6 @@ enum Enum {
    A(
      Error //~ ERROR
 //~^ ERROR
-//~^^ ERROR
-//~^^^ ERROR
-//~^^^^ ERROR
      )
 }
 

--- a/src/test/compile-fail/derives-span-PartialOrd-struct.rs
+++ b/src/test/compile-fail/derives-span-PartialOrd-struct.rs
@@ -16,7 +16,6 @@ struct Error;
 #[derive(PartialOrd,PartialEq)]
 struct Struct {
     x: Error //~ ERROR
-//~^ ERROR
 }
 
 fn main() {}

--- a/src/test/compile-fail/derives-span-PartialOrd-struct.rs
+++ b/src/test/compile-fail/derives-span-PartialOrd-struct.rs
@@ -17,9 +17,6 @@ struct Error;
 struct Struct {
     x: Error //~ ERROR
 //~^ ERROR
-//~^^ ERROR
-//~^^^ ERROR
-//~^^^^ ERROR
 }
 
 fn main() {}

--- a/src/test/compile-fail/derives-span-PartialOrd-tuple-struct.rs
+++ b/src/test/compile-fail/derives-span-PartialOrd-tuple-struct.rs
@@ -17,9 +17,6 @@ struct Error;
 struct Struct(
     Error //~ ERROR
 //~^ ERROR
-//~^^ ERROR
-//~^^^ ERROR
-//~^^^^ ERROR
 );
 
 fn main() {}

--- a/src/test/compile-fail/derives-span-PartialOrd-tuple-struct.rs
+++ b/src/test/compile-fail/derives-span-PartialOrd-tuple-struct.rs
@@ -16,7 +16,6 @@ struct Error;
 #[derive(PartialOrd,PartialEq)]
 struct Struct(
     Error //~ ERROR
-//~^ ERROR
 );
 
 fn main() {}

--- a/src/test/compile-fail/range_traits-1.rs
+++ b/src/test/compile-fail/range_traits-1.rs
@@ -15,27 +15,21 @@ struct AllTheRanges {
     a: Range<usize>,
     //~^ ERROR PartialOrd
     //~^^ ERROR Ord
-    //~^^^ the trait bound
     b: RangeTo<usize>,
     //~^ ERROR PartialOrd
     //~^^ ERROR Ord
-    //~^^^ no method named `partial_cmp`
     c: RangeFrom<usize>,
     //~^ ERROR PartialOrd
     //~^^ ERROR Ord
-    //~^^^ the trait bound
     d: RangeFull,
     //~^ ERROR PartialOrd
     //~^^ ERROR Ord
-    //~^^^ no method named `partial_cmp`
     e: RangeInclusive<usize>,
     //~^ ERROR PartialOrd
     //~^^ ERROR Ord
-    //~^^^ the trait bound
     f: RangeToInclusive<usize>,
     //~^ ERROR PartialOrd
     //~^^ ERROR Ord
-    //~^^^ no method named `partial_cmp`
 }
 
 fn main() {}

--- a/src/test/compile-fail/range_traits-1.rs
+++ b/src/test/compile-fail/range_traits-1.rs
@@ -15,35 +15,27 @@ struct AllTheRanges {
     a: Range<usize>,
     //~^ ERROR PartialOrd
     //~^^ ERROR Ord
-    //~^^^ ERROR binary operation `<` cannot be applied to type
-    //~^^^^ ERROR binary operation `>` cannot be applied to type
+    //~^^^ the trait bound
     b: RangeTo<usize>,
     //~^ ERROR PartialOrd
     //~^^ ERROR Ord
-    //~^^^ ERROR binary operation `<` cannot be applied to type
-    //~^^^^ ERROR binary operation `>` cannot be applied to type
+    //~^^^ no method named `partial_cmp`
     c: RangeFrom<usize>,
     //~^ ERROR PartialOrd
     //~^^ ERROR Ord
-    //~^^^ ERROR binary operation `<` cannot be applied to type
-    //~^^^^ ERROR binary operation `>` cannot be applied to type
+    //~^^^ the trait bound
     d: RangeFull,
     //~^ ERROR PartialOrd
     //~^^ ERROR Ord
-    //~^^^ ERROR binary operation `<` cannot be applied to type
-    //~^^^^ ERROR binary operation `>` cannot be applied to type
+    //~^^^ no method named `partial_cmp`
     e: RangeInclusive<usize>,
     //~^ ERROR PartialOrd
     //~^^ ERROR Ord
-    //~^^^ ERROR binary operation `<` cannot be applied to type
-    //~^^^^ ERROR binary operation `>` cannot be applied to type
+    //~^^^ the trait bound
     f: RangeToInclusive<usize>,
     //~^ ERROR PartialOrd
     //~^^ ERROR Ord
-    //~^^^ ERROR binary operation `<` cannot be applied to type
-    //~^^^^ ERROR binary operation `>` cannot be applied to type
-    //~^^^^^ ERROR binary operation `<=` cannot be applied to type
-    //~^^^^^^ ERROR binary operation `>=` cannot be applied to type
+    //~^^^ no method named `partial_cmp`
 }
 
 fn main() {}


### PR DESCRIPTION
Previously, two comparison operations would be generated for each field, each of which could delegate to another derived PartialOrd. Now we use ordering and optional chaining to ensure each pair of fields is only compared once, addressing https://github.com/rust-lang/rust/issues/49650#issuecomment-379467572.

Closes #49505.

r? @Manishearth (sorry for changing it again so soon!)

Close #50755