### PR TITLE
rustdoc codeblock hash escape

### DIFF
--- a/src/doc/rustdoc/src/documentation-tests.md
+++ b/src/doc/rustdoc/src/documentation-tests.md
@@ -170,6 +170,23 @@ By repeating all parts of the example, you can ensure that your example still
 compiles, while only showing the parts that are relevant to that part of your
 explanation.
 
+The `#`-hiding of lines can be prevented by using two consecutive hashes
+`##`. This only needs to be done with with the first `#` which would've
+otherwise caused hiding. If we have a string literal like the following,
+which has a line that starts with a `#`:
+
+```rust
+let s = "foo
+## bar # baz";
+```
+
+We can document it by escaping the initial `#`:
+
+```text
+/// let s = "foo
+/// ## bar # baz";
+```
+
 
 ## Using `?` in doc tests
 


### PR DESCRIPTION
So that docstring text such as the following (in a code block) can be created ergonomically:

```rust
let s = "
    foo
    # bar
    baz
";
```

Such code in a docstring hide the <code>&nbsp;&nbsp;&nbsp;&nbsp;# bar</code> line.

Previously, using two consecutive hashes <code>&nbsp;&nbsp;&nbsp;&nbsp;## bar</code> would turn the line into _shown_ `# bar`, losing the leading whitespace. A line of code like <code>&nbsp;&nbsp;&nbsp;&nbsp;# bar</code> (such as in the example above) **could not be represented** in the docstring text.

This commit makes the two consecutive hashes not also trim the leading whitespace — the two hashes simply **escape** into a single hash and do not hide the line, leaving the rest of that line unaffected. The new docstring text to achieve the above code block is:

```rust
/// ```
/// let s = "
///     foo
///     ## bar
///     baz
/// ";
/// ```
```