### PR TITLE
stabilize RangeBounds collections_range #30877

### DIFF
--- a/src/liballoc/btree/map.rs
+++ b/src/liballoc/btree/map.rs
@@ -1834,7 +1834,7 @@ fn range_search<BorrowType, K, V, Q: ?Sized, R: RangeBounds<Q>>(
      Handle<NodeRef<BorrowType, K, V, marker::Leaf>, marker::Edge>)
         where Q: Ord, K: Borrow<Q>
 {
-    match (range.start(), range.end()) {
+    match (range.start_bound(), range.end_bound()) {
         (Excluded(s), Excluded(e)) if s==e =>
             panic!("range start and end are equal and excluded in BTreeMap"),
         (Included(s), Included(e)) |
@@ -1852,7 +1852,7 @@ fn range_search<BorrowType, K, V, Q: ?Sized, R: RangeBounds<Q>>(
     let mut diverged = false;
 
     loop {
-        let min_edge = match (min_found, range.start()) {
+        let min_edge = match (min_found, range.start_bound()) {
             (false, Included(key)) => match search::search_linear(&min_node, key) {
                 (i, true) => { min_found = true; i },
                 (i, false) => i,
@@ -1866,7 +1866,7 @@ fn range_search<BorrowType, K, V, Q: ?Sized, R: RangeBounds<Q>>(
             (true, Excluded(_)) => 0,
         };
 
-        let max_edge = match (max_found, range.end()) {
+        let max_edge = match (max_found, range.end_bound()) {
             (false, Included(key)) => match search::search_linear(&max_node, key) {
                 (i, true) => { max_found = true; i+1 },
                 (i, false) => i,

--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -1493,12 +1493,12 @@ impl String {
         // Because the range removal happens in Drop, if the Drain iterator is leaked,
         // the removal will not happen.
         let len = self.len();
-        let start = match range.start() {
+        let start = match range.start_bound() {
             Included(&n) => n,
             Excluded(&n) => n + 1,
             Unbounded => 0,
         };
-        let end = match range.end() {
+        let end = match range.end_bound() {
             Included(&n) => n + 1,
             Excluded(&n) => n,
             Unbounded => len,
@@ -1551,12 +1551,12 @@ impl String {
         // Replace_range does not have the memory safety issues of a vector Splice.
         // of the vector version. The data is just plain bytes.
 
-        match range.start() {
+        match range.start_bound() {
              Included(&n) => assert!(self.is_char_boundary(n)),
              Excluded(&n) => assert!(self.is_char_boundary(n + 1)),
              Unbounded => {},
         };
-        match range.end() {
+        match range.end_bound() {
              Included(&n) => assert!(self.is_char_boundary(n + 1)),
              Excluded(&n) => assert!(self.is_char_boundary(n)),
              Unbounded => {},

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1166,12 +1166,12 @@ impl<T> Vec<T> {
         // the hole, and the vector length is restored to the new length.
         //
         let len = self.len();
-        let start = match range.start() {
+        let start = match range.start_bound() {
             Included(&n) => n,
             Excluded(&n) => n + 1,
             Unbounded    => 0,
         };
-        let end = match range.end() {
+        let end = match range.end_bound() {
             Included(&n) => n + 1,
             Excluded(&n) => n,
             Unbounded    => len,

--- a/src/liballoc/vec_deque.rs
+++ b/src/liballoc/vec_deque.rs
@@ -980,12 +980,12 @@ impl<T> VecDeque<T> {
         // and the head/tail values will be restored correctly.
         //
         let len = self.len();
-        let start = match range.start() {
+        let start = match range.start_bound() {
             Included(&n) => n,
             Excluded(&n) => n + 1,
             Unbounded    => 0,
         };
-        let end = match range.end() {
+        let end = match range.end_bound() {
             Included(&n) => n + 1,
             Excluded(&n) => n,
             Unbounded    => len,

--- a/src/libcore/ops/range.rs
+++ b/src/libcore/ops/range.rs
@@ -588,14 +588,12 @@ impl<Idx: PartialOrd<Idx>> RangeToInclusive<Idx> {
 /// `Bound`s are range endpoints:
 ///
 /// ```
-/// #![feature(collections_range)]
-///
 /// use std::ops::Bound::*;
 /// use std::ops::RangeBounds;
 ///
-/// assert_eq!((..100).start(), Unbounded);
-/// assert_eq!((1..12).start(), Included(&1));
-/// assert_eq!((1..12).end(), Excluded(&12));
+/// assert_eq!((..100).start_bound(), Unbounded);
+/// assert_eq!((1..12).start_bound(), Included(&1));
+/// assert_eq!((1..12).end_bound(), Excluded(&12));
 /// ```
 ///
 /// Using a tuple of `Bound`s as an argument to [`BTreeMap::range`].
@@ -632,9 +630,7 @@ pub enum Bound<T> {
     Unbounded,
 }
 
-#[unstable(feature = "collections_range",
-           reason = "might be replaced with `Into<_>` and a type containing two `Bound` values",
-           issue = "30877")]
+#[stable(feature = "collections_range", since = "1.28.0")]
 /// `RangeBounds` is implemented by Rust's built-in range types, produced
 /// by range syntax like `..`, `a..`, `..b` or `c..d`.
 pub trait RangeBounds<T: ?Sized> {
@@ -645,17 +641,16 @@ pub trait RangeBounds<T: ?Sized> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(collections_range)]
-    ///
     /// # fn main() {
     /// use std::ops::Bound::*;
     /// use std::ops::RangeBounds;
     ///
-    /// assert_eq!((..10).start(), Unbounded);
-    /// assert_eq!((3..10).start(), Included(&3));
+    /// assert_eq!((..10).start_bound(), Unbounded);
+    /// assert_eq!((3..10).start_bound(), Included(&3));
     /// # }
     /// ```
-    fn start(&self) -> Bound<&T>;
+    #[stable(feature = "collections_range", since = "1.28.0")]
+    fn start_bound(&self) -> Bound<&T>;
 
     /// End index bound.
     ///
@@ -664,17 +659,16 @@ pub trait RangeBounds<T: ?Sized> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(collections_range)]
-    ///
     /// # fn main() {
     /// use std::ops::Bound::*;
     /// use std::ops::RangeBounds;
     ///
-    /// assert_eq!((3..).end(), Unbounded);
-    /// assert_eq!((3..10).end(), Excluded(&10));
+    /// assert_eq!((3..).end_bound(), Unbounded);
+    /// assert_eq!((3..10).end_bound(), Excluded(&10));
     /// # }
     /// ```
-    fn end(&self) -> Bound<&T>;
+    #[stable(feature = "collections_range", since = "1.28.0")]
+    fn end_bound(&self) -> Bound<&T>;
 
 
     /// Returns `true` if `item` is contained in the range.
@@ -699,13 +693,13 @@ pub trait RangeBounds<T: ?Sized> {
         T: PartialOrd<U>,
         U: ?Sized + PartialOrd<T>,
     {
-        (match self.start() {
+        (match self.start_bound() {
             Included(ref start) => *start <= item,
             Excluded(ref start) => *start < item,
             Unbounded => true,
         })
         &&
-        (match self.end() {
+        (match self.end_bound() {
             Included(ref end) => item <= *end,
             Excluded(ref end) => item < *end,
             Unbounded => true,
@@ -715,83 +709,69 @@ pub trait RangeBounds<T: ?Sized> {
 
 use self::Bound::{Excluded, Included, Unbounded};
 
-#[unstable(feature = "collections_range",
-           reason = "might be replaced with `Into<_>` and a type containing two `Bound` values",
-           issue = "30877")]
+#[stable(feature = "collections_range", since = "1.28.0")]
 impl<T: ?Sized> RangeBounds<T> for RangeFull {
-    fn start(&self) -> Bound<&T> {
+    fn start_bound(&self) -> Bound<&T> {
         Unbounded
     }
-    fn end(&self) -> Bound<&T> {
+    fn end_bound(&self) -> Bound<&T> {
         Unbounded
     }
 }
 
-#[unstable(feature = "collections_range",
-           reason = "might be replaced with `Into<_>` and a type containing two `Bound` values",
-           issue = "30877")]
+#[stable(feature = "collections_range", since = "1.28.0")]
 impl<T> RangeBounds<T> for RangeFrom<T> {
-    fn start(&self) -> Bound<&T> {
+    fn start_bound(&self) -> Bound<&T> {
         Included(&self.start)
     }
-    fn end(&self) -> Bound<&T> {
+    fn end_bound(&self) -> Bound<&T> {
         Unbounded
     }
 }
 
-#[unstable(feature = "collections_range",
-           reason = "might be replaced with `Into<_>` and a type containing two `Bound` values",
-           issue = "30877")]
+#[stable(feature = "collections_range", since = "1.28.0")]
 impl<T> RangeBounds<T> for RangeTo<T> {
-    fn start(&self) -> Bound<&T> {
+    fn start_bound(&self) -> Bound<&T> {
         Unbounded
     }
-    fn end(&self) -> Bound<&T> {
+    fn end_bound(&self) -> Bound<&T> {
         Excluded(&self.end)
     }
 }
 
-#[unstable(feature = "collections_range",
-           reason = "might be replaced with `Into<_>` and a type containing two `Bound` values",
-           issue = "30877")]
+#[stable(feature = "collections_range", since = "1.28.0")]
 impl<T> RangeBounds<T> for Range<T> {
-    fn start(&self) -> Bound<&T> {
+    fn start_bound(&self) -> Bound<&T> {
         Included(&self.start)
     }
-    fn end(&self) -> Bound<&T> {
+    fn end_bound(&self) -> Bound<&T> {
         Excluded(&self.end)
     }
 }
 
-#[unstable(feature = "collections_range",
-           reason = "might be replaced with `Into<_>` and a type containing two `Bound` values",
-           issue = "30877")]
+#[stable(feature = "collections_range", since = "1.28.0")]
 impl<T> RangeBounds<T> for RangeInclusive<T> {
-    fn start(&self) -> Bound<&T> {
+    fn start_bound(&self) -> Bound<&T> {
         Included(&self.start)
     }
-    fn end(&self) -> Bound<&T> {
+    fn end_bound(&self) -> Bound<&T> {
         Included(&self.end)
     }
 }
 
-#[unstable(feature = "collections_range",
-           reason = "might be replaced with `Into<_>` and a type containing two `Bound` values",
-           issue = "30877")]
+#[stable(feature = "collections_range", since = "1.28.0")]
 impl<T> RangeBounds<T> for RangeToInclusive<T> {
-    fn start(&self) -> Bound<&T> {
+    fn start_bound(&self) -> Bound<&T> {
         Unbounded
     }
-    fn end(&self) -> Bound<&T> {
+    fn end_bound(&self) -> Bound<&T> {
         Included(&self.end)
     }
 }
 
-#[unstable(feature = "collections_range",
-           reason = "might be replaced with `Into<_>` and a type containing two `Bound` values",
-           issue = "30877")]
+#[stable(feature = "collections_range", since = "1.28.0")]
 impl<T> RangeBounds<T> for (Bound<T>, Bound<T>) {
-    fn start(&self) -> Bound<&T> {
+    fn start_bound(&self) -> Bound<&T> {
         match *self {
             (Included(ref start), _) => Included(start),
             (Excluded(ref start), _) => Excluded(start),
@@ -799,7 +779,7 @@ impl<T> RangeBounds<T> for (Bound<T>, Bound<T>) {
         }
     }
 
-    fn end(&self) -> Bound<&T> {
+    fn end_bound(&self) -> Bound<&T> {
         match *self {
             (_, Included(ref end)) => Included(end),
             (_, Excluded(ref end)) => Excluded(end),
@@ -808,75 +788,63 @@ impl<T> RangeBounds<T> for (Bound<T>, Bound<T>) {
     }
 }
 
-#[unstable(feature = "collections_range",
-           reason = "might be replaced with `Into<_>` and a type containing two `Bound` values",
-           issue = "30877")]
+#[stable(feature = "collections_range", since = "1.28.0")]
 impl<'a, T: ?Sized + 'a> RangeBounds<T> for (Bound<&'a T>, Bound<&'a T>) {
-    fn start(&self) -> Bound<&T> {
+    fn start_bound(&self) -> Bound<&T> {
         self.0
     }
 
-    fn end(&self) -> Bound<&T> {
+    fn end_bound(&self) -> Bound<&T> {
         self.1
     }
 }
 
-#[unstable(feature = "collections_range",
-           reason = "might be replaced with `Into<_>` and a type containing two `Bound` values",
-           issue = "30877")]
+#[stable(feature = "collections_range", since = "1.28.0")]
 impl<'a, T> RangeBounds<T> for RangeFrom<&'a T> {
-    fn start(&self) -> Bound<&T> {
+    fn start_bound(&self) -> Bound<&T> {
         Included(self.start)
     }
-    fn end(&self) -> Bound<&T> {
+    fn end_bound(&self) -> Bound<&T> {
         Unbounded
     }
 }
 
-#[unstable(feature = "collections_range",
-           reason = "might be replaced with `Into<_>` and a type containing two `Bound` values",
-           issue = "30877")]
+#[stable(feature = "collections_range", since = "1.28.0")]
 impl<'a, T> RangeBounds<T> for RangeTo<&'a T> {
-    fn start(&self) -> Bound<&T> {
+    fn start_bound(&self) -> Bound<&T> {
         Unbounded
     }
-    fn end(&self) -> Bound<&T> {
+    fn end_bound(&self) -> Bound<&T> {
         Excluded(self.end)
     }
 }
 
-#[unstable(feature = "collections_range",
-           reason = "might be replaced with `Into<_>` and a type containing two `Bound` values",
-           issue = "30877")]
+#[stable(feature = "collections_range", since = "1.28.0")]
 impl<'a, T> RangeBounds<T> for Range<&'a T> {
-    fn start(&self) -> Bound<&T> {
+    fn start_bound(&self) -> Bound<&T> {
         Included(self.start)
     }
-    fn end(&self) -> Bound<&T> {
+    fn end_bound(&self) -> Bound<&T> {
         Excluded(self.end)
     }
 }
 
-#[unstable(feature = "collections_range",
-           reason = "might be replaced with `Into<_>` and a type containing two `Bound` values",
-           issue = "30877")]
+#[stable(feature = "collections_range", since = "1.28.0")]
 impl<'a, T> RangeBounds<T> for RangeInclusive<&'a T> {
-    fn start(&self) -> Bound<&T> {
+    fn start_bound(&self) -> Bound<&T> {
         Included(self.start)
     }
-    fn end(&self) -> Bound<&T> {
+    fn end_bound(&self) -> Bound<&T> {
         Included(self.end)
     }
 }
 
-#[unstable(feature = "collections_range",
-           reason = "might be replaced with `Into<_>` and a type containing two `Bound` values",
-           issue = "30877")]
+#[stable(feature = "collections_range", since = "1.28.0")]
 impl<'a, T> RangeBounds<T> for RangeToInclusive<&'a T> {
-    fn start(&self) -> Bound<&T> {
+    fn start_bound(&self) -> Bound<&T> {
         Unbounded
     }
-    fn end(&self) -> Bound<&T> {
+    fn end_bound(&self) -> Bound<&T> {
         Included(self.end)
     }
 }

--- a/src/librustc_data_structures/array_vec.rs
+++ b/src/librustc_data_structures/array_vec.rs
@@ -119,12 +119,12 @@ impl<A: Array> ArrayVec<A> {
         // the hole, and the vector length is restored to the new length.
         //
         let len = self.len();
-        let start = match range.start() {
+        let start = match range.start_bound() {
             Included(&n) => n,
             Excluded(&n) => n + 1,
             Unbounded    => 0,
         };
-        let end = match range.end() {
+        let end = match range.end_bound() {
             Included(&n) => n + 1,
             Excluded(&n) => n,
             Unbounded    => len,

--- a/src/librustc_data_structures/sorted_map.rs
+++ b/src/librustc_data_structures/sorted_map.rs
@@ -214,7 +214,7 @@ impl<K: Ord, V> SortedMap<K, V> {
     fn range_slice_indices<R>(&self, range: R) -> (usize, usize)
         where R: RangeBounds<K>
     {
-        let start = match range.start() {
+        let start = match range.start_bound() {
             Bound::Included(ref k) => {
                 match self.lookup_index_for(k) {
                     Ok(index) | Err(index) => index
@@ -229,7 +229,7 @@ impl<K: Ord, V> SortedMap<K, V> {
             Bound::Unbounded => 0,
         };
 
-        let end = match range.end() {
+        let end = match range.end_bound() {
             Bound::Included(ref k) => {
                 match self.lookup_index_for(k) {
                     Ok(index) => index + 1,

--- a/src/libstd/collections/mod.rs
+++ b/src/libstd/collections/mod.rs
@@ -437,14 +437,6 @@ pub use self::hash_map::HashMap;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::hash_set::HashSet;
 
-#[unstable(feature = "collections_range", issue = "30877")]
-#[rustc_deprecated(reason = "renamed and moved to `std::ops::RangeBounds`", since = "1.26.0")]
-#[doc(hidden)]
-/// Range syntax
-pub mod range {
-    pub use ops::RangeBounds as RangeArgument;
-}
-
 #[unstable(feature = "try_reserve", reason = "new API", issue="48043")]
 pub use heap::CollectionAllocErr;
 


### PR DESCRIPTION
The FCP for #30877 closed last month, with the decision to:
1. move from `collections::range::RangeArgument` to `ops::RangeBounds`, and
2. rename `start()` and `end()` to `start_bounds()` and `end_bounds()`.

Simon Sapin already moved it to `ops::RangeBounds` in #49163.

I renamed the functions, and removed the old `collections::range::RangeArgument` alias.

This is my first Rust PR, please let me know if I can improve anything. This passes all tests for me, except the `clippy` tool (which uses `RangeArgument::start()`).

I considered deprecating `start()` and `end()` instead of removing them, but the contribution guidelines indicate we can break `clippy` temporarily. I thought it was best to remove the functions, since we're worried about name collisions with `Range::start` and `end`.

Closes #30877.