### PR TITLE
rustc_codegen_llvm: replace the first argument early in FnType::new_vtable.

### DIFF
--- a/src/test/run-pass/issue-51907.rs
+++ b/src/test/run-pass/issue-51907.rs
@@ -1,0 +1,26 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Foo {
+    extern fn borrow(&self);
+    extern fn take(self: Box<Self>);
+}
+
+struct Bar;
+impl Foo for Bar {
+    extern fn borrow(&self) {}
+    extern fn take(self: Box<Self>) {}
+}
+
+fn main() {
+    let foo: Box<dyn Foo> = Box::new(Bar);
+    foo.borrow();
+    foo.take()
+}


### PR DESCRIPTION
Fixes #51907 by removing the vtable pointer before the `ArgType` is even created.
This allows any ABI to support trait object method calls, regardless of how it passes `*dyn Trait`.

r? @nikomatsakis 