### PR TITLE
Fix variant background color on hover in search results

### DIFF
--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -108,7 +108,7 @@ pre {
 
 .content .highlighted {
 	color: #eee !important;
-	background-color: #333;
+	background-color: #616161;
 }
 .content .highlighted a, .content .highlighted span { color: #eee !important; }
 .content .highlighted.trait { background-color: #013191; }


### PR DESCRIPTION
Fixes #51792.

<img width="1440" alt="screen shot 2018-06-26 at 00 37 24" src="https://user-images.githubusercontent.com/3050060/41879313-60ecf3be-78d9-11e8-9986-21af529ab758.png">


r? @QuietMisdreavus 