### PR TITLE
Add target for Big-endian ARM Cortex-R4F/R5F MCUs

### DIFF
--- a/src/ci/docker/disabled/dist-armebv7r-none-eabihf/Dockerfile
+++ b/src/ci/docker/disabled/dist-armebv7r-none-eabihf/Dockerfile
@@ -29,7 +29,7 @@ ENV PATH=$PATH:/$GCC_LINARO/bin
 ENV TARGET=armebv7r-none-eabihf
 
 ENV CC_armebv7r_none_eabihf=armeb-eabi-gcc \
-    CFLAGS_armebv7r_none_eabihf="-mthumb -march=armv7-r"
+    CFLAGS_armebv7r_none_eabihf="-march=armv7-r"
 
 ENV RUST_CONFIGURE_ARGS --disable-docs
 

--- a/src/ci/docker/disabled/dist-armebv7r-none-eabihf/Dockerfile
+++ b/src/ci/docker/disabled/dist-armebv7r-none-eabihf/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  g++ \
+  make \
+  file \
+  curl \
+  ca-certificates \
+  python2.7 \
+  git \
+  cmake \
+  sudo \
+  xz-utils \
+  bzip2 \
+  libssl-dev \
+  pkg-config
+
+
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
+ENV BASE_URL=https://releases.linaro.org/components/toolchain/binaries/latest/armeb-eabi/
+ENV GCC_LINARO=gcc-linaro-7.2.1-2017.11-x86_64_armeb-eabi
+
+RUN curl -sL $BASE_URL/$GCC_LINARO.tar.xz | tar -xJ
+
+ENV PATH=$PATH:/$GCC_LINARO/bin
+
+ENV TARGET=armebv7r-none-eabihf
+
+ENV CC_armebv7r_none_eabihf=armeb-eabi-gcc \
+    CFLAGS_armebv7r_none_eabihf="-mthumb -march=armv7-r"
+
+ENV RUST_CONFIGURE_ARGS --disable-docs
+
+ENV SCRIPT python2.7 ../x.py dist --target $TARGET

--- a/src/librustc_target/spec/armebv7r_none_eabihf.rs
+++ b/src/librustc_target/spec/armebv7r_none_eabihf.rs
@@ -1,0 +1,40 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Targets the Cortex-R4F/R5F processor (ARMv7-R)
+
+use std::default::Default;
+use spec::{LinkerFlavor, PanicStrategy, Target, TargetOptions, TargetResult};
+
+pub fn target() -> TargetResult {
+    Ok(Target {
+        llvm_target: "armebv7r-none-eabihf".to_string(),
+        target_endian: "big".to_string(),
+        target_pointer_width: "32".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "E-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
+        arch: "arm".to_string(),
+        target_os: "none".to_string(),
+        target_env: "".to_string(),
+        target_vendor: "".to_string(),
+        linker_flavor: LinkerFlavor::Gcc,
+
+        options: TargetOptions {
+            executables: true,
+            relocation_model: "static".to_string(),
+            panic_strategy: PanicStrategy::Abort,
+            features: "+v7,+thumb2,+vfp3,+d16,+fp-only-sp".to_string(),
+            max_atomic_width: Some(32),
+            abi_blacklist: super::arm_base::abi_blacklist(),
+            emit_debug_gdb_scripts: false,
+            .. Default::default()
+        },
+    })
+}

--- a/src/librustc_target/spec/armebv7r_none_eabihf.rs
+++ b/src/librustc_target/spec/armebv7r_none_eabihf.rs
@@ -30,7 +30,7 @@ pub fn target() -> TargetResult {
             executables: true,
             relocation_model: "static".to_string(),
             panic_strategy: PanicStrategy::Abort,
-            features: "+v7,+thumb2,+vfp3,+d16,+fp-only-sp".to_string(),
+            features: "+v7,+vfp3,+d16,+fp-only-sp".to_string(),
             max_atomic_width: Some(32),
             abi_blacklist: super::arm_base::abi_blacklist(),
             emit_debug_gdb_scripts: false,

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -342,6 +342,8 @@ supported_targets! {
     ("armv7-apple-ios", armv7_apple_ios),
     ("armv7s-apple-ios", armv7s_apple_ios),
 
+    ("armebv7r-none-eabihf", armebv7r_none_eabihf),
+
     ("x86_64-sun-solaris", x86_64_sun_solaris),
     ("sparcv9-sun-solaris", sparcv9_sun_solaris),
 

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -63,6 +63,7 @@ static TARGETS: &'static [&'static str] = &[
     "armv7-unknown-cloudabi-eabihf",
     "armv7-unknown-linux-gnueabihf",
     "armv7-unknown-linux-musleabihf",
+    "armebv7r-none-eabihf",
     "armv7s-apple-ios",
     "asmjs-unknown-emscripten",
     "i386-apple-ios",


### PR DESCRIPTION
The ARM Real-Time (‘R’) profile provides high-performing processors for safety-critical environments.

Cortex-R has ARM, Thumb instruction whereas Cortex-M makes use of Thumb only.

CI/Dockerfile is intentionally in the `disabled` folder.