### PR TITLE
typeck: Fix ICE with struct update syntax

### DIFF
--- a/src/test/ui/issue-50618.rs
+++ b/src/test/ui/issue-50618.rs
@@ -1,0 +1,29 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Point {
+    pub x: u64,
+    pub y: u64,
+}
+
+const TEMPLATE: Point = Point {
+    x: 0,
+    y: 0
+};
+
+fn main() {
+    let _ = || {
+        Point {
+            nonexistent: 0,
+            //~^ ERROR struct `Point` has no field named `nonexistent`
+            ..TEMPLATE
+        }
+    };
+}

--- a/src/test/ui/issue-50618.stderr
+++ b/src/test/ui/issue-50618.stderr
@@ -1,0 +1,11 @@
+error[E0560]: struct `Point` has no field named `nonexistent`
+  --> $DIR/issue-50618.rs:24:13
+   |
+LL |             nonexistent: 0,
+   |             ^^^^^^^^^^^ `Point` does not have this field
+   |
+   = note: available fields are: `x`, `y`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0560`.


### PR DESCRIPTION
If check_expr_struct_fields fails, do not continue to record update.
If we continue to record update, the struct may cause us to ICE later
on indexing a field that may or may not exist.


Fixes: #50618