### PR TITLE
Re-enable trivial bounds

### DIFF
--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -648,12 +648,7 @@ pub fn normalize_param_env_or_error<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
     let predicates: Vec<_> =
         util::elaborate_predicates(tcx, unnormalized_env.caller_bounds.to_vec())
-        .filter(|p| !p.is_global() || p.has_late_bound_regions()) // (*)
         .collect();
-
-    // (*) FIXME(#50825) This shouldn't be needed.
-    // Removing the bounds here stopped them from being prefered in selection.
-    // See the issue-50825 ui tests for examples
 
     debug!("normalize_param_env_or_error: elaborated-predicates={:?}",
            predicates);

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -711,6 +711,7 @@ fn check_false_global_bounds<'a, 'gcx, 'tcx>(
     for pred in implied_obligations {
         // Match the existing behavior.
         if pred.is_global() && !pred.has_late_bound_regions() {
+            let pred = fcx.normalize_associated_types_in(span, &pred);
             let obligation = traits::Obligation::new(
                 traits::ObligationCause::new(
                     span,

--- a/src/test/ui/feature-gate-trivial_bounds.rs
+++ b/src/test/ui/feature-gate-trivial_bounds.rs
@@ -28,7 +28,7 @@ union U where i32: Foo { f: i32 } //~ ERROR
 type Y where i32: Foo = (); // OK - bound is ignored
 
 impl Foo for () where i32: Foo { //~ ERROR
-    fn test(&self) { //~ ERROR
+    fn test(&self) {
         3i32.test();
         Foo::test(&4i32);
         generic_function(5i32);
@@ -60,7 +60,7 @@ struct Dst<X: ?Sized> {
 }
 
 struct TwoStrs(str, str) where str: Sized; //~ ERROR
-//~^ ERROR
+
 
 fn unsized_local() where Dst<A>: Sized { //~ ERROR
     let x: Dst<A> = *(Box::new(Dst { x: 1 }) as Box<Dst<A>>);

--- a/src/test/ui/feature-gate-trivial_bounds.stderr
+++ b/src/test/ui/feature-gate-trivial_bounds.stderr
@@ -38,7 +38,7 @@ error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/feature-gate-trivial_bounds.rs:30:1
    |
 LL | / impl Foo for () where i32: Foo { //~ ERROR
-LL | |     fn test(&self) { //~ ERROR
+LL | |     fn test(&self) {
 LL | |         3i32.test();
 LL | |         Foo::test(&4i32);
 LL | |         generic_function(5i32);
@@ -97,15 +97,6 @@ LL | struct TwoStrs(str, str) where str: Sized; //~ ERROR
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
-error[E0277]: the trait bound `str: std::marker::Sized` is not satisfied
-  --> $DIR/feature-gate-trivial_bounds.rs:62:16
-   |
-LL | struct TwoStrs(str, str) where str: Sized; //~ ERROR
-   |                ^^^ `str` does not have a constant size known at compile-time
-   |
-   = help: the trait `std::marker::Sized` is not implemented for `str`
-   = note: only the last field of a struct may have a dynamically sized type
-
 error[E0277]: the trait bound `A + 'static: std::marker::Sized` is not satisfied in `Dst<A + 'static>`
   --> $DIR/feature-gate-trivial_bounds.rs:65:1
    |
@@ -131,22 +122,6 @@ LL | | }
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
-error[E0277]: the trait bound `i32: Foo` is not satisfied
-  --> $DIR/feature-gate-trivial_bounds.rs:31:5
-   |
-LL | /     fn test(&self) { //~ ERROR
-LL | |         3i32.test();
-LL | |         Foo::test(&4i32);
-LL | |         generic_function(5i32);
-LL | |     }
-   | |_____^ the trait `Foo` is not implemented for `i32`
-   |
-note: required by `Foo`
-  --> $DIR/feature-gate-trivial_bounds.rs:14:1
-   |
-LL | pub trait Foo {
-   | ^^^^^^^^^^^^^
-
-error: aborting due to 13 previous errors
+error: aborting due to 11 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/issue-50825-1.rs
+++ b/src/test/ui/issue-50825-1.rs
@@ -10,7 +10,7 @@
 
 // run-pass
 // regression test for issue #50825
-// Make sure that the `impl` bound (): X<T = ()> is prefered over
+// Make sure that the `impl` bound (): X<T = ()> is preferred over
 // the (): X bound in the where clause.
 
 trait X {

--- a/src/test/ui/issue-50825.rs
+++ b/src/test/ui/issue-50825.rs
@@ -10,7 +10,7 @@
 
 // run-pass
 // regression test for issue #50825
-// Make sure that the built-in bound {integer}: Sized is prefered over
+// Make sure that the built-in bound {integer}: Sized is preferred over
 // the u64: Sized bound in the where clause.
 
 fn foo(y: &[()])

--- a/src/test/ui/issue-51044.rs
+++ b/src/test/ui/issue-51044.rs
@@ -1,0 +1,40 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-pass
+// regression test for issue #50825
+// Check that the feature gate normalizes associated types.
+
+#![allow(dead_code)]
+struct Foo<T>(T);
+struct Duck;
+struct Quack;
+
+trait Hello<A> where A: Animal {
+}
+
+trait Animal {
+    type Noise;
+}
+
+trait Loud<R>  {
+}
+
+impl Loud<Quack> for f32 {
+}
+
+impl Animal for Duck {
+    type Noise = Quack;
+}
+
+impl Hello<Duck> for Foo<f32> where f32: Loud<<Duck as Animal>::Noise> {
+}
+
+fn main() {}

--- a/src/test/ui/trivial-bounds-inconsistent-associated-functions.rs
+++ b/src/test/ui/trivial-bounds-inconsistent-associated-functions.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-test FIXME(#50825)
 // run-pass
 // Inconsistent bounds with trait implementations
 

--- a/src/test/ui/trivial-bounds-inconsistent-copy-reborrow.rs
+++ b/src/test/ui/trivial-bounds-inconsistent-copy-reborrow.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-test FIXME(#50825)
 // Check that reborrows are still illegal with Copy mutable references
 #![feature(trivial_bounds)]
 #![allow(unused)]

--- a/src/test/ui/trivial-bounds-inconsistent-copy.rs
+++ b/src/test/ui/trivial-bounds-inconsistent-copy.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-test FIXME(#50825)
 // run-pass
 // Check tautalogically false `Copy` bounds
 #![feature(trivial_bounds)]

--- a/src/test/ui/trivial-bounds-inconsistent-projection-error.rs
+++ b/src/test/ui/trivial-bounds-inconsistent-projection-error.rs
@@ -1,0 +1,33 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(trivial_bounds)]
+#![allow(unused)]
+
+struct B;
+
+trait A {
+    type X;
+    fn get_x() -> Self::X;
+}
+
+impl A for B {
+    type X = u8;
+    fn get_x() -> u8 { 0 }
+}
+
+fn global_bound_is_hidden() -> u8
+where
+    B: A<X = i32>
+{
+    B::get_x() //~ ERROR
+}
+
+fn main () {}

--- a/src/test/ui/trivial-bounds-inconsistent-projection-error.stderr
+++ b/src/test/ui/trivial-bounds-inconsistent-projection-error.stderr
@@ -1,0 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/trivial-bounds-inconsistent-projection-error.rs:30:5
+   |
+LL | fn global_bound_is_hidden() -> u8
+   |                                -- expected `u8` because of return type
+...
+LL |     B::get_x() //~ ERROR
+   |     ^^^^^^^^^^ expected u8, found i32
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/trivial-bounds-inconsistent-projection.rs
+++ b/src/test/ui/trivial-bounds-inconsistent-projection.rs
@@ -1,0 +1,64 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-pass
+// Check that global bounds result in the expected choice of associated type
+
+#![feature(trivial_bounds)]
+#![allow(unused)]
+
+struct B;
+
+trait A {
+    type X;
+    fn get_x() -> Self::X;
+}
+
+impl A for B {
+    type X = u8;
+    fn get_x() -> u8 { 0 }
+}
+
+fn underspecified_bound() -> u8
+where
+    B: A
+{
+    B::get_x()
+}
+
+fn inconsistent_bound() -> i32
+where
+    B: A<X = i32>
+{
+    B::get_x()
+}
+
+fn redundant_bound() -> u8
+where
+    B: A<X = u8>
+{
+    B::get_x()
+}
+
+fn inconsistent_dup_bound() -> i32
+where
+    B: A<X = i32> + A
+{
+    B::get_x()
+}
+
+fn redundant_dup_bound() -> u8
+where
+    B: A<X = u8> + A
+{
+    B::get_x()
+}
+
+fn main () {}

--- a/src/test/ui/trivial-bounds-inconsistent-projection.stderr
+++ b/src/test/ui/trivial-bounds-inconsistent-projection.stderr
@@ -1,0 +1,57 @@
+warning: Trait bound B: A does not depend on any type or lifetime parameters
+  --> $DIR/trivial-bounds-inconsistent-projection.rs:29:1
+   |
+LL | / fn underspecified_bound() -> u8
+LL | | where
+LL | |     B: A
+LL | | {
+LL | |     B::get_x()
+LL | | }
+   | |_^
+   |
+   = note: #[warn(trivial_bounds)] on by default
+
+warning: Trait bound B: A does not depend on any type or lifetime parameters
+  --> $DIR/trivial-bounds-inconsistent-projection.rs:36:1
+   |
+LL | / fn inconsistent_bound() -> i32
+LL | | where
+LL | |     B: A<X = i32>
+LL | | {
+LL | |     B::get_x()
+LL | | }
+   | |_^
+
+warning: Trait bound B: A does not depend on any type or lifetime parameters
+  --> $DIR/trivial-bounds-inconsistent-projection.rs:43:1
+   |
+LL | / fn redundant_bound() -> u8
+LL | | where
+LL | |     B: A<X = u8>
+LL | | {
+LL | |     B::get_x()
+LL | | }
+   | |_^
+
+warning: Trait bound B: A does not depend on any type or lifetime parameters
+  --> $DIR/trivial-bounds-inconsistent-projection.rs:50:1
+   |
+LL | / fn inconsistent_dup_bound() -> i32
+LL | | where
+LL | |     B: A<X = i32> + A
+LL | | {
+LL | |     B::get_x()
+LL | | }
+   | |_^
+
+warning: Trait bound B: A does not depend on any type or lifetime parameters
+  --> $DIR/trivial-bounds-inconsistent-projection.rs:57:1
+   |
+LL | / fn redundant_dup_bound() -> u8
+LL | | where
+LL | |     B: A<X = u8> + A
+LL | | {
+LL | |     B::get_x()
+LL | | }
+   | |_^
+

--- a/src/test/ui/trivial-bounds-inconsistent-sized.rs
+++ b/src/test/ui/trivial-bounds-inconsistent-sized.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-test FIXME(#50825)
 // run-pass
 // Check tautalogically false `Sized` bounds
 #![feature(trivial_bounds)]

--- a/src/test/ui/trivial-bounds-inconsistent-well-formed.rs
+++ b/src/test/ui/trivial-bounds-inconsistent-well-formed.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-test FIXME(#50825)
 // run-pass
 // Test that inconsistent bounds are used in well-formedness checks
 #![feature(trivial_bounds)]

--- a/src/test/ui/trivial-bounds-inconsistent.rs
+++ b/src/test/ui/trivial-bounds-inconsistent.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-test FIXME(#50825)
 // run-pass
 
 // Check that tautalogically false bounds are accepted, and are used

--- a/src/test/ui/trivial-bounds-leak-copy.rs
+++ b/src/test/ui/trivial-bounds-leak-copy.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-test FIXME(#50825)
 // Check that false Copy bounds don't leak
 #![feature(trivial_bounds)]
 

--- a/src/test/ui/trivial-bounds-leak.rs
+++ b/src/test/ui/trivial-bounds-leak.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-test FIXME(#50825)
 // Check that false bounds don't leak
 #![feature(trivial_bounds)]
 

--- a/src/test/ui/trivial-bounds-lint.rs
+++ b/src/test/ui/trivial-bounds-lint.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-test FIXME(#50825)
 #![feature(trivial_bounds)]
 #![allow(unused)]
 #![deny(trivial_bounds)]

--- a/src/test/ui/trivial-bounds-object.rs
+++ b/src/test/ui/trivial-bounds-object.rs
@@ -1,0 +1,28 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-pass
+// Check that the object bound dyn A + 'a: A is preferred over the
+// where clause bound dyn A + 'static: A.
+
+#![allow(unused)]
+
+trait A {
+    fn test(&self);
+}
+
+fn foo(x: &dyn A)
+where
+    dyn A + 'static: A, // Using this bound would lead to a lifetime error.
+{
+    x.test();
+}
+
+fn main () {}


### PR DESCRIPTION
cc #50825 

Remove implementations from global bounds in winnowing when there is ambiguity.

This results in the reverse of #24066 happening sometimes. I'm not sure if anything can be done about that though.

cc #48214

r? @nikomatsakis 