### PR TITLE
Fix bad merge in #49991

### DIFF
--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -930,7 +930,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
             } else if let hir::ImplItemKind::Method(ref sig, _) = ast_item.node {
                 let generics = self.tcx.generics_of(def_id);
                 let types = generics.parent_types as usize + generics.types.len();
-                let needs_inline = types > 0 || tcx.trans_fn_attrs(def_id).requests_inline() &&
+                let needs_inline = (types > 0 || tcx.trans_fn_attrs(def_id).requests_inline()) &&
                     !self.metadata_output_only();
                 let is_const_fn = sig.constness == hir::Constness::Const;
                 let always_encode_mir = self.tcx.sess.opts.debugging_opts.always_encode_mir;


### PR DESCRIPTION
When I rebased #49991 on `master`, I messed up the merge for this line. I'm reverting this back to the way it was in f15e5c1.

r? @michaelwoerister 