### PR TITLE
rustc: Include semicolon when removing `extern crate`

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1560,10 +1560,10 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ExternCrate {
 
                 if let Some(orig) = orig {
                     err.span_suggestion(it.span, &help,
-                        format!("{}use {} as {}", pub_, orig, it.name));
+                        format!("{}use {} as {};", pub_, orig, it.name));
                 } else {
                     err.span_suggestion(it.span, &help,
-                        format!("{}use {}", pub_, it.name));
+                        format!("{}use {};", pub_, it.name));
                 }
             } else {
                 err.span_suggestion(it.span, "remove it", "".into());

--- a/src/test/ui-fulldeps/unnecessary-extern-crate.stderr
+++ b/src/test/ui-fulldeps/unnecessary-extern-crate.stderr
@@ -14,55 +14,55 @@ error: `extern crate` is unnecessary in the new edition
   --> $DIR/unnecessary-extern-crate.rs:17:1
    |
 LL | extern crate alloc as x;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ help: use `use`: `use alloc as x`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ help: use `use`: `use alloc as x;`
 
 error: `extern crate` is unnecessary in the new edition
   --> $DIR/unnecessary-extern-crate.rs:23:1
    |
 LL | pub extern crate test as y;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `pub use`: `pub use test as y`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `pub use`: `pub use test as y;`
 
 error: `extern crate` is unnecessary in the new edition
   --> $DIR/unnecessary-extern-crate.rs:26:1
    |
 LL | pub extern crate libc;
-   | ^^^^^^^^^^^^^^^^^^^^^^ help: use `pub use`: `pub use libc`
+   | ^^^^^^^^^^^^^^^^^^^^^^ help: use `pub use`: `pub use libc;`
 
 error: `extern crate` is unnecessary in the new edition
   --> $DIR/unnecessary-extern-crate.rs:32:5
    |
 LL |     extern crate alloc;
-   |     ^^^^^^^^^^^^^^^^^^^ help: use `use`: `use alloc`
+   |     ^^^^^^^^^^^^^^^^^^^ help: use `use`: `use alloc;`
 
 error: `extern crate` is unnecessary in the new edition
   --> $DIR/unnecessary-extern-crate.rs:35:5
    |
 LL |     extern crate alloc as x;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: use `use`: `use alloc as x`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: use `use`: `use alloc as x;`
 
 error: `extern crate` is unnecessary in the new edition
   --> $DIR/unnecessary-extern-crate.rs:38:5
    |
 LL |     pub extern crate test;
-   |     ^^^^^^^^^^^^^^^^^^^^^^ help: use `pub use`: `pub use test`
+   |     ^^^^^^^^^^^^^^^^^^^^^^ help: use `pub use`: `pub use test;`
 
 error: `extern crate` is unnecessary in the new edition
   --> $DIR/unnecessary-extern-crate.rs:41:5
    |
 LL |     pub extern crate test as y;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `pub use`: `pub use test as y`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `pub use`: `pub use test as y;`
 
 error: `extern crate` is unnecessary in the new edition
   --> $DIR/unnecessary-extern-crate.rs:45:9
    |
 LL |         extern crate alloc;
-   |         ^^^^^^^^^^^^^^^^^^^ help: use `use`: `use alloc`
+   |         ^^^^^^^^^^^^^^^^^^^ help: use `use`: `use alloc;`
 
 error: `extern crate` is unnecessary in the new edition
   --> $DIR/unnecessary-extern-crate.rs:48:9
    |
 LL |         extern crate alloc as x;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^ help: use `use`: `use alloc as x`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ help: use `use`: `use alloc as x;`
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/suggestions/auxiliary/removing-extern-crate.rs
+++ b/src/test/ui/suggestions/auxiliary/removing-extern-crate.rs
@@ -1,0 +1,11 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// intentionally blank

--- a/src/test/ui/suggestions/removing-extern-crate.fixed
+++ b/src/test/ui/suggestions/removing-extern-crate.fixed
@@ -1,0 +1,27 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --edition 2018
+// aux-build:removing-extern-crate.rs
+// run-rustfix
+// compile-pass
+
+#![warn(rust_2018_idioms)]
+#![allow(unused_imports)]
+
+use std as foo;
+
+
+mod another {
+    use std as foo;
+    use std;
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/removing-extern-crate.rs
+++ b/src/test/ui/suggestions/removing-extern-crate.rs
@@ -1,0 +1,27 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --edition 2018
+// aux-build:removing-extern-crate.rs
+// run-rustfix
+// compile-pass
+
+#![warn(rust_2018_idioms)]
+#![allow(unused_imports)]
+
+extern crate std as foo;
+extern crate core;
+
+mod another {
+    extern crate std as foo;
+    extern crate std;
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/removing-extern-crate.stderr
+++ b/src/test/ui/suggestions/removing-extern-crate.stderr
@@ -1,0 +1,31 @@
+warning: `extern crate` is unnecessary in the new edition
+  --> $DIR/removing-extern-crate.rs:19:1
+   |
+LL | extern crate std as foo;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ help: use `use`: `use std as foo;`
+   |
+note: lint level defined here
+  --> $DIR/removing-extern-crate.rs:16:9
+   |
+LL | #![warn(rust_2018_idioms)]
+   |         ^^^^^^^^^^^^^^^^
+   = note: #[warn(unnecessary_extern_crate)] implied by #[warn(rust_2018_idioms)]
+
+warning: `extern crate` is unnecessary in the new edition
+  --> $DIR/removing-extern-crate.rs:20:1
+   |
+LL | extern crate core;
+   | ^^^^^^^^^^^^^^^^^^ help: remove it
+
+warning: `extern crate` is unnecessary in the new edition
+  --> $DIR/removing-extern-crate.rs:23:5
+   |
+LL |     extern crate std as foo;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: use `use`: `use std as foo;`
+
+warning: `extern crate` is unnecessary in the new edition
+  --> $DIR/removing-extern-crate.rs:24:5
+   |
+LL |     extern crate std;
+   |     ^^^^^^^^^^^^^^^^^ help: use `use`: `use std;`
+


### PR DESCRIPTION
Currently the lint for removing `extern crate` suggests removing `extern crate`
most of the time, but the rest of the time it suggest replacing it with `use
crate_name`. Unfortunately though when spliced into the original code you're
replacing

    extern crate foo;

with

    use foo

which is syntactically invalid! This commit ensure that the trailing semicolon
is included in rustc's suggestion to ensure that the code continues to compile
afterwards.