### PR TITLE
Use escape_default() for strings in LitKind::token().

### DIFF
--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -1228,10 +1228,7 @@ impl LitKind {
 
         match *self {
             LitKind::Str(string, ast::StrStyle::Cooked) => {
-                let mut escaped = String::new();
-                for ch in string.as_str().chars() {
-                    escaped.extend(ch.escape_unicode());
-                }
+                let escaped = string.as_str().escape_default();
                 Token::Literal(token::Lit::Str_(Symbol::intern(&escaped)), None)
             }
             LitKind::Str(string, ast::StrStyle::Raw(n)) => {

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -25,6 +25,7 @@
 #![feature(non_exhaustive)]
 #![feature(const_atomic_usize_new)]
 #![feature(rustc_attrs)]
+#![feature(str_escape)]
 
 #![recursion_limit="256"]
 

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -298,14 +298,10 @@ pub fn char_lit(lit: &str, diag: Option<(Span, &Handler)>) -> (char, isize) {
     }
 }
 
-pub fn escape_default(s: &str) -> String {
-    s.chars().map(char::escape_default).flat_map(|x| x).collect()
-}
-
 /// Parse a string representing a string literal into its final form. Does
 /// unescaping.
 pub fn str_lit(lit: &str, diag: Option<(Span, &Handler)>) -> String {
-    debug!("parse_str_lit: given {}", escape_default(lit));
+    debug!("str_lit: given {}", lit.escape_default());
     let mut res = String::with_capacity(lit.len());
 
     let error = |i| format!("lexer should have rejected {} at {}", lit, i);
@@ -374,7 +370,7 @@ pub fn str_lit(lit: &str, diag: Option<(Span, &Handler)>) -> String {
 /// Parse a string representing a raw string literal into its final form. The
 /// only operation this does is convert embedded CRLF into a single LF.
 pub fn raw_str_lit(lit: &str) -> String {
-    debug!("raw_str_lit: given {}", escape_default(lit));
+    debug!("raw_str_lit: given {}", lit.escape_default());
     let mut res = String::with_capacity(lit.len());
 
     let mut chars = lit.chars().peekable();

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -656,7 +656,7 @@ pub trait PrintState<'a> {
                     style: ast::StrStyle) -> io::Result<()> {
         let st = match style {
             ast::StrStyle::Cooked => {
-                (format!("\"{}\"", parse::escape_default(st)))
+                (format!("\"{}\"", st.escape_default()))
             }
             ast::StrStyle::Raw(n) => {
                 (format!("r{delim}\"{string}\"{delim}",


### PR DESCRIPTION
This avoids converting every char to \u{...} form, which bloats the
resulting strings unnecessarily. It also provides consistency with the
existing escape_default() calls in LitKind::token() used for raw
string literals, char literals, and raw byte char literals.

There are two benefits from this change.

- Compilation is faster. Most of the rustc-perf benchmarks see a
  non-trivial speedup, particularly for incremental rebuilds, with the
  best speedup over 13%, and multiple others over 10%.

- Generated rlibs are smaller. An extreme example is libfutures.rlib,
  which shrinks from 2073306 bytes to 1765927 bytes, a 15% reduction.

r? @jseyfried 

<details><summary>Here are full numbers for all the rustc-perf runs where the improvement was > 1%.</summary>


```
regex-check
	avg: -11.1%	min: -13.4%	max: -5.5%
futures-check
	avg: -7.6%	min: -11.4%	max: -3.5%
futures-opt
	avg: -6.3%	min: -10.3%	max: -2.3%
futures
	avg: -6.6%	min: -10.3%	max: -2.8%
regex-opt
	avg: -4.7%	min: -10.2%	max: -0.4%
regex
	avg: -5.3%	min: -10.2%	max: -1.2%
hyper-check
	avg: -4.8%	min: -6.6%	max: -2.7%
encoding-check
	avg: -4.1%	min: -5.5%	max: -2.5%
issue-46449-check
	avg: -4.7%	min: -5.2%	max: -4.1%
clap-rs-check
	avg: -2.9%	min: -5.2%	max: -1.1%
hyper
	avg: -3.0%	min: -5.1%	max: -0.8%
parser-check
	avg: -4.2%	min: -4.9%	max: -3.2%
hyper-opt
	avg: -2.6%	min: -4.9%	max: -0.3%
encoding-opt
	avg: -2.3%	min: -4.6%	max: -0.5%
encoding
	avg: -2.5%	min: -4.4%	max: -0.6%
issue-46449
	avg: -2.3%	min: -4.4%	max: -1.8%
issue-46449-opt
	avg: -1.7%	min: -4.3%	max: -0.9%
clap-rs-opt
	avg: -1.6%	min: -4.2%	max: -0.2%
serde-check
	avg: -1.4%	min: -4.1%	max: -0.2%
clap-rs
	avg: -1.6%	min: -3.9%	max: -0.7%
unify-linearly-check
	avg: -3.2%	min: -3.7%	max: -2.7%
serde
	avg: -1.1%	min: -3.5%	max: -0.1%
regression-31157-check
	avg: -2.6%	min: -3.4%	max: -1.6%
helloworld-check
	avg: -2.5%	min: -3.4%	max: -0.6%
serde-opt
	avg: -1.3%	min: -3.3%	max: -0.5%
tokio-webpush-simple-check
	avg: -2.4%	min: -3.2%	max: -1.8%
piston-image-check
	avg: -1.7%	min: -3.2%	max: -0.9%
deeply-nested-opt
	avg: -1.5%	min: -3.0%	max: -0.6%
deeply-nested-check
	avg: -1.9%	min: -2.9%	max: -0.4%
deeply-nested
	avg: -1.9%	min: -2.9%	max: -1.2%
syn-check
	avg: -1.8%	min: -2.8%	max: -0.6%
coercions
	avg: -0.5%	min: -2.8%	max: 0.4%
syn-opt
	avg: -0.9%	min: -2.4%	max: -0.1%
syn
	avg: -1.1%	min: -2.2%	max: -0.3%
parser-opt
	avg: -1.9%	min: -2.1%	max: -1.6%
parser
	avg: -1.9%	min: -2.1%	max: -1.6%
style-servo-check
	avg: -1.3%	min: -2.0%	max: -0.8%
regression-31157-opt
	avg: -0.8%	min: -2.0%	max: 0.0%
piston-image
	avg: -0.7%	min: -1.8%	max: -0.2%
piston-image-opt
	avg: -0.6%	min: -1.8%	max: -0.0%
regression-31157
	avg: -1.0%	min: -1.7%	max: -0.3%
html5ever-opt
	avg: -0.6%	min: -1.5%	max: -0.1%
unify-linearly-opt
	avg: -1.3%	min: -1.5%	max: -1.1%
unify-linearly
	avg: -1.3%	min: -1.4%	max: -1.2%
tokio-webpush-simple-opt
	avg: -0.4%	min: -1.2%	max: -0.0%
helloworld-opt
	avg: -1.0%	min: -1.1%	max: -0.6%
helloworld
	avg: -1.0%	min: -1.1%	max: -0.7%
inflate-opt
	avg: -0.3%	min: -1.1%	max: 0.1%
html5ever-check
	avg: -0.6%	min: -1.0%	max: -0.3%
inflate-check
	avg: -0.3%	min: -1.0%	max: -0.1%
```

</details>