### PR TITLE
NLL: Suggest `ref mut` and `&mut self`

### DIFF
--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -1209,11 +1209,16 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                 let let_span = self.tcx.hir.span(node_id);
                 match self.local_binding_mode(node_id) {
                     ty::BindByReference(..) => {
-                        let ref_span = self.tcx.sess.codemap().span_until_whitespace(let_span);
-                        if let Ok(_) = self.tcx.sess.codemap().span_to_snippet(let_span) {
+                        if let Ok(snippet) = self.tcx.sess.codemap().span_to_snippet(let_span) {
+                            let replace_str = if snippet.starts_with("ref ") {
+                                snippet.replacen("ref ", "ref mut ", 1)
+                            } else {
+                                snippet
+                            };
                             db.span_label(
-                                ref_span,
-                                format!("consider changing this to `{}`", "ref mut"));
+                                let_span,
+                                format!("consider changing this to `{}`", replace_str)
+                            );
                         };
                     }
                     ty::BindByValue(..) => {

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -1214,7 +1214,7 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                             db.span_label(
                                 let_span,
                                 format!("consider changing this to `{}`",
-                                         snippet.replace("ref ", "ref mut "))
+                                         snippet.replacen("ref ", "ref mut ", 1))
                             );
                         }
                     }

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -1209,14 +1209,12 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                 let let_span = self.tcx.hir.span(node_id);
                 match self.local_binding_mode(node_id) {
                     ty::BindByReference(..) => {
-                        let snippet = self.tcx.sess.codemap().span_to_snippet(let_span);
-                        if let Ok(snippet) = snippet {
+                        let ref_span = self.tcx.sess.codemap().span_until_whitespace(let_span);
+                        if let Ok(_) = self.tcx.sess.codemap().span_to_snippet(let_span) {
                             db.span_label(
-                                let_span,
-                                format!("consider changing this to `{}`",
-                                         snippet.replacen("ref ", "ref mut ", 1))
-                            );
-                        }
+                                ref_span,
+                                format!("consider changing this to `{}`", "ref mut"));
+                        };
                     }
                     ty::BindByValue(..) => {
                         if let (Some(local_ty), is_implicit_self) = self.local_ty(node_id) {

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -1215,9 +1215,10 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                             } else {
                                 snippet
                             };
-                            db.span_label(
+                            db.span_suggestion(
                                 let_span,
-                                format!("consider changing this to `{}`", replace_str)
+                                "use a mutable reference instead",
+                                replace_str,
                             );
                         };
                     }

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -1841,31 +1841,29 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                 elem: ProjectionElem::Deref,
             }) if self.mir.local_decls[*local].is_user_variable.is_some() => {
                 let local_decl = &self.mir.local_decls[*local];
-                let suggestion = match local_decl.is_user_variable {
-                    Some(ClearCrossCrate::Set(mir::BindingForm::ImplicitSelf)) => {
+                let suggestion = match local_decl.is_user_variable.as_ref().unwrap() {
+                    ClearCrossCrate::Set(mir::BindingForm::ImplicitSelf) => {
                         Some(suggest_ampmut_self(local_decl))
                     },
 
-                    Some(ClearCrossCrate::Set(mir::BindingForm::Var(mir::VarBindingForm {
+                    ClearCrossCrate::Set(mir::BindingForm::Var(mir::VarBindingForm {
                         binding_mode: ty::BindingMode::BindByValue(_),
                         opt_ty_info,
                         ..
-                    }))) => Some(suggest_ampmut(
+                    })) => Some(suggest_ampmut(
                         self.tcx,
                         self.mir,
                         *local,
                         local_decl,
-                        opt_ty_info,
+                        *opt_ty_info,
                     )),
 
-                    Some(ClearCrossCrate::Set(mir::BindingForm::Var(mir::VarBindingForm {
+                    ClearCrossCrate::Set(mir::BindingForm::Var(mir::VarBindingForm {
                         binding_mode: ty::BindingMode::BindByReference(_),
                         ..
-                    }))) => suggest_ref_mut(self.tcx, local_decl),
+                    })) => suggest_ref_mut(self.tcx, local_decl),
 
-                    Some(ClearCrossCrate::Clear) => bug!("saw cleared local state"),
-
-                    None => bug!(),
+                    ClearCrossCrate::Clear => bug!("saw cleared local state"),
                 };
 
                 if let Some((err_help_span, suggested_code)) = suggestion {

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -29,6 +29,8 @@ use rustc_data_structures::indexed_set::IdxSetBuf;
 use rustc_data_structures::indexed_vec::Idx;
 use rustc_data_structures::small_vec::SmallVec;
 
+use core::unicode::property::Pattern_White_Space;
+
 use std::rc::Rc;
 
 use syntax_pos::Span;
@@ -1837,17 +1839,45 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
             Place::Projection(box Projection {
                 base: Place::Local(local),
                 elem: ProjectionElem::Deref,
-            }) if self.mir.local_decls[*local].is_nonref_binding() =>
-            {
-                let (err_help_span, suggested_code) =
-                    find_place_to_suggest_ampmut(self.tcx, self.mir, *local);
+            }) if self.mir.local_decls[*local].is_user_variable.is_some() => {
+                let local_decl = &self.mir.local_decls[*local];
+                let (err_help_span, suggested_code) = match local_decl.is_user_variable {
+                    Some(ClearCrossCrate::Set(mir::BindingForm::ImplicitSelf)) => {
+                        suggest_ampmut_self(local_decl)
+                    },
+
+                    Some(ClearCrossCrate::Set(mir::BindingForm::Var(mir::VarBindingForm {
+                        binding_mode: ty::BindingMode::BindByValue(_),
+                        opt_ty_info,
+                        ..
+                    }))) => {
+                        if let Some(x) = try_suggest_ampmut_rhs(
+                            self.tcx, self.mir, *local,
+                        ) {
+                            x
+                        } else {
+                            suggest_ampmut_type(local_decl, opt_ty_info)
+                        }
+                    },
+
+                    Some(ClearCrossCrate::Set(mir::BindingForm::Var(mir::VarBindingForm {
+                        binding_mode: ty::BindingMode::BindByReference(_),
+                        ..
+                    }))) => {
+                        suggest_ref_mut(self.tcx, local_decl)
+                    },
+
+                    Some(ClearCrossCrate::Clear) => bug!("saw cleared local state"),
+
+                    None => bug!(),
+                };
+
                 err.span_suggestion(
                     err_help_span,
                     "consider changing this to be a mutable reference",
                     suggested_code,
                 );
 
-                let local_decl = &self.mir.local_decls[*local];
                 if let Some(name) = local_decl.name {
                     err.span_label(
                         span,
@@ -1874,13 +1904,16 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         err.emit();
         return true;
 
-        // Returns the span to highlight and the associated text to
-        // present when suggesting that the user use an `&mut`.
-        //
+        fn suggest_ampmut_self<'cx, 'gcx, 'tcx>(
+            local_decl: &mir::LocalDecl<'tcx>,
+        ) -> (Span, String) {
+            (local_decl.source_info.span, "&mut self".to_string())
+        }
+
         // When we want to suggest a user change a local variable to be a `&mut`, there
         // are three potential "obvious" things to highlight:
         //
-        // let ident [: Type] [= RightHandSideExresssion];
+        // let ident [: Type] [= RightHandSideExpression];
         //     ^^^^^    ^^^^     ^^^^^^^^^^^^^^^^^^^^^^^
         //     (1.)     (2.)              (3.)
         //
@@ -1889,48 +1922,58 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         // for example, if the RHS is present and the Type is not, then the type is going to
         // be inferred *from* the RHS, which means we should highlight that (and suggest
         // that they borrow the RHS mutably).
-        fn find_place_to_suggest_ampmut<'cx, 'gcx, 'tcx>(
+        //
+        // This implementation attempts to emulate AST-borrowck prioritization
+        // by trying (3.), then (2.) and finally falling back on (1.).
+
+        fn try_suggest_ampmut_rhs<'cx, 'gcx, 'tcx>(
             tcx: TyCtxt<'cx, 'gcx, 'tcx>,
             mir: &Mir<'tcx>,
             local: Local,
-        ) -> (Span, String) {
-            // This implementation attempts to emulate AST-borrowck prioritization
-            // by trying (3.), then (2.) and finally falling back on (1.).
+        ) -> Option<(Span, String)> {
             let locations = mir.find_assignments(local);
             if locations.len() > 0 {
                 let assignment_rhs_span = mir.source_info(locations[0]).span;
                 let snippet = tcx.sess.codemap().span_to_snippet(assignment_rhs_span);
                 if let Ok(src) = snippet {
-                    // pnkfelix inherited code; believes intention is
-                    // highlighted text will always be `&<expr>` and
-                    // thus can transform to `&mut` by slicing off
-                    // first ASCII character and prepending "&mut ".
                     if src.starts_with('&') {
                         let borrowed_expr = src[1..].to_string();
-                        return (assignment_rhs_span, format!("&mut {}", borrowed_expr));
+                        return Some((assignment_rhs_span, format!("&mut {}", borrowed_expr)));
                     }
                 }
             }
+            None
+        }
 
-            let local_decl = &mir.local_decls[local];
-            let highlight_span = match local_decl.is_user_variable {
+        fn suggest_ampmut_type<'tcx>(
+            local_decl: &mir::LocalDecl<'tcx>,
+            opt_ty_info: Option<Span>,
+        ) -> (Span, String) {
+            let highlight_span = match opt_ty_info {
                 // if this is a variable binding with an explicit type,
                 // try to highlight that for the suggestion.
-                Some(ClearCrossCrate::Set(mir::BindingForm::Var(mir::VarBindingForm {
-                    opt_ty_info: Some(ty_span),
-                    ..
-                }))) => ty_span,
-
-                Some(ClearCrossCrate::Clear) => bug!("saw cleared local state"),
+                Some(ty_span) => ty_span,
 
                 // otherwise, just highlight the span associated with
                 // the (MIR) LocalDecl.
-                _ => local_decl.source_info.span,
+                None => local_decl.source_info.span,
             };
 
             let ty_mut = local_decl.ty.builtin_deref(true).unwrap();
             assert_eq!(ty_mut.mutbl, hir::MutImmutable);
-            return (highlight_span, format!("&mut {}", ty_mut.ty));
+            (highlight_span, format!("&mut {}", ty_mut.ty))
+        }
+
+        fn suggest_ref_mut<'cx, 'gcx, 'tcx>(
+            tcx: TyCtxt<'cx, 'gcx, 'tcx>,
+            local_decl: &mir::LocalDecl<'tcx>,
+        ) -> (Span, String) {
+            let hi_span = local_decl.source_info.span;
+            let hi_src = tcx.sess.codemap().span_to_snippet(hi_span).unwrap();
+            assert!(hi_src.starts_with("ref"));
+            assert!(hi_src["ref".len()..].starts_with(Pattern_White_Space));
+            let suggestion = format!("ref mut{}", &hi_src["ref".len()..]);
+            (hi_span, suggestion)
         }
     }
 

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -33,6 +33,7 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![feature(never_type)]
 #![feature(specialization)]
 #![feature(try_trait)]
+#![feature(unicode_internals)]
 
 #![recursion_limit="256"]
 
@@ -56,6 +57,7 @@ extern crate rustc_target;
 extern crate log_settings;
 extern crate rustc_apfloat;
 extern crate byteorder;
+extern crate core;
 
 mod diagnostics;
 

--- a/src/librustc_mir/util/mod.rs
+++ b/src/librustc_mir/util/mod.rs
@@ -8,6 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::unicode::property::Pattern_White_Space;
+use rustc::ty;
+use syntax_pos::Span;
+
 pub mod borrowck_errors;
 pub mod elaborate_drops;
 pub mod def_use;
@@ -23,3 +27,19 @@ pub use self::alignment::is_disaligned;
 pub use self::pretty::{dump_enabled, dump_mir, write_mir_pretty, PassWhere};
 pub use self::graphviz::{write_mir_graphviz};
 pub use self::graphviz::write_node_label as write_graphviz_node_label;
+
+/// If possible, suggest replacing `ref` with `ref mut`.
+pub fn suggest_ref_mut<'cx, 'gcx, 'tcx>(
+    tcx: ty::TyCtxt<'cx, 'gcx, 'tcx>,
+    pattern_span: Span,
+) -> Option<(Span, String)> {
+    let hi_src = tcx.sess.codemap().span_to_snippet(pattern_span).unwrap();
+    if hi_src.starts_with("ref")
+        && hi_src["ref".len()..].starts_with(Pattern_White_Space)
+    {
+        let replacement = format!("ref mut{}", &hi_src["ref".len()..]);
+        Some((pattern_span, replacement))
+    } else {
+        None
+    }
+}

--- a/src/test/ui/did_you_mean/issue-38147-1.nll.stderr
+++ b/src/test/ui/did_you_mean/issue-38147-1.nll.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow immutable item `*self.s` as mutable
   --> $DIR/issue-38147-1.rs:27:9
    |
 LL |     fn f(&self) {
-   |          ----- help: consider changing this to be a mutable reference: `&mut Foo<'_>`
+   |          ----- help: consider changing this to be a mutable reference: `&mut self`
 LL |         self.s.push('x'); //~ ERROR cannot borrow data mutably
    |         ^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
 

--- a/src/test/ui/did_you_mean/issue-39544.nll.stderr
+++ b/src/test/ui/did_you_mean/issue-39544.nll.stderr
@@ -10,7 +10,7 @@ error[E0596]: cannot borrow immutable item `self.x` as mutable
   --> $DIR/issue-39544.rs:26:17
    |
 LL |     fn foo<'z>(&'z self) {
-   |                -------- help: consider changing this to be a mutable reference: `&mut Z`
+   |                -------- help: consider changing this to be a mutable reference: `&mut self`
 LL |         let _ = &mut self.x; //~ ERROR cannot borrow
    |                 ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
 
@@ -18,7 +18,7 @@ error[E0596]: cannot borrow immutable item `self.x` as mutable
   --> $DIR/issue-39544.rs:30:17
    |
 LL |     fn foo1(&self, other: &Z) {
-   |             ----- help: consider changing this to be a mutable reference: `&mut Z`
+   |             ----- help: consider changing this to be a mutable reference: `&mut self`
 LL |         let _ = &mut self.x; //~ ERROR cannot borrow
    |                 ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
 
@@ -35,7 +35,7 @@ error[E0596]: cannot borrow immutable item `self.x` as mutable
   --> $DIR/issue-39544.rs:35:17
    |
 LL |     fn foo2<'a>(&'a self, other: &Z) {
-   |                 -------- help: consider changing this to be a mutable reference: `&mut Z`
+   |                 -------- help: consider changing this to be a mutable reference: `&mut self`
 LL |         let _ = &mut self.x; //~ ERROR cannot borrow
    |                 ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
 

--- a/src/test/ui/nll/issue-51244.rs
+++ b/src/test/ui/nll/issue-51244.rs
@@ -12,5 +12,6 @@
 
 fn main() {
     let ref my_ref @ _ = 0;
-    *my_ref = 0; //~ ERROR cannot assign to data in a `&` reference [E0594]
+    *my_ref = 0;
+    //~^ ERROR cannot assign to `*my_ref` which is behind a `&` reference [E0594]
 }

--- a/src/test/ui/nll/issue-51244.rs
+++ b/src/test/ui/nll/issue-51244.rs
@@ -1,0 +1,16 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(nll)]
+
+fn main() {
+    let ref my_ref @ _ = 0;
+    *my_ref = 0; //~ ERROR cannot assign to data in a `&` reference [E0594]
+}

--- a/src/test/ui/nll/issue-51244.stderr
+++ b/src/test/ui/nll/issue-51244.stderr
@@ -1,9 +1,9 @@
 error[E0594]: cannot assign to data in a `&` reference
-  --> $DIR/issue-51244.rs:13:5
+  --> $DIR/issue-51244.rs:15:5
    |
 LL |     let ref my_ref @ _ = 0;
    |         -------------- help: consider changing this to be a mutable reference: `&mut ef my_ref @ _`
-LL |     *my_ref = 0; //~ ERROR cannot assign to immutable borrowed content `*my_ref` [E0594]
+LL |     *my_ref = 0; //~ ERROR cannot assign to data in a `&` reference [E0594]
    |     ^^^^^^^^^^^
 
 error: aborting due to previous error

--- a/src/test/ui/nll/issue-51244.stderr
+++ b/src/test/ui/nll/issue-51244.stderr
@@ -1,10 +1,10 @@
-error[E0594]: cannot assign to data in a `&` reference
+error[E0594]: cannot assign to `*my_ref` which is behind a `&` reference
   --> $DIR/issue-51244.rs:15:5
    |
 LL |     let ref my_ref @ _ = 0;
-   |         -------------- help: consider changing this to be a mutable reference: `&mut ef my_ref @ _`
-LL |     *my_ref = 0; //~ ERROR cannot assign to data in a `&` reference [E0594]
-   |     ^^^^^^^^^^^
+   |         -------------- help: consider changing this to be a mutable reference: `ref mut my_ref @ _`
+LL |     *my_ref = 0;
+   |     ^^^^^^^^^^^ `my_ref` is a `&` reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2005-default-binding-mode/enum.nll.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/enum.nll.stderr
@@ -2,19 +2,19 @@ error[E0594]: cannot assign to `*x` which is behind a `&` reference
   --> $DIR/enum.rs:19:5
    |
 LL |     *x += 1; //~ ERROR cannot assign to immutable
-   |     ^^^^^^^ cannot assign
+   |     ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*x` which is behind a `&` reference
   --> $DIR/enum.rs:23:9
    |
 LL |         *x += 1; //~ ERROR cannot assign to immutable
-   |         ^^^^^^^ cannot assign
+   |         ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*x` which is behind a `&` reference
   --> $DIR/enum.rs:29:9
    |
 LL |         *x += 1; //~ ERROR cannot assign to immutable
-   |         ^^^^^^^ cannot assign
+   |         ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/rfc-2005-default-binding-mode/enum.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/enum.stderr
@@ -1,24 +1,18 @@
 error[E0594]: cannot assign to immutable borrowed content `*x`
   --> $DIR/enum.rs:19:5
    |
-LL |     let Wrap(x) = &Wrap(3);
-   |              - help: use a mutable reference instead: `x`
 LL |     *x += 1; //~ ERROR cannot assign to immutable
    |     ^^^^^^^ cannot borrow as mutable
 
 error[E0594]: cannot assign to immutable borrowed content `*x`
   --> $DIR/enum.rs:23:9
    |
-LL |     if let Some(x) = &Some(3) {
-   |                 - help: use a mutable reference instead: `x`
 LL |         *x += 1; //~ ERROR cannot assign to immutable
    |         ^^^^^^^ cannot borrow as mutable
 
 error[E0594]: cannot assign to immutable borrowed content `*x`
   --> $DIR/enum.rs:29:9
    |
-LL |     while let Some(x) = &Some(3) {
-   |                    - help: use a mutable reference instead: `x`
 LL |         *x += 1; //~ ERROR cannot assign to immutable
    |         ^^^^^^^ cannot borrow as mutable
 

--- a/src/test/ui/rfc-2005-default-binding-mode/enum.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/enum.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to immutable borrowed content `*x`
   --> $DIR/enum.rs:19:5
    |
 LL |     let Wrap(x) = &Wrap(3);
-   |              - consider changing this to `x`
+   |              - help: use a mutable reference instead: `x`
 LL |     *x += 1; //~ ERROR cannot assign to immutable
    |     ^^^^^^^ cannot borrow as mutable
 
@@ -10,7 +10,7 @@ error[E0594]: cannot assign to immutable borrowed content `*x`
   --> $DIR/enum.rs:23:9
    |
 LL |     if let Some(x) = &Some(3) {
-   |                 - consider changing this to `x`
+   |                 - help: use a mutable reference instead: `x`
 LL |         *x += 1; //~ ERROR cannot assign to immutable
    |         ^^^^^^^ cannot borrow as mutable
 
@@ -18,7 +18,7 @@ error[E0594]: cannot assign to immutable borrowed content `*x`
   --> $DIR/enum.rs:29:9
    |
 LL |     while let Some(x) = &Some(3) {
-   |                    - consider changing this to `x`
+   |                    - help: use a mutable reference instead: `x`
 LL |         *x += 1; //~ ERROR cannot assign to immutable
    |         ^^^^^^^ cannot borrow as mutable
 

--- a/src/test/ui/rfc-2005-default-binding-mode/explicit-mut.nll.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/explicit-mut.nll.stderr
@@ -2,19 +2,19 @@ error[E0594]: cannot assign to `*n` which is behind a `&` reference
   --> $DIR/explicit-mut.rs:17:13
    |
 LL |             *n += 1; //~ ERROR cannot assign to immutable
-   |             ^^^^^^^ cannot assign
+   |             ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*n` which is behind a `&` reference
   --> $DIR/explicit-mut.rs:25:13
    |
 LL |             *n += 1; //~ ERROR cannot assign to immutable
-   |             ^^^^^^^ cannot assign
+   |             ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*n` which is behind a `&` reference
   --> $DIR/explicit-mut.rs:33:13
    |
 LL |             *n += 1; //~ ERROR cannot assign to immutable
-   |             ^^^^^^^ cannot assign
+   |             ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/rfc-2005-default-binding-mode/explicit-mut.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/explicit-mut.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to immutable borrowed content `*n`
   --> $DIR/explicit-mut.rs:17:13
    |
 LL |         Some(n) => {
-   |              - consider changing this to `n`
+   |              - help: use a mutable reference instead: `n`
 LL |             *n += 1; //~ ERROR cannot assign to immutable
    |             ^^^^^^^ cannot borrow as mutable
 
@@ -10,7 +10,7 @@ error[E0594]: cannot assign to immutable borrowed content `*n`
   --> $DIR/explicit-mut.rs:25:13
    |
 LL |         Some(n) => {
-   |              - consider changing this to `n`
+   |              - help: use a mutable reference instead: `n`
 LL |             *n += 1; //~ ERROR cannot assign to immutable
    |             ^^^^^^^ cannot borrow as mutable
 
@@ -18,7 +18,7 @@ error[E0594]: cannot assign to immutable borrowed content `*n`
   --> $DIR/explicit-mut.rs:33:13
    |
 LL |         Some(n) => {
-   |              - consider changing this to `n`
+   |              - help: use a mutable reference instead: `n`
 LL |             *n += 1; //~ ERROR cannot assign to immutable
    |             ^^^^^^^ cannot borrow as mutable
 

--- a/src/test/ui/rfc-2005-default-binding-mode/explicit-mut.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/explicit-mut.stderr
@@ -1,24 +1,18 @@
 error[E0594]: cannot assign to immutable borrowed content `*n`
   --> $DIR/explicit-mut.rs:17:13
    |
-LL |         Some(n) => {
-   |              - help: use a mutable reference instead: `n`
 LL |             *n += 1; //~ ERROR cannot assign to immutable
    |             ^^^^^^^ cannot borrow as mutable
 
 error[E0594]: cannot assign to immutable borrowed content `*n`
   --> $DIR/explicit-mut.rs:25:13
    |
-LL |         Some(n) => {
-   |              - help: use a mutable reference instead: `n`
 LL |             *n += 1; //~ ERROR cannot assign to immutable
    |             ^^^^^^^ cannot borrow as mutable
 
 error[E0594]: cannot assign to immutable borrowed content `*n`
   --> $DIR/explicit-mut.rs:33:13
    |
-LL |         Some(n) => {
-   |              - help: use a mutable reference instead: `n`
 LL |             *n += 1; //~ ERROR cannot assign to immutable
    |             ^^^^^^^ cannot borrow as mutable
 

--- a/src/test/ui/suggestions/issue-51244.nll.stderr
+++ b/src/test/ui/suggestions/issue-51244.nll.stderr
@@ -1,0 +1,11 @@
+error[E0594]: cannot assign to data in a `&` reference
+  --> $DIR/issue-51244.rs:13:5
+   |
+LL |     let ref my_ref @ _ = 0;
+   |         -------------- help: consider changing this to be a mutable reference: `&mut ef my_ref @ _`
+LL |     *my_ref = 0; //~ ERROR cannot assign to immutable borrowed content `*my_ref` [E0594]
+   |     ^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0594`.

--- a/src/test/ui/suggestions/issue-51244.nll.stderr
+++ b/src/test/ui/suggestions/issue-51244.nll.stderr
@@ -1,0 +1,11 @@
+error[E0594]: cannot assign to `*my_ref` which is behind a `&` reference
+  --> $DIR/issue-51244.rs:13:5
+   |
+LL |     let ref my_ref @ _ = 0;
+   |         -------------- help: consider changing this to be a mutable reference: `ref mut my_ref @ _`
+LL |     *my_ref = 0; //~ ERROR cannot assign to immutable borrowed content `*my_ref` [E0594]
+   |     ^^^^^^^^^^^ `my_ref` is a `&` reference, so the data it refers to cannot be written
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0594`.

--- a/src/test/ui/suggestions/issue-51244.rs
+++ b/src/test/ui/suggestions/issue-51244.rs
@@ -1,0 +1,14 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let ref my_ref @ _ = 0;
+    *my_ref = 0;
+}

--- a/src/test/ui/suggestions/issue-51244.rs
+++ b/src/test/ui/suggestions/issue-51244.rs
@@ -10,5 +10,5 @@
 
 fn main() {
     let ref my_ref @ _ = 0;
-    *my_ref = 0;
+    *my_ref = 0; //~ ERROR cannot assign to immutable borrowed content `*my_ref` [E0594]
 }

--- a/src/test/ui/suggestions/issue-51244.stderr
+++ b/src/test/ui/suggestions/issue-51244.stderr
@@ -2,8 +2,8 @@ error[E0594]: cannot assign to immutable borrowed content `*my_ref`
   --> $DIR/issue-51244.rs:13:5
    |
 LL |     let ref my_ref @ _ = 0;
-   |         --- consider changing this to `ref mut`
-LL |     *my_ref = 0;
+   |         -------------- consider changing this to `ref mut my_ref @ _`
+LL |     *my_ref = 0; //~ ERROR cannot assign to immutable borrowed content `*my_ref` [E0594]
    |     ^^^^^^^^^^^ cannot borrow as mutable
 
 error: aborting due to previous error

--- a/src/test/ui/suggestions/issue-51244.stderr
+++ b/src/test/ui/suggestions/issue-51244.stderr
@@ -1,0 +1,11 @@
+error[E0594]: cannot assign to immutable borrowed content `*my_ref`
+  --> $DIR/issue-51244.rs:13:5
+   |
+LL |     let ref my_ref @ _ = 0;
+   |         -------------- consider changing this to `ref mut my_ref @ _`
+LL |     *my_ref = 0;
+   |     ^^^^^^^^^^^ cannot borrow as mutable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0594`.

--- a/src/test/ui/suggestions/issue-51244.stderr
+++ b/src/test/ui/suggestions/issue-51244.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to immutable borrowed content `*my_ref`
   --> $DIR/issue-51244.rs:13:5
    |
 LL |     let ref my_ref @ _ = 0;
-   |         -------------- consider changing this to `ref mut my_ref @ _`
+   |         --- consider changing this to `ref mut`
 LL |     *my_ref = 0;
    |     ^^^^^^^^^^^ cannot borrow as mutable
 

--- a/src/test/ui/suggestions/issue-51244.stderr
+++ b/src/test/ui/suggestions/issue-51244.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to immutable borrowed content `*my_ref`
   --> $DIR/issue-51244.rs:13:5
    |
 LL |     let ref my_ref @ _ = 0;
-   |         -------------- consider changing this to `ref mut my_ref @ _`
+   |         -------------- help: use a mutable reference instead: `ref mut my_ref @ _`
 LL |     *my_ref = 0; //~ ERROR cannot assign to immutable borrowed content `*my_ref` [E0594]
    |     ^^^^^^^^^^^ cannot borrow as mutable
 

--- a/src/test/ui/suggestions/suggest-ref-mut.rs
+++ b/src/test/ui/suggestions/suggest-ref-mut.rs
@@ -10,6 +10,17 @@
 
 #![feature(nll)]
 
+struct X(usize);
+
+impl X {
+    fn zap(&self) {
+        //~^ HELP
+        //~| SUGGESTION &mut self
+        self.0 = 32;
+        //~^ ERROR
+    }
+}
+
 fn main() {
     let ref foo = 16;
     //~^ HELP

--- a/src/test/ui/suggestions/suggest-ref-mut.rs
+++ b/src/test/ui/suggestions/suggest-ref-mut.rs
@@ -1,0 +1,31 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(nll)]
+
+fn main() {
+    let ref foo = 16;
+    //~^ HELP
+    //~| SUGGESTION ref mut foo
+    *foo = 32;
+    //~^ ERROR
+    if let Some(ref bar) = Some(16) {
+        //~^ HELP
+        //~| SUGGESTION ref mut bar
+        *bar = 32;
+        //~^ ERROR
+    }
+    match 16 {
+        ref quo => { *quo = 32; },
+        //~^ ERROR
+        //~| HELP
+        //~| SUGGESTION ref mut quo
+    }
+}

--- a/src/test/ui/suggestions/suggest-ref-mut.stderr
+++ b/src/test/ui/suggestions/suggest-ref-mut.stderr
@@ -1,20 +1,28 @@
 error[E0594]: cannot assign to `*foo` which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:17:5
    |
+LL |     let ref foo = 16;
+   |         ------- help: consider changing this to be a mutable reference: `ref mut foo`
+...
 LL |     *foo = 32;
-   |     ^^^^^^^^^ cannot assign
+   |     ^^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*bar` which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:22:9
    |
+LL |     if let Some(ref bar) = Some(16) {
+   |                 ------- help: consider changing this to be a mutable reference: `ref mut bar`
+...
 LL |         *bar = 32;
-   |         ^^^^^^^^^ cannot assign
+   |         ^^^^^^^^^ `bar` is a `&` reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*quo` which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:26:22
    |
 LL |         ref quo => { *quo = 32; },
-   |                      ^^^^^^^^^ cannot assign
+   |         -------      ^^^^^^^^^ `quo` is a `&` reference, so the data it refers to cannot be written
+   |         |
+   |         help: consider changing this to be a mutable reference: `ref mut quo`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/suggestions/suggest-ref-mut.stderr
+++ b/src/test/ui/suggestions/suggest-ref-mut.stderr
@@ -1,5 +1,14 @@
+error[E0594]: cannot assign to `self.0` which is behind a `&` reference
+  --> $DIR/suggest-ref-mut.rs:19:9
+   |
+LL |     fn zap(&self) {
+   |            ----- help: consider changing this to be a mutable reference: `&mut self`
+...
+LL |         self.0 = 32;
+   |         ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
+
 error[E0594]: cannot assign to `*foo` which is behind a `&` reference
-  --> $DIR/suggest-ref-mut.rs:17:5
+  --> $DIR/suggest-ref-mut.rs:28:5
    |
 LL |     let ref foo = 16;
    |         ------- help: consider changing this to be a mutable reference: `ref mut foo`
@@ -8,7 +17,7 @@ LL |     *foo = 32;
    |     ^^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*bar` which is behind a `&` reference
-  --> $DIR/suggest-ref-mut.rs:22:9
+  --> $DIR/suggest-ref-mut.rs:33:9
    |
 LL |     if let Some(ref bar) = Some(16) {
    |                 ------- help: consider changing this to be a mutable reference: `ref mut bar`
@@ -17,13 +26,13 @@ LL |         *bar = 32;
    |         ^^^^^^^^^ `bar` is a `&` reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*quo` which is behind a `&` reference
-  --> $DIR/suggest-ref-mut.rs:26:22
+  --> $DIR/suggest-ref-mut.rs:37:22
    |
 LL |         ref quo => { *quo = 32; },
    |         -------      ^^^^^^^^^ `quo` is a `&` reference, so the data it refers to cannot be written
    |         |
    |         help: consider changing this to be a mutable reference: `ref mut quo`
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0594`.

--- a/src/test/ui/suggestions/suggest-ref-mut.stderr
+++ b/src/test/ui/suggestions/suggest-ref-mut.stderr
@@ -1,0 +1,21 @@
+error[E0594]: cannot assign to `*foo` which is behind a `&` reference
+  --> $DIR/suggest-ref-mut.rs:17:5
+   |
+LL |     *foo = 32;
+   |     ^^^^^^^^^ cannot assign
+
+error[E0594]: cannot assign to `*bar` which is behind a `&` reference
+  --> $DIR/suggest-ref-mut.rs:22:9
+   |
+LL |         *bar = 32;
+   |         ^^^^^^^^^ cannot assign
+
+error[E0594]: cannot assign to `*quo` which is behind a `&` reference
+  --> $DIR/suggest-ref-mut.rs:26:22
+   |
+LL |         ref quo => { *quo = 32; },
+   |                      ^^^^^^^^^ cannot assign
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0594`.


### PR DESCRIPTION
Fixes #51244. Supersedes #51249, I think.

Under the old lexical lifetimes, the compiler provided helpful suggestions about adding `mut` when you tried to mutate a variable bound as `&self` or (explicit) `ref`. NLL doesn't have those suggestions yet. This pull request adds them.

I didn't bother making the help text exactly the same as without NLL, but I can if that's important.

(Originally this was supposed to be part of #51612, but I got bogged down trying to fit everything in one PR.)