### PR TITLE
Make `String::new()` const

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -125,6 +125,7 @@
 #![feature(inclusive_range_methods)]
 #![cfg_attr(stage0, feature(generic_param_attrs))]
 #![feature(rustc_const_unstable)]
+#![feature(const_vec_new)]
 
 #![cfg_attr(not(test), feature(fn_traits, i128))]
 #![cfg_attr(test, feature(test))]

--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -380,7 +380,8 @@ impl String {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn new() -> String {
+    #[rustc_const_unstable(feature = "const_string_new")]
+    pub const fn new() -> String {
         String { vec: Vec::new() }
     }
 

--- a/src/test/run-pass/collections-const-new.rs
+++ b/src/test/run-pass/collections-const-new.rs
@@ -8,10 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test that Vec::new() can be used for constants
+// Test several functions can be used for constants
+// 1. Vec::new()
+// 2. String::new()
 
 #![feature(const_vec_new)]
+#![feature(const_string_new)]
 
 const MY_VEC: Vec<usize> = Vec::new();
+
+const MY_STRING: String = String::new();
 
 pub fn main() {}


### PR DESCRIPTION
Following the steps of https://github.com/rust-lang/rust/pull/50233 , make `String::new()` a `const fn`.