### PR TITLE
Ensure every unstable language feature has a tracking issue.

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -235,7 +235,7 @@ declare_features! (
     (active, platform_intrinsics, "1.4.0", Some(27731), None),
 
     // allow `#[unwind(..)]`
-    // rust runtime internal
+    // rustc internal for rust runtime
     (active, unwind_attributes, "1.4.0", None, None),
 
     // allow the use of `#[naked]` on functions.
@@ -276,7 +276,7 @@ declare_features! (
     (active, never_type, "1.13.0", Some(35121), None),
 
     // Allows exhaustive pattern matching on types that contain uninhabited types.
-    (active, exhaustive_patterns, "1.13.0", None, None),
+    (active, exhaustive_patterns, "1.13.0", Some(51085), None),
 
     // Allows all literals in attribute lists and values of key-value pairs.
     (active, attr_literals, "1.13.0", Some(34981), None),
@@ -294,12 +294,13 @@ declare_features! (
     (active, use_extern_macros, "1.15.0", Some(35896), None),
 
     // `extern "ptx-*" fn()`
-    (active, abi_ptx, "1.15.0", None, None),
+    (active, abi_ptx, "1.15.0", Some(38788), None),
 
     // The `repr(i128)` annotation for enums
     (active, repr128, "1.16.0", Some(35118), None),
 
     // The `unadjusted` ABI. Perma unstable.
+    // rustc internal
     (active, abi_unadjusted, "1.16.0", None, None),
 
     // Procedural macros 2.0.
@@ -351,13 +352,14 @@ declare_features! (
     (active, unsized_tuple_coercion, "1.20.0", Some(42877), None),
 
     // Generators
-    (active, generators, "1.21.0", None, None),
+    (active, generators, "1.21.0", Some(43122), None),
 
     // Trait aliases
     (active, trait_alias, "1.24.0", Some(41517), None),
 
     // global allocators and their internals
-    (active, global_allocator, "1.20.0", None, None),
+    (active, global_allocator, "1.20.0", Some(27389), None),
+    // rustc internal
     (active, allocator_internals, "1.20.0", None, None),
 
     // #[doc(cfg(...))]
@@ -415,7 +417,7 @@ declare_features! (
     (active, if_while_or_patterns, "1.26.0", Some(48215), None),
 
     // Parentheses in patterns
-    (active, pattern_parentheses, "1.26.0", None, None),
+    (active, pattern_parentheses, "1.26.0", Some(51087), None),
 
     // Allows `#[repr(packed)]` attribute on structs
     (active, repr_packed, "1.26.0", Some(33158), None),
@@ -424,10 +426,10 @@ declare_features! (
     (active, underscore_imports, "1.26.0", Some(48216), None),
 
     // The #[wasm_custom_section] attribute
-    (active, wasm_custom_section, "1.26.0", None, None),
+    (active, wasm_custom_section, "1.26.0", Some(51088), None),
 
     // The #![wasm_import_module] attribute
-    (active, wasm_import_module, "1.26.0", None, None),
+    (active, wasm_import_module, "1.26.0", Some(51088), None),
 
     // Allows keywords to be escaped for use as identifiers
     (active, raw_identifiers, "1.26.0", Some(48589), None),
@@ -436,25 +438,25 @@ declare_features! (
     (active, macros_in_extern, "1.27.0", Some(49476), None),
 
     // unstable #[target_feature] directives
-    (active, arm_target_feature, "1.27.0", None, None),
-    (active, aarch64_target_feature, "1.27.0", None, None),
-    (active, hexagon_target_feature, "1.27.0", None, None),
-    (active, powerpc_target_feature, "1.27.0", None, None),
-    (active, mips_target_feature, "1.27.0", None, None),
-    (active, avx512_target_feature, "1.27.0", None, None),
-    (active, mmx_target_feature, "1.27.0", None, None),
-    (active, sse4a_target_feature, "1.27.0", None, None),
-    (active, tbm_target_feature, "1.27.0", None, None),
+    (active, arm_target_feature, "1.27.0", Some(44839), None),
+    (active, aarch64_target_feature, "1.27.0", Some(44839), None),
+    (active, hexagon_target_feature, "1.27.0", Some(44839), None),
+    (active, powerpc_target_feature, "1.27.0", Some(44839), None),
+    (active, mips_target_feature, "1.27.0", Some(44839), None),
+    (active, avx512_target_feature, "1.27.0", Some(44839), None),
+    (active, mmx_target_feature, "1.27.0", Some(44839), None),
+    (active, sse4a_target_feature, "1.27.0", Some(44839), None),
+    (active, tbm_target_feature, "1.27.0", Some(44839), None),
 
     // Allows macro invocations of the form `#[foo::bar]`
-    (active, proc_macro_path_invoc, "1.27.0", None, None),
+    (active, proc_macro_path_invoc, "1.27.0", Some(38356), None),
 
     // Allows macro invocations on modules expressions and statements and
     // procedural macros to expand to non-items.
-    (active, proc_macro_mod, "1.27.0", None, None),
-    (active, proc_macro_expr, "1.27.0", None, None),
-    (active, proc_macro_non_items, "1.27.0", None, None),
-    (active, proc_macro_gen, "1.27.0", None, None),
+    (active, proc_macro_mod, "1.27.0", Some(38356), None),
+    (active, proc_macro_expr, "1.27.0", Some(38356), None),
+    (active, proc_macro_non_items, "1.27.0", Some(38356), None),
+    (active, proc_macro_gen, "1.27.0", Some(38356), None),
 
     // #[doc(alias = "...")]
     (active, doc_alias, "1.27.0", Some(50146), None),

--- a/src/test/ui/feature-gate-abi.stderr
+++ b/src/test/ui/feature-gate-abi.stderr
@@ -38,7 +38,7 @@ LL | extern "msp430-interrupt" fn f5() {} //~ ERROR msp430-interrupt ABI is expe
    |
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
-error[E0658]: PTX ABIs are experimental and subject to change
+error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
   --> $DIR/feature-gate-abi.rs:24:1
    |
 LL | extern "ptx-kernel" fn f6() {} //~ ERROR PTX ABIs are experimental and subject to change
@@ -102,7 +102,7 @@ LL |     extern "msp430-interrupt" fn m5(); //~ ERROR msp430-interrupt ABI is ex
    |
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
-error[E0658]: PTX ABIs are experimental and subject to change
+error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
   --> $DIR/feature-gate-abi.rs:35:5
    |
 LL |     extern "ptx-kernel" fn m6(); //~ ERROR PTX ABIs are experimental and subject to change
@@ -166,7 +166,7 @@ LL |     extern "msp430-interrupt" fn dm5() {} //~ ERROR msp430-interrupt ABI is
    |
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
-error[E0658]: PTX ABIs are experimental and subject to change
+error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
   --> $DIR/feature-gate-abi.rs:44:5
    |
 LL |     extern "ptx-kernel" fn dm6() {} //~ ERROR PTX ABIs are experimental and subject to change
@@ -230,7 +230,7 @@ LL |     extern "msp430-interrupt" fn m5() {} //~ ERROR msp430-interrupt ABI is 
    |
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
-error[E0658]: PTX ABIs are experimental and subject to change
+error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
   --> $DIR/feature-gate-abi.rs:58:5
    |
 LL |     extern "ptx-kernel" fn m6() {} //~ ERROR PTX ABIs are experimental and subject to change
@@ -294,7 +294,7 @@ LL |     extern "msp430-interrupt" fn im5() {} //~ ERROR msp430-interrupt ABI is
    |
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
-error[E0658]: PTX ABIs are experimental and subject to change
+error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
   --> $DIR/feature-gate-abi.rs:70:5
    |
 LL |     extern "ptx-kernel" fn im6() {} //~ ERROR PTX ABIs are experimental and subject to change
@@ -358,7 +358,7 @@ LL | type A5 = extern "msp430-interrupt" fn(); //~ ERROR msp430-interrupt ABI is
    |
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
-error[E0658]: PTX ABIs are experimental and subject to change
+error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
   --> $DIR/feature-gate-abi.rs:81:11
    |
 LL | type A6 = extern "ptx-kernel" fn (); //~ ERROR PTX ABIs are experimental and subject to change
@@ -422,7 +422,7 @@ LL | extern "msp430-interrupt" {} //~ ERROR msp430-interrupt ABI is experimental
    |
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
-error[E0658]: PTX ABIs are experimental and subject to change
+error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
   --> $DIR/feature-gate-abi.rs:91:1
    |
 LL | extern "ptx-kernel" {} //~ ERROR PTX ABIs are experimental and subject to change

--- a/src/test/ui/feature-gate-generators.stderr
+++ b/src/test/ui/feature-gate-generators.stderr
@@ -1,4 +1,4 @@
-error[E0658]: yield syntax is experimental
+error[E0658]: yield syntax is experimental (see issue #43122)
   --> $DIR/feature-gate-generators.rs:12:5
    |
 LL |     yield true; //~ ERROR yield syntax is experimental

--- a/src/test/ui/feature-gate-global_allocator.stderr
+++ b/src/test/ui/feature-gate-global_allocator.stderr
@@ -1,4 +1,4 @@
-error[E0658]: the `#[global_allocator]` attribute is an experimental feature
+error[E0658]: the `#[global_allocator]` attribute is an experimental feature (see issue #27389)
   --> $DIR/feature-gate-global_allocator.rs:11:1
    |
 LL | #[global_allocator] //~ ERROR: attribute is an experimental feature

--- a/src/test/ui/feature-gate-pattern_parentheses.stderr
+++ b/src/test/ui/feature-gate-pattern_parentheses.stderr
@@ -1,4 +1,4 @@
-error[E0658]: parentheses in patterns are unstable
+error[E0658]: parentheses in patterns are unstable (see issue #51087)
   --> $DIR/feature-gate-pattern_parentheses.rs:13:9
    |
 LL |         (pat) => {} //~ ERROR parentheses in patterns are unstable

--- a/src/test/ui/feature-gate-wasm_custom_section.stderr
+++ b/src/test/ui/feature-gate-wasm_custom_section.stderr
@@ -1,4 +1,4 @@
-error[E0658]: attribute is currently unstable
+error[E0658]: attribute is currently unstable (see issue #51088)
   --> $DIR/feature-gate-wasm_custom_section.rs:11:1
    |
 LL | #[wasm_custom_section = "foo"] //~ ERROR: attribute is currently unstable

--- a/src/test/ui/feature-gate-wasm_import_module.stderr
+++ b/src/test/ui/feature-gate-wasm_import_module.stderr
@@ -1,4 +1,4 @@
-error[E0658]: experimental attribute
+error[E0658]: experimental attribute (see issue #51088)
   --> $DIR/feature-gate-wasm_import_module.rs:11:1
    |
 LL | #[wasm_import_module = "test"] //~ ERROR: experimental

--- a/src/test/ui/target-feature-gate.stderr
+++ b/src/test/ui/target-feature-gate.stderr
@@ -1,4 +1,4 @@
-error[E0658]: the target feature `avx512bw` is currently unstable
+error[E0658]: the target feature `avx512bw` is currently unstable (see issue #44839)
   --> $DIR/target-feature-gate.rs:26:18
    |
 LL | #[target_feature(enable = "avx512bw")]

--- a/src/tools/tidy/src/unstable_book.rs
+++ b/src/tools/tidy/src/unstable_book.rs
@@ -86,7 +86,7 @@ pub fn check(path: &path::Path, bad: &mut bool) {
 
     // Library features
 
-    let lang_features = collect_lang_features(path);
+    let lang_features = collect_lang_features(path, bad);
     let lib_features = collect_lib_features(path).into_iter().filter(|&(ref name, _)| {
         !lang_features.contains_key(name)
     }).collect();

--- a/src/tools/unstable-book-gen/src/main.rs
+++ b/src/tools/unstable-book-gen/src/main.rs
@@ -131,7 +131,7 @@ fn main() {
     let src_path = Path::new(&src_path_str);
     let dest_path = Path::new(&dest_path_str).join("src");
 
-    let lang_features = collect_lang_features(src_path);
+    let lang_features = collect_lang_features(src_path, &mut false);
     let lib_features = collect_lib_features(src_path).into_iter().filter(|&(ref name, _)| {
         !lang_features.contains_key(name)
     }).collect();


### PR DESCRIPTION
Filled in the missing numbers:

* `abi_ptx` → #38788
* `generators` → #43122
* `global_allocator` → #27389

Reused existing tracking issues because they were decomposed from a larger feature

* `*_target_feature` → #44839 (reusing the old `target_feature` number)
* `proc_macros_*` → #38356 (reusing the to-be-stabilized `proc_macros` number)

Filed new issues

* `exhaustive_patterns` → #51085
* `pattern_parentheses` → #51087
* `wasm_custom_section` and `wasm_import_module` → #51088 

