### PR TITLE
Rewrite docs for `std::ptr` (Take #2) 

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -976,19 +976,15 @@ extern "rust-intrinsic" {
     ///
     /// Behavior is undefined if any of the following conditions are violated:
     ///
+    /// * `src` must be [valid] for reads of `count * size_of::<T>()` bytes.
+    ///
+    /// * `dst` must be [valid] for writes of `count * size_of::<T>()` bytes.
+    ///
     /// * Both `src` and `dst` must be properly aligned.
     ///
-    /// * `src.offset(i)` must be [valid] for all `i` in `0..count`. In other
-    ///   words, the region of memory which begins at `src` and has a length of
-    ///   `count * size_of::<T>()` bytes must belong to a single, live
-    ///   allocation.
-    ///
-    /// * `dst.offset(i)` must be [valid] for all `i` in `0..count`. In other
-    ///   words, the region of memory which begins at `dst` and has a length of
-    ///   `count * size_of::<T>()` bytes must belong to a single, live
-    ///   allocation.
-    ///
-    /// * The two regions of memory must *not* overlap.
+    /// * The region of memory beginning at `src` with a size of `count *
+    ///   size_of::<T>()` bytes must *not* overlap with the region of memory
+    ///   beginning at `dst` with the same size.
     ///
     /// Like [`read`], `copy` creates a bitwise copy of `T`, regardless of
     /// whether `T` is [`Copy`].  If `T` is not [`Copy`], using both the values
@@ -1064,17 +1060,11 @@ extern "rust-intrinsic" {
     ///
     /// Behavior is undefined if any of the following conditions are violated:
     ///
+    /// * `src` must be [valid] for reads of `count * size_of::<T>()` bytes.
+    ///
+    /// * `dst` must be [valid] for writes of `count * size_of::<T>()` bytes.
+    ///
     /// * Both `src` and `dst` must be properly aligned.
-    ///
-    /// * `src.offset(i)` must be [valid] for all `i` in `0..count`. In other
-    ///   words, the region of memory which begins at `src` and has a length of
-    ///   `count * size_of::<T>()` bytes must belong to a single, live
-    ///   allocation.
-    ///
-    /// * `dst.offset(i)` must be [valid] for all `i` in `0..count`. In other
-    ///   words, the region of memory which begins at `dst` and has a length of
-    ///   `count * size_of::<T>()` bytes must belong to a single, live
-    ///   allocation.
     ///
     /// Like [`read`], `copy` creates a bitwise copy of `T`, regardless of
     /// whether `T` is [`Copy`].  If `T` is not [`Copy`], using both the values
@@ -1116,12 +1106,9 @@ extern "rust-intrinsic" {
     ///
     /// Behavior is undefined if any of the following conditions are violated:
     ///
-    /// * `dst` must be properly aligned.
+    /// * `dst` must be [valid] for writes of `count * size_of::<T>()` bytes.
     ///
-    /// * `dst.offset(i)` must be [valid] for all `i` in `0..count`. In other
-    ///   words, the region of memory which begins at `dst` and has a length of
-    ///   `count * size_of::<T>()` bytes must belong to a single, live
-    ///   allocation.
+    /// * `dst` must be properly aligned.
     ///
     /// Additionally, the caller must ensure that writing `count *
     /// size_of::<T>()` bytes to the given region of memory results in a valid

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -980,11 +980,11 @@ extern "rust-intrinsic" {
     ///
     /// * Both `src` and `dst` must be properly aligned.
     ///
-    /// * `src.offset(count)` must be [valid]. In other words, the region of
+    /// * `src.offset(count-1)` must be [valid]. In other words, the region of
     ///   memory which begins at `src` and has a length of `count *
     ///   size_of::<T>()` bytes must belong to a single, live allocation.
     ///
-    /// * `dst.offset(count)` must be [valid]. In other words, the region of
+    /// * `dst.offset(count-1)` must be [valid]. In other words, the region of
     ///   memory which begins at `dst` and has a length of `count *
     ///   size_of::<T>()` bytes must belong to a single, live allocation.
     ///
@@ -1068,11 +1068,11 @@ extern "rust-intrinsic" {
     ///
     /// * Both `src` and `dst` must be properly aligned.
     ///
-    /// * `src.offset(count)` must be [valid]. In other words, the region of
+    /// * `src.offset(count-1)` must be [valid]. In other words, the region of
     ///   memory which begins at `src` and has a length of `count *
     ///   size_of::<T>()` bytes must belong to a single, live allocation.
     ///
-    /// * `dst.offset(count)` must be [valid]. In other words, the region of
+    /// * `dst.offset(count-1)` must be [valid]. In other words, the region of
     ///   memory which begins at `dst` and has a length of `count *
     ///   size_of::<T>()` bytes must belong to a single, live allocation.
     ///
@@ -1118,7 +1118,7 @@ extern "rust-intrinsic" {
     ///
     /// * `dst` must be [valid].
     ///
-    /// * `dst.offset(count)` must be [valid]. In other words, the region of
+    /// * `dst.offset(count-1)` must be [valid]. In other words, the region of
     ///   memory which begins at `dst` and has a length of `count *
     ///   size_of::<T>()` bytes must belong to a single, live allocation.
     ///

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1149,7 +1149,7 @@ extern "rust-intrinsic" {
     /// Creating an invalid value:
     ///
     /// ```no_run
-    /// use std::{mem, ptr};
+    /// use std::ptr;
     ///
     /// let mut v = Box::new(0i32);
     ///

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -976,17 +976,17 @@ extern "rust-intrinsic" {
     ///
     /// Behavior is undefined if any of the following conditions are violated:
     ///
-    /// * Both `src` and `dst` must be [valid].
-    ///
     /// * Both `src` and `dst` must be properly aligned.
     ///
-    /// * `src.offset(count-1)` must be [valid]. In other words, the region of
-    ///   memory which begins at `src` and has a length of `count *
-    ///   size_of::<T>()` bytes must belong to a single, live allocation.
+    /// * `src.offset(i)` must be [valid] for all `i` in `0..count`. In other
+    ///   words, the region of memory which begins at `src` and has a length of
+    ///   `count * size_of::<T>()` bytes must belong to a single, live
+    ///   allocation.
     ///
-    /// * `dst.offset(count-1)` must be [valid]. In other words, the region of
-    ///   memory which begins at `dst` and has a length of `count *
-    ///   size_of::<T>()` bytes must belong to a single, live allocation.
+    /// * `dst.offset(i)` must be [valid] for all `i` in `0..count`. In other
+    ///   words, the region of memory which begins at `dst` and has a length of
+    ///   `count * size_of::<T>()` bytes must belong to a single, live
+    ///   allocation.
     ///
     /// * The two regions of memory must *not* overlap.
     ///
@@ -1064,17 +1064,17 @@ extern "rust-intrinsic" {
     ///
     /// Behavior is undefined if any of the following conditions are violated:
     ///
-    /// * Both `src` and `dst` must be [valid].
-    ///
     /// * Both `src` and `dst` must be properly aligned.
     ///
-    /// * `src.offset(count-1)` must be [valid]. In other words, the region of
-    ///   memory which begins at `src` and has a length of `count *
-    ///   size_of::<T>()` bytes must belong to a single, live allocation.
+    /// * `src.offset(i)` must be [valid] for all `i` in `0..count`. In other
+    ///   words, the region of memory which begins at `src` and has a length of
+    ///   `count * size_of::<T>()` bytes must belong to a single, live
+    ///   allocation.
     ///
-    /// * `dst.offset(count-1)` must be [valid]. In other words, the region of
-    ///   memory which begins at `dst` and has a length of `count *
-    ///   size_of::<T>()` bytes must belong to a single, live allocation.
+    /// * `dst.offset(i)` must be [valid] for all `i` in `0..count`. In other
+    ///   words, the region of memory which begins at `dst` and has a length of
+    ///   `count * size_of::<T>()` bytes must belong to a single, live
+    ///   allocation.
     ///
     /// Like [`read`], `copy` creates a bitwise copy of `T`, regardless of
     /// whether `T` is [`Copy`].  If `T` is not [`Copy`], using both the values
@@ -1116,13 +1116,12 @@ extern "rust-intrinsic" {
     ///
     /// Behavior is undefined if any of the following conditions are violated:
     ///
-    /// * `dst` must be [valid].
-    ///
-    /// * `dst.offset(count-1)` must be [valid]. In other words, the region of
-    ///   memory which begins at `dst` and has a length of `count *
-    ///   size_of::<T>()` bytes must belong to a single, live allocation.
-    ///
     /// * `dst` must be properly aligned.
+    ///
+    /// * `dst.offset(i)` must be [valid] for all `i` in `0..count`. In other
+    ///   words, the region of memory which begins at `dst` and has a length of
+    ///   `count * size_of::<T>()` bytes must belong to a single, live
+    ///   allocation.
     ///
     /// Additionally, the caller must ensure that writing `count *
     /// size_of::<T>()` bytes to the given region of memory results in a valid

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -226,12 +226,28 @@ pub unsafe fn swap<T>(x: *mut T, y: *mut T) {
     mem::forget(tmp);
 }
 
-/// Swaps a sequence of values at two mutable locations of the same type.
+/// Swaps `count * size_of::<T>()` bytes between the two regions of memory
+/// beginning at `x` and `y`. The two regions must *not* overlap.
 ///
 /// # Safety
 ///
-/// The two arguments must each point to the beginning of `count` locations
-/// of valid memory, and the two memory ranges must not overlap.
+/// Behavior is undefined if any of the following conditions are violated:
+///
+/// * Both `x` and `y` must be [valid].
+///
+/// * Both `x` and `y` must be properly aligned.
+///
+/// * `x.offset(count)` must be [valid]. In other words, the region of memory
+///   which begins at `x` and has a length of `count * size_of::<T>()` bytes
+///   must belong to a single, live allocation.
+///
+/// * `y.offset(count)` must be [valid]. In other words, the region of memory
+///   which begins at `y` and has a length of `count * size_of::<T>()` bytes
+///   must belong to a single, live allocation.
+///
+/// * The two regions of memory must *not* overlap.
+///
+/// [valid]: ../ptr/index.html#safety
 ///
 /// # Examples
 ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -16,18 +16,23 @@
 //!
 //! # Safety
 //!
-//! Most functions in this module [dereference raw pointers].
-//!
-//! In order for a pointer dereference to be safe, the pointer must be "valid".
-//! A valid pointer is one that satisfies **all** of the following conditions:
+//! Many functions in this module take raw pointers as arguments and dereference
+//! them. For this to be safe, these pointers must be valid. A valid pointer
+//! is one that satisfies **all** of the following conditions:
 //!
 //! * The pointer is not null.
 //! * The pointer is not dangling (it does not point to memory which has been
 //!   freed).
 //! * The pointer satisfies [LLVM's pointer aliasing rules].
 //!
-//! [dereference raw pointers]: https://doc.rust-lang.org/book/second-edition/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer
+//! Valid pointers are not necessarily properly aligned. However, except for
+//! [`read_unaligned`] and [`write_unaligned`], most functions require their
+//! arguments to be aligned. Any alignment requirements will be explicitly
+//! stated in the function's documentation.
+//!
 //! [LLVM's pointer aliasing rules]: https://llvm.org/docs/LangRef.html#pointer-aliasing-rules
+//! [`read_unaligned`]: ./fn.read_unaligned.html
+//! [`write_unaligned`]: ./fn.write_unaligned.html
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -654,6 +659,7 @@ pub unsafe fn write<T>(dst: *mut T, src: T) {
 ///
 /// // Accessing unaligned values directly is safe.
 /// assert!(x.unaligned == v);
+/// ```
 #[inline]
 #[stable(feature = "ptr_unaligned", since = "1.17.0")]
 pub unsafe fn write_unaligned<T>(dst: *mut T, src: T) {

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -25,10 +25,10 @@
 //!   freed).
 //! * The pointer satisfies [LLVM's pointer aliasing rules].
 //!
-//! Valid pointers are not necessarily properly aligned. However, except for
-//! [`read_unaligned`] and [`write_unaligned`], most functions require their
-//! arguments to be aligned. Any alignment requirements will be explicitly
-//! stated in the function's documentation.
+//! Valid pointers are not necessarily properly aligned. However, most functions
+//! require their arguments to be properly aligned, and will explicitly state
+//! this requirement in the `Safety` section. Notable exceptions to this are
+//! [`read_unaligned`] and [`write_unaligned`].
 //!
 //! [LLVM's pointer aliasing rules]: https://llvm.org/docs/LangRef.html#pointer-aliasing-rules
 //! [`read_unaligned`]: ./fn.read_unaligned.html

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -240,17 +240,15 @@ pub unsafe fn swap<T>(x: *mut T, y: *mut T) {
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-/// * Both `x` and `y` must be [valid].
-///
 /// * Both `x` and `y` must be properly aligned.
 ///
-/// * `x.offset(count-1)` must be [valid]. In other words, the region of memory
-///   which begins at `x` and has a length of `count * size_of::<T>()` bytes
-///   must belong to a single, live allocation.
+/// * `x.offset(i)` must be [valid] for all `i` in `0..count`. In other words,
+///   the region of memory which begins at `x` and has a length of `count *
+///   size_of::<T>()` bytes must belong to a single, live allocation.
 ///
-/// * `y.offset(count-1)` must be [valid]. In other words, the region of memory
-///   which begins at `y` and has a length of `count * size_of::<T>()` bytes
-///   must belong to a single, live allocation.
+/// * `y.offset(i)` must be [valid] for all `i` in `0..count`. In other words,
+///   the region of memory which begins at `y` and has a length of `count *
+///   size_of::<T>()` bytes must belong to a single, live allocation.
 ///
 /// * The two regions of memory must *not* overlap.
 ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -50,7 +50,7 @@
 //! [aliasing]: ../../nomicon/aliasing.html
 //! [book]: ../../book/second-edition/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer
 //! [ub]: ../../reference/behavior-considered-undefined.html
-//! [`copy`]: ./fn.copy.html
+//! [`copy`]: ../../std/ptr/fn.copy.html
 //! [`read_unaligned`]: ./fn.read_unaligned.html
 //! [`write_unaligned`]: ./fn.write_unaligned.html
 

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -383,7 +383,7 @@ pub unsafe fn replace<T>(dest: *mut T, mut src: T) -> T {
 /// ```
 /// use std::ptr;
 ///
-/// let mut s = String::new("foo");
+/// let mut s = String::from("foo");
 /// unsafe {
 ///     // `s2` now points to the same underlying memory as `s1`.
 ///     let mut s2 = ptr::read(&s);
@@ -397,10 +397,10 @@ pub unsafe fn replace<T>(dest: *mut T, mut src: T) -> T {
 ///
 ///     // Assigning to `s` would cause the old value to be dropped again,
 ///     // resulting in undefined behavior.
-///     // s = String::new("bar"); // ERROR
+///     // s = String::from("bar"); // ERROR
 ///
 ///     // `ptr::write` can be used to overwrite a value without dropping it.
-///     ptr::write(&s, String::new("bar"));
+///     ptr::write(&mut s, String::from("bar"));
 /// }
 ///
 /// assert_eq!(s, "bar");

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -237,11 +237,11 @@ pub unsafe fn swap<T>(x: *mut T, y: *mut T) {
 ///
 /// * Both `x` and `y` must be properly aligned.
 ///
-/// * `x.offset(count)` must be [valid]. In other words, the region of memory
+/// * `x.offset(count-1)` must be [valid]. In other words, the region of memory
 ///   which begins at `x` and has a length of `count * size_of::<T>()` bytes
 ///   must belong to a single, live allocation.
 ///
-/// * `y.offset(count)` must be [valid]. In other words, the region of memory
+/// * `y.offset(count-1)` must be [valid]. In other words, the region of memory
 ///   which begins at `y` and has a length of `count * size_of::<T>()` bytes
 ///   must belong to a single, live allocation.
 ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -17,20 +17,27 @@
 //! # Safety
 //!
 //! Many functions in this module take raw pointers as arguments and dereference
-//! them. For this to be safe, these pointers must be valid. A valid pointer
-//! is one that satisfies **all** of the following conditions:
+//! them. For this to be safe, these pointers must be valid. However, because
+//! rust does not yet have a formal memory model, determining whether an
+//! arbitrary pointer is a valid one can be tricky. One thing is certain:
+//! creating a raw pointer from a reference (e.g. `&x as *const _`) *always*
+//! results in a valid pointer. By exploiting this—and by taking care when
+//! using [pointer arithmetic]—users can be confident in the correctness of
+//! their unsafe code.
 //!
-//! * The pointer is not null.
-//! * The pointer is not dangling (it does not point to memory which has been
-//!   freed).
-//! * The pointer satisfies [LLVM's pointer aliasing rules].
+//! For more information on dereferencing raw pointers, see the both the [book]
+//! and the section in the reference devoted to [undefined behavior][ub].
+//!
+//! ## Alignment
 //!
 //! Valid pointers are not necessarily properly aligned. However, most functions
 //! require their arguments to be properly aligned, and will explicitly state
 //! this requirement in the `Safety` section. Notable exceptions to this are
 //! [`read_unaligned`] and [`write_unaligned`].
 //!
-//! [LLVM's pointer aliasing rules]: https://llvm.org/docs/LangRef.html#pointer-aliasing-rules
+//! [ub]: ../../reference/behavior-considered-undefined.html
+//! [book]: ../../book/second-edition/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer
+//! [pointer arithmetic]: ../../std/primitive.pointer.html#method.offset
 //! [`read_unaligned`]: ./fn.read_unaligned.html
 //! [`write_unaligned`]: ./fn.write_unaligned.html
 

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -394,6 +394,7 @@ pub unsafe fn replace<T>(dest: *mut T, mut src: T) -> T {
 ///     // this point, `s` must no longer be used, as the underlying memory has
 ///     // been freed.
 ///     s2 = String::default();
+///     assert_eq!(s2, "");
 ///
 ///     // Assigning to `s` would cause the old value to be dropped again,
 ///     // resulting in undefined behavior.

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -42,10 +42,9 @@
 //!
 //! * The result of casting a reference to a pointer is valid for as long as the
 //!   underlying object is live.
-//! * All pointers to types with a [size of zero][zst] are valid for all
-//!   operations of size zero.
-//! * A [null] pointer is *never* valid, except when it points to a zero-sized
-//!   type.
+//! * A [null] pointer is *never* valid.
+//! * All pointers (except for the null pointer) are valid for all operations of
+//!   [size zero][zst].
 //!
 //! These axioms, along with careful use of [`offset`] for pointer arithmentic,
 //! are enough to correctly implement many useful things in unsafe code. Still,


### PR DESCRIPTION
Addresses #29371 and #36450.

This is a continuation of my work in [this PR](https://github.com/rust-lang/rust/pull/49767), which was merged prematurely.

The latest changes address all of @Gankro's concerns except the one regarding ordering of invariants for `copy_nonoverlapping`. The fact that memory regions must be nonoverlapping depends on the definition of the two memory regions above, and is also repeated in the function summary. 

@Gankro and @rkruppe pointed out that we don't have rigorously defined semantics for uninitialized memory, so all mention of it has been removed. The nomicon [implies that the functions in `std::ptr` work with uninitialized memory](https://doc.rust-lang.org/nomicon/unchecked-uninit.html), so requiring memory that is to be read be initialized is not an invariant. This conflicts with a strict interpretation of [the reference](https://doc.rust-lang.org/reference/behavior-considered-undefined.html), but resolving that is outside the scope of this PR.

Before this is merged, I need to resolve the following issues:

- [x] The new docs assert that `drop_in_place` is equivalent to calling `read` and discarding the value. Is this correct?
- [x] Do `write_bytes` and `swap_nonoverlapping` require properly aligned pointers?
- [x] Update docs for the unstable [`swap_nonoverlapping`](https://github.com/rust-lang/rust/issues/42818)
- [x] ~~Update docs for the unstable [unsafe pointer methods RFC](https://github.com/rust-lang/rfcs/pull/1966)~~ Will be done later.

In the meantime, I'm in desperate need of feedback. I'm also hosting a [rendered version of my changes](https://ecstatic-morse.github.io/rust/std/ptr/index.html) to make reviewing easier.

r? @steveklabnik 