### PR TITLE
Micro-optimization on PR#50697

### DIFF
--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -1853,6 +1853,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                     for index in ii {
                         if flow_state.ever_inits.contains(index) {
                             self.used_mut.insert(*local);
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
We should stop iterating through the indices in the `init_path_map` once we've already found a match for the local.

r? @nikomatsakis or @pnkfelix 