### PR TITLE
Add missing _excess methods to Alloc and use them in RawVec

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -574,6 +574,10 @@ impl<T> Vec<T> {
     /// It will drop down as close as possible to the length but the allocator
     /// may still inform the vector that there is space for a few more elements.
     ///
+    /// Note: `shrink_to_fit` is a non-binding request. Whether the `Vec` size
+    /// will be shrunk at all, and if so by how much depends on the particular
+    /// allocator being used.
+    ///
     /// # Examples
     ///
     /// ```
@@ -597,6 +601,10 @@ impl<T> Vec<T> {
     ///
     /// Panics if the current capacity is smaller than the supplied
     /// minimum capacity.
+    ///
+    /// Note: `shrink_to` is a non-binding request. Whether the `Vec` size
+    /// will be shrunk at all, and if so by how much depends on the particular
+    /// allocator being used.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Adds the following methods to the `Alloc` trait:

* `alloc_zeroed_excess`
* `shrink_in_place_excess`
* `grow_in_place_excess`

Uses them in the appropriate places within the `RawVec` implementation.