### PR TITLE
Fix naming conventions for new lints

### DIFF
--- a/src/doc/rustc/src/lints/listing/allowed-by-default.md
+++ b/src/doc/rustc/src/lints/listing/allowed-by-default.md
@@ -64,7 +64,7 @@ To fix it, do as the help message suggests:
 
 ```rust
 #![feature(dyn_trait)]
-#![deny(bare_trait_object)]
+#![deny(bare_trait_objects)]
 
 trait Trait { }
 

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -4125,7 +4125,7 @@ impl<'a> LoweringContext<'a> {
 
     fn maybe_lint_bare_trait(&self, span: Span, id: NodeId, is_global: bool) {
         self.sess.buffer_lint_with_diagnostic(
-            builtin::BARE_TRAIT_OBJECT,
+            builtin::BARE_TRAIT_OBJECTS,
             id,
             span,
             "trait objects without an explicit `dyn` are deprecated",

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -225,13 +225,13 @@ declare_lint! {
 }
 
 declare_lint! {
-    pub SINGLE_USE_LIFETIME,
+    pub SINGLE_USE_LIFETIMES,
     Allow,
     "detects lifetime parameters that are only used once"
 }
 
 declare_lint! {
-    pub UNUSED_LIFETIME,
+    pub UNUSED_LIFETIMES,
     Allow,
     "detects lifetime parameters that are never used"
 }
@@ -243,19 +243,19 @@ declare_lint! {
 }
 
 declare_lint! {
-    pub ELIDED_LIFETIME_IN_PATH,
+    pub ELIDED_LIFETIMES_IN_PATHS,
     Allow,
     "hidden lifetime parameters are deprecated, try `Foo<'_>`"
 }
 
 declare_lint! {
-    pub BARE_TRAIT_OBJECT,
+    pub BARE_TRAIT_OBJECTS,
     Allow,
     "suggest using `dyn Trait` for trait objects"
 }
 
 declare_lint! {
-    pub ABSOLUTE_PATH_NOT_STARTING_WITH_CRATE,
+    pub ABSOLUTE_PATHS_NOT_STARTING_WITH_CRATE,
     Allow,
     "fully qualified paths that start with a module name \
      instead of `crate`, `self`, or an extern crate name"
@@ -268,7 +268,7 @@ declare_lint! {
 }
 
 declare_lint! {
-    pub UNSTABLE_NAME_COLLISION,
+    pub UNSTABLE_NAME_COLLISIONS,
     Warn,
     "detects name collision with an existing but unstable method"
 }
@@ -328,14 +328,14 @@ impl LintPass for HardwiredLints {
             DEPRECATED,
             UNUSED_UNSAFE,
             UNUSED_MUT,
-            SINGLE_USE_LIFETIME,
-            UNUSED_LIFETIME,
+            SINGLE_USE_LIFETIMES,
+            UNUSED_LIFETIMES,
             UNUSED_LABELS,
             TYVAR_BEHIND_RAW_POINTER,
-            ELIDED_LIFETIME_IN_PATH,
-            BARE_TRAIT_OBJECT,
-            ABSOLUTE_PATH_NOT_STARTING_WITH_CRATE,
-            UNSTABLE_NAME_COLLISION,
+            ELIDED_LIFETIMES_IN_PATHS,
+            BARE_TRAIT_OBJECTS,
+            ABSOLUTE_PATHS_NOT_STARTING_WITH_CRATE,
+            UNSTABLE_NAME_COLLISIONS,
             DUPLICATE_ASSOCIATED_TYPE_BINDINGS,
         )
     }

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -505,7 +505,7 @@ pub fn struct_lint_level<'a>(sess: &'a Session,
             "this was previously accepted by the compiler but is being phased out; \
              it will become a hard error";
 
-        let explanation = if lint_id == LintId::of(::lint::builtin::UNSTABLE_NAME_COLLISION) {
+        let explanation = if lint_id == LintId::of(::lint::builtin::UNSTABLE_NAME_COLLISIONS) {
             "once this method is added to the standard library, \
              the ambiguity may cause an error or change in behavior!"
                 .to_owned()

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -1344,7 +1344,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
 
                         self.tcx
                             .struct_span_lint_node(
-                                lint::builtin::SINGLE_USE_LIFETIME,
+                                lint::builtin::SINGLE_USE_LIFETIMES,
                                 id,
                                 span,
                                 &format!(
@@ -1366,7 +1366,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
 
                         self.tcx
                             .struct_span_lint_node(
-                                lint::builtin::UNUSED_LIFETIME,
+                                lint::builtin::UNUSED_LIFETIMES,
                                 id,
                                 span,
                                 &format!(
@@ -1981,7 +1981,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
         if deprecated {
             self.tcx
                 .struct_span_lint_node(
-                    lint::builtin::ELIDED_LIFETIME_IN_PATH,
+                    lint::builtin::ELIDED_LIFETIMES_IN_PATHS,
                     id,
                     span,
                     &format!("hidden lifetime parameters are deprecated, try `Foo<'_>`"),

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -694,7 +694,7 @@ impl EarlyLintPass for DeprecatedAttr {
 }
 
 declare_lint! {
-    pub UNUSED_DOC_COMMENT,
+    pub UNUSED_DOC_COMMENTS,
     Warn,
     "detects doc comments that aren't used by rustdoc"
 }
@@ -704,7 +704,7 @@ pub struct UnusedDocComment;
 
 impl LintPass for UnusedDocComment {
     fn get_lints(&self) -> LintArray {
-        lint_array![UNUSED_DOC_COMMENT]
+        lint_array![UNUSED_DOC_COMMENTS]
     }
 }
 
@@ -713,7 +713,7 @@ impl UnusedDocComment {
                    I: Iterator<Item=&'a ast::Attribute>,
                    C: LintContext<'tcx>>(&self, mut attrs: I, cx: &C) {
         if let Some(attr) = attrs.find(|a| a.is_value_str() && a.check_name("doc")) {
-            cx.struct_span_lint(UNUSED_DOC_COMMENT, attr.span, "doc comment not used by rustdoc")
+            cx.struct_span_lint(UNUSED_DOC_COMMENTS, attr.span, "doc comment not used by rustdoc")
               .emit();
         }
     }
@@ -1527,7 +1527,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedBrokenConst {
 }
 
 declare_lint! {
-    pub UNNECESSARY_EXTERN_CRATE,
+    pub UNNECESSARY_EXTERN_CRATES,
     Allow,
     "suggest removing `extern crate` for the 2018 edition"
 }
@@ -1542,7 +1542,7 @@ impl ExternCrate {
 
 impl LintPass for ExternCrate {
     fn get_lints(&self) -> LintArray {
-        lint_array!(UNNECESSARY_EXTERN_CRATE)
+        lint_array!(UNNECESSARY_EXTERN_CRATES)
     }
 }
 
@@ -1555,7 +1555,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ExternCrate {
             if it.attrs.iter().any(|a| a.check_name("macro_use")) {
                 return
             }
-            let mut err = cx.struct_span_lint(UNNECESSARY_EXTERN_CRATE,
+            let mut err = cx.struct_span_lint(UNNECESSARY_EXTERN_CRATES,
                 it.span, "`extern crate` is unnecessary in the new edition");
             if it.vis == hir::Visibility::Public || self.0 > 1 || orig.is_some() {
                 let pub_ = if it.vis == hir::Visibility::Public {

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -40,7 +40,7 @@ extern crate rustc_target;
 extern crate syntax_pos;
 
 use rustc::lint;
-use rustc::lint::builtin::{BARE_TRAIT_OBJECT, ABSOLUTE_PATH_NOT_STARTING_WITH_CRATE};
+use rustc::lint::builtin::{BARE_TRAIT_OBJECTS, ABSOLUTE_PATHS_NOT_STARTING_WITH_CRATE};
 use rustc::session;
 use rustc::util;
 
@@ -174,7 +174,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
                     UNUSED_ATTRIBUTES,
                     UNUSED_MACROS,
                     UNUSED_ALLOCATION,
-                    UNUSED_DOC_COMMENT,
+                    UNUSED_DOC_COMMENTS,
                     UNUSED_EXTERN_CRATES,
                     UNUSED_FEATURES,
                     UNUSED_LABELS,
@@ -182,9 +182,9 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
 
     add_lint_group!(sess,
                     "rust_2018_idioms",
-                    BARE_TRAIT_OBJECT,
+                    BARE_TRAIT_OBJECTS,
                     UNREACHABLE_PUB,
-                    UNNECESSARY_EXTERN_CRATE);
+                    UNNECESSARY_EXTERN_CRATES);
 
     // Guidelines for creating a future incompatibility lint:
     //
@@ -272,14 +272,14 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
             edition: Some(Edition::Edition2018),
         },
         FutureIncompatibleInfo {
-            id: LintId::of(UNSTABLE_NAME_COLLISION),
+            id: LintId::of(UNSTABLE_NAME_COLLISIONS),
             reference: "issue #48919 <https://github.com/rust-lang/rust/issues/48919>",
             edition: None,
             // Note: this item represents future incompatibility of all unstable functions in the
             //       standard library, and thus should never be removed or changed to an error.
         },
         FutureIncompatibleInfo {
-            id: LintId::of(ABSOLUTE_PATH_NOT_STARTING_WITH_CRATE),
+            id: LintId::of(ABSOLUTE_PATHS_NOT_STARTING_WITH_CRATE),
             reference: "issue TBD",
             edition: Some(Edition::Edition2018),
         },
@@ -291,6 +291,11 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
         ]);
 
     // Register renamed and removed lints
+    store.register_renamed("single_use_lifetime", "single_use_lifetimes");
+    store.register_renamed("elided_lifetime_in_path", "elided_lifetimes_in_paths");
+    store.register_renamed("bare_trait_object", "bare_trait_objects");
+    store.register_renamed("unstable_name_collision", "unstable_name_collisions");
+    store.register_renamed("unused_doc_comment", "unused_doc_comments");
     store.register_renamed("unknown_features", "unused_features");
     store.register_removed("unsigned_negation", "replaced by negate_unsigned feature gate");
     store.register_removed("negate_unsigned", "cast a signed value instead");
@@ -325,6 +330,4 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
         "converted into hard error, see https://github.com/rust-lang/rust/issues/48950");
     store.register_removed("resolve_trait_on_defaulted_unit",
         "converted into hard error, see https://github.com/rust-lang/rust/issues/48950");
-    store.register_removed("absolute_path_starting_with_module",
-        "renamed to `absolute_path_not_starting_with_crate`");
 }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3486,7 +3486,7 @@ impl<'a> Resolver<'a> {
         let diag = lint::builtin::BuiltinLintDiagnostics
             ::AbsPathWithModule(span);
         self.session.buffer_lint_with_diagnostic(
-            lint::builtin::ABSOLUTE_PATH_NOT_STARTING_WITH_CRATE,
+            lint::builtin::ABSOLUTE_PATHS_NOT_STARTING_WITH_CRATE,
             id, span,
             "absolute paths must start with `self`, `super`, \
             `crate`, or an external crate name in the 2018 edition",

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -1057,7 +1057,7 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
         unstable_candidates: &[(&Candidate<'tcx>, Symbol)],
     ) {
         let mut diag = self.tcx.struct_span_lint_node(
-            lint::builtin::UNSTABLE_NAME_COLLISION,
+            lint::builtin::UNSTABLE_NAME_COLLISIONS,
             self.fcx.body_id,
             self.span,
             "a method with this name may be added to the standard library in the future",

--- a/src/test/compile-fail/trait-bounds-not-on-struct.rs
+++ b/src/test/compile-fail/trait-bounds-not-on-struct.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(bare_trait_object)]
+#![allow(bare_trait_objects)]
 
 struct Foo;
 

--- a/src/test/compile-fail/useless_comment.rs
+++ b/src/test/compile-fail/useless_comment.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![deny(unused_doc_comment)]
+#![deny(unused_doc_comments)]
 
 fn foo() {
     /// a //~ ERROR doc comment not used by rustdoc

--- a/src/test/ui-fulldeps/unnecessary-extern-crate.rs
+++ b/src/test/ui-fulldeps/unnecessary-extern-crate.rs
@@ -10,7 +10,7 @@
 
 // compile-flags: --edition 2018
 
-#![deny(unnecessary_extern_crate)]
+#![deny(unnecessary_extern_crates)]
 #![feature(alloc, test, libc)]
 
 extern crate alloc;

--- a/src/test/ui-fulldeps/unnecessary-extern-crate.stderr
+++ b/src/test/ui-fulldeps/unnecessary-extern-crate.stderr
@@ -7,8 +7,8 @@ LL | extern crate alloc;
 note: lint level defined here
   --> $DIR/unnecessary-extern-crate.rs:13:9
    |
-LL | #![deny(unnecessary_extern_crate)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(unnecessary_extern_crates)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `extern crate` is unnecessary in the new edition
   --> $DIR/unnecessary-extern-crate.rs:19:1

--- a/src/test/ui/in-band-lifetimes/ellided-lifetimes.rs
+++ b/src/test/ui/in-band-lifetimes/ellided-lifetimes.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 #![allow(warnings)]
 #![allow(unused_variables, dead_code, unused, bad_style)]
-#![deny(elided_lifetime_in_path)]
+#![deny(elided_lifetimes_in_paths)]
 
 struct Foo<'a> { x: &'a u32 }
 fn foo(x: &Foo) {

--- a/src/test/ui/in-band-lifetimes/ellided-lifetimes.stderr
+++ b/src/test/ui/in-band-lifetimes/ellided-lifetimes.stderr
@@ -7,8 +7,8 @@ LL | fn foo(x: &Foo) {
 note: lint level defined here
   --> $DIR/ellided-lifetimes.rs:12:9
    |
-LL | #![deny(elided_lifetime_in_path)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(elided_lifetimes_in_paths)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/inference_unstable.stderr
+++ b/src/test/ui/inference_unstable.stderr
@@ -4,7 +4,7 @@ warning: a method with this name may be added to the standard library in the fut
 LL |     assert_eq!('x'.ipu_flatten(), 1);
    |                    ^^^^^^^^^^^
    |
-   = note: #[warn(unstable_name_collision)] on by default
+   = note: #[warn(unstable_name_collisions)] on by default
    = warning: once this method is added to the standard library, the ambiguity may cause an error or change in behavior!
    = note: for more information, see issue #48919 <https://github.com/rust-lang/rust/issues/48919>
    = help: call with fully qualified syntax `inference_unstable_itertools::IpuItertools::ipu_flatten(...)` to keep using the current method

--- a/src/test/ui/rust-2018/edition-lint-fully-qualified-paths.fixed
+++ b/src/test/ui/rust-2018/edition-lint-fully-qualified-paths.fixed
@@ -11,7 +11,7 @@
 // run-rustfix
 
 #![feature(rust_2018_preview)]
-#![deny(absolute_path_not_starting_with_crate)]
+#![deny(absolute_paths_not_starting_with_crate)]
 
 mod foo {
     crate trait Foo {

--- a/src/test/ui/rust-2018/edition-lint-fully-qualified-paths.rs
+++ b/src/test/ui/rust-2018/edition-lint-fully-qualified-paths.rs
@@ -11,7 +11,7 @@
 // run-rustfix
 
 #![feature(rust_2018_preview)]
-#![deny(absolute_path_not_starting_with_crate)]
+#![deny(absolute_paths_not_starting_with_crate)]
 
 mod foo {
     crate trait Foo {

--- a/src/test/ui/rust-2018/edition-lint-fully-qualified-paths.stderr
+++ b/src/test/ui/rust-2018/edition-lint-fully-qualified-paths.stderr
@@ -7,8 +7,8 @@ LL |     let _: <foo::Baz as ::foo::Foo>::Bar = ();
 note: lint level defined here
   --> $DIR/edition-lint-fully-qualified-paths.rs:14:9
    |
-LL | #![deny(absolute_path_not_starting_with_crate)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(absolute_paths_not_starting_with_crate)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue TBD
 

--- a/src/test/ui/rust-2018/edition-lint-nested-empty-paths.fixed
+++ b/src/test/ui/rust-2018/edition-lint-nested-empty-paths.fixed
@@ -11,7 +11,7 @@
 // run-rustfix
 
 #![feature(rust_2018_preview)]
-#![deny(absolute_path_not_starting_with_crate)]
+#![deny(absolute_paths_not_starting_with_crate)]
 #![allow(unused_imports)]
 #![allow(dead_code)]
 

--- a/src/test/ui/rust-2018/edition-lint-nested-empty-paths.rs
+++ b/src/test/ui/rust-2018/edition-lint-nested-empty-paths.rs
@@ -11,7 +11,7 @@
 // run-rustfix
 
 #![feature(rust_2018_preview)]
-#![deny(absolute_path_not_starting_with_crate)]
+#![deny(absolute_paths_not_starting_with_crate)]
 #![allow(unused_imports)]
 #![allow(dead_code)]
 

--- a/src/test/ui/rust-2018/edition-lint-nested-empty-paths.stderr
+++ b/src/test/ui/rust-2018/edition-lint-nested-empty-paths.stderr
@@ -7,8 +7,8 @@ LL | use foo::{bar::{baz::{}}};
 note: lint level defined here
   --> $DIR/edition-lint-nested-empty-paths.rs:14:9
    |
-LL | #![deny(absolute_path_not_starting_with_crate)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(absolute_paths_not_starting_with_crate)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue TBD
 

--- a/src/test/ui/rust-2018/edition-lint-nested-paths.fixed
+++ b/src/test/ui/rust-2018/edition-lint-nested-paths.fixed
@@ -11,7 +11,7 @@
 // run-rustfix
 
 #![feature(rust_2018_preview)]
-#![deny(absolute_path_not_starting_with_crate)]
+#![deny(absolute_paths_not_starting_with_crate)]
 
 use crate::foo::{a, b};
 //~^ ERROR absolute paths must start with

--- a/src/test/ui/rust-2018/edition-lint-nested-paths.rs
+++ b/src/test/ui/rust-2018/edition-lint-nested-paths.rs
@@ -11,7 +11,7 @@
 // run-rustfix
 
 #![feature(rust_2018_preview)]
-#![deny(absolute_path_not_starting_with_crate)]
+#![deny(absolute_paths_not_starting_with_crate)]
 
 use foo::{a, b};
 //~^ ERROR absolute paths must start with

--- a/src/test/ui/rust-2018/edition-lint-nested-paths.stderr
+++ b/src/test/ui/rust-2018/edition-lint-nested-paths.stderr
@@ -7,8 +7,8 @@ LL | use foo::{a, b};
 note: lint level defined here
   --> $DIR/edition-lint-nested-paths.rs:14:9
    |
-LL | #![deny(absolute_path_not_starting_with_crate)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(absolute_paths_not_starting_with_crate)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue TBD
 

--- a/src/test/ui/rust-2018/edition-lint-paths.fixed
+++ b/src/test/ui/rust-2018/edition-lint-paths.fixed
@@ -12,7 +12,7 @@
 // run-rustfix
 
 #![feature(rust_2018_preview)]
-#![deny(absolute_path_not_starting_with_crate)]
+#![deny(absolute_paths_not_starting_with_crate)]
 #![allow(unused)]
 
 extern crate edition_lint_paths;

--- a/src/test/ui/rust-2018/edition-lint-paths.rs
+++ b/src/test/ui/rust-2018/edition-lint-paths.rs
@@ -12,7 +12,7 @@
 // run-rustfix
 
 #![feature(rust_2018_preview)]
-#![deny(absolute_path_not_starting_with_crate)]
+#![deny(absolute_paths_not_starting_with_crate)]
 #![allow(unused)]
 
 extern crate edition_lint_paths;

--- a/src/test/ui/rust-2018/edition-lint-paths.stderr
+++ b/src/test/ui/rust-2018/edition-lint-paths.stderr
@@ -7,8 +7,8 @@ LL |     use ::bar::Bar;
 note: lint level defined here
   --> $DIR/edition-lint-paths.rs:15:9
    |
-LL | #![deny(absolute_path_not_starting_with_crate)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(absolute_paths_not_starting_with_crate)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue TBD
 

--- a/src/test/ui/rust-2018/extern-crate-idiomatic.fixed
+++ b/src/test/ui/rust-2018/extern-crate-idiomatic.fixed
@@ -16,7 +16,7 @@
 // but we don't.
 
 #![feature(rust_2018_preview)]
-#![deny(absolute_path_not_starting_with_crate)]
+#![deny(absolute_paths_not_starting_with_crate)]
 
 extern crate edition_lint_paths;
 

--- a/src/test/ui/rust-2018/extern-crate-idiomatic.rs
+++ b/src/test/ui/rust-2018/extern-crate-idiomatic.rs
@@ -16,7 +16,7 @@
 // but we don't.
 
 #![feature(rust_2018_preview)]
-#![deny(absolute_path_not_starting_with_crate)]
+#![deny(absolute_paths_not_starting_with_crate)]
 
 extern crate edition_lint_paths;
 

--- a/src/test/ui/rust-2018/extern-crate-referenced-by-self-path.fixed
+++ b/src/test/ui/rust-2018/extern-crate-referenced-by-self-path.fixed
@@ -17,7 +17,7 @@
 // we can't drop the extern crate.
 
 #![feature(rust_2018_preview)]
-#![deny(absolute_path_not_starting_with_crate)]
+#![deny(absolute_paths_not_starting_with_crate)]
 
 extern crate edition_lint_paths;
 use self::edition_lint_paths::foo;

--- a/src/test/ui/rust-2018/extern-crate-referenced-by-self-path.rs
+++ b/src/test/ui/rust-2018/extern-crate-referenced-by-self-path.rs
@@ -17,7 +17,7 @@
 // we can't drop the extern crate.
 
 #![feature(rust_2018_preview)]
-#![deny(absolute_path_not_starting_with_crate)]
+#![deny(absolute_paths_not_starting_with_crate)]
 
 extern crate edition_lint_paths;
 use self::edition_lint_paths::foo;

--- a/src/test/ui/rust-2018/extern-crate-rename.fixed
+++ b/src/test/ui/rust-2018/extern-crate-rename.fixed
@@ -15,7 +15,7 @@
 // paths. We don't (and we leave the `extern crate` in place).
 
 #![feature(rust_2018_preview)]
-#![deny(absolute_path_not_starting_with_crate)]
+#![deny(absolute_paths_not_starting_with_crate)]
 
 extern crate edition_lint_paths as my_crate;
 

--- a/src/test/ui/rust-2018/extern-crate-rename.rs
+++ b/src/test/ui/rust-2018/extern-crate-rename.rs
@@ -15,7 +15,7 @@
 // paths. We don't (and we leave the `extern crate` in place).
 
 #![feature(rust_2018_preview)]
-#![deny(absolute_path_not_starting_with_crate)]
+#![deny(absolute_paths_not_starting_with_crate)]
 
 extern crate edition_lint_paths as my_crate;
 

--- a/src/test/ui/rust-2018/extern-crate-rename.stderr
+++ b/src/test/ui/rust-2018/extern-crate-rename.stderr
@@ -7,8 +7,8 @@ LL | use my_crate::foo;
 note: lint level defined here
   --> $DIR/extern-crate-rename.rs:18:9
    |
-LL | #![deny(absolute_path_not_starting_with_crate)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(absolute_paths_not_starting_with_crate)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue TBD
 

--- a/src/test/ui/rust-2018/extern-crate-submod.fixed
+++ b/src/test/ui/rust-2018/extern-crate-submod.fixed
@@ -16,7 +16,7 @@
 // place).
 
 #![feature(rust_2018_preview)]
-#![deny(absolute_path_not_starting_with_crate)]
+#![deny(absolute_paths_not_starting_with_crate)]
 
 mod m {
     // Because this extern crate does not appear at the root, we

--- a/src/test/ui/rust-2018/extern-crate-submod.rs
+++ b/src/test/ui/rust-2018/extern-crate-submod.rs
@@ -16,7 +16,7 @@
 // place).
 
 #![feature(rust_2018_preview)]
-#![deny(absolute_path_not_starting_with_crate)]
+#![deny(absolute_paths_not_starting_with_crate)]
 
 mod m {
     // Because this extern crate does not appear at the root, we

--- a/src/test/ui/rust-2018/extern-crate-submod.stderr
+++ b/src/test/ui/rust-2018/extern-crate-submod.stderr
@@ -7,8 +7,8 @@ LL | use m::edition_lint_paths::foo;
 note: lint level defined here
   --> $DIR/extern-crate-submod.rs:19:9
    |
-LL | #![deny(absolute_path_not_starting_with_crate)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(absolute_paths_not_starting_with_crate)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue TBD
 

--- a/src/test/ui/single-use-lifetime/fn-types.rs
+++ b/src/test/ui/single-use-lifetime/fn-types.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![deny(single_use_lifetime)]
+#![deny(single_use_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/single-use-lifetime/fn-types.stderr
+++ b/src/test/ui/single-use-lifetime/fn-types.stderr
@@ -7,8 +7,8 @@ LL |   a: for<'a> fn(&'a u32), //~ ERROR `'a` only used once
 note: lint level defined here
   --> $DIR/fn-types.rs:11:9
    |
-LL | #![deny(single_use_lifetime)]
-   |         ^^^^^^^^^^^^^^^^^^^
+LL | #![deny(single_use_lifetimes)]
+   |         ^^^^^^^^^^^^^^^^^^^^
 
 error[E0581]: return type references lifetime `'a`, which is not constrained by the fn input types
   --> $DIR/fn-types.rs:22:22

--- a/src/test/ui/single-use-lifetime/one-use-in-fn-argument-in-band.rs
+++ b/src/test/ui/single-use-lifetime/one-use-in-fn-argument-in-band.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #![feature(in_band_lifetimes)]
-#![deny(single_use_lifetime)]
+#![deny(single_use_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/single-use-lifetime/one-use-in-fn-argument-in-band.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-fn-argument-in-band.stderr
@@ -7,8 +7,8 @@ LL | fn a(x: &'a u32, y: &'b u32) {
 note: lint level defined here
   --> $DIR/one-use-in-fn-argument-in-band.rs:12:9
    |
-LL | #![deny(single_use_lifetime)]
-   |         ^^^^^^^^^^^^^^^^^^^
+LL | #![deny(single_use_lifetimes)]
+   |         ^^^^^^^^^^^^^^^^^^^^
 
 error: lifetime parameter `'a` only used once
   --> $DIR/one-use-in-fn-argument-in-band.rs:19:10

--- a/src/test/ui/single-use-lifetime/one-use-in-fn-argument.rs
+++ b/src/test/ui/single-use-lifetime/one-use-in-fn-argument.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![deny(single_use_lifetime)]
+#![deny(single_use_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/single-use-lifetime/one-use-in-fn-argument.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-fn-argument.stderr
@@ -7,8 +7,8 @@ LL | fn a<'a>(x: &'a u32) { //~ ERROR `'a` only used once
 note: lint level defined here
   --> $DIR/one-use-in-fn-argument.rs:11:9
    |
-LL | #![deny(single_use_lifetime)]
-   |         ^^^^^^^^^^^^^^^^^^^
+LL | #![deny(single_use_lifetimes)]
+   |         ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/single-use-lifetime/one-use-in-fn-return.rs
+++ b/src/test/ui/single-use-lifetime/one-use-in-fn-return.rs
@@ -10,7 +10,7 @@
 
 // compile-pass
 
-#![deny(single_use_lifetime)]
+#![deny(single_use_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/single-use-lifetime/one-use-in-inherent-impl-header.rs
+++ b/src/test/ui/single-use-lifetime/one-use-in-inherent-impl-header.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![deny(single_use_lifetime)]
+#![deny(single_use_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/single-use-lifetime/one-use-in-inherent-impl-header.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-inherent-impl-header.stderr
@@ -7,8 +7,8 @@ LL | impl<'f> Foo<'f> { //~ ERROR `'f` only used once
 note: lint level defined here
   --> $DIR/one-use-in-inherent-impl-header.rs:11:9
    |
-LL | #![deny(single_use_lifetime)]
-   |         ^^^^^^^^^^^^^^^^^^^
+LL | #![deny(single_use_lifetimes)]
+   |         ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/single-use-lifetime/one-use-in-inherent-method-argument.rs
+++ b/src/test/ui/single-use-lifetime/one-use-in-inherent-method-argument.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![deny(single_use_lifetime)]
+#![deny(single_use_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/single-use-lifetime/one-use-in-inherent-method-argument.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-inherent-method-argument.stderr
@@ -7,8 +7,8 @@ LL |     fn inherent_a<'a>(&self, data: &'a u32) { //~ ERROR `'a` only used once
 note: lint level defined here
   --> $DIR/one-use-in-inherent-method-argument.rs:11:9
    |
-LL | #![deny(single_use_lifetime)]
-   |         ^^^^^^^^^^^^^^^^^^^
+LL | #![deny(single_use_lifetimes)]
+   |         ^^^^^^^^^^^^^^^^^^^^
 
 error: lifetime parameter `'f` only used once
   --> $DIR/one-use-in-inherent-method-argument.rs:21:6

--- a/src/test/ui/single-use-lifetime/one-use-in-inherent-method-return.rs
+++ b/src/test/ui/single-use-lifetime/one-use-in-inherent-method-return.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![deny(single_use_lifetime)]
+#![deny(single_use_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/single-use-lifetime/one-use-in-inherent-method-return.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-inherent-method-return.stderr
@@ -7,8 +7,8 @@ LL | impl<'f> Foo<'f> { //~ ERROR `'f` only used once
 note: lint level defined here
   --> $DIR/one-use-in-inherent-method-return.rs:11:9
    |
-LL | #![deny(single_use_lifetime)]
-   |         ^^^^^^^^^^^^^^^^^^^
+LL | #![deny(single_use_lifetimes)]
+   |         ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/single-use-lifetime/one-use-in-struct.rs
+++ b/src/test/ui/single-use-lifetime/one-use-in-struct.rs
@@ -14,7 +14,7 @@
 //
 // compile-pass
 
-#![deny(single_use_lifetime)]
+#![deny(single_use_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/single-use-lifetime/one-use-in-trait-method-argument.rs
+++ b/src/test/ui/single-use-lifetime/one-use-in-trait-method-argument.rs
@@ -11,7 +11,7 @@
 // Test that we DO warn for a lifetime on an impl used only in `&self`
 // in a trait method.
 
-#![deny(single_use_lifetime)]
+#![deny(single_use_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/single-use-lifetime/one-use-in-trait-method-argument.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-trait-method-argument.stderr
@@ -7,8 +7,8 @@ LL |     fn next<'g>(&'g mut self) -> Option<Self::Item> { //~ ERROR `'g` only u
 note: lint level defined here
   --> $DIR/one-use-in-trait-method-argument.rs:14:9
    |
-LL | #![deny(single_use_lifetime)]
-   |         ^^^^^^^^^^^^^^^^^^^
+LL | #![deny(single_use_lifetimes)]
+   |         ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/single-use-lifetime/two-uses-in-fn-argument-and-return.rs
+++ b/src/test/ui/single-use-lifetime/two-uses-in-fn-argument-and-return.rs
@@ -13,7 +13,7 @@
 //
 // compile-pass
 
-#![deny(single_use_lifetime)]
+#![deny(single_use_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/single-use-lifetime/two-uses-in-fn-arguments.rs
+++ b/src/test/ui/single-use-lifetime/two-uses-in-fn-arguments.rs
@@ -13,7 +13,7 @@
 //
 // compile-pass
 
-#![deny(single_use_lifetime)]
+#![deny(single_use_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/single-use-lifetime/two-uses-in-inherent-impl-header.rs
+++ b/src/test/ui/single-use-lifetime/two-uses-in-inherent-impl-header.rs
@@ -12,7 +12,7 @@
 //
 // compile-pass
 
-#![deny(single_use_lifetime)]
+#![deny(single_use_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/single-use-lifetime/two-uses-in-inherent-method-argument-and-return.rs
+++ b/src/test/ui/single-use-lifetime/two-uses-in-inherent-method-argument-and-return.rs
@@ -11,7 +11,7 @@
 // Test that we DO NOT warn for a lifetime used twice in an impl method and
 // header.
 
-#![deny(single_use_lifetime)]
+#![deny(single_use_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/single-use-lifetime/two-uses-in-inherent-method-argument-and-return.stderr
+++ b/src/test/ui/single-use-lifetime/two-uses-in-inherent-method-argument-and-return.stderr
@@ -7,8 +7,8 @@ LL | impl<'f> Foo<'f> { //~ ERROR `'f` only used once
 note: lint level defined here
   --> $DIR/two-uses-in-inherent-method-argument-and-return.rs:14:9
    |
-LL | #![deny(single_use_lifetime)]
-   |         ^^^^^^^^^^^^^^^^^^^
+LL | #![deny(single_use_lifetimes)]
+   |         ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/single-use-lifetime/two-uses-in-trait-impl.rs
+++ b/src/test/ui/single-use-lifetime/two-uses-in-trait-impl.rs
@@ -13,7 +13,7 @@
 //
 // compile-pass
 
-#![deny(single_use_lifetime)]
+#![deny(single_use_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/single-use-lifetime/zero-uses-in-fn.rs
+++ b/src/test/ui/single-use-lifetime/zero-uses-in-fn.rs
@@ -10,7 +10,7 @@
 
 // Test that we DO warn when lifetime name is not used at all.
 
-#![deny(unused_lifetime)]
+#![deny(unused_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/single-use-lifetime/zero-uses-in-fn.stderr
+++ b/src/test/ui/single-use-lifetime/zero-uses-in-fn.stderr
@@ -7,8 +7,8 @@ LL | fn d<'a>() { } //~ ERROR `'a` never used
 note: lint level defined here
   --> $DIR/zero-uses-in-fn.rs:13:9
    |
-LL | #![deny(unused_lifetime)]
-   |         ^^^^^^^^^^^^^^^
+LL | #![deny(unused_lifetimes)]
+   |         ^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/single-use-lifetime/zero-uses-in-impl.rs
+++ b/src/test/ui/single-use-lifetime/zero-uses-in-impl.rs
@@ -10,7 +10,7 @@
 
 // Test that we DO warn when lifetime name is not used at all.
 
-#![deny(unused_lifetime)]
+#![deny(unused_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/single-use-lifetime/zero-uses-in-impl.stderr
+++ b/src/test/ui/single-use-lifetime/zero-uses-in-impl.stderr
@@ -7,8 +7,8 @@ LL | impl<'a> Foo { } //~ ERROR `'a` never used
 note: lint level defined here
   --> $DIR/zero-uses-in-impl.rs:13:9
    |
-LL | #![deny(unused_lifetime)]
-   |         ^^^^^^^^^^^^^^^
+LL | #![deny(unused_lifetimes)]
+   |         ^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/removing-extern-crate.stderr
+++ b/src/test/ui/suggestions/removing-extern-crate.stderr
@@ -9,7 +9,7 @@ note: lint level defined here
    |
 LL | #![warn(rust_2018_idioms)]
    |         ^^^^^^^^^^^^^^^^
-   = note: #[warn(unnecessary_extern_crate)] implied by #[warn(rust_2018_idioms)]
+   = note: #[warn(unnecessary_extern_crates)] implied by #[warn(rust_2018_idioms)]
 
 warning: `extern crate` is unnecessary in the new edition
   --> $DIR/removing-extern-crate.rs:20:1


### PR DESCRIPTION
We actually have an RFC from Oct 2014 specifying naming conventions for lints that is still relevant - https://github.com/rust-lang/rfcs/blob/master/text/0344-conventions-galore.md#lints.
Unfortunately, human memory doesn't work for such prolonged periods of time, so a number of recently added edition-related lints don't follow the conventions.
This PR fixes names for those lints.

Unstable lints, simply renamed:
- `unused_lifetime` -> `unused_lifetimes`
- `absolute_path_not_starting_with_crate` -> `absolute_paths_not_starting_with_crate`
- `unnecessary_extern_crate` -> `unnecessary_extern_crates`

New lints stabilized in the last couple of releases, registered as renamed (old names still work with a warning):
- `single_use_lifetime` -> `single_use_lifetimes`
- `elided_lifetime_in_path` -> `elided_lifetimes_in_paths`
- `bare_trait_object` -> `bare_trait_objects`
- `unstable_name_collision` -> `unstable_name_collisions`
- `unused_doc_comment` -> `unused_doc_comments`

NOT changed, too old to rename:
- `const_err` -> `const_errors`
- `unused_allocation` -> `unused_allocations`

NOT changed, deprecation lints, no need to rename, they are going to be removed anyway:
- `invalid_type_param_default` -> `invalid_type_param_defaults`
- `missing_fragment_specifier` -> `missing_fragment_specifiers`
- `tyvar_behind_raw_pointer` -> `tyvars_behind_raw_pointer`
- `illegal_floating_point_literal_pattern` -> `illegal_floating_point_literal_patterns`