### PR TITLE
Replace unwrap calls in examples by expect

### DIFF
--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -678,9 +678,9 @@ impl<T, S> HashSet<T, S>
     /// let mut set = HashSet::new();
     /// set.insert(Vec::<i32>::new());
     ///
-    /// assert_eq!(set.get(&[][..]).unwrap().capacity(), 0);
+    /// assert_eq!(set.get(&[][..]).expect("get() failed").capacity(), 0);
     /// set.replace(Vec::with_capacity(10));
-    /// assert_eq!(set.get(&[][..]).unwrap().capacity(), 10);
+    /// assert_eq!(set.get(&[][..]).expect("get() failed").capacity(), 10);
     /// ```
     #[stable(feature = "set_recovery", since = "1.9.0")]
     pub fn replace(&mut self, value: T) -> Option<T> {

--- a/src/libstd/collections/mod.rs
+++ b/src/libstd/collections/mod.rs
@@ -401,10 +401,10 @@
 //! map.insert(Foo { a: 1, b: "xyz" }, 100);
 //!
 //! // The value has been updated...
-//! assert_eq!(map.values().next().unwrap(), &100);
+//! assert_eq!(map.values().next().expect("empty value: we reached the end"), &100);
 //!
 //! // ...but the key hasn't changed. b is still "baz", not "xyz".
-//! assert_eq!(map.keys().next().unwrap().b, "baz");
+//! assert_eq!(map.keys().next().expect("empty value: we reached the end").b, "baz");
 //! ```
 //!
 //! [`Vec`]: ../../std/vec/struct.Vec.html

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -131,7 +131,7 @@ pub trait Error: Debug + Display {
     ///     match get_super_error() {
     ///         Err(e) => {
     ///             println!("Error: {}", e.description());
-    ///             println!("Caused by: {}", e.cause().unwrap());
+    ///             println!("Caused by: {}", e.cause().expect("no cause provided"));
     ///         }
     ///         _ => println!("No error"),
     ///     }

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -101,8 +101,8 @@ use sys;
 /// }
 ///
 /// // We are certain that our string doesn't have 0 bytes in the middle,
-/// // so we can .unwrap()
-/// let c_to_print = CString::new("Hello, world!").unwrap();
+/// // so we can .expect()
+/// let c_to_print = CString::new("Hello, world!").expect("CString::new failed");
 /// unsafe {
 ///     my_printer(c_to_print.as_ptr());
 /// }
@@ -174,7 +174,7 @@ pub struct CString {
 ///     unsafe { work_with(data.as_ptr()) }
 /// }
 ///
-/// let s = CString::new("data data data data").unwrap();
+/// let s = CString::new("data data data data").expect("CString::new failed");
 /// work(&s);
 /// ```
 ///
@@ -313,7 +313,7 @@ impl CString {
     ///
     /// extern { fn puts(s: *const c_char); }
     ///
-    /// let to_print = CString::new("Hello!").unwrap();
+    /// let to_print = CString::new("Hello!").expect("CString::new failed");
     /// unsafe {
     ///     puts(to_print.as_ptr());
     /// }
@@ -397,7 +397,7 @@ impl CString {
     ///     fn some_extern_function(s: *mut c_char);
     /// }
     ///
-    /// let c_string = CString::new("Hello!").unwrap();
+    /// let c_string = CString::new("Hello!").expect("CString::new failed");
     /// let raw = c_string.into_raw();
     /// unsafe {
     ///     some_extern_function(raw);
@@ -427,7 +427,7 @@ impl CString {
     /// ```
     /// use std::ffi::CString;
     ///
-    /// let c_string = CString::new("foo").unwrap();
+    /// let c_string = CString::new("foo").expect("CString::new failed");
     ///
     /// let ptr = c_string.into_raw();
     ///
@@ -459,12 +459,12 @@ impl CString {
     /// use std::ffi::CString;
     ///
     /// let valid_utf8 = vec![b'f', b'o', b'o'];
-    /// let cstring = CString::new(valid_utf8).unwrap();
-    /// assert_eq!(cstring.into_string().unwrap(), "foo");
+    /// let cstring = CString::new(valid_utf8).expect("CString::new failed");
+    /// assert_eq!(cstring.into_string().expect("into_string() call failed"), "foo");
     ///
     /// let invalid_utf8 = vec![b'f', 0xff, b'o', b'o'];
-    /// let cstring = CString::new(invalid_utf8).unwrap();
-    /// let err = cstring.into_string().err().unwrap();
+    /// let cstring = CString::new(invalid_utf8).expect("CString::new failed");
+    /// let err = cstring.into_string().err().expect("into_string().err() failed");
     /// assert_eq!(err.utf8_error().valid_up_to(), 1);
     /// ```
 
@@ -488,7 +488,7 @@ impl CString {
     /// ```
     /// use std::ffi::CString;
     ///
-    /// let c_string = CString::new("foo").unwrap();
+    /// let c_string = CString::new("foo").expect("CString::new failed");
     /// let bytes = c_string.into_bytes();
     /// assert_eq!(bytes, vec![b'f', b'o', b'o']);
     /// ```
@@ -510,7 +510,7 @@ impl CString {
     /// ```
     /// use std::ffi::CString;
     ///
-    /// let c_string = CString::new("foo").unwrap();
+    /// let c_string = CString::new("foo").expect("CString::new failed");
     /// let bytes = c_string.into_bytes_with_nul();
     /// assert_eq!(bytes, vec![b'f', b'o', b'o', b'\0']);
     /// ```
@@ -533,7 +533,7 @@ impl CString {
     /// ```
     /// use std::ffi::CString;
     ///
-    /// let c_string = CString::new("foo").unwrap();
+    /// let c_string = CString::new("foo").expect("CString::new failed");
     /// let bytes = c_string.as_bytes();
     /// assert_eq!(bytes, &[b'f', b'o', b'o']);
     /// ```
@@ -553,7 +553,7 @@ impl CString {
     /// ```
     /// use std::ffi::CString;
     ///
-    /// let c_string = CString::new("foo").unwrap();
+    /// let c_string = CString::new("foo").expect("CString::new failed");
     /// let bytes = c_string.as_bytes_with_nul();
     /// assert_eq!(bytes, &[b'f', b'o', b'o', b'\0']);
     /// ```
@@ -572,9 +572,10 @@ impl CString {
     /// ```
     /// use std::ffi::{CString, CStr};
     ///
-    /// let c_string = CString::new(b"foo".to_vec()).unwrap();
+    /// let c_string = CString::new(b"foo".to_vec()).expect("CString::new failed");
     /// let c_str = c_string.as_c_str();
-    /// assert_eq!(c_str, CStr::from_bytes_with_nul(b"foo\0").unwrap());
+    /// assert_eq!(c_str,
+    ///            CStr::from_bytes_with_nul(b"foo\0").expect("CStr::from_bytes_with_nul failed"));
     /// ```
     #[inline]
     #[stable(feature = "as_c_str", since = "1.20.0")]
@@ -591,16 +592,17 @@ impl CString {
     /// ```
     /// use std::ffi::{CString, CStr};
     ///
-    /// let c_string = CString::new(b"foo".to_vec()).unwrap();
+    /// let c_string = CString::new(b"foo".to_vec()).expect("CString::new failed");
     /// let boxed = c_string.into_boxed_c_str();
-    /// assert_eq!(&*boxed, CStr::from_bytes_with_nul(b"foo\0").unwrap());
+    /// assert_eq!(&*boxed,
+    ///            CStr::from_bytes_with_nul(b"foo\0").expect("CStr::from_bytes_with_nul failed"));
     /// ```
     #[stable(feature = "into_boxed_c_str", since = "1.20.0")]
     pub fn into_boxed_c_str(self) -> Box<CStr> {
         unsafe { Box::from_raw(Box::into_raw(self.into_inner()) as *mut CStr) }
     }
 
-    // Bypass "move out of struct which implements [`Drop`] trait" restriction.
+    /// Bypass "move out of struct which implements [`Drop`] trait" restriction.
     ///
     /// [`Drop`]: ../ops/trait.Drop.html
     fn into_inner(self) -> Box<[u8]> {
@@ -961,7 +963,7 @@ impl CStr {
     ///
     /// unsafe {
     ///     let slice = CStr::from_ptr(my_string());
-    ///     println!("string returned: {}", slice.to_str().unwrap());
+    ///     println!("string returned: {}", slice.to_str().expect("to_str() call failed"));
     /// }
     /// # }
     /// ```
@@ -1030,7 +1032,7 @@ impl CStr {
     /// use std::ffi::{CStr, CString};
     ///
     /// unsafe {
-    ///     let cstring = CString::new("hello").unwrap();
+    ///     let cstring = CString::new("hello").expect("CString::new failed");
     ///     let cstr = CStr::from_bytes_with_nul_unchecked(cstring.to_bytes_with_nul());
     ///     assert_eq!(cstr, &*cstring);
     /// }
@@ -1057,7 +1059,7 @@ impl CStr {
     /// # #![allow(unused_must_use)]
     /// use std::ffi::{CString};
     ///
-    /// let ptr = CString::new("Hello").unwrap().as_ptr();
+    /// let ptr = CString::new("Hello").expect("CString::new failed").as_ptr();
     /// unsafe {
     ///     // `ptr` is dangling
     ///     *ptr;
@@ -1066,14 +1068,14 @@ impl CStr {
     ///
     /// This happens because the pointer returned by `as_ptr` does not carry any
     /// lifetime information and the [`CString`] is deallocated immediately after
-    /// the `CString::new("Hello").unwrap().as_ptr()` expression is evaluated.
+    /// the `CString::new("Hello").expect("CString::new failed").as_ptr()` expression is evaluated.
     /// To fix the problem, bind the `CString` to a local variable:
     ///
     /// ```no_run
     /// # #![allow(unused_must_use)]
     /// use std::ffi::{CString};
     ///
-    /// let hello = CString::new("Hello").unwrap();
+    /// let hello = CString::new("Hello").expect("CString::new failed");
     /// let ptr = hello.as_ptr();
     /// unsafe {
     ///     // `ptr` is valid because `hello` is in scope
@@ -1105,7 +1107,7 @@ impl CStr {
     /// ```
     /// use std::ffi::CStr;
     ///
-    /// let c_str = CStr::from_bytes_with_nul(b"foo\0").unwrap();
+    /// let c_str = CStr::from_bytes_with_nul(b"foo\0").expect("CStr::from_bytes_with_nul failed");
     /// assert_eq!(c_str.to_bytes(), b"foo");
     /// ```
     #[inline]
@@ -1131,7 +1133,7 @@ impl CStr {
     /// ```
     /// use std::ffi::CStr;
     ///
-    /// let c_str = CStr::from_bytes_with_nul(b"foo\0").unwrap();
+    /// let c_str = CStr::from_bytes_with_nul(b"foo\0").expect("CStr::from_bytes_with_nul failed");
     /// assert_eq!(c_str.to_bytes_with_nul(), b"foo\0");
     /// ```
     #[inline]
@@ -1158,7 +1160,7 @@ impl CStr {
     /// ```
     /// use std::ffi::CStr;
     ///
-    /// let c_str = CStr::from_bytes_with_nul(b"foo\0").unwrap();
+    /// let c_str = CStr::from_bytes_with_nul(b"foo\0").expect("CStr::from_bytes_with_nul");
     /// assert_eq!(c_str.to_str(), Ok("foo"));
     /// ```
     #[stable(feature = "cstr_to_str", since = "1.4.0")]
@@ -1198,7 +1200,8 @@ impl CStr {
     /// use std::borrow::Cow;
     /// use std::ffi::CStr;
     ///
-    /// let c_str = CStr::from_bytes_with_nul(b"Hello World\0").unwrap();
+    /// let c_str = CStr::from_bytes_with_nul(b"Hello World\0")
+    ///                  .expect("CStr::from_bytes_with_nul failed");
     /// assert_eq!(c_str.to_string_lossy(), Cow::Borrowed("Hello World"));
     /// ```
     ///
@@ -1208,7 +1211,8 @@ impl CStr {
     /// use std::borrow::Cow;
     /// use std::ffi::CStr;
     ///
-    /// let c_str = CStr::from_bytes_with_nul(b"Hello \xF0\x90\x80World\0").unwrap();
+    /// let c_str = CStr::from_bytes_with_nul(b"Hello \xF0\x90\x80World\0")
+    ///                  .expect("CStr::from_bytes_with_nul failed");
     /// assert_eq!(
     ///     c_str.to_string_lossy(),
     ///     Cow::Owned(String::from("Hello �World")) as Cow<str>
@@ -1229,9 +1233,9 @@ impl CStr {
     /// ```
     /// use std::ffi::CString;
     ///
-    /// let c_string = CString::new(b"foo".to_vec()).unwrap();
+    /// let c_string = CString::new(b"foo".to_vec()).expect("CString::new failed");
     /// let boxed = c_string.into_boxed_c_str();
-    /// assert_eq!(boxed.into_c_string(), CString::new("foo").unwrap());
+    /// assert_eq!(boxed.into_c_string(), CString::new("foo").expect("CString::new failed"));
     /// ```
     #[stable(feature = "into_boxed_c_str", since = "1.20.0")]
     pub fn into_c_string(self: Box<CStr>) -> CString {

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -2023,9 +2023,10 @@ impl DirBuilder {
     /// let path = "/tmp/foo/bar/baz";
     /// DirBuilder::new()
     ///     .recursive(true)
-    ///     .create(path).unwrap();
+    ///     .create(path)
+    ///     .expect("DirBuilder creation failed");
     ///
-    /// assert!(fs::metadata(path).unwrap().is_dir());
+    /// assert!(fs::metadata(path).expect("fs::metadata call failed").is_dir());
     /// ```
     #[stable(feature = "dir_builder", since = "1.6.0")]
     pub fn create<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -358,10 +358,10 @@ impl<R: Seek> Seek for BufReader<R> {
 /// use std::io::prelude::*;
 /// use std::net::TcpStream;
 ///
-/// let mut stream = TcpStream::connect("127.0.0.1:34254").unwrap();
+/// let mut stream = TcpStream::connect("127.0.0.1:34254").expect("TcpStream::connect failed");
 ///
 /// for i in 0..10 {
-///     stream.write(&[i+1]).unwrap();
+///     stream.write(&[i + 1]).expect("write() call failed");
 /// }
 /// ```
 ///
@@ -374,10 +374,11 @@ impl<R: Seek> Seek for BufReader<R> {
 /// use std::io::BufWriter;
 /// use std::net::TcpStream;
 ///
-/// let mut stream = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+/// let mut stream = BufWriter::new(TcpStream::connect("127.0.0.1:34254")
+///                                           .expect("TcpStream::connect failed"));
 ///
 /// for i in 0..10 {
-///     stream.write(&[i+1]).unwrap();
+///     stream.write(&[i + 1]).expect("write() call failed");
 /// }
 /// ```
 ///
@@ -409,7 +410,8 @@ pub struct BufWriter<W: Write> {
 /// use std::io::BufWriter;
 /// use std::net::TcpStream;
 ///
-/// let mut stream = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+/// let mut stream = BufWriter::new(TcpStream::connect("127.0.0.1:34254")
+///                                           .expect("TcpStream::connect failed"));
 ///
 /// // do stuff with the stream
 ///
@@ -437,7 +439,8 @@ impl<W: Write> BufWriter<W> {
     /// use std::io::BufWriter;
     /// use std::net::TcpStream;
     ///
-    /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254")
+    ///                                           .expect("TcpStream::connect failed"));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn new(inner: W) -> BufWriter<W> {
@@ -454,7 +457,7 @@ impl<W: Write> BufWriter<W> {
     /// use std::io::BufWriter;
     /// use std::net::TcpStream;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:34254").unwrap();
+    /// let stream = TcpStream::connect("127.0.0.1:34254").expect("TcpStream::connect failed");
     /// let mut buffer = BufWriter::with_capacity(100, stream);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -501,7 +504,8 @@ impl<W: Write> BufWriter<W> {
     /// use std::io::BufWriter;
     /// use std::net::TcpStream;
     ///
-    /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254")
+    ///                                           .expect("TcpStream::connect failed"));
     ///
     /// // we can use reference just like buffer
     /// let reference = buffer.get_ref();
@@ -519,7 +523,8 @@ impl<W: Write> BufWriter<W> {
     /// use std::io::BufWriter;
     /// use std::net::TcpStream;
     ///
-    /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254")
+    ///                                           .expect("TcpStream::connect failed"));
     ///
     /// // we can use reference just like buffer
     /// let reference = buffer.get_mut();
@@ -541,10 +546,11 @@ impl<W: Write> BufWriter<W> {
     /// use std::io::BufWriter;
     /// use std::net::TcpStream;
     ///
-    /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254")
+    ///                                           .expect("TcpStream::connect failed"));
     ///
     /// // unwrap the TcpStream and flush the buffer
-    /// let stream = buffer.into_inner().unwrap();
+    /// let stream = buffer.into_inner().expect("into_inner() call");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn into_inner(mut self) -> Result<W, IntoInnerError<BufWriter<W>>> {
@@ -616,7 +622,8 @@ impl<W> IntoInnerError<W> {
     /// use std::io::BufWriter;
     /// use std::net::TcpStream;
     ///
-    /// let mut stream = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    /// let mut stream = BufWriter::new(TcpStream::connect("127.0.0.1:34254")
+    ///                                           .expect("TcpStream::connect failed"));
     ///
     /// // do stuff with the stream
     ///
@@ -648,7 +655,8 @@ impl<W> IntoInnerError<W> {
     /// use std::io::BufWriter;
     /// use std::net::TcpStream;
     ///
-    /// let mut stream = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    /// let mut stream = BufWriter::new(TcpStream::connect("127.0.0.1:34254")
+    ///                                           .expect("TcpStream::connect failed"));
     ///
     /// // do stuff with the stream
     ///
@@ -663,7 +671,7 @@ impl<W> IntoInnerError<W> {
     ///         // do stuff to try to recover
     ///
     ///         // afterwards, let's just return the stream
-    ///         buffer.into_inner().unwrap()
+    ///         buffer.into_inner().expect("into_inner() call failed")
     ///     }
     /// };
     /// ```

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -75,7 +75,7 @@ use io::{self, Initializer, SeekFrom, Error, ErrorKind};
 ///     use std::io::Cursor;
 ///     let mut buff = Cursor::new(vec![0; 15]);
 ///
-///     write_ten_bytes_at_end(&mut buff).unwrap();
+///     write_ten_bytes_at_end(&mut buff).expect("write_ten_bytes_at_end() call failed");
 ///
 ///     assert_eq!(&buff.get_ref()[5..15], &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 /// }
@@ -172,10 +172,10 @@ impl<T> Cursor<T> {
     ///
     /// assert_eq!(buff.position(), 0);
     ///
-    /// buff.seek(SeekFrom::Current(2)).unwrap();
+    /// buff.seek(SeekFrom::Current(2)).expect("seek() call failed");
     /// assert_eq!(buff.position(), 2);
     ///
-    /// buff.seek(SeekFrom::Current(-1)).unwrap();
+    /// buff.seek(SeekFrom::Current(-1)).expect("seek() call failed");
     /// assert_eq!(buff.position(), 1);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -423,7 +423,9 @@ impl Error {
     ///
     /// fn change_error(mut err: Error) -> Error {
     ///     if let Some(inner_err) = err.get_mut() {
-    ///         inner_err.downcast_mut::<MyError>().unwrap().change_message("I've been changed!");
+    ///         inner_err.downcast_mut::<MyError>()
+    ///                  .expect("downcast_mut::<MyError>() call failed")
+    ///                  .change_message("I've been changed!");
     ///     }
     ///     err
     /// }

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -147,7 +147,7 @@
 //! ```
 //!
 //! Note that you cannot use the [`?` operator] in functions that do not return
-//! a [`Result<T, E>`][`Result`]. Instead, you can call [`.unwrap()`]
+//! a [`Result<T, E>`][`Result`]. Instead, you can call [`.expect()`]
 //! or `match` on the return value to catch any possible errors:
 //!
 //! ```no_run
@@ -155,7 +155,7 @@
 //!
 //! let mut input = String::new();
 //!
-//! io::stdin().read_line(&mut input).unwrap();
+//! io::stdin().read_line(&mut input).expect("read_line() call failed");
 //! ```
 //!
 //! And a very common source of output is standard output:
@@ -265,7 +265,7 @@
 //! [`?` operator]: ../../book/first-edition/syntax-index.html
 //! [`Read::read`]: trait.Read.html#tymethod.read
 //! [`Result`]: ../result/enum.Result.html
-//! [`.unwrap()`]: ../result/enum.Result.html#method.unwrap
+//! [`.expect()`]: ../result/enum.Result.html#method.expect
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -794,7 +794,7 @@ pub trait Read {
     ///     let mut f = File::open("foo.txt")?;
     ///
     ///     for byte in f.bytes() {
-    ///         println!("{}", byte.unwrap());
+    ///         println!("{}", byte.expect("failed to get byte"));
     ///     }
     ///     Ok(())
     /// }
@@ -1295,7 +1295,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
 ///
 /// let stdin = io::stdin();
 /// for line in stdin.lock().lines() {
-///     println!("{}", line.unwrap());
+///     println!("{}", line.expect("failed to get line"));
 /// }
 /// ```
 ///
@@ -1321,7 +1321,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
 ///     let f = BufReader::new(f);
 ///
 ///     for line in f.lines() {
-///         println!("{}", line.unwrap());
+///         println!("{}", line.expect("failed to get line"));
 ///     }
 ///
 ///     Ok(())
@@ -1362,7 +1362,7 @@ pub trait BufRead: Read {
     /// // we can't have two `&mut` references to `stdin`, so use a block
     /// // to end the borrow early.
     /// let length = {
-    ///     let buffer = stdin.fill_buf().unwrap();
+    ///     let buffer = stdin.fill_buf().expect("fill_buff() called failed");
     ///
     ///     // work with buffer
     ///     println!("{:?}", buffer);
@@ -1545,7 +1545,7 @@ pub trait BufRead: Read {
     ///
     /// let cursor = io::Cursor::new(b"lorem-ipsum-dolor");
     ///
-    /// let mut split_iter = cursor.split(b'-').map(|l| l.unwrap());
+    /// let mut split_iter = cursor.split(b'-').map(|l| l.expect("failed to get string"));
     /// assert_eq!(split_iter.next(), Some(b"lorem".to_vec()));
     /// assert_eq!(split_iter.next(), Some(b"ipsum".to_vec()));
     /// assert_eq!(split_iter.next(), Some(b"dolor".to_vec()));
@@ -1578,7 +1578,7 @@ pub trait BufRead: Read {
     ///
     /// let cursor = io::Cursor::new(b"lorem\nipsum\r\ndolor");
     ///
-    /// let mut lines_iter = cursor.lines().map(|l| l.unwrap());
+    /// let mut lines_iter = cursor.lines().map(|l| l.expect("failed to get string"));
     /// assert_eq!(lines_iter.next(), Some(String::from("lorem")));
     /// assert_eq!(lines_iter.next(), Some(String::from("ipsum")));
     /// assert_eq!(lines_iter.next(), Some(String::from("dolor")));

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -90,7 +90,7 @@ pub struct Empty { _priv: () }
 /// use std::io::{self, Read};
 ///
 /// let mut buffer = String::new();
-/// io::empty().read_to_string(&mut buffer).unwrap();
+/// io::empty().read_to_string(&mut buffer).expect("read_to_string() call failed");
 /// assert!(buffer.is_empty());
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -141,7 +141,7 @@ pub struct Repeat { byte: u8 }
 /// use std::io::{self, Read};
 ///
 /// let mut buffer = [0; 3];
-/// io::repeat(0b101).read_exact(&mut buffer).unwrap();
+/// io::repeat(0b101).read_exact(&mut buffer).expect("read_exact() call failed");
 /// assert_eq!(buffer, [0b101, 0b101, 0b101]);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -190,7 +190,7 @@ pub struct Sink { _priv: () }
 /// use std::io::{self, Write};
 ///
 /// let buffer = vec![1, 2, 3, 5, 8];
-/// let num_bytes = io::sink().write(&buffer).unwrap();
+/// let num_bytes = io::sink().write(&buffer).expect("write() call failed");
 /// assert_eq!(num_bytes, 5);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -113,11 +113,11 @@ macro_rules! panic {
 /// print!("same ");
 /// print!("line ");
 ///
-/// io::stdout().flush().unwrap();
+/// io::stdout().flush().expect("flush() call failed");
 ///
 /// print!("this string has a newline, why not choose println! instead?\n");
 ///
-/// io::stdout().flush().unwrap();
+/// io::stdout().flush().expect("flush() call failed");
 /// ```
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -263,13 +263,13 @@ macro_rules! await {
 /// let (tx1, rx1) = mpsc::channel();
 /// let (tx2, rx2) = mpsc::channel();
 ///
-/// thread::spawn(move|| { long_running_thread(); tx1.send(()).unwrap(); });
-/// thread::spawn(move|| { tx2.send(calculate_the_answer()).unwrap(); });
+/// thread::spawn(move|| { long_running_thread(); tx1.send(()).expect("send() call failed"); });
+/// thread::spawn(move|| { tx2.send(calculate_the_answer()).expect("send() call failed"); });
 ///
 /// select! {
 ///     _ = rx1.recv() => println!("the long running thread finished first"),
 ///     answer = rx2.recv() => {
-///         println!("the answer was: {}", answer.unwrap());
+///         println!("the answer was: {}", answer.expect("failed to get answer"));
 ///     }
 /// }
 /// # drop(rx1.recv());

--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -721,7 +721,7 @@ impl hash::Hash for SocketAddrV6 {
 /// use std::net::{ToSocketAddrs, SocketAddr};
 ///
 /// let addr = SocketAddr::from(([127, 0, 0, 1], 443));
-/// let mut addrs_iter = addr.to_socket_addrs().unwrap();
+/// let mut addrs_iter = addr.to_socket_addrs().expect("to_socket_addrs() call failed");
 ///
 /// assert_eq!(Some(addr), addrs_iter.next());
 /// assert!(addrs_iter.next().is_none());
@@ -733,7 +733,7 @@ impl hash::Hash for SocketAddrV6 {
 /// use std::net::{SocketAddr, ToSocketAddrs};
 ///
 /// // assuming 'localhost' resolves to 127.0.0.1
-/// let mut addrs_iter = "localhost:443".to_socket_addrs().unwrap();
+/// let mut addrs_iter = "localhost:443".to_socket_addrs().expect("to_socket_addrs() call failed");
 /// assert_eq!(addrs_iter.next(), Some(SocketAddr::from(([127, 0, 0, 1], 443))));
 /// assert!(addrs_iter.next().is_none());
 ///
@@ -750,7 +750,7 @@ impl hash::Hash for SocketAddrV6 {
 /// let addr2 = SocketAddr::from(([127, 0, 0, 1], 443));
 /// let addrs = vec![addr1, addr2];
 ///
-/// let mut addrs_iter = (&addrs[..]).to_socket_addrs().unwrap();
+/// let mut addrs_iter = (&addrs[..]).to_socket_addrs().expect("to_socket_addrs() call failed");
 ///
 /// assert_eq!(Some(addr1), addrs_iter.next());
 /// assert_eq!(Some(addr2), addrs_iter.next());

--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -44,7 +44,7 @@ use time::Duration;
 /// use std::net::TcpStream;
 ///
 /// {
-///     let mut stream = TcpStream::connect("127.0.0.1:34254").unwrap();
+///     let mut stream = TcpStream::connect("127.0.0.1:34254").expect("TcpStream::connect failed");
 ///
 ///     // ignore the Result
 ///     let _ = stream.write(&[1]);
@@ -181,7 +181,7 @@ impl TcpStream {
     ///
     /// let stream = TcpStream::connect("127.0.0.1:8080")
     ///                        .expect("Couldn't connect to the server...");
-    /// assert_eq!(stream.peer_addr().unwrap(),
+    /// assert_eq!(stream.peer_addr().expect("peer_addr() call failed"),
     ///            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080)));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -198,7 +198,7 @@ impl TcpStream {
     ///
     /// let stream = TcpStream::connect("127.0.0.1:8080")
     ///                        .expect("Couldn't connect to the server...");
-    /// assert_eq!(stream.local_addr().unwrap().ip(),
+    /// assert_eq!(stream.local_addr().expect("local_addr() call failed").ip(),
     ///            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -293,7 +293,7 @@ impl TcpStream {
     /// use std::net::TcpStream;
     /// use std::time::Duration;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080").unwrap();
+    /// let stream = TcpStream::connect("127.0.0.1:8080").expect("TcpStream::connect failed");
     /// let result = stream.set_read_timeout(Some(Duration::new(0, 0)));
     /// let err = result.unwrap_err();
     /// assert_eq!(err.kind(), io::ErrorKind::InvalidInput)
@@ -340,7 +340,7 @@ impl TcpStream {
     /// use std::net::TcpStream;
     /// use std::time::Duration;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080").unwrap();
+    /// let stream = TcpStream::connect("127.0.0.1:8080").expect("TcpStream::connect failed");
     /// let result = stream.set_write_timeout(Some(Duration::new(0, 0)));
     /// let err = result.unwrap_err();
     /// assert_eq!(err.kind(), io::ErrorKind::InvalidInput)
@@ -369,7 +369,7 @@ impl TcpStream {
     /// let stream = TcpStream::connect("127.0.0.1:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// stream.set_read_timeout(None).expect("set_read_timeout call failed");
-    /// assert_eq!(stream.read_timeout().unwrap(), None);
+    /// assert_eq!(stream.read_timeout().expect("read_timeout() call failed"), None);
     /// ```
     #[stable(feature = "socket_timeout", since = "1.4.0")]
     pub fn read_timeout(&self) -> io::Result<Option<Duration>> {
@@ -395,7 +395,7 @@ impl TcpStream {
     /// let stream = TcpStream::connect("127.0.0.1:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// stream.set_write_timeout(None).expect("set_write_timeout call failed");
-    /// assert_eq!(stream.write_timeout().unwrap(), None);
+    /// assert_eq!(stream.write_timeout().expect("write_timeout() call failed"), None);
     /// ```
     #[stable(feature = "socket_timeout", since = "1.4.0")]
     pub fn write_timeout(&self) -> io::Result<Option<Duration>> {
@@ -651,7 +651,7 @@ impl TcpListener {
     /// ```no_run
     /// use std::net::TcpListener;
     ///
-    /// let listener = TcpListener::bind("127.0.0.1:80").unwrap();
+    /// let listener = TcpListener::bind("127.0.0.1:80").expect("TcpStream::bind failed");
     /// ```
     ///
     /// Create a TCP listener bound to `127.0.0.1:80`. If that fails, create a
@@ -664,7 +664,7 @@ impl TcpListener {
     ///     SocketAddr::from(([127, 0, 0, 1], 80)),
     ///     SocketAddr::from(([127, 0, 0, 1], 443)),
     /// ];
-    /// let listener = TcpListener::bind(&addrs[..]).unwrap();
+    /// let listener = TcpListener::bind(&addrs[..]).expect("TcpStream::bind failed");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<TcpListener> {
@@ -678,8 +678,8 @@ impl TcpListener {
     /// ```no_run
     /// use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpListener};
     ///
-    /// let listener = TcpListener::bind("127.0.0.1:8080").unwrap();
-    /// assert_eq!(listener.local_addr().unwrap(),
+    /// let listener = TcpListener::bind("127.0.0.1:8080").expect("TcpStream::bind failed");
+    /// assert_eq!(listener.local_addr().expect("local_addr() call failed"),
     ///            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080)));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -700,8 +700,8 @@ impl TcpListener {
     /// ```no_run
     /// use std::net::TcpListener;
     ///
-    /// let listener = TcpListener::bind("127.0.0.1:8080").unwrap();
-    /// let listener_clone = listener.try_clone().unwrap();
+    /// let listener = TcpListener::bind("127.0.0.1:8080").expect("TcpStream::bind failed");
+    /// let listener_clone = listener.try_clone().expect("try_clone() call failed");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn try_clone(&self) -> io::Result<TcpListener> {
@@ -721,7 +721,7 @@ impl TcpListener {
     /// ```no_run
     /// use std::net::TcpListener;
     ///
-    /// let listener = TcpListener::bind("127.0.0.1:8080").unwrap();
+    /// let listener = TcpListener::bind("127.0.0.1:8080").expect("TcpStream::bind failed");
     /// match listener.accept() {
     ///     Ok((_socket, addr)) => println!("new client: {:?}", addr),
     ///     Err(e) => println!("couldn't get client: {:?}", e),
@@ -748,7 +748,7 @@ impl TcpListener {
     /// ```no_run
     /// use std::net::TcpListener;
     ///
-    /// let listener = TcpListener::bind("127.0.0.1:80").unwrap();
+    /// let listener = TcpListener::bind("127.0.0.1:80").expect("TcpStream::bind failed");
     ///
     /// for stream in listener.incoming() {
     ///     match stream {
@@ -774,7 +774,7 @@ impl TcpListener {
     /// ```no_run
     /// use std::net::TcpListener;
     ///
-    /// let listener = TcpListener::bind("127.0.0.1:80").unwrap();
+    /// let listener = TcpListener::bind("127.0.0.1:80").expect("TcpStream::bind failed");
     /// listener.set_ttl(100).expect("could not set TTL");
     /// ```
     #[stable(feature = "net2_mutators", since = "1.9.0")]
@@ -793,7 +793,7 @@ impl TcpListener {
     /// ```no_run
     /// use std::net::TcpListener;
     ///
-    /// let listener = TcpListener::bind("127.0.0.1:80").unwrap();
+    /// let listener = TcpListener::bind("127.0.0.1:80").expect("TcpStream::bind failed");
     /// listener.set_ttl(100).expect("could not set TTL");
     /// assert_eq!(listener.ttl().unwrap_or(0), 100);
     /// ```
@@ -829,7 +829,7 @@ impl TcpListener {
     /// ```no_run
     /// use std::net::TcpListener;
     ///
-    /// let listener = TcpListener::bind("127.0.0.1:80").unwrap();
+    /// let listener = TcpListener::bind("127.0.0.1:80").expect("TcpStream::bind failed");
     /// listener.take_error().expect("No error was expected");
     /// ```
     #[stable(feature = "net2_mutators", since = "1.9.0")]
@@ -858,7 +858,7 @@ impl TcpListener {
     /// use std::io;
     /// use std::net::TcpListener;
     ///
-    /// let listener = TcpListener::bind("127.0.0.1:7878").unwrap();
+    /// let listener = TcpListener::bind("127.0.0.1:7878").expect("TcpStream::bind failed");
     /// listener.set_nonblocking(true).expect("Cannot set non-blocking");
     ///
     /// # fn wait_for_fd() { unimplemented!() }

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -198,7 +198,7 @@ impl UdpSocket {
     /// use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, UdpSocket};
     ///
     /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
-    /// assert_eq!(socket.local_addr().unwrap(),
+    /// assert_eq!(socket.local_addr().expect("local_addr() call failed"),
     ///            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 34254)));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -261,7 +261,7 @@ impl UdpSocket {
     /// use std::net::UdpSocket;
     /// use std::time::Duration;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").unwrap();
+    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("UdpSocket::bind failed");
     /// let result = socket.set_read_timeout(Some(Duration::new(0, 0)));
     /// let err = result.unwrap_err();
     /// assert_eq!(err.kind(), io::ErrorKind::InvalidInput)
@@ -307,7 +307,7 @@ impl UdpSocket {
     /// use std::net::UdpSocket;
     /// use std::time::Duration;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").unwrap();
+    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("UdpSocket::bind failed");
     /// let result = socket.set_write_timeout(Some(Duration::new(0, 0)));
     /// let err = result.unwrap_err();
     /// assert_eq!(err.kind(), io::ErrorKind::InvalidInput)
@@ -331,7 +331,7 @@ impl UdpSocket {
     ///
     /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
     /// socket.set_read_timeout(None).expect("set_read_timeout call failed");
-    /// assert_eq!(socket.read_timeout().unwrap(), None);
+    /// assert_eq!(socket.read_timeout().expect("read_timeout() call failed"), None);
     /// ```
     #[stable(feature = "socket_timeout", since = "1.4.0")]
     pub fn read_timeout(&self) -> io::Result<Option<Duration>> {
@@ -352,7 +352,7 @@ impl UdpSocket {
     ///
     /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
     /// socket.set_write_timeout(None).expect("set_write_timeout call failed");
-    /// assert_eq!(socket.write_timeout().unwrap(), None);
+    /// assert_eq!(socket.write_timeout().expect("write_timeout() call failed"), None);
     /// ```
     #[stable(feature = "socket_timeout", since = "1.4.0")]
     pub fn write_timeout(&self) -> io::Result<Option<Duration>> {
@@ -391,7 +391,7 @@ impl UdpSocket {
     ///
     /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
     /// socket.set_broadcast(false).expect("set_broadcast call failed");
-    /// assert_eq!(socket.broadcast().unwrap(), false);
+    /// assert_eq!(socket.broadcast().expect("broadcast() call failed"), false);
     /// ```
     #[stable(feature = "net2_mutators", since = "1.9.0")]
     pub fn broadcast(&self) -> io::Result<bool> {
@@ -430,7 +430,7 @@ impl UdpSocket {
     ///
     /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
     /// socket.set_multicast_loop_v4(false).expect("set_multicast_loop_v4 call failed");
-    /// assert_eq!(socket.multicast_loop_v4().unwrap(), false);
+    /// assert_eq!(socket.multicast_loop_v4().expect("multicast_loop_v4() call failed"), false);
     /// ```
     #[stable(feature = "net2_mutators", since = "1.9.0")]
     pub fn multicast_loop_v4(&self) -> io::Result<bool> {
@@ -472,7 +472,7 @@ impl UdpSocket {
     ///
     /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
     /// socket.set_multicast_ttl_v4(42).expect("set_multicast_ttl_v4 call failed");
-    /// assert_eq!(socket.multicast_ttl_v4().unwrap(), 42);
+    /// assert_eq!(socket.multicast_ttl_v4().expect("multicast_ttl_v4() call failed"), 42);
     /// ```
     #[stable(feature = "net2_mutators", since = "1.9.0")]
     pub fn multicast_ttl_v4(&self) -> io::Result<u32> {
@@ -511,7 +511,7 @@ impl UdpSocket {
     ///
     /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
     /// socket.set_multicast_loop_v6(false).expect("set_multicast_loop_v6 call failed");
-    /// assert_eq!(socket.multicast_loop_v6().unwrap(), false);
+    /// assert_eq!(socket.multicast_loop_v6().expect("multicast_loop_v6() call failed"), false);
     /// ```
     #[stable(feature = "net2_mutators", since = "1.9.0")]
     pub fn multicast_loop_v6(&self) -> io::Result<bool> {
@@ -549,7 +549,7 @@ impl UdpSocket {
     ///
     /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
     /// socket.set_ttl(42).expect("set_ttl call failed");
-    /// assert_eq!(socket.ttl().unwrap(), 42);
+    /// assert_eq!(socket.ttl().expect("ttl() call failed"), 42);
     /// ```
     #[stable(feature = "net2_mutators", since = "1.9.0")]
     pub fn ttl(&self) -> io::Result<u32> {
@@ -773,8 +773,8 @@ impl UdpSocket {
     /// use std::io;
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:7878").unwrap();
-    /// socket.set_nonblocking(true).unwrap();
+    /// let socket = UdpSocket::bind("127.0.0.1:7878").expect("UdpSocket::bind failed");
+    /// socket.set_nonblocking(true).expect("set_nonblocking() call failed");
     ///
     /// # fn wait_for_fd() { unimplemented!() }
     /// let mut buf = [0; 10];

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -124,7 +124,7 @@ use sys::path::{is_sep_byte, is_verbatim_sep, MAIN_SEP_STR, parse_prefix};
 ///
 /// fn get_path_prefix(s: &str) -> Prefix {
 ///     let path = Path::new(s);
-///     match path.components().next().unwrap() {
+///     match path.components().next().expect("failed to get next component") {
 ///         Component::Prefix(prefix_component) => prefix_component.kind(),
 ///         _ => panic!(),
 ///     }
@@ -403,7 +403,7 @@ enum State {
 /// use std::ffi::OsStr;
 ///
 /// let path = Path::new(r"c:\you\later\");
-/// match path.components().next().unwrap() {
+/// match path.components().next().expect("failed to get next component") {
 ///     Component::Prefix(prefix_component) => {
 ///         assert_eq!(Prefix::Disk(b'C'), prefix_component.kind());
 ///         assert_eq!(OsStr::new("c:"), prefix_component.as_os_str());
@@ -1861,10 +1861,10 @@ impl Path {
     /// use std::path::Path;
     ///
     /// let path = Path::new("/foo/bar");
-    /// let parent = path.parent().unwrap();
+    /// let parent = path.parent().expect("parent() call failed");
     /// assert_eq!(parent, Path::new("/foo"));
     ///
-    /// let grand_parent = parent.parent().unwrap();
+    /// let grand_parent = parent.parent().expect("parent() call failed");
     /// assert_eq!(grand_parent, Path::new("/"));
     /// assert_eq!(grand_parent.parent(), None);
     /// ```
@@ -2055,7 +2055,7 @@ impl Path {
     ///
     /// let path = Path::new("foo.rs");
     ///
-    /// assert_eq!("foo", path.file_stem().unwrap());
+    /// assert_eq!("foo", path.file_stem().expect("file_stem() call failed"));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn file_stem(&self) -> Option<&OsStr> {
@@ -2081,7 +2081,7 @@ impl Path {
     ///
     /// let path = Path::new("foo.rs");
     ///
-    /// assert_eq!("rs", path.extension().unwrap());
+    /// assert_eq!("rs", path.extension().expect("extension() call failed"));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn extension(&self) -> Option<&OsStr> {
@@ -2314,7 +2314,8 @@ impl Path {
     /// use std::path::{Path, PathBuf};
     ///
     /// let path = Path::new("/foo/test/../test/bar.rs");
-    /// assert_eq!(path.canonicalize().unwrap(), PathBuf::from("/foo/test/bar.rs"));
+    /// assert_eq!(path.canonicalize().expect("canonicalize() call failed"),
+    ///            PathBuf::from("/foo/test/bar.rs"));
     /// ```
     #[stable(feature = "path_ext", since = "1.5.0")]
     pub fn canonicalize(&self) -> io::Result<PathBuf> {

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1225,7 +1225,7 @@ impl Child {
     /// ```no_run
     /// use std::process::Command;
     ///
-    /// let mut child = Command::new("ls").spawn().unwrap();
+    /// let mut child = Command::new("ls").spawn().expect("spawn() call failed");
     ///
     /// match child.try_wait() {
     ///     Ok(Some(status)) => println!("exited with: {}", status),

--- a/src/libstd/sync/barrier.rs
+++ b/src/libstd/sync/barrier.rs
@@ -34,7 +34,7 @@ use sync::{Mutex, Condvar};
 /// }
 /// // Wait for other threads to finish.
 /// for handle in handles {
-///     handle.join().unwrap();
+///     handle.join().expect("join() call failed");
 /// }
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -134,7 +134,7 @@ impl Barrier {
     /// }
     /// // Wait for other threads to finish.
     /// for handle in handles {
-    ///     handle.join().unwrap();
+    ///     handle.join().expect("join() call failed");
     /// }
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/sync/condvar.rs
+++ b/src/libstd/sync/condvar.rs
@@ -51,7 +51,7 @@ impl WaitTimeoutResult {
     ///     // Let's wait 20 milliseconds before notifying the condvar.
     ///     thread::sleep(Duration::from_millis(20));
     ///
-    ///     let mut started = lock.lock().unwrap();
+    ///     let mut started = lock.lock().expect("lock() call failed");
     ///     // We update the boolean value.
     ///     *started = true;
     ///     cvar.notify_one();
@@ -59,10 +59,11 @@ impl WaitTimeoutResult {
     ///
     /// // Wait for the thread to start up.
     /// let &(ref lock, ref cvar) = &*pair;
-    /// let mut started = lock.lock().unwrap();
+    /// let mut started = lock.lock().expect("lock() call failed");
     /// loop {
     ///     // Let's put a timeout on the condvar's wait.
-    ///     let result = cvar.wait_timeout(started, Duration::from_millis(10)).unwrap();
+    ///     let result = cvar.wait_timeout(started, Duration::from_millis(10))
+    ///                      .expect("wait_timeout() call failed");
     ///     // 10 milliseconds have passed, or maybe the value changed!
     ///     started = result.0;
     ///     if *started == true {
@@ -105,7 +106,7 @@ impl WaitTimeoutResult {
 /// // Inside of our lock, spawn a new thread, and then wait for it to start.
 /// thread::spawn(move|| {
 ///     let &(ref lock, ref cvar) = &*pair2;
-///     let mut started = lock.lock().unwrap();
+///     let mut started = lock.lock().expect("lock() call failed");
 ///     *started = true;
 ///     // We notify the condvar that the value has changed.
 ///     cvar.notify_one();
@@ -113,9 +114,9 @@ impl WaitTimeoutResult {
 ///
 /// // Wait for the thread to start up.
 /// let &(ref lock, ref cvar) = &*pair;
-/// let mut started = lock.lock().unwrap();
+/// let mut started = lock.lock().expect("lock() call failed");
 /// while !*started {
-///     started = cvar.wait(started).unwrap();
+///     started = cvar.wait(started).expect("wait() call failed");
 /// }
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -191,7 +192,7 @@ impl Condvar {
     ///
     /// thread::spawn(move|| {
     ///     let &(ref lock, ref cvar) = &*pair2;
-    ///     let mut started = lock.lock().unwrap();
+    ///     let mut started = lock.lock().expect("lock() call failed");
     ///     *started = true;
     ///     // We notify the condvar that the value has changed.
     ///     cvar.notify_one();
@@ -199,10 +200,10 @@ impl Condvar {
     ///
     /// // Wait for the thread to start up.
     /// let &(ref lock, ref cvar) = &*pair;
-    /// let mut started = lock.lock().unwrap();
+    /// let mut started = lock.lock().expect("lock() call failed");
     /// // As long as the value inside the `Mutex` is false, we wait.
     /// while !*started {
-    ///     started = cvar.wait(started).unwrap();
+    ///     started = cvar.wait(started).expect("wait() call failed");
     /// }
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -256,7 +257,7 @@ impl Condvar {
     ///
     /// thread::spawn(move|| {
     ///     let &(ref lock, ref cvar) = &*pair2;
-    ///     let mut started = lock.lock().unwrap();
+    ///     let mut started = lock.lock().expect("lock() call failed");
     ///     *started = true;
     ///     // We notify the condvar that the value has changed.
     ///     cvar.notify_one();
@@ -265,7 +266,8 @@ impl Condvar {
     /// // Wait for the thread to start up.
     /// let &(ref lock, ref cvar) = &*pair;
     /// // As long as the value inside the `Mutex` is false, we wait.
-    /// let _guard = cvar.wait_until(lock.lock().unwrap(), |started| { *started }).unwrap();
+    /// let _guard = cvar.wait_until(lock.lock().expect("lock() call failed"),
+    ///                              |started| { *started }).expect("wait_until() call failed");
     /// ```
     #[unstable(feature = "wait_until", issue = "47960")]
     pub fn wait_until<'a, T, F>(&self, mut guard: MutexGuard<'a, T>,
@@ -312,7 +314,7 @@ impl Condvar {
     ///
     /// thread::spawn(move|| {
     ///     let &(ref lock, ref cvar) = &*pair2;
-    ///     let mut started = lock.lock().unwrap();
+    ///     let mut started = lock.lock().expect("lock() call failed");
     ///     *started = true;
     ///     // We notify the condvar that the value has changed.
     ///     cvar.notify_one();
@@ -320,10 +322,10 @@ impl Condvar {
     ///
     /// // Wait for the thread to start up.
     /// let &(ref lock, ref cvar) = &*pair;
-    /// let mut started = lock.lock().unwrap();
+    /// let mut started = lock.lock().expect("lock() call failed");
     /// // As long as the value inside the `Mutex` is false, we wait.
     /// loop {
-    ///     let result = cvar.wait_timeout_ms(started, 10).unwrap();
+    ///     let result = cvar.wait_timeout_ms(started, 10).expect("wait_timeout_ms() call failed");
     ///     // 10 milliseconds have passed, or maybe the value changed!
     ///     started = result.0;
     ///     if *started == true {
@@ -385,7 +387,7 @@ impl Condvar {
     ///
     /// thread::spawn(move|| {
     ///     let &(ref lock, ref cvar) = &*pair2;
-    ///     let mut started = lock.lock().unwrap();
+    ///     let mut started = lock.lock().expect("lock() call failed");
     ///     *started = true;
     ///     // We notify the condvar that the value has changed.
     ///     cvar.notify_one();
@@ -393,10 +395,11 @@ impl Condvar {
     ///
     /// // wait for the thread to start up
     /// let &(ref lock, ref cvar) = &*pair;
-    /// let mut started = lock.lock().unwrap();
+    /// let mut started = lock.lock().expect("lock() call failed");
     /// // as long as the value inside the `Mutex` is false, we wait
     /// loop {
-    ///     let result = cvar.wait_timeout(started, Duration::from_millis(10)).unwrap();
+    ///     let result = cvar.wait_timeout(started, Duration::from_millis(10))
+    ///                      .expect("wait_timeout() call failed");
     ///     // 10 milliseconds have passed, or maybe the value changed!
     ///     started = result.0;
     ///     if *started == true {
@@ -460,7 +463,7 @@ impl Condvar {
     ///
     /// thread::spawn(move|| {
     ///     let &(ref lock, ref cvar) = &*pair2;
-    ///     let mut started = lock.lock().unwrap();
+    ///     let mut started = lock.lock().expect("lock() call failed");
     ///     *started = true;
     ///     // We notify the condvar that the value has changed.
     ///     cvar.notify_one();
@@ -469,10 +472,10 @@ impl Condvar {
     /// // wait for the thread to start up
     /// let &(ref lock, ref cvar) = &*pair;
     /// let result = cvar.wait_timeout_until(
-    ///     lock.lock().unwrap(),
+    ///     lock.lock().expect("lock() call failed"),
     ///     Duration::from_millis(100),
     ///     |&mut started| started,
-    /// ).unwrap();
+    /// ).expect("wait_timeout_until() call failed");
     /// if result.1.timed_out() {
     ///     // timed-out without the condition ever evaluating to true.
     /// }
@@ -519,7 +522,7 @@ impl Condvar {
     ///
     /// thread::spawn(move|| {
     ///     let &(ref lock, ref cvar) = &*pair2;
-    ///     let mut started = lock.lock().unwrap();
+    ///     let mut started = lock.lock().expect("lock() call failed");
     ///     *started = true;
     ///     // We notify the condvar that the value has changed.
     ///     cvar.notify_one();
@@ -527,10 +530,10 @@ impl Condvar {
     ///
     /// // Wait for the thread to start up.
     /// let &(ref lock, ref cvar) = &*pair;
-    /// let mut started = lock.lock().unwrap();
+    /// let mut started = lock.lock().expect("lock() call failed");
     /// // As long as the value inside the `Mutex` is false, we wait.
     /// while !*started {
-    ///     started = cvar.wait(started).unwrap();
+    ///     started = cvar.wait(started).expect("wait() call failed");
     /// }
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -559,7 +562,7 @@ impl Condvar {
     ///
     /// thread::spawn(move|| {
     ///     let &(ref lock, ref cvar) = &*pair2;
-    ///     let mut started = lock.lock().unwrap();
+    ///     let mut started = lock.lock().expect("lock() call failed");
     ///     *started = true;
     ///     // We notify the condvar that the value has changed.
     ///     cvar.notify_all();
@@ -567,10 +570,10 @@ impl Condvar {
     ///
     /// // Wait for the thread to start up.
     /// let &(ref lock, ref cvar) = &*pair;
-    /// let mut started = lock.lock().unwrap();
+    /// let mut started = lock.lock().expect("lock() call failed");
     /// // As long as the value inside the `Mutex` is false, we wait.
     /// while !*started {
-    ///     started = cvar.wait(started).unwrap();
+    ///     started = cvar.wait(started).expect("wait() call failed");
     /// }
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -51,12 +51,12 @@
 //!
 //! Once half of a channel has been deallocated, most operations can no longer
 //! continue to make progress, so [`Err`] will be returned. Many applications
-//! will continue to [`unwrap`] the results returned from this module,
+//! will continue to [`expect`] the results returned from this module,
 //! instigating a propagation of failure among threads if one unexpectedly dies.
 //!
 //! [`Result`]: ../../../std/result/enum.Result.html
 //! [`Err`]: ../../../std/result/enum.Result.html#variant.Err
-//! [`unwrap`]: ../../../std/result/enum.Result.html#method.unwrap
+//! [`expect`]: ../../../std/result/enum.Result.html#method.expect
 //!
 //! # Examples
 //!
@@ -69,9 +69,9 @@
 //! // Create a simple streaming channel
 //! let (tx, rx) = channel();
 //! thread::spawn(move|| {
-//!     tx.send(10).unwrap();
+//!     tx.send(10).expect("send() call failed");
 //! });
-//! assert_eq!(rx.recv().unwrap(), 10);
+//! assert_eq!(rx.recv().expect("recv() call failed"), 10);
 //! ```
 //!
 //! Shared usage:
@@ -87,12 +87,12 @@
 //! for i in 0..10 {
 //!     let tx = tx.clone();
 //!     thread::spawn(move|| {
-//!         tx.send(i).unwrap();
+//!         tx.send(i).expect("send() call failed");
 //!     });
 //! }
 //!
 //! for _ in 0..10 {
-//!     let j = rx.recv().unwrap();
+//!     let j = rx.recv().expect("recv() call failed");
 //!     assert!(0 <= j && j < 10);
 //! }
 //! ```
@@ -118,9 +118,9 @@
 //! let (tx, rx) = sync_channel::<i32>(0);
 //! thread::spawn(move|| {
 //!     // This will wait for the parent thread to start receiving
-//!     tx.send(53).unwrap();
+//!     tx.send(53).expect("send() call failed");
 //! });
-//! rx.recv().unwrap();
+//! rx.recv().expect("recv() call failed");
 //! ```
 
 #![stable(feature = "rust1", since = "1.0.0")]
@@ -318,14 +318,14 @@ mod cache_aligned;
 /// let (send, recv) = channel();
 ///
 /// thread::spawn(move || {
-///     send.send("Hello world!").unwrap();
+///     send.send("Hello world!").expect("send() call failed");
 ///     thread::sleep(Duration::from_secs(2)); // block for two seconds
-///     send.send("Delayed for 2 seconds").unwrap();
+///     send.send("Delayed for 2 seconds").expect("send() call failed");
 /// });
 ///
-/// println!("{}", recv.recv().unwrap()); // Received immediately
+/// println!("{}", recv.recv().expect("recv() call failed")); // Received immediately
 /// println!("Waiting...");
-/// println!("{}", recv.recv().unwrap()); // Received after 2 seconds
+/// println!("{}", recv.recv().expect("recv() call failed")); // Received after 2 seconds
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Receiver<T> {
@@ -360,9 +360,9 @@ impl<T> !Sync for Receiver<T> { }
 /// let (send, recv) = channel();
 ///
 /// thread::spawn(move || {
-///     send.send(1u8).unwrap();
-///     send.send(2u8).unwrap();
-///     send.send(3u8).unwrap();
+///     send.send(1u8).expect("send() call failed");
+///     send.send(2u8).expect("send() call failed");
+///     send.send(3u8).expect("send() call failed");
 /// });
 ///
 /// for x in recv.iter() {
@@ -402,9 +402,9 @@ pub struct Iter<'a, T: 'a> {
 /// println!("Nothing in the buffer...");
 ///
 /// thread::spawn(move || {
-///     sender.send(1).unwrap();
-///     sender.send(2).unwrap();
-///     sender.send(3).unwrap();
+///     sender.send(1).expect("send() call#1 failed");
+///     sender.send(2).expect("send() call#2 failed");
+///     sender.send(3).expect("send() call#3 failed");
 /// });
 ///
 /// println!("Going to sleep...");
@@ -440,9 +440,9 @@ pub struct TryIter<'a, T: 'a> {
 /// let (send, recv) = channel();
 ///
 /// thread::spawn(move || {
-///     send.send(1u8).unwrap();
-///     send.send(2u8).unwrap();
-///     send.send(3u8).unwrap();
+///     send.send(1u8).expect("send() call#1 failed");
+///     send.send(2u8).expect("send() call#2 failed");
+///     send.send(3u8).expect("send() call#3 failed");
 /// });
 ///
 /// for x in recv.into_iter() {
@@ -474,16 +474,16 @@ pub struct IntoIter<T> {
 ///
 /// // First thread owns sender
 /// thread::spawn(move || {
-///     sender.send(1).unwrap();
+///     sender.send(1).expect("send() call#1 failed");
 /// });
 ///
 /// // Second thread owns sender2
 /// thread::spawn(move || {
-///     sender2.send(2).unwrap();
+///     sender2.send(2).expect("send() call#2 failed");
 /// });
 ///
-/// let msg = receiver.recv().unwrap();
-/// let msg2 = receiver.recv().unwrap();
+/// let msg = receiver.recv().expect("recv() call#1 failed");
+/// let msg2 = receiver.recv().expect("recv() call#2 failed");
 ///
 /// assert_eq!(3, msg + msg2);
 /// ```
@@ -522,28 +522,28 @@ impl<T> !Sync for Sender<T> { }
 ///
 /// // First thread owns sync_sender
 /// thread::spawn(move || {
-///     sync_sender.send(1).unwrap();
-///     sync_sender.send(2).unwrap();
+///     sync_sender.send(1).expect("send() call#1 failed");
+///     sync_sender.send(2).expect("send() call#2 failed");
 /// });
 ///
 /// // Second thread owns sync_sender2
 /// thread::spawn(move || {
-///     sync_sender2.send(3).unwrap();
+///     sync_sender2.send(3).expect("send() call#3 failed");
 ///     // thread will now block since the buffer is full
 ///     println!("Thread unblocked!");
 /// });
 ///
 /// let mut msg;
 ///
-/// msg = receiver.recv().unwrap();
+/// msg = receiver.recv().expect("recv() call#1 failed");
 /// println!("message {} received", msg);
 ///
 /// // "Thread unblocked!" will be printed now
 ///
-/// msg = receiver.recv().unwrap();
+/// msg = receiver.recv().expect("recv() call#2 failed");
 /// println!("message {} received", msg);
 ///
-/// msg = receiver.recv().unwrap();
+/// msg = receiver.recv().expect("recv() call#3 failed");
 ///
 /// println!("message {} received", msg);
 /// ```
@@ -712,13 +712,13 @@ impl<T> UnsafeFlavor<T> for Receiver<T> {
 /// // Spawn off an expensive computation
 /// thread::spawn(move|| {
 /// #   fn expensive_computation() {}
-///     sender.send(expensive_computation()).unwrap();
+///     sender.send(expensive_computation()).expect("send() call failed");
 /// });
 ///
 /// // Do some useful work for awhile
 ///
 /// // Let's see what that answer was
-/// println!("{:?}", receiver.recv().unwrap());
+/// println!("{:?}", receiver.recv().expect("recv() call failed"));
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
@@ -763,15 +763,15 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
 /// let (sender, receiver) = sync_channel(1);
 ///
 /// // this returns immediately
-/// sender.send(1).unwrap();
+/// sender.send(1).expect("send() call#1 failed");
 ///
 /// thread::spawn(move|| {
 ///     // this will block until the previous message has been received
-///     sender.send(2).unwrap();
+///     sender.send(2).expect("send() call#2 failed");
 /// });
 ///
-/// assert_eq!(receiver.recv().unwrap(), 1);
-/// assert_eq!(receiver.recv().unwrap(), 2);
+/// assert_eq!(receiver.recv().expect("recv() call#1 failed"), 1);
+/// assert_eq!(receiver.recv().expect("recv() call#2 failed"), 2);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn sync_channel<T>(bound: usize) -> (SyncSender<T>, Receiver<T>) {
@@ -814,7 +814,7 @@ impl<T> Sender<T> {
     /// let (tx, rx) = channel();
     ///
     /// // This send is always successful
-    /// tx.send(1).unwrap();
+    /// tx.send(1).expect("send() call failed");
     ///
     /// // This send will fail because the receiver is gone
     /// drop(rx);
@@ -964,13 +964,13 @@ impl<T> SyncSender<T> {
     ///
     /// thread::spawn(move || {
     ///    println!("sending message...");
-    ///    sync_sender.send(1).unwrap();
+    ///    sync_sender.send(1).expect("send() call failed");
     ///    // Thread is now blocked until the message is received
     ///
     ///    println!("...message received!");
     /// });
     ///
-    /// let msg = receiver.recv().unwrap();
+    /// let msg = receiver.recv().expect("recv() call failed");
     /// assert_eq!(1, msg);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -1002,8 +1002,8 @@ impl<T> SyncSender<T> {
     ///
     /// // First thread owns sync_sender
     /// thread::spawn(move || {
-    ///     sync_sender.send(1).unwrap();
-    ///     sync_sender.send(2).unwrap();
+    ///     sync_sender.send(1).expect("send() call#1 failed");
+    ///     sync_sender.send(2).expect("send() call#2 failed");
     ///     // Thread blocked
     /// });
     ///
@@ -1015,10 +1015,10 @@ impl<T> SyncSender<T> {
     /// });
     ///
     /// let mut msg;
-    /// msg = receiver.recv().unwrap();
+    /// msg = receiver.recv().expect("recv() call#1 failed");
     /// println!("message {} received", msg);
     ///
-    /// msg = receiver.recv().unwrap();
+    /// msg = receiver.recv().expect("recv() call#2 failed");
     /// println!("message {} received", msg);
     ///
     /// // Third message may have never been sent
@@ -1163,10 +1163,10 @@ impl<T> Receiver<T> {
     ///
     /// let (send, recv) = mpsc::channel();
     /// let handle = thread::spawn(move || {
-    ///     send.send(1u8).unwrap();
+    ///     send.send(1u8).expect("send() call#1 failed");
     /// });
     ///
-    /// handle.join().unwrap();
+    /// handle.join().expect("join() call#1 failed");
     ///
     /// assert_eq!(Ok(1), recv.recv());
     /// ```
@@ -1180,14 +1180,14 @@ impl<T> Receiver<T> {
     ///
     /// let (send, recv) = mpsc::channel();
     /// let handle = thread::spawn(move || {
-    ///     send.send(1u8).unwrap();
-    ///     send.send(2).unwrap();
-    ///     send.send(3).unwrap();
+    ///     send.send(1u8).expect("send() call#2 failed");
+    ///     send.send(2).expect("send() call#3 failed");
+    ///     send.send(3).expect("send() call#4 failed");
     ///     drop(send);
     /// });
     ///
     /// // wait for the thread to join so we ensure the sender is dropped
-    /// handle.join().unwrap();
+    /// handle.join().expect("join() call#2 failed");
     ///
     /// assert_eq!(Ok(1), recv.recv());
     /// assert_eq!(Ok(2), recv.recv());
@@ -1259,7 +1259,7 @@ impl<T> Receiver<T> {
     /// let (send, recv) = mpsc::channel();
     ///
     /// thread::spawn(move || {
-    ///     send.send('a').unwrap();
+    ///     send.send('a').expect("send() call failed");
     /// });
     ///
     /// assert_eq!(
@@ -1279,7 +1279,7 @@ impl<T> Receiver<T> {
     ///
     /// thread::spawn(move || {
     ///     thread::sleep(Duration::from_millis(800));
-    ///     send.send('a').unwrap();
+    ///     send.send('a').expect("send() call failed");
     /// });
     ///
     /// assert_eq!(
@@ -1332,7 +1332,7 @@ impl<T> Receiver<T> {
     /// let (send, recv) = mpsc::channel();
     ///
     /// thread::spawn(move || {
-    ///     send.send('a').unwrap();
+    ///     send.send('a').expect("send() call failed");
     /// });
     ///
     /// assert_eq!(
@@ -1353,7 +1353,7 @@ impl<T> Receiver<T> {
     ///
     /// thread::spawn(move || {
     ///     thread::sleep(Duration::from_millis(800));
-    ///     send.send('a').unwrap();
+    ///     send.send('a').expect("send() call failed");
     /// });
     ///
     /// assert_eq!(
@@ -1428,9 +1428,9 @@ impl<T> Receiver<T> {
     /// let (send, recv) = channel();
     ///
     /// thread::spawn(move || {
-    ///     send.send(1).unwrap();
-    ///     send.send(2).unwrap();
-    ///     send.send(3).unwrap();
+    ///     send.send(1).expect("send() call#1 failed");
+    ///     send.send(2).expect("send() call#2 failed");
+    ///     send.send(3).expect("send() call#3 failed");
     /// });
     ///
     /// let mut iter = recv.iter();
@@ -1465,9 +1465,9 @@ impl<T> Receiver<T> {
     ///
     /// thread::spawn(move || {
     ///     thread::sleep(Duration::from_secs(1));
-    ///     sender.send(1).unwrap();
-    ///     sender.send(2).unwrap();
-    ///     sender.send(3).unwrap();
+    ///     sender.send(1).expect("send() call#1 failed");
+    ///     sender.send(2).expect("send() call#2 failed");
+    ///     sender.send(3).expect("send() call#3 failed");
     /// });
     ///
     /// // nothing is in the buffer yet

--- a/src/libstd/sync/mpsc/select.rs
+++ b/src/libstd/sync/mpsc/select.rs
@@ -34,15 +34,15 @@
 //! let (tx1, rx1) = channel();
 //! let (tx2, rx2) = channel();
 //!
-//! tx1.send(1).unwrap();
-//! tx2.send(2).unwrap();
+//! tx1.send(1).expect("send() call#1 failed");
+//! tx2.send(2).expect("send() call#2 failed");
 //!
 //! select! {
 //!     val = rx1.recv() => {
-//!         assert_eq!(val.unwrap(), 1);
+//!         assert_eq!(val.expect("recv() call#1 failed"), 1);
 //!     },
 //!     val = rx2.recv() => {
-//!         assert_eq!(val.unwrap(), 2);
+//!         assert_eq!(val.expect("recv() call#2 failed"), 2);
 //!     }
 //! }
 //! ```

--- a/src/libstd/sync/rwlock.rs
+++ b/src/libstd/sync/rwlock.rs
@@ -54,15 +54,15 @@ use sys_common::rwlock as sys;
 ///
 /// // many reader locks can be held at once
 /// {
-///     let r1 = lock.read().unwrap();
-///     let r2 = lock.read().unwrap();
+///     let r1 = lock.read().expect("read() call#1 failed");
+///     let r2 = lock.read().expect("read() call#2 failed");
 ///     assert_eq!(*r1, 5);
 ///     assert_eq!(*r2, 5);
 /// } // read locks are dropped at this point
 ///
 /// // only one write lock may be held, however
 /// {
-///     let mut w = lock.write().unwrap();
+///     let mut w = lock.write().expect("write() call failed");
 ///     *w += 1;
 ///     assert_eq!(*w, 6);
 /// } // write lock is dropped here
@@ -180,13 +180,13 @@ impl<T: ?Sized> RwLock<T> {
     /// let lock = Arc::new(RwLock::new(1));
     /// let c_lock = lock.clone();
     ///
-    /// let n = lock.read().unwrap();
+    /// let n = lock.read().expect("read() call failed");
     /// assert_eq!(*n, 1);
     ///
     /// thread::spawn(move || {
     ///     let r = c_lock.read();
     ///     assert!(r.is_ok());
-    /// }).join().unwrap();
+    /// }).join().expect("join() call failed");
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -265,7 +265,7 @@ impl<T: ?Sized> RwLock<T> {
     ///
     /// let lock = RwLock::new(1);
     ///
-    /// let mut n = lock.write().unwrap();
+    /// let mut n = lock.write().expect("write() call failed");
     /// *n = 2;
     ///
     /// assert!(lock.try_read().is_err());
@@ -304,7 +304,7 @@ impl<T: ?Sized> RwLock<T> {
     ///
     /// let lock = RwLock::new(1);
     ///
-    /// let n = lock.read().unwrap();
+    /// let n = lock.read().expect("read() call failed");
     /// assert_eq!(*n, 1);
     ///
     /// assert!(lock.try_write().is_err());
@@ -337,7 +337,7 @@ impl<T: ?Sized> RwLock<T> {
     /// let c_lock = lock.clone();
     ///
     /// let _ = thread::spawn(move || {
-    ///     let _lock = c_lock.write().unwrap();
+    ///     let _lock = c_lock.write().expect("write() call failed");
     ///     panic!(); // the lock gets poisoned
     /// }).join();
     /// assert_eq!(lock.is_poisoned(), true);
@@ -364,10 +364,10 @@ impl<T: ?Sized> RwLock<T> {
     ///
     /// let lock = RwLock::new(String::new());
     /// {
-    ///     let mut s = lock.write().unwrap();
+    ///     let mut s = lock.write().expect("write() call failed");
     ///     *s = "modified".to_owned();
     /// }
-    /// assert_eq!(lock.into_inner().unwrap(), "modified");
+    /// assert_eq!(lock.into_inner().expect("into_inner() call failed"), "modified");
     /// ```
     #[stable(feature = "rwlock_into_inner", since = "1.6.0")]
     pub fn into_inner(self) -> LockResult<T> where T: Sized {
@@ -409,8 +409,8 @@ impl<T: ?Sized> RwLock<T> {
     /// use std::sync::RwLock;
     ///
     /// let mut lock = RwLock::new(0);
-    /// *lock.get_mut().unwrap() = 10;
-    /// assert_eq!(*lock.read().unwrap(), 10);
+    /// *lock.get_mut().expect("get_mut() call failed") = 10;
+    /// assert_eq!(*lock.read().expect("read() call failed"), 10);
     /// ```
     #[stable(feature = "rwlock_get_mut", since = "1.6.0")]
     pub fn get_mut(&mut self) -> LockResult<&mut T> {

--- a/src/libstd/sys/redox/ext/mod.rs
+++ b/src/libstd/sys/redox/ext/mod.rs
@@ -20,7 +20,7 @@
 //! use std::os::unix::prelude::*;
 //!
 //! fn main() {
-//!     let f = File::create("foo.txt").unwrap();
+//!     let f = File::create("foo.txt").expect("File::create failed");
 //!     let fd = f.as_raw_fd();
 //!
 //!     // use fd with native unix bindings

--- a/src/libstd/sys/unix/ext/mod.rs
+++ b/src/libstd/sys/unix/ext/mod.rs
@@ -26,7 +26,7 @@
 //! use std::os::unix::prelude::*;
 //!
 //! fn main() {
-//!     let f = File::create("foo.txt").unwrap();
+//!     let f = File::create("foo.txt").expect("File::create failed");
 //!     let fd = f.as_raw_fd();
 //!
 //!     // use fd with native unix bindings

--- a/src/libstd/sys/unix/ext/net.rs
+++ b/src/libstd/sys/unix/ext/net.rs
@@ -153,7 +153,7 @@ impl SocketAddr {
     /// ```no_run
     /// use std::os::unix::net::UnixListener;
     ///
-    /// let socket = UnixListener::bind("/tmp/sock").unwrap();
+    /// let socket = UnixListener::bind("/tmp/sock").expect("UnixListener::bind failed");
     /// let addr = socket.local_addr().expect("Couldn't get local address");
     /// assert_eq!(addr.is_unnamed(), false);
     /// ```
@@ -163,7 +163,7 @@ impl SocketAddr {
     /// ```
     /// use std::os::unix::net::UnixDatagram;
     ///
-    /// let socket = UnixDatagram::unbound().unwrap();
+    /// let socket = UnixDatagram::unbound().expect("UnixDatagram::unbound failed");
     /// let addr = socket.local_addr().expect("Couldn't get local address");
     /// assert_eq!(addr.is_unnamed(), true);
     /// ```
@@ -186,7 +186,7 @@ impl SocketAddr {
     /// use std::os::unix::net::UnixListener;
     /// use std::path::Path;
     ///
-    /// let socket = UnixListener::bind("/tmp/sock").unwrap();
+    /// let socket = UnixListener::bind("/tmp/sock").expect("UnixListener::bind failed");
     /// let addr = socket.local_addr().expect("Couldn't get local address");
     /// assert_eq!(addr.as_pathname(), Some(Path::new("/tmp/sock")));
     /// ```
@@ -196,7 +196,7 @@ impl SocketAddr {
     /// ```
     /// use std::os::unix::net::UnixDatagram;
     ///
-    /// let socket = UnixDatagram::unbound().unwrap();
+    /// let socket = UnixDatagram::unbound().expect("UnixDatagram::unbound failed");
     /// let addr = socket.local_addr().expect("Couldn't get local address");
     /// assert_eq!(addr.as_pathname(), None);
     /// ```
@@ -258,10 +258,10 @@ impl<'a> fmt::Display for AsciiEscaped<'a> {
 /// use std::os::unix::net::UnixStream;
 /// use std::io::prelude::*;
 ///
-/// let mut stream = UnixStream::connect("/path/to/my/socket").unwrap();
-/// stream.write_all(b"hello world").unwrap();
+/// let mut stream = UnixStream::connect("/path/to/my/socket").expect("UnixStream::connect failed");
+/// stream.write_all(b"hello world").expect("write_all() call failed");
 /// let mut response = String::new();
-/// stream.read_to_string(&mut response).unwrap();
+/// stream.read_to_string(&mut response).expect("read_to_string() call failed");
 /// println!("{}", response);
 /// ```
 #[stable(feature = "unix_socket", since = "1.10.0")]
@@ -347,7 +347,7 @@ impl UnixStream {
     /// ```no_run
     /// use std::os::unix::net::UnixStream;
     ///
-    /// let socket = UnixStream::connect("/tmp/sock").unwrap();
+    /// let socket = UnixStream::connect("/tmp/sock").expect("UnixStream::connect failed");
     /// let sock_copy = socket.try_clone().expect("Couldn't clone socket");
     /// ```
     #[stable(feature = "unix_socket", since = "1.10.0")]
@@ -362,7 +362,7 @@ impl UnixStream {
     /// ```no_run
     /// use std::os::unix::net::UnixStream;
     ///
-    /// let socket = UnixStream::connect("/tmp/sock").unwrap();
+    /// let socket = UnixStream::connect("/tmp/sock").expect("UnixStream::connect failed");
     /// let addr = socket.local_addr().expect("Couldn't get local address");
     /// ```
     #[stable(feature = "unix_socket", since = "1.10.0")]
@@ -377,7 +377,7 @@ impl UnixStream {
     /// ```no_run
     /// use std::os::unix::net::UnixStream;
     ///
-    /// let socket = UnixStream::connect("/tmp/sock").unwrap();
+    /// let socket = UnixStream::connect("/tmp/sock").expect("UnixStream::connect failed");
     /// let addr = socket.peer_addr().expect("Couldn't get peer address");
     /// ```
     #[stable(feature = "unix_socket", since = "1.10.0")]
@@ -402,7 +402,7 @@ impl UnixStream {
     /// use std::os::unix::net::UnixStream;
     /// use std::time::Duration;
     ///
-    /// let socket = UnixStream::connect("/tmp/sock").unwrap();
+    /// let socket = UnixStream::connect("/tmp/sock").expect("UnixStream::connect failed");
     /// socket.set_read_timeout(Some(Duration::new(1, 0))).expect("Couldn't set read timeout");
     /// ```
     ///
@@ -414,7 +414,7 @@ impl UnixStream {
     /// use std::os::unix::net::UnixStream;
     /// use std::time::Duration;
     ///
-    /// let socket = UnixStream::connect("/tmp/sock").unwrap();
+    /// let socket = UnixStream::connect("/tmp/sock").expect("UnixStream::connect failed");
     /// let result = socket.set_read_timeout(Some(Duration::new(0, 0)));
     /// let err = result.unwrap_err();
     /// assert_eq!(err.kind(), io::ErrorKind::InvalidInput)
@@ -441,7 +441,7 @@ impl UnixStream {
     /// use std::os::unix::net::UnixStream;
     /// use std::time::Duration;
     ///
-    /// let socket = UnixStream::connect("/tmp/sock").unwrap();
+    /// let socket = UnixStream::connect("/tmp/sock").expect("UnixStream::connect failed");
     /// socket.set_write_timeout(Some(Duration::new(1, 0))).expect("Couldn't set write timeout");
     /// ```
     ///
@@ -453,7 +453,7 @@ impl UnixStream {
     /// use std::net::UdpSocket;
     /// use std::time::Duration;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").unwrap();
+    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("UdpSocket::bind failed");
     /// let result = socket.set_write_timeout(Some(Duration::new(0, 0)));
     /// let err = result.unwrap_err();
     /// assert_eq!(err.kind(), io::ErrorKind::InvalidInput)
@@ -471,9 +471,10 @@ impl UnixStream {
     /// use std::os::unix::net::UnixStream;
     /// use std::time::Duration;
     ///
-    /// let socket = UnixStream::connect("/tmp/sock").unwrap();
+    /// let socket = UnixStream::connect("/tmp/sock").expect("UnixStream::connect failed");
     /// socket.set_read_timeout(Some(Duration::new(1, 0))).expect("Couldn't set read timeout");
-    /// assert_eq!(socket.read_timeout().unwrap(), Some(Duration::new(1, 0)));
+    /// assert_eq!(socket.read_timeout().expect("read_timeout() call failed"),
+    ///            Some(Duration::new(1, 0)));
     /// ```
     #[stable(feature = "unix_socket", since = "1.10.0")]
     pub fn read_timeout(&self) -> io::Result<Option<Duration>> {
@@ -488,9 +489,10 @@ impl UnixStream {
     /// use std::os::unix::net::UnixStream;
     /// use std::time::Duration;
     ///
-    /// let socket = UnixStream::connect("/tmp/sock").unwrap();
+    /// let socket = UnixStream::connect("/tmp/sock").expect("UnixStream::connect failed");
     /// socket.set_write_timeout(Some(Duration::new(1, 0))).expect("Couldn't set write timeout");
-    /// assert_eq!(socket.write_timeout().unwrap(), Some(Duration::new(1, 0)));
+    /// assert_eq!(socket.write_timeout().expect("write_timeout() call failed"),
+    ///            Some(Duration::new(1, 0)));
     /// ```
     #[stable(feature = "unix_socket", since = "1.10.0")]
     pub fn write_timeout(&self) -> io::Result<Option<Duration>> {
@@ -504,7 +506,7 @@ impl UnixStream {
     /// ```no_run
     /// use std::os::unix::net::UnixStream;
     ///
-    /// let socket = UnixStream::connect("/tmp/sock").unwrap();
+    /// let socket = UnixStream::connect("/tmp/sock").expect("UnixStream::connect failed");
     /// socket.set_nonblocking(true).expect("Couldn't set nonblocking");
     /// ```
     #[stable(feature = "unix_socket", since = "1.10.0")]
@@ -519,7 +521,7 @@ impl UnixStream {
     /// ```no_run
     /// use std::os::unix::net::UnixStream;
     ///
-    /// let socket = UnixStream::connect("/tmp/sock").unwrap();
+    /// let socket = UnixStream::connect("/tmp/sock").expect("UnixStream::connect failed");
     /// if let Ok(Some(err)) = socket.take_error() {
     ///     println!("Got error: {:?}", err);
     /// }
@@ -546,7 +548,7 @@ impl UnixStream {
     /// use std::os::unix::net::UnixStream;
     /// use std::net::Shutdown;
     ///
-    /// let socket = UnixStream::connect("/tmp/sock").unwrap();
+    /// let socket = UnixStream::connect("/tmp/sock").expect("UnixStream::connect failed");
     /// socket.shutdown(Shutdown::Both).expect("shutdown function failed");
     /// ```
     #[stable(feature = "unix_socket", since = "1.10.0")]
@@ -692,7 +694,7 @@ impl IntoRawFd for net::UdpSocket {
 ///     // ...
 /// }
 ///
-/// let listener = UnixListener::bind("/path/to/the/socket").unwrap();
+/// let listener = UnixListener::bind("/path/to/the/socket").expect("UnixListener::bind failed");
 ///
 /// // accept connections and process them, spawning a new thread for each one
 /// for stream in listener.incoming() {
@@ -768,7 +770,8 @@ impl UnixListener {
     /// ```no_run
     /// use std::os::unix::net::UnixListener;
     ///
-    /// let listener = UnixListener::bind("/path/to/the/socket").unwrap();
+    /// let listener = UnixListener::bind("/path/to/the/socket")
+    ///                             .expect("UnixListener::bind failed");
     ///
     /// match listener.accept() {
     ///     Ok((socket, addr)) => println!("Got a client: {:?}", addr),
@@ -795,7 +798,8 @@ impl UnixListener {
     /// ```no_run
     /// use std::os::unix::net::UnixListener;
     ///
-    /// let listener = UnixListener::bind("/path/to/the/socket").unwrap();
+    /// let listener = UnixListener::bind("/path/to/the/socket")
+    ///                             .expect("UnixListener::bind failed");
     ///
     /// let listener_copy = listener.try_clone().expect("try_clone failed");
     /// ```
@@ -811,7 +815,8 @@ impl UnixListener {
     /// ```no_run
     /// use std::os::unix::net::UnixListener;
     ///
-    /// let listener = UnixListener::bind("/path/to/the/socket").unwrap();
+    /// let listener = UnixListener::bind("/path/to/the/socket")
+    ///                             .expect("UnixListener::bind failed");
     ///
     /// let addr = listener.local_addr().expect("Couldn't get local address");
     /// ```
@@ -827,7 +832,8 @@ impl UnixListener {
     /// ```no_run
     /// use std::os::unix::net::UnixListener;
     ///
-    /// let listener = UnixListener::bind("/path/to/the/socket").unwrap();
+    /// let listener = UnixListener::bind("/path/to/the/socket")
+    ///                             .expect("UnixListener::bind failed");
     ///
     /// listener.set_nonblocking(true).expect("Couldn't set non blocking");
     /// ```
@@ -843,7 +849,8 @@ impl UnixListener {
     /// ```no_run
     /// use std::os::unix::net::UnixListener;
     ///
-    /// let listener = UnixListener::bind("/tmp/sock").unwrap();
+    /// let listener = UnixListener::bind("/tmp/sock")
+    ///                             .expect("UnixListener::bind failed");
     ///
     /// if let Ok(Some(err)) = listener.take_error() {
     ///     println!("Got error: {:?}", err);
@@ -875,7 +882,8 @@ impl UnixListener {
     ///     // ...
     /// }
     ///
-    /// let listener = UnixListener::bind("/path/to/the/socket").unwrap();
+    /// let listener = UnixListener::bind("/path/to/the/socket")
+    ///                             .expect("UnixListener::bind failed");
     ///
     /// for stream in listener.incoming() {
     ///     match stream {
@@ -942,7 +950,7 @@ impl<'a> IntoIterator for &'a UnixListener {
 ///     // ...
 /// }
 ///
-/// let listener = UnixListener::bind("/path/to/the/socket").unwrap();
+/// let listener = UnixListener::bind("/path/to/the/socket").expect("UnixListener::bind failed");
 ///
 /// for stream in listener.incoming() {
 ///     match stream {
@@ -981,10 +989,10 @@ impl<'a> Iterator for Incoming<'a> {
 /// ```no_run
 /// use std::os::unix::net::UnixDatagram;
 ///
-/// let socket = UnixDatagram::bind("/path/to/my/socket").unwrap();
-/// socket.send_to(b"hello world", "/path/to/other/socket").unwrap();
+/// let socket = UnixDatagram::bind("/path/to/my/socket").expect("UnixDatagram::bind failed");
+/// socket.send_to(b"hello world", "/path/to/other/socket").expect("send_to() call failed");
 /// let mut buf = [0; 100];
-/// let (count, address) = socket.recv_from(&mut buf).unwrap();
+/// let (count, address) = socket.recv_from(&mut buf).expect("recv_from() call failed");
 /// println!("socket {:?} sent {:?}", address, &buf[..count]);
 /// ```
 #[stable(feature = "unix_socket", since = "1.10.0")]
@@ -1094,7 +1102,7 @@ impl UnixDatagram {
     /// ```no_run
     /// use std::os::unix::net::UnixDatagram;
     ///
-    /// let sock = UnixDatagram::unbound().unwrap();
+    /// let sock = UnixDatagram::unbound().expect("UnixDatagram::unbound failed");
     /// match sock.connect("/path/to/the/socket") {
     ///     Ok(sock) => sock,
     ///     Err(e) => {
@@ -1128,7 +1136,7 @@ impl UnixDatagram {
     /// ```no_run
     /// use std::os::unix::net::UnixDatagram;
     ///
-    /// let sock = UnixDatagram::bind("/path/to/the/socket").unwrap();
+    /// let sock = UnixDatagram::bind("/path/to/the/socket").expect("UnixDatagram::bind failed");
     ///
     /// let sock_copy = sock.try_clone().expect("try_clone failed");
     /// ```
@@ -1144,7 +1152,7 @@ impl UnixDatagram {
     /// ```no_run
     /// use std::os::unix::net::UnixDatagram;
     ///
-    /// let sock = UnixDatagram::bind("/path/to/the/socket").unwrap();
+    /// let sock = UnixDatagram::bind("/path/to/the/socket").expect("UnixDatagram::bind failed");
     ///
     /// let addr = sock.local_addr().expect("Couldn't get local address");
     /// ```
@@ -1164,8 +1172,8 @@ impl UnixDatagram {
     /// ```no_run
     /// use std::os::unix::net::UnixDatagram;
     ///
-    /// let sock = UnixDatagram::unbound().unwrap();
-    /// sock.connect("/path/to/the/socket").unwrap();
+    /// let sock = UnixDatagram::unbound().expect("UnixDatagram::unbound failed");
+    /// sock.connect("/path/to/the/socket").expect("connect() call failed");
     ///
     /// let addr = sock.peer_addr().expect("Couldn't get peer address");
     /// ```
@@ -1184,7 +1192,7 @@ impl UnixDatagram {
     /// ```no_run
     /// use std::os::unix::net::UnixDatagram;
     ///
-    /// let sock = UnixDatagram::unbound().unwrap();
+    /// let sock = UnixDatagram::unbound().expect("UnixDatagram::unbound failed");
     /// let mut buf = vec![0; 10];
     /// match sock.recv_from(buf.as_mut_slice()) {
     ///     Ok((size, sender)) => println!("received {} bytes from {:?}", size, sender),
@@ -1224,7 +1232,7 @@ impl UnixDatagram {
     /// ```no_run
     /// use std::os::unix::net::UnixDatagram;
     ///
-    /// let sock = UnixDatagram::bind("/path/to/the/socket").unwrap();
+    /// let sock = UnixDatagram::bind("/path/to/the/socket").expect("UnixDatagram::bind failed");
     /// let mut buf = vec![0; 10];
     /// sock.recv(buf.as_mut_slice()).expect("recv function failed");
     /// ```
@@ -1242,7 +1250,7 @@ impl UnixDatagram {
     /// ```no_run
     /// use std::os::unix::net::UnixDatagram;
     ///
-    /// let sock = UnixDatagram::unbound().unwrap();
+    /// let sock = UnixDatagram::unbound().expect("UnixDatagram::unbound failed");
     /// sock.send_to(b"omelette au fromage", "/some/sock").expect("send_to function failed");
     /// ```
     #[stable(feature = "unix_socket", since = "1.10.0")]
@@ -1275,7 +1283,7 @@ impl UnixDatagram {
     /// ```no_run
     /// use std::os::unix::net::UnixDatagram;
     ///
-    /// let sock = UnixDatagram::unbound().unwrap();
+    /// let sock = UnixDatagram::unbound().expect("UnixDatagram::unbound failed");
     /// sock.connect("/some/sock").expect("Couldn't connect");
     /// sock.send(b"omelette au fromage").expect("send_to function failed");
     /// ```
@@ -1302,7 +1310,7 @@ impl UnixDatagram {
     /// use std::os::unix::net::UnixDatagram;
     /// use std::time::Duration;
     ///
-    /// let sock = UnixDatagram::unbound().unwrap();
+    /// let sock = UnixDatagram::unbound().expect("UnixDatagram::unbound failed");
     /// sock.set_read_timeout(Some(Duration::new(1, 0))).expect("set_read_timeout function failed");
     /// ```
     ///
@@ -1314,7 +1322,7 @@ impl UnixDatagram {
     /// use std::os::unix::net::UnixDatagram;
     /// use std::time::Duration;
     ///
-    /// let socket = UnixDatagram::unbound().unwrap();
+    /// let socket = UnixDatagram::unbound().expect("UnixDatagram::unbound failed");
     /// let result = socket.set_read_timeout(Some(Duration::new(0, 0)));
     /// let err = result.unwrap_err();
     /// assert_eq!(err.kind(), io::ErrorKind::InvalidInput)
@@ -1341,7 +1349,7 @@ impl UnixDatagram {
     /// use std::os::unix::net::UnixDatagram;
     /// use std::time::Duration;
     ///
-    /// let sock = UnixDatagram::unbound().unwrap();
+    /// let sock = UnixDatagram::unbound().expect("UnixDatagram::unbound failed");
     /// sock.set_write_timeout(Some(Duration::new(1, 0)))
     ///     .expect("set_write_timeout function failed");
     /// ```
@@ -1354,7 +1362,7 @@ impl UnixDatagram {
     /// use std::os::unix::net::UnixDatagram;
     /// use std::time::Duration;
     ///
-    /// let socket = UnixDatagram::unbound().unwrap();
+    /// let socket = UnixDatagram::unbound().expect("UnixDatagram::unbound failed");
     /// let result = socket.set_write_timeout(Some(Duration::new(0, 0)));
     /// let err = result.unwrap_err();
     /// assert_eq!(err.kind(), io::ErrorKind::InvalidInput)
@@ -1372,9 +1380,10 @@ impl UnixDatagram {
     /// use std::os::unix::net::UnixDatagram;
     /// use std::time::Duration;
     ///
-    /// let sock = UnixDatagram::unbound().unwrap();
+    /// let sock = UnixDatagram::unbound().expect("UnixDatagram::unbound failed");
     /// sock.set_read_timeout(Some(Duration::new(1, 0))).expect("set_read_timeout function failed");
-    /// assert_eq!(sock.read_timeout().unwrap(), Some(Duration::new(1, 0)));
+    /// assert_eq!(sock.read_timeout().expect("read_timeout() call failed"),
+    ///            Some(Duration::new(1, 0)));
     /// ```
     #[stable(feature = "unix_socket", since = "1.10.0")]
     pub fn read_timeout(&self) -> io::Result<Option<Duration>> {
@@ -1389,10 +1398,11 @@ impl UnixDatagram {
     /// use std::os::unix::net::UnixDatagram;
     /// use std::time::Duration;
     ///
-    /// let sock = UnixDatagram::unbound().unwrap();
+    /// let sock = UnixDatagram::unbound().expect("UnixDatagram::unbound failed");
     /// sock.set_write_timeout(Some(Duration::new(1, 0)))
     ///     .expect("set_write_timeout function failed");
-    /// assert_eq!(sock.write_timeout().unwrap(), Some(Duration::new(1, 0)));
+    /// assert_eq!(sock.write_timeout().expect("write_timeout() call failed"),
+    ///            Some(Duration::new(1, 0)));
     /// ```
     #[stable(feature = "unix_socket", since = "1.10.0")]
     pub fn write_timeout(&self) -> io::Result<Option<Duration>> {
@@ -1406,7 +1416,7 @@ impl UnixDatagram {
     /// ```
     /// use std::os::unix::net::UnixDatagram;
     ///
-    /// let sock = UnixDatagram::unbound().unwrap();
+    /// let sock = UnixDatagram::unbound().expect("UnixDatagram::unbound failed");
     /// sock.set_nonblocking(true).expect("set_nonblocking function failed");
     /// ```
     #[stable(feature = "unix_socket", since = "1.10.0")]
@@ -1421,7 +1431,7 @@ impl UnixDatagram {
     /// ```no_run
     /// use std::os::unix::net::UnixDatagram;
     ///
-    /// let sock = UnixDatagram::unbound().unwrap();
+    /// let sock = UnixDatagram::unbound().expect("UnixDatagram::unbound failed");
     /// if let Ok(Some(err)) = sock.take_error() {
     ///     println!("Got error: {:?}", err);
     /// }
@@ -1443,7 +1453,7 @@ impl UnixDatagram {
     /// use std::os::unix::net::UnixDatagram;
     /// use std::net::Shutdown;
     ///
-    /// let sock = UnixDatagram::unbound().unwrap();
+    /// let sock = UnixDatagram::unbound().expect("UnixDatagram::unbound failed");
     /// sock.shutdown(Shutdown::Both).expect("shutdown function failed");
     /// ```
     #[stable(feature = "unix_socket", since = "1.10.0")]

--- a/src/libstd/sys_common/poison.rs
+++ b/src/libstd/sys_common/poison.rs
@@ -76,7 +76,7 @@ pub struct Guard {
 /// // poison the mutex
 /// let c_mutex = mutex.clone();
 /// let _ = thread::spawn(move || {
-///     let mut data = c_mutex.lock().unwrap();
+///     let mut data = c_mutex.lock().expect("lock() call failed");
 ///     *data = 2;
 ///     panic!();
 /// }).join();
@@ -192,7 +192,7 @@ impl<T> PoisonError<T> {
     /// // poison the mutex
     /// let c_mutex = mutex.clone();
     /// let _ = thread::spawn(move || {
-    ///     let mut data = c_mutex.lock().unwrap();
+    ///     let mut data = c_mutex.lock().expect("lock() call failed");
     ///     data.insert(10);
     ///     panic!();
     /// }).join();

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -229,7 +229,7 @@ pub use self::local::{LocalKey, AccessError};
 /// [`io::Result`] to the thread handle with the given configuration.
 ///
 /// The [`thread::spawn`] free function uses a `Builder` with default
-/// configuration and [`unwrap`]s its return value.
+/// configuration and get its return value through [`expect`].
 ///
 /// You may want to use [`spawn`] instead of [`thread::spawn`], when you want
 /// to recover from a failure to launch a thread, indeed the free function will
@@ -244,9 +244,9 @@ pub use self::local::{LocalKey, AccessError};
 ///
 /// let handler = builder.spawn(|| {
 ///     // thread code
-/// }).unwrap();
+/// }).expect("spawn() call failed");
 ///
-/// handler.join().unwrap();
+/// handler.join().expect("join() call failed");
 /// ```
 ///
 /// [`thread::spawn`]: ../../std/thread/fn.spawn.html
@@ -254,7 +254,7 @@ pub use self::local::{LocalKey, AccessError};
 /// [`name`]: ../../std/thread/struct.Builder.html#method.name
 /// [`spawn`]: ../../std/thread/struct.Builder.html#method.spawn
 /// [`io::Result`]: ../../std/io/type.Result.html
-/// [`unwrap`]: ../../std/result/enum.Result.html#method.unwrap
+/// [`expect`]: ../../std/result/enum.Result.html#method.expect
 /// [naming-threads]: ./index.html#naming-threads
 /// [stack-size]: ./index.html#stack-size
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -281,9 +281,9 @@ impl Builder {
     ///
     /// let handler = builder.spawn(|| {
     ///     // thread code
-    /// }).unwrap();
+    /// }).expect("spawn() call failed");
     ///
-    /// handler.join().unwrap();
+    /// handler.join().expect("join() call failed");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn new() -> Builder {
@@ -311,9 +311,9 @@ impl Builder {
     ///
     /// let handler = builder.spawn(|| {
     ///     assert_eq!(thread::current().name(), Some("foo"))
-    /// }).unwrap();
+    /// }).expect("spawn() call failed");
     ///
-    /// handler.join().unwrap();
+    /// handler.join().expect("join() call failed");
     /// ```
     ///
     /// [naming-threads]: ./index.html#naming-threads
@@ -379,9 +379,9 @@ impl Builder {
     ///
     /// let handler = builder.spawn(|| {
     ///     // thread code
-    /// }).unwrap();
+    /// }).expect("spawn() call failed");
     ///
-    /// handler.join().unwrap();
+    /// handler.join().expect("join() call failed");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn spawn<F, T>(self, f: F) -> io::Result<JoinHandle<T>> where
@@ -478,7 +478,7 @@ impl Builder {
 ///     // thread code
 /// });
 ///
-/// handler.join().unwrap();
+/// handler.join().expect("join() call failed");
 /// ```
 ///
 /// As mentioned in the module documentation, threads are usually made to
@@ -519,7 +519,7 @@ impl Builder {
 ///     42
 /// });
 ///
-/// let result = computation.join().unwrap();
+/// let result = computation.join().expect("join() call failed");
 /// println!("{}", result);
 /// ```
 ///
@@ -554,9 +554,9 @@ pub fn spawn<F, T>(f: F) -> JoinHandle<T> where
 ///         let handle = thread::current();
 ///         assert_eq!(handle.name(), Some("named thread"));
 ///     })
-///     .unwrap();
+///     .expect("spawn() call failed");
 ///
-/// handler.join().unwrap();
+/// handler.join().expect("join() call failed");
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn current() -> Thread {
@@ -762,7 +762,7 @@ const NOTIFIED: usize = 2;
 ///         thread::park();
 ///         println!("Thread unparked");
 ///     })
-///     .unwrap();
+///     .expect("spawn() call failed");
 ///
 /// // Let some time pass for the thread to be spawned.
 /// thread::sleep(Duration::from_millis(10));
@@ -772,7 +772,7 @@ const NOTIFIED: usize = 2;
 /// println!("Unpark the thread");
 /// parked_thread.thread().unpark();
 ///
-/// parked_thread.join().unwrap();
+/// parked_thread.join().expect("join() call failed");
 /// ```
 ///
 /// [`Thread`]: ../../std/thread/struct.Thread.html
@@ -927,7 +927,7 @@ pub fn park_timeout(dur: Duration) {
 ///     thread::current().id()
 /// });
 ///
-/// let other_thread_id = other_thread.join().unwrap();
+/// let other_thread_id = other_thread.join().expect("join() call failed");
 /// assert!(thread::current().id() != other_thread_id);
 /// ```
 ///
@@ -1044,7 +1044,7 @@ impl Thread {
     ///         thread::park();
     ///         println!("Thread unparked");
     ///     })
-    ///     .unwrap();
+    ///     .expect("spawn() call failed");
     ///
     /// // Let some time pass for the thread to be spawned.
     /// thread::sleep(Duration::from_millis(10));
@@ -1052,7 +1052,7 @@ impl Thread {
     /// println!("Unpark the thread");
     /// parked_thread.thread().unpark();
     ///
-    /// parked_thread.join().unwrap();
+    /// parked_thread.join().expect("join() call failed");
     /// ```
     ///
     /// [park]: fn.park.html
@@ -1088,7 +1088,7 @@ impl Thread {
     ///     thread::current().id()
     /// });
     ///
-    /// let other_thread_id = other_thread.join().unwrap();
+    /// let other_thread_id = other_thread.join().expect("join() call failed");
     /// assert!(thread::current().id() != other_thread_id);
     /// ```
     #[stable(feature = "thread_id", since = "1.19.0")]
@@ -1112,9 +1112,9 @@ impl Thread {
     ///
     /// let handler = builder.spawn(|| {
     ///     assert!(thread::current().name().is_none());
-    /// }).unwrap();
+    /// }).expect("spawn() call failed");
     ///
-    /// handler.join().unwrap();
+    /// handler.join().expect("join() call failed");
     /// ```
     ///
     /// Thread with a specified name:
@@ -1127,9 +1127,9 @@ impl Thread {
     ///
     /// let handler = builder.spawn(|| {
     ///     assert_eq!(thread::current().name(), Some("foo"))
-    /// }).unwrap();
+    /// }).expect("spawn() call failed");
     ///
-    /// handler.join().unwrap();
+    /// handler.join().expect("join() call failed");
     /// ```
     ///
     /// [naming-threads]: ./index.html#naming-threads
@@ -1167,7 +1167,7 @@ impl fmt::Debug for Thread {
 /// use std::fs;
 ///
 /// fn copy_in_thread() -> thread::Result<()> {
-///     thread::spawn(move || { fs::copy("foo.txt", "bar.txt").unwrap(); }).join()
+///     thread::spawn(move || { fs::copy("foo.txt", "bar.txt").expect("fs::copy failed"); }).join()
 /// }
 ///
 /// fn main() {
@@ -1248,7 +1248,7 @@ impl<T> JoinInner<T> {
 ///
 /// let join_handle: thread::JoinHandle<_> = builder.spawn(|| {
 ///     // some work here
-/// }).unwrap();
+/// }).expect("spawn() call failed");
 /// ```
 ///
 /// Child being detached and outliving its parent:
@@ -1298,7 +1298,7 @@ impl<T> JoinHandle<T> {
     ///
     /// let join_handle: thread::JoinHandle<_> = builder.spawn(|| {
     ///     // some work here
-    /// }).unwrap();
+    /// }).expect("spawn() call failed");
     ///
     /// let thread = join_handle.thread();
     /// println!("thread id: {:?}", thread.id());
@@ -1330,7 +1330,7 @@ impl<T> JoinHandle<T> {
     ///
     /// let join_handle: thread::JoinHandle<_> = builder.spawn(|| {
     ///     // some work here
-    /// }).unwrap();
+    /// }).expect("spawn() call failed");
     /// join_handle.join().expect("Couldn't join on the associated thread");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -351,7 +351,7 @@ impl SystemTime {
     /// let sys_time = SystemTime::now();
     /// let one_sec = Duration::from_secs(1);
     /// sleep(one_sec);
-    /// assert!(sys_time.elapsed().unwrap() >= one_sec);
+    /// assert!(sys_time.elapsed().expect("elapsed() call failed") >= one_sec);
     /// ```
     #[stable(feature = "time2", since = "1.8.0")]
     pub fn elapsed(&self) -> Result<Duration, SystemTimeError> {


### PR DESCRIPTION
Because no one should use `unwrap`!

r? @steveklabnik 