### PR TITLE
Ignore test files on powerpc64* that's already ignored on powerpc

### DIFF
--- a/src/test/codegen/stack-probes.rs
+++ b/src/test/codegen/stack-probes.rs
@@ -13,6 +13,8 @@
 // ignore-mips
 // ignore-mips64
 // ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
 // ignore-s390x
 // ignore-wasm
 // ignore-emscripten

--- a/src/test/compile-fail/asm-bad-clobber.rs
+++ b/src/test/compile-fail/asm-bad-clobber.rs
@@ -14,6 +14,8 @@
 // ignore-s390x
 // ignore-emscripten
 // ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
 // ignore-sparc
 // ignore-mips
 // ignore-mips64

--- a/src/test/compile-fail/asm-in-bad-modifier.rs
+++ b/src/test/compile-fail/asm-in-bad-modifier.rs
@@ -11,6 +11,8 @@
 // ignore-s390x
 // ignore-emscripten
 // ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
 // ignore-sparc
 // ignore-mips
 // ignore-mips64

--- a/src/test/compile-fail/asm-misplaced-option.rs
+++ b/src/test/compile-fail/asm-misplaced-option.rs
@@ -14,6 +14,8 @@
 // ignore-s390x
 // ignore-emscripten
 // ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
 // ignore-sparc
 // ignore-mips
 // ignore-mips64

--- a/src/test/compile-fail/asm-out-no-modifier.rs
+++ b/src/test/compile-fail/asm-out-no-modifier.rs
@@ -11,6 +11,8 @@
 // ignore-s390x
 // ignore-emscripten
 // ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
 // ignore-sparc
 // ignore-mips
 // ignore-mips64

--- a/src/test/compile-fail/asm-out-read-uninit.rs
+++ b/src/test/compile-fail/asm-out-read-uninit.rs
@@ -11,6 +11,8 @@
 // ignore-s390x
 // ignore-emscripten
 // ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
 // ignore-sparc
 // ignore-mips
 // ignore-mips64

--- a/src/test/compile-fail/borrowck/borrowck-asm.rs
+++ b/src/test/compile-fail/borrowck/borrowck-asm.rs
@@ -11,6 +11,8 @@
 // ignore-s390x
 // ignore-emscripten
 // ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
 // ignore-sparc
 
 // revisions: ast mir

--- a/src/test/ui/asm-out-assign-imm.rs
+++ b/src/test/ui/asm-out-assign-imm.rs
@@ -11,6 +11,8 @@
 // ignore-s390x
 // ignore-emscripten
 // ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
 // ignore-sparc
 // ignore-mips
 


### PR DESCRIPTION
Fixes #50989.

The ignore-checker was made more strict recently so we now need more explicit ones
