### PR TITLE
[NLL] Use better span for initializing a variable twice

### DIFF
--- a/src/test/compile-fail/immut-function-arguments.rs
+++ b/src/test/compile-fail/immut-function-arguments.rs
@@ -13,12 +13,12 @@
 
 fn f(y: Box<isize>) {
     *y = 5; //[ast]~ ERROR cannot assign
-            //[mir]~^ ERROR cannot assign twice
+            //[mir]~^ ERROR cannot assign
 }
 
 fn g() {
     let _frob = |q: Box<isize>| { *q = 2; }; //[ast]~ ERROR cannot assign
-    //[mir]~^ ERROR cannot assign twice
+    //[mir]~^ ERROR cannot assign
 }
 
 fn main() {}

--- a/src/test/ui/command-line-diagnostics.nll.stderr
+++ b/src/test/ui/command-line-diagnostics.nll.stderr
@@ -2,8 +2,9 @@ error[E0384]: cannot assign twice to immutable variable `x`
   --> $DIR/command-line-diagnostics.rs:16:5
    |
 LL |     let x = 42;
-   |         -   -- first assignment to `x`
+   |         -
    |         |
+   |         first assignment to `x`
    |         consider changing this to `mut x`
 LL |     x = 43;
    |     ^^^^^^ cannot assign twice to immutable variable

--- a/src/test/ui/did_you_mean/issue-35937.nll.stderr
+++ b/src/test/ui/did_you_mean/issue-35937.nll.stderr
@@ -6,26 +6,24 @@ LL |     let f = Foo { v: Vec::new() };
 LL |     f.v.push("cat".to_string()); //~ ERROR cannot borrow
    |     ^^^ cannot borrow as mutable
 
-error[E0384]: cannot assign twice to immutable variable `s.x`
+error[E0384]: cannot assign twice to immutable variable `s`
   --> $DIR/issue-35937.rs:26:5
    |
 LL |     let s = S { x: 42 };
-   |         -   ----------- first assignment to `s.x`
+   |         -
    |         |
+   |         first assignment to `s`
    |         consider changing this to `mut s`
 LL |     s.x += 1; //~ ERROR cannot assign
    |     ^^^^^^^^ cannot assign twice to immutable variable
 
-error[E0384]: cannot assign twice to immutable variable `s.x`
+error[E0384]: cannot assign to immutable argument `s`
   --> $DIR/issue-35937.rs:30:5
    |
 LL | fn bar(s: S) {
-   |        -
-   |        |
-   |        first assignment to `s.x`
-   |        consider changing this to `mut s`
+   |        - consider changing this to `mut s`
 LL |     s.x += 1; //~ ERROR cannot assign
-   |     ^^^^^^^^ cannot assign twice to immutable variable
+   |     ^^^^^^^^ cannot assign to immutable argument
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Closes #51217

When assigning to a (projection from a) local immutable local which starts initialised (everything except `let PATTERN;`):

* Point to the declaration of that local
* Make the error message refer to the local, rather than the projection.

r? @nikomatsakis 