### PR TITLE
Make `Vec::new` a `const fn`

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -123,6 +123,7 @@
 #![feature(pointer_methods)]
 #![feature(inclusive_range_fields)]
 #![cfg_attr(stage0, feature(generic_param_attrs))]
+#![feature(rustc_const_unstable)]
 
 #![cfg_attr(not(test), feature(fn_traits, i128))]
 #![cfg_attr(test, feature(test))]

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -65,7 +65,7 @@ impl<T, A: Alloc> RawVec<T, A> {
         RawVec {
             ptr: Unique::empty(),
             // FIXME(mark-i-m): use `cap` when ifs are allowed in const
-            cap: [0, !0][(mem::size_of::<T>() != 0) as usize],
+            cap: [0, !0][(mem::size_of::<T>() == 0) as usize],
             a,
         }
     }

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -54,6 +54,7 @@ pub struct RawVec<T, A: Alloc = Global> {
 }
 
 impl<T, A: Alloc> RawVec<T, A> {
+    // FIXME: this should be made `const` when `if` statements are allowed
     /// Like `new` but parameterized over the choice of allocator for
     /// the returned RawVec.
     pub fn new_in(a: A) -> Self {
@@ -68,6 +69,7 @@ impl<T, A: Alloc> RawVec<T, A> {
         }
     }
 
+    // FIXME: this should removed when `new_in` can be made `const`
     /// Like `empty` but parametrized over the choice of allocator for the returned `RawVec`.
     pub const fn empty_in(a: A) -> Self {
         // Unique::empty() doubles as "unallocated" and "zero-sized allocation"
@@ -134,9 +136,10 @@ impl<T> RawVec<T, Global> {
         Self::new_in(Global)
     }
 
+    // FIXME: this should removed when `new` can be made `const`
     /// Create a `RawVec` with capcity 0 (on the system heap), regardless of `T`, without
     /// allocating.
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         Self::empty_in(Global)
     }
 

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -68,6 +68,16 @@ impl<T, A: Alloc> RawVec<T, A> {
         }
     }
 
+    /// Like `empty` but parametrized over the choice of allocator for the returned `RawVec`.
+    pub const fn empty_in(a: A) -> Self {
+        // Unique::empty() doubles as "unallocated" and "zero-sized allocation"
+        RawVec {
+            ptr: Unique::empty(),
+            cap: 0,
+            a,
+        }
+    }
+
     /// Like `with_capacity` but parameterized over the choice of
     /// allocator for the returned RawVec.
     #[inline]
@@ -122,6 +132,12 @@ impl<T> RawVec<T, Global> {
     /// delayed allocation.
     pub fn new() -> Self {
         Self::new_in(Global)
+    }
+
+    /// Create a `RawVec` with capcity 0 (on the system heap), regardless of `T`, without
+    /// allocating.
+    pub fn empty() -> Self {
+        Self::empty_in(Global)
     }
 
     /// Creates a RawVec (on the system heap) with exactly the

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -324,7 +324,7 @@ impl<T> Vec<T> {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn new() -> Vec<T> {
         Vec {
-            buf: RawVec::new(),
+            buf: RawVec::empty(),
             len: 0,
         }
     }

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -325,7 +325,7 @@ impl<T> Vec<T> {
     #[rustc_const_unstable(feature = "const_vec_new")]
     pub const fn new() -> Vec<T> {
         Vec {
-            buf: RawVec::empty(),
+            buf: RawVec::new(),
             len: 0,
         }
     }

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -322,7 +322,7 @@ impl<T> Vec<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn new() -> Vec<T> {
+    pub const fn new() -> Vec<T> {
         Vec {
             buf: RawVec::empty(),
             len: 0,

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -322,6 +322,7 @@ impl<T> Vec<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_const_unstable(feature = "const_vec_new")]
     pub const fn new() -> Vec<T> {
         Vec {
             buf: RawVec::empty(),

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2551,10 +2551,9 @@ impl<T: Sized> Unique<T> {
     /// This is useful for initializing types which lazily allocate, like
     /// `Vec::new` does.
     // FIXME: rename to dangling() to match NonNull?
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         unsafe {
-            let ptr = mem::align_of::<T>() as *mut T;
-            Unique::new_unchecked(ptr)
+            Unique::new_unchecked(mem::align_of::<T>() as *mut T)
         }
     }
 }

--- a/src/test/run-pass/vec-const-new.rs
+++ b/src/test/run-pass/vec-const-new.rs
@@ -10,6 +10,8 @@
 
 // Test that Vec::new() can be used for constants
 
+#![feature(const_vec_new)]
+
 const MY_VEC: Vec<usize> = Vec::new();
 
 pub fn main() {}

--- a/src/test/run-pass/vec-const-new.rs
+++ b/src/test/run-pass/vec-const-new.rs
@@ -1,0 +1,15 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that Vec::new() can be used for constants
+
+const MY_VEC: Vec<usize> = Vec::new();
+
+pub fn main() {}


### PR DESCRIPTION
`RawVec::empty/_in` are a hack. They're there because `if size_of::<T> == 0 { !0 } else { 0 }` is not allowed in `const` yet. However, because `RawVec` is unstable, the `empty/empty_in` constructors can be removed when #49146 is done...