### PR TITLE
Tweak output on E0599 for assoc fn used as method

### DIFF
--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -385,7 +385,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 if static_sources.len() == 1 {
                     if let Some(expr) = rcvr_expr {
                         err.span_suggestion(expr.span.to(span),
-                                            "use associated function syntax intead",
+                                            "use associated function syntax instead",
                                             format!("{}::{}",
                                                     self.ty_to_string(actual),
                                                     item_name));

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -297,7 +297,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     tcx.sess.diagnostic().struct_dummy()
                 };
 
-                if let Some(def) =  actual.ty_adt_def() {
+                if let Some(def) = actual.ty_adt_def() {
                     if let Some(full_sp) = tcx.hir.span_if_local(def.did) {
                         let def_sp = tcx.sess.codemap().def_span(full_sp);
                         err.span_label(def_sp, format!("{} `{}` not found {}",
@@ -380,6 +380,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 if !static_sources.is_empty() {
                     err.note("found the following associated functions; to be used as methods, \
                               functions must have a `self` parameter");
+                    err.span_label(span, "this is an associated function, not a method");
                 }
                 if static_sources.len() == 1 {
                     if let Some(expr) = rcvr_expr {

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -380,6 +380,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 if !static_sources.is_empty() {
                     err.note("found the following associated functions; to be used as methods, \
                               functions must have a `self` parameter");
+                }
+                if static_sources.len() == 1 {
                     if let Some(expr) = rcvr_expr {
                         err.span_suggestion(expr.span.to(span),
                                             "use associated function syntax intead",
@@ -388,6 +390,9 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         err.help(&format!("try with `{}::{}`",
                                           self.ty_to_string(actual), item_name));
                     }
+
+                    report_candidates(&mut err, static_sources);
+                } else if static_sources.len() > 1 {
 
                     report_candidates(&mut err, static_sources);
                 }

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -386,7 +386,9 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     if let Some(expr) = rcvr_expr {
                         err.span_suggestion(expr.span.to(span),
                                             "use associated function syntax intead",
-                                            format!("{}::{}", self.ty_to_string(actual), item_name));
+                                            format!("{}::{}",
+                                                    self.ty_to_string(actual),
+                                                    item_name));
                     } else {
                         err.help(&format!("try with `{}::{}`",
                                           self.ty_to_string(actual), item_name));

--- a/src/test/ui/hygiene/no_implicit_prelude.stderr
+++ b/src/test/ui/hygiene/no_implicit_prelude.stderr
@@ -22,7 +22,7 @@ LL |         ().clone() //~ ERROR no method named `clone` found
    |
    = help: items from traits can only be used if the trait is in scope
    = note: the following trait is implemented but not in scope, perhaps add a `use` for it:
-           candidate #1: `use std::clone::Clone;`
+           `use std::clone::Clone;`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/hygiene/trait_items.stderr
+++ b/src/test/ui/hygiene/trait_items.stderr
@@ -9,7 +9,7 @@ LL |     pub macro m() { ().f() } //~ ERROR no method named `f` found for type `
    |
    = help: items from traits can only be used if the trait is in scope
    = note: the following trait is implemented but not in scope, perhaps add a `use` for it:
-           candidate #1: `use foo::T;`
+           `use foo::T;`
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/issue-7575.stderr
+++ b/src/test/ui/span/issue-7575.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `f9` found for type `usize` in the current scope
   --> $DIR/issue-7575.rs:74:18
    |
 LL |     u.f8(42) + u.f9(342) + m.fff(42)
-   |                  ^^
+   |                  ^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: candidate #1 is defined in the trait `CtxtFn`
@@ -37,7 +37,8 @@ LL | struct Myisize(isize);
 ...
 LL |     u.f8(42) + u.f9(342) + m.fff(42)
    |                            --^^^
-   |                            |
+   |                            | |
+   |                            | this is an associated function, not a method
    |                            help: use associated function syntax intead: `Myisize::fff`
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
@@ -51,7 +52,7 @@ error[E0599]: no method named `is_str` found for type `T` in the current scope
   --> $DIR/issue-7575.rs:82:7
    |
 LL |     t.is_str()
-   |       ^^^^^^
+   |       ^^^^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in the trait `ManyImplTrait`

--- a/src/test/ui/span/issue-7575.stderr
+++ b/src/test/ui/span/issue-7575.stderr
@@ -2,9 +2,7 @@ error[E0599]: no method named `f9` found for type `usize` in the current scope
   --> $DIR/issue-7575.rs:74:18
    |
 LL |     u.f8(42) + u.f9(342) + m.fff(42)
-   |                --^^
-   |                |
-   |                help: use associated function syntax intead: `usize::f9`
+   |                  ^^
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: candidate #1 is defined in the trait `CtxtFn`
@@ -53,9 +51,7 @@ error[E0599]: no method named `is_str` found for type `T` in the current scope
   --> $DIR/issue-7575.rs:82:7
    |
 LL |     t.is_str()
-   |     --^^^^^^
-   |     |
-   |     help: use associated function syntax intead: `T::is_str`
+   |       ^^^^^^
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in the trait `ManyImplTrait`

--- a/src/test/ui/span/issue-7575.stderr
+++ b/src/test/ui/span/issue-7575.stderr
@@ -39,7 +39,7 @@ LL |     u.f8(42) + u.f9(342) + m.fff(42)
    |                            --^^^
    |                            | |
    |                            | this is an associated function, not a method
-   |                            help: use associated function syntax intead: `Myisize::fff`
+   |                            help: use associated function syntax instead: `Myisize::fff`
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in an impl for the type `Myisize`

--- a/src/test/ui/span/issue-7575.stderr
+++ b/src/test/ui/span/issue-7575.stderr
@@ -2,10 +2,11 @@ error[E0599]: no method named `f9` found for type `usize` in the current scope
   --> $DIR/issue-7575.rs:74:18
    |
 LL |     u.f8(42) + u.f9(342) + m.fff(42)
-   |                  ^^
+   |                --^^
+   |                |
+   |                help: use associated function syntax intead: `usize::f9`
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
-   = help: try with `usize::f9`
 note: candidate #1 is defined in the trait `CtxtFn`
   --> $DIR/issue-7575.rs:16:5
    |
@@ -37,11 +38,12 @@ LL | struct Myisize(isize);
    | ---------------------- method `fff` not found for this
 ...
 LL |     u.f8(42) + u.f9(342) + m.fff(42)
-   |                              ^^^
+   |                            --^^^
+   |                            |
+   |                            help: use associated function syntax intead: `Myisize::fff`
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
-   = help: try with `Myisize::fff`
-note: candidate #1 is defined in an impl for the type `Myisize`
+note: the candidate is defined in an impl for the type `Myisize`
   --> $DIR/issue-7575.rs:51:5
    |
 LL |     fn fff(i: isize) -> isize {
@@ -51,11 +53,12 @@ error[E0599]: no method named `is_str` found for type `T` in the current scope
   --> $DIR/issue-7575.rs:82:7
    |
 LL |     t.is_str()
-   |       ^^^^^^
+   |     --^^^^^^
+   |     |
+   |     help: use associated function syntax intead: `T::is_str`
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
-   = help: try with `T::is_str`
-note: candidate #1 is defined in the trait `ManyImplTrait`
+note: the candidate is defined in the trait `ManyImplTrait`
   --> $DIR/issue-7575.rs:57:5
    |
 LL |     fn is_str() -> bool {


### PR DESCRIPTION
 - Use suggestion instead of `help` when possible
 - Add primary span label
 - Remove incorrect `help` suggestion using incorrect syntax
 - Do not refer to only one possible candidate as `candidate #1`, refer to it as `the candidate`