### PR TITLE
rustc: Only suggest deleting `extern crate` if it works

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1543,6 +1543,9 @@ impl LintPass for ExternCrate {
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ExternCrate {
     fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
+        if !cx.tcx.features().extern_absolute_paths {
+            return
+        }
         if let hir::ItemExternCrate(ref orig) =  it.node {
             if it.attrs.iter().any(|a| a.check_name("macro_use")) {
                 return

--- a/src/test/compile-fail/auxiliary/edition-extern-crate-allowed.rs
+++ b/src/test/compile-fail/auxiliary/edition-extern-crate-allowed.rs
@@ -1,0 +1,11 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// intentionally empty

--- a/src/test/compile-fail/edition-extern-crate-allowed.rs
+++ b/src/test/compile-fail/edition-extern-crate-allowed.rs
@@ -1,0 +1,19 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:edition-extern-crate-allowed.rs
+// compile-flags: --edition 2015
+// compile-pass
+
+#![deny(rust_2018_idioms)]
+
+extern crate edition_extern_crate_allowed;
+
+fn main() {}

--- a/src/test/ui-fulldeps/unnecessary-extern-crate.rs
+++ b/src/test/ui-fulldeps/unnecessary-extern-crate.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: --edition 2018
+
 #![deny(unnecessary_extern_crate)]
 #![feature(alloc, test, libc)]
 

--- a/src/test/ui-fulldeps/unnecessary-extern-crate.stderr
+++ b/src/test/ui-fulldeps/unnecessary-extern-crate.stderr
@@ -1,65 +1,65 @@
 error: `extern crate` is unnecessary in the new edition
-  --> $DIR/unnecessary-extern-crate.rs:14:1
+  --> $DIR/unnecessary-extern-crate.rs:16:1
    |
 LL | extern crate alloc;
    | ^^^^^^^^^^^^^^^^^^^ help: remove it
    |
 note: lint level defined here
-  --> $DIR/unnecessary-extern-crate.rs:11:9
+  --> $DIR/unnecessary-extern-crate.rs:13:9
    |
 LL | #![deny(unnecessary_extern_crate)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `extern crate` is unnecessary in the new edition
-  --> $DIR/unnecessary-extern-crate.rs:17:1
+  --> $DIR/unnecessary-extern-crate.rs:19:1
    |
 LL | extern crate alloc as x;
    | ^^^^^^^^^^^^^^^^^^^^^^^^ help: use `use`: `use alloc as x`
 
 error: `extern crate` is unnecessary in the new edition
-  --> $DIR/unnecessary-extern-crate.rs:23:1
+  --> $DIR/unnecessary-extern-crate.rs:25:1
    |
 LL | pub extern crate test as y;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `pub use`: `pub use test as y`
 
 error: `extern crate` is unnecessary in the new edition
-  --> $DIR/unnecessary-extern-crate.rs:26:1
+  --> $DIR/unnecessary-extern-crate.rs:28:1
    |
 LL | pub extern crate libc;
    | ^^^^^^^^^^^^^^^^^^^^^^ help: use `pub use`: `pub use libc`
 
 error: `extern crate` is unnecessary in the new edition
-  --> $DIR/unnecessary-extern-crate.rs:32:5
+  --> $DIR/unnecessary-extern-crate.rs:34:5
    |
 LL |     extern crate alloc;
    |     ^^^^^^^^^^^^^^^^^^^ help: use `use`: `use alloc`
 
 error: `extern crate` is unnecessary in the new edition
-  --> $DIR/unnecessary-extern-crate.rs:35:5
+  --> $DIR/unnecessary-extern-crate.rs:37:5
    |
 LL |     extern crate alloc as x;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: use `use`: `use alloc as x`
 
 error: `extern crate` is unnecessary in the new edition
-  --> $DIR/unnecessary-extern-crate.rs:38:5
+  --> $DIR/unnecessary-extern-crate.rs:40:5
    |
 LL |     pub extern crate test;
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: use `pub use`: `pub use test`
 
 error: `extern crate` is unnecessary in the new edition
-  --> $DIR/unnecessary-extern-crate.rs:41:5
+  --> $DIR/unnecessary-extern-crate.rs:43:5
    |
 LL |     pub extern crate test as y;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `pub use`: `pub use test as y`
 
 error: `extern crate` is unnecessary in the new edition
-  --> $DIR/unnecessary-extern-crate.rs:45:9
+  --> $DIR/unnecessary-extern-crate.rs:47:9
    |
 LL |         extern crate alloc;
    |         ^^^^^^^^^^^^^^^^^^^ help: use `use`: `use alloc`
 
 error: `extern crate` is unnecessary in the new edition
-  --> $DIR/unnecessary-extern-crate.rs:48:9
+  --> $DIR/unnecessary-extern-crate.rs:50:9
    |
 LL |         extern crate alloc as x;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ help: use `use`: `use alloc as x`


### PR DESCRIPTION
This commit updates one of the edition lints to only suggest deleting `extern
crate` if it actually works. Otherwise this can yield some confusing behavior
with rustfix specifically where if you accidentally deny the `rust_2018_idioms`
lint in the 2015 edition it's suggesting features that don't work!