### PR TITLE
Pass -lfoo to linker rather than -l foo.

### DIFF
--- a/src/librustc_codegen_llvm/back/linker.rs
+++ b/src/librustc_codegen_llvm/back/linker.rs
@@ -159,6 +159,15 @@ impl<'a> GccLinker<'a> {
         self
     }
 
+    fn add_lib<S>(&mut self, lib: S) -> &mut Self
+        where S: AsRef<OsStr>
+    {
+        let mut os = OsString::from("-l");
+        os.push(lib.as_ref());
+        self.cmd.arg(os);
+        self
+    }
+
     fn takes_hints(&self) -> bool {
         !self.sess.target.target.options.is_like_osx
     }
@@ -185,8 +194,8 @@ impl<'a> GccLinker<'a> {
 }
 
 impl<'a> Linker for GccLinker<'a> {
-    fn link_dylib(&mut self, lib: &str) { self.hint_dynamic(); self.cmd.arg("-l").arg(lib); }
-    fn link_staticlib(&mut self, lib: &str) { self.hint_static(); self.cmd.arg("-l").arg(lib); }
+    fn link_dylib(&mut self, lib: &str) { self.hint_dynamic(); self.add_lib(lib); }
+    fn link_staticlib(&mut self, lib: &str) { self.hint_static(); self.add_lib(lib); }
     fn link_rlib(&mut self, lib: &Path) { self.hint_static(); self.cmd.arg(lib); }
     fn include_path(&mut self, path: &Path) { self.cmd.arg("-L").arg(path); }
     fn framework_path(&mut self, path: &Path) { self.cmd.arg("-F").arg(path); }
@@ -202,7 +211,7 @@ impl<'a> Linker for GccLinker<'a> {
 
     fn link_rust_dylib(&mut self, lib: &str, _path: &Path) {
         self.hint_dynamic();
-        self.cmd.arg("-l").arg(lib);
+        self.add_lib(lib);
     }
 
     fn link_framework(&mut self, framework: &str) {
@@ -238,7 +247,7 @@ impl<'a> Linker for GccLinker<'a> {
             v.push(lib);
             self.linker_arg(&v);
         } else {
-            self.linker_arg("--whole-archive").cmd.arg(lib);
+            self.linker_arg("--whole-archive").add_lib(lib);
             self.linker_arg("--no-whole-archive");
         }
     }

--- a/src/librustc_codegen_llvm/back/linker.rs
+++ b/src/librustc_codegen_llvm/back/linker.rs
@@ -159,9 +159,7 @@ impl<'a> GccLinker<'a> {
         self
     }
 
-    fn add_lib<S>(&mut self, lib: S) -> &mut Self
-        where S: AsRef<OsStr>
-    {
+    fn add_lib(&mut self, lib: &str) -> &mut Self {
         let mut os = OsString::from("-l");
         os.push(lib.as_ref());
         self.cmd.arg(os);
@@ -229,7 +227,7 @@ impl<'a> Linker for GccLinker<'a> {
         self.hint_static();
         let target = &self.sess.target.target;
         if !target.options.is_like_osx {
-            self.linker_arg("--whole-archive").cmd.arg("-l").arg(lib);
+            self.linker_arg("--whole-archive").add_lib(lib);
             self.linker_arg("--no-whole-archive");
         } else {
             // -force_load is the macOS equivalent of --whole-archive, but it
@@ -247,7 +245,7 @@ impl<'a> Linker for GccLinker<'a> {
             v.push(lib);
             self.linker_arg(&v);
         } else {
-            self.linker_arg("--whole-archive").add_lib(lib);
+            self.linker_arg("--whole-archive").cmd.arg(lib);
             self.linker_arg("--no-whole-archive");
         }
     }


### PR DESCRIPTION
When invoking the linker and trying to link against a specific library, rustc currently passes `-l foo` as two separate arguments, rather than the more common syntax `-lfoo`.  GCC, Clang, and GNU ld all support `-l foo`, but Darwin ld64 does not.  By default, rustc currently uses the C compiler as its linker on all platforms (other than wasm), so it passes `-l foo` to `clang`, which then transforms it to `-lfoo` when invoking `ld`.  However, if you try to pass `-C linker=ld` – or, more usefully, `-C linker=ld64.lld` – it gets confused.  Since `-lfoo` is the preferred form on all Unix platforms, use it everywhere.

As a side benefit, this makes printed linker command lines significantly more succinct, given that rustc wraps every argument in quotes, so you currently get things like `"-l" "System" "-l" "resolv" "-l" "pthread" "-l" "c" "-l" "m"`.  (Of course, this could be improved further by omitting the quotes entirely for arguments that don't contain spaces.)

This PR is simply a plagiarized subset of PR #46255, written by tamird, which @alexcrichton requested to be deferred until #48125 landed – something that's since happened.  Actually, everything in that PR seems necessary for linking using `ld64` directly to work *properly*, but since I'm not the original author, I'm too lazy to convince myself that it's all correct.  Landing this by itself will at least make some basic cases work.