### PR TITLE
Fix potential divide by zero

### DIFF
--- a/src/librustc_codegen_llvm/abi.rs
+++ b/src/librustc_codegen_llvm/abi.rs
@@ -127,8 +127,12 @@ impl LlvmType for Reg {
 impl LlvmType for CastTarget {
     fn llvm_type(&self, cx: &CodegenCx) -> Type {
         let rest_ll_unit = self.rest.unit.llvm_type(cx);
-        let rest_count = self.rest.total.bytes() / self.rest.unit.size.bytes();
-        let rem_bytes = self.rest.total.bytes() % self.rest.unit.size.bytes();
+        let (rest_count, rem_bytes) = if self.rest.unit.size.bytes() == 0 {
+            (0, 0)
+        } else {
+            (self.rest.total.bytes() / self.rest.unit.size.bytes(),
+            self.rest.total.bytes() % self.rest.unit.size.bytes())
+        };
 
         if self.prefix.iter().all(|x| x.is_none()) {
             // Simplify to a single unit when there is no prefix and size <= unit size

--- a/src/test/ui/issue-50761.rs
+++ b/src/test/ui/issue-50761.rs
@@ -1,0 +1,35 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Confirm that we don't accidently divide or mod by zero in llvm_type
+
+// compile-pass
+
+#![feature(test)]
+
+mod a {
+    pub trait A {}
+}
+
+mod b {
+    pub struct Builder {}
+
+    pub fn new() -> Builder {
+        Builder {}
+    }
+
+    impl Builder {
+        pub fn with_a(&mut self, _a: fn() -> ::a::A) {}
+    }
+}
+
+pub use self::b::new;
+
+fn main() {}

--- a/src/test/ui/issue-50761.rs
+++ b/src/test/ui/issue-50761.rs
@@ -12,8 +12,6 @@
 
 // compile-pass
 
-#![feature(test)]
-
 mod a {
     pub trait A {}
 }


### PR DESCRIPTION
This should fix #50761

I had trouble reproducing with the provided code, but looking at the stack trace would indicate that this code is the likely cause. I made a number of assumptions here, because I don't have enough context on how the register size is set:

1. I assumed `rest.unit.size.bytes()` can be 0, and it's ok if it's set to 0 before this function is called
2. I assumed that if `rest.unit.size.bytes()` is 0, that we want `rest_count` to also be 0.