### PR TITLE
[beta] Remove dependency on `parking_lot`

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1691,8 +1691,6 @@ dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ena 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "serialize 0.0.0",
  "stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/ci/docker/x86_64-gnu-debug/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-debug/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV PARALLEL_CHECK 1
 ENV RUST_CONFIGURE_ARGS \
       --build=x86_64-unknown-linux-gnu \
       --enable-debug \

--- a/src/librustc_data_structures/Cargo.toml
+++ b/src/librustc_data_structures/Cargo.toml
@@ -14,8 +14,3 @@ log = "0.4"
 serialize = { path = "../libserialize" }
 cfg-if = "0.1.2"
 stable_deref_trait = "1.0.0"
-parking_lot_core = "0.2.8"
-
-[dependencies.parking_lot]
-version = "0.5"
-features = ["nightly"]

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -45,7 +45,6 @@ extern crate log;
 extern crate serialize as rustc_serialize; // used by deriving
 #[cfg(unix)]
 extern crate libc;
-extern crate parking_lot;
 #[macro_use]
 extern crate cfg_if;
 extern crate stable_deref_trait;


### PR DESCRIPTION
Unfortunately the `parking_lot` crate enables the `synchapi` feature of the
`winapi` crate which activates a dependency on `libsynchronization.a`. The MinGW
version of `libsynchronization.a` pulls in a dependency
`api-ms-core-synch-l1-2-0.dll` which causes rustc to not work on Windows 7
(tracked in #49438)

The `parking_lot` crate is not currently used in the compiler unless parallel
queries are enabled. This feature is not enabled by default and not used at all
in the beta/stable compilers. As a result the dependency in this commit was
removed and the CI build which checks parallel queries was disabled.

This isn't a great long-term solution but should hopefully be enough of a patch
for beta to buy us some more time to figure this out.