### PR TITLE
rustdoc: set tab width in rust source blocks

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1010,6 +1010,8 @@ span.since {
 
 pre.rust {
 	position: relative;
+	tab-width: 4;
+	-moz-tab-width: 4;
 }
 
 .search-failed {


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/issues/49155 (fixes it?)

This sets the tab width ([in supported browsers](https://developer.mozilla.org/en-US/docs/Web/CSS/tab-size)) in Rust source blocks to 4 spaces wide (instead of the default 8), to correspond with the style guidelines.