### PR TITLE
Rename OOM to allocation error

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -32,7 +32,7 @@ use core::hash::{Hash, Hasher};
 use core::{isize, usize};
 use core::convert::From;
 
-use alloc::{Global, Alloc, Layout, box_free, oom};
+use alloc::{Global, Alloc, Layout, box_free, handle_alloc_error};
 use boxed::Box;
 use string::String;
 use vec::Vec;
@@ -554,7 +554,7 @@ impl<T: ?Sized> Arc<T> {
         let layout = Layout::for_value(&*fake_ptr);
 
         let mem = Global.alloc(layout)
-            .unwrap_or_else(|_| oom(layout));
+            .unwrap_or_else(|_| handle_alloc_error(layout));
 
         // Initialize the real ArcInner
         let inner = set_data_ptr(ptr as *mut T, mem.as_ptr() as *mut u8) as *mut ArcInner<T>;

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -259,7 +259,7 @@ use core::ops::CoerceUnsized;
 use core::ptr::{self, NonNull};
 use core::convert::From;
 
-use alloc::{Global, Alloc, Layout, box_free, oom};
+use alloc::{Global, Alloc, Layout, box_free, handle_alloc_error};
 use string::String;
 use vec::Vec;
 
@@ -662,7 +662,7 @@ impl<T: ?Sized> Rc<T> {
         let layout = Layout::for_value(&*fake_ptr);
 
         let mem = Global.alloc(layout)
-            .unwrap_or_else(|_| oom(layout));
+            .unwrap_or_else(|_| handle_alloc_error(layout));
 
         // Initialize the real RcBox
         let inner = set_data_ptr(ptr as *mut T, mem.as_ptr() as *mut u8) as *mut RcBox<T>;

--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -492,10 +492,10 @@ pub unsafe trait GlobalAlloc {
     /// library that aborts on memory exhaustion.)
     ///
     /// Clients wishing to abort computation in response to an
-    /// allocation error are encouraged to call the [`oom`] function,
+    /// allocation error are encouraged to call the [`handle_alloc_error`] function,
     /// rather than directly invoking `panic!` or similar.
     ///
-    /// [`oom`]: ../../alloc/alloc/fn.oom.html
+    /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
     #[stable(feature = "global_alloc", since = "1.28.0")]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8;
 
@@ -529,10 +529,10 @@ pub unsafe trait GlobalAlloc {
     /// just as in `alloc`.
     ///
     /// Clients wishing to abort computation in response to an
-    /// allocation error are encouraged to call the [`oom`] function,
+    /// allocation error are encouraged to call the [`handle_alloc_error`] function,
     /// rather than directly invoking `panic!` or similar.
     ///
-    /// [`oom`]: ../../alloc/alloc/fn.oom.html
+    /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
     #[stable(feature = "global_alloc", since = "1.28.0")]
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
         let size = layout.size();
@@ -589,10 +589,10 @@ pub unsafe trait GlobalAlloc {
     /// library that aborts on memory exhaustion.)
     ///
     /// Clients wishing to abort computation in response to a
-    /// reallocation error are encouraged to call the [`oom`] function,
+    /// reallocation error are encouraged to call the [`handle_alloc_error`] function,
     /// rather than directly invoking `panic!` or similar.
     ///
-    /// [`oom`]: ../../alloc/alloc/fn.oom.html
+    /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
     #[stable(feature = "global_alloc", since = "1.28.0")]
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
         let new_layout = Layout::from_size_align_unchecked(new_size, layout.align());
@@ -733,10 +733,10 @@ pub unsafe trait Alloc {
     /// library that aborts on memory exhaustion.)
     ///
     /// Clients wishing to abort computation in response to an
-    /// allocation error are encouraged to call the [`oom`] function,
+    /// allocation error are encouraged to call the [`handle_alloc_error`] function,
     /// rather than directly invoking `panic!` or similar.
     ///
-    /// [`oom`]: ../../alloc/alloc/fn.oom.html
+    /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
     unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr>;
 
     /// Deallocate the memory referenced by `ptr`.
@@ -843,10 +843,10 @@ pub unsafe trait Alloc {
     /// library that aborts on memory exhaustion.)
     ///
     /// Clients wishing to abort computation in response to a
-    /// reallocation error are encouraged to call the [`oom`] function,
+    /// reallocation error are encouraged to call the [`handle_alloc_error`] function,
     /// rather than directly invoking `panic!` or similar.
     ///
-    /// [`oom`]: ../../alloc/alloc/fn.oom.html
+    /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
     unsafe fn realloc(&mut self,
                       ptr: NonNull<u8>,
                       layout: Layout,
@@ -889,10 +889,10 @@ pub unsafe trait Alloc {
     /// constraints, just as in `alloc`.
     ///
     /// Clients wishing to abort computation in response to an
-    /// allocation error are encouraged to call the [`oom`] function,
+    /// allocation error are encouraged to call the [`handle_alloc_error`] function,
     /// rather than directly invoking `panic!` or similar.
     ///
-    /// [`oom`]: ../../alloc/alloc/fn.oom.html
+    /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
     unsafe fn alloc_zeroed(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
         let size = layout.size();
         let p = self.alloc(layout);
@@ -917,10 +917,10 @@ pub unsafe trait Alloc {
     /// constraints, just as in `alloc`.
     ///
     /// Clients wishing to abort computation in response to an
-    /// allocation error are encouraged to call the [`oom`] function,
+    /// allocation error are encouraged to call the [`handle_alloc_error`] function,
     /// rather than directly invoking `panic!` or similar.
     ///
-    /// [`oom`]: ../../alloc/alloc/fn.oom.html
+    /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
     unsafe fn alloc_excess(&mut self, layout: Layout) -> Result<Excess, AllocErr> {
         let usable_size = self.usable_size(&layout);
         self.alloc(layout).map(|p| Excess(p, usable_size.1))
@@ -941,10 +941,10 @@ pub unsafe trait Alloc {
     /// constraints, just as in `realloc`.
     ///
     /// Clients wishing to abort computation in response to a
-    /// reallocation error are encouraged to call the [`oom`] function,
+    /// reallocation error are encouraged to call the [`handle_alloc_error`] function,
     /// rather than directly invoking `panic!` or similar.
     ///
-    /// [`oom`]: ../../alloc/alloc/fn.oom.html
+    /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
     unsafe fn realloc_excess(&mut self,
                              ptr: NonNull<u8>,
                              layout: Layout,
@@ -986,7 +986,7 @@ pub unsafe trait Alloc {
     /// unable to assert that the memory block referenced by `ptr`
     /// could fit `layout`.
     ///
-    /// Note that one cannot pass `CannotReallocInPlace` to the `oom`
+    /// Note that one cannot pass `CannotReallocInPlace` to the `handle_alloc_error`
     /// function; clients are expected either to be able to recover from
     /// `grow_in_place` failures without aborting, or to fall back on
     /// another reallocation method before resorting to an abort.
@@ -1041,7 +1041,7 @@ pub unsafe trait Alloc {
     /// unable to assert that the memory block referenced by `ptr`
     /// could fit `layout`.
     ///
-    /// Note that one cannot pass `CannotReallocInPlace` to the `oom`
+    /// Note that one cannot pass `CannotReallocInPlace` to the `handle_alloc_error`
     /// function; clients are expected either to be able to recover from
     /// `shrink_in_place` failures without aborting, or to fall back
     /// on another reallocation method before resorting to an abort.
@@ -1090,10 +1090,10 @@ pub unsafe trait Alloc {
     /// will *not* yield undefined behavior.
     ///
     /// Clients wishing to abort computation in response to an
-    /// allocation error are encouraged to call the [`oom`] function,
+    /// allocation error are encouraged to call the [`handle_alloc_error`] function,
     /// rather than directly invoking `panic!` or similar.
     ///
-    /// [`oom`]: ../../alloc/alloc/fn.oom.html
+    /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
     fn alloc_one<T>(&mut self) -> Result<NonNull<T>, AllocErr>
         where Self: Sized
     {
@@ -1159,10 +1159,10 @@ pub unsafe trait Alloc {
     /// Always returns `Err` on arithmetic overflow.
     ///
     /// Clients wishing to abort computation in response to an
-    /// allocation error are encouraged to call the [`oom`] function,
+    /// allocation error are encouraged to call the [`handle_alloc_error`] function,
     /// rather than directly invoking `panic!` or similar.
     ///
-    /// [`oom`]: ../../alloc/alloc/fn.oom.html
+    /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
     fn alloc_array<T>(&mut self, n: usize) -> Result<NonNull<T>, AllocErr>
         where Self: Sized
     {
@@ -1206,10 +1206,10 @@ pub unsafe trait Alloc {
     /// Always returns `Err` on arithmetic overflow.
     ///
     /// Clients wishing to abort computation in response to a
-    /// reallocation error are encouraged to call the [`oom`] function,
+    /// reallocation error are encouraged to call the [`handle_alloc_error`] function,
     /// rather than directly invoking `panic!` or similar.
     ///
-    /// [`oom`]: ../../alloc/alloc/fn.oom.html
+    /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
     unsafe fn realloc_array<T>(&mut self,
                                ptr: NonNull<T>,
                                n_old: usize,

--- a/src/libstd/alloc.rs
+++ b/src/libstd/alloc.rs
@@ -88,38 +88,38 @@ pub use alloc_system::System;
 
 static HOOK: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 
-/// Registers a custom OOM hook, replacing any that was previously registered.
+/// Registers a custom allocation error hook, replacing any that was previously registered.
 ///
-/// The OOM hook is invoked when an infallible memory allocation fails, before
+/// The allocation error hook is invoked when an infallible memory allocation fails, before
 /// the runtime aborts. The default hook prints a message to standard error,
-/// but this behavior can be customized with the [`set_oom_hook`] and
-/// [`take_oom_hook`] functions.
+/// but this behavior can be customized with the [`set_alloc_error_hook`] and
+/// [`take_alloc_error_hook`] functions.
 ///
 /// The hook is provided with a `Layout` struct which contains information
 /// about the allocation that failed.
 ///
-/// The OOM hook is a global resource.
-#[unstable(feature = "oom_hook", issue = "51245")]
-pub fn set_oom_hook(hook: fn(Layout)) {
+/// The allocation error hook is a global resource.
+#[unstable(feature = "alloc_error_hook", issue = "51245")]
+pub fn set_alloc_error_hook(hook: fn(Layout)) {
     HOOK.store(hook as *mut (), Ordering::SeqCst);
 }
 
-/// Unregisters the current OOM hook, returning it.
+/// Unregisters the current allocation error hook, returning it.
 ///
-/// *See also the function [`set_oom_hook`].*
+/// *See also the function [`set_alloc_error_hook`].*
 ///
 /// If no custom hook is registered, the default hook will be returned.
-#[unstable(feature = "oom_hook", issue = "51245")]
-pub fn take_oom_hook() -> fn(Layout) {
+#[unstable(feature = "alloc_error_hook", issue = "51245")]
+pub fn take_alloc_error_hook() -> fn(Layout) {
     let hook = HOOK.swap(ptr::null_mut(), Ordering::SeqCst);
     if hook.is_null() {
-        default_oom_hook
+        default_alloc_error_hook
     } else {
         unsafe { mem::transmute(hook) }
     }
 }
 
-fn default_oom_hook(layout: Layout) {
+fn default_alloc_error_hook(layout: Layout) {
     dumb_print(format_args!("memory allocation of {} bytes failed", layout.size()));
 }
 
@@ -130,7 +130,7 @@ fn default_oom_hook(layout: Layout) {
 pub extern fn rust_oom(layout: Layout) -> ! {
     let hook = HOOK.load(Ordering::SeqCst);
     let hook: fn(Layout) = if hook.is_null() {
-        default_oom_hook
+        default_alloc_error_hook
     } else {
         unsafe { mem::transmute(hook) }
     };

--- a/src/libstd/collections/hash/table.rs
+++ b/src/libstd/collections/hash/table.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use alloc::{Global, Alloc, Layout, LayoutErr, CollectionAllocErr, oom};
+use alloc::{Global, Alloc, Layout, LayoutErr, CollectionAllocErr, handle_alloc_error};
 use hash::{BuildHasher, Hash, Hasher};
 use marker;
 use mem::{size_of, needs_drop};
@@ -699,7 +699,7 @@ impl<K, V> RawTable<K, V> {
         // point into it.
         let (layout, _) = calculate_layout::<K, V>(capacity)?;
         let buffer = Global.alloc(layout).map_err(|e| match fallibility {
-            Infallible => oom(layout),
+            Infallible => handle_alloc_error(layout),
             Fallible => e,
         })?;
 

--- a/src/test/run-pass/allocator-alloc-one.rs
+++ b/src/test/run-pass/allocator-alloc-one.rs
@@ -10,11 +10,13 @@
 
 #![feature(allocator_api, nonnull)]
 
-use std::alloc::{Alloc, Global, Layout, oom};
+use std::alloc::{Alloc, Global, Layout, handle_alloc_error};
 
 fn main() {
     unsafe {
-        let ptr = Global.alloc_one::<i32>().unwrap_or_else(|_| oom(Layout::new::<i32>()));
+        let ptr = Global.alloc_one::<i32>().unwrap_or_else(|_| {
+            handle_alloc_error(Layout::new::<i32>())
+        });
         *ptr.as_ptr() = 4;
         assert_eq!(*ptr.as_ptr(), 4);
         Global.dealloc_one(ptr);

--- a/src/test/run-pass/realloc-16687.rs
+++ b/src/test/run-pass/realloc-16687.rs
@@ -15,7 +15,7 @@
 
 #![feature(heap_api, allocator_api)]
 
-use std::alloc::{Global, Alloc, Layout, oom};
+use std::alloc::{Global, Alloc, Layout, handle_alloc_error};
 use std::ptr::{self, NonNull};
 
 fn main() {
@@ -50,7 +50,7 @@ unsafe fn test_triangle() -> bool {
             println!("allocate({:?})", layout);
         }
 
-        let ret = Global.alloc(layout).unwrap_or_else(|_| oom(layout));
+        let ret = Global.alloc(layout).unwrap_or_else(|_| handle_alloc_error(layout));
 
         if PRINT {
             println!("allocate({:?}) = {:?}", layout, ret);
@@ -73,7 +73,9 @@ unsafe fn test_triangle() -> bool {
         }
 
         let ret = Global.realloc(NonNull::new_unchecked(ptr), old, new.size())
-            .unwrap_or_else(|_| oom(Layout::from_size_align_unchecked(new.size(), old.align())));
+            .unwrap_or_else(|_| handle_alloc_error(
+                Layout::from_size_align_unchecked(new.size(), old.align())
+            ));
 
         if PRINT {
             println!("reallocate({:?}, old={:?}, new={:?}) = {:?}",

--- a/src/test/run-pass/regions-mock-codegen.rs
+++ b/src/test/run-pass/regions-mock-codegen.rs
@@ -12,7 +12,7 @@
 
 #![feature(allocator_api)]
 
-use std::alloc::{Alloc, Global, Layout, oom};
+use std::alloc::{Alloc, Global, Layout, handle_alloc_error};
 use std::ptr::NonNull;
 
 struct arena(());
@@ -33,7 +33,7 @@ struct Ccx {
 fn alloc<'a>(_bcx : &'a arena) -> &'a Bcx<'a> {
     unsafe {
         let layout = Layout::new::<Bcx>();
-        let ptr = Global.alloc(layout).unwrap_or_else(|_| oom(layout));
+        let ptr = Global.alloc(layout).unwrap_or_else(|_| handle_alloc_error(layout));
         &*(ptr.as_ptr() as *const _)
     }
 }


### PR DESCRIPTION
The acronym is not descriptive unless one has seen it before.

* Rename the `oom` function to `handle_alloc_error`. It was **stabilized in 1.28**, so if we do this at all we need to land it this cycle.
* Rename `set_oom_hook` to `set_alloc_error_hook`
* Rename `take_oom_hook` to `take_alloc_error_hook`

Bikeshed: `on` v.s. `for`, `alloc` v.s. `allocator`, `error` v.s. `failure`