### PR TITLE
Add inline attributes to syntax_pos

### DIFF
--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -53,6 +53,7 @@ pub enum MarkKind {
 }
 
 impl Mark {
+    #[inline]
     pub fn fresh(parent: Mark) -> Self {
         HygieneData::with(|data| {
             data.marks.push(MarkData { parent: parent, kind: MarkKind::Legacy, expn_info: None });
@@ -171,6 +172,7 @@ impl HygieneData {
         }
     }
 
+    #[inline]
     fn with<T, F: FnOnce(&mut HygieneData) -> T>(f: F) -> T {
         GLOBALS.with(|globals| f(&mut *globals.hygiene_data.borrow_mut()))
     }
@@ -181,6 +183,7 @@ pub fn clear_markings() {
 }
 
 impl SyntaxContext {
+    #[inline]
     pub const fn empty() -> Self {
         SyntaxContext(0)
     }
@@ -450,6 +453,7 @@ pub struct NameAndSpan {
 }
 
 impl NameAndSpan {
+    #[inline]
     pub fn name(&self) -> Symbol {
         match self.format {
             ExpnFormat::MacroAttribute(s) |
@@ -479,6 +483,7 @@ pub enum CompilerDesugaringKind {
 }
 
 impl CompilerDesugaringKind {
+    #[inline]
     pub fn as_symbol(&self) -> Symbol {
         use CompilerDesugaringKind::*;
         let s = match *self {
@@ -491,18 +496,21 @@ impl CompilerDesugaringKind {
 }
 
 impl Encodable for SyntaxContext {
+    #[inline]
     fn encode<E: Encoder>(&self, _: &mut E) -> Result<(), E::Error> {
         Ok(()) // FIXME(jseyfried) intercrate hygiene
     }
 }
 
 impl Decodable for SyntaxContext {
+    #[inline]
     fn decode<D: Decoder>(_: &mut D) -> Result<SyntaxContext, D::Error> {
         Ok(SyntaxContext::empty()) // FIXME(jseyfried) intercrate hygiene
     }
 }
 
 impl Symbol {
+    #[inline]
     pub fn from_ident(ident: Ident) -> Symbol {
         HygieneData::with(|data| {
             let gensym = ident.name.gensymed();
@@ -511,6 +519,7 @@ impl Symbol {
         })
     }
 
+    #[inline]
     pub fn to_ident(self) -> Ident {
         HygieneData::with(|data| {
             match data.gensym_to_ctxt.get(&self) {

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -191,11 +191,13 @@ impl !Send for Span {}
 impl !Sync for Span {}
 
 impl PartialOrd for Span {
+    #[inline]
     fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
         PartialOrd::partial_cmp(&self.data(), &rhs.data())
     }
 }
 impl Ord for Span {
+    #[inline]
     fn cmp(&self, rhs: &Self) -> Ordering {
         Ord::cmp(&self.data(), &rhs.data())
     }
@@ -253,11 +255,13 @@ impl Span {
     }
 
     /// Returns `self` if `self` is not the dummy span, and `other` otherwise.
+    #[inline]
     pub fn substitute_dummy(self, other: Span) -> Span {
         if self.source_equal(&DUMMY_SP) { other } else { self }
     }
 
     /// Return true if `self` fully encloses `other`.
+    #[inline]
     pub fn contains(self, other: Span) -> bool {
         let span = self.data();
         let other = other.data();
@@ -268,6 +272,7 @@ impl Span {
     ///
     /// Use this instead of `==` when either span could be generated code,
     /// and you only care that they point to the same bytes of source text.
+    #[inline]
     pub fn source_equal(&self, other: &Span) -> bool {
         let span = self.data();
         let other = other.data();
@@ -275,6 +280,7 @@ impl Span {
     }
 
     /// Returns `Some(span)`, where the start is trimmed by the end of `other`
+    #[inline]
     pub fn trim_start(self, other: Span) -> Option<Span> {
         let span = self.data();
         let other = other.data();
@@ -406,6 +412,7 @@ impl Span {
     }
 
     /// Return a `Span` between the end of `self` to the beginning of `end`.
+    #[inline]
     pub fn between(self, end: Span) -> Span {
         let span = self.data();
         let end = end.data();
@@ -417,6 +424,7 @@ impl Span {
     }
 
     /// Return a `Span` between the beginning of `self` to the beginning of `end`.
+    #[inline]
     pub fn until(self, end: Span) -> Span {
         let span = self.data();
         let end = end.data();
@@ -488,6 +496,7 @@ pub struct SpanLabel {
 }
 
 impl Default for Span {
+    #[inline]
     fn default() -> Self {
         DUMMY_SP
     }
@@ -539,6 +548,7 @@ impl fmt::Debug for SpanData {
 }
 
 impl MultiSpan {
+    #[inline]
     pub fn new() -> MultiSpan {
         MultiSpan {
             primary_spans: vec![],
@@ -546,6 +556,7 @@ impl MultiSpan {
         }
     }
 
+    #[inline]
     pub fn from_span(primary_span: Span) -> MultiSpan {
         MultiSpan {
             primary_spans: vec![primary_span],
@@ -553,6 +564,7 @@ impl MultiSpan {
         }
     }
 
+    #[inline]
     pub fn from_spans(vec: Vec<Span>) -> MultiSpan {
         MultiSpan {
             primary_spans: vec,
@@ -560,16 +572,19 @@ impl MultiSpan {
         }
     }
 
+    #[inline]
     pub fn push_span_label(&mut self, span: Span, label: String) {
         self.span_labels.push((span, label));
     }
 
     /// Selects the first primary span (if any)
+    #[inline]
     pub fn primary_span(&self) -> Option<Span> {
         self.primary_spans.first().cloned()
     }
 
     /// Returns all primary spans.
+    #[inline]
     pub fn primary_spans(&self) -> &[Span] {
         &self.primary_spans
     }
@@ -625,12 +640,14 @@ impl MultiSpan {
 }
 
 impl From<Span> for MultiSpan {
+    #[inline]
     fn from(span: Span) -> MultiSpan {
         MultiSpan::from_span(span)
     }
 }
 
 impl From<Vec<Span>> for MultiSpan {
+    #[inline]
     fn from(spans: Vec<Span>) -> MultiSpan {
         MultiSpan::from_spans(spans)
     }
@@ -659,6 +676,7 @@ pub enum NonNarrowChar {
 }
 
 impl NonNarrowChar {
+    #[inline]
     fn new(pos: BytePos, width: usize) -> Self {
         match width {
             0 => NonNarrowChar::ZeroWidth(pos),
@@ -669,6 +687,7 @@ impl NonNarrowChar {
     }
 
     /// Returns the absolute offset of the character in the CodeMap
+    #[inline]
     pub fn pos(&self) -> BytePos {
         match *self {
             NonNarrowChar::ZeroWidth(p) |
@@ -678,6 +697,7 @@ impl NonNarrowChar {
     }
 
     /// Returns the width of the character, 0 (zero-width) or 2 (wide)
+    #[inline]
     pub fn width(&self) -> usize {
         match *self {
             NonNarrowChar::ZeroWidth(_) => 0,
@@ -690,6 +710,7 @@ impl NonNarrowChar {
 impl Add<BytePos> for NonNarrowChar {
     type Output = Self;
 
+    #[inline]
     fn add(self, rhs: BytePos) -> Self {
         match self {
             NonNarrowChar::ZeroWidth(pos) => NonNarrowChar::ZeroWidth(pos + rhs),
@@ -702,6 +723,7 @@ impl Add<BytePos> for NonNarrowChar {
 impl Sub<BytePos> for NonNarrowChar {
     type Output = Self;
 
+    #[inline]
     fn sub(self, rhs: BytePos) -> Self {
         match self {
             NonNarrowChar::ZeroWidth(pos) => NonNarrowChar::ZeroWidth(pos - rhs),
@@ -962,6 +984,7 @@ impl FileMap {
     /// and CodeMap will append a newline when adding a filemap without a newline at the end,
     /// so the safe way to call this is with value calculated as
     /// filemap.start_pos + newline_offset_relative_to_the_start_of_filemap.
+    #[inline]
     pub fn next_line(&self, pos: BytePos) {
         // the new charpos must be > the last one (or it's the first one).
         let mut lines = self.lines.borrow_mut();
@@ -1037,6 +1060,7 @@ impl FileMap {
         }
     }
 
+    #[inline]
     pub fn record_multibyte_char(&self, pos: BytePos, bytes: usize) {
         assert!(bytes >=2 && bytes <= 4);
         let mbc = MultiByteChar {
@@ -1046,6 +1070,7 @@ impl FileMap {
         self.multibyte_chars.borrow_mut().push(mbc);
     }
 
+    #[inline]
     pub fn record_width(&self, pos: BytePos, ch: char) {
         let width = match ch {
             '\t' =>
@@ -1176,12 +1201,14 @@ impl Sub for BytePos {
 }
 
 impl Encodable for BytePos {
+    #[inline]
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         s.emit_u32(self.0)
     }
 }
 
 impl Decodable for BytePos {
+    #[inline]
     fn decode<D: Decoder>(d: &mut D) -> Result<BytePos, D::Error> {
         Ok(BytePos(d.read_u32()?))
     }

--- a/src/libsyntax_pos/span_encoding.rs
+++ b/src/libsyntax_pos/span_encoding.rs
@@ -31,11 +31,13 @@ pub struct Span(u32);
 
 impl Copy for Span {}
 impl Clone for Span {
+    #[inline]
     fn clone(&self) -> Span {
         *self
     }
 }
 impl PartialEq for Span {
+    #[inline]
     fn eq(&self, other: &Span) -> bool {
         let a = self.0;
         let b = other.0;
@@ -44,6 +46,7 @@ impl PartialEq for Span {
 }
 impl Eq for Span {}
 impl Hash for Span {
+    #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         let a = self.0;
         a.hash(state)
@@ -139,6 +142,7 @@ pub struct SpanInterner {
 }
 
 impl SpanInterner {
+    #[inline]
     fn intern(&mut self, span_data: &SpanData) -> u32 {
         if let Some(index) = self.spans.get(span_data) {
             return *index;


### PR DESCRIPTION
The existing `impl PartialOrd<InternedString> for InternedString` causes an error in some of my branches for some reason...