### PR TITLE
Allow to implement more operators on raw pointers

### DIFF
--- a/src/librustc_passes/rvalue_promotion.rs
+++ b/src/librustc_passes/rvalue_promotion.rs
@@ -306,7 +306,9 @@ fn check_expr<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>, e: &hir::Expr, node
                 ty::TyRawPtr(_) => {
                     assert!(op.node == hir::BiEq || op.node == hir::BiNe ||
                             op.node == hir::BiLe || op.node == hir::BiLt ||
-                            op.node == hir::BiGe || op.node == hir::BiGt);
+                            op.node == hir::BiGe || op.node == hir::BiGt ||
+                            op.node == hir::BiAdd || op.node == hir::BiSub || 
+                            op.node == hir::BiBitAnd || op.node == hir::BiBitOr );
 
                     v.promotable = false;
                 }

--- a/src/librustc_passes/rvalue_promotion.rs
+++ b/src/librustc_passes/rvalue_promotion.rs
@@ -307,8 +307,8 @@ fn check_expr<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>, e: &hir::Expr, node
                     assert!(op.node == hir::BiEq || op.node == hir::BiNe ||
                             op.node == hir::BiLe || op.node == hir::BiLt ||
                             op.node == hir::BiGe || op.node == hir::BiGt ||
-                            op.node == hir::BiAdd || op.node == hir::BiSub || 
-                            op.node == hir::BiBitAnd || op.node == hir::BiBitOr );
+                            op.node == hir::BiAdd || op.node == hir::BiSub ||
+                            op.node == hir::BiBitAnd || op.node == hir::BiBitOr);
 
                     v.promotable = false;
                 }


### PR DESCRIPTION
As evidenced by [this issue](https://github.com/rust-lang/rust/issues/51766), part of the compiler’s code explicitly forbids implementing some operators for raw pointers. But it is rather common to add, sub, and and or with raw pointers, so it seems useful to add the possibility.