### PR TITLE
rustc: Fix `crate` lint for single-item paths 

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -261,7 +261,7 @@ declare_lint! {
 }
 
 declare_lint! {
-    pub ABSOLUTE_PATH_STARTING_WITH_MODULE,
+    pub ABSOLUTE_PATH_NOT_STARTING_WITH_CRATE,
     Allow,
     "fully qualified paths that start with a module name \
      instead of `crate`, `self`, or an extern crate name"
@@ -328,7 +328,7 @@ impl LintPass for HardwiredLints {
             TYVAR_BEHIND_RAW_POINTER,
             ELIDED_LIFETIME_IN_PATH,
             BARE_TRAIT_OBJECT,
-            ABSOLUTE_PATH_STARTING_WITH_MODULE,
+            ABSOLUTE_PATH_NOT_STARTING_WITH_CRATE,
             UNSTABLE_NAME_COLLISION,
         )
     }

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -40,7 +40,7 @@ extern crate rustc_target;
 extern crate syntax_pos;
 
 use rustc::lint;
-use rustc::lint::builtin::{BARE_TRAIT_OBJECT, ABSOLUTE_PATH_STARTING_WITH_MODULE};
+use rustc::lint::builtin::{BARE_TRAIT_OBJECT, ABSOLUTE_PATH_NOT_STARTING_WITH_CRATE};
 use rustc::session;
 use rustc::util;
 
@@ -282,7 +282,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
             //       standard library, and thus should never be removed or changed to an error.
         },
         FutureIncompatibleInfo {
-            id: LintId::of(ABSOLUTE_PATH_STARTING_WITH_MODULE),
+            id: LintId::of(ABSOLUTE_PATH_NOT_STARTING_WITH_CRATE),
             reference: "issue TBD",
             edition: Some(Edition::Edition2018),
         },
@@ -321,4 +321,6 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
         "converted into hard error, see https://github.com/rust-lang/rust/issues/48950");
     store.register_removed("resolve_trait_on_defaulted_unit",
         "converted into hard error, see https://github.com/rust-lang/rust/issues/48950");
+    store.register_removed("absolute_path_starting_with_module",
+        "renamed to `absolute_path_not_starting_with_crate`");
 }

--- a/src/test/ui/auxiliary/edition-lint-paths.rs
+++ b/src/test/ui/auxiliary/edition-lint-paths.rs
@@ -1,0 +1,11 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn foo() {}

--- a/src/test/ui/edition-lint-paths.fixed
+++ b/src/test/ui/edition-lint-paths.fixed
@@ -19,18 +19,18 @@ extern crate edition_lint_paths;
 
 pub mod foo {
     use edition_lint_paths;
-    use ::bar::Bar;
+    use crate::bar::Bar;
     //~^ ERROR absolute
     //~| WARN this was previously accepted
     use super::bar::Bar2;
     use crate::bar::Bar3;
 
-    use bar;
+    use crate::bar;
     //~^ ERROR absolute
     //~| WARN this was previously accepted
     use crate::{bar as something_else};
 
-    use {Bar as SomethingElse, main};
+    use {crate::Bar as SomethingElse, crate::main};
     //~^ ERROR absolute
     //~| WARN this was previously accepted
     //~| ERROR absolute
@@ -42,7 +42,7 @@ pub mod foo {
     }
 }
 
-use bar::Bar;
+use crate::bar::Bar;
 //~^ ERROR absolute
 //~| WARN this was previously accepted
 
@@ -54,13 +54,13 @@ pub mod bar {
 }
 
 mod baz {
-    use *;
+    use crate::*;
     //~^ ERROR absolute
     //~| WARN this was previously accepted
 }
 
 fn main() {
-    let x = ::bar::Bar;
+    let x = crate::bar::Bar;
     //~^ ERROR absolute
     //~| WARN this was previously accepted
     let x = bar::Bar;

--- a/src/test/ui/edition-lint-paths.stderr
+++ b/src/test/ui/edition-lint-paths.stderr
@@ -1,19 +1,46 @@
-error: Absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:16:9
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-paths.rs:22:9
    |
 LL |     use ::bar::Bar;
    |         ^^^^^^^^^^ help: use `crate`: `crate::bar::Bar`
    |
 note: lint level defined here
-  --> $DIR/edition-lint-paths.rs:12:9
+  --> $DIR/edition-lint-paths.rs:15:9
    |
-LL | #![deny(absolute_path_starting_with_module)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(absolute_path_not_starting_with_crate)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue TBD
 
-error: Absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:24:5
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-paths.rs:28:9
+   |
+LL |     use bar;
+   |         ^^^ help: use `crate`: `crate::bar`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = note: for more information, see issue TBD
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-paths.rs:33:10
+   |
+LL |     use {Bar as SomethingElse, main};
+   |          ^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::Bar as SomethingElse`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = note: for more information, see issue TBD
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-paths.rs:33:32
+   |
+LL |     use {Bar as SomethingElse, main};
+   |                                ^^^^ help: use `crate`: `crate::main`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = note: for more information, see issue TBD
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-paths.rs:45:5
    |
 LL | use bar::Bar;
    |     ^^^^^^^^ help: use `crate`: `crate::bar::Bar`
@@ -21,8 +48,17 @@ LL | use bar::Bar;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue TBD
 
-error: Absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:35:13
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-paths.rs:57:9
+   |
+LL |     use *;
+   |         ^ help: use `crate`: `crate::*`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = note: for more information, see issue TBD
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-paths.rs:63:13
    |
 LL |     let x = ::bar::Bar;
    |             ^^^^^^^^^^ help: use `crate`: `crate::bar::Bar`
@@ -30,5 +66,5 @@ LL |     let x = ::bar::Bar;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue TBD
 
-error: aborting due to 3 previous errors
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
This commit fixes recommending the `crate` prefix when migrating to 2018 for
paths that look like `use foo;` or `use {bar, baz}`

Closes #50660