### PR TITLE
test: Ignore some problematic tests on sparc and sparc64

### DIFF
--- a/src/test/codegen/abi-main-signature-16bit-c-int.rs
+++ b/src/test/codegen/abi-main-signature-16bit-c-int.rs
@@ -22,6 +22,7 @@
 // ignore-powerpc64
 // ignore-s390x
 // ignore-sparc
+// ignore-sparc64
 // ignore-wasm32
 // ignore-x86
 // ignore-x86_64

--- a/src/test/codegen/fastcall-inreg.rs
+++ b/src/test/codegen/fastcall-inreg.rs
@@ -29,6 +29,7 @@
 // ignore-r600
 // ignore-amdgcn
 // ignore-sparc
+// ignore-sparc64
 // ignore-sparcv9
 // ignore-sparcel
 // ignore-s390x

--- a/src/test/codegen/repr-transparent-aggregates-2.rs
+++ b/src/test/codegen/repr-transparent-aggregates-2.rs
@@ -14,6 +14,8 @@
 // ignore-asmjs
 // ignore-mips64
 // ignore-s390x
+// ignore-sparc
+// ignore-sparc64
 // ignore-wasm
 // ignore-x86
 // ignore-x86_64

--- a/src/test/codegen/stack-probes.rs
+++ b/src/test/codegen/stack-probes.rs
@@ -14,6 +14,8 @@
 // ignore-mips64
 // ignore-powerpc
 // ignore-s390x
+// ignore-sparc
+// ignore-sparc64
 // ignore-wasm
 // ignore-emscripten
 // ignore-windows

--- a/src/test/codegen/x86_mmx.rs
+++ b/src/test/codegen/x86_mmx.rs
@@ -13,6 +13,8 @@
 // ignore-emscripten
 // ignore-mips
 // ignore-mips64
+// ignore-sparc
+// ignore-sparc64
 // compile-flags: -O
 
 #![feature(repr_simd)]

--- a/src/test/compile-fail/asm-bad-clobber.rs
+++ b/src/test/compile-fail/asm-bad-clobber.rs
@@ -15,6 +15,7 @@
 // ignore-emscripten
 // ignore-powerpc
 // ignore-sparc
+// ignore-sparc64
 // ignore-mips
 // ignore-mips64
 

--- a/src/test/compile-fail/asm-in-bad-modifier.rs
+++ b/src/test/compile-fail/asm-in-bad-modifier.rs
@@ -12,6 +12,7 @@
 // ignore-emscripten
 // ignore-powerpc
 // ignore-sparc
+// ignore-sparc64
 // ignore-mips
 // ignore-mips64
 

--- a/src/test/compile-fail/asm-misplaced-option.rs
+++ b/src/test/compile-fail/asm-misplaced-option.rs
@@ -15,6 +15,7 @@
 // ignore-emscripten
 // ignore-powerpc
 // ignore-sparc
+// ignore-sparc64
 // ignore-mips
 // ignore-mips64
 

--- a/src/test/compile-fail/asm-out-no-modifier.rs
+++ b/src/test/compile-fail/asm-out-no-modifier.rs
@@ -12,6 +12,7 @@
 // ignore-emscripten
 // ignore-powerpc
 // ignore-sparc
+// ignore-sparc64
 // ignore-mips
 // ignore-mips64
 

--- a/src/test/compile-fail/asm-out-read-uninit.rs
+++ b/src/test/compile-fail/asm-out-read-uninit.rs
@@ -12,6 +12,7 @@
 // ignore-emscripten
 // ignore-powerpc
 // ignore-sparc
+// ignore-sparc64
 // ignore-mips
 // ignore-mips64
 

--- a/src/test/compile-fail/borrowck/borrowck-asm.rs
+++ b/src/test/compile-fail/borrowck/borrowck-asm.rs
@@ -12,6 +12,7 @@
 // ignore-emscripten
 // ignore-powerpc
 // ignore-sparc
+// ignore-sparc64
 
 // revisions: ast mir
 //[mir]compile-flags: -Z borrowck=mir

--- a/src/test/run-pass/stack-probes-lto.rs
+++ b/src/test/run-pass/stack-probes-lto.rs
@@ -14,6 +14,8 @@
 // ignore-mips64
 // ignore-powerpc
 // ignore-s390x
+// ignore-sparc
+// ignore-sparc64
 // ignore-wasm
 // ignore-cloudabi no processes
 // ignore-emscripten no processes

--- a/src/test/run-pass/stack-probes.rs
+++ b/src/test/run-pass/stack-probes.rs
@@ -14,6 +14,8 @@
 // ignore-mips64
 // ignore-powerpc
 // ignore-s390x
+// ignore-sparc
+// ignore-sparc64
 // ignore-wasm
 // ignore-cloudabi no processes
 // ignore-emscripten no processes

--- a/src/test/ui/asm-out-assign-imm.rs
+++ b/src/test/ui/asm-out-assign-imm.rs
@@ -12,6 +12,7 @@
 // ignore-emscripten
 // ignore-powerpc
 // ignore-sparc
+// ignore-sparc64
 // ignore-mips
 
 #![feature(asm)]

--- a/src/test/ui/asm-out-assign-imm.stderr
+++ b/src/test/ui/asm-out-assign-imm.stderr
@@ -1,5 +1,5 @@
 error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/asm-out-assign-imm.rs:30:9
+  --> $DIR/asm-out-assign-imm.rs:31:9
    |
 LL |     x = 1;
    |     ----- first assignment to `x`

--- a/src/test/ui/target-feature-wrong.rs
+++ b/src/test/ui/target-feature-wrong.rs
@@ -15,6 +15,8 @@
 // ignore-mips
 // ignore-powerpc
 // ignore-s390x
+// ignore-sparc
+// ignore-sparc64
 
 #![feature(target_feature)]
 

--- a/src/test/ui/target-feature-wrong.stderr
+++ b/src/test/ui/target-feature-wrong.stderr
@@ -1,35 +1,35 @@
 error: #[target_feature] attribute must be of the form #[target_feature(..)]
-  --> $DIR/target-feature-wrong.rs:21:1
+  --> $DIR/target-feature-wrong.rs:23:1
    |
 LL | #[target_feature = "+sse2"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: the feature named `foo` is not valid for this target
-  --> $DIR/target-feature-wrong.rs:23:18
+  --> $DIR/target-feature-wrong.rs:25:18
    |
 LL | #[target_feature(enable = "foo")]
    |                  ^^^^^^^^^^^^^^
 
 error: #[target_feature(..)] only accepts sub-keys of `enable` currently
-  --> $DIR/target-feature-wrong.rs:25:18
+  --> $DIR/target-feature-wrong.rs:27:18
    |
 LL | #[target_feature(bar)]
    |                  ^^^
 
 error: #[target_feature(..)] only accepts sub-keys of `enable` currently
-  --> $DIR/target-feature-wrong.rs:27:18
+  --> $DIR/target-feature-wrong.rs:29:18
    |
 LL | #[target_feature(disable = "baz")]
    |                  ^^^^^^^^^^^^^^^
 
 error: #[target_feature(..)] can only be applied to `unsafe` function
-  --> $DIR/target-feature-wrong.rs:31:1
+  --> $DIR/target-feature-wrong.rs:33:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute should be applied to a function
-  --> $DIR/target-feature-wrong.rs:35:1
+  --> $DIR/target-feature-wrong.rs:37:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -38,7 +38,7 @@ LL | mod another {}
    | -------------- not a function
 
 error: cannot use #[inline(always)] with #[target_feature]
-  --> $DIR/target-feature-wrong.rs:39:1
+  --> $DIR/target-feature-wrong.rs:41:1
    |
 LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This updates the list of tests which can be safely ignored on sparc and sparc64.