### PR TITLE
Add implementation of Extend for ()

### DIFF
--- a/src/libcore/iter/traits.rs
+++ b/src/libcore/iter/traits.rs
@@ -352,6 +352,13 @@ pub trait Extend<A> {
     fn extend<T: IntoIterator<Item=A>>(&mut self, iter: T);
 }
 
+#[stable(feature = "extend_for_unit", since = "1.28.0")]
+impl Extend<()> for () {
+    fn extend<T: IntoIterator<Item = ()>>(&mut self, iter: T) {
+        iter.into_iter().for_each(drop)
+    }
+}
+
 /// An iterator able to yield elements from both ends.
 ///
 /// Something that implements `DoubleEndedIterator` has one extra capability

--- a/src/test/run-pass/extend-for-unit.rs
+++ b/src/test/run-pass/extend-for-unit.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    let mut x = 0;
+    {
+        let iter = (0..5).map(|_| {
+            x += 1;
+        });
+        ().extend(iter);
+    }
+    assert_eq!(x, 5);
+}


### PR DESCRIPTION
This is useful in some generic code which wants to collect iterators of items into a result.