### PR TITLE
Add Iterator::{sum_nonempty, product_nonempty}

### DIFF
--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1036,6 +1036,15 @@ fn test_iterator_sum() {
 }
 
 #[test]
+fn test_iterator_sum_nonempty() {
+    let v: &[i32] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    assert_eq!(v[..0].iter().cloned().sum_nonempty::<i32>(), None);
+    assert_eq!(v[1..2].iter().cloned().sum_nonempty::<i32>(), Some(1));
+    assert_eq!(v[1..3].iter().cloned().sum_nonempty::<i32>(), Some(3));
+    assert_eq!(v.iter().cloned().sum_nonempty::<i32>(), Some(55));
+}
+
+#[test]
 fn test_iterator_sum_result() {
     let v: &[Result<i32, ()>] = &[Ok(1), Ok(2), Ok(3), Ok(4)];
     assert_eq!(v.iter().cloned().sum::<Result<i32, _>>(), Ok(10));
@@ -1049,6 +1058,15 @@ fn test_iterator_product() {
     assert_eq!(v[..4].iter().cloned().product::<i32>(), 0);
     assert_eq!(v[1..5].iter().cloned().product::<i32>(), 24);
     assert_eq!(v[..0].iter().cloned().product::<i32>(), 1);
+}
+
+#[test]
+fn test_iterator_product_nonempty() {
+    let v: &[i32] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    assert_eq!(v[..0].iter().cloned().product_nonempty::<i32>(), None);
+    assert_eq!(v[..1].iter().cloned().product_nonempty::<i32>(), Some(0));
+    assert_eq!(v[1..3].iter().cloned().product_nonempty::<i32>(), Some(2));
+    assert_eq!(v[1..5].iter().cloned().product_nonempty::<i32>(), Some(24));
 }
 
 #[test]

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -23,6 +23,7 @@
 #![feature(flt2dec)]
 #![feature(fmt_internals)]
 #![feature(hashmap_internals)]
+#![feature(nonempty_iter_arith)]
 #![feature(pattern)]
 #![feature(range_is_empty)]
 #![feature(raw)]


### PR DESCRIPTION
This implements `{Sum<U>, Product<U>} for Option<T>` such that it returns `None` if the iter is empty.
That allows one to distinguish between an empty iter and iters that sum/multiply to their neutral element.

There's an alternative way of summing into `Option<T>`, which doesn't require a neutral starting element and therefore no `T: Sum / Product` bound. It works by taking the first element and then adding / multiplying the rest onto that, but it can't accomodate the case of different types such as `Iterator<Item = U> -> Option<T>`. This PR keeps in line with the rest of the trait impls and therefore does require `T: Sum<U>`.

This impl is for a stable trait and would therefore be insta-stable if merged.