### PR TITLE
Add a compiletest header for edition

### DIFF
--- a/src/test/compile-fail/edition-raw-pointer-method-2015.rs
+++ b/src/test/compile-fail/edition-raw-pointer-method-2015.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags: --edition=2015 -Zunstable-options
+// edition:2015
 
 // tests that editions work with the tyvar warning-turned-error
 

--- a/src/test/compile-fail/edition-raw-pointer-method-2018.rs
+++ b/src/test/compile-fail/edition-raw-pointer-method-2018.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags: --edition=2018 -Zunstable-options
+// edition:2018
 
 // tests that editions work with the tyvar warning-turned-error
 

--- a/src/test/compile-fail/rfc-2126-extern-absolute-paths/non-existent-1.rs
+++ b/src/test/compile-fail/rfc-2126-extern-absolute-paths/non-existent-1.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2018 -Zunstable-options
+// edition:2018
 
 #![feature(extern_absolute_paths)]
 

--- a/src/test/compile-fail/rfc-2126-extern-absolute-paths/non-existent-2.rs
+++ b/src/test/compile-fail/rfc-2126-extern-absolute-paths/non-existent-2.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2018 -Zunstable-options
+// edition:2018
 
 #![feature(extern_absolute_paths)]
 

--- a/src/test/compile-fail/rfc-2126-extern-absolute-paths/non-existent-3.rs
+++ b/src/test/compile-fail/rfc-2126-extern-absolute-paths/non-existent-3.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2018 -Zunstable-options
+// edition:2018
 
 #![feature(extern_absolute_paths)]
 

--- a/src/test/compile-fail/rfc-2126-extern-absolute-paths/single-segment.rs
+++ b/src/test/compile-fail/rfc-2126-extern-absolute-paths/single-segment.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:xcrate.rs
-// compile-flags: --edition=2018 -Zunstable-options
+// edition:2018
 
 #![feature(crate_in_paths)]
 #![feature(extern_absolute_paths)]

--- a/src/test/run-pass/async-await.rs
+++ b/src/test/run-pass/async-await.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2018
+// edition:2018
 
 #![feature(arbitrary_self_types, async_await, await_macro, futures_api, pin)]
 

--- a/src/test/run-pass/auxiliary/edition-kw-macro-2015.rs
+++ b/src/test/run-pass/auxiliary/edition-kw-macro-2015.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2015
+// edition:2015
 
 #![feature(raw_identifiers)]
 

--- a/src/test/run-pass/auxiliary/edition-kw-macro-2018.rs
+++ b/src/test/run-pass/auxiliary/edition-kw-macro-2018.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2018
+// edition:2018
 
 #![feature(raw_identifiers)]
 

--- a/src/test/run-pass/edition-keywords-2015-2015.rs
+++ b/src/test/run-pass/edition-keywords-2015-2015.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2015
+// edition:2015
 // aux-build:edition-kw-macro-2015.rs
 
 #![feature(raw_identifiers)]

--- a/src/test/run-pass/edition-keywords-2015-2018.rs
+++ b/src/test/run-pass/edition-keywords-2015-2018.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2015
+// edition:2015
 // aux-build:edition-kw-macro-2018.rs
 
 #![feature(raw_identifiers)]

--- a/src/test/run-pass/edition-keywords-2018-2015.rs
+++ b/src/test/run-pass/edition-keywords-2018-2015.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2018
+// edition:2018
 // aux-build:edition-kw-macro-2015.rs
 
 #![feature(raw_identifiers)]

--- a/src/test/run-pass/edition-keywords-2018-2018.rs
+++ b/src/test/run-pass/edition-keywords-2018-2018.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2018
+// edition:2018
 // aux-build:edition-kw-macro-2018.rs
 
 #![feature(raw_identifiers)]

--- a/src/test/run-pass/rfc-2126-extern-absolute-paths/basic.rs
+++ b/src/test/run-pass/rfc-2126-extern-absolute-paths/basic.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:xcrate.rs
-// compile-flags: --edition=2018 -Zunstable-options
+// edition:2018
 
 #![feature(extern_absolute_paths)]
 

--- a/src/test/run-pass/rfc-2126-extern-absolute-paths/test.rs
+++ b/src/test/run-pass/rfc-2126-extern-absolute-paths/test.rs
@@ -12,7 +12,8 @@
 //
 // Regression test for #47075.
 
-// compile-flags: --test --edition=2018 -Zunstable-options
+// edition:2018
+// compile-flags: --test
 
 #![feature(extern_absolute_paths)]
 

--- a/src/test/ui/async-fn-multiple-lifetimes.rs
+++ b/src/test/ui/async-fn-multiple-lifetimes.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2018
+// edition:2018
 
 #![feature(arbitrary_self_types, async_await, await_macro, futures_api, pin)]
 

--- a/src/test/ui/auxiliary/edition-kw-macro-2015.rs
+++ b/src/test/ui/auxiliary/edition-kw-macro-2015.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2015
+// edition:2015
 
 #![feature(raw_identifiers)]
 

--- a/src/test/ui/auxiliary/edition-kw-macro-2018.rs
+++ b/src/test/ui/auxiliary/edition-kw-macro-2018.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2018
+// edition:2018
 
 #![feature(raw_identifiers)]
 

--- a/src/test/ui/edition-keywords-2015-2015-expansion.rs
+++ b/src/test/ui/edition-keywords-2015-2015-expansion.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2015
+// edition:2015
 // aux-build:edition-kw-macro-2015.rs
 // compile-pass
 

--- a/src/test/ui/edition-keywords-2015-2015-parsing.rs
+++ b/src/test/ui/edition-keywords-2015-2015-parsing.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2015
+// edition:2015
 // aux-build:edition-kw-macro-2015.rs
 
 #![feature(raw_identifiers)]

--- a/src/test/ui/edition-keywords-2015-2018-expansion.rs
+++ b/src/test/ui/edition-keywords-2015-2018-expansion.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2015
+// edition:2015
 // aux-build:edition-kw-macro-2018.rs
 
 #![feature(raw_identifiers)]

--- a/src/test/ui/edition-keywords-2015-2018-parsing.rs
+++ b/src/test/ui/edition-keywords-2015-2018-parsing.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2015
+// edition:2015
 // aux-build:edition-kw-macro-2018.rs
 
 #![feature(raw_identifiers)]

--- a/src/test/ui/edition-keywords-2018-2015-expansion.rs
+++ b/src/test/ui/edition-keywords-2018-2015-expansion.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2018
+// edition:2018
 // aux-build:edition-kw-macro-2015.rs
 // compile-pass
 

--- a/src/test/ui/edition-keywords-2018-2015-parsing.rs
+++ b/src/test/ui/edition-keywords-2018-2015-parsing.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2018
+// edition:2018
 // aux-build:edition-kw-macro-2015.rs
 
 #![feature(raw_identifiers)]

--- a/src/test/ui/edition-keywords-2018-2018-expansion.rs
+++ b/src/test/ui/edition-keywords-2018-2018-expansion.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2018
+// edition:2018
 // aux-build:edition-kw-macro-2018.rs
 
 #![feature(raw_identifiers)]

--- a/src/test/ui/edition-keywords-2018-2018-parsing.rs
+++ b/src/test/ui/edition-keywords-2018-2018-parsing.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2018
+// edition:2018
 // aux-build:edition-kw-macro-2018.rs
 
 #![feature(raw_identifiers)]

--- a/src/test/ui/feature-gate-async-await-2015-edition.rs
+++ b/src/test/ui/feature-gate-async-await-2015-edition.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2015
+// edition:2015
 
 #![feature(futures_api)]
 

--- a/src/test/ui/feature-gate-async-await.rs
+++ b/src/test/ui/feature-gate-async-await.rs
@@ -8,7 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2018
+// edition:2018
+
 #![feature(futures_api)]
 
 async fn foo() {} //~ ERROR async fn is unstable

--- a/src/test/ui/feature-gate-async-await.stderr
+++ b/src/test/ui/feature-gate-async-await.stderr
@@ -1,5 +1,5 @@
 error[E0658]: async fn is unstable (see issue #50547)
-  --> $DIR/feature-gate-async-await.rs:14:1
+  --> $DIR/feature-gate-async-await.rs:15:1
    |
 LL | async fn foo() {} //~ ERROR async fn is unstable
    | ^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | async fn foo() {} //~ ERROR async fn is unstable
    = help: add #![feature(async_await)] to the crate attributes to enable
 
 error[E0658]: async blocks are unstable (see issue #50547)
-  --> $DIR/feature-gate-async-await.rs:17:13
+  --> $DIR/feature-gate-async-await.rs:18:13
    |
 LL |     let _ = async {}; //~ ERROR async blocks are unstable
    |             ^^^^^^^^
@@ -15,7 +15,7 @@ LL |     let _ = async {}; //~ ERROR async blocks are unstable
    = help: add #![feature(async_await)] to the crate attributes to enable
 
 error[E0658]: async closures are unstable (see issue #50547)
-  --> $DIR/feature-gate-async-await.rs:18:13
+  --> $DIR/feature-gate-async-await.rs:19:13
    |
 LL |     let _ = async || {}; //~ ERROR async closures are unstable
    |             ^^^^^^^^^^^

--- a/src/test/ui/lint-anon-param-edition.fixed
+++ b/src/test/ui/lint-anon-param-edition.fixed
@@ -11,7 +11,7 @@
 // tests that the anonymous_parameters lint is warn-by-default on the 2018 edition
 
 // compile-pass
-// compile-flags: --edition=2018
+// edition:2018
 // run-rustfix
 
 trait Foo {

--- a/src/test/ui/lint-anon-param-edition.rs
+++ b/src/test/ui/lint-anon-param-edition.rs
@@ -11,7 +11,7 @@
 // tests that the anonymous_parameters lint is warn-by-default on the 2018 edition
 
 // compile-pass
-// compile-flags: --edition=2018
+// edition:2018
 // run-rustfix
 
 trait Foo {

--- a/src/test/ui/no-args-non-move-async-closure.rs
+++ b/src/test/ui/no-args-non-move-async-closure.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition=2018
+// edition:2018
 
 #![feature(arbitrary_self_types, async_await, await_macro, futures_api, pin)]
 

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -298,6 +298,10 @@ impl TestProps {
                     .extend(flags.split_whitespace().map(|s| s.to_owned()));
             }
 
+            if let Some(edition) = config.parse_edition(ln) {
+                self.compile_flags.push(format!("--edition={}", edition));
+            }
+
             if let Some(r) = config.parse_revisions(ln) {
                 self.revisions.extend(r);
             }
@@ -371,9 +375,9 @@ impl TestProps {
                 self.compile_pass = config.parse_compile_pass(ln) || self.run_pass;
             }
 
-                        if !self.skip_codegen {
-                            self.skip_codegen = config.parse_skip_codegen(ln);
-                        }
+            if !self.skip_codegen {
+                self.skip_codegen = config.parse_skip_codegen(ln);
+            }
 
             if !self.disable_ui_testing_normalization {
                 self.disable_ui_testing_normalization =
@@ -646,6 +650,10 @@ impl Config {
 
     fn parse_run_rustfix(&self, line: &str) -> bool {
         self.parse_name_directive(line, "run-rustfix")
+    }
+
+    fn parse_edition(&self, line: &str) -> Option<String> {
+        self.parse_name_value_directive(line, "edition")
     }
 }
 

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1368,6 +1368,7 @@ impl<'test> TestCx<'test> {
             .arg(out_dir)
             .arg(&self.testpaths.file)
             .args(&self.props.compile_flags);
+
         if let Some(ref linker) = self.config.linker {
             rustdoc
                 .arg("--linker")


### PR DESCRIPTION
r? @nikomatsakis 

Are the `-Zunstable-options` options needed in these tests? It looks like they aren't. If not, I can remove them.