### PR TITLE
Fix conversion from Miri Value to ConstValue

### DIFF
--- a/src/test/run-pass/match-larger-const.rs
+++ b/src/test/run-pass/match-larger-const.rs
@@ -1,0 +1,21 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[derive(Eq, PartialEq)]
+pub struct Data([u8; 4]);
+
+const DATA: Data = Data([1, 2, 3, 4]);
+
+fn main() {
+    match DATA {
+        DATA => (),
+        _ => (),
+    }
+}


### PR DESCRIPTION
This fixes an error compiling the `immeta` 0.3.6 crate. https://github.com/rust-lang/rust/issues/50707 may be fixed too.

r? @oli-obk 