### PR TITLE
Revert "Set opt-level to 3"

### DIFF
--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -40,6 +40,14 @@ members = [
   "tools/rls/test_data/workspace_symbol",
 ]
 
+# Curiously, compiletest will segfault if compiled with opt-level=3 on 64-bit
+# MSVC when running the compile-fail test suite when a should-fail test panics.
+# But hey if this is removed and it gets past the bots, sounds good to me.
+[profile.release]
+opt-level = 2
+[profile.bench]
+opt-level = 2
+
 # These options are controlled from our rustc wrapper script, so turn them off
 # here and have them controlled elsewhere.
 [profile.dev]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -40,9 +40,8 @@ members = [
   "tools/rls/test_data/workspace_symbol",
 ]
 
-# Curiously, compiletest will segfault if compiled with opt-level=3 on 64-bit
-# MSVC when running the compile-fail test suite when a should-fail test panics.
-# But hey if this is removed and it gets past the bots, sounds good to me.
+# Curiously, libtest will segfault if compiled with opt-level=3
+# with some versions of XCode: https://github.com/rust-lang/rust/issues/50867
 [profile.release]
 opt-level = 2
 [profile.bench]


### PR DESCRIPTION
This reverts commit aad9840ad49c56830384e87bc8bd87fd0199dc44.

Level 3 (possibly indirectly, the underlying bug might be in XCode’s linker) causes unit tests to sefault when compiled with some versions of XCode: https://github.com/rust-lang/rust/issues/50867

It also appears to cause some segfaults on Windows: https://github.com/rust-lang/rust/pull/50329#issuecomment-386853473, and regressions in some rustc performance benchmarks: https://github.com/rust-lang/rust/pull/50329#issuecomment-388084894