### PR TITLE
[fuchsia] Update zx_cprng_draw to target semantics

### DIFF
--- a/src/libstd/sys/unix/rand.rs
+++ b/src/libstd/sys/unix/rand.rs
@@ -183,34 +183,10 @@ mod imp {
 mod imp {
     #[link(name = "zircon")]
     extern {
-        fn zx_cprng_draw_new(buffer: *mut u8, len: usize) -> i32;
-    }
-
-    fn getrandom(buf: &mut [u8]) -> Result<usize, i32> {
-        unsafe {
-            let status = zx_cprng_draw_new(buf.as_mut_ptr(), buf.len());
-            if status == 0 {
-                Ok(buf.len())
-            } else {
-                Err(status)
-            }
-        }
+        fn zx_cprng_draw(buffer: *mut u8, len: usize);
     }
 
     pub fn fill_bytes(v: &mut [u8]) {
-        let mut buf = v;
-        while !buf.is_empty() {
-            let ret = getrandom(buf);
-            match ret {
-                Err(err) => {
-                    panic!("kernel zx_cprng_draw call failed! (returned {}, buf.len() {})",
-                        err, buf.len())
-                }
-                Ok(actual) => {
-                    let move_buf = buf;
-                    buf = &mut move_buf[(actual as usize)..];
-                }
-            }
-        }
+        unsafe { zx_cprng_draw(v.as_mut_ptr(), v.len()) }
     }
 }


### PR DESCRIPTION
This change is the final step in improving the semantics of
zx_cprng_draw. Now the syscall always generates the requested number of
bytes. If the syscall would have failed to generate the requested number
of bytes, the syscall either terminates the entire operating system or
terminates the calling process, depending on whether the error is a
result of the kernel misbehaving or the userspace program misbehaving.