### PR TITLE
std: Inline `DefaultResizePolicy::new`

### DIFF
--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -33,6 +33,7 @@ const MIN_NONZERO_RAW_CAPACITY: usize = 32;     // must be a power of two
 struct DefaultResizePolicy;
 
 impl DefaultResizePolicy {
+    #[inline]
     fn new() -> DefaultResizePolicy {
         DefaultResizePolicy
     }


### PR DESCRIPTION
This should allow us to tighten up the [codegen][example] a bit more, avoiding a
function call across object boundaries in the default optimized case.

[example]: https://play.rust-lang.org/?gist=c1179088b0f8a4dcd93a9906463f993d&version=stable&mode=release