### PR TITLE
Remove process::id from 'Stabilized APIs' in 1.27.0 release notes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -56,7 +56,6 @@ Stabilized APIs
 - [`Take::set_limit`]
 - [`hint::unreachable_unchecked`]
 - [`os::unix::process::parent_id`]
-- [`process::id`]
 - [`ptr::swap_nonoverlapping`]
 - [`slice::rsplit_mut`]
 - [`slice::rsplit`]


### PR DESCRIPTION
process::id was already stabilized in 1.26.0 and is marked as such in the docs.