### PR TITLE
Fix for $crate var normalization in proc macro for externally defined macros

### DIFF
--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/double.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/double.rs
@@ -16,6 +16,8 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 
+// Outputs another copy of the struct.  Useful for testing the tokens
+// seen by the proc_macro.
 #[proc_macro_derive(Double)]
 pub fn derive(input: TokenStream) -> TokenStream {
     format!("mod foo {{ {} }}", input.to_string()).parse().unwrap()

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/external-crate-var.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/external-crate-var.rs
@@ -8,64 +8,44 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// aux-build:double.rs
-// aux-build:external-crate-var.rs
-// ignore-stage1
+pub struct ExternFoo;
 
-#![allow(unused)]
-
-#[macro_use]
-extern crate double;
-#[macro_use]
-extern crate external_crate_var;
-
-struct Foo;
-
-trait Trait {
+pub trait ExternTrait {
     const CONST: u32;
     type Assoc;
 }
 
-impl Trait for Foo {
+impl ExternTrait for ExternFoo {
     const CONST: u32 = 0;
-    type Assoc = Foo;
+    type Assoc = ExternFoo;
 }
 
-macro_rules! local { () => {
-    // derive_Double outputs secondary copies of each definition
-    // to test what the proc_macro sees.
+#[macro_export]
+macro_rules! external { () => {
     mod bar {
         #[derive(Double)]
-        struct Bar($crate::Foo);
+        struct Bar($crate::ExternFoo);
     }
 
     mod qself {
         #[derive(Double)]
-        struct QSelf(<::Foo as $crate::Trait>::Assoc);
+        struct QSelf(<$crate::ExternFoo as $crate::ExternTrait>::Assoc);
     }
 
     mod qself_recurse {
         #[derive(Double)]
-        struct QSelfRecurse(<<$crate::Foo as $crate::Trait>::Assoc as $crate::Trait>::Assoc);
+        struct QSelfRecurse(<
+            <$crate::ExternFoo as $crate::ExternTrait>::Assoc
+            as $crate::ExternTrait>::Assoc
+        );
     }
 
     mod qself_in_const {
         #[derive(Double)]
         #[repr(u32)]
         enum QSelfInConst {
-            Variant = <::Foo as $crate::Trait>::CONST,
+            Variant = <$crate::ExternFoo as $crate::ExternTrait>::CONST,
         }
     }
 } }
 
-mod local {
-    local!();
-}
-
-// and now repeat the above tests, using a macro defined in another crate
-
-mod external {
-    external!{}
-}
-
-fn main() {}


### PR DESCRIPTION
Fixes #51331, a bug that has existed in at least *some* form for a year and a half.

The PR includes the addition of a `fold_qpath` method to `syntax::fold::Folder`.  Overriding this method is useful for folds that modify paths in a way that invalidates indices (insertion or removal of a component), as it provides the opportunity to update `qself.position` in `<A as B>::C` paths.  I added it because the bugfix is messy without it.

(unfortunately, grepping around the codebase, I did not see anything else that could use it.)