### PR TITLE
Select Polonius algorithm via `POLONIUS_ALGORITHM` environment variable

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1456,10 +1456,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "polonius-engine"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "datafrog 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1785,7 +1786,7 @@ dependencies = [
  "jobserver 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "polonius-engine 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "polonius-engine 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc_macro 0.0.0",
  "rustc_apfloat 0.0.0",
  "rustc_data_structures 0.0.0",
@@ -2174,7 +2175,7 @@ dependencies = [
  "graphviz 0.0.0",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log_settings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "polonius-engine 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "polonius-engine 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc 0.0.0",
  "rustc_apfloat 0.0.0",
  "rustc_data_structures 0.0.0",
@@ -3176,7 +3177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum phf_generator 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "6b07ffcc532ccc85e3afc45865469bf5d9e4ef5bfcf9622e3cfe80c2d275ec03"
 "checksum phf_shared 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "07e24b0ca9643bdecd0632f2b3da6b1b89bbb0030e0b992afc1113b23a7bc2f2"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
-"checksum polonius-engine 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9385a6d8f8ff6fd7e48a803c6a77fb89cc929dc7e2af6bf972494bbc8ff8b9e4"
+"checksum polonius-engine 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b6b0a7f5f4278b991ffd14abce1d01b013121ad297460237ef0a2f08d43201"
 "checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 "checksum pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a029430f0d744bc3d15dd474d591bed2402b645d024583082b9f63bb936dac6"
 "checksum proc-macro2 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "49b6a521dc81b643e9a51e0d1cf05df46d5a2f3c0280ea72bcb68276ba64a118"

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -16,7 +16,7 @@ graphviz = { path = "../libgraphviz" }
 jobserver = "0.1"
 lazy_static = "1.0.0"
 log = { version = "0.4", features = ["release_max_level_info", "std"] }
-polonius-engine = "0.4.0"
+polonius-engine = "0.5.0"
 proc_macro = { path = "../libproc_macro" }
 rustc_apfloat = { path = "../librustc_apfloat" }
 rustc_target = { path = "../librustc_target" }

--- a/src/librustc_mir/Cargo.toml
+++ b/src/librustc_mir/Cargo.toml
@@ -15,7 +15,7 @@ either = "1.5.0"
 graphviz = { path = "../libgraphviz" }
 log = "0.4"
 log_settings = "0.1.1"
-polonius-engine = "0.4.0"
+polonius-engine = "0.5.0"
 rustc = { path = "../librustc" }
 rustc_target = { path = "../librustc_target" }
 rustc_data_structures = { path = "../librustc_data_structures" }

--- a/src/librustc_mir/borrow_check/nll/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/mod.rs
@@ -161,7 +161,7 @@ pub(in borrow_check) fn compute_regions<'cx, 'gcx, 'tcx>(
             let algorithm = env::var("POLONIUS_ALGORITHM")
                 .unwrap_or(String::from("DatafrogOpt"));
             let algorithm = Algorithm::from_str(&algorithm).unwrap();
-            info!("Using Polonius algorithm: {:?}", algorithm);
+            debug!("compute_regions: using polonius algorithm {:?}", algorithm);
             Some(Rc::new(Output::compute(
                 &all_facts,
                 algorithm,

--- a/src/librustc_mir/borrow_check/nll/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/mod.rs
@@ -22,9 +22,11 @@ use rustc::ty::{self, RegionKind, RegionVid};
 use rustc::util::nodemap::FxHashMap;
 use std::collections::BTreeSet;
 use std::fmt::Debug;
+use std::env;
 use std::io;
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::str::FromStr;
 use transform::MirSource;
 use util::liveness::{LivenessResults, LocalSet};
 
@@ -156,9 +158,13 @@ pub(in borrow_check) fn compute_regions<'cx, 'gcx, 'tcx>(
         }
 
         if infcx.tcx.sess.opts.debugging_opts.polonius {
+            let algorithm = env::var("POLONIUS_ALGORITHM")
+                .unwrap_or(String::from("DatafrogOpt"));
+            let algorithm = Algorithm::from_str(&algorithm).unwrap();
+            info!("Using Polonius algorithm: {:?}", algorithm);
             Some(Rc::new(Output::compute(
                 &all_facts,
-                Algorithm::DatafrogOpt,
+                algorithm,
                 false,
             )))
         } else {


### PR DESCRIPTION
This pull request allows selecting the Polonius algorithm being used by providing an environment variable `POLONIUS_ALGORITHM`.

Example usage:
```
POLONIUS_ALGORITHM=compare RUST_LOG=rustc_mir::borrow_check::nll=trace  ./x.py test --stage 1 --compare-mode polonius -- src/test/ui/nll/issue-47680.rs
...
stderr:
------------------------------------------
 INFO 2018-05-31T17:35:31Z: rustc_mir::borrow_check::nll: Using Polonius algorithm: Compare
 INFO 2018-05-31T17:35:31Z: rustc_mir::borrow_check::nll: Using Polonius algorithm: Compare

------------------------------------------
...
```

r? @nikomatsakis 