### PR TITLE
std: Ensure OOM is classified as `nounwind`

### DIFF
--- a/src/liballoc/alloc.rs
+++ b/src/liballoc/alloc.rs
@@ -133,6 +133,7 @@ pub(crate) unsafe fn box_free<T: ?Sized>(ptr: Unique<T>) {
     }
 }
 
+#[rustc_allocator_nounwind]
 pub fn oom() -> ! {
     extern {
         #[lang = "oom"]

--- a/src/librustc_codegen_llvm/callee.rs
+++ b/src/librustc_codegen_llvm/callee.rs
@@ -26,7 +26,6 @@ use rustc::hir::def_id::DefId;
 use rustc::ty::{self, TypeFoldable};
 use rustc::ty::layout::LayoutOf;
 use rustc::ty::subst::Substs;
-use rustc_target::spec::PanicStrategy;
 
 /// Codegens a reference to a fn/method item, monomorphizing and
 /// inlining as it goes.
@@ -101,16 +100,6 @@ pub fn get_fn<'a, 'tcx>(cx: &CodegenCx<'a, 'tcx>,
         attributes::from_fn_attrs(cx, llfn, instance.def.def_id());
 
         let instance_def_id = instance.def_id();
-
-        // Perhaps questionable, but we assume that anything defined
-        // *in Rust code* may unwind. Foreign items like `extern "C" {
-        // fn foo(); }` are assumed not to unwind **unless** they have
-        // a `#[unwind]` attribute.
-        if tcx.sess.panic_strategy() == PanicStrategy::Unwind {
-            if !tcx.is_foreign_item(instance_def_id) {
-                attributes::unwind(llfn, true);
-            }
-        }
 
         // Apply an appropriate linkage/visibility value to our item that we
         // just declared.

--- a/src/test/codegen/vec-iter-collect-len.rs
+++ b/src/test/codegen/vec-iter-collect-len.rs
@@ -1,0 +1,21 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-system-llvm
+// compile-flags: -O
+#![crate_type="lib"]
+
+#[no_mangle]
+pub fn get_len() -> usize {
+    // CHECK-LABEL: @get_len
+    // CHECK-NOT: call
+    // CHECK-NOT: invoke
+    [1, 2, 3].iter().collect::<Vec<_>>().len()
+}


### PR DESCRIPTION
OOM can't unwind today, and historically it's been optimized as if it can't
unwind. This accidentally regressed with recent changes to the OOM handler, so
this commit adds in a codegen test to assert that everything gets optimized away
after the OOM function is approrpiately classified as nounwind

Closes #50925