### PR TITLE
Inline `Span` methods.

### DIFF
--- a/src/libsyntax_pos/span_encoding.rs
+++ b/src/libsyntax_pos/span_encoding.rs
@@ -31,11 +31,13 @@ pub struct Span(u32);
 
 impl Copy for Span {}
 impl Clone for Span {
+    #[inline]
     fn clone(&self) -> Span {
         *self
     }
 }
 impl PartialEq for Span {
+    #[inline]
     fn eq(&self, other: &Span) -> bool {
         let a = self.0;
         let b = other.0;
@@ -44,6 +46,7 @@ impl PartialEq for Span {
 }
 impl Eq for Span {}
 impl Hash for Span {
+    #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         let a = self.0;
         a.hash(state)


### PR DESCRIPTION
Because they are simple and hot.

This change speeds up some incremental runs of a few rustc-perf
benchmarks, the best by 3%.

Here are the ones with a speedup of at least 1%:
```
coercions
        avg: -1.1%      min: -3.4%      max: -0.2%
html5ever-opt
        avg: -0.8%      min: -1.7%      max: -0.2%
clap-rs-check
        avg: -0.3%      min: -1.4%      max: 0.7%
html5ever
        avg: -0.7%      min: -1.2%      max: -0.4%
html5ever-check
        avg: -0.9%      min: -1.1%      max: -0.8%
clap-rs
        avg: -0.4%      min: -1.1%      max: -0.1%
crates.io-check
        avg: -0.8%      min: -1.0%      max: -0.6%
serde-opt
        avg: -0.6%      min: -1.0%      max: -0.3%
```