### PR TITLE
resolve: Don't add unnecessary import candidates for `prefix::{self}` imports

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -312,8 +312,8 @@ impl<'a> Resolver<'a> {
 
         self.indeterminate_imports.push(directive);
         match directive.subclass {
-            SingleImport { target, .. } => {
-                self.per_ns(|this, ns| {
+            SingleImport { target, type_ns_only, .. } => {
+                self.per_ns(|this, ns| if !type_ns_only || ns == TypeNS {
                     let mut resolution = this.resolution(current_module, target, ns).borrow_mut();
                     resolution.single_imports.add_directive(directive, this.use_extern_macros);
                 });

--- a/src/test/run-pass/auxiliary/use-macro-self.rs
+++ b/src/test/run-pass/auxiliary/use-macro-self.rs
@@ -1,0 +1,16 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub mod foobarius {}
+
+#[macro_export]
+macro_rules! foobarius {
+    () => { () }
+}

--- a/src/test/run-pass/use-macro-self.rs
+++ b/src/test/run-pass/use-macro-self.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:use-macro-self.rs
+
+#![feature(use_extern_macros)]
+
+#[macro_use]
+extern crate use_macro_self;
+
+use use_macro_self::foobarius::{self};
+
+fn main() {
+    let _: () = foobarius!(); // OK, the macro returns `()`
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/50725