### PR TITLE
rustc: Always emit `uwtable` on Android

### DIFF
--- a/src/librustc_back/target/android_base.rs
+++ b/src/librustc_back/target/android_base.rs
@@ -20,5 +20,6 @@ pub fn opts() -> TargetOptions {
     base.is_like_android = true;
     base.position_independent_executables = true;
     base.has_elf_tls = false;
+    base.requires_uwtable = true;
     base
 }

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -481,6 +481,11 @@ pub struct TargetOptions {
 
     /// Whether a .debug_gdb_scripts section will be added to the output object file
     pub emit_debug_gdb_scripts: bool,
+
+    /// Whether or not to unconditionally `uwtable` attributes on functions,
+    /// typically because the platform needs to unwind for things like stack
+    /// unwinders.
+    pub requires_uwtable: bool,
 }
 
 impl Default for TargetOptions {
@@ -554,6 +559,7 @@ impl Default for TargetOptions {
             default_hidden_visibility: false,
             embed_bitcode: false,
             emit_debug_gdb_scripts: true,
+            requires_uwtable: false,
         }
     }
 }
@@ -804,6 +810,7 @@ impl Target {
         key!(default_hidden_visibility, bool);
         key!(embed_bitcode, bool);
         key!(emit_debug_gdb_scripts, bool);
+        key!(requires_uwtable, bool);
 
         if let Some(array) = obj.find("abi-blacklist").and_then(Json::as_array) {
             for name in array.iter().filter_map(|abi| abi.as_string()) {
@@ -1008,6 +1015,7 @@ impl ToJson for Target {
         target_option_val!(default_hidden_visibility);
         target_option_val!(embed_bitcode);
         target_option_val!(emit_debug_gdb_scripts);
+        target_option_val!(requires_uwtable);
 
         if default.abi_blacklist != self.options.abi_blacklist {
             d.insert("abi-blacklist".to_string(), self.options.abi_blacklist.iter()

--- a/src/librustc_back/target/windows_base.rs
+++ b/src/librustc_back/target/windows_base.rs
@@ -103,6 +103,7 @@ pub fn opts() -> TargetOptions {
         custom_unwind_resume: true,
         abi_return_struct_as_int: true,
         emit_debug_gdb_scripts: false,
+        requires_uwtable: true,
 
         .. Default::default()
     }

--- a/src/librustc_back/target/windows_msvc_base.rs
+++ b/src/librustc_back/target/windows_msvc_base.rs
@@ -35,6 +35,7 @@ pub fn opts() -> TargetOptions {
         crt_static_respected: true,
         abi_return_struct_as_int: true,
         emit_debug_gdb_scripts: false,
+        requires_uwtable: true,
 
         .. Default::default()
     }

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -492,7 +492,7 @@ pub fn trans_instance<'a, 'tcx>(cx: &CodegenCx<'a, 'tcx>, instance: Instance<'tc
     // You can also find more info on why Windows is whitelisted here in:
     //      https://bugzilla.mozilla.org/show_bug.cgi?id=1302078
     if !cx.sess().no_landing_pads() ||
-       cx.sess().target.target.options.is_like_windows {
+       cx.sess().target.target.options.requires_uwtable {
         attributes::emit_uwtable(lldecl, true);
     }
 

--- a/src/test/codegen/nounwind.rs
+++ b/src/test/codegen/nounwind.rs
@@ -11,6 +11,7 @@
 // aux-build:nounwind.rs
 // compile-flags: -C no-prepopulate-passes -C panic=abort -C metadata=a
 // ignore-windows
+// ignore-android
 
 #![crate_type = "lib"]
 


### PR DESCRIPTION
Long ago (#40549) we enabled the `uwtable` attribute on Windows by default
(even with `-C panic=abort`) to allow unwinding binaries for [stack unwinding
information][winstack]. It looks like this same issue is [plaguing][arm1]
Gecko's Android platforms [as well][arm2]. This commit applies the same fix
as #40549 except that this time it's applied for all Android targets.

Generating a `-C panic=abort` binary for `armv7-linux-androideabi` before this
commit generated a number of `cantunwind` functions (detected with `readelf -u`)
but after this commit they all list appropriate unwind information.

Closes #49867

[winstack]: https://bugzilla.mozilla.org/show_bug.cgi?id=1302078
[arm1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1453220
[arm2]: https://bugzilla.mozilla.org/show_bug.cgi?id=1451741