### PR TITLE
Correct initial field alignment for repr(C)/repr(int)

### DIFF
--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -940,11 +940,15 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                 // We increase the size of the discriminant to avoid LLVM copying
                 // padding when it doesn't need to. This normally causes unaligned
                 // load/stores and excessive memcpy/memset operations. By using a
-                // bigger integer size, LLVM can be sure about it's contents and
+                // bigger integer size, LLVM can be sure about its contents and
                 // won't be so conservative.
 
                 // Use the initial field alignment
-                let mut ity = Integer::for_abi_align(dl, start_align).unwrap_or(min_ity);
+                let mut ity = if def.repr.c() || def.repr.int.is_some() {
+                    min_ity
+                } else {
+                    Integer::for_abi_align(dl, start_align).unwrap_or(min_ity)
+                };
 
                 // If the alignment is not larger than the chosen discriminant size,
                 // don't use the alignment as the final size.

--- a/src/test/run-pass/repr_c_int_align.rs
+++ b/src/test/run-pass/repr_c_int_align.rs
@@ -18,6 +18,12 @@ enum ReprCu8 {
     B,
 }
 
+#[repr(u8)]
+enum Repru8 {
+    A(u16),
+    B,
+}
+
 #[repr(C)]
 struct ReprC {
     tag: u8,
@@ -26,6 +32,7 @@ struct ReprC {
 }
 
 fn main() {
+    // Test `repr(C, u8)`.
     let r1 = ReprC { tag: 0, padding: 0, payload: 0 };
     let r2 = ReprC { tag: 0, padding: 1, payload: 1 };
 
@@ -34,6 +41,15 @@ fn main() {
 
     match (t1, t2) {
         (ReprCu8::A(_), ReprCu8::A(_)) => (),
+        _ => assert!(false)
+    };
+
+    // Test `repr(u8)`.
+    let t1: &Repru8 = unsafe { std::mem::transmute(&r1) };
+    let t2: &Repru8 = unsafe { std::mem::transmute(&r2) };
+
+    match (t1, t2) {
+        (Repru8::A(_), Repru8::A(_)) => (),
         _ => assert!(false)
     };
 }

--- a/src/test/run-pass/repr_c_int_align.rs
+++ b/src/test/run-pass/repr_c_int_align.rs
@@ -1,0 +1,39 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -O
+
+#![allow(dead_code)]
+
+#[repr(C, u8)]
+enum ReprCu8 {
+    A(u16),
+    B,
+}
+
+#[repr(C)]
+struct ReprC {
+    tag: u8,
+    padding: u8,
+    payload: u16,
+}
+
+fn main() {
+    let r1 = ReprC { tag: 0, padding: 0, payload: 0 };
+    let r2 = ReprC { tag: 0, padding: 1, payload: 1 };
+
+    let t1: &ReprCu8 = unsafe { std::mem::transmute(&r1) };
+    let t2: &ReprCu8 = unsafe { std::mem::transmute(&r2) };
+
+    match (t1, t2) {
+        (ReprCu8::A(_), ReprCu8::A(_)) => (),
+        _ => assert!(false)
+    };
+}

--- a/src/test/ui/print_type_sizes/repr_int_c.rs
+++ b/src/test/ui/print_type_sizes/repr_int_c.rs
@@ -1,0 +1,35 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z print-type-sizes
+// compile-pass
+
+// This test makes sure that the tag is not grown for `repr(C)` or `repr(u8)`
+// variants (see https://github.com/rust-lang/rust/issues/50098 for the original bug).
+
+#![feature(start)]
+#![allow(dead_code)]
+
+#[repr(C, u8)]
+enum ReprCu8 {
+    A(u16),
+    B,
+}
+
+#[repr(u8)]
+enum Repru8 {
+    A(u16),
+    B,
+}
+
+#[start]
+fn start(_: isize, _: *const *const u8) -> isize {
+    0
+}

--- a/src/test/ui/print_type_sizes/repr_int_c.stdout
+++ b/src/test/ui/print_type_sizes/repr_int_c.stdout
@@ -1,0 +1,12 @@
+print-type-size type: `ReprCu8`: 4 bytes, alignment: 2 bytes
+print-type-size     discriminant: 1 bytes
+print-type-size     variant `A`: 3 bytes
+print-type-size         padding: 1 bytes
+print-type-size         field `.0`: 2 bytes, alignment: 2 bytes
+print-type-size     variant `B`: 1 bytes
+print-type-size type: `Repru8`: 4 bytes, alignment: 2 bytes
+print-type-size     discriminant: 1 bytes
+print-type-size     variant `A`: 3 bytes
+print-type-size         padding: 1 bytes
+print-type-size         field `.0`: 2 bytes, alignment: 2 bytes
+print-type-size     variant `B`: 0 bytes


### PR DESCRIPTION
Fixes #50098 following https://github.com/rust-lang/rust/issues/50098#issuecomment-385497333.

(I wasn't sure which kind of test was best suited here — I picked run-pass simply because that was convenient, but if codegen is more appropriate, let me know and I'll change it.)

r? @eddyb 