### PR TITLE
Replace `if` with `if and only if` in the definition dox of `Sync`

### DIFF
--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -294,7 +294,7 @@ pub trait Copy : Clone {
 /// This trait is automatically implemented when the compiler determines
 /// it's appropriate.
 ///
-/// The precise definition is: a type `T` is `Sync` if `&T` is
+/// The precise definition is: a type `T` is `Sync` if and only if `&T` is
 /// [`Send`][send]. In other words, if there is no possibility of
 /// [undefined behavior][ub] (including data races) when passing
 /// `&T` references between threads.


### PR DESCRIPTION
The old text was: "The precise definition is: a type `T` is `Sync` if `&T` is Send."

Since we've also got
```
impl<'a, T> Send for &'a T 
where
    T: Sync + ?Sized,
```
I purpose we can change the `if` to `if and only if` to make it more precise.