### PR TITLE
Add an extended prelude for the 2018 editions

### DIFF
--- a/src/libcore/prelude/rust2018.rs
+++ b/src/libcore/prelude/rust2018.rs
@@ -1,0 +1,53 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! The 2018 edition core prelude
+//!
+//! This module is intended for users of libcore which do not link to libstd as
+//! well. This module is imported by default when `#![no_std]` is used in the
+//! same manner as the standard library's prelude.
+
+#![unstable(feature = "rust2018_prelude", issue = "51418")]
+
+// Re-exported core operators
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use marker::{Copy, Send, Sized, Sync};
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use ops::{Drop, Fn, FnMut, FnOnce};
+
+// Re-exported functions
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use mem::drop;
+
+// Re-exported types and traits
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use clone::Clone;
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use cmp::{PartialEq, PartialOrd, Eq, Ord};
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use convert::{AsRef, AsMut, Into, From};
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use default::Default;
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use iter::{Iterator, Extend, IntoIterator};
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use iter::{DoubleEndedIterator, ExactSizeIterator};
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use option::Option::{self, Some, None};
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use result::Result::{self, Ok, Err};
+
+
+// Contents so far are equivalent to v1.rs
+
+
+// Not in v1.rs because of breakage: https://github.com/rust-lang/rust/pull/49518
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use convert::{TryFrom, TryInto};

--- a/src/libcore/prelude/v1.rs
+++ b/src/libcore/prelude/v1.rs
@@ -18,39 +18,28 @@
 
 // Re-exported core operators
 #[stable(feature = "core_prelude", since = "1.4.0")]
-#[doc(no_inline)]
-pub use marker::{Copy, Send, Sized, Sync};
+#[doc(no_inline)] pub use marker::{Copy, Send, Sized, Sync};
 #[stable(feature = "core_prelude", since = "1.4.0")]
-#[doc(no_inline)]
-pub use ops::{Drop, Fn, FnMut, FnOnce};
+#[doc(no_inline)] pub use ops::{Drop, Fn, FnMut, FnOnce};
 
 // Re-exported functions
 #[stable(feature = "core_prelude", since = "1.4.0")]
-#[doc(no_inline)]
-pub use mem::drop;
+#[doc(no_inline)] pub use mem::drop;
 
 // Re-exported types and traits
 #[stable(feature = "core_prelude", since = "1.4.0")]
-#[doc(no_inline)]
-pub use clone::Clone;
+#[doc(no_inline)] pub use clone::Clone;
 #[stable(feature = "core_prelude", since = "1.4.0")]
-#[doc(no_inline)]
-pub use cmp::{PartialEq, PartialOrd, Eq, Ord};
+#[doc(no_inline)] pub use cmp::{PartialEq, PartialOrd, Eq, Ord};
 #[stable(feature = "core_prelude", since = "1.4.0")]
-#[doc(no_inline)]
-pub use convert::{AsRef, AsMut, Into, From};
+#[doc(no_inline)] pub use convert::{AsRef, AsMut, Into, From};
 #[stable(feature = "core_prelude", since = "1.4.0")]
-#[doc(no_inline)]
-pub use default::Default;
+#[doc(no_inline)] pub use default::Default;
 #[stable(feature = "core_prelude", since = "1.4.0")]
-#[doc(no_inline)]
-pub use iter::{Iterator, Extend, IntoIterator};
+#[doc(no_inline)] pub use iter::{Iterator, Extend, IntoIterator};
 #[stable(feature = "core_prelude", since = "1.4.0")]
-#[doc(no_inline)]
-pub use iter::{DoubleEndedIterator, ExactSizeIterator};
+#[doc(no_inline)] pub use iter::{DoubleEndedIterator, ExactSizeIterator};
 #[stable(feature = "core_prelude", since = "1.4.0")]
-#[doc(no_inline)]
-pub use option::Option::{self, Some, None};
+#[doc(no_inline)] pub use option::Option::{self, Some, None};
 #[stable(feature = "core_prelude", since = "1.4.0")]
-#[doc(no_inline)]
-pub use result::Result::{self, Ok, Err};
+#[doc(no_inline)] pub use result::Result::{self, Ok, Err};

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -850,7 +850,7 @@ where
 
     krate = time(sess, "crate injection", || {
         let alt_std_name = sess.opts.alt_std_name.as_ref().map(|s| &**s);
-        syntax::std_inject::maybe_inject_crates_ref(krate, alt_std_name)
+        syntax::std_inject::maybe_inject_crates_ref(sess.edition(), krate, alt_std_name)
     });
 
     let mut addl_plugins = Some(addl_plugins);

--- a/src/libstd/prelude/mod.rs
+++ b/src/libstd/prelude/mod.rs
@@ -146,3 +146,4 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 pub mod v1;
+pub mod rust2018;

--- a/src/libstd/prelude/rust2018.rs
+++ b/src/libstd/prelude/rust2018.rs
@@ -1,0 +1,69 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+//! The 2018 edition of the prelude of The Rust Standard Library.
+//!
+//! See the [module-level documentation](../index.html) for more.
+
+
+#![unstable(feature = "rust2018_prelude", issue = "51418")]
+
+// Re-exported core operators
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use marker::{Copy, Send, Sized, Sync};
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use ops::{Drop, Fn, FnMut, FnOnce};
+
+// Re-exported functions
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use mem::drop;
+
+// Re-exported types and traits
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use clone::Clone;
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use cmp::{PartialEq, PartialOrd, Eq, Ord};
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use convert::{AsRef, AsMut, Into, From};
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use default::Default;
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use iter::{Iterator, Extend, IntoIterator};
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use iter::{DoubleEndedIterator, ExactSizeIterator};
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use option::Option::{self, Some, None};
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use result::Result::{self, Ok, Err};
+
+
+// Contents so far are equivalent to src/libcore/prelude/v1.rs
+
+
+// Re-exported types and traits that involve memory allocation
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use boxed::Box;
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use borrow::ToOwned;
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use slice::SliceConcatExt;
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use string::{String, ToString};
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use vec::Vec;
+
+
+// Contents so far are equivalent to v1.rs
+
+
+// Not in v1.rs because of breakage: https://github.com/rust-lang/rust/pull/49518
+#[unstable(feature = "rust2018_prelude", issue = "51418")]
+#[doc(no_inline)] pub use convert::{TryFrom, TryInto};

--- a/src/libstd/prelude/v1.rs
+++ b/src/libstd/prelude/v1.rs
@@ -8,9 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+
 //! The first version of the prelude of The Rust Standard Library.
 //!
 //! See the [module-level documentation](../index.html) for more.
+
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -25,10 +27,6 @@
 #[doc(no_inline)] pub use mem::drop;
 
 // Re-exported types and traits
-#[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)] pub use boxed::Box;
-#[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)] pub use borrow::ToOwned;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)] pub use clone::Clone;
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -45,6 +43,16 @@
 #[doc(no_inline)] pub use option::Option::{self, Some, None};
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)] pub use result::Result::{self, Ok, Err};
+
+
+// Contents so far are equivalent to src/libcore/prelude/v1.rs
+
+
+// Re-exported types and traits that involve memory allocation
+#[stable(feature = "rust1", since = "1.0.0")]
+#[doc(no_inline)] pub use boxed::Box;
+#[stable(feature = "rust1", since = "1.0.0")]
+#[doc(no_inline)] pub use borrow::ToOwned;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)] pub use slice::SliceConcatExt;
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libsyntax/std_inject.rs
+++ b/src/libsyntax/std_inject.rs
@@ -11,6 +11,7 @@
 use ast;
 use attr;
 use std::cell::Cell;
+use edition::Edition;
 use ext::hygiene::{Mark, SyntaxContext};
 use symbol::{Symbol, keywords};
 use syntax_pos::{DUMMY_SP, Span};
@@ -44,7 +45,11 @@ thread_local! {
     static INJECTED_CRATE_NAME: Cell<Option<&'static str>> = Cell::new(None);
 }
 
-pub fn maybe_inject_crates_ref(mut krate: ast::Crate, alt_std_name: Option<&str>) -> ast::Crate {
+pub fn maybe_inject_crates_ref(
+    edition: Edition,
+    mut krate: ast::Crate,
+    alt_std_name: Option<&str>,
+) -> ast::Crate {
     // the first name in this list is the crate name of the crate with the prelude
     let names: &[&str] = if attr::contains_name(&krate.attrs, "no_core") {
         return krate;
@@ -92,7 +97,7 @@ pub fn maybe_inject_crates_ref(mut krate: ast::Crate, alt_std_name: Option<&str>
         vis: respan(span.shrink_to_lo(), ast::VisibilityKind::Inherited),
         node: ast::ItemKind::Use(P(ast::UseTree {
             prefix: ast::Path {
-                segments: [name, "prelude", "v1"].into_iter().map(|name| {
+                segments: [name, "prelude", edition.prelude_module()].into_iter().map(|name| {
                     ast::PathSegment::from_ident(ast::Ident::from_str(name))
                 }).collect(),
                 span,

--- a/src/libsyntax_pos/edition.rs
+++ b/src/libsyntax_pos/edition.rs
@@ -68,6 +68,14 @@ impl Edition {
             Edition::Edition2018 => false,
         }
     }
+
+    /// Name of the respective sub-modules of `std::prelude` and `core::prelude`.
+    pub fn prelude_module(&self) -> &'static str {
+        match *self {
+            Edition::Edition2015 => "v1",
+            Edition::Edition2018 => "rust2018",
+        }
+    }
 }
 
 impl FromStr for Edition {

--- a/src/test/run-pass/edition-2018-prelude-no-std.rs
+++ b/src/test/run-pass/edition-2018-prelude-no-std.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,9 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! The libcore prelude
+// compile-flags: --edition=2018
 
-#![stable(feature = "core_prelude", since = "1.4.0")]
+#![no_std]
+#![feature(try_from)]
 
-pub mod v1;
-pub mod rust2018;
+extern crate std;
+
+fn main() {
+    u8::try_from(4_u32).unwrap();  // Using the TryFrom trait from core::prelude::rust2018
+}

--- a/src/test/run-pass/edition-2018-prelude.rs
+++ b/src/test/run-pass/edition-2018-prelude.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,9 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! The libcore prelude
+// compile-flags: --edition=2018
 
-#![stable(feature = "core_prelude", since = "1.4.0")]
+#![feature(try_from)]
 
-pub mod v1;
-pub mod rust2018;
+fn main() {
+    u8::try_from(4_u32).unwrap();  // Using the TryFrom trait from std::prelude::rust2018
+}

--- a/src/test/ui/issue-35675.stderr
+++ b/src/test/ui/issue-35675.stderr
@@ -42,6 +42,7 @@ error[E0573]: expected type, found variant `Ok`
 LL | fn foo() -> Ok {
    |             ^^ not a type
    |
+   = help: there is an enum variant `std::prelude::rust2018::Ok`, try using `std::prelude::rust2018`?
    = help: there is an enum variant `std::prelude::v1::Ok`, try using `std::prelude::v1`?
    = help: there is an enum variant `std::result::Result::Ok`, try using `std::result::Result`?
 
@@ -60,6 +61,7 @@ error[E0573]: expected type, found variant `Some`
 LL | fn qux() -> Some {
    |             ^^^^ not a type
    |
+   = help: there is an enum variant `std::prelude::rust2018::Some`, try using `std::prelude::rust2018`?
    = help: there is an enum variant `std::prelude::v1::Option::Some`, try using `std::prelude::v1::Option`?
    = help: there is an enum variant `std::prelude::v1::Some`, try using `std::prelude::v1`?
 


### PR DESCRIPTION
As proposed in https://github.com/rust-lang/rust/issues/51418.

----

**Update:** Per discussion below this PR also needs to add a warning for 2015 edition code that would break with the new prelude. Help wanted: any ideas how to make that happen?