### PR TITLE
rust-gdb: work around the re-used -d argument in cgdb

### DIFF
--- a/src/etc/rust-gdb
+++ b/src/etc/rust-gdb
@@ -21,6 +21,6 @@ GDB_PYTHON_MODULE_DIRECTORY="$RUSTC_SYSROOT/lib/rustlib/etc"
 # different/specific command (defaults to `gdb`).
 RUST_GDB="${RUST_GDB:-gdb}"
 PYTHONPATH="$PYTHONPATH:$GDB_PYTHON_MODULE_DIRECTORY" ${RUST_GDB} \
-  -d "$GDB_PYTHON_MODULE_DIRECTORY" \
+  --directory="$GDB_PYTHON_MODULE_DIRECTORY" \
   -iex "add-auto-load-safe-path $GDB_PYTHON_MODULE_DIRECTORY" \
   "$@"


### PR DESCRIPTION
Use --directory= to pass $GDB_PYTHON_MODULE_DIRECTORY instead of -d, because [cgdb](https://github.com/cgdb/cgdb) reuses '-d' to select a debugger, whereas the long option works with both gdb and cgdb.