### PR TITLE
mark most of std::str methods as #[must_use]

### DIFF
--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -86,6 +86,7 @@ pub use core::str::EncodeUtf16;
 impl<S: Borrow<str>> SliceConcatExt<str> for [S] {
     type Output = String;
 
+    #[must_use]
     fn concat(&self) -> String {
         if self.is_empty() {
             return String::new();
@@ -102,6 +103,7 @@ impl<S: Borrow<str>> SliceConcatExt<str> for [S] {
         result
     }
 
+    #[must_use]
     fn join(&self, sep: &str) -> String {
         if self.is_empty() {
             return String::new();
@@ -130,6 +132,7 @@ impl<S: Borrow<str>> SliceConcatExt<str> for [S] {
         result
     }
 
+    #[must_use]
     fn connect(&self, sep: &str) -> String {
         self.join(sep)
     }
@@ -137,6 +140,7 @@ impl<S: Borrow<str>> SliceConcatExt<str> for [S] {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Borrow<str> for String {
+    #[must_use]
     #[inline]
     fn borrow(&self) -> &str {
         &self[..]
@@ -146,6 +150,8 @@ impl Borrow<str> for String {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl ToOwned for str {
     type Owned = String;
+
+    #[must_use]
     fn to_owned(&self) -> String {
         unsafe { String::from_utf8_unchecked(self.as_bytes().to_owned()) }
     }
@@ -177,6 +183,7 @@ impl str {
     /// let boxed_bytes = boxed_str.into_boxed_bytes();
     /// assert_eq!(*boxed_bytes, *s.as_bytes());
     /// ```
+    #[must_use]
     #[stable(feature = "str_box_extras", since = "1.20.0")]
     #[inline]
     pub fn into_boxed_bytes(self: Box<str>) -> Box<[u8]> {
@@ -303,6 +310,7 @@ impl str {
     ///
     /// assert_eq!(new_year, new_year.to_lowercase());
     /// ```
+    #[must_use]
     #[stable(feature = "unicode_case_mapping", since = "1.2.0")]
     pub fn to_lowercase(&self) -> String {
         let mut s = String::with_capacity(self.len());
@@ -366,6 +374,7 @@ impl str {
     ///
     /// assert_eq!(new_year, new_year.to_uppercase());
     /// ```
+    #[must_use]
     #[stable(feature = "unicode_case_mapping", since = "1.2.0")]
     pub fn to_uppercase(&self) -> String {
         let mut s = String::with_capacity(self.len());
@@ -376,6 +385,7 @@ impl str {
     /// Escapes each char in `s` with [`char::escape_debug`].
     ///
     /// [`char::escape_debug`]: primitive.char.html#method.escape_debug
+    #[must_use]
     #[unstable(feature = "str_escape",
                reason = "return type may change to be an iterator",
                issue = "27791")]
@@ -386,6 +396,7 @@ impl str {
     /// Escapes each char in `s` with [`char::escape_default`].
     ///
     /// [`char::escape_default`]: primitive.char.html#method.escape_default
+    #[must_use]
     #[unstable(feature = "str_escape",
                reason = "return type may change to be an iterator",
                issue = "27791")]
@@ -396,6 +407,7 @@ impl str {
     /// Escapes each char in `s` with [`char::escape_unicode`].
     ///
     /// [`char::escape_unicode`]: primitive.char.html#method.escape_unicode
+    #[must_use]
     #[unstable(feature = "str_escape",
                reason = "return type may change to be an iterator",
                issue = "27791")]
@@ -436,6 +448,7 @@ impl str {
     /// ```
     /// assert_eq!("abc".repeat(4), String::from("abcabcabcabc"));
     /// ```
+    #[must_use]
     #[stable(feature = "repeat_str", since = "1.16.0")]
     pub fn repeat(&self, n: usize) -> String {
         unsafe { String::from_utf8_unchecked(self.as_bytes().repeat(n)) }
@@ -462,6 +475,7 @@ impl str {
     ///
     /// [`make_ascii_uppercase`]: #method.make_ascii_uppercase
     /// [`to_uppercase`]: #method.to_uppercase
+    #[must_use]
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn to_ascii_uppercase(&self) -> String {
@@ -492,6 +506,7 @@ impl str {
     ///
     /// [`make_ascii_lowercase`]: #method.make_ascii_lowercase
     /// [`to_lowercase`]: #method.to_lowercase
+    #[must_use]
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn to_ascii_lowercase(&self) -> String {
@@ -515,6 +530,7 @@ impl str {
 ///
 /// assert_eq!("☺", &*smile);
 /// ```
+#[must_use]
 #[stable(feature = "str_box_extras", since = "1.20.0")]
 #[inline]
 pub unsafe fn from_boxed_utf8_unchecked(v: Box<[u8]>) -> Box<str> {


### PR DESCRIPTION
I have recently noticed #50117 and realized that most of the methods in `std::str` should be annotated with `#[must_use]`. I have even accidentally noticed a wrong use of `.to_lowercase()` in one of a recent Reddit answers, which proves that it is worthwhile to warn users about incorrect usage.

P.S. It seems that there is a need to annotate quite a lot of functions. Is there a plan to do that?