### PR TITLE
Add expected closing delimiter to diagnostic

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -651,7 +651,7 @@ impl<'a> Parser<'a> {
                 Err(err)
             }
         } else {
-            self.expect_one_of(unsafe { slice::from_raw_parts(t, 1) }, &[])
+            self.expect_one_of(slice::from_ref(t), &[])
         }
     }
 
@@ -1107,7 +1107,12 @@ impl<'a> Parser<'a> {
     {
         let mut first: bool = true;
         let mut v = vec![];
-        while !kets.contains(&&self.token) {
+        while !kets.iter().any(|k| {
+                match expect {
+                    TokenExpectType::Expect => self.check(k),
+                    TokenExpectType::NoExpect => self.token == **k,
+                }
+            }) {
             match self.token {
                 token::CloseDelim(..) | token::Eof => break,
                 _ => {}

--- a/src/test/compile-fail/issue-39616.rs
+++ b/src/test/compile-fail/issue-39616.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 fn foo(a: [0; 1]) {} //~ ERROR expected type, found `0`
-//~| ERROR expected one of `)`, `->`, `where`, or `{`, found `]`
+//~| ERROR expected one of `)`, `,`, `->`, `where`, or `{`, found `]`
 // FIXME(jseyfried): avoid emitting the second error (preexisting)
 
 fn main() {}

--- a/src/test/compile-fail/issue-39616.rs
+++ b/src/test/compile-fail/issue-39616.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 fn foo(a: [0; 1]) {} //~ ERROR expected type, found `0`
-//~| ERROR expected one of `->`, `where`, or `{`, found `]`
+//~| ERROR expected one of `)`, `->`, `where`, or `{`, found `]`
 // FIXME(jseyfried): avoid emitting the second error (preexisting)
 
 fn main() {}

--- a/src/test/ui/resolve/token-error-correct-3.stderr
+++ b/src/test/ui/resolve/token-error-correct-3.stderr
@@ -10,11 +10,11 @@ note: unclosed delimiter
 LL |             callback(path.as_ref(); //~ ERROR expected one of
    |                     ^
 
-error: expected one of `,`, `.`, `?`, or an operator, found `;`
+error: expected one of `)`, `,`, `.`, `?`, or an operator, found `;`
   --> $DIR/token-error-correct-3.rs:24:35
    |
 LL |             callback(path.as_ref(); //~ ERROR expected one of
-   |                                   ^ expected one of `,`, `.`, `?`, or an operator here
+   |                                   ^ expected one of `)`, `,`, `.`, `?`, or an operator here
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `)`
   --> $DIR/token-error-correct-3.rs:30:9

--- a/src/test/ui/similar-tokens.rs
+++ b/src/test/ui/similar-tokens.rs
@@ -14,6 +14,6 @@ mod x {
 }
 
 // `.` is similar to `,` so list parsing should continue to closing `}`
-use x::{A. B}; //~ ERROR expected one of `,`, `::`, or `as`, found `.`
+use x::{A. B}; //~ ERROR expected one of `,`, `::`, `as`, or `}`, found `.`
 
 fn main() {}

--- a/src/test/ui/similar-tokens.stderr
+++ b/src/test/ui/similar-tokens.stderr
@@ -1,4 +1,4 @@
-error: expected one of `,`, `::`, or `as`, found `.`
+error: expected one of `,`, `::`, `as`, or `}`, found `.`
   --> $DIR/similar-tokens.rs:17:10
    |
 LL | use x::{A. B}; //~ ERROR expected one of `,`, `::`, `as`, or `}`, found `.`

--- a/src/test/ui/similar-tokens.stderr
+++ b/src/test/ui/similar-tokens.stderr
@@ -1,8 +1,8 @@
 error: expected one of `,`, `::`, or `as`, found `.`
   --> $DIR/similar-tokens.rs:17:10
    |
-LL | use x::{A. B}; //~ ERROR expected one of `,`, `::`, or `as`, found `.`
-   |          ^ expected one of `,`, `::`, or `as` here
+LL | use x::{A. B}; //~ ERROR expected one of `,`, `::`, `as`, or `}`, found `.`
+   |          ^ expected one of `,`, `::`, `as`, or `}` here
 
 error: aborting due to previous error
 

--- a/src/test/ui/token/issue-10636-2.stderr
+++ b/src/test/ui/token/issue-10636-2.stderr
@@ -10,11 +10,11 @@ note: unclosed delimiter
 LL |     option.map(|some| 42;
    |               ^
 
-error: expected one of `,`, `.`, `?`, or an operator, found `;`
+error: expected one of `)`, `,`, `.`, `?`, or an operator, found `;`
   --> $DIR/issue-10636-2.rs:15:25
    |
 LL |     option.map(|some| 42;
-   |                         ^ expected one of `,`, `.`, `?`, or an operator here
+   |                         ^ expected one of `)`, `,`, `.`, `?`, or an operator here
 
 error: expected expression, found `)`
   --> $DIR/issue-10636-2.rs:18:1

--- a/src/test/ui/tuple-struct-fields/test.rs
+++ b/src/test/ui/tuple-struct-fields/test.rs
@@ -12,6 +12,6 @@ mod foo {
     type T = ();
     struct S1(pub(in foo) (), pub(T), pub(crate) (), pub(((), T)));
     struct S2(pub((foo)) ());
-    //~^ ERROR expected `,`, found `(`
+    //~^ ERROR expected one of `)` or `,`, found `(`
     //~| ERROR cannot find type `foo` in this scope
 }

--- a/src/test/ui/tuple-struct-fields/test.stderr
+++ b/src/test/ui/tuple-struct-fields/test.stderr
@@ -1,0 +1,20 @@
+error: expected one of `)` or `,`, found `(`
+  --> $DIR/test.rs:14:26
+   |
+LL |     struct S2(pub((foo)) ());
+   |                          ^ expected one of `)` or `,` here
+
+error[E0412]: cannot find type `foo` in this scope
+  --> $DIR/test.rs:14:20
+   |
+LL |     struct S2(pub((foo)) ());
+   |                    ^^^ not found in this scope
+
+error[E0601]: `main` function not found in crate `test`
+   |
+   = note: consider adding a `main` function to `$DIR/test.rs`
+
+error: aborting due to 3 previous errors
+
+Some errors occurred: E0412, E0601.
+For more information about an error, try `rustc --explain E0412`.

--- a/src/test/ui/tuple-struct-fields/test2.rs
+++ b/src/test/ui/tuple-struct-fields/test2.rs
@@ -13,7 +13,7 @@ macro_rules! define_struct {
         struct S1(pub $t);
         struct S2(pub (in foo) ());
         struct S3(pub $t ());
-        //~^ ERROR expected `,`, found `(`
+        //~^ ERROR expected one of `)` or `,`, found `(`
     }
 }
 

--- a/src/test/ui/tuple-struct-fields/test2.stderr
+++ b/src/test/ui/tuple-struct-fields/test2.stderr
@@ -1,0 +1,11 @@
+error: expected one of `)` or `,`, found `(`
+  --> $DIR/test2.rs:15:26
+   |
+LL |         struct S3(pub $t ());
+   |                          ^ expected one of `)` or `,` here
+...
+LL |     define_struct! { (foo) }
+   |     ------------------------ in this macro invocation
+
+error: aborting due to previous error
+

--- a/src/test/ui/tuple-struct-fields/test3.rs
+++ b/src/test/ui/tuple-struct-fields/test3.rs
@@ -13,7 +13,7 @@ macro_rules! define_struct {
         struct S1(pub($t));
         struct S2(pub (in foo) ());
         struct S3(pub($t) ());
-        //~^ ERROR expected `,`, found `(`
+        //~^ ERROR expected one of `)` or `,`, found `(`
     }
 }
 

--- a/src/test/ui/tuple-struct-fields/test3.stderr
+++ b/src/test/ui/tuple-struct-fields/test3.stderr
@@ -1,0 +1,11 @@
+error: expected one of `)` or `,`, found `(`
+  --> $DIR/test3.rs:15:27
+   |
+LL |         struct S3(pub($t) ());
+   |                           ^ expected one of `)` or `,` here
+...
+LL |     define_struct! { foo }
+   |     ---------------------- in this macro invocation
+
+error: aborting due to previous error
+


### PR DESCRIPTION
When looking through for a closing bracket in the loop condition, adds them to expecteds.

Fix #38777.