### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1787,15 +1787,18 @@ impl Step for LlvmTools {
         let tmp = tmpdir(builder);
         let image = tmp.join("llvm-tools-image");
         drop(fs::remove_dir_all(&image));
-        t!(fs::create_dir_all(&image.join("bin")));
 
         // Prepare the image directory
+        let bindir = builder
+            .llvm_out(target)
+            .join("bin");
+        let dst = image.join("lib/rustlib")
+            .join(target)
+            .join("bin");
+        t!(fs::create_dir_all(&dst));
         for tool in LLVM_TOOLS {
-            let exe = builder
-                .llvm_out(target)
-                .join("bin")
-                .join(exe(tool, &target));
-            builder.install(&exe, &image.join("bin"), 0o755);
+            let exe = bindir.join(exe(tool, &target));
+            builder.install(&exe, &dst, 0o755);
         }
 
         // Prepare the overlay
@@ -1818,7 +1821,7 @@ impl Step for LlvmTools {
             .arg("--non-installed-overlay").arg(&overlay)
             .arg(format!("--package-name={}-{}", name, target))
             .arg("--legacy-manifest-dirs=rustlib,cargo")
-            .arg("--component-name=llvm-tools");
+            .arg("--component-name=llvm-tools-preview");
 
 
         builder.run(&mut cmd);

--- a/src/libcore/future.rs
+++ b/src/libcore/future.rs
@@ -45,18 +45,18 @@ pub trait Future {
     ///
     /// This function returns:
     ///
-    /// - `Poll::Pending` if the future is not ready yet
-    /// - `Poll::Ready(val)` with the result `val` of this future if it finished
-    /// successfully.
+    /// - [`Poll::Pending`] if the future is not ready yet
+    /// - [`Poll::Ready(val)`] with the result `val` of this future if it
+    ///   finished successfully.
     ///
     /// Once a future has finished, clients should not `poll` it again.
     ///
     /// When a future is not ready yet, `poll` returns
-    /// [`Poll::Pending`](::task::Poll). The future will *also* register the
+    /// `Poll::Pending`. The future will *also* register the
     /// interest of the current task in the value being produced. For example,
     /// if the future represents the availability of data on a socket, then the
     /// task is recorded so that when data arrives, it is woken up (via
-    /// [`cx.waker()`](::task::Context::waker)). Once a task has been woken up,
+    /// [`cx.waker()`]). Once a task has been woken up,
     /// it should attempt to `poll` the future again, which may or may not
     /// produce a final value.
     ///
@@ -90,6 +90,10 @@ pub trait Future {
     /// then any future calls to `poll` may panic, block forever, or otherwise
     /// cause bad behavior. The `Future` trait itself provides no guarantees
     /// about the behavior of `poll` after a future has completed.
+    ///
+    /// [`Poll::Pending`]: ../task/enum.Poll.html#variant.Pending
+    /// [`Poll::Ready(val)`]: ../task/enum.Poll.html#variant.Ready
+    /// [`cx.waker()`]: ../task/struct.Context.html#method.waker
     fn poll(self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output>;
 }
 

--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -1036,8 +1036,6 @@ pub trait Iterator {
     /// Basic usage:
     ///
     /// ```
-    /// #![feature(iterator_flatten)]
-    ///
     /// let data = vec![vec![1, 2, 3, 4], vec![5, 6]];
     /// let flattened = data.into_iter().flatten().collect::<Vec<u8>>();
     /// assert_eq!(flattened, &[1, 2, 3, 4, 5, 6]);
@@ -1046,8 +1044,6 @@ pub trait Iterator {
     /// Mapping and then flattening:
     ///
     /// ```
-    /// #![feature(iterator_flatten)]
-    ///
     /// let words = ["alpha", "beta", "gamma"];
     ///
     /// // chars() returns an iterator
@@ -1074,8 +1070,6 @@ pub trait Iterator {
     /// Flattening once only removes one level of nesting:
     ///
     /// ```
-    /// #![feature(iterator_flatten)]
-    ///
     /// let d3 = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]];
     ///
     /// let d2 = d3.iter().flatten().collect::<Vec<_>>();
@@ -1093,7 +1087,7 @@ pub trait Iterator {
     ///
     /// [`flat_map()`]: #method.flat_map
     #[inline]
-    #[unstable(feature = "iterator_flatten", issue = "48213")]
+    #[stable(feature = "iterator_flatten", since = "1.29")]
     fn flatten(self) -> Flatten<Self>
     where Self: Sized, Self::Item: IntoIterator {
         Flatten { inner: flatten_compat(self) }

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -2524,13 +2524,13 @@ impl<I, U, F> FusedIterator for FlatMap<I, U, F>
 /// [`flatten`]: trait.Iterator.html#method.flatten
 /// [`Iterator`]: trait.Iterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[unstable(feature = "iterator_flatten", issue = "48213")]
+#[stable(feature = "iterator_flatten", since = "1.29")]
 pub struct Flatten<I: Iterator>
 where I::Item: IntoIterator {
     inner: FlattenCompat<I, <I::Item as IntoIterator>::IntoIter>,
 }
 
-#[unstable(feature = "iterator_flatten", issue = "48213")]
+#[stable(feature = "iterator_flatten", since = "1.29")]
 impl<I, U> fmt::Debug for Flatten<I>
     where I: Iterator + fmt::Debug, U: Iterator + fmt::Debug,
           I::Item: IntoIterator<IntoIter = U, Item = U::Item>,
@@ -2540,7 +2540,7 @@ impl<I, U> fmt::Debug for Flatten<I>
     }
 }
 
-#[unstable(feature = "iterator_flatten", issue = "48213")]
+#[stable(feature = "iterator_flatten", since = "1.29")]
 impl<I, U> Clone for Flatten<I>
     where I: Iterator + Clone, U: Iterator + Clone,
           I::Item: IntoIterator<IntoIter = U, Item = U::Item>,
@@ -2548,7 +2548,7 @@ impl<I, U> Clone for Flatten<I>
     fn clone(&self) -> Self { Flatten { inner: self.inner.clone() } }
 }
 
-#[unstable(feature = "iterator_flatten", issue = "48213")]
+#[stable(feature = "iterator_flatten", since = "1.29")]
 impl<I, U> Iterator for Flatten<I>
     where I: Iterator, U: Iterator,
           I::Item: IntoIterator<IntoIter = U, Item = U::Item>
@@ -2576,7 +2576,7 @@ impl<I, U> Iterator for Flatten<I>
     }
 }
 
-#[unstable(feature = "iterator_flatten", issue = "48213")]
+#[stable(feature = "iterator_flatten", since = "1.29")]
 impl<I, U> DoubleEndedIterator for Flatten<I>
     where I: DoubleEndedIterator, U: DoubleEndedIterator,
           I::Item: IntoIterator<IntoIter = U, Item = U::Item>
@@ -2599,7 +2599,7 @@ impl<I, U> DoubleEndedIterator for Flatten<I>
     }
 }
 
-#[unstable(feature = "iterator_flatten", issue = "48213")]
+#[stable(feature = "iterator_flatten", since = "1.29")]
 impl<I, U> FusedIterator for Flatten<I>
     where I: FusedIterator, U: Iterator,
           I::Item: IntoIterator<IntoIter = U, Item = U::Item> {}

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -89,7 +89,6 @@
 #![feature(extern_types)]
 #![feature(fundamental)]
 #![feature(intrinsics)]
-#![feature(iterator_flatten)]
 #![feature(lang_items)]
 #![feature(link_llvm_intrinsics)]
 #![feature(never_type)]

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -23,7 +23,6 @@
 #![feature(flt2dec)]
 #![feature(fmt_internals)]
 #![feature(hashmap_internals)]
-#![feature(iterator_flatten)]
 #![feature(pattern)]
 #![feature(range_is_empty)]
 #![feature(raw)]

--- a/src/librustc/middle/weak_lang_items.rs
+++ b/src/librustc/middle/weak_lang_items.rs
@@ -112,9 +112,13 @@ fn verify<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         if missing.contains(&lang_items::$item) &&
            !whitelisted(tcx, lang_items::$item) &&
            items.$name().is_none() {
-            tcx.sess.err(&format!("language item required, but not found: `{}`",
-                                  stringify!($name)));
-
+            if lang_items::$item == lang_items::PanicImplLangItem {
+                tcx.sess.err(&format!("`#[panic_implementation]` function required, \
+                                        but not found"));
+            } else {
+                tcx.sess.err(&format!("language item required, but not found: `{}`",
+                                        stringify!($name)));
+            }
         }
     )*
 }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2794,7 +2794,7 @@ impl<'a> Resolver<'a> {
     /// A variant of `smart_resolve_path` where you also specify extra
     /// information about where the path came from; this extra info is
     /// sometimes needed for the lint that recommends rewriting
-    /// absoluate paths to `crate`, so that it knows how to frame the
+    /// absolute paths to `crate`, so that it knows how to frame the
     /// suggestion. If you are just resolving a path like `foo::bar`
     /// that appears...somewhere, though, then you just want
     /// `CrateLint::SimplePath`, which is what `smart_resolve_path`

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -245,12 +245,11 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                             "f32"
                         };
                         match expr.node {
-                            hir::ExprLit(_) => {  // numeric literal
-                                let snippet = tcx.sess.codemap().span_to_snippet(expr.span)
+                            hir::ExprLit(ref lit) => {  // numeric literal
+                                let snippet = tcx.sess.codemap().span_to_snippet(lit.span)
                                     .unwrap_or("<numeric literal>".to_string());
-                                // FIXME: use the literal for missing snippet
 
-                                err.span_suggestion(expr.span,
+                                err.span_suggestion(lit.span,
                                                     &format!("you must specify a concrete type for \
                                                               this numeric value, like `{}`",
                                                              concrete_type),

--- a/src/libstd/alloc.rs
+++ b/src/libstd/alloc.rs
@@ -61,7 +61,7 @@
 //! ```rust,ignore (demonstrates crates.io usage)
 //! extern crate jemallocator;
 //!
-//! use jemallacator::Jemalloc;
+//! use jemallocator::Jemalloc;
 //!
 //! #[global_allocator]
 //! static GLOBAL: Jemalloc = Jemalloc;

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -49,6 +49,7 @@ use string;
 ///
 /// [`Result<T, E>`]: ../result/enum.Result.html
 /// [`Display`]: ../fmt/trait.Display.html
+/// [`Debug`]: ../fmt/trait.Debug.html
 /// [`cause`]: trait.Error.html#method.cause
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Error: Debug + Display {

--- a/src/test/compile-fail/panic-implementation-missing.rs
+++ b/src/test/compile-fail/panic-implementation-missing.rs
@@ -1,0 +1,18 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: `#[panic_implementation]` function required, but not found
+
+#![feature(lang_items)]
+#![no_main]
+#![no_std]
+
+#[lang = "eh_personality"]
+fn eh() {}

--- a/src/test/compile-fail/weak-lang-item.rs
+++ b/src/test/compile-fail/weak-lang-item.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:weak-lang-items.rs
-// error-pattern: language item required, but not found: `panic_impl`
+// error-pattern: `#[panic_implementation]` function required, but not found
 // error-pattern: language item required, but not found: `eh_personality`
 // ignore-wasm32-bare compiled with panic=abort, personality not required
 

--- a/src/test/ui/issue-51874.rs
+++ b/src/test/ui/issue-51874.rs
@@ -1,0 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let a = (1.0).pow(1.0); //~ ERROR can't call method `pow` on ambiguous numeric type
+}

--- a/src/test/ui/issue-51874.stderr
+++ b/src/test/ui/issue-51874.stderr
@@ -1,0 +1,13 @@
+error[E0689]: can't call method `pow` on ambiguous numeric type `{float}`
+  --> $DIR/issue-51874.rs:12:19
+   |
+LL |     let a = (1.0).pow(1.0); //~ ERROR can't call method `pow` on ambiguous numeric type
+   |                   ^^^
+help: you must specify a concrete type for this numeric value, like `f32`
+   |
+LL |     let a = (1.0_f32).pow(1.0); //~ ERROR can't call method `pow` on ambiguous numeric type
+   |              ^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0689`.

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -298,11 +298,11 @@ impl Builder {
         self.package("rls-preview", &mut manifest.pkg, HOSTS);
         self.package("rustfmt-preview", &mut manifest.pkg, HOSTS);
         self.package("rust-analysis", &mut manifest.pkg, TARGETS);
-        self.package("llvm-tools", &mut manifest.pkg, TARGETS);
+        self.package("llvm-tools-preview", &mut manifest.pkg, TARGETS);
 
         let rls_present = manifest.pkg.contains_key("rls-preview");
         let rustfmt_present = manifest.pkg.contains_key("rustfmt-preview");
-        let llvm_tools_present = manifest.pkg.contains_key("llvm-tools");
+        let llvm_tools_present = manifest.pkg.contains_key("llvm-tools-preview");
 
         if rls_present {
             manifest.renames.insert("rls".to_owned(), Rename { to: "rls-preview".to_owned() });
@@ -359,7 +359,7 @@ impl Builder {
             }
             if llvm_tools_present {
                 extensions.push(Component {
-                    pkg: "llvm-tools".to_string(),
+                    pkg: "llvm-tools-preview".to_string(),
                     target: host.to_string(),
                 });
             }
@@ -486,7 +486,7 @@ impl Builder {
             &self.rls_version
         } else if component == "rustfmt" || component == "rustfmt-preview" {
             &self.rustfmt_version
-        } else if component == "llvm-tools" {
+        } else if component == "llvm-tools" || component == "llvm-tools-preview" {
             &self.llvm_tools_version
         } else {
             &self.rust_version
@@ -500,7 +500,7 @@ impl Builder {
             &self.rls_git_commit_hash
         } else if component == "rustfmt" || component == "rustfmt-preview" {
             &self.rustfmt_git_commit_hash
-        } else if component == "llvm-tools" {
+        } else if component == "llvm-tools" || component == "llvm-tools-preview" {
             &self.llvm_tools_git_commit_hash
         } else {
             &self.rust_git_commit_hash


### PR DESCRIPTION
Successful merges:

 - #51511 (Stabilize Iterator::flatten in 1.29, fixes #48213.)
 - #51853 (Fix some doc links)
 - #51890 (Fix inconsequential typo in GlobalAlloc doc example)
 - #51920 (use literal span for concrete type suggestion)
 - #51921 (improve the error message when `#[panic_implementation]` is missing)
 - #51922 (rename the llvm-tools component to llvm-tools-preview and tweak its image)
 - #51961 (Fix typo in /src/librustc_resolve/lib.rs)

Failed merges:


r? @ghost