### PR TITLE
reset anonymous-lifetime-mode as we enter `()` scopes

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1033,17 +1033,22 @@ impl<'a> LoweringContext<'a> {
                     _ => None,
                 }),
                 |this| {
-                    hir::TyBareFn(P(hir::BareFnTy {
-                        generic_params: this.lower_generic_params(
-                            &f.generic_params,
-                            &NodeMap(),
-                            ImplTraitContext::Disallowed,
-                        ),
-                        unsafety: this.lower_unsafety(f.unsafety),
-                        abi: f.abi,
-                        decl: this.lower_fn_decl(&f.decl, None, false),
-                        arg_names: this.lower_fn_args_to_names(&f.decl),
-                    }))
+                    this.with_anonymous_lifetime_mode(
+                        AnonymousLifetimeMode::PassThrough,
+                        |this| {
+                            hir::TyBareFn(P(hir::BareFnTy {
+                                generic_params: this.lower_generic_params(
+                                    &f.generic_params,
+                                    &NodeMap(),
+                                    ImplTraitContext::Disallowed,
+                                ),
+                                unsafety: this.lower_unsafety(f.unsafety),
+                                abi: f.abi,
+                                decl: this.lower_fn_decl(&f.decl, None, false),
+                                arg_names: this.lower_fn_args_to_names(&f.decl),
+                            }))
+                        },
+                    )
                 },
             ),
             TyKind::Never => hir::TyNever,

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -101,6 +101,13 @@ impl Region {
         let depth = ty::DebruijnIndex::INNERMOST;
         let def_id = hir_map.local_def_id(def.lifetime.id);
         let origin = LifetimeDefOrigin::from_is_in_band(def.in_band);
+        debug!(
+            "Region::late: def={:?} depth={:?} def_id={:?} origin={:?}",
+            def,
+            depth,
+            def_id,
+            origin,
+        );
         (def.lifetime.name, Region::LateBound(depth, def_id, origin))
     }
 

--- a/src/test/ui/rust-2018/issue-51008-1.rs
+++ b/src/test/ui/rust-2018/issue-51008-1.rs
@@ -1,0 +1,25 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for #51008 -- the anonymous lifetime in `&i32` was
+// being incorrectly considered part of the "elided lifetimes" from
+// the impl.
+//
+// run-pass
+
+#![feature(rust_2018_preview)]
+
+trait A {
+
+}
+
+impl<F> A for F where F: PartialEq<fn(&i32)> { }
+
+fn main() {}

--- a/src/test/ui/rust-2018/issue-51008.rs
+++ b/src/test/ui/rust-2018/issue-51008.rs
@@ -1,0 +1,25 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for #51008 -- the anonymous lifetime in `&i32` was
+// being incorrectly considered part of the "elided lifetimes" from
+// the impl.
+//
+// run-pass
+
+#![feature(rust_2018_preview)]
+
+trait A {
+
+}
+
+impl<F> A for F where F: FnOnce(&i32) {}
+
+fn main() {}


### PR DESCRIPTION
Background:

The anonymous lifetime mode is used to prohibit elided lifetimes where
they didn't used to be permitted, and instead require that `'_` be
used. For example:

```rust
impl Trait for Ref<T> { .. }
//             ^^^^^^ ERROR: should be `Ref<'_, T>`
```

When we are parsing the parts of the impl header, we enter into an alternate mode called `CreateParameter`. In this mode, we give an error for things like `Ref<T>`, but for elided lifetimes in a reference type like `&T` we make the elided lifetime into an in-band lifetime:

https://github.com/rust-lang/rust/blob/4f99f37b7e213d69a489884f651adfc6d217cef5/src/librustc/hir/lowering.rs#L4017-L4035

This was not intended to change behavior because we only enter into that mode in contexts where elision was not historically permitted. However, the problem is that we fail to reset the mode when we enter into bounds like `Fn(&u32)`, where elision *was* allowed -- the same occurs for fn types like `fn(&u32`). This PR restores the original mode in those contexts.

Fixes #51008

r? @cramertj 