### PR TITLE
Add inner links in documentation

### DIFF
--- a/src/liballoc/fmt.rs
+++ b/src/liballoc/fmt.rs
@@ -340,7 +340,8 @@
 //!
 //! ## Fill/Alignment
 //!
-//! The fill character is provided normally in conjunction with the `width`
+//! The fill character is provided normally in conjunction with the
+//! [`width`](#width)
 //! parameter. This indicates that if the value being formatted is smaller than
 //! `width` some extra characters will be printed around it. The extra
 //! characters are specified by `fill`, and the alignment can be one of the
@@ -388,7 +389,8 @@
 //! padding specified by fill/alignment will be used to take up the required
 //! space.
 //!
-//! The default fill/alignment for non-numerics is a space and left-aligned. The
+//! The default [fill/alignment](#fillalignment) for non-numerics is a space and
+//! left-aligned. The
 //! defaults for numeric formatters is also a space but with right-alignment. If
 //! the `0` flag is specified for numerics, then the implicit fill character is
 //! `0`.


### PR DESCRIPTION
From [this SO question](https://stackoverflow.com/q/50518757/2733851) it looks like this page isn't really clear.
I personally do think this page is quite clear, the only think I could think of was adding some references.