### PR TITLE
fix a typo in signed-integer::from_str_radix()

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -252,7 +252,7 @@ depending on `radix`:
 
  * `0-9`
  * `a-z`
- * `a-z`
+ * `A-Z`
 
 # Panics
 


### PR DESCRIPTION
a minor typo in docs.