### PR TITLE
Do not consume semicolon twice while parsing local statement

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4700,7 +4700,7 @@ impl<'a> Parser<'a> {
                 if macro_legacy_warnings && self.token != token::Semi {
                     self.warn_missing_semicolon();
                 } else {
-                    self.expect_one_of(&[token::Semi], &[])?;
+                    self.expect_one_of(&[], &[token::Semi])?;
                 }
             }
             _ => {}


### PR DESCRIPTION
The span for a `let` statement includes multiple semicolons. For example,

```rust
    let x = 2;;;
//  ^^^^^^^^^^^ The span for the above statement.
```


This PR fixes it.

cc https://github.com/rust-lang-nursery/rustfmt/issues/2791.