### PR TITLE
Speed up compilation of huge constant arrays

### DIFF
--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -124,7 +124,7 @@ impl<'tcx> Scalar {
                         bits: layout.offset(bits as u64, i.bytes())? as u128,
                         defined: pointer_size,
                     })
-            }
+                }
             }
             Scalar::Ptr(ptr) => ptr.offset(i, layout).map(Scalar::Ptr),
         }

--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -208,6 +208,7 @@ pub trait HasDataLayout: Copy {
 }
 
 impl<'a> HasDataLayout for &'a TargetDataLayout {
+    #[inline]
     fn data_layout(&self) -> &TargetDataLayout {
         self
     }
@@ -240,10 +241,12 @@ impl Size {
         }
     }
 
+    #[inline]
     pub fn bytes(self) -> u64 {
         self.raw
     }
 
+    #[inline]
     pub fn bits(self) -> u64 {
         self.bytes().checked_mul(8).unwrap_or_else(|| {
             panic!("Size::bits: {} bytes in bits doesn't fit in u64", self.bytes())
@@ -289,6 +292,7 @@ impl Size {
 
 impl Add for Size {
     type Output = Size;
+    #[inline]
     fn add(self, other: Size) -> Size {
         Size::from_bytes(self.bytes().checked_add(other.bytes()).unwrap_or_else(|| {
             panic!("Size::add: {} + {} doesn't fit in u64", self.bytes(), other.bytes())
@@ -298,6 +302,7 @@ impl Add for Size {
 
 impl Sub for Size {
     type Output = Size;
+    #[inline]
     fn sub(self, other: Size) -> Size {
         Size::from_bytes(self.bytes().checked_sub(other.bytes()).unwrap_or_else(|| {
             panic!("Size::sub: {} - {} would result in negative size", self.bytes(), other.bytes())
@@ -314,6 +319,7 @@ impl Mul<Size> for u64 {
 
 impl Mul<u64> for Size {
     type Output = Size;
+    #[inline]
     fn mul(self, count: u64) -> Size {
         match self.bytes().checked_mul(count) {
             Some(bytes) => Size::from_bytes(bytes),
@@ -374,18 +380,22 @@ impl Align {
         })
     }
 
+    #[inline]
     pub fn abi(self) -> u64 {
         1 << self.abi_pow2
     }
 
+    #[inline]
     pub fn pref(self) -> u64 {
         1 << self.pref_pow2
     }
 
+    #[inline]
     pub fn abi_bits(self) -> u64 {
         self.abi() * 8
     }
 
+    #[inline]
     pub fn pref_bits(self) -> u64 {
         self.pref() * 8
     }


### PR DESCRIPTION
@oli-obk mentioned a [toy program](https://github.com/rust-lang/rust/blob/c2f4744d2db4e162df824d0bd0b093ba4b351545/src/test/run-pass/mir_heavy_promoted.rs) recently on IRC, which contains this slow-to-compile constant:

> const TEST_DATA: [u8; 32 * 1024 * 1024] = [42; 32 * 1024 * 1024];

The attached commits roughly double compilation speed of this. The first commit does some inlining, which should be uncontroversial. The second commit introduces `write_values_to_ptr`, which more or less duplicates `write_value_to_ptr`, while moving a chunk of the code outside the hot loop. There is more room for improvement here by pushing the loop down some more, but I'm not sure how realistic this program is and thus whether it's worth the effort.

Also, the code duplication is unfortunate. One possibility would be to replace `write_value_to_ptr()` calls with `write_values_to_ptr(1)`, and remove `write_value_to_ptr()` altogether.

Thoughts?  CC @rust-lang/wg-compiler-performance 

(This PR probably shouldn't land in it's current form, so I'll mark it with r? @nnethercote so nobody else is pinged for review.)