### PR TITLE
Make verbose --version show if parallel queries are supported.

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1151,6 +1151,14 @@ pub fn version(binary: &str, matches: &getopts::Matches) {
         println!("host: {}", config::host_triple());
         println!("release: {}", unw(release_str()));
         get_codegen_sysroot("llvm")().print_version();
+
+        if nightly_options::is_nightly_build() {
+            println!("parallel-queries: {}", if cfg!(parallel_queries) {
+                "yes"
+            } else {
+                "no"
+            });
+        }
     }
 }
 


### PR DESCRIPTION
This should not break anything, right?

r? @Mark-Simulacrum 
cc @rust-lang/release @Zoxc 