### PR TITLE
Add impls for powers of 2 length arrays.

### DIFF
--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -260,7 +260,7 @@ array_impls! {
      0  1  2  3  4  5  6  7  8  9
     10 11 12 13 14 15 16 17 18 19
     20 21 22 23 24 25 26 27 28 29
-    30 31 32 64 128 256 512 1024
+    30 31 32 48 64 128 256 512 1024
 }
 
 // The Default impls cannot be generated using the array_impls! macro because

--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -260,7 +260,7 @@ array_impls! {
      0  1  2  3  4  5  6  7  8  9
     10 11 12 13 14 15 16 17 18 19
     20 21 22 23 24 25 26 27 28 29
-    30 31 32
+    30 31 32 64 128 256 512 1024
 }
 
 // The Default impls cannot be generated using the array_impls! macro because


### PR DESCRIPTION
It would be really nice if there could be more array impls. I know that const generics are coming, but this would allow me to avoid having to write a lot of these impls myself, which would save me a lot of time, and make the eventual conversion to const generics a zero-work job for me. :)

I'm just submitting this as a PR because the change is so small, it's the same amount of effort as writing an issue.