### PR TITLE
 rustdoc: hide macro export statements from docs

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -97,6 +97,9 @@ pub fn try_inline(cx: &DocContext, def: Def, name: ast::Name, visited: &mut FxHa
             record_extern_fqn(cx, did, clean::TypeKind::Const);
             clean::ConstantItem(build_const(cx, did))
         }
+        // Macros are eagerly inlined back in visit_ast, don't show their export statements
+        // FIXME(50647): the eager inline does not take doc(hidden)/doc(no_inline) into account
+        Def::Macro(..) => return Some(Vec::new()),
         _ => return None,
     };
     cx.renderinfo.borrow_mut().inlined.insert(did);

--- a/src/test/rustdoc/pub-use-extern-macros.rs
+++ b/src/test/rustdoc/pub-use-extern-macros.rs
@@ -15,6 +15,7 @@
 extern crate macros;
 
 // @has pub_use_extern_macros/macro.bar.html
+// @!has pub_use_extern_macros/index.html 'pub use macros::bar;'
 pub use macros::bar;
 
 // @has pub_use_extern_macros/macro.baz.html

--- a/src/test/rustdoc/pub-use-extern-macros.rs
+++ b/src/test/rustdoc/pub-use-extern-macros.rs
@@ -15,15 +15,15 @@
 extern crate macros;
 
 // @has pub_use_extern_macros/macro.bar.html
-// @!has pub_use_extern_macros/index.html 'pub use macros::bar;'
+// @!has pub_use_extern_macros/index.html '//code' 'pub use macros::bar;'
 pub use macros::bar;
 
 // @has pub_use_extern_macros/macro.baz.html
-// @!has pub_use_extern_macros/index.html 'pub use macros::baz;'
+// @!has pub_use_extern_macros/index.html '//code' 'pub use macros::baz;'
 #[doc(inline)]
 pub use macros::baz;
 
 // @has pub_use_extern_macros/macro.quux.html
-// @!has pub_use_extern_macros/index.html 'pub use macros::quux;'
+// @!has pub_use_extern_macros/index.html '//code' 'pub use macros::quux;'
 #[doc(hidden)]
 pub use macros::quux;


### PR DESCRIPTION
As mentioned in https://github.com/rust-lang/rust/issues/50647, rustdoc now prints both the import statement and the macro itself when re-exporting macros. This is a stopgap solution to clean up the std docs and get something small backported into beta.

What this does: When rustdoc finds an export statement for a macro, instead of printing the export and bailing, now it will instead hide the export and bail. Until we can solve https://github.com/rust-lang/rust/issues/34843 or have a better way to find the attributes on an export statement when inlining macros, this will at least match the current behavior and clean up the re-export statements from the docs.