### PR TITLE
Closures cannot be constants

### DIFF
--- a/src/librustc/hir/map/def_collector.rs
+++ b/src/librustc/hir/map/def_collector.rs
@@ -74,18 +74,19 @@ impl<'a> DefCollector<'a> {
         self.parent_def = parent;
     }
 
-    pub fn visit_const_expr(&mut self, expr: &Expr) {
+    pub fn visit_const_expr(&mut self, expr: &Expr) -> Option<DefIndex> {
         match expr.node {
             // Find the node which will be used after lowering.
-            ExprKind::Paren(ref inner) => return self.visit_const_expr(inner),
-            ExprKind::Mac(..) => return self.visit_macro_invoc(expr.id, true),
+            ExprKind::Paren(ref inner) => self.visit_const_expr(inner),
+            ExprKind::Mac(..) =>  {
+                self.visit_macro_invoc(expr.id, true);
+                None
+            }
             // FIXME(eddyb) Closures should have separate
             // function definition IDs and expression IDs.
-            ExprKind::Closure(..) => return,
-            _ => {}
+            ExprKind::Closure(..) => None,
+            _ => Some(self.create_def(expr.id, DefPathData::Initializer, REGULAR_SPACE, expr.span))
         }
-
-        self.create_def(expr.id, DefPathData::Initializer, REGULAR_SPACE, expr.span);
     }
 
     fn visit_macro_invoc(&mut self, id: NodeId, const_expr: bool) {
@@ -268,34 +269,41 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
     fn visit_expr(&mut self, expr: &'a Expr) {
         let parent_def = self.parent_def;
 
-        match expr.node {
+        self.parent_def = match expr.node {
             ExprKind::Mac(..) => return self.visit_macro_invoc(expr.id, false),
             ExprKind::Repeat(_, ref count) => self.visit_const_expr(count),
             ExprKind::Closure(..) => {
-                let def = self.create_def(expr.id,
-                                          DefPathData::ClosureExpr,
-                                          REGULAR_SPACE,
-                                          expr.span);
-                self.parent_def = Some(def);
+                Some(self.create_def(expr.id,
+                                     DefPathData::ClosureExpr,
+                                     REGULAR_SPACE,
+                                     expr.span))
             }
-            _ => {}
-        }
+            _ => None
+        }.or(self.parent_def);
 
         visit::walk_expr(self, expr);
         self.parent_def = parent_def;
     }
 
     fn visit_ty(&mut self, ty: &'a Ty) {
-        match ty.node {
+        let parent = match ty.node {
             TyKind::Mac(..) => return self.visit_macro_invoc(ty.id, false),
-            TyKind::Array(_, ref length) => self.visit_const_expr(length),
+            TyKind::Array(_, ref length) => {
+                self.visit_const_expr(length)
+            }
             TyKind::ImplTrait(..) => {
                 self.create_def(ty.id, DefPathData::ImplTrait, REGULAR_SPACE, ty.span);
+                None
             }
-            TyKind::Typeof(ref expr) => self.visit_const_expr(expr),
-            _ => {}
-        }
+            TyKind::Typeof(ref expr) => {
+                self.visit_const_expr(expr)
+            }
+            _ => None
+        };
+        let prev_parent = self.parent_def;
+        self.parent_def = parent.or(self.parent_def);
         visit::walk_ty(self, ty);
+        self.parent_def = prev_parent;
     }
 
     fn visit_stmt(&mut self, stmt: &'a Stmt) {

--- a/src/librustc_mir/interpret/const_eval.rs
+++ b/src/librustc_mir/interpret/const_eval.rs
@@ -444,9 +444,18 @@ pub fn const_eval_provider<'a, 'tcx>(
     }
 
     if let Some(id) = tcx.hir.as_local_node_id(def_id) {
-        let tables = tcx.typeck_tables_of(def_id);
         let span = tcx.def_span(def_id);
+        
+        // Closures in constant position can hit this in type collection.
+        if !tcx.has_typeck_tables(def_id) {
+            return Err(ConstEvalErr {
+                kind: Lrc::new(TypeckError),
+                span,
+            });
+        }
 
+        let tables = tcx.typeck_tables_of(def_id);
+    
         // Do match-check before building MIR
         if tcx.check_match(def_id).is_err() {
             return Err(ConstEvalErr {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1092,7 +1092,7 @@ fn type_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             }
 
             if !tcx.has_typeck_tables(def_id) {
-                span_err!(tcx.sess, span, E0912, "closures cannot be constants");
+                span_err!(tcx.sess, span, E0912, "expected numerical constant, found closure");
             }
 
             let substs = ty::ClosureSubsts {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1085,10 +1085,14 @@ fn type_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
         NodeField(field) => icx.to_ty(&field.ty),
 
-        NodeExpr(&hir::Expr { node: hir::ExprClosure(.., gen), .. }) => {
+        NodeExpr(&hir::Expr { node: hir::ExprClosure(.., gen), span, .. }) => {
             if gen.is_some() {
                 let hir_id = tcx.hir.node_to_hir_id(node_id);
                 return tcx.typeck_tables_of(def_id).node_id_to_type(hir_id);
+            }
+
+            if !tcx.has_typeck_tables(def_id) {
+                span_err!(tcx.sess, span, E0912, "closures cannot be constants");
             }
 
             let substs = ty::ClosureSubsts {

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -4770,5 +4770,5 @@ register_diagnostics! {
     E0641, // cannot cast to/from a pointer with an unknown kind
     E0645, // trait aliases not finished
     E0907, // type inside generator must be known in this context
-    E0912, // closures cannot be constants
+    E0912, // expected numerical constant, found closure
 }

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -4770,4 +4770,5 @@ register_diagnostics! {
     E0641, // cannot cast to/from a pointer with an unknown kind
     E0645, // trait aliases not finished
     E0907, // type inside generator must be known in this context
+    E0912, // closures cannot be constants
 }

--- a/src/test/run-pass/ctfe/closure-in-constant.rs
+++ b/src/test/run-pass/ctfe/closure-in-constant.rs
@@ -1,0 +1,21 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo ([u8; (|x: u8| { }, 9).1]);
+
+// FIXME(#50689) We'd like the below to also work,
+// but due to how DefCollector handles discr_expr differently it doesn't right now.
+/*
+enum Functions {
+    Square = (|x:i32| { }, 42).1,
+}
+*/
+
+fn main() {}

--- a/src/test/ui/const-eval/issue-50600.rs
+++ b/src/test/ui/const-eval/issue-50600.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Testing that these do not ICE.
+
+struct Foo ([u8; |x: u8| { }]);
+//~^ ERROR closures cannot be constants
+enum Functions {
+    Square = |x:i32| { },
+    //~^ ERROR closures cannot be constants
+}
+
+fn main() {}

--- a/src/test/ui/const-eval/issue-50600.rs
+++ b/src/test/ui/const-eval/issue-50600.rs
@@ -11,10 +11,10 @@
 // Testing that these do not ICE.
 
 struct Foo ([u8; |x: u8| { }]);
-//~^ ERROR closures cannot be constants
+//~^ ERROR expected numerical constant, found closure
 enum Functions {
     Square = |x:i32| { },
-    //~^ ERROR closures cannot be constants
+    //~^ ERROR expected numerical constant, found closure
 }
 
 fn main() {}

--- a/src/test/ui/const-eval/issue-50600.stderr
+++ b/src/test/ui/const-eval/issue-50600.stderr
@@ -1,10 +1,10 @@
-error[E0912]: closures cannot be constants
+error[E0912]: expected numerical constant, found closure
   --> $DIR/issue-50600.rs:13:18
    |
 LL | struct Foo ([u8; |x: u8| { }]);
    |                  ^^^^^^^^^^^
 
-error[E0912]: closures cannot be constants
+error[E0912]: expected numerical constant, found closure
   --> $DIR/issue-50600.rs:16:14
    |
 LL |     Square = |x:i32| { },

--- a/src/test/ui/const-eval/issue-50600.stderr
+++ b/src/test/ui/const-eval/issue-50600.stderr
@@ -1,0 +1,15 @@
+error[E0912]: closures cannot be constants
+  --> $DIR/issue-50600.rs:13:18
+   |
+LL | struct Foo ([u8; |x: u8| { }]);
+   |                  ^^^^^^^^^^^
+
+error[E0912]: closures cannot be constants
+  --> $DIR/issue-50600.rs:16:14
+   |
+LL |     Square = |x:i32| { },
+   |              ^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0912`.


### PR DESCRIPTION
During type collection, error if a closures is found in constant position, catching that before they go causing ICEs.

Fixes #50600.
Fixes #48838.