### PR TITLE
make ui tests robust with respect to NLL

### DIFF
--- a/src/test/ui/borrowck/borrowck-report-with-custom-diagnostic.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-report-with-custom-diagnostic.nll.stderr
@@ -1,14 +1,40 @@
-error: compilation successful
-  --> $DIR/borrowck-report-with-custom-diagnostic.rs:12:1
+error[E0502]: cannot borrow `x` as immutable because it is also borrowed as mutable
+  --> $DIR/borrowck-report-with-custom-diagnostic.rs:17:13
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     // Original borrow ends at end of function
-LL | |     let mut x = 1;
-LL | |     let y = &mut x;
-...  |
-LL | |     //~^ immutable borrow occurs here
-LL | | }
-   | |_^
+LL |     let y = &mut x;
+   |             ------ mutable borrow occurs here
+LL |     //~^ mutable borrow occurs here
+LL |     let z = &x; //~ ERROR cannot borrow
+   |             ^^ immutable borrow occurs here
+...
+LL |     y.use_mut();
+   |     - borrow later used here
 
-error: aborting due to previous error
+error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immutable
+  --> $DIR/borrowck-report-with-custom-diagnostic.rs:30:21
+   |
+LL |             let y = &x;
+   |                     -- immutable borrow occurs here
+LL |             //~^ immutable borrow occurs here
+LL |             let z = &mut x; //~ ERROR cannot borrow
+   |                     ^^^^^^ mutable borrow occurs here
+...
+LL |             y.use_ref();
+   |             - borrow later used here
 
+error[E0499]: cannot borrow `x` as mutable more than once at a time
+  --> $DIR/borrowck-report-with-custom-diagnostic.rs:45:17
+   |
+LL |         let y = &mut x;
+   |                 ------ first mutable borrow occurs here
+LL |         //~^ first mutable borrow occurs here
+LL |         let z = &mut x; //~ ERROR cannot borrow
+   |                 ^^^^^^ second mutable borrow occurs here
+...
+LL |         y.use_mut();
+   |         - borrow later used here
+
+error: aborting due to 3 previous errors
+
+Some errors occurred: E0499, E0502.
+For more information about an error, try `rustc --explain E0499`.

--- a/src/test/ui/borrowck/borrowck-report-with-custom-diagnostic.rs
+++ b/src/test/ui/borrowck/borrowck-report-with-custom-diagnostic.rs
@@ -16,6 +16,8 @@ fn main() { #![rustc_error] // rust-lang/rust#49855
     //~^ mutable borrow occurs here
     let z = &x; //~ ERROR cannot borrow
     //~^ immutable borrow occurs here
+    z.use_ref();
+    y.use_mut();
 }
 
 fn foo() {
@@ -27,6 +29,8 @@ fn foo() {
             //~^ immutable borrow occurs here
             let z = &mut x; //~ ERROR cannot borrow
             //~^ mutable borrow occurs here
+            z.use_mut();
+            y.use_ref();
         }
         false => ()
     }
@@ -40,5 +44,10 @@ fn bar() {
         //~^ first mutable borrow occurs here
         let z = &mut x; //~ ERROR cannot borrow
         //~^ second mutable borrow occurs here
+        z.use_mut();
+        y.use_mut();
     };
 }
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/borrowck/borrowck-report-with-custom-diagnostic.stderr
+++ b/src/test/ui/borrowck/borrowck-report-with-custom-diagnostic.stderr
@@ -6,31 +6,31 @@ LL |     let y = &mut x;
 LL |     //~^ mutable borrow occurs here
 LL |     let z = &x; //~ ERROR cannot borrow
    |              ^ immutable borrow occurs here
-LL |     //~^ immutable borrow occurs here
+...
 LL | }
    | - mutable borrow ends here
 
 error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immutable
-  --> $DIR/borrowck-report-with-custom-diagnostic.rs:28:26
+  --> $DIR/borrowck-report-with-custom-diagnostic.rs:30:26
    |
 LL |             let y = &x;
    |                      - immutable borrow occurs here
 LL |             //~^ immutable borrow occurs here
 LL |             let z = &mut x; //~ ERROR cannot borrow
    |                          ^ mutable borrow occurs here
-LL |             //~^ mutable borrow occurs here
+...
 LL |         }
    |         - immutable borrow ends here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
-  --> $DIR/borrowck-report-with-custom-diagnostic.rs:41:22
+  --> $DIR/borrowck-report-with-custom-diagnostic.rs:45:22
    |
 LL |         let y = &mut x;
    |                      - first mutable borrow occurs here
 LL |         //~^ first mutable borrow occurs here
 LL |         let z = &mut x; //~ ERROR cannot borrow
    |                      ^ second mutable borrow occurs here
-LL |         //~^ second mutable borrow occurs here
+...
 LL |     };
    |     - first borrow ends here
 

--- a/src/test/ui/borrowck/mut-borrow-outside-loop.nll.stderr
+++ b/src/test/ui/borrowck/mut-borrow-outside-loop.nll.stderr
@@ -1,14 +1,24 @@
-error: compilation successful
-  --> $DIR/mut-borrow-outside-loop.rs:13:1
+error[E0499]: cannot borrow `void` as mutable more than once at a time
+  --> $DIR/mut-borrow-outside-loop.rs:17:18
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     let mut void = ();
-LL | |
-LL | |     let first = &mut void;
-...  |
-LL | |     }
-LL | | }
-   | |_^
+LL |     let first = &mut void;
+   |                 --------- first mutable borrow occurs here
+LL |     let second = &mut void; //~ ERROR cannot borrow
+   |                  ^^^^^^^^^ second mutable borrow occurs here
+LL |     first.use_mut();
+   |     ----- borrow later used here
 
-error: aborting due to previous error
+error[E0499]: cannot borrow `inner_void` as mutable more than once at a time
+  --> $DIR/mut-borrow-outside-loop.rs:25:28
+   |
+LL |         let inner_first = &mut inner_void;
+   |                           --------------- first mutable borrow occurs here
+LL |         let inner_second = &mut inner_void; //~ ERROR cannot borrow
+   |                            ^^^^^^^^^^^^^^^ second mutable borrow occurs here
+LL |         inner_second.use_mut();
+LL |         inner_first.use_mut();
+   |         ----------- borrow later used here
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0499`.

--- a/src/test/ui/borrowck/mut-borrow-outside-loop.rs
+++ b/src/test/ui/borrowck/mut-borrow-outside-loop.rs
@@ -15,12 +15,18 @@ fn main() { #![rustc_error] // rust-lang/rust#49855
 
     let first = &mut void;
     let second = &mut void; //~ ERROR cannot borrow
+    first.use_mut();
+    second.use_mut();
 
     loop {
         let mut inner_void = ();
 
         let inner_first = &mut inner_void;
         let inner_second = &mut inner_void; //~ ERROR cannot borrow
+        inner_second.use_mut();
+        inner_first.use_mut();
     }
 }
 
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/borrowck/mut-borrow-outside-loop.stderr
+++ b/src/test/ui/borrowck/mut-borrow-outside-loop.stderr
@@ -10,12 +10,13 @@ LL | }
    | - first borrow ends here
 
 error[E0499]: cannot borrow `inner_void` as mutable more than once at a time
-  --> $DIR/mut-borrow-outside-loop.rs:23:33
+  --> $DIR/mut-borrow-outside-loop.rs:25:33
    |
 LL |         let inner_first = &mut inner_void;
    |                                ---------- first mutable borrow occurs here
 LL |         let inner_second = &mut inner_void; //~ ERROR cannot borrow
    |                                 ^^^^^^^^^^ second mutable borrow occurs here
+...
 LL |     }
    |     - first borrow ends here
 

--- a/src/test/ui/codemap_tests/issue-11715.nll.stderr
+++ b/src/test/ui/codemap_tests/issue-11715.nll.stderr
@@ -1,12 +1,14 @@
-error: compilation successful
-  --> $DIR/issue-11715.rs:97:1
+error[E0499]: cannot borrow `x` as mutable more than once at a time
+  --> $DIR/issue-11715.rs:100:13
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     let mut x = "foo";
-LL | |     let y = &mut x;
-LL | |     let z = &mut x; //~ ERROR cannot borrow
-LL | | }
-   | |_^
+LL |     let y = &mut x;
+   |             ------ first mutable borrow occurs here
+LL |     let z = &mut x; //~ ERROR cannot borrow
+   |             ^^^^^^ second mutable borrow occurs here
+LL |     z.use_mut();
+LL |     y.use_mut();
+   |     - borrow later used here
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0499`.

--- a/src/test/ui/codemap_tests/issue-11715.rs
+++ b/src/test/ui/codemap_tests/issue-11715.rs
@@ -98,4 +98,9 @@ fn main() { #![rustc_error] // rust-lang/rust#49855
     let mut x = "foo";
     let y = &mut x;
     let z = &mut x; //~ ERROR cannot borrow
+    z.use_mut();
+    y.use_mut();
 }
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/codemap_tests/issue-11715.stderr
+++ b/src/test/ui/codemap_tests/issue-11715.stderr
@@ -5,6 +5,7 @@ LL |     let y = &mut x;
    |                  - first mutable borrow occurs here
 LL |     let z = &mut x; //~ ERROR cannot borrow
    |                  ^ second mutable borrow occurs here
+...
 LL | }
    | - first borrow ends here
 

--- a/src/test/ui/dropck/dropck-eyepatch-extern-crate.nll.stderr
+++ b/src/test/ui/dropck/dropck-eyepatch-extern-crate.nll.stderr
@@ -1,14 +1,15 @@
-error: compilation successful
-  --> $DIR/dropck-eyepatch-extern-crate.rs:27:1
+error[E0597]: `c_shortest` does not live long enough
+  --> $DIR/dropck-eyepatch-extern-crate.rs:47:19
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     use std::cell::Cell;
-LL | |     let c_long;
-LL | |     let (c, mut dt, mut dr, mut pt, mut pr, st, sr)
-...  |
-LL | |     println!("{:?}", (dt.0, dr.0, pt.0, pr.0, st.0, sr.0));
-LL | | }
-   | |_^
+LL |     dt = Dt("dt", &c_shortest);
+   |                   ^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `dt` is dropped
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/dropck/dropck-eyepatch-extern-crate.rs
+++ b/src/test/ui/dropck/dropck-eyepatch-extern-crate.rs
@@ -27,33 +27,41 @@ use other::{Dt,Dr,Pt,Pr,St,Sr};
 fn main() { #![rustc_error] // rust-lang/rust#49855
     use std::cell::Cell;
     let c_long;
-    let (c, mut dt, mut dr, mut pt, mut pr, st, sr)
-        : (Cell<_>, Dt<_>, Dr<_>, Pt<_, _>, Pr<_>, St<_>, Sr<_>);
+    let (c, mut dt, mut dr, mut pt, mut pr, st, sr, c_shortest)
+        : (Cell<_>, Dt<_>, Dr<_>, Pt<_, _>, Pr<_>, St<_>, Sr<_>, Cell<_>);
     c_long = Cell::new(1);
     c = Cell::new(1);
+    c_shortest = Cell::new(1);
 
     // No error: sufficiently long-lived state can be referenced in dtors
     dt = Dt("dt", &c_long);
     dr = Dr("dr", &c_long);
+
     // Error: destructor order imprecisely modelled
     dt = Dt("dt", &c);
     //~^ ERROR `c` does not live long enough
     dr = Dr("dr", &c);
     //~^ ERROR `c` does not live long enough
 
+    // Error: `c_shortest` dies too soon for the references in dtors to be valid.
+    dt = Dt("dt", &c_shortest);
+    //~^ ERROR `c_shortest` does not live long enough
+    dr = Dr("dr", &c_shortest);
+    //~^ ERROR `c_shortest` does not live long enough
+
     // No error: Drop impl asserts .1 (A and &'a _) are not accessed
-    pt = Pt("pt", &c, &c_long);
-    pr = Pr("pr", &c, &c_long);
+    pt = Pt("pt", &c_shortest, &c_long);
+    pr = Pr("pr", &c_shortest, &c_long);
 
     // Error: Drop impl's assertion does not apply to `B` nor `&'b _`
-    pt = Pt("pt", &c_long, &c);
-    //~^ ERROR `c` does not live long enough
-    pr = Pr("pr", &c_long, &c);
-    //~^ ERROR `c` does not live long enough
+    pt = Pt("pt", &c_long, &c_shortest);
+    //~^ ERROR `c_shortest` does not live long enough
+    pr = Pr("pr", &c_long, &c_shortest);
+    //~^ ERROR `c_shortest` does not live long enough
 
     // No error: St and Sr have no destructor.
-    st = St("st", &c);
-    sr = Sr("sr", &c);
+    st = St("st", &c_shortest);
+    sr = Sr("sr", &c_shortest);
 
     println!("{:?}", (dt.0, dr.0, pt.0, pr.0, st.0, sr.0));
 }

--- a/src/test/ui/dropck/dropck-eyepatch-extern-crate.stderr
+++ b/src/test/ui/dropck/dropck-eyepatch-extern-crate.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch-extern-crate.rs:39:20
+  --> $DIR/dropck-eyepatch-extern-crate.rs:41:20
    |
 LL |     dt = Dt("dt", &c);
    |                    ^ borrowed value does not live long enough
@@ -10,7 +10,7 @@ LL | }
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch-extern-crate.rs:41:20
+  --> $DIR/dropck-eyepatch-extern-crate.rs:43:20
    |
 LL |     dr = Dr("dr", &c);
    |                    ^ borrowed value does not live long enough
@@ -20,28 +20,50 @@ LL | }
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch-extern-crate.rs:49:29
+error[E0597]: `c_shortest` does not live long enough
+  --> $DIR/dropck-eyepatch-extern-crate.rs:47:20
    |
-LL |     pt = Pt("pt", &c_long, &c);
-   |                             ^ borrowed value does not live long enough
+LL |     dt = Dt("dt", &c_shortest);
+   |                    ^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL | }
-   | - `c` dropped here while still borrowed
+   | - `c_shortest` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch-extern-crate.rs:51:29
+error[E0597]: `c_shortest` does not live long enough
+  --> $DIR/dropck-eyepatch-extern-crate.rs:49:20
    |
-LL |     pr = Pr("pr", &c_long, &c);
-   |                             ^ borrowed value does not live long enough
+LL |     dr = Dr("dr", &c_shortest);
+   |                    ^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL | }
-   | - `c` dropped here while still borrowed
+   | - `c_shortest` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to 4 previous errors
+error[E0597]: `c_shortest` does not live long enough
+  --> $DIR/dropck-eyepatch-extern-crate.rs:57:29
+   |
+LL |     pt = Pt("pt", &c_long, &c_shortest);
+   |                             ^^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | - `c_shortest` dropped here while still borrowed
+   |
+   = note: values in a scope are dropped in the opposite order they are created
+
+error[E0597]: `c_shortest` does not live long enough
+  --> $DIR/dropck-eyepatch-extern-crate.rs:59:29
+   |
+LL |     pr = Pr("pr", &c_long, &c_shortest);
+   |                             ^^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | - `c_shortest` dropped here while still borrowed
+   |
+   = note: values in a scope are dropped in the opposite order they are created
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/dropck/dropck-eyepatch-reorder.nll.stderr
+++ b/src/test/ui/dropck/dropck-eyepatch-reorder.nll.stderr
@@ -1,14 +1,15 @@
-error: compilation successful
-  --> $DIR/dropck-eyepatch-reorder.rs:44:1
+error[E0597]: `c_shortest` does not live long enough
+  --> $DIR/dropck-eyepatch-reorder.rs:64:19
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     use std::cell::Cell;
-LL | |     let c_long;
-LL | |     let (c, mut dt, mut dr, mut pt, mut pr, st, sr)
-...  |
-LL | |     println!("{:?}", (dt.0, dr.0, pt.0, pr.0, st.0, sr.0));
-LL | | }
-   | |_^
+LL |     dt = Dt("dt", &c_shortest);
+   |                   ^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `dt` is dropped
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/dropck/dropck-eyepatch-reorder.rs
+++ b/src/test/ui/dropck/dropck-eyepatch-reorder.rs
@@ -44,33 +44,41 @@ unsafe impl<'b, #[may_dangle] 'a, B: fmt::Debug> Drop for Pr<'a, 'b, B> {
 fn main() { #![rustc_error] // rust-lang/rust#49855
     use std::cell::Cell;
     let c_long;
-    let (c, mut dt, mut dr, mut pt, mut pr, st, sr)
-        : (Cell<_>, Dt<_>, Dr<_>, Pt<_, _>, Pr<_>, St<_>, Sr<_>);
+    let (c, mut dt, mut dr, mut pt, mut pr, st, sr, c_shortest)
+        : (Cell<_>, Dt<_>, Dr<_>, Pt<_, _>, Pr<_>, St<_>, Sr<_>, Cell<_>);
     c_long = Cell::new(1);
     c = Cell::new(1);
+    c_shortest = Cell::new(1);
 
     // No error: sufficiently long-lived state can be referenced in dtors
     dt = Dt("dt", &c_long);
     dr = Dr("dr", &c_long);
+
     // Error: destructor order imprecisely modelled
     dt = Dt("dt", &c);
     //~^ ERROR `c` does not live long enough
     dr = Dr("dr", &c);
     //~^ ERROR `c` does not live long enough
 
+    // Error: `c_shortest` dies too soon for the references in dtors to be valid.
+    dt = Dt("dt", &c_shortest);
+    //~^ ERROR `c_shortest` does not live long enough
+    dr = Dr("dr", &c_shortest);
+    //~^ ERROR `c_shortest` does not live long enough
+
     // No error: Drop impl asserts .1 (A and &'a _) are not accessed
-    pt = Pt("pt", &c, &c_long);
-    pr = Pr("pr", &c, &c_long);
+    pt = Pt("pt", &c_shortest, &c_long);
+    pr = Pr("pr", &c_shortest, &c_long);
 
     // Error: Drop impl's assertion does not apply to `B` nor `&'b _`
-    pt = Pt("pt", &c_long, &c);
-    //~^ ERROR `c` does not live long enough
-    pr = Pr("pr", &c_long, &c);
-    //~^ ERROR `c` does not live long enough
+    pt = Pt("pt", &c_long, &c_shortest);
+    //~^ ERROR `c_shortest` does not live long enough
+    pr = Pr("pr", &c_long, &c_shortest);
+    //~^ ERROR `c_shortest` does not live long enough
 
     // No error: St and Sr have no destructor.
-    st = St("st", &c);
-    sr = Sr("sr", &c);
+    st = St("st", &c_shortest);
+    sr = Sr("sr", &c_shortest);
 
     println!("{:?}", (dt.0, dr.0, pt.0, pr.0, st.0, sr.0));
 }

--- a/src/test/ui/dropck/dropck-eyepatch-reorder.stderr
+++ b/src/test/ui/dropck/dropck-eyepatch-reorder.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch-reorder.rs:56:20
+  --> $DIR/dropck-eyepatch-reorder.rs:58:20
    |
 LL |     dt = Dt("dt", &c);
    |                    ^ borrowed value does not live long enough
@@ -10,7 +10,7 @@ LL | }
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch-reorder.rs:58:20
+  --> $DIR/dropck-eyepatch-reorder.rs:60:20
    |
 LL |     dr = Dr("dr", &c);
    |                    ^ borrowed value does not live long enough
@@ -20,28 +20,50 @@ LL | }
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch-reorder.rs:66:29
+error[E0597]: `c_shortest` does not live long enough
+  --> $DIR/dropck-eyepatch-reorder.rs:64:20
    |
-LL |     pt = Pt("pt", &c_long, &c);
-   |                             ^ borrowed value does not live long enough
+LL |     dt = Dt("dt", &c_shortest);
+   |                    ^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL | }
-   | - `c` dropped here while still borrowed
+   | - `c_shortest` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch-reorder.rs:68:29
+error[E0597]: `c_shortest` does not live long enough
+  --> $DIR/dropck-eyepatch-reorder.rs:66:20
    |
-LL |     pr = Pr("pr", &c_long, &c);
-   |                             ^ borrowed value does not live long enough
+LL |     dr = Dr("dr", &c_shortest);
+   |                    ^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL | }
-   | - `c` dropped here while still borrowed
+   | - `c_shortest` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to 4 previous errors
+error[E0597]: `c_shortest` does not live long enough
+  --> $DIR/dropck-eyepatch-reorder.rs:74:29
+   |
+LL |     pt = Pt("pt", &c_long, &c_shortest);
+   |                             ^^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | - `c_shortest` dropped here while still borrowed
+   |
+   = note: values in a scope are dropped in the opposite order they are created
+
+error[E0597]: `c_shortest` does not live long enough
+  --> $DIR/dropck-eyepatch-reorder.rs:76:29
+   |
+LL |     pr = Pr("pr", &c_long, &c_shortest);
+   |                             ^^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | - `c_shortest` dropped here while still borrowed
+   |
+   = note: values in a scope are dropped in the opposite order they are created
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/dropck/dropck-eyepatch.nll.stderr
+++ b/src/test/ui/dropck/dropck-eyepatch.nll.stderr
@@ -1,14 +1,15 @@
-error: compilation successful
-  --> $DIR/dropck-eyepatch.rs:67:1
+error[E0597]: `c_shortest` does not live long enough
+  --> $DIR/dropck-eyepatch.rs:87:19
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     use std::cell::Cell;
-LL | |     let c_long;
-LL | |     let (c, mut dt, mut dr, mut pt, mut pr, st, sr)
-...  |
-LL | |     println!("{:?}", (dt.0, dr.0, pt.0, pr.0, st.0, sr.0));
-LL | | }
-   | |_^
+LL |     dt = Dt("dt", &c_shortest);
+   |                   ^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `dt` is dropped
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/dropck/dropck-eyepatch.rs
+++ b/src/test/ui/dropck/dropck-eyepatch.rs
@@ -67,33 +67,42 @@ unsafe impl<#[may_dangle] 'a, 'b, B: fmt::Debug> Drop for Pr<'a, 'b, B> {
 fn main() { #![rustc_error] // rust-lang/rust#49855
     use std::cell::Cell;
     let c_long;
-    let (c, mut dt, mut dr, mut pt, mut pr, st, sr)
-        : (Cell<_>, Dt<_>, Dr<_>, Pt<_, _>, Pr<_>, St<_>, Sr<_>);
+    let (c, mut dt, mut dr, mut pt, mut pr, st, sr, c_shortest)
+        : (Cell<_>, Dt<_>, Dr<_>, Pt<_, _>, Pr<_>, St<_>, Sr<_>, Cell<_>);
     c_long = Cell::new(1);
     c = Cell::new(1);
+    c_shortest = Cell::new(1);
 
     // No error: sufficiently long-lived state can be referenced in dtors
     dt = Dt("dt", &c_long);
     dr = Dr("dr", &c_long);
+
     // Error: destructor order imprecisely modelled
     dt = Dt("dt", &c);
     //~^ ERROR `c` does not live long enough
     dr = Dr("dr", &c);
     //~^ ERROR `c` does not live long enough
 
+    // Error: `c_shortest` dies too soon for the references in dtors to be valid.
+    dt = Dt("dt", &c_shortest);
+    //~^ ERROR `c_shortest` does not live long enough
+    dr = Dr("dr", &c_shortest);
+    //~^ ERROR `c_shortest` does not live long enough
+
+
     // No error: Drop impl asserts .1 (A and &'a _) are not accessed
-    pt = Pt("pt", &c, &c_long);
-    pr = Pr("pr", &c, &c_long);
+    pt = Pt("pt", &c_shortest, &c_long);
+    pr = Pr("pr", &c_shortest, &c_long);
 
     // Error: Drop impl's assertion does not apply to `B` nor `&'b _`
-    pt = Pt("pt", &c_long, &c);
-    //~^ ERROR `c` does not live long enough
-    pr = Pr("pr", &c_long, &c);
-    //~^ ERROR `c` does not live long enough
+    pt = Pt("pt", &c_long, &c_shortest);
+    //~^ ERROR `c_shortest` does not live long enough
+    pr = Pr("pr", &c_long, &c_shortest);
+    //~^ ERROR `c_shortest` does not live long enough
 
     // No error: St and Sr have no destructor.
-    st = St("st", &c);
-    sr = Sr("sr", &c);
+    st = St("st", &c_shortest);
+    sr = Sr("sr", &c_shortest);
 
     println!("{:?}", (dt.0, dr.0, pt.0, pr.0, st.0, sr.0));
 }

--- a/src/test/ui/dropck/dropck-eyepatch.stderr
+++ b/src/test/ui/dropck/dropck-eyepatch.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch.rs:79:20
+  --> $DIR/dropck-eyepatch.rs:81:20
    |
 LL |     dt = Dt("dt", &c);
    |                    ^ borrowed value does not live long enough
@@ -10,7 +10,7 @@ LL | }
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch.rs:81:20
+  --> $DIR/dropck-eyepatch.rs:83:20
    |
 LL |     dr = Dr("dr", &c);
    |                    ^ borrowed value does not live long enough
@@ -20,28 +20,50 @@ LL | }
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch.rs:89:29
+error[E0597]: `c_shortest` does not live long enough
+  --> $DIR/dropck-eyepatch.rs:87:20
    |
-LL |     pt = Pt("pt", &c_long, &c);
-   |                             ^ borrowed value does not live long enough
+LL |     dt = Dt("dt", &c_shortest);
+   |                    ^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL | }
-   | - `c` dropped here while still borrowed
+   | - `c_shortest` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error[E0597]: `c` does not live long enough
-  --> $DIR/dropck-eyepatch.rs:91:29
+error[E0597]: `c_shortest` does not live long enough
+  --> $DIR/dropck-eyepatch.rs:89:20
    |
-LL |     pr = Pr("pr", &c_long, &c);
-   |                             ^ borrowed value does not live long enough
+LL |     dr = Dr("dr", &c_shortest);
+   |                    ^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL | }
-   | - `c` dropped here while still borrowed
+   | - `c_shortest` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 
-error: aborting due to 4 previous errors
+error[E0597]: `c_shortest` does not live long enough
+  --> $DIR/dropck-eyepatch.rs:98:29
+   |
+LL |     pt = Pt("pt", &c_long, &c_shortest);
+   |                             ^^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | - `c_shortest` dropped here while still borrowed
+   |
+   = note: values in a scope are dropped in the opposite order they are created
+
+error[E0597]: `c_shortest` does not live long enough
+  --> $DIR/dropck-eyepatch.rs:100:29
+   |
+LL |     pr = Pr("pr", &c_long, &c_shortest);
+   |                             ^^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | - `c_shortest` dropped here while still borrowed
+   |
+   = note: values in a scope are dropped in the opposite order they are created
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/error-codes/E0499.nll.stderr
+++ b/src/test/ui/error-codes/E0499.nll.stderr
@@ -1,12 +1,14 @@
-error: compilation successful
-  --> $DIR/E0499.rs:11:1
+error[E0499]: cannot borrow `i` as mutable more than once at a time
+  --> $DIR/E0499.rs:14:17
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     let mut i = 0;
-LL | |     let mut x = &mut i;
-LL | |     let mut a = &mut i; //~ ERROR E0499
-LL | | }
-   | |_^
+LL |     let mut x = &mut i;
+   |                 ------ first mutable borrow occurs here
+LL |     let mut a = &mut i; //~ ERROR E0499
+   |                 ^^^^^^ second mutable borrow occurs here
+LL |     a.use_mut();
+LL |     x.use_mut();
+   |     - borrow later used here
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0499`.

--- a/src/test/ui/error-codes/E0499.rs
+++ b/src/test/ui/error-codes/E0499.rs
@@ -7,9 +7,14 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(rustc_attrs)]
-fn main() { #![rustc_error] // rust-lang/rust#49855
+
+fn main() {
     let mut i = 0;
     let mut x = &mut i;
     let mut a = &mut i; //~ ERROR E0499
+    a.use_mut();
+    x.use_mut();
 }
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/error-codes/E0499.stderr
+++ b/src/test/ui/error-codes/E0499.stderr
@@ -5,6 +5,7 @@ LL |     let mut x = &mut i;
    |                      - first mutable borrow occurs here
 LL |     let mut a = &mut i; //~ ERROR E0499
    |                      ^ second mutable borrow occurs here
+...
 LL | }
    | - first borrow ends here
 

--- a/src/test/ui/error-codes/E0502.nll.stderr
+++ b/src/test/ui/error-codes/E0502.nll.stderr
@@ -1,9 +1,13 @@
-error: compilation successful
-  --> $DIR/E0502.rs:17:1
+error[E0502]: cannot borrow `*a` as mutable because it is also borrowed as immutable
+  --> $DIR/E0502.rs:14:5
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | | }
-   | |_^
+LL |     let ref y = a;
+   |         ----- immutable borrow occurs here
+LL |     bar(a); //~ ERROR E0502
+   |     ^^^^^^ mutable borrow occurs here
+LL |     y.use_ref();
+   |     - borrow later used here
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0502`.

--- a/src/test/ui/error-codes/E0502.rs
+++ b/src/test/ui/error-codes/E0502.rs
@@ -7,12 +7,16 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(rustc_attrs)]
+
 fn bar(x: &mut i32) {}
 fn foo(a: &mut i32) {
     let ref y = a;
     bar(a); //~ ERROR E0502
+    y.use_ref();
 }
 
-fn main() { #![rustc_error] // rust-lang/rust#49855
+fn main() {
 }
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/error-codes/E0502.stderr
+++ b/src/test/ui/error-codes/E0502.stderr
@@ -5,6 +5,7 @@ LL |     let ref y = a;
    |         ----- immutable borrow occurs here
 LL |     bar(a); //~ ERROR E0502
    |         ^ mutable borrow occurs here
+LL |     y.use_ref();
 LL | }
    | - immutable borrow ends here
 

--- a/src/test/ui/error-codes/E0503.nll.stderr
+++ b/src/test/ui/error-codes/E0503.nll.stderr
@@ -1,12 +1,13 @@
-error: compilation successful
-  --> $DIR/E0503.rs:11:1
+error[E0503]: cannot use `value` because it was mutably borrowed
+  --> $DIR/E0503.rs:14:16
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     let mut value = 3;
-LL | |     let _borrow = &mut value;
-LL | |     let _sum = value + 1; //~ ERROR E0503
-LL | | }
-   | |_^
+LL |     let _borrow = &mut value;
+   |                   ---------- borrow of `value` occurs here
+LL |     let _sum = value + 1; //~ ERROR E0503
+   |                ^^^^^ use of borrowed `value`
+LL |     _borrow.use_mut();
+   |     ------- borrow later used here
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0503`.

--- a/src/test/ui/error-codes/E0503.rs
+++ b/src/test/ui/error-codes/E0503.rs
@@ -7,9 +7,13 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(rustc_attrs)]
-fn main() { #![rustc_error] // rust-lang/rust#49855
+
+fn main() {
     let mut value = 3;
     let _borrow = &mut value;
     let _sum = value + 1; //~ ERROR E0503
+    _borrow.use_mut();
 }
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/error-codes/E0505.nll.stderr
+++ b/src/test/ui/error-codes/E0505.nll.stderr
@@ -1,14 +1,13 @@
-error: compilation successful
-  --> $DIR/E0505.rs:15:1
+error[E0505]: cannot move out of `x` because it is borrowed
+  --> $DIR/E0505.rs:19:13
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     let x = Value{};
-LL | |     {
-LL | |         let _ref_to_val: &Value = &x;
-LL | |         eat(x); //~ ERROR E0505
-LL | |     }
-LL | | }
-   | |_^
+LL |         let _ref_to_val: &Value = &x;
+   |                                   -- borrow of `x` occurs here
+LL |         eat(x); //~ ERROR E0505
+   |             ^ move out of `x` occurs here
+LL |         _ref_to_val.use_ref();
+   |         ----------- borrow later used here
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0505`.

--- a/src/test/ui/error-codes/E0505.rs
+++ b/src/test/ui/error-codes/E0505.rs
@@ -7,15 +7,19 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(rustc_attrs)]
+
 struct Value {}
 
 fn eat(val: Value) {}
 
-fn main() { #![rustc_error] // rust-lang/rust#49855
+fn main() {
     let x = Value{};
     {
         let _ref_to_val: &Value = &x;
         eat(x); //~ ERROR E0505
+        _ref_to_val.use_ref();
     }
 }
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/error-codes/E0597.nll.stderr
+++ b/src/test/ui/error-codes/E0597.nll.stderr
@@ -1,13 +1,15 @@
-error: compilation successful
-  --> $DIR/E0597.rs:15:1
+error[E0597]: `y` does not live long enough
+  --> $DIR/E0597.rs:18:16
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     let mut x = Foo { x: None };
-LL | |     let y = 0;
-LL | |     x.x = Some(&y);
-LL | |     //~^ `y` does not live long enough [E0597]
-LL | | }
-   | |_^
+LL |     x.x = Some(&y);
+   |                ^^ borrowed value does not live long enough
+LL |     //~^ `y` does not live long enough [E0597]
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `x` is dropped
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/error-codes/E0597.rs
+++ b/src/test/ui/error-codes/E0597.rs
@@ -7,14 +7,16 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(rustc_attrs)]
+
 struct Foo<'a> {
     x: Option<&'a u32>,
 }
 
-fn main() { #![rustc_error] // rust-lang/rust#49855
+fn main() {
     let mut x = Foo { x: None };
     let y = 0;
     x.x = Some(&y);
     //~^ `y` does not live long enough [E0597]
 }
+
+impl<'a> Drop for Foo<'a> { fn drop(&mut self) { } }

--- a/src/test/ui/generator/dropck.nll.stderr
+++ b/src/test/ui/generator/dropck.nll.stderr
@@ -1,3 +1,15 @@
+error[E0597]: `*cell` does not live long enough
+  --> $DIR/dropck.rs:19:40
+   |
+LL |     let ref_ = Box::leak(Box::new(Some(cell.borrow_mut())));
+   |                                        ^^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `gen` is dropped
+
 error[E0597]: `ref_` does not live long enough
   --> $DIR/dropck.rs:22:11
    |
@@ -15,6 +27,6 @@ LL |   }
    |   borrowed value only lives until here
    |   borrow later used here, when `gen` is dropped
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/generator/dropck.rs
+++ b/src/test/ui/generator/dropck.rs
@@ -14,7 +14,7 @@ use std::cell::RefCell;
 use std::ops::Generator;
 
 fn main() {
-    let (cell, mut gen);
+    let (mut gen, cell);
     cell = Box::new(RefCell::new(0));
     let ref_ = Box::leak(Box::new(Some(cell.borrow_mut())));
     //~^ ERROR `*cell` does not live long enough [E0597]

--- a/src/test/ui/generator/pattern-borrow.nll.stderr
+++ b/src/test/ui/generator/pattern-borrow.nll.stderr
@@ -1,8 +1,11 @@
-error: compilation successful
-  --> $DIR/pattern-borrow.rs:15:1
+error[E0626]: borrow may still be in use when generator yields
+  --> $DIR/pattern-borrow.rs:19:24
    |
-LL | fn main() { #![rustc_error] } // rust-lang/rust#49855
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         if let Test::A(ref _a) = test { //~ ERROR borrow may still be in use when generator yields
+   |                        ^^^^^^
+LL |             yield ();
+   |             -------- possible yield occurs here
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0626`.

--- a/src/test/ui/generator/pattern-borrow.rs
+++ b/src/test/ui/generator/pattern-borrow.rs
@@ -8,16 +8,20 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(generators, rustc_attrs)]
+#![feature(generators)]
 
 enum Test { A(i32), B, }
 
-fn main() { #![rustc_error] } // rust-lang/rust#49855
+fn main() { }
 
 fn fun(test: Test) {
     move || {
         if let Test::A(ref _a) = test { //~ ERROR borrow may still be in use when generator yields
             yield ();
+            _a.use_ref();
         }
     };
 }
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/hygiene/fields-numeric-borrowck.nll.stderr
+++ b/src/test/ui/hygiene/fields-numeric-borrowck.nll.stderr
@@ -1,13 +1,14 @@
-error: compilation successful
-  --> $DIR/fields-numeric-borrowck.rs:13:1
+error[E0499]: cannot borrow `s.0` as mutable more than once at a time
+  --> $DIR/fields-numeric-borrowck.rs:16:16
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     let mut s = S(0);
-LL | |     let borrow1 = &mut s.0;
-LL | |     let S { 0: ref mut borrow2 } = s;
-LL | |     //~^ ERROR cannot borrow `s.0` as mutable more than once at a time
-LL | | }
-   | |_^
+LL |     let borrow1 = &mut s.0;
+   |                   -------- first mutable borrow occurs here
+LL |     let S { 0: ref mut borrow2 } = s;
+   |                ^^^^^^^^^^^^^^^ second mutable borrow occurs here
+...
+LL |     borrow1.use_mut();
+   |     ------- borrow later used here
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0499`.

--- a/src/test/ui/hygiene/fields-numeric-borrowck.rs
+++ b/src/test/ui/hygiene/fields-numeric-borrowck.rs
@@ -7,12 +7,17 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(rustc_attrs)]
+
 struct S(u8);
 
-fn main() { #![rustc_error] // rust-lang/rust#49855
+fn main() {
     let mut s = S(0);
     let borrow1 = &mut s.0;
     let S { 0: ref mut borrow2 } = s;
     //~^ ERROR cannot borrow `s.0` as mutable more than once at a time
+    borrow2.use_mut();
+    borrow1.use_mut();
 }
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/hygiene/fields-numeric-borrowck.stderr
+++ b/src/test/ui/hygiene/fields-numeric-borrowck.stderr
@@ -5,7 +5,7 @@ LL |     let borrow1 = &mut s.0;
    |                        --- first mutable borrow occurs here
 LL |     let S { 0: ref mut borrow2 } = s;
    |                ^^^^^^^^^^^^^^^ second mutable borrow occurs here
-LL |     //~^ ERROR cannot borrow `s.0` as mutable more than once at a time
+...
 LL | }
    | - first borrow ends here
 

--- a/src/test/ui/issue-25793.nll.stderr
+++ b/src/test/ui/issue-25793.nll.stderr
@@ -1,8 +1,17 @@
-error: compilation successful
-  --> $DIR/issue-25793.rs:32:1
+error[E0503]: cannot use `self.width` because it was mutably borrowed
+  --> $DIR/issue-25793.rs:13:9
    |
-LL | fn main() { #![rustc_error] } // rust-lang/rust#49855
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         $this.width.unwrap()
+   |         ^^^^^^^^^^^ use of borrowed `*self`
+...
+LL |         let r = &mut *self;
+   |                 ---------- borrow of `*self` occurs here
+LL |         r.get_size(width!(self))
+   |         ------------------------
+   |         |          |
+   |         |          in this macro invocation
+   |         borrow later used here
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0503`.

--- a/src/test/ui/issue-25793.rs
+++ b/src/test/ui/issue-25793.rs
@@ -25,8 +25,11 @@ impl HasInfo {
     }
 
     fn get_other(&mut self) -> usize {
-        self.get_size(width!(self))
+        let r = &mut *self;
+        r.get_size(width!(self))
     }
+    // Above is like `self.get_size(width!(self))`, but it
+    // deliberately avoids NLL's two phase borrow feature.
 }
 
-fn main() { #![rustc_error] } // rust-lang/rust#49855
+fn main() { }

--- a/src/test/ui/issue-25793.stderr
+++ b/src/test/ui/issue-25793.stderr
@@ -4,10 +4,10 @@ error[E0503]: cannot use `self.width` because it was mutably borrowed
 LL |         $this.width.unwrap()
    |         ^^^^^^^^^^^ use of borrowed `*self`
 ...
-LL |         self.get_size(width!(self))
-   |         ----          ------------ in this macro invocation
-   |         |
-   |         borrow of `*self` occurs here
+LL |         let r = &mut *self;
+   |                      ----- borrow of `*self` occurs here
+LL |         r.get_size(width!(self))
+   |                    ------------ in this macro invocation
 
 error: aborting due to previous error
 

--- a/src/test/ui/issue-42106.nll.stderr
+++ b/src/test/ui/issue-42106.nll.stderr
@@ -1,8 +1,13 @@
-error: compilation successful
-  --> $DIR/issue-42106.rs:16:1
+error[E0502]: cannot borrow `*collection` as mutable because it is also borrowed as immutable
+  --> $DIR/issue-42106.rs:13:5
    |
-LL | fn main() { #![rustc_error] } // rust-lang/rust#49855
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _a = &collection;
+   |              ----------- immutable borrow occurs here
+LL |     collection.swap(1, 2); //~ ERROR also borrowed as immutable
+   |     ^^^^^^^^^^ mutable borrow occurs here
+LL |     _a.use_ref();
+   |     -- borrow later used here
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0502`.

--- a/src/test/ui/issue-42106.rs
+++ b/src/test/ui/issue-42106.rs
@@ -7,10 +7,14 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(rustc_attrs)]
+
 fn do_something<T>(collection: &mut Vec<T>) {
     let _a = &collection;
     collection.swap(1, 2); //~ ERROR also borrowed as immutable
+    _a.use_ref();
 }
 
-fn main() { #![rustc_error] } // rust-lang/rust#49855
+fn main() { }
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/issue-42106.stderr
+++ b/src/test/ui/issue-42106.stderr
@@ -5,6 +5,7 @@ LL |     let _a = &collection;
    |               ---------- immutable borrow occurs here
 LL |     collection.swap(1, 2); //~ ERROR also borrowed as immutable
    |     ^^^^^^^^^^ mutable borrow occurs here
+LL |     _a.use_ref();
 LL | }
    | - immutable borrow ends here
 

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-2.nll.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-2.nll.stderr
@@ -1,17 +1,17 @@
 warning: not reporting region error due to nll
-  --> $DIR/ex3-both-anon-regions-2.rs:12:9
+  --> $DIR/ex3-both-anon-regions-2.rs:12:10
    |
-LL |     v = x; //~ ERROR lifetime mismatch
-   |         ^
+LL |     *v = x; //~ ERROR lifetime mismatch
+   |          ^
 
-error[E0384]: cannot assign twice to immutable variable `v`
-  --> $DIR/ex3-both-anon-regions-2.rs:12:5
+error[E0623]: lifetime mismatch
+  --> $DIR/ex3-both-anon-regions-2.rs:11:14
    |
-LL | fn foo((v, w): (&u8, &u8), x: &u8) {
-   |         - first assignment to `v`
-LL |     v = x; //~ ERROR lifetime mismatch
-   |     ^^^^^ cannot assign twice to immutable variable
+LL | fn foo(&mut (ref mut v, w): &mut (&u8, &u8), x: &u8) {
+   |              ^^^^^^^^^            ---           --- these two types are declared with different lifetimes...
+   |              |
+   |              ...but data from `x` flows here
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0384`.
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-2.rs
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-2.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn foo((v, w): (&u8, &u8), x: &u8) {
-    v = x; //~ ERROR lifetime mismatch
+fn foo(&mut (ref mut v, w): &mut (&u8, &u8), x: &u8) {
+    *v = x; //~ ERROR lifetime mismatch
 }
 
 fn main() { }

--- a/src/test/ui/lifetime-errors/ex3-both-anon-regions-2.stderr
+++ b/src/test/ui/lifetime-errors/ex3-both-anon-regions-2.stderr
@@ -1,10 +1,10 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/ex3-both-anon-regions-2.rs:12:9
+  --> $DIR/ex3-both-anon-regions-2.rs:12:10
    |
-LL | fn foo((v, w): (&u8, &u8), x: &u8) {
-   |                 ---           --- these two types are declared with different lifetimes...
-LL |     v = x; //~ ERROR lifetime mismatch
-   |         ^ ...but data from `x` flows here
+LL | fn foo(&mut (ref mut v, w): &mut (&u8, &u8), x: &u8) {
+   |                                   ---           --- these two types are declared with different lifetimes...
+LL |     *v = x; //~ ERROR lifetime mismatch
+   |          ^ ...but data from `x` flows here
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/borrowck-let-suggestion.nll.stderr
+++ b/src/test/ui/lifetimes/borrowck-let-suggestion.nll.stderr
@@ -1,10 +1,15 @@
-error: compilation successful
-  --> $DIR/borrowck-let-suggestion.rs:15:1
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/borrowck-let-suggestion.rs:12:17
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     f();
-LL | | }
-   | |_^
+LL |     let mut x = vec![1].iter();
+   |                 ^^^^^^^       - temporary value only lives until here
+   |                 |
+   |                 temporary value does not live long enough
+LL |     x.use_mut();
+   |     - borrow later used here
+   |
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/lifetimes/borrowck-let-suggestion.rs
+++ b/src/test/ui/lifetimes/borrowck-let-suggestion.rs
@@ -7,11 +7,15 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(rustc_attrs)]
+
 fn f() {
-    let x = vec![1].iter();
+    let mut x = vec![1].iter();
+    x.use_mut();
 }
 
-fn main() { #![rustc_error] // rust-lang/rust#49855
+fn main() {
     f();
 }
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/lifetimes/borrowck-let-suggestion.stderr
+++ b/src/test/ui/lifetimes/borrowck-let-suggestion.stderr
@@ -1,10 +1,11 @@
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/borrowck-let-suggestion.rs:12:13
+  --> $DIR/borrowck-let-suggestion.rs:12:17
    |
-LL |     let x = vec![1].iter();
-   |             ^^^^^^^       - temporary value dropped here while still borrowed
-   |             |
-   |             temporary value does not live long enough
+LL |     let mut x = vec![1].iter();
+   |                 ^^^^^^^       - temporary value dropped here while still borrowed
+   |                 |
+   |                 temporary value does not live long enough
+LL |     x.use_mut();
 LL | }
    | - temporary value needs to live until here
    |

--- a/src/test/ui/span/borrowck-let-suggestion-suffixes.nll.stderr
+++ b/src/test/ui/span/borrowck-let-suggestion-suffixes.nll.stderr
@@ -1,10 +1,36 @@
-error: compilation successful
-  --> $DIR/borrowck-let-suggestion-suffixes.rs:61:1
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/borrowck-let-suggestion-suffixes.rs:28:14
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     f();
-LL | | }
-   | |_^
+LL |     v3.push(&id('x'));           // statement 6
+   |              ^^^^^^^ - temporary value only lives until here
+   |              |
+   |              temporary value does not live long enough
+...
+LL |     (v1, v2, v3, /* v4 is above. */ v5).use_ref();
+   |              -- borrow later used here
 
-error: aborting due to previous error
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/borrowck-let-suggestion-suffixes.rs:38:18
+   |
+LL |         v4.push(&id('y'));
+   |                  ^^^^^^^ - temporary value only lives until here
+   |                  |
+   |                  temporary value does not live long enough
+...
+LL |         v4.use_ref();
+   |         -- borrow later used here
 
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/borrowck-let-suggestion-suffixes.rs:49:14
+   |
+LL |     v5.push(&id('z'));
+   |              ^^^^^^^ - temporary value only lives until here
+   |              |
+   |              temporary value does not live long enough
+...
+LL |     (v1, v2, v3, /* v4 is above. */ v5).use_ref();
+   |                                     -- borrow later used here
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/borrowck-let-suggestion-suffixes.rs
+++ b/src/test/ui/span/borrowck-let-suggestion-suffixes.rs
@@ -40,7 +40,7 @@ fn f() {
         //~| NOTE temporary value does not live long enough
         //~| NOTE temporary value dropped here while still borrowed
         //~| NOTE consider using a `let` binding to increase its lifetime
-
+        v4.use_ref();
     }                       // (statement 7)
     //~^ NOTE temporary value needs to live until here
 
@@ -53,6 +53,8 @@ fn f() {
     //~| NOTE consider using a `let` binding to increase its lifetime
 
     v1.push(&old[0]);
+
+    (v1, v2, v3, /* v4 is above. */ v5).use_ref();
 }
 //~^ NOTE `young[..]` dropped here while still borrowed
 //~| NOTE temporary value needs to live until here
@@ -61,3 +63,6 @@ fn f() {
 fn main() { #![rustc_error] // rust-lang/rust#49855
     f();
 }
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/span/issue-36537.nll.stderr
+++ b/src/test/ui/span/issue-36537.nll.stderr
@@ -1,13 +1,14 @@
-error: compilation successful
-  --> $DIR/issue-36537.rs:11:1
+error[E0597]: `a` does not live long enough
+  --> $DIR/issue-36537.rs:15:9
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     let p;
-LL | |     let a = 42;
-LL | |     p = &a;
-LL | |     //~^ ERROR `a` does not live long enough
-LL | | }
-   | |_^
+LL |         p = &a;
+   |         ^^^^^^ borrowed value does not live long enough
+...
+LL |     }
+   |     - borrowed value only lives until here
+LL |     p.use_ref();
+   |     - borrow later used here
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/issue-36537.rs
+++ b/src/test/ui/span/issue-36537.rs
@@ -7,10 +7,18 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(rustc_attrs)]
-fn main() { #![rustc_error] // rust-lang/rust#49855
+
+fn main() {
     let p;
-    let a = 42;
-    p = &a;
-    //~^ ERROR `a` does not live long enough
+    {
+        let a = 42;
+        p = &a;
+        //~^ ERROR `a` does not live long enough
+
+    }
+    p.use_ref();
+
 }
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/span/issue-36537.stderr
+++ b/src/test/ui/span/issue-36537.stderr
@@ -1,13 +1,14 @@
 error[E0597]: `a` does not live long enough
-  --> $DIR/issue-36537.rs:14:10
+  --> $DIR/issue-36537.rs:15:14
    |
-LL |     p = &a;
-   |          ^ borrowed value does not live long enough
-LL |     //~^ ERROR `a` does not live long enough
+LL |         p = &a;
+   |              ^ borrowed value does not live long enough
+...
+LL |     }
+   |     - `a` dropped here while still borrowed
+...
 LL | }
-   | - `a` dropped here while still borrowed
-   |
-   = note: values in a scope are dropped in the opposite order they are created
+   | - borrowed value needs to live until here
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/mut-ptr-cant-outlive-ref.nll.stderr
+++ b/src/test/ui/span/mut-ptr-cant-outlive-ref.nll.stderr
@@ -1,14 +1,14 @@
-error: compilation successful
-  --> $DIR/mut-ptr-cant-outlive-ref.rs:13:1
+error[E0597]: `b` does not live long enough
+  --> $DIR/mut-ptr-cant-outlive-ref.rs:18:15
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     let m = RefCell::new(0);
-LL | |     let p;
-LL | |     {
-...  |
-LL | |     //~^^ ERROR `b` does not live long enough
-LL | | }
-   | |_^
+LL |         p = &*b;
+   |               ^ borrowed value does not live long enough
+LL |     }
+   |     - borrowed value only lives until here
+LL |     //~^^ ERROR `b` does not live long enough
+LL |     p.use_ref();
+   |     - borrow later used here
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/mut-ptr-cant-outlive-ref.rs
+++ b/src/test/ui/span/mut-ptr-cant-outlive-ref.rs
@@ -7,10 +7,10 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(rustc_attrs)]
+
 use std::cell::RefCell;
 
-fn main() { #![rustc_error] // rust-lang/rust#49855
+fn main() {
     let m = RefCell::new(0);
     let p;
     {
@@ -18,4 +18,8 @@ fn main() { #![rustc_error] // rust-lang/rust#49855
         p = &*b;
     }
     //~^^ ERROR `b` does not live long enough
+    p.use_ref();
 }
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/span/mut-ptr-cant-outlive-ref.stderr
+++ b/src/test/ui/span/mut-ptr-cant-outlive-ref.stderr
@@ -5,7 +5,7 @@ LL |         p = &*b;
    |               ^ borrowed value does not live long enough
 LL |     }
    |     - `b` dropped here while still borrowed
-LL |     //~^^ ERROR `b` does not live long enough
+...
 LL | }
    | - borrowed value needs to live until here
 

--- a/src/test/ui/span/range-2.nll.stderr
+++ b/src/test/ui/span/range-2.nll.stderr
@@ -1,14 +1,25 @@
-error: compilation successful
-  --> $DIR/range-2.rs:13:1
+error[E0597]: `b` does not live long enough
+  --> $DIR/range-2.rs:17:13
    |
-LL | / pub fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     let r = {
-LL | |         let a = 42;
-LL | |         let b = 42;
-...  |
-LL | |     //~| ERROR `b` does not live long enough
-LL | | }
-   | |_^
+LL |         &a..&b
+   |             ^^ borrowed value does not live long enough
+LL |     };
+   |     - borrowed value only lives until here
+...
+LL |     r.use_ref();
+   |     - borrow later used here
 
-error: aborting due to previous error
+error[E0597]: `a` does not live long enough
+  --> $DIR/range-2.rs:17:9
+   |
+LL |         &a..&b
+   |         ^^ borrowed value does not live long enough
+LL |     };
+   |     - borrowed value only lives until here
+...
+LL |     r.use_ref();
+   |     - borrow later used here
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/range-2.rs
+++ b/src/test/ui/span/range-2.rs
@@ -18,4 +18,8 @@ pub fn main() { #![rustc_error] // rust-lang/rust#49855
     };
     //~^^ ERROR `a` does not live long enough
     //~| ERROR `b` does not live long enough
+    r.use_ref();
 }
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/span/regionck-unboxed-closure-lifetimes.nll.stderr
+++ b/src/test/ui/span/regionck-unboxed-closure-lifetimes.nll.stderr
@@ -1,14 +1,14 @@
-error: compilation successful
-  --> $DIR/regionck-unboxed-closure-lifetimes.rs:13:1
+error[E0597]: `c` does not live long enough
+  --> $DIR/regionck-unboxed-closure-lifetimes.rs:17:21
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     let mut f;
-LL | |     {
-LL | |         let c = 1;
-...  |
-LL | |     }
-LL | | }
-   | |_^
+LL |         let c_ref = &c;
+   |                     ^^ borrowed value does not live long enough
+...
+LL |     }
+   |     - borrowed value only lives until here
+LL |     f.use_mut();
+   |     - borrow later used here
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/regionck-unboxed-closure-lifetimes.rs
+++ b/src/test/ui/span/regionck-unboxed-closure-lifetimes.rs
@@ -18,4 +18,8 @@ fn main() { #![rustc_error] // rust-lang/rust#49855
         //~^ ERROR `c` does not live long enough
         f = move |a: isize, b: isize| { a + b + *c_ref };
     }
+    f.use_mut();
 }
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/span/regionck-unboxed-closure-lifetimes.stderr
+++ b/src/test/ui/span/regionck-unboxed-closure-lifetimes.stderr
@@ -6,6 +6,7 @@ LL |         let c_ref = &c;
 ...
 LL |     }
    |     - `c` dropped here while still borrowed
+LL |     f.use_mut();
 LL | }
    | - borrowed value needs to live until here
 

--- a/src/test/ui/span/send-is-not-static-std-sync.nll.stderr
+++ b/src/test/ui/span/send-is-not-static-std-sync.nll.stderr
@@ -9,8 +9,19 @@ LL |     drop(y); //~ ERROR cannot move out
 LL |         *lock.lock().unwrap() = &z;
    |          ---- borrow later used here
 
+error[E0597]: `z` does not live long enough
+  --> $DIR/send-is-not-static-std-sync.rs:26:33
+   |
+LL |         *lock.lock().unwrap() = &z;
+   |                                 ^^ borrowed value does not live long enough
+LL |     }
+   |     - borrowed value only lives until here
+LL |     //~^^ ERROR `z` does not live long enough
+LL |     lock.use_ref(); // (Mutex is #[may_dangle] so its dtor does not use `z` => needs explicit use)
+   |     ---- borrow later used here
+
 error[E0505]: cannot move out of `y` because it is borrowed
-  --> $DIR/send-is-not-static-std-sync.rs:36:10
+  --> $DIR/send-is-not-static-std-sync.rs:37:10
    |
 LL |     *lock.write().unwrap() = &*y;
    |                              --- borrow of `*y` occurs here
@@ -20,8 +31,19 @@ LL |     drop(y); //~ ERROR cannot move out
 LL |         *lock.write().unwrap() = &z;
    |          ---- borrow later used here
 
+error[E0597]: `z` does not live long enough
+  --> $DIR/send-is-not-static-std-sync.rs:40:34
+   |
+LL |         *lock.write().unwrap() = &z;
+   |                                  ^^ borrowed value does not live long enough
+LL |     }
+   |     - borrowed value only lives until here
+LL |     //~^^ ERROR `z` does not live long enough
+LL |     lock.use_ref(); // (RwLock is #[may_dangle] so its dtor does not use `z` => needs explicit use)
+   |     ---- borrow later used here
+
 error[E0505]: cannot move out of `y` because it is borrowed
-  --> $DIR/send-is-not-static-std-sync.rs:51:10
+  --> $DIR/send-is-not-static-std-sync.rs:53:10
    |
 LL |     tx.send(&*y);
    |             --- borrow of `*y` occurs here
@@ -32,17 +54,17 @@ LL |         tx.send(&z).unwrap();
    |         -- borrow later used here
 
 error[E0597]: `z` does not live long enough
-  --> $DIR/send-is-not-static-std-sync.rs:54:17
+  --> $DIR/send-is-not-static-std-sync.rs:56:17
    |
 LL |         tx.send(&z).unwrap();
    |                 ^^ borrowed value does not live long enough
 LL |     }
    |     - borrowed value only lives until here
-LL |     //~^^ ERROR `z` does not live long enough
+...
 LL | }
    | - borrow later used here, when `tx` is dropped
 
-error: aborting due to 4 previous errors
+error: aborting due to 6 previous errors
 
 Some errors occurred: E0505, E0597.
 For more information about an error, try `rustc --explain E0505`.

--- a/src/test/ui/span/send-is-not-static-std-sync.rs
+++ b/src/test/ui/span/send-is-not-static-std-sync.rs
@@ -26,6 +26,7 @@ fn mutex() {
         *lock.lock().unwrap() = &z;
     }
     //~^^ ERROR `z` does not live long enough
+    lock.use_ref(); // (Mutex is #[may_dangle] so its dtor does not use `z` => needs explicit use)
 }
 
 fn rwlock() {
@@ -39,6 +40,7 @@ fn rwlock() {
         *lock.write().unwrap() = &z;
     }
     //~^^ ERROR `z` does not live long enough
+    lock.use_ref(); // (RwLock is #[may_dangle] so its dtor does not use `z` => needs explicit use)
 }
 
 fn channel() {
@@ -54,6 +56,10 @@ fn channel() {
         tx.send(&z).unwrap();
     }
     //~^^ ERROR `z` does not live long enough
+    // (channels lack #[may_dangle], thus their dtors are implicit uses of `z`)
 }
 
 fn main() {}
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/span/send-is-not-static-std-sync.stderr
+++ b/src/test/ui/span/send-is-not-static-std-sync.stderr
@@ -5,7 +5,7 @@ LL |         *lock.lock().unwrap() = &z;
    |                                  ^ borrowed value does not live long enough
 LL |     }
    |     - `z` dropped here while still borrowed
-LL |     //~^^ ERROR `z` does not live long enough
+...
 LL | }
    | - borrowed value needs to live until here
 
@@ -18,18 +18,18 @@ LL |     drop(y); //~ ERROR cannot move out
    |          ^ move out of `y` occurs here
 
 error[E0597]: `z` does not live long enough
-  --> $DIR/send-is-not-static-std-sync.rs:39:35
+  --> $DIR/send-is-not-static-std-sync.rs:40:35
    |
 LL |         *lock.write().unwrap() = &z;
    |                                   ^ borrowed value does not live long enough
 LL |     }
    |     - `z` dropped here while still borrowed
-LL |     //~^^ ERROR `z` does not live long enough
+...
 LL | }
    | - borrowed value needs to live until here
 
 error[E0505]: cannot move out of `y` because it is borrowed
-  --> $DIR/send-is-not-static-std-sync.rs:36:10
+  --> $DIR/send-is-not-static-std-sync.rs:37:10
    |
 LL |     *lock.write().unwrap() = &*y;
    |                               -- borrow of `*y` occurs here
@@ -37,18 +37,18 @@ LL |     drop(y); //~ ERROR cannot move out
    |          ^ move out of `y` occurs here
 
 error[E0597]: `z` does not live long enough
-  --> $DIR/send-is-not-static-std-sync.rs:54:18
+  --> $DIR/send-is-not-static-std-sync.rs:56:18
    |
 LL |         tx.send(&z).unwrap();
    |                  ^ borrowed value does not live long enough
 LL |     }
    |     - `z` dropped here while still borrowed
-LL |     //~^^ ERROR `z` does not live long enough
+...
 LL | }
    | - borrowed value needs to live until here
 
 error[E0505]: cannot move out of `y` because it is borrowed
-  --> $DIR/send-is-not-static-std-sync.rs:51:10
+  --> $DIR/send-is-not-static-std-sync.rs:53:10
    |
 LL |     tx.send(&*y);
    |              -- borrow of `*y` occurs here

--- a/src/test/ui/span/slice-borrow.nll.stderr
+++ b/src/test/ui/span/slice-borrow.nll.stderr
@@ -1,14 +1,16 @@
-error: compilation successful
-  --> $DIR/slice-borrow.rs:13:1
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/slice-borrow.rs:16:28
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     let y;
-LL | |     {
-LL | |         let x: &[isize] = &vec![1, 2, 3, 4, 5];
-LL | |         y = &x[1..];
-LL | |     }
-LL | | }
-   | |_^
+LL |         let x: &[isize] = &vec![1, 2, 3, 4, 5];
+   |                            ^^^^^^^^^^^^^^^^^^^ temporary value does not live long enough
+LL |         y = &x[1..];
+LL |     }
+   |     - temporary value only lives until here
+LL |     y.use_ref();
+   |     - borrow later used here
+   |
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/slice-borrow.rs
+++ b/src/test/ui/span/slice-borrow.rs
@@ -7,13 +7,17 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(rustc_attrs)]
+
 // Test slicing expressions doesn't defeat the borrow checker.
 
-fn main() { #![rustc_error] // rust-lang/rust#49855
+fn main() {
     let y;
     {
         let x: &[isize] = &vec![1, 2, 3, 4, 5];
         y = &x[1..];
     }
+    y.use_ref();
 }
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/span/slice-borrow.stderr
+++ b/src/test/ui/span/slice-borrow.stderr
@@ -6,6 +6,7 @@ LL |         let x: &[isize] = &vec![1, 2, 3, 4, 5];
 LL |         y = &x[1..];
 LL |     }
    |     - temporary value dropped here while still borrowed
+LL |     y.use_ref();
 LL | }
    | - temporary value needs to live until here
    |

--- a/src/test/ui/span/vec_refs_data_with_early_death.nll.stderr
+++ b/src/test/ui/span/vec_refs_data_with_early_death.nll.stderr
@@ -1,14 +1,27 @@
-error: compilation successful
-  --> $DIR/vec_refs_data_with_early_death.rs:21:1
+error[E0597]: `y` does not live long enough
+  --> $DIR/vec_refs_data_with_early_death.rs:29:12
    |
-LL | / fn main() { #![rustc_error] // rust-lang/rust#49855
-LL | |     let mut v = Vec::new();
-LL | |
-LL | |     let x: i8 = 3;
-...  |
-LL | |     assert_eq!(v, [&3, &4]);
-LL | | }
-   | |_^
+LL |     v.push(&y);
+   |            ^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `v` is dropped
 
-error: aborting due to previous error
+error[E0597]: `x` does not live long enough
+  --> $DIR/vec_refs_data_with_early_death.rs:27:12
+   |
+LL |     v.push(&x);
+   |            ^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | borrowed value only lives until here
+   | borrow later used here, when `v` is dropped
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/span/vec_refs_data_with_early_death.rs
+++ b/src/test/ui/span/vec_refs_data_with_early_death.rs
@@ -9,17 +9,17 @@
 // except according to those terms.
 
 // This test is a simple example of code that violates the dropck
-// rules: it pushes `&x` and `&y` into `v`, but the referenced data
-// will be dropped before the vector itself is.
+// rules: it pushes `&x` and `&y` into a bag (with dtor), but the
+// referenced data will be dropped before the bag is.
 
-// (In principle we know that `Vec` does not reference the data it
-//  owns from within its drop code, apart from calling drop on each
-//  element it owns; thus, for data like this, it seems like we could
-//  loosen the restrictions here if we wanted. But it also is not
-//  clear whether such loosening is terribly important.)
-#![feature(rustc_attrs)]
-fn main() { #![rustc_error] // rust-lang/rust#49855
-    let mut v = Vec::new();
+
+
+
+
+
+
+fn main() {
+    let mut v = Bag::new();
 
     let x: i8 = 3;
     let y: i8 = 4;
@@ -29,5 +29,15 @@ fn main() { #![rustc_error] // rust-lang/rust#49855
     v.push(&y);
     //~^ ERROR `y` does not live long enough
 
-    assert_eq!(v, [&3, &4]);
+    assert_eq!(v.0, [&3, &4]);
+}
+
+//`Vec<T>` is #[may_dangle] w.r.t. `T`; putting a bag over its head
+// forces borrowck to treat dropping the bag as a potential use.
+struct Bag<T>(Vec<T>);
+impl<T> Drop for Bag<T> { fn drop(&mut self) { } }
+
+impl<T> Bag<T> {
+    fn new() -> Self { Bag(Vec::new()) }
+    fn push(&mut self, t: T) { self.0.push(t); }
 }


### PR DESCRIPTION
This PR revises the `ui` tests that I could quickly identify that:
 1. previously had successful compilations under non-lexical lifetimes (NLL) because they assumed lexical lifetimes, but
 2. such assumption of lexical lifetimes was actually not necessarily part of the spirit of the original issue/bug we want to witness.

In many cases, this is simply a matter of adding a use of a borrow so that it gets extended long enough to observe a conflict.

(In some cases the revision was more subtle, such as adding a destructor, or revising the order of declaration of some variables.)

----

With these test revisions in place, I subsequently updated the expected stderr output under the NLL compiletest mode. So now we should get even more testing of NLL than we were before.

Fix #51025 
