### PR TITLE
[WIP] Treat crates specially when expanding

### DIFF
--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -454,6 +454,7 @@ pub struct Crate {
     pub module: Mod,
     pub attrs: Vec<Attribute>,
     pub span: Span,
+    pub tokens: Option<TokenStream>,
 }
 
 /// A spanned compile-time attribute list item.

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -1383,6 +1383,6 @@ macro_rules! derive_has_attrs {
 }
 
 derive_has_attrs! {
-    Item, Expr, Local, ast::ForeignItem, ast::StructField, ast::ImplItem, ast::TraitItem, ast::Arm,
-    ast::Field, ast::FieldPat, ast::Variant_
+    Item, Expr, Local, ast::ForeignItem, ast::StructField, ast::ImplItem, ast::TraitItem,
+    ast::Arm, ast::Field, ast::FieldPat, ast::Variant_, ast::Crate
 }

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -118,6 +118,20 @@ impl Annotatable {
         }
     }
 
+    pub fn expect_stmt(self) -> ast::Stmt {
+        match self {
+            Annotatable::Stmt(stmt) => stmt.into_inner(),
+            _ => panic!("expected statement"),
+        }
+    }
+
+    pub fn expect_expr(self) -> P<ast::Expr> {
+        match self {
+            Annotatable::Expr(expr) => expr,
+            _ => panic!("expected expression"),
+        }
+    }
+
     pub fn derive_allowed(&self) -> bool {
         match *self {
             Annotatable::Item(ref item) => match item.node {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -143,7 +143,7 @@ impl ExpansionKind {
     }
 
     fn expect_from_annotatables<I: IntoIterator<Item = Annotatable>>(self, items: I) -> Expansion {
-        let items = items.into_iter();
+        let mut items = items.into_iter();
         match self {
             ExpansionKind::Items =>
                 Expansion::Items(items.map(Annotatable::expect_item).collect()),
@@ -153,7 +153,14 @@ impl ExpansionKind {
                 Expansion::TraitItems(items.map(Annotatable::expect_trait_item).collect()),
             ExpansionKind::ForeignItems =>
                 Expansion::ForeignItems(items.map(Annotatable::expect_foreign_item).collect()),
-            _ => unreachable!(),
+            ExpansionKind::Stmts => Expansion::Stmts(items.map(Annotatable::expect_stmt).collect()),
+            ExpansionKind::Expr => Expansion::Expr(
+                items.next().expect("expected exactly one expression").expect_expr()
+            ),
+            ExpansionKind::OptExpr =>
+                Expansion::OptExpr(items.next().map(Annotatable::expect_expr)),
+            ExpansionKind::Pat | ExpansionKind::Ty =>
+                panic!("patterns and types aren't annotatable"),
         }
     }
 }

--- a/src/libsyntax/ext/placeholders.rs
+++ b/src/libsyntax/ext/placeholders.rs
@@ -42,6 +42,14 @@ pub fn placeholder(kind: ExpansionKind, id: ast::NodeId) -> Expansion {
     });
 
     match kind {
+        ExpansionKind::Crate => Expansion::Crate(P(ast::Crate {
+            attrs, module: ast::Mod {
+                inner: span,
+                items: vec![],
+            },
+            span,
+            tokens: None,
+        })),
         ExpansionKind::Expr => Expansion::Expr(expr_placeholder()),
         ExpansionKind::OptExpr => Expansion::OptExpr(Some(expr_placeholder())),
         ExpansionKind::Items => Expansion::Items(SmallVector::one(P(ast::Item {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -7047,6 +7047,7 @@ impl<'a> Parser<'a> {
             attrs: self.parse_inner_attributes()?,
             module: self.parse_mod_items(&token::Eof, lo)?,
             span: lo.to(self.span),
+            tokens: None,
         })
     }
 

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -541,6 +541,9 @@ impl Token {
         let mut tokens = None;
 
         match nt.0 {
+            Nonterminal::NtCrate(ref krate) => {
+                tokens = prepend_attrs(sess, &krate.attrs, krate.tokens.as_ref(), span);
+            }
             Nonterminal::NtItem(ref item) => {
                 tokens = prepend_attrs(sess, &item.attrs, item.tokens.as_ref(), span);
             }
@@ -581,6 +584,7 @@ impl Token {
 #[derive(Clone, RustcEncodable, RustcDecodable, Eq, Hash)]
 /// For interpolation during macro expansion.
 pub enum Nonterminal {
+    NtCrate(P<ast::Crate>),
     NtItem(P<ast::Item>),
     NtBlock(P<ast::Block>),
     NtStmt(ast::Stmt),
@@ -623,6 +627,7 @@ impl PartialEq for Nonterminal {
 impl fmt::Debug for Nonterminal {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            NtCrate(..) => f.pad("NtCrate(..)"),
             NtItem(..) => f.pad("NtItem(..)"),
             NtBlock(..) => f.pad("NtBlock(..)"),
             NtStmt(..) => f.pad("NtStmt(..)"),

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -262,6 +262,7 @@ pub fn token_to_string(tok: &Token) -> String {
         token::Shebang(s)           => format!("/* shebang: {}*/", s),
 
         token::Interpolated(ref nt) => match nt.0 {
+            token::NtCrate(ref k)       => crate_to_string(k),
             token::NtExpr(ref e)        => expr_to_string(e),
             token::NtMeta(ref e)        => meta_item_to_string(e),
             token::NtTy(ref e)          => ty_to_string(e),
@@ -284,6 +285,10 @@ pub fn token_to_string(tok: &Token) -> String {
             token::NtForeignItem(ref e) => foreign_item_to_string(e),
         }
     }
+}
+
+pub fn crate_to_string(krate: &ast::Crate) -> String {
+    to_string(|s| s.print_mod(&krate.module, &krate.attrs))
 }
 
 pub fn ty_to_string(ty: &ast::Ty) -> String {

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -150,6 +150,10 @@ pub trait Visitor<'ast>: Sized {
     fn visit_fn_ret_ty(&mut self, ret_ty: &'ast FunctionRetTy) {
         walk_fn_ret_ty(self, ret_ty)
     }
+
+    fn visit_crate(&mut self, krate: &'ast Crate) {
+        walk_crate(self, krate)
+    }
 }
 
 #[macro_export]

--- a/src/libsyntax_ext/deriving/custom.rs
+++ b/src/libsyntax_ext/deriving/custom.rs
@@ -57,7 +57,8 @@ impl MultiItemModifier for ProcMacroDerive {
             Annotatable::TraitItem(_) |
             Annotatable::ForeignItem(_) |
             Annotatable::Stmt(_) |
-            Annotatable::Expr(_) => {
+            Annotatable::Expr(_) |
+            Annotatable::Crate(_) => {
                 ecx.span_err(span, "proc-macro derives may only be \
                                     applied to struct/enum items");
                 return Vec::new()

--- a/src/test/compile-fail/issue-49934.rs
+++ b/src/test/compile-fail/issue-49934.rs
@@ -1,0 +1,23 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![feature(stmt_expr_attributes)]
+
+fn main() {
+    #[derive(Debug)] //~ ERROR `derive`
+    println!("Hello, world!");
+
+    let _ = #[derive(Debug)] "Hello, world!";
+    //~^ ERROR `derive`
+
+    let _ = [
+        #[derive(Debug)] //~ ERROR `derive`
+        "Hello, world!"
+    ];
+}


### PR DESCRIPTION
Give the base compilation unit of Rust source code the special treatment it deserves during macro expansion.

Pretty-prints crates as they should appear, doesn't pretend they're just modules without names (which breaks `syn`). 

I think this should also require proc-macro-attributes on the crate to be invoked with absolute paths which should alleviate resolution issues without doing anything too crazy.

TODO:
- [ ] implement tests
- [ ] require absolute paths in non-built-in attributes

I branched this from #50092, will rebase when that one is merged so only relevant commits appear (if that isn't fixed automatically)
closes #41430

r? @petrochenkov 
cc @Rantanen @jseyfried 