### PR TITLE
Display correct unused field suggestion for nested struct patterns

### DIFF
--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -430,8 +430,9 @@ fn visit_arm<'a, 'tcx>(ir: &mut IrMaps<'a, 'tcx>, arm: &'tcx hir::Arm) {
                     }
                     break;
                 }
-                hir::PatKind::Ref(ref deref_pat, _) => {
-                    pat = deref_pat;
+                hir::PatKind::Ref(ref inner_pat, _) |
+                hir::PatKind::Box(ref inner_pat) => {
+                    pat = inner_pat;
                 }
                 _ => break
             }

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
@@ -18,6 +18,10 @@ struct SoulHistory {
     endless_and_singing: bool
 }
 
+enum Large {
+    Suit { case: () }
+}
+
 fn main() {
     let i_think_continually = 2;
     let who_from_the_womb_remembered = SoulHistory {
@@ -31,4 +35,12 @@ fn main() {
                          endless_and_singing: true } = who_from_the_womb_remembered {
         hours_are_suns = false;
     }
+
+    let bag = &Large::Suit {
+        case: ()
+    };
+
+    match bag {
+        &Large::Suit { case } => {}
+    };
 }

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
@@ -10,6 +10,8 @@
 
 // compile-pass
 
+#![feature(box_syntax)]
+#![feature(box_patterns)]
 #![warn(unused)] // UI tests pass `-A unused` (#43896)
 
 struct SoulHistory {
@@ -36,11 +38,15 @@ fn main() {
         hours_are_suns = false;
     }
 
-    let bag = &Large::Suit {
+    let bag = Large::Suit {
         case: ()
     };
 
-    match bag {
+    match &bag {
         &Large::Suit { case } => {}
+    };
+
+    match box bag {
+        box Large::Suit { case } => {}
     };
 }

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
@@ -20,9 +20,12 @@ struct SoulHistory {
     endless_and_singing: bool
 }
 
+#[derive(Clone, Copy)]
 enum Large {
     Suit { case: () }
 }
+
+struct Tuple(Large, ());
 
 fn main() {
     let i_think_continually = 2;
@@ -42,11 +45,33 @@ fn main() {
         case: ()
     };
 
+    // Plain struct
+    match bag {
+        Large::Suit { case } => {}
+    };
+
+    // Referenced struct
     match &bag {
         &Large::Suit { case } => {}
     };
 
+    // Boxed struct
     match box bag {
         box Large::Suit { case } => {}
+    };
+
+    // Tuple with struct
+    match (bag,) {
+        (Large::Suit { case },) => {}
+    };
+
+    // Slice with struct
+    match [bag] {
+        [Large::Suit { case }] => {}
+    };
+
+    // Tuple struct with struct
+    match Tuple(bag, ()) {
+        Tuple(Large::Suit { case }, ()) => {}
     };
 }

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
@@ -1,24 +1,24 @@
 warning: unused variable: `i_think_continually`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:26:9
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:28:9
    |
 LL |     let i_think_continually = 2;
    |         ^^^^^^^^^^^^^^^^^^^ help: consider using `_i_think_continually` instead
    |
 note: lint level defined here
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:13:9
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:15:9
    |
 LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
    |         ^^^^^^
    = note: #[warn(unused_variables)] implied by #[warn(unused)]
 
 warning: unused variable: `corridors_of_light`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:33:26
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:35:26
    |
 LL |     if let SoulHistory { corridors_of_light,
    |                          ^^^^^^^^^^^^^^^^^^ help: try ignoring the field: `corridors_of_light: _`
 
 warning: variable `hours_are_suns` is assigned to, but never used
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:34:26
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:36:26
    |
 LL |                          mut hours_are_suns,
    |                          ^^^^^^^^^^^^^^^^^^
@@ -26,21 +26,27 @@ LL |                          mut hours_are_suns,
    = note: consider using `_hours_are_suns` instead
 
 warning: value assigned to `hours_are_suns` is never read
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:36:9
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:38:9
    |
 LL |         hours_are_suns = false;
    |         ^^^^^^^^^^^^^^
    |
 note: lint level defined here
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:13:9
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:15:9
    |
 LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
    |         ^^^^^^
    = note: #[warn(unused_assignments)] implied by #[warn(unused)]
 
 warning: unused variable: `case`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:44:24
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:46:24
    |
 LL |         &Large::Suit { case } => {}
    |                        ^^^^ help: try ignoring the field: `case: _`
+
+warning: unused variable: `case`
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:50:27
+   |
+LL |         box Large::Suit { case } => {}
+   |                           ^^^^ help: try ignoring the field: `case: _`
 

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
@@ -1,5 +1,5 @@
 warning: unused variable: `i_think_continually`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:28:9
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:31:9
    |
 LL |     let i_think_continually = 2;
    |         ^^^^^^^^^^^^^^^^^^^ help: consider using `_i_think_continually` instead
@@ -12,13 +12,13 @@ LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
    = note: #[warn(unused_variables)] implied by #[warn(unused)]
 
 warning: unused variable: `corridors_of_light`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:35:26
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:38:26
    |
 LL |     if let SoulHistory { corridors_of_light,
    |                          ^^^^^^^^^^^^^^^^^^ help: try ignoring the field: `corridors_of_light: _`
 
 warning: variable `hours_are_suns` is assigned to, but never used
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:36:26
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:39:26
    |
 LL |                          mut hours_are_suns,
    |                          ^^^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL |                          mut hours_are_suns,
    = note: consider using `_hours_are_suns` instead
 
 warning: value assigned to `hours_are_suns` is never read
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:38:9
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:41:9
    |
 LL |         hours_are_suns = false;
    |         ^^^^^^^^^^^^^^
@@ -39,14 +39,38 @@ LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
    = note: #[warn(unused_assignments)] implied by #[warn(unused)]
 
 warning: unused variable: `case`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:46:24
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:50:23
+   |
+LL |         Large::Suit { case } => {}
+   |                       ^^^^ help: try ignoring the field: `case: _`
+
+warning: unused variable: `case`
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:55:24
    |
 LL |         &Large::Suit { case } => {}
    |                        ^^^^ help: try ignoring the field: `case: _`
 
 warning: unused variable: `case`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:50:27
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:60:27
    |
 LL |         box Large::Suit { case } => {}
    |                           ^^^^ help: try ignoring the field: `case: _`
+
+warning: unused variable: `case`
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:65:24
+   |
+LL |         (Large::Suit { case },) => {}
+   |                        ^^^^ help: try ignoring the field: `case: _`
+
+warning: unused variable: `case`
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:70:24
+   |
+LL |         [Large::Suit { case }] => {}
+   |                        ^^^^ help: try ignoring the field: `case: _`
+
+warning: unused variable: `case`
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:75:29
+   |
+LL |         Tuple(Large::Suit { case }, ()) => {}
+   |                             ^^^^ help: try ignoring the field: `case: _`
 

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
@@ -1,5 +1,5 @@
 warning: unused variable: `i_think_continually`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:22:9
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:26:9
    |
 LL |     let i_think_continually = 2;
    |         ^^^^^^^^^^^^^^^^^^^ help: consider using `_i_think_continually` instead
@@ -12,13 +12,13 @@ LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
    = note: #[warn(unused_variables)] implied by #[warn(unused)]
 
 warning: unused variable: `corridors_of_light`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:29:26
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:33:26
    |
 LL |     if let SoulHistory { corridors_of_light,
    |                          ^^^^^^^^^^^^^^^^^^ help: try ignoring the field: `corridors_of_light: _`
 
 warning: variable `hours_are_suns` is assigned to, but never used
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:30:26
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:34:26
    |
 LL |                          mut hours_are_suns,
    |                          ^^^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL |                          mut hours_are_suns,
    = note: consider using `_hours_are_suns` instead
 
 warning: value assigned to `hours_are_suns` is never read
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:32:9
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:36:9
    |
 LL |         hours_are_suns = false;
    |         ^^^^^^^^^^^^^^
@@ -37,4 +37,10 @@ note: lint level defined here
 LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
    |         ^^^^^^
    = note: #[warn(unused_assignments)] implied by #[warn(unused)]
+
+warning: unused variable: `case`
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:44:24
+   |
+LL |         &Large::Suit { case } => {}
+   |                        ^^^^ help: try ignoring the field: `case: _`
 


### PR DESCRIPTION
Extends https://github.com/rust-lang/rust/pull/47922 by checking more sophisticated patterns (e.g. references, slices, etc.).
Before:
```
warning: unused variable: `bar`
  --> src/main.rs:37:21
   |
37 |         &Foo::Bar { bar } => true,
   |                     ^^^ help: consider using `_bar` instead
   |
   = note: #[warn(unused_variables)] on by default
```
After:
```
warning: unused variable: `bar`
  --> src/main.rs:37:21
   |
37 |         &Foo::Bar { bar } => true,
   |                     ^^^ help: try ignoring the field: `bar: _`
   |
   = note: #[warn(unused_variables)] on by default
```

Fixes #50303.

r? @estebank 