### PR TITLE
Prevent some markdown transformation on short docblocks

### DIFF
--- a/src/test/rustdoc/short-dockblock.rs
+++ b/src/test/rustdoc/short-dockblock.rs
@@ -1,0 +1,35 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "foo"]
+
+// @has foo/index.html '//*[@class="docblock-short"]/p' 'fooo'
+// @!has foo/index.html '//*[@class="docblock-short"]/p/h1' 'fooo'
+// @has foo/fn.foo.html '//h1[@id="fooo"]/a[@href="#fooo"]' 'fooo'
+
+/// # fooo
+///
+/// foo
+pub fn foo() {}
+
+// @has foo/index.html '//*[@class="docblock-short"]/p' 'mooood'
+// @!has foo/index.html '//*[@class="docblock-short"]/p/h2' 'mooood'
+// @has foo/foo/index.html '//h2[@id="mooood"]/a[@href="#mooood"]' 'mooood'
+
+/// ## mooood
+///
+/// foo mod
+pub mod foo {}
+
+// @has foo/index.html '//*[@class="docblock-short"]/p/a[@href=\
+//                      "https://nougat.world"]/code' 'nougat'
+
+/// [`nougat`](https://nougat.world)
+pub struct Bar;


### PR DESCRIPTION
Before:

<img width="1440" alt="screen shot 2018-06-28 at 01 46 01" src="https://user-images.githubusercontent.com/3050060/42005762-7d533bbe-7a76-11e8-8361-027886803399.png">

After:

<img width="1440" alt="screen shot 2018-06-28 at 01 46 02" src="https://user-images.githubusercontent.com/3050060/42005768-81bd59a0-7a76-11e8-819b-9b4be72579d6.png">

This is only performed on short doc blocks, not on plain ones. Not all transformations are prevented (you still have a few like urls, code blocks, etc...).

cc @nical 

r? @QuietMisdreavus 