### PR TITLE
Build `librustc_llvm` as a dylib, and install it as part of the private rustc crates.

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1762,6 +1762,7 @@ dependencies = [
  "graphviz 0.0.0",
  "jobserver 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc_macro 0.0.0",
  "rustc_apfloat 0.0.0",
@@ -2092,7 +2093,6 @@ dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "build_helper 0.1.0",
  "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_cratesio_shim 0.0.0",
 ]
 

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -57,5 +57,5 @@ chalk-engine = { version = "0.6.0", default-features=false }
 #        compiles, then please feel free to do so!
 flate2 = "1.0"
 tempdir = "0.3"
-
+libc = "0.2"
 

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -59,7 +59,7 @@ use std::sync::mpsc::{channel, Sender, Receiver};
 use std::slice;
 use std::time::Instant;
 use std::thread;
-use libc::{c_uint, c_void, c_char, size_t};
+use libc::{c_uint, c_char, size_t};
 
 pub const RELOC_MODEL_ARGS : [(&'static str, llvm::RelocMode); 7] = [
     ("pic", llvm::RelocMode::PIC),
@@ -436,7 +436,7 @@ unsafe extern "C" fn report_inline_asm<'a, 'b>(cgcx: &'a CodegenContext,
 }
 
 unsafe extern "C" fn inline_asm_handler(diag: SMDiagnosticRef,
-                                        user: *const c_void,
+                                        user: *const ::std::os::raw::c_void,
                                         cookie: c_uint) {
     if user.is_null() {
         return
@@ -449,7 +449,8 @@ unsafe extern "C" fn inline_asm_handler(diag: SMDiagnosticRef,
     report_inline_asm(cgcx, &msg, cookie);
 }
 
-unsafe extern "C" fn diagnostic_handler(info: DiagnosticInfoRef, user: *mut c_void) {
+unsafe extern "C" fn diagnostic_handler(info: DiagnosticInfoRef,
+                                        user: *mut ::std::os::raw::c_void) {
     if user.is_null() {
         return
     }

--- a/src/librustc_llvm/Cargo.toml
+++ b/src/librustc_llvm/Cargo.toml
@@ -7,6 +7,7 @@ build = "build.rs"
 [lib]
 name = "rustc_llvm"
 path = "lib.rs"
+crate-type = ["dylib"]
 
 [features]
 static-libstdcpp = []
@@ -14,7 +15,6 @@ emscripten = []
 
 [dependencies]
 bitflags = "1.0"
-libc = "0.2"
 rustc_cratesio_shim = { path = "../librustc_cratesio_shim" }
 
 [build-dependencies]

--- a/src/librustc_llvm/diagnostic.rs
+++ b/src/librustc_llvm/diagnostic.rs
@@ -13,7 +13,7 @@
 pub use self::OptimizationDiagnosticKind::*;
 pub use self::Diagnostic::*;
 
-use libc::c_uint;
+use std::os::raw::c_uint;
 use std::ptr;
 
 use {DiagnosticInfoRef, TwineRef, ValueRef};

--- a/src/librustc_llvm/ffi.rs
+++ b/src/librustc_llvm/ffi.rs
@@ -19,13 +19,15 @@ use debuginfo::{DIBuilderRef, DIDescriptor, DIFile, DILexicalBlock, DISubprogram
                 DIGlobalVariable, DIArray, DISubrange, DITemplateTypeParameter, DIEnumerator,
                 DINameSpace, DIFlags};
 
-use libc::{c_uint, c_int, size_t, c_char};
-use libc::{c_longlong, c_ulonglong, c_void};
+use std::os::raw::{c_uint, c_int, c_char};
+use std::os::raw::{c_longlong, c_ulonglong, c_void};
+
+use super::size_t;
 
 use RustStringRef;
 
 pub type Opcode = u32;
-pub type Bool = c_uint;
+pub type Bool = c_int;
 
 pub const True: Bool = 1 as Bool;
 pub const False: Bool = 0 as Bool;
@@ -482,7 +484,7 @@ pub mod debuginfo {
     bitflags! {
         #[repr(C)]
         #[derive(Default)]
-        pub struct DIFlags: ::libc::uint32_t {
+        pub struct DIFlags: u32 {
             const FlagZero                = 0;
             const FlagPrivate             = 1;
             const FlagProtected           = 2;
@@ -1323,7 +1325,7 @@ extern "C" {
 
     pub fn LLVMPassManagerBuilderCreate() -> PassManagerBuilderRef;
     pub fn LLVMPassManagerBuilderDispose(PMB: PassManagerBuilderRef);
-    pub fn LLVMPassManagerBuilderSetSizeLevel(PMB: PassManagerBuilderRef, Value: Bool);
+    pub fn LLVMPassManagerBuilderSetSizeLevel(PMB: PassManagerBuilderRef, Value: c_uint);
     pub fn LLVMPassManagerBuilderSetDisableUnrollLoops(PMB: PassManagerBuilderRef, Value: Bool);
     pub fn LLVMPassManagerBuilderUseInlinerWithThreshold(PMB: PassManagerBuilderRef,
                                                          threshold: c_uint);

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -383,6 +383,9 @@ pub fn initialize_available_targets() {
 }
 
 pub fn last_error() -> Option<String> {
+  extern "C" {
+    fn free(ptr: *mut std::os::raw::c_void);
+  }
     unsafe {
         let cstr = LLVMRustGetLastError();
         if cstr.is_null() {
@@ -390,7 +393,7 @@ pub fn last_error() -> Option<String> {
         } else {
             let err = CStr::from_ptr(cstr).to_bytes();
             let err = String::from_utf8_lossy(err).to_string();
-            libc::free(cstr as *mut _);
+            free(cstr as *mut _);
             Some(err)
         }
     }


### PR DESCRIPTION
I had to remove `librustc_llvm`'s dependence on the `libc` crate as a part of
this. This seems reasonable as the global changes required were quite minimal.

Fix an FFI bug: `Bool` is signed.