### PR TITLE
Update the man page with additional --print options

### DIFF
--- a/src/doc/man/rustc.1
+++ b/src/doc/man/rustc.1
@@ -55,7 +55,7 @@ Configure the output that \fBrustc\fR will produce. Each emission may also have
 an optional explicit output \fIPATH\fR specified for that particular emission
 kind. This path takes precedence over the \fB-o\fR option.
 .TP
-\fB\-\-print\fR [crate\-name|file\-names|sysroot]
+\fB\-\-print\fR [crate\-name|\:file\-names|\:sysroot|\:cfg|\:target\-list|\:target\-cpus|\:target\-features|\:relocation\-models|\:code\-models|\:tls\-models|\:target\-spec\-json|\:native\-static\-libs]
 Comma separated list of compiler information to print on stdout.
 .TP
 \fB\-g\fR


### PR DESCRIPTION
`\:` is a `groff` for `<wbr>` to get better line breaking.