### PR TITLE
Use EverInit instead of MaybeInit to determine initialization

### DIFF
--- a/src/test/run-pass/nll/issue-50461-used-mut-from-moves.rs
+++ b/src/test/run-pass/nll/issue-50461-used-mut-from-moves.rs
@@ -1,0 +1,25 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(nll)]
+#![deny(unused_mut)]
+
+struct Foo {
+    pub value: i32
+}
+
+fn use_foo_mut(mut foo: Foo) {
+    foo = foo;
+    println!("{}", foo.value);
+}
+
+fn main() {
+    use_foo_mut(Foo { value: 413 });
+}


### PR DESCRIPTION
Fixes #50461.
Fixes #50463.