### PR TITLE
rustdoc: Fix missing search results

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1236,20 +1236,10 @@
             var output = '';
             if (array.length > 0) {
                 output = '<table class="search-results"' + extraStyle + '>';
-                var shown = [];
 
                 array.forEach(function(item) {
-                    var name, type, href, displayPath;
-
-                    var id_ty = item.ty + item.path + item.name;
-                    if (shown.indexOf(id_ty) !== -1) {
-                        return;
-                    }
-
-                    shown.push(id_ty);
-                    name = item.name;
-                    type = itemTypes[item.ty];
-
+                    var name = item.name;
+                    var type = itemTypes[item.ty];
                     var res = buildHrefAndPath(item);
                     var href = res[1];
                     var displayPath = res[0];


### PR DESCRIPTION
This code seemed to be trying to remove duplicates from the search results but that should already have happened by this point. It was removing results that only differed in their parent causing missing results.

For example `f64::is_nan` is missing from https://doc.rust-lang.org/nightly/std/?search=is_nan

r? @GuillaumeGomez 