### PR TITLE
rustc_codegen_llvm: don't treat i1 as signed, even for #[repr(i8)] enums.

### DIFF
--- a/src/test/run-pass/issue-51582.rs
+++ b/src/test/run-pass/issue-51582.rs
@@ -1,0 +1,27 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(core_intrinsics)]
+
+#[repr(i8)]
+pub enum Enum {
+    VariantA,
+    VariantB,
+}
+
+fn make_b() -> Enum { Enum::VariantB }
+
+fn main() {
+    assert_eq!(1, make_b() as i8);
+    assert_eq!(1, make_b() as u8);
+    assert_eq!(1, make_b() as i32);
+    assert_eq!(1, make_b() as u32);
+    assert_eq!(1, unsafe { std::intrinsics::discriminant_value(&make_b()) });
+}


### PR DESCRIPTION
Fixes #51582. r? @nagisa cc @nox @oli-obk 