### PR TITLE
Use SmallVec for DepNodeIndex within dep_graph.

### DIFF
--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -12,6 +12,7 @@ use errors::DiagnosticBuilder;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::indexed_vec::{Idx, IndexVec};
+use rustc_data_structures::small_vec::SmallVec;
 use rustc_data_structures::sync::{Lrc, RwLock, ReadGuard, Lock};
 use std::env;
 use std::hash::Hash;
@@ -131,7 +132,7 @@ impl DepGraph {
         let mut edges = Vec::new();
         for (index, edge_targets) in current_dep_graph.edges.iter_enumerated() {
             let from = current_dep_graph.nodes[index];
-            for &edge_target in edge_targets {
+            for &edge_target in edge_targets.iter() {
                 let to = current_dep_graph.nodes[edge_target];
                 edges.push((from, to));
             }
@@ -209,7 +210,7 @@ impl DepGraph {
         self.with_task_impl(key, cx, arg, false, task,
             |key| OpenTask::Regular(Lock::new(RegularOpenTask {
                 node: key,
-                reads: Vec::new(),
+                reads: SmallVec::new(),
                 read_set: FxHashSet(),
             })),
             |data, key, task| data.borrow_mut().complete_task(key, task))
@@ -230,7 +231,7 @@ impl DepGraph {
 
         self.with_task_impl(key, cx, input, true, identity_fn,
             |_| OpenTask::Ignore,
-            |data, key, _| data.borrow_mut().alloc_node(key, Vec::new()))
+            |data, key, _| data.borrow_mut().alloc_node(key, SmallVec::new()))
     }
 
     fn with_task_impl<'gcx, C, A, R>(
@@ -353,7 +354,7 @@ impl DepGraph {
         if let Some(ref data) = self.data {
             let (result, open_task) = ty::tls::with_context(|icx| {
                 let task = OpenTask::Anon(Lock::new(AnonOpenTask {
-                    reads: Vec::new(),
+                    reads: SmallVec::new(),
                     read_set: FxHashSet(),
                 }));
 
@@ -626,7 +627,7 @@ impl DepGraph {
 
         debug_assert!(data.colors.borrow().get(prev_dep_node_index).is_none());
 
-        let mut current_deps = Vec::new();
+        let mut current_deps = SmallVec::new();
 
         for &dep_dep_node_index in prev_deps {
             let dep_dep_node_color = data.colors.borrow().get(dep_dep_node_index);
@@ -923,7 +924,7 @@ pub enum WorkProductFileKind {
 
 pub(super) struct CurrentDepGraph {
     nodes: IndexVec<DepNodeIndex, DepNode>,
-    edges: IndexVec<DepNodeIndex, Vec<DepNodeIndex>>,
+    edges: IndexVec<DepNodeIndex, SmallVec<[DepNodeIndex; 8]>>,
     node_to_node_index: FxHashMap<DepNode, DepNodeIndex>,
     forbidden_edge: Option<EdgeFilter>,
 
@@ -1061,7 +1062,7 @@ impl CurrentDepGraph {
         } = task {
             debug_assert_eq!(node, key);
             let krate_idx = self.node_to_node_index[&DepNode::new_no_params(DepKind::Krate)];
-            self.alloc_node(node, vec![krate_idx])
+            self.alloc_node(node, SmallVec::one(krate_idx))
         } else {
             bug!("complete_eval_always_task() - Expected eval always task to be popped");
         }
@@ -1107,7 +1108,7 @@ impl CurrentDepGraph {
 
     fn alloc_node(&mut self,
                   dep_node: DepNode,
-                  edges: Vec<DepNodeIndex>)
+                  edges: SmallVec<[DepNodeIndex; 8]>)
                   -> DepNodeIndex {
         debug_assert_eq!(self.edges.len(), self.nodes.len());
         debug_assert_eq!(self.node_to_node_index.len(), self.nodes.len());
@@ -1122,12 +1123,12 @@ impl CurrentDepGraph {
 
 pub struct RegularOpenTask {
     node: DepNode,
-    reads: Vec<DepNodeIndex>,
+    reads: SmallVec<[DepNodeIndex; 8]>,
     read_set: FxHashSet<DepNodeIndex>,
 }
 
 pub struct AnonOpenTask {
-    reads: Vec<DepNodeIndex>,
+    reads: SmallVec<[DepNodeIndex; 8]>,
     read_set: FxHashSet<DepNodeIndex>,
 }
 


### PR DESCRIPTION
This avoids a decent number of allocations, enough to speed up
incremental runs of many rustc-benchmarks, the best by 2%.

Here are the rustc-perf benchmarks that showed an improvement of at least 1% on one run:
```
unused-warnings-check
	avg: -1.7%	min: -2.4%	max: 0.0%
unused-warnings-opt
	avg: -1.4%	min: -2.0%	max: 0.0%
unused-warnings
	avg: -1.4%	min: -2.0%	max: -0.0%
tokio-webpush-simple-check
	avg: -1.0%	min: -1.7%	max: 0.0%
futures-opt
	avg: -0.9%	min: -1.6%	max: 0.0%
encoding
	avg: -1.2%	min: -1.6%	max: -0.6%
encoding-check
	avg: -0.9%	min: -1.6%	max: 0.0%
encoding-opt
	avg: -0.8%	min: -1.6%	max: -0.1%
futures
	avg: -0.9%	min: -1.5%	max: 0.0%
futures-check
	avg: -0.9%	min: -1.5%	max: 0.1%
regression-31157-check
	avg: -0.9%	min: -1.5%	max: 0.0%
regex
	avg: -0.6%	min: -1.4%	max: 0.0%
regression-31157-opt
	avg: -0.5%	min: -1.4%	max: 0.1%
regression-31157
	avg: -0.7%	min: -1.4%	max: 0.2%
regex-opt
	avg: -0.6%	min: -1.4%	max: 0.1%
hyper-check
	avg: -0.8%	min: -1.4%	max: -0.1%
regex-check
	avg: -1.0%	min: -1.4%	max: 0.0%
hyper-opt
	avg: -0.7%	min: -1.4%	max: -0.1%
hyper
	avg: -0.7%	min: -1.3%	max: 0.1%
piston-image-opt
	avg: -0.4%	min: -1.3%	max: 0.0%
tokio-webpush-simple-opt
	avg: -0.3%	min: -1.3%	max: 0.0%
piston-image-check
	avg: -0.5%	min: -1.3%	max: -0.0%
syn-opt
	avg: -0.5%	min: -1.3%	max: 0.0%
clap-rs-check
	avg: -0.3%	min: -1.3%	max: 0.2%
piston-image
	avg: -0.5%	min: -1.2%	max: 0.1%
syn
	avg: -0.5%	min: -1.2%	max: 0.1%
syn-check
	avg: -0.6%	min: -1.2%	max: -0.1%
issue-46449-opt
	avg: -0.4%	min: -1.2%	max: -0.1%
parser-check
	avg: -0.7%	min: -1.2%	max: 0.1%
issue-46449
	avg: -0.5%	min: -1.2%	max: -0.0%
```