### PR TITLE
Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Read ["Installation"] from [The Book].
 3. Build and install:
 
     ```sh
+    $ git submodule update --init --recursive --progress
     $ ./x.py build && sudo ./x.py install
     ```
 


### PR DESCRIPTION
It get stuck at the cloning step. 
`./x.py build `   
Updating only changed submodules
Updating submodule src/llvm
Submodule 'src/llvm' (https://github.com/rust-lang/llvm.git) registered for path 'src/llvm'
Cloning into '/home/username/rust/src/llvm'...
