### PR TITLE
Iterator::map_into method

### DIFF
--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -493,6 +493,8 @@ pub trait Iterator {
     /// # Examples
     ///
     /// ```
+    /// #![feature(move_into)]
+    ///
     /// (1i32..42i32).map_into().collect::<Vec<f64>>();
     /// ```
     #[unstable(feature = "move_into", issue = "0")]

--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -9,12 +9,13 @@
 // except according to those terms.
 
 use cmp::Ordering;
+use marker::PhantomData;
 use ops::Try;
 
 use super::LoopState;
 use super::{Chain, Cycle, Cloned, Enumerate, Filter, FilterMap, Fuse};
 use super::{Flatten, FlatMap, flatten_compat};
-use super::{Inspect, Map, Peekable, Scan, Skip, SkipWhile, StepBy, Take, TakeWhile, Rev};
+use super::{Inspect, Map, MapInto, Peekable, Scan, Skip, SkipWhile, StepBy, Take, TakeWhile, Rev};
 use super::{Zip, Sum, Product};
 use super::{ChainState, FromIterator, ZipImpl};
 
@@ -485,6 +486,21 @@ pub trait Iterator {
         Self: Sized, F: FnMut(Self::Item) -> B,
     {
         Map{iter: self, f: f}
+    }
+
+    /// Converts each item of the iterator using the `Into` trait.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// (1i32..42i32).map_into().collect::<Vec<f64>>();
+    /// ```
+    #[unstable(feature = "move_into", issue = "0")]
+    fn map_into<R>(self) -> MapInto<Self, R>
+    where
+        Self: Sized, Self::Item: Into<R>,
+    {
+        MapInto{iter: self, _res: PhantomData}
     }
 
     /// Calls a closure on each element of an iterator.

--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -495,7 +495,9 @@ pub trait Iterator {
     /// ```
     /// #![feature(move_into)]
     ///
-    /// (1i32..42i32).map_into().collect::<Vec<f64>>();
+    /// let floats = (1i32..42i32).map_into().collect::<Vec<f64>>();
+    /// assert_eq!(41, floats.len());
+    /// assert_eq!(861.0, floats.iter().sum());
     /// ```
     #[unstable(feature = "move_into", issue = "0")]
     fn map_into<R>(self) -> MapInto<Self, R>


### PR DESCRIPTION
An iterator adaptor that passes each element through an `Into`
conversion.

I originally proposed this to the `IterTools` crate, but was asked to propose it here first (https://github.com/bluss/rust-itertools/pull/288) and that it wouldn't probably need an RFC. I'm not completely sure this feature is interesting/wanted enough to go into the standard library, but I'm OK with someone else making the decision, so here it goes.

However, I'm unsure about some things:

* The compiler mandates the stability attributes. I just made some up, as there's no RFC and no tracking issue for this ‒ is that OK?
* Even in the edited files the style differs from structure to structure a bit. I used something close to what rustfmt does now, but it probably introduces yet another variation of the style.
* Is the one little doc-test enough, or should I create some more?

If it is deemed useful and should go in, I'll happily provide some more examples and tests if needed.