### PR TITLE
Undeprecate `thread::sleep_ms`

### DIFF
--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -652,6 +652,8 @@ pub fn panicking() -> bool {
 
 /// Puts the current thread to sleep for the specified amount of time.
 ///
+/// Equivalent to `sleep(Duration::from_millis(ms))`.
+///
 /// The thread may sleep longer than the duration specified due to scheduling
 /// specifics or platform-dependent functionality.
 ///
@@ -669,7 +671,6 @@ pub fn panicking() -> bool {
 /// thread::sleep_ms(2000);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.6.0", reason = "replaced by `std::thread::sleep`")]
 pub fn sleep_ms(ms: u32) {
     sleep(Duration::from_millis(ms as u64))
 }


### PR DESCRIPTION
Hi! Currently, `thread::sleep_ms` is deprecated in favor of `thread::sleep`, but I want to argue that `_ms` variant is really useful and we should un-deprecate it :) 

`sleep` is an odd function, in that it is rarely useful in "real code"; you almost always want to wait for some condition to happen rather than just sleep for some wall-clock time.

However, there are two "not real code" cases where sleep is used **a lot**:

1. Debugging: it might be useful to insert `sleep(a little)` to freeze the system in some particular state. For example, it could be useful to wait to be able to attach debugger to some process, or to expose some race condition.

2. Tests: although sleep in tests is in general an awful idea, sometimes there's just no way around it, and in test code such "correct with some luck" code might actually be acceptable. As an example, in Cargo tests we sleep for a second sometimes because mtimes on MacOS have resolution of one second. 

Both of this use-cases are write once/read never, and you have the time to sleep as an integer constant. For such use-cases `sleep_ms(92)` is so much shorter and clearer than `sleep(Duration::from_millis(92))`.

Moreover, for debugging case you'd really want to avoid adding imports (luckily, we live in a glorious age when IDEs can insert imports for you automatically, but you *will* forget to remove the import once sleep is deleted), and the difference between `::std::thread::sleep_ms(92)` and `::std::thread::sleep(::std::time::Duration::from_millis(92))` is even more pronounced!


I think there are no problems with `sleep_ms` per se, besides it being non-orthogonal with `sleep`? It should be fine to add common-case utility functions which are expressed in terms of underling low-level API (case study: `println` and `eprintln`). <sarcasm\>One potential problem is that someone could try to use `sleep_ms` to sleep for a given `Duration`. Luckily, it is excruciatingly non-trivial to extract milliseconds from a `Duration`, and this should help the user to discover `thread::sleep`</sarcasm\>.



Note: we actually have `sleep_ms` function [in Cargo](https://github.com/rust-lang/cargo/blob/e2348c2db296ce33428933c3ab8786d5f3c54a2e/tests/testsuite/cargotest/mod.rs#L177) for tests specifically. 