### PR TITLE
Create ResolvePath abstraction in librustc_resolve

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2839,7 +2839,8 @@ impl<'a> Resolver<'a> {
                 let item_span = path.ident[path.ident.len() - 1].span;
                 let (mod_prefix, mod_str) = if path.ident.len() == 1 {
                     (format!(""), format!("this scope"))
-                } else if path.ident.len() == 2 && path.ident[0].name == keywords::CrateRoot.name() {
+                } else if path.ident.len() == 2 &&
+                          path.ident[0].name == keywords::CrateRoot.name() {
                     (format!(""), format!("the crate root"))
                 } else {
                     let mod_path = ResolvePath {
@@ -3176,7 +3177,8 @@ impl<'a> Resolver<'a> {
                                    source : Some(id),
                                    speculative : false,
                                };
-            let res = self.smart_resolve_path_fragment(id, None, &resolve_path, span, PathSource::TraitItem(ns));
+            let res = self.smart_resolve_path_fragment(id, None, &resolve_path,
+                                                       span, PathSource::TraitItem(ns));
             return Some(PathResolution::with_unresolved_segments(
                 res.base_def(), res.unresolved_segments() + path.ident.len() - qself.position - 1
             ));
@@ -3243,10 +3245,7 @@ impl<'a> Resolver<'a> {
                     path: &ResolvePath,
                     opt_ns: Option<Namespace>, // `None` indicates a module path
                     record_used: bool,
-                    path_span: Span)//,
-                    //node_id: Option<NodeId>) // None indicates that we don't care about linting
-                                             // `::module` paths
-                    -> PathResult<'a> {
+                    path_span: Span) -> PathResult<'a> {
         let mut module = None;
         let mut allow_super = true;
 

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -84,6 +84,13 @@ mod check_unused;
 mod build_reduced_graph;
 mod resolve_imports;
 
+pub struct ResolvePath<'a>
+{
+    ident : &'a [Ident],
+    source : Option<NodeId>,    // None if this path is speculative
+    speculative : bool,
+}
+
 /// A free importable items suggested in case of resolution failure.
 struct ImportSuggestion {
     path: Path,
@@ -1654,12 +1661,18 @@ impl<'a> Resolver<'a> {
         let path: Vec<Ident> = segments.iter()
             .map(|seg| Ident::new(seg.name, span))
             .collect();
+
+        let resolve_path = ResolvePath {
+                               ident : &path,
+                               source : None,
+                               speculative : true,
+                           };
         // FIXME (Manishearth): Intra doc links won't get warned of epoch changes
-        match self.resolve_path(&path, Some(namespace), true, span, None) {
+        match self.resolve_path(&resolve_path, Some(namespace), true, span) {
             PathResult::Module(module) => *def = module.def().unwrap(),
             PathResult::NonModule(path_res) if path_res.unresolved_segments() == 0 =>
                 *def = path_res.base_def(),
-            PathResult::NonModule(..) => match self.resolve_path(&path, None, true, span, None) {
+            PathResult::NonModule(..) => match self.resolve_path(&resolve_path, None, true, span) {
                 PathResult::Failed(span, msg, _) => {
                     error_callback(self, span, ResolutionError::FailedToResolve(&msg));
                 }
@@ -2351,6 +2364,11 @@ impl<'a> Resolver<'a> {
             let path: Vec<_> = trait_ref.path.segments.iter()
                 .map(|seg| seg.ident)
                 .collect();
+            let path = ResolvePath {
+                           ident : &path,
+                           source : Some(trait_ref.ref_id),
+                           speculative : false,
+                       };
             let def = self.smart_resolve_path_fragment(
                 trait_ref.ref_id,
                 None,
@@ -2361,8 +2379,7 @@ impl<'a> Resolver<'a> {
             if def != Def::Err {
                 new_id = Some(def.def_id());
                 let span = trait_ref.path.span;
-                if let PathResult::Module(module) = self.resolve_path(&path, None, false, span,
-                                                                      Some(trait_ref.ref_id)) {
+                if let PathResult::Module(module) = self.resolve_path(&path, None, false, span) {
                     new_val = Some((module, trait_ref.clone()));
                 }
             }
@@ -2787,17 +2804,22 @@ impl<'a> Resolver<'a> {
         let segments = &path.segments.iter()
             .map(|seg| seg.ident)
             .collect::<Vec<_>>();
-        self.smart_resolve_path_fragment(id, qself, segments, path.span, source)
+        let resolve_path = ResolvePath {
+                               ident : &segments,
+                               source : Some(id),
+                               speculative : false,
+                           };
+        self.smart_resolve_path_fragment(id, qself, &resolve_path, path.span, source)
     }
 
     fn smart_resolve_path_fragment(&mut self,
                                    id: NodeId,
                                    qself: Option<&QSelf>,
-                                   path: &[Ident],
+                                   path: &ResolvePath,
                                    span: Span,
                                    source: PathSource)
                                    -> PathResolution {
-        let ident_span = path.last().map_or(span, |ident| ident.span);
+        let ident_span = path.ident.last().map_or(span, |ident| ident.span);
         let ns = source.namespace();
         let is_expected = &|def| source.is_expected(def);
         let is_enum_variant = &|def| if let Def::Variant(..) = def { true } else { false };
@@ -2806,27 +2828,31 @@ impl<'a> Resolver<'a> {
         let report_errors = |this: &mut Self, def: Option<Def>| {
             // Make the base error.
             let expected = source.descr_expected();
-            let path_str = names_to_string(path);
+            let path_str = names_to_string(path.ident);
             let code = source.error_code(def.is_some());
             let (base_msg, fallback_label, base_span) = if let Some(def) = def {
                 (format!("expected {}, found {} `{}`", expected, def.kind_name(), path_str),
                  format!("not a {}", expected),
                  span)
             } else {
-                let item_str = path[path.len() - 1];
-                let item_span = path[path.len() - 1].span;
-                let (mod_prefix, mod_str) = if path.len() == 1 {
+                let item_str = path.ident[path.ident.len() - 1];
+                let item_span = path.ident[path.ident.len() - 1].span;
+                let (mod_prefix, mod_str) = if path.ident.len() == 1 {
                     (format!(""), format!("this scope"))
-                } else if path.len() == 2 && path[0].name == keywords::CrateRoot.name() {
+                } else if path.ident.len() == 2 && path.ident[0].name == keywords::CrateRoot.name() {
                     (format!(""), format!("the crate root"))
                 } else {
-                    let mod_path = &path[..path.len() - 1];
-                    let mod_prefix = match this.resolve_path(mod_path, Some(TypeNS),
-                                                             false, span, None) {
+                    let mod_path = ResolvePath {
+                                       ident : &path.ident[..path.ident.len() - 1],
+                                       source : Some(id),
+                                       speculative : false,
+                                   };
+                    let mod_prefix = match this.resolve_path(&mod_path, Some(TypeNS),
+                                                             false, span) {
                         PathResult::Module(module) => module.def(),
                         _ => None,
                     }.map_or(format!(""), |def| format!("{} ", def.kind_name()));
-                    (mod_prefix, format!("`{}`", names_to_string(mod_path)))
+                    (mod_prefix, format!("`{}`", names_to_string(mod_path.ident)))
                 };
                 (format!("cannot find {} `{}` in {}{}", expected, item_str, mod_prefix, mod_str),
                  format!("not found in {}", mod_str),
@@ -2836,13 +2862,13 @@ impl<'a> Resolver<'a> {
             let mut err = this.session.struct_span_err_with_code(base_span, &base_msg, code);
 
             // Emit special messages for unresolved `Self` and `self`.
-            if is_self_type(path, ns) {
+            if is_self_type(path.ident, ns) {
                 __diagnostic_used!(E0411);
                 err.code(DiagnosticId::Error("E0411".into()));
                 err.span_label(span, "`Self` is only available in traits and impls");
                 return (err, Vec::new());
             }
-            if is_self_value(path, ns) {
+            if is_self_value(path.ident, ns) {
                 __diagnostic_used!(E0424);
                 err.code(DiagnosticId::Error("E0424".into()));
                 err.span_label(span, format!("`self` value is only available in \
@@ -2851,7 +2877,7 @@ impl<'a> Resolver<'a> {
             }
 
             // Try to lookup the name in more relaxed fashion for better error reporting.
-            let ident = *path.last().unwrap();
+            let ident = *path.ident.last().unwrap();
             let candidates = this.lookup_import_candidates(ident.name, ns, is_expected);
             if candidates.is_empty() && is_expected(Def::Enum(DefId::local(CRATE_DEF_INDEX))) {
                 let enum_candidates =
@@ -2872,9 +2898,9 @@ impl<'a> Resolver<'a> {
                     }
                 }
             }
-            if path.len() == 1 && this.self_type_is_available(span) {
+            if path.ident.len() == 1 && this.self_type_is_available(span) {
                 if let Some(candidate) = this.lookup_assoc_candidate(ident, ns, is_expected) {
-                    let self_is_available = this.self_value_is_available(path[0].span, span);
+                    let self_is_available = this.self_value_is_available(path.ident[0].span, span);
                     match candidate {
                         AssocSuggestion::Field => {
                             err.span_suggestion(span, "try",
@@ -2900,7 +2926,7 @@ impl<'a> Resolver<'a> {
             let mut levenshtein_worked = false;
 
             // Try Levenshtein.
-            if let Some(candidate) = this.lookup_typo_candidate(path, ns, is_expected, span) {
+            if let Some(candidate) = this.lookup_typo_candidate(path.ident, ns, is_expected, span) {
                 err.span_label(ident_span, format!("did you mean `{}`?", candidate));
                 levenshtein_worked = true;
             }
@@ -3028,7 +3054,7 @@ impl<'a> Resolver<'a> {
                 // or `<T>::A::B`. If `B` should be resolved in value namespace then
                 // it needs to be added to the trait map.
                 if ns == ValueNS {
-                    let item_name = *path.last().unwrap();
+                    let item_name = *path.ident.last().unwrap();
                     let traits = self.get_traits_containing_item(item_name, ns);
                     self.trait_map.insert(id, traits);
                 }
@@ -3095,7 +3121,7 @@ impl<'a> Resolver<'a> {
     fn resolve_qpath_anywhere(&mut self,
                               id: NodeId,
                               qself: Option<&QSelf>,
-                              path: &[Ident],
+                              path: &ResolvePath,
                               primary_ns: Namespace,
                               span: Span,
                               defer_to_typeck: bool,
@@ -3115,10 +3141,10 @@ impl<'a> Resolver<'a> {
                 };
             }
         }
-        let is_global = self.global_macros.get(&path[0].name).cloned()
+        let is_global = self.global_macros.get(&path.ident[0].name).cloned()
             .map(|binding| binding.get_macro(self).kind() == MacroKind::Bang).unwrap_or(false);
         if primary_ns != MacroNS && (is_global ||
-                                     self.macro_names.contains(&path[0].modern())) {
+                                     self.macro_names.contains(&path.ident[0].modern())) {
             // Return some dummy definition, it's enough for error reporting.
             return Some(
                 PathResolution::new(Def::Macro(DefId::local(CRATE_DEF_INDEX), MacroKind::Bang))
@@ -3131,7 +3157,7 @@ impl<'a> Resolver<'a> {
     fn resolve_qpath(&mut self,
                      id: NodeId,
                      qself: Option<&QSelf>,
-                     path: &[Ident],
+                     path: &ResolvePath,
                      ns: Namespace,
                      span: Span,
                      global_by_default: bool)
@@ -3140,19 +3166,23 @@ impl<'a> Resolver<'a> {
             if qself.position == 0 {
                 // FIXME: Create some fake resolution that can't possibly be a type.
                 return Some(PathResolution::with_unresolved_segments(
-                    Def::Mod(DefId::local(CRATE_DEF_INDEX)), path.len()
+                    Def::Mod(DefId::local(CRATE_DEF_INDEX)), path.ident.len()
                 ));
             }
             // Make sure `A::B` in `<T as A>::B::C` is a trait item.
-            let ns = if qself.position + 1 == path.len() { ns } else { TypeNS };
-            let res = self.smart_resolve_path_fragment(id, None, &path[..qself.position + 1],
-                                                       span, PathSource::TraitItem(ns));
+            let ns = if qself.position + 1 == path.ident.len() { ns } else { TypeNS };
+            let resolve_path = ResolvePath {
+                                   ident : &path.ident[..qself.position + 1],
+                                   source : Some(id),
+                                   speculative : false,
+                               };
+            let res = self.smart_resolve_path_fragment(id, None, &resolve_path, span, PathSource::TraitItem(ns));
             return Some(PathResolution::with_unresolved_segments(
-                res.base_def(), res.unresolved_segments() + path.len() - qself.position - 1
+                res.base_def(), res.unresolved_segments() + path.ident.len() - qself.position - 1
             ));
         }
 
-        let result = match self.resolve_path(&path, Some(ns), true, span, Some(id)) {
+        let result = match self.resolve_path(&path, Some(ns), true, span) {
             PathResult::NonModule(path_res) => path_res,
             PathResult::Module(module) if !module.is_normal() => {
                 PathResolution::new(module.def().unwrap())
@@ -3170,11 +3200,11 @@ impl<'a> Resolver<'a> {
             // Such behavior is required for backward compatibility.
             // The same fallback is used when `a` resolves to nothing.
             PathResult::Module(..) | PathResult::Failed(..)
-                    if (ns == TypeNS || path.len() > 1) &&
+                    if (ns == TypeNS || path.ident.len() > 1) &&
                        self.primitive_type_table.primitive_types
-                           .contains_key(&path[0].name) => {
-                let prim = self.primitive_type_table.primitive_types[&path[0].name];
-                PathResolution::with_unresolved_segments(Def::PrimTy(prim), path.len() - 1)
+                           .contains_key(&path.ident[0].name) => {
+                let prim = self.primitive_type_table.primitive_types[&path.ident[0].name];
+                PathResolution::with_unresolved_segments(Def::PrimTy(prim), path.ident.len() - 1)
             }
             PathResult::Module(module) => PathResolution::new(module.def().unwrap()),
             PathResult::Failed(span, msg, false) => {
@@ -3185,11 +3215,16 @@ impl<'a> Resolver<'a> {
             PathResult::Indeterminate => bug!("indetermined path result in resolve_qpath"),
         };
 
-        if path.len() > 1 && !global_by_default && result.base_def() != Def::Err &&
-           path[0].name != keywords::CrateRoot.name() &&
-           path[0].name != keywords::DollarCrate.name() {
+        if path.ident.len() > 1 && !global_by_default && result.base_def() != Def::Err &&
+           path.ident[0].name != keywords::CrateRoot.name() &&
+           path.ident[0].name != keywords::DollarCrate.name() {
             let unqualified_result = {
-                match self.resolve_path(&[*path.last().unwrap()], Some(ns), false, span, None) {
+                let resolve_path = ResolvePath {
+                                       ident : &[*path.ident.last().unwrap()],
+                                       source : None,
+                                       speculative : true,
+                                   };
+                match self.resolve_path(&resolve_path, Some(ns), false, span) {
                     PathResult::NonModule(path_res) => path_res.base_def(),
                     PathResult::Module(module) => module.def().unwrap(),
                     _ => return Some(result),
@@ -3205,19 +3240,19 @@ impl<'a> Resolver<'a> {
     }
 
     fn resolve_path(&mut self,
-                    path: &[Ident],
+                    path: &ResolvePath,
                     opt_ns: Option<Namespace>, // `None` indicates a module path
                     record_used: bool,
-                    path_span: Span,
-                    node_id: Option<NodeId>) // None indicates that we don't care about linting
+                    path_span: Span)//,
+                    //node_id: Option<NodeId>) // None indicates that we don't care about linting
                                              // `::module` paths
                     -> PathResult<'a> {
         let mut module = None;
         let mut allow_super = true;
 
-        for (i, &ident) in path.iter().enumerate() {
+        for (i, &ident) in path.ident.iter().enumerate() {
             debug!("resolve_path ident {} {:?}", i, ident);
-            let is_last = i == path.len() - 1;
+            let is_last = i == path.ident.len() - 1;
             let ns = if is_last { opt_ns.unwrap_or(TypeNS) } else { TypeNS };
             let name = ident.name;
 
@@ -3247,7 +3282,7 @@ impl<'a> Resolver<'a> {
                 if (i == 0 && name == keywords::CrateRoot.name()) ||
                    (i == 0 && name == keywords::Crate.name()) ||
                    (i == 1 && name == keywords::Crate.name() &&
-                              path[0].name == keywords::CrateRoot.name()) {
+                              path.ident[0].name == keywords::CrateRoot.name()) {
                     // `::a::b` or `::crate::a::b`
                     module = Some(self.resolve_crate_root(ident.span.ctxt(), false));
                     continue
@@ -3256,7 +3291,7 @@ impl<'a> Resolver<'a> {
                     module = Some(self.resolve_crate_root(ident.span.ctxt(), true));
                     continue
                 } else if i == 1 && !token::is_path_segment_keyword(ident) {
-                    let prev_name = path[0].name;
+                    let prev_name = path.ident[0].name;
                     if prev_name == keywords::Extern.name() ||
                        prev_name == keywords::CrateRoot.name() &&
                        // Note: When this feature stabilizes, this should
@@ -3282,14 +3317,14 @@ impl<'a> Resolver<'a> {
                name == keywords::Extern.name() && i != 0 ||
                // we allow crate::foo and ::crate::foo but nothing else
                name == keywords::Crate.name() && i > 1 &&
-                    path[0].name != keywords::CrateRoot.name() ||
-               name == keywords::Crate.name() && path.len() == 1 {
+                    path.ident[0].name != keywords::CrateRoot.name() ||
+               name == keywords::Crate.name() && path.ident.len() == 1 {
                 let name_str = if name == keywords::CrateRoot.name() {
                     format!("crate root")
                 } else {
                     format!("`{}`", name)
                 };
-                let msg = if i == 1 && path[0].name == keywords::CrateRoot.name() {
+                let msg = if i == 1 && path.ident[0].name == keywords::CrateRoot.name() {
                     format!("global paths cannot start with {}", name_str)
                 } else {
                     format!("{} in paths can only be used in start position", name_str)
@@ -3308,7 +3343,7 @@ impl<'a> Resolver<'a> {
                     Some(LexicalScopeBinding::Def(def))
                             if opt_ns == Some(TypeNS) || opt_ns == Some(ValueNS) => {
                         return PathResult::NonModule(PathResolution::with_unresolved_segments(
-                            def, path.len() - 1
+                            def, path.ident.len() - 1
                         ));
                     }
                     _ => Err(if record_used { Determined } else { Undetermined }),
@@ -3325,7 +3360,7 @@ impl<'a> Resolver<'a> {
                         return PathResult::NonModule(err_path_resolution());
                     } else if opt_ns.is_some() && (is_last || maybe_assoc) {
                         return PathResult::NonModule(PathResolution::with_unresolved_segments(
-                            def, path.len() - i - 1
+                            def, path.ident.len() - i - 1
                         ));
                     } else {
                         return PathResult::Failed(ident.span,
@@ -3333,10 +3368,10 @@ impl<'a> Resolver<'a> {
                                                   is_last);
                     }
 
-                    if let Some(id) = node_id {
+                    if let Some(id) = path.source {
                         if i == 1 && self.session.features_untracked().crate_in_paths
                                   && !self.session.rust_2018() {
-                            let prev_name = path[0].name;
+                            let prev_name = path.ident[0].name;
                             if prev_name == keywords::Extern.name() ||
                                prev_name == keywords::CrateRoot.name() {
                                 let mut is_crate = false;
@@ -3365,7 +3400,7 @@ impl<'a> Resolver<'a> {
                     if let Some(module) = module {
                         if opt_ns.is_some() && !module.is_normal() {
                             return PathResult::NonModule(PathResolution::with_unresolved_segments(
-                                module.def().unwrap(), path.len() - i
+                                module.def().unwrap(), path.ident.len() - i
                             ));
                         }
                     }
@@ -3384,7 +3419,7 @@ impl<'a> Resolver<'a> {
                     } else if i == 0 {
                         format!("Use of undeclared type or module `{}`", ident)
                     } else {
-                        format!("Could not find `{}` in `{}`", ident, path[i - 1])
+                        format!("Could not find `{}` in `{}`", ident, path.ident[i - 1])
                     };
                     return PathResult::Failed(ident.span, msg, is_last);
                 }
@@ -3604,9 +3639,13 @@ impl<'a> Resolver<'a> {
             }
         } else {
             // Search in module.
-            let mod_path = &path[..path.len() - 1];
-            if let PathResult::Module(module) = self.resolve_path(mod_path, Some(TypeNS),
-                                                                  false, span, None) {
+            let mod_path = ResolvePath {
+                               ident : &path[..path.len() - 1],
+                               source : None,
+                               speculative : true,
+                           };
+            if let PathResult::Module(module) = self.resolve_path(&mod_path, Some(TypeNS),
+                                                                  false, span) {
                 add_module_candidates(module, &mut names);
             }
         }
@@ -4024,7 +4063,12 @@ impl<'a> Resolver<'a> {
                 let segments = path.make_root().iter().chain(path.segments.iter())
                     .map(|seg| seg.ident)
                     .collect::<Vec<_>>();
-                let def = self.smart_resolve_path_fragment(id, None, &segments, path.span,
+                let resolve_path = ResolvePath {
+                                       ident : &segments,
+                                       source : None,
+                                       speculative : true,
+                                   };
+                let def = self.smart_resolve_path_fragment(id, None, &resolve_path, path.span,
                                                            PathSource::Visibility).base_def();
                 if def == Def::Err {
                     ty::Visibility::Public

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -679,14 +679,14 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
                 return None;
             }
             PathResult::Failed(span, msg, true) => {
-                let (mut self_path, mut self_result) = (module_path.segments.clone(), None);
+                let (mut self_path, mut self_result) = (module_path.segments.to_vec(), None);
                 let is_special = |ident| token::is_path_segment_keyword(ident) &&
                                          ident.name != keywords::CrateRoot.name();
                 if !self_path.is_empty() && !is_special(self_path[0]) &&
                    !(self_path.len() > 1 && is_special(self_path[1])) {
                     self_path[0].name = keywords::SelfValue.name();
                     let self_path = ResolvePath {
-                        segments: self_path,
+                        segments: &self_path,
                         source: None,
                     };
                     self_result = Some(self.resolve_path(&self_path, None, false, span));

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -535,12 +535,11 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
             // For better failure detection, pretend that the import will not define any names
             // while resolving its module path.
             directive.vis.set(ty::Visibility::Invisible);
-            let resolve_path = ResolvePath {
-                                   ident : &directive.module_path[..],
-                                   source : Some(directive.id),
-                                   speculative : false,
-                               };
-            let result = self.resolve_path(&resolve_path, None, false, directive.span);
+            let path = ResolvePath {
+                ident: &directive.module_path[..],
+                source: Some(directive.id),
+            };
+            let result = self.resolve_path(&path, None, false, directive.span);
             directive.vis.set(vis);
 
             match result {
@@ -668,12 +667,11 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
             }
         }
 
-        let module_resolve_path = ResolvePath {
-                                      ident : &module_path,
-                                      source : Some(directive.id),
-                                      speculative : false,
-                                  };
-        let module_result = self.resolve_path(&module_resolve_path, None, true, span);
+        let module_path = ResolvePath {
+            ident: &module_path,
+            source: Some(directive.id),
+        };
+        let module_result = self.resolve_path(&module_path, None, true, span);
         let module = match module_result {
             PathResult::Module(module) => module,
             PathResult::Failed(span, msg, false) => {
@@ -681,22 +679,21 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
                 return None;
             }
             PathResult::Failed(span, msg, true) => {
-                let (mut self_path, mut self_result) = (module_path.clone(), None);
+                let (mut self_path_ident, mut self_result) = (module_path.ident.clone(), None);
                 let is_special = |ident| token::is_path_segment_keyword(ident) &&
                                          ident.name != keywords::CrateRoot.name();
-                if !self_path.is_empty() && !is_special(self_path[0]) &&
-                   !(self_path.len() > 1 && is_special(self_path[1])) {
-                    self_path[0].name = keywords::SelfValue.name();
-
-                    let self_resolve_path = ResolvePath {
-                                                ident : &self_path,
-                                                source : None,
-                                                speculative : true,
-                                            };
-                    self_result = Some(self.resolve_path(&self_resolve_path, None, false, span));
+                if !self_path_ident.is_empty() && !is_special(self_path_ident[0]) &&
+                   !(self_path_ident.len() > 1 && is_special(self_path_ident[1])) {
+                    self_path_ident[0].name = keywords::SelfValue.name();
+                    let self_path = ResolvePath {
+                        ident: self_path_ident,
+                        source: None,
+                    };
+                    self_result = Some(self.resolve_path(&self_path, None, false, span));
                 }
                 return if let Some(PathResult::Module(..)) = self_result {
-                    Some((span, format!("Did you mean `{}`?", names_to_string(&self_path[..]))))
+                    Some((span, format!("Did you mean `{}`?",
+                                        names_to_string(&self_path_ident[..]))))
                 } else {
                     Some((span, msg))
                 };

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -536,7 +536,7 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
             // while resolving its module path.
             directive.vis.set(ty::Visibility::Invisible);
             let path = ResolvePath {
-                ident: &directive.module_path[..],
+                segments: &directive.module_path[..],
                 source: Some(directive.id),
             };
             let result = self.resolve_path(&path, None, false, directive.span);
@@ -668,7 +668,7 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
         }
 
         let module_path = ResolvePath {
-            ident: &module_path,
+            segments: &module_path,
             source: Some(directive.id),
         };
         let module_result = self.resolve_path(&module_path, None, true, span);
@@ -679,21 +679,21 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
                 return None;
             }
             PathResult::Failed(span, msg, true) => {
-                let (mut self_path_ident, mut self_result) = (module_path.ident.clone(), None);
+                let (mut self_path, mut self_result) = (module_path.segments.clone(), None);
                 let is_special = |ident| token::is_path_segment_keyword(ident) &&
                                          ident.name != keywords::CrateRoot.name();
-                if !self_path_ident.is_empty() && !is_special(self_path_ident[0]) &&
-                   !(self_path_ident.len() > 1 && is_special(self_path_ident[1])) {
-                    self_path_ident[0].name = keywords::SelfValue.name();
+                if !self_path.is_empty() && !is_special(self_path[0]) &&
+                   !(self_path.len() > 1 && is_special(self_path[1])) {
+                    self_path[0].name = keywords::SelfValue.name();
                     let self_path = ResolvePath {
-                        ident: self_path_ident,
+                        segments: self_path,
                         source: None,
                     };
                     self_result = Some(self.resolve_path(&self_path, None, false, span));
                 }
                 return if let Some(PathResult::Module(..)) = self_result {
                     Some((span, format!("Did you mean `{}`?",
-                                        names_to_string(&self_path_ident[..]))))
+                                        names_to_string(&self_path[..]))))
                 } else {
                     Some((span, msg))
                 };


### PR DESCRIPTION
Fixes #50258 

This creates a struct called `ResolvePath` to replace the use of `&[Ident]` in `librustc_resolve`.

However, this currently doesn't build because we don't use the `speculative` flag. The only place it could be used atm (as far as I can see), is instead now written like this (`librustc_resolve::3370`):
``` rust
if let Some(id) = path.source {
    ...
}
```
I can make the change to testing `speculative` and then unwrapping it if that's better?

Overall, I don't know if this is what was intended from the issue, but I thought I'd give it a shot.
r? @Manishearth 