### PR TITLE
rustc: leave space for fields of uninhabited types to allow partial initialization.

### DIFF
--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -761,17 +761,6 @@ impl LayoutDetails {
             align,
         }
     }
-
-    pub fn uninhabited(field_count: usize) -> Self {
-        let align = Align::from_bytes(1, 1).unwrap();
-        LayoutDetails {
-            variants: Variants::Single { index: 0 },
-            fields: FieldPlacement::Union(field_count),
-            abi: Abi::Uninhabited,
-            align,
-            size: Size::from_bytes(0)
-        }
-    }
 }
 
 /// The details of the layout of a type, alongside the type itself.
@@ -826,10 +815,10 @@ impl<'a, Ty> TyLayout<'a, Ty> {
     /// Returns true if the type is a ZST and not unsized.
     pub fn is_zst(&self) -> bool {
         match self.abi {
-            Abi::Uninhabited => true,
             Abi::Scalar(_) |
             Abi::ScalarPair(..) |
             Abi::Vector { .. } => false,
+            Abi::Uninhabited => self.size.bytes() == 0,
             Abi::Aggregate { sized } => sized && self.size.bytes() == 0
         }
     }

--- a/src/librustc_trans/mir/operand.rs
+++ b/src/librustc_trans/mir/operand.rs
@@ -223,12 +223,9 @@ impl<'a, 'tcx> OperandRef<'tcx> {
         let offset = self.layout.fields.offset(i);
 
         let mut val = match (self.val, &self.layout.abi) {
-            // If we're uninhabited, or the field is ZST, it has no data.
-            _ if self.layout.abi == layout::Abi::Uninhabited || field.is_zst() => {
-                return OperandRef {
-                    val: OperandValue::Immediate(C_undef(field.immediate_llvm_type(bx.cx))),
-                    layout: field
-                };
+            // If the field is ZST, it has no data.
+            _ if field.is_zst() => {
+                return OperandRef::new_zst(bx.cx, field);
             }
 
             // Newtype of a scalar, scalar pair or vector.

--- a/src/librustc_trans/type_of.rs
+++ b/src/librustc_trans/type_of.rs
@@ -213,10 +213,10 @@ pub trait LayoutLlvmExt<'tcx> {
 impl<'tcx> LayoutLlvmExt<'tcx> for TyLayout<'tcx> {
     fn is_llvm_immediate(&self) -> bool {
         match self.abi {
-            layout::Abi::Uninhabited |
             layout::Abi::Scalar(_) |
             layout::Abi::Vector { .. } => true,
             layout::Abi::ScalarPair(..) => false,
+            layout::Abi::Uninhabited |
             layout::Abi::Aggregate { .. } => self.is_zst()
         }
     }

--- a/src/test/run-pass/issue-46845.rs
+++ b/src/test/run-pass/issue-46845.rs
@@ -24,6 +24,7 @@ union Foo {
 }
 
 // If all the variants are uninhabited, however, the union should be uninhabited.
+// NOTE(#49298) the union being uninhabited shouldn't change its size.
 union Bar {
     _a: (Never, u64),
     _b: (u64, Never)
@@ -31,7 +32,8 @@ union Bar {
 
 fn main() {
     assert_eq!(mem::size_of::<Foo>(), 8);
-    assert_eq!(mem::size_of::<Bar>(), 0);
+    // See the note on `Bar`'s definition for why this isn't `0`.
+    assert_eq!(mem::size_of::<Bar>(), 8);
 
     let f = [Foo { a: 42 }, Foo { a: 10 }];
     println!("{}", unsafe { f[0].a });

--- a/src/test/run-pass/issue-49298.rs
+++ b/src/test/run-pass/issue-49298.rs
@@ -1,0 +1,34 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(test)]
+
+extern crate test;
+
+enum Void {}
+
+fn main() {
+    let mut x: (Void, usize);
+    let mut y = 42;
+    x.1 = 13;
+
+    // Make sure `y` stays on the stack.
+    test::black_box(&mut y);
+
+    // Check that the write to `x.1` did not overwrite `y`.
+    // Note that this doesn't fail with optimizations enabled,
+    // because we can't keep `x.1` on the stack, like we can `y`,
+    // as we can't borrow partially initialized variables.
+    assert_eq!(y.to_string(), "42");
+
+    // Check that `(Void, usize)` has space for the `usize` field.
+    assert_eq!(std::mem::size_of::<(Void, usize)>(),
+               std::mem::size_of::<usize>());
+}

--- a/src/test/run-pass/issue-50442.rs
+++ b/src/test/run-pass/issue-50442.rs
@@ -1,0 +1,21 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum Void {}
+
+enum Foo {
+    A(i32),
+    B(Void),
+    C(i32)
+}
+
+fn main() {
+    let _foo = Foo::A(0);
+}

--- a/src/test/run-pass/type-sizes.rs
+++ b/src/test/run-pass/type-sizes.rs
@@ -68,9 +68,15 @@ enum EnumSingle5 {
     A = 42 as u8,
 }
 
-enum NicheFilledEnumWithInhabitedVariant {
+enum EnumWithMaybeUninhabitedVariant<T> {
     A(&'static ()),
-    B(&'static (), !),
+    B(&'static (), T),
+    C,
+}
+
+enum NicheFilledEnumWithAbsentVariant {
+    A(&'static ()),
+    B((), !),
     C,
 }
 
@@ -107,5 +113,7 @@ pub fn main() {
     assert_eq!(size_of::<EnumSingle4>(), 1);
     assert_eq!(size_of::<EnumSingle5>(), 1);
 
-    assert_eq!(size_of::<NicheFilledEnumWithInhabitedVariant>(), size_of::<&'static ()>());
+    assert_eq!(size_of::<EnumWithMaybeUninhabitedVariant<!>>(),
+               size_of::<EnumWithMaybeUninhabitedVariant<()>>());
+    assert_eq!(size_of::<NicheFilledEnumWithAbsentVariant>(), size_of::<&'static ()>());
 }


### PR DESCRIPTION
Fixes #49298 by only collapsing uninhabited enum variants, and only if they only have ZST fields.
Fixes #50442 incidentally (@nox's optimization didn't take into account uninhabited variants).