### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/src/libcore/future.rs
+++ b/src/libcore/future.rs
@@ -45,18 +45,18 @@ pub trait Future {
     ///
     /// This function returns:
     ///
-    /// - `Poll::Pending` if the future is not ready yet
-    /// - `Poll::Ready(val)` with the result `val` of this future if it finished
-    /// successfully.
+    /// - [`Poll::Pending`] if the future is not ready yet
+    /// - [`Poll::Ready(val)`] with the result `val` of this future if it
+    ///   finished successfully.
     ///
     /// Once a future has finished, clients should not `poll` it again.
     ///
     /// When a future is not ready yet, `poll` returns
-    /// [`Poll::Pending`](::task::Poll). The future will *also* register the
+    /// `Poll::Pending`. The future will *also* register the
     /// interest of the current task in the value being produced. For example,
     /// if the future represents the availability of data on a socket, then the
     /// task is recorded so that when data arrives, it is woken up (via
-    /// [`cx.waker()`](::task::Context::waker)). Once a task has been woken up,
+    /// [`cx.waker()`]). Once a task has been woken up,
     /// it should attempt to `poll` the future again, which may or may not
     /// produce a final value.
     ///
@@ -90,6 +90,10 @@ pub trait Future {
     /// then any future calls to `poll` may panic, block forever, or otherwise
     /// cause bad behavior. The `Future` trait itself provides no guarantees
     /// about the behavior of `poll` after a future has completed.
+    ///
+    /// [`Poll::Pending`]: ../task/enum.Poll.html#variant.Pending
+    /// [`Poll::Ready(val)`]: ../task/enum.Poll.html#variant.Ready
+    /// [`cx.waker()`]: ../task/struct.Context.html#method.waker
     fn poll(self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output>;
 }
 

--- a/src/libproc_macro/diagnostic.rs
+++ b/src/libproc_macro/diagnostic.rs
@@ -97,7 +97,7 @@ impl Diagnostic {
     /// Emit the diagnostic.
     #[unstable(feature = "proc_macro", issue = "38356")]
     pub fn emit(self) {
-        ::__internal::with_sess(move |(sess, _)| {
+        ::__internal::with_sess(move |sess, _| {
             let handler = &sess.span_diagnostic;
             let level = __internal::level_to_internal_level(self.level);
             let mut diag = rustc::DiagnosticBuilder::new(handler, level, &*self.message);

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -177,8 +177,6 @@ impl iter::FromIterator<TokenStream> for TokenStream {
 #[unstable(feature = "proc_macro", issue = "38356")]
 pub mod token_stream {
     use syntax::tokenstream;
-    use syntax_pos::DUMMY_SP;
-
     use {TokenTree, TokenStream, Delimiter};
 
     /// An iterator over `TokenStream`'s `TokenTree`s.
@@ -207,7 +205,7 @@ pub mod token_stream {
                 // need to flattened during iteration over stream's token trees.
                 // Eventually this needs to be removed in favor of keeping original token trees
                 // and not doing the roundtrip through AST.
-                if tree.span().0 == DUMMY_SP {
+                if tree.span().0.is_dummy() {
                     if let TokenTree::Group(ref group) = tree {
                         if group.delimiter() == Delimiter::None {
                             self.cursor.insert(group.stream.clone().0);

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -1434,9 +1434,12 @@ pub mod __internal {
         CURRENT_SESS.with(|p| {
             let _reset = Reset { prev: p.get() };
 
-            // No way to determine def location for a proc macro rigth now, so use call location.
+            // No way to determine def location for a proc macro right now, so use call location.
             let location = cx.current_expansion.mark.expn_info().unwrap().call_site;
             // Opaque mark was already created by expansion, now create its transparent twin.
+            // We can't use the call-site span literally here, even if it appears to provide
+            // correct name resolution, because it has all the `ExpnInfo` wrong, so the edition
+            // checks, lint macro checks, macro backtraces will all break.
             let opaque_mark = cx.current_expansion.mark;
             let transparent_mark = Mark::fresh_cloned(opaque_mark);
             transparent_mark.set_transparency(Transparency::Transparent);

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -486,12 +486,7 @@ impl Definitions {
     #[inline]
     pub fn opt_span(&self, def_id: DefId) -> Option<Span> {
         if def_id.krate == LOCAL_CRATE {
-            let span = self.def_index_to_span.get(&def_id.index).cloned().unwrap_or(DUMMY_SP);
-            if span != DUMMY_SP {
-                Some(span)
-            } else {
-                None
-            }
+            self.def_index_to_span.get(&def_id.index).cloned()
         } else {
             None
         }
@@ -588,8 +583,8 @@ impl Definitions {
             self.opaque_expansions_that_defined.insert(index, expansion);
         }
 
-        // The span is added if it isn't DUMMY_SP
-        if span != DUMMY_SP {
+        // The span is added if it isn't dummy
+        if !span.is_dummy() {
             self.def_index_to_span.insert(index, span);
         }
 

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -671,7 +671,14 @@ impl<'hir> Map<'hir> {
                 NodeTraitItem(ref trait_item) => Some(&trait_item.generics),
                 NodeItem(ref item) => {
                     match item.node {
-                        ItemFn(_, _, ref generics, _) => Some(generics),
+                        ItemFn(_, _, ref generics, _) |
+                        ItemTy(_, ref generics) |
+                        ItemEnum(_, ref generics) |
+                        ItemStruct(_, ref generics) |
+                        ItemUnion(_, ref generics) |
+                        ItemTrait(_, _, ref generics, ..) |
+                        ItemTraitAlias(ref generics, _) |
+                        ItemImpl(_, _, _, ref generics, ..) => Some(generics),
                         _ => None,
                     }
                 }

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -550,7 +550,7 @@ impl Generics {
 
     pub fn get_named(&self, name: &InternedString) -> Option<&GenericParam> {
         for param in &self.params {
-            if *name == param.name.name().as_interned_str() {
+            if *name == param.name.ident().as_interned_str() {
                 return Some(param);
             }
         }

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -31,7 +31,7 @@ use hir::def_id::{DefId, DefIndex, LocalDefId, CRATE_DEF_INDEX};
 use util::nodemap::{NodeMap, FxHashSet};
 use mir::mono::Linkage;
 
-use syntax_pos::{Span, DUMMY_SP};
+use syntax_pos::{Span, DUMMY_SP, symbol::InternedString};
 use syntax::codemap::{self, Spanned};
 use rustc_target::spec::abi::Abi;
 use syntax::ast::{self, CrateSugar, Ident, Name, NodeId, DUMMY_NODE_ID, AsmDialect};
@@ -546,6 +546,15 @@ impl Generics {
         }
 
         own_counts
+    }
+
+    pub fn get_named(&self, name: &InternedString) -> Option<&GenericParam> {
+        for param in &self.params {
+            if *name == param.name.name().as_interned_str() {
+                return Some(param);
+            }
+        }
+        None
     }
 }
 

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -232,6 +232,19 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                 }
                 (format!("the lifetime {} as defined on", br.name), sp)
             }
+            ty::ReFree(ty::FreeRegion {
+                bound_region: ty::BoundRegion::BrNamed(_, ref name), ..
+            }) => {
+                let mut sp = cm.def_span(self.hir.span(node));
+                if let Some(generics) = self.hir.get_generics(scope) {
+                    for param in &generics.params {
+                        if param.name.name().as_str() == name.as_str() {
+                            sp = param.span;
+                        }
+                    }
+                }
+                (format!("the lifetime {} as defined on", name), sp)
+            }
             ty::ReFree(ref fr) => match fr.bound_region {
                 ty::BrAnon(idx) => (
                     format!("the anonymous lifetime #{} defined on", idx + 1),

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -223,12 +223,10 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         let (prefix, span) = match *region {
             ty::ReEarlyBound(ref br) => {
                 let mut sp = cm.def_span(self.hir.span(node));
-                if let Some(generics) = self.hir.get_generics(scope) {
-                    for param in &generics.params {
-                        if param.name.name().as_str() == br.name.as_str() {
-                            sp = param.span;
-                        }
-                    }
+                if let Some(param) = self.hir.get_generics(scope).and_then(|generics| {
+                    generics.get_named(&br.name)
+                }) {
+                    sp = param.span;
                 }
                 (format!("the lifetime {} as defined on", br.name), sp)
             }
@@ -236,12 +234,10 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                 bound_region: ty::BoundRegion::BrNamed(_, ref name), ..
             }) => {
                 let mut sp = cm.def_span(self.hir.span(node));
-                if let Some(generics) = self.hir.get_generics(scope) {
-                    for param in &generics.params {
-                        if param.name.name().as_str() == name.as_str() {
-                            sp = param.span;
-                        }
-                    }
+                if let Some(param) = self.hir.get_generics(scope).and_then(|generics| {
+                    generics.get_named(&name)
+                }) {
+                    sp = param.span;
                 }
                 (format!("the lifetime {} as defined on", name), sp)
             }

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -20,7 +20,7 @@ use ty::{self, TyCtxt};
 use middle::privacy::AccessLevels;
 use session::DiagnosticMessageId;
 use syntax::symbol::Symbol;
-use syntax_pos::{Span, MultiSpan, DUMMY_SP};
+use syntax_pos::{Span, MultiSpan};
 use syntax::ast;
 use syntax::ast::{NodeId, Attribute};
 use syntax::feature_gate::{GateIssue, emit_feature_err, find_lang_feature_accepted_version};
@@ -687,7 +687,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                 let msp: MultiSpan = span.into();
                 let cm = &self.sess.parse_sess.codemap();
                 let span_key = msp.primary_span().and_then(|sp: Span|
-                    if sp != DUMMY_SP {
+                    if !sp.is_dummy() {
                         let file = cm.lookup_char_pos(sp.lo()).file;
                         if file.name.is_macros() {
                             None
@@ -725,7 +725,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Checker<'a, 'tcx> {
         match item.node {
             hir::ItemExternCrate(_) => {
                 // compiler-generated `extern crate` items have a dummy span.
-                if item.span == DUMMY_SP { return }
+                if item.span.is_dummy() { return }
 
                 let def_id = self.tcx.hir.local_def_id(item.id);
                 let cnum = match self.tcx.extern_mod_stmt_cnum(def_id) {

--- a/src/librustc/middle/weak_lang_items.rs
+++ b/src/librustc/middle/weak_lang_items.rs
@@ -112,9 +112,13 @@ fn verify<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         if missing.contains(&lang_items::$item) &&
            !whitelisted(tcx, lang_items::$item) &&
            items.$name().is_none() {
-            tcx.sess.err(&format!("language item required, but not found: `{}`",
-                                  stringify!($name)));
-
+            if lang_items::$item == lang_items::PanicImplLangItem {
+                tcx.sess.err(&format!("`#[panic_implementation]` function required, \
+                                        but not found"));
+            } else {
+                tcx.sess.err(&format!("language item required, but not found: `{}`",
+                                        stringify!($name)));
+            }
         }
     )*
 }

--- a/src/librustc/ty/query/plumbing.rs
+++ b/src/librustc/ty/query/plumbing.rs
@@ -708,7 +708,7 @@ macro_rules! define_queries {
 
             // FIXME(eddyb) Get more valid Span's on queries.
             pub fn default_span(&self, tcx: TyCtxt<'_, $tcx, '_>, span: Span) -> Span {
-                if span != DUMMY_SP {
+                if !span.is_dummy() {
                     return span;
                 }
                 // The def_span query is used to calculate default_span,

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -1662,7 +1662,7 @@ pub fn create_global_var_metadata(cx: &CodegenCx,
     let var_scope = get_namespace_for_item(cx, def_id);
     let span = tcx.def_span(def_id);
 
-    let (file_metadata, line_number) = if span != syntax_pos::DUMMY_SP {
+    let (file_metadata, line_number) = if !span.is_dummy() {
         let loc = span_start(cx, span);
         (file_metadata(cx, &loc.file.name, LOCAL_CRATE), loc.line as c_uint)
     } else {

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -219,7 +219,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CodegenCx<'a, 'tcx>,
     let span = mir.span;
 
     // This can be the case for functions inlined from another crate
-    if span == syntax_pos::DUMMY_SP {
+    if span.is_dummy() {
         // FIXME(simulacrum): Probably can't happen; remove.
         return FunctionDebugContext::FunctionWithoutDebugInfo;
     }

--- a/src/librustc_codegen_llvm/mir/constant.rs
+++ b/src/librustc_codegen_llvm/mir/constant.rs
@@ -118,7 +118,7 @@ pub fn const_alloc_to_llvm(cx: &CodegenCx, alloc: &Allocation) -> ValueRef {
 pub fn codegen_static_initializer<'a, 'tcx>(
     cx: &CodegenCx<'a, 'tcx>,
     def_id: DefId)
-    -> Result<ValueRef, Lrc<ConstEvalErr<'tcx>>>
+    -> Result<(ValueRef, &'tcx Allocation), Lrc<ConstEvalErr<'tcx>>>
 {
     let instance = ty::Instance::mono(cx.tcx, def_id);
     let cid = GlobalId {
@@ -132,7 +132,7 @@ pub fn codegen_static_initializer<'a, 'tcx>(
         ConstValue::ByRef(alloc, n) if n.bytes() == 0 => alloc,
         _ => bug!("static const eval returned {:#?}", static_),
     };
-    Ok(const_alloc_to_llvm(cx, alloc))
+    Ok((const_alloc_to_llvm(cx, alloc), alloc))
 }
 
 impl<'a, 'tcx> FunctionCx<'a, 'tcx> {

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -10,7 +10,7 @@
 
 use self::Destination::*;
 
-use syntax_pos::{DUMMY_SP, FileMap, Span, MultiSpan};
+use syntax_pos::{FileMap, Span, MultiSpan};
 
 use {Level, CodeSuggestion, DiagnosticBuilder, SubDiagnostic, CodeMapperDyn, DiagnosticId};
 use snippet::{Annotation, AnnotationType, Line, MultilineAnnotation, StyledString, Style};
@@ -216,7 +216,7 @@ impl EmitterWriter {
 
         if let Some(ref cm) = self.cm {
             for span_label in msp.span_labels() {
-                if span_label.span == DUMMY_SP {
+                if span_label.span.is_dummy() {
                     continue;
                 }
 
@@ -730,7 +730,7 @@ impl EmitterWriter {
         let mut max = 0;
         if let Some(ref cm) = self.cm {
             for primary_span in msp.primary_spans() {
-                if primary_span != &DUMMY_SP {
+                if !primary_span.is_dummy() {
                     let hi = cm.lookup_char_pos(primary_span.hi());
                     if hi.line > max {
                         max = hi.line;
@@ -739,7 +739,7 @@ impl EmitterWriter {
             }
             if !self.short_message {
                 for span_label in msp.span_labels() {
-                    if span_label.span != DUMMY_SP {
+                    if !span_label.span.is_dummy() {
                         let hi = cm.lookup_char_pos(span_label.span.hi());
                         if hi.line > max {
                             max = hi.line;
@@ -778,7 +778,7 @@ impl EmitterWriter {
 
             // First, find all the spans in <*macros> and point instead at their use site
             for sp in span.primary_spans() {
-                if *sp == DUMMY_SP {
+                if sp.is_dummy() {
                     continue;
                 }
                 let call_sp = cm.call_span_if_macro(*sp);
@@ -790,7 +790,7 @@ impl EmitterWriter {
                     // Only show macro locations that are local
                     // and display them like a span_note
                     if let Some(def_site) = trace.def_site_span {
-                        if def_site == DUMMY_SP {
+                        if def_site.is_dummy() {
                             continue;
                         }
                         if always_backtrace {
@@ -830,7 +830,7 @@ impl EmitterWriter {
                 span.push_span_label(label_span, label_text);
             }
             for sp_label in span.span_labels() {
-                if sp_label.span == DUMMY_SP {
+                if sp_label.span.is_dummy() {
                     continue;
                 }
                 if cm.span_to_filename(sp_label.span.clone()).is_macros() &&
@@ -1003,7 +1003,7 @@ impl EmitterWriter {
         // Make sure our primary file comes first
         let (primary_lo, cm) = if let (Some(cm), Some(ref primary_span)) =
             (self.cm.as_ref(), msp.primary_span().as_ref()) {
-            if primary_span != &&DUMMY_SP {
+            if !primary_span.is_dummy() {
                 (cm.lookup_char_pos(primary_span.lo()), cm)
             } else {
                 emit_to_destination(&buffer.render(), level, &mut self.dst, self.short_message)?;

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -569,9 +569,11 @@ impl<'a> CrateLoader<'a> {
             fn register_bang_proc_macro(&mut self,
                                         name: &str,
                                         expand: fn(TokenStream) -> TokenStream) {
-                let expand = SyntaxExtension::ProcMacro(
-                    Box::new(BangProcMacro { inner: expand }), false, self.edition
-                );
+                let expand = SyntaxExtension::ProcMacro {
+                    expander: Box::new(BangProcMacro { inner: expand }),
+                    allow_internal_unstable: false,
+                    edition: self.edition,
+                };
                 self.extensions.push((Symbol::intern(name), Lrc::new(expand)));
             }
         }

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -518,8 +518,11 @@ impl CrateStore for cstore::CStore {
             return LoadedMacro::ProcMacro(proc_macros[id.index.to_proc_macro_index()].1.clone());
         } else if data.name == "proc_macro" &&
                   self.get_crate_data(id.krate).item_name(id.index) == "quote" {
-            let ext = SyntaxExtension::ProcMacro(Box::new(::proc_macro::__internal::Quoter),
-                                                 true, data.root.edition);
+            let ext = SyntaxExtension::ProcMacro {
+                expander: Box::new(::proc_macro::__internal::Quoter),
+                allow_internal_unstable: true,
+                edition: data.root.edition,
+            };
             return LoadedMacro::ProcMacro(Lrc::new(ext));
         }
 

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -41,7 +41,7 @@ use std::u32;
 use syntax::ast::{self, CRATE_NODE_ID};
 use syntax::attr;
 use syntax::symbol::keywords;
-use syntax_pos::{self, hygiene, FileName, FileMap, Span, DUMMY_SP};
+use syntax_pos::{self, hygiene, FileName, FileMap, Span};
 
 use rustc::hir::{self, PatKind};
 use rustc::hir::itemlikevisit::ItemLikeVisitor;
@@ -147,7 +147,7 @@ impl<'a, 'tcx> SpecializedEncoder<DefIndex> for EncodeContext<'a, 'tcx> {
 
 impl<'a, 'tcx> SpecializedEncoder<Span> for EncodeContext<'a, 'tcx> {
     fn specialized_encode(&mut self, span: &Span) -> Result<(), Self::Error> {
-        if *span == DUMMY_SP {
+        if span.is_dummy() {
             return TAG_INVALID_SPAN.encode(self)
         }
 

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -190,7 +190,7 @@ struct TypeVerifier<'a, 'b: 'a, 'gcx: 'b + 'tcx, 'tcx: 'b> {
 
 impl<'a, 'b, 'gcx, 'tcx> Visitor<'tcx> for TypeVerifier<'a, 'b, 'gcx, 'tcx> {
     fn visit_span(&mut self, span: &Span) {
-        if *span != DUMMY_SP {
+        if !span.is_dummy() {
             self.last_span = *span;
         }
     }
@@ -1601,7 +1601,7 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
                 statement_index: 0,
             };
             for stmt in &block_data.statements {
-                if stmt.source_info.span != DUMMY_SP {
+                if !stmt.source_info.span.is_dummy() {
                     self.last_span = stmt.source_info.span;
                 }
                 self.check_stmt(mir, stmt, location);

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -172,12 +172,27 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
             ExprKind::InlineAsm(..) if !self.session.target.target.options.allow_asm => {
                 span_err!(self.session, expr.span, E0472, "asm! is unsupported on this target");
             }
-            ExprKind::ObsoleteInPlace(..) => {
-                self.err_handler()
-                    .struct_span_err(expr.span, "emplacement syntax is obsolete (for now, anyway)")
-                    .note("for more information, see \
-                           <https://github.com/rust-lang/rust/issues/27779#issuecomment-378416911>")
-                    .emit();
+            ExprKind::ObsoleteInPlace(ref place, ref val) => {
+                let mut err = self.err_handler().struct_span_err(
+                    expr.span,
+                    "emplacement syntax is obsolete (for now, anyway)",
+                );
+                err.note(
+                    "for more information, see \
+                     <https://github.com/rust-lang/rust/issues/27779#issuecomment-378416911>"
+                );
+                match val.node {
+                    ExprKind::Lit(ref v) if v.node.is_numeric() => {
+                        err.span_suggestion(
+                            place.span.between(val.span),
+                            "if you meant to write a comparison against a negative value, add a \
+                             space in between `<` and `-`",
+                            "< -".to_string(),
+                        );
+                    }
+                    _ => {}
+                }
+                err.emit();
             }
             _ => {}
         }

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -156,7 +156,7 @@ impl<'a> Resolver<'a> {
 
                     // Disallow `use $crate;`
                     if source.name == keywords::DollarCrate.name() && path.segments.len() == 1 {
-                        let crate_root = self.resolve_crate_root(source.span.ctxt(), true);
+                        let crate_root = self.resolve_crate_root(source);
                         let crate_name = match crate_root.kind {
                             ModuleKind::Def(_, name) => name,
                             ModuleKind::Block(..) => unreachable!(),

--- a/src/librustc_resolve/check_unused.rs
+++ b/src/librustc_resolve/check_unused.rs
@@ -86,7 +86,7 @@ impl<'a, 'b> Visitor<'a> for UnusedImportCheckVisitor<'a, 'b> {
         // because this means that they were generated in some fashion by the
         // compiler and we don't need to consider them.
         if let ast::ItemKind::Use(..) = item.node {
-            if item.vis.node == ast::VisibilityKind::Public || item.span.source_equal(&DUMMY_SP) {
+            if item.vis.node == ast::VisibilityKind::Public || item.span.is_dummy() {
                 return;
             }
         }
@@ -129,7 +129,7 @@ pub fn check_crate(resolver: &mut Resolver, krate: &ast::Crate) {
         match directive.subclass {
             _ if directive.used.get() ||
                  directive.vis.get() == ty::Visibility::Public ||
-                 directive.span.source_equal(&DUMMY_SP) => {}
+                 directive.span.is_dummy() => {}
             ImportDirectiveSubclass::ExternCrate(_) => {
                 resolver.maybe_unused_extern_crates.push((directive.id, directive.span));
             }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2005,10 +2005,9 @@ impl<'a> Resolver<'a> {
                 }
             }
             // Then find the last legacy mark from the end if it exists.
-            while let Some(&mark) = iter.peek() {
+            for mark in iter {
                 if mark.transparency() == Transparency::SemiTransparent {
                     result = Some(mark);
-                    iter.next();
                 } else {
                     break;
                 }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2861,7 +2861,7 @@ impl<'a> Resolver<'a> {
                     .map(|suggestion| import_candidate_to_paths(&suggestion)).collect::<Vec<_>>();
                 enum_candidates.sort();
                 for (sp, variant_path, enum_path) in enum_candidates {
-                    if sp == DUMMY_SP {
+                    if sp.is_dummy() {
                         let msg = format!("there is an enum variant `{}`, \
                                         try using `{}`?",
                                         variant_path,
@@ -4285,7 +4285,7 @@ impl<'a> Resolver<'a> {
             let mut err = struct_span_err!(self.session, span, E0659, "`{}` is ambiguous", name);
             err.span_note(b1.span, &msg1);
             match b2.def() {
-                Def::Macro(..) if b2.span == DUMMY_SP =>
+                Def::Macro(..) if b2.span.is_dummy() =>
                     err.note(&format!("`{}` is also a builtin macro", name)),
                 _ => err.span_note(b2.span, &msg2),
             };
@@ -4398,14 +4398,14 @@ impl<'a> Resolver<'a> {
                           container));
 
         err.span_label(span, format!("`{}` re{} here", name, new_participle));
-        if old_binding.span != DUMMY_SP {
+        if !old_binding.span.is_dummy() {
             err.span_label(self.session.codemap().def_span(old_binding.span),
                            format!("previous {} of the {} `{}` here", old_noun, old_kind, name));
         }
 
         // See https://github.com/rust-lang/rust/issues/32354
         if old_binding.is_import() || new_binding.is_import() {
-            let binding = if new_binding.is_import() && new_binding.span != DUMMY_SP {
+            let binding = if new_binding.is_import() && !new_binding.span.is_dummy() {
                 new_binding
             } else {
                 old_binding

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -332,7 +332,9 @@ impl<'a> base::Resolver for Resolver<'a> {
         self.unused_macros.remove(&def_id);
         let ext = self.get_macro(def);
         if ext.is_modern() {
-            invoc.expansion_data.mark.set_transparency(Transparency::Opaque);
+            let transparency =
+                if ext.is_transparent() { Transparency::Transparent } else { Transparency::Opaque };
+            invoc.expansion_data.mark.set_transparency(transparency);
         } else if def_id.krate == BUILTIN_MACROS_CRATE {
             invoc.expansion_data.mark.set_is_builtin(true);
         }

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -155,10 +155,9 @@ impl<'a> base::Resolver for Resolver<'a> {
                     }
                 });
 
-                let ident = path.segments[0].ident;
-                if ident.name == keywords::DollarCrate.name() {
+                if path.segments[0].ident.name == keywords::DollarCrate.name() {
+                    let module = self.0.resolve_crate_root(path.segments[0].ident);
                     path.segments[0].ident.name = keywords::CrateRoot.name();
-                    let module = self.0.resolve_crate_root(ident.span.ctxt(), true);
                     if !module.is_local() {
                         let span = path.segments[0].ident.span;
                         path.segments.insert(1, match module.kind {

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -698,7 +698,7 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
                                          "crate root imports need to be explicitly named: \
                                           `use crate as name;`".to_string()));
                         } else {
-                            Some(self.resolve_crate_root(source.span.ctxt().modern(), false))
+                            Some(self.resolve_crate_root(source))
                         }
                     } else if is_extern && !source.is_path_segment_keyword() {
                         let crate_id =

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -1157,7 +1157,7 @@ fn escape(s: String) -> String {
 // Helper function to determine if a span came from a
 // macro expansion or syntax extension.
 fn generated_code(span: Span) -> bool {
-    span.ctxt() != NO_EXPANSION || span == DUMMY_SP
+    span.ctxt() != NO_EXPANSION || span.is_dummy()
 }
 
 // DefId::index is a newtype and so the JSON serialisation is ugly. Therefore

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -245,12 +245,11 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                             "f32"
                         };
                         match expr.node {
-                            hir::ExprLit(_) => {  // numeric literal
-                                let snippet = tcx.sess.codemap().span_to_snippet(expr.span)
+                            hir::ExprLit(ref lit) => {  // numeric literal
+                                let snippet = tcx.sess.codemap().span_to_snippet(lit.span)
                                     .unwrap_or("<numeric literal>".to_string());
-                                // FIXME: use the literal for missing snippet
 
-                                err.span_suggestion(expr.span,
+                                err.span_suggestion(lit.span,
                                                     &format!("you must specify a concrete type for \
                                                               this numeric value, like `{}`",
                                                              concrete_type),

--- a/src/librustc_typeck/check_unused.rs
+++ b/src/librustc_typeck/check_unused.rs
@@ -12,7 +12,7 @@ use lint;
 use rustc::ty::TyCtxt;
 
 use syntax::ast;
-use syntax_pos::{Span, DUMMY_SP};
+use syntax_pos::Span;
 
 use rustc::hir::def_id::{DefId, LOCAL_CRATE};
 use rustc::hir::itemlikevisit::ItemLikeVisitor;
@@ -39,7 +39,7 @@ pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
 
 impl<'a, 'tcx, 'v> ItemLikeVisitor<'v> for CheckVisitor<'a, 'tcx> {
     fn visit_item(&mut self, item: &hir::Item) {
-        if item.vis == hir::Public || item.span == DUMMY_SP {
+        if item.vis == hir::Public || item.span.is_dummy() {
             return;
         }
         if let hir::ItemUse(ref path, _) = item.node {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1219,7 +1219,7 @@ fn macro_resolve(cx: &DocContext, path_str: &str) -> Option<Def> {
     let res = resolver
         .resolve_macro_to_def_inner(mark, &path, MacroKind::Bang, false);
     if let Ok(def) = res {
-        if let SyntaxExtension::DeclMacro(..) = *resolver.get_macro(def) {
+        if let SyntaxExtension::DeclMacro { .. } = *resolver.get_macro(def) {
             Some(def)
         } else {
             None

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -3464,7 +3464,7 @@ impl Span {
 
 impl Clean<Span> for syntax_pos::Span {
     fn clean(&self, cx: &DocContext) -> Span {
-        if *self == DUMMY_SP {
+        if self.is_dummy() {
             return Span::empty();
         }
 

--- a/src/libstd/alloc.rs
+++ b/src/libstd/alloc.rs
@@ -61,7 +61,7 @@
 //! ```rust,ignore (demonstrates crates.io usage)
 //! extern crate jemallocator;
 //!
-//! use jemallacator::Jemalloc;
+//! use jemallocator::Jemalloc;
 //!
 //! #[global_allocator]
 //! static GLOBAL: Jemalloc = Jemalloc;

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -49,6 +49,7 @@ use string;
 ///
 /// [`Result<T, E>`]: ../result/enum.Result.html
 /// [`Display`]: ../fmt/trait.Display.html
+/// [`Debug`]: ../fmt/trait.Debug.html
 /// [`cause`]: trait.Error.html#method.cause
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Error: Debug + Display {

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -417,14 +417,14 @@ impl PartialEq<OsString> for str {
     }
 }
 
-#[stable(feature = "rust1", since = "1.28.0")]
+#[stable(feature = "os_str_str_ref_eq", since = "1.28.0")]
 impl<'a> PartialEq<&'a str> for OsString {
     fn eq(&self, other: &&'a str) -> bool {
         **self == **other
     }
 }
 
-#[stable(feature = "rust1", since = "1.28.0")]
+#[stable(feature = "os_str_str_ref_eq", since = "1.28.0")]
 impl<'a> PartialEq<OsString> for &'a str {
     fn eq(&self, other: &OsString) -> bool {
         **other == **self

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -417,6 +417,20 @@ impl PartialEq<OsString> for str {
     }
 }
 
+#[stable(feature = "rust1", since = "1.28.0")]
+impl<'a> PartialEq<&'a str> for OsString {
+    fn eq(&self, other: &&'a str) -> bool {
+        **self == **other
+    }
+}
+
+#[stable(feature = "rust1", since = "1.28.0")]
+impl<'a> PartialEq<OsString> for &'a str {
+    fn eq(&self, other: &OsString) -> bool {
+        **other == **self
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Eq for OsString {}
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1298,6 +1298,16 @@ impl LitKind {
         }
     }
 
+    /// Returns true if this is a numeric literal.
+    pub fn is_numeric(&self) -> bool {
+        match *self {
+            LitKind::Int(..) |
+            LitKind::Float(..) |
+            LitKind::FloatUnsuffixed(..) => true,
+            _ => false,
+        }
+    }
+
     /// Returns true if this literal has no suffix. Note: this will return true
     /// for literals with prefixes such as raw strings and byte strings.
     pub fn is_unsuffixed(&self) -> bool {

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -443,7 +443,7 @@ impl CodeMap {
     }
 
     pub fn span_to_string(&self, sp: Span) -> String {
-        if self.files.borrow().file_maps.is_empty() && sp.source_equal(&DUMMY_SP) {
+        if self.files.borrow().file_maps.is_empty() && sp.is_dummy() {
             return "no-location".to_string();
         }
 

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -649,6 +649,7 @@ pub enum SyntaxExtension {
     DeclMacro {
         expander: Box<TTMacroExpander + sync::Sync + sync::Send>,
         def_info: Option<(ast::NodeId, Span)>,
+        is_transparent: bool,
         edition: Edition,
     }
 }
@@ -678,6 +679,13 @@ impl SyntaxExtension {
             SyntaxExtension::ProcMacro { .. } |
             SyntaxExtension::AttrProcMacro(..) |
             SyntaxExtension::ProcMacroDerive(..) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_transparent(&self) -> bool {
+        match *self {
+            SyntaxExtension::DeclMacro { is_transparent, .. } => is_transparent,
             _ => false,
         }
     }

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -597,11 +597,11 @@ pub enum SyntaxExtension {
     MultiModifier(Box<MultiItemModifier + sync::Sync + sync::Send>),
 
     /// A function-like procedural macro. TokenStream -> TokenStream.
-    ProcMacro(
-        /* expander: */ Box<ProcMacro + sync::Sync + sync::Send>,
-        /* allow_internal_unstable: */ bool,
-        /* edition: */ Edition,
-    ),
+    ProcMacro {
+        expander: Box<ProcMacro + sync::Sync + sync::Send>,
+        allow_internal_unstable: bool,
+        edition: Edition,
+    },
 
     /// An attribute-like procedural macro. TokenStream, TokenStream -> TokenStream.
     /// The first TokenSteam is the attribute, the second is the annotated item.
@@ -646,19 +646,21 @@ pub enum SyntaxExtension {
     BuiltinDerive(BuiltinDeriveFn),
 
     /// A declarative macro, e.g. `macro m() {}`.
-    ///
-    /// The second element is the definition site span.
-    DeclMacro(Box<TTMacroExpander + sync::Sync + sync::Send>, Option<(ast::NodeId, Span)>, Edition),
+    DeclMacro {
+        expander: Box<TTMacroExpander + sync::Sync + sync::Send>,
+        def_info: Option<(ast::NodeId, Span)>,
+        edition: Edition,
+    }
 }
 
 impl SyntaxExtension {
     /// Return which kind of macro calls this syntax extension.
     pub fn kind(&self) -> MacroKind {
         match *self {
-            SyntaxExtension::DeclMacro(..) |
+            SyntaxExtension::DeclMacro { .. } |
             SyntaxExtension::NormalTT { .. } |
             SyntaxExtension::IdentTT(..) |
-            SyntaxExtension::ProcMacro(..) =>
+            SyntaxExtension::ProcMacro { .. } =>
                 MacroKind::Bang,
             SyntaxExtension::MultiDecorator(..) |
             SyntaxExtension::MultiModifier(..) |
@@ -672,8 +674,8 @@ impl SyntaxExtension {
 
     pub fn is_modern(&self) -> bool {
         match *self {
-            SyntaxExtension::DeclMacro(..) |
-            SyntaxExtension::ProcMacro(..) |
+            SyntaxExtension::DeclMacro { .. } |
+            SyntaxExtension::ProcMacro { .. } |
             SyntaxExtension::AttrProcMacro(..) |
             SyntaxExtension::ProcMacroDerive(..) => true,
             _ => false,
@@ -683,8 +685,8 @@ impl SyntaxExtension {
     pub fn edition(&self) -> Edition {
         match *self {
             SyntaxExtension::NormalTT { edition, .. } |
-            SyntaxExtension::DeclMacro(.., edition) |
-            SyntaxExtension::ProcMacro(.., edition) |
+            SyntaxExtension::DeclMacro { edition, .. } |
+            SyntaxExtension::ProcMacro { edition, .. } |
             SyntaxExtension::AttrProcMacro(.., edition) |
             SyntaxExtension::ProcMacroDerive(.., edition) => edition,
             // Unstable legacy stuff

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1297,7 +1297,7 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
                 // Detect if this is an inline module (`mod m { ... }` as opposed to `mod m;`).
                 // In the non-inline case, `inner` is never the dummy span (c.f. `parse_item_mod`).
                 // Thus, if `inner` is the dummy span, we know the module is inline.
-                let inline_module = item.span.contains(inner) || inner == DUMMY_SP;
+                let inline_module = item.span.contains(inner) || inner.is_dummy();
 
                 if inline_module {
                     if let Some(path) = attr::first_attr_value_str_by_name(&item.attrs, "path") {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -738,13 +738,13 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
         };
 
         let opt_expanded = match *ext {
-            DeclMacro(ref expand, def_span, edition) => {
-                if let Err(dummy_span) = validate_and_set_expn_info(self, def_span.map(|(_, s)| s),
+            DeclMacro { ref expander, def_info, edition } => {
+                if let Err(dummy_span) = validate_and_set_expn_info(self, def_info.map(|(_, s)| s),
                                                                     false, false, false, None,
                                                                     edition) {
                     dummy_span
                 } else {
-                    kind.make_from(expand.expand(self.cx, span, mac.node.stream()))
+                    kind.make_from(expander.expand(self.cx, span, mac.node.stream()))
                 }
             }
 
@@ -804,7 +804,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                 kind.dummy(span)
             }
 
-            ProcMacro(ref expandfun, allow_internal_unstable, edition) => {
+            SyntaxExtension::ProcMacro { ref expander, allow_internal_unstable, edition } => {
                 if ident.name != keywords::Invalid.name() {
                     let msg =
                         format!("macro {}! expects no ident argument, given '{}'", path, ident);
@@ -826,7 +826,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                         edition,
                     });
 
-                    let tok_result = expandfun.expand(self.cx, span, mac.node.stream());
+                    let tok_result = expander.expand(self.cx, span, mac.node.stream());
                     let result = self.parse_ast_fragment(tok_result, kind, path, span);
                     self.gate_proc_macro_expansion(span, &result);
                     result

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -738,7 +738,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
         };
 
         let opt_expanded = match *ext {
-            DeclMacro { ref expander, def_info, edition } => {
+            DeclMacro { ref expander, def_info, edition, .. } => {
                 if let Err(dummy_span) = validate_and_set_expn_info(self, def_info.map(|(_, s)| s),
                                                                     false, false, false, None,
                                                                     edition) {

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -312,9 +312,12 @@ pub fn compile(sess: &ParseSess, features: &Features, def: &ast::Item, edition: 
             edition,
         }
     } else {
+        let is_transparent = attr::contains_name(&def.attrs, "rustc_transparent_macro");
+
         SyntaxExtension::DeclMacro {
             expander,
             def_info: Some((def.id, def.span)),
+            is_transparent,
             edition,
         }
     }

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -312,7 +312,11 @@ pub fn compile(sess: &ParseSess, features: &Features, def: &ast::Item, edition: 
             edition,
         }
     } else {
-        SyntaxExtension::DeclMacro(expander, Some((def.id, def.span)), edition)
+        SyntaxExtension::DeclMacro {
+            expander,
+            def_info: Some((def.id, def.span)),
+            edition,
+        }
     }
 }
 

--- a/src/libsyntax/ext/tt/quoted.rs
+++ b/src/libsyntax/ext/tt/quoted.rs
@@ -14,7 +14,7 @@ use feature_gate::{self, emit_feature_err, Features, GateIssue};
 use parse::{token, ParseSess};
 use print::pprust;
 use symbol::keywords;
-use syntax_pos::{BytePos, Span, DUMMY_SP};
+use syntax_pos::{BytePos, Span};
 use tokenstream;
 
 use std::iter::Peekable;
@@ -41,8 +41,8 @@ impl Delimited {
 
     /// Return a `self::TokenTree` with a `Span` corresponding to the opening delimiter.
     pub fn open_tt(&self, span: Span) -> TokenTree {
-        let open_span = if span == DUMMY_SP {
-            DUMMY_SP
+        let open_span = if span.is_dummy() {
+            span
         } else {
             span.with_lo(span.lo() + BytePos(self.delim.len() as u32))
         };
@@ -51,8 +51,8 @@ impl Delimited {
 
     /// Return a `self::TokenTree` with a `Span` corresponding to the closing delimiter.
     pub fn close_tt(&self, span: Span) -> TokenTree {
-        let close_span = if span == DUMMY_SP {
-            DUMMY_SP
+        let close_span = if span.is_dummy() {
+            span
         } else {
             span.with_lo(span.hi() - BytePos(self.delim.len() as u32))
         };

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -13,7 +13,7 @@
 use rustc_data_structures::sync::{Lrc, Lock};
 use ast::{self, CrateConfig};
 use codemap::{CodeMap, FilePathMapping};
-use syntax_pos::{self, Span, FileMap, NO_EXPANSION, FileName};
+use syntax_pos::{Span, FileMap, FileName};
 use errors::{Handler, ColorConfig, DiagnosticBuilder};
 use feature_gate::UnstableFeatures;
 use parse::parser::Parser;
@@ -188,8 +188,8 @@ fn filemap_to_parser(sess: & ParseSess, filemap: Lrc<FileMap>) -> Parser {
     let end_pos = filemap.end_pos;
     let mut parser = stream_to_parser(sess, filemap_to_stream(sess, filemap, None));
 
-    if parser.token == token::Eof && parser.span == syntax_pos::DUMMY_SP {
-        parser.span = Span::new(end_pos, end_pos, NO_EXPANSION);
+    if parser.token == token::Eof && parser.span.is_dummy() {
+        parser.span = Span::new(end_pos, end_pos, parser.span.ctxt());
     }
 
     parser

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -43,7 +43,7 @@ use ast::{BinOpKind, UnOp};
 use ast::{RangeEnd, RangeSyntax};
 use {ast, attr};
 use codemap::{self, CodeMap, Spanned, respan};
-use syntax_pos::{self, Span, MultiSpan, BytePos, FileName, DUMMY_SP, edition::Edition};
+use syntax_pos::{self, Span, MultiSpan, BytePos, FileName, edition::Edition};
 use errors::{self, Applicability, DiagnosticBuilder};
 use parse::{self, SeqSep, classify, token};
 use parse::lexer::TokenAndSpan;
@@ -567,7 +567,7 @@ impl<'a> Parser<'a> {
 
         if let Some(directory) = directory {
             parser.directory = directory;
-        } else if !parser.span.source_equal(&DUMMY_SP) {
+        } else if !parser.span.is_dummy() {
             if let FileName::Real(mut path) = sess.codemap().span_to_unmapped_path(parser.span) {
                 path.pop();
                 parser.directory.path = Cow::from(path);
@@ -584,7 +584,7 @@ impl<'a> Parser<'a> {
         } else {
             self.token_cursor.next()
         };
-        if next.sp == syntax_pos::DUMMY_SP {
+        if next.sp.is_dummy() {
             // Tweak the location for better diagnostics, but keep syntactic context intact.
             next.sp = self.prev_span.with_ctxt(next.sp.ctxt());
         }
@@ -6137,7 +6137,7 @@ impl<'a> Parser<'a> {
             return Err(err);
         }
 
-        let hi = if self.span == syntax_pos::DUMMY_SP {
+        let hi = if self.span.is_dummy() {
             inner_lo
         } else {
             self.prev_span
@@ -6368,7 +6368,7 @@ impl<'a> Parser<'a> {
                 }
                 let mut err = self.diagnostic().struct_span_err(id_sp,
                     "cannot declare a new module at this location");
-                if id_sp != syntax_pos::DUMMY_SP {
+                if !id_sp.is_dummy() {
                     let src_path = self.sess.codemap().span_to_filename(id_sp);
                     if let FileName::Real(src_path) = src_path {
                         if let Some(stem) = src_path.file_stem() {

--- a/src/libsyntax/tokenstream.rs
+++ b/src/libsyntax/tokenstream.rs
@@ -57,8 +57,8 @@ impl Delimited {
 
     /// Returns the opening delimiter as a token tree.
     pub fn open_tt(&self, span: Span) -> TokenTree {
-        let open_span = if span == DUMMY_SP {
-            DUMMY_SP
+        let open_span = if span.is_dummy() {
+            span
         } else {
             span.with_hi(span.lo() + BytePos(self.delim.len() as u32))
         };
@@ -67,8 +67,8 @@ impl Delimited {
 
     /// Returns the closing delimiter as a token tree.
     pub fn close_tt(&self, span: Span) -> TokenTree {
-        let close_span = if span == DUMMY_SP {
-            DUMMY_SP
+        let close_span = if span.is_dummy() {
+            span
         } else {
             span.with_lo(span.hi() - BytePos(self.delim.len() as u32))
         };

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -57,7 +57,6 @@ struct MarkData {
 pub enum Transparency {
     /// Identifier produced by a transparent expansion is always resolved at call-site.
     /// Call-site spans in procedural macros, hygiene opt-out in `macro` should use this.
-    /// (Not used yet.)
     Transparent,
     /// Identifier produced by a semi-transparent expansion may be resolved
     /// either at call-site or at definition-site.

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -248,6 +248,13 @@ impl Span {
         self.data().with_ctxt(ctxt)
     }
 
+    /// Returns `true` if this is a dummy span with any hygienic context.
+    #[inline]
+    pub fn is_dummy(self) -> bool {
+        let span = self.data();
+        span.lo.0 == 0 && span.hi.0 == 0
+    }
+
     /// Returns a new span representing an empty span at the beginning of this span
     #[inline]
     pub fn shrink_to_lo(self) -> Span {
@@ -263,7 +270,7 @@ impl Span {
 
     /// Returns `self` if `self` is not the dummy span, and `other` otherwise.
     pub fn substitute_dummy(self, other: Span) -> Span {
-        if self.source_equal(&DUMMY_SP) { other } else { self }
+        if self.is_dummy() { other } else { self }
     }
 
     /// Return true if `self` fully encloses `other`.

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -491,6 +491,12 @@ impl Span {
         let span = self.data();
         span.with_ctxt(span.ctxt.modern())
     }
+
+    #[inline]
+    pub fn modern_and_legacy(self) -> Span {
+        let span = self.data();
+        span.with_ctxt(span.ctxt.modern_and_legacy())
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -68,11 +68,11 @@ impl Ident {
         Ident::new(self.name, self.span.modern())
     }
 
-    // "Normalize" ident for use in comparisons using "local variable hygiene".
-    // Identifiers with same string value become same if they came from the same non-transparent
-    // macro (e.g. `macro` or `macro_rules!` items) and stay different if they came from different
-    // non-transparent macros.
-    // Technically, this operation strips all transparent marks from ident's syntactic context.
+    /// "Normalize" ident for use in comparisons using "local variable hygiene".
+    /// Identifiers with same string value become same if they came from the same non-transparent
+    /// macro (e.g. `macro` or `macro_rules!` items) and stay different if they came from different
+    /// non-transparent macros.
+    /// Technically, this operation strips all transparent marks from ident's syntactic context.
     pub fn modern_and_legacy(self) -> Ident {
         Ident::new(self.name, self.span.modern_and_legacy())
     }

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -68,6 +68,15 @@ impl Ident {
         Ident::new(self.name, self.span.modern())
     }
 
+    // "Normalize" ident for use in comparisons using "local variable hygiene".
+    // Identifiers with same string value become same if they came from the same non-transparent
+    // macro (e.g. `macro` or `macro_rules!` items) and stay different if they came from different
+    // non-transparent macros.
+    // Technically, this operation strips all transparent marks from ident's syntactic context.
+    pub fn modern_and_legacy(self) -> Ident {
+        Ident::new(self.name, self.span.modern_and_legacy())
+    }
+
     pub fn gensym(self) -> Ident {
         Ident::new(self.name.gensymed(), self.span)
     }

--- a/src/test/codegen/issue-44056-macos-tls-align.rs
+++ b/src/test/codegen/issue-44056-macos-tls-align.rs
@@ -1,0 +1,40 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-tidy-linelength
+// only-macos
+// no-system-llvm
+// min-llvm-version 6.0
+// compile-flags: -O
+
+#![crate_type = "rlib"]
+#![feature(thread_local)]
+
+// CHECK: @STATIC_VAR_1 = internal thread_local unnamed_addr global <{ [32 x i8] }> zeroinitializer, section "__DATA,__thread_bss", align 8
+#[no_mangle]
+#[allow(private_no_mangle_statics)]
+#[thread_local]
+static mut STATIC_VAR_1: [u64; 4] = [0; 4];
+
+// CHECK: @STATIC_VAR_2 = internal thread_local unnamed_addr global <{ [32 x i8] }> <{{[^>]*}}>, section "__DATA,__thread_data", align 8
+#[no_mangle]
+#[allow(private_no_mangle_statics)]
+#[thread_local]
+static mut STATIC_VAR_2: [u64; 4] = [4; 4];
+
+#[no_mangle]
+pub unsafe fn f(x: &mut [u64; 4]) {
+    std::mem::swap(x, &mut STATIC_VAR_1)
+}
+
+#[no_mangle]
+pub unsafe fn g(x: &mut [u64; 4]) {
+    std::mem::swap(x, &mut STATIC_VAR_2)
+}

--- a/src/test/compile-fail/issue-36122.rs
+++ b/src/test/compile-fail/issue-36122.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-tidy-linelength
+
+fn main() {
+    extern "C" {
+        static symbol: [usize];
+        //~^ ERROR the size for value values of type `[usize]` cannot be known at compilation time [E0277]
+    }
+
+    unsafe {
+        println!("{}", symbol[0]);
+    }
+}

--- a/src/test/compile-fail/panic-implementation-missing.rs
+++ b/src/test/compile-fail/panic-implementation-missing.rs
@@ -1,0 +1,18 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: `#[panic_implementation]` function required, but not found
+
+#![feature(lang_items)]
+#![no_main]
+#![no_std]
+
+#[lang = "eh_personality"]
+fn eh() {}

--- a/src/test/compile-fail/weak-lang-item.rs
+++ b/src/test/compile-fail/weak-lang-item.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:weak-lang-items.rs
-// error-pattern: language item required, but not found: `panic_impl`
+// error-pattern: `#[panic_implementation]` function required, but not found
 // error-pattern: language item required, but not found: `eh_personality`
 // ignore-wasm32-bare compiled with panic=abort, personality not required
 

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/call-site.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/call-site.rs
@@ -1,0 +1,37 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+#![feature(proc_macro)]
+
+extern crate proc_macro;
+use proc_macro::*;
+
+#[proc_macro]
+pub fn check(input: TokenStream) -> TokenStream {
+    // Parsed `x2` can refer to `x2` from `input`
+    let parsed1: TokenStream = "let x3 = x2;".parse().unwrap();
+    // `x3` parsed from one string can refer to `x3` parsed from another string.
+    let parsed2: TokenStream = "let x4 = x3;".parse().unwrap();
+    // Manually assembled `x4` can refer to parsed `x4`.
+    let manual: Vec<TokenTree> = vec![
+        Ident::new("let", Span::call_site()).into(),
+        Ident::new("x5", Span::call_site()).into(),
+        Punct::new('=', Spacing::Alone).into(),
+        Ident::new("x4", Span::call_site()).into(),
+        Punct::new(';', Spacing::Alone).into(),
+    ];
+    input.into_iter().chain(parsed1.into_iter())
+                     .chain(parsed2.into_iter())
+                     .chain(manual.into_iter())
+                     .collect()
+}

--- a/src/test/run-pass-fulldeps/proc-macro/call-site.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/call-site.rs
@@ -8,20 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// aux-build:bang_proc_macro2.rs
+// aux-build:call-site.rs
 // ignore-stage1
 
-#![feature(use_extern_macros, proc_macro_non_items)]
-#![allow(unused_macros)]
+#![feature(proc_macro, proc_macro_non_items)]
 
-extern crate bang_proc_macro2;
-
-use bang_proc_macro2::bang_proc_macro2;
+extern crate call_site;
+use call_site::*;
 
 fn main() {
-    let foobar = 42;
-    bang_proc_macro2!();
-    //~^ ERROR cannot find value `foobar2` in this scope
-    //~^^ did you mean `foobar`?
-    println!("{}", x);
+    let x1 = 10;
+    call_site::check!(let x2 = x1;);
+    let x6 = x5;
 }

--- a/src/test/run-pass/issue-44056.rs
+++ b/src/test/run-pass/issue-44056.rs
@@ -1,0 +1,15 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// only-x86_64
+// no-prefer-dynamic
+// compile-flags: -Ctarget-feature=+avx -Clto
+
+fn main() {}

--- a/src/test/run-pass/issue-49854.rs
+++ b/src/test/run-pass/issue-49854.rs
@@ -1,0 +1,18 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::ffi::OsString;
+
+fn main() {
+    let os_str = OsString::from("Hello Rust!");
+
+    assert_eq!(os_str, "Hello Rust!");
+    assert_eq!("Hello Rust!", os_str);
+}

--- a/src/test/ui/associated-const-impl-wrong-lifetime.stderr
+++ b/src/test/ui/associated-const-impl-wrong-lifetime.stderr
@@ -6,11 +6,11 @@ LL |     const NAME: &'a str = "unit";
    |
    = note: expected type `&'static str`
               found type `&'a str`
-note: the lifetime 'a as defined on the impl at 17:1...
-  --> $DIR/associated-const-impl-wrong-lifetime.rs:17:1
+note: the lifetime 'a as defined on the impl at 17:6...
+  --> $DIR/associated-const-impl-wrong-lifetime.rs:17:6
    |
 LL | impl<'a> Foo for &'a () {
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |      ^^
    = note: ...does not necessarily outlive the static lifetime
 
 error: aborting due to previous error

--- a/src/test/ui/borrowck/borrowck-escaping-closure-error-2.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-escaping-closure-error-2.nll.stderr
@@ -7,11 +7,11 @@ LL |     //~^ ERROR E0373
 LL | }
    | - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 19:1...
-  --> $DIR/borrowck-escaping-closure-error-2.rs:19:1
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 19:8...
+  --> $DIR/borrowck-escaping-closure-error-2.rs:19:8
    |
 LL | fn foo<'a>(x: &'a i32) -> Box<FnMut()+'a> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/regions-bound-missing-bound-in-impl.rs
+++ b/src/test/ui/borrowck/regions-bound-missing-bound-in-impl.rs
@@ -36,7 +36,6 @@ impl<'a, 't> Foo<'a, 't> for &'a isize {
 
     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
         //~^ ERROR method not compatible with trait
-        //~| ERROR method not compatible with trait
         //
         // Note: This is a terrible error message. It is caused
         // because, in the trait, 'b is early bound, and in the impl,

--- a/src/test/ui/borrowck/regions-bound-missing-bound-in-impl.rs
+++ b/src/test/ui/borrowck/regions-bound-missing-bound-in-impl.rs
@@ -20,6 +20,7 @@ pub trait Foo<'a, 't> {
     fn no_bound<'b>(self, b: Inv<'b>);
     fn has_bound<'b:'a>(self, b: Inv<'b>);
     fn wrong_bound1<'b,'c,'d:'a+'b>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>);
+    fn wrong_bound2<'b,'c,'d:'a+'b>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>);
     fn okay_bound<'b,'c,'d:'a+'b+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>);
     fn another_bound<'x: 'a>(self, x: Inv<'x>, y: Inv<'t>);
 }
@@ -45,6 +46,10 @@ impl<'a, 't> Foo<'a, 't> for &'a isize {
         // information about the lifetime declarations in the trait so
         // that we can compare better to the impl, even in cross-crate
         // cases.
+    }
+
+    fn wrong_bound2(self, b: Inv, c: Inv, d: Inv) {
+        //~^ ERROR lifetime parameters or bounds on method `wrong_bound2` do not match the trait
     }
 
     fn okay_bound<'b,'c,'e:'b+'c>(self, b: Inv<'b>, c: Inv<'c>, e: Inv<'e>) {

--- a/src/test/ui/borrowck/regions-bound-missing-bound-in-impl.rs
+++ b/src/test/ui/borrowck/regions-bound-missing-bound-in-impl.rs
@@ -36,6 +36,7 @@ impl<'a, 't> Foo<'a, 't> for &'a isize {
 
     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
         //~^ ERROR method not compatible with trait
+        //~| ERROR method not compatible with trait
         //
         // Note: This is a terrible error message. It is caused
         // because, in the trait, 'b is early bound, and in the impl,

--- a/src/test/ui/borrowck/regions-bound-missing-bound-in-impl.stderr
+++ b/src/test/ui/borrowck/regions-bound-missing-bound-in-impl.stderr
@@ -1,42 +1,51 @@
 error[E0195]: lifetime parameters or bounds on method `no_bound` do not match the trait declaration
-  --> $DIR/regions-bound-missing-bound-in-impl.rs:28:5
+  --> $DIR/regions-bound-missing-bound-in-impl.rs:29:16
    |
 LL |     fn no_bound<'b>(self, b: Inv<'b>);
-   |     ---------------------------------- lifetimes in impl do not match this method in trait
+   |                ---- lifetimes in impl do not match this method in trait
 ...
 LL |     fn no_bound<'b:'a>(self, b: Inv<'b>) {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetimes do not match method in trait
+   |                ^^^^^^^ lifetimes do not match method in trait
 
 error[E0195]: lifetime parameters or bounds on method `has_bound` do not match the trait declaration
-  --> $DIR/regions-bound-missing-bound-in-impl.rs:32:5
+  --> $DIR/regions-bound-missing-bound-in-impl.rs:33:17
    |
 LL |     fn has_bound<'b:'a>(self, b: Inv<'b>);
-   |     -------------------------------------- lifetimes in impl do not match this method in trait
+   |                 ------- lifetimes in impl do not match this method in trait
 ...
 LL |     fn has_bound<'b>(self, b: Inv<'b>) {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetimes do not match method in trait
+   |                 ^^^^ lifetimes do not match method in trait
 
 error[E0308]: method not compatible with trait
-  --> $DIR/regions-bound-missing-bound-in-impl.rs:36:5
+  --> $DIR/regions-bound-missing-bound-in-impl.rs:37:5
    |
 LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
    = note: expected type `fn(&'a isize, Inv<'c>, Inv<'c>, Inv<'d>)`
               found type `fn(&'a isize, Inv<'_>, Inv<'c>, Inv<'d>)`
-note: the lifetime 'c as defined on the method body at 36:5...
-  --> $DIR/regions-bound-missing-bound-in-impl.rs:36:5
+note: the lifetime 'c as defined on the method body at 37:5...
+  --> $DIR/regions-bound-missing-bound-in-impl.rs:37:5
    |
 LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...does not necessarily outlive the lifetime 'c as defined on the method body at 36:5
-  --> $DIR/regions-bound-missing-bound-in-impl.rs:36:5
+note: ...does not necessarily outlive the lifetime 'c as defined on the method body at 37:5
+  --> $DIR/regions-bound-missing-bound-in-impl.rs:37:5
    |
 LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error[E0195]: lifetime parameters or bounds on method `wrong_bound2` do not match the trait declaration
+  --> $DIR/regions-bound-missing-bound-in-impl.rs:51:5
+   |
+LL |     fn wrong_bound2<'b,'c,'d:'a+'b>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>);
+   |                    ---------------- lifetimes in impl do not match this method in trait
+...
+LL |     fn wrong_bound2(self, b: Inv, c: Inv, d: Inv) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetimes do not match method in trait
+
 error[E0276]: impl has stricter requirements than trait
-  --> $DIR/regions-bound-missing-bound-in-impl.rs:53:5
+  --> $DIR/regions-bound-missing-bound-in-impl.rs:58:5
    |
 LL |     fn another_bound<'x: 'a>(self, x: Inv<'x>, y: Inv<'t>);
    |     ------------------------------------------------------- definition of `another_bound` from trait
@@ -44,7 +53,7 @@ LL |     fn another_bound<'x: 'a>(self, x: Inv<'x>, y: Inv<'t>);
 LL |     fn another_bound<'x: 't>(self, x: Inv<'x>, y: Inv<'t>) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl has extra requirement `'x: 't`
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
 Some errors occurred: E0195, E0276, E0308.
 For more information about an error, try `rustc --explain E0195`.

--- a/src/test/ui/borrowck/regions-bound-missing-bound-in-impl.stderr
+++ b/src/test/ui/borrowck/regions-bound-missing-bound-in-impl.stderr
@@ -24,38 +24,19 @@ LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d
    |
    = note: expected type `fn(&'a isize, Inv<'c>, Inv<'c>, Inv<'d>)`
               found type `fn(&'a isize, Inv<'_>, Inv<'c>, Inv<'d>)`
-note: the lifetime 'c as defined on the method body at 37:5...
-  --> $DIR/regions-bound-missing-bound-in-impl.rs:37:5
+note: the lifetime 'c as defined on the method body at 37:24...
+  --> $DIR/regions-bound-missing-bound-in-impl.rs:37:24
    |
 LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                        ^^
 note: ...does not necessarily outlive the lifetime 'c as defined on the method body at 37:24
   --> $DIR/regions-bound-missing-bound-in-impl.rs:37:24
    |
 LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
    |                        ^^
 
-error[E0308]: method not compatible with trait
-  --> $DIR/regions-bound-missing-bound-in-impl.rs:37:5
-   |
-LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
-   |
-   = note: expected type `fn(&'a isize, Inv<'c>, Inv<'c>, Inv<'d>)`
-              found type `fn(&'a isize, Inv<'_>, Inv<'c>, Inv<'d>)`
-note: the lifetime 'c as defined on the method body at 37:24...
-  --> $DIR/regions-bound-missing-bound-in-impl.rs:37:24
-   |
-LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
-   |                        ^^
-note: ...does not necessarily outlive the lifetime 'c as defined on the method body at 37:5
-  --> $DIR/regions-bound-missing-bound-in-impl.rs:37:5
-   |
-LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error[E0195]: lifetime parameters or bounds on method `wrong_bound2` do not match the trait declaration
-  --> $DIR/regions-bound-missing-bound-in-impl.rs:52:5
+  --> $DIR/regions-bound-missing-bound-in-impl.rs:51:5
    |
 LL |     fn wrong_bound2<'b,'c,'d:'a+'b>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>);
    |                    ---------------- lifetimes in impl do not match this method in trait
@@ -64,7 +45,7 @@ LL |     fn wrong_bound2(self, b: Inv, c: Inv, d: Inv) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetimes do not match method in trait
 
 error[E0276]: impl has stricter requirements than trait
-  --> $DIR/regions-bound-missing-bound-in-impl.rs:59:5
+  --> $DIR/regions-bound-missing-bound-in-impl.rs:58:5
    |
 LL |     fn another_bound<'x: 'a>(self, x: Inv<'x>, y: Inv<'t>);
    |     ------------------------------------------------------- definition of `another_bound` from trait
@@ -72,7 +53,7 @@ LL |     fn another_bound<'x: 'a>(self, x: Inv<'x>, y: Inv<'t>);
 LL |     fn another_bound<'x: 't>(self, x: Inv<'x>, y: Inv<'t>) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl has extra requirement `'x: 't`
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
 Some errors occurred: E0195, E0276, E0308.
 For more information about an error, try `rustc --explain E0195`.

--- a/src/test/ui/borrowck/regions-bound-missing-bound-in-impl.stderr
+++ b/src/test/ui/borrowck/regions-bound-missing-bound-in-impl.stderr
@@ -29,6 +29,25 @@ note: the lifetime 'c as defined on the method body at 37:5...
    |
 LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...does not necessarily outlive the lifetime 'c as defined on the method body at 37:24
+  --> $DIR/regions-bound-missing-bound-in-impl.rs:37:24
+   |
+LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
+   |                        ^^
+
+error[E0308]: method not compatible with trait
+  --> $DIR/regions-bound-missing-bound-in-impl.rs:37:5
+   |
+LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
+   |
+   = note: expected type `fn(&'a isize, Inv<'c>, Inv<'c>, Inv<'d>)`
+              found type `fn(&'a isize, Inv<'_>, Inv<'c>, Inv<'d>)`
+note: the lifetime 'c as defined on the method body at 37:24...
+  --> $DIR/regions-bound-missing-bound-in-impl.rs:37:24
+   |
+LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
+   |                        ^^
 note: ...does not necessarily outlive the lifetime 'c as defined on the method body at 37:5
   --> $DIR/regions-bound-missing-bound-in-impl.rs:37:5
    |
@@ -53,7 +72,7 @@ LL |     fn another_bound<'x: 'a>(self, x: Inv<'x>, y: Inv<'t>);
 LL |     fn another_bound<'x: 't>(self, x: Inv<'x>, y: Inv<'t>) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl has extra requirement `'x: 't`
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 
 Some errors occurred: E0195, E0276, E0308.
 For more information about an error, try `rustc --explain E0195`.

--- a/src/test/ui/borrowck/regions-bound-missing-bound-in-impl.stderr
+++ b/src/test/ui/borrowck/regions-bound-missing-bound-in-impl.stderr
@@ -55,7 +55,7 @@ LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0195]: lifetime parameters or bounds on method `wrong_bound2` do not match the trait declaration
-  --> $DIR/regions-bound-missing-bound-in-impl.rs:51:5
+  --> $DIR/regions-bound-missing-bound-in-impl.rs:52:5
    |
 LL |     fn wrong_bound2<'b,'c,'d:'a+'b>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>);
    |                    ---------------- lifetimes in impl do not match this method in trait
@@ -64,7 +64,7 @@ LL |     fn wrong_bound2(self, b: Inv, c: Inv, d: Inv) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetimes do not match method in trait
 
 error[E0276]: impl has stricter requirements than trait
-  --> $DIR/regions-bound-missing-bound-in-impl.rs:58:5
+  --> $DIR/regions-bound-missing-bound-in-impl.rs:59:5
    |
 LL |     fn another_bound<'x: 'a>(self, x: Inv<'x>, y: Inv<'t>);
    |     ------------------------------------------------------- definition of `another_bound` from trait

--- a/src/test/ui/closure-expected-type/expect-region-supply-region.stderr
+++ b/src/test/ui/closure-expected-type/expect-region-supply-region.stderr
@@ -38,11 +38,11 @@ LL | |
 LL | |         //~^ ERROR borrowed data cannot be stored outside of its closure
 LL | |     });
    | |_____^
-note: ...does not necessarily outlive the lifetime 'x as defined on the function body at 42:1
-  --> $DIR/expect-region-supply-region.rs:42:1
+note: ...does not necessarily outlive the lifetime 'x as defined on the function body at 42:30
+  --> $DIR/expect-region-supply-region.rs:42:30
    |
 LL | fn expect_bound_supply_named<'x>() {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                              ^^
 
 error[E0308]: mismatched types
   --> $DIR/expect-region-supply-region.rs:47:33
@@ -52,11 +52,11 @@ LL |     closure_expecting_bound(|x: &'x u32| {
    |
    = note: expected type `&u32`
               found type `&'x u32`
-note: the lifetime 'x as defined on the function body at 42:1...
-  --> $DIR/expect-region-supply-region.rs:42:1
+note: the lifetime 'x as defined on the function body at 42:30...
+  --> $DIR/expect-region-supply-region.rs:42:30
    |
 LL | fn expect_bound_supply_named<'x>() {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                              ^^
 note: ...does not necessarily outlive the anonymous lifetime #2 defined on the body at 47:29
   --> $DIR/expect-region-supply-region.rs:47:29
    |

--- a/src/test/ui/error-codes/E0195.stderr
+++ b/src/test/ui/error-codes/E0195.stderr
@@ -1,11 +1,11 @@
 error[E0195]: lifetime parameters or bounds on method `bar` do not match the trait declaration
-  --> $DIR/E0195.rs:19:5
+  --> $DIR/E0195.rs:19:11
    |
 LL |     fn bar<'a,'b:'a>(x: &'a str, y: &'b str);
-   |     ----------------------------------------- lifetimes in impl do not match this method in trait
+   |           ---------- lifetimes in impl do not match this method in trait
 ...
 LL |     fn bar<'a,'b>(x: &'a str, y: &'b str) { //~ ERROR E0195
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetimes do not match method in trait
+   |           ^^^^^^^ lifetimes do not match method in trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0478.stderr
+++ b/src/test/ui/error-codes/E0478.stderr
@@ -4,16 +4,16 @@ error[E0478]: lifetime bound not satisfied
 LL |     child: Box<Wedding<'kiss> + 'SnowWhite>, //~ ERROR E0478
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lifetime parameter instantiated with the lifetime 'SnowWhite as defined on the struct at 13:1
-  --> $DIR/E0478.rs:13:1
+note: lifetime parameter instantiated with the lifetime 'SnowWhite as defined on the struct at 13:22
+  --> $DIR/E0478.rs:13:22
    |
 LL | struct Prince<'kiss, 'SnowWhite> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: but lifetime parameter must outlive the lifetime 'kiss as defined on the struct at 13:1
-  --> $DIR/E0478.rs:13:1
+   |                      ^^^^^^^^^^
+note: but lifetime parameter must outlive the lifetime 'kiss as defined on the struct at 13:15
+  --> $DIR/E0478.rs:13:15
    |
 LL | struct Prince<'kiss, 'SnowWhite> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/hygiene/auxiliary/intercrate.rs
+++ b/src/test/ui/hygiene/auxiliary/intercrate.rs
@@ -22,6 +22,35 @@ pub mod foo {
 
 pub struct SomeType;
 
-pub macro uses_dollar_crate() {
+// `$crate`
+pub macro uses_dollar_crate_modern() {
     type Alias = $crate::SomeType;
+}
+
+pub macro define_uses_dollar_crate_modern_nested($uses_dollar_crate_modern_nested: ident) {
+    macro $uses_dollar_crate_modern_nested() {
+        type AliasCrateModernNested = $crate::SomeType;
+    }
+}
+
+#[macro_export]
+macro_rules! define_uses_dollar_crate_legacy_nested {
+    () => {
+        macro_rules! uses_dollar_crate_legacy_nested {
+            () => {
+                type AliasLegacyNested = $crate::SomeType;
+            }
+        }
+    }
+}
+
+// `crate`
+pub macro uses_crate_modern() {
+    type AliasCrate = crate::SomeType;
+}
+
+pub macro define_uses_crate_modern_nested($uses_crate_modern_nested: ident) {
+    macro $uses_crate_modern_nested() {
+        type AliasCrateModernNested = crate::SomeType;
+    }
 }

--- a/src/test/ui/hygiene/auxiliary/transparent-basic.rs
+++ b/src/test/ui/hygiene/auxiliary/transparent-basic.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,20 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(decl_macro)]
+#![feature(decl_macro, rustc_attrs)]
 
-pub mod foo {
-    pub use self::bar::m;
-    mod bar {
-        fn f() -> u32 { 1 }
-        pub macro m() {
-            f();
-        }
-    }
-}
-
-pub struct SomeType;
-
-pub macro uses_dollar_crate() {
-    type Alias = $crate::SomeType;
+#[rustc_transparent_macro]
+pub macro dollar_crate() {
+    let s = $crate::S;
 }

--- a/src/test/ui/hygiene/dollar-crate-modern.rs
+++ b/src/test/ui/hygiene/dollar-crate-modern.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,20 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(decl_macro)]
+// Make sure `$crate` works in `macro` macros.
 
-pub mod foo {
-    pub use self::bar::m;
-    mod bar {
-        fn f() -> u32 { 1 }
-        pub macro m() {
-            f();
-        }
-    }
-}
+// compile-pass
+// aux-build:intercrate.rs
 
-pub struct SomeType;
+#![feature(use_extern_macros)]
 
-pub macro uses_dollar_crate() {
-    type Alias = $crate::SomeType;
-}
+extern crate intercrate;
+
+intercrate::uses_dollar_crate!();
+
+fn main() {}

--- a/src/test/ui/hygiene/dollar-crate-modern.rs
+++ b/src/test/ui/hygiene/dollar-crate-modern.rs
@@ -8,15 +8,28 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Make sure `$crate` works in `macro` macros.
+// Make sure `$crate` and `crate` work in for basic cases of nested macros.
 
 // compile-pass
 // aux-build:intercrate.rs
 
-#![feature(use_extern_macros)]
+#![feature(decl_macro, crate_in_paths)]
 
 extern crate intercrate;
 
-intercrate::uses_dollar_crate!();
+// `$crate`
+intercrate::uses_dollar_crate_modern!();
+
+intercrate::define_uses_dollar_crate_modern_nested!(uses_dollar_crate_modern_nested);
+uses_dollar_crate_modern_nested!();
+
+intercrate::define_uses_dollar_crate_legacy_nested!();
+uses_dollar_crate_legacy_nested!();
+
+// `crate`
+intercrate::uses_crate_modern!();
+
+intercrate::define_uses_crate_modern_nested!(uses_crate_modern_nested);
+uses_crate_modern_nested!();
 
 fn main() {}

--- a/src/test/ui/hygiene/generate-mod.rs
+++ b/src/test/ui/hygiene/generate-mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,20 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(decl_macro)]
+// This is an equivalent of issue #50504, but for declarative macros.
 
-pub mod foo {
-    pub use self::bar::m;
-    mod bar {
-        fn f() -> u32 { 1 }
-        pub macro m() {
-            f();
-        }
+#![feature(decl_macro, rustc_attrs)]
+
+#[rustc_transparent_macro]
+macro genmod() {
+    mod m {
+        type A = S; //~ ERROR cannot find type `S` in this scope
     }
 }
 
-pub struct SomeType;
+struct S;
 
-pub macro uses_dollar_crate() {
-    type Alias = $crate::SomeType;
-}
+genmod!();

--- a/src/test/ui/hygiene/generate-mod.stderr
+++ b/src/test/ui/hygiene/generate-mod.stderr
@@ -1,0 +1,17 @@
+error[E0412]: cannot find type `S` in this scope
+  --> $DIR/generate-mod.rs:18:18
+   |
+LL |         type A = S; //~ ERROR cannot find type `S` in this scope
+   |                  ^ did you mean `A`?
+...
+LL | genmod!();
+   | ---------- in this macro invocation
+
+error[E0601]: `main` function not found in crate `generate_mod`
+   |
+   = note: consider adding a `main` function to `$DIR/generate-mod.rs`
+
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0412, E0601.
+For more information about an error, try `rustc --explain E0412`.

--- a/src/test/ui/hygiene/transparent-basic.rs
+++ b/src/test/ui/hygiene/transparent-basic.rs
@@ -1,0 +1,53 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-pass
+// aux-build:transparent-basic.rs
+
+#![feature(decl_macro, rustc_attrs)]
+
+extern crate transparent_basic;
+
+#[rustc_transparent_macro]
+macro binding() {
+    let x = 10;
+}
+
+#[rustc_transparent_macro]
+macro label() {
+    break 'label
+}
+
+macro_rules! legacy {
+    () => {
+        binding!();
+        let y = x;
+    }
+}
+
+fn legacy_interaction1() {
+    legacy!();
+}
+
+struct S;
+
+fn check_dollar_crate() {
+    // `$crate::S` inside the macro resolves to `S` from this crate.
+    transparent_basic::dollar_crate!();
+}
+
+fn main() {
+    binding!();
+    let y = x;
+
+    'label: loop {
+        label!();
+    }
+}

--- a/src/test/ui/impl-trait/region-escape-via-bound.stderr
+++ b/src/test/ui/impl-trait/region-escape-via-bound.stderr
@@ -4,16 +4,11 @@ error[E0700]: hidden type for `impl Trait` captures lifetime that does not appea
 LL | fn foo(x: Cell<&'x u32>) -> impl Trait<'y>
    |                             ^^^^^^^^^^^^^^
    |
-note: hidden type `std::cell::Cell<&'x u32>` captures the lifetime 'x as defined on the function body at 26:1
-  --> $DIR/region-escape-via-bound.rs:26:1
+note: hidden type `std::cell::Cell<&'x u32>` captures the lifetime 'x as defined on the function body at 28:7
+  --> $DIR/region-escape-via-bound.rs:28:7
    |
-LL | / fn foo(x: Cell<&'x u32>) -> impl Trait<'y>
-LL | |     //~^ ERROR hidden type for `impl Trait` captures lifetime that does not appear in bounds [E0700]
-LL | | where 'x: 'y
-LL | | {
-LL | |     x
-LL | | }
-   | |_^
+LL | where 'x: 'y
+   |       ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/impl-trait/static-return-lifetime-infered.stderr
+++ b/src/test/ui/impl-trait/static-return-lifetime-infered.stderr
@@ -30,12 +30,12 @@ LL |         self.x.iter().map(|a| a.0)
    |         |
    |         ...but this borrow...
    |
-note: ...can't outlive the lifetime 'a as defined on the method body at 20:5
-  --> $DIR/static-return-lifetime-infered.rs:20:5
+note: ...can't outlive the lifetime 'a as defined on the method body at 20:20
+  --> $DIR/static-return-lifetime-infered.rs:20:20
    |
 LL |     fn iter_values<'a>(&'a self) -> impl Iterator<Item=u32> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime 'a as defined on the method body at 20:5
+   |                    ^^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime 'a as defined on the method body at 20:20
    |
 LL |     fn iter_values<'a>(&'a self) -> impl Iterator<Item=u32> + 'a {
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/in-band-lifetimes/impl/dyn-trait.stderr
+++ b/src/test/ui/in-band-lifetimes/impl/dyn-trait.stderr
@@ -4,11 +4,11 @@ error[E0495]: cannot infer an appropriate lifetime due to conflicting requiremen
 LL |     static_val(x); //~ ERROR cannot infer
    |                ^
    |
-note: first, the lifetime cannot outlive the lifetime 'a as defined on the function body at 31:1...
-  --> $DIR/dyn-trait.rs:31:1
+note: first, the lifetime cannot outlive the lifetime 'a as defined on the function body at 31:26...
+  --> $DIR/dyn-trait.rs:31:26
    |
 LL | fn with_dyn_debug_static<'a>(x: Box<dyn Debug + 'a>) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                          ^^
    = note: ...so that the expression is assignable:
            expected std::boxed::Box<dyn std::fmt::Debug>
               found std::boxed::Box<(dyn std::fmt::Debug + 'a)>

--- a/src/test/ui/in-band-lifetimes/mismatched_trait_impl.stderr
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait_impl.stderr
@@ -11,11 +11,11 @@ LL | /     fn foo(&self, x: &u32, y: &'a u32) -> &'a u32 { //~ ERROR cannot infe
 LL | |         x
 LL | |     }
    | |_____^
-note: ...but the lifetime must also be valid for the lifetime 'a as defined on the method body at 19:5...
-  --> $DIR/mismatched_trait_impl.rs:19:5
+note: ...but the lifetime must also be valid for the lifetime 'a as defined on the method body at 19:32...
+  --> $DIR/mismatched_trait_impl.rs:19:32
    |
 LL |     fn foo(&self, x: &u32, y: &'a u32) -> &'a u32 { //~ ERROR cannot infer
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                ^^
    = note: ...so that the method type is compatible with trait:
            expected fn(&i32, &'a u32, &u32) -> &'a u32
               found fn(&i32, &u32, &u32) -> &u32

--- a/src/test/ui/issue-27942.stderr
+++ b/src/test/ui/issue-27942.stderr
@@ -11,11 +11,11 @@ note: the anonymous lifetime #1 defined on the method body at 15:5...
    |
 LL |     fn select(&self) -> BufferViewHandle<R>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...does not necessarily outlive the lifetime 'a as defined on the trait at 13:1
-  --> $DIR/issue-27942.rs:13:1
+note: ...does not necessarily outlive the lifetime 'a as defined on the trait at 13:18
+  --> $DIR/issue-27942.rs:13:18
    |
 LL | pub trait Buffer<'a, R: Resources<'a>> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^
 
 error[E0308]: mismatched types
   --> $DIR/issue-27942.rs:15:5
@@ -25,11 +25,11 @@ LL |     fn select(&self) -> BufferViewHandle<R>;
    |
    = note: expected type `Resources<'_>`
               found type `Resources<'a>`
-note: the lifetime 'a as defined on the trait at 13:1...
-  --> $DIR/issue-27942.rs:13:1
+note: the lifetime 'a as defined on the trait at 13:18...
+  --> $DIR/issue-27942.rs:13:18
    |
 LL | pub trait Buffer<'a, R: Resources<'a>> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^
 note: ...does not necessarily outlive the anonymous lifetime #1 defined on the method body at 15:5
   --> $DIR/issue-27942.rs:15:5
    |

--- a/src/test/ui/issue-37884.stderr
+++ b/src/test/ui/issue-37884.stderr
@@ -21,11 +21,11 @@ LL | |     {
 LL | |         Some(&mut self.0)
 LL | |     }
    | |_____^
-note: ...does not necessarily outlive the lifetime 'a as defined on the impl at 13:1
-  --> $DIR/issue-37884.rs:13:1
+note: ...does not necessarily outlive the lifetime 'a as defined on the impl at 13:6
+  --> $DIR/issue-37884.rs:13:6
    |
 LL | impl<'a, T: 'a> Iterator for RepeatMut<'a, T> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |      ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issue-4335.nll.stderr
+++ b/src/test/ui/issue-4335.nll.stderr
@@ -13,11 +13,11 @@ LL |     id(Box::new(|| *v))
 LL | }
    | - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'r as defined on the function body at 15:1...
-  --> $DIR/issue-4335.rs:15:1
+note: borrowed value must be valid for the lifetime 'r as defined on the function body at 15:6...
+  --> $DIR/issue-4335.rs:15:6
    |
 LL | fn f<'r, T>(v: &'r T) -> Box<FnMut() -> T + 'r> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |      ^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issue-46472.stderr
+++ b/src/test/ui/issue-46472.stderr
@@ -7,11 +7,11 @@ LL |     &mut 4
 LL | }
    | - temporary value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 13:1...
-  --> $DIR/issue-46472.rs:13:1
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 13:8...
+  --> $DIR/issue-46472.rs:13:8
    |
 LL | fn bar<'a>() -> &'a mut u32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^
 
 error[E0597]: borrowed value does not live long enough (Mir)
   --> $DIR/issue-46472.rs:14:10
@@ -22,11 +22,11 @@ LL |     &mut 4
 LL | }
    | - temporary value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 13:1...
-  --> $DIR/issue-46472.rs:13:1
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 13:8...
+  --> $DIR/issue-46472.rs:13:8
    |
 LL | fn bar<'a>() -> &'a mut u32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issue-51874.rs
+++ b/src/test/ui/issue-51874.rs
@@ -1,0 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let a = (1.0).pow(1.0); //~ ERROR can't call method `pow` on ambiguous numeric type
+}

--- a/src/test/ui/issue-51874.stderr
+++ b/src/test/ui/issue-51874.stderr
@@ -1,0 +1,13 @@
+error[E0689]: can't call method `pow` on ambiguous numeric type `{float}`
+  --> $DIR/issue-51874.rs:12:19
+   |
+LL |     let a = (1.0).pow(1.0); //~ ERROR can't call method `pow` on ambiguous numeric type
+   |                   ^^^
+help: you must specify a concrete type for this numeric value, like `f32`
+   |
+LL |     let a = (1.0_f32).pow(1.0); //~ ERROR can't call method `pow` on ambiguous numeric type
+   |              ^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0689`.

--- a/src/test/ui/nll/borrowed-universal-error-2.stderr
+++ b/src/test/ui/nll/borrowed-universal-error-2.stderr
@@ -7,11 +7,11 @@ LL |     //~^ ERROR `v` does not live long enough [E0597]
 LL | }
    | - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 14:1...
-  --> $DIR/borrowed-universal-error-2.rs:14:1
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 14:8...
+  --> $DIR/borrowed-universal-error-2.rs:14:8
    |
 LL | fn foo<'a>(x: &'a (u32,)) -> &'a u32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/borrowed-universal-error.stderr
+++ b/src/test/ui/nll/borrowed-universal-error.stderr
@@ -7,11 +7,11 @@ LL |     //~^ ERROR borrowed value does not live long enough [E0597]
 LL | }
    | - temporary value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 18:1...
-  --> $DIR/borrowed-universal-error.rs:18:1
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 18:8...
+  --> $DIR/borrowed-universal-error.rs:18:8
    |
 LL | fn foo<'a>(x: &'a (u32,)) -> &'a u32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-31567.stderr
+++ b/src/test/ui/nll/issue-31567.stderr
@@ -7,11 +7,11 @@ LL |     &s_inner.0
 LL | }
    | - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 21:1...
-  --> $DIR/issue-31567.rs:21:1
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 21:17...
+  --> $DIR/issue-31567.rs:21:17
    |
 LL | fn get_dangling<'a>(v: VecWrapper<'a>) -> &'a u32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-47470.stderr
+++ b/src/test/ui/nll/issue-47470.stderr
@@ -6,11 +6,11 @@ LL |         &local //~ ERROR `local` does not live long enough
 LL |     }
    |     - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the impl at 23:1...
-  --> $DIR/issue-47470.rs:23:1
+note: borrowed value must be valid for the lifetime 'a as defined on the impl at 23:6...
+  --> $DIR/issue-47470.rs:23:6
    |
 LL | impl<'a> Bar for Foo<'a> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |      ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/normalization-bounds-error.stderr
+++ b/src/test/ui/nll/normalization-bounds-error.stderr
@@ -4,16 +4,16 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'d` d
 LL | fn visit_seq<'d, 'a: 'd>() -> <&'a () as Visitor<'d>>::Value {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: first, the lifetime cannot outlive the lifetime 'd as defined on the function body at 23:1...
-  --> $DIR/normalization-bounds-error.rs:23:1
+note: first, the lifetime cannot outlive the lifetime 'd as defined on the function body at 23:14...
+  --> $DIR/normalization-bounds-error.rs:23:14
    |
 LL | fn visit_seq<'d, 'a: 'd>() -> <&'a () as Visitor<'d>>::Value {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...but the lifetime must also be valid for the lifetime 'a as defined on the function body at 23:1...
-  --> $DIR/normalization-bounds-error.rs:23:1
+   |              ^^
+note: ...but the lifetime must also be valid for the lifetime 'a as defined on the function body at 23:18...
+  --> $DIR/normalization-bounds-error.rs:23:18
    |
 LL | fn visit_seq<'d, 'a: 'd>() -> <&'a () as Visitor<'d>>::Value {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^
    = note: ...so that the types are compatible:
            expected Visitor<'d>
               found Visitor<'_>

--- a/src/test/ui/nll/trait-associated-constant.stderr
+++ b/src/test/ui/nll/trait-associated-constant.stderr
@@ -6,16 +6,16 @@ LL |     const AC: Option<&'c str> = None;
    |
    = note: expected type `std::option::Option<&'b str>`
               found type `std::option::Option<&'c str>`
-note: the lifetime 'c as defined on the impl at 30:1...
-  --> $DIR/trait-associated-constant.rs:30:1
+note: the lifetime 'c as defined on the impl at 30:18...
+  --> $DIR/trait-associated-constant.rs:30:18
    |
 LL | impl<'a: 'b, 'b, 'c> Anything<'a, 'b> for FailStruct1 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...does not necessarily outlive the lifetime 'b as defined on the impl at 30:1
-  --> $DIR/trait-associated-constant.rs:30:1
+   |                  ^^
+note: ...does not necessarily outlive the lifetime 'b as defined on the impl at 30:14
+  --> $DIR/trait-associated-constant.rs:30:14
    |
 LL | impl<'a: 'b, 'b, 'c> Anything<'a, 'b> for FailStruct1 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^
 
 error[E0308]: mismatched types
   --> $DIR/trait-associated-constant.rs:38:5
@@ -25,16 +25,16 @@ LL |     const AC: Option<&'a str> = None;
    |
    = note: expected type `std::option::Option<&'b str>`
               found type `std::option::Option<&'a str>`
-note: the lifetime 'a as defined on the impl at 37:1...
-  --> $DIR/trait-associated-constant.rs:37:1
+note: the lifetime 'a as defined on the impl at 37:6...
+  --> $DIR/trait-associated-constant.rs:37:6
    |
 LL | impl<'a: 'b, 'b> Anything<'a, 'b> for FailStruct2 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...does not necessarily outlive the lifetime 'b as defined on the impl at 37:1
-  --> $DIR/trait-associated-constant.rs:37:1
+   |      ^^
+note: ...does not necessarily outlive the lifetime 'b as defined on the impl at 37:14
+  --> $DIR/trait-associated-constant.rs:37:14
    |
 LL | impl<'a: 'b, 'b> Anything<'a, 'b> for FailStruct2 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/region-borrow-params-issue-29793-small.nll.stderr
+++ b/src/test/ui/region-borrow-params-issue-29793-small.nll.stderr
@@ -43,11 +43,11 @@ LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x
 LL |     };
    |     - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 64:5...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:64:5
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 64:10...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:64:10
    |
 LL |     fn g<'a>(x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          ^^
 
 error[E0597]: `y` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:65:17
@@ -58,11 +58,11 @@ LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x
 LL |     };
    |     - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 64:5...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:64:5
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 64:10...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:64:10
    |
 LL |     fn g<'a>(x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          ^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:76:17
@@ -73,11 +73,11 @@ LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x
 LL |     };
    |     - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 75:5...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:75:5
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 75:10...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:75:10
    |
 LL |     fn g<'a>(x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          ^^
 
 error[E0597]: `y` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:76:17
@@ -88,11 +88,11 @@ LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x
 LL |     };
    |     - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 75:5...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:75:5
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 75:10...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:75:10
    |
 LL |     fn g<'a>(x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          ^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:100:21
@@ -103,11 +103,11 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
 LL |         }
    |         - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 99:9...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:99:9
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 99:14...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:99:14
    |
 LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^
 
 error[E0597]: `y` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:100:21
@@ -118,11 +118,11 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
 LL |         }
    |         - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 99:9...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:99:9
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 99:14...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:99:14
    |
 LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:114:21
@@ -133,11 +133,11 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
 LL |         }
    |         - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 113:9...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:113:9
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 113:14...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:113:14
    |
 LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^
 
 error[E0597]: `y` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:114:21
@@ -148,11 +148,11 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
 LL |         }
    |         - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 113:9...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:113:9
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 113:14...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:113:14
    |
 LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:142:21
@@ -163,11 +163,11 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
 LL |         }
    |         - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 141:9...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:141:9
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 141:14...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:141:14
    |
 LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^
 
 error[E0597]: `y` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:142:21
@@ -178,11 +178,11 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
 LL |         }
    |         - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 141:9...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:141:9
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 141:14...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:141:14
    |
 LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:157:21
@@ -193,11 +193,11 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
 LL |         }
    |         - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 156:9...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:156:9
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 156:14...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:156:14
    |
 LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^
 
 error[E0597]: `y` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:157:21
@@ -208,11 +208,11 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
 LL |         }
    |         - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 156:9...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:156:9
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 156:14...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:156:14
    |
 LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:185:21
@@ -223,11 +223,11 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
 LL |         }
    |         - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 184:9...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:184:9
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 184:14...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:184:14
    |
 LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^
 
 error[E0597]: `y` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:185:21
@@ -238,11 +238,11 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
 LL |         }
    |         - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 184:9...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:184:9
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 184:14...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:184:14
    |
 LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:199:21
@@ -253,11 +253,11 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
 LL |         }
    |         - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 198:9...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:198:9
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 198:14...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:198:14
    |
 LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^
 
 error[E0597]: `y` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:199:21
@@ -268,11 +268,11 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
 LL |         }
    |         - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 198:9...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:198:9
+note: borrowed value must be valid for the lifetime 'a as defined on the method body at 198:14...
+  --> $DIR/region-borrow-params-issue-29793-small.rs:198:14
    |
 LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^
 
 error: aborting due to 20 previous errors
 

--- a/src/test/ui/static-lifetime.stderr
+++ b/src/test/ui/static-lifetime.stderr
@@ -4,11 +4,11 @@ error[E0478]: lifetime bound not satisfied
 LL | impl<'a, A: Clone> Arbitrary for ::std::borrow::Cow<'a, A> {} //~ ERROR lifetime bound
    |                    ^^^^^^^^^
    |
-note: lifetime parameter instantiated with the lifetime 'a as defined on the impl at 13:1
-  --> $DIR/static-lifetime.rs:13:1
+note: lifetime parameter instantiated with the lifetime 'a as defined on the impl at 13:6
+  --> $DIR/static-lifetime.rs:13:6
    |
 LL | impl<'a, A: Clone> Arbitrary for ::std::borrow::Cow<'a, A> {} //~ ERROR lifetime bound
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |      ^^
    = note: but lifetime parameter must outlive the static lifetime
 
 error: aborting due to previous error

--- a/src/test/ui/suggestions/placement-syntax.rs
+++ b/src/test/ui/suggestions/placement-syntax.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let x = -5;
+    if x<-1 {
+    //~^ ERROR emplacement syntax is obsolete
+        println!("ok");
+    }
+}

--- a/src/test/ui/suggestions/placement-syntax.stderr
+++ b/src/test/ui/suggestions/placement-syntax.stderr
@@ -1,0 +1,14 @@
+error: emplacement syntax is obsolete (for now, anyway)
+  --> $DIR/placement-syntax.rs:13:8
+   |
+LL |     if x<-1 {
+   |        ^^^^
+   |
+   = note: for more information, see <https://github.com/rust-lang/rust/issues/27779#issuecomment-378416911>
+help: if you meant to write a comparison against a negative value, add a space in between `<` and `-`
+   |
+LL |     if x< -1 {
+   |         ^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Successful merges:

 - #51178 (Implement PartialEq between &str and OsString)
 - #51762 (hygiene: Implement transparent marks and use them for call-site hygiene in proc-macros)
 - #51828 (Do not allow LLVM to increase a TLS's alignment on macOS.)
 - #51853 (Fix some doc links)
 - #51862 (Point to lifetime spans on lifetime errors)
 - #51864 (Update liblibc)
 - #51867 (Require type is sized in wfcheck.check_item_type for externed DSTs, c…)
 - #51883 (Suggest correct comparison against negative literal)
 - #51890 (Fix inconsequential typo in GlobalAlloc doc example)
 - #51920 (use literal span for concrete type suggestion)
 - #51921 (improve the error message when `#[panic_implementation]` is missing)

Failed merges:


r? @ghost