### PR TITLE
NLL: bad error message when converting anonymous lifetime to `'static`

### DIFF
--- a/src/librustc_mir/borrow_check/nll/constraint_generation.rs
+++ b/src/librustc_mir/borrow_check/nll/constraint_generation.rs
@@ -315,7 +315,6 @@ impl<'cx, 'cg, 'gcx, 'tcx> ConstraintGeneration<'cx, 'cg, 'gcx, 'tcx> {
                                 span,
                                 ref_region.to_region_vid(),
                                 borrow_region.to_region_vid(),
-                                location.successor_within_block(),
                             );
 
                             if let Some(all_facts) = self.all_facts {

--- a/src/librustc_mir/borrow_check/nll/constraint_generation.rs
+++ b/src/librustc_mir/borrow_check/nll/constraint_generation.rs
@@ -10,9 +10,10 @@
 
 use borrow_check::borrow_set::BorrowSet;
 use borrow_check::location::LocationTable;
+use borrow_check::nll::ToRegionVid;
 use borrow_check::nll::facts::AllFacts;
 use borrow_check::nll::region_infer::{Cause, RegionInferenceContext};
-use borrow_check::nll::ToRegionVid;
+use borrow_check::nll::type_check::AtLocation;
 use rustc::hir;
 use rustc::infer::InferCtxt;
 use rustc::mir::visit::TyContext;
@@ -310,9 +311,8 @@ impl<'cx, 'cg, 'gcx, 'tcx> ConstraintGeneration<'cx, 'cg, 'gcx, 'tcx> {
                     debug!("add_reborrow_constraint - base_ty = {:?}", base_ty);
                     match base_ty.sty {
                         ty::TyRef(ref_region, _, mutbl) => {
-                            let span = self.mir.source_info(location).span;
                             self.regioncx.add_outlives(
-                                span,
+                                location.boring(),
                                 ref_region.to_region_vid(),
                                 borrow_region.to_region_vid(),
                             );

--- a/src/librustc_mir/borrow_check/nll/constraint_set.rs
+++ b/src/librustc_mir/borrow_check/nll/constraint_set.rs
@@ -13,7 +13,6 @@ use rustc_data_structures::indexed_vec::{Idx, IndexVec};
 use borrow_check::nll::type_check::Locations;
 
 use std::fmt;
-use std::cmp::Ordering;
 use std::ops::Deref;
 
 #[derive(Clone, Default)]
@@ -112,37 +111,12 @@ impl fmt::Debug for OutlivesConstraint {
 
 /// Constraints that are considered interesting can be categorized to
 /// determine why they are interesting.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
 crate enum ConstraintCategory {
     Assignment,
     CallArgument,
     Cast,
     Other,
 }
-
-impl Ord for ConstraintCategory {
-    fn cmp(&self, other: &Self) -> Ordering {
-        if self == other {
-            return Ordering::Equal;
-        }
-
-        match (self, other) {
-            (ConstraintCategory::Assignment, _) => Ordering::Greater,
-            (_, ConstraintCategory::Assignment) => Ordering::Less,
-            (ConstraintCategory::CallArgument, _) => Ordering::Greater,
-            (_, ConstraintCategory::CallArgument) => Ordering::Less,
-            (ConstraintCategory::Cast, _) => Ordering::Greater,
-            (_, ConstraintCategory::Cast) => Ordering::Less,
-            (ConstraintCategory::Other, _) => Ordering::Greater,
-        }
-    }
-}
-
-impl PartialOrd for ConstraintCategory {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
 
 newtype_index!(ConstraintIndex { DEBUG_FORMAT = "ConstraintIndex({})" });

--- a/src/librustc_mir/borrow_check/nll/constraint_set.rs
+++ b/src/librustc_mir/borrow_check/nll/constraint_set.rs
@@ -109,14 +109,4 @@ impl fmt::Debug for OutlivesConstraint {
     }
 }
 
-/// Constraints that are considered interesting can be categorized to
-/// determine why they are interesting.
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
-crate enum ConstraintCategory {
-    Assignment,
-    CallArgument,
-    Cast,
-    Other,
-}
-
 newtype_index!(ConstraintIndex { DEBUG_FORMAT = "ConstraintIndex({})" });

--- a/src/librustc_mir/borrow_check/nll/constraint_set.rs
+++ b/src/librustc_mir/borrow_check/nll/constraint_set.rs
@@ -13,6 +13,7 @@ use rustc_data_structures::indexed_vec::{Idx, IndexVec};
 use borrow_check::nll::type_check::Locations;
 
 use std::fmt;
+use std::cmp::Ordering;
 use std::ops::Deref;
 
 #[derive(Clone, Default)]
@@ -108,5 +109,40 @@ impl fmt::Debug for OutlivesConstraint {
         )
     }
 }
+
+/// Constraints that are considered interesting can be categorized to
+/// determine why they are interesting.
+#[derive(Debug, Eq, PartialEq)]
+crate enum ConstraintCategory {
+    Assignment,
+    CallArgument,
+    Cast,
+    Other,
+}
+
+impl Ord for ConstraintCategory {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self == other {
+            return Ordering::Equal;
+        }
+
+        match (self, other) {
+            (ConstraintCategory::Assignment, _) => Ordering::Greater,
+            (_, ConstraintCategory::Assignment) => Ordering::Less,
+            (ConstraintCategory::CallArgument, _) => Ordering::Greater,
+            (_, ConstraintCategory::CallArgument) => Ordering::Less,
+            (ConstraintCategory::Cast, _) => Ordering::Greater,
+            (_, ConstraintCategory::Cast) => Ordering::Less,
+            (ConstraintCategory::Other, _) => Ordering::Greater,
+        }
+    }
+}
+
+impl PartialOrd for ConstraintCategory {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 
 newtype_index!(ConstraintIndex { DEBUG_FORMAT = "ConstraintIndex({})" });

--- a/src/librustc_mir/borrow_check/nll/constraint_set.rs
+++ b/src/librustc_mir/borrow_check/nll/constraint_set.rs
@@ -10,9 +10,9 @@
 
 use rustc::ty::RegionVid;
 use rustc_data_structures::indexed_vec::{Idx, IndexVec};
+use borrow_check::nll::type_check::Locations;
 
 use std::fmt;
-use syntax_pos::Span;
 use std::ops::Deref;
 
 #[derive(Clone, Default)]
@@ -23,8 +23,8 @@ crate struct ConstraintSet {
 impl ConstraintSet {
     pub fn push(&mut self, constraint: OutlivesConstraint) {
         debug!(
-            "add_outlives({:?}: {:?})",
-            constraint.sup, constraint.sub
+            "add_outlives({:?}: {:?} @ {:?})",
+            constraint.sup, constraint.sub, constraint.locations
         );
         if constraint.sup == constraint.sub {
             // 'a: 'a is pretty uninteresting
@@ -96,7 +96,7 @@ pub struct OutlivesConstraint {
     pub next: Option<ConstraintIndex>,
 
     /// Where did this constraint arise?
-    pub span: Span,
+    pub locations: Locations,
 }
 
 impl fmt::Debug for OutlivesConstraint {
@@ -104,7 +104,7 @@ impl fmt::Debug for OutlivesConstraint {
         write!(
             formatter,
             "({:?}: {:?}) due to {:?}",
-            self.sup, self.sub, self.span
+            self.sup, self.sub, self.locations
         )
     }
 }

--- a/src/librustc_mir/borrow_check/nll/constraint_set.rs
+++ b/src/librustc_mir/borrow_check/nll/constraint_set.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use rustc::mir::Location;
 use rustc::ty::RegionVid;
 use rustc_data_structures::indexed_vec::{Idx, IndexVec};
 
@@ -24,8 +23,8 @@ crate struct ConstraintSet {
 impl ConstraintSet {
     pub fn push(&mut self, constraint: OutlivesConstraint) {
         debug!(
-            "add_outlives({:?}: {:?} @ {:?}",
-            constraint.sup, constraint.sub, constraint.point
+            "add_outlives({:?}: {:?})",
+            constraint.sup, constraint.sub
         );
         if constraint.sup == constraint.sub {
             // 'a: 'a is pretty uninteresting
@@ -86,9 +85,6 @@ pub struct OutlivesConstraint {
     /// Region that must be outlived.
     pub sub: RegionVid,
 
-    /// At this location.
-    pub point: Location,
-
     /// Later on, we thread the constraints onto a linked list
     /// grouped by their `sub` field. So if you had:
     ///
@@ -107,8 +103,8 @@ impl fmt::Debug for OutlivesConstraint {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(
             formatter,
-            "({:?}: {:?} @ {:?}) due to {:?}",
-            self.sup, self.sub, self.point, self.span
+            "({:?}: {:?}) due to {:?}",
+            self.sup, self.sub, self.span
         )
     }
 }

--- a/src/librustc_mir/borrow_check/nll/region_infer/dump_mir.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/dump_mir.rs
@@ -82,14 +82,14 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             let OutlivesConstraint {
                 sup,
                 sub,
-                span,
+                locations,
                 next: _,
             } = constraint;
             with_msg(&format!(
                 "{:?}: {:?} due to {:?}",
                 sup,
                 sub,
-                span
+                locations,
             ))?;
         }
 

--- a/src/librustc_mir/borrow_check/nll/region_infer/dump_mir.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/dump_mir.rs
@@ -82,15 +82,13 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             let OutlivesConstraint {
                 sup,
                 sub,
-                point,
                 span,
                 next: _,
             } = constraint;
             with_msg(&format!(
-                "{:?}: {:?} @ {:?} due to {:?}",
+                "{:?}: {:?} due to {:?}",
                 sup,
                 sub,
-                point,
                 span
             ))?;
         }

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting.rs
@@ -37,11 +37,11 @@ enum ConstraintCategory {
 impl fmt::Display for ConstraintCategory {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ConstraintCategory::Assignment => write!(f, "Assignment"),
-            ConstraintCategory::Return => write!(f, "Return"),
-            ConstraintCategory::Cast => write!(f, "Cast"),
-            ConstraintCategory::CallArgument => write!(f, "Argument"),
-            _ => write!(f, "Free region"),
+            ConstraintCategory::Assignment => write!(f, "assignment"),
+            ConstraintCategory::Return => write!(f, "return"),
+            ConstraintCategory::Cast => write!(f, "cast"),
+            ConstraintCategory::CallArgument => write!(f, "argument"),
+            _ => write!(f, "free region"),
         }
     }
 }

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting.rs
@@ -1,0 +1,324 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use borrow_check::nll::region_infer::{Cause, ConstraintIndex, RegionInferenceContext};
+use borrow_check::nll::region_infer::values::ToElementIndex;
+use borrow_check::nll::type_check::Locations;
+use rustc::hir::def_id::DefId;
+use rustc::infer::InferCtxt;
+use rustc::infer::error_reporting::nice_region_error::NiceRegionError;
+use rustc::mir::{Location, Mir, StatementKind, TerminatorKind, Rvalue};
+use rustc::ty::RegionVid;
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_data_structures::indexed_vec::IndexVec;
+use syntax_pos::Span;
+
+/// Constraints that are considered interesting can be categorized to
+/// determine why they are interesting.
+#[derive(Debug, Eq, PartialEq, PartialOrd, Ord)]
+enum ConstraintCategory {
+    Assignment,
+    Cast,
+    CallArgument,
+    Other,
+}
+
+impl<'tcx> RegionInferenceContext<'tcx> {
+    /// When reporting an error, it is useful to be able to determine which constraints influenced
+    /// the region being reported as an error. This function finds all of the paths from the
+    /// constraint.
+    fn find_constraint_paths_from_region(
+        &self,
+        r0: RegionVid
+    ) -> Vec<Vec<ConstraintIndex>> {
+        let constraints = self.constraints.clone();
+
+        // Mapping of regions to the previous region and constraint index that led to it.
+        let mut previous = FxHashMap();
+        // Regions yet to be visited.
+        let mut next = vec! [ r0 ];
+        // Regions that have been visited.
+        let mut visited = FxHashSet();
+        // Ends of paths.
+        let mut end_regions: Vec<RegionVid> = Vec::new();
+
+        // When we've still got points to visit...
+        while let Some(current) = next.pop() {
+            // ...take the next point...
+            debug!("find_constraint_paths_from_region: current={:?} next={:?}", current, next);
+
+            // ...find the edges containing it...
+            let mut upcoming = Vec::new();
+            for (index, constraint) in constraints.iter_enumerated() {
+                if constraint.sub == current {
+                    // ...add the regions that join us with to the path we've taken...
+                    debug!("find_constraint_paths_from_region: index={:?} constraint={:?}",
+                           index, constraint);
+                    let next_region = constraint.sup.clone();
+
+                    // ...unless we've visited it since this was added...
+                    if visited.contains(&next_region) {
+                        debug!("find_constraint_paths_from_region: skipping as visited");
+                        continue;
+                    }
+
+                    previous.insert(next_region, (index, Some(current)));
+                    upcoming.push(next_region);
+                }
+            }
+
+            if upcoming.is_empty() {
+                // If we didn't find any edges then this is the end of a path...
+                debug!("find_constraint_paths_from_region: new end region current={:?}", current);
+                end_regions.push(current);
+            } else {
+                // ...but, if we did find edges, then add these to the regions yet to visit...
+                debug!("find_constraint_paths_from_region: extend next upcoming={:?}", upcoming);
+                next.extend(upcoming);
+            }
+
+            // ...and don't visit it again.
+            visited.insert(current.clone());
+            debug!("find_constraint_paths_from_region: next={:?} visited={:?}", next, visited);
+        }
+
+        // Now we've visited each point, compute the final paths.
+        let mut paths: Vec<Vec<ConstraintIndex>> = Vec::new();
+        debug!("find_constraint_paths_from_region: end_regions={:?}", end_regions);
+        for end_region in end_regions {
+            debug!("find_constraint_paths_from_region: end_region={:?}", end_region);
+
+            // Get the constraint and region that led to this end point.
+            // We can unwrap as we know if end_point was in the vector that it
+            // must also be in our previous map.
+            let (mut index, mut region) = previous.get(&end_region).unwrap();
+            debug!("find_constraint_paths_from_region: index={:?} region={:?}", index, region);
+
+            // Keep track of the indices.
+            let mut path: Vec<ConstraintIndex> = vec![index];
+
+            while region.is_some() && region != Some(r0) {
+                let p = previous.get(&region.unwrap()).unwrap();
+                index = p.0;
+                region = p.1;
+
+                debug!("find_constraint_paths_from_region: index={:?} region={:?}", index, region);
+                path.push(index);
+            }
+
+            // Add to our paths.
+            paths.push(path);
+        }
+
+        debug!("find_constraint_paths_from_region: paths={:?}", paths);
+        paths
+    }
+
+    /// This function will return true if a constraint is interesting and false if a constraint
+    /// is not. It is useful in filtering constraint paths to only interesting points.
+    fn constraint_is_interesting(&self, index: &ConstraintIndex) -> bool {
+        self.constraints.get(*index).filter(|constraint| {
+            debug!("constraint_is_interesting: locations={:?} constraint={:?}",
+                   constraint.locations, constraint);
+            if let Locations::Interesting(_) = constraint.locations { true } else { false }
+        }).is_some()
+    }
+
+    /// This function classifies a constraint from a location.
+    fn classify_constraint(&self, location: Location, mir: &Mir<'tcx>) -> ConstraintCategory {
+        let data = &mir[location.block];
+        if location.statement_index == data.statements.len() {
+            if let Some(ref terminator) = data.terminator {
+                match terminator.kind {
+                    TerminatorKind::DropAndReplace { .. } => ConstraintCategory::Assignment,
+                    TerminatorKind::Call { .. } => ConstraintCategory::CallArgument,
+                    _ => ConstraintCategory::Other,
+                }
+            } else {
+                ConstraintCategory::Other
+            }
+        } else {
+            let statement = &data.statements[location.statement_index];
+            match statement.kind {
+                StatementKind::Assign(_, ref rvalue) => match rvalue {
+                    Rvalue::Cast(..) => ConstraintCategory::Cast,
+                    Rvalue::Use(..) => ConstraintCategory::Assignment,
+                    _ => ConstraintCategory::Other,
+                },
+                _ => ConstraintCategory::Other,
+            }
+        }
+    }
+
+    /// Report an error because the universal region `fr` was required to outlive
+    /// `outlived_fr` but it is not known to do so. For example:
+    ///
+    /// ```
+    /// fn foo<'a, 'b>(x: &'a u32) -> &'b u32 { x }
+    /// ```
+    ///
+    /// Here we would be invoked with `fr = 'a` and `outlived_fr = `'b`.
+    pub(super) fn report_error(
+        &self,
+        mir: &Mir<'tcx>,
+        infcx: &InferCtxt<'_, '_, 'tcx>,
+        mir_def_id: DefId,
+        fr: RegionVid,
+        outlived_fr: RegionVid,
+        blame_span: Span,
+    ) {
+        // Obviously uncool error reporting.
+
+        let fr_name = self.to_error_region(fr);
+        let outlived_fr_name = self.to_error_region(outlived_fr);
+
+        if let (Some(f), Some(o)) = (fr_name, outlived_fr_name) {
+            let tables = infcx.tcx.typeck_tables_of(mir_def_id);
+            let nice = NiceRegionError::new_from_span(infcx.tcx, blame_span, o, f, Some(tables));
+            if let Some(_error_reported) = nice.try_report() {
+                return;
+            }
+        }
+
+        let constraints = self.find_constraint_paths_from_region(fr.clone());
+        let path = constraints.iter().min_by_key(|p| p.len()).unwrap();
+        debug!("report_error: path={:?}", path);
+
+        let path = path.iter()
+            .filter(|index| self.constraint_is_interesting(index))
+            .collect::<Vec<&ConstraintIndex>>();
+        debug!("report_error: path={:?}", path);
+
+        let mut categorized_path = path.iter().filter_map(|index| {
+            self.constraints.get(**index).iter().filter_map(|constraint| {
+                let span = constraint.locations.span(mir);
+                constraint.locations.from_location().iter().filter_map(|location| {
+                    let classification = self.classify_constraint(*location, mir);
+                    Some((classification, span))
+                }).next()
+            }).next()
+        }).collect::<Vec<(ConstraintCategory, Span)>>();
+        debug!("report_error: categorized_path={:?}", categorized_path);
+
+        categorized_path.sort_by(|p0, p1| p0.0.cmp(&p1.0));
+        debug!("report_error: sorted_path={:?}", categorized_path);
+
+        if categorized_path.len() > 0 {
+            let blame_constraint = &categorized_path[0];
+
+            let mut diag = infcx.tcx.sess.struct_span_err(
+                blame_constraint.1,
+                &format!("{:?}", blame_constraint.0),
+            );
+
+            for secondary in categorized_path.iter().skip(1) {
+                diag.span_label(secondary.1, format!("{:?}", secondary.0));
+            }
+
+            diag.emit();
+        } else {
+            let fr_string = match fr_name {
+                Some(r) => format!("free region `{}`", r),
+                None => format!("free region `{:?}`", fr),
+            };
+
+            let outlived_fr_string = match outlived_fr_name {
+                Some(r) => format!("free region `{}`", r),
+                None => format!("free region `{:?}`", outlived_fr),
+            };
+
+            let mut diag = infcx.tcx.sess.struct_span_err(
+                blame_span,
+                &format!("{} does not outlive {}", fr_string, outlived_fr_string,),
+            );
+
+            diag.emit();
+        }
+    }
+
+    crate fn why_region_contains_point(&self, fr1: RegionVid, elem: Location) -> Option<Cause> {
+        // Find some constraint `X: Y` where:
+        // - `fr1: X` transitively
+        // - and `Y` is live at `elem`
+        let index = self.blame_constraint(fr1, elem);
+        let region_sub = self.constraints[index].sub;
+
+        // then return why `Y` was live at `elem`
+        self.liveness_constraints.cause(region_sub, elem)
+    }
+
+    /// Tries to finds a good span to blame for the fact that `fr1`
+    /// contains `fr2`.
+    pub(super) fn blame_constraint(&self, fr1: RegionVid,
+                                   elem: impl ToElementIndex) -> ConstraintIndex {
+        // Find everything that influenced final value of `fr`.
+        let influenced_fr1 = self.dependencies(fr1);
+
+        // Try to find some outlives constraint `'X: fr2` where `'X`
+        // influenced `fr1`. Blame that.
+        //
+        // NB, this is a pretty bad choice most of the time. In
+        // particular, the connection between `'X` and `fr1` may not
+        // be obvious to the user -- not to mention the naive notion
+        // of dependencies, which doesn't account for the locations of
+        // contraints at all. But it will do for now.
+        let relevant_constraint = self.constraints
+            .iter_enumerated()
+            .filter_map(|(i, constraint)| {
+                if !self.liveness_constraints.contains(constraint.sub, elem) {
+                    None
+                } else {
+                    influenced_fr1[constraint.sup]
+                        .map(|distance| (distance, i))
+                }
+            })
+            .min() // constraining fr1 with fewer hops *ought* to be more obvious
+            .map(|(_dist, i)| i);
+
+        relevant_constraint.unwrap_or_else(|| {
+            bug!(
+                "could not find any constraint to blame for {:?}: {:?}",
+                fr1,
+                elem,
+            );
+        })
+    }
+
+    /// Finds all regions whose values `'a` may depend on in some way.
+    /// For each region, returns either `None` (does not influence
+    /// `'a`) or `Some(d)` which indicates that it influences `'a`
+    /// with distinct `d` (minimum number of edges that must be
+    /// traversed).
+    ///
+    /// Used during error reporting, extremely naive and inefficient.
+    fn dependencies(&self, r0: RegionVid) -> IndexVec<RegionVid, Option<usize>> {
+        let mut result_set = IndexVec::from_elem(None, &self.definitions);
+        let mut changed = true;
+        result_set[r0] = Some(0); // distance 0 from `r0`
+
+        while changed {
+            changed = false;
+            for constraint in &*self.constraints {
+                if let Some(n) = result_set[constraint.sup] {
+                    let m = n + 1;
+                    if result_set[constraint.sub]
+                        .map(|distance| m < distance)
+                        .unwrap_or(true)
+                    {
+                        result_set[constraint.sub] = Some(m);
+                        changed = true;
+                    }
+                }
+            }
+        }
+
+        result_set
+    }
+}

--- a/src/librustc_mir/borrow_check/nll/region_infer/graphviz.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/graphviz.rs
@@ -44,7 +44,7 @@ impl<'this, 'tcx> dot::Labeller<'this> for RegionInferenceContext<'tcx> {
         dot::LabelText::LabelStr(format!("{:?}", n).into_cow())
     }
     fn edge_label(&'this self, e: &OutlivesConstraint) -> dot::LabelText<'this> {
-        dot::LabelText::LabelStr(format!("{:?}", e.span).into_cow())
+        dot::LabelText::LabelStr(format!("{:?}", e.locations).into_cow())
     }
 }
 

--- a/src/librustc_mir/borrow_check/nll/region_infer/graphviz.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/graphviz.rs
@@ -44,7 +44,7 @@ impl<'this, 'tcx> dot::Labeller<'this> for RegionInferenceContext<'tcx> {
         dot::LabelText::LabelStr(format!("{:?}", n).into_cow())
     }
     fn edge_label(&'this self, e: &OutlivesConstraint) -> dot::LabelText<'this> {
-        dot::LabelText::LabelStr(format!("{:?}", e.point).into_cow())
+        dot::LabelText::LabelStr(format!("{:?}", e.span).into_cow())
     }
 }
 

--- a/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
@@ -9,32 +9,28 @@
 // except according to those terms.
 
 use super::universal_regions::UniversalRegions;
-use borrow_check::nll::region_infer::values::ToElementIndex;
-use borrow_check::nll::constraint_set::{ConstraintIndex, ConstraintCategory, ConstraintSet};
-use borrow_check::nll::constraint_set::{OutlivesConstraint};
+use borrow_check::nll::constraint_set::{ConstraintIndex, ConstraintSet, OutlivesConstraint};
 use borrow_check::nll::type_check::Locations;
 use rustc::hir::def_id::DefId;
 use rustc::infer::canonical::QueryRegionConstraint;
-use rustc::infer::error_reporting::nice_region_error::NiceRegionError;
 use rustc::infer::region_constraints::{GenericKind, VarInfos};
 use rustc::infer::InferCtxt;
 use rustc::infer::NLLRegionVariableOrigin;
 use rustc::infer::RegionVariableOrigin;
 use rustc::mir::{
     ClosureOutlivesRequirement, ClosureOutlivesSubject, ClosureRegionRequirements, Local, Location,
-    Mir, StatementKind, TerminatorKind, Rvalue
+    Mir
 };
 use rustc::ty::{self, RegionVid, Ty, TyCtxt, TypeFoldable};
-use rustc::util::common::{self, ErrorReported};
+use rustc::util::common;
 use rustc_data_structures::bitvec::BitVector;
-use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::indexed_vec::{Idx, IndexVec};
 
 use std::rc::Rc;
-use syntax_pos::Span;
 
 mod annotation;
 mod dump_mir;
+mod error_reporting;
 mod graphviz;
 mod values;
 use self::values::{RegionValueElements, RegionValues};
@@ -965,296 +961,6 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             // in some cases.
             self.report_error(mir, infcx, mir_def_id, longer_fr, shorter_fr, blame_span);
         }
-    }
-
-    /// When reporting an error, it is useful to be able to determine which constraints influenced
-    /// the region being reported as an error. This function finds all of the paths from the
-    /// constraint.
-    fn find_constraint_paths_from_region(
-        &self,
-        r0: RegionVid
-    ) -> Vec<Vec<ConstraintIndex>> {
-        let constraints = self.constraints.clone();
-
-        // Mapping of regions to the previous region and constraint index that led to it.
-        let mut previous = FxHashMap();
-        // Regions yet to be visited.
-        let mut next = vec! [ r0 ];
-        // Regions that have been visited.
-        let mut visited = FxHashSet();
-        // Ends of paths.
-        let mut end_regions: Vec<RegionVid> = Vec::new();
-
-        // When we've still got points to visit...
-        while let Some(current) = next.pop() {
-            // ...take the next point...
-            debug!("find_constraint_paths_from_region: current={:?} next={:?}", current, next);
-
-            // ...find the edges containing it...
-            let mut upcoming = Vec::new();
-            for (index, constraint) in constraints.iter_enumerated() {
-                if constraint.sub == current {
-                    // ...add the regions that join us with to the path we've taken...
-                    debug!("find_constraint_paths_from_region: index={:?} constraint={:?}",
-                           index, constraint);
-                    let next_region = constraint.sup.clone();
-
-                    // ...unless we've visited it since this was added...
-                    if visited.contains(&next_region) {
-                        debug!("find_constraint_paths_from_region: skipping as visited");
-                        continue;
-                    }
-
-                    previous.insert(next_region, (index, Some(current)));
-                    upcoming.push(next_region);
-                }
-            }
-
-            if upcoming.is_empty() {
-                // If we didn't find any edges then this is the end of a path...
-                debug!("find_constraint_paths_from_region: new end region current={:?}", current);
-                end_regions.push(current);
-            } else {
-                // ...but, if we did find edges, then add these to the regions yet to visit...
-                debug!("find_constraint_paths_from_region: extend next upcoming={:?}", upcoming);
-                next.extend(upcoming);
-            }
-
-            // ...and don't visit it again.
-            visited.insert(current.clone());
-            debug!("find_constraint_paths_from_region: next={:?} visited={:?}", next, visited);
-        }
-
-        // Now we've visited each point, compute the final paths.
-        let mut paths: Vec<Vec<ConstraintIndex>> = Vec::new();
-        debug!("find_constraint_paths_from_region: end_regions={:?}", end_regions);
-        for end_region in end_regions {
-            debug!("find_constraint_paths_from_region: end_region={:?}", end_region);
-
-            // Get the constraint and region that led to this end point.
-            // We can unwrap as we know if end_point was in the vector that it
-            // must also be in our previous map.
-            let (mut index, mut region) = previous.get(&end_region).unwrap();
-            debug!("find_constraint_paths_from_region: index={:?} region={:?}", index, region);
-
-            // Keep track of the indices.
-            let mut path: Vec<ConstraintIndex> = vec![index];
-
-            while region.is_some() && region != Some(r0) {
-                let p = previous.get(&region.unwrap()).unwrap();
-                index = p.0;
-                region = p.1;
-
-                debug!("find_constraint_paths_from_region: index={:?} region={:?}", index, region);
-                path.push(index);
-            }
-
-            // Add to our paths.
-            paths.push(path);
-        }
-
-        debug!("find_constraint_paths_from_region: paths={:?}", paths);
-        paths
-    }
-
-    /// This function will return true if a constraint is interesting and false if a constraint
-    /// is not. It is useful in filtering constraint paths to only interesting points.
-    fn constraint_is_interesting(&self, index: &ConstraintIndex) -> bool {
-        self.constraints.get(*index).filter(|constraint| {
-            debug!("constraint_is_interesting: locations={:?} constraint={:?}",
-                   constraint.locations, constraint);
-            if let Locations::Interesting(_) = constraint.locations { true } else { false }
-        }).is_some()
-    }
-
-    /// This function classifies a constraint from a location.
-    fn classify_constraint(&self, location: Location, mir: &Mir<'tcx>) -> ConstraintCategory {
-        let data = &mir[location.block];
-        if location.statement_index == data.statements.len() {
-            if let Some(ref terminator) = data.terminator {
-                match terminator.kind {
-                    TerminatorKind::DropAndReplace { .. } => ConstraintCategory::Assignment,
-                    TerminatorKind::Call { .. } => ConstraintCategory::CallArgument,
-                    _ => ConstraintCategory::Other,
-                }
-            } else {
-                ConstraintCategory::Other
-            }
-        } else {
-            let statement = &data.statements[location.statement_index];
-            match statement.kind {
-                StatementKind::Assign(_, ref rvalue) => match rvalue {
-                    Rvalue::Cast(..) => ConstraintCategory::Cast,
-                    Rvalue::Use(..) => ConstraintCategory::Assignment,
-                    _ => ConstraintCategory::Other,
-                },
-                _ => ConstraintCategory::Other,
-            }
-        }
-    }
-
-    /// Report an error because the universal region `fr` was required to outlive
-    /// `outlived_fr` but it is not known to do so. For example:
-    ///
-    /// ```
-    /// fn foo<'a, 'b>(x: &'a u32) -> &'b u32 { x }
-    /// ```
-    ///
-    /// Here we would be invoked with `fr = 'a` and `outlived_fr = `'b`.
-    fn report_error(
-        &self,
-        mir: &Mir<'tcx>,
-        infcx: &InferCtxt<'_, '_, 'tcx>,
-        mir_def_id: DefId,
-        fr: RegionVid,
-        outlived_fr: RegionVid,
-        blame_span: Span,
-    ) {
-        // Obviously uncool error reporting.
-
-        let fr_name = self.to_error_region(fr);
-        let outlived_fr_name = self.to_error_region(outlived_fr);
-
-        if let (Some(f), Some(o)) = (fr_name, outlived_fr_name) {
-            let tables = infcx.tcx.typeck_tables_of(mir_def_id);
-            let nice = NiceRegionError::new_from_span(infcx.tcx, blame_span, o, f, Some(tables));
-            if let Some(ErrorReported) = nice.try_report() {
-                return;
-            }
-        }
-
-        let constraints = self.find_constraint_paths_from_region(fr.clone());
-        let path = constraints.iter().min_by_key(|p| p.len()).unwrap();
-        debug!("report_error: path={:?}", path);
-
-        let path = path.iter()
-            .filter(|index| self.constraint_is_interesting(index))
-            .collect::<Vec<&ConstraintIndex>>();
-        debug!("report_error: path={:?}", path);
-
-        let mut categorized_path = path.iter().filter_map(|index| {
-            self.constraints.get(**index).iter().filter_map(|constraint| {
-                let span = constraint.locations.span(mir);
-                constraint.locations.from_location().iter().filter_map(|location| {
-                    let classification = self.classify_constraint(*location, mir);
-                    Some((classification, span))
-                }).next()
-            }).next()
-        }).collect::<Vec<(ConstraintCategory, Span)>>();
-        debug!("report_error: categorized_path={:?}", categorized_path);
-
-        categorized_path.sort_by(|p0, p1| p0.0.cmp(&p1.0));
-        debug!("report_error: sorted_path={:?}", categorized_path);
-
-        if categorized_path.len() > 0 {
-            let blame_constraint = &categorized_path[0];
-
-            let mut diag = infcx.tcx.sess.struct_span_err(
-                blame_constraint.1,
-                &format!("{:?}", blame_constraint.0),
-            );
-
-            for secondary in categorized_path.iter().skip(1) {
-                diag.span_label(secondary.1, format!("{:?}", secondary.0));
-            }
-
-            diag.emit();
-        } else {
-            let fr_string = match fr_name {
-                Some(r) => format!("free region `{}`", r),
-                None => format!("free region `{:?}`", fr),
-            };
-
-            let outlived_fr_string = match outlived_fr_name {
-                Some(r) => format!("free region `{}`", r),
-                None => format!("free region `{:?}`", outlived_fr),
-            };
-
-            let mut diag = infcx.tcx.sess.struct_span_err(
-                blame_span,
-                &format!("{} does not outlive {}", fr_string, outlived_fr_string,),
-            );
-
-            diag.emit();
-        }
-    }
-
-    crate fn why_region_contains_point(&self, fr1: RegionVid, elem: Location) -> Option<Cause> {
-        // Find some constraint `X: Y` where:
-        // - `fr1: X` transitively
-        // - and `Y` is live at `elem`
-        let index = self.blame_constraint(fr1, elem);
-        let region_sub = self.constraints[index].sub;
-
-        // then return why `Y` was live at `elem`
-        self.liveness_constraints.cause(region_sub, elem)
-    }
-
-    /// Tries to finds a good span to blame for the fact that `fr1`
-    /// contains `fr2`.
-    fn blame_constraint(&self, fr1: RegionVid, elem: impl ToElementIndex) -> ConstraintIndex {
-        // Find everything that influenced final value of `fr`.
-        let influenced_fr1 = self.dependencies(fr1);
-
-        // Try to find some outlives constraint `'X: fr2` where `'X`
-        // influenced `fr1`. Blame that.
-        //
-        // NB, this is a pretty bad choice most of the time. In
-        // particular, the connection between `'X` and `fr1` may not
-        // be obvious to the user -- not to mention the naive notion
-        // of dependencies, which doesn't account for the locations of
-        // contraints at all. But it will do for now.
-        let relevant_constraint = self.constraints
-            .iter_enumerated()
-            .filter_map(|(i, constraint)| {
-                if !self.liveness_constraints.contains(constraint.sub, elem) {
-                    None
-                } else {
-                    influenced_fr1[constraint.sup]
-                        .map(|distance| (distance, i))
-                }
-            })
-            .min() // constraining fr1 with fewer hops *ought* to be more obvious
-            .map(|(_dist, i)| i);
-
-        relevant_constraint.unwrap_or_else(|| {
-            bug!(
-                "could not find any constraint to blame for {:?}: {:?}",
-                fr1,
-                elem,
-            );
-        })
-    }
-
-    /// Finds all regions whose values `'a` may depend on in some way.
-    /// For each region, returns either `None` (does not influence
-    /// `'a`) or `Some(d)` which indicates that it influences `'a`
-    /// with distinct `d` (minimum number of edges that must be
-    /// traversed).
-    ///
-    /// Used during error reporting, extremely naive and inefficient.
-    fn dependencies(&self, r0: RegionVid) -> IndexVec<RegionVid, Option<usize>> {
-        let mut result_set = IndexVec::from_elem(None, &self.definitions);
-        let mut changed = true;
-        result_set[r0] = Some(0); // distance 0 from `r0`
-
-        while changed {
-            changed = false;
-            for constraint in self.constraints.iter() {
-                if let Some(n) = result_set[constraint.sup] {
-                    let m = n + 1;
-                    if result_set[constraint.sub]
-                        .map(|distance| m < distance)
-                        .unwrap_or(true)
-                    {
-                        result_set[constraint.sub] = Some(m);
-                        changed = true;
-                    }
-                }
-            }
-        }
-
-        result_set
     }
 }
 

--- a/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
@@ -359,14 +359,12 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         span: Span,
         sup: RegionVid,
         sub: RegionVid,
-        point: Location,
     ) {
         assert!(self.inferred_values.is_none(), "values already inferred");
         self.constraints.push(OutlivesConstraint {
             span,
             sup,
             sub,
-            point,
             next: None,
         })
     }
@@ -503,7 +501,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         for type_test in &self.type_tests {
             debug!("check_type_test: {:?}", type_test);
 
-            if self.eval_region_test(mir, type_test.point, type_test.lower_bound, &type_test.test) {
+            if self.eval_region_test(mir, type_test.lower_bound, &type_test.test) {
                 continue;
             }
 
@@ -765,31 +763,30 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     fn eval_region_test(
         &self,
         mir: &Mir<'tcx>,
-        point: Location,
         lower_bound: RegionVid,
         test: &RegionTest,
     ) -> bool {
         debug!(
-            "eval_region_test(point={:?}, lower_bound={:?}, test={:?})",
-            point, lower_bound, test
+            "eval_region_test(lower_bound={:?}, test={:?})",
+            lower_bound, test
         );
 
         match test {
             RegionTest::IsOutlivedByAllRegionsIn(regions) => regions
                 .iter()
-                .all(|&r| self.eval_outlives(mir, r, lower_bound, point)),
+                .all(|&r| self.eval_outlives(mir, r, lower_bound)),
 
             RegionTest::IsOutlivedByAnyRegionIn(regions) => regions
                 .iter()
-                .any(|&r| self.eval_outlives(mir, r, lower_bound, point)),
+                .any(|&r| self.eval_outlives(mir, r, lower_bound)),
 
             RegionTest::Any(tests) => tests
                 .iter()
-                .any(|test| self.eval_region_test(mir, point, lower_bound, test)),
+                .any(|test| self.eval_region_test(mir, lower_bound, test)),
 
             RegionTest::All(tests) => tests
                 .iter()
-                .all(|test| self.eval_region_test(mir, point, lower_bound, test)),
+                .all(|test| self.eval_region_test(mir, lower_bound, test)),
         }
     }
 
@@ -799,11 +796,10 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         _mir: &Mir<'tcx>,
         sup_region: RegionVid,
         sub_region: RegionVid,
-        point: Location,
     ) -> bool {
         debug!(
-            "eval_outlives({:?}: {:?} @ {:?})",
-            sup_region, sub_region, point
+            "eval_outlives({:?}: {:?})",
+            sup_region, sub_region
         );
 
         let inferred_values = self

--- a/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
@@ -978,20 +978,17 @@ impl<'tcx> RegionInferenceContext<'tcx> {
 
         // Mapping of regions to the previous region and constraint index that led to it.
         let mut previous = FxHashMap();
-        // Current region in traversal.
-        let mut current = r0;
         // Regions yet to be visited.
-        let mut next = vec! [ current ];
+        let mut next = vec! [ r0 ];
         // Regions that have been visited.
         let mut visited = FxHashSet();
         // Ends of paths.
         let mut end_regions: Vec<RegionVid> = Vec::new();
 
         // When we've still got points to visit...
-        while !next.is_empty() {
+        while let Some(current) = next.pop() {
             // ...take the next point...
-            debug!("find_constraint_paths_from_region: next={:?}", next);
-            current = next.pop().unwrap(); // Can unwrap here as we know the vector is not empty.
+            debug!("find_constraint_paths_from_region: current={:?} next={:?}", current, next);
 
             // ...find the edges containing it...
             let mut upcoming = Vec::new();

--- a/src/librustc_mir/borrow_check/nll/type_check/constraint_conversion.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/constraint_conversion.rs
@@ -146,7 +146,7 @@ impl<'a, 'gcx, 'tcx> ConstraintConversion<'a, 'gcx, 'tcx> {
     ) -> TypeTest<'tcx> {
         let lower_bound = self.to_region_vid(region);
 
-        let point = self.locations.at_location().unwrap_or(Location::START);
+        let point = self.locations.from_location().unwrap_or(Location::START);
 
         let test = self.verify_bound_to_region_test(&bound);
 
@@ -197,13 +197,11 @@ impl<'a, 'gcx, 'tcx> ConstraintConversion<'a, 'gcx, 'tcx> {
 
     fn add_outlives(&mut self, sup: ty::RegionVid, sub: ty::RegionVid) {
         let span = self.span();
-        let point = self.locations.at_location().unwrap_or(Location::START);
 
         self.outlives_constraints.push(OutlivesConstraint {
             span,
             sub,
             sup,
-            point,
             next: None,
         });
     }

--- a/src/librustc_mir/borrow_check/nll/type_check/liveness.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/liveness.rs
@@ -199,7 +199,7 @@ impl<'gen, 'typeck, 'flow, 'gcx, 'tcx> TypeLivenessGenerator<'gen, 'typeck, 'flo
         });
 
         if let Some(data) = &drop_data.region_constraint_data {
-            self.cx.push_region_constraints(location.at_self(), data);
+            self.cx.push_region_constraints(location.boring(), data);
         }
 
         drop_data.dropck_result.report_overflows(

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -1614,7 +1614,7 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
         }
     }
 
-    fn normalize<T>(&mut self, value: T, location: impl ToLocations) -> T
+    fn normalize<T>(&mut self, value: T, location: impl NormalizeLocation) -> T
     where
         T: type_op::normalize::Normalizable<'gcx, 'tcx> + Copy,
     {
@@ -1701,17 +1701,17 @@ impl AtLocation for Location {
     }
 }
 
-trait ToLocations: fmt::Debug + Copy {
+trait NormalizeLocation: fmt::Debug + Copy {
     fn to_locations(self) -> Locations;
 }
 
-impl ToLocations for Locations {
+impl NormalizeLocation for Locations {
     fn to_locations(self) -> Locations {
         self
     }
 }
 
-impl ToLocations for Location {
+impl NormalizeLocation for Location {
     fn to_locations(self) -> Locations {
         self.at_self()
     }

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -1523,7 +1523,10 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
             AggregateKind::Array(_) | AggregateKind::Tuple => ty::InstantiatedPredicates::empty(),
         };
 
-        self.normalize_and_prove_instantiated_predicates(instantiated_predicates, location.boring());
+        self.normalize_and_prove_instantiated_predicates(
+            instantiated_predicates,
+            location.boring(),
+        );
     }
 
     fn prove_trait_ref(&mut self, trait_ref: ty::TraitRef<'tcx>, locations: Locations) {

--- a/src/test/ui/borrowck/issue-45983.nll.stderr
+++ b/src/test/ui/borrowck/issue-45983.nll.stderr
@@ -4,7 +4,7 @@ warning: not reporting region error due to nll
 LL |     give_any(|y| x = Some(y));
    |                           ^
 
-error: free region `` does not outlive free region `'_#2r`
+error: Assignment requires that data must outlive free region `'_#2r`
   --> $DIR/issue-45983.rs:17:27
    |
 LL |     give_any(|y| x = Some(y));

--- a/src/test/ui/borrowck/issue-45983.nll.stderr
+++ b/src/test/ui/borrowck/issue-45983.nll.stderr
@@ -4,7 +4,7 @@ warning: not reporting region error due to nll
 LL |     give_any(|y| x = Some(y));
    |                           ^
 
-error: assignment requires that data must outlive free region `'_#2r`
+error: free region `` does not outlive free region `'_#2r`
   --> $DIR/issue-45983.rs:17:27
    |
 LL |     give_any(|y| x = Some(y));

--- a/src/test/ui/borrowck/issue-45983.nll.stderr
+++ b/src/test/ui/borrowck/issue-45983.nll.stderr
@@ -4,7 +4,7 @@ warning: not reporting region error due to nll
 LL |     give_any(|y| x = Some(y));
    |                           ^
 
-error: Assignment requires that data must outlive free region `'_#2r`
+error: assignment requires that data must outlive free region `'_#2r`
   --> $DIR/issue-45983.rs:17:27
    |
 LL |     give_any(|y| x = Some(y));

--- a/src/test/ui/borrowck/regions-escape-bound-fn-2.nll.stderr
+++ b/src/test/ui/borrowck/regions-escape-bound-fn-2.nll.stderr
@@ -4,7 +4,7 @@ warning: not reporting region error due to nll
 LL |     with_int(|y| x = Some(y));
    |                           ^
 
-error: Assignment requires that data must outlive free region `'_#2r`
+error: assignment requires that data must outlive free region `'_#2r`
   --> $DIR/regions-escape-bound-fn-2.rs:18:27
    |
 LL |     with_int(|y| x = Some(y));

--- a/src/test/ui/borrowck/regions-escape-bound-fn-2.nll.stderr
+++ b/src/test/ui/borrowck/regions-escape-bound-fn-2.nll.stderr
@@ -4,7 +4,7 @@ warning: not reporting region error due to nll
 LL |     with_int(|y| x = Some(y));
    |                           ^
 
-error: free region `` does not outlive free region `'_#2r`
+error: Assignment requires that data must outlive free region `'_#2r`
   --> $DIR/regions-escape-bound-fn-2.rs:18:27
    |
 LL |     with_int(|y| x = Some(y));

--- a/src/test/ui/borrowck/regions-escape-bound-fn-2.nll.stderr
+++ b/src/test/ui/borrowck/regions-escape-bound-fn-2.nll.stderr
@@ -4,7 +4,7 @@ warning: not reporting region error due to nll
 LL |     with_int(|y| x = Some(y));
    |                           ^
 
-error: assignment requires that data must outlive free region `'_#2r`
+error: free region `` does not outlive free region `'_#2r`
   --> $DIR/regions-escape-bound-fn-2.rs:18:27
    |
 LL |     with_int(|y| x = Some(y));

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.rs
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.rs
@@ -31,7 +31,7 @@ fn case1() {
     foo(cell, |cell_a, cell_x| {
         //~^ WARNING not reporting region error due to nll
         cell_a.set(cell_x.get()); // forces 'x: 'a, error in closure
-        //~^ ERROR does not outlive free region
+        //~^ ERROR Argument requires that data must outlive free region
     })
 }
 

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.rs
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.rs
@@ -31,7 +31,7 @@ fn case1() {
     foo(cell, |cell_a, cell_x| {
         //~^ WARNING not reporting region error due to nll
         cell_a.set(cell_x.get()); // forces 'x: 'a, error in closure
-        //~^ ERROR Argument requires that data must outlive free region
+        //~^ ERROR argument requires that data must outlive free region
     })
 }
 

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -4,11 +4,11 @@ warning: not reporting region error due to nll
 LL |     foo(cell, |cell_a, cell_x| {
    |     ^^^
 
-error: free region `ReFree(DefId(0/1:12 ~ propagate_approximated_shorter_to_static_comparing_against_free[317d]::case1[0]::{{closure}}[0]), BrAnon(1))` does not outlive free region `'_#1r`
-  --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:33:9
+error: Argument requires that data must outlive free region `'_#1r`
+  --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:33:20
    |
 LL |         cell_a.set(cell_x.get()); // forces 'x: 'a, error in closure
-   |         ^^^^^^
+   |                    ^^^^^^^^^^^^
 
 note: No external requirements
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:31:15
@@ -17,7 +17,7 @@ LL |       foo(cell, |cell_a, cell_x| {
    |  _______________^
 LL | |         //~^ WARNING not reporting region error due to nll
 LL | |         cell_a.set(cell_x.get()); // forces 'x: 'a, error in closure
-LL | |         //~^ ERROR does not outlive free region
+LL | |         //~^ ERROR Argument requires that data must outlive free region
 LL | |     })
    | |_____^
    |

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -4,7 +4,7 @@ warning: not reporting region error due to nll
 LL |     foo(cell, |cell_a, cell_x| {
    |     ^^^
 
-error: Argument requires that data must outlive free region `'_#1r`
+error: argument requires that data must outlive free region `'_#1r`
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:33:20
    |
 LL |         cell_a.set(cell_x.get()); // forces 'x: 'a, error in closure
@@ -17,7 +17,7 @@ LL |       foo(cell, |cell_a, cell_x| {
    |  _______________^
 LL | |         //~^ WARNING not reporting region error due to nll
 LL | |         cell_a.set(cell_x.get()); // forces 'x: 'a, error in closure
-LL | |         //~^ ERROR Argument requires that data must outlive free region
+LL | |         //~^ ERROR argument requires that data must outlive free region
 LL | |     })
    | |_____^
    |

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.rs
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.rs
@@ -43,7 +43,7 @@ fn demand_y<'x, 'y>(_cell_x: &Cell<&'x u32>, _cell_y: &Cell<&'y u32>, _y: &'y u3
 #[rustc_regions]
 fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
-        //~^ ERROR does not outlive free region
+        //~^ ERROR Argument requires that data must outlive free region
 
         // Only works if 'x: 'y:
         demand_y(x, y, x.get()) //~ WARNING not reporting region error due to nll

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.rs
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.rs
@@ -43,7 +43,7 @@ fn demand_y<'x, 'y>(_cell_x: &Cell<&'x u32>, _cell_y: &Cell<&'y u32>, _y: &'y u3
 #[rustc_regions]
 fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
-        //~^ ERROR Argument requires that data must outlive free region
+        //~^ ERROR argument requires that data must outlive free region
 
         // Only works if 'x: 'y:
         demand_y(x, y, x.get()) //~ WARNING not reporting region error due to nll

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
@@ -32,7 +32,7 @@ LL | |
 LL | |         // Only works if 'x: 'y:
 LL | |         demand_y(x, y, x.get()) //~ WARNING not reporting region error due to nll
 LL | |     });
-   | |_____^
+   | |______^
 
 note: No external requirements
   --> $DIR/propagate-approximated-shorter-to-static-no-bound.rs:44:1

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
@@ -9,7 +9,7 @@ note: External requirements
    |
 LL |       establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
    |  _______________________________________________^
-LL | |         //~^ ERROR does not outlive free region
+LL | |         //~^ ERROR Argument requires that data must outlive free region
 LL | |
 LL | |         // Only works if 'x: 'y:
 LL | |         demand_y(x, y, x.get()) //~ WARNING not reporting region error due to nll
@@ -23,12 +23,11 @@ LL | |     });
    = note: number of external vids: 2
    = note: where '_#1r: '_#0r
 
-error: free region `ReFree(DefId(0/0:6 ~ propagate_approximated_shorter_to_static_no_bound[317d]::supply[0]), BrNamed(crate0:DefIndex(1:16), 'a))` does not outlive free region `ReStatic`
-  --> $DIR/propagate-approximated-shorter-to-static-no-bound.rs:45:47
+error: Argument requires that data must outlive free region `ReStatic`
+  --> $DIR/propagate-approximated-shorter-to-static-no-bound.rs:45:5
    |
-LL |       establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
-   |  _______________________________________________^
-LL | |         //~^ ERROR does not outlive free region
+LL | /     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
+LL | |         //~^ ERROR Argument requires that data must outlive free region
 LL | |
 LL | |         // Only works if 'x: 'y:
 LL | |         demand_y(x, y, x.get()) //~ WARNING not reporting region error due to nll
@@ -40,7 +39,7 @@ note: No external requirements
    |
 LL | / fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
 LL | |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
-LL | |         //~^ ERROR does not outlive free region
+LL | |         //~^ ERROR Argument requires that data must outlive free region
 LL | |
 ...  |
 LL | |     });

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
@@ -9,7 +9,7 @@ note: External requirements
    |
 LL |       establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
    |  _______________________________________________^
-LL | |         //~^ ERROR Argument requires that data must outlive free region
+LL | |         //~^ ERROR argument requires that data must outlive free region
 LL | |
 LL | |         // Only works if 'x: 'y:
 LL | |         demand_y(x, y, x.get()) //~ WARNING not reporting region error due to nll
@@ -23,11 +23,11 @@ LL | |     });
    = note: number of external vids: 2
    = note: where '_#1r: '_#0r
 
-error: Argument requires that data must outlive free region `ReStatic`
+error: argument requires that data must outlive free region `ReStatic`
   --> $DIR/propagate-approximated-shorter-to-static-no-bound.rs:45:5
    |
 LL | /     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
-LL | |         //~^ ERROR Argument requires that data must outlive free region
+LL | |         //~^ ERROR argument requires that data must outlive free region
 LL | |
 LL | |         // Only works if 'x: 'y:
 LL | |         demand_y(x, y, x.get()) //~ WARNING not reporting region error due to nll
@@ -39,7 +39,7 @@ note: No external requirements
    |
 LL | / fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
 LL | |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
-LL | |         //~^ ERROR Argument requires that data must outlive free region
+LL | |         //~^ ERROR argument requires that data must outlive free region
 LL | |
 ...  |
 LL | |     });

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.rs
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.rs
@@ -46,7 +46,7 @@ fn demand_y<'x, 'y>(_cell_x: &Cell<&'x u32>, _cell_y: &Cell<&'y u32>, _y: &'y u3
 #[rustc_regions]
 fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
-        //~^ ERROR Argument requires that data must outlive free region
+        //~^ ERROR argument requires that data must outlive free region
         // Only works if 'x: 'y:
         demand_y(x, y, x.get())
         //~^ WARNING not reporting region error due to nll

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.rs
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.rs
@@ -46,7 +46,7 @@ fn demand_y<'x, 'y>(_cell_x: &Cell<&'x u32>, _cell_y: &Cell<&'y u32>, _y: &'y u3
 #[rustc_regions]
 fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
-        //~^ ERROR does not outlive free region
+        //~^ ERROR Argument requires that data must outlive free region
         // Only works if 'x: 'y:
         demand_y(x, y, x.get())
         //~^ WARNING not reporting region error due to nll

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
@@ -9,7 +9,7 @@ note: External requirements
    |
 LL |       establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
    |  _______________________________________________^
-LL | |         //~^ ERROR Argument requires that data must outlive free region
+LL | |         //~^ ERROR argument requires that data must outlive free region
 LL | |         // Only works if 'x: 'y:
 LL | |         demand_y(x, y, x.get())
 LL | |         //~^ WARNING not reporting region error due to nll
@@ -23,11 +23,11 @@ LL | |     });
    = note: number of external vids: 3
    = note: where '_#1r: '_#0r
 
-error: Argument requires that data must outlive free region `ReStatic`
+error: argument requires that data must outlive free region `ReStatic`
   --> $DIR/propagate-approximated-shorter-to-static-wrong-bound.rs:48:5
    |
 LL | /     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
-LL | |         //~^ ERROR Argument requires that data must outlive free region
+LL | |         //~^ ERROR argument requires that data must outlive free region
 LL | |         // Only works if 'x: 'y:
 LL | |         demand_y(x, y, x.get())
 LL | |         //~^ WARNING not reporting region error due to nll
@@ -39,7 +39,7 @@ note: No external requirements
    |
 LL | / fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
 LL | |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
-LL | |         //~^ ERROR Argument requires that data must outlive free region
+LL | |         //~^ ERROR argument requires that data must outlive free region
 LL | |         // Only works if 'x: 'y:
 ...  |
 LL | |     });

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
@@ -9,7 +9,7 @@ note: External requirements
    |
 LL |       establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
    |  _______________________________________________^
-LL | |         //~^ ERROR does not outlive free region
+LL | |         //~^ ERROR Argument requires that data must outlive free region
 LL | |         // Only works if 'x: 'y:
 LL | |         demand_y(x, y, x.get())
 LL | |         //~^ WARNING not reporting region error due to nll
@@ -23,12 +23,11 @@ LL | |     });
    = note: number of external vids: 3
    = note: where '_#1r: '_#0r
 
-error: free region `ReFree(DefId(0/0:6 ~ propagate_approximated_shorter_to_static_wrong_bound[317d]::supply[0]), BrNamed(crate0:DefIndex(1:16), 'a))` does not outlive free region `ReStatic`
-  --> $DIR/propagate-approximated-shorter-to-static-wrong-bound.rs:48:47
+error: Argument requires that data must outlive free region `ReStatic`
+  --> $DIR/propagate-approximated-shorter-to-static-wrong-bound.rs:48:5
    |
-LL |       establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
-   |  _______________________________________________^
-LL | |         //~^ ERROR does not outlive free region
+LL | /     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
+LL | |         //~^ ERROR Argument requires that data must outlive free region
 LL | |         // Only works if 'x: 'y:
 LL | |         demand_y(x, y, x.get())
 LL | |         //~^ WARNING not reporting region error due to nll
@@ -40,7 +39,7 @@ note: No external requirements
    |
 LL | / fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
 LL | |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
-LL | |         //~^ ERROR does not outlive free region
+LL | |         //~^ ERROR Argument requires that data must outlive free region
 LL | |         // Only works if 'x: 'y:
 ...  |
 LL | |     });

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
@@ -32,7 +32,7 @@ LL | |         // Only works if 'x: 'y:
 LL | |         demand_y(x, y, x.get())
 LL | |         //~^ WARNING not reporting region error due to nll
 LL | |     });
-   | |_____^
+   | |______^
 
 note: No external requirements
   --> $DIR/propagate-approximated-shorter-to-static-wrong-bound.rs:47:1

--- a/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.rs
+++ b/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.rs
@@ -46,7 +46,7 @@ fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
         // Only works if 'x: 'y:
         demand_y(x, y, x.get())
         //~^ WARN not reporting region error due to nll
-        //~| ERROR does not outlive free region
+        //~| ERROR Argument requires that data must outlive free region
     });
 }
 

--- a/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.rs
+++ b/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.rs
@@ -46,7 +46,7 @@ fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
         // Only works if 'x: 'y:
         demand_y(x, y, x.get())
         //~^ WARN not reporting region error due to nll
-        //~| ERROR Argument requires that data must outlive free region
+        //~| ERROR argument requires that data must outlive free region
     });
 }
 

--- a/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
@@ -4,11 +4,11 @@ warning: not reporting region error due to nll
 LL |         demand_y(x, y, x.get())
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: free region `ReFree(DefId(0/1:18 ~ propagate_fail_to_approximate_longer_no_bounds[317d]::supply[0]::{{closure}}[0]), BrAnon(4))` does not outlive free region `ReFree(DefId(0/1:18 ~ propagate_fail_to_approximate_longer_no_bounds[317d]::supply[0]::{{closure}}[0]), BrAnon(2))`
-  --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:47:18
+error: Argument requires that data must outlive free region `ReFree(DefId(0/1:18 ~ propagate_fail_to_approximate_longer_no_bounds[317d]::supply[0]::{{closure}}[0]), BrAnon(2))`
+  --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:47:9
    |
 LL |         demand_y(x, y, x.get())
-   |                  ^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 note: No external requirements
   --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:45:47
@@ -18,7 +18,7 @@ LL |       establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
 LL | |         // Only works if 'x: 'y:
 LL | |         demand_y(x, y, x.get())
 LL | |         //~^ WARN not reporting region error due to nll
-LL | |         //~| ERROR does not outlive free region
+LL | |         //~| ERROR Argument requires that data must outlive free region
 LL | |     });
    | |_____^
    |

--- a/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
@@ -4,7 +4,7 @@ warning: not reporting region error due to nll
 LL |         demand_y(x, y, x.get())
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Argument requires that data must outlive free region `ReFree(DefId(0/1:18 ~ propagate_fail_to_approximate_longer_no_bounds[317d]::supply[0]::{{closure}}[0]), BrAnon(2))`
+error: argument requires that data must outlive free region `ReFree(DefId(0/1:18 ~ propagate_fail_to_approximate_longer_no_bounds[317d]::supply[0]::{{closure}}[0]), BrAnon(2))`
   --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:47:9
    |
 LL |         demand_y(x, y, x.get())
@@ -18,7 +18,7 @@ LL |       establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
 LL | |         // Only works if 'x: 'y:
 LL | |         demand_y(x, y, x.get())
 LL | |         //~^ WARN not reporting region error due to nll
-LL | |         //~| ERROR Argument requires that data must outlive free region
+LL | |         //~| ERROR argument requires that data must outlive free region
 LL | |     });
    | |_____^
    |

--- a/src/test/ui/nll/issue-50716.rs
+++ b/src/test/ui/nll/issue-50716.rs
@@ -22,7 +22,7 @@ where
     for<'b> &'b T: A,
     <&'static T as A>::X: Sized
 {
-    let _x = *s; //~ ERROR free region `'a` does not outlive free region `'static`
+    let _x = *s; //~ ERROR assignment requires that data must outlive free region `'static`
 }
 
 fn main() {}

--- a/src/test/ui/nll/issue-50716.stderr
+++ b/src/test/ui/nll/issue-50716.stderr
@@ -1,7 +1,7 @@
-error: free region `'a` does not outlive free region `'static`
+error: assignment requires that data must outlive free region `'static`
   --> $DIR/issue-50716.rs:25:14
    |
-LL |     let _x = *s; //~ ERROR free region `'a` does not outlive free region `'static`
+LL |     let _x = *s; //~ ERROR assignment requires that data must outlive free region `'static`
    |              ^^
 
 error: aborting due to previous error

--- a/src/test/ui/nll/ty-outlives/projection-one-region-closure.rs
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-closure.rs
@@ -55,7 +55,7 @@ where
     with_signature(cell, t, |cell, t| require(cell, t));
     //~^ WARNING not reporting region error due to nll
     //~| ERROR the parameter type `T` may not live long enough
-    //~| ERROR Argument requires that data must outlive free region
+    //~| ERROR argument requires that data must outlive free region
 }
 
 #[rustc_regions]
@@ -67,7 +67,7 @@ where
     with_signature(cell, t, |cell, t| require(cell, t));
     //~^ WARNING not reporting region error due to nll
     //~| ERROR the parameter type `T` may not live long enough
-    //~| ERROR Argument requires that data must outlive free region
+    //~| ERROR argument requires that data must outlive free region
 }
 
 #[rustc_regions]
@@ -89,7 +89,7 @@ where
     with_signature(cell, t, |cell, t| require(cell, t));
     //~^ WARNING not reporting region error due to nll
     //~| ERROR the parameter type `T` may not live long enough
-    //~| ERROR Argument requires that data must outlive free region
+    //~| ERROR argument requires that data must outlive free region
 }
 
 #[rustc_regions]

--- a/src/test/ui/nll/ty-outlives/projection-one-region-closure.rs
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-closure.rs
@@ -55,7 +55,7 @@ where
     with_signature(cell, t, |cell, t| require(cell, t));
     //~^ WARNING not reporting region error due to nll
     //~| ERROR the parameter type `T` may not live long enough
-    //~| ERROR does not outlive free region
+    //~| ERROR Argument requires that data must outlive free region
 }
 
 #[rustc_regions]
@@ -67,7 +67,7 @@ where
     with_signature(cell, t, |cell, t| require(cell, t));
     //~^ WARNING not reporting region error due to nll
     //~| ERROR the parameter type `T` may not live long enough
-    //~| ERROR does not outlive free region
+    //~| ERROR Argument requires that data must outlive free region
 }
 
 #[rustc_regions]
@@ -89,7 +89,7 @@ where
     with_signature(cell, t, |cell, t| require(cell, t));
     //~^ WARNING not reporting region error due to nll
     //~| ERROR the parameter type `T` may not live long enough
-    //~| ERROR free region `ReEarlyBound(1, 'b)` does not outlive free region `ReEarlyBound(0, 'a)`
+    //~| ERROR Argument requires that data must outlive free region
 }
 
 #[rustc_regions]

--- a/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
@@ -40,11 +40,11 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |
    = help: consider adding an explicit lifetime bound `T: ReFree(DefId(0/0:8 ~ projection_one_region_closure[317d]::no_relationships_late[0]), BrNamed(crate0:DefIndex(1:16), 'a))`...
 
-error: free region `ReEarlyBound(0, 'b)` does not outlive free region `ReFree(DefId(0/0:8 ~ projection_one_region_closure[317d]::no_relationships_late[0]), BrNamed(crate0:DefIndex(1:16), 'a))`
-  --> $DIR/projection-one-region-closure.rs:55:20
+error: Argument requires that data must outlive free region `ReFree(DefId(0/0:8 ~ projection_one_region_closure[317d]::no_relationships_late[0]), BrNamed(crate0:DefIndex(1:16), 'a))`
+  --> $DIR/projection-one-region-closure.rs:55:5
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                    ^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: No external requirements
   --> $DIR/projection-one-region-closure.rs:51:1
@@ -54,7 +54,7 @@ LL | | where
 LL | |     T: Anything<'b>,
 LL | | {
 ...  |
-LL | |     //~| ERROR does not outlive free region
+LL | |     //~| ERROR Argument requires that data must outlive free region
 LL | | }
    | |_^
    |
@@ -88,11 +88,11 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |
    = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
 
-error: free region `ReEarlyBound(1, 'b)` does not outlive free region `ReEarlyBound(0, 'a)`
-  --> $DIR/projection-one-region-closure.rs:67:20
+error: Argument requires that data must outlive free region `ReEarlyBound(0, 'a)`
+  --> $DIR/projection-one-region-closure.rs:67:5
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                    ^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: No external requirements
   --> $DIR/projection-one-region-closure.rs:62:1
@@ -102,7 +102,7 @@ LL | | where
 LL | |     T: Anything<'b>,
 LL | |     'a: 'a,
 ...  |
-LL | |     //~| ERROR does not outlive free region
+LL | |     //~| ERROR Argument requires that data must outlive free region
 LL | | }
    | |_^
    |
@@ -137,11 +137,11 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |
    = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
 
-error: free region `ReEarlyBound(1, 'b)` does not outlive free region `ReEarlyBound(0, 'a)`
-  --> $DIR/projection-one-region-closure.rs:89:20
+error: Argument requires that data must outlive free region `ReEarlyBound(0, 'a)`
+  --> $DIR/projection-one-region-closure.rs:89:5
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                    ^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: No external requirements
   --> $DIR/projection-one-region-closure.rs:74:1
@@ -151,7 +151,7 @@ LL | | where
 LL | |     T: Anything<'b>,
 LL | |     T::AssocType: 'a,
 ...  |
-LL | |     //~| ERROR free region `ReEarlyBound(1, 'b)` does not outlive free region `ReEarlyBound(0, 'a)`
+LL | |     //~| ERROR Argument requires that data must outlive free region
 LL | | }
    | |_^
    |

--- a/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
@@ -40,7 +40,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |
    = help: consider adding an explicit lifetime bound `T: ReFree(DefId(0/0:8 ~ projection_one_region_closure[317d]::no_relationships_late[0]), BrNamed(crate0:DefIndex(1:16), 'a))`...
 
-error: Argument requires that data must outlive free region `ReFree(DefId(0/0:8 ~ projection_one_region_closure[317d]::no_relationships_late[0]), BrNamed(crate0:DefIndex(1:16), 'a))`
+error: argument requires that data must outlive free region `ReFree(DefId(0/0:8 ~ projection_one_region_closure[317d]::no_relationships_late[0]), BrNamed(crate0:DefIndex(1:16), 'a))`
   --> $DIR/projection-one-region-closure.rs:55:5
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -54,7 +54,7 @@ LL | | where
 LL | |     T: Anything<'b>,
 LL | | {
 ...  |
-LL | |     //~| ERROR Argument requires that data must outlive free region
+LL | |     //~| ERROR argument requires that data must outlive free region
 LL | | }
    | |_^
    |
@@ -88,7 +88,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |
    = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
 
-error: Argument requires that data must outlive free region `ReEarlyBound(0, 'a)`
+error: argument requires that data must outlive free region `ReEarlyBound(0, 'a)`
   --> $DIR/projection-one-region-closure.rs:67:5
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -102,7 +102,7 @@ LL | | where
 LL | |     T: Anything<'b>,
 LL | |     'a: 'a,
 ...  |
-LL | |     //~| ERROR Argument requires that data must outlive free region
+LL | |     //~| ERROR argument requires that data must outlive free region
 LL | | }
    | |_^
    |
@@ -137,7 +137,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |
    = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
 
-error: Argument requires that data must outlive free region `ReEarlyBound(0, 'a)`
+error: argument requires that data must outlive free region `ReEarlyBound(0, 'a)`
   --> $DIR/projection-one-region-closure.rs:89:5
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -151,7 +151,7 @@ LL | | where
 LL | |     T: Anything<'b>,
 LL | |     T::AssocType: 'a,
 ...  |
-LL | |     //~| ERROR Argument requires that data must outlive free region
+LL | |     //~| ERROR argument requires that data must outlive free region
 LL | | }
    | |_^
    |

--- a/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.rs
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.rs
@@ -46,7 +46,7 @@ where
 {
     with_signature(cell, t, |cell, t| require(cell, t));
     //~^ WARNING not reporting region error due to nll
-    //~| ERROR does not outlive free region
+    //~| ERROR Argument requires that data must outlive free region
 }
 
 #[rustc_regions]
@@ -57,7 +57,7 @@ where
 {
     with_signature(cell, t, |cell, t| require(cell, t));
     //~^ WARNING not reporting region error due to nll
-    //~| ERROR does not outlive free region
+    //~| ERROR Argument requires that data must outlive free region
 }
 
 #[rustc_regions]
@@ -78,7 +78,7 @@ where
 
     with_signature(cell, t, |cell, t| require(cell, t));
     //~^ WARNING not reporting region error due to nll
-    //~| ERROR does not outlive free region
+    //~| ERROR Argument requires that data must outlive free region
 }
 
 #[rustc_regions]

--- a/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.rs
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.rs
@@ -46,7 +46,7 @@ where
 {
     with_signature(cell, t, |cell, t| require(cell, t));
     //~^ WARNING not reporting region error due to nll
-    //~| ERROR Argument requires that data must outlive free region
+    //~| ERROR argument requires that data must outlive free region
 }
 
 #[rustc_regions]
@@ -57,7 +57,7 @@ where
 {
     with_signature(cell, t, |cell, t| require(cell, t));
     //~^ WARNING not reporting region error due to nll
-    //~| ERROR Argument requires that data must outlive free region
+    //~| ERROR argument requires that data must outlive free region
 }
 
 #[rustc_regions]
@@ -78,7 +78,7 @@ where
 
     with_signature(cell, t, |cell, t| require(cell, t));
     //~^ WARNING not reporting region error due to nll
-    //~| ERROR Argument requires that data must outlive free region
+    //~| ERROR argument requires that data must outlive free region
 }
 
 #[rustc_regions]

--- a/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
@@ -31,7 +31,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 3
    = note: where '_#1r: '_#2r
 
-error: Argument requires that data must outlive free region `ReFree(DefId(0/0:8 ~ projection_one_region_trait_bound_closure[317d]::no_relationships_late[0]), BrNamed(crate0:DefIndex(1:16), 'a))`
+error: argument requires that data must outlive free region `ReFree(DefId(0/0:8 ~ projection_one_region_trait_bound_closure[317d]::no_relationships_late[0]), BrNamed(crate0:DefIndex(1:16), 'a))`
   --> $DIR/projection-one-region-trait-bound-closure.rs:47:5
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -45,7 +45,7 @@ LL | | where
 LL | |     T: Anything<'b>,
 LL | | {
 ...  |
-LL | |     //~| ERROR Argument requires that data must outlive free region
+LL | |     //~| ERROR argument requires that data must outlive free region
 LL | | }
    | |_^
    |
@@ -70,7 +70,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 4
    = note: where '_#2r: '_#3r
 
-error: Argument requires that data must outlive free region `ReEarlyBound(0, 'a)`
+error: argument requires that data must outlive free region `ReEarlyBound(0, 'a)`
   --> $DIR/projection-one-region-trait-bound-closure.rs:58:5
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -84,7 +84,7 @@ LL | | where
 LL | |     T: Anything<'b>,
 LL | |     'a: 'a,
 ...  |
-LL | |     //~| ERROR Argument requires that data must outlive free region
+LL | |     //~| ERROR argument requires that data must outlive free region
 LL | | }
    | |_^
    |
@@ -110,7 +110,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 4
    = note: where '_#2r: '_#3r
 
-error: Argument requires that data must outlive free region `ReEarlyBound(0, 'a)`
+error: argument requires that data must outlive free region `ReEarlyBound(0, 'a)`
   --> $DIR/projection-one-region-trait-bound-closure.rs:79:5
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -124,7 +124,7 @@ LL | | where
 LL | |     T: Anything<'b>,
 LL | |     T::AssocType: 'a,
 ...  |
-LL | |     //~| ERROR Argument requires that data must outlive free region
+LL | |     //~| ERROR argument requires that data must outlive free region
 LL | | }
    | |_^
    |

--- a/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
@@ -31,11 +31,11 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 3
    = note: where '_#1r: '_#2r
 
-error: free region `ReEarlyBound(0, 'b)` does not outlive free region `ReFree(DefId(0/0:8 ~ projection_one_region_trait_bound_closure[317d]::no_relationships_late[0]), BrNamed(crate0:DefIndex(1:16), 'a))`
-  --> $DIR/projection-one-region-trait-bound-closure.rs:47:20
+error: Argument requires that data must outlive free region `ReFree(DefId(0/0:8 ~ projection_one_region_trait_bound_closure[317d]::no_relationships_late[0]), BrNamed(crate0:DefIndex(1:16), 'a))`
+  --> $DIR/projection-one-region-trait-bound-closure.rs:47:5
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                    ^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: No external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:43:1
@@ -45,7 +45,7 @@ LL | | where
 LL | |     T: Anything<'b>,
 LL | | {
 ...  |
-LL | |     //~| ERROR does not outlive free region
+LL | |     //~| ERROR Argument requires that data must outlive free region
 LL | | }
    | |_^
    |
@@ -70,11 +70,11 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 4
    = note: where '_#2r: '_#3r
 
-error: free region `ReEarlyBound(1, 'b)` does not outlive free region `ReEarlyBound(0, 'a)`
-  --> $DIR/projection-one-region-trait-bound-closure.rs:58:20
+error: Argument requires that data must outlive free region `ReEarlyBound(0, 'a)`
+  --> $DIR/projection-one-region-trait-bound-closure.rs:58:5
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                    ^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: No external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:53:1
@@ -84,7 +84,7 @@ LL | | where
 LL | |     T: Anything<'b>,
 LL | |     'a: 'a,
 ...  |
-LL | |     //~| ERROR does not outlive free region
+LL | |     //~| ERROR Argument requires that data must outlive free region
 LL | | }
    | |_^
    |
@@ -110,11 +110,11 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 4
    = note: where '_#2r: '_#3r
 
-error: free region `ReEarlyBound(1, 'b)` does not outlive free region `ReEarlyBound(0, 'a)`
-  --> $DIR/projection-one-region-trait-bound-closure.rs:79:20
+error: Argument requires that data must outlive free region `ReEarlyBound(0, 'a)`
+  --> $DIR/projection-one-region-trait-bound-closure.rs:79:5
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                    ^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: No external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:64:1
@@ -124,7 +124,7 @@ LL | | where
 LL | |     T: Anything<'b>,
 LL | |     T::AssocType: 'a,
 ...  |
-LL | |     //~| ERROR does not outlive free region
+LL | |     //~| ERROR Argument requires that data must outlive free region
 LL | | }
    | |_^
    |

--- a/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.rs
+++ b/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.rs
@@ -107,7 +107,7 @@ where
 {
     with_signature(cell, t, |cell, t| require(cell, t));
     //~^ WARNING not reporting region error due to nll
-    //~| ERROR Argument requires that data must outlive free region
+    //~| ERROR argument requires that data must outlive free region
 }
 
 #[rustc_regions]

--- a/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.rs
+++ b/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.rs
@@ -107,7 +107,7 @@ where
 {
     with_signature(cell, t, |cell, t| require(cell, t));
     //~^ WARNING not reporting region error due to nll
-    //~| ERROR does not outlive free region
+    //~| ERROR Argument requires that data must outlive free region
 }
 
 #[rustc_regions]

--- a/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
@@ -239,7 +239,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 3
    = note: where <T as Anything<ReClosureBound('_#1r), ReClosureBound('_#1r)>>::AssocType: '_#2r
 
-error: Argument requires that data must outlive free region `ReFree(DefId(0/0:13 ~ projection_two_region_trait_bound_closure[317d]::two_regions[0]), BrNamed(crate0:DefIndex(1:43), 'a))`
+error: argument requires that data must outlive free region `ReFree(DefId(0/0:13 ~ projection_two_region_trait_bound_closure[317d]::two_regions[0]), BrNamed(crate0:DefIndex(1:43), 'a))`
   --> $DIR/projection-two-region-trait-bound-closure.rs:108:5
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -253,7 +253,7 @@ LL | | where
 LL | |     T: Anything<'b, 'b>,
 LL | | {
 ...  |
-LL | |     //~| ERROR Argument requires that data must outlive free region
+LL | |     //~| ERROR argument requires that data must outlive free region
 LL | | }
    | |_^
    |

--- a/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
@@ -239,11 +239,11 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 3
    = note: where <T as Anything<ReClosureBound('_#1r), ReClosureBound('_#1r)>>::AssocType: '_#2r
 
-error: free region `ReEarlyBound(0, 'b)` does not outlive free region `ReFree(DefId(0/0:13 ~ projection_two_region_trait_bound_closure[317d]::two_regions[0]), BrNamed(crate0:DefIndex(1:43), 'a))`
-  --> $DIR/projection-two-region-trait-bound-closure.rs:108:20
+error: Argument requires that data must outlive free region `ReFree(DefId(0/0:13 ~ projection_two_region_trait_bound_closure[317d]::two_regions[0]), BrNamed(crate0:DefIndex(1:43), 'a))`
+  --> $DIR/projection-two-region-trait-bound-closure.rs:108:5
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                    ^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: No external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:104:1
@@ -253,7 +253,7 @@ LL | | where
 LL | |     T: Anything<'b, 'b>,
 LL | | {
 ...  |
-LL | |     //~| ERROR does not outlive free region
+LL | |     //~| ERROR Argument requires that data must outlive free region
 LL | | }
    | |_^
    |

--- a/src/test/ui/underscore-lifetime/dyn-trait-underscore.nll.stderr
+++ b/src/test/ui/underscore-lifetime/dyn-trait-underscore.nll.stderr
@@ -22,15 +22,11 @@ warning: not reporting region error due to nll
 LL |     Box::new(items.iter()) //~ ERROR cannot infer an appropriate lifetime
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
-error: free region `` does not outlive free region `'static`
-  --> $DIR/dyn-trait-underscore.rs:16:52
+error: Cast requires that data must outlive free region `'static`
+  --> $DIR/dyn-trait-underscore.rs:18:5
    |
-LL |   fn a<T>(items: &[T]) -> Box<dyn Iterator<Item=&T>> {
-   |  ____________________________________________________^
-LL | |     //                      ^^^^^^^^^^^^^^^^^^^^^ bound *here* defaults to `'static`
-LL | |     Box::new(items.iter()) //~ ERROR cannot infer an appropriate lifetime
-LL | | }
-   | |_^
+LL |     Box::new(items.iter()) //~ ERROR cannot infer an appropriate lifetime
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/underscore-lifetime/dyn-trait-underscore.nll.stderr
+++ b/src/test/ui/underscore-lifetime/dyn-trait-underscore.nll.stderr
@@ -22,7 +22,7 @@ warning: not reporting region error due to nll
 LL |     Box::new(items.iter()) //~ ERROR cannot infer an appropriate lifetime
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
-error: Cast requires that data must outlive free region `'static`
+error: cast requires that data must outlive free region `'static`
   --> $DIR/dyn-trait-underscore.rs:18:5
    |
 LL |     Box::new(items.iter()) //~ ERROR cannot infer an appropriate lifetime


### PR DESCRIPTION
Contributes to #46983. This PR doesn't introduce fantastic errors, but it should hopefully lay some groundwork for diagnostic improvements.
r? @nikomatsakis 