### PR TITLE
Rename the 2018 edition lint names

### DIFF
--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -179,7 +179,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
                     UNUSED_PARENS);
 
     add_lint_group!(sess,
-                    "rust_2018_migration",
+                    "rust_2018_idioms",
                     BARE_TRAIT_OBJECT,
                     UNREACHABLE_PUB,
                     UNNECESSARY_EXTERN_CRATE);

--- a/src/libsyntax/edition.rs
+++ b/src/libsyntax/edition.rs
@@ -50,8 +50,8 @@ impl fmt::Display for Edition {
 impl Edition {
     pub fn lint_name(&self) -> &'static str {
         match *self {
-            Edition::Edition2015 => "rust_2015_breakage",
-            Edition::Edition2018 => "rust_2018_breakage",
+            Edition::Edition2015 => "rust_2015_compatibility",
+            Edition::Edition2018 => "rust_2018_compatibility",
         }
     }
 


### PR DESCRIPTION
* `rust_2018_breakage` -> `rust_2018_compatibility` - the lint for ensuring
  that your code, in the 2015 edition, is compatible with the 2018 edition's
  semantics. This is required to pass *before* you enable the 2018 edition.
* `rust_2018_migration` -> `rust_2018_idioms` - the lint for writing idiomatic
  code after you've already enabled the 2018 edition