### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -952,8 +952,7 @@ impl Step for Compiletest {
         if suite.ends_with("fulldeps") ||
             // FIXME: Does pretty need librustc compiled? Note that there are
             // fulldeps test suites with mode = pretty as well.
-            mode == "pretty" ||
-            mode == "rustdoc"
+            mode == "pretty"
         {
             builder.ensure(compile::Rustc { compiler, target });
         }

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -104,7 +104,6 @@
 #![feature(ptr_internals)]
 #![feature(ptr_offset_from)]
 #![feature(rustc_attrs)]
-#![feature(slice_get_slice)]
 #![feature(specialization)]
 #![feature(staged_api)]
 #![feature(str_internals)]

--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -121,7 +121,7 @@ pub use core::slice::{RSplit, RSplitMut};
 pub use core::slice::{from_raw_parts, from_raw_parts_mut};
 #[stable(feature = "from_ref", since = "1.28.0")]
 pub use core::slice::{from_ref, from_mut};
-#[unstable(feature = "slice_get_slice", issue = "35729")]
+#[stable(feature = "slice_get_slice", since = "1.28.0")]
 pub use core::slice::SliceIndex;
 #[unstable(feature = "exact_chunks", issue = "47115")]
 pub use core::slice::{ExactChunks, ExactChunksMut};

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -635,8 +635,9 @@ pub fn swap<T>(x: &mut T, y: &mut T) {
     }
 }
 
-/// Replaces the value at a mutable location with a new one, returning the old value, without
-/// deinitializing either one.
+/// Moves `src` into the referenced `dest`, returning the previous `dest` value.
+///
+/// Neither value is dropped.
 ///
 /// # Examples
 ///

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -33,7 +33,11 @@ pub const MANTISSA_DIGITS: u32 = 24;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const DIGITS: u32 = 6;
 
-/// Difference between `1.0` and the next largest representable number.
+/// [Machine epsilon] value for `f32`.
+///
+/// This is the difference between `1.0` and the next largest representable number.
+///
+/// [Machine epsilon]: https://en.wikipedia.org/wiki/Machine_epsilon
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const EPSILON: f32 = 1.19209290e-07_f32;
 

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -33,7 +33,11 @@ pub const MANTISSA_DIGITS: u32 = 53;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const DIGITS: u32 = 15;
 
-/// Difference between `1.0` and the next largest representable number.
+/// [Machine epsilon] value for `f64`.
+///
+/// This is the difference between `1.0` and the next largest representable number.
+///
+/// [Machine epsilon]: https://en.wikipedia.org/wiki/Machine_epsilon
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const EPSILON: f64 = 2.2204460492503131e-16_f64;
 

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -239,8 +239,9 @@ unsafe fn swap_nonoverlapping_bytes(x: *mut u8, y: *mut u8, len: usize) {
     }
 }
 
-/// Replaces the value at `dest` with `src`, returning the old
-/// value, without dropping either.
+/// Moves `src` into the pointed `dest`, returning the previous `dest` value.
+///
+/// Neither value is dropped.
 ///
 /// # Safety
 ///

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1977,35 +1977,63 @@ fn slice_index_overflow_fail() -> ! {
     panic!("attempted to index slice up to maximum usize");
 }
 
+mod private_slice_index {
+    use super::ops;
+    #[stable(feature = "slice_get_slice", since = "1.28.0")]
+    pub trait Sealed {}
+
+    #[stable(feature = "slice_get_slice", since = "1.28.0")]
+    impl Sealed for usize {}
+    #[stable(feature = "slice_get_slice", since = "1.28.0")]
+    impl Sealed for ops::Range<usize> {}
+    #[stable(feature = "slice_get_slice", since = "1.28.0")]
+    impl Sealed for ops::RangeTo<usize> {}
+    #[stable(feature = "slice_get_slice", since = "1.28.0")]
+    impl Sealed for ops::RangeFrom<usize> {}
+    #[stable(feature = "slice_get_slice", since = "1.28.0")]
+    impl Sealed for ops::RangeFull {}
+    #[stable(feature = "slice_get_slice", since = "1.28.0")]
+    impl Sealed for ops::RangeInclusive<usize> {}
+    #[stable(feature = "slice_get_slice", since = "1.28.0")]
+    impl Sealed for ops::RangeToInclusive<usize> {}
+}
+
 /// A helper trait used for indexing operations.
-#[unstable(feature = "slice_get_slice", issue = "35729")]
+#[stable(feature = "slice_get_slice", since = "1.28.0")]
 #[rustc_on_unimplemented = "slice indices are of type `usize` or ranges of `usize`"]
-pub trait SliceIndex<T: ?Sized> {
+pub trait SliceIndex<T: ?Sized>: private_slice_index::Sealed {
     /// The output type returned by methods.
+    #[stable(feature = "slice_get_slice", since = "1.28.0")]
     type Output: ?Sized;
 
     /// Returns a shared reference to the output at this location, if in
     /// bounds.
+    #[unstable(feature = "slice_index_methods", issue = "0")]
     fn get(self, slice: &T) -> Option<&Self::Output>;
 
     /// Returns a mutable reference to the output at this location, if in
     /// bounds.
+    #[unstable(feature = "slice_index_methods", issue = "0")]
     fn get_mut(self, slice: &mut T) -> Option<&mut Self::Output>;
 
     /// Returns a shared reference to the output at this location, without
     /// performing any bounds checking.
+    #[unstable(feature = "slice_index_methods", issue = "0")]
     unsafe fn get_unchecked(self, slice: &T) -> &Self::Output;
 
     /// Returns a mutable reference to the output at this location, without
     /// performing any bounds checking.
+    #[unstable(feature = "slice_index_methods", issue = "0")]
     unsafe fn get_unchecked_mut(self, slice: &mut T) -> &mut Self::Output;
 
     /// Returns a shared reference to the output at this location, panicking
     /// if out of bounds.
+    #[unstable(feature = "slice_index_methods", issue = "0")]
     fn index(self, slice: &T) -> &Self::Output;
 
     /// Returns a mutable reference to the output at this location, panicking
     /// if out of bounds.
+    #[unstable(feature = "slice_index_methods", issue = "0")]
     fn index_mut(self, slice: &mut T) -> &mut Self::Output;
 }
 

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -277,7 +277,7 @@ impl Duration {
     #[unstable(feature = "duration_as_u128", issue = "50202")]
     #[inline]
     pub fn as_millis(&self) -> u128 {
-        self.secs as u128 * MILLIS_PER_SEC as u128 + self.nanos as u128 / NANOS_PER_MILLI as u128
+        self.secs as u128 * MILLIS_PER_SEC as u128 + (self.nanos / NANOS_PER_MILLI) as u128
     }
 
     /// Returns the total number of microseconds contained by this `Duration`.
@@ -294,7 +294,7 @@ impl Duration {
     #[unstable(feature = "duration_as_u128", issue = "50202")]
     #[inline]
     pub fn as_micros(&self) -> u128 {
-        self.secs as u128 * MICROS_PER_SEC as u128 + self.nanos as u128 / NANOS_PER_MICRO as u128
+        self.secs as u128 * MICROS_PER_SEC as u128 + (self.nanos / NANOS_PER_MICRO) as u128
     }
 
     /// Returns the total number of nanoseconds contained by this `Duration`.

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -268,6 +268,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
+    /// # #![feature(duration_nanos)]
     /// use std::time::Duration;
     ///
     /// let duration = Duration::new(5, 730023852);

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -273,7 +273,7 @@ impl Duration {
     /// let duration = Duration::new(5, 730023852);
     /// assert_eq!(duration.as_nanos(), 5730023852);
     /// ```
-    #[unstable(feature = "duration_nanos", issue = "0")]
+    #[unstable(feature = "duration_nanos", issue = "50167")]
     #[inline]
     pub fn as_nanos(&self) -> u128 {
         self.secs as u128 * NANOS_PER_SEC as u128 + self.nanos as u128

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -274,7 +274,7 @@ impl Duration {
     /// let duration = Duration::new(5, 730023852);
     /// assert_eq!(duration.as_nanos(), 5730023852);
     /// ```
-    #[unstable(feature = "duration_nanos", issue = "50167")]
+    #[unstable(feature = "duration_nanos", issue = "50202")]
     #[inline]
     pub fn as_nanos(&self) -> u128 {
         self.secs as u128 * NANOS_PER_SEC as u128 + self.nanos as u128

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -263,6 +263,22 @@ impl Duration {
     #[inline]
     pub fn subsec_nanos(&self) -> u32 { self.nanos }
 
+    /// Returns the total number of nanoseconds contained by this `Duration`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::time::Duration;
+    ///
+    /// let duration = Duration::new(5, 730023852);
+    /// assert_eq!(duration.as_nanos(), 5730023852);
+    /// ```
+    #[unstable(feature = "duration_nanos", issue = "0")]
+    #[inline]
+    pub fn as_nanos(&self) -> u128 {
+        self.secs as u128 * 1000_000_000 + self.nanos as u128
+    }
+
     /// Checked `Duration` addition. Computes `self + other`, returning [`None`]
     /// if overflow occurred.
     ///

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -276,7 +276,7 @@ impl Duration {
     #[unstable(feature = "duration_nanos", issue = "0")]
     #[inline]
     pub fn as_nanos(&self) -> u128 {
-        self.secs as u128 * 1000_000_000 + self.nanos as u128
+        self.secs as u128 * NANOS_PER_SEC as u128 + self.nanos as u128
     }
 
     /// Checked `Duration` addition. Computes `self + other`, returning [`None`]

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -263,18 +263,52 @@ impl Duration {
     #[inline]
     pub fn subsec_nanos(&self) -> u32 { self.nanos }
 
+    /// Returns the total number of milliseconds contained by this `Duration`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(duration_as_u128)]
+    /// use std::time::Duration;
+    ///
+    /// let duration = Duration::new(5, 730023852);
+    /// assert_eq!(duration.as_millis(), 5730);
+    /// ```
+    #[unstable(feature = "duration_as_u128", issue = "50202")]
+    #[inline]
+    pub fn as_millis(&self) -> u128 {
+        self.secs as u128 * MILLIS_PER_SEC as u128 + self.nanos as u128 / NANOS_PER_MILLI as u128
+    }
+
+    /// Returns the total number of microseconds contained by this `Duration`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(duration_as_u128)]
+    /// use std::time::Duration;
+    ///
+    /// let duration = Duration::new(5, 730023852);
+    /// assert_eq!(duration.as_micros(), 5730023);
+    /// ```
+    #[unstable(feature = "duration_as_u128", issue = "50202")]
+    #[inline]
+    pub fn as_micros(&self) -> u128 {
+        self.secs as u128 * MICROS_PER_SEC as u128 + self.nanos as u128 / NANOS_PER_MICRO as u128
+    }
+
     /// Returns the total number of nanoseconds contained by this `Duration`.
     ///
     /// # Examples
     ///
     /// ```
-    /// # #![feature(duration_nanos)]
+    /// # #![feature(duration_as_u128)]
     /// use std::time::Duration;
     ///
     /// let duration = Duration::new(5, 730023852);
     /// assert_eq!(duration.as_nanos(), 5730023852);
     /// ```
-    #[unstable(feature = "duration_nanos", issue = "50202")]
+    #[unstable(feature = "duration_as_u128", issue = "50202")]
     #[inline]
     pub fn as_nanos(&self) -> u128 {
         self.secs as u128 * NANOS_PER_SEC as u128 + self.nanos as u128

--- a/src/librustc/traits/project.rs
+++ b/src/librustc/traits/project.rs
@@ -146,7 +146,7 @@ impl<'tcx> ProjectionTyCandidateSet<'tcx> {
         // was not used). On other paths, it is not assigned,
         // and hence if those paths *could* reach the code that
         // comes after the match, this fn would not compile.
-        let convert_to_ambigious;
+        let convert_to_ambiguous;
 
         match self {
             None => {
@@ -169,10 +169,10 @@ impl<'tcx> ProjectionTyCandidateSet<'tcx> {
                 // clauses are the safer choice. See the comment on
                 // `select::SelectionCandidate` and #21974 for more details.
                 match (current, candidate) {
-                    (ParamEnv(..), ParamEnv(..)) => convert_to_ambigious = (),
+                    (ParamEnv(..), ParamEnv(..)) => convert_to_ambiguous = (),
                     (ParamEnv(..), _) => return false,
                     (_, ParamEnv(..)) => { unreachable!(); }
-                    (_, _) => convert_to_ambigious = (),
+                    (_, _) => convert_to_ambiguous = (),
                 }
             }
 
@@ -183,7 +183,7 @@ impl<'tcx> ProjectionTyCandidateSet<'tcx> {
 
         // We only ever get here when we moved from a single candidate
         // to ambiguous.
-        let () = convert_to_ambigious;
+        let () = convert_to_ambiguous;
         *self = Ambiguous;
         false
     }

--- a/src/librustc/traits/query/normalize.rs
+++ b/src/librustc/traits/query/normalize.rs
@@ -33,7 +33,7 @@ impl<'cx, 'gcx, 'tcx> At<'cx, 'gcx, 'tcx> {
     /// normalized. If you don't care about regions, you should prefer
     /// `normalize_erasing_regions`, which is more efficient.
     ///
-    /// If the normalization succeeds and is unambigious, returns back
+    /// If the normalization succeeds and is unambiguous, returns back
     /// the normalized value along with various outlives relations (in
     /// the form of obligations that must be discharged).
     ///

--- a/src/test/rustdoc/rustc-macro-crate.rs
+++ b/src/test/rustdoc/rustc-macro-crate.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // no-prefer-dynamic
+// ignore-stage1
 
 #![crate_type = "proc-macro"]
 


### PR DESCRIPTION
Successful merges:

 - #50167 ( Add as_nanos function to Duration)
 - #50919 (Provide more context for what the {f32,f64}::EPSILON values represent.)
 - #51124 (Reword {ptr,mem}::replace docs.)
 - #51147 (Stabilize SliceIndex trait.)
 - #51291 (Fix typos of ‘ambiguous’)
 - #51302 (Permit building rustdoc without compiler artifacts)

Failed merges:

