### PR TITLE
Pass a test directory to rustfmt

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -313,6 +313,9 @@ impl Step for Rustfmt {
 
         // Don't build tests dynamically, just a pain to work with
         cargo.env("RUSTC_NO_PREFER_DYNAMIC", "1");
+        let dir = testdir(builder, compiler.host);
+        t!(fs::create_dir_all(&dir));
+        cargo.env("RUSTFMT_TEST_DIR", dir);
 
         builder.add_rustc_lib_path(compiler, &mut cargo);
 


### PR DESCRIPTION
Another attempt to fix the rustfmt tests. `RUSTFMT_TEST_DIR` is consumed by Rustfmt in the latext commit (thus the Rustfmt update) because we need a place to create temp files that won't be read-only.

r? @alexcrichton 