### PR TITLE
Use Vec::with_capacity(1) in a couple of places.

### DIFF
--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -181,7 +181,7 @@ fn build_local_id_to_index(body: Option<&hir::Body>,
 
     cfg.graph.each_node(|node_idx, node| {
         if let cfg::CFGNodeData::AST(id) = node.data {
-            index.entry(id).or_insert(vec![]).push(node_idx);
+            index.entry(id).or_insert_with(|| Vec::with_capacity(1)).push(node_idx);
         }
         true
     });
@@ -209,7 +209,8 @@ fn build_local_id_to_index(body: Option<&hir::Body>,
             }
 
             fn visit_pat(&mut self, p: &hir::Pat) {
-                self.index.entry(p.hir_id.local_id).or_insert(vec![]).push(self.entry);
+                self.index.entry(p.hir_id.local_id)
+                    .or_insert_with(|| Vec::with_capacity(1)).push(self.entry);
                 intravisit::walk_pat(self, p)
             }
         }

--- a/src/librustc/traits/project.rs
+++ b/src/librustc/traits/project.rs
@@ -597,7 +597,11 @@ fn opt_normalize_projection_type<'a, 'b, 'gcx, 'tcx>(
             // can ignore the `obligations` from that point on.
             if !infcx.any_unresolved_type_vars(&ty.value) {
                 infcx.projection_cache.borrow_mut().complete(cache_key);
-                ty.obligations = vec![];
+                // Use with_capacity(1) because
+                // push_paranoid_cache_value_obligation() will push one
+                // element, and then usually no more elements are pushed.
+                // (Vec::new() + push() gives a capacity of 4.)
+                ty.obligations = Vec::with_capacity(1);
             }
 
             push_paranoid_cache_value_obligation(infcx,


### PR DESCRIPTION
Because Vec::new() + push() results in a capacity of 4, and these
particular vectors almost never grow past a length of 1.

This change reduces the number of bytes of heap allocation
significantly. (For serde it's a 15% reduction for a debug build.) This
didn't give noticeable speed-ups on my machine but it's a trivial change
and certainly can't hurt.