### PR TITLE
rustc: Correctly pretty-print macro delimiters

### DIFF
--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1239,7 +1239,15 @@ pub type Mac = Spanned<Mac_>;
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct Mac_ {
     pub path: Path,
+    pub delim: MacDelimiter,
     pub tts: ThinTokenStream,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum MacDelimiter {
+    Parenthesis,
+    Bracket,
+    Brace,
 }
 
 impl Mac_ {

--- a/src/libsyntax/ext/placeholders.rs
+++ b/src/libsyntax/ext/placeholders.rs
@@ -27,6 +27,7 @@ pub fn placeholder(kind: ExpansionKind, id: ast::NodeId) -> Expansion {
         dummy_spanned(ast::Mac_ {
             path: ast::Path { span: DUMMY_SP, segments: Vec::new() },
             tts: TokenStream::empty().into(),
+            delim: ast::MacDelimiter::Brace,
         })
     }
 

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -520,6 +520,7 @@ pub fn noop_fold_mac<T: Folder>(Spanned {node, span}: Mac, fld: &mut T) -> Mac {
         node: Mac_ {
             tts: fld.fold_tts(node.stream()).into(),
             path: fld.fold_path(node.path),
+            delim: node.delim,
         },
         span: fld.new_span(span)
     }

--- a/src/libsyntax_ext/assert.rs
+++ b/src/libsyntax_ext/assert.rs
@@ -53,6 +53,7 @@ pub fn expand_assert<'cx>(
                 ),
             )).into()
         },
+        delim: MacDelimiter::Parenthesis,
     };
     let if_expr = cx.expr_if(
         sp,

--- a/src/test/ui-fulldeps/proc-macro/auxiliary/macro-brackets.rs
+++ b/src/test/ui-fulldeps/proc-macro/auxiliary/macro-brackets.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+#![feature(proc_macro)]
+
+extern crate proc_macro;
+use proc_macro::*;
+
+#[proc_macro_attribute]
+pub fn doit(_: TokenStream, input: TokenStream) -> TokenStream {
+    input.into_iter().collect()
+}

--- a/src/test/ui-fulldeps/proc-macro/macro-brackets.rs
+++ b/src/test/ui-fulldeps/proc-macro/macro-brackets.rs
@@ -1,0 +1,26 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:macro-brackets.rs
+
+#![feature(proc_macro)]
+
+extern crate macro_brackets as bar;
+use bar::doit;
+
+macro_rules! id {
+    ($($t:tt)*) => ($($t)*)
+}
+
+#[doit]
+id![static X: u32 = 'a';]; //~ ERROR: mismatched types
+
+
+fn main() {}

--- a/src/test/ui-fulldeps/proc-macro/macro-brackets.stderr
+++ b/src/test/ui-fulldeps/proc-macro/macro-brackets.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/macro-brackets.rs:23:21
+   |
+LL | id![static X: u32 = 'a';]; //~ ERROR: mismatched types
+   |                     ^^^ expected u32, found char
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
This commit updates the `Mac_` AST structure to keep track of the delimiters
that it originally had for its invocation. This allows us to faithfully
pretty-print macro invocations not using parentheses (e.g. `vec![...]`). This in
turn helps procedural macros due to #43081.

Closes #50840