### PR TITLE
GitHub: Stop treating Cargo.lock as a generated file.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,4 +7,4 @@
 src/etc/installer/gfx/* binary
 *.woff binary
 src/vendor/** -text
-Cargo.lock -merge
+Cargo.lock -merge linguist-generated=false


### PR DESCRIPTION
We do want to inspect the changes to Cargo.lock, hiding the diff by default would make it easier to miss important details like https://github.com/rust-lang/rust/pull/50629#discussion_r187556602 and https://github.com/rust-lang/rust/pull/50696#pullrequestreview-119648156