### PR TITLE
Use FxHashMap in syntax_pos::symbol::Interner::intern.

### DIFF
--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -15,8 +15,8 @@
 use hygiene::SyntaxContext;
 use {Span, DUMMY_SP, GLOBALS};
 
+use rustc_data_structures::fx::FxHashMap;
 use serialize::{Decodable, Decoder, Encodable, Encoder};
-use std::collections::HashMap;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
@@ -184,7 +184,7 @@ impl<T: ::std::ops::Deref<Target=str>> PartialEq<T> for Symbol {
 
 #[derive(Default)]
 pub struct Interner {
-    names: HashMap<Box<str>, Symbol>,
+    names: FxHashMap<Box<str>, Symbol>,
     strings: Vec<Box<str>>,
     gensyms: Vec<Symbol>,
 }


### PR DESCRIPTION
Because it's faster than HashMap.

This change reduces the time taken for a few of the rustc-perf
benchmarks, mostly the small ones, by up to 5%.
```
coercions
        avg: -1.3%      min: -5.5%      max: -0.0%
helloworld-check
        avg: -2.3%      min: -3.5%      max: -1.8%
deeply-nested-check
        avg: -1.4%      min: -3.2%      max: -0.5%
tuple-stress-opt
        avg: -0.7%      min: -2.0%      max: -0.1%
unify-linearly-check
        avg: -1.2%      min: -1.9%      max: -0.6%
coercions-check
        avg: -0.8%      min: -1.3%      max: -0.4%
unused-warnings-check
        avg: -1.0%      min: -1.3%      max: -0.8%
deeply-nested-opt
        avg: -0.5%      min: -1.2%      max: -0.2%
deeply-nested
        avg: -0.7%      min: -1.2%      max: -0.4%
helloworld
        avg: -0.8%      min: -1.1%      max: -0.7%
tuple-stress-check
        avg: -0.5%      min: -1.0%      max: -0.1%
unused-warnings
        avg: -0.8%      min: -1.0%      max: -0.7%
unused-warnings-opt
        avg: -0.8%      min: -1.0%      max: -0.7%
coercions-opt
        avg: -0.5%      min: -1.0%      max: -0.1%
helloworld-opt
        avg: -0.7%      min: -1.0%      max: -0.6%
```