### PR TITLE
resolve suggestions should use `crate::` when enabled

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4273,12 +4273,9 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                         if self.session.rust_2018() {
                             // crate-local absolute paths start with `crate::` in edition 2018
                             // FIXME: may also be stabilized for Rust 2015 (Issues #45477, #44660)
-                            let first_segment_ident = segms[0].ident;
-                            if first_segment_ident.name != "std" {
-                                segms.insert(
-                                    0, ast::PathSegment::from_ident(crate_name)
-                                );
-                            }
+                            segms.insert(
+                                0, ast::PathSegment::from_ident(crate_name)
+                            );
                         }
 
                         segms.push(ast::PathSegment::from_ident(ident));
@@ -4307,8 +4304,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
 
                     let is_extern_crate_that_also_appears_in_prelude =
                         name_binding.is_extern_crate() &&
-                        self.session.rust_2018() &&
-                        self.extern_prelude.contains(&ident.name);
+                        self.session.rust_2018();
 
                     let is_visible_to_user =
                         !in_module_is_extern || name_binding.vis == ty::Visibility::Public;

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4334,7 +4334,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
 
         suggestions.extend(
             self.lookup_import_candidates_from_module(
-                lookup_name, namespace, self.graph_root, keywords::Crate.name(), filter_fn
+                lookup_name, namespace, self.graph_root, keywords::Crate.ident(), &filter_fn
             )
         );
 
@@ -4346,7 +4346,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
 
                 suggestions.extend(
                     self.lookup_import_candidates_from_module(
-                        lookup_name, namespace, external_prelude_module, krate_name, filter_fn
+                        lookup_name, namespace, external_prelude_module, krate_ident, &filter_fn
                     )
                 );
             }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4241,7 +4241,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                                           lookup_name: Name,
                                           namespace: Namespace,
                                           start_module: &'a ModuleData<'a>,
-                                          name: Name,
+                                          crate_name: Ident,
                                           filter_fn: FilterFn)
                                           -> Vec<ImportSuggestion>
         where FilterFn: Fn(Def) -> bool
@@ -4272,11 +4272,10 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                         if self.session.rust_2018() && !in_module_is_extern {
                             // crate-local absolute paths start with `crate::` in edition 2018
                             // FIXME: may also be stabilized for Rust 2015 (Issues #45477, #44660)
-                            if name == keywords::Crate.name() {
-                                segms.insert(
-                                    0, ast::PathSegment::from_ident(keywords::Crate.ident())
-                                );
-                            }
+
+                            segms.insert(
+                                0, ast::PathSegment::from_ident(crate_name)
+                            );
                         }
 
                         segms.push(ast::PathSegment::from_ident(ident));

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4302,7 +4302,14 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                     let mut path_segments = path_segments.clone();
                     path_segments.push(ast::PathSegment::from_ident(ident));
 
-                    if !in_module_is_extern || name_binding.vis == ty::Visibility::Public {
+                    let is_extern_crate_that_also_appears_in_prelude =
+                        name_binding.is_extern_crate() &&
+                        self.extern_prelude.contains(&ident.name);
+
+                    let is_visible_to_user =
+                        !in_module_is_extern || name_binding.vis == ty::Visibility::Public;
+
+                    if !is_extern_crate_that_also_appears_in_prelude || is_visible_to_user {
                         // add the module to the lookup
                         let is_extern = in_module_is_extern || name_binding.is_extern_crate();
                         if seen_modules.insert(module.def_id().unwrap()) {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4488,7 +4488,8 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
         for UseError { mut err, candidates, node_id, better } in self.use_injections.drain(..) {
             let (span, found_use) = UsePlacementFinder::check(krate, node_id);
             if !candidates.is_empty() {
-                show_candidates(&mut err, span, &candidates, better, found_use, self.session.features_untracked().crate_in_paths);
+                let crate_in_paths = self.session.features_untracked().crate_in_paths;
+                show_candidates(&mut err, span, &candidates, better, found_use, crate_in_paths);
             }
             err.emit();
         }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4269,7 +4269,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                     if filter_fn(name_binding.def()) {
                         // create the path
                         let mut segms = path_segments.clone();
-                        if self.session.rust_2018() && !in_module_is_extern {
+                        if self.session.rust_2018() {
                             // crate-local absolute paths start with `crate::` in edition 2018
                             // FIXME: may also be stabilized for Rust 2015 (Issues #45477, #44660)
 

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1964,9 +1964,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                                 "access to extern crates through prelude is experimental").emit();
                 }
 
-                let crate_id = self.crate_loader.process_path_extern(ident.name, ident.span);
-                let crate_root = self.get_module(DefId { krate: crate_id, index: CRATE_DEF_INDEX });
-                self.populate_module_if_necessary(crate_root);
+                let crate_root = self.load_extern_prelude_crate_if_needed(ident);
 
                 let binding = (crate_root, ty::Visibility::Public,
                                ident.span, Mark::root()).to_name_binding(self.arenas);
@@ -1992,6 +1990,13 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
         }
 
         None
+    }
+
+    fn load_extern_prelude_crate_if_needed(&mut self, ident: Ident) -> Module<'a> {
+                let crate_id = self.crate_loader.process_path_extern(ident.name, ident.span);
+                let crate_root = self.get_module(DefId { krate: crate_id, index: CRATE_DEF_INDEX });
+                self.populate_module_if_necessary(&crate_root);
+                crate_root
     }
 
     fn hygienic_lexical_parent(&mut self, module: Module<'a>, span: &mut Span)

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4342,7 +4342,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
             let extern_prelude_names = self.extern_prelude.clone();
             for &krate_name in extern_prelude_names.iter() {
                 let krate_ident = Ident::with_empty_ctxt(krate_name);
-                let external_prelude_module =  self.load_extern_prelude_crate_if_needed(krate_ident);
+                let external_prelude_module = self.load_extern_prelude_crate_if_needed(krate_ident);
 
                 suggestions.extend(
                     self.lookup_import_candidates_from_module(

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4309,7 +4309,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                     let is_visible_to_user =
                         !in_module_is_extern || name_binding.vis == ty::Visibility::Public;
 
-                    if !is_extern_crate_that_also_appears_in_prelude || is_visible_to_user {
+                    if !is_extern_crate_that_also_appears_in_prelude && is_visible_to_user {
                         // add the module to the lookup
                         let is_extern = in_module_is_extern || name_binding.is_extern_crate();
                         if seen_modules.insert(module.def_id().unwrap()) {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4250,7 +4250,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
         let mut worklist = Vec::new();
         let mut seen_modules = FxHashSet();
         let not_local_module = crate_name != keywords::Crate.ident();
-        worklist.push((start_module, Vec::new(), not_local_module));
+        worklist.push((start_module, Vec::<ast::PathSegment>::new(), not_local_module));
 
         while let Some((in_module,
                         path_segments,
@@ -4273,10 +4273,12 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                         if self.session.rust_2018() {
                             // crate-local absolute paths start with `crate::` in edition 2018
                             // FIXME: may also be stabilized for Rust 2015 (Issues #45477, #44660)
-
-                            segms.insert(
-                                0, ast::PathSegment::from_ident(crate_name)
-                            );
+                            let first_segment_ident = segms[0].ident;
+                            if first_segment_ident.name != "std" {
+                                segms.insert(
+                                    0, ast::PathSegment::from_ident(crate_name)
+                                );
+                            }
                         }
 
                         segms.push(ast::PathSegment::from_ident(ident));

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4241,7 +4241,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                                           lookup_name: Name,
                                           namespace: Namespace,
                                           start_module: &'a ModuleData<'a>,
-                                          graph_root: bool,
+                                          name: Name,
                                           filter_fn: FilterFn)
                                           -> Vec<ImportSuggestion>
         where FilterFn: Fn(Def) -> bool
@@ -4272,7 +4272,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                         if self.session.rust_2018() && !in_module_is_extern {
                             // crate-local absolute paths start with `crate::` in edition 2018
                             // FIXME: may also be stabilized for Rust 2015 (Issues #45477, #44660)
-                            if graph_root {
+                            if name == keywords::Crate.name() {
                                 segms.insert(
                                     0, ast::PathSegment::from_ident(keywords::Crate.ident())
                                 );

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4488,8 +4488,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
         for UseError { mut err, candidates, node_id, better } in self.use_injections.drain(..) {
             let (span, found_use) = UsePlacementFinder::check(krate, node_id);
             if !candidates.is_empty() {
-                let crate_in_paths = self.session.features_untracked().crate_in_paths;
-                show_candidates(&mut err, span, &candidates, better, found_use, crate_in_paths);
+                show_candidates(&mut err, span, &candidates, better, found_use);
             }
             err.emit();
         }
@@ -4703,8 +4702,7 @@ fn show_candidates(err: &mut DiagnosticBuilder,
                    span: Option<Span>,
                    candidates: &[ImportSuggestion],
                    better: bool,
-                   found_use: bool,
-                   crate_in_paths: bool) {
+                   found_use: bool) {
 
     // we want consistent results across executions, but candidates are produced
     // by iterating through a hash map, so make sure they are ordered:
@@ -4728,12 +4726,7 @@ fn show_candidates(err: &mut DiagnosticBuilder,
             } else {
                 "\n"
             };
-            let crate_prefix = if crate_in_paths {
-                "crate::"
-            } else {
-                ""
-            };
-            *candidate = format!("use {}{};\n{}", crate_prefix, candidate, additional_newline);
+            *candidate = format!("use {};\n{}", candidate, additional_newline);
         }
 
         err.span_suggestions(span, &msg, path_strings);

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1993,10 +1993,10 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
     }
 
     fn load_extern_prelude_crate_if_needed(&mut self, ident: Ident) -> Module<'a> {
-                let crate_id = self.crate_loader.process_path_extern(ident.name, ident.span);
-                let crate_root = self.get_module(DefId { krate: crate_id, index: CRATE_DEF_INDEX });
-                self.populate_module_if_necessary(&crate_root);
-                crate_root
+        let crate_id = self.crate_loader.process_path_extern(ident.name, ident.span);
+        let crate_root = self.get_module(DefId { krate: crate_id, index: CRATE_DEF_INDEX });
+        self.populate_module_if_necessary(&crate_root);
+        crate_root
     }
 
     fn hygienic_lexical_parent(&mut self, module: Module<'a>, span: &mut Span)

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4268,7 +4268,9 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                             // crate-local absolute paths start with `crate::` in edition 2018
                             // FIXME: may also be stabilized for Rust 2015 (Issues #45477, #44660)
                             if graph_root {
-                                segms.insert(0, ast::PathSegment::from_ident(keywords::Crate.ident()));
+                                segms.insert(
+                                    0, ast::PathSegment::from_ident(keywords::Crate.ident())
+                                );
                             }
                         }
 
@@ -4324,7 +4326,9 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                                           -> Vec<ImportSuggestion>
         where FilterFn: Fn(Def) -> bool
     {
-        self.lookup_import_candidates_from_module(lookup_name, namespace, self.graph_root, true, filter_fn)
+        self.lookup_import_candidates_from_module(
+            lookup_name, namespace, self.graph_root, true, filter_fn
+        )
     }
 
     fn find_module(&mut self,

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4304,6 +4304,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
 
                     let is_extern_crate_that_also_appears_in_prelude =
                         name_binding.is_extern_crate() &&
+                        self.session.rust_2018() &&
                         self.extern_prelude.contains(&ident.name);
 
                     let is_visible_to_user =

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4249,7 +4249,8 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
         let mut candidates = Vec::new();
         let mut worklist = Vec::new();
         let mut seen_modules = FxHashSet();
-        worklist.push((start_module, Vec::new(), false));
+        let not_local_module = crate_name != keywords::Crate.ident();
+        worklist.push((start_module, Vec::new(), not_local_module));
 
         while let Some((in_module,
                         path_segments,

--- a/src/test/run-make-fulldeps/use-suggestions-rust-2018/Makefile
+++ b/src/test/run-make-fulldeps/use-suggestions-rust-2018/Makefile
@@ -1,0 +1,7 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) ep-nested-lib.rs
+
+	$(RUSTC) use-suggestions.rs --edition=2018 --extern ep_nested_lib=$(TMPDIR)/libep_nested_lib.rlib 2>&1 | $(CGREP) "use ep_nested_lib::foo::bar::Baz"
+

--- a/src/test/run-make-fulldeps/use-suggestions-rust-2018/ep-nested-lib.rs
+++ b/src/test/run-make-fulldeps/use-suggestions-rust-2018/ep-nested-lib.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rlib"]
+
+pub mod foo {
+    pub mod bar {
+        pub struct Baz;
+    }
+}

--- a/src/test/run-make-fulldeps/use-suggestions-rust-2018/use-suggestions.rs
+++ b/src/test/run-make-fulldeps/use-suggestions-rust-2018/use-suggestions.rs
@@ -1,0 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let x = Baz{};
+}

--- a/src/test/ui/crate-in-paths.rs
+++ b/src/test/ui/crate-in-paths.rs
@@ -1,3 +1,13 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 #![feature(crate_visibility_modifier)]
 #![feature(crate_in_paths)]
 

--- a/src/test/ui/crate-in-paths.rs
+++ b/src/test/ui/crate-in-paths.rs
@@ -1,0 +1,11 @@
+#![feature(crate_visibility_modifier)]
+#![feature(crate_in_paths)]
+
+mod bar {
+    crate struct Foo;
+}
+
+fn main() {
+    Foo;
+    //~^ ERROR cannot find value `Foo` in this scope [E0425]
+}

--- a/src/test/ui/crate-in-paths.rs
+++ b/src/test/ui/crate-in-paths.rs
@@ -8,8 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(crate_visibility_modifier)]
-#![feature(crate_in_paths)]
+// edition:2018
+
+#![feature(edition_2018_preview)]
 
 mod bar {
     crate struct Foo;

--- a/src/test/ui/crate-in-paths.stderr
+++ b/src/test/ui/crate-in-paths.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find value `Foo` in this scope
-  --> $DIR/crate-in-paths.rs:9:5
+  --> $DIR/crate-in-paths.rs:19:5
    |
 LL |     Foo;
    |     ^^^ not found in this scope

--- a/src/test/ui/crate-in-paths.stderr
+++ b/src/test/ui/crate-in-paths.stderr
@@ -1,0 +1,13 @@
+error[E0425]: cannot find value `Foo` in this scope
+  --> $DIR/crate-in-paths.rs:9:5
+   |
+LL |     Foo;
+   |     ^^^ not found in this scope
+help: possible candidate is found in another module, you can import it into scope
+   |
+LL | use crate::bar::Foo;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0425`.

--- a/src/test/ui/crate-in-paths.stderr
+++ b/src/test/ui/crate-in-paths.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find value `Foo` in this scope
-  --> $DIR/crate-in-paths.rs:19:5
+  --> $DIR/crate-in-paths.rs:20:5
    |
 LL |     Foo;
    |     ^^^ not found in this scope

--- a/src/test/ui/rust-2018/issue-52202-use-suggestions.stderr
+++ b/src/test/ui/rust-2018/issue-52202-use-suggestions.stderr
@@ -9,11 +9,11 @@ LL | use crate::plumbing::Drain;
    |
 LL | use std::collections::binary_heap::Drain;
    |
+LL | use std::collections::binary_heap::Drain;
+   |
 LL | use std::collections::hash_map::Drain;
    |
-LL | use std::collections::hash_set::Drain;
-   |
-and 3 other candidates
+and 9 other candidates
 
 error: aborting due to previous error
 

--- a/src/test/ui/rust-2018/issue-52202-use-suggestions.stderr
+++ b/src/test/ui/rust-2018/issue-52202-use-suggestions.stderr
@@ -9,11 +9,11 @@ LL | use crate::plumbing::Drain;
    |
 LL | use std::collections::binary_heap::Drain;
    |
-LL | use std::collections::binary_heap::Drain;
-   |
 LL | use std::collections::hash_map::Drain;
    |
-and 9 other candidates
+LL | use std::collections::hash_set::Drain;
+   |
+and 3 other candidates
 
 error: aborting due to previous error
 


### PR DESCRIPTION
I couldn't find a way to add a specific assertion for the ui test, so the expected output is living under the `crates-in-path.stderr` ui test.

- is this the right place for the test?

fixes #51212 
