### PR TITLE
Haiku: several smaller fixes to build and run rust on Haiku

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -177,7 +177,7 @@ mod toolstate;
 #[cfg(windows)]
 mod job;
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "haiku")))]
 mod job {
     use libc;
 
@@ -188,7 +188,7 @@ mod job {
     }
 }
 
-#[cfg(not(any(unix, windows)))]
+#[cfg(any(target_os = "haiku", not(any(unix, windows))))]
 mod job {
     pub unsafe fn setup(_build: &mut ::Build) {
     }

--- a/src/librustc_target/spec/x86_64_unknown_haiku.rs
+++ b/src/librustc_target/spec/x86_64_unknown_haiku.rs
@@ -16,6 +16,8 @@ pub fn target() -> TargetResult {
     base.max_atomic_width = Some(64);
     base.pre_link_args.insert(LinkerFlavor::Gcc, vec!["-m64".to_string()]);
     base.stack_probes = true;
+    // This option is required to build executables on Haiku x86_64
+    base.position_independent_executables = true;
 
     Ok(Target {
         llvm_target: "x86_64-unknown-haiku".to_string(),

--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -126,7 +126,8 @@ fn build_libbacktrace(target: &str) -> Result<(), ()> {
     if !target.contains("apple-ios") &&
        !target.contains("solaris") &&
        !target.contains("redox") &&
-       !target.contains("android") {
+       !target.contains("android") &&
+       !target.contains("haiku") {
         build.define("HAVE_DL_ITERATE_PHDR", "1");
     }
     build.define("_GNU_SOURCE", "1");


### PR DESCRIPTION
This PR combines three small patches that help Rust build and run on the Haiku platform. These patches do not intend to impact other platforms. 