### PR TITLE
suggest semicolon on double-call that doesn't typecheck as callable

### DIFF
--- a/src/test/ui/block-result/issue-20862.stderr
+++ b/src/test/ui/block-result/issue-20862.stderr
@@ -13,7 +13,9 @@ error[E0618]: expected function, found `()`
   --> $DIR/issue-20862.rs:17:13
    |
 LL |     let x = foo(5)(2);
-   |             ^^^^^^^^^ not a function
+   |             ^^^^^^-^^
+   |                   |
+   |                   help: try adding a semicolon: `;`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/suggestions/issue-51055-missing-semicolon-between-call-and-tuple.rs
+++ b/src/test/ui/suggestions/issue-51055-missing-semicolon-between-call-and-tuple.rs
@@ -1,0 +1,18 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn vindictive() -> bool { true }
+
+fn perfidy() -> (i32, i32) {
+    vindictive() //~ ERROR expected function, found `bool`
+    (1, 2)
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/issue-51055-missing-semicolon-between-call-and-tuple.stderr
+++ b/src/test/ui/suggestions/issue-51055-missing-semicolon-between-call-and-tuple.stderr
@@ -1,0 +1,13 @@
+error[E0618]: expected function, found `bool`
+  --> $DIR/issue-51055-missing-semicolon-between-call-and-tuple.rs:14:5
+   |
+LL |       vindictive() //~ ERROR expected function, found `bool`
+   |       ^           - help: try adding a semicolon: `;`
+   |  _____|
+   | |
+LL | |     (1, 2)
+   | |__________^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0618`.


### PR DESCRIPTION
This provides the desired suggestion for #51055.

The suggestion in changed UI test output for [test/ui/block-result/issue-20862](https://github.com/rust-lang/rust/blob/5015fa346c1bf7e295fc16996ed0d3309c84f09a/src/test/ui/block-result/issue-20862.rs) doesn't actually solve that test file's problems, but you can at least see how it's a plausible guess, and arguably less confusing than the "not a function" label in that context.

r? @estebank 