### PR TITLE
Remove feature flag from fs::read_to_string example

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -295,8 +295,6 @@ pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
 /// # Examples
 ///
 /// ```no_run
-/// #![feature(fs_read_write)]
-///
 /// use std::fs;
 /// use std::net::SocketAddr;
 ///


### PR DESCRIPTION
This is stable, and so no longer needed