### PR TITLE
Support future deprecation for rustc_deprecated

### DIFF
--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -614,10 +614,12 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         debug!("stability: \
                 inspecting def_id={:?} span={:?} of stability={:?}", def_id, span, stability);
 
-        if let Some(&Stability{rustc_depr: Some(attr::RustcDeprecation { reason, .. }), ..})
+        if let Some(&Stability{rustc_depr: Some(attr::RustcDeprecation { reason, since }), ..})
                 = stability {
             if let Some(id) = id {
-                lint_deprecated(def_id, id, Some(reason));
+                if deprecation_in_effect(&since.as_str()) {
+                    lint_deprecated(def_id, id, Some(reason));
+                }
             }
         }
 

--- a/src/test/compile-fail/auxiliary/lint_stability.rs
+++ b/src/test/compile-fail/auxiliary/lint_stability.rs
@@ -7,6 +7,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
 #![crate_name="lint_stability"]
 #![crate_type = "lib"]
 #![feature(staged_api)]
@@ -19,6 +20,10 @@ pub fn deprecated() {}
 #[stable(feature = "test_feature", since = "1.0.0")]
 #[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub fn deprecated_text() {}
+
+#[stable(feature = "test_feature", since = "1.0.0")]
+#[rustc_deprecated(since = "99.99.99", reason = "text")]
+pub fn deprecated_future() {}
 
 #[unstable(feature = "test_feature", issue = "0")]
 #[rustc_deprecated(since = "1.0.0", reason = "text")]

--- a/src/test/compile-fail/lint-stability.rs
+++ b/src/test/compile-fail/lint-stability.rs
@@ -50,6 +50,8 @@ mod cross_crate {
         <Foo>::trait_deprecated_text(&foo);
         <Foo as Trait>::trait_deprecated_text(&foo);
 
+        deprecated_future(); // Fine; no error.
+
         deprecated_unstable();
         //~^ ERROR use of unstable library feature
         Trait::trait_deprecated_unstable(&foo);
@@ -218,6 +220,10 @@ mod this_crate {
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub fn deprecated_text() {}
 
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_deprecated(since = "99.99.99", reason = "text")]
+    pub fn deprecated_future() {}
+
     #[unstable(feature = "test_feature", issue = "0")]
     pub fn unstable() {}
     #[unstable(feature = "test_feature", reason = "text", issue = "0")]
@@ -337,6 +343,8 @@ mod this_crate {
         Trait::trait_deprecated_text(&foo);
         <Foo>::trait_deprecated_text(&foo);
         <Foo as Trait>::trait_deprecated_text(&foo);
+
+        deprecated_future();
 
         unstable();
         foo.method_unstable();


### PR DESCRIPTION
Follow-up to #49179 to allow `since` parameters to be set to future versions of Rust and correspondingly to not be treated as deprecated until that version. This is required for #30459 to be completed (though we'll need to wait until this hits beta).