### PR TITLE
Plugin provided "intrinsics".

### DIFF
--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -26,6 +26,7 @@ use type_of::PointeeInfo;
 
 use rustc_data_structures::base_n;
 use rustc::mir::mono::Stats;
+use rustc::mir::PluginIntrinsics;
 use rustc::session::config::{self, NoDebugInfo};
 use rustc::session::Session;
 use rustc::ty::layout::{LayoutError, LayoutOf, Size, TyLayout};
@@ -102,6 +103,7 @@ pub struct CodegenCx<'a, 'tcx: 'a> {
     pub rust_try_fn: Cell<Option<ValueRef>>,
 
     intrinsics: RefCell<FxHashMap<&'static str, ValueRef>>,
+    pub plugin_intrinsics: Arc<PluginIntrinsics>,
 
     /// A counter that is used for generating local symbol names
     local_gen_sym_counter: Cell<usize>,
@@ -306,6 +308,7 @@ impl<'a, 'tcx> CodegenCx<'a, 'tcx> {
                 eh_unwind_resume: Cell::new(None),
                 rust_try_fn: Cell::new(None),
                 intrinsics: RefCell::new(FxHashMap()),
+                plugin_intrinsics: tcx.sess.plugin_intrinsics.get(),
                 local_gen_sym_counter: Cell::new(0),
             };
             cx.isize_ty = Type::isize(&cx);

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -50,7 +50,7 @@ use std::io::{self, Write};
 use std::iter;
 use std::path::{Path, PathBuf};
 use rustc_data_structures::sync::{self, Lrc, Lock};
-use std::sync::mpsc;
+use std::sync::{mpsc, Arc, };
 use syntax::{self, ast, attr, diagnostics, visit};
 use syntax::ext::base::ExtCtxt;
 use syntax::fold::Folder;
@@ -896,6 +896,7 @@ where
         lint_groups,
         llvm_passes,
         attributes,
+        intrinsics,
         ..
     } = registry;
 
@@ -914,6 +915,7 @@ where
 
         *sess.plugin_llvm_passes.borrow_mut() = llvm_passes;
         *sess.plugin_attributes.borrow_mut() = attributes.clone();
+        sess.plugin_intrinsics.set(Arc::new(intrinsics));
     })?;
 
     // Lint plugins are registered; now we can process command line flags.

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -319,12 +319,20 @@ pub fn check_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             }
 
             ref other => {
-                struct_span_err!(tcx.sess, it.span, E0093,
+                let plugin_intrinsics = tcx.sess.plugin_intrinsics.get();
+                if let Some(plugin) = plugin_intrinsics.get(*other) {
+                  (plugin.generic_parameter_count(tcx),
+                   plugin.inputs(tcx),
+                   plugin.output(tcx))
+                } else {
+                    struct_span_err!(tcx.sess, it.span, E0093,
                                 "unrecognized intrinsic function: `{}`",
                                 *other)
                                 .span_label(it.span, "unrecognized intrinsic")
                                 .emit();
-                return;
+                    return;
+
+                }
             }
         };
         (n_tps, inputs, output)

--- a/src/test/compile-fail-fulldeps/auxiliary/plugin_intrinsic_codegen.rs
+++ b/src/test/compile-fail-fulldeps/auxiliary/plugin_intrinsic_codegen.rs
@@ -1,0 +1,84 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// force-host
+
+#![feature(plugin_registrar, rustc_private)]
+#![deny(plugin_as_library)] // should have no effect in a plugin crate
+
+extern crate rustc;
+extern crate rustc_plugin;
+
+
+use rustc::mir::*;
+use rustc::ty::{Ty, TyCtxt, FnSig, subst::Substs, };
+use rustc_plugin::Registry;
+
+#[plugin_registrar]
+pub fn plugin_registrar(reg: &mut Registry) {
+  let codegen = Box::new(GenericCountMismatch) as Box<_>;
+  reg.register_intrinsic("generic_count_mismatch".into(), codegen);
+  let codegen = Box::new(InputOutputMismatch) as Box<_>;
+  reg.register_intrinsic("type_mismatch".into(), codegen);
+}
+
+struct GenericCountMismatch;
+impl PluginIntrinsicCodegen for GenericCountMismatch {
+  fn codegen_simple_intrinsic<'a, 'tcx>(&self,
+                                        _tcx: TyCtxt<'a, 'tcx, 'tcx>,
+                                        _source_info: SourceInfo,
+                                        _sig: &FnSig<'tcx>,
+                                        _parent_mir: &Mir<'tcx>,
+                                        _parent_param_substs: &'tcx Substs<'tcx>,
+                                        _args: &Vec<Operand<'tcx>>,
+                                        _dest: Place<'tcx>,
+                                        _extra_stmts: &mut Vec<StatementKind<'tcx>>)
+    where 'tcx: 'a,
+  {
+    unreachable!()
+  }
+
+  /// The number of generic parameters expected.
+  fn generic_parameter_count<'a, 'tcx>(&self, _tcx: TyCtxt<'a, 'tcx, 'tcx>) -> usize { 5 }
+  /// The types of the input args.
+  fn inputs<'a, 'tcx>(&self, _tcx: TyCtxt<'a, 'tcx, 'tcx>) -> Vec<Ty<'tcx>> { vec![] }
+  /// The return type.
+  fn output<'a, 'tcx>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> Ty<'tcx> {
+    tcx.mk_nil()
+  }
+}
+
+struct InputOutputMismatch;
+impl PluginIntrinsicCodegen for InputOutputMismatch {
+  fn codegen_simple_intrinsic<'a, 'tcx>(&self,
+                                        _tcx: TyCtxt<'a, 'tcx, 'tcx>,
+                                        _source_info: SourceInfo,
+                                        _sig: &FnSig<'tcx>,
+                                        _parent_mir: &Mir<'tcx>,
+                                        _parent_param_substs: &'tcx Substs<'tcx>,
+                                        _args: &Vec<Operand<'tcx>>,
+                                        _dest: Place<'tcx>,
+                                        _extra_stmts: &mut Vec<StatementKind<'tcx>>)
+    where 'tcx: 'a,
+  {
+    unreachable!()
+  }
+
+  /// The number of generic parameters expected.
+  fn generic_parameter_count<'a, 'tcx>(&self, _tcx: TyCtxt<'a, 'tcx, 'tcx>) -> usize { 0 }
+  /// The types of the input args.
+  fn inputs<'a, 'tcx>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> Vec<Ty<'tcx>> {
+    vec![tcx.types.u64]
+  }
+  /// The return type.
+  fn output<'a, 'tcx>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> Ty<'tcx> {
+    tcx.types.u64
+  }
+}

--- a/src/test/compile-fail-fulldeps/plugin-intrinsic-arg.rs
+++ b/src/test/compile-fail-fulldeps/plugin-intrinsic-arg.rs
@@ -1,0 +1,25 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:plugin_intrinsic_codegen.rs
+// ignore-stage1
+
+#![feature(plugin, intrinsics)]
+#![plugin(plugin_intrinsic_codegen)]
+
+extern "rust-intrinsic" {
+    /// The plugin expects `arg1` to be `u64`.
+    fn type_mismatch(arg1: i64) -> u64;
+    //~^ ERROR intrinsic has wrong type
+}
+
+fn main() {
+    unreachable!();
+}

--- a/src/test/compile-fail-fulldeps/plugin-intrinsic-generic.rs
+++ b/src/test/compile-fail-fulldeps/plugin-intrinsic-generic.rs
@@ -1,0 +1,25 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:plugin_intrinsic_codegen.rs
+// ignore-stage1
+
+#![feature(plugin, intrinsics)]
+#![plugin(plugin_intrinsic_codegen)]
+
+extern "rust-intrinsic" {
+    /// The plugin expects 5 generic params
+    fn generic_count_mismatch<T>();
+    //~^ ERROR intrinsic has wrong number of type parameters: found 1, expected 5
+}
+
+fn main() {
+    unreachable!();
+}

--- a/src/test/compile-fail-fulldeps/plugin-intrinsic-ret.rs
+++ b/src/test/compile-fail-fulldeps/plugin-intrinsic-ret.rs
@@ -1,0 +1,25 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:plugin_intrinsic_codegen.rs
+// ignore-stage1
+
+#![feature(plugin, intrinsics)]
+#![plugin(plugin_intrinsic_codegen)]
+
+extern "rust-intrinsic" {
+    /// The plugin expects the return to be `u64`.
+    fn type_mismatch(arg1: u64) -> i64;
+    //~^ ERROR intrinsic has wrong type
+}
+
+fn main() {
+    unreachable!();
+}

--- a/src/test/run-pass-fulldeps/auxiliary/plugin_intrinsic_codegen.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/plugin_intrinsic_codegen.rs
@@ -1,0 +1,73 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// force-host
+
+#![feature(plugin_registrar, rustc_private)]
+#![deny(plugin_as_library)] // should have no effect in a plugin crate
+
+extern crate rustc;
+extern crate rustc_plugin;
+
+use rustc::mir::*;
+use rustc::ty::{Ty, TyCtxt, FnSig, Const, subst::Substs, ParamEnv, };
+use rustc_plugin::Registry;
+
+#[plugin_registrar]
+pub fn plugin_registrar(reg: &mut Registry) {
+  let codegen = Box::new(GetSecretValueCodegen) as Box<_>;
+  reg.register_intrinsic("get_secret_value".into(), codegen);
+}
+
+struct GetSecretValueCodegen;
+impl PluginIntrinsicCodegen for GetSecretValueCodegen {
+  fn codegen_simple_intrinsic<'a, 'tcx>(&self,
+                                        tcx: TyCtxt<'a, 'tcx, 'tcx>,
+                                        source_info: SourceInfo,
+                                        _sig: &FnSig<'tcx>,
+                                        _parent_mir: &Mir<'tcx>,
+                                        _parent_param_substs: &'tcx Substs<'tcx>,
+                                        _args: &Vec<Operand<'tcx>>,
+                                        dest: Place<'tcx>,
+                                        extra_stmts: &mut Vec<StatementKind<'tcx>>)
+    where 'tcx: 'a,
+  {
+    // chosen by fair dice roll.
+    // guaranteed to be random.
+    const SECRET_VALUE: u64 = 4;
+
+    let v = Const::from_bits(tcx, SECRET_VALUE as u128,
+                             ParamEnv::empty().and(tcx.types.u64));
+    let v = tcx.mk_const(*v);
+    let v = Literal::Value {
+      value: v,
+    };
+    let v = Constant {
+      span: source_info.span,
+      ty: tcx.types.u64,
+      literal: v,
+    };
+    let v = Box::new(v);
+    let v = Operand::Constant(v);
+    let ret = Rvalue::Use(v);
+
+    let stmt = StatementKind::Assign(dest, ret);
+    extra_stmts.push(stmt);
+  }
+
+  /// The number of generic parameters expected.
+  fn generic_parameter_count<'a, 'tcx>(&self, _tcx: TyCtxt<'a, 'tcx, 'tcx>) -> usize { 0 }
+  /// The types of the input args.
+  fn inputs<'a, 'tcx>(&self, _tcx: TyCtxt<'a, 'tcx, 'tcx>) -> Vec<Ty<'tcx>> { vec![] }
+  /// The return type.
+  fn output<'a, 'tcx>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> Ty<'tcx> {
+    tcx.types.u64
+  }
+}

--- a/src/test/run-pass-fulldeps/plugin-intrinsic.rs
+++ b/src/test/run-pass-fulldeps/plugin-intrinsic.rs
@@ -1,0 +1,25 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:plugin_intrinsic_codegen.rs
+// ignore-stage1
+
+#![feature(plugin, intrinsics)]
+#![plugin(plugin_intrinsic_codegen)]
+
+extern "rust-intrinsic" {
+  /// Returns the secret value.
+  fn get_secret_value() -> u64;
+}
+
+fn main() {
+  const SECRET_VALUE: u64 = 4;
+  assert_eq!(unsafe { get_secret_value() }, SECRET_VALUE);
+}


### PR DESCRIPTION
Allows plugins to define functions which are only expanded by the plugin after all type checking, inference, etc etc, ie only once codegen encounters a call to the intrinsic. In this initial version, the codegen crate is reponsible for calling the plugin intrinsic codgen trait and codegening the resulting extra MIR statements. Plugins are limited to `mir::StatementKind` and those contained therein, so they can't insert extra basic blocks, or insert calls to arbitraty functions. This means
the compiler can still reason about what is reachable.

The form of the interface with the plugins is slightly different than what was proposed in https://github.com/rust-lang/rust/issues/51623.

I understand the desired path is to do an RFC for these sort of things. I haven't started one, and honestly didn't plan to due to time required (and it really doesn't need an RFC; if one would like to see a change,
 make the change!), but considering that it'll create a common place to discuss this, maybe I will.

r? @eddyb Probably others too?