### PR TITLE
Remove Allocation.runtime_mutability

### DIFF
--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -452,7 +452,6 @@ impl<'a> HashStable<StableHashingContext<'a>> for mir::interpret::Allocation {
         }
         self.undef_mask.hash_stable(hcx, hasher);
         self.align.hash_stable(hcx, hasher);
-        self.runtime_mutability.hash_stable(hcx, hasher);
     }
 }
 

--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -20,7 +20,6 @@ use ty::{self, TyCtxt};
 use ty::layout::{self, Align, HasDataLayout};
 use middle::region;
 use std::iter;
-use syntax::ast::Mutability;
 use rustc_serialize::{Encoder, Decoder, Decodable, Encodable};
 
 #[derive(Clone, Debug, PartialEq)]
@@ -247,10 +246,6 @@ pub struct Allocation {
     pub undef_mask: UndefMask,
     /// The alignment of the allocation to detect unaligned reads.
     pub align: Align,
-    /// Whether the allocation (of a static) should be put into mutable memory when translating
-    ///
-    /// Only happens for `static mut` or `static` with interior mutability
-    pub runtime_mutability: Mutability,
 }
 
 impl Allocation {
@@ -262,7 +257,6 @@ impl Allocation {
             relocations: BTreeMap::new(),
             undef_mask,
             align: Align::from_bytes(1, 1).unwrap(),
-            runtime_mutability: Mutability::Immutable,
         }
     }
 }

--- a/src/librustc_mir/interpret/const_eval.rs
+++ b/src/librustc_mir/interpret/const_eval.rs
@@ -115,14 +115,7 @@ fn eval_body_and_ecx<'a, 'mir, 'tcx>(
             layout.align,
             None,
         )?;
-        let internally_mutable = !layout.ty.is_freeze(tcx, param_env, mir.span);
-        let mutability = tcx.is_static(cid.instance.def_id());
-        let mutability = if mutability == Some(hir::Mutability::MutMutable) || internally_mutable {
-            Mutability::Mutable
-        } else {
-            Mutability::Immutable
-        };
-        let cleanup = StackPopCleanup::MarkStatic(mutability);
+        let cleanup = StackPopCleanup::MarkStatic;
         let name = ty::tls::with(|tcx| tcx.item_path_str(cid.instance.def_id()));
         let prom = cid.promoted.map_or(String::new(), |p| format!("::promoted[{:?}]", p));
         trace!("const_eval: pushing stack frame for global: {}{}", name, prom);
@@ -315,7 +308,6 @@ impl<'mir, 'tcx> super::Machine<'mir, 'tcx> for CompileTimeEvaluator {
     fn mark_static_initialized<'a>(
         _mem: &mut Memory<'a, 'mir, 'tcx, Self>,
         _id: AllocId,
-        _mutability: Mutability,
     ) -> EvalResult<'tcx, bool> {
         Ok(false)
     }

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -63,7 +63,6 @@ pub trait Machine<'mir, 'tcx>: Sized {
     fn mark_static_initialized<'a>(
         _mem: &mut Memory<'a, 'mir, 'tcx, Self>,
         _id: AllocId,
-        _mutability: Mutability,
     ) -> EvalResult<'tcx, bool>;
 
     /// Called when requiring a pointer to a static. Non const eval can

--- a/src/librustc_mir/interpret/traits.rs
+++ b/src/librustc_mir/interpret/traits.rs
@@ -1,6 +1,5 @@
 use rustc::ty::{self, Ty};
 use rustc::ty::layout::{Size, Align, LayoutOf};
-use syntax::ast::Mutability;
 
 use rustc::mir::interpret::{PrimVal, Value, MemoryPointer, EvalResult};
 use super::{EvalContext, Machine};
@@ -53,7 +52,6 @@ impl<'a, 'mir, 'tcx, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> {
 
         self.memory.mark_static_initialized(
             vtable.alloc_id,
-            Mutability::Immutable,
         )?;
 
         Ok(vtable)

--- a/src/librustc_trans/mir/constant.rs
+++ b/src/librustc_trans/mir/constant.rs
@@ -23,7 +23,6 @@ use common::{C_bytes, C_struct, C_uint_big, C_undef, C_usize};
 use consts;
 use type_of::LayoutLlvmExt;
 use type_::Type;
-use syntax::ast::Mutability;
 
 use super::super::callee;
 use super::FunctionCx;
@@ -57,11 +56,7 @@ pub fn primval_to_llvm(cx: &CodegenCx,
                 } else if let Some(alloc) = cx.tcx.interpret_interner
                                               .get_alloc(ptr.alloc_id) {
                     let init = global_initializer(cx, alloc);
-                    if alloc.runtime_mutability == Mutability::Mutable {
-                        consts::addr_of_mut(cx, init, alloc.align, "byte_str")
-                    } else {
-                        consts::addr_of(cx, init, alloc.align, "byte_str")
-                    }
+                    consts::addr_of(cx, init, alloc.align, "byte_str")
                 } else {
                     bug!("missing allocation {:?}", ptr.alloc_id);
                 };


### PR DESCRIPTION
This fixes a bug where `NopLogger` in `static mut LOGGER: &'static Log = &NopLogger` will be marked mutable by `mark_static_initialized`. With this bugfix, `Allocation.runtime_mutability` is entirely unused and is removed.

r? @oli-obk 