### PR TITLE
rustc: Fix another double-lint issue with `crate::`

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -684,7 +684,10 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
                                  "cannot glob-import all possible crates".to_string()));
                 }
                 GlobImport { .. } if self.session.features_untracked().extern_absolute_paths => {
-                    self.lint_path_starts_with_module(directive.id, span);
+                    self.lint_path_starts_with_module(
+                        directive.root_id,
+                        directive.root_span,
+                    );
                 }
                 SingleImport { source, target, .. } => {
                     let crate_root = if source.name == keywords::Crate.name() &&
@@ -903,7 +906,10 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
                     return
                 }
                 warned = true;
-                this.lint_path_starts_with_module(directive.id, span);
+                this.lint_path_starts_with_module(
+                    directive.root_id,
+                    directive.root_span,
+                );
             });
         }
 

--- a/src/test/ui/rust-2018/edition-lint-nested-paths.fixed
+++ b/src/test/ui/rust-2018/edition-lint-nested-paths.fixed
@@ -20,9 +20,18 @@ use crate::foo::{a, b};
 mod foo {
     crate fn a() {}
     crate fn b() {}
+    crate fn c() {}
 }
 
 fn main() {
     a();
     b();
+
+    {
+        use crate::foo::{self as x, c};
+        //~^ ERROR absolute paths must start with
+        //~| this was previously accepted
+        x::a();
+        c();
+    }
 }

--- a/src/test/ui/rust-2018/edition-lint-nested-paths.rs
+++ b/src/test/ui/rust-2018/edition-lint-nested-paths.rs
@@ -20,9 +20,18 @@ use foo::{a, b};
 mod foo {
     crate fn a() {}
     crate fn b() {}
+    crate fn c() {}
 }
 
 fn main() {
     a();
     b();
+
+    {
+        use foo::{self as x, c};
+        //~^ ERROR absolute paths must start with
+        //~| this was previously accepted
+        x::a();
+        c();
+    }
 }

--- a/src/test/ui/rust-2018/edition-lint-nested-paths.stderr
+++ b/src/test/ui/rust-2018/edition-lint-nested-paths.stderr
@@ -12,5 +12,14 @@ LL | #![deny(absolute_path_not_starting_with_crate)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue TBD
 
-error: aborting due to previous error
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-paths.rs:31:13
+   |
+LL |         use foo::{self as x, c};
+   |             ^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{self as x, c}`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = note: for more information, see issue TBD
+
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/rust-2018/edition-lint-paths.fixed
+++ b/src/test/ui/rust-2018/edition-lint-paths.fixed
@@ -30,10 +30,8 @@ pub mod foo {
     //~| WARN this was previously accepted
     use crate::{bar as something_else};
 
-    use {crate::Bar as SomethingElse, crate::main};
+    use crate::{Bar as SomethingElse, main};
     //~^ ERROR absolute
-    //~| WARN this was previously accepted
-    //~| ERROR absolute
     //~| WARN this was previously accepted
 
     use crate::{Bar as SomethingElse2, main as another_main};

--- a/src/test/ui/rust-2018/edition-lint-paths.rs
+++ b/src/test/ui/rust-2018/edition-lint-paths.rs
@@ -33,8 +33,6 @@ pub mod foo {
     use {Bar as SomethingElse, main};
     //~^ ERROR absolute
     //~| WARN this was previously accepted
-    //~| ERROR absolute
-    //~| WARN this was previously accepted
 
     use crate::{Bar as SomethingElse2, main as another_main};
 

--- a/src/test/ui/rust-2018/edition-lint-paths.stderr
+++ b/src/test/ui/rust-2018/edition-lint-paths.stderr
@@ -22,25 +22,16 @@ LL |     use bar;
    = note: for more information, see issue TBD
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:33:10
+  --> $DIR/edition-lint-paths.rs:33:9
    |
 LL |     use {Bar as SomethingElse, main};
-   |          ^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::Bar as SomethingElse`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::{Bar as SomethingElse, main}`
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue TBD
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:33:32
-   |
-LL |     use {Bar as SomethingElse, main};
-   |                                ^^^^ help: use `crate`: `crate::main`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
-   = note: for more information, see issue TBD
-
-error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:47:5
+  --> $DIR/edition-lint-paths.rs:45:5
    |
 LL | use bar::Bar;
    |     ^^^^^^^^ help: use `crate`: `crate::bar::Bar`
@@ -49,7 +40,7 @@ LL | use bar::Bar;
    = note: for more information, see issue TBD
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:59:9
+  --> $DIR/edition-lint-paths.rs:57:9
    |
 LL |     use *;
    |         ^ help: use `crate`: `crate::*`
@@ -58,7 +49,7 @@ LL |     use *;
    = note: for more information, see issue TBD
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:64:6
+  --> $DIR/edition-lint-paths.rs:62:6
    |
 LL | impl ::foo::SomeTrait for u32 { }
    |      ^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::SomeTrait`
@@ -67,7 +58,7 @@ LL | impl ::foo::SomeTrait for u32 { }
    = note: for more information, see issue TBD
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:69:13
+  --> $DIR/edition-lint-paths.rs:67:13
    |
 LL |     let x = ::bar::Bar;
    |             ^^^^^^^^^^ help: use `crate`: `crate::bar::Bar`
@@ -75,5 +66,5 @@ LL |     let x = ::bar::Bar;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue TBD
 
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
This commit fixes another issue in the `absolute_path_not_starting_with_crate`
lint where it warns twice about an import which may contain `self`. It turns out
there were a few more locations that needed updating to use `root_id` and
`root_span` introduced in #50970 and after that it looks to work like a charm!

Closes #50978