### PR TITLE
Explicitely disable WASM code generation for Emscripten

### DIFF
--- a/src/librustc_target/spec/asmjs_unknown_emscripten.rs
+++ b/src/librustc_target/spec/asmjs_unknown_emscripten.rs
@@ -16,7 +16,9 @@ pub fn target() -> Result<Target, String> {
                 vec!["-s".to_string(),
                      "ERROR_ON_UNDEFINED_SYMBOLS=1".to_string(),
                      "-s".to_string(),
-                     "ABORTING_MALLOC=0".to_string()]);
+                     "ABORTING_MALLOC=0".to_string(),
+                     "-s".to_string(),
+                     "WASM=0".to_string()]);
 
     let opts = TargetOptions {
         dynamic_linking: false,


### PR DESCRIPTION
Emscripten changed the default behavior recently:
https://github.com/kripken/emscripten/blob/bd050e64bb0d9952df1344b8ea9356252328ad83/ChangeLog.markdown#v1381-05172018

It now defaults to WebAssembly and requires an explicit flag to generate asm.js.
WASM=0 is also valid for older emcc and thus doesn't break it.