### PR TITLE
Use LazyBTreeMap for region constraints.

### DIFF
--- a/src/librustc/infer/lexical_region_resolve/graphviz.rs
+++ b/src/librustc/infer/lexical_region_resolve/graphviz.rs
@@ -25,11 +25,11 @@ use middle::region;
 use super::Constraint;
 use infer::SubregionOrigin;
 use infer::region_constraints::RegionConstraintData;
+use rustc_data_structures::lazy_btree_map::LazyBTreeMap;
 use util::nodemap::{FxHashMap, FxHashSet};
 
 use std::borrow::Cow;
 use std::collections::hash_map::Entry::Vacant;
-use std::collections::btree_map::BTreeMap;
 use std::env;
 use std::fs::File;
 use std::io;
@@ -124,7 +124,7 @@ pub fn maybe_print_constraints_for<'a, 'gcx, 'tcx>(
 struct ConstraintGraph<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
     graph_name: String,
     region_rels: &'a RegionRelations<'a, 'gcx, 'tcx>,
-    map: &'a BTreeMap<Constraint<'tcx>, SubregionOrigin<'tcx>>,
+    map: &'a LazyBTreeMap<Constraint<'tcx>, SubregionOrigin<'tcx>>,
     node_ids: FxHashMap<Node, usize>,
 }
 
@@ -264,7 +264,7 @@ impl<'a, 'gcx, 'tcx> dot::GraphWalk<'a> for ConstraintGraph<'a, 'gcx, 'tcx> {
     }
 }
 
-pub type ConstraintMap<'tcx> = BTreeMap<Constraint<'tcx>, SubregionOrigin<'tcx>>;
+pub type ConstraintMap<'tcx> = LazyBTreeMap<Constraint<'tcx>, SubregionOrigin<'tcx>>;
 
 fn dump_region_data_to<'a, 'gcx, 'tcx>(region_rels: &RegionRelations<'a, 'gcx, 'tcx>,
                                        map: &ConstraintMap<'tcx>,

--- a/src/librustc/infer/region_constraints/mod.rs
+++ b/src/librustc/infer/region_constraints/mod.rs
@@ -16,15 +16,15 @@ use self::CombineMapType::*;
 use super::{MiscVariable, RegionVariableOrigin, SubregionOrigin};
 use super::unify_key;
 
-use rustc_data_structures::indexed_vec::{IndexVec, Idx};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_data_structures::indexed_vec::{IndexVec, Idx};
+use rustc_data_structures::lazy_btree_map::LazyBTreeMap;
 use rustc_data_structures::unify as ut;
 use ty::{self, Ty, TyCtxt};
 use ty::{Region, RegionVid};
 use ty::ReStatic;
 use ty::{BrFresh, ReLateBound, ReVar};
 
-use std::collections::BTreeMap;
 use std::{cmp, fmt, mem, u32};
 
 mod taint;
@@ -81,7 +81,7 @@ pub type VarInfos = IndexVec<RegionVid, RegionVariableInfo>;
 pub struct RegionConstraintData<'tcx> {
     /// Constraints of the form `A <= B`, where either `A` or `B` can
     /// be a region variable (or neither, as it happens).
-    pub constraints: BTreeMap<Constraint<'tcx>, SubregionOrigin<'tcx>>,
+    pub constraints: LazyBTreeMap<Constraint<'tcx>, SubregionOrigin<'tcx>>,
 
     /// A "verify" is something that we need to verify after inference
     /// is done, but which does not directly affect inference in any


### PR DESCRIPTION
Because a lot of these BTreeMaps don't get anything inserted into them.

In the most extreme case, this halves the number of total bytes
allocated for a debug build of tuple-stress, from 2.2GB to 1.1GB. That
reduction in turn speeds up runs of many benchmarks, the best by 3%.