### PR TITLE
Make dump_{alloc,allocs,local}() no-ops when tracing is disabled.

### DIFF
--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -749,9 +749,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M
             }
         }
 
-        if log_enabled!(::log::Level::Trace) {
-            self.dump_local(dest);
-        }
+        self.dump_local(dest);
 
         Ok(())
     }
@@ -1538,6 +1536,9 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M
 
     pub fn dump_local(&self, place: Place) {
         // Debug output
+        if !log_enabled!(::log::Level::Trace) {
+            return;
+        }
         match place {
             Place::Local { frame, local } => {
                 let mut allocs = Vec::new();

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -334,11 +334,17 @@ impl<'a, 'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'a, 'mir, 'tcx, M> {
 
     /// For debugging, print an allocation and all allocations it points to, recursively.
     pub fn dump_alloc(&self, id: AllocId) {
+        if !log_enabled!(::log::Level::Trace) {
+            return;
+        }
         self.dump_allocs(vec![id]);
     }
 
     /// For debugging, print a list of allocations and all allocations they point to, recursively.
     pub fn dump_allocs(&self, mut allocs: Vec<AllocId>) {
+        if !log_enabled!(::log::Level::Trace) {
+            return;
+        }
         use std::fmt::Write;
         allocs.sort();
         allocs.dedup();

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -218,9 +218,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> {
             }
         };
 
-        if log_enabled!(::log::Level::Trace) {
-            self.dump_local(place);
-        }
+        self.dump_local(place);
 
         Ok(place)
     }


### PR DESCRIPTION
Because they traverse data structures and build up strings, which is
wasted effort if those strings aren't printed.

The patch also removes some now-unnecessary log_enabled! tests at call
sites.

This is a big win for the Debug and Opt runs of coercions, tuple-stress, html5ever, and encoding.
```
coercions-opt
        avg: -7.8%      min: -14.8%     max: 0.1%
coercions
        avg: -8.0%      min: -12.8%     max: 0.1%
tuple-stress
        avg: -7.2%      min: -10.8%     max: -0.7%
tuple-stress-opt
        avg: -6.9%      min: -10.7%     max: 0.6%
html5ever
        avg: -4.6%      min: -7.3%      max: -0.3%
encoding
        avg: -2.4%      min: -4.5%      max: 0.1%
html5ever-opt
        avg: -2.7%      min: -4.2%      max: -0.2%
encoding-opt
        avg: -1.4%      min: -2.4%      max: 0.0%
```