### PR TITLE
resolve: Modularize crate-local `#[macro_export] macro_rules`

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1117,7 +1117,7 @@ impl<'a> ToNameBinding<'a> for &'a NameBinding<'a> {
 
 #[derive(Clone, Debug)]
 enum NameBindingKind<'a> {
-    Def(Def),
+    Def(Def, /* is_macro_export */ bool),
     Module(Module<'a>),
     Import {
         binding: &'a NameBinding<'a>,
@@ -1161,7 +1161,7 @@ impl<'a> NameBinding<'a> {
 
     fn def(&self) -> Def {
         match self.kind {
-            NameBindingKind::Def(def) => def,
+            NameBindingKind::Def(def, _) => def,
             NameBindingKind::Module(module) => module.def().unwrap(),
             NameBindingKind::Import { binding, .. } => binding.def(),
             NameBindingKind::Ambiguity { .. } => Def::Err,
@@ -1191,8 +1191,8 @@ impl<'a> NameBinding<'a> {
 
     fn is_variant(&self) -> bool {
         match self.kind {
-            NameBindingKind::Def(Def::Variant(..)) |
-            NameBindingKind::Def(Def::VariantCtor(..)) => true,
+            NameBindingKind::Def(Def::Variant(..), _) |
+            NameBindingKind::Def(Def::VariantCtor(..), _) => true,
             _ => false,
         }
     }
@@ -1241,7 +1241,7 @@ impl<'a> NameBinding<'a> {
 
     fn is_macro_def(&self) -> bool {
         match self.kind {
-            NameBindingKind::Def(Def::Macro(..)) => true,
+            NameBindingKind::Def(Def::Macro(..), _) => true,
             _ => false,
         }
     }
@@ -1397,7 +1397,7 @@ pub struct Resolver<'a> {
     macro_map: FxHashMap<DefId, Lrc<SyntaxExtension>>,
     macro_defs: FxHashMap<Mark, DefId>,
     local_macro_def_scopes: FxHashMap<NodeId, Module<'a>>,
-    macro_exports: Vec<Export>,
+    macro_exports: Vec<Export>, // FIXME: Remove when `use_extern_macros` is stabilized
     pub whitelisted_legacy_custom_derives: Vec<Name>,
     pub found_unresolved_macro: bool,
 
@@ -1427,6 +1427,9 @@ pub struct Resolver<'a> {
 
     /// Only supposed to be used by rustdoc, otherwise should be false.
     pub ignore_extern_prelude_feature: bool,
+
+    /// Macro invocations in the whole crate that can expand into a `#[macro_export] macro_rules`.
+    unresolved_invocations_macro_export: FxHashSet<Mark>,
 }
 
 /// Nothing really interesting here, it just provides memory for the rest of the crate.
@@ -1701,7 +1704,7 @@ impl<'a> Resolver<'a> {
 
             arenas,
             dummy_binding: arenas.alloc_name_binding(NameBinding {
-                kind: NameBindingKind::Def(Def::Err),
+                kind: NameBindingKind::Def(Def::Err, false),
                 expansion: Mark::root(),
                 span: DUMMY_SP,
                 vis: ty::Visibility::Public,
@@ -1731,6 +1734,7 @@ impl<'a> Resolver<'a> {
             current_type_ascription: Vec::new(),
             injected_crate: None,
             ignore_extern_prelude_feature: false,
+            unresolved_invocations_macro_export: FxHashSet(),
         }
     }
 

--- a/src/test/run-pass/auxiliary/issue_38715-modern.rs
+++ b/src/test/run-pass/auxiliary/issue_38715-modern.rs
@@ -8,17 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// aux-build:issue_38715.rs
-// aux-build:issue_38715-modern.rs
+#![feature(use_extern_macros)]
+#![allow(duplicate_macro_exports)]
 
-// Test that `#[macro_export] macro_rules!` shadow earlier `#[macro_export] macro_rules!`
+#[macro_export]
+macro_rules! foo_modern { ($i:ident) => {} }
 
-#[macro_use]
-extern crate issue_38715;
-#[macro_use]
-extern crate issue_38715_modern;
-
-fn main() {
-    foo!();
-    foo_modern!();
-}
+#[macro_export]
+macro_rules! foo_modern { () => {} }

--- a/src/test/ui/duplicate-check-macro-exports.rs
+++ b/src/test/ui/duplicate-check-macro-exports.rs
@@ -13,6 +13,6 @@
 pub use std::panic;
 
 #[macro_export]
-macro_rules! panic { () => {} } //~ ERROR a macro named `panic` has already been exported
+macro_rules! panic { () => {} } //~ ERROR the name `panic` is defined multiple times
 
 fn main() {}

--- a/src/test/ui/duplicate-check-macro-exports.stderr
+++ b/src/test/ui/duplicate-check-macro-exports.stderr
@@ -1,14 +1,18 @@
-error: a macro named `panic` has already been exported
+error[E0255]: the name `panic` is defined multiple times
   --> $DIR/duplicate-check-macro-exports.rs:16:1
    |
-LL | macro_rules! panic { () => {} } //~ ERROR a macro named `panic` has already been exported
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `panic` already exported
-   |
-note: previous macro export here
-  --> $DIR/duplicate-check-macro-exports.rs:13:9
-   |
 LL | pub use std::panic;
-   |         ^^^^^^^^^^
+   |         ---------- previous import of the macro `panic` here
+...
+LL | macro_rules! panic { () => {} } //~ ERROR the name `panic` is defined multiple times
+   | ^^^^^^^^^^^^^^^^^^ `panic` redefined here
+   |
+   = note: `panic` must be defined only once in the macro namespace of this module
+help: You can use `as` to change the binding name of the import
+   |
+LL | pub use std::panic as other_panic;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0255`.

--- a/src/test/ui/imports/local-modularized-tricky-fail-1.rs
+++ b/src/test/ui/imports/local-modularized-tricky-fail-1.rs
@@ -1,0 +1,57 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(decl_macro)]
+
+macro_rules! define_exported { () => {
+    #[macro_export]
+    macro_rules! exported {
+        () => ()
+    }
+}}
+macro_rules! define_panic { () => {
+    #[macro_export]
+    macro_rules! panic {
+        () => ()
+    }
+}}
+macro_rules! define_include { () => {
+    #[macro_export]
+    macro_rules! include {
+        () => ()
+    }
+}}
+
+use inner1::*;
+
+mod inner1 {
+    pub macro exported() {}
+}
+
+exported!(); //~ ERROR `exported` is ambiguous
+
+mod inner2 {
+    define_exported!();
+}
+
+fn main() {
+    panic!(); //~ ERROR `panic` is ambiguous
+              //~^ ERROR `panic` is ambiguous
+}
+
+mod inner3 {
+    define_panic!();
+}
+
+mod inner4 {
+    define_include!();
+}
+
+include!(); //~ ERROR `include` is ambiguous

--- a/src/test/ui/imports/local-modularized-tricky-fail-1.stderr
+++ b/src/test/ui/imports/local-modularized-tricky-fail-1.stderr
@@ -1,0 +1,84 @@
+error[E0659]: `exported` is ambiguous
+  --> $DIR/local-modularized-tricky-fail-1.rs:38:1
+   |
+LL | exported!(); //~ ERROR `exported` is ambiguous
+   | ^^^^^^^^
+   |
+note: `exported` could refer to the name defined here
+  --> $DIR/local-modularized-tricky-fail-1.rs:15:5
+   |
+LL | /     macro_rules! exported {
+LL | |         () => ()
+LL | |     }
+   | |_____^
+...
+LL |       define_exported!();
+   |       ------------------- in this macro invocation
+note: `exported` could also refer to the name imported here
+  --> $DIR/local-modularized-tricky-fail-1.rs:32:5
+   |
+LL | use inner1::*;
+   |     ^^^^^^^^^
+   = note: macro-expanded macros do not shadow
+
+error[E0659]: `include` is ambiguous
+  --> $DIR/local-modularized-tricky-fail-1.rs:57:1
+   |
+LL | include!(); //~ ERROR `include` is ambiguous
+   | ^^^^^^^
+   |
+note: `include` could refer to the name defined here
+  --> $DIR/local-modularized-tricky-fail-1.rs:27:5
+   |
+LL | /     macro_rules! include {
+LL | |         () => ()
+LL | |     }
+   | |_____^
+...
+LL |       define_include!();
+   |       ------------------ in this macro invocation
+   = note: `include` is also a builtin macro
+   = note: macro-expanded macros do not shadow
+
+error[E0659]: `panic` is ambiguous
+  --> $DIR/local-modularized-tricky-fail-1.rs:45:5
+   |
+LL |     panic!(); //~ ERROR `panic` is ambiguous
+   |     ^^^^^
+   |
+note: `panic` could refer to the name defined here
+  --> $DIR/local-modularized-tricky-fail-1.rs:21:5
+   |
+LL | /     macro_rules! panic {
+LL | |         () => ()
+LL | |     }
+   | |_____^
+...
+LL |       define_panic!();
+   |       ---------------- in this macro invocation
+   = note: `panic` is also a builtin macro
+   = note: macro-expanded macros do not shadow
+
+error[E0659]: `panic` is ambiguous
+  --> $DIR/local-modularized-tricky-fail-1.rs:45:5
+   |
+LL |     panic!(); //~ ERROR `panic` is ambiguous
+   |     ^^^^^^^^^
+   |
+note: `panic` could refer to the name defined here
+  --> $DIR/local-modularized-tricky-fail-1.rs:21:5
+   |
+LL | /     macro_rules! panic {
+LL | |         () => ()
+LL | |     }
+   | |_____^
+...
+LL |       define_panic!();
+   |       ---------------- in this macro invocation
+   = note: `panic` is also a builtin macro
+   = note: macro-expanded macros do not shadow
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0659`.

--- a/src/test/ui/imports/local-modularized-tricky-fail-2.rs
+++ b/src/test/ui/imports/local-modularized-tricky-fail-2.rs
@@ -1,0 +1,58 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// `#[macro_export] macro_rules` that doen't originate from macro expansions can be placed
+// into the root module soon enough to act as usual items and shadow globs and preludes.
+
+#![feature(decl_macro)]
+
+// `macro_export` shadows globs
+use inner1::*;
+
+mod inner1 {
+    pub macro exported() {}
+}
+
+exported!();
+
+mod deep {
+    fn deep() {
+        type Deeper = [u8; {
+            #[macro_export]
+            macro_rules! exported {
+                () => ( struct Б; ) //~ ERROR non-ascii idents are not fully supported
+            }
+
+            0
+        }];
+    }
+}
+
+// `macro_export` shadows std prelude
+fn main() {
+    panic!();
+}
+
+mod inner3 {
+    #[macro_export]
+    macro_rules! panic {
+        () => ( struct Г; ) //~ ERROR non-ascii idents are not fully supported
+    }
+}
+
+// `macro_export` shadows builtin macros
+include!();
+
+mod inner4 {
+    #[macro_export]
+    macro_rules! include {
+        () => ( struct Д; ) //~ ERROR non-ascii idents are not fully supported
+    }
+}

--- a/src/test/ui/imports/local-modularized-tricky-fail-2.stderr
+++ b/src/test/ui/imports/local-modularized-tricky-fail-2.stderr
@@ -1,0 +1,36 @@
+error[E0658]: non-ascii idents are not fully supported. (see issue #28979)
+  --> $DIR/local-modularized-tricky-fail-2.rs:30:32
+   |
+LL | exported!();
+   | ------------ in this macro invocation
+...
+LL |                 () => ( struct Б; ) //~ ERROR non-ascii idents are not fully supported
+   |                                ^
+   |
+   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+
+error[E0658]: non-ascii idents are not fully supported. (see issue #28979)
+  --> $DIR/local-modularized-tricky-fail-2.rs:46:24
+   |
+LL |     panic!();
+   |     --------- in this macro invocation
+...
+LL |         () => ( struct Г; ) //~ ERROR non-ascii idents are not fully supported
+   |                        ^
+   |
+   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+
+error[E0658]: non-ascii idents are not fully supported. (see issue #28979)
+  --> $DIR/local-modularized-tricky-fail-2.rs:56:24
+   |
+LL | include!();
+   | ----------- in this macro invocation
+...
+LL |         () => ( struct Д; ) //~ ERROR non-ascii idents are not fully supported
+   |                        ^
+   |
+   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/imports/local-modularized-tricky-pass.rs
+++ b/src/test/ui/imports/local-modularized-tricky-pass.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,17 +8,24 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// aux-build:issue_38715.rs
-// aux-build:issue_38715-modern.rs
+// compile-pass
 
-// Test that `#[macro_export] macro_rules!` shadow earlier `#[macro_export] macro_rules!`
+#![feature(use_extern_macros)]
 
-#[macro_use]
-extern crate issue_38715;
-#[macro_use]
-extern crate issue_38715_modern;
+macro_rules! define_exported { () => {
+    #[macro_export]
+    macro_rules! exported {
+        () => ()
+    }
+}}
 
-fn main() {
-    foo!();
-    foo_modern!();
+mod inner1 {
+    use super::*;
+    exported!();
 }
+
+mod inner2 {
+    define_exported!();
+}
+
+fn main() {}

--- a/src/test/ui/imports/local-modularized.rs
+++ b/src/test/ui/imports/local-modularized.rs
@@ -1,0 +1,47 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-pass
+
+#![feature(use_extern_macros)]
+
+#[macro_export(local_inner_macros)]
+macro_rules! dollar_crate_exported {
+    (1) => { $crate::exported!(); };
+    (2) => { exported!(); };
+}
+
+// Before `exported` is defined
+exported!();
+
+mod inner {
+
+    ::exported!();
+    crate::exported!();
+    dollar_crate_exported!(1);
+    dollar_crate_exported!(2);
+
+    mod inner_inner {
+        #[macro_export]
+        macro_rules! exported {
+            () => ()
+        }
+    }
+
+    // After `exported` is defined
+    ::exported!();
+    crate::exported!();
+    dollar_crate_exported!(1);
+    dollar_crate_exported!(2);
+}
+
+exported!();
+
+fn main() {}


### PR DESCRIPTION
Based on https://github.com/rust-lang/rust/pull/50911, cc https://github.com/rust-lang/rust/pull/50911#issuecomment-401151270

`#[macro_export] macro_rules` items are collected from the whole crate and are planted into the root module as items, so the external view of the crate is symmetric with its internal view and something like `$crate::my_macro` where `my_macro` is `#[macro_export] macro_rules` works both locally and from other crates.

Closes https://github.com/rust-lang/rust/issues/52726