### PR TITLE
Right-size the `VecDeque` in `coerce_unsized`.

### DIFF
--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -537,8 +537,9 @@ impl<'f, 'gcx, 'tcx> Coerce<'f, 'gcx, 'tcx> {
 
         let mut selcx = traits::SelectionContext::new(self);
 
-        // Use a FIFO queue for this custom fulfillment procedure.
-        let mut queue = VecDeque::new();
+        // Use a FIFO queue for this custom fulfillment procedure. (The maximum
+        // length is almost always 1.)
+        let mut queue = VecDeque::with_capacity(1);
 
         // Create an obligation for `Source: CoerceUnsized<Target>`.
         let cause = ObligationCause::misc(self.cause.span, self.body_id);


### PR DESCRIPTION
The default capacity of a VecDeque is 8, which is excessive here. In a
"base incremental" check build of rustc-perf's tuple-stress benchmark,
this decreases total heap allocation by 26%. I couldn't see a clear
speedup, but it can't hurt.