### PR TITLE
Issue #50636: Improve error diagnostic with missing commas after struct fields.

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5797,9 +5797,18 @@ impl<'a> Parser<'a> {
                     return Err(err);
                 }
             }
-            _ => return Err(self.span_fatal_help(self.span,
-                    &format!("expected `,`, or `}}`, found `{}`", self.this_token_to_string()),
-                    "struct fields should be separated by commas")),
+            _ => {
+                let sp = self.sess.codemap().next_point(self.prev_span);
+                let mut err = self.struct_span_err(sp, &format!("expected `,`, or `}}`, found `{}`",
+                                                                self.this_token_to_string()));
+                if self.token.is_ident() {
+                    // This is likely another field; emit the diagnostic and keep going
+                    err.span_suggestion(sp, "try adding a comma", ",".into());
+                    err.emit();
+                } else {
+                    return Err(err)
+                }
+            }
         }
         Ok(a_var)
     }

--- a/src/test/ui/struct-missing-comma.rs
+++ b/src/test/ui/struct-missing-comma.rs
@@ -1,0 +1,23 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z parse-only
+
+// Issue #50636
+
+struct S {
+    foo: u32 //~ expected `,`, or `}`, found `bar`
+    //     ~^ HELP try adding a comma: ','
+    bar: u32
+}
+
+fn main() {
+    let s = S { foo: 5, bar: 6 };
+}

--- a/src/test/ui/struct-missing-comma.stderr
+++ b/src/test/ui/struct-missing-comma.stderr
@@ -1,0 +1,8 @@
+error: expected `,`, or `}`, found `bar`
+  --> $DIR/struct-missing-comma.rs:16:13
+   |
+LL |     foo: u32 //~ expected `,`, or `}`, found `bar`
+   |             ^ help: try adding a comma: `,`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #50636 