### PR TITLE
Changes to GlobalAlloc

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -518,7 +518,7 @@ impl<T: ?Sized> Arc<T> {
 
         if self.inner().weak.fetch_sub(1, Release) == 1 {
             atomic::fence(Acquire);
-            Global.dealloc(self.ptr.as_opaque(), Layout::for_value(self.ptr.as_ref()))
+            Global.dealloc(self.ptr.cast(), Layout::for_value(self.ptr.as_ref()))
         }
     }
 
@@ -638,7 +638,7 @@ impl<T: Clone> ArcFromSlice<T> for Arc<[T]> {
                     let slice = from_raw_parts_mut(self.elems, self.n_elems);
                     ptr::drop_in_place(slice);
 
-                    Global.dealloc(self.mem.as_opaque(), self.layout.clone());
+                    Global.dealloc(self.mem.cast(), self.layout.clone());
                 }
             }
         }
@@ -1157,7 +1157,7 @@ impl<T: ?Sized> Drop for Weak<T> {
         if self.inner().weak.fetch_sub(1, Release) == 1 {
             atomic::fence(Acquire);
             unsafe {
-                Global.dealloc(self.ptr.as_opaque(), Layout::for_value(self.ptr.as_ref()))
+                Global.dealloc(self.ptr.cast(), Layout::for_value(self.ptr.as_ref()))
             }
         }
     }

--- a/src/liballoc/btree/node.rs
+++ b/src/liballoc/btree/node.rs
@@ -287,7 +287,7 @@ impl<K, V> Root<K, V> {
         self.as_mut().as_leaf_mut().parent = ptr::null();
 
         unsafe {
-            Global.dealloc(NonNull::from(top).as_opaque(), Layout::new::<InternalNode<K, V>>());
+            Global.dealloc(NonNull::from(top).cast(), Layout::new::<InternalNode<K, V>>());
         }
     }
 }
@@ -478,7 +478,7 @@ impl<K, V> NodeRef<marker::Owned, K, V, marker::Leaf> {
         debug_assert!(!self.is_shared_root());
         let node = self.node;
         let ret = self.ascend().ok();
-        Global.dealloc(node.as_opaque(), Layout::new::<LeafNode<K, V>>());
+        Global.dealloc(node.cast(), Layout::new::<LeafNode<K, V>>());
         ret
     }
 }
@@ -499,7 +499,7 @@ impl<K, V> NodeRef<marker::Owned, K, V, marker::Internal> {
     > {
         let node = self.node;
         let ret = self.ascend().ok();
-        Global.dealloc(node.as_opaque(), Layout::new::<InternalNode<K, V>>());
+        Global.dealloc(node.cast(), Layout::new::<InternalNode<K, V>>());
         ret
     }
 }
@@ -1321,12 +1321,12 @@ impl<'a, K, V> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::
                 }
 
                 Global.dealloc(
-                    right_node.node.as_opaque(),
+                    right_node.node.cast(),
                     Layout::new::<InternalNode<K, V>>(),
                 );
             } else {
                 Global.dealloc(
-                    right_node.node.as_opaque(),
+                    right_node.node.cast(),
                     Layout::new::<LeafNode<K, V>>(),
                 );
             }

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -93,7 +93,7 @@ impl<T, A: Alloc> RawVec<T, A> {
 
             // handles ZSTs and `cap = 0` alike
             let ptr = if alloc_size == 0 {
-                NonNull::<T>::dangling().as_opaque()
+                NonNull::<T>::dangling().cast()
             } else {
                 let align = mem::align_of::<T>();
                 let layout = Layout::from_size_align(alloc_size, align).unwrap();
@@ -314,7 +314,7 @@ impl<T, A: Alloc> RawVec<T, A> {
                     let new_cap = 2 * self.cap;
                     let new_size = new_cap * elem_size;
                     alloc_guard(new_size).unwrap_or_else(|_| capacity_overflow());
-                    let ptr_res = self.a.realloc(NonNull::from(self.ptr).as_opaque(),
+                    let ptr_res = self.a.realloc(NonNull::from(self.ptr).cast(),
                                                  cur,
                                                  new_size);
                     match ptr_res {
@@ -373,7 +373,7 @@ impl<T, A: Alloc> RawVec<T, A> {
             let new_cap = 2 * self.cap;
             let new_size = new_cap * elem_size;
             alloc_guard(new_size).unwrap_or_else(|_| capacity_overflow());
-            match self.a.grow_in_place(NonNull::from(self.ptr).as_opaque(), old_layout, new_size) {
+            match self.a.grow_in_place(NonNull::from(self.ptr).cast(), old_layout, new_size) {
                 Ok(_) => {
                     // We can't directly divide `size`.
                     self.cap = new_cap;
@@ -546,7 +546,7 @@ impl<T, A: Alloc> RawVec<T, A> {
             // FIXME: may crash and burn on over-reserve
             alloc_guard(new_layout.size()).unwrap_or_else(|_| capacity_overflow());
             match self.a.grow_in_place(
-                NonNull::from(self.ptr).as_opaque(), old_layout, new_layout.size(),
+                NonNull::from(self.ptr).cast(), old_layout, new_layout.size(),
             ) {
                 Ok(_) => {
                     self.cap = new_cap;
@@ -607,7 +607,7 @@ impl<T, A: Alloc> RawVec<T, A> {
                 let new_size = elem_size * amount;
                 let align = mem::align_of::<T>();
                 let old_layout = Layout::from_size_align_unchecked(old_size, align);
-                match self.a.realloc(NonNull::from(self.ptr).as_opaque(),
+                match self.a.realloc(NonNull::from(self.ptr).cast(),
                                      old_layout,
                                      new_size) {
                     Ok(p) => self.ptr = p.cast().into(),
@@ -667,7 +667,7 @@ impl<T, A: Alloc> RawVec<T, A> {
             let res = match self.current_layout() {
                 Some(layout) => {
                     debug_assert!(new_layout.align() == layout.align());
-                    self.a.realloc(NonNull::from(self.ptr).as_opaque(), layout, new_layout.size())
+                    self.a.realloc(NonNull::from(self.ptr).cast(), layout, new_layout.size())
                 }
                 None => self.a.alloc(new_layout),
             };
@@ -710,7 +710,7 @@ impl<T, A: Alloc> RawVec<T, A> {
         let elem_size = mem::size_of::<T>();
         if elem_size != 0 {
             if let Some(layout) = self.current_layout() {
-                self.a.dealloc(NonNull::from(self.ptr).as_opaque(), layout);
+                self.a.dealloc(NonNull::from(self.ptr).cast(), layout);
             }
         }
     }

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -845,7 +845,7 @@ unsafe impl<#[may_dangle] T: ?Sized> Drop for Rc<T> {
                 self.dec_weak();
 
                 if self.weak() == 0 {
-                    Global.dealloc(self.ptr.as_opaque(), Layout::for_value(self.ptr.as_ref()));
+                    Global.dealloc(self.ptr.cast(), Layout::for_value(self.ptr.as_ref()));
                 }
             }
         }
@@ -1269,7 +1269,7 @@ impl<T: ?Sized> Drop for Weak<T> {
             // the weak count starts at 1, and will only go to zero if all
             // the strong pointers have disappeared.
             if self.weak() == 0 {
-                Global.dealloc(self.ptr.as_opaque(), Layout::for_value(self.ptr.as_ref()));
+                Global.dealloc(self.ptr.cast(), Layout::for_value(self.ptr.as_ref()));
             }
         }
     }

--- a/src/liballoc_system/lib.rs
+++ b/src/liballoc_system/lib.rs
@@ -51,17 +51,17 @@ pub struct System;
 unsafe impl Alloc for System {
     #[inline]
     unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<Opaque>, AllocErr> {
-        NonNull::new(GlobalAlloc::alloc(self, layout)).ok_or(AllocErr)
+        GlobalAlloc::alloc(self, layout)
     }
 
     #[inline]
     unsafe fn alloc_zeroed(&mut self, layout: Layout) -> Result<NonNull<Opaque>, AllocErr> {
-        NonNull::new(GlobalAlloc::alloc_zeroed(self, layout)).ok_or(AllocErr)
+        GlobalAlloc::alloc_zeroed(self, layout)
     }
 
     #[inline]
     unsafe fn dealloc(&mut self, ptr: NonNull<Opaque>, layout: Layout) {
-        GlobalAlloc::dealloc(self, ptr.as_ptr(), layout)
+        GlobalAlloc::dealloc(self, ptr, layout)
     }
 
     #[inline]
@@ -69,29 +69,31 @@ unsafe impl Alloc for System {
                       ptr: NonNull<Opaque>,
                       layout: Layout,
                       new_size: usize) -> Result<NonNull<Opaque>, AllocErr> {
-        NonNull::new(GlobalAlloc::realloc(self, ptr.as_ptr(), layout, new_size)).ok_or(AllocErr)
+        GlobalAlloc::realloc(self, ptr, layout, new_size)
     }
 }
 
 #[cfg(any(windows, unix, target_os = "cloudabi", target_os = "redox"))]
 mod realloc_fallback {
-    use core::alloc::{GlobalAlloc, Opaque, Layout};
+    use core::alloc::{GlobalAlloc, Opaque, Layout, AllocErr};
     use core::cmp;
-    use core::ptr;
+    use core::ptr::{self, NonNull};
 
     impl super::System {
-        pub(crate) unsafe fn realloc_fallback(&self, ptr: *mut Opaque, old_layout: Layout,
-                                              new_size: usize) -> *mut Opaque {
+        pub(crate) unsafe fn realloc_fallback(
+            &self,
+            ptr: NonNull<Opaque>,
+            old_layout: Layout,
+            new_size: usize,
+        ) -> Result<NonNull<Opaque>, AllocErr> {
             // Docs for GlobalAlloc::realloc require this to be valid:
             let new_layout = Layout::from_size_align_unchecked(new_size, old_layout.align());
 
-            let new_ptr = GlobalAlloc::alloc(self, new_layout);
-            if !new_ptr.is_null() {
-                let size = cmp::min(old_layout.size(), new_size);
-                ptr::copy_nonoverlapping(ptr as *mut u8, new_ptr as *mut u8, size);
-                GlobalAlloc::dealloc(self, ptr, old_layout);
-            }
-            new_ptr
+            let new_ptr = GlobalAlloc::alloc(self, new_layout)?;
+            let size = cmp::min(old_layout.size(), new_size);
+            ptr::copy_nonoverlapping(ptr.as_ptr() as *mut u8, new_ptr.as_ptr() as *mut u8, size);
+            GlobalAlloc::dealloc(self, ptr, old_layout);
+            Ok(new_ptr)
         }
     }
 }
@@ -104,21 +106,20 @@ mod platform {
 
     use MIN_ALIGN;
     use System;
-    use core::alloc::{GlobalAlloc, Layout, Opaque};
+    use core::alloc::{GlobalAlloc, Layout, Opaque, AllocErr};
+    use core::ptr::NonNull;
 
     #[unstable(feature = "allocator_api", issue = "32838")]
     unsafe impl GlobalAlloc for System {
         #[inline]
-        unsafe fn alloc(&self, layout: Layout) -> *mut Opaque {
+        unsafe fn alloc(&self, layout: Layout) -> Result<NonNull<Opaque>, AllocErr> {
             if layout.align() <= MIN_ALIGN && layout.align() <= layout.size() {
-                libc::malloc(layout.size()) as *mut Opaque
+                NonNull::new(libc::malloc(layout.size()) as *mut Opaque).ok_or(AllocErr)
             } else {
                 #[cfg(target_os = "macos")]
                 {
                     if layout.align() > (1 << 31) {
-                        // FIXME: use Opaque::null_mut
-                        // https://github.com/rust-lang/rust/issues/49659
-                        return 0 as *mut Opaque
+                        return Err(AllocErr);
                     }
                 }
                 aligned_malloc(&layout)
@@ -126,27 +127,32 @@ mod platform {
         }
 
         #[inline]
-        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut Opaque {
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> Result<NonNull<Opaque>, AllocErr> {
             if layout.align() <= MIN_ALIGN && layout.align() <= layout.size() {
-                libc::calloc(layout.size(), 1) as *mut Opaque
+                NonNull::new(libc::calloc(layout.size(), 1) as *mut Opaque).ok_or(AllocErr)
             } else {
-                let ptr = self.alloc(layout.clone());
-                if !ptr.is_null() {
-                    ptr::write_bytes(ptr as *mut u8, 0, layout.size());
-                }
-                ptr
+                let ptr = self.alloc(layout.clone())?;
+                ptr::write_bytes(ptr.as_ptr() as *mut u8, 0, layout.size());
+                Ok(ptr)
             }
         }
 
         #[inline]
-        unsafe fn dealloc(&self, ptr: *mut Opaque, _layout: Layout) {
-            libc::free(ptr as *mut libc::c_void)
+        unsafe fn dealloc(&self, ptr: NonNull<Opaque>, _layout: Layout) {
+            libc::free(ptr.as_ptr() as *mut libc::c_void)
         }
 
         #[inline]
-        unsafe fn realloc(&self, ptr: *mut Opaque, layout: Layout, new_size: usize) -> *mut Opaque {
+        unsafe fn realloc(
+            &self,
+            ptr: NonNull<Opaque>,
+            layout: Layout,
+            new_size: usize,
+        ) -> Result<NonNull<Opaque>, AllocErr> {
             if layout.align() <= MIN_ALIGN && layout.align() <= new_size {
-                libc::realloc(ptr as *mut libc::c_void, new_size) as *mut Opaque
+                NonNull::new(
+                    libc::realloc(ptr.as_ptr() as *mut libc::c_void, new_size) as *mut Opaque
+                ).ok_or(AllocErr)
             } else {
                 self.realloc_fallback(ptr, layout, new_size)
             }
@@ -155,7 +161,7 @@ mod platform {
 
     #[cfg(any(target_os = "android", target_os = "redox", target_os = "solaris"))]
     #[inline]
-    unsafe fn aligned_malloc(layout: &Layout) -> *mut Opaque {
+    unsafe fn aligned_malloc(layout: &Layout) -> Result<NonNull<Opaque>, AllocErr> {
         // On android we currently target API level 9 which unfortunately
         // doesn't have the `posix_memalign` API used below. Instead we use
         // `memalign`, but this unfortunately has the property on some systems
@@ -173,19 +179,18 @@ mod platform {
         // [3]: https://bugs.chromium.org/p/chromium/issues/detail?id=138579
         // [4]: https://chromium.googlesource.com/chromium/src/base/+/master/
         //                                       /memory/aligned_memory.cc
-        libc::memalign(layout.align(), layout.size()) as *mut Opaque
+        NonNull::new(libc::memalign(layout.align(), layout.size()) as *mut Opaque).ok_or(AllocErr)
     }
 
     #[cfg(not(any(target_os = "android", target_os = "redox", target_os = "solaris")))]
     #[inline]
-    unsafe fn aligned_malloc(layout: &Layout) -> *mut Opaque {
+    unsafe fn aligned_malloc(layout: &Layout) -> Result<NonNull<Opaque>, AllocErr> {
         let mut out = ptr::null_mut();
         let ret = libc::posix_memalign(&mut out, layout.align(), layout.size());
         if ret != 0 {
-            // FIXME: use Opaque::null_mut https://github.com/rust-lang/rust/issues/49659
-            0 as *mut Opaque
+            Err(AllocErr)
         } else {
-            out as *mut Opaque
+            Ok(NonNull::new_unchecked(out as *mut Opaque))
         }
     }
 }
@@ -195,7 +200,8 @@ mod platform {
 mod platform {
     use MIN_ALIGN;
     use System;
-    use core::alloc::{GlobalAlloc, Opaque, Layout};
+    use core::alloc::{GlobalAlloc, Opaque, Layout, AllocErr};
+    use core::ptr::NonNull;
 
     type LPVOID = *mut u8;
     type HANDLE = LPVOID;
@@ -227,7 +233,10 @@ mod platform {
     }
 
     #[inline]
-    unsafe fn allocate_with_flags(layout: Layout, flags: DWORD) -> *mut Opaque {
+    unsafe fn allocate_with_flags(
+        layout: Layout,
+        flags: DWORD,
+    ) -> Result<NonNull<Opaque>, AllocErr> {
         let ptr = if layout.align() <= MIN_ALIGN {
             HeapAlloc(GetProcessHeap(), flags, layout.size())
         } else {
@@ -239,39 +248,45 @@ mod platform {
                 align_ptr(ptr, layout.align())
             }
         };
-        ptr as *mut Opaque
+        NonNull::new(ptr as *mut Opaque).ok_or(AllocErr)
     }
 
     #[unstable(feature = "allocator_api", issue = "32838")]
     unsafe impl GlobalAlloc for System {
         #[inline]
-        unsafe fn alloc(&self, layout: Layout) -> *mut Opaque {
+        unsafe fn alloc(&self, layout: Layout) -> Result<NonNull<Opaque>, AllocErr> {
             allocate_with_flags(layout, 0)
         }
 
         #[inline]
-        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut Opaque {
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> Result<NonNull<Opaque>, AllocErr> {
             allocate_with_flags(layout, HEAP_ZERO_MEMORY)
         }
 
         #[inline]
-        unsafe fn dealloc(&self, ptr: *mut Opaque, layout: Layout) {
+        unsafe fn dealloc(&self, ptr: NonNull<Opaque>, layout: Layout) {
             if layout.align() <= MIN_ALIGN {
-                let err = HeapFree(GetProcessHeap(), 0, ptr as LPVOID);
-                debug_assert!(err != 0, "Failed to free heap memory: {}",
-                              GetLastError());
+                let err = HeapFree(GetProcessHeap(), 0, ptr.as_ptr() as LPVOID);
+                debug_assert!(err != 0, "Failed to free heap memory: {}", GetLastError());
             } else {
-                let header = get_header(ptr as *mut u8);
+                let header = get_header(ptr.as_ptr() as *mut u8);
                 let err = HeapFree(GetProcessHeap(), 0, header.0 as LPVOID);
-                debug_assert!(err != 0, "Failed to free heap memory: {}",
-                              GetLastError());
+                debug_assert!(err != 0, "Failed to free heap memory: {}", GetLastError());
             }
         }
 
         #[inline]
-        unsafe fn realloc(&self, ptr: *mut Opaque, layout: Layout, new_size: usize) -> *mut Opaque {
+        unsafe fn realloc(
+            &self,
+            ptr: NonNull<Opaque>,
+            layout: Layout,
+            new_size: usize,
+        ) -> Result<NonNull<Opaque>, AllocErr> {
             if layout.align() <= MIN_ALIGN {
-                HeapReAlloc(GetProcessHeap(), 0, ptr as LPVOID, new_size) as *mut Opaque
+                NonNull::new(
+                    HeapReAlloc(GetProcessHeap(), 0, ptr.as_ptr() as LPVOID, new_size)
+                        as *mut Opaque
+                ).ok_or(AllocErr)
             } else {
                 self.realloc_fallback(ptr, layout, new_size)
             }
@@ -300,7 +315,8 @@ mod platform {
 mod platform {
     extern crate dlmalloc;
 
-    use core::alloc::{GlobalAlloc, Layout, Opaque};
+    use core::alloc::{GlobalAlloc, Layout, Opaque, AllocErr};
+    use core::ptr::NonNull;
     use System;
 
     // No need for synchronization here as wasm is currently single-threaded
@@ -309,23 +325,33 @@ mod platform {
     #[unstable(feature = "allocator_api", issue = "32838")]
     unsafe impl GlobalAlloc for System {
         #[inline]
-        unsafe fn alloc(&self, layout: Layout) -> *mut Opaque {
-            DLMALLOC.malloc(layout.size(), layout.align()) as *mut Opaque
+        unsafe fn alloc(&self, layout: Layout) -> Result<NonNull<Opaque>, AllocErr> {
+            NonNull::new(DLMALLOC.malloc(layout.size(), layout.align()) as *mut Opaque)
+                .ok_or(AllocErr)
         }
 
         #[inline]
-        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut Opaque {
-            DLMALLOC.calloc(layout.size(), layout.align()) as *mut Opaque
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> Result<NonNull<Opaque>, AllocErr> {
+            NonNull::new(DLMALLOC.calloc(layout.size(), layout.align()) as *mut Opaque)
+                .ok_or(AllocErr)
         }
 
         #[inline]
-        unsafe fn dealloc(&self, ptr: *mut Opaque, layout: Layout) {
-            DLMALLOC.free(ptr as *mut u8, layout.size(), layout.align())
+        unsafe fn dealloc(&self, ptr: NonNull<Opaque>, layout: Layout) {
+            DLMALLOC.free(ptr.as_ptr() as *mut u8, layout.size(), layout.align())
         }
 
         #[inline]
-        unsafe fn realloc(&self, ptr: *mut Opaque, layout: Layout, new_size: usize) -> *mut Opaque {
-            DLMALLOC.realloc(ptr as *mut u8, layout.size(), layout.align(), new_size) as *mut Opaque
+        unsafe fn realloc(
+            &self,
+            ptr: NonNull<Opaque>,
+            layout: Layout,
+            new_size: usize,
+        ) -> Result<NonNull<Opaque>, AllocErr> {
+            NonNull::new(
+                DLMALLOC.realloc(ptr.as_ptr() as *mut u8, layout.size(), layout.align(), new_size)
+                    as *mut Opaque,
+            ).ok_or(AllocErr)
         }
     }
 }

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2921,14 +2921,6 @@ impl<T: ?Sized> NonNull<T> {
             NonNull::new_unchecked(self.as_ptr() as *mut U)
         }
     }
-
-    /// Cast to an `Opaque` pointer
-    #[unstable(feature = "allocator_api", issue = "32838")]
-    pub fn as_opaque(self) -> NonNull<::alloc::Opaque> {
-        unsafe {
-            NonNull::new_unchecked(self.as_ptr() as _)
-        }
-    }
 }
 
 #[stable(feature = "nonnull", since = "1.25.0")]

--- a/src/librustc_asan/lib.rs
+++ b/src/librustc_asan/lib.rs
@@ -21,7 +21,10 @@
 
 extern crate alloc_system;
 
+#[cfg(not(stage0))]
 use alloc_system::System;
 
+// The GlobalAllocator trait has changed since stage0
+#[cfg(not(stage0))]
 #[global_allocator]
 static ALLOC: System = System;

--- a/src/librustc_lsan/lib.rs
+++ b/src/librustc_lsan/lib.rs
@@ -21,7 +21,10 @@
 
 extern crate alloc_system;
 
+#[cfg(not(stage0))]
 use alloc_system::System;
 
+// The GlobalAllocator trait has changed since stage0
+#[cfg(not(stage0))]
 #[global_allocator]
 static ALLOC: System = System;

--- a/src/librustc_msan/lib.rs
+++ b/src/librustc_msan/lib.rs
@@ -21,7 +21,10 @@
 
 extern crate alloc_system;
 
+#[cfg(not(stage0))]
 use alloc_system::System;
 
+// The GlobalAllocator trait has changed since stage0
+#[cfg(not(stage0))]
 #[global_allocator]
 static ALLOC: System = System;

--- a/src/librustc_tsan/lib.rs
+++ b/src/librustc_tsan/lib.rs
@@ -21,7 +21,10 @@
 
 extern crate alloc_system;
 
+#[cfg(not(stage0))]
 use alloc_system::System;
 
+// The GlobalAllocator trait has changed since stage0
+#[cfg(not(stage0))]
 #[global_allocator]
 static ALLOC: System = System;

--- a/src/libstd/alloc.rs
+++ b/src/libstd/alloc.rs
@@ -73,6 +73,7 @@ pub extern fn rust_oom(layout: Layout) -> ! {
 #[allow(unused_attributes)]
 pub mod __default_lib_allocator {
     use super::{System, Layout, GlobalAlloc, Opaque};
+    use ptr::{self, NonNull};
     // for symbol names src/librustc/middle/allocator.rs
     // for signatures src/librustc_allocator/lib.rs
 
@@ -83,7 +84,10 @@ pub mod __default_lib_allocator {
     #[rustc_std_internal_symbol]
     pub unsafe extern fn __rdl_alloc(size: usize, align: usize) -> *mut u8 {
         let layout = Layout::from_size_align_unchecked(size, align);
-        System.alloc(layout) as *mut u8
+        match System.alloc(layout) {
+            Ok(p) => p.as_ptr() as *mut u8,
+            Err(_) => ptr::null_mut(),
+        }
     }
 
     #[no_mangle]
@@ -91,7 +95,8 @@ pub mod __default_lib_allocator {
     pub unsafe extern fn __rdl_dealloc(ptr: *mut u8,
                                        size: usize,
                                        align: usize) {
-        System.dealloc(ptr as *mut Opaque, Layout::from_size_align_unchecked(size, align))
+        let layout = Layout::from_size_align_unchecked(size, align);
+        System.dealloc(NonNull::new_unchecked(ptr as *mut Opaque), layout);
     }
 
     #[no_mangle]
@@ -101,13 +106,19 @@ pub mod __default_lib_allocator {
                                        align: usize,
                                        new_size: usize) -> *mut u8 {
         let old_layout = Layout::from_size_align_unchecked(old_size, align);
-        System.realloc(ptr as *mut Opaque, old_layout, new_size) as *mut u8
+        match System.realloc(NonNull::new_unchecked(ptr as *mut Opaque), old_layout, new_size) {
+            Ok(p) => p.as_ptr() as *mut u8,
+            Err(_) => ptr::null_mut(),
+        }
     }
 
     #[no_mangle]
     #[rustc_std_internal_symbol]
     pub unsafe extern fn __rdl_alloc_zeroed(size: usize, align: usize) -> *mut u8 {
         let layout = Layout::from_size_align_unchecked(size, align);
-        System.alloc_zeroed(layout) as *mut u8
+        match System.alloc_zeroed(layout) {
+            Ok(p) => p.as_ptr() as *mut u8,
+            Err(_) => ptr::null_mut(),
+        }
     }
 }

--- a/src/libstd/collections/hash/table.rs
+++ b/src/libstd/collections/hash/table.rs
@@ -1204,7 +1204,7 @@ unsafe impl<#[may_dangle] K, #[may_dangle] V> Drop for RawTable<K, V> {
         debug_assert!(!oflo, "should be impossible");
 
         unsafe {
-            Global.dealloc(NonNull::new_unchecked(self.hashes.ptr()).as_opaque(),
+            Global.dealloc(NonNull::new_unchecked(self.hashes.ptr()).cast(),
                            Layout::from_size_align(size, align).unwrap());
             // Remember how everything was allocated out of one buffer
             // during initialization? We only need one call to free here.

--- a/src/test/run-make-fulldeps/std-core-cycle/bar.rs
+++ b/src/test/run-make-fulldeps/std-core-cycle/bar.rs
@@ -12,15 +12,16 @@
 #![crate_type = "rlib"]
 
 use std::alloc::*;
+use std::ptr::NonNull;
 
 pub struct A;
 
 unsafe impl GlobalAlloc for A {
-    unsafe fn alloc(&self, _: Layout) -> *mut Opaque {
+    unsafe fn alloc(&self, _: Layout) -> Result<NonNull<Opaque>, AllocErr> {
         loop {}
     }
 
-    unsafe fn dealloc(&self, _ptr: *mut Opaque, _: Layout) {
+    unsafe fn dealloc(&self, _ptr: NonNull<Opaque>, _: Layout) {
         loop {}
     }
 }

--- a/src/test/run-pass/allocator/auxiliary/custom.rs
+++ b/src/test/run-pass/allocator/auxiliary/custom.rs
@@ -13,18 +13,19 @@
 #![feature(heap_api, allocator_api)]
 #![crate_type = "rlib"]
 
-use std::alloc::{GlobalAlloc, System, Layout, Opaque};
+use std::alloc::{AllocErr, GlobalAlloc, System, Layout, Opaque};
+use std::ptr::NonNull;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub struct A(pub AtomicUsize);
 
 unsafe impl GlobalAlloc for A {
-    unsafe fn alloc(&self, layout: Layout) -> *mut Opaque {
+    unsafe fn alloc(&self, layout: Layout) -> Result<NonNull<Opaque>, AllocErr> {
         self.0.fetch_add(1, Ordering::SeqCst);
         System.alloc(layout)
     }
 
-    unsafe fn dealloc(&self, ptr: *mut Opaque, layout: Layout) {
+    unsafe fn dealloc(&self, ptr: NonNull<Opaque>, layout: Layout) {
         self.0.fetch_add(1, Ordering::SeqCst);
         System.dealloc(ptr, layout)
     }

--- a/src/test/run-pass/allocator/custom.rs
+++ b/src/test/run-pass/allocator/custom.rs
@@ -15,20 +15,21 @@
 
 extern crate helper;
 
-use std::alloc::{self, Global, Alloc, System, Layout, Opaque};
+use std::alloc::{self, Global, Alloc, AllocErr, System, Layout, Opaque};
 use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::ptr::NonNull;
 
 static HITS: AtomicUsize = ATOMIC_USIZE_INIT;
 
 struct A;
 
 unsafe impl alloc::GlobalAlloc for A {
-    unsafe fn alloc(&self, layout: Layout) -> *mut Opaque {
+    unsafe fn alloc(&self, layout: Layout) -> Result<NonNull<Opaque>, AllocErr> {
         HITS.fetch_add(1, Ordering::SeqCst);
         System.alloc(layout)
     }
 
-    unsafe fn dealloc(&self, ptr: *mut Opaque, layout: Layout) {
+    unsafe fn dealloc(&self, ptr: NonNull<Opaque>, layout: Layout) {
         HITS.fetch_add(1, Ordering::SeqCst);
         System.dealloc(ptr, layout)
     }

--- a/src/test/run-pass/allocator/xcrate-use2.rs
+++ b/src/test/run-pass/allocator/xcrate-use2.rs
@@ -30,21 +30,21 @@ fn main() {
         let layout = Layout::from_size_align(4, 2).unwrap();
 
         // Global allocator routes to the `custom_as_global` global
-        let ptr = Global.alloc(layout.clone());
+        let ptr = Global.alloc(layout.clone()).unwrap();
         helper::work_with(&ptr);
         assert_eq!(custom_as_global::get(), n + 1);
         Global.dealloc(ptr, layout.clone());
         assert_eq!(custom_as_global::get(), n + 2);
 
         // Usage of the system allocator avoids all globals
-        let ptr = System.alloc(layout.clone());
+        let ptr = System.alloc(layout.clone()).unwrap();
         helper::work_with(&ptr);
         assert_eq!(custom_as_global::get(), n + 2);
         System.dealloc(ptr, layout.clone());
         assert_eq!(custom_as_global::get(), n + 2);
 
         // Usage of our personal allocator doesn't affect other instances
-        let ptr = GLOBAL.alloc(layout.clone());
+        let ptr = GLOBAL.alloc(layout.clone()).unwrap();
         helper::work_with(&ptr);
         assert_eq!(custom_as_global::get(), n + 2);
         assert_eq!(GLOBAL.0.load(Ordering::SeqCst), 1);

--- a/src/test/run-pass/realloc-16687.rs
+++ b/src/test/run-pass/realloc-16687.rs
@@ -64,7 +64,7 @@ unsafe fn test_triangle() -> bool {
             println!("deallocate({:?}, {:?}", ptr, layout);
         }
 
-        Global.dealloc(NonNull::new_unchecked(ptr).as_opaque(), layout);
+        Global.dealloc(NonNull::new_unchecked(ptr).cast(), layout);
     }
 
     unsafe fn reallocate(ptr: *mut u8, old: Layout, new: Layout) -> *mut u8 {
@@ -72,7 +72,7 @@ unsafe fn test_triangle() -> bool {
             println!("reallocate({:?}, old={:?}, new={:?})", ptr, old, new);
         }
 
-        let ret = Global.realloc(NonNull::new_unchecked(ptr).as_opaque(), old, new.size())
+        let ret = Global.realloc(NonNull::new_unchecked(ptr).cast(), old, new.size())
             .unwrap_or_else(|_| oom(Layout::from_size_align_unchecked(new.size(), old.align())));
 
         if PRINT {


### PR DESCRIPTION
As discussed with @SimonSapin at Rustfest Paris, this PR makes several changes to `GlobalAlloc`:

- `Opaque` is changed from an extern type to a `u8` newtype (with a private member). This allows `.offset` to work on `*mut Opaque`.
- `GlobalAlloc` signatures are changed to take `NonNull<Opaque>` as parameters and return `Result<NonNull<Opaque>, AllocErr>`. This has the same size as `*mut Opaque` but matches the `Alloc` trait and generally makes it easier to write custom allocators in Rust.

r? @SimonSapin 