### PR TITLE
Clarify wordings of the `unstable_name_collision` lint.

### DIFF
--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -507,7 +507,7 @@ pub fn struct_lint_level<'a>(sess: &'a Session,
 
         let explanation = if lint_id == LintId::of(::lint::builtin::UNSTABLE_NAME_COLLISION) {
             "once this method is added to the standard library, \
-             there will be ambiguity here, which will cause a hard error!"
+             the ambiguity may cause an error or change in behavior!"
                 .to_owned()
         } else if let Some(edition) = future_incompatible.edition {
             format!("{} in the {} edition!", STANDARD_MESSAGE, edition)

--- a/src/test/ui/inference_unstable.rs
+++ b/src/test/ui/inference_unstable.rs
@@ -25,5 +25,5 @@ use inference_unstable_itertools::IpuItertools;
 fn main() {
     assert_eq!('x'.ipu_flatten(), 1);
     //~^ WARN a method with this name may be added to the standard library in the future
-    //~^^ WARN once this method is added to the standard library, there will be ambiguity here
+    //~^^ WARN once this method is added to the standard library, the ambiguity may cause an error
 }

--- a/src/test/ui/inference_unstable.stderr
+++ b/src/test/ui/inference_unstable.stderr
@@ -5,7 +5,7 @@ LL |     assert_eq!('x'.ipu_flatten(), 1);
    |                    ^^^^^^^^^^^
    |
    = note: #[warn(unstable_name_collision)] on by default
-   = warning: once this method is added to the standard library, there will be ambiguity here, which will cause a hard error!
+   = warning: once this method is added to the standard library, the ambiguity may cause an error or change in behavior!
    = note: for more information, see issue #48919 <https://github.com/rust-lang/rust/issues/48919>
    = help: call with fully qualified syntax `inference_unstable_itertools::IpuItertools::ipu_flatten(...)` to keep using the current method
    = note: add #![feature(ipu_flatten)] to the crate attributes to enable `inference_unstable_iterator::IpuIterator::ipu_flatten`


### PR DESCRIPTION
Stabilizing an inherent method may cause change in behavior instead of inference error. Updated to use the wording from [varkor's comment].

Closes #50232.

[varkor's comment]: https://github.com/rust-lang/rust/issues/50232#issuecomment-384678097