### PR TITLE
Improve error message for #[repr(align=x)]

### DIFF
--- a/src/libsyntax/diagnostic_list.rs
+++ b/src/libsyntax/diagnostic_list.rs
@@ -324,4 +324,5 @@ register_diagnostics! {
     E0589, // invalid `repr(align)` attribute
     E0629, // missing 'feature' (rustc_const_unstable)
     E0630, // rustc_const_unstable attribute must be paired with stable/unstable attribute
+    E0693, // incorrect `repr(align)` attribute format
 }

--- a/src/test/ui/repr-align-assign.rs
+++ b/src/test/ui/repr-align-assign.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[repr(align=8)] //~ ERROR incorrect `repr(align)` attribute format
+struct A(u64);
+
+#[repr(align="8")] //~ ERROR incorrect `repr(align)` attribute format
+struct B(u64);
+
+fn main() {}

--- a/src/test/ui/repr-align-assign.stderr
+++ b/src/test/ui/repr-align-assign.stderr
@@ -1,0 +1,15 @@
+error[E0693]: incorrect `repr(align)` attribute format
+  --> $DIR/repr-align-assign.rs:11:8
+   |
+LL | #[repr(align=8)] //~ ERROR incorrect `repr(align)` attribute format
+   |        ^^^^^^^ help: use parentheses instead: `align(8)`
+
+error[E0693]: incorrect `repr(align)` attribute format
+  --> $DIR/repr-align-assign.rs:14:8
+   |
+LL | #[repr(align="8")] //~ ERROR incorrect `repr(align)` attribute format
+   |        ^^^^^^^^^ help: use parentheses instead: `align(8)`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0693`.


### PR DESCRIPTION
Before:
```
error[E0552]: unrecognized representation hint
 --> src/main.rs:1:8
  |
1 | #[repr(align="8")]
  |        ^^^^^^^^^
```
After:
```
error[E0693]: incorrect `repr(align)` attribute format
 --> src/main.rs:1:8
  |
2 | #[repr(align="8")]
  |        ^^^^^^^^^ help: use parentheses instead: `align(8)`
```

Fixes #50314.