### PR TITLE
ARM: expose the "mclass" target feature

### DIFF
--- a/src/librustc_codegen_llvm/llvm_util.rs
+++ b/src/librustc_codegen_llvm/llvm_util.rs
@@ -84,6 +84,7 @@ unsafe fn configure_llvm(sess: &Session) {
 // array, leading to crashes.
 
 const ARM_WHITELIST: &[(&str, Option<&str>)] = &[
+    ("mclass", Some("arm_target_feature")),
     ("neon", Some("arm_target_feature")),
     ("v7", Some("arm_target_feature")),
     ("vfp2", Some("arm_target_feature")),


### PR DESCRIPTION
This let us differentiate, in conditional compilation context, between ARM Cortex-M targets, like
the `thumbv*` targets, and other ARM targets, like the ARM Cortex-A Linux targets.

r? @alexcrichton
cc @gnzlbg 
cc rust-lang-nursery/stdsimd#437