### PR TITLE
Add some utilities to `libsyntax`

### DIFF
--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -270,7 +270,7 @@ impl Span {
     /// `self` was generated from, if any.
     #[unstable(feature = "proc_macro", issue = "38356")]
     pub fn parent(&self) -> Option<Span> {
-        self.0.ctxt().outer().expn_info().map(|i| Span(i.call_site))
+        self.0.parent().map(|x| { Span(x) })
     }
 
     /// The span for the origin source code that `self` was generated from. If

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -270,7 +270,7 @@ impl Span {
     /// `self` was generated from, if any.
     #[unstable(feature = "proc_macro", issue = "38356")]
     pub fn parent(&self) -> Option<Span> {
-        self.0.parent().map(|x| { Span(x) })
+        self.0.parent().map(Span)
     }
 
     /// The span for the origin source code that `self` was generated from. If

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -238,6 +238,22 @@ impl SyntaxContext {
         })
     }
 
+    /// Pulls a single mark off of the syntax context. This effectively moves the
+    /// context up one macro definition level. That is, if we have a nested macro
+    /// definition as follows:
+    ///
+    /// ```rust
+    /// macro_rules! f {
+    ///    macro_rules! g {
+    ///        ...
+    ///    }
+    /// }
+    /// ```
+    ///
+    /// and we have a SyntaxContext that is referring to something declared by an invocation
+    /// of g (call it g1), calling remove_mark will result in the SyntaxContext for the
+    /// invocation of f that created g1.
+    /// Returns the mark that was removed.
     pub fn remove_mark(&mut self) -> Mark {
         HygieneData::with(|data| {
             let outer_mark = data.syntax_contexts[self.0 as usize].outer_mark;

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -123,11 +123,11 @@ impl Mark {
     /// mark. That is, the following holds:
     ///
     /// ```rust
-    /// let lub = lub(a, b);
-    /// assert!(a.is_descendant_of(lub))
-    /// assert!(b.is_descendant_of(lub))
+    /// let la = least_ancestor(a, b);
+    /// assert!(a.is_descendant_of(la))
+    /// assert!(b.is_descendant_of(la))
     /// ```
-    pub fn lub(mut a: Mark, mut b: Mark) -> Mark {
+    pub fn least_ancestor(mut a: Mark, mut b: Mark) -> Mark {
         HygieneData::with(|data| {
             // Compute the path from a to the root
             let mut a_path = FxHashSet::<Mark>();
@@ -138,7 +138,7 @@ impl Mark {
 
             // While the path from b to the root hasn't intersected, move up the tree
             while !a_path.contains(&b) {
-                b =  data.marks[b.0 as usize].parent;
+                b = data.marks[b.0 as usize].parent;
             }
 
             b

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -291,6 +291,12 @@ impl Span {
         self.ctxt().outer().expn_info().map(|info| info.call_site.source_callsite()).unwrap_or(self)
     }
 
+    /// The `Span for the tokens in the previous macro expansion from which `self` was generated,
+    /// if any
+    pub fn parent(self) -> Option<Span> {
+        self.ctxt().outer().expn_info().map(|i| i.call_site)
+    }
+
     /// Return the source callee.
     ///
     /// Returns None if the supplied span has no expansion trace,

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -291,7 +291,7 @@ impl Span {
         self.ctxt().outer().expn_info().map(|info| info.call_site.source_callsite()).unwrap_or(self)
     }
 
-    /// The `Span for the tokens in the previous macro expansion from which `self` was generated,
+    /// The `Span` for the tokens in the previous macro expansion from which `self` was generated,
     /// if any
     pub fn parent(self) -> Option<Span> {
         self.ctxt().outer().expn_info().map(|i| i.call_site)


### PR DESCRIPTION
Adds a few functions to `Mark` and `Span` that I found useful in an upcoming refactor of NLL region error reporting. Also includes some new documentation based on my discussion with @jseyfried on IRC.

r? @jseyfried 