### PR TITLE
Add label to lint for lifetimes used once

### DIFF
--- a/src/test/ui/single-use-lifetime/fn-types.stderr
+++ b/src/test/ui/single-use-lifetime/fn-types.stderr
@@ -2,7 +2,9 @@ error: lifetime parameter `'a` only used once
   --> $DIR/fn-types.rs:19:10
    |
 LL |   a: for<'a> fn(&'a u32), //~ ERROR `'a` only used once
-   |          ^^
+   |          ^^      -- ...is used only here
+   |          |
+   |          this lifetime...
    |
 note: lint level defined here
   --> $DIR/fn-types.rs:11:9

--- a/src/test/ui/single-use-lifetime/one-use-in-fn-argument-in-band.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-fn-argument-in-band.stderr
@@ -3,6 +3,9 @@ error: lifetime parameter `'b` only used once
    |
 LL | fn a(x: &'a u32, y: &'b u32) {
    |                      ^^
+   |                      |
+   |                      this lifetime...
+   |                      ...is used only here
    |
 note: lint level defined here
   --> $DIR/one-use-in-fn-argument-in-band.rs:12:9
@@ -15,6 +18,9 @@ error: lifetime parameter `'a` only used once
    |
 LL | fn a(x: &'a u32, y: &'b u32) {
    |          ^^
+   |          |
+   |          this lifetime...
+   |          ...is used only here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/single-use-lifetime/one-use-in-fn-argument.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-fn-argument.stderr
@@ -2,7 +2,9 @@ error: lifetime parameter `'a` only used once
   --> $DIR/one-use-in-fn-argument.rs:18:6
    |
 LL | fn a<'a>(x: &'a u32) { //~ ERROR `'a` only used once
-   |      ^^
+   |      ^^      -- ...is used only here
+   |      |
+   |      this lifetime...
    |
 note: lint level defined here
   --> $DIR/one-use-in-fn-argument.rs:11:9

--- a/src/test/ui/single-use-lifetime/one-use-in-inherent-impl-header.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-inherent-impl-header.stderr
@@ -2,7 +2,9 @@ error: lifetime parameter `'f` only used once
   --> $DIR/one-use-in-inherent-impl-header.rs:24:6
    |
 LL | impl<'f> Foo<'f> { //~ ERROR `'f` only used once
-   |      ^^
+   |      ^^      -- ...is used only here
+   |      |
+   |      this lifetime...
    |
 note: lint level defined here
   --> $DIR/one-use-in-inherent-impl-header.rs:11:9

--- a/src/test/ui/single-use-lifetime/one-use-in-inherent-method-argument.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-inherent-method-argument.stderr
@@ -2,7 +2,9 @@ error: lifetime parameter `'a` only used once
   --> $DIR/one-use-in-inherent-method-argument.rs:22:19
    |
 LL |     fn inherent_a<'a>(&self, data: &'a u32) { //~ ERROR `'a` only used once
-   |                   ^^
+   |                   ^^                -- ...is used only here
+   |                   |
+   |                   this lifetime...
    |
 note: lint level defined here
   --> $DIR/one-use-in-inherent-method-argument.rs:11:9
@@ -14,7 +16,9 @@ error: lifetime parameter `'f` only used once
   --> $DIR/one-use-in-inherent-method-argument.rs:21:6
    |
 LL | impl<'f> Foo<'f> { //~ ERROR `'f` only used once
-   |      ^^
+   |      ^^      -- ...is used only here
+   |      |
+   |      this lifetime...
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/single-use-lifetime/one-use-in-inherent-method-return.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-inherent-method-return.stderr
@@ -2,7 +2,9 @@ error: lifetime parameter `'f` only used once
   --> $DIR/one-use-in-inherent-method-return.rs:22:6
    |
 LL | impl<'f> Foo<'f> { //~ ERROR `'f` only used once
-   |      ^^
+   |      ^^      -- ...is used only here
+   |      |
+   |      this lifetime...
    |
 note: lint level defined here
   --> $DIR/one-use-in-inherent-method-return.rs:11:9

--- a/src/test/ui/single-use-lifetime/one-use-in-trait-method-argument.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-trait-method-argument.stderr
@@ -2,7 +2,9 @@ error: lifetime parameter `'g` only used once
   --> $DIR/one-use-in-trait-method-argument.rs:25:13
    |
 LL |     fn next<'g>(&'g mut self) -> Option<Self::Item> { //~ ERROR `'g` only used once
-   |             ^^
+   |             ^^   -- ...is used only here
+   |             |
+   |             this lifetime...
    |
 note: lint level defined here
   --> $DIR/one-use-in-trait-method-argument.rs:14:9

--- a/src/test/ui/single-use-lifetime/two-uses-in-inherent-method-argument-and-return.stderr
+++ b/src/test/ui/single-use-lifetime/two-uses-in-inherent-method-argument-and-return.stderr
@@ -2,7 +2,9 @@ error: lifetime parameter `'f` only used once
   --> $DIR/two-uses-in-inherent-method-argument-and-return.rs:22:6
    |
 LL | impl<'f> Foo<'f> { //~ ERROR `'f` only used once
-   |      ^^
+   |      ^^      -- ...is used only here
+   |      |
+   |      this lifetime...
    |
 note: lint level defined here
   --> $DIR/two-uses-in-inherent-method-argument-and-return.rs:14:9


### PR DESCRIPTION
```
error: lifetime parameter `'a` only used once
  --> $DIR/fn-types.rs:19:10
   |
LL |   a: for<'a> fn(&'a u32), //~ ERROR `'a` only used once
   |          ^^      -- ...is used only here
   |          |
   |          this lifetime...
```