### PR TITLE
Rename TokenStream::empty to TokenStream::new

### DIFF
--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -93,7 +93,7 @@ impl !Sync for LexError {}
 impl TokenStream {
     /// Returns an empty `TokenStream` containing no token trees.
     #[unstable(feature = "proc_macro", issue = "38356")]
-    pub fn empty() -> TokenStream {
+    pub fn new() -> TokenStream {
         TokenStream(tokenstream::TokenStream::empty())
     }
 

--- a/src/libproc_macro/quote.rs
+++ b/src/libproc_macro/quote.rs
@@ -71,7 +71,7 @@ macro_rules! quote_tree {
 }
 
 macro_rules! quote {
-    () => { TokenStream::empty() };
+    () => { TokenStream::new() };
     ($($t:tt)*) => {
         [$(quote_tree!($t),)*].iter()
             .cloned()
@@ -104,7 +104,7 @@ impl<T: Quote> Quote for Option<T> {
 impl Quote for TokenStream {
     fn quote(self) -> TokenStream {
         if self.is_empty() {
-            return quote!(::TokenStream::empty());
+            return quote!(::TokenStream::new());
         }
         let mut after_dollar = false;
         let tokens = self.into_iter().filter_map(|tree| {

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/modify-ast.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/modify-ast.rs
@@ -26,7 +26,7 @@ pub fn assert1(_a: TokenStream, b: TokenStream) -> TokenStream {
 #[proc_macro_derive(Foo, attributes(foo))]
 pub fn assert2(a: TokenStream) -> TokenStream {
     assert_eq(a, "pub struct MyStructc { _a: i32, }".parse().unwrap());
-    TokenStream::empty()
+    TokenStream::new()
 }
 
 fn assert_eq(a: TokenStream, b: TokenStream) {

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/not-joint.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/not-joint.rs
@@ -20,13 +20,13 @@ use proc_macro::*;
 #[proc_macro]
 pub fn tokens(input: TokenStream) -> TokenStream {
     assert_nothing_joint(input);
-    TokenStream::empty()
+    TokenStream::new()
 }
 
 #[proc_macro_attribute]
 pub fn nothing(_: TokenStream, input: TokenStream) -> TokenStream {
     assert_nothing_joint(input);
-    TokenStream::empty()
+    TokenStream::new()
 }
 
 fn assert_nothing_joint(s: TokenStream) {

--- a/src/test/ui-fulldeps/proc-macro/auxiliary/three-equals.rs
+++ b/src/test/ui-fulldeps/proc-macro/auxiliary/three-equals.rs
@@ -50,7 +50,7 @@ fn parse(input: TokenStream) -> Result<(), Diagnostic> {
 pub fn three_equals(input: TokenStream) -> TokenStream {
     if let Err(diag) = parse(input) {
         diag.emit();
-        return TokenStream::empty();
+        return TokenStream::new();
     }
 
     "3".parse().unwrap()


### PR DESCRIPTION
There is no precedent for the `empty` name -- we do not have `Vec::empty` or `HashMap::empty` etc.

I would propose landing this but reflecting it in a non-breaking release of proc-macro2 that provides both `new` and a deprecated `empty` constructor.

Tracking issue: #38356

r? @alexcrichton 