### PR TITLE
[beta] Prepare 1.28.0 beta release

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -46,7 +46,7 @@ fi
 #
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
-export RUST_RELEASE_CHANNEL=nightly
+export RUST_RELEASE_CHANNEL=beta
 if [ "$DEPLOY$DEPLOY_ALT" != "" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=$RUST_RELEASE_CHANNEL"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,9 +12,9 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2018-05-10
-rustc: beta
-cargo: beta
+date: 2018-06-20
+rustc: 1.27.0
+cargo: 0.28.0
 
 # When making a stable release the process currently looks like:
 #
@@ -34,4 +34,4 @@ cargo: beta
 # looking at a beta source tarball and it's uncommented we'll shortly comment it
 # out.
 
-#dev: 1
+dev: 1


### PR DESCRIPTION
This feels likely to fail due to https://github.com/rust-lang/rust/issues/51650 but I want to see what CI says.