### PR TITLE
build: add llvm-tools to manifest

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -44,7 +44,7 @@ pub fn pkgname(builder: &Builder, component: &str) -> String {
     } else if component == "rustfmt" {
         format!("{}-{}", component, builder.rustfmt_package_vers())
     } else if component == "llvm-tools" {
-        format!("{}-{}", component, builder.llvm_tools_vers())
+        format!("{}-{}", component, builder.llvm_tools_package_vers())
     } else {
         assert!(component.starts_with("rust"));
         format!("{}-{}", component, builder.rust_package_vers())
@@ -1303,6 +1303,7 @@ impl Step for Extended {
         let cargo_installer = builder.ensure(Cargo { stage, target });
         let rustfmt_installer = builder.ensure(Rustfmt { stage, target });
         let rls_installer = builder.ensure(Rls { stage, target });
+        let llvm_tools_installer = builder.ensure(LlvmTools { stage, target, compiler: builder.compiler(stage, target) });
         let mingw_installer = builder.ensure(Mingw { host: target });
         let analysis_installer = builder.ensure(Analysis {
             compiler: builder.compiler(stage, self.host),
@@ -1340,6 +1341,7 @@ impl Step for Extended {
         tarballs.push(cargo_installer);
         tarballs.extend(rls_installer.clone());
         tarballs.extend(rustfmt_installer.clone());
+        tarballs.extend(llvm_tools_installer.clone());
         tarballs.push(analysis_installer);
         tarballs.push(std_installer);
         if builder.config.docs {
@@ -1740,7 +1742,7 @@ impl Step for HashSign {
         cmd.arg(builder.package_vers(&builder.release_num("cargo")));
         cmd.arg(builder.package_vers(&builder.release_num("rls")));
         cmd.arg(builder.package_vers(&builder.release_num("rustfmt")));
-        cmd.arg(builder.llvm_tools_vers());
+        cmd.arg(builder.llvm_tools_package_vers());
         cmd.arg(addr);
 
         builder.create_dir(&distdir(builder));
@@ -1806,6 +1808,7 @@ impl Step for LlvmTools {
         builder.create_dir(&overlay);
         builder.install(&src.join("README.txt"), &overlay, 0o644);
         builder.install(&src.join("LICENSE.TXT"), &overlay, 0o644);
+        builder.create(&overlay.join("version"), &builder.llvm_tools_vers());
 
         // Generate the installer tarball
         let mut cmd = rust_installer(builder);

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1303,7 +1303,11 @@ impl Step for Extended {
         let cargo_installer = builder.ensure(Cargo { stage, target });
         let rustfmt_installer = builder.ensure(Rustfmt { stage, target });
         let rls_installer = builder.ensure(Rls { stage, target });
-        let llvm_tools_installer = builder.ensure(LlvmTools { stage, target, compiler: builder.compiler(stage, target) });
+        let llvm_tools_installer = builder.ensure(LlvmTools {
+            stage,
+            target,
+            compiler: builder.compiler(stage, target)
+        });
         let mingw_installer = builder.ensure(Mingw { host: target });
         let analysis_installer = builder.ensure(Analysis {
             compiler: builder.compiler(stage, self.host),

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -973,24 +973,11 @@ impl Build {
         self.package_vers(&self.release_num("rustfmt"))
     }
 
+    fn llvm_tools_package_vers(&self) -> String {
+        self.package_vers(&self.rust_version())
+    }
+
     fn llvm_tools_vers(&self) -> String {
-        // japaric: should we use LLVM version here?
-        // let stdout = build_helper::output(
-        //     Command::new(self.llvm_out(self.config.build).join("build/bin/llvm-size"))
-        //         .arg("--version"),
-        // );
-
-        // for line in stdout.lines() {
-        //     if line.contains("LLVM version") {
-        //         if let Some(vers) = line.split_whitespace().nth(2) {
-        //             return vers.to_string();
-        //         }
-        //     }
-        // }
-
-        // panic!("The output of $LLVM_TOOL has changed; \
-        //         please fix `bootstrap::Build.llvm_tools_vers`");
-
         self.rust_version()
     }
 

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -260,7 +260,8 @@ impl Builder {
         self.cargo_git_commit_hash = self.git_commit_hash("cargo", "x86_64-unknown-linux-gnu");
         self.rls_git_commit_hash = self.git_commit_hash("rls", "x86_64-unknown-linux-gnu");
         self.rustfmt_git_commit_hash = self.git_commit_hash("rustfmt", "x86_64-unknown-linux-gnu");
-        self.llvm_tools_git_commit_hash = self.git_commit_hash("llvm-tools", "x86_64-unknown-linux-gnu");
+        self.llvm_tools_git_commit_hash = self.git_commit_hash("llvm-tools",
+                                                               "x86_64-unknown-linux-gnu");
 
         self.digest_and_sign();
         let manifest = self.build_manifest();

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -184,6 +184,7 @@ struct Builder {
     cargo_release: String,
     rls_release: String,
     rustfmt_release: String,
+    llvm_tools_release: String,
 
     input: PathBuf,
     output: PathBuf,
@@ -196,11 +197,13 @@ struct Builder {
     cargo_version: Option<String>,
     rls_version: Option<String>,
     rustfmt_version: Option<String>,
+    llvm_tools_version: Option<String>,
 
     rust_git_commit_hash: Option<String>,
     cargo_git_commit_hash: Option<String>,
     rls_git_commit_hash: Option<String>,
     rustfmt_git_commit_hash: Option<String>,
+    llvm_tools_git_commit_hash: Option<String>,
 }
 
 fn main() {
@@ -212,7 +215,7 @@ fn main() {
     let cargo_release = args.next().unwrap();
     let rls_release = args.next().unwrap();
     let rustfmt_release = args.next().unwrap();
-    let _llvm_tools_vers = args.next().unwrap(); // FIXME do something with it?
+    let llvm_tools_release = args.next().unwrap();
     let s3_address = args.next().unwrap();
     let mut passphrase = String::new();
     t!(io::stdin().read_to_string(&mut passphrase));
@@ -222,6 +225,7 @@ fn main() {
         cargo_release,
         rls_release,
         rustfmt_release,
+        llvm_tools_release,
 
         input,
         output,
@@ -234,11 +238,13 @@ fn main() {
         cargo_version: None,
         rls_version: None,
         rustfmt_version: None,
+        llvm_tools_version: None,
 
         rust_git_commit_hash: None,
         cargo_git_commit_hash: None,
         rls_git_commit_hash: None,
         rustfmt_git_commit_hash: None,
+        llvm_tools_git_commit_hash: None,
     }.build();
 }
 
@@ -248,11 +254,13 @@ impl Builder {
         self.cargo_version = self.version("cargo", "x86_64-unknown-linux-gnu");
         self.rls_version = self.version("rls", "x86_64-unknown-linux-gnu");
         self.rustfmt_version = self.version("rustfmt", "x86_64-unknown-linux-gnu");
+        self.llvm_tools_version = self.version("llvm-tools", "x86_64-unknown-linux-gnu");
 
         self.rust_git_commit_hash = self.git_commit_hash("rust", "x86_64-unknown-linux-gnu");
         self.cargo_git_commit_hash = self.git_commit_hash("cargo", "x86_64-unknown-linux-gnu");
         self.rls_git_commit_hash = self.git_commit_hash("rls", "x86_64-unknown-linux-gnu");
         self.rustfmt_git_commit_hash = self.git_commit_hash("rustfmt", "x86_64-unknown-linux-gnu");
+        self.llvm_tools_git_commit_hash = self.git_commit_hash("llvm-tools", "x86_64-unknown-linux-gnu");
 
         self.digest_and_sign();
         let manifest = self.build_manifest();
@@ -289,9 +297,11 @@ impl Builder {
         self.package("rls-preview", &mut manifest.pkg, HOSTS);
         self.package("rustfmt-preview", &mut manifest.pkg, HOSTS);
         self.package("rust-analysis", &mut manifest.pkg, TARGETS);
+        self.package("llvm-tools", &mut manifest.pkg, TARGETS);
 
         let rls_present = manifest.pkg.contains_key("rls-preview");
         let rustfmt_present = manifest.pkg.contains_key("rustfmt-preview");
+        let llvm_tools_present = manifest.pkg.contains_key("llvm-tools");
 
         if rls_present {
             manifest.renames.insert("rls".to_owned(), Rename { to: "rls-preview".to_owned() });
@@ -343,6 +353,12 @@ impl Builder {
             if rustfmt_present {
                 extensions.push(Component {
                     pkg: "rustfmt-preview".to_string(),
+                    target: host.to_string(),
+                });
+            }
+            if llvm_tools_present {
+                extensions.push(Component {
+                    pkg: "llvm-tools".to_string(),
                     target: host.to_string(),
                 });
             }
@@ -455,6 +471,8 @@ impl Builder {
             format!("rls-{}-{}.tar.gz", self.rls_release, target)
         } else if component == "rustfmt" || component == "rustfmt-preview" {
             format!("rustfmt-{}-{}.tar.gz", self.rustfmt_release, target)
+        } else if component == "llvm_tools" {
+            format!("llvm-tools-{}-{}.tar.gz", self.llvm_tools_release, target)
         } else {
             format!("{}-{}-{}.tar.gz", component, self.rust_release, target)
         }
@@ -467,6 +485,8 @@ impl Builder {
             &self.rls_version
         } else if component == "rustfmt" || component == "rustfmt-preview" {
             &self.rustfmt_version
+        } else if component == "llvm-tools" {
+            &self.llvm_tools_version
         } else {
             &self.rust_version
         }
@@ -479,6 +499,8 @@ impl Builder {
             &self.rls_git_commit_hash
         } else if component == "rustfmt" || component == "rustfmt-preview" {
             &self.rustfmt_git_commit_hash
+        } else if component == "llvm-tools" {
+            &self.llvm_tools_git_commit_hash
         } else {
             &self.rust_git_commit_hash
         }


### PR DESCRIPTION
This commit expands on a previous commit to build llvm-tools as a rustup component. It causes the llvm-tools component to be built if the extended step is active. It also adds llvm-tools to the build manifest so rustup can find it.

I tested this as far as I could, but had to hack `build-manifest/src/main.rs` a bit as it is not supported on MacOS. The main change I am not sure about is this line:

```rust
self.package("llvm-tools", &mut manifest.pkg, TARGETS);
```

There are numerous calls to `self.package()`, and I'm not sure if `TARGETS`, `HOSTS`, or `["*"]` is appropriate for llvm-tools.

Otherwise I mostly copied the example set by `rustfmt-preview`.