### PR TITLE
Compile core crates before std

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -21,8 +21,6 @@ version = "0.0.0"
 dependencies = [
  "build_helper 0.1.0",
  "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "compiler_builtins 0.0.0",
- "core 0.0.0",
  "libc 0.0.0",
 ]
 
@@ -30,8 +28,6 @@ dependencies = [
 name = "alloc_system"
 version = "0.0.0"
 dependencies = [
- "compiler_builtins 0.0.0",
- "core 0.0.0",
  "dlmalloc 0.0.0",
  "libc 0.0.0",
 ]
@@ -598,10 +594,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "dlmalloc"
 version = "0.0.0"
-dependencies = [
- "compiler_builtins 0.0.0",
- "core 0.0.0",
-]
 
 [[package]]
 name = "dtoa"
@@ -1060,10 +1052,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libc"
 version = "0.0.0"
-dependencies = [
- "compiler_builtins 0.0.0",
- "core 0.0.0",
-]
 
 [[package]]
 name = "libc"
@@ -1350,8 +1338,6 @@ dependencies = [
 name = "panic_abort"
 version = "0.0.0"
 dependencies = [
- "compiler_builtins 0.0.0",
- "core 0.0.0",
  "libc 0.0.0",
 ]
 
@@ -1359,9 +1345,6 @@ dependencies = [
 name = "panic_unwind"
 version = "0.0.0"
 dependencies = [
- "alloc 0.0.0",
- "compiler_builtins 0.0.0",
- "core 0.0.0",
  "libc 0.0.0",
  "unwind 0.0.0",
 ]
@@ -1501,8 +1484,6 @@ name = "profiler_builtins"
 version = "0.0.0"
 dependencies = [
  "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "compiler_builtins 0.0.0",
- "core 0.0.0",
 ]
 
 [[package]]
@@ -2054,12 +2035,9 @@ dependencies = [
 name = "rustc_asan"
 version = "0.0.0"
 dependencies = [
- "alloc 0.0.0",
  "alloc_system 0.0.0",
  "build_helper 0.1.0",
  "cmake 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "compiler_builtins 0.0.0",
- "core 0.0.0",
 ]
 
 [[package]]
@@ -2235,12 +2213,9 @@ dependencies = [
 name = "rustc_lsan"
 version = "0.0.0"
 dependencies = [
- "alloc 0.0.0",
  "alloc_system 0.0.0",
  "build_helper 0.1.0",
  "cmake 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "compiler_builtins 0.0.0",
- "core 0.0.0",
 ]
 
 [[package]]
@@ -2286,12 +2261,9 @@ dependencies = [
 name = "rustc_msan"
 version = "0.0.0"
 dependencies = [
- "alloc 0.0.0",
  "alloc_system 0.0.0",
  "build_helper 0.1.0",
  "cmake 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "compiler_builtins 0.0.0",
- "core 0.0.0",
 ]
 
 [[package]]
@@ -2390,12 +2362,9 @@ dependencies = [
 name = "rustc_tsan"
 version = "0.0.0"
 dependencies = [
- "alloc 0.0.0",
  "alloc_system 0.0.0",
  "build_helper 0.1.0",
  "cmake 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "compiler_builtins 0.0.0",
- "core 0.0.0",
 ]
 
 [[package]]
@@ -2632,13 +2601,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "std"
 version = "0.0.0"
 dependencies = [
- "alloc 0.0.0",
  "alloc_jemalloc 0.0.0",
  "alloc_system 0.0.0",
  "build_helper 0.1.0",
  "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "compiler_builtins 0.0.0",
- "core 0.0.0",
  "libc 0.0.0",
  "panic_abort 0.0.0",
  "panic_unwind 0.0.0",
@@ -2648,7 +2614,6 @@ dependencies = [
  "rustc_lsan 0.0.0",
  "rustc_msan 0.0.0",
  "rustc_tsan 0.0.0",
- "std_unicode 0.0.0",
  "unwind 0.0.0",
 ]
 
@@ -3037,8 +3002,6 @@ dependencies = [
 name = "unwind"
 version = "0.0.0"
 dependencies = [
- "compiler_builtins 0.0.0",
- "core 0.0.0",
  "libc 0.0.0",
 ]
 

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,6 +1,9 @@
 [workspace]
 members = [
   "bootstrap",
+  "libcore",
+  "libstd_unicode",
+  "liballoc",
   "rustc",
   "libstd",
   "libtest",

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -29,6 +29,10 @@ impl Step for Std {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         run.all_krates("std")
+            .path("src/libcore")
+            .path("src/liballoc")
+            .path("src/libstd_unicode")
+            .path("src/rustc/compiler_builtins_shim")
     }
 
     fn make_run(run: RunConfig) {

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -50,6 +50,10 @@ impl Step for Std {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         run.all_krates("std")
+            .path("src/libcore")
+            .path("src/liballoc")
+            .path("src/libstd_unicode")
+            .path("src/rustc/compiler_builtins_shim")
     }
 
     fn make_run(run: RunConfig) {

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -133,15 +133,19 @@ fn copy_musl_third_party_objects(builder: &Builder,
     }
 }
 
+fn mac_os_deployment_env_var(cargo: &mut Command) {
+    if let Some(target) = env::var_os("MACOSX_STD_DEPLOYMENT_TARGET") {
+        cargo.env("MACOSX_DEPLOYMENT_TARGET", target);
+    }
+}
+
 /// Configure cargo to compile the standard library, adding appropriate env vars
 /// and such.
 pub fn std_cargo(builder: &Builder,
                  compiler: &Compiler,
                  target: Interned<String>,
                  cargo: &mut Command) {
-    if let Some(target) = env::var_os("MACOSX_STD_DEPLOYMENT_TARGET") {
-        cargo.env("MACOSX_DEPLOYMENT_TARGET", target);
-    }
+    mac_os_deployment_env_var(cargo);
 
     if builder.no_std(target) == Some(true) {
         // for no-std targets we only compile a few no_std crates
@@ -394,9 +398,7 @@ pub fn test_cargo(builder: &Builder,
                   _compiler: &Compiler,
                   _target: Interned<String>,
                   cargo: &mut Command) {
-    if let Some(target) = env::var_os("MACOSX_STD_DEPLOYMENT_TARGET") {
-        cargo.env("MACOSX_DEPLOYMENT_TARGET", target);
-    }
+    mac_os_deployment_env_var(cargo);
     cargo.arg("--manifest-path")
         .arg(builder.src.join("src/libtest/Cargo.toml"));
 }

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -85,6 +85,12 @@ impl Step for Std {
                 copy_musl_third_party_objects(builder, target, &libdir);
             }
 
+            builder.ensure(CoreLink {
+                compiler: from,
+                target_compiler: compiler,
+                target,
+            });
+
             builder.ensure(StdLink {
                 compiler: from,
                 target_compiler: compiler,

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -434,7 +434,12 @@ impl Step for Std {
 
     fn should_run(run: ShouldRun) -> ShouldRun {
         let builder = run.builder;
-        run.all_krates("std").default_condition(builder.config.docs)
+        run.all_krates("std")
+            .path("src/libcore")
+            .path("src/liballoc")
+            .path("src/libstd_unicode")
+            .path("src/rustc/compiler_builtins_shim")
+            .default_condition(builder.config.docs)
     }
 
     fn make_run(run: RunConfig) {

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1526,7 +1526,10 @@ impl Step for Crate {
                 run = run.path(krate.local_path(&builder).to_str().unwrap());
             }
         }
-        run
+        run.path("src/libcore")
+            .path("src/liballoc")
+            .path("src/libstd_unicode")
+            .path("src/rustc/compiler_builtins_shim")
     }
 
     fn make_run(run: RunConfig) {

--- a/src/liballoc_jemalloc/Cargo.toml
+++ b/src/liballoc_jemalloc/Cargo.toml
@@ -12,9 +12,7 @@ test = false
 doc = false
 
 [dependencies]
-core = { path = "../libcore" }
 libc = { path = "../rustc/libc_shim" }
-compiler_builtins = { path = "../rustc/compiler_builtins_shim" }
 
 [build-dependencies]
 build_helper = { path = "../build_helper" }

--- a/src/liballoc_system/Cargo.toml
+++ b/src/liballoc_system/Cargo.toml
@@ -10,9 +10,7 @@ test = false
 doc = false
 
 [dependencies]
-core = { path = "../libcore" }
 libc = { path = "../rustc/libc_shim" }
-compiler_builtins = { path = "../rustc/compiler_builtins_shim" }
 
 # See comments in the source for what this dependency is
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]

--- a/src/libpanic_abort/Cargo.toml
+++ b/src/libpanic_abort/Cargo.toml
@@ -10,6 +10,4 @@ bench = false
 doc = false
 
 [dependencies]
-core = { path = "../libcore" }
 libc = { path = "../rustc/libc_shim" }
-compiler_builtins = { path = "../rustc/compiler_builtins_shim" }

--- a/src/libpanic_unwind/Cargo.toml
+++ b/src/libpanic_unwind/Cargo.toml
@@ -10,8 +10,5 @@ bench = false
 doc = false
 
 [dependencies]
-alloc = { path = "../liballoc" }
-core = { path = "../libcore" }
 libc = { path = "../rustc/libc_shim" }
 unwind = { path = "../libunwind" }
-compiler_builtins = { path = "../rustc/compiler_builtins_shim" }

--- a/src/libprofiler_builtins/Cargo.toml
+++ b/src/libprofiler_builtins/Cargo.toml
@@ -11,9 +11,5 @@ test = false
 bench = false
 doc = false
 
-[dependencies]
-core = { path = "../libcore" }
-compiler_builtins = { path = "../rustc/compiler_builtins_shim" }
-
 [build-dependencies]
 cc = "1.0.1"

--- a/src/librustc_asan/Cargo.toml
+++ b/src/librustc_asan/Cargo.toml
@@ -14,7 +14,4 @@ build_helper = { path = "../build_helper" }
 cmake = "0.1.18"
 
 [dependencies]
-alloc = { path = "../liballoc" }
 alloc_system = { path = "../liballoc_system" }
-core = { path = "../libcore" }
-compiler_builtins = { path = "../rustc/compiler_builtins_shim" }

--- a/src/librustc_lsan/Cargo.toml
+++ b/src/librustc_lsan/Cargo.toml
@@ -14,7 +14,4 @@ build_helper = { path = "../build_helper" }
 cmake = "0.1.18"
 
 [dependencies]
-alloc = { path = "../liballoc" }
 alloc_system = { path = "../liballoc_system" }
-core = { path = "../libcore" }
-compiler_builtins = { path = "../rustc/compiler_builtins_shim" }

--- a/src/librustc_msan/Cargo.toml
+++ b/src/librustc_msan/Cargo.toml
@@ -14,7 +14,4 @@ build_helper = { path = "../build_helper" }
 cmake = "0.1.18"
 
 [dependencies]
-alloc = { path = "../liballoc" }
 alloc_system = { path = "../liballoc_system" }
-core = { path = "../libcore" }
-compiler_builtins = { path = "../rustc/compiler_builtins_shim" }

--- a/src/librustc_tsan/Cargo.toml
+++ b/src/librustc_tsan/Cargo.toml
@@ -14,7 +14,4 @@ build_helper = { path = "../build_helper" }
 cmake = "0.1.18"
 
 [dependencies]
-alloc = { path = "../liballoc" }
 alloc_system = { path = "../liballoc_system" }
-core = { path = "../libcore" }
-compiler_builtins = { path = "../rustc/compiler_builtins_shim" }

--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -13,16 +13,12 @@ path = "lib.rs"
 crate-type = ["dylib", "rlib"]
 
 [dependencies]
-alloc = { path = "../liballoc" }
 alloc_jemalloc = { path = "../liballoc_jemalloc", optional = true }
 alloc_system = { path = "../liballoc_system" }
 panic_unwind = { path = "../libpanic_unwind", optional = true }
 panic_abort = { path = "../libpanic_abort" }
-core = { path = "../libcore" }
 libc = { path = "../rustc/libc_shim" }
-compiler_builtins = { path = "../rustc/compiler_builtins_shim" }
 profiler_builtins = { path = "../libprofiler_builtins", optional = true }
-std_unicode = { path = "../libstd_unicode" }
 unwind = { path = "../libunwind" }
 
 [dev-dependencies]

--- a/src/libunwind/Cargo.toml
+++ b/src/libunwind/Cargo.toml
@@ -12,6 +12,4 @@ bench = false
 doc = false
 
 [dependencies]
-core = { path = "../libcore" }
 libc = { path = "../rustc/libc_shim" }
-compiler_builtins = { path = "../rustc/compiler_builtins_shim" }

--- a/src/rustc/dlmalloc_shim/Cargo.toml
+++ b/src/rustc/dlmalloc_shim/Cargo.toml
@@ -8,7 +8,3 @@ path = "../../dlmalloc/src/lib.rs"
 test = false
 bench = false
 doc = false
-
-[dependencies]
-core = { path = "../../libcore" }
-compiler_builtins = { path = "../../rustc/compiler_builtins_shim" }

--- a/src/rustc/libc_shim/Cargo.toml
+++ b/src/rustc/libc_shim/Cargo.toml
@@ -10,28 +10,6 @@ test = false
 bench = false
 doc = false
 
-[dependencies]
-# Specify the path to libcore; at the time of writing, removing this shim in
-# favor of using libc from git results in a compilation failure:
-#
-# Building stage0 std artifacts (x86_64-apple-darwin -> x86_64-apple-darwin)
-#    Compiling libc v0.0.0 (file:///Users/tamird/src/rust/src/rustc/libc_shim)
-# error[E0463]: can't find crate for `core`
-#
-# error: aborting due to previous error
-#
-# error: Could not compile `libc`.
-#
-# Caused by:
-#   process didn't exit successfully: `/Users/tamird/src/rust/build/bootstrap/debug/rustc --crate-name libc src/rustc/libc_shim/../../liblibc/src/lib.rs --error-format json --crate-type lib --emit=dep-info,link -C opt-level=2 --cfg feature="default" --cfg feature="no_std" --cfg feature="stdbuild" -C metadata=d758f87058112d7d -C extra-filename=-d758f87058112d7d --out-dir /Users/tamird/src/rust/build/x86_64-apple-darwin/stage0-std/x86_64-apple-darwin/release/deps --target x86_64-apple-darwin -L dependency=/Users/tamird/src/rust/build/x86_64-apple-darwin/stage0-std/x86_64-apple-darwin/release/deps -L dependency=/Users/tamird/src/rust/build/x86_64-apple-darwin/stage0-std/release/deps` (exit code: 101)
-# thread 'main' panicked at 'command did not execute successfully: "/Users/tamird/src/rust/build/x86_64-apple-darwin/stage0/bin/cargo" "build" "-j" "4" "--target" "x86_64-apple-darwin" "--release" "--features" "panic-unwind jemalloc backtrace" "--manifest-path" "/Users/tamird/src/rust/src/libstd/Cargo.toml" "--message-format" "json"
-# expected success, got: exit code: 101', src/bootstrap/compile.rs:883:8
-#
-# See https://github.com/rust-lang/rfcs/pull/1133.
-core = { path = "../../libcore" }
-compiler_builtins = { path = "../compiler_builtins_shim" }
-
-
 [features]
 # Certain parts of libc are conditionally compiled differently than when used
 # outside rustc. See https://github.com/rust-lang/libc/search?l=Rust&q=stdbuild&type=&utf8=%E2%9C%93.


### PR DESCRIPTION
Right now, many crates used by `std` need to manually specify dependencies onto crates like `core`, as they need to be built after core has been built. For some crates from external sources, we provide our own Cargo.toml files so that we can write out that dependency (and other, rustbuild specific things).

This PR splits up the std compilation step in rustbuild into two semi-steps. One which compiles three `#![no_std]` crates `libcore`, `compiler_builtins`, and `libstd_unicode`, and a second step which compiles the remainder.

Thanks to this, it alleviates the need to specify dependencies onto those crates, and allows libstd to depend on `#![no_std]` crates from crates.io without modification.

Needed by #51408

r? @Mark-Simulacrum 