### PR TITLE
Add the 2018 edition of the book to doc.rust-lang.org

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -272,6 +272,12 @@ impl Step for TheBook {
             name: INTERNER.intern_string(format!("{}/second-edition", name)),
         });
 
+        // build book 2018 edition
+        builder.ensure(Rustbook {
+            target,
+            name: INTERNER.intern_string(format!("{}/2018-edition", name)),
+        });
+
         // build the version info page and CSS
         builder.ensure(Standalone {
             compiler,


### PR DESCRIPTION
The second edition of the book is on its way to the printers, and as such, is frozen. We've forked off the 2018 edition to add new stuff to; this PR now builds it so that people can read it on doc.rust-lang.org.