### PR TITLE
Cleanup a `use` in a raw_vec test

### DIFF
--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -748,7 +748,7 @@ mod tests {
 
     #[test]
     fn allocator_param() {
-        use allocator::{Alloc, AllocErr};
+        use alloc::AllocErr;
 
         // Writing a test of integration between third-party
         // allocators and RawVec is a little tricky because the RawVec


### PR DESCRIPTION
`allocator` is deprecated in favor of `alloc`, and `Alloc` is already imported
through `super::*`.