### PR TITLE
move type out of unsafe block

### DIFF
--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -2246,13 +2246,11 @@ impl str {
     #[inline(always)]
     #[rustc_const_unstable(feature="const_str_as_bytes")]
     pub const fn as_bytes(&self) -> &[u8] {
-        unsafe {
-            union Slices<'a> {
-                str: &'a str,
-                slice: &'a [u8],
-            }
-            Slices { str: self }.slice
+        union Slices<'a> {
+            str: &'a str,
+            slice: &'a [u8],
         }
+        unsafe { Slices { str: self }.slice }
     }
 
     /// Converts a mutable string slice to a mutable byte slice. To convert the


### PR DESCRIPTION
from https://github.com/rust-lang/rust/pull/50863#discussion_r190213000

move the union definition outside of the unsafe block as it's definition is not unsafe