### PR TITLE
Skip checking for unused mutable locals that have no name

### DIFF
--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -295,10 +295,10 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
                 continue;
             }
 
-            // Skip over locals that begin with an underscore
+            // Skip over locals that begin with an underscore or have no name
             match local_decl.name {
-                Some(name) if name.as_str().starts_with("_") => continue,
-                _ => {},
+                Some(name) => if name.as_str().starts_with("_") { continue; },
+                None => continue,
             }
 
             let source_info = local_decl.source_info;

--- a/src/test/compile-fail/nll/unused-mut-issue-50343.rs
+++ b/src/test/compile-fail/nll/unused-mut-issue-50343.rs
@@ -1,0 +1,17 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(nll)]
+#![deny(unused_mut)]
+
+fn main() {
+    vec![(42, 22)].iter().map(|(mut x, _y)| ()).count();
+    //~^ ERROR: variable does not need to be mutable
+}

--- a/src/test/run-pass/nll/issue-50343.rs
+++ b/src/test/run-pass/nll/issue-50343.rs
@@ -1,0 +1,17 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(nll)]
+#![deny(unused_mut)]
+
+fn main() {
+    vec![42].iter().map(|_| ()).count();
+    vec![(42, 22)].iter().map(|(_x, _y)| ()).count();
+}


### PR DESCRIPTION
Fixes #50343.