### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/src/libcore/future.rs
+++ b/src/libcore/future.rs
@@ -45,18 +45,18 @@ pub trait Future {
     ///
     /// This function returns:
     ///
-    /// - `Poll::Pending` if the future is not ready yet
-    /// - `Poll::Ready(val)` with the result `val` of this future if it finished
-    /// successfully.
+    /// - [`Poll::Pending`] if the future is not ready yet
+    /// - [`Poll::Ready(val)`] with the result `val` of this future if it
+    ///   finished successfully.
     ///
     /// Once a future has finished, clients should not `poll` it again.
     ///
     /// When a future is not ready yet, `poll` returns
-    /// [`Poll::Pending`](::task::Poll). The future will *also* register the
+    /// `Poll::Pending`. The future will *also* register the
     /// interest of the current task in the value being produced. For example,
     /// if the future represents the availability of data on a socket, then the
     /// task is recorded so that when data arrives, it is woken up (via
-    /// [`cx.waker()`](::task::Context::waker)). Once a task has been woken up,
+    /// [`cx.waker()`]). Once a task has been woken up,
     /// it should attempt to `poll` the future again, which may or may not
     /// produce a final value.
     ///
@@ -90,6 +90,10 @@ pub trait Future {
     /// then any future calls to `poll` may panic, block forever, or otherwise
     /// cause bad behavior. The `Future` trait itself provides no guarantees
     /// about the behavior of `poll` after a future has completed.
+    ///
+    /// [`Poll::Pending`]: ../task/enum.Poll.html#variant.Pending
+    /// [`Poll::Ready(val)`]: ../task/enum.Poll.html#variant.Ready
+    /// [`cx.waker()`]: ../task/struct.Context.html#method.waker
     fn poll(self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output>;
 }
 

--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -1036,8 +1036,6 @@ pub trait Iterator {
     /// Basic usage:
     ///
     /// ```
-    /// #![feature(iterator_flatten)]
-    ///
     /// let data = vec![vec![1, 2, 3, 4], vec![5, 6]];
     /// let flattened = data.into_iter().flatten().collect::<Vec<u8>>();
     /// assert_eq!(flattened, &[1, 2, 3, 4, 5, 6]);
@@ -1046,8 +1044,6 @@ pub trait Iterator {
     /// Mapping and then flattening:
     ///
     /// ```
-    /// #![feature(iterator_flatten)]
-    ///
     /// let words = ["alpha", "beta", "gamma"];
     ///
     /// // chars() returns an iterator
@@ -1074,8 +1070,6 @@ pub trait Iterator {
     /// Flattening once only removes one level of nesting:
     ///
     /// ```
-    /// #![feature(iterator_flatten)]
-    ///
     /// let d3 = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]];
     ///
     /// let d2 = d3.iter().flatten().collect::<Vec<_>>();
@@ -1093,7 +1087,7 @@ pub trait Iterator {
     ///
     /// [`flat_map()`]: #method.flat_map
     #[inline]
-    #[unstable(feature = "iterator_flatten", issue = "48213")]
+    #[stable(feature = "iterator_flatten", since = "1.29")]
     fn flatten(self) -> Flatten<Self>
     where Self: Sized, Self::Item: IntoIterator {
         Flatten { inner: flatten_compat(self) }

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -2524,13 +2524,13 @@ impl<I, U, F> FusedIterator for FlatMap<I, U, F>
 /// [`flatten`]: trait.Iterator.html#method.flatten
 /// [`Iterator`]: trait.Iterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[unstable(feature = "iterator_flatten", issue = "48213")]
+#[stable(feature = "iterator_flatten", since = "1.29")]
 pub struct Flatten<I: Iterator>
 where I::Item: IntoIterator {
     inner: FlattenCompat<I, <I::Item as IntoIterator>::IntoIter>,
 }
 
-#[unstable(feature = "iterator_flatten", issue = "48213")]
+#[stable(feature = "iterator_flatten", since = "1.29")]
 impl<I, U> fmt::Debug for Flatten<I>
     where I: Iterator + fmt::Debug, U: Iterator + fmt::Debug,
           I::Item: IntoIterator<IntoIter = U, Item = U::Item>,
@@ -2540,7 +2540,7 @@ impl<I, U> fmt::Debug for Flatten<I>
     }
 }
 
-#[unstable(feature = "iterator_flatten", issue = "48213")]
+#[stable(feature = "iterator_flatten", since = "1.29")]
 impl<I, U> Clone for Flatten<I>
     where I: Iterator + Clone, U: Iterator + Clone,
           I::Item: IntoIterator<IntoIter = U, Item = U::Item>,
@@ -2548,7 +2548,7 @@ impl<I, U> Clone for Flatten<I>
     fn clone(&self) -> Self { Flatten { inner: self.inner.clone() } }
 }
 
-#[unstable(feature = "iterator_flatten", issue = "48213")]
+#[stable(feature = "iterator_flatten", since = "1.29")]
 impl<I, U> Iterator for Flatten<I>
     where I: Iterator, U: Iterator,
           I::Item: IntoIterator<IntoIter = U, Item = U::Item>
@@ -2576,7 +2576,7 @@ impl<I, U> Iterator for Flatten<I>
     }
 }
 
-#[unstable(feature = "iterator_flatten", issue = "48213")]
+#[stable(feature = "iterator_flatten", since = "1.29")]
 impl<I, U> DoubleEndedIterator for Flatten<I>
     where I: DoubleEndedIterator, U: DoubleEndedIterator,
           I::Item: IntoIterator<IntoIter = U, Item = U::Item>
@@ -2599,7 +2599,7 @@ impl<I, U> DoubleEndedIterator for Flatten<I>
     }
 }
 
-#[unstable(feature = "iterator_flatten", issue = "48213")]
+#[stable(feature = "iterator_flatten", since = "1.29")]
 impl<I, U> FusedIterator for Flatten<I>
     where I: FusedIterator, U: Iterator,
           I::Item: IntoIterator<IntoIter = U, Item = U::Item> {}

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -89,7 +89,6 @@
 #![feature(extern_types)]
 #![feature(fundamental)]
 #![feature(intrinsics)]
-#![feature(iterator_flatten)]
 #![feature(lang_items)]
 #![feature(link_llvm_intrinsics)]
 #![feature(never_type)]

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -23,7 +23,6 @@
 #![feature(flt2dec)]
 #![feature(fmt_internals)]
 #![feature(hashmap_internals)]
-#![feature(iterator_flatten)]
 #![feature(pattern)]
 #![feature(range_is_empty)]
 #![feature(raw)]

--- a/src/librustc/middle/weak_lang_items.rs
+++ b/src/librustc/middle/weak_lang_items.rs
@@ -112,9 +112,13 @@ fn verify<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         if missing.contains(&lang_items::$item) &&
            !whitelisted(tcx, lang_items::$item) &&
            items.$name().is_none() {
-            tcx.sess.err(&format!("language item required, but not found: `{}`",
-                                  stringify!($name)));
-
+            if lang_items::$item == lang_items::PanicImplLangItem {
+                tcx.sess.err(&format!("`#[panic_implementation]` function required, \
+                                        but not found"));
+            } else {
+                tcx.sess.err(&format!("language item required, but not found: `{}`",
+                                        stringify!($name)));
+            }
         }
     )*
 }

--- a/src/librustc_data_structures/indexed_set.rs
+++ b/src/librustc_data_structures/indexed_set.rs
@@ -233,7 +233,9 @@ impl<T: Idx> IdxSet<T> {
         &mut self.bits
     }
 
-    pub fn clone_from(&mut self, other: &IdxSet<T>) {
+    /// Efficiently overwrite `self` with `other`. Panics if `self` and `other`
+    /// don't have the same length.
+    pub fn overwrite(&mut self, other: &IdxSet<T>) {
         self.words_mut().clone_from_slice(other.words());
     }
 

--- a/src/librustc_mir/dataflow/at_location.rs
+++ b/src/librustc_mir/dataflow/at_location.rs
@@ -139,7 +139,7 @@ impl<BD> FlowsAtLocation for FlowAtLocation<BD>
     where BD: BitDenotation
 {
     fn reset_to_entry_of(&mut self, bb: BasicBlock) {
-        (*self.curr_state).clone_from(self.base_results.sets().on_entry_set_for(bb.index()));
+        self.curr_state.overwrite(self.base_results.sets().on_entry_set_for(bb.index()));
     }
 
     fn reconstruct_statement_effect(&mut self, loc: Location) {

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -242,7 +242,7 @@ impl<'b, 'a: 'b, 'tcx: 'a, BD> PropagationContext<'b, 'a, 'tcx, BD> where BD: Bi
             {
                 let sets = builder.flow_state.sets.for_block(bb_idx);
                 debug_assert!(in_out.words().len() == sets.on_entry.words().len());
-                in_out.clone_from(sets.on_entry);
+                in_out.overwrite(sets.on_entry);
                 in_out.union(sets.gen_set);
                 in_out.subtract(sets.kill_set);
             }

--- a/src/librustc_mir/util/liveness.rs
+++ b/src/librustc_mir/util/liveness.rs
@@ -141,14 +141,14 @@ pub fn liveness_of_locals<'tcx>(mir: &Mir<'tcx>, mode: LivenessMode) -> Liveness
             for &successor in mir.basic_blocks()[b].terminator().successors() {
                 bits.union(&ins[successor]);
             }
-            outs[b].clone_from(&bits);
+            outs[b].overwrite(&bits);
 
             // bits = use ∪ (bits - def)
             def_use[b].apply(&mut bits);
 
             // update bits on entry and flag if they have changed
             if ins[b] != bits {
-                ins[b].clone_from(&bits);
+                ins[b].overwrite(&bits);
                 changed = true;
             }
         }

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -172,12 +172,27 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
             ExprKind::InlineAsm(..) if !self.session.target.target.options.allow_asm => {
                 span_err!(self.session, expr.span, E0472, "asm! is unsupported on this target");
             }
-            ExprKind::ObsoleteInPlace(..) => {
-                self.err_handler()
-                    .struct_span_err(expr.span, "emplacement syntax is obsolete (for now, anyway)")
-                    .note("for more information, see \
-                           <https://github.com/rust-lang/rust/issues/27779#issuecomment-378416911>")
-                    .emit();
+            ExprKind::ObsoleteInPlace(ref place, ref val) => {
+                let mut err = self.err_handler().struct_span_err(
+                    expr.span,
+                    "emplacement syntax is obsolete (for now, anyway)",
+                );
+                err.note(
+                    "for more information, see \
+                     <https://github.com/rust-lang/rust/issues/27779#issuecomment-378416911>"
+                );
+                match val.node {
+                    ExprKind::Lit(ref v) if v.node.is_numeric() => {
+                        err.span_suggestion(
+                            place.span.between(val.span),
+                            "if you meant to write a comparison against a negative value, add a \
+                             space in between `<` and `-`",
+                            "< -".to_string(),
+                        );
+                    }
+                    _ => {}
+                }
+                err.emit();
             }
             _ => {}
         }

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -245,12 +245,11 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                             "f32"
                         };
                         match expr.node {
-                            hir::ExprLit(_) => {  // numeric literal
-                                let snippet = tcx.sess.codemap().span_to_snippet(expr.span)
+                            hir::ExprLit(ref lit) => {  // numeric literal
+                                let snippet = tcx.sess.codemap().span_to_snippet(lit.span)
                                     .unwrap_or("<numeric literal>".to_string());
-                                // FIXME: use the literal for missing snippet
 
-                                err.span_suggestion(expr.span,
+                                err.span_suggestion(lit.span,
                                                     &format!("you must specify a concrete type for \
                                                               this numeric value, like `{}`",
                                                              concrete_type),

--- a/src/libstd/alloc.rs
+++ b/src/libstd/alloc.rs
@@ -61,7 +61,7 @@
 //! ```rust,ignore (demonstrates crates.io usage)
 //! extern crate jemallocator;
 //!
-//! use jemallacator::Jemalloc;
+//! use jemallocator::Jemalloc;
 //!
 //! #[global_allocator]
 //! static GLOBAL: Jemalloc = Jemalloc;

--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -22,7 +22,6 @@ fn main() {
     if cfg!(feature = "backtrace") &&
         !target.contains("cloudabi") &&
         !target.contains("emscripten") &&
-        !target.contains("fuchsia") &&
         !target.contains("msvc") &&
         !target.contains("wasm32")
     {
@@ -68,10 +67,6 @@ fn main() {
         println!("cargo:rustc-link-lib=userenv");
         println!("cargo:rustc-link-lib=shell32");
     } else if target.contains("fuchsia") {
-        // use system-provided libbacktrace
-        if cfg!(feature = "backtrace") {
-            println!("cargo:rustc-link-lib=backtrace");
-        }
         println!("cargo:rustc-link-lib=zircon");
         println!("cargo:rustc-link-lib=fdio");
     } else if target.contains("cloudabi") {

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -49,6 +49,7 @@ use string;
 ///
 /// [`Result<T, E>`]: ../result/enum.Result.html
 /// [`Display`]: ../fmt/trait.Display.html
+/// [`Debug`]: ../fmt/trait.Debug.html
 /// [`cause`]: trait.Error.html#method.cause
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Error: Debug + Display {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1298,6 +1298,16 @@ impl LitKind {
         }
     }
 
+    /// Returns true if this is a numeric literal.
+    pub fn is_numeric(&self) -> bool {
+        match *self {
+            LitKind::Int(..) |
+            LitKind::Float(..) |
+            LitKind::FloatUnsuffixed(..) => true,
+            _ => false,
+        }
+    }
+
     /// Returns true if this literal has no suffix. Note: this will return true
     /// for literals with prefixes such as raw strings and byte strings.
     pub fn is_unsuffixed(&self) -> bool {

--- a/src/test/compile-fail/panic-implementation-missing.rs
+++ b/src/test/compile-fail/panic-implementation-missing.rs
@@ -1,0 +1,18 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: `#[panic_implementation]` function required, but not found
+
+#![feature(lang_items)]
+#![no_main]
+#![no_std]
+
+#[lang = "eh_personality"]
+fn eh() {}

--- a/src/test/compile-fail/weak-lang-item.rs
+++ b/src/test/compile-fail/weak-lang-item.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:weak-lang-items.rs
-// error-pattern: language item required, but not found: `panic_impl`
+// error-pattern: `#[panic_implementation]` function required, but not found
 // error-pattern: language item required, but not found: `eh_personality`
 // ignore-wasm32-bare compiled with panic=abort, personality not required
 

--- a/src/test/ui/issue-51874.rs
+++ b/src/test/ui/issue-51874.rs
@@ -1,0 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let a = (1.0).pow(1.0); //~ ERROR can't call method `pow` on ambiguous numeric type
+}

--- a/src/test/ui/issue-51874.stderr
+++ b/src/test/ui/issue-51874.stderr
@@ -1,0 +1,13 @@
+error[E0689]: can't call method `pow` on ambiguous numeric type `{float}`
+  --> $DIR/issue-51874.rs:12:19
+   |
+LL |     let a = (1.0).pow(1.0); //~ ERROR can't call method `pow` on ambiguous numeric type
+   |                   ^^^
+help: you must specify a concrete type for this numeric value, like `f32`
+   |
+LL |     let a = (1.0_f32).pow(1.0); //~ ERROR can't call method `pow` on ambiguous numeric type
+   |              ^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0689`.

--- a/src/test/ui/suggestions/placement-syntax.rs
+++ b/src/test/ui/suggestions/placement-syntax.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let x = -5;
+    if x<-1 {
+    //~^ ERROR emplacement syntax is obsolete
+        println!("ok");
+    }
+}

--- a/src/test/ui/suggestions/placement-syntax.stderr
+++ b/src/test/ui/suggestions/placement-syntax.stderr
@@ -1,0 +1,14 @@
+error: emplacement syntax is obsolete (for now, anyway)
+  --> $DIR/placement-syntax.rs:13:8
+   |
+LL |     if x<-1 {
+   |        ^^^^
+   |
+   = note: for more information, see <https://github.com/rust-lang/rust/issues/27779#issuecomment-378416911>
+help: if you meant to write a comparison against a negative value, add a space in between `<` and `-`
+   |
+LL |     if x< -1 {
+   |         ^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Successful merges:

 - #51511 (Stabilize Iterator::flatten in 1.29, fixes #48213.)
 - #51853 (Fix some doc links)
 - #51864 (Update liblibc)
 - #51869 (Avoid needless allocations in `liveness_of_locals`.)
 - #51883 (Suggest correct comparison against negative literal)
 - #51890 (Fix inconsequential typo in GlobalAlloc doc example)
 - #51920 (use literal span for concrete type suggestion)
 - #51921 (improve the error message when `#[panic_implementation]` is missing)
 - #51931 (Use in-tree libbacktrace on Fuchsia)

Failed merges:


r? @ghost