### PR TITLE
Only convert chars when needed in str case conversion methods.

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -106,6 +106,7 @@
 #![feature(ptr_internals)]
 #![feature(ptr_offset_from)]
 #![feature(rustc_attrs)]
+#![feature(slice_index_methods)]
 #![feature(specialization)]
 #![feature(split_ascii_whitespace)]
 #![feature(staged_api)]

--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -381,7 +381,7 @@ impl str {
                 } else {
                     s.extend(c.to_lowercase());
                 }
-                
+
                 // The next possible interval of lowercase `char`s start after `c`.
                 lower = i + c.len_utf8();
             }

--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -360,17 +360,34 @@ impl str {
     #[stable(feature = "unicode_case_mapping", since = "1.2.0")]
     pub fn to_lowercase(&self) -> String {
         let mut s = String::with_capacity(self.len());
+        let mut lower = 0;
         for (i, c) in self[..].char_indices() {
-            if c == 'Σ' {
-                // Σ maps to σ, except at the end of a word where it maps to ς.
-                // This is the only conditional (contextual) but language-independent mapping
-                // in `SpecialCasing.txt`,
-                // so hard-code it rather than have a generic "condition" mechanism.
-                // See https://github.com/rust-lang/rust/issues/26035
-                map_uppercase_sigma(self, i, &mut s)
-            } else {
-                s.extend(c.to_lowercase());
+            // Lowercase `char`s are inserted into `s` in slices,
+            // uppercase `char`s are converted to lowercase and inserted individually.
+            if c.is_uppercase() {
+                if lower != i {
+                    unsafe {
+                        // lower..i is an interval of lowercase `char`s before `c`.
+                        s.push_str((lower..i).get_unchecked(self));
+                    }
+                }
+                if c == 'Σ' {
+                    // Σ maps to σ, except at the end of a word where it maps to ς.
+                    // This is the only conditional (contextual) but language-independent mapping
+                    // in `SpecialCasing.txt`,
+                    // so hard-code it rather than have a generic "condition" mechanism.
+                    // See https://github.com/rust-lang/rust/issues/26035
+                    map_uppercase_sigma(self, i, &mut s);
+                } else {
+                    s.extend(c.to_lowercase());
+                }
+                
+                // The next possible interval of lowercase `char`s start after `c`.
+                lower = i + c.len_utf8();
             }
+        }
+        unsafe {
+            s.push_str((lower..self.len()).get_unchecked(self));
         }
         return s;
 
@@ -423,7 +440,26 @@ impl str {
     #[stable(feature = "unicode_case_mapping", since = "1.2.0")]
     pub fn to_uppercase(&self) -> String {
         let mut s = String::with_capacity(self.len());
-        s.extend(self.chars().flat_map(|c| c.to_uppercase()));
+        let mut lower = 0;
+        for (i, c) in self[..].char_indices() {
+            // Uppercase `char`s are inserted into `s` in slices,
+            // lowercase `char`s are converted to uppercase and inserted individually.
+            if c.is_lowercase() {
+                if lower != i {
+                    unsafe {
+                        // lower..i is an interval of uppercase `char`s before `c`.
+                        s.push_str((lower..i).get_unchecked(self));
+                    }
+                }
+                s.extend(c.to_uppercase());
+
+                // The next possible interval of uppercase `char`s start after `c`.
+                lower = i + c.len_utf8();
+            }
+        }
+        unsafe {
+            s.push_str((lower..self.len()).get_unchecked(self));
+        }
         return s;
     }
 


### PR DESCRIPTION
Optimizes `str.to_lowercase()` and `str.to_uppercase()` by appending slices of correct characters to the new string instead of inserting them individually. 

I benched these changes ([file](https://gist.github.com/Pazzaz/126a5300a3bbd706eee5f8e43ee5749b)) with these simple test cases:
```

ALL_LOWER:       "loremipsumdolorsitametduosensibusmnesarchumabcdefgh"
ALL_UPPER:       "LOREMIPSUMDOLORSITAMETDUOSENSIBUSMNESARCHUMABCDEFGH"
REALISTIC_UPPER: "LOREM IPSUM DOLOR SIT AMET, DUO SENSIBUS MNESARCHUM"
SIGMAS:          "ΣΣΣΣΣ ΣΣΣΣΣ ΣΣΣΣΣ ΣΣΣ ΣΣΣΣ, ΣΣΣ ΣΣΣΣΣΣΣΣ ΣΣΣΣΣΣΣΣΣΣ" // to_lowercase() special case
WORD_UPPER:      "Lorem Ipsum Dolor Sit Amet, Duo Sensibus Mnesarchum";
```
These were the results of the change to `to_uppercase()`:
```
running 10 tests
test tests::all_lower_uppercase           ... bench:       1,707 ns/iter (+/- 24)
test tests::all_lower_uppercase_new       ... bench:       1,753 ns/iter (+/- 35)
test tests::all_upper_uppercase           ... bench:       1,631 ns/iter (+/- 26)
test tests::all_upper_uppercase_new       ... bench:         145 ns/iter (+/- 10)
test tests::realistic_upper_uppercase     ... bench:       1,629 ns/iter (+/- 34)
test tests::realistic_upper_uppercase_new ... bench:         145 ns/iter (+/- 1)
test tests::sigmas_uppercase              ... bench:       1,876 ns/iter (+/- 57)
test tests::sigmas_uppercase_new          ... bench:         322 ns/iter (+/- 8)
test tests::word_upper_uppercase          ... bench:       1,868 ns/iter (+/- 34)
test tests::word_upper_uppercase_new      ... bench:       1,332 ns/iter (+/- 34)
```
And these were the results of the change to `to_lowercase()`:
```
running 10 tests
test tests::all_lower_lowercase           ... bench:       1,591 ns/iter (+/- 53)
test tests::all_lower_lowercase_new       ... bench:         143 ns/iter (+/- 4)
test tests::all_upper_lowercase           ... bench:       1,688 ns/iter (+/- 18)
test tests::all_upper_lowercase_new       ... bench:       1,760 ns/iter (+/- 34)
test tests::realistic_upper_lowercase     ... bench:       1,858 ns/iter (+/- 45)
test tests::realistic_upper_lowercase_new ... bench:       1,585 ns/iter (+/- 22)
test tests::sigmas_lowercase              ... bench:       1,196 ns/iter (+/- 33)
test tests::sigmas_lowercase_new          ... bench:       1,095 ns/iter (+/- 45)
test tests::word_upper_lowercase          ... bench:       1,756 ns/iter (+/- 49)
test tests::word_upper_lowercase_new      ... bench:         519 ns/iter (+/- 21)
```
So an improvement across the board, *except* for, `all_upper_lowercase` and `all_lower_uppercase`, where every single character had to be converted. I think that's a fair trade considering the gain in performance is pretty large in many other cases.