### PR TITLE
Fix behaviour of divergence in while loop conditions

### DIFF
--- a/src/test/ui/break-while-condition.rs
+++ b/src/test/ui/break-while-condition.rs
@@ -11,7 +11,29 @@
 #![feature(never_type)]
 
 fn main() {
-    let _: ! = { //~ ERROR mismatched types
-        'a: while break 'a {};
-    };
+    // The `if false` expressions are simply to
+    // make sure we don't avoid checking everything
+    // simply because a few expressions are unreachable.
+
+    if false {
+        let _: ! = { //~ ERROR mismatched types
+            'a: while break 'a {};
+        };
+    }
+
+    if false {
+        let _: ! = { //~ ERROR mismatched types
+            while false {
+                break
+            }
+        };
+    }
+
+    if false {
+        let _: ! = { //~ ERROR mismatched types
+            while false {
+                return
+            }
+        };
+    }
 }

--- a/src/test/ui/break-while-condition.rs
+++ b/src/test/ui/break-while-condition.rs
@@ -22,16 +22,16 @@ fn main() {
     }
 
     if false {
-        let _: ! = { //~ ERROR mismatched types
-            while false {
+        let _: ! = {
+            while false { //~ ERROR mismatched types
                 break
             }
         };
     }
 
     if false {
-        let _: ! = { //~ ERROR mismatched types
-            while false {
+        let _: ! = {
+            while false { //~ ERROR mismatched types
                 return
             }
         };

--- a/src/test/ui/break-while-condition.rs
+++ b/src/test/ui/break-while-condition.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(never_type)]
+
+fn main() {
+    let _: ! = { //~ ERROR mismatched types
+        'a: while break 'a {};
+    };
+}

--- a/src/test/ui/break-while-condition.stderr
+++ b/src/test/ui/break-while-condition.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
 LL |   fn main() {
    |             - expected `()` because of default return type
 ...
-LL | /             while false {
+LL | /             while false { //~ ERROR mismatched types
 LL | |                 break
 LL | |             }
    | |_____________^ expected !, found ()
@@ -30,7 +30,7 @@ error[E0308]: mismatched types
 LL |   fn main() {
    |             - expected `()` because of default return type
 ...
-LL | /             while false {
+LL | /             while false { //~ ERROR mismatched types
 LL | |                 return
 LL | |             }
    | |_____________^ expected !, found ()

--- a/src/test/ui/break-while-condition.stderr
+++ b/src/test/ui/break-while-condition.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+  --> $DIR/break-while-condition.rs:14:16
+   |
+LL |       let _: ! = { //~ ERROR mismatched types
+   |  ________________^
+LL | |         'a: while break 'a {};
+LL | |     };
+   | |_____^ expected !, found ()
+   |
+   = note: expected type `!`
+              found type `()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/break-while-condition.stderr
+++ b/src/test/ui/break-while-condition.stderr
@@ -1,15 +1,43 @@
 error[E0308]: mismatched types
-  --> $DIR/break-while-condition.rs:14:16
+  --> $DIR/break-while-condition.rs:19:20
    |
-LL |       let _: ! = { //~ ERROR mismatched types
-   |  ________________^
-LL | |         'a: while break 'a {};
-LL | |     };
-   | |_____^ expected !, found ()
+LL |           let _: ! = { //~ ERROR mismatched types
+   |  ____________________^
+LL | |             'a: while break 'a {};
+LL | |         };
+   | |_________^ expected !, found ()
    |
    = note: expected type `!`
               found type `()`
 
-error: aborting due to previous error
+error[E0308]: mismatched types
+  --> $DIR/break-while-condition.rs:26:13
+   |
+LL |   fn main() {
+   |             - expected `()` because of default return type
+...
+LL | /             while false {
+LL | |                 break
+LL | |             }
+   | |_____________^ expected !, found ()
+   |
+   = note: expected type `!`
+              found type `()`
+
+error[E0308]: mismatched types
+  --> $DIR/break-while-condition.rs:34:13
+   |
+LL |   fn main() {
+   |             - expected `()` because of default return type
+...
+LL | /             while false {
+LL | |                 return
+LL | |             }
+   | |_____________^ expected !, found ()
+   |
+   = note: expected type `!`
+              found type `()`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
This fixes `'a: while break 'a {};` being treated as diverging, by tracking break expressions in the same way as in `loop` expressions.

Fixes #50856.

r? @nikomatsakis 