### PR TITLE
Make Layout's align a NonZeroUsize

### DIFF
--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -204,9 +204,6 @@ impl Layout {
     /// satisfy this constraint is to ensure `align <= self.align()`.
     #[inline]
     pub fn padding_needed_for(&self, align: usize) -> usize {
-        // **FIXME**: This function is only called with proper power-of-two
-        // alignments. Maybe we should turn this into a real assert!.
-        debug_assert!(align.is_power_of_two());
         let len = self.size();
 
         // Rounded up value is:


### PR DESCRIPTION
This PR makes the `Layout`'s align field a `NonZeroUsize` since it cannot ever be zero, not even while building a `Layout`. It also contains some drive-by minor cleanups over the docs and the code, like updating the documented error types, or using the `size()` and `align()` methods instead of accessing the fields directly (the latter was required for the `NonZeroUsize` change anyways).

r? @SimonSapin 

cc @Amanieu 