### PR TITLE
park/park_timeout: prohibit spurious wakeups in next park

### DIFF
--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -796,10 +796,10 @@ pub fn park() {
     let mut m = thread.inner.lock.lock().unwrap();
     match thread.inner.state.compare_exchange(EMPTY, PARKED, SeqCst, SeqCst) {
         Ok(_) => {}
-        Err(NOTIFIED) => { 
+        Err(NOTIFIED) => {
         	// should consume this notification, so prohibit spurious wakeups in next park...
-        	thread.inner.state.store(EMPTY, SeqCst); 
-        	return; 
+        	thread.inner.state.store(EMPTY, SeqCst);
+        	return;
         }, // notified after we locked
         Err(_) => panic!("inconsistent park state"),
     }
@@ -886,10 +886,10 @@ pub fn park_timeout(dur: Duration) {
     let m = thread.inner.lock.lock().unwrap();
     match thread.inner.state.compare_exchange(EMPTY, PARKED, SeqCst, SeqCst) {
         Ok(_) => {}
-        Err(NOTIFIED) => { 
+        Err(NOTIFIED) => {
         	// should consume this notification, so prohibit spurious wakeups in next park...
-        	thread.inner.state.store(EMPTY, SeqCst); 
-        	return; 
+        	thread.inner.state.store(EMPTY, SeqCst);
+        	return;
         }, // notified after we locked
         Err(_) => panic!("inconsistent park_timeout state"),
     }

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -796,7 +796,11 @@ pub fn park() {
     let mut m = thread.inner.lock.lock().unwrap();
     match thread.inner.state.compare_exchange(EMPTY, PARKED, SeqCst, SeqCst) {
         Ok(_) => {}
-        Err(NOTIFIED) => return, // notified after we locked
+        Err(NOTIFIED) => { 
+        	// should consume this notification, so prohibit spurious wakeups in next park...
+        	thread.inner.state.store(EMPTY, SeqCst); 
+        	return; 
+        }, // notified after we locked
         Err(_) => panic!("inconsistent park state"),
     }
     loop {
@@ -882,7 +886,11 @@ pub fn park_timeout(dur: Duration) {
     let m = thread.inner.lock.lock().unwrap();
     match thread.inner.state.compare_exchange(EMPTY, PARKED, SeqCst, SeqCst) {
         Ok(_) => {}
-        Err(NOTIFIED) => return, // notified after we locked
+        Err(NOTIFIED) => { 
+        	// should consume this notification, so prohibit spurious wakeups in next park...
+        	thread.inner.state.store(EMPTY, SeqCst); 
+        	return; 
+        }, // notified after we locked
         Err(_) => panic!("inconsistent park_timeout state"),
     }
 

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -797,10 +797,9 @@ pub fn park() {
     match thread.inner.state.compare_exchange(EMPTY, PARKED, SeqCst, SeqCst) {
         Ok(_) => {}
         Err(NOTIFIED) => {
-        	// should consume this notification, so prohibit spurious wakeups in next park...
-        	thread.inner.state.store(EMPTY, SeqCst);
-        	return;
-        }, // notified after we locked
+            thread.inner.state.store(EMPTY, SeqCst);
+            return;
+        } // should consume this notification, so prohibit spurious wakeups in next park.
         Err(_) => panic!("inconsistent park state"),
     }
     loop {
@@ -887,10 +886,9 @@ pub fn park_timeout(dur: Duration) {
     match thread.inner.state.compare_exchange(EMPTY, PARKED, SeqCst, SeqCst) {
         Ok(_) => {}
         Err(NOTIFIED) => {
-        	// should consume this notification, so prohibit spurious wakeups in next park...
-        	thread.inner.state.store(EMPTY, SeqCst);
-        	return;
-        }, // notified after we locked
+            thread.inner.state.store(EMPTY, SeqCst);
+            return;
+        } // should consume this notification, so prohibit spurious wakeups in next park.
         Err(_) => panic!("inconsistent park_timeout state"),
     }
 


### PR DESCRIPTION
<pre><code>
// The implementation currently uses the trivial strategy of a Mutex+Condvar
// with wakeup flag, which does not actually allow spurious wakeups.
</pre></code>

Because does not actually allow spurious wakeups.
so we have let thread.inner.cvar.wait(m) in the loop to prohibit spurious wakeups.
but if notified after we locked, this notification doesn't be consumed, it return, the next park will consume this notification...this is also 'spurious wakeup' case, 'one unpark() wakeups two  park()'. 

We should improve this situation：
`thread.inner.state.store(EMPTY, SeqCst);`
