### PR TITLE
Tweak `main` type arguments and where clause spans

### DIFF
--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -598,6 +598,18 @@ pub struct WhereClause {
     pub predicates: HirVec<WherePredicate>,
 }
 
+impl WhereClause {
+    pub fn span(&self) -> Option<Span> {
+        self.predicates.iter().map(|predicate| predicate.span())
+            .fold(None, |acc, i| match (acc, i) {
+                (None, i) => Some(i),
+                (Some(acc), i) => {
+                    Some(acc.to(i))
+                }
+            })
+    }
+}
+
 /// A single predicate in a `where` clause
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub enum WherePredicate {

--- a/src/test/compile-fail/issue-1900.rs
+++ b/src/test/compile-fail/issue-1900.rs
@@ -8,5 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: main function is not allowed to have type parameters
+// error-pattern: `main` function is not allowed to have type parameters
 fn main<T>() { }

--- a/src/test/ui/error-codes/E0131.stderr
+++ b/src/test/ui/error-codes/E0131.stderr
@@ -1,8 +1,8 @@
-error[E0131]: main function is not allowed to have type parameters
+error[E0131]: `main` function is not allowed to have type parameters
   --> $DIR/E0131.rs:11:8
    |
 LL | fn main<T>() {
-   |        ^^^ main cannot have type parameters
+   |        ^^^ `main` cannot have type parameters
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0646.stderr
+++ b/src/test/ui/error-codes/E0646.stderr
@@ -1,8 +1,8 @@
-error[E0646]: main function is not allowed to have a where clause
-  --> $DIR/E0646.rs:11:1
+error[E0646]: `main` function is not allowed to have a `where` clause
+  --> $DIR/E0646.rs:11:17
    |
 LL | fn main() where (): Copy {} //~ ERROR [E0646]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^ `main` cannot have a `where` clause
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0647.stderr
+++ b/src/test/ui/error-codes/E0647.stderr
@@ -1,10 +1,8 @@
-error[E0647]: start function is not allowed to have a where clause
-  --> $DIR/E0647.rs:17:1
+error[E0647]: start function is not allowed to have a `where` clause
+  --> $DIR/E0647.rs:17:56
    |
-LL | / fn start(_: isize, _: *const *const u8) -> isize where (): Copy { //~ ERROR [E0647]
-LL | |     0
-LL | | }
-   | |_^
+LL | fn start(_: isize, _: *const *const u8) -> isize where (): Copy { //~ ERROR [E0647]
+   |                                                        ^^^^^^^^ start function cannot have a `where` clause
 
 error: aborting due to previous error
 

--- a/src/test/ui/issue-50714-1.stderr
+++ b/src/test/ui/issue-50714-1.stderr
@@ -1,10 +1,8 @@
-error[E0647]: start function is not allowed to have a where clause
-  --> $DIR/issue-50714-1.rs:19:1
+error[E0647]: start function is not allowed to have a `where` clause
+  --> $DIR/issue-50714-1.rs:19:56
    |
-LL | / fn start(_: isize, _: *const *const u8) -> isize where fn(&()): Eq { //~ ERROR [E0647]
-LL | |     0
-LL | | }
-   | |_^
+LL | fn start(_: isize, _: *const *const u8) -> isize where fn(&()): Eq { //~ ERROR [E0647]
+   |                                                        ^^^^^^^^^^^ start function cannot have a `where` clause
 
 error: aborting due to previous error
 

--- a/src/test/ui/issue-50714.stderr
+++ b/src/test/ui/issue-50714.stderr
@@ -1,8 +1,8 @@
-error[E0646]: main function is not allowed to have a where clause
-  --> $DIR/issue-50714.rs:13:1
+error[E0646]: `main` function is not allowed to have a `where` clause
+  --> $DIR/issue-50714.rs:13:17
    |
 LL | fn main() where fn(&()): Eq {} //~ ERROR [E0646]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^ `main` cannot have a `where` clause
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Tweak the spans for error when finding type arguments or where clauses
in main and start functions.