### PR TITLE
Implement a self profiler

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -165,6 +165,7 @@ pub mod util {
     pub mod nodemap;
     pub mod fs;
     pub mod time_graph;
+    pub mod profiling;
 }
 
 // A private module so that macro-expanded idents like

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1369,6 +1369,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
         "inject the given attribute in the crate"),
     self_profile: bool = (false, parse_bool, [UNTRACKED],
           "run the self profiler"),
+    profile_json: bool = (false, parse_bool, [UNTRACKED],
+          "output a json file with profiler results"),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -65,7 +65,7 @@ pub enum Sanitizer {
     Thread,
 }
 
-#[derive(Clone, Copy, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Hash)]
 pub enum OptLevel {
     No,         // -O0
     Less,       // -O1
@@ -1367,6 +1367,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
         "disables the 'leak check' for subtyping; unsound, but useful for tests"),
     crate_attr: Vec<String> = (Vec::new(), parse_string_push, [TRACKED],
         "inject the given attribute in the crate"),
+    self_profile: bool = (false, parse_bool, [UNTRACKED],
+          "run the self profiler"),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -841,7 +841,7 @@ impl Session {
 
     pub fn save_json_results(&self) {
         let profiler = self.self_profiling.borrow();
-        profiler.save_results();
+        profiler.save_results(&self.opts);
     }
 
     pub fn print_perf_stats(&self) {

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -839,6 +839,11 @@ impl Session {
         profiler.print_results(&self.opts);
     }
 
+    pub fn save_json_results(&self) {
+        let profiler = self.self_profiling.borrow();
+        profiler.save_results();
+    }
+
     pub fn print_perf_stats(&self) {
         println!(
             "Total time spent computing symbol hashes:      {}",

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -40,6 +40,7 @@ use syntax::parse::ParseSess;
 use syntax::{ast, codemap};
 use syntax::feature_gate::AttributeType;
 use syntax_pos::{MultiSpan, Span};
+use util::profiling::SelfProfiler;
 
 use rustc_target::spec::{LinkerFlavor, PanicStrategy};
 use rustc_target::spec::{Target, TargetTriple};
@@ -132,6 +133,9 @@ pub struct Session {
 
     /// Used by -Z profile-queries in util::common
     pub profile_channel: Lock<Option<mpsc::Sender<ProfileQueriesMsg>>>,
+
+    /// Used by -Z self-profile
+    pub self_profiling: Lock<SelfProfiler>,
 
     /// Some measurements that are being gathered during compilation.
     pub perf_stats: PerfStats,
@@ -825,6 +829,16 @@ impl Session {
         }
     }
 
+    pub fn profiler<F: FnOnce(&mut SelfProfiler) -> ()>(&self, f: F) {
+        let mut profiler = self.self_profiling.borrow_mut();
+        f(&mut profiler);
+    }
+
+    pub fn print_profiler_results(&self) {
+        let mut profiler = self.self_profiling.borrow_mut();
+        profiler.print_results(&self.opts);
+    }
+
     pub fn print_perf_stats(&self) {
         println!(
             "Total time spent computing symbol hashes:      {}",
@@ -1125,6 +1139,7 @@ pub fn build_session_(
         imported_macro_spans: OneThread::new(RefCell::new(HashMap::new())),
         incr_comp_session: OneThread::new(RefCell::new(IncrCompSession::NotInitialized)),
         ignored_attr_names: ich::compute_ignored_attr_names(),
+        self_profiling: Lock::new(SelfProfiler::new()),
         profile_channel: Lock::new(None),
         perf_stats: PerfStats {
             symbol_hash_time: Lock::new(Duration::from_secs(0)),

--- a/src/librustc/ty/query/config.rs
+++ b/src/librustc/ty/query/config.rs
@@ -21,6 +21,7 @@ use ty::subst::Substs;
 use ty::query::queries;
 use ty::query::Query;
 use ty::query::QueryCache;
+use util::profiling::ProfileCategory;
 
 use std::hash::Hash;
 use std::fmt::Debug;
@@ -33,6 +34,7 @@ use ich::StableHashingContext;
 
 pub trait QueryConfig<'tcx> {
     const NAME: &'static str;
+    const CATEGORY: ProfileCategory;
 
     type Key: Eq + Hash + Clone + Debug;
     type Value: Clone + for<'a> HashStable<StableHashingContext<'a>>;

--- a/src/librustc/ty/query/mod.rs
+++ b/src/librustc/ty/query/mod.rs
@@ -46,6 +46,7 @@ use ty::steal::Steal;
 use ty::subst::Substs;
 use util::nodemap::{DefIdSet, DefIdMap, ItemLocalSet};
 use util::common::{ErrorReported};
+use util::profiling::ProfileCategory::*;
 
 use rustc_data_structures::indexed_set::IdxSetBuf;
 use rustc_target::spec::PanicStrategy;

--- a/src/librustc/ty/query/plumbing.rs
+++ b/src/librustc/ty/query/plumbing.rs
@@ -363,6 +363,8 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             )
         );
 
+        self.sess.profiler(|p| p.record_query(Q::CATEGORY));
+
         let job = match JobOwner::try_get(self, span, &key) {
             TryGetJob::NotYetStarted(job) => job,
             TryGetJob::JobCompleted(result) => {
@@ -384,10 +386,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 
         if dep_node.kind.is_anon() {
             profq_msg!(self, ProfileQueriesMsg::ProviderBegin);
-            self.sess.profiler(|p| {
-                p.start_activity(Q::CATEGORY);
-                p.record_query(Q::CATEGORY);
-            });
+            self.sess.profiler(|p| p.start_activity(Q::CATEGORY));
 
             let res = job.start(self, |tcx| {
                 tcx.dep_graph.with_anon_task(dep_node.kind, || {

--- a/src/librustc/util/profiling.rs
+++ b/src/librustc/util/profiling.rs
@@ -93,7 +93,8 @@ impl CategoryData {
             ($name:tt, $rustic_name:ident) => {
                 let (hits, total) = self.query_counts.$rustic_name;
                 let (hits, total) = if total > 0 {
-                    (format!("{:.2}", (((hits as f32) / (total as f32)) * 100.0)), total.to_string())
+                    (format!("{:.2}",
+                     (((hits as f32) / (total as f32)) * 100.0)), total.to_string())
                 } else {
                     ("".into(), "".into())
                 };
@@ -109,8 +110,10 @@ impl CategoryData {
             };
         }
 
-        writeln!(lock, "| Phase            | Time (ms)      | Queries        | Hits (%) |").unwrap();
-        writeln!(lock, "| ---------------- | -------------- | -------------- | -------- |").unwrap();
+        writeln!(lock, "| Phase            | Time (ms)      | Queries        | Hits (%) |")
+            .unwrap();
+        writeln!(lock, "| ---------------- | -------------- | -------------- | -------- |")
+            .unwrap();
 
         p!("Parsing", parsing);
         p!("Expansion", expansion);
@@ -126,7 +129,9 @@ impl CategoryData {
             ($category:tt, $rustic_name:ident) => {{
                 let (hits, total) = self.query_counts.$rustic_name;
 
-                format!("{{ \"category\": {}, \"time_ms\": {}, \"query_count\": {}, \"query_hits\": {} }}",
+                format!(
+                    "{{ \"category\": {}, \"time_ms\": {},
+                        \"query_count\": {}, \"query_hits\": {} }}",
                     stringify!($category),
                     self.times.$rustic_name / 1_000_000,
                     total,
@@ -209,9 +214,9 @@ impl SelfProfiler {
     pub fn end_activity(&mut self, category: ProfileCategory) {
         match self.timer_stack.pop() {
             None => bug!("end_activity() was called but there was no running activity"),
-            Some(c) => 
+            Some(c) =>
                 assert!(
-                    c == category, 
+                    c == category,
                     "end_activity() was called but a different activity was running"),
         }
 
@@ -223,7 +228,8 @@ impl SelfProfiler {
             }
         }
 
-        //the new timer is different than the previous, so record the elapsed time and start a new timer
+        //the new timer is different than the previous,
+        //so record the elapsed time and start a new timer
         let elapsed = self.stop_timer();
         let new_time = self.data.times.get(category) + elapsed;
         self.data.times.set(category, new_time);
@@ -240,12 +246,18 @@ impl SelfProfiler {
     pub fn print_results(&mut self, opts: &Options) {
         self.end_activity(ProfileCategory::Other);
 
-        assert!(self.timer_stack.is_empty(), "there were timers running when print_results() was called");
+        assert!(
+            self.timer_stack.is_empty(),
+            "there were timers running when print_results() was called");
 
         let out = io::stdout();
         let mut lock = out.lock();
 
-        let crate_name = opts.crate_name.as_ref().map(|n| format!(" for {}", n)).unwrap_or_default();
+        let crate_name =
+            opts.crate_name
+            .as_ref()
+            .map(|n| format!(" for {}", n))
+            .unwrap_or_default();
 
         writeln!(lock, "Self profiling results{}:", crate_name).unwrap();
         writeln!(lock).unwrap();
@@ -261,9 +273,10 @@ impl SelfProfiler {
 
     pub fn save_results(&self, opts: &Options) {
         let category_data = self.data.json();
-        let compilation_options = format!("{{ \"optimization_level\": \"{:?}\", \"incremental\": {} }}",
-                                    opts.optimize,
-                                    if opts.incremental.is_some() { "true" } else { "false" });
+        let compilation_options =
+            format!("{{ \"optimization_level\": \"{:?}\", \"incremental\": {} }}",
+                    opts.optimize,
+                    if opts.incremental.is_some() { "true" } else { "false" });
 
         let json = format!("{{ \"category_data\": {}, \"compilation_options\": {} }}",
                         category_data,

--- a/src/librustc/util/profiling.rs
+++ b/src/librustc/util/profiling.rs
@@ -269,8 +269,17 @@ impl SelfProfiler {
         writeln!(lock, "Incremental: {}", incremental).unwrap();
     }
 
-    pub fn save_results(&self) {
-        fs::write("self_profiler_results.json", self.data.json()).unwrap();
+    pub fn save_results(&self, opts: &Options) {
+        let category_data = self.data.json();
+        let compilation_options = format!("{{ \"optimization_level\": \"{:?}\", \"incremental\": {} }}",
+                                    opts.optimize,
+                                    if opts.incremental.is_some() { "true" } else { "false" });
+
+        let json = format!("{{ \"category_data\": {}, \"compilation_options\": {} }}",
+                        category_data,
+                        compilation_options);
+
+        fs::write("self_profiler_results.json", json).unwrap();
     }
 
     pub fn record_activity<'a>(&'a mut self, category: ProfileCategory) -> ProfilerActivity<'a> {

--- a/src/librustc/util/profiling.rs
+++ b/src/librustc/util/profiling.rs
@@ -123,9 +123,16 @@ impl CategoryData {
 
     fn json(&self) -> String {
         macro_rules! j {
-            ($category:tt, $rustic_name:ident) => {
-                format!("{{ \"category\": {}, \"time_ms\": {} }}", stringify!($category), self.times.$rustic_name / 1_000_000)
-            }
+            ($category:tt, $rustic_name:ident) => {{
+                let (hits, total) = self.query_counts.$rustic_name;
+
+                format!("{{ \"category\": {}, \"time_ms\": {}, \"query_count\": {}, \"query_hits\": {} }}",
+                    stringify!($category),
+                    self.times.$rustic_name / 1_000_000,
+                    total,
+                    format!("{:.2}", (((hits as f32) / (total as f32)) * 100.0))
+                )
+            }}
         }
 
         format!("[

--- a/src/librustc/util/profiling.rs
+++ b/src/librustc/util/profiling.rs
@@ -161,16 +161,6 @@ pub struct SelfProfiler {
     current_timer: Instant,
 }
 
-pub struct ProfilerActivity<'a>(ProfileCategory, &'a mut SelfProfiler);
-
-impl<'a> Drop for ProfilerActivity<'a> {
-    fn drop(&mut self) {
-        let ProfilerActivity (category, profiler) = self;
-
-        profiler.end_activity(*category);
-    }
-}
-
 impl SelfProfiler {
     pub fn new() -> SelfProfiler {
         let mut profiler = SelfProfiler {
@@ -280,11 +270,5 @@ impl SelfProfiler {
                         compilation_options);
 
         fs::write("self_profiler_results.json", json).unwrap();
-    }
-
-    pub fn record_activity<'a>(&'a mut self, category: ProfileCategory) -> ProfilerActivity<'a> {
-        self.start_activity(category);
-
-        ProfilerActivity(category, self)
     }
 }

--- a/src/librustc/util/profiling.rs
+++ b/src/librustc/util/profiling.rs
@@ -92,7 +92,7 @@ impl CategoryData {
             ($name:tt, $rustic_name:ident) => {
                 writeln!(
                    lock,
-                   "{0: <15} \t\t {1: <15}",
+                   "{0: <15} \t\t {1: <15}ms",
                    $name,
                    self.times.$rustic_name / 1_000_000
                 ).unwrap();

--- a/src/librustc/util/profiling.rs
+++ b/src/librustc/util/profiling.rs
@@ -1,0 +1,207 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use session::config::Options;
+
+use std::io::{self, StdoutLock, Write};
+use std::time::Instant;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ProfileCategory {
+    Parsing,
+    Expansion,
+    TypeChecking,
+    BorrowChecking,
+    Codegen,
+    Linking,
+    Other,
+}
+
+struct Categories<T> {
+    parsing: T,
+    expansion: T,
+    type_checking: T,
+    borrow_checking: T,
+    codegen: T,
+    linking: T,
+    other: T,
+}
+
+impl<T: Default> Categories<T> {
+    fn new() -> Categories<T> {
+        Categories {
+            parsing: T::default(),
+            expansion: T::default(),
+            type_checking: T::default(),
+            borrow_checking: T::default(),
+            codegen: T::default(),
+            linking: T::default(),
+            other: T::default(),
+        }
+    }
+}
+
+impl<T> Categories<T> {
+    fn get(&self, category: ProfileCategory) -> &T {
+        match category {
+            ProfileCategory::Parsing => &self.parsing,
+            ProfileCategory::Expansion => &self.expansion,
+            ProfileCategory::TypeChecking => &self.type_checking,
+            ProfileCategory::BorrowChecking => &self.borrow_checking,
+            ProfileCategory::Codegen => &self.codegen,
+            ProfileCategory::Linking => &self.linking,
+            ProfileCategory::Other => &self.other,
+        }
+    }
+
+    fn set(&mut self, category: ProfileCategory, value: T) {
+        match category {
+            ProfileCategory::Parsing => self.parsing = value,
+            ProfileCategory::Expansion => self.expansion = value,
+            ProfileCategory::TypeChecking => self.type_checking = value,
+            ProfileCategory::BorrowChecking => self.borrow_checking = value,
+            ProfileCategory::Codegen => self.codegen = value,
+            ProfileCategory::Linking => self.linking = value,
+            ProfileCategory::Other => self.other = value,
+        }
+    }
+}
+
+struct CategoryData {
+    times: Categories<u64>,
+}
+
+impl CategoryData {
+    fn new() -> CategoryData {
+        CategoryData {
+            times: Categories::new(),
+        }
+    }
+
+    fn print(&self, lock: &mut StdoutLock) {
+        writeln!(lock, "{0: <15} \t\t {1: <15}", "Parsing", self.times.parsing / 1_000_000).unwrap();
+        writeln!(lock, "{0: <15} \t\t {1: <15}", "Expansion", self.times.expansion / 1_000_000).unwrap();
+        writeln!(lock, "{0: <15} \t\t {1: <15}", "TypeChecking", self.times.type_checking / 1_000_000).unwrap();
+        writeln!(lock, "{0: <15} \t\t {1: <15}", "BorrowChecking", self.times.borrow_checking / 1_000_000).unwrap();
+        writeln!(lock, "{0: <15} \t\t {1: <15}", "Codegen", self.times.codegen / 1_000_000).unwrap();
+        writeln!(lock, "{0: <15} \t\t {1: <15}", "Linking", self.times.linking / 1_000_000).unwrap();
+        writeln!(lock, "{0: <15} \t\t {1: <15}", "Other", self.times.other / 1_000_000).unwrap();
+    }
+}
+
+pub struct SelfProfiler {
+    timer_stack: Vec<ProfileCategory>,
+    data: CategoryData,
+    current_timer: Instant,
+}
+
+pub struct ProfilerActivity<'a>(ProfileCategory, &'a mut SelfProfiler);
+
+impl<'a> Drop for ProfilerActivity<'a> {
+    fn drop(&mut self) {
+        let ProfilerActivity (category, profiler) = self;
+
+        profiler.end_activity(*category);
+    }
+}
+
+impl SelfProfiler {
+    pub fn new() -> SelfProfiler {
+        let mut profiler = SelfProfiler {
+            timer_stack: Vec::new(),
+            data: CategoryData::new(),
+            current_timer: Instant::now(),
+        };
+
+        profiler.start_activity(ProfileCategory::Other);
+
+        profiler
+    }
+
+    pub fn start_activity(&mut self, category: ProfileCategory) {
+        match self.timer_stack.last().cloned() {
+            None => {
+                self.current_timer = Instant::now();
+            },
+            Some(current_category) if current_category == category => {
+                //since the current category is the same as the new activity's category,
+                //we don't need to do anything with the timer, we just need to push it on the stack
+            }
+            Some(current_category) => {
+                let elapsed = self.stop_timer();
+
+                //record the current category's time
+                let new_time = self.data.times.get(current_category) + elapsed;
+                self.data.times.set(current_category, new_time);
+            }
+        }
+
+        //push the new category
+        self.timer_stack.push(category);
+    }
+
+    pub fn end_activity(&mut self, category: ProfileCategory) {
+        match self.timer_stack.pop() {
+            None => bug!("end_activity() was called but there was no running activity"),
+            Some(c) => 
+                assert!(
+                    c == category, 
+                    "end_activity() was called but a different activity was running"),
+        }
+
+        //check if the new running timer is in the same category as this one
+        //if it is, we don't need to do anything
+        if let Some(c) = self.timer_stack.last() {
+            if *c == category {
+                return;
+            }
+        }
+
+        //the new timer is different than the previous, so record the elapsed time and start a new timer
+        let elapsed = self.stop_timer();
+        let new_time = self.data.times.get(category) + elapsed;
+        self.data.times.set(category, new_time);
+    }
+
+    fn stop_timer(&mut self) -> u64 {
+        let elapsed = self.current_timer.elapsed();
+
+        self.current_timer = Instant::now();
+
+        (elapsed.as_secs() * 1_000_000_000) + (elapsed.subsec_nanos() as u64)
+    }
+
+    pub fn print_results(&mut self, opts: &Options) {
+        self.end_activity(ProfileCategory::Other);
+
+        assert!(self.timer_stack.is_empty(), "there were timers running when print_results() was called");
+
+        let out = io::stdout();
+        let mut lock = out.lock();
+
+        let crate_name = opts.crate_name.as_ref().map(|n| format!(" for {}", n)).unwrap_or_default();
+
+        writeln!(lock, "Self profiling results{}:", crate_name).unwrap();
+
+        self.data.print(&mut lock);
+
+        writeln!(lock).unwrap();
+        writeln!(lock, "Optimization level: {:?}", opts.optimize).unwrap();
+
+        let incremental = if opts.incremental.is_some() { "on" } else { "off" };
+        writeln!(lock, "Incremental: {}", incremental).unwrap();
+    }
+
+    pub fn record_activity<'a>(&'a mut self, category: ProfileCategory) -> ProfilerActivity<'a> {
+        self.start_activity(category);
+
+        ProfilerActivity(category, self)
+    }
+}

--- a/src/librustc/util/profiling.rs
+++ b/src/librustc/util/profiling.rs
@@ -122,43 +122,29 @@ impl CategoryData {
     }
 
     fn json(&self) -> String {
+        macro_rules! j {
+            ($category:tt, $rustic_name:ident) => {
+                format!("{{ \"category\": {}, \"time_ms\": {} }}", stringify!($category), self.times.$rustic_name / 1_000_000)
+            }
+        }
+
         format!("[
-            {{
-                \"category\": \"Parsing\",
-                \"time_ms\": {}
-            }},
-            {{
-                \"category\": \"Expansion\",
-                \"time_ms\": {}
-            }},
-            {{
-                \"category\": \"TypeChecking\",
-                \"time_ms\": {}
-            }},
-            {{
-                \"category\": \"BorrowChecking\",
-                \"time_ms\": {}
-            }},
-            {{
-                \"category\": \"Codegen\",
-                \"time_ms\": {}
-            }},
-            {{
-                \"category\": \"Linking\",
-                \"time_ms\": {}
-            }},
-            {{
-                \"category\": \"Other\",
-                \"time_ms\": {}
-            }}
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {}
         ]",
-        self.times.parsing / 1_000_000,
-        self.times.expansion / 1_000_000,
-        self.times.type_checking / 1_000_000,
-        self.times.borrow_checking / 1_000_000,
-        self.times.codegen / 1_000_000,
-        self.times.linking / 1_000_000,
-        self.times.other / 1_000_000)
+            j!("Parsing", parsing),
+            j!("Expansion", expansion),
+            j!("TypeChecking", type_checking),
+            j!("BorrowChecking", borrow_checking),
+            j!("Codegen", codegen),
+            j!("Linking", linking),
+            j!("Other", other)
+        )
     }
 }
 

--- a/src/librustc/util/profiling.rs
+++ b/src/librustc/util/profiling.rs
@@ -10,6 +10,7 @@
 
 use session::config::Options;
 
+use std::fs;
 use std::io::{self, StdoutLock, Write};
 use std::time::Instant;
 
@@ -118,6 +119,46 @@ impl CategoryData {
         p!("Codegen", codegen);
         p!("Linking", linking);
         p!("Other", other);
+    }
+
+    fn json(&self) -> String {
+        format!("[
+            {{
+                \"category\": \"Parsing\",
+                \"time_ms\": {}
+            }},
+            {{
+                \"category\": \"Expansion\",
+                \"time_ms\": {}
+            }},
+            {{
+                \"category\": \"TypeChecking\",
+                \"time_ms\": {}
+            }},
+            {{
+                \"category\": \"BorrowChecking\",
+                \"time_ms\": {}
+            }},
+            {{
+                \"category\": \"Codegen\",
+                \"time_ms\": {}
+            }},
+            {{
+                \"category\": \"Linking\",
+                \"time_ms\": {}
+            }},
+            {{
+                \"category\": \"Other\",
+                \"time_ms\": {}
+            }}
+        ]",
+        self.times.parsing / 1_000_000,
+        self.times.expansion / 1_000_000,
+        self.times.type_checking / 1_000_000,
+        self.times.borrow_checking / 1_000_000,
+        self.times.codegen / 1_000_000,
+        self.times.linking / 1_000_000,
+        self.times.other / 1_000_000)
     }
 }
 
@@ -233,6 +274,10 @@ impl SelfProfiler {
 
         let incremental = if opts.incremental.is_some() { "on" } else { "off" };
         writeln!(lock, "Incremental: {}", incremental).unwrap();
+    }
+
+    pub fn save_results(&self) {
+        fs::write("self_profiler_results.json", self.data.json()).unwrap();
     }
 
     pub fn record_activity<'a>(&'a mut self, category: ProfileCategory) -> ProfilerActivity<'a> {

--- a/src/librustc/util/profiling.rs
+++ b/src/librustc/util/profiling.rs
@@ -92,7 +92,7 @@ impl CategoryData {
             ($name:tt, $rustic_name:ident) => {
                 let (hits, total) = self.query_counts.$rustic_name;
                 let (hits, total) = if total > 0 {
-                    (format!("{:.2}%", (((hits as f32) / (total as f32)) * 100.0)), total.to_string())
+                    (format!("{:.2}", (((hits as f32) / (total as f32)) * 100.0)), total.to_string())
                 } else {
                     ("".into(), "".into())
                 };

--- a/src/librustc_codegen_llvm/base.rs
+++ b/src/librustc_codegen_llvm/base.rs
@@ -45,6 +45,7 @@ use rustc::dep_graph::{DepNode, DepConstructor};
 use rustc::middle::cstore::{self, LinkMeta, LinkagePreference};
 use rustc::middle::exported_symbols;
 use rustc::util::common::{time, print_time_passes_entry};
+use rustc::util::profiling::ProfileCategory;
 use rustc::session::config::{self, NoDebugInfo};
 use rustc::session::Session;
 use rustc_incremental;
@@ -741,11 +742,13 @@ pub fn codegen_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let link_meta = link::build_link_meta(crate_hash);
 
     // Codegen the metadata.
+    tcx.sess.profiler(|p| p.start_activity(ProfileCategory::Codegen));
     let llmod_id = "metadata";
     let metadata_llvm_module = ModuleLlvm::new(tcx.sess, llmod_id);
     let metadata = time(tcx.sess, "write metadata", || {
         write_metadata(tcx, &metadata_llvm_module, &link_meta)
     });
+    tcx.sess.profiler(|p| p.end_activity(ProfileCategory::Codegen));
 
     let metadata_module = ModuleCodegen {
         name: link::METADATA_MODULE_NAME.to_string(),

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -355,6 +355,10 @@ pub fn compile_input(
 
     if sess.opts.debugging_opts.self_profile {
         sess.print_profiler_results();
+
+        if sess.opts.debugging_opts.profile_json {
+            sess.save_json_results();
+        }
     }
 
     controller_entry_point!(

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -109,6 +109,7 @@ use rustc::ty::subst::Substs;
 use rustc::ty::{self, Ty, TyCtxt};
 use rustc::ty::query::Providers;
 use rustc::traits::{ObligationCause, ObligationCauseCode, TraitEngine, TraitEngineExt};
+use rustc::util::profiling::ProfileCategory;
 use session::{CompileIncomplete, config};
 use util::common::time;
 
@@ -334,6 +335,8 @@ pub fn provide(providers: &mut Providers) {
 pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>)
                              -> Result<(), CompileIncomplete>
 {
+    tcx.sess.profiler(|p| p.start_activity(ProfileCategory::TypeChecking));
+
     // this ensures that later parts of type checking can assume that items
     // have valid types and not error
     tcx.sess.track_errors(|| {
@@ -370,6 +373,8 @@ pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>)
 
     check_unused::check_crate(tcx);
     check_for_entry_fn(tcx);
+
+    tcx.sess.profiler(|p| p.end_activity(ProfileCategory::TypeChecking));
 
     tcx.sess.compile_status()
 }


### PR DESCRIPTION
This is a work in progress implementation of #50780. I'd love feedback on the overall structure and code as well as some specific things:

- [The query categorization mechanism](https://github.com/rust-lang/rust/compare/master...wesleywiser:wip_profiling?expand=1#diff-19e0a69c10eff31eb2d16805e79f3437R101). This works but looks kind of ugly to me. Perhaps there's a better way?

- [The profiler assumes only one activity can run at a time](https://github.com/rust-lang/rust/compare/master...wesleywiser:wip_profiling?expand=1#diff-f8a403b2d88d873e4b27c097c614a236R177). This is obviously incompatible with the ongoing parallel queries. 

- [The output code is just a bunch of `format!()`s](https://github.com/rust-lang/rust/compare/master...wesleywiser:wip_profiling?expand=1#diff-f8a403b2d88d873e4b27c097c614a236R91). Is there a better way to generate markdown or json in the compiler? 

- [The query categorizations are likely wrong](https://github.com/rust-lang/rust/compare/master...wesleywiser:wip_profiling?expand=1#diff-19e0a69c10eff31eb2d16805e79f3437R101). I've marked what seemed obvious to me but I'm sure I got a lot of them wrong.

The overhead currently seems very low. Running `perf` on a sample compilation with profiling enabled reveals: 
![image](https://user-images.githubusercontent.com/831192/41657821-9775efec-7462-11e8-9e5e-47ec94105d9d.png)
