### PR TITLE
Filter global bounds from ParamEnv again.

### DIFF
--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -644,7 +644,12 @@ pub fn normalize_param_env_or_error<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
     let predicates: Vec<_> =
         util::elaborate_predicates(tcx, unnormalized_env.caller_bounds.to_vec())
+        .filter(|p| !p.is_global() || p.has_late_bound_regions()) // (*)
         .collect();
+
+    // (*) FIXME(#50825) This shouldn't be needed.
+    // Removing the bounds here stopped them from being prefered in selection.
+    // See the issue-50825 ui tests for examples
 
     debug!("normalize_param_env_or_error: elaborated-predicates={:?}",
            predicates);

--- a/src/test/ui/feature-gate-trivial_bounds.rs
+++ b/src/test/ui/feature-gate-trivial_bounds.rs
@@ -28,7 +28,7 @@ union U where i32: Foo { f: i32 } //~ ERROR
 type Y where i32: Foo = (); // OK - bound is ignored
 
 impl Foo for () where i32: Foo { //~ ERROR
-    fn test(&self) {
+    fn test(&self) { //~ ERROR
         3i32.test();
         Foo::test(&4i32);
         generic_function(5i32);
@@ -60,6 +60,7 @@ struct Dst<X: ?Sized> {
 }
 
 struct TwoStrs(str, str) where str: Sized; //~ ERROR
+//~^ ERROR
 
 fn unsized_local() where Dst<A>: Sized { //~ ERROR
     let x: Dst<A> = *(Box::new(Dst { x: 1 }) as Box<Dst<A>>);

--- a/src/test/ui/feature-gate-trivial_bounds.stderr
+++ b/src/test/ui/feature-gate-trivial_bounds.stderr
@@ -38,7 +38,7 @@ error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/feature-gate-trivial_bounds.rs:30:1
    |
 LL | / impl Foo for () where i32: Foo { //~ ERROR
-LL | |     fn test(&self) {
+LL | |     fn test(&self) { //~ ERROR
 LL | |         3i32.test();
 LL | |         Foo::test(&4i32);
 LL | |         generic_function(5i32);
@@ -97,8 +97,17 @@ LL | struct TwoStrs(str, str) where str: Sized; //~ ERROR
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
+error[E0277]: the trait bound `str: std::marker::Sized` is not satisfied
+  --> $DIR/feature-gate-trivial_bounds.rs:62:16
+   |
+LL | struct TwoStrs(str, str) where str: Sized; //~ ERROR
+   |                ^^^ `str` does not have a constant size known at compile-time
+   |
+   = help: the trait `std::marker::Sized` is not implemented for `str`
+   = note: only the last field of a struct may have a dynamically sized type
+
 error[E0277]: the trait bound `A + 'static: std::marker::Sized` is not satisfied in `Dst<A + 'static>`
-  --> $DIR/feature-gate-trivial_bounds.rs:64:1
+  --> $DIR/feature-gate-trivial_bounds.rs:65:1
    |
 LL | / fn unsized_local() where Dst<A>: Sized { //~ ERROR
 LL | |     let x: Dst<A> = *(Box::new(Dst { x: 1 }) as Box<Dst<A>>);
@@ -111,7 +120,7 @@ LL | | }
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
 error[E0277]: the trait bound `str: std::marker::Sized` is not satisfied
-  --> $DIR/feature-gate-trivial_bounds.rs:68:1
+  --> $DIR/feature-gate-trivial_bounds.rs:69:1
    |
 LL | / fn return_str() -> str where str: Sized { //~ ERROR
 LL | |     *"Sized".to_string().into_boxed_str()
@@ -122,6 +131,22 @@ LL | | }
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
-error: aborting due to 11 previous errors
+error[E0277]: the trait bound `i32: Foo` is not satisfied
+  --> $DIR/feature-gate-trivial_bounds.rs:31:5
+   |
+LL | /     fn test(&self) { //~ ERROR
+LL | |         3i32.test();
+LL | |         Foo::test(&4i32);
+LL | |         generic_function(5i32);
+LL | |     }
+   | |_____^ the trait `Foo` is not implemented for `i32`
+   |
+note: required by `Foo`
+  --> $DIR/feature-gate-trivial_bounds.rs:14:1
+   |
+LL | pub trait Foo {
+   | ^^^^^^^^^^^^^
+
+error: aborting due to 13 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/issue-50825-1.rs
+++ b/src/test/ui/issue-50825-1.rs
@@ -8,28 +8,25 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-test FIXME(#50825)
 // run-pass
-// Check tautalogically false `Sized` bounds
-#![feature(trivial_bounds)]
-#![allow(unused)]
+// regression test for issue #50825
+// Make sure that the `impl` bound (): X<T = ()> is prefered over
+// the (): X bound in the where clause.
 
-trait A {}
-
-impl A for i32 {}
-
-struct T<X: ?Sized> {
-    x: X,
+trait X {
+    type T;
 }
 
-struct S(str, str) where str: Sized;
-
-fn unsized_local() where for<'a> T<A + 'a>: Sized {
-    let x: T<A> = *(Box::new(T { x: 1 }) as Box<T<A>>);
+trait Y<U>: X {
+    fn foo(x: &Self::T);
 }
 
-fn return_str() -> str where str: Sized {
-    *"Sized".to_string().into_boxed_str()
+impl X for () {
+    type T = ();
 }
 
-fn main() {}
+impl<T> Y<Vec<T>> for () where (): Y<T> {
+    fn foo(_x: &()) {}
+}
+
+fn main () {}

--- a/src/test/ui/issue-50825.rs
+++ b/src/test/ui/issue-50825.rs
@@ -8,28 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-test FIXME(#50825)
 // run-pass
-// Check tautalogically false `Sized` bounds
-#![feature(trivial_bounds)]
-#![allow(unused)]
+// regression test for issue #50825
+// Make sure that the built-in bound {integer}: Sized is prefered over
+// the u64: Sized bound in the where clause.
 
-trait A {}
-
-impl A for i32 {}
-
-struct T<X: ?Sized> {
-    x: X,
+fn foo(y: &[()])
+where
+    u64: Sized,
+{
+    y[0]
 }
 
-struct S(str, str) where str: Sized;
-
-fn unsized_local() where for<'a> T<A + 'a>: Sized {
-    let x: T<A> = *(Box::new(T { x: 1 }) as Box<T<A>>);
+fn main () {
+    foo(&[()]);
 }
-
-fn return_str() -> str where str: Sized {
-    *"Sized".to_string().into_boxed_str()
-}
-
-fn main() {}

--- a/src/test/ui/trivial-bounds-inconsistent-associated-functions.rs
+++ b/src/test/ui/trivial-bounds-inconsistent-associated-functions.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test FIXME(#50825)
 // run-pass
 // Inconsistent bounds with trait implementations
 

--- a/src/test/ui/trivial-bounds-inconsistent-copy-reborrow.rs
+++ b/src/test/ui/trivial-bounds-inconsistent-copy-reborrow.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test FIXME(#50825)
 // Check that reborrows are still illegal with Copy mutable references
 #![feature(trivial_bounds)]
 #![allow(unused)]

--- a/src/test/ui/trivial-bounds-inconsistent-copy.rs
+++ b/src/test/ui/trivial-bounds-inconsistent-copy.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test FIXME(#50825)
 // run-pass
 // Check tautalogically false `Copy` bounds
 #![feature(trivial_bounds)]

--- a/src/test/ui/trivial-bounds-inconsistent-well-formed.rs
+++ b/src/test/ui/trivial-bounds-inconsistent-well-formed.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test FIXME(#50825)
 // run-pass
 // Test that inconsistent bounds are used in well-formedness checks
 #![feature(trivial_bounds)]

--- a/src/test/ui/trivial-bounds-inconsistent.rs
+++ b/src/test/ui/trivial-bounds-inconsistent.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test FIXME(#50825)
 // run-pass
 
 // Check that tautalogically false bounds are accepted, and are used

--- a/src/test/ui/trivial-bounds-leak-copy.rs
+++ b/src/test/ui/trivial-bounds-leak-copy.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test FIXME(#50825)
 // Check that false Copy bounds don't leak
 #![feature(trivial_bounds)]
 

--- a/src/test/ui/trivial-bounds-leak.rs
+++ b/src/test/ui/trivial-bounds-leak.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test FIXME(#50825)
 // Check that false bounds don't leak
 #![feature(trivial_bounds)]
 

--- a/src/test/ui/trivial-bounds-lint.rs
+++ b/src/test/ui/trivial-bounds-lint.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test FIXME(#50825)
 #![feature(trivial_bounds)]
 #![allow(unused)]
 #![deny(trivial_bounds)]


### PR DESCRIPTION
This PR adds back the filtering of global bounds from ParamEnv as a temporary solution for #50825.

<details>

Long term, the fix seems like it should be changing the priority in `candidate_should_be_dropped_in_favor_of` so that (global) where clauses aren't considered as highly.

https://github.com/rust-lang/rust/blob/a722296b6ec17fecd3f16a7d3f9232b83e5de800/src/librustc/traits/select.rs#L2017-L2022

</details>

r? @nikomatsakis 
