### PR TITLE
Use two vectors in nearest_common_ancestor.

### DIFF
--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -690,21 +690,22 @@ impl<'tcx> ScopeTree {
         // the start. So this algorithm is faster.
         let mut ma = Some(scope_a);
         let mut mb = Some(scope_b);
-        let mut seen: SmallVec<[Scope; 32]> = SmallVec::new();
+        let mut seen_a: SmallVec<[Scope; 32]> = SmallVec::new();
+        let mut seen_b: SmallVec<[Scope; 32]> = SmallVec::new();
         loop {
             if let Some(a) = ma {
-                if seen.iter().position(|s| *s == a).is_some() {
+                if seen_b.iter().position(|s| *s == a).is_some() {
                     return a;
                 }
-                seen.push(a);
+                seen_a.push(a);
                 ma = self.parent_map.get(&a).map(|s| *s);
             }
 
             if let Some(b) = mb {
-                if seen.iter().position(|s| *s == b).is_some() {
+                if seen_a.iter().position(|s| *s == b).is_some() {
                     return b;
                 }
-                seen.push(b);
+                seen_b.push(b);
                 mb = self.parent_map.get(&b).map(|s| *s);
             }
 


### PR DESCRIPTION
When looking at any scope in scope chain A, we only need to look for
matches among scopes previously seen in scope chain B, and vice versa.
This halves the number of "seen before?" comparisons, speeding up some
runs of style-servo, clap-rs, and syn by 1--2%.

Thanks to @kirillkh for the suggestion.

r? @nikomatsakis 