### PR TITLE
Add nowrap_{add|sub|mul|neg} intrinsics

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1367,4 +1367,26 @@ extern "rust-intrinsic" {
     /// Emits a `!nontemporal` store according to LLVM (see their docs).
     /// Probably will never become stable.
     pub fn nontemporal_store<T>(ptr: *mut T, val: T);
+
+    /// Add `a + b`, but with undefined behaviour if the sum overflows.
+    #[cfg(not(stage0))]
+    pub fn nowrap_add<T>(a: T, b: T) -> T;
+    /// Subtract `a - b`, but with undefined behaviour if the difference overflows.
+    #[cfg(not(stage0))]
+    pub fn nowrap_sub<T>(a: T, b: T) -> T;
+    /// Multiply `a * b`, but with undefined behaviour if the produce overflows.
+    #[cfg(not(stage0))]
+    pub fn nowrap_mul<T>(a: T, b: T) -> T;
+    /// Negate `-a`, but with undefined behaviour if it the negation overflows.
+    #[cfg(not(stage0))]
+    pub fn nowrap_neg<T>(a: T) -> T;
 }
+
+#[cfg(stage0)]
+pub unsafe fn nowrap_add<T>(a: T, b: T) -> T { add_with_overflow(a, b).0 }
+#[cfg(stage0)]
+pub unsafe fn nowrap_sub<T>(a: T, b: T) -> T { sub_with_overflow(a, b).0 }
+#[cfg(stage0)]
+pub unsafe fn nowrap_mul<T>(a: T, b: T) -> T { mul_with_overflow(a, b).0 }
+#[cfg(stage0)]
+pub unsafe fn nowrap_neg<T: Default>(a: T) -> T { nowrap_sub(T::default(), a) }

--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -271,7 +271,8 @@ pub fn codegen_intrinsic_call<'a, 'tcx>(bx: &Builder<'a, 'tcx>,
         "ctlz" | "ctlz_nonzero" | "cttz" | "cttz_nonzero" | "ctpop" | "bswap" |
         "bitreverse" | "add_with_overflow" | "sub_with_overflow" |
         "mul_with_overflow" | "overflowing_add" | "overflowing_sub" | "overflowing_mul" |
-        "unchecked_div" | "unchecked_rem" | "unchecked_shl" | "unchecked_shr" | "exact_div" => {
+        "unchecked_div" | "unchecked_rem" | "unchecked_shl" | "unchecked_shr" | "exact_div" |
+        "nowrap_add" | "nowrap_sub" | "nowrap_mul" | "nowrap_neg" => {
             let ty = arg_tys[0];
             match int_type_width_signed(ty, cx) {
                 Some((width, signed)) =>
@@ -349,6 +350,30 @@ pub fn codegen_intrinsic_call<'a, 'tcx>(bx: &Builder<'a, 'tcx>,
                                 bx.ashr(args[0].immediate(), args[1].immediate())
                             } else {
                                 bx.lshr(args[0].immediate(), args[1].immediate())
+                            },
+                        "nowrap_add" =>
+                            if signed {
+                                bx.nswadd(args[0].immediate(), args[1].immediate())
+                            } else {
+                                bx.nuwadd(args[0].immediate(), args[1].immediate())
+                            },
+                        "nowrap_sub" =>
+                            if signed {
+                                bx.nswsub(args[0].immediate(), args[1].immediate())
+                            } else {
+                                bx.nuwsub(args[0].immediate(), args[1].immediate())
+                            },
+                        "nowrap_mul" =>
+                            if signed {
+                                bx.nswmul(args[0].immediate(), args[1].immediate())
+                            } else {
+                                bx.nuwmul(args[0].immediate(), args[1].immediate())
+                            },
+                        "nowrap_neg" =>
+                            if signed {
+                                bx.nswneg(args[0].immediate())
+                            } else {
+                                bx.nuwneg(args[0].immediate())
                             },
                         _ => bug!(),
                     },

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -318,6 +318,13 @@ pub fn check_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 (1, vec![ tcx.mk_mut_ptr(param(0)), param(0) ], tcx.mk_nil())
             }
 
+            "nowrap_add" | "nowrap_sub" | "nowrap_mul" => {
+                (1, vec![param(0), param(0)], param(0))
+            }
+            "nowrap_neg" => {
+                (1, vec![param(0)], param(0))
+            }
+
             ref other => {
                 struct_span_err!(tcx.sess, it.span, E0093,
                                 "unrecognized intrinsic function: `{}`",

--- a/src/test/codegen/nowrap-intrinsic.rs
+++ b/src/test/codegen/nowrap-intrinsic.rs
@@ -1,0 +1,70 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "lib"]
+#![feature(core_intrinsics)]
+
+use std::intrinsics::*;
+
+// CHECK-LABEL: @nowrap_add_signed
+#[no_mangle]
+pub unsafe fn nowrap_add_signed(a: i32, b: i32) -> i32 {
+    // CHECK: add nsw
+    nowrap_add(a, b)
+}
+
+// CHECK-LABEL: @nowrap_add_unsigned
+#[no_mangle]
+pub unsafe fn nowrap_add_unsigned(a: u32, b: u32) -> u32 {
+    // CHECK: add nuw
+    nowrap_add(a, b)
+}
+
+// CHECK-LABEL: @nowrap_sub_signed
+#[no_mangle]
+pub unsafe fn nowrap_sub_signed(a: i32, b: i32) -> i32 {
+    // CHECK: sub nsw
+    nowrap_sub(a, b)
+}
+
+// CHECK-LABEL: @nowrap_sub_unsigned
+#[no_mangle]
+pub unsafe fn nowrap_sub_unsigned(a: u32, b: u32) -> u32 {
+    // CHECK: sub nuw
+    nowrap_sub(a, b)
+}
+
+// CHECK-LABEL: @nowrap_mul_signed
+#[no_mangle]
+pub unsafe fn nowrap_mul_signed(a: i32, b: i32) -> i32 {
+    // CHECK: mul nsw
+    nowrap_mul(a, b)
+}
+
+// CHECK-LABEL: @nowrap_mul_unsigned
+#[no_mangle]
+pub unsafe fn nowrap_mul_unsigned(a: u32, b: u32) -> u32 {
+    // CHECK: mul nuw
+    nowrap_mul(a, b)
+}
+
+// CHECK-LABEL: @nowrap_neg_signed
+#[no_mangle]
+pub unsafe fn nowrap_neg_signed(a: i32) -> i32 {
+    // CHECK: sub nsw i32 0,
+    nowrap_neg(a)
+}
+
+// CHECK-LABEL: @nowrap_neg_unsigned
+#[no_mangle]
+pub unsafe fn nowrap_neg_unsigned(a: u32) -> u32 {
+    // CHECK: ret i32 0
+    nowrap_neg(a)
+}


### PR DESCRIPTION
[LLVM cannot deduce nsw/nuw for things like `Range::next` today](https://play.rust-lang.org/?gist=e232272d4a843214df76db23fbc3a980&version=nightly&mode=release&edition=2015), so add these so that my next PR can use them to improve what `Range` tells LLVM.

(This adds the ones that [`rustc_codegen_llvm::builder::Builder`](https://github.com/rust-lang/rust/issues/51737) and `rustc_llvm::ffi` currently support, which is why it has `nowrap_neg` but not [`nowrap_shl`](http://llvm.org/docs/LangRef.html#shl-instruction).)

tag guess: T-compiler