### PR TITLE
Removed two unused variables in os.rs

### DIFF
--- a/src/libstd/sys/redox/os.rs
+++ b/src/libstd/sys/redox/os.rs
@@ -30,9 +30,6 @@ use sys_common::mutex::Mutex;
 use sys::{cvt, fd, syscall};
 use vec;
 
-const TMPBUF_SZ: usize = 128;
-static ENV_LOCK: Mutex = Mutex::new();
-
 extern {
     #[link_name = "__errno_location"]
     fn errno_location() -> *mut i32;


### PR DESCRIPTION
Issue #51419 suggested removing two unused variables in `libstd/sys/redox/os.rs`. This PR implements that change.

It compiles for me locally, but I haven't run any other tests.