### PR TITLE
do not ICE when existing type info is incomplete

### DIFF
--- a/src/librustc/infer/anon_types/mod.rs
+++ b/src/librustc/infer/anon_types/mod.rs
@@ -434,8 +434,8 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         instantiated_ty: Ty<'gcx>,
     ) -> Ty<'gcx> {
         debug!(
-            "infer_anon_definition_from_instantiation(instantiated_ty={:?})",
-            instantiated_ty
+            "infer_anon_definition_from_instantiation(def_id={:?}, instantiated_ty={:?})",
+            def_id, instantiated_ty
         );
 
         let gcx = self.tcx.global_tcx();

--- a/src/test/ui/error-codes/E0657.rs
+++ b/src/test/ui/error-codes/E0657.rs
@@ -19,7 +19,7 @@ fn free_fn_capture_hrtb_in_impl_trait()
     -> Box<for<'a> Id<impl Lt<'a>>>
         //~^ ERROR `impl Trait` can only capture lifetimes bound at the fn or impl level [E0657]
 {
-    ()
+    () //~ ERROR mismatched types
 }
 
 struct Foo;
@@ -28,7 +28,7 @@ impl Foo {
         -> Box<for<'a> Id<impl Lt<'a>>>
             //~^ ERROR `impl Trait` can only capture lifetimes bound at the fn or impl level
     {
-        ()
+        () //~ ERROR mismatched types
     }
 }
 

--- a/src/test/ui/error-codes/E0657.stderr
+++ b/src/test/ui/error-codes/E0657.stderr
@@ -10,6 +10,25 @@ error[E0657]: `impl Trait` can only capture lifetimes bound at the fn or impl le
 LL |         -> Box<for<'a> Id<impl Lt<'a>>>
    |                                   ^^
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/E0657.rs:22:5
+   |
+LL |     () //~ ERROR mismatched types
+   |     ^^ expected struct `std::boxed::Box`, found ()
+   |
+   = note: expected type `std::boxed::Box<Id<_> + 'static>`
+              found type `()`
 
-For more information about this error, try `rustc --explain E0657`.
+error[E0308]: mismatched types
+  --> $DIR/E0657.rs:31:9
+   |
+LL |         () //~ ERROR mismatched types
+   |         ^^ expected struct `std::boxed::Box`, found ()
+   |
+   = note: expected type `std::boxed::Box<Id<_> + 'static>`
+              found type `()`
+
+error: aborting due to 4 previous errors
+
+Some errors occurred: E0308, E0657.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/impl_trait_projections.rs
+++ b/src/test/ui/impl_trait_projections.rs
@@ -34,8 +34,9 @@ fn projection_with_named_trait_is_disallowed(x: impl Iterator)
 fn projection_with_named_trait_inside_path_is_disallowed()
     -> <::std::ops::Range<impl Debug> as Iterator>::Item
 //~^ ERROR `impl Trait` is not allowed in path parameters
-{
-    (1i32..100).next().unwrap()
+//~| ERROR trait bound `impl std::fmt::Debug: std::iter::Step` is not satisfied
+{ //~ ERROR trait bound `impl std::fmt::Debug: std::iter::Step` is not satisfied
+    (1i32..100).next().unwrap() //~ ERROR mismatched types
 }
 
 fn projection_from_impl_trait_inside_dyn_trait_is_disallowed()

--- a/src/test/ui/impl_trait_projections.stderr
+++ b/src/test/ui/impl_trait_projections.stderr
@@ -17,7 +17,7 @@ LL |     -> <::std::ops::Range<impl Debug> as Iterator>::Item
    |                           ^^^^^^^^^^
 
 error[E0667]: `impl Trait` is not allowed in path parameters
-  --> $DIR/impl_trait_projections.rs:42:29
+  --> $DIR/impl_trait_projections.rs:43:29
    |
 LL |     -> <dyn Iterator<Item = impl Debug> as Iterator>::Item
    |                             ^^^^^^^^^^
@@ -30,7 +30,34 @@ LL | fn projection_is_disallowed(x: impl Iterator) -> <impl Iterator>::Item {
    |
    = note: specify the type using the syntax `<impl std::iter::Iterator as Trait>::Item`
 
-error: aborting due to 5 previous errors
+error[E0277]: the trait bound `impl std::fmt::Debug: std::iter::Step` is not satisfied
+  --> $DIR/impl_trait_projections.rs:38:1
+   |
+LL | / { //~ ERROR trait bound `impl std::fmt::Debug: std::iter::Step` is not satisfied
+LL | |     (1i32..100).next().unwrap() //~ ERROR mismatched types
+LL | | }
+   | |_^ the trait `std::iter::Step` is not implemented for `impl std::fmt::Debug`
+   |
+   = note: required because of the requirements on the impl of `std::iter::Iterator` for `std::ops::Range<impl std::fmt::Debug>`
 
-Some errors occurred: E0223, E0667.
+error[E0308]: mismatched types
+  --> $DIR/impl_trait_projections.rs:39:5
+   |
+LL |     (1i32..100).next().unwrap() //~ ERROR mismatched types
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected anonymized type, found i32
+   |
+   = note: expected type `impl std::fmt::Debug`
+              found type `i32`
+
+error[E0277]: the trait bound `impl std::fmt::Debug: std::iter::Step` is not satisfied
+  --> $DIR/impl_trait_projections.rs:35:8
+   |
+LL |     -> <::std::ops::Range<impl Debug> as Iterator>::Item
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::iter::Step` is not implemented for `impl std::fmt::Debug`
+   |
+   = note: required because of the requirements on the impl of `std::iter::Iterator` for `std::ops::Range<impl std::fmt::Debug>`
+
+error: aborting due to 8 previous errors
+
+Some errors occurred: E0223, E0277, E0308, E0667.
 For more information about an error, try `rustc --explain E0223`.


### PR DESCRIPTION
Apparently master is kinda ICE-y right now, but only for some people (sadly that set includes me).

I'm not crazy about this PR, because it seems to regress diagnostics a lot, but it *does* fix the problems. I think probably fixing the diagnostics should be done by doing a better job of suppressing errors?

Mitigates  #51683 

r? @oli-obk 