### PR TITLE
impl Hash for !

### DIFF
--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -603,6 +603,13 @@ mod impls {
         }
     }
 
+    #[stable(feature = "never_hash", since = "1.29.0")]
+    impl Hash for ! {
+        fn hash<H: Hasher>(&self, _: &mut H) {
+            *self
+        }
+    }
+
     macro_rules! impl_hash_tuple {
         () => (
             #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
This was missing in some generic code I was writing and I figured that it would be worthwhile to add this. Blanket-requiring these traits to allow usage of errors in `HashSet`s and `HashMap`s isn't too unreasonable of a use case, and a prerequisite for allowing `!` as an error in such situations is this impl.