### PR TITLE
overhaul exit codes for rustc and rustdoc

### DIFF
--- a/src/test/run-make-fulldeps/exit-code/Makefile
+++ b/src/test/run-make-fulldeps/exit-code/Makefile
@@ -1,0 +1,11 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) success.rs; [ $$? -eq 0 ]
+	$(RUSTC) --invalid-arg-foo; [ $$? -eq 1 ]
+	$(RUSTC) compile-error.rs; [ $$? -eq 1 ]
+	$(RUSTC) -Ztreat-err-as-bug compile-error.rs; [ $$? -eq 101 ]
+	$(RUSTDOC) -o $(TMPDIR)/exit-code success.rs; [ $$? -eq 0 ]
+	$(RUSTDOC) --invalid-arg-foo; [ $$? -eq 1 ]
+	$(RUSTDOC) compile-error.rs; [ $$? -eq 1 ]
+	$(RUSTDOC) lint-failure.rs; [ $$? -eq 1 ]

--- a/src/test/run-make-fulldeps/exit-code/compile-error.rs
+++ b/src/test/run-make-fulldeps/exit-code/compile-error.rs
@@ -1,0 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    compile_error!("kaboom");
+}

--- a/src/test/run-make-fulldeps/exit-code/lint-failure.rs
+++ b/src/test/run-make-fulldeps/exit-code/lint-failure.rs
@@ -1,0 +1,16 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(intra_doc_link_resolution_failure)]
+
+/// [intradoc::failure]
+fn main() {
+    println!("Hello, world!");
+}

--- a/src/test/run-make-fulldeps/exit-code/success.rs
+++ b/src/test/run-make-fulldeps/exit-code/success.rs
@@ -1,0 +1,14 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// Main function
+fn main() {
+    println!("Hello, world!");
+}

--- a/src/test/ui/issue-20801.rs
+++ b/src/test/ui/issue-20801.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test currently ICEs when using NLL (#52416)
+
 // We used to ICE when moving out of a `*mut T` or `*const T`.
 
 struct T(u8);

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -14,8 +14,7 @@ use std::io::prelude::*;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
-use common;
-use common::Config;
+use common::{self, Config, Mode};
 use util;
 
 use extract_gdb_version;
@@ -262,7 +261,7 @@ impl TestProps {
             disable_ui_testing_normalization: false,
             normalize_stdout: vec![],
             normalize_stderr: vec![],
-            failure_status: 101,
+            failure_status: -1,
             run_rustfix: false,
         }
     }
@@ -393,6 +392,11 @@ impl TestProps {
 
             if let Some(code) = config.parse_failure_status(ln) {
                 self.failure_status = code;
+            } else {
+                self.failure_status = match config.mode {
+                    Mode::RunFail => 101,
+                    _ => 1,
+                };
             }
 
             if !self.run_rustfix {

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1170,12 +1170,10 @@ impl<'test> TestCx<'test> {
     }
 
     fn check_no_compiler_crash(&self, proc_res: &ProcRes) {
-        for line in proc_res.stderr.lines() {
-            if line.contains("error: internal compiler error") {
-                self.fatal_proc_rec("compiler encountered internal error", proc_res);
-            } else if line.contains(" panicked at ") {
-                self.fatal_proc_rec("compiler panicked", proc_res);
-            }
+        match proc_res.status.code() {
+            Some(101) => self.fatal_proc_rec("compiler encountered internal error", proc_res),
+            None => self.fatal_proc_rec("compiler terminated by signal", proc_res),
+            _ => (),
         }
     }
 


### PR DESCRIPTION
This commit changes the exit status of rustc to 1 in the presence of
compilation errors. In the event of an unexpected panic (ICE) the
standard panic error exit status of 101 remains.

A run-make test is added to ensure that the exit code does not regress,
and compiletest is updated to check for an exit status of 1 or 101,
depending on the mode and suite.

This is a breaking change for custom drivers.

Note that while changes were made to the rustdoc binary, there is no
intended behavior change. rustdoc errors (i.e., failed lints) will still
report 101. While this could *also* hide potential ICEs, I will leave
that work to a future PR.

Fixes #51971.