### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/src/liballoc/btree/map.rs
+++ b/src/liballoc/btree/map.rs
@@ -2369,6 +2369,11 @@ impl<'a, K: Ord, V> OccupiedEntry<'a, K, V> {
 
     /// Gets a mutable reference to the value in the entry.
     ///
+    /// If you need a reference to the `OccupiedEntry` which may outlive the
+    /// destruction of the `Entry` value, see [`into_mut`].
+    ///
+    /// [`into_mut`]: #method.into_mut
+    ///
     /// # Examples
     ///
     /// ```
@@ -2380,9 +2385,13 @@ impl<'a, K: Ord, V> OccupiedEntry<'a, K, V> {
     ///
     /// assert_eq!(map["poneyland"], 12);
     /// if let Entry::Occupied(mut o) = map.entry("poneyland") {
-    ///      *o.get_mut() += 10;
+    ///     *o.get_mut() += 10;
+    ///     assert_eq!(*o.get(), 22);
+    ///
+    ///     // We can use the same Entry multiple times.
+    ///     *o.get_mut() += 2;
     /// }
-    /// assert_eq!(map["poneyland"], 22);
+    /// assert_eq!(map["poneyland"], 24);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn get_mut(&mut self) -> &mut V {
@@ -2390,6 +2399,10 @@ impl<'a, K: Ord, V> OccupiedEntry<'a, K, V> {
     }
 
     /// Converts the entry into a mutable reference to its value.
+    ///
+    /// If you need multiple references to the `OccupiedEntry`, see [`get_mut`].
+    ///
+    /// [`get_mut`]: #method.get_mut
     ///
     /// # Examples
     ///

--- a/src/liballoc/tests/str.rs
+++ b/src/liballoc/tests/str.rs
@@ -1326,6 +1326,7 @@ fn test_str_default() {
 
     t::<&str>();
     t::<String>();
+    t::<&mut str>();
 }
 
 #[test]

--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -204,9 +204,6 @@ impl Layout {
     /// satisfy this constraint is to ensure `align <= self.align()`.
     #[inline]
     pub fn padding_needed_for(&self, align: usize) -> usize {
-        // **FIXME**: This function is only called with proper power-of-two
-        // alignments. Maybe we should turn this into a real assert!.
-        debug_assert!(align.is_power_of_two());
         let len = self.size();
 
         // Rounded up value is:

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -3875,6 +3875,12 @@ impl<'a> Default for &'a str {
     fn default() -> &'a str { "" }
 }
 
+#[stable(feature = "default_mut_str", since = "1.28.0")]
+impl<'a> Default for &'a mut str {
+    /// Creates an empty mutable str
+    fn default() -> &'a mut str { unsafe { from_utf8_unchecked_mut(&mut []) } }
+}
+
 /// An iterator over the non-whitespace substrings of a string,
 /// separated by any amount of whitespace.
 ///

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -362,8 +362,8 @@ fn unsafe_derive_on_repr_packed<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: D
         format!("#[derive] can't be used on a #[repr(packed)] struct with \
                  type parameters (error E0133)")
     } else {
-        format!("#[derive] can't be used on a non-Copy #[repr(packed)] struct \
-                 (error E0133)")
+        format!("#[derive] can't be used on a #[repr(packed)] struct that \
+                 does not derive Copy (error E0133)")
     };
     tcx.lint_node(SAFE_PACKED_BORROWS,
                   lint_node_id,

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -195,7 +195,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 let ty_string = self.ty_to_string(actual);
                 let is_method = mode == Mode::MethodCall;
                 let mut suggestion = None;
-                let type_str = if is_method {
+                let item_kind = if is_method {
                     "method"
                 } else if actual.is_enum() {
                     if let TyAdt(ref adt_def, _) = actual.sty {
@@ -235,7 +235,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                             span,
                             E0689,
                             "can't call {} `{}` on ambiguous numeric type `{}`",
-                            type_str,
+                            item_kind,
                             item_name,
                             ty_string
                         );
@@ -284,12 +284,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                             span,
                             E0599,
                             "no {} named `{}` found for type `{}` in the current scope",
-                            type_str,
+                            item_kind,
                             item_name,
                             ty_string
                         );
                         if let Some(suggestion) = suggestion {
-                            err.note(&format!("did you mean `{}::{}`?", type_str, suggestion));
+                            err.note(&format!("did you mean `{}::{}`?", ty_string, suggestion));
                         }
                         err
                     }
@@ -301,7 +301,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     if let Some(full_sp) = tcx.hir.span_if_local(def.did) {
                         let def_sp = tcx.sess.codemap().def_span(full_sp);
                         err.span_label(def_sp, format!("{} `{}` not found {}",
-                                                       type_str,
+                                                       item_kind,
                                                        item_name,
                                                        if def.is_enum() && !is_method {
                                                            "here"
@@ -355,7 +355,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         }
                     }
                 } else {
-                    err.span_label(span, format!("{} not found in `{}`", type_str, ty_string));
+                    err.span_label(span, format!("{} not found in `{}`", item_kind, ty_string));
                 }
 
                 if self.is_fn_ty(&rcvr_ty, span) {

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -561,7 +561,8 @@ a {
 	content: '\2002\00a7\2002';
 }
 
-.docblock a:not(.srclink):hover, .docblock-short a:not(.srclink):hover, .stability a {
+.docblock a:not(.srclink):not(.test-arrow):hover,
+.docblock-short a:not(.srclink):not(.test-arrow):hover, .stability a {
 	text-decoration: underline;
 }
 

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -163,7 +163,8 @@ a {
 	color: #ddd;
 }
 
-.docblock a:not(.srclink), .docblock-short a:not(.srclink), .stability a {
+.docblock a:not(.srclink):not(.test-arrow), .docblock-short a:not(.srclink):not(.test-arrow),
+.stability a {
 	color: #D2991D;
 }
 

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -163,7 +163,8 @@ a {
 	color: #000;
 }
 
-.docblock a:not(.srclink), .docblock-short a:not(.srclink), .stability a {
+.docblock a:not(.srclink):not(.test-arrow), .docblock-short a:not(.srclink):not(.test-arrow),
+.stability a {
 	color: #3873AD;
 }
 

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -2250,6 +2250,11 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
 
     /// Gets a mutable reference to the value in the entry.
     ///
+    /// If you need a reference to the `OccupiedEntry` which may outlive the
+    /// destruction of the `Entry` value, see [`into_mut`].
+    ///
+    /// [`into_mut`]: #method.into_mut
+    ///
     /// # Examples
     ///
     /// ```
@@ -2277,6 +2282,10 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
 
     /// Converts the OccupiedEntry into a mutable reference to the value in the entry
     /// with a lifetime bound to the map itself.
+    ///
+    /// If you need multiple references to the `OccupiedEntry`, see [`get_mut`].
+    ///
+    /// [`get_mut`]: #method.get_mut
     ///
     /// # Examples
     ///

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -2262,7 +2262,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// assert_eq!(map["poneyland"], 12);
     /// if let Entry::Occupied(mut o) = map.entry("poneyland") {
     ///     *o.get_mut() += 10;
-    ///     assert_eq!(o.get(), 22);
+    ///     assert_eq!(*o.get(), 22);
     ///
     ///     // We can use the same Entry multiple times.
     ///     *o.get_mut() += 2;

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -2261,10 +2261,14 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     ///
     /// assert_eq!(map["poneyland"], 12);
     /// if let Entry::Occupied(mut o) = map.entry("poneyland") {
-    ///      *o.get_mut() += 10;
+    ///     *o.get_mut() += 10;
+    ///     assert_eq!(o.get(), 22);
+    ///
+    ///     // We can use the same Entry multiple times.
+    ///     *o.get_mut() += 2;
     /// }
     ///
-    /// assert_eq!(map["poneyland"], 22);
+    /// assert_eq!(map["poneyland"], 24);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn get_mut(&mut self) -> &mut V {

--- a/src/test/ui/deriving-with-repr-packed.rs
+++ b/src/test/ui/deriving-with-repr-packed.rs
@@ -33,7 +33,7 @@ pub struct Bar(u32, u32, u32);
 struct Y(usize);
 
 #[derive(PartialEq)]
-//~^ ERROR #[derive] can't be used on a non-Copy #[repr(packed)]
+//~^ ERROR #[derive] can't be used
 //~| hard error
 #[repr(packed)]
 struct X(Y);

--- a/src/test/ui/deriving-with-repr-packed.stderr
+++ b/src/test/ui/deriving-with-repr-packed.stderr
@@ -21,7 +21,7 @@ LL | #[derive(Copy, Clone, PartialEq, Eq)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #46043 <https://github.com/rust-lang/rust/issues/46043>
 
-error: #[derive] can't be used on a non-Copy #[repr(packed)] struct (error E0133)
+error: #[derive] can't be used on a #[repr(packed)] struct that does not derive Copy (error E0133)
   --> $DIR/deriving-with-repr-packed.rs:26:10
    |
 LL | #[derive(PartialEq, Eq)]
@@ -30,7 +30,7 @@ LL | #[derive(PartialEq, Eq)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #46043 <https://github.com/rust-lang/rust/issues/46043>
 
-error: #[derive] can't be used on a non-Copy #[repr(packed)] struct (error E0133)
+error: #[derive] can't be used on a #[repr(packed)] struct that does not derive Copy (error E0133)
   --> $DIR/deriving-with-repr-packed.rs:35:10
    |
 LL | #[derive(PartialEq)]

--- a/src/test/ui/issue-23217.stderr
+++ b/src/test/ui/issue-23217.stderr
@@ -6,7 +6,7 @@ LL | pub enum SomeEnum {
 LL |     B = SomeEnum::A,
    |         ^^^^^^^^^^^ variant not found in `SomeEnum`
    |
-   = note: did you mean `variant::B`?
+   = note: did you mean `SomeEnum::B`?
 
 error: aborting due to previous error
 

--- a/src/test/ui/issue-28971.stderr
+++ b/src/test/ui/issue-28971.stderr
@@ -7,7 +7,7 @@ LL | enum Foo {
 LL |             Foo::Baz(..) => (),
    |             ^^^^^^^^^^^^ variant not found in `Foo`
    |
-   = note: did you mean `variant::Bar`?
+   = note: did you mean `Foo::Bar`?
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #51143 (Specify that packed types must derive, not implement, Copy)
 - #51226 (Make Layout's align a NonZeroUsize)
 - #51297 (Fix run button style)
 - #51306 (impl Default for &mut str)
 - #51312 (Clarify the difference between get_mut and into_mut for OccupiedEntry)
 - #51313 (use type name in E0599 enum variant suggestion)

Failed merges:

