### PR TITLE
Fix thinning pointers to extern types in miri

### DIFF
--- a/src/test/ui/const-eval/extern_fat_pointer.rs
+++ b/src/test/ui/const-eval/extern_fat_pointer.rs
@@ -1,0 +1,23 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-pass
+
+#![feature(extern_types)]
+
+extern {
+    type Opaque;
+}
+
+const FOO: *const u8 = &42 as *const _ as *const Opaque as *const u8;
+
+fn main() {
+    let _foo = FOO;
+}


### PR DESCRIPTION
r? @kennytm as an alternative to disabling the miri build

fixes #50495