### PR TITLE
Clean up `IsolatedEncoder::encode_info_for_impl_item()` a bit

### DIFF
--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -925,18 +925,19 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
         };
 
         let mir =
-            if let hir::ImplItemKind::Const(..) = ast_item.node {
-                true
-            } else if let hir::ImplItemKind::Method(ref sig, _) = ast_item.node {
-                let generics = self.tcx.generics_of(def_id);
-                let types = generics.parent_types as usize + generics.types.len();
-                let needs_inline = (types > 0 || tcx.trans_fn_attrs(def_id).requests_inline()) &&
-                    !self.metadata_output_only();
-                let is_const_fn = sig.constness == hir::Constness::Const;
-                let always_encode_mir = self.tcx.sess.opts.debugging_opts.always_encode_mir;
-                needs_inline || is_const_fn || always_encode_mir
-            } else {
-                false
+            match ast_item.node {
+                hir::ImplItemKind::Const(..) => true,
+                hir::ImplItemKind::Method(ref sig, _) => {
+                    let generics = self.tcx.generics_of(def_id);
+                    let types = generics.parent_types as usize + generics.types.len();
+                    let needs_inline =
+                        (types > 0 || tcx.trans_fn_attrs(def_id).requests_inline())
+                            && !self.metadata_output_only();
+                    let is_const_fn = sig.constness == hir::Constness::Const;
+                    let always_encode_mir = self.tcx.sess.opts.debugging_opts.always_encode_mir;
+                    needs_inline || is_const_fn || always_encode_mir
+                },
+                hir::ImplItemKind::Type(..) => false,
             };
 
         Entry {


### PR DESCRIPTION
Suggested in the [comments of #49991](https://github.com/rust-lang/rust/pull/49991/files/4a77d35c1ed89310a0ed128ce931cd4b85ca4cd4#r183048939)