### PR TITLE
Reword {ptr,mem}::replace docs.

### DIFF
--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -635,8 +635,9 @@ pub fn swap<T>(x: &mut T, y: &mut T) {
     }
 }
 
-/// Replaces the value at a mutable location with a new one, returning the old value, without
-/// deinitializing either one.
+/// Moves `src` into the referenced `dest`, returning the previous `dest` value.
+///
+/// Neither value is dropped.
 ///
 /// # Examples
 ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -239,8 +239,9 @@ unsafe fn swap_nonoverlapping_bytes(x: *mut u8, y: *mut u8, len: usize) {
     }
 }
 
-/// Replaces the value at `dest` with `src`, returning the old
-/// value, without dropping either.
+/// Moves `src` into the pointed `dest`, returning the previous `dest` value.
+///
+/// Neither value is dropped.
 ///
 /// # Safety
 ///


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/50657.