### PR TITLE
Use assert_eq! in copy_from_slice

### DIFF
--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1642,8 +1642,8 @@ impl<T> [T] {
     /// [`split_at_mut`]: #method.split_at_mut
     #[stable(feature = "copy_from_slice", since = "1.9.0")]
     pub fn copy_from_slice(&mut self, src: &[T]) where T: Copy {
-        assert!(self.len() == src.len(),
-                "destination and source slices have different lengths");
+        assert_eq!(self.len(), src.len(),
+                   "destination and source slices have different lengths");
         unsafe {
             ptr::copy_nonoverlapping(
                 src.as_ptr(), self.as_mut_ptr(), self.len());


### PR DESCRIPTION
This will print both lengths when the assertion fails instead of just saying that they're different.

Output of current stable and nightly (modulo the exact line number):
```
thread 'main' panicked at 'destination and source slices have different lengths', libcore/slice/mod.rs:1645:9
```

Output after this PR:
```
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `123`,
 right: `456`: destination and source slices have different lengths', libcore/slice/mod.rs:1645:9
```

Note that I have not run the tests locally.