### PR TITLE
Suggest replacing named lifetime with `'static`

### DIFF
--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -475,6 +475,13 @@ impl GenericParam {
             _ => false,
         }
     }
+
+    pub fn span(&self) -> Span {
+        match *self {
+            GenericParam::Lifetime(ref lifetime) => lifetime.lifetime.span,
+            GenericParam::Type(ref typaram) => typaram.span,
+        }
+    }
 }
 
 pub trait GenericParamsExt {
@@ -1660,6 +1667,16 @@ pub struct Ty {
     pub node: Ty_,
     pub span: Span,
     pub hir_id: HirId,
+}
+
+impl Ty {
+    pub fn lifetimes(&self) -> Vec<Lifetime> {
+        // FIXME(estebank): expand to all `Ty_`s
+        match self.node {
+            TyRptr(lifetime, _) => vec![lifetime],
+            _ => vec![],
+        }
+    }
 }
 
 impl fmt::Debug for Ty {

--- a/src/test/ui/issue-26638.stderr
+++ b/src/test/ui/issue-26638.stderr
@@ -10,19 +10,23 @@ error[E0106]: missing lifetime specifier
   --> $DIR/issue-26638.rs:14:40
    |
 LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
-   |                                        ^ expected lifetime parameter
+   |                                        ^
+   |                                        |
+   |                                        expected lifetime parameter
+   |                                        help: consider giving it an explicit bound  or `'static` lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
-   = help: consider giving it an explicit bounded or 'static lifetime
 
 error[E0106]: missing lifetime specifier
   --> $DIR/issue-26638.rs:17:22
    |
 LL | fn parse_type_3() -> &str { unimplemented!() }
-   |                      ^ expected lifetime parameter
+   |                      ^
+   |                      |
+   |                      expected lifetime parameter
+   |                      help: consider giving it a `'static` lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-   = help: consider giving it a 'static lifetime
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lifetime-elision-return-type-requires-explicit-lifetime.stderr
+++ b/src/test/ui/lifetime-elision-return-type-requires-explicit-lifetime.stderr
@@ -2,10 +2,12 @@ error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:12:11
    |
 LL | fn f() -> &isize {    //~ ERROR missing lifetime specifier
-   |           ^ expected lifetime parameter
+   |           ^
+   |           |
+   |           expected lifetime parameter
+   |           help: consider giving it a `'static` lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-   = help: consider giving it a 'static lifetime
 
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:17:33
@@ -27,28 +29,34 @@ error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:31:20
    |
 LL | fn i(_x: isize) -> &isize { //~ ERROR missing lifetime specifier
-   |                    ^ expected lifetime parameter
+   |                    ^
+   |                    |
+   |                    expected lifetime parameter
+   |                    help: consider giving it an explicit bound  or `'static` lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
-   = help: consider giving it an explicit bounded or 'static lifetime
 
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:44:24
    |
 LL | fn j(_x: StaticStr) -> &isize { //~ ERROR missing lifetime specifier
-   |                        ^ expected lifetime parameter
+   |                        ^
+   |                        |
+   |                        expected lifetime parameter
+   |                        help: consider giving it an explicit bound  or `'static` lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
-   = help: consider giving it an explicit bounded or 'static lifetime
 
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:50:49
    |
 LL | fn k<'a, T: WithLifetime<'a>>(_x: T::Output) -> &isize {
-   |                                                 ^ expected lifetime parameter
+   |                                                 ^
+   |                                                 |
+   |                                                 expected lifetime parameter
+   |                                                 help: consider giving it an explicit bound  or `'static` lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
-   = help: consider giving it an explicit bounded or 'static lifetime
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/suggestions/static-lifetime.rs
+++ b/src/test/ui/suggestions/static-lifetime.rs
@@ -1,0 +1,39 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn _foo<'a: 'static, 'b>(_x: &'a str, _y: &'b str) -> &'a str {
+//~^ WARNING unnecessary lifetime parameter `'a`
+    ""
+}
+
+fn _foo1<'b, 'a: 'static>(_x: &'a str, _y: &'b str) -> &'a str {
+//~^ WARNING unnecessary lifetime parameter `'a`
+    ""
+}
+
+fn _foo2<'c, 'a: 'static, 'b>(_x: &'a str, _y: &'b str) -> &'a str {
+//~^ WARNING unnecessary lifetime parameter `'a`
+    ""
+}
+
+fn _foo3<'c, 'a: 'static, 'b, 'd>(_x: &'a str, _y: &'b str) -> &'a str {
+//~^ WARNING unnecessary lifetime parameter `'a`
+    ""
+}
+
+fn _foo4<'a: 'static>(_x: &'a str, _y: &str) -> &'a str {
+//~^ WARNING unnecessary lifetime parameter `'a`
+    ""
+}
+
+fn _foo5<'a: 'static, 'b>(_x: &'a str, _y: &'b str) -> &'b str {
+//~^ WARNING unnecessary lifetime parameter `'a`
+    ""
+}

--- a/src/test/ui/suggestions/static-lifetime.rs
+++ b/src/test/ui/suggestions/static-lifetime.rs
@@ -8,12 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+struct Foo<'a>(&'a str);
+
 fn _foo<'a: 'static, 'b>(_x: &'a str, _y: &'b str) -> &'a str {
 //~^ WARNING unnecessary lifetime parameter `'a`
     ""
 }
 
-fn _foo1<'b, 'a: 'static>(_x: &'a str, _y: &'b str) -> &'a str {
+fn _foo1<'b, 'a: 'static>(_x: &'a str, _y: Foo<'a>) -> &'a str {
 //~^ WARNING unnecessary lifetime parameter `'a`
     ""
 }
@@ -23,7 +25,7 @@ fn _foo2<'c, 'a: 'static, 'b>(_x: &'a str, _y: &'b str) -> &'a str {
     ""
 }
 
-fn _foo3<'c, 'a: 'static, 'b, 'd>(_x: &'a str, _y: &'b str) -> &'a str {
+fn _foo3<'c, 'a: 'static, 'b: 'a, 'd>(_x: &'a str, _y: &'b str) -> &'a str {
 //~^ WARNING unnecessary lifetime parameter `'a`
     ""
 }

--- a/src/test/ui/suggestions/static-lifetime.stderr
+++ b/src/test/ui/suggestions/static-lifetime.stderr
@@ -1,0 +1,67 @@
+error[E0601]: `main` function not found in crate `static_lifetime`
+   |
+   = note: consider adding a `main` function to `$DIR/static-lifetime.rs`
+
+warning: unnecessary lifetime parameter `'a`
+  --> $DIR/static-lifetime.rs:11:9
+   |
+LL | fn _foo<'a: 'static, 'b>(_x: &'a str, _y: &'b str) -> &'a str {
+   |         ^^^^^^^^^^^
+help: you can use the `'static` lifetime directly, in place of `'a`
+   |
+LL | fn _foo<'b>(_x: &'static str, _y: &'b str) -> &'static str {
+   |        --        ^^^^^^^                       ^^^^^^^
+
+warning: unnecessary lifetime parameter `'a`
+  --> $DIR/static-lifetime.rs:16:14
+   |
+LL | fn _foo1<'b, 'a: 'static>(_x: &'a str, _y: &'b str) -> &'a str {
+   |              ^^^^^^^^^^^
+help: you can use the `'static` lifetime directly, in place of `'a`
+   |
+LL | fn _foo1<'b>(_x: &'static str, _y: &'b str) -> &'static str {
+   |           --      ^^^^^^^                       ^^^^^^^
+
+warning: unnecessary lifetime parameter `'a`
+  --> $DIR/static-lifetime.rs:21:14
+   |
+LL | fn _foo2<'c, 'a: 'static, 'b>(_x: &'a str, _y: &'b str) -> &'a str {
+   |              ^^^^^^^^^^^
+help: you can use the `'static` lifetime directly, in place of `'a`
+   |
+LL | fn _foo2<'c, 'b>(_x: &'static str, _y: &'b str) -> &'static str {
+   |             --        ^^^^^^^                       ^^^^^^^
+
+warning: unnecessary lifetime parameter `'a`
+  --> $DIR/static-lifetime.rs:26:14
+   |
+LL | fn _foo3<'c, 'a: 'static, 'b, 'd>(_x: &'a str, _y: &'b str) -> &'a str {
+   |              ^^^^^^^^^^^
+help: you can use the `'static` lifetime directly, in place of `'a`
+   |
+LL | fn _foo3<'c, 'b, 'd>(_x: &'static str, _y: &'b str) -> &'static str {
+   |             --            ^^^^^^^                       ^^^^^^^
+
+warning: unnecessary lifetime parameter `'a`
+  --> $DIR/static-lifetime.rs:31:10
+   |
+LL | fn _foo4<'a: 'static>(_x: &'a str, _y: &str) -> &'a str {
+   |          ^^^^^^^^^^^
+help: you can use the `'static` lifetime directly, in place of `'a`
+   |
+LL | fn _foo4(_x: &'static str, _y: &str) -> &'static str {
+   |        --     ^^^^^^^                    ^^^^^^^
+
+warning: unnecessary lifetime parameter `'a`
+  --> $DIR/static-lifetime.rs:36:10
+   |
+LL | fn _foo5<'a: 'static, 'b>(_x: &'a str, _y: &'b str) -> &'b str {
+   |          ^^^^^^^^^^^
+help: you can use the `'static` lifetime directly, in place of `'a`
+   |
+LL | fn _foo5<'b>(_x: &'static str, _y: &'b str) -> &'b str {
+   |         --        ^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/suggestions/static-lifetime.stderr
+++ b/src/test/ui/suggestions/static-lifetime.stderr
@@ -3,7 +3,7 @@ error[E0601]: `main` function not found in crate `static_lifetime`
    = note: consider adding a `main` function to `$DIR/static-lifetime.rs`
 
 warning: unnecessary lifetime parameter `'a`
-  --> $DIR/static-lifetime.rs:11:9
+  --> $DIR/static-lifetime.rs:13:9
    |
 LL | fn _foo<'a: 'static, 'b>(_x: &'a str, _y: &'b str) -> &'a str {
    |         ^^^^^^^^^^^
@@ -13,17 +13,17 @@ LL | fn _foo<'b>(_x: &'static str, _y: &'b str) -> &'static str {
    |        --        ^^^^^^^                       ^^^^^^^
 
 warning: unnecessary lifetime parameter `'a`
-  --> $DIR/static-lifetime.rs:16:14
+  --> $DIR/static-lifetime.rs:18:14
    |
-LL | fn _foo1<'b, 'a: 'static>(_x: &'a str, _y: &'b str) -> &'a str {
+LL | fn _foo1<'b, 'a: 'static>(_x: &'a str, _y: Foo<'a>) -> &'a str {
    |              ^^^^^^^^^^^
 help: you can use the `'static` lifetime directly, in place of `'a`
    |
-LL | fn _foo1<'b>(_x: &'static str, _y: &'b str) -> &'static str {
-   |           --      ^^^^^^^                       ^^^^^^^
+LL | fn _foo1<'b>(_x: &'static str, _y: Foo<'static>) -> &'static str {
+   |           --      ^^^^^^^              ^^^^^^^       ^^^^^^^
 
 warning: unnecessary lifetime parameter `'a`
-  --> $DIR/static-lifetime.rs:21:14
+  --> $DIR/static-lifetime.rs:23:14
    |
 LL | fn _foo2<'c, 'a: 'static, 'b>(_x: &'a str, _y: &'b str) -> &'a str {
    |              ^^^^^^^^^^^
@@ -33,17 +33,17 @@ LL | fn _foo2<'c, 'b>(_x: &'static str, _y: &'b str) -> &'static str {
    |             --        ^^^^^^^                       ^^^^^^^
 
 warning: unnecessary lifetime parameter `'a`
-  --> $DIR/static-lifetime.rs:26:14
+  --> $DIR/static-lifetime.rs:28:14
    |
-LL | fn _foo3<'c, 'a: 'static, 'b, 'd>(_x: &'a str, _y: &'b str) -> &'a str {
+LL | fn _foo3<'c, 'a: 'static, 'b: 'a, 'd>(_x: &'a str, _y: &'b str) -> &'a str {
    |              ^^^^^^^^^^^
 help: you can use the `'static` lifetime directly, in place of `'a`
    |
-LL | fn _foo3<'c, 'b, 'd>(_x: &'static str, _y: &'b str) -> &'static str {
-   |             --            ^^^^^^^                       ^^^^^^^
+LL | fn _foo3<'c, 'b: 'static, 'd>(_x: &'static str, _y: &'b str) -> &'static str {
+   |             --   ^^^^^^^           ^^^^^^^                       ^^^^^^^
 
 warning: unnecessary lifetime parameter `'a`
-  --> $DIR/static-lifetime.rs:31:10
+  --> $DIR/static-lifetime.rs:33:10
    |
 LL | fn _foo4<'a: 'static>(_x: &'a str, _y: &str) -> &'a str {
    |          ^^^^^^^^^^^
@@ -53,7 +53,7 @@ LL | fn _foo4(_x: &'static str, _y: &str) -> &'static str {
    |        --     ^^^^^^^                    ^^^^^^^
 
 warning: unnecessary lifetime parameter `'a`
-  --> $DIR/static-lifetime.rs:36:10
+  --> $DIR/static-lifetime.rs:38:10
    |
 LL | fn _foo5<'a: 'static, 'b>(_x: &'a str, _y: &'b str) -> &'b str {
    |          ^^^^^^^^^^^


### PR DESCRIPTION
```
warning: unnecessary lifetime parameter `'a`
  --> file.rs:11:14
   |
11 | fn foo<'c, 'a: 'static, 'b, 'd>(_x: &'a str) -> &'a str {
   |            ^^^^^^^^^^^
help: you can use the `'static` lifetime directly, in place of `'a`
   |
11 | fn foo<'c, 'b, 'd>(_x: &'static str) -> &'static str {
   |           --            ^^^^^^^          ^^^^^^^

warning: unnecessary lifetime parameter `'a`
  --> file.rs:14:9
   |
14 | fn bar<'a: 'static>(_x: &'a str) -> &'a str {
   |        ^^^^^^^^^^^
help: you can use the `'static` lifetime directly, in place of `'a`
   |
14 | fn bar(_x: &'static str) -> &'static str {
   |      --     ^^^^^^^          ^^^^^^^
```

cc #36179