### PR TITLE
Rollup of 19 pull requests

### DIFF
--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -36,8 +36,10 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
       s3url="s3://$SCCACHE_BUCKET/docker/$cksum"
       url="https://s3-us-west-1.amazonaws.com/$SCCACHE_BUCKET/docker/$cksum"
       echo "Attempting to download $s3url"
+      rm -f /tmp/rustci_docker_cache
       set +e
-      loaded_images=$(curl $url | docker load | sed 's/.* sha/sha/')
+      retry curl -f -L -C - -o /tmp/rustci_docker_cache "$url"
+      loaded_images=$(docker load -i /tmp/rustci_docker_cache | sed 's/.* sha/sha/')
       set -e
       echo "Downloaded containers:\n$loaded_images"
     fi

--- a/src/ci/docker/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/x86_64-gnu-tools/checktools.sh
@@ -23,6 +23,8 @@ SIX_WEEK_CYCLE="$(( ($(date +%s) / 604800 - 3) % 6 ))"
 
 touch "$TOOLSTATE_FILE"
 
+# Try to test all the tools and store the build/test success in the TOOLSTATE_FILE
+
 set +e
 python2.7 "$X_PY" test --no-fail-fast \
     src/doc/book \
@@ -38,6 +40,7 @@ set -e
 cat "$TOOLSTATE_FILE"
 echo
 
+# This function checks that if a tool's submodule changed, the tool's state must improve
 verify_status() {
     echo "Verifying status of $1..."
     if echo "$CHANGED_FILES" | grep -q "^M[[:blank:]]$2$"; then
@@ -57,6 +60,7 @@ verify_status() {
     fi
 }
 
+# deduplicates the submodule check and the assertion that on beta some tools MUST be passing
 check_dispatch() {
     if [ "$1" = submodule_changed ]; then
         # ignore $2 (branch id)
@@ -69,6 +73,7 @@ check_dispatch() {
     fi
 }
 
+# list all tools here
 status_check() {
     check_dispatch $1 beta book src/doc/book
     check_dispatch $1 beta nomicon src/doc/nomicon
@@ -103,4 +108,6 @@ $COMMIT\t$(cat "$TOOLSTATE_FILE")
     exit 0
 fi
 
+# abort compilation if an important tool doesn't build
+# (this code is reachable if not on the nightly channel)
 status_check "beta_required"

--- a/src/ci/shared.sh
+++ b/src/ci/shared.sh
@@ -21,11 +21,12 @@ function retry {
   while true; do
     "$@" && break || {
       if [[ $n -lt $max ]]; then
+        sleep $n  # don't retry immediately
         ((n++))
         echo "Command failed. Attempt $n/$max:"
       else
         echo "The command has failed after $n attempts."
-        exit 1
+        return 1
       fi
     }
   done

--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -10,6 +10,8 @@
 
 //! A dynamically-sized view into a contiguous sequence, `[T]`.
 //!
+//! *[See also the slice primitive type](../../std/primitive.slice.html).*
+//!
 //! Slices are a view into a block of memory represented as a pointer and a
 //! length.
 //!
@@ -77,8 +79,6 @@
 //!   iterators.
 //! * Further methods that return iterators are [`.split`], [`.splitn`],
 //!   [`.chunks`], [`.windows`] and more.
-//!
-//! *[See also the slice primitive type](../../std/primitive.slice.html).*
 //!
 //! [`Clone`]: ../../std/clone/trait.Clone.html
 //! [`Eq`]: ../../std/cmp/trait.Eq.html

--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -10,6 +10,8 @@
 
 //! Unicode string slices.
 //!
+//! *[See also the `str` primitive type](../../std/primitive.str.html).*
+//!
 //! The `&str` type is one of the two main string types, the other being `String`.
 //! Unlike its `String` counterpart, its contents are borrowed.
 //!
@@ -29,8 +31,6 @@
 //! ```
 //! let hello_world: &'static str = "Hello, world!";
 //! ```
-//!
-//! *[See also the `str` primitive type](../../std/primitive.str.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2533,9 +2533,11 @@ impl<'a, T> Drop for Drain<'a, T> {
                 // memmove back untouched tail, update to new length
                 let start = source_vec.len();
                 let tail = self.tail_start;
-                let src = source_vec.as_ptr().offset(tail as isize);
-                let dst = source_vec.as_mut_ptr().offset(start as isize);
-                ptr::copy(src, dst, self.tail_len);
+                if tail != start {
+                    let src = source_vec.as_ptr().offset(tail as isize);
+                    let dst = source_vec.as_mut_ptr().offset(start as isize);
+                    ptr::copy(src, dst, self.tail_len);
+                }
                 source_vec.set_len(start + self.tail_len);
             }
         }

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -11,9 +11,9 @@
 //! This module provides constants which are specific to the implementation
 //! of the `f32` floating point data type.
 //!
-//! Mathematically significant numbers are provided in the `consts` sub-module.
-//!
 //! *[See also the `f32` primitive type](../../std/primitive.f32.html).*
+//!
+//! Mathematically significant numbers are provided in the `consts` sub-module.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -11,9 +11,9 @@
 //! This module provides constants which are specific to the implementation
 //! of the `f64` floating point data type.
 //!
-//! Mathematically significant numbers are provided in the `consts` sub-module.
-//!
 //! *[See also the `f64` primitive type](../../std/primitive.f64.html).*
+//!
+//! Mathematically significant numbers are provided in the `consts` sub-module.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/ops/range.rs
+++ b/src/libcore/ops/range.rs
@@ -411,6 +411,21 @@ impl<Idx> RangeInclusive<Idx> {
     pub fn end(&self) -> &Idx {
         &self.end
     }
+
+    /// Destructures the RangeInclusive into (lower bound, upper (inclusive) bound).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(inclusive_range_methods)]
+    ///
+    /// assert_eq!((3..=5).into_inner(), (3, 5));
+    /// ```
+    #[unstable(feature = "inclusive_range_methods", issue = "49022")]
+    #[inline]
+    pub fn into_inner(self) -> (Idx, Idx) {
+        (self.start, self.end)
+    }
 }
 
 #[stable(feature = "inclusive_range", since = "1.26.0")]

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -715,6 +715,7 @@ impl Term {
         }
     }
 
+    // FIXME: Remove this, do not stabilize
     /// Get a reference to the interned string.
     #[unstable(feature = "proc_macro", issue = "38356")]
     pub fn as_str(&self) -> &str {
@@ -739,7 +740,7 @@ impl Term {
 #[unstable(feature = "proc_macro", issue = "38356")]
 impl fmt::Display for Term {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.as_str().fmt(f)
+        self.sym.as_str().fmt(f)
     }
 }
 
@@ -1131,7 +1132,7 @@ impl TokenTree {
             },
             self::TokenTree::Term(tt) => {
                 let ident = ast::Ident::new(tt.sym, tt.span.0);
-                let sym_str = tt.sym.as_str();
+                let sym_str = tt.sym.to_string();
                 let token = if sym_str.starts_with("'") {
                     Lifetime(ident)
                 } else if sym_str.starts_with("r#") {

--- a/src/libproc_macro/quote.rs
+++ b/src/libproc_macro/quote.rs
@@ -183,7 +183,7 @@ impl Quote for Op {
 
 impl Quote for Term {
     fn quote(self) -> TokenStream {
-        quote!(::Term::new((quote self.as_str()), (quote self.span())))
+        quote!(::Term::new((quote self.sym.as_str()), (quote self.span())))
     }
 }
 

--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -534,15 +534,9 @@ impl DepGraph {
     }
 
     pub fn serialize(&self) -> SerializedDepGraph {
-        let mut fingerprints = self.fingerprints.borrow_mut();
         let current_dep_graph = self.data.as_ref().unwrap().current.borrow();
 
-        // Make sure we don't run out of bounds below.
-        if current_dep_graph.nodes.len() > fingerprints.len() {
-            fingerprints.resize(current_dep_graph.nodes.len(), Fingerprint::ZERO);
-        }
-
-        let fingerprints = fingerprints.clone().convert_index_type();
+        let fingerprints = self.fingerprints.borrow().clone().convert_index_type();
         let nodes = current_dep_graph.nodes.clone().convert_index_type();
 
         let total_edge_count: usize = current_dep_graph.edges.iter()

--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -12,6 +12,7 @@ use errors::DiagnosticBuilder;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::indexed_vec::{Idx, IndexVec};
+use rustc_data_structures::small_vec::SmallVec;
 use rustc_data_structures::sync::{Lrc, RwLock, ReadGuard, Lock};
 use std::env;
 use std::hash::Hash;
@@ -131,7 +132,7 @@ impl DepGraph {
         let mut edges = Vec::new();
         for (index, edge_targets) in current_dep_graph.edges.iter_enumerated() {
             let from = current_dep_graph.nodes[index];
-            for &edge_target in edge_targets {
+            for &edge_target in edge_targets.iter() {
                 let to = current_dep_graph.nodes[edge_target];
                 edges.push((from, to));
             }
@@ -209,7 +210,7 @@ impl DepGraph {
         self.with_task_impl(key, cx, arg, false, task,
             |key| OpenTask::Regular(Lock::new(RegularOpenTask {
                 node: key,
-                reads: Vec::new(),
+                reads: SmallVec::new(),
                 read_set: FxHashSet(),
             })),
             |data, key, task| data.borrow_mut().complete_task(key, task))
@@ -230,7 +231,7 @@ impl DepGraph {
 
         self.with_task_impl(key, cx, input, true, identity_fn,
             |_| OpenTask::Ignore,
-            |data, key, _| data.borrow_mut().alloc_node(key, Vec::new()))
+            |data, key, _| data.borrow_mut().alloc_node(key, SmallVec::new()))
     }
 
     fn with_task_impl<'gcx, C, A, R>(
@@ -353,7 +354,7 @@ impl DepGraph {
         if let Some(ref data) = self.data {
             let (result, open_task) = ty::tls::with_context(|icx| {
                 let task = OpenTask::Anon(Lock::new(AnonOpenTask {
-                    reads: Vec::new(),
+                    reads: SmallVec::new(),
                     read_set: FxHashSet(),
                 }));
 
@@ -626,7 +627,7 @@ impl DepGraph {
 
         debug_assert!(data.colors.borrow().get(prev_dep_node_index).is_none());
 
-        let mut current_deps = Vec::new();
+        let mut current_deps = SmallVec::new();
 
         for &dep_dep_node_index in prev_deps {
             let dep_dep_node_color = data.colors.borrow().get(dep_dep_node_index);
@@ -923,7 +924,7 @@ pub enum WorkProductFileKind {
 
 pub(super) struct CurrentDepGraph {
     nodes: IndexVec<DepNodeIndex, DepNode>,
-    edges: IndexVec<DepNodeIndex, Vec<DepNodeIndex>>,
+    edges: IndexVec<DepNodeIndex, SmallVec<[DepNodeIndex; 8]>>,
     node_to_node_index: FxHashMap<DepNode, DepNodeIndex>,
     forbidden_edge: Option<EdgeFilter>,
 
@@ -1061,7 +1062,7 @@ impl CurrentDepGraph {
         } = task {
             debug_assert_eq!(node, key);
             let krate_idx = self.node_to_node_index[&DepNode::new_no_params(DepKind::Krate)];
-            self.alloc_node(node, vec![krate_idx])
+            self.alloc_node(node, SmallVec::one(krate_idx))
         } else {
             bug!("complete_eval_always_task() - Expected eval always task to be popped");
         }
@@ -1107,7 +1108,7 @@ impl CurrentDepGraph {
 
     fn alloc_node(&mut self,
                   dep_node: DepNode,
-                  edges: Vec<DepNodeIndex>)
+                  edges: SmallVec<[DepNodeIndex; 8]>)
                   -> DepNodeIndex {
         debug_assert_eq!(self.edges.len(), self.nodes.len());
         debug_assert_eq!(self.node_to_node_index.len(), self.nodes.len());
@@ -1122,12 +1123,12 @@ impl CurrentDepGraph {
 
 pub struct RegularOpenTask {
     node: DepNode,
-    reads: Vec<DepNodeIndex>,
+    reads: SmallVec<[DepNodeIndex; 8]>,
     read_set: FxHashSet<DepNodeIndex>,
 }
 
 pub struct AnonOpenTask {
-    reads: Vec<DepNodeIndex>,
+    reads: SmallVec<[DepNodeIndex; 8]>,
     read_set: FxHashSet<DepNodeIndex>,
 }
 

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -657,6 +657,13 @@ impl Session {
         }
     }
 
+    pub fn target_cpu(&self) -> &str {
+        match self.opts.cg.target_cpu {
+            Some(ref s) => &**s,
+            None => &*self.target.target.options.cpu
+        }
+    }
+
     pub fn must_not_eliminate_frame_pointers(&self) -> bool {
         if let Some(x) = self.opts.cg.force_frame_pointers {
             x

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -980,15 +980,16 @@ where
     let dep_graph = match future_dep_graph {
         None => DepGraph::new_disabled(),
         Some(future) => {
-            let prev_graph = time(sess, "blocked while dep-graph loading finishes", || {
-                future
-                    .open()
-                    .unwrap_or_else(|e| rustc_incremental::LoadResult::Error {
-                        message: format!("could not decode incremental cache: {:?}", e),
-                    })
-                    .open(sess)
-            });
-            DepGraph::new(prev_graph)
+            let (prev_graph, prev_work_products) =
+                time(sess, "blocked while dep-graph loading finishes", || {
+                    future
+                        .open()
+                        .unwrap_or_else(|e| rustc_incremental::LoadResult::Error {
+                            message: format!("could not decode incremental cache: {:?}", e),
+                        })
+                        .open(sess)
+                });
+            DepGraph::new(prev_graph, prev_work_products)
         }
     };
     let hir_forest = time(sess, "lowering ast -> hir", || {

--- a/src/librustc_incremental/persist/load.rs
+++ b/src/librustc_incremental/persist/load.rs
@@ -130,7 +130,7 @@ pub fn load_dep_graph(sess: &Session) ->
     let mut prev_work_products = FxHashMap();
 
     // If we are only building with -Zquery-dep-graph but without an actual
-    // incr. comp. session directory, we exit here. Otherwise we'd fail
+    // incr. comp. session directory, we skip this. Otherwise we'd fail
     // when trying to load work products.
     if sess.incr_comp_session_dir_opt().is_some() {
         let work_products_path = work_products_path(sess);

--- a/src/librustc_incremental/persist/load.rs
+++ b/src/librustc_incremental/persist/load.rs
@@ -10,7 +10,8 @@
 
 //! Code to save/load the dep-graph from files.
 
-use rustc::dep_graph::{PreviousDepGraph, SerializedDepGraph};
+use rustc_data_structures::fx::FxHashMap;
+use rustc::dep_graph::{PreviousDepGraph, SerializedDepGraph, WorkProduct, WorkProductId};
 use rustc::session::Session;
 use rustc::ty::TyCtxt;
 use rustc::ty::maps::OnDiskCache;
@@ -32,51 +33,9 @@ pub fn dep_graph_tcx_init<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
 
     tcx.allocate_metadata_dep_nodes();
     tcx.precompute_in_scope_traits_hashes();
-
-    if tcx.sess.incr_comp_session_dir_opt().is_none() {
-        // If we are only building with -Zquery-dep-graph but without an actual
-        // incr. comp. session directory, we exit here. Otherwise we'd fail
-        // when trying to load work products.
-        return
-    }
-
-    let work_products_path = work_products_path(tcx.sess);
-    let load_result = load_data(tcx.sess.opts.debugging_opts.incremental_info, &work_products_path);
-
-    if let LoadResult::Ok { data: (work_products_data, start_pos) } = load_result {
-        // Decode the list of work_products
-        let mut work_product_decoder = Decoder::new(&work_products_data[..], start_pos);
-        let work_products: Vec<SerializedWorkProduct> =
-            RustcDecodable::decode(&mut work_product_decoder).unwrap_or_else(|e| {
-                let msg = format!("Error decoding `work-products` from incremental \
-                                   compilation session directory: {}", e);
-                tcx.sess.fatal(&msg[..])
-            });
-
-        for swp in work_products {
-            let mut all_files_exist = true;
-            for &(_, ref file_name) in swp.work_product.saved_files.iter() {
-                let path = in_incr_comp_dir_sess(tcx.sess, file_name);
-                if !path.exists() {
-                    all_files_exist = false;
-
-                    if tcx.sess.opts.debugging_opts.incremental_info {
-                        eprintln!("incremental: could not find file for work \
-                                   product: {}", path.display());
-                    }
-                }
-            }
-
-            if all_files_exist {
-                debug!("reconcile_work_products: all files for {:?} exist", swp);
-                tcx.dep_graph.insert_previous_work_product(&swp.id, swp.work_product);
-            } else {
-                debug!("reconcile_work_products: some file for {:?} does not exist", swp);
-                delete_dirty_work_product(tcx, swp);
-            }
-        }
-    }
 }
+
+type WorkProductMap = FxHashMap<WorkProductId, WorkProduct>;
 
 pub enum LoadResult<T> {
     Ok { data: T },
@@ -84,13 +43,12 @@ pub enum LoadResult<T> {
     Error { message: String },
 }
 
-
-impl LoadResult<PreviousDepGraph> {
-    pub fn open(self, sess: &Session) -> PreviousDepGraph {
+impl LoadResult<(PreviousDepGraph, WorkProductMap)> {
+    pub fn open(self, sess: &Session) -> (PreviousDepGraph, WorkProductMap) {
         match self {
             LoadResult::Error { message } => {
                 sess.warn(&message);
-                PreviousDepGraph::new(SerializedDepGraph::new())
+                (PreviousDepGraph::new(SerializedDepGraph::new()), FxHashMap())
             },
             LoadResult::DataOutOfDate => {
                 if let Err(err) = delete_all_session_dir_contents(sess) {
@@ -98,7 +56,7 @@ impl LoadResult<PreviousDepGraph> {
                                       incremental compilation session directory contents `{}`: {}.",
                                       dep_graph_path(sess).display(), err));
                 }
-                PreviousDepGraph::new(SerializedDepGraph::new())
+                (PreviousDepGraph::new(SerializedDepGraph::new()), FxHashMap())
             }
             LoadResult::Ok { data } => data
         }
@@ -125,10 +83,10 @@ fn load_data(report_incremental_info: bool, path: &Path) -> LoadResult<(Vec<u8>,
     }
 }
 
-fn delete_dirty_work_product(tcx: TyCtxt,
+fn delete_dirty_work_product(sess: &Session,
                              swp: SerializedWorkProduct) {
     debug!("delete_dirty_work_product({:?})", swp);
-    work_product::delete_workproduct_files(tcx.sess, &swp.work_product);
+    work_product::delete_workproduct_files(sess, &swp.work_product);
 }
 
 /// Either a result that has already be computed or a
@@ -149,7 +107,7 @@ impl<T> MaybeAsync<T> {
 
 /// Launch a thread and load the dependency graph in the background.
 pub fn load_dep_graph(sess: &Session) ->
-    MaybeAsync<LoadResult<PreviousDepGraph>>
+    MaybeAsync<LoadResult<(PreviousDepGraph, WorkProductMap)>>
 {
     // Since `sess` isn't `Sync`, we perform all accesses to `sess`
     // before we fire the background thread.
@@ -159,7 +117,7 @@ pub fn load_dep_graph(sess: &Session) ->
     if sess.opts.incremental.is_none() {
         // No incremental compilation.
         return MaybeAsync::Sync(LoadResult::Ok {
-            data: PreviousDepGraph::new(SerializedDepGraph::new())
+            data: (PreviousDepGraph::new(SerializedDepGraph::new()), FxHashMap())
         });
     }
 
@@ -168,6 +126,50 @@ pub fn load_dep_graph(sess: &Session) ->
     let path = dep_graph_path_from(&sess.incr_comp_session_dir());
     let report_incremental_info = sess.opts.debugging_opts.incremental_info;
     let expected_hash = sess.opts.dep_tracking_hash();
+
+    let mut prev_work_products = FxHashMap();
+
+    // If we are only building with -Zquery-dep-graph but without an actual
+    // incr. comp. session directory, we exit here. Otherwise we'd fail
+    // when trying to load work products.
+    if sess.incr_comp_session_dir_opt().is_some() {
+        let work_products_path = work_products_path(sess);
+        let load_result = load_data(report_incremental_info, &work_products_path);
+
+        if let LoadResult::Ok { data: (work_products_data, start_pos) } = load_result {
+            // Decode the list of work_products
+            let mut work_product_decoder = Decoder::new(&work_products_data[..], start_pos);
+            let work_products: Vec<SerializedWorkProduct> =
+                RustcDecodable::decode(&mut work_product_decoder).unwrap_or_else(|e| {
+                    let msg = format!("Error decoding `work-products` from incremental \
+                                    compilation session directory: {}", e);
+                    sess.fatal(&msg[..])
+                });
+
+            for swp in work_products {
+                let mut all_files_exist = true;
+                for &(_, ref file_name) in swp.work_product.saved_files.iter() {
+                    let path = in_incr_comp_dir_sess(sess, file_name);
+                    if !path.exists() {
+                        all_files_exist = false;
+
+                        if sess.opts.debugging_opts.incremental_info {
+                            eprintln!("incremental: could not find file for work \
+                                    product: {}", path.display());
+                        }
+                    }
+                }
+
+                if all_files_exist {
+                    debug!("reconcile_work_products: all files for {:?} exist", swp);
+                    prev_work_products.insert(swp.id, swp.work_product);
+                } else {
+                    debug!("reconcile_work_products: some file for {:?} does not exist", swp);
+                    delete_dirty_work_product(sess, swp);
+                }
+            }
+        }
+    }
 
     MaybeAsync::Async(std::thread::spawn(move || {
         time_ext(time_passes, None, "background load prev dep-graph", move || {
@@ -195,7 +197,7 @@ pub fn load_dep_graph(sess: &Session) ->
                     let dep_graph = SerializedDepGraph::decode(&mut decoder)
                         .expect("Error reading cached dep-graph");
 
-                    LoadResult::Ok { data: PreviousDepGraph::new(dep_graph) }
+                    LoadResult::Ok { data: (PreviousDepGraph::new(dep_graph), prev_work_products) }
                 }
             }
         })

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -51,7 +51,6 @@ pub struct Library {
 pub struct CrateLoader<'a> {
     pub sess: &'a Session,
     cstore: &'a CStore,
-    next_crate_num: CrateNum,
     local_crate_name: Symbol,
 }
 
@@ -102,7 +101,6 @@ impl<'a> CrateLoader<'a> {
         CrateLoader {
             sess,
             cstore,
-            next_crate_num: cstore.next_crate_num(),
             local_crate_name: Symbol::intern(local_crate_name),
         }
     }
@@ -198,8 +196,7 @@ impl<'a> CrateLoader<'a> {
         self.verify_no_symbol_conflicts(span, &crate_root);
 
         // Claim this crate number and cache it
-        let cnum = self.next_crate_num;
-        self.next_crate_num = CrateNum::from_u32(cnum.as_u32() + 1);
+        let cnum = self.cstore.alloc_new_crate_num();
 
         // Stash paths for top-most crate locally if necessary.
         let crate_paths = if root.is_none() {

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -64,8 +64,9 @@ pub struct CrateMetadata {
     pub extern_crate: Lock<Option<ExternCrate>>,
 
     pub blob: MetadataBlob,
-    pub cnum_map: Lock<CrateNumMap>,
+    pub cnum_map: CrateNumMap,
     pub cnum: CrateNum,
+    pub dependencies: Lock<Vec<CrateNum>>,
     pub codemap_import_info: RwLock<Vec<ImportedFileMap>>,
     pub attribute_cache: Lock<[Vec<Option<Lrc<[ast::Attribute]>>>; 2]>,
 
@@ -144,7 +145,7 @@ impl CStore {
         }
 
         let data = self.get_crate_data(krate);
-        for &dep in data.cnum_map.borrow().iter() {
+        for &dep in data.dependencies.borrow().iter() {
             if dep != krate {
                 self.push_dependencies_in_postorder(ordering, dep);
             }

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -96,6 +96,10 @@ pub struct CStore {
 impl CStore {
     pub fn new(metadata_loader: Box<MetadataLoader + Sync>) -> CStore {
         CStore {
+            // We add an empty entry for LOCAL_CRATE (which maps to zero) in
+            // order to make array indices in `metas` match with the
+            // corresponding `CrateNum`. This first entry will always remain
+            // `None`.
             metas: RwLock::new(IndexVec::from_elem_n(None, 1)),
             extern_mod_crate_map: Lock::new(FxHashMap()),
             metadata_loader,

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -104,15 +104,15 @@ impl CStore {
 
     /// You cannot use this function to allocate a CrateNum in a thread-safe manner.
     /// It is currently only used in CrateLoader which is single-threaded code.
-    pub fn next_crate_num(&self) -> CrateNum {
+    pub(super) fn next_crate_num(&self) -> CrateNum {
         CrateNum::new(self.metas.borrow().len() + 1)
     }
 
-    pub fn get_crate_data(&self, cnum: CrateNum) -> Lrc<CrateMetadata> {
+    pub(super) fn get_crate_data(&self, cnum: CrateNum) -> Lrc<CrateMetadata> {
         self.metas.borrow()[cnum].clone().unwrap()
     }
 
-    pub fn set_crate_data(&self, cnum: CrateNum, data: Lrc<CrateMetadata>) {
+    pub(super) fn set_crate_data(&self, cnum: CrateNum, data: Lrc<CrateMetadata>) {
         use rustc_data_structures::indexed_vec::Idx;
         let mut met = self.metas.borrow_mut();
         while met.len() <= cnum.index() {
@@ -121,7 +121,7 @@ impl CStore {
         met[cnum] = Some(data);
     }
 
-    pub fn iter_crate_data<I>(&self, mut i: I)
+    pub(super) fn iter_crate_data<I>(&self, mut i: I)
         where I: FnMut(CrateNum, &Lrc<CrateMetadata>)
     {
         for (k, v) in self.metas.borrow().iter_enumerated() {
@@ -131,14 +131,16 @@ impl CStore {
         }
     }
 
-    pub fn crate_dependencies_in_rpo(&self, krate: CrateNum) -> Vec<CrateNum> {
+    pub(super) fn crate_dependencies_in_rpo(&self, krate: CrateNum) -> Vec<CrateNum> {
         let mut ordering = Vec::new();
         self.push_dependencies_in_postorder(&mut ordering, krate);
         ordering.reverse();
         ordering
     }
 
-    pub fn push_dependencies_in_postorder(&self, ordering: &mut Vec<CrateNum>, krate: CrateNum) {
+    pub(super) fn push_dependencies_in_postorder(&self,
+                                                 ordering: &mut Vec<CrateNum>,
+                                                 krate: CrateNum) {
         if ordering.contains(&krate) {
             return;
         }
@@ -153,7 +155,7 @@ impl CStore {
         ordering.push(krate);
     }
 
-    pub fn do_postorder_cnums_untracked(&self) -> Vec<CrateNum> {
+    pub(super) fn do_postorder_cnums_untracked(&self) -> Vec<CrateNum> {
         let mut ordering = Vec::new();
         for (num, v) in self.metas.borrow().iter_enumerated() {
             if let &Some(_) = v {
@@ -163,11 +165,11 @@ impl CStore {
         return ordering
     }
 
-    pub fn add_extern_mod_stmt_cnum(&self, emod_id: ast::NodeId, cnum: CrateNum) {
+    pub(super) fn add_extern_mod_stmt_cnum(&self, emod_id: ast::NodeId, cnum: CrateNum) {
         self.extern_mod_crate_map.borrow_mut().insert(emod_id, cnum);
     }
 
-    pub fn do_extern_mod_stmt_cnum(&self, emod_id: ast::NodeId) -> Option<CrateNum> {
+    pub(super) fn do_extern_mod_stmt_cnum(&self, emod_id: ast::NodeId) -> Option<CrateNum> {
         self.extern_mod_crate_map.borrow().get(&emod_id).cloned()
     }
 }

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -246,7 +246,7 @@ impl<'a, 'tcx: 'a> TyDecoder<'a, 'tcx> for DecodeContext<'a, 'tcx> {
         if cnum == LOCAL_CRATE {
             self.cdata().cnum
         } else {
-            self.cdata().cnum_map.borrow()[cnum]
+            self.cdata().cnum_map[cnum]
         }
     }
 }
@@ -932,7 +932,7 @@ impl<'a, 'tcx> CrateMetadata {
     // Translate a DefId from the current compilation environment to a DefId
     // for an external crate.
     fn reverse_translate_def_id(&self, did: DefId) -> Option<DefId> {
-        for (local, &global) in self.cnum_map.borrow().iter_enumerated() {
+        for (local, &global) in self.cnum_map.iter_enumerated() {
             if global == did.krate {
                 return Some(DefId {
                     krate: local,
@@ -1007,7 +1007,7 @@ impl<'a, 'tcx> CrateMetadata {
             .enumerate()
             .flat_map(|(i, link)| {
                 let cnum = CrateNum::new(i + 1);
-                link.map(|link| (self.cnum_map.borrow()[cnum], link))
+                link.map(|link| (self.cnum_map[cnum], link))
             })
             .collect()
     }

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -970,6 +970,9 @@ fn link_args(cmd: &mut Linker,
              out_filename: &Path,
              trans: &CrateTranslation) {
 
+    // Linker plugins should be specified early in the list of arguments
+    cmd.cross_lang_lto();
+
     // The default library location, we need this to find the runtime.
     // The location of crates will be determined as needed.
     let lib_path = sess.target_filesearch(PathKind::All).get_lib_path();

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -258,7 +258,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                     format!("cannot use `{}=` on type `{}`",
                                     op.node.as_str(), lhs_ty));
                             let mut suggested_deref = false;
-                            if let TyRef(_, ref ty_mut) = lhs_ty.sty {
+                            if let TyRef(_, mut ty_mut) = lhs_ty.sty {
                                 if {
                                     !self.infcx.type_moves_by_default(self.param_env,
                                                                         ty_mut.ty,
@@ -269,10 +269,16 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                             .is_ok()
                                 } {
                                     if let Ok(lstring) = codemap.span_to_snippet(lhs_expr.span) {
+                                        while let TyRef(_, ty_mut_inner) = ty_mut.ty.sty{
+                                            ty_mut = ty_mut_inner;
+                                        }
                                         let msg = &format!(
                                                 "`{}=` can be used on '{}', you can \
                                                 dereference `{2}`: `*{2}`",
-                                                op.node.as_str(), ty_mut.ty, lstring);
+                                                op.node.as_str(),
+                                                ty_mut.ty,
+                                                lstring
+                                        );
                                         err.help(msg);
                                         suggested_deref = true;
                                     }
@@ -300,14 +306,16 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                     // we don't want the note in the else clause to be emitted
                                 } else if let ty::TyParam(_) = lhs_ty.sty {
                                     // FIXME: point to span of param
-                                    err.note(
-                                        &format!("`{}` might need a bound for `{}`",
-                                                    lhs_ty, missing_trait));
+                                    err.note(&format!(
+                                        "`{}` might need a bound for `{}`",
+                                        lhs_ty, missing_trait
+                                    ));
                                 } else if !suggested_deref {
-                                    err.note(
-                                        &format!("an implementation of `{}` might \
-                                                    be missing for `{}`",
-                                                    missing_trait, lhs_ty));
+                                    err.note(&format!(
+                                        "an implementation of `{}` might \
+                                         be missing for `{}`",
+                                        missing_trait, lhs_ty
+                                    ));
                                 }
                             }
                             err.emit();
@@ -318,7 +326,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                             op.node.as_str(),
                                             lhs_ty);
                             let mut suggested_deref = false;
-                            if let TyRef(_, ref ty_mut) = lhs_ty.sty {
+                            if let TyRef(_, mut ty_mut) = lhs_ty.sty {
                                 if {
                                     !self.infcx.type_moves_by_default(self.param_env,
                                                                         ty_mut.ty,
@@ -329,10 +337,16 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                             .is_ok()
                                 } {
                                     if let Ok(lstring) = codemap.span_to_snippet(lhs_expr.span) {
+                                        while let TyRef(_, ty_mut_inner) = ty_mut.ty.sty{
+                                            ty_mut = ty_mut_inner;
+                                        }
                                         let msg = &format!(
                                                 "`{}` can be used on '{}', you can \
                                                 dereference `{2}`: `*{2}`",
-                                                op.node.as_str(), ty_mut.ty, lstring);
+                                                op.node.as_str(),
+                                                ty_mut.ty,
+                                                lstring
+                                        );
                                         err.help(msg);
                                         suggested_deref = true;
                                     }
@@ -363,14 +377,16 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                     // we don't want the note in the else clause to be emitted
                                 } else if let ty::TyParam(_) = lhs_ty.sty {
                                     // FIXME: point to span of param
-                                    err.note(
-                                        &format!("`{}` might need a bound for `{}`",
-                                                    lhs_ty, missing_trait));
+                                    err.note(&format!(
+                                        "`{}` might need a bound for `{}`",
+                                        lhs_ty, missing_trait
+                                    ));
                                 } else if !suggested_deref {
-                                    err.note(
-                                        &format!("an implementation of `{}` might \
-                                                    be missing for `{}`",
-                                                    missing_trait, lhs_ty));
+                                    err.note(&format!(
+                                        "an implementation of `{}` might \
+                                         be missing for `{}`",
+                                        missing_trait, lhs_ty
+                                    ));
                                 }
                             }
                             err.emit();

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -246,77 +246,92 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             Err(()) => {
                 // error types are considered "builtin"
                 if !lhs_ty.references_error() {
-                    if let IsAssign::Yes = is_assign {
-                        struct_span_err!(self.tcx.sess, expr.span, E0368,
-                                         "binary assignment operation `{}=` \
-                                          cannot be applied to type `{}`",
-                                         op.node.as_str(),
-                                         lhs_ty)
-                            .span_label(lhs_expr.span,
-                                        format!("cannot use `{}=` on type `{}`",
-                                        op.node.as_str(), lhs_ty))
-                            .emit();
-                    } else {
-                        let mut err = struct_span_err!(self.tcx.sess, expr.span, E0369,
-                            "binary operation `{}` cannot be applied to type `{}`",
-                            op.node.as_str(),
-                            lhs_ty);
-
-                        if let TypeVariants::TyRef(_, ref ty_mut) = lhs_ty.sty {
-                            if {
-                                !self.infcx.type_moves_by_default(self.param_env,
-                                                                  ty_mut.ty,
-                                                                  lhs_expr.span) &&
-                                    self.lookup_op_method(ty_mut.ty,
-                                                          &[rhs_ty],
-                                                          Op::Binary(op, is_assign))
-                                        .is_ok()
-                            } {
-                                err.note(
-                                    &format!(
-                                        "this is a reference to a type that `{}` can be applied \
-                                        to; you need to dereference this variable once for this \
-                                        operation to work",
-                                    op.node.as_str()));
-                            }
+                    let (mut err, missing_trait) = match is_assign{
+                        IsAssign::Yes => {
+                            let mut err = struct_span_err!(self.tcx.sess, expr.span, E0368,
+                                                "binary assignment operation `{}=` \
+                                                cannot be applied to type `{}`",
+                                                op.node.as_str(),
+                                                lhs_ty);
+                            err.span_label(lhs_expr.span,
+                                    format!("cannot use `{}=` on type `{}`",
+                                    op.node.as_str(), lhs_ty));
+                            let missing_trait = match op.node {
+                                hir::BiAdd    => Some("std::ops::AddAssign"),
+                                hir::BiSub    => Some("std::ops::SubAssign"),
+                                hir::BiMul    => Some("std::ops::MulAssign"),
+                                hir::BiDiv    => Some("std::ops::DivAssign"),
+                                hir::BiRem    => Some("std::ops::RemAssign"),
+                                hir::BiBitAnd => Some("std::ops::BitAndAssign"),
+                                hir::BiBitXor => Some("std::ops::BitXorAssign"),
+                                hir::BiBitOr  => Some("std::ops::BitOrAssign"),
+                                hir::BiShl    => Some("std::ops::ShlAssign"),
+                                hir::BiShr    => Some("std::ops::ShrAssign"),
+                                _             => None
+                            };
+                            (err, missing_trait)
                         }
-
-                        let missing_trait = match op.node {
-                            hir::BiAdd    => Some("std::ops::Add"),
-                            hir::BiSub    => Some("std::ops::Sub"),
-                            hir::BiMul    => Some("std::ops::Mul"),
-                            hir::BiDiv    => Some("std::ops::Div"),
-                            hir::BiRem    => Some("std::ops::Rem"),
-                            hir::BiBitAnd => Some("std::ops::BitAnd"),
-                            hir::BiBitOr  => Some("std::ops::BitOr"),
-                            hir::BiShl    => Some("std::ops::Shl"),
-                            hir::BiShr    => Some("std::ops::Shr"),
-                            hir::BiEq | hir::BiNe => Some("std::cmp::PartialEq"),
-                            hir::BiLt | hir::BiLe | hir::BiGt | hir::BiGe =>
-                                Some("std::cmp::PartialOrd"),
-                            _             => None
-                        };
-
-                        if let Some(missing_trait) = missing_trait {
-                            if missing_trait == "std::ops::Add" &&
-                                self.check_str_addition(expr, lhs_expr, rhs_expr, lhs_ty,
-                                                        rhs_ty, &mut err) {
-                                // This has nothing here because it means we did string
-                                // concatenation (e.g. "Hello " + "World!"). This means
-                                // we don't want the note in the else clause to be emitted
-                            } else if let ty::TyParam(_) = lhs_ty.sty {
-                                // FIXME: point to span of param
-                                err.note(
-                                    &format!("`{}` might need a bound for `{}`",
-                                             lhs_ty, missing_trait));
-                            } else {
-                                err.note(
-                                    &format!("an implementation of `{}` might be missing for `{}`",
-                                             missing_trait, lhs_ty));
+                        IsAssign::No => {
+                            let mut err = struct_span_err!(self.tcx.sess, expr.span, E0369,
+                                            "binary operation `{}` cannot be applied to type `{}`",
+                                            op.node.as_str(),
+                                            lhs_ty);
+                            let missing_trait = match op.node {
+                                hir::BiAdd    => Some("std::ops::Add"),
+                                hir::BiSub    => Some("std::ops::Sub"),
+                                hir::BiMul    => Some("std::ops::Mul"),
+                                hir::BiDiv    => Some("std::ops::Div"),
+                                hir::BiRem    => Some("std::ops::Rem"),
+                                hir::BiBitAnd => Some("std::ops::BitAnd"),
+                                hir::BiBitXor => Some("std::ops::BitXor"),
+                                hir::BiBitOr  => Some("std::ops::BitOr"),
+                                hir::BiShl    => Some("std::ops::Shl"),
+                                hir::BiShr    => Some("std::ops::Shr"),
+                                hir::BiEq | hir::BiNe => Some("std::cmp::PartialEq"),
+                                hir::BiLt | hir::BiLe | hir::BiGt | hir::BiGe =>
+                                    Some("std::cmp::PartialOrd"),
+                                _             => None
+                            };
+                            if let TypeVariants::TyRef(_, ref ty_mut) = lhs_ty.sty {
+                                if {
+                                    !self.infcx.type_moves_by_default(self.param_env,
+                                                                        ty_mut.ty,
+                                                                        lhs_expr.span) &&
+                                        self.lookup_op_method(ty_mut.ty,
+                                                                &[rhs_ty],
+                                                                Op::Binary(op, is_assign))
+                                            .is_ok()
+                                } {
+                                    err.note(
+                                        &format!(
+                                                "this is a reference to a type that `{}` can be \
+                                                applied to; you need to dereference this variable \
+                                                once for this operation to work",
+                                        op.node.as_str()));
+                                }
                             }
+                            (err, missing_trait)
                         }
-                        err.emit();
+                    };
+                    if let Some(missing_trait) = missing_trait {
+                        if missing_trait == "std::ops::Add" &&
+                            self.check_str_addition(expr, lhs_expr, rhs_expr, lhs_ty,
+                                                    rhs_ty, &mut err) {
+                            // This has nothing here because it means we did string
+                            // concatenation (e.g. "Hello " + "World!"). This means
+                            // we don't want the note in the else clause to be emitted
+                        } else if let ty::TyParam(_) = lhs_ty.sty {
+                            // FIXME: point to span of param
+                            err.note(
+                                &format!("`{}` might need a bound for `{}`",
+                                            lhs_ty, missing_trait));
+                        } else {
+                            err.note(
+                                &format!("an implementation of `{}` might be missing for `{}`",
+                                            missing_trait, lhs_ty));
+                        }
                     }
+                    err.emit();
                 }
                 self.tcx.types.err
             }
@@ -393,9 +408,17 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             Err(()) => {
                 let actual = self.resolve_type_vars_if_possible(&operand_ty);
                 if !actual.references_error() {
-                    struct_span_err!(self.tcx.sess, ex.span, E0600,
+                    let mut err = struct_span_err!(self.tcx.sess, ex.span, E0600,
                                      "cannot apply unary operator `{}` to type `{}`",
-                                     op.as_str(), actual).emit();
+                                     op.as_str(), actual);
+                    let missing_trait = match op {
+                        hir::UnNeg => "std::ops::Neg",
+                        hir::UnNot => "std::ops::Not",
+                        hir::UnDeref => "std::ops::UnDerf"
+                    };
+                    err.note(&format!("an implementation of `{}` might be missing for `{}`",
+                                             missing_trait, operand_ty));
+                    err.emit();
                 }
                 self.tcx.types.err
             }

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -12,8 +12,8 @@
 
 use super::{FnCtxt, Needs};
 use super::method::MethodCallee;
-use rustc::ty::{self, Ty, TypeFoldable, TypeVariants};
-use rustc::ty::TypeVariants::{TyStr, TyRef, TyAdt};
+use rustc::ty::{self, Ty, TypeFoldable};
+use rustc::ty::TypeVariants::{TyRef, TyAdt, TyStr, TyUint, TyNever, TyTuple, TyChar, TyArray};
 use rustc::ty::adjustment::{Adjustment, Adjust, AllowTwoPhase, AutoBorrow, AutoBorrowMutability};
 use rustc::infer::type_variable::TypeVariableOrigin;
 use errors;
@@ -246,7 +246,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             Err(()) => {
                 // error types are considered "builtin"
                 if !lhs_ty.references_error() {
-                    let (mut err, missing_trait) = match is_assign{
+                    match is_assign{
                         IsAssign::Yes => {
                             let mut err = struct_span_err!(self.tcx.sess, expr.span, E0368,
                                                 "binary assignment operation `{}=` \
@@ -269,7 +269,53 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                 hir::BiShr    => Some("std::ops::ShrAssign"),
                                 _             => None
                             };
-                            (err, missing_trait)
+                            let mut suggested_deref = false;
+                            if let TyRef(_, ref ty_mut) = lhs_ty.sty {
+                                if {
+                                    !self.infcx.type_moves_by_default(self.param_env,
+                                                                        ty_mut.ty,
+                                                                        lhs_expr.span) &&
+                                        self.lookup_op_method(ty_mut.ty,
+                                                                &[rhs_ty],
+                                                                Op::Binary(op, is_assign))
+                                            .is_ok()
+                                } {
+                                    let codemap = self.tcx.sess.codemap();
+                                    match codemap.span_to_snippet(lhs_expr.span) {
+                                        Ok(lstring) =>{
+                                            let msg = &format!(
+                                                "`{}=` can be used on '{}', you can \
+                                                dereference `{2}`: `*{2}`",
+                                                op.node.as_str(), ty_mut.ty, lstring);
+                                            err.help(msg);
+                                            suggested_deref = true;
+                                        },
+                                        _ => {}
+                                    };
+                                }
+                            }
+                            if let Some(missing_trait) = missing_trait {
+                                if missing_trait == "std::ops::AddAssign" &&
+                                    self.check_str_addition(expr, lhs_expr, rhs_expr, lhs_ty,
+                                                            rhs_ty, &mut err) {
+                                    // This has nothing here because it means we did string
+                                    // concatenation (e.g. "Hello " + "World!"). This means
+                                    // we don't want the note in the else clause to be emitted
+                                } else if let ty::TyParam(_) = lhs_ty.sty {
+                                    // FIXME: point to span of param
+                                    err.note(
+                                        &format!("`{}` might need a bound for `{}`",
+                                                    lhs_ty, missing_trait));
+                                } else {
+                                    if !suggested_deref{
+                                        err.note(
+                                            &format!("an implementation of `{}` might \
+                                                        be missing for `{}`",
+                                                        missing_trait, lhs_ty));
+                                    }
+                                }
+                            }
+                            err.emit();
                         }
                         IsAssign::No => {
                             let mut err = struct_span_err!(self.tcx.sess, expr.span, E0369,
@@ -292,7 +338,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                     Some("std::cmp::PartialOrd"),
                                 _             => None
                             };
-                            if let TypeVariants::TyRef(_, ref ty_mut) = lhs_ty.sty {
+                            let mut suggested_deref = false;
+                            if let TyRef(_, ref ty_mut) = lhs_ty.sty {
                                 if {
                                     !self.infcx.type_moves_by_default(self.param_env,
                                                                         ty_mut.ty,
@@ -302,36 +349,44 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                                                 Op::Binary(op, is_assign))
                                             .is_ok()
                                 } {
-                                    err.note(
-                                        &format!(
-                                                "this is a reference to a type that `{}` can be \
-                                                applied to; you need to dereference this variable \
-                                                once for this operation to work",
-                                        op.node.as_str()));
+                                    let codemap = self.tcx.sess.codemap();
+                                    match codemap.span_to_snippet(lhs_expr.span) {
+                                        Ok(lstring) =>{
+                                            let msg = &format!(
+                                                "`{}` can be used on '{}', you can \
+                                                dereference `{2}`: `*{2}`",
+                                                op.node.as_str(), ty_mut.ty, lstring);
+                                            err.help(msg);
+                                            suggested_deref = true;
+                                        },
+                                        _ =>{}
+                                    }
                                 }
                             }
-                            (err, missing_trait)
-                        }
-                    };
-                    if let Some(missing_trait) = missing_trait {
-                        if missing_trait == "std::ops::Add" &&
-                            self.check_str_addition(expr, lhs_expr, rhs_expr, lhs_ty,
-                                                    rhs_ty, &mut err) {
-                            // This has nothing here because it means we did string
-                            // concatenation (e.g. "Hello " + "World!"). This means
-                            // we don't want the note in the else clause to be emitted
-                        } else if let ty::TyParam(_) = lhs_ty.sty {
-                            // FIXME: point to span of param
-                            err.note(
-                                &format!("`{}` might need a bound for `{}`",
-                                            lhs_ty, missing_trait));
-                        } else {
-                            err.note(
-                                &format!("an implementation of `{}` might be missing for `{}`",
-                                            missing_trait, lhs_ty));
+                            if let Some(missing_trait) = missing_trait {
+                                if missing_trait == "std::ops::Add" &&
+                                    self.check_str_addition(expr, lhs_expr, rhs_expr, lhs_ty,
+                                                            rhs_ty, &mut err) {
+                                    // This has nothing here because it means we did string
+                                    // concatenation (e.g. "Hello " + "World!"). This means
+                                    // we don't want the note in the else clause to be emitted
+                                } else if let ty::TyParam(_) = lhs_ty.sty {
+                                    // FIXME: point to span of param
+                                    err.note(
+                                        &format!("`{}` might need a bound for `{}`",
+                                                    lhs_ty, missing_trait));
+                                } else {
+                                    if !suggested_deref{
+                                        err.note(
+                                            &format!("an implementation of `{}` might \
+                                                        be missing for `{}`",
+                                                        missing_trait, lhs_ty));
+                                    }
+                                }
+                            }
+                            err.emit();
                         }
                     }
-                    err.emit();
                 }
                 self.tcx.types.err
             }
@@ -411,13 +466,27 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     let mut err = struct_span_err!(self.tcx.sess, ex.span, E0600,
                                      "cannot apply unary operator `{}` to type `{}`",
                                      op.as_str(), actual);
+                    err.span_label(ex.span, format!("cannot apply unary \
+                                                    operator `{}`", op.as_str()));
                     let missing_trait = match op {
                         hir::UnNeg => "std::ops::Neg",
                         hir::UnNot => "std::ops::Not",
                         hir::UnDeref => "std::ops::UnDerf"
                     };
-                    err.note(&format!("an implementation of `{}` might be missing for `{}`",
+                    match actual.sty{
+                        TyUint(_) => {
+                            if op == hir::UnNeg{
+                                err.note(&format!("unsigned values cannot be negated"));
+                            }
+                        },
+                        TyStr | TyNever | TyChar | TyTuple(_) | TyArray(_,_) => {},
+                        TyRef(_, ref lty) if lty.ty.sty == TyStr => {},
+                        _ => {
+                            err.note(&format!("an implementation of `{}` might \
+                                                be missing for `{}`",
                                              missing_trait, operand_ty));
+                        }
+                    }
                     err.emit();
                 }
                 self.tcx.types.err

--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -195,8 +195,10 @@ impl f32 {
     }
 
     /// Fused multiply-add. Computes `(self * a) + b` with only one rounding
-    /// error. This produces a more accurate result with better performance than
-    /// a separate multiplication operation followed by an add.
+    /// error, yielding a more accurate result than an unfused multiply-add.
+    ///
+    /// Using `mul_add` can be more performant than an unfused multiply-add if
+    /// the target architecture has a dedicated `fma` CPU instruction.
     ///
     /// ```
     /// use std::f32;

--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -11,9 +11,9 @@
 //! This module provides constants which are specific to the implementation
 //! of the `f32` floating point data type.
 //!
-//! Mathematically significant numbers are provided in the `consts` sub-module.
-//!
 //! *[See also the `f32` primitive type](../../std/primitive.f32.html).*
+//!
+//! Mathematically significant numbers are provided in the `consts` sub-module.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![allow(missing_docs)]

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -173,8 +173,10 @@ impl f64 {
     }
 
     /// Fused multiply-add. Computes `(self * a) + b` with only one rounding
-    /// error. This produces a more accurate result with better performance than
-    /// a separate multiplication operation followed by an add.
+    /// error, yielding a more accurate result than an unfused multiply-add.
+    ///
+    /// Using `mul_add` can be more performant than an unfused multiply-add if
+    /// the target architecture has a dedicated `fma` CPU instruction.
     ///
     /// ```
     /// let m = 10.0_f64;

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -11,9 +11,9 @@
 //! This module provides constants which are specific to the implementation
 //! of the `f64` floating point data type.
 //!
-//! Mathematically significant numbers are provided in the `consts` sub-module.
-//!
 //! *[See also the `f64` primitive type](../../std/primitive.f64.html).*
+//!
+//! Mathematically significant numbers are provided in the `consts` sub-module.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![allow(missing_docs)]

--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -594,15 +594,13 @@ mod prim_slice { }
 //
 /// String slices.
 ///
+/// *[See also the `std::str` module](str/index.html).*
+///
 /// The `str` type, also called a 'string slice', is the most primitive string
 /// type. It is usually seen in its borrowed form, `&str`. It is also the type
 /// of string literals, `&'static str`.
 ///
-/// Strings slices are always valid UTF-8.
-///
-/// This documentation describes a number of methods and trait implementations
-/// on the `str` type. For technical reasons, there is additional, separate
-/// documentation in the [`std::str`](str/index.html) module as well.
+/// String slices are always valid UTF-8.
 ///
 /// # Examples
 ///

--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -370,6 +370,8 @@ mod prim_unit { }
 //
 /// Raw, unsafe pointers, `*const T`, and `*mut T`.
 ///
+/// *[See also the `std::ptr` module](ptr/index.html).*
+///
 /// Working with raw pointers in Rust is uncommon,
 /// typically limited to a few patterns.
 ///
@@ -443,8 +445,6 @@ mod prim_unit { }
 /// Usually you wouldn't literally use `malloc` and `free` from Rust,
 /// but C APIs hand out a lot of pointers generally, so are a common source
 /// of raw pointers in Rust.
-///
-/// *[See also the `std::ptr` module](ptr/index.html).*
 ///
 /// [`null`]: ../std/ptr/fn.null.html
 /// [`null_mut`]: ../std/ptr/fn.null_mut.html
@@ -563,6 +563,8 @@ mod prim_array { }
 //
 /// A dynamically-sized view into a contiguous sequence, `[T]`.
 ///
+/// *[See also the `std::slice` module](slice/index.html).*
+///
 /// Slices are a view into a block of memory represented as a pointer and a
 /// length.
 ///
@@ -584,8 +586,6 @@ mod prim_array { }
 /// x[1] = 7;
 /// assert_eq!(x, &[1, 7, 3]);
 /// ```
-///
-/// *[See also the `std::slice` module](slice/index.html).*
 ///
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_slice { }
@@ -862,11 +862,11 @@ mod prim_u128 { }
 //
 /// The pointer-sized signed integer type.
 ///
+/// *[See also the `std::isize` module](isize/index.html).*
+///
 /// The size of this primitive is how many bytes it takes to reference any
 /// location in memory. For example, on a 32 bit target, this is 4 bytes
 /// and on a 64 bit target, this is 8 bytes.
-///
-/// *[See also the `std::isize` module](isize/index.html).*
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_isize { }
 
@@ -874,11 +874,11 @@ mod prim_isize { }
 //
 /// The pointer-sized unsigned integer type.
 ///
+/// *[See also the `std::usize` module](usize/index.html).*
+///
 /// The size of this primitive is how many bytes it takes to reference any
 /// location in memory. For example, on a 32 bit target, this is 4 bytes
 /// and on a 64 bit target, this is 8 bytes.
-///
-/// *[See also the `std::usize` module](usize/index.html).*
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_usize { }
 

--- a/src/libsyntax_pos/span_encoding.rs
+++ b/src/libsyntax_pos/span_encoding.rs
@@ -31,11 +31,13 @@ pub struct Span(u32);
 
 impl Copy for Span {}
 impl Clone for Span {
+    #[inline]
     fn clone(&self) -> Span {
         *self
     }
 }
 impl PartialEq for Span {
+    #[inline]
     fn eq(&self, other: &Span) -> bool {
         let a = self.0;
         let b = other.0;
@@ -44,6 +46,7 @@ impl PartialEq for Span {
 }
 impl Eq for Span {}
 impl Hash for Span {
+    #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         let a = self.0;
         a.hash(state)

--- a/src/test/compile-fail-fulldeps/proc-macro/auxiliary/attributes-included.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/auxiliary/attributes-included.rs
@@ -86,7 +86,7 @@ fn assert_doc(slice: &mut &[TokenTree]) {
     }
 
     match &tokens[0] {
-        TokenTree::Term(tt) => assert_eq!("doc", tt.as_str()),
+        TokenTree::Term(tt) => assert_eq!("doc", &*tt.to_string()),
         _ => panic!("expected `doc`"),
     }
     match &tokens[1] {
@@ -118,11 +118,11 @@ fn assert_invoc(slice: &mut &[TokenTree]) {
 
 fn assert_foo(slice: &mut &[TokenTree]) {
     match &slice[0] {
-        TokenTree::Term(tt) => assert_eq!(tt.as_str(), "fn"),
+        TokenTree::Term(tt) => assert_eq!(&*tt.to_string(), "fn"),
         _ => panic!("expected fn"),
     }
     match &slice[1] {
-        TokenTree::Term(tt) => assert_eq!(tt.as_str(), "foo"),
+        TokenTree::Term(tt) => assert_eq!(&*tt.to_string(), "foo"),
         _ => panic!("expected foo"),
     }
     match &slice[2] {

--- a/src/test/run-make/cross-lang-lto/Makefile
+++ b/src/test/run-make/cross-lang-lto/Makefile
@@ -18,9 +18,9 @@ endif
 OBJDUMP=llvm-objdump
 SECTION_HEADERS=$(OBJDUMP) -section-headers
 
-BUILD_LIB=$(RUSTC) lib.rs -Copt-level=2 -Z cross-lang-lto -Ccodegen-units=1
+BUILD_LIB=$(RUSTC) lib.rs -Copt-level=2 -Z cross-lang-lto=no-link -Ccodegen-units=1
 
-BUILD_EXE=$(RUSTC) main.rs -Copt-level=2 -Z cross-lang-lto -Ccodegen-units=1 --emit=obj
+BUILD_EXE=$(RUSTC) main.rs -Copt-level=2 -Z cross-lang-lto=no-link -Ccodegen-units=1 --emit=obj
 
 all: staticlib staticlib-fat-lto staticlib-thin-lto rlib exe cdylib rdylib
 

--- a/src/test/run-pass-fulldeps/auxiliary/cond_plugin.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/cond_plugin.rs
@@ -33,7 +33,7 @@ pub fn cond(input: TokenStream) -> TokenStream {
             panic!("Invalid macro usage in cond: {}", cond);
         }
         let is_else = match test {
-            TokenTree::Term(word) => word.as_str() == "else",
+            TokenTree::Term(word) => &*word.to_string() == "else",
             _ => false,
         };
         conds.push(if is_else || input.peek().is_none() {

--- a/src/test/ui/binary-op-on-double-ref.stderr
+++ b/src/test/ui/binary-op-on-double-ref.stderr
@@ -4,7 +4,7 @@ error[E0369]: binary operation `%` cannot be applied to type `&&{integer}`
 LL |         x % 2 == 0
    |         ^^^^^
    |
-   = help: `%` can be used on '&{integer}', you can dereference `x`: `*x`
+   = help: `%` can be used on '{integer}', you can dereference `x`: `*x`
 
 error: aborting due to previous error
 

--- a/src/test/ui/binary-op-on-double-ref.stderr
+++ b/src/test/ui/binary-op-on-double-ref.stderr
@@ -4,8 +4,7 @@ error[E0369]: binary operation `%` cannot be applied to type `&&{integer}`
 LL |         x % 2 == 0
    |         ^^^^^
    |
-   = note: this is a reference to a type that `%` can be applied to; you need to dereference this variable once for this operation to work
-   = note: an implementation of `std::ops::Rem` might be missing for `&&{integer}`
+   = help: `%` can be used on '&{integer}', you can dereference `x`: `*x`
 
 error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/issue-28308.stderr
+++ b/src/test/ui/codemap_tests/issue-28308.stderr
@@ -3,6 +3,8 @@ error[E0600]: cannot apply unary operator `!` to type `&'static str`
    |
 LL |     assert!("foo");
    |     ^^^^^^^^^^^^^^^
+   |
+   = note: an implementation of `std::ops::Not` might be missing for `&'static str`
 
 error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/issue-28308.stderr
+++ b/src/test/ui/codemap_tests/issue-28308.stderr
@@ -2,9 +2,7 @@ error[E0600]: cannot apply unary operator `!` to type `&'static str`
   --> $DIR/issue-28308.rs:12:5
    |
 LL |     assert!("foo");
-   |     ^^^^^^^^^^^^^^^
-   |
-   = note: an implementation of `std::ops::Not` might be missing for `&'static str`
+   |     ^^^^^^^^^^^^^^^ cannot apply unary operator `!`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0067.stderr
+++ b/src/test/ui/error-codes/E0067.stderr
@@ -5,6 +5,8 @@ LL |     LinkedList::new() += 1; //~ ERROR E0368
    |     -----------------^^^^^
    |     |
    |     cannot use `+=` on type `std::collections::LinkedList<_>`
+   |
+   = note: an implementation of `std::ops::AddAssign` might be missing for `std::collections::LinkedList<_>`
 
 error[E0067]: invalid left-hand side expression
   --> $DIR/E0067.rs:14:5

--- a/src/test/ui/error-codes/E0600.stderr
+++ b/src/test/ui/error-codes/E0600.stderr
@@ -3,6 +3,8 @@ error[E0600]: cannot apply unary operator `!` to type `&'static str`
    |
 LL |     !"a"; //~ ERROR E0600
    |     ^^^^
+   |
+   = note: an implementation of `std::ops::Not` might be missing for `&'static str`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0600.stderr
+++ b/src/test/ui/error-codes/E0600.stderr
@@ -2,9 +2,7 @@ error[E0600]: cannot apply unary operator `!` to type `&'static str`
   --> $DIR/E0600.rs:12:5
    |
 LL |     !"a"; //~ ERROR E0600
-   |     ^^^^
-   |
-   = note: an implementation of `std::ops::Not` might be missing for `&'static str`
+   |     ^^^^ cannot apply unary operator `!`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-festival.stderr
+++ b/src/test/ui/error-festival.stderr
@@ -17,6 +17,8 @@ LL |     x += 2;
    |     -^^^^^
    |     |
    |     cannot use `+=` on type `&str`
+   |
+   = note: an implementation of `std::ops::AddAssign` might be missing for `&str`
 
 error[E0599]: no method named `z` found for type `&str` in the current scope
   --> $DIR/error-festival.rs:26:7
@@ -29,6 +31,8 @@ error[E0600]: cannot apply unary operator `!` to type `Question`
    |
 LL |     !Question::Yes;
    |     ^^^^^^^^^^^^^^
+   |
+   = note: an implementation of `std::ops::Not` might be missing for `Question`
 
 error[E0604]: only `u8` can be cast as `char`, not `u32`
   --> $DIR/error-festival.rs:35:5

--- a/src/test/ui/error-festival.stderr
+++ b/src/test/ui/error-festival.stderr
@@ -30,7 +30,7 @@ error[E0600]: cannot apply unary operator `!` to type `Question`
   --> $DIR/error-festival.rs:29:5
    |
 LL |     !Question::Yes;
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^ cannot apply unary operator `!`
    |
    = note: an implementation of `std::ops::Not` might be missing for `Question`
 

--- a/src/test/ui/feature-gate-negate-unsigned.stderr
+++ b/src/test/ui/feature-gate-negate-unsigned.stderr
@@ -3,12 +3,16 @@ error[E0600]: cannot apply unary operator `-` to type `usize`
    |
 LL |     let _max: usize = -1;
    |                       ^^
+   |
+   = note: an implementation of `std::ops::Neg` might be missing for `usize`
 
 error[E0600]: cannot apply unary operator `-` to type `u8`
   --> $DIR/feature-gate-negate-unsigned.rs:24:14
    |
 LL |     let _y = -x;
    |              ^^
+   |
+   = note: an implementation of `std::ops::Neg` might be missing for `u8`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/feature-gate-negate-unsigned.stderr
+++ b/src/test/ui/feature-gate-negate-unsigned.stderr
@@ -2,17 +2,17 @@ error[E0600]: cannot apply unary operator `-` to type `usize`
   --> $DIR/feature-gate-negate-unsigned.rs:20:23
    |
 LL |     let _max: usize = -1;
-   |                       ^^
+   |                       ^^ cannot apply unary operator `-`
    |
-   = note: an implementation of `std::ops::Neg` might be missing for `usize`
+   = note: unsigned values cannot be negated
 
 error[E0600]: cannot apply unary operator `-` to type `u8`
   --> $DIR/feature-gate-negate-unsigned.rs:24:14
    |
 LL |     let _y = -x;
-   |              ^^
+   |              ^^ cannot apply unary operator `-`
    |
-   = note: an implementation of `std::ops::Neg` might be missing for `u8`
+   = note: unsigned values cannot be negated
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issue-5239-1.stderr
+++ b/src/test/ui/issue-5239-1.stderr
@@ -6,7 +6,7 @@ LL |     let x = |ref x: isize| { x += 1; };
    |                              |
    |                              cannot use `+=` on type `&isize`
    |
-   = note: an implementation of `std::ops::AddAssign` might be missing for `&isize`
+   = help: `+=` can be used on 'isize', you can dereference `x`: `*x`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issue-5239-1.stderr
+++ b/src/test/ui/issue-5239-1.stderr
@@ -5,6 +5,8 @@ LL |     let x = |ref x: isize| { x += 1; };
    |                              -^^^^^
    |                              |
    |                              cannot use `+=` on type `&isize`
+   |
+   = note: an implementation of `std::ops::AddAssign` might be missing for `&isize`
 
 error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_unary.stderr
+++ b/src/test/ui/reachable/expr_unary.stderr
@@ -2,9 +2,7 @@ error[E0600]: cannot apply unary operator `!` to type `!`
   --> $DIR/expr_unary.rs:17:16
    |
 LL |     let x: ! = ! { return; }; //~ ERROR unreachable
-   |                ^^^^^^^^^^^^^
-   |
-   = note: an implementation of `std::ops::Not` might be missing for `!`
+   |                ^^^^^^^^^^^^^ cannot apply unary operator `!`
 
 error: unreachable expression
   --> $DIR/expr_unary.rs:17:16

--- a/src/test/ui/reachable/expr_unary.stderr
+++ b/src/test/ui/reachable/expr_unary.stderr
@@ -3,6 +3,8 @@ error[E0600]: cannot apply unary operator `!` to type `!`
    |
 LL |     let x: ! = ! { return; }; //~ ERROR unreachable
    |                ^^^^^^^^^^^^^
+   |
+   = note: an implementation of `std::ops::Not` might be missing for `!`
 
 error: unreachable expression
   --> $DIR/expr_unary.rs:17:16

--- a/src/test/ui/rfc1598-generic-associated-types/collections.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/collections.rs
@@ -1,0 +1,85 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(generic_associated_types)]
+#![feature(associated_type_defaults)]
+
+//FIXME(#44265): "lifetime parameters are not allowed on this type" errors will be addressed in a
+//follow-up PR
+
+// A Collection trait and collection families.
+// Based on http://smallcultfollowing.com/babysteps/blog/2016/11/03/associated-type-constructors-part-2-family-traits/
+
+trait Collection<T> {
+    fn empty() -> Self;
+    fn add(&mut self, value: T);
+    fn iterate<'iter>(&'iter self) -> Self::Iter<'iter>;
+    //~^ ERROR lifetime parameters are not allowed on this type [E0110]
+    type Iter<'iter>: Iterator<Item=&'iter T>;
+    type Family: CollectionFamily;
+    // Test associated type defaults with parameters
+    type Sibling<U>: Collection<U> = <<Self as Collection<T>>::Family as CollectionFamily>::Member<U>;
+    //~^ ERROR type parameters are not allowed on this type [E0109]
+}
+
+trait CollectionFamily {
+    type Member<T>: Collection<T, Family = Self>;
+}
+
+struct VecFamily;
+
+impl CollectionFamily for VecFamily {
+    type Member<T> = Vec<T>;
+}
+
+impl<T> Collection<T> for Vec<T> {
+    fn empty() -> Self {
+        Vec::new()
+    }
+    fn add(&mut self, value: T) {
+        self.push(value)
+    }
+    fn iterate<'iter>(&'iter self) -> Self::Iter<'iter> {
+    //~^ ERROR lifetime parameters are not allowed on this type [E0110]
+        self.iter()
+    }
+    type Iter<'iter> = std::slice::Iter<'iter, T>;
+    type Family = VecFamily;
+}
+
+fn floatify<C>(ints: &C) -> <<C as Collection<i32>>::Family as CollectionFamily>::Member<f32>
+    //~^ ERROR type parameters are not allowed on this type [E0109]
+    where C: Collection<i32> {
+    let mut res = C::Family::Member::<f32>::empty();
+    for &v in ints.iterate() {
+        res.add(v as f32);
+    }
+    res
+}
+
+fn floatify_sibling<C>(ints: &C) -> <C as Collection<i32>>::Sibling<f32>
+    //~^ ERROR type parameters are not allowed on this type [E0109]
+    where C: Collection<i32> {
+    let mut res = C::Family::Member::<f32>::empty();
+    for &v in ints.iterate() {
+        res.add(v as f32);
+    }
+    res
+}
+
+fn use_floatify() {
+    let a = vec![1i32, 2, 3];
+    let b = floatify(a);
+    println!("{}", b.iterate().next());
+    let c = floatify_sibling(a);
+    println!("{}", c.iterate().next());
+}
+
+fn main() {}

--- a/src/test/ui/rfc1598-generic-associated-types/collections.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/collections.rs
@@ -22,8 +22,8 @@ trait Collection<T> {
     type Iter<'iter>: Iterator<Item=&'iter T>;
     type Family: CollectionFamily;
     // Test associated type defaults with parameters
-    type Sibling<U>: Collection<U> = <<Self as Collection<T>>::Family as CollectionFamily>::
-        Member<U>;
+    type Sibling<U>: Collection<U> =
+        <<Self as Collection<T>>::Family as CollectionFamily>::Member<U>;
     //~^ ERROR type parameters are not allowed on this type [E0109]
 
     fn empty() -> Self;
@@ -63,7 +63,7 @@ impl<T> Collection<T> for Vec<T> {
 }
 
 fn floatify<C>(ints: &C) -> <<C as Collection<i32>>::Family as CollectionFamily>::Member<f32>
-    //~^ ERROR type parameters are not allowed on this type [E0109]
+//~^ ERROR type parameters are not allowed on this type [E0109]
 where
     C: Collection<i32>,
 {
@@ -75,7 +75,7 @@ where
 }
 
 fn floatify_sibling<C>(ints: &C) -> <C as Collection<i32>>::Sibling<f32>
-    //~^ ERROR type parameters are not allowed on this type [E0109]
+//~^ ERROR type parameters are not allowed on this type [E0109]
 where
     C: Collection<i32>,
 {

--- a/src/test/ui/rfc1598-generic-associated-types/collections.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/collections.rs
@@ -14,8 +14,9 @@
 //FIXME(#44265): "lifetime parameters are not allowed on this type" errors will be addressed in a
 //follow-up PR
 
-// A Collection trait and collection families.
-// Based on http://smallcultfollowing.com/babysteps/blog/2016/11/03/associated-type-constructors-part-2-family-traits/
+// A Collection trait and collection families. Based on
+// http://smallcultfollowing.com/babysteps/blog/2016/11/03/
+// associated-type-constructors-part-2-family-traits/
 
 trait Collection<T> {
     fn empty() -> Self;
@@ -25,7 +26,8 @@ trait Collection<T> {
     type Iter<'iter>: Iterator<Item=&'iter T>;
     type Family: CollectionFamily;
     // Test associated type defaults with parameters
-    type Sibling<U>: Collection<U> = <<Self as Collection<T>>::Family as CollectionFamily>::Member<U>;
+    type Sibling<U>: Collection<U> = <<Self as Collection<T>>::Family as CollectionFamily>::
+        Member<U>;
     //~^ ERROR type parameters are not allowed on this type [E0109]
 }
 

--- a/src/test/ui/rfc1598-generic-associated-types/collections.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/collections.stderr
@@ -1,0 +1,34 @@
+error[E0109]: type parameters are not allowed on this type
+  --> $DIR/collections.rs:57:90
+   |
+LL | fn floatify<C>(ints: &C) -> <<C as Collection<i32>>::Family as CollectionFamily>::Member<f32>
+   |                                                                                          ^^^ type parameter not allowed
+
+error[E0109]: type parameters are not allowed on this type
+  --> $DIR/collections.rs:67:69
+   |
+LL | fn floatify_sibling<C>(ints: &C) -> <C as Collection<i32>>::Sibling<f32>
+   |                                                                     ^^^ type parameter not allowed
+
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/collections.rs:23:50
+   |
+LL |     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter>;
+   |                                                  ^^^^^ lifetime parameter not allowed on this type
+
+error[E0109]: type parameters are not allowed on this type
+  --> $DIR/collections.rs:28:100
+   |
+LL |     type Sibling<U>: Collection<U> = <<Self as Collection<T>>::Family as CollectionFamily>::Member<U>;
+   |                                                                                                    ^ type parameter not allowed
+
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/collections.rs:49:50
+   |
+LL |     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter> {
+   |                                                  ^^^^^ lifetime parameter not allowed on this type
+
+error: aborting due to 5 previous errors
+
+Some errors occurred: E0109, E0110.
+For more information about an error, try `rustc --explain E0109`.

--- a/src/test/ui/rfc1598-generic-associated-types/collections.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/collections.stderr
@@ -1,29 +1,29 @@
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/collections.rs:59:90
+  --> $DIR/collections.rs:65:90
    |
 LL | fn floatify<C>(ints: &C) -> <<C as Collection<i32>>::Family as CollectionFamily>::Member<f32>
    |                                                                                          ^^^ type parameter not allowed
 
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/collections.rs:69:69
+  --> $DIR/collections.rs:77:69
    |
 LL | fn floatify_sibling<C>(ints: &C) -> <C as Collection<i32>>::Sibling<f32>
    |                                                                     ^^^ type parameter not allowed
 
-error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/collections.rs:24:50
-   |
-LL |     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter>;
-   |                                                  ^^^^^ lifetime parameter not allowed on this type
-
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/collections.rs:30:16
+  --> $DIR/collections.rs:26:16
    |
 LL |         Member<U>;
    |                ^ type parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/collections.rs:51:50
+  --> $DIR/collections.rs:33:50
+   |
+LL |     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter>;
+   |                                                  ^^^^^ lifetime parameter not allowed on this type
+
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/collections.rs:59:50
    |
 LL |     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter> {
    |                                                  ^^^^^ lifetime parameter not allowed on this type

--- a/src/test/ui/rfc1598-generic-associated-types/collections.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/collections.stderr
@@ -1,29 +1,29 @@
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/collections.rs:57:90
+  --> $DIR/collections.rs:59:90
    |
 LL | fn floatify<C>(ints: &C) -> <<C as Collection<i32>>::Family as CollectionFamily>::Member<f32>
    |                                                                                          ^^^ type parameter not allowed
 
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/collections.rs:67:69
+  --> $DIR/collections.rs:69:69
    |
 LL | fn floatify_sibling<C>(ints: &C) -> <C as Collection<i32>>::Sibling<f32>
    |                                                                     ^^^ type parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/collections.rs:23:50
+  --> $DIR/collections.rs:24:50
    |
 LL |     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter>;
    |                                                  ^^^^^ lifetime parameter not allowed on this type
 
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/collections.rs:28:100
+  --> $DIR/collections.rs:30:16
    |
-LL |     type Sibling<U>: Collection<U> = <<Self as Collection<T>>::Family as CollectionFamily>::Member<U>;
-   |                                                                                                    ^ type parameter not allowed
+LL |         Member<U>;
+   |                ^ type parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/collections.rs:49:50
+  --> $DIR/collections.rs:51:50
    |
 LL |     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter> {
    |                                                  ^^^^^ lifetime parameter not allowed on this type

--- a/src/test/ui/rfc1598-generic-associated-types/collections.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/collections.stderr
@@ -11,10 +11,10 @@ LL | fn floatify_sibling<C>(ints: &C) -> <C as Collection<i32>>::Sibling<f32>
    |                                                                     ^^^ type parameter not allowed
 
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/collections.rs:26:16
+  --> $DIR/collections.rs:26:71
    |
-LL |         Member<U>;
-   |                ^ type parameter not allowed
+LL |         <<Self as Collection<T>>::Family as CollectionFamily>::Member<U>;
+   |                                                                       ^ type parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
   --> $DIR/collections.rs:33:50

--- a/src/test/ui/rfc1598-generic-associated-types/construct_with_other_type.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/construct_with_other_type.rs
@@ -10,6 +10,8 @@
 
 #![feature(generic_associated_types)]
 
+use std::ops::Deref;
+
 //FIXME(#44265): "lifetime parameters are not allowed on this type" errors will be addressed in a
 //follow-up PR
 
@@ -18,11 +20,18 @@ trait Foo {
 }
 
 trait Baz {
-    type Quux<'a>;
+    type Quux<'a>: Foo;
+
+    // This weird type tests that we can use universal function call syntax to access the Item on
+    type Baa<'a>: Deref<Target = <Self::Quux<'a> as Foo>::Bar<'a, 'static>>;
+    //~^ ERROR lifetime parameters are not allowed on this type [E0110]
+    //~| ERROR lifetime parameters are not allowed on this type [E0110]
 }
 
 impl<T> Baz for T where T: Foo {
-    type Quux<'a> = <T as Foo>::Bar<'a, 'static>;
+    type Quux<'a> = T;
+
+    type Baa<'a> = &'a <T as Foo>::Bar<'a, 'static>;
     //~^ ERROR lifetime parameters are not allowed on this type [E0110]
 }
 

--- a/src/test/ui/rfc1598-generic-associated-types/construct_with_other_type.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/construct_with_other_type.stderr
@@ -1,9 +1,21 @@
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/construct_with_other_type.rs:25:37
+  --> $DIR/construct_with_other_type.rs:26:46
    |
-LL |     type Quux<'a> = <T as Foo>::Bar<'a, 'static>;
-   |                                     ^^ lifetime parameter not allowed on this type
+LL |     type Baa<'a>: Deref<Target = <Self::Quux<'a> as Foo>::Bar<'a, 'static>>;
+   |                                              ^^ lifetime parameter not allowed on this type
 
-error: aborting due to previous error
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/construct_with_other_type.rs:26:63
+   |
+LL |     type Baa<'a>: Deref<Target = <Self::Quux<'a> as Foo>::Bar<'a, 'static>>;
+   |                                                               ^^ lifetime parameter not allowed on this type
+
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/construct_with_other_type.rs:34:40
+   |
+LL |     type Baa<'a> = &'a <T as Foo>::Bar<'a, 'static>;
+   |                                        ^^ lifetime parameter not allowed on this type
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0110`.

--- a/src/test/ui/rfc1598-generic-associated-types/iterable.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/iterable.rs
@@ -20,11 +20,6 @@ trait Iterable {
     type Iter<'a>: Iterator<Item = Self::Item<'a>>;
     //~^ ERROR lifetime parameters are not allowed on this type [E0110]
 
-    // This weird type tests that we can use universal function call syntax to access the Item on
-    // Self::Iter which we have declared to be an Iterator
-    type Iter2<'a>: Deref<Target = <Self::Iter<'a> as Iterator>::Item>;
-    //~^ ERROR lifetime parameters are not allowed on this type [E0110]
-
     fn iter<'a>(&'a self) -> Self::Iter<'a>;
     //~^ ERROR lifetime parameters are not allowed on this type [E0110]
 }
@@ -33,8 +28,7 @@ trait Iterable {
 impl<T> Iterable for Vec<T> {
     type Item<'a> = &'a T;
     type Iter<'a> = std::slice::Iter<'a, T>;
-    type Iter2<'a> = &'a T;
-    // gavento: ^^^ Not 100% sure about the intention here
+
     fn iter<'a>(&'a self) -> Self::Iter<'a> {
     //~^ ERROR lifetime parameters are not allowed on this type [E0110]
         self.iter()
@@ -45,8 +39,7 @@ impl<T> Iterable for Vec<T> {
 impl<T> Iterable for [T] {
     type Item<'a> = &'a T;
     type Iter<'a> = std::slice::Iter<'a, T>;
-    type Iter2<'a> = &'a T;
-    // gavento: ^^^ Not 100% sure about the intention here
+
     fn iter<'a>(&'a self) -> Self::Iter<'a> {
     //~^ ERROR lifetime parameters are not allowed on this type [E0110]
         self.iter()

--- a/src/test/ui/rfc1598-generic-associated-types/iterable.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/iterable.rs
@@ -29,4 +29,38 @@ trait Iterable {
     //~^ ERROR lifetime parameters are not allowed on this type [E0110]
 }
 
+// Impl for struct type
+impl<T> Iterable for Vec<T> {
+    type Item<'a> = &'a T;
+    type Iter<'a> = std::slice::Iter<'a, T>;
+    type Iter2<'a> = &'a T;
+    // gavento: ^^^ Not 100% sure about the intention here
+    fn iter<'a>(&'a self) -> Self::Iter<'a> {
+    //~^ ERROR lifetime parameters are not allowed on this type [E0110]
+        self.iter()
+    }
+}
+
+// Impl for a primitive type
+impl<T> Iterable for [T] {
+    type Item<'a> = &'a T;
+    type Iter<'a> = std::slice::Iter<'a, T>;
+    type Iter2<'a> = &'a T;
+    // gavento: ^^^ Not 100% sure about the intention here
+    fn iter<'a>(&'a self) -> Self::Iter<'a> {
+    //~^ ERROR lifetime parameters are not allowed on this type [E0110]
+        self.iter()
+    }
+}
+
+fn make_iter<'a, I: Iterable>(it: &'a I) -> I::Iter<'a> {
+    //~^ ERROR lifetime parameters are not allowed on this type [E0110]
+    it.iter()
+}
+
+fn get_first<'a, I: Iterable>(it: &'a I) -> Option<I::Item<'a>> {
+    //~^ ERROR lifetime parameters are not allowed on this type [E0110]
+    it.iter().next()
+}
+
 fn main() {}

--- a/src/test/ui/rfc1598-generic-associated-types/iterable.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/iterable.stderr
@@ -11,11 +11,35 @@ LL |     type Iter2<'a>: Deref<Target = <Self::Iter<'a> as Iterator>::Item>;
    |                                                ^^ lifetime parameter not allowed on this type
 
 error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/iterable.rs:56:53
+   |
+LL | fn make_iter<'a, I: Iterable>(it: &'a I) -> I::Iter<'a> {
+   |                                                     ^^ lifetime parameter not allowed on this type
+
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/iterable.rs:61:60
+   |
+LL | fn get_first<'a, I: Iterable>(it: &'a I) -> Option<I::Item<'a>> {
+   |                                                            ^^ lifetime parameter not allowed on this type
+
+error[E0110]: lifetime parameters are not allowed on this type
   --> $DIR/iterable.rs:28:41
    |
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'a>;
    |                                         ^^ lifetime parameter not allowed on this type
 
-error: aborting due to 3 previous errors
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/iterable.rs:38:41
+   |
+LL |     fn iter<'a>(&'a self) -> Self::Iter<'a> {
+   |                                         ^^ lifetime parameter not allowed on this type
+
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/iterable.rs:50:41
+   |
+LL |     fn iter<'a>(&'a self) -> Self::Iter<'a> {
+   |                                         ^^ lifetime parameter not allowed on this type
+
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0110`.

--- a/src/test/ui/rfc1598-generic-associated-types/iterable.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/iterable.stderr
@@ -5,41 +5,35 @@ LL |     type Iter<'a>: Iterator<Item = Self::Item<'a>>;
    |                                               ^^ lifetime parameter not allowed on this type
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/iterable.rs:25:48
-   |
-LL |     type Iter2<'a>: Deref<Target = <Self::Iter<'a> as Iterator>::Item>;
-   |                                                ^^ lifetime parameter not allowed on this type
-
-error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/iterable.rs:56:53
+  --> $DIR/iterable.rs:49:53
    |
 LL | fn make_iter<'a, I: Iterable>(it: &'a I) -> I::Iter<'a> {
    |                                                     ^^ lifetime parameter not allowed on this type
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/iterable.rs:61:60
+  --> $DIR/iterable.rs:54:60
    |
 LL | fn get_first<'a, I: Iterable>(it: &'a I) -> Option<I::Item<'a>> {
    |                                                            ^^ lifetime parameter not allowed on this type
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/iterable.rs:28:41
+  --> $DIR/iterable.rs:23:41
    |
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'a>;
    |                                         ^^ lifetime parameter not allowed on this type
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/iterable.rs:38:41
+  --> $DIR/iterable.rs:32:41
    |
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'a> {
    |                                         ^^ lifetime parameter not allowed on this type
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/iterable.rs:50:41
+  --> $DIR/iterable.rs:43:41
    |
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'a> {
    |                                         ^^ lifetime parameter not allowed on this type
 
-error: aborting due to 7 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0110`.

--- a/src/test/ui/rfc1598-generic-associated-types/parameter_number_and_kind.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/parameter_number_and_kind.rs
@@ -1,0 +1,56 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(generic_associated_types)]
+#![feature(associated_type_defaults)]
+
+//FIXME(#44265): "lifetime parameters are not allowed on this type" errors will be addressed in a
+//follow-up PR
+
+//FIXME(#44265): Update expected errors once E110 is resolved, now does not get past `trait Foo`
+
+trait Foo {
+    type A<'a>;
+    type B<'a, 'b>;
+    type C;
+    type D<T>;
+    type E<'a, T>;
+    // Test parameters in default values
+    type FOk<T> = Self::E<'static, T>;
+    //~^ ERROR type parameters are not allowed on this type [E0109]
+    //~| ERROR lifetime parameters are not allowed on this type [E0110]
+    type FErr1 = Self::E<'static, 'static>; // Error
+    //~^ ERROR lifetime parameters are not allowed on this type [E0110]
+    type FErr2<T> = Self::E<'static, T, u32>; // Error
+    //~^ ERROR type parameters are not allowed on this type [E0109]
+    //~| ERROR lifetime parameters are not allowed on this type [E0110]
+}
+
+struct Fooy;
+
+impl Foo for Fooy {
+    type A = u32; // Error: parameter expected
+    type B<'a, T> = Vec<T>; // Error: lifetime param expected
+    type C<'a> = u32; // Error: no param expected
+    type D<'a> = u32; // Error: type param expected
+    type E<T, U> = u32; // Error: lifetime expected as the first param
+}
+
+struct Fooer;
+
+impl Foo for Fooer {
+    type A<T> = u32; // Error: lifetime parameter expected
+    type B<'a> = u32; // Error: another lifetime param expected
+    type C<T> = T; // Error: no param expected
+    type D<'b, T> = u32; // Error: unexpected lifetime param
+    type E<'a, 'b> = u32; // Error: type expected as the second param
+}
+
+fn main() {}

--- a/src/test/ui/rfc1598-generic-associated-types/parameter_number_and_kind.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/parameter_number_and_kind.stderr
@@ -1,0 +1,34 @@
+error[E0109]: type parameters are not allowed on this type
+  --> $DIR/parameter_number_and_kind.rs:26:36
+   |
+LL |     type FOk<T> = Self::E<'static, T>;
+   |                                    ^ type parameter not allowed
+
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/parameter_number_and_kind.rs:26:27
+   |
+LL |     type FOk<T> = Self::E<'static, T>;
+   |                           ^^^^^^^ lifetime parameter not allowed on this type
+
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/parameter_number_and_kind.rs:29:26
+   |
+LL |     type FErr1 = Self::E<'static, 'static>; // Error
+   |                          ^^^^^^^ lifetime parameter not allowed on this type
+
+error[E0109]: type parameters are not allowed on this type
+  --> $DIR/parameter_number_and_kind.rs:31:38
+   |
+LL |     type FErr2<T> = Self::E<'static, T, u32>; // Error
+   |                                      ^ type parameter not allowed
+
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/parameter_number_and_kind.rs:31:29
+   |
+LL |     type FErr2<T> = Self::E<'static, T, u32>; // Error
+   |                             ^^^^^^^ lifetime parameter not allowed on this type
+
+error: aborting due to 5 previous errors
+
+Some errors occurred: E0109, E0110.
+For more information about an error, try `rustc --explain E0109`.

--- a/src/test/ui/rfc1598-generic-associated-types/shadowing.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/shadowing.rs
@@ -13,7 +13,7 @@
 //FIXME(#44265): The lifetime shadowing and type parameter shadowing
 // should cause an error. Now it compiles (errorneously) and this will be addressed
 // by a future PR. Then remove the following:
-// must-compile-successfully
+// compile-pass
 
 trait Shadow<'a> {
     type Bar<'a>; // Error: shadowed lifetime

--- a/src/test/ui/rfc1598-generic-associated-types/shadowing.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/shadowing.rs
@@ -23,8 +23,7 @@ trait NoShadow<'a> {
     type Bar<'b>; // OK
 }
 
-impl<'a> NoShadow<'a> for &'a u32
-{
+impl<'a> NoShadow<'a> for &'a u32 {
     type Bar<'a> = i32; // Error: shadowed lifetime
 }
 
@@ -36,8 +35,7 @@ trait NoShadowT<T> {
     type Bar<U>; // OK
 }
 
-impl<T> NoShadowT<T> for Option<T>
-{
+impl<T> NoShadowT<T> for Option<T> {
     type Bar<T> = i32; // Error: shadowed type parameter
 }
 

--- a/src/test/ui/rfc1598-generic-associated-types/shadowing.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/shadowing.rs
@@ -11,8 +11,8 @@
 #![feature(generic_associated_types)]
 
 //FIXME(#44265): The lifetime shadowing and type parameter shadowing
-// should cause an error. This will be addressed by a future PR.
-// For now this compiles:
+// should cause an error. Now it compiles (errorneously) and this will be addressed
+// by a future PR. Then remove the following:
 // must-compile-successfully
 
 trait Shadow<'a> {

--- a/src/test/ui/rfc1598-generic-associated-types/shadowing.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/shadowing.rs
@@ -1,0 +1,44 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(generic_associated_types)]
+
+//FIXME(#44265): The lifetime shadowing and type parameter shadowing
+// should cause an error. This will be addressed by a future PR.
+// For now this compiles:
+// must-compile-successfully
+
+trait Shadow<'a> {
+    type Bar<'a>; // Error: shadowed lifetime
+}
+
+trait NoShadow<'a> {
+    type Bar<'b>; // OK
+}
+
+impl<'a> NoShadow<'a> for &'a u32
+{
+    type Bar<'a> = i32; // Error: shadowed lifetime
+}
+
+trait ShadowT<T> {
+    type Bar<T>; // Error: shadowed type parameter
+}
+
+trait NoShadowT<T> {
+    type Bar<U>; // OK
+}
+
+impl<T> NoShadowT<T> for Option<T>
+{
+    type Bar<T> = i32; // Error: shadowed type parameter
+}
+
+fn main() {}

--- a/src/test/ui/rfc1598-generic-associated-types/streaming_iterator.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/streaming_iterator.rs
@@ -35,4 +35,48 @@ struct Foo<T: StreamingIterator> {
 fn foo<T>(iter: T) where T: StreamingIterator, for<'a> T::Item<'a>: Display { /* ... */ }
 //~^ ERROR lifetime parameters are not allowed on this type [E0110]
 
+// Full example of enumerate iterator
+
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+struct StreamEnumerate<I> {
+    iter: I,
+    count: usize,
+}
+
+impl<I: StreamingIterator> StreamingIterator for StreamEnumerate<I> {
+    type Item<'a> = (usize, I::Item<'a>);
+    //~^ ERROR lifetime parameters are not allowed on this type [E0110]
+    fn next<'a>(&'a self) -> Option<Self::Item<'a>> {
+        //~^ ERROR lifetime parameters are not allowed on this type [E0110]
+        match self.iter.next() {
+            None => None,
+            Some(val) => {
+                let r = Some((self.count, val));
+                self.count += 1;
+                r
+            }
+        }
+    }
+}
+
+impl<I> StreamEnumerate<I> {
+    pub fn new(iter: I) -> Self {
+        StreamEnumerate {
+            count: 0,
+            iter: iter,
+        }
+    }
+}
+
+fn test_stream_enumerate() {
+    let v = vec!["a", "b", "c"];
+    let se = StreamEnumerate::new(v.iter());
+    let a: &str = se.next().unwrap().1;
+    for (i, s) in se {
+        println!("{} {}", i, s);
+    }
+    println!("{}", a);
+}
+
+
 fn main() {}

--- a/src/test/ui/rfc1598-generic-associated-types/streaming_iterator.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/streaming_iterator.stderr
@@ -16,6 +16,18 @@ error[E0110]: lifetime parameters are not allowed on this type
 LL |     fn next<'a>(&'a self) -> Option<Self::Item<'a>>;
    |                                                ^^ lifetime parameter not allowed on this type
 
-error: aborting due to 3 previous errors
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/streaming_iterator.rs:47:37
+   |
+LL |     type Item<'a> = (usize, I::Item<'a>);
+   |                                     ^^ lifetime parameter not allowed on this type
+
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/streaming_iterator.rs:49:48
+   |
+LL |     fn next<'a>(&'a self) -> Option<Self::Item<'a>> {
+   |                                                ^^ lifetime parameter not allowed on this type
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0110`.

--- a/src/test/ui/type-check/missing_trait_impl.rs
+++ b/src/test/ui/type-check/missing_trait_impl.rs
@@ -14,3 +14,7 @@ fn main() {
 fn foo<T>(x: T, y: T) {
     let z = x + y; //~ ERROR binary operation `+` cannot be applied to type `T`
 }
+
+fn bar<T>(x: T) {
+    x += x; //~ ERROR binary assignment operation `+=` cannot be applied to type `T`
+}

--- a/src/test/ui/type-check/missing_trait_impl.stderr
+++ b/src/test/ui/type-check/missing_trait_impl.stderr
@@ -6,6 +6,17 @@ LL |     let z = x + y; //~ ERROR binary operation `+` cannot be applied to type
    |
    = note: `T` might need a bound for `std::ops::Add`
 
-error: aborting due to previous error
+error[E0368]: binary assignment operation `+=` cannot be applied to type `T`
+  --> $DIR/missing_trait_impl.rs:19:5
+   |
+LL |     x += x; //~ ERROR binary assignment operation `+=` cannot be applied to type `T`
+   |     -^^^^^
+   |     |
+   |     cannot use `+=` on type `T`
+   |
+   = note: `T` might need a bound for `std::ops::AddAssign`
 
-For more information about this error, try `rustc --explain E0369`.
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0368, E0369.
+For more information about an error, try `rustc --explain E0368`.

--- a/src/test/ui/update-references.sh
+++ b/src/test/ui/update-references.sh
@@ -26,6 +26,7 @@ if [[ "$1" == "--help" || "$1" == "-h" || "$1" == "" || "$2" == "" ]]; then
     echo "   $0 ../../../build/x86_64-apple-darwin/test/ui *.rs */*.rs"
 fi
 
+MYDIR=$(dirname $0)
 
 BUILD_DIR="$1"
 shift
@@ -33,13 +34,13 @@ shift
 shopt -s nullglob
 
 while [[ "$1" != "" ]]; do
-    MYDIR=$(dirname $1)
     for EXT in "stderr" "stdout" "fixed"; do
         for OUT_NAME in $BUILD_DIR/${1%.rs}.*$EXT; do
+            OUT_DIR=`dirname "$1"`
             OUT_BASE=`basename "$OUT_NAME"`
-            if ! (diff $OUT_NAME $MYDIR/$OUT_BASE >& /dev/null); then
-                echo updating $MYDIR/$OUT_BASE
-                cp $OUT_NAME $MYDIR
+            if ! (diff $OUT_NAME $MYDIR/$OUT_DIR/$OUT_BASE >& /dev/null); then
+                echo updating $MYDIR/$OUT_DIR/$OUT_BASE
+                cp $OUT_NAME $MYDIR/$OUT_DIR
             fi
         done
     done


### PR DESCRIPTION
Successful merges:

 - #49423 (Extend tests for RFC1598 (GAT))
 - #49823 (Remove usages of Term::as_str and mark it for removal)
 - #50161 (added missing implementation hint)
 - #50447 (Fix update-references for tests within subdirectories.)
 - #50514 (Pull in a wasm fix from LLVM upstream)
 - #50524 (Make DepGraph::previous_work_products immutable)
 - #50532 (Don't use Lock for heavily accessed CrateMetadata::cnum_map.)
 - #50538 ( Make CrateNum allocation more thread-safe. )
 - #50564 (Inline `Span` methods.)
 - #50565 (Use SmallVec for DepNodeIndex within dep_graph.)
 - #50569 (Allow for specifying a linker plugin for cross-language LTO)
 - #50572 (Clarify in the docs that `mul_add` is not always faster.)
 - #50573 (Don't require clippy/miri for beta)
 - #50574 (add fn `into_inner(self) -> (Idx, Idx)` to RangeInclusive (#49022))
 - #50575 (std: Avoid `ptr::copy` if unnecessary in `vec::Drain`)
 - #50588 (Move "See also" disambiguation links for primitive types to top)
 - #50591 (Restore RawVec::reserve* documentation)
 - #50598 (Remove unnecessary mutable borrow and resizing in DepGraph::serialize)
 - #50606 (Retry when downloading the Docker cache.)

Failed merges:

 - #50558 (Remove all reference to DepGraph::work_products)
