### PR TITLE
rustc_codegen_llvm: remove some debuginfo cruft.

### DIFF
--- a/src/librustc_codegen_llvm/mir/mod.rs
+++ b/src/librustc_codegen_llvm/mir/mod.rs
@@ -634,7 +634,7 @@ fn arg_local_refs<'a, 'tcx>(bx: &Builder<'a, 'tcx>,
                     ty,
                     scope,
                     variable_access,
-                    VariableKind::CapturedVariable,
+                    VariableKind::LocalVariable,
                     DUMMY_SP
                 );
             }


### PR DESCRIPTION
(The second commit passes tests locally but might not on older LLVM versions)

r? @nikomatsakis 