### PR TITLE
Enable fall through past $:lifetime matcher

### DIFF
--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -827,6 +827,14 @@ fn may_begin_with(name: &str, token: &Token) -> bool {
             Token::Interpolated(ref nt) => may_be_ident(&nt.0),
             _ => false,
         },
+        "lifetime" => match *token {
+            Token::Lifetime(_) => true,
+            Token::Interpolated(ref nt) => match nt.0 {
+                token::NtLifetime(_) | token::NtTT(_) => true,
+                _ => false,
+            },
+            _ => false,
+        },
         _ => match *token {
             token::CloseDelim(_) => false,
             _ => true,

--- a/src/test/compile-fail/macro-non-lifetime.rs
+++ b/src/test/compile-fail/macro-non-lifetime.rs
@@ -16,5 +16,5 @@ macro_rules! m { ($x:lifetime) => { } }
 
 fn main() {
     m!(a);
-    //~^ ERROR expected a lifetime, found `a`
+    //~^ ERROR no rules expected the token `a`
 }

--- a/src/test/run-pass/macro-first-set.rs
+++ b/src/test/run-pass/macro-first-set.rs
@@ -199,6 +199,40 @@ fn test_24189() {
 
 //}}}
 
+//{{{ issue 50903 ==============================================================
+
+macro_rules! foo_50903 {
+    ($($lif:lifetime ,)* #) => {};
+}
+
+foo_50903!('a, 'b, #);
+foo_50903!('a, #);
+foo_50903!(#);
+
+//}}}
+
+//{{{ issue 51477 ==============================================================
+
+macro_rules! foo_51477 {
+    ($lifetime:lifetime) => {
+        "last token is lifetime"
+    };
+    ($other:tt) => {
+        "last token is other"
+    };
+    ($first:tt $($rest:tt)*) => {
+        foo_51477!($($rest)*)
+    };
+}
+
+fn test_51477() {
+    assert_eq!("last token is lifetime", foo_51477!('a));
+    assert_eq!("last token is other", foo_51477!(@));
+    assert_eq!("last token is lifetime", foo_51477!(@ {} 'a));
+}
+
+//}}}
+
 //{{{ some more tests ==========================================================
 
 macro_rules! test_block {
@@ -234,6 +268,14 @@ macro_rules! test_meta_block {
 
 test_meta_block!(windows {});
 
+macro_rules! test_lifetime {
+    (1. $($l:lifetime)* $($b:block)*) => {};
+    (2. $($b:block)* $($l:lifetime)*) => {};
+}
+
+test_lifetime!(1. 'a 'b {} {});
+test_lifetime!(2. {} {} 'a 'b);
+
 //}}}
 
 fn main() {
@@ -241,5 +283,6 @@ fn main() {
     test_40569();
     test_35650();
     test_24189();
+    test_51477();
 }
 


### PR DESCRIPTION
```rust
macro_rules! is_lifetime {
    ($lifetime:lifetime) => { true };
    ($other:tt) => { false };
}

fn main() {
    println!("{}", is_lifetime!('lifetime));
    println!("{}", is_lifetime!(@));
}
```

Before this fix, the `is_lifetime!` invocation would fail to compile with:

```
error: expected a lifetime, found `@`
 --> src/main.rs:8:33
  |
8 |     println!("{}", is_lifetime!(@));
  |                                 ^
```

Fixes #50903.
Fixes #51477.

r? @kennytm