### PR TITLE
Document that Layout::from_size_align does not allow align=0

### DIFF
--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -67,6 +67,8 @@ impl Layout {
     /// or returns `LayoutErr` if either of the following conditions
     /// are not met:
     ///
+    /// * `align` must not be zero,
+    ///
     /// * `align` must be a power of two,
     ///
     /// * `size`, when rounded up to the nearest multiple of `align`,


### PR DESCRIPTION
This was already implied since zero is not a power of two, but maybe worth pointing out.