### PR TITLE
Remove unsound `Context::waker` method

### DIFF
--- a/src/libcore/task.rs
+++ b/src/libcore/task.rs
@@ -380,12 +380,6 @@ impl<'a> Context<'a> {
         self.local_waker
     }
 
-    /// Get the `Waker` associated with the current task.
-    #[inline]
-    pub fn waker(&self) -> &'a Waker {
-        unsafe { &*(self.local_waker as *const LocalWaker as *const Waker) }
-    }
-
     /// Get the default executor associated with this task.
     ///
     /// This method is useful primarily if you want to explicitly handle


### PR DESCRIPTION
This method is unsound because `Waker` is `Sync` and the `LocalWaker` that is being cast to a `Waker` is not. It'd be possible to give the shared reference to multiple threads which join the the current thread again before the reference ends. These threads would use the waker reference (to a waker which just pretends to be `Sync`, but is not) in an unsynchronized way.