### PR TITLE
Ignore non .rs files for tidy libcoretest

### DIFF
--- a/src/tools/tidy/src/libcoretest.rs
+++ b/src/tools/tidy/src/libcoretest.rs
@@ -22,12 +22,15 @@ pub fn check(path: &Path, bad: &mut bool) {
         &libcore_path,
         &mut |subpath| t!(subpath.strip_prefix(&libcore_path)).starts_with("tests"),
         &mut |subpath| {
-            if t!(read_to_string(subpath)).contains("#[test]") {
-                tidy_error!(
-                    bad,
-                    "{} contains #[test]; libcore tests must be placed inside `src/libcore/tests/`",
-                    subpath.display()
-                );
+            if subpath.ends_with(".rs") {
+                if t!(read_to_string(subpath)).contains("#[test]") {
+                    tidy_error!(
+                        bad,
+                        "{} contains #[test]; libcore tests must be placed inside \
+                        `src/libcore/tests/`",
+                        subpath.display()
+                    );
+                }
             }
         },
     );

--- a/src/tools/tidy/src/libcoretest.rs
+++ b/src/tools/tidy/src/libcoretest.rs
@@ -22,14 +22,21 @@ pub fn check(path: &Path, bad: &mut bool) {
         &libcore_path,
         &mut |subpath| t!(subpath.strip_prefix(&libcore_path)).starts_with("tests"),
         &mut |subpath| {
-            if subpath.ends_with(".rs") {
-                if t!(read_to_string(subpath)).contains("#[test]") {
-                    tidy_error!(
-                        bad,
-                        "{} contains #[test]; libcore tests must be placed inside \
-                        `src/libcore/tests/`",
-                        subpath.display()
-                    );
+            if let Some("rs") = subpath.extension().and_then(|e| e.to_str()) {
+                match read_to_string(subpath) {
+                    Ok(contents) => {
+                        if contents.contains("#[test]") {
+                            tidy_error!(
+                                bad,
+                                "{} contains #[test]; libcore tests must be placed inside \
+                                `src/libcore/tests/`",
+                                subpath.display()
+                            );
+                        }
+                    }
+                    Err(err) => {
+                        panic!("failed to read file {:?}: {}", subpath, err);
+                    }
                 }
             }
         },


### PR DESCRIPTION
Previously, any file would be read, which is both unnecessary, and causes issues if irrelevant non-Unicode files were read (e.g. `.DS_STORE`).