### PR TITLE
Accept `TyError` in patterns to avoid ICE on bad input

### DIFF
--- a/src/test/ui/issue-50585.rs
+++ b/src/test/ui/issue-50585.rs
@@ -1,0 +1,14 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    |y: Vec<[(); for x in 0..2 {}]>| {};
+    //~^ ERROR mismatched types
+}

--- a/src/test/ui/issue-50585.stderr
+++ b/src/test/ui/issue-50585.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-50585.rs:12:18
+   |
+LL | fn main() {
+   |           - expected `()` because of default return type
+LL |     |y: Vec<[(); for x in 0..2 {}]>| {};
+   |                  ^^^^^^^^^^^^^^^^ expected usize, found ()
+   |
+   = note: expected type `usize`
+              found type `()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fix #50585.