### PR TITLE
mark std::str::replace(,n) as #[must_use]

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -96,6 +96,7 @@
 #![feature(dropck_eyepatch)]
 #![feature(exact_size_is_empty)]
 #![feature(fmt_internals)]
+#![feature(fn_must_use)]
 #![feature(from_ref)]
 #![feature(fundamental)]
 #![feature(lang_items)]

--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -207,6 +207,7 @@ impl str {
     /// let s = "this is old";
     /// assert_eq!(s, s.replace("cookie monster", "little lamb"));
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn replace<'a, P: Pattern<'a>>(&'a self, from: P, to: &str) -> String {
@@ -246,6 +247,7 @@ impl str {
     /// let s = "this is old";
     /// assert_eq!(s, s.replacen("cookie monster", "little lamb", 10));
     /// ```
+    #[must_use]
     #[stable(feature = "str_replacen", since = "1.16.0")]
     pub fn replacen<'a, P: Pattern<'a>>(&'a self, pat: P, to: &str, count: usize) -> String {
         // Hope to reduce the times of re-allocation


### PR DESCRIPTION
let x = "a b c c";
x.replacen("c", "d", 2");
might not do what people might think it does.