### PR TITLE
Warn windows-gnu users that the bundled gcc can't compile

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -308,6 +308,14 @@ fn make_win_dist(
         builder.copy_to_folder(&src, &target_bin_dir);
     }
 
+    // Warn windows-gnu users that the bundled GCC cannot compile C files
+    builder.create(
+        &target_bin_dir.join("DO NOT USE THIS gcc.exe FOR COMPILATION.txt"),
+        &"gcc.exe contained in this folder cannot be used for compiling C files - it is only\
+         used as a linker. In order to be able to compile projects containing C code use\
+         the GCC provided by MinGW or Cygwin."
+    );
+
     //Copy platform libs to platform-specific lib directory
     let target_lib_dir = plat_root.join("lib").join("rustlib").join(target_triple).join("lib");
     fs::create_dir_all(&target_lib_dir).expect("creating target_lib_dir failed");

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -310,8 +310,8 @@ fn make_win_dist(
 
     // Warn windows-gnu users that the bundled GCC cannot compile C files
     builder.create(
-        &target_bin_dir.join("DO NOT USE THIS gcc.exe FOR COMPILATION.txt"),
-        &"gcc.exe contained in this folder cannot be used for compiling C files - it is only\
+        &target_bin_dir.join("GCC-WARNING.txt"),
+        "gcc.exe contained in this folder cannot be used for compiling C files - it is only\
          used as a linker. In order to be able to compile projects containing C code use\
          the GCC provided by MinGW or Cygwin."
     );


### PR DESCRIPTION
Add a `DO NOT USE THIS gcc.exe FOR COMPILATION.txt` file to `lib\rustlib\*-pc-windows-gnu\bin` folders in `windows-gnu` installations in order to warn against attempting to use the bundled `gcc.exe` as a C compiler. I'm pretty sure that location is usually found manually, so this should be easily noticeable.

This mistake has been made plenty of times and has lead to misunderstandings:
Rust: [Bundled gcc (windows x64) is unable to build any c file](https://github.com/rust-lang/rust/issues/24418)
gtk-rs:    [Compiling on windows](https://github.com/gtk-rs/gtk/issues/625)
bzip2-rs: [Build failure at gcc level: blocksort.c not found](https://github.com/alexcrichton/bzip2-rs/issues/30)

Alternatives: rename the bundled `gcc.exe` to e.g. `rustc-gcc.exe` or `gcc-linker.exe`. This might require a more comprehensive change or break crates already using it as a linker.

r? @alexcrichton 