### PR TITLE
Unpin references

### DIFF
--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -625,6 +625,12 @@ pub struct Pinned;
 #[unstable(feature = "pin", issue = "49150")]
 impl !Unpin for Pinned {}
 
+#[unstable(feature = "pin", issue = "49150")]
+impl<'a, T: ?Sized + 'a> Unpin for &'a T {}
+
+#[unstable(feature = "pin", issue = "49150")]
+impl<'a, T: ?Sized + 'a> Unpin for &'a mut T {}
+
 /// Implementations of `Copy` for primitive types.
 ///
 /// Implementations that cannot be described in Rust

--- a/src/libcore/task/wake.rs
+++ b/src/libcore/task/wake.rs
@@ -13,6 +13,7 @@
             issue = "50547")]
 
 use fmt;
+use marker::Unpin;
 use ptr::NonNull;
 
 /// A `Waker` is a handle for waking up a task by notifying its executor that it
@@ -25,6 +26,7 @@ pub struct Waker {
     inner: NonNull<UnsafeWake>,
 }
 
+impl Unpin for Waker {}
 unsafe impl Send for Waker {}
 unsafe impl Sync for Waker {}
 
@@ -99,6 +101,7 @@ pub struct LocalWaker {
     inner: NonNull<UnsafeWake>,
 }
 
+impl Unpin for LocalWaker {}
 impl !Send for LocalWaker {}
 impl !Sync for LocalWaker {}
 


### PR DESCRIPTION
I also considered adding an impl for raw pointers as well, but that makes it easy to accidentally have unsound owning-collections that might otherwise be able to project pinned-ness (e.g. `Box`).

cc @RalfJung 

r? @withoutboats 