### PR TITLE
parser: Do not override syntactic context for dummy spans

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -589,7 +589,8 @@ impl<'a> Parser<'a> {
             self.token_cursor.next()
         };
         if next.sp == syntax_pos::DUMMY_SP {
-            next.sp = self.prev_span;
+            // Tweak the location for better diagnostics, but keep syntactic context intact.
+            next.sp = self.prev_span.with_ctxt(next.sp.ctxt());
         }
         next
     }

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/issue-50061.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/issue-50061.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+#![feature(proc_macro)]
+
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn check(_a: TokenStream, b: TokenStream) -> TokenStream {
+    b.into_iter().collect()
+}

--- a/src/test/run-pass-fulldeps/proc-macro/issue-50061.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/issue-50061.rs
@@ -1,0 +1,31 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-50061.rs
+// ignore-stage1
+
+#![feature(proc_macro, proc_macro_path_invoc, decl_macro)]
+
+extern crate issue_50061;
+
+macro inner(any_token $v: tt) {
+    $v
+}
+
+macro outer($v: tt) {
+    inner!(any_token $v)
+}
+
+#[issue_50061::check]
+fn main() {
+    //! this doc comment forces roundtrip through a string
+    let checkit = 0;
+    outer!(checkit);
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/50061

https://github.com/rust-lang/rust/commit/e2afefd80bf779bc3c6f697a3c6cc3a476993602 seemingly did everything right, but uncovered a preexisting bug.