### PR TITLE
Fix ICE #48984

### DIFF
--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -977,7 +977,13 @@ impl<'a, 'tcx> CrateMetadata {
     }
 
     pub fn get_trait_of_item(&self, id: DefIndex) -> Option<DefId> {
-        self.def_key(id).parent.and_then(|parent_index| {
+        let def_key = self.def_key(id);
+        match def_key.disambiguated_data.data {
+            DefPathData::TypeNs(..) | DefPathData::ValueNs(..) => (),
+            // Not an associated item
+            _ => return None,
+        }
+        def_key.parent.and_then(|parent_index| {
             match self.entry(parent_index).kind {
                 EntryKind::Trait(_) => Some(self.local_def_id(parent_index)),
                 _ => None,

--- a/src/test/run-pass/auxiliary/issue-48984-aux.rs
+++ b/src/test/run-pass/auxiliary/issue-48984-aux.rs
@@ -1,0 +1,16 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "lib"]
+#![crate_name = "issue48984aux"]
+
+pub trait Foo { type Item; }
+
+pub trait Bar: Foo<Item=[u8;1]> {  }

--- a/src/test/run-pass/issue-48984.rs
+++ b/src/test/run-pass/issue-48984.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-48984-aux.rs
+extern crate issue48984aux;
+use issue48984aux::Bar;
+
+fn do_thing<T: Bar>() { }
+
+fn main() { }


### PR DESCRIPTION
* ~~fbf6423  The tail type was not normalized.~~
* https://github.com/rust-lang/rust/commit/d0839d5680d2a51785eeb0811cf3e2beba90eacb  The method had a wrong assumption that something whose parent is a trait is an associated item. Fixes #48984.