### PR TITLE
Provide more context for what the {f32,f64}::EPSILON values represent.

### DIFF
--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -33,7 +33,11 @@ pub const MANTISSA_DIGITS: u32 = 24;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const DIGITS: u32 = 6;
 
-/// Difference between `1.0` and the next largest representable number.
+/// [Machine epsilon] value for `f32`.
+///
+/// This is the difference between `1.0` and the next largest representable number.
+///
+/// [Machine epsilon]: https://en.wikipedia.org/wiki/Machine_epsilon
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const EPSILON: f32 = 1.19209290e-07_f32;
 

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -33,7 +33,11 @@ pub const MANTISSA_DIGITS: u32 = 53;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const DIGITS: u32 = 15;
 
-/// Difference between `1.0` and the next largest representable number.
+/// [Machine epsilon] value for `f64`.
+///
+/// This is the difference between `1.0` and the next largest representable number.
+///
+/// [Machine epsilon]: https://en.wikipedia.org/wiki/Machine_epsilon
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const EPSILON: f64 = 2.2204460492503131e-16_f64;
 


### PR DESCRIPTION
Introduce the 'machine epsilon' term because if one googles 'epsilon', they might stumble upon https://en.wikipedia.org/wiki/Epsilon_numbers_(mathematics) instead of https://en.wikipedia.org/wiki/Machine_epsilon