### PR TITLE
Optimize RefCell refcount tracking

### DIFF
--- a/src/test/compile-fail/not-panic-safe-2.rs
+++ b/src/test/compile-fail/not-panic-safe-2.rs
@@ -19,5 +19,5 @@ fn assert<T: UnwindSafe + ?Sized>() {}
 fn main() {
     assert::<Rc<RefCell<i32>>>();
     //~^ ERROR the type `std::cell::UnsafeCell<i32>` may contain interior mutability and a
-    //~| ERROR the type `std::cell::UnsafeCell<usize>` may contain interior mutability and a
+    //~| ERROR the type `std::cell::UnsafeCell<isize>` may contain interior mutability and a
 }

--- a/src/test/compile-fail/not-panic-safe-3.rs
+++ b/src/test/compile-fail/not-panic-safe-3.rs
@@ -19,5 +19,5 @@ fn assert<T: UnwindSafe + ?Sized>() {}
 fn main() {
     assert::<Arc<RefCell<i32>>>();
     //~^ ERROR the type `std::cell::UnsafeCell<i32>` may contain interior mutability and a
-    //~| ERROR the type `std::cell::UnsafeCell<usize>` may contain interior mutability and a
+    //~| ERROR the type `std::cell::UnsafeCell<isize>` may contain interior mutability and a
 }

--- a/src/test/compile-fail/not-panic-safe-4.rs
+++ b/src/test/compile-fail/not-panic-safe-4.rs
@@ -18,5 +18,5 @@ fn assert<T: UnwindSafe + ?Sized>() {}
 fn main() {
     assert::<&RefCell<i32>>();
     //~^ ERROR the type `std::cell::UnsafeCell<i32>` may contain interior mutability and a
-    //~| ERROR the type `std::cell::UnsafeCell<usize>` may contain interior mutability and a
+    //~| ERROR the type `std::cell::UnsafeCell<isize>` may contain interior mutability and a
 }

--- a/src/test/compile-fail/not-panic-safe-6.rs
+++ b/src/test/compile-fail/not-panic-safe-6.rs
@@ -18,5 +18,5 @@ fn assert<T: UnwindSafe + ?Sized>() {}
 fn main() {
     assert::<*mut RefCell<i32>>();
     //~^ ERROR the type `std::cell::UnsafeCell<i32>` may contain interior mutability and a
-    //~| ERROR the type `std::cell::UnsafeCell<usize>` may contain interior mutability and a
+    //~| ERROR the type `std::cell::UnsafeCell<isize>` may contain interior mutability and a
 }


### PR DESCRIPTION
Address the performance concern raised in https://github.com/rust-lang/rust/pull/51466#issuecomment-398255276

cc @dtolnay  @nnethercote @rust-lang/wg-compiler-performance

cc @RalfJung @jhjourdan for soundness concerns

Can somebody kick off a perf run on this? I'm not sure how that's done, but I understand it has to be started manually.

The idea of this change is to switch to representing mutable refcount as values below 0 to eliminate some branching that was required with the old algorithm.