### PR TITLE
[cross-lang-lto] Allow the linker to choose the LTO-plugin (which is useful when using LLD)

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -98,6 +98,7 @@ pub enum Lto {
 #[derive(Clone, PartialEq, Hash)]
 pub enum CrossLangLto {
     LinkerPlugin(PathBuf),
+    LinkerPluginAuto,
     NoLink,
     Disabled
 }
@@ -106,6 +107,7 @@ impl CrossLangLto {
     pub fn embed_bitcode(&self) -> bool {
         match *self {
             CrossLangLto::LinkerPlugin(_) |
+            CrossLangLto::LinkerPluginAuto |
             CrossLangLto::NoLink => true,
             CrossLangLto::Disabled => false,
         }
@@ -1020,7 +1022,7 @@ macro_rules! options {
                 let mut bool_arg = None;
                 if parse_opt_bool(&mut bool_arg, v) {
                     *slot = if bool_arg.unwrap() {
-                        CrossLangLto::NoLink
+                        CrossLangLto::LinkerPluginAuto
                     } else {
                         CrossLangLto::Disabled
                     };


### PR DESCRIPTION
This PR allows for not specifying an LTO-linker plugin but still let `rustc` invoke the linker with the correct plugin arguments. This is useful when using LLD which does not need the `-plugin` argument. Since LLD is the best linker for this scenario anyway, this change should improve ergonomics quite a bit.

r? @alexcrichton 