### PR TITLE
 Add as_nanos function to Duration

### DIFF
--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -277,7 +277,7 @@ impl Duration {
     #[unstable(feature = "duration_as_u128", issue = "50202")]
     #[inline]
     pub fn as_millis(&self) -> u128 {
-        self.secs as u128 * MILLIS_PER_SEC as u128 + self.nanos as u128 / NANOS_PER_MILLI as u128
+        self.secs as u128 * MILLIS_PER_SEC as u128 + (self.nanos / NANOS_PER_MILLI) as u128
     }
 
     /// Returns the total number of microseconds contained by this `Duration`.
@@ -294,7 +294,7 @@ impl Duration {
     #[unstable(feature = "duration_as_u128", issue = "50202")]
     #[inline]
     pub fn as_micros(&self) -> u128 {
-        self.secs as u128 * MICROS_PER_SEC as u128 + self.nanos as u128 / NANOS_PER_MICRO as u128
+        self.secs as u128 * MICROS_PER_SEC as u128 + (self.nanos / NANOS_PER_MICRO) as u128
     }
 
     /// Returns the total number of nanoseconds contained by this `Duration`.

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -268,6 +268,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
+    /// # #![feature(duration_nanos)]
     /// use std::time::Duration;
     ///
     /// let duration = Duration::new(5, 730023852);

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -273,7 +273,7 @@ impl Duration {
     /// let duration = Duration::new(5, 730023852);
     /// assert_eq!(duration.as_nanos(), 5730023852);
     /// ```
-    #[unstable(feature = "duration_nanos", issue = "0")]
+    #[unstable(feature = "duration_nanos", issue = "50167")]
     #[inline]
     pub fn as_nanos(&self) -> u128 {
         self.secs as u128 * NANOS_PER_SEC as u128 + self.nanos as u128

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -274,7 +274,7 @@ impl Duration {
     /// let duration = Duration::new(5, 730023852);
     /// assert_eq!(duration.as_nanos(), 5730023852);
     /// ```
-    #[unstable(feature = "duration_nanos", issue = "50167")]
+    #[unstable(feature = "duration_nanos", issue = "50202")]
     #[inline]
     pub fn as_nanos(&self) -> u128 {
         self.secs as u128 * NANOS_PER_SEC as u128 + self.nanos as u128

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -263,6 +263,22 @@ impl Duration {
     #[inline]
     pub fn subsec_nanos(&self) -> u32 { self.nanos }
 
+    /// Returns the total number of nanoseconds contained by this `Duration`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::time::Duration;
+    ///
+    /// let duration = Duration::new(5, 730023852);
+    /// assert_eq!(duration.as_nanos(), 5730023852);
+    /// ```
+    #[unstable(feature = "duration_nanos", issue = "0")]
+    #[inline]
+    pub fn as_nanos(&self) -> u128 {
+        self.secs as u128 * 1000_000_000 + self.nanos as u128
+    }
+
     /// Checked `Duration` addition. Computes `self + other`, returning [`None`]
     /// if overflow occurred.
     ///

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -276,7 +276,7 @@ impl Duration {
     #[unstable(feature = "duration_nanos", issue = "0")]
     #[inline]
     pub fn as_nanos(&self) -> u128 {
-        self.secs as u128 * 1000_000_000 + self.nanos as u128
+        self.secs as u128 * NANOS_PER_SEC as u128 + self.nanos as u128
     }
 
     /// Checked `Duration` addition. Computes `self + other`, returning [`None`]

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -263,18 +263,52 @@ impl Duration {
     #[inline]
     pub fn subsec_nanos(&self) -> u32 { self.nanos }
 
+    /// Returns the total number of milliseconds contained by this `Duration`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(duration_as_u128)]
+    /// use std::time::Duration;
+    ///
+    /// let duration = Duration::new(5, 730023852);
+    /// assert_eq!(duration.as_millis(), 5730);
+    /// ```
+    #[unstable(feature = "duration_as_u128", issue = "50202")]
+    #[inline]
+    pub fn as_millis(&self) -> u128 {
+        self.secs as u128 * MILLIS_PER_SEC as u128 + self.nanos as u128 / NANOS_PER_MILLI as u128
+    }
+
+    /// Returns the total number of microseconds contained by this `Duration`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(duration_as_u128)]
+    /// use std::time::Duration;
+    ///
+    /// let duration = Duration::new(5, 730023852);
+    /// assert_eq!(duration.as_micros(), 5730023);
+    /// ```
+    #[unstable(feature = "duration_as_u128", issue = "50202")]
+    #[inline]
+    pub fn as_micros(&self) -> u128 {
+        self.secs as u128 * MICROS_PER_SEC as u128 + self.nanos as u128 / NANOS_PER_MICRO as u128
+    }
+
     /// Returns the total number of nanoseconds contained by this `Duration`.
     ///
     /// # Examples
     ///
     /// ```
-    /// # #![feature(duration_nanos)]
+    /// # #![feature(duration_as_u128)]
     /// use std::time::Duration;
     ///
     /// let duration = Duration::new(5, 730023852);
     /// assert_eq!(duration.as_nanos(), 5730023852);
     /// ```
-    #[unstable(feature = "duration_nanos", issue = "50202")]
+    #[unstable(feature = "duration_as_u128", issue = "50202")]
     #[inline]
     pub fn as_nanos(&self) -> u128 {
         self.secs as u128 * NANOS_PER_SEC as u128 + self.nanos as u128


### PR DESCRIPTION
Duration has historically lacked a way to get the actual number of nanoseconds it contained as a normal Rust type because u64 was of insufficient range, and f64 of insufficient precision. The u128 type solves both issues, so I propose adding an `as_nanos` function to expose the capability. 