### PR TITLE
Implement rfc 1789: Conversions from `&mut T` to `&Cell<T>`

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -200,8 +200,9 @@ use cmp::Ordering;
 use fmt::{self, Debug, Display};
 use marker::Unsize;
 use mem;
-use ops::{Deref, DerefMut, CoerceUnsized};
+use ops::{Deref, DerefMut, CoerceUnsized, Index};
 use ptr;
+use slice::SliceIndex;
 
 /// A mutable memory location.
 ///
@@ -236,7 +237,7 @@ use ptr;
 /// See the [module-level documentation](index.html) for more.
 #[stable(feature = "rust1", since = "1.0.0")]
 #[repr(transparent)]
-pub struct Cell<T> {
+pub struct Cell<T: ?Sized> {
     value: UnsafeCell<T>,
 }
 
@@ -287,10 +288,10 @@ impl<T:Copy> Cell<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-unsafe impl<T> Send for Cell<T> where T: Send {}
+unsafe impl<T: ?Sized> Send for Cell<T> where T: Send {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> !Sync for Cell<T> {}
+impl<T: ?Sized> !Sync for Cell<T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T:Copy> Clone for Cell<T> {
@@ -381,46 +382,6 @@ impl<T> Cell<T> {
         }
     }
 
-    /// Returns a raw pointer to the underlying data in this cell.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::cell::Cell;
-    ///
-    /// let c = Cell::new(5);
-    ///
-    /// let ptr = c.as_ptr();
-    /// ```
-    #[inline]
-    #[stable(feature = "cell_as_ptr", since = "1.12.0")]
-    pub fn as_ptr(&self) -> *mut T {
-        self.value.get()
-    }
-
-    /// Returns a mutable reference to the underlying data.
-    ///
-    /// This call borrows `Cell` mutably (at compile-time) which guarantees
-    /// that we possess the only reference.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::cell::Cell;
-    ///
-    /// let mut c = Cell::new(5);
-    /// *c.get_mut() += 1;
-    ///
-    /// assert_eq!(c.get(), 6);
-    /// ```
-    #[inline]
-    #[stable(feature = "cell_get_mut", since = "1.11.0")]
-    pub fn get_mut(&mut self) -> &mut T {
-        unsafe {
-            &mut *self.value.get()
-        }
-    }
-
     /// Sets the contained value.
     ///
     /// # Examples
@@ -499,6 +460,90 @@ impl<T> Cell<T> {
     }
 }
 
+impl<T: ?Sized> Cell<T> {
+    /// Returns a raw pointer to the underlying data in this cell.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::cell::Cell;
+    ///
+    /// let c = Cell::new(5);
+    ///
+    /// let ptr = c.as_ptr();
+    /// ```
+    #[inline]
+    #[stable(feature = "cell_as_ptr", since = "1.12.0")]
+    pub fn as_ptr(&self) -> *mut T {
+        self.value.get()
+    }
+
+    /// Returns a mutable reference to the underlying data.
+    ///
+    /// This call borrows `Cell` mutably (at compile-time) which guarantees
+    /// that we possess the only reference.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::cell::Cell;
+    ///
+    /// let mut c = Cell::new(5);
+    /// *c.get_mut() += 1;
+    ///
+    /// assert_eq!(c.get(), 6);
+    /// ```
+    #[inline]
+    #[stable(feature = "cell_get_mut", since = "1.11.0")]
+    pub fn get_mut(&mut self) -> &mut T {
+        unsafe {
+            &mut *self.value.get()
+        }
+    }
+
+    /// Returns a `&Cell<T>` from a `&mut T`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(as_cell)]
+    /// use std::cell::Cell;
+    /// let slice: &mut [i32] = &mut [1,2,3];
+    /// let cell_slice: &Cell<[i32]> = Cell::from_mut(slice);
+    ///
+    /// assert_eq!(cell_slice.get_with(|v|v.len()), 3)
+    /// ```
+    #[inline]
+    #[unstable(feature = "as_cell", issue="43038")]
+    pub fn from_mut<'a>(t: &'a mut T) -> &'a Cell<T> {
+        unsafe {
+            &*(t as *mut T as *const Cell<T>)
+        }
+    }
+
+    /// Returns a value by applying a function on contained value
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(as_cell)]
+    /// use std::cell::Cell;
+    /// let c : Cell<Vec<i32>> = Cell::new(vec![1,2,3]);
+    /// let sum : i32 = c.get_with(|v|v.iter().sum());
+    /// assert_eq!(sum, 6_i32);
+    /// ```
+    #[inline]
+    #[unstable(feature = "as_cell", issue="43038")]
+    pub fn get_with<U, F>(&self, f: F) -> U
+    where
+        F: Fn(&T) -> U, U: 'static
+    {
+        unsafe {
+            f(&*self.value.get())
+        }
+    }
+}
+
 impl<T: Default> Cell<T> {
     /// Takes the value of the cell, leaving `Default::default()` in its place.
     ///
@@ -521,6 +566,20 @@ impl<T: Default> Cell<T> {
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: CoerceUnsized<U>, U> CoerceUnsized<Cell<U>> for Cell<T> {}
+
+#[unstable(feature = "as_cell", issue="43038")]
+impl<T, I> Index<I> for Cell<[T]>
+where
+    I: SliceIndex<[Cell<T>]>
+{
+    type Output = I::Output;
+
+    fn index(&self, index: I) -> &Self::Output {
+        unsafe {
+            Index::index(&*(self as *const Cell<[T]> as *const [Cell<T>]), index)
+        }
+    }
+}
 
 /// A mutable memory location with dynamically checked borrow rules
 ///

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -200,9 +200,8 @@ use cmp::Ordering;
 use fmt::{self, Debug, Display};
 use marker::Unsize;
 use mem;
-use ops::{Deref, DerefMut, CoerceUnsized, Index};
+use ops::{Deref, DerefMut, CoerceUnsized};
 use ptr;
-use slice::SliceIndex;
 
 /// A mutable memory location.
 ///
@@ -510,8 +509,9 @@ impl<T: ?Sized> Cell<T> {
     /// use std::cell::Cell;
     /// let slice: &mut [i32] = &mut [1,2,3];
     /// let cell_slice: &Cell<[i32]> = Cell::from_mut(slice);
+    /// assert_eq!(cell_slice.len(), 3);
     /// let slice_cell : &[Cell<i32>] = &cell_slice[..];
-    /// assert_eq!(slice_cell.len(), 3)
+    /// assert_eq!(slice_cell.len(), 3);
     /// ```
     #[inline]
     #[unstable(feature = "as_cell", issue="43038")]
@@ -546,15 +546,13 @@ impl<T: Default> Cell<T> {
 impl<T: CoerceUnsized<U>, U> CoerceUnsized<Cell<U>> for Cell<T> {}
 
 #[unstable(feature = "as_cell", issue="43038")]
-impl<T, I> Index<I> for Cell<[T]>
-where
-    I: SliceIndex<[Cell<T>]>
-{
-    type Output = I::Output;
+impl<T> Deref for Cell<[T]> {
+    type Target = [Cell<T>];
 
-    fn index(&self, index: I) -> &Self::Output {
+    #[inline]
+    fn deref(&self) -> &[Cell<T>] {
         unsafe {
-            Index::index(&*(self as *const Cell<[T]> as *const [Cell<T>]), index)
+            &*(self as *const Cell<[T]> as *const [Cell<T>])
         }
     }
 }

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -559,6 +559,16 @@ impl<T> Deref for Cell<[T]> {
     }
 }
 
+#[unstable(feature = "as_cell", issue="43038")]
+impl<T> DerefMut for Cell<[T]> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut [Cell<T>] {
+        unsafe {
+            &mut *(self as *mut Cell<[T]> as *mut [Cell<T>])
+        }
+    }
+}
+
 /// A mutable memory location with dynamically checked borrow rules
 ///
 /// See the [module-level documentation](index.html) for more.

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -507,10 +507,12 @@ impl<T: ?Sized> Cell<T> {
     /// ```
     /// #![feature(as_cell)]
     /// use std::cell::Cell;
-    /// let slice: &mut [i32] = &mut [1,2,3];
+    ///
+    /// let slice: &mut [i32] = &mut [1, 2, 3];
     /// let cell_slice: &Cell<[i32]> = Cell::from_mut(slice);
     /// assert_eq!(cell_slice.len(), 3);
-    /// let slice_cell : &[Cell<i32>] = &cell_slice[..];
+    ///
+    /// let slice_cell: &[Cell<i32>] = &cell_slice[..];
     /// assert_eq!(slice_cell.len(), 3);
     /// ```
     #[inline]

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -510,36 +510,14 @@ impl<T: ?Sized> Cell<T> {
     /// use std::cell::Cell;
     /// let slice: &mut [i32] = &mut [1,2,3];
     /// let cell_slice: &Cell<[i32]> = Cell::from_mut(slice);
-    ///
-    /// assert_eq!(cell_slice.get_with(|v|v.len()), 3)
+    /// let slice_cell : &[Cell<i32>] = &cell_slice[..];
+    /// assert_eq!(slice_cell.len(), 3)
     /// ```
     #[inline]
     #[unstable(feature = "as_cell", issue="43038")]
     pub fn from_mut<'a>(t: &'a mut T) -> &'a Cell<T> {
         unsafe {
             &*(t as *mut T as *const Cell<T>)
-        }
-    }
-
-    /// Returns a value by applying a function on contained value
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(as_cell)]
-    /// use std::cell::Cell;
-    /// let c : Cell<Vec<i32>> = Cell::new(vec![1,2,3]);
-    /// let sum : i32 = c.get_with(|v|v.iter().sum());
-    /// assert_eq!(sum, 6_i32);
-    /// ```
-    #[inline]
-    #[unstable(feature = "as_cell", issue="43038")]
-    pub fn get_with<U, F>(&self, f: F) -> U
-    where
-        F: Fn(&T) -> U, U: 'static
-    {
-        unsafe {
-            f(&*self.value.get())
         }
     }
 }

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -200,9 +200,8 @@ use cmp::Ordering;
 use fmt::{self, Debug, Display};
 use marker::Unsize;
 use mem;
-use ops::{Deref, DerefMut, CoerceUnsized, Index};
+use ops::{Deref, DerefMut, CoerceUnsized};
 use ptr;
-use slice::SliceIndex;
 
 /// A mutable memory location.
 ///
@@ -511,9 +510,8 @@ impl<T: ?Sized> Cell<T> {
     ///
     /// let slice: &mut [i32] = &mut [1, 2, 3];
     /// let cell_slice: &Cell<[i32]> = Cell::from_mut(slice);
-    /// assert_eq!(cell_slice[..].len(), 3);
+    /// let slice_cell: &[Cell<i32>] = cell_slice.as_slice_of_cells();
     ///
-    /// let slice_cell: &[Cell<i32>] = &cell_slice[..];
     /// assert_eq!(slice_cell.len(), 3);
     /// ```
     #[inline]
@@ -548,15 +546,25 @@ impl<T: Default> Cell<T> {
 #[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: CoerceUnsized<U>, U> CoerceUnsized<Cell<U>> for Cell<T> {}
 
-#[unstable(feature = "as_cell", issue="43038")]
-impl<T, I> Index<I> for Cell<[T]>
-    where I: SliceIndex<[Cell<T>]>
-{
-    type Output = I::Output;
-
-    fn index(&self, index: I) -> &Self::Output {
+impl<T> Cell<[T]> {
+    /// Returns a `&[Cell<T>]` from a `&Cell<[T]>`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(as_cell)]
+    /// use std::cell::Cell;
+    ///
+    /// let slice: &mut [i32] = &mut [1, 2, 3];
+    /// let cell_slice: &Cell<[i32]> = Cell::from_mut(slice);
+    /// let slice_cell: &[Cell<i32>] = cell_slice.as_slice_of_cells();
+    ///
+    /// assert_eq!(slice_cell.len(), 3);
+    /// ```
+    #[unstable(feature = "as_cell", issue="43038")]
+    pub fn as_slice_of_cells(&self) -> &[Cell<T>] {
         unsafe {
-            Index::index(&*(self as *const Cell<[T]> as *const [Cell<T>]), index)
+            &*(self as *const Cell<[T]> as *const [Cell<T>])
         }
     }
 }

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -515,7 +515,7 @@ impl<T: ?Sized> Cell<T> {
     /// ```
     #[inline]
     #[unstable(feature = "as_cell", issue="43038")]
-    pub fn from_mut<'a>(t: &'a mut T) -> &'a Cell<T> {
+    pub fn from_mut(t: &mut T) -> &Cell<T> {
         unsafe {
             &*(t as *mut T as *const Cell<T>)
         }

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -112,6 +112,7 @@
 #![feature(unwind_attributes)]
 #![feature(doc_alias)]
 #![feature(inclusive_range_methods)]
+#![feature(repr_transparent)]
 #![feature(mmx_target_feature)]
 #![feature(tbm_target_feature)]
 #![feature(sse4a_target_feature)]

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -112,7 +112,6 @@
 #![feature(unwind_attributes)]
 #![feature(doc_alias)]
 #![feature(inclusive_range_methods)]
-#![feature(repr_transparent)]
 #![feature(mmx_target_feature)]
 #![feature(tbm_target_feature)]
 #![feature(sse4a_target_feature)]

--- a/src/test/run-pass/rfc-1789-as-cell/from-mut.rs
+++ b/src/test/run-pass/rfc-1789-as-cell/from-mut.rs
@@ -13,9 +13,10 @@
 use std::cell::Cell;
 
 fn main() {
-    let slice: &mut [i32] = &mut [1,2,3];
+    let slice: &mut [i32] = &mut [1, 2, 3];
     let cell_slice: &Cell<[i32]> = Cell::from_mut(slice);
     assert_eq!(cell_slice.len(), 3);
-    let sub_slice : &[Cell<i32>] = &cell_slice[1..];
+
+    let sub_slice: &[Cell<i32>] = &cell_slice[1..];
     assert_eq!(sub_slice.len(), 2);
 }

--- a/src/test/run-pass/rfc-1789-as-cell/from-mut.rs
+++ b/src/test/run-pass/rfc-1789-as-cell/from-mut.rs
@@ -15,7 +15,7 @@ use std::cell::Cell;
 fn main() {
     let slice: &mut [i32] = &mut [1, 2, 3];
     let cell_slice: &Cell<[i32]> = Cell::from_mut(slice);
-    assert_eq!(cell_slice.len(), 3);
+    assert_eq!(cell_slice[..].len(), 3);
 
     let sub_slice: &[Cell<i32>] = &cell_slice[1..];
     assert_eq!(sub_slice.len(), 2);

--- a/src/test/run-pass/rfc-1789-as-cell/from-mut.rs
+++ b/src/test/run-pass/rfc-1789-as-cell/from-mut.rs
@@ -15,8 +15,7 @@ use std::cell::Cell;
 fn main() {
     let slice: &mut [i32] = &mut [1, 2, 3];
     let cell_slice: &Cell<[i32]> = Cell::from_mut(slice);
-    assert_eq!(cell_slice[..].len(), 3);
+    let slice_cell: &[Cell<i32>] = cell_slice.as_slice_of_cells();
 
-    let sub_slice: &[Cell<i32>] = &cell_slice[1..];
-    assert_eq!(sub_slice.len(), 2);
+    assert_eq!(slice_cell.len(), 3);
 }

--- a/src/test/run-pass/rfc-1789-as-cell/from-mut.rs
+++ b/src/test/run-pass/rfc-1789-as-cell/from-mut.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(as_cell)]
+
+use std::cell::Cell;
+
+fn main() {
+    let slice: &mut [i32] = &mut [1,2,3];
+    let cell_slice: &Cell<[i32]> = Cell::from_mut(slice);
+    assert_eq!(cell_slice.get_with(|v|v.len()), 3);
+
+    let sub_slice : &[Cell<i32>] = &cell_slice[1..];
+    assert_eq!(sub_slice.len(), 2);
+}

--- a/src/test/run-pass/rfc-1789-as-cell/from-mut.rs
+++ b/src/test/run-pass/rfc-1789-as-cell/from-mut.rs
@@ -15,8 +15,6 @@ use std::cell::Cell;
 fn main() {
     let slice: &mut [i32] = &mut [1,2,3];
     let cell_slice: &Cell<[i32]> = Cell::from_mut(slice);
-    assert_eq!(cell_slice.get_with(|v|v.len()), 3);
-
     let sub_slice : &[Cell<i32>] = &cell_slice[1..];
     assert_eq!(sub_slice.len(), 2);
 }

--- a/src/test/run-pass/rfc-1789-as-cell/from-mut.rs
+++ b/src/test/run-pass/rfc-1789-as-cell/from-mut.rs
@@ -15,6 +15,7 @@ use std::cell::Cell;
 fn main() {
     let slice: &mut [i32] = &mut [1,2,3];
     let cell_slice: &Cell<[i32]> = Cell::from_mut(slice);
+    assert_eq!(cell_slice.len(), 3);
     let sub_slice : &[Cell<i32>] = &cell_slice[1..];
     assert_eq!(sub_slice.len(), 2);
 }


### PR DESCRIPTION
I'm surprised that RFC 1789 has not been implemented for several months. Tracking issue: https://github.com/rust-lang/rust/issues/43038

Please note: when I was writing tests for `&Cell<[i32]>`, I found it is not easy to get the length of the contained slice. So I designed a `get_with` method which might be useful for similar cases. This method is not designed in the RFC, and it certainly needs to be reviewed by core team. I think it has some connections with `Cell::update` https://github.com/rust-lang/rust/issues/50186 , which is also in design phase.