### PR TITLE
Don't auto-hide inherent impls even if `rustdoc-collapse == true`.

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1775,7 +1775,7 @@
         }
     }
 
-    function toggleAllDocs(pageId) {
+    function toggleAllDocs(pageId, fromAutoCollapse) {
         var toggle = document.getElementById("toggle-all-docs");
         if (!toggle) {
             return;
@@ -1787,9 +1787,11 @@
                 e.innerHTML = labelForToggleButton(false);
             });
             toggle.title = "collapse all docs";
-            onEach(document.getElementsByClassName("collapse-toggle"), function(e) {
-                collapseDocs(e, "show");
-            });
+            if (fromAutoCollapse !== true) {
+                onEach(document.getElementsByClassName("collapse-toggle"), function(e) {
+                    collapseDocs(e, "show");
+                });
+            }
         } else {
             updateLocalStorage("rustdoc-collapse", "true");
             addClass(toggle, "will-expand");
@@ -1797,10 +1799,11 @@
                 e.innerHTML = labelForToggleButton(true);
             });
             toggle.title = "expand all docs";
-
-            onEach(document.getElementsByClassName("collapse-toggle"), function(e) {
-                collapseDocs(e, "hide", pageId);
-            });
+            if (fromAutoCollapse !== true) {
+                onEach(document.getElementsByClassName("collapse-toggle"), function(e) {
+                    collapseDocs(e, "hide", pageId);
+                });
+            }
         }
     }
 
@@ -1921,17 +1924,19 @@
         }
     }
 
-    function autoCollapseAllImpls(pageId) {
-        // Automatically minimize all non-inherent impls
-        onEach(document.getElementsByClassName('impl'), function(n) {
-            // inherent impl ids are like 'impl' or impl-<number>'
-            var inherent = (n.id.match(/^impl(?:-\d+)?$/) !== null);
-            if (!inherent) {
-                onEach(n.childNodes, function(m) {
-                    if (hasClass(m, "collapse-toggle")) {
-                        collapseDocs(m, "hide", pageId);
-                    }
-                });
+    function autoCollapse(pageId, collapse) {
+        if (collapse) {
+            toggleAllDocs(pageId, true);
+        }
+        onEach(document.getElementsByClassName("collapse-toggle"), function(e) {
+            // inherent impl ids are like 'impl' or impl-<number>'.
+            // they will never be hidden by default.
+            var n = e.parentNode;
+            if (n.id.match(/^impl(?:-\d+)?$/) === null) {
+                // Automatically minimize all non-inherent impls
+                if (collapse || hasClass(n, 'impl')) {
+                    collapseDocs(e, "hide", pageId);
+                }
             }
         });
     }
@@ -2043,8 +2048,6 @@
             }
         }
     });
-
-    autoCollapseAllImpls(getPageId());
 
     function createToggleWrapper(tog) {
         var span = document.createElement('span');
@@ -2175,9 +2178,7 @@
         hideSidebar();
     };
 
-    if (getCurrentValue("rustdoc-collapse") === "true") {
-        toggleAllDocs(getPageId());
-    }
+    autoCollapse(getPageId(), getCurrentValue("rustdoc-collapse") === "true");
 }());
 
 // Sets the focus on the search bar at the top of the page


### PR DESCRIPTION
This PR changes the auto-collapse behavior when a page is first loaded:

* Inherent impls will never be collapsed by default (new behavior).
* Trait impls will always be collapsed by default, same as before.
* Other items are collapsed according to localStorage, same as before.

This should be much more useful since there is no hint what the content of a collapsed inherent impl would be (try to collapse everything in https://doc.rust-lang.org/std/vec/struct.Vec.html and guess where a method like `try_reserve` or `splice` would be).

Manually clicking the global [-]/[+] will still collapse/expand everything.