### PR TITLE
Deny bare trait objects in src/bootstrap

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -44,7 +44,7 @@ pub struct Builder<'a> {
     pub top_stage: u32,
     pub kind: Kind,
     cache: Cache,
-    stack: RefCell<Vec<Box<Any>>>,
+    stack: RefCell<Vec<Box<dyn Any>>>,
     time_spent_on_dependencies: Cell<Duration>,
     pub paths: Vec<PathBuf>,
     graph_nodes: RefCell<HashMap<String, NodeIndex>>,

--- a/src/bootstrap/cache.rs
+++ b/src/bootstrap/cache.rs
@@ -249,7 +249,7 @@ lazy_static! {
 pub struct Cache(
     RefCell<HashMap<
         TypeId,
-        Box<Any>, // actually a HashMap<Step, Interned<Step::Output>>
+        Box<dyn Any>, // actually a HashMap<Step, Interned<Step::Output>>
     >>
 );
 

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -1189,7 +1189,7 @@ pub fn run_cargo(builder: &Builder, cargo: &mut Command, stamp: &Path, is_check:
 pub fn stream_cargo(
     builder: &Builder,
     cargo: &mut Command,
-    cb: &mut FnMut(CargoMessage),
+    cb: &mut dyn FnMut(CargoMessage),
 ) -> bool {
     if builder.config.dry_run {
         return true;

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -113,7 +113,7 @@
 //! More documentation can be found in each respective module below, and you can
 //! also check out the `src/bootstrap/README.md` file for more information.
 
-#![deny(warnings)]
+#![deny(bare_trait_objects)]
 #![feature(core_intrinsics)]
 #![feature(drain_filter)]
 
@@ -1174,13 +1174,13 @@ impl Build {
     /// Copies the `src` directory recursively to `dst`. Both are assumed to exist
     /// when this function is called. Unwanted files or directories can be skipped
     /// by returning `false` from the filter function.
-    pub fn cp_filtered(&self, src: &Path, dst: &Path, filter: &Fn(&Path) -> bool) {
+    pub fn cp_filtered(&self, src: &Path, dst: &Path, filter: &dyn Fn(&Path) -> bool) {
         // Immediately recurse with an empty relative path
         self.recurse_(src, dst, Path::new(""), filter)
     }
 
     // Inner function does the actual work
-    fn recurse_(&self, src: &Path, dst: &Path, relative: &Path, filter: &Fn(&Path) -> bool) {
+    fn recurse_(&self, src: &Path, dst: &Path, relative: &Path, filter: &dyn Fn(&Path) -> bool) {
         for f in self.read_dir(src) {
             let path = f.path();
             let name = path.file_name().unwrap();

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -114,6 +114,7 @@
 //! also check out the `src/bootstrap/README.md` file for more information.
 
 #![deny(bare_trait_objects)]
+#![deny(warnings)]
 #![feature(core_intrinsics)]
 #![feature(drain_filter)]
 


### PR DESCRIPTION
Enforce `#![deny(bare_trait_objects)]` in `src/bootstrap`.