### PR TITLE
Accept `TyError` in `analyze_closure` to avoid ICE

### DIFF
--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -111,6 +111,10 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         let (closure_def_id, substs) = match self.node_ty(closure_hir_id).sty {
             ty::TyClosure(def_id, substs) => (def_id, UpvarSubsts::Closure(substs)),
             ty::TyGenerator(def_id, substs, _) => (def_id, UpvarSubsts::Generator(substs)),
+            ty::TyError => {
+                // #51714: skip analysis when we have already encountered type errors
+                return;
+            }
             ref t => {
                 span_bug!(
                     span,

--- a/src/test/ui/issue-51714.rs
+++ b/src/test/ui/issue-51714.rs
@@ -1,0 +1,19 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    |_:  [_; return || {}] | {}
+    //~^ ERROR return statement outside of function body
+}
+
+fn foo() {
+    [(); return || {}];
+    //~^ ERROR return statement outside of function body
+}

--- a/src/test/ui/issue-51714.stderr
+++ b/src/test/ui/issue-51714.stderr
@@ -1,0 +1,15 @@
+error[E0572]: return statement outside of function body
+  --> $DIR/issue-51714.rs:12:14
+   |
+LL |     |_:  [_; return || {}] | {}
+   |              ^^^^^^^^^^^^
+
+error[E0572]: return statement outside of function body
+  --> $DIR/issue-51714.rs:17:10
+   |
+LL |     [(); return || {}];
+   |          ^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0572`.


### PR DESCRIPTION
Fix #51714.