### PR TITLE
[Do not merge, perf only] Try enabling NewGVN

### DIFF
--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -438,6 +438,9 @@ extern "C" void LLVMRustConfigurePassManagerBuilder(
 #if LLVM_VERSION_GE(4, 0)
   unwrap(PMBR)->PrepareForThinLTO = PrepareForThinLTO;
 #endif
+#if LLVM_VERSION_GE(6, 0)
+  unwrap(PMBR)->NewGVN = true;
+#endif
 
 #ifdef PGO_AVAILABLE
   if (PGOGenPath) {

--- a/src/test/codegen/vec-optimizes-away.rs
+++ b/src/test/codegen/vec-optimizes-away.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 //
+// ignore-test Not optimized away under NewGVN :(
 // no-system-llvm
 // compile-flags: -O
 #![crate_type="lib"]


### PR DESCRIPTION
GVN commonly takes up 5-10% of the compilation time and the new sparse GVN implementation is supposed to be much faster.

This is not suitable for merging in this form, but I'd like to get a perf run to see if this is something worth looking into.