### PR TITLE
try to infer linker flavor from linker name and vice versa

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -42,7 +42,7 @@ use syntax::feature_gate::AttributeType;
 use syntax_pos::{MultiSpan, Span};
 use util::profiling::SelfProfiler;
 
-use rustc_target::spec::{LinkerFlavor, PanicStrategy};
+use rustc_target::spec::PanicStrategy;
 use rustc_target::spec::{Target, TargetTriple};
 use rustc_data_structures::flock;
 use jobserver::Client;
@@ -607,13 +607,6 @@ impl Session {
             .panic
             .unwrap_or(self.target.target.options.panic_strategy)
     }
-    pub fn linker_flavor(&self) -> LinkerFlavor {
-        self.opts
-            .debugging_opts
-            .linker_flavor
-            .unwrap_or(self.target.target.linker_flavor)
-    }
-
     pub fn fewer_names(&self) -> bool {
         let more_names = self.opts
             .output_types

--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -60,7 +60,7 @@ pub use rustc_codegen_utils::link::{find_crate_name, filename_for_input, default
 // The third parameter is for env vars, used on windows to set up the
 // path for MSVC to find its DLLs, and gcc to find its bundled
 // toolchain
-pub fn get_linker(sess: &Session) -> (PathBuf, Command) {
+pub fn get_linker(sess: &Session, linker: &Path, flavor: LinkerFlavor) -> (PathBuf, Command) {
     // If our linker looks like a batch script on Windows then to execute this
     // we'll need to spawn `cmd` explicitly. This is primarily done to handle
     // emscripten where the linker is `emcc.bat` and needs to be spawned as
@@ -69,35 +69,20 @@ pub fn get_linker(sess: &Session) -> (PathBuf, Command) {
     // This worked historically but is needed manually since #42436 (regression
     // was tagged as #42791) and some more info can be found on #44443 for
     // emscripten itself.
-    let cmd = |linker: &Path| {
+    let mut cmd = (|| {
         if let Some(linker) = linker.to_str() {
             if cfg!(windows) && linker.ends_with(".bat") {
                 return Command::bat_script(linker)
             }
         }
-        match sess.linker_flavor() {
+        match flavor {
             LinkerFlavor::Lld(f) => Command::lld(linker, f),
             _ => Command::new(linker),
 
         }
-    };
+    })();
 
     let msvc_tool = windows_registry::find_tool(&sess.opts.target_triple.triple(), "link.exe");
-
-    let linker_path = sess.opts.cg.linker.as_ref().map(|s| &**s)
-        .or(sess.target.target.options.linker.as_ref().map(|s| s.as_ref()))
-        .unwrap_or(match sess.linker_flavor() {
-            LinkerFlavor::Msvc => {
-                msvc_tool.as_ref().map(|t| t.path()).unwrap_or("link.exe".as_ref())
-            }
-            LinkerFlavor::Em if cfg!(windows) => "emcc.bat".as_ref(),
-            LinkerFlavor::Em => "emcc".as_ref(),
-            LinkerFlavor::Gcc => "cc".as_ref(),
-            LinkerFlavor::Ld => "ld".as_ref(),
-            LinkerFlavor::Lld(_) => "lld".as_ref(),
-        });
-
-    let mut cmd = cmd(linker_path);
 
     // The compiler's sysroot often has some bundled tools, so add it to the
     // PATH for the child.
@@ -125,7 +110,7 @@ pub fn get_linker(sess: &Session) -> (PathBuf, Command) {
     }
     cmd.env("PATH", env::join_paths(new_path).unwrap());
 
-    (linker_path.to_path_buf(), cmd)
+    (linker.to_path_buf(), cmd)
 }
 
 pub fn remove(sess: &Session, path: &Path) {
@@ -615,6 +600,71 @@ fn print_native_static_libs(sess: &Session, all_native_libs: &[NativeLibrary]) {
     }
 }
 
+pub fn linker_and_flavor(sess: &Session) -> Result<(PathBuf, LinkerFlavor), ()> {
+    fn from<F>(
+        sess: &Session,
+        linker: Option<PathBuf>,
+        flavor: Option<LinkerFlavor>,
+        otherwise: F,
+    ) -> Result<(PathBuf, LinkerFlavor), ()>
+    where
+        F: FnOnce() -> Result<(PathBuf, LinkerFlavor), ()>
+    {
+        match (linker, flavor) {
+            (Some(linker), Some(flavor)) => Ok((linker, flavor)),
+            // only the linker flavor is known; use the default linker for the selected flavor
+            (None, Some(flavor)) => Ok((PathBuf::from(match flavor {
+                LinkerFlavor::Em => "emcc",
+                LinkerFlavor::Gcc => "gcc",
+                LinkerFlavor::Ld => "ld",
+                LinkerFlavor::Msvc => "link.exe",
+                LinkerFlavor::Lld(_) => "lld",
+            }), flavor)),
+            // infer the linker flavor from the linker name
+            (Some(linker), None) => {
+                let stem = linker.file_stem().and_then(|stem| stem.to_str()).ok_or_else(|| {
+                    sess
+                        .struct_err(&format!("couldn't extract file stem from specified linker"))
+                        .emit();
+                })?.to_owned();
+
+                let flavor = if stem == "emcc" {
+                    LinkerFlavor::Em
+                } else if stem == "gcc" || stem.ends_with("-gcc") {
+                    LinkerFlavor::Gcc
+                } else if stem == "ld" || stem == "ld.lld" || stem.ends_with("-ld") {
+                    LinkerFlavor::Ld
+                } else if stem == "link" || stem == "lld-link" {
+                    LinkerFlavor::Msvc
+                } else {
+                    sess
+                        .struct_err(&format!("couldn't infer linker flavor from specified linker"))
+                        .emit();
+                    return Err(());
+                };
+
+                Ok((linker, flavor))
+            },
+            (None, None) => otherwise(),
+        }
+    }
+
+    // linker and linker flavor specified via command line have precedence over what the target
+    // specification specifies
+    from(sess, sess.opts.cg.linker.clone(), sess.opts.debugging_opts.linker_flavor, || {
+        from(
+            sess,
+            sess.target.target.options.linker.clone().map(PathBuf::from),
+            Some(sess.target.target.linker_flavor),
+            || {
+                sess
+                    .struct_err(&format!("no linker or linker flavor information provided"))
+                    .emit();
+                Err(())
+            })
+    })
+}
+
 // Create a dynamic library or executable
 //
 // This will invoke the system linker/cc to create the resulting file. This
@@ -625,10 +675,15 @@ fn link_natively(sess: &Session,
                  codegen_results: &CodegenResults,
                  tmpdir: &Path) {
     info!("preparing {:?} to {:?}", crate_type, out_filename);
-    let flavor = sess.linker_flavor();
+    let (linker, flavor) = if let Ok((linker, flavor)) = linker_and_flavor(sess) {
+        (linker, flavor)
+    } else {
+        sess.abort_if_errors();
+        return;
+    };
 
     // The invocations of cc share some flags across platforms
-    let (pname, mut cmd) = get_linker(sess);
+    let (pname, mut cmd) = get_linker(sess, &linker, flavor);
 
     let root = sess.target_filesearch(PathKind::Native).get_lib_path();
     if let Some(args) = sess.target.target.options.pre_link_args.get(&flavor) {
@@ -669,8 +724,8 @@ fn link_natively(sess: &Session,
     }
 
     {
-        let mut linker = codegen_results.linker_info.to_linker(cmd, &sess);
-        link_args(&mut *linker, sess, crate_type, tmpdir,
+        let mut linker = codegen_results.linker_info.to_linker(cmd, &sess, flavor);
+        link_args(&mut *linker, flavor, sess, crate_type, tmpdir,
                   out_filename, codegen_results);
         cmd = linker.finalize();
     }
@@ -742,7 +797,7 @@ fn link_natively(sess: &Session,
         // linking executables as pie. Different versions of gcc seem to use
         // different quotes in the error message so don't check for them.
         if sess.target.target.options.linker_is_gnu &&
-           sess.linker_flavor() != LinkerFlavor::Ld &&
+           flavor != LinkerFlavor::Ld &&
            (out.contains("unrecognized command line option") ||
             out.contains("unknown argument")) &&
            out.contains("-no-pie") &&
@@ -991,6 +1046,7 @@ fn exec_linker(sess: &Session, cmd: &mut Command, out_filename: &Path, tmpdir: &
 }
 
 fn link_args(cmd: &mut dyn Linker,
+             flavor: LinkerFlavor,
              sess: &Session,
              crate_type: config::CrateType,
              tmpdir: &Path,
@@ -1075,7 +1131,7 @@ fn link_args(cmd: &mut dyn Linker,
             // independent executables by default. We have to pass -no-pie to
             // explicitly turn that off. Not applicable to ld.
             if sess.target.target.options.linker_is_gnu
-                && sess.linker_flavor() != LinkerFlavor::Ld {
+                && flavor != LinkerFlavor::Ld {
                 cmd.no_position_independent_executable();
             }
         }

--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -75,7 +75,9 @@ pub fn get_linker(sess: &Session, linker: &Path, flavor: LinkerFlavor) -> (PathB
         Some(linker) if cfg!(windows) && linker.ends_with(".bat") => Command::bat_script(linker),
         _ => match flavor {
             LinkerFlavor::Lld(f) => Command::lld(linker, f),
-            LinkerFlavor::Msvc => {
+            LinkerFlavor::Msvc
+                if sess.opts.cg.linker.is_none() && sess.target.target.options.linker.is_none() =>
+            {
                 Command::new(msvc_tool.as_ref().map(|t| t.path()).unwrap_or(linker))
             },
             _ => Command::new(linker),

--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -624,6 +624,8 @@ pub fn linker_and_flavor(sess: &Session) -> (PathBuf, LinkerFlavor) {
                     LinkerFlavor::Ld
                 } else if stem == "link" || stem == "lld-link" {
                     LinkerFlavor::Msvc
+                } else if stem == "lld" || stem == "rust-lld" {
+                    LinkerFlavor::Lld(sess.target.target.options.lld_flavor)
                 } else {
                     // fall back to the value in the target spec
                     sess.target.target.linker_flavor

--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -606,7 +606,7 @@ pub fn linker_and_flavor(sess: &Session) -> (PathBuf, LinkerFlavor) {
             // only the linker flavor is known; use the default linker for the selected flavor
             (None, Some(flavor)) => Some((PathBuf::from(match flavor {
                 LinkerFlavor::Em  => if cfg!(windows) { "emcc.bat" } else { "emcc" },
-                LinkerFlavor::Gcc => "gcc",
+                LinkerFlavor::Gcc => "cc",
                 LinkerFlavor::Ld => "ld",
                 LinkerFlavor::Msvc => "link.exe",
                 LinkerFlavor::Lld(_) => "lld",

--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -655,7 +655,7 @@ pub fn linker_and_flavor(sess: &Session) -> (PathBuf, LinkerFlavor) {
         return ret;
     }
 
-    sess.fatal("Not enough information provided to determine how to invoke the linker");
+    bug!("Not enough information provided to determine how to invoke the linker");
 }
 
 // Create a dynamic library or executable

--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -69,18 +69,13 @@ pub fn get_linker(sess: &Session, linker: &Path, flavor: LinkerFlavor) -> (PathB
     // This worked historically but is needed manually since #42436 (regression
     // was tagged as #42791) and some more info can be found on #44443 for
     // emscripten itself.
-    let mut cmd = (|| {
-        if let Some(linker) = linker.to_str() {
-            if cfg!(windows) && linker.ends_with(".bat") {
-                return Command::bat_script(linker)
-            }
-        }
-        match flavor {
+    let mut cmd = match linker.to_str() {
+        Some(linker) if cfg!(windows) && linker.ends_with(".bat") => Command::bat_script(linker),
+        _ => match flavor {
             LinkerFlavor::Lld(f) => Command::lld(linker, f),
             _ => Command::new(linker),
-
         }
-    })();
+    };
 
     let msvc_tool = windows_registry::find_tool(&sess.opts.target_triple.triple(), "link.exe");
 
@@ -600,33 +595,26 @@ fn print_native_static_libs(sess: &Session, all_native_libs: &[NativeLibrary]) {
     }
 }
 
-pub fn linker_and_flavor(sess: &Session) -> Result<(PathBuf, LinkerFlavor), ()> {
-    fn from<F>(
+pub fn linker_and_flavor(sess: &Session) -> (PathBuf, LinkerFlavor) {
+    fn infer_from(
         sess: &Session,
         linker: Option<PathBuf>,
         flavor: Option<LinkerFlavor>,
-        otherwise: F,
-    ) -> Result<(PathBuf, LinkerFlavor), ()>
-    where
-        F: FnOnce() -> Result<(PathBuf, LinkerFlavor), ()>
-    {
+    ) -> Option<(PathBuf, LinkerFlavor)> {
         match (linker, flavor) {
-            (Some(linker), Some(flavor)) => Ok((linker, flavor)),
+            (Some(linker), Some(flavor)) => Some((linker, flavor)),
             // only the linker flavor is known; use the default linker for the selected flavor
-            (None, Some(flavor)) => Ok((PathBuf::from(match flavor {
-                LinkerFlavor::Em => "emcc",
+            (None, Some(flavor)) => Some((PathBuf::from(match flavor {
+                LinkerFlavor::Em  => if cfg!(windows) { "emcc.bat" } else { "emcc" },
                 LinkerFlavor::Gcc => "gcc",
                 LinkerFlavor::Ld => "ld",
                 LinkerFlavor::Msvc => "link.exe",
                 LinkerFlavor::Lld(_) => "lld",
             }), flavor)),
-            // infer the linker flavor from the linker name
             (Some(linker), None) => {
-                let stem = linker.file_stem().and_then(|stem| stem.to_str()).ok_or_else(|| {
-                    sess
-                        .struct_err(&format!("couldn't extract file stem from specified linker"))
-                        .emit();
-                })?.to_owned();
+                let stem = linker.file_stem().and_then(|stem| stem.to_str()).unwrap_or_else(|| {
+                    sess.fatal("couldn't extract file stem from specified linker");
+                }).to_owned();
 
                 let flavor = if stem == "emcc" {
                     LinkerFlavor::Em
@@ -637,32 +625,35 @@ pub fn linker_and_flavor(sess: &Session) -> Result<(PathBuf, LinkerFlavor), ()> 
                 } else if stem == "link" || stem == "lld-link" {
                     LinkerFlavor::Msvc
                 } else {
-                    sess
-                        .struct_err(&format!("couldn't infer linker flavor from specified linker"))
-                        .emit();
-                    return Err(());
+                    // fall back to the value in the target spec
+                    sess.target.target.linker_flavor
                 };
 
-                Ok((linker, flavor))
+                Some((linker, flavor))
             },
-            (None, None) => otherwise(),
+            (None, None) => None,
         }
     }
 
     // linker and linker flavor specified via command line have precedence over what the target
     // specification specifies
-    from(sess, sess.opts.cg.linker.clone(), sess.opts.debugging_opts.linker_flavor, || {
-        from(
-            sess,
-            sess.target.target.options.linker.clone().map(PathBuf::from),
-            Some(sess.target.target.linker_flavor),
-            || {
-                sess
-                    .struct_err(&format!("no linker or linker flavor information provided"))
-                    .emit();
-                Err(())
-            })
-    })
+    if let Some(ret) = infer_from(
+        sess,
+        sess.opts.cg.linker.clone(),
+        sess.opts.debugging_opts.linker_flavor,
+    ) {
+        return ret;
+    }
+
+    if let Some(ret) = infer_from(
+        sess,
+        sess.target.target.options.linker.clone().map(PathBuf::from),
+        Some(sess.target.target.linker_flavor),
+    ) {
+        return ret;
+    }
+
+    sess.fatal("Not enough information provided to determine how to invoke the linker");
 }
 
 // Create a dynamic library or executable
@@ -675,12 +666,7 @@ fn link_natively(sess: &Session,
                  codegen_results: &CodegenResults,
                  tmpdir: &Path) {
     info!("preparing {:?} to {:?}", crate_type, out_filename);
-    let (linker, flavor) = if let Ok((linker, flavor)) = linker_and_flavor(sess) {
-        (linker, flavor)
-    } else {
-        sess.abort_if_errors();
-        return;
-    };
+    let (linker, flavor) = linker_and_flavor(sess);
 
     // The invocations of cc share some flags across platforms
     let (pname, mut cmd) = get_linker(sess, &linker, flavor);

--- a/src/librustc_codegen_llvm/back/linker.rs
+++ b/src/librustc_codegen_llvm/back/linker.rs
@@ -44,8 +44,9 @@ impl LinkerInfo {
 
     pub fn to_linker<'a>(&'a self,
                          cmd: Command,
-                         sess: &'a Session) -> Box<dyn Linker+'a> {
-        match sess.linker_flavor() {
+                         sess: &'a Session,
+                         flavor: LinkerFlavor) -> Box<dyn Linker+'a> {
+        match flavor {
             LinkerFlavor::Lld(LldFlavor::Link) |
             LinkerFlavor::Msvc => {
                 Box::new(MsvcLinker {

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -1503,17 +1503,14 @@ fn start_executing_work(tcx: TyCtxt,
 
     let assembler_cmd = if modules_config.no_integrated_as {
         // HACK: currently we use linker (gcc) as our assembler
-        if let Ok((linker, flavor)) = link::linker_and_flavor(sess) {
-            let (name, mut cmd) = get_linker(sess, &linker, flavor);
-            cmd.args(&sess.target.target.options.asm_args);
-            Some(Arc::new(AssemblerCommand {
-                name,
-                cmd,
-            }))
-        } else {
-            sess.abort_if_errors();
-            None
-        }
+        let (linker, flavor) = link::linker_and_flavor(sess);
+
+        let (name, mut cmd) = get_linker(sess, &linker, flavor);
+        cmd.args(&sess.target.target.options.asm_args);
+        Some(Arc::new(AssemblerCommand {
+            name,
+            cmd,
+        }))
     } else {
         None
     };

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -1503,12 +1503,17 @@ fn start_executing_work(tcx: TyCtxt,
 
     let assembler_cmd = if modules_config.no_integrated_as {
         // HACK: currently we use linker (gcc) as our assembler
-        let (name, mut cmd) = get_linker(sess);
-        cmd.args(&sess.target.target.options.asm_args);
-        Some(Arc::new(AssemblerCommand {
-            name,
-            cmd,
-        }))
+        if let Ok((linker, flavor)) = link::linker_and_flavor(sess) {
+            let (name, mut cmd) = get_linker(sess, &linker, flavor);
+            cmd.args(&sess.target.target.options.asm_args);
+            Some(Arc::new(AssemblerCommand {
+                name,
+                cmd,
+            }))
+        } else {
+            sess.abort_if_errors();
+            None
+        }
     } else {
         None
     };

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -433,6 +433,9 @@ pub struct TargetOptions {
     /// Linker to invoke
     pub linker: Option<String>,
 
+    /// LLD flavor
+    pub lld_flavor: LldFlavor,
+
     /// Linker arguments that are passed *before* any user-defined libraries.
     pub pre_link_args: LinkArgs, // ... unconditionally
     pub pre_link_args_crt: LinkArgs, // ... when linking with a bundled crt
@@ -650,6 +653,7 @@ impl Default for TargetOptions {
         TargetOptions {
             is_builtin: false,
             linker: option_env!("CFG_DEFAULT_LINKER").map(|s| s.to_string()),
+            lld_flavor: LldFlavor::Ld,
             pre_link_args: LinkArgs::new(),
             pre_link_args_crt: LinkArgs::new(),
             post_link_args: LinkArgs::new(),

--- a/src/librustc_target/spec/wasm32_unknown_unknown.rs
+++ b/src/librustc_target/spec/wasm32_unknown_unknown.rs
@@ -53,6 +53,7 @@ pub fn target() -> Result<Target, String> {
 
         // we use the LLD shipped with the Rust toolchain by default
         linker: Some("rust-lld".to_owned()),
+        lld_flavor: LldFlavor::Wasm,
 
         .. Default::default()
     };


### PR DESCRIPTION
This is a second take on PR #50359 that implements the logic proposed in https://github.com/rust-lang/rust/pull/50359#pullrequestreview-116663121

With this change it would become possible to link `thumb*` binaries using GNU's LD on stable as `-C linker=arm-none-eabi-ld` would be enough to change both the linker and the linker flavor from their default values of `arm-none-eabi-gcc` and `gcc`.

To link `thumb*` binaries using rustc's LLD on stable `-Z linker-flavor` would need to be stabilized as `-C linker=rust-lld -Z linker-flavor=ld.lld` are both required to change the linker and the linker flavor, but this PR doesn't propose that. We would probably need some sort of stability guarantee around `rust-lld`'s name and availability to make linking with rustc's LLD truly stable.

With this change it would also be possible to link `thumb*` binaries using a system installed LLD on stable using the `-C linker=ld.lld` flag (provided that `ld.lld` is a symlink to the system installed LLD).

r? @alexcrichton 