### PR TITLE
Performance improvement of Vec's swap_remove.

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -809,9 +809,13 @@ impl<T> Vec<T> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn swap_remove(&mut self, index: usize) -> T {
-        let length = self.len();
-        self.swap(index, length - 1);
-        self.pop().unwrap()
+        unsafe {
+            // We replace self[index] with the last element. Note that this is
+            // safe even when index == self.len() - 1, as pop() only uses
+            // ptr::read and leaves the memory at self[index] untouched.
+            let hole: *mut T = &mut self[index];
+            ptr::replace(hole, self.pop().unwrap())
+        }
     }
 
     /// Inserts an element at position `index` within the vector, shifting all

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -810,7 +810,7 @@ impl<T> Vec<T> {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn swap_remove(&mut self, index: usize) -> T {
         unsafe {
-            // We replace self[index] with the last element. Note that if the 
+            // We replace self[index] with the last element. Note that if the
             // bounds check on hole succeeds there must be a last element (which
             // can be self[index] itself).
             let hole: *mut T = &mut self[index];

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -810,11 +810,13 @@ impl<T> Vec<T> {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn swap_remove(&mut self, index: usize) -> T {
         unsafe {
-            // We replace self[index] with the last element. Note that this is
-            // safe even when index == self.len() - 1, as pop() only uses
-            // ptr::read and leaves the memory at self[index] untouched.
+            // We replace self[index] with the last element. Note that if the 
+            // bounds check on hole succeeds there must be a last element (which
+            // can be self[index] itself).
             let hole: *mut T = &mut self[index];
-            ptr::replace(hole, self.pop().unwrap())
+            let last = ptr::read(self.get_unchecked(self.len - 1));
+            self.len -= 1;
+            ptr::replace(hole, last)
         }
     }
 


### PR DESCRIPTION
The old implementation *literally* swapped and then removed, which resulted in unnecessary move instructions. The new implementation does use unsafe code, but is easy to see that it is correct.

Fixes https://github.com/rust-lang/rust/issues/52150.