### PR TITLE
rustbuild: generate full list of dependencies for metadata

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -280,7 +280,8 @@ pub struct Build {
 struct Crate {
     name: Interned<String>,
     version: String,
-    deps: Vec<Interned<String>>,
+    deps: HashSet<Interned<String>>,
+    id: String,
     path: PathBuf,
     doc_step: String,
     build_step: String,


### PR DESCRIPTION
Previously, we didn't send --features to our cargo metadata invocations,
and thus missed some dependencies that we enable through the --features
mechanism.