### PR TITLE
Add deprecation lint for duplicated `macro_export`s

### DIFF
--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -213,6 +213,11 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
             edition: None,
         },
         FutureIncompatibleInfo {
+            id: LintId::of(DUPLICATE_MACRO_EXPORTS),
+            reference: "issue #35896 <https://github.com/rust-lang/rust/issues/35896>",
+            edition: Some(Edition::Edition2018),
+        },
+        FutureIncompatibleInfo {
             id: LintId::of(SAFE_EXTERN_STATICS),
             reference: "issue #36247 <https://github.com/rust-lang/rust/issues/36247>",
             edition: None,

--- a/src/test/run-pass/auxiliary/two_macros_2.rs
+++ b/src/test/run-pass/auxiliary/two_macros_2.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(duplicate_macro_exports)]
+macro_rules! macro_one { ($($t:tt)*) => ($($t)*) }
 
-#[macro_export]
-macro_rules! foo { ($i:ident) => {} }
-
-#[macro_export]
-macro_rules! foo { () => {} }
+macro_rules! macro_two { ($($t:tt)*) => ($($t)*) }

--- a/src/test/run-pass/mod_dir_path.rs
+++ b/src/test/run-pass/mod_dir_path.rs
@@ -20,12 +20,12 @@ pub fn main() {
 
     #[path = "auxiliary"]
     mod foo {
-        mod two_macros;
+        mod two_macros_2;
     }
 
     #[path = "auxiliary"]
     mod bar {
-        macro_rules! m { () => { mod two_macros; } }
+        macro_rules! m { () => { mod two_macros_2; } }
         m!();
     }
 }

--- a/src/test/ui/issue-38715.rs
+++ b/src/test/ui/issue-38715.rs
@@ -8,10 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(duplicate_macro_exports)]
-
 #[macro_export]
 macro_rules! foo { ($i:ident) => {} }
 
 #[macro_export]
-macro_rules! foo { () => {} }
+macro_rules! foo { () => {} } //~ ERROR a macro named `foo` has already been exported
+                              //~| WARN this was previously accepted

--- a/src/test/ui/issue-38715.stderr
+++ b/src/test/ui/issue-38715.stderr
@@ -1,0 +1,22 @@
+error: a macro named `foo` has already been exported
+  --> $DIR/issue-38715.rs:15:1
+   |
+LL | macro_rules! foo { () => {} } //~ ERROR a macro named `foo` has already been exported
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `foo` already exported
+   |
+   = note: #[deny(duplicate_macro_exports)] on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = note: for more information, see issue #35896 <https://github.com/rust-lang/rust/issues/35896>
+note: previous macro export is now shadowed
+  --> $DIR/issue-38715.rs:12:1
+   |
+LL | macro_rules! foo { ($i:ident) => {} }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0601]: `main` function not found in crate `issue_38715`
+   |
+   = note: consider adding a `main` function to `$DIR/issue-38715.rs`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0601`.


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/issues/35896#issuecomment-381370556