### PR TITLE
Stable point release (1.26.1)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,209 @@
+Version 1.26.0 (2018-05-10)
+==========================
+
+Language
+--------
+- [Closures now implement `Copy` and/or `Clone` if all captured variables
+  implement either or both traits.][49299]
+- [The inclusive range syntax e.g. `for x in 0..=10` is now stable.][47813]
+- [Stablise `'_`. The underscore lifetime can be used anywhere where a
+  lifetime can be elided.][49458]
+- [`impl Trait` is now stable allowing you to have abstract types in returns
+   or in function parameters.][49255] e.g. `fn foo() -> impl Iterator<Item=u8>` or
+  `fn open(path: impl AsRef<Path>)`.
+- [Pattern matching will now automatically apply dereferences.][49394]
+- [128-bit integers in the form of `u128` and `i128` are now stable.][49101]
+- [`main` can now return `Result<(), E: Debug>`][49162] in addition to `()`.
+- [A lot of operations are now available in a const context.][46882] E.g. You
+  can now index into constant arrays, reference and dereference into constants,
+  and use Tuple struct constructors.
+- [Fixed entry slice patterns are now stable.][48516] e.g.
+  ```rust
+  let points = [1, 2, 3, 4];
+  match points {
+      [1, 2, 3, 4] => println!("All points were sequential."),
+      _ => println!("Not all points were sequential."),
+  }
+  ```
+
+
+Compiler
+--------
+- [LLD is now used as the default linker for `wasm32-unknown-unknown`.][48125]
+- [Fixed exponential projection complexity on nested types.][48296]
+  This can provide up to a ~12% reduction in compile times for certain crates.
+- [Added the `--remap-path-prefix` option to rustc.][48359] Allowing you
+  to remap path prefixes outputted by the compiler.
+- [Added `powerpc-unknown-netbsd` target.][48281]
+
+Libraries
+---------
+- [Implemented `From<u16> for usize` & `From<{u8, i16}> for isize`.][49305]
+- [Added hexadecimal formatting for integers with fmt::Debug][48978]
+  e.g. `assert!(format!("{:02x?}", b"Foo\0") == "[46, 6f, 6f, 00]")`
+- [Implemented `Default, Hash` for `cmp::Reverse`.][48628]
+- [Optimized `str::repeat` being 8x faster in large cases.][48657]
+- [`ascii::escape_default` is now available in libcore.][48735]
+- [Trailing commas are now supported in std and core macros.][48056]
+- [Implemented `Copy, Clone` for `cmp::Reverse`][47379]
+- [Implemented `Clone` for `char::{ToLowercase, ToUppercase}`.][48629]
+
+Stabilized APIs
+---------------
+- [`*const T::add`]
+- [`*const T::copy_to_nonoverlapping`]
+- [`*const T::copy_to`]
+- [`*const T::read_unaligned`]
+- [`*const T::read_volatile`]
+- [`*const T::read`]
+- [`*const T::sub`]
+- [`*const T::wrapping_add`]
+- [`*const T::wrapping_sub`]
+- [`*mut T::add`]
+- [`*mut T::copy_to_nonoverlapping`]
+- [`*mut T::copy_to`]
+- [`*mut T::read_unaligned`]
+- [`*mut T::read_volatile`]
+- [`*mut T::read`]
+- [`*mut T::replace`]
+- [`*mut T::sub`]
+- [`*mut T::swap`]
+- [`*mut T::wrapping_add`]
+- [`*mut T::wrapping_sub`]
+- [`*mut T::write_bytes`]
+- [`*mut T::write_unaligned`]
+- [`*mut T::write_volatile`]
+- [`*mut T::write`]
+- [`Box::leak`]
+- [`FromUtf8Error::as_bytes`]
+- [`LocalKey::try_with`]
+- [`Option::cloned`]
+- [`btree_map::Entry::and_modify`]
+- [`fs::read_to_string`]
+- [`fs::read`]
+- [`fs::write`]
+- [`hash_map::Entry::and_modify`]
+- [`iter::FusedIterator`]
+- [`ops::RangeInclusive`]
+- [`ops::RangeToInclusive`]
+- [`process::id`]
+- [`slice::rotate_left`]
+- [`slice::rotate_right`]
+- [`String::retain`]
+
+
+Cargo
+-----
+- [Cargo will now output path to custom commands when `-v` is
+  passed with `--list`][cargo/5041]
+- [The Cargo binary version is now the same as the Rust version][cargo/5083]
+- [`Cargo.lock` files are now included in published crates.][cargo/5093]
+
+Misc
+----
+- [The second edition of "The Rust Programming Language" book is now recommended
+  over the first.][48404]
+
+Compatibility Notes
+-------------------
+
+- [aliasing a `Fn` trait as `dyn` no longer works.][48481] E.g. the following
+  syntax is now invalid.
+  ```
+  use std::ops::Fn as dyn;
+  fn g(_: Box<dyn(std::fmt::Debug)>) {}
+  ```
+- [The result of dereferences are no longer promoted to `'static`.][47408]
+  e.g.
+  ```rust
+  fn main() {
+      const PAIR: &(i32, i32) = &(0, 1);
+      let _reversed_pair: &'static _ = &(PAIR.1, PAIR.0); // Doesn't work
+  }
+  ```
+- [Deprecate `AsciiExt` trait in favor of inherent methods.][49109]
+- [`".e0"` will now no longer parse as `0.0` and will instead cause
+  an error.][48235]
+- [Removed hoedown from rustdoc.][48274]
+- [Bounds on higher-kinded lifetimes a hard error.][48326]
+
+[46882]: https://github.com/rust-lang/rust/pull/46882
+[47379]: https://github.com/rust-lang/rust/pull/47379
+[47408]: https://github.com/rust-lang/rust/pull/47408
+[47813]: https://github.com/rust-lang/rust/pull/47813
+[48056]: https://github.com/rust-lang/rust/pull/48056
+[48125]: https://github.com/rust-lang/rust/pull/48125
+[48166]: https://github.com/rust-lang/rust/pull/48166
+[48235]: https://github.com/rust-lang/rust/pull/48235
+[48274]: https://github.com/rust-lang/rust/pull/48274
+[48281]: https://github.com/rust-lang/rust/pull/48281
+[48296]: https://github.com/rust-lang/rust/pull/48296
+[48326]: https://github.com/rust-lang/rust/pull/48326
+[48359]: https://github.com/rust-lang/rust/pull/48359
+[48404]: https://github.com/rust-lang/rust/pull/48404
+[48481]: https://github.com/rust-lang/rust/pull/48481
+[48516]: https://github.com/rust-lang/rust/pull/48516
+[48628]: https://github.com/rust-lang/rust/pull/48628
+[48629]: https://github.com/rust-lang/rust/pull/48629
+[48657]: https://github.com/rust-lang/rust/pull/48657
+[48735]: https://github.com/rust-lang/rust/pull/48735
+[48978]: https://github.com/rust-lang/rust/pull/48978
+[49101]: https://github.com/rust-lang/rust/pull/49101
+[49109]: https://github.com/rust-lang/rust/pull/49109
+[49121]: https://github.com/rust-lang/rust/pull/49121
+[49162]: https://github.com/rust-lang/rust/pull/49162
+[49184]: https://github.com/rust-lang/rust/pull/49184
+[49234]: https://github.com/rust-lang/rust/pull/49234
+[49255]: https://github.com/rust-lang/rust/pull/49255
+[49299]: https://github.com/rust-lang/rust/pull/49299
+[49305]: https://github.com/rust-lang/rust/pull/49305
+[49394]: https://github.com/rust-lang/rust/pull/49394
+[49458]: https://github.com/rust-lang/rust/pull/49458
+[`*const T::add`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.add
+[`*const T::copy_to_nonoverlapping`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.copy_to_nonoverlapping
+[`*const T::copy_to`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.copy_to
+[`*const T::read_unaligned`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.read_unaligned
+[`*const T::read_volatile`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.read_volatile
+[`*const T::read`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.read
+[`*const T::sub`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.sub
+[`*const T::wrapping_add`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.wrapping_add
+[`*const T::wrapping_sub`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.wrapping_sub
+[`*mut T::add`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.add-1
+[`*mut T::copy_to_nonoverlapping`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.copy_to_nonoverlapping-1
+[`*mut T::copy_to`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.copy_to-1
+[`*mut T::read_unaligned`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.read_unaligned-1
+[`*mut T::read_volatile`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.read_volatile-1
+[`*mut T::read`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.read-1
+[`*mut T::replace`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.replace
+[`*mut T::sub`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.sub-1
+[`*mut T::swap`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.swap
+[`*mut T::wrapping_add`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.wrapping_add-1
+[`*mut T::wrapping_sub`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.wrapping_sub-1
+[`*mut T::write_bytes`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.write_bytes
+[`*mut T::write_unaligned`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.write_unaligned
+[`*mut T::write_volatile`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.write_volatile
+[`*mut T::write`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.write
+[`Box::leak`]: https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak
+[`FromUtf8Error::as_bytes`]: https://doc.rust-lang.org/std/string/struct.FromUtf8Error.html#method.as_bytes
+[`LocalKey::try_with`]: https://doc.rust-lang.org/std/thread/struct.LocalKey.html#method.try_with
+[`Option::cloned`]: https://doc.rust-lang.org/std/option/enum.Option.html#method.cloned
+[`btree_map::Entry::and_modify`]: https://doc.rust-lang.org/std/collections/btree_map/enum.Entry.html#method.and_modify
+[`fs::read_to_string`]: https://doc.rust-lang.org/std/fs/fn.read_to_string.html
+[`fs::read`]: https://doc.rust-lang.org/std/fs/fn.read.html
+[`fs::write`]: https://doc.rust-lang.org/std/fs/fn.write.html
+[`hash_map::Entry::and_modify`]: https://doc.rust-lang.org/std/collections/hash_map/enum.Entry.html#method.and_modify
+[`iter::FusedIterator`]: https://doc.rust-lang.org/std/iter/trait.FusedIterator.html
+[`ops::RangeInclusive`]: https://doc.rust-lang.org/std/ops/struct.RangeInclusive.html
+[`ops::RangeToInclusive`]: https://doc.rust-lang.org/std/ops/struct.RangeToInclusive.html
+[`process::id`]: https://doc.rust-lang.org/std/process/fn.id.html
+[`slice::rotate_left`]: https://doc.rust-lang.org/std/primitive.slice.html#method.rotate_left
+[`slice::rotate_right`]: https://doc.rust-lang.org/std/primitive.slice.html#method.rotate_right
+[`String::retain`]: https://doc.rust-lang.org/std/string/struct.String.html#method.retain
+[cargo/5041]: https://github.com/rust-lang/cargo/pull/5041
+[cargo/5083]: https://github.com/rust-lang/cargo/pull/5083
+[cargo/5093]: https://github.com/rust-lang/cargo/pull/5093
+
+
 Version 1.25.0 (2018-03-29)
 ==========================
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,27 @@
+Version 1.26.1 (2018-05-29)
+==========================
+
+Tools
+-----
+
+- [RLS now works on Windows][50646]
+- [Rustfmt stopped badly formatting text in some cases][rustfmt/2695]
+
+Compatibility Notes
+--------
+
+- [`fn main() -> impl Trait` no longer works for non-Termination
+  trait][50656]
+  This reverts an accidental stabilization.
+- [`NaN > NaN` no longer returns true in const-fn contexts][50812]
+- [Prohibit using turbofish for `impl Trait` in method arguments][50950]
+
+[50646]: https://github.com/rust-lang/rust/issues/50646
+[50656]: https://github.com/rust-lang/rust/pull/50656
+[50812]: https://github.com/rust-lang/rust/pull/50812
+[50950]: https://github.com/rust-lang/rust/issues/50950
+[rustfmt/2695]: https://github.com/rust-lang-nursery/rustfmt/issues/2695
+
 Version 1.26.0 (2018-05-10)
 ==========================
 

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -198,7 +198,7 @@ dependencies = [
  "serde_json 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell-escape 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -284,26 +284,6 @@ dependencies = [
 [[package]]
 name = "clippy-mini-macro-test"
 version = "0.2.0"
-
-[[package]]
-name = "clippy_lints"
-version = "0.0.189"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "pulldown-cmark 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "clippy_lints"
@@ -896,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "languageserver-types"
-version = "0.31.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1415,12 +1395,12 @@ version = "0.126.0"
 dependencies = [
  "cargo 0.27.0",
  "cargo_metadata 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy_lints 0.0.189 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy_lints 0.0.191",
  "env_logger 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.11.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "languageserver-types 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "languageserver-types 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1432,7 +1412,7 @@ dependencies = [
  "rls-rustc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-vfs 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustfmt-nightly 0.4.1",
+ "rustfmt-nightly 0.4.2",
  "serde 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1528,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_cratesio_shim"
-version = "73.0.0"
+version = "94.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1537,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "73.0.0"
+version = "94.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1545,20 +1525,20 @@ dependencies = [
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot_core 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 73.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 94.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "73.0.0"
+version = "94.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 73.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 73.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax_pos 73.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 94.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 94.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax_pos 94.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1566,32 +1546,32 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-serialize"
-version = "73.0.0"
+version = "94.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-ap-syntax"
-version = "73.0.0"
+version = "94.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_cratesio_shim 73.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 73.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 73.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 73.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax_pos 73.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_cratesio_shim 94.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 94.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 94.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 94.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax_pos 94.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-syntax_pos"
-version = "73.0.0"
+version = "94.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-rustc_data_structures 73.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 73.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 94.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 94.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2012,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "rustfmt-nightly"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "cargo_metadata 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive-new 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2024,7 +2004,7 @@ dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax 73.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax 94.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2319,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2646,7 +2626,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f16b89cbb9ee36d87483dc939fe9f1e13c05898d56d7b230a0d4dff033a536"
-"checksum clippy_lints 0.0.189 (registry+https://github.com/rust-lang/crates.io-index)" = "fef652630bbf8c5e89601220abd000f5057e8fa9db608484b5ebaad98e9bce53"
 "checksum cmake 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "56d741ea7a69e577f6d06b36b7dff4738f680593dc27a701ffa8506b73ce28bb"
 "checksum commoncrypto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"
 "checksum commoncrypto-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
@@ -2699,7 +2678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum json 0.11.12 (registry+https://github.com/rust-lang/crates.io-index)" = "39ebf0fac977ee3a4a3242b6446004ff64514889e3e2730bbd4f764a67a2e483"
 "checksum jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ddf83704f4e79979a424d1082dd2c1e52683058056c9280efa19ac5f6bc9033c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum languageserver-types 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d25086d59f44b80253d5ff96c66a692fb69de8485cf7a25b28677e89126de0d"
+"checksum languageserver-types 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)" = "36e264ab825353617bbc80844717555be6e9e1d403474b1d0a3b8e190440b13e"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
@@ -2757,12 +2736,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rls-rustc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "885f66b92757420572cbb02e033d4a9558c7413ca9b7ac206f28fd58ffdb44ea"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
 "checksum rls-vfs 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "be231e1e559c315bc60ced5ad2cc2d7a9c208ed7d4e2c126500149836fda19bb"
-"checksum rustc-ap-rustc_cratesio_shim 73.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "421262e22426c06306e46057a75048f883dbc43886f78dbe1e750397a9c9b8e6"
-"checksum rustc-ap-rustc_data_structures 73.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8460c1207f9abb48a9720aee8be418bcfac018b6eee7b740b98a410e7799d24a"
-"checksum rustc-ap-rustc_errors 73.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad2077469162e52fcd84543334e18632088b9e342fe54e3b78c37d7077d09714"
-"checksum rustc-ap-serialize 73.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "69943901ae255dca5f63faeae2ff08b402d34a56d1eb50d34fbff6e83e6ace60"
-"checksum rustc-ap-syntax 73.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a44363359a43df753e26a4d4fef72720af183de635ebae8699686cb5d5de813"
-"checksum rustc-ap-syntax_pos 73.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "413f464657e8d5f3864de308dba1867526f21a44809b6f338b34e8c0caf88fb0"
+"checksum rustc-ap-rustc_cratesio_shim 94.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02ab246f7da18804a51d3676c2229a9e74951ed4362687647609fefd6e4f55fa"
+"checksum rustc-ap-rustc_data_structures 94.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b652047d793132b5f38b7eb010192d9aec72a8e52a1685822d3097ff5e04834a"
+"checksum rustc-ap-rustc_errors 94.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc91190fa312cdf88d1ed63b8574ef57ea6b4260eb123e1979ca2d1848a7afa7"
+"checksum rustc-ap-serialize 94.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06e78f89811eaddebb2b8c51a52cf21b5fcfaf8da6fabe9091a19927e57cd520"
+"checksum rustc-ap-syntax 94.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2fb9d06911de80e4ba6bef14f348c948485d18a20601dd23698c349e0f8d3fbb"
+"checksum rustc-ap-syntax_pos 94.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba449d1d913b9ec98294968828576514b5adef0239cb39d2c42c62b8f38aa14f"
 "checksum rustc-demangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11fb43a206a04116ffd7cfcf9bcb941f8eb6cc7ff667272246b0a1c74259a3cb"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
@@ -2791,7 +2770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syntex_syntax 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "76a302e717e348aa372ff577791c3832395650073b8d8432f8b3cb170b34afde"
 "checksum tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)" = "1605d3388ceb50252952ffebab4b5dc43017ead7e4481b175961c283bb951195"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-"checksum tempfile 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "439d9a7c00f98b1b5ee730039bf5b1f9203d508690e3c76b509e7ad59f8f7c99"
+"checksum tempfile 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "47776f63b85777d984a50ce49d6b9e58826b6a3766a449fc95bc66cd5663c15b"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
 "checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"

--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -24,7 +24,7 @@ use Build;
 use config::Config;
 
 // The version number
-pub const CFG_RELEASE_NUM: &str = "1.26.0";
+pub const CFG_RELEASE_NUM: &str = "1.26.1";
 
 pub struct GitInfo {
     inner: Option<Info>,

--- a/src/librustc_const_math/float.rs
+++ b/src/librustc_const_math/float.rs
@@ -38,19 +38,18 @@ impl ConstFloat {
     }
 
     /// Compares the values if they are of the same type
-    pub fn try_cmp(self, rhs: Self) -> Result<Ordering, ConstMathErr> {
+    pub fn try_cmp(self, rhs: Self) -> Result<Option<Ordering>, ConstMathErr> {
         match (self.ty, rhs.ty) {
             (ast::FloatTy::F64, ast::FloatTy::F64)  => {
                 let a = Double::from_bits(self.bits);
                 let b = Double::from_bits(rhs.bits);
-                // This is pretty bad but it is the existing behavior.
-                Ok(a.partial_cmp(&b).unwrap_or(Ordering::Greater))
+                Ok(a.partial_cmp(&b))
             }
 
             (ast::FloatTy::F32, ast::FloatTy::F32) => {
                 let a = Single::from_bits(self.bits);
                 let b = Single::from_bits(rhs.bits);
-                Ok(a.partial_cmp(&b).unwrap_or(Ordering::Greater))
+                Ok(a.partial_cmp(&b))
             }
 
             _ => Err(CmpBetweenUnequalTypes),

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -1115,7 +1115,12 @@ pub fn compare_const_vals<'a, 'tcx>(
                         ty,
                     };
                     // FIXME(oli-obk): report cmp errors?
-                    l.try_cmp(r).ok()
+                    // FIXME: Just returning Ordering::Greater here is the previous behavior but may
+                    // not be what we want. It means that NaN > NaN is true, which if false.
+                    match l.try_cmp(r) {
+                        Ok(opt) => Some(opt.unwrap_or(Ordering::Greater)),
+                        _ => None,
+                    }
                 },
                 ty::TyInt(_) => {
                     let a = interpret::sign_extend(tcx, a, ty).expect("layout error for TyInt");

--- a/src/librustc_mir/interpret/operator.rs
+++ b/src/librustc_mir/interpret/operator.rs
@@ -2,7 +2,6 @@ use rustc::mir;
 use rustc::ty::{self, Ty};
 use rustc_const_math::ConstFloat;
 use syntax::ast::FloatTy;
-use std::cmp::Ordering;
 use rustc::ty::layout::LayoutOf;
 
 use super::{EvalContext, Place, Machine, ValTy};
@@ -135,12 +134,12 @@ impl<'a, 'mir, 'tcx, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> {
                 ty,
             };
             match op {
-                Eq => PrimVal::from_bool(l.try_cmp(r).unwrap() == Ordering::Equal),
-                Ne => PrimVal::from_bool(l.try_cmp(r).unwrap() != Ordering::Equal),
-                Lt => PrimVal::from_bool(l.try_cmp(r).unwrap() == Ordering::Less),
-                Le => PrimVal::from_bool(l.try_cmp(r).unwrap() != Ordering::Greater),
-                Gt => PrimVal::from_bool(l.try_cmp(r).unwrap() == Ordering::Greater),
-                Ge => PrimVal::from_bool(l.try_cmp(r).unwrap() != Ordering::Less),
+                Eq => PrimVal::from_bool(l == r),
+                Ne => PrimVal::from_bool(l != r),
+                Lt => PrimVal::from_bool(l < r),
+                Le => PrimVal::from_bool(l <= r),
+                Gt => PrimVal::from_bool(l > r),
+                Ge => PrimVal::from_bool(l >= r),
                 Add => PrimVal::Bytes((l + r).unwrap().bits),
                 Sub => PrimVal::Bytes((l - r).unwrap().bits),
                 Mul => PrimVal::Bytes((l * r).unwrap().bits),

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -31,6 +31,7 @@ use rustc::middle::privacy::{AccessLevel, AccessLevels};
 use rustc::ty::{self, TyCtxt, Ty, TypeFoldable};
 use rustc::ty::fold::TypeVisitor;
 use rustc::ty::maps::Providers;
+use rustc::ty::subst::UnpackedKind;
 use rustc::util::nodemap::NodeSet;
 use syntax::ast::{self, CRATE_NODE_ID, Ident};
 use syntax::symbol::keywords;
@@ -39,6 +40,7 @@ use syntax_pos::hygiene::SyntaxContext;
 
 use std::cmp;
 use std::mem::replace;
+use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::sync::Lrc;
 
 mod diagnostics;
@@ -624,6 +626,7 @@ struct TypePrivacyVisitor<'a, 'tcx: 'a> {
     in_body: bool,
     span: Span,
     empty_tables: &'a ty::TypeckTables<'tcx>,
+    visited_anon_tys: FxHashSet<DefId>
 }
 
 impl<'a, 'tcx> TypePrivacyVisitor<'a, 'tcx> {
@@ -943,8 +946,15 @@ impl<'a, 'tcx> TypeVisitor<'tcx> for TypePrivacyVisitor<'a, 'tcx> {
                             self.tcx.sess.span_err(self.span, &msg);
                             return true;
                         }
-                        // `Self` here is the same `TyAnon`, so skip it to avoid infinite recursion
-                        for subst in trait_ref.substs.iter().skip(1) {
+                        for subst in trait_ref.substs.iter() {
+                            // Skip repeated `TyAnon`s to avoid infinite recursion.
+                            if let UnpackedKind::Type(ty) = subst.unpack() {
+                                if let ty::TyAnon(def_id, ..) = ty.sty {
+                                    if !self.visited_anon_tys.insert(def_id) {
+                                        continue;
+                                    }
+                                }
+                            }
                             if subst.visit_with(self) {
                                 return true;
                             }
@@ -1677,6 +1687,7 @@ fn privacy_access_levels<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         in_body: false,
         span: krate.span,
         empty_tables: &empty_tables,
+        visited_anon_tys: FxHashSet()
     };
     intravisit::walk_crate(&mut visitor, krate);
 

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -45,18 +45,21 @@ pub struct ConfirmResult<'tcx> {
 }
 
 impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
-    pub fn confirm_method(&self,
-                          span: Span,
-                          self_expr: &'gcx hir::Expr,
-                          call_expr: &'gcx hir::Expr,
-                          unadjusted_self_ty: Ty<'tcx>,
-                          pick: probe::Pick<'tcx>,
-                          segment: &hir::PathSegment)
-                          -> ConfirmResult<'tcx> {
-        debug!("confirm(unadjusted_self_ty={:?}, pick={:?}, generic_args={:?})",
-               unadjusted_self_ty,
-               pick,
-               segment.parameters);
+    pub fn confirm_method(
+        &self,
+        span: Span,
+        self_expr: &'gcx hir::Expr,
+        call_expr: &'gcx hir::Expr,
+        unadjusted_self_ty: Ty<'tcx>,
+        pick: probe::Pick<'tcx>,
+        segment: &hir::PathSegment,
+    ) -> ConfirmResult<'tcx> {
+        debug!(
+            "confirm(unadjusted_self_ty={:?}, pick={:?}, generic_args={:?})",
+            unadjusted_self_ty,
+            pick,
+            segment.parameters,
+        );
 
         let mut confirm_cx = ConfirmContext::new(self, span, self_expr, call_expr);
         confirm_cx.confirm(unadjusted_self_ty, pick, segment)
@@ -77,11 +80,12 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
         }
     }
 
-    fn confirm(&mut self,
-               unadjusted_self_ty: Ty<'tcx>,
-               pick: probe::Pick<'tcx>,
-               segment: &hir::PathSegment)
-               -> ConfirmResult<'tcx> {
+    fn confirm(
+        &mut self,
+        unadjusted_self_ty: Ty<'tcx>,
+        pick: probe::Pick<'tcx>,
+        segment: &hir::PathSegment,
+    ) -> ConfirmResult<'tcx> {
         // Adjust the self expression the user provided and obtain the adjusted type.
         let self_ty = self.adjust_self_ty(unadjusted_self_ty, &pick);
 
@@ -299,16 +303,18 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
             })
     }
 
-    fn instantiate_method_substs(&mut self,
-                                 pick: &probe::Pick<'tcx>,
-                                 segment: &hir::PathSegment,
-                                 parent_substs: &Substs<'tcx>)
-                                 -> &'tcx Substs<'tcx> {
+    fn instantiate_method_substs(
+        &mut self,
+        pick: &probe::Pick<'tcx>,
+        segment: &hir::PathSegment,
+        parent_substs: &Substs<'tcx>,
+    ) -> &'tcx Substs<'tcx> {
         // Determine the values for the generic parameters of the method.
         // If they were not explicitly supplied, just construct fresh
         // variables.
         let method_generics = self.tcx.generics_of(pick.item.def_id);
         let mut fn_segment = Some((segment, method_generics));
+        self.fcx.check_impl_trait(self.span, fn_segment);
         self.fcx.check_path_parameter_count(self.span, &mut fn_segment, true);
 
         // Create subst for early-bound lifetime parameters, combining

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -173,12 +173,14 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
         self.tcx.check_stability(pick.item.def_id, Some(call_expr.id), span);
 
-        let result = self.confirm_method(span,
-                                         self_expr,
-                                         call_expr,
-                                         self_ty,
-                                         pick.clone(),
-                                         segment);
+        let result = self.confirm_method(
+            span,
+            self_expr,
+            call_expr,
+            self_ty,
+            pick.clone(),
+            segment,
+        );
 
         if result.illegal_sized_bound {
             // We probe again, taking all traits into account (not only those in scope).

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1035,13 +1035,13 @@ fn check_fn<'a, 'gcx, 'tcx>(inherited: &'a Inherited<'a, 'gcx, 'tcx>,
     let mut fcx = FnCtxt::new(inherited, param_env, body.value.id);
     *fcx.ps.borrow_mut() = UnsafetyState::function(fn_sig.unsafety, fn_id);
 
-    let ret_ty = fn_sig.output();
-    fcx.require_type_is_sized(ret_ty, decl.output.span(), traits::SizedReturnType);
-    let ret_ty = fcx.instantiate_anon_types_from_return_value(fn_id, &ret_ty);
-    fcx.ret_coercion = Some(RefCell::new(CoerceMany::new(ret_ty)));
+    let declared_ret_ty = fn_sig.output();
+    fcx.require_type_is_sized(declared_ret_ty, decl.output.span(), traits::SizedReturnType);
+    let revealed_ret_ty = fcx.instantiate_anon_types_from_return_value(fn_id, &declared_ret_ty);
+    fcx.ret_coercion = Some(RefCell::new(CoerceMany::new(revealed_ret_ty)));
     fn_sig = fcx.tcx.mk_fn_sig(
         fn_sig.inputs().iter().cloned(),
-        ret_ty,
+        revealed_ret_ty,
         fn_sig.variadic,
         fn_sig.unsafety,
         fn_sig.abi
@@ -1123,7 +1123,7 @@ fn check_fn<'a, 'gcx, 'tcx>(inherited: &'a Inherited<'a, 'gcx, 'tcx>,
         actual_return_ty = fcx.next_diverging_ty_var(
             TypeVariableOrigin::DivergingFn(span));
     }
-    fcx.demand_suptype(span, ret_ty, actual_return_ty);
+    fcx.demand_suptype(span, revealed_ret_ty, actual_return_ty);
 
     // Check that the main return type implements the termination trait.
     if let Some(term_id) = fcx.tcx.lang_items().termination() {
@@ -1131,7 +1131,7 @@ fn check_fn<'a, 'gcx, 'tcx>(inherited: &'a Inherited<'a, 'gcx, 'tcx>,
             if id == fn_id {
                 match fcx.sess().entry_type.get() {
                     Some(config::EntryMain) => {
-                        let substs = fcx.tcx.mk_substs(iter::once(Kind::from(ret_ty)));
+                        let substs = fcx.tcx.mk_substs(iter::once(Kind::from(declared_ret_ty)));
                         let trait_ref = ty::TraitRef::new(term_id, substs);
                         let return_ty_span = decl.output.span();
                         let cause = traits::ObligationCause::new(

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4806,7 +4806,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         // a problem.
         self.check_path_parameter_count(span, &mut type_segment, false);
         self.check_path_parameter_count(span, &mut fn_segment, false);
-        self.check_impl_trait(span, &mut fn_segment);
+        self.check_impl_trait(span, fn_segment);
 
         let (fn_start, has_self) = match (type_segment, fn_segment) {
             (_, Some((_, generics))) => {
@@ -5066,7 +5066,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
     /// Report error if there is an explicit type parameter when using `impl Trait`.
     fn check_impl_trait(&self,
                         span: Span,
-                        segment: &mut Option<(&hir::PathSegment, &ty::Generics)>) {
+                        segment: Option<(&hir::PathSegment, &ty::Generics)>) {
         use hir::SyntheticTyParamKind::*;
 
         segment.map(|(path_segment, generics)| {

--- a/src/test/run-pass/impl-trait/issue-49376.rs
+++ b/src/test/run-pass/impl-trait/issue-49376.rs
@@ -1,0 +1,29 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests for nested self-reference which caused a stack overflow.
+
+use std::fmt::Debug;
+use std::ops::*;
+
+fn gen() -> impl PartialOrd + PartialEq + Debug { }
+
+struct Bar {}
+trait Foo<T = Self> {}
+impl Foo for Bar {}
+
+fn foo() -> impl Foo {
+    Bar {}
+}
+
+fn test_impl_ops() -> impl Add + Sub + Mul + Div { 1 }
+fn test_impl_assign_ops() -> impl AddAssign + SubAssign + MulAssign + DivAssign { 1 }
+
+fn main() {}

--- a/src/test/run-pass/issue-50811.rs
+++ b/src/test/run-pass/issue-50811.rs
@@ -1,0 +1,65 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(test)]
+
+extern crate test;
+
+use std::f64::{NAN, NEG_INFINITY, INFINITY, MAX};
+use std::mem::size_of;
+use test::black_box;
+
+// Ensure the const-eval result and runtime result of float comparison are equivalent.
+
+macro_rules! compare {
+    ($op:tt) => {
+        compare!(
+            [NEG_INFINITY, -MAX, -1.0, -0.0, 0.0, 1.0, MAX, INFINITY, NAN],
+            $op
+        );
+    };
+    ([$($lhs:expr),+], $op:tt) => {
+        $(compare!(
+            $lhs,
+            $op,
+            [NEG_INFINITY, -MAX, -1.0, -0.0, 0.0, 1.0, MAX, INFINITY, NAN]
+        );)+
+    };
+    ($lhs:expr, $op:tt, [$($rhs:expr),+]) => {
+        $({
+            // Wrap the check in its own function to reduce time needed to borrowck.
+            fn check() {
+                static CONST_EVAL: bool = $lhs $op $rhs;
+                let runtime_eval = black_box($lhs) $op black_box($rhs);
+                assert_eq!(CONST_EVAL, runtime_eval, stringify!($lhs $op $rhs));
+                assert_eq!(
+                    size_of::<[u8; ($lhs $op $rhs) as usize]>(),
+                    runtime_eval as usize,
+                    stringify!($lhs $op $rhs (forced const eval))
+                );
+            }
+            check();
+        })+
+    };
+}
+
+fn main() {
+    assert_eq!(0.0/0.0 < 0.0/0.0, false);
+    assert_eq!(0.0/0.0 > 0.0/0.0, false);
+    assert_eq!(NAN < NAN, false);
+    assert_eq!(NAN > NAN, false);
+
+    compare!(==);
+    compare!(!=);
+    compare!(<);
+    compare!(<=);
+    compare!(>);
+    compare!(>=);
+}

--- a/src/test/run-pass/rfc-1937-termination-trait/termination-trait-for-impl-termination.rs
+++ b/src/test/run-pass/rfc-1937-termination-trait/termination-trait-for-impl-termination.rs
@@ -1,0 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(termination_trait_lib)]
+
+fn main() -> impl std::process::Termination { }

--- a/src/test/ui/impl-trait/universal-turbofish-in-method-issue-50950.rs
+++ b/src/test/ui/impl-trait/universal-turbofish-in-method-issue-50950.rs
@@ -1,0 +1,27 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::any::Any;
+pub struct EventHandler {
+}
+
+impl EventHandler
+{
+    pub fn handle_event<T: Any>(&mut self, _efunc: impl FnMut(T)) {}
+}
+
+struct TestEvent(i32);
+
+fn main() {
+    let mut evt = EventHandler {};
+    evt.handle_event::<TestEvent, fn(TestEvent)>(|_evt| {
+        //~^ ERROR cannot provide explicit type parameters
+    });
+}

--- a/src/test/ui/impl-trait/universal-turbofish-in-method-issue-50950.stderr
+++ b/src/test/ui/impl-trait/universal-turbofish-in-method-issue-50950.stderr
@@ -1,0 +1,9 @@
+error[E0632]: cannot provide explicit type parameters when `impl Trait` is used in argument position.
+  --> $DIR/universal-turbofish-in-method-issue-50950.rs:24:9
+   |
+LL |     evt.handle_event::<TestEvent, fn(TestEvent)>(|_evt| {
+   |         ^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0632`.

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-impl-trait.rs
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-impl-trait.rs
@@ -1,0 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests that an `impl Trait` that is not `impl Termination` will not work.
+fn main() -> impl Copy { }
+//~^ ERROR `main` has invalid return type `impl std::marker::Copy`

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-impl-trait.stderr
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-impl-trait.stderr
@@ -1,0 +1,11 @@
+error[E0277]: `main` has invalid return type `impl std::marker::Copy`
+  --> $DIR/termination-trait-impl-trait.rs:12:14
+   |
+LL | fn main() -> impl Copy { }
+   |              ^^^^^^^^^ `main` can only return types that implement `std::process::Termination`
+   |
+   = help: consider using `()`, or a `Result`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -356,6 +356,28 @@ impl Builder {
                 target: "*".to_string(),
             });
 
+            // If the components/extensions don't actually exist for this
+            // particular host/target combination then nix it entirely from our
+            // lists.
+            {
+                let has_component = |c: &Component| {
+                    if c.target == "*" {
+                        return true
+                    }
+                    let pkg = match manifest.pkg.get(&c.pkg) {
+                        Some(p) => p,
+                        None => return false,
+                    };
+                    let target = match pkg.target.get(&c.target) {
+                        Some(t) => t,
+                        None => return false,
+                    };
+                    target.available
+                };
+                extensions.retain(&has_component);
+                components.retain(&has_component);
+            }
+
             pkg.target.insert(host.to_string(), Target {
                 available: true,
                 url: Some(self.url(&filename)),


### PR DESCRIPTION
This includes all items on [the wishlist](https://github.com/rust-lang/rust/issues/50756), plus https://github.com/rust-lang/rust/pull/50694, which backported cleanly.

The target date is May 29th, Tuesday next week.

cc @rust-lang/compiler @oli-obk @eddyb  -- I backported https://github.com/rust-lang/rust/pull/50812, but it wasn't a clean patch so review would be appreciated.