### PR TITLE
Add the `alloc::prelude` module

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -169,7 +169,7 @@ pub mod collections;
 pub mod sync;
 pub mod rc;
 pub mod raw_vec;
-
+pub mod prelude;
 pub mod borrow;
 pub mod fmt;
 pub mod slice;

--- a/src/liballoc/prelude.rs
+++ b/src/liballoc/prelude.rs
@@ -1,0 +1,29 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! The alloc Prelude
+//!
+//! The purpose of this module is to alleviate imports of commonly-used
+//! items of the `alloc` crate by adding a glob import to the top of modules:
+//!
+//! ```
+//! # #![allow(unused_imports)]
+//! # #![feature(alloc)]
+//! extern crate alloc;
+//! use alloc::prelude::*;
+//! ```
+
+#![unstable(feature = "alloc", issue = "27783")]
+
+#[unstable(feature = "alloc", issue = "27783")] pub use borrow::ToOwned;
+#[unstable(feature = "alloc", issue = "27783")] pub use boxed::Box;
+#[unstable(feature = "alloc", issue = "27783")] pub use slice::SliceConcatExt;
+#[unstable(feature = "alloc", issue = "27783")] pub use string::{String, ToString};
+#[unstable(feature = "alloc", issue = "27783")] pub use vec::Vec;

--- a/src/libstd/prelude/v1.rs
+++ b/src/libstd/prelude/v1.rs
@@ -12,42 +12,68 @@
 //!
 //! See the [module-level documentation](../index.html) for more.
 
+
+
 #![stable(feature = "rust1", since = "1.0.0")]
 
 // Re-exported core operators
 #[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)] pub use marker::{Copy, Send, Sized, Sync};
+#[doc(no_inline)]
+pub use marker::{Copy, Send, Sized, Sync};
 #[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)] pub use ops::{Drop, Fn, FnMut, FnOnce};
+#[doc(no_inline)]
+pub use ops::{Drop, Fn, FnMut, FnOnce};
 
 // Re-exported functions
 #[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)] pub use mem::drop;
+#[doc(no_inline)]
+pub use mem::drop;
 
 // Re-exported types and traits
 #[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)] pub use boxed::Box;
+#[doc(no_inline)]
+pub use clone::Clone;
 #[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)] pub use borrow::ToOwned;
+#[doc(no_inline)]
+pub use cmp::{PartialEq, PartialOrd, Eq, Ord};
 #[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)] pub use clone::Clone;
+#[doc(no_inline)]
+pub use convert::{AsRef, AsMut, Into, From};
 #[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)] pub use cmp::{PartialEq, PartialOrd, Eq, Ord};
+#[doc(no_inline)]
+pub use default::Default;
 #[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)] pub use convert::{AsRef, AsMut, Into, From};
+#[doc(no_inline)]
+pub use iter::{Iterator, Extend, IntoIterator};
 #[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)] pub use default::Default;
+#[doc(no_inline)]
+pub use iter::{DoubleEndedIterator, ExactSizeIterator};
 #[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)] pub use iter::{Iterator, Extend, IntoIterator};
+#[doc(no_inline)]
+pub use option::Option::{self, Some, None};
 #[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)] pub use iter::{DoubleEndedIterator, ExactSizeIterator};
+#[doc(no_inline)]
+pub use result::Result::{self, Ok, Err};
+
+
+// The file so far is equivalent to src/libcore/prelude/v1.rs,
+// and below to src/liballoc/prelude.rs.
+// Those files are duplicated rather than using glob imports
+// because we want docs to show these re-exports as pointing to within `std`.
+
+
 #[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)] pub use option::Option::{self, Some, None};
+#[doc(no_inline)]
+pub use boxed::Box;
 #[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)] pub use result::Result::{self, Ok, Err};
+#[doc(no_inline)]
+pub use borrow::ToOwned;
 #[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)] pub use slice::SliceConcatExt;
+#[doc(no_inline)]
+pub use slice::SliceConcatExt;
 #[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)] pub use string::{String, ToString};
+#[doc(no_inline)]
+pub use string::{String, ToString};
 #[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)] pub use vec::Vec;
+#[doc(no_inline)]
+pub use vec::Vec;


### PR DESCRIPTION
It contains the re-exports that are in `std::prelude::v1` but not in `core::prelude::v1`.

Calling it prelude is somewhat of a misnomer since (unlike those modules in `std` or `core`) its contents are never implicitly imported in modules. Rather it is intended to be used with an explicit glob import like `use alloc::prelude::*;`. However there is precedent for the same misnomer with `std::io::prelude`, for example.

This new module is unstable with the same feature name as the `alloc` care. They are proposed for stabilization together in RFC https://github.com/rust-lang/rfcs/pull/2480.