### PR TITLE
Reusable handle to thread-local replaceable stdout/err

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -297,6 +297,11 @@ pub use self::stdio::{_print, _eprint};
 #[unstable(feature = "libstd_io_internals", issue = "42788")]
 #[doc(no_inline, hidden)]
 pub use self::stdio::{set_panic, set_print};
+#[unstable(feature = "set_stdio",
+           reason = "this may disappear completely or be replaced \
+                                         with a more general mechanism",
+           issue = "0")]
+pub use self::stdio::{LocalStderr, LocalStdout};
 
 pub mod prelude;
 mod buffered;


### PR DESCRIPTION
Lays the groundwork for mitigating:
- rust-lang/rust#12309
- rust-lang/rust#31983
- rust-lang/rust#40298
- rust-lang/rust#42474

When running tests with logging, logs directed to `io::stdout()` are not captured by the test runner, and intermingle with the test runner's output. This does not aim to directly solve that problem, but rather provides the infrastructure towards allowing users to opt-in to the same behavior that `println!` and friends have in regards to std(out|err) for any type generic over `Write`.

By providing `LocalStderr`/`LocalStdout`, when building logging for tests, the logger can be constructed to use `io::LocalStdout` rather than `io::stdout()`, which will redirect the output with the exact same mechanism that `println!` output is captured in the test runner.

The hidden fn `_print` and `_eprint` have not been removed to avoid necessitating inlining the panicking code for if stdio/stdout error. However, they have been adjusted to write to `LocalStdout`/`LocalStderr`. `print_to` has been replaced with `with_write`, allowing the `Write` impls to defer to the backing `Write` implementation for all methods.

Is this approach amenable? Is this approach towards allowing well-behaved logs to be captured by test runners one that could in the future potentially be stabilized? Would that require a full RFC? (I can write one up.) (I'm not exactly certain how to add a new feature gate, so for now they're gated by `set_stdio`, which isn't _wrong_.) Any bikeshed on naming?

This is mostly a proof-of-concept that this approach would (hopefully) work. Alternately, this switching behavior can be added directly onto `io::Stdin`/`Stdout`, in which case the local versions would not be needed, and test output capturing would be closer to avoiding leakage, but spawning a new thread would still avoid the capture, as the approach used to change stdout in tests is inherently thread-local.

(My local `./x.py test` also stalled out due to what I assume is an environment error, so I'm hoping Travis will indicate if I messed something up horribly.)

WARNING: this touches the output routine used by `print!`/`eprint!`/the default panic handler.
HANDLE WITH CAUTION