### PR TITLE
Update the error message for a missing global allocator

### DIFF
--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -986,8 +986,10 @@ impl<'a> CrateLoader<'a> {
             },
             None => {
                 if !attr::contains_name(&krate.attrs, "default_lib_allocator") {
-                    self.sess.err("no #[default_lib_allocator] found but one is \
-                                   required; is libstd not linked?");
+                    self.sess.err("no global memory allocator found but one is \
+                                   required; link to std or \
+                                   add #[global_allocator] to a static item \
+                                   that implements the GlobalAlloc trait.");
                     return;
                 }
                 self.sess.allocator_kind.set(Some(AllocatorKind::DefaultLib));

--- a/src/test/ui/missing-allocator.rs
+++ b/src/test/ui/missing-allocator.rs
@@ -1,0 +1,26 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -C panic=abort
+// no-prefer-dynamic
+
+#![no_std]
+#![crate_type = "staticlib"]
+#![feature(panic_implementation, lang_items, alloc)]
+
+#[panic_implementation]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[lang = "oom"]
+fn oom() {}
+
+extern crate alloc;

--- a/src/test/ui/missing-allocator.stderr
+++ b/src/test/ui/missing-allocator.stderr
@@ -1,4 +1,4 @@
-error: no #[default_lib_allocator] found but one is required; is libstd not linked?
+error: no global memory allocator found but one is required; link to std or add #[global_allocator] to a static item that implements the GlobalAlloc trait.
 
 error: aborting due to previous error
 

--- a/src/test/ui/missing-allocator.stderr
+++ b/src/test/ui/missing-allocator.stderr
@@ -1,0 +1,4 @@
+error: no #[default_lib_allocator] found but one is required; is libstd not linked?
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Don’t mention `#[default_lib_allocator]` (which is an implementation detail irrelevant to most users) and  instead suggest using `#[global_allocator]`, which is often the correct fix.