### PR TITLE
turn `mem::uninitialized` into a constant function

### DIFF
--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -869,7 +869,9 @@ This does not pose a problem by itself because they can't be accessed directly."
                     Abi::PlatformIntrinsic => {
                         assert!(!self.tcx.is_const_fn(def_id));
                         match &self.tcx.item_name(def_id)[..] {
-                            "size_of" | "min_align_of" | "type_id" => is_const_fn = Some(def_id),
+                            "size_of" | "min_align_of" | "type_id" | "uninit" => {
+                                is_const_fn = Some(def_id)
+                            },
 
                             name if name.starts_with("simd_shuffle") => {
                                 is_shuffle = true;


### PR DESCRIPTION
one can implement a `const fn` version of `mem::uninitialized` using unions (see below) so there's no real reason to not make the standard version const, IMO.

``` rust
#![feature(const_fn)]
#![feature(untagged_unions)]

fn main() {
    static mut X: u32 = unsafe { uninitialized() };
    println!("{}", unsafe { X });
}

const unsafe fn uninitialized<T>() -> T {
    union U<T> {
        none: (),
        some: T,
    }

    U { none: () }.some
}
```

r? @oli-obk 
cc @rust-lang/libs 