### PR TITLE
[beta] Rollup backports

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -65,6 +65,7 @@ Cargo
 -----
 - [`cargo-metadata` now includes `authors`, `categories`, `keywords`,
   `readme`, and `repository` fields.][cargo/5386]
+- [`cargo-metadata` now includes a package's `metadata` table.][cargo/5360]
 - [Added the `--target-dir` optional argument.][cargo/5393] This allows you to specify
   a different directory than `target` for placing compilation artifacts.
 - [Cargo will be adding automatic target inference for binaries, benchmarks,
@@ -114,6 +115,7 @@ Compatibility Notes
 [cargo/5203]: https://github.com/rust-lang/cargo/pull/5203/
 [cargo/5335]: https://github.com/rust-lang/cargo/pull/5335/
 [cargo/5359]: https://github.com/rust-lang/cargo/pull/5359/
+[cargo/5360]: https://github.com/rust-lang/cargo/pull/5360/
 [cargo/5386]: https://github.com/rust-lang/cargo/pull/5386/
 [cargo/5393]: https://github.com/rust-lang/cargo/pull/5393/
 [`DoubleEndedIterator::rfind`]: https://doc.rust-lang.org/std/iter/trait.DoubleEndedIterator.html#method.rfind

--- a/src/librustc_codegen_llvm/mir/constant.rs
+++ b/src/librustc_codegen_llvm/mir/constant.rs
@@ -117,7 +117,7 @@ pub fn const_alloc_to_llvm(cx: &CodegenCx, alloc: &Allocation) -> ValueRef {
 pub fn codegen_static_initializer<'a, 'tcx>(
     cx: &CodegenCx<'a, 'tcx>,
     def_id: DefId)
-    -> Result<ValueRef, ConstEvalErr<'tcx>>
+    -> Result<(ValueRef, &'tcx Allocation), ConstEvalErr<'tcx>>
 {
     let instance = ty::Instance::mono(cx.tcx, def_id);
     let cid = GlobalId {
@@ -131,7 +131,7 @@ pub fn codegen_static_initializer<'a, 'tcx>(
         ConstVal::Value(ConstValue::ByRef(alloc, n)) if n.bytes() == 0 => alloc,
         _ => bug!("static const eval returned {:#?}", static_),
     };
-    Ok(const_alloc_to_llvm(cx, alloc))
+    Ok((const_alloc_to_llvm(cx, alloc), alloc))
 }
 
 impl<'a, 'tcx> FunctionCx<'a, 'tcx> {

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -160,7 +160,6 @@
     // used for special search precedence
     var TY_PRIMITIVE = itemTypes.indexOf("primitive");
     var TY_KEYWORD = itemTypes.indexOf("keyword");
-    var TY_MACRO = itemTypes.indexOf("macro");
 
     onEach(document.getElementsByClassName('js-only'), function(e) {
         removeClass(e, 'js-only');

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -467,11 +467,7 @@
                             obj.displayPath = pathSplitter(res[0]);
                             obj.fullPath = obj.displayPath + obj.name;
                             // To be sure than it some items aren't considered as duplicate.
-                            if (obj.ty === TY_KEYWORD) {
-                                obj.fullPath += '|k';
-                            } else if (obj.ty === TY_MACRO) {
-                                obj.fullPath += '|m';
-                            }
+                            obj.fullPath += '|' + obj.ty;
                             obj.href = res[1];
                             out.push(obj);
                             if (out.length >= MAX_RESULTS) {

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -160,6 +160,7 @@
     // used for special search precedence
     var TY_PRIMITIVE = itemTypes.indexOf("primitive");
     var TY_KEYWORD = itemTypes.indexOf("keyword");
+    var TY_MACRO = itemTypes.indexOf("macro");
 
     onEach(document.getElementsByClassName('js-only'), function(e) {
         removeClass(e, 'js-only');
@@ -465,9 +466,11 @@
                             var res = buildHrefAndPath(obj);
                             obj.displayPath = pathSplitter(res[0]);
                             obj.fullPath = obj.displayPath + obj.name;
+                            // To be sure than it some items aren't considered as duplicate.
                             if (obj.ty === TY_KEYWORD) {
-                                // To be sure than it isn't considered as duplicate with items.
                                 obj.fullPath += '|k';
+                            } else if (obj.ty === TY_MACRO) {
+                                obj.fullPath += '|m';
                             }
                             obj.href = res[1];
                             out.push(obj);

--- a/src/test/codegen/issue-44056-macos-tls-align.rs
+++ b/src/test/codegen/issue-44056-macos-tls-align.rs
@@ -1,0 +1,40 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-tidy-linelength
+// only-macos
+// no-system-llvm
+// min-llvm-version 6.0
+// compile-flags: -O
+
+#![crate_type = "rlib"]
+#![feature(thread_local)]
+
+// CHECK: @STATIC_VAR_1 = internal thread_local unnamed_addr global <{ [32 x i8] }> zeroinitializer, section "__DATA,__thread_bss", align 4
+#[no_mangle]
+#[allow(private_no_mangle_statics)]
+#[thread_local]
+static mut STATIC_VAR_1: [u32; 8] = [0; 8];
+
+// CHECK: @STATIC_VAR_2 = internal thread_local unnamed_addr global <{ [32 x i8] }> <{{[^>]*}}>, section "__DATA,__thread_data", align 4
+#[no_mangle]
+#[allow(private_no_mangle_statics)]
+#[thread_local]
+static mut STATIC_VAR_2: [u32; 8] = [4; 8];
+
+#[no_mangle]
+pub unsafe fn f(x: &mut [u32; 8]) {
+    std::mem::swap(x, &mut STATIC_VAR_1)
+}
+
+#[no_mangle]
+pub unsafe fn g(x: &mut [u32; 8]) {
+    std::mem::swap(x, &mut STATIC_VAR_2)
+}

--- a/src/test/run-pass/issue-44056.rs
+++ b/src/test/run-pass/issue-44056.rs
@@ -1,0 +1,15 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// only-x86_64
+// no-prefer-dynamic
+// compile-flags: -Ctarget-feature=+avx -Clto
+
+fn main() {}

--- a/src/test/rustdoc-js/macro-check.js
+++ b/src/test/rustdoc-js/macro-check.js
@@ -1,0 +1,20 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-order
+
+const QUERY = 'panic';
+
+const EXPECTED = {
+    'others': [
+        { 'path': 'std', 'name': 'panic', ty: 14 }, // 15 is for macros
+        { 'path': 'std', 'name': 'panic', ty: 0 }, // 0 is for modules
+    ],
+};

--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -233,7 +233,7 @@ function main(argv) {
 
     var arraysToLoad = ["itemTypes"];
     var variablesToLoad = ["MAX_LEV_DISTANCE", "MAX_RESULTS",
-                           "TY_PRIMITIVE", "TY_KEYWORD", "TY_MACRO",
+                           "TY_PRIMITIVE", "TY_KEYWORD",
                            "levenshtein_row2"];
     // execQuery first parameter is built in getQuery (which takes in the search input).
     // execQuery last parameter is built in buildIndex.

--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -233,7 +233,7 @@ function main(argv) {
 
     var arraysToLoad = ["itemTypes"];
     var variablesToLoad = ["MAX_LEV_DISTANCE", "MAX_RESULTS",
-                           "TY_PRIMITIVE", "TY_KEYWORD",
+                           "TY_PRIMITIVE", "TY_KEYWORD", "TY_MACRO",
                            "levenshtein_row2"];
     // execQuery first parameter is built in getQuery (which takes in the search input).
     // execQuery last parameter is built in buildIndex.


### PR DESCRIPTION
Merged and approved:

* #51997: add entry for cargo-metadata feature to RELEASES
* #51592: Fix macro missing from doc search
* #51828: Do not allow LLVM to increase a TLS's alignment on macOS.

r? @ghost