### PR TITLE
Dedup auto traits in trait objects.

### DIFF
--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1318,7 +1318,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
     }
 }
 
-/// Divides a list of general trait bounds into two groups: builtin bounds (Sync/Send) and the
+/// Divides a list of general trait bounds into two groups: auto traits (e.g. Sync and Send) and the
 /// remaining general trait bounds.
 fn split_auto_traits<'a, 'b, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
                                          trait_bounds: &'b [hir::PolyTraitRef])

--- a/src/test/run-pass/trait-object-auto-dedup.rs
+++ b/src/test/run-pass/trait-object-auto-dedup.rs
@@ -1,0 +1,53 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that duplicate auto trait bounds in trait objects don't create new types.
+#[allow(unused_assignments)]
+
+use std::marker::Send as SendAlias;
+
+// A dummy trait for the non-auto trait.
+trait Trait {}
+
+// A dummy struct to implement Trait, Send, and .
+struct Struct;
+
+impl Trait for Struct {}
+
+// These three functions should be equivalent.
+fn takes_dyn_trait_send(_: Box<dyn Trait + Send>) {}
+fn takes_dyn_trait_send_send(_: Box<dyn Trait + Send + Send>) {}
+fn takes_dyn_trait_send_sendalias(_: Box<dyn Trait + Send + SendAlias>) {}
+
+impl dyn Trait + Send + Send {
+    fn do_nothing(&self) {}
+}
+
+fn main() {
+    // 1. Moving into a variable with more Sends and back.
+    let mut dyn_trait_send = Box::new(Struct) as Box<dyn Trait + Send>;
+    let dyn_trait_send_send: Box<dyn Trait + Send + Send> = dyn_trait_send;
+    dyn_trait_send = dyn_trait_send_send;
+
+    // 2. Calling methods with different number of Sends.
+    let dyn_trait_send = Box::new(Struct) as Box<dyn Trait + Send>;
+    takes_dyn_trait_send_send(dyn_trait_send);
+
+    let dyn_trait_send_send = Box::new(Struct) as Box<dyn Trait + Send + Send>;
+    takes_dyn_trait_send(dyn_trait_send_send);
+
+    // 3. Aliases to the trait are transparent.
+    let dyn_trait_send = Box::new(Struct) as Box<dyn Trait + Send>;
+    takes_dyn_trait_send_sendalias(dyn_trait_send);
+
+    // 4. Calling an impl that duplicates an auto trait.
+    let dyn_trait_send = Box::new(Struct) as Box<dyn Trait + Send>;
+    dyn_trait_send.do_nothing();
+}

--- a/src/test/ui/trait-object-auto-dedup-in-impl.rs
+++ b/src/test/ui/trait-object-auto-dedup-in-impl.rs
@@ -1,0 +1,29 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Checks to make sure that `dyn Trait + Send` and `dyn Trait + Send + Send` are the same type.
+// Issue: #47010
+
+struct Struct;
+impl Trait for Struct {}
+trait Trait {}
+
+type Send1 = Trait + Send;
+type Send2 = Trait + Send + Send;
+
+fn main () {}
+
+impl Trait + Send {
+    fn test(&self) { println!("one"); } //~ ERROR duplicate definitions with name `test`
+}
+
+impl Trait + Send + Send {
+    fn test(&self) { println!("two"); }
+}

--- a/src/test/ui/trait-object-auto-dedup-in-impl.stderr
+++ b/src/test/ui/trait-object-auto-dedup-in-impl.stderr
@@ -1,0 +1,12 @@
+error[E0592]: duplicate definitions with name `test`
+  --> $DIR/trait-object-auto-dedup-in-impl.rs:24:5
+   |
+LL |     fn test(&self) { println!("one"); } //~ ERROR duplicate definitions with name `test`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `test`
+...
+LL |     fn test(&self) { println!("two"); }
+   |     ----------------------------------- other definition for `test`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0592`.


### PR DESCRIPTION
Fixes #47010

Note that the test file `run-pass/trait-object-auto-dedup.rs` passes before and after this change. It's the `ui` test that changed from compiling to not compiling. Which does make this a breaking change, but I cannot imagine anybody actually being broken by it.