### PR TITLE
Revert "Implement FromStr for PathBuf"

### DIFF
--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -87,7 +87,6 @@ use io;
 use iter::{self, FusedIterator};
 use ops::{self, Deref};
 use rc::Rc;
-use str::FromStr;
 use sync::Arc;
 
 use ffi::{OsStr, OsString};
@@ -1438,32 +1437,6 @@ impl From<PathBuf> for OsString {
 impl From<String> for PathBuf {
     fn from(s: String) -> PathBuf {
         PathBuf::from(OsString::from(s))
-    }
-}
-
-/// Error returned from [`PathBuf::from_str`][`from_str`].
-///
-/// Note that parsing a path will never fail. This error is just a placeholder
-/// for implementing `FromStr` for `PathBuf`.
-///
-/// [`from_str`]: struct.PathBuf.html#method.from_str
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[stable(feature = "path_from_str", since = "1.26.0")]
-pub enum ParsePathError {}
-
-#[stable(feature = "path_from_str", since = "1.26.0")]
-impl fmt::Display for ParsePathError {
-    fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
-        match *self {}
-    }
-}
-
-#[stable(feature = "path_from_str", since = "1.26.0")]
-impl FromStr for PathBuf {
-    type Err = ParsePathError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(PathBuf::from(s))
     }
 }
 


### PR DESCRIPTION
This reverts commit 05a9acc3b844ff284a3e3d85dde2d9798abfb215.

The libs team was discussing https://github.com/rust-lang/rust/issues/44431 today and the changes originally added in https://github.com/rust-lang/rust/pull/48292 and the conclusion was that we'd like to revert this for now until `!` is stable. This'll provide us maximal flexibility to tweak the error type here in the future, and it looks like `!` is close-ish to stabilization so hopefully this won't be delayed for too long.