### PR TITLE
Don't ICE when performing `lower_pattern_unadjusted` on a `TyError`

### DIFF
--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -416,7 +416,6 @@ impl<'a, 'tcx> PatternContext<'a, 'tcx> {
             }
 
             PatKind::Slice(ref prefix, ref slice, ref suffix) => {
-                let ty = self.tables.node_id_to_type(pat.hir_id);
                 match ty.sty {
                     ty::TyRef(_, ty, _) =>
                         PatternKind::Deref {
@@ -427,11 +426,12 @@ impl<'a, 'tcx> PatternContext<'a, 'tcx> {
                                     pat.span, ty, prefix, slice, suffix))
                             },
                         },
-
                     ty::TySlice(..) |
                     ty::TyArray(..) =>
                         self.slice_or_array_pattern(pat.span, ty, prefix, slice, suffix),
-
+                    ty::TyError => { // Avoid ICE
+                        return Pattern { span: pat.span, ty, kind: Box::new(PatternKind::Wild) };
+                    }
                     ref sty =>
                         span_bug!(
                             pat.span,
@@ -441,7 +441,6 @@ impl<'a, 'tcx> PatternContext<'a, 'tcx> {
             }
 
             PatKind::Tuple(ref subpatterns, ddpos) => {
-                let ty = self.tables.node_id_to_type(pat.hir_id);
                 match ty.sty {
                     ty::TyTuple(ref tys) => {
                         let subpatterns =
@@ -455,7 +454,9 @@ impl<'a, 'tcx> PatternContext<'a, 'tcx> {
 
                         PatternKind::Leaf { subpatterns: subpatterns }
                     }
-
+                    ty::TyError => { // Avoid ICE (#50577)
+                        return Pattern { span: pat.span, ty, kind: Box::new(PatternKind::Wild) };
+                    }
                     ref sty => span_bug!(pat.span, "unexpected type for tuple pattern: {:?}", sty),
                 }
             }
@@ -464,6 +465,9 @@ impl<'a, 'tcx> PatternContext<'a, 'tcx> {
                 let var_ty = self.tables.node_id_to_type(pat.hir_id);
                 let region = match var_ty.sty {
                     ty::TyRef(r, _, _) => Some(r),
+                    ty::TyError => { // Avoid ICE
+                        return Pattern { span: pat.span, ty, kind: Box::new(PatternKind::Wild) };
+                    }
                     _ => None,
                 };
                 let bm = *self.tables.pat_binding_modes().get(pat.hir_id)
@@ -505,12 +509,8 @@ impl<'a, 'tcx> PatternContext<'a, 'tcx> {
                 let def = self.tables.qpath_def(qpath, pat.hir_id);
                 let adt_def = match ty.sty {
                     ty::TyAdt(adt_def, _) => adt_def,
-                    ty::TyError => {  // Avoid ICE (#50585)
-                        return Pattern {
-                            span: pat.span,
-                            ty,
-                            kind: Box::new(PatternKind::Wild),
-                        };
+                    ty::TyError => { // Avoid ICE (#50585)
+                        return Pattern { span: pat.span, ty, kind: Box::new(PatternKind::Wild) };
                     }
                     _ => span_bug!(pat.span,
                                    "tuple struct pattern not applied to an ADT {:?}",

--- a/src/test/ui/issue-50577.rs
+++ b/src/test/ui/issue-50577.rs
@@ -1,0 +1,15 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    enum Foo {
+        Drop = assert_eq!(1, 1)
+    }
+}

--- a/src/test/ui/issue-50577.stderr
+++ b/src/test/ui/issue-50577.stderr
@@ -1,0 +1,13 @@
+error[E0317]: if may be missing an else clause
+  --> $DIR/issue-50577.rs:13:16
+   |
+LL |         Drop = assert_eq!(1, 1)
+   |                ^^^^^^^^^^^^^^^^ expected (), found isize
+   |
+   = note: expected type `()`
+              found type `isize`
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0317`.


### PR DESCRIPTION
Fix #50577. CC #51696.

r? @oli-obk 