### PR TITLE
in which the unused-must-use lint adapts to the world of impl-Trait

### DIFF
--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -58,7 +58,15 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
         }
 
         let t = cx.tables.expr_ty(&expr);
-        let ty_warned = match t.sty {
+
+        let checkee_ty = if let ty::TyAnon(def, _) = t.sty {
+            // get concrete type of the `impl Trait` (Issue #51560)
+            cx.tcx.type_of(def)
+        } else {
+            t
+        };
+
+        let ty_warned = match checkee_ty.sty {
             ty::TyTuple(ref tys) if tys.is_empty() => return,
             ty::TyNever => return,
             ty::TyAdt(def, _) => {

--- a/src/test/ui/lint/issue-51560-must-use-impl-trait.rs
+++ b/src/test/ui/lint/issue-51560-must-use-impl-trait.rs
@@ -1,0 +1,30 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(dead_code)]
+#![deny(unused_must_use)]
+
+trait CompilerHackingToDistractFromHeartbreak {}
+
+#[must_use]
+struct IGuessICanMakeNewFriends {
+    somehow: bool
+}
+
+impl CompilerHackingToDistractFromHeartbreak for IGuessICanMakeNewFriends {}
+
+fn its_not_fair() -> impl CompilerHackingToDistractFromHeartbreak {
+    IGuessICanMakeNewFriends { somehow: false }
+}
+
+fn main() {
+    its_not_fair();
+    //~^ ERROR unused `IGuessICanMakeNewFriends` which must be used
+}

--- a/src/test/ui/lint/issue-51560-must-use-impl-trait.stderr
+++ b/src/test/ui/lint/issue-51560-must-use-impl-trait.stderr
@@ -1,0 +1,14 @@
+error: unused `IGuessICanMakeNewFriends` which must be used
+  --> $DIR/issue-51560-must-use-impl-trait.rs:28:5
+   |
+LL |     its_not_fair();
+   |     ^^^^^^^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/issue-51560-must-use-impl-trait.rs:12:9
+   |
+LL | #![deny(unused_must_use)]
+   |         ^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
![impl_must_use](https://user-images.githubusercontent.com/1076988/41449455-09835710-7016-11e8-918d-1b0b9e70fe11.png)

The message names the concrete type. If we wanted it to say `impl TraitName`, that would be a little more work—and would also be potentially misleading, because other implementors of the trait might not be must-use. (Perhaps this is an argument for introducing must-use traits, as was [floated in the thread](https://github.com/rust-lang/rust/issues/51560#issuecomment-397396890)? I guess it depends on whether we want to think of `impl Trait` as mere syntactic sugar (in which case I think this is fine), or if _nothing_ about the concrete type is supposed to leak into user-visibility.)

Resolves #51560.

r? @oli-obk 