### PR TITLE
Update Cargo

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -190,13 +190,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "bufstream 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crates-io 0.16.0",
+ "crates-io 0.17.0",
  "crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-hash 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "crates-io"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "curl 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1621,7 +1621,7 @@ dependencies = [
 name = "rls"
 version = "0.128.0"
 dependencies = [
- "cargo 0.28.0",
+ "cargo 0.29.0",
  "cargo_metadata 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy_lints 0.0.200",
  "env_logger 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Unblocking PRs:
- rust-lang/cargo#5535 - Ignore tab in libtest output. (unblocks #50387)
- rust-lang/cargo#5537 - Remove -Zno-trans test. (unblocks #50615)
- rust-lang/cargo#5540 - Fix tests when CARGO_TARGET_DIR is set. (unblocks self)

Regression fixes:
- rust-lang/cargo#5503 - cargo rustc broken for tests in project with bins
- rust-lang/cargo#5520 - shared proc-macro dependency built incorrectly

Changes:
- rust-lang/cargo#5527 - Point Source Replacement to the Overriding Dependencies section
- rust-lang/cargo#5533 - Detail how to run locally-built nightly cargo
- rust-lang/cargo#5522 - Add option to set user-agent
- rust-lang/cargo#5519 - NFC: fix a couple of typos, found by codespell.
- rust-lang/cargo#5513 - Fix `panic` for binaries built during tests.
- rust-lang/cargo#5512 - simplify build_requirements
- rust-lang/cargo#5301 - Add --build-plan for 'cargo build'
- rust-lang/cargo#5460 - Be more conservative about which files are linked to the output dir.
- rust-lang/cargo#5509 - Use the new stable
- rust-lang/cargo#5507 - Does not print seconds fraction with minutes
- rust-lang/cargo#5498 - Bump to 0.29.0
- rust-lang/cargo#5497 - Mention +nightly in ARCHITECTURE.md

The PR fixes #50640.