### PR TITLE
Removed `uninitialized_statics` field from `Memory` struct in miri

### DIFF
--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write;
+use std::mem;
 
 use rustc::hir::def_id::DefId;
 use rustc::hir::def::Def;
@@ -9,14 +10,13 @@ use rustc::ty::subst::{Subst, Substs};
 use rustc::ty::{self, Ty, TyCtxt, TypeAndMut};
 use rustc::ty::query::TyCtxtAt;
 use rustc_data_structures::indexed_vec::{IndexVec, Idx};
-use rustc::mir::interpret::FrameInfo;
-use syntax::codemap::{self, Span};
-use syntax::ast::Mutability;
 use rustc::mir::interpret::{
-    GlobalId, Value, Scalar,
+    FrameInfo, GlobalId, Value, Scalar,
     EvalResult, EvalErrorKind, Pointer, ConstValue,
 };
-use std::mem;
+
+use syntax::codemap::{self, Span};
+use syntax::ast::Mutability;
 
 use super::{Place, PlaceExtra, Memory,
             HasMemory, MemoryKind,
@@ -206,7 +206,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M
         let layout = self.layout_of(ty)?;
         assert!(!layout.is_unsized(), "cannot alloc memory for unsized type");
 
-        self.memory.allocate(layout.size, layout.align, Some(MemoryKind::Stack))
+        self.memory.allocate(layout.size, layout.align, MemoryKind::Stack)
     }
 
     pub fn memory(&self) -> &Memory<'a, 'mir, 'tcx, M> {
@@ -246,7 +246,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M
             }
             ConstValue::ByRef(alloc, offset) => {
                 // FIXME: Allocate new AllocId for all constants inside
-                let id = self.memory.allocate_value(alloc.clone(), Some(MemoryKind::Stack))?;
+                let id = self.memory.allocate_value(alloc.clone(), MemoryKind::Stack)?;
                 Ok(Value::ByRef(Pointer::new(id, offset).into(), alloc.align))
             },
             ConstValue::ScalarPair(a, b) => Ok(Value::ScalarPair(a, b)),

--- a/src/librustc_mir/interpret/traits.rs
+++ b/src/librustc_mir/interpret/traits.rs
@@ -1,9 +1,10 @@
 use rustc::ty::{self, Ty};
 use rustc::ty::layout::{Size, Align, LayoutOf};
+use rustc::mir::interpret::{Scalar, Value, Pointer, EvalResult};
+
 use syntax::ast::Mutability;
 
-use rustc::mir::interpret::{Scalar, Value, Pointer, EvalResult};
-use super::{EvalContext, Machine};
+use super::{EvalContext, Machine, MemoryKind};
 
 impl<'a, 'mir, 'tcx, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> {
     /// Creates a dynamic vtable for the given type and vtable origin. This is used only for
@@ -30,7 +31,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> {
         let vtable = self.memory.allocate(
             ptr_size * (3 + methods.len() as u64),
             ptr_align,
-            None,
+            MemoryKind::Stack,
         )?;
 
         let drop = ::monomorphize::resolve_drop_in_place(*self.tcx, ty);


### PR DESCRIPTION
based on #51110 

r? @oli-obk

CC @eddyb