### PR TITLE
[WIP] Move `Self: Trait` predicate to trait items instead of the trait itself

### DIFF
--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -750,16 +750,13 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                       -> UnitResult<'tcx>
         where T: at::ToTrace<'tcx>
     {
-        debug!("can_sub({:?}, {:?})", a, b);
         let origin = &ObligationCause::dummy();
-        let result = self.probe(|_| {
+        self.probe(|_| {
             self.at(origin, param_env).sub(a, b).map(|InferOk { obligations: _, .. }| {
                 // Ignore obligations, since we are unrolling
                 // everything anyway.
             })
-        });
-        debug!("can_sub({:?}, {:?}) returning {:?}", a, b, result);
-        result
+        })
     }
 
     pub fn can_eq<T>(&self,
@@ -769,16 +766,13 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                       -> UnitResult<'tcx>
         where T: at::ToTrace<'tcx>
     {
-        debug!("can_eq({:?}, {:?})", a, b);
         let origin = &ObligationCause::dummy();
-        let result = self.probe(|_| {
+        self.probe(|_| {
             self.at(origin, param_env).eq(a, b).map(|InferOk { obligations: _, .. }| {
                 // Ignore obligations, since we are unrolling
                 // everything anyway.
             })
-        });
-        debug!("can_eq({:?}, {:?}) returning {:?}", a, b, result);
-        result
+        })
     }
 
     pub fn sub_regions(&self,

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -750,13 +750,16 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                       -> UnitResult<'tcx>
         where T: at::ToTrace<'tcx>
     {
+        debug!("can_sub({:?}, {:?})", a, b);
         let origin = &ObligationCause::dummy();
-        self.probe(|_| {
+        let result = self.probe(|_| {
             self.at(origin, param_env).sub(a, b).map(|InferOk { obligations: _, .. }| {
                 // Ignore obligations, since we are unrolling
                 // everything anyway.
             })
-        })
+        });
+        debug!("can_sub({:?}, {:?}) returning {:?}", a, b, result);
+        result
     }
 
     pub fn can_eq<T>(&self,
@@ -766,13 +769,16 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                       -> UnitResult<'tcx>
         where T: at::ToTrace<'tcx>
     {
+        debug!("can_eq({:?}, {:?})", a, b);
         let origin = &ObligationCause::dummy();
-        self.probe(|_| {
+        let result = self.probe(|_| {
             self.at(origin, param_env).eq(a, b).map(|InferOk { obligations: _, .. }| {
                 // Ignore obligations, since we are unrolling
                 // everything anyway.
             })
-        })
+        });
+        debug!("can_eq({:?}, {:?}) returning {:?}", a, b, result);
+        result
     }
 
     pub fn sub_regions(&self,

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -1174,18 +1174,6 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
         // resolving specializations.
         if candidates.len() > 1 {
             let mut i = 0;
-            //candidates.retain(|c| {
-            //    match c.candidate {
-            //        ParamCandidate(poly_trait_ref) => {
-            //            if poly_trait_ref == stack.obligation.predicate.map_bound(|x| x.trait_ref) {
-            //                debug!("Dropping candidate (== obligation): {:?}", c);
-            //                return false;
-            //            }
-            //        }
-            //        _ => {}
-            //    }
-            //    true
-            //});
             while i < candidates.len() {
                 let is_dup =
                     (0..candidates.len())

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -1934,9 +1934,6 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
     // attempt to evaluate recursive bounds to see if they are
     // satisfied.
 
-    /// Returns true if `candidate_i` should be dropped in favor of
-    /// `candidate_j`.  Generally speaking we will drop duplicate
-    /// candidates and prefer where-clause candidates.
     /// Returns true if `victim` should be dropped in favor of
     /// `other`.  Generally speaking we will drop duplicate
     /// candidates and prefer where-clause candidates.

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -1164,11 +1164,28 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
             }
         }).collect();
 
+        debug!("winnowed to {} candidates for {:?}: {:?}",
+               candidates.len(),
+               stack,
+               candidates);
+
         // If there are STILL multiple candidate, we can further
         // reduce the list by dropping duplicates -- including
         // resolving specializations.
         if candidates.len() > 1 {
             let mut i = 0;
+            //candidates.retain(|c| {
+            //    match c.candidate {
+            //        ParamCandidate(poly_trait_ref) => {
+            //            if poly_trait_ref == stack.obligation.predicate.map_bound(|x| x.trait_ref) {
+            //                debug!("Dropping candidate (== obligation): {:?}", c);
+            //                return false;
+            //            }
+            //        }
+            //        _ => {}
+            //    }
+            //    true
+            //});
             while i < candidates.len() {
                 let is_dup =
                     (0..candidates.len())

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2748,10 +2748,9 @@ fn param_env<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 }
 
 pub fn is_trait<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> bool {
-    if let Some(id) = tcx.hir.as_local_node_id(def_id) {
-        is_trait_node(tcx, id)
-    } else {
-        false
+    match tcx.def_key(def_id).disambiguated_data.data {
+        DefPathData::Trait(_) => true,
+        _ => false,
     }
 }
 

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2732,21 +2732,21 @@ fn param_env<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     // are any errors at that point, so after type checking you can be
     // sure that this will succeed without errors anyway.
 
-    let id = tcx.hir.as_local_node_id(def_id).unwrap();
-    debug!("param_env: handling def_id={:?}, id={:?}", def_id, id);
-
-    if let Some(hir::map::NodeItem(item)) = tcx.hir.find(id) {
-        debug!("  param_env: self node: {:?}", item.node);
-        if let hir::ItemTrait(..) = item.node {
-            debug!("    param_env: self is trait!");
-            let trait_ref = ty::TraitRef {
-                def_id: def_id,
-                substs: Substs::identity_for_item(tcx, def_id)
-            };
-            predicates.push(trait_ref.to_poly_trait_ref().to_predicate());
+    if let Some(id) = tcx.hir.as_local_node_id(def_id) {
+        debug!("param_env: handling def_id={:?}, id={:?}", def_id, id);
+        if let Some(hir::map::NodeItem(item)) = tcx.hir.find(id) {
+            debug!("  param_env: self node: {:?}", item.node);
+            if let hir::ItemTrait(..) = item.node {
+                debug!("    param_env: self is trait!");
+                let trait_ref = ty::TraitRef {
+                    def_id: def_id,
+                    substs: Substs::identity_for_item(tcx, def_id)
+                };
+                predicates.push(trait_ref.to_poly_trait_ref().to_predicate());
+            }
         }
+        debug!("  param_env predicates: {:?}", predicates);
     }
-    debug!("  param_env predicates: {:?}", predicates);
 
     let unnormalized_env = ty::ParamEnv::new(tcx.intern_predicates(&predicates),
                                              traits::Reveal::UserFacing);

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2718,7 +2718,7 @@ fn param_env<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     // Compute the bounds on Self and the type parameters.
 
     let bounds = tcx.predicates_of(def_id).instantiate_identity(tcx);
-    let predicates = bounds.predicates;
+    let mut predicates = bounds.predicates;
 
     // Finally, we have to normalize the bounds in the environment, in
     // case they contain any associated type projections. This process
@@ -2731,6 +2731,22 @@ fn param_env<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     // every fn once during type checking, and we'll abort if there
     // are any errors at that point, so after type checking you can be
     // sure that this will succeed without errors anyway.
+
+    let id = tcx.hir.as_local_node_id(def_id).unwrap();
+    debug!("param_env: handling def_id={:?}, id={:?}", def_id, id);
+
+    if let Some(hir::map::NodeItem(item)) = tcx.hir.find(id) {
+        debug!("  param_env: self node: {:?}", item.node);
+        if let hir::ItemTrait(..) = item.node {
+            debug!("    param_env: self is trait!");
+            let trait_ref = ty::TraitRef {
+                def_id: def_id,
+                substs: Substs::identity_for_item(tcx, def_id)
+            };
+            predicates.push(trait_ref.to_poly_trait_ref().to_predicate());
+        }
+    }
+    debug!("  param_env predicates: {:?}", predicates);
 
     let unnormalized_env = ty::ParamEnv::new(tcx.intern_predicates(&predicates),
                                              traits::Reveal::UserFacing);

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -550,6 +550,14 @@ impl<'tcx> TraitRef<'tcx> {
         TraitRef { def_id: def_id, substs: substs }
     }
 
+    /// Returns a TraitRef of the form `Self: Foo<U>`.
+    pub fn identity<'a, 'gcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>, def_id: DefId) -> TraitRef<'tcx> {
+        TraitRef {
+            def_id,
+            substs: Substs::identity_for_item(tcx, def_id),
+        }
+    }
+
     pub fn self_ty(&self) -> Ty<'tcx> {
         self.substs.type_at(0)
     }

--- a/src/librustc/ty/wf.rs
+++ b/src/librustc/ty/wf.rs
@@ -465,7 +465,7 @@ impl<'a, 'gcx, 'tcx> WfPredicates<'a, 'gcx, 'tcx> {
             def_id: trait_ref.def_id,
             substs: Substs::identity_for_item(self.infcx.tcx, trait_ref.def_id)
         };
-        predicates.predicates.push(identity_trait_ref.to_poly_trait_ref().to_predicate());
+        predicates.predicates.insert(0, identity_trait_ref.to_poly_trait_ref().to_predicate());
 
         debug!("nominal_trait_obligations: trait_ref={:?} predicates={:?}",
                trait_ref, predicates.predicates);

--- a/src/librustc/ty/wf.rs
+++ b/src/librustc/ty/wf.rs
@@ -13,7 +13,7 @@ use middle::const_val::ConstVal;
 use infer::InferCtxt;
 use ty::subst::Substs;
 use traits;
-use ty::{self, ToPolyTraitRef, ToPredicate, Ty, TyCtxt, TypeFoldable};
+use ty::{self, ToPredicate, Ty, TyCtxt, TypeFoldable};
 use std::iter::once;
 use syntax::ast;
 use syntax_pos::Span;
@@ -457,7 +457,7 @@ impl<'a, 'gcx, 'tcx> WfPredicates<'a, 'gcx, 'tcx> {
         // Add in a predicate that `Self:Trait` (where `Trait` is the
         // current trait).
         let self_trait = if !trait_ref.has_escaping_regions() {
-            Some(trait_ref.to_poly_trait_ref().to_predicate())
+            Some(trait_ref.to_predicate())
         } else {
             None
         };

--- a/src/librustc_traits/lowering.rs
+++ b/src/librustc_traits/lowering.rs
@@ -234,10 +234,8 @@ fn program_clauses_for_trait<'a, 'tcx>(
     // ```
 
     // `FromEnv(WC) :- FromEnv(Self: Trait<P1..Pn>)`, for each where clause WC
-    // FIXME: Remove the [1..] slice; this is a hack because the query
-    // predicates_of currently includes the trait itself (`Self: Trait<P1..Pn>`).
     let where_clauses = &tcx.predicates_of(def_id).predicates;
-    let implied_bound_clauses = where_clauses[1..]
+    let implied_bound_clauses = where_clauses
         .into_iter()
         .map(|wc| implied_bound_from_trait(tcx, trait_pred, wc));
 

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -30,7 +30,6 @@ use super::{Inherited, FnCtxt};
 /// - impl_m_span: span to use for reporting errors
 /// - trait_m: the method in the trait
 /// - impl_trait_ref: the TraitRef corresponding to the trait implementation
-
 pub fn compare_impl_method<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                      impl_m: &ty::AssociatedItem,
                                      impl_m_span: Span,

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -188,10 +188,17 @@ fn compare_predicate_entailment<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             match pred {
                 ty::Predicate::Trait(trait_ref) => {
                     if trait_ref.def_id() == trait_def_id {
-                        false
-                    } else {
-                        true
+                        use ty::TypeVariants::TyParam;
+                        if let TyParam(param) = trait_ref.skip_binder().self_ty().sty {
+                            if param.is_self() {
+                                debug!(
+                                    "compare_impl_method: removing `{:?}` from trait_m_predicates",
+                                    pred);
+                                return false;
+                            }
+                        }
                     }
+                    true
                 }
                 _ => true
             }

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -183,6 +183,8 @@ fn compare_predicate_entailment<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let impl_m_predicates = tcx.predicates_of(impl_m.def_id);
     let mut trait_m_predicates = tcx.predicates_of(trait_m.def_id);
 
+    // A `Self: Trait` predicate on trait items breaks selection, so filter it out.
+    // FIXME: This is a big hack!
     if let Some(trait_def_id) = trait_m_predicates.parent {
         trait_m_predicates.predicates.retain(|pred| {
             match pred {

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -447,6 +447,7 @@ fn check_where_clauses<'a, 'gcx, 'fcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'gcx>,
     let predicates = predicates.instantiate_identity(fcx.tcx);
     let predicates = fcx.normalize_associated_types_in(span, &predicates);
 
+    debug!("check_where_clauses: predicates={:?}", predicates.predicates);
     let obligations =
         predicates.predicates
                     .iter()
@@ -457,6 +458,7 @@ fn check_where_clauses<'a, 'gcx, 'fcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'gcx>,
                                                                 span));
 
     for obligation in obligations {
+        debug!("next obligation cause: {:?}", obligation.cause);
         fcx.register_predicate(obligation);
     }
 }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1321,14 +1321,14 @@ pub fn explicit_predicates_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let node = tcx.hir.get(node_id);
 
     let mut is_trait = None;
-    let mut is_trait_item = None;
+    let mut is_trait_item = false;
     let mut is_default_impl_trait = None;
 
     let icx = ItemCtxt::new(tcx, def_id);
     let no_generics = hir::Generics::empty();
     let ast_generics = match node {
         NodeTraitItem(item) => {
-            is_trait_item = Some(());
+            is_trait_item = true;
             &item.generics
         }
 
@@ -1408,35 +1408,7 @@ pub fn explicit_predicates_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     // associated types.
     if let Some((_trait_ref, _)) = is_trait {
         predicates = tcx.super_predicates_of(def_id).predicates;
-
-        // Add in a predicate that `Self:Trait` (where `Trait` is the
-        // current trait).  This is needed for builtin bounds.
-        //predicates.push(trait_ref.to_poly_trait_ref().to_predicate());
     }
-
-    if let Some(()) = is_trait_item {
-        let id = tcx.hir.as_local_node_id(def_id).unwrap();
-        debug!("explicit_predicates_of: handling def_id={:?}, id={:?}", def_id, id);
-
-        let parent_id = tcx.hir.get_parent(id);
-        let parent_def_id = tcx.hir.local_def_id(parent_id);
-        if let Some(hir::map::NodeItem(parent_item)) = tcx.hir.find(parent_id) {
-            debug!("  explicit_predicates_of: has parent, node: {:?}", parent_item.node);
-            if let hir::ItemTrait(..) = parent_item.node {
-                debug!("    explicit_predicates_of: parent is trait!");
-                let trait_ref = ty::TraitRef {
-                    def_id: parent_def_id,
-                    substs: Substs::identity_for_item(tcx, parent_def_id)
-                };
-                predicates.push(trait_ref.to_poly_trait_ref().to_predicate());
-            } else {
-                debug!("    explicit_predicates_of: parent is not trait :((");
-            }
-        } else {
-            debug!("  explicit_predicates_of: no parent :(");
-        }
-    }
-    debug!("explicit_predicates_of: predicates={:?}", predicates);
 
     // In default impls, we can assume that the self type implements
     // the trait. So in:
@@ -1448,6 +1420,14 @@ pub fn explicit_predicates_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     // set of defaults that can be incorporated into another impl.
     if let Some(trait_ref) = is_default_impl_trait {
         predicates.push(trait_ref.to_poly_trait_ref().to_predicate());
+    }
+
+    // For trait items, add `Self: Trait` predicate.
+    if is_trait_item {
+        let parent_id = tcx.hir.get_parent(node_id);
+        let parent_def_id = tcx.hir.local_def_id(parent_id);
+        debug_assert!(ty::is_trait_node(tcx, parent_id));
+        predicates.push(ty::TraitRef::identity(tcx, parent_def_id).to_predicate());
     }
 
     // Collect the region predicates that were declared inline as

--- a/src/test/ui/chalkify/lower_env1.stderr
+++ b/src/test/ui/chalkify/lower_env1.stderr
@@ -4,7 +4,7 @@ error: program clause dump
 LL | #[rustc_dump_program_clauses] //~ ERROR program clause dump
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: FromEnv(Self: Bar) :- FromEnv(Self: Bar).
+   = note: FromEnv(Self: Foo) :- FromEnv(Self: Bar).
    = note: FromEnv(Self: Foo) :- FromEnv(Self: Bar).
    = note: Implemented(Self: Bar) :- FromEnv(Self: Bar).
 
@@ -14,7 +14,7 @@ error: program clause dump
 LL | #[rustc_dump_env_program_clauses] //~ ERROR program clause dump
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: FromEnv(Self: Bar) :- FromEnv(Self: Bar).
+   = note: FromEnv(Self: Foo) :- FromEnv(Self: Bar).
    = note: FromEnv(Self: Foo) :- FromEnv(Self: Bar).
    = note: Implemented(Self: Bar) :- FromEnv(Self: Bar).
    = note: Implemented(Self: Foo) :- FromEnv(Self: Foo).


### PR DESCRIPTION
The `predicates_of` query on a trait `Foo` should only return where clauses on that trait. Right now, it includes `Self: Foo`, which causes problems when lowering to new chalk-style logic.

This PR moves `Self: Foo` to the trait items, rather than the trait itself.

Status: Functional enough to compile std, but some tests failing; needs cleanup.

r? @nikomatsakis 