### PR TITLE
clarify why we're suggesting removing semicolon after braced items

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -6132,6 +6132,22 @@ impl<'a> Parser<'a> {
                 err.span_suggestion_short_with_applicability(
                     self.span, msg, "".to_string(), Applicability::MachineApplicable
                 );
+                if !items.is_empty() {  // Issue #51603
+                    let previous_item = &items[items.len()-1];
+                    let previous_item_kind_name = match previous_item.node {
+                        // say "braced struct" because tuple-structs and
+                        // braceless-empty-struct declarations do take a semicolon
+                        ItemKind::Struct(..) => Some("braced struct"),
+                        ItemKind::Enum(..) => Some("enum"),
+                        ItemKind::Trait(..) => Some("trait"),
+                        ItemKind::Union(..) => Some("union"),
+                        _ => None,
+                    };
+                    if let Some(name) = previous_item_kind_name {
+                        err.help(&format!("{} declarations are not followed by a semicolon",
+                                          name));
+                    }
+                }
             } else {
                 err.span_label(self.span, "expected item");
             }

--- a/src/test/ui/issue-46186.stderr
+++ b/src/test/ui/issue-46186.stderr
@@ -3,6 +3,8 @@ error: expected item, found `;`
    |
 LL | }; //~ ERROR expected item, found `;`
    |  ^ help: consider removing this semicolon
+   |
+   = help: braced struct declarations are not followed by a semicolon
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Previously (issue #46186, pull-request #46258), a suggestion was added
to remove the semicolon after we fail to parse an item, but issue #51603
complains that it's still insufficiently obvious why. Let's add a note.

Resolves #51603.