### PR TITLE
Prohibit `global_allocator` in submodules

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2035,6 +2035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "rustc_allocator"
 version = "0.0.0"
 dependencies = [
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc 0.0.0",
  "rustc_errors 0.0.0",
  "rustc_target 0.0.0",

--- a/src/librustc_allocator/Cargo.toml
+++ b/src/librustc_allocator/Cargo.toml
@@ -14,3 +14,4 @@ rustc_errors = { path = "../librustc_errors" }
 rustc_target = { path = "../librustc_target" }
 syntax = { path = "../libsyntax" }
 syntax_pos = { path = "../libsyntax_pos" }
+log = "0.4"

--- a/src/librustc_allocator/expand.rs
+++ b/src/librustc_allocator/expand.rs
@@ -13,7 +13,7 @@ use rustc_errors;
 use syntax::{
     ast::{
         self, Arg, Attribute, Crate, Expr, FnHeader, Generics, Ident, Item, ItemKind,
-        LitKind, Mod, Mutability, StrStyle, Ty, TyKind, Unsafety, VisibilityKind,
+        LitKind, Mac, Mod, Mutability, StrStyle, Ty, TyKind, Unsafety, VisibilityKind,
     },
     attr,
     codemap::{
@@ -166,6 +166,11 @@ impl<'a> Folder for ExpandAllocatorDirectives<'a> {
         self.in_submod -= 1;
         info!("exit submodule");
         ret
+    }
+
+    // `fold_mac` is disabled by default. Enable it here.
+    fn fold_mac(&mut self, mac: Mac) -> Mac {
+        fold::noop_fold_mac(mac, self)
     }
 }
 

--- a/src/librustc_allocator/expand.rs
+++ b/src/librustc_allocator/expand.rs
@@ -66,7 +66,7 @@ struct ExpandAllocatorDirectives<'a> {
 
 impl<'a> Folder for ExpandAllocatorDirectives<'a> {
     fn fold_item(&mut self, item: P<Item>) -> SmallVector<P<Item>> {
-        info!("in submodule {}", self.in_submod);
+        debug!("in submodule {}", self.in_submod);
 
         let name = if attr::contains_name(&item.attrs, "global_allocator") {
             "global_allocator"
@@ -160,11 +160,11 @@ impl<'a> Folder for ExpandAllocatorDirectives<'a> {
 
     // If we enter a submodule, take note.
     fn fold_mod(&mut self, m: Mod) -> Mod {
-        info!("enter submodule");
+        debug!("enter submodule");
         self.in_submod += 1;
         let ret = fold::noop_fold_mod(m, self);
         self.in_submod -= 1;
-        info!("exit submodule");
+        debug!("exit submodule");
         ret
     }
 

--- a/src/librustc_allocator/expand.rs
+++ b/src/librustc_allocator/expand.rs
@@ -8,27 +8,30 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(unused_imports, unused_variables, dead_code)]
-
 use rustc::middle::allocator::AllocatorKind;
 use rustc_errors;
-use syntax::ast::{Attribute, Crate, LitKind, StrStyle};
-use syntax::ast::{Arg, FnHeader, Generics, Mac, Mutability, Ty, Unsafety};
-use syntax::ast::{self, Expr, Ident, Item, ItemKind, TyKind, VisibilityKind};
-use syntax::attr;
-use syntax::codemap::respan;
-use syntax::codemap::{ExpnInfo, MacroAttribute};
-use syntax::ext::base::ExtCtxt;
-use syntax::ext::base::Resolver;
-use syntax::ext::build::AstBuilder;
-use syntax::ext::expand::ExpansionConfig;
-use syntax::ext::hygiene::{self, Mark, SyntaxContext};
-use syntax::fold::{self, Folder};
-use syntax::parse::ParseSess;
-use syntax::ptr::P;
-use syntax::symbol::Symbol;
-use syntax::util::small_vector::SmallVector;
-use syntax_pos::{Span, DUMMY_SP};
+use syntax::{
+    ast::{
+        self, Arg, Attribute, Crate, Expr, FnHeader, Generics, Ident, Item, ItemKind,
+        LitKind, Mod, Mutability, StrStyle, Ty, TyKind, Unsafety, VisibilityKind,
+    },
+    attr,
+    codemap::{
+        respan, ExpnInfo, MacroAttribute,
+    },
+    ext::{
+        base::{ExtCtxt, Resolver},
+        build::AstBuilder,
+        expand::ExpansionConfig,
+        hygiene::{self, Mark, SyntaxContext},
+    },
+    fold::{self, Folder},
+    parse::ParseSess,
+    ptr::P,
+    symbol::Symbol,
+    util::small_vector::SmallVector,
+};
+use syntax_pos::Span;
 
 use {AllocatorMethod, AllocatorTy, ALLOCATOR_METHODS};
 
@@ -45,6 +48,7 @@ pub fn modify(
         resolver,
         found: false,
         crate_name: Some(crate_name),
+        in_submod: -1, // -1 to account for the "root" module
     }.fold_crate(krate)
 }
 
@@ -54,10 +58,16 @@ struct ExpandAllocatorDirectives<'a> {
     sess: &'a ParseSess,
     resolver: &'a mut Resolver,
     crate_name: Option<String>,
+
+    // For now, we disallow `global_allocator` in submodules because hygiene is hard. Keep track of
+    // whether we are in a submodule or not. If `in_submod > 0` we are in a submodule.
+    in_submod: isize,
 }
 
 impl<'a> Folder for ExpandAllocatorDirectives<'a> {
     fn fold_item(&mut self, item: P<Item>) -> SmallVector<P<Item>> {
+        info!("in submodule {}", self.in_submod);
+
         let name = if attr::contains_name(&item.attrs, "global_allocator") {
             "global_allocator"
         } else {
@@ -72,12 +82,15 @@ impl<'a> Folder for ExpandAllocatorDirectives<'a> {
             }
         }
 
+        if self.in_submod > 0 {
+            self.handler
+                .span_err(item.span, "`global_allocator` cannot be used in submodules");
+            return SmallVector::one(item);
+        }
+
         if self.found {
-            self.handler.span_err(
-                item.span,
-                "cannot define more than one \
-                 #[global_allocator]",
-            );
+            self.handler
+                .span_err(item.span, "cannot define more than one #[global_allocator]");
             return SmallVector::one(item);
         }
         self.found = true;
@@ -85,7 +98,7 @@ impl<'a> Folder for ExpandAllocatorDirectives<'a> {
         // Create a fresh Mark for the new macro expansion we are about to do
         let mark = Mark::fresh(Mark::root());
         mark.set_expn_info(ExpnInfo {
-            call_site: item.span,
+            call_site: item.span, // use the call site of the static
             def_site: None,
             format: MacroAttribute(Symbol::intern(name)),
             allow_internal_unstable: true,
@@ -104,27 +117,55 @@ impl<'a> Folder for ExpandAllocatorDirectives<'a> {
             span,
             kind: AllocatorKind::Global,
             global: item.ident,
-            core: Ident::with_empty_ctxt(Symbol::gensym("core")),
+            core: Ident::from_str("core"),
             cx: ExtCtxt::new(self.sess, ecfg, self.resolver),
         };
 
-        let extcore = {
-            let extcore = f.cx.item_extern_crate(item.span, f.core);
-            f.cx.monotonic_expander().fold_item(extcore).pop().unwrap()
-        };
+        // We will generate a new submodule. To `use` the static from that module, we need to get
+        // the `super::...` path.
+        let super_path = f.cx.path(f.span, vec![Ident::from_str("super"), f.global]);
 
-        let mut ret = SmallVector::new();
+        // Generate the items in the submodule
+        let mut items = vec![
+            // import `core` to use allocators
+            f.cx.item_extern_crate(f.span, f.core),
+            // `use` the `global_allocator` in `super`
+            f.cx.item_use_simple(
+                f.span,
+                respan(f.span.shrink_to_lo(), VisibilityKind::Inherited),
+                super_path,
+            ),
+        ];
+
+        // Add the allocator methods to the submodule
+        items.extend(
+            ALLOCATOR_METHODS
+                .iter()
+                .map(|method| f.allocator_fn(method)),
+        );
+
+        // Generate the submodule itself
+        let name = f.kind.fn_name("allocator_abi");
+        let allocator_abi = Ident::with_empty_ctxt(Symbol::gensym(&name));
+        let module = f.cx.item_mod(span, span, allocator_abi, Vec::new(), items);
+        let module = f.cx.monotonic_expander().fold_item(module).pop().unwrap();
+
+        // Return the item and new submodule
+        let mut ret = SmallVector::with_capacity(2);
         ret.push(item);
-        ret.push(extcore);
-        ret.extend(ALLOCATOR_METHODS.iter().map(|method| {
-            let method = f.allocator_fn(method);
-            f.cx.monotonic_expander().fold_item(method).pop().unwrap()
-        }));
+        ret.push(module);
+
         return ret;
     }
 
-    fn fold_mac(&mut self, mac: Mac) -> Mac {
-        fold::noop_fold_mac(mac, self)
+    // If we enter a submodule, take note.
+    fn fold_mod(&mut self, m: Mod) -> Mod {
+        info!("enter submodule");
+        self.in_submod += 1;
+        let ret = fold::noop_fold_mod(m, self);
+        self.in_submod -= 1;
+        info!("exit submodule");
+        ret
     }
 }
 
@@ -173,7 +214,6 @@ impl<'a> AllocFnFactory<'a> {
         let method = self.cx.path(
             self.span,
             vec![
-                Ident::from_str("self"),
                 self.core,
                 Ident::from_str("alloc"),
                 Ident::from_str("GlobalAlloc"),
@@ -224,7 +264,6 @@ impl<'a> AllocFnFactory<'a> {
                 let layout_new = self.cx.path(
                     self.span,
                     vec![
-                        Ident::from_str("self"),
                         self.core,
                         Ident::from_str("alloc"),
                         Ident::from_str("Layout"),

--- a/src/librustc_allocator/lib.rs
+++ b/src/librustc_allocator/lib.rs
@@ -10,6 +10,7 @@
 
 #![feature(rustc_private)]
 
+#[macro_use] extern crate log;
 extern crate rustc;
 extern crate rustc_errors;
 extern crate rustc_target;

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1051,9 +1051,18 @@ where
         });
     }
 
+    // Expand global allocators, which are treated as an in-tree proc macro
     krate = time(sess, "creating allocators", || {
-        allocator::expand::modify(&sess.parse_sess, &mut resolver, krate, sess.diagnostic())
+        allocator::expand::modify(
+            &sess.parse_sess,
+            &mut resolver,
+            krate,
+            crate_name.to_string(),
+            sess.diagnostic(),
+        )
     });
+
+    // Done with macro expansion!
 
     after_expand(&krate)?;
 

--- a/src/test/ui/allocator-submodule.rs
+++ b/src/test/ui/allocator-submodule.rs
@@ -15,16 +15,19 @@
 
 extern crate alloc;
 
-use std::alloc::{GlobalAlloc, Layout, Opaque};
+use std::{
+    alloc::{GlobalAlloc, Layout},
+    ptr,
+};
 
 struct MyAlloc;
 
 unsafe impl GlobalAlloc for MyAlloc {
-    unsafe fn alloc(&self, layout: Layout) -> *mut Opaque {
-        0 as usize as *mut Opaque
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ptr::null_mut()
     }
 
-    unsafe fn dealloc(&self, ptr: *mut Opaque, layout: Layout) {}
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {}
 }
 
 mod submod {

--- a/src/test/ui/allocator-submodule.rs
+++ b/src/test/ui/allocator-submodule.rs
@@ -1,0 +1,37 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests that it is possible to create a global allocator in a submodule, rather than in the crate
+// root.
+
+#![feature(alloc, allocator_api, global_allocator)]
+
+extern crate alloc;
+
+use std::alloc::{GlobalAlloc, Layout, Opaque};
+
+struct MyAlloc;
+
+unsafe impl GlobalAlloc for MyAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut Opaque {
+        0 as usize as *mut Opaque
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut Opaque, layout: Layout) {}
+}
+
+mod submod {
+    use super::MyAlloc;
+
+    #[global_allocator]
+    static MY_HEAP: MyAlloc = MyAlloc;
+}
+
+fn main() {}

--- a/src/test/ui/allocator-submodule.rs
+++ b/src/test/ui/allocator-submodule.rs
@@ -31,7 +31,7 @@ mod submod {
     use super::MyAlloc;
 
     #[global_allocator]
-    static MY_HEAP: MyAlloc = MyAlloc;
+    static MY_HEAP: MyAlloc = MyAlloc; //~ ERROR global_allocator
 }
 
 fn main() {}

--- a/src/test/ui/allocator-submodule.stderr
+++ b/src/test/ui/allocator-submodule.stderr
@@ -1,5 +1,5 @@
 error: `global_allocator` cannot be used in submodules
-  --> $DIR/allocator-submodule.rs:34:5
+  --> $DIR/allocator-submodule.rs:37:5
    |
 LL |     static MY_HEAP: MyAlloc = MyAlloc; //~ ERROR global_allocator
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/allocator-submodule.stderr
+++ b/src/test/ui/allocator-submodule.stderr
@@ -1,0 +1,8 @@
+error: `global_allocator` cannot be used in submodules
+  --> $DIR/allocator-submodule.rs:34:5
+   |
+LL |     static MY_HEAP: MyAlloc = MyAlloc; //~ ERROR global_allocator
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Background: #44113 is caused by weird interactions with hygiene. Hygiene is hard. After a lot of playing around, we decided that the best path forward would be to prohibit `global_allocator`s from being in submodules for now. When somebody gets it working, we can re-enable it.

This PR contains the following
- Some hygiene "fixes" -- things I suspect are the correct thing to do that will make life easier in the future. This includes using call_site hygiene for the generated module and passing the correct crate name to the expansion config.
- Comments and minor formatting fixes
- Some debugging code
- Code to prohibit `global_allocator` in submodules
- Test checking that the proper error occurs.

cc #44113 #49320 #51241

r? @alexcrichton