### PR TITLE
Improve `Debug` impl of `time::Duration`

### DIFF
--- a/src/libcore/tests/time.rs
+++ b/src/libcore/tests/time.rs
@@ -202,13 +202,19 @@ fn debug_formatting_precision_zero() {
     assert_eq!(format!("{:.0?}", Duration::new(0, 123)), "123ns");
 
     assert_eq!(format!("{:.0?}", Duration::new(0, 1_001)), "1µs");
-    assert_eq!(format!("{:.0?}", Duration::new(0, 1_999)), "1µs");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_499)), "1µs");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_500)), "2µs");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_999)), "2µs");
 
     assert_eq!(format!("{:.0?}", Duration::new(0, 1_000_001)), "1ms");
-    assert_eq!(format!("{:.0?}", Duration::new(0, 1_999_999)), "1ms");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_499_999)), "1ms");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_500_000)), "2ms");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_999_999)), "2ms");
 
     assert_eq!(format!("{:.0?}", Duration::new(1, 000_000_001)), "1s");
-    assert_eq!(format!("{:.0?}", Duration::new(1, 999_999_999)), "1s");
+    assert_eq!(format!("{:.0?}", Duration::new(1, 499_999_999)), "1s");
+    assert_eq!(format!("{:.0?}", Duration::new(1, 500_000_000)), "2s");
+    assert_eq!(format!("{:.0?}", Duration::new(1, 999_999_999)), "2s");
 }
 
 #[test]
@@ -222,15 +228,19 @@ fn debug_formatting_precision_two() {
     assert_eq!(format!("{:.2?}", Duration::new(0, 1_000)), "1.00µs");
     assert_eq!(format!("{:.2?}", Duration::new(0, 7_001)), "7.00µs");
     assert_eq!(format!("{:.2?}", Duration::new(0, 7_100)), "7.10µs");
-    assert_eq!(format!("{:.2?}", Duration::new(0, 1_999)), "1.99µs");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 7_109)), "7.11µs");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 7_199)), "7.20µs");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 1_999)), "2.00µs");
 
     assert_eq!(format!("{:.2?}", Duration::new(0, 1_000_000)), "1.00ms");
     assert_eq!(format!("{:.2?}", Duration::new(0, 3_001_000)), "3.00ms");
     assert_eq!(format!("{:.2?}", Duration::new(0, 3_100_000)), "3.10ms");
-    assert_eq!(format!("{:.2?}", Duration::new(0, 1_999_999)), "1.99ms");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 1_999_999)), "2.00ms");
 
     assert_eq!(format!("{:.2?}", Duration::new(1, 000_000_000)), "1.00s");
     assert_eq!(format!("{:.2?}", Duration::new(4, 001_000_000)), "4.00s");
     assert_eq!(format!("{:.2?}", Duration::new(2, 100_000_000)), "2.10s");
-    assert_eq!(format!("{:.2?}", Duration::new(8, 999_999_999)), "8.99s");
+    assert_eq!(format!("{:.2?}", Duration::new(2, 104_990_000)), "2.10s");
+    assert_eq!(format!("{:.2?}", Duration::new(2, 105_000_000)), "2.11s");
+    assert_eq!(format!("{:.2?}", Duration::new(8, 999_999_999)), "9.00s");
 }

--- a/src/libcore/tests/time.rs
+++ b/src/libcore/tests/time.rs
@@ -219,11 +219,8 @@ fn debug_formatting_precision_zero() {
 
 #[test]
 fn debug_formatting_precision_two() {
-    // This might seem inconsistent with the other units, but printing
-    // fractional digits for nano seconds would imply more precision than is
-    // actually stored.
-    assert_eq!(format!("{:.2?}", Duration::new(0, 0)), "0ns");
-    assert_eq!(format!("{:.2?}", Duration::new(0, 123)), "123ns");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 0)), "0.00ns");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 123)), "123.00ns");
 
     assert_eq!(format!("{:.2?}", Duration::new(0, 1_000)), "1.00µs");
     assert_eq!(format!("{:.2?}", Duration::new(0, 7_001)), "7.00µs");
@@ -243,4 +240,13 @@ fn debug_formatting_precision_two() {
     assert_eq!(format!("{:.2?}", Duration::new(2, 104_990_000)), "2.10s");
     assert_eq!(format!("{:.2?}", Duration::new(2, 105_000_000)), "2.11s");
     assert_eq!(format!("{:.2?}", Duration::new(8, 999_999_999)), "9.00s");
+}
+
+#[test]
+fn debug_formatting_precision_high() {
+    assert_eq!(format!("{:.5?}",  Duration::new(0, 23_678)), "23.67800µs");
+
+    assert_eq!(format!("{:.9?}",  Duration::new(1, 000_000_000)), "1.000000000s");
+    assert_eq!(format!("{:.10?}", Duration::new(4, 001_000_000)), "4.0010000000s");
+    assert_eq!(format!("{:.20?}", Duration::new(4, 001_000_000)), "4.00100000000000000000s");
 }

--- a/src/libcore/tests/time.rs
+++ b/src/libcore/tests/time.rs
@@ -122,3 +122,115 @@ fn checked_div() {
     assert_eq!(Duration::new(1, 0).checked_div(2), Some(Duration::new(0, 500_000_000)));
     assert_eq!(Duration::new(2, 0).checked_div(0), None);
 }
+
+#[test]
+fn debug_formatting_extreme_values() {
+    assert_eq!(
+        format!("{:?}", Duration::new(18_446_744_073_709_551_615, 123_456_789)),
+        "18446744073709551615.123456789s"
+    );
+}
+
+#[test]
+fn debug_formatting_secs() {
+    assert_eq!(format!("{:?}", Duration::new(7, 000_000_000)), "7s");
+    assert_eq!(format!("{:?}", Duration::new(7, 100_000_000)), "7.1s");
+    assert_eq!(format!("{:?}", Duration::new(7, 000_010_000)), "7.00001s");
+    assert_eq!(format!("{:?}", Duration::new(7, 000_000_001)), "7.000000001s");
+    assert_eq!(format!("{:?}", Duration::new(7, 123_456_789)), "7.123456789s");
+
+    assert_eq!(format!("{:?}", Duration::new(88, 000_000_000)), "88s");
+    assert_eq!(format!("{:?}", Duration::new(88, 100_000_000)), "88.1s");
+    assert_eq!(format!("{:?}", Duration::new(88, 000_010_000)), "88.00001s");
+    assert_eq!(format!("{:?}", Duration::new(88, 000_000_001)), "88.000000001s");
+    assert_eq!(format!("{:?}", Duration::new(88, 123_456_789)), "88.123456789s");
+
+    assert_eq!(format!("{:?}", Duration::new(999, 000_000_000)), "999s");
+    assert_eq!(format!("{:?}", Duration::new(999, 100_000_000)), "999.1s");
+    assert_eq!(format!("{:?}", Duration::new(999, 000_010_000)), "999.00001s");
+    assert_eq!(format!("{:?}", Duration::new(999, 000_000_001)), "999.000000001s");
+    assert_eq!(format!("{:?}", Duration::new(999, 123_456_789)), "999.123456789s");
+}
+
+#[test]
+fn debug_formatting_millis() {
+    assert_eq!(format!("{:?}", Duration::new(0, 7_000_000)), "7ms");
+    assert_eq!(format!("{:?}", Duration::new(0, 7_100_000)), "7.1ms");
+    assert_eq!(format!("{:?}", Duration::new(0, 7_000_001)), "7.000001ms");
+    assert_eq!(format!("{:?}", Duration::new(0, 7_123_456)), "7.123456ms");
+
+    assert_eq!(format!("{:?}", Duration::new(0, 88_000_000)), "88ms");
+    assert_eq!(format!("{:?}", Duration::new(0, 88_100_000)), "88.1ms");
+    assert_eq!(format!("{:?}", Duration::new(0, 88_000_001)), "88.000001ms");
+    assert_eq!(format!("{:?}", Duration::new(0, 88_123_456)), "88.123456ms");
+
+    assert_eq!(format!("{:?}", Duration::new(0, 999_000_000)), "999ms");
+    assert_eq!(format!("{:?}", Duration::new(0, 999_100_000)), "999.1ms");
+    assert_eq!(format!("{:?}", Duration::new(0, 999_000_001)), "999.000001ms");
+    assert_eq!(format!("{:?}", Duration::new(0, 999_123_456)), "999.123456ms");
+}
+
+#[test]
+fn debug_formatting_micros() {
+    assert_eq!(format!("{:?}", Duration::new(0, 7_000)), "7µs");
+    assert_eq!(format!("{:?}", Duration::new(0, 7_100)), "7.1µs");
+    assert_eq!(format!("{:?}", Duration::new(0, 7_001)), "7.001µs");
+    assert_eq!(format!("{:?}", Duration::new(0, 7_123)), "7.123µs");
+
+    assert_eq!(format!("{:?}", Duration::new(0, 88_000)), "88µs");
+    assert_eq!(format!("{:?}", Duration::new(0, 88_100)), "88.1µs");
+    assert_eq!(format!("{:?}", Duration::new(0, 88_001)), "88.001µs");
+    assert_eq!(format!("{:?}", Duration::new(0, 88_123)), "88.123µs");
+
+    assert_eq!(format!("{:?}", Duration::new(0, 999_000)), "999µs");
+    assert_eq!(format!("{:?}", Duration::new(0, 999_100)), "999.1µs");
+    assert_eq!(format!("{:?}", Duration::new(0, 999_001)), "999.001µs");
+    assert_eq!(format!("{:?}", Duration::new(0, 999_123)), "999.123µs");
+}
+
+#[test]
+fn debug_formatting_nanos() {
+    assert_eq!(format!("{:?}", Duration::new(0, 0)), "0ns");
+    assert_eq!(format!("{:?}", Duration::new(0, 1)), "1ns");
+    assert_eq!(format!("{:?}", Duration::new(0, 88)), "88ns");
+    assert_eq!(format!("{:?}", Duration::new(0, 999)), "999ns");
+}
+
+#[test]
+fn debug_formatting_precision_zero() {
+    assert_eq!(format!("{:.0?}", Duration::new(0, 0)), "0ns");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 123)), "123ns");
+
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_001)), "1µs");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_999)), "1µs");
+
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_000_001)), "1ms");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_999_999)), "1ms");
+
+    assert_eq!(format!("{:.0?}", Duration::new(1, 000_000_001)), "1s");
+    assert_eq!(format!("{:.0?}", Duration::new(1, 999_999_999)), "1s");
+}
+
+#[test]
+fn debug_formatting_precision_two() {
+    // This might seem inconsistent with the other units, but printing
+    // fractional digits for nano seconds would imply more precision than is
+    // actually stored.
+    assert_eq!(format!("{:.2?}", Duration::new(0, 0)), "0ns");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 123)), "123ns");
+
+    assert_eq!(format!("{:.2?}", Duration::new(0, 1_000)), "1.00µs");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 7_001)), "7.00µs");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 7_100)), "7.10µs");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 1_999)), "1.99µs");
+
+    assert_eq!(format!("{:.2?}", Duration::new(0, 1_000_000)), "1.00ms");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 3_001_000)), "3.00ms");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 3_100_000)), "3.10ms");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 1_999_999)), "1.99ms");
+
+    assert_eq!(format!("{:.2?}", Duration::new(1, 000_000_000)), "1.00s");
+    assert_eq!(format!("{:.2?}", Duration::new(4, 001_000_000)), "4.00s");
+    assert_eq!(format!("{:.2?}", Duration::new(2, 100_000_000)), "2.10s");
+    assert_eq!(format!("{:.2?}", Duration::new(8, 999_999_999)), "8.99s");
+}


### PR DESCRIPTION
Hi there!

For a long time now, I was getting annoyed by the derived `Debug` impl of `Duration`. Usually, I use `Duration` to either do quick'n'dirty benchmarking or measuring the time of some operation in general. The output of the derived Debug impl is hard to parse for humans: is { secs: 0, nanos: 968360102 } or { secs: 0, nanos 98507324 } longer? 

So after running into the annoyance several times (sometimes building my own function to print the Duration properly), I decided to tackle this. Now the output looks like this:

```
Duration::new(1, 0)                 => 1s
Duration::new(1, 1)                 => 1.000000001s
Duration::new(1, 300)               => 1.0000003s
Duration::new(1, 4000)              => 1.000004s
Duration::new(1, 600000)            => 1.0006s
Duration::new(1, 7000000)           => 1.007s
Duration::new(0, 0)                 => 0ns
Duration::new(0, 1)                 => 1ns
Duration::new(0, 300)               => 300ns
Duration::new(0, 4001)              => 4.001µs
Duration::new(0, 600300)            => 600.3µs
Duration::new(0, 7000000)           => 7ms
```

Note that I implemented the formatting manually and didn't use floats. No information is "lost" when printing. So `Duration::new(123_456_789_000, 900_000_001)` prints as `123456789000.900000001s`.

~~This is not yet finished~~, but I wanted to open the PR now already in order to get some feedback (maybe everyone likes the derived impl).

### Still ToDo:

- [x] Respect precision ~~and width~~ parameter of the formatter (see [this comment](https://github.com/rust-lang/rust/pull/50364#issuecomment-386107107))

### Alternatives/Decisions

- Should large durations displayed in minutes, hours, days, ...? For now, I decided not to because the current formatting is close the how a `Duration` is stored. From this new `Debug` output, you can still easily see what the values of `secs` and `nanos` are. A formatting like `3h 27m 12s 9ms` might be more appropriate for a `Display` impl?
- Should this rather be a `Display` impl and should `Debug` be derived? Maybe this formatting is too fancy for `Debug`? In my opinion it's not and, as already mentioned, from the current format one can still very easily determine the values for `secs` and `nanos`.
- Whitespace between the number and the unit?

### Notes for reviewers

- ~~The combined diff sucks. Rather review both commits individually.~~
- ~~In the unit test, I am building my own type implementing `fmt::Write` to test the output. Maybe there is already something like that which I can use?~~
- My `Debug` impl block is marked as `#[stable(...)]`... but that's fine since the derived Debug impl was stable already, right?

---

~~Apart from the main change, I moved all `time` unit tests into the `tests` directory. All other `libcore` tests are there, so I guess it was simply an oversight. Prior to this change, the `time` tests weren't run, so I guess this is kind of a bug fix. If my `Debug` impl is rejected, I can of course just send the fix as PR.~~ (this was already merged in #50466)
