### PR TITLE
NLL Liveness: Skip regionless types when visiting free regions

### DIFF
--- a/src/librustc/ty/fold.rs
+++ b/src/librustc/ty/fold.rs
@@ -307,6 +307,15 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 
                 false // keep visiting
             }
+
+            fn visit_ty(&mut self, ty: Ty<'tcx>) -> bool {
+                // We're only interested in types involving regions
+                if ty.flags.intersects(TypeFlags::HAS_FREE_REGIONS) {
+                    ty.super_visit_with(self)
+                } else {
+                    false // keep visiting
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The tuple-stress benchmark exercises the liveness constraint generation code for types which do not have regions

Closes #52027 