### PR TITLE
Only check for unused mut user variables and not all arguments

### DIFF
--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -254,9 +254,7 @@ impl<'tcx> Mir<'tcx> {
         (1..self.local_decls.len()).filter_map(move |index| {
             let local = Local::new(index);
             let decl = &self.local_decls[local];
-            if (decl.is_user_variable || index < self.arg_count + 1)
-               && decl.mutability == Mutability::Mut
-            {
+            if decl.is_user_variable && decl.mutability == Mutability::Mut {
                 Some(local)
             } else {
                 None

--- a/src/test/run-pass/nll/issue-50343.rs
+++ b/src/test/run-pass/nll/issue-50343.rs
@@ -1,0 +1,16 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(nll)]
+#![deny(unused_mut)]
+
+fn foo<'r>(_: &'r ()) -> &'r () { &() }
+
+fn main() { }


### PR DESCRIPTION
Fixes #50343.