### PR TITLE
Reduce span highlighted code in unused_variables lint 

### DIFF
--- a/src/librustc/hir/pat_util.rs
+++ b/src/librustc/hir/pat_util.rs
@@ -141,6 +141,15 @@ impl hir::Pat {
         }
     }
 
+    pub fn simple_span(&self) -> Option<Span> {
+        match self.node {
+            PatKind::Binding(hir::BindingAnnotation::Unannotated, _, ref path1, None) |
+            PatKind::Binding(hir::BindingAnnotation::Mutable, _, ref path1, None) =>
+                Some(path1.span),
+            _ => None,
+        }
+    }
+
     /// Return variants that are necessary to exist for the pattern to match.
     pub fn necessary_variants(&self) -> Vec<DefId> {
         let mut variants = vec![];

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -106,6 +106,7 @@ use self::LoopKind::*;
 use self::LiveNodeKind::*;
 use self::VarKind::*;
 
+use errors::Applicability;
 use hir::def::*;
 use ty::{self, TyCtxt};
 use lint;
@@ -1558,8 +1559,9 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                         err.span_suggestion(sp, "try ignoring the field",
                                             format!("{}: _", name));
                     } else {
-                        err.span_suggestion_short(sp, &suggest_underscore_msg,
-                                                  format!("_{}", name));
+                        err.span_suggestion_with_applicability(
+                            sp, &suggest_underscore_msg,
+                            format!("_{}", name), Applicability::MachineApplicable);
                     }
                     err.emit()
                 }

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -106,7 +106,6 @@ use self::LoopKind::*;
 use self::LiveNodeKind::*;
 use self::VarKind::*;
 
-use errors::Applicability;
 use hir::def::*;
 use ty::{self, TyCtxt};
 use lint;
@@ -1559,9 +1558,8 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                         err.span_suggestion(sp, "try ignoring the field",
                                             format!("{}: _", name));
                     } else {
-                        err.span_suggestion_with_applicability(
-                            sp, &suggest_underscore_msg,
-                            format!("_{}", name), Applicability::MachineApplicable);
+                        err.span_suggestion_short(sp, &suggest_underscore_msg,
+                                                  format!("_{}", name));
                     }
                     err.emit()
                 }

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // compile-pass
+// run-rustfix
 
 #![feature(box_syntax)]
 #![feature(box_patterns)]

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 // compile-pass
-// run-rustfix
 
 #![feature(box_syntax)]
 #![feature(box_patterns)]

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
@@ -35,6 +35,10 @@ fn main() {
         endless_and_singing: true
     };
 
+    let mut mut_unused_var = 1;
+
+    let (mut var, unused_var) = (1, 2);
+
     if let SoulHistory { corridors_of_light,
                          mut hours_are_suns,
                          endless_and_singing: true } = who_from_the_womb_remembered {

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
@@ -11,22 +11,40 @@ LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
    |         ^^^^^^
    = note: #[warn(unused_variables)] implied by #[warn(unused)]
 
+warning: unused variable: `mut_unused_var`
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:38:13
+   |
+LL |     let mut mut_unused_var = 1;
+   |             ^^^^^^^^^^^^^^ help: consider using `_mut_unused_var` instead
+
+warning: unused variable: `var`
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:40:14
+   |
+LL |     let (mut var, unused_var) = (1, 2);
+   |              ^^^ help: consider using `_var` instead
+
+warning: unused variable: `unused_var`
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:40:19
+   |
+LL |     let (mut var, unused_var) = (1, 2);
+   |                   ^^^^^^^^^^ help: consider using `_unused_var` instead
+
 warning: unused variable: `corridors_of_light`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:38:26
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:42:26
    |
 LL |     if let SoulHistory { corridors_of_light,
    |                          ^^^^^^^^^^^^^^^^^^ help: try ignoring the field: `corridors_of_light: _`
 
 warning: variable `hours_are_suns` is assigned to, but never used
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:39:26
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:43:30
    |
 LL |                          mut hours_are_suns,
-   |                          ^^^^^^^^^^^^^^^^^^
+   |                              ^^^^^^^^^^^^^^
    |
    = note: consider using `_hours_are_suns` instead
 
 warning: value assigned to `hours_are_suns` is never read
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:41:9
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:45:9
    |
 LL |         hours_are_suns = false;
    |         ^^^^^^^^^^^^^^
@@ -39,38 +57,61 @@ LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
    = note: #[warn(unused_assignments)] implied by #[warn(unused)]
 
 warning: unused variable: `case`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:50:23
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:54:23
    |
 LL |         Large::Suit { case } => {}
    |                       ^^^^ help: try ignoring the field: `case: _`
 
 warning: unused variable: `case`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:55:24
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:59:24
    |
 LL |         &Large::Suit { case } => {}
    |                        ^^^^ help: try ignoring the field: `case: _`
 
 warning: unused variable: `case`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:60:27
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:64:27
    |
 LL |         box Large::Suit { case } => {}
    |                           ^^^^ help: try ignoring the field: `case: _`
 
 warning: unused variable: `case`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:65:24
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:69:24
    |
 LL |         (Large::Suit { case },) => {}
    |                        ^^^^ help: try ignoring the field: `case: _`
 
 warning: unused variable: `case`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:70:24
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:74:24
    |
 LL |         [Large::Suit { case }] => {}
    |                        ^^^^ help: try ignoring the field: `case: _`
 
 warning: unused variable: `case`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:75:29
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:79:29
    |
 LL |         Tuple(Large::Suit { case }, ()) => {}
    |                             ^^^^ help: try ignoring the field: `case: _`
+
+warning: variable does not need to be mutable
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:38:9
+   |
+LL |     let mut mut_unused_var = 1;
+   |         ----^^^^^^^^^^^^^^
+   |         |
+   |         help: remove this `mut`
+   |
+note: lint level defined here
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:15:9
+   |
+LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
+   |         ^^^^^^
+   = note: #[warn(unused_mut)] implied by #[warn(unused)]
+
+warning: variable does not need to be mutable
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:40:10
+   |
+LL |     let (mut var, unused_var) = (1, 2);
+   |          ----^^^
+   |          |
+   |          help: remove this `mut`
 


### PR DESCRIPTION
Fixes #50472 
- [X] reduce var span
- [ ] mark applicable
 
Before:
```
mut unused_mut_var
^^^^^^^^^^^^^^^^^^
```
After:
```
mut unused_mut_var
    ^^^^^^^^^^^^^^
```