### PR TITLE
Use crate name for reexported `extern crate` paths

### DIFF
--- a/src/librustc/ty/item_path.rs
+++ b/src/librustc/ty/item_path.rs
@@ -169,7 +169,11 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 
             let data = cur_def_key.disambiguated_data.data;
             let symbol = data.get_opt_name().map(|n| n.as_str()).unwrap_or_else(|| {
-                Symbol::intern("<unnamed>").as_str()
+                if let DefPathData::CrateRoot = data {  // reexported `extern crate` (#43189)
+                    self.original_crate_name(cur_def.krate).as_str()
+                } else {
+                    Symbol::intern("<unnamed>").as_str()
+                }
             });
             cur_path.push(symbol);
 

--- a/src/test/ui/auxiliary/xcrate_issue_43189_a.rs
+++ b/src/test/ui/auxiliary/xcrate_issue_43189_a.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type="lib"]
+
+
+pub trait A {
+    fn a(&self) {}
+}
+impl A for () {}

--- a/src/test/ui/auxiliary/xcrate_issue_43189_b.rs
+++ b/src/test/ui/auxiliary/xcrate_issue_43189_b.rs
@@ -1,0 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type="lib"]
+
+pub extern crate xcrate_issue_43189_a;

--- a/src/test/ui/issue-43189.rs
+++ b/src/test/ui/issue-43189.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue 46112: An extern crate pub re-exporting libcore was causing
+// paths rooted from `std` to be misrendered in the diagnostic output.
+
+// ignore-windows
+// aux-build:xcrate_issue_43189_a.rs
+// aux-build:xcrate_issue_43189_b.rs
+
+extern crate xcrate_issue_43189_b;
+fn main() {
+    ().a();
+    //~^ ERROR no method named `a` found for type `()` in the current scope [E0599]
+}

--- a/src/test/ui/issue-43189.stderr
+++ b/src/test/ui/issue-43189.stderr
@@ -1,0 +1,15 @@
+error[E0599]: no method named `a` found for type `()` in the current scope
+  --> $DIR/issue-43189.rs:20:8
+   |
+LL |     ().a();
+   |        ^
+   |
+   = help: items from traits can only be used if the trait is in scope
+help: the following trait is implemented but not in scope, perhaps add a `use` for it:
+   |
+LL | use xcrate_issue_43189_b::xcrate_issue_43189_a::A;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Fix #43189.