### PR TITLE
Make parse_ident public

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -760,7 +760,7 @@ impl<'a> Parser<'a> {
         err
     }
 
-    fn parse_ident(&mut self) -> PResult<'a, ast::Ident> {
+    pub fn parse_ident(&mut self) -> PResult<'a, ast::Ident> {
         self.parse_ident_common(true)
     }
 


### PR DESCRIPTION
`parse_ident` was made private in #51265. In rustfmt the method is used to create a custom parser for macro call.