### PR TITLE
improve the error message when `#[panic_implementation]` is missing

### DIFF
--- a/src/librustc/middle/weak_lang_items.rs
+++ b/src/librustc/middle/weak_lang_items.rs
@@ -112,9 +112,13 @@ fn verify<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         if missing.contains(&lang_items::$item) &&
            !whitelisted(tcx, lang_items::$item) &&
            items.$name().is_none() {
-            tcx.sess.err(&format!("language item required, but not found: `{}`",
-                                  stringify!($name)));
-
+            if lang_items::$item == lang_items::PanicImplLangItem {
+                tcx.sess.err(&format!("`#[panic_implementation]` function required, \
+                                        but not found"));
+            } else {
+                tcx.sess.err(&format!("language item required, but not found: `{}`",
+                                        stringify!($name)));
+            }
         }
     )*
 }

--- a/src/test/compile-fail/panic-implementation-missing.rs
+++ b/src/test/compile-fail/panic-implementation-missing.rs
@@ -1,0 +1,18 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: `#[panic_implementation]` function required, but not found
+
+#![feature(lang_items)]
+#![no_main]
+#![no_std]
+
+#[lang = "eh_personality"]
+fn eh() {}

--- a/src/test/compile-fail/weak-lang-item.rs
+++ b/src/test/compile-fail/weak-lang-item.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:weak-lang-items.rs
-// error-pattern: language item required, but not found: `panic_impl`
+// error-pattern: `#[panic_implementation]` function required, but not found
 // error-pattern: language item required, but not found: `eh_personality`
 // ignore-wasm32-bare compiled with panic=abort, personality not required
 


### PR DESCRIPTION
closes #51341

r? @nagisa 
cc @phil-opp 