### PR TITLE
Split the common usage patterns off the `Alloc` trait

### DIFF
--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -14,7 +14,7 @@ use core::ops::Drop;
 use core::ptr::{self, NonNull, Unique};
 use core::slice;
 
-use alloc::{Alloc, Layout, Global, oom};
+use alloc::{Alloc, AllocExt, Layout, Global, oom};
 use alloc::CollectionAllocErr;
 use alloc::CollectionAllocErr::*;
 use boxed::Box;

--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -934,7 +934,6 @@ pub trait AllocExt: Alloc {
     /// allocation error are encouraged to call the allocator's `oom`
     /// method, rather than directly invoking `panic!` or similar.
     fn alloc_one<T>(&mut self) -> Result<NonNull<T>, AllocErr>
-        where Self: Sized
     {
         let k = Layout::new::<T>();
         if k.size() > 0 {
@@ -962,7 +961,6 @@ pub trait AllocExt: Alloc {
     ///
     /// * the layout of `T` must *fit* that block of memory.
     unsafe fn dealloc_one<T>(&mut self, ptr: NonNull<T>)
-        where Self: Sized
     {
         let k = Layout::new::<T>();
         if k.size() > 0 {
@@ -1001,7 +999,6 @@ pub trait AllocExt: Alloc {
     /// allocation error are encouraged to call the allocator's `oom`
     /// method, rather than directly invoking `panic!` or similar.
     fn alloc_array<T>(&mut self, n: usize) -> Result<NonNull<T>, AllocErr>
-        where Self: Sized
     {
         match Layout::array::<T>(n) {
             Ok(ref layout) if layout.size() > 0 => {
@@ -1049,7 +1046,6 @@ pub trait AllocExt: Alloc {
                                ptr: NonNull<T>,
                                n_old: usize,
                                n_new: usize) -> Result<NonNull<T>, AllocErr>
-        where Self: Sized
     {
         match (Layout::array::<T>(n_old), Layout::array::<T>(n_new)) {
             (Ok(ref k_old), Ok(ref k_new)) if k_old.size() > 0 && k_new.size() > 0 => {
@@ -1083,7 +1079,6 @@ pub trait AllocExt: Alloc {
     ///
     /// Always returns `Err` on arithmetic overflow.
     unsafe fn dealloc_array<T>(&mut self, ptr: NonNull<T>, n: usize) -> Result<(), AllocErr>
-        where Self: Sized
     {
         match Layout::array::<T>(n) {
             Ok(ref k) if k.size() > 0 => {

--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -899,8 +899,10 @@ pub unsafe trait Alloc {
             return Err(CannotReallocInPlace);
         }
     }
+}
 
-
+/// Extension methods for allocators.
+pub trait AllocExt: Alloc {
     // == COMMON USAGE PATTERNS ==
     // alloc_one, dealloc_one, alloc_array, realloc_array. dealloc_array
 
@@ -1093,3 +1095,5 @@ pub unsafe trait Alloc {
         }
     }
 }
+
+impl<A: Alloc> AllocExt for A {}

--- a/src/test/run-pass/allocator-alloc-one.rs
+++ b/src/test/run-pass/allocator-alloc-one.rs
@@ -10,7 +10,7 @@
 
 #![feature(allocator_api, nonnull)]
 
-use std::alloc::{Alloc, Global, oom};
+use std::alloc::{Alloc, AllocExt, Global, oom};
 
 fn main() {
     unsafe {


### PR DESCRIPTION
The `Alloc` trait keeps functions like `alloc`, `dealloc`, `realloc`,
etc. and a new `AllocExt` trait provides `alloc_one`, `dealloc_one`,
`alloc_array`, etc.  While there are some hypothetical benefits from
being able to have custom implementation for the latter, it's far from
the most common need, and when you need to implement generic wrappers
(which I've found to be incredibly common, to the point I've actually
started to write a custom derive for that), you still need to implement
all of them because the wrappee might be customizing them.

OTOH, if an `Alloc` trait implementer does try to do fancy things in
e.g. `alloc_one`, they're not guaranteed that `dealloc_one` will be
called for that allocation. There are multiple reasons for this:

  - The helpers are not used consistently. Just one example, `raw_vec`
uses a mix of `alloc_array`, `alloc`/`alloc_zeroed`, but only uses
`dealloc`.

  - Even with consistent use of e.g. `alloc_array`/`dealloc_array`, one
can still safely convert a `Vec` into a `Box`, which would then use
`dealloc`.

  - Then there are some parts of the API that just don't exist (no
zeroed version of `alloc_one`/`alloc_array`)

So even though there are actual use cases for specialization of e.g.
`alloc_one` (and as a matter of fact, I do have such a need for
mozjemalloc), one is better off using a specialized allocator instead.

Actually, it's worse than that, in the rust repo, there's exactly one
use of `alloc_array`, and no use of `alloc_one`, `dealloc_one`,
`realloc_array`, `dealloc_array`. Not even box syntax uses `alloc_one`,
it uses `exchange_malloc`, which takes a `size` and `align`. So those
functions are more meant as a convenience for clients than for
implementers.

The `AllocExt` trait is implemented for all types implementing `Alloc`
automatically, allowing clients to opt into using its methods, while
preventing implementers from shooting themselves in the foot by trying
to do fancy things by overriding those methods (and making it easier on
people implementing proxy allocators).