### PR TITLE
hygiene: Eliminate expansion hierarchy in favor of call-site hierarchy

### DIFF
--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -123,7 +123,7 @@ impl FromStr for TokenStream {
             let expn_info = mark.expn_info().unwrap();
             let call_site = expn_info.call_site;
             // notify the expansion info that it is unhygienic
-            let mark = Mark::fresh(mark);
+            let mark = Mark::fresh();
             mark.set_expn_info(expn_info);
             let span = call_site.with_ctxt(SyntaxContext::empty().apply_mark(mark));
             let stream = parse::parse_stream_from_source_str(name, src, sess, Some(span));

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -580,7 +580,7 @@ impl<'a> LoweringContext<'a> {
     }
 
     fn allow_internal_unstable(&self, reason: CompilerDesugaringKind, span: Span) -> Span {
-        let mark = Mark::fresh(Mark::root());
+        let mark = Mark::fresh();
         mark.set_expn_info(codemap::ExpnInfo {
             call_site: span,
             callee: codemap::NameAndSpan {

--- a/src/librustc_allocator/expand.rs
+++ b/src/librustc_allocator/expand.rs
@@ -78,7 +78,7 @@ impl<'a> Folder for ExpandAllocatorDirectives<'a> {
         }
         self.found = true;
 
-        let mark = Mark::fresh(Mark::root());
+        let mark = Mark::fresh();
         mark.set_expn_info(ExpnInfo {
             call_site: DUMMY_SP,
             callee: NameAndSpan {

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -123,7 +123,7 @@ impl<'a> base::Resolver for Resolver<'a> {
     }
 
     fn get_module_scope(&mut self, id: ast::NodeId) -> Mark {
-        let mark = Mark::fresh(Mark::root());
+        let mark = Mark::fresh();
         let module = self.module_map[&self.definitions.local_def_id(id)];
         self.invocations.insert(mark, self.arenas.alloc_invocation_data(InvocationData {
             module: Cell::new(module),

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -347,7 +347,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                     let derives = derives.entry(invoc.expansion_data.mark).or_insert_with(Vec::new);
 
                     for path in &traits {
-                        let mark = Mark::fresh(self.cx.current_expansion.mark);
+                        let mark = Mark::fresh();
                         derives.push(mark);
                         let item = match self.cx.resolver.resolve_macro(
                                 Mark::root(), path, MacroKind::Derive, false) {
@@ -999,7 +999,7 @@ struct InvocationCollector<'a, 'b: 'a> {
 
 impl<'a, 'b> InvocationCollector<'a, 'b> {
     fn collect(&mut self, expansion_kind: ExpansionKind, kind: InvocationKind) -> Expansion {
-        let mark = Mark::fresh(self.cx.current_expansion.mark);
+        let mark = Mark::fresh();
         self.invocations.push(Invocation {
             kind,
             expansion_kind,

--- a/src/libsyntax/std_inject.rs
+++ b/src/libsyntax/std_inject.rs
@@ -22,7 +22,7 @@ use tokenstream::TokenStream;
 /// call to codemap's `is_internal` check.
 /// The expanded code uses the unstable `#[prelude_import]` attribute.
 fn ignored_span(sp: Span) -> Span {
-    let mark = Mark::fresh(Mark::root());
+    let mark = Mark::fresh();
     mark.set_expn_info(ExpnInfo {
         call_site: DUMMY_SP,
         callee: NameAndSpan {

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -275,7 +275,7 @@ fn generate_test_harness(sess: &ParseSess,
     let mut cleaner = EntryPointCleaner { depth: 0 };
     let krate = cleaner.fold_crate(krate);
 
-    let mark = Mark::fresh(Mark::root());
+    let mark = Mark::fresh();
 
     let mut econfig = ExpansionConfig::default("test".to_string());
     econfig.features = Some(features);

--- a/src/libsyntax_ext/deriving/mod.rs
+++ b/src/libsyntax_ext/deriving/mod.rs
@@ -159,7 +159,7 @@ fn call_intrinsic(cx: &ExtCtxt,
     } else { // Avoid instability errors with user defined curstom derives, cc #36316
         let mut info = cx.current_expansion.mark.expn_info().unwrap();
         info.callee.allow_internal_unstable = true;
-        let mark = Mark::fresh(Mark::root());
+        let mark = Mark::fresh();
         mark.set_expn_info(info);
         span = span.with_ctxt(SyntaxContext::empty().apply_mark(mark));
     }

--- a/src/libsyntax_ext/proc_macro_registrar.rs
+++ b/src/libsyntax_ext/proc_macro_registrar.rs
@@ -361,7 +361,7 @@ fn mk_registrar(cx: &mut ExtCtxt,
                 custom_derives: &[ProcMacroDerive],
                 custom_attrs: &[ProcMacroDef],
                 custom_macros: &[ProcMacroDef]) -> P<ast::Item> {
-    let mark = Mark::fresh(Mark::root());
+    let mark = Mark::fresh();
     mark.set_expn_info(ExpnInfo {
         call_site: DUMMY_SP,
         callee: NameAndSpan {

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -53,7 +53,7 @@ pub enum MarkKind {
 }
 
 impl Mark {
-    pub fn fresh(_parent: Mark) -> Self {
+    pub fn fresh() -> Self {
         HygieneData::with(|data| {
             data.marks.push(MarkData { kind: MarkKind::Legacy, expn_info: None });
             Mark(data.marks.len() as u32 - 1)
@@ -92,7 +92,6 @@ impl Mark {
                 if self == Mark::root() || data.marks[self.0 as usize].kind == MarkKind::Modern {
                     return self;
                 }
-
                 self = self.call_site_mark(data);
             }
         })
@@ -114,7 +113,6 @@ impl Mark {
                 if self == Mark::root() {
                     return false;
                 }
-
                 self = self.call_site_mark(data);
             }
             true
@@ -135,7 +133,6 @@ impl Mark {
             let mut a_path = FxHashSet::<Mark>();
             while a != Mark::root() {
                 a_path.insert(a);
-
                 a = a.call_site_mark(data);
             }
 

--- a/src/test/ui/hygiene/call-site-parent-vs-expansion-parent.rs
+++ b/src/test/ui/hygiene/call-site-parent-vs-expansion-parent.rs
@@ -1,0 +1,31 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-pass
+
+#![feature(decl_macro)]
+
+macro_rules! define_field {
+    () => {
+        struct S { field: u8 }
+    }
+}
+
+macro use_field($define_field: item) {
+    $define_field
+
+    // OK, both struct name `S` and field `name` resolve to definitions produced by `define_field`
+    // and living in the "root" context that is in scope at `use_field`'s def-site.
+    fn f() { S { field: 0 }; }
+}
+
+use_field!(define_field!{});
+
+fn main() {}

--- a/src/test/ui/hygiene/call-site-parent-vs-expansion-parent.rs
+++ b/src/test/ui/hygiene/call-site-parent-vs-expansion-parent.rs
@@ -15,17 +15,38 @@
 macro_rules! define_field {
     () => {
         struct S { field: u8 }
+    };
+    ($field: ident) => {
+        struct Z { $field: u8 }
+    };
+}
+
+mod modern {
+    macro use_field($define_field1: item, $define_field2: item) {
+        $define_field1
+        $define_field2
+
+        // OK, both struct name `S` and field `name` resolve to definitions
+        // produced by `define_field` and living in the "root" context
+        // that is in scope at `use_field`'s def-site.
+        fn f() { S { field: 0 }; }
+        fn g() { Z { field: 0 }; }
     }
+
+    use_field!(define_field!{}, define_field!{ field });
 }
 
-macro use_field($define_field: item) {
-    $define_field
+mod legacy {
+    macro_rules! use_field {($define_field1: item, $define_field2: item) => {
+        $define_field1
+        $define_field2
 
-    // OK, both struct name `S` and field `name` resolve to definitions produced by `define_field`
-    // and living in the "root" context that is in scope at `use_field`'s def-site.
-    fn f() { S { field: 0 }; }
+        // OK, everything is at the same call-site.
+        fn f() { S { field: 0 }; }
+        fn g() { Z { field: 0 }; }
+    }}
+
+    use_field!(define_field!{}, define_field!{ field });
 }
-
-use_field!(define_field!{});
 
 fn main() {}


### PR DESCRIPTION
"Expansion hierarchy" and "call-site hierarchy" are two slightly different ways to nest macro invocations and answer the question "who is the parent" for a given invocation.

For example, here both hierarchies coincide
```rust
macro inner() { ... }
macro outer() { inner!() }

outer!();
// expansions: root -> outer -> inner
// call-sites: root -> outer -> inner
```
but here they are different
```rust
macro inner() { ... }
macro outer($stuff: stuff) { $stuff }

// expansions: root -> outer -> inner (`inner` is expanded as a part of `outer`'s output)
// call-sites: root -> outer; root -> inner
outer!(inner!())
```

All our talk about hygiene was in terms of "def-site" and "call-site" name resolution so far and the "expansion hierarchy" is an internal detail, but it was actually used in few places in the way affecting resolution results. For example, in the attached test case the structure `S` itself was previously resolved succesfully, but resolution of its field `field` failed due to use of "expansion hierarchy".
This PR eliminates expansion hierarchy from hygiene algorithm and uses call-site hierarchy instead.

This is also a nice simplification of the model.
Instead of growing in *three* dimensions in similar but subtly different ways (def-site, call-site, expansion) hygiene hierarchies now grow in *two* dimensions in similar but subtly different ways (def-site, call-site).