### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -123,6 +123,7 @@
 #![feature(pointer_methods)]
 #![feature(inclusive_range_fields)]
 #![cfg_attr(stage0, feature(generic_param_attrs))]
+#![feature(rustc_const_unstable)]
 
 #![cfg_attr(not(test), feature(fn_traits, i128))]
 #![cfg_attr(test, feature(test))]

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -65,7 +65,7 @@ impl<T, A: Alloc> RawVec<T, A> {
         RawVec {
             ptr: Unique::empty(),
             // FIXME(mark-i-m): use `cap` when ifs are allowed in const
-            cap: [0, !0][(mem::size_of::<T>() != 0) as usize],
+            cap: [0, !0][(mem::size_of::<T>() == 0) as usize],
             a,
         }
     }

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -54,6 +54,7 @@ pub struct RawVec<T, A: Alloc = Global> {
 }
 
 impl<T, A: Alloc> RawVec<T, A> {
+    // FIXME: this should be made `const` when `if` statements are allowed
     /// Like `new` but parameterized over the choice of allocator for
     /// the returned RawVec.
     pub fn new_in(a: A) -> Self {
@@ -68,6 +69,7 @@ impl<T, A: Alloc> RawVec<T, A> {
         }
     }
 
+    // FIXME: this should removed when `new_in` can be made `const`
     /// Like `empty` but parametrized over the choice of allocator for the returned `RawVec`.
     pub const fn empty_in(a: A) -> Self {
         // Unique::empty() doubles as "unallocated" and "zero-sized allocation"
@@ -134,9 +136,10 @@ impl<T> RawVec<T, Global> {
         Self::new_in(Global)
     }
 
+    // FIXME: this should removed when `new` can be made `const`
     /// Create a `RawVec` with capcity 0 (on the system heap), regardless of `T`, without
     /// allocating.
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         Self::empty_in(Global)
     }
 

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -68,6 +68,16 @@ impl<T, A: Alloc> RawVec<T, A> {
         }
     }
 
+    /// Like `empty` but parametrized over the choice of allocator for the returned `RawVec`.
+    pub const fn empty_in(a: A) -> Self {
+        // Unique::empty() doubles as "unallocated" and "zero-sized allocation"
+        RawVec {
+            ptr: Unique::empty(),
+            cap: 0,
+            a,
+        }
+    }
+
     /// Like `with_capacity` but parameterized over the choice of
     /// allocator for the returned RawVec.
     #[inline]
@@ -122,6 +132,12 @@ impl<T> RawVec<T, Global> {
     /// delayed allocation.
     pub fn new() -> Self {
         Self::new_in(Global)
+    }
+
+    /// Create a `RawVec` with capcity 0 (on the system heap), regardless of `T`, without
+    /// allocating.
+    pub fn empty() -> Self {
+        Self::empty_in(Global)
     }
 
     /// Creates a RawVec (on the system heap) with exactly the

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -324,7 +324,7 @@ impl<T> Vec<T> {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn new() -> Vec<T> {
         Vec {
-            buf: RawVec::new(),
+            buf: RawVec::empty(),
             len: 0,
         }
     }

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -325,7 +325,7 @@ impl<T> Vec<T> {
     #[rustc_const_unstable(feature = "const_vec_new")]
     pub const fn new() -> Vec<T> {
         Vec {
-            buf: RawVec::empty(),
+            buf: RawVec::new(),
             len: 0,
         }
     }

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -322,7 +322,7 @@ impl<T> Vec<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn new() -> Vec<T> {
+    pub const fn new() -> Vec<T> {
         Vec {
             buf: RawVec::empty(),
             len: 0,

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -322,6 +322,7 @@ impl<T> Vec<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_const_unstable(feature = "const_vec_new")]
     pub const fn new() -> Vec<T> {
         Vec {
             buf: RawVec::empty(),

--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -1094,6 +1094,8 @@ pub trait Iterator {
     /// `flatten()` a three-dimensional array the result will be
     /// two-dimensional and not one-dimensional. To get a one-dimensional
     /// structure, you have to `flatten()` again.
+    ///
+    /// [`flat_map()`]: #method.flat_map
     #[inline]
     #[unstable(feature = "iterator_flatten", issue = "48213")]
     fn flatten(self) -> Flatten<Self>

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -602,6 +602,8 @@ unsafe impl<'a, T: ?Sized> Freeze for &'a mut T {}
 /// `Pin` pointer.
 ///
 /// This trait is automatically implemented for almost every type.
+///
+/// [`Pin`]: ../mem/struct.Pin.html
 #[unstable(feature = "pin", issue = "49150")]
 pub unsafe auto trait Unpin {}
 

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2551,10 +2551,9 @@ impl<T: Sized> Unique<T> {
     /// This is useful for initializing types which lazily allocate, like
     /// `Vec::new` does.
     // FIXME: rename to dangling() to match NonNull?
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         unsafe {
-            let ptr = mem::align_of::<T>() as *mut T;
-            Unique::new_unchecked(ptr)
+            Unique::new_unchecked(mem::align_of::<T>() as *mut T)
         }
     }
 }

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -430,8 +430,9 @@ fn visit_arm<'a, 'tcx>(ir: &mut IrMaps<'a, 'tcx>, arm: &'tcx hir::Arm) {
                     }
                     break;
                 }
-                hir::PatKind::Ref(ref deref_pat, _) => {
-                    pat = deref_pat;
+                hir::PatKind::Ref(ref inner_pat, _) |
+                hir::PatKind::Box(ref inner_pat) => {
+                    pat = inner_pat;
                 }
                 _ => break
             }

--- a/src/libstd/collections/hash/table.rs
+++ b/src/libstd/collections/hash/table.rs
@@ -79,7 +79,7 @@ impl TaggedHashUintPtr {
 ///
 /// Essential invariants of this structure:
 ///
-///   - if t.hashes[i] == EMPTY_BUCKET, then `Bucket::at_index(&t, i).raw`
+///   - if `t.hashes[i] == EMPTY_BUCKET`, then `Bucket::at_index(&t, i).raw`
 ///     points to 'undefined' contents. Don't read from it. This invariant is
 ///     enforced outside this module with the `EmptyBucket`, `FullBucket`,
 ///     and `SafeHash` types.

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -1118,6 +1118,7 @@ impl CStr {
     ///
     /// [`Cow`]: ../borrow/enum.Cow.html
     /// [`Borrowed`]: ../borrow/enum.Cow.html#variant.Borrowed
+    /// [`Owned`]: ../borrow/enum.Cow.html#variant.Owned
     /// [`str`]: ../primitive.str.html
     /// [`String`]: ../string/struct.String.html
     ///

--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -31,9 +31,13 @@ pub use core::panic::{PanicInfo, Location};
 /// A marker trait which represents "panic safe" types in Rust.
 ///
 /// This trait is implemented by default for many types and behaves similarly in
-/// terms of inference of implementation to the `Send` and `Sync` traits. The
-/// purpose of this trait is to encode what types are safe to cross a `catch_unwind`
+/// terms of inference of implementation to the [`Send`] and [`Sync`] traits. The
+/// purpose of this trait is to encode what types are safe to cross a [`catch_unwind`]
 /// boundary with no fear of unwind safety.
+///
+/// [`Send`]: ../marker/trait.Send.html
+/// [`Sync`]: ../marker/trait.Sync.html
+/// [`catch_unwind`]: ./fn.catch_unwind.html
 ///
 /// ## What is unwind safety?
 ///
@@ -95,12 +99,13 @@ pub use core::panic::{PanicInfo, Location};
 ///
 /// ## When should `UnwindSafe` be used?
 ///
-/// Is not intended that most types or functions need to worry about this trait.
-/// It is only used as a bound on the `catch_unwind` function and as mentioned above,
-/// the lack of `unsafe` means it is mostly an advisory. The `AssertUnwindSafe`
-/// wrapper struct in this module can be used to force this trait to be
-/// implemented for any closed over variables passed to the `catch_unwind` function
-/// (more on this below).
+/// It is not intended that most types or functions need to worry about this trait.
+/// It is only used as a bound on the `catch_unwind` function and as mentioned
+/// above, the lack of `unsafe` means it is mostly an advisory. The
+/// [`AssertUnwindSafe`] wrapper struct can be used to force this trait to be
+/// implemented for any closed over variables passed to `catch_unwind`.
+///
+/// [`AssertUnwindSafe`]: ./struct.AssertUnwindSafe.html
 #[stable(feature = "catch_unwind", since = "1.9.0")]
 #[rustc_on_unimplemented = "the type {Self} may not be safely transferred \
                             across an unwind boundary"]
@@ -109,11 +114,14 @@ pub auto trait UnwindSafe {}
 /// A marker trait representing types where a shared reference is considered
 /// unwind safe.
 ///
-/// This trait is namely not implemented by `UnsafeCell`, the root of all
+/// This trait is namely not implemented by [`UnsafeCell`], the root of all
 /// interior mutability.
 ///
 /// This is a "helper marker trait" used to provide impl blocks for the
-/// `UnwindSafe` trait, for more information see that documentation.
+/// [`UnwindSafe`] trait, for more information see that documentation.
+///
+/// [`UnsafeCell`]: ../cell/struct.UnsafeCell.html
+/// [`UnwindSafe`]: ./trait.UnwindSafe.html
 #[stable(feature = "catch_unwind", since = "1.9.0")]
 #[rustc_on_unimplemented = "the type {Self} may contain interior mutability \
                             and a reference may not be safely transferrable \
@@ -122,14 +130,15 @@ pub auto trait RefUnwindSafe {}
 
 /// A simple wrapper around a type to assert that it is unwind safe.
 ///
-/// When using `catch_unwind` it may be the case that some of the closed over
+/// When using [`catch_unwind`] it may be the case that some of the closed over
 /// variables are not unwind safe. For example if `&mut T` is captured the
 /// compiler will generate a warning indicating that it is not unwind safe. It
 /// may not be the case, however, that this is actually a problem due to the
-/// specific usage of `catch_unwind` if unwind safety is specifically taken into
+/// specific usage of [`catch_unwind`] if unwind safety is specifically taken into
 /// account. This wrapper struct is useful for a quick and lightweight
 /// annotation that a variable is indeed unwind safe.
 ///
+/// [`catch_unwind`]: ./fn.catch_unwind.html
 /// # Examples
 ///
 /// One way to use `AssertUnwindSafe` is to assert that the entire closure
@@ -318,18 +327,22 @@ impl<T: fmt::Debug> fmt::Debug for AssertUnwindSafe<T> {
 /// panic and allowing a graceful handling of the error.
 ///
 /// It is **not** recommended to use this function for a general try/catch
-/// mechanism. The `Result` type is more appropriate to use for functions that
+/// mechanism. The [`Result`] type is more appropriate to use for functions that
 /// can fail on a regular basis. Additionally, this function is not guaranteed
 /// to catch all panics, see the "Notes" section below.
 ///
-/// The closure provided is required to adhere to the `UnwindSafe` trait to ensure
+/// [`Result`]: ../result/enum.Result.html
+///
+/// The closure provided is required to adhere to the [`UnwindSafe`] trait to ensure
 /// that all captured variables are safe to cross this boundary. The purpose of
 /// this bound is to encode the concept of [exception safety][rfc] in the type
 /// system. Most usage of this function should not need to worry about this
 /// bound as programs are naturally unwind safe without `unsafe` code. If it
-/// becomes a problem the associated `AssertUnwindSafe` wrapper type in this
-/// module can be used to quickly assert that the usage here is indeed unwind
-/// safe.
+/// becomes a problem the [`AssertUnwindSafe`] wrapper struct can be used to quickly
+/// assert that the usage here is indeed unwind safe.
+///
+/// [`AssertUnwindSafe`]: ./struct.AssertUnwindSafe.html
+/// [`UnwindSafe`]: ./trait.UnwindSafe.html
 ///
 /// [rfc]: https://github.com/rust-lang/rfcs/blob/master/text/1236-stabilize-catch-panic.md
 ///
@@ -364,8 +377,10 @@ pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
 
 /// Triggers a panic without invoking the panic hook.
 ///
-/// This is designed to be used in conjunction with `catch_unwind` to, for
+/// This is designed to be used in conjunction with [`catch_unwind`] to, for
 /// example, carry a panic across a layer of C code.
+///
+/// [`catch_unwind`]: ./fn.catch_unwind.html
 ///
 /// # Notes
 ///

--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -76,7 +76,9 @@ static mut HOOK: Hook = Hook::Default;
 /// is invoked. As such, the hook will run with both the aborting and unwinding
 /// runtimes. The default hook prints a message to standard error and generates
 /// a backtrace if requested, but this behavior can be customized with the
-/// `set_hook` and `take_hook` functions.
+/// `set_hook` and [`take_hook`] functions.
+///
+/// [`take_hook`]: ./fn.take_hook.html
 ///
 /// The hook is provided with a `PanicInfo` struct which contains information
 /// about the origin of the panic, including the payload passed to `panic!` and
@@ -120,6 +122,10 @@ pub fn set_hook(hook: Box<Fn(&PanicInfo) + 'static + Sync + Send>) {
 }
 
 /// Unregisters the current panic hook, returning it.
+///
+/// *See also the function [`set_hook`].*
+///
+/// [`set_hook`]: ./fn.set_hook.html
 ///
 /// If no custom hook is registered, the default hook will be returned.
 ///

--- a/src/test/compile-fail-fulldeps/proc-macro/proc-macro-gates.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/proc-macro-gates.rs
@@ -24,8 +24,16 @@ use foo::*;
 #[foo::a] //~ ERROR: paths of length greater than one
 fn _test() {}
 
+fn _test_inner() {
+    #![a] // OK
+}
+
 #[a] //~ ERROR: custom attributes cannot be applied to modules
 mod _test2 {}
+
+mod _test2_inner {
+    #![a] //~ ERROR: custom attributes cannot be applied to modules
+}
 
 #[a = y] //~ ERROR: must only be followed by a delimiter token
 fn _test3() {}
@@ -36,19 +44,40 @@ fn _test4() {}
 #[a () = ] //~ ERROR: must only be followed by a delimiter token
 fn _test5() {}
 
-fn main() {
+fn attrs() {
+    // Statement, item
+    #[a] // OK
+    struct S;
+
+    // Statement, macro
+    #[a] //~ ERROR: custom attributes cannot be applied to statements
+    println!();
+
+    // Statement, semi
+    #[a] //~ ERROR: custom attributes cannot be applied to statements
+    S;
+
+    // Statement, local
     #[a] //~ ERROR: custom attributes cannot be applied to statements
     let _x = 2;
-    let _x = #[a] 2;
-    //~^ ERROR: custom attributes cannot be applied to expressions
 
-    let _x: m!(u32) = 3;
-    //~^ ERROR: procedural macros cannot be expanded to types
-    if let m!(Some(_x)) = Some(3) {
-    //~^ ERROR: procedural macros cannot be expanded to patterns
-    }
-    let _x = m!(3);
-    //~^ ERROR: procedural macros cannot be expanded to expressions
-    m!(let _x = 3;);
-    //~^ ERROR: procedural macros cannot be expanded to statements
+    // Expr
+    let _x = #[a] 2; //~ ERROR: custom attributes cannot be applied to expressions
+
+    // Opt expr
+    let _x = [#[a] 2]; //~ ERROR: custom attributes cannot be applied to expressions
+
+    // Expr macro
+    let _x = #[a] println!(); //~ ERROR: custom attributes cannot be applied to expressions
+}
+
+fn main() {
+    let _x: m!(u32) = 3; //~ ERROR: procedural macros cannot be expanded to types
+    if let m!(Some(_x)) = Some(3) {} //~ ERROR: procedural macros cannot be expanded to patterns
+
+    m!(struct S;); //~ ERROR: procedural macros cannot be expanded to statements
+    m!(let _x = 3;); //~ ERROR: procedural macros cannot be expanded to statements
+
+    let _x = m!(3); //~ ERROR: procedural macros cannot be expanded to expressions
+    let _x = [m!(3)]; //~ ERROR: procedural macros cannot be expanded to expressions
 }

--- a/src/test/compile-fail/used.rs
+++ b/src/test/compile-fail/used.rs
@@ -1,0 +1,28 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(used)]
+
+#[used]
+static FOO: u32 = 0; // OK
+
+#[used] //~ ERROR attribute must be applied to a `static` variable
+fn foo() {}
+
+#[used] //~ ERROR attribute must be applied to a `static` variable
+struct Foo {}
+
+#[used] //~ ERROR attribute must be applied to a `static` variable
+trait Bar {}
+
+#[used] //~ ERROR attribute must be applied to a `static` variable
+impl Bar for Foo {}
+
+fn main() {}

--- a/src/test/run-pass/vec-const-new.rs
+++ b/src/test/run-pass/vec-const-new.rs
@@ -10,6 +10,8 @@
 
 // Test that Vec::new() can be used for constants
 
+#![feature(const_vec_new)]
+
 const MY_VEC: Vec<usize> = Vec::new();
 
 pub fn main() {}

--- a/src/test/run-pass/vec-const-new.rs
+++ b/src/test/run-pass/vec-const-new.rs
@@ -1,0 +1,15 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that Vec::new() can be used for constants
+
+const MY_VEC: Vec<usize> = Vec::new();
+
+pub fn main() {}

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
@@ -18,6 +18,10 @@ struct SoulHistory {
     endless_and_singing: bool
 }
 
+enum Large {
+    Suit { case: () }
+}
+
 fn main() {
     let i_think_continually = 2;
     let who_from_the_womb_remembered = SoulHistory {
@@ -31,4 +35,12 @@ fn main() {
                          endless_and_singing: true } = who_from_the_womb_remembered {
         hours_are_suns = false;
     }
+
+    let bag = &Large::Suit {
+        case: ()
+    };
+
+    match bag {
+        &Large::Suit { case } => {}
+    };
 }

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
@@ -10,6 +10,8 @@
 
 // compile-pass
 
+#![feature(box_syntax)]
+#![feature(box_patterns)]
 #![warn(unused)] // UI tests pass `-A unused` (#43896)
 
 struct SoulHistory {
@@ -36,11 +38,15 @@ fn main() {
         hours_are_suns = false;
     }
 
-    let bag = &Large::Suit {
+    let bag = Large::Suit {
         case: ()
     };
 
-    match bag {
+    match &bag {
         &Large::Suit { case } => {}
+    };
+
+    match box bag {
+        box Large::Suit { case } => {}
     };
 }

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
@@ -20,9 +20,12 @@ struct SoulHistory {
     endless_and_singing: bool
 }
 
+#[derive(Clone, Copy)]
 enum Large {
     Suit { case: () }
 }
+
+struct Tuple(Large, ());
 
 fn main() {
     let i_think_continually = 2;
@@ -42,11 +45,33 @@ fn main() {
         case: ()
     };
 
+    // Plain struct
+    match bag {
+        Large::Suit { case } => {}
+    };
+
+    // Referenced struct
     match &bag {
         &Large::Suit { case } => {}
     };
 
+    // Boxed struct
     match box bag {
         box Large::Suit { case } => {}
+    };
+
+    // Tuple with struct
+    match (bag,) {
+        (Large::Suit { case },) => {}
+    };
+
+    // Slice with struct
+    match [bag] {
+        [Large::Suit { case }] => {}
+    };
+
+    // Tuple struct with struct
+    match Tuple(bag, ()) {
+        Tuple(Large::Suit { case }, ()) => {}
     };
 }

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
@@ -1,24 +1,24 @@
 warning: unused variable: `i_think_continually`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:26:9
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:28:9
    |
 LL |     let i_think_continually = 2;
    |         ^^^^^^^^^^^^^^^^^^^ help: consider using `_i_think_continually` instead
    |
 note: lint level defined here
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:13:9
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:15:9
    |
 LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
    |         ^^^^^^
    = note: #[warn(unused_variables)] implied by #[warn(unused)]
 
 warning: unused variable: `corridors_of_light`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:33:26
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:35:26
    |
 LL |     if let SoulHistory { corridors_of_light,
    |                          ^^^^^^^^^^^^^^^^^^ help: try ignoring the field: `corridors_of_light: _`
 
 warning: variable `hours_are_suns` is assigned to, but never used
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:34:26
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:36:26
    |
 LL |                          mut hours_are_suns,
    |                          ^^^^^^^^^^^^^^^^^^
@@ -26,21 +26,27 @@ LL |                          mut hours_are_suns,
    = note: consider using `_hours_are_suns` instead
 
 warning: value assigned to `hours_are_suns` is never read
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:36:9
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:38:9
    |
 LL |         hours_are_suns = false;
    |         ^^^^^^^^^^^^^^
    |
 note: lint level defined here
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:13:9
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:15:9
    |
 LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
    |         ^^^^^^
    = note: #[warn(unused_assignments)] implied by #[warn(unused)]
 
 warning: unused variable: `case`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:44:24
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:46:24
    |
 LL |         &Large::Suit { case } => {}
    |                        ^^^^ help: try ignoring the field: `case: _`
+
+warning: unused variable: `case`
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:50:27
+   |
+LL |         box Large::Suit { case } => {}
+   |                           ^^^^ help: try ignoring the field: `case: _`
 

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
@@ -1,5 +1,5 @@
 warning: unused variable: `i_think_continually`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:28:9
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:31:9
    |
 LL |     let i_think_continually = 2;
    |         ^^^^^^^^^^^^^^^^^^^ help: consider using `_i_think_continually` instead
@@ -12,13 +12,13 @@ LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
    = note: #[warn(unused_variables)] implied by #[warn(unused)]
 
 warning: unused variable: `corridors_of_light`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:35:26
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:38:26
    |
 LL |     if let SoulHistory { corridors_of_light,
    |                          ^^^^^^^^^^^^^^^^^^ help: try ignoring the field: `corridors_of_light: _`
 
 warning: variable `hours_are_suns` is assigned to, but never used
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:36:26
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:39:26
    |
 LL |                          mut hours_are_suns,
    |                          ^^^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL |                          mut hours_are_suns,
    = note: consider using `_hours_are_suns` instead
 
 warning: value assigned to `hours_are_suns` is never read
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:38:9
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:41:9
    |
 LL |         hours_are_suns = false;
    |         ^^^^^^^^^^^^^^
@@ -39,14 +39,38 @@ LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
    = note: #[warn(unused_assignments)] implied by #[warn(unused)]
 
 warning: unused variable: `case`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:46:24
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:50:23
+   |
+LL |         Large::Suit { case } => {}
+   |                       ^^^^ help: try ignoring the field: `case: _`
+
+warning: unused variable: `case`
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:55:24
    |
 LL |         &Large::Suit { case } => {}
    |                        ^^^^ help: try ignoring the field: `case: _`
 
 warning: unused variable: `case`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:50:27
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:60:27
    |
 LL |         box Large::Suit { case } => {}
    |                           ^^^^ help: try ignoring the field: `case: _`
+
+warning: unused variable: `case`
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:65:24
+   |
+LL |         (Large::Suit { case },) => {}
+   |                        ^^^^ help: try ignoring the field: `case: _`
+
+warning: unused variable: `case`
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:70:24
+   |
+LL |         [Large::Suit { case }] => {}
+   |                        ^^^^ help: try ignoring the field: `case: _`
+
+warning: unused variable: `case`
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:75:29
+   |
+LL |         Tuple(Large::Suit { case }, ()) => {}
+   |                             ^^^^ help: try ignoring the field: `case: _`
 

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
@@ -1,5 +1,5 @@
 warning: unused variable: `i_think_continually`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:22:9
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:26:9
    |
 LL |     let i_think_continually = 2;
    |         ^^^^^^^^^^^^^^^^^^^ help: consider using `_i_think_continually` instead
@@ -12,13 +12,13 @@ LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
    = note: #[warn(unused_variables)] implied by #[warn(unused)]
 
 warning: unused variable: `corridors_of_light`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:29:26
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:33:26
    |
 LL |     if let SoulHistory { corridors_of_light,
    |                          ^^^^^^^^^^^^^^^^^^ help: try ignoring the field: `corridors_of_light: _`
 
 warning: variable `hours_are_suns` is assigned to, but never used
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:30:26
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:34:26
    |
 LL |                          mut hours_are_suns,
    |                          ^^^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL |                          mut hours_are_suns,
    = note: consider using `_hours_are_suns` instead
 
 warning: value assigned to `hours_are_suns` is never read
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:32:9
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:36:9
    |
 LL |         hours_are_suns = false;
    |         ^^^^^^^^^^^^^^
@@ -37,4 +37,10 @@ note: lint level defined here
 LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
    |         ^^^^^^
    = note: #[warn(unused_assignments)] implied by #[warn(unused)]
+
+warning: unused variable: `case`
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:44:24
+   |
+LL |         &Large::Suit { case } => {}
+   |                        ^^^^ help: try ignoring the field: `case: _`
 


### PR DESCRIPTION
Successful merges:

 - #50233 (Make `Vec::new` a `const fn`)
 - #50312 (Add more links in panic docs)
 - #50316 (Fix some broken links in docs.)
 - #50325 (Add a few more tests for proc macro feature gating)
 - #50327 (Display correct unused field suggestion for nested struct patterns)
 - #50330 (check that #[used] is used only on statics)
 - #50344 (Update Cargo to 2018-04-28 122fd5be5201913d42e219e132d6569493583bca)

Failed merges:

