### PR TITLE
Rollup of 15 pull requests

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -272,6 +272,12 @@ impl Step for TheBook {
             name: INTERNER.intern_string(format!("{}/second-edition", name)),
         });
 
+        // build book 2018 edition
+        builder.ensure(Rustbook {
+            target,
+            name: INTERNER.intern_string(format!("{}/2018-edition", name)),
+        });
+
         // build the version info page and CSS
         builder.ensure(Standalone {
             compiler,

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -592,12 +592,20 @@ impl Build {
             Path::new(llvm_bindir.trim()).join(exe("FileCheck", &*target))
         } else {
             let base = self.llvm_out(self.config.build).join("build");
-            let exe = exe("FileCheck", &*target);
-            if !self.config.ninja && self.config.build.contains("msvc") {
-                base.join("Release/bin").join(exe)
+            let base = if !self.config.ninja && self.config.build.contains("msvc") {
+                if self.config.llvm_optimize {
+                    if self.config.llvm_release_debuginfo {
+                        base.join("RelWithDebInfo")
+                    } else {
+                        base.join("Release")
+                    }
+                } else {
+                    base.join("Debug")
+                }
             } else {
-                base.join("bin").join(exe)
-            }
+                base
+            };
+            base.join("bin").join(exe("FileCheck", &*target))
         }
     }
 

--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -119,8 +119,8 @@ pub use core::slice::{SplitN, RSplitN, SplitNMut, RSplitNMut};
 pub use core::slice::{RSplit, RSplitMut};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{from_raw_parts, from_raw_parts_mut};
-#[unstable(feature = "from_ref", issue = "45703")]
-pub use core::slice::{from_ref, from_ref_mut};
+#[stable(feature = "from_ref", since = "1.28.0")]
+pub use core::slice::{from_ref, from_mut};
 #[unstable(feature = "slice_get_slice", issue = "35729")]
 pub use core::slice::SliceIndex;
 #[unstable(feature = "exact_chunks", issue = "47115")]

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1256,7 +1256,7 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for RefMut<'a, T> {
 /// To assist with proper design, the following scenarios are explicitly declared legal
 /// for single-threaded code:
 ///
-/// 1. A `&T` reference can be released to safe code and there it can co-exit with other `&T`
+/// 1. A `&T` reference can be released to safe code and there it can co-exist with other `&T`
 /// references, but not with a `&mut T`
 ///
 /// 2. A `&mut T` reference may be released to safe code, provided neither other `&mut T` nor `&T`

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -119,6 +119,9 @@
 #![feature(powerpc_target_feature)]
 #![feature(mips_target_feature)]
 #![feature(aarch64_target_feature)]
+#![feature(const_slice_len)]
+#![feature(const_str_as_bytes)]
+#![feature(const_str_len)]
 
 #[prelude_import]
 #[allow(unused)]

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -3874,7 +3874,7 @@ pub unsafe fn from_raw_parts_mut<'a, T>(p: *mut T, len: usize) -> &'a mut [T] {
 }
 
 /// Converts a reference to T into a slice of length 1 (without copying).
-#[unstable(feature = "from_ref", issue = "45703")]
+#[stable(feature = "from_ref", since = "1.28.0")]
 pub fn from_ref<T>(s: &T) -> &[T] {
     unsafe {
         from_raw_parts(s, 1)
@@ -3882,8 +3882,8 @@ pub fn from_ref<T>(s: &T) -> &[T] {
 }
 
 /// Converts a reference to T into a slice of length 1 (without copying).
-#[unstable(feature = "from_ref", issue = "45703")]
-pub fn from_ref_mut<T>(s: &mut T) -> &mut [T] {
+#[stable(feature = "from_ref", since = "1.28.0")]
+pub fn from_mut<T>(s: &mut T) -> &mut [T] {
     unsafe {
         from_raw_parts_mut(s, 1)
     }

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -2166,7 +2166,8 @@ impl str {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    pub fn len(&self) -> usize {
+    #[rustc_const_unstable(feature = "const_str_len")]
+    pub const fn len(&self) -> usize {
         self.as_bytes().len()
     }
 
@@ -2185,7 +2186,8 @@ impl str {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn is_empty(&self) -> bool {
+    #[rustc_const_unstable(feature = "const_str_len")]
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
@@ -2242,8 +2244,15 @@ impl str {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline(always)]
-    pub fn as_bytes(&self) -> &[u8] {
-        unsafe { &*(self as *const str as *const [u8]) }
+    #[rustc_const_unstable(feature="const_str_as_bytes")]
+    pub const fn as_bytes(&self) -> &[u8] {
+        unsafe {
+            union Slices<'a> {
+                str: &'a str,
+                slice: &'a [u8],
+            }
+            Slices { str: self }.slice
+        }
     }
 
     /// Converts a mutable string slice to a mutable byte slice. To convert the
@@ -2303,7 +2312,8 @@ impl str {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    pub fn as_ptr(&self) -> *const u8 {
+    #[rustc_const_unstable(feature = "const_str_as_ptr")]
+    pub const fn as_ptr(&self) -> *const u8 {
         self as *const str as *const u8
     }
 

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -948,7 +948,7 @@ impl<'tcx> TerminatorKind<'tcx> {
             Drop { target: ref mut t, unwind: Some(ref mut u), .. } |
             Assert { target: ref mut t, cleanup: Some(ref mut u), .. } |
             FalseUnwind { real_target: ref mut t, unwind: Some(ref mut u) } => {
-                Some(t).into_iter().chain(slice::from_ref_mut(u))
+                Some(t).into_iter().chain(slice::from_mut(u))
             }
             SwitchInt { ref mut targets, .. } => {
                 None.into_iter().chain(&mut targets[..])

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -3356,13 +3356,28 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
                     predicate: predicate.value
                 }))
         }).collect();
+
         // We are performing deduplication here to avoid exponential blowups
         // (#38528) from happening, but the real cause of the duplication is
         // unknown. What we know is that the deduplication avoids exponential
-        // amount of predicates being propogated when processing deeply nested
+        // amount of predicates being propagated when processing deeply nested
         // types.
-        let mut seen = FxHashSet();
-        predicates.retain(|i| seen.insert(i.clone()));
+        //
+        // This code is hot enough that it's worth avoiding the allocation
+        // required for the FxHashSet when possible. Special-casing lengths 0,
+        // 1 and 2 covers roughly 75--80% of the cases.
+        if predicates.len() <= 1 {
+            // No possibility of duplicates.
+        } else if predicates.len() == 2 {
+            // Only two elements. Drop the second if they are equal.
+            if predicates[0] == predicates[1] {
+                predicates.truncate(1);
+            }
+        } else {
+            // Three or more elements. Use a general deduplication process.
+            let mut seen = FxHashSet();
+            predicates.retain(|i| seen.insert(i.clone()));
+        }
         self.infcx().plug_leaks(skol_map, snapshot, predicates)
     }
 }

--- a/src/librustc/ty/maps/plumbing.rs
+++ b/src/librustc/ty/maps/plumbing.rs
@@ -105,6 +105,10 @@ impl<'a, 'tcx, Q: QueryDescription<'tcx>> JobOwner<'a, 'tcx, Q> {
     /// start executing the query, or it returns with the result of the query.
     /// If the query is executing elsewhere, this will wait for it.
     /// If the query panicked, this will silently panic.
+    ///
+    /// This function is inlined because that results in a noticeable speedup
+    /// for some compile-time benchmarks.
+    #[inline(always)]
     pub(super) fn try_get(
         tcx: TyCtxt<'a, 'tcx, '_>,
         span: Span,

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -1853,6 +1853,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                     for index in ii {
                         if flow_state.ever_inits.contains(index) {
                             self.used_mut.insert(*local);
+                            break;
                         }
                     }
                 }

--- a/src/librustc_passes/loops.rs
+++ b/src/librustc_passes/loops.rs
@@ -82,7 +82,8 @@ impl<'a, 'hir> Visitor<'hir> for CheckLoopVisitor<'a, 'hir> {
             hir::ExprLoop(ref b, _, source) => {
                 self.with_context(Loop(LoopKind::Loop(source)), |v| v.visit_block(&b));
             }
-            hir::ExprClosure(.., b, _, _) => {
+            hir::ExprClosure(_, ref function_decl, b, _, _) => {
+                self.visit_fn_decl(&function_decl);
                 self.with_context(Closure, |v| v.visit_nested_body(b));
             }
             hir::ExprBlock(ref b, Some(_label)) => {

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -537,8 +537,9 @@ impl<'f, 'gcx, 'tcx> Coerce<'f, 'gcx, 'tcx> {
 
         let mut selcx = traits::SelectionContext::new(self);
 
-        // Use a FIFO queue for this custom fulfillment procedure.
-        let mut queue = VecDeque::new();
+        // Use a FIFO queue for this custom fulfillment procedure. (The maximum
+        // length is almost always 1.)
+        let mut queue = VecDeque::with_capacity(1);
 
         // Create an obligation for `Source: CoerceUnsized<Target>`.
         let cause = ObligationCause::misc(self.cause.span, self.body_id);

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1010,6 +1010,8 @@ span.since {
 
 pre.rust {
 	position: relative;
+	tab-width: 4;
+	-moz-tab-width: 4;
 }
 
 .search-failed {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5797,9 +5797,18 @@ impl<'a> Parser<'a> {
                     return Err(err);
                 }
             }
-            _ => return Err(self.span_fatal_help(self.span,
-                    &format!("expected `,`, or `}}`, found `{}`", self.this_token_to_string()),
-                    "struct fields should be separated by commas")),
+            _ => {
+                let sp = self.sess.codemap().next_point(self.prev_span);
+                let mut err = self.struct_span_err(sp, &format!("expected `,`, or `}}`, found `{}`",
+                                                                self.this_token_to_string()));
+                if self.token.is_ident() {
+                    // This is likely another field; emit the diagnostic and keep going
+                    err.span_suggestion(sp, "try adding a comma", ",".into());
+                    err.emit();
+                } else {
+                    return Err(err)
+                }
+            }
         }
         Ok(a_var)
     }

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -22,6 +22,7 @@ use serialize::{Decodable, Decoder, Encodable, Encoder};
 use symbol::keywords;
 use syntax::parse::parse_stream_from_source_str;
 use syntax_pos::{self, Span, FileName};
+use syntax_pos::symbol::{self, Symbol};
 use tokenstream::{TokenStream, TokenTree};
 use tokenstream;
 
@@ -478,7 +479,13 @@ impl Token {
                 _ => return None,
             },
             SingleQuote => match joint {
-                Ident(ident, false) => Lifetime(ident),
+                Ident(ident, false) => {
+                    let name = Symbol::intern(&format!("'{}", ident));
+                    Lifetime(symbol::Ident {
+                        name,
+                        span: ident.span,
+                    })
+                }
                 _ => return None,
             },
 

--- a/src/libsyntax_ext/asm.rs
+++ b/src/libsyntax_ext/asm.rs
@@ -45,17 +45,6 @@ impl State {
     }
 }
 
-macro_rules! span_err_if_not_stage0 {
-    ($cx:expr, $sp:expr, $code:ident, $text:tt) => {
-        #[cfg(not(stage0))] {
-            span_err!($cx, $sp, $code, $text)
-        }
-        #[cfg(stage0)] {
-            $cx.span_err($sp, $text)
-        }
-    }
-}
-
 const OPTIONS: &'static [&'static str] = &["volatile", "alignstack", "intel"];
 
 pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt,

--- a/src/libsyntax_ext/deriving/default.rs
+++ b/src/libsyntax_ext/deriving/default.rs
@@ -76,8 +76,8 @@ fn default_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructur
             }
         }
         StaticEnum(..) => {
-            cx.span_err(trait_span,
-                        "`Default` cannot be derived for enums, only structs");
+            span_err_if_not_stage0!(cx, trait_span, E0665,
+                                    "`Default` cannot be derived for enums, only structs");
             // let compilation continue
             cx.expr_usize(trait_span, 0)
         }

--- a/src/libsyntax_ext/deriving/mod.rs
+++ b/src/libsyntax_ext/deriving/mod.rs
@@ -19,6 +19,17 @@ use syntax::ptr::P;
 use syntax::symbol::Symbol;
 use syntax_pos::Span;
 
+macro_rules! span_err_if_not_stage0 {
+    ($cx:expr, $sp:expr, $code:ident, $text:tt) => {
+        #[cfg(not(stage0))] {
+            span_err!($cx, $sp, $code, $text)
+        }
+        #[cfg(stage0)] {
+            $cx.span_err($sp, $text)
+        }
+    }
+}
+
 macro path_local($x:ident) {
     generic::ty::Path::new_local(stringify!($x))
 }

--- a/src/libsyntax_ext/diagnostics.rs
+++ b/src/libsyntax_ext/diagnostics.rs
@@ -82,7 +82,7 @@ A clobber was surrounded by braces in the `asm` macro.
 
 Erroneous code example:
 
-```compile_fail,E0663
+```compile_fail,E0664
 asm!("mov $$0x200, %eax"
      :
      :
@@ -93,5 +93,39 @@ asm!("mov $$0x200, %eax"
 Considering that this would be a long explanation, we instead recommend you to
 take a look at the unstable book:
 https://doc.rust-lang.org/unstable-book/language-features/asm.html
+"##,
+
+E0665: r##"
+The `Default` trait was derived on an enum.
+
+Erroneous code example:
+
+```compile_fail,E0665
+#[derive(Default)]
+enum Food {
+    Sweet,
+    Salty,
+}
+```
+
+The `Default` cannot be derived on an enum for the simple reason that the
+compiler doesn't know which value to pick by default whereas it can for a
+struct as long as all its fields implement the `Default` trait as well.
+
+If you still want to implement `Default` on your enum, you'll have to do it "by
+hand":
+
+```
+enum Food {
+    Sweet,
+    Salty,
+}
+
+impl Default for Food {
+    fn default() -> Food {
+        Food::Sweet
+    }
+}
+```
 "##,
 }

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -32,8 +32,12 @@ extern crate rustc_target;
 #[cfg(not(stage0))]
 mod diagnostics;
 
-mod assert;
+#[macro_use]
+// for custom_derive
+pub mod deriving;
+
 mod asm;
+mod assert;
 mod cfg;
 mod compile_error;
 mod concat;
@@ -47,8 +51,6 @@ mod trace_macros;
 
 pub mod proc_macro_registrar;
 
-// for custom_derive
-pub mod deriving;
 
 pub mod proc_macro_impl;
 

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/gen-lifetime-token.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/gen-lifetime-token.rs
@@ -1,0 +1,35 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+#![feature(proc_macro)]
+
+extern crate proc_macro;
+
+use proc_macro::*;
+
+#[proc_macro]
+pub fn bar(_input: TokenStream) -> TokenStream {
+    let mut ret = Vec::<TokenTree>::new();
+    ret.push(Ident::new("static", Span::call_site()).into());
+    ret.push(Ident::new("FOO", Span::call_site()).into());
+    ret.push(Punct::new(':', Spacing::Alone).into());
+    ret.push(Punct::new('&', Spacing::Alone).into());
+    ret.push(Punct::new('\'', Spacing::Joint).into());
+    ret.push(Ident::new("static", Span::call_site()).into());
+    ret.push(Ident::new("i32", Span::call_site()).into());
+    ret.push(Punct::new('=', Spacing::Alone).into());
+    ret.push(Punct::new('&', Spacing::Alone).into());
+    ret.push(Literal::i32_unsuffixed(1).into());
+    ret.push(Punct::new(';', Spacing::Alone).into());
+    ret.into_iter().collect()
+}

--- a/src/test/run-pass-fulldeps/proc-macro/gen-lifetime-token.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/gen-lifetime-token.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:gen-lifetime-token.rs
+
+#![feature(proc_macro)]
+
+extern crate gen_lifetime_token as bar;
+
+bar::bar!();
+
+fn main() {
+    let x: &'static i32 = FOO;
+    assert_eq!(*x, 1);
+}

--- a/src/test/ui/E0665.rs
+++ b/src/test/ui/E0665.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-stage1
+
+#[derive(Default)] //~ ERROR E0665
+enum Food {
+    Sweet,
+    Salty,
+}
+
+fn main() {
+}

--- a/src/test/ui/E0665.stderr
+++ b/src/test/ui/E0665.stderr
@@ -1,0 +1,9 @@
+error[E0665]: `Default` cannot be derived for enums, only structs
+  --> $DIR/E0665.rs:13:10
+   |
+LL | #[derive(Default)] //~ ERROR E0665
+   |          ^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0665`.

--- a/src/test/ui/const-eval/strlen.rs
+++ b/src/test/ui/const-eval/strlen.rs
@@ -1,0 +1,26 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-pass
+
+#![feature(const_str_len, const_str_as_bytes)]
+
+#![crate_type = "lib"]
+
+const S: &str = "foo";
+pub const B: &[u8] = S.as_bytes();
+
+pub fn foo() -> [u8; S.len()] {
+    let mut buf = [0; S.len()];
+    for (i, &c) in S.as_bytes().iter().enumerate() {
+        buf[i] = c;
+    }
+    buf
+}

--- a/src/test/ui/const-eval/strlen.rs
+++ b/src/test/ui/const-eval/strlen.rs
@@ -8,11 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-pass
+// run-pass
 
 #![feature(const_str_len, const_str_as_bytes)]
-
-#![crate_type = "lib"]
 
 const S: &str = "foo";
 pub const B: &[u8] = S.as_bytes();
@@ -23,4 +21,13 @@ pub fn foo() -> [u8; S.len()] {
         buf[i] = c;
     }
     buf
+}
+
+fn main() {
+    assert_eq!(&foo()[..], b"foo");
+    assert_eq!(foo().len(), S.len());
+    const LEN: usize = S.len();
+    assert_eq!(LEN, S.len());
+    assert_eq!(B, foo());
+    assert_eq!(B, b"foo");
 }

--- a/src/test/ui/struct-missing-comma.rs
+++ b/src/test/ui/struct-missing-comma.rs
@@ -1,0 +1,23 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z parse-only
+
+// Issue #50636
+
+struct S {
+    foo: u32 //~ expected `,`, or `}`, found `bar`
+    //     ~^ HELP try adding a comma: ','
+    bar: u32
+}
+
+fn main() {
+    let s = S { foo: 5, bar: 6 };
+}

--- a/src/test/ui/struct-missing-comma.stderr
+++ b/src/test/ui/struct-missing-comma.stderr
@@ -1,0 +1,8 @@
+error: expected `,`, or `}`, found `bar`
+  --> $DIR/struct-missing-comma.rs:16:13
+   |
+LL |     foo: u32 //~ expected `,`, or `}`, found `bar`
+   |             ^ help: try adding a comma: `,`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Successful merges:

 - #50846 (Add E0665)
 - #50849 (CheckLoopVisitor: also visit closure arguments)
 - #50863 (Make `[T]::len` and `str::len` const fn)
 - #50875 (rustdoc: use "short form" doc(cfg) printing even when combined with other conditionals)
 - #50913 (Fix typo in cell.rs)
 - #50914 (Issue #50636: Improve error diagnostic with missing commas after struct fields.)
 - #50931 (Inline `try_get`.)
 - #50932 (Optimize seen Predicate filtering.)
 - #50945 (Stabilize feature from_ref)
 - #50946 (rustc: Fix procedural macros generating lifetime tokens)
 - #50947 (rustdoc: set tab width in rust source blocks)
 - #50952 (Add the 2018 edition of the book to doc.rust-lang.org)
 - #50958 (Micro-optimization on PR#50697)
 - #50961 (Fix FileCheck finding with MSVC)
 - #50963 (Right-size the `VecDeque` in `coerce_unsized`.)

Failed merges:

