### PR TITLE
Add -Z no-parallel-llvm flag

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1337,6 +1337,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
           "enable the experimental Chalk-based trait solving engine"),
     cross_lang_lto: CrossLangLto = (CrossLangLto::Disabled, parse_cross_lang_lto, [TRACKED],
           "generate build artifacts that are compatible with linker-based LTO."),
+    no_parallel_llvm: bool = (false, parse_bool, [UNTRACKED],
+          "don't run LLVM in parallel (while keeping codegen-units and ThinLTO)"),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -1738,7 +1738,9 @@ fn start_executing_work(tcx: TyCtxt,
                             .binary_search_by_key(&cost, |&(_, cost)| cost)
                             .unwrap_or_else(|e| e);
                         work_items.insert(insertion_index, (work, cost));
-                        helper.request_token();
+                        if !cgcx.opts.debugging_opts.no_parallel_llvm {
+                            helper.request_token();
+                        }
                     }
                 }
 
@@ -1842,7 +1844,9 @@ fn start_executing_work(tcx: TyCtxt,
                     };
                     work_items.insert(insertion_index, (llvm_work_item, cost));
 
-                    helper.request_token();
+                    if !cgcx.opts.debugging_opts.no_parallel_llvm {
+                        helper.request_token();
+                    }
                     assert_eq!(main_thread_worker_state,
                                MainThreadWorkerState::Codegenning);
                     main_thread_worker_state = MainThreadWorkerState::Idle;


### PR DESCRIPTION
Codegen issues commonly only manifest under specific circumstances,
e.g. if multiple codegen units are used and ThinLTO is enabled.
However, these configuration are threaded, making the use of LLVM
debugging facilities hard, as output is interleaved.

This patch adds a -Z no-parallel-llvm flag, which allows disabling
parallelization of codegen and linking, while otherwise preserving
behavior with regard to codegen units and LTO.