### PR TITLE
Make `[T]::len` and `str::len` const fn

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -119,6 +119,9 @@
 #![feature(powerpc_target_feature)]
 #![feature(mips_target_feature)]
 #![feature(aarch64_target_feature)]
+#![feature(const_slice_len)]
+#![feature(const_str_as_bytes)]
+#![feature(const_str_len)]
 
 #[prelude_import]
 #[allow(unused)]

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -2166,7 +2166,8 @@ impl str {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    pub fn len(&self) -> usize {
+    #[rustc_const_unstable(feature = "const_str_len")]
+    pub const fn len(&self) -> usize {
         self.as_bytes().len()
     }
 
@@ -2185,7 +2186,8 @@ impl str {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn is_empty(&self) -> bool {
+    #[rustc_const_unstable(feature = "const_str_len")]
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
@@ -2242,8 +2244,15 @@ impl str {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline(always)]
-    pub fn as_bytes(&self) -> &[u8] {
-        unsafe { &*(self as *const str as *const [u8]) }
+    #[rustc_const_unstable(feature="const_str_as_bytes")]
+    pub const fn as_bytes(&self) -> &[u8] {
+        unsafe {
+            union Slices<'a> {
+                str: &'a str,
+                slice: &'a [u8],
+            }
+            Slices { str: self }.slice
+        }
     }
 
     /// Converts a mutable string slice to a mutable byte slice. To convert the
@@ -2303,7 +2312,8 @@ impl str {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    pub fn as_ptr(&self) -> *const u8 {
+    #[rustc_const_unstable(feature = "const_str_as_ptr")]
+    pub const fn as_ptr(&self) -> *const u8 {
         self as *const str as *const u8
     }
 

--- a/src/test/ui/const-eval/strlen.rs
+++ b/src/test/ui/const-eval/strlen.rs
@@ -1,0 +1,26 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-pass
+
+#![feature(const_str_len, const_str_as_bytes)]
+
+#![crate_type = "lib"]
+
+const S: &str = "foo";
+pub const B: &[u8] = S.as_bytes();
+
+pub fn foo() -> [u8; S.len()] {
+    let mut buf = [0; S.len()];
+    for (i, &c) in S.as_bytes().iter().enumerate() {
+        buf[i] = c;
+    }
+    buf
+}

--- a/src/test/ui/const-eval/strlen.rs
+++ b/src/test/ui/const-eval/strlen.rs
@@ -8,11 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-pass
+// run-pass
 
 #![feature(const_str_len, const_str_as_bytes)]
-
-#![crate_type = "lib"]
 
 const S: &str = "foo";
 pub const B: &[u8] = S.as_bytes();
@@ -23,4 +21,13 @@ pub fn foo() -> [u8; S.len()] {
         buf[i] = c;
     }
     buf
+}
+
+fn main() {
+    assert_eq!(&foo()[..], b"foo");
+    assert_eq!(foo().len(), S.len());
+    const LEN: usize = S.len();
+    assert_eq!(LEN, S.len());
+    assert_eq!(B, foo());
+    assert_eq!(B, b"foo");
 }


### PR DESCRIPTION
r? @Gankro 