### PR TITLE
rustdoc: import cross-crate macros alongside everything else

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -104,7 +104,7 @@ pub fn try_inline(cx: &DocContext, def: Def, name: ast::Name, visited: &mut FxHa
         // separately
         Def::Macro(did, MacroKind::Bang) => {
             record_extern_fqn(cx, did, clean::TypeKind::Macro);
-            clean::MacroItem(build_macro(cx, did))
+            clean::MacroItem(build_macro(cx, did, name))
         }
         _ => return None,
     };
@@ -463,7 +463,7 @@ fn build_static(cx: &DocContext, did: DefId, mutable: bool) -> clean::Static {
     }
 }
 
-fn build_macro(cx: &DocContext, did: DefId) -> clean::Macro {
+fn build_macro(cx: &DocContext, did: DefId, name: ast::Name) -> clean::Macro {
     let imported_from = cx.tcx.original_crate_name(did.krate);
     let def = match cx.cstore.load_macro_untracked(did, cx.sess()) {
         LoadedMacro::MacroDef(macro_def) => macro_def,
@@ -479,7 +479,7 @@ fn build_macro(cx: &DocContext, did: DefId) -> clean::Macro {
     };
 
     let source = format!("macro_rules! {} {{\n{}}}",
-                         def.ident.name.clean(cx),
+                         name.clean(cx),
                          matchers.iter().map(|span| {
                              format!("    {} => {{ ... }};\n", span.to_src(cx))
                          }).collect::<String>());

--- a/src/test/rustdoc/cross-crate-links.rs
+++ b/src/test/rustdoc/cross-crate-links.rs
@@ -66,6 +66,6 @@ pub use all_item_types::FOO_STATIC;
 #[doc(no_inline)]
 pub use all_item_types::FOO_CONSTANT;
 
-// @has 'foo/index.html' '//a[@href="../foo/macro.foo_macro.html"]' 'foo_macro'
+// @has 'foo/index.html' '//a[@href="../all_item_types/macro.foo_macro.html"]' 'foo_macro'
 #[doc(no_inline)]
 pub use all_item_types::foo_macro;

--- a/src/test/rustdoc/inline_cross/auxiliary/macro-vis.rs
+++ b/src/test/rustdoc/inline_cross/auxiliary/macro-vis.rs
@@ -1,0 +1,35 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "qwop"]
+
+/// (writen on a spider's web) Some Macro
+#[macro_export]
+macro_rules! some_macro {
+    () => {
+        println!("this is some macro, for sure");
+    };
+}
+
+/// Some other macro, to fill space.
+#[macro_export]
+macro_rules! other_macro {
+    () => {
+        println!("this is some other macro, whatev");
+    };
+}
+
+/// This macro is so cool, it's Super.
+#[macro_export]
+macro_rules! super_macro {
+    () => {
+        println!("is it a bird? a plane? no, it's Super Macro!");
+    };
+}

--- a/src/test/rustdoc/inline_cross/macro-vis.rs
+++ b/src/test/rustdoc/inline_cross/macro-vis.rs
@@ -1,0 +1,42 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:macro-vis.rs
+// build-aux-docs
+// ignore-cross-compile
+
+#![feature(use_extern_macros)]
+
+#[macro_use] extern crate qwop;
+
+// @has macro_vis/macro.some_macro.html
+// @has macro_vis/index.html '//a/@href' 'macro.some_macro.html'
+pub use qwop::some_macro;
+
+// @!has macro_vis/macro.other_macro.html
+// @!has macro_vis/index.html '//a/@href' 'macro.other_macro.html'
+// @!has - '//code' 'pub use qwop::other_macro;'
+#[doc(hidden)]
+pub use qwop::other_macro;
+
+// @has macro_vis/index.html '//code' 'pub use qwop::super_macro;'
+// @!has macro_vis/macro.super_macro.html
+#[doc(no_inline)]
+pub use qwop::super_macro;
+
+// @has macro_vis/macro.this_is_dope.html
+// @has macro_vis/index.html '//a/@href' 'macro.this_is_dope.html'
+/// What it says on the tin.
+#[macro_export]
+macro_rules! this_is_dope {
+    () => {
+        println!("yo check this out");
+    };
+}

--- a/src/test/rustdoc/inline_cross/macro-vis.rs
+++ b/src/test/rustdoc/inline_cross/macro-vis.rs
@@ -20,6 +20,12 @@
 // @has macro_vis/index.html '//a/@href' 'macro.some_macro.html'
 pub use qwop::some_macro;
 
+// @has macro_vis/macro.renamed_macro.html
+// @!has - '//pre' 'some_macro'
+// @has macro_vis/index.html '//a/@href' 'macro.renamed_macro.html'
+#[doc(inline)]
+pub use qwop::some_macro as renamed_macro;
+
 // @!has macro_vis/macro.other_macro.html
 // @!has macro_vis/index.html '//a/@href' 'macro.other_macro.html'
 // @!has - '//code' 'pub use qwop::other_macro;'

--- a/src/test/rustdoc/pub-use-extern-macros.rs
+++ b/src/test/rustdoc/pub-use-extern-macros.rs
@@ -23,7 +23,7 @@ pub use macros::bar;
 #[doc(inline)]
 pub use macros::baz;
 
-// @has pub_use_extern_macros/macro.quux.html
+// @!has pub_use_extern_macros/macro.quux.html
 // @!has pub_use_extern_macros/index.html '//code' 'pub use macros::quux;'
 #[doc(hidden)]
 pub use macros::quux;


### PR DESCRIPTION
The thrilling conclusion of the cross-crate macro saga in rustdoc! After https://github.com/rust-lang/rust/pull/51425 made sure we saw all the namespaces of an import (and prevented us from losing the `vec!` macro in std's documentation), here is the PR to handle cross-crate macro re-exports at the same time as everything else. This way, attributes like `#[doc(hidden)]` and `#[doc(no_inline)]` can be used to control how the documentation for these macros is seen, rather than rustdoc inlining every macro every time.

Fixes https://github.com/rust-lang/rust/issues/50647