### PR TITLE
[futures] add a few blanket impls to std

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -933,27 +933,6 @@ impl<'a, F: ?Sized + Future> Future for PinBox<F> {
 }
 
 #[unstable(feature = "futures_api", issue = "50547")]
-unsafe impl<F: Future<Output = ()> + Send + 'static> UnsafePoll for Box<F> {
-    fn into_raw(self) -> *mut () {
-        unsafe {
-            mem::transmute(self)
-        }
-    }
-
-    unsafe fn poll(task: *mut (), cx: &mut Context) -> Poll<()> {
-        let ptr: *mut F = mem::transmute(task);
-        let pin: PinMut<F> = PinMut::new_unchecked(&mut *ptr);
-        pin.poll(cx)
-    }
-
-    unsafe fn drop(task: *mut ()) {
-        let ptr: *mut F = mem::transmute(task);
-        let boxed = Box::from_raw(ptr);
-        drop(boxed)
-    }
-}
-
-#[unstable(feature = "futures_api", issue = "50547")]
 unsafe impl<F: Future<Output = ()> + Send + 'static> UnsafePoll for PinBox<F> {
     fn into_raw(self) -> *mut () {
         PinBox::into_raw(self) as *mut ()

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -80,6 +80,7 @@
 #![cfg_attr(test, feature(rand, test))]
 #![feature(allocator_api)]
 #![feature(allow_internal_unstable)]
+#![feature(arbitrary_self_types)]
 #![feature(ascii_ctype)]
 #![feature(box_into_raw_non_null)]
 #![feature(box_patterns)]

--- a/src/libcore/task.rs
+++ b/src/libcore/task.rs
@@ -32,6 +32,12 @@ pub enum Poll<T> {
     Pending,
 }
 
+impl<T> From<T> for Poll<T> {
+    fn from(t: T) -> Poll<T> {
+        Poll::Ready(t)
+    }
+}
+
 /// A `Waker` is a handle for waking up a task by notifying its executor that it
 /// is ready to be run.
 ///

--- a/src/libcore/task.rs
+++ b/src/libcore/task.rs
@@ -32,6 +32,55 @@ pub enum Poll<T> {
     Pending,
 }
 
+impl<T> Poll<T> {
+    /// Change the ready value of this `Poll` with the closure provided
+    pub fn map<U, F>(self, f: F) -> Poll<U>
+        where F: FnOnce(T) -> U
+    {
+        match self {
+            Poll::Ready(t) => Poll::Ready(f(t)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    /// Returns whether this is `Poll::Ready`
+    pub fn is_ready(&self) -> bool {
+        match *self {
+            Poll::Ready(_) => true,
+            Poll::Pending => false,
+        }
+    }
+
+    /// Returns whether this is `Poll::Pending`
+    pub fn is_pending(&self) -> bool {
+        !self.is_ready()
+    }
+}
+
+impl<T, E> Poll<Result<T, E>> {
+    /// Change the success value of this `Poll` with the closure provided
+    pub fn map_ok<U, F>(self, f: F) -> Poll<Result<U, E>>
+        where F: FnOnce(T) -> U
+    {
+        match self {
+            Poll::Ready(Ok(t)) => Poll::Ready(Ok(f(t))),
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    /// Change the error value of this `Poll` with the closure provided
+    pub fn map_err<U, F>(self, f: F) -> Poll<Result<T, U>>
+        where F: FnOnce(E) -> U
+    {
+        match self {
+            Poll::Ready(Ok(t)) => Poll::Ready(Ok(t)),
+            Poll::Ready(Err(e)) => Poll::Ready(Err(f(e))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
 impl<T> From<T> for Poll<T> {
     fn from(t: T) -> Poll<T> {
         Poll::Ready(t)

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -239,6 +239,7 @@
 #![feature(allow_internal_unsafe)]
 #![feature(allow_internal_unstable)]
 #![feature(align_offset)]
+#![feature(arbitrary_self_types)]
 #![feature(array_error_internals)]
 #![feature(ascii_ctype)]
 #![feature(asm)]

--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -326,9 +326,9 @@ impl<'a, F: Future> Future for AssertUnwindSafe<F> {
         unsafe {
             let pinned_field = PinMut::new_unchecked(
                 &mut PinMut::get_mut(self.reborrow()).0
-            ); 
-
-            pinned_field.poll(cx) 
+            );
+            
+            pinned_field.poll(cx)
         }
     }
 }

--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -327,7 +327,7 @@ impl<'a, F: Future> Future for AssertUnwindSafe<F> {
             let pinned_field = PinMut::new_unchecked(
                 &mut PinMut::get_mut(self.reborrow()).0
             );
-            
+
             pinned_field.poll(cx)
         }
     }


### PR DESCRIPTION
these were defined in the futures crate, but with the core definitions moving to std these would need to move too.