### PR TITLE
Rollup of 18 pull requests

### DIFF
--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -36,8 +36,10 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
       s3url="s3://$SCCACHE_BUCKET/docker/$cksum"
       url="https://s3-us-west-1.amazonaws.com/$SCCACHE_BUCKET/docker/$cksum"
       echo "Attempting to download $s3url"
+      rm -f /tmp/rustci_docker_cache
       set +e
-      loaded_images=$(curl $url | docker load | sed 's/.* sha/sha/')
+      retry curl -f -L -C - -o /tmp/rustci_docker_cache "$url"
+      loaded_images=$(docker load -i /tmp/rustci_docker_cache | sed 's/.* sha/sha/')
       set -e
       echo "Downloaded containers:\n$loaded_images"
     fi

--- a/src/ci/shared.sh
+++ b/src/ci/shared.sh
@@ -21,11 +21,12 @@ function retry {
   while true; do
     "$@" && break || {
       if [[ $n -lt $max ]]; then
+        sleep $n  # don't retry immediately
         ((n++))
         echo "Command failed. Attempt $n/$max:"
       else
         echo "The command has failed after $n attempts."
-        exit 1
+        return 1
       fi
     }
   done

--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -10,6 +10,8 @@
 
 //! A dynamically-sized view into a contiguous sequence, `[T]`.
 //!
+//! *[See also the slice primitive type](../../std/primitive.slice.html).*
+//!
 //! Slices are a view into a block of memory represented as a pointer and a
 //! length.
 //!
@@ -77,8 +79,6 @@
 //!   iterators.
 //! * Further methods that return iterators are [`.split`], [`.splitn`],
 //!   [`.chunks`], [`.windows`] and more.
-//!
-//! *[See also the slice primitive type](../../std/primitive.slice.html).*
 //!
 //! [`Clone`]: ../../std/clone/trait.Clone.html
 //! [`Eq`]: ../../std/cmp/trait.Eq.html

--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -10,6 +10,8 @@
 
 //! Unicode string slices.
 //!
+//! *[See also the `str` primitive type](../../std/primitive.str.html).*
+//!
 //! The `&str` type is one of the two main string types, the other being `String`.
 //! Unlike its `String` counterpart, its contents are borrowed.
 //!
@@ -29,8 +31,6 @@
 //! ```
 //! let hello_world: &'static str = "Hello, world!";
 //! ```
-//!
-//! *[See also the `str` primitive type](../../std/primitive.str.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/liballoc/tests/str.rs
+++ b/src/liballoc/tests/str.rs
@@ -291,113 +291,160 @@ fn test_replace_pattern() {
     assert_eq!(data.replace(|c| c == 'γ', "😺😺😺"), "abcdαβ😺😺😺δabcdαβ😺😺😺δ");
 }
 
-#[test]
-fn test_slice() {
-    assert_eq!("ab", &"abc"[0..2]);
-    assert_eq!("bc", &"abc"[1..3]);
-    assert_eq!("", &"abc"[1..1]);
-    assert_eq!("\u{65e5}", &"\u{65e5}\u{672c}"[0..3]);
+mod slice_index {
+    #[test]
+    fn test_slice() {
+        assert_eq!("ab", &"abc"[0..2]);
+        assert_eq!("bc", &"abc"[1..3]);
+        assert_eq!("", &"abc"[1..1]);
+        assert_eq!("\u{65e5}", &"\u{65e5}\u{672c}"[0..3]);
 
-    let data = "ประเทศไทย中华";
-    assert_eq!("ป", &data[0..3]);
-    assert_eq!("ร", &data[3..6]);
-    assert_eq!("", &data[3..3]);
-    assert_eq!("华", &data[30..33]);
+        let data = "ประเทศไทย中华";
+        assert_eq!("ป", &data[0..3]);
+        assert_eq!("ร", &data[3..6]);
+        assert_eq!("", &data[3..3]);
+        assert_eq!("华", &data[30..33]);
 
-    fn a_million_letter_x() -> String {
-        let mut i = 0;
-        let mut rs = String::new();
-        while i < 100000 {
-            rs.push_str("华华华华华华华华华华");
-            i += 1;
+        fn a_million_letter_x() -> String {
+            let mut i = 0;
+            let mut rs = String::new();
+            while i < 100000 {
+                rs.push_str("华华华华华华华华华华");
+                i += 1;
+            }
+            rs
         }
-        rs
-    }
-    fn half_a_million_letter_x() -> String {
-        let mut i = 0;
-        let mut rs = String::new();
-        while i < 100000 {
-            rs.push_str("华华华华华");
-            i += 1;
+        fn half_a_million_letter_x() -> String {
+            let mut i = 0;
+            let mut rs = String::new();
+            while i < 100000 {
+                rs.push_str("华华华华华");
+                i += 1;
+            }
+            rs
         }
-        rs
+        let letters = a_million_letter_x();
+        assert_eq!(half_a_million_letter_x(), &letters[0..3 * 500000]);
     }
-    let letters = a_million_letter_x();
-    assert_eq!(half_a_million_letter_x(), &letters[0..3 * 500000]);
-}
 
-#[test]
-fn test_slice_2() {
-    let ss = "中华Việt Nam";
+    #[test]
+    fn test_slice_2() {
+        let ss = "中华Việt Nam";
 
-    assert_eq!("华", &ss[3..6]);
-    assert_eq!("Việt Nam", &ss[6..16]);
+        assert_eq!("华", &ss[3..6]);
+        assert_eq!("Việt Nam", &ss[6..16]);
 
-    assert_eq!("ab", &"abc"[0..2]);
-    assert_eq!("bc", &"abc"[1..3]);
-    assert_eq!("", &"abc"[1..1]);
+        assert_eq!("ab", &"abc"[0..2]);
+        assert_eq!("bc", &"abc"[1..3]);
+        assert_eq!("", &"abc"[1..1]);
 
-    assert_eq!("中", &ss[0..3]);
-    assert_eq!("华V", &ss[3..7]);
-    assert_eq!("", &ss[3..3]);
-    /*0: 中
-      3: 华
-      6: V
-      7: i
-      8: ệ
-     11: t
-     12:
-     13: N
-     14: a
-     15: m */
-}
-
-#[test]
-#[should_panic]
-fn test_slice_fail() {
-    &"中华Việt Nam"[0..2];
-}
-
-#[test]
-#[should_panic]
-fn test_str_slice_rangetoinclusive_max_panics() {
-    &"hello"[..=usize::max_value()];
-}
-
-#[test]
-#[should_panic]
-fn test_str_slice_rangeinclusive_max_panics() {
-    &"hello"[1..=usize::max_value()];
-}
-
-#[test]
-#[should_panic]
-fn test_str_slicemut_rangetoinclusive_max_panics() {
-    let mut s = "hello".to_owned();
-    let s: &mut str = &mut s;
-    &mut s[..=usize::max_value()];
-}
-
-#[test]
-#[should_panic]
-fn test_str_slicemut_rangeinclusive_max_panics() {
-    let mut s = "hello".to_owned();
-    let s: &mut str = &mut s;
-    &mut s[1..=usize::max_value()];
-}
-
-#[test]
-fn test_str_get_maxinclusive() {
-    let mut s = "hello".to_owned();
-    {
-        let s: &str = &s;
-        assert_eq!(s.get(..=usize::max_value()), None);
-        assert_eq!(s.get(1..=usize::max_value()), None);
+        assert_eq!("中", &ss[0..3]);
+        assert_eq!("华V", &ss[3..7]);
+        assert_eq!("", &ss[3..3]);
+        /*0: 中
+          3: 华
+          6: V
+          7: i
+          8: ệ
+         11: t
+         12:
+         13: N
+         14: a
+         15: m */
     }
-    {
+
+    #[test]
+    #[should_panic]
+    fn test_slice_fail() {
+        &"中华Việt Nam"[0..2];
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_str_slice_rangetoinclusive_max_panics() {
+        &"hello"[..=usize::max_value()];
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_str_slice_rangeinclusive_max_panics() {
+        &"hello"[1..=usize::max_value()];
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_str_slicemut_rangetoinclusive_max_panics() {
+        let mut s = "hello".to_owned();
         let s: &mut str = &mut s;
-        assert_eq!(s.get(..=usize::max_value()), None);
-        assert_eq!(s.get(1..=usize::max_value()), None);
+        &mut s[..=usize::max_value()];
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_str_slicemut_rangeinclusive_max_panics() {
+        let mut s = "hello".to_owned();
+        let s: &mut str = &mut s;
+        &mut s[1..=usize::max_value()];
+    }
+
+    #[test]
+    fn test_str_get_maxinclusive() {
+        let mut s = "hello".to_owned();
+        {
+            let s: &str = &s;
+            assert_eq!(s.get(..=usize::max_value()), None);
+            assert_eq!(s.get(1..=usize::max_value()), None);
+        }
+        {
+            let s: &mut str = &mut s;
+            assert_eq!(s.get(..=usize::max_value()), None);
+            assert_eq!(s.get(1..=usize::max_value()), None);
+        }
+    }
+
+    const LOREM_PARAGRAPH: &'static str = "\
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse quis lorem sit amet dolor \
+    ultricies condimentum. Praesent iaculis purus elit, ac malesuada quam malesuada in. Duis sed orci \
+    eros. Suspendisse sit amet magna mollis, mollis nunc luctus, imperdiet mi. Integer fringilla non \
+    sem ut lacinia. Fusce varius tortor a risus porttitor hendrerit. Morbi mauris dui, ultricies nec \
+    tempus vel, gravida nec quam.";
+
+    // check the panic includes the prefix of the sliced string
+    #[test]
+    #[should_panic(expected="byte index 1024 is out of bounds of `Lorem ipsum dolor sit amet")]
+    fn test_slice_fail_truncated_1() {
+        &LOREM_PARAGRAPH[..1024];
+    }
+    // check the truncation in the panic message
+    #[test]
+    #[should_panic(expected="luctus, im`[...]")]
+    fn test_slice_fail_truncated_2() {
+        &LOREM_PARAGRAPH[..1024];
+    }
+
+    #[test]
+    #[should_panic(expected="byte index 4 is not a char boundary; it is inside 'α' (bytes 3..5) of")]
+    fn test_slice_fail_boundary_1() {
+        &"abcαβγ"[4..];
+    }
+
+    #[test]
+    #[should_panic(expected="byte index 6 is not a char boundary; it is inside 'β' (bytes 5..7) of")]
+    fn test_slice_fail_boundary_2() {
+        &"abcαβγ"[2..6];
+    }
+
+    #[test]
+    fn test_slice_from() {
+        assert_eq!(&"abcd"[0..], "abcd");
+        assert_eq!(&"abcd"[2..], "cd");
+        assert_eq!(&"abcd"[4..], "");
+    }
+    #[test]
+    fn test_slice_to() {
+        assert_eq!(&"abcd"[..0], "");
+        assert_eq!(&"abcd"[..2], "ab");
+        assert_eq!(&"abcd"[..4], "abcd");
     }
 }
 
@@ -445,50 +492,6 @@ fn test_is_char_boundary() {
                     "{} should not be a char boundary in {:?}", i + j, s);
         }
     }
-}
-const LOREM_PARAGRAPH: &'static str = "\
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse quis lorem sit amet dolor \
-ultricies condimentum. Praesent iaculis purus elit, ac malesuada quam malesuada in. Duis sed orci \
-eros. Suspendisse sit amet magna mollis, mollis nunc luctus, imperdiet mi. Integer fringilla non \
-sem ut lacinia. Fusce varius tortor a risus porttitor hendrerit. Morbi mauris dui, ultricies nec \
-tempus vel, gravida nec quam.";
-
-// check the panic includes the prefix of the sliced string
-#[test]
-#[should_panic(expected="byte index 1024 is out of bounds of `Lorem ipsum dolor sit amet")]
-fn test_slice_fail_truncated_1() {
-    &LOREM_PARAGRAPH[..1024];
-}
-// check the truncation in the panic message
-#[test]
-#[should_panic(expected="luctus, im`[...]")]
-fn test_slice_fail_truncated_2() {
-    &LOREM_PARAGRAPH[..1024];
-}
-
-#[test]
-#[should_panic(expected="byte index 4 is not a char boundary; it is inside 'α' (bytes 3..5) of")]
-fn test_slice_fail_boundary_1() {
-    &"abcαβγ"[4..];
-}
-
-#[test]
-#[should_panic(expected="byte index 6 is not a char boundary; it is inside 'β' (bytes 5..7) of")]
-fn test_slice_fail_boundary_2() {
-    &"abcαβγ"[2..6];
-}
-
-#[test]
-fn test_slice_from() {
-    assert_eq!(&"abcd"[0..], "abcd");
-    assert_eq!(&"abcd"[2..], "cd");
-    assert_eq!(&"abcd"[4..], "");
-}
-#[test]
-fn test_slice_to() {
-    assert_eq!(&"abcd"[..0], "");
-    assert_eq!(&"abcd"[..2], "ab");
-    assert_eq!(&"abcd"[..4], "abcd");
 }
 
 #[test]

--- a/src/liballoc/tests/str.rs
+++ b/src/liballoc/tests/str.rs
@@ -602,7 +602,9 @@ mod slice_index {
             mod rangeinclusive {
                 let DATA = "hello";
 
-                let BAD_INPUT = 1..=usize::max_value();
+                // note: using 0 specifically ensures that the result of overflowing is 0..0,
+                //       so that `get` doesn't simply return None for the wrong reason.
+                let BAD_INPUT = 0..=usize::max_value();
                 const EXPECT_MSG = "maximum usize";
 
                 !!generate_tests!!

--- a/src/liballoc/tests/str.rs
+++ b/src/liballoc/tests/str.rs
@@ -479,6 +479,7 @@ mod slice_index {
     }
 
     #[test]
+    #[cfg(not(target_arch = "asmjs"))] // hits an OOM
     fn simple_big() {
         fn a_million_letter_x() -> String {
             let mut i = 0;

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2533,9 +2533,11 @@ impl<'a, T> Drop for Drain<'a, T> {
                 // memmove back untouched tail, update to new length
                 let start = source_vec.len();
                 let tail = self.tail_start;
-                let src = source_vec.as_ptr().offset(tail as isize);
-                let dst = source_vec.as_mut_ptr().offset(start as isize);
-                ptr::copy(src, dst, self.tail_len);
+                if tail != start {
+                    let src = source_vec.as_ptr().offset(tail as isize);
+                    let dst = source_vec.as_mut_ptr().offset(start as isize);
+                    ptr::copy(src, dst, self.tail_len);
+                }
                 source_vec.set_len(start + self.tail_len);
             }
         }

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -11,9 +11,9 @@
 //! This module provides constants which are specific to the implementation
 //! of the `f32` floating point data type.
 //!
-//! Mathematically significant numbers are provided in the `consts` sub-module.
-//!
 //! *[See also the `f32` primitive type](../../std/primitive.f32.html).*
+//!
+//! Mathematically significant numbers are provided in the `consts` sub-module.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -11,9 +11,9 @@
 //! This module provides constants which are specific to the implementation
 //! of the `f64` floating point data type.
 //!
-//! Mathematically significant numbers are provided in the `consts` sub-module.
-//!
 //! *[See also the `f64` primitive type](../../std/primitive.f64.html).*
+//!
+//! Mathematically significant numbers are provided in the `consts` sub-module.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/ops/range.rs
+++ b/src/libcore/ops/range.rs
@@ -411,6 +411,21 @@ impl<Idx> RangeInclusive<Idx> {
     pub fn end(&self) -> &Idx {
         &self.end
     }
+
+    /// Destructures the RangeInclusive into (lower bound, upper (inclusive) bound).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(inclusive_range_methods)]
+    ///
+    /// assert_eq!((3..=5).into_inner(), (3, 5));
+    /// ```
+    #[unstable(feature = "inclusive_range_methods", issue = "49022")]
+    #[inline]
+    pub fn into_inner(self) -> (Idx, Idx) {
+        (self.start, self.end)
+    }
 }
 
 #[stable(feature = "inclusive_range", since = "1.26.0")]

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -2262,6 +2262,12 @@ fn slice_index_order_fail(index: usize, end: usize) -> ! {
     panic!("slice index starts at {} but ends at {}", index, end);
 }
 
+#[inline(never)]
+#[cold]
+fn slice_index_overflow_fail() -> ! {
+    panic!("attempted to index slice up to maximum usize");
+}
+
 /// A helper trait used for indexing operations.
 #[unstable(feature = "slice_get_slice", issue = "35729")]
 #[rustc_on_unimplemented = "slice indices are of type `usize` or ranges of `usize`"]
@@ -2538,15 +2544,13 @@ impl<T> SliceIndex<[T]> for ops::RangeInclusive<usize> {
 
     #[inline]
     fn index(self, slice: &[T]) -> &[T] {
-        assert!(self.end != usize::max_value(),
-            "attempted to index slice up to maximum usize");
+        if self.end == usize::max_value() { slice_index_overflow_fail(); }
         (self.start..self.end + 1).index(slice)
     }
 
     #[inline]
     fn index_mut(self, slice: &mut [T]) -> &mut [T] {
-        assert!(self.end != usize::max_value(),
-            "attempted to index slice up to maximum usize");
+        if self.end == usize::max_value() { slice_index_overflow_fail(); }
         (self.start..self.end + 1).index_mut(slice)
     }
 }

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -1849,6 +1849,12 @@ mod traits {
         }
     }
 
+    #[inline(never)]
+    #[cold]
+    fn str_index_overflow_fail() -> ! {
+        panic!("attempted to index str up to maximum usize");
+    }
+
     #[stable(feature = "str_checked_slicing", since = "1.20.0")]
     impl SliceIndex<str> for ops::RangeFull {
         type Output = str;
@@ -2053,14 +2059,12 @@ mod traits {
         }
         #[inline]
         fn index(self, slice: &str) -> &Self::Output {
-            assert!(self.end != usize::max_value(),
-                "attempted to index str up to maximum usize");
+            if self.end == usize::max_value() { str_index_overflow_fail(); }
             (self.start..self.end+1).index(slice)
         }
         #[inline]
         fn index_mut(self, slice: &mut str) -> &mut Self::Output {
-            assert!(self.end != usize::max_value(),
-                "attempted to index str up to maximum usize");
+            if self.end == usize::max_value() { str_index_overflow_fail(); }
             (self.start..self.end+1).index_mut(slice)
         }
     }
@@ -2098,14 +2102,12 @@ mod traits {
         }
         #[inline]
         fn index(self, slice: &str) -> &Self::Output {
-            assert!(self.end != usize::max_value(),
-                "attempted to index str up to maximum usize");
+            if self.end == usize::max_value() { str_index_overflow_fail(); }
             (..self.end+1).index(slice)
         }
         #[inline]
         fn index_mut(self, slice: &mut str) -> &mut Self::Output {
-            assert!(self.end != usize::max_value(),
-                "attempted to index str up to maximum usize");
+            if self.end == usize::max_value() { str_index_overflow_fail(); }
             (..self.end+1).index_mut(slice)
         }
     }

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -2035,19 +2035,13 @@ mod traits {
         type Output = str;
         #[inline]
         fn get(self, slice: &str) -> Option<&Self::Output> {
-            if let Some(end) = self.end.checked_add(1) {
-                (self.start..end).get(slice)
-            } else {
-                None
-            }
+            if self.end == usize::max_value() { None }
+            else { (self.start..self.end+1).get(slice) }
         }
         #[inline]
         fn get_mut(self, slice: &mut str) -> Option<&mut Self::Output> {
-            if let Some(end) = self.end.checked_add(1) {
-                (self.start..end).get_mut(slice)
-            } else {
-                None
-            }
+            if self.end == usize::max_value() { None }
+            else { (self.start..self.end+1).get_mut(slice) }
         }
         #[inline]
         unsafe fn get_unchecked(self, slice: &str) -> &Self::Output {
@@ -2076,29 +2070,21 @@ mod traits {
         type Output = str;
         #[inline]
         fn get(self, slice: &str) -> Option<&Self::Output> {
-            if self.end < usize::max_value() && slice.is_char_boundary(self.end + 1) {
-                Some(unsafe { self.get_unchecked(slice) })
-            } else {
-                None
-            }
+            if self.end == usize::max_value() { None }
+            else { (..self.end+1).get(slice) }
         }
         #[inline]
         fn get_mut(self, slice: &mut str) -> Option<&mut Self::Output> {
-            if self.end < usize::max_value() && slice.is_char_boundary(self.end + 1) {
-                Some(unsafe { self.get_unchecked_mut(slice) })
-            } else {
-                None
-            }
+            if self.end == usize::max_value() { None }
+            else { (..self.end+1).get_mut(slice) }
         }
         #[inline]
         unsafe fn get_unchecked(self, slice: &str) -> &Self::Output {
-            let ptr = slice.as_ptr();
-            super::from_utf8_unchecked(slice::from_raw_parts(ptr, self.end + 1))
+            (..self.end+1).get_unchecked(slice)
         }
         #[inline]
         unsafe fn get_unchecked_mut(self, slice: &mut str) -> &mut Self::Output {
-            let ptr = slice.as_ptr();
-            super::from_utf8_unchecked_mut(slice::from_raw_parts_mut(ptr as *mut u8, self.end + 1))
+            (..self.end+1).get_unchecked_mut(slice)
         }
         #[inline]
         fn index(self, slice: &str) -> &Self::Output {

--- a/src/libcore/tests/str.rs
+++ b/src/libcore/tests/str.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// All `str` tests live in collectionstests::str
+// All `str` tests live in liballoc/tests

--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -534,15 +534,9 @@ impl DepGraph {
     }
 
     pub fn serialize(&self) -> SerializedDepGraph {
-        let mut fingerprints = self.fingerprints.borrow_mut();
         let current_dep_graph = self.data.as_ref().unwrap().current.borrow();
 
-        // Make sure we don't run out of bounds below.
-        if current_dep_graph.nodes.len() > fingerprints.len() {
-            fingerprints.resize(current_dep_graph.nodes.len(), Fingerprint::ZERO);
-        }
-
-        let fingerprints = fingerprints.clone().convert_index_type();
+        let fingerprints = self.fingerprints.borrow().clone().convert_index_type();
         let nodes = current_dep_graph.nodes.clone().convert_index_type();
 
         let total_edge_count: usize = current_dep_graph.edges.iter()

--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -12,6 +12,7 @@ use errors::DiagnosticBuilder;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::indexed_vec::{Idx, IndexVec};
+use rustc_data_structures::small_vec::SmallVec;
 use rustc_data_structures::sync::{Lrc, RwLock, ReadGuard, Lock};
 use std::env;
 use std::hash::Hash;
@@ -131,7 +132,7 @@ impl DepGraph {
         let mut edges = Vec::new();
         for (index, edge_targets) in current_dep_graph.edges.iter_enumerated() {
             let from = current_dep_graph.nodes[index];
-            for &edge_target in edge_targets {
+            for &edge_target in edge_targets.iter() {
                 let to = current_dep_graph.nodes[edge_target];
                 edges.push((from, to));
             }
@@ -209,7 +210,7 @@ impl DepGraph {
         self.with_task_impl(key, cx, arg, false, task,
             |key| OpenTask::Regular(Lock::new(RegularOpenTask {
                 node: key,
-                reads: Vec::new(),
+                reads: SmallVec::new(),
                 read_set: FxHashSet(),
             })),
             |data, key, task| data.borrow_mut().complete_task(key, task))
@@ -230,7 +231,7 @@ impl DepGraph {
 
         self.with_task_impl(key, cx, input, true, identity_fn,
             |_| OpenTask::Ignore,
-            |data, key, _| data.borrow_mut().alloc_node(key, Vec::new()))
+            |data, key, _| data.borrow_mut().alloc_node(key, SmallVec::new()))
     }
 
     fn with_task_impl<'gcx, C, A, R>(
@@ -353,7 +354,7 @@ impl DepGraph {
         if let Some(ref data) = self.data {
             let (result, open_task) = ty::tls::with_context(|icx| {
                 let task = OpenTask::Anon(Lock::new(AnonOpenTask {
-                    reads: Vec::new(),
+                    reads: SmallVec::new(),
                     read_set: FxHashSet(),
                 }));
 
@@ -626,7 +627,7 @@ impl DepGraph {
 
         debug_assert!(data.colors.borrow().get(prev_dep_node_index).is_none());
 
-        let mut current_deps = Vec::new();
+        let mut current_deps = SmallVec::new();
 
         for &dep_dep_node_index in prev_deps {
             let dep_dep_node_color = data.colors.borrow().get(dep_dep_node_index);
@@ -923,7 +924,7 @@ pub enum WorkProductFileKind {
 
 pub(super) struct CurrentDepGraph {
     nodes: IndexVec<DepNodeIndex, DepNode>,
-    edges: IndexVec<DepNodeIndex, Vec<DepNodeIndex>>,
+    edges: IndexVec<DepNodeIndex, SmallVec<[DepNodeIndex; 8]>>,
     node_to_node_index: FxHashMap<DepNode, DepNodeIndex>,
     forbidden_edge: Option<EdgeFilter>,
 
@@ -1061,7 +1062,7 @@ impl CurrentDepGraph {
         } = task {
             debug_assert_eq!(node, key);
             let krate_idx = self.node_to_node_index[&DepNode::new_no_params(DepKind::Krate)];
-            self.alloc_node(node, vec![krate_idx])
+            self.alloc_node(node, SmallVec::one(krate_idx))
         } else {
             bug!("complete_eval_always_task() - Expected eval always task to be popped");
         }
@@ -1107,7 +1108,7 @@ impl CurrentDepGraph {
 
     fn alloc_node(&mut self,
                   dep_node: DepNode,
-                  edges: Vec<DepNodeIndex>)
+                  edges: SmallVec<[DepNodeIndex; 8]>)
                   -> DepNodeIndex {
         debug_assert_eq!(self.edges.len(), self.nodes.len());
         debug_assert_eq!(self.node_to_node_index.len(), self.nodes.len());
@@ -1122,12 +1123,12 @@ impl CurrentDepGraph {
 
 pub struct RegularOpenTask {
     node: DepNode,
-    reads: Vec<DepNodeIndex>,
+    reads: SmallVec<[DepNodeIndex; 8]>,
     read_set: FxHashSet<DepNodeIndex>,
 }
 
 pub struct AnonOpenTask {
-    reads: Vec<DepNodeIndex>,
+    reads: SmallVec<[DepNodeIndex; 8]>,
     read_set: FxHashSet<DepNodeIndex>,
 }
 

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -657,6 +657,13 @@ impl Session {
         }
     }
 
+    pub fn target_cpu(&self) -> &str {
+        match self.opts.cg.target_cpu {
+            Some(ref s) => &**s,
+            None => &*self.target.target.options.cpu
+        }
+    }
+
     pub fn must_not_eliminate_frame_pointers(&self) -> bool {
         if let Some(x) = self.opts.cg.force_frame_pointers {
             x

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -980,15 +980,16 @@ where
     let dep_graph = match future_dep_graph {
         None => DepGraph::new_disabled(),
         Some(future) => {
-            let prev_graph = time(sess, "blocked while dep-graph loading finishes", || {
-                future
-                    .open()
-                    .unwrap_or_else(|e| rustc_incremental::LoadResult::Error {
-                        message: format!("could not decode incremental cache: {:?}", e),
-                    })
-                    .open(sess)
-            });
-            DepGraph::new(prev_graph)
+            let (prev_graph, prev_work_products) =
+                time(sess, "blocked while dep-graph loading finishes", || {
+                    future
+                        .open()
+                        .unwrap_or_else(|e| rustc_incremental::LoadResult::Error {
+                            message: format!("could not decode incremental cache: {:?}", e),
+                        })
+                        .open(sess)
+                });
+            DepGraph::new(prev_graph, prev_work_products)
         }
     };
     let hir_forest = time(sess, "lowering ast -> hir", || {

--- a/src/librustc_incremental/persist/load.rs
+++ b/src/librustc_incremental/persist/load.rs
@@ -130,7 +130,7 @@ pub fn load_dep_graph(sess: &Session) ->
     let mut prev_work_products = FxHashMap();
 
     // If we are only building with -Zquery-dep-graph but without an actual
-    // incr. comp. session directory, we exit here. Otherwise we'd fail
+    // incr. comp. session directory, we skip this. Otherwise we'd fail
     // when trying to load work products.
     if sess.incr_comp_session_dir_opt().is_some() {
         let work_products_path = work_products_path(sess);

--- a/src/librustc_incremental/persist/load.rs
+++ b/src/librustc_incremental/persist/load.rs
@@ -10,7 +10,8 @@
 
 //! Code to save/load the dep-graph from files.
 
-use rustc::dep_graph::{PreviousDepGraph, SerializedDepGraph};
+use rustc_data_structures::fx::FxHashMap;
+use rustc::dep_graph::{PreviousDepGraph, SerializedDepGraph, WorkProduct, WorkProductId};
 use rustc::session::Session;
 use rustc::ty::TyCtxt;
 use rustc::ty::maps::OnDiskCache;
@@ -32,51 +33,9 @@ pub fn dep_graph_tcx_init<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
 
     tcx.allocate_metadata_dep_nodes();
     tcx.precompute_in_scope_traits_hashes();
-
-    if tcx.sess.incr_comp_session_dir_opt().is_none() {
-        // If we are only building with -Zquery-dep-graph but without an actual
-        // incr. comp. session directory, we exit here. Otherwise we'd fail
-        // when trying to load work products.
-        return
-    }
-
-    let work_products_path = work_products_path(tcx.sess);
-    let load_result = load_data(tcx.sess.opts.debugging_opts.incremental_info, &work_products_path);
-
-    if let LoadResult::Ok { data: (work_products_data, start_pos) } = load_result {
-        // Decode the list of work_products
-        let mut work_product_decoder = Decoder::new(&work_products_data[..], start_pos);
-        let work_products: Vec<SerializedWorkProduct> =
-            RustcDecodable::decode(&mut work_product_decoder).unwrap_or_else(|e| {
-                let msg = format!("Error decoding `work-products` from incremental \
-                                   compilation session directory: {}", e);
-                tcx.sess.fatal(&msg[..])
-            });
-
-        for swp in work_products {
-            let mut all_files_exist = true;
-            for &(_, ref file_name) in swp.work_product.saved_files.iter() {
-                let path = in_incr_comp_dir_sess(tcx.sess, file_name);
-                if !path.exists() {
-                    all_files_exist = false;
-
-                    if tcx.sess.opts.debugging_opts.incremental_info {
-                        eprintln!("incremental: could not find file for work \
-                                   product: {}", path.display());
-                    }
-                }
-            }
-
-            if all_files_exist {
-                debug!("reconcile_work_products: all files for {:?} exist", swp);
-                tcx.dep_graph.insert_previous_work_product(&swp.id, swp.work_product);
-            } else {
-                debug!("reconcile_work_products: some file for {:?} does not exist", swp);
-                delete_dirty_work_product(tcx, swp);
-            }
-        }
-    }
 }
+
+type WorkProductMap = FxHashMap<WorkProductId, WorkProduct>;
 
 pub enum LoadResult<T> {
     Ok { data: T },
@@ -84,13 +43,12 @@ pub enum LoadResult<T> {
     Error { message: String },
 }
 
-
-impl LoadResult<PreviousDepGraph> {
-    pub fn open(self, sess: &Session) -> PreviousDepGraph {
+impl LoadResult<(PreviousDepGraph, WorkProductMap)> {
+    pub fn open(self, sess: &Session) -> (PreviousDepGraph, WorkProductMap) {
         match self {
             LoadResult::Error { message } => {
                 sess.warn(&message);
-                PreviousDepGraph::new(SerializedDepGraph::new())
+                (PreviousDepGraph::new(SerializedDepGraph::new()), FxHashMap())
             },
             LoadResult::DataOutOfDate => {
                 if let Err(err) = delete_all_session_dir_contents(sess) {
@@ -98,7 +56,7 @@ impl LoadResult<PreviousDepGraph> {
                                       incremental compilation session directory contents `{}`: {}.",
                                       dep_graph_path(sess).display(), err));
                 }
-                PreviousDepGraph::new(SerializedDepGraph::new())
+                (PreviousDepGraph::new(SerializedDepGraph::new()), FxHashMap())
             }
             LoadResult::Ok { data } => data
         }
@@ -125,10 +83,10 @@ fn load_data(report_incremental_info: bool, path: &Path) -> LoadResult<(Vec<u8>,
     }
 }
 
-fn delete_dirty_work_product(tcx: TyCtxt,
+fn delete_dirty_work_product(sess: &Session,
                              swp: SerializedWorkProduct) {
     debug!("delete_dirty_work_product({:?})", swp);
-    work_product::delete_workproduct_files(tcx.sess, &swp.work_product);
+    work_product::delete_workproduct_files(sess, &swp.work_product);
 }
 
 /// Either a result that has already be computed or a
@@ -149,7 +107,7 @@ impl<T> MaybeAsync<T> {
 
 /// Launch a thread and load the dependency graph in the background.
 pub fn load_dep_graph(sess: &Session) ->
-    MaybeAsync<LoadResult<PreviousDepGraph>>
+    MaybeAsync<LoadResult<(PreviousDepGraph, WorkProductMap)>>
 {
     // Since `sess` isn't `Sync`, we perform all accesses to `sess`
     // before we fire the background thread.
@@ -159,7 +117,7 @@ pub fn load_dep_graph(sess: &Session) ->
     if sess.opts.incremental.is_none() {
         // No incremental compilation.
         return MaybeAsync::Sync(LoadResult::Ok {
-            data: PreviousDepGraph::new(SerializedDepGraph::new())
+            data: (PreviousDepGraph::new(SerializedDepGraph::new()), FxHashMap())
         });
     }
 
@@ -168,6 +126,50 @@ pub fn load_dep_graph(sess: &Session) ->
     let path = dep_graph_path_from(&sess.incr_comp_session_dir());
     let report_incremental_info = sess.opts.debugging_opts.incremental_info;
     let expected_hash = sess.opts.dep_tracking_hash();
+
+    let mut prev_work_products = FxHashMap();
+
+    // If we are only building with -Zquery-dep-graph but without an actual
+    // incr. comp. session directory, we exit here. Otherwise we'd fail
+    // when trying to load work products.
+    if sess.incr_comp_session_dir_opt().is_some() {
+        let work_products_path = work_products_path(sess);
+        let load_result = load_data(report_incremental_info, &work_products_path);
+
+        if let LoadResult::Ok { data: (work_products_data, start_pos) } = load_result {
+            // Decode the list of work_products
+            let mut work_product_decoder = Decoder::new(&work_products_data[..], start_pos);
+            let work_products: Vec<SerializedWorkProduct> =
+                RustcDecodable::decode(&mut work_product_decoder).unwrap_or_else(|e| {
+                    let msg = format!("Error decoding `work-products` from incremental \
+                                    compilation session directory: {}", e);
+                    sess.fatal(&msg[..])
+                });
+
+            for swp in work_products {
+                let mut all_files_exist = true;
+                for &(_, ref file_name) in swp.work_product.saved_files.iter() {
+                    let path = in_incr_comp_dir_sess(sess, file_name);
+                    if !path.exists() {
+                        all_files_exist = false;
+
+                        if sess.opts.debugging_opts.incremental_info {
+                            eprintln!("incremental: could not find file for work \
+                                    product: {}", path.display());
+                        }
+                    }
+                }
+
+                if all_files_exist {
+                    debug!("reconcile_work_products: all files for {:?} exist", swp);
+                    prev_work_products.insert(swp.id, swp.work_product);
+                } else {
+                    debug!("reconcile_work_products: some file for {:?} does not exist", swp);
+                    delete_dirty_work_product(sess, swp);
+                }
+            }
+        }
+    }
 
     MaybeAsync::Async(std::thread::spawn(move || {
         time_ext(time_passes, None, "background load prev dep-graph", move || {
@@ -195,7 +197,7 @@ pub fn load_dep_graph(sess: &Session) ->
                     let dep_graph = SerializedDepGraph::decode(&mut decoder)
                         .expect("Error reading cached dep-graph");
 
-                    LoadResult::Ok { data: PreviousDepGraph::new(dep_graph) }
+                    LoadResult::Ok { data: (PreviousDepGraph::new(dep_graph), prev_work_products) }
                 }
             }
         })

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -51,7 +51,6 @@ pub struct Library {
 pub struct CrateLoader<'a> {
     pub sess: &'a Session,
     cstore: &'a CStore,
-    next_crate_num: CrateNum,
     local_crate_name: Symbol,
 }
 
@@ -102,7 +101,6 @@ impl<'a> CrateLoader<'a> {
         CrateLoader {
             sess,
             cstore,
-            next_crate_num: cstore.next_crate_num(),
             local_crate_name: Symbol::intern(local_crate_name),
         }
     }
@@ -198,8 +196,7 @@ impl<'a> CrateLoader<'a> {
         self.verify_no_symbol_conflicts(span, &crate_root);
 
         // Claim this crate number and cache it
-        let cnum = self.next_crate_num;
-        self.next_crate_num = CrateNum::from_u32(cnum.as_u32() + 1);
+        let cnum = self.cstore.alloc_new_crate_num();
 
         // Stash paths for top-most crate locally if necessary.
         let crate_paths = if root.is_none() {

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -64,8 +64,9 @@ pub struct CrateMetadata {
     pub extern_crate: Lock<Option<ExternCrate>>,
 
     pub blob: MetadataBlob,
-    pub cnum_map: Lock<CrateNumMap>,
+    pub cnum_map: CrateNumMap,
     pub cnum: CrateNum,
+    pub dependencies: Lock<Vec<CrateNum>>,
     pub codemap_import_info: RwLock<Vec<ImportedFileMap>>,
     pub attribute_cache: Lock<[Vec<Option<Lrc<[ast::Attribute]>>>; 2]>,
 
@@ -144,7 +145,7 @@ impl CStore {
         }
 
         let data = self.get_crate_data(krate);
-        for &dep in data.cnum_map.borrow().iter() {
+        for &dep in data.dependencies.borrow().iter() {
             if dep != krate {
                 self.push_dependencies_in_postorder(ordering, dep);
             }

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -96,6 +96,10 @@ pub struct CStore {
 impl CStore {
     pub fn new(metadata_loader: Box<MetadataLoader + Sync>) -> CStore {
         CStore {
+            // We add an empty entry for LOCAL_CRATE (which maps to zero) in
+            // order to make array indices in `metas` match with the
+            // corresponding `CrateNum`. This first entry will always remain
+            // `None`.
             metas: RwLock::new(IndexVec::from_elem_n(None, 1)),
             extern_mod_crate_map: Lock::new(FxHashMap()),
             metadata_loader,

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -104,15 +104,15 @@ impl CStore {
 
     /// You cannot use this function to allocate a CrateNum in a thread-safe manner.
     /// It is currently only used in CrateLoader which is single-threaded code.
-    pub fn next_crate_num(&self) -> CrateNum {
+    pub(super) fn next_crate_num(&self) -> CrateNum {
         CrateNum::new(self.metas.borrow().len() + 1)
     }
 
-    pub fn get_crate_data(&self, cnum: CrateNum) -> Lrc<CrateMetadata> {
+    pub(super) fn get_crate_data(&self, cnum: CrateNum) -> Lrc<CrateMetadata> {
         self.metas.borrow()[cnum].clone().unwrap()
     }
 
-    pub fn set_crate_data(&self, cnum: CrateNum, data: Lrc<CrateMetadata>) {
+    pub(super) fn set_crate_data(&self, cnum: CrateNum, data: Lrc<CrateMetadata>) {
         use rustc_data_structures::indexed_vec::Idx;
         let mut met = self.metas.borrow_mut();
         while met.len() <= cnum.index() {
@@ -121,7 +121,7 @@ impl CStore {
         met[cnum] = Some(data);
     }
 
-    pub fn iter_crate_data<I>(&self, mut i: I)
+    pub(super) fn iter_crate_data<I>(&self, mut i: I)
         where I: FnMut(CrateNum, &Lrc<CrateMetadata>)
     {
         for (k, v) in self.metas.borrow().iter_enumerated() {
@@ -131,14 +131,16 @@ impl CStore {
         }
     }
 
-    pub fn crate_dependencies_in_rpo(&self, krate: CrateNum) -> Vec<CrateNum> {
+    pub(super) fn crate_dependencies_in_rpo(&self, krate: CrateNum) -> Vec<CrateNum> {
         let mut ordering = Vec::new();
         self.push_dependencies_in_postorder(&mut ordering, krate);
         ordering.reverse();
         ordering
     }
 
-    pub fn push_dependencies_in_postorder(&self, ordering: &mut Vec<CrateNum>, krate: CrateNum) {
+    pub(super) fn push_dependencies_in_postorder(&self,
+                                                 ordering: &mut Vec<CrateNum>,
+                                                 krate: CrateNum) {
         if ordering.contains(&krate) {
             return;
         }
@@ -153,7 +155,7 @@ impl CStore {
         ordering.push(krate);
     }
 
-    pub fn do_postorder_cnums_untracked(&self) -> Vec<CrateNum> {
+    pub(super) fn do_postorder_cnums_untracked(&self) -> Vec<CrateNum> {
         let mut ordering = Vec::new();
         for (num, v) in self.metas.borrow().iter_enumerated() {
             if let &Some(_) = v {
@@ -163,11 +165,11 @@ impl CStore {
         return ordering
     }
 
-    pub fn add_extern_mod_stmt_cnum(&self, emod_id: ast::NodeId, cnum: CrateNum) {
+    pub(super) fn add_extern_mod_stmt_cnum(&self, emod_id: ast::NodeId, cnum: CrateNum) {
         self.extern_mod_crate_map.borrow_mut().insert(emod_id, cnum);
     }
 
-    pub fn do_extern_mod_stmt_cnum(&self, emod_id: ast::NodeId) -> Option<CrateNum> {
+    pub(super) fn do_extern_mod_stmt_cnum(&self, emod_id: ast::NodeId) -> Option<CrateNum> {
         self.extern_mod_crate_map.borrow().get(&emod_id).cloned()
     }
 }

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -246,7 +246,7 @@ impl<'a, 'tcx: 'a> TyDecoder<'a, 'tcx> for DecodeContext<'a, 'tcx> {
         if cnum == LOCAL_CRATE {
             self.cdata().cnum
         } else {
-            self.cdata().cnum_map.borrow()[cnum]
+            self.cdata().cnum_map[cnum]
         }
     }
 }
@@ -932,7 +932,7 @@ impl<'a, 'tcx> CrateMetadata {
     // Translate a DefId from the current compilation environment to a DefId
     // for an external crate.
     fn reverse_translate_def_id(&self, did: DefId) -> Option<DefId> {
-        for (local, &global) in self.cnum_map.borrow().iter_enumerated() {
+        for (local, &global) in self.cnum_map.iter_enumerated() {
             if global == did.krate {
                 return Some(DefId {
                     krate: local,
@@ -1007,7 +1007,7 @@ impl<'a, 'tcx> CrateMetadata {
             .enumerate()
             .flat_map(|(i, link)| {
                 let cnum = CrateNum::new(i + 1);
-                link.map(|link| (self.cnum_map.borrow()[cnum], link))
+                link.map(|link| (self.cnum_map[cnum], link))
             })
             .collect()
     }

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -970,6 +970,9 @@ fn link_args(cmd: &mut Linker,
              out_filename: &Path,
              trans: &CrateTranslation) {
 
+    // Linker plugins should be specified early in the list of arguments
+    cmd.cross_lang_lto();
+
     // The default library location, we need this to find the runtime.
     // The location of crates will be determined as needed.
     let lib_path = sess.target_filesearch(PathKind::All).get_lib_path();

--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -195,8 +195,10 @@ impl f32 {
     }
 
     /// Fused multiply-add. Computes `(self * a) + b` with only one rounding
-    /// error. This produces a more accurate result with better performance than
-    /// a separate multiplication operation followed by an add.
+    /// error, yielding a more accurate result than an unfused multiply-add.
+    ///
+    /// Using `mul_add` can be more performant than an unfused multiply-add if
+    /// the target architecture has a dedicated `fma` CPU instruction.
     ///
     /// ```
     /// use std::f32;

--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -11,9 +11,9 @@
 //! This module provides constants which are specific to the implementation
 //! of the `f32` floating point data type.
 //!
-//! Mathematically significant numbers are provided in the `consts` sub-module.
-//!
 //! *[See also the `f32` primitive type](../../std/primitive.f32.html).*
+//!
+//! Mathematically significant numbers are provided in the `consts` sub-module.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![allow(missing_docs)]

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -173,8 +173,10 @@ impl f64 {
     }
 
     /// Fused multiply-add. Computes `(self * a) + b` with only one rounding
-    /// error. This produces a more accurate result with better performance than
-    /// a separate multiplication operation followed by an add.
+    /// error, yielding a more accurate result than an unfused multiply-add.
+    ///
+    /// Using `mul_add` can be more performant than an unfused multiply-add if
+    /// the target architecture has a dedicated `fma` CPU instruction.
     ///
     /// ```
     /// let m = 10.0_f64;

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -11,9 +11,9 @@
 //! This module provides constants which are specific to the implementation
 //! of the `f64` floating point data type.
 //!
-//! Mathematically significant numbers are provided in the `consts` sub-module.
-//!
 //! *[See also the `f64` primitive type](../../std/primitive.f64.html).*
+//!
+//! Mathematically significant numbers are provided in the `consts` sub-module.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![allow(missing_docs)]

--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -594,15 +594,13 @@ mod prim_slice { }
 //
 /// String slices.
 ///
+/// *[See also the `std::str` module](str/index.html).*
+///
 /// The `str` type, also called a 'string slice', is the most primitive string
 /// type. It is usually seen in its borrowed form, `&str`. It is also the type
 /// of string literals, `&'static str`.
 ///
-/// Strings slices are always valid UTF-8.
-///
-/// This documentation describes a number of methods and trait implementations
-/// on the `str` type. For technical reasons, there is additional, separate
-/// documentation in the [`std::str`](str/index.html) module as well.
+/// String slices are always valid UTF-8.
 ///
 /// # Examples
 ///

--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -370,6 +370,8 @@ mod prim_unit { }
 //
 /// Raw, unsafe pointers, `*const T`, and `*mut T`.
 ///
+/// *[See also the `std::ptr` module](ptr/index.html).*
+///
 /// Working with raw pointers in Rust is uncommon,
 /// typically limited to a few patterns.
 ///
@@ -443,8 +445,6 @@ mod prim_unit { }
 /// Usually you wouldn't literally use `malloc` and `free` from Rust,
 /// but C APIs hand out a lot of pointers generally, so are a common source
 /// of raw pointers in Rust.
-///
-/// *[See also the `std::ptr` module](ptr/index.html).*
 ///
 /// [`null`]: ../std/ptr/fn.null.html
 /// [`null_mut`]: ../std/ptr/fn.null_mut.html
@@ -563,6 +563,8 @@ mod prim_array { }
 //
 /// A dynamically-sized view into a contiguous sequence, `[T]`.
 ///
+/// *[See also the `std::slice` module](slice/index.html).*
+///
 /// Slices are a view into a block of memory represented as a pointer and a
 /// length.
 ///
@@ -584,8 +586,6 @@ mod prim_array { }
 /// x[1] = 7;
 /// assert_eq!(x, &[1, 7, 3]);
 /// ```
-///
-/// *[See also the `std::slice` module](slice/index.html).*
 ///
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_slice { }
@@ -862,11 +862,11 @@ mod prim_u128 { }
 //
 /// The pointer-sized signed integer type.
 ///
+/// *[See also the `std::isize` module](isize/index.html).*
+///
 /// The size of this primitive is how many bytes it takes to reference any
 /// location in memory. For example, on a 32 bit target, this is 4 bytes
 /// and on a 64 bit target, this is 8 bytes.
-///
-/// *[See also the `std::isize` module](isize/index.html).*
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_isize { }
 
@@ -874,11 +874,11 @@ mod prim_isize { }
 //
 /// The pointer-sized unsigned integer type.
 ///
+/// *[See also the `std::usize` module](usize/index.html).*
+///
 /// The size of this primitive is how many bytes it takes to reference any
 /// location in memory. For example, on a 32 bit target, this is 4 bytes
 /// and on a 64 bit target, this is 8 bytes.
-///
-/// *[See also the `std::usize` module](usize/index.html).*
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_usize { }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5741,7 +5741,7 @@ impl<'a> Parser<'a> {
                 let vis = p.parse_visibility(true)?;
                 let ty = p.parse_ty()?;
                 Ok(StructField {
-                    span: lo.to(p.span),
+                    span: lo.to(ty.span),
                     vis,
                     ident: None,
                     id: ast::DUMMY_NODE_ID,

--- a/src/libsyntax_pos/span_encoding.rs
+++ b/src/libsyntax_pos/span_encoding.rs
@@ -31,11 +31,13 @@ pub struct Span(u32);
 
 impl Copy for Span {}
 impl Clone for Span {
+    #[inline]
     fn clone(&self) -> Span {
         *self
     }
 }
 impl PartialEq for Span {
+    #[inline]
     fn eq(&self, other: &Span) -> bool {
         let a = self.0;
         let b = other.0;
@@ -44,6 +46,7 @@ impl PartialEq for Span {
 }
 impl Eq for Span {}
 impl Hash for Span {
+    #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         let a = self.0;
         a.hash(state)

--- a/src/test/run-make/cross-lang-lto/Makefile
+++ b/src/test/run-make/cross-lang-lto/Makefile
@@ -18,9 +18,9 @@ endif
 OBJDUMP=llvm-objdump
 SECTION_HEADERS=$(OBJDUMP) -section-headers
 
-BUILD_LIB=$(RUSTC) lib.rs -Copt-level=2 -Z cross-lang-lto -Ccodegen-units=1
+BUILD_LIB=$(RUSTC) lib.rs -Copt-level=2 -Z cross-lang-lto=no-link -Ccodegen-units=1
 
-BUILD_EXE=$(RUSTC) main.rs -Copt-level=2 -Z cross-lang-lto -Ccodegen-units=1 --emit=obj
+BUILD_EXE=$(RUSTC) main.rs -Copt-level=2 -Z cross-lang-lto=no-link -Ccodegen-units=1 --emit=obj
 
 all: staticlib staticlib-fat-lto staticlib-thin-lto rlib exe cdylib rdylib
 

--- a/src/test/ui/issue-3008-1.stderr
+++ b/src/test/ui/issue-3008-1.stderr
@@ -5,7 +5,7 @@ LL | enum Bar {
    | ^^^^^^^^ recursive type has infinite size
 ...
 LL |     BarSome(Bar)
-   |             ---- recursive without indirection
+   |             --- recursive without indirection
    |
    = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `Bar` representable
 

--- a/src/test/ui/issue-32326.stderr
+++ b/src/test/ui/issue-32326.stderr
@@ -4,7 +4,7 @@ error[E0072]: recursive type `Expr` has infinite size
 LL | enum Expr { //~ ERROR E0072
    | ^^^^^^^^^ recursive type has infinite size
 LL |     Plus(Expr, Expr),
-   |          ----- ----- recursive without indirection
+   |          ----  ---- recursive without indirection
    |          |
    |          recursive without indirection
    |

--- a/src/test/ui/rfc-2093-infer-outlives/enum.rs
+++ b/src/test/ui/rfc-2093-infer-outlives/enum.rs
@@ -20,14 +20,14 @@ enum Foo<'a, T> {
 
 // Type U needs to outlive lifetime 'b
 struct Bar<'b, U> {
-    field2: &'b U //~ ERROR 23:5: 23:18: the parameter type `U` may not live long enough [E0309]
+    field2: &'b U //~ ERROR the parameter type `U` may not live long enough [E0309]
 }
 
 
 
 // Type K needs to outlive lifetime 'c.
 enum Ying<'c, K> {
-    One(&'c Yang<K>) //~ ERROR 30:9: 30:21: the parameter type `K` may not live long enough [E0309]
+    One(&'c Yang<K>) //~ ERROR the parameter type `K` may not live long enough [E0309]
 }
 
 struct Yang<V> {

--- a/src/test/ui/rfc-2093-infer-outlives/enum.stderr
+++ b/src/test/ui/rfc-2093-infer-outlives/enum.stderr
@@ -3,13 +3,13 @@ error[E0309]: the parameter type `U` may not live long enough
    |
 LL | struct Bar<'b, U> {
    |                - help: consider adding an explicit lifetime bound `U: 'b`...
-LL |     field2: &'b U //~ ERROR 23:5: 23:18: the parameter type `U` may not live long enough [E0309]
+LL |     field2: &'b U //~ ERROR the parameter type `U` may not live long enough [E0309]
    |     ^^^^^^^^^^^^^
    |
 note: ...so that the reference type `&'b U` does not outlive the data it points at
   --> $DIR/enum.rs:23:5
    |
-LL |     field2: &'b U //~ ERROR 23:5: 23:18: the parameter type `U` may not live long enough [E0309]
+LL |     field2: &'b U //~ ERROR the parameter type `U` may not live long enough [E0309]
    |     ^^^^^^^^^^^^^
 
 error[E0309]: the parameter type `K` may not live long enough
@@ -17,14 +17,14 @@ error[E0309]: the parameter type `K` may not live long enough
    |
 LL | enum Ying<'c, K> {
    |               - help: consider adding an explicit lifetime bound `K: 'c`...
-LL |     One(&'c Yang<K>) //~ ERROR 30:9: 30:21: the parameter type `K` may not live long enough [E0309]
-   |         ^^^^^^^^^^^^
+LL |     One(&'c Yang<K>) //~ ERROR the parameter type `K` may not live long enough [E0309]
+   |         ^^^^^^^^^^^
    |
 note: ...so that the reference type `&'c Yang<K>` does not outlive the data it points at
   --> $DIR/enum.rs:30:9
    |
-LL |     One(&'c Yang<K>) //~ ERROR 30:9: 30:21: the parameter type `K` may not live long enough [E0309]
-   |         ^^^^^^^^^^^^
+LL |     One(&'c Yang<K>) //~ ERROR the parameter type `K` may not live long enough [E0309]
+   |         ^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc1598-generic-associated-types/collections.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/collections.rs
@@ -1,0 +1,85 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(generic_associated_types)]
+#![feature(associated_type_defaults)]
+
+//FIXME(#44265): "lifetime parameters are not allowed on this type" errors will be addressed in a
+//follow-up PR
+
+// A Collection trait and collection families.
+// Based on http://smallcultfollowing.com/babysteps/blog/2016/11/03/associated-type-constructors-part-2-family-traits/
+
+trait Collection<T> {
+    fn empty() -> Self;
+    fn add(&mut self, value: T);
+    fn iterate<'iter>(&'iter self) -> Self::Iter<'iter>;
+    //~^ ERROR lifetime parameters are not allowed on this type [E0110]
+    type Iter<'iter>: Iterator<Item=&'iter T>;
+    type Family: CollectionFamily;
+    // Test associated type defaults with parameters
+    type Sibling<U>: Collection<U> = <<Self as Collection<T>>::Family as CollectionFamily>::Member<U>;
+    //~^ ERROR type parameters are not allowed on this type [E0109]
+}
+
+trait CollectionFamily {
+    type Member<T>: Collection<T, Family = Self>;
+}
+
+struct VecFamily;
+
+impl CollectionFamily for VecFamily {
+    type Member<T> = Vec<T>;
+}
+
+impl<T> Collection<T> for Vec<T> {
+    fn empty() -> Self {
+        Vec::new()
+    }
+    fn add(&mut self, value: T) {
+        self.push(value)
+    }
+    fn iterate<'iter>(&'iter self) -> Self::Iter<'iter> {
+    //~^ ERROR lifetime parameters are not allowed on this type [E0110]
+        self.iter()
+    }
+    type Iter<'iter> = std::slice::Iter<'iter, T>;
+    type Family = VecFamily;
+}
+
+fn floatify<C>(ints: &C) -> <<C as Collection<i32>>::Family as CollectionFamily>::Member<f32>
+    //~^ ERROR type parameters are not allowed on this type [E0109]
+    where C: Collection<i32> {
+    let mut res = C::Family::Member::<f32>::empty();
+    for &v in ints.iterate() {
+        res.add(v as f32);
+    }
+    res
+}
+
+fn floatify_sibling<C>(ints: &C) -> <C as Collection<i32>>::Sibling<f32>
+    //~^ ERROR type parameters are not allowed on this type [E0109]
+    where C: Collection<i32> {
+    let mut res = C::Family::Member::<f32>::empty();
+    for &v in ints.iterate() {
+        res.add(v as f32);
+    }
+    res
+}
+
+fn use_floatify() {
+    let a = vec![1i32, 2, 3];
+    let b = floatify(a);
+    println!("{}", b.iterate().next());
+    let c = floatify_sibling(a);
+    println!("{}", c.iterate().next());
+}
+
+fn main() {}

--- a/src/test/ui/rfc1598-generic-associated-types/collections.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/collections.rs
@@ -22,8 +22,8 @@ trait Collection<T> {
     type Iter<'iter>: Iterator<Item=&'iter T>;
     type Family: CollectionFamily;
     // Test associated type defaults with parameters
-    type Sibling<U>: Collection<U> = <<Self as Collection<T>>::Family as CollectionFamily>::
-        Member<U>;
+    type Sibling<U>: Collection<U> =
+        <<Self as Collection<T>>::Family as CollectionFamily>::Member<U>;
     //~^ ERROR type parameters are not allowed on this type [E0109]
 
     fn empty() -> Self;
@@ -63,7 +63,7 @@ impl<T> Collection<T> for Vec<T> {
 }
 
 fn floatify<C>(ints: &C) -> <<C as Collection<i32>>::Family as CollectionFamily>::Member<f32>
-    //~^ ERROR type parameters are not allowed on this type [E0109]
+//~^ ERROR type parameters are not allowed on this type [E0109]
 where
     C: Collection<i32>,
 {
@@ -75,7 +75,7 @@ where
 }
 
 fn floatify_sibling<C>(ints: &C) -> <C as Collection<i32>>::Sibling<f32>
-    //~^ ERROR type parameters are not allowed on this type [E0109]
+//~^ ERROR type parameters are not allowed on this type [E0109]
 where
     C: Collection<i32>,
 {

--- a/src/test/ui/rfc1598-generic-associated-types/collections.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/collections.rs
@@ -14,8 +14,9 @@
 //FIXME(#44265): "lifetime parameters are not allowed on this type" errors will be addressed in a
 //follow-up PR
 
-// A Collection trait and collection families.
-// Based on http://smallcultfollowing.com/babysteps/blog/2016/11/03/associated-type-constructors-part-2-family-traits/
+// A Collection trait and collection families. Based on
+// http://smallcultfollowing.com/babysteps/blog/2016/11/03/
+// associated-type-constructors-part-2-family-traits/
 
 trait Collection<T> {
     fn empty() -> Self;
@@ -25,7 +26,8 @@ trait Collection<T> {
     type Iter<'iter>: Iterator<Item=&'iter T>;
     type Family: CollectionFamily;
     // Test associated type defaults with parameters
-    type Sibling<U>: Collection<U> = <<Self as Collection<T>>::Family as CollectionFamily>::Member<U>;
+    type Sibling<U>: Collection<U> = <<Self as Collection<T>>::Family as CollectionFamily>::
+        Member<U>;
     //~^ ERROR type parameters are not allowed on this type [E0109]
 }
 

--- a/src/test/ui/rfc1598-generic-associated-types/collections.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/collections.stderr
@@ -1,0 +1,34 @@
+error[E0109]: type parameters are not allowed on this type
+  --> $DIR/collections.rs:57:90
+   |
+LL | fn floatify<C>(ints: &C) -> <<C as Collection<i32>>::Family as CollectionFamily>::Member<f32>
+   |                                                                                          ^^^ type parameter not allowed
+
+error[E0109]: type parameters are not allowed on this type
+  --> $DIR/collections.rs:67:69
+   |
+LL | fn floatify_sibling<C>(ints: &C) -> <C as Collection<i32>>::Sibling<f32>
+   |                                                                     ^^^ type parameter not allowed
+
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/collections.rs:23:50
+   |
+LL |     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter>;
+   |                                                  ^^^^^ lifetime parameter not allowed on this type
+
+error[E0109]: type parameters are not allowed on this type
+  --> $DIR/collections.rs:28:100
+   |
+LL |     type Sibling<U>: Collection<U> = <<Self as Collection<T>>::Family as CollectionFamily>::Member<U>;
+   |                                                                                                    ^ type parameter not allowed
+
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/collections.rs:49:50
+   |
+LL |     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter> {
+   |                                                  ^^^^^ lifetime parameter not allowed on this type
+
+error: aborting due to 5 previous errors
+
+Some errors occurred: E0109, E0110.
+For more information about an error, try `rustc --explain E0109`.

--- a/src/test/ui/rfc1598-generic-associated-types/collections.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/collections.stderr
@@ -1,29 +1,29 @@
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/collections.rs:59:90
+  --> $DIR/collections.rs:65:90
    |
 LL | fn floatify<C>(ints: &C) -> <<C as Collection<i32>>::Family as CollectionFamily>::Member<f32>
    |                                                                                          ^^^ type parameter not allowed
 
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/collections.rs:69:69
+  --> $DIR/collections.rs:77:69
    |
 LL | fn floatify_sibling<C>(ints: &C) -> <C as Collection<i32>>::Sibling<f32>
    |                                                                     ^^^ type parameter not allowed
 
-error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/collections.rs:24:50
-   |
-LL |     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter>;
-   |                                                  ^^^^^ lifetime parameter not allowed on this type
-
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/collections.rs:30:16
+  --> $DIR/collections.rs:26:16
    |
 LL |         Member<U>;
    |                ^ type parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/collections.rs:51:50
+  --> $DIR/collections.rs:33:50
+   |
+LL |     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter>;
+   |                                                  ^^^^^ lifetime parameter not allowed on this type
+
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/collections.rs:59:50
    |
 LL |     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter> {
    |                                                  ^^^^^ lifetime parameter not allowed on this type

--- a/src/test/ui/rfc1598-generic-associated-types/collections.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/collections.stderr
@@ -1,29 +1,29 @@
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/collections.rs:57:90
+  --> $DIR/collections.rs:59:90
    |
 LL | fn floatify<C>(ints: &C) -> <<C as Collection<i32>>::Family as CollectionFamily>::Member<f32>
    |                                                                                          ^^^ type parameter not allowed
 
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/collections.rs:67:69
+  --> $DIR/collections.rs:69:69
    |
 LL | fn floatify_sibling<C>(ints: &C) -> <C as Collection<i32>>::Sibling<f32>
    |                                                                     ^^^ type parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/collections.rs:23:50
+  --> $DIR/collections.rs:24:50
    |
 LL |     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter>;
    |                                                  ^^^^^ lifetime parameter not allowed on this type
 
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/collections.rs:28:100
+  --> $DIR/collections.rs:30:16
    |
-LL |     type Sibling<U>: Collection<U> = <<Self as Collection<T>>::Family as CollectionFamily>::Member<U>;
-   |                                                                                                    ^ type parameter not allowed
+LL |         Member<U>;
+   |                ^ type parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/collections.rs:49:50
+  --> $DIR/collections.rs:51:50
    |
 LL |     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter> {
    |                                                  ^^^^^ lifetime parameter not allowed on this type

--- a/src/test/ui/rfc1598-generic-associated-types/collections.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/collections.stderr
@@ -11,10 +11,10 @@ LL | fn floatify_sibling<C>(ints: &C) -> <C as Collection<i32>>::Sibling<f32>
    |                                                                     ^^^ type parameter not allowed
 
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/collections.rs:26:16
+  --> $DIR/collections.rs:26:71
    |
-LL |         Member<U>;
-   |                ^ type parameter not allowed
+LL |         <<Self as Collection<T>>::Family as CollectionFamily>::Member<U>;
+   |                                                                       ^ type parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
   --> $DIR/collections.rs:33:50

--- a/src/test/ui/rfc1598-generic-associated-types/construct_with_other_type.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/construct_with_other_type.rs
@@ -10,6 +10,8 @@
 
 #![feature(generic_associated_types)]
 
+use std::ops::Deref;
+
 //FIXME(#44265): "lifetime parameters are not allowed on this type" errors will be addressed in a
 //follow-up PR
 
@@ -18,11 +20,18 @@ trait Foo {
 }
 
 trait Baz {
-    type Quux<'a>;
+    type Quux<'a>: Foo;
+
+    // This weird type tests that we can use universal function call syntax to access the Item on
+    type Baa<'a>: Deref<Target = <Self::Quux<'a> as Foo>::Bar<'a, 'static>>;
+    //~^ ERROR lifetime parameters are not allowed on this type [E0110]
+    //~| ERROR lifetime parameters are not allowed on this type [E0110]
 }
 
 impl<T> Baz for T where T: Foo {
-    type Quux<'a> = <T as Foo>::Bar<'a, 'static>;
+    type Quux<'a> = T;
+
+    type Baa<'a> = &'a <T as Foo>::Bar<'a, 'static>;
     //~^ ERROR lifetime parameters are not allowed on this type [E0110]
 }
 

--- a/src/test/ui/rfc1598-generic-associated-types/construct_with_other_type.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/construct_with_other_type.stderr
@@ -1,9 +1,21 @@
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/construct_with_other_type.rs:25:37
+  --> $DIR/construct_with_other_type.rs:26:46
    |
-LL |     type Quux<'a> = <T as Foo>::Bar<'a, 'static>;
-   |                                     ^^ lifetime parameter not allowed on this type
+LL |     type Baa<'a>: Deref<Target = <Self::Quux<'a> as Foo>::Bar<'a, 'static>>;
+   |                                              ^^ lifetime parameter not allowed on this type
 
-error: aborting due to previous error
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/construct_with_other_type.rs:26:63
+   |
+LL |     type Baa<'a>: Deref<Target = <Self::Quux<'a> as Foo>::Bar<'a, 'static>>;
+   |                                                               ^^ lifetime parameter not allowed on this type
+
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/construct_with_other_type.rs:34:40
+   |
+LL |     type Baa<'a> = &'a <T as Foo>::Bar<'a, 'static>;
+   |                                        ^^ lifetime parameter not allowed on this type
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0110`.

--- a/src/test/ui/rfc1598-generic-associated-types/iterable.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/iterable.rs
@@ -20,11 +20,6 @@ trait Iterable {
     type Iter<'a>: Iterator<Item = Self::Item<'a>>;
     //~^ ERROR lifetime parameters are not allowed on this type [E0110]
 
-    // This weird type tests that we can use universal function call syntax to access the Item on
-    // Self::Iter which we have declared to be an Iterator
-    type Iter2<'a>: Deref<Target = <Self::Iter<'a> as Iterator>::Item>;
-    //~^ ERROR lifetime parameters are not allowed on this type [E0110]
-
     fn iter<'a>(&'a self) -> Self::Iter<'a>;
     //~^ ERROR lifetime parameters are not allowed on this type [E0110]
 }
@@ -33,8 +28,7 @@ trait Iterable {
 impl<T> Iterable for Vec<T> {
     type Item<'a> = &'a T;
     type Iter<'a> = std::slice::Iter<'a, T>;
-    type Iter2<'a> = &'a T;
-    // gavento: ^^^ Not 100% sure about the intention here
+
     fn iter<'a>(&'a self) -> Self::Iter<'a> {
     //~^ ERROR lifetime parameters are not allowed on this type [E0110]
         self.iter()
@@ -45,8 +39,7 @@ impl<T> Iterable for Vec<T> {
 impl<T> Iterable for [T] {
     type Item<'a> = &'a T;
     type Iter<'a> = std::slice::Iter<'a, T>;
-    type Iter2<'a> = &'a T;
-    // gavento: ^^^ Not 100% sure about the intention here
+
     fn iter<'a>(&'a self) -> Self::Iter<'a> {
     //~^ ERROR lifetime parameters are not allowed on this type [E0110]
         self.iter()

--- a/src/test/ui/rfc1598-generic-associated-types/iterable.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/iterable.rs
@@ -29,4 +29,38 @@ trait Iterable {
     //~^ ERROR lifetime parameters are not allowed on this type [E0110]
 }
 
+// Impl for struct type
+impl<T> Iterable for Vec<T> {
+    type Item<'a> = &'a T;
+    type Iter<'a> = std::slice::Iter<'a, T>;
+    type Iter2<'a> = &'a T;
+    // gavento: ^^^ Not 100% sure about the intention here
+    fn iter<'a>(&'a self) -> Self::Iter<'a> {
+    //~^ ERROR lifetime parameters are not allowed on this type [E0110]
+        self.iter()
+    }
+}
+
+// Impl for a primitive type
+impl<T> Iterable for [T] {
+    type Item<'a> = &'a T;
+    type Iter<'a> = std::slice::Iter<'a, T>;
+    type Iter2<'a> = &'a T;
+    // gavento: ^^^ Not 100% sure about the intention here
+    fn iter<'a>(&'a self) -> Self::Iter<'a> {
+    //~^ ERROR lifetime parameters are not allowed on this type [E0110]
+        self.iter()
+    }
+}
+
+fn make_iter<'a, I: Iterable>(it: &'a I) -> I::Iter<'a> {
+    //~^ ERROR lifetime parameters are not allowed on this type [E0110]
+    it.iter()
+}
+
+fn get_first<'a, I: Iterable>(it: &'a I) -> Option<I::Item<'a>> {
+    //~^ ERROR lifetime parameters are not allowed on this type [E0110]
+    it.iter().next()
+}
+
 fn main() {}

--- a/src/test/ui/rfc1598-generic-associated-types/iterable.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/iterable.stderr
@@ -11,11 +11,35 @@ LL |     type Iter2<'a>: Deref<Target = <Self::Iter<'a> as Iterator>::Item>;
    |                                                ^^ lifetime parameter not allowed on this type
 
 error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/iterable.rs:56:53
+   |
+LL | fn make_iter<'a, I: Iterable>(it: &'a I) -> I::Iter<'a> {
+   |                                                     ^^ lifetime parameter not allowed on this type
+
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/iterable.rs:61:60
+   |
+LL | fn get_first<'a, I: Iterable>(it: &'a I) -> Option<I::Item<'a>> {
+   |                                                            ^^ lifetime parameter not allowed on this type
+
+error[E0110]: lifetime parameters are not allowed on this type
   --> $DIR/iterable.rs:28:41
    |
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'a>;
    |                                         ^^ lifetime parameter not allowed on this type
 
-error: aborting due to 3 previous errors
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/iterable.rs:38:41
+   |
+LL |     fn iter<'a>(&'a self) -> Self::Iter<'a> {
+   |                                         ^^ lifetime parameter not allowed on this type
+
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/iterable.rs:50:41
+   |
+LL |     fn iter<'a>(&'a self) -> Self::Iter<'a> {
+   |                                         ^^ lifetime parameter not allowed on this type
+
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0110`.

--- a/src/test/ui/rfc1598-generic-associated-types/iterable.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/iterable.stderr
@@ -5,41 +5,35 @@ LL |     type Iter<'a>: Iterator<Item = Self::Item<'a>>;
    |                                               ^^ lifetime parameter not allowed on this type
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/iterable.rs:25:48
-   |
-LL |     type Iter2<'a>: Deref<Target = <Self::Iter<'a> as Iterator>::Item>;
-   |                                                ^^ lifetime parameter not allowed on this type
-
-error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/iterable.rs:56:53
+  --> $DIR/iterable.rs:49:53
    |
 LL | fn make_iter<'a, I: Iterable>(it: &'a I) -> I::Iter<'a> {
    |                                                     ^^ lifetime parameter not allowed on this type
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/iterable.rs:61:60
+  --> $DIR/iterable.rs:54:60
    |
 LL | fn get_first<'a, I: Iterable>(it: &'a I) -> Option<I::Item<'a>> {
    |                                                            ^^ lifetime parameter not allowed on this type
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/iterable.rs:28:41
+  --> $DIR/iterable.rs:23:41
    |
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'a>;
    |                                         ^^ lifetime parameter not allowed on this type
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/iterable.rs:38:41
+  --> $DIR/iterable.rs:32:41
    |
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'a> {
    |                                         ^^ lifetime parameter not allowed on this type
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/iterable.rs:50:41
+  --> $DIR/iterable.rs:43:41
    |
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'a> {
    |                                         ^^ lifetime parameter not allowed on this type
 
-error: aborting due to 7 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0110`.

--- a/src/test/ui/rfc1598-generic-associated-types/parameter_number_and_kind.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/parameter_number_and_kind.rs
@@ -1,0 +1,56 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(generic_associated_types)]
+#![feature(associated_type_defaults)]
+
+//FIXME(#44265): "lifetime parameters are not allowed on this type" errors will be addressed in a
+//follow-up PR
+
+//FIXME(#44265): Update expected errors once E110 is resolved, now does not get past `trait Foo`
+
+trait Foo {
+    type A<'a>;
+    type B<'a, 'b>;
+    type C;
+    type D<T>;
+    type E<'a, T>;
+    // Test parameters in default values
+    type FOk<T> = Self::E<'static, T>;
+    //~^ ERROR type parameters are not allowed on this type [E0109]
+    //~| ERROR lifetime parameters are not allowed on this type [E0110]
+    type FErr1 = Self::E<'static, 'static>; // Error
+    //~^ ERROR lifetime parameters are not allowed on this type [E0110]
+    type FErr2<T> = Self::E<'static, T, u32>; // Error
+    //~^ ERROR type parameters are not allowed on this type [E0109]
+    //~| ERROR lifetime parameters are not allowed on this type [E0110]
+}
+
+struct Fooy;
+
+impl Foo for Fooy {
+    type A = u32; // Error: parameter expected
+    type B<'a, T> = Vec<T>; // Error: lifetime param expected
+    type C<'a> = u32; // Error: no param expected
+    type D<'a> = u32; // Error: type param expected
+    type E<T, U> = u32; // Error: lifetime expected as the first param
+}
+
+struct Fooer;
+
+impl Foo for Fooer {
+    type A<T> = u32; // Error: lifetime parameter expected
+    type B<'a> = u32; // Error: another lifetime param expected
+    type C<T> = T; // Error: no param expected
+    type D<'b, T> = u32; // Error: unexpected lifetime param
+    type E<'a, 'b> = u32; // Error: type expected as the second param
+}
+
+fn main() {}

--- a/src/test/ui/rfc1598-generic-associated-types/parameter_number_and_kind.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/parameter_number_and_kind.stderr
@@ -1,0 +1,34 @@
+error[E0109]: type parameters are not allowed on this type
+  --> $DIR/parameter_number_and_kind.rs:26:36
+   |
+LL |     type FOk<T> = Self::E<'static, T>;
+   |                                    ^ type parameter not allowed
+
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/parameter_number_and_kind.rs:26:27
+   |
+LL |     type FOk<T> = Self::E<'static, T>;
+   |                           ^^^^^^^ lifetime parameter not allowed on this type
+
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/parameter_number_and_kind.rs:29:26
+   |
+LL |     type FErr1 = Self::E<'static, 'static>; // Error
+   |                          ^^^^^^^ lifetime parameter not allowed on this type
+
+error[E0109]: type parameters are not allowed on this type
+  --> $DIR/parameter_number_and_kind.rs:31:38
+   |
+LL |     type FErr2<T> = Self::E<'static, T, u32>; // Error
+   |                                      ^ type parameter not allowed
+
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/parameter_number_and_kind.rs:31:29
+   |
+LL |     type FErr2<T> = Self::E<'static, T, u32>; // Error
+   |                             ^^^^^^^ lifetime parameter not allowed on this type
+
+error: aborting due to 5 previous errors
+
+Some errors occurred: E0109, E0110.
+For more information about an error, try `rustc --explain E0109`.

--- a/src/test/ui/rfc1598-generic-associated-types/shadowing.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/shadowing.rs
@@ -13,7 +13,7 @@
 //FIXME(#44265): The lifetime shadowing and type parameter shadowing
 // should cause an error. Now it compiles (errorneously) and this will be addressed
 // by a future PR. Then remove the following:
-// must-compile-successfully
+// compile-pass
 
 trait Shadow<'a> {
     type Bar<'a>; // Error: shadowed lifetime

--- a/src/test/ui/rfc1598-generic-associated-types/shadowing.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/shadowing.rs
@@ -23,8 +23,7 @@ trait NoShadow<'a> {
     type Bar<'b>; // OK
 }
 
-impl<'a> NoShadow<'a> for &'a u32
-{
+impl<'a> NoShadow<'a> for &'a u32 {
     type Bar<'a> = i32; // Error: shadowed lifetime
 }
 
@@ -36,8 +35,7 @@ trait NoShadowT<T> {
     type Bar<U>; // OK
 }
 
-impl<T> NoShadowT<T> for Option<T>
-{
+impl<T> NoShadowT<T> for Option<T> {
     type Bar<T> = i32; // Error: shadowed type parameter
 }
 

--- a/src/test/ui/rfc1598-generic-associated-types/shadowing.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/shadowing.rs
@@ -11,8 +11,8 @@
 #![feature(generic_associated_types)]
 
 //FIXME(#44265): The lifetime shadowing and type parameter shadowing
-// should cause an error. This will be addressed by a future PR.
-// For now this compiles:
+// should cause an error. Now it compiles (errorneously) and this will be addressed
+// by a future PR. Then remove the following:
 // must-compile-successfully
 
 trait Shadow<'a> {

--- a/src/test/ui/rfc1598-generic-associated-types/shadowing.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/shadowing.rs
@@ -1,0 +1,44 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(generic_associated_types)]
+
+//FIXME(#44265): The lifetime shadowing and type parameter shadowing
+// should cause an error. This will be addressed by a future PR.
+// For now this compiles:
+// must-compile-successfully
+
+trait Shadow<'a> {
+    type Bar<'a>; // Error: shadowed lifetime
+}
+
+trait NoShadow<'a> {
+    type Bar<'b>; // OK
+}
+
+impl<'a> NoShadow<'a> for &'a u32
+{
+    type Bar<'a> = i32; // Error: shadowed lifetime
+}
+
+trait ShadowT<T> {
+    type Bar<T>; // Error: shadowed type parameter
+}
+
+trait NoShadowT<T> {
+    type Bar<U>; // OK
+}
+
+impl<T> NoShadowT<T> for Option<T>
+{
+    type Bar<T> = i32; // Error: shadowed type parameter
+}
+
+fn main() {}

--- a/src/test/ui/rfc1598-generic-associated-types/streaming_iterator.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/streaming_iterator.rs
@@ -35,4 +35,48 @@ struct Foo<T: StreamingIterator> {
 fn foo<T>(iter: T) where T: StreamingIterator, for<'a> T::Item<'a>: Display { /* ... */ }
 //~^ ERROR lifetime parameters are not allowed on this type [E0110]
 
+// Full example of enumerate iterator
+
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+struct StreamEnumerate<I> {
+    iter: I,
+    count: usize,
+}
+
+impl<I: StreamingIterator> StreamingIterator for StreamEnumerate<I> {
+    type Item<'a> = (usize, I::Item<'a>);
+    //~^ ERROR lifetime parameters are not allowed on this type [E0110]
+    fn next<'a>(&'a self) -> Option<Self::Item<'a>> {
+        //~^ ERROR lifetime parameters are not allowed on this type [E0110]
+        match self.iter.next() {
+            None => None,
+            Some(val) => {
+                let r = Some((self.count, val));
+                self.count += 1;
+                r
+            }
+        }
+    }
+}
+
+impl<I> StreamEnumerate<I> {
+    pub fn new(iter: I) -> Self {
+        StreamEnumerate {
+            count: 0,
+            iter: iter,
+        }
+    }
+}
+
+fn test_stream_enumerate() {
+    let v = vec!["a", "b", "c"];
+    let se = StreamEnumerate::new(v.iter());
+    let a: &str = se.next().unwrap().1;
+    for (i, s) in se {
+        println!("{} {}", i, s);
+    }
+    println!("{}", a);
+}
+
+
 fn main() {}

--- a/src/test/ui/rfc1598-generic-associated-types/streaming_iterator.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/streaming_iterator.stderr
@@ -16,6 +16,18 @@ error[E0110]: lifetime parameters are not allowed on this type
 LL |     fn next<'a>(&'a self) -> Option<Self::Item<'a>>;
    |                                                ^^ lifetime parameter not allowed on this type
 
-error: aborting due to 3 previous errors
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/streaming_iterator.rs:47:37
+   |
+LL |     type Item<'a> = (usize, I::Item<'a>);
+   |                                     ^^ lifetime parameter not allowed on this type
+
+error[E0110]: lifetime parameters are not allowed on this type
+  --> $DIR/streaming_iterator.rs:49:48
+   |
+LL |     fn next<'a>(&'a self) -> Option<Self::Item<'a>> {
+   |                                                ^^ lifetime parameter not allowed on this type
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0110`.

--- a/src/test/ui/span/E0204.stderr
+++ b/src/test/ui/span/E0204.stderr
@@ -32,7 +32,7 @@ LL | #[derive(Copy)] //~ ERROR may not be implemented for this type
    |          ^^^^
 LL | enum EFoo2<'a> {
 LL |     Bar(&'a mut bool),
-   |         ------------- this field does not implement `Copy`
+   |         ------------ this field does not implement `Copy`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/union/union-sized-field.stderr
+++ b/src/test/ui/union/union-sized-field.stderr
@@ -22,7 +22,7 @@ error[E0277]: the trait bound `T: std::marker::Sized` is not satisfied
   --> $DIR/union-sized-field.rs:23:11
    |
 LL |     Value(T), //~ ERROR the trait bound `T: std::marker::Sized` is not satisfied
-   |           ^^ `T` does not have a constant size known at compile-time
+   |           ^ `T` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `T`
    = help: consider adding a `where T: std::marker::Sized` bound

--- a/src/test/ui/unsized-enum2.stderr
+++ b/src/test/ui/unsized-enum2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `W: std::marker::Sized` is not satisfied
   --> $DIR/unsized-enum2.rs:33:8
    |
 LL |     VA(W), //~ ERROR `W: std::marker::Sized` is not satisfied
-   |        ^^ `W` does not have a constant size known at compile-time
+   |        ^ `W` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `W`
    = help: consider adding a `where W: std::marker::Sized` bound
@@ -22,7 +22,7 @@ error[E0277]: the trait bound `Y: std::marker::Sized` is not satisfied
   --> $DIR/unsized-enum2.rs:35:15
    |
 LL |     VC(isize, Y), //~ ERROR `Y: std::marker::Sized` is not satisfied
-   |               ^^ `Y` does not have a constant size known at compile-time
+   |               ^ `Y` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `Y`
    = help: consider adding a `where Y: std::marker::Sized` bound
@@ -42,7 +42,7 @@ error[E0277]: the trait bound `[u8]: std::marker::Sized` is not satisfied
   --> $DIR/unsized-enum2.rs:39:8
    |
 LL |     VE([u8]), //~ ERROR `[u8]: std::marker::Sized` is not satisfied
-   |        ^^^^^ `[u8]` does not have a constant size known at compile-time
+   |        ^^^^ `[u8]` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[u8]`
    = note: no field of an enum variant may have a dynamically sized type
@@ -60,7 +60,7 @@ error[E0277]: the trait bound `[f32]: std::marker::Sized` is not satisfied
   --> $DIR/unsized-enum2.rs:41:15
    |
 LL |     VG(isize, [f32]), //~ ERROR `[f32]: std::marker::Sized` is not satisfied
-   |               ^^^^^^ `[f32]` does not have a constant size known at compile-time
+   |               ^^^^^ `[f32]` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[f32]`
    = note: no field of an enum variant may have a dynamically sized type
@@ -78,7 +78,7 @@ error[E0277]: the trait bound `Foo + 'static: std::marker::Sized` is not satisfi
   --> $DIR/unsized-enum2.rs:51:8
    |
 LL |     VM(Foo),  //~ ERROR `Foo + 'static: std::marker::Sized` is not satisfied
-   |        ^^^^ `Foo + 'static` does not have a constant size known at compile-time
+   |        ^^^ `Foo + 'static` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `Foo + 'static`
    = note: no field of an enum variant may have a dynamically sized type
@@ -96,7 +96,7 @@ error[E0277]: the trait bound `FooBar + 'static: std::marker::Sized` is not sati
   --> $DIR/unsized-enum2.rs:53:15
    |
 LL |     VO(isize, FooBar), //~ ERROR `FooBar + 'static: std::marker::Sized` is not satisfied
-   |               ^^^^^^^ `FooBar + 'static` does not have a constant size known at compile-time
+   |               ^^^^^^ `FooBar + 'static` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `FooBar + 'static`
    = note: no field of an enum variant may have a dynamically sized type
@@ -114,7 +114,7 @@ error[E0277]: the trait bound `[i8]: std::marker::Sized` is not satisfied
   --> $DIR/unsized-enum2.rs:57:8
    |
 LL |     VQ(<&'static [i8] as Deref>::Target), //~ ERROR `[i8]: std::marker::Sized` is not satisfied
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `[i8]` does not have a constant size known at compile-time
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `[i8]` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[i8]`
    = note: no field of an enum variant may have a dynamically sized type
@@ -132,7 +132,7 @@ error[E0277]: the trait bound `[f64]: std::marker::Sized` is not satisfied
   --> $DIR/unsized-enum2.rs:60:15
    |
 LL |     VS(isize, <&'static [f64] as Deref>::Target),
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `[f64]` does not have a constant size known at compile-time
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `[f64]` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[f64]`
    = note: no field of an enum variant may have a dynamically sized type
@@ -150,7 +150,7 @@ error[E0277]: the trait bound `PathHelper1 + 'static: std::marker::Sized` is not
   --> $DIR/unsized-enum2.rs:45:8
    |
 LL |     VI(Path1), //~ ERROR `PathHelper1 + 'static: std::marker::Sized` is not satisfied
-   |        ^^^^^^ `PathHelper1 + 'static` does not have a constant size known at compile-time
+   |        ^^^^^ `PathHelper1 + 'static` does not have a constant size known at compile-time
    |
    = help: within `Path1`, the trait `std::marker::Sized` is not implemented for `PathHelper1 + 'static`
    = note: required because it appears within the type `Path1`
@@ -170,7 +170,7 @@ error[E0277]: the trait bound `PathHelper3 + 'static: std::marker::Sized` is not
   --> $DIR/unsized-enum2.rs:47:15
    |
 LL |     VK(isize, Path3), //~ ERROR `PathHelper3 + 'static: std::marker::Sized` is not satisfied
-   |               ^^^^^^ `PathHelper3 + 'static` does not have a constant size known at compile-time
+   |               ^^^^^ `PathHelper3 + 'static` does not have a constant size known at compile-time
    |
    = help: within `Path3`, the trait `std::marker::Sized` is not implemented for `PathHelper3 + 'static`
    = note: required because it appears within the type `Path3`

--- a/src/test/ui/update-references.sh
+++ b/src/test/ui/update-references.sh
@@ -26,6 +26,7 @@ if [[ "$1" == "--help" || "$1" == "-h" || "$1" == "" || "$2" == "" ]]; then
     echo "   $0 ../../../build/x86_64-apple-darwin/test/ui *.rs */*.rs"
 fi
 
+MYDIR=$(dirname $0)
 
 BUILD_DIR="$1"
 shift
@@ -33,13 +34,13 @@ shift
 shopt -s nullglob
 
 while [[ "$1" != "" ]]; do
-    MYDIR=$(dirname $1)
     for EXT in "stderr" "stdout" "fixed"; do
         for OUT_NAME in $BUILD_DIR/${1%.rs}.*$EXT; do
+            OUT_DIR=`dirname "$1"`
             OUT_BASE=`basename "$OUT_NAME"`
-            if ! (diff $OUT_NAME $MYDIR/$OUT_BASE >& /dev/null); then
-                echo updating $MYDIR/$OUT_BASE
-                cp $OUT_NAME $MYDIR
+            if ! (diff $OUT_NAME $MYDIR/$OUT_DIR/$OUT_BASE >& /dev/null); then
+                echo updating $MYDIR/$OUT_DIR/$OUT_BASE
+                cp $OUT_NAME $MYDIR/$OUT_DIR
             fi
         done
     done


### PR DESCRIPTION
Successful merges:

 - #49423 (Extend tests for RFC1598 (GAT))
 - #50010 (Give SliceIndex impls a test suite of girth befitting the implementation (and fix a UTF8 boundary check))
 - #50447 (Fix update-references for tests within subdirectories.)
 - #50514 (Pull in a wasm fix from LLVM upstream)
 - #50524 (Make DepGraph::previous_work_products immutable)
 - #50532 (Don't use Lock for heavily accessed CrateMetadata::cnum_map.)
 - #50538 ( Make CrateNum allocation more thread-safe. )
 - #50564 (Inline `Span` methods.)
 - #50565 (Use SmallVec for DepNodeIndex within dep_graph.)
 - #50569 (Allow for specifying a linker plugin for cross-language LTO)
 - #50572 (Clarify in the docs that `mul_add` is not always faster.)
 - #50574 (add fn `into_inner(self) -> (Idx, Idx)` to RangeInclusive (#49022))
 - #50575 (std: Avoid `ptr::copy` if unnecessary in `vec::Drain`)
 - #50588 (Move "See also" disambiguation links for primitive types to top)
 - #50590 (Fix tuple struct field spans)
 - #50591 (Restore RawVec::reserve* documentation)
 - #50598 (Remove unnecessary mutable borrow and resizing in DepGraph::serialize)
 - #50606 (Retry when downloading the Docker cache.)

Failed merges:

 - #50161 (added missing implementation hint)
 - #50558 (Remove all reference to DepGraph::work_products)
