### PR TITLE
Dummy commit to attempt to recreate prerelease artifacts

### DIFF
--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -34,4 +34,5 @@ cargo: 0.27.0
 # looking at a beta source tarball and it's uncommented we'll shortly comment it
 # out.
 
+
 #dev: 1


### PR DESCRIPTION
I am uncertain that this will work, but I think it might.

I believe that due to a rather late start on starting the prerelease deploy/build we may have been deploying around the time of date change which resulted in the manifest getting a different date than the directory the artifacts were uploaded into. I'm uncertain that was the case, but it seems like it.

This is an attempt to re-deploy, hopefully not hitting the same problem.