### PR TITLE
Implement size_hint for several unicode-based iterators.

### DIFF
--- a/src/libcore/char/mod.rs
+++ b/src/libcore/char/mod.rs
@@ -404,10 +404,16 @@ impl Iterator for ToLowercase {
     fn next(&mut self) -> Option<char> {
         self.0.next()
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl FusedIterator for ToLowercase {}
+
+#[unstable(feature = "exact_unicode_iters", issue = "0")]
+impl ExactSizeIterator for ToLowercase {}
 
 /// Returns an iterator that yields the uppercase equivalent of a `char`.
 ///
@@ -426,10 +432,16 @@ impl Iterator for ToUppercase {
     fn next(&mut self) -> Option<char> {
         self.0.next()
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl FusedIterator for ToUppercase {}
+
+#[unstable(feature = "exact_unicode_iters", issue = "0")]
+impl ExactSizeIterator for ToUppercase {}
 
 #[derive(Debug, Clone)]
 enum CaseMappingIter {
@@ -472,7 +484,25 @@ impl Iterator for CaseMappingIter {
             CaseMappingIter::Zero => None,
         }
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match *self {
+            CaseMappingIter::Three(_, _, _) => {
+                (3, Some(3))
+            }
+            CaseMappingIter::Two(_, _) => {
+                (2, Some(2))
+            }
+            CaseMappingIter::One(_) => {
+                (1, Some(1))
+            }
+            CaseMappingIter::Zero => (0, Some(0))
+        }
+    }
 }
+
+impl FusedIterator for CaseMappingIter {}
+
+impl ExactSizeIterator for CaseMappingIter {}
 
 impl fmt::Display for CaseMappingIter {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/libcore/char/mod.rs
+++ b/src/libcore/char/mod.rs
@@ -412,7 +412,6 @@ impl Iterator for ToLowercase {
 #[stable(feature = "fused", since = "1.26.0")]
 impl FusedIterator for ToLowercase {}
 
-#[unstable(feature = "exact_unicode_iters", issue = "0")]
 impl ExactSizeIterator for ToLowercase {}
 
 /// Returns an iterator that yields the uppercase equivalent of a `char`.
@@ -440,7 +439,6 @@ impl Iterator for ToUppercase {
 #[stable(feature = "fused", since = "1.26.0")]
 impl FusedIterator for ToUppercase {}
 
-#[unstable(feature = "exact_unicode_iters", issue = "0")]
 impl ExactSizeIterator for ToUppercase {}
 
 #[derive(Debug, Clone)]

--- a/src/libcore/str/lossy.rs
+++ b/src/libcore/str/lossy.rs
@@ -146,7 +146,11 @@ impl<'a> Iterator for Utf8LossyChunksIter<'a> {
             broken: &[],
         };
         self.source = &[];
-        return Some(r);
+        Some(r)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(self.source.len()))
     }
 }
 
@@ -176,6 +180,8 @@ impl fmt::Display for Utf8Lossy {
         Ok(())
     }
 }
+
+impl FusedIterator for Utf8LossyChunksIter {}
 
 impl fmt::Debug for Utf8Lossy {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/libcore/str/lossy.rs
+++ b/src/libcore/str/lossy.rs
@@ -151,6 +151,8 @@ impl<'a> Iterator for Utf8LossyChunksIter<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
+        // We might return no characters (we encounter an error).
+        // We will return the most characters when the input is all ASCII.
         (0, Some(self.source.len()))
     }
 }

--- a/src/libcore/str/lossy.rs
+++ b/src/libcore/str/lossy.rs
@@ -13,6 +13,7 @@ use str as core_str;
 use fmt;
 use fmt::Write;
 use mem;
+use iter::FusedIterator;
 
 /// Lossy UTF-8 string.
 #[unstable(feature = "str_internals", issue = "0")]
@@ -181,7 +182,7 @@ impl fmt::Display for Utf8Lossy {
     }
 }
 
-impl FusedIterator for Utf8LossyChunksIter {}
+impl<'a> FusedIterator for Utf8LossyChunksIter<'a> {}
 
 impl fmt::Debug for Utf8Lossy {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -4316,6 +4316,10 @@ impl<'a> Iterator for SplitWhitespace<'a> {
     fn next(&mut self) -> Option<&'a str> {
         self.inner.next()
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
 }
 
 #[stable(feature = "split_whitespace", since = "1.1.0")]


### PR DESCRIPTION
This continues work on issue #49205.

This PR also implements ExactSizeIterator and FusedIterator where
they make sense.

I didn't know what to put for the issue number when making the [unstable] annotation, so I put 0 as a placeholder.