### PR TITLE
Set opt-level = 3 the third time.

### DIFF
--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -40,13 +40,6 @@ members = [
   "tools/rls/test_data/workspace_symbol",
 ]
 
-# Curiously, libtest will segfault if compiled with opt-level=3
-# with some versions of XCode: https://github.com/rust-lang/rust/issues/50867
-[profile.release]
-opt-level = 2
-[profile.bench]
-opt-level = 2
-
 # These options are controlled from our rustc wrapper script, so turn them off
 # here and have them controlled elsewhere.
 [profile.dev]


### PR DESCRIPTION
This PR reverts #51165 (set -O2 for fixing #50867), 
which reverted #50329 (set -O3),
which was second attempt of #48204 (set -O3, closed due to Windows segfault that is fixed now),
which reverted #42123 (set -O2 to fix spurious Windows segfaults),
which reverted #41967 (set -O3).

Since we have found the root cause of #50867, this optimization could be tried again.

Last time we've found that setting -O3 regressed the wall time of NLL (https://github.com/rust-lang/rust/pull/50329#issuecomment-388084894), so we may need another perf run to confirm. I'd like to check this *after* the LLVM 7 upgrade #51966 has been merged, so marking this as <kbd>S-blocked</kbd> for now.