### PR TITLE
prohibit types named dyn`

### DIFF
--- a/src/librustc_passes/diagnostics.rs
+++ b/src/librustc_passes/diagnostics.rs
@@ -297,6 +297,20 @@ loop {
     break;
 }
 ```
+"##,
+
+E0705: r##"
+Traits and other types cannot be named `dyn`.
+
+Example of erroneous code:
+
+```compile_fail,E0705
+trait dyn { }
+```
+
+`dyn` is a contextual keyword that is used to designate a dynamic
+trait type (e.g., `dyn Debug`). Traits, structs, and other type
+definitions cannot be named `dyn`.
 "##
 }
 

--- a/src/test/ui/issue-50405-types-named-dyn.rs
+++ b/src/test/ui/issue-50405-types-named-dyn.rs
@@ -1,0 +1,35 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #50405: do not permit traits or other types named `dyn` to
+// resolve parsing ambiguity.
+
+mod a {
+    trait dyn { //~ ERROR types cannot be named `dyn`
+    }
+}
+
+mod b {
+    struct dyn { } //~ ERROR types cannot be named `dyn`
+}
+
+mod c {
+    enum dyn { } //~ ERROR types cannot be named `dyn`
+}
+
+mod d {
+    union dyn { _f: () } //~ ERROR types cannot be named `dyn`
+}
+
+mod e {
+    type dyn = u32; //~ ERROR types cannot be named `dyn`
+}
+
+fn main() {}

--- a/src/test/ui/issue-50405-types-named-dyn.stderr
+++ b/src/test/ui/issue-50405-types-named-dyn.stderr
@@ -1,0 +1,34 @@
+error[E0705]: types cannot be named `dyn`
+  --> $DIR/issue-50405-types-named-dyn.rs:15:5
+   |
+LL | /     trait dyn { //~ ERROR types cannot be named `dyn`
+LL | |     }
+   | |_____^
+
+error[E0705]: types cannot be named `dyn`
+  --> $DIR/issue-50405-types-named-dyn.rs:20:5
+   |
+LL |     struct dyn { } //~ ERROR types cannot be named `dyn`
+   |     ^^^^^^^^^^^^^^
+
+error[E0705]: types cannot be named `dyn`
+  --> $DIR/issue-50405-types-named-dyn.rs:24:5
+   |
+LL |     enum dyn { } //~ ERROR types cannot be named `dyn`
+   |     ^^^^^^^^^^^^
+
+error[E0705]: types cannot be named `dyn`
+  --> $DIR/issue-50405-types-named-dyn.rs:28:5
+   |
+LL |     union dyn { _f: () } //~ ERROR types cannot be named `dyn`
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error[E0705]: types cannot be named `dyn`
+  --> $DIR/issue-50405-types-named-dyn.rs:32:5
+   |
+LL |     type dyn = u32; //~ ERROR types cannot be named `dyn`
+   |     ^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0705`.


### PR DESCRIPTION
Fixes #50405 

cc @rust-lang/lang -- I took the liberty of extending the "no traits named `dyn`" rule to be "no types named `dyn`". It seemed more uniform. People ok with that?

Should we do a crater run for this?

r? @petrochenkov 