### PR TITLE
The stack size is also okay if the current limit matches the maximum

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1504,7 +1504,7 @@ pub fn in_rustc_thread<F, R>(f: F) -> Result<R, Box<Any + Send>>
             let err = io::Error::last_os_error();
             error!("in_rustc_thread: error calling getrlimit: {}", err);
             true
-        } else if rlim.rlim_max < STACK_SIZE as libc::rlim_t {
+        } else if rlim.rlim_max <= STACK_SIZE as libc::rlim_t {
             true
         } else {
             std::rt::deinit_stack_guard();


### PR DESCRIPTION
I would like an opinion on this PR. I have two questions about the patch and the rationale. The first one is just practical: is the logic sound? The code tries to use set_rlimit to set te stack size to a certain maximum. To determine whether it needs to do this, it first gets the current limit and compares the desired limit to that. The check just checks whether the current limit is higher than the desired maximum, but in my view it is also okay if it is equal to the desired maximum. That's what set_rlimit aims to do! As far as I could find in documentation there is no off-by-one logic in set_rlimit. Will this patch work correctly?

The second question is about the underlying rationale. In Haiku the set_rlimit function is not implemented for stack size. This leads to the error message being displayed that the operation failed. Now the initial impulse was to create code that works around this issue with platform-specific logic. Luckily, the maximum stack size on Haiku is [also 16 MB](https://github.com/haiku/haiku/blob/8547d09e97f8f27852bfdcb312d0ca4652297d01/headers/private/system/thread_defs.h#L17), just like the maximum Rust would like to set. Thus instead of implementing a platform specific logic, I can just 'fix' the logic and not worry about set_rlimit. 

For this second question I am wondering if instead I do have to add platform specific code, as it now seems that I am hiding a possible future issue, when Haiku's maximum stack size might change. At the other hand, the error message will show up then again, which means it is not really hiding, and it saves the codebase from getting additional platform-specific logic. It would be great to hear other thoughts on this.
