### PR TITLE
fs::write: Add example writing a &str

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -331,6 +331,7 @@ pub fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
 ///
 /// fn main() -> std::io::Result<()> {
 ///     fs::write("foo.txt", b"Lorem ipsum")?;
+///     fs::write("bar.txt", "dolor sit")?;
 ///     Ok(())
 /// }
 /// ```


### PR DESCRIPTION
This adds an example to the documentation for `fs::write` that demonstrates the use of the `AsRef<[u8]>` implementation for &str. Experienced users should already recognize the possibility from the type signature, but new users may not recognize the significance.