### PR TITLE
Do not require stage 2 compiler for rustdoc

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -800,10 +800,7 @@ impl<'a> Builder<'a> {
             cargo.env("RUSTC_ERROR_FORMAT", error_format);
         }
         if cmd != "build" && cmd != "check" && want_rustdoc {
-            cargo.env(
-                "RUSTDOC_LIBDIR",
-                self.rustc_libdir(self.compiler(2, self.config.build)),
-            );
+            cargo.env("RUSTDOC_LIBDIR", self.sysroot_libdir(compiler, self.config.build));
         }
 
         if mode.is_tool() {


### PR DESCRIPTION
r? @QuietMisdreavus 

Fixes https://github.com/rust-lang/rust/issues/51424

I *think* this is correct; though I'm not certain. If it passes CI though I expect that to be good enough...