### PR TITLE
Point to the current box syntax tracking issue

### DIFF
--- a/src/doc/unstable-book/src/language-features/box-syntax.md
+++ b/src/doc/unstable-book/src/language-features/box-syntax.md
@@ -1,8 +1,8 @@
 # `box_syntax`
 
-The tracking issue for this feature is: [#27779]
+The tracking issue for this feature is: [#49733]
 
-[#27779]: https://github.com/rust-lang/rust/issues/27779
+[#49733]: https://github.com/rust-lang/rust/issues/49733
 
 See also [`box_patterns`](language-features/box-patterns.html)
 

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -145,7 +145,7 @@ declare_features! (
     // rustc internal
     (active, rustc_diagnostic_macros, "1.0.0", None, None),
     (active, rustc_const_unstable, "1.0.0", None, None),
-    (active, box_syntax, "1.0.0", Some(27779), None),
+    (active, box_syntax, "1.0.0", Some(49733), None),
     (active, unboxed_closures, "1.0.0", Some(29625), None),
 
     (active, fundamental, "1.0.0", Some(29635), None),

--- a/src/test/ui/feature-gate-box-expr.stderr
+++ b/src/test/ui/feature-gate-box-expr.stderr
@@ -1,4 +1,4 @@
-error[E0658]: box expression syntax is experimental; you can call `Box::new` instead. (see issue #27779)
+error[E0658]: box expression syntax is experimental; you can call `Box::new` instead. (see issue #49733)
   --> $DIR/feature-gate-box-expr.rs:22:13
    |
 LL |     let x = box 'c'; //~ ERROR box expression syntax is experimental

--- a/src/test/ui/feature-gate-box_syntax.stderr
+++ b/src/test/ui/feature-gate-box_syntax.stderr
@@ -1,4 +1,4 @@
-error[E0658]: box expression syntax is experimental; you can call `Box::new` instead. (see issue #27779)
+error[E0658]: box expression syntax is experimental; you can call `Box::new` instead. (see issue #49733)
   --> $DIR/feature-gate-box_syntax.rs:14:13
    |
 LL |     let x = box 3;


### PR DESCRIPTION
The issue was used for both box syntax as well as placement new.
It got closed due to placement new being unapproved.
So a new one got created for box syntax, yet neither
the unstable book nor feature_gate.rs got updated.
We are doing this now.

r? @aidanhs