### PR TITLE
[WIP] Implement RFC 1260

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -481,6 +481,46 @@ fn main() {
 ```
 "##,
 
+E0134: r##"
+More than one item was re-exported as `main`.
+
+Erroneous code example:
+
+```compile_fail,E0134
+#![feature(main_reexport)]
+
+mod foo {
+    pub fn bar() { }
+    pub fn baz() { }
+}
+
+use foo::bar as main;
+use foo::baz as main;
+```
+
+This error indicates that the compiler found multiple items re-exported as
+`main`. This is an error because there must be a unique entry point into a
+Rust program.
+"##,
+
+E0135: r##"
+The item re-exported as `main` is not a function.
+
+Erroneous code example:
+
+```compile_fail,E0135
+#![feature(main_reexport)]
+
+mod foo {
+    pub const bar: &'static str = "hello";
+}
+
+use foo::bar as main;
+```
+
+This is an error because the entry point of a Rust program must be a function.
+"##,
+
 // This shouldn't really ever trigger since the repeated value error comes first
 E0136: r##"
 A binary can only have one entry point, and by default that entry point is the

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -70,7 +70,7 @@ pub struct Session {
     pub opts: config::Options,
     pub parse_sess: ParseSess,
     /// For a library crate, this is always none
-    pub entry_fn: Once<Option<(NodeId, Span, config::EntryFnType)>>,
+    pub entry_fn: Once<Option<config::EntryFnType>>,
     pub plugin_registrar_fn: Once<Option<ast::NodeId>>,
     pub derive_registrar_fn: Once<Option<ast::NodeId>>,
     pub default_sysroot: Option<PathBuf>,

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -262,13 +262,10 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CodegenCx<'a, 'tcx>,
     let mut flags = DIFlags::FlagPrototyped;
 
     let local_id = cx.tcx.hir.as_local_node_id(def_id);
-    match *cx.sess().entry_fn.borrow() {
-        Some((id, _, _)) => {
-            if local_id == Some(id) {
-                flags = flags | DIFlags::FlagMainSubprogram;
-            }
+    if let Some(e) = cx.sess().entry_fn.borrow() {
+        if local_id == Some(e.get_local_id()) {
+            flags = flags | DIFlags::FlagMainSubprogram;
         }
-        None => {}
     };
     if cx.layout_of(sig.output()).abi == ty::layout::Abi::Uninhabited {
         flags = flags | DIFlags::FlagNoReturn;

--- a/src/librustc_codegen_utils/lib.rs
+++ b/src/librustc_codegen_utils/lib.rs
@@ -51,11 +51,11 @@ pub mod symbol_names_test;
 /// that actually test that compilation succeeds without
 /// reporting an error.
 pub fn check_for_rustc_errors_attr(tcx: TyCtxt) {
-    if let Some((id, span, _)) = *tcx.sess.entry_fn.borrow() {
-        let main_def_id = tcx.hir.local_def_id(id);
+    if let Some(entry) = tcx.sess.entry_fn.borrow() {
+        let main_def_id = entry.get_def_id(&tcx.hir);
 
         if tcx.has_attr(main_def_id, "rustc_error") {
-            tcx.sess.span_fatal(span, "compilation successful");
+            tcx.sess.span_fatal(entry.get_span(), "compilation successful");
         }
     }
 }

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -12,7 +12,7 @@
 //! ===========================
 //!
 //! This module is responsible for discovering all items that will contribute to
-//! to code generation of the crate. The important part here is that it not only
+//! code generation of the crate. The important part here is that it not only
 //! needs to find syntax-level items (functions, structs, etc) but also all
 //! their monomorphized instantiations. Every non-generic, non-const function
 //! maps to one LLVM artifact. Every generic function can produce
@@ -325,8 +325,8 @@ fn collect_roots<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let mut roots = Vec::new();
 
     {
-        let entry_fn = tcx.sess.entry_fn.borrow().map(|(node_id, _, _)| {
-            tcx.hir.local_def_id(node_id)
+        let entry_fn = tcx.sess.entry_fn.borrow().as_ref().map(|entry|{
+            entry.get_def_id(&tcx.hir)
         });
 
         debug!("collect_roots: entry_fn = {:?}", entry_fn);
@@ -1038,8 +1038,8 @@ impl<'b, 'a, 'v> RootCollector<'b, 'a, 'v> {
     /// the return type of `main`. This is not needed when
     /// the user writes their own `start` manually.
     fn push_extra_entry_roots(&mut self) {
-        if self.tcx.sess.entry_fn.get().map(|e| e.2) != Some(config::EntryMain) {
-            return
+        if let Some(config::EntryStart(..)) = self.tcx.sess.entry_fn.get() {
+            return;
         }
 
         let main_def_id = if let Some(def_id) = self.entry_fn {

--- a/src/librustc_mir/monomorphize/item.rs
+++ b/src/librustc_mir/monomorphize/item.rs
@@ -92,7 +92,9 @@ pub trait MonoItemExt<'a, 'tcx>: fmt::Debug {
         match *self.as_mono_item() {
             MonoItem::Fn(ref instance) => {
                 let entry_def_id =
-                    tcx.sess.entry_fn.borrow().map(|(id, _, _)| tcx.hir.local_def_id(id));
+                    tcx.sess.entry_fn.borrow().as_ref().map(|entry|{
+                        entry.get_def_id(&tcx.hir)
+                    });
                 // If this function isn't inlined or otherwise has explicit
                 // linkage, then we'll be creating a globally shared version.
                 if self.explicit_linkage(tcx).is_some() ||

--- a/src/librustc_resolve/check_unused.rs
+++ b/src/librustc_resolve/check_unused.rs
@@ -85,9 +85,16 @@ impl<'a, 'b> Visitor<'a> for UnusedImportCheckVisitor<'a, 'b> {
         // whether they're used or not. Also ignore imports with a dummy span
         // because this means that they were generated in some fashion by the
         // compiler and we don't need to consider them.
-        if let ast::ItemKind::Use(..) = item.node {
-            if item.vis.node == ast::VisibilityKind::Public || item.span.source_equal(&DUMMY_SP) {
+        if let ast::ItemKind::Use(ref tree) = item.node {
+            if item.vis.node == ast::VisibilityKind::Public ||
+               item.span.source_equal(&DUMMY_SP) {
                 return;
+            }
+            // And ignore the item imported as "main".
+            if let ast::UseTreeKind::Simple(Some(ident)) = tree.kind {
+                if ident.name == "main" {
+                    return;
+                }
             }
         }
 

--- a/src/librustc_typeck/check_unused.rs
+++ b/src/librustc_typeck/check_unused.rs
@@ -47,7 +47,7 @@ impl<'a, 'tcx> CheckVisitor<'a, 'tcx> {
 
 impl<'a, 'tcx, 'v> ItemLikeVisitor<'v> for CheckVisitor<'a, 'tcx> {
     fn visit_item(&mut self, item: &hir::Item) {
-        if item.vis == hir::Public || item.span == DUMMY_SP {
+        if item.vis == hir::Public || item.span == DUMMY_SP || item.name == "main" {
             return;
         }
         if let hir::ItemUse(ref path, _) = item.node {

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -1544,6 +1544,18 @@ fn my_start(argc: isize, argv: *const *const u8) -> isize {
 ```
 "##,
 
+E0133: r##"
+A function exported as `main` was declared with type parameters.
+
+Erroneous code example:
+
+```compile_fail,E0133
+#![feature(main_reexport)]
+
+
+```
+"##,
+
 E0164: r##"
 This error means that an attempt was made to match a struct type enum
 variant as a non-struct type:

--- a/src/libsyntax/entry.rs
+++ b/src/libsyntax/entry.rs
@@ -16,11 +16,10 @@ pub enum EntryPointType {
     MainNamed,
     MainAttr,
     Start,
+    Import,
     OtherMain, // Not an entry point, but some other function named main
 }
 
-// Beware, this is duplicated in librustc/middle/entry.rs, make sure to keep
-// them in sync.
 pub fn entry_point_type(item: &Item, depth: usize) -> EntryPointType {
     match item.node {
         ItemKind::Fn(..) => {
@@ -32,6 +31,17 @@ pub fn entry_point_type(item: &Item, depth: usize) -> EntryPointType {
                 if depth == 1 {
                     // This is a top-level function so can be 'main'
                     EntryPointType::MainNamed
+                } else {
+                    EntryPointType::OtherMain
+                }
+            } else {
+                EntryPointType::None
+            }
+        }
+        ItemKind::Use(..) => {
+            if item.ident.name == "main" {
+                if depth == 1 {
+                    EntryPointType::Import
                 } else {
                     EntryPointType::OtherMain
                 }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -475,6 +475,9 @@ declare_features! (
 
     // 'a: { break 'a; }
     (active, label_break_value, "1.28.0", Some(48594), None),
+
+    // Allow a re-export of a function as entry point `main`.
+    (active, main_reexport, "1.28.0", Some(28937), None),
 );
 
 declare_features! (

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -219,6 +219,7 @@ impl fold::Folder for EntryPointCleaner {
                     }
                 }),
             EntryPointType::None |
+            EntryPointType::Import |
             EntryPointType::OtherMain => folded,
         };
 

--- a/src/test/ui/rfc-1260-main-reexport/generic-fn.rs
+++ b/src/test/ui/rfc-1260-main-reexport/generic-fn.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(main_reexport)]
+
+mod foo {
+    use std::mem::size_of;
+    pub fn bar<T>() { //~ ERROR
+        println!("{}", size_of::<T>());
+    }
+}
+
+use foo::bar as main;

--- a/src/test/ui/rfc-1260-main-reexport/generic-fn.stderr
+++ b/src/test/ui/rfc-1260-main-reexport/generic-fn.stderr
@@ -1,0 +1,9 @@
+error[E0131]: `main` function is not allowed to have type parameters
+  --> $DIR/generic-fn.rs:15:15
+   |
+LL |     pub fn bar<T>() { //~ ERROR
+   |               ^^^ `main` cannot have type parameters
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0131`.

--- a/src/test/ui/rfc-1260-main-reexport/nested-re-export.rs
+++ b/src/test/ui/rfc-1260-main-reexport/nested-re-export.rs
@@ -1,0 +1,24 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-pass
+
+#![feature(main_reexport)]
+
+mod foo {
+    pub use self::foo1::bar;
+    mod foo1 {
+        pub fn bar() {
+            println!("Re-exported fn.");
+        }
+    }
+}
+
+use foo::bar as main;

--- a/src/test/ui/rfc-1260-main-reexport/not-an-fn.rs
+++ b/src/test/ui/rfc-1260-main-reexport/not-an-fn.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(main_reexport)]
+
+mod foo {
+    pub const bar: &'static str = "hello";
+}
+
+use foo::bar as main;  //~ ERROR

--- a/src/test/ui/rfc-1260-main-reexport/not-an-fn.stderr
+++ b/src/test/ui/rfc-1260-main-reexport/not-an-fn.stderr
@@ -1,0 +1,14 @@
+error[E0135]: The item re-exported as `main` is not a function
+  --> $DIR/not-an-fn.rs:17:1
+   |
+LL | use foo::bar as main;  //~ ERROR
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0601]: `main` function not found in crate `not_an_fn`
+   |
+   = note: consider adding a `main` function to `$DIR/not-an-fn.rs`
+
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0135, E0601.
+For more information about an error, try `rustc --explain E0135`.

--- a/src/test/ui/rfc-1260-main-reexport/re-export.rs
+++ b/src/test/ui/rfc-1260-main-reexport/re-export.rs
@@ -1,0 +1,21 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-pass
+
+#![feature(main_reexport)]
+
+mod foo {
+    pub fn bar() {
+        println!("Re-exported fn.");
+    }
+}
+
+use foo::bar as main;

--- a/src/test/ui/rfc-1260-main-reexport/termination.rs
+++ b/src/test/ui/rfc-1260-main-reexport/termination.rs
@@ -1,0 +1,25 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-pass
+
+#![feature(main_reexport)]
+#![feature(process_exitcode_placeholder)]
+#![feature(termination_trait_lib)]
+
+mod foo {
+    use std::process::ExitCode;
+
+    pub fn bar() -> ExitCode {
+        return ExitCode::SUCCESS;
+    }
+}
+
+use foo::bar as main;

--- a/src/test/ui/rfc-1260-main-reexport/with-args-fn.rs
+++ b/src/test/ui/rfc-1260-main-reexport/with-args-fn.rs
@@ -1,0 +1,19 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(main_reexport)]
+
+mod foo {
+    pub fn bar(value: i32) {
+        println!("{}", value);
+    }
+}
+
+use foo::bar as main;  //~ ERROR

--- a/src/test/ui/rfc-1260-main-reexport/with-args-fn.stderr
+++ b/src/test/ui/rfc-1260-main-reexport/with-args-fn.stderr
@@ -1,0 +1,12 @@
+error[E0580]: main function has wrong type
+  --> $DIR/with-args-fn.rs:19:1
+   |
+LL | use foo::bar as main;  //~ ERROR
+   | ^^^^^^^^^^^^^^^^^^^^^ incorrect number of function parameters
+   |
+   = note: expected type `fn()`
+              found type `fn(i32)`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0580`.


### PR DESCRIPTION
This is my in-progress work to implement RFC 1260: main_reexport. 

Tracking issue: https://github.com/rust-lang/rust/issues/28937

There is a known problem that, I have no idea how to get the foreign function's signature if it is imported from another crate. Thus, the type check for this case is not done yet. I'd appreciate it if someone can provide some helps.