### PR TITLE
Add lint warning for inner function marked as `#[test]`

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1740,20 +1740,20 @@ impl EarlyLintPass for EllipsisInclusiveRangePatterns {
 }
 
 declare_lint! {
-    UNTESTABLE_METHOD,
+    UNNAMEABLE_TEST_FUNCTIONS,
     Warn,
-    "detects untestable method marked as #[test]"
+    "detects an function that cannot be named being marked as #[test]"
 }
 
-pub struct UntestableMethod;
+pub struct UnnameableTestFunctions;
 
-impl LintPass for UntestableMethod {
+impl LintPass for UnnameableTestFunctions {
     fn get_lints(&self) -> LintArray {
-        lint_array!(UNTESTABLE_METHOD)
+        lint_array!(UNNAMEABLE_TEST_FUNCTIONS)
     }
 }
 
-impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UntestableMethod {
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnnameableTestFunctions {
     fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
         match it.node {
             hir::ItemFn(..) => {
@@ -1765,7 +1765,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UntestableMethod {
                             None => {}
                             _ => {
                                 cx.struct_span_lint(
-                                    UNTESTABLE_METHOD,
+                                    UNNAMEABLE_TEST_FUNCTIONS,
                                     attr.span,
                                     "cannot test inner function",
                                 ).emit();

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -130,6 +130,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
         MutableTransmutes: MutableTransmutes,
         UnionsWithDropFields: UnionsWithDropFields,
         UnreachablePub: UnreachablePub,
+        UntestableMethod: UntestableMethod,
         TypeAliasBounds: TypeAliasBounds,
         UnusedBrokenConst: UnusedBrokenConst,
         TrivialConstraints: TrivialConstraints,

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -130,7 +130,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
         MutableTransmutes: MutableTransmutes,
         UnionsWithDropFields: UnionsWithDropFields,
         UnreachablePub: UnreachablePub,
-        UntestableMethod: UntestableMethod,
+        UnnameableTestFunctions: UnnameableTestFunctions,
         TypeAliasBounds: TypeAliasBounds,
         UnusedBrokenConst: UnusedBrokenConst,
         TrivialConstraints: TrivialConstraints,

--- a/src/test/ui/lint/test-inner-fn.rs
+++ b/src/test/ui/lint/test-inner-fn.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --test -D untestable_method
+// compile-flags: --test -D unnameable_test_functions
 
 #[test]
 fn foo() {
-    #[test] //~ ERROR cannot test inner function [untestable_method]
+    #[test] //~ ERROR cannot test inner function [unnameable_test_functions]
     fn bar() {}
     bar();
 }
@@ -20,7 +20,7 @@ fn foo() {
 mod x {
     #[test]
     fn foo() {
-        #[test] //~ ERROR cannot test inner function [untestable_method]
+        #[test] //~ ERROR cannot test inner function [unnameable_test_functions]
         fn bar() {}
         bar();
     }

--- a/src/test/ui/lint/test-inner-fn.rs
+++ b/src/test/ui/lint/test-inner-fn.rs
@@ -1,0 +1,29 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --test -D untestable_method
+
+#[test]
+fn foo() {
+    #[test] //~ ERROR cannot test inner function [untestable_method]
+    fn bar() {}
+    bar();
+}
+
+mod x {
+    #[test]
+    fn foo() {
+        #[test] //~ ERROR cannot test inner function [untestable_method]
+        fn bar() {}
+        bar();
+    }
+}
+
+fn main() {}

--- a/src/test/ui/lint/test-inner-fn.stderr
+++ b/src/test/ui/lint/test-inner-fn.stderr
@@ -1,0 +1,16 @@
+error: cannot test inner function
+  --> $DIR/test-inner-fn.rs:15:5
+   |
+LL |     #[test] //~ ERROR cannot test inner function [untestable_method]
+   |     ^^^^^^^
+   |
+   = note: requested on the command line with `-D untestable-method`
+
+error: cannot test inner function
+  --> $DIR/test-inner-fn.rs:23:9
+   |
+LL |         #[test] //~ ERROR cannot test inner function [untestable_method]
+   |         ^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/lint/test-inner-fn.stderr
+++ b/src/test/ui/lint/test-inner-fn.stderr
@@ -1,15 +1,15 @@
 error: cannot test inner function
   --> $DIR/test-inner-fn.rs:15:5
    |
-LL |     #[test] //~ ERROR cannot test inner function [untestable_method]
+LL |     #[test] //~ ERROR cannot test inner function [unnameable_test_functions]
    |     ^^^^^^^
    |
-   = note: requested on the command line with `-D untestable-method`
+   = note: requested on the command line with `-D unnameable-test-functions`
 
 error: cannot test inner function
   --> $DIR/test-inner-fn.rs:23:9
    |
-LL |         #[test] //~ ERROR cannot test inner function [untestable_method]
+LL |         #[test] //~ ERROR cannot test inner function [unnameable_test_functions]
    |         ^^^^^^^
 
 error: aborting due to 2 previous errors


### PR DESCRIPTION
Fix #36629.