### PR TITLE
wasm: Increase default stack size to 1MB

### DIFF
--- a/src/librustc_trans/back/linker.rs
+++ b/src/librustc_trans/back/linker.rs
@@ -960,6 +960,7 @@ impl Linker for WasmLd {
 
     fn finalize(&mut self) -> Command {
         self.cmd.arg("--threads");
+        self.cmd.arg("-z").arg("stack-size=1048576");
 
         // FIXME we probably shouldn't pass this but instead pass an explicit
         // whitelist of symbols we'll allow to be undefined. Unfortunately


### PR DESCRIPTION
This commit increases the dfeault stack size allocated to the
wasm32-unknown-unknown target to 1MB by default. Currently the default stack
size is one wasm page, or 64 kilobytes. This default stack is quite small and
has caused a stack overflow or two in the wild by accident.

The current "best practice" for fixing this is to pass `-Clink-args='-z
stack-size=$bigger'` but that's not great nor always easy to do. A default of
1MB matches more closely with other platforms where it's "pretty big" by
default.

Note that it was tested and if the users uses `-C link-args` to pass a custom
stack size that's still resepected as lld seems to take the first argument, and
where rustc is passing it will always be last.