### PR TITLE
Update the clippy submodule and enable building edition crates

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -306,12 +306,12 @@ dependencies = [
 
 [[package]]
 name = "clippy"
-version = "0.0.202"
+version = "0.0.207"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_metadata 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy-mini-macro-test 0.2.0",
- "clippy_lints 0.0.202",
+ "clippy_lints 0.0.207",
  "compiletest_rs 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive-new 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -328,7 +328,8 @@ version = "0.2.0"
 
 [[package]]
 name = "clippy_lints"
-version = "0.0.202"
+version = "0.0.205"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cargo_metadata 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -348,8 +349,7 @@ dependencies = [
 
 [[package]]
 name = "clippy_lints"
-version = "0.0.205"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.0.207"
 dependencies = [
  "cargo_metadata 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -607,6 +607,7 @@ class RustBuild(object):
             (os.pathsep + env["LIBRARY_PATH"]) \
             if "LIBRARY_PATH" in env else ""
         env["RUSTFLAGS"] = "-Cdebuginfo=2 "
+        env["__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS"] = "dev"
 
         build_section = "target.{}".format(self.build_triple())
         target_features = []

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -729,6 +729,8 @@ impl<'a> Builder<'a> {
             &self.config.channel
         };
         cargo.env("__CARGO_DEFAULT_LIB_METADATA", &metadata);
+        // HACK: we do want to be able to compile edition crates, even though that isn't stable yet
+        cargo.env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "dev");
 
         let stage;
         if compiler.stage == 0 && self.local_rebuild {

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -947,6 +947,7 @@ impl Step for PlainSourceTarball {
             // Get cargo-vendor installed, if it isn't already.
             let mut has_cargo_vendor = false;
             let mut cmd = Command::new(&builder.initial_cargo);
+            cmd.env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "dev");
             for line in output(cmd.arg("install").arg("--list")).lines() {
                 has_cargo_vendor |= line.starts_with("cargo-vendor ");
             }
@@ -973,6 +974,7 @@ impl Step for PlainSourceTarball {
             // Vendor all Cargo dependencies
             let mut cmd = Command::new(&builder.initial_cargo);
             cmd.arg("vendor")
+               .env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "dev")
                .current_dir(&plain_dst_src.join("src"));
             builder.run(&mut cmd);
         }

--- a/src/bootstrap/metadata.rs
+++ b/src/bootstrap/metadata.rs
@@ -59,6 +59,7 @@ fn build_krate(build: &mut Build, krate: &str) {
     // the dependency graph and what `-p` arguments there are.
     let mut cargo = Command::new(&build.initial_cargo);
     cargo.arg("metadata")
+         .env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "dev")
          .arg("--format-version").arg("1")
          .arg("--manifest-path").arg(build.src.join(krate).join("Cargo.toml"));
     let output = output(&mut cargo);

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1878,6 +1878,7 @@ impl Step for Distcheck {
         let toml = dir.join("rust-src/lib/rustlib/src/rust/src/libstd/Cargo.toml");
         builder.run(
             Command::new(&builder.initial_cargo)
+                .env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "dev")
                 .arg("generate-lockfile")
                 .arg("--manifest-path")
                 .arg(&toml)
@@ -1899,6 +1900,7 @@ impl Step for Bootstrap {
         let mut cmd = Command::new(&builder.initial_cargo);
         cmd.arg("test")
             .current_dir(builder.src.join("src/bootstrap"))
+            .env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "dev")
             .env("RUSTFLAGS", "-Cdebuginfo=2")
             .env("CARGO_TARGET_DIR", builder.out.join("bootstrap"))
             .env("RUSTC_BOOTSTRAP", "1")

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -285,6 +285,7 @@ fn extract_license(line: &str) -> String {
 fn get_deps(path: &Path, cargo: &Path) -> Resolve {
     // Run `cargo metadata` to get the set of dependencies
     let output = Command::new(cargo)
+        .env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "dev")
         .arg("metadata")
         .arg("--format-version")
         .arg("1")


### PR DESCRIPTION
r? @alexcrichton 

This is extremely hacky, but I see no way other than reverting the 2018 edition update for clippy