### PR TITLE
Make the `const_err` lint `deny`-by-default

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -27,7 +27,7 @@ declare_lint! {
 
 declare_lint! {
     pub CONST_ERR,
-    Warn,
+    Deny,
     "constant evaluation detected erroneous expression"
 }
 

--- a/src/test/compile-fail/array_const_index-0.rs
+++ b/src/test/compile-fail/array_const_index-0.rs
@@ -10,9 +10,8 @@
 
 const A: &'static [i32] = &[];
 const B: i32 = (&A)[1];
-//~^ ERROR constant evaluation error
-//~| index out of bounds: the len is 0 but the index is 1
-//~| WARN this constant cannot be used
+//~^ index out of bounds: the len is 0 but the index is 1
+//~| ERROR this constant cannot be used
 
 fn main() {
     let _ = B;

--- a/src/test/compile-fail/array_const_index-1.rs
+++ b/src/test/compile-fail/array_const_index-1.rs
@@ -10,9 +10,8 @@
 
 const A: [i32; 0] = [];
 const B: i32 = A[1];
-//~^ ERROR constant evaluation error
-//~| index out of bounds: the len is 0 but the index is 1
-//~| WARN this constant cannot be used
+//~^ index out of bounds: the len is 0 but the index is 1
+//~| ERROR this constant cannot be used
 
 fn main() {
     let _ = B;

--- a/src/test/compile-fail/const-slice-oob.rs
+++ b/src/test/compile-fail/const-slice-oob.rs
@@ -12,9 +12,8 @@
 
 const FOO: &'static[u32] = &[1, 2, 3];
 const BAR: u32 = FOO[5];
-//~^ ERROR constant evaluation error [E0080]
-//~| index out of bounds: the len is 3 but the index is 5
-//~| WARN this constant cannot be used
+//~^ index out of bounds: the len is 3 but the index is 5
+//~| ERROR this constant cannot be used
 
 fn main() {
     let _ = BAR;

--- a/src/test/compile-fail/eval-enum.rs
+++ b/src/test/compile-fail/eval-enum.rs
@@ -12,11 +12,11 @@ enum Test {
     DivZero = 1/0,
     //~^ attempt to divide by zero
     //~| ERROR constant evaluation error
-    //~| WARN constant evaluation error
+    //~| ERROR constant evaluation error
     RemZero = 1%0,
     //~^ attempt to calculate the remainder with a divisor of zero
     //~| ERROR constant evaluation error
-    //~| WARN constant evaluation error
+    //~| ERROR constant evaluation error
 }
 
 fn main() {}

--- a/src/test/incremental/warnings-reemitted.rs
+++ b/src/test/incremental/warnings-reemitted.rs
@@ -13,6 +13,7 @@
 // compile-pass
 
 #![allow(warnings)]
+#![warn(const_err)]
 
 fn main() {
     255u8 + 1; //~ WARNING this expression will panic at run-time

--- a/src/test/run-fail/overflowing-add.rs
+++ b/src/test/run-fail/overflowing-add.rs
@@ -11,6 +11,8 @@
 // error-pattern:thread 'main' panicked at 'attempt to add with overflow'
 // compile-flags: -C debug-assertions
 
+#![allow(const_err)]
+
 fn main() {
     let _x = 200u8 + 200u8 + 200u8;
 }

--- a/src/test/run-fail/overflowing-mul.rs
+++ b/src/test/run-fail/overflowing-mul.rs
@@ -11,6 +11,8 @@
 // error-pattern:thread 'main' panicked at 'attempt to multiply with overflow'
 // compile-flags: -C debug-assertions
 
+#![allow(const_err)]
+
 fn main() {
     let x = 200u8 * 4;
 }

--- a/src/test/run-fail/overflowing-neg.rs
+++ b/src/test/run-fail/overflowing-neg.rs
@@ -11,6 +11,8 @@
 // error-pattern:thread 'main' panicked at 'attempt to negate with overflow'
 // compile-flags: -C debug-assertions
 
+#![allow(const_err)]
+
 fn main() {
     let _x = -std::i8::MIN;
 }

--- a/src/test/run-fail/overflowing-sub.rs
+++ b/src/test/run-fail/overflowing-sub.rs
@@ -11,6 +11,8 @@
 // error-pattern:thread 'main' panicked at 'attempt to subtract with overflow'
 // compile-flags: -C debug-assertions
 
+#![allow(const_err)]
+
 fn main() {
     let _x = 42u8 - (42u8 + 1);
 }

--- a/src/test/ui/const-eval-overflow-2.rs
+++ b/src/test/ui/const-eval-overflow-2.rs
@@ -11,7 +11,7 @@
 // Evaluation of constants in refutable patterns goes through
 // different compiler control-flow paths.
 
-#![allow(unused_imports, warnings)]
+#![allow(unused_imports, warnings, const_err)]
 
 use std::fmt;
 use std::{i8, i16, i32, i64, isize};

--- a/src/test/ui/const-eval-overflow-4.rs
+++ b/src/test/ui/const-eval-overflow-4.rs
@@ -22,7 +22,7 @@ use std::{u8, u16, u32, u64, usize};
 const A_I8_T
     : [u32; (i8::MAX as i8 + 1i8) as usize]
     //~^ ERROR E0080
-    //~| WARN attempt to add with overflow
+    //~| ERROR attempt to add with overflow
     = [0; (i8::MAX as usize) + 1];
 
 fn main() {

--- a/src/test/ui/const-eval-overflow-4.stderr
+++ b/src/test/ui/const-eval-overflow-4.stderr
@@ -1,10 +1,10 @@
-warning: attempt to add with overflow
+error: attempt to add with overflow
   --> $DIR/const-eval-overflow-4.rs:23:13
    |
 LL |     : [u32; (i8::MAX as i8 + 1i8) as usize]
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: #[warn(const_err)] on by default
+   = note: #[deny(const_err)] on by default
 
 error[E0080]: constant evaluation error
   --> $DIR/const-eval-overflow-4.rs:23:13
@@ -12,6 +12,6 @@ error[E0080]: constant evaluation error
 LL |     : [u32; (i8::MAX as i8 + 1i8) as usize]
    |             ^^^^^^^^^^^^^^^^^^^^^ attempt to add with overflow
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/const-eval/conditional_array_execution.rs
+++ b/src/test/ui/const-eval/conditional_array_execution.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // compile-pass
+#![warn(const_err)]
 
 const X: u32 = 5;
 const Y: u32 = 6;

--- a/src/test/ui/const-eval/conditional_array_execution.stderr
+++ b/src/test/ui/const-eval/conditional_array_execution.stderr
@@ -1,19 +1,23 @@
 warning: attempt to subtract with overflow
-  --> $DIR/conditional_array_execution.rs:15:19
+  --> $DIR/conditional_array_execution.rs:16:19
    |
 LL | const FOO: u32 = [X - Y, Y - X][(X < Y) as usize];
    |                   ^^^^^
    |
-   = note: #[warn(const_err)] on by default
+note: lint level defined here
+  --> $DIR/conditional_array_execution.rs:12:9
+   |
+LL | #![warn(const_err)]
+   |         ^^^^^^^^^
 
 warning: this constant cannot be used
-  --> $DIR/conditional_array_execution.rs:15:1
+  --> $DIR/conditional_array_execution.rs:16:1
    |
 LL | const FOO: u32 = [X - Y, Y - X][(X < Y) as usize];
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to subtract with overflow
 
 warning: constant evaluation error
-  --> $DIR/conditional_array_execution.rs:20:20
+  --> $DIR/conditional_array_execution.rs:21:20
    |
 LL |     println!("{}", FOO);
    |                    ^^^ referenced constant has errors

--- a/src/test/ui/const-eval/issue-43197.rs
+++ b/src/test/ui/const-eval/issue-43197.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // compile-pass
+#![warn(const_err)]
 
 #![feature(const_fn)]
 

--- a/src/test/ui/const-eval/issue-43197.stderr
+++ b/src/test/ui/const-eval/issue-43197.stderr
@@ -1,37 +1,41 @@
 warning: attempt to subtract with overflow
-  --> $DIR/issue-43197.rs:20:20
+  --> $DIR/issue-43197.rs:21:20
    |
 LL |     const X: u32 = 0-1;
    |                    ^^^
    |
-   = note: #[warn(const_err)] on by default
+note: lint level defined here
+  --> $DIR/issue-43197.rs:12:9
+   |
+LL | #![warn(const_err)]
+   |         ^^^^^^^^^
 
 warning: this constant cannot be used
-  --> $DIR/issue-43197.rs:20:5
+  --> $DIR/issue-43197.rs:21:5
    |
 LL |     const X: u32 = 0-1;
    |     ^^^^^^^^^^^^^^^^^^^ attempt to subtract with overflow
 
 warning: attempt to subtract with overflow
-  --> $DIR/issue-43197.rs:23:24
+  --> $DIR/issue-43197.rs:24:24
    |
 LL |     const Y: u32 = foo(0-1);
    |                        ^^^
 
 warning: this constant cannot be used
-  --> $DIR/issue-43197.rs:23:5
+  --> $DIR/issue-43197.rs:24:5
    |
 LL |     const Y: u32 = foo(0-1);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ attempt to subtract with overflow
 
 warning: constant evaluation error
-  --> $DIR/issue-43197.rs:26:23
+  --> $DIR/issue-43197.rs:27:23
    |
 LL |     println!("{} {}", X, Y);
    |                       ^ referenced constant has errors
 
 warning: constant evaluation error
-  --> $DIR/issue-43197.rs:26:26
+  --> $DIR/issue-43197.rs:27:26
    |
 LL |     println!("{} {}", X, Y);
    |                          ^ referenced constant has errors

--- a/src/test/ui/const-eval/issue-44578.rs
+++ b/src/test/ui/const-eval/issue-44578.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // compile-pass
+#![warn(const_err)]
 
 trait Foo {
     const AMT: usize;

--- a/src/test/ui/const-eval/issue-44578.stderr
+++ b/src/test/ui/const-eval/issue-44578.stderr
@@ -1,13 +1,17 @@
 warning: constant evaluation error
-  --> $DIR/issue-44578.rs:35:20
+  --> $DIR/issue-44578.rs:36:20
    |
 LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT); //~ WARN const_err
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
    |
-   = note: #[warn(const_err)] on by default
+note: lint level defined here
+  --> $DIR/issue-44578.rs:12:9
+   |
+LL | #![warn(const_err)]
+   |         ^^^^^^^^^
 
 warning: constant evaluation error
-  --> $DIR/issue-44578.rs:35:20
+  --> $DIR/issue-44578.rs:36:20
    |
 LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT); //~ WARN const_err
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors

--- a/src/test/ui/const-eval/promoted_errors.rs
+++ b/src/test/ui/const-eval/promoted_errors.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![warn(const_err)]
+
 // compile-pass
 // compile-flags: -O
 fn main() {

--- a/src/test/ui/const-eval/promoted_errors.stderr
+++ b/src/test/ui/const-eval/promoted_errors.stderr
@@ -1,49 +1,53 @@
 warning: constant evaluation error
-  --> $DIR/promoted_errors.rs:14:20
+  --> $DIR/promoted_errors.rs:16:20
    |
 LL |     println!("{}", 0u32 - 1);
    |                    ^^^^^^^^ attempt to subtract with overflow
    |
-   = note: #[warn(const_err)] on by default
+note: lint level defined here
+  --> $DIR/promoted_errors.rs:11:9
+   |
+LL | #![warn(const_err)]
+   |         ^^^^^^^^^
 
 warning: constant evaluation error
-  --> $DIR/promoted_errors.rs:14:20
+  --> $DIR/promoted_errors.rs:16:20
    |
 LL |     println!("{}", 0u32 - 1);
    |                    ^^^^^^^^ attempt to subtract with overflow
 
 warning: constant evaluation error
-  --> $DIR/promoted_errors.rs:17:14
+  --> $DIR/promoted_errors.rs:19:14
    |
 LL |     let _x = 0u32 - 1;
    |              ^^^^^^^^ attempt to subtract with overflow
 
 warning: attempt to divide by zero
-  --> $DIR/promoted_errors.rs:19:20
+  --> $DIR/promoted_errors.rs:21:20
    |
 LL |     println!("{}", 1/(1-1));
    |                    ^^^^^^^
 
 warning: constant evaluation error
-  --> $DIR/promoted_errors.rs:19:20
+  --> $DIR/promoted_errors.rs:21:20
    |
 LL |     println!("{}", 1/(1-1));
    |                    ^^^^^^^ attempt to divide by zero
 
 warning: attempt to divide by zero
-  --> $DIR/promoted_errors.rs:22:14
+  --> $DIR/promoted_errors.rs:24:14
    |
 LL |     let _x = 1/(1-1);
    |              ^^^^^^^
 
 warning: constant evaluation error
-  --> $DIR/promoted_errors.rs:22:14
+  --> $DIR/promoted_errors.rs:24:14
    |
 LL |     let _x = 1/(1-1);
    |              ^^^^^^^ attempt to divide by zero
 
 warning: constant evaluation error
-  --> $DIR/promoted_errors.rs:25:20
+  --> $DIR/promoted_errors.rs:27:20
    |
 LL |     println!("{}", 1/(false as u32));
    |                    ^^^^^^^^^^^^^^^^ attempt to divide by zero

--- a/src/test/ui/const-eval/pub_const_err.rs
+++ b/src/test/ui/const-eval/pub_const_err.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // compile-pass
+#![warn(const_err)]
 
 #![crate_type = "lib"]
 

--- a/src/test/ui/const-eval/pub_const_err.stderr
+++ b/src/test/ui/const-eval/pub_const_err.stderr
@@ -1,25 +1,29 @@
 warning: attempt to subtract with overflow
-  --> $DIR/pub_const_err.rs:15:20
+  --> $DIR/pub_const_err.rs:16:20
    |
 LL | pub const Z: u32 = 0 - 1;
    |                    ^^^^^
    |
-   = note: #[warn(const_err)] on by default
+note: lint level defined here
+  --> $DIR/pub_const_err.rs:12:9
+   |
+LL | #![warn(const_err)]
+   |         ^^^^^^^^^
 
 warning: this constant cannot be used
-  --> $DIR/pub_const_err.rs:15:1
+  --> $DIR/pub_const_err.rs:16:1
    |
 LL | pub const Z: u32 = 0 - 1;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to subtract with overflow
 
 warning: attempt to subtract with overflow
-  --> $DIR/pub_const_err.rs:19:22
+  --> $DIR/pub_const_err.rs:20:22
    |
 LL | pub type Foo = [i32; 0 - 1];
    |                      ^^^^^
 
 warning: this array length cannot be used
-  --> $DIR/pub_const_err.rs:19:22
+  --> $DIR/pub_const_err.rs:20:22
    |
 LL | pub type Foo = [i32; 0 - 1];
    |                      ^^^^^ attempt to subtract with overflow

--- a/src/test/ui/const-eval/pub_const_err_bin.rs
+++ b/src/test/ui/const-eval/pub_const_err_bin.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // compile-pass
+#![warn(const_err)]
 
 pub const Z: u32 = 0 - 1;
 //~^ WARN attempt to subtract with overflow

--- a/src/test/ui/const-eval/pub_const_err_bin.stderr
+++ b/src/test/ui/const-eval/pub_const_err_bin.stderr
@@ -1,25 +1,29 @@
 warning: attempt to subtract with overflow
-  --> $DIR/pub_const_err_bin.rs:13:20
+  --> $DIR/pub_const_err_bin.rs:14:20
    |
 LL | pub const Z: u32 = 0 - 1;
    |                    ^^^^^
    |
-   = note: #[warn(const_err)] on by default
+note: lint level defined here
+  --> $DIR/pub_const_err_bin.rs:12:9
+   |
+LL | #![warn(const_err)]
+   |         ^^^^^^^^^
 
 warning: this constant cannot be used
-  --> $DIR/pub_const_err_bin.rs:13:1
+  --> $DIR/pub_const_err_bin.rs:14:1
    |
 LL | pub const Z: u32 = 0 - 1;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to subtract with overflow
 
 warning: attempt to subtract with overflow
-  --> $DIR/pub_const_err_bin.rs:17:22
+  --> $DIR/pub_const_err_bin.rs:18:22
    |
 LL | pub type Foo = [i32; 0 - 1];
    |                      ^^^^^
 
 warning: this array length cannot be used
-  --> $DIR/pub_const_err_bin.rs:17:22
+  --> $DIR/pub_const_err_bin.rs:18:22
    |
 LL | pub type Foo = [i32; 0 - 1];
    |                      ^^^^^ attempt to subtract with overflow

--- a/src/test/ui/const-len-underflow-separate-spans.rs
+++ b/src/test/ui/const-len-underflow-separate-spans.rs
@@ -16,7 +16,7 @@ const ONE: usize = 1;
 const TWO: usize = 2;
 const LEN: usize = ONE - TWO;
 //~^ ERROR E0080
-//~| WARN attempt to subtract with overflow
+//~| ERROR attempt to subtract with overflow
 
 fn main() {
     let a: [i8; LEN] = unimplemented!();

--- a/src/test/ui/const-len-underflow-separate-spans.stderr
+++ b/src/test/ui/const-len-underflow-separate-spans.stderr
@@ -1,10 +1,10 @@
-warning: attempt to subtract with overflow
+error: attempt to subtract with overflow
   --> $DIR/const-len-underflow-separate-spans.rs:17:20
    |
 LL | const LEN: usize = ONE - TWO;
    |                    ^^^^^^^^^
    |
-   = note: #[warn(const_err)] on by default
+   = note: #[deny(const_err)] on by default
 
 error[E0080]: constant evaluation error
   --> $DIR/const-len-underflow-separate-spans.rs:17:20
@@ -18,6 +18,6 @@ error[E0080]: constant evaluation error
 LL |     let a: [i8; LEN] = unimplemented!();
    |                 ^^^ referenced constant has errors
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/error-codes/E0080.stderr
+++ b/src/test/ui/error-codes/E0080.stderr
@@ -12,15 +12,15 @@ error[E0080]: constant evaluation error
 LL |     X = (1 << 500), //~ ERROR E0080
    |         ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: attempt to divide by zero
+error: attempt to divide by zero
   --> $DIR/E0080.rs:14:9
    |
 LL |     Y = (1 / 0) //~ ERROR E0080
    |         ^^^^^^^
    |
-   = note: #[warn(const_err)] on by default
+   = note: #[deny(const_err)] on by default
 
-warning: constant evaluation error
+error: constant evaluation error
   --> $DIR/E0080.rs:14:9
    |
 LL |     Y = (1 / 0) //~ ERROR E0080
@@ -32,6 +32,6 @@ error[E0080]: constant evaluation error
 LL |     Y = (1 / 0) //~ ERROR E0080
    |         ^^^^^^^ attempt to divide by zero
 
-error: aborting due to 3 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
At best these things are runtime panics (debug mode) or overflows (release mode). More likely they are public constants that are unused in the crate declaring them.

This is not a breaking change, as dependencies won't break and root crates can `#![warn(const_err)]`, though I don't know why anyone would do that.