### PR TITLE
typeck: Do not pass the field check on field error

### DIFF
--- a/src/test/ui/issue-51102.rs
+++ b/src/test/ui/issue-51102.rs
@@ -1,0 +1,48 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum SimpleEnum {
+    NoState,
+}
+
+struct SimpleStruct {
+    no_state_here: u64,
+}
+
+fn main() {
+    let _ = |simple| {
+        match simple {
+            SimpleStruct {
+                state: 0,
+                //~^ struct `SimpleStruct` does not have a field named `state` [E0026]
+                ..
+            } => (),
+        }
+    };
+
+    let _ = |simple| {
+        match simple {
+            SimpleStruct {
+                no_state_here: 0,
+                no_state_here: 1
+                //~^ ERROR field `no_state_here` bound multiple times in the pattern [E0025]
+            } => (),
+        }
+    };
+
+    let _ = |simple| {
+        match simple {
+            SimpleEnum::NoState {
+                state: 0
+                //~^ ERROR variant `SimpleEnum::NoState` does not have a field named `state` [E0026]
+            } => (),
+        }
+    };
+}

--- a/src/test/ui/issue-51102.stderr
+++ b/src/test/ui/issue-51102.stderr
@@ -1,0 +1,24 @@
+error[E0026]: struct `SimpleStruct` does not have a field named `state`
+  --> $DIR/issue-51102.rs:23:17
+   |
+LL |                 state: 0,
+   |                 ^^^^^^^^ struct `SimpleStruct` does not have this field
+
+error[E0025]: field `no_state_here` bound multiple times in the pattern
+  --> $DIR/issue-51102.rs:34:17
+   |
+LL |                 no_state_here: 0,
+   |                 ---------------- first use of `no_state_here`
+LL |                 no_state_here: 1
+   |                 ^^^^^^^^^^^^^^^^ multiple uses of `no_state_here` in pattern
+
+error[E0026]: variant `SimpleEnum::NoState` does not have a field named `state`
+  --> $DIR/issue-51102.rs:43:17
+   |
+LL |                 state: 0
+   |                 ^^^^^^^^ variant `SimpleEnum::NoState` does not have this field
+
+error: aborting due to 3 previous errors
+
+Some errors occurred: E0025, E0026.
+For more information about an error, try `rustc --explain E0025`.


### PR DESCRIPTION
If a struct pattern has a field error return an error.

Fixes: #51102