### PR TITLE
make various intrinsics work in const contexts

### DIFF
--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -869,8 +869,63 @@ This does not pose a problem by itself because they can't be accessed directly."
                     Abi::PlatformIntrinsic => {
                         assert!(!self.tcx.is_const_fn(def_id));
                         match &self.tcx.item_name(def_id).as_str()[..] {
-                            "size_of" | "min_align_of" | "type_id" => is_const_fn = Some(def_id),
-
+                            "add_with_overflow" |
+                            "sub_with_overflow" |
+                            "mul_with_overflow" |
+                            "overflowing_sub" |
+                            "overflowing_mul" |
+                            "overflowing_add" |
+                            "powf32" |
+                            "powf64" |
+                            "fmaf32" |
+                            "fmaf64" |
+                            "powif32" |
+                            "powif64" |
+                            "unchecked_shl" |
+                            "unchecked_shr" |
+                            "unchecked_div" |
+                            "unchecked_rem" |
+                            "ctpop" |
+                            "cttz" |
+                            "cttz_nonzero" |
+                            "ctlz" |
+                            "ctlz_nonzero" |
+                            "bswap" |
+                            "sinf32" |
+                            "fabsf32" |
+                            "cosf32" |
+                            "sqrtf32" |
+                            "expf32" |
+                            "exp2f32" |
+                            "logf32" |
+                            "log10f32" |
+                            "log2f32" |
+                            "floorf32" |
+                            "ceilf32" |
+                            "truncf32" |
+                            "sinf64" |
+                            "fabsf64" |
+                            "cosf64" |
+                            "sqrtf64" |
+                            "expf64" |
+                            "exp2f64" |
+                            "logf64" |
+                            "log10f64" |
+                            "log2f64" |
+                            "floorf64" |
+                            "ceilf64" |
+                            "truncf64" |
+                            "assume" |
+                            "likely" |
+                            "unlikely" |
+                            "forget" |
+                            "align_offset" |
+                            "min_align_of" |
+                            "size_of" |
+                            "transmute" |
+                            "type_id" => {
+                                is_const_fn = Some(def_id);
+                            }
                             name if name.starts_with("simd_shuffle") => {
                                 is_shuffle = true;
                             }

--- a/src/test/compile-fail/const-fn-not-safe-for-const.rs
+++ b/src/test/compile-fail/const-fn-not-safe-for-const.rs
@@ -12,12 +12,12 @@
 
 #![feature(const_fn)]
 
-use std::mem::transmute;
+use std::mem::size_of_val;
 
 fn random() -> u32 { 0 }
 
 const fn sub(x: &u32) -> usize {
-    unsafe { transmute(x) } //~ ERROR E0015
+    unsafe { size_of_val(x) } //~ ERROR E0015
 }
 
 const fn sub1() -> u32 {


### PR DESCRIPTION
These intrinsics are fairly inoffensive, and marking them as usable in const contexts doesn't make them any more usable to stable users while making them available to the stdlib at our own discretion. Doing this sooner rather than later minimizes the amount of `cfg(stage0)` shenanigans that will be required.

Mostly this just avoids enum, dst, and pointer intrinsics.

The implementations are copied from miri verbatim.