### PR TITLE
Create mips64 soft float target

### DIFF
--- a/src/librustc_target/spec/mips64_unknown_linux_gnuabi64sf.rs
+++ b/src/librustc_target/spec/mips64_unknown_linux_gnuabi64sf.rs
@@ -1,0 +1,37 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+
+pub fn target() -> TargetResult {
+    Ok(Target {
+        llvm_target: "mips64-unknown-linux-gnuabi64".to_string(),
+        target_endian: "big".to_string(),
+        target_pointer_width: "64".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "E-m:e-i8:8:32-i16:16:32-i64:64-n32:64-S128".to_string(),
+        arch: "mips64".to_string(),
+        target_os: "linux".to_string(),
+        target_env: "gnu".to_string(),
+        target_vendor: "unknown".to_string(),
+        linker_flavor: LinkerFlavor::Gcc,
+        options: TargetOptions {
+            // NOTE(mips64r2) matches C toolchain
+            cpu: "mips64r2".to_string(),
+            features: "+mips64r2,+soft-float".to_string(),
+            max_atomic_width: Some(64),
+
+            // see #36994
+            exe_allocation_crate: None,
+
+            ..super::linux_base::opts()
+        },
+    })
+}

--- a/src/librustc_target/spec/mips64_unknown_linux_musl.rs
+++ b/src/librustc_target/spec/mips64_unknown_linux_musl.rs
@@ -1,0 +1,37 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+
+pub fn target() -> TargetResult {
+    Ok(Target {
+        llvm_target: "mips64-unknown-linux-gnuabi64".to_string(),
+        target_endian: "big".to_string(),
+        target_pointer_width: "64".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "E-m:e-i8:8:32-i16:16:32-i64:64-n32:64-S128".to_string(),
+        arch: "mips64".to_string(),
+        target_os: "linux".to_string(),
+        target_env: "musl".to_string(),
+        target_vendor: "unknown".to_string(),
+        linker_flavor: LinkerFlavor::Gcc,
+        options: TargetOptions {
+            // NOTE(mips64r2) matches C toolchain
+            cpu: "mips64r2".to_string(),
+            features: "+mips64r2".to_string(),
+            max_atomic_width: Some(64),
+
+            // see #36994
+            exe_allocation_crate: None,
+
+            ..super::linux_base::opts()
+        },
+    })
+}

--- a/src/librustc_target/spec/mips64_unknown_linux_muslsf.rs
+++ b/src/librustc_target/spec/mips64_unknown_linux_muslsf.rs
@@ -1,0 +1,37 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+
+pub fn target() -> TargetResult {
+    Ok(Target {
+        llvm_target: "mips64-unknown-linux-gnuabi64".to_string(),
+        target_endian: "big".to_string(),
+        target_pointer_width: "64".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "E-m:e-i8:8:32-i16:16:32-i64:64-n32:64-S128".to_string(),
+        arch: "mips64".to_string(),
+        target_os: "linux".to_string(),
+        target_env: "musl".to_string(),
+        target_vendor: "unknown".to_string(),
+        linker_flavor: LinkerFlavor::Gcc,
+        options: TargetOptions {
+            // NOTE(mips64r2) matches C toolchain
+            cpu: "mips64r2".to_string(),
+            features: "+mips64r2,+soft-float".to_string(),
+            max_atomic_width: Some(64),
+
+            // see #36994
+            exe_allocation_crate: None,
+
+            ..super::linux_base::opts()
+        },
+    })
+}

--- a/src/librustc_target/spec/mips64el_unknown_linux_gnuabi64sf.rs
+++ b/src/librustc_target/spec/mips64el_unknown_linux_gnuabi64sf.rs
@@ -1,0 +1,37 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+
+pub fn target() -> TargetResult {
+    Ok(Target {
+        llvm_target: "mips64el-unknown-linux-gnuabi64".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "64".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "e-m:e-i8:8:32-i16:16:32-i64:64-n32:64-S128".to_string(),
+        arch: "mips64".to_string(),
+        target_os: "linux".to_string(),
+        target_env: "gnu".to_string(),
+        target_vendor: "unknown".to_string(),
+        linker_flavor: LinkerFlavor::Gcc,
+        options: TargetOptions {
+            // NOTE(mips64r2) matches C toolchain
+            cpu: "mips64r2".to_string(),
+            features: "+mips64r2,+soft-float".to_string(),
+            max_atomic_width: Some(64),
+
+            // see #36994
+            exe_allocation_crate: None,
+
+            ..super::linux_base::opts()
+        },
+    })
+}

--- a/src/librustc_target/spec/mips64el_unknown_linux_musl.rs
+++ b/src/librustc_target/spec/mips64el_unknown_linux_musl.rs
@@ -1,0 +1,37 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+
+pub fn target() -> TargetResult {
+    Ok(Target {
+        llvm_target: "mips64el-unknown-linux-gnuabi64".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "64".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "e-m:e-i8:8:32-i16:16:32-i64:64-n32:64-S128".to_string(),
+        arch: "mips64".to_string(),
+        target_os: "linux".to_string(),
+        target_env: "musl".to_string(),
+        target_vendor: "unknown".to_string(),
+        linker_flavor: LinkerFlavor::Gcc,
+        options: TargetOptions {
+            // NOTE(mips64r2) matches C toolchain
+            cpu: "mips64r2".to_string(),
+            features: "+mips64r2".to_string(),
+            max_atomic_width: Some(64),
+
+            // see #36994
+            exe_allocation_crate: None,
+
+            ..super::linux_base::opts()
+        },
+    })
+}

--- a/src/librustc_target/spec/mips64el_unknown_linux_muslsf.rs
+++ b/src/librustc_target/spec/mips64el_unknown_linux_muslsf.rs
@@ -1,0 +1,37 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+
+pub fn target() -> TargetResult {
+    Ok(Target {
+        llvm_target: "mips64el-unknown-linux-gnuabi64".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "64".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "e-m:e-i8:8:32-i16:16:32-i64:64-n32:64-S128".to_string(),
+        arch: "mips64".to_string(),
+        target_os: "linux".to_string(),
+        target_env: "musl".to_string(),
+        target_vendor: "unknown".to_string(),
+        linker_flavor: LinkerFlavor::Gcc,
+        options: TargetOptions {
+            // NOTE(mips64r2) matches C toolchain
+            cpu: "mips64r2".to_string(),
+            features: "+mips64r2,+soft-float".to_string(),
+            max_atomic_width: Some(64),
+
+            // see #36994
+            exe_allocation_crate: None,
+
+            ..super::linux_base::opts()
+        },
+    })
+}


### PR DESCRIPTION
resolves #50890 
probably missing some intermediate step here, I'm basing this off of https://github.com/rust-lang/rust/issues/34922 but the first step seems deprecated? 