### PR TITLE
Always inline simple BytePos and CharPos methods.

### DIFF
--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -1150,13 +1150,17 @@ pub struct CharPos(pub usize);
 // have been unsuccessful
 
 impl Pos for BytePos {
+    #[inline(always)]
     fn from_usize(n: usize) -> BytePos { BytePos(n as u32) }
+
+    #[inline(always)]
     fn to_usize(&self) -> usize { let BytePos(n) = *self; n as usize }
 }
 
 impl Add for BytePos {
     type Output = BytePos;
 
+    #[inline(always)]
     fn add(self, rhs: BytePos) -> BytePos {
         BytePos((self.to_usize() + rhs.to_usize()) as u32)
     }
@@ -1165,6 +1169,7 @@ impl Add for BytePos {
 impl Sub for BytePos {
     type Output = BytePos;
 
+    #[inline(always)]
     fn sub(self, rhs: BytePos) -> BytePos {
         BytePos((self.to_usize() - rhs.to_usize()) as u32)
     }
@@ -1183,13 +1188,17 @@ impl Decodable for BytePos {
 }
 
 impl Pos for CharPos {
+    #[inline(always)]
     fn from_usize(n: usize) -> CharPos { CharPos(n) }
+
+    #[inline(always)]
     fn to_usize(&self) -> usize { let CharPos(n) = *self; n }
 }
 
 impl Add for CharPos {
     type Output = CharPos;
 
+    #[inline(always)]
     fn add(self, rhs: CharPos) -> CharPos {
         CharPos(self.to_usize() + rhs.to_usize())
     }
@@ -1198,6 +1207,7 @@ impl Add for CharPos {
 impl Sub for CharPos {
     type Output = CharPos;
 
+    #[inline(always)]
     fn sub(self, rhs: CharPos) -> CharPos {
         CharPos(self.to_usize() - rhs.to_usize())
     }


### PR DESCRIPTION
Because they are (a) trivial, and (b) super hot.

This change speeds up most rustc-perf benchmarks, the best by 5%.

Full measurements:
```
coercions-check
	avg: -3.0%	min: -5.4%	max: -1.3%
helloworld-check
	avg: -3.9%	min: -4.1%	max: -3.6%
unify-linearly-check
	avg: -3.1%	min: -3.7%	max: -2.5%
deeply-nested-check
	avg: -2.6%	min: -3.6%	max: -2.1%
coercions-opt
	avg: -2.1%	min: -3.6%	max: -1.3%
coercions
	avg: -2.0%	min: -3.5%	max: -1.0%
issue-46449-check
	avg: -2.8%	min: -3.1%	max: -2.6%
parser-check
	avg: -2.6%	min: -3.1%	max: -2.0%
deeply-nested-opt
	avg: -1.5%	min: -3.0%	max: -0.8%
deeply-nested
	avg: -1.8%	min: -2.9%	max: -1.1%
issue-46449
	avg: -1.4%	min: -2.7%	max: -1.1%
issue-46449-opt
	avg: -1.0%	min: -2.7%	max: -0.5%
regression-31157-check
	avg: -1.7%	min: -2.3%	max: -1.1%
tuple-stress-opt
	avg: -1.0%	min: -2.2%	max: -0.5%
tokio-webpush-simple-check
	avg: -1.6%	min: -2.1%	max: -1.2%
tuple-stress-check
	avg: -1.2%	min: -2.1%	max: -0.8%
unused-warnings-check
	avg: -1.6%	min: -2.0%	max: -1.4%
encoding-check
	avg: -1.4%	min: -1.8%	max: -1.0%
tuple-stress
	avg: -1.0%	min: -1.7%	max: -0.6%
encoding-opt
	avg: -0.9%	min: -1.6%	max: -0.3%
unused-warnings
	avg: -1.3%	min: -1.6%	max: -1.2%
unused-warnings-opt
	avg: -1.3%	min: -1.5%	max: -1.2%
encoding
	avg: -1.0%	min: -1.5%	max: -0.4%
html5ever-opt
	avg: -0.7%	min: -1.5%	max: -0.3%
futures
	avg: -1.0%	min: -1.5%	max: -0.5%
futures-check
	avg: -1.0%	min: -1.5%	max: -0.5%
futures-opt
	avg: -0.8%	min: -1.4%	max: -0.3%
regression-31157-opt
	avg: -0.5%	min: -1.4%	max: -0.0%
unify-linearly-opt
	avg: -1.2%	min: -1.4%	max: -1.0%
parser-opt
	avg: -1.2%	min: -1.4%	max: -1.0%
helloworld
	avg: -1.3%	min: -1.4%	max: -1.3%
helloworld-opt
	avg: -1.3%	min: -1.3%	max: -1.3%
parser
	avg: -1.2%	min: -1.3%	max: -1.0%
regex-check
	avg: -1.1%	min: -1.3%	max: -0.7%
unify-linearly
	avg: -1.1%	min: -1.3%	max: -1.0%
syn-check
	avg: -0.8%	min: -1.3%	max: -0.3%
piston-image-check
	avg: -0.7%	min: -1.2%	max: -0.4%
regex-opt
	avg: -0.5%	min: -1.2%	max: -0.0%
syn
	avg: -0.6%	min: -1.2%	max: -0.3%
hyper
	avg: -0.8%	min: -1.2%	max: -0.4%
syn-opt
	avg: -0.5%	min: -1.2%	max: -0.1%
regex
	avg: -0.7%	min: -1.2%	max: -0.3%
regression-31157
	avg: -0.7%	min: -1.2%	max: -0.3%
clap-rs-check
	avg: -0.6%	min: -1.1%	max: -0.2%
hyper-check
	avg: -0.8%	min: -1.1%	max: -0.5%
piston-image-opt
	avg: -0.4%	min: -1.1%	max: -0.0%
hyper-opt
	avg: -0.6%	min: -1.0%	max: 0.0%
inflate
	avg: -0.4%	min: -1.0%	max: -0.2%
html5ever
	avg: -0.5%	min: -1.0%	max: -0.2%
inflate-opt
	avg: -0.3%	min: -1.0%	max: 0.3%
deep-vector-check
	avg: -0.6%	min: -1.0%	max: -0.3%
style-servo-check
	avg: -0.7%	min: -1.0%	max: -0.5%
tokio-webpush-simple-opt
	avg: -0.3%	min: -0.9%	max: 0.0%
inflate-check
	avg: -0.3%	min: -0.9%	max: -0.1%
piston-image
	avg: -0.4%	min: -0.8%	max: -0.2%
deep-vector
	avg: -0.4%	min: -0.8%	max: -0.1%
clap-rs
	avg: -0.4%	min: -0.7%	max: -0.2%
deep-vector-opt
	avg: -0.2%	min: -0.7%	max: 0.2%
style-servo
	avg: -0.3%	min: -0.7%	max: 0.1%
crates.io
	avg: -0.4%	min: -0.6%	max: -0.2%
crates.io-opt
	avg: -0.3%	min: -0.6%	max: -0.1%
tokio-webpush-simple
	avg: -0.4%	min: -0.6%	max: -0.3%
crates.io-check
	avg: -0.4%	min: -0.6%	max: -0.3%
html5ever-check
	avg: -0.4%	min: -0.6%	max: -0.2%
serde
	avg: -0.1%	min: -0.6%	max: 0.2%
serde-check
	avg: -0.1%	min: -0.5%	max: 0.4%
serde-opt
	avg: -0.2%	min: -0.5%	max: -0.1%
style-servo-opt
	avg: -0.2%	min: -0.4%	max: -0.0%
clap-rs-opt
	avg: -0.1%	min: -0.3%	max: 0.0%

