### PR TITLE
Make NonNull::dangling a const fn.

### DIFF
--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2685,7 +2685,7 @@ impl<T: Sized> NonNull<T> {
     /// This is useful for initializing types which lazily allocate, like
     /// `Vec::new` does.
     #[stable(feature = "nonnull", since = "1.25.0")]
-    pub fn dangling() -> Self {
+    pub const fn dangling() -> Self {
         unsafe {
             let ptr = mem::align_of::<T>() as *mut T;
             NonNull::new_unchecked(ptr)


### PR DESCRIPTION
As far as I can tell, there no reason why `NonNull::dangling` isn't a `const fn`. This pr adds that keyword.