### PR TITLE
Remove the deprecated std::net::{lookup_host,LookupHost}

### DIFF
--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -13,11 +13,10 @@ use hash;
 use io;
 use mem;
 use net::{ntoh, hton, IpAddr, Ipv4Addr, Ipv6Addr};
-#[allow(deprecated)]
-use net::lookup_host;
 use option;
 use sys::net::netc as c;
 use sys_common::{FromInner, AsInner, IntoInner};
+use sys_common::net::lookup_host;
 use vec;
 use iter;
 use slice;
@@ -856,7 +855,6 @@ impl ToSocketAddrs for (Ipv6Addr, u16) {
     }
 }
 
-#[allow(deprecated)]
 fn resolve_socket_addr(s: &str, p: u16) -> io::Result<vec::IntoIter<SocketAddr>> {
     let ips = lookup_host(s)?;
     let v: Vec<_> = ips.map(|mut a| { a.set_port(p); a }).collect();

--- a/src/libstd/net/mod.rs
+++ b/src/libstd/net/mod.rs
@@ -38,9 +38,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use fmt;
 use io::{self, Error, ErrorKind};
-use sys_common::net as net_imp;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::ip::{IpAddr, Ipv4Addr, Ipv6Addr, Ipv6MulticastScope};
@@ -127,67 +125,4 @@ fn each_addr<A: ToSocketAddrs, F, T>(addr: A, mut f: F) -> io::Result<T>
         Error::new(ErrorKind::InvalidInput,
                    "could not resolve to any addresses")
     }))
-}
-
-/// An iterator over `SocketAddr` values returned from a host lookup operation.
-#[unstable(feature = "lookup_host", reason = "unsure about the returned \
-                                              iterator and returning socket \
-                                              addresses",
-           issue = "27705")]
-#[rustc_deprecated(since = "1.25.0", reason = "Use the ToSocketAddrs trait instead")]
-pub struct LookupHost(net_imp::LookupHost);
-
-#[unstable(feature = "lookup_host", reason = "unsure about the returned \
-                                              iterator and returning socket \
-                                              addresses",
-           issue = "27705")]
-#[rustc_deprecated(since = "1.25.0", reason = "Use the ToSocketAddrs trait instead")]
-#[allow(deprecated)]
-impl Iterator for LookupHost {
-    type Item = SocketAddr;
-    fn next(&mut self) -> Option<SocketAddr> { self.0.next() }
-}
-
-#[unstable(feature = "lookup_host", reason = "unsure about the returned \
-                                              iterator and returning socket \
-                                              addresses",
-           issue = "27705")]
-#[rustc_deprecated(since = "1.25.0", reason = "Use the ToSocketAddrs trait instead")]
-#[allow(deprecated)]
-impl fmt::Debug for LookupHost {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.pad("LookupHost { .. }")
-    }
-}
-
-/// Resolve the host specified by `host` as a number of `SocketAddr` instances.
-///
-/// This method may perform a DNS query to resolve `host` and may also inspect
-/// system configuration to resolve the specified hostname.
-///
-/// The returned iterator will skip over any unknown addresses returned by the
-/// operating system.
-///
-/// # Examples
-///
-/// ```no_run
-/// #![feature(lookup_host)]
-///
-/// use std::net;
-///
-/// fn main() -> std::io::Result<()> {
-///     for host in net::lookup_host("rust-lang.org")? {
-///         println!("found address: {}", host);
-///     }
-///     Ok(())
-/// }
-/// ```
-#[unstable(feature = "lookup_host", reason = "unsure about the returned \
-                                              iterator and returning socket \
-                                              addresses",
-           issue = "27705")]
-#[rustc_deprecated(since = "1.25.0", reason = "Use the ToSocketAddrs trait instead")]
-#[allow(deprecated)]
-pub fn lookup_host(host: &str) -> io::Result<LookupHost> {
-    net_imp::lookup_host(host).map(LookupHost)
 }

--- a/src/test/run-pass/sync-send-in-std.rs
+++ b/src/test/run-pass/sync-send-in-std.rs
@@ -11,9 +11,7 @@
 // ignore-cloudabi networking not available
 // ignore-wasm32-bare networking not available
 
-#![feature(lookup_host)]
-
-use std::net::lookup_host;
+use std::net::ToSocketAddrs;
 
 fn is_sync<T>(_: T) where T: Sync {}
 fn is_send<T>(_: T) where T: Send {}
@@ -30,5 +28,5 @@ macro_rules! all_sync_send {
 }
 
 fn main() {
-    all_sync_send!(lookup_host("localhost").unwrap(), next);
+    all_sync_send!("localhost:80".to_socket_addrs().unwrap(), next);
 }


### PR DESCRIPTION
These are unstable, and were deprecated by #47510, since Rust 1.25.  The
internal `sys` implementations are still kept to support the call in the
common `resolve_socket_addr`.