### PR TITLE
Ensure that statics are always ByRef

### DIFF
--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -401,8 +401,9 @@ for ::mir::interpret::ConstValue<'gcx> {
                 a.hash_stable(hcx, hasher);
                 b.hash_stable(hcx, hasher);
             }
-            ByRef(alloc) => {
+            ByRef(alloc, offset) => {
                 alloc.hash_stable(hcx, hasher);
+                offset.hash_stable(hcx, hasher);
             }
         }
     }

--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -17,7 +17,7 @@ use std::fmt;
 use mir;
 use hir::def_id::DefId;
 use ty::{self, TyCtxt};
-use ty::layout::{self, Align, HasDataLayout};
+use ty::layout::{self, Align, HasDataLayout, Size};
 use middle::region;
 use std::iter;
 use std::io;
@@ -109,42 +109,42 @@ impl<T: layout::HasDataLayout> PointerArithmetic for T {}
 #[derive(Copy, Clone, Debug, Eq, PartialEq, RustcEncodable, RustcDecodable, Hash)]
 pub struct MemoryPointer {
     pub alloc_id: AllocId,
-    pub offset: u64,
+    pub offset: Size,
 }
 
 impl<'tcx> MemoryPointer {
-    pub fn new(alloc_id: AllocId, offset: u64) -> Self {
+    pub fn new(alloc_id: AllocId, offset: Size) -> Self {
         MemoryPointer { alloc_id, offset }
     }
 
     pub(crate) fn wrapping_signed_offset<C: HasDataLayout>(self, i: i64, cx: C) -> Self {
         MemoryPointer::new(
             self.alloc_id,
-            cx.data_layout().wrapping_signed_offset(self.offset, i),
+            Size::from_bytes(cx.data_layout().wrapping_signed_offset(self.offset.bytes(), i)),
         )
     }
 
     pub fn overflowing_signed_offset<C: HasDataLayout>(self, i: i128, cx: C) -> (Self, bool) {
-        let (res, over) = cx.data_layout().overflowing_signed_offset(self.offset, i);
-        (MemoryPointer::new(self.alloc_id, res), over)
+        let (res, over) = cx.data_layout().overflowing_signed_offset(self.offset.bytes(), i);
+        (MemoryPointer::new(self.alloc_id, Size::from_bytes(res)), over)
     }
 
     pub(crate) fn signed_offset<C: HasDataLayout>(self, i: i64, cx: C) -> EvalResult<'tcx, Self> {
         Ok(MemoryPointer::new(
             self.alloc_id,
-            cx.data_layout().signed_offset(self.offset, i)?,
+            Size::from_bytes(cx.data_layout().signed_offset(self.offset.bytes(), i)?),
         ))
     }
 
-    pub fn overflowing_offset<C: HasDataLayout>(self, i: u64, cx: C) -> (Self, bool) {
-        let (res, over) = cx.data_layout().overflowing_offset(self.offset, i);
-        (MemoryPointer::new(self.alloc_id, res), over)
+    pub fn overflowing_offset<C: HasDataLayout>(self, i: Size, cx: C) -> (Self, bool) {
+        let (res, over) = cx.data_layout().overflowing_offset(self.offset.bytes(), i.bytes());
+        (MemoryPointer::new(self.alloc_id, Size::from_bytes(res)), over)
     }
 
-    pub fn offset<C: HasDataLayout>(self, i: u64, cx: C) -> EvalResult<'tcx, Self> {
+    pub fn offset<C: HasDataLayout>(self, i: Size, cx: C) -> EvalResult<'tcx, Self> {
         Ok(MemoryPointer::new(
             self.alloc_id,
-            cx.data_layout().offset(self.offset, i)?,
+            Size::from_bytes(cx.data_layout().offset(self.offset.bytes(), i.bytes())?),
         ))
     }
 }
@@ -244,7 +244,7 @@ pub struct Allocation {
     pub bytes: Vec<u8>,
     /// Maps from byte addresses to allocations.
     /// Only the first byte of a pointer is inserted into the map.
-    pub relocations: BTreeMap<u64, AllocId>,
+    pub relocations: BTreeMap<Size, AllocId>,
     /// Denotes undefined memory. Reading from undefined memory is forbidden in miri
     pub undef_mask: UndefMask,
     /// The alignment of the allocation to detect unaligned reads.
@@ -257,8 +257,8 @@ pub struct Allocation {
 
 impl Allocation {
     pub fn from_bytes(slice: &[u8], align: Align) -> Self {
-        let mut undef_mask = UndefMask::new(0);
-        undef_mask.grow(slice.len() as u64, true);
+        let mut undef_mask = UndefMask::new(Size::from_bytes(0));
+        undef_mask.grow(Size::from_bytes(slice.len() as u64), true);
         Self {
             bytes: slice.to_owned(),
             relocations: BTreeMap::new(),
@@ -272,10 +272,10 @@ impl Allocation {
         Allocation::from_bytes(slice, Align::from_bytes(1, 1).unwrap())
     }
 
-    pub fn undef(size: u64, align: Align) -> Self {
-        assert_eq!(size as usize as u64, size);
+    pub fn undef(size: Size, align: Align) -> Self {
+        assert_eq!(size.bytes() as usize as u64, size.bytes());
         Allocation {
-            bytes: vec![0; size as usize],
+            bytes: vec![0; size.bytes() as usize],
             relocations: BTreeMap::new(),
             undef_mask: UndefMask::new(size),
             align,
@@ -331,35 +331,35 @@ const BLOCK_SIZE: u64 = 64;
 #[derive(Clone, Debug, Eq, PartialEq, Hash, RustcEncodable, RustcDecodable)]
 pub struct UndefMask {
     blocks: Vec<Block>,
-    len: u64,
+    len: Size,
 }
 
 impl_stable_hash_for!(struct mir::interpret::UndefMask{blocks, len});
 
 impl UndefMask {
-    pub fn new(size: u64) -> Self {
+    pub fn new(size: Size) -> Self {
         let mut m = UndefMask {
             blocks: vec![],
-            len: 0,
+            len: Size::from_bytes(0),
         };
         m.grow(size, false);
         m
     }
 
     /// Check whether the range `start..end` (end-exclusive) is entirely defined.
-    pub fn is_range_defined(&self, start: u64, end: u64) -> bool {
+    pub fn is_range_defined(&self, start: Size, end: Size) -> bool {
         if end > self.len {
             return false;
         }
-        for i in start..end {
-            if !self.get(i) {
+        for i in start.bytes()..end.bytes() {
+            if !self.get(Size::from_bytes(i)) {
                 return false;
             }
         }
         true
     }
 
-    pub fn set_range(&mut self, start: u64, end: u64, new_state: bool) {
+    pub fn set_range(&mut self, start: Size, end: Size, new_state: bool) {
         let len = self.len;
         if end > len {
             self.grow(end - len, new_state);
@@ -367,18 +367,18 @@ impl UndefMask {
         self.set_range_inbounds(start, end, new_state);
     }
 
-    pub fn set_range_inbounds(&mut self, start: u64, end: u64, new_state: bool) {
-        for i in start..end {
-            self.set(i, new_state);
+    pub fn set_range_inbounds(&mut self, start: Size, end: Size, new_state: bool) {
+        for i in start.bytes()..end.bytes() {
+            self.set(Size::from_bytes(i), new_state);
         }
     }
 
-    pub fn get(&self, i: u64) -> bool {
+    pub fn get(&self, i: Size) -> bool {
         let (block, bit) = bit_index(i);
         (self.blocks[block] & 1 << bit) != 0
     }
 
-    pub fn set(&mut self, i: u64, new_state: bool) {
+    pub fn set(&mut self, i: Size, new_state: bool) {
         let (block, bit) = bit_index(i);
         if new_state {
             self.blocks[block] |= 1 << bit;
@@ -387,10 +387,10 @@ impl UndefMask {
         }
     }
 
-    pub fn grow(&mut self, amount: u64, new_state: bool) {
-        let unused_trailing_bits = self.blocks.len() as u64 * BLOCK_SIZE - self.len;
-        if amount > unused_trailing_bits {
-            let additional_blocks = amount / BLOCK_SIZE + 1;
+    pub fn grow(&mut self, amount: Size, new_state: bool) {
+        let unused_trailing_bits = self.blocks.len() as u64 * BLOCK_SIZE - self.len.bytes();
+        if amount.bytes() > unused_trailing_bits {
+            let additional_blocks = amount.bytes() / BLOCK_SIZE + 1;
             assert_eq!(additional_blocks as usize as u64, additional_blocks);
             self.blocks.extend(
                 iter::repeat(0).take(additional_blocks as usize),
@@ -402,7 +402,8 @@ impl UndefMask {
     }
 }
 
-fn bit_index(bits: u64) -> (usize, usize) {
+fn bit_index(bits: Size) -> (usize, usize) {
+    let bits = bits.bytes();
     let a = bits / BLOCK_SIZE;
     let b = bits % BLOCK_SIZE;
     assert_eq!(a as usize as u64, a);

--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -9,12 +9,12 @@ use super::{EvalResult, MemoryPointer, PointerArithmetic, Allocation};
 /// matches Value's optimizations for easy conversions between these two types
 #[derive(Clone, Copy, Debug, Eq, PartialEq, RustcEncodable, RustcDecodable, Hash)]
 pub enum ConstValue<'tcx> {
-    // Used only for types with layout::abi::Scalar ABI and ZSTs which use PrimVal::Undef
+    /// Used only for types with layout::abi::Scalar ABI and ZSTs which use PrimVal::Undef
     ByVal(PrimVal),
-    // Used only for types with layout::abi::ScalarPair
+    /// Used only for types with layout::abi::ScalarPair
     ByValPair(PrimVal, PrimVal),
-    // Used only for the remaining cases
-    ByRef(&'tcx Allocation),
+    /// Used only for the remaining cases. An allocation + offset into the allocation
+    ByRef(&'tcx Allocation, u64),
 }
 
 impl<'tcx> ConstValue<'tcx> {

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1913,7 +1913,7 @@ pub fn print_miri_value<W: Write>(value: Value, ty: Ty, f: &mut W) -> fmt::Resul
                     .get_alloc(ptr.alloc_id);
                 if let Some(alloc) = alloc {
                     assert_eq!(len as usize as u128, len);
-                    let slice = &alloc.bytes[(ptr.offset as usize)..][..(len as usize)];
+                    let slice = &alloc.bytes[(ptr.offset.bytes() as usize)..][..(len as usize)];
                     let s = ::std::str::from_utf8(slice)
                         .expect("non utf8 str from miri");
                     write!(f, "{:?}", s)

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -19,7 +19,7 @@ use ty::subst::{Substs, Subst, Kind, UnpackedKind};
 use ty::{self, AdtDef, TypeFlags, Ty, TyCtxt, TypeFoldable};
 use ty::{Slice, TyS};
 use util::captures::Captures;
-use mir::interpret::{Allocation, PrimVal, MemoryPointer, Value, ConstValue};
+use mir::interpret::{PrimVal, MemoryPointer, Value, ConstValue};
 
 use std::iter;
 use std::cmp::Ordering;
@@ -1765,15 +1765,6 @@ impl<'tcx> Const<'tcx> {
         ty: Ty<'tcx>,
     ) -> &'tcx Self {
         Self::from_const_val(tcx, ConstVal::Value(val), ty)
-    }
-
-    #[inline]
-    pub fn from_alloc(
-        tcx: TyCtxt<'_, '_, 'tcx>,
-        alloc: &'tcx Allocation,
-        ty: Ty<'tcx>,
-    ) -> &'tcx Self {
-        Self::from_const_value(tcx, ConstValue::ByRef(alloc), ty)
     }
 
     #[inline]

--- a/src/librustc_codegen_llvm/mir/constant.rs
+++ b/src/librustc_codegen_llvm/mir/constant.rs
@@ -129,7 +129,7 @@ pub fn codegen_static_initializer<'a, 'tcx>(
     let static_ = cx.tcx.const_eval(param_env.and(cid))?;
 
     let alloc = match static_.val {
-        ConstVal::Value(ConstValue::ByRef(alloc)) => alloc,
+        ConstVal::Value(ConstValue::ByRef(alloc, 0)) => alloc,
         _ => bug!("static const eval returned {:#?}", static_),
     };
     Ok(const_alloc_to_llvm(cx, alloc))

--- a/src/librustc_codegen_llvm/mir/operand.rs
+++ b/src/librustc_codegen_llvm/mir/operand.rs
@@ -143,7 +143,7 @@ impl<'a, 'tcx> OperandRef<'tcx> {
 
                 let llval = unsafe { LLVMConstInBoundsGEP(
                     consts::bitcast(base_addr, Type::i8p(bx.cx)),
-                    &C_usize(bx.cx, offset),
+                    &C_usize(bx.cx, offset.bytes()),
                     1,
                 )};
                 let llval = consts::bitcast(llval, layout.llvm_type(bx.cx).ptr_to());

--- a/src/librustc_codegen_llvm/mir/operand.rs
+++ b/src/librustc_codegen_llvm/mir/operand.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use llvm::ValueRef;
+use llvm::{ValueRef, LLVMConstInBoundsGEP};
 use rustc::middle::const_val::ConstEvalErr;
 use rustc::mir;
 use rustc::mir::interpret::ConstValue;
@@ -137,9 +137,15 @@ impl<'a, 'tcx> OperandRef<'tcx> {
                 );
                 OperandValue::Pair(a_llval, b_llval)
             },
-            ConstValue::ByRef(alloc) => {
+            ConstValue::ByRef(alloc, offset) => {
                 let init = const_alloc_to_llvm(bx.cx, alloc);
-                let llval = consts::addr_of(bx.cx, init, layout.align, "byte_str");
+                let base_addr = consts::addr_of(bx.cx, init, layout.align, "byte_str");
+
+                let llval = unsafe { LLVMConstInBoundsGEP(
+                    consts::bitcast(base_addr, Type::i8p(bx.cx)),
+                    &C_usize(bx.cx, offset),
+                    1,
+                )};
                 let llval = consts::bitcast(llval, layout.llvm_type(bx.cx).ptr_to());
                 return Ok(PlaceRef::new_sized(llval, layout, alloc.align).load(bx));
             },

--- a/src/librustc_mir/hair/cx/mod.rs
+++ b/src/librustc_mir/hair/cx/mod.rs
@@ -21,7 +21,7 @@ use rustc::hir::def_id::{DefId, LOCAL_CRATE};
 use rustc::hir::map::blocks::FnLikeNode;
 use rustc::middle::region;
 use rustc::infer::InferCtxt;
-use rustc::ty::layout::IntegerExt;
+use rustc::ty::layout::{IntegerExt, Size};
 use rustc::ty::subst::Subst;
 use rustc::ty::{self, Ty, TyCtxt, layout};
 use rustc::ty::subst::Substs;
@@ -182,7 +182,7 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
             LitKind::Str(ref s, _) => {
                 let s = s.as_str();
                 let id = self.tcx.allocate_cached(s.as_bytes());
-                let ptr = MemoryPointer::new(id, 0);
+                let ptr = MemoryPointer::new(id, Size::from_bytes(0));
                 ConstValue::ByValPair(
                     PrimVal::Ptr(ptr),
                     PrimVal::from_u128(s.len() as u128),
@@ -190,7 +190,7 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
             },
             LitKind::ByteStr(ref data) => {
                 let id = self.tcx.allocate_cached(data);
-                let ptr = MemoryPointer::new(id, 0);
+                let ptr = MemoryPointer::new(id, Size::from_bytes(0));
                 ConstValue::ByVal(PrimVal::Ptr(ptr))
             },
             LitKind::Byte(n) => ConstValue::ByVal(PrimVal::Bytes(n as u128)),

--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -191,7 +191,7 @@ impl<'a, 'tcx> MatchCheckCtxt<'a, 'tcx> {
                             .interpret_interner
                             .get_alloc(ptr.alloc_id)
                             .unwrap();
-                        assert_eq!(ptr.offset, 0);
+                        assert_eq!(ptr.offset.bytes(), 0);
                         // FIXME: check length
                         alloc.bytes.iter().map(|b| {
                             &*pattern_arena.alloc(Pattern {

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -22,6 +22,7 @@ use rustc::middle::const_val::ConstVal;
 use rustc::mir::{fmt_const_val, Field, BorrowKind, Mutability};
 use rustc::mir::interpret::{PrimVal, GlobalId, ConstValue};
 use rustc::ty::{self, TyCtxt, AdtDef, Ty, Region};
+use rustc::ty::layout::Size;
 use rustc::ty::subst::{Substs, Kind};
 use rustc::hir::{self, PatKind, RangeEnd};
 use rustc::hir::def::{Def, CtorKind};
@@ -1083,7 +1084,7 @@ fn lit_to_const<'a, 'tcx>(lit: &'tcx ast::LitKind,
         LitKind::Str(ref s, _) => {
             let s = s.as_str();
             let id = tcx.allocate_cached(s.as_bytes());
-            let ptr = MemoryPointer::new(id, 0);
+            let ptr = MemoryPointer::new(id, Size::from_bytes(0));
             ConstValue::ByValPair(
                 PrimVal::Ptr(ptr),
                 PrimVal::from_u128(s.len() as u128),
@@ -1091,7 +1092,7 @@ fn lit_to_const<'a, 'tcx>(lit: &'tcx ast::LitKind,
         },
         LitKind::ByteStr(ref data) => {
             let id = tcx.allocate_cached(data);
-            let ptr = MemoryPointer::new(id, 0);
+            let ptr = MemoryPointer::new(id, Size::from_bytes(0));
             ConstValue::ByVal(PrimVal::Ptr(ptr))
         },
         LitKind::Byte(n) => ConstValue::ByVal(PrimVal::Bytes(n as u128)),

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -73,7 +73,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> {
         match dest_ty.sty {
             // float -> uint
             TyUint(t) => {
-                let width = t.bit_width().unwrap_or(self.memory.pointer_size() as usize * 8);
+                let width = t.bit_width().unwrap_or(self.memory.pointer_size().bytes() as usize * 8);
                 match fty {
                     FloatTy::F32 => Ok(PrimVal::Bytes(Single::from_bits(bits).to_u128(width).value)),
                     FloatTy::F64 => Ok(PrimVal::Bytes(Double::from_bits(bits).to_u128(width).value)),
@@ -81,7 +81,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> {
             },
             // float -> int
             TyInt(t) => {
-                let width = t.bit_width().unwrap_or(self.memory.pointer_size() as usize * 8);
+                let width = t.bit_width().unwrap_or(self.memory.pointer_size().bytes() as usize * 8);
                 match fty {
                     FloatTy::F32 => Ok(PrimVal::from_i128(Single::from_bits(bits).to_i128(width).value)),
                     FloatTy::F64 => Ok(PrimVal::from_i128(Double::from_bits(bits).to_i128(width).value)),

--- a/src/librustc_mir/interpret/const_eval.rs
+++ b/src/librustc_mir/interpret/const_eval.rs
@@ -98,6 +98,13 @@ pub fn value_to_const_value<'tcx>(
     mut val: Value,
     ty: Ty<'tcx>,
 ) -> &'tcx ty::Const<'tcx> {
+    let layout = tcx.layout_of(ty::ParamEnv::reveal_all().and(ty)).unwrap();
+    match (val, &layout.abi) {
+        (Value::ByRef(..), _) |
+        (Value::ByVal(_), &layout::Abi::Scalar(_)) |
+        (Value::ByValPair(..), &layout::Abi::ScalarPair(..)) => {},
+        _ => bug!("bad value/layout combo: {:#?}, {:#?}", val, layout),
+    }
     let val = (|| {
         // Convert to ByVal or ByValPair if possible
         if let Value::ByRef(ptr, align) = val {

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -1416,10 +1416,6 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M
         let layout = self.layout_of(ty)?;
         self.memory.check_align(ptr, ptr_align)?;
 
-        if layout.size.bytes() == 0 {
-            return Ok(Some(Value::ByVal(PrimVal::Undef)));
-        }
-
         let ptr = ptr.to_ptr()?;
 
         // Not the right place to do this

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -243,10 +243,10 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M
         _ty: Ty<'tcx>,
     ) -> EvalResult<'tcx, Value> {
         match val {
-            ConstValue::ByRef(alloc) => {
+            ConstValue::ByRef(alloc, offset) => {
                 // FIXME: Allocate new AllocId for all constants inside
                 let id = self.memory.allocate_value(alloc.clone(), Some(MemoryKind::Stack))?;
-                Ok(Value::ByRef(MemoryPointer::new(id, 0).into(), alloc.align))
+                Ok(Value::ByRef(MemoryPointer::new(id, offset).into(), alloc.align))
             },
             ConstValue::ByValPair(a, b) => Ok(Value::ByValPair(a, b)),
             ConstValue::ByVal(val) => Ok(Value::ByVal(val)),

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -7,6 +7,7 @@ use super::{EvalContext, Place, ValTy, Memory};
 
 use rustc::mir;
 use rustc::ty::{self, Ty};
+use rustc::ty::layout::Size;
 use syntax::codemap::Span;
 use syntax::ast::Mutability;
 
@@ -92,7 +93,7 @@ pub trait Machine<'mir, 'tcx>: Sized {
     fn check_locks<'a>(
         _mem: &Memory<'a, 'mir, 'tcx, Self>,
         _ptr: MemoryPointer,
-        _size: u64,
+        _size: Size,
         _access: AccessKind,
     ) -> EvalResult<'tcx> {
         Ok(())

--- a/src/librustc_mir/interpret/terminator/mod.rs
+++ b/src/librustc_mir/interpret/terminator/mod.rs
@@ -341,7 +341,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> {
                                     Value::ByRef(ptr, align) => {
                                         for (i, arg_local) in arg_locals.enumerate() {
                                             let field = layout.field(&self, i)?;
-                                            let offset = layout.fields.offset(i).bytes();
+                                            let offset = layout.fields.offset(i);
                                             let arg = Value::ByRef(ptr.offset(offset, &self)?,
                                                                    align.min(field.align));
                                             let dest =

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -1249,7 +1249,7 @@ fn collect_const<'a, 'tcx>(
         ConstVal::Value(ConstValue::ByValPair(PrimVal::Ptr(ptr), _)) |
         ConstVal::Value(ConstValue::ByVal(PrimVal::Ptr(ptr))) =>
             collect_miri(tcx, ptr.alloc_id, output),
-        ConstVal::Value(ConstValue::ByRef(alloc)) => {
+        ConstVal::Value(ConstValue::ByRef(alloc, _offset)) => {
             for &id in alloc.relocations.values() {
                 collect_miri(tcx, id, output);
             }

--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -221,7 +221,7 @@ pub enum Endian {
 }
 
 /// Size of a type in bytes.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, RustcEncodable, RustcDecodable)]
 pub struct Size {
     raw: u64
 }

--- a/src/test/codegen/link_section.rs
+++ b/src/test/codegen/link_section.rs
@@ -12,10 +12,16 @@
 
 #![crate_type = "lib"]
 
-// CHECK: @VAR1 = constant i32 1, section ".test_one"
+// CHECK: @VAR1 = constant <{ [4 x i8] }> <{ [4 x i8] c"\01\00\00\00" }>, section ".test_one"
 #[no_mangle]
 #[link_section = ".test_one"]
+#[cfg(target_endian = "little")]
 pub static VAR1: u32 = 1;
+
+#[no_mangle]
+#[link_section = ".test_one"]
+#[cfg(target_endian = "big")]
+pub static VAR1: u32 = 0x01000000;
 
 pub enum E {
     A(u32),

--- a/src/test/ui/const-eval/issue-50706.rs
+++ b/src/test/ui/const-eval/issue-50706.rs
@@ -1,0 +1,47 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-pass
+
+pub struct Stats;
+
+#[derive(PartialEq, Eq)]
+pub struct StatVariant {
+    pub id: u8,
+    _priv: (),
+}
+
+#[derive(PartialEq, Eq)]
+pub struct Stat {
+    pub variant: StatVariant,
+    pub index: usize,
+    _priv: (),
+}
+
+impl Stats {
+    pub const TEST: StatVariant = StatVariant{id: 0, _priv: (),};
+    #[allow(non_upper_case_globals)]
+    pub const A: Stat = Stat{
+         variant: Self::TEST,
+         index: 0,
+         _priv: (),};
+}
+
+impl Stat {
+    pub fn from_index(variant: StatVariant, index: usize) -> Option<Stat> {
+        let stat = Stat{variant, index, _priv: (),};
+        match stat {
+            Stats::A => Some(Stats::A),
+            _ => None,
+        }
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Statics aren't values to be used, they are names for memory locations.

r? @eddyb

cc @Zoxc 

fixes #50706