### PR TITLE
Disable LLVM verification by default

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -356,6 +356,9 @@
 # Print backtrace on internal compiler errors during bootstrap
 #backtrace-on-ice = false
 
+# Whether to verify generated LLVM IR
+#verify-llvm-ir = false
+
 # =============================================================================
 # Options for specific targets
 #

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -283,6 +283,10 @@ fn main() {
         cmd.arg("--cfg").arg("parallel_queries");
     }
 
+    if env::var_os("RUSTC_VERIFY_LLVM_IR").is_some() {
+        cmd.arg("-Z").arg("verify-llvm-ir");
+    }
+
     let color = match env::var("RUSTC_COLOR") {
         Ok(s) => usize::from_str(&s).expect("RUSTC_COLOR should be an integer"),
         Err(_) => 0,

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -898,6 +898,10 @@ impl<'a> Builder<'a> {
             cargo.env("RUSTC_BACKTRACE_ON_ICE", "1");
         }
 
+        if self.config.rust_verify_llvm_ir {
+            cargo.env("RUSTC_VERIFY_LLVM_IR", "1");
+        }
+
         cargo.env("RUSTC_VERBOSE", format!("{}", self.verbosity));
 
         // in std, we want to avoid denying warnings for stage 0 as that makes cfg's painful.

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -105,6 +105,7 @@ pub struct Config {
     pub rust_dist_src: bool,
     pub rust_codegen_backends: Vec<Interned<String>>,
     pub rust_codegen_backends_dir: String,
+    pub rust_verify_llvm_ir: bool,
 
     pub build: Interned<String>,
     pub hosts: Vec<Interned<String>>,
@@ -311,6 +312,7 @@ struct Rust {
     lld: Option<bool>,
     deny_warnings: Option<bool>,
     backtrace_on_ice: Option<bool>,
+    verify_llvm_ir: Option<bool>,
 }
 
 /// TOML representation of how each build target is configured.
@@ -542,6 +544,7 @@ impl Config {
             config.save_toolstates = rust.save_toolstates.clone().map(PathBuf::from);
             set(&mut config.deny_warnings, rust.deny_warnings.or(flags.warnings));
             set(&mut config.backtrace_on_ice, rust.backtrace_on_ice);
+            set(&mut config.rust_verify_llvm_ir, rust.verify_llvm_ir);
 
             if let Some(ref backends) = rust.codegen_backends {
                 config.rust_codegen_backends = backends.iter()

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1152,8 +1152,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
         "gather codegen statistics"),
     asm_comments: bool = (false, parse_bool, [TRACKED],
         "generate comments into the assembly (may change behavior)"),
-    no_verify: bool = (false, parse_bool, [TRACKED],
-        "skip LLVM verification"),
+    verify_llvm_ir: bool = (false, parse_bool, [TRACKED],
+        "verify LLVM IR"),
     borrowck_stats: bool = (false, parse_bool, [UNTRACKED],
         "gather borrowck statistics"),
     no_landing_pads: bool = (false, parse_bool, [TRACKED],
@@ -3097,7 +3097,7 @@ mod tests {
         assert!(reference.dep_tracking_hash() != opts.dep_tracking_hash());
 
         opts = reference.clone();
-        opts.debugging_opts.no_verify = true;
+        opts.debugging_opts.verify_llvm_ir = true;
         assert!(reference.dep_tracking_hash() != opts.dep_tracking_hash());
 
         opts = reference.clone();

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -513,8 +513,8 @@ impl Session {
     pub fn asm_comments(&self) -> bool {
         self.opts.debugging_opts.asm_comments
     }
-    pub fn no_verify(&self) -> bool {
-        self.opts.debugging_opts.no_verify
+    pub fn verify_llvm_ir(&self) -> bool {
+        self.opts.debugging_opts.verify_llvm_ir
     }
     pub fn borrowck_stats(&self) -> bool {
         self.opts.debugging_opts.borrowck_stats

--- a/src/librustc_codegen_llvm/back/lto.rs
+++ b/src/librustc_codegen_llvm/back/lto.rs
@@ -461,9 +461,12 @@ fn run_pass_manager(cgcx: &CodegenContext,
     unsafe {
         let pm = llvm::LLVMCreatePassManager();
         llvm::LLVMRustAddAnalysisPasses(tm, pm, llmod);
-        let pass = llvm::LLVMRustFindAndCreatePass("verify\0".as_ptr() as *const _);
-        assert!(!pass.is_null());
-        llvm::LLVMRustAddPass(pm, pass);
+
+        if !config.no_verify {
+            let pass = llvm::LLVMRustFindAndCreatePass("verify\0".as_ptr() as *const _);
+            assert!(!pass.is_null());
+            llvm::LLVMRustAddPass(pm, pass);
+        }
 
         // When optimizing for LTO we don't actually pass in `-O0`, but we force
         // it to always happen at least with `-O1`.
@@ -494,9 +497,11 @@ fn run_pass_manager(cgcx: &CodegenContext,
             }
         });
 
-        let pass = llvm::LLVMRustFindAndCreatePass("verify\0".as_ptr() as *const _);
-        assert!(!pass.is_null());
-        llvm::LLVMRustAddPass(pm, pass);
+        if !config.no_verify {
+            let pass = llvm::LLVMRustFindAndCreatePass("verify\0".as_ptr() as *const _);
+            assert!(!pass.is_null());
+            llvm::LLVMRustAddPass(pm, pass);
+        }
 
         time_ext(cgcx.time_passes, None, "LTO passes", ||
              llvm::LLVMRunPassManager(pm, llmod));

--- a/src/librustc_codegen_llvm/back/lto.rs
+++ b/src/librustc_codegen_llvm/back/lto.rs
@@ -462,7 +462,7 @@ fn run_pass_manager(cgcx: &CodegenContext,
         let pm = llvm::LLVMCreatePassManager();
         llvm::LLVMRustAddAnalysisPasses(tm, pm, llmod);
 
-        if !config.no_verify {
+        if config.verify_llvm_ir {
             let pass = llvm::LLVMRustFindAndCreatePass("verify\0".as_ptr() as *const _);
             assert!(!pass.is_null());
             llvm::LLVMRustAddPass(pm, pass);
@@ -497,7 +497,7 @@ fn run_pass_manager(cgcx: &CodegenContext,
             }
         });
 
-        if !config.no_verify {
+        if config.verify_llvm_ir {
             let pass = llvm::LLVMRustFindAndCreatePass("verify\0".as_ptr() as *const _);
             assert!(!pass.is_null());
             llvm::LLVMRustAddPass(pm, pass);

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -232,7 +232,7 @@ pub struct ModuleConfig {
     emit_obj: bool,
     // Miscellaneous flags.  These are mostly copied from command-line
     // options.
-    pub no_verify: bool,
+    pub verify_llvm_ir: bool,
     no_prepopulate_passes: bool,
     no_builtins: bool,
     time_passes: bool,
@@ -271,7 +271,7 @@ impl ModuleConfig {
             embed_bitcode_marker: false,
             no_integrated_as: false,
 
-            no_verify: false,
+            verify_llvm_ir: false,
             no_prepopulate_passes: false,
             no_builtins: false,
             time_passes: false,
@@ -283,7 +283,7 @@ impl ModuleConfig {
     }
 
     fn set_flags(&mut self, sess: &Session, no_builtins: bool) {
-        self.no_verify = sess.no_verify();
+        self.verify_llvm_ir = sess.verify_llvm_ir();
         self.no_prepopulate_passes = sess.opts.cg.no_prepopulate_passes;
         self.no_builtins = no_builtins || sess.target.target.options.no_builtins;
         self.time_passes = sess.time_passes();
@@ -542,7 +542,7 @@ unsafe fn optimize(cgcx: &CodegenContext,
             true
         };
 
-        if !config.no_verify { assert!(addpass("verify")); }
+        if config.verify_llvm_ir { assert!(addpass("verify")); }
         if !config.no_prepopulate_passes {
             llvm::LLVMRustAddAnalysisPasses(tm, fpm, llmod);
             llvm::LLVMRustAddAnalysisPasses(tm, mpm, llmod);

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -232,7 +232,7 @@ pub struct ModuleConfig {
     emit_obj: bool,
     // Miscellaneous flags.  These are mostly copied from command-line
     // options.
-    no_verify: bool,
+    pub no_verify: bool,
     no_prepopulate_passes: bool,
     no_builtins: bool,
     time_passes: bool,


### PR DESCRIPTION
Currently -Z no-verify only controls IR verification prior to LLVM codegen, while verification is performed unconditionally both before and after linking with (Thin)LTO.

Also wondering what the sentiment is on disabling verification by default (and e.g. only enabling it on ALT builds with assertions). This does not seem terribly useful outside of rustc development and it does seem to show up in profiles (at something like 3%).

**EDIT:** A table showing the various configurations and what is enabled when.

| Configuration | Dynamic verification performed | LLVM static assertions compiled in |
| --- | --- | --- |
| alt builds | | yes |
| nightly builds | | no |
| stable builds | | no |
| CI builds | | |
| dev builds in a checkout | | |