### PR TITLE
Fix the error reference for LocalKey::try_with

### DIFF
--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -276,7 +276,7 @@ impl<T: 'static> LocalKey<T> {
     ///
     /// This will lazily initialize the value if this thread has not referenced
     /// this key yet. If the key has been destroyed (which may happen if this is called
-    /// in a destructor), this function will return a `ThreadLocalError`.
+    /// in a destructor), this function will return an [`AccessError`](struct.AccessError.html).
     ///
     /// # Panics
     ///


### PR DESCRIPTION
There's no such thing as `ThreadLocalError` and the method obviously returns `AccessError`, so adjusting (probably only outdated docs).