### PR TITLE
Check for confusable Unicode chars in float literal exponent 

### DIFF
--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1081,10 +1081,12 @@ impl<'a> StringReader<'a> {
                 );
                 if let Some(ch) = self.ch {
                     // check for e.g. Unicode minus '−' (Issue #49746)
-                    unicode_chars::check_for_substitution(self, ch, &mut err);
+                    if unicode_chars::check_for_substitution(self, ch, &mut err) {
+                        self.bump();
+                        self.scan_digits(10, 10);
+                    }
                 }
                 err.emit();
-                FatalError.raise();
             }
         }
     }

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1075,9 +1075,16 @@ impl<'a> StringReader<'a> {
                 self.bump();
             }
             if self.scan_digits(10, 10) == 0 {
-                self.err_span_(self.pos,
-                               self.next_pos,
-                               "expected at least one digit in exponent")
+                let mut err = self.struct_span_fatal(
+                    self.pos, self.next_pos,
+                    "expected at least one digit in exponent"
+                );
+                if let Some(ch) = self.ch {
+                    // check for e.g. Unicode minus '−' (Issue #49746)
+                    unicode_chars::check_for_substitution(self, ch, &mut err);
+                }
+                err.emit();
+                FatalError.raise();
             }
         }
     }

--- a/src/libsyntax/parse/lexer/unicode_chars.rs
+++ b/src/libsyntax/parse/lexer/unicode_chars.rs
@@ -335,7 +335,7 @@ const ASCII_ARRAY: &'static [(char, &'static str)] = &[
 
 pub fn check_for_substitution<'a>(reader: &StringReader<'a>,
                                   ch: char,
-                                  err: &mut DiagnosticBuilder<'a>) {
+                                  err: &mut DiagnosticBuilder<'a>) -> bool {
     UNICODE_ARRAY
     .iter()
     .find(|&&(c, _, _)| c == ch)
@@ -347,11 +347,13 @@ pub fn check_for_substitution<'a>(reader: &StringReader<'a>,
                     format!("Unicode character '{}' ({}) looks like '{}' ({}), but it is not",
                             ch, u_name, ascii_char, ascii_name);
                 err.span_suggestion(span, &msg, ascii_char.to_string());
+                true
             },
             None => {
                 let msg = format!("substitution character not found for '{}'", ch);
                 reader.sess.span_diagnostic.span_bug_no_panic(span, &msg);
+                false
             }
         }
-    });
+    }).unwrap_or(false)
 }

--- a/src/libsyntax/parse/lexer/unicode_chars.rs
+++ b/src/libsyntax/parse/lexer/unicode_chars.rs
@@ -344,9 +344,9 @@ pub fn check_for_substitution<'a>(reader: &StringReader<'a>,
         match ASCII_ARRAY.iter().find(|&&(c, _)| c == ascii_char) {
             Some(&(ascii_char, ascii_name)) => {
                 let msg =
-                    format!("unicode character '{}' ({}) looks like '{}' ({}), but it's not",
+                    format!("Unicode character '{}' ({}) looks like '{}' ({}), but it is not",
                             ch, u_name, ascii_char, ascii_name);
-                err.span_help(span, &msg);
+                err.span_suggestion(span, &msg, ascii_char.to_string());
             },
             None => {
                 let msg = format!("substitution character not found for '{}'", ch);

--- a/src/test/parse-fail/unicode-chars.rs
+++ b/src/test/parse-fail/unicode-chars.rs
@@ -13,5 +13,5 @@
 fn main() {
     let y = 0;
     //~^ ERROR unknown start of token: \u{37e}
-    //~^^ HELP unicode character ';' (Greek Question Mark) looks like ';' (Semicolon), but it's not
+    //~^^ HELP Unicode character ';' (Greek Question Mark) looks like ';' (Semicolon), but it is not
 }

--- a/src/test/ui/did_you_mean/issue-49746-unicode-confusable-in-float-literal-expt.rs
+++ b/src/test/ui/did_you_mean/issue-49746-unicode-confusable-in-float-literal-expt.rs
@@ -1,0 +1,14 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const UNIVERSAL_GRAVITATIONAL_CONSTANT = 6.674e−11; // m³⋅kg⁻¹⋅s⁻²
+//~^ ERROR expected at least one digit in exponent
+
+fn main() {}

--- a/src/test/ui/did_you_mean/issue-49746-unicode-confusable-in-float-literal-expt.rs
+++ b/src/test/ui/did_you_mean/issue-49746-unicode-confusable-in-float-literal-expt.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-const UNIVERSAL_GRAVITATIONAL_CONSTANT = 6.674e−11; // m³⋅kg⁻¹⋅s⁻²
+const UNIVERSAL_GRAVITATIONAL_CONSTANT: f64 = 6.674e−11; // m³⋅kg⁻¹⋅s⁻²
 //~^ ERROR expected at least one digit in exponent
 
 fn main() {}

--- a/src/test/ui/did_you_mean/issue-49746-unicode-confusable-in-float-literal-expt.stderr
+++ b/src/test/ui/did_you_mean/issue-49746-unicode-confusable-in-float-literal-expt.stderr
@@ -1,12 +1,12 @@
 error: expected at least one digit in exponent
-  --> $DIR/issue-49746-unicode-confusable-in-float-literal-expt.rs:11:48
+  --> $DIR/issue-49746-unicode-confusable-in-float-literal-expt.rs:11:53
    |
-LL | const UNIVERSAL_GRAVITATIONAL_CONSTANT = 6.674e−11; // m³⋅kg⁻¹⋅s⁻²
-   |                                                ^
+LL | const UNIVERSAL_GRAVITATIONAL_CONSTANT: f64 = 6.674e−11; // m³⋅kg⁻¹⋅s⁻²
+   |                                                     ^
 help: Unicode character '−' (Minus Sign) looks like '-' (Minus/Hyphen), but it is not
    |
-LL | const UNIVERSAL_GRAVITATIONAL_CONSTANT = 6.674e-11; // m³⋅kg⁻¹⋅s⁻²
-   |                                                ^
+LL | const UNIVERSAL_GRAVITATIONAL_CONSTANT: f64 = 6.674e-11; // m³⋅kg⁻¹⋅s⁻²
+   |                                                     ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/issue-49746-unicode-confusable-in-float-literal-expt.stderr
+++ b/src/test/ui/did_you_mean/issue-49746-unicode-confusable-in-float-literal-expt.stderr
@@ -1,0 +1,12 @@
+error: expected at least one digit in exponent
+  --> $DIR/issue-49746-unicode-confusable-in-float-literal-expt.rs:11:48
+   |
+LL | const UNIVERSAL_GRAVITATIONAL_CONSTANT = 6.674e−11; // m³⋅kg⁻¹⋅s⁻²
+   |                                                ^
+help: Unicode character '−' (Minus Sign) looks like '-' (Minus/Hyphen), but it is not
+   |
+LL | const UNIVERSAL_GRAVITATIONAL_CONSTANT = 6.674e-11; // m³⋅kg⁻¹⋅s⁻²
+   |                                                ^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixing tests for #49989. Resolves #49746.