### PR TITLE
[WIP] undo #49719 for rust 2015 with feature flag

### DIFF
--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -240,8 +240,14 @@ pub fn compile(sess: &ParseSess, features: &Features, def: &ast::Item, edition: 
             s.iter().map(|m| {
                 if let MatchedNonterminal(ref nt) = *m {
                     if let NtTT(ref tt) = **nt {
-                        let tt = quoted::parse(tt.clone().into(), true, sess, features, &def.attrs)
-                            .pop().unwrap();
+                        let tt = quoted::parse(
+                            tt.clone().into(),
+                            true,
+                            sess,
+                            features,
+                            &def.attrs,
+                            edition
+                        ).pop().unwrap();
                         valid &= check_lhs_nt_follows(sess, features, &def.attrs, &tt);
                         return tt;
                     }
@@ -257,8 +263,14 @@ pub fn compile(sess: &ParseSess, features: &Features, def: &ast::Item, edition: 
             s.iter().map(|m| {
                 if let MatchedNonterminal(ref nt) = *m {
                     if let NtTT(ref tt) = **nt {
-                        return quoted::parse(tt.clone().into(), false, sess, features, &def.attrs)
-                            .pop().unwrap();
+                        return quoted::parse(
+                            tt.clone().into(),
+                            false,
+                            sess,
+                            features,
+                            &def.attrs,
+                            edition
+                        ).pop().unwrap();
                     }
                 }
                 sess.span_diagnostic.span_bug(def.span, "wrong-structured lhs")


### PR DESCRIPTION
**Do not merge yet**

#49719 was a breaking change that became insta-stable with an FCP. Pending the decision made in that thread, this PR can be used to roll back that PR for rust 2015. The change would only go into effect in rust 2018 edition.

cc @alexreg @sgrif @pietroalbini @durka @oli-obk, who were involved in that discussion

r? @petrochenkov 