### PR TITLE
Add a ui test for an incorrect Result success type in a #[test]

### DIFF
--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.rs
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --test
+
+#![feature(termination_trait_test)]
+
+use std::num::ParseIntError;
+
+#[test]
+fn can_parse_zero_as_f32() -> Result<f32, ParseIntError> { //~ ERROR
+    "0".parse()
+}

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
@@ -1,0 +1,14 @@
+error[E0277]: `main` has invalid return type `std::result::Result<f32, std::num::ParseIntError>`
+  --> $DIR/termination-trait-test-wrong-type.rs:18:1
+   |
+LL | / fn can_parse_zero_as_f32() -> Result<f32, ParseIntError> { //~ ERROR
+LL | |     "0".parse()
+LL | | }
+   | |_^ `main` can only return types that implement `std::process::Termination`
+   |
+   = help: the trait `std::process::Termination` is not implemented for `std::result::Result<f32, std::num::ParseIntError>`
+   = note: required by `__test::test::assert_test_result`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/issues/48854#issuecomment-384730601
r? @nikomatsakis 