### PR TITLE
Rollup of 14 pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,13 +225,16 @@ variety of channels on Mozilla's IRC network, irc.mozilla.org. The
 most popular channel is [#rust], a venue for general discussion about
 Rust. And a good place to ask for help would be [#rust-beginners].
 
-Also, the [rustc guide] might be a good place to start if you want to
-find out how various parts of the compiler work.
+The [rustc guide] might be a good place to start if you want to find out how
+various parts of the compiler work.
+
+Also, you may find the [rustdocs for the compiler itself][rustdocs] useful.
 
 [IRC]: https://en.wikipedia.org/wiki/Internet_Relay_Chat
 [#rust]: irc://irc.mozilla.org/rust
 [#rust-beginners]: irc://irc.mozilla.org/rust-beginners
 [rustc guide]: https://rust-lang-nursery.github.io/rustc-guide/about-this-guide.html
+[rustdocs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/
 
 ## License
 [license]: #license

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -115,6 +115,7 @@
 
 #![deny(warnings)]
 #![feature(core_intrinsics)]
+#![feature(drain_filter)]
 
 #[macro_use]
 extern crate build_helper;

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -617,6 +617,7 @@ impl Step for Openssl {
             "powerpc-unknown-netbsd" => "BSD-generic32",
             "powerpc64-unknown-linux-gnu" => "linux-ppc64",
             "powerpc64le-unknown-linux-gnu" => "linux-ppc64le",
+            "powerpc64le-unknown-linux-musl" => "linux-ppc64le",
             "s390x-unknown-linux-gnu" => "linux64-s390x",
             "sparc-unknown-linux-gnu" => "linux-sparcv9",
             "sparc64-unknown-linux-gnu" => "linux64-sparcv9",

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -186,27 +186,20 @@ impl Step for ToolBuild {
                       than in a previous build:\n");
             println!("the following dependencies are duplicated although they \
                       have the same features enabled:");
-            for (id, cur, prev) in &duplicates {
+            for (id, cur, prev) in duplicates.drain_filter(|(_, cur, prev)| cur.2 == prev.2) {
                 println!("  {}", id);
-                if cur.2 == prev.2 {
-                    // same features
-                    println!("    `{}` ({:?})\n    `{}` ({:?})", cur.0, cur.1, prev.0, prev.1);
-                }
+                // same features
+                println!("    `{}` ({:?})\n    `{}` ({:?})", cur.0, cur.1, prev.0, prev.1);
             }
             println!("the following dependencies have different features:");
             for (id, cur, prev) in duplicates {
                 println!("  {}", id);
-                if cur.2 == prev.2 {
-                    continue;
-                }
                 let cur_features: HashSet<_> = cur.2.into_iter().collect();
                 let prev_features: HashSet<_> = prev.2.into_iter().collect();
-                let cur_extra: Vec<_> = cur_features.difference(&prev_features).collect();
-                let prev_extra: Vec<_> = prev_features.difference(&cur_features).collect();
                 println!("    `{}` additionally enabled features {:?} at {:?}",
-                         cur.0, cur_extra, cur.1);
+                         cur.0, &cur_features - &prev_features, cur.1);
                 println!("    `{}` additionally enabled features {:?} at {:?}",
-                         prev.0, prev_extra, prev.1);
+                         prev.0, &prev_features - &cur_features, prev.1);
             }
             println!("");
             panic!("tools should not compile multiple copies of the same crate");

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -118,8 +118,13 @@ impl Step for ToolBuild {
         let mut duplicates = Vec::new();
         let is_expected = compile::stream_cargo(builder, &mut cargo, &mut |msg| {
             // Only care about big things like the RLS/Cargo for now
-            if tool != "rls" && tool != "cargo" && tool != "clippy-driver" {
-                return
+            match tool {
+                | "rls"
+                | "cargo"
+                | "clippy-driver"
+                => {}
+
+                _ => return,
             }
             let (id, features, filenames) = match msg {
                 compile::CargoMessage::CompilerArtifact {

--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -431,7 +431,7 @@ impl Any+Send+Sync {
 ///
 /// While `TypeId` implements `Hash`, `PartialOrd`, and `Ord`, it is worth
 /// noting that the hashes and ordering will vary between Rust releases. Beware
-/// of relying on them outside of your code!
+/// of relying on them inside of your code!
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct TypeId {

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1256,7 +1256,7 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for RefMut<'a, T> {
 /// To assist with proper design, the following scenarios are explicitly declared legal
 /// for single-threaded code:
 ///
-/// 1. A `&T` reference can be released to safe code and there it can co-exit with other `&T`
+/// 1. A `&T` reference can be released to safe code and there it can co-exist with other `&T`
 /// references, but not with a `&mut T`
 ///
 /// 2. A `&mut T` reference may be released to safe code, provided neither other `&mut T` nor `&T`

--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -7,7 +7,7 @@ use hir::def_id::DefId;
 
 use super::{EvalResult, Pointer, PointerArithmetic, Allocation};
 
-/// Represents a constant value in Rust. ByVal and ScalarPair are optimizations which
+/// Represents a constant value in Rust. Scalar and ScalarPair are optimizations which
 /// matches Value's optimizations for easy conversions between these two types
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, RustcEncodable, RustcDecodable, Hash)]
 pub enum ConstValue<'tcx> {
@@ -72,7 +72,7 @@ impl<'tcx> ConstValue<'tcx> {
 /// A `Value` represents a single self-contained Rust value.
 ///
 /// A `Value` can either refer to a block of memory inside an allocation (`ByRef`) or to a primitve
-/// value held directly, outside of any allocation (`ByVal`).  For `ByRef`-values, we remember
+/// value held directly, outside of any allocation (`Scalar`).  For `ByRef`-values, we remember
 /// whether the pointer is supposed to be aligned or not (also see Place).
 ///
 /// For optimization of a few very common cases, there is also a representation for a pair of

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -98,6 +98,7 @@ pub enum Lto {
 #[derive(Clone, PartialEq, Hash)]
 pub enum CrossLangLto {
     LinkerPlugin(PathBuf),
+    LinkerPluginAuto,
     NoLink,
     Disabled
 }
@@ -106,6 +107,7 @@ impl CrossLangLto {
     pub fn embed_bitcode(&self) -> bool {
         match *self {
             CrossLangLto::LinkerPlugin(_) |
+            CrossLangLto::LinkerPluginAuto |
             CrossLangLto::NoLink => true,
             CrossLangLto::Disabled => false,
         }
@@ -1020,7 +1022,7 @@ macro_rules! options {
                 let mut bool_arg = None;
                 if parse_opt_bool(&mut bool_arg, v) {
                     *slot = if bool_arg.unwrap() {
-                        CrossLangLto::NoLink
+                        CrossLangLto::LinkerPluginAuto
                     } else {
                         CrossLangLto::Disabled
                     };

--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -816,7 +816,7 @@ fn link_natively(sess: &Session,
             if sess.target.target.options.is_like_msvc && linker_not_found {
                 sess.note_without_error("the msvc targets depend on the msvc linker \
                     but `link.exe` was not found");
-                sess.note_without_error("please ensure that VS 2013 or VS 2015 was installed \
+                sess.note_without_error("please ensure that VS 2013, VS 2015 or VS 2017 was installed \
                     with the Visual C++ option");
             }
             sess.abort_if_errors();

--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -816,8 +816,8 @@ fn link_natively(sess: &Session,
             if sess.target.target.options.is_like_msvc && linker_not_found {
                 sess.note_without_error("the msvc targets depend on the msvc linker \
                     but `link.exe` was not found");
-                sess.note_without_error("please ensure that VS 2013, VS 2015 or VS 2017 was installed \
-                    with the Visual C++ option");
+                sess.note_without_error("please ensure that VS 2013, VS 2015 or VS 2017 \
+                    was installed with the Visual C++ option");
             }
             sess.abort_if_errors();
         }

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -395,15 +395,8 @@ fn collect_items_rec<'a, 'tcx: 'a>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             };
             let param_env = ty::ParamEnv::reveal_all();
 
-            match tcx.const_eval(param_env.and(cid)) {
-                Ok(val) => collect_const(tcx, val, instance.substs, &mut neighbors),
-                Err(err) => {
-                    let span = tcx.def_span(def_id);
-                    err.report_as_error(
-                        tcx.at(span),
-                        "could not evaluate static initializer",
-                    );
-                }
+            if let Ok(val) = tcx.const_eval(param_env.and(cid)) {
+                collect_const(tcx, val, instance.substs, &mut neighbors);
             }
         }
         MonoItem::Fn(instance) => {

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -274,6 +274,7 @@ supported_targets! {
     ("powerpc-unknown-linux-gnuspe", powerpc_unknown_linux_gnuspe),
     ("powerpc64-unknown-linux-gnu", powerpc64_unknown_linux_gnu),
     ("powerpc64le-unknown-linux-gnu", powerpc64le_unknown_linux_gnu),
+    ("powerpc64le-unknown-linux-musl", powerpc64le_unknown_linux_musl),
     ("s390x-unknown-linux-gnu", s390x_unknown_linux_gnu),
     ("sparc-unknown-linux-gnu", sparc_unknown_linux_gnu),
     ("sparc64-unknown-linux-gnu", sparc64_unknown_linux_gnu),

--- a/src/librustc_target/spec/powerpc64le_unknown_linux_musl.rs
+++ b/src/librustc_target/spec/powerpc64le_unknown_linux_musl.rs
@@ -1,0 +1,35 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use spec::{LinkerFlavor, Target, TargetResult};
+
+pub fn target() -> TargetResult {
+    let mut base = super::linux_musl_base::opts();
+    base.cpu = "ppc64le".to_string();
+    base.pre_link_args.get_mut(&LinkerFlavor::Gcc).unwrap().push("-m64".to_string());
+    base.max_atomic_width = Some(64);
+
+    // see #36994
+    base.exe_allocation_crate = None;
+
+    Ok(Target {
+        llvm_target: "powerpc64le-unknown-linux-musl".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "64".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "e-m:e-i64:64-n32:64".to_string(),
+        arch: "powerpc64".to_string(),
+        target_os: "linux".to_string(),
+        target_env: "musl".to_string(),
+        target_vendor: "unknown".to_string(),
+        linker_flavor: LinkerFlavor::Gcc,
+        options: base,
+    })
+}

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -108,7 +108,7 @@ pre {
 
 .content .highlighted {
 	color: #eee !important;
-	background-color: #333;
+	background-color: #616161;
 }
 .content .highlighted a, .content .highlighted span { color: #eee !important; }
 .content .highlighted.trait { background-color: #013191; }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -421,7 +421,7 @@ declare_features! (
     (active, wasm_custom_section, "1.26.0", Some(51088), None),
 
     // The #![wasm_import_module] attribute
-    (active, wasm_import_module, "1.26.0", Some(51088), None),
+    (active, wasm_import_module, "1.26.0", Some(52090), None),
 
     // Allows keywords to be escaped for use as identifiers
     (active, raw_identifiers, "1.26.0", Some(48589), None),

--- a/src/test/compile-fail/issue-14227.rs
+++ b/src/test/compile-fail/issue-14227.rs
@@ -16,7 +16,5 @@ extern {
 static CRASH: () = symbol;
 //~^ ERROR could not evaluate static initializer
 //~| tried to read from foreign (extern) static
-//~^^^ ERROR could not evaluate static initializer
-//~| tried to read from foreign (extern) static
 
 fn main() {}

--- a/src/test/compile-fail/issue-28324.rs
+++ b/src/test/compile-fail/issue-28324.rs
@@ -17,7 +17,5 @@ extern {
 pub static BAZ: u32 = *&error_message_count;
 //~^ ERROR could not evaluate static initializer
 //~| tried to read from foreign (extern) static
-//~^^^ ERROR could not evaluate static initializer
-//~| tried to read from foreign (extern) static
 
 fn main() {}

--- a/src/test/run-pass/weird-exprs.rs
+++ b/src/test/run-pass/weird-exprs.rs
@@ -10,6 +10,8 @@
 
 // compile-flags: -Z borrowck=compare
 
+#![recursion_limit = "128"]
+
 use std::cell::Cell;
 use std::mem::swap;
 
@@ -121,6 +123,16 @@ fn special_characters() {
     assert!(!val);
 }
 
+fn punch_card() -> impl std::fmt::Debug {
+    ..=..=.. ..    .. .. .. ..    .. .. .. ..    .. ..=.. ..
+    ..=.. ..=..    .. .. .. ..    .. .. .. ..    ..=..=..=..
+    ..=.. ..=..    ..=.. ..=..    .. ..=..=..    .. ..=.. ..
+    ..=..=.. ..    ..=.. ..=..    ..=.. .. ..    .. ..=.. ..
+    ..=.. ..=..    ..=.. ..=..    .. ..=.. ..    .. ..=.. ..
+    ..=.. ..=..    ..=.. ..=..    .. .. ..=..    .. ..=.. ..
+    ..=.. ..=..    .. ..=..=..    ..=..=.. ..    .. ..=.. ..
+}
+
 pub fn main() {
     strange();
     funny();
@@ -135,4 +147,5 @@ pub fn main() {
     fishy();
     union();
     special_characters();
+    punch_card();
 }

--- a/src/test/ui/const-eval/index_out_of_bounds.rs
+++ b/src/test/ui/const-eval/index_out_of_bounds.rs
@@ -10,7 +10,6 @@
 
 static FOO: i32 = [][0];
 //~^ ERROR E0080
-//~| ERROR E0080
 
 fn main() {
     let array = [std::env::args().len()];

--- a/src/test/ui/const-eval/index_out_of_bounds.stderr
+++ b/src/test/ui/const-eval/index_out_of_bounds.stderr
@@ -4,22 +4,14 @@ error[E0080]: could not evaluate static initializer
 LL | static FOO: i32 = [][0];
    |                   ^^^^^ index out of bounds: the len is 0 but the index is 0
 
-error[E0080]: could not evaluate static initializer
-  --> $DIR/index_out_of_bounds.rs:11:1
-   |
-LL | static FOO: i32 = [][0];
-   | ^^^^^^^^^^^^^^^^^^-----^
-   |                   |
-   |                   index out of bounds: the len is 0 but the index is 0
-
 error: index out of bounds: the len is 1 but the index is 1
-  --> $DIR/index_out_of_bounds.rs:17:5
+  --> $DIR/index_out_of_bounds.rs:16:5
    |
 LL |     array[1]; //~ ERROR index out of bounds
    |     ^^^^^^^^
    |
    = note: #[deny(const_err)] on by default
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/feature-gate-wasm_import_module.stderr
+++ b/src/test/ui/feature-gate-wasm_import_module.stderr
@@ -1,4 +1,4 @@
-error[E0658]: experimental attribute (see issue #51088)
+error[E0658]: experimental attribute (see issue #52090)
   --> $DIR/feature-gate-wasm_import_module.rs:11:1
    |
 LL | #[wasm_import_module = "test"] //~ ERROR: experimental

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -88,6 +88,7 @@ static TARGETS: &'static [&'static str] = &[
     "powerpc-unknown-linux-gnuspe",
     "powerpc64-unknown-linux-gnu",
     "powerpc64le-unknown-linux-gnu",
+    "powerpc64le-unknown-linux-musl",
     "s390x-unknown-linux-gnu",
     "sparc-unknown-linux-gnu",
     "sparc64-unknown-linux-gnu",


### PR DESCRIPTION
Successful merges:

 - #51619 (rust: add initial changes to support powerpc64le musl)
 - #51793 (Fix variant background color on hover in search results)
 - #52005 (Update LLVM to bring in a wasm codegen fix)
 - #52016 (Deduplicate error reports for statics)
 - #52019 ([cross-lang-lto] Allow the linker to choose the LTO-plugin (which is useful when using LLD))
 - #52030 (Any docs preposition change)
 - #52031 (Strenghten synchronization in `Arc::is_unique`)
 - #52033 ([Gardening] Update outdated comments: ByVal -> Scalar)
 - #52055 (Include VS 2017 in error message.)
 - #52063 (Add a link to the rustc docs)
 - #52073 (Add a punch card to weird expressions test)
 - #52080 (Improve dependency deduplication diagnostics)
 - #52093 (rustc: Update tracking issue for wasm_import_module)
 - #52096 (Fix typo in cell.rs)

Failed merges: