### PR TITLE
Don't use `ParamEnv::reveal_all()` if there is a real one available

### DIFF
--- a/src/librustc_mir/interpret/const_eval.rs
+++ b/src/librustc_mir/interpret/const_eval.rs
@@ -76,7 +76,7 @@ pub fn value_to_const_value<'tcx>(
     val: Value,
     ty: Ty<'tcx>,
 ) -> &'tcx ty::Const<'tcx> {
-    let layout = ecx.tcx.layout_of(ty::ParamEnv::reveal_all().and(ty)).unwrap();
+    let layout = ecx.layout_of(ty).unwrap();
     match (val, &layout.abi) {
         (Value::Scalar(Scalar::Bits { defined: 0, ..}), _) if layout.is_zst() => {},
         (Value::ByRef(..), _) |

--- a/src/test/ui/const-eval/ice-generic-assoc-const.rs
+++ b/src/test/ui/const-eval/ice-generic-assoc-const.rs
@@ -1,0 +1,28 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-pass
+
+pub trait Nullable {
+    const NULL: Self;
+
+    fn is_null(&self) -> bool;
+}
+
+impl<T> Nullable for *const T {
+    const NULL: Self = 0 as *const T;
+
+    fn is_null(&self) -> bool {
+        *self == Self::NULL
+    }
+}
+
+fn main() {
+}


### PR DESCRIPTION
fixes #51841 

r? @Zoxc 