### PR TITLE
AppVeyor: Read back trace from crash dump on failure.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -211,6 +211,11 @@ test_script:
   - set NO_CCACHE=1
   - sh src/ci/run.sh
 
+on_failure:
+  # Dump crash log
+  - set PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\Debuggers\X64"
+  - if exist %LOCALAPPDATA%\CrashDumps for %%f in (%LOCALAPPDATA%\CrashDumps\*) do cdb -c "k;q" -G -z "%%f"
+
 branches:
   only:
     - auto


### PR DESCRIPTION
This is an attempt to debug spurious access violations on Windows (#33434, #50604). Thanks to #50276, there should be minidumps to read when rustc segfault.

(The implementation is based on <https://github.com/springmeyer/travis-coredump/blob/master/test.bat>.)
