### PR TITLE
rustdoc: set panic output before starting compiler thread pool

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -550,7 +550,7 @@ impl Collector {
         debug!("Creating test {}: {}", name, test);
         self.tests.push(testing::TestDescAndFn {
             desc: testing::TestDesc {
-                name: testing::DynTestName(name),
+                name: testing::DynTestName(name.clone()),
                 ignore: should_ignore,
                 // compiler failures are test failures
                 should_panic: testing::ShouldPanic::No,
@@ -560,7 +560,7 @@ impl Collector {
                 let panic = io::set_panic(None);
                 let print = io::set_print(None);
                 match {
-                    rustc_driver::in_rustc_thread(move || with_globals(move || {
+                    rustc_driver::in_named_rustc_thread(name, move || with_globals(move || {
                         io::set_panic(panic);
                         io::set_print(print);
                         hygiene::set_default_edition(edition);

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -260,7 +260,7 @@ fn run_test(test: &str, cratename: &str, filename: &FileName, line: usize,
     let old = io::set_panic(Some(box Sink(data.clone())));
     let _bomb = Bomb(data.clone(), old.unwrap_or(box io::stdout()));
 
-    let (libdir, outdir) = driver::spawn_thread_pool(sessopts, |sessopts| {
+    let (libdir, outdir, compile_result) = driver::spawn_thread_pool(sessopts, |sessopts| {
         let codemap = Lrc::new(CodeMap::new_doctest(
             sessopts.file_path_mapping(), filename.clone(), line as isize - line_offset as isize
         ));
@@ -314,28 +314,28 @@ fn run_test(test: &str, cratename: &str, filename: &FileName, line: usize,
             Err(_) | Ok(Err(CompileIncomplete::Errored(_))) => Err(())
         };
 
-        match (compile_result, compile_fail) {
-            (Ok(()), true) => {
-                panic!("test compiled while it wasn't supposed to")
-            }
-            (Ok(()), false) => {}
-            (Err(()), true) => {
-                if error_codes.len() > 0 {
-                    let out = String::from_utf8(data.lock().unwrap().to_vec()).unwrap();
-                    error_codes.retain(|err| !out.contains(err));
-                }
-            }
-            (Err(()), false) => {
-                panic!("couldn't compile the test")
-            }
-        }
-
-        if error_codes.len() > 0 {
-            panic!("Some expected error codes were not found: {:?}", error_codes);
-        }
-
-        (libdir, outdir)
+        (libdir, outdir, compile_result)
     });
+
+    match (compile_result, compile_fail) {
+        (Ok(()), true) => {
+            panic!("test compiled while it wasn't supposed to")
+        }
+        (Ok(()), false) => {}
+        (Err(()), true) => {
+            if error_codes.len() > 0 {
+                let out = String::from_utf8(data.lock().unwrap().to_vec()).unwrap();
+                error_codes.retain(|err| !out.contains(err));
+            }
+        }
+        (Err(()), false) => {
+            panic!("couldn't compile the test")
+        }
+    }
+
+    if error_codes.len() > 0 {
+        panic!("Some expected error codes were not found: {:?}", error_codes);
+    }
 
     if no_run { return }
 

--- a/src/test/rustdoc-ui/failed-doctest-output.rs
+++ b/src/test/rustdoc-ui/failed-doctest-output.rs
@@ -1,0 +1,19 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #51162: A failed doctest was not printing its stdout/stderr
+
+// compile-flags:--test
+// disable-ui-testing-normalization
+
+/// ```
+/// panic!("oh no");
+/// ```
+pub struct SomeStruct;

--- a/src/test/rustdoc-ui/failed-doctest-output.rs
+++ b/src/test/rustdoc-ui/failed-doctest-output.rs
@@ -9,15 +9,19 @@
 // except according to those terms.
 
 // Issue #51162: A failed doctest was not printing its stdout/stderr
+// FIXME: if/when the output of the test harness can be tested on its own, this test should be
+// adapted to use that, and that normalize line can go away
 
 // compile-flags:--test
-// disable-ui-testing-normalization
+// normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
 
+// doctest fails at runtime
 /// ```
 /// panic!("oh no");
 /// ```
 pub struct SomeStruct;
 
+// doctest fails at compile time
 /// ```
 /// no
 /// ```

--- a/src/test/rustdoc-ui/failed-doctest-output.rs
+++ b/src/test/rustdoc-ui/failed-doctest-output.rs
@@ -14,6 +14,7 @@
 
 // compile-flags:--test
 // normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// failure-status: 101
 
 // doctest fails at runtime
 /// ```

--- a/src/test/rustdoc-ui/failed-doctest-output.rs
+++ b/src/test/rustdoc-ui/failed-doctest-output.rs
@@ -17,3 +17,8 @@
 /// panic!("oh no");
 /// ```
 pub struct SomeStruct;
+
+/// ```
+/// no
+/// ```
+pub struct OtherStruct;

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -1,32 +1,32 @@
 
 running 2 tests
-test src/test/rustdoc-ui/failed-doctest-output.rs - OtherStruct (line 21) ... FAILED
-test src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16) ... FAILED
+test $DIR/failed-doctest-output.rs - OtherStruct (line 21) ... FAILED
+test $DIR/failed-doctest-output.rs - SomeStruct (line 16) ... FAILED
 
 failures:
 
----- src/test/rustdoc-ui/failed-doctest-output.rs - OtherStruct (line 21) stdout ----
+---- $DIR/failed-doctest-output.rs - OtherStruct (line 21) stdout ----
 error[E0425]: cannot find value `no` in this scope
- --> src/test/rustdoc-ui/failed-doctest-output.rs:22:1
+ --> $DIR/failed-doctest-output.rs:22:1
   |
 3 | no
   | ^^ not found in this scope
 
-thread 'src/test/rustdoc-ui/failed-doctest-output.rs - OtherStruct (line 21)' panicked at 'couldn't compile the test', librustdoc/test.rs:332:13
+thread '$DIR/failed-doctest-output.rs - OtherStruct (line 21)' panicked at 'couldn't compile the test', librustdoc/test.rs:332:13
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
----- src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16) stdout ----
-thread 'src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16)' panicked at 'test executable failed:
+---- $DIR/failed-doctest-output.rs - SomeStruct (line 16) stdout ----
+thread '$DIR/failed-doctest-output.rs - SomeStruct (line 16)' panicked at 'test executable failed:
 
-thread 'main' panicked at 'oh no', src/test/rustdoc-ui/failed-doctest-output.rs:3:1
+thread 'main' panicked at 'oh no', $DIR/failed-doctest-output.rs:3:1
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
 ', librustdoc/test.rs:367:17
 
 
 failures:
-    src/test/rustdoc-ui/failed-doctest-output.rs - OtherStruct (line 21)
-    src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16)
+    $DIR/failed-doctest-output.rs - OtherStruct (line 21)
+    $DIR/failed-doctest-output.rs - SomeStruct (line 16)
 
 test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
 

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -1,22 +1,22 @@
 
 running 2 tests
-test $DIR/failed-doctest-output.rs - OtherStruct (line 21) ... FAILED
-test $DIR/failed-doctest-output.rs - SomeStruct (line 16) ... FAILED
+test $DIR/failed-doctest-output.rs - OtherStruct (line 25) ... FAILED
+test $DIR/failed-doctest-output.rs - SomeStruct (line 19) ... FAILED
 
 failures:
 
----- $DIR/failed-doctest-output.rs - OtherStruct (line 21) stdout ----
+---- $DIR/failed-doctest-output.rs - OtherStruct (line 25) stdout ----
 error[E0425]: cannot find value `no` in this scope
- --> $DIR/failed-doctest-output.rs:22:1
+ --> $DIR/failed-doctest-output.rs:26:1
   |
 3 | no
   | ^^ not found in this scope
 
-thread '$DIR/failed-doctest-output.rs - OtherStruct (line 21)' panicked at 'couldn't compile the test', librustdoc/test.rs:332:13
+thread '$DIR/failed-doctest-output.rs - OtherStruct (line 25)' panicked at 'couldn't compile the test', librustdoc/test.rs:332:13
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
----- $DIR/failed-doctest-output.rs - SomeStruct (line 16) stdout ----
-thread '$DIR/failed-doctest-output.rs - SomeStruct (line 16)' panicked at 'test executable failed:
+---- $DIR/failed-doctest-output.rs - SomeStruct (line 19) stdout ----
+thread '$DIR/failed-doctest-output.rs - SomeStruct (line 19)' panicked at 'test executable failed:
 
 thread 'main' panicked at 'oh no', $DIR/failed-doctest-output.rs:3:1
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
@@ -25,8 +25,8 @@ note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
 
 failures:
-    $DIR/failed-doctest-output.rs - OtherStruct (line 21)
-    $DIR/failed-doctest-output.rs - SomeStruct (line 16)
+    $DIR/failed-doctest-output.rs - OtherStruct (line 25)
+    $DIR/failed-doctest-output.rs - SomeStruct (line 19)
 
 test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
 

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -1,8 +1,19 @@
 
-running 1 test
+running 2 tests
+test src/test/rustdoc-ui/failed-doctest-output.rs - OtherStruct (line 21) ... FAILED
 test src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16) ... FAILED
 
 failures:
+
+---- src/test/rustdoc-ui/failed-doctest-output.rs - OtherStruct (line 21) stdout ----
+error[E0425]: cannot find value `no` in this scope
+ --> src/test/rustdoc-ui/failed-doctest-output.rs:22:1
+  |
+3 | no
+  | ^^ not found in this scope
+
+thread 'src/test/rustdoc-ui/failed-doctest-output.rs - OtherStruct (line 21)' panicked at 'couldn't compile the test', librustdoc/test.rs:332:13
+note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
 ---- src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16) stdout ----
 thread 'src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16)' panicked at 'test executable failed:
@@ -11,11 +22,11 @@ thread 'main' panicked at 'oh no', src/test/rustdoc-ui/failed-doctest-output.rs:
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
 ', librustdoc/test.rs:367:17
-note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
 
 failures:
+    src/test/rustdoc-ui/failed-doctest-output.rs - OtherStruct (line 21)
     src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16)
 
-test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
+test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
 

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -1,22 +1,22 @@
 
 running 2 tests
-test $DIR/failed-doctest-output.rs - OtherStruct (line 25) ... FAILED
-test $DIR/failed-doctest-output.rs - SomeStruct (line 19) ... FAILED
+test $DIR/failed-doctest-output.rs - OtherStruct (line 26) ... FAILED
+test $DIR/failed-doctest-output.rs - SomeStruct (line 20) ... FAILED
 
 failures:
 
----- $DIR/failed-doctest-output.rs - OtherStruct (line 25) stdout ----
+---- $DIR/failed-doctest-output.rs - OtherStruct (line 26) stdout ----
 error[E0425]: cannot find value `no` in this scope
- --> $DIR/failed-doctest-output.rs:26:1
+ --> $DIR/failed-doctest-output.rs:27:1
   |
 3 | no
   | ^^ not found in this scope
 
-thread '$DIR/failed-doctest-output.rs - OtherStruct (line 25)' panicked at 'couldn't compile the test', librustdoc/test.rs:332:13
+thread '$DIR/failed-doctest-output.rs - OtherStruct (line 26)' panicked at 'couldn't compile the test', librustdoc/test.rs:332:13
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
----- $DIR/failed-doctest-output.rs - SomeStruct (line 19) stdout ----
-thread '$DIR/failed-doctest-output.rs - SomeStruct (line 19)' panicked at 'test executable failed:
+---- $DIR/failed-doctest-output.rs - SomeStruct (line 20) stdout ----
+thread '$DIR/failed-doctest-output.rs - SomeStruct (line 20)' panicked at 'test executable failed:
 
 thread 'main' panicked at 'oh no', $DIR/failed-doctest-output.rs:3:1
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
@@ -25,8 +25,8 @@ note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
 
 failures:
-    $DIR/failed-doctest-output.rs - OtherStruct (line 25)
-    $DIR/failed-doctest-output.rs - SomeStruct (line 19)
+    $DIR/failed-doctest-output.rs - OtherStruct (line 26)
+    $DIR/failed-doctest-output.rs - SomeStruct (line 20)
 
 test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
 

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -1,0 +1,21 @@
+
+running 1 test
+test src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16) ... FAILED
+
+failures:
+
+---- src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16) stdout ----
+thread 'src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16)' panicked at 'test executable failed:
+
+thread 'main' panicked at 'oh no', src/test/rustdoc-ui/failed-doctest-output.rs:3:1
+note: Run with `RUST_BACKTRACE=1` for a backtrace.
+
+', librustdoc/test.rs:367:17
+note: Run with `RUST_BACKTRACE=1` for a backtrace.
+
+
+failures:
+    src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16)
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
+

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -392,17 +392,19 @@ impl TestProps {
 
             if let Some(code) = config.parse_failure_status(ln) {
                 self.failure_status = code;
-            } else {
-                self.failure_status = match config.mode {
-                    Mode::RunFail => 101,
-                    _ => 1,
-                };
             }
 
             if !self.run_rustfix {
                 self.run_rustfix = config.parse_run_rustfix(ln);
             }
         });
+
+        if self.failure_status == -1 {
+            self.failure_status = match config.mode {
+                Mode::RunFail => 101,
+                _ => 1,
+            };
+        }
 
         for key in &["RUST_TEST_NOCAPTURE", "RUST_TEST_THREADS"] {
             if let Ok(val) = env::var(key) {


### PR DESCRIPTION
When the compiler was updated to run on a thread pool, rustdoc's processing of compiler/doctest stderr/stdout was moved into each compiler thread. However, this caused output of the test to be lost if the test failed at *runtime* instead of compile time. This change sets up the `set_panic` call and output bomb before starting the compiler thread pool, so that the `Drop` call that writes back to the test's stdout happens after the test runs, not just after it compiles.

Fixes https://github.com/rust-lang/rust/issues/51162