### PR TITLE
Implement PartialEq between &str and OsString

### DIFF
--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -417,14 +417,14 @@ impl PartialEq<OsString> for str {
     }
 }
 
-#[stable(feature = "rust1", since = "1.28.0")]
+#[stable(feature = "os_str_str_ref_eq", since = "1.28.0")]
 impl<'a> PartialEq<&'a str> for OsString {
     fn eq(&self, other: &&'a str) -> bool {
         **self == **other
     }
 }
 
-#[stable(feature = "rust1", since = "1.28.0")]
+#[stable(feature = "os_str_str_ref_eq", since = "1.28.0")]
 impl<'a> PartialEq<OsString> for &'a str {
     fn eq(&self, other: &OsString) -> bool {
         **other == **self

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -417,6 +417,20 @@ impl PartialEq<OsString> for str {
     }
 }
 
+#[stable(feature = "rust1", since = "1.28.0")]
+impl<'a> PartialEq<&'a str> for OsString {
+    fn eq(&self, other: &&'a str) -> bool {
+        **self == **other
+    }
+}
+
+#[stable(feature = "rust1", since = "1.28.0")]
+impl<'a> PartialEq<OsString> for &'a str {
+    fn eq(&self, other: &OsString) -> bool {
+        **other == **self
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Eq for OsString {}
 

--- a/src/test/run-pass/issue-49854.rs
+++ b/src/test/run-pass/issue-49854.rs
@@ -1,0 +1,18 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::ffi::OsString;
+
+fn main() {
+    let os_str = OsString::from("Hello Rust!");
+
+    assert_eq!(os_str, "Hello Rust!");
+    assert_eq!("Hello Rust!", os_str);
+}


### PR DESCRIPTION
This fixes #49854.

It allows equality comparison between `OsString` values and `str` references, such as `os_string == "something"`.