### PR TITLE
Recognize the extra "LLVM tools versions" argument to build-manifest.

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -212,6 +212,7 @@ fn main() {
     let cargo_release = args.next().unwrap();
     let rls_release = args.next().unwrap();
     let rustfmt_release = args.next().unwrap();
+    let _llvm_tools_vers = args.next().unwrap(); // FIXME do something with it?
     let s3_address = args.next().unwrap();
     let mut passphrase = String::new();
     t!(io::stdin().read_to_string(&mut passphrase));


### PR DESCRIPTION
Fix #51699.