### PR TITLE
Enforce stability of const fn in promoteds

### DIFF
--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -982,13 +982,8 @@ This does not pose a problem by itself because they can't be accessed directly."
                         // this doesn't come from a macro that has #[allow_internal_unstable]
                         !self.span.allows_unstable()
                     {
-                        if self.mode == Mode::Fn {
-                            // We are in a normal function
-                            // with a turned off feature gate. We can still call the function
-                            // but we can't promote it
-                            self.qualif = Qualif::NOT_CONST;
-                            debug!("unstable const fn");
-                        } else {
+                        self.qualif = Qualif::NOT_CONST;
+                        if self.mode != Mode::Fn {
                             // inside a constant environment, not having the feature gate is
                             // an error
                             let mut err = self.tcx.sess.struct_span_err(self.span,

--- a/src/test/ui/const-eval/dont_promote_unstable_const_fn.nll.stderr
+++ b/src/test/ui/const-eval/dont_promote_unstable_const_fn.nll.stderr
@@ -1,0 +1,21 @@
+error: `foo` is not yet stable as a const fn
+  --> $DIR/dont_promote_unstable_const_fn.rs:25:25
+   |
+LL | const fn bar() -> u32 { foo() } //~ ERROR `foo` is not yet stable as a const fn
+   |                         ^^^^^
+   |
+   = help: in Nightly builds, add `#![feature(foo)]` to the crate attributes to enable
+
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/dont_promote_unstable_const_fn.rs:33:26
+   |
+LL |     let x: &'static _ = &std::time::Duration::from_millis(42).subsec_millis();
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ temporary value does not live long enough
+LL | }
+   | - temporary value only lives until here
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/const-eval/dont_promote_unstable_const_fn.rs
+++ b/src/test/ui/const-eval/dont_promote_unstable_const_fn.rs
@@ -1,0 +1,34 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![unstable(feature = "humans",
+            reason = "who ever let humans program computers,
+            we're apparently really bad at it",
+            issue = "0")]
+
+#![feature(rustc_const_unstable, const_fn)]
+#![feature(staged_api)]
+
+#[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_const_unstable(feature="foo")]
+const fn foo() -> u32 { 42 }
+
+fn meh() -> u32 { 42 }
+
+const fn bar() -> u32 { foo() } //~ ERROR `foo` is not yet stable as a const fn
+
+fn a() {
+    let _: &'static u32 = &foo(); //~ ERROR does not live long enough
+}
+
+fn main() {
+    let _: &'static u32 = &meh(); //~ ERROR does not live long enough
+    let x: &'static _ = &std::time::Duration::from_millis(42).subsec_millis();
+}

--- a/src/test/ui/const-eval/dont_promote_unstable_const_fn.stderr
+++ b/src/test/ui/const-eval/dont_promote_unstable_const_fn.stderr
@@ -1,0 +1,32 @@
+error: `foo` is not yet stable as a const fn
+  --> $DIR/dont_promote_unstable_const_fn.rs:25:25
+   |
+LL | const fn bar() -> u32 { foo() } //~ ERROR `foo` is not yet stable as a const fn
+   |                         ^^^^^
+   |
+   = help: in Nightly builds, add `#![feature(foo)]` to the crate attributes to enable
+
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/dont_promote_unstable_const_fn.rs:28:28
+   |
+LL |     let _: &'static u32 = &foo(); //~ ERROR does not live long enough
+   |                            ^^^^^ temporary value does not live long enough
+LL | }
+   | - temporary value only lives until here
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/dont_promote_unstable_const_fn.rs:32:28
+   |
+LL |     let _: &'static u32 = &meh(); //~ ERROR does not live long enough
+   |                            ^^^^^ temporary value does not live long enough
+LL |     let x: &'static _ = &std::time::Duration::from_millis(42).subsec_millis();
+LL | }
+   | - temporary value only lives until here
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0597`.


### PR DESCRIPTION
r? @eddyb 

fixes #50901

what's going on here? Why do we have two promoted computation algorithms?