### PR TITLE
Make `librustc_codegen_llvm` aware of LLVM address spaces.

### DIFF
--- a/src/librustc_codegen_llvm/abi.rs
+++ b/src/librustc_codegen_llvm/abi.rs
@@ -11,7 +11,7 @@ use rustc_target::abi::call::ArgType;
 
 use rustc_codegen_ssa::traits::*;
 
-use rustc_target::abi::{HasDataLayout, LayoutOf, Size, TyLayout, Abi as LayoutAbi};
+use rustc_target::abi::{LayoutOf, Size, TyLayout, Abi as LayoutAbi};
 use rustc::ty::{self, Ty, Instance};
 use rustc::ty::layout;
 
@@ -311,7 +311,6 @@ pub trait FnTypeExt<'tcx> {
                       cx: &CodegenCx<'ll, 'tcx>,
                       abi: Abi);
     fn llvm_type(&self, cx: &CodegenCx<'ll, 'tcx>) -> &'ll Type;
-    fn ptr_to_llvm_type(&self, cx: &CodegenCx<'ll, 'tcx>) -> &'ll Type;
     fn llvm_cconv(&self) -> llvm::CallConv;
     fn apply_attrs_llfn(&self, llfn: &'ll Value);
     fn apply_attrs_callsite(&self, bx: &mut Builder<'a, 'll, 'tcx>, callsite: &'ll Value);
@@ -692,13 +691,6 @@ impl<'tcx> FnTypeExt<'tcx> for FnType<'tcx, Ty<'tcx>> {
             cx.type_variadic_func(&llargument_tys, llreturn_ty)
         } else {
             cx.type_func(&llargument_tys, llreturn_ty)
-        }
-    }
-
-    fn ptr_to_llvm_type(&self, cx: &CodegenCx<'ll, 'tcx>) -> &'ll Type {
-        unsafe {
-            llvm::LLVMPointerType(self.llvm_type(cx),
-                                  cx.data_layout().instruction_address_space as c_uint)
         }
     }
 

--- a/src/librustc_codegen_llvm/abi.rs
+++ b/src/librustc_codegen_llvm/abi.rs
@@ -652,7 +652,7 @@ impl<'tcx> FnTypeExt<'tcx> for FnType<'tcx, Ty<'tcx>> {
             }
             PassMode::Cast(cast) => cast.llvm_type(cx),
             PassMode::Indirect(..) => {
-                llargument_tys.push(cx.type_ptr_to_flat(self.ret.memory_ty(cx)));
+                llargument_tys.push(cx.type_ptr_to_alloca(self.ret.memory_ty(cx)));
                 cx.type_void()
             }
         };
@@ -682,7 +682,7 @@ impl<'tcx> FnTypeExt<'tcx> for FnType<'tcx, Ty<'tcx>> {
                     continue;
                 }
                 PassMode::Cast(cast) => cast.llvm_type(cx),
-                PassMode::Indirect(_, None) => cx.type_ptr_to_flat(arg.memory_ty(cx)),
+                PassMode::Indirect(_, None) => cx.type_ptr_to_alloca(arg.memory_ty(cx)),
             };
             llargument_tys.push(llarg_ty);
         }

--- a/src/librustc_codegen_llvm/abi.rs
+++ b/src/librustc_codegen_llvm/abi.rs
@@ -649,10 +649,11 @@ impl<'tcx> FnTypeExt<'tcx> for FnType<'tcx, Ty<'tcx>> {
             PassMode::Ignore => cx.type_void(),
             PassMode::Direct(_) | PassMode::Pair(..) => {
                 self.ret.layout.immediate_llvm_type(cx)
+                  .copy_addr_space(cx.flat_addr_space())
             }
             PassMode::Cast(cast) => cast.llvm_type(cx),
             PassMode::Indirect(..) => {
-                llargument_tys.push(cx.type_ptr_to(self.ret.memory_ty(cx)));
+                llargument_tys.push(cx.type_ptr_to_flat(self.ret.memory_ty(cx)));
                 cx.type_void()
             }
         };
@@ -665,8 +666,11 @@ impl<'tcx> FnTypeExt<'tcx> for FnType<'tcx, Ty<'tcx>> {
 
             let llarg_ty = match arg.mode {
                 PassMode::Ignore => continue,
-                PassMode::Direct(_) => arg.layout.immediate_llvm_type(cx),
+                PassMode::Direct(_) => arg.layout.immediate_llvm_type(cx)
+                  .copy_addr_space(cx.flat_addr_space()),
                 PassMode::Pair(..) => {
+                    // Keep the argument type address space given by
+                    // `scalar_pair_element_llvm_type`.
                     llargument_tys.push(arg.layout.scalar_pair_element_llvm_type(cx, 0, true));
                     llargument_tys.push(arg.layout.scalar_pair_element_llvm_type(cx, 1, true));
                     continue;
@@ -679,7 +683,7 @@ impl<'tcx> FnTypeExt<'tcx> for FnType<'tcx, Ty<'tcx>> {
                     continue;
                 }
                 PassMode::Cast(cast) => cast.llvm_type(cx),
-                PassMode::Indirect(_, None) => cx.type_ptr_to(arg.memory_ty(cx)),
+                PassMode::Indirect(_, None) => cx.type_ptr_to_flat(arg.memory_ty(cx)),
             };
             llargument_tys.push(llarg_ty);
         }

--- a/src/librustc_codegen_llvm/common.rs
+++ b/src/librustc_codegen_llvm/common.rs
@@ -13,7 +13,9 @@ use rustc_codegen_ssa::traits::*;
 use rustc::ty::layout::{HasDataLayout, LayoutOf, self, TyLayout, Size};
 use rustc::mir::interpret::{Scalar, AllocKind, Allocation};
 use consts::const_alloc_to_llvm;
+use rustc_codegen_ssa::common::TypeKind;
 use rustc_codegen_ssa::mir::place::PlaceRef;
+use rustc_target::spec::AddrSpaceIdx;
 
 use libc::{c_uint, c_char};
 
@@ -170,9 +172,9 @@ impl ConstMethods<'tcx> for CodegenCx<'ll, 'tcx> {
                                                     s.len() as c_uint,
                                                     !null_terminated as Bool);
             let sym = self.generate_local_symbol_name("str");
-            let g = self.define_global(&sym[..], self.val_ty(sc)).unwrap_or_else(||{
-                bug!("symbol `{}` is already defined", sym);
-            });
+            let addr_space = self.const_addr_space();
+            let g = self.define_global(&sym[..], self.val_ty(sc), addr_space)
+                .unwrap_or_else(|| bug!("symbol `{}` is already defined", sym) );
             llvm::LLVMSetInitializer(g, sc);
             llvm::LLVMSetGlobalConstant(g, True);
             llvm::LLVMRustSetLinkage(g, llvm::Linkage::InternalLinkage);
@@ -284,6 +286,10 @@ impl ConstMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         }
     }
 
+    fn const_as_cast(&self, val: &'ll Value, addr_space: AddrSpaceIdx) -> &'ll Value {
+        self.const_addrcast(val, addr_space)
+    }
+
     fn scalar_to_backend(
         &self,
         cv: Scalar,
@@ -299,10 +305,16 @@ impl ConstMethods<'tcx> for CodegenCx<'ll, 'tcx> {
             Scalar::Bits { bits, size } => {
                 assert_eq!(size as u64, layout.value.size(self).bytes());
                 let llval = self.const_uint_big(self.type_ix(bitsize), bits);
-                if layout.value == layout::Pointer {
-                    unsafe { llvm::LLVMConstIntToPtr(llval, llty) }
+                let flat_llty = llty.copy_addr_space(self.flat_addr_space());
+                let llval = if layout.value == layout::Pointer {
+                    unsafe { llvm::LLVMConstIntToPtr(llval, flat_llty) }
                 } else {
-                    self.const_bitcast(llval, llty)
+                    self.const_bitcast(llval, flat_llty)
+                };
+                if llty.is_ptr() {
+                    self.const_as_cast(llval, llty.address_space())
+                } else {
+                    llval
                 }
             },
             Scalar::Ptr(ptr) => {
@@ -311,7 +323,8 @@ impl ConstMethods<'tcx> for CodegenCx<'ll, 'tcx> {
                     Some(AllocKind::Memory(alloc)) => {
                         let init = const_alloc_to_llvm(self, alloc);
                         if alloc.mutability == Mutability::Mutable {
-                            self.static_addr_of_mut(init, alloc.align, None)
+                            self.static_addr_of_mut(init, alloc.align, None,
+                                                    self.mutable_addr_space())
                         } else {
                             self.static_addr_of(init, alloc.align, None)
                         }
@@ -330,6 +343,7 @@ impl ConstMethods<'tcx> for CodegenCx<'ll, 'tcx> {
                     &self.const_usize(ptr.offset.bytes()),
                     1,
                 ) };
+                let llval = self.const_flat_as_cast(llval);
                 if layout.value != layout::Pointer {
                     unsafe { llvm::LLVMConstPtrToInt(llval, llty) }
                 } else {
@@ -366,6 +380,17 @@ pub fn val_ty(v: &'ll Value) -> &'ll Type {
     unsafe {
         llvm::LLVMTypeOf(v)
     }
+}
+pub fn val_addr_space_opt(v: &'ll Value) -> Option<AddrSpaceIdx> {
+    let ty = val_ty(v);
+    if ty.kind() == TypeKind::Pointer {
+        Some(ty.address_space())
+    } else {
+        None
+    }
+}
+pub fn val_addr_space(v: &'ll Value) -> AddrSpaceIdx {
+    val_addr_space_opt(v).unwrap_or_default()
 }
 
 pub fn bytes_in_context(llcx: &'ll llvm::Context, bytes: &[u8]) -> &'ll Value {

--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -89,6 +89,7 @@ pub struct CodegenCx<'ll, 'tcx: 'll> {
     const_addr_space: AddrSpaceIdx,
     mutable_addr_space: AddrSpaceIdx,
     flat_addr_space: AddrSpaceIdx,
+    instruction_addr_space: AddrSpaceIdx,
 
     pub dbg_cx: Option<debuginfo::CrateDebugContext<'ll, 'tcx>>,
 
@@ -299,6 +300,11 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
               .get(&AddrSpaceKind::Flat)
               .map(|v| v.index )
               .unwrap_or_default();
+        let instruction_addr_space =
+            tcx.sess.target.target.options.addr_spaces
+              .get(&AddrSpaceKind::Instruction)
+              .map(|v| v.index )
+              .unwrap_or_default();
 
         CodegenCx {
             tcx,
@@ -325,6 +331,7 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
             const_addr_space,
             mutable_addr_space,
             flat_addr_space,
+            instruction_addr_space,
 
             dbg_cx,
             eh_personality: Cell::new(None),
@@ -496,6 +503,9 @@ impl MiscMethods<'tcx> for CodegenCx<'ll, 'tcx> {
           .unwrap_or_else(&bug);
 
         from_props.shared_with.contains(&to_kind)
+    }
+    fn inst_addr_space(&self) -> AddrSpaceIdx {
+        self.instruction_addr_space
     }
     fn alloca_addr_space(&self) -> AddrSpaceIdx {
         self.alloca_addr_space

--- a/src/librustc_codegen_llvm/debuginfo/gdb.rs
+++ b/src/librustc_codegen_llvm/debuginfo/gdb.rs
@@ -46,9 +46,9 @@ pub fn get_or_insert_gdb_debug_scripts_section_global(cx: &CodegenCx<'ll, '_>)
         unsafe {
             let llvm_type = cx.type_array(cx.type_i8(),
                                         section_contents.len() as u64);
-
+            let addr_space = cx.flat_addr_space();
             let section_var = cx.define_global(section_var_name,
-                                                     llvm_type).unwrap_or_else(||{
+                                                     llvm_type, addr_space).unwrap_or_else(||{
                 bug!("symbol `{}` is already defined", section_var_name)
             });
             llvm::LLVMSetSection(section_var, section_name.as_ptr() as *const _);

--- a/src/librustc_codegen_llvm/declare.rs
+++ b/src/librustc_codegen_llvm/declare.rs
@@ -24,6 +24,7 @@ use context::CodegenCx;
 use type_::Type;
 use rustc_codegen_ssa::traits::*;
 use value::Value;
+use common::val_ty;
 
 /// Declare a function.
 ///
@@ -40,6 +41,7 @@ fn declare_raw_fn(
     let llfn = unsafe {
         llvm::LLVMRustGetOrInsertFunction(cx.llmod, namebuf.as_ptr(), ty)
     };
+    assert_eq!(val_ty(llfn).address_space(), cx.inst_addr_space());
 
     llvm::SetFunctionCallConv(llfn, callconv);
     // Function addresses in Rust are never significant, allowing functions to

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -656,6 +656,7 @@ extern "C" {
 
     pub fn LLVMGetElementType(Ty: &Type) -> &Type;
     pub fn LLVMGetVectorSize(VectorTy: &Type) -> c_uint;
+    pub fn LLVMGetPointerAddressSpace(Ty: &Type) -> c_uint;
 
     // Operations on other types
     pub fn LLVMVoidTypeInContext(C: &Context) -> &Type;
@@ -716,6 +717,7 @@ extern "C" {
     pub fn LLVMConstIntToPtr(ConstantVal: &'a Value, ToType: &'a Type) -> &'a Value;
     pub fn LLVMConstBitCast(ConstantVal: &'a Value, ToType: &'a Type) -> &'a Value;
     pub fn LLVMConstPointerCast(ConstantVal: &'a Value, ToType: &'a Type) -> &'a Value;
+    pub fn LLVMConstAddrSpaceCast(ConstantVal: &'a Value, ToType: &'a Type) -> &'a Value;
     pub fn LLVMConstExtractValue(AggConstant: &Value,
                                  IdxList: *const c_uint,
                                  NumIdx: c_uint)
@@ -737,8 +739,10 @@ extern "C" {
     pub fn LLVMIsAGlobalVariable(GlobalVar: &Value) -> Option<&Value>;
     pub fn LLVMAddGlobal(M: &'a Module, Ty: &'a Type, Name: *const c_char) -> &'a Value;
     pub fn LLVMGetNamedGlobal(M: &Module, Name: *const c_char) -> Option<&Value>;
-    pub fn LLVMRustGetOrInsertGlobal(M: &'a Module, Name: *const c_char, T: &'a Type) -> &'a Value;
-    pub fn LLVMRustInsertPrivateGlobal(M: &'a Module, T: &'a Type) -> &'a Value;
+    pub fn LLVMRustGetOrInsertGlobal(M: &'a Module, Name: *const c_char, T: &'a Type,
+                                     AS: c_uint) -> &'a Value;
+    pub fn LLVMRustInsertPrivateGlobal(M: &'a Module, T: &'a Type,
+                                       AS: c_uint) -> &'a Value;
     pub fn LLVMGetFirstGlobal(M: &Module) -> Option<&Value>;
     pub fn LLVMGetNextGlobal(GlobalVar: &Value) -> Option<&Value>;
     pub fn LLVMDeleteGlobal(GlobalVar: &Value);
@@ -1083,6 +1087,11 @@ extern "C" {
                                 DestTy: &'a Type,
                                 Name: *const c_char)
                                 -> &'a Value;
+    pub fn LLVMBuildAddrSpaceCast(B: &Builder<'a>,
+                                  Val: &'a Value,
+                                  DestTy: &'a Type,
+                                  Name: *const c_char)
+                                  -> &'a Value;
     pub fn LLVMRustBuildIntCast(B: &Builder<'a>,
                                 Val: &'a Value,
                                 DestTy: &'a Type,

--- a/src/librustc_codegen_llvm/type_.rs
+++ b/src/librustc_codegen_llvm/type_.rs
@@ -337,7 +337,8 @@ impl LayoutTypeMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         ty.llvm_type(self)
     }
     fn fn_ptr_backend_type(&self, ty: &FnType<'tcx, Ty<'tcx>>) -> &'ll Type {
-        ty.ptr_to_llvm_type(self)
+        self.type_as_ptr_to(ty.llvm_type(self), self.inst_addr_space())
+
     }
     fn reg_backend_type(&self, ty: &Reg) -> &'ll Type {
         ty.llvm_type(self)

--- a/src/librustc_codegen_llvm/type_of.rs
+++ b/src/librustc_codegen_llvm/type_of.rs
@@ -237,6 +237,12 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyLayout<'tcx> {
     /// with the inner-most trailing unsized field using the "minimal unit"
     /// of that field's type - this is useful for taking the address of
     /// that field and ensuring the struct has the right alignment.
+    ///
+    /// Note: the address space used for ptrs is important. Due to the nested
+    /// nature of these types, we must assume pointers are in the flat space.
+    /// Spaces are overriden as needed (or will be, in a later patch), when it
+    /// is known in which space a memory location will reside.
+    ///
     fn llvm_type<'a>(&self, cx: &CodegenCx<'a, 'tcx>) -> &'a Type {
         if let layout::Abi::Scalar(ref scalar) = self.abi {
             // Use a different cache for scalars because pointers to DSTs
@@ -247,10 +253,10 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyLayout<'tcx> {
             let llty = match self.ty.sty {
                 ty::Ref(_, ty, _) |
                 ty::RawPtr(ty::TypeAndMut { ty, .. }) => {
-                    cx.type_ptr_to(cx.layout_of(ty).llvm_type(cx))
+                    cx.type_ptr_to_flat(cx.layout_of(ty).llvm_type(cx))
                 }
                 ty::Adt(def, _) if def.is_box() => {
-                    cx.type_ptr_to(cx.layout_of(self.ty.boxed_ty()).llvm_type(cx))
+                    cx.type_ptr_to_flat(cx.layout_of(self.ty.boxed_ty()).llvm_type(cx))
                 }
                 ty::FnPtr(sig) => {
                     let sig = cx.tcx.normalize_erasing_late_bound_regions(

--- a/src/librustc_codegen_ssa/meth.rs
+++ b/src/librustc_codegen_ssa/meth.rs
@@ -81,7 +81,7 @@ pub fn get_vtable<'tcx, Cx: CodegenMethods<'tcx>>(
     }
 
     // Not in the cache. Build it.
-    let nullptr = cx.const_null(cx.type_i8p());
+    let nullptr = cx.const_null(cx.type_inst_i8p());
 
     let methods_root;
     let methods = if let Some(trait_ref) = trait_ref {

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -279,6 +279,8 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         bx.load(addr, self.fn_ty.ret.layout.align.abi)
                     }
                 };
+                // make sure pointers are flat:
+                let llval = bx.flat_addr_cast(llval);
                 bx.ret(llval);
             }
 
@@ -389,6 +391,7 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                             align,
                             Some("panic_bounds_check_loc")
                         );
+                        let file_line_col = bx.cx().const_flat_as_cast(file_line_col);
                         (lang_items::PanicBoundsCheckFnLangItem,
                          vec![file_line_col, index, len])
                     }
@@ -405,6 +408,7 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                             align,
                             Some("panic_loc")
                         );
+                        let msg_file_line_col = bx.cx().const_flat_as_cast(msg_file_line_col);
                         (lang_items::PanicFnLangItem,
                          vec![msg_file_line_col])
                     }
@@ -529,6 +533,7 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                             align,
                             Some("panic_loc"),
                         );
+                    let msg_file_line_col = bx.cx().const_flat_as_cast(msg_file_line_col);
 
                         // Obtain the panic entry point.
                         let def_id =

--- a/src/librustc_codegen_ssa/mir/mod.rs
+++ b/src/librustc_codegen_ssa/mir/mod.rs
@@ -277,7 +277,7 @@ pub fn codegen_mir<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
                     // FIXME: add an appropriate debuginfo
                     LocalRef::UnsizedPlace(indirect_place)
                 } else {
-                    let place = PlaceRef::alloca(&mut bx, layout, &name.as_str());
+                    let place = PlaceRef::alloca_addr_space(&mut bx, layout, &name.as_str());
                     if dbg {
                         let (scope, span) = fx.debug_loc(mir::SourceInfo {
                             span: decl.source_info.span,
@@ -305,7 +305,8 @@ pub fn codegen_mir<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
                         );
                         LocalRef::UnsizedPlace(indirect_place)
                     } else {
-                        LocalRef::Place(PlaceRef::alloca(&mut bx, layout, &format!("{:?}", local)))
+                        LocalRef::Place(PlaceRef::alloca_addr_space(&mut bx, layout,
+                                                                    &format!("{:?}", local)))
                     }
                 } else {
                     // If this is an immediate local, we do not create an
@@ -468,7 +469,7 @@ fn arg_local_refs<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
                 _ => bug!("spread argument isn't a tuple?!")
             };
 
-            let place = PlaceRef::alloca(bx, bx.layout_of(arg_ty), &name);
+            let place = PlaceRef::alloca_addr_space(bx, bx.layout_of(arg_ty), &name);
             for i in 0..tupled_arg_tys.len() {
                 let arg = &fx.fn_ty.args[idx];
                 idx += 1;
@@ -559,7 +560,7 @@ fn arg_local_refs<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
             indirect_operand.store(bx, tmp);
             tmp
         } else {
-            let tmp = PlaceRef::alloca(bx, arg.layout, &name);
+            let tmp = PlaceRef::alloca_addr_space(bx, arg.layout, &name);
             bx.store_fn_arg(arg, &mut llarg_idx, tmp);
             tmp
         };

--- a/src/librustc_codegen_ssa/mir/place.rs
+++ b/src/librustc_codegen_ssa/mir/place.rs
@@ -74,7 +74,7 @@ impl<'a, 'tcx: 'a, V: CodegenObject> PlaceRef<'tcx, V> {
         assert!(layout.is_unsized(), "tried to allocate indirect place for sized values");
         let ptr_ty = bx.cx().tcx().mk_mut_ptr(layout.ty);
         let ptr_layout = bx.cx().layout_of(ptr_ty);
-        Self::alloca(bx, ptr_layout, name)
+        Self::alloca_addr_space(bx, ptr_layout, name)
     }
 
     pub fn len<Cx: CodegenMethods<'tcx, Value = V>>(

--- a/src/librustc_codegen_ssa/mir/place.rs
+++ b/src/librustc_codegen_ssa/mir/place.rs
@@ -49,6 +49,18 @@ impl<'a, 'tcx: 'a, V: CodegenObject> PlaceRef<'tcx, V> {
         debug!("alloca({:?}: {:?})", name, layout);
         assert!(!layout.is_unsized(), "tried to statically allocate unsized place");
         let tmp = bx.alloca(bx.cx().backend_type(layout), name, layout.align.abi);
+        Self::new_sized(bx.flat_addr_cast(tmp), layout, layout.align.abi)
+    }
+
+    /// An alloca, left in the alloca address space. If unsure, use `alloca` below.
+    pub fn alloca_addr_space<Bx: BuilderMethods<'a, 'tcx, Value = V>>(
+        bx: &mut Bx,
+        layout: TyLayout<'tcx>,
+        name: &str
+    ) -> Self {
+        debug!("alloca({:?}: {:?})", name, layout);
+        assert!(!layout.is_unsized(), "tried to statically allocate unsized place");
+        let tmp = bx.alloca(bx.cx().backend_type(layout), name, layout.align.abi);
         Self::new_sized(tmp, layout, layout.align.abi)
     }
 

--- a/src/librustc_codegen_ssa/traits/builder.rs
+++ b/src/librustc_codegen_ssa/traits/builder.rs
@@ -9,6 +9,7 @@ use mir::operand::OperandRef;
 use mir::place::PlaceRef;
 use rustc::ty::Ty;
 use rustc::ty::layout::{Align, Size};
+use rustc_target::spec::AddrSpaceIdx;
 use std::ffi::CStr;
 use MemFlags;
 
@@ -155,7 +156,19 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
     fn inttoptr(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value;
     fn bitcast(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value;
     fn intcast(&mut self, val: Self::Value, dest_ty: Self::Type, is_signed: bool) -> Self::Value;
+    /// Impls should ignore the address space of `dest_ty`.
     fn pointercast(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value;
+
+    /// address space casts, then bitcasts to dest_ty without changing address spaces.
+    fn as_ptr_cast(&mut self,
+                   val: Self::Value,
+                   addr_space: AddrSpaceIdx,
+                   dest_ty: Self::Type) -> Self::Value;
+    fn addrspace_cast(&mut self, val: Self::Value,
+                      dest: AddrSpaceIdx) -> Self::Value;
+    fn flat_addr_cast(&mut self, val: Self::Value) -> Self::Value;
+    fn flat_as_ptr_cast(&mut self, val: Self::Value,
+                        dest_ty: Self::Type) -> Self::Value;
 
     fn icmp(&mut self, op: IntPredicate, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
     fn fcmp(&mut self, op: RealPredicate, lhs: Self::Value, rhs: Self::Value) -> Self::Value;

--- a/src/librustc_codegen_ssa/traits/consts.rs
+++ b/src/librustc_codegen_ssa/traits/consts.rs
@@ -1,11 +1,12 @@
-use super::BackendTypes;
+use super::MiscMethods;
 use mir::place::PlaceRef;
 use rustc::mir::interpret::Allocation;
 use rustc::mir::interpret::Scalar;
 use rustc::ty::layout;
 use syntax::symbol::LocalInternedString;
+use rustc_target::spec::AddrSpaceIdx;
 
-pub trait ConstMethods<'tcx>: BackendTypes {
+pub trait ConstMethods<'tcx>: MiscMethods<'tcx> {
     // Constant constructors
     fn const_null(&self, t: Self::Type) -> Self::Value;
     fn const_undef(&self, t: Self::Type) -> Self::Value;
@@ -34,6 +35,11 @@ pub trait ConstMethods<'tcx>: BackendTypes {
     fn const_get_real(&self, v: Self::Value) -> Option<(f64, bool)>;
     fn const_to_uint(&self, v: Self::Value) -> u64;
     fn const_to_opt_u128(&self, v: Self::Value, sign_ext: bool) -> Option<u128>;
+
+    fn const_as_cast(&self, v: Self::Value, space: AddrSpaceIdx) -> Self::Value;
+    fn const_flat_as_cast(&self, v: Self::Value) -> Self::Value {
+        self.const_as_cast(v, self.flat_addr_space())
+    }
 
     fn is_const_integral(&self, v: Self::Value) -> bool;
     fn is_const_real(&self, v: Self::Value) -> bool;

--- a/src/librustc_codegen_ssa/traits/declare.rs
+++ b/src/librustc_codegen_ssa/traits/declare.rs
@@ -3,13 +3,15 @@ use rustc::hir::def_id::DefId;
 use rustc::mir::mono::{Linkage, Visibility};
 use rustc::ty;
 use rustc_mir::monomorphize::Instance;
+use rustc_target::spec::AddrSpaceIdx;
 
 pub trait DeclareMethods<'tcx>: BackendTypes {
     /// Declare a global value.
     ///
     /// If there’s a value with the same name already declared, the function will
     /// return its Value instead.
-    fn declare_global(&self, name: &str, ty: Self::Type) -> Self::Value;
+    fn declare_global(&self, name: &str, ty: Self::Type,
+                      addr_space: AddrSpaceIdx) -> Self::Value;
 
     /// Declare a C ABI function.
     ///
@@ -32,12 +34,14 @@ pub trait DeclareMethods<'tcx>: BackendTypes {
     /// return None if the name already has a definition associated with it. In that
     /// case an error should be reported to the user, because it usually happens due
     /// to user’s fault (e.g., misuse of #[no_mangle] or #[export_name] attributes).
-    fn define_global(&self, name: &str, ty: Self::Type) -> Option<Self::Value>;
+    fn define_global(&self, name: &str, ty: Self::Type,
+                     addr_space: AddrSpaceIdx) -> Option<Self::Value>;
 
     /// Declare a private global
     ///
     /// Use this function when you intend to define a global without a name.
-    fn define_private_global(&self, ty: Self::Type) -> Self::Value;
+    fn define_private_global(&self, ty: Self::Type,
+                             addr_space: AddrSpaceIdx) -> Self::Value;
 
     /// Declare a Rust function with an intention to define it.
     ///

--- a/src/librustc_codegen_ssa/traits/misc.rs
+++ b/src/librustc_codegen_ssa/traits/misc.rs
@@ -29,6 +29,7 @@ pub trait MiscMethods<'tcx>: BackendTypes {
     fn create_used_variable(&self);
 
     fn can_cast_addr_space(&self, _from: AddrSpaceIdx, _to: AddrSpaceIdx) -> bool { true }
+    fn inst_addr_space(&self) -> AddrSpaceIdx { Default::default() }
     fn alloca_addr_space(&self) -> AddrSpaceIdx { Default::default() }
     fn const_addr_space(&self) -> AddrSpaceIdx { Default::default() }
     fn mutable_addr_space(&self) -> AddrSpaceIdx { Default::default() }

--- a/src/librustc_codegen_ssa/traits/misc.rs
+++ b/src/librustc_codegen_ssa/traits/misc.rs
@@ -5,6 +5,7 @@ use rustc::session::Session;
 use rustc::ty::{self, Instance, Ty};
 use rustc::util::nodemap::FxHashMap;
 use rustc_mir::monomorphize::partitioning::CodegenUnit;
+use rustc_target::spec::AddrSpaceIdx;
 use std::cell::RefCell;
 use std::sync::Arc;
 
@@ -26,4 +27,10 @@ pub trait MiscMethods<'tcx>: BackendTypes {
     fn set_frame_pointer_elimination(&self, llfn: Self::Value);
     fn apply_target_cpu_attr(&self, llfn: Self::Value);
     fn create_used_variable(&self);
+
+    fn can_cast_addr_space(&self, _from: AddrSpaceIdx, _to: AddrSpaceIdx) -> bool { true }
+    fn alloca_addr_space(&self) -> AddrSpaceIdx { Default::default() }
+    fn const_addr_space(&self) -> AddrSpaceIdx { Default::default() }
+    fn mutable_addr_space(&self) -> AddrSpaceIdx { Default::default() }
+    fn flat_addr_space(&self) -> AddrSpaceIdx { Default::default() }
 }

--- a/src/librustc_codegen_ssa/traits/mod.rs
+++ b/src/librustc_codegen_ssa/traits/mod.rs
@@ -59,6 +59,20 @@ pub trait CodegenMethods<'tcx>:
     + AsmMethods<'tcx>
     + PreDefineMethods<'tcx>
 {
+    /// Check that we can actually cast between these addr spaces.
+    fn check_addr_space_cast(&self, val: Self::Value, dest: Self::Type) {
+        let src_ty = self.val_ty(val);
+
+        match (self.type_addr_space(src_ty), self.type_addr_space(dest)) {
+            (Some(left), Some(right)) if !self.can_cast_addr_space(left, right) => {
+                bug!("Target incompatible address space cast:\n\
+                      source addr space `{}`, dest addr space `{}`\n\
+                      source value: {:?}, dest ty: {:?}",
+                     left, right, val, dest);
+            },
+            _ => { },
+        }
+    }
 }
 
 impl<'tcx, T> CodegenMethods<'tcx> for T where

--- a/src/librustc_codegen_ssa/traits/type_.rs
+++ b/src/librustc_codegen_ssa/traits/type_.rs
@@ -84,6 +84,9 @@ pub trait DerivedTypeMethods<'tcx>: BaseTypeMethods<'tcx> + MiscMethods<'tcx> {
     fn type_i8p_as(&self, addr_space: AddrSpaceIdx) -> Self::Type {
         self.type_as_ptr_to(self.type_i8(), addr_space)
     }
+    fn type_inst_i8p(&self) -> Self::Type {
+        self.type_i8p_as(self.inst_addr_space())
+    }
     fn type_alloca_i8p(&self) -> Self::Type {
         self.type_i8p_as(self.alloca_addr_space())
     }
@@ -213,6 +216,9 @@ pub trait DerivedTypeMethods<'tcx>: BaseTypeMethods<'tcx> + MiscMethods<'tcx> {
             },
             _ => { },
         }
+    }
+    fn type_ptr_to_inst(&self, ty: Self::Type) -> Self::Type {
+        self.type_as_ptr_to(ty, self.inst_addr_space())
     }
     fn type_ptr_to_alloca(&self, ty: Self::Type) -> Self::Type {
         self.type_as_ptr_to(ty, self.alloca_addr_space())

--- a/src/librustc_codegen_ssa/traits/type_.rs
+++ b/src/librustc_codegen_ssa/traits/type_.rs
@@ -7,6 +7,7 @@ use rustc::ty::layout::{self, Align, Size, TyLayout};
 use rustc::ty::{self, Ty};
 use rustc::util::nodemap::FxHashMap;
 use rustc_target::abi::call::{ArgType, CastTarget, FnType, Reg};
+use rustc_target::spec::AddrSpaceIdx;
 use std::cell::RefCell;
 use syntax::ast;
 
@@ -36,7 +37,13 @@ pub trait BaseTypeMethods<'tcx>: Backend<'tcx> {
     fn type_array(&self, ty: Self::Type, len: u64) -> Self::Type;
     fn type_vector(&self, ty: Self::Type, len: u64) -> Self::Type;
     fn type_kind(&self, ty: Self::Type) -> TypeKind;
-    fn type_ptr_to(&self, ty: Self::Type) -> Self::Type;
+
+    /// Return a pointer to `ty` in the default address space.
+    fn type_ptr_to(&self, ty: Self::Type) -> Self::Type {
+        self.type_as_ptr_to(ty, Default::default())
+    }
+    fn type_as_ptr_to(&self, ty: Self::Type, addr_space: AddrSpaceIdx) -> Self::Type;
+
     fn element_type(&self, ty: Self::Type) -> Self::Type;
 
     /// Return the number of elements in `self` if it is a LLVM vector type.
@@ -49,7 +56,21 @@ pub trait BaseTypeMethods<'tcx>: Backend<'tcx> {
     fn int_width(&self, ty: Self::Type) -> u64;
 
     fn val_ty(&self, v: Self::Value) -> Self::Type;
+    fn val_addr_space(&self, v: Self::Value) -> Option<AddrSpaceIdx> {
+        self.type_addr_space(self.val_ty(v))
+    }
     fn scalar_lltypes(&self) -> &RefCell<FxHashMap<Ty<'tcx>, Self::Type>>;
+
+    fn type_addr_space(&self, ty: Self::Type) -> Option<AddrSpaceIdx>;
+    fn type_copy_addr_space(&self, ty: Self::Type, addr_space: Option<AddrSpaceIdx>) -> Self::Type {
+        match (addr_space, self.type_kind(ty)) {
+            (Some(addr_space), TypeKind::Pointer) => {
+                let elem = self.element_type(ty);
+                self.type_as_ptr_to(elem, addr_space)
+            },
+            _ => ty,
+        }
+    }
 }
 
 pub trait DerivedTypeMethods<'tcx>: BaseTypeMethods<'tcx> + MiscMethods<'tcx> {
@@ -59,6 +80,21 @@ pub trait DerivedTypeMethods<'tcx>: BaseTypeMethods<'tcx> + MiscMethods<'tcx> {
 
     fn type_i8p(&self) -> Self::Type {
         self.type_ptr_to(self.type_i8())
+    }
+    fn type_i8p_as(&self, addr_space: AddrSpaceIdx) -> Self::Type {
+        self.type_as_ptr_to(self.type_i8(), addr_space)
+    }
+    fn type_alloca_i8p(&self) -> Self::Type {
+        self.type_i8p_as(self.alloca_addr_space())
+    }
+    fn type_const_i8p(&self) -> Self::Type {
+        self.type_i8p_as(self.const_addr_space())
+    }
+    fn type_mut_i8p(&self) -> Self::Type {
+        self.type_i8p_as(self.mutable_addr_space())
+    }
+    fn type_flat_i8p(&self) -> Self::Type {
+        self.type_i8p_as(self.flat_addr_space())
     }
 
     fn type_int(&self) -> Self::Type {
@@ -150,6 +186,45 @@ pub trait DerivedTypeMethods<'tcx>: BaseTypeMethods<'tcx> + MiscMethods<'tcx> {
             ty::Str | ty::Slice(..) | ty::Dynamic(..) => true,
             _ => bug!("unexpected unsized tail: {:?}", tail.sty),
         }
+    }
+    /// Enforce no address space changes are happening in a cast.
+    /// Pointers in different address spaces can have different
+    /// machine level sizes (ie on AMDGPU, allocas are 32bits,
+    /// not 64bits!). We enforce that the flat address space is the
+    /// largest (+alignment), so that address space is safe to cast to
+    /// ints/etc. Also, address space changes require computing a offset
+    /// or two, so a straight bitcast is wrong.
+    fn type_check_no_addr_space_change(&self, what: &str,
+                                       src: Self::Value,
+                                       dest_ty: Self::Type) {
+        let src_ty = self.val_ty(src);
+        match (self.type_addr_space(src_ty), self.type_addr_space(dest_ty)) {
+            (Some(src_as), Some(dest_as)) if src_as != dest_as => {
+                bug!("Invalid address space cast in `{}` cast:\n\
+                     source addr space `{}`, dest addr space `{}`\n\
+                     source value: {:?}, dest ty: {:?}", what,
+                     src_as, dest_as, src, dest_ty);
+            },
+            (Some(src_as), None) if src_as != self.flat_addr_space() => {
+                bug!("Invalid address space cast in `{}` cast:\n\
+                     source addr space `{}` is not flat\n\
+                     source value: {:?}",
+                     what, src_as, src);
+            },
+            _ => { },
+        }
+    }
+    fn type_ptr_to_alloca(&self, ty: Self::Type) -> Self::Type {
+        self.type_as_ptr_to(ty, self.alloca_addr_space())
+    }
+    fn type_ptr_to_const(&self, ty: Self::Type) -> Self::Type {
+        self.type_as_ptr_to(ty, self.const_addr_space())
+    }
+    fn type_ptr_to_mut(&self, ty: Self::Type) -> Self::Type {
+        self.type_as_ptr_to(ty, self.mutable_addr_space())
+    }
+    fn type_ptr_to_flat(&self, ty: Self::Type) -> Self::Type {
+        self.type_as_ptr_to(ty, self.flat_addr_space())
     }
 }
 

--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -1,7 +1,7 @@
 pub use self::Integer::*;
 pub use self::Primitive::*;
 
-use spec::Target;
+use spec::{Target, AddrSpaceIdx, };
 
 use std::fmt;
 use std::ops::{Add, Deref, Sub, Mul, AddAssign, Range, RangeInclusive};
@@ -22,12 +22,15 @@ pub struct TargetDataLayout {
     pub i128_align: AbiAndPrefAlign,
     pub f32_align: AbiAndPrefAlign,
     pub f64_align: AbiAndPrefAlign,
+    pub pointers: Vec<Option<(Size, AbiAndPrefAlign)>>,
     pub pointer_size: Size,
     pub pointer_align: AbiAndPrefAlign,
     pub aggregate_align: AbiAndPrefAlign,
 
     /// Alignments for vector types.
     pub vector_align: Vec<(Size, AbiAndPrefAlign)>,
+
+    pub alloca_address_space: AddrSpaceIdx,
 
     pub instruction_address_space: u32,
 }
@@ -46,9 +49,11 @@ impl Default for TargetDataLayout {
             i128_align: AbiAndPrefAlign { abi: align(32), pref: align(64) },
             f32_align: AbiAndPrefAlign::new(align(32)),
             f64_align: AbiAndPrefAlign::new(align(64)),
+            pointers: vec![],
             pointer_size: Size::from_bits(64),
             pointer_align: AbiAndPrefAlign::new(align(64)),
             aggregate_align: AbiAndPrefAlign { abi: align(0), pref: align(64) },
+            alloca_address_space: Default::default(),
             vector_align: vec![
                 (Size::from_bits(64), AbiAndPrefAlign::new(align(64))),
                 (Size::from_bits(128), AbiAndPrefAlign::new(align(128))),
@@ -60,14 +65,6 @@ impl Default for TargetDataLayout {
 
 impl TargetDataLayout {
     pub fn parse(target: &Target) -> Result<TargetDataLayout, String> {
-        // Parse an address space index from a string.
-        let parse_address_space = |s: &str, cause: &str| {
-            s.parse::<u32>().map_err(|err| {
-                format!("invalid address space `{}` for `{}` in \"data-layout\": {}",
-                        s, cause, err)
-            })
-        };
-
         // Parse a bit count from a string.
         let parse_bits = |s: &str, kind: &str, cause: &str| {
             s.parse::<u64>().map_err(|err| {
@@ -100,23 +97,38 @@ impl TargetDataLayout {
             })
         };
 
+        fn resize_and_set<T>(vec: &mut Vec<T>, idx: usize, v: T)
+            where T: Default,
+        {
+          while idx >= vec.len() {
+            vec.push(T::default());
+          }
+
+          vec[idx] = v;
+        }
+
         let mut dl = TargetDataLayout::default();
         let mut i128_align_src = 64;
         for spec in target.data_layout.split('-') {
             match spec.split(':').collect::<Vec<_>>()[..] {
                 ["e"] => dl.endian = Endian::Little,
                 ["E"] => dl.endian = Endian::Big,
-                [p] if p.starts_with("P") => {
-                    dl.instruction_address_space = parse_address_space(&p[1..], "P")?
-                }
                 ["a", ref a..] => dl.aggregate_align = align(a, "a")?,
                 ["f32", ref a..] => dl.f32_align = align(a, "f32")?,
                 ["f64", ref a..] => dl.f64_align = align(a, "f64")?,
                 [p @ "p", s, ref a..] | [p @ "p0", s, ref a..] => {
                     dl.pointer_size = size(s, p)?;
                     dl.pointer_align = align(a, p)?;
-                }
-                [s, ref a..] if s.starts_with("i") => {
+                    resize_and_set(&mut dl.pointers, 0, Some((dl.pointer_size,
+                                                              dl.pointer_align)));
+                },
+                [p, s, ref a..] if p.starts_with('p') => {
+                  let idx = parse_bits(&p[1..], "u32", "address space index")? as usize;
+                  let size = size(s, p)?;
+                  let align = align(a, p)?;
+                  resize_and_set(&mut dl.pointers, idx, Some((size, align)));
+                },
+               [s, ref a..] if s.starts_with("i") => {
                     let bits = match s[1..].parse::<u64>() {
                         Ok(bits) => bits,
                         Err(_) => {
@@ -149,7 +161,13 @@ impl TargetDataLayout {
                     }
                     // No existing entry, add a new one.
                     dl.vector_align.push((v_size, a));
-                }
+                },
+                [s, ..] if s.starts_with("A") => {
+                    // default alloca address space
+                    let idx = parse_bits(&s[1..], "u32",
+                                         "default alloca address space")? as u32;
+                    dl.alloca_address_space = AddrSpaceIdx(idx);
+                },
                 _ => {} // Ignore everything else.
             }
         }
@@ -171,7 +189,35 @@ impl TargetDataLayout {
                                dl.pointer_size.bits(), target.target_pointer_width));
         }
 
+        // We don't specialize pointer sizes for specific address spaces,
+        // so enforce that the default address space can hold all the bits
+        // of any other spaces. Similar for alignment.
+        {
+            let ptrs_iter = dl.pointers.iter().enumerate()
+              .filter_map(|(idx, ptrs)| {
+                  ptrs.map(|(s, a)| (idx, s, a) )
+              });
+            for (idx, size, align) in ptrs_iter {
+                if size > dl.pointer_size {
+                    return Err(format!("Address space {} pointer is bigger than the default \
+                                    pointer: {} vs {}",
+                                       idx, size.bits(), dl.pointer_size.bits()));
+                }
+                if align.abi > dl.pointer_align.abi {
+                    return Err(format!("Address space {} pointer alignment is bigger than the \
+                                    default pointer: {} vs {}",
+                                       idx, align.abi.bits(), dl.pointer_align.abi.bits()));
+                }
+            }
+        }
+
         Ok(dl)
+    }
+
+    pub fn pointer_info(&self, addr_space: AddrSpaceIdx) -> (Size, AbiAndPrefAlign) {
+        self.pointers.get(addr_space.0 as usize)
+            .and_then(|&v| v )
+            .unwrap_or((self.pointer_size, self.pointer_align))
     }
 
     /// Return exclusive upper bound on object size.
@@ -938,5 +984,84 @@ impl<'a, Ty> TyLayout<'a, Ty> {
             Abi::Uninhabited => self.size.bytes() == 0,
             Abi::Aggregate { sized } => sized && self.size.bytes() == 0
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spec::{Target, TargetTriple, };
+
+    #[test]
+    fn pointer_size_align() {
+        // amdgcn-amd-amdhsa-amdgiz
+        const DL: &'static str = "e-p:64:64-p1:64:64-p2:64:64-p3:32:32-\
+                                  p4:32:32-p5:32:32-i64:64-v16:16-v24:32-\
+                                  v32:32-v48:64-v96:128-v192:256-v256:256-\
+                                  v512:512-v1024:1024-v2048:2048-n32:64-A5";
+
+        // Doesn't need to be real...
+        let triple = TargetTriple::TargetTriple("x86_64-unknown-linux-gnu".into());
+        let mut target = Target::search(&triple).unwrap();
+        target.data_layout = DL.into();
+
+        let dl = TargetDataLayout::parse(&target);
+        assert!(dl.is_ok());
+        let dl = dl.unwrap();
+
+        let default = (dl.pointer_size, dl.pointer_align);
+
+        let thirty_two_size = Size::from_bits(32);
+        let thirty_two_align = AbiAndPrefAlign::new(Align::from_bits(32).unwrap());
+        let thirty_two = (thirty_two_size, thirty_two_align);
+        let sixty_four_size = Size::from_bits(64);
+        let sixty_four_align = AbiAndPrefAlign::new(Align::from_bits(64).unwrap());
+        let sixty_four = (sixty_four_size, sixty_four_align);
+
+        assert_eq!(dl.pointer_info(AddrSpaceIdx(0)), default);
+        assert_eq!(dl.pointer_info(AddrSpaceIdx(0)), sixty_four);
+        assert_eq!(dl.pointer_info(AddrSpaceIdx(1)), sixty_four);
+        assert_eq!(dl.pointer_info(AddrSpaceIdx(2)), sixty_four);
+        assert_eq!(dl.pointer_info(AddrSpaceIdx(3)), thirty_two);
+        assert_eq!(dl.pointer_info(AddrSpaceIdx(4)), thirty_two);
+        assert_eq!(dl.pointer_info(AddrSpaceIdx(5)), thirty_two);
+
+        // unknown address spaces need to be the same as the default:
+        assert_eq!(dl.pointer_info(AddrSpaceIdx(7)), default);
+    }
+
+    #[test]
+    fn default_is_biggest() {
+        // Note p1 is 128 bits.
+        const DL: &'static str = "e-p:64:64-p1:128:128-p2:64:64-p3:32:32-\
+                                  p4:32:32-p5:32:32-i64:64-v16:16-v24:32-\
+                                  v32:32-v48:64-v96:128-v192:256-v256:256-\
+                                  v512:512-v1024:1024-v2048:2048-n32:64-A5";
+
+        // Doesn't need to be real...
+        let triple = TargetTriple::TargetTriple("x86_64-unknown-linux-gnu".into());
+        let mut target = Target::search(&triple).unwrap();
+        target.data_layout = DL.into();
+
+        assert!(TargetDataLayout::parse(&target).is_err());
+    }
+    #[test]
+    fn alloca_addr_space() {
+        // amdgcn-amd-amdhsa-amdgiz
+        const DL: &'static str = "e-p:64:64-p1:64:64-p2:64:64-p3:32:32-\
+                                  p4:32:32-p5:32:32-i64:64-v16:16-v24:32-\
+                                  v32:32-v48:64-v96:128-v192:256-v256:256-\
+                                  v512:512-v1024:1024-v2048:2048-n32:64-A5";
+
+        // Doesn't need to be real...
+        let triple = TargetTriple::TargetTriple("x86_64-unknown-linux-gnu".into());
+        let mut target = Target::search(&triple).unwrap();
+        target.data_layout = DL.into();
+
+        let dl = TargetDataLayout::parse(&target);
+        assert!(dl.is_ok());
+        let dl = dl.unwrap();
+
+        assert_eq!(dl.alloca_address_space, AddrSpaceIdx(5));
     }
 }

--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -31,8 +31,7 @@ pub struct TargetDataLayout {
     pub vector_align: Vec<(Size, AbiAndPrefAlign)>,
 
     pub alloca_address_space: AddrSpaceIdx,
-
-    pub instruction_address_space: u32,
+    pub instruction_address_space: AddrSpaceIdx,
 }
 
 impl Default for TargetDataLayout {
@@ -54,11 +53,11 @@ impl Default for TargetDataLayout {
             pointer_align: AbiAndPrefAlign::new(align(64)),
             aggregate_align: AbiAndPrefAlign { abi: align(0), pref: align(64) },
             alloca_address_space: Default::default(),
+            instruction_address_space: Default::default(),
             vector_align: vec![
                 (Size::from_bits(64), AbiAndPrefAlign::new(align(64))),
                 (Size::from_bits(128), AbiAndPrefAlign::new(align(128))),
             ],
-            instruction_address_space: 0,
         }
     }
 }
@@ -128,6 +127,11 @@ impl TargetDataLayout {
                   let align = align(a, p)?;
                   resize_and_set(&mut dl.pointers, idx, Some((size, align)));
                 },
+                [ref p] if p.starts_with("P") => {
+                    let idx = parse_bits(&p[1..], "u32",
+                                         "instruction address space")? as u32;
+                    dl.instruction_address_space = AddrSpaceIdx(idx);
+                }
                [s, ref a..] if s.starts_with("i") => {
                     let bits = match s[1..].parse::<u64>() {
                         Ok(bits) => bits,

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -35,11 +35,12 @@
 //! to the list specified by the target, rather than replace.
 
 use serialize::json::{Json, ToJson};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::default::Default;
 use std::{fmt, io};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::ops::{Deref, DerefMut, };
 use spec::abi::{Abi, lookup as lookup_abi};
 
 pub mod abi;
@@ -259,6 +260,158 @@ impl ToJson for MergeFunctions {
 
 pub type LinkArgs = BTreeMap<LinkerFlavor, Vec<String>>;
 pub type TargetResult = Result<Target, String>;
+
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub struct AddrSpaceIdx(pub u32);
+impl Default for AddrSpaceIdx {
+    fn default() -> Self {
+        AddrSpaceIdx(0)
+    }
+}
+impl fmt::Display for AddrSpaceIdx {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+impl FromStr for AddrSpaceIdx {
+    type Err = <u32 as FromStr>::Err;
+    fn from_str(s: &str) -> Result<AddrSpaceIdx, Self::Err> {
+        Ok(AddrSpaceIdx(u32::from_str(s)?))
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub enum AddrSpaceKind {
+    Flat,
+    Alloca,
+    /// aka constant
+    ReadOnly,
+    /// aka global
+    ReadWrite,
+    Named(String),
+}
+
+impl FromStr for AddrSpaceKind {
+    type Err = String;
+    fn from_str(s: &str) -> Result<AddrSpaceKind, String> {
+        Ok(match s {
+            "flat" => AddrSpaceKind::Flat,
+            "alloca" => AddrSpaceKind::Alloca,
+            "readonly" => AddrSpaceKind::ReadOnly,
+            "readwrite" => AddrSpaceKind::ReadWrite,
+            named => AddrSpaceKind::Named(named.into()),
+        })
+    }
+}
+impl fmt::Display for AddrSpaceKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", match self {
+            &AddrSpaceKind::Flat => "flat",
+            &AddrSpaceKind::Alloca => "alloca",
+            &AddrSpaceKind::ReadOnly => "readonly",
+            &AddrSpaceKind::ReadWrite => "readwrite",
+            &AddrSpaceKind::Named(ref s) => s,
+        })
+    }
+}
+impl ToJson for AddrSpaceKind {
+    fn to_json(&self) -> Json {
+        Json::String(format!("{}", self))
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct AddrSpaceProps {
+    pub index: AddrSpaceIdx,
+    /// Indicates which addr spaces this addr space can be addrspacecast-ed to.
+    pub shared_with: BTreeSet<AddrSpaceKind>,
+}
+
+impl AddrSpaceProps {
+    pub fn from_json(json: &Json) -> Result<Self, String> {
+        let index = json.find("index").and_then(|v| v.as_u64() )
+          .ok_or_else(|| {
+              "invalid address space index, expected an unsigned integer"
+          })?;
+
+        let mut shared_with = vec![];
+        if let Some(shared) = json.find("shared-with").and_then(|v| v.as_array() ) {
+            for s in shared {
+                let s = s.as_string()
+                    .ok_or_else(|| {
+                        "expected string for address space kind"
+                    })?;
+
+                let kind = AddrSpaceKind::from_str(s)?;
+                shared_with.push(kind);
+            }
+        }
+
+        Ok(AddrSpaceProps {
+            index: AddrSpaceIdx(index as u32),
+            shared_with: shared_with.into_iter().collect(),
+        })
+    }
+}
+impl ToJson for AddrSpaceProps {
+    fn to_json(&self) -> Json {
+        let mut obj = BTreeMap::new();
+        obj.insert("index".to_string(), self.index.0.to_json());
+        let mut shared_with = vec![];
+        for sw in self.shared_with.iter() {
+            shared_with.push(sw.to_json());
+        }
+        obj.insert("shared-with".to_string(), Json::Array(shared_with));
+
+        Json::Object(obj)
+    }
+}
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct AddrSpaces(pub BTreeMap<AddrSpaceKind, AddrSpaceProps>);
+impl Deref for AddrSpaces {
+    type Target = BTreeMap<AddrSpaceKind, AddrSpaceProps>;
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+impl DerefMut for AddrSpaces {
+    fn deref_mut(&mut self) -> &mut BTreeMap<AddrSpaceKind, AddrSpaceProps> { &mut self.0 }
+}
+impl ToJson for AddrSpaces {
+    fn to_json(&self) -> Json {
+        let obj = self.iter()
+          .map(|(k, v)| {
+              (format!("{}", k), v.to_json())
+          })
+          .collect();
+        Json::Object(obj)
+    }
+}
+impl Default for AddrSpaces {
+    fn default() -> Self {
+        let mut asp = BTreeMap::new();
+
+        let kinds = vec![AddrSpaceKind::ReadOnly,
+                         AddrSpaceKind::ReadWrite,
+                         AddrSpaceKind::Alloca,
+                         AddrSpaceKind::Flat, ];
+
+        let insert = |asp: &mut BTreeMap<_, _>, kind, idx| {
+            let props = AddrSpaceProps {
+                index: idx,
+                shared_with: kinds.clone()
+                  .into_iter()
+                  .filter(|k| *k != kind)
+                  .collect(),
+            };
+            assert!(asp.insert(kind, props).is_none());
+        };
+
+        for kind in kinds.iter() {
+            insert(&mut asp, kind.clone(), Default::default());
+        }
+
+        AddrSpaces(asp)
+    }
+}
 
 macro_rules! supported_targets {
     ( $(($triple:expr, $module:ident),)+ ) => (
@@ -732,6 +885,11 @@ pub struct TargetOptions {
     /// the usual logic to figure this out from the crate itself.
     pub override_export_symbols: Option<Vec<String>>,
 
+    /// Description of all address spaces and how they are shared with one another.
+    /// Defaults to a single, flat, address space. Note it is generally assumed that
+    /// the address space `0` is your flat address space.
+    pub addr_spaces: AddrSpaces,
+
     /// Determines how or whether the MergeFunctions LLVM pass should run for
     /// this target. Either "disabled", "trampolines", or "aliases".
     /// The MergeFunctions pass is generally useful, but some targets may need
@@ -821,6 +979,7 @@ impl Default for TargetOptions {
             requires_uwtable: false,
             simd_types_indirect: true,
             override_export_symbols: None,
+            addr_spaces: Default::default(),
             merge_functions: MergeFunctions::Aliases,
         }
     }
@@ -1051,6 +1210,16 @@ impl Target {
                     }
                 }
             } );
+            ($key_name:ident, addr_spaces) => ( {
+                let name = (stringify!($key_name)).replace("_", "-");
+                if let Some(obj) = obj.find(&name[..]).and_then(|o| o.as_object() ) {
+                    for (k, v) in obj {
+                        let k = AddrSpaceKind::from_str(&k).unwrap();
+                        let props = AddrSpaceProps::from_json(v)?;
+                        base.options.$key_name.insert(k, props);
+                    }
+                }
+            } );
         }
 
         key!(is_builtin, bool);
@@ -1126,6 +1295,7 @@ impl Target {
         key!(requires_uwtable, bool);
         key!(simd_types_indirect, bool);
         key!(override_export_symbols, opt_list);
+        key!(addr_spaces, addr_spaces);
         key!(merge_functions, MergeFunctions)?;
 
         if let Some(array) = obj.find("abi-blacklist").and_then(Json::as_array) {
@@ -1338,6 +1508,7 @@ impl ToJson for Target {
         target_option_val!(requires_uwtable);
         target_option_val!(simd_types_indirect);
         target_option_val!(override_export_symbols);
+        target_option_val!(addr_spaces);
         target_option_val!(merge_functions);
 
         if default.abi_blacklist != self.options.abi_blacklist {

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -288,6 +288,8 @@ pub enum AddrSpaceKind {
     ReadOnly,
     /// aka global
     ReadWrite,
+    /// For Harvard architectures, the program instruction's address space
+    Instruction,
     Named(String),
 }
 
@@ -299,6 +301,7 @@ impl FromStr for AddrSpaceKind {
             "alloca" => AddrSpaceKind::Alloca,
             "readonly" => AddrSpaceKind::ReadOnly,
             "readwrite" => AddrSpaceKind::ReadWrite,
+            "instruction" => AddrSpaceKind::Instruction,
             named => AddrSpaceKind::Named(named.into()),
         })
     }
@@ -310,6 +313,7 @@ impl fmt::Display for AddrSpaceKind {
             &AddrSpaceKind::Alloca => "alloca",
             &AddrSpaceKind::ReadOnly => "readonly",
             &AddrSpaceKind::ReadWrite => "readwrite",
+            &AddrSpaceKind::Instruction => "instruction",
             &AddrSpaceKind::Named(ref s) => s,
         })
     }
@@ -389,10 +393,13 @@ impl Default for AddrSpaces {
     fn default() -> Self {
         let mut asp = BTreeMap::new();
 
-        let kinds = vec![AddrSpaceKind::ReadOnly,
-                         AddrSpaceKind::ReadWrite,
-                         AddrSpaceKind::Alloca,
-                         AddrSpaceKind::Flat, ];
+        let kinds = vec![
+            AddrSpaceKind::ReadOnly,
+            AddrSpaceKind::ReadWrite,
+            AddrSpaceKind::Alloca,
+            AddrSpaceKind::Flat,
+            AddrSpaceKind::Instruction,
+        ];
 
         let insert = |asp: &mut BTreeMap<_, _>, kind, idx| {
             let props = AddrSpaceProps {

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -121,17 +121,35 @@ extern "C" LLVMValueRef LLVMRustGetOrInsertFunction(LLVMModuleRef M,
 }
 
 extern "C" LLVMValueRef
-LLVMRustGetOrInsertGlobal(LLVMModuleRef M, const char *Name, LLVMTypeRef Ty) {
-  return wrap(unwrap(M)->getOrInsertGlobal(Name, unwrap(Ty)));
+LLVMRustGetOrInsertGlobal(LLVMModuleRef M, const char *Name, LLVMTypeRef Ty, unsigned AS) {
+  GlobalVariable* GV = nullptr;
+  Module* MM = unwrap(M);
+  Type* ETy = unwrap(Ty);
+  if (!(GV = MM->getNamedGlobal(Name))) {
+    GV = new GlobalVariable(ETy, false, GlobalVariable::ExternalLinkage,
+                            nullptr, Name, GlobalVariable::NotThreadLocal, AS);
+    MM->getGlobalList().push_back(GV);
+  }
+  Type *GVTy = GV->getType();
+  PointerType *PTy = PointerType::get(ETy, GVTy->getPointerAddressSpace());
+  if (GVTy != PTy) {
+     return wrap(ConstantExpr::getBitCast(GV, PTy));
+  } else {
+     return wrap(GV);
+  }
 }
 
 extern "C" LLVMValueRef
-LLVMRustInsertPrivateGlobal(LLVMModuleRef M, LLVMTypeRef Ty) {
+LLVMRustInsertPrivateGlobal(LLVMModuleRef M, LLVMTypeRef Ty, unsigned AS) {
   return wrap(new GlobalVariable(*unwrap(M),
                                  unwrap(Ty),
                                  false,
                                  GlobalValue::PrivateLinkage,
-                                 nullptr));
+                                 nullptr,
+                                 "",
+                                 nullptr,
+                                 GlobalVariable::NotThreadLocal,
+                                 AS));
 }
 
 extern "C" LLVMTypeRef LLVMRustMetadataTypeInContext(LLVMContextRef C) {


### PR DESCRIPTION
In order to not require overloading functions based on their argument's address
space (among other things), we require the presence of a "flat" (ie an address
space which is shared with every other address space) address space.

This isn't exposed in any way to Rust code. This just makes Rust compatible with
LLVM target machines which, for example, place allocas in a different address
space. `amdgcn-amd-amdhsa-amdgiz` is a specific example, which places allocas in
address space 5 or the private (at the work item level) address space. This
includes working with nonuniform sized pointers.