### PR TITLE
adds Default impl for Instant

### DIFF
--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -210,7 +210,7 @@ impl Instant {
     }
 }
 
-#[stable(feature = "time2", since = "1.8.0")]
+#[stable(feature = "instant_default", since = "1.28.0")]
 impl Default for Instant {
     fn default() -> Self {
         Self::now()

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -211,6 +211,13 @@ impl Instant {
 }
 
 #[stable(feature = "time2", since = "1.8.0")]
+impl Default for Instant {
+    fn default() -> Self {
+        Self::now()
+    }
+}
+
+#[stable(feature = "time2", since = "1.8.0")]
 impl Add<Duration> for Instant {
     type Output = Instant;
 


### PR DESCRIPTION
Simple commit to add a `Default` impl for `Instant`. I frequently run into situations where `Instant` is the only reason I can't derive `Default` on a struct. There is only one way to instantiate an `Instant` (`Instant::now()`), so there should be little question what the default value of should be.

Apologies if the `stable` annotation is incorrect, second pull request. I just mimicked the other `Instant` impls. The tidy tool said it was ok. 