### PR TITLE
rustc: Avoid /tmp/ in graphviz writing

### DIFF
--- a/src/librustc/infer/lexical_region_resolve/graphviz.rs
+++ b/src/librustc/infer/lexical_region_resolve/graphviz.rs
@@ -39,14 +39,14 @@ use std::sync::atomic::{AtomicBool, Ordering};
 fn print_help_message() {
     println!("\
 -Z print-region-graph by default prints a region constraint graph for every \n\
-function body, to the path `/tmp/constraints.nodeXXX.dot`, where the XXX is \n\
+function body, to the path `constraints.nodeXXX.dot`, where the XXX is \n\
 replaced with the node id of the function under analysis.                   \n\
                                                                             \n\
 To select one particular function body, set `RUST_REGION_GRAPH_NODE=XXX`,   \n\
 where XXX is the node id desired.                                           \n\
                                                                             \n\
 To generate output to some path other than the default                      \n\
-`/tmp/constraints.nodeXXX.dot`, set `RUST_REGION_GRAPH=/path/desired.dot`;  \n\
+`constraints.nodeXXX.dot`, set `RUST_REGION_GRAPH=/path/desired.dot`;  \n\
 occurrences of the character `%` in the requested path will be replaced with\n\
 the node id of the function under analysis.                                 \n\
                                                                             \n\
@@ -90,7 +90,7 @@ pub fn maybe_print_constraints_for<'a, 'gcx, 'tcx>(
             }
 
             Ok(other_path) => other_path,
-            Err(_) => "/tmp/constraints.node%.dot".to_string(),
+            Err(_) => "constraints.node%.dot".to_string(),
         };
 
         if output_template.is_empty() {


### PR DESCRIPTION
This issue was reported to security@rust-lang.org by Sebastien Marie following
our recent [security advisory][1]. Because `/tmp` is typically globally writable
it's possible for one user to place symlinks in `/tmp` pointing to files in
another user's directories, causing `rustc` to overwrite the contents of
innocent files by accident.

This patch instead defaults the output path here to the cwd which should avoid
this issue.

[1]: https://blog.rust-lang.org/2018/07/06/security-advisory-for-rustdoc.html