### PR TITLE
smaller PR just to fix #50002

### DIFF
--- a/src/liballoc/tests/str.rs
+++ b/src/liballoc/tests/str.rs
@@ -402,6 +402,22 @@ fn test_str_get_maxinclusive() {
 }
 
 #[test]
+fn test_str_slicemut_rangetoinclusive_ok() {
+    let mut s = "abcαβγ".to_owned();
+    let s: &mut str = &mut s;
+    &mut s[..=3]; // before alpha
+    &mut s[..=5]; // after alpha
+}
+
+#[test]
+#[should_panic]
+fn test_str_slicemut_rangetoinclusive_notok() {
+    let mut s = "abcαβγ".to_owned();
+    let s: &mut str = &mut s;
+    &mut s[..=4]; // middle of alpha, which is 2 bytes long
+}
+
+#[test]
 fn test_is_char_boundary() {
     let s = "ศไทย中华Việt Nam β-release 🐱123";
     assert!(s.is_char_boundary(0));

--- a/src/liballoc/tests/str.rs
+++ b/src/liballoc/tests/str.rs
@@ -402,11 +402,25 @@ fn test_str_get_maxinclusive() {
 }
 
 #[test]
+fn test_str_slice_rangetoinclusive_ok() {
+    let s = "abcαβγ";
+    assert_eq!(&s[..=2], "abc");
+    assert_eq!(&s[..=4], "abcα");
+}
+
+#[test]
+#[should_panic]
+fn test_str_slice_rangetoinclusive_notok() {
+    let s = "abcαβγ";
+    &s[..=3];
+}
+
+#[test]
 fn test_str_slicemut_rangetoinclusive_ok() {
     let mut s = "abcαβγ".to_owned();
     let s: &mut str = &mut s;
-    &mut s[..=3]; // before alpha
-    &mut s[..=5]; // after alpha
+    assert_eq!(&mut s[..=2], "abc");
+    assert_eq!(&mut s[..=4], "abcα");
 }
 
 #[test]
@@ -414,7 +428,7 @@ fn test_str_slicemut_rangetoinclusive_ok() {
 fn test_str_slicemut_rangetoinclusive_notok() {
     let mut s = "abcαβγ".to_owned();
     let s: &mut str = &mut s;
-    &mut s[..=4]; // middle of alpha, which is 2 bytes long
+    &mut s[..=3];
 }
 
 #[test]

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -2100,18 +2100,13 @@ mod traits {
         fn index(self, slice: &str) -> &Self::Output {
             assert!(self.end != usize::max_value(),
                 "attempted to index str up to maximum usize");
-            let end = self.end + 1;
-            self.get(slice).unwrap_or_else(|| super::slice_error_fail(slice, 0, end))
+            (..self.end+1).index(slice)
         }
         #[inline]
         fn index_mut(self, slice: &mut str) -> &mut Self::Output {
             assert!(self.end != usize::max_value(),
                 "attempted to index str up to maximum usize");
-            if slice.is_char_boundary(self.end) {
-                unsafe { self.get_unchecked_mut(slice) }
-            } else {
-                super::slice_error_fail(slice, 0, self.end + 1)
-            }
+            (..self.end+1).index_mut(slice)
         }
     }
 


### PR DESCRIPTION
I pulled this out of #50010 to make it easier to backport to beta if necessary, considering that inclusive range syntax is stabilizing soon (?).

It fixes a bug in `<str>::index_mut` with `(..=end)` ranges (#50002), which prior to this fix was not only unusable but also UB in the cases where it "worked" (it gave improperly truncated UTF-8).

(not that I can imagine why anybody would *use* `<str>::index_mut`... but I'm not here to judge)