### PR TITLE
Minor language change to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ file. If you still have a `config.mk` file in your directory - from
 ### Building
 [building]: #building
 
-A default configuration shall use around 3.5 GB of disk space, whereas building a debug configuration may require more than 30 GB.
+A default configuration requires around 3.5 GB of disk space, whereas building a debug configuration may require more than 30 GB.
 
 Dependencies
 - [build dependencies](README.md#building-from-source)


### PR DESCRIPTION
In the `#building` section, the doc read that a default configuration "shall use around 3.5 GB of disk space." Changed "shall use" to "requires," as I don't think it's meant to sound so prescriptive.