### PR TITLE
Don't inject clippy into the rls anymore

### DIFF
--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -556,15 +556,6 @@ tool_extended!((self, builder),
     };
     Miri, miri, "src/tools/miri", "miri", {};
     Rls, rls, "src/tools/rls", "rls", {
-        let clippy = builder.ensure(Clippy {
-            compiler: self.compiler,
-            target: self.target,
-            extra_features: Vec::new(),
-        });
-        let channel = &builder.config.channel;
-        if clippy.is_some() && channel != "stable" && channel != "beta" {
-            self.extra_features.push("clippy".to_owned());
-        }
         builder.ensure(native::Openssl {
             target: self.target,
         });


### PR DESCRIPTION
r? @kennytm 

sorry about breaking nightlies.

The issue is that the `[patch.crates-io]` doesn't work if the versions differ. So every time we update clippy, we can only update it to the verison that rls is depending on.

I'm disabling the injection of clippy into rls for now. I'm not sure how to do this properly. We could

* add a version check, so rls only builds clippy if its dependency clippy is the same as the submodule clippy
* do something crazy like auto-patching the Cargo.toml of the rls tool repo to just use a path dependency on clippy
* build crates-io clippy instead of submodule clippy and gate clippy injection on that
    * that's somewhat automatic, and is essentially what is necessary right now, but done manually
* make clippy 0.1.* instead of 0.0.* and update patch versions for nightly updates and minor version updates for `clippy_lints` api changes.
    * not sure how semver-great this is