### PR TITLE
CheckLoopVisitor: also visit closure arguments

### DIFF
--- a/src/librustc_passes/loops.rs
+++ b/src/librustc_passes/loops.rs
@@ -82,7 +82,8 @@ impl<'a, 'hir> Visitor<'hir> for CheckLoopVisitor<'a, 'hir> {
             hir::ExprLoop(ref b, _, source) => {
                 self.with_context(Loop(LoopKind::Loop(source)), |v| v.visit_block(&b));
             }
-            hir::ExprClosure(.., b, _, _) => {
+            hir::ExprClosure(_, ref function_decl, b, _, _) => {
+                self.visit_fn_decl(&function_decl);
                 self.with_context(Closure, |v| v.visit_nested_body(b));
             }
             hir::ExprBlock(ref b, Some(_label)) => {


### PR DESCRIPTION
This turns the ICE #50581 in this code:

```rust
fn main() {
    |_: [u8; break]| ();
}
```

from
```
    'assertion failed: self.tcx.sess.err_count() > 0', librustc_typeck/check/mod.rs
```
to
```
    librustc_mir/hair/cx/expr.rs:543: invalid loop id for break: not inside loop scope
```

which is an ICE as well but at a later stage during compilation and most importantly
fixes of bug #50576 will fix this as well.

As this "only" moves an ICE to a later stage, I didn't add any tests.

Now I have manually verified the default impls of the visitor trait to check whether we have missed any other opportunity to visit more stuff and coudln't find anything (except the missing `break` visit I've fixed in #50829 but that one was already r+'d so I didn't want to push more commits).