### PR TITLE
Tries to address the recent network issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -301,7 +301,6 @@ before_deploy:
           rm -rf obj/build/dist/doc &&
           cp -r obj/build/dist/* deploy/$TRAVIS_COMMIT;
       fi
-  - travis_retry gem update --system
   - ls -la deploy/$TRAVIS_COMMIT
 
 deploy:

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -118,6 +118,10 @@ fi
 # goes ahead and sets it for all builders.
 args="$args --privileged"
 
+if [ "$CI" != "" ]; then
+    args="$args --dns 8.8.8.8 --dns 8.8.4.4 --dns 1.1.1.1 --dns 1.0.0.1"
+fi
+
 exec docker \
   run \
   --volume "$root_dir:/checkout:ro" \


### PR DESCRIPTION
1. Set the DNS server to 8.8.8.8/8.8.4.4/1.1.1.1/1.0.0.1 to workaround the daily "Cannot resolve host" error these two weeks.
2. Remove the unnecessary command `gem update --system` (originally added as experiment of the "Could not find a valid gem" error, which turns out to be useless). 