### PR TITLE
Don't inspect the generated existential type items

### DIFF
--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -419,7 +419,7 @@ fn convert_item<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, item_id: ast::NodeId) {
                 convert_variant_ctor(tcx, struct_def.id());
             }
         },
-        hir::ItemExistential(..) |
+        hir::ItemExistential(..) => {}
         hir::ItemTy(..) | hir::ItemStatic(..) | hir::ItemConst(..) | hir::ItemFn(..) => {
             tcx.generics_of(def_id);
             tcx.type_of(def_id);
@@ -1066,24 +1066,7 @@ fn type_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 ItemExistential(hir::ExistTy { impl_trait_fn: None, .. }) => unimplemented!(),
                 // existential types desugared from impl Trait
                 ItemExistential(hir::ExistTy { impl_trait_fn: Some(owner), .. }) => {
-                    tcx.typeck_tables_of(owner).concrete_existential_types
-                        .get(&def_id)
-                        .cloned()
-                        .unwrap_or_else(|| {
-                            // This can occur if some error in the
-                            // owner fn prevented us from populating
-                            // the `concrete_existential_types` table.
-                            tcx.sess.delay_span_bug(
-                                DUMMY_SP,
-                                &format!(
-                                    "owner {:?} has no existential type for {:?} in its tables",
-                                    owner,
-                                    def_id,
-                                ),
-                            );
-
-                            tcx.types.err
-                        })
+                    tcx.typeck_tables_of(owner).concrete_existential_types[&def_id]
                 },
                 ItemTrait(..) | ItemTraitAlias(..) |
                 ItemMod(..) |

--- a/src/test/ui/error-codes/E0657.rs
+++ b/src/test/ui/error-codes/E0657.rs
@@ -19,7 +19,7 @@ fn free_fn_capture_hrtb_in_impl_trait()
     -> Box<for<'a> Id<impl Lt<'a>>>
         //~^ ERROR `impl Trait` can only capture lifetimes bound at the fn or impl level [E0657]
 {
-    () //~ ERROR mismatched types
+    Box::new(())
 }
 
 struct Foo;
@@ -28,7 +28,7 @@ impl Foo {
         -> Box<for<'a> Id<impl Lt<'a>>>
             //~^ ERROR `impl Trait` can only capture lifetimes bound at the fn or impl level
     {
-        () //~ ERROR mismatched types
+        Box::new(())
     }
 }
 

--- a/src/test/ui/error-codes/E0657.stderr
+++ b/src/test/ui/error-codes/E0657.stderr
@@ -10,25 +10,6 @@ error[E0657]: `impl Trait` can only capture lifetimes bound at the fn or impl le
 LL |         -> Box<for<'a> Id<impl Lt<'a>>>
    |                                   ^^
 
-error[E0308]: mismatched types
-  --> $DIR/E0657.rs:22:5
-   |
-LL |     () //~ ERROR mismatched types
-   |     ^^ expected struct `std::boxed::Box`, found ()
-   |
-   = note: expected type `std::boxed::Box<(dyn Id<_> + 'static)>`
-              found type `()`
+error: aborting due to 2 previous errors
 
-error[E0308]: mismatched types
-  --> $DIR/E0657.rs:31:9
-   |
-LL |         () //~ ERROR mismatched types
-   |         ^^ expected struct `std::boxed::Box`, found ()
-   |
-   = note: expected type `std::boxed::Box<(dyn Id<_> + 'static)>`
-              found type `()`
-
-error: aborting due to 4 previous errors
-
-Some errors occurred: E0308, E0657.
-For more information about an error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0657`.

--- a/src/test/ui/impl-trait/auto-trait-leak.rs
+++ b/src/test/ui/impl-trait/auto-trait-leak.rs
@@ -23,9 +23,7 @@ fn main() {
 // return type, which can't depend on the obligation.
 fn cycle1() -> impl Clone {
     //~^ ERROR cycle detected
-    //~| ERROR cycle detected
     send(cycle2().clone());
-    //~^ ERROR `std::rc::Rc<std::string::String>` cannot be sent between threads safely
 
     Rc::new(Cell::new(5))
 }

--- a/src/test/ui/impl-trait/auto-trait-leak.stderr
+++ b/src/test/ui/impl-trait/auto-trait-leak.stderr
@@ -1,67 +1,29 @@
-error[E0391]: cycle detected when processing `cycle1::{{exist-impl-Trait}}`
-  --> $DIR/auto-trait-leak.rs:24:16
-   |
-LL | fn cycle1() -> impl Clone {
-   |                ^^^^^^^^^^
-   |
-note: ...which requires processing `cycle1`...
+error[E0391]: cycle detected when processing `cycle1`
   --> $DIR/auto-trait-leak.rs:24:1
    |
 LL | fn cycle1() -> impl Clone {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
 note: ...which requires evaluating trait selection obligation `impl std::clone::Clone: std::marker::Send`...
 note: ...which requires processing `cycle2::{{exist-impl-Trait}}`...
-  --> $DIR/auto-trait-leak.rs:33:16
+  --> $DIR/auto-trait-leak.rs:31:16
    |
 LL | fn cycle2() -> impl Clone {
    |                ^^^^^^^^^^
 note: ...which requires processing `cycle2`...
-  --> $DIR/auto-trait-leak.rs:33:1
+  --> $DIR/auto-trait-leak.rs:31:1
    |
 LL | fn cycle2() -> impl Clone {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires evaluating trait selection obligation `impl std::clone::Clone: std::marker::Send`...
-   = note: ...which again requires processing `cycle1::{{exist-impl-Trait}}`, completing the cycle
-
-error[E0391]: cycle detected when processing `cycle1::{{exist-impl-Trait}}`
+note: ...which requires processing `cycle1::{{exist-impl-Trait}}`...
   --> $DIR/auto-trait-leak.rs:24:16
    |
 LL | fn cycle1() -> impl Clone {
    |                ^^^^^^^^^^
-   |
-note: ...which requires processing `cycle1`...
-  --> $DIR/auto-trait-leak.rs:24:1
-   |
-LL | fn cycle1() -> impl Clone {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires evaluating trait selection obligation `impl std::clone::Clone: std::marker::Send`...
-note: ...which requires processing `cycle2::{{exist-impl-Trait}}`...
-  --> $DIR/auto-trait-leak.rs:33:16
-   |
-LL | fn cycle2() -> impl Clone {
-   |                ^^^^^^^^^^
-note: ...which requires processing `cycle2`...
-  --> $DIR/auto-trait-leak.rs:33:1
-   |
-LL | fn cycle2() -> impl Clone {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: ...which again requires processing `cycle1::{{exist-impl-Trait}}`, completing the cycle
+   = note: ...which again requires processing `cycle1`, completing the cycle
+note: cycle used when type-checking all item bodies
 
-error[E0277]: `std::rc::Rc<std::string::String>` cannot be sent between threads safely
-  --> $DIR/auto-trait-leak.rs:27:5
-   |
-LL |     send(cycle2().clone());
-   |     ^^^^ `std::rc::Rc<std::string::String>` cannot be sent between threads safely
-   |
-   = help: within `impl std::clone::Clone`, the trait `std::marker::Send` is not implemented for `std::rc::Rc<std::string::String>`
-   = note: required because it appears within the type `impl std::clone::Clone`
-note: required by `send`
-  --> $DIR/auto-trait-leak.rs:16:1
-   |
-LL | fn send<T: Send>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^
+error: aborting due to previous error
 
-error: aborting due to 3 previous errors
-
-Some errors occurred: E0277, E0391.
-For more information about an error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0391`.

--- a/src/test/ui/impl_trait_projections.rs
+++ b/src/test/ui/impl_trait_projections.rs
@@ -34,9 +34,8 @@ fn projection_with_named_trait_is_disallowed(x: impl Iterator)
 fn projection_with_named_trait_inside_path_is_disallowed()
     -> <::std::ops::Range<impl Debug> as Iterator>::Item
 //~^ ERROR `impl Trait` is not allowed in path parameters
-//~| ERROR trait bound `impl std::fmt::Debug: std::iter::Step` is not satisfied
-{ //~ ERROR trait bound `impl std::fmt::Debug: std::iter::Step` is not satisfied
-    (1i32..100).next().unwrap() //~ ERROR mismatched types
+{
+    (1i32..100).next().unwrap()
 }
 
 fn projection_from_impl_trait_inside_dyn_trait_is_disallowed()

--- a/src/test/ui/impl_trait_projections.stderr
+++ b/src/test/ui/impl_trait_projections.stderr
@@ -17,7 +17,7 @@ LL |     -> <::std::ops::Range<impl Debug> as Iterator>::Item
    |                           ^^^^^^^^^^
 
 error[E0667]: `impl Trait` is not allowed in path parameters
-  --> $DIR/impl_trait_projections.rs:43:29
+  --> $DIR/impl_trait_projections.rs:42:29
    |
 LL |     -> <dyn Iterator<Item = impl Debug> as Iterator>::Item
    |                             ^^^^^^^^^^
@@ -30,34 +30,7 @@ LL | fn projection_is_disallowed(x: impl Iterator) -> <impl Iterator>::Item {
    |
    = note: specify the type using the syntax `<impl std::iter::Iterator as Trait>::Item`
 
-error[E0277]: the trait bound `impl std::fmt::Debug: std::iter::Step` is not satisfied
-  --> $DIR/impl_trait_projections.rs:38:1
-   |
-LL | / { //~ ERROR trait bound `impl std::fmt::Debug: std::iter::Step` is not satisfied
-LL | |     (1i32..100).next().unwrap() //~ ERROR mismatched types
-LL | | }
-   | |_^ the trait `std::iter::Step` is not implemented for `impl std::fmt::Debug`
-   |
-   = note: required because of the requirements on the impl of `std::iter::Iterator` for `std::ops::Range<impl std::fmt::Debug>`
+error: aborting due to 5 previous errors
 
-error[E0308]: mismatched types
-  --> $DIR/impl_trait_projections.rs:39:5
-   |
-LL |     (1i32..100).next().unwrap() //~ ERROR mismatched types
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected anonymized type, found i32
-   |
-   = note: expected type `impl std::fmt::Debug`
-              found type `i32`
-
-error[E0277]: the trait bound `impl std::fmt::Debug: std::iter::Step` is not satisfied
-  --> $DIR/impl_trait_projections.rs:35:8
-   |
-LL |     -> <::std::ops::Range<impl Debug> as Iterator>::Item
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::iter::Step` is not implemented for `impl std::fmt::Debug`
-   |
-   = note: required because of the requirements on the impl of `std::iter::Iterator` for `std::ops::Range<impl std::fmt::Debug>`
-
-error: aborting due to 8 previous errors
-
-Some errors occurred: E0223, E0277, E0308, E0667.
+Some errors occurred: E0223, E0667.
 For more information about an error, try `rustc --explain E0223`.


### PR DESCRIPTION
r? @nikomatsakis 

My debugging led me to the `hir::ItemExistential(..)` checks, which are entirely unnecessary because we never use the items directly. The issue was that items were iterated over in a random order (due to hashmaps), so if you checked the `ItemExistential` before the function that has the actual return `impl Trait`, you'd run into those ICEs you encountered.