### PR TITLE
Remove unnecessary empty checking in imported_filemaps

### DIFF
--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -1148,12 +1148,6 @@ impl<'a, 'tcx> CrateMetadata {
 
         // Lock the codemap_import_info to ensure this only happens once
         let mut codemap_import_info = self.codemap_import_info.borrow_mut();
-
-        if !codemap_import_info.is_empty() {
-            drop(codemap_import_info);
-            return self.codemap_import_info.borrow();
-        }
-
         let external_codemap = self.root.codemap.decode(self);
 
         let imported_filemaps = external_codemap.map(|filemap_to_import| {


### PR DESCRIPTION
This isn't really a big deal, but there's an unnecessary check for `is_empty` as it is already covered here: https://github.com/whitfin/rust/blob/3e56e9b1fe2275d3ea2e48221fc0c9c4d37df67d/src/librustc_metadata/decoder.rs#L1142-L1147 (if you expand the diff upwards one block, you'll see it too).

