### PR TITLE
Suggest correct comparison against negative literal

### DIFF
--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -172,12 +172,27 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
             ExprKind::InlineAsm(..) if !self.session.target.target.options.allow_asm => {
                 span_err!(self.session, expr.span, E0472, "asm! is unsupported on this target");
             }
-            ExprKind::ObsoleteInPlace(..) => {
-                self.err_handler()
-                    .struct_span_err(expr.span, "emplacement syntax is obsolete (for now, anyway)")
-                    .note("for more information, see \
-                           <https://github.com/rust-lang/rust/issues/27779#issuecomment-378416911>")
-                    .emit();
+            ExprKind::ObsoleteInPlace(ref place, ref val) => {
+                let mut err = self.err_handler().struct_span_err(
+                    expr.span,
+                    "emplacement syntax is obsolete (for now, anyway)",
+                );
+                err.note(
+                    "for more information, see \
+                     <https://github.com/rust-lang/rust/issues/27779#issuecomment-378416911>"
+                );
+                match val.node {
+                    ExprKind::Lit(ref v) if v.node.is_numeric() => {
+                        err.span_suggestion(
+                            place.span.between(val.span),
+                            "if you meant to write a comparison against a negative value, add a \
+                             space in between `<` and `-`",
+                            "< -".to_string(),
+                        );
+                    }
+                    _ => {}
+                }
+                err.emit();
             }
             _ => {}
         }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1298,6 +1298,16 @@ impl LitKind {
         }
     }
 
+    /// Returns true if this is a numeric literal.
+    pub fn is_numeric(&self) -> bool {
+        match *self {
+            LitKind::Int(..) |
+            LitKind::Float(..) |
+            LitKind::FloatUnsuffixed(..) => true,
+            _ => false,
+        }
+    }
+
     /// Returns true if this literal has no suffix. Note: this will return true
     /// for literals with prefixes such as raw strings and byte strings.
     pub fn is_unsuffixed(&self) -> bool {

--- a/src/test/ui/suggestions/placement-syntax.rs
+++ b/src/test/ui/suggestions/placement-syntax.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let x = -5;
+    if x<-1 {
+    //~^ ERROR emplacement syntax is obsolete
+        println!("ok");
+    }
+}

--- a/src/test/ui/suggestions/placement-syntax.stderr
+++ b/src/test/ui/suggestions/placement-syntax.stderr
@@ -1,0 +1,14 @@
+error: emplacement syntax is obsolete (for now, anyway)
+  --> $DIR/placement-syntax.rs:13:8
+   |
+LL |     if x<-1 {
+   |        ^^^^
+   |
+   = note: for more information, see <https://github.com/rust-lang/rust/issues/27779#issuecomment-378416911>
+help: if you meant to write a comparison against a negative value, add a space in between `<` and `-`
+   |
+LL |     if x< -1 {
+   |         ^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
When parsing as emplacement syntax (`x<-1`), suggest the correct syntax
for comparison against a negative value (`x< -1`).

Fix #45651.