### PR TITLE
Prevent Windows filesystem races in bootstrap tests

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -370,7 +370,6 @@ impl<'a> Builder<'a> {
             ),
             Kind::Test => describe!(
                 test::Tidy,
-                test::Bootstrap,
                 test::Ui,
                 test::RunPass,
                 test::CompileFail,
@@ -416,6 +415,8 @@ impl<'a> Builder<'a> {
                 test::Clippy,
                 test::RustdocJS,
                 test::RustdocTheme,
+                // Run bootstrap close to the end as it's unlikely to fail
+                test::Bootstrap,
                 // Run run-make last, since these won't pass without make on Windows
                 test::RunMake,
                 test::RustdocUi

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1921,6 +1921,9 @@ impl Step for Bootstrap {
             cmd.arg("--no-fail-fast");
         }
         cmd.arg("--").args(&builder.config.cmd.test_args());
+        // rustbuild tests are racy on directory creation so just run them one at a time.
+        // Since there's not many this shouldn't be a problem.
+        cmd.arg("--test-threads=1");
         try_run(builder, &mut cmd);
     }
 


### PR DESCRIPTION
Fixes #51595.

This also makes bootstrap tests run near last in `./x.py test` invocations
since they are unlikely to fail.

r? @petrochenkov