### PR TITLE
Add Content Security Policy to default

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -42,6 +42,7 @@ pub fn render<T: fmt::Display, S: fmt::Display>(
 <head>\
     <meta charset=\"utf-8\">\
     <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\
+    <meta http-equiv=\"Content-Security-Policy\" content=\"default-src *; script-src 'self'; object-src 'none'">
     <meta name=\"generator\" content=\"rustdoc\">\
     <meta name=\"description\" content=\"{description}\">\
     <meta name=\"keywords\" content=\"{keywords}\">\


### PR DESCRIPTION
This CSP intends to prevent pwnie attacks as seen in https://docs.rs/pwnies/0.0.14/pwnies/

The idea is that we don't allow script tags with inline scripts. And no scripts from JSfiles unless they are hosted in the same origin.
(We also have to disallow plugins (Java, Flash) because they do weird things with the Same Origin Policy)


This might leave in an attack where a crate contains the JS file itself though?