### PR TITLE
Various changes to existing diagnostics

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1693,7 +1693,10 @@ impl<T: Hash> Hash for Vec<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented = "vector indices are of type `usize` or ranges of `usize`"]
+#[rustc_on_unimplemented(
+    message="vector indices are of type `usize` or ranges of `usize`",
+    label="vector indices are of type `usize` or ranges of `usize`",
+)]
 impl<T, I> Index<I> for Vec<T>
 where
     I: ::core::slice::SliceIndex<[T]>,
@@ -1707,7 +1710,10 @@ where
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented = "vector indices are of type `usize` or ranges of `usize`"]
+#[rustc_on_unimplemented(
+    message="vector indices are of type `usize` or ranges of `usize`",
+    label="vector indices are of type `usize` or ranges of `usize`",
+)]
 impl<T, I> IndexMut<I> for Vec<T>
 where
     I: ::core::slice::SliceIndex<[T]>,

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -108,7 +108,10 @@ use self::Ordering::*;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(alias = "==")]
 #[doc(alias = "!=")]
-#[rustc_on_unimplemented = "can't compare `{Self}` with `{Rhs}`"]
+#[rustc_on_unimplemented(
+    message="can't compare `{Self}` with `{Rhs}`",
+    label="no implementation for `{Self} == {Rhs}`",
+)]
 pub trait PartialEq<Rhs: ?Sized = Self> {
     /// This method tests for `self` and `other` values to be equal, and is used
     /// by `==`.
@@ -611,7 +614,10 @@ impl PartialOrd for Ordering {
 #[doc(alias = "<")]
 #[doc(alias = "<=")]
 #[doc(alias = ">=")]
-#[rustc_on_unimplemented = "can't compare `{Self}` with `{Rhs}`"]
+#[rustc_on_unimplemented(
+    message="can't compare `{Self}` with `{Rhs}`",
+    label="no implementation for `{Self} < {Rhs}` and `{Self} > {Rhs}`",
+)]
 pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
     /// This method returns an ordering between `self` and `other` values if one exists.
     ///

--- a/src/libcore/iter/traits.rs
+++ b/src/libcore/iter/traits.rs
@@ -104,8 +104,11 @@ use super::LoopState;
 /// assert_eq!(c.0, vec![0, 1, 2, 3, 4]);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented="a collection of type `{Self}` cannot be \
-                          built from an iterator over elements of type `{A}`"]
+#[rustc_on_unimplemented(
+    message="a collection of type `{Self}` cannot be built from an iterator \
+             over elements of type `{A}`",
+    label="a collection of type `{Self}` cannot be built from `std::iter::Iterator<Item={A}>`",
+)]
 pub trait FromIterator<A>: Sized {
     /// Creates a value from an iterator.
     ///

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -39,7 +39,10 @@ use hash::Hasher;
 /// [arc]: ../../std/sync/struct.Arc.html
 /// [ub]: ../../reference/behavior-considered-undefined.html
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented = "`{Self}` cannot be sent between threads safely"]
+#[rustc_on_unimplemented(
+    message="`{Self}` cannot be sent between threads safely",
+    label="`{Self}` cannot be sent between threads safely"
+)]
 pub unsafe auto trait Send {
     // empty.
 }
@@ -88,7 +91,10 @@ impl<T: ?Sized> !Send for *mut T { }
 /// [trait object]: ../../book/first-edition/trait-objects.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[lang = "sized"]
-#[rustc_on_unimplemented = "`{Self}` does not have a constant size known at compile-time"]
+#[rustc_on_unimplemented(
+    message="`{Self}` does not have a constant size known at compile-time",
+    label="`{Self}` does not have a constant size known at compile-time"
+)]
 #[fundamental] // for Default, for example, which requires that `[T]: !Default` be evaluatable
 pub trait Sized {
     // Empty.

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -93,7 +93,9 @@ impl<T: ?Sized> !Send for *mut T { }
 #[lang = "sized"]
 #[rustc_on_unimplemented(
     message="`{Self}` does not have a constant size known at compile-time",
-    label="`{Self}` does not have a constant size known at compile-time"
+    label="`{Self}` does not have a constant size known at compile-time",
+    note="to learn more, visit <https://doc.rust-lang.org/book/second-edition/\
+          ch19-04-advanced-types.html#dynamically-sized-types--sized>",
 )]
 #[fundamental] // for Default, for example, which requires that `[T]: !Default` be evaluatable
 pub trait Sized {

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -92,8 +92,8 @@ impl<T: ?Sized> !Send for *mut T { }
 #[stable(feature = "rust1", since = "1.0.0")]
 #[lang = "sized"]
 #[rustc_on_unimplemented(
-    message="`{Self}` does not have a constant size known at compile-time",
-    label="`{Self}` does not have a constant size known at compile-time",
+    message="the size for value values of type `{Self}` cannot be known at compilation time",
+    label="doesn't have a size known at compile-time",
     note="to learn more, visit <https://doc.rust-lang.org/book/second-edition/\
           ch19-04-advanced-types.html#dynamically-sized-types--sized>",
 )]

--- a/src/libcore/ops/index.rs
+++ b/src/libcore/ops/index.rs
@@ -60,7 +60,10 @@
 /// assert_eq!(nucleotide_count[Nucleotide::T], 12);
 /// ```
 #[lang = "index"]
-#[rustc_on_unimplemented = "the type `{Self}` cannot be indexed by `{Idx}`"]
+#[rustc_on_unimplemented(
+    message="the type `{Self}` cannot be indexed by `{Idx}`",
+    label="`{Self}` cannot be indexed by `{Idx}`",
+)]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(alias = "]")]
 #[doc(alias = "[")]
@@ -147,7 +150,10 @@ pub trait Index<Idx: ?Sized> {
 /// balance[Side::Left] = Weight::Kilogram(3.0);
 /// ```
 #[lang = "index_mut"]
-#[rustc_on_unimplemented = "the type `{Self}` cannot be mutably indexed by `{Idx}`"]
+#[rustc_on_unimplemented(
+    message="the type `{Self}` cannot be mutably indexed by `{Idx}`",
+    label="`{Self}` cannot be mutably indexed by `{Idx}`",
+)]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(alias = "[")]
 #[doc(alias = "]")]

--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -110,8 +110,10 @@ pub use core::panic::{PanicInfo, Location};
 ///
 /// [`AssertUnwindSafe`]: ./struct.AssertUnwindSafe.html
 #[stable(feature = "catch_unwind", since = "1.9.0")]
-#[rustc_on_unimplemented = "the type {Self} may not be safely transferred \
-                            across an unwind boundary"]
+#[rustc_on_unimplemented(
+    message="the type `{Self}` may not be safely transferred across an unwind boundary",
+    label="`{Self}` may not be safely transferred across an unwind boundary",
+)]
 pub auto trait UnwindSafe {}
 
 /// A marker trait representing types where a shared reference is considered
@@ -126,9 +128,12 @@ pub auto trait UnwindSafe {}
 /// [`UnsafeCell`]: ../cell/struct.UnsafeCell.html
 /// [`UnwindSafe`]: ./trait.UnwindSafe.html
 #[stable(feature = "catch_unwind", since = "1.9.0")]
-#[rustc_on_unimplemented = "the type {Self} may contain interior mutability \
-                            and a reference may not be safely transferrable \
-                            across a catch_unwind boundary"]
+#[rustc_on_unimplemented(
+    message="the type `{Self}` may contain interior mutability and a reference may not be safely \
+             transferrable across a catch_unwind boundary",
+    label="`{Self}` may contain interior mutability and a reference may not be safely \
+           transferrable across a catch_unwind boundary",
+)]
 pub auto trait RefUnwindSafe {}
 
 /// A simple wrapper around a type to assert that it is unwind safe.

--- a/src/libsyntax/diagnostic_list.rs
+++ b/src/libsyntax/diagnostic_list.rs
@@ -397,4 +397,5 @@ register_diagnostics! {
     E0630, // rustc_const_unstable attribute must be paired with stable/unstable attribute
     E0693, // incorrect `repr(align)` attribute format
     E0694, // an unknown tool name found in scoped attributes
+    E0697, // invalid ABI
 }

--- a/src/libsyntax/diagnostic_list.rs
+++ b/src/libsyntax/diagnostic_list.rs
@@ -397,6 +397,6 @@ register_diagnostics! {
     E0630, // rustc_const_unstable attribute must be paired with stable/unstable attribute
     E0693, // incorrect `repr(align)` attribute format
     E0694, // an unknown tool name found in scoped attributes
-    E0697, // invalid ABI
-    E0698, // incorrect visibility restriction
+    E0703, // invalid ABI
+    E0704, // incorrect visibility restriction
 }

--- a/src/libsyntax/diagnostic_list.rs
+++ b/src/libsyntax/diagnostic_list.rs
@@ -398,4 +398,5 @@ register_diagnostics! {
     E0693, // incorrect `repr(align)` attribute format
     E0694, // an unknown tool name found in scoped attributes
     E0697, // invalid ABI
+    E0698, // incorrect visibility restriction
 }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5986,12 +5986,13 @@ impl<'a> Parser<'a> {
 `pub(super)`: visible only in the current module's parent
 `pub(in path::to::module)`: visible only on the specified path"##;
                 let path = self.parse_path(PathStyle::Mod)?;
-                let path_span = self.prev_span;
+                let sp = self.prev_span;
                 let help_msg = format!("make this visible only to module `{}` with `in`", path);
                 self.expect(&token::CloseDelim(token::Paren))?;  // `)`
-                let mut err = self.span_fatal_help(path_span, msg, suggestion);
+                let mut err = struct_span_err!(self.sess.span_diagnostic, sp, E0698, "{}", msg);
+                err.help(suggestion);
                 err.span_suggestion_with_applicability(
-                    path_span, &help_msg, format!("in {}", path), Applicability::MachineApplicable
+                    sp, &help_msg, format!("in {}", path), Applicability::MachineApplicable
                 );
                 err.emit();  // emit diagnostic, but continue with public visibility
             }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -648,8 +648,8 @@ impl<'a> Parser<'a> {
                 let cm = self.sess.codemap();
                 match (cm.lookup_line(self.span.lo()), cm.lookup_line(sp.lo())) {
                     (Ok(ref a), Ok(ref b)) if a.line == b.line => {
-                        // When the spans are in the same line, it means that the only content between
-                        // them is whitespace, point only at the found token.
+                        // When the spans are in the same line, it means that the only content
+                        // between them is whitespace, point only at the found token.
                         err.span_label(self.span, label_exp);
                     }
                     _ => {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -6535,12 +6535,15 @@ impl<'a> Parser<'a> {
                     Some(abi) => Ok(Some(abi)),
                     None => {
                         let prev_span = self.prev_span;
-                        self.span_err(
+                        let mut err = struct_span_err!(
+                            self.sess.span_diagnostic,
                             prev_span,
-                            &format!("invalid ABI: expected one of [{}], \
-                                     found `{}`",
-                                    abi::all_names().join(", "),
-                                    s));
+                            E0697,
+                            "invalid ABI: found `{}`",
+                            s);
+                        err.span_label(prev_span, "invalid ABI");
+                        err.help(&format!("valid ABIs: {}", abi::all_names().join(", ")));
+                        err.emit();
                         Ok(None)
                     }
                 }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1204,14 +1204,6 @@ impl<'a> Parser<'a> {
     fn span_fatal_err<S: Into<MultiSpan>>(&self, sp: S, err: Error) -> DiagnosticBuilder<'a> {
         err.span_err(sp, self.diagnostic())
     }
-    fn span_fatal_help<S: Into<MultiSpan>>(&self,
-                                            sp: S,
-                                            m: &str,
-                                            help: &str) -> DiagnosticBuilder<'a> {
-        let mut err = self.sess.span_diagnostic.struct_span_fatal(sp, m);
-        err.help(help);
-        err
-    }
     fn bug(&self, m: &str) -> ! {
         self.sess.span_diagnostic.span_bug(self.span, m)
     }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -6000,7 +6000,7 @@ impl<'a> Parser<'a> {
                 let sp = self.prev_span;
                 let help_msg = format!("make this visible only to module `{}` with `in`", path);
                 self.expect(&token::CloseDelim(token::Paren))?;  // `)`
-                let mut err = struct_span_err!(self.sess.span_diagnostic, sp, E0698, "{}", msg);
+                let mut err = struct_span_err!(self.sess.span_diagnostic, sp, E0704, "{}", msg);
                 err.help(suggestion);
                 err.span_suggestion_with_applicability(
                     sp, &help_msg, format!("in {}", path), Applicability::MachineApplicable
@@ -6550,7 +6550,7 @@ impl<'a> Parser<'a> {
                         let mut err = struct_span_err!(
                             self.sess.span_diagnostic,
                             prev_span,
-                            E0697,
+                            E0703,
                             "invalid ABI: found `{}`",
                             s);
                         err.span_label(prev_span, "invalid ABI");

--- a/src/test/compile-fail/associated-types-unsized.rs
+++ b/src/test/compile-fail/associated-types-unsized.rs
@@ -14,7 +14,7 @@ trait Get {
 }
 
 fn foo<T:Get>(t: T) {
-    let x = t.get(); //~ ERROR `<T as Get>::Value` does not have a constant size known at
+    let x = t.get(); //~ ERROR the size for value values of type
 }
 
 fn main() {

--- a/src/test/compile-fail/associated-types-unsized.rs
+++ b/src/test/compile-fail/associated-types-unsized.rs
@@ -14,7 +14,7 @@ trait Get {
 }
 
 fn foo<T:Get>(t: T) {
-    let x = t.get(); //~ ERROR `<T as Get>::Value` does not have a constant size known at compile-time
+    let x = t.get(); //~ ERROR `<T as Get>::Value` does not have a constant size known at
 }
 
 fn main() {

--- a/src/test/compile-fail/associated-types-unsized.rs
+++ b/src/test/compile-fail/associated-types-unsized.rs
@@ -14,7 +14,7 @@ trait Get {
 }
 
 fn foo<T:Get>(t: T) {
-    let x = t.get(); //~ ERROR `<T as Get>::Value: std::marker::Sized` is not
+    let x = t.get(); //~ ERROR `<T as Get>::Value` does not have a constant size known at compile-time
 }
 
 fn main() {

--- a/src/test/compile-fail/bad-method-typaram-kind.rs
+++ b/src/test/compile-fail/bad-method-typaram-kind.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 fn foo<T:'static>() {
-    1.bar::<T>(); //~ ERROR `T: std::marker::Send` is not satisfied
+    1.bar::<T>(); //~ ERROR `T` cannot be sent between threads safely
 }
 
 trait bar {

--- a/src/test/compile-fail/bad-sized.rs
+++ b/src/test/compile-fail/bad-sized.rs
@@ -13,6 +13,6 @@ trait Trait {}
 pub fn main() {
     let x: Vec<Trait + Sized> = Vec::new();
     //~^ ERROR only auto traits can be used as additional traits in a trait object
-    //~| ERROR the trait bound `Trait: std::marker::Sized` is not satisfied
-    //~| ERROR the trait bound `Trait: std::marker::Sized` is not satisfied
+    //~| ERROR `Trait` does not have a constant size known at compile-time
+    //~| ERROR `Trait` does not have a constant size known at compile-time
 }

--- a/src/test/compile-fail/bad-sized.rs
+++ b/src/test/compile-fail/bad-sized.rs
@@ -13,6 +13,6 @@ trait Trait {}
 pub fn main() {
     let x: Vec<Trait + Sized> = Vec::new();
     //~^ ERROR only auto traits can be used as additional traits in a trait object
-    //~| ERROR `Trait` does not have a constant size known at compile-time
-    //~| ERROR `Trait` does not have a constant size known at compile-time
+    //~| ERROR the size for value values of type
+    //~| ERROR the size for value values of type
 }

--- a/src/test/compile-fail/builtin-superkinds-double-superkind.rs
+++ b/src/test/compile-fail/builtin-superkinds-double-superkind.rs
@@ -14,7 +14,7 @@
 trait Foo : Send+Sync { }
 
 impl <T: Sync+'static> Foo for (T,) { }
-//~^ ERROR the trait bound `T: std::marker::Send` is not satisfied in `(T,)` [E0277]
+//~^ ERROR `T` cannot be sent between threads safely [E0277]
 
 impl <T: Send> Foo for (T,T) { }
 //~^ ERROR `T` cannot be shared between threads safely [E0277]

--- a/src/test/compile-fail/builtin-superkinds-in-metadata.rs
+++ b/src/test/compile-fail/builtin-superkinds-in-metadata.rs
@@ -22,6 +22,6 @@ struct X<T>(T);
 impl <T:Sync> RequiresShare for X<T> { }
 
 impl <T:Sync+'static> RequiresRequiresShareAndSend for X<T> { }
-//~^ ERROR `T: std::marker::Send` is not satisfied
+//~^ ERROR `T` cannot be sent between threads safely [E0277]
 
 fn main() { }

--- a/src/test/compile-fail/builtin-superkinds-simple.rs
+++ b/src/test/compile-fail/builtin-superkinds-simple.rs
@@ -14,6 +14,6 @@
 trait Foo : Send { }
 
 impl Foo for std::rc::Rc<i8> { }
-//~^ ERROR `std::rc::Rc<i8>: std::marker::Send` is not satisfied
+//~^ ERROR `std::rc::Rc<i8>` cannot be sent between threads safely
 
 fn main() { }

--- a/src/test/compile-fail/builtin-superkinds-typaram-not-send.rs
+++ b/src/test/compile-fail/builtin-superkinds-typaram-not-send.rs
@@ -12,6 +12,7 @@
 
 trait Foo : Send { }
 
-impl <T: Sync+'static> Foo for T { } //~ ERROR `T: std::marker::Send` is not satisfied
+impl <T: Sync+'static> Foo for T { }
+//~^ ERROR `T` cannot be sent between threads safely
 
 fn main() { }

--- a/src/test/compile-fail/closure-bounds-cant-promote-superkind-in-struct.rs
+++ b/src/test/compile-fail/closure-bounds-cant-promote-superkind-in-struct.rs
@@ -13,7 +13,7 @@ struct X<F> where F: FnOnce() + 'static + Send {
 }
 
 fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static {
-    //~^ ERROR `F: std::marker::Send` is not satisfied
+    //~^ ERROR `F` cannot be sent between threads safely
     return X { field: blk };
 }
 

--- a/src/test/compile-fail/dst-bad-assign-2.rs
+++ b/src/test/compile-fail/dst-bad-assign-2.rs
@@ -43,5 +43,6 @@ pub fn main() {
     let f5: &mut Fat<ToBar> = &mut Fat { f1: 5, f2: "some str", ptr: Bar1 {f :42} };
     let z: Box<ToBar> = Box::new(Bar1 {f: 36});
     f5.ptr = *z;
-    //~^ ERROR `ToBar` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
+
 }

--- a/src/test/compile-fail/dst-bad-assign-2.rs
+++ b/src/test/compile-fail/dst-bad-assign-2.rs
@@ -43,5 +43,5 @@ pub fn main() {
     let f5: &mut Fat<ToBar> = &mut Fat { f1: 5, f2: "some str", ptr: Bar1 {f :42} };
     let z: Box<ToBar> = Box::new(Bar1 {f: 36});
     f5.ptr = *z;
-    //~^ ERROR `ToBar: std::marker::Sized` is not satisfied
+    //~^ ERROR `ToBar` does not have a constant size known at compile-time
 }

--- a/src/test/compile-fail/dst-bad-assign-3.rs
+++ b/src/test/compile-fail/dst-bad-assign-3.rs
@@ -45,5 +45,5 @@ pub fn main() {
     //~| expected type `ToBar`
     //~| found type `Bar1`
     //~| expected trait ToBar, found struct `Bar1`
-    //~| ERROR `ToBar: std::marker::Sized` is not satisfied
+    //~| ERROR `ToBar` does not have a constant size known at compile-time
 }

--- a/src/test/compile-fail/dst-bad-assign-3.rs
+++ b/src/test/compile-fail/dst-bad-assign-3.rs
@@ -45,5 +45,5 @@ pub fn main() {
     //~| expected type `ToBar`
     //~| found type `Bar1`
     //~| expected trait ToBar, found struct `Bar1`
-    //~| ERROR `ToBar` does not have a constant size known at compile-time
+    //~| ERROR the size for value values of type
 }

--- a/src/test/compile-fail/dst-bad-assign.rs
+++ b/src/test/compile-fail/dst-bad-assign.rs
@@ -47,5 +47,5 @@ pub fn main() {
     //~| expected type `ToBar`
     //~| found type `Bar1`
     //~| expected trait ToBar, found struct `Bar1`
-    //~| ERROR `ToBar: std::marker::Sized` is not satisfied
+    //~| ERROR `ToBar` does not have a constant size known at compile-time
 }

--- a/src/test/compile-fail/dst-bad-assign.rs
+++ b/src/test/compile-fail/dst-bad-assign.rs
@@ -47,5 +47,5 @@ pub fn main() {
     //~| expected type `ToBar`
     //~| found type `Bar1`
     //~| expected trait ToBar, found struct `Bar1`
-    //~| ERROR `ToBar` does not have a constant size known at compile-time
+    //~| ERROR the size for value values of type
 }

--- a/src/test/compile-fail/dst-bad-deep-2.rs
+++ b/src/test/compile-fail/dst-bad-deep-2.rs
@@ -19,5 +19,5 @@ pub fn main() {
     let f: ([isize; 3],) = ([5, 6, 7],);
     let g: &([isize],) = &f;
     let h: &(([isize],),) = &(*g,);
-    //~^ ERROR `[isize]` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }

--- a/src/test/compile-fail/dst-bad-deep-2.rs
+++ b/src/test/compile-fail/dst-bad-deep-2.rs
@@ -19,5 +19,5 @@ pub fn main() {
     let f: ([isize; 3],) = ([5, 6, 7],);
     let g: &([isize],) = &f;
     let h: &(([isize],),) = &(*g,);
-    //~^ ERROR `[isize]: std::marker::Sized` is not satisfied
+    //~^ ERROR `[isize]` does not have a constant size known at compile-time
 }

--- a/src/test/compile-fail/dst-bad-deep.rs
+++ b/src/test/compile-fail/dst-bad-deep.rs
@@ -21,5 +21,5 @@ pub fn main() {
     let f: Fat<[isize; 3]> = Fat { ptr: [5, 6, 7] };
     let g: &Fat<[isize]> = &f;
     let h: &Fat<Fat<[isize]>> = &Fat { ptr: *g };
-    //~^ ERROR `[isize]: std::marker::Sized` is not satisfied
+    //~^ ERROR `[isize]` does not have a constant size known at compile-time
 }

--- a/src/test/compile-fail/dst-bad-deep.rs
+++ b/src/test/compile-fail/dst-bad-deep.rs
@@ -21,5 +21,5 @@ pub fn main() {
     let f: Fat<[isize; 3]> = Fat { ptr: [5, 6, 7] };
     let g: &Fat<[isize]> = &f;
     let h: &Fat<Fat<[isize]>> = &Fat { ptr: *g };
-    //~^ ERROR `[isize]` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }

--- a/src/test/compile-fail/dst-object-from-unsized-type.rs
+++ b/src/test/compile-fail/dst-object-from-unsized-type.rs
@@ -16,22 +16,22 @@ impl Foo for [u8] {}
 
 fn test1<T: ?Sized + Foo>(t: &T) {
     let u: &Foo = t;
-    //~^ ERROR `T: std::marker::Sized` is not satisfied
+    //~^ ERROR `T` does not have a constant size known at compile-time
 }
 
 fn test2<T: ?Sized + Foo>(t: &T) {
     let v: &Foo = t as &Foo;
-    //~^ ERROR `T: std::marker::Sized` is not satisfied
+    //~^ ERROR `T` does not have a constant size known at compile-time
 }
 
 fn test3() {
     let _: &[&Foo] = &["hi"];
-    //~^ ERROR `str: std::marker::Sized` is not satisfied
+    //~^ ERROR `str` does not have a constant size known at compile-time
 }
 
 fn test4(x: &[u8]) {
     let _: &Foo = x as &Foo;
-    //~^ ERROR `[u8]: std::marker::Sized` is not satisfied
+    //~^ ERROR `[u8]` does not have a constant size known at compile-time
 }
 
 fn main() { }

--- a/src/test/compile-fail/dst-object-from-unsized-type.rs
+++ b/src/test/compile-fail/dst-object-from-unsized-type.rs
@@ -16,22 +16,22 @@ impl Foo for [u8] {}
 
 fn test1<T: ?Sized + Foo>(t: &T) {
     let u: &Foo = t;
-    //~^ ERROR `T` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 
 fn test2<T: ?Sized + Foo>(t: &T) {
     let v: &Foo = t as &Foo;
-    //~^ ERROR `T` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 
 fn test3() {
     let _: &[&Foo] = &["hi"];
-    //~^ ERROR `str` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 
 fn test4(x: &[u8]) {
     let _: &Foo = x as &Foo;
-    //~^ ERROR `[u8]` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 
 fn main() { }

--- a/src/test/compile-fail/dst-sized-trait-param.rs
+++ b/src/test/compile-fail/dst-sized-trait-param.rs
@@ -15,9 +15,9 @@
 trait Foo<T> : Sized { fn take(self, x: &T) { } } // Note: T is sized
 
 impl Foo<[isize]> for usize { }
-//~^ ERROR `[isize]` does not have a constant size known at compile-time
+//~^ ERROR the size for value values of type
 
 impl Foo<isize> for [usize] { }
-//~^ ERROR `[usize]` does not have a constant size known at compile-time
+//~^ ERROR the size for value values of type
 
 pub fn main() { }

--- a/src/test/compile-fail/dst-sized-trait-param.rs
+++ b/src/test/compile-fail/dst-sized-trait-param.rs
@@ -15,9 +15,9 @@
 trait Foo<T> : Sized { fn take(self, x: &T) { } } // Note: T is sized
 
 impl Foo<[isize]> for usize { }
-//~^ ERROR `[isize]: std::marker::Sized` is not satisfied
+//~^ ERROR `[isize]` does not have a constant size known at compile-time
 
 impl Foo<isize> for [usize] { }
-//~^ ERROR `[usize]: std::marker::Sized` is not satisfied
+//~^ ERROR `[usize]` does not have a constant size known at compile-time
 
 pub fn main() { }

--- a/src/test/compile-fail/extern-types-not-sync-send.rs
+++ b/src/test/compile-fail/extern-types-not-sync-send.rs
@@ -24,5 +24,5 @@ fn main() {
     //~^ ERROR `A` cannot be shared between threads safely [E0277]
 
     assert_send::<A>();
-    //~^ ERROR the trait bound `A: std::marker::Send` is not satisfied
+    //~^ ERROR `A` cannot be sent between threads safely [E0277]
 }

--- a/src/test/compile-fail/extern-types-unsized.rs
+++ b/src/test/compile-fail/extern-types-unsized.rs
@@ -30,14 +30,14 @@ fn assert_sized<T>() { }
 
 fn main() {
     assert_sized::<A>();
-    //~^ ERROR the trait bound `A: std::marker::Sized` is not satisfied
+    //~^ ERROR `A` does not have a constant size known at compile-time
 
     assert_sized::<Foo>();
-    //~^ ERROR the trait bound `A: std::marker::Sized` is not satisfied
+    //~^ ERROR `A` does not have a constant size known at compile-time
 
     assert_sized::<Bar<A>>();
-    //~^ ERROR the trait bound `A: std::marker::Sized` is not satisfied
+    //~^ ERROR `A` does not have a constant size known at compile-time
 
     assert_sized::<Bar<Bar<A>>>();
-    //~^ ERROR the trait bound `A: std::marker::Sized` is not satisfied
+    //~^ ERROR `A` does not have a constant size known at compile-time
 }

--- a/src/test/compile-fail/extern-types-unsized.rs
+++ b/src/test/compile-fail/extern-types-unsized.rs
@@ -30,14 +30,14 @@ fn assert_sized<T>() { }
 
 fn main() {
     assert_sized::<A>();
-    //~^ ERROR `A` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 
     assert_sized::<Foo>();
-    //~^ ERROR `A` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 
     assert_sized::<Bar<A>>();
-    //~^ ERROR `A` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 
     assert_sized::<Bar<Bar<A>>>();
-    //~^ ERROR `A` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }

--- a/src/test/compile-fail/issue-14366.rs
+++ b/src/test/compile-fail/issue-14366.rs
@@ -10,5 +10,5 @@
 
 fn main() {
     let _x = "test" as &::std::any::Any;
-    //~^ ERROR `str` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }

--- a/src/test/compile-fail/issue-14366.rs
+++ b/src/test/compile-fail/issue-14366.rs
@@ -10,5 +10,5 @@
 
 fn main() {
     let _x = "test" as &::std::any::Any;
-//~^ ERROR `str: std::marker::Sized` is not satisfied
+    //~^ ERROR `str` does not have a constant size known at compile-time
 }

--- a/src/test/compile-fail/issue-15756.rs
+++ b/src/test/compile-fail/issue-15756.rs
@@ -15,7 +15,7 @@ fn dft_iter<'a, T>(arg1: Chunks<'a,T>, arg2: ChunksMut<'a,T>)
 {
     for
     &mut something
-//~^ ERROR `[T]: std::marker::Sized` is not satisfied
+    //~^ ERROR `[T]` does not have a constant size known at compile-time
     in arg2
     {
     }

--- a/src/test/compile-fail/issue-15756.rs
+++ b/src/test/compile-fail/issue-15756.rs
@@ -15,7 +15,7 @@ fn dft_iter<'a, T>(arg1: Chunks<'a,T>, arg2: ChunksMut<'a,T>)
 {
     for
     &mut something
-    //~^ ERROR `[T]` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     in arg2
     {
     }

--- a/src/test/compile-fail/issue-17651.rs
+++ b/src/test/compile-fail/issue-17651.rs
@@ -13,5 +13,5 @@
 
 fn main() {
     (|| Box::new(*(&[0][..])))();
-    //~^ ERROR `[{integer}]` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }

--- a/src/test/compile-fail/issue-17651.rs
+++ b/src/test/compile-fail/issue-17651.rs
@@ -13,5 +13,5 @@
 
 fn main() {
     (|| Box::new(*(&[0][..])))();
-    //~^ ERROR `[{integer}]: std::marker::Sized` is not satisfied
+    //~^ ERROR `[{integer}]` does not have a constant size known at compile-time
 }

--- a/src/test/compile-fail/issue-18107.rs
+++ b/src/test/compile-fail/issue-18107.rs
@@ -12,7 +12,7 @@ pub trait AbstractRenderer {}
 
 fn _create_render(_: &()) ->
     AbstractRenderer
-//~^ ERROR: `AbstractRenderer + 'static` does not have a constant size known at compile-time
+//~^ ERROR the size for value values of type
 {
     match 0 {
         _ => unimplemented!()

--- a/src/test/compile-fail/issue-18107.rs
+++ b/src/test/compile-fail/issue-18107.rs
@@ -12,7 +12,7 @@ pub trait AbstractRenderer {}
 
 fn _create_render(_: &()) ->
     AbstractRenderer
-//~^ ERROR: `AbstractRenderer + 'static: std::marker::Sized` is not satisfied
+//~^ ERROR: `AbstractRenderer + 'static` does not have a constant size known at compile-time
 {
     match 0 {
         _ => unimplemented!()

--- a/src/test/compile-fail/issue-18919.rs
+++ b/src/test/compile-fail/issue-18919.rs
@@ -11,7 +11,7 @@
 type FuncType<'f> = Fn(&isize) -> isize + 'f;
 
 fn ho_func(f: Option<FuncType>) {
-    //~^ ERROR: `for<'r> std::ops::Fn(&'r isize) -> isize: std::marker::Sized` is not satisfied
+    //~^ ERROR: `for<'r> std::ops::Fn(&'r isize) -> isize` does not have a constant size known at
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-18919.rs
+++ b/src/test/compile-fail/issue-18919.rs
@@ -11,7 +11,7 @@
 type FuncType<'f> = Fn(&isize) -> isize + 'f;
 
 fn ho_func(f: Option<FuncType>) {
-    //~^ ERROR: `for<'r> std::ops::Fn(&'r isize) -> isize` does not have a constant size known at
+    //~^ ERROR the size for value values of type
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-20005.rs
+++ b/src/test/compile-fail/issue-20005.rs
@@ -15,7 +15,7 @@ trait From<Src> {
 }
 
 trait To {
-    fn to<Dst>(  //~ ERROR `Self: std::marker::Sized` is not satisfied
+    fn to<Dst>(  //~ ERROR `Self` does not have a constant size known at compile-time
         self
     ) -> <Dst as From<Self>>::Result where Dst: From<Self> {
         From::from(self)

--- a/src/test/compile-fail/issue-20005.rs
+++ b/src/test/compile-fail/issue-20005.rs
@@ -15,7 +15,7 @@ trait From<Src> {
 }
 
 trait To {
-    fn to<Dst>(  //~ ERROR `Self` does not have a constant size known at compile-time
+    fn to<Dst>(  //~ ERROR the size for value values of type
         self
     ) -> <Dst as From<Self>>::Result where Dst: From<Self> {
         From::from(self)

--- a/src/test/compile-fail/issue-20433.rs
+++ b/src/test/compile-fail/issue-20433.rs
@@ -14,5 +14,5 @@ struct The;
 
 impl The {
     fn iceman(c: Vec<[i32]>) {}
-    //~^ ERROR the trait bound `[i32]: std::marker::Sized` is not satisfied
+    //~^ ERROR `[i32]` does not have a constant size known at compile-time
 }

--- a/src/test/compile-fail/issue-20433.rs
+++ b/src/test/compile-fail/issue-20433.rs
@@ -14,5 +14,5 @@ struct The;
 
 impl The {
     fn iceman(c: Vec<[i32]>) {}
-    //~^ ERROR `[i32]` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }

--- a/src/test/compile-fail/issue-20605.rs
+++ b/src/test/compile-fail/issue-20605.rs
@@ -10,7 +10,7 @@
 
 fn changer<'a>(mut things: Box<Iterator<Item=&'a mut u8>>) {
     for item in *things { *item = 0 }
-//~^ ERROR `std::iter::Iterator<Item=&mut u8>` does not have a constant size known at compile-time
+//~^ ERROR the size for value values of type
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-20605.rs
+++ b/src/test/compile-fail/issue-20605.rs
@@ -10,7 +10,7 @@
 
 fn changer<'a>(mut things: Box<Iterator<Item=&'a mut u8>>) {
     for item in *things { *item = 0 }
-//~^ ERROR the trait bound `std::iter::Iterator<Item=&mut u8>: std::marker::Sized` is not satisfied
+//~^ ERROR `std::iter::Iterator<Item=&mut u8>` does not have a constant size known at compile-time
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-21763.rs
+++ b/src/test/compile-fail/issue-21763.rs
@@ -17,5 +17,5 @@ fn foo<T: Send>() {}
 
 fn main() {
     foo::<HashMap<Rc<()>, Rc<()>>>();
-    //~^ ERROR: `std::rc::Rc<()>: std::marker::Send` is not satisfied
+    //~^ ERROR `std::rc::Rc<()>` cannot be sent between threads safely
 }

--- a/src/test/compile-fail/issue-22874.rs
+++ b/src/test/compile-fail/issue-22874.rs
@@ -10,7 +10,7 @@
 
 struct Table {
     rows: [[String]],
-    //~^ ERROR `[std::string::String]` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 
 fn f(table: &Table) -> &[String] {

--- a/src/test/compile-fail/issue-22874.rs
+++ b/src/test/compile-fail/issue-22874.rs
@@ -10,7 +10,7 @@
 
 struct Table {
     rows: [[String]],
-    //~^ ERROR the trait bound `[std::string::String]: std::marker::Sized` is not satisfied [E0277]
+    //~^ ERROR `[std::string::String]` does not have a constant size known at compile-time
 }
 
 fn f(table: &Table) -> &[String] {

--- a/src/test/compile-fail/issue-23281.rs
+++ b/src/test/compile-fail/issue-23281.rs
@@ -14,7 +14,7 @@ pub struct Struct;
 
 impl Struct {
     pub fn function(funs: Vec<Fn() -> ()>) {}
-    //~^ ERROR `std::ops::Fn() + 'static` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-23281.rs
+++ b/src/test/compile-fail/issue-23281.rs
@@ -14,7 +14,7 @@ pub struct Struct;
 
 impl Struct {
     pub fn function(funs: Vec<Fn() -> ()>) {}
-    //~^ ERROR the trait bound `std::ops::Fn() + 'static: std::marker::Sized` is not satisfied
+    //~^ ERROR `std::ops::Fn() + 'static` does not have a constant size known at compile-time
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-24446.rs
+++ b/src/test/compile-fail/issue-24446.rs
@@ -10,8 +10,8 @@
 
 fn main() {
     static foo: Fn() -> u32 = || -> u32 {
-        //~^ ERROR: mismatched types
-        //~| ERROR: `std::ops::Fn() -> u32 + 'static` does not have a constant size known at
+        //~^ ERROR mismatched types
+        //~| ERROR the size for value values of type
         0
     };
 }

--- a/src/test/compile-fail/issue-24446.rs
+++ b/src/test/compile-fail/issue-24446.rs
@@ -11,7 +11,7 @@
 fn main() {
     static foo: Fn() -> u32 = || -> u32 {
         //~^ ERROR: mismatched types
-        //~| ERROR: `std::ops::Fn() -> u32 + 'static: std::marker::Sized` is not satisfied
+        //~| ERROR: `std::ops::Fn() -> u32 + 'static` does not have a constant size known at compile-time
         0
     };
 }

--- a/src/test/compile-fail/issue-24446.rs
+++ b/src/test/compile-fail/issue-24446.rs
@@ -11,7 +11,7 @@
 fn main() {
     static foo: Fn() -> u32 = || -> u32 {
         //~^ ERROR: mismatched types
-        //~| ERROR: `std::ops::Fn() -> u32 + 'static` does not have a constant size known at compile-time
+        //~| ERROR: `std::ops::Fn() -> u32 + 'static` does not have a constant size known at
         0
     };
 }

--- a/src/test/compile-fail/issue-27060-2.rs
+++ b/src/test/compile-fail/issue-27060-2.rs
@@ -10,7 +10,7 @@
 
 #[repr(packed)]
 pub struct Bad<T: ?Sized> {
-    data: T, //~ ERROR `T: std::marker::Sized` is not satisfied
+    data: T, //~ ERROR `T` does not have a constant size known at compile-time
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-27060-2.rs
+++ b/src/test/compile-fail/issue-27060-2.rs
@@ -10,7 +10,7 @@
 
 #[repr(packed)]
 pub struct Bad<T: ?Sized> {
-    data: T, //~ ERROR `T` does not have a constant size known at compile-time
+    data: T, //~ ERROR the size for value values of type
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-27078.rs
+++ b/src/test/compile-fail/issue-27078.rs
@@ -13,7 +13,7 @@
 trait Foo {
     const BAR: i32;
     fn foo(self) -> &'static i32 {
-        //~^ ERROR the trait bound `Self: std::marker::Sized` is not satisfied
+        //~^ ERROR `Self` does not have a constant size known at compile-time
         &<Self>::BAR
     }
 }

--- a/src/test/compile-fail/issue-27078.rs
+++ b/src/test/compile-fail/issue-27078.rs
@@ -13,7 +13,7 @@
 trait Foo {
     const BAR: i32;
     fn foo(self) -> &'static i32 {
-        //~^ ERROR `Self` does not have a constant size known at compile-time
+        //~^ ERROR the size for value values of type
         &<Self>::BAR
     }
 }

--- a/src/test/compile-fail/issue-35988.rs
+++ b/src/test/compile-fail/issue-35988.rs
@@ -10,7 +10,7 @@
 
 enum E {
     V([Box<E>]),
-    //~^ ERROR `[std::boxed::Box<E>]` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-35988.rs
+++ b/src/test/compile-fail/issue-35988.rs
@@ -10,7 +10,7 @@
 
 enum E {
     V([Box<E>]),
-    //~^ ERROR the trait bound `[std::boxed::Box<E>]: std::marker::Sized` is not satisfied [E0277]
+    //~^ ERROR `[std::boxed::Box<E>]` does not have a constant size known at compile-time
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-38954.rs
+++ b/src/test/compile-fail/issue-38954.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 fn _test(ref _p: str) {}
-//~^ ERROR the trait bound `str: std::marker::Sized` is not satisfied [E0277]
+//~^ ERROR `str` does not have a constant size known at compile-time
 
 fn main() { }

--- a/src/test/compile-fail/issue-38954.rs
+++ b/src/test/compile-fail/issue-38954.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 fn _test(ref _p: str) {}
-//~^ ERROR `str` does not have a constant size known at compile-time
+//~^ ERROR the size for value values of type
 
 fn main() { }

--- a/src/test/compile-fail/issue-41229-ref-str.rs
+++ b/src/test/compile-fail/issue-41229-ref-str.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 pub fn example(ref s: str) {}
-//~^ ERROR `str` does not have a constant size known at compile-time
+//~^ ERROR the size for value values of type
 
 fn main() {}

--- a/src/test/compile-fail/issue-41229-ref-str.rs
+++ b/src/test/compile-fail/issue-41229-ref-str.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 pub fn example(ref s: str) {}
-//~^ ERROR the trait bound `str: std::marker::Sized` is not satisfied
-//~| `str` does not have a constant size known at compile-time
-//~| the trait `std::marker::Sized` is not implemented for `str`
+//~^ ERROR `str` does not have a constant size known at compile-time
 
 fn main() {}

--- a/src/test/compile-fail/issue-42312.rs
+++ b/src/test/compile-fail/issue-42312.rs
@@ -12,10 +12,10 @@ use std::ops::Deref;
 
 pub trait Foo {
     fn baz(_: Self::Target) where Self: Deref {}
-    //~^ ERROR `<Self as std::ops::Deref>::Target` does not have a constant size known at
+    //~^ ERROR the size for value values of type
 }
 
 pub fn f(_: ToString) {}
-//~^ ERROR `std::string::ToString + 'static` does not have a constant size known at compile-time
+//~^ ERROR the size for value values of type
 
 fn main() { }

--- a/src/test/compile-fail/issue-42312.rs
+++ b/src/test/compile-fail/issue-42312.rs
@@ -12,10 +12,10 @@ use std::ops::Deref;
 
 pub trait Foo {
     fn baz(_: Self::Target) where Self: Deref {}
-    //~^ ERROR `<Self as std::ops::Deref>::Target: std::marker::Sized` is not satisfied
+    //~^ ERROR `<Self as std::ops::Deref>::Target` does not have a constant size known at
 }
 
 pub fn f(_: ToString) {}
-//~^ ERROR the trait bound `std::string::ToString + 'static: std::marker::Sized` is not satisfied
+//~^ ERROR `std::string::ToString + 'static` does not have a constant size known at compile-time
 
 fn main() { }

--- a/src/test/compile-fail/issue-5883.rs
+++ b/src/test/compile-fail/issue-5883.rs
@@ -15,8 +15,8 @@ struct Struct {
 }
 
 fn new_struct(r: A+'static)
-    -> Struct { //~^  ERROR `A + 'static: std::marker::Sized` is not satisfied
-    //~^ ERROR `A + 'static: std::marker::Sized` is not satisfied
+    -> Struct { //~^  ERROR `A + 'static` does not have a constant size known at compile-time
+    //~^ ERROR `A + 'static` does not have a constant size known at compile-time
     Struct { r: r }
 }
 

--- a/src/test/compile-fail/issue-5883.rs
+++ b/src/test/compile-fail/issue-5883.rs
@@ -15,8 +15,8 @@ struct Struct {
 }
 
 fn new_struct(r: A+'static)
-    -> Struct { //~^  ERROR `A + 'static` does not have a constant size known at compile-time
-    //~^ ERROR `A + 'static` does not have a constant size known at compile-time
+    -> Struct { //~^ ERROR the size for value values of type
+    //~^ ERROR the size for value values of type
     Struct { r: r }
 }
 

--- a/src/test/compile-fail/issue-7013.rs
+++ b/src/test/compile-fail/issue-7013.rs
@@ -34,5 +34,5 @@ struct A {
 
 fn main() {
     let a = A {v: box B{v: None} as Box<Foo+Send>};
-    //~^ ERROR `std::rc::Rc<std::cell::RefCell<A>>: std::marker::Send` is not satisfied
+    //~^ ERROR `std::rc::Rc<std::cell::RefCell<A>>` cannot be sent between threads safely
 }

--- a/src/test/compile-fail/kindck-impl-type-params.rs
+++ b/src/test/compile-fail/kindck-impl-type-params.rs
@@ -26,15 +26,15 @@ impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
 fn f<T>(val: T) {
     let t: S<T> = S(marker::PhantomData);
     let a = &t as &Gettable<T>;
-    //~^ ERROR : std::marker::Send` is not satisfied
-    //~^^ ERROR : std::marker::Copy` is not satisfied
+    //~^ ERROR `T` cannot be sent between threads safely
+    //~| ERROR : std::marker::Copy` is not satisfied
 }
 
 fn g<T>(val: T) {
     let t: S<T> = S(marker::PhantomData);
     let a: &Gettable<T> = &t;
-    //~^ ERROR : std::marker::Send` is not satisfied
-    //~^^ ERROR : std::marker::Copy` is not satisfied
+    //~^ ERROR `T` cannot be sent between threads safely
+    //~| ERROR : std::marker::Copy` is not satisfied
 }
 
 fn foo<'a>() {

--- a/src/test/compile-fail/kindck-nonsendable-1.rs
+++ b/src/test/compile-fail/kindck-nonsendable-1.rs
@@ -18,5 +18,5 @@ fn bar<F:FnOnce() + Send>(_: F) { }
 fn main() {
     let x = Rc::new(3);
     bar(move|| foo(x));
-    //~^ ERROR : std::marker::Send` is not satisfied
+    //~^ ERROR `std::rc::Rc<usize>` cannot be sent between threads safely
 }

--- a/src/test/compile-fail/kindck-send-object.rs
+++ b/src/test/compile-fail/kindck-send-object.rs
@@ -24,7 +24,8 @@ fn object_ref_with_static_bound_not_ok() {
 }
 
 fn box_object_with_no_bound_not_ok<'a>() {
-    assert_send::<Box<Dummy>>(); //~ ERROR : std::marker::Send` is not satisfied
+    assert_send::<Box<Dummy>>();
+    //~^ ERROR `Dummy` cannot be sent between threads safely
 }
 
 fn object_with_send_bound_ok() {

--- a/src/test/compile-fail/kindck-send-object1.rs
+++ b/src/test/compile-fail/kindck-send-object1.rs
@@ -37,7 +37,7 @@ fn test61() {
 // them not ok
 fn test_71<'a>() {
     assert_send::<Box<Dummy+'a>>();
-    //~^ ERROR : std::marker::Send` is not satisfied
+    //~^ ERROR `Dummy + 'a` cannot be sent between threads safely
 }
 
 fn main() { }

--- a/src/test/compile-fail/kindck-send-object2.rs
+++ b/src/test/compile-fail/kindck-send-object2.rs
@@ -19,7 +19,8 @@ fn test50() {
 }
 
 fn test53() {
-    assert_send::<Box<Dummy>>(); //~ ERROR : std::marker::Send` is not satisfied
+    assert_send::<Box<Dummy>>();
+    //~^ ERROR `Dummy` cannot be sent between threads safely
 }
 
 // ...unless they are properly bounded

--- a/src/test/compile-fail/kindck-send-owned.rs
+++ b/src/test/compile-fail/kindck-send-owned.rs
@@ -19,7 +19,8 @@ fn test32() { assert_send::<Vec<isize> >(); }
 
 // but not if they own a bad thing
 fn test40() {
-    assert_send::<Box<*mut u8>>(); //~ ERROR : std::marker::Send` is not satisfied
+    assert_send::<Box<*mut u8>>();
+    //~^ ERROR `*mut u8` cannot be sent between threads safely
 }
 
 fn main() { }

--- a/src/test/compile-fail/kindck-send-unsafe.rs
+++ b/src/test/compile-fail/kindck-send-unsafe.rs
@@ -14,7 +14,7 @@ fn assert_send<T:Send>() { }
 
 fn test71<'a>() {
     assert_send::<*mut &'a isize>();
-    //~^ ERROR `*mut &'a isize: std::marker::Send` is not satisfied
+    //~^ ERROR `*mut &'a isize` cannot be sent between threads safely
 }
 
 fn main() {

--- a/src/test/compile-fail/no-send-res-ports.rs
+++ b/src/test/compile-fail/no-send-res-ports.rs
@@ -33,7 +33,7 @@ fn main() {
     let x = foo(Port(Rc::new(())));
 
     thread::spawn(move|| {
-        //~^ ERROR `std::rc::Rc<()>: std::marker::Send` is not satisfied
+        //~^ ERROR `std::rc::Rc<()>` cannot be sent between threads safely
         let y = x;
         println!("{:?}", y);
     });

--- a/src/test/compile-fail/no_send-enum.rs
+++ b/src/test/compile-fail/no_send-enum.rs
@@ -24,5 +24,5 @@ fn bar<T: Send>(_: T) {}
 fn main() {
     let x = Foo::A(NoSend);
     bar(x);
-    //~^ ERROR `NoSend: std::marker::Send` is not satisfied
+    //~^ ERROR `NoSend` cannot be sent between threads safely
 }

--- a/src/test/compile-fail/no_send-rc.rs
+++ b/src/test/compile-fail/no_send-rc.rs
@@ -15,5 +15,5 @@ fn bar<T: Send>(_: T) {}
 fn main() {
     let x = Rc::new(5);
     bar(x);
-    //~^ ERROR `std::rc::Rc<{integer}>: std::marker::Send` is not satisfied
+    //~^ ERROR `std::rc::Rc<{integer}>` cannot be sent between threads safely
 }

--- a/src/test/compile-fail/no_send-struct.rs
+++ b/src/test/compile-fail/no_send-struct.rs
@@ -23,5 +23,5 @@ fn bar<T: Send>(_: T) {}
 fn main() {
     let x = Foo { a: 5 };
     bar(x);
-    //~^ ERROR `Foo: std::marker::Send` is not satisfied
+    //~^ ERROR `Foo` cannot be sent between threads safely
 }

--- a/src/test/compile-fail/not-panic-safe-2.rs
+++ b/src/test/compile-fail/not-panic-safe-2.rs
@@ -18,6 +18,6 @@ fn assert<T: UnwindSafe + ?Sized>() {}
 
 fn main() {
     assert::<Rc<RefCell<i32>>>();
-    //~^ ERROR `std::cell::UnsafeCell<i32>: std::panic::RefUnwindSafe` is not satisfied
-    //~^^ ERROR `std::cell::UnsafeCell<usize>: std::panic::RefUnwindSafe` is not satisfied
+    //~^ ERROR the type `std::cell::UnsafeCell<i32>` may contain interior mutability and a
+    //~| ERROR the type `std::cell::UnsafeCell<usize>` may contain interior mutability and a
 }

--- a/src/test/compile-fail/not-panic-safe-3.rs
+++ b/src/test/compile-fail/not-panic-safe-3.rs
@@ -18,6 +18,6 @@ fn assert<T: UnwindSafe + ?Sized>() {}
 
 fn main() {
     assert::<Arc<RefCell<i32>>>();
-    //~^ ERROR `std::cell::UnsafeCell<i32>: std::panic::RefUnwindSafe` is not satisfied
-    //~^^ ERROR `std::cell::UnsafeCell<usize>: std::panic::RefUnwindSafe` is not satisfied
+    //~^ ERROR the type `std::cell::UnsafeCell<i32>` may contain interior mutability and a
+    //~| ERROR the type `std::cell::UnsafeCell<usize>` may contain interior mutability and a
 }

--- a/src/test/compile-fail/not-panic-safe-4.rs
+++ b/src/test/compile-fail/not-panic-safe-4.rs
@@ -17,6 +17,6 @@ fn assert<T: UnwindSafe + ?Sized>() {}
 
 fn main() {
     assert::<&RefCell<i32>>();
-    //~^ ERROR `std::cell::UnsafeCell<i32>: std::panic::RefUnwindSafe` is not satisfied
-    //~^^ ERROR `std::cell::UnsafeCell<usize>: std::panic::RefUnwindSafe` is not satisfied
+    //~^ ERROR the type `std::cell::UnsafeCell<i32>` may contain interior mutability and a
+    //~| ERROR the type `std::cell::UnsafeCell<usize>` may contain interior mutability and a
 }

--- a/src/test/compile-fail/not-panic-safe-6.rs
+++ b/src/test/compile-fail/not-panic-safe-6.rs
@@ -17,6 +17,6 @@ fn assert<T: UnwindSafe + ?Sized>() {}
 
 fn main() {
     assert::<*mut RefCell<i32>>();
-    //~^ ERROR `std::cell::UnsafeCell<i32>: std::panic::RefUnwindSafe` is not satisfied
-    //~^^ ERROR `std::cell::UnsafeCell<usize>: std::panic::RefUnwindSafe` is not satisfied
+    //~^ ERROR the type `std::cell::UnsafeCell<i32>` may contain interior mutability and a
+    //~| ERROR the type `std::cell::UnsafeCell<usize>` may contain interior mutability and a
 }

--- a/src/test/compile-fail/not-panic-safe.rs
+++ b/src/test/compile-fail/not-panic-safe.rs
@@ -16,5 +16,6 @@ use std::panic::UnwindSafe;
 fn assert<T: UnwindSafe + ?Sized>() {}
 
 fn main() {
-    assert::<&mut i32>(); //~ ERROR: UnwindSafe` is not satisfied
+    assert::<&mut i32>();
+    //~^ ERROR the type `&mut i32` may not be safely transferred across an unwind boundary
 }

--- a/src/test/compile-fail/range-1.rs
+++ b/src/test/compile-fail/range-1.rs
@@ -22,5 +22,5 @@ pub fn main() {
     // Unsized type.
     let arr: &[_] = &[1, 2, 3];
     let range = *arr..;
-    //~^ ERROR `[{integer}]: std::marker::Sized` is not satisfied
+    //~^ ERROR `[{integer}]` does not have a constant size known at compile-time
 }

--- a/src/test/compile-fail/range-1.rs
+++ b/src/test/compile-fail/range-1.rs
@@ -22,5 +22,5 @@ pub fn main() {
     // Unsized type.
     let arr: &[_] = &[1, 2, 3];
     let range = *arr..;
-    //~^ ERROR `[{integer}]` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }

--- a/src/test/compile-fail/range_traits-1.rs
+++ b/src/test/compile-fail/range_traits-1.rs
@@ -13,23 +13,23 @@ use std::ops::*;
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 struct AllTheRanges {
     a: Range<usize>,
-    //~^ ERROR PartialOrd
-    //~^^ ERROR Ord
+    //~^ ERROR can't compare
+    //~| ERROR Ord
     b: RangeTo<usize>,
-    //~^ ERROR PartialOrd
-    //~^^ ERROR Ord
+    //~^ ERROR can't compare
+    //~| ERROR Ord
     c: RangeFrom<usize>,
-    //~^ ERROR PartialOrd
-    //~^^ ERROR Ord
+    //~^ ERROR can't compare
+    //~| ERROR Ord
     d: RangeFull,
-    //~^ ERROR PartialOrd
-    //~^^ ERROR Ord
+    //~^ ERROR can't compare
+    //~| ERROR Ord
     e: RangeInclusive<usize>,
-    //~^ ERROR PartialOrd
-    //~^^ ERROR Ord
+    //~^ ERROR can't compare
+    //~| ERROR Ord
     f: RangeToInclusive<usize>,
-    //~^ ERROR PartialOrd
-    //~^^ ERROR Ord
+    //~^ ERROR can't compare
+    //~| ERROR Ord
 }
 
 fn main() {}

--- a/src/test/compile-fail/str-idx.rs
+++ b/src/test/compile-fail/str-idx.rs
@@ -10,5 +10,5 @@
 
 pub fn main() {
     let s: &str = "hello";
-    let c: u8 = s[4]; //~ ERROR `str: std::ops::Index<{integer}>` is not satisfied
+    let c: u8 = s[4]; //~ ERROR the type `str` cannot be indexed by `{integer}`
 }

--- a/src/test/compile-fail/str-mut-idx.rs
+++ b/src/test/compile-fail/str-mut-idx.rs
@@ -12,8 +12,8 @@ fn bot<T>() -> T { loop {} }
 
 fn mutate(s: &mut str) {
     s[1..2] = bot();
-    //~^ ERROR `str` does not have a constant size known at compile-time
-    //~| ERROR `str` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
+    //~| ERROR the size for value values of type
     s[1usize] = bot();
     //~^ ERROR the type `str` cannot be mutably indexed by `usize`
 }

--- a/src/test/compile-fail/str-mut-idx.rs
+++ b/src/test/compile-fail/str-mut-idx.rs
@@ -12,10 +12,10 @@ fn bot<T>() -> T { loop {} }
 
 fn mutate(s: &mut str) {
     s[1..2] = bot();
-    //~^ ERROR `str: std::marker::Sized` is not satisfied
-    //~| ERROR `str: std::marker::Sized` is not satisfied
+    //~^ ERROR `str` does not have a constant size known at compile-time
+    //~| ERROR `str` does not have a constant size known at compile-time
     s[1usize] = bot();
-    //~^ ERROR `str: std::ops::IndexMut<usize>` is not satisfied
+    //~^ ERROR the type `str` cannot be mutably indexed by `usize`
 }
 
 pub fn main() {}

--- a/src/test/compile-fail/substs-ppaux.rs
+++ b/src/test/compile-fail/substs-ppaux.rs
@@ -56,6 +56,6 @@ fn foo<'z>() where &'z (): Sized {
     //[normal]~| found type `fn() {foo::<'static>}`
 
     <str as Foo<u8>>::bar;
-    //[verbose]~^ ERROR `str: std::marker::Sized` is not satisfied
-    //[normal]~^^ ERROR `str: std::marker::Sized` is not satisfied
+    //[verbose]~^ ERROR `str` does not have a constant size known at compile-time
+    //[normal]~^^ ERROR `str` does not have a constant size known at compile-time
 }

--- a/src/test/compile-fail/substs-ppaux.rs
+++ b/src/test/compile-fail/substs-ppaux.rs
@@ -56,6 +56,6 @@ fn foo<'z>() where &'z (): Sized {
     //[normal]~| found type `fn() {foo::<'static>}`
 
     <str as Foo<u8>>::bar;
-    //[verbose]~^ ERROR `str` does not have a constant size known at compile-time
-    //[normal]~^^ ERROR `str` does not have a constant size known at compile-time
+    //[verbose]~^ ERROR the size for value values of type
+    //[normal]~^^ ERROR the size for value values of type
 }

--- a/src/test/compile-fail/trait-bounds-not-on-bare-trait.rs
+++ b/src/test/compile-fail/trait-bounds-not-on-bare-trait.rs
@@ -15,7 +15,7 @@ trait Foo {
 // This should emit the less confusing error, not the more confusing one.
 
 fn foo(_x: Foo + Send) {
-    //~^ ERROR the trait bound `Foo + std::marker::Send + 'static: std::marker::Sized` is not
+    //~^ ERROR `Foo + std::marker::Send + 'static` does not have a constant size known at compile-time
 }
 
 fn main() { }

--- a/src/test/compile-fail/trait-bounds-not-on-bare-trait.rs
+++ b/src/test/compile-fail/trait-bounds-not-on-bare-trait.rs
@@ -15,7 +15,7 @@ trait Foo {
 // This should emit the less confusing error, not the more confusing one.
 
 fn foo(_x: Foo + Send) {
-    //~^ ERROR `Foo + std::marker::Send + 'static` does not have a constant size known at compile-time
+    //~^ ERROR `Foo + std::marker::Send + 'static` does not have a constant size known at
 }
 
 fn main() { }

--- a/src/test/compile-fail/trait-bounds-not-on-bare-trait.rs
+++ b/src/test/compile-fail/trait-bounds-not-on-bare-trait.rs
@@ -15,7 +15,7 @@ trait Foo {
 // This should emit the less confusing error, not the more confusing one.
 
 fn foo(_x: Foo + Send) {
-    //~^ ERROR `Foo + std::marker::Send + 'static` does not have a constant size known at
+    //~^ ERROR the size for value values of type
 }
 
 fn main() { }

--- a/src/test/compile-fail/traits-negative-impls.rs
+++ b/src/test/compile-fail/traits-negative-impls.rs
@@ -31,8 +31,8 @@ fn dummy() {
     impl !Send for TestType {}
 
     Outer(TestType);
-    //~^ ERROR `dummy::TestType: std::marker::Send` is not satisfied
-    //~| ERROR `dummy::TestType: std::marker::Send` is not satisfied
+    //~^ ERROR `dummy::TestType` cannot be sent between threads safely
+    //~| ERROR `dummy::TestType` cannot be sent between threads safely
 }
 
 fn dummy1b() {
@@ -40,7 +40,7 @@ fn dummy1b() {
     impl !Send for TestType {}
 
     is_send(TestType);
-    //~^ ERROR `dummy1b::TestType: std::marker::Send` is not satisfied
+    //~^ ERROR `dummy1b::TestType` cannot be sent between threads safely
 }
 
 fn dummy1c() {
@@ -48,7 +48,7 @@ fn dummy1c() {
     impl !Send for TestType {}
 
     is_send((8, TestType));
-    //~^ ERROR `dummy1c::TestType: std::marker::Send` is not satisfied
+    //~^ ERROR `dummy1c::TestType` cannot be sent between threads safely
 }
 
 fn dummy2() {
@@ -56,7 +56,7 @@ fn dummy2() {
     impl !Send for TestType {}
 
     is_send(Box::new(TestType));
-    //~^ ERROR `dummy2::TestType: std::marker::Send` is not satisfied
+    //~^ ERROR `dummy2::TestType` cannot be sent between threads safely
 }
 
 fn dummy3() {
@@ -64,7 +64,7 @@ fn dummy3() {
     impl !Send for TestType {}
 
     is_send(Box::new(Outer2(TestType)));
-    //~^ ERROR `dummy3::TestType: std::marker::Send` is not satisfied
+    //~^ ERROR `dummy3::TestType` cannot be sent between threads safely
 }
 
 fn main() {
@@ -74,5 +74,5 @@ fn main() {
     // This will complain about a missing Send impl because `Sync` is implement *just*
     // for T that are `Send`. Look at #20366 and #19950
     is_sync(Outer2(TestType));
-    //~^ ERROR `main::TestType: std::marker::Send` is not satisfied
+    //~^ ERROR `main::TestType` cannot be sent between threads safely
 }

--- a/src/test/compile-fail/typeck-default-trait-impl-negation-send.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-negation-send.rs
@@ -27,5 +27,5 @@ fn is_send<T: Send>() {}
 fn main() {
     is_send::<MySendable>();
     is_send::<MyNotSendable>();
-    //~^ ERROR `MyNotSendable: std::marker::Send` is not satisfied
+    //~^ ERROR `MyNotSendable` cannot be sent between threads safely
 }

--- a/src/test/compile-fail/union/union-unsized.rs
+++ b/src/test/compile-fail/union/union-unsized.rs
@@ -12,14 +12,15 @@
 
 union U {
     a: str,
-    //~^ ERROR `str` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
+
     b: u8,
 }
 
 union W {
     a: u8,
     b: str,
-    //~^ ERROR `str` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 
 fn main() {}

--- a/src/test/compile-fail/union/union-unsized.rs
+++ b/src/test/compile-fail/union/union-unsized.rs
@@ -11,13 +11,15 @@
 #![feature(untagged_unions)]
 
 union U {
-    a: str, //~ ERROR the trait bound `str: std::marker::Sized` is not satisfied
+    a: str,
+    //~^ ERROR `str` does not have a constant size known at compile-time
     b: u8,
 }
 
 union W {
     a: u8,
-    b: str, //~ ERROR the trait bound `str: std::marker::Sized` is not satisfied
+    b: str,
+    //~^ ERROR `str` does not have a constant size known at compile-time
 }
 
 fn main() {}

--- a/src/test/compile-fail/unsized-bare-typaram.rs
+++ b/src/test/compile-fail/unsized-bare-typaram.rs
@@ -9,5 +9,6 @@
 // except according to those terms.
 
 fn bar<T: Sized>() { }
-fn foo<T: ?Sized>() { bar::<T>() } //~ ERROR `T: std::marker::Sized` is not satisfied
+fn foo<T: ?Sized>() { bar::<T>() }
+//~^ ERROR `T` does not have a constant size known at compile-time
 fn main() { }

--- a/src/test/compile-fail/unsized-bare-typaram.rs
+++ b/src/test/compile-fail/unsized-bare-typaram.rs
@@ -10,5 +10,5 @@
 
 fn bar<T: Sized>() { }
 fn foo<T: ?Sized>() { bar::<T>() }
-//~^ ERROR `T` does not have a constant size known at compile-time
+//~^ ERROR the size for value values of type
 fn main() { }

--- a/src/test/compile-fail/unsized-enum.rs
+++ b/src/test/compile-fail/unsized-enum.rs
@@ -15,7 +15,7 @@ fn not_sized<T: ?Sized>() { }
 enum Foo<U> { FooSome(U), FooNone }
 fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
 fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
-//~^ ERROR `T: std::marker::Sized` is not satisfied
+//~^ ERROR `T` does not have a constant size known at compile-time
 //
 // Not OK: `T` is not sized.
 

--- a/src/test/compile-fail/unsized-enum.rs
+++ b/src/test/compile-fail/unsized-enum.rs
@@ -15,7 +15,7 @@ fn not_sized<T: ?Sized>() { }
 enum Foo<U> { FooSome(U), FooNone }
 fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
 fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
-//~^ ERROR `T` does not have a constant size known at compile-time
+//~^ ERROR the size for value values of type
 //
 // Not OK: `T` is not sized.
 

--- a/src/test/compile-fail/unsized-inherent-impl-self-type.rs
+++ b/src/test/compile-fail/unsized-inherent-impl-self-type.rs
@@ -14,7 +14,8 @@
 
 struct S5<Y>(Y);
 
-impl<X: ?Sized> S5<X> { //~ ERROR E0277
+impl<X: ?Sized> S5<X> {
+    //~^ ERROR `X` does not have a constant size known at compile-time
 }
 
 fn main() { }

--- a/src/test/compile-fail/unsized-inherent-impl-self-type.rs
+++ b/src/test/compile-fail/unsized-inherent-impl-self-type.rs
@@ -15,7 +15,7 @@
 struct S5<Y>(Y);
 
 impl<X: ?Sized> S5<X> {
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 
 fn main() { }

--- a/src/test/compile-fail/unsized-struct.rs
+++ b/src/test/compile-fail/unsized-struct.rs
@@ -15,14 +15,14 @@ fn not_sized<T: ?Sized>() { }
 struct Foo<T> { data: T }
 fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
 fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
-//~^ ERROR `T` does not have a constant size known at compile-time
+//~^ ERROR the size for value values of type
 //
 // Not OK: `T` is not sized.
 
 struct Bar<T: ?Sized> { data: T }
 fn bar1<T: ?Sized>() { not_sized::<Bar<T>>() }
 fn bar2<T: ?Sized>() { is_sized::<Bar<T>>() }
-//~^ ERROR `T` does not have a constant size known at compile-time
+//~^ ERROR the size for value values of type
 //
 // Not OK: `Bar<T>` is not sized, but it should be.
 

--- a/src/test/compile-fail/unsized-struct.rs
+++ b/src/test/compile-fail/unsized-struct.rs
@@ -15,14 +15,14 @@ fn not_sized<T: ?Sized>() { }
 struct Foo<T> { data: T }
 fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
 fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
-//~^ ERROR `T: std::marker::Sized` is not satisfied
+//~^ ERROR `T` does not have a constant size known at compile-time
 //
 // Not OK: `T` is not sized.
 
 struct Bar<T: ?Sized> { data: T }
 fn bar1<T: ?Sized>() { not_sized::<Bar<T>>() }
 fn bar2<T: ?Sized>() { is_sized::<Bar<T>>() }
-//~^ ERROR `T: std::marker::Sized` is not satisfied
+//~^ ERROR `T` does not have a constant size known at compile-time
 //
 // Not OK: `Bar<T>` is not sized, but it should be.
 

--- a/src/test/compile-fail/unsized-trait-impl-self-type.rs
+++ b/src/test/compile-fail/unsized-trait-impl-self-type.rs
@@ -17,7 +17,8 @@ trait T3<Z: ?Sized> {
 
 struct S5<Y>(Y);
 
-impl<X: ?Sized> T3<X> for S5<X> { //~ ERROR E0277
+impl<X: ?Sized> T3<X> for S5<X> {
+    //~^ ERROR `X` does not have a constant size known at compile-time
 }
 
 fn main() { }

--- a/src/test/compile-fail/unsized-trait-impl-self-type.rs
+++ b/src/test/compile-fail/unsized-trait-impl-self-type.rs
@@ -18,7 +18,7 @@ trait T3<Z: ?Sized> {
 struct S5<Y>(Y);
 
 impl<X: ?Sized> T3<X> for S5<X> {
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 
 fn main() { }

--- a/src/test/compile-fail/unsized-trait-impl-trait-arg.rs
+++ b/src/test/compile-fail/unsized-trait-impl-trait-arg.rs
@@ -16,7 +16,7 @@ trait T2<Z> {
 }
 struct S4<Y: ?Sized>(Box<Y>);
 impl<X: ?Sized> T2<X> for S4<X> {
-    //~^ ERROR `X: std::marker::Sized` is not satisfied
+    //~^ ERROR `X` does not have a constant size known at compile-time
 }
 
 fn main() { }

--- a/src/test/compile-fail/unsized-trait-impl-trait-arg.rs
+++ b/src/test/compile-fail/unsized-trait-impl-trait-arg.rs
@@ -16,7 +16,7 @@ trait T2<Z> {
 }
 struct S4<Y: ?Sized>(Box<Y>);
 impl<X: ?Sized> T2<X> for S4<X> {
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 
 fn main() { }

--- a/src/test/compile-fail/unsized3.rs
+++ b/src/test/compile-fail/unsized3.rs
@@ -15,7 +15,7 @@ use std::marker;
 // Unbounded.
 fn f1<X: ?Sized>(x: &X) {
     f2::<X>(x);
-    //~^ ERROR `X: std::marker::Sized` is not satisfied
+    //~^ ERROR `X` does not have a constant size known at compile-time
 }
 fn f2<X>(x: &X) {
 }
@@ -26,7 +26,7 @@ trait T {
 }
 fn f3<X: ?Sized + T>(x: &X) {
     f4::<X>(x);
-    //~^ ERROR `X: std::marker::Sized` is not satisfied
+    //~^ ERROR `X` does not have a constant size known at compile-time
 }
 fn f4<X: T>(x: &X) {
 }
@@ -41,20 +41,20 @@ struct S<X: ?Sized> {
 
 fn f8<X: ?Sized>(x1: &S<X>, x2: &S<X>) {
     f5(x1);
-    //~^ ERROR `X: std::marker::Sized` is not satisfied
+    //~^ ERROR `X` does not have a constant size known at compile-time
     f6(x2); // ok
 }
 
 // Test some tuples.
 fn f9<X: ?Sized>(x1: Box<S<X>>) {
     f5(&(*x1, 34));
-    //~^ ERROR `X: std::marker::Sized` is not satisfied
+    //~^ ERROR `X` does not have a constant size known at compile-time
 }
 
 fn f10<X: ?Sized>(x1: Box<S<X>>) {
     f5(&(32, *x1));
-    //~^ ERROR `X: std::marker::Sized` is not satisfied
-    //~| ERROR `X: std::marker::Sized` is not satisfied
+    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~| ERROR `X` does not have a constant size known at compile-time
 }
 
 pub fn main() {

--- a/src/test/compile-fail/unsized3.rs
+++ b/src/test/compile-fail/unsized3.rs
@@ -15,7 +15,7 @@ use std::marker;
 // Unbounded.
 fn f1<X: ?Sized>(x: &X) {
     f2::<X>(x);
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 fn f2<X>(x: &X) {
 }
@@ -26,7 +26,7 @@ trait T {
 }
 fn f3<X: ?Sized + T>(x: &X) {
     f4::<X>(x);
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 fn f4<X: T>(x: &X) {
 }
@@ -41,20 +41,20 @@ struct S<X: ?Sized> {
 
 fn f8<X: ?Sized>(x1: &S<X>, x2: &S<X>) {
     f5(x1);
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     f6(x2); // ok
 }
 
 // Test some tuples.
 fn f9<X: ?Sized>(x1: Box<S<X>>) {
     f5(&(*x1, 34));
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 
 fn f10<X: ?Sized>(x1: Box<S<X>>) {
     f5(&(32, *x1));
-    //~^ ERROR `X` does not have a constant size known at compile-time
-    //~| ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
+    //~| ERROR the size for value values of type
 }
 
 pub fn main() {

--- a/src/test/compile-fail/unsized5.rs
+++ b/src/test/compile-fail/unsized5.rs
@@ -11,27 +11,33 @@
 // Test `?Sized` types not allowed in fields (except the last one).
 
 struct S1<X: ?Sized> {
-    f1: X, //~ ERROR `X: std::marker::Sized` is not satisfied
+    f1: X,
+    //~^ ERROR `X` does not have a constant size known at compile-time
     f2: isize,
 }
 struct S2<X: ?Sized> {
     f: isize,
-    g: X, //~ ERROR `X: std::marker::Sized` is not satisfied
+    g: X,
+    //~^ ERROR `X` does not have a constant size known at compile-time
     h: isize,
 }
 struct S3 {
-    f: str, //~ ERROR `str: std::marker::Sized` is not satisfied
+    f: str,
+    //~^ ERROR `str` does not have a constant size known at compile-time
     g: [usize]
 }
 struct S4 {
-    f: [u8], //~ ERROR `[u8]: std::marker::Sized` is not satisfied
+    f: [u8],
+    //~^ ERROR `[u8]` does not have a constant size known at compile-time
     g: usize
 }
 enum E<X: ?Sized> {
-    V1(X, isize), //~ERROR `X: std::marker::Sized` is not satisfied
+    V1(X, isize),
+    //~^ ERROR `X` does not have a constant size known at compile-time
 }
 enum F<X: ?Sized> {
-    V2{f1: X, f: isize}, //~ERROR `X: std::marker::Sized` is not satisfied
+    V2{f1: X, f: isize},
+    //~^ ERROR `X` does not have a constant size known at compile-time
 }
 
 pub fn main() {

--- a/src/test/compile-fail/unsized5.rs
+++ b/src/test/compile-fail/unsized5.rs
@@ -12,32 +12,32 @@
 
 struct S1<X: ?Sized> {
     f1: X,
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     f2: isize,
 }
 struct S2<X: ?Sized> {
     f: isize,
     g: X,
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     h: isize,
 }
 struct S3 {
     f: str,
-    //~^ ERROR `str` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     g: [usize]
 }
 struct S4 {
     f: [u8],
-    //~^ ERROR `[u8]` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     g: usize
 }
 enum E<X: ?Sized> {
     V1(X, isize),
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 enum F<X: ?Sized> {
     V2{f1: X, f: isize},
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 
 pub fn main() {

--- a/src/test/compile-fail/unsized6.rs
+++ b/src/test/compile-fail/unsized6.rs
@@ -14,28 +14,41 @@ trait T {}
 
 fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
     let _: W; // <-- this is OK, no bindings created, no initializer.
-    let _: (isize, (X, isize)); //~ERROR `X: std::marker::Sized` is not satisfie
-    let y: Y; //~ERROR `Y: std::marker::Sized` is not satisfied
-    let y: (isize, (Z, usize)); //~ERROR `Z: std::marker::Sized` is not satisfied
+    let _: (isize, (X, isize));
+    //~^ ERROR `X` does not have a constant size known at compile-time
+    let y: Y;
+    //~^ ERROR `Y` does not have a constant size known at compile-time
+    let y: (isize, (Z, usize));
+    //~^ ERROR `Z` does not have a constant size known at compile-time
 }
 fn f2<X: ?Sized, Y: ?Sized>(x: &X) {
-    let y: X; //~ERROR `X: std::marker::Sized` is not satisfied
-    let y: (isize, (Y, isize)); //~ERROR `Y: std::marker::Sized` is not satisfied
+    let y: X;
+    //~^ ERROR `X` does not have a constant size known at compile-time
+    let y: (isize, (Y, isize));
+    //~^ ERROR `Y` does not have a constant size known at compile-time
 }
 
 fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-    let y: X = *x1; //~ERROR `X: std::marker::Sized` is not satisfied
-    let y = *x2; //~ERROR `X: std::marker::Sized` is not satisfied
-    let (y, z) = (*x3, 4); //~ERROR `X: std::marker::Sized` is not satisfied
+    let y: X = *x1;
+    //~^ ERROR `X` does not have a constant size known at compile-time
+    let y = *x2;
+    //~^ ERROR `X` does not have a constant size known at compile-time
+    let (y, z) = (*x3, 4);
+    //~^ ERROR `X` does not have a constant size known at compile-time
 }
 fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-    let y: X = *x1;         //~ERROR `X: std::marker::Sized` is not satisfied
-    let y = *x2;            //~ERROR `X: std::marker::Sized` is not satisfied
-    let (y, z) = (*x3, 4); //~ERROR `X: std::marker::Sized` is not satisfied
+    let y: X = *x1;
+    //~^ ERROR `X` does not have a constant size known at compile-time
+    let y = *x2;
+    //~^ ERROR `X` does not have a constant size known at compile-time
+    let (y, z) = (*x3, 4);
+    //~^ ERROR `X` does not have a constant size known at compile-time
 }
 
-fn g1<X: ?Sized>(x: X) {} //~ERROR `X: std::marker::Sized` is not satisfied
-fn g2<X: ?Sized + T>(x: X) {} //~ERROR `X: std::marker::Sized` is not satisfied
+fn g1<X: ?Sized>(x: X) {}
+//~^ ERROR `X` does not have a constant size known at compile-time
+fn g2<X: ?Sized + T>(x: X) {}
+//~^ ERROR `X` does not have a constant size known at compile-time
 
 pub fn main() {
 }

--- a/src/test/compile-fail/unsized6.rs
+++ b/src/test/compile-fail/unsized6.rs
@@ -15,40 +15,40 @@ trait T {}
 fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
     let _: W; // <-- this is OK, no bindings created, no initializer.
     let _: (isize, (X, isize));
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     let y: Y;
-    //~^ ERROR `Y` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     let y: (isize, (Z, usize));
-    //~^ ERROR `Z` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 fn f2<X: ?Sized, Y: ?Sized>(x: &X) {
     let y: X;
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     let y: (isize, (Y, isize));
-    //~^ ERROR `Y` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 
 fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
     let y: X = *x1;
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     let y = *x2;
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     let (y, z) = (*x3, 4);
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
     let y: X = *x1;
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     let y = *x2;
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     let (y, z) = (*x3, 4);
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 
 fn g1<X: ?Sized>(x: X) {}
-//~^ ERROR `X` does not have a constant size known at compile-time
+//~^ ERROR the size for value values of type
 fn g2<X: ?Sized + T>(x: X) {}
-//~^ ERROR `X` does not have a constant size known at compile-time
+//~^ ERROR the size for value values of type
 
 pub fn main() {
 }

--- a/src/test/compile-fail/unsized7.rs
+++ b/src/test/compile-fail/unsized7.rs
@@ -20,7 +20,7 @@ trait T1<Z: T> {
 
 struct S3<Y: ?Sized>(Box<Y>);
 impl<X: ?Sized + T> T1<X> for S3<X> {
-    //~^ ERROR `X: std::marker::Sized` is not satisfied
+    //~^ ERROR `X` does not have a constant size known at compile-time
 }
 
 fn main() { }

--- a/src/test/compile-fail/unsized7.rs
+++ b/src/test/compile-fail/unsized7.rs
@@ -20,7 +20,7 @@ trait T1<Z: T> {
 
 struct S3<Y: ?Sized>(Box<Y>);
 impl<X: ?Sized + T> T1<X> for S3<X> {
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 
 fn main() { }

--- a/src/test/ui/codemap_tests/unicode.stderr
+++ b/src/test/ui/codemap_tests/unicode.stderr
@@ -1,4 +1,4 @@
-error[E0697]: invalid ABI: found `路濫狼á́́`
+error[E0703]: invalid ABI: found `路濫狼á́́`
   --> $DIR/unicode.rs:11:8
    |
 LL | extern "路濫狼á́́" fn foo() {} //~ ERROR invalid ABI
@@ -8,4 +8,4 @@ LL | extern "路濫狼á́́" fn foo() {} //~ ERROR invalid ABI
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0697`.
+For more information about this error, try `rustc --explain E0703`.

--- a/src/test/ui/codemap_tests/unicode.stderr
+++ b/src/test/ui/codemap_tests/unicode.stderr
@@ -1,8 +1,11 @@
-error: invalid ABI: expected one of [cdecl, stdcall, fastcall, vectorcall, thiscall, aapcs, win64, sysv64, ptx-kernel, msp430-interrupt, x86-interrupt, Rust, C, system, rust-intrinsic, rust-call, platform-intrinsic, unadjusted], found `路濫狼á́́`
+error[E0697]: invalid ABI: found `路濫狼á́́`
   --> $DIR/unicode.rs:11:8
    |
 LL | extern "路濫狼á́́" fn foo() {} //~ ERROR invalid ABI
-   |        ^^^^^^^^^
+   |        ^^^^^^^^^ invalid ABI
+   |
+   = help: valid ABIs: cdecl, stdcall, fastcall, vectorcall, thiscall, aapcs, win64, sysv64, ptx-kernel, msp430-interrupt, x86-interrupt, Rust, C, system, rust-intrinsic, rust-call, platform-intrinsic, unadjusted
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0697`.

--- a/src/test/ui/const-unsized.rs
+++ b/src/test/ui/const-unsized.rs
@@ -11,16 +11,16 @@
 use std::fmt::Debug;
 
 const CONST_0: Debug+Sync = *(&0 as &(Debug+Sync));
-//~^ ERROR `std::fmt::Debug + std::marker::Sync + 'static: std::marker::Sized` is not satisfied
+//~^ ERROR `std::fmt::Debug + std::marker::Sync + 'static` does not have a constant size known at
 
 const CONST_FOO: str = *"foo";
-//~^ ERROR `str: std::marker::Sized` is not satisfied
+//~^ ERROR `str` does not have a constant size known at compile-time
 
 static STATIC_1: Debug+Sync = *(&1 as &(Debug+Sync));
-//~^ ERROR `std::fmt::Debug + std::marker::Sync + 'static: std::marker::Sized` is not satisfied
+//~^ ERROR `std::fmt::Debug + std::marker::Sync + 'static` does not have a constant size known at
 
 static STATIC_BAR: str = *"bar";
-//~^ ERROR `str: std::marker::Sized` is not satisfied
+//~^ ERROR `str` does not have a constant size known at compile-time
 
 fn main() {
     println!("{:?} {:?} {:?} {:?}", &CONST_0, &CONST_FOO, &STATIC_1, &STATIC_BAR);

--- a/src/test/ui/const-unsized.rs
+++ b/src/test/ui/const-unsized.rs
@@ -11,16 +11,16 @@
 use std::fmt::Debug;
 
 const CONST_0: Debug+Sync = *(&0 as &(Debug+Sync));
-//~^ ERROR `std::fmt::Debug + std::marker::Sync + 'static` does not have a constant size known at
+//~^ ERROR the size for value values of type
 
 const CONST_FOO: str = *"foo";
-//~^ ERROR `str` does not have a constant size known at compile-time
+//~^ ERROR the size for value values of type
 
 static STATIC_1: Debug+Sync = *(&1 as &(Debug+Sync));
-//~^ ERROR `std::fmt::Debug + std::marker::Sync + 'static` does not have a constant size known at
+//~^ ERROR the size for value values of type
 
 static STATIC_BAR: str = *"bar";
-//~^ ERROR `str` does not have a constant size known at compile-time
+//~^ ERROR the size for value values of type
 
 fn main() {
     println!("{:?} {:?} {:?} {:?}", &CONST_0, &CONST_FOO, &STATIC_1, &STATIC_BAR);

--- a/src/test/ui/const-unsized.stderr
+++ b/src/test/ui/const-unsized.stderr
@@ -1,38 +1,38 @@
-error[E0277]: `std::fmt::Debug + std::marker::Sync + 'static` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `std::fmt::Debug + std::marker::Sync + 'static` cannot be known at compilation time
   --> $DIR/const-unsized.rs:13:29
    |
 LL | const CONST_0: Debug+Sync = *(&0 as &(Debug+Sync));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^ `std::fmt::Debug + std::marker::Sync + 'static` does not have a constant size known at compile-time
+   |                             ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `std::fmt::Debug + std::marker::Sync + 'static`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: constant expressions must have a statically known size
 
-error[E0277]: `str` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `str` cannot be known at compilation time
   --> $DIR/const-unsized.rs:16:24
    |
 LL | const CONST_FOO: str = *"foo";
-   |                        ^^^^^^ `str` does not have a constant size known at compile-time
+   |                        ^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: constant expressions must have a statically known size
 
-error[E0277]: `std::fmt::Debug + std::marker::Sync + 'static` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `std::fmt::Debug + std::marker::Sync + 'static` cannot be known at compilation time
   --> $DIR/const-unsized.rs:19:31
    |
 LL | static STATIC_1: Debug+Sync = *(&1 as &(Debug+Sync));
-   |                               ^^^^^^^^^^^^^^^^^^^^^^ `std::fmt::Debug + std::marker::Sync + 'static` does not have a constant size known at compile-time
+   |                               ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `std::fmt::Debug + std::marker::Sync + 'static`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: constant expressions must have a statically known size
 
-error[E0277]: `str` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `str` cannot be known at compilation time
   --> $DIR/const-unsized.rs:22:26
    |
 LL | static STATIC_BAR: str = *"bar";
-   |                          ^^^^^^ `str` does not have a constant size known at compile-time
+   |                          ^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>

--- a/src/test/ui/const-unsized.stderr
+++ b/src/test/ui/const-unsized.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `std::fmt::Debug + std::marker::Sync + 'static: std::marker::Sized` is not satisfied
+error[E0277]: `std::fmt::Debug + std::marker::Sync + 'static` does not have a constant size known at compile-time
   --> $DIR/const-unsized.rs:13:29
    |
 LL | const CONST_0: Debug+Sync = *(&0 as &(Debug+Sync));
@@ -7,7 +7,7 @@ LL | const CONST_0: Debug+Sync = *(&0 as &(Debug+Sync));
    = help: the trait `std::marker::Sized` is not implemented for `std::fmt::Debug + std::marker::Sync + 'static`
    = note: constant expressions must have a statically known size
 
-error[E0277]: the trait bound `str: std::marker::Sized` is not satisfied
+error[E0277]: `str` does not have a constant size known at compile-time
   --> $DIR/const-unsized.rs:16:24
    |
 LL | const CONST_FOO: str = *"foo";
@@ -16,7 +16,7 @@ LL | const CONST_FOO: str = *"foo";
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: constant expressions must have a statically known size
 
-error[E0277]: the trait bound `std::fmt::Debug + std::marker::Sync + 'static: std::marker::Sized` is not satisfied
+error[E0277]: `std::fmt::Debug + std::marker::Sync + 'static` does not have a constant size known at compile-time
   --> $DIR/const-unsized.rs:19:31
    |
 LL | static STATIC_1: Debug+Sync = *(&1 as &(Debug+Sync));
@@ -25,7 +25,7 @@ LL | static STATIC_1: Debug+Sync = *(&1 as &(Debug+Sync));
    = help: the trait `std::marker::Sized` is not implemented for `std::fmt::Debug + std::marker::Sync + 'static`
    = note: constant expressions must have a statically known size
 
-error[E0277]: the trait bound `str: std::marker::Sized` is not satisfied
+error[E0277]: `str` does not have a constant size known at compile-time
   --> $DIR/const-unsized.rs:22:26
    |
 LL | static STATIC_BAR: str = *"bar";

--- a/src/test/ui/const-unsized.stderr
+++ b/src/test/ui/const-unsized.stderr
@@ -5,6 +5,7 @@ LL | const CONST_0: Debug+Sync = *(&0 as &(Debug+Sync));
    |                             ^^^^^^^^^^^^^^^^^^^^^^ `std::fmt::Debug + std::marker::Sync + 'static` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `std::fmt::Debug + std::marker::Sync + 'static`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: constant expressions must have a statically known size
 
 error[E0277]: `str` does not have a constant size known at compile-time
@@ -14,6 +15,7 @@ LL | const CONST_FOO: str = *"foo";
    |                        ^^^^^^ `str` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: constant expressions must have a statically known size
 
 error[E0277]: `std::fmt::Debug + std::marker::Sync + 'static` does not have a constant size known at compile-time
@@ -23,6 +25,7 @@ LL | static STATIC_1: Debug+Sync = *(&1 as &(Debug+Sync));
    |                               ^^^^^^^^^^^^^^^^^^^^^^ `std::fmt::Debug + std::marker::Sync + 'static` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `std::fmt::Debug + std::marker::Sync + 'static`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: constant expressions must have a statically known size
 
 error[E0277]: `str` does not have a constant size known at compile-time
@@ -32,6 +35,7 @@ LL | static STATIC_BAR: str = *"bar";
    |                          ^^^^^^ `str` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: constant expressions must have a statically known size
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/error-codes/E0277-2.rs
+++ b/src/test/ui/error-codes/E0277-2.rs
@@ -24,5 +24,5 @@ fn is_send<T: Send>() { }
 
 fn main() {
     is_send::<Foo>();
-    //~^ ERROR the trait bound `*const u8: std::marker::Send` is not satisfied in `Foo`
+    //~^ ERROR `*const u8` cannot be sent between threads safely
 }

--- a/src/test/ui/error-codes/E0277-2.stderr
+++ b/src/test/ui/error-codes/E0277-2.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `*const u8: std::marker::Send` is not satisfied in `Foo`
+error[E0277]: `*const u8` cannot be sent between threads safely
   --> $DIR/E0277-2.rs:26:5
    |
 LL |     is_send::<Foo>();

--- a/src/test/ui/error-codes/E0277.rs
+++ b/src/test/ui/error-codes/E0277.rs
@@ -21,7 +21,7 @@ fn some_func<T: Foo>(foo: T) {
 }
 
 fn f(p: Path) { }
-//~^ ERROR the trait bound `[u8]: std::marker::Sized` is not satisfied in `std::path::Path`
+//~^ ERROR `[u8]` does not have a constant size known at compile-time
 
 fn main() {
     some_func(5i32);

--- a/src/test/ui/error-codes/E0277.rs
+++ b/src/test/ui/error-codes/E0277.rs
@@ -21,7 +21,7 @@ fn some_func<T: Foo>(foo: T) {
 }
 
 fn f(p: Path) { }
-//~^ ERROR `[u8]` does not have a constant size known at compile-time
+//~^ ERROR the size for value values of type
 
 fn main() {
     some_func(5i32);

--- a/src/test/ui/error-codes/E0277.stderr
+++ b/src/test/ui/error-codes/E0277.stderr
@@ -5,6 +5,7 @@ LL | fn f(p: Path) { }
    |      ^ `[u8]` does not have a constant size known at compile-time
    |
    = help: within `std::path::Path`, the trait `std::marker::Sized` is not implemented for `[u8]`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: required because it appears within the type `std::path::Path`
    = note: all local variables must have a statically known size
 

--- a/src/test/ui/error-codes/E0277.stderr
+++ b/src/test/ui/error-codes/E0277.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `[u8]: std::marker::Sized` is not satisfied in `std::path::Path`
+error[E0277]: `[u8]` does not have a constant size known at compile-time
   --> $DIR/E0277.rs:23:6
    |
 LL | fn f(p: Path) { }

--- a/src/test/ui/error-codes/E0277.stderr
+++ b/src/test/ui/error-codes/E0277.stderr
@@ -1,8 +1,8 @@
-error[E0277]: `[u8]` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `[u8]` cannot be known at compilation time
   --> $DIR/E0277.rs:23:6
    |
 LL | fn f(p: Path) { }
-   |      ^ `[u8]` does not have a constant size known at compile-time
+   |      ^ doesn't have a size known at compile-time
    |
    = help: within `std::path::Path`, the trait `std::marker::Sized` is not implemented for `[u8]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>

--- a/src/test/ui/feature-gate-trivial_bounds.stderr
+++ b/src/test/ui/feature-gate-trivial_bounds.stderr
@@ -87,7 +87,7 @@ LL | | }
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
-error[E0277]: the trait bound `str: std::marker::Sized` is not satisfied
+error[E0277]: `str` does not have a constant size known at compile-time
   --> $DIR/feature-gate-trivial_bounds.rs:62:1
    |
 LL | struct TwoStrs(str, str) where str: Sized; //~ ERROR
@@ -97,7 +97,7 @@ LL | struct TwoStrs(str, str) where str: Sized; //~ ERROR
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
-error[E0277]: the trait bound `A + 'static: std::marker::Sized` is not satisfied in `Dst<A + 'static>`
+error[E0277]: `A + 'static` does not have a constant size known at compile-time
   --> $DIR/feature-gate-trivial_bounds.rs:65:1
    |
 LL | / fn unsized_local() where Dst<A>: Sized { //~ ERROR
@@ -110,7 +110,7 @@ LL | | }
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
-error[E0277]: the trait bound `str: std::marker::Sized` is not satisfied
+error[E0277]: `str` does not have a constant size known at compile-time
   --> $DIR/feature-gate-trivial_bounds.rs:69:1
    |
 LL | / fn return_str() -> str where str: Sized { //~ ERROR

--- a/src/test/ui/feature-gate-trivial_bounds.stderr
+++ b/src/test/ui/feature-gate-trivial_bounds.stderr
@@ -87,24 +87,24 @@ LL | | }
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
-error[E0277]: `str` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `str` cannot be known at compilation time
   --> $DIR/feature-gate-trivial_bounds.rs:62:1
    |
 LL | struct TwoStrs(str, str) where str: Sized; //~ ERROR
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `str` does not have a constant size known at compile-time
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
-error[E0277]: `A + 'static` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `A + 'static` cannot be known at compilation time
   --> $DIR/feature-gate-trivial_bounds.rs:65:1
    |
 LL | / fn unsized_local() where Dst<A>: Sized { //~ ERROR
 LL | |     let x: Dst<A> = *(Box::new(Dst { x: 1 }) as Box<Dst<A>>);
 LL | | }
-   | |_^ `A + 'static` does not have a constant size known at compile-time
+   | |_^ doesn't have a size known at compile-time
    |
    = help: within `Dst<A + 'static>`, the trait `std::marker::Sized` is not implemented for `A + 'static`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
@@ -112,13 +112,13 @@ LL | | }
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
-error[E0277]: `str` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `str` cannot be known at compilation time
   --> $DIR/feature-gate-trivial_bounds.rs:69:1
    |
 LL | / fn return_str() -> str where str: Sized { //~ ERROR
 LL | |     *"Sized".to_string().into_boxed_str()
 LL | | }
-   | |_^ `str` does not have a constant size known at compile-time
+   | |_^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>

--- a/src/test/ui/feature-gate-trivial_bounds.stderr
+++ b/src/test/ui/feature-gate-trivial_bounds.stderr
@@ -94,6 +94,7 @@ LL | struct TwoStrs(str, str) where str: Sized; //~ ERROR
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `str` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
@@ -106,6 +107,7 @@ LL | | }
    | |_^ `A + 'static` does not have a constant size known at compile-time
    |
    = help: within `Dst<A + 'static>`, the trait `std::marker::Sized` is not implemented for `A + 'static`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: required because it appears within the type `Dst<A + 'static>`
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
@@ -119,6 +121,7 @@ LL | | }
    | |_^ `str` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 

--- a/src/test/ui/generator/sized-yield.rs
+++ b/src/test/ui/generator/sized-yield.rs
@@ -15,9 +15,9 @@ use std::ops::Generator;
 fn main() {
    let s = String::from("foo");
    let mut gen = move || {
-   //~^ ERROR `str` does not have a constant size known at compile-time
+   //~^ ERROR the size for value values of type
        yield s[..];
    };
    unsafe { gen.resume(); }
-   //~^ ERROR `str` does not have a constant size known at compile-time
+   //~^ ERROR the size for value values of type
 }

--- a/src/test/ui/generator/sized-yield.rs
+++ b/src/test/ui/generator/sized-yield.rs
@@ -14,8 +14,10 @@ use std::ops::Generator;
 
 fn main() {
    let s = String::from("foo");
-   let mut gen = move || { //~ ERROR the trait bound `str: std::marker::Sized` is not satisfied
+   let mut gen = move || {
+   //~^ ERROR `str` does not have a constant size known at compile-time
        yield s[..];
    };
-   unsafe { gen.resume(); } //~ ERROR the trait bound `str: std::marker::Sized` is not satisfied
+   unsafe { gen.resume(); }
+   //~^ ERROR `str` does not have a constant size known at compile-time
 }

--- a/src/test/ui/generator/sized-yield.stderr
+++ b/src/test/ui/generator/sized-yield.stderr
@@ -1,22 +1,22 @@
-error[E0277]: `str` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `str` cannot be known at compilation time
   --> $DIR/sized-yield.rs:17:26
    |
 LL |      let mut gen = move || {
    |  __________________________^
-LL | |    //~^ ERROR `str` does not have a constant size known at compile-time
+LL | |    //~^ ERROR the size for value values of type
 LL | |        yield s[..];
 LL | |    };
-   | |____^ `str` does not have a constant size known at compile-time
+   | |____^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: the yield type of a generator must have a statically known size
 
-error[E0277]: `str` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `str` cannot be known at compilation time
   --> $DIR/sized-yield.rs:21:17
    |
 LL |    unsafe { gen.resume(); }
-   |                 ^^^^^^ `str` does not have a constant size known at compile-time
+   |                 ^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>

--- a/src/test/ui/generator/sized-yield.stderr
+++ b/src/test/ui/generator/sized-yield.stderr
@@ -1,8 +1,9 @@
-error[E0277]: the trait bound `str: std::marker::Sized` is not satisfied
+error[E0277]: `str` does not have a constant size known at compile-time
   --> $DIR/sized-yield.rs:17:26
    |
-LL |      let mut gen = move || { //~ ERROR the trait bound `str: std::marker::Sized` is not satisfied
+LL |      let mut gen = move || {
    |  __________________________^
+LL | |    //~^ ERROR `str` does not have a constant size known at compile-time
 LL | |        yield s[..];
 LL | |    };
    | |____^ `str` does not have a constant size known at compile-time
@@ -10,10 +11,10 @@ LL | |    };
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: the yield type of a generator must have a statically known size
 
-error[E0277]: the trait bound `str: std::marker::Sized` is not satisfied
-  --> $DIR/sized-yield.rs:20:17
+error[E0277]: `str` does not have a constant size known at compile-time
+  --> $DIR/sized-yield.rs:21:17
    |
-LL |    unsafe { gen.resume(); } //~ ERROR the trait bound `str: std::marker::Sized` is not satisfied
+LL |    unsafe { gen.resume(); }
    |                 ^^^^^^ `str` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`

--- a/src/test/ui/generator/sized-yield.stderr
+++ b/src/test/ui/generator/sized-yield.stderr
@@ -9,6 +9,7 @@ LL | |    };
    | |____^ `str` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: the yield type of a generator must have a statically known size
 
 error[E0277]: `str` does not have a constant size known at compile-time
@@ -18,6 +19,7 @@ LL |    unsafe { gen.resume(); }
    |                 ^^^^^^ `str` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/impl-trait/auto-trait-leak.rs
+++ b/src/test/ui/impl-trait/auto-trait-leak.rs
@@ -25,7 +25,7 @@ fn cycle1() -> impl Clone {
     //~^ ERROR cycle detected
     //~| ERROR cycle detected
     send(cycle2().clone());
-    //~^ ERROR Send` is not satisfied
+    //~^ ERROR `std::rc::Rc<std::string::String>` cannot be sent between threads safely
 
     Rc::new(Cell::new(5))
 }

--- a/src/test/ui/impl-trait/auto-trait-leak.stderr
+++ b/src/test/ui/impl-trait/auto-trait-leak.stderr
@@ -47,7 +47,7 @@ LL | fn cycle2() -> impl Clone {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires processing `cycle1::{{exist-impl-Trait}}`, completing the cycle
 
-error[E0277]: the trait bound `std::rc::Rc<std::string::String>: std::marker::Send` is not satisfied in `impl std::clone::Clone`
+error[E0277]: `std::rc::Rc<std::string::String>` cannot be sent between threads safely
   --> $DIR/auto-trait-leak.rs:27:5
    |
 LL |     send(cycle2().clone());

--- a/src/test/ui/impl-trait/auto-trait-leak2.rs
+++ b/src/test/ui/impl-trait/auto-trait-leak2.rs
@@ -23,10 +23,10 @@ fn send<T: Send>(_: T) {}
 
 fn main() {
     send(before());
-    //~^ ERROR the trait bound `std::rc::Rc<std::cell::Cell<i32>>: std::marker::Send` is not satisfied
+    //~^ ERROR `std::rc::Rc<std::cell::Cell<i32>>` cannot be sent between threads safely
 
     send(after());
-    //~^ ERROR the trait bound `std::rc::Rc<std::cell::Cell<i32>>: std::marker::Send` is not satisfied
+    //~^ ERROR `std::rc::Rc<std::cell::Cell<i32>>` cannot be sent between threads safely
 }
 
 // Deferred path, main has to wait until typeck finishes,

--- a/src/test/ui/impl-trait/auto-trait-leak2.stderr
+++ b/src/test/ui/impl-trait/auto-trait-leak2.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `std::rc::Rc<std::cell::Cell<i32>>: std::marker::Send` is not satisfied in `impl std::ops::Fn<(i32,)>`
+error[E0277]: `std::rc::Rc<std::cell::Cell<i32>>` cannot be sent between threads safely
   --> $DIR/auto-trait-leak2.rs:25:5
    |
 LL |     send(before());
@@ -13,7 +13,7 @@ note: required by `send`
 LL | fn send<T: Send>(_: T) {}
    | ^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `std::rc::Rc<std::cell::Cell<i32>>: std::marker::Send` is not satisfied in `impl std::ops::Fn<(i32,)>`
+error[E0277]: `std::rc::Rc<std::cell::Cell<i32>>` cannot be sent between threads safely
   --> $DIR/auto-trait-leak2.rs:28:5
    |
 LL |     send(after());

--- a/src/test/ui/interior-mutability/interior-mutability.rs
+++ b/src/test/ui/interior-mutability/interior-mutability.rs
@@ -12,5 +12,6 @@ use std::cell::Cell;
 use std::panic::catch_unwind;
 fn main() {
     let mut x = Cell::new(22);
-    catch_unwind(|| { x.set(23); }); //~ ERROR the trait bound
+    catch_unwind(|| { x.set(23); });
+    //~^ ERROR the type `std::cell::UnsafeCell<i32>` may contain interior mutability and a
 }

--- a/src/test/ui/interior-mutability/interior-mutability.stderr
+++ b/src/test/ui/interior-mutability/interior-mutability.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `std::cell::UnsafeCell<i32>: std::panic::RefUnwindSafe` is not satisfied in `std::cell::Cell<i32>`
+error[E0277]: the type `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> $DIR/interior-mutability.rs:15:5
    |
-LL |     catch_unwind(|| { x.set(23); }); //~ ERROR the trait bound
-   |     ^^^^^^^^^^^^ the type std::cell::UnsafeCell<i32> may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+LL |     catch_unwind(|| { x.set(23); });
+   |     ^^^^^^^^^^^^ `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
    = help: within `std::cell::Cell<i32>`, the trait `std::panic::RefUnwindSafe` is not implemented for `std::cell::UnsafeCell<i32>`
    = note: required because it appears within the type `std::cell::Cell<i32>`

--- a/src/test/ui/mismatched_types/binops.rs
+++ b/src/test/ui/mismatched_types/binops.rs
@@ -13,6 +13,6 @@ fn main() {
     2 as usize - Some(1); //~ ERROR cannot subtract `std::option::Option<{integer}>` from `usize`
     3 * (); //~ ERROR cannot multiply `()` to `{integer}`
     4 / ""; //~ ERROR cannot divide `{integer}` by `&str`
-    5 < String::new(); //~ ERROR is not satisfied
-    6 == Ok(1); //~ ERROR is not satisfied
+    5 < String::new(); //~ ERROR can't compare `{integer}` with `std::string::String`
+    6 == Ok(1); //~ ERROR can't compare `{integer}` with `std::result::Result<{integer}, _>`
 }

--- a/src/test/ui/mismatched_types/binops.stderr
+++ b/src/test/ui/mismatched_types/binops.stderr
@@ -30,19 +30,19 @@ LL |     4 / ""; //~ ERROR cannot divide `{integer}` by `&str`
    |
    = help: the trait `std::ops::Div<&str>` is not implemented for `{integer}`
 
-error[E0277]: the trait bound `{integer}: std::cmp::PartialOrd<std::string::String>` is not satisfied
+error[E0277]: can't compare `{integer}` with `std::string::String`
   --> $DIR/binops.rs:16:7
    |
-LL |     5 < String::new(); //~ ERROR is not satisfied
-   |       ^ can't compare `{integer}` with `std::string::String`
+LL |     5 < String::new(); //~ ERROR can't compare `{integer}` with `std::string::String`
+   |       ^ no implementation for `{integer} < std::string::String` and `{integer} > std::string::String`
    |
    = help: the trait `std::cmp::PartialOrd<std::string::String>` is not implemented for `{integer}`
 
-error[E0277]: the trait bound `{integer}: std::cmp::PartialEq<std::result::Result<{integer}, _>>` is not satisfied
+error[E0277]: can't compare `{integer}` with `std::result::Result<{integer}, _>`
   --> $DIR/binops.rs:17:7
    |
-LL |     6 == Ok(1); //~ ERROR is not satisfied
-   |       ^^ can't compare `{integer}` with `std::result::Result<{integer}, _>`
+LL |     6 == Ok(1); //~ ERROR can't compare `{integer}` with `std::result::Result<{integer}, _>`
+   |       ^^ no implementation for `{integer} == std::result::Result<{integer}, _>`
    |
    = help: the trait `std::cmp::PartialEq<std::result::Result<{integer}, _>>` is not implemented for `{integer}`
 

--- a/src/test/ui/mismatched_types/cast-rfc0401.rs
+++ b/src/test/ui/mismatched_types/cast-rfc0401.rs
@@ -60,7 +60,7 @@ fn main()
 
     let _ = 42usize as *const [u8]; //~ ERROR is invalid
     let _ = v as *const [u8]; //~ ERROR cannot cast
-    let _ = fat_v as *const Foo; //~ ERROR `[u8]` does not have a constant size known at
+    let _ = fat_v as *const Foo; //~ ERROR the size for value values of type
     let _ = foo as *const str; //~ ERROR is invalid
     let _ = foo as *mut str; //~ ERROR is invalid
     let _ = main as *mut str; //~ ERROR is invalid
@@ -69,7 +69,7 @@ fn main()
     let _ = fat_sv as usize; //~ ERROR is invalid
 
     let a : *const str = "hello";
-    let _ = a as *const Foo; //~ ERROR `str` does not have a constant size known at compile-time
+    let _ = a as *const Foo; //~ ERROR the size for value values of type
 
     // check no error cascade
     let _ = main.f as *const u32; //~ ERROR no field

--- a/src/test/ui/mismatched_types/cast-rfc0401.rs
+++ b/src/test/ui/mismatched_types/cast-rfc0401.rs
@@ -60,7 +60,7 @@ fn main()
 
     let _ = 42usize as *const [u8]; //~ ERROR is invalid
     let _ = v as *const [u8]; //~ ERROR cannot cast
-    let _ = fat_v as *const Foo; //~ ERROR `[u8]` does not have a constant size known at compile-time
+    let _ = fat_v as *const Foo; //~ ERROR `[u8]` does not have a constant size known at
     let _ = foo as *const str; //~ ERROR is invalid
     let _ = foo as *mut str; //~ ERROR is invalid
     let _ = main as *mut str; //~ ERROR is invalid

--- a/src/test/ui/mismatched_types/cast-rfc0401.rs
+++ b/src/test/ui/mismatched_types/cast-rfc0401.rs
@@ -60,7 +60,7 @@ fn main()
 
     let _ = 42usize as *const [u8]; //~ ERROR is invalid
     let _ = v as *const [u8]; //~ ERROR cannot cast
-    let _ = fat_v as *const Foo; //~ ERROR is not satisfied
+    let _ = fat_v as *const Foo; //~ ERROR `[u8]` does not have a constant size known at compile-time
     let _ = foo as *const str; //~ ERROR is invalid
     let _ = foo as *mut str; //~ ERROR is invalid
     let _ = main as *mut str; //~ ERROR is invalid
@@ -69,7 +69,7 @@ fn main()
     let _ = fat_sv as usize; //~ ERROR is invalid
 
     let a : *const str = "hello";
-    let _ = a as *const Foo; //~ ERROR is not satisfied
+    let _ = a as *const Foo; //~ ERROR `str` does not have a constant size known at compile-time
 
     // check no error cascade
     let _ = main.f as *const u32; //~ ERROR no field

--- a/src/test/ui/mismatched_types/cast-rfc0401.stderr
+++ b/src/test/ui/mismatched_types/cast-rfc0401.stderr
@@ -216,21 +216,21 @@ LL |     let _ = cf as *const Bar; //~ ERROR is invalid
    |
    = note: vtable kinds may not match
 
-error[E0277]: `[u8]` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `[u8]` cannot be known at compilation time
   --> $DIR/cast-rfc0401.rs:63:13
    |
-LL |     let _ = fat_v as *const Foo; //~ ERROR `[u8]` does not have a constant size known at
-   |             ^^^^^ `[u8]` does not have a constant size known at compile-time
+LL |     let _ = fat_v as *const Foo; //~ ERROR the size for value values of type
+   |             ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[u8]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: required for the cast to the object type `Foo`
 
-error[E0277]: `str` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `str` cannot be known at compilation time
   --> $DIR/cast-rfc0401.rs:72:13
    |
-LL |     let _ = a as *const Foo; //~ ERROR `str` does not have a constant size known at compile-time
-   |             ^ `str` does not have a constant size known at compile-time
+LL |     let _ = a as *const Foo; //~ ERROR the size for value values of type
+   |             ^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>

--- a/src/test/ui/mismatched_types/cast-rfc0401.stderr
+++ b/src/test/ui/mismatched_types/cast-rfc0401.stderr
@@ -219,7 +219,7 @@ LL |     let _ = cf as *const Bar; //~ ERROR is invalid
 error[E0277]: `[u8]` does not have a constant size known at compile-time
   --> $DIR/cast-rfc0401.rs:63:13
    |
-LL |     let _ = fat_v as *const Foo; //~ ERROR `[u8]` does not have a constant size known at compile-time
+LL |     let _ = fat_v as *const Foo; //~ ERROR `[u8]` does not have a constant size known at
    |             ^^^^^ `[u8]` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[u8]`

--- a/src/test/ui/mismatched_types/cast-rfc0401.stderr
+++ b/src/test/ui/mismatched_types/cast-rfc0401.stderr
@@ -216,19 +216,19 @@ LL |     let _ = cf as *const Bar; //~ ERROR is invalid
    |
    = note: vtable kinds may not match
 
-error[E0277]: the trait bound `[u8]: std::marker::Sized` is not satisfied
+error[E0277]: `[u8]` does not have a constant size known at compile-time
   --> $DIR/cast-rfc0401.rs:63:13
    |
-LL |     let _ = fat_v as *const Foo; //~ ERROR is not satisfied
+LL |     let _ = fat_v as *const Foo; //~ ERROR `[u8]` does not have a constant size known at compile-time
    |             ^^^^^ `[u8]` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[u8]`
    = note: required for the cast to the object type `Foo`
 
-error[E0277]: the trait bound `str: std::marker::Sized` is not satisfied
+error[E0277]: `str` does not have a constant size known at compile-time
   --> $DIR/cast-rfc0401.rs:72:13
    |
-LL |     let _ = a as *const Foo; //~ ERROR is not satisfied
+LL |     let _ = a as *const Foo; //~ ERROR `str` does not have a constant size known at compile-time
    |             ^ `str` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`

--- a/src/test/ui/mismatched_types/cast-rfc0401.stderr
+++ b/src/test/ui/mismatched_types/cast-rfc0401.stderr
@@ -223,6 +223,7 @@ LL |     let _ = fat_v as *const Foo; //~ ERROR `[u8]` does not have a constant 
    |             ^^^^^ `[u8]` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[u8]`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: required for the cast to the object type `Foo`
 
 error[E0277]: `str` does not have a constant size known at compile-time
@@ -232,6 +233,7 @@ LL |     let _ = a as *const Foo; //~ ERROR `str` does not have a constant size 
    |             ^ `str` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: required for the cast to the object type `Foo`
 
 error[E0606]: casting `&{float}` as `f32` is invalid

--- a/src/test/ui/parser/expected-comma-found-token.rs
+++ b/src/test/ui/parser/expected-comma-found-token.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests that two closures cannot simultaneously have mutable
+// access to the variable, whether that mutable access be used
+// for direct assignment or for taking mutable ref. Issue #6801.
+
+#![feature(on_unimplemented)]
+
+#[rustc_on_unimplemented(
+    message="the message"
+    label="the label"
+)]
+trait T {}
+//~^^^ ERROR expected one of `)` or `,`, found `label`

--- a/src/test/ui/parser/expected-comma-found-token.stderr
+++ b/src/test/ui/parser/expected-comma-found-token.stderr
@@ -1,0 +1,10 @@
+error: expected one of `)` or `,`, found `label`
+  --> $DIR/expected-comma-found-token.rs:19:5
+   |
+LL |     message="the message"
+   |                          - expected one of `)` or `,` here
+LL |     label="the label"
+   |     ^^^^^ unexpected token
+
+error: aborting due to previous error
+

--- a/src/test/ui/partialeq_help.stderr
+++ b/src/test/ui/partialeq_help.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `&T: std::cmp::PartialEq<T>` is not satisfied
+error[E0277]: can't compare `&T` with `T`
   --> $DIR/partialeq_help.rs:12:7
    |
 LL |     a == b; //~ ERROR E0277
-   |       ^^ can't compare `&T` with `T`
+   |       ^^ no implementation for `&T == T`
    |
    = help: the trait `std::cmp::PartialEq<T>` is not implemented for `&T`
    = help: consider adding a `where &T: std::cmp::PartialEq<T>` bound

--- a/src/test/ui/pub/pub-restricted.stderr
+++ b/src/test/ui/pub/pub-restricted.stderr
@@ -1,4 +1,4 @@
-error: incorrect visibility restriction
+error[E0698]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:15:6
    |
 LL | pub (a) fn afn() {} //~ incorrect visibility restriction
@@ -9,7 +9,7 @@ LL | pub (a) fn afn() {} //~ incorrect visibility restriction
            `pub(super)`: visible only in the current module's parent
            `pub(in path::to::module)`: visible only on the specified path
 
-error: incorrect visibility restriction
+error[E0698]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:16:6
    |
 LL | pub (b) fn bfn() {} //~ incorrect visibility restriction
@@ -20,7 +20,7 @@ LL | pub (b) fn bfn() {} //~ incorrect visibility restriction
            `pub(super)`: visible only in the current module's parent
            `pub(in path::to::module)`: visible only on the specified path
 
-error: incorrect visibility restriction
+error[E0698]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:32:14
    |
 LL |         pub (a) invalid: usize, //~ incorrect visibility restriction
@@ -31,7 +31,7 @@ LL |         pub (a) invalid: usize, //~ incorrect visibility restriction
            `pub(super)`: visible only in the current module's parent
            `pub(in path::to::module)`: visible only on the specified path
 
-error: incorrect visibility restriction
+error[E0698]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:41:6
    |
 LL | pub (xyz) fn xyz() {} //~ incorrect visibility restriction
@@ -50,3 +50,4 @@ LL |         pub (in x) non_parent_invalid: usize, //~ ERROR visibilities can on
 
 error: aborting due to 5 previous errors
 
+For more information about this error, try `rustc --explain E0698`.

--- a/src/test/ui/pub/pub-restricted.stderr
+++ b/src/test/ui/pub/pub-restricted.stderr
@@ -1,4 +1,4 @@
-error[E0698]: incorrect visibility restriction
+error[E0704]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:15:6
    |
 LL | pub (a) fn afn() {} //~ incorrect visibility restriction
@@ -9,7 +9,7 @@ LL | pub (a) fn afn() {} //~ incorrect visibility restriction
            `pub(super)`: visible only in the current module's parent
            `pub(in path::to::module)`: visible only on the specified path
 
-error[E0698]: incorrect visibility restriction
+error[E0704]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:16:6
    |
 LL | pub (b) fn bfn() {} //~ incorrect visibility restriction
@@ -20,7 +20,7 @@ LL | pub (b) fn bfn() {} //~ incorrect visibility restriction
            `pub(super)`: visible only in the current module's parent
            `pub(in path::to::module)`: visible only on the specified path
 
-error[E0698]: incorrect visibility restriction
+error[E0704]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:32:14
    |
 LL |         pub (a) invalid: usize, //~ incorrect visibility restriction
@@ -31,7 +31,7 @@ LL |         pub (a) invalid: usize, //~ incorrect visibility restriction
            `pub(super)`: visible only in the current module's parent
            `pub(in path::to::module)`: visible only on the specified path
 
-error[E0698]: incorrect visibility restriction
+error[E0704]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:41:6
    |
 LL | pub (xyz) fn xyz() {} //~ incorrect visibility restriction
@@ -50,4 +50,4 @@ LL |         pub (in x) non_parent_invalid: usize, //~ ERROR visibilities can on
 
 error: aborting due to 5 previous errors
 
-For more information about this error, try `rustc --explain E0698`.
+For more information about this error, try `rustc --explain E0704`.

--- a/src/test/ui/resolve/issue-5035-2.rs
+++ b/src/test/ui/resolve/issue-5035-2.rs
@@ -11,6 +11,7 @@
 trait I {}
 type K = I+'static;
 
-fn foo(_x: K) {} //~ ERROR: `I + 'static: std::marker::Sized` is not satisfied
+fn foo(_x: K) {}
+//~^ ERROR `I + 'static` does not have a constant size known at compile-time
 
 fn main() {}

--- a/src/test/ui/resolve/issue-5035-2.rs
+++ b/src/test/ui/resolve/issue-5035-2.rs
@@ -12,6 +12,6 @@ trait I {}
 type K = I+'static;
 
 fn foo(_x: K) {}
-//~^ ERROR `I + 'static` does not have a constant size known at compile-time
+//~^ ERROR the size for value values of type
 
 fn main() {}

--- a/src/test/ui/resolve/issue-5035-2.stderr
+++ b/src/test/ui/resolve/issue-5035-2.stderr
@@ -1,8 +1,8 @@
-error[E0277]: `I + 'static` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `I + 'static` cannot be known at compilation time
   --> $DIR/issue-5035-2.rs:14:8
    |
 LL | fn foo(_x: K) {}
-   |        ^^ `I + 'static` does not have a constant size known at compile-time
+   |        ^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `I + 'static`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>

--- a/src/test/ui/resolve/issue-5035-2.stderr
+++ b/src/test/ui/resolve/issue-5035-2.stderr
@@ -5,6 +5,7 @@ LL | fn foo(_x: K) {}
    |        ^^ `I + 'static` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `I + 'static`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: all local variables must have a statically known size
 
 error: aborting due to previous error

--- a/src/test/ui/resolve/issue-5035-2.stderr
+++ b/src/test/ui/resolve/issue-5035-2.stderr
@@ -1,7 +1,7 @@
-error[E0277]: the trait bound `I + 'static: std::marker::Sized` is not satisfied
+error[E0277]: `I + 'static` does not have a constant size known at compile-time
   --> $DIR/issue-5035-2.rs:14:8
    |
-LL | fn foo(_x: K) {} //~ ERROR: `I + 'static: std::marker::Sized` is not satisfied
+LL | fn foo(_x: K) {}
    |        ^^ `I + 'static` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `I + 'static`

--- a/src/test/ui/suggestions/str-array-assignment.rs
+++ b/src/test/ui/suggestions/str-array-assignment.rs
@@ -15,7 +15,7 @@ fn main() {
   let u: &str = if true { s[..2] } else { s };
   //~^ ERROR mismatched types
   let v = s[..2];
-  //~^ ERROR `str` does not have a constant size known at compile-time
+  //~^ ERROR the size for value values of type
   let w: &str = s[..2];
   //~^ ERROR mismatched types
 }

--- a/src/test/ui/suggestions/str-array-assignment.rs
+++ b/src/test/ui/suggestions/str-array-assignment.rs
@@ -15,7 +15,7 @@ fn main() {
   let u: &str = if true { s[..2] } else { s };
   //~^ ERROR mismatched types
   let v = s[..2];
-  //~^ ERROR the trait bound `str: std::marker::Sized` is not satisfied
+  //~^ ERROR `str` does not have a constant size known at compile-time
   let w: &str = s[..2];
   //~^ ERROR mismatched types
 }

--- a/src/test/ui/suggestions/str-array-assignment.stderr
+++ b/src/test/ui/suggestions/str-array-assignment.stderr
@@ -19,7 +19,7 @@ LL |   let u: &str = if true { s[..2] } else { s };
    = note: expected type `&str`
               found type `str`
 
-error[E0277]: the trait bound `str: std::marker::Sized` is not satisfied
+error[E0277]: `str` does not have a constant size known at compile-time
   --> $DIR/str-array-assignment.rs:17:7
    |
 LL |   let v = s[..2];

--- a/src/test/ui/suggestions/str-array-assignment.stderr
+++ b/src/test/ui/suggestions/str-array-assignment.stderr
@@ -28,6 +28,7 @@ LL |   let v = s[..2];
    |       `str` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: all local variables must have a statically known size
 
 error[E0308]: mismatched types

--- a/src/test/ui/suggestions/str-array-assignment.stderr
+++ b/src/test/ui/suggestions/str-array-assignment.stderr
@@ -19,13 +19,13 @@ LL |   let u: &str = if true { s[..2] } else { s };
    = note: expected type `&str`
               found type `str`
 
-error[E0277]: `str` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `str` cannot be known at compilation time
   --> $DIR/str-array-assignment.rs:17:7
    |
 LL |   let v = s[..2];
    |       ^   ------ help: consider borrowing here: `&s[..2]`
    |       |
-   |       `str` does not have a constant size known at compile-time
+   |       doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>

--- a/src/test/ui/trait-suggest-where-clause.rs
+++ b/src/test/ui/trait-suggest-where-clause.rs
@@ -15,10 +15,10 @@ struct Misc<T:?Sized>(T);
 fn check<T: Iterator, U: ?Sized>() {
     // suggest a where-clause, if needed
     mem::size_of::<U>();
-    //~^ ERROR `U: std::marker::Sized` is not satisfied
+    //~^ ERROR `U` does not have a constant size known at compile-time
 
     mem::size_of::<Misc<U>>();
-    //~^ ERROR `U: std::marker::Sized` is not satisfied
+    //~^ ERROR `U` does not have a constant size known at compile-time
 
     // ... even if T occurs as a type parameter
 
@@ -36,10 +36,10 @@ fn check<T: Iterator, U: ?Sized>() {
     // ... and also not if the error is not related to the type
 
     mem::size_of::<[T]>();
-    //~^ ERROR `[T]: std::marker::Sized` is not satisfied
+    //~^ ERROR `[T]` does not have a constant size known at compile-time
 
     mem::size_of::<[&U]>();
-    //~^ ERROR `[&U]: std::marker::Sized` is not satisfied
+    //~^ ERROR `[&U]` does not have a constant size known at compile-time
 }
 
 fn main() {

--- a/src/test/ui/trait-suggest-where-clause.rs
+++ b/src/test/ui/trait-suggest-where-clause.rs
@@ -15,10 +15,10 @@ struct Misc<T:?Sized>(T);
 fn check<T: Iterator, U: ?Sized>() {
     // suggest a where-clause, if needed
     mem::size_of::<U>();
-    //~^ ERROR `U` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 
     mem::size_of::<Misc<U>>();
-    //~^ ERROR `U` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 
     // ... even if T occurs as a type parameter
 
@@ -36,10 +36,10 @@ fn check<T: Iterator, U: ?Sized>() {
     // ... and also not if the error is not related to the type
 
     mem::size_of::<[T]>();
-    //~^ ERROR `[T]` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 
     mem::size_of::<[&U]>();
-    //~^ ERROR `[&U]` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 
 fn main() {

--- a/src/test/ui/trait-suggest-where-clause.stderr
+++ b/src/test/ui/trait-suggest-where-clause.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `U: std::marker::Sized` is not satisfied
+error[E0277]: `U` does not have a constant size known at compile-time
   --> $DIR/trait-suggest-where-clause.rs:17:5
    |
 LL |     mem::size_of::<U>();
@@ -8,7 +8,7 @@ LL |     mem::size_of::<U>();
    = help: consider adding a `where U: std::marker::Sized` bound
    = note: required by `std::mem::size_of`
 
-error[E0277]: the trait bound `U: std::marker::Sized` is not satisfied in `Misc<U>`
+error[E0277]: `U` does not have a constant size known at compile-time
   --> $DIR/trait-suggest-where-clause.rs:20:5
    |
 LL |     mem::size_of::<Misc<U>>();
@@ -45,7 +45,7 @@ LL |     <Misc<_> as From<T>>::from;
    |
    = note: required by `std::convert::From::from`
 
-error[E0277]: the trait bound `[T]: std::marker::Sized` is not satisfied
+error[E0277]: `[T]` does not have a constant size known at compile-time
   --> $DIR/trait-suggest-where-clause.rs:38:5
    |
 LL |     mem::size_of::<[T]>();
@@ -54,7 +54,7 @@ LL |     mem::size_of::<[T]>();
    = help: the trait `std::marker::Sized` is not implemented for `[T]`
    = note: required by `std::mem::size_of`
 
-error[E0277]: the trait bound `[&U]: std::marker::Sized` is not satisfied
+error[E0277]: `[&U]` does not have a constant size known at compile-time
   --> $DIR/trait-suggest-where-clause.rs:41:5
    |
 LL |     mem::size_of::<[&U]>();

--- a/src/test/ui/trait-suggest-where-clause.stderr
+++ b/src/test/ui/trait-suggest-where-clause.stderr
@@ -5,6 +5,7 @@ LL |     mem::size_of::<U>();
    |     ^^^^^^^^^^^^^^^^^ `U` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `U`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = help: consider adding a `where U: std::marker::Sized` bound
    = note: required by `std::mem::size_of`
 
@@ -15,6 +16,7 @@ LL |     mem::size_of::<Misc<U>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ `U` does not have a constant size known at compile-time
    |
    = help: within `Misc<U>`, the trait `std::marker::Sized` is not implemented for `U`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = help: consider adding a `where U: std::marker::Sized` bound
    = note: required because it appears within the type `Misc<U>`
    = note: required by `std::mem::size_of`
@@ -52,6 +54,7 @@ LL |     mem::size_of::<[T]>();
    |     ^^^^^^^^^^^^^^^^^^^ `[T]` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[T]`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: required by `std::mem::size_of`
 
 error[E0277]: `[&U]` does not have a constant size known at compile-time
@@ -61,6 +64,7 @@ LL |     mem::size_of::<[&U]>();
    |     ^^^^^^^^^^^^^^^^^^^^ `[&U]` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[&U]`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: required by `std::mem::size_of`
 
 error: aborting due to 7 previous errors

--- a/src/test/ui/trait-suggest-where-clause.stderr
+++ b/src/test/ui/trait-suggest-where-clause.stderr
@@ -1,19 +1,19 @@
-error[E0277]: `U` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `U` cannot be known at compilation time
   --> $DIR/trait-suggest-where-clause.rs:17:5
    |
 LL |     mem::size_of::<U>();
-   |     ^^^^^^^^^^^^^^^^^ `U` does not have a constant size known at compile-time
+   |     ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `U`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = help: consider adding a `where U: std::marker::Sized` bound
    = note: required by `std::mem::size_of`
 
-error[E0277]: `U` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `U` cannot be known at compilation time
   --> $DIR/trait-suggest-where-clause.rs:20:5
    |
 LL |     mem::size_of::<Misc<U>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ `U` does not have a constant size known at compile-time
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `Misc<U>`, the trait `std::marker::Sized` is not implemented for `U`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
@@ -47,21 +47,21 @@ LL |     <Misc<_> as From<T>>::from;
    |
    = note: required by `std::convert::From::from`
 
-error[E0277]: `[T]` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `[T]` cannot be known at compilation time
   --> $DIR/trait-suggest-where-clause.rs:38:5
    |
 LL |     mem::size_of::<[T]>();
-   |     ^^^^^^^^^^^^^^^^^^^ `[T]` does not have a constant size known at compile-time
+   |     ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[T]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: required by `std::mem::size_of`
 
-error[E0277]: `[&U]` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `[&U]` cannot be known at compilation time
   --> $DIR/trait-suggest-where-clause.rs:41:5
    |
 LL |     mem::size_of::<[&U]>();
-   |     ^^^^^^^^^^^^^^^^^^^^ `[&U]` does not have a constant size known at compile-time
+   |     ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[&U]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>

--- a/src/test/ui/trivial-bounds-leak.stderr
+++ b/src/test/ui/trivial-bounds-leak.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `str: std::marker::Sized` is not satisfied
+error[E0277]: `str` does not have a constant size known at compile-time
   --> $DIR/trivial-bounds-leak.rs:22:25
    |
 LL | fn cant_return_str() -> str { //~ ERROR

--- a/src/test/ui/trivial-bounds-leak.stderr
+++ b/src/test/ui/trivial-bounds-leak.stderr
@@ -5,6 +5,7 @@ LL | fn cant_return_str() -> str { //~ ERROR
    |                         ^^^ `str` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: the return type of a function must have a statically known size
 
 error[E0599]: no method named `test` found for type `i32` in the current scope

--- a/src/test/ui/trivial-bounds-leak.stderr
+++ b/src/test/ui/trivial-bounds-leak.stderr
@@ -1,8 +1,8 @@
-error[E0277]: `str` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `str` cannot be known at compilation time
   --> $DIR/trivial-bounds-leak.rs:22:25
    |
 LL | fn cant_return_str() -> str { //~ ERROR
-   |                         ^^^ `str` does not have a constant size known at compile-time
+   |                         ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>

--- a/src/test/ui/type-check-defaults.rs
+++ b/src/test/ui/type-check-defaults.rs
@@ -14,24 +14,24 @@ use std::ops::Add;
 
 struct Foo<T, U: FromIterator<T>>(T, U);
 struct WellFormed<Z = Foo<i32, i32>>(Z);
-//~^ error: the trait bound `i32: std::iter::FromIterator<i32>` is not satisfied [E0277]
+//~^ ERROR a collection of type `i32` cannot be built from an iterator over elements of type `i32`
 struct WellFormedNoBounds<Z:?Sized = Foo<i32, i32>>(Z);
-//~^ error: the trait bound `i32: std::iter::FromIterator<i32>` is not satisfied [E0277]
+//~^ ERROR a collection of type `i32` cannot be built from an iterator over elements of type `i32`
 
 struct Bounds<T:Copy=String>(T);
-//~^ error: the trait bound `std::string::String: std::marker::Copy` is not satisfied [E0277]
+//~^ ERROR the trait bound `std::string::String: std::marker::Copy` is not satisfied [E0277]
 
 struct WhereClause<T=String>(T) where T: Copy;
-//~^ error: the trait bound `std::string::String: std::marker::Copy` is not satisfied [E0277]
+//~^ ERROR the trait bound `std::string::String: std::marker::Copy` is not satisfied [E0277]
 
 trait TraitBound<T:Copy=String> {}
-//~^ error: the trait bound `std::string::String: std::marker::Copy` is not satisfied [E0277]
+//~^ ERROR the trait bound `std::string::String: std::marker::Copy` is not satisfied [E0277]
 
 trait Super<T: Copy> { }
 trait Base<T = String>: Super<T> { }
-//~^ error: the trait bound `T: std::marker::Copy` is not satisfied [E0277]
+//~^ ERROR the trait bound `T: std::marker::Copy` is not satisfied [E0277]
 
 trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
-//~^ error:  cannot add `u8` to `i32` [E0277]
+//~^ ERROR cannot add `u8` to `i32` [E0277]
 
 fn main() { }

--- a/src/test/ui/type-check-defaults.stderr
+++ b/src/test/ui/type-check-defaults.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `i32: std::iter::FromIterator<i32>` is not satisfied
+error[E0277]: a collection of type `i32` cannot be built from an iterator over elements of type `i32`
   --> $DIR/type-check-defaults.rs:16:19
    |
 LL | struct WellFormed<Z = Foo<i32, i32>>(Z);
-   |                   ^ a collection of type `i32` cannot be built from an iterator over elements of type `i32`
+   |                   ^ a collection of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
    |
    = help: the trait `std::iter::FromIterator<i32>` is not implemented for `i32`
 note: required by `Foo`
@@ -11,11 +11,11 @@ note: required by `Foo`
 LL | struct Foo<T, U: FromIterator<T>>(T, U);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `i32: std::iter::FromIterator<i32>` is not satisfied
+error[E0277]: a collection of type `i32` cannot be built from an iterator over elements of type `i32`
   --> $DIR/type-check-defaults.rs:18:27
    |
 LL | struct WellFormedNoBounds<Z:?Sized = Foo<i32, i32>>(Z);
-   |                           ^ a collection of type `i32` cannot be built from an iterator over elements of type `i32`
+   |                           ^ a collection of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
    |
    = help: the trait `std::iter::FromIterator<i32>` is not implemented for `i32`
 note: required by `Foo`

--- a/src/test/ui/union/union-sized-field.rs
+++ b/src/test/ui/union/union-sized-field.rs
@@ -11,16 +11,19 @@
 #![feature(untagged_unions)]
 
 union Foo<T: ?Sized> {
-    value: T, //~ ERROR the trait bound `T: std::marker::Sized` is not satisfied
+    value: T,
+    //~^ ERROR `T` does not have a constant size known at compile-time
 }
 
 struct Foo2<T: ?Sized> {
-    value: T, //~ ERROR the trait bound `T: std::marker::Sized` is not satisfied
+    value: T,
+    //~^ ERROR `T` does not have a constant size known at compile-time
     t: u32,
 }
 
 enum Foo3<T: ?Sized> {
-    Value(T), //~ ERROR the trait bound `T: std::marker::Sized` is not satisfied
+    Value(T),
+    //~^ ERROR `T` does not have a constant size known at compile-time
 }
 
 fn main() {}

--- a/src/test/ui/union/union-sized-field.rs
+++ b/src/test/ui/union/union-sized-field.rs
@@ -12,18 +12,18 @@
 
 union Foo<T: ?Sized> {
     value: T,
-    //~^ ERROR `T` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 
 struct Foo2<T: ?Sized> {
     value: T,
-    //~^ ERROR `T` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     t: u32,
 }
 
 enum Foo3<T: ?Sized> {
     Value(T),
-    //~^ ERROR `T` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 
 fn main() {}

--- a/src/test/ui/union/union-sized-field.stderr
+++ b/src/test/ui/union/union-sized-field.stderr
@@ -1,27 +1,27 @@
-error[E0277]: the trait bound `T: std::marker::Sized` is not satisfied
+error[E0277]: `T` does not have a constant size known at compile-time
   --> $DIR/union-sized-field.rs:14:5
    |
-LL |     value: T, //~ ERROR the trait bound `T: std::marker::Sized` is not satisfied
+LL |     value: T,
    |     ^^^^^^^^ `T` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `T`
    = help: consider adding a `where T: std::marker::Sized` bound
    = note: no field of a union may have a dynamically sized type
 
-error[E0277]: the trait bound `T: std::marker::Sized` is not satisfied
-  --> $DIR/union-sized-field.rs:18:5
+error[E0277]: `T` does not have a constant size known at compile-time
+  --> $DIR/union-sized-field.rs:19:5
    |
-LL |     value: T, //~ ERROR the trait bound `T: std::marker::Sized` is not satisfied
+LL |     value: T,
    |     ^^^^^^^^ `T` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `T`
    = help: consider adding a `where T: std::marker::Sized` bound
    = note: only the last field of a struct may have a dynamically sized type
 
-error[E0277]: the trait bound `T: std::marker::Sized` is not satisfied
-  --> $DIR/union-sized-field.rs:23:11
+error[E0277]: `T` does not have a constant size known at compile-time
+  --> $DIR/union-sized-field.rs:25:11
    |
-LL |     Value(T), //~ ERROR the trait bound `T: std::marker::Sized` is not satisfied
+LL |     Value(T),
    |           ^ `T` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `T`

--- a/src/test/ui/union/union-sized-field.stderr
+++ b/src/test/ui/union/union-sized-field.stderr
@@ -5,6 +5,7 @@ LL |     value: T,
    |     ^^^^^^^^ `T` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `T`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = help: consider adding a `where T: std::marker::Sized` bound
    = note: no field of a union may have a dynamically sized type
 
@@ -15,6 +16,7 @@ LL |     value: T,
    |     ^^^^^^^^ `T` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `T`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = help: consider adding a `where T: std::marker::Sized` bound
    = note: only the last field of a struct may have a dynamically sized type
 
@@ -25,6 +27,7 @@ LL |     Value(T),
    |           ^ `T` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `T`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = help: consider adding a `where T: std::marker::Sized` bound
    = note: no field of an enum variant may have a dynamically sized type
 

--- a/src/test/ui/union/union-sized-field.stderr
+++ b/src/test/ui/union/union-sized-field.stderr
@@ -1,30 +1,30 @@
-error[E0277]: `T` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `T` cannot be known at compilation time
   --> $DIR/union-sized-field.rs:14:5
    |
 LL |     value: T,
-   |     ^^^^^^^^ `T` does not have a constant size known at compile-time
+   |     ^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `T`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = help: consider adding a `where T: std::marker::Sized` bound
    = note: no field of a union may have a dynamically sized type
 
-error[E0277]: `T` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `T` cannot be known at compilation time
   --> $DIR/union-sized-field.rs:19:5
    |
 LL |     value: T,
-   |     ^^^^^^^^ `T` does not have a constant size known at compile-time
+   |     ^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `T`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = help: consider adding a `where T: std::marker::Sized` bound
    = note: only the last field of a struct may have a dynamically sized type
 
-error[E0277]: `T` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `T` cannot be known at compilation time
   --> $DIR/union-sized-field.rs:25:11
    |
 LL |     Value(T),
-   |           ^ `T` does not have a constant size known at compile-time
+   |           ^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `T`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>

--- a/src/test/ui/unsized-enum2.rs
+++ b/src/test/ui/unsized-enum2.rs
@@ -30,37 +30,54 @@ struct Path4(PathHelper4);
 
 enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
     // parameter
-    VA(W), //~ ERROR `W: std::marker::Sized` is not satisfied
-    VB{x: X}, //~ ERROR `X: std::marker::Sized` is not satisfied
-    VC(isize, Y), //~ ERROR `Y: std::marker::Sized` is not satisfied
-    VD{u: isize, x: Z}, //~ ERROR `Z: std::marker::Sized` is not satisfied
+    VA(W),
+    //~^ ERROR `W` does not have a constant size known at compile-time
+    VB{x: X},
+    //~^ ERROR `X` does not have a constant size known at compile-time
+    VC(isize, Y),
+    //~^ ERROR `Y` does not have a constant size known at compile-time
+    VD{u: isize, x: Z},
+    //~^ ERROR `Z` does not have a constant size known at compile-time
 
     // slice / str
-    VE([u8]), //~ ERROR `[u8]: std::marker::Sized` is not satisfied
-    VF{x: str}, //~ ERROR `str: std::marker::Sized` is not satisfied
-    VG(isize, [f32]), //~ ERROR `[f32]: std::marker::Sized` is not satisfied
-    VH{u: isize, x: [u32]}, //~ ERROR `[u32]: std::marker::Sized` is not satisfied
+    VE([u8]),
+    //~^ ERROR `[u8]` does not have a constant size known at compile-time
+    VF{x: str},
+    //~^ ERROR `str` does not have a constant size known at compile-time
+    VG(isize, [f32]),
+    //~^ ERROR `[f32]` does not have a constant size known at compile-time
+    VH{u: isize, x: [u32]},
+    //~^ ERROR `[u32]` does not have a constant size known at compile-time
 
     // unsized struct
-    VI(Path1), //~ ERROR `PathHelper1 + 'static: std::marker::Sized` is not satisfied
-    VJ{x: Path2}, //~ ERROR `PathHelper2 + 'static: std::marker::Sized` is not satisfied
-    VK(isize, Path3), //~ ERROR `PathHelper3 + 'static: std::marker::Sized` is not satisfied
-    VL{u: isize, x: Path4}, //~ ERROR `PathHelper4 + 'static: std::marker::Sized` is not satisfied
+    VI(Path1),
+    //~^ ERROR `PathHelper1 + 'static` does not have a constant size known at compile-time
+    VJ{x: Path2},
+    //~^ ERROR `PathHelper2 + 'static` does not have a constant size known at compile-time
+    VK(isize, Path3),
+    //~^ ERROR `PathHelper3 + 'static` does not have a constant size known at compile-time
+    VL{u: isize, x: Path4},
+    //~^ ERROR `PathHelper4 + 'static` does not have a constant size known at compile-time
 
     // plain trait
-    VM(Foo),  //~ ERROR `Foo + 'static: std::marker::Sized` is not satisfied
-    VN{x: Bar}, //~ ERROR `Bar + 'static: std::marker::Sized` is not satisfied
-    VO(isize, FooBar), //~ ERROR `FooBar + 'static: std::marker::Sized` is not satisfied
-    VP{u: isize, x: BarFoo}, //~ ERROR `BarFoo + 'static: std::marker::Sized` is not satisfied
+    VM(Foo),
+    //~^ ERROR `Foo + 'static` does not have a constant size known at compile-time
+    VN{x: Bar},
+    //~^ ERROR `Bar + 'static` does not have a constant size known at compile-time
+    VO(isize, FooBar),
+    //~^ ERROR `FooBar + 'static` does not have a constant size known at compile-time
+    VP{u: isize, x: BarFoo},
+    //~^ ERROR `BarFoo + 'static` does not have a constant size known at compile-time
 
     // projected
-    VQ(<&'static [i8] as Deref>::Target), //~ ERROR `[i8]: std::marker::Sized` is not satisfied
+    VQ(<&'static [i8] as Deref>::Target),
+    //~^ ERROR `[i8]` does not have a constant size known at compile-time
     VR{x: <&'static [char] as Deref>::Target},
-    //~^ ERROR `[char]: std::marker::Sized` is not satisfied
+    //~^ ERROR `[char]` does not have a constant size known at compile-time
     VS(isize, <&'static [f64] as Deref>::Target),
-    //~^ ERROR `[f64]: std::marker::Sized` is not satisfied
+    //~^ ERROR `[f64]` does not have a constant size known at compile-time
     VT{u: isize, x: <&'static [i32] as Deref>::Target},
-    //~^ ERROR `[i32]: std::marker::Sized` is not satisfied
+    //~^ ERROR `[i32]` does not have a constant size known at compile-time
 }
 
 

--- a/src/test/ui/unsized-enum2.rs
+++ b/src/test/ui/unsized-enum2.rs
@@ -31,53 +31,53 @@ struct Path4(PathHelper4);
 enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
     // parameter
     VA(W),
-    //~^ ERROR `W` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     VB{x: X},
-    //~^ ERROR `X` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     VC(isize, Y),
-    //~^ ERROR `Y` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     VD{u: isize, x: Z},
-    //~^ ERROR `Z` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 
     // slice / str
     VE([u8]),
-    //~^ ERROR `[u8]` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     VF{x: str},
-    //~^ ERROR `str` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     VG(isize, [f32]),
-    //~^ ERROR `[f32]` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     VH{u: isize, x: [u32]},
-    //~^ ERROR `[u32]` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 
     // unsized struct
     VI(Path1),
-    //~^ ERROR `PathHelper1 + 'static` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     VJ{x: Path2},
-    //~^ ERROR `PathHelper2 + 'static` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     VK(isize, Path3),
-    //~^ ERROR `PathHelper3 + 'static` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     VL{u: isize, x: Path4},
-    //~^ ERROR `PathHelper4 + 'static` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 
     // plain trait
     VM(Foo),
-    //~^ ERROR `Foo + 'static` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     VN{x: Bar},
-    //~^ ERROR `Bar + 'static` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     VO(isize, FooBar),
-    //~^ ERROR `FooBar + 'static` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     VP{u: isize, x: BarFoo},
-    //~^ ERROR `BarFoo + 'static` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 
     // projected
     VQ(<&'static [i8] as Deref>::Target),
-    //~^ ERROR `[i8]` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     VR{x: <&'static [char] as Deref>::Target},
-    //~^ ERROR `[char]` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     VS(isize, <&'static [f64] as Deref>::Target),
-    //~^ ERROR `[f64]` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
     VT{u: isize, x: <&'static [i32] as Deref>::Target},
-    //~^ ERROR `[i32]` does not have a constant size known at compile-time
+    //~^ ERROR the size for value values of type
 }
 
 

--- a/src/test/ui/unsized-enum2.stderr
+++ b/src/test/ui/unsized-enum2.stderr
@@ -1,205 +1,205 @@
-error[E0277]: `W` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `W` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:33:8
    |
 LL |     VA(W),
-   |        ^ `W` does not have a constant size known at compile-time
+   |        ^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `W`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = help: consider adding a `where W: std::marker::Sized` bound
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: `X` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `X` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:35:8
    |
 LL |     VB{x: X},
-   |        ^^^^ `X` does not have a constant size known at compile-time
+   |        ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = help: consider adding a `where X: std::marker::Sized` bound
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: `Y` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `Y` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:37:15
    |
 LL |     VC(isize, Y),
-   |               ^ `Y` does not have a constant size known at compile-time
+   |               ^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `Y`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = help: consider adding a `where Y: std::marker::Sized` bound
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: `Z` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `Z` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:39:18
    |
 LL |     VD{u: isize, x: Z},
-   |                  ^^^^ `Z` does not have a constant size known at compile-time
+   |                  ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `Z`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = help: consider adding a `where Z: std::marker::Sized` bound
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: `[u8]` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `[u8]` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:43:8
    |
 LL |     VE([u8]),
-   |        ^^^^ `[u8]` does not have a constant size known at compile-time
+   |        ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[u8]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: `str` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `str` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:45:8
    |
 LL |     VF{x: str},
-   |        ^^^^^^ `str` does not have a constant size known at compile-time
+   |        ^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: `[f32]` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `[f32]` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:47:15
    |
 LL |     VG(isize, [f32]),
-   |               ^^^^^ `[f32]` does not have a constant size known at compile-time
+   |               ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[f32]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: `[u32]` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `[u32]` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:49:18
    |
 LL |     VH{u: isize, x: [u32]},
-   |                  ^^^^^^^^ `[u32]` does not have a constant size known at compile-time
+   |                  ^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[u32]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: `Foo + 'static` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `Foo + 'static` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:63:8
    |
 LL |     VM(Foo),
-   |        ^^^ `Foo + 'static` does not have a constant size known at compile-time
+   |        ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `Foo + 'static`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: `Bar + 'static` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `Bar + 'static` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:65:8
    |
 LL |     VN{x: Bar},
-   |        ^^^^^^ `Bar + 'static` does not have a constant size known at compile-time
+   |        ^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `Bar + 'static`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: `FooBar + 'static` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `FooBar + 'static` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:67:15
    |
 LL |     VO(isize, FooBar),
-   |               ^^^^^^ `FooBar + 'static` does not have a constant size known at compile-time
+   |               ^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `FooBar + 'static`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: `BarFoo + 'static` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `BarFoo + 'static` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:69:18
    |
 LL |     VP{u: isize, x: BarFoo},
-   |                  ^^^^^^^^^ `BarFoo + 'static` does not have a constant size known at compile-time
+   |                  ^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `BarFoo + 'static`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: `[i8]` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `[i8]` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:73:8
    |
 LL |     VQ(<&'static [i8] as Deref>::Target),
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `[i8]` does not have a constant size known at compile-time
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[i8]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: `[char]` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `[char]` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:75:8
    |
 LL |     VR{x: <&'static [char] as Deref>::Target},
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `[char]` does not have a constant size known at compile-time
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[char]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: `[f64]` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `[f64]` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:77:15
    |
 LL |     VS(isize, <&'static [f64] as Deref>::Target),
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `[f64]` does not have a constant size known at compile-time
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[f64]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: `[i32]` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `[i32]` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:79:18
    |
 LL |     VT{u: isize, x: <&'static [i32] as Deref>::Target},
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `[i32]` does not have a constant size known at compile-time
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[i32]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: `PathHelper1 + 'static` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `PathHelper1 + 'static` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:53:8
    |
 LL |     VI(Path1),
-   |        ^^^^^ `PathHelper1 + 'static` does not have a constant size known at compile-time
+   |        ^^^^^ doesn't have a size known at compile-time
    |
    = help: within `Path1`, the trait `std::marker::Sized` is not implemented for `PathHelper1 + 'static`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: required because it appears within the type `Path1`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: `PathHelper2 + 'static` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `PathHelper2 + 'static` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:55:8
    |
 LL |     VJ{x: Path2},
-   |        ^^^^^^^^ `PathHelper2 + 'static` does not have a constant size known at compile-time
+   |        ^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `Path2`, the trait `std::marker::Sized` is not implemented for `PathHelper2 + 'static`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: required because it appears within the type `Path2`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: `PathHelper3 + 'static` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `PathHelper3 + 'static` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:57:15
    |
 LL |     VK(isize, Path3),
-   |               ^^^^^ `PathHelper3 + 'static` does not have a constant size known at compile-time
+   |               ^^^^^ doesn't have a size known at compile-time
    |
    = help: within `Path3`, the trait `std::marker::Sized` is not implemented for `PathHelper3 + 'static`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: required because it appears within the type `Path3`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: `PathHelper4 + 'static` does not have a constant size known at compile-time
+error[E0277]: the size for value values of type `PathHelper4 + 'static` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:59:18
    |
 LL |     VL{u: isize, x: Path4},
-   |                  ^^^^^^^^ `PathHelper4 + 'static` does not have a constant size known at compile-time
+   |                  ^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `Path4`, the trait `std::marker::Sized` is not implemented for `PathHelper4 + 'static`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>

--- a/src/test/ui/unsized-enum2.stderr
+++ b/src/test/ui/unsized-enum2.stderr
@@ -5,6 +5,7 @@ LL |     VA(W),
    |        ^ `W` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `W`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = help: consider adding a `where W: std::marker::Sized` bound
    = note: no field of an enum variant may have a dynamically sized type
 
@@ -15,6 +16,7 @@ LL |     VB{x: X},
    |        ^^^^ `X` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = help: consider adding a `where X: std::marker::Sized` bound
    = note: no field of an enum variant may have a dynamically sized type
 
@@ -25,6 +27,7 @@ LL |     VC(isize, Y),
    |               ^ `Y` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `Y`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = help: consider adding a `where Y: std::marker::Sized` bound
    = note: no field of an enum variant may have a dynamically sized type
 
@@ -35,6 +38,7 @@ LL |     VD{u: isize, x: Z},
    |                  ^^^^ `Z` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `Z`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = help: consider adding a `where Z: std::marker::Sized` bound
    = note: no field of an enum variant may have a dynamically sized type
 
@@ -45,6 +49,7 @@ LL |     VE([u8]),
    |        ^^^^ `[u8]` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[u8]`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
 error[E0277]: `str` does not have a constant size known at compile-time
@@ -54,6 +59,7 @@ LL |     VF{x: str},
    |        ^^^^^^ `str` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
 error[E0277]: `[f32]` does not have a constant size known at compile-time
@@ -63,6 +69,7 @@ LL |     VG(isize, [f32]),
    |               ^^^^^ `[f32]` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[f32]`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
 error[E0277]: `[u32]` does not have a constant size known at compile-time
@@ -72,6 +79,7 @@ LL |     VH{u: isize, x: [u32]},
    |                  ^^^^^^^^ `[u32]` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[u32]`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
 error[E0277]: `Foo + 'static` does not have a constant size known at compile-time
@@ -81,6 +89,7 @@ LL |     VM(Foo),
    |        ^^^ `Foo + 'static` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `Foo + 'static`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
 error[E0277]: `Bar + 'static` does not have a constant size known at compile-time
@@ -90,6 +99,7 @@ LL |     VN{x: Bar},
    |        ^^^^^^ `Bar + 'static` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `Bar + 'static`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
 error[E0277]: `FooBar + 'static` does not have a constant size known at compile-time
@@ -99,6 +109,7 @@ LL |     VO(isize, FooBar),
    |               ^^^^^^ `FooBar + 'static` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `FooBar + 'static`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
 error[E0277]: `BarFoo + 'static` does not have a constant size known at compile-time
@@ -108,6 +119,7 @@ LL |     VP{u: isize, x: BarFoo},
    |                  ^^^^^^^^^ `BarFoo + 'static` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `BarFoo + 'static`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
 error[E0277]: `[i8]` does not have a constant size known at compile-time
@@ -117,6 +129,7 @@ LL |     VQ(<&'static [i8] as Deref>::Target),
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `[i8]` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[i8]`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
 error[E0277]: `[char]` does not have a constant size known at compile-time
@@ -126,6 +139,7 @@ LL |     VR{x: <&'static [char] as Deref>::Target},
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `[char]` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[char]`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
 error[E0277]: `[f64]` does not have a constant size known at compile-time
@@ -135,6 +149,7 @@ LL |     VS(isize, <&'static [f64] as Deref>::Target),
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `[f64]` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[f64]`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
 error[E0277]: `[i32]` does not have a constant size known at compile-time
@@ -144,6 +159,7 @@ LL |     VT{u: isize, x: <&'static [i32] as Deref>::Target},
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `[i32]` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[i32]`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
 error[E0277]: `PathHelper1 + 'static` does not have a constant size known at compile-time
@@ -153,6 +169,7 @@ LL |     VI(Path1),
    |        ^^^^^ `PathHelper1 + 'static` does not have a constant size known at compile-time
    |
    = help: within `Path1`, the trait `std::marker::Sized` is not implemented for `PathHelper1 + 'static`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: required because it appears within the type `Path1`
    = note: no field of an enum variant may have a dynamically sized type
 
@@ -163,6 +180,7 @@ LL |     VJ{x: Path2},
    |        ^^^^^^^^ `PathHelper2 + 'static` does not have a constant size known at compile-time
    |
    = help: within `Path2`, the trait `std::marker::Sized` is not implemented for `PathHelper2 + 'static`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: required because it appears within the type `Path2`
    = note: no field of an enum variant may have a dynamically sized type
 
@@ -173,6 +191,7 @@ LL |     VK(isize, Path3),
    |               ^^^^^ `PathHelper3 + 'static` does not have a constant size known at compile-time
    |
    = help: within `Path3`, the trait `std::marker::Sized` is not implemented for `PathHelper3 + 'static`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: required because it appears within the type `Path3`
    = note: no field of an enum variant may have a dynamically sized type
 
@@ -183,6 +202,7 @@ LL |     VL{u: isize, x: Path4},
    |                  ^^^^^^^^ `PathHelper4 + 'static` does not have a constant size known at compile-time
    |
    = help: within `Path4`, the trait `std::marker::Sized` is not implemented for `PathHelper4 + 'static`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: required because it appears within the type `Path4`
    = note: no field of an enum variant may have a dynamically sized type
 

--- a/src/test/ui/unsized-enum2.stderr
+++ b/src/test/ui/unsized-enum2.stderr
@@ -1,126 +1,126 @@
-error[E0277]: the trait bound `W: std::marker::Sized` is not satisfied
+error[E0277]: `W` does not have a constant size known at compile-time
   --> $DIR/unsized-enum2.rs:33:8
    |
-LL |     VA(W), //~ ERROR `W: std::marker::Sized` is not satisfied
+LL |     VA(W),
    |        ^ `W` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `W`
    = help: consider adding a `where W: std::marker::Sized` bound
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the trait bound `X: std::marker::Sized` is not satisfied
-  --> $DIR/unsized-enum2.rs:34:8
+error[E0277]: `X` does not have a constant size known at compile-time
+  --> $DIR/unsized-enum2.rs:35:8
    |
-LL |     VB{x: X}, //~ ERROR `X: std::marker::Sized` is not satisfied
+LL |     VB{x: X},
    |        ^^^^ `X` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = help: consider adding a `where X: std::marker::Sized` bound
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the trait bound `Y: std::marker::Sized` is not satisfied
-  --> $DIR/unsized-enum2.rs:35:15
+error[E0277]: `Y` does not have a constant size known at compile-time
+  --> $DIR/unsized-enum2.rs:37:15
    |
-LL |     VC(isize, Y), //~ ERROR `Y: std::marker::Sized` is not satisfied
+LL |     VC(isize, Y),
    |               ^ `Y` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `Y`
    = help: consider adding a `where Y: std::marker::Sized` bound
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the trait bound `Z: std::marker::Sized` is not satisfied
-  --> $DIR/unsized-enum2.rs:36:18
+error[E0277]: `Z` does not have a constant size known at compile-time
+  --> $DIR/unsized-enum2.rs:39:18
    |
-LL |     VD{u: isize, x: Z}, //~ ERROR `Z: std::marker::Sized` is not satisfied
+LL |     VD{u: isize, x: Z},
    |                  ^^^^ `Z` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `Z`
    = help: consider adding a `where Z: std::marker::Sized` bound
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the trait bound `[u8]: std::marker::Sized` is not satisfied
-  --> $DIR/unsized-enum2.rs:39:8
+error[E0277]: `[u8]` does not have a constant size known at compile-time
+  --> $DIR/unsized-enum2.rs:43:8
    |
-LL |     VE([u8]), //~ ERROR `[u8]: std::marker::Sized` is not satisfied
+LL |     VE([u8]),
    |        ^^^^ `[u8]` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[u8]`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the trait bound `str: std::marker::Sized` is not satisfied
-  --> $DIR/unsized-enum2.rs:40:8
+error[E0277]: `str` does not have a constant size known at compile-time
+  --> $DIR/unsized-enum2.rs:45:8
    |
-LL |     VF{x: str}, //~ ERROR `str: std::marker::Sized` is not satisfied
+LL |     VF{x: str},
    |        ^^^^^^ `str` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the trait bound `[f32]: std::marker::Sized` is not satisfied
-  --> $DIR/unsized-enum2.rs:41:15
+error[E0277]: `[f32]` does not have a constant size known at compile-time
+  --> $DIR/unsized-enum2.rs:47:15
    |
-LL |     VG(isize, [f32]), //~ ERROR `[f32]: std::marker::Sized` is not satisfied
+LL |     VG(isize, [f32]),
    |               ^^^^^ `[f32]` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[f32]`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the trait bound `[u32]: std::marker::Sized` is not satisfied
-  --> $DIR/unsized-enum2.rs:42:18
+error[E0277]: `[u32]` does not have a constant size known at compile-time
+  --> $DIR/unsized-enum2.rs:49:18
    |
-LL |     VH{u: isize, x: [u32]}, //~ ERROR `[u32]: std::marker::Sized` is not satisfied
+LL |     VH{u: isize, x: [u32]},
    |                  ^^^^^^^^ `[u32]` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[u32]`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the trait bound `Foo + 'static: std::marker::Sized` is not satisfied
-  --> $DIR/unsized-enum2.rs:51:8
+error[E0277]: `Foo + 'static` does not have a constant size known at compile-time
+  --> $DIR/unsized-enum2.rs:63:8
    |
-LL |     VM(Foo),  //~ ERROR `Foo + 'static: std::marker::Sized` is not satisfied
+LL |     VM(Foo),
    |        ^^^ `Foo + 'static` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `Foo + 'static`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the trait bound `Bar + 'static: std::marker::Sized` is not satisfied
-  --> $DIR/unsized-enum2.rs:52:8
+error[E0277]: `Bar + 'static` does not have a constant size known at compile-time
+  --> $DIR/unsized-enum2.rs:65:8
    |
-LL |     VN{x: Bar}, //~ ERROR `Bar + 'static: std::marker::Sized` is not satisfied
+LL |     VN{x: Bar},
    |        ^^^^^^ `Bar + 'static` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `Bar + 'static`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the trait bound `FooBar + 'static: std::marker::Sized` is not satisfied
-  --> $DIR/unsized-enum2.rs:53:15
+error[E0277]: `FooBar + 'static` does not have a constant size known at compile-time
+  --> $DIR/unsized-enum2.rs:67:15
    |
-LL |     VO(isize, FooBar), //~ ERROR `FooBar + 'static: std::marker::Sized` is not satisfied
+LL |     VO(isize, FooBar),
    |               ^^^^^^ `FooBar + 'static` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `FooBar + 'static`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the trait bound `BarFoo + 'static: std::marker::Sized` is not satisfied
-  --> $DIR/unsized-enum2.rs:54:18
+error[E0277]: `BarFoo + 'static` does not have a constant size known at compile-time
+  --> $DIR/unsized-enum2.rs:69:18
    |
-LL |     VP{u: isize, x: BarFoo}, //~ ERROR `BarFoo + 'static: std::marker::Sized` is not satisfied
+LL |     VP{u: isize, x: BarFoo},
    |                  ^^^^^^^^^ `BarFoo + 'static` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `BarFoo + 'static`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the trait bound `[i8]: std::marker::Sized` is not satisfied
-  --> $DIR/unsized-enum2.rs:57:8
+error[E0277]: `[i8]` does not have a constant size known at compile-time
+  --> $DIR/unsized-enum2.rs:73:8
    |
-LL |     VQ(<&'static [i8] as Deref>::Target), //~ ERROR `[i8]: std::marker::Sized` is not satisfied
+LL |     VQ(<&'static [i8] as Deref>::Target),
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `[i8]` does not have a constant size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[i8]`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the trait bound `[char]: std::marker::Sized` is not satisfied
-  --> $DIR/unsized-enum2.rs:58:8
+error[E0277]: `[char]` does not have a constant size known at compile-time
+  --> $DIR/unsized-enum2.rs:75:8
    |
 LL |     VR{x: <&'static [char] as Deref>::Target},
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `[char]` does not have a constant size known at compile-time
@@ -128,8 +128,8 @@ LL |     VR{x: <&'static [char] as Deref>::Target},
    = help: the trait `std::marker::Sized` is not implemented for `[char]`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the trait bound `[f64]: std::marker::Sized` is not satisfied
-  --> $DIR/unsized-enum2.rs:60:15
+error[E0277]: `[f64]` does not have a constant size known at compile-time
+  --> $DIR/unsized-enum2.rs:77:15
    |
 LL |     VS(isize, <&'static [f64] as Deref>::Target),
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `[f64]` does not have a constant size known at compile-time
@@ -137,8 +137,8 @@ LL |     VS(isize, <&'static [f64] as Deref>::Target),
    = help: the trait `std::marker::Sized` is not implemented for `[f64]`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the trait bound `[i32]: std::marker::Sized` is not satisfied
-  --> $DIR/unsized-enum2.rs:62:18
+error[E0277]: `[i32]` does not have a constant size known at compile-time
+  --> $DIR/unsized-enum2.rs:79:18
    |
 LL |     VT{u: isize, x: <&'static [i32] as Deref>::Target},
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `[i32]` does not have a constant size known at compile-time
@@ -146,40 +146,40 @@ LL |     VT{u: isize, x: <&'static [i32] as Deref>::Target},
    = help: the trait `std::marker::Sized` is not implemented for `[i32]`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the trait bound `PathHelper1 + 'static: std::marker::Sized` is not satisfied in `Path1`
-  --> $DIR/unsized-enum2.rs:45:8
+error[E0277]: `PathHelper1 + 'static` does not have a constant size known at compile-time
+  --> $DIR/unsized-enum2.rs:53:8
    |
-LL |     VI(Path1), //~ ERROR `PathHelper1 + 'static: std::marker::Sized` is not satisfied
+LL |     VI(Path1),
    |        ^^^^^ `PathHelper1 + 'static` does not have a constant size known at compile-time
    |
    = help: within `Path1`, the trait `std::marker::Sized` is not implemented for `PathHelper1 + 'static`
    = note: required because it appears within the type `Path1`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the trait bound `PathHelper2 + 'static: std::marker::Sized` is not satisfied in `Path2`
-  --> $DIR/unsized-enum2.rs:46:8
+error[E0277]: `PathHelper2 + 'static` does not have a constant size known at compile-time
+  --> $DIR/unsized-enum2.rs:55:8
    |
-LL |     VJ{x: Path2}, //~ ERROR `PathHelper2 + 'static: std::marker::Sized` is not satisfied
+LL |     VJ{x: Path2},
    |        ^^^^^^^^ `PathHelper2 + 'static` does not have a constant size known at compile-time
    |
    = help: within `Path2`, the trait `std::marker::Sized` is not implemented for `PathHelper2 + 'static`
    = note: required because it appears within the type `Path2`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the trait bound `PathHelper3 + 'static: std::marker::Sized` is not satisfied in `Path3`
-  --> $DIR/unsized-enum2.rs:47:15
+error[E0277]: `PathHelper3 + 'static` does not have a constant size known at compile-time
+  --> $DIR/unsized-enum2.rs:57:15
    |
-LL |     VK(isize, Path3), //~ ERROR `PathHelper3 + 'static: std::marker::Sized` is not satisfied
+LL |     VK(isize, Path3),
    |               ^^^^^ `PathHelper3 + 'static` does not have a constant size known at compile-time
    |
    = help: within `Path3`, the trait `std::marker::Sized` is not implemented for `PathHelper3 + 'static`
    = note: required because it appears within the type `Path3`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the trait bound `PathHelper4 + 'static: std::marker::Sized` is not satisfied in `Path4`
-  --> $DIR/unsized-enum2.rs:48:18
+error[E0277]: `PathHelper4 + 'static` does not have a constant size known at compile-time
+  --> $DIR/unsized-enum2.rs:59:18
    |
-LL |     VL{u: isize, x: Path4}, //~ ERROR `PathHelper4 + 'static: std::marker::Sized` is not satisfied
+LL |     VL{u: isize, x: Path4},
    |                  ^^^^^^^^ `PathHelper4 + 'static` does not have a constant size known at compile-time
    |
    = help: within `Path4`, the trait `std::marker::Sized` is not implemented for `PathHelper4 + 'static`


### PR DESCRIPTION
* [Add code to `invalid ABI` error, add span label, move list to help to make message shorter](https://github.com/rust-lang/rust/pull/51463/commits/23ae5af274defa9ff884f593e44a2bbcaf814a02):
```
error[E0697]: invalid ABI: found `路濫狼á́́`
  --> $DIR/unicode.rs:11:8
   |
LL | extern "路濫狼á́́" fn foo() {} //~ ERROR invalid ABI
   |        ^^^^^^^^^ invalid ABI
   |
   = help: valid ABIs: cdecl, stdcall, fastcall, vectorcall, thiscall, aapcs, win64, sysv64, ptx-kernel, msp430-interrupt, x86-interrupt, Rust, C, system, rust-intrinsic, rust-call, platform-intrinsic, unadjusted
``` 
* [Add code to incorrect `pub` restriction error](https://github.com/rust-lang/rust/pull/51463/commits/e96fdea8a38f39f99f8b9a4000a689187a457e08)
* [Add message to `rustc_on_unimplemented` attributes in core to have them set a custom message _and_ label](https://github.com/rust-lang/rust/pull/51463/commits/2cc7e5ed307aee936c20479cfdc7409d6b52a464):
```
error[E0277]: `W` does not have a constant size known at compile-time
  --> $DIR/unsized-enum2.rs:33:8
   |
LL |     VA(W),
   |        ^ `W` does not have a constant size known at compile-time
   |
   = help: the trait `std::marker::Sized` is not implemented for `W`
   = help: consider adding a `where W: std::marker::Sized` bound
   = note: no field of an enum variant may have a dynamically sized type
```
```
error[E0277]: `Foo` cannot be sent between threads safely
  --> $DIR/E0277-2.rs:26:5
   |
LL |     is_send::<Foo>();
   |     ^^^^^^^^^^^^^^ `Foo` cannot be sent between threads safely
   |
   = help: the trait `std::marker::Send` is not implemented for `Foo`
```
```
error[E0277]: can't compare `{integer}` with `std::string::String`
  --> $DIR/binops.rs:16:7
   |
LL |     5 < String::new();
   |       ^ no implementation for `{integer} < std::string::String` and `{integer} > std::string::String`
   |
   = help: the trait `std::cmp::PartialOrd<std::string::String>` is not implemented for `{integer}`
```
```
error[E0277]: can't compare `{integer}` with `std::result::Result<{integer}, _>`
  --> $DIR/binops.rs:17:7
   |
LL |     6 == Ok(1);
   |       ^^ no implementation for `{integer} == std::result::Result<{integer}, _>`
   |
   = help: the trait `std::cmp::PartialEq<std::result::Result<{integer}, _>>` is not implemented for `{integer}`
```
```
error[E0277]: a collection of type `i32` cannot be built from an iterator over elements of type `i32`
  --> $DIR/type-check-defaults.rs:16:19
   |
LL | struct WellFormed<Z = Foo<i32, i32>>(Z);
   |                   ^ a collection of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
   |
   = help: the trait `std::iter::FromIterator<i32>` is not implemented for `i32`
note: required by `Foo`
  --> $DIR/type-check-defaults.rs:15:1
   |
LL | struct Foo<T, U: FromIterator<T>>(T, U);
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
* [Add link to book for `Sized` errors](https://github.com/rust-lang/rust/pull/51463/commits/1244dc7c283323aea1a3457a4458d590a3e160c8):
```
error[E0277]: `std::fmt::Debug + std::marker::Sync + 'static` does not have a constant size known at compile-time
  --> $DIR/const-unsized.rs:13:29
   |
LL | const CONST_0: Debug+Sync = *(&0 as &(Debug+Sync));
   |                             ^^^^^^^^^^^^^^^^^^^^^^ `std::fmt::Debug + std::marker::Sync + 'static` does not have a constant size known at compile-time
   |
   = help: the trait `std::marker::Sized` is not implemented for `std::fmt::Debug + std::marker::Sync + 'static`
   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
   = note: constant expressions must have a statically known size
```
* [Point to previous line for single expected token not found](https://github.com/rust-lang/rust/pull/51463/commits/48165168fb0f059d8536cd4a2276b609d4a7f721) (if the current token is in a different line)