### PR TITLE
[WIP] remove `Location::All`

### DIFF
--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -188,6 +188,11 @@ impl<'tcx> Mir<'tcx> {
         (&mut self.basic_blocks, &mut self.local_decls)
     }
 
+    pub fn terminator_location(&self, block: BasicBlock) -> Location {
+        let num_statements = self.basic_blocks[block].statements.len();
+        Location { block, statement_index: num_statements }
+    }
+
     #[inline]
     pub fn predecessors(&self) -> ReadGuard<IndexVec<BasicBlock, Vec<BasicBlock>>> {
         self.cache.predecessors(self)

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -193,6 +193,10 @@ impl<'tcx> Mir<'tcx> {
         Location { block, statement_index: num_statements }
     }
 
+    pub fn visitable(&self, location: Location) -> &dyn MirVisitable<'tcx> {
+        self.basic_blocks[location.block].visitable(location.statement_index)
+    }
+
     #[inline]
     pub fn predecessors(&self) -> ReadGuard<IndexVec<BasicBlock, Vec<BasicBlock>>> {
         self.cache.predecessors(self)

--- a/src/librustc_mir/borrow_check/location.rs
+++ b/src/librustc_mir/borrow_check/location.rs
@@ -23,7 +23,6 @@ use rustc_data_structures::indexed_vec::{Idx, IndexVec};
 /// table serves another purpose: it compresses locations from
 /// multiple words into a single u32.
 crate struct LocationTable {
-    num_points: usize,
     statements_before_block: IndexVec<BasicBlock, usize>,
 }
 
@@ -54,13 +53,8 @@ impl LocationTable {
         debug!("LocationTable: num_points={:#?}", num_points);
 
         Self {
-            num_points,
             statements_before_block,
         }
-    }
-
-    crate fn all_points(&self) -> impl Iterator<Item = LocationIndex> {
-        (0..self.num_points).map(LocationIndex::new)
     }
 
     crate fn start_index(&self, location: Location) -> LocationIndex {

--- a/src/librustc_mir/borrow_check/location.rs
+++ b/src/librustc_mir/borrow_check/location.rs
@@ -23,6 +23,7 @@ use rustc_data_structures::indexed_vec::{Idx, IndexVec};
 /// table serves another purpose: it compresses locations from
 /// multiple words into a single u32.
 crate struct LocationTable {
+    num_points: usize,
     statements_before_block: IndexVec<BasicBlock, usize>,
 }
 
@@ -53,8 +54,13 @@ impl LocationTable {
         debug!("LocationTable: num_points={:#?}", num_points);
 
         Self {
+            num_points,
             statements_before_block,
         }
+    }
+
+    crate fn all_points(&self) -> impl Iterator<Item = LocationIndex> {
+        (0..self.num_points).map(LocationIndex::new)
     }
 
     crate fn start_index(&self, location: Location) -> LocationIndex {

--- a/src/librustc_mir/borrow_check/nll/constraint_generation.rs
+++ b/src/librustc_mir/borrow_check/nll/constraint_generation.rs
@@ -276,7 +276,6 @@ impl<'cx, 'cg, 'gcx, 'tcx> ConstraintGeneration<'cx, 'cg, 'gcx, 'tcx> {
                                 span,
                                 ref_region.to_region_vid(),
                                 borrow_region.to_region_vid(),
-                                location.successor_within_block(),
                             );
 
                             if let Some(all_facts) = self.all_facts {

--- a/src/librustc_mir/borrow_check/nll/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/mod.rs
@@ -111,9 +111,14 @@ pub(in borrow_check) fn compute_regions<'cx, 'gcx, 'tcx>(
     };
 
     if let Some(all_facts) = &mut all_facts {
-        all_facts
-            .universal_region
-            .extend(universal_regions.universal_regions());
+        // Declare that each universal region is live at every point.
+        for ur in universal_regions.universal_regions() {
+            all_facts.region_live_at.extend(
+                location_table
+                    .all_points()
+                    .map(|p| (ur, p))
+            );
+        }
     }
 
     // Create the region inference context, taking ownership of the region inference

--- a/src/librustc_mir/borrow_check/nll/region_infer/dump_mir.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/dump_mir.rs
@@ -82,15 +82,13 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             let Constraint {
                 sup,
                 sub,
-                point,
                 span,
                 next: _,
             } = constraint;
             with_msg(&format!(
-                "{:?}: {:?} @ {:?} due to {:?}",
+                "{:?}: {:?} due to {:?}",
                 sup,
                 sub,
-                point,
                 span
             ))?;
         }

--- a/src/librustc_mir/borrow_check/nll/region_infer/graphviz.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/graphviz.rs
@@ -41,9 +41,6 @@ impl<'this, 'tcx> dot::Labeller<'this> for RegionInferenceContext<'tcx> {
     fn node_label(&'this self, n: &RegionVid) -> dot::LabelText<'this> {
         dot::LabelText::LabelStr(format!("{:?}", n).into_cow())
     }
-    fn edge_label(&'this self, e: &Constraint) -> dot::LabelText<'this> {
-        dot::LabelText::LabelStr(format!("{:?}", e.point).into_cow())
-    }
 }
 
 impl<'this, 'tcx> dot::GraphWalk<'this> for RegionInferenceContext<'tcx> {

--- a/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
@@ -129,9 +129,6 @@ pub struct Constraint {
     /// Region that must be outlived.
     sub: RegionVid,
 
-    /// At this location.
-    point: Location,
-
     /// Later on, we thread the constraints onto a linked list
     /// grouped by their `sub` field. So if you had:
     ///
@@ -383,15 +380,13 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         span: Span,
         sup: RegionVid,
         sub: RegionVid,
-        point: Location,
     ) {
-        debug!("add_outlives({:?}: {:?} @ {:?}", sup, sub, point);
+        debug!("add_outlives({:?}: {:?})", sup, sub);
         assert!(self.inferred_values.is_none(), "values already inferred");
         self.constraints.push(Constraint {
             span,
             sup,
             sub,
-            point,
             next: None,
         });
     }
@@ -1143,8 +1138,8 @@ impl fmt::Debug for Constraint {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(
             formatter,
-            "({:?}: {:?} @ {:?}) due to {:?}",
-            self.sup, self.sub, self.point, self.span
+            "({:?}: {:?}) due to {:?}",
+            self.sup, self.sub, self.span
         )
     }
 }

--- a/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use super::universal_regions::UniversalRegions;
+use borrow_check::nll::type_check::Locations;
 use borrow_check::nll::region_infer::values::ToElementIndex;
 use rustc::hir::def_id::DefId;
 use rustc::infer::error_reporting::nice_region_error::NiceRegionError;
@@ -185,8 +186,8 @@ pub struct TypeTest<'tcx> {
     /// The region `'x` that the type must outlive.
     pub lower_bound: RegionVid,
 
-    /// The point where the outlives relation must hold.
-    pub point: Location,
+    /// Where does this type-test have to hold?
+    pub locations: Locations,
 
     /// Where did this constraint arise?
     pub span: Span,
@@ -541,7 +542,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         for type_test in &self.type_tests {
             debug!("check_type_test: {:?}", type_test);
 
-            if self.eval_region_test(mir, type_test.point, type_test.lower_bound, &type_test.test) {
+            if self.eval_region_test(mir, type_test.lower_bound, &type_test.test) {
                 continue;
             }
 
@@ -613,9 +614,9 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         let TypeTest {
             generic_kind,
             lower_bound,
-            point: _,
             span,
             test: _,
+            locations: _,
         } = type_test;
 
         let generic_ty = generic_kind.to_ty(tcx);
@@ -798,31 +799,30 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     fn eval_region_test(
         &self,
         mir: &Mir<'tcx>,
-        point: Location,
         lower_bound: RegionVid,
         test: &RegionTest,
     ) -> bool {
         debug!(
-            "eval_region_test(point={:?}, lower_bound={:?}, test={:?})",
-            point, lower_bound, test
+            "eval_region_test(lower_bound={:?}, test={:?})",
+            lower_bound, test
         );
 
         match test {
             RegionTest::IsOutlivedByAllRegionsIn(regions) => regions
                 .iter()
-                .all(|&r| self.eval_outlives(mir, r, lower_bound, point)),
+                .all(|&r| self.eval_outlives(mir, r, lower_bound)),
 
             RegionTest::IsOutlivedByAnyRegionIn(regions) => regions
                 .iter()
-                .any(|&r| self.eval_outlives(mir, r, lower_bound, point)),
+                .any(|&r| self.eval_outlives(mir, r, lower_bound)),
 
             RegionTest::Any(tests) => tests
                 .iter()
-                .any(|test| self.eval_region_test(mir, point, lower_bound, test)),
+                .any(|test| self.eval_region_test(mir, lower_bound, test)),
 
             RegionTest::All(tests) => tests
                 .iter()
-                .all(|test| self.eval_region_test(mir, point, lower_bound, test)),
+                .all(|test| self.eval_region_test(mir, lower_bound, test)),
         }
     }
 
@@ -832,11 +832,10 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         _mir: &Mir<'tcx>,
         sup_region: RegionVid,
         sub_region: RegionVid,
-        point: Location,
     ) -> bool {
         debug!(
-            "eval_outlives({:?}: {:?} @ {:?})",
-            sup_region, sub_region, point
+            "eval_outlives({:?}: {:?})",
+            sup_region, sub_region
         );
 
         let inferred_values = self.inferred_values

--- a/src/librustc_mir/borrow_check/nll/subtype_constraint_generation.rs
+++ b/src/librustc_mir/borrow_check/nll/subtype_constraint_generation.rs
@@ -110,21 +110,17 @@ impl<'cx, 'tcx> SubtypeConstraintGenerator<'cx, 'tcx> {
                 // talk about `<=`.
                 self.regioncx.add_outlives(span, b_vid, a_vid);
 
-                // In the new analysis, all outlives relations etc
-                // "take effect" at the mid point of the statement
-                // that requires them, so ignore the `at_location`.
                 if let Some(all_facts) = all_facts {
-                    if let Some(from_location) = locations.from_location() {
+                    locations.each_point(self.mir, |location| {
+                        // In the new analysis, all outlives relations etc
+                        // "take effect" at the mid point of the
+                        // statement(s) that require them.
                         all_facts.outlives.push((
                             b_vid,
                             a_vid,
-                            self.location_table.mid_index(from_location),
+                            self.location_table.mid_index(location),
                         ));
-                    } else {
-                        for location in self.location_table.all_points() {
-                            all_facts.outlives.push((b_vid, a_vid, location));
-                        }
-                    }
+                    });
                 }
             }
 

--- a/src/librustc_mir/borrow_check/nll/subtype_constraint_generation.rs
+++ b/src/librustc_mir/borrow_check/nll/subtype_constraint_generation.rs
@@ -94,8 +94,6 @@ impl<'cx, 'tcx> SubtypeConstraintGenerator<'cx, 'tcx> {
                 .source_info(locations.from_location().unwrap_or(Location::START))
                 .span;
 
-            let at_location = locations.at_location().unwrap_or(Location::START);
-
             for constraint in constraints.keys() {
                 debug!("generate: constraint: {:?}", constraint);
                 let (a_vid, b_vid) = match constraint {
@@ -112,7 +110,7 @@ impl<'cx, 'tcx> SubtypeConstraintGenerator<'cx, 'tcx> {
                 // reverse direction, because `regioncx` talks about
                 // "outlives" (`>=`) whereas the region constraints
                 // talk about `<=`.
-                self.regioncx.add_outlives(span, b_vid, a_vid, at_location);
+                self.regioncx.add_outlives(span, b_vid, a_vid);
 
                 // In the new analysis, all outlives relations etc
                 // "take effect" at the mid point of the statement

--- a/src/librustc_mir/borrow_check/nll/subtype_constraint_generation.rs
+++ b/src/librustc_mir/borrow_check/nll/subtype_constraint_generation.rs
@@ -13,7 +13,7 @@ use borrow_check::nll::facts::AllFacts;
 use rustc::infer::region_constraints::Constraint;
 use rustc::infer::region_constraints::RegionConstraintData;
 use rustc::infer::region_constraints::{Verify, VerifyBound};
-use rustc::mir::{Location, Mir};
+use rustc::mir::Mir;
 use rustc::ty;
 use std::iter;
 use syntax::codemap::Span;
@@ -90,9 +90,7 @@ impl<'cx, 'tcx> SubtypeConstraintGenerator<'cx, 'tcx> {
                 givens,
             } = data;
 
-            let span = self.mir
-                .source_info(locations.from_location().unwrap_or(Location::START))
-                .span;
+            let span = locations.span(self.mir);
 
             for constraint in constraints.keys() {
                 debug!("generate: constraint: {:?}", constraint);

--- a/src/librustc_mir/borrow_check/nll/subtype_constraint_generation.rs
+++ b/src/librustc_mir/borrow_check/nll/subtype_constraint_generation.rs
@@ -152,14 +152,12 @@ impl<'cx, 'tcx> SubtypeConstraintGenerator<'cx, 'tcx> {
 
         let lower_bound = self.to_region_vid(verify.region);
 
-        let point = locations.at_location().unwrap_or(Location::START);
-
         let test = self.verify_bound_to_region_test(&verify.bound);
 
         TypeTest {
             generic_kind,
             lower_bound,
-            point,
+            locations: *locations,
             span,
             test,
         }

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -677,13 +677,6 @@ impl Locations {
             Locations::Pair { from_location, .. } => Some(*from_location),
         }
     }
-
-    pub fn at_location(&self) -> Option<Location> {
-        match self {
-            Locations::All => None,
-            Locations::Pair { at_location, .. } => Some(*at_location),
-        }
-    }
 }
 
 impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -671,7 +671,15 @@ pub enum Locations {
 }
 
 impl Locations {
-    pub fn from_location(&self) -> Option<Location> {
+    crate fn span(&self, mir: &Mir<'_>) -> Span {
+        let location = match self {
+            Locations::All => Location::START,
+            Locations::Pair { from_location, .. } => *from_location,
+        };
+        mir.source_info(location).span
+    }
+
+    crate fn from_location(&self) -> Option<Location> {
         match self {
             Locations::All => None,
             Locations::Pair { from_location, .. } => Some(*from_location),

--- a/src/librustc_mir/util/liveness.rs
+++ b/src/librustc_mir/util/liveness.rs
@@ -355,6 +355,18 @@ impl<'tcx> Visitor<'tcx> for DefsUsesVisitor {
             None => {}
         }
     }
+
+    fn visit_terminator(
+        &mut self,
+        block: BasicBlock,
+        terminator: &Terminator<'tcx>,
+        location: Location,
+    ) {
+        if let TerminatorKind::Return = terminator.kind {
+            self.defs_uses.add_use(RETURN_PLACE);
+        }
+        self.super_terminator(block, terminator, location);
+    }
 }
 
 fn block<'tcx>(mode: LivenessMode, b: &BasicBlockData<'tcx>, locals: usize) -> DefsUses {

--- a/src/test/ui/borrowck/mut-borrow-in-loop.nll.stderr
+++ b/src/test/ui/borrowck/mut-borrow-in-loop.nll.stderr
@@ -2,28 +2,19 @@ error[E0499]: cannot borrow `*arg` as mutable more than once at a time
   --> $DIR/mut-borrow-in-loop.rs:20:25
    |
 LL |             (self.func)(arg) //~ ERROR cannot borrow
-   |             ------------^^^-
-   |             |           |
-   |             |           mutable borrow starts here in previous iteration of loop
-   |             borrow later used here
+   |                         ^^^ mutable borrow starts here in previous iteration of loop
 
 error[E0499]: cannot borrow `*arg` as mutable more than once at a time
   --> $DIR/mut-borrow-in-loop.rs:26:25
    |
 LL |             (self.func)(arg) //~ ERROR cannot borrow
-   |             ------------^^^-
-   |             |           |
-   |             |           mutable borrow starts here in previous iteration of loop
-   |             borrow later used here
+   |                         ^^^ mutable borrow starts here in previous iteration of loop
 
 error[E0499]: cannot borrow `*arg` as mutable more than once at a time
   --> $DIR/mut-borrow-in-loop.rs:33:25
    |
 LL |             (self.func)(arg) //~ ERROR cannot borrow
-   |             ------------^^^-
-   |             |           |
-   |             |           mutable borrow starts here in previous iteration of loop
-   |             borrow later used here
+   |                         ^^^ mutable borrow starts here in previous iteration of loop
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issue-46471.stderr
+++ b/src/test/ui/issue-46471.stderr
@@ -17,8 +17,6 @@ LL |     &x
 ...
 LL | }
    | - borrowed value only lives until here
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issue-46472.stderr
+++ b/src/test/ui/issue-46472.stderr
@@ -21,12 +21,6 @@ LL |     &mut 4
 ...
 LL | }
    | - temporary value only lives until here
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 13:1...
-  --> $DIR/issue-46472.rs:13:1
-   |
-LL | fn bar<'a>() -> &'a mut u32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issue-46983.rs
+++ b/src/test/ui/issue-46983.rs
@@ -11,8 +11,8 @@
 #![feature(nll)]
 
 fn foo(x: &u32) -> &'static u32 {
-    &*x
     //~^ ERROR explicit lifetime required in the type of `x` [E0621]
+    &*x
 }
 
 fn main() {}

--- a/src/test/ui/issue-46983.stderr
+++ b/src/test/ui/issue-46983.stderr
@@ -1,10 +1,14 @@
 error[E0621]: explicit lifetime required in the type of `x`
-  --> $DIR/issue-46983.rs:14:5
+  --> $DIR/issue-46983.rs:13:1
    |
-LL | fn foo(x: &u32) -> &'static u32 {
-   |        - consider changing the type of `x` to `&'static u32`
-LL |     &*x
-   |     ^^^ lifetime `'static` required
+LL |   fn foo(x: &u32) -> &'static u32 {
+   |   ^      - consider changing the type of `x` to `&'static u32`
+   |  _|
+   | |
+LL | |     //~^ ERROR explicit lifetime required in the type of `x` [E0621]
+LL | |     &*x
+LL | | }
+   | |_^ lifetime `'static` required
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/borrowed-universal-error-2.stderr
+++ b/src/test/ui/nll/borrowed-universal-error-2.stderr
@@ -6,12 +6,6 @@ LL |     &v
 LL |     //~^ ERROR `v` does not live long enough [E0597]
 LL | }
    | - borrowed value only lives until here
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 14:1...
-  --> $DIR/borrowed-universal-error-2.rs:14:1
-   |
-LL | fn foo<'a>(x: &'a (u32,)) -> &'a u32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-requirements/region-lbr-anon-does-not-outlive-static.rs
+++ b/src/test/ui/nll/closure-requirements/region-lbr-anon-does-not-outlive-static.rs
@@ -16,9 +16,9 @@
 // compile-flags:-Zborrowck=mir -Zverbose
 
 fn foo(x: &u32) -> &'static u32 {
+        //~^ ERROR explicit lifetime required in the type of `x`
     &*x
         //~^ WARN not reporting region error due to nll
-        //~| ERROR explicit lifetime required in the type of `x`
 }
 
 fn main() { }

--- a/src/test/ui/nll/closure-requirements/region-lbr-anon-does-not-outlive-static.stderr
+++ b/src/test/ui/nll/closure-requirements/region-lbr-anon-does-not-outlive-static.stderr
@@ -1,16 +1,21 @@
 warning: not reporting region error due to nll
-  --> $DIR/region-lbr-anon-does-not-outlive-static.rs:19:5
+  --> $DIR/region-lbr-anon-does-not-outlive-static.rs:20:5
    |
 LL |     &*x
    |     ^^^
 
 error[E0621]: explicit lifetime required in the type of `x`
-  --> $DIR/region-lbr-anon-does-not-outlive-static.rs:19:5
+  --> $DIR/region-lbr-anon-does-not-outlive-static.rs:18:1
    |
-LL | fn foo(x: &u32) -> &'static u32 {
-   |        - consider changing the type of `x` to `&ReStatic u32`
-LL |     &*x
-   |     ^^^ lifetime `ReStatic` required
+LL |   fn foo(x: &u32) -> &'static u32 {
+   |   ^      - consider changing the type of `x` to `&ReStatic u32`
+   |  _|
+   | |
+LL | |         //~^ ERROR explicit lifetime required in the type of `x`
+LL | |     &*x
+LL | |         //~^ WARN not reporting region error due to nll
+LL | | }
+   | |_^ lifetime `ReStatic` required
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-requirements/region-lbr-named-does-not-outlive-static.rs
+++ b/src/test/ui/nll/closure-requirements/region-lbr-named-does-not-outlive-static.rs
@@ -16,9 +16,9 @@
 // compile-flags:-Zborrowck=mir -Zverbose
 
 fn foo<'a>(x: &'a u32) -> &'static u32 {
+        //~^ ERROR does not outlive free region
     &*x
         //~^ WARN not reporting region error due to nll
-        //~| ERROR does not outlive free region
 }
 
 fn main() { }

--- a/src/test/ui/nll/closure-requirements/region-lbr-named-does-not-outlive-static.stderr
+++ b/src/test/ui/nll/closure-requirements/region-lbr-named-does-not-outlive-static.stderr
@@ -1,14 +1,18 @@
 warning: not reporting region error due to nll
-  --> $DIR/region-lbr-named-does-not-outlive-static.rs:19:5
+  --> $DIR/region-lbr-named-does-not-outlive-static.rs:20:5
    |
 LL |     &*x
    |     ^^^
 
 error: free region `ReFree(DefId(0/0:3 ~ region_lbr_named_does_not_outlive_static[317d]::foo[0]), BrNamed(crate0:DefIndex(1:9), 'a))` does not outlive free region `ReStatic`
-  --> $DIR/region-lbr-named-does-not-outlive-static.rs:19:5
+  --> $DIR/region-lbr-named-does-not-outlive-static.rs:18:1
    |
-LL |     &*x
-   |     ^^^
+LL | / fn foo<'a>(x: &'a u32) -> &'static u32 {
+LL | |         //~^ ERROR does not outlive free region
+LL | |     &*x
+LL | |         //~^ WARN not reporting region error due to nll
+LL | | }
+   | |_^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-requirements/region-lbr1-does-not-outlive-ebr2.rs
+++ b/src/test/ui/nll/closure-requirements/region-lbr1-does-not-outlive-ebr2.rs
@@ -16,9 +16,9 @@
 // compile-flags:-Zborrowck=mir -Zverbose
 
 fn foo<'a, 'b>(x: &'a u32, y: &'b u32) -> &'b u32 {
+        //~^ ERROR lifetime mismatch
     &*x
         //~^ WARN not reporting region error due to nll
-        //~| ERROR lifetime mismatch
 }
 
 fn main() { }

--- a/src/test/ui/nll/closure-requirements/region-lbr1-does-not-outlive-ebr2.stderr
+++ b/src/test/ui/nll/closure-requirements/region-lbr1-does-not-outlive-ebr2.stderr
@@ -1,18 +1,22 @@
 warning: not reporting region error due to nll
-  --> $DIR/region-lbr1-does-not-outlive-ebr2.rs:19:5
+  --> $DIR/region-lbr1-does-not-outlive-ebr2.rs:20:5
    |
 LL |     &*x
    |     ^^^
 
 error[E0623]: lifetime mismatch
-  --> $DIR/region-lbr1-does-not-outlive-ebr2.rs:19:5
+  --> $DIR/region-lbr1-does-not-outlive-ebr2.rs:18:1
    |
-LL | fn foo<'a, 'b>(x: &'a u32, y: &'b u32) -> &'b u32 {
-   |                   -------                 -------
-   |                   |
-   |                   this parameter and the return type are declared with different lifetimes...
-LL |     &*x
-   |     ^^^ ...but data from `x` is returned here
+LL |   fn foo<'a, 'b>(x: &'a u32, y: &'b u32) -> &'b u32 {
+   |   ^                 -------                 -------
+   |   |                 |
+   |  _|                 this parameter and the return type are declared with different lifetimes...
+   | |
+LL | |         //~^ ERROR lifetime mismatch
+LL | |     &*x
+LL | |         //~^ WARN not reporting region error due to nll
+LL | | }
+   | |_^ ...but data from `x` is returned here
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-requirements/return-wrong-bound-region.stderr
+++ b/src/test/ui/nll/closure-requirements/return-wrong-bound-region.stderr
@@ -5,10 +5,10 @@ LL |     expect_sig(|a, b| b); // ought to return `a`
    |                       ^
 
 error: free region `ReFree(DefId(0/1:9 ~ return_wrong_bound_region[317d]::test[0]::{{closure}}[0]), BrAnon(2))` does not outlive free region `ReFree(DefId(0/1:9 ~ return_wrong_bound_region[317d]::test[0]::{{closure}}[0]), BrAnon(1))`
-  --> $DIR/return-wrong-bound-region.rs:21:23
+  --> $DIR/return-wrong-bound-region.rs:21:16
    |
 LL |     expect_sig(|a, b| b); // ought to return `a`
-   |                       ^
+   |                ^^^^^^^^
 
 note: No external requirements
   --> $DIR/return-wrong-bound-region.rs:21:16

--- a/src/test/ui/nll/guarantor-issue-46974.rs
+++ b/src/test/ui/nll/guarantor-issue-46974.rs
@@ -20,9 +20,9 @@ fn foo(s: &mut (i32,)) -> i32 {
     *x
 }
 
-fn bar(s: &Box<(i32,)>) -> &'static i32 {
+fn bar(s: &Box<(i32,)>) -> &'static i32 { //~ ERROR explicit lifetime required
     // FIXME(#46983): error message should be better
-    &s.0 //~ ERROR explicit lifetime required in the type of `s` [E0621]
+    &s.0
 }
 
 fn main() {

--- a/src/test/ui/nll/guarantor-issue-46974.stderr
+++ b/src/test/ui/nll/guarantor-issue-46974.stderr
@@ -10,13 +10,16 @@ LL |     *x
    |     -- borrow later used here
 
 error[E0621]: explicit lifetime required in the type of `s`
-  --> $DIR/guarantor-issue-46974.rs:25:5
+  --> $DIR/guarantor-issue-46974.rs:23:1
    |
-LL | fn bar(s: &Box<(i32,)>) -> &'static i32 {
-   |        - consider changing the type of `s` to `&'static std::boxed::Box<(i32,)>`
-LL |     // FIXME(#46983): error message should be better
-LL |     &s.0 //~ ERROR explicit lifetime required in the type of `s` [E0621]
-   |     ^^^^ lifetime `'static` required
+LL |   fn bar(s: &Box<(i32,)>) -> &'static i32 { //~ ERROR explicit lifetime required
+   |   ^      - consider changing the type of `s` to `&'static std::boxed::Box<(i32,)>`
+   |  _|
+   | |
+LL | |     // FIXME(#46983): error message should be better
+LL | |     &s.0
+LL | | }
+   | |_^ lifetime `'static` required
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/issue-47470.stderr
+++ b/src/test/ui/nll/issue-47470.stderr
@@ -5,12 +5,6 @@ LL |         &local //~ ERROR `local` does not live long enough
    |         ^^^^^^ borrowed value does not live long enough
 LL |     }
    |     - borrowed value only lives until here
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the impl at 23:1...
-  --> $DIR/issue-47470.rs:23:1
-   |
-LL | impl<'a> Bar for Foo<'a> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-48238.stderr
+++ b/src/test/ui/nll/issue-48238.stderr
@@ -1,8 +1,8 @@
 error: free region `` does not outlive free region `'_#1r`
-  --> $DIR/issue-48238.rs:21:21
+  --> $DIR/issue-48238.rs:21:5
    |
 LL |     move || use_val(&orig); //~ ERROR free region `` does not outlive free region `'_#1r`
-   |                     ^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/ty-outlives/impl-trait-captures.rs
+++ b/src/test/ui/nll/ty-outlives/impl-trait-captures.rs
@@ -18,9 +18,9 @@ trait Foo<'a> {
 impl<'a, T> Foo<'a> for T { }
 
 fn foo<'a, T>(x: &T) -> impl Foo<'a> {
+        //~^ ERROR explicit lifetime required in the type of `x` [E0621]
     x
         //~^ WARNING not reporting region error due to nll
-        //~| ERROR explicit lifetime required in the type of `x` [E0621]
 }
 
 fn main() {}

--- a/src/test/ui/nll/ty-outlives/impl-trait-captures.stderr
+++ b/src/test/ui/nll/ty-outlives/impl-trait-captures.stderr
@@ -1,16 +1,21 @@
 warning: not reporting region error due to nll
-  --> $DIR/impl-trait-captures.rs:21:5
+  --> $DIR/impl-trait-captures.rs:22:5
    |
 LL |     x
    |     ^
 
 error[E0621]: explicit lifetime required in the type of `x`
-  --> $DIR/impl-trait-captures.rs:21:5
+  --> $DIR/impl-trait-captures.rs:20:1
    |
-LL | fn foo<'a, T>(x: &T) -> impl Foo<'a> {
-   |               - consider changing the type of `x` to `&ReEarlyBound(0, 'a) T`
-LL |     x
-   |     ^ lifetime `ReEarlyBound(0, 'a)` required
+LL |   fn foo<'a, T>(x: &T) -> impl Foo<'a> {
+   |   ^             - consider changing the type of `x` to `&ReEarlyBound(0, 'a) T`
+   |  _|
+   | |
+LL | |         //~^ ERROR explicit lifetime required in the type of `x` [E0621]
+LL | |     x
+LL | |         //~^ WARNING not reporting region error due to nll
+LL | | }
+   | |_^ lifetime `ReEarlyBound(0, 'a)` required
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/ty-outlives/impl-trait-outlives.rs
+++ b/src/test/ui/nll/ty-outlives/impl-trait-outlives.rs
@@ -16,11 +16,11 @@ use std::fmt::Debug;
 
 fn no_region<'a, T>(x: Box<T>) -> impl Debug + 'a
     //~^ WARNING not reporting region error due to nll
+    //~| ERROR the parameter type `T` may not live long enough [E0309]
 where
     T: Debug,
 {
     x
-    //~^ ERROR the parameter type `T` may not live long enough [E0309]
 }
 
 fn correct_region<'a, T>(x: Box<T>) -> impl Debug + 'a
@@ -32,11 +32,11 @@ where
 
 fn wrong_region<'a, 'b, T>(x: Box<T>) -> impl Debug + 'a
     //~^ WARNING not reporting region error due to nll
+    //~| ERROR the parameter type `T` may not live long enough [E0309]
 where
     T: 'b + Debug,
 {
     x
-    //~^ ERROR the parameter type `T` may not live long enough [E0309]
 }
 
 fn outlives_region<'a, 'b, T>(x: Box<T>) -> impl Debug + 'a

--- a/src/test/ui/nll/ty-outlives/impl-trait-outlives.stderr
+++ b/src/test/ui/nll/ty-outlives/impl-trait-outlives.stderr
@@ -11,18 +11,30 @@ LL | fn wrong_region<'a, 'b, T>(x: Box<T>) -> impl Debug + 'a
    |                                          ^^^^^^^^^^^^^^^
 
 error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/impl-trait-outlives.rs:22:5
+  --> $DIR/impl-trait-outlives.rs:17:1
    |
-LL |     x
-   |     ^
+LL | / fn no_region<'a, T>(x: Box<T>) -> impl Debug + 'a
+LL | |     //~^ WARNING not reporting region error due to nll
+LL | |     //~| ERROR the parameter type `T` may not live long enough [E0309]
+LL | | where
+...  |
+LL | |     x
+LL | | }
+   | |_^
    |
    = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
 
 error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/impl-trait-outlives.rs:38:5
+  --> $DIR/impl-trait-outlives.rs:33:1
    |
-LL |     x
-   |     ^
+LL | / fn wrong_region<'a, 'b, T>(x: Box<T>) -> impl Debug + 'a
+LL | |     //~^ WARNING not reporting region error due to nll
+LL | |     //~| ERROR the parameter type `T` may not live long enough [E0309]
+LL | | where
+...  |
+LL | |     x
+LL | | }
+   | |_^
    |
    = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
 


### PR DESCRIPTION
When adding the facts for the new analysis, I added this idea of a `Locations::All` which enforces an outlives relation at **all** points in the CFG. This was kind of a hack to deal with a problem in the return slot `_0`. What would happen is this. We would unify the type of `_0` with the return type from the signature at the **entry point** of the function. Then later, we would write to `_0`:

```
...
_0 = ...
RETURN
```

This means that `_0` — which is otherwise treated like a regular local variable — would be **dead** at the entry point. In the existing analysis, in part because of its imprecision, this still works out ok, but in the new analysis it did not: in effect, the type of `_0` was severed from the signature. So the hack I added basically re-equates the type of `_0` (and all parameters) with the signature at all points in the CFG. But this winds up adding a *ton* of redundant outlives relations (hence https://github.com/rust-lang-nursery/polonius/issues/24).

So now I am taking a different approach. I equate the return type with the type from the signature **only at the return location**. This has the same soundness effect but without a hacky notion like `Location::All`. In the case of yields, I equate at all points. The argument types are equated on function entry.

I think this is the right general direction; we may want to think about the use of liveness in general, as it does mean that something like this will type-check:

```rust
fn foo(mut x: &'static u32) {
    let p = 22;
    x = &p; // here the old value of `x` is dead hence the region takes on a new, shorter value
    println!("x = {}", x);
}
```

This might seem surprising, since the type of `x` is declared as `&'static u32`, but `&p` cannot live for `'static` lifetime. But it works because `x` is dead at the point `x = &p` and hence it effectively gets a "fresh set of regions" from its initial value.

I think we can address this concern in other ways, though, and not via the `Locations::All` hack (e.g., perhaps we should not use *liveness* to decide when regions in local variable types go dead, but rather going out of scope?). But anyway I'd rather we focus on that question in a separate PR.

I'm marking this PR as WIP, because IIRC it still had a few problems in travis, but I wanted to get it posted for feedback purposes.

r? @pnkfelix 
cc @rust-lang/wg-compiler-nll 