### PR TITLE
Remove use of uninitialized() in Weak::new()

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -1028,6 +1028,15 @@ impl<T> Weak<T> {
     #[stable(feature = "downgraded_weak", since = "1.10.0")]
     pub fn new() -> Weak<T> {
         unsafe {
+            // Statically assert that we’re not about to allocate zero bytes
+            // but at least enough space for the `strong` and `weak` fields
+            // even if `T` is uninhabited.
+            // https://github.com/rust-lang/rust/issues/48493#issuecomment-372438465
+            // https://github.com/rust-lang/rust/pull/50622
+            #[cfg(not(stage0))] enum Void {}
+            #[cfg(not(stage0))] let _ = mem::transmute::<ArcInner<Void>, ArcInner<()>>;
+            #[cfg(not(stage0))] let _ = mem::transmute::<ArcInner<!>, ArcInner<()>>;
+
             let layout = Layout::new::<ArcInner<T>>();
             let mut ptr = Global.alloc(layout)
                 .unwrap_or_else(|_| handle_alloc_error(layout))

--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -23,7 +23,7 @@ use core::borrow;
 use core::fmt;
 use core::cmp::Ordering;
 use core::intrinsics::abort;
-use core::mem::{self, align_of_val, size_of_val, uninitialized};
+use core::mem::{self, align_of_val, size_of_val};
 use core::ops::Deref;
 use core::ops::CoerceUnsized;
 use core::ptr::{self, NonNull};
@@ -1028,13 +1028,13 @@ impl<T> Weak<T> {
     #[stable(feature = "downgraded_weak", since = "1.10.0")]
     pub fn new() -> Weak<T> {
         unsafe {
-            Weak {
-                ptr: Box::into_raw_non_null(box ArcInner {
-                    strong: atomic::AtomicUsize::new(0),
-                    weak: atomic::AtomicUsize::new(1),
-                    data: uninitialized(),
-                }),
-            }
+            let layout = Layout::new::<ArcInner<T>>();
+            let mut ptr = Global.alloc(layout)
+                .unwrap_or_else(|_| handle_alloc_error(layout))
+                .cast::<ArcInner<T>>();
+            ptr::write(&mut ptr.as_mut().strong, atomic::AtomicUsize::new(0));
+            ptr::write(&mut ptr.as_mut().weak, atomic::AtomicUsize::new(1));
+            Weak { ptr }
         }
     }
 }

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -100,6 +100,7 @@
 #![feature(lang_items)]
 #![feature(libc)]
 #![feature(needs_allocator)]
+#![feature(never_type)]
 #![feature(optin_builtin_traits)]
 #![feature(pattern)]
 #![feature(pin)]

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -253,7 +253,7 @@ use core::hash::{Hash, Hasher};
 use core::intrinsics::abort;
 use core::marker;
 use core::marker::{Unsize, PhantomData};
-use core::mem::{self, align_of_val, forget, size_of_val, uninitialized};
+use core::mem::{self, align_of_val, forget, size_of_val};
 use core::ops::Deref;
 use core::ops::CoerceUnsized;
 use core::ptr::{self, NonNull};
@@ -1182,13 +1182,13 @@ impl<T> Weak<T> {
     #[stable(feature = "downgraded_weak", since = "1.10.0")]
     pub fn new() -> Weak<T> {
         unsafe {
-            Weak {
-                ptr: Box::into_raw_non_null(box RcBox {
-                    strong: Cell::new(0),
-                    weak: Cell::new(1),
-                    value: uninitialized(),
-                }),
-            }
+            let layout = Layout::new::<RcBox<T>>();
+            let mut ptr = Global.alloc(layout)
+                .unwrap_or_else(|_| handle_alloc_error(layout))
+                .cast::<RcBox<T>>();
+            ptr::write(&mut ptr.as_mut().strong, Cell::new(0));
+            ptr::write(&mut ptr.as_mut().weak, Cell::new(1));
+            Weak { ptr }
         }
     }
 }

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -1182,6 +1182,15 @@ impl<T> Weak<T> {
     #[stable(feature = "downgraded_weak", since = "1.10.0")]
     pub fn new() -> Weak<T> {
         unsafe {
+            // Assert that we’re not about to allocate zero bytes
+            // but at least enough space for the `strong` and `weak` fields
+            // even if `T` is uninhabited.
+            // https://github.com/rust-lang/rust/issues/48493#issuecomment-372438465
+            // https://github.com/rust-lang/rust/pull/50622
+            #[cfg(not(stage0))] enum Void {}
+            #[cfg(not(stage0))] let _ = mem::transmute::<RcBox<Void>, RcBox<()>>;
+            #[cfg(not(stage0))] let _ = mem::transmute::<RcBox<!>, RcBox<()>>;
+
             let layout = Layout::new::<RcBox<T>>();
             let mut ptr = Global.alloc(layout)
                 .unwrap_or_else(|_| handle_alloc_error(layout))

--- a/src/test/run-pass/weak-new-uninhabited-issue-48493.rs
+++ b/src/test/run-pass/weak-new-uninhabited-issue-48493.rs
@@ -1,0 +1,14 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    enum Void {}
+    std::rc::Weak::<Void>::new();
+}


### PR DESCRIPTION
This avoids the question of whether `uninitialized::<T>()` is necessarily UB when `T = !`

Fixes https://github.com/rust-lang/rust/issues/48493