### PR TITLE
Include parens to type parameter

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4886,6 +4886,8 @@ impl<'a> Parser<'a> {
                     bounds.push(RegionTyParamBound(self.expect_lifetime()));
                     if has_parens {
                         self.expect(&token::CloseDelim(token::Paren))?;
+                        self.span_err(self.prev_span,
+                                      "parenthesized lifetime bounds are not supported");
                     }
                 } else {
                     let lifetime_defs = self.parse_late_bound_lifetime_defs()?;
@@ -4900,12 +4902,6 @@ impl<'a> Parser<'a> {
                         TraitBoundModifier::None
                     };
                     bounds.push(TraitTyParamBound(poly_trait, modifier));
-                }
-                if has_parens {
-                    if let Some(&RegionTyParamBound(..)) = bounds.last() {
-                        self.span_err(self.prev_span,
-                                      "parenthesized lifetime bounds are not supported");
-                    }
                 }
             } else {
                 break

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4875,6 +4875,7 @@ impl<'a> Parser<'a> {
                                  self.check_keyword(keywords::For) ||
                                  self.check(&token::OpenDelim(token::Paren));
             if is_bound_start {
+                let lo = self.span;
                 let has_parens = self.eat(&token::OpenDelim(token::Paren));
                 let question = if self.eat(&token::Question) { Some(self.prev_span) } else { None };
                 if self.token.is_lifetime() {
@@ -4883,10 +4884,15 @@ impl<'a> Parser<'a> {
                                       "`?` may only modify trait bounds, not lifetime bounds");
                     }
                     bounds.push(RegionTyParamBound(self.expect_lifetime()));
+                    if has_parens {
+                        self.expect(&token::CloseDelim(token::Paren))?;
+                    }
                 } else {
-                    let lo = self.span;
                     let lifetime_defs = self.parse_late_bound_lifetime_defs()?;
                     let path = self.parse_path(PathStyle::Type)?;
+                    if has_parens {
+                        self.expect(&token::CloseDelim(token::Paren))?;
+                    }
                     let poly_trait = PolyTraitRef::new(lifetime_defs, path, lo.to(self.prev_span));
                     let modifier = if question.is_some() {
                         TraitBoundModifier::Maybe
@@ -4896,7 +4902,6 @@ impl<'a> Parser<'a> {
                     bounds.push(TraitTyParamBound(poly_trait, modifier));
                 }
                 if has_parens {
-                    self.expect(&token::CloseDelim(token::Paren))?;
                     if let Some(&RegionTyParamBound(..)) = bounds.last() {
                         self.span_err(self.prev_span,
                                       "parenthesized lifetime bounds are not supported");

--- a/src/test/ui/maybe-bounds.rs
+++ b/src/test/ui/maybe-bounds.rs
@@ -10,7 +10,7 @@
 
 trait Tr: ?Sized {} //~ ERROR `?Trait` is not permitted in supertraits
 
-type A1 = Tr + ?Sized; //~ ERROR `?Trait` is not permitted in trait object types
-type A2 = for<'a> Tr + ?Sized; //~ ERROR `?Trait` is not permitted in trait object types
+type A1 = Tr + (?Sized); //~ ERROR `?Trait` is not permitted in trait object types
+type A2 = for<'a> Tr + (?Sized); //~ ERROR `?Trait` is not permitted in trait object types
 
 fn main() {}

--- a/src/test/ui/maybe-bounds.stderr
+++ b/src/test/ui/maybe-bounds.stderr
@@ -9,14 +9,14 @@ LL | trait Tr: ?Sized {} //~ ERROR `?Trait` is not permitted in supertraits
 error: `?Trait` is not permitted in trait object types
   --> $DIR/maybe-bounds.rs:13:16
    |
-LL | type A1 = Tr + ?Sized; //~ ERROR `?Trait` is not permitted in trait object types
-   |                ^^^^^^
+LL | type A1 = Tr + (?Sized); //~ ERROR `?Trait` is not permitted in trait object types
+   |                ^^^^^^^^
 
 error: `?Trait` is not permitted in trait object types
   --> $DIR/maybe-bounds.rs:14:24
    |
-LL | type A2 = for<'a> Tr + ?Sized; //~ ERROR `?Trait` is not permitted in trait object types
-   |                        ^^^^^^
+LL | type A2 = for<'a> Tr + (?Sized); //~ ERROR `?Trait` is not permitted in trait object types
+   |                        ^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/maybe-bounds.stderr
+++ b/src/test/ui/maybe-bounds.stderr
@@ -1,22 +1,22 @@
 error: `?Trait` is not permitted in supertraits
-  --> $DIR/maybe-bounds.rs:11:12
+  --> $DIR/maybe-bounds.rs:11:11
    |
 LL | trait Tr: ?Sized {} //~ ERROR `?Trait` is not permitted in supertraits
-   |            ^^^^^
+   |           ^^^^^^
    |
    = note: traits are `?Sized` by default
 
 error: `?Trait` is not permitted in trait object types
-  --> $DIR/maybe-bounds.rs:13:17
+  --> $DIR/maybe-bounds.rs:13:16
    |
 LL | type A1 = Tr + ?Sized; //~ ERROR `?Trait` is not permitted in trait object types
-   |                 ^^^^^
+   |                ^^^^^^
 
 error: `?Trait` is not permitted in trait object types
-  --> $DIR/maybe-bounds.rs:14:25
+  --> $DIR/maybe-bounds.rs:14:24
    |
 LL | type A2 = for<'a> Tr + ?Sized; //~ ERROR `?Trait` is not permitted in trait object types
-   |                         ^^^^^
+   |                        ^^^^^^
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
The motivation of this PR is to fix a bug in rustfmt (cc https://github.com/rust-lang-nursery/rustfmt/issues/2630).