### PR TITLE
Change RangeInclusive to a three-field struct.

### DIFF
--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -787,17 +787,19 @@ where
     #[inline]
     fn spec_next(&mut self) -> Option<Self::Item> {
         self.first_take = false;
-        if !(self.iter.start <= self.iter.end) {
+        if self.iter.is_empty() {
+            self.iter.is_iterating = Some(false);
             return None;
         }
         // add 1 to self.step to get original step size back
         // it was decremented for the general case on construction
         if let Some(n) = self.iter.start.add_usize(self.step+1) {
+            self.iter.is_iterating = Some(n <= self.iter.end);
             let next = mem::replace(&mut self.iter.start, n);
             Some(next)
         } else {
-            let last = self.iter.start.replace_one();
-            self.iter.end.replace_zero();
+            let last = self.iter.start.clone();
+            self.iter.is_iterating = Some(false);
             Some(last)
         }
     }

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -787,19 +787,19 @@ where
     #[inline]
     fn spec_next(&mut self) -> Option<Self::Item> {
         self.first_take = false;
-        if self.iter.is_empty() {
-            self.iter.is_iterating = Some(false);
+        self.iter.compute_is_empty();
+        if self.iter.is_empty.unwrap_or_default() {
             return None;
         }
         // add 1 to self.step to get original step size back
         // it was decremented for the general case on construction
         if let Some(n) = self.iter.start.add_usize(self.step+1) {
-            self.iter.is_iterating = Some(n <= self.iter.end);
+            self.iter.is_empty = Some(!(n <= self.iter.end));
             let next = mem::replace(&mut self.iter.start, n);
             Some(next)
         } else {
             let last = self.iter.start.clone();
-            self.iter.is_iterating = Some(false);
+            self.iter.is_empty = Some(true);
             Some(last)
         }
     }

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -330,18 +330,18 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
 
     #[inline]
     fn next(&mut self) -> Option<A> {
-        if self.is_empty() {
-            self.is_iterating = Some(false);
+        self.compute_is_empty();
+        if self.is_empty.unwrap_or_default() {
             return None;
         }
-        if self.start < self.end {
+        let is_iterating = self.start < self.end;
+        self.is_empty = Some(!is_iterating);
+        Some(if is_iterating {
             let n = self.start.add_one();
-            self.is_iterating = Some(true);
-            Some(mem::replace(&mut self.start, n))
+            mem::replace(&mut self.start, n)
         } else {
-            self.is_iterating = Some(false);
-            Some(self.start.clone())
-        }
+            self.start.clone()
+        })
     }
 
     #[inline]
@@ -358,8 +358,8 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
 
     #[inline]
     fn nth(&mut self, n: usize) -> Option<A> {
-        if self.is_empty() {
-            self.is_iterating = Some(false);
+        self.compute_is_empty();
+        if self.is_empty.unwrap_or_default() {
             return None;
         }
 
@@ -368,19 +368,19 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
 
             match plus_n.partial_cmp(&self.end) {
                 Some(Less) => {
-                    self.is_iterating = Some(true);
+                    self.is_empty = Some(false);
                     self.start = plus_n.add_one();
                     return Some(plus_n)
                 }
                 Some(Equal) => {
-                    self.is_iterating = Some(false);
+                    self.is_empty = Some(true);
                     return Some(plus_n)
                 }
                 _ => {}
             }
         }
 
-        self.is_iterating = Some(false);
+        self.is_empty = Some(true);
         None
     }
 
@@ -404,18 +404,18 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
 impl<A: Step> DoubleEndedIterator for ops::RangeInclusive<A> {
     #[inline]
     fn next_back(&mut self) -> Option<A> {
-        if self.is_empty() {
-            self.is_iterating = Some(false);
+        self.compute_is_empty();
+        if self.is_empty.unwrap_or_default() {
             return None;
         }
-        if self.start < self.end {
+        let is_iterating = self.start < self.end;
+        self.is_empty = Some(!is_iterating);
+        Some(if is_iterating {
             let n = self.end.sub_one();
-            self.is_iterating = Some(true);
-            Some(mem::replace(&mut self.end, n))
+            mem::replace(&mut self.end, n)
         } else {
-            self.is_iterating = Some(false);
-            Some(self.end.clone())
-        }
+            self.end.clone()
+        })
     }
 }
 

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -2262,36 +2262,36 @@ impl<T> SliceIndex<[T]> for ops::RangeInclusive<usize> {
 
     #[inline]
     fn get(self, slice: &[T]) -> Option<&[T]> {
-        if self.end == usize::max_value() { None }
-        else { (self.start..self.end + 1).get(slice) }
+        if *self.end() == usize::max_value() { None }
+        else { (*self.start()..self.end() + 1).get(slice) }
     }
 
     #[inline]
     fn get_mut(self, slice: &mut [T]) -> Option<&mut [T]> {
-        if self.end == usize::max_value() { None }
-        else { (self.start..self.end + 1).get_mut(slice) }
+        if *self.end() == usize::max_value() { None }
+        else { (*self.start()..self.end() + 1).get_mut(slice) }
     }
 
     #[inline]
     unsafe fn get_unchecked(self, slice: &[T]) -> &[T] {
-        (self.start..self.end + 1).get_unchecked(slice)
+        (*self.start()..self.end() + 1).get_unchecked(slice)
     }
 
     #[inline]
     unsafe fn get_unchecked_mut(self, slice: &mut [T]) -> &mut [T] {
-        (self.start..self.end + 1).get_unchecked_mut(slice)
+        (*self.start()..self.end() + 1).get_unchecked_mut(slice)
     }
 
     #[inline]
     fn index(self, slice: &[T]) -> &[T] {
-        if self.end == usize::max_value() { slice_index_overflow_fail(); }
-        (self.start..self.end + 1).index(slice)
+        if *self.end() == usize::max_value() { slice_index_overflow_fail(); }
+        (*self.start()..self.end() + 1).index(slice)
     }
 
     #[inline]
     fn index_mut(self, slice: &mut [T]) -> &mut [T] {
-        if self.end == usize::max_value() { slice_index_overflow_fail(); }
-        (self.start..self.end + 1).index_mut(slice)
+        if *self.end() == usize::max_value() { slice_index_overflow_fail(); }
+        (*self.start()..self.end() + 1).index_mut(slice)
     }
 }
 

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -2004,31 +2004,31 @@ mod traits {
         type Output = str;
         #[inline]
         fn get(self, slice: &str) -> Option<&Self::Output> {
-            if self.end == usize::max_value() { None }
-            else { (self.start..self.end+1).get(slice) }
+            if *self.end() == usize::max_value() { None }
+            else { (*self.start()..self.end()+1).get(slice) }
         }
         #[inline]
         fn get_mut(self, slice: &mut str) -> Option<&mut Self::Output> {
-            if self.end == usize::max_value() { None }
-            else { (self.start..self.end+1).get_mut(slice) }
+            if *self.end() == usize::max_value() { None }
+            else { (*self.start()..self.end()+1).get_mut(slice) }
         }
         #[inline]
         unsafe fn get_unchecked(self, slice: &str) -> &Self::Output {
-            (self.start..self.end+1).get_unchecked(slice)
+            (*self.start()..self.end()+1).get_unchecked(slice)
         }
         #[inline]
         unsafe fn get_unchecked_mut(self, slice: &mut str) -> &mut Self::Output {
-            (self.start..self.end+1).get_unchecked_mut(slice)
+            (*self.start()..self.end()+1).get_unchecked_mut(slice)
         }
         #[inline]
         fn index(self, slice: &str) -> &Self::Output {
-            if self.end == usize::max_value() { str_index_overflow_fail(); }
-            (self.start..self.end+1).index(slice)
+            if *self.end() == usize::max_value() { str_index_overflow_fail(); }
+            (*self.start()..self.end()+1).index(slice)
         }
         #[inline]
         fn index_mut(self, slice: &mut str) -> &mut Self::Output {
-            if self.end == usize::max_value() { str_index_overflow_fail(); }
-            (self.start..self.end+1).index_mut(slice)
+            if *self.end() == usize::max_value() { str_index_overflow_fail(); }
+            (*self.start()..self.end()+1).index_mut(slice)
         }
     }
 

--- a/src/test/codegen/issue-45222.rs
+++ b/src/test/codegen/issue-45222.rs
@@ -1,0 +1,74 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -O
+// min-llvm-version 6.0
+
+#![crate_type = "lib"]
+
+// verify that LLVM recognizes a loop involving 0..=n and will const-fold it.
+
+//------------------------------------------------------------------------------
+// Example from original issue #45222
+
+fn foo2(n: u64) -> u64 {
+    let mut count = 0;
+    for _ in 0..n {
+        for j in (0..=n).rev() {
+            count += j;
+        }
+    }
+    count
+}
+
+// CHECK-LABEL: @check_foo2
+#[no_mangle]
+pub fn check_foo2() -> u64 {
+    // CHECK: ret i64 500005000000000
+    foo2(100000)
+}
+
+//------------------------------------------------------------------------------
+// Simplified example of #45222
+
+fn triangle_inc(n: u64) -> u64 {
+    let mut count = 0;
+    for j in 0 ..= n {
+        count += j;
+    }
+    count
+}
+
+// CHECK-LABEL: @check_triangle_inc
+#[no_mangle]
+pub fn check_triangle_inc() -> u64 {
+    // CHECK: ret i64 5000050000
+    triangle_inc(100000)
+}
+
+//------------------------------------------------------------------------------
+// Demo in #48012
+
+fn foo3r(n: u64) -> u64 {
+    let mut count = 0;
+    (0..n).for_each(|_| {
+        (0 ..= n).rev().for_each(|j| {
+            count += j;
+        })
+    });
+    count
+}
+
+// CHECK-LABEL: @check_foo3r
+#[no_mangle]
+pub fn check_foo3r() -> u64 {
+    // CHECK: ret i64 500005000000000
+    foo3r(100000)
+}

--- a/src/test/run-pass/range_inclusive.rs
+++ b/src/test/run-pass/range_inclusive.rs
@@ -10,12 +10,18 @@
 
 // Test inclusive range syntax.
 
-use std::ops::{RangeInclusive, RangeToInclusive};
+#![feature(range_is_empty)]
+#![allow(unused_comparisons)]
+
+use std::ops::RangeToInclusive;
 
 fn foo() -> isize { 42 }
 
 // Test that range syntax works in return statements
-fn return_range_to() -> RangeToInclusive<i32> { return ..=1; }
+pub fn return_range_to() -> RangeToInclusive<i32> { return ..=1; }
+
+#[derive(Debug)]
+struct P(u8);
 
 pub fn main() {
     let mut count = 0;
@@ -26,7 +32,7 @@ pub fn main() {
     assert_eq!(count, 55);
 
     let mut count = 0;
-    let mut range = 0_usize..=10;
+    let range = 0_usize..=10;
     for i in range {
         assert!(i >= 0 && i <= 10);
         count += i;
@@ -80,7 +86,7 @@ pub fn main() {
     short.next();
     assert_eq!(long.size_hint(), (255, Some(255)));
     assert_eq!(short.size_hint(), (0, Some(0)));
-    assert_eq!(short, 1..=0);
+    assert!(short.is_empty());
 
     assert_eq!(long.len(), 255);
     assert_eq!(short.len(), 0);
@@ -95,28 +101,31 @@ pub fn main() {
     for i in 3..=251 {
         assert_eq!(long.next(), Some(i));
     }
-    assert_eq!(long, 1..=0);
+    assert!(long.is_empty());
 
     // check underflow
     let mut narrow = 1..=0;
     assert_eq!(narrow.next_back(), None);
-    assert_eq!(narrow, 1..=0);
+    assert!(narrow.is_empty());
     let mut zero = 0u8..=0;
     assert_eq!(zero.next_back(), Some(0));
     assert_eq!(zero.next_back(), None);
-    assert_eq!(zero, 1..=0);
+    assert!(zero.is_empty());
     let mut high = 255u8..=255;
     assert_eq!(high.next_back(), Some(255));
     assert_eq!(high.next_back(), None);
-    assert_eq!(high, 1..=0);
+    assert!(high.is_empty());
 
     // what happens if you have a nonsense range?
     let mut nonsense = 10..=5;
     assert_eq!(nonsense.next(), None);
-    assert_eq!(nonsense, 10..=5);
+    assert!(nonsense.is_empty());
 
     // output
     assert_eq!(format!("{:?}", 0..=10), "0..=10");
     assert_eq!(format!("{:?}", ..=10), "..=10");
-    assert_eq!(format!("{:?}", long), "1..=0");
+    assert_eq!(format!("{:?}", 9..=6), "9..=6");
+
+    // ensure that constructing a RangeInclusive does not need PartialOrd bound
+    assert_eq!(format!("{:?}", P(1)..=P(2)), "P(1)..=P(2)");
 }


### PR DESCRIPTION
Fix #45222.

This PR also reverts #48012 (i.e. removed the `try_fold`/`try_rfold` specialization for `RangeInclusive`) because LLVM no longer has trouble recognizing a RangeInclusive loop.

