### PR TITLE
Tweak some stabilizations in libstd

### DIFF
--- a/src/liballoc/btree/map.rs
+++ b/src/liballoc/btree/map.rs
@@ -2155,8 +2155,8 @@ impl<'a, K: Ord, V> Entry<'a, K, V> {
     /// assert_eq!(map["poneyland"], 43);
     /// ```
     #[stable(feature = "entry_and_modify", since = "1.26.0")]
-    pub fn and_modify<F>(self, mut f: F) -> Self
-        where F: FnMut(&mut V)
+    pub fn and_modify<F>(self, f: F) -> Self
+        where F: FnOnce(&mut V)
     {
         match self {
             Occupied(mut entry) => {

--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -2140,48 +2140,6 @@ impl str {
         unsafe { String::from_utf8_unchecked(buf) }
     }
 
-    /// Returns true if this `str` is entirely whitespace, and false otherwise.
-    ///
-    /// 'Whitespace' is defined according to the terms of the Unicode Derived Core
-    /// Property `White_Space`.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// assert!("    \t ".is_whitespace());
-    ///
-    /// // a non-breaking space
-    /// assert!("\u{A0}".is_whitespace());
-    ///
-    /// assert!(!"   越".is_whitespace());
-    /// ```
-    #[stable(feature = "unicode_methods_on_intrinsics", since = "1.27.0")]
-    #[inline]
-    pub fn is_whitespace(&self) -> bool {
-        StrExt::is_whitespace(self)
-    }
-
-    /// Returns true if this `str` is entirely alphanumeric, and false otherwise.
-    ///
-    /// 'Alphanumeric'-ness is defined in terms of the Unicode General Categories
-    /// 'Nd', 'Nl', 'No' and the Derived Core Property 'Alphabetic'.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// assert!("٣7৬Kو藏".is_alphanumeric());
-    /// assert!(!"¾①".is_alphanumeric());
-    /// ```
-    #[stable(feature = "unicode_methods_on_intrinsics", since = "1.27.0")]
-    #[inline]
-    pub fn is_alphanumeric(&self) -> bool {
-        StrExt::is_alphanumeric(self)
-    }
-
     /// Checks if all characters in this string are within the ASCII range.
     ///
     /// # Examples

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -437,7 +437,7 @@ fn partition_source(s: &str) -> (String, String) {
 
     for line in s.lines() {
         let trimline = line.trim();
-        let header = trimline.is_whitespace() ||
+        let header = trimline.chars().all(|c| c.is_whitespace()) ||
             trimline.starts_with("#![") ||
             trimline.starts_with("#[macro_use] extern crate") ||
             trimline.starts_with("extern crate");

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -2127,8 +2127,8 @@ impl<'a, K, V> Entry<'a, K, V> {
     /// assert_eq!(map["poneyland"], 43);
     /// ```
     #[stable(feature = "entry_and_modify", since = "1.26.0")]
-    pub fn and_modify<F>(self, mut f: F) -> Self
-        where F: FnMut(&mut V)
+    pub fn and_modify<F>(self, f: F) -> Self
+        where F: FnOnce(&mut V)
     {
         match self {
             Occupied(mut entry) => {


### PR DESCRIPTION
This commit tweaks a few stable APIs in the `beta` branch before they hit
stable. The `str::is_whitespace` and `str::is_alphanumeric` functions were
deleted (added in #49381, issue at #49657). The `and_modify` APIs added
in #44734 were altered to take a `FnOnce` closure rather than a `FnMut` closure.

Closes #49581
Closes #49657