### PR TITLE
"crate-ify" paths that begin with a renamed crate

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3533,7 +3533,9 @@ impl<'a> Resolver<'a> {
         // warning, this looks all good!
         if let Some(binding) = second_binding {
             if let NameBindingKind::Import { directive: d, .. } = binding.kind {
-                if let ImportDirectiveSubclass::ExternCrate(..) = d.subclass {
+                // Careful: we still want to rewrite paths from
+                // renamed extern crates.
+                if let ImportDirectiveSubclass::ExternCrate(None) = d.subclass {
                     return
                 }
             }

--- a/src/test/ui/rust-2018/extern-crate-idiomatic.fixed
+++ b/src/test/ui/rust-2018/extern-crate-idiomatic.fixed
@@ -1,0 +1,28 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-pass
+// aux-build:edition-lint-paths.rs
+// run-rustfix
+
+// The "normal case". Ideally we would remove the `extern crate` here,
+// but we don't.
+
+#![feature(rust_2018_preview)]
+#![deny(absolute_path_not_starting_with_crate)]
+
+extern crate edition_lint_paths;
+
+use edition_lint_paths::foo;
+
+fn main() {
+    foo();
+}
+

--- a/src/test/ui/rust-2018/extern-crate-idiomatic.rs
+++ b/src/test/ui/rust-2018/extern-crate-idiomatic.rs
@@ -1,0 +1,28 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-pass
+// aux-build:edition-lint-paths.rs
+// run-rustfix
+
+// The "normal case". Ideally we would remove the `extern crate` here,
+// but we don't.
+
+#![feature(rust_2018_preview)]
+#![deny(absolute_path_not_starting_with_crate)]
+
+extern crate edition_lint_paths;
+
+use edition_lint_paths::foo;
+
+fn main() {
+    foo();
+}
+

--- a/src/test/ui/rust-2018/extern-crate-referenced-by-self-path.fixed
+++ b/src/test/ui/rust-2018/extern-crate-referenced-by-self-path.fixed
@@ -1,0 +1,28 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-pass
+// aux-build:edition-lint-paths.rs
+// run-rustfix
+
+// Oddball: `edition_lint_paths` is accessed via this `self` path
+// rather than being accessed directly. Unless we rewrite that path,
+// we can't drop the extern crate.
+
+#![feature(rust_2018_preview)]
+#![deny(absolute_path_not_starting_with_crate)]
+
+extern crate edition_lint_paths;
+use self::edition_lint_paths::foo;
+
+fn main() {
+    foo();
+}
+

--- a/src/test/ui/rust-2018/extern-crate-referenced-by-self-path.rs
+++ b/src/test/ui/rust-2018/extern-crate-referenced-by-self-path.rs
@@ -1,0 +1,28 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-pass
+// aux-build:edition-lint-paths.rs
+// run-rustfix
+
+// Oddball: `edition_lint_paths` is accessed via this `self` path
+// rather than being accessed directly. Unless we rewrite that path,
+// we can't drop the extern crate.
+
+#![feature(rust_2018_preview)]
+#![deny(absolute_path_not_starting_with_crate)]
+
+extern crate edition_lint_paths;
+use self::edition_lint_paths::foo;
+
+fn main() {
+    foo();
+}
+

--- a/src/test/ui/rust-2018/extern-crate-rename.fixed
+++ b/src/test/ui/rust-2018/extern-crate-rename.fixed
@@ -1,0 +1,29 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:edition-lint-paths.rs
+// run-rustfix
+
+// Oddball: crate is renamed, making it harder for us to rewrite
+// paths. We don't (and we leave the `extern crate` in place).
+
+#![feature(rust_2018_preview)]
+#![deny(absolute_path_not_starting_with_crate)]
+
+extern crate edition_lint_paths as my_crate;
+
+use crate::my_crate::foo;
+//~^ ERROR absolute paths must start
+//~| WARNING this was previously accepted
+
+fn main() {
+    foo();
+}
+

--- a/src/test/ui/rust-2018/extern-crate-rename.rs
+++ b/src/test/ui/rust-2018/extern-crate-rename.rs
@@ -1,0 +1,29 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:edition-lint-paths.rs
+// run-rustfix
+
+// Oddball: crate is renamed, making it harder for us to rewrite
+// paths. We don't (and we leave the `extern crate` in place).
+
+#![feature(rust_2018_preview)]
+#![deny(absolute_path_not_starting_with_crate)]
+
+extern crate edition_lint_paths as my_crate;
+
+use my_crate::foo;
+//~^ ERROR absolute paths must start
+//~| WARNING this was previously accepted
+
+fn main() {
+    foo();
+}
+

--- a/src/test/ui/rust-2018/extern-crate-rename.stderr
+++ b/src/test/ui/rust-2018/extern-crate-rename.stderr
@@ -1,0 +1,16 @@
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/extern-crate-rename.rs:22:5
+   |
+LL | use my_crate::foo;
+   |     ^^^^^^^^^^^^^ help: use `crate`: `crate::my_crate::foo`
+   |
+note: lint level defined here
+  --> $DIR/extern-crate-rename.rs:18:9
+   |
+LL | #![deny(absolute_path_not_starting_with_crate)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = note: for more information, see issue TBD
+
+error: aborting due to previous error
+

--- a/src/test/ui/rust-2018/extern-crate-submod.fixed
+++ b/src/test/ui/rust-2018/extern-crate-submod.fixed
@@ -1,0 +1,36 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:edition-lint-paths.rs
+// run-rustfix
+
+// Oddball: extern crate appears in a submodule, making it harder for
+// us to rewrite paths. We don't (and we leave the `extern crate` in
+// place).
+
+#![feature(rust_2018_preview)]
+#![deny(absolute_path_not_starting_with_crate)]
+
+mod m {
+    // Because this extern crate does not appear at the root, we
+    // ignore it altogether.
+    pub extern crate edition_lint_paths;
+}
+
+// And we don't being smart about paths like this, even though you
+// *could* rewrite it to `use edition_lint_paths::foo`
+use crate::m::edition_lint_paths::foo;
+//~^ ERROR absolute paths must start
+//~| WARNING this was previously accepted
+
+fn main() {
+    foo();
+}
+

--- a/src/test/ui/rust-2018/extern-crate-submod.rs
+++ b/src/test/ui/rust-2018/extern-crate-submod.rs
@@ -1,0 +1,36 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:edition-lint-paths.rs
+// run-rustfix
+
+// Oddball: extern crate appears in a submodule, making it harder for
+// us to rewrite paths. We don't (and we leave the `extern crate` in
+// place).
+
+#![feature(rust_2018_preview)]
+#![deny(absolute_path_not_starting_with_crate)]
+
+mod m {
+    // Because this extern crate does not appear at the root, we
+    // ignore it altogether.
+    pub extern crate edition_lint_paths;
+}
+
+// And we don't being smart about paths like this, even though you
+// *could* rewrite it to `use edition_lint_paths::foo`
+use m::edition_lint_paths::foo;
+//~^ ERROR absolute paths must start
+//~| WARNING this was previously accepted
+
+fn main() {
+    foo();
+}
+

--- a/src/test/ui/rust-2018/extern-crate-submod.stderr
+++ b/src/test/ui/rust-2018/extern-crate-submod.stderr
@@ -1,0 +1,16 @@
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/extern-crate-submod.rs:29:5
+   |
+LL | use m::edition_lint_paths::foo;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::m::edition_lint_paths::foo`
+   |
+note: lint level defined here
+  --> $DIR/extern-crate-submod.rs:19:9
+   |
+LL | #![deny(absolute_path_not_starting_with_crate)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = note: for more information, see issue TBD
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This does two things:

- crate-ify paths that begin with a renamed crate (i.e., add `crate::`) to the front

Fixes https://github.com/rust-lang/rust/issues/50996

I also added tests for a few other scenarios.

r? @alexcrichton 