### PR TITLE
Greatly improve tables display in docs

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -407,31 +407,27 @@ h4 > code, h3 > code, .invisible > code {
 
 .content table:not(.table-display) {
 	border-spacing: 0 5px;
-	border-collapse: separate;
 }
 .content td { vertical-align: top; }
 .content td:first-child { padding-right: 20px; }
 .content td p:first-child { margin-top: 0; }
 .content td h1, .content td h2 { margin-left: 0; font-size: 1.1em; }
+.content tr:first-child td { border-top: 0; }
 
 .docblock table {
-	border: 1px solid;
 	margin: .5em 0;
-	border-collapse: collapse;
 	width: 100%;
 }
 
 .docblock table td {
 	padding: .5em;
-	border-top: 1px dashed;
-	border-bottom: 1px dashed;
+	border: 1px dashed;
 }
 
 .docblock table th {
 	padding: .5em;
 	text-align: left;
-	border-top: 1px solid;
-	border-bottom: 1px solid;
+	border: 1px solid;
 }
 
 .fields + table {


### PR DESCRIPTION
Fixes #51454.

r? @QuietMisdreavus 

Before:

<img width="1440" alt="screen shot 2018-06-10 at 22 43 52" src="https://user-images.githubusercontent.com/3050060/41206138-cc61b2b4-6cff-11e8-9b6f-0b1e435d4b1b.png">

After:

<img width="1440" alt="screen shot 2018-06-10 at 23 33 16" src="https://user-images.githubusercontent.com/3050060/41207049-d455c03c-6d0e-11e8-968f-d4fccaeb4265.png">

