### PR TITLE
Make some std::intrinsics `const fn`s

### DIFF
--- a/src/librustc_mir/interpret/const_eval.rs
+++ b/src/librustc_mir/interpret/const_eval.rs
@@ -593,20 +593,20 @@ pub fn const_eval_provider<'a, 'tcx>(
 
 fn numeric_intrinsic<'tcx>(
     name: &str,
-    bytes: u128,
+    bits: u128,
     kind: Primitive,
 ) -> EvalResult<'tcx, Scalar> {
     let defined = match kind {
         Primitive::Int(integer, _) => integer.size().bits() as u8,
-        _ => bug!("invalid `{}` argument: {:?}", name, bytes),
+        _ => bug!("invalid `{}` argument: {:?}", name, bits),
     };
     let extra = 128 - defined as u128;
-    let bytes_out = match name {
-        "ctpop" => bytes.count_ones() as u128,
-        "ctlz" => bytes.leading_zeros() as u128 - extra,
-        "cttz" => (bytes << extra).trailing_zeros() as u128 - extra,
-        "bswap" => (bytes << extra).swap_bytes(),
+    let bits_out = match name {
+        "ctpop" => bits.count_ones() as u128,
+        "ctlz" => bits.leading_zeros() as u128 - extra,
+        "cttz" => (bits << extra).trailing_zeros() as u128 - extra,
+        "bswap" => (bits << extra).swap_bytes(),
         _ => bug!("not a numeric intrinsic: {}", name),
     };
-    Ok(Scalar::Bits { bits: bytes_out, defined })
+    Ok(Scalar::Bits { bits: bits_out, defined })
 }

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -907,7 +907,15 @@ This does not pose a problem by itself because they can't be accessed directly."
                     Abi::PlatformIntrinsic => {
                         assert!(!self.tcx.is_const_fn(def_id));
                         match &self.tcx.item_name(def_id).as_str()[..] {
-                            "size_of" | "min_align_of" | "type_id" => is_const_fn = Some(def_id),
+                            | "size_of"
+                            | "min_align_of"
+                            | "type_id"
+                            | "bswap"
+                            | "ctpop"
+                            | "cttz"
+                            | "cttz_nonzero"
+                            | "ctlz"
+                            | "ctlz_nonzero" => is_const_fn = Some(def_id),
 
                             name if name.starts_with("simd_shuffle") => {
                                 is_shuffle = true;

--- a/src/test/run-pass/ctfe/bswap-const.rs
+++ b/src/test/run-pass/ctfe/bswap-const.rs
@@ -1,0 +1,23 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(core_intrinsics)]
+
+use std::intrinsics;
+
+const SWAPPED_U8: u8 = unsafe { intrinsics::bswap(0x12_u8) };
+const SWAPPED_U16: u16 = unsafe { intrinsics::bswap(0x12_34_u16) };
+const SWAPPED_I32: i32 = unsafe { intrinsics::bswap(0x12_34_56_78_i32) };
+
+fn main() {
+    assert_eq!(SWAPPED_U8, 0x12);
+    assert_eq!(SWAPPED_U16, 0x34_12);
+    assert_eq!(SWAPPED_I32, 0x78_56_34_12);
+}


### PR DESCRIPTION
Making some rustc intrinsics (`ctpop`, `cttz`, `ctlz` and `bswap`) `const fn`s.

This is a pre-step to being able to make `swap_bytes`, `to_be` and `from_be` constant functions. That in itself could be ergonomic and useful. But even better is that it would allow `Ipv4Addr::new` etc becoming `const fn`s as well. Which might be really useful since I find it quite common to want to define them as constants.

r? @oli-obk 