### PR TITLE
Optimize sum of Durations by using custom function

### DIFF
--- a/src/libcore/tests/time.rs
+++ b/src/libcore/tests/time.rs
@@ -162,6 +162,20 @@ fn checked_div() {
 }
 
 #[test]
+fn correct_sum() {
+    let durations = [
+        Duration::new(1, 999_999_999),
+        Duration::new(2, 999_999_999),
+        Duration::new(0, 999_999_999),
+        Duration::new(0, 999_999_999),
+        Duration::new(0, 999_999_999),
+        Duration::new(5, 0),
+    ];
+    let sum = durations.iter().sum::<Duration>();
+    assert_eq!(sum, Duration::new(1+2+5+4, 1_000_000_000 - 5));
+}
+
+#[test]
 fn debug_formatting_extreme_values() {
     assert_eq!(
         format!("{:?}", Duration::new(18_446_744_073_709_551_615, 123_456_789)),

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -524,17 +524,47 @@ impl DivAssign<u32> for Duration {
     }
 }
 
+macro_rules! sum_durations {
+    ($iter:expr) => {{
+        let mut total_secs: u64 = 0;
+        let mut total_nanos: u64 = 0;
+
+        for entry in $iter {
+            total_secs = total_secs
+                .checked_add(entry.secs)
+                .expect("overflow in iter::sum over durations");
+            total_nanos = match total_nanos.checked_add(entry.nanos as u64) {
+                Some(n) => n,
+                None => {
+                    total_secs = total_secs
+                        .checked_add(total_nanos / NANOS_PER_SEC as u64)
+                        .expect("overflow in iter::sum over durations");
+                    (total_nanos % NANOS_PER_SEC as u64) + entry.nanos as u64
+                }
+            };
+        }
+        total_secs = total_secs
+            .checked_add(total_nanos / NANOS_PER_SEC as u64)
+            .expect("overflow in iter::sum over durations");
+        total_nanos = total_nanos % NANOS_PER_SEC as u64;
+        Duration {
+            secs: total_secs,
+            nanos: total_nanos as u32,
+        }
+    }};
+}
+
 #[stable(feature = "duration_sum", since = "1.16.0")]
 impl Sum for Duration {
     fn sum<I: Iterator<Item=Duration>>(iter: I) -> Duration {
-        iter.fold(Duration::new(0, 0), |a, b| a + b)
+        sum_durations!(iter)
     }
 }
 
 #[stable(feature = "duration_sum", since = "1.16.0")]
 impl<'a> Sum<&'a Duration> for Duration {
     fn sum<I: Iterator<Item=&'a Duration>>(iter: I) -> Duration {
-        iter.fold(Duration::new(0, 0), |a, b| a + *b)
+        sum_durations!(iter)
     }
 }
 


### PR DESCRIPTION
The current `impl Sum for Duration` uses `fold` to perform several `add`s (or really `checked_add`s) of durations. In doing so, it has to guarantee the number of nanoseconds is valid after every addition. If you squeese the current implementation into a single function it looks kind of like this:
````rust
fn sum<I: Iterator<Item = Duration>>(iter: I) -> Duration {
    let mut sum = Duration::new(0, 0);
    for rhs in iter {
        if let Some(mut secs) = sum.secs.checked_add(rhs.secs) {
            let mut nanos = sum.nanos + rhs.nanos;
            if nanos >= NANOS_PER_SEC {
                nanos -= NANOS_PER_SEC;
                if let Some(new_secs) = secs.checked_add(1) {
                    secs = new_secs;
                } else {
                    panic!("overflow when adding durations");
                }
            }
            sum = Duration { secs, nanos }
        } else {
            panic!("overflow when adding durations");
        }
    }
    sum
}
````
We only need to check if `nanos` is in the correct range when giving our final answer so we can have a more optimized version like so:
````rust
fn sum<I: Iterator<Item = Duration>>(iter: I) -> Duration {
    let mut total_secs: u64 = 0;
    let mut total_nanos: u64 = 0;

    for entry in iter {
        total_secs = total_secs
            .checked_add(entry.secs)
            .expect("overflow in iter::sum over durations");
        total_nanos = match total_nanos.checked_add(entry.nanos as u64) {
            Some(n) => n,
            None => {
                total_secs = total_secs
                    .checked_add(total_nanos / NANOS_PER_SEC as u64)
                    .expect("overflow in iter::sum over durations");
                (total_nanos % NANOS_PER_SEC as u64) + entry.nanos as u64
            }
        };
    }
    total_secs = total_secs
        .checked_add(total_nanos / NANOS_PER_SEC as u64)
        .expect("overflow in iter::sum over durations");
    total_nanos = total_nanos % NANOS_PER_SEC as u64;
    Duration {
        secs: total_secs,
        nanos: total_nanos as u32,
    }
}
````
We now only convert `total_nanos` to `total_secs` (1) if `total_nanos` overflows and (2) at the end of the function when we have to output a valid `Duration`. This gave a 5-22% performance improvement when I benchmarked it, depending on how big the `nano` value of the `Duration`s in `iter` were.