### PR TITLE
shrink_to_fit shrinks in place

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -569,10 +569,7 @@ impl<T> Vec<T> {
         self.buf.try_reserve_exact(self.len, additional)
     }
 
-    /// Shrinks the capacity of the vector as much as possible.
-    ///
-    /// It will drop down as close as possible to the length but the allocator
-    /// may still inform the vector that there is space for a few more elements.
+    /// Non-binding request to reduce the capacity of the vector.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
This PR updates the documentation of `Vec::shrink_to_fit` to indicate that the request to shrink the vector's capacity is non-binding.

It used to say that "it shrinks the capacity as much as possible" but that was a lie since it also said "the allocator might inform the vector that there is space for a few more elements". Implementation-wise it called `realloc` which does not shrink the capacity as much as possible.

The only way to really shrink the capacity "as much as possible", is to perform a new allocation of the desired capacity, and move the elements over to it. This is not what was intended by the previous documentation.

The new docs more clearly state the "spirit" of `shrink_to_fit`, which is to reduce the unused capacity of the vector in whichever way it makes sense. This will depend, among other things, on the vector's allocator

The way this is now implemented in `RawVec` is to use `shrink_in_place`. Once PR https://github.com/rust-lang/rust/pull/50738 is merged this can be updated to use `shrink_in_place_excess`.

