### PR TITLE
Copy libgcc as well after building musl

### DIFF
--- a/src/ci/docker/scripts/musl.sh
+++ b/src/ci/docker/scripts/musl.sh
@@ -72,3 +72,6 @@ cmake ../libunwind-release_$LLVM \
 hide_output make -j$(nproc)
 cp lib/libunwind.a /musl-$TAG/lib
 cd ../ && rm -rf libunwind-build
+
+# Copy libgcc since musl may depend on symbols defined in it
+cp $($CC $CFLAGS -print-libgcc-file-name) /musl-$TAG/lib


### PR DESCRIPTION
This is needed for rust-lang/libc#1034.

r? @alexcrichton 