### PR TITLE
Fix the recent spurious breakage on AppVeyor.

### DIFF
--- a/src/ci/docker/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/x86_64-gnu-tools/checktools.sh
@@ -91,7 +91,7 @@ status_check() {
 
 status_check "submodule_changed"
 
-CHECK_NOT="$(dirname $0)/checkregression.py"
+CHECK_NOT="$(readlink -f "$(dirname $0)/checkregression.py")"
 change_toolstate() {
     # only update the history
     if python2.7 "$CHECK_NOT" "$OS" "$TOOLSTATE_FILE" "_data/latest.json" changed; then


### PR DESCRIPTION
Fixed the spurious error introduced by d2b5b7603b6b7ecb4ff93981c785aef640015e68 due to a wrongly resolved relative path on AppVeyor. 

This only starts to happen today because we just entered the last week of the 6-week cycle.

