### PR TITLE
rustdoc: Don't include private paths in all.html

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1728,7 +1728,9 @@ impl Context {
                 let mut dst = try_err!(File::create(&joint_dst), &joint_dst);
                 try_err!(dst.write_all(&buf), &joint_dst);
 
-                all.append(full_path(self, &item), &item_type);
+                if !self.render_redirect_pages {
+                    all.append(full_path(self, &item), &item_type);
+                }
                 // Redirect from a sane URL using the namespace to Rustdoc's
                 // URL for the page.
                 let redir_name = format!("{}.{}.html", name, item_type.name_space());

--- a/src/test/rustdoc/all.rs
+++ b/src/test/rustdoc/all.rs
@@ -28,3 +28,11 @@ pub union Union {
 pub const CONST: u32 = 0;
 pub static STATIC: &str = "baguette";
 pub fn function() {}
+
+mod private_module {
+    pub struct ReexportedStruct;
+}
+
+// @has foo/all.html '//a[@href="struct.ReexportedStruct.html"]' 'ReexportedStruct'
+// @!has foo/all.html 'private_module'
+pub use private_module::ReexportedStruct;


### PR DESCRIPTION
For example the `std` [`all.html`](https://doc.rust-lang.org/nightly/std/all.html) includes references to the `coresimd` module which is a private implementation detail.

r? @GuillaumeGomez