### PR TITLE
Suggest more helpful formatting string

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -542,10 +542,10 @@ impl<'a> Display for Arguments<'a> {
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_on_unimplemented(
-    on(crate_local, label="`{Self}` cannot be formatted using `:?`; \
-                            add `#[derive(Debug)]` or manually implement `{Debug}`"),
+    on(crate_local, label="`{Self}` cannot be formatted using `{{:?}}`",
+                    note="add `#[derive(Debug)]` or manually implement `{Debug}`"),
     message="`{Self}` doesn't implement `{Debug}`",
-    label="`{Self}` cannot be formatted using `:?` because it doesn't implement `{Debug}`",
+    label="`{Self}` cannot be formatted using `{{:?}}` because it doesn't implement `{Debug}`",
 )]
 #[doc(alias = "{:?}")]
 #[lang = "debug_trait"]
@@ -610,8 +610,9 @@ pub trait Debug {
 /// ```
 #[rustc_on_unimplemented(
     message="`{Self}` doesn't implement `{Display}`",
-    label="`{Self}` cannot be formatted with the default formatter; \
-           try using `:?` instead if you are using a format string",
+    label="`{Self}` cannot be formatted with the default formatter",
+    note="in format strings you may be able to use `{{:?}}` \
+          (or {{:#?}} for pretty-print) instead",
 )]
 #[doc(alias = "{}")]
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/test/ui/on-unimplemented/no-debug.stderr
+++ b/src/test/ui/on-unimplemented/no-debug.stderr
@@ -2,16 +2,17 @@ error[E0277]: `Foo` doesn't implement `std::fmt::Debug`
   --> $DIR/no-debug.rs:20:27
    |
 LL |     println!("{:?} {:?}", Foo, Bar);
-   |                           ^^^ `Foo` cannot be formatted using `:?`; add `#[derive(Debug)]` or manually implement `std::fmt::Debug`
+   |                           ^^^ `Foo` cannot be formatted using `{:?}`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `Foo`
+   = note: add `#[derive(Debug)]` or manually implement `std::fmt::Debug`
    = note: required by `std::fmt::Debug::fmt`
 
 error[E0277]: `no_debug::Bar` doesn't implement `std::fmt::Debug`
   --> $DIR/no-debug.rs:20:32
    |
 LL |     println!("{:?} {:?}", Foo, Bar);
-   |                                ^^^ `no_debug::Bar` cannot be formatted using `:?` because it doesn't implement `std::fmt::Debug`
+   |                                ^^^ `no_debug::Bar` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `no_debug::Bar`
    = note: required by `std::fmt::Debug::fmt`
@@ -20,18 +21,20 @@ error[E0277]: `Foo` doesn't implement `std::fmt::Display`
   --> $DIR/no-debug.rs:21:23
    |
 LL |     println!("{} {}", Foo, Bar);
-   |                       ^^^ `Foo` cannot be formatted with the default formatter; try using `:?` instead if you are using a format string
+   |                       ^^^ `Foo` cannot be formatted with the default formatter
    |
    = help: the trait `std::fmt::Display` is not implemented for `Foo`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`
 
 error[E0277]: `no_debug::Bar` doesn't implement `std::fmt::Display`
   --> $DIR/no-debug.rs:21:28
    |
 LL |     println!("{} {}", Foo, Bar);
-   |                            ^^^ `no_debug::Bar` cannot be formatted with the default formatter; try using `:?` instead if you are using a format string
+   |                            ^^^ `no_debug::Bar` cannot be formatted with the default formatter
    |
    = help: the trait `std::fmt::Display` is not implemented for `no_debug::Bar`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`
 
 error: aborting due to 4 previous errors


### PR DESCRIPTION
Based on [user feedback](https://users.rust-lang.org/t/ux-feedback-from-a-rust-newbie/17220) the minimal suggestion of `:?` is unclear. 

Also `{:#?}` is much more readable than the standard debug, so this PR suggests it to help surface this nice feature.