### PR TITLE
Fix ICE when using a..=b in a closure. 

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -3121,9 +3121,9 @@ impl<'a> LoweringContext<'a> {
             }
             // Desugar `<start>..=<end>` to `std::ops::RangeInclusive::new(<start>, <end>)`
             ExprKind::Range(Some(ref e1), Some(ref e2), RangeLimits::Closed) => {
-                // FIXME: Use head_sp directly after RangeInclusive::new() is stabilized in stage0.
+                // FIXME: Use e.span directly after RangeInclusive::new() is stabilized in stage0.
                 let span = self.allow_internal_unstable(CompilerDesugaringKind::DotFill, e.span);
-                let id = self.lower_node_id(e.id);
+                let id = self.next_id();
                 let e1 = self.lower_expr(e1);
                 let e2 = self.lower_expr(e2);
                 let ty_path = P(self.std_path(span, &["ops", "RangeInclusive"], false));

--- a/src/test/run-pass/issue-50415.rs
+++ b/src/test/run-pass/issue-50415.rs
@@ -1,0 +1,27 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    // -------- Simplified test case --------
+
+    let _ = || 0..=1;
+
+    // -------- Original test case --------
+
+    let full_length = 1024;
+    let range = {
+        // do some stuff, omit here
+        None
+    };
+
+    let range = range.map(|(s, t)| s..=t).unwrap_or(0..=(full_length-1));
+
+    assert_eq!(range, 0..=1023);
+}


### PR DESCRIPTION
Fix #50415.