### PR TITLE
Fix ICE in assertion macro

### DIFF
--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -656,7 +656,7 @@ pub trait PrintState<'a> {
                     style: ast::StrStyle) -> io::Result<()> {
         let st = match style {
             ast::StrStyle::Cooked => {
-                (format!("\"{}\"", st.escape_default()))
+                (format!("\"{}\"", st.escape_debug()))
             }
             ast::StrStyle::Raw(n) => {
                 (format!("r{delim}\"{string}\"{delim}",

--- a/src/libsyntax_ext/assert.rs
+++ b/src/libsyntax_ext/assert.rs
@@ -42,16 +42,13 @@ pub fn expand_assert<'cx>(
         tts: if let Some(ts) = custom_msg_args {
             ts.into()
         } else {
-            // `expr_to_string` escapes the string literals with `.escape_default()`
-            // which escapes all non-ASCII characters with `\u`.
-            let escaped_expr = escape_format_string(&unescape_printable_unicode(
-                &pprust::expr_to_string(&cond_expr),
-            ));
-
             TokenStream::from(TokenTree::Token(
                 DUMMY_SP,
                 token::Literal(
-                    token::Lit::Str_(Name::intern(&format!("assertion failed: {}", escaped_expr))),
+                    token::Lit::Str_(Name::intern(&format!(
+                        "assertion failed: {}",
+                        pprust::expr_to_string(&cond_expr).escape_debug()
+                    ))),
                     None,
                 ),
             )).into()
@@ -70,54 +67,4 @@ pub fn expand_assert<'cx>(
         None,
     );
     MacEager::expr(if_expr)
-}
-
-/// Escapes a string for use as a formatting string.
-fn escape_format_string(s: &str) -> String {
-    let mut res = String::with_capacity(s.len());
-    for c in s.chars() {
-        res.extend(c.escape_debug());
-        match c {
-            '{' | '}' => res.push(c),
-            _ => {}
-        }
-    }
-    res
-}
-
-#[test]
-fn test_escape_format_string() {
-    assert!(escape_format_string(r"foo{}\") == r"foo{{}}\\");
-}
-
-/// Unescapes the escaped unicodes (`\u{...}`) that are printable.
-fn unescape_printable_unicode(mut s: &str) -> String {
-    use std::{char, u32};
-
-    let mut res = String::with_capacity(s.len());
-
-    loop {
-        if let Some(start) = s.find(r"\u{") {
-            res.push_str(&s[0..start]);
-            s = &s[start..];
-            s.find('}')
-                .and_then(|end| {
-                    let v = u32::from_str_radix(&s[3..end], 16).ok()?;
-                    let c = char::from_u32(v)?;
-                    // Escape unprintable characters.
-                    res.extend(c.escape_debug());
-                    s = &s[end + 1..];
-                    Some(())
-                })
-                .expect("lexer should have rejected invalid escape sequences");
-        } else {
-            res.push_str(s);
-            return res;
-        }
-    }
-}
-
-#[test]
-fn test_unescape_printable_unicode() {
-    assert!(unescape_printable_unicode(r"\u{2603}\n\u{0}") == r"☃\n\u{0}");
 }

--- a/src/test/compile-fail/issue-50471.rs
+++ b/src/test/compile-fail/issue-50471.rs
@@ -1,0 +1,19 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-pass
+
+fn main() {
+    assert!({false});
+
+    assert!(r"\u{41}" == "A");
+
+    assert!(r"\u{".is_empty());
+}


### PR DESCRIPTION
Fixes #50471. Needs beta-backport (stable-to-beta/nightly regression).

* `panic` with single argument does not need escaping `{` and `}`
* Instead of unescaping `\u{...}` manually, just use `escape_debug` in pprust