### PR TITLE
Fix crate-name option in rustdoc

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -230,7 +230,10 @@ pub fn run_core(search_paths: SearchPaths,
 
         let krate = panictry!(driver::phase_1_parse_input(control, &sess, &input));
 
-        let name = ::rustc_codegen_utils::link::find_crate_name(Some(&sess), &krate.attrs, &input);
+        let name = match crate_name {
+            Some(ref crate_name) => crate_name.clone(),
+            None => ::rustc_codegen_utils::link::find_crate_name(Some(&sess), &krate.attrs, &input),
+        };
 
         let mut crate_loader = CrateLoader::new(&sess, &cstore, &name);
 

--- a/src/test/rustdoc/invalid.crate.name.rs
+++ b/src/test/rustdoc/invalid.crate.name.rs
@@ -1,0 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --crate-name foo
+
+pub fn foo() {}


### PR DESCRIPTION
Fixes #51229.

r? @QuietMisdreavus 