### PR TITLE
Fix typos of ‘ambiguous’

### DIFF
--- a/src/librustc/traits/project.rs
+++ b/src/librustc/traits/project.rs
@@ -146,7 +146,7 @@ impl<'tcx> ProjectionTyCandidateSet<'tcx> {
         // was not used). On other paths, it is not assigned,
         // and hence if those paths *could* reach the code that
         // comes after the match, this fn would not compile.
-        let convert_to_ambigious;
+        let convert_to_ambiguous;
 
         match self {
             None => {
@@ -169,10 +169,10 @@ impl<'tcx> ProjectionTyCandidateSet<'tcx> {
                 // clauses are the safer choice. See the comment on
                 // `select::SelectionCandidate` and #21974 for more details.
                 match (current, candidate) {
-                    (ParamEnv(..), ParamEnv(..)) => convert_to_ambigious = (),
+                    (ParamEnv(..), ParamEnv(..)) => convert_to_ambiguous = (),
                     (ParamEnv(..), _) => return false,
                     (_, ParamEnv(..)) => { unreachable!(); }
-                    (_, _) => convert_to_ambigious = (),
+                    (_, _) => convert_to_ambiguous = (),
                 }
             }
 
@@ -183,7 +183,7 @@ impl<'tcx> ProjectionTyCandidateSet<'tcx> {
 
         // We only ever get here when we moved from a single candidate
         // to ambiguous.
-        let () = convert_to_ambigious;
+        let () = convert_to_ambiguous;
         *self = Ambiguous;
         false
     }

--- a/src/librustc/traits/query/normalize.rs
+++ b/src/librustc/traits/query/normalize.rs
@@ -33,7 +33,7 @@ impl<'cx, 'gcx, 'tcx> At<'cx, 'gcx, 'tcx> {
     /// normalized. If you don't care about regions, you should prefer
     /// `normalize_erasing_regions`, which is more efficient.
     ///
-    /// If the normalization succeeds and is unambigious, returns back
+    /// If the normalization succeeds and is unambiguous, returns back
     /// the normalized value along with various outlives relations (in
     /// the form of obligations that must be discharged).
     ///


### PR DESCRIPTION
I had trouble finding this code because of the typo after it was [referenced in a tweet](https://twitter.com/bstrie/status/1002751044605153280). Also fixes an identical but unrelated typo in a comment.