### PR TITLE
parser: Split `+=` into `+` and `=` where `+` is explicitly requested (such as generics)

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -880,11 +880,11 @@ impl<'a> Parser<'a> {
             false
         }
     }
-    
+
     /// Expect and consume a `+`. if `+=` is seen, replace it with a `=`
     /// and continue. If a `+` is not seen, return false.
     ///
-    /// This is using when token splitting += into +. 
+    /// This is using when token splitting += into +.
     /// See issue 47856 for an example of when this may occur.
     fn eat_plus(&mut self) -> bool {
         self.expected_tokens.push(TokenType::Token(token::BinOp(token::Plus)));
@@ -901,8 +901,8 @@ impl<'a> Parser<'a> {
             _ => false,
         }
     }
-    
-    
+
+
     /// Checks to see if the next token is either `+` or `+=`.
     /// Otherwise returns false.
     fn check_plus(&mut self) -> bool {
@@ -1679,7 +1679,7 @@ impl<'a> Parser<'a> {
         let poly_trait_ref = PolyTraitRef::new(generic_params, path, lo.to(self.prev_span));
         let mut bounds = vec![TraitTyParamBound(poly_trait_ref, TraitBoundModifier::None)];
         if parse_plus {
-            self.eat_plus(); // `+` or `+=` gets split and `+` is discarded 
+            self.eat_plus(); // `+`, or `+=` gets split and `+` is discarded
             bounds.append(&mut self.parse_ty_param_bounds()?);
         }
         Ok(TyKind::TraitObject(bounds, TraitObjectSyntax::None))

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1546,7 +1546,7 @@ impl<'a> Parser<'a> {
 
             if ts.len() == 1 && !last_comma {
                 let ty = ts.into_iter().nth(0).unwrap().into_inner();
-                let maybe_bounds = allow_plus && self.check_plus();
+                let maybe_bounds = allow_plus && self.token.is_like_plus();
                 match ty.node {
                     // `(TY_BOUND_NOPAREN) + BOUND + ...`.
                     TyKind::Path(None, ref path) if maybe_bounds => {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -910,8 +910,8 @@ impl<'a> Parser<'a> {
             true
         }
         else {
-                self.expected_tokens.push(TokenType::Token(token::BinOp(token::Plus)));
-                false
+            self.expected_tokens.push(TokenType::Token(token::BinOp(token::Plus)));
+            false
         }
     }
 

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -224,7 +224,7 @@ impl Token {
             _ => false,
         }
     }
-    
+
     pub fn is_like_plus(&self) -> bool {
         match *self {
             BinOp(Plus) | BinOpEq(Plus) => true,

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -224,6 +224,13 @@ impl Token {
             _ => false,
         }
     }
+    
+    pub fn is_like_plus(&self) -> bool {
+        match *self {
+            BinOp(Plus) | BinOpEq(Plus) => true,
+            _ => false,
+        }
+    }
 
     /// Returns `true` if the token can appear at the start of an expression.
     pub fn can_begin_expr(&self) -> bool {

--- a/src/test/parse-fail/trait-plusequal-splitting.rs
+++ b/src/test/parse-fail/trait-plusequal-splitting.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z parse-only
+// Fixes issue where `+` in generics weren't parsed if they were part of a `+=`.
+
+struct Whitespace<T: Clone + = ()> { t: T }
+struct TokenSplit<T: Clone +=  ()> { t: T }
+
+fn main() {
+}
+
+FAIL //~ ERROR


### PR DESCRIPTION
Added functions in tokens to check whether a token leads with `+`. Used them when parsing to allow for token splitting of `+=` into `+` and `=`. 
Fixes https://github.com/rust-lang/rust/issues/47856