### PR TITLE
Fix null exclusions in grammar docs

### DIFF
--- a/src/doc/grammar.md
+++ b/src/doc/grammar.md
@@ -121,9 +121,9 @@ that does _not_ occur in the set of [keywords](#keywords).
 Some productions are defined by exclusion of particular Unicode characters:
 
 - `non_null` is any single Unicode character aside from `U+0000` (null)
-- `non_eol` is `non_null` restricted to exclude `U+000A` (`'\n'`)
-- `non_single_quote` is `non_null` restricted to exclude `U+0027`  (`'`)
-- `non_double_quote` is `non_null` restricted to exclude `U+0022` (`"`)
+- `non_eol` is any single Unicode character aside from `U+000A` (`'\n'`)
+- `non_single_quote` is any single Unicode character aside from `U+0027`  (`'`)
+- `non_double_quote` is any single Unicode character aside from `U+0022` (`"`)
 
 ## Comments
 


### PR DESCRIPTION
The grammar documentation incorrectly says that comments, character literals,
and string literals may not include null.