### PR TITLE
Lazily evaluate EvalErrorKind::*.into() calls.

### DIFF
--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -260,7 +260,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M
             self.param_env,
             def_id,
             substs,
-        ).ok_or(EvalErrorKind::TypeckError.into()) // turn error prop into a panic to expose associated type in const issue
+        ).ok_or_else(|| EvalErrorKind::TypeckError.into()) // turn error prop into a panic to expose associated type in const issue
     }
 
     pub(super) fn type_is_sized(&self, ty: Ty<'tcx>) -> bool {
@@ -279,9 +279,9 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M
         trace!("load mir {:?}", instance);
         match instance {
             ty::InstanceDef::Item(def_id) => {
-                self.tcx.maybe_optimized_mir(def_id).ok_or_else(|| {
+                self.tcx.maybe_optimized_mir(def_id).ok_or_else(||
                     EvalErrorKind::NoMirFor(self.tcx.item_path_str(def_id)).into()
-                })
+                )
             }
             _ => Ok(self.tcx.instance_mir(instance)),
         }
@@ -691,7 +691,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M
                                     self.param_env,
                                     def_id,
                                     substs,
-                                ).ok_or(EvalErrorKind::TypeckError.into());
+                                ).ok_or_else(|| EvalErrorKind::TypeckError.into());
                                 let fn_ptr = self.memory.create_fn_alloc(instance?);
                                 let valty = ValTy {
                                     value: Value::ByVal(PrimVal::Ptr(fn_ptr)),
@@ -1699,7 +1699,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M
 
 impl<'mir, 'tcx> Frame<'mir, 'tcx> {
     pub fn get_local(&self, local: mir::Local) -> EvalResult<'tcx, Value> {
-        self.locals[local].ok_or(EvalErrorKind::DeadLocal.into())
+        self.locals[local].ok_or_else(|| EvalErrorKind::DeadLocal.into())
     }
 
     fn set_local(&mut self, local: mir::Local, value: Value) -> EvalResult<'tcx> {


### PR DESCRIPTION
eval_context.rs calls `ok_or` in multiple places with an eagerly
evaluated `EvalErrorKind::*.into()` argument, which calls
EvalError::from(), which calls env::var("MIRI_BACKTRACE"), which
allocates a String. This code is hot enough for this to have a
measurable effect on some benchmarks.

This patch changes the `ok_or` calls into `ok_or_else`, thus avoiding
the evaluations when they're not needed. As a result, most of the
rustc-perf benchmarks get a measurable speedup, particularly the
shorter-running ones, where the improvement is as high as 6%.

Output from rustc-perf, comparing stage 2 builds with jemalloc disabled:

<details>

```
coercions
	avg: -1.8%	min: -6.0%	max: -0.0%
helloworld-opt
	avg: -3.7%	min: -4.0%	max: -3.4%
helloworld
	avg: -3.7%	min: -3.9%	max: -3.5%
parser
	avg: -3.5%	min: -3.9%	max: -3.1%
unify-linearly-opt
	avg: -3.2%	min: -3.8%	max: -2.8%
unify-linearly
	avg: -3.2%	min: -3.7%	max: -2.8%
parser-opt
	avg: -3.2%	min: -3.6%	max: -2.8%
clap-rs
	avg: -0.9%	min: -3.6%	max: 0.1%
encoding
	avg: -1.9%	min: -3.0%	max: -1.2%
clap-rs-opt
	avg: -0.8%	min: -2.7%	max: -0.1%
helloworld-check
	avg: -1.9%	min: -2.2%	max: -1.7%
deeply-nested-check
	avg: -1.4%	min: -2.1%	max: -0.9%
issue-46449-opt
	avg: -0.7%	min: -2.0%	max: -0.3%
unify-linearly-check
	avg: -1.5%	min: -1.9%	max: -1.2%
issue-46449
	avg: -1.0%	min: -1.8%	max: -0.8%
deeply-nested-opt
	avg: -0.7%	min: -1.7%	max: -0.2%
deeply-nested
	avg: -1.0%	min: -1.6%	max: -0.6%
parser-check
	avg: -1.3%	min: -1.6%	max: -0.8%
encoding-check
	avg: -1.5%	min: -1.6%	max: -1.2%
tuple-stress
	avg: -0.9%	min: -1.5%	max: 0.0%
tuple-stress-opt
	avg: -1.0%	min: -1.5%	max: -0.3%
issue-46449-check
	avg: -1.3%	min: -1.4%	max: -1.0%
encoding-opt
	avg: -1.1%	min: -1.2%	max: -0.9%
regression-31157
	avg: -0.7%	min: -1.2%	max: -0.2%
regression-31157-check
	avg: -0.8%	min: -1.2%	max: -0.5%
futures-check
	avg: -0.8%	min: -1.2%	max: -0.4%
unused-warnings-opt
	avg: -1.0%	min: -1.2%	max: -0.9%
unused-warnings
	avg: -1.0%	min: -1.1%	max: -0.9%
coercions-opt
	avg: -0.6%	min: -1.0%	max: -0.2%
inflate-check
	avg: -0.4%	min: -0.9%	max: -0.1%
regex-check
	avg: -0.8%	min: -0.9%	max: -0.5%
piston-image-check
	avg: -0.8%	min: -0.9%	max: -0.8%
deep-vector
	avg: -0.3%	min: -0.9%	max: 0.1%
futures
	avg: -0.5%	min: -0.8%	max: -0.2%
futures-opt
	avg: -0.5%	min: -0.7%	max: -0.1%
html5ever
	avg: -0.6%	min: -0.7%	max: -0.4%
tokio-webpush-simple-check
	avg: -0.2%	min: -0.7%	max: 0.1%
piston-image-opt
	avg: -0.3%	min: -0.7%	max: -0.1%
regex
	avg: -0.4%	min: -0.7%	max: -0.1%
piston-image
	avg: -0.4%	min: -0.7%	max: -0.2%
regex-opt
	avg: -0.3%	min: -0.7%	max: 0.1%
tokio-webpush-simple-opt
	avg: -0.2%	min: -0.6%	max: 0.0%
coercions-check
	avg: -0.3%	min: -0.6%	max: -0.1%
hyper
	avg: -0.4%	min: -0.6%	max: -0.2%
syn-opt
	avg: -0.3%	min: -0.6%	max: -0.0%
hyper-check
	avg: -0.5%	min: -0.6%	max: -0.3%
syn-check
	avg: -0.4%	min: -0.5%	max: -0.2%
hyper-opt
	avg: -0.3%	min: -0.5%	max: -0.1%
html5ever-opt
	avg: -0.3%	min: -0.5%	max: -0.2%
syn
	avg: -0.2%	min: -0.4%	max: -0.1%
deep-vector-opt
	avg: -0.2%	min: -0.4%	max: 0.1%
tokio-webpush-simple
	avg: -0.2%	min: -0.4%	max: -0.1%
inflate
	avg: -0.2%	min: -0.4%	max: -0.1%
inflate-opt
	avg: -0.2%	min: -0.4%	max: -0.0%
regression-31157-opt
	avg: -0.1%	min: -0.4%	max: 0.0%
html5ever-check
	avg: -0.3%	min: -0.4%	max: -0.2%
unused-warnings-check
	avg: -0.2%	min: -0.3%	max: -0.2%
script-servo-check
	avg: -0.1%	min: -0.3%	max: 0.0%
crates.io-check
	avg: -0.2%	min: -0.3%	max: -0.0%
script-servo
	avg: -0.1%	min: -0.2%	max: 0.0%
clap-rs-check
	avg: 0.0%	min: -0.1%	max: 0.2%
deep-vector-check
	avg: -0.0%	min: -0.2%	max: 0.2%
tuple-stress-check
	avg: -0.1%	min: -0.2%	max: 0.0%
crates.io-opt
	avg: -0.1%	min: -0.2%	max: 0.0%
crates.io
	avg: -0.1%	min: -0.2%	max: -0.0%
script-servo-opt
	avg: -0.0%	min: -0.1%	max: 0.0%
```

</details>