### PR TITLE
rustc: Disable threads in LLD for wasm

### DIFF
--- a/src/librustc_trans/back/linker.rs
+++ b/src/librustc_trans/back/linker.rs
@@ -959,7 +959,11 @@ impl Linker for WasmLd {
     }
 
     fn finalize(&mut self) -> Command {
-        self.cmd.arg("--threads");
+        // There have been reports in the wild (rustwasm/wasm-bindgen#119) of
+        // using threads causing weird hangs and bugs. Disable it entirely as
+        // this isn't yet the bottleneck of compilation at all anyway.
+        self.cmd.arg("--no-threads");
+
         self.cmd.arg("-z").arg("stack-size=1048576");
 
         // FIXME we probably shouldn't pass this but instead pass an explicit


### PR DESCRIPTION
Upstream bug reports (rustwasm/wasm-bindgen#119) show that this may be the
culprit of odd crashes/hangs. The linker is a tiny fraction of build time anyway
right now so let's disable it and figure out how to possibly reenable it later
if necessary.