### PR TITLE
Add a lint for unused const fn results

### DIFF
--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -177,7 +177,8 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
                     UNUSED_DOC_COMMENT,
                     UNUSED_EXTERN_CRATES,
                     UNUSED_FEATURES,
-                    UNUSED_PARENS);
+                    UNUSED_PARENS,
+                    UNUSED_CONST_FN_RESULTS);
 
     add_lint_group!(sess,
                     "rust_2018_idioms",

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -32,6 +32,12 @@ declare_lint! {
 }
 
 declare_lint! {
+    pub UNUSED_CONST_FN_RESULTS,
+    Warn,
+    "unused result of a const fn invocation in a statement"
+}
+
+declare_lint! {
     pub UNUSED_RESULTS,
     Allow,
     "unused result of an expression in a statement"
@@ -42,7 +48,7 @@ pub struct UnusedResults;
 
 impl LintPass for UnusedResults {
     fn get_lints(&self) -> LintArray {
-        lint_array!(UNUSED_MUST_USE, UNUSED_RESULTS)
+        lint_array!(UNUSED_MUST_USE, UNUSED_CONST_FN_RESULTS, UNUSED_RESULTS)
     }
 }
 
@@ -95,6 +101,10 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
         if let Some(def) = maybe_def {
             let def_id = def.def_id();
             fn_warned = check_must_use(cx, def_id, s.span, "return value of ");
+            if cx.tcx.is_const_fn(def_id) {
+                cx.span_lint(UNUSED_CONST_FN_RESULTS, s.span,
+                             "unused const fn result");
+            }
         }
         let must_use_op = match expr.node {
             // Hardcoding operators here seemed more expedient than the

--- a/src/test/ui/unused-const-fn-result.rs
+++ b/src/test/ui/unused-const-fn-result.rs
@@ -1,0 +1,25 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(const_fn,test)]
+#![deny(unused_const_fn_results)]
+
+extern crate test;
+
+use test::black_box;
+
+const fn identity<T>(v: T) -> T {
+    v
+}
+
+fn main() {
+    identity(42); //~ ERROR unused const fn result [unused_const_fn_results]
+    identity(black_box(42)); //~ ERROR unused const fn result [unused_const_fn_results]
+}

--- a/src/test/ui/unused-const-fn-result.stderr
+++ b/src/test/ui/unused-const-fn-result.stderr
@@ -1,0 +1,20 @@
+error: unused const fn result
+  --> $DIR/unused-const-fn-result.rs:23:5
+   |
+LL |     identity(42); //~ ERROR unused const fn result [unused_const_fn_results]
+   |     ^^^^^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/unused-const-fn-result.rs:12:9
+   |
+LL | #![deny(unused_const_fn_results)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unused const fn result
+  --> $DIR/unused-const-fn-result.rs:24:5
+   |
+LL |     identity(black_box(42)); //~ ERROR unused const fn result [unused_const_fn_results]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Implements [RFC 2450](https://github.com/rust-lang/rfcs/pull/2450).
This PR adds a lint that checks for invocations of functions which are `const fn` where the result is discarded.

This is dead code as `const fn` is free of side effects.

Implements my suggestion from https://github.com/rust-lang/rust/issues/48926#issuecomment-389152854

Important gotcha: this is not a "unused constant expression" lint but a superset of such a lint: we also lint for `const fn` invocations with non-constant parameters. Invocations in such cases would still be side effect free... well maybe except for drop impls but this is as close as we can get.