### PR TITLE
Add the `amdgpu-kernel` ABI.

### DIFF
--- a/src/librustc/ich/impls_syntax.rs
+++ b/src/librustc/ich/impls_syntax.rs
@@ -114,6 +114,7 @@ impl_stable_hash_for!(enum ::rustc_target::spec::abi::Abi {
     PtxKernel,
     Msp430Interrupt,
     X86Interrupt,
+    AmdGpuKernel,
     Rust,
     C,
     System,

--- a/src/librustc_codegen_llvm/abi.rs
+++ b/src/librustc_codegen_llvm/abi.rs
@@ -343,6 +343,7 @@ impl<'a, 'tcx> FnTypeExt<'a, 'tcx> for FnType<'tcx, Ty<'tcx>> {
             PtxKernel => Conv::PtxKernel,
             Msp430Interrupt => Conv::Msp430Intr,
             X86Interrupt => Conv::X86Intr,
+            AmdGpuKernel => Conv::AmdGpuKernel,
 
             // These API constants ought to be more specific...
             Cdecl => Conv::C,
@@ -608,6 +609,7 @@ impl<'a, 'tcx> FnTypeExt<'a, 'tcx> for FnType<'tcx, Ty<'tcx>> {
     fn llvm_cconv(&self) -> llvm::CallConv {
         match self.conv {
             Conv::C => llvm::CCallConv,
+            Conv::AmdGpuKernel => llvm::AmdGpuKernel,
             Conv::ArmAapcs => llvm::ArmAapcsCallConv,
             Conv::Msp430Intr => llvm::Msp430Intr,
             Conv::PtxKernel => llvm::PtxKernel,

--- a/src/librustc_llvm/ffi.rs
+++ b/src/librustc_llvm/ffi.rs
@@ -55,6 +55,7 @@ pub enum CallConv {
     X86_64_Win64 = 79,
     X86_VectorCall = 80,
     X86_Intr = 83,
+    AmdGpuKernel = 91,
 }
 
 /// LLVMRustLinkage

--- a/src/librustc_target/abi/call/mod.rs
+++ b/src/librustc_target/abi/call/mod.rs
@@ -436,6 +436,8 @@ pub enum Conv {
 
     X86_64SysV,
     X86_64Win64,
+
+    AmdGpuKernel,
 }
 
 /// Metadata describing how the arguments to a native function

--- a/src/librustc_target/spec/abi.rs
+++ b/src/librustc_target/spec/abi.rs
@@ -27,6 +27,7 @@ pub enum Abi {
     PtxKernel,
     Msp430Interrupt,
     X86Interrupt,
+    AmdGpuKernel,
 
     // Multiplatform / generic ABIs
     Rust,
@@ -63,6 +64,7 @@ const AbiDatas: &'static [AbiData] = &[
     AbiData {abi: Abi::PtxKernel, name: "ptx-kernel", generic: false },
     AbiData {abi: Abi::Msp430Interrupt, name: "msp430-interrupt", generic: false },
     AbiData {abi: Abi::X86Interrupt, name: "x86-interrupt", generic: false },
+    AbiData {abi: Abi::AmdGpuKernel, name: "amdgpu-kernel", generic: false },
 
     // Cross-platform ABIs
     AbiData {abi: Abi::Rust, name: "Rust", generic: true },

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -484,6 +484,8 @@ declare_features! (
 
     // #[alloc_error_handler]
     (active, alloc_error_handler, "1.29.0", Some(51540), None),
+
+    (active, abi_amdgpu_kernel, "1.29.0", Some(51575), None),
 );
 
 declare_features! (
@@ -1438,6 +1440,10 @@ impl<'a> PostExpansionVisitor<'a> {
             Abi::X86Interrupt => {
                 gate_feature_post!(&self, abi_x86_interrupt, span,
                                    "x86-interrupt ABI is experimental and subject to change");
+            },
+            Abi::AmdGpuKernel => {
+                gate_feature_post!(&self, abi_amdgpu_kernel, span,
+                                   "amdgpu-kernel ABI is experimental and subject to change");
             },
             // Stable
             Abi::Cdecl |

--- a/src/test/ui/codemap_tests/unicode.stderr
+++ b/src/test/ui/codemap_tests/unicode.stderr
@@ -4,7 +4,7 @@ error[E0703]: invalid ABI: found `路濫狼á́́`
 LL | extern "路濫狼á́́" fn foo() {} //~ ERROR invalid ABI
    |        ^^^^^^^^^ invalid ABI
    |
-   = help: valid ABIs: cdecl, stdcall, fastcall, vectorcall, thiscall, aapcs, win64, sysv64, ptx-kernel, msp430-interrupt, x86-interrupt, Rust, C, system, rust-intrinsic, rust-call, platform-intrinsic, unadjusted
+   = help: valid ABIs: cdecl, stdcall, fastcall, vectorcall, thiscall, aapcs, win64, sysv64, ptx-kernel, msp430-interrupt, x86-interrupt, amdgpu-kernel, Rust, C, system, rust-intrinsic, rust-call, platform-intrinsic, unadjusted
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gate-abi.rs
+++ b/src/test/ui/feature-gate-abi.rs
@@ -7,13 +7,14 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
+// ignore-tidy-linelength
 // gate-test-intrinsics
 // gate-test-platform_intrinsics
 // gate-test-abi_vectorcall
 // gate-test-abi_thiscall
 // gate-test-abi_ptx
 // gate-test-abi_x86_interrupt
+// gate-test-abi_amdgpu_kernel
 
 // Functions
 extern "rust-intrinsic" fn f1() {} //~ ERROR intrinsics are subject to change
@@ -24,6 +25,7 @@ extern "msp430-interrupt" fn f5() {} //~ ERROR msp430-interrupt ABI is experimen
 extern "ptx-kernel" fn f6() {} //~ ERROR PTX ABIs are experimental and subject to change
 extern "x86-interrupt" fn f7() {} //~ ERROR x86-interrupt ABI is experimental
 extern "thiscall" fn f8() {} //~ ERROR thiscall is experimental and subject to change
+extern "amdgpu-kernel" fn f9() {} //~ ERROR amdgpu-kernel ABI is experimental and subject to change
 
 // Methods in trait definition
 trait Tr {
@@ -35,6 +37,7 @@ trait Tr {
     extern "ptx-kernel" fn m6(); //~ ERROR PTX ABIs are experimental and subject to change
     extern "x86-interrupt" fn m7(); //~ ERROR x86-interrupt ABI is experimental
     extern "thiscall" fn m8(); //~ ERROR thiscall is experimental and subject to change
+    extern "amdgpu-kernel" fn m9(); //~ ERROR amdgpu-kernel ABI is experimental and subject to change
 
     extern "rust-intrinsic" fn dm1() {} //~ ERROR intrinsics are subject to change
     extern "platform-intrinsic" fn dm2() {} //~ ERROR platform intrinsics are experimental
@@ -44,6 +47,7 @@ trait Tr {
     extern "ptx-kernel" fn dm6() {} //~ ERROR PTX ABIs are experimental and subject to change
     extern "x86-interrupt" fn dm7() {} //~ ERROR x86-interrupt ABI is experimental
     extern "thiscall" fn dm8() {} //~ ERROR thiscall is experimental and subject to change
+    extern "amdgpu-kernel" fn dm9() {} //~ ERROR amdgpu-kernel ABI is experimental and subject to change
 }
 
 struct S;
@@ -58,6 +62,7 @@ impl Tr for S {
     extern "ptx-kernel" fn m6() {} //~ ERROR PTX ABIs are experimental and subject to change
     extern "x86-interrupt" fn m7() {} //~ ERROR x86-interrupt ABI is experimental
     extern "thiscall" fn m8() {} //~ ERROR thiscall is experimental and subject to change
+    extern "amdgpu-kernel" fn m9() {} //~ ERROR amdgpu-kernel ABI is experimental and subject to change
 }
 
 // Methods in inherent impl
@@ -70,6 +75,7 @@ impl S {
     extern "ptx-kernel" fn im6() {} //~ ERROR PTX ABIs are experimental and subject to change
     extern "x86-interrupt" fn im7() {} //~ ERROR x86-interrupt ABI is experimental
     extern "thiscall" fn im8() {} //~ ERROR thiscall is experimental and subject to change
+    extern "amdgpu-kernel" fn im9() {} //~ ERROR amdgpu-kernel ABI is experimental and subject to change
 }
 
 // Function pointer types
@@ -81,6 +87,7 @@ type A5 = extern "msp430-interrupt" fn(); //~ ERROR msp430-interrupt ABI is expe
 type A6 = extern "ptx-kernel" fn (); //~ ERROR PTX ABIs are experimental and subject to change
 type A7 = extern "x86-interrupt" fn(); //~ ERROR x86-interrupt ABI is experimental
 type A8 = extern "thiscall" fn(); //~ ERROR thiscall is experimental and subject to change
+type A9 = extern "amdgpu-kernel" fn(); //~ ERROR amdgpu-kernel ABI is experimental and subject to change
 
 // Foreign modules
 extern "rust-intrinsic" {} //~ ERROR intrinsics are subject to change
@@ -91,5 +98,6 @@ extern "msp430-interrupt" {} //~ ERROR msp430-interrupt ABI is experimental
 extern "ptx-kernel" {} //~ ERROR PTX ABIs are experimental and subject to change
 extern "x86-interrupt" {} //~ ERROR x86-interrupt ABI is experimental
 extern "thiscall" {} //~ ERROR thiscall is experimental and subject to change
+extern "amdgpu-kernel" {} //~ ERROR amdgpu-kernel ABI is experimental and subject to change
 
 fn main() {}

--- a/src/test/ui/feature-gate-abi.stderr
+++ b/src/test/ui/feature-gate-abi.stderr
@@ -1,5 +1,5 @@
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:19:1
+  --> $DIR/feature-gate-abi.rs:20:1
    |
 LL | extern "rust-intrinsic" fn f1() {} //~ ERROR intrinsics are subject to change
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | extern "rust-intrinsic" fn f1() {} //~ ERROR intrinsics are subject to chan
    = help: add #![feature(intrinsics)] to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy (see issue #27731)
-  --> $DIR/feature-gate-abi.rs:20:1
+  --> $DIR/feature-gate-abi.rs:21:1
    |
 LL | extern "platform-intrinsic" fn f2() {} //~ ERROR platform intrinsics are experimental
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL | extern "platform-intrinsic" fn f2() {} //~ ERROR platform intrinsics are ex
    = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:21:1
+  --> $DIR/feature-gate-abi.rs:22:1
    |
 LL | extern "vectorcall" fn f3() {} //~ ERROR vectorcall is experimental and subject to change
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL | extern "vectorcall" fn f3() {} //~ ERROR vectorcall is experimental and sub
    = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change (see issue #29625)
-  --> $DIR/feature-gate-abi.rs:22:1
+  --> $DIR/feature-gate-abi.rs:23:1
    |
 LL | extern "rust-call" fn f4() {} //~ ERROR rust-call ABI is subject to change
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -31,7 +31,7 @@ LL | extern "rust-call" fn f4() {} //~ ERROR rust-call ABI is subject to change
    = help: add #![feature(unboxed_closures)] to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change (see issue #38487)
-  --> $DIR/feature-gate-abi.rs:23:1
+  --> $DIR/feature-gate-abi.rs:24:1
    |
 LL | extern "msp430-interrupt" fn f5() {} //~ ERROR msp430-interrupt ABI is experimental
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL | extern "msp430-interrupt" fn f5() {} //~ ERROR msp430-interrupt ABI is expe
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
-  --> $DIR/feature-gate-abi.rs:24:1
+  --> $DIR/feature-gate-abi.rs:25:1
    |
 LL | extern "ptx-kernel" fn f6() {} //~ ERROR PTX ABIs are experimental and subject to change
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -47,7 +47,7 @@ LL | extern "ptx-kernel" fn f6() {} //~ ERROR PTX ABIs are experimental and subj
    = help: add #![feature(abi_ptx)] to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change (see issue #40180)
-  --> $DIR/feature-gate-abi.rs:25:1
+  --> $DIR/feature-gate-abi.rs:26:1
    |
 LL | extern "x86-interrupt" fn f7() {} //~ ERROR x86-interrupt ABI is experimental
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -55,15 +55,23 @@ LL | extern "x86-interrupt" fn f7() {} //~ ERROR x86-interrupt ABI is experiment
    = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:26:1
+  --> $DIR/feature-gate-abi.rs:27:1
    |
 LL | extern "thiscall" fn f8() {} //~ ERROR thiscall is experimental and subject to change
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(abi_thiscall)] to the crate attributes to enable
 
+error[E0658]: amdgpu-kernel ABI is experimental and subject to change (see issue #51575)
+  --> $DIR/feature-gate-abi.rs:28:1
+   |
+LL | extern "amdgpu-kernel" fn f9() {} //~ ERROR amdgpu-kernel ABI is experimental and subject to change
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(abi_amdgpu_kernel)] to the crate attributes to enable
+
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:30:5
+  --> $DIR/feature-gate-abi.rs:32:5
    |
 LL |     extern "rust-intrinsic" fn m1(); //~ ERROR intrinsics are subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,7 +79,7 @@ LL |     extern "rust-intrinsic" fn m1(); //~ ERROR intrinsics are subject to ch
    = help: add #![feature(intrinsics)] to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy (see issue #27731)
-  --> $DIR/feature-gate-abi.rs:31:5
+  --> $DIR/feature-gate-abi.rs:33:5
    |
 LL |     extern "platform-intrinsic" fn m2(); //~ ERROR platform intrinsics are experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -79,7 +87,7 @@ LL |     extern "platform-intrinsic" fn m2(); //~ ERROR platform intrinsics are 
    = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:32:5
+  --> $DIR/feature-gate-abi.rs:34:5
    |
 LL |     extern "vectorcall" fn m3(); //~ ERROR vectorcall is experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -87,7 +95,7 @@ LL |     extern "vectorcall" fn m3(); //~ ERROR vectorcall is experimental and s
    = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change (see issue #29625)
-  --> $DIR/feature-gate-abi.rs:33:5
+  --> $DIR/feature-gate-abi.rs:35:5
    |
 LL |     extern "rust-call" fn m4(); //~ ERROR rust-call ABI is subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -95,7 +103,7 @@ LL |     extern "rust-call" fn m4(); //~ ERROR rust-call ABI is subject to chang
    = help: add #![feature(unboxed_closures)] to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change (see issue #38487)
-  --> $DIR/feature-gate-abi.rs:34:5
+  --> $DIR/feature-gate-abi.rs:36:5
    |
 LL |     extern "msp430-interrupt" fn m5(); //~ ERROR msp430-interrupt ABI is experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -103,7 +111,7 @@ LL |     extern "msp430-interrupt" fn m5(); //~ ERROR msp430-interrupt ABI is ex
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
-  --> $DIR/feature-gate-abi.rs:35:5
+  --> $DIR/feature-gate-abi.rs:37:5
    |
 LL |     extern "ptx-kernel" fn m6(); //~ ERROR PTX ABIs are experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -111,7 +119,7 @@ LL |     extern "ptx-kernel" fn m6(); //~ ERROR PTX ABIs are experimental and su
    = help: add #![feature(abi_ptx)] to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change (see issue #40180)
-  --> $DIR/feature-gate-abi.rs:36:5
+  --> $DIR/feature-gate-abi.rs:38:5
    |
 LL |     extern "x86-interrupt" fn m7(); //~ ERROR x86-interrupt ABI is experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -119,15 +127,23 @@ LL |     extern "x86-interrupt" fn m7(); //~ ERROR x86-interrupt ABI is experime
    = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:37:5
+  --> $DIR/feature-gate-abi.rs:39:5
    |
 LL |     extern "thiscall" fn m8(); //~ ERROR thiscall is experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(abi_thiscall)] to the crate attributes to enable
 
+error[E0658]: amdgpu-kernel ABI is experimental and subject to change (see issue #51575)
+  --> $DIR/feature-gate-abi.rs:40:5
+   |
+LL |     extern "amdgpu-kernel" fn m9(); //~ ERROR amdgpu-kernel ABI is experimental and subject to change
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(abi_amdgpu_kernel)] to the crate attributes to enable
+
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:39:5
+  --> $DIR/feature-gate-abi.rs:42:5
    |
 LL |     extern "rust-intrinsic" fn dm1() {} //~ ERROR intrinsics are subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -135,7 +151,7 @@ LL |     extern "rust-intrinsic" fn dm1() {} //~ ERROR intrinsics are subject to
    = help: add #![feature(intrinsics)] to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy (see issue #27731)
-  --> $DIR/feature-gate-abi.rs:40:5
+  --> $DIR/feature-gate-abi.rs:43:5
    |
 LL |     extern "platform-intrinsic" fn dm2() {} //~ ERROR platform intrinsics are experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -143,7 +159,7 @@ LL |     extern "platform-intrinsic" fn dm2() {} //~ ERROR platform intrinsics a
    = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:41:5
+  --> $DIR/feature-gate-abi.rs:44:5
    |
 LL |     extern "vectorcall" fn dm3() {} //~ ERROR vectorcall is experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -151,7 +167,7 @@ LL |     extern "vectorcall" fn dm3() {} //~ ERROR vectorcall is experimental an
    = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change (see issue #29625)
-  --> $DIR/feature-gate-abi.rs:42:5
+  --> $DIR/feature-gate-abi.rs:45:5
    |
 LL |     extern "rust-call" fn dm4() {} //~ ERROR rust-call ABI is subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -159,7 +175,7 @@ LL |     extern "rust-call" fn dm4() {} //~ ERROR rust-call ABI is subject to ch
    = help: add #![feature(unboxed_closures)] to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change (see issue #38487)
-  --> $DIR/feature-gate-abi.rs:43:5
+  --> $DIR/feature-gate-abi.rs:46:5
    |
 LL |     extern "msp430-interrupt" fn dm5() {} //~ ERROR msp430-interrupt ABI is experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -167,7 +183,7 @@ LL |     extern "msp430-interrupt" fn dm5() {} //~ ERROR msp430-interrupt ABI is
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
-  --> $DIR/feature-gate-abi.rs:44:5
+  --> $DIR/feature-gate-abi.rs:47:5
    |
 LL |     extern "ptx-kernel" fn dm6() {} //~ ERROR PTX ABIs are experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -175,7 +191,7 @@ LL |     extern "ptx-kernel" fn dm6() {} //~ ERROR PTX ABIs are experimental and
    = help: add #![feature(abi_ptx)] to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change (see issue #40180)
-  --> $DIR/feature-gate-abi.rs:45:5
+  --> $DIR/feature-gate-abi.rs:48:5
    |
 LL |     extern "x86-interrupt" fn dm7() {} //~ ERROR x86-interrupt ABI is experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -183,15 +199,23 @@ LL |     extern "x86-interrupt" fn dm7() {} //~ ERROR x86-interrupt ABI is exper
    = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:46:5
+  --> $DIR/feature-gate-abi.rs:49:5
    |
 LL |     extern "thiscall" fn dm8() {} //~ ERROR thiscall is experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(abi_thiscall)] to the crate attributes to enable
 
+error[E0658]: amdgpu-kernel ABI is experimental and subject to change (see issue #51575)
+  --> $DIR/feature-gate-abi.rs:50:5
+   |
+LL |     extern "amdgpu-kernel" fn dm9() {} //~ ERROR amdgpu-kernel ABI is experimental and subject to change
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(abi_amdgpu_kernel)] to the crate attributes to enable
+
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:53:5
+  --> $DIR/feature-gate-abi.rs:57:5
    |
 LL |     extern "rust-intrinsic" fn m1() {} //~ ERROR intrinsics are subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -199,7 +223,7 @@ LL |     extern "rust-intrinsic" fn m1() {} //~ ERROR intrinsics are subject to 
    = help: add #![feature(intrinsics)] to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy (see issue #27731)
-  --> $DIR/feature-gate-abi.rs:54:5
+  --> $DIR/feature-gate-abi.rs:58:5
    |
 LL |     extern "platform-intrinsic" fn m2() {} //~ ERROR platform intrinsics are experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -207,7 +231,7 @@ LL |     extern "platform-intrinsic" fn m2() {} //~ ERROR platform intrinsics ar
    = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:55:5
+  --> $DIR/feature-gate-abi.rs:59:5
    |
 LL |     extern "vectorcall" fn m3() {} //~ ERROR vectorcall is experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -215,7 +239,7 @@ LL |     extern "vectorcall" fn m3() {} //~ ERROR vectorcall is experimental and
    = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change (see issue #29625)
-  --> $DIR/feature-gate-abi.rs:56:5
+  --> $DIR/feature-gate-abi.rs:60:5
    |
 LL |     extern "rust-call" fn m4() {} //~ ERROR rust-call ABI is subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -223,7 +247,7 @@ LL |     extern "rust-call" fn m4() {} //~ ERROR rust-call ABI is subject to cha
    = help: add #![feature(unboxed_closures)] to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change (see issue #38487)
-  --> $DIR/feature-gate-abi.rs:57:5
+  --> $DIR/feature-gate-abi.rs:61:5
    |
 LL |     extern "msp430-interrupt" fn m5() {} //~ ERROR msp430-interrupt ABI is experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -231,7 +255,7 @@ LL |     extern "msp430-interrupt" fn m5() {} //~ ERROR msp430-interrupt ABI is 
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
-  --> $DIR/feature-gate-abi.rs:58:5
+  --> $DIR/feature-gate-abi.rs:62:5
    |
 LL |     extern "ptx-kernel" fn m6() {} //~ ERROR PTX ABIs are experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -239,7 +263,7 @@ LL |     extern "ptx-kernel" fn m6() {} //~ ERROR PTX ABIs are experimental and 
    = help: add #![feature(abi_ptx)] to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change (see issue #40180)
-  --> $DIR/feature-gate-abi.rs:59:5
+  --> $DIR/feature-gate-abi.rs:63:5
    |
 LL |     extern "x86-interrupt" fn m7() {} //~ ERROR x86-interrupt ABI is experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -247,15 +271,23 @@ LL |     extern "x86-interrupt" fn m7() {} //~ ERROR x86-interrupt ABI is experi
    = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:60:5
+  --> $DIR/feature-gate-abi.rs:64:5
    |
 LL |     extern "thiscall" fn m8() {} //~ ERROR thiscall is experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(abi_thiscall)] to the crate attributes to enable
 
-error[E0658]: intrinsics are subject to change
+error[E0658]: amdgpu-kernel ABI is experimental and subject to change (see issue #51575)
   --> $DIR/feature-gate-abi.rs:65:5
+   |
+LL |     extern "amdgpu-kernel" fn m9() {} //~ ERROR amdgpu-kernel ABI is experimental and subject to change
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(abi_amdgpu_kernel)] to the crate attributes to enable
+
+error[E0658]: intrinsics are subject to change
+  --> $DIR/feature-gate-abi.rs:70:5
    |
 LL |     extern "rust-intrinsic" fn im1() {} //~ ERROR intrinsics are subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -263,7 +295,7 @@ LL |     extern "rust-intrinsic" fn im1() {} //~ ERROR intrinsics are subject to
    = help: add #![feature(intrinsics)] to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy (see issue #27731)
-  --> $DIR/feature-gate-abi.rs:66:5
+  --> $DIR/feature-gate-abi.rs:71:5
    |
 LL |     extern "platform-intrinsic" fn im2() {} //~ ERROR platform intrinsics are experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -271,7 +303,7 @@ LL |     extern "platform-intrinsic" fn im2() {} //~ ERROR platform intrinsics a
    = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:67:5
+  --> $DIR/feature-gate-abi.rs:72:5
    |
 LL |     extern "vectorcall" fn im3() {} //~ ERROR vectorcall is experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -279,7 +311,7 @@ LL |     extern "vectorcall" fn im3() {} //~ ERROR vectorcall is experimental an
    = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change (see issue #29625)
-  --> $DIR/feature-gate-abi.rs:68:5
+  --> $DIR/feature-gate-abi.rs:73:5
    |
 LL |     extern "rust-call" fn im4() {} //~ ERROR rust-call ABI is subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -287,7 +319,7 @@ LL |     extern "rust-call" fn im4() {} //~ ERROR rust-call ABI is subject to ch
    = help: add #![feature(unboxed_closures)] to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change (see issue #38487)
-  --> $DIR/feature-gate-abi.rs:69:5
+  --> $DIR/feature-gate-abi.rs:74:5
    |
 LL |     extern "msp430-interrupt" fn im5() {} //~ ERROR msp430-interrupt ABI is experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -295,7 +327,7 @@ LL |     extern "msp430-interrupt" fn im5() {} //~ ERROR msp430-interrupt ABI is
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
-  --> $DIR/feature-gate-abi.rs:70:5
+  --> $DIR/feature-gate-abi.rs:75:5
    |
 LL |     extern "ptx-kernel" fn im6() {} //~ ERROR PTX ABIs are experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -303,7 +335,7 @@ LL |     extern "ptx-kernel" fn im6() {} //~ ERROR PTX ABIs are experimental and
    = help: add #![feature(abi_ptx)] to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change (see issue #40180)
-  --> $DIR/feature-gate-abi.rs:71:5
+  --> $DIR/feature-gate-abi.rs:76:5
    |
 LL |     extern "x86-interrupt" fn im7() {} //~ ERROR x86-interrupt ABI is experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -311,15 +343,23 @@ LL |     extern "x86-interrupt" fn im7() {} //~ ERROR x86-interrupt ABI is exper
    = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:72:5
+  --> $DIR/feature-gate-abi.rs:77:5
    |
 LL |     extern "thiscall" fn im8() {} //~ ERROR thiscall is experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(abi_thiscall)] to the crate attributes to enable
 
+error[E0658]: amdgpu-kernel ABI is experimental and subject to change (see issue #51575)
+  --> $DIR/feature-gate-abi.rs:78:5
+   |
+LL |     extern "amdgpu-kernel" fn im9() {} //~ ERROR amdgpu-kernel ABI is experimental and subject to change
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(abi_amdgpu_kernel)] to the crate attributes to enable
+
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:76:11
+  --> $DIR/feature-gate-abi.rs:82:11
    |
 LL | type A1 = extern "rust-intrinsic" fn(); //~ ERROR intrinsics are subject to change
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -327,7 +367,7 @@ LL | type A1 = extern "rust-intrinsic" fn(); //~ ERROR intrinsics are subject to
    = help: add #![feature(intrinsics)] to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy (see issue #27731)
-  --> $DIR/feature-gate-abi.rs:77:11
+  --> $DIR/feature-gate-abi.rs:83:11
    |
 LL | type A2 = extern "platform-intrinsic" fn(); //~ ERROR platform intrinsics are experimental
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -335,7 +375,7 @@ LL | type A2 = extern "platform-intrinsic" fn(); //~ ERROR platform intrinsics a
    = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:78:11
+  --> $DIR/feature-gate-abi.rs:84:11
    |
 LL | type A3 = extern "vectorcall" fn(); //~ ERROR vectorcall is experimental and subject to change
    |           ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -343,7 +383,7 @@ LL | type A3 = extern "vectorcall" fn(); //~ ERROR vectorcall is experimental an
    = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change (see issue #29625)
-  --> $DIR/feature-gate-abi.rs:79:11
+  --> $DIR/feature-gate-abi.rs:85:11
    |
 LL | type A4 = extern "rust-call" fn(); //~ ERROR rust-call ABI is subject to change
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -351,7 +391,7 @@ LL | type A4 = extern "rust-call" fn(); //~ ERROR rust-call ABI is subject to ch
    = help: add #![feature(unboxed_closures)] to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change (see issue #38487)
-  --> $DIR/feature-gate-abi.rs:80:11
+  --> $DIR/feature-gate-abi.rs:86:11
    |
 LL | type A5 = extern "msp430-interrupt" fn(); //~ ERROR msp430-interrupt ABI is experimental
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -359,7 +399,7 @@ LL | type A5 = extern "msp430-interrupt" fn(); //~ ERROR msp430-interrupt ABI is
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
-  --> $DIR/feature-gate-abi.rs:81:11
+  --> $DIR/feature-gate-abi.rs:87:11
    |
 LL | type A6 = extern "ptx-kernel" fn (); //~ ERROR PTX ABIs are experimental and subject to change
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -367,7 +407,7 @@ LL | type A6 = extern "ptx-kernel" fn (); //~ ERROR PTX ABIs are experimental an
    = help: add #![feature(abi_ptx)] to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change (see issue #40180)
-  --> $DIR/feature-gate-abi.rs:82:11
+  --> $DIR/feature-gate-abi.rs:88:11
    |
 LL | type A7 = extern "x86-interrupt" fn(); //~ ERROR x86-interrupt ABI is experimental
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -375,15 +415,23 @@ LL | type A7 = extern "x86-interrupt" fn(); //~ ERROR x86-interrupt ABI is exper
    = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:83:11
+  --> $DIR/feature-gate-abi.rs:89:11
    |
 LL | type A8 = extern "thiscall" fn(); //~ ERROR thiscall is experimental and subject to change
    |           ^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(abi_thiscall)] to the crate attributes to enable
 
+error[E0658]: amdgpu-kernel ABI is experimental and subject to change (see issue #51575)
+  --> $DIR/feature-gate-abi.rs:90:11
+   |
+LL | type A9 = extern "amdgpu-kernel" fn(); //~ ERROR amdgpu-kernel ABI is experimental and subject to change
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(abi_amdgpu_kernel)] to the crate attributes to enable
+
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:86:1
+  --> $DIR/feature-gate-abi.rs:93:1
    |
 LL | extern "rust-intrinsic" {} //~ ERROR intrinsics are subject to change
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -391,7 +439,7 @@ LL | extern "rust-intrinsic" {} //~ ERROR intrinsics are subject to change
    = help: add #![feature(intrinsics)] to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy (see issue #27731)
-  --> $DIR/feature-gate-abi.rs:87:1
+  --> $DIR/feature-gate-abi.rs:94:1
    |
 LL | extern "platform-intrinsic" {} //~ ERROR platform intrinsics are experimental
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -399,7 +447,7 @@ LL | extern "platform-intrinsic" {} //~ ERROR platform intrinsics are experiment
    = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:88:1
+  --> $DIR/feature-gate-abi.rs:95:1
    |
 LL | extern "vectorcall" {} //~ ERROR vectorcall is experimental and subject to change
    | ^^^^^^^^^^^^^^^^^^^^^^
@@ -407,7 +455,7 @@ LL | extern "vectorcall" {} //~ ERROR vectorcall is experimental and subject to 
    = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change (see issue #29625)
-  --> $DIR/feature-gate-abi.rs:89:1
+  --> $DIR/feature-gate-abi.rs:96:1
    |
 LL | extern "rust-call" {} //~ ERROR rust-call ABI is subject to change
    | ^^^^^^^^^^^^^^^^^^^^^
@@ -415,7 +463,7 @@ LL | extern "rust-call" {} //~ ERROR rust-call ABI is subject to change
    = help: add #![feature(unboxed_closures)] to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change (see issue #38487)
-  --> $DIR/feature-gate-abi.rs:90:1
+  --> $DIR/feature-gate-abi.rs:97:1
    |
 LL | extern "msp430-interrupt" {} //~ ERROR msp430-interrupt ABI is experimental
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -423,7 +471,7 @@ LL | extern "msp430-interrupt" {} //~ ERROR msp430-interrupt ABI is experimental
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
-  --> $DIR/feature-gate-abi.rs:91:1
+  --> $DIR/feature-gate-abi.rs:98:1
    |
 LL | extern "ptx-kernel" {} //~ ERROR PTX ABIs are experimental and subject to change
    | ^^^^^^^^^^^^^^^^^^^^^^
@@ -431,7 +479,7 @@ LL | extern "ptx-kernel" {} //~ ERROR PTX ABIs are experimental and subject to c
    = help: add #![feature(abi_ptx)] to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change (see issue #40180)
-  --> $DIR/feature-gate-abi.rs:92:1
+  --> $DIR/feature-gate-abi.rs:99:1
    |
 LL | extern "x86-interrupt" {} //~ ERROR x86-interrupt ABI is experimental
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -439,13 +487,21 @@ LL | extern "x86-interrupt" {} //~ ERROR x86-interrupt ABI is experimental
    = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:93:1
+  --> $DIR/feature-gate-abi.rs:100:1
    |
 LL | extern "thiscall" {} //~ ERROR thiscall is experimental and subject to change
    | ^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(abi_thiscall)] to the crate attributes to enable
 
-error: aborting due to 56 previous errors
+error[E0658]: amdgpu-kernel ABI is experimental and subject to change (see issue #51575)
+  --> $DIR/feature-gate-abi.rs:101:1
+   |
+LL | extern "amdgpu-kernel" {} //~ ERROR amdgpu-kernel ABI is experimental and subject to change
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(abi_amdgpu_kernel)] to the crate attributes to enable
+
+error: aborting due to 63 previous errors
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Technically, there are requirements imposed by the LLVM
`AMDGPUTargetMachine` on functions with this ABI (eg, the return type
must be void), but I'm unsure exactly where this should be enforced.