### PR TITLE
added missing implementation hint

### DIFF
--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -258,7 +258,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                     format!("cannot use `{}=` on type `{}`",
                                     op.node.as_str(), lhs_ty));
                             let mut suggested_deref = false;
-                            if let TyRef(_, ref ty_mut) = lhs_ty.sty {
+                            if let TyRef(_, mut ty_mut) = lhs_ty.sty {
                                 if {
                                     !self.infcx.type_moves_by_default(self.param_env,
                                                                         ty_mut.ty,
@@ -269,10 +269,16 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                             .is_ok()
                                 } {
                                     if let Ok(lstring) = codemap.span_to_snippet(lhs_expr.span) {
+                                        while let TyRef(_, ty_mut_inner) = ty_mut.ty.sty{
+                                            ty_mut = ty_mut_inner;
+                                        }
                                         let msg = &format!(
                                                 "`{}=` can be used on '{}', you can \
                                                 dereference `{2}`: `*{2}`",
-                                                op.node.as_str(), ty_mut.ty, lstring);
+                                                op.node.as_str(),
+                                                ty_mut.ty,
+                                                lstring
+                                        );
                                         err.help(msg);
                                         suggested_deref = true;
                                     }
@@ -300,14 +306,16 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                     // we don't want the note in the else clause to be emitted
                                 } else if let ty::TyParam(_) = lhs_ty.sty {
                                     // FIXME: point to span of param
-                                    err.note(
-                                        &format!("`{}` might need a bound for `{}`",
-                                                    lhs_ty, missing_trait));
+                                    err.note(&format!(
+                                        "`{}` might need a bound for `{}`",
+                                        lhs_ty, missing_trait
+                                    ));
                                 } else if !suggested_deref {
-                                    err.note(
-                                        &format!("an implementation of `{}` might \
-                                                    be missing for `{}`",
-                                                    missing_trait, lhs_ty));
+                                    err.note(&format!(
+                                        "an implementation of `{}` might \
+                                         be missing for `{}`",
+                                        missing_trait, lhs_ty
+                                    ));
                                 }
                             }
                             err.emit();
@@ -318,7 +326,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                             op.node.as_str(),
                                             lhs_ty);
                             let mut suggested_deref = false;
-                            if let TyRef(_, ref ty_mut) = lhs_ty.sty {
+                            if let TyRef(_, mut ty_mut) = lhs_ty.sty {
                                 if {
                                     !self.infcx.type_moves_by_default(self.param_env,
                                                                         ty_mut.ty,
@@ -329,10 +337,16 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                             .is_ok()
                                 } {
                                     if let Ok(lstring) = codemap.span_to_snippet(lhs_expr.span) {
+                                        while let TyRef(_, ty_mut_inner) = ty_mut.ty.sty{
+                                            ty_mut = ty_mut_inner;
+                                        }
                                         let msg = &format!(
                                                 "`{}` can be used on '{}', you can \
                                                 dereference `{2}`: `*{2}`",
-                                                op.node.as_str(), ty_mut.ty, lstring);
+                                                op.node.as_str(),
+                                                ty_mut.ty,
+                                                lstring
+                                        );
                                         err.help(msg);
                                         suggested_deref = true;
                                     }
@@ -363,14 +377,16 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                     // we don't want the note in the else clause to be emitted
                                 } else if let ty::TyParam(_) = lhs_ty.sty {
                                     // FIXME: point to span of param
-                                    err.note(
-                                        &format!("`{}` might need a bound for `{}`",
-                                                    lhs_ty, missing_trait));
+                                    err.note(&format!(
+                                        "`{}` might need a bound for `{}`",
+                                        lhs_ty, missing_trait
+                                    ));
                                 } else if !suggested_deref {
-                                    err.note(
-                                        &format!("an implementation of `{}` might \
-                                                    be missing for `{}`",
-                                                    missing_trait, lhs_ty));
+                                    err.note(&format!(
+                                        "an implementation of `{}` might \
+                                         be missing for `{}`",
+                                        missing_trait, lhs_ty
+                                    ));
                                 }
                             }
                             err.emit();

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -258,25 +258,25 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                     format!("cannot use `{}=` on type `{}`",
                                     op.node.as_str(), lhs_ty));
                             let mut suggested_deref = false;
-                            if let TyRef(_, mut ty_mut) = lhs_ty.sty {
+                            if let TyRef(_, mut rty, _) = lhs_ty.sty {
                                 if {
                                     !self.infcx.type_moves_by_default(self.param_env,
-                                                                        ty_mut.ty,
+                                                                        rty,
                                                                         lhs_expr.span) &&
-                                        self.lookup_op_method(ty_mut.ty,
-                                                                &[rhs_ty],
-                                                                Op::Binary(op, is_assign))
+                                        self.lookup_op_method(rty,
+                                                              &[rhs_ty],
+                                                              Op::Binary(op, is_assign))
                                             .is_ok()
                                 } {
                                     if let Ok(lstring) = codemap.span_to_snippet(lhs_expr.span) {
-                                        while let TyRef(_, ty_mut_inner) = ty_mut.ty.sty{
-                                            ty_mut = ty_mut_inner;
+                                        while let TyRef(_, rty_inner, _) = rty.sty {
+                                            rty = rty_inner;
                                         }
                                         let msg = &format!(
                                                 "`{}=` can be used on '{}', you can \
                                                 dereference `{2}`: `*{2}`",
                                                 op.node.as_str(),
-                                                ty_mut.ty,
+                                                rty,
                                                 lstring
                                         );
                                         err.help(msg);
@@ -326,25 +326,25 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                             op.node.as_str(),
                                             lhs_ty);
                             let mut suggested_deref = false;
-                            if let TyRef(_, mut ty_mut) = lhs_ty.sty {
+                            if let TyRef(_, mut rty, _) = lhs_ty.sty {
                                 if {
                                     !self.infcx.type_moves_by_default(self.param_env,
-                                                                        ty_mut.ty,
+                                                                        rty,
                                                                         lhs_expr.span) &&
-                                        self.lookup_op_method(ty_mut.ty,
-                                                                &[rhs_ty],
-                                                                Op::Binary(op, is_assign))
+                                        self.lookup_op_method(rty,
+                                                              &[rhs_ty],
+                                                              Op::Binary(op, is_assign))
                                             .is_ok()
                                 } {
                                     if let Ok(lstring) = codemap.span_to_snippet(lhs_expr.span) {
-                                        while let TyRef(_, ty_mut_inner) = ty_mut.ty.sty{
-                                            ty_mut = ty_mut_inner;
+                                        while let TyRef(_, rty_inner, _) = rty.sty {
+                                            rty = rty_inner;
                                         }
                                         let msg = &format!(
                                                 "`{}` can be used on '{}', you can \
                                                 dereference `{2}`: `*{2}`",
                                                 op.node.as_str(),
-                                                ty_mut.ty,
+                                                rty,
                                                 lstring
                                         );
                                         err.help(msg);
@@ -478,7 +478,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                             err.note(&format!("unsigned values cannot be negated"));
                         },
                         TyStr | TyNever | TyChar | TyTuple(_) | TyArray(_,_) => {},
-                        TyRef(_, ref lty) if lty.ty.sty == TyStr => {},
+                        TyRef(_, ref lty, _) if lty.sty == TyStr => {},
                         _ => {
                             let missing_trait = match op {
                                 hir::UnNeg => "std::ops::Neg",

--- a/src/test/ui/binary-op-on-double-ref.stderr
+++ b/src/test/ui/binary-op-on-double-ref.stderr
@@ -4,7 +4,7 @@ error[E0369]: binary operation `%` cannot be applied to type `&&{integer}`
 LL |         x % 2 == 0
    |         ^^^^^
    |
-   = help: `%` can be used on '&{integer}', you can dereference `x`: `*x`
+   = help: `%` can be used on '{integer}', you can dereference `x`: `*x`
 
 error: aborting due to previous error
 

--- a/src/test/ui/binary-op-on-double-ref.stderr
+++ b/src/test/ui/binary-op-on-double-ref.stderr
@@ -4,8 +4,7 @@ error[E0369]: binary operation `%` cannot be applied to type `&&{integer}`
 LL |         x % 2 == 0
    |         ^^^^^
    |
-   = note: this is a reference to a type that `%` can be applied to; you need to dereference this variable once for this operation to work
-   = note: an implementation of `std::ops::Rem` might be missing for `&&{integer}`
+   = help: `%` can be used on '&{integer}', you can dereference `x`: `*x`
 
 error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/issue-28308.stderr
+++ b/src/test/ui/codemap_tests/issue-28308.stderr
@@ -3,6 +3,8 @@ error[E0600]: cannot apply unary operator `!` to type `&'static str`
    |
 LL |     assert!("foo");
    |     ^^^^^^^^^^^^^^^
+   |
+   = note: an implementation of `std::ops::Not` might be missing for `&'static str`
 
 error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/issue-28308.stderr
+++ b/src/test/ui/codemap_tests/issue-28308.stderr
@@ -2,9 +2,7 @@ error[E0600]: cannot apply unary operator `!` to type `&'static str`
   --> $DIR/issue-28308.rs:12:5
    |
 LL |     assert!("foo");
-   |     ^^^^^^^^^^^^^^^
-   |
-   = note: an implementation of `std::ops::Not` might be missing for `&'static str`
+   |     ^^^^^^^^^^^^^^^ cannot apply unary operator `!`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0067.stderr
+++ b/src/test/ui/error-codes/E0067.stderr
@@ -5,6 +5,8 @@ LL |     LinkedList::new() += 1; //~ ERROR E0368
    |     -----------------^^^^^
    |     |
    |     cannot use `+=` on type `std::collections::LinkedList<_>`
+   |
+   = note: an implementation of `std::ops::AddAssign` might be missing for `std::collections::LinkedList<_>`
 
 error[E0067]: invalid left-hand side expression
   --> $DIR/E0067.rs:14:5

--- a/src/test/ui/error-codes/E0600.stderr
+++ b/src/test/ui/error-codes/E0600.stderr
@@ -3,6 +3,8 @@ error[E0600]: cannot apply unary operator `!` to type `&'static str`
    |
 LL |     !"a"; //~ ERROR E0600
    |     ^^^^
+   |
+   = note: an implementation of `std::ops::Not` might be missing for `&'static str`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0600.stderr
+++ b/src/test/ui/error-codes/E0600.stderr
@@ -2,9 +2,7 @@ error[E0600]: cannot apply unary operator `!` to type `&'static str`
   --> $DIR/E0600.rs:12:5
    |
 LL |     !"a"; //~ ERROR E0600
-   |     ^^^^
-   |
-   = note: an implementation of `std::ops::Not` might be missing for `&'static str`
+   |     ^^^^ cannot apply unary operator `!`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-festival.stderr
+++ b/src/test/ui/error-festival.stderr
@@ -17,6 +17,8 @@ LL |     x += 2;
    |     -^^^^^
    |     |
    |     cannot use `+=` on type `&str`
+   |
+   = note: an implementation of `std::ops::AddAssign` might be missing for `&str`
 
 error[E0599]: no method named `z` found for type `&str` in the current scope
   --> $DIR/error-festival.rs:26:7
@@ -29,6 +31,8 @@ error[E0600]: cannot apply unary operator `!` to type `Question`
    |
 LL |     !Question::Yes;
    |     ^^^^^^^^^^^^^^
+   |
+   = note: an implementation of `std::ops::Not` might be missing for `Question`
 
 error[E0604]: only `u8` can be cast as `char`, not `u32`
   --> $DIR/error-festival.rs:35:5

--- a/src/test/ui/error-festival.stderr
+++ b/src/test/ui/error-festival.stderr
@@ -30,7 +30,7 @@ error[E0600]: cannot apply unary operator `!` to type `Question`
   --> $DIR/error-festival.rs:29:5
    |
 LL |     !Question::Yes;
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^ cannot apply unary operator `!`
    |
    = note: an implementation of `std::ops::Not` might be missing for `Question`
 

--- a/src/test/ui/feature-gate-negate-unsigned.stderr
+++ b/src/test/ui/feature-gate-negate-unsigned.stderr
@@ -3,12 +3,16 @@ error[E0600]: cannot apply unary operator `-` to type `usize`
    |
 LL |     let _max: usize = -1;
    |                       ^^
+   |
+   = note: an implementation of `std::ops::Neg` might be missing for `usize`
 
 error[E0600]: cannot apply unary operator `-` to type `u8`
   --> $DIR/feature-gate-negate-unsigned.rs:24:14
    |
 LL |     let _y = -x;
    |              ^^
+   |
+   = note: an implementation of `std::ops::Neg` might be missing for `u8`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/feature-gate-negate-unsigned.stderr
+++ b/src/test/ui/feature-gate-negate-unsigned.stderr
@@ -2,17 +2,17 @@ error[E0600]: cannot apply unary operator `-` to type `usize`
   --> $DIR/feature-gate-negate-unsigned.rs:20:23
    |
 LL |     let _max: usize = -1;
-   |                       ^^
+   |                       ^^ cannot apply unary operator `-`
    |
-   = note: an implementation of `std::ops::Neg` might be missing for `usize`
+   = note: unsigned values cannot be negated
 
 error[E0600]: cannot apply unary operator `-` to type `u8`
   --> $DIR/feature-gate-negate-unsigned.rs:24:14
    |
 LL |     let _y = -x;
-   |              ^^
+   |              ^^ cannot apply unary operator `-`
    |
-   = note: an implementation of `std::ops::Neg` might be missing for `u8`
+   = note: unsigned values cannot be negated
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issue-5239-1.stderr
+++ b/src/test/ui/issue-5239-1.stderr
@@ -6,7 +6,7 @@ LL |     let x = |ref x: isize| { x += 1; };
    |                              |
    |                              cannot use `+=` on type `&isize`
    |
-   = note: an implementation of `std::ops::AddAssign` might be missing for `&isize`
+   = help: `+=` can be used on 'isize', you can dereference `x`: `*x`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issue-5239-1.stderr
+++ b/src/test/ui/issue-5239-1.stderr
@@ -5,6 +5,8 @@ LL |     let x = |ref x: isize| { x += 1; };
    |                              -^^^^^
    |                              |
    |                              cannot use `+=` on type `&isize`
+   |
+   = note: an implementation of `std::ops::AddAssign` might be missing for `&isize`
 
 error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_unary.stderr
+++ b/src/test/ui/reachable/expr_unary.stderr
@@ -2,9 +2,7 @@ error[E0600]: cannot apply unary operator `!` to type `!`
   --> $DIR/expr_unary.rs:17:16
    |
 LL |     let x: ! = ! { return; }; //~ ERROR unreachable
-   |                ^^^^^^^^^^^^^
-   |
-   = note: an implementation of `std::ops::Not` might be missing for `!`
+   |                ^^^^^^^^^^^^^ cannot apply unary operator `!`
 
 error: unreachable expression
   --> $DIR/expr_unary.rs:17:16

--- a/src/test/ui/reachable/expr_unary.stderr
+++ b/src/test/ui/reachable/expr_unary.stderr
@@ -3,6 +3,8 @@ error[E0600]: cannot apply unary operator `!` to type `!`
    |
 LL |     let x: ! = ! { return; }; //~ ERROR unreachable
    |                ^^^^^^^^^^^^^
+   |
+   = note: an implementation of `std::ops::Not` might be missing for `!`
 
 error: unreachable expression
   --> $DIR/expr_unary.rs:17:16

--- a/src/test/ui/type-check/missing_trait_impl.rs
+++ b/src/test/ui/type-check/missing_trait_impl.rs
@@ -14,3 +14,7 @@ fn main() {
 fn foo<T>(x: T, y: T) {
     let z = x + y; //~ ERROR binary operation `+` cannot be applied to type `T`
 }
+
+fn bar<T>(x: T) {
+    x += x; //~ ERROR binary assignment operation `+=` cannot be applied to type `T`
+}

--- a/src/test/ui/type-check/missing_trait_impl.stderr
+++ b/src/test/ui/type-check/missing_trait_impl.stderr
@@ -6,6 +6,17 @@ LL |     let z = x + y; //~ ERROR binary operation `+` cannot be applied to type
    |
    = note: `T` might need a bound for `std::ops::Add`
 
-error: aborting due to previous error
+error[E0368]: binary assignment operation `+=` cannot be applied to type `T`
+  --> $DIR/missing_trait_impl.rs:19:5
+   |
+LL |     x += x; //~ ERROR binary assignment operation `+=` cannot be applied to type `T`
+   |     -^^^^^
+   |     |
+   |     cannot use `+=` on type `T`
+   |
+   = note: `T` might need a bound for `std::ops::AddAssign`
 
-For more information about this error, try `rustc --explain E0369`.
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0368, E0369.
+For more information about an error, try `rustc --explain E0368`.


### PR DESCRIPTION
Fixes [#50151](https://github.com/rust-lang/rust/issues/50151).
Actually, i don't know, should following code
`let x = |ref x: isize| { x += 1; };`
emit 
`note: an implementation of std::ops::AddAssign might be missing for &isize`
or
`note: this is a reference to a type that + can be applied to; you need to dereference this variable once for this operation to work`
or both