### PR TITLE
Implement Unsized Rvalues

### DIFF
--- a/src/doc/unstable-book/src/language-features/unsized-locals.md
+++ b/src/doc/unstable-book/src/language-features/unsized-locals.md
@@ -178,22 +178,3 @@ fn main() {
 ```
 
 will unnecessarily extend the stack frame.
-
-Allocation will be improved in the future, but there are still examples that are difficult to optimize:
-
-```rust
-#![feature(unsized_locals)]
-
-fn main() {
-    let mut counter = 10;
-    let x = loop {
-        let x: Box<[i32]> = Box::new([1, 2, 3, 4, 5]);
-        let x = *x;
-        if counter > 0 {
-            counter -= 1;
-        } else {
-            break x;
-        }
-    };
-}
-```

--- a/src/doc/unstable-book/src/language-features/unsized-locals.md
+++ b/src/doc/unstable-book/src/language-features/unsized-locals.md
@@ -1,0 +1,199 @@
+# `unsized_locals`
+
+The tracking issue for this feature is: [#48055]
+
+[#48055]: https://github.com/rust-lang/rust/issues/48055
+
+------------------------
+
+This implements [RFC1909]. When turned on, you can have unsized arguments and locals:
+
+[RFC1909]: https://github.com/rust-lang/rfcs/blob/master/text/1909-coercions.md
+
+```rust
+#![feature(unsized_locals)]
+
+use std::any::Any;
+
+fn main() {
+    let x: Box<dyn Any> = Box::new(42);
+    let x: dyn Any = *x;
+    //  ^ unsized local variable
+    //               ^^ unsized temporary
+    foo(x);
+}
+
+fn foo(_: dyn Any) {}
+//     ^^^^^^ unsized argument
+```
+
+The RFC still forbids the following unsized expressions:
+
+```rust,ignore
+#![feature(unsized_locals)]
+
+use std::any::Any;
+
+struct MyStruct<T: ?Sized> {
+    content: T,
+}
+
+struct MyTupleStruct<T: ?Sized>(T);
+
+fn answer() -> Box<dyn Any> {
+    Box::new(42)
+}
+
+fn main() {
+    // You CANNOT have unsized statics.
+    static X: dyn Any = *answer();  // ERROR
+    const Y: dyn Any = *answer();  // ERROR
+
+    // You CANNOT have struct initialized unsized.
+    MyStruct { content: *answer() };  // ERROR
+    MyTupleStruct(*answer());  // ERROR
+    (42, *answer());  // ERROR
+
+    // You CANNOT have unsized return types.
+    fn my_function() -> dyn Any { *answer() }  // ERROR
+
+    // You CAN have unsized local variables...
+    let mut x: dyn Any = *answer();  // OK
+    // ...but you CANNOT reassign to them.
+    x = *answer();  // ERROR
+
+    // You CANNOT even initialize them separately.
+    let y: dyn Any;  // OK
+    y = *answer();  // ERROR
+
+    // Not mentioned in the RFC, but by-move captured variables are also Sized.
+    let x: dyn Any = *answer();
+    (move || {  // ERROR
+        let y = x;
+    })();
+
+    // You CAN create a closure with unsized arguments,
+    // but you CANNOT call it.
+    // This is an implementation detail and may be changed in the future.
+    let f = |x: dyn Any| {};
+    f(*answer());  // ERROR
+}
+```
+
+However, the current implementation allows `MyTupleStruct(..)` to be unsized. This will be fixed in the future.
+
+## By-value trait objects
+
+With this feature, you can have by-value `self` arguments without `Self: Sized` bounds.
+
+```rust
+#![feature(unsized_locals)]
+
+trait Foo {
+    fn foo(self) {}
+}
+
+impl<T: ?Sized> Foo for T {}
+
+fn main() {
+    let slice: Box<[i32]> = Box::new([1, 2, 3]);
+    <[i32] as Foo>::foo(*slice);
+}
+```
+
+And `Foo` will also be object-safe. However, this object-safety is not yet implemented.
+
+```rust,ignore
+#![feature(unsized_locals)]
+
+trait Foo {
+    fn foo(self) {}
+}
+
+impl<T: ?Sized> Foo for T {}
+
+fn main () {
+    let slice: Box<dyn Foo> = Box::new([1, 2, 3]);
+    // doesn't compile yet
+    <dyn Foo as Foo>::foo(*slice);
+}
+```
+
+Unfortunately, this is not implemented yet.
+
+One of the objectives of this feature is to allow `Box<dyn FnOnce>`, instead of `Box<dyn FnBox>` in the future. See [#28796] for details.
+
+[#28796]: https://github.com/rust-lang/rust/issues/28796
+
+## Variable length arrays
+
+The RFC also describes an extension to the array literal syntax `[e; n]`: you'll be able to specify non-const `n` to allocate variable length arrays on the stack.
+
+```rust,ignore
+#![feature(unsized_locals)]
+
+fn mergesort<T: Ord>(a: &mut [T]) {
+    let mut tmp = [T; a.len()];
+    // ...
+}
+
+fn main() {
+    let mut a = [3, 1, 5, 6];
+    mergesort(&mut a);
+    assert_eq!(a, [1, 3, 5, 6]);
+}
+```
+
+VLAs are not implemented yet.
+
+## Advisory on stack usage
+
+It's advised not to casually use the `#![feature(unsized_locals)]` feature. Typical use-cases are:
+
+- When you need a by-value trait objects.
+- When you really need a fast allocation of small temporary arrays.
+
+Another pitfall is repetitive allocation and temporaries. Currently the compiler simply extends the stack frame every time it encounters an unsized assignment. So for example, the code
+
+```rust
+#![feature(unsized_locals)]
+
+fn main() {
+    let x: Box<[i32]> = Box::new([1, 2, 3, 4, 5]);
+    let _x = {{{{{{{{{{*x}}}}}}}}}};
+}
+```
+
+and the code
+
+```rust
+#![feature(unsized_locals)]
+
+fn main() {
+    for _ in 0..10 {
+        let x: Box<[i32]> = Box::new([1, 2, 3, 4, 5]);
+        let _x = *x;
+    }
+}
+```
+
+will unnecessarily extend the stack frame.
+
+Allocation will be improved in the future, but there are still examples that are difficult to optimize:
+
+```rust
+#![feature(unsized_locals)]
+
+fn main() {
+    let mut counter = 10;
+    let x = loop {
+        let x: Box<[i32]> = Box::new([1, 2, 3, 4, 5]);
+        let x = *x;
+        if counter > 0 {
+            counter -= 1;
+        } else {
+            break x;
+        }
+    };
+}
+```

--- a/src/doc/unstable-book/src/language-features/unsized-locals.md
+++ b/src/doc/unstable-book/src/language-features/unsized-locals.md
@@ -127,13 +127,13 @@ One of the objectives of this feature is to allow `Box<dyn FnOnce>`, instead of 
 
 ## Variable length arrays
 
-The RFC also describes an extension to the array literal syntax `[e; n]`: you'll be able to specify non-const `n` to allocate variable length arrays on the stack.
+The RFC also describes an extension to the array literal syntax: `[e; dyn n]`. In the syntax, `n` isn't necessarily a constant expression. The array is dynamically allocated on the stack and has the type of `[T]`, instead of `[T; n]`.
 
 ```rust,ignore
 #![feature(unsized_locals)]
 
 fn mergesort<T: Ord>(a: &mut [T]) {
-    let mut tmp = [T; a.len()];
+    let mut tmp = [T; dyn a.len()];
     // ...
 }
 
@@ -144,7 +144,7 @@ fn main() {
 }
 ```
 
-VLAs are not implemented yet.
+VLAs are not implemented yet. The syntax isn't final, either. We may need an alternative syntax for Rust 2015 because, in Rust 2015, expressions like `[e; dyn(1)]` would be ambiguous. One possible alternative proposed in the RFC is `[e; n]`: if `n` captures one or more local variables, then it is considered as `[e; dyn n]`.
 
 ## Advisory on stack usage
 

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -1455,6 +1455,9 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             ObligationCauseCode::VariableType(_) => {
                 err.note("all local variables must have a statically known size");
             }
+            ObligationCauseCode::SizedArgumentType => {
+                err.note("all function arguments must have a statically known size");
+            }
             ObligationCauseCode::SizedReturnType => {
                 err.note("the return type of a function must have a \
                           statically known size");

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -1454,9 +1454,15 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             }
             ObligationCauseCode::VariableType(_) => {
                 err.note("all local variables must have a statically known size");
+                if !self.tcx.features().unsized_locals {
+                    err.help("unsized locals are gated as an unstable feature");
+                }
             }
             ObligationCauseCode::SizedArgumentType => {
                 err.note("all function arguments must have a statically known size");
+                if !self.tcx.features().unsized_locals {
+                    err.help("unsized locals are gated as an unstable feature");
+                }
             }
             ObligationCauseCode::SizedReturnType => {
                 err.note("the return type of a function must have a \

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -185,6 +185,8 @@ pub enum ObligationCauseCode<'tcx> {
     StructInitializerSized,
     /// Type of each variable must be Sized
     VariableType(ast::NodeId),
+    /// Argument type must be Sized
+    SizedArgumentType,
     /// Return type must be Sized
     SizedReturnType,
     /// Yield type must be Sized

--- a/src/librustc/traits/structural_impls.rs
+++ b/src/librustc/traits/structural_impls.rs
@@ -203,6 +203,7 @@ impl<'a, 'tcx> Lift<'tcx> for traits::ObligationCauseCode<'a> {
             super::StructInitializerSized => Some(super::StructInitializerSized),
             super::VariableType(id) => Some(super::VariableType(id)),
             super::ReturnType(id) => Some(super::ReturnType(id)),
+            super::SizedArgumentType => Some(super::SizedArgumentType),
             super::SizedReturnType => Some(super::SizedReturnType),
             super::SizedYieldType => Some(super::SizedYieldType),
             super::RepeatVec => Some(super::RepeatVec),

--- a/src/librustc_codegen_llvm/abi.rs
+++ b/src/librustc_codegen_llvm/abi.rs
@@ -188,7 +188,7 @@ impl ArgTypeExt<'ll, 'tcx> for ArgType<'tcx, Ty<'tcx>> {
         }
         let cx = bx.cx;
         if self.is_sized_indirect() {
-            OperandValue::Ref(val, self.layout.align).store(bx, dst)
+            OperandValue::Ref(val, None, self.layout.align).store(bx, dst)
         } else if self.is_unsized_indirect() {
             bug!("unsized ArgType must be handled through store_fn_arg");
         } else if let PassMode::Cast(cast) = self.mode {
@@ -249,7 +249,7 @@ impl ArgTypeExt<'ll, 'tcx> for ArgType<'tcx, Ty<'tcx>> {
                 OperandValue::Pair(next(), next()).store(bx, dst);
             }
             PassMode::Indirect(_, Some(_)) => {
-                OperandValue::UnsizedRef(next(), next()).store(bx, dst);
+                OperandValue::Ref(next(), Some(next()), self.layout.align).store(bx, dst);
             }
             PassMode::Direct(_) | PassMode::Indirect(_, None) | PassMode::Cast(_) => {
                 self.store(bx, next(), dst);

--- a/src/librustc_codegen_llvm/base.rs
+++ b/src/librustc_codegen_llvm/base.rs
@@ -295,7 +295,7 @@ pub fn coerce_unsized_into(
             OperandValue::Immediate(base) => {
                 unsize_thin_ptr(bx, base, src_ty, dst_ty)
             }
-            OperandValue::Ref(..) => bug!()
+            OperandValue::Ref(..) | OperandValue::UnsizedRef(..) => bug!()
         };
         OperandValue::Pair(base, info).store(bx, dst);
     };

--- a/src/librustc_codegen_llvm/base.rs
+++ b/src/librustc_codegen_llvm/base.rs
@@ -295,7 +295,7 @@ pub fn coerce_unsized_into(
             OperandValue::Immediate(base) => {
                 unsize_thin_ptr(bx, base, src_ty, dst_ty)
             }
-            OperandValue::Ref(..) | OperandValue::UnsizedRef(..) => bug!()
+            OperandValue::Ref(..) => bug!()
         };
         OperandValue::Pair(base, info).store(bx, dst);
     };

--- a/src/librustc_codegen_llvm/builder.rs
+++ b/src/librustc_codegen_llvm/builder.rs
@@ -445,6 +445,25 @@ impl Builder<'a, 'll, 'tcx> {
         }
     }
 
+    pub fn array_alloca(&self,
+                        ty: &'ll Type,
+                        len: &'ll Value,
+                        name: &str,
+                        align: Align) -> &'ll Value {
+        self.count_insn("alloca");
+        unsafe {
+            let alloca = if name.is_empty() {
+                llvm::LLVMBuildArrayAlloca(self.llbuilder, ty, len, noname())
+            } else {
+                let name = SmallCStr::new(name);
+                llvm::LLVMBuildArrayAlloca(self.llbuilder, ty, len,
+                                           name.as_ptr())
+            };
+            llvm::LLVMSetAlignment(alloca, align.abi() as c_uint);
+            alloca
+        }
+    }
+
     pub fn load(&self, ptr: &'ll Value, align: Align) -> &'ll Value {
         self.count_insn("load");
         unsafe {

--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -605,7 +605,7 @@ pub fn codegen_intrinsic_call(
                         // etc.
                         assert!(!bx.cx.type_needs_drop(arg.layout.ty));
                         let (ptr, align) = match arg.val {
-                            OperandValue::Ref(ptr, align) => (ptr, align),
+                            OperandValue::Ref(ptr, None, align) => (ptr, align),
                             _ => bug!()
                         };
                         let arg = PlaceRef::new_sized(ptr, arg.layout, align);

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -875,6 +875,11 @@ extern "C" {
 
     // Memory
     pub fn LLVMBuildAlloca(B: &Builder<'a>, Ty: &'a Type, Name: *const c_char) -> &'a Value;
+    pub fn LLVMBuildArrayAlloca(B: &Builder<'a>,
+                                Ty: &'a Type,
+                                Val: &'a Value,
+                                Name: *const c_char)
+                                -> &'a Value;
     pub fn LLVMBuildLoad(B: &Builder<'a>, PointerVal: &'a Value, Name: *const c_char) -> &'a Value;
 
     pub fn LLVMBuildStore(B: &Builder<'a>, Val: &'a Value, Ptr: &'a Value) -> &'a Value;

--- a/src/librustc_codegen_llvm/mir/mod.rs
+++ b/src/librustc_codegen_llvm/mir/mod.rs
@@ -541,7 +541,7 @@ fn arg_local_refs(
             }
         }
 
-        let place = if arg.is_indirect() {
+        let place = if arg.is_sized_indirect() {
             // Don't copy an indirect argument to an alloca, the caller
             // already put it in a temporary alloca and gave it up.
             // FIXME: lifetimes

--- a/src/librustc_codegen_llvm/mir/place.rs
+++ b/src/librustc_codegen_llvm/mir/place.rs
@@ -132,7 +132,7 @@ impl PlaceRef<'ll, 'tcx> {
         };
 
         let val = if let Some(llextra) = self.llextra {
-            OperandValue::UnsizedRef(self.llval, llextra)
+            OperandValue::Ref(self.llval, Some(llextra), self.align)
         } else if self.layout.is_llvm_immediate() {
             let mut const_llval = None;
             unsafe {
@@ -163,7 +163,7 @@ impl PlaceRef<'ll, 'tcx> {
             };
             OperandValue::Pair(load(0, a), load(1, b))
         } else {
-            OperandValue::Ref(self.llval, self.align)
+            OperandValue::Ref(self.llval, None, self.align)
         };
 
         OperandRef { val, layout: self.layout }

--- a/src/librustc_codegen_llvm/mir/rvalue.rs
+++ b/src/librustc_codegen_llvm/mir/rvalue.rs
@@ -83,11 +83,11 @@ impl FunctionCx<'a, 'll, 'tcx> {
                         base::coerce_unsized_into(&bx, scratch, dest);
                         scratch.storage_dead(&bx);
                     }
-                    OperandValue::Ref(llref, align) => {
+                    OperandValue::Ref(llref, None, align) => {
                         let source = PlaceRef::new_sized(llref, operand.layout, align);
                         base::coerce_unsized_into(&bx, source, dest);
                     }
-                    OperandValue::UnsizedRef(..) => {
+                    OperandValue::Ref(_, Some(_), _) => {
                         bug!("unsized coercion on an unsized rvalue")
                     }
                 }
@@ -267,9 +267,6 @@ impl FunctionCx<'a, 'll, 'tcx> {
                             OperandValue::Ref(..) => {
                                 bug!("by-ref operand {:?} in codegen_rvalue_operand",
                                      operand);
-                            }
-                            OperandValue::UnsizedRef(..) => {
-                                bug!("unsized coercion on an unsized rvalue")
                             }
                         }
                     }

--- a/src/librustc_codegen_llvm/mir/statement.rs
+++ b/src/librustc_codegen_llvm/mir/statement.rs
@@ -31,6 +31,9 @@ impl FunctionCx<'a, 'll, 'tcx> {
                         LocalRef::Place(cg_dest) => {
                             self.codegen_rvalue(bx, cg_dest, rvalue)
                         }
+                        LocalRef::UnsizedPlace(cg_indirect_dest) => {
+                            self.codegen_rvalue_unsized(bx, cg_indirect_dest, rvalue)
+                        }
                         LocalRef::Operand(None) => {
                             let (bx, operand) = self.codegen_rvalue_operand(bx, rvalue);
                             self.locals[index] = LocalRef::Operand(Some(operand));
@@ -61,12 +64,16 @@ impl FunctionCx<'a, 'll, 'tcx> {
             mir::StatementKind::StorageLive(local) => {
                 if let LocalRef::Place(cg_place) = self.locals[local] {
                     cg_place.storage_live(&bx);
+                } else if let LocalRef::UnsizedPlace(cg_indirect_place) = self.locals[local] {
+                    cg_indirect_place.storage_live(&bx);
                 }
                 bx
             }
             mir::StatementKind::StorageDead(local) => {
                 if let LocalRef::Place(cg_place) = self.locals[local] {
                     cg_place.storage_dead(&bx);
+                } else if let LocalRef::UnsizedPlace(cg_indirect_place) = self.locals[local] {
+                    cg_indirect_place.storage_dead(&bx);
                 }
                 bx
             }

--- a/src/librustc_target/abi/call/x86.rs
+++ b/src/librustc_target/abi/call/x86.rs
@@ -99,10 +99,10 @@ pub fn compute_abi_info<'a, Ty, C>(cx: C, fty: &mut FnType<'a, Ty>, flavor: Flav
         for arg in &mut fty.args {
             let attrs = match arg.mode {
                 PassMode::Ignore |
-                PassMode::Indirect(_) => continue,
+                PassMode::Indirect(_, None) => continue,
                 PassMode::Direct(ref mut attrs) => attrs,
                 PassMode::Pair(..) |
-                PassMode::UnsizedIndirect(..) |
+                PassMode::Indirect(_, Some(_)) |
                 PassMode::Cast(_) => {
                     unreachable!("x86 shouldn't be passing arguments by {:?}", arg.mode)
                 }

--- a/src/librustc_target/abi/call/x86.rs
+++ b/src/librustc_target/abi/call/x86.rs
@@ -102,6 +102,7 @@ pub fn compute_abi_info<'a, Ty, C>(cx: C, fty: &mut FnType<'a, Ty>, flavor: Flav
                 PassMode::Indirect(_) => continue,
                 PassMode::Direct(ref mut attrs) => attrs,
                 PassMode::Pair(..) |
+                PassMode::UnsizedIndirect(..) |
                 PassMode::Cast(_) => {
                     unreachable!("x86 shouldn't be passing arguments by {:?}", arg.mode)
                 }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1049,7 +1049,7 @@ fn check_fn<'a, 'gcx, 'tcx>(inherited: &'a Inherited<'a, 'gcx, 'tcx>,
         // for simple cases like `fn foo(x: Trait)`,
         // where we would error once on the parameter as a whole, and once on the binding `x`.
         if arg.pat.simple_ident().is_none() {
-            fcx.require_type_is_sized(arg_ty, decl.output.span(), traits::MiscObligation);
+            fcx.require_type_is_sized(arg_ty, decl.output.span(), traits::SizedArgumentType);
         }
 
         fcx.write_ty(arg.hir_id, arg_ty);

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -961,8 +961,10 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for GatherLocalsVisitor<'a, 'gcx, 'tcx> {
         if let PatKind::Binding(_, _, ident, _) = p.node {
             let var_ty = self.assign(p.span, p.id, None);
 
-            self.fcx.require_type_is_sized(var_ty, p.span,
-                                           traits::VariableType(p.id));
+            if !self.fcx.tcx.features().unsized_locals {
+                self.fcx.require_type_is_sized(var_ty, p.span,
+                                               traits::VariableType(p.id));
+            }
 
             debug!("Pattern binding {} is assigned to {} with type {:?}",
                    ident,
@@ -1048,7 +1050,7 @@ fn check_fn<'a, 'gcx, 'tcx>(inherited: &'a Inherited<'a, 'gcx, 'tcx>,
         // The check for a non-trivial pattern is a hack to avoid duplicate warnings
         // for simple cases like `fn foo(x: Trait)`,
         // where we would error once on the parameter as a whole, and once on the binding `x`.
-        if arg.pat.simple_ident().is_none() {
+        if arg.pat.simple_ident().is_none() && !fcx.tcx.features().unsized_locals {
             fcx.require_type_is_sized(arg_ty, decl.output.span(), traits::SizedArgumentType);
         }
 

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -503,6 +503,9 @@ declare_features! (
 
     // Allows `Self` in type definitions
     (active, self_in_typedefs, "1.30.0", Some(49303), None),
+
+    // unsized rvalues at arguments and parameters
+    (active, unsized_locals, "1.30.0", Some(48055), None),
 );
 
 declare_features! (

--- a/src/test/compile-fail/unsized-locals/unsized-exprs.rs
+++ b/src/test/compile-fail/unsized-locals/unsized-exprs.rs
@@ -1,0 +1,36 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unsized_tuple_coercion, unsized_locals)]
+
+struct A<X: ?Sized>(X);
+
+fn udrop<T: ?Sized>(_x: T) {}
+fn foo() -> Box<[u8]> {
+    Box::new(*b"foo")
+}
+fn tfoo() -> Box<(i32, [u8])> {
+    Box::new((42, *b"foo"))
+}
+fn afoo() -> Box<A<[u8]>> {
+    Box::new(A(*b"foo"))
+}
+
+impl std::ops::Add<i32> for A<[u8]> {
+    type Output = ();
+    fn add(self, _rhs: i32) -> Self::Output {}
+}
+
+fn main() {
+    udrop::<(i32, [u8])>((42, *foo()));
+    //~^ERROR E0277
+    udrop::<A<[u8]>>(A { 0: *foo() });
+    //~^ERROR E0277
+}

--- a/src/test/compile-fail/unsized-locals/unsized-exprs2.rs
+++ b/src/test/compile-fail/unsized-locals/unsized-exprs2.rs
@@ -1,0 +1,36 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unsized_tuple_coercion, unsized_locals)]
+
+struct A<X: ?Sized>(X);
+
+fn udrop<T: ?Sized>(_x: T) {}
+fn foo() -> Box<[u8]> {
+    Box::new(*b"foo")
+}
+fn tfoo() -> Box<(i32, [u8])> {
+    Box::new((42, *b"foo"))
+}
+fn afoo() -> Box<A<[u8]>> {
+    Box::new(A(*b"foo"))
+}
+
+impl std::ops::Add<i32> for A<[u8]> {
+    type Output = ();
+    fn add(self, _rhs: i32) -> Self::Output {}
+}
+
+fn main() {
+    udrop::<[u8]>(foo()[..]);
+    //~^ERROR cannot move out of indexed content
+    // FIXME: should be error
+    udrop::<A<[u8]>>(A(*foo()));
+}

--- a/src/test/run-pass-valgrind/unsized-locals/long-live-the-unsized-temporary.rs
+++ b/src/test/run-pass-valgrind/unsized-locals/long-live-the-unsized-temporary.rs
@@ -1,0 +1,65 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unsized_locals)]
+
+use std::fmt;
+
+fn gen_foo() -> Box<fmt::Display> {
+    Box::new(Box::new("foo"))
+}
+
+fn foo(x: fmt::Display) {
+    assert_eq!(x.to_string(), "foo");
+}
+
+fn foo_indirect(x: fmt::Display) {
+    foo(x);
+}
+
+fn main() {
+    foo(*gen_foo());
+    foo_indirect(*gen_foo());
+
+    {
+        let x: fmt::Display = *gen_foo();
+        foo(x);
+    }
+
+    {
+        let x: fmt::Display = *gen_foo();
+        let y: fmt::Display = *gen_foo();
+        foo(x);
+        foo(y);
+    }
+
+    {
+        let mut cnt: usize = 3;
+        let x = loop {
+            let x: fmt::Display = *gen_foo();
+            if cnt == 0 {
+                break x;
+            } else {
+                cnt -= 1;
+            }
+        };
+        foo(x);
+    }
+
+    {
+        let x: fmt::Display = *gen_foo();
+        let x = if true {
+            x
+        } else {
+            *gen_foo()
+        };
+        foo(x);
+    }
+}

--- a/src/test/run-pass/unsized-locals/reference-unsized-locals.rs
+++ b/src/test/run-pass/unsized-locals/reference-unsized-locals.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unsized_locals)]
+
+fn main() {
+    let foo: Box<[u8]> = Box::new(*b"foo");
+    let foo: [u8] = *foo;
+    assert_eq!(&foo, b"foo" as &[u8]);
+}

--- a/src/test/run-pass/unsized-locals/simple-unsized-locals.rs
+++ b/src/test/run-pass/unsized-locals/simple-unsized-locals.rs
@@ -1,0 +1,16 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unsized_locals)]
+
+fn main() {
+    let foo: Box<[u8]> = Box::new(*b"foo");
+    let _foo: [u8] = *foo;
+}

--- a/src/test/run-pass/unsized-locals/unsized-exprs.rs
+++ b/src/test/run-pass/unsized-locals/unsized-exprs.rs
@@ -1,0 +1,45 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unsized_tuple_coercion, unsized_locals)]
+
+struct A<X: ?Sized>(X);
+
+fn udrop<T: ?Sized>(_x: T) {}
+fn foo() -> Box<[u8]> {
+    Box::new(*b"foo")
+}
+fn tfoo() -> Box<(i32, [u8])> {
+    Box::new((42, *b"foo"))
+}
+fn afoo() -> Box<A<[u8]>> {
+    Box::new(A(*b"foo"))
+}
+
+impl std::ops::Add<i32> for A<[u8]> {
+    type Output = ();
+    fn add(self, _rhs: i32) -> Self::Output {}
+}
+
+fn main() {
+    udrop::<[u8]>(loop {
+        break *foo();
+    });
+    udrop::<[u8]>(if true {
+        *foo()
+    } else {
+        *foo()
+    });
+    udrop::<[u8]>({*foo()});
+    #[allow(unused_parens)]
+    udrop::<[u8]>((*foo()));
+    udrop::<[u8]>((*tfoo()).1);
+    *afoo() + 42;
+}

--- a/src/test/run-pass/unsized-locals/unsized-parameters.rs
+++ b/src/test/run-pass/unsized-locals/unsized-parameters.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unsized_locals)]
+
+pub fn f0(_f: dyn FnOnce()) {}
+pub fn f1(_s: str) {}
+pub fn f2((_x, _y): (i32, [i32])) {}
+
+fn main() {
+    let foo = "foo".to_string().into_boxed_str();
+    f1(*foo);
+}

--- a/src/test/ui/associated-types/associated-types-unsized.stderr
+++ b/src/test/ui/associated-types/associated-types-unsized.stderr
@@ -8,6 +8,7 @@ LL |     let x = t.get(); //~ ERROR the size for values of type
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where <T as Get>::Value: std::marker::Sized` bound
    = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0277.stderr
+++ b/src/test/ui/error-codes/E0277.stderr
@@ -8,6 +8,7 @@ LL | fn f(p: Path) { }
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: required because it appears within the type `std::path::Path`
    = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/E0277.rs:27:5

--- a/src/test/ui/feature-gate-unsized_locals.rs
+++ b/src/test/ui/feature-gate-unsized_locals.rs
@@ -1,0 +1,15 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn f(f: FnOnce()) {}
+//~^ ERROR E0277
+
+fn main() {
+}

--- a/src/test/ui/feature-gate-unsized_locals.stderr
+++ b/src/test/ui/feature-gate-unsized_locals.stderr
@@ -1,0 +1,13 @@
+error[E0277]: the size for values of type `(dyn std::ops::FnOnce() + 'static)` cannot be known at compilation time
+  --> $DIR/feature-gate-unsized_locals.rs:11:6
+   |
+LL | fn f(f: FnOnce()) {}
+   |      ^ doesn't have a size known at compile-time
+   |
+   = help: the trait `std::marker::Sized` is not implemented for `(dyn std::ops::FnOnce() + 'static)`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+   = note: all local variables must have a statically known size
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/feature-gate-unsized_locals.stderr
+++ b/src/test/ui/feature-gate-unsized_locals.stderr
@@ -7,6 +7,7 @@ LL | fn f(f: FnOnce()) {}
    = help: the trait `std::marker::Sized` is not implemented for `(dyn std::ops::FnOnce() + 'static)`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-15756.stderr
+++ b/src/test/ui/issues/issue-15756.stderr
@@ -7,6 +7,7 @@ LL |     &mut something
    = help: the trait `std::marker::Sized` is not implemented for `[T]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-27078.stderr
+++ b/src/test/ui/issues/issue-27078.stderr
@@ -8,6 +8,7 @@ LL |     fn foo(self) -> &'static i32 {
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where Self: std::marker::Sized` bound
    = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-38954.stderr
+++ b/src/test/ui/issues/issue-38954.stderr
@@ -6,6 +6,7 @@ LL | fn _test(ref _p: str) {}
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+   = note: all function arguments must have a statically known size
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-38954.stderr
+++ b/src/test/ui/issues/issue-38954.stderr
@@ -7,6 +7,7 @@ LL | fn _test(ref _p: str) {}
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: all function arguments must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-41229-ref-str.stderr
+++ b/src/test/ui/issues/issue-41229-ref-str.stderr
@@ -6,6 +6,7 @@ LL | pub fn example(ref s: str) {}
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+   = note: all function arguments must have a statically known size
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-41229-ref-str.stderr
+++ b/src/test/ui/issues/issue-41229-ref-str.stderr
@@ -7,6 +7,7 @@ LL | pub fn example(ref s: str) {}
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: all function arguments must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-42312.stderr
+++ b/src/test/ui/issues/issue-42312.stderr
@@ -7,6 +7,7 @@ LL |     fn baz(_: Self::Target) where Self: Deref {}
    = help: the trait `std::marker::Sized` is not implemented for `<Self as std::ops::Deref>::Target`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where <Self as std::ops::Deref>::Target: std::marker::Sized` bound
+   = note: all function arguments must have a statically known size
 
 error[E0277]: the size for values of type `(dyn std::string::ToString + 'static)` cannot be known at compilation time
   --> $DIR/issue-42312.rs:18:23
@@ -16,6 +17,7 @@ LL | pub fn f(_: ToString) {}
    |
    = help: the trait `std::marker::Sized` is not implemented for `(dyn std::string::ToString + 'static)`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+   = note: all function arguments must have a statically known size
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-42312.stderr
+++ b/src/test/ui/issues/issue-42312.stderr
@@ -8,6 +8,7 @@ LL |     fn baz(_: Self::Target) where Self: Deref {}
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where <Self as std::ops::Deref>::Target: std::marker::Sized` bound
    = note: all function arguments must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error[E0277]: the size for values of type `(dyn std::string::ToString + 'static)` cannot be known at compilation time
   --> $DIR/issue-42312.rs:18:23
@@ -18,6 +19,7 @@ LL | pub fn f(_: ToString) {}
    = help: the trait `std::marker::Sized` is not implemented for `(dyn std::string::ToString + 'static)`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: all function arguments must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-5883.stderr
+++ b/src/test/ui/issues/issue-5883.stderr
@@ -7,6 +7,7 @@ LL | fn new_struct(r: A+'static)
    = help: the trait `std::marker::Sized` is not implemented for `(dyn A + 'static)`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
   --> $DIR/issue-5883.rs:18:8

--- a/src/test/ui/resolve/issue-5035-2.stderr
+++ b/src/test/ui/resolve/issue-5035-2.stderr
@@ -7,6 +7,7 @@ LL | fn foo(_x: K) {}
    = help: the trait `std::marker::Sized` is not implemented for `(dyn I + 'static)`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error: aborting due to previous error
 

--- a/src/test/ui/str/str-array-assignment.stderr
+++ b/src/test/ui/str/str-array-assignment.stderr
@@ -30,6 +30,7 @@ LL |   let v = s[..2];
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error[E0308]: mismatched types
   --> $DIR/str-array-assignment.rs:19:17

--- a/src/test/ui/traits/trait-bounds-not-on-bare-trait.stderr
+++ b/src/test/ui/traits/trait-bounds-not-on-bare-trait.stderr
@@ -7,6 +7,7 @@ LL | fn foo(_x: Foo + Send) {
    = help: the trait `std::marker::Sized` is not implemented for `(dyn Foo + std::marker::Send + 'static)`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsized6.stderr
+++ b/src/test/ui/unsized6.stderr
@@ -8,6 +8,7 @@ LL |     let y: Y;
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where Y: std::marker::Sized` bound
    = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized6.rs:17:12
@@ -41,6 +42,7 @@ LL |     let y: X;
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where X: std::marker::Sized` bound
    = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error[E0277]: the size for values of type `Y` cannot be known at compilation time
   --> $DIR/unsized6.rs:27:12
@@ -63,6 +65,7 @@ LL |     let y: X = *x1;
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where X: std::marker::Sized` bound
    = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized6.rs:34:9
@@ -74,6 +77,7 @@ LL |     let y = *x2;
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where X: std::marker::Sized` bound
    = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized6.rs:36:10
@@ -85,6 +89,7 @@ LL |     let (y, z) = (*x3, 4);
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where X: std::marker::Sized` bound
    = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized6.rs:40:9
@@ -96,6 +101,7 @@ LL |     let y: X = *x1;
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where X: std::marker::Sized` bound
    = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized6.rs:42:9
@@ -107,6 +113,7 @@ LL |     let y = *x2;
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where X: std::marker::Sized` bound
    = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized6.rs:44:10
@@ -118,6 +125,7 @@ LL |     let (y, z) = (*x3, 4);
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where X: std::marker::Sized` bound
    = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized6.rs:48:18
@@ -129,6 +137,7 @@ LL | fn g1<X: ?Sized>(x: X) {}
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where X: std::marker::Sized` bound
    = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized6.rs:50:22
@@ -140,6 +149,7 @@ LL | fn g2<X: ?Sized + T>(x: X) {}
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where X: std::marker::Sized` bound
    = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error: aborting due to 13 previous errors
 


### PR DESCRIPTION
This PR is the first step to implement RFC1909: unsized rvalues (#48055).

## Implemented

- `Sized` is removed for arguments and local bindings. (under `#![feature(unsized_locals)]`)
- Unsized locations are allowed in MIR
- Unsized places and operands are correctly translated at codegen

## Not implemented in this PR

- Additional `Sized` checks:
  - tuple struct constructor (accidentally compiles now)
  - closure arguments at closure generation (accidentally compiles now)
  - upvars (ICEs now)
- Generating vtable for `fn method(self)` (ICEs now)
- VLAs: `[e; n]` where `n` isn't const
- Reduce unnecessary allocations

## Current status

- [x] Fix `__rust_probestack` (rust-lang-nursery/compiler-builtins#244)
  - [x] Get the fix merged
- [x] `#![feature(unsized_locals)]`
  - [x] Give it a tracking issue number
- [x] Lift sized checks in typeck and MIR-borrowck
  - [ ] <del>Forbid `A(unsized-expr)`</del> will be another PR
- [x] Minimum working codegen
- [x] Add more examples and fill in unimplemented codegen paths
- [ ] <del>Loosen object-safety rules (will be another PR)</del>
- [ ] <del>Implement `Box<FnOnce>` (will be another PR)</del>
- [ ] <del>Reduce temporaries (will be another PR)</del>