### PR TITLE
Fix Python exception when debugging.

### DIFF
--- a/src/etc/debugger_pretty_printers_common.py
+++ b/src/etc/debugger_pretty_printers_common.py
@@ -289,7 +289,7 @@ class EncodedEnumInfo(object):
 
         # If the discriminant field is a fat pointer we have to consider the
         # first word as the true discriminant
-        if discriminant_val.type.get_dwarf_type_kind() == DWARF_TYPE_CODE_STRUCT:
+        while discriminant_val.type.get_dwarf_type_kind() == DWARF_TYPE_CODE_STRUCT:
             discriminant_val = discriminant_val.get_child_at_index(0)
 
         return discriminant_val.as_integer() == 0


### PR DESCRIPTION
During debugging, I would get the below exception. Looking into this a little, I found that changing the `is_null_variant` function to keep checking for fat pointers until finding the true discriminant fixed the issue. I'm not familiar with what this code should really be doing - so it's certainly possible that this fix makes no sense but it did stop the exception from happening, so there's that.

Not sure who to assign for this, so I'll let the bot handle it.

```
Traceback (most recent call last):
  File "/home/david/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/etc/gdb_rust_pretty_printing.py", line 166, in rust_pretty_printer_lookup_function
    if encoded_enum_info.is_null_variant():
  File "/home/david/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/etc/debugger_pretty_printers_common.py", line 295, in is_null_variant
    return discriminant_val.as_integer() == 0
  File "/home/david/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/etc/gdb_rust_pretty_printing.py", line 83, in as_integer
    return int(self.gdb_val)
gdb.error: Cannot convert value to long.
```